### PR TITLE
AK: Mark smart pointers as [[nodiscard]]

### DIFF
--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -25,7 +25,7 @@ template<typename T>
 class WeakPtr;
 
 template<typename T>
-class NonnullOwnPtr {
+class [[nodiscard]] NonnullOwnPtr {
 public:
     using ElementType = T;
 

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -39,7 +39,7 @@ ALWAYS_INLINE void unref_if_not_null(T* ptr)
 }
 
 template<typename T>
-class NonnullRefPtr {
+class [[nodiscard]] NonnullRefPtr {
     template<typename U, typename P>
     friend class RefPtr;
     template<typename U>
@@ -218,8 +218,11 @@ public:
         AK::swap(m_ptr, other.m_ptr);
     }
 
+    // clang-format off
 private:
     NonnullRefPtr() = delete;
+    // clang-format on
+
     ALWAYS_INLINE RETURNS_NONNULL T* as_nonnull_ptr() const
     {
         VERIFY(m_ptr);

--- a/AK/OwnPtr.h
+++ b/AK/OwnPtr.h
@@ -15,7 +15,7 @@
 namespace AK {
 
 template<typename T>
-class OwnPtr {
+class [[nodiscard]] OwnPtr {
 public:
     OwnPtr() = default;
 

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -27,7 +27,7 @@ template<typename T>
 class OwnPtr;
 
 template<typename T, typename PtrTraits>
-class RefPtr {
+class [[nodiscard]] RefPtr {
     template<typename U, typename P>
     friend class RefPtr;
     template<typename U>

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -15,7 +15,7 @@
 namespace AK {
 
 template<typename T>
-class WeakPtr {
+class [[nodiscard]] WeakPtr {
     template<typename U>
     friend class Weakable;
 

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -476,7 +476,7 @@ void UHCIController::spawn_port_proc()
     if (process_name.is_error())
         TODO();
 
-    Process::create_kernel_process(usb_hotplug_thread, process_name.release_value(), [&] {
+    (void)Process::create_kernel_process(usb_hotplug_thread, process_name.release_value(), [&] {
         for (;;) {
             if (m_root_hub)
                 m_root_hub->check_for_port_updates();

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -656,7 +656,7 @@ void Plan9FS::ensure_thread()
         auto process_name = KString::try_create("Plan9FS");
         if (process_name.is_error())
             TODO();
-        Process::create_kernel_process(m_thread, process_name.release_value(), [&]() {
+        (void)Process::create_kernel_process(m_thread, process_name.release_value(), [&]() {
             thread_main();
             m_thread_running.store(false, AK::MemoryOrder::memory_order_release);
         });

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -319,7 +319,7 @@ ErrorOr<void> VirtualFileSystem::mknod(StringView path, mode_t mode, dev_t dev, 
 
     auto basename = KLexicalPath::basename(path);
     dbgln_if(VFS_DEBUG, "VirtualFileSystem::mknod: '{}' mode={} dev={} in {}", basename, mode, dev, parent_inode.identifier());
-    TRY(parent_inode.create_child(basename, mode, dev, current_process.euid(), current_process.egid()));
+    (void)TRY(parent_inode.create_child(basename, mode, dev, current_process.euid(), current_process.egid()));
     return {};
 }
 
@@ -385,7 +385,7 @@ ErrorOr<void> VirtualFileSystem::mkdir(StringView path, mode_t mode, Custody& ba
 
     auto basename = KLexicalPath::basename(path);
     dbgln_if(VFS_DEBUG, "VirtualFileSystem::mkdir: '{}' in {}", basename, parent_inode.identifier());
-    TRY(parent_inode.create_child(basename, S_IFDIR | mode, 0, current_process.euid(), current_process.egid()));
+    (void)TRY(parent_inode.create_child(basename, S_IFDIR | mode, 0, current_process.euid(), current_process.egid()));
     return {};
 }
 

--- a/Kernel/Library/ThreadSafeNonnullRefPtr.h
+++ b/Kernel/Library/ThreadSafeNonnullRefPtr.h
@@ -40,7 +40,7 @@ ALWAYS_INLINE void unref_if_not_null(T* ptr)
 }
 
 template<typename T>
-class NonnullRefPtr {
+class [[nodiscard]] NonnullRefPtr {
     template<typename U, typename P>
     friend class RefPtr;
     template<typename U>
@@ -223,8 +223,10 @@ public:
         other.exchange(ptr);
     }
 
+    // clang-format off
 private:
     NonnullRefPtr() = delete;
+    // clang-format on
 
     ALWAYS_INLINE T* as_ptr() const
     {

--- a/Kernel/Library/ThreadSafeRefPtr.h
+++ b/Kernel/Library/ThreadSafeRefPtr.h
@@ -117,7 +117,7 @@ struct RefPtrTraits {
 };
 
 template<typename T, typename PtrTraits>
-class RefPtr {
+class [[nodiscard]] RefPtr {
     template<typename U, typename P>
     friend class RefPtr;
     template<typename U>

--- a/Kernel/Library/ThreadSafeWeakPtr.h
+++ b/Kernel/Library/ThreadSafeWeakPtr.h
@@ -11,7 +11,7 @@
 namespace AK {
 
 template<typename T>
-class WeakPtr {
+class [[nodiscard]] WeakPtr {
     template<typename U>
     friend class Weakable;
 

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -197,7 +197,7 @@ ErrorOr<Region*> AddressSpace::allocate_region_with_vmobject(VirtualRange const&
 
 void AddressSpace::deallocate_region(Region& region)
 {
-    take_region(region);
+    (void)take_region(region);
 }
 
 NonnullOwnPtr<Region> AddressSpace::take_region(Region& region)

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -46,7 +46,7 @@ void NetworkTask::spawn()
     auto name = KString::try_create("NetworkTask");
     if (name.is_error())
         TODO();
-    Process::create_kernel_process(thread, name.release_value(), NetworkTask_main, nullptr);
+    (void)Process::create_kernel_process(thread, name.release_value(), NetworkTask_main, nullptr);
     network_task = thread;
 }
 

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -15,7 +15,7 @@ namespace Kernel {
 UNMAP_AFTER_INIT void SyncTask::spawn()
 {
     RefPtr<Thread> syncd_thread;
-    Process::create_kernel_process(syncd_thread, KString::must_create("SyncTask"), [] {
+    (void)Process::create_kernel_process(syncd_thread, KString::must_create("SyncTask"), [] {
         dbgln("SyncTask is running");
         for (;;) {
             VirtualFileSystem::sync();

--- a/Kernel/WorkQueue.cpp
+++ b/Kernel/WorkQueue.cpp
@@ -25,7 +25,7 @@ UNMAP_AFTER_INIT WorkQueue::WorkQueue(StringView name)
     auto name_kstring = KString::try_create(name);
     if (name_kstring.is_error())
         TODO();
-    Process::create_kernel_process(thread, name_kstring.release_value(), [this] {
+    (void)Process::create_kernel_process(thread, name_kstring.release_value(), [this] {
         for (;;) {
             WorkItem* item;
             bool have_more;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -220,7 +220,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
 
     {
         RefPtr<Thread> init_stage2_thread;
-        Process::create_kernel_process(init_stage2_thread, KString::must_create("init_stage2"), init_stage2, nullptr, THREAD_AFFINITY_DEFAULT, Process::RegisterProcess::No);
+        (void)Process::create_kernel_process(init_stage2_thread, KString::must_create("init_stage2"), init_stage2, nullptr, THREAD_AFFINITY_DEFAULT, Process::RegisterProcess::No);
         // We need to make sure we drop the reference for init_stage2_thread
         // before calling into Scheduler::start, otherwise we will have a
         // dangling Thread that never gets cleaned up
@@ -319,7 +319,7 @@ void init_stage2(void*)
     (void)RandomDevice::must_create().leak_ref();
     PTYMultiplexer::initialize();
 
-    SB16::try_detect_and_create();
+    (void)SB16::try_detect_and_create();
     AC97::detect();
 
     StorageManagement::the().initialize(kernel_command_line().root_device(), kernel_command_line().is_force_pio());

--- a/Meta/Lagom/Fuzzers/FuzzGemini.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGemini.cpp
@@ -13,6 +13,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto gemini = StringView(static_cast<const unsigned char*>(data), size);
-    Gemini::Document::parse(gemini, {});
+    (void)Gemini::Document::parse(gemini, {});
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzMarkdown.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMarkdown.cpp
@@ -13,6 +13,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto markdown = StringView(static_cast<const unsigned char*>(data), size);
-    Markdown::Document::parse(markdown);
+    (void)Markdown::Document::parse(markdown);
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzShell.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzShell.cpp
@@ -13,6 +13,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto source = StringView(static_cast<const unsigned char*>(data), size);
     Shell::Parser parser(source);
-    parser.parse();
+    (void)parser.parse();
     return 0;
 }

--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -544,7 +544,7 @@ public:
                             message_generator.append("move(*");
                     } else {
                         message_generator.append(R"~~~(
-        )~~~");
+        (void) )~~~");
                     }
 
                     message_generator.append("m_connection.template send_sync<Messages::@endpoint.name@::@message.pascal_name@>(");

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -20,7 +20,7 @@ TESTJS_GLOBAL_FUNCTION(can_parse_source, canParseSource)
 {
     auto source = TRY(vm.argument(0).to_string(global_object));
     auto parser = JS::Parser(JS::Lexer(source));
-    parser.parse_program();
+    (void)parser.parse_program();
     return JS::Value(!parser.has_errors());
 }
 

--- a/Tests/LibSQL/TestSqlDatabase.cpp
+++ b/Tests/LibSQL/TestSqlDatabase.cpp
@@ -95,7 +95,7 @@ void insert_and_verify(int count)
     {
         auto db = SQL::Database::construct("/tmp/test.db");
         EXPECT(!db->open().is_error());
-        setup_table(db);
+        (void)setup_table(db);
         commit(db);
     }
     {
@@ -154,7 +154,7 @@ TEST_CASE(add_schema_to_database)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     auto db = SQL::Database::construct("/tmp/test.db");
     EXPECT(!db->open().is_error());
-    setup_schema(db);
+    (void)setup_schema(db);
     commit(db);
 }
 
@@ -164,7 +164,7 @@ TEST_CASE(get_schema_from_database)
     {
         auto db = SQL::Database::construct("/tmp/test.db");
         EXPECT(!db->open().is_error());
-        setup_schema(db);
+        (void)setup_schema(db);
         commit(db);
     }
     {
@@ -181,7 +181,7 @@ TEST_CASE(add_table_to_database)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     auto db = SQL::Database::construct("/tmp/test.db");
     EXPECT(!db->open().is_error());
-    setup_table(db);
+    (void)setup_table(db);
     commit(db);
 }
 
@@ -191,7 +191,7 @@ TEST_CASE(get_table_from_database)
     {
         auto db = SQL::Database::construct("/tmp/test.db");
         EXPECT(!db->open().is_error());
-        setup_table(db);
+        (void)setup_table(db);
         commit(db);
     }
     {

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -163,7 +163,7 @@ void FileProvider::build_filesystem_cache()
     m_building_cache = true;
     m_work_queue.enqueue("/");
 
-    Threading::BackgroundAction<int>::construct(
+    (void)Threading::BackgroundAction<int>::construct(
         [this](auto&) {
             String slash = "/";
             auto timer = Core::ElapsedTimer::start_new();

--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Browser Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
-    TRY(window->add_tab<BrowserSettingsWidget>("Browser"));
+    (void)TRY(window->add_tab<BrowserSettingsWidget>("Browser"));
 
     window->show();
     return app->exec();

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -276,7 +276,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& tab_widget = *widget->find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     auto backtrace_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Backtrace"));
-    TRY(backtrace_tab->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(backtrace_tab->try_set_layout<GUI::VerticalBoxLayout>());
     backtrace_tab->layout()->set_margins(4);
 
     auto backtrace_label = TRY(backtrace_tab->try_add<GUI::Label>("A backtrace for each thread alive during the crash is listed below:"));
@@ -287,7 +287,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     backtrace_tab_widget->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
     for (auto& backtrace : thread_backtraces) {
         auto container = TRY(backtrace_tab_widget->try_add_tab<GUI::Widget>(backtrace.title));
-        TRY(container->try_set_layout<GUI::VerticalBoxLayout>());
+        (void)TRY(container->try_set_layout<GUI::VerticalBoxLayout>());
         container->layout()->set_margins(4);
         auto backtrace_text_editor = TRY(container->try_add<GUI::TextEditor>());
         backtrace_text_editor->set_text(backtrace.text);
@@ -307,7 +307,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     cpu_registers_tab_widget->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
     for (auto& cpu_registers : thread_cpu_registers) {
         auto container = TRY(cpu_registers_tab_widget->try_add_tab<GUI::Widget>(cpu_registers.title));
-        TRY(container->try_set_layout<GUI::VerticalBoxLayout>());
+        (void)TRY(container->try_set_layout<GUI::VerticalBoxLayout>());
         container->layout()->set_margins(4);
         auto cpu_registers_text_editor = TRY(container->try_add<GUI::TextEditor>());
         cpu_registers_text_editor->set_text(cpu_registers.text);
@@ -316,7 +316,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto environment_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Environment"));
-    TRY(environment_tab->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(environment_tab->try_set_layout<GUI::VerticalBoxLayout>());
     environment_tab->layout()->set_margins(4);
 
     auto environment_text_editor = TRY(environment_tab->try_add<GUI::TextEditor>());
@@ -325,7 +325,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     environment_text_editor->set_should_hide_unnecessary_scrollbars(true);
 
     auto memory_regions_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Memory Regions"));
-    TRY(memory_regions_tab->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(memory_regions_tab->try_set_layout<GUI::VerticalBoxLayout>());
     memory_regions_tab->layout()->set_margins(4);
 
     auto memory_regions_text_editor = TRY(memory_regions_tab->try_add<GUI::TextEditor>());

--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -30,7 +30,7 @@ bool MonitorWidget::set_wallpaper(String path)
     if (!is_different_to_current_wallpaper_path(path))
         return false;
 
-    Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
+    (void)Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
         [path](auto&) -> ErrorOr<NonnullRefPtr<Gfx::Bitmap>> {
             if (path.is_empty())
                 return Error::from_errno(ENOENT);

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -27,10 +27,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-display-settings");
 
     auto window = TRY(GUI::SettingsWindow::create("Display Settings"));
-    TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background"));
-    TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts"));
-    TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor"));
-    TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces"));
+    (void)TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background"));
+    (void)TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts"));
+    (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor"));
+    (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces"));
 
     window->set_icon(app_icon.bitmap_for_size(16));
 

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -278,7 +278,7 @@ ErrorOr<int> run_in_desktop_mode()
     window->set_has_alpha_channel(true);
 
     auto desktop_widget = TRY(window->try_set_main_widget<FileManager::DesktopWidget>());
-    TRY(desktop_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(desktop_widget->try_set_layout<GUI::VerticalBoxLayout>());
 
     auto directory_view = TRY(desktop_widget->try_add<DirectoryView>(DirectoryView::Mode::Desktop));
     directory_view->set_name("directory_view");
@@ -904,31 +904,31 @@ ErrorOr<int> run_in_windowed_mode(String initial_location, String entry_focused_
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("File Manager", GUI::Icon::default_icon("app-file-manager"), window)));
 
-    TRY(main_toolbar.try_add_action(go_back_action));
-    TRY(main_toolbar.try_add_action(go_forward_action));
-    TRY(main_toolbar.try_add_action(open_parent_directory_action));
-    TRY(main_toolbar.try_add_action(go_home_action));
+    (void)TRY(main_toolbar.try_add_action(go_back_action));
+    (void)TRY(main_toolbar.try_add_action(go_forward_action));
+    (void)TRY(main_toolbar.try_add_action(open_parent_directory_action));
+    (void)TRY(main_toolbar.try_add_action(go_home_action));
 
     TRY(main_toolbar.try_add_separator());
-    TRY(main_toolbar.try_add_action(directory_view->open_terminal_action()));
+    (void)TRY(main_toolbar.try_add_action(directory_view->open_terminal_action()));
 
     TRY(main_toolbar.try_add_separator());
-    TRY(main_toolbar.try_add_action(mkdir_action));
-    TRY(main_toolbar.try_add_action(touch_action));
+    (void)TRY(main_toolbar.try_add_action(mkdir_action));
+    (void)TRY(main_toolbar.try_add_action(touch_action));
     TRY(main_toolbar.try_add_separator());
 
-    TRY(main_toolbar.try_add_action(focus_dependent_delete_action));
-    TRY(main_toolbar.try_add_action(directory_view->rename_action()));
+    (void)TRY(main_toolbar.try_add_action(focus_dependent_delete_action));
+    (void)TRY(main_toolbar.try_add_action(directory_view->rename_action()));
 
     TRY(main_toolbar.try_add_separator());
-    TRY(main_toolbar.try_add_action(cut_action));
-    TRY(main_toolbar.try_add_action(copy_action));
-    TRY(main_toolbar.try_add_action(paste_action));
+    (void)TRY(main_toolbar.try_add_action(cut_action));
+    (void)TRY(main_toolbar.try_add_action(copy_action));
+    (void)TRY(main_toolbar.try_add_action(paste_action));
 
     TRY(main_toolbar.try_add_separator());
-    TRY(main_toolbar.try_add_action(directory_view->view_as_icons_action()));
-    TRY(main_toolbar.try_add_action(directory_view->view_as_table_action()));
-    TRY(main_toolbar.try_add_action(directory_view->view_as_columns_action()));
+    (void)TRY(main_toolbar.try_add_action(directory_view->view_as_icons_action()));
+    (void)TRY(main_toolbar.try_add_action(directory_view->view_as_table_action()));
+    (void)TRY(main_toolbar.try_add_action(directory_view->view_as_columns_action()));
 
     directory_view->on_path_change = [&](String const& new_path, bool can_read_in_path, bool can_write_in_path) {
         auto icon = GUI::FileIconProvider::icon_for_path(new_path);

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -58,7 +58,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(570, 500);
 
     auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    TRY(widget->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(widget->try_set_layout<GUI::VerticalBoxLayout>());
     widget->set_fill_with_background_color(true);
     widget->layout()->set_spacing(2);
 
@@ -72,11 +72,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto left_tab_bar = TRY(splitter->try_add<GUI::TabWidget>());
     auto tree_view_container = TRY(left_tab_bar->try_add_tab<GUI::Widget>("Browse"));
-    TRY(tree_view_container->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(tree_view_container->try_set_layout<GUI::VerticalBoxLayout>());
     tree_view_container->layout()->set_margins(4);
     auto tree_view = TRY(tree_view_container->try_add<GUI::TreeView>());
     auto search_view = TRY(left_tab_bar->try_add_tab<GUI::Widget>("Search"));
-    TRY(search_view->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(search_view->try_set_layout<GUI::VerticalBoxLayout>());
     search_view->layout()->set_margins(4);
     auto search_box = TRY(search_view->try_add<GUI::TextBox>());
     auto search_list_view = TRY(search_view->try_add<GUI::ListView>());
@@ -234,9 +234,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         open_page(path);
     });
 
-    TRY(toolbar->try_add_action(*go_back_action));
-    TRY(toolbar->try_add_action(*go_forward_action));
-    TRY(toolbar->try_add_action(*go_home_action));
+    (void)TRY(toolbar->try_add_action(*go_back_action));
+    (void)TRY(toolbar->try_add_action(*go_forward_action));
+    (void)TRY(toolbar->try_add_action(*go_home_action));
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([](auto&) {

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Keyboard Settings"));
     window->set_icon(app_icon.bitmap_for_size(16));
-    TRY(window->add_tab<KeyboardSettingsWidget>("Keyboard"));
+    (void)TRY(window->add_tab<KeyboardSettingsWidget>("Keyboard"));
 
     window->show();
     return app->exec();

--- a/Userland/Applications/MailSettings/main.cpp
+++ b/Userland/Applications/MailSettings/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-mail");
 
     auto window = TRY(GUI::SettingsWindow::create("Mail Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    TRY(window->add_tab<MailSettingsWidget>("Mail"));
+    (void)TRY(window->add_tab<MailSettingsWidget>("Mail"));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/MouseSettings/main.cpp
+++ b/Userland/Applications/MouseSettings/main.cpp
@@ -26,8 +26,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-mouse");
 
     auto window = TRY(GUI::SettingsWindow::create("Mouse Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    TRY(window->add_tab<MouseWidget>("Mouse"));
-    TRY(window->add_tab<ThemeWidget>("Cursor Theme"));
+    (void)TRY(window->add_tab<MouseWidget>("Mouse"));
+    (void)TRY(window->add_tab<ThemeWidget>("Cursor Theme"));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -113,7 +113,7 @@ private:
 
 void ThreadStackWidget::refresh()
 {
-    Threading::BackgroundAction<Vector<Symbolication::Symbol>>::construct(
+    (void)Threading::BackgroundAction<Vector<Symbolication::Symbol>>::construct(
         [pid = m_pid, tid = m_tid](auto&) {
             return Symbolication::symbolicate_thread(pid, tid, Symbolication::IncludeSourcePosition::No);
         },

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -160,11 +160,11 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     main_widget->set_background_role(ColorRole::Button);
-    TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
     main_widget->layout()->set_margins(4);
 
     auto find = TRY(main_widget->try_add<GUI::Widget>());
-    TRY(find->try_set_layout<GUI::HorizontalBoxLayout>());
+    (void)TRY(find->try_set_layout<GUI::HorizontalBoxLayout>());
     find->layout()->set_margins(4);
     find->set_fixed_height(30);
 

--- a/Userland/Applications/TerminalSettings/main.cpp
+++ b/Userland/Applications/TerminalSettings/main.cpp
@@ -28,8 +28,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Terminal Settings"));
     window->set_icon(app_icon.bitmap_for_size(16));
-    TRY(window->add_tab<TerminalSettingsMainWidget>("Terminal"));
-    TRY(window->add_tab<TerminalSettingsViewWidget>("View"));
+    (void)TRY(window->add_tab<TerminalSettingsMainWidget>("Terminal"));
+    (void)TRY(window->add_tab<TerminalSettingsViewWidget>("View"));
 
     window->show();
     return app->exec();

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto catdog_widget = TRY(window->try_set_main_widget<CatDog>());
-    TRY(catdog_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(catdog_widget->try_set_layout<GUI::VerticalBoxLayout>());
     catdog_widget->layout()->set_spacing(0);
 
     auto context_menu = TRY(GUI::Menu::try_create());
@@ -59,7 +59,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     advice_window->set_alpha_hit_threshold(1.0f);
 
     auto advice_widget = TRY(advice_window->try_set_main_widget<SpeechBubble>());
-    TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>());
     advice_widget->layout()->set_spacing(0);
 
     auto advice_timer = TRY(Core::Timer::try_create());

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -64,7 +64,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(75 * (full_rows > 0 ? max_in_row : extra_columns), 100 * (full_rows + (extra_columns > 0 ? 1 : 0)));
     window->set_has_alpha_channel(true);
 
-    TRY(window->try_set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns));
+    (void)TRY(window->try_set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns));
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); })));

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -203,7 +203,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-libgfx-demo");
     window->set_icon(app_icon.bitmap_for_size(16));
-    TRY(window->try_set_main_widget<Canvas>());
+    (void)TRY(window->try_set_main_widget<Canvas>());
     window->show();
 
     return app->exec();

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -122,7 +122,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-libgfx-demo");
     window->set_icon(app_icon.bitmap_for_size(16));
-    TRY(window->try_set_main_widget<Canvas>());
+    (void)TRY(window->try_set_main_widget<Canvas>());
     window->show();
 
     return app->exec();

--- a/Userland/Demos/ModelGallery/main.cpp
+++ b/Userland/Demos/ModelGallery/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Model Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(430, 480);
-    TRY(window->try_set_main_widget<GalleryWidget>());
+    (void)TRY(window->try_set_main_widget<GalleryWidget>());
 
     window->show();
     return app->exec();

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(430, 480);
     window->set_title("Widget Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
-    TRY(window->try_set_main_widget<GalleryWidget>());
+    (void)TRY(window->try_set_main_widget<GalleryWidget>());
     window->show();
 
     return app->exec();

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> mode_server()
     TRY(Core::System::pledge("stdio unix recvfd rpath"));
 
     auto socket = TRY(Core::LocalSocket::take_over_accepted_socket_from_system_server());
-    IPC::new_client_connection<LanguageServers::Cpp::ClientConnection>(move(socket), 1);
+    (void)IPC::new_client_connection<LanguageServers::Cpp::ClientConnection>(move(socket), 1);
 
     TRY(Core::System::pledge("stdio recvfd rpath"));
     TRY(Core::System::unveil("/usr/include", "r"));

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/main.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/main.cpp
@@ -17,7 +17,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::pledge("stdio unix rpath recvfd"));
 
     auto socket = TRY(Core::LocalSocket::take_over_accepted_socket_from_system_server());
-    IPC::new_client_connection<LanguageServers::Shell::ClientConnection>(move(socket), 1);
+    (void)IPC::new_client_connection<LanguageServers::Shell::ClientConnection>(move(socket), 1);
     TRY(Core::System::pledge("stdio rpath recvfd"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
 

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -60,7 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(315, 336);
 
     auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
     main_widget->set_fill_with_background_color(true);
 
     Game game { board_size, target_tile, evil_ai };

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -98,27 +98,27 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         statusbar.set_text(click_tip);
         board_widget->run_generation();
     });
-    TRY(main_toolbar.try_add_action(run_one_generation_action));
+    (void)TRY(main_toolbar.try_add_action(run_one_generation_action));
 
     auto clear_board_action = GUI::Action::create("&Clear board", { Mod_Ctrl, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         statusbar.set_text(click_tip);
         board_widget->clear_cells();
         board_widget->update();
     });
-    TRY(main_toolbar.try_add_action(clear_board_action));
+    (void)TRY(main_toolbar.try_add_action(clear_board_action));
 
     auto randomize_cells_action = GUI::Action::create("&Randomize board", { Mod_Ctrl, Key_R }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/reload.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         statusbar.set_text(click_tip);
         board_widget->randomize_cells();
         board_widget->update();
     });
-    TRY(main_toolbar.try_add_action(randomize_cells_action));
+    (void)TRY(main_toolbar.try_add_action(randomize_cells_action));
 
     auto rotate_pattern_action = GUI::Action::create("&Rotate pattern", { 0, Key_R }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/redo.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         board_widget->selected_pattern()->rotate_clockwise();
     });
     rotate_pattern_action->set_enabled(false);
-    TRY(main_toolbar.try_add_action(rotate_pattern_action));
+    (void)TRY(main_toolbar.try_add_action(rotate_pattern_action));
 
     auto game_menu = TRY(window->try_add_menu("&Game"));
 

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(139, 175);
 
     auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    TRY(widget->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(widget->try_set_layout<GUI::VerticalBoxLayout>());
     widget->layout()->set_spacing(0);
 
     auto top_line = TRY(widget->try_add<GUI::SeparatorWidget>(Gfx::Orientation::Horizontal));
@@ -52,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto container = TRY(widget->try_add<GUI::Widget>());
     container->set_fill_with_background_color(true);
     container->set_fixed_height(36);
-    TRY(container->try_set_layout<GUI::HorizontalBoxLayout>());
+    (void)TRY(container->try_set_layout<GUI::HorizontalBoxLayout>());
 
     container->layout()->add_spacer();
 

--- a/Userland/Games/Pong/main.cpp
+++ b/Userland/Games/Pong/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Pong");
     window->set_double_buffering_enabled(false);
-    TRY(window->try_set_main_widget<Pong::Game>());
+    (void)TRY(window->try_set_main_widget<Pong::Game>());
     window->set_resizable(false);
 
     auto game_menu = TRY(window->try_add_menu("&Game"));

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -294,7 +294,7 @@ void Game::mouseup_event(GUI::MouseEvent& event)
                     for (auto& to_intersect : m_focused_cards) {
                         mark_intersecting_stacks_dirty(to_intersect);
                         stack.push(to_intersect);
-                        m_focused_stack->pop();
+                        (void)m_focused_stack->pop();
                     }
 
                     remember_move_for_undo(*m_focused_stack, stack, m_focused_cards);
@@ -629,7 +629,7 @@ void Game::perform_undo()
     for (auto& to_intersect : m_last_move.cards) {
         mark_intersecting_stacks_dirty(to_intersect);
         m_last_move.from->push(to_intersect);
-        m_last_move.to->pop();
+        (void)m_last_move.to->pop();
     }
 
     if (m_last_move.from->type() == CardStack::Type::Stock) {

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -303,7 +303,7 @@ void Game::mouseup_event(GUI::MouseEvent& event)
                     for (auto& to_intersect : m_focused_cards) {
                         mark_intersecting_stacks_dirty(to_intersect);
                         stack.push(to_intersect);
-                        m_focused_stack->pop();
+                        (void)m_focused_stack->pop();
                     }
 
                     update_score(-1);

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -252,7 +252,7 @@ bool Parser::match_template_arguments()
     while (!eof() && peek().type() != Token::Type::Greater) {
         if (!match_named_type())
             return false;
-        parse_type(get_dummy_node());
+        (void)parse_type(get_dummy_node());
     }
 
     return peek().type() == Token::Type::Greater;
@@ -285,13 +285,13 @@ bool Parser::match_variable_declaration()
     }
 
     VERIFY(m_root_node);
-    parse_type(get_dummy_node());
+    (void)parse_type(get_dummy_node());
 
     // Identifier
     if (!match_name())
         return false;
 
-    parse_name(get_dummy_node());
+    (void)parse_name(get_dummy_node());
 
     if (match(Token::Type::Equals)) {
         consume(Token::Type::Equals);
@@ -303,7 +303,7 @@ bool Parser::match_variable_declaration()
     }
 
     if (match_braced_init_list())
-        parse_braced_init_list(get_dummy_node());
+        (void)parse_braced_init_list(get_dummy_node());
 
     return match(Token::Type::Semicolon);
 }
@@ -695,7 +695,7 @@ bool Parser::match_class_declaration()
 
             if (!match_name())
                 return false;
-            parse_name(get_dummy_node());
+            (void)parse_name(get_dummy_node());
         } while (peek().type() == Token::Type::Comma);
     }
 
@@ -718,7 +718,7 @@ bool Parser::match_function_declaration()
         return false;
 
     VERIFY(m_root_node);
-    parse_type(get_dummy_node());
+    (void)parse_type(get_dummy_node());
 
     if (!peek(Token::Type::Identifier).has_value())
         return false;
@@ -1157,7 +1157,7 @@ NonnullRefPtr<StructOrClassDeclaration> Parser::parse_class_declaration(ASTNode&
             while (match_keyword("private") || match_keyword("public") || match_keyword("protected") || match_keyword("virtual"))
                 consume();
 
-            parse_name(get_dummy_node());
+            (void)parse_name(get_dummy_node());
         } while (peek().type() == Token::Type::Comma);
     }
 
@@ -1479,7 +1479,7 @@ bool Parser::match_c_style_cast_expression()
 
     if (!match_type())
         return false;
-    parse_type(get_dummy_node());
+    (void)parse_type(get_dummy_node());
 
     if (consume().type() != Token::Type::RightParen)
         return false;

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -17,7 +17,7 @@ bool Track::add_processor(NonnullRefPtr<Processor> new_processor)
 {
     m_processor_chain.append(move(new_processor));
     if (!check_processor_chain_valid()) {
-        m_processor_chain.take_last();
+        (void)m_processor_chain.take_last();
         return false;
     }
     return true;

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -520,7 +520,7 @@ void ELF::DynamicLinker::linker_main(String&& main_program_name, int main_progra
         fflush(stderr);
         _exit(1);
     }
-    result1.release_value();
+    (void)result1.release_value();
 
     auto result2 = map_dependencies(library_name);
     if (result2.is_error()) {

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -649,7 +649,7 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
 
     auto weak_this = make_weak_ptr();
 
-    Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
+    (void)Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
         [path](auto&) {
             return render_thumbnail(path);
         },

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -26,7 +26,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
 
     auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
-    TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
     main_widget->layout()->set_margins(4);
     main_widget->layout()->set_spacing(6);
 
@@ -34,7 +34,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
 
     auto button_container = TRY(main_widget->try_add<GUI::Widget>());
     button_container->set_shrink_to_fit(true);
-    TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
+    (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
     button_container->layout()->set_spacing(6);
 
     if (show_defaults_button == ShowDefaultsButton::Yes) {

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -85,7 +85,7 @@ bool TextDocument::set_text(StringView text, AllowCallback allow_callback)
 
     // Don't show the file's trailing newline as an actual new line.
     if (line_count() > 1 && line(line_count() - 1).is_empty())
-        m_lines.take_last();
+        (void)m_lines.take_last();
 
     m_client_notifications_enabled = true;
 

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -118,7 +118,7 @@ ErrorOr<void> Toolbar::try_add_separator()
 
     auto item = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Item));
     item->type = Item::Type::Separator;
-    TRY(try_add<SeparatorWidget>(m_orientation == Gfx::Orientation::Horizontal ? Gfx::Orientation::Vertical : Gfx::Orientation::Horizontal));
+    (void)TRY(try_add<SeparatorWidget>(m_orientation == Gfx::Orientation::Horizontal ? Gfx::Orientation::Vertical : Gfx::Orientation::Horizontal));
     m_items.unchecked_append(move(item));
     return {};
 }

--- a/Userland/Libraries/LibGUI/UndoStack.cpp
+++ b/Userland/Libraries/LibGUI/UndoStack.cpp
@@ -57,7 +57,7 @@ void UndoStack::push(NonnullOwnPtr<Command> command)
 {
     // If the stack cursor is behind the top of the stack, nuke everything from here to the top.
     while (m_stack.size() != m_stack_index)
-        m_stack.take_last();
+        (void)m_stack.take_last();
 
     if (m_clean_index.has_value() && m_clean_index.value() > m_stack.size())
         m_clean_index = {};

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -1568,7 +1568,7 @@ void Terminal::set_size(u16 columns, u16 rows)
                 if (m_history.size() >= 2 && m_history[m_history.size() - 2].termination_column().has_value())
                     break;
                 --extra_lines;
-                m_history.take_last();
+                (void)m_history.take_last();
                 continue;
             }
             break;

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -229,7 +229,7 @@ void Element::recompute_style()
             return;
         // We need a new layout tree here!
         Layout::TreeBuilder tree_builder;
-        tree_builder.build(*this);
+        (void)tree_builder.build(*this);
         return;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -390,7 +390,7 @@ void HTMLScriptElement::prepare_script()
 
                 // 3. Remove the first element from this list of scripts that will execute in order
                 //    as soon as possible.
-                m_preparation_time_document->scripts_to_execute_as_soon_as_possible().take_first();
+                (void)m_preparation_time_document->scripts_to_execute_as_soon_as_possible().take_first();
 
                 // 4. If this list of scripts that will execute in order as soon as possible is still
                 //    not empty and the first entry has already been marked as ready, then jump back

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -203,7 +203,7 @@ void HTMLParser::the_end()
 
     // 4. Pop all the nodes off the stack of open elements.
     while (!m_stack_of_open_elements.is_empty())
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
 
     // 5. While the list of scripts that will execute when the document has finished parsing is not empty:
     while (!m_document->scripts_to_execute_when_parsing_has_finished().is_empty()) {
@@ -218,7 +218,7 @@ void HTMLParser::the_end()
         m_document->scripts_to_execute_when_parsing_has_finished().first().execute_script();
 
         // 3. Remove the first script element from the list of scripts that will execute when the document has finished parsing (i.e. shift out the first entry in the list).
-        m_document->scripts_to_execute_when_parsing_has_finished().take_first();
+        (void)m_document->scripts_to_execute_when_parsing_has_finished().take_first();
     }
 
     // 6. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
@@ -663,21 +663,21 @@ void HTMLParser::handle_in_head(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::base, HTML::TagNames::basefont, HTML::TagNames::bgsound, HTML::TagNames::link)) {
-        insert_html_element(token);
-        m_stack_of_open_elements.pop();
+        (void)insert_html_element(token);
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::meta) {
         auto element = insert_html_element(token);
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::title) {
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_tokenizer.switch_to({}, HTMLTokenizer::State::RCDATA);
         m_original_insertion_mode = m_insertion_mode;
         m_insertion_mode = InsertionMode::Text;
@@ -690,7 +690,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::noscript && !m_scripting_enabled) {
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_insertion_mode = InsertionMode::InHeadNoscript;
         return;
     }
@@ -718,7 +718,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
         return;
     }
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::head) {
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = InsertionMode::AfterHead;
         return;
     }
@@ -728,7 +728,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::template_) {
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_list_of_active_formatting_elements.add_marker();
         m_frameset_ok = false;
         m_insertion_mode = InsertionMode::InTemplate;
@@ -760,7 +760,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
     }
 
 AnythingElse:
-    m_stack_of_open_elements.pop();
+    (void)m_stack_of_open_elements.pop();
     m_insertion_mode = InsertionMode::AfterHead;
     process_using_the_rules_for(m_insertion_mode, token);
 }
@@ -778,7 +778,7 @@ void HTMLParser::handle_in_head_noscript(HTMLToken& token)
     }
 
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::noscript) {
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = InsertionMode::InHead;
         return;
     }
@@ -799,14 +799,14 @@ void HTMLParser::handle_in_head_noscript(HTMLToken& token)
 
 AnythingElse:
     log_parse_error();
-    m_stack_of_open_elements.pop();
+    (void)m_stack_of_open_elements.pop();
     m_insertion_mode = InsertionMode::InHead;
     process_using_the_rules_for(m_insertion_mode, token);
 }
 
 void HTMLParser::parse_generic_raw_text_element(HTMLToken& token)
 {
-    insert_html_element(token);
+    (void)insert_html_element(token);
     m_tokenizer.switch_to({}, HTMLTokenizer::State::RAWTEXT);
     m_original_insertion_mode = m_insertion_mode;
     m_insertion_mode = InsertionMode::Text;
@@ -876,14 +876,14 @@ void HTMLParser::handle_after_head(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::body) {
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_frameset_ok = false;
         m_insertion_mode = InsertionMode::InBody;
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::frameset) {
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_insertion_mode = InsertionMode::InFrameset;
         return;
     }
@@ -913,7 +913,7 @@ void HTMLParser::handle_after_head(HTMLToken& token)
     }
 
 AnythingElse:
-    insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::body));
+    (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::body));
     m_insertion_mode = InsertionMode::InBody;
     process_using_the_rules_for(m_insertion_mode, token);
 }
@@ -921,13 +921,13 @@ AnythingElse:
 void HTMLParser::generate_implied_end_tags(const FlyString& exception)
 {
     while (current_node().local_name() != exception && current_node().local_name().is_one_of(HTML::TagNames::dd, HTML::TagNames::dt, HTML::TagNames::li, HTML::TagNames::optgroup, HTML::TagNames::option, HTML::TagNames::p, HTML::TagNames::rb, HTML::TagNames::rp, HTML::TagNames::rt, HTML::TagNames::rtc))
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
 }
 
 void HTMLParser::generate_all_implied_end_tags_thoroughly()
 {
     while (current_node().local_name().is_one_of(HTML::TagNames::caption, HTML::TagNames::colgroup, HTML::TagNames::dd, HTML::TagNames::dt, HTML::TagNames::li, HTML::TagNames::optgroup, HTML::TagNames::option, HTML::TagNames::p, HTML::TagNames::rb, HTML::TagNames::rp, HTML::TagNames::rt, HTML::TagNames::rtc, HTML::TagNames::tbody, HTML::TagNames::td, HTML::TagNames::tfoot, HTML::TagNames::th, HTML::TagNames::thead, HTML::TagNames::tr))
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
 }
 
 void HTMLParser::close_a_p_element()
@@ -1056,7 +1056,7 @@ HTMLParser::AdoptionAgencyAlgorithmOutcome HTMLParser::run_the_adoption_agency_a
     // and the current node is not in the list of active formatting elements,
     // then pop the current node off the stack of open elements, and return.
     if (current_node().local_name() == subject && !m_list_of_active_formatting_elements.contains(current_node())) {
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         return AdoptionAgencyAlgorithmOutcome::DoNothing;
     }
 
@@ -1083,8 +1083,8 @@ HTMLParser::AdoptionAgencyAlgorithmOutcome HTMLParser::run_the_adoption_agency_a
 
     if (!furthest_block) {
         while (&current_node() != formatting_element)
-            m_stack_of_open_elements.pop();
-        m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
 
         m_list_of_active_formatting_elements.remove(*formatting_element);
         return AdoptionAgencyAlgorithmOutcome::DoNothing;
@@ -1330,7 +1330,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::address, HTML::TagNames::article, HTML::TagNames::aside, HTML::TagNames::blockquote, HTML::TagNames::center, HTML::TagNames::details, HTML::TagNames::dialog, HTML::TagNames::dir, HTML::TagNames::div, HTML::TagNames::dl, HTML::TagNames::fieldset, HTML::TagNames::figcaption, HTML::TagNames::figure, HTML::TagNames::footer, HTML::TagNames::header, HTML::TagNames::hgroup, HTML::TagNames::main, HTML::TagNames::menu, HTML::TagNames::nav, HTML::TagNames::ol, HTML::TagNames::p, HTML::TagNames::section, HTML::TagNames::summary, HTML::TagNames::ul)) {
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
@@ -1339,9 +1339,9 @@ void HTMLParser::handle_in_body(HTMLToken& token)
             close_a_p_element();
         if (current_node().local_name().is_one_of(HTML::TagNames::h1, HTML::TagNames::h2, HTML::TagNames::h3, HTML::TagNames::h4, HTML::TagNames::h5, HTML::TagNames::h6)) {
             log_parse_error();
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
         }
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
@@ -1349,7 +1349,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
 
-        insert_html_element(token);
+        (void)insert_html_element(token);
 
         m_frameset_ok = false;
 
@@ -1400,7 +1400,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
 
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
@@ -1429,14 +1429,14 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         }
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::plaintext) {
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_tokenizer.switch_to({}, HTMLTokenizer::State::PLAINTEXT);
         return;
     }
@@ -1448,7 +1448,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
             m_stack_of_open_elements.pop_until_an_element_with_tag_name_has_been_popped(HTML::TagNames::button);
         }
         reconstruct_the_active_formatting_elements();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_frameset_ok = false;
         return;
     }
@@ -1499,7 +1499,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::p) {
         if (!m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p)) {
             log_parse_error();
-            insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::p));
+            (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::p));
         }
         close_a_p_element();
         return;
@@ -1599,7 +1599,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::applet, HTML::TagNames::marquee, HTML::TagNames::object)) {
         reconstruct_the_active_formatting_elements();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_list_of_active_formatting_elements.add_marker();
         m_frameset_ok = false;
         return;
@@ -1625,7 +1625,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
             if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
                 close_a_p_element();
         }
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_frameset_ok = false;
         m_insertion_mode = InsertionMode::InTable;
         return;
@@ -1639,8 +1639,8 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::area, HTML::TagNames::br, HTML::TagNames::embed, HTML::TagNames::img, HTML::TagNames::keygen, HTML::TagNames::wbr)) {
     BRStartTag:
         reconstruct_the_active_formatting_elements();
-        insert_html_element(token);
-        m_stack_of_open_elements.pop();
+        (void)insert_html_element(token);
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         m_frameset_ok = false;
         return;
@@ -1648,8 +1648,8 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::input) {
         reconstruct_the_active_formatting_elements();
-        insert_html_element(token);
-        m_stack_of_open_elements.pop();
+        (void)insert_html_element(token);
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         auto type_attribute = token.attribute(HTML::AttributeNames::type);
         if (type_attribute.is_null() || !type_attribute.equals_ignoring_case("hidden")) {
@@ -1659,8 +1659,8 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::param, HTML::TagNames::source, HTML::TagNames::track)) {
-        insert_html_element(token);
-        m_stack_of_open_elements.pop();
+        (void)insert_html_element(token);
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
@@ -1668,8 +1668,8 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::hr) {
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
-        insert_html_element(token);
-        m_stack_of_open_elements.pop();
+        (void)insert_html_element(token);
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         m_frameset_ok = false;
         return;
@@ -1684,7 +1684,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::textarea) {
-        insert_html_element(token);
+        (void)insert_html_element(token);
 
         m_tokenizer.switch_to({}, HTMLTokenizer::State::RCDATA);
 
@@ -1728,7 +1728,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::select) {
         reconstruct_the_active_formatting_elements();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_frameset_ok = false;
         switch (m_insertion_mode) {
         case InsertionMode::InTable:
@@ -1747,9 +1747,9 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::optgroup, HTML::TagNames::option)) {
         if (current_node().local_name() == HTML::TagNames::option)
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
         reconstruct_the_active_formatting_elements();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
@@ -1760,7 +1760,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         if (current_node().local_name() != HTML::TagNames::ruby)
             log_parse_error();
 
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
@@ -1771,7 +1771,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         if (current_node().local_name() != HTML::TagNames::rtc || current_node().local_name() != HTML::TagNames::ruby)
             log_parse_error();
 
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
@@ -1780,10 +1780,10 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         adjust_mathml_attributes(token);
         adjust_foreign_attributes(token);
 
-        insert_foreign_element(token, Namespace::MathML);
+        (void)insert_foreign_element(token, Namespace::MathML);
 
         if (token.is_self_closing()) {
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
             token.acknowledge_self_closing_flag_if_set();
         }
         return;
@@ -1794,10 +1794,10 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         adjust_svg_attributes(token);
         adjust_foreign_attributes(token);
 
-        insert_foreign_element(token, Namespace::SVG);
+        (void)insert_foreign_element(token, Namespace::SVG);
 
         if (token.is_self_closing()) {
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
             token.acknowledge_self_closing_flag_if_set();
         }
         return;
@@ -1811,7 +1811,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     // Any other start tag
     if (token.is_start_tag()) {
         reconstruct_the_active_formatting_elements();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
@@ -1826,9 +1826,9 @@ void HTMLParser::handle_in_body(HTMLToken& token)
                     log_parse_error();
                 }
                 while (&current_node() != node) {
-                    m_stack_of_open_elements.pop();
+                    (void)m_stack_of_open_elements.pop();
                 }
-                m_stack_of_open_elements.pop();
+                (void)m_stack_of_open_elements.pop();
                 break;
             }
             if (is_special_tag(node->local_name(), node->namespace_())) {
@@ -1983,7 +1983,7 @@ void HTMLParser::handle_text(HTMLToken& token)
         log_parse_error();
         if (current_node().local_name() == HTML::TagNames::script)
             verify_cast<HTMLScriptElement>(current_node()).set_already_started({}, true);
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = m_original_insertion_mode;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -1993,7 +1993,7 @@ void HTMLParser::handle_text(HTMLToken& token)
         flush_character_insertions();
 
         NonnullRefPtr<HTMLScriptElement> script = verify_cast<HTMLScriptElement>(current_node());
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = m_original_insertion_mode;
         // FIXME: Handle tokenizer insertion point stuff here.
         increment_script_nesting_level();
@@ -2053,7 +2053,7 @@ void HTMLParser::handle_text(HTMLToken& token)
     }
 
     if (token.is_end_tag()) {
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = m_original_insertion_mode;
         return;
     }
@@ -2063,7 +2063,7 @@ void HTMLParser::handle_text(HTMLToken& token)
 void HTMLParser::clear_the_stack_back_to_a_table_context()
 {
     while (!current_node().local_name().is_one_of(HTML::TagNames::table, HTML::TagNames::template_, HTML::TagNames::html))
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
 
     if (current_node().local_name() == HTML::TagNames::html)
         VERIFY(m_parsing_fragment);
@@ -2072,7 +2072,7 @@ void HTMLParser::clear_the_stack_back_to_a_table_context()
 void HTMLParser::clear_the_stack_back_to_a_table_row_context()
 {
     while (!current_node().local_name().is_one_of(HTML::TagNames::tr, HTML::TagNames::template_, HTML::TagNames::html))
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
 
     if (current_node().local_name() == HTML::TagNames::html)
         VERIFY(m_parsing_fragment);
@@ -2081,7 +2081,7 @@ void HTMLParser::clear_the_stack_back_to_a_table_row_context()
 void HTMLParser::clear_the_stack_back_to_a_table_body_context()
 {
     while (!current_node().local_name().is_one_of(HTML::TagNames::tbody, HTML::TagNames::tfoot, HTML::TagNames::thead, HTML::TagNames::template_, HTML::TagNames::html))
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
 
     if (current_node().local_name() == HTML::TagNames::html)
         VERIFY(m_parsing_fragment);
@@ -2091,7 +2091,7 @@ void HTMLParser::handle_in_row(HTMLToken& token)
 {
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::th, HTML::TagNames::td)) {
         clear_the_stack_back_to_a_table_row_context();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_insertion_mode = InsertionMode::InCell;
         m_list_of_active_formatting_elements.add_marker();
         return;
@@ -2103,7 +2103,7 @@ void HTMLParser::handle_in_row(HTMLToken& token)
             return;
         }
         clear_the_stack_back_to_a_table_row_context();
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = InsertionMode::InTableBody;
         return;
     }
@@ -2115,7 +2115,7 @@ void HTMLParser::handle_in_row(HTMLToken& token)
             return;
         }
         clear_the_stack_back_to_a_table_row_context();
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = InsertionMode::InTableBody;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2130,7 +2130,7 @@ void HTMLParser::handle_in_row(HTMLToken& token)
             return;
         }
         clear_the_stack_back_to_a_table_row_context();
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = InsertionMode::InTableBody;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2151,8 +2151,8 @@ void HTMLParser::close_the_cell()
         log_parse_error();
     }
     while (!current_node().local_name().is_one_of(HTML::TagNames::td, HTML::TagNames::th))
-        m_stack_of_open_elements.pop();
-    m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
+    (void)m_stack_of_open_elements.pop();
     m_list_of_active_formatting_elements.clear_up_to_the_last_marker();
     m_insertion_mode = InsertionMode::InRow;
 }
@@ -2246,7 +2246,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
 {
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::tr) {
         clear_the_stack_back_to_a_table_body_context();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_insertion_mode = InsertionMode::InRow;
         return;
     }
@@ -2254,7 +2254,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::th, HTML::TagNames::td)) {
         log_parse_error();
         clear_the_stack_back_to_a_table_body_context();
-        insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tr));
+        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tr));
         m_insertion_mode = InsertionMode::InRow;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2266,7 +2266,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
             return;
         }
         clear_the_stack_back_to_a_table_body_context();
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = InsertionMode::InTable;
         return;
     }
@@ -2282,7 +2282,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
         }
 
         clear_the_stack_back_to_a_table_body_context();
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = InsertionMode::InTable;
         process_using_the_rules_for(InsertionMode::InTable, token);
         return;
@@ -2316,32 +2316,32 @@ void HTMLParser::handle_in_table(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::caption) {
         clear_the_stack_back_to_a_table_context();
         m_list_of_active_formatting_elements.add_marker();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_insertion_mode = InsertionMode::InCaption;
         return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::colgroup) {
         clear_the_stack_back_to_a_table_context();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_insertion_mode = InsertionMode::InColumnGroup;
         return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::col) {
         clear_the_stack_back_to_a_table_context();
-        insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::colgroup));
+        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::colgroup));
         m_insertion_mode = InsertionMode::InColumnGroup;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
     }
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::tbody, HTML::TagNames::tfoot, HTML::TagNames::thead)) {
         clear_the_stack_back_to_a_table_context();
-        insert_html_element(token);
+        (void)insert_html_element(token);
         m_insertion_mode = InsertionMode::InTableBody;
         return;
     }
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::td, HTML::TagNames::th, HTML::TagNames::tr)) {
         clear_the_stack_back_to_a_table_context();
-        insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tbody));
+        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tbody));
         m_insertion_mode = InsertionMode::InTableBody;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2384,12 +2384,12 @@ void HTMLParser::handle_in_table(HTMLToken& token)
         }
 
         log_parse_error();
