### PR TITLE
ImageViewer: Fix "Set as Desktop Wallpaper" action

### DIFF
--- a/Base/etc/fstab
+++ b/Base/etc/fstab
@@ -5,6 +5,7 @@
 /bin	/bin	bind	bind,nodev,ro
 /etc	/etc	bind	bind,nodev,nosuid
 /home	/home	bind	bind,nodev,nosuid
+/res	/res	bind	bind,nodev,nosuid
 /root	/root	bind	bind,nodev,nosuid
 /var	/var	bind	bind,nodev,nosuid
 /www	/www	bind	bind,nodev,nosuid


### PR DESCRIPTION
Because WindowServer uses unveil for security, you can't set a wallpaper from any random directory anymore (as described in #11158).
In practice, this means that you can only set wallpapers that are located in /res/, which is mounted read-only by default.

This PR makes /res writeable to root and ImageViewer copy the image to /res/wallpapers before actually setting it as a wallpaper.
Note, however, that this does not work for the default user, since he has no write permissions for /res.
