### PR TITLE
LibGUI: Add movement methods to AbstractSlider

### DIFF
--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -95,7 +95,7 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
                     scrollbar.set_value(0);
                 }
             } else {
-                scrollbar.set_value(scrollbar.value() + 20);
+                scrollbar.increase_slider_by(20);
             }
         } else {
             if (scrollbar.value() == 0) {

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -106,7 +106,7 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
                     scrollbar.set_value(scrollbar.max());
                 }
             } else {
-                scrollbar.set_value(scrollbar.value() - 20);
+                scrollbar.decrease_slider_by(20);
             }
         }
     }

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -239,7 +239,7 @@ void RollWidget::mouseup_event([[maybe_unused]] GUI::MouseEvent& event)
 void RollWidget::mousewheel_event(GUI::MouseEvent& event)
 {
     if (event.modifiers() & KeyModifier::Mod_Shift) {
-        horizontal_scrollbar().set_value(horizontal_scrollbar().value() + (event.wheel_delta() * horizontal_scroll_sensitivity));
+        horizontal_scrollbar().increase_slider_by(event.wheel_delta() * horizontal_scroll_sensitivity);
         return;
     }
 

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -248,7 +248,7 @@ void LayerListWidget::on_automatic_scrolling_timer_fired()
     if (vertical_scrollbar().is_max() && m_automatic_scroll_delta.y() > 0)
         return;
 
-    vertical_scrollbar().set_value(vertical_scrollbar().value() + m_automatic_scroll_delta.y());
+    vertical_scrollbar().increase_slider_by(m_automatic_scroll_delta.y());
     gadget.movement_delta.set_y(gadget.movement_delta.y() + m_automatic_scroll_delta.y());
 
     auto inner_rect_max_height = widget_inner_rect().height() - 2 + vertical_scrollbar().max();

--- a/Userland/Applications/PixelPaint/Tools/Tool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/Tool.cpp
@@ -34,7 +34,7 @@ void Tool::on_keydown(GUI::KeyEvent& event)
     switch (event.key()) {
     case KeyCode::Key_LeftBracket:
         if (m_primary_slider)
-            m_primary_slider->set_value(m_primary_slider->value() - 1);
+            m_primary_slider->decrease_slider_by(1);
         break;
     case KeyCode::Key_RightBracket:
         if (m_primary_slider)
@@ -42,7 +42,7 @@ void Tool::on_keydown(GUI::KeyEvent& event)
         break;
     case KeyCode::Key_LeftBrace:
         if (m_secondary_slider)
-            m_secondary_slider->set_value(m_secondary_slider->value() - 1);
+            m_secondary_slider->decrease_slider_by(1);
         break;
     case KeyCode::Key_RightBrace:
         if (m_secondary_slider)

--- a/Userland/Applications/PixelPaint/Tools/Tool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/Tool.cpp
@@ -38,7 +38,7 @@ void Tool::on_keydown(GUI::KeyEvent& event)
         break;
     case KeyCode::Key_RightBracket:
         if (m_primary_slider)
-            m_primary_slider->set_value(m_primary_slider->value() + 1);
+            m_primary_slider->increase_slider_by(1);
         break;
     case KeyCode::Key_LeftBrace:
         if (m_secondary_slider)
@@ -46,7 +46,7 @@ void Tool::on_keydown(GUI::KeyEvent& event)
         break;
     case KeyCode::Key_RightBrace:
         if (m_secondary_slider)
-            m_secondary_slider->set_value(m_secondary_slider->value() + 1);
+            m_secondary_slider->increase_slider_by(1);
         break;
     default:
         break;

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -152,7 +152,7 @@ void SoundPlayerWidgetAdvancedView::keydown_event(GUI::KeyEvent& event)
         m_volume_slider->increase_slider_by_page_steps(1);
 
     if (event.key() == Key_Down)
-        m_volume_slider->set_value(m_volume_slider->value() - m_volume_slider->page_step());
+        m_volume_slider->decrease_slider_by_page_steps(1);
 
     GUI::Widget::keydown_event(event);
 }

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -149,7 +149,7 @@ void SoundPlayerWidgetAdvancedView::keydown_event(GUI::KeyEvent& event)
         m_stop_button->click();
 
     if (event.key() == Key_Up)
-        m_volume_slider->set_value(m_volume_slider->value() + m_volume_slider->page_step());
+        m_volume_slider->increase_slider_by_page_steps(1);
 
     if (event.key() == Key_Down)
         m_volume_slider->set_value(m_volume_slider->value() - m_volume_slider->page_step());

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -49,9 +49,9 @@ void AbstractScrollableWidget::handle_wheel_event(MouseEvent& event, Widget& eve
     }
     // FIXME: The wheel delta multiplier should probably come from... somewhere?
     if (event.shift() || &event_source == m_horizontal_scrollbar.ptr()) {
-        horizontal_scrollbar().set_value(horizontal_scrollbar().value() + event.wheel_delta() * 60);
+        horizontal_scrollbar().increase_slider_by(event.wheel_delta() * 60);
     } else {
-        vertical_scrollbar().set_value(vertical_scrollbar().value() + event.wheel_delta() * 20);
+        vertical_scrollbar().increase_slider_by(event.wheel_delta() * 20);
     }
 }
 

