### PR TITLE
LibGL: Initialize all GL context matrices with the identity matrix

### DIFF
--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -120,10 +120,9 @@ private:
 
     GLenum m_current_draw_mode;
     GLenum m_current_matrix_mode;
-    FloatMatrix4x4 m_projection_matrix;
-    FloatMatrix4x4 m_model_view_matrix;
-
-    FloatMatrix4x4 m_current_matrix;
+    FloatMatrix4x4 m_projection_matrix = FloatMatrix4x4::identity();
+    FloatMatrix4x4 m_model_view_matrix = FloatMatrix4x4::identity();
+    FloatMatrix4x4 m_current_matrix = FloatMatrix4x4::identity();
 
     Vector<FloatMatrix4x4> m_projection_matrix_stack;
     Vector<FloatMatrix4x4> m_model_view_matrix_stack;


### PR DESCRIPTION
This fixes a bug that came up while creating a POC for lagom testing LibGL.
According to the official specs, all gl state matrices are initialized as the identity matrix.

See Table 6.8 on page 216 here:
https://www.khronos.org/registry/OpenGL/specs/gl/glspec13.pdf
