### PR TITLE
LibWeb: Expand `var()` capabilities

### DIFF
--- a/Base/res/html/misc/custom-properties.html
+++ b/Base/res/html/misc/custom-properties.html
@@ -6,6 +6,12 @@
     <style>
         :root {
             --my-color: purple;
+            --width: 10px;
+            --color: orange;
+            --style: solid;
+            --border: var(--width) var(--color) var(--style);
+            --background-color: yellow;
+            --background-position: top 10px right 5px;
         }
 
         div {
@@ -25,6 +31,67 @@
             width: 150px;
             height: 150px;
             border: 1px solid black;
+        }
+
+        .test-fallback {
+            background-color: var(--fallback, lime);
+        }
+
+        .test-fallback.with {
+            --fallback: cyan;
+        }
+
+        .test-nested {
+            border: var(--border);
+        }
+
+        .test-mixed {
+            background: var(--background-color) url("background-repeat.png") var(--background-position) no-repeat;
+        }
+
+        .billion-laughs {
+            --prop1: lol;
+            --prop2: var(--prop1) var(--prop1);
+            --prop3: var(--prop2) var(--prop2);
+            --prop4: var(--prop3) var(--prop3);
+            --prop5: var(--prop4) var(--prop4);
+            --prop6: var(--prop5) var(--prop5);
+            --prop7: var(--prop6) var(--prop6);
+            --prop8: var(--prop7) var(--prop7);
+            --prop9: var(--prop8) var(--prop8);
+            --prop10: var(--prop9) var(--prop9);
+            --prop11: var(--prop10) var(--prop10);
+            --prop12: var(--prop11) var(--prop11);
+            --prop13: var(--prop12) var(--prop12);
+            --prop14: var(--prop13) var(--prop13);
+            --prop15: var(--prop14) var(--prop14);
+            --prop16: var(--prop15) var(--prop15);
+            --prop17: var(--prop16) var(--prop16);
+            --prop18: var(--prop17) var(--prop17);
+            --prop19: var(--prop18) var(--prop18);
+            --prop20: var(--prop19) var(--prop19);
+            --prop21: var(--prop20) var(--prop20);
+            --prop22: var(--prop21) var(--prop21);
+            --prop23: var(--prop22) var(--prop22);
+            --prop24: var(--prop23) var(--prop23);
+            --prop25: var(--prop24) var(--prop24);
+            --prop26: var(--prop25) var(--prop25);
+            --prop27: var(--prop26) var(--prop26);
+            --prop28: var(--prop27) var(--prop27);
+            --prop29: var(--prop28) var(--prop28);
+            --prop30: var(--prop29) var(--prop29);
+
+            background: var(--prop30);
+        }
+
+        .dependency-cycle {
+            --recursive: var(--recursive);
+
+            --a: var(--b);
+            --b: var(--a);
+
+            background: var(--a);
+            color: var(--recursive);
         }
     </style>
 </head>
@@ -62,6 +129,98 @@
             </pre>
             This should be pink
         </div>
+    </div>
+
+    <h2>Fallback Values</h2>
+    <pre>
+        .test-fallback {
+            background-color: var(--fallback, lime);
+        }
+
+        .test-fallback.with {
+            --fallback: cyan;
+        }
+    </pre>
+
+    <div class="box test-fallback">
+        <pre>.test-fallback</pre>
+        This should be green
+    </div>
+
+    <div class="box test-fallback with">
+        <pre>.test-fallback.with</pre>
+        This should be cyan
+    </div>
+
+    <h2>Nested var()</h2>
+    <pre>
+        :root {
+            --width: 10px;
+            --color: orange;
+            --style: solid;
+            --border: var(--width) var(--color) var(--style);
+        }
+        .test-nested {
+            border: var(--border);
+        }
+    </pre>
+
+    <div class="box test-nested">
+        <pre>.test-nested</pre>
+        This should have a 10px solid orange border
+    </div>
+
+    <h2>Mixed var()</h2>
+    <pre>
+        :root {
+            --background-color: yellow;
+            --background-position: top 10px right 5px;
+        }
+
+        .test-mixed {
+            background: var(--background-color) url("background-repeat.png") var(--background-position) no-repeat;
+        }
+    </pre>
+
+    <div class="box test-mixed">
+        <pre>.test-mixed</pre>
+        This should have a yellow background with a smiley face in the top-right corner
+    </div>
+
+    <h2>Billion laughs attack</h2>
+    <pre>
+        .billion-laughs {
+            --prop1: lol;
+            --prop2: var(--prop1) var(--prop1);
+            --prop3: var(--prop2) var(--prop2);
+
+            /* ... */
+
+            --prop30: var(--prop29) var(--prop29);
+
+            background: var(--prop30);
+        }
+    </pre>
+    <div class="box billion-laughs">
+        <pre>.billion-laughs</pre>
+        This box tests that we handle the billion laughs attack. If we don't crash, it worked!
+    </div>
+
+    <h2>Dependency cycles</h2>
+    <pre>
+        .dependency-cycle {
+            --recursive: var(--recursive);
+
+            --a: var(--b);
+            --b: var(--a);
+
+            background: var(--a);
+            color: var(--recursive);
+        }
+    </pre>
+    <div class="box dependency-cycle">
+        <pre>.dependency-cycle</pre>
+        This box tests that we handle dependency cycles correctly. If we don't crash, it worked!
     </div>
 </body>
 

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
@@ -267,7 +267,7 @@ bool property_has_quirk(PropertyID property_id, Quirk quirk)
 
 bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
 {
-    if (style_value.is_builtin() || style_value.is_custom_property())
+    if (style_value.is_builtin())
         return true;
 
     switch (property_id) {

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleDeclaration.h
@@ -65,6 +65,7 @@ public:
     virtual bool set_property(PropertyID, StringView css_text) override;
 
     const Vector<StyleProperty>& properties() const { return m_properties; }
+    const HashMap<String, StyleProperty>& custom_properties() const { return m_custom_properties; }
     Optional<StyleProperty> custom_property(const String& custom_property_name) const { return m_custom_properties.get(custom_property_name); }
     size_t custom_property_count() const { return m_custom_properties.size(); }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1908,15 +1908,8 @@ RefPtr<StyleValue> Parser::parse_dynamic_value(StyleComponentValueRule const& co
             if (calc_expression)
                 return CalculatedStyleValue::create("(FIXME:calc to string)", calc_expression.release_nonnull());
         } else if (function.name().equals_ignoring_case("var")) {
-            // FIXME: Handle fallback value as second parameter
-            // https://www.w3.org/TR/css-variables-1/#using-variables
-            if (!component_value.function().values().is_empty()) {
-                auto& property_name_token = component_value.function().values().first();
-                if (property_name_token.is(Token::Type::Ident))
-                    return CustomStyleValue::create(property_name_token.token().ident());
-                else
-                    dbgln("First argument to var() function was not an ident: '{}'", property_name_token.to_debug_string());
-            }
+            // Declarations using `var()` should already be parsed as an UnresolvedStyleValue before this point.
+            VERIFY_NOT_REACHED();
         }
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -113,6 +113,8 @@ public:
 
     RefPtr<StyleValue> parse_as_css_value(PropertyID);
 
+    static RefPtr<StyleValue> parse_css_value(Badge<StyleComputer>, ParsingContext const&, PropertyID, Vector<StyleComponentValueRule> const&);
+
 private:
     enum class ParsingResult {
         Done,

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleBlockRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleBlockRule.h
@@ -19,11 +19,18 @@ class StyleBlockRule : public RefCounted<StyleBlockRule> {
 
 public:
     StyleBlockRule();
+    explicit StyleBlockRule(Token token, Vector<StyleComponentValueRule>&& values)
+        : m_token(token)
+        , m_values(move(values))
+    {
+    }
     ~StyleBlockRule();
 
     bool is_curly() const { return m_token.is(Token::Type::OpenCurly); }
     bool is_paren() const { return m_token.is(Token::Type::OpenParen); }
     bool is_square() const { return m_token.is(Token::Type::OpenSquare); }
+
+    Token const& token() const { return m_token; }
 
     Vector<StyleComponentValueRule> const& values() const { return m_values; }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleFunctionRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleFunctionRule.h
@@ -20,7 +20,8 @@ class StyleFunctionRule : public RefCounted<StyleFunctionRule> {
     friend class Parser;
 
 public:
-    StyleFunctionRule(String name);
+    explicit StyleFunctionRule(String name);
+    StyleFunctionRule(String name, Vector<StyleComponentValueRule>&& values);
     ~StyleFunctionRule();
 
     String const& name() const { return m_name; }

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
@@ -57,7 +57,13 @@ StyleDeclarationRule::StyleDeclarationRule() { }
 StyleDeclarationRule::~StyleDeclarationRule() { }
 
 StyleFunctionRule::StyleFunctionRule(String name)
-    : m_name(name)
+    : m_name(move(name))
+{
+}
+
+StyleFunctionRule::StyleFunctionRule(String name, Vector<StyleComponentValueRule>&& values)
+    : m_name(move(name))
+    , m_values(move(values))
 {
 }
 StyleFunctionRule::~StyleFunctionRule() { }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -459,7 +459,14 @@ bool StyleComputer::expand_unresolved_values(DOM::Element& element, Vector<Style
     // This is a very naive solution, and we could do better if the CSS Parser could accept tokens one at a time.
 
     // FIXME: Handle dependency cycles. https://www.w3.org/TR/css-variables-1/#cycles
-    // FIXME: Handle overly-long variables. https://www.w3.org/TR/css-variables-1/#long-variables
+
+    // Arbitrary large value chosen to avoid the billion-laughs attack.
+    // https://www.w3.org/TR/css-variables-1/#long-variables
+    const size_t MAX_VALUE_COUNT = 16384;
+    if (source.size() + dest.size() > MAX_VALUE_COUNT) {
+        dbgln("Stopped expanding CSS variables: maximum length reached.");
+        return false;
+    }
 
     auto get_custom_property = [this, &element](auto& name) -> RefPtr<StyleValue> {
         auto custom_property = resolve_custom_property(element, name);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -572,13 +572,6 @@ void StyleComputer::cascade_declarations(StyleProperties& style, DOM::Element& e
             if (important != property.important)
                 continue;
             auto property_value = property.value;
-            if (property.value->is_custom_property()) {
-                auto custom_property_name = property.value->as_custom_property().custom_property_name();
-                auto resolved = resolve_custom_property(element, custom_property_name);
-                if (resolved.has_value()) {
-                    property_value = resolved.value().value;
-                }
-            }
             if (property.value->is_unresolved()) {
                 if (auto resolved = resolve_unresolved_style_value(element, property.property_id, property.value->as_unresolved()))
                     property_value = resolved.release_nonnull();

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -62,7 +62,7 @@ private:
     void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID) const;
 
     RefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, PropertyID, UnresolvedStyleValue const&) const;
-    bool expand_unresolved_values(DOM::Element&, Vector<StyleComponentValueRule> const& source, Vector<StyleComponentValueRule>& dest) const;
+    bool expand_unresolved_values(DOM::Element&, Vector<StyleComponentValueRule> const& source, Vector<StyleComponentValueRule>& dest, size_t source_start_index = 0) const;
 
     template<typename Callback>
     void for_each_stylesheet(CascadeOrigin, Callback) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -9,6 +9,7 @@
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/OwnPtr.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
+#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/Forward.h>
 
@@ -59,6 +60,9 @@ private:
     void absolutize_values(StyleProperties&, DOM::Element const*) const;
 
     void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID) const;
+
+    RefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, PropertyID, UnresolvedStyleValue const&) const;
+    bool expand_unresolved_values(DOM::Element&, Vector<StyleComponentValueRule> const& source, Vector<StyleComponentValueRule>& dest) const;
 
     template<typename Callback>
     void for_each_stylesheet(CascadeOrigin, Callback) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -169,6 +169,12 @@ TransformationStyleValue const& StyleValue::as_transformation() const
     return static_cast<TransformationStyleValue const&>(*this);
 }
 
+UnresolvedStyleValue const& StyleValue::as_unresolved() const
+{
+    VERIFY(is_unresolved());
+    return static_cast<UnresolvedStyleValue const&>(*this);
+}
+
 UnsetStyleValue const& StyleValue::as_unset() const
 {
     VERIFY(is_unset());
@@ -490,6 +496,14 @@ String PositionStyleValue::to_string() const
     };
 
     return String::formatted("{} {} {} {}", to_string(m_edge_x), m_offset_x.to_string(), to_string(m_edge_y), m_offset_y.to_string());
+}
+
+String UnresolvedStyleValue::to_string() const
+{
+    StringBuilder builder;
+    for (auto& value : m_values)
+        builder.append(value.to_string());
+    return builder.to_string();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -73,12 +73,6 @@ ColorStyleValue const& StyleValue::as_color() const
     return static_cast<ColorStyleValue const&>(*this);
 }
 
-CustomStyleValue const& StyleValue::as_custom_property() const
-{
-    VERIFY(is_custom_property());
-    return static_cast<CustomStyleValue const&>(*this);
-}
-
 FlexStyleValue const& StyleValue::as_flex() const
 {
     VERIFY(is_flex());

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -24,6 +24,7 @@
 #include <LibGfx/Color.h>
 #include <LibWeb/CSS/Display.h>
 #include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/ValueID.h>
 #include <LibWeb/Forward.h>
@@ -288,6 +289,7 @@ public:
         String,
         TextDecoration,
         Transformation,
+        Unresolved,
         Unset,
         ValueList,
     };
@@ -318,6 +320,7 @@ public:
     bool is_string() const { return type() == Type::String; }
     bool is_text_decoration() const { return type() == Type::TextDecoration; }
     bool is_transformation() const { return type() == Type::Transformation; }
+    bool is_unresolved() const { return type() == Type::Unresolved; }
     bool is_unset() const { return type() == Type::Unset; }
     bool is_value_list() const { return type() == Type::ValueList; }
 
@@ -347,6 +350,7 @@ public:
     StringStyleValue const& as_string() const;
     TextDecorationStyleValue const& as_text_decoration() const;
     TransformationStyleValue const& as_transformation() const;
+    UnresolvedStyleValue const& as_unresolved() const;
     UnsetStyleValue const& as_unset() const;
     StyleValueList const& as_value_list() const;
 
@@ -374,6 +378,7 @@ public:
     StringStyleValue& as_string() { return const_cast<StringStyleValue&>(const_cast<StyleValue const&>(*this).as_string()); }
     TextDecorationStyleValue& as_text_decoration() { return const_cast<TextDecorationStyleValue&>(const_cast<StyleValue const&>(*this).as_text_decoration()); }
     TransformationStyleValue& as_transformation() { return const_cast<TransformationStyleValue&>(const_cast<StyleValue const&>(*this).as_transformation()); }
+    UnresolvedStyleValue& as_unresolved() { return const_cast<UnresolvedStyleValue&>(const_cast<StyleValue const&>(*this).as_unresolved()); }
     UnsetStyleValue& as_unset() { return const_cast<UnsetStyleValue&>(const_cast<StyleValue const&>(*this).as_unset()); }
     StyleValueList& as_value_list() { return const_cast<StyleValueList&>(const_cast<StyleValue const&>(*this).as_value_list()); }
 
@@ -1306,6 +1311,31 @@ private:
 
     CSS::TransformFunction m_transform_function;
     NonnullRefPtrVector<StyleValue> m_values;
+};
+
+class UnresolvedStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<UnresolvedStyleValue> create(Vector<StyleComponentValueRule>&& values, bool contains_var)
+    {
+        return adopt_ref(*new UnresolvedStyleValue(move(values), contains_var));
+    }
+    virtual ~UnresolvedStyleValue() override { }
+
+    virtual String to_string() const override;
+
+    Vector<StyleComponentValueRule> const& values() const { return m_values; }
+    bool contains_var() const { return m_contains_var; }
+
+private:
+    UnresolvedStyleValue(Vector<StyleComponentValueRule>&& values, bool contains_var)
+        : StyleValue(Type::Unresolved)
+        , m_values(move(values))
+        , m_contains_var(contains_var)
+    {
+    }
+
+    Vector<StyleComponentValueRule> m_values;
+    bool m_contains_var { false };
 };
 
 class UnsetStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -272,7 +272,6 @@ public:
         Calculated,
         Color,
         CombinedBorderRadius,
-        CustomProperty,
         Flex,
         FlexFlow,
         Font,
@@ -304,7 +303,6 @@ public:
     bool is_box_shadow() const { return type() == Type::BoxShadow; }
     bool is_calculated() const { return type() == Type::Calculated; }
     bool is_color() const { return type() == Type::Color; }
-    bool is_custom_property() const { return type() == Type::CustomProperty; }
     bool is_flex() const { return type() == Type::Flex; }
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
@@ -334,7 +332,6 @@ public:
     BoxShadowStyleValue const& as_box_shadow() const;
     CalculatedStyleValue const& as_calculated() const;
     ColorStyleValue const& as_color() const;
-    CustomStyleValue const& as_custom_property() const;
     FlexFlowStyleValue const& as_flex_flow() const;
     FlexStyleValue const& as_flex() const;
     FontStyleValue const& as_font() const;
@@ -362,7 +359,6 @@ public:
     BoxShadowStyleValue& as_box_shadow() { return const_cast<BoxShadowStyleValue&>(const_cast<StyleValue const&>(*this).as_box_shadow()); }
     CalculatedStyleValue& as_calculated() { return const_cast<CalculatedStyleValue&>(const_cast<StyleValue const&>(*this).as_calculated()); }
     ColorStyleValue& as_color() { return const_cast<ColorStyleValue&>(const_cast<StyleValue const&>(*this).as_color()); }
-    CustomStyleValue& as_custom_property() { return const_cast<CustomStyleValue&>(const_cast<StyleValue const&>(*this).as_custom_property()); }
     FlexFlowStyleValue& as_flex_flow() { return const_cast<FlexFlowStyleValue&>(const_cast<StyleValue const&>(*this).as_flex_flow()); }
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
     FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
@@ -850,26 +846,6 @@ private:
     NonnullRefPtr<BorderRadiusStyleValue> m_top_right;
     NonnullRefPtr<BorderRadiusStyleValue> m_bottom_right;
     NonnullRefPtr<BorderRadiusStyleValue> m_bottom_left;
-};
-
-// FIXME: Allow for fallback
-class CustomStyleValue : public StyleValue {
-public:
-    static NonnullRefPtr<CustomStyleValue> create(String const& custom_property_name)
-    {
-        return adopt_ref(*new CustomStyleValue(custom_property_name));
-    }
-    String custom_property_name() const { return m_custom_property_name; }
-    String to_string() const override { return m_custom_property_name; }
-
-private:
-    explicit CustomStyleValue(String const& custom_property_name)
-        : StyleValue(Type::CustomProperty)
-        , m_custom_property_name(custom_property_name)
-    {
-    }
-
-    String m_custom_property_name {};
 };
 
 class FlexStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -558,10 +558,18 @@ void dump_style_rule(StringBuilder& builder, CSS::CSSStyleRule const& rule, int 
     }
     indent(builder, indent_levels);
     builder.append("  Declarations:\n");
-    for (auto& property : verify_cast<CSS::PropertyOwningCSSStyleDeclaration>(rule.declaration()).properties()) {
+    auto& style_declaration = verify_cast<CSS::PropertyOwningCSSStyleDeclaration>(rule.declaration());
+    for (auto& property : style_declaration.properties()) {
         indent(builder, indent_levels);
         builder.appendff("    {}: '{}'", CSS::string_from_property_id(property.property_id), property.value->to_string());
         if (property.important)
+            builder.append(" \033[31;1m!important\033[0m");
+        builder.append('\n');
+    }
+    for (auto& property : style_declaration.custom_properties()) {
+        indent(builder, indent_levels);
+        builder.appendff("    {}: '{}'", property.key, property.value.value->to_string());
+        if (property.value.important)
             builder.append(" \033[31;1m!important\033[0m");
         builder.append('\n');
     }

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -67,6 +67,7 @@ class StyleValueList;
 class Supports;
 class TextDecorationStyleValue;
 class TransformationStyleValue;
+class UnresolvedStyleValue;
 class UnsetStyleValue;
 }
 

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -35,7 +35,6 @@ class CSSStyleDeclaration;
 class CSSStyleRule;
 class CSSStyleSheet;
 class CSSSupportsRule;
-class CustomStyleValue;
 class Display;
 class ElementInlineCSSStyleDeclaration;
 class FlexFlowStyleValue;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/144882519-d23999a5-0a1b-4996-987a-dd6e0c542b64.png)

CSS `var()` is complicated, to say the least. Our existing implementation only supports custom properties (aka, variables) with a single value, and use of `var()` on its own, like this:

```css
a {
  --my-var: yellow;
  background-color: var(--my-var);
}
```

This PR extends it to support:
- Multiple values in a custom property: `--my-var: yellow 30px solid;`
- `var()` mixed in as part of a property's value: `border: var(--thickness) var(--main-color) solid;`
- Nested variables: `--my-var: yellow var(--my-other-var) solid;`
- Fallback values: `background: var(--background-color, blue);`

There are two hostile things the spec wants us to protect against: The "billion laughs" attack where a few variables combined can produce a value that is massively long; and dependency cycles. Both are mitigated in this patch. :^)