--- a/Userland/Libraries/LibGUI/AbstractSlider.h
+++ b/Userland/Libraries/LibGUI/AbstractSlider.h
@@ -38,6 +38,13 @@ public:
     void set_page_step(int page_step);
     void set_jump_to_cursor(bool b) { m_jump_to_cursor = b; }
 
+    void increase_slider_by(int delta) { set_value(value() + delta); }
+    void decrease_slider_by(int delta) { set_value(value() - delta); }
+    void increase_slider_by_page_steps(int page_steps) { set_value(value() + page_step() * page_steps); }
+    void decrease_slider_by_page_steps(int page_steps) { set_value(value() - page_step() * page_steps); }
+    void increase_slider_by_steps(int steps) { set_value(value() + step() * steps); }
+    void decrease_slider_by_steps(int steps) { set_value(value() - step() * steps); }
+
     Function<void(int)> on_change;
 
 protected:

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -797,8 +797,8 @@ void AbstractView::on_automatic_scrolling_timer_fired()
     if (m_automatic_scroll_delta.is_null())
         return;
 
-    vertical_scrollbar().set_value(vertical_scrollbar().value() + m_automatic_scroll_delta.y());
-    horizontal_scrollbar().set_value(horizontal_scrollbar().value() + m_automatic_scroll_delta.x());
+    vertical_scrollbar().increase_slider_by(m_automatic_scroll_delta.y());
+    horizontal_scrollbar().increase_slider_by(m_automatic_scroll_delta.x());
 }
 
 }

--- a/Userland/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Userland/Libraries/LibGUI/OpacitySlider.cpp
@@ -139,7 +139,7 @@ void OpacitySlider::mouseup_event(MouseEvent& event)
 
 void OpacitySlider::mousewheel_event(MouseEvent& event)
 {
-    set_value(value() - event.wheel_delta());
+    decrease_slider_by(event.wheel_delta());
 }
 
 }

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -332,7 +332,7 @@ void Scrollbar::scroll_by_page(const Gfx::IntPoint& click_position)
         set_value(value() - page_increment);
     } else {
         gutter_click_state = GutterClickState::AfterScrubber;
-        set_value(value() + page_increment);
+        increase_slider_by(page_increment);
     }
 }
 

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -329,7 +329,7 @@ void Scrollbar::scroll_by_page(const Gfx::IntPoint& click_position)
 
     if (click_position.primary_offset_for_orientation(orientation()) < scrubber_rect().primary_offset_for_orientation(orientation())) {
         gutter_click_state = GutterClickState::BeforeScrubber;
-        set_value(value() - page_increment);
+        decrease_slider_by(page_increment);
     } else {
         gutter_click_state = GutterClickState::AfterScrubber;
         increase_slider_by(page_increment);

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -228,7 +228,7 @@ void Scrollbar::paint_event(PaintEvent& event)
 void Scrollbar::on_automatic_scrolling_timer_fired()
 {
     if (m_pressed_component == Component::DecrementButton && component_at_position(m_last_mouse_position) == Component::DecrementButton) {
-        set_value(value() - step());
+        decrease_slider_by_steps(1);
         return;
     }
     if (m_pressed_component == Component::IncrementButton && component_at_position(m_last_mouse_position) == Component::IncrementButton) {

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -232,7 +232,7 @@ void Scrollbar::on_automatic_scrolling_timer_fired()
         return;
     }
     if (m_pressed_component == Component::IncrementButton && component_at_position(m_last_mouse_position) == Component::IncrementButton) {
-        set_value(value() + step());
+        increase_slider_by_steps(1);
         return;
     }
     if (m_pressed_component == Component::Gutter && component_at_position(m_last_mouse_position) == Component::Gutter) {
@@ -299,7 +299,7 @@ void Scrollbar::mousewheel_event(MouseEvent& event)
 {
     if (!is_scrollable())
         return;
-    set_value(value() + event.wheel_delta() * step());
+    increase_slider_by_steps(event.wheel_delta());
     Widget::mousewheel_event(event);
 }
 

--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -106,7 +106,7 @@ void Slider::mousedown_event(MouseEvent& event)
             if (mouse_offset > knob_last_edge)
                 increase_slider_by_page_steps(1);
             else if (mouse_offset < knob_first_edge)
-                set_value(value() - page_step());
+                decrease_slider_by_page_steps(1);
         }
     }
     return Widget::mousedown_event(event);

--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -147,7 +147,7 @@ void Slider::mousewheel_event(MouseEvent& event)
         wheel_delta /= abs(wheel_delta);
 
     if (orientation() == Orientation::Horizontal)
-        set_value(value() - wheel_delta * acceleration_modifier);
+        decrease_slider_by(wheel_delta * acceleration_modifier);
     else
         increase_slider_by(wheel_delta * acceleration_modifier);
 

--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -104,7 +104,7 @@ void Slider::mousedown_event(MouseEvent& event)
             auto knob_first_edge = knob_rect().first_edge_for_orientation(orientation());
             auto knob_last_edge = knob_rect().last_edge_for_orientation(orientation());
             if (mouse_offset > knob_last_edge)
-                set_value(value() + page_step());
+                increase_slider_by_page_steps(1);
             else if (mouse_offset < knob_first_edge)
                 set_value(value() - page_step());
         }

