### PR TITLE
LibGUI: Make FilteringProxyModel reference-count its parent model

### DIFF
--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -30,7 +30,7 @@ int FilteringProxyModel::column_count(ModelIndex const& index) const
     if ((size_t)index.row() > m_matching_indices.size() || index.row() < 0)
         return 0;
 
-    return m_model.column_count(m_matching_indices[index.row()]);
+    return m_model->column_count(m_matching_indices[index.row()]);
 }
 
 Variant FilteringProxyModel::data(ModelIndex const& index, ModelRole role) const
@@ -55,12 +55,12 @@ void FilteringProxyModel::filter()
     m_matching_indices.clear();
 
     Function<void(ModelIndex&)> add_matching = [&](ModelIndex& parent_index) {
-        for (auto i = 0; i < m_model.row_count(parent_index); ++i) {
-            auto index = m_model.index(i, 0, parent_index);
+        for (auto i = 0; i < m_model->row_count(parent_index); ++i) {
+            auto index = m_model->index(i, 0, parent_index);
             if (!index.is_valid())
                 continue;
 
-            auto filter_matches = m_model.data_matches(index, m_filter_term);
+            auto filter_matches = m_model->data_matches(index, m_filter_term);
             bool matches = filter_matches == TriState::True;
             if (filter_matches == TriState::Unknown) {
                 auto data = index.data();
@@ -100,12 +100,12 @@ ModelIndex FilteringProxyModel::map(ModelIndex const& index) const
 
 bool FilteringProxyModel::is_searchable() const
 {
-    return m_model.is_searchable();
+    return m_model->is_searchable();
 }
 
 Vector<ModelIndex> FilteringProxyModel::matches(StringView searching, unsigned flags, ModelIndex const& index)
 {
-    auto found_indices = m_model.matches(searching, flags, index);
+    auto found_indices = m_model->matches(searching, flags, index);
     for (size_t i = 0; i < found_indices.size(); i++)
         found_indices[i] = map(found_indices[i]);
     return found_indices;

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.h
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.h
@@ -17,14 +17,14 @@ namespace GUI {
 class FilteringProxyModel final : public Model
     , public ModelClient {
 public:
-    static ErrorOr<NonnullRefPtr<FilteringProxyModel>> create(Model& model)
+    static ErrorOr<NonnullRefPtr<FilteringProxyModel>> create(NonnullRefPtr<Model> model)
     {
-        return adopt_nonnull_ref_or_enomem(new (nothrow) FilteringProxyModel(model));
+        return adopt_nonnull_ref_or_enomem(new (nothrow) FilteringProxyModel(move(model)));
     }
 
     virtual ~FilteringProxyModel() override
     {
-        m_model.unregister_client(*this);
+        m_model->unregister_client(*this);
     };
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
@@ -44,13 +44,13 @@ protected:
 
 private:
     void filter();
-    explicit FilteringProxyModel(Model& model)
-        : m_model(model)
+    explicit FilteringProxyModel(NonnullRefPtr<Model> model)
+        : m_model(move(model))
     {
-        m_model.register_client(*this);
+        m_model->register_client(*this);
     }
 
-    Model& m_model;
+    NonnullRefPtr<Model> m_model;
 
     // Maps row to actual model index.
     Vector<ModelIndex> m_matching_indices;


### PR DESCRIPTION
Before this change, the destructor of FilteringProxyModel
would crash if the parent model had been destroyed earlier.

This unifies the behaviour of FilteringProxyModel with
SortingProxyModel in this respect.

Fixes #11112 .