### PR TITLE
AudioServer+SoundPlayer: Allow each client on AudioServer to be muted

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -30,9 +30,9 @@ public:
         , m_show_percent(Config::read_bool("AudioApplet", "Applet", "ShowPercent", false))
     {
         m_audio_volume = static_cast<int>(m_audio_client->get_main_mix_volume() * 100);
-        m_audio_muted = m_audio_client->get_muted();
+        m_audio_muted = m_audio_client->is_main_mix_muted();
 
-        m_audio_client->on_muted_state_change = [this](bool muted) {
+        m_audio_client->on_main_mix_muted_state_change = [this](bool muted) {
             if (m_audio_muted == muted)
                 return;
             m_mute_box->set_checked(!m_audio_muted);
@@ -104,7 +104,7 @@ public:
         m_mute_box->set_tooltip(m_audio_muted ? "Unmute" : "Mute");
         m_mute_box->on_checked = [&](bool is_muted) {
             m_mute_box->set_tooltip(is_muted ? "Unmute" : "Mute");
-            m_audio_client->set_muted(is_muted);
+            m_audio_client->set_main_mix_muted(is_muted);
             GUI::Application::the()->hide_tooltip();
         };
     }
@@ -130,7 +130,7 @@ private:
             return;
         }
         if (event.button() == GUI::MouseButton::Secondary) {
-            m_audio_client->set_muted(!m_audio_muted);
+            m_audio_client->set_main_mix_muted(!m_audio_muted);
             update();
         }
     }

--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -93,6 +93,15 @@ void Player::set_volume(double volume)
     volume_changed(m_volume);
 }
 
+void Player::set_mute(bool muted)
+{
+    if (m_muted != muted) {
+        m_muted = muted;
+        m_audio_client_connection.set_self_muted(muted);
+        mute_changed(muted);
+    }
+}
+
 void Player::set_shuffle_mode(ShuffleMode mode)
 {
     if (m_shuffle_mode != mode) {
@@ -124,6 +133,16 @@ void Player::stop()
 {
     m_playback_manager.stop();
     set_play_state(PlayState::Stopped);
+}
+
+void Player::mute()
+{
+    set_mute(true);
+}
+
+void Player::toggle_mute()
+{
+    set_mute(!m_muted);
 }
 
 void Player::seek(int sample)

--- a/Userland/Applications/SoundPlayer/Player.h
+++ b/Userland/Applications/SoundPlayer/Player.h
@@ -49,11 +49,16 @@ public:
     double volume() const { return m_volume; }
     void set_volume(double value);
 
+    bool is_muted() const { return m_muted; }
+    void set_mute(bool);
+
     void play();
     void pause();
     void toggle_pause();
     void stop();
     void seek(int sample);
+    void mute();
+    void toggle_mute();
 
     virtual void play_state_changed(PlayState) = 0;
     virtual void loop_mode_changed(LoopMode) = 0;
@@ -63,6 +68,7 @@ public:
     virtual void audio_load_error(StringView, StringView) = 0;
     virtual void shuffle_mode_changed(ShuffleMode) = 0;
     virtual void volume_changed(double) = 0;
+    virtual void mute_changed(bool) = 0;
     virtual void total_samples_changed(int) = 0;
     virtual void sound_buffer_played(RefPtr<Audio::Buffer>, [[maybe_unused]] int sample_rate, [[maybe_unused]] int samples_played) = 0;
 
@@ -73,6 +79,7 @@ protected:
         set_loop_mode(LoopMode::None);
         time_elapsed(0);
         set_volume(1.);
+        set_mute(false);
     }
 
 private:
@@ -86,4 +93,5 @@ private:
 
     String m_loaded_filename;
     double m_volume { 0 };
+    bool m_muted { false };
 };

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -180,6 +180,10 @@ void SoundPlayerWidgetAdvancedView::loop_mode_changed(Player::LoopMode)
 {
 }
 
+void SoundPlayerWidgetAdvancedView::mute_changed(bool)
+{
+}
+
 void SoundPlayerWidgetAdvancedView::sync_previous_next_buttons()
 {
     m_back_button->set_enabled(playlist().size() > 1 && !playlist().shuffling());

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -142,6 +142,9 @@ void SoundPlayerWidgetAdvancedView::keydown_event(GUI::KeyEvent& event)
     if (event.key() == Key_Space)
         m_play_button->click();
 
+    if (event.key() == Key_M)
+        toggle_mute();
+
     if (event.key() == Key_S)
         m_stop_button->click();
 
@@ -182,6 +185,7 @@ void SoundPlayerWidgetAdvancedView::loop_mode_changed(Player::LoopMode)
 
 void SoundPlayerWidgetAdvancedView::mute_changed(bool)
 {
+    // FIXME: Update the volume slider when player is muted
 }
 
 void SoundPlayerWidgetAdvancedView::sync_previous_next_buttons()

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -42,6 +42,7 @@ public:
     virtual void playlist_loaded(StringView, bool) override;
     virtual void audio_load_error(StringView path, StringView error_reason) override;
     virtual void volume_changed(double) override;
+    virtual void mute_changed(bool) override;
     virtual void total_samples_changed(int) override;
     virtual void sound_buffer_played(RefPtr<Audio::Buffer>, int sample_rate, int samples_played) override;
 

--- a/Userland/Libraries/LibAudio/ClientConnection.cpp
+++ b/Userland/Libraries/LibAudio/ClientConnection.cpp
@@ -45,10 +45,10 @@ void ClientConnection::finished_playing_buffer(i32 buffer_id)
         on_finish_playing_buffer(buffer_id);
 }
 
