### PR TITLE
LibDSP+LibCpp: Static Analysis Fixes

### DIFF
--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -377,7 +377,7 @@ bool Parser::match_secondary_expression()
         || type == Token::Type::PercentEquals
         || type == Token::Type::Equals
         || type == Token::Type::Greater
-        || type == Token::Type::Greater
+        || type == Token::Type::GreaterEquals
         || type == Token::Type::Less
         || type == Token::Type::LessEquals
         || type == Token::Type::Dot

--- a/Userland/Libraries/LibDSP/Envelope.h
+++ b/Userland/Libraries/LibDSP/Envelope.h
@@ -50,7 +50,7 @@ struct Envelope {
 
     constexpr void reset() { envelope = -1; }
 
-    constexpr operator EnvelopeState()
+    constexpr operator EnvelopeState() const
     {
         if (!is_active())
             return EnvelopeState::Off;

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -64,7 +64,7 @@ Signal Classic::process_impl(Signal const& input_signal)
 }
 
 // Linear ADSR envelope with no peak adjustment.
-double Classic::volume_from_envelope(Envelope envelope)
+double Classic::volume_from_envelope(Envelope const& envelope)
 {
     switch (static_cast<EnvelopeState>(envelope)) {
     case EnvelopeState::Off:

--- a/Userland/Libraries/LibDSP/Synthesizers.h
+++ b/Userland/Libraries/LibDSP/Synthesizers.h
@@ -49,7 +49,7 @@ public:
 private:
     virtual Signal process_impl(Signal const&) override;
 
-    double volume_from_envelope(Envelope);
+    double volume_from_envelope(Envelope const&);
     double wave_position(u8 note);
     double samples_per_cycle(u8 note);
     double sin_position(u8 note);


### PR DESCRIPTION
- LibCpp: Fix copy paste typo in Parser::match_secondary_expression
- LibDSP: Fix potential slicing issue in volume_from_envelope
