### PR TITLE
AK: Fix a copy-paste error in TypedTransfer::copy

### DIFF
--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -37,7 +37,7 @@ public:
             return 0;
 
         if constexpr (Traits<T>::is_trivial()) {
-            __builtin_memmove(destination, source, count * sizeof(T));
+            __builtin_memcpy(destination, source, count * sizeof(T));
             return count;
         }
 


### PR DESCRIPTION
Actually copy trivial data and not move it.

---
This might not actually make a difference on instruction level, but you never know...