### PR TITLE
AK: Remove unused static member of Bitmap

### DIFF
--- a/AK/Bitmap.h
+++ b/AK/Bitmap.h
@@ -175,8 +175,6 @@ public:
         __builtin_memset(m_data, value ? 0xff : 0x00, size_in_bytes());
     }
 
-    static constexpr size_t max_size = 0xffffffff;
-
 private:
     bool m_is_owning { true };
 };


### PR DESCRIPTION
This is a remnant of the Bitmap/BitmapView split.