### PR TITLE
LibJS+LibUnicode: Miscellaneous Intl.DateTimeFormat follow-ups 

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -151,6 +151,11 @@ static ErrorOr<void> parse_calendars(String locale_calendars_path, UnicodeLocale
     };
 
     calendars_object.as_object().for_each_member([&](auto const& calendar_name, JsonValue const& value) {
+        // The generic calendar is not a supported Unicode calendar key, so skip it:
+        // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar#unicode_calendar_keys
+        if (calendar_name == "generic"sv)
+            return;
+
         auto& calendar = ensure_calendar(calendar_name);
 
         if (!locale_data.calendars.contains_slow(calendar_name))

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
@@ -407,12 +407,17 @@ static ErrorOr<void> parse_calendar_keywords(String locale_dates_path, UnicodeLo
         auto const& calendars_object = dates_object.as_object().get("calendars"sv);
 
         calendars_object.as_object().for_each_member([&](auto const& calendar_name, JsonValue const&) {
-            keyword_values.append(calendar_name);
+            // The generic calendar is not a supported Unicode calendar key, so skip it:
+            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/calendar#unicode_calendar_keys
+            if (calendar_name == "generic"sv)
+                return;
 
             // FIXME: Similar to the calendar aliases defined in GenerateUnicodeDateTimeFormat, this
             //        should be parsed from BCP47. https://unicode-org.atlassian.net/browse/CLDR-15158
             if (calendar_name == "gregorian"sv)
                 keyword_values.append("gregory"sv);
+            else
+                keyword_values.append(calendar_name);
         });
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -373,7 +373,7 @@ static auto& find_key_in_value(T& value, StringView key)
 }
 
 // 9.2.7 ResolveLocale ( availableLocales, requestedLocales, options, relevantExtensionKeys, localeData ), https://tc39.es/ecma402/#sec-resolvelocale
-LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptions const& options, Vector<StringView> const& relevant_extension_keys)
+LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptions const& options, Span<StringView const> relevant_extension_keys)
 {
     // 1. Let matcher be options.[[localeMatcher]].
     auto const& matcher = options.locale_matcher;

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -46,7 +46,7 @@ bool is_well_formed_unit_identifier(StringView unit_identifier);
 ThrowCompletionOr<Vector<String>> canonicalize_locale_list(GlobalObject&, Value locales);
 Optional<String> best_available_locale(StringView locale);
 String insert_unicode_extension_and_canonicalize(Unicode::LocaleID locale_id, Unicode::LocaleExtension extension);
-LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptions const& options, Vector<StringView> const& relevant_extension_keys);
+LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptions const& options, Span<StringView const> relevant_extension_keys);
 Vector<String> lookup_supported_locales(Vector<String> const& requested_locales);
 Vector<String> best_fit_supported_locales(Vector<String> const& requested_locales);
 ThrowCompletionOr<Array*> supported_locales(GlobalObject&, Vector<String> const& requested_locales, Value options);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -12,14 +12,6 @@
 
 namespace JS::Intl {
 
-Vector<StringView> const& DateTimeFormat::relevant_extension_keys()
-{
-    // 11.3.3 Internal slots, https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots
-    // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "hc", "nu" ».
-    static Vector<StringView> relevant_extension_keys { "ca"sv, "hc"sv, "nu"sv };
-    return relevant_extension_keys;
-}
-
 // 11 DateTimeFormat Objects, https://tc39.es/ecma402/#datetimeformat-objects
 DateTimeFormat::DateTimeFormat(Object& prototype)
     : Object(prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
@@ -32,7 +33,12 @@ public:
         Short,
     };
 
-    static Vector<StringView> const& relevant_extension_keys(); // [[RelevantExtensionKeys]]
+    static constexpr auto relevant_extension_keys()
+    {
+        // 11.3.3 Internal slots, https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots
+        // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "hc", "nu" ».
+        return AK::Array { "ca"sv, "hc"sv, "nu"sv };
+    }
 
     DateTimeFormat(Object& prototype);
     virtual ~DateTimeFormat() override = default;

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.cpp
@@ -15,18 +15,6 @@ Locale* Locale::create(GlobalObject& global_object, Unicode::LocaleID const& loc
     return global_object.heap().allocate<Locale>(global_object, locale_id, *global_object.intl_locale_prototype());
 }
 
-Vector<StringView> const& Locale::relevant_extension_keys()
-{
-    // 14.2.2 Internal slots, https://tc39.es/ecma402/#sec-intl.locale-internal-slots
-    // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "co", "hc", "kf", "kn", "nu" ».
-    // If %Collator%.[[RelevantExtensionKeys]] does not contain "kf", then remove "kf" from %Locale%.[[RelevantExtensionKeys]].
-    // If %Collator%.[[RelevantExtensionKeys]] does not contain "kn", then remove "kn" from %Locale%.[[RelevantExtensionKeys]].
-
-    // FIXME: We do not yet have an Intl.Collator object. For now, we behave as if "kf" and "kn" exist, as test262 depends on it.
-    static Vector<StringView> relevant_extension_keys { "ca"sv, "co"sv, "hc"sv, "kf"sv, "kn"sv, "nu"sv };
-    return relevant_extension_keys;
-}
-
 // 14 Locale Objects, https://tc39.es/ecma402/#locale-objects
 Locale::Locale(Object& prototype)
     : Object(prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Locale.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
@@ -21,7 +22,16 @@ class Locale final : public Object {
 public:
     static Locale* create(GlobalObject&, Unicode::LocaleID const&);
 
-    static Vector<StringView> const& relevant_extension_keys(); // [[RelevantExtensionKeys]]
+    static constexpr auto relevant_extension_keys()
+    {
+        // 14.2.2 Internal slots, https://tc39.es/ecma402/#sec-intl.locale-internal-slots
+        // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "co", "hc", "kf", "kn", "nu" ».
+        // If %Collator%.[[RelevantExtensionKeys]] does not contain "kf", then remove "kf" from %Locale%.[[RelevantExtensionKeys]].
+        // If %Collator%.[[RelevantExtensionKeys]] does not contain "kn", then remove "kn" from %Locale%.[[RelevantExtensionKeys]].
+
+        // FIXME: We do not yet have an Intl.Collator object. For now, we behave as if "kf" and "kn" exist, as test262 depends on it.
+        return AK::Array { "ca"sv, "co"sv, "hc"sv, "kf"sv, "kn"sv, "nu"sv };
+    }
 
     Locale(Object& prototype);
     Locale(Unicode::LocaleID const&, Object& prototype);

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -108,7 +108,7 @@ static ThrowCompletionOr<String> apply_options_to_tag(GlobalObject& global_objec
 }
 
 // 14.1.2 ApplyUnicodeExtensionToTag ( tag, options, relevantExtensionKeys ), https://tc39.es/ecma402/#sec-apply-unicode-extension-to-tag
-static LocaleAndKeys apply_unicode_extension_to_tag(StringView tag, LocaleAndKeys options, Vector<StringView> const& relevant_extension_keys)
+static LocaleAndKeys apply_unicode_extension_to_tag(StringView tag, LocaleAndKeys options, Span<StringView const> relevant_extension_keys)
 {
     // 1. Assert: Type(tag) is String.
     // 2. Assert: tag matches the unicode_locale_id production.
@@ -253,7 +253,7 @@ ThrowCompletionOr<Object*> LocaleConstructor::construct(FunctionObject& new_targ
     auto options_value = vm.argument(1);
 
     // 2. Let relevantExtensionKeys be %Locale%.[[RelevantExtensionKeys]].
-    auto const& relevant_extension_keys = Locale::relevant_extension_keys();
+    auto relevant_extension_keys = Locale::relevant_extension_keys();
 
     // 3. Let internalSlotsList be « [[InitializedLocale]], [[Locale]], [[Calendar]], [[Collation]], [[HourCycle]], [[NumberingSystem]] ».
     // 4. If relevantExtensionKeys contains "kf", then
@@ -341,14 +341,14 @@ ThrowCompletionOr<Object*> LocaleConstructor::construct(FunctionObject& new_targ
         locale->set_hour_cycle(result.hc.release_value());
 
     // 34. If relevantExtensionKeys contains "kf", then
-    if (relevant_extension_keys.contains_slow("kf"sv)) {
+    if (relevant_extension_keys.span().contains_slow("kf"sv)) {
         // a. Set locale.[[CaseFirst]] to r.[[kf]].
         if (result.kf.has_value())
             locale->set_case_first(result.kf.release_value());
     }
 
     // 35. If relevantExtensionKeys contains "kn", then
-    if (relevant_extension_keys.contains_slow("kn"sv)) {
+    if (relevant_extension_keys.span().contains_slow("kn"sv)) {
         // a. If ! SameValue(r.[[kn]], "true") is true or r.[[kn]] is the empty String, then
         if (result.kn.has_value() && (same_value(js_string(vm, *result.kn), js_string(vm, "true")) || result.kn->is_empty())) {
             // i. Set locale.[[Numeric]] to true.

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
 #include <AK/Utf8View.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -16,14 +15,6 @@
 #include <stdlib.h>
 
 namespace JS::Intl {
-
-Vector<StringView> const& NumberFormat::relevant_extension_keys()
-{
-    // 15.3.3 Internal slots, https://tc39.es/ecma402/#sec-intl.numberformat-internal-slots
-    // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
-    static Vector<StringView> relevant_extension_keys { "nu"sv };
-    return relevant_extension_keys;
-}
 
 // 15 NumberFormat Objects, https://tc39.es/ecma402/#numberformat-objects
 NumberFormat::NumberFormat(Object& prototype)

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Optional.h>
 #include <AK/String.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
@@ -72,7 +73,12 @@ public:
         ExceptZero,
     };
 
-    static Vector<StringView> const& relevant_extension_keys(); // [[RelevantExtensionKeys]]
+    static constexpr auto relevant_extension_keys()
+    {
+        // 15.3.3 Internal slots, https://tc39.es/ecma402/#sec-intl.numberformat-internal-slots
+        // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
+        return AK::Array { "nu"sv };
+    }
 
     NumberFormat(Object& prototype);
     virtual ~NumberFormat() override = default;

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
@@ -21,32 +21,27 @@ describe("correct behavior", () => {
         const en = Intl.DateTimeFormat("en", { calendar: "gregory" });
         expect(en.resolvedOptions().calendar).toBe("gregory");
 
-        const el = Intl.DateTimeFormat("el", { calendar: "generic" });
-        expect(el.resolvedOptions().calendar).toBe("generic");
+        const el = Intl.DateTimeFormat("el", { calendar: "gregory" });
+        expect(el.resolvedOptions().calendar).toBe("gregory");
     });
 
     test("calendar may be set by locale extension", () => {
         const en = Intl.DateTimeFormat("en-u-ca-gregory");
         expect(en.resolvedOptions().calendar).toBe("gregory");
 
-        const el = Intl.DateTimeFormat("el-u-ca-generic");
-        expect(el.resolvedOptions().calendar).toBe("generic");
+        const el = Intl.DateTimeFormat("el-u-ca-gregory");
+        expect(el.resolvedOptions().calendar).toBe("gregory");
     });
 
     test("calendar option overrides locale extension", () => {
-        const el = Intl.DateTimeFormat("el-u-ca-generic", { calendar: "gregory" });
+        const el = Intl.DateTimeFormat("el-u-ca-gregory", { calendar: "gregory" });
         expect(el.resolvedOptions().calendar).toBe("gregory");
     });
 
     test("calendar option limited to known 'ca' values", () => {
-        ["generic", "hello"].forEach(calendar => {
+        ["gregory", "hello"].forEach(calendar => {
             const en = Intl.DateTimeFormat("en", { calendar: calendar });
-            expect(en.resolvedOptions().calendar).toBe("generic");
-        });
-
-        ["generic", "hello"].forEach(calendar => {
-            const en = Intl.DateTimeFormat(`en-u-ca-${calendar}`);
-            expect(en.resolvedOptions().calendar).toBe("generic");
+            expect(en.resolvedOptions().calendar).toBe("gregory");
         });
     });
 

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -67,7 +67,7 @@ StringView calendar_pattern_style_to_string(CalendarPatternStyle style)
     case CalendarPatternStyle::Long:
         return "long"sv;
     case CalendarPatternStyle::Numeric:
-        return "Numeric"sv;
+        return "numeric"sv;
     case CalendarPatternStyle::TwoDigit:
         return "2-digit"sv;
     default:


### PR DESCRIPTION
Mostly for the last commit, which fixes the flakiness of this test:
https://dev.azure.com/SerenityOS/SerenityOS/_build/results?buildId=5537&view=logs&j=85a3409c-8a2a-5c59-a399-3144c1987667&t=db5da47f-8506-5bb6-d73c-b7b743960fc8&l=421

I'm not sure why that test isn't deterministic. CLDR has a data file to define per-locale calendar preferences, which we aren't parsing yet, because the idea for now is only to support Gregorian as a base (other calendars are each defined in their own CLDR packages).