--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -149,7 +149,7 @@ void Slider::mousewheel_event(MouseEvent& event)
     if (orientation() == Orientation::Horizontal)
         set_value(value() - wheel_delta * acceleration_modifier);
     else
-        set_value(value() + wheel_delta * acceleration_modifier);
+        increase_slider_by(wheel_delta * acceleration_modifier);
 
     Widget::mousewheel_event(event);
 }

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -46,7 +46,7 @@ ValueSlider::ValueSlider(Gfx::Orientation orientation, String suffix)
 
     m_textbox->on_up_pressed = [&]() {
         if (value() < max())
-            AbstractSlider::set_value(value() + 1);
+            AbstractSlider::increase_slider_by(1);
         m_textbox->set_text(formatted_value());
     };
 
@@ -159,7 +159,7 @@ void ValueSlider::leave_event(Core::Event&)
 void ValueSlider::mousewheel_event(MouseEvent& event)
 {
     if (event.wheel_delta() < 0)
-        set_value(value() + 1);
+        increase_slider_by(1);
     else
         set_value(value() - 1);
 }

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -52,7 +52,7 @@ ValueSlider::ValueSlider(Gfx::Orientation orientation, String suffix)
 
     m_textbox->on_down_pressed = [&]() {
         if (value() > min())
-            AbstractSlider::set_value(value() - 1);
+            AbstractSlider::decrease_slider_by(1);
         m_textbox->set_text(formatted_value());
     };
 
@@ -161,7 +161,7 @@ void ValueSlider::mousewheel_event(MouseEvent& event)
     if (event.wheel_delta() < 0)
         increase_slider_by(1);
     else
-        set_value(value() - 1);
+        decrease_slider_by(1);
 }
 
 void ValueSlider::mousemove_event(MouseEvent& event)

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -215,7 +215,7 @@ void TerminalWidget::keydown_event(GUI::KeyEvent& event)
     m_cursor_blink_timer->start();
 
     if (event.key() == KeyCode::Key_PageUp && event.modifiers() == Mod_Shift) {
-        m_scrollbar->set_value(m_scrollbar->value() - m_terminal.rows());
+        m_scrollbar->decrease_slider_by(m_terminal.rows());
         return;
     }
     if (event.key() == KeyCode::Key_PageDown && event.modifiers() == Mod_Shift) {

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -107,7 +107,7 @@ TerminalWidget::TerminalWidget(int ptm_fd, bool automatic_size_policy)
     m_auto_scroll_timer->on_timeout = [this] {
         if (m_auto_scroll_direction != AutoScrollDirection::None) {
             int scroll_amount = m_auto_scroll_direction == AutoScrollDirection::Up ? -1 : 1;
-            m_scrollbar->set_value(m_scrollbar->value() + scroll_amount);
+            m_scrollbar->increase_slider_by(scroll_amount);
         }
     };
     m_auto_scroll_timer->start();
@@ -219,7 +219,7 @@ void TerminalWidget::keydown_event(GUI::KeyEvent& event)
         return;
     }
     if (event.key() == KeyCode::Key_PageDown && event.modifiers() == Mod_Shift) {
-        m_scrollbar->set_value(m_scrollbar->value() + m_terminal.rows());
+        m_scrollbar->increase_slider_by(m_terminal.rows());
         return;
     }
     if (event.key() == KeyCode::Key_Alt) {
@@ -916,7 +916,7 @@ void TerminalWidget::mousewheel_event(GUI::MouseEvent& event)
     if (!is_scrollable())
         return;
     set_auto_scroll_direction(AutoScrollDirection::None);
-    m_scrollbar->set_value(m_scrollbar->value() + event.wheel_delta() * scroll_length());
+    m_scrollbar->increase_slider_by(event.wheel_delta() * scroll_length());
     GUI::Frame::mousewheel_event(event);
 }
 

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -269,7 +269,7 @@ void InProcessWebView::keydown_event(GUI::KeyEvent& event)
             vertical_scrollbar().increase_slider_by(frame_inner_rect().height());
             break;
         case Key_PageUp:
