### PR TITLE
Kernel: Allow switching to IOAPIC mode even without enabling SMP

### DIFF
--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -111,6 +111,16 @@ UNMAP_AFTER_INIT bool CommandLine::is_smp_enabled() const
     return lookup("smp"sv).value_or("off"sv) == "on"sv;
 }
 
+UNMAP_AFTER_INIT bool CommandLine::is_ioapic_enabled() const
+{
+    auto value = lookup("enable_ioapic"sv).value_or("on"sv);
+    if (value == "on"sv)
+        return true;
+    if (value == "off"sv)
+        return false;
+    PANIC("Unknown enable_ioapic setting: {}", value);
+}
+
 UNMAP_AFTER_INIT bool CommandLine::is_vmmouse_enabled() const
 {
     return lookup("vmmouse"sv).value_or("on"sv) == "on"sv;

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -59,6 +59,7 @@ public:
 
     [[nodiscard]] bool is_boot_profiling_enabled() const;
     [[nodiscard]] bool is_ide_enabled() const;
+    [[nodiscard]] bool is_ioapic_enabled() const;
     [[nodiscard]] bool is_smp_enabled() const;
     [[nodiscard]] bool is_physical_networking_disabled() const;
     [[nodiscard]] bool is_vmmouse_enabled() const;

--- a/Kernel/Interrupts/InterruptManagement.cpp
+++ b/Kernel/Interrupts/InterruptManagement.cpp
@@ -41,10 +41,10 @@ UNMAP_AFTER_INIT void InterruptManagement::initialize()
     VERIFY(!InterruptManagement::initialized());
     s_interrupt_management = new InterruptManagement();
 
-    if (kernel_command_line().is_smp_enabled())
-        InterruptManagement::the().switch_to_ioapic_mode();
-    else
+    if (!kernel_command_line().is_ioapic_enabled() && !kernel_command_line().is_smp_enabled())
         InterruptManagement::the().switch_to_pic_mode();
+    else
+        InterruptManagement::the().switch_to_ioapic_mode();
 }
 
 void InterruptManagement::enumerate_interrupt_handlers(Function<void(GenericInterruptHandler&)> callback)
@@ -220,7 +220,7 @@ UNMAP_AFTER_INIT void InterruptManagement::locate_apic_data()
             dbgln("Interrupts: Overriding INT {:#x} with GSI {}, for bus {:#x}",
                 interrupt_override_entry->source,
                 global_system_interrupt,
-                flags);
+                interrupt_override_entry->bus);
         }
         madt_entry = (ACPI::Structures::MADTEntryHeader*)(VirtualAddress(madt_entry).offset(entry_length).get());
         entries_length -= entry_length;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -271,7 +271,7 @@ void init_stage2(void*)
 
     WorkQueue::initialize();
 
-    if (APIC::initialized() && APIC::the().enabled_processor_count() > 1) {
+    if (kernel_command_line().is_smp_enabled() && APIC::initialized() && APIC::the().enabled_processor_count() > 1) {
         // We can't start the APs until we have a scheduler up and running.
         // We need to be able to process ICI messages, otherwise another
         // core may send too many and end up deadlocking once the pool is


### PR DESCRIPTION
This small change allows to use the IOAPIC by default without to enable
SMP mode, which emulates Uni-Processor setup with IOAPIC instead of
using the PIC.

This opens the opportunity to utilize other types of interrupts like MSI
and MSI-X interrupts.