### PR TITLE
LibDebug: Improve DWARF 4 support

### DIFF
--- a/Userland/Libraries/LibDebug/Dwarf/AddressRanges.h
+++ b/Userland/Libraries/LibDebug/Dwarf/AddressRanges.h
@@ -14,21 +14,36 @@
 
 namespace Debug::Dwarf {
 
-class AddressRanges {
-    AK_MAKE_NONCOPYABLE(AddressRanges);
-    AK_MAKE_NONMOVABLE(AddressRanges);
+struct Range {
+    FlatPtr start { 0 };
+    FlatPtr end { 0 };
+};
+
+class AddressRangesV5 {
+    AK_MAKE_NONCOPYABLE(AddressRangesV5);
+    AK_MAKE_NONMOVABLE(AddressRangesV5);
 
 public:
-    AddressRanges(ReadonlyBytes range_lists_data, size_t offset, CompilationUnit const& compilation_unit);
+    AddressRangesV5(ReadonlyBytes range_lists_data, size_t offset, CompilationUnit const& compilation_unit);
 
-    struct Range {
-        FlatPtr start { 0 };
-        FlatPtr end { 0 };
-    };
     void for_each_range(Function<void(Range)>);
 
 private:
     InputMemoryStream m_range_lists_stream;
+    CompilationUnit const& m_compilation_unit;
+};
+
+class AddressRangesV4 {
+    AK_MAKE_NONCOPYABLE(AddressRangesV4);
+    AK_MAKE_NONMOVABLE(AddressRangesV4);
+
+public:
+    AddressRangesV4(ReadonlyBytes ranges_data, size_t offset, CompilationUnit const&);
+
+    void for_each_range(Function<void(Range)>);
+
+private:
+    InputMemoryStream m_ranges_stream;
     CompilationUnit const& m_compilation_unit;
 };
 

--- a/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.h
+++ b/Userland/Libraries/LibDebug/Dwarf/CompilationUnit.h
@@ -34,6 +34,8 @@ public:
     FlatPtr get_address(size_t index) const;
     char const* get_string(size_t index) const;
 
+    u8 dwarf_version() const { return m_header.version(); }
+
     DwarfInfo const& dwarf_info() const { return m_dwarf_info; }
     AbbreviationsMap const& abbreviations_map() const { return m_abbreviations; }
     LineProgram const& line_program() const { return *m_line_program; }

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.h
@@ -33,6 +33,7 @@ public:
     ReadonlyBytes debug_range_lists_data() const { return m_debug_range_lists_data; }
     ReadonlyBytes debug_str_offsets_data() const { return m_debug_str_offsets_data; }
     ReadonlyBytes debug_addr_data() const { return m_debug_addr_data; }
+    ReadonlyBytes debug_ranges_data() const { return m_debug_ranges_data; }
 
     template<typename Callback>
     void for_each_compilation_unit(Callback) const;
@@ -64,6 +65,7 @@ private:
     ReadonlyBytes m_debug_range_lists_data;
     ReadonlyBytes m_debug_str_offsets_data;
     ReadonlyBytes m_debug_addr_data;
+    ReadonlyBytes m_debug_ranges_data;
 
     NonnullOwnPtrVector<Dwarf::CompilationUnit> m_compilation_units;
 

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -170,7 +170,8 @@ void LineProgram::handle_extended_opcode()
     }
     case ExtendedOpcodes::SetDiscriminator: {
         dbgln_if(DWARF_DEBUG, "SetDiscriminator");
-        m_stream.discard_or_error(1);
+        size_t discriminator;
+        m_stream.read_LEB128_unsigned(discriminator);
         break;
     }
     default:


### PR DESCRIPTION
The DWARF 5 format is not completely backward compatible with DWARF 4, which lead to an assertion failure when trying to parse address ranges. Although our userland is in DWARF 5, some ports can only be compiled with an earlier standard. This change will allow us to dump their backtraces too.

cc @IdanHo 