### PR TITLE
Kernel: Log when a process exits with an unlocked veil

### DIFF
--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -608,6 +608,9 @@ void Process::finalize()
 
     dbgln_if(PROCESS_DEBUG, "Finalizing process {}", *this);
 
+    if (veil_state() == VeilState::Dropped)
+        dbgln("\x1b[01;31mProcess '{}' exited with the veil left open\x1b[0m", name());
+
     if (is_dumpable()) {
         if (m_should_generate_coredump)
             dump_core();


### PR DESCRIPTION
This catches applications that make use of `unveil()`, but then do not lock the veil with `unveil(nullptr, nullptr)`.

Feedback welcome. I know that printf in the kernel isn't great. Also the error message isn't that easy to notice.