### PR TITLE
LibGL: Implement texture unit texturing states

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -188,7 +188,10 @@ extern "C" {
 #define GL_REPLACE 0x1E01
 
 // Texture targets
+#define GL_TEXTURE_1D 0x0DE0
 #define GL_TEXTURE_2D 0x0DE1
+#define GL_TEXTURE_3D 0x806F
+#define GL_TEXTURE_CUBE_MAP 0x8513
 
 // Texture Unit indices
 #define GL_TEXTURE0 0x84C0

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -553,6 +553,18 @@ void SoftwareGLContext::gl_enable(GLenum capability)
         rasterizer_options.scissor_enabled = true;
         update_rasterizer_options = true;
         break;
+    case GL_TEXTURE_1D:
+        m_active_texture_unit->set_texture_1d_enabled(true);
+        break;
+    case GL_TEXTURE_2D:
+        m_active_texture_unit->set_texture_2d_enabled(true);
+        break;
+    case GL_TEXTURE_3D:
+        m_active_texture_unit->set_texture_3d_enabled(true);
+        break;
+    case GL_TEXTURE_CUBE_MAP:
+        m_active_texture_unit->set_texture_cube_map_enabled(true);
+        break;
     default:
         RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
     }
@@ -596,6 +608,18 @@ void SoftwareGLContext::gl_disable(GLenum capability)
     case GL_SCISSOR_TEST:
         rasterizer_options.scissor_enabled = false;
         update_rasterizer_options = true;
+        break;
+    case GL_TEXTURE_1D:
+        m_active_texture_unit->set_texture_1d_enabled(false);
+        break;
+    case GL_TEXTURE_2D:
+        m_active_texture_unit->set_texture_2d_enabled(false);
+        break;
+    case GL_TEXTURE_3D:
+        m_active_texture_unit->set_texture_3d_enabled(false);
+        break;
+    case GL_TEXTURE_CUBE_MAP:
+        m_active_texture_unit->set_texture_cube_map_enabled(false);
         break;
     default:
         RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
@@ -1457,6 +1481,18 @@ void SoftwareGLContext::gl_get_booleanv(GLenum pname, GLboolean* data)
         break;
     case GL_CULL_FACE:
         *data = m_cull_faces ? GL_TRUE : GL_FALSE;
+        break;
+    case GL_TEXTURE_1D:
+        *data = m_active_texture_unit->texture_1d_enabled() ? GL_TRUE : GL_FALSE;
+        break;
+    case GL_TEXTURE_2D:
+        *data = m_active_texture_unit->texture_2d_enabled() ? GL_TRUE : GL_FALSE;
+        break;
+    case GL_TEXTURE_3D:
+        *data = m_active_texture_unit->texture_3d_enabled() ? GL_TRUE : GL_FALSE;
+        break;
+    case GL_TEXTURE_CUBE_MAP:
+        *data = m_active_texture_unit->texture_cube_map_enabled() ? GL_TRUE : GL_FALSE;
         break;
     default:
         // According to the Khronos docs, we always return GL_INVALID_ENUM if we encounter a non-accepted value

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -685,7 +685,7 @@ void SoftwareGLContext::gl_delete_textures(GLsizei n, const GLuint* textures)
         // Check all texture units
         for (auto& texture_unit : m_texture_units) {
             if (texture_object->value == texture_unit.bound_texture())
-                texture_unit.unbind_texture(GL_TEXTURE_2D);
+                texture_unit.bind_texture_to_target(GL_TEXTURE_2D, nullptr);
         }
 
         m_allocated_textures.remove(name);
