### PR TITLE
Meta: Allow overlong 'fixup!' commit titles in pre-commit hook

### DIFF
--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -3,6 +3,7 @@ name: Commit linter
 on: [pull_request_target]
 
 # Make sure to update Meta/lint-commit.sh to match this script when adding new checks!
+# (… but don't accept overlong 'fixup!' commit descriptions.)
 
 jobs:
   lint_commits:

--- a/Meta/lint-commit.sh
+++ b/Meta/lint-commit.sh
@@ -24,6 +24,8 @@ while read -r line; do
 
   # ignore comment lines
   [[ "$line" =~ ^#.* ]] && continue
+  # ignore overlong 'fixup!' commit descriptions
+  [[ "$line" =~ ^fixup!\ .* ]] && continue
 
   ((line_number += 1))
   line_length=${#line}


### PR DESCRIPTION
Has THIS happened to YOU?!

```console
$ git commit -a --fixup=1e0703d0ff5e7737f12fa0c90f4d7dfe70170c3a
Running Meta/lint-ci.sh to ensure changes will pass linting on CI..........................Passed
Running Meta/lint-ports.py to ensure changes will pass linting on CI...(no files to check)Skipped
Lint commit message to ensure it will pass the commit linting on CI.......................Failed
- hook id: meta-lint-commit
- exit code: 1

Commit message lines are too long (maximum allowed is 72 characters):
fixup! LibCore: Implement new ptrace_peekbuf wrapper for PT_PEEKBUF syscall
```

Do YOU wish there was an EASIER solution?!

```console
$ git commit -a --fixup=1e0703d0ff5e7737f12fa0c90f4d7dfe70170c3a
Running Meta/lint-ci.sh to ensure changes will pass linting on CI..........................Passed
Running Meta/lint-ports.py to ensure changes will pass linting on CI...(no files to check)Skipped
Lint commit message to ensure it will pass the commit linting on CI.......................Failed
- hook id: meta-lint-commit
- exit code: 1

Commit message lines are too long (maximum allowed is 72 characters):
fixup! LibCore: Implement new ptrace_peekbuf wrapper for PT_PEEKBUF syscall

$ git commit -a --fixup=1e0703d0ff5e7737f12fa0c90f4d7dfe70170c3a --skip-verify
error: unknown option `skip-verify'
usage: git commit [<options>] [--] <pathspec>...

    -q, --quiet           suppress summary after successful commit
    -v, --verbose         show diff in commit message template

…

$ git commit -a --fixup=1e0703d0ff5e7737f12fa0c90f4d7dfe70170c3a --no-verify
[dev-ptrace-rewrite 3b9df17f88] fixup! LibCore: Implement new ptrace_peekbuf wrapper for PT_PEEKBUF syscall
 1 file changed, 1 insertion(+)

$ # Oh my god, finally.
```

F[r](https://en.wikipedia.org/wiki/Fret_(disambiguation))et no more, this PR has the solution FOR YOU! This PR uses advanced REGEX™ technology to detect the `fixup! ` line-prefix typical to a git® fixup™ commit, and allows any such line in a commit description to pass! Watch how it works:

```console
$ git commit -a --fixup=1e0703d0ff5e7737f12fa0c90f4d7dfe70170c3a
Running Meta/lint-ci.sh to ensure changes will pass linting on CI..........................Passed
Running Meta/lint-ports.py to ensure changes will pass linting on CI...(no files to check)Skipped
Lint commit message to ensure it will pass the commit linting on CI.......................Passed
[dev-fixup-too-long d3c2bbb665] fixup! LibCore: Implement new ptrace_peekbuf wrapper for PT_PEEKBUF syscall
 1 file changed, 1 deletion(-)

$ # Wow, so easy!!!
```

Yes, it really IS so easy! Click :merge: NOW to use ALL of the benefits that this PR can achieve for YOU!