### PR TITLE
Kernel: Make the Aarch64 port compile with Clang

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -489,6 +489,7 @@ struct SC_statvfs_params {
 void initialize();
 int sync();
 
+#    if ARCH(I386) || ARCH(X86_64)
 inline uintptr_t invoke(Function function)
 {
     uintptr_t result;
@@ -542,6 +543,7 @@ inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
                  : "memory");
     return result;
 }
+#    endif
 #endif
 
 }

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -58,7 +58,7 @@ public:
         return 0;
     }
 
-    ALWAYS_INLINE static Processor& current() { return *((Processor*)0); }
+    ALWAYS_INLINE static Processor& current() { VERIFY_NOT_REACHED(); }
 
     static void deferred_call_queue(Function<void()> /* callback */) { }
 

--- a/Kernel/Prekernel/Arch/aarch64/PrekernelMMU.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/PrekernelMMU.cpp
@@ -48,7 +48,7 @@ constexpr u32 INNER_SHAREABLE = (3 << 8);
 constexpr u32 NORMAL_MEMORY = (0 << 2);
 constexpr u32 DEVICE_MEMORY = (1 << 2);
 
-constexpr u64* descriptor_to_pointer(FlatPtr descriptor)
+ALWAYS_INLINE static u64* descriptor_to_pointer(FlatPtr descriptor)
 {
     return (u64*)(descriptor & DESCRIPTOR_MASK);
 }


### PR DESCRIPTION
This fixes the small issues that prevented the Aarch64 kernel from compiling with the Clang toolchain.

Now, the `Meta/serenity.sh run aarch64 Clang` command works. You don't even need to build a separate toolchain for it, as our Clang build is multi-target.