-            vertical_scrollbar().set_value(vertical_scrollbar().value() - frame_inner_rect().height());
+            vertical_scrollbar().decrease_slider_by(frame_inner_rect().height());
             break;
         default:
             if (!page_accepted_event) {

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -254,13 +254,13 @@ void InProcessWebView::keydown_event(GUI::KeyEvent& event)
             vertical_scrollbar().set_value(vertical_scrollbar().max());
             break;
         case Key_Down:
-            vertical_scrollbar().set_value(vertical_scrollbar().value() + vertical_scrollbar().step());
+            vertical_scrollbar().increase_slider_by_steps(1);
             break;
         case Key_Up:
             vertical_scrollbar().set_value(vertical_scrollbar().value() - vertical_scrollbar().step());
             break;
         case Key_Left:
-            horizontal_scrollbar().set_value(horizontal_scrollbar().value() + horizontal_scrollbar().step());
+            horizontal_scrollbar().increase_slider_by_steps(1);
             break;
         case Key_Right:
             horizontal_scrollbar().set_value(horizontal_scrollbar().value() - horizontal_scrollbar().step());

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -257,13 +257,13 @@ void InProcessWebView::keydown_event(GUI::KeyEvent& event)
             vertical_scrollbar().increase_slider_by_steps(1);
             break;
         case Key_Up:
-            vertical_scrollbar().set_value(vertical_scrollbar().value() - vertical_scrollbar().step());
+            vertical_scrollbar().decrease_slider_by_steps(1);
             break;
         case Key_Left:
             horizontal_scrollbar().increase_slider_by_steps(1);
             break;
         case Key_Right:
-            horizontal_scrollbar().set_value(horizontal_scrollbar().value() - horizontal_scrollbar().step());
+            horizontal_scrollbar().decrease_slider_by_steps(1);
             break;
         case Key_PageDown:
             vertical_scrollbar().increase_slider_by(frame_inner_rect().height());

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -266,7 +266,7 @@ void InProcessWebView::keydown_event(GUI::KeyEvent& event)
             horizontal_scrollbar().set_value(horizontal_scrollbar().value() - horizontal_scrollbar().step());
             break;
         case Key_PageDown:
-            vertical_scrollbar().set_value(vertical_scrollbar().value() + frame_inner_rect().height());
+            vertical_scrollbar().increase_slider_by(frame_inner_rect().height());
             break;
         case Key_PageUp:
             vertical_scrollbar().set_value(vertical_scrollbar().value() - frame_inner_rect().height());

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -243,8 +243,8 @@ void OutOfProcessWebView::notify_server_did_change_title(Badge<WebContentClient>
 
 void OutOfProcessWebView::notify_server_did_request_scroll(Badge<WebContentClient>, i32 x_delta, i32 y_delta)
 {
-    horizontal_scrollbar().set_value(horizontal_scrollbar().value() + x_delta);
-    vertical_scrollbar().set_value(vertical_scrollbar().value() + y_delta);
+    horizontal_scrollbar().increase_slider_by(x_delta);
+    vertical_scrollbar().increase_slider_by(y_delta);
 }
 
 void OutOfProcessWebView::notify_server_did_request_scroll_to(Badge<WebContentClient>, Gfx::IntPoint const& scroll_position)


### PR DESCRIPTION
When I was adding the volume shortcuts for SoundPlayer, @kleinesfilmroellchen suggested me that we could add some methods to make easier moving the slider (https://github.com/SerenityOS/serenity/pull/10715#pullrequestreview-793701706).

With that in mind, this PR adds six methods to AbstractSlider to help us move the slider up and down without needing to repeat the pattern `set_value(value() +/- delta)`

These new methods are:
- `increase_by(int delta)` / `decrease_by(int delta)`
- `increase_by_page_steps(int page_steps)` / `decrease_by_page_steps(int page_steps)`
- `increase_by_steps(int steps)` / `decrease_by_steps(int steps)`

For example, this is how it can be used to move the slider up by some value.
```diff
-scrollbar.set_value(scrollbar.value() + 20);
+scrollbar.increase_by(20);
```