### PR TITLE
WebContent: Wrap IPC call in `TRY()`

### DIFF
--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -21,6 +21,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/tmp/portal/websocket", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto client = IPC::take_over_accepted_client_from_system_server<WebContent::ClientConnection>();
+    auto client = TRY(IPC::take_over_accepted_client_from_system_server<WebContent::ClientConnection>());
     return event_loop.exec();
 }


### PR DESCRIPTION
971b3645efa31df913b7d614e0c5e1a865e24644 introduced `IPC::take_over_accepted_client_from_system_server()`, but forgot to wrap this call in `TRY()`.