### PR TITLE
3DFileViewer: Set correct aspect ratio in view frustum

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -71,7 +71,9 @@ private:
         // Set projection matrix
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();
-        glFrustum(-0.5, 0.5, -0.5, 0.5, 1, 1500);
+
+        auto const half_aspect_ratio = static_cast<double>(RENDER_WIDTH) / RENDER_HEIGHT / 2;
+        glFrustum(-half_aspect_ratio, half_aspect_ratio, -0.5, 0.5, 1, 1500);
 
         m_init_list = glGenLists(1);
         glNewList(m_init_list, GL_COMPILE);


### PR DESCRIPTION
Unsquashes Utah Teapots.

Before:

![image](https://user-images.githubusercontent.com/3210731/143942333-9f8a7159-16a3-4445-951a-1303257fd702.png)

After:

![image](https://user-images.githubusercontent.com/3210731/143941429-3292b471-26e4-4277-9e7f-6b724ac1070b.png)