### PR TITLE
ptrace+strace: Halve number of syscalls done by strace

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -93,7 +93,9 @@ public:
     ErrorOr& operator=(ErrorOr const& other) = default;
 
     T& value() { return m_value.value(); }
-    Error& error() { return m_error.value(); }
+    T const& value() const { return m_value.value(); }
+    ErrorType& error() { return m_error.value(); }
+    ErrorType const& error() const { return m_error.value(); }
 
     bool is_error() const { return m_error.has_value(); }
 

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -624,6 +624,16 @@ struct Formatter<Error> : Formatter<FormatString> {
     }
 };
 
+template<typename T, typename ErrorType>
+struct Formatter<ErrorOr<T, ErrorType>> : Formatter<FormatString> {
+    ErrorOr<void> format(FormatBuilder& builder, ErrorOr<T, ErrorType> const& error_or)
+    {
+        if (error_or.is_error())
+            return Formatter<FormatString>::format(builder, "{}", error_or.error());
+        return Formatter<FormatString>::format(builder, "{{{}}}", error_or.value());
+    }
+};
+
 } // namespace AK
 
 #ifdef KERNEL

--- a/Kernel/API/POSIX/sys/ptrace.h
+++ b/Kernel/API/POSIX/sys/ptrace.h
@@ -21,8 +21,11 @@ extern "C" {
 #define PT_PEEK 7
 #define PT_POKE 8
 #define PT_SETREGS 9
+
+// Serenity extensions:
 #define PT_POKEDEBUG 10
 #define PT_PEEKDEBUG 11
+#define PT_PEEKBUF 12
 
 #define PT_READ_I PT_PEEK
 #define PT_READ_D PT_PEEK

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -458,6 +458,10 @@ struct SC_stat_params {
     int follow_symlinks;
 };
 
+struct SC_ptrace_buf_params {
+    MutableBufferArgument<u8, size_t> buf;
+};
+
 struct SC_ptrace_params {
     int request;
     pid_t tid;

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -465,11 +465,6 @@ struct SC_ptrace_params {
     FlatPtr data;
 };
 
-struct SC_ptrace_peek_params {
-    const void* address;
-    FlatPtr* out_data;
-};
-
 struct SC_set_coredump_metadata_params {
     StringArgument key;
     StringArgument value;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -481,6 +481,7 @@ public:
         m_wait_for_tracer_at_next_execve = val;
     }
 
+    ErrorOr<void> peek_user_data(Span<u8> destination, Userspace<const u8*> address);
     ErrorOr<FlatPtr> peek_user_data(Userspace<const FlatPtr*> address);
     ErrorOr<void> poke_user_data(Userspace<FlatPtr*> address, FlatPtr data);
 

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -162,8 +162,7 @@ ErrorOr<FlatPtr> Process::sys$ptrace(Userspace<const Syscall::SC_ptrace_params*>
     REQUIRE_PROMISE(ptrace);
     auto params = TRY(copy_typed_from_user(user_params));
 
-    auto result = handle_ptrace(params, *this);
-    return result.is_error() ? result.error().code() : result.value();
+    return handle_ptrace(params, *this);
 }
 
 /**

--- a/Kernel/Syscalls/ptrace.cpp
+++ b/Kernel/Syscalls/ptrace.cpp
@@ -114,26 +114,18 @@ static ErrorOr<FlatPtr> handle_ptrace(const Kernel::Syscall::SC_ptrace_params& p
     }
 
     case PT_PEEK: {
-        Kernel::Syscall::SC_ptrace_peek_params peek_params {};
-        TRY(copy_from_user(&peek_params, reinterpret_cast<Kernel::Syscall::SC_ptrace_peek_params*>(params.addr)));
-        if (!Memory::is_user_address(VirtualAddress { peek_params.address }))
-            return EFAULT;
-        auto data = TRY(peer->process().peek_user_data(Userspace<const FlatPtr*> { (FlatPtr)peek_params.address }));
-        TRY(copy_to_user(peek_params.out_data, &data));
+        auto data = TRY(peer->process().peek_user_data(Userspace<const FlatPtr*> { (FlatPtr)params.addr }));
+        TRY(copy_to_user((FlatPtr*)params.data, &data));
         break;
     }
 
     case PT_POKE:
-        if (!Memory::is_user_address(VirtualAddress { params.addr }))
-            return EFAULT;
         TRY(peer->process().poke_user_data(Userspace<FlatPtr*> { (FlatPtr)params.addr }, params.data));
         return 0;
 
     case PT_PEEKDEBUG: {
-        Kernel::Syscall::SC_ptrace_peek_params peek_params {};
-        TRY(copy_from_user(&peek_params, reinterpret_cast<Kernel::Syscall::SC_ptrace_peek_params*>(params.addr)));
-        auto data = TRY(peer->peek_debug_register(reinterpret_cast<uintptr_t>(peek_params.address)));
-        TRY(copy_to_user(peek_params.out_data, &data));
+        auto data = TRY(peer->peek_debug_register(reinterpret_cast<uintptr_t>(params.addr)));
+        TRY(copy_to_user((FlatPtr*)params.data, &data));
         break;
     }
     case PT_POKEDEBUG:

--- a/Userland/Libraries/LibC/sys/ptrace.cpp
+++ b/Userland/Libraries/LibC/sys/ptrace.cpp
@@ -12,6 +12,15 @@ extern "C" {
 
 long ptrace(int request, pid_t tid, void* addr, void* data)
 {
+    if (request == PT_PEEKBUF) {
+        // PT_PEEKBUF cannot easily be correctly used through this function signature:
+        // The amount of data to be copied is not available.
+        // We could VERIFY() here, but to safeguard against ports that attempt to use
+        // the same number, let's claim that the Kernel just doesn't know the command.
+        // Use Core::System::ptrace_peekbuf instead.
+        return EINVAL;
+    }
+
     // PT_PEEK needs special handling since the syscall wrapper
     // returns the peeked value as an int, which can be negative because of the cast.
     // When using PT_PEEK, the user can check if an error occurred

--- a/Userland/Libraries/LibC/sys/ptrace.cpp
+++ b/Userland/Libraries/LibC/sys/ptrace.cpp
@@ -18,12 +18,9 @@ long ptrace(int request, pid_t tid, void* addr, void* data)
     // by looking at errno rather than the return value.
 
     FlatPtr out_data;
-    Syscall::SC_ptrace_peek_params peek_params;
     auto is_peek_type = request == PT_PEEK || request == PT_PEEKDEBUG;
     if (is_peek_type) {
-        peek_params.address = reinterpret_cast<FlatPtr*>(addr);
-        peek_params.out_data = &out_data;
-        addr = &peek_params;
+        data = &out_data;
     }
 
     Syscall::SC_ptrace_params params {

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -19,6 +19,7 @@ ErrorOr<void> unveil(StringView path, StringView permissions);
 ErrorOr<Array<int, 2>> pipe2(int flags);
 ErrorOr<void> sendfd(int sockfd, int fd);
 ErrorOr<int> recvfd(int sockfd, int options);
+ErrorOr<void> ptrace_peekbuf(pid_t tid, void const* tracee_addr, Bytes destination_buf);
 #endif
 
 ErrorOr<void> sigaction(int signal, struct sigaction const* action, struct sigaction* old_action);

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -329,8 +329,45 @@ struct Formatter<PointerArgument> : StandardFormatter {
 };
 }
 
-class FormattedSyscallBuilder {
+struct StringArgument {
+    Syscall::StringArgument argument;
+    StringView trim_by {};
+};
 
+namespace AK {
+template<>
+struct Formatter<StringArgument> : StandardFormatter {
+    Formatter() = default;
+    explicit Formatter(StandardFormatter formatter)
+        : StandardFormatter(formatter)
+    {
+    }
+
+    ErrorOr<void> format(FormatBuilder& format_builder, StringArgument const& string_argument)
+    {
+        auto& builder = format_builder.builder();
+        if (string_argument.argument.characters == nullptr) {
+            builder.append("null");
+            return {};
+        }
+
+        // TODO: Avoid trying to copy excessively long strings.
+        auto string_buffer = copy_from_process(string_argument.argument.characters, string_argument.argument.length);
+        if (string_buffer.is_error()) {
+            builder.appendff("{}{{{:p}, {}b}}", string_buffer.error(), (void const*)string_argument.argument.characters, string_argument.argument.length);
+        } else {
+            auto view = StringView(string_buffer.value());
+            if (!string_argument.trim_by.is_empty())
+                view = view.trim(string_argument.trim_by);
+            builder.appendff("\"{}\"", view);
+        }
+
+        return {};
+    }
+};
+}
+
+class FormattedSyscallBuilder {
 public:
     FormattedSyscallBuilder(StringView syscall_name)
     {
@@ -349,19 +386,6 @@ public:
     void add_argument(T&& arg)
     {
         add_argument("{}", forward<T>(arg));
-    }
-
-    void add_string_argument(Syscall::StringArgument const& string_argument, StringView trim_by = {})
-    {
-        if (string_argument.characters == nullptr)
-            add_argument("null");
-        else {
-            auto string_buffer = copy_from_process(string_argument.characters, string_argument.length).release_value_but_fixme_should_propagate_errors();
-            auto view = StringView(string_buffer);
-            if (!trim_by.is_empty())
-                view = view.trim(trim_by);
-            add_argument("\"{}\"", view);
-        }
     }
 
     template<typename... Ts>
@@ -427,13 +451,7 @@ static void format_getrandom(FormattedSyscallBuilder& builder, void* buffer, siz
 static void format_realpath(FormattedSyscallBuilder& builder, Syscall::SC_realpath_params* params_p)
 {
     auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
-    builder.add_string_argument(params.path);
-    if (params.buffer.size == 0)
-        builder.add_argument("null");
-    else {
-        auto buffer = copy_from_process(params.buffer.data, params.buffer.size).release_value_but_fixme_should_propagate_errors();
-        builder.add_argument("\"{}\"", StringView { (const char*)buffer.data() });
-    }
+    builder.add_arguments(StringArgument { params.path }, StringArgument { { params.buffer.data, params.buffer.size } });
 }
 
 static void format_exit(FormattedSyscallBuilder& builder, int status)
@@ -459,9 +477,7 @@ static void format_open(FormattedSyscallBuilder& builder, Syscall::SC_open_param
     else
         builder.add_argument(params.dirfd);
 
-    builder.add_string_argument(params.path);
-
-    builder.add_argument(OpenOptions { params.options });
+    builder.add_arguments(StringArgument { params.path }, OpenOptions { params.options });
 
     if (params.options & O_CREAT)
         builder.add_argument("{:04o}", params.mode);
@@ -526,8 +542,7 @@ static void format_stat(FormattedSyscallBuilder& builder, Syscall::SC_stat_param
         builder.add_argument("AT_FDCWD");
     else
         builder.add_argument(params.dirfd);
-    builder.add_string_argument(params.path);
-    builder.add_arguments(copy_from_process(params.statbuf), params.follow_symlinks);
+    builder.add_arguments(StringArgument { params.path }, copy_from_process(params.statbuf), params.follow_symlinks);
 }
 
 static void format_lseek(FormattedSyscallBuilder& builder, int fd, off_t offset, int whence)
@@ -632,8 +647,7 @@ struct MemoryProtectionFlags : BitflagBase {
 static void format_mmap(FormattedSyscallBuilder& builder, Syscall::SC_mmap_params* params_p)
 {
     auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
-    builder.add_arguments(params.addr, params.size, MemoryProtectionFlags { params.prot }, MmapFlags { params.flags }, params.fd, params.offset, params.alignment);
-    builder.add_string_argument(params.name);
+    builder.add_arguments(params.addr, params.size, MemoryProtectionFlags { params.prot }, MmapFlags { params.flags }, params.fd, params.offset, params.alignment, StringArgument { params.name });
 }
 
 static void format_munmap(FormattedSyscallBuilder& builder, void* addr, size_t size)
@@ -649,8 +663,7 @@ static void format_mprotect(FormattedSyscallBuilder& builder, void* addr, size_t
 static void format_set_mmap_name(FormattedSyscallBuilder& builder, Syscall::SC_set_mmap_name_params* params_p)
 {
     auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
-    builder.add_arguments(params.addr, params.size);
-    builder.add_string_argument(params.name);
+    builder.add_arguments(params.addr, params.size, StringArgument { params.name });
 }
 
 static void format_clock_gettime(FormattedSyscallBuilder& builder, clockid_t clockid, struct timespec* time)
@@ -660,12 +673,12 @@ static void format_clock_gettime(FormattedSyscallBuilder& builder, clockid_t clo
 
 static void format_dbgputstr(FormattedSyscallBuilder& builder, char* characters, size_t size)
 {
-    builder.add_string_argument({ characters, size }, "\0\n"sv);
+    builder.add_argument(StringArgument { { characters, size }, "\0\n"sv });
 }
 
 static void format_get_process_name(FormattedSyscallBuilder& builder, char* buffer, size_t buffer_size)
 {
-    builder.add_string_argument({ buffer, buffer_size });
+    builder.add_argument(StringArgument { { buffer, buffer_size }, "\0"sv });
 }
 
 static void format_syscall(FormattedSyscallBuilder& builder, Syscall::Function syscall_function, syscall_arg_t arg1, syscall_arg_t arg2, syscall_arg_t arg3, syscall_arg_t res)

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -12,6 +12,7 @@
 #include <LibC/sys/arch/i386/regs.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
+#include <LibCore/System.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>
@@ -220,32 +221,27 @@ static void handle_sigint(int)
     }
 }
 
-static void copy_from_process(const void* source_p, Bytes target)
+static ErrorOr<void> copy_from_process(const void* source, Bytes target)
 {
-    auto source = static_cast<const char*>(source_p);
-    size_t offset = 0;
-    size_t left = target.size();
-    while (left) {
-        int value = ptrace(PT_PEEK, g_pid, const_cast<char*>(source) + offset, 0);
-        size_t to_copy = min(sizeof(int), left);
-        target.overwrite(offset, &value, to_copy);
-        left -= to_copy;
-        offset += to_copy;
-    }
+    return Core::System::ptrace_peekbuf(g_pid, const_cast<void*>(source), target);
 }
 
-static ByteBuffer copy_from_process(const void* source, size_t length)
+static ErrorOr<ByteBuffer> copy_from_process(const void* source, size_t length)
 {
-    auto buffer = ByteBuffer::create_uninitialized(length).value();
-    copy_from_process(source, buffer.bytes());
-    return buffer;
+    auto buffer = ByteBuffer::create_uninitialized(length);
+    if (!buffer.has_value()) {
+        // Allocation failed. Inject an error:
+        return Error::from_errno(ENOMEM);
+    }
+    TRY(copy_from_process(source, buffer->bytes()));
+    return buffer.release_value();
 }
 
 template<typename T>
-static T copy_from_process(const T* source)
+static ErrorOr<T> copy_from_process(const T* source)
 {
     T value {};
-    copy_from_process(source, Bytes { &value, sizeof(T) });
+    TRY(copy_from_process(source, Bytes { &value, sizeof(T) }));
     return value;
 }
 
@@ -360,7 +356,7 @@ public:
         if (string_argument.characters == nullptr)
             add_argument("null");
         else {
-            auto string_buffer = copy_from_process(string_argument.characters, string_argument.length);
+            auto string_buffer = copy_from_process(string_argument.characters, string_argument.length).release_value_but_fixme_should_propagate_errors();
             auto view = StringView(string_buffer);
             if (!trim_by.is_empty())
                 view = view.trim(trim_by);
@@ -430,12 +426,12 @@ static void format_getrandom(FormattedSyscallBuilder& builder, void* buffer, siz
 
 static void format_realpath(FormattedSyscallBuilder& builder, Syscall::SC_realpath_params* params_p)
 {
-    auto params = copy_from_process(params_p);
+    auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
     builder.add_string_argument(params.path);
     if (params.buffer.size == 0)
         builder.add_argument("null");
     else {
-        auto buffer = copy_from_process(params.buffer.data, params.buffer.size);
+        auto buffer = copy_from_process(params.buffer.data, params.buffer.size).release_value_but_fixme_should_propagate_errors();
         builder.add_argument("\"{}\"", StringView { (const char*)buffer.data() });
     }
 }
@@ -456,7 +452,7 @@ struct OpenOptions : BitflagBase {
 
 static void format_open(FormattedSyscallBuilder& builder, Syscall::SC_open_params* params_p)
 {
-    auto params = copy_from_process(params_p);
+    auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
 
     if (params.dirfd == AT_FDCWD)
         builder.add_argument("AT_FDCWD");
@@ -525,7 +521,7 @@ static void format_fstat(FormattedSyscallBuilder& builder, int fd, struct stat* 
 
 static void format_stat(FormattedSyscallBuilder& builder, Syscall::SC_stat_params* params_p)
 {
-    auto params = copy_from_process(params_p);
+    auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
     if (params.dirfd == AT_FDCWD)
         builder.add_argument("AT_FDCWD");
     else
@@ -557,7 +553,7 @@ static void format_close(FormattedSyscallBuilder& builder, int fd)
 static void format_select(FormattedSyscallBuilder& builder, Syscall::SC_select_params* params_p)
 {
     // TODO: format fds and sigmask properly
-    auto params = copy_from_process(params_p);
+    auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
     builder.add_arguments(
         params.nfds,
         PointerArgument { params.readfds },
@@ -635,7 +631,7 @@ struct MemoryProtectionFlags : BitflagBase {
 
 static void format_mmap(FormattedSyscallBuilder& builder, Syscall::SC_mmap_params* params_p)
 {
-    auto params = copy_from_process(params_p);
+    auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
     builder.add_arguments(params.addr, params.size, MemoryProtectionFlags { params.prot }, MmapFlags { params.flags }, params.fd, params.offset, params.alignment);
     builder.add_string_argument(params.name);
 }
@@ -652,7 +648,7 @@ static void format_mprotect(FormattedSyscallBuilder& builder, void* addr, size_t
 
 static void format_set_mmap_name(FormattedSyscallBuilder& builder, Syscall::SC_set_mmap_name_params* params_p)
 {
-    auto params = copy_from_process(params_p);
+    auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
     builder.add_arguments(params.addr, params.size);
     builder.add_string_argument(params.name);
 }


### PR DESCRIPTION
The ptrace mechanism is silly: It requires dozens if not hundreds of syscalls by the tracer for each syscall by the tracee. That ratio alone is cause for excessive slowdown. One reason for this high ratio is the weird dance required to gather the various hints regarding why the tracee has stopped.

This PR fixes the *other* reason for the high ratio: Memory used to be copied in 4-byte increments. Now, memory is copied buffer-to-buffer, in a single syscall. This means less syscall traffic for the Kernel, and a saner interface, especially for future applications (yes, I have one in mind) that use ptrace to copy more than just a struct or two.

before:
![Bildschirmfoto_2021-11-26_20-26-37](https://user-images.githubusercontent.com/2690845/143769676-5910415e-3e4a-4737-86d6-1a864ca3554e.png)
after:
![Bildschirmfoto_2021-11-27_23-58-32](https://user-images.githubusercontent.com/2690845/143769680-cc1ea7c5-279d-4c21-8231-e223008d0b2a.png)

Sadly, this does not significantly improve the runtime impact of strace/ptrace:
before:
![before_pr](https://user-images.githubusercontent.com/2690845/143769705-42d673be-5875-4d22-9789-8253345f2f10.png)
after:
![after_pr](https://user-images.githubusercontent.com/2690845/143769712-e32e58be-a1e9-4813-a4b5-205b5b6ba732.png)

This seems to be due to other factors:
![Bildschirmfoto_2021-11-28_14-15-40](https://user-images.githubusercontent.com/2690845/143769727-000f41d2-ed74-452d-b9fc-77b19710de97.png)
My wild guess is that somehow ptrace starting/stopping a process interferes with the scheduler, and causes a lot of contention on the tracee's address space spinlock. This would explain why reducing the number of `PT_PEEK`s only has marginal effect on the running time.

Nevertheless, improving the running time wasn't my goal here, so I just declare improving the running time to be out-of-scope for this PR.