### PR TITLE
LibGL: Add `GL::present_context()`

### DIFF
--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -33,4 +33,9 @@ void make_context_current(GLContext* context)
     g_gl_context = context;
 }
 
+void present_context(GLContext* context)
+{
+    context->present();
+}
+
 }

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -93,5 +93,6 @@ public:
 
 OwnPtr<GLContext> create_context(Gfx::Bitmap&);
 void make_context_current(GLContext*);
+void present_context(GLContext*);
 
 }


### PR DESCRIPTION
This provides a convenience method that performs the virtual resolution for `::present` on the provided `GLContext`.

After merging this, this fix for SDL2 should also be merged:
https://github.com/SerenityPorts/SDL/pull/24