### PR TITLE
ByteBuffer: Make less often senseless copies

### DIFF
--- a/Tests/AK/TestBase64.cpp
+++ b/Tests/AK/TestBase64.cpp
@@ -15,7 +15,7 @@ TEST_CASE(test_decode)
     auto decode_equal = [&](const char* input, const char* expected) {
         auto decoded_option = decode_base64(StringView(input));
         EXPECT(decoded_option.has_value());
-        auto decoded = decoded_option.value();
+        auto decoded = decoded_option.release_value();
         EXPECT(String::copy(decoded) == String(expected));
         EXPECT(StringView(expected).length() <= calculate_base64_decoded_length(StringView(input).bytes()));
     };

--- a/Tests/LibCrypto/TestAES.cpp
+++ b/Tests/LibCrypto/TestAES.cpp
@@ -10,9 +10,9 @@
 #include <LibTest/TestCase.h>
 #include <cstring>
 
-static ByteBuffer operator""_b(const char* string, size_t length)
+static ReadonlyBytes operator""_b(const char* string, size_t length)
 {
-    return ByteBuffer::copy(string, length).release_value();
+    return ReadonlyBytes(string, length);
 }
 
 TEST_CASE(test_AES_CBC_name)
@@ -348,7 +348,7 @@ TEST_CASE(test_AES_GCM_128bit_encrypt_empty)
     u8 result_tag[] { 0x58, 0xe2, 0xfc, 0xce, 0xfa, 0x7e, 0x30, 0x61, 0x36, 0x7f, 0x1d, 0x57, 0xa4, 0xe7, 0x45, 0x5a };
     Bytes out;
     auto tag = ByteBuffer::create_uninitialized(16).release_value();
-    cipher.encrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, tag);
+    cipher.encrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, tag);
     EXPECT(memcmp(result_tag, tag.data(), tag.size()) == 0);
 }
 
@@ -360,7 +360,7 @@ TEST_CASE(test_AES_GCM_128bit_encrypt_zeros)
     auto tag = ByteBuffer::create_uninitialized(16).release_value();
     auto out = ByteBuffer::create_uninitialized(16).release_value();
     auto out_bytes = out.bytes();
-    cipher.encrypt("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, tag);
+    cipher.encrypt("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, tag);
     EXPECT(memcmp(result_ct, out.data(), out.size()) == 0);
     EXPECT(memcmp(result_tag, tag.data(), tag.size()) == 0);
 }
@@ -374,9 +374,9 @@ TEST_CASE(test_AES_GCM_128bit_encrypt_multiple_blocks_with_iv)
     auto out = ByteBuffer::create_uninitialized(64).release_value();
     auto out_bytes = out.bytes();
     cipher.encrypt(
-        "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b.bytes(),
+        "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b,
         out_bytes,
-        "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b.bytes(),
+        "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b,
         {},
         tag);
     EXPECT(memcmp(result_ct, out.data(), out.size()) == 0);
@@ -392,9 +392,9 @@ TEST_CASE(test_AES_GCM_128bit_encrypt_with_aad)
     auto out = ByteBuffer::create_uninitialized(64).release_value();
     auto out_bytes = out.bytes();
     cipher.encrypt(
-        "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b.bytes(),
+        "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b,
         out_bytes,
-        "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b.bytes(),
+        "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b,
         {},
         tag);
     EXPECT(memcmp(result_ct, out.data(), out.size()) == 0);
@@ -406,7 +406,7 @@ TEST_CASE(test_AES_GCM_128bit_decrypt_empty)
     Crypto::Cipher::AESCipher::GCMMode cipher("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, 128, Crypto::Cipher::Intent::Encryption);
     u8 input_tag[] { 0x58, 0xe2, 0xfc, 0xce, 0xfa, 0x7e, 0x30, 0x61, 0x36, 0x7f, 0x1d, 0x57, 0xa4, 0xe7, 0x45, 0x5a };
     Bytes out;
-    auto consistency = cipher.decrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, { input_tag, 16 });
+    auto consistency = cipher.decrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, { input_tag, 16 });
     EXPECT_EQ(consistency, Crypto::VerificationConsistency::Consistent);
     EXPECT_EQ(out.size(), 0u);
 }
