### PR TITLE
Minesweeper: Replace potentially offensive term

### DIFF
--- a/Userland/Games/Minesweeper/Field.cpp
+++ b/Userland/Games/Minesweeper/Field.cpp
@@ -497,7 +497,7 @@ void Field::set_field_difficulty(Difficulty difficulty)
     case Difficulty::Expert:
         set_field_size(difficulty, 16, 30, 99);
         break;
-    case Difficulty::Madwoman:
+    case Difficulty::Madness:
         set_field_size(difficulty, 32, 60, 350);
         break;
     default:

--- a/Userland/Games/Minesweeper/Field.h
+++ b/Userland/Games/Minesweeper/Field.h
@@ -49,7 +49,7 @@ public:
         Beginner,
         Intermediate,
         Expert,
-        Madwoman,
+        Madness,
         Custom
     };
 
@@ -62,8 +62,8 @@ public:
             return "intermediate"sv;
         case Difficulty::Expert:
             return "expert"sv;
-        case Difficulty::Madwoman:
-            return "madwoman"sv;
+        case Difficulty::Madness:
+            return "madness"sv;
         case Difficulty::Custom:
             return "custom"sv;
         default:
@@ -83,7 +83,10 @@ public:
             return Difficulty::Expert;
 
         if (difficulty_string.equals_ignoring_case("madwoman"))
-            return Difficulty::Madwoman;
+            return Difficulty::Madness;
+
+        if (difficulty_string.equals_ignoring_case("madness"))
+            return Difficulty::Madness;
 
         if (difficulty_string.equals_ignoring_case("custom"))
             return Difficulty::Custom;

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -133,10 +133,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(difficulty_menu->try_add_action(action));
     difficulty_actions.add_action(action);
 
-    action = GUI::Action::create_checkable("&Madwoman", { Mod_Ctrl, Key_M }, [&](auto&) {
-        field->set_field_difficulty(Field::Difficulty::Madwoman);
+    action = GUI::Action::create_checkable("&Madness", { Mod_Ctrl, Key_M }, [&](auto&) {
+        field->set_field_difficulty(Field::Difficulty::Madness);
     });
-    action->set_checked(field->difficulty() == Field::Difficulty::Madwoman);
+    action->set_checked(field->difficulty() == Field::Difficulty::Madness);
     TRY(difficulty_menu->try_add_action(action));
     difficulty_actions.add_action(action);
 


### PR DESCRIPTION
The hardest difficulty in Minesweeper was called "madwoman". It was a
nice idea to use a feminine variant of "madman" as an attempt of being
inclusive, but that variant might be considered offensive as well: it
can be interpreted as if we are implying all women are mad.

This commit replaces it with "madness". It is similar enough to be
recognizable but it is also gender-neutral.