-void ClientConnection::muted_state_changed(bool muted)
+void ClientConnection::main_mix_muted_state_changed(bool muted)
 {
-    if (on_muted_state_change)
-        on_muted_state_change(muted);
+    if (on_main_mix_muted_state_change)
+        on_main_mix_muted_state_change(muted);
 }
 
 void ClientConnection::main_mix_volume_changed(double volume)

--- a/Userland/Libraries/LibAudio/ClientConnection.h
+++ b/Userland/Libraries/LibAudio/ClientConnection.h
@@ -24,7 +24,7 @@ public:
     void async_enqueue(Buffer const&);
 
     Function<void(i32 buffer_id)> on_finish_playing_buffer;
-    Function<void(bool muted)> on_muted_state_change;
+    Function<void(bool muted)> on_main_mix_muted_state_change;
     Function<void(double volume)> on_main_mix_volume_change;
     Function<void(double volume)> on_client_volume_change;
 
@@ -32,7 +32,7 @@ private:
     ClientConnection();
 
     virtual void finished_playing_buffer(i32) override;
-    virtual void muted_state_changed(bool) override;
+    virtual void main_mix_muted_state_changed(bool) override;
     virtual void main_mix_volume_changed(double) override;
     virtual void client_volume_changed(double) override;
 };

--- a/Userland/Services/AudioServer/AudioClient.ipc
+++ b/Userland/Services/AudioServer/AudioClient.ipc
@@ -3,7 +3,7 @@
 endpoint AudioClient
 {
     finished_playing_buffer(i32 buffer_id) =|
-    muted_state_changed(bool muted) =|
+    main_mix_muted_state_changed(bool muted) =|
     main_mix_volume_changed(double volume) =|
     client_volume_changed(double volume) =|
 }

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -5,6 +5,8 @@ endpoint AudioServer
     // Mixer functions
     set_main_mix_muted(bool muted) => ()
     is_main_mix_muted() => (bool muted)
+    set_self_muted(bool muted) => ()
+    is_self_muted() => (bool muted)
     get_main_mix_volume() => (double volume)
     set_main_mix_volume(double volume) => ()
     get_self_volume() => (double volume)

--- a/Userland/Services/AudioServer/AudioServer.ipc
+++ b/Userland/Services/AudioServer/AudioServer.ipc
@@ -3,8 +3,8 @@
 endpoint AudioServer
 {
     // Mixer functions
-    set_muted(bool muted) => ()
-    get_muted() => (bool muted)
+    set_main_mix_muted(bool muted) => ()
+    is_main_mix_muted() => (bool muted)
     get_main_mix_volume() => (double volume)
     set_main_mix_volume(double volume) => ()
     get_self_volume() => (double volume)

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -43,9 +43,9 @@ void ClientConnection::did_finish_playing_buffer(Badge<ClientAudioStream>, int b
     async_finished_playing_buffer(buffer_id);
 }
 
-void ClientConnection::did_change_muted_state(Badge<Mixer>, bool muted)
+void ClientConnection::did_change_main_mix_muted_state(Badge<Mixer>, bool muted)
 {
-    async_muted_state_changed(muted);
+    async_main_mix_muted_state_changed(muted);
 }
 
 void ClientConnection::did_change_main_mix_volume(Badge<Mixer>, double volume)
@@ -140,12 +140,12 @@ Messages::AudioServer::GetPlayingBufferResponse ClientConnection::get_playing_bu
     return id;
 }
 
-Messages::AudioServer::GetMutedResponse ClientConnection::get_muted()
+Messages::AudioServer::IsMainMixMutedResponse ClientConnection::is_main_mix_muted()
 {
     return m_mixer.is_muted();
 }
 
-void ClientConnection::set_muted(bool muted)
+void ClientConnection::set_main_mix_muted(bool muted)
 {
     m_mixer.set_muted(muted);
 }

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -149,4 +149,18 @@ void ClientConnection::set_main_mix_muted(bool muted)
 {
     m_mixer.set_muted(muted);
 }
