### PR TITLE
HackStudio: Fix crash & freeze caused by invalid preprocessor statement

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudio.h
+++ b/Userland/DevTools/HackStudio/HackStudio.h
@@ -21,6 +21,7 @@ void open_file(const String&, size_t line, size_t column);
 Project& project();
 String currently_open_file();
 void set_current_editor_wrapper(RefPtr<EditorWrapper>);
+void for_each_open_file(Function<void(ProjectFile const&)>);
 
 class Locator;
 Locator& locator();

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1484,4 +1484,11 @@ void HackStudioWidget::open_coredump(String const& coredump_path)
     }
 }
 
+void HackStudioWidget::for_each_open_file(Function<void(ProjectFile const&)> func)
+{
+    for (auto& open_file : m_open_files) {
+        func(*open_file.value);
+    }
+}
+
 }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -69,6 +69,7 @@ public:
     };
 
     void open_coredump(String const& coredump_path);
+    void for_each_open_file(Function<void(ProjectFile const&)>);
 
 private:
     static String get_full_path_of_serenity_source(const String& file);

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -171,7 +171,7 @@ void ServerConnectionWrapper::on_crash()
     show_crash_notification();
     m_connection.clear();
 
-    static constexpr int max_crash_frequency_seconds = 3;
+    static constexpr int max_crash_frequency_seconds = 10;
     if (m_last_crash_timer.is_valid() && m_last_crash_timer.elapsed() / 1000 < max_crash_frequency_seconds) {
         dbgln("LanguageServer crash frequency is too high");
         m_respawn_allowed = false;

--- a/Userland/DevTools/HackStudio/LanguageClient.cpp
+++ b/Userland/DevTools/HackStudio/LanguageClient.cpp
@@ -241,9 +241,9 @@ void ServerConnectionWrapper::try_respawn_connection()
     dbgln("Respawning ServerConnection");
     create_connection();
 
-    // After respawning the language-server, we have to flush the content of the project files
+    // After respawning the language-server, we have to send the content of open project files
     // so the server's FileDB will be up-to-date.
-    project().for_each_text_file([this](const ProjectFile& file) {
+    for_each_open_file([this](const ProjectFile& file) {
         if (file.code_document().language() != m_language)
             return;
         m_connection->async_set_file_content(file.code_document().file_path(), file.document().text());

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -574,6 +574,7 @@ OwnPtr<CppComprehensionEngine::DocumentData> CppComprehensionEngine::create_docu
     document_data->m_text = move(text);
     document_data->m_preprocessor = make<Preprocessor>(document_data->m_filename, document_data->text());
     document_data->preprocessor().set_ignore_unsupported_keywords(true);
+    document_data->preprocessor().set_ignore_invalid_statements(true);
     document_data->preprocessor().set_keep_include_statements(true);
 
     document_data->preprocessor().definitions_in_header_callback = [this](StringView include_path) -> Preprocessor::Definitions {

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -168,4 +168,9 @@ Locator& locator()
     return s_hack_studio_widget->locator();
 }
 
+void for_each_open_file(Function<void(ProjectFile const&)> func)
+{
+    s_hack_studio_widget->for_each_open_file(move(func));
+}
+
 }

--- a/Userland/Libraries/LibCpp/Preprocessor.cpp
+++ b/Userland/Libraries/LibCpp/Preprocessor.cpp
@@ -117,6 +117,8 @@ void Preprocessor::handle_preprocessor_keyword(StringView keyword, GenericLexer&
     }
 
     if (keyword == "else") {
+        if (m_options.ignore_invalid_statements && m_current_depth == 0)
+            return;
         VERIFY(m_current_depth > 0);
         if (m_depths_of_not_taken_branches.contains_slow(m_current_depth - 1)) {
             m_depths_of_not_taken_branches.remove_all_matching([this](auto x) { return x == m_current_depth - 1; });
@@ -129,6 +131,8 @@ void Preprocessor::handle_preprocessor_keyword(StringView keyword, GenericLexer&
     }
 
     if (keyword == "endif") {
+        if (m_options.ignore_invalid_statements && m_current_depth == 0)
+            return;
         VERIFY(m_current_depth > 0);
         --m_current_depth;
         if (m_depths_of_not_taken_branches.contains_slow(m_current_depth)) {
@@ -198,6 +202,8 @@ void Preprocessor::handle_preprocessor_keyword(StringView keyword, GenericLexer&
     }
 
     if (keyword == "elif") {
+        if (m_options.ignore_invalid_statements && m_current_depth == 0)
+            return;
         VERIFY(m_current_depth > 0);
         // FIXME: Evaluate the elif expression
         // We currently always treat the expression in #elif as true.

--- a/Userland/Libraries/LibCpp/Preprocessor.h
+++ b/Userland/Libraries/LibCpp/Preprocessor.h
@@ -44,6 +44,7 @@ public:
     Vector<Substitution> const& substitutions() const { return m_substitutions; }
 
     void set_ignore_unsupported_keywords(bool ignore) { m_options.ignore_unsupported_keywords = ignore; }
+    void set_ignore_invalid_statements(bool ignore) { m_options.ignore_invalid_statements = ignore; }
     void set_keep_include_statements(bool keep) { m_options.keep_include_statements = keep; }
 
     Function<Definitions(StringView)> definitions_in_header_callback { nullptr };
@@ -91,6 +92,7 @@ private:
 
     struct Options {
         bool ignore_unsupported_keywords { false };
+        bool ignore_invalid_statements { false };
         bool keep_include_statements { false };
     } m_options;
 };


### PR DESCRIPTION
#11064 crashed the c++ language server by inserting an invalid preprocessor statement.

Worse than that, it actually caused Hack Studio to freeze because both the language client and server attempted to send a large amount of data to each other over IPC, filled their send buffers and blocked.

This PR fixes the language server crash and mitigates the freezing problem by having the language client only send the content of open files to the server when it is respawned (instead of sending all of the files in the project).

Fixes #11064.