-        insert_html_element(token);
+        (void)insert_html_element(token);
 
         // FIXME: Is this the correct interpretation of "Pop that input element off the stack of open elements."?
         //        Because this wording is the first time it's seen in the spec.
         //        Other times it's worded as: "Immediately pop the current node off the stack of open elements."
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
@@ -2402,7 +2402,7 @@ void HTMLParser::handle_in_table(HTMLToken& token)
         m_form_element = verify_cast<HTMLFormElement>(*insert_html_element(token));
 
         // FIXME: See previous FIXME, as this is the same situation but for form.
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         return;
     }
     if (token.is_end_of_file()) {
@@ -2470,29 +2470,29 @@ void HTMLParser::handle_in_select(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::option) {
         if (current_node().local_name() == HTML::TagNames::option) {
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
         }
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::optgroup) {
         if (current_node().local_name() == HTML::TagNames::option) {
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
         }
         if (current_node().local_name() == HTML::TagNames::optgroup) {
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
         }
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::optgroup) {
         if (current_node().local_name() == HTML::TagNames::option && node_before_current_node().local_name() == HTML::TagNames::optgroup)
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
 
         if (current_node().local_name() == HTML::TagNames::optgroup) {
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
         } else {
             log_parse_error();
             return;
@@ -2502,7 +2502,7 @@ void HTMLParser::handle_in_select(HTMLToken& token)
 
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::option) {
         if (current_node().local_name() == HTML::TagNames::option) {
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
         } else {
             log_parse_error();
             return;
@@ -2639,8 +2639,8 @@ void HTMLParser::handle_in_column_group(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::col) {
-        insert_html_element(token);
-        m_stack_of_open_elements.pop();
+        (void)insert_html_element(token);
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
@@ -2651,7 +2651,7 @@ void HTMLParser::handle_in_column_group(HTMLToken& token)
             return;
         }
 
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         m_insertion_mode = InsertionMode::InTable;
         return;
     }
@@ -2676,7 +2676,7 @@ void HTMLParser::handle_in_column_group(HTMLToken& token)
         return;
     }
 
-    m_stack_of_open_elements.pop();
+    (void)m_stack_of_open_elements.pop();
     m_insertion_mode = InsertionMode::InTable;
     process_using_the_rules_for(m_insertion_mode, token);
 }
@@ -2782,14 +2782,14 @@ void HTMLParser::handle_in_frameset(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::frameset) {
-        insert_html_element(token);
+        (void)insert_html_element(token);
         return;
     }
 
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::frameset) {
         // FIXME: If the current node is the root html element, then this is a parse error; ignore the token. (fragment case)
 
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
 
         if (!m_parsing_fragment && current_node().local_name() != HTML::TagNames::frameset) {
             m_insertion_mode = InsertionMode::AfterFrameset;
@@ -2798,8 +2798,8 @@ void HTMLParser::handle_in_frameset(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::frame) {
-        insert_html_element(token);
-        m_stack_of_open_elements.pop();
+        (void)insert_html_element(token);
+        (void)m_stack_of_open_elements.pop();
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
@@ -2921,7 +2921,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
         while (!is_mathml_text_integration_point(current_node())
             && !is_html_integration_point(current_node())
             && current_node().namespace_() != Namespace::HTML) {
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
         }
 
         // Reprocess the token according to the rules given in the section corresponding to the current insertion mode in HTML content.
@@ -2939,7 +2939,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
         }
 
         adjust_foreign_attributes(token);
-        insert_foreign_element(token, adjusted_current_node().namespace_());
+        (void)insert_foreign_element(token, adjusted_current_node().namespace_());
 
         if (token.is_self_closing()) {
             if (token.tag_name() == SVG::TagNames::script && current_node().namespace_() == Namespace::SVG) {
@@ -2947,7 +2947,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
                 goto ScriptEndTag;
             }
 
-            m_stack_of_open_elements.pop();
+            (void)m_stack_of_open_elements.pop();
             token.acknowledge_self_closing_flag_if_set();
         }
 
@@ -2956,7 +2956,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
 
     if (token.is_end_tag() && current_node().namespace_() == Namespace::SVG && current_node().tag_name() == SVG::TagNames::script) {
     ScriptEndTag:
-        m_stack_of_open_elements.pop();
+        (void)m_stack_of_open_elements.pop();
         TODO();
     }
 
@@ -2973,8 +2973,8 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
             // FIXME: See the above FIXME
             if (node->tag_name().to_lowercase() == token.tag_name()) {
                 while (current_node() != node)
-                    m_stack_of_open_elements.pop();
-                m_stack_of_open_elements.pop();
+                    (void)m_stack_of_open_elements.pop();
+                (void)m_stack_of_open_elements.pop();
                 return;
             }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.cpp
@@ -96,8 +96,8 @@ bool StackOfOpenElements::contains(const FlyString& tag_name) const
 void StackOfOpenElements::pop_until_an_element_with_tag_name_has_been_popped(const FlyString& tag_name)
 {
     while (m_elements.last().local_name() != tag_name)
-        pop();
-    pop();
+        (void)pop();
+    (void)pop();
 }
 
 DOM::Element* StackOfOpenElements::topmost_special_node_below(const DOM::Element& formatting_element)

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -398,7 +398,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer& block_c
         }
 
         compute_width(child_box);
-        layout_inside(child_box, layout_mode);
+        (void)layout_inside(child_box, layout_mode);
         compute_height(child_box);
 
         if (child_box.computed_values().position() == CSS::Position::Relative)
@@ -576,7 +576,7 @@ void BlockFormattingContext::layout_floating_child(Box& box, BlockContainer cons
     VERIFY(box.is_floating());
 
     compute_width(box);
-    layout_inside(box, LayoutMode::Default);
+    (void)layout_inside(box, LayoutMode::Default);
     compute_height(box);
 
     // First we place the box normally (to get the right y coordinate.)

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -143,7 +143,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
     }
 
     flex_container().for_each_child_of_type<Box>([&](Box& child_box) {
-        layout_inside(child_box, LayoutMode::Default);
+        (void)layout_inside(child_box, LayoutMode::Default);
         // Skip anonymous text runs that are only whitespace.
         if (child_box.is_anonymous() && !child_box.first_child_of_type<BlockContainer>()) {
             bool contains_only_white_space = true;
@@ -444,7 +444,7 @@ float FlexFormattingContext::layout_for_maximum_main_size(Box& box)
         }
     }
     if (is_row_layout()) {
-        layout_inside(box, LayoutMode::OnlyRequiredLineBreaks);
+        (void)layout_inside(box, LayoutMode::OnlyRequiredLineBreaks);
         return box.width();
     } else {
         return BlockFormattingContext::compute_theoretical_height(box);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -137,13 +137,13 @@ FormattingContext::ShrinkToFitResult FormattingContext::calculate_shrink_to_fit_
 {
     // Calculate the preferred width by formatting the content without breaking lines
     // other than where explicit line breaks occur.
-    layout_inside(box, LayoutMode::OnlyRequiredLineBreaks);
+    (void)layout_inside(box, LayoutMode::OnlyRequiredLineBreaks);
     float preferred_width = greatest_child_width(box);
 
     // Also calculate the preferred minimum width, e.g., by trying all possible line breaks.
     // CSS 2.2 does not define the exact algorithm.
 
-    layout_inside(box, LayoutMode::AllPossibleLineBreaks);
+    (void)layout_inside(box, LayoutMode::AllPossibleLineBreaks);
     float preferred_minimum_width = greatest_child_width(box);
 
     return { preferred_width, preferred_minimum_width };
@@ -603,7 +603,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     auto specified_width = box.computed_values().width().resolved_or_auto(box, containing_block.width());
 
     compute_width_for_absolutely_positioned_element(box);
-    layout_inside(box, LayoutMode::Default);
+    (void)layout_inside(box, LayoutMode::Default);
     compute_height_for_absolutely_positioned_element(box);
 
     box_model.margin.left = box.computed_values().margin().left.resolved_or_auto(box, containing_block.width()).to_px(box);

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -215,7 +215,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
         } else {
             inline_block.set_width(inline_block.computed_values().width().resolved_or_zero(inline_block, containing_block().width()).to_px(inline_block));
         }
-        layout_inside(inline_block, layout_mode);
+        (void)layout_inside(inline_block, layout_mode);
 
         if (inline_block.computed_values().height().is_undefined_or_auto()) {
             // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -76,9 +76,9 @@ void TableFormattingContext::calculate_column_widths(Box& row, Vector<float>& co
     row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
         compute_width(cell);
         if (use_auto_layout) {
-            layout_inside(cell, LayoutMode::OnlyRequiredLineBreaks);
+            (void)layout_inside(cell, LayoutMode::OnlyRequiredLineBreaks);
         } else {
-            layout_inside(cell, LayoutMode::Default);
+            (void)layout_inside(cell, LayoutMode::Default);
         }
         column_widths[column_index] = max(column_widths[column_index], cell.width());
         column_index += cell.colspan();
@@ -98,9 +98,9 @@ void TableFormattingContext::layout_row(Box& row, Vector<float>& column_widths)
 
         // Layout the cell contents a second time, now that we know its final width.
         if (use_auto_layout) {
-            layout_inside(cell, LayoutMode::OnlyRequiredLineBreaks);
+            (void)layout_inside(cell, LayoutMode::OnlyRequiredLineBreaks);
         } else {
-            layout_inside(cell, LayoutMode::Default);
+            (void)layout_inside(cell, LayoutMode::Default);
         }
 
         size_t cell_colspan = cell.colspan();

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -104,7 +104,7 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyObject::validate)
     // Drop the module from the cache, we're never going to refer to it.
     ScopeGuard drop_from_cache {
         [&] {
-            s_compiled_modules.take_last();
+            (void)s_compiled_modules.take_last();
         }
     };
 

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     server->on_accept = [&](NonnullRefPtr<Core::LocalSocket> client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<AudioServer::ClientConnection>(move(client_socket), client_id, *mixer);
+        (void)IPC::new_client_connection<AudioServer::ClientConnection>(move(client_socket), client_id, *mixer);
     };
 
     TRY(Core::System::pledge("stdio recvfd thread accept cpath rpath wpath"));

--- a/Userland/Services/Clipboard/main.cpp
+++ b/Userland/Services/Clipboard/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     server->on_accept = [&](auto client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<Clipboard::ClientConnection>(move(client_socket), client_id);
+        (void)IPC::new_client_connection<Clipboard::ClientConnection>(move(client_socket), client_id);
     };
 
     Clipboard::Storage::the().on_content_change = [&] {

--- a/Userland/Services/ConfigServer/main.cpp
+++ b/Userland/Services/ConfigServer/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     server->on_accept = [&](auto client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<ConfigServer::ClientConnection>(move(client_socket), client_id);
+        (void)IPC::new_client_connection<ConfigServer::ClientConnection>(move(client_socket), client_id);
     };
 
     return event_loop.exec();

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -243,7 +243,7 @@ void DHCPv4Client::handle_ack(const DHCPv4Packet& packet, const ParsedDHCPv4Opti
     interface.current_ip_address = new_ip;
     auto lease_time = AK::convert_between_host_and_network_endian(options.get<u32>(DHCPOption::IPAddressLeaseTime).value_or(transaction->offered_lease_time));
     // set a timer for the duration of the lease, we shall renew if needed
-    Core::Timer::create_single_shot(
+    (void)Core::Timer::create_single_shot(
         lease_time * 1000,
         [this, transaction, interface = InterfaceDescriptor { interface }] {
             transaction->accepted_offer = false;
@@ -267,7 +267,7 @@ void DHCPv4Client::handle_nak(const DHCPv4Packet& packet, const ParsedDHCPv4Opti
     transaction->accepted_offer = false;
     transaction->has_ip = false;
     auto& iface = transaction->interface;
-    Core::Timer::create_single_shot(
+    (void)Core::Timer::create_single_shot(
         10000,
         [this, iface = InterfaceDescriptor { iface }] {
             dhcp_discover(iface);

--- a/Userland/Services/FileSystemAccessServer/main.cpp
+++ b/Userland/Services/FileSystemAccessServer/main.cpp
@@ -19,6 +19,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     app->set_quit_when_last_window_deleted(false);
 
     auto socket = TRY(Core::LocalSocket::take_over_accepted_socket_from_system_server());
-    IPC::new_client_connection<FileSystemAccessServer::ClientConnection>(move(socket), 1);
+    (void)IPC::new_client_connection<FileSystemAccessServer::ClientConnection>(move(socket), 1);
     return app->exec();
 }

--- a/Userland/Services/InspectorServer/main.cpp
+++ b/Userland/Services/InspectorServer/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     server->on_accept = [&](auto client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<InspectorServer::ClientConnection>(move(client_socket), client_id);
+        (void)IPC::new_client_connection<InspectorServer::ClientConnection>(move(client_socket), client_id);
     };
 
     auto inspectables_server = TRY(Core::LocalServer::try_create());

--- a/Userland/Services/LaunchServer/main.cpp
+++ b/Userland/Services/LaunchServer/main.cpp
@@ -32,7 +32,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     server->on_accept = [&](auto client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<LaunchServer::ClientConnection>(move(client_socket), client_id);
+        (void)IPC::new_client_connection<LaunchServer::ClientConnection>(move(client_socket), client_id);
     };
 
     return event_loop.exec();

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -76,7 +76,7 @@ LookupServer::LookupServer()
     m_local_server->on_accept = [](auto client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<ClientConnection>(move(client_socket), client_id);
+        (void)IPC::new_client_connection<ClientConnection>(move(client_socket), client_id);
     };
     bool ok = m_local_server->take_over_from_system_server();
     VERIFY(ok);

--- a/Userland/Services/NotificationServer/main.cpp
+++ b/Userland/Services/NotificationServer/main.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     server->on_accept = [&](auto client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<NotificationServer::ClientConnection>(move(client_socket), client_id);
+        (void)IPC::new_client_connection<NotificationServer::ClientConnection>(move(client_socket), client_id);
     };
 
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     [[maybe_unused]] auto https = make<RequestServer::HttpsProtocol>();
 
     auto socket = TRY(Core::LocalSocket::take_over_accepted_socket_from_system_server());
-    IPC::new_client_connection<RequestServer::ClientConnection>(move(socket), 1);
+    (void)IPC::new_client_connection<RequestServer::ClientConnection>(move(socket), 1);
     auto result = event_loop.exec();
 
     // FIXME: We exit instead of returning, so that protocol destructors don't get called.

--- a/Userland/Services/SQLServer/main.cpp
+++ b/Userland/Services/SQLServer/main.cpp
@@ -40,7 +40,7 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv)
     server->on_accept = [&](auto client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<SQLServer::ClientConnection>(client_socket, client_id);
+        (void)IPC::new_client_connection<SQLServer::ClientConnection>(client_socket, client_id);
     };
 
     return event_loop.exec();

--- a/Userland/Services/WebSocket/main.cpp
+++ b/Userland/Services/WebSocket/main.cpp
@@ -26,6 +26,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto socket = TRY(Core::LocalSocket::take_over_accepted_socket_from_system_server());
-    IPC::new_client_connection<WebSocket::ClientConnection>(move(socket), 1);
+    (void)IPC::new_client_connection<WebSocket::ClientConnection>(move(socket), 1);
     return event_loop.exec();
 }

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -807,7 +807,7 @@ bool Compositor::set_wallpaper_mode(const String& mode)
 
 bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callback)
 {
-    Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
+    (void)Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
         [path](auto&) {
             return Gfx::Bitmap::try_load_from_file(path);
         },

--- a/Userland/Services/WindowServer/EventLoop.cpp
+++ b/Userland/Services/WindowServer/EventLoop.cpp
@@ -33,13 +33,13 @@ EventLoop::EventLoop()
     m_window_server->on_accept = [&](auto client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        IPC::new_client_connection<ClientConnection>(move(client_socket), client_id);
+        (void)IPC::new_client_connection<ClientConnection>(move(client_socket), client_id);
     };
 
     m_wm_server->on_accept = [&](auto client_socket) {
         static int s_next_wm_id = 0;
         int wm_id = ++s_next_wm_id;
-        IPC::new_client_connection<WMClientConnection>(move(client_socket), wm_id);
+        (void)IPC::new_client_connection<WMClientConnection>(move(client_socket), wm_id);
     };
 
     if (m_keyboard_fd >= 0) {

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -839,7 +839,7 @@ int Shell::builtin_shift(int argc, const char** argv)
     }
 
     for (auto i = 0; i < count; ++i)
-        values.take_first();
+        (void)values.take_first();
 
     return 0;
 }

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -466,7 +466,7 @@ bool Shell::invoke_function(const AST::Command& command, int& retval)
     Core::EventLoop loop;
     setup_signals();
 
-    function.body->run(*this);
+    (void)function.body->run(*this);
 
     retval = last_return_code;
     return true;
@@ -491,7 +491,7 @@ Shell::Frame Shell::push_frame(String name)
 void Shell::pop_frame()
 {
     VERIFY(m_local_frames.size() > 1);
-    m_local_frames.take_last();
+    (void)m_local_frames.take_last();
 }
 
 Shell::Frame::~Frame()
@@ -505,7 +505,7 @@ Shell::Frame::~Frame()
             dbgln("- {:p}: {}", &frame, frame.name);
         VERIFY_NOT_REACHED();
     }
-    frames.take_last();
+    (void)frames.take_last();
 }
 
 String Shell::resolve_alias(const String& name) const
@@ -570,7 +570,7 @@ int Shell::run_command(StringView cmd, Optional<SourcePosition> source_position_
     tcgetattr(0, &termios);
     tcsetattr(0, TCSANOW, &default_termios);
 
-    command->run(*this);
+    (void)command->run(*this);
 
     tcsetattr(0, TCSANOW, &termios);
 
@@ -930,13 +930,13 @@ void Shell::run_tail(const AST::Command& invoking_command, const AST::NodeWithAc
     }
     auto evaluate = [&] {
         if (next_in_chain.node->would_execute()) {
-            next_in_chain.node->run(*this);
+            (void)next_in_chain.node->run(*this);
             return;
         }
         auto node = next_in_chain.node;
         if (!invoking_command.should_wait)
             node = adopt_ref(static_cast<AST::Node&>(*new AST::Background(next_in_chain.node->position(), move(node))));
-        adopt_ref(static_cast<AST::Node&>(*new AST::Execute(next_in_chain.node->position(), move(node))))->run(*this);
+        (void)adopt_ref(static_cast<AST::Node&>(*new AST::Execute(next_in_chain.node->position(), move(node))))->run(*this);
     };
     switch (next_in_chain.action) {
     case AST::NodeWithAction::And:


### PR DESCRIPTION
This change makes the following smart pointer classes `[[nodiscard]]`, so that ignoring one when it is returned from a function is a compile error:

- OwnPtr
- NonnullOwnPtr
- RefPtr
- NonnullRefPtr
- WeakPtr

And the Kernel-internal smart pointer replacements:
- ThreadSafeRefPtr
- ThreadSafeNonnullRefPtr
- ThreadSafeWeakPtr

This should help catch silly mistakes. (Like the one I spent over an hour debugging. :sweat_smile:)

Much of this PR is preparatory work casting any ignored smart pointers to `(void)`. No behavior should change.