@@ -1386,7 +1386,7 @@ void SoftwareGLContext::gl_bind_texture(GLenum target, GLuint texture)
     if (texture == 0) {
         switch (target) {
         case GL_TEXTURE_2D:
-            m_active_texture_unit->unbind_texture(target);
+            m_active_texture_unit->bind_texture_to_target(target, nullptr);
             return;
         default:
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -498,8 +498,17 @@ void SoftwareRasterizer::submit_triangle(const GLTriangle& triangle, const Array
             if (!texture_unit.is_bound())
                 continue;
 
-            // FIXME: Don't assume Texture2D
-            auto texel = texture_unit.bound_texture_2d()->sampler().sample(uv);
+            // FIXME: implement GL_TEXTURE_1D, GL_TEXTURE_3D and GL_TEXTURE_CUBE_MAP
+            FloatVector4 texel;
+            switch (texture_unit.currently_bound_target()) {
+            case GL_TEXTURE_2D:
+                if (!texture_unit.texture_2d_enabled() || texture_unit.texture_3d_enabled() || texture_unit.texture_cube_map_enabled())
+                    continue;
+                texel = texture_unit.bound_texture_2d()->sampler().sample(uv);
+                break;
+            default:
+                VERIFY_NOT_REACHED();
+            }
 
             // FIXME: Implement more blend modes
             switch (texture_unit.env_mode()) {

--- a/Userland/Libraries/LibGL/Tex/TextureUnit.cpp
+++ b/Userland/Libraries/LibGL/Tex/TextureUnit.cpp
@@ -11,6 +11,13 @@ namespace GL {
 
 void TextureUnit::bind_texture_to_target(GLenum texture_target, const RefPtr<Texture>& texture)
 {
+    if (!texture) {
+        m_texture_target_2d = nullptr;
+        m_currently_bound_target = GL_NONE;
+        m_currently_bound_texture = nullptr;
+        return;
+    }
+
     switch (texture_target) {
     case GL_TEXTURE_2D:
         m_texture_target_2d = static_ptr_cast<Texture2D>(texture);
@@ -20,20 +27,6 @@ void TextureUnit::bind_texture_to_target(GLenum texture_target, const RefPtr<Tex
     default:
         VERIFY_NOT_REACHED();
     }
-}
-
-void TextureUnit::unbind_texture(GLenum texture_target)
-{
-    switch (texture_target) {
-    case GL_TEXTURE_2D:
-        m_texture_target_2d = nullptr;
-        m_currently_bound_target = GL_NONE;
-        break;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-
-    m_currently_bound_texture = nullptr;
 }
 
 }

--- a/Userland/Libraries/LibGL/Tex/TextureUnit.cpp
+++ b/Userland/Libraries/LibGL/Tex/TextureUnit.cpp
@@ -14,8 +14,8 @@ void TextureUnit::bind_texture_to_target(GLenum texture_target, const RefPtr<Tex
     switch (texture_target) {
     case GL_TEXTURE_2D:
         m_texture_target_2d = static_ptr_cast<Texture2D>(texture);
-        m_currently_bound_texture = texture;
         m_currently_bound_target = GL_TEXTURE_2D;
+        m_currently_bound_texture = texture;
         break;
     default:
         VERIFY_NOT_REACHED();
@@ -27,7 +27,7 @@ void TextureUnit::unbind_texture(GLenum texture_target)
     switch (texture_target) {
     case GL_TEXTURE_2D:
         m_texture_target_2d = nullptr;
-        m_currently_bound_target = 0;
+        m_currently_bound_target = GL_NONE;
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibGL/Tex/TextureUnit.h
+++ b/Userland/Libraries/LibGL/Tex/TextureUnit.h
@@ -16,7 +16,6 @@ public:
     TextureUnit() = default;
 
     void bind_texture_to_target(GLenum texture_target, const RefPtr<Texture>& texture);
-    void unbind_texture(GLenum texture_target);
 
     RefPtr<Texture2D>& bound_texture_2d() const { return m_texture_target_2d; }
     RefPtr<Texture>& bound_texture() const { return m_currently_bound_texture; }

--- a/Userland/Libraries/LibGL/Tex/TextureUnit.h
+++ b/Userland/Libraries/LibGL/Tex/TextureUnit.h
@@ -27,11 +27,26 @@ public:
     void set_env_mode(GLenum mode) { m_env_mode = mode; }
     GLenum env_mode() const { return m_env_mode; }
 
+    bool texture_1d_enabled() const { return m_texture_1d_enabled; };
+    void set_texture_1d_enabled(bool texture_1d_enabled) { m_texture_1d_enabled = texture_1d_enabled; }
+    bool texture_2d_enabled() const { return m_texture_2d_enabled; };
+    void set_texture_2d_enabled(bool texture_2d_enabled) { m_texture_2d_enabled = texture_2d_enabled; }
+    bool texture_3d_enabled() const { return m_texture_3d_enabled; };
+    void set_texture_3d_enabled(bool texture_3d_enabled) { m_texture_3d_enabled = texture_3d_enabled; }
+    bool texture_cube_map_enabled() const { return m_texture_cube_map_enabled; };
+    void set_texture_cube_map_enabled(bool texture_cube_map_enabled) { m_texture_cube_map_enabled = texture_cube_map_enabled; }
+
 private:
     mutable RefPtr<Texture2D> m_texture_target_2d { nullptr };
     mutable RefPtr<Texture> m_currently_bound_texture { nullptr };
     GLenum m_currently_bound_target;
     GLenum m_env_mode { GL_MODULATE };
+
+    // Texturing state per unit, in increasing priority:
+    bool m_texture_1d_enabled { false };
+    bool m_texture_2d_enabled { false };
+    bool m_texture_3d_enabled { false };
+    bool m_texture_cube_map_enabled { false };
 };
 
 }


### PR DESCRIPTION
This PR allows OpenGL applications to call `glEnable(GL_TEXTURE_2D)` and `glDisable(GL_TEXTURE_2D)` to enable or disable the active texture unit's 2D texturing state. 1D, 3D and cube map texturing states were implemented as well, but they are not yet supported by the rasterizer.

GLQuake now has fancy flash effects! (note that merging #11108 is required to see anything in `glquake` at the moment)

![image](https://user-images.githubusercontent.com/3210731/143934519-97c15638-4870-4804-83c3-b4577c9f9237.png)

Also, you can now look at naked teapots:

![image](https://user-images.githubusercontent.com/3210731/143940165-370018df-6b05-4619-97fc-5d55fb358007.png)