### PR TITLE
Kernel: Register Virtio console ports with device management

### DIFF
--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -207,14 +207,7 @@ static void populate_devfs_char_devices()
             break;
         }
         case 229: {
-            switch (minor_number) {
-            case 0: {
-                create_devfs_char_device("/dev/hvc0p0", 0666, 229, 0);
-                break;
-            }
-            default:
-                warnln("Unknown character device {}:{}", major_number, minor_number);
-            }
+            create_devfs_char_device(String::formatted("/dev/hvc0p{}", minor_number), 0666, major_number, minor_number);
             break;
         }
         case 10: {


### PR DESCRIPTION
Previously, Virtio console ports would not show up in `/sys/dev/char/`. Also adds support to `SystemServer` to create more than one console port device in `/dev/` in the multiport case.

As a result, `SpiceAgent` no longer crashes. Clipboard integration still does not work however.