### PR TITLE
Fix the Lagom_Linux_Fuzz build

### DIFF
--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -167,6 +167,7 @@ ErrorOr<void> Decoder::decode([[maybe_unused]] File& file)
     file = File(fd, File::ConstructWithReceivedFileDescriptor);
     return {};
 #else
+    [[maybe_unused]] auto fd = m_sockfd;
     return Error::from_string_literal("File descriptor passing not supported on this platform");
 #endif
 }


### PR DESCRIPTION
The `m_sockfd` member is unused on non Serenity platforms and before it was marked maybe_unused like this otherwise clang starts complaining in the fuzz build. Just added it back as it was.