+
+Messages::AudioServer::IsSelfMutedResponse ClientConnection::is_self_muted()
+{
+    if (m_queue)
+        return m_queue->is_muted();
+
+    return false;
+}
+
+void ClientConnection::set_self_muted(bool muted)
+{
+    if (m_queue)
+        m_queue->set_muted(muted);
+}
 }

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -27,7 +27,7 @@ public:
 
     void did_finish_playing_buffer(Badge<ClientAudioStream>, int buffer_id);
     void did_change_client_volume(Badge<ClientAudioStream>, double volume);
-    void did_change_muted_state(Badge<Mixer>, bool muted);
+    void did_change_main_mix_muted_state(Badge<Mixer>, bool muted);
     void did_change_main_mix_volume(Badge<Mixer>, double volume);
 
     virtual void die() override;
@@ -47,8 +47,8 @@ private:
     virtual void set_paused(bool) override;
     virtual void clear_buffer(bool) override;
     virtual Messages::AudioServer::GetPlayingBufferResponse get_playing_buffer() override;
-    virtual Messages::AudioServer::GetMutedResponse get_muted() override;
-    virtual void set_muted(bool) override;
+    virtual Messages::AudioServer::IsMainMixMutedResponse is_main_mix_muted() override;
+    virtual void set_main_mix_muted(bool) override;
     virtual void set_sample_rate(u32 sample_rate) override;
     virtual Messages::AudioServer::GetSampleRateResponse get_sample_rate() override;
 

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -49,6 +49,8 @@ private:
     virtual Messages::AudioServer::GetPlayingBufferResponse get_playing_buffer() override;
     virtual Messages::AudioServer::IsMainMixMutedResponse is_main_mix_muted() override;
     virtual void set_main_mix_muted(bool) override;
+    virtual Messages::AudioServer::IsSelfMutedResponse is_self_muted() override;
+    virtual void set_self_muted(bool) override;
     virtual void set_sample_rate(u32 sample_rate) override;
     virtual Messages::AudioServer::GetSampleRateResponse get_sample_rate() override;
 

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -161,7 +161,7 @@ void Mixer::set_muted(bool muted)
     request_setting_sync();
 
     ClientConnection::for_each([muted](ClientConnection& client) {
-        client.did_change_muted_state({}, muted);
+        client.did_change_main_mix_muted_state({}, muted);
     });
 }
 

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -97,6 +97,8 @@ void Mixer::mix()
                 Audio::Sample sample;
                 if (!queue->get_next_sample(sample))
                     break;
+                if (queue->is_muted())
+                    continue;
                 sample.log_multiply(SAMPLE_HEADROOM);
                 sample.log_multiply(queue->volume());
                 mixed_sample += sample;

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -92,6 +92,8 @@ public:
     FadingProperty<double>& volume() { return m_volume; }
     double volume() const { return m_volume; }
     void set_volume(double const volume) { m_volume = volume; }
+    bool is_muted() const { return m_muted; }
+    void set_muted(bool muted) { m_muted = muted; }
 
 private:
     RefPtr<Audio::Buffer> m_current;
@@ -100,6 +102,7 @@ private:
     int m_remaining_samples { 0 };
     int m_played_samples { 0 };
     bool m_paused { false };
+    bool m_muted { false };
 
     WeakPtr<ClientConnection> m_client;
     FadingProperty<double> m_volume { 1 };

--- a/Userland/Utilities/asctl.cpp
+++ b/Userland/Utilities/asctl.cpp
@@ -78,7 +78,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 break;
             }
             case AudioVariable::Mute: {
-                bool muted = audio_client->get_muted();
+                bool muted = audio_client->is_main_mix_muted();
                 if (human_mode)
                     outln("Muted: {}", muted ? "Yes" : "No");
                 else
@@ -151,7 +151,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
             case AudioVariable::Mute: {
                 bool& mute = to_set.value.get<bool>();
-                audio_client->set_muted(mute);
+                audio_client->set_main_mix_muted(mute);
                 break;
             }
             case AudioVariable::SampleRate: {


### PR DESCRIPTION
Initially I wanted to add a 'mute' shortcut to SoundPlayer but there was no way of 'muting' a client on AudioServer. We could only mute the 'main mix', which meant that we could only mute the whole system.

This PR does four things to improve that: 

- Refactors the IPC methods of AudioServer to distinguish between 'main mix mute' and 'self mute', this way each client can mute themselves but also the 'main mix'.
- Adds a 'self muted' state to each audio client connection, so we can know if it's muted or not.
- Allows the main mixer to ignore 'muted' clients when computing the output mix.
- Adds a 'mute' shortcut to SoundPlayer (key M) but it still doesn't update the volume slider because the actual widget can't show a muted state.

Note: This is a re-do of my previous PR (#10758) after a failed rebase.