### PR TITLE
Kernel: Allow unveil() calls that reduce permissions after locking it

### DIFF
--- a/Base/usr/share/man/man2/unveil.md
+++ b/Base/usr/share/man/man2/unveil.md
@@ -42,11 +42,11 @@ Unveiling a directory allows the process to access any files inside the
 directory.
 
 Calling `unveil()` with both `path` and `permissions` set to null locks the
-veil; no further `unveil()` calls are allowed after that. Although `unveil()`
-calls start to take effect the moment they are made, until the veil is locked,
-it remains possible to sometimes circumvent the restrictions set by unveiling
-files and directories contained inside a restricted directory with different
-permissions.
+veil; after that, only `unveil()` calls that reduce permissions on previously
+unveiled paths are permitted. Although `unveil()` calls start to take effect
+the moment they are made, until the veil is locked, it remains possible to
+sometimes circumvent the restrictions set by unveiling files and directories
+contained inside a restricted directory with different permissions.
 
 When a process calls `fork()`, the unveil state is copied to the new process.
 The veil state is reset after the program successfully performs an `execve()`

--- a/Tests/Kernel/TestKernelUnveil.cpp
+++ b/Tests/Kernel/TestKernelUnveil.cpp
@@ -73,6 +73,11 @@ TEST_CASE(test_failures)
     if (res >= 0)
         FAIL("unveil create permitted after unveil browse only");
 
+    // This one exists only to test reduction later
+    res = unveil("/home/anon/Documents", "bc");
+    if (res < 0)
+        FAIL("unveil browse & create failed");
+
     res = unveil(nullptr, nullptr);
     if (res < 0)
         FAIL("unveil state lock failed");
@@ -84,4 +89,8 @@ TEST_CASE(test_failures)
     res = access("/bin/id", F_OK);
     if (res == 0)
         FAIL("access(..., F_OK) permitted after locked veil without relevant unveil");
+
+    res = unveil("/home/anon/Documents", "b");
+    if (res < 0)
+        FAIL("unveil permission reduction after locked veil failed");
 }


### PR DESCRIPTION
The same path can be unveiled multiple times in order to reduce the
permissions, similar to `pledge()`. This allows code like the following:

```c++
unveil("/dangerous/path", "rw");
do_dangerous_things();
unveil("/dangerous/path", "");
```

However, previously locking the veil would prevent you from reducing the
permissions afterwards:

```c++
unveil("/dangerous/path", "rw");
unveil(nullptr, nullptr);

do_dangerous_things();

unveil("/dangerous/path", ""); // ERROR!
```

This patch enables `unveil()` calls after the lock, but only on
already-unveiled paths. This allows that second code snippet to work,
without weakening the benefits of locking.

----
This does break compatibility with BSD's documented `unveil()` behavior, but I don't know if that is important or not.