### PR TITLE
ClipboardHistory: Add debug dump action

### DIFF
--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -30,6 +30,9 @@ public:
     const GUI::Clipboard::DataAndType& item_at(int index) const { return m_history_items[index]; }
     void remove_item(int index);
 
+    // ^GUI::Model
+    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+
     // ^Config::Listener
     virtual void config_string_did_change(String const& domain, String const& group, String const& key, String const& value) override;
 
@@ -41,7 +44,6 @@ private:
     virtual int row_count(const GUI::ModelIndex&) const override { return m_history_items.size(); }
     virtual String column_name(int) const override;
     virtual int column_count(const GUI::ModelIndex&) const override { return Column::__Count; }
-    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
 
     // ^GUI::Clipboard::ClipboardClient
     virtual void clipboard_content_did_change(const String&) override { add_item(GUI::Clipboard::the().fetch_data_and_type()); }

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -62,10 +62,18 @@ int main(int argc, char* argv[])
         model->remove_item(table_view.selection().first().row());
     });
 
+    auto debug_dump_action = GUI::Action::create("Dump to debug console", [&](const GUI::Action&) {
+        table_view.selection().for_each_index([&](GUI::ModelIndex& index) {
+            dbgln("{}", model->data(index, GUI::ModelRole::Display).as_string());
+        });
+    });
+
     auto entry_context_menu = GUI::Menu::construct();
     entry_context_menu->add_action(delete_action);
+    entry_context_menu->add_action(debug_dump_action);
     table_view.on_context_menu_request = [&](const GUI::ModelIndex&, const GUI::ContextMenuEvent& event) {
         delete_action->set_enabled(!table_view.selection().is_empty());
+        debug_dump_action->set_enabled(!table_view.selection().is_empty());
         entry_context_menu->popup(event.screen_position());
     };
 


### PR DESCRIPTION
This allows for easy dumping of clipboard data to the debug console.

![image](https://user-images.githubusercontent.com/3210731/143784007-c27a455f-2b31-4752-9eba-86c802ef2102.png)
