### PR TITLE
HackStudio: Fix cursor not jumping to column 1 in the embedded terminal

### DIFF
--- a/Userland/DevTools/HackStudio/TerminalWrapper.cpp
+++ b/Userland/DevTools/HackStudio/TerminalWrapper.cpp
@@ -55,11 +55,11 @@ void TerminalWrapper::run_command(const String& command)
             VERIFY_NOT_REACHED();
         }
         if (WIFEXITED(wstatus)) {
-            m_terminal_widget->inject_string(String::formatted("\033[{};1m(Command exited with code {})\033[0m\n", wstatus == 0 ? 32 : 31, WEXITSTATUS(wstatus)));
+            m_terminal_widget->inject_string(String::formatted("\033[{};1m(Command exited with code {})\033[0m\r\n", wstatus == 0 ? 32 : 31, WEXITSTATUS(wstatus)));
         } else if (WIFSTOPPED(wstatus)) {
-            m_terminal_widget->inject_string("\033[34;1m(Command stopped!)\033[0m\n");
+            m_terminal_widget->inject_string("\033[34;1m(Command stopped!)\033[0m\r\n");
         } else if (WIFSIGNALED(wstatus)) {
-            m_terminal_widget->inject_string(String::formatted("\033[34;1m(Command signaled with {}!)\033[0m\n", strsignal(WTERMSIG(wstatus))));
+            m_terminal_widget->inject_string(String::formatted("\033[34;1m(Command signaled with {}!)\033[0m\r\n", strsignal(WTERMSIG(wstatus))));
         }
         m_pid = -1;
 


### PR DESCRIPTION
Normally, it's the TTY layer's job to translate '\n' into the separate
'\r' and '\n' control characters needed by the terminal to move the
cursor to the first column of the next line.
(see 5d80debc1f891cacb155aa7eaaad51a9a3325ec9).

In HackStudio, we directly inject data into the TerminalWidget to
display command status. This means that this automatic translation
doesn't happen, so we need to explicitly give it the '\r' too.