### PR TITLE
Kernel: Cleanup Processor.h a bit

### DIFF
--- a/Kernel/Arch/DeferredCallEntry.h
+++ b/Kernel/Arch/DeferredCallEntry.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2020, Tom <tomut@yahoo.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/BitCast.h>
+#include <AK/Function.h>
+
+namespace Kernel {
+
+struct DeferredCallEntry {
+    using HandlerFunction = Function<void()>;
+
+    DeferredCallEntry* next;
+    alignas(HandlerFunction) u8 handler_storage[sizeof(HandlerFunction)];
+    bool was_allocated;
+
+    HandlerFunction& handler_value()
+    {
+        return *bit_cast<HandlerFunction*>(&handler_storage);
+    }
+
+    void invoke_handler()
+    {
+        handler_value()();
+    }
+};
+
+}

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -10,6 +10,14 @@
 #include <AK/Function.h>
 #include <Kernel/Arch/DeferredCallEntry.h>
 
+#if ARCH(X86_64) || ARCH(I386)
+#    include <Kernel/Arch/x86/Processor.h>
+#elif ARCH(AARCH64)
+#    include <Kernel/Arch/aarch64/Processor.h>
+#else
+#    error "Unknown architecture"
+#endif
+
 namespace Kernel {
 
 namespace Memory {
@@ -57,17 +65,6 @@ struct ProcessorMessageEntry {
     ProcessorMessage* msg;
 };
 
-}
-
-#if ARCH(X86_64) || ARCH(I386)
-#    include <Kernel/Arch/x86/Processor.h>
-#elif ARCH(AARCH64)
-#    include <Kernel/Arch/aarch64/Processor.h>
-#else
-#    error "Unknown architecture"
-#endif
-
-namespace Kernel {
 template<typename T>
 class ProcessorSpecific {
 public:

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -17,10 +17,6 @@ class PageDirectory;
 }
 
 struct ProcessorMessageEntry;
-enum class ProcessorSpecificDataID {
-    MemoryManager,
-    __Count,
-};
 struct ProcessorMessage {
     using CallbackFunction = Function<void()>;
 

--- a/Kernel/Arch/Processor.h
+++ b/Kernel/Arch/Processor.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Function.h>
+#include <Kernel/Arch/DeferredCallEntry.h>
 
 namespace Kernel {
 
@@ -16,8 +17,6 @@ class PageDirectory;
 }
 
 struct ProcessorMessageEntry;
-struct DeferredCallEntry;
-
 enum class ProcessorSpecificDataID {
     MemoryManager,
     __Count,
@@ -60,24 +59,6 @@ struct ProcessorMessage {
 struct ProcessorMessageEntry {
     ProcessorMessageEntry* next;
     ProcessorMessage* msg;
-};
-
-struct DeferredCallEntry {
-    using HandlerFunction = Function<void()>;
-
-    DeferredCallEntry* next;
-    alignas(HandlerFunction) u8 handler_storage[sizeof(HandlerFunction)];
-    bool was_allocated;
-
-    HandlerFunction& handler_value()
-    {
-        return *bit_cast<HandlerFunction*>(&handler_storage);
-    }
-
-    void invoke_handler()
-    {
-        handler_value()();
-    }
 };
 
 }

--- a/Kernel/Arch/ProcessorSpecificDataID.h
+++ b/Kernel/Arch/ProcessorSpecificDataID.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace Kernel {
+
+enum class ProcessorSpecificDataID {
+    MemoryManager,
+    __Count,
+};
+
+}

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -11,6 +11,8 @@
 #include <AK/Function.h>
 #include <AK/Types.h>
 
+#include <Kernel/Arch/ProcessorSpecificDataID.h>
+
 namespace Kernel {
 
 class Thread;

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -12,6 +12,7 @@
 #include <AK/Types.h>
 
 #include <Kernel/Arch/DeferredCallEntry.h>
+#include <Kernel/Arch/ProcessorSpecificDataID.h>
 #include <Kernel/Arch/x86/ASM_wrapper.h>
 #include <Kernel/Arch/x86/CPUID.h>
 #include <Kernel/Arch/x86/DescriptorTable.h>

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -11,6 +11,7 @@
 #include <AK/Function.h>
 #include <AK/Types.h>
 
+#include <Kernel/Arch/DeferredCallEntry.h>
 #include <Kernel/Arch/x86/ASM_wrapper.h>
 #include <Kernel/Arch/x86/CPUID.h>
 #include <Kernel/Arch/x86/DescriptorTable.h>


### PR DESCRIPTION
This is just a small cleanup that allows us to bring the architecture dependent includes to the top of the file.

Tell me if I need to adjust the copyright headers.