@@ -419,7 +419,7 @@ TEST_CASE(test_AES_GCM_128bit_decrypt_zeros)
     u8 result_pt[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     auto out = ByteBuffer::create_uninitialized(16).release_value();
     auto out_bytes = out.bytes();
-    auto consistency = cipher.decrypt({ input_ct, 16 }, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, { input_tag, 16 });
+    auto consistency = cipher.decrypt({ input_ct, 16 }, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, { input_tag, 16 });
     EXPECT_EQ(consistency, Crypto::VerificationConsistency::Consistent);
     EXPECT(memcmp(result_pt, out.data(), out.size()) == 0);
 }
@@ -432,7 +432,7 @@ TEST_CASE(test_AES_GCM_128bit_decrypt_multiple_blocks_with_iv)
     u8 result_pt[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
     auto out = ByteBuffer::create_uninitialized(16).release_value();
     auto out_bytes = out.bytes();
-    auto consistency = cipher.decrypt({ input_ct, 16 }, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, { input_tag, 16 });
+    auto consistency = cipher.decrypt({ input_ct, 16 }, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, { input_tag, 16 });
     EXPECT_EQ(consistency, Crypto::VerificationConsistency::Consistent);
     EXPECT(memcmp(result_pt, out.data(), out.size()) == 0);
 }
@@ -448,8 +448,8 @@ TEST_CASE(test_AES_GCM_128bit_decrypt_multiple_blocks_with_aad)
     auto consistency = cipher.decrypt(
         { input_ct, 64 },
         out_bytes,
-        "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b.bytes(),
-        "\xde\xad\xbe\xef\xfa\xaf\x11\xcc"_b.bytes(),
+        "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b,
+        "\xde\xad\xbe\xef\xfa\xaf\x11\xcc"_b,
         { input_tag, 16 });
     EXPECT(memcmp(result_pt, out.data(), out.size()) == 0);
     EXPECT_EQ(consistency, Crypto::VerificationConsistency::Consistent);

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -266,7 +266,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
         ScopeGuard update_after_drop { [this] { update(); } };
 
         if (event.mime_data().has_format("text/x-spreadsheet-data")) {
-            auto data = event.mime_data().data("text/x-spreadsheet-data");
+            auto const& data = event.mime_data().data("text/x-spreadsheet-data");
             StringView urls { data.data(), data.size() };
             Vector<Position> source_positions, target_positions;
 

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -20,7 +20,7 @@ public:
     virtual ~MimeData() { }
 
     ByteBuffer data(const String& mime_type) const { return m_data.get(mime_type).value_or({}); }
-    void set_data(const String& mime_type, const ByteBuffer& data) { m_data.set(mime_type, data); }
+    void set_data(const String& mime_type, ByteBuffer&& data) { m_data.set(mime_type, move(data)); }
 
     bool has_format(const String& mime_type) const { return m_data.contains(mime_type); }
     Vector<String> formats() const;

--- a/Userland/Libraries/LibGemini/Job.cpp
+++ b/Userland/Libraries/LibGemini/Job.cpp
@@ -122,8 +122,8 @@ void Job::on_socket_connected()
                 }
             }
 
-            m_received_buffers.append(payload);
             m_received_size += payload.size();
+            m_received_buffers.append(move(payload));
             flush_received_buffers();
 
             deferred_invoke([this] { did_progress({}, m_received_size); });

--- a/Userland/Libraries/LibHTTP/HttpJob.h
+++ b/Userland/Libraries/LibHTTP/HttpJob.h
@@ -41,8 +41,8 @@ protected:
     virtual bool is_established() const override { return true; }
 
 private:
-    explicit HttpJob(const HttpRequest& request, OutputStream& output_stream)
-        : Job(request, output_stream)
+    explicit HttpJob(HttpRequest&& request, OutputStream& output_stream)
+        : Job(move(request), output_stream)
     {
     }
 

--- a/Userland/Libraries/LibHTTP/HttpsJob.h
+++ b/Userland/Libraries/LibHTTP/HttpsJob.h
@@ -45,8 +45,8 @@ protected:
     virtual void read_while_data_available(Function<IterationDecision()>) override;
 
 private:
-    explicit HttpsJob(const HttpRequest& request, OutputStream& output_stream, const Vector<Certificate>* override_certs = nullptr)
-        : Job(request, output_stream)
+    explicit HttpsJob(HttpRequest&& request, OutputStream& output_stream, const Vector<Certificate>* override_certs = nullptr)
+        : Job(move(request), output_stream)
         , m_override_ca_certificates(override_certs)
     {
     }

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -40,7 +40,7 @@ static Optional<ByteBuffer> handle_content_encoding(const ByteBuffer& buf, const
             dbgln("  Output size: {}", uncompressed.value().size());
         }
 
-        return uncompressed.value();
+        return uncompressed.release_value();
     } else if (content_encoding == "deflate") {
         dbgln_if(JOB_DEBUG, "Job::handle_content_encoding: buf is deflate compressed!");
 
@@ -66,15 +66,15 @@ static Optional<ByteBuffer> handle_content_encoding(const ByteBuffer& buf, const
             dbgln("  Output size: {}", uncompressed.value().size());
         }
 
-        return uncompressed.value();
+        return uncompressed.release_value();
     }
 
     return buf;
 }
 
-Job::Job(const HttpRequest& request, OutputStream& output_stream)
+Job::Job(HttpRequest&& request, OutputStream& output_stream)
     : Core::NetworkJob(output_stream)
-    , m_request(request)
+    , m_request(move(request))
 {
 }
 

--- a/Userland/Libraries/LibHTTP/Job.h
+++ b/Userland/Libraries/LibHTTP/Job.h
@@ -18,7 +18,7 @@ namespace HTTP {
 
 class Job : public Core::NetworkJob {
 public:
-    explicit Job(const HttpRequest&, OutputStream&);
+    explicit Job(HttpRequest&&, OutputStream&);
     virtual ~Job() override;
 
     virtual void start(NonnullRefPtr<Core::Socket>) override = 0;

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -72,7 +72,7 @@ ErrorOr<ByteBuffer> Heap::read_block(u32 block)
     }
     auto buffer_or_empty = m_write_ahead_log.get(block);
     if (buffer_or_empty.has_value())
-        return buffer_or_empty.value();
+        return buffer_or_empty.release_value();
 
     if (block >= m_next_block) {
         warnln("Heap({})::read_block({}): block # out of range (>= {})"sv, name(), block, m_next_block);
@@ -203,10 +203,7 @@ constexpr static int USER_VALUES_OFFSET = 32;
 
 ErrorOr<void> Heap::read_zero_block()
 {
-    auto bytes_or_error = read_block(0);
-    if (bytes_or_error.is_error())
-        return bytes_or_error.error();
-    auto buffer = bytes_or_error.value();
+    auto buffer = TRY(read_block(0));
     auto file_id_buffer = buffer.slice(0, FILE_ID.length());
     auto file_id = StringView(file_id_buffer);
     if (file_id != FILE_ID) {

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -341,7 +341,7 @@ bool TLSv12::add_client_key(ReadonlyBytes certificate_pem_buffer, ReadonlyBytes 
     }
 
     Crypto::PK::RSA rsa(rsa_key);
-    auto certificate = maybe_certificate.value();
+    auto certificate = maybe_certificate.release_value();
     certificate.private_key = rsa.private_key();
 
     return add_client_key(certificate);

--- a/Userland/Services/RequestServer/HttpCommon.h
+++ b/Userland/Services/RequestServer/HttpCommon.h
@@ -81,7 +81,7 @@ OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ClientConnection& clie
 
     auto output_stream = make<OutputFileStream>(pipe_result.value().write_fd);
     output_stream->make_unbuffered();
-    auto job = TJob::construct(request, *output_stream);
+    auto job = TJob::construct(move(request), *output_stream);
     auto protocol_request = TRequest::create_with_job(forward<TBadgedProtocol>(protocol), client, (TJob&)*job, move(output_stream));
     protocol_request->set_request_fd(pipe_result.value().read_fd);
 

--- a/Userland/Utilities/test-crypto.cpp
+++ b/Userland/Utilities/test-crypto.cpp
@@ -547,9 +547,9 @@ auto main(int argc, char** argv) -> int
         g_some_test_failed = true; \
     } while (0)
 
-static ByteBuffer operator""_b(const char* string, size_t length)
+static ReadonlyBytes operator""_b(const char* string, size_t length)
 {
-    return ByteBuffer::copy(string, length).release_value();
+    return ReadonlyBytes(string, length);
 }
 
 // tests go after here
@@ -1051,7 +1051,7 @@ static void aes_gcm_test_encrypt()
         u8 result_tag[] { 0x58, 0xe2, 0xfc, 0xce, 0xfa, 0x7e, 0x30, 0x61, 0x36, 0x7f, 0x1d, 0x57, 0xa4, 0xe7, 0x45, 0x5a };
         Bytes out;
         auto tag = ByteBuffer::create_uninitialized(16).release_value();
-        cipher.encrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, tag);
+        cipher.encrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, tag);
         if (memcmp(result_tag, tag.data(), tag.size()) != 0) {
             FAIL(Invalid auth tag);
             print_buffer(tag, -1);
@@ -1066,7 +1066,7 @@ static void aes_gcm_test_encrypt()
         auto tag = ByteBuffer::create_uninitialized(16).release_value();
         auto out = ByteBuffer::create_uninitialized(16).release_value();
         auto out_bytes = out.bytes();
-        cipher.encrypt("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, tag);
+        cipher.encrypt("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, tag);
         if (memcmp(result_ct, out.data(), out.size()) != 0) {
             FAIL(Invalid ciphertext);
             print_buffer(out, -1);
@@ -1085,9 +1085,9 @@ static void aes_gcm_test_encrypt()
         auto out = ByteBuffer::create_uninitialized(64).release_value();
         auto out_bytes = out.bytes();
         cipher.encrypt(
-            "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b.bytes(),
+            "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b,
             out_bytes,
-            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b.bytes(),
+            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b,
             {},
             tag);
         if (memcmp(result_ct, out.data(), out.size()) != 0) {
@@ -1108,10 +1108,10 @@ static void aes_gcm_test_encrypt()
         auto out = ByteBuffer::create_uninitialized(64).release_value();
         auto out_bytes = out.bytes();
         cipher.encrypt(
-            "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b.bytes(),
+            "\xd9\x31\x32\x25\xf8\x84\x06\xe5\xa5\x59\x09\xc5\xaf\xf5\x26\x9a\x86\xa7\xa9\x53\x15\x34\xf7\xda\x2e\x4c\x30\x3d\x8a\x31\x8a\x72\x1c\x3c\x0c\x95\x95\x68\x09\x53\x2f\xcf\x0e\x24\x49\xa6\xb5\x25\xb1\x6a\xed\xf5\xaa\x0d\xe6\x57\xba\x63\x7b\x39\x1a\xaf\xd2\x55"_b,
             out_bytes,
-            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b.bytes(),
-            "\xde\xad\xbe\xef\xfa\xaf\x11\xcc"_b.bytes(),
+            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b,
+            "\xde\xad\xbe\xef\xfa\xaf\x11\xcc"_b,
             tag);
         if (memcmp(result_ct, out.data(), out.size()) != 0) {
             FAIL(Invalid ciphertext);
@@ -1131,7 +1131,7 @@ static void aes_gcm_test_decrypt()
         Crypto::Cipher::AESCipher::GCMMode cipher("\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, 128, Crypto::Cipher::Intent::Encryption);
         u8 input_tag[] { 0x58, 0xe2, 0xfc, 0xce, 0xfa, 0x7e, 0x30, 0x61, 0x36, 0x7f, 0x1d, 0x57, 0xa4, 0xe7, 0x45, 0x5a };
         Bytes out;
-        auto consistency = cipher.decrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, { input_tag, 16 });
+        auto consistency = cipher.decrypt({}, out, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, { input_tag, 16 });
         if (consistency != Crypto::VerificationConsistency::Consistent) {
             FAIL(Verification reported inconsistent);
         } else if (out.size() != 0) {
@@ -1147,7 +1147,7 @@ static void aes_gcm_test_decrypt()
         u8 result_pt[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
         auto out = ByteBuffer::create_uninitialized(16).release_value();
         auto out_bytes = out.bytes();
-        auto consistency = cipher.decrypt({ input_ct, 16 }, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b.bytes(), {}, { input_tag, 16 });
+        auto consistency = cipher.decrypt({ input_ct, 16 }, out_bytes, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"_b, {}, { input_tag, 16 });
         if (consistency != Crypto::VerificationConsistency::Consistent) {
             FAIL(Verification reported inconsistent);
         } else if (memcmp(result_pt, out.data(), out.size()) != 0) {
@@ -1168,7 +1168,7 @@ static void aes_gcm_test_decrypt()
         auto consistency = cipher.decrypt(
             { input_ct, 64 },
             out_bytes,
-            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b.bytes(),
+            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b,
             {},
             { input_tag, 16 });
         if (memcmp(result_pt, out.data(), out.size()) != 0) {
@@ -1190,8 +1190,8 @@ static void aes_gcm_test_decrypt()
         auto consistency = cipher.decrypt(
             { input_ct, 64 },
             out_bytes,
-            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b.bytes(),
-            "\xde\xad\xbe\xef\xfa\xaf\x11\xcc"_b.bytes(),
+            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b,
+            "\xde\xad\xbe\xef\xfa\xaf\x11\xcc"_b,
             { input_tag, 16 });
         if (memcmp(result_pt, out.data(), out.size()) != 0) {
             FAIL(Invalid plaintext);
@@ -1211,8 +1211,8 @@ static void aes_gcm_test_decrypt()
         auto consistency = cipher.decrypt(
             { input_ct, 64 },
             out_bytes,
-            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b.bytes(),
-            "\xde\xad\xbe\xef\xfa\xaf\x11\xcc"_b.bytes(),
+            "\xca\xfe\xba\xbe\xfa\xce\xdb\xad\xde\xca\xf8\x88\x00\x00\x00\x00"_b,
+            "\xde\xad\xbe\xef\xfa\xaf\x11\xcc"_b,
             { input_tag, 16 });
 
         if (consistency != Crypto::VerificationConsistency::Inconsistent)
@@ -1851,7 +1851,7 @@ static void rsa_test_encrypt()
 {
     {
         I_TEST((RSA RAW | Encryption));
-        ByteBuffer data { "hellohellohellohellohellohellohellohellohellohellohellohello123-"_b };
+        ReadonlyBytes data { "hellohellohellohellohellohellohellohellohellohellohellohello123-"_b };
         u8 result[] { 0x6f, 0x7b, 0xe2, 0xd3, 0x95, 0xf8, 0x8d, 0x87, 0x6d, 0x10, 0x5e, 0xc3, 0xcd, 0xf7, 0xbb, 0xa6, 0x62, 0x8e, 0x45, 0xa0, 0xf1, 0xe5, 0x0f, 0xdf, 0x69, 0xcb, 0xb6, 0xd5, 0x42, 0x06, 0x7d, 0x72, 0xa9, 0x5e, 0xae, 0xbf, 0xbf, 0x0f, 0xe0, 0xeb, 0x31, 0x31, 0xca, 0x8a, 0x81, 0x1e, 0xb9, 0xec, 0x6d, 0xcc, 0xb8, 0xa4, 0xac, 0xa3, 0x31, 0x05, 0xa9, 0xac, 0xc9, 0xd3, 0xe6, 0x2a, 0x18, 0xfe };
         Crypto::PK::RSA rsa(
             "8126832723025844890518845777858816391166654950553329127845898924164623511718747856014227624997335860970996746552094406240834082304784428582653994490504519"_bigint,
@@ -1869,7 +1869,7 @@ static void rsa_test_encrypt()
     }
     {
         I_TEST((RSA PKCS #1 1.5 | Encryption));
-        ByteBuffer data { "hellohellohellohellohellohellohellohellohello123-"_b };
+        ReadonlyBytes data { "hellohellohellohellohellohellohellohellohello123-"_b };
         Crypto::PK::RSA_PKCS1_EME rsa(
             "8126832723025844890518845777858816391166654950553329127845898924164623511718747856014227624997335860970996746552094406240834082304784428582653994490504519"_bigint,
             "4234603516465654167360850580101327813936403862038934287300450163438938741499875303761385527882335478349599685406941909381269804396099893549838642251053393"_bigint,


### PR DESCRIPTION
A while ago, I noticed that `ByteBuffer` has an implicit copy-constructor. So if you have a 10 Megabyte ByteBuffer, it's really easy to accidentally create lots and lots of copies of it, without noticing it.

I thought I'd "fix" this problem by just deleting the copy-constructor, replacing it by an explicit `copy() const` method, and be done with it. But alas, there are many problems:
- This bug is pretty pervasive, and this PR only fixes *very few* of the bugs instances.
- Some places even rely on this implicit copying, most prominently at least two places do `HashMap<T, ByteBuffer> m_foo; m_foo.get(…)`.

So maybe it there should be a `ByteBufferView` type, of maybe we should specialize `Traits<ByteBuffer>::PeekType` to be something different (`Bytes` probably?), or `get` shouldn't copy in the first place, or something like that. This discussion is out of scope for this PR, but I'd like to know how we wanna solve this. Let's discuss it in #ak.

This PR fixes the issue in *some* places. But not all. But at least it's progress.