### PR TITLE
Kernel: Terminate current thread immediately on unhandled urgent signal

### DIFF
--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -701,6 +701,10 @@ void Thread::send_urgent_signal_to_self(u8 signal)
         SpinlockLocker lock(g_scheduler_lock);
         result = dispatch_signal(signal);
     }
+    if (result == DispatchSignalResult::Terminate) {
+        Thread::current()->die_if_needed();
+        VERIFY_NOT_REACHED(); // dispatch_signal will request termination of the thread, so the above call should never return
+    }
     if (result == DispatchSignalResult::Yield)
         yield_and_release_relock_big_lock();
 }


### PR DESCRIPTION
If we're sending an urgent signal (i.e. due to unexpected conditions) and the Process did not setup any signal handler, we should immediately terminate the Thread, to ensure the current trap frame is preserved for the impending core dump.