### PR TITLE
LibJS+LibUnicode: Parse and extend date-time format patterns

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -322,8 +322,13 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         // f. If dateTimeformat.[[HourCycle]] is "h11" or "h12", then
         if ((hour_cycle == Unicode::HourCycle::H11) || (hour_cycle == Unicode::HourCycle::H12)) {
             // i. Let pattern be bestFormat.[[pattern12]].
-            if (best_format->pattern12.has_value())
+            if (best_format->pattern12.has_value()) {
                 pattern = best_format->pattern12.release_value();
+            } else {
+                // Non-standard, LibUnicode only provides [[pattern12]] when [[pattern]] has a day
+                // period. Other implementations provide [[pattern12]] as a copy of [[pattern]].
+                pattern = move(best_format->pattern);
+            }
 
             // ii. Let rangePatterns be bestFormat.[[rangePatterns12]].
         }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
@@ -1,6 +1,6 @@
-// NOTE: We cannot yet test the fields of ECMA-402's Table 4 (week, day, etc.) because those fields
-//       won't be copied into the Intl.DateTimeFormat object until the date-time pattern generator
-//       actually parses the CLDR patterns (see parse_date_time_pattern).
+// NOTE: We cannot yet test the fractionalSecondDigits option. There aren't any patterns in the CLDR
+//       with this field ('S' in https://unicode.org/reports/tr35/tr35-dates.html#dfst-second). We
+//       will need to figure out how this field should be generated.
 describe("correct behavior", () => {
     test("length is 0", () => {
         expect(Intl.DateTimeFormat.prototype.resolvedOptions).toHaveLength(0);
@@ -113,6 +113,76 @@ describe("correct behavior", () => {
         ["full", "long", "medium", "short"].forEach(style => {
             const el = new Intl.DateTimeFormat("el", { timeStyle: style });
             expect(el.resolvedOptions().timeStyle).toBe(style);
+        });
+    });
+
+    test("weekday", () => {
+        ["narrow", "short", "long"].forEach(weekday => {
+            const en = new Intl.DateTimeFormat("en", { weekday: weekday });
+            expect(en.resolvedOptions().weekday).toBe(weekday);
+        });
+    });
+
+    test("era", () => {
+        ["narrow", "short", "long"].forEach(era => {
+            const en = new Intl.DateTimeFormat("en", { era: era });
+            expect(en.resolvedOptions().era).toBe(era);
+        });
+    });
+
+    test("year", () => {
+        ["2-digit", "numeric"].forEach(year => {
+            const en = new Intl.DateTimeFormat("en", { year: year });
+            expect(en.resolvedOptions().year).toBe(year);
+        });
+    });
+
+    test("month", () => {
+        ["2-digit", "numeric", "narrow", "short", "long"].forEach(month => {
+            const en = new Intl.DateTimeFormat("en", { month: month });
+            expect(en.resolvedOptions().month).toBe(month);
+        });
+    });
+
+    test("day", () => {
+        ["2-digit", "numeric"].forEach(day => {
+            const en = new Intl.DateTimeFormat("en", { day: day });
+            expect(en.resolvedOptions().day).toBe(day);
+        });
+    });
+
+    test("dayPeriod", () => {
+        ["narrow", "short", "long"].forEach(dayPeriod => {
+            const en = new Intl.DateTimeFormat("en", { dayPeriod: dayPeriod });
+            expect(en.resolvedOptions().dayPeriod).toBe(dayPeriod);
+        });
+    });
+
+    test("hour", () => {
+        ["2-digit", "numeric"].forEach(hour => {
+            const en = new Intl.DateTimeFormat("en", { hour: hour });
+            expect(en.resolvedOptions().hour).toBe(hour);
+        });
+    });
+
+    test("minute", () => {
+        ["2-digit", "numeric"].forEach(minute => {
+            const en = new Intl.DateTimeFormat("en", { minute: minute });
+            expect(en.resolvedOptions().minute).toBe(minute);
+        });
+    });
+
+    test("second", () => {
+        ["2-digit", "numeric"].forEach(second => {
+            const en = new Intl.DateTimeFormat("en", { second: second });
+            expect(en.resolvedOptions().second).toBe(second);
+        });
+    });
+
+    test("timeZoneName", () => {
+        ["short", "long"].forEach(timeZoneName => {
+            const en = new Intl.DateTimeFormat("en", { timeZoneName: timeZoneName });
+            expect(en.resolvedOptions().timeZoneName).toBe(timeZoneName);
         });
     });
 });


### PR DESCRIPTION
There was a big FIXME in the previous DateTimeFormat PR to actually parse the format patterns. This PR implements that, and implements the "missing skeleton" algorithm to generate a larger set of patterns than are directly available in the CLDR. Fixes a handful of test262 tests.

The first commit serves to prevent this newly generated data from growing too large / taking too long to compile. We would otherwise generate a couple hundred thousand patterns, of which only about 22K (~12%) are actually unique. The second commit is unrelated to date-times, but I used NumberFormat to make sure the first commit worked.

One remaining issue is I have no idea how `fractionalSecondDigits` is supposed to work. There aren't any patterns in the CLDR with this option (though it is described in TR-35), so it's gotta come from somewhere, I just don't see where yet.