### PR TITLE
AK: Add (maybe_)discard and (maybe_)unused documenting functions

### DIFF
--- a/AK/Discard.cpp
+++ b/AK/Discard.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Discard.h>
+
+#if defined(__serenity__) && defined(KERNEL)
+#    include <Kernel/Process.h>
+#    include <Kernel/kstdio.h>
+#endif
+
+namespace AK::Detail {
+
+void __discarded_non_discardable()
+{
+#if defined(__serenity__) && defined(KERNEL)
+    auto trace_or_error = Processor::current_thread()->backtrace();
+    if (!trace_or_error.is_error()) {
+        auto trace = trace_or_error.release_value();
+        dbgln("Backtrace:");
+        kernelputstr(trace->characters(), trace->length());
+    } else {
+        dbgln("Failed to create backtrace: {}", trace_or_error.error());
+    }
+#else
+    abort();
+#endif
+}
+
+}

--- a/AK/Discard.h
+++ b/AK/Discard.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Platform.h>
 
 #ifdef maybe_discard
@@ -15,7 +16,20 @@
 
 namespace AK::Detail {
 
+void __discarded_non_discardable();
+
 ALWAYS_INLINE void discard(auto&&) { }
+
+void discard(Error&&) = delete;
+
+template<typename T>
+void discard(ErrorOr<T>&& error_or)
+{
+    if (error_or.is_error()) {
+        dbgln("Discarded error: {}", error_or.error());
+        __discarded_non_discardable();
+    }
+}
 
 }
 

--- a/AK/Discard.h
+++ b/AK/Discard.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#ifdef maybe_discard
+#    undef maybe_discard
+#endif
+#define maybe_discard(x) (static_cast<void>(x))
+
+namespace AK::Detail {
+
+ALWAYS_INLINE void discard(auto&&) { }
+
+}
+
+using AK::Detail::discard;

--- a/AK/JsonArraySerializer.h
+++ b/AK/JsonArraySerializer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Discard.h>
 #include <AK/JsonValue.h>
 
 namespace AK {
@@ -19,7 +20,7 @@ public:
     explicit JsonArraySerializer(Builder& builder)
         : m_builder(builder)
     {
-        (void)m_builder.append('[');
+        maybe_discard(m_builder.append('['));
     }
 
     JsonArraySerializer(const JsonArraySerializer&) = delete;
@@ -42,67 +43,67 @@ public:
     void add(StringView value)
     {
         begin_item();
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        maybe_discard(m_builder.append('"'));
+        maybe_discard(m_builder.append_escaped_for_json(value));
+        maybe_discard(m_builder.append('"'));
     }
 
     void add(const String& value)
     {
         begin_item();
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        maybe_discard(m_builder.append('"'));
+        maybe_discard(m_builder.append_escaped_for_json(value));
+        maybe_discard(m_builder.append('"'));
     }
 
     void add(const char* value)
     {
         begin_item();
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        maybe_discard(m_builder.append('"'));
+        maybe_discard(m_builder.append_escaped_for_json(value));
+        maybe_discard(m_builder.append('"'));
     }
 
     void add(bool value)
     {
         begin_item();
-        (void)m_builder.append(value ? "true"sv : "false"sv);
+        maybe_discard(m_builder.append(value ? "true"sv : "false"sv));
     }
 
     void add(int value)
     {
         begin_item();
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(unsigned value)
     {
         begin_item();
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(long value)
     {
         begin_item();
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(long unsigned value)
     {
         begin_item();
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(long long value)
     {
         begin_item();
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(long long unsigned value)
     {
         begin_item();
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     JsonArraySerializer<Builder> add_array()
@@ -118,14 +119,14 @@ public:
     {
         VERIFY(!m_finished);
         m_finished = true;
-        (void)m_builder.append(']');
+        maybe_discard(m_builder.append(']'));
     }
 
 private:
     void begin_item()
     {
         if (!m_empty)
-            (void)m_builder.append(',');
+            maybe_discard(m_builder.append(','));
         m_empty = false;
     }
 

--- a/AK/JsonObjectSerializer.h
+++ b/AK/JsonObjectSerializer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Discard.h>
 #include <AK/JsonArraySerializer.h>
 
 #ifndef KERNEL
@@ -20,7 +21,7 @@ public:
     explicit JsonObjectSerializer(Builder& builder)
         : m_builder(builder)
     {
-        (void)m_builder.append('{');
+        maybe_discard(m_builder.append('{'));
     }
 
     JsonObjectSerializer(const JsonObjectSerializer&) = delete;
@@ -43,74 +44,74 @@ public:
     void add(StringView key, StringView value)
     {
         begin_item(key);
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        maybe_discard(m_builder.append('"'));
+        maybe_discard(m_builder.append_escaped_for_json(value));
+        maybe_discard(m_builder.append('"'));
     }
 
     void add(StringView key, const String& value)
     {
         begin_item(key);
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        maybe_discard(m_builder.append('"'));
+        maybe_discard(m_builder.append_escaped_for_json(value));
+        maybe_discard(m_builder.append('"'));
     }
 
     void add(StringView key, const char* value)
     {
         begin_item(key);
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        maybe_discard(m_builder.append('"'));
+        maybe_discard(m_builder.append_escaped_for_json(value));
+        maybe_discard(m_builder.append('"'));
     }
 
     void add(StringView key, bool value)
     {
         begin_item(key);
-        (void)m_builder.append(value ? "true" : "false");
+        maybe_discard(m_builder.append(value ? "true" : "false"));
     }
 
     void add(StringView key, int value)
     {
         begin_item(key);
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(StringView key, unsigned value)
     {
         begin_item(key);
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(StringView key, long value)
     {
         begin_item(key);
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(StringView key, long unsigned value)
     {
         begin_item(key);
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(StringView key, long long value)
     {
         begin_item(key);
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
     void add(StringView key, long long unsigned value)
     {
         begin_item(key);
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 
 #ifndef KERNEL
     void add(StringView key, double value)
     {
         begin_item(key);
-        (void)m_builder.appendff("{}", value);
+        maybe_discard(m_builder.appendff("{}", value));
     }
 #endif
 
@@ -130,19 +131,19 @@ public:
     {
         VERIFY(!m_finished);
         m_finished = true;
-        (void)m_builder.append('}');
+        maybe_discard(m_builder.append('}'));
     }
 
 private:
     void begin_item(StringView key)
     {
         if (!m_empty)
-            (void)m_builder.append(',');
+            maybe_discard(m_builder.append(','));
         m_empty = false;
 
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(key);
-        (void)m_builder.append("\":");
+        maybe_discard(m_builder.append('"'));
+        maybe_discard(m_builder.append_escaped_for_json(key));
+        maybe_discard(m_builder.append("\":"));
     }
 
     Builder& m_builder;

--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -16,7 +16,7 @@ struct LEB128 {
     template<typename StreamT, typename ValueType = size_t>
     static bool read_unsigned(StreamT& stream, ValueType& result)
     {
-        [[maybe_unused]] size_t backup_offset = 0;
+        size_t backup_offset = 0;
         if constexpr (requires { stream.offset(); })
             backup_offset = stream.offset();
         InputStream& input_stream { stream };
@@ -59,7 +59,7 @@ struct LEB128 {
         // Note: We read into a u64 to simplify the parsing logic;
         //    result is range checked into ValueType after parsing.
         static_assert(sizeof(ValueType) <= sizeof(u64), "Error checking logic assumes 64 bits or less!");
-        [[maybe_unused]] size_t backup_offset = 0;
+        size_t backup_offset = 0;
         if constexpr (requires { stream.offset(); })
             backup_offset = stream.offset();
         InputStream& input_stream { stream };

--- a/AK/NoAllocationGuard.h
+++ b/AK/NoAllocationGuard.h
@@ -8,6 +8,7 @@
 
 #include <AK/Forward.h>
 #include <AK/Noncopyable.h>
+#include <AK/Unused.h>
 
 #if defined(KERNEL)
 #    include <Kernel/Arch/Processor.h>
@@ -49,12 +50,11 @@ private:
 
     static void set_thread_allocation_state(bool value)
     {
+        maybe_unused(value);
 #if defined(KERNEL)
         Processor::current_thread()->set_allocation_enabled(value);
 #elif defined(__serenity__)
         s_allocation_enabled = value;
-#else
-        (void)value;
 #endif
     }
 

--- a/AK/Random.h
+++ b/AK/Random.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Discard.h>
 #include <AK/Platform.h>
 #include <AK/Types.h>
 
@@ -29,7 +30,7 @@ inline void fill_with_random([[maybe_unused]] void* buffer, [[maybe_unused]] siz
     arc4random_buf(buffer, length);
 #elif defined(OSS_FUZZ)
 #elif defined(__unix__) or defined(AK_OS_MACOS)
-    [[maybe_unused]] int rc = getentropy(buffer, length);
+    discard(getentropy(buffer, length));
 #endif
 }
 

--- a/AK/Unused.h
+++ b/AK/Unused.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+namespace AK::Detail {
+
+ALWAYS_INLINE void maybe_unused(auto&&) { }
+ALWAYS_INLINE void unused(auto&&) { }
+
+}
+
+using AK::Detail::maybe_unused;
+using AK::Detail::unused;

--- a/Kernel/AddressSanitizer.cpp
+++ b/Kernel/AddressSanitizer.cpp
@@ -6,20 +6,21 @@
 
 #if defined(__SANITIZE_ADDRESS__)
 
+#    include <AK/Unused.h>
 #    include <Kernel/AddressSanitizer.h>
 
 void Kernel::AddressSanitizer::shadow_va_check_load(unsigned long address, size_t size, void* return_address)
 {
-    (void)address;
-    (void)size;
-    (void)return_address;
+    unused(address);
+    unused(size);
+    unused(return_address);
 }
 
 void Kernel::AddressSanitizer::shadow_va_check_store(unsigned long address, size_t size, void* return_address)
 {
-    (void)address;
-    (void)size;
-    (void)return_address;
+    unused(address);
+    unused(size);
+    unused(return_address);
 }
 
 using namespace Kernel;

--- a/Kernel/Arch/aarch64/Spinlock.h
+++ b/Kernel/Arch/aarch64/Spinlock.h
@@ -8,6 +8,7 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/Types.h>
+#include <AK/Unused.h>
 #include <Kernel/Locking/LockRank.h>
 
 namespace Kernel {
@@ -19,7 +20,7 @@ class Spinlock {
 public:
     Spinlock(LockRank rank = LockRank::None)
     {
-        (void)rank;
+        unused(rank);
     }
 
     ALWAYS_INLINE u32 lock()
@@ -48,7 +49,7 @@ class RecursiveSpinlock {
 public:
     RecursiveSpinlock(LockRank rank = LockRank::None)
     {
-        (void)rank;
+        unused(rank);
     }
 
     ALWAYS_INLINE u32 lock()

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Format.h>
 #include <AK/Types.h>
 
@@ -395,14 +396,14 @@ void page_fault_handler(TrapFrame* trap)
             if (current_process.is_user_process()) {
                 auto fault_address_string = KString::formatted("{:p}", fault_address);
                 auto fault_address_view = fault_address_string.is_error() ? ""sv : fault_address_string.value()->view();
-                (void)current_process.try_set_coredump_property("fault_address"sv, fault_address_view);
-                (void)current_process.try_set_coredump_property("fault_type"sv, fault.type() == PageFault::Type::PageNotPresent ? "NotPresent"sv : "ProtectionViolation"sv);
+                discard(current_process.try_set_coredump_property("fault_address"sv, fault_address_view));
+                discard(current_process.try_set_coredump_property("fault_type"sv, fault.type() == PageFault::Type::PageNotPresent ? "NotPresent"sv : "ProtectionViolation"sv));
                 StringView fault_access;
                 if (fault.is_instruction_fetch())
                     fault_access = "Execute"sv;
                 else
                     fault_access = fault.access() == PageFault::Access::Read ? "Read"sv : "Write"sv;
-                (void)current_process.try_set_coredump_property("fault_access"sv, fault_access);
+                discard(current_process.try_set_coredump_property("fault_access"sv, fault_access));
             }
         }
 

--- a/Kernel/Arch/x86/common/SafeMem.cpp
+++ b/Kernel/Arch/x86/common/SafeMem.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Unused.h>
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Arch/RegisterState.h>
 #include <Kernel/Arch/x86/SafeMem.h>
@@ -42,12 +43,12 @@ namespace Kernel {
 
 ALWAYS_INLINE bool validate_canonical_address(size_t address)
 {
+    maybe_unused(address);
 #if ARCH(X86_64)
     auto most_significant_bits = Processor::current().virtual_address_bit_width() - 1;
     auto insignificant_bits = address >> most_significant_bits;
     return insignificant_bits == 0 || insignificant_bits == (0xffffffffffffffffull >> most_significant_bits);
 #else
-    (void)address;
     return true;
 #endif
 }

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Platform.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/USB/UHCI/UHCIController.h>
@@ -467,14 +468,14 @@ size_t UHCIController::poll_transfer_queue(QueueHead& transfer_queue)
 ErrorOr<void> UHCIController::spawn_port_process()
 {
     RefPtr<Thread> usb_hotplug_thread;
-    (void)Process::create_kernel_process(usb_hotplug_thread, TRY(KString::try_create("UHCI hotplug")), [&] {
+    discard(Process::create_kernel_process(usb_hotplug_thread, TRY(KString::try_create("UHCI hotplug")), [&] {
         for (;;) {
             if (m_root_hub)
                 m_root_hub->check_for_port_updates();
 
-            (void)Thread::current()->sleep(Time::from_seconds(1));
+            discard(Thread::current()->sleep(Time::from_seconds(1)));
         }
-    });
+    }));
     return {};
 }
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -330,6 +330,7 @@ if ("${SERENITY_ARCH}" STREQUAL "i686" OR "${SERENITY_ARCH}" STREQUAL "x86_64")
 endif()
 
 set(AK_SOURCES
+    ../AK/Discard.cpp
     ../AK/FlyString.cpp
     ../AK/GenericLexer.cpp
     ../AK/Hex.cpp

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/CommandLine.h>
 #include <Kernel/Panic.h>
@@ -44,7 +45,7 @@ UNMAP_AFTER_INIT void CommandLine::initialize()
     s_the = new CommandLine(s_cmd_line);
     dmesgln("Kernel Commandline: {}", kernel_command_line().string());
     // Validate the modes the user passed in.
-    (void)s_the->panic_mode(Validate::Yes);
+    discard(s_the->panic_mode(Validate::Yes));
     if (s_the->contains("boot_mode"sv)) {
         // I know, we don't do legacy, but even though I eliminated 'boot_mode' from the codebase, there
         // is a good chance that someone's still using it. Let's be nice and tell them where to look.

--- a/Kernel/Coredump.cpp
+++ b/Kernel/Coredump.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <AK/ByteBuffer.h>
+#include <AK/Discard.h>
 #include <AK/JsonObjectSerializer.h>
 #include <Kernel/Coredump.h>
 #include <Kernel/FileSystem/Custody.h>
@@ -153,7 +154,7 @@ ErrorOr<void> Coredump::write_program_headers(size_t notes_size)
 
         offset += phdr.p_filesz;
 
-        [[maybe_unused]] auto rc = m_description->write(UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<uint8_t*>(&phdr)), sizeof(ElfW(Phdr)));
+        discard(m_description->write(UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<uint8_t*>(&phdr)), sizeof(ElfW(Phdr))));
     }
 
     ElfW(Phdr) notes_pheader {};

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/IntrusiveList.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/BlockBasedFileSystem.h>
@@ -269,7 +270,7 @@ void BlockBasedFileSystem::flush_specific_block_if_needed(BlockIndex index)
             return;
         size_t base_offset = entry->block_index.value() * block_size();
         auto entry_data_buffer = UserOrKernelBuffer::for_kernel_buffer(entry->data);
-        (void)file_description().write(base_offset, entry_data_buffer, block_size());
+        discard(file_description().write(base_offset, entry_data_buffer, block_size()));
     });
 }
 
@@ -282,7 +283,7 @@ void BlockBasedFileSystem::flush_writes_impl()
         cache->for_each_dirty_entry([&](CacheEntry& entry) {
             auto base_offset = entry.block_index.value() * block_size();
             auto entry_data_buffer = UserOrKernelBuffer::for_kernel_buffer(entry.data);
-            [[maybe_unused]] auto rc = file_description().write(base_offset, entry_data_buffer, block_size());
+            discard(file_description().write(base_offset, entry_data_buffer, block_size()));
             ++count;
         });
         cache->mark_all_clean();

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/HashMap.h>
 #include <AK/MemoryStream.h>
 #include <AK/StdLibExtras.h>
@@ -711,7 +712,7 @@ Ext2FSInode::~Ext2FSInode()
 {
     if (m_raw_inode.i_links_count == 0) {
         // Alas, we have nowhere to propagate any errors that occur here.
-        (void)fs().free_inode(*this);
+        discard(fs().free_inode(*this));
     }
 }
 

--- a/Kernel/FileSystem/ISO9660FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FileSystem.cpp
@@ -6,6 +6,7 @@
 
 #include "ISO9660FileSystem.h"
 #include <AK/CharacterTypes.h>
+#include <AK/Discard.h>
 #include <AK/Endian.h>
 #include <AK/HashFunctions.h>
 #include <AK/NonnullRefPtr.h>
@@ -39,7 +40,7 @@ public:
         , m_current_header(&header)
     {
         // FIXME: Panic or alternative method?
-        (void)read_directory_contents();
+        discard(read_directory_contents());
         get_header();
     }
 

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/Singleton.h>
 #include <AK/StringView.h>
@@ -40,14 +41,14 @@ void Inode::sync_all()
 
     for (auto& inode : inodes) {
         VERIFY(inode.is_metadata_dirty());
-        (void)inode.flush_metadata();
+        discard(inode.flush_metadata());
     }
 }
 
 void Inode::sync()
 {
     if (is_metadata_dirty())
-        (void)flush_metadata();
+        discard(flush_metadata());
     fs().flush_writes();
 }
 
@@ -102,7 +103,7 @@ void Inode::will_be_destroyed()
 {
     MutexLocker locker(m_inode_lock);
     if (m_metadata_dirty)
-        (void)flush_metadata();
+        discard(flush_metadata());
 }
 
 ErrorOr<void> Inode::set_atime(time_t)

--- a/Kernel/FileSystem/InodeWatcher.cpp
+++ b/Kernel/FileSystem/InodeWatcher.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Memory.h>
 #include <Kernel/FileSystem/Inode.h>
 #include <Kernel/FileSystem/InodeWatcher.h>
@@ -19,7 +20,7 @@ ErrorOr<NonnullRefPtr<InodeWatcher>> InodeWatcher::try_create()
 
 InodeWatcher::~InodeWatcher()
 {
-    (void)close();
+    discard(close());
 }
 
 bool InodeWatcher::can_read(const OpenFileDescription&, u64) const

--- a/Kernel/FileSystem/OpenFileDescription.cpp
+++ b/Kernel/FileSystem/OpenFileDescription.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/MemoryStream.h>
 #include <Kernel/API/POSIX/errno.h>
 #include <Kernel/Debug.h>
@@ -56,7 +57,7 @@ OpenFileDescription::~OpenFileDescription()
     if (is_fifo())
         static_cast<FIFO*>(m_file.ptr())->detach(m_fifo_direction);
     // FIXME: Should this error path be observed somehow?
-    (void)m_file->close();
+    discard(m_file->close());
     if (m_inode)
         m_inode->detach(*this);
 

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <Kernel/FileSystem/Plan9FileSystem.h>
 #include <Kernel/Process.h>
 
@@ -179,7 +180,7 @@ private:
     {
         VERIFY(!m_have_been_built);
         // FIXME: Handle append failure.
-        (void)m_builder.append(reinterpret_cast<const char*>(&number), sizeof(number));
+        discard(m_builder.append(reinterpret_cast<const char*>(&number), sizeof(number)));
         return *this;
     }
 
@@ -266,7 +267,7 @@ Plan9FS::Message& Plan9FS::Message::operator<<(StringView string)
 {
     *this << static_cast<u16>(string.length());
     // FIXME: Handle append failure.
-    (void)m_builder.append(string);
+    discard(m_builder.append(string));
     return *this;
 }
 
@@ -274,7 +275,7 @@ void Plan9FS::Message::append_data(StringView data)
 {
     *this << static_cast<u32>(data.length());
     // FIXME: Handle append failure.
-    (void)m_builder.append(data);
+    discard(m_builder.append(data));
 }
 
 Plan9FS::Message::Decoder& Plan9FS::Message::Decoder::operator>>(u8& number)
@@ -658,10 +659,10 @@ void Plan9FS::ensure_thread()
         auto process_name = KString::try_create("Plan9FS");
         if (process_name.is_error())
             TODO();
-        (void)Process::create_kernel_process(m_thread, process_name.release_value(), [&]() {
+        discard(Process::create_kernel_process(m_thread, process_name.release_value(), [&]() {
             thread_main();
             m_thread_running.store(false, AK::MemoryOrder::memory_order_release);
-        });
+        }));
     }
 }
 

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -681,7 +681,7 @@ Plan9FSInode::~Plan9FSInode()
     Plan9FS::Message clunk_request { fs(), Plan9FS::Message::Type::Tclunk };
     clunk_request << fid();
     // FIXME: Should we observe this  error somehow?
-    [[maybe_unused]] auto rc = fs().post_message_and_explicitly_ignore_reply(clunk_request);
+    discard(fs().post_message_and_explicitly_ignore_reply(clunk_request));
 }
 
 ErrorOr<void> Plan9FSInode::ensure_open_for_mode(int mode)
@@ -849,7 +849,7 @@ ErrorOr<void> Plan9FSInode::traverse_as_directory(Function<ErrorOr<void>(FileSys
                 Plan9FS::Message close_message { fs(), Plan9FS::Message::Type::Tclunk };
                 close_message << clone_fid;
                 // FIXME: Should we observe this error?
-                [[maybe_unused]] auto rc = fs().post_message_and_explicitly_ignore_reply(close_message);
+                discard(fs().post_message_and_explicitly_ignore_reply(close_message));
                 return result;
             }
         }
@@ -888,7 +888,7 @@ ErrorOr<void> Plan9FSInode::traverse_as_directory(Function<ErrorOr<void>(FileSys
         Plan9FS::Message close_message { fs(), Plan9FS::Message::Type::Tclunk };
         close_message << clone_fid;
         // FIXME: Should we observe this error?
-        [[maybe_unused]] auto rc = fs().post_message_and_explicitly_ignore_reply(close_message);
+        discard(fs().post_message_and_explicitly_ignore_reply(close_message));
         return result;
     }
 

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Singleton.h>
 #include <Kernel/API/POSIX/errno.h>
 #include <Kernel/Debug.h>
@@ -442,7 +443,7 @@ void ProcFSProcessPropertyInode::did_seek(OpenFileDescription& description, off_
 {
     if (offset != 0)
         return;
-    (void)refresh_data(description);
+    discard(refresh_data(description));
 }
 
 static mode_t determine_procfs_process_inode_mode(SegmentedProcFSIndex::ProcessSubDirectory parent_sub_directory_type, SegmentedProcFSIndex::MainProcessProperty main_property)

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/GenericLexer.h>
 #include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
@@ -314,7 +315,7 @@ ErrorOr<void> VirtualFileSystem::mknod(StringView path, mode_t mode, dev_t dev, 
 
     auto basename = KLexicalPath::basename(path);
     dbgln_if(VFS_DEBUG, "VirtualFileSystem::mknod: '{}' mode={} dev={} in {}", basename, mode, dev, parent_inode.identifier());
-    (void)TRY(parent_inode.create_child(basename, mode, dev, current_process.euid(), current_process.egid()));
+    discard(TRY(parent_inode.create_child(basename, mode, dev, current_process.euid(), current_process.egid())));
     return {};
 }
 
@@ -380,7 +381,7 @@ ErrorOr<void> VirtualFileSystem::mkdir(StringView path, mode_t mode, Custody& ba
 
     auto basename = KLexicalPath::basename(path);
     dbgln_if(VFS_DEBUG, "VirtualFileSystem::mkdir: '{}' in {}", basename, parent_inode.identifier());
-    (void)TRY(parent_inode.create_child(basename, S_IFDIR | mode, 0, current_process.euid(), current_process.egid()));
+    discard(TRY(parent_inode.create_child(basename, S_IFDIR | mode, 0, current_process.euid(), current_process.egid())));
     return {};
 }
 

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/AddressSpace.h>
 #include <Kernel/Memory/AnonymousVMObject.h>
@@ -205,7 +206,7 @@ ErrorOr<Region*> AddressSpace::allocate_region_with_vmobject(VirtualRange const&
 
 void AddressSpace::deallocate_region(Region& region)
 {
-    (void)take_region(region);
+    discard(take_region(region));
 }
 
 NonnullOwnPtr<Region> AddressSpace::take_region(Region& region)

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -516,7 +516,7 @@ UNMAP_AFTER_INIT void MemoryManager::initialize_physical_pages()
         auto physical_page = adopt_ref(*new (&physical_page_entry.allocated.physical_page) PhysicalPage(MayReturnToFreeList::No));
 
         // NOTE: This leaked ref is matched by the unref in MemoryManager::release_pte()
-        (void)physical_page.leak_ref();
+        discard(physical_page.leak_ref());
 
         virtual_page_array_current_page += (PAGE_SIZE / sizeof(PageTableEntry)) * PAGE_SIZE;
     }
@@ -595,7 +595,7 @@ PageTableEntry* MemoryManager::ensure_pte(PageDirectory& page_directory, Virtual
     pde.set_global(&page_directory == m_kernel_page_directory.ptr());
 
     // NOTE: This leaked ref is matched by the unref in MemoryManager::release_pte()
-    (void)page_table.leak_ref();
+    discard(page_table.leak_ref());
 
     return &quickmap_pt(PhysicalAddress(pde.page_table_base()))[page_table_index];
 }

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Memory.h>
 #include <AK/StringView.h>
 #include <Kernel/Arch/x86/PageFault.h>
@@ -44,7 +45,7 @@ Region::~Region()
 {
     if (is_writable() && vmobject().is_shared_inode()) {
         // FIXME: This is very aggressive. Find a way to do less work!
-        (void)static_cast<SharedInodeVMObject&>(vmobject()).sync();
+        discard(static_cast<SharedInodeVMObject&>(vmobject()).sync());
     }
 
     m_vmobject->remove_region(*this);

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Singleton.h>
 #include <AK/StringBuilder.h>
 #include <Kernel/API/POSIX/errno.h>
@@ -796,7 +797,7 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
 
 ErrorOr<void> IPv4Socket::close()
 {
-    [[maybe_unused]] auto rc = shutdown(SHUT_RDWR);
+    discard(shutdown(SHUT_RDWR));
     return {};
 }
 

--- a/Kernel/PerformanceManager.h
+++ b/Kernel/PerformanceManager.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Discard.h>
 #include <Kernel/PerformanceEventBuffer.h>
 #include <Kernel/Process.h>
 #include <Kernel/Thread.h>
@@ -18,14 +19,14 @@ public:
     {
         if (g_profiling_all_threads) {
             VERIFY(g_global_perf_events);
-            (void)g_global_perf_events->add_process(process, ProcessEventType::Create);
+            discard(g_global_perf_events->add_process(process, ProcessEventType::Create));
         }
     }
 
     inline static void add_process_exec_event(Process& process)
     {
         if (auto* event_buffer = process.current_perf_events_buffer()) {
-            (void)event_buffer->add_process(process, ProcessEventType::Exec);
+            discard(event_buffer->add_process(process, ProcessEventType::Exec));
         }
     }
 
@@ -33,8 +34,8 @@ public:
     {
         if (g_profiling_all_threads) {
             VERIFY(g_global_perf_events);
-            [[maybe_unused]] auto rc = g_global_perf_events->append_with_ip_and_bp(
-                process.pid(), 0, 0, 0, PERF_EVENT_PROCESS_EXIT, 0, 0, 0, nullptr);
+            discard(g_global_perf_events->append_with_ip_and_bp(
+                process.pid(), 0, 0, 0, PERF_EVENT_PROCESS_EXIT, 0, 0, 0, nullptr));
         }
     }
 
@@ -43,7 +44,7 @@ public:
         if (thread.is_profiling_suppressed())
             return;
         if (auto* event_buffer = thread.process().current_perf_events_buffer()) {
-            [[maybe_unused]] auto rc = event_buffer->append(PERF_EVENT_THREAD_CREATE, thread.tid().value(), 0, nullptr, &thread);
+            discard(event_buffer->append(PERF_EVENT_THREAD_CREATE, thread.tid().value(), 0, nullptr, &thread));
         }
     }
 
@@ -52,7 +53,7 @@ public:
         // As an exception this doesn't check whether profiling is suppressed for
         // the thread so we can record the thread_exit event anyway.
         if (auto* event_buffer = thread.process().current_perf_events_buffer()) {
-            [[maybe_unused]] auto rc = event_buffer->append(PERF_EVENT_THREAD_EXIT, thread.tid().value(), 0, nullptr, &thread);
+            discard(event_buffer->append(PERF_EVENT_THREAD_EXIT, thread.tid().value(), 0, nullptr, &thread));
         }
     }
 
@@ -61,22 +62,22 @@ public:
         if (current_thread.is_profiling_suppressed())
             return;
         if (auto* event_buffer = current_thread.process().current_perf_events_buffer()) {
-            [[maybe_unused]] auto rc = event_buffer->append_with_ip_and_bp(
-                current_thread.pid(), current_thread.tid(), regs, PERF_EVENT_SAMPLE, lost_time, 0, 0, nullptr);
+            discard(event_buffer->append_with_ip_and_bp(
+                current_thread.pid(), current_thread.tid(), regs, PERF_EVENT_SAMPLE, lost_time, 0, 0, nullptr));
         }
     }
 
     inline static void add_mmap_perf_event(Process& current_process, Memory::Region const& region)
     {
         if (auto* event_buffer = current_process.current_perf_events_buffer()) {
-            [[maybe_unused]] auto res = event_buffer->append(PERF_EVENT_MMAP, region.vaddr().get(), region.size(), region.name());
+            discard(event_buffer->append(PERF_EVENT_MMAP, region.vaddr().get(), region.size(), region.name()));
         }
     }
 
     inline static void add_unmap_perf_event(Process& current_process, Memory::VirtualRange const& region)
     {
         if (auto* event_buffer = current_process.current_perf_events_buffer()) {
-            [[maybe_unused]] auto res = event_buffer->append(PERF_EVENT_MUNMAP, region.base().get(), region.size(), nullptr);
+            discard(event_buffer->append(PERF_EVENT_MUNMAP, region.base().get(), region.size(), nullptr));
         }
     }
 
@@ -85,7 +86,7 @@ public:
         if (current_thread.is_profiling_suppressed())
             return;
         if (auto* event_buffer = current_thread.process().current_perf_events_buffer()) {
-            [[maybe_unused]] auto res = event_buffer->append(PERF_EVENT_CONTEXT_SWITCH, next_thread.pid().value(), next_thread.tid().value(), nullptr);
+            discard(event_buffer->append(PERF_EVENT_CONTEXT_SWITCH, next_thread.pid().value(), next_thread.tid().value(), nullptr));
         }
     }
 
@@ -94,7 +95,7 @@ public:
         if (current_thread.is_profiling_suppressed())
             return;
         if (auto* event_buffer = current_thread.process().current_perf_events_buffer()) {
-            [[maybe_unused]] auto res = event_buffer->append(PERF_EVENT_KMALLOC, size, ptr, nullptr);
+            discard(event_buffer->append(PERF_EVENT_KMALLOC, size, ptr, nullptr));
         }
     }
 
@@ -103,7 +104,7 @@ public:
         if (current_thread.is_profiling_suppressed())
             return;
         if (auto* event_buffer = current_thread.process().current_perf_events_buffer()) {
-            [[maybe_unused]] auto res = event_buffer->append(PERF_EVENT_KFREE, size, ptr, nullptr);
+            discard(event_buffer->append(PERF_EVENT_KFREE, size, ptr, nullptr));
         }
     }
 
@@ -112,8 +113,8 @@ public:
         if (thread.is_profiling_suppressed())
             return;
         if (auto* event_buffer = thread.process().current_perf_events_buffer()) {
-            [[maybe_unused]] auto rc = event_buffer->append_with_ip_and_bp(
-                thread.pid(), thread.tid(), regs, PERF_EVENT_PAGE_FAULT, 0, 0, 0, nullptr);
+            discard(event_buffer->append_with_ip_and_bp(
+                thread.pid(), thread.tid(), regs, PERF_EVENT_PAGE_FAULT, 0, 0, 0, nullptr));
         }
     }
 
@@ -122,8 +123,8 @@ public:
         if (thread.is_profiling_suppressed())
             return;
         if (auto* event_buffer = thread.process().current_perf_events_buffer()) {
-            [[maybe_unused]] auto rc = event_buffer->append_with_ip_and_bp(
-                thread.pid(), thread.tid(), regs, PERF_EVENT_SYSCALL, 0, 0, 0, nullptr);
+            discard(event_buffer->append_with_ip_and_bp(
+                thread.pid(), thread.tid(), regs, PERF_EVENT_SYSCALL, 0, 0, 0, nullptr));
         }
     }
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Singleton.h>
 #include <AK/StdLibExtras.h>
 #include <AK/Time.h>
@@ -881,7 +882,7 @@ ErrorOr<void> Process::require_promise(Pledge promise)
 
     dbgln("Has not pledged {}", to_string(promise));
     Thread::current()->set_promise_violation_pending(true);
-    (void)try_set_coredump_property("pledge_violation"sv, to_string(promise));
+    discard(try_set_coredump_property("pledge_violation"sv, to_string(promise)));
     return EPROMISEVIOLATION;
 }
 

--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/JsonArraySerializer.h>
 #include <AK/JsonObjectSerializer.h>
 #include <AK/JsonValue.h>
@@ -104,7 +105,7 @@ ErrorOr<void> Process::traverse_file_descriptions_directory(FileSystemID fsid, F
             StringBuilder builder;
             builder.appendff("{}", count);
             // FIXME: Propagate errors from callback.
-            (void)callback({ builder.string_view(), { fsid, SegmentedProcFSIndex::build_segmented_index_for_file_description(pid(), count) }, DT_LNK });
+            discard(callback({ builder.string_view(), { fsid, SegmentedProcFSIndex::build_segmented_index_for_file_description(pid(), count) }, DT_LNK }));
             count++;
         });
     });

--- a/Kernel/Syscalls/alarm.cpp
+++ b/Kernel/Syscalls/alarm.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <Kernel/Process.h>
 #include <Kernel/Time/TimeManagement.h>
 #include <Kernel/TimerQueue.h>
@@ -34,7 +35,7 @@ ErrorOr<FlatPtr> Process::sys$alarm(unsigned seconds)
             m_alarm_timer = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Timer));
         }
         auto timer_was_added = TimerQueue::the().add_timer_without_id(*m_alarm_timer, CLOCK_REALTIME_COARSE, deadline, [this]() {
-            [[maybe_unused]] auto rc = send_signal(SIGALRM, nullptr);
+            discard(send_signal(SIGALRM, nullptr));
         });
         if (!timer_was_added)
             return ENOMEM;

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/ScopeGuard.h>
 #include <AK/TemporaryChange.h>
 #include <AK/WeakPtr.h>
@@ -631,7 +632,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     }
 
     u32 lock_count_to_restore;
-    [[maybe_unused]] auto rc = big_lock().force_unlock_exclusive_if_locked(lock_count_to_restore);
+    discard(big_lock().force_unlock_exclusive_if_locked(lock_count_to_restore));
     VERIFY_INTERRUPTS_DISABLED();
     VERIFY(Processor::in_critical());
     return {};

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/Custody.h>
 #include <Kernel/Memory/Region.h>
@@ -125,7 +126,7 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     auto child_pid = child->pid().value();
 
     // NOTE: All user processes have a leaked ref on them. It's balanced by Thread::WaitBlockerSet::finalize().
-    (void)child.leak_ref();
+    discard(child.leak_ref());
 
     return child_pid;
 }

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -64,7 +64,7 @@ void SlavePTY::echo(u8 ch)
 {
     if (should_echo_input()) {
         auto buffer = UserOrKernelBuffer::for_kernel_buffer(&ch);
-        [[maybe_unused]] auto result = m_master->on_slave_write(buffer, 1);
+        discard(m_master->on_slave_write(buffer, 1));
     }
 }
 

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
 #include <Kernel/Sections.h>
@@ -15,13 +16,13 @@ namespace Kernel {
 UNMAP_AFTER_INIT void SyncTask::spawn()
 {
     RefPtr<Thread> syncd_thread;
-    (void)Process::create_kernel_process(syncd_thread, KString::must_create("SyncTask"), [] {
+    discard(Process::create_kernel_process(syncd_thread, KString::must_create("SyncTask"), [] {
         dbgln("SyncTask is running");
         for (;;) {
             VirtualFileSystem::sync();
-            (void)Thread::current()->sleep(Time::from_seconds(1));
+            discard(Thread::current()->sleep(Time::from_seconds(1)));
         }
-    });
+    }));
 }
 
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -442,7 +442,7 @@ void Thread::die_if_needed()
         return;
 
     u32 unlock_count;
-    [[maybe_unused]] auto rc = unlock_process_if_locked(unlock_count);
+    discard(unlock_process_if_locked(unlock_count));
 
     dbgln_if(THREAD_DEBUG, "Thread {} is dying", *this);
 
@@ -477,7 +477,7 @@ void Thread::exit(void* exit_value)
     m_join_blocker_set.thread_did_exit(exit_value);
     set_should_die();
     u32 unlock_count;
-    [[maybe_unused]] auto rc = unlock_process_if_locked(unlock_count);
+    discard(unlock_process_if_locked(unlock_count));
     if (m_thread_specific_range.has_value()) {
         auto* region = process().address_space().find_region_from_range(m_thread_specific_range.value());
         process().address_space().deallocate_region(*region);
@@ -1228,7 +1228,7 @@ void Thread::set_state(State new_state, u8 stop_signal)
             process.unblock_waiters(Thread::WaitBlocker::UnblockFlags::Continued);
             // Tell the parent process (if any) about this change.
             if (auto parent = Process::from_pid(process.ppid())) {
-                [[maybe_unused]] auto result = parent->send_signal(SIGCHLD, &process);
+                discard(parent->send_signal(SIGCHLD, &process));
             }
         }
     }
@@ -1252,7 +1252,7 @@ void Thread::set_state(State new_state, u8 stop_signal)
             process.unblock_waiters(Thread::WaitBlocker::UnblockFlags::Stopped, stop_signal);
             // Tell the parent process (if any) about this change.
             if (auto parent = Process::from_pid(process.ppid())) {
-                [[maybe_unused]] auto result = parent->send_signal(SIGCHLD, &process);
+                discard(parent->send_signal(SIGCHLD, &process));
             }
         }
     } else if (m_state == Thread::State::Dying) {

--- a/Kernel/WaitQueue.h
+++ b/Kernel/WaitQueue.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Atomic.h>
+#include <AK/Discard.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Thread.h>
 
@@ -27,7 +28,7 @@ public:
     template<class... Args>
     void wait_forever(Args&&... args)
     {
-        (void)Thread::current()->block<Thread::WaitQueueBlocker>({}, *this, forward<Args>(args)...);
+        discard(Thread::current()->block<Thread::WaitQueueBlocker>({}, *this, forward<Args>(args)...));
     }
 
 protected:

--- a/Kernel/WorkQueue.cpp
+++ b/Kernel/WorkQueue.cpp
@@ -41,7 +41,7 @@ UNMAP_AFTER_INIT WorkQueue::WorkQueue(StringView name)
                 if (have_more)
                     continue;
             }
-            [[maybe_unused]] auto result = m_wait_queue.wait_on({});
+            discard(m_wait_queue.wait_on({}));
         }
     }));
     // If we can't create the thread we're in trouble...

--- a/Kernel/WorkQueue.cpp
+++ b/Kernel/WorkQueue.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <Kernel/Process.h>
 #include <Kernel/Sections.h>
 #include <Kernel/WaitQueue.h>
@@ -25,7 +26,7 @@ UNMAP_AFTER_INIT WorkQueue::WorkQueue(StringView name)
     auto name_kstring = KString::try_create(name);
     if (name_kstring.is_error())
         TODO();
-    (void)Process::create_kernel_process(thread, name_kstring.release_value(), [this] {
+    discard(Process::create_kernel_process(thread, name_kstring.release_value(), [this] {
         for (;;) {
             WorkItem* item;
             bool have_more;
@@ -42,7 +43,7 @@ UNMAP_AFTER_INIT WorkQueue::WorkQueue(StringView name)
             }
             [[maybe_unused]] auto result = m_wait_queue.wait_on({});
         }
-    });
+    }));
     // If we can't create the thread we're in trouble...
     m_thread = thread.release_nonnull();
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/BootInfo.h>
@@ -228,7 +229,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
 
     {
         RefPtr<Thread> init_stage2_thread;
-        (void)Process::create_kernel_process(init_stage2_thread, KString::must_create("init_stage2"), init_stage2, nullptr, THREAD_AFFINITY_DEFAULT, Process::RegisterProcess::No);
+        discard(Process::create_kernel_process(init_stage2_thread, KString::must_create("init_stage2"), init_stage2, nullptr, THREAD_AFFINITY_DEFAULT, Process::RegisterProcess::No));
         // We need to make sure we drop the reference for init_stage2_thread
         // before calling into Scheduler::start, otherwise we will have a
         // dangling Thread that never gets cleaned up
@@ -294,10 +295,10 @@ void init_stage2(void*)
     VirtualFileSystem::initialize();
 
     if (!get_serial_debug())
-        (void)SerialDevice::must_create(0).leak_ref();
-    (void)SerialDevice::must_create(1).leak_ref();
-    (void)SerialDevice::must_create(2).leak_ref();
-    (void)SerialDevice::must_create(3).leak_ref();
+        discard(SerialDevice::must_create(0).leak_ref());
+    discard(SerialDevice::must_create(1).leak_ref());
+    discard(SerialDevice::must_create(2).leak_ref());
+    discard(SerialDevice::must_create(3).leak_ref());
 
     VMWareBackdoor::the(); // don't wait until first mouse packet
     HIDManagement::initialize();
@@ -319,15 +320,15 @@ void init_stage2(void*)
     Syscall::initialize();
 
 #ifdef ENABLE_KERNEL_COVERAGE_COLLECTION
-    (void)KCOVDevice::must_create().leak_ref();
+    discard(KCOVDevice::must_create().leak_ref());
 #endif
-    (void)MemoryDevice::must_create().leak_ref();
-    (void)ZeroDevice::must_create().leak_ref();
-    (void)FullDevice::must_create().leak_ref();
-    (void)RandomDevice::must_create().leak_ref();
+    discard(MemoryDevice::must_create().leak_ref());
+    discard(ZeroDevice::must_create().leak_ref());
+    discard(FullDevice::must_create().leak_ref());
+    discard(RandomDevice::must_create().leak_ref());
     PTYMultiplexer::initialize();
 
-    (void)SB16::try_detect_and_create();
+    discard(SB16::try_detect_and_create());
     AC97::detect();
 
     StorageManagement::the().initialize(kernel_command_line().root_device(), kernel_command_line().is_force_pio(), kernel_command_line().is_nvme_polling_enabled());

--- a/Meta/Lagom/Fuzzers/FuzzASN1.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzASN1.cpp
@@ -4,13 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibTLS/Certificate.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    (void)TLS::Certificate::parse_asn1({ data, size });
+    discard(TLS::Certificate::parse_asn1({ data, size }));
 
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzBMPLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzBMPLoader.cpp
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGfx/BMPLoader.h>
 #include <stdio.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     Gfx::BMPImageDecoderPlugin decoder(data, size);
-    (void)decoder.frame(0);
+    discard(decoder.frame(0));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzGemini.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGemini.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/StringView.h>
 #include <AK/URL.h>
 #include <LibGemini/Document.h>
@@ -13,6 +14,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto gemini = StringView(static_cast<const unsigned char*>(data), size);
-    (void)Gemini::Document::parse(gemini, {});
+    discard(Gemini::Document::parse(gemini, {}));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzICOLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzICOLoader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGfx/ICOLoader.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -11,6 +12,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     Gfx::ICOImageDecoderPlugin decoder(data, size);
-    (void)decoder.frame(0);
+    discard(decoder.frame(0));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzJPGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzJPGLoader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGfx/JPGLoader.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -11,6 +12,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     Gfx::JPGImageDecoderPlugin decoder(data, size);
-    (void)decoder.frame(0);
+    discard(decoder.frame(0));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzMarkdown.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzMarkdown.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/OwnPtr.h>
 #include <AK/StringView.h>
 #include <LibMarkdown/Document.h>
@@ -13,6 +14,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto markdown = StringView(static_cast<const unsigned char*>(data), size);
-    (void)Markdown::Document::parse(markdown);
+    discard(Markdown::Document::parse(markdown));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzPBMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPBMLoader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGfx/PBMLoader.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -11,6 +12,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     Gfx::PBMImageDecoderPlugin decoder(data, size);
-    (void)decoder.frame(0);
+    discard(decoder.frame(0));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzPDF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPDF.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibPDF/Document.h>
 #include <stdint.h>
 
@@ -15,7 +16,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     if (doc) {
         auto pages = doc->get_page_count();
         for (size_t i = 0; i < pages; ++i) {
-            (void)doc->get_page(i);
+            discard(doc->get_page(i));
         }
     }
 

--- a/Meta/Lagom/Fuzzers/FuzzPEM.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPEM.cpp
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibCrypto/ASN1/PEM.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
-    (void)Crypto::decode_pem({ data, size });
+    discard(Crypto::decode_pem({ data, size }));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzPGMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPGMLoader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGfx/PGMLoader.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -11,6 +12,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     Gfx::PGMImageDecoderPlugin decoder(data, size);
-    (void)decoder.frame(0);
+    discard(decoder.frame(0));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzPNGLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPNGLoader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGfx/PNGLoader.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -11,6 +12,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     Gfx::PNGImageDecoderPlugin decoder(data, size);
-    (void)decoder.frame(0);
+    discard(decoder.frame(0));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzPPMLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzPPMLoader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGfx/PPMLoader.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -11,6 +12,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     Gfx::PPMImageDecoderPlugin decoder(data, size);
-    (void)decoder.frame(0);
+    discard(decoder.frame(0));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzRegexECMA262.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexECMA262.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/StringView.h>
 #include <LibRegex/Regex.h>
 #include <stddef.h>
@@ -12,6 +13,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto pattern = StringView(static_cast<const unsigned char*>(data), size);
-    [[maybe_unused]] auto re = Regex<ECMA262>(pattern);
+    discard(Regex<ECMA262>(pattern));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzRegexPosixBasic.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexPosixBasic.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/StringView.h>
 #include <LibRegex/Regex.h>
 #include <stddef.h>
@@ -12,6 +13,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto pattern = StringView(static_cast<const unsigned char*>(data), size);
-    [[maybe_unused]] auto re = Regex<PosixBasic>(pattern);
+    discard(Regex<PosixBasic>(pattern));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzRegexPosixExtended.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzRegexPosixExtended.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/StringView.h>
 #include <LibRegex/Regex.h>
 #include <stddef.h>
@@ -12,6 +13,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto pattern = StringView(static_cast<const unsigned char*>(data), size);
-    [[maybe_unused]] auto re = Regex<PosixExtended>(pattern);
+    discard(Regex<PosixExtended>(pattern));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzSQLParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzSQLParser.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibSQL/AST/Lexer.h>
 #include <LibSQL/AST/Parser.h>
 #include <stdio.h>
@@ -11,6 +12,6 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto parser = SQL::AST::Parser(SQL::AST::Lexer({ data, size }));
-    [[maybe_unused]] auto statement = parser.next_statement();
+    discard(parser.next_statement());
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzShell.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzShell.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/StringView.h>
 #include <Shell/Shell.h>
 #include <stddef.h>
@@ -13,6 +14,6 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto source = StringView(static_cast<const unsigned char*>(data), size);
     Shell::Parser parser(source);
-    (void)parser.parse();
+    discard(parser.parse());
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzTTF.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzTTF.cpp
@@ -4,12 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGfx/TrueTypeFont/Font.h>
 #include <stddef.h>
 #include <stdint.h>
 
 extern "C" int LLVMFuzzerTestOneInput(u8 const* data, size_t size)
 {
-    (void)TTF::Font::try_load_from_externally_owned_memory({ data, size });
+    discard(TTF::Font::try_load_from_externally_owned_memory({ data, size }));
     return 0;
 }

--- a/Meta/Lagom/Fuzzers/FuzzWasmParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWasmParser.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/MemoryStream.h>
 #include <AK/Stream.h>
 #include <LibWasm/Types.h>
@@ -14,7 +15,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     ReadonlyBytes bytes { data, size };
     InputMemoryStream stream { bytes };
-    [[maybe_unused]] auto result = Wasm::Module::parse(stream);
+    discard(Wasm::Module::parse(stream));
     stream.handle_any_error();
     return 0;
 }

--- a/Tests/AK/TestByteBuffer.cpp
+++ b/Tests/AK/TestByteBuffer.cpp
@@ -45,7 +45,7 @@ TEST_CASE(negative_operator_lt)
 {
     ByteBuffer a = ByteBuffer::copy("Hello, world", 10).release_value();
     ByteBuffer b = ByteBuffer::copy("Hello, friend", 10).release_value();
-    [[maybe_unused]] auto res = a < b;
+    discard(a < b);
     // error: error: use of deleted function ‘bool AK::ByteBuffer::operator<(const AK::ByteBuffer&) const’
 }
 #endif /* COMPILE_NEGATIVE_TESTS */

--- a/Tests/AK/TestChecked.cpp
+++ b/Tests/AK/TestChecked.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/Checked.h>
+#include <AK/Discard.h>
 #include <AK/NumericLimits.h>
 
 // These tests only check whether the usual operator semantics work.
@@ -387,5 +388,5 @@ TEST_CASE(should_constexpr_compare_checked_values_rhs)
 
 TEST_CASE(should_constexpr_make_via_factory)
 {
-    [[maybe_unused]] constexpr auto value = make_checked(42);
+    discard(make_checked(42));
 }

--- a/Tests/AK/TestDistinctNumeric.cpp
+++ b/Tests/AK/TestDistinctNumeric.cpp
@@ -236,35 +236,35 @@ TEST_CASE(negative_incr)
 TEST_CASE(negative_cmp)
 {
     BareNumeric a = 12;
-    [[maybe_unused]] auto res = (a < a);
+    discard(a < a);
     // error: static assertion failed: 'a<b' is only available for DistinctNumeric types with 'Cmp'.
 }
 
 TEST_CASE(negative_bool)
 {
     BareNumeric a = 12;
-    [[maybe_unused]] auto res = !a;
+    discard(!a);
     // error: static assertion failed: '!a', 'a&&b', 'a||b' and similar operators are only available for DistinctNumeric types with 'Bool'.
 }
 
 TEST_CASE(negative_flags)
 {
     BareNumeric a = 12;
-    [[maybe_unused]] auto res = (a & a);
+    discard(a & a);
     // error: static assertion failed: 'a&b' is only available for DistinctNumeric types with 'Flags'.
 }
 
 TEST_CASE(negative_shift)
 {
     BareNumeric a = 12;
-    [[maybe_unused]] auto res = (a << a);
+    discard(a << a);
     // error: static assertion failed: 'a<<b' is only available for DistinctNumeric types with 'Shift'.
 }
 
 TEST_CASE(negative_arith)
 {
     BareNumeric a = 12;
-    [[maybe_unused]] auto res = (a + a);
+    discard(a + a);
     // error: static assertion failed: 'a+b' is only available for DistinctNumeric types with 'Arith'.
 }
 
@@ -274,12 +274,12 @@ TEST_CASE(negative_incompatible)
     ArithNumeric b = 345;
     // And this is the entire point of `DistinctNumeric`:
     // Theoretically, the operation *could* be supported, but we declared those int types incompatible.
-    [[maybe_unused]] auto res = (a + b);
+    discard(a + b);
     // error: no match for ‘operator+’ (operand types are ‘GeneralNumeric’ {aka ‘AK::DistinctNumeric<int, true, true, true, true, true, true, 64, 64>’} and ‘ArithNumeric’ {aka ‘AK::DistinctNumeric<int, false, false, false, false, false, true, 64, 63>’})
-    //    313 |     [[maybe_unused]] auto res = (a + b);
-    //        |                                  ~ ^ ~
-    //        |                                  |   |
-    //        |                                  |   DistinctNumeric<[...],false,false,false,false,false,[...],[...],63>
-    //        |                                  DistinctNumeric<[...],true,true,true,true,true,[...],[...],64>
+    //    313 |     discard(a + b);
+    //        |             ~ ^ ~
+    //        |             |   |
+    //        |             |   DistinctNumeric<[...],false,false,false,false,false,[...],[...],63>
+    //        |             DistinctNumeric<[...],true,true,true,true,true,[...],[...],64>
 }
 #endif /* COMPILE_NEGATIVE_TESTS */

--- a/Tests/AK/TestIntrusiveList.cpp
+++ b/Tests/AK/TestIntrusiveList.cpp
@@ -9,6 +9,7 @@
 #include <AK/IntrusiveList.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefPtr.h>
+#include <AK/Unused.h>
 
 class IntrusiveTestItem {
 public:
@@ -69,7 +70,7 @@ TEST_CASE(enumeration)
 
     size_t actual_size = 0;
     for (auto& elem : list) {
-        (void)elem;
+        unused(elem);
         actual_size++;
     }
     EXPECT_EQ(expected_size, actual_size);

--- a/Tests/AK/TestSpan.cpp
+++ b/Tests/AK/TestSpan.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/Checked.h>
+#include <AK/Discard.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
 #include <string.h>
@@ -114,14 +115,14 @@ TEST_CASE(can_subspan_as_intended)
 TEST_CASE(span_from_void_pointer)
 {
     int value = 0;
-    [[maybe_unused]] Bytes bytes0 { reinterpret_cast<void*>(value), 4 };
-    [[maybe_unused]] ReadonlyBytes bytes1 { reinterpret_cast<const void*>(value), 4 };
+    discard(Bytes { reinterpret_cast<void*>(value), 4 });
+    discard(ReadonlyBytes { reinterpret_cast<const void*>(value), 4 });
 }
 
 TEST_CASE(span_from_c_string)
 {
     const char* str = "Serenity";
-    [[maybe_unused]] ReadonlyBytes bytes { str, strlen(str) };
+    discard(ReadonlyBytes { str, strlen(str) });
 }
 
 TEST_CASE(starts_with)

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestSuite.h>
 
+#include <AK/Discard.h>
 #include <AK/RefPtr.h>
 #include <AK/Variant.h>
 
@@ -141,8 +142,8 @@ TEST_CASE(moved_from_state)
     Variant<Vector<i32>, Empty> optionally_a_bunch_of_values { Vector<i32> { 1, 2, 3, 4, 5, 6, 7, 8 } };
 
     {
-        [[maybe_unused]] auto devnull_0 = move(bunch_of_values);
-        [[maybe_unused]] auto devnull_1 = move(optionally_a_bunch_of_values);
+        discard(Vector<i32> { move(bunch_of_values) });
+        discard(Variant<Vector<i32>, Empty> { move(optionally_a_bunch_of_values) });
     }
 
     // The moved-from state should be the same in both cases, and the variant should still contain a moved-from vector.

--- a/Tests/Kernel/TestSigAltStack.cpp
+++ b/Tests/Kernel/TestSigAltStack.cpp
@@ -10,6 +10,7 @@
 #    pragma GCC optimize("O0")
 #endif
 
+#include <AK/Discard.h>
 #include <LibTest/TestCase.h>
 #include <signal.h>
 #include <unistd.h>
@@ -54,6 +55,6 @@ TEST_CASE(success_case)
     res = sigaction(SIGSEGV, &sa, 0);
     EXPECT_EQ(res, 0);
 
-    (void)infinite_recursion(0);
+    discard(infinite_recursion(0));
     FAIL("Infinite recursion finished successfully");
 }

--- a/Tests/LibC/TestIo.cpp
+++ b/Tests/LibC/TestIo.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/Discard.h>
 #include <AK/Types.h>
 #include <LibCore/File.h>
 #include <LibTest/TestCase.h>
@@ -242,7 +243,7 @@ TEST_CASE(tmpfs_eoverflow)
     EXPECT_EQ(rc, -1);
     EXPECT_EQ(errno, EOVERFLOW);
 
-    [[maybe_unused]] auto ignored = strlcpy(buffer, "abcdefghijklmno", sizeof(buffer) - 1);
+    discard(strlcpy(buffer, "abcdefghijklmno", sizeof(buffer) - 1));
 
     rc = write(fd, buffer, sizeof(buffer));
     EXPECT_EQ(rc, -1);
@@ -288,7 +289,7 @@ TEST_CASE(tmpfs_massive_file)
     rc = read(fd, buffer, sizeof(buffer));
     EXPECT_EQ(rc, 0);
 
-    [[maybe_unused]] auto ignored = strlcpy(buffer, "abcdefghijklmno", sizeof(buffer) - 1);
+    discard(strlcpy(buffer, "abcdefghijklmno", sizeof(buffer) - 1));
 
     rc = write(fd, buffer, sizeof(buffer));
     EXPECT_EQ(rc, -1);

--- a/Tests/LibC/TestStrtodAccuracy.cpp
+++ b/Tests/LibC/TestStrtodAccuracy.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
+#include <AK/Discard.h>
 #include <AK/Format.h>
 #include <AK/String.h>
 #include <stdlib.h>
@@ -240,11 +241,11 @@ static long long cast_ll(double d)
         long long as_ll;
     };
     typedef char assert_double_8bytes[sizeof(double) == 8 ? 1 : -1];
-    [[maybe_unused]] auto double_size = sizeof(assert_double_8bytes);
+    discard(sizeof(assert_double_8bytes));
     typedef char assert_ll_8bytes[sizeof(long long) == 8 ? 1 : -1];
-    [[maybe_unused]] auto longlong_size = sizeof(assert_ll_8bytes);
+    discard(sizeof(assert_ll_8bytes));
     typedef char assert_readable_8bytes[sizeof(readable_t) == 8 ? 1 : -1];
-    [[maybe_unused]] auto readable8_size = sizeof(assert_readable_8bytes);
+    discard(sizeof(assert_readable_8bytes));
     readable_t readable;
     readable.as_double = d;
     return readable.as_ll;
@@ -257,9 +258,9 @@ static bool is_strtod_close(strtod_fn_t strtod_fn, const char* test_string, cons
         unsigned char as_bytes[8];
     };
     typedef char assert_double_8bytes[sizeof(double) == 8 ? 1 : -1];
-    [[maybe_unused]] auto double_size = sizeof(assert_double_8bytes);
+    discard(sizeof(assert_double_8bytes));
     typedef char assert_readable_8bytes[sizeof(readable_t) == 8 ? 1 : -1];
-    [[maybe_unused]] auto readable8_size = sizeof(assert_readable_8bytes);
+    discard(sizeof(assert_readable_8bytes));
     readable_t readable;
     char* endptr = (char*)0x123;
 

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibTest/JavaScriptTestRunner.h>
 
 TEST_ROOT("Userland/Libraries/LibJS/Tests");
@@ -20,7 +21,7 @@ TESTJS_GLOBAL_FUNCTION(can_parse_source, canParseSource)
 {
     auto source = TRY(vm.argument(0).to_string(global_object));
     auto parser = JS::Parser(JS::Lexer(source));
-    (void)parser.parse_program();
+    discard(parser.parse_program());
     return JS::Value(!parser.has_errors());
 }
 

--- a/Tests/LibSQL/TestSqlDatabase.cpp
+++ b/Tests/LibSQL/TestSqlDatabase.cpp
@@ -6,6 +6,7 @@
 
 #include <unistd.h>
 
+#include <AK/Discard.h>
 #include <AK/ScopeGuard.h>
 #include <LibSQL/BTree.h>
 #include <LibSQL/Database.h>
@@ -95,7 +96,7 @@ void insert_and_verify(int count)
     {
         auto db = SQL::Database::construct("/tmp/test.db");
         EXPECT(!db->open().is_error());
-        (void)setup_table(db);
+        discard(setup_table(db));
         commit(db);
     }
     {
@@ -154,7 +155,7 @@ TEST_CASE(add_schema_to_database)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     auto db = SQL::Database::construct("/tmp/test.db");
     EXPECT(!db->open().is_error());
-    (void)setup_schema(db);
+    discard(setup_schema(db));
     commit(db);
 }
 
@@ -164,7 +165,7 @@ TEST_CASE(get_schema_from_database)
     {
         auto db = SQL::Database::construct("/tmp/test.db");
         EXPECT(!db->open().is_error());
-        (void)setup_schema(db);
+        discard(setup_schema(db));
         commit(db);
     }
     {
@@ -181,7 +182,7 @@ TEST_CASE(add_table_to_database)
     ScopeGuard guard([]() { unlink("/tmp/test.db"); });
     auto db = SQL::Database::construct("/tmp/test.db");
     EXPECT(!db->open().is_error());
-    (void)setup_table(db);
+    discard(setup_table(db));
     commit(db);
 }
 
@@ -191,7 +192,7 @@ TEST_CASE(get_table_from_database)
     {
         auto db = SQL::Database::construct("/tmp/test.db");
         EXPECT(!db->open().is_error());
-        (void)setup_table(db);
+        discard(setup_table(db));
         commit(db);
     }
     {

--- a/Tests/LibSQL/TestSqlValueAndTuple.cpp
+++ b/Tests/LibSQL/TestSqlValueAndTuple.cpp
@@ -6,6 +6,7 @@
 
 #include <unistd.h>
 
+#include <AK/Discard.h>
 #include <LibSQL/Meta.h>
 #include <LibSQL/Row.h>
 #include <LibSQL/Tuple.h>
@@ -87,7 +88,7 @@ TEST_CASE(text_value_to_other_types)
 TEST_CASE(text_value_to_int_crash)
 {
     SQL::Value v(SQL::SQLType::Text, "Not a valid integer");
-    EXPECT_CRASH("Can't convert 'Not a valid integer' to integer", [&]() { (void) (int) v; return Test::Crash::Failure::DidNotCrash; });
+    EXPECT_CRASH("Can't convert 'Not a valid integer' to integer", [&]() { discard((int) v); return Test::Crash::Failure::DidNotCrash; });
 }
 
 TEST_CASE(serialize_text_value)

--- a/Tests/LibWeb/test-web.cpp
+++ b/Tests/LibWeb/test-web.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/URL.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
@@ -63,7 +64,7 @@ TESTJS_GLOBAL_FUNCTION(after_initial_page_load, afterInitialPageLoad)
     }
 
     after_initial_load_hooks.append([fn = JS::make_handle(&function.as_function()), &global_object](auto& page_object) {
-        [[maybe_unused]] auto unused = JS::call(global_object, const_cast<JS::FunctionObject&>(*fn.cell()), JS::js_undefined(), &page_object);
+        discard(JS::call(global_object, const_cast<JS::FunctionObject&>(*fn.cell()), JS::js_undefined(), &page_object));
     });
     return JS::js_undefined();
 }
@@ -77,7 +78,7 @@ TESTJS_GLOBAL_FUNCTION(before_initial_page_load, beforeInitialPageLoad)
     }
 
     before_initial_load_hooks.append([fn = JS::make_handle(&function.as_function()), &global_object](auto& page_object) {
-        [[maybe_unused]] auto unused = JS::call(global_object, const_cast<JS::FunctionObject&>(*fn.cell()), JS::js_undefined(), &page_object);
+        discard(JS::call(global_object, const_cast<JS::FunctionObject&>(*fn.cell()), JS::js_undefined(), &page_object));
     });
     return JS::js_undefined();
 }

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -6,6 +6,7 @@
 
 #include "Providers.h"
 #include "FuzzyMatch.h"
+#include <AK/Discard.h>
 #include <AK/LexicalPath.h>
 #include <AK/URL.h>
 #include <LibCore/DirIterator.h>
@@ -161,7 +162,7 @@ void FileProvider::build_filesystem_cache()
     m_building_cache = true;
     m_work_queue.enqueue("/");
 
-    (void)Threading::BackgroundAction<int>::construct(
+    discard(Threading::BackgroundAction<int>::construct(
         [this, strong_ref = NonnullRefPtr(*this)](auto&) {
             String slash = "/";
             auto timer = Core::ElapsedTimer::start_new();
@@ -198,7 +199,7 @@ void FileProvider::build_filesystem_cache()
         },
         [this](auto) {
             m_building_cache = false;
-        });
+        }));
 }
 
 void TerminalProvider::query(String const& query, Function<void(NonnullRefPtrVector<Result>)> on_complete)

--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "BrowserSettingsWidget.h"
+#include <AK/Discard.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
@@ -26,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Browser Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->add_tab<BrowserSettingsWidget>("Browser"));
+    discard(TRY(window->add_tab<BrowserSettingsWidget>("Browser")));
 
     window->show();
     return app->exec();

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "AddEventDialog.h"
+#include <AK/Discard.h>
 #include <Applications/Calendar/CalendarWindowGML.h>
 #include <LibCore/System.h>
 #include <LibGUI/Action.h>
@@ -99,14 +100,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     view_type_action_group->add_action(*view_month_action);
     view_type_action_group->add_action(*view_year_action);
 
-    (void)TRY(toolbar->try_add_action(prev_date_action));
-    (void)TRY(toolbar->try_add_action(next_date_action));
+    discard(TRY(toolbar->try_add_action(prev_date_action)));
+    discard(TRY(toolbar->try_add_action(next_date_action)));
     TRY(toolbar->try_add_separator());
-    (void)TRY(toolbar->try_add_action(jump_to_action));
-    (void)TRY(toolbar->try_add_action(add_event_action));
+    discard(TRY(toolbar->try_add_action(jump_to_action)));
+    discard(TRY(toolbar->try_add_action(add_event_action)));
     TRY(toolbar->try_add_separator());
-    (void)TRY(toolbar->try_add_action(view_month_action));
-    (void)TRY(toolbar->try_add_action(view_year_action));
+    discard(TRY(toolbar->try_add_action(view_month_action)));
+    discard(TRY(toolbar->try_add_action(view_year_action)));
 
     calendar->on_tile_doubleclick = [&] {
         AddEventDialog::show(calendar->selected_date(), window);

--- a/Userland/Applications/ClockSettings/main.cpp
+++ b/Userland/Applications/ClockSettings/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "ClockSettingsWidget.h"
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -26,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-analog-clock"); // FIXME: Create a ClockSettings icon.
 
     auto window = TRY(GUI::SettingsWindow::create("Clock Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    (void)TRY(window->add_tab<ClockSettingsWidget>("Clock"));
+    discard(TRY(window->add_tab<ClockSettingsWidget>("Clock")));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -292,7 +292,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     };
 
-    (void)Threading::BackgroundAction<ThreadBacktracesAndCpuRegisters>::construct(
+    discard(Threading::BackgroundAction<ThreadBacktracesAndCpuRegisters>::construct(
         [&, coredump = move(coredump)](auto&) {
             ThreadBacktracesAndCpuRegisters results;
             size_t thread_index = 0;
@@ -317,7 +317,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             for (auto& backtrace : results.thread_backtraces) {
                 auto container = MUST(backtrace_tab_widget->try_add_tab<GUI::Widget>(backtrace.title));
-                (void)MUST(container->template try_set_layout<GUI::VerticalBoxLayout>());
+                discard(MUST(container->template try_set_layout<GUI::VerticalBoxLayout>()));
                 container->layout()->set_margins(4);
                 auto backtrace_text_editor = MUST(container->template try_add<GUI::TextEditor>());
                 backtrace_text_editor->set_text(backtrace.text);
@@ -327,7 +327,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             for (auto& cpu_registers : results.thread_cpu_registers) {
                 auto container = MUST(cpu_registers_tab_widget->try_add_tab<GUI::Widget>(cpu_registers.title));
-                (void)MUST(container->template try_set_layout<GUI::VerticalBoxLayout>());
+                discard(MUST(container->template try_set_layout<GUI::VerticalBoxLayout>()));
                 container->layout()->set_margins(4);
                 auto cpu_registers_text_editor = MUST(container->template try_add<GUI::TextEditor>());
                 cpu_registers_text_editor->set_text(cpu_registers.text);
@@ -339,7 +339,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             tab_widget.set_visible(true);
             window->resize(window->width(), max(340, window->height()));
             window->set_progress(0);
-        });
+        }));
 
     window->show();
 

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
@@ -231,7 +232,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& tab_widget = *widget->find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     auto backtrace_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Backtrace"));
-    (void)TRY(backtrace_tab->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(backtrace_tab->try_set_layout<GUI::VerticalBoxLayout>()));
     backtrace_tab->layout()->set_margins(4);
 
     auto backtrace_label = TRY(backtrace_tab->try_add<GUI::Label>("A backtrace for each thread alive during the crash is listed below:"));
@@ -253,7 +254,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     cpu_registers_tab_widget->set_tab_position(GUI::TabWidget::TabPosition::Bottom);
 
     auto environment_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Environment"));
-    (void)TRY(environment_tab->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(environment_tab->try_set_layout<GUI::VerticalBoxLayout>()));
     environment_tab->layout()->set_margins(4);
 
     auto environment_text_editor = TRY(environment_tab->try_add<GUI::TextEditor>());
@@ -262,7 +263,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     environment_text_editor->set_should_hide_unnecessary_scrollbars(true);
 
     auto memory_regions_tab = TRY(tab_widget.try_add_tab<GUI::Widget>("Memory Regions"));
-    (void)TRY(memory_regions_tab->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(memory_regions_tab->try_set_layout<GUI::VerticalBoxLayout>()));
     memory_regions_tab->layout()->set_margins(4);
 
     auto memory_regions_text_editor = TRY(memory_regions_tab->try_add<GUI::TextEditor>());

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -9,6 +9,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/Platform.h>
 #include <AK/StringBuilder.h>
+#include <AK/Unused.h>
 #include <LibC/sys/arch/i386/regs.h>
 #include <LibCore/ArgsParser.h>
 #include <LibDebug/DebugInfo.h>
@@ -88,6 +89,7 @@ static bool handle_disassemble_command(const String& command, FlatPtr first_inst
 
 static bool handle_backtrace_command(const PtraceRegisters& regs)
 {
+    maybe_unused(regs);
 #if ARCH(I386)
     auto ebp_val = regs.ebp;
     auto eip_val = regs.eip;
@@ -107,7 +109,6 @@ static bool handle_backtrace_command(const PtraceRegisters& regs)
         ebp_val = (u32)next_ebp.value();
     }
 #else
-    (void)regs;
     TODO();
 #endif
     return true;

--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "MonitorWidget.h"
+#include <AK/Discard.h>
 #include <LibGUI/Desktop.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Bitmap.h>
@@ -30,7 +31,7 @@ bool MonitorWidget::set_wallpaper(String path)
     if (!is_different_to_current_wallpaper_path(path))
         return false;
 
-    (void)Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
+    discard(Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
         [path](auto&) -> ErrorOr<NonnullRefPtr<Gfx::Bitmap>> {
             if (path.is_empty())
                 return Error::from_errno(ENOENT);
@@ -48,7 +49,7 @@ bool MonitorWidget::set_wallpaper(String path)
                 m_wallpaper_bitmap = bitmap_or_error.release_value();
             m_desktop_dirty = true;
             update();
-        });
+        }));
 
     if (path.is_empty())
         m_desktop_wallpaper_path = nullptr;

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -10,6 +10,7 @@
 #include "DesktopSettingsWidget.h"
 #include "FontSettingsWidget.h"
 #include "MonitorSettingsWidget.h"
+#include <AK/Discard.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
@@ -27,10 +28,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-display-settings");
 
     auto window = TRY(GUI::SettingsWindow::create("Display Settings"));
-    (void)TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background"));
-    (void)TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts"));
-    (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor"));
-    (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces"));
+    discard(TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background")));
+    discard(TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts")));
+    discard(TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor")));
+    discard(TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces")));
 
     window->set_icon(app_icon.bitmap_for_size(16));
 

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -10,6 +10,7 @@
 #include "DirectoryView.h"
 #include "FileUtils.h"
 #include "PropertiesWindow.h"
+#include <AK/Discard.h>
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <AK/URL.h>
@@ -332,7 +333,7 @@ ErrorOr<int> run_in_desktop_mode()
     window->set_has_alpha_channel(true);
 
     auto desktop_widget = TRY(window->try_set_main_widget<FileManager::DesktopWidget>());
-    (void)TRY(desktop_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(desktop_widget->try_set_layout<GUI::VerticalBoxLayout>()));
 
     auto directory_view = TRY(desktop_widget->try_add<DirectoryView>(DirectoryView::Mode::Desktop));
     directory_view->set_name("directory_view");
@@ -990,31 +991,31 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("File Manager", GUI::Icon::default_icon("app-file-manager"), window)));
 
-    (void)TRY(main_toolbar.try_add_action(go_back_action));
-    (void)TRY(main_toolbar.try_add_action(go_forward_action));
-    (void)TRY(main_toolbar.try_add_action(open_parent_directory_action));
-    (void)TRY(main_toolbar.try_add_action(go_home_action));
+    discard(TRY(main_toolbar.try_add_action(go_back_action)));
+    discard(TRY(main_toolbar.try_add_action(go_forward_action)));
+    discard(TRY(main_toolbar.try_add_action(open_parent_directory_action)));
+    discard(TRY(main_toolbar.try_add_action(go_home_action)));
 
     TRY(main_toolbar.try_add_separator());
-    (void)TRY(main_toolbar.try_add_action(directory_view->open_terminal_action()));
+    discard(TRY(main_toolbar.try_add_action(directory_view->open_terminal_action())));
 
     TRY(main_toolbar.try_add_separator());
-    (void)TRY(main_toolbar.try_add_action(mkdir_action));
-    (void)TRY(main_toolbar.try_add_action(touch_action));
+    discard(TRY(main_toolbar.try_add_action(mkdir_action)));
+    discard(TRY(main_toolbar.try_add_action(touch_action)));
     TRY(main_toolbar.try_add_separator());
 
-    (void)TRY(main_toolbar.try_add_action(focus_dependent_delete_action));
-    (void)TRY(main_toolbar.try_add_action(directory_view->rename_action()));
+    discard(TRY(main_toolbar.try_add_action(focus_dependent_delete_action)));
+    discard(TRY(main_toolbar.try_add_action(directory_view->rename_action())));
 
     TRY(main_toolbar.try_add_separator());
-    (void)TRY(main_toolbar.try_add_action(cut_action));
-    (void)TRY(main_toolbar.try_add_action(copy_action));
-    (void)TRY(main_toolbar.try_add_action(paste_action));
+    discard(TRY(main_toolbar.try_add_action(cut_action)));
+    discard(TRY(main_toolbar.try_add_action(copy_action)));
+    discard(TRY(main_toolbar.try_add_action(paste_action)));
 
     TRY(main_toolbar.try_add_separator());
-    (void)TRY(main_toolbar.try_add_action(directory_view->view_as_icons_action()));
-    (void)TRY(main_toolbar.try_add_action(directory_view->view_as_table_action()));
-    (void)TRY(main_toolbar.try_add_action(directory_view->view_as_columns_action()));
+    discard(TRY(main_toolbar.try_add_action(directory_view->view_as_icons_action())));
+    discard(TRY(main_toolbar.try_add_action(directory_view->view_as_table_action())));
+    discard(TRY(main_toolbar.try_add_action(directory_view->view_as_columns_action())));
 
     directory_view->on_path_change = [&](String const& new_path, bool can_read_in_path, bool can_write_in_path) {
         auto icon = GUI::FileIconProvider::icon_for_path(new_path);

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -8,6 +8,7 @@
 
 #include "History.h"
 #include "ManualModel.h"
+#include <AK/Discard.h>
 #include <AK/URL.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
@@ -92,7 +93,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(570, 500);
 
     auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    (void)TRY(widget->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(widget->try_set_layout<GUI::VerticalBoxLayout>()));
     widget->set_fill_with_background_color(true);
     widget->layout()->set_spacing(2);
 
@@ -106,11 +107,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto left_tab_bar = TRY(splitter->try_add<GUI::TabWidget>());
     auto tree_view_container = TRY(left_tab_bar->try_add_tab<GUI::Widget>("Browse"));
-    (void)TRY(tree_view_container->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(tree_view_container->try_set_layout<GUI::VerticalBoxLayout>()));
     tree_view_container->layout()->set_margins(4);
     auto tree_view = TRY(tree_view_container->try_add<GUI::TreeView>());
     auto search_view = TRY(left_tab_bar->try_add_tab<GUI::Widget>("Search"));
-    (void)TRY(search_view->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(search_view->try_set_layout<GUI::VerticalBoxLayout>()));
     search_view->layout()->set_margins(4);
     auto search_box = TRY(search_view->try_add<GUI::TextBox>());
     auto search_list_view = TRY(search_view->try_add<GUI::ListView>());
@@ -279,9 +280,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         open_page(path);
     });
 
-    (void)TRY(toolbar->try_add_action(*go_back_action));
-    (void)TRY(toolbar->try_add_action(*go_forward_action));
-    (void)TRY(toolbar->try_add_action(*go_home_action));
+    discard(TRY(toolbar->try_add_action(*go_back_action)));
+    discard(TRY(toolbar->try_add_action(*go_forward_action)));
+    discard(TRY(toolbar->try_add_action(*go_home_action)));
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([](auto&) {

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -266,12 +266,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     (void)TRY(main_toolbar->try_add_action(open_action));
     (void)TRY(main_toolbar->try_add_action(delete_action));
-    (void)TRY(main_toolbar->try_add_separator());
+    TRY(main_toolbar->try_add_separator());
     (void)TRY(main_toolbar->try_add_action(go_first_action));
     (void)TRY(main_toolbar->try_add_action(go_back_action));
     (void)TRY(main_toolbar->try_add_action(go_forward_action));
     (void)TRY(main_toolbar->try_add_action(go_last_action));
-    (void)TRY(main_toolbar->try_add_separator());
+    TRY(main_toolbar->try_add_separator());
     (void)TRY(main_toolbar->try_add_action(zoom_in_action));
     (void)TRY(main_toolbar->try_add_action(reset_zoom_action));
     (void)TRY(main_toolbar->try_add_action(zoom_out_action));

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ViewWidget.h"
+#include <AK/Discard.h>
 #include <AK/URL.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
@@ -264,17 +265,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     };
 
-    (void)TRY(main_toolbar->try_add_action(open_action));
-    (void)TRY(main_toolbar->try_add_action(delete_action));
+    discard(TRY(main_toolbar->try_add_action(open_action)));
+    discard(TRY(main_toolbar->try_add_action(delete_action)));
     TRY(main_toolbar->try_add_separator());
-    (void)TRY(main_toolbar->try_add_action(go_first_action));
-    (void)TRY(main_toolbar->try_add_action(go_back_action));
-    (void)TRY(main_toolbar->try_add_action(go_forward_action));
-    (void)TRY(main_toolbar->try_add_action(go_last_action));
+    discard(TRY(main_toolbar->try_add_action(go_first_action)));
+    discard(TRY(main_toolbar->try_add_action(go_back_action)));
+    discard(TRY(main_toolbar->try_add_action(go_forward_action)));
+    discard(TRY(main_toolbar->try_add_action(go_last_action)));
     TRY(main_toolbar->try_add_separator());
-    (void)TRY(main_toolbar->try_add_action(zoom_in_action));
-    (void)TRY(main_toolbar->try_add_action(reset_zoom_action));
-    (void)TRY(main_toolbar->try_add_action(zoom_out_action));
+    discard(TRY(main_toolbar->try_add_action(zoom_in_action)));
+    discard(TRY(main_toolbar->try_add_action(reset_zoom_action)));
+    discard(TRY(main_toolbar->try_add_action(zoom_out_action)));
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(open_action));

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "KeyboardSettingsWidget.h"
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/SettingsWindow.h>

--- a/Userland/Applications/MailSettings/main.cpp
+++ b/Userland/Applications/MailSettings/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "MailSettingsWidget.h"
+#include <AK/Discard.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
@@ -28,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-mail");
 
     auto window = TRY(GUI::SettingsWindow::create("Mail Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    (void)TRY(window->add_tab<MailSettingsWidget>("Mail"));
+    discard(TRY(window->add_tab<MailSettingsWidget>("Mail")));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/MouseSettings/main.cpp
+++ b/Userland/Applications/MouseSettings/main.cpp
@@ -9,6 +9,7 @@
 
 #include "MouseWidget.h"
 #include "ThemeWidget.h"
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -26,8 +27,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-mouse");
 
     auto window = TRY(GUI::SettingsWindow::create("Mouse Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    (void)TRY(window->add_tab<MouseWidget>("Mouse"));
-    (void)TRY(window->add_tab<ThemeWidget>("Cursor Theme"));
+    discard(TRY(window->add_tab<MouseWidget>("Mouse")));
+    discard(TRY(window->add_tab<ThemeWidget>("Cursor Theme")));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -8,6 +8,7 @@
 #include "AudioPlayerLoop.h"
 
 #include "TrackManager.h"
+#include <AK/Unused.h>
 
 // Converts Piano-internal data to an Audio::Buffer that AudioServer receives
 static NonnullRefPtr<Audio::Buffer> music_samples_to_buffer(Array<Sample, sample_count> samples)
@@ -29,7 +30,7 @@ AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, bool& need_to_writ
 {
     m_audio_client = Audio::ClientConnection::try_create().release_value_but_fixme_should_propagate_errors();
     m_audio_client->on_finish_playing_buffer = [this](int buffer_id) {
-        (void)buffer_id;
+        unused(buffer_id);
         enqueue_audio();
     };
 

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -10,6 +10,7 @@
 #include "Layer.h"
 #include "Selection.h"
 #include <AK/Base64.h>
+#include <AK/Discard.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonObjectSerializer.h>
 #include <AK/JsonValue.h>
@@ -445,7 +446,7 @@ ImageUndoCommand::ImageUndoCommand(Image& image)
 void ImageUndoCommand::undo()
 {
     // FIXME: Handle errors.
-    (void)m_image.restore_snapshot(*m_snapshot);
+    discard(m_image.restore_snapshot(*m_snapshot));
 }
 
 void ImageUndoCommand::redo()

--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "PlaybackManager.h"
+#include <AK/Discard.h>
 
 PlaybackManager::PlaybackManager(NonnullRefPtr<Audio::ClientConnection> connection)
     : m_connection(connection)
@@ -54,7 +55,7 @@ void PlaybackManager::stop()
     m_current_buffer = nullptr;
 
     if (m_loader)
-        (void)m_loader->reset();
+        discard(m_loader->reset());
 }
 
 void PlaybackManager::play()

--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -80,7 +80,7 @@ void PlaybackManager::seek(const int position)
     m_connection->clear_buffer(true);
     m_current_buffer = nullptr;
 
-    [[maybe_unused]] auto result = m_loader->seek(position);
+    discard(m_loader->seek(position));
 
     if (!paused_state)
         set_paused(false);

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "ThreadStackWidget.h"
+#include <AK/Discard.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Model.h>
@@ -113,7 +114,7 @@ private:
 
 void ThreadStackWidget::refresh()
 {
-    (void)Threading::BackgroundAction<Vector<Symbolication::Symbol>>::construct(
+    discard(Threading::BackgroundAction<Vector<Symbolication::Symbol>>::construct(
         [pid = m_pid, tid = m_tid](auto&) {
             return Symbolication::symbolicate_thread(pid, tid, Symbolication::IncludeSourcePosition::No);
         },
@@ -122,7 +123,7 @@ void ThreadStackWidget::refresh()
             if (!weak_this)
                 return;
             Core::EventLoop::with_main_locked([&](auto* main_event_loop) { main_event_loop->post_event(const_cast<Core::Object&>(*weak_this), make<CompletionEvent>(move(result))); });
-        });
+        }));
 }
 
 void ThreadStackWidget::custom_event(Core::CustomEvent& event)

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/QuickSort.h>
 #include <AK/URL.h>
 #include <LibConfig/Client.h>
@@ -169,11 +170,11 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
     main_widget->set_background_role(ColorRole::Button);
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>()));
     main_widget->layout()->set_margins(4);
 
     auto find = TRY(main_widget->try_add<GUI::Widget>());
-    (void)TRY(find->try_set_layout<GUI::HorizontalBoxLayout>());
+    discard(TRY(find->try_set_layout<GUI::HorizontalBoxLayout>()));
     find->layout()->set_margins(4);
     find->set_fixed_height(30);
 

--- a/Userland/Applications/TerminalSettings/main.cpp
+++ b/Userland/Applications/TerminalSettings/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "TerminalSettingsWidget.h"
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/SettingsWindow.h>
@@ -28,8 +29,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Terminal Settings"));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->add_tab<TerminalSettingsMainWidget>("Terminal"));
-    (void)TRY(window->add_tab<TerminalSettingsViewWidget>("View"));
+    discard(TRY(window->add_tab<TerminalSettingsMainWidget>("Terminal")));
+    discard(TRY(window->add_tab<TerminalSettingsViewWidget>("View")));
 
     window->show();
     return app->exec();

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -6,6 +6,7 @@
 
 #include "CatDog.h"
 #include "SpeechBubble.h"
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/Action.h>
@@ -38,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto catdog_widget = TRY(window->try_set_main_widget<CatDog>());
-    (void)TRY(catdog_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(catdog_widget->try_set_layout<GUI::VerticalBoxLayout>()));
     catdog_widget->layout()->set_spacing(0);
 
     auto context_menu = TRY(GUI::Menu::try_create());
@@ -59,7 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     advice_window->set_alpha_hit_threshold(1.0f);
 
     auto advice_widget = TRY(advice_window->try_set_main_widget<SpeechBubble>());
-    (void)TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(advice_widget->try_set_layout<GUI::VerticalBoxLayout>()));
     advice_widget->layout()->set_spacing(0);
 
     auto advice_timer = TRY(Core::Timer::try_create());

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "EyesWidget.h"
+#include <AK/Discard.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
@@ -64,7 +65,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(75 * (full_rows > 0 ? max_in_row : extra_columns), 100 * (full_rows + (extra_columns > 0 ? 1 : 0)));
     window->set_has_alpha_channel(true);
 
-    (void)TRY(window->try_set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns));
+    discard(TRY(window->try_set_main_widget<EyesWidget>(num_eyes, full_rows, extra_columns)));
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); })));

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
@@ -203,7 +204,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-libgfx-demo"));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->try_set_main_widget<Canvas>());
+    discard(TRY(window->try_set_main_widget<Canvas>()));
     window->show();
 
     return app->exec();

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
@@ -122,7 +123,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-libgfx-demo"));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->try_set_main_widget<Canvas>());
+    discard(TRY(window->try_set_main_widget<Canvas>()));
     window->show();
 
     return app->exec();

--- a/Userland/Demos/ModelGallery/GalleryWidget.cpp
+++ b/Userland/Demos/ModelGallery/GalleryWidget.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "GalleryWidget.h"
+#include <AK/Discard.h>
 #include <Demos/ModelGallery/BasicModelTabGML.h>
 
 GalleryWidget::GalleryWidget()
@@ -19,7 +20,7 @@ GalleryWidget::GalleryWidget()
     m_tab_widget = inner_widget.try_add<GUI::TabWidget>().release_value_but_fixme_should_propagate_errors();
     m_statusbar = add<GUI::Statusbar>();
 
-    (void)load_basic_model_tab();
+    discard(load_basic_model_tab());
     load_sorting_filtering_tab();
 }
 

--- a/Userland/Demos/ModelGallery/main.cpp
+++ b/Userland/Demos/ModelGallery/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "GalleryWidget.h"
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
@@ -28,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("Model Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(430, 480);
-    (void)TRY(window->try_set_main_widget<GalleryWidget>());
+    discard(TRY(window->try_set_main_widget<GalleryWidget>()));
 
     window->show();
     return app->exec();

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "GalleryWidget.h"
+#include <AK/Discard.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -28,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(430, 480);
     window->set_title("Widget Gallery");
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->try_set_main_widget<GalleryWidget>());
+    discard(TRY(window->try_set_main_widget<GalleryWidget>()));
     window->show();
 
     return app->exec();

--- a/Userland/DevTools/HackStudio/TerminalWrapper.cpp
+++ b/Userland/DevTools/HackStudio/TerminalWrapper.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "TerminalWrapper.h"
+#include <AK/Discard.h>
 #include <AK/String.h>
 #include <LibCore/ConfigFile.h>
 #include <LibGUI/Application.h>
@@ -184,7 +185,7 @@ void TerminalWrapper::kill_running_command()
     VERIFY(m_pid != -1);
 
     // Kill our child process and its whole process group.
-    [[maybe_unused]] auto rc = killpg(m_pid, SIGTERM);
+    discard(killpg(m_pid, SIGTERM));
 }
 
 void TerminalWrapper::clear_including_history()

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -126,7 +126,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto main_splitter = TRY(main_widget->try_add<GUI::VerticalSplitter>());
 
-    [[maybe_unused]] auto timeline_container = TRY(main_splitter->try_add<TimelineContainer>(*timeline_header_container, *timeline_view));
+    discard(TRY(main_splitter->try_add<TimelineContainer>(*timeline_header_container, *timeline_view)));
 
     auto tab_widget = TRY(main_splitter->try_add<GUI::TabWidget>());
 

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -7,6 +7,7 @@
 #include "BoardView.h"
 #include "Game.h"
 #include "GameSizeDialog.h"
+#include <AK/Discard.h>
 #include <AK/URL.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
@@ -66,7 +67,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(315, 336);
 
     auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>()));
     main_widget->set_fill_with_background_color(true);
 
     Game game { board_size, target_tile, evil_ai };

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -104,27 +104,27 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         statusbar.set_text(click_tip);
         board_widget->run_generation();
     });
-    (void)TRY(main_toolbar.try_add_action(run_one_generation_action));
+    discard(TRY(main_toolbar.try_add_action(run_one_generation_action)));
 
     auto clear_board_action = GUI::Action::create("&Clear board", { Mod_Ctrl, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         statusbar.set_text(click_tip);
         board_widget->clear_cells();
         board_widget->update();
     });
-    (void)TRY(main_toolbar.try_add_action(clear_board_action));
+    discard(TRY(main_toolbar.try_add_action(clear_board_action)));
 
     auto randomize_cells_action = GUI::Action::create("&Randomize board", { Mod_Ctrl, Key_R }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/reload.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         statusbar.set_text(click_tip);
         board_widget->randomize_cells();
         board_widget->update();
     });
-    (void)TRY(main_toolbar.try_add_action(randomize_cells_action));
+    discard(TRY(main_toolbar.try_add_action(randomize_cells_action)));
 
     auto rotate_pattern_action = GUI::Action::create("&Rotate pattern", { 0, Key_R }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/redo.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         board_widget->selected_pattern()->rotate_clockwise();
     });
     rotate_pattern_action->set_enabled(false);
-    (void)TRY(main_toolbar.try_add_action(rotate_pattern_action));
+    discard(TRY(main_toolbar.try_add_action(rotate_pattern_action)));
 
     auto game_menu = TRY(window->try_add_menu("&Game"));
 

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -6,6 +6,7 @@
 
 #include "CustomGameDialog.h"
 #include "Field.h"
+#include <AK/Discard.h>
 #include <AK/URL.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
@@ -49,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->resize(139, 175);
 
     auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
-    (void)TRY(widget->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(widget->try_set_layout<GUI::VerticalBoxLayout>()));
     widget->layout()->set_spacing(0);
 
     auto top_line = TRY(widget->try_add<GUI::SeparatorWidget>(Gfx::Orientation::Horizontal));
@@ -58,7 +59,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto container = TRY(widget->try_add<GUI::Widget>());
     container->set_fill_with_background_color(true);
     container->set_fixed_height(36);
-    (void)TRY(container->try_set_layout<GUI::HorizontalBoxLayout>());
+    discard(TRY(container->try_set_layout<GUI::HorizontalBoxLayout>()));
 
     container->layout()->add_spacer();
 

--- a/Userland/Games/Pong/main.cpp
+++ b/Userland/Games/Pong/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Pong");
     window->set_double_buffering_enabled(false);
-    (void)TRY(window->try_set_main_widget<Pong::Game>());
+    discard(TRY(window->try_set_main_widget<Pong::Game>()));
     window->set_resizable(false);
 
     auto game_menu = TRY(window->try_add_menu("&Game"));

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -7,6 +7,7 @@
 
 #include "Game.h"
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/Random.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Palette.h>
@@ -294,7 +295,7 @@ void Game::mouseup_event(GUI::MouseEvent& event)
                     for (auto& to_intersect : m_focused_cards) {
                         mark_intersecting_stacks_dirty(to_intersect);
                         stack.push(to_intersect);
-                        (void)m_focused_stack->pop();
+                        discard(m_focused_stack->pop());
                     }
 
                     remember_move_for_undo(*m_focused_stack, stack, m_focused_cards);
@@ -629,7 +630,7 @@ void Game::perform_undo()
     for (auto& to_intersect : m_last_move.cards) {
         mark_intersecting_stacks_dirty(to_intersect);
         m_last_move.from->push(to_intersect);
-        (void)m_last_move.to->pop();
+        discard(m_last_move.to->pop());
     }
 
     if (m_last_move.from->type() == CardStack::Type::Stock) {

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Game.h"
+#include <AK/Discard.h>
 #include <AK/Random.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Painter.h>
@@ -285,7 +286,7 @@ void Game::move_focused_cards(CardStack& stack)
     for (auto& to_intersect : m_focused_cards) {
         mark_intersecting_stacks_dirty(to_intersect);
         stack.push(to_intersect);
-        (void)m_focused_stack->pop();
+        discard(m_focused_stack->pop());
     }
 
     update_score(-1);

--- a/Userland/Libraries/LibC/pty.cpp
+++ b/Userland/Libraries/LibC/pty.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Format.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -45,7 +46,7 @@ int openpty(int* amaster, int* aslave, char* name, const struct termios* termp, 
 
     if (name) {
         /* The spec doesn't say how large name has to be. Good luck. */
-        [[maybe_unused]] auto rc = strlcpy(name, tty_name, 128);
+        discard(strlcpy(name, tty_name, 128));
     }
 
     *aslave = open(tty_name, O_RDWR | O_NOCTTY);

--- a/Userland/Libraries/LibC/termcap.cpp
+++ b/Userland/Libraries/LibC/termcap.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
@@ -118,7 +119,7 @@ char* __attribute__((weak)) tgoto([[maybe_unused]] const char* cap, [[maybe_unus
 
     s_tgoto_buffer.clear_with_capacity();
     s_tgoto_buffer.ensure_capacity(cap_str.length());
-    (void)cap_str.copy_characters_to_buffer(s_tgoto_buffer.data(), cap_str.length());
+    discard(cap_str.copy_characters_to_buffer(s_tgoto_buffer.data(), cap_str.length()));
     return s_tgoto_buffer.data();
 }
 

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/ScopedValueRollback.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
@@ -119,18 +120,18 @@ int daemon(int nochdir, int noclose)
         return -1;
 
     if (nochdir == 0)
-        (void)chdir("/");
+        discard(chdir("/"));
 
     if (noclose == 0) {
         // redirect stdout and stderr to /dev/null
         int fd = open("/dev/null", O_WRONLY);
         if (fd < 0)
             return -1;
-        (void)close(STDOUT_FILENO);
-        (void)close(STDERR_FILENO);
-        (void)dup2(fd, STDOUT_FILENO);
-        (void)dup2(fd, STDERR_FILENO);
-        (void)close(fd);
+        discard(close(STDOUT_FILENO));
+        discard(close(STDERR_FILENO));
+        discard(dup2(fd, STDOUT_FILENO));
+        discard(dup2(fd, STDERR_FILENO));
+        discard(close(fd));
     }
     return 0;
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -7,6 +7,7 @@
 #include <AK/Assertions.h>
 #include <AK/Format.h>
 #include <AK/UnicodeUtils.h>
+#include <AK/Unused.h>
 #include <errno.h>
 #include <string.h>
 #include <wchar.h>
@@ -689,10 +690,10 @@ size_t wcsspn(wchar_t const* wcs, wchar_t const* accept)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsftime.html
 size_t wcsftime(wchar_t* __restrict wcs, size_t maxsize, wchar_t const* __restrict format, const struct tm* __restrict timeptr)
 {
-    (void)wcs;
-    (void)maxsize;
-    (void)format;
-    (void)timeptr;
+    unused(wcs);
+    unused(maxsize);
+    unused(format);
+    unused(timeptr);
     dbgln("FIXME: Implement wcsftime()");
     TODO();
 }

--- a/Userland/Libraries/LibC/wstdio.cpp
+++ b/Userland/Libraries/LibC/wstdio.cpp
@@ -9,6 +9,7 @@
 #include <AK/PrintfImplementation.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
+#include <AK/Unused.h>
 #include <bits/stdio_file_implementation.h>
 #include <errno.h>
 #include <stdio.h>
@@ -243,9 +244,9 @@ int wscanf(wchar_t const* __restrict format, ...)
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/vfwscanf.html
 int vfwscanf(FILE* __restrict stream, wchar_t const* __restrict format, va_list arg)
 {
-    (void)stream;
-    (void)format;
-    (void)arg;
+    unused(stream);
+    unused(format);
+    unused(arg);
     dbgln("FIXME: Implement vfwscanf()");
     TODO();
 }
@@ -253,9 +254,9 @@ int vfwscanf(FILE* __restrict stream, wchar_t const* __restrict format, va_list 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/vswscanf.html
 int vswscanf(wchar_t const* __restrict ws, wchar_t const* __restrict format, va_list arg)
 {
-    (void)ws;
-    (void)format;
-    (void)arg;
+    unused(ws);
+    unused(format);
+    unused(arg);
     dbgln("FIXME: Implement vswscanf()");
     TODO();
 }
@@ -263,8 +264,8 @@ int vswscanf(wchar_t const* __restrict ws, wchar_t const* __restrict format, va_
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/vwscanf.html
 int vwscanf(wchar_t const* __restrict format, va_list arg)
 {
-    (void)format;
-    (void)arg;
+    unused(format);
+    unused(arg);
     dbgln("FIXME: Implement vwscanf()");
     TODO();
 }

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/LocalSocket.h>
 #include <LibCore/Notifier.h>
@@ -157,7 +158,7 @@ ErrorOr<NonnullOwnPtr<Stream::LocalSocket>> LocalServer::accept()
 #ifdef AK_OS_MACOS
     int option = 1;
     ioctl(m_fd, FIONBIO, &option);
-    (void)fcntl(accepted_fd, F_SETFD, FD_CLOEXEC);
+    discard(fcntl(accepted_fd, F_SETFD, FD_CLOEXEC));
 #endif
 
     return Stream::LocalSocket::adopt_fd(accepted_fd);

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Stream.h"
+#include <AK/Unused.h>
 #include <LibCore/System.h>
 #include <fcntl.h>
 #include <netdb.h>
@@ -484,20 +485,20 @@ ErrorOr<NonnullOwnPtr<LocalSocket>> LocalSocket::adopt_fd(int fd)
 
 ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
+    maybe_unused(flags);
 #ifdef __serenity__
     return Core::System::recvfd(m_helper.fd(), flags);
 #else
-    (void)flags;
     return Error::from_string_literal("File descriptor passing not supported on this platform");
 #endif
 }
 
 ErrorOr<void> LocalSocket::send_fd(int fd)
 {
+    maybe_unused(fd);
 #ifdef __serenity__
     return Core::System::sendfd(m_helper.fd(), fd);
 #else
-    (void)fd;
     return Error::from_string_literal("File descriptor passing not supported on this platform");
 #endif
 }

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -7,6 +7,7 @@
 #include "Parser.h"
 #include "AST.h"
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/ScopeGuard.h>
 #include <AK/ScopeLogger.h>
 #include <LibCpp/Lexer.h>
@@ -252,7 +253,7 @@ bool Parser::match_template_arguments()
     while (!eof() && peek().type() != Token::Type::Greater) {
         if (!match_named_type())
             return false;
-        (void)parse_type(get_dummy_node());
+        discard(parse_type(get_dummy_node()));
     }
 
     return peek().type() == Token::Type::Greater;
@@ -285,13 +286,13 @@ bool Parser::match_variable_declaration()
     }
 
     VERIFY(m_root_node);
-    (void)parse_type(get_dummy_node());
+    discard(parse_type(get_dummy_node()));
 
     // Identifier
     if (!match_name())
         return false;
 
-    (void)parse_name(get_dummy_node());
+    discard(parse_name(get_dummy_node()));
 
     if (match(Token::Type::Equals)) {
         consume(Token::Type::Equals);
@@ -303,7 +304,7 @@ bool Parser::match_variable_declaration()
     }
 
     if (match_braced_init_list())
-        (void)parse_braced_init_list(get_dummy_node());
+        discard(parse_braced_init_list(get_dummy_node()));
 
     return match(Token::Type::Semicolon);
 }
@@ -695,7 +696,7 @@ bool Parser::match_class_declaration()
 
             if (!match_name())
                 return false;
-            (void)parse_name(get_dummy_node());
+            discard(parse_name(get_dummy_node()));
         } while (peek().type() == Token::Type::Comma);
     }
 
@@ -718,7 +719,7 @@ bool Parser::match_function_declaration()
         return false;
 
     VERIFY(m_root_node);
-    (void)parse_type(get_dummy_node());
+    discard(parse_type(get_dummy_node()));
 
     if (!peek(Token::Type::Identifier).has_value())
         return false;
@@ -1157,7 +1158,7 @@ NonnullRefPtr<StructOrClassDeclaration> Parser::parse_class_declaration(ASTNode&
             while (match_keyword("private") || match_keyword("public") || match_keyword("protected") || match_keyword("virtual"))
                 consume();
 
-            (void)parse_name(get_dummy_node());
+            discard(parse_name(get_dummy_node()));
         } while (peek().type() == Token::Type::Comma);
     }
 
@@ -1479,7 +1480,7 @@ bool Parser::match_c_style_cast_expression()
 
     if (!match_type())
         return false;
-    (void)parse_type(get_dummy_node());
+    discard(parse_type(get_dummy_node()));
 
     if (consume().type() != Token::Type::RightParen)
         return false;

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Optional.h>
 #include <AK/Types.h>
 #include <LibDSP/Processor.h>
@@ -17,7 +18,7 @@ bool Track::add_processor(NonnullRefPtr<Processor> new_processor)
 {
     m_processor_chain.append(move(new_processor));
     if (!check_processor_chain_valid()) {
-        (void)m_processor_chain.take_last();
+        discard(m_processor_chain.take_last());
         return false;
     }
     return true;

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/LexicalPath.h>
@@ -540,7 +541,7 @@ void ELF::DynamicLinker::linker_main(String&& main_program_name, int main_progra
         fflush(stderr);
         _exit(1);
     }
-    (void)result1.release_value();
+    discard(result1.release_value());
 
     auto result2 = map_dependencies(library_name);
     if (result2.is_error()) {

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
 #include <AK/QuickSort.h>
@@ -649,7 +650,7 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
 
     auto weak_this = make_weak_ptr();
 
-    (void)Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
+    discard(Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
         [path](auto&) {
             return render_thumbnail(path);
         },
@@ -676,7 +677,7 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
             }
 
             did_update(UpdateFlag::DontInvalidateIndices);
-        });
+        }));
 
     return false;
 }

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -7,6 +7,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -26,7 +27,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
 
     auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
     main_widget->set_fill_with_background_color(true);
-    (void)TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>());
+    discard(TRY(main_widget->try_set_layout<GUI::VerticalBoxLayout>()));
     main_widget->layout()->set_margins(4);
     main_widget->layout()->set_spacing(6);
 
@@ -34,7 +35,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
 
     auto button_container = TRY(main_widget->try_add<GUI::Widget>());
     button_container->set_shrink_to_fit(true);
-    (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
+    discard(TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>()));
     button_container->layout()->set_spacing(6);
 
     if (show_defaults_button == ShowDefaultsButton::Yes) {

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Badge.h>
 #include <AK/CharacterTypes.h>
+#include <AK/Discard.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
@@ -85,7 +86,7 @@ bool TextDocument::set_text(StringView text, AllowCallback allow_callback)
 
     // Don't show the file's trailing newline as an actual new line.
     if (line_count() > 1 && line(line_count() - 1).is_empty())
-        (void)m_lines.take_last();
+        discard(m_lines.take_last());
 
     m_client_notifications_enabled = true;
 

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/EventLoop.h>
@@ -118,7 +119,7 @@ ErrorOr<void> Toolbar::try_add_separator()
 
     auto item = TRY(adopt_nonnull_own_or_enomem(new (nothrow) Item));
     item->type = Item::Type::Separator;
-    (void)TRY(try_add<SeparatorWidget>(m_orientation == Gfx::Orientation::Horizontal ? Gfx::Orientation::Vertical : Gfx::Orientation::Horizontal));
+    discard(TRY(try_add<SeparatorWidget>(m_orientation == Gfx::Orientation::Horizontal ? Gfx::Orientation::Vertical : Gfx::Orientation::Horizontal)));
     m_items.unchecked_append(move(item));
     return {};
 }

--- a/Userland/Libraries/LibGUI/UndoStack.cpp
+++ b/Userland/Libraries/LibGUI/UndoStack.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGUI/Command.h>
 #include <LibGUI/UndoStack.h>
 
@@ -57,7 +58,7 @@ void UndoStack::push(NonnullOwnPtr<Command> command)
 {
     // If the stack cursor is behind the top of the stack, nuke everything from here to the top.
     while (m_stack.size() != m_stack_index)
-        (void)m_stack.take_last();
+        discard(m_stack.take_last());
 
     if (m_clean_index.has_value() && m_clean_index.value() > m_stack.size())
         m_clean_index = {};

--- a/Userland/Libraries/LibIPC/ClientConnection.h
+++ b/Userland/Libraries/LibIPC/ClientConnection.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Discard.h>
 #include <LibIPC/Connection.h>
 
 namespace IPC {
@@ -32,7 +33,7 @@ public:
         VERIFY(this->socket().is_open());
         this->socket().on_ready_to_read = [this] {
             // FIXME: Do something about errors.
-            (void)this->drain_messages_from_peer();
+            discard(this->drain_messages_from_peer());
         };
     }
 

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/Discard.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/Try.h>
 #include <LibCore/Event.h>
@@ -75,7 +76,7 @@ public:
         m_socket->on_ready_to_read = [this] {
             NonnullRefPtr protect = *this;
             // FIXME: Do something about errors.
-            (void)drain_messages_from_peer();
+            discard(drain_messages_from_peer());
             handle_messages();
         };
     }

--- a/Userland/Libraries/LibIPC/MultiServer.h
+++ b/Userland/Libraries/LibIPC/MultiServer.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Discard.h>
 #include <AK/Error.h>
 #include <LibCore/LocalServer.h>
 #include <LibIPC/ClientConnection.h>
@@ -28,7 +29,7 @@ private:
     {
         m_server->on_accept = [&](auto client_socket) {
             auto client_id = ++m_next_client_id;
-            (void)IPC::new_client_connection<ClientConnectionType>(move(client_socket), client_id);
+            discard(IPC::new_client_connection<ClientConnectionType>(move(client_socket), client_id));
         };
     }
 

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Demangle.h>
+#include <AK/Discard.h>
 #include <AK/HashMap.h>
 #include <AK/HashTable.h>
 #include <AK/QuickSort.h>
@@ -4505,9 +4506,9 @@ ThrowCompletionOr<void> Program::global_declaration_instantiation(Interpreter& i
     for_each_lexically_scoped_declaration([&](Declaration const& declaration) {
         declaration.for_each_bound_name([&](auto const& name) {
             if (declaration.is_constant_declaration())
-                (void)global_environment.create_immutable_binding(global_object, name, true);
+                discard(global_environment.create_immutable_binding(global_object, name, true));
             else
-                (void)global_environment.create_mutable_binding(global_object, name, false);
+                discard(global_environment.create_mutable_binding(global_object, name, false));
             if (interpreter.exception())
                 return IterationDecision::Break;
             return IterationDecision::Continue;

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/HashTable.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Bytecode/Op.h>
@@ -307,7 +308,7 @@ void SetVariable::execute_impl(Bytecode::Interpreter& interpreter) const
 
     auto reference = reference_or_error.release_value();
     // TODO: ThrowCompletionOr<void> return
-    (void)reference.put_value(interpreter.global_object(), interpreter.accumulator());
+    discard(reference.put_value(interpreter.global_object(), interpreter.accumulator()));
 }
 
 void GetById::execute_impl(Bytecode::Interpreter& interpreter) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -616,7 +616,6 @@ void IteratorResultValue::execute_impl(Bytecode::Interpreter& interpreter) const
 
 void NewClass::execute_impl(Bytecode::Interpreter&) const
 {
-    (void)m_class_expression;
     TODO();
 }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/Unused.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
 #include <LibJS/Bytecode/Instruction.h>
@@ -494,6 +495,7 @@ public:
         : Instruction(Type::NewClass)
         , m_class_expression(class_expression)
     {
+        unused(m_class_expression);
     }
 
     void execute_impl(Bytecode::Interpreter&) const;

--- a/Userland/Libraries/LibJS/Bytecode/Pass/MergeBlocks.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/MergeBlocks.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Bytecode/PassManager.h>
 
 namespace JS::Bytecode::Passes {
@@ -89,7 +90,7 @@ void MergeBlocks::perform(PassPipelineExecutable& executable)
 
     for (auto& entry : blocks_to_replace) {
         AK::Array candidates { entry.key };
-        (void)replace_blocks(candidates, *entry.value);
+        discard(replace_blocks(candidates, *entry.value));
     }
 
     while (!blocks_to_merge.is_empty()) {

--- a/Userland/Libraries/LibJS/Bytecode/Pass/PlaceBlocks.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/PlaceBlocks.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Bytecode/PassManager.h>
 
 namespace JS::Bytecode::Passes {
@@ -43,7 +44,7 @@ void PlaceBlocks::perform(PassPipelineExecutable& executable)
     // Put the unreferenced blocks back in at the end
     for (auto& entry : static_cast<Vector<NonnullOwnPtr<BasicBlock>>&>(executable.executable.basic_blocks)) {
         if (reachable_blocks.contains(entry.ptr()))
-            (void)entry.leak_ptr();
+            discard(entry.leak_ptr());
         else
             replaced_blocks.append(*entry.leak_ptr()); // Don't try to do DCE here.
     }

--- a/Userland/Libraries/LibJS/Bytecode/Pass/UnifySameBlocks.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/UnifySameBlocks.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Bytecode/PassManager.h>
 #include <string.h>
 
@@ -54,7 +55,7 @@ void UnifySameBlocks::perform(PassPipelineExecutable& executable)
     };
 
     for (auto& entry : equal_blocks)
-        (void)replace_blocks(entry.key, *entry.value);
+        discard(replace_blocks(entry.key, *entry.value));
 
     finished();
 }

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -15,6 +15,7 @@
 #include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>
 #include <AK/TemporaryChange.h>
+#include <AK/Unused.h>
 #include <LibJS/Runtime/RegExpObject.h>
 #include <LibRegex/Regex.h>
 
@@ -1046,6 +1047,7 @@ NonnullRefPtr<ClassExpression> Parser::parse_class_expression(bool expect_class_
     if (match(TokenType::Extends)) {
         consume();
         auto [expression, should_continue_parsing] = parse_primary_expression();
+        unused(should_continue_parsing);
 
         // Basically a (much) simplified parse_secondary_expression().
         for (;;) {
@@ -1063,7 +1065,6 @@ NonnullRefPtr<ClassExpression> Parser::parse_class_expression(bool expect_class_
         }
 
         super_class = move(expression);
-        (void)should_continue_parsing;
     }
 
     consume(TokenType::CurlyOpen);

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/Discard.h>
 #include <AK/Function.h>
 #include <AK/Optional.h>
 #include <AK/TemporaryChange.h>
@@ -743,9 +744,9 @@ ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, GlobalObject& glo
     program.for_each_lexically_scoped_declaration([&](Declaration const& declaration) {
         declaration.for_each_bound_name([&](auto const& name) {
             if (declaration.is_constant_declaration())
-                (void)lexical_environment->create_immutable_binding(global_object, name, true);
+                discard(lexical_environment->create_immutable_binding(global_object, name, true));
             else
-                (void)lexical_environment->create_mutable_binding(global_object, name, false);
+                discard(lexical_environment->create_mutable_binding(global_object, name, false));
             if (vm.exception())
                 return IterationDecision::Break;
             return IterationDecision::Continue;

--- a/Userland/Libraries/LibJS/Runtime/Accessor.h
+++ b/Userland/Libraries/LibJS/Runtime/Accessor.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/Discard.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/VM.h>
 

--- a/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AtomicsObject.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Atomic.h>
 #include <AK/ByteBuffer.h>
+#include <AK/Discard.h>
 #include <AK/Endian.h>
 #include <LibJS/Runtime/AtomicsObject.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -266,7 +267,7 @@ static ThrowCompletionOr<Value> atomic_compare_exchange_impl(GlobalObject& globa
         auto* v = reinterpret_cast<U*>(block.span().slice(indexed_position).data());
         auto* e = reinterpret_cast<U*>(expected_bytes.data());
         auto* r = reinterpret_cast<U*>(replacement_bytes.data());
-        (void)AK::atomic_compare_exchange_strong(v, *e, *r);
+        discard(AK::atomic_compare_exchange_strong(v, *e, *r));
     }
 
     // 16. Return RawBytesToNumeric(elementType, rawBytesRead, isLittleEndian).

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/FinalizationRegistry.h>
 
@@ -65,7 +66,7 @@ void FinalizationRegistry::cleanup(FunctionObject* callback)
     for (auto it = m_records.begin(); it != m_records.end(); ++it) {
         if (it->target != nullptr)
             continue;
-        (void)call(global_object(), *cleanup_callback, js_undefined(), it->held_value);
+        discard(call(global_object(), *cleanup_callback, js_undefined(), it->held_value));
         it.remove(m_records);
         if (vm.exception())
             return;
@@ -81,5 +82,4 @@ void FinalizationRegistry::visit_edges(Cell::Visitor& visitor)
         visitor.visit(record.unregister_token);
     }
 }
-
 }

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/String.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -862,7 +863,7 @@ ThrowCompletionOr<bool> Object::ordinary_set_with_own_descriptor(PropertyKey con
         return false;
 
     // 7. Perform ? Call(setter, Receiver, « V »).
-    (void)TRY(call(global_object(), *setter, receiver, value));
+    discard(TRY(call(global_object(), *setter, receiver, value)));
 
     // 8. Return true.
     return true;

--- a/Userland/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Promise.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/Function.h>
 #include <AK/Optional.h>
 #include <AK/TypeCasts.h>
@@ -37,7 +38,7 @@ ThrowCompletionOr<Object*> promise_resolve(GlobalObject& global_object, Object& 
     auto promise_capability = TRY(new_promise_capability(global_object, &constructor));
 
     // 3. Perform ? Call(promiseCapability.[[Resolve]], undefined, « x »).
-    (void)TRY(call(global_object, *promise_capability.resolve, js_undefined(), value));
+    discard(TRY(call(global_object, *promise_capability.resolve, js_undefined(), value)));
 
     // 4. Return promiseCapability.[[Promise]].
     return promise_capability.promise;

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/Function.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -304,7 +305,7 @@ ThrowCompletionOr<Object*> PromiseConstructor::construct(FunctionObject& new_tar
     auto [resolve_function, reject_function] = promise->create_resolving_functions();
 
     // 9. Let completion be Call(executor, undefined, « resolvingFunctions.[[Resolve]], resolvingFunctions.[[Reject]] »).
-    (void)JS::call(global_object, executor.as_function(), js_undefined(), &resolve_function, &reject_function);
+    discard(JS::call(global_object, executor.as_function(), js_undefined(), &resolve_function, &reject_function));
 
     // 10. If completion is an abrupt completion, then
     if (auto* exception = vm.exception()) {

--- a/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseConstructor.cpp
@@ -467,7 +467,7 @@ JS_DEFINE_NATIVE_FUNCTION(PromiseConstructor::reject)
     auto promise_capability = TRY(new_promise_capability(global_object, constructor));
 
     // 3. Perform ? Call(promiseCapability.[[Reject]], undefined, « r »).
-    [[maybe_unused]] auto result = TRY(JS::call(global_object, *promise_capability.reject, js_undefined(), reason));
+    discard(TRY(JS::call(global_object, *promise_capability.reject, js_undefined(), reason)));
 
     // 4. Return promiseCapability.[[Promise]].
     return promise_capability.promise;

--- a/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ShadowRealm.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Unused.h>
 #include <LibJS/Lexer.h>
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -230,7 +231,7 @@ ThrowCompletionOr<Value> shadow_realm_import_value(GlobalObject& global_object, 
     // 10. Let onFulfilled be ! CreateBuiltinFunction(steps, 1, "", « [[ExportNameString]] », callerRealm).
     // 11. Set onFulfilled.[[ExportNameString]] to exportNameString.
     // FIXME: Support passing a realm to NativeFunction::create()
-    (void)caller_realm;
+    unused(caller_realm);
     auto* on_fulfilled = NativeFunction::create(
         global_object,
         "",

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -379,7 +379,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::days_in_week)
     VERIFY(calendar->identifier() == "iso8601"sv);
 
     // 4. Let temporalDate be ? ToTemporalDate(temporalDateLike).
-    [[maybe_unused]] auto* temporal_date = TRY(to_temporal_date(global_object, vm.argument(0)));
+    discard(TRY(to_temporal_date(global_object, vm.argument(0))));
 
     // 5. Return 7𝔽.
     return Value(7);

--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -443,7 +444,7 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::months_in_year)
     // 4. If Type(temporalDateLike) is not Object or temporalDateLike does not have an [[InitializedTemporalDate]], [[InitializedTemporalDateTime]] or [[InitializedTemporalYearMonth]] internal slot, then
     if (!temporal_date_like.is_object() || !(is<PlainDate>(temporal_date_like.as_object()) || is<PlainDateTime>(temporal_date_like.as_object()) || is<PlainYearMonth>(temporal_date_like.as_object()))) {
         // a. Perform ? ToTemporalDate(temporalDateLike).
-        (void)TRY(to_temporal_date(global_object, temporal_date_like));
+        discard(TRY(to_temporal_date(global_object, temporal_date_like)));
     }
 
     // 5. Return 12𝔽.

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/Discard.h>
 #include <LibJS/Runtime/Temporal/ISO8601.h>
 
 namespace JS::Temporal {
@@ -719,11 +720,11 @@ bool ISO8601Parser::parse_time_zone_numeric_utc_offset()
         if (m_state.lexer.consume_specific(':')) {
             if (!parse_time_zone_utc_offset_second())
                 return false;
-            (void)parse_time_zone_utc_offset_fraction();
+            discard(parse_time_zone_utc_offset_fraction());
         }
     } else if (parse_time_zone_utc_offset_minute()) {
         if (parse_time_zone_utc_offset_second())
-            (void)parse_time_zone_utc_offset_fraction();
+            discard(parse_time_zone_utc_offset_fraction());
     }
     m_state.parse_result.time_zone_numeric_utc_offset = transaction.parsed_string_view();
     transaction.commit();
@@ -815,11 +816,11 @@ bool ISO8601Parser::parse_time_zone_utc_offset_name()
         if (m_state.lexer.consume_specific(':')) {
             if (!parse_minute_second())
                 return false;
-            (void)parse_fraction();
+            discard(parse_fraction());
         }
     } else if (parse_minute_second()) {
         if (parse_minute_second())
-            (void)parse_fraction();
+            discard(parse_fraction());
     }
     transaction.commit();
     return true;
@@ -952,7 +953,7 @@ bool ISO8601Parser::parse_time_zone_offset_required()
     StateTransaction transaction { *this };
     if (!parse_time_zone_utc_offset())
         return false;
-    (void)parse_time_zone_bracketed_annotation();
+    discard(parse_time_zone_bracketed_annotation());
     transaction.commit();
     return true;
 }
@@ -963,7 +964,7 @@ bool ISO8601Parser::parse_time_zone_name_required()
     // TimeZoneNameRequired :
     //     TimeZoneUTCOffset[opt] TimeZoneBracketedAnnotation
     StateTransaction transaction { *this };
-    (void)parse_time_zone_utc_offset();
+    discard(parse_time_zone_utc_offset());
     if (!parse_time_zone_bracketed_annotation())
         return false;
     transaction.commit();
@@ -1050,11 +1051,11 @@ bool ISO8601Parser::parse_time_spec()
         if (m_state.lexer.consume_specific(':')) {
             if (!parse_time_second())
                 return false;
-            (void)parse_time_fraction();
+            discard(parse_time_fraction());
         }
     } else if (parse_time_minute()) {
         if (parse_time_second())
-            (void)parse_time_fraction();
+            discard(parse_time_fraction());
     }
     transaction.commit();
     return true;
@@ -1195,8 +1196,8 @@ bool ISO8601Parser::parse_date_time()
     //     Date TimeSpecSeparator[opt] TimeZone[opt]
     if (!parse_date())
         return false;
-    (void)parse_time_spec_separator();
-    (void)parse_time_zone();
+    discard(parse_time_spec_separator());
+    discard(parse_time_zone());
     return true;
 }
 
@@ -1236,7 +1237,7 @@ bool ISO8601Parser::parse_calendar_date_time()
     //     DateTime Calendar[opt]
     if (!parse_date_time())
         return false;
-    (void)parse_calendar();
+    discard(parse_calendar());
     return true;
 }
 
@@ -1290,7 +1291,7 @@ bool ISO8601Parser::parse_duration_seconds_part()
     StateTransaction transaction { *this };
     if (!parse_duration_whole_seconds())
         return false;
-    (void)parse_duration_seconds_fraction();
+    discard(parse_duration_seconds_fraction());
     if (!parse_seconds_designator())
         return false;
     transaction.commit();
@@ -1331,10 +1332,10 @@ bool ISO8601Parser::parse_duration_minutes_part()
     StateTransaction transaction { *this };
     if (!parse_duration_whole_minutes())
         return false;
-    (void)parse_duration_minutes_fraction();
+    discard(parse_duration_minutes_fraction());
     if (!parse_minutes_designator())
         return false;
-    (void)parse_duration_seconds_part();
+    discard(parse_duration_seconds_part());
     transaction.commit();
     return true;
 }
@@ -1374,11 +1375,11 @@ bool ISO8601Parser::parse_duration_hours_part()
     StateTransaction transaction { *this };
     if (!parse_duration_whole_hours())
         return false;
-    (void)parse_duration_hours_fraction();
+    discard(parse_duration_hours_fraction());
     if (!parse_hours_designator())
         return false;
-    (void)(parse_duration_minutes_part()
-        || parse_duration_seconds_part());
+    discard((parse_duration_minutes_part()
+        || parse_duration_seconds_part()));
     transaction.commit();
     return true;
 }
@@ -1452,7 +1453,7 @@ bool ISO8601Parser::parse_duration_weeks_part()
         return false;
     if (!parse_weeks_designator())
         return false;
-    (void)parse_duration_days_part();
+    discard(parse_duration_days_part());
     transaction.commit();
     return true;
 }
@@ -1481,8 +1482,8 @@ bool ISO8601Parser::parse_duration_months_part()
         return false;
     if (!parse_months_designator())
         return false;
-    (void)(parse_duration_weeks_part()
-        || parse_duration_days_part());
+    discard((parse_duration_weeks_part()
+        || parse_duration_days_part()));
     transaction.commit();
     return true;
 }
@@ -1512,9 +1513,9 @@ bool ISO8601Parser::parse_duration_years_part()
         return false;
     if (!parse_years_designator())
         return false;
-    (void)(parse_duration_months_part()
+    discard((parse_duration_months_part()
         || parse_duration_weeks_part()
-        || parse_duration_days_part());
+        || parse_duration_days_part()));
     transaction.commit();
     return true;
 }
@@ -1533,7 +1534,7 @@ bool ISO8601Parser::parse_duration_date()
         || parse_duration_days_part();
     if (!success)
         return false;
-    (void)parse_duration_time();
+    discard(parse_duration_time());
     return true;
 }
 
@@ -1544,7 +1545,7 @@ bool ISO8601Parser::parse_duration()
     //     Sign[opt] DurationDesignator DurationDate
     //     Sign[opt] DurationDesignator DurationTime
     StateTransaction transaction { *this };
-    (void)parse_sign();
+    discard(parse_sign());
     if (!parse_duration_designator())
         return false;
     auto success = parse_duration_date()
@@ -1563,7 +1564,7 @@ bool ISO8601Parser::parse_temporal_instant_string()
     StateTransaction transaction { *this };
     if (!parse_date())
         return false;
-    (void)parse_time_spec_separator();
+    discard(parse_time_spec_separator());
     if (!parse_time_zone_offset_required())
         return false;
     transaction.commit();
@@ -1638,10 +1639,10 @@ bool ISO8601Parser::parse_temporal_time_zone_string()
     if (!parse_temporal_time_zone_identifier()) {
         if (!parse_date())
             return false;
-        (void)parse_time_spec_separator();
+        discard(parse_time_spec_separator());
         if (!parse_time_zone())
             return false;
-        (void)parse_calendar();
+        discard(parse_calendar());
     }
     transaction.commit();
     return true;
@@ -1667,10 +1668,10 @@ bool ISO8601Parser::parse_temporal_zoned_date_time_string()
     StateTransaction transaction { *this };
     if (!parse_date())
         return false;
-    (void)parse_time_spec_separator();
+    discard(parse_time_spec_separator());
     if (!parse_time_zone_name_required())
         return false;
-    (void)parse_calendar();
+    discard(parse_calendar());
     transaction.commit();
     return true;
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -122,7 +123,7 @@ ThrowCompletionOr<PlainDate*> to_temporal_date(GlobalObject& global_object, Valu
     }
 
     // 4. Perform ? ToTemporalOverflow(options).
-    (void)TRY(to_temporal_overflow(global_object, *options));
+    discard(TRY(to_temporal_overflow(global_object, *options)));
 
     // 5. Let string be ? ToString(item).
     auto string = TRY(item.to_string(global_object));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateConstructor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Checked.h>
+#include <AK/Discard.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
@@ -84,7 +85,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateConstructor::from)
     if (item.is_object() && is<PlainDate>(item.as_object())) {
         auto& plain_date_item = static_cast<PlainDate&>(item.as_object());
         // a. Perform ? ToTemporalOverflow(options).
-        (void)TRY(to_temporal_overflow(global_object, *options));
+        discard(TRY(to_temporal_overflow(global_object, *options)));
 
         // b. Return ? CreateTemporalDate(item.[[ISOYear]], item.[[ISOMonth]], item.[[ISODay]], item.[[Calendar]]).
         return TRY(create_temporal_date(global_object, plain_date_item.iso_year(), plain_date_item.iso_month(), plain_date_item.iso_day(), plain_date_item.calendar()));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTime.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Date.h>
@@ -186,7 +187,7 @@ ThrowCompletionOr<PlainDateTime*> to_temporal_date_time(GlobalObject& global_obj
     // 3. Else,
     else {
         // a. Perform ? ToTemporalOverflow(options).
-        (void)TRY(to_temporal_overflow(global_object, *options));
+        discard(TRY(to_temporal_overflow(global_object, *options)));
 
         // b. Let string be ? ToString(item).
         auto string = TRY(item.to_string(global_object));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDateTimeConstructor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Checked.h>
+#include <AK/Discard.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
@@ -105,7 +106,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainDateTimeConstructor::from)
         auto& plain_date_time = static_cast<PlainDateTime&>(item.as_object());
 
         // a. Perform ? ToTemporalOverflow(options).
-        (void)TRY(to_temporal_overflow(global_object, *options));
+        discard(TRY(to_temporal_overflow(global_object, *options)));
 
         // b. Return ? CreateTemporalDateTime(item.[[ISOYear]], item.[[ISOMonth]], item.[[ISODay]], item.[[ISOHour]], item.[[ISOMinute]], item.[[ISOSecond]], item.[[ISOMillisecond]], item.[[ISOMicrosecond]], item.[[ISONanosecond]], item.[[Calendar]]).
         return TRY(create_temporal_date_time(global_object, plain_date_time.iso_year(), plain_date_time.iso_month(), plain_date_time.iso_day(), plain_date_time.iso_hour(), plain_date_time.iso_minute(), plain_date_time.iso_second(), plain_date_time.iso_millisecond(), plain_date_time.iso_microsecond(), plain_date_time.iso_nanosecond(), plain_date_time.calendar()));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDay.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
@@ -119,7 +120,7 @@ ThrowCompletionOr<PlainMonthDay*> to_temporal_month_day(GlobalObject& global_obj
     }
 
     // 4. Perform ? ToTemporalOverflow(options).
-    (void)TRY(to_temporal_overflow(global_object, *options));
+    discard(TRY(to_temporal_overflow(global_object, *options)));
 
     // 5. Let string be ? ToString(item).
     auto string = TRY(item.to_string(global_object));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainMonthDayConstructor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
@@ -93,7 +94,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainMonthDayConstructor::from)
     // 2. If Type(item) is Object and item has an [[InitializedTemporalMonthDay]] internal slot, then
     if (item.is_object() && is<PlainMonthDay>(item.as_object())) {
         // a. Perform ? ToTemporalOverflow(options).
-        (void)TRY(to_temporal_overflow(global_object, *options));
+        discard(TRY(to_temporal_overflow(global_object, *options)));
 
         auto& plain_month_day_object = static_cast<PlainMonthDay&>(item.as_object());
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonth.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
@@ -65,7 +66,7 @@ ThrowCompletionOr<PlainYearMonth*> to_temporal_year_month(GlobalObject& global_o
     }
 
     // 4. Perform ? ToTemporalOverflow(options).
-    (void)TRY(to_temporal_overflow(global_object, *options));
+    discard(TRY(to_temporal_overflow(global_object, *options)));
 
     // 5. Let string be ? ToString(item).
     auto string = TRY(item.to_string(global_object));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainYearMonthConstructor.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/AbstractOperations.h>
@@ -95,7 +96,7 @@ JS_DEFINE_NATIVE_FUNCTION(PlainYearMonthConstructor::from)
     // 2. If Type(item) is Object and item has an [[InitializedTemporalYearMonth]] internal slot, then
     if (item.is_object() && is<PlainYearMonth>(item.as_object())) {
         // a. Perform ? ToTemporalOverflow(options).
-        (void)TRY(to_temporal_overflow(global_object, *options));
+        discard(TRY(to_temporal_overflow(global_object, *options)));
 
         auto& plain_year_month_object = static_cast<PlainYearMonth&>(item.as_object());
 

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTime.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
@@ -187,7 +188,7 @@ ThrowCompletionOr<ZonedDateTime*> to_temporal_zoned_date_time(GlobalObject& glob
     // 5. Else,
     else {
         // a. Perform ? ToTemporalOverflow(options).
-        (void)TRY(to_temporal_overflow(global_object, *options));
+        discard(TRY(to_temporal_overflow(global_object, *options)));
 
         // b. Let string be ? ToString(item).
         auto string = TRY(item.to_string(global_object));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ZonedDateTimeConstructor.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Temporal/Calendar.h>
@@ -83,13 +84,13 @@ JS_DEFINE_NATIVE_FUNCTION(ZonedDateTimeConstructor::from)
         auto& item_object = static_cast<ZonedDateTime&>(item.as_object());
 
         // a. Perform ? ToTemporalOverflow(options).
-        (void)TRY(to_temporal_overflow(global_object, *options));
+        discard(TRY(to_temporal_overflow(global_object, *options)));
 
         // b. Perform ? ToTemporalDisambiguation(options).
-        (void)TRY(to_temporal_disambiguation(global_object, *options));
+        discard(TRY(to_temporal_disambiguation(global_object, *options)));
 
         // c. Perform ? ToTemporalOffset(options, "reject").
-        (void)TRY(to_temporal_offset(global_object, *options, "reject"));
+        discard(TRY(to_temporal_offset(global_object, *options, "reject")));
 
         // d. Return ! CreateTemporalZonedDateTime(item.[[Nanoseconds]], item.[[TimeZone]], item.[[Calendar]]).
         return MUST(create_temporal_zoned_date_time(global_object, item_object.nanoseconds(), item_object.time_zone(), item_object.calendar()));

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -7,6 +7,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
@@ -628,7 +629,7 @@ void VM::run_queued_promise_jobs()
             pushed_execution_context = true;
         }
 
-        [[maybe_unused]] auto result = call(job->global_object(), *job, js_undefined());
+        discard(call(job->global_object(), *job, js_undefined()));
 
         // This doesn't match the spec, it actually defines that Job Abstract Closures must return
         // a normal completion. In reality that's not the case however, and all major engines clear

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1797,7 +1797,7 @@ Result<Vector<size_t, 2>, Editor::Error> Editor::vt_dsr()
 
     do {
         more_junk_to_read = false;
-        [[maybe_unused]] auto rc = select(1, &readfds, nullptr, nullptr, &timeout);
+        discard(select(1, &readfds, nullptr, nullptr, &timeout));
         if (FD_ISSET(0, &readfds)) {
             auto nread = read(0, buf, 16);
             if (nread < 0) {

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -9,6 +9,7 @@
 #include <AK/Debug.h>
 #include <AK/Format.h>
 #include <AK/StdLibExtras.h>
+#include <AK/Unused.h>
 #include <Kernel/API/Syscall.h>
 #include <LibSystem/syscall.h>
 #include <bits/pthread_integration.h>
@@ -650,7 +651,7 @@ constexpr static u32 writer_intent_mask = 1 << 16;
 int pthread_rwlock_init(pthread_rwlock_t* __restrict lockp, const pthread_rwlockattr_t* __restrict attr)
 {
     // Just ignore the attributes. use defaults for now.
-    (void)attr;
+    unused(attr);
 
     // No readers, no writer, not locked at all.
     *lockp = 0;

--- a/Userland/Libraries/LibThreading/Thread.cpp
+++ b/Userland/Libraries/LibThreading/Thread.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibThreading/Thread.h>
 #include <pthread.h>
 #include <string.h>
@@ -22,7 +23,7 @@ Threading::Thread::~Thread()
 {
     if (m_tid && !m_detached) {
         dbgln("Destroying thread \"{}\"({}) while it is still running!", m_thread_name, m_tid);
-        [[maybe_unused]] auto res = join();
+        discard(join());
     }
 }
 

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -384,7 +384,7 @@ void Terminal::XTERM_WM(Parameters params)
             return;
         }
         dbgln_if(TERMINAL_DEBUG, "Title stack push: {}", m_current_window_title);
-        [[maybe_unused]] auto rc = m_title_stack.try_append(move(m_current_window_title));
+        discard(m_title_stack.try_append(move(m_current_window_title)));
         break;
     }
     case 23: {

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/Queue.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
@@ -1568,7 +1569,7 @@ void Terminal::set_size(u16 columns, u16 rows)
                 if (m_history.size() >= 2 && m_history[m_history.size() - 2].termination_column().has_value())
                     break;
                 --extra_lines;
-                (void)m_history.take_last();
+                discard(m_history.take_last());
                 continue;
             }
             break;

--- a/Userland/Libraries/LibWasm/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWasm/Parser/Parser.cpp
@@ -7,6 +7,7 @@
 #include <AK/LEB128.h>
 #include <AK/ScopeGuard.h>
 #include <AK/ScopeLogger.h>
+#include <AK/Unused.h>
 #include <LibWasm/Types.h>
 
 namespace Wasm {
@@ -973,42 +974,42 @@ ParseResult<ElementSection::SegmentType1> ElementSection::SegmentType1::parse(In
 ParseResult<ElementSection::SegmentType2> ElementSection::SegmentType2::parse(InputStream& stream)
 {
     dbgln("Type 2");
-    (void)stream;
+    unused(stream);
     return ParseError::NotImplemented;
 }
 
 ParseResult<ElementSection::SegmentType3> ElementSection::SegmentType3::parse(InputStream& stream)
 {
     dbgln("Type 3");
-    (void)stream;
+    unused(stream);
     return ParseError::NotImplemented;
 }
 
 ParseResult<ElementSection::SegmentType4> ElementSection::SegmentType4::parse(InputStream& stream)
 {
     dbgln("Type 4");
-    (void)stream;
+    unused(stream);
     return ParseError::NotImplemented;
 }
 
 ParseResult<ElementSection::SegmentType5> ElementSection::SegmentType5::parse(InputStream& stream)
 {
     dbgln("Type 5");
-    (void)stream;
+    unused(stream);
     return ParseError::NotImplemented;
 }
 
 ParseResult<ElementSection::SegmentType6> ElementSection::SegmentType6::parse(InputStream& stream)
 {
     dbgln("Type 6");
-    (void)stream;
+    unused(stream);
     return ParseError::NotImplemented;
 }
 
 ParseResult<ElementSection::SegmentType7> ElementSection::SegmentType7::parse(InputStream& stream)
 {
     dbgln("Type 7");
-    (void)stream;
+    unused(stream);
     return ParseError::NotImplemented;
 }
 

--- a/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSRuleList.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/TypeCasts.h>
+#include <AK/Unused.h>
 #include <LibWeb/CSS/CSSImportRule.h>
 #include <LibWeb/CSS/CSSMediaRule.h>
 #include <LibWeb/CSS/CSSRuleList.h>
@@ -68,7 +69,7 @@ DOM::ExceptionOr<void> CSSRuleList::remove_a_css_rule(u32 index)
     auto& old_rule = m_rules[index];
 
     // FIXME: 4. If old rule is an @namespace at-rule, and list contains anything other than @import at-rules, and @namespace at-rules, throw an InvalidStateError exception.
-    (void)old_rule;
+    unused(old_rule);
 
     // 5. Remove rule old rule from list at the zero-indexed position index.
     m_rules.remove(index);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -9,6 +9,7 @@
 
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/SourceLocation.h>
 #include <LibWeb/CSS/CSSImportRule.h>
@@ -1682,7 +1683,7 @@ Vector<DeclarationOrAtRule> Parser::consume_a_list_of_declarations(TokenStream<T
             if (peek.is(Token::Type::Semicolon) || peek.is(Token::Type::EndOfFile))
                 break;
             dbgln("Discarding token: '{}'", peek.to_debug_string());
-            (void)consume_a_component_value(tokens);
+            discard(consume_a_component_value(tokens));
         }
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/CharacterTypes.h>
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/SourceLocation.h>
 #include <AK/Vector.h>
 #include <LibTextCodec/Decoder.h>
@@ -389,7 +390,7 @@ u32 Tokenizer::consume_escaped_code_point()
 
         // If the next input code point is whitespace, consume it as well.
         if (is_whitespace(peek_code_point())) {
-            (void)next_code_point();
+            discard(next_code_point());
         }
 
         // Interpret the hex digits as a hexadecimal number.
@@ -428,7 +429,7 @@ Token Tokenizer::consume_an_ident_like_token()
     // If string’s value is an ASCII case-insensitive match for "url", and the next input code
     // point is U+0028 LEFT PARENTHESIS ((), consume it.
     if (string.equals_ignoring_case("url") && is_left_paren(peek_code_point())) {
-        (void)next_code_point();
+        discard(next_code_point());
 
         // While the next two input code points are whitespace, consume the next input code point.
         for (;;) {
@@ -437,7 +438,7 @@ Token Tokenizer::consume_an_ident_like_token()
                 break;
             }
 
-            (void)next_code_point();
+            discard(next_code_point());
         }
 
         // If the next one or two input code points are U+0022 QUOTATION MARK ("), U+0027 APOSTROPHE ('),
@@ -454,7 +455,7 @@ Token Tokenizer::consume_an_ident_like_token()
 
     // Otherwise, if the next input code point is U+0028 LEFT PARENTHESIS ((), consume it.
     if (is_left_paren(peek_code_point())) {
-        (void)next_code_point();
+        discard(next_code_point());
 
         // Create a <function-token> with its value set to string and return it.
         return create_value_token(Token::Type::Function, string);
@@ -729,12 +730,12 @@ Token Tokenizer::consume_a_url_token()
             input = peek_code_point();
 
             if (is_right_paren(input)) {
-                (void)next_code_point();
+                discard(next_code_point());
                 return make_token();
             }
 
             if (is_eof(input)) {
-                (void)next_code_point();
+                discard(next_code_point());
                 log_parse_error();
                 return make_token();
             }
@@ -800,7 +801,7 @@ void Tokenizer::consume_the_remnants_of_a_bad_url()
             // Consume an escaped code point.
             // This allows an escaped right parenthesis ("\)") to be encountered without ending
             // the <bad-url-token>. This is otherwise identical to the "anything else" clause.
-            (void)consume_escaped_code_point();
+            discard(consume_escaped_code_point());
         }
 
         // anything else
@@ -811,7 +812,7 @@ void Tokenizer::consume_the_remnants_of_a_bad_url()
 void Tokenizer::consume_as_much_whitespace_as_possible()
 {
     while (is_whitespace(peek_code_point())) {
-        (void)next_code_point();
+        discard(next_code_point());
     }
 }
 
@@ -850,7 +851,7 @@ Token Tokenizer::consume_a_numeric_token()
 
     // Otherwise, if the next input code point is U+0025 PERCENTAGE SIGN (%), consume it.
     if (is_percent(peek_code_point())) {
-        (void)next_code_point();
+        discard(next_code_point());
 
         // Create a <percentage-token> with the same value as number, and return it.
         auto token = create_new_token(Token::Type::Percentage);
@@ -1029,7 +1030,7 @@ Token Tokenizer::consume_string_token(u32 ending_code_point)
 
             // Otherwise, if the next input code point is a newline, consume it.
             if (is_newline(next_input)) {
-                (void)next_code_point();
+                discard(next_code_point());
                 continue;
             }
 
@@ -1063,8 +1064,8 @@ start:
     if (!(is_solidus(twin.first) && is_asterisk(twin.second)))
         return;
 
-    (void)next_code_point();
-    (void)next_code_point();
+    discard(next_code_point());
+    discard(next_code_point());
 
     for (;;) {
         auto twin_inner = peek_twin();
@@ -1074,12 +1075,12 @@ start:
         }
 
         if (is_asterisk(twin_inner.first) && is_solidus(twin_inner.second)) {
-            (void)next_code_point();
-            (void)next_code_point();
+            discard(next_code_point());
+            discard(next_code_point());
             goto start;
         }
 
-        (void)next_code_point();
+        discard(next_code_point());
     }
 }
 
@@ -1196,8 +1197,8 @@ Token Tokenizer::consume_a_token()
         // GREATER-THAN SIGN (->), consume them and return a <CDC-token>.
         auto next_twin = peek_twin();
         if (is_hyphen_minus(next_twin.first) && is_greater_than_sign(next_twin.second)) {
-            (void)next_code_point();
-            (void)next_code_point();
+            discard(next_code_point());
+            discard(next_code_point());
 
             return create_new_token(Token::Type::CDC);
         }
@@ -1248,9 +1249,9 @@ Token Tokenizer::consume_a_token()
         // U+002D HYPHEN-MINUS (!--), consume them and return a <CDO-token>.
         auto maybe_cdo = peek_triplet();
         if (is_exclamation_mark(maybe_cdo.first) && is_hyphen_minus(maybe_cdo.second) && is_hyphen_minus(maybe_cdo.third)) {
-            (void)next_code_point();
-            (void)next_code_point();
-            (void)next_code_point();
+            discard(next_code_point());
+            discard(next_code_point());
+            discard(next_code_point());
 
             return create_new_token(Token::Type::CDO);
         }

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/NonnullRefPtr.h>
+#include <AK/Unused.h>
 #include <LibWeb/CSS/ResolvedCSSStyleDeclaration.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
@@ -29,7 +30,7 @@ size_t ResolvedCSSStyleDeclaration::length() const
 
 String ResolvedCSSStyleDeclaration::item(size_t index) const
 {
-    (void)index;
+    unused(index);
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/AnyOf.h>
+#include <AK/Discard.h>
 #include <AK/StringBuilder.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
@@ -241,7 +242,7 @@ void Element::recompute_style()
             return;
         // We need a new layout tree here!
         Layout::TreeBuilder tree_builder;
-        (void)tree_builder.build(*this);
+        discard(tree_builder.build(*this));
         return;
     }
 

--- a/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventDispatcher.cpp
@@ -90,7 +90,7 @@ bool EventDispatcher::inner_invoke(Event& event, Vector<EventTarget::EventListen
         auto* this_value = Bindings::wrap(global, *event.current_target());
         auto* wrapped_event = Bindings::wrap(global, event);
         auto& vm = global.vm();
-        [[maybe_unused]] auto rc = JS::call(global, function, this_value, wrapped_event);
+        discard(JS::call(global, function, this_value, wrapped_event));
         if (vm.exception()) {
             vm.clear_exception();
             // FIXME: Set legacyOutputDidListenersThrowFlag if given. (Only used by IndexedDB currently)

--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/StringBuilder.h>
+#include <AK/Unused.h>
 #include <LibJS/Interpreter.h>
 #include <LibJS/Parser.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>

--- a/Userland/Libraries/LibWeb/DOM/Window.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Window.cpp
@@ -173,7 +173,7 @@ void Window::timer_did_fire(Badge<Timer>, Timer& timer)
         VERIFY(wrapper());
         auto& vm = wrapper()->vm();
 
-        [[maybe_unused]] auto rc = JS::call(wrapper()->global_object(), strong_timer->callback(), wrapper());
+        discard(JS::call(wrapper()->global_object(), strong_timer->callback(), wrapper()));
         if (vm.exception())
             vm.clear_exception();
     });
@@ -395,7 +395,7 @@ void Window::queue_microtask(JS::FunctionObject& callback)
     // The queueMicrotask(callback) method must queue a microtask to invoke callback,
     HTML::queue_a_microtask(associated_document(), [&callback, handle = JS::make_handle(&callback)]() {
         auto& vm = callback.vm();
-        [[maybe_unused]] auto rc = JS::call(callback.global_object(), callback, JS::js_null());
+        discard(JS::call(callback.global_object(), callback, JS::js_null()));
         // FIXME: ...and if callback throws an exception, report the exception.
         if (vm.exception())
             vm.clear_exception();

--- a/Userland/Libraries/LibWeb/DOM/Window.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Window.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibGUI/DisplayLink.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/FunctionObject.h>
@@ -203,7 +204,7 @@ i32 Window::request_animation_frame(JS::FunctionObject& js_callback)
     auto callback = request_animation_frame_driver().add([this, handle = JS::make_handle(&js_callback)](i32 id) mutable {
         auto& function = *handle.cell();
         auto& vm = function.vm();
-        (void)JS::call(function.global_object(), function, JS::js_undefined(), JS::Value(performance().now()));
+        discard(JS::call(function.global_object(), function, JS::js_undefined(), JS::Value(performance().now())));
         if (vm.exception())
             vm.clear_exception();
         m_request_animation_frame_callbacks.remove(id);

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/StringBuilder.h>
 #include <LibTextCodec/Decoder.h>
 #include <LibWeb/DOM/Document.h>
@@ -391,7 +392,7 @@ void HTMLScriptElement::prepare_script()
 
                 // 3. Remove the first element from this list of scripts that will execute in order
                 //    as soon as possible.
-                (void)m_preparation_time_document->scripts_to_execute_as_soon_as_possible().take_first();
+                discard(m_preparation_time_document->scripts_to_execute_as_soon_as_possible().take_first());
 
                 // 4. If this list of scripts that will execute in order as soon as possible is still
                 //    not empty and the first entry has already been marked as ready, then jump back

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Unused.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLStyleElement.h>
@@ -81,7 +82,7 @@ static void create_a_css_style_sheet(DOM::Document& document, String type, DOM::
     sheet->set_title(move(title));
     sheet->set_alternate(alternate);
     sheet->set_origin_clean(origin_clean);
-    (void)location;
+    unused(location);
 
     // 2. Then run the add a CSS style sheet steps for the newly created CSS style sheet.
     add_a_css_style_sheet(document, move(sheet));

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/SourceLocation.h>
 #include <AK/Utf32View.h>
 #include <LibTextCodec/Decoder.h>
@@ -203,7 +204,7 @@ void HTMLParser::the_end()
 
     // 4. Pop all the nodes off the stack of open elements.
     while (!m_stack_of_open_elements.is_empty())
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
 
     // 5. While the list of scripts that will execute when the document has finished parsing is not empty:
     while (!m_document->scripts_to_execute_when_parsing_has_finished().is_empty()) {
@@ -218,7 +219,7 @@ void HTMLParser::the_end()
         m_document->scripts_to_execute_when_parsing_has_finished().first().execute_script();
 
         // 3. Remove the first script element from the list of scripts that will execute when the document has finished parsing (i.e. shift out the first entry in the list).
-        (void)m_document->scripts_to_execute_when_parsing_has_finished().take_first();
+        discard(m_document->scripts_to_execute_when_parsing_has_finished().take_first());
     }
 
     // 6. Queue a global task on the DOM manipulation task source given the Document's relevant global object to run the following substeps:
@@ -663,21 +664,21 @@ void HTMLParser::handle_in_head(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::base, HTML::TagNames::basefont, HTML::TagNames::bgsound, HTML::TagNames::link)) {
-        (void)insert_html_element(token);
-        (void)m_stack_of_open_elements.pop();
+        discard(insert_html_element(token));
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::meta) {
         auto element = insert_html_element(token);
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::title) {
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_tokenizer.switch_to({}, HTMLTokenizer::State::RCDATA);
         m_original_insertion_mode = m_insertion_mode;
         m_insertion_mode = InsertionMode::Text;
@@ -690,7 +691,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::noscript && !m_scripting_enabled) {
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_insertion_mode = InsertionMode::InHeadNoscript;
         return;
     }
@@ -718,7 +719,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
         return;
     }
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::head) {
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = InsertionMode::AfterHead;
         return;
     }
@@ -728,7 +729,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::template_) {
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_list_of_active_formatting_elements.add_marker();
         m_frameset_ok = false;
         m_insertion_mode = InsertionMode::InTemplate;
@@ -760,7 +761,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
     }
 
 AnythingElse:
-    (void)m_stack_of_open_elements.pop();
+    discard(m_stack_of_open_elements.pop());
     m_insertion_mode = InsertionMode::AfterHead;
     process_using_the_rules_for(m_insertion_mode, token);
 }
@@ -778,7 +779,7 @@ void HTMLParser::handle_in_head_noscript(HTMLToken& token)
     }
 
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::noscript) {
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = InsertionMode::InHead;
         return;
     }
@@ -799,14 +800,14 @@ void HTMLParser::handle_in_head_noscript(HTMLToken& token)
 
 AnythingElse:
     log_parse_error();
-    (void)m_stack_of_open_elements.pop();
+    discard(m_stack_of_open_elements.pop());
     m_insertion_mode = InsertionMode::InHead;
     process_using_the_rules_for(m_insertion_mode, token);
 }
 
 void HTMLParser::parse_generic_raw_text_element(HTMLToken& token)
 {
-    (void)insert_html_element(token);
+    discard(insert_html_element(token));
     m_tokenizer.switch_to({}, HTMLTokenizer::State::RAWTEXT);
     m_original_insertion_mode = m_insertion_mode;
     m_insertion_mode = InsertionMode::Text;
@@ -876,14 +877,14 @@ void HTMLParser::handle_after_head(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::body) {
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_frameset_ok = false;
         m_insertion_mode = InsertionMode::InBody;
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::frameset) {
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_insertion_mode = InsertionMode::InFrameset;
         return;
     }
@@ -913,7 +914,7 @@ void HTMLParser::handle_after_head(HTMLToken& token)
     }
 
 AnythingElse:
-    (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::body));
+    discard(insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::body)));
     m_insertion_mode = InsertionMode::InBody;
     process_using_the_rules_for(m_insertion_mode, token);
 }
@@ -921,13 +922,13 @@ AnythingElse:
 void HTMLParser::generate_implied_end_tags(const FlyString& exception)
 {
     while (current_node().local_name() != exception && current_node().local_name().is_one_of(HTML::TagNames::dd, HTML::TagNames::dt, HTML::TagNames::li, HTML::TagNames::optgroup, HTML::TagNames::option, HTML::TagNames::p, HTML::TagNames::rb, HTML::TagNames::rp, HTML::TagNames::rt, HTML::TagNames::rtc))
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
 }
 
 void HTMLParser::generate_all_implied_end_tags_thoroughly()
 {
     while (current_node().local_name().is_one_of(HTML::TagNames::caption, HTML::TagNames::colgroup, HTML::TagNames::dd, HTML::TagNames::dt, HTML::TagNames::li, HTML::TagNames::optgroup, HTML::TagNames::option, HTML::TagNames::p, HTML::TagNames::rb, HTML::TagNames::rp, HTML::TagNames::rt, HTML::TagNames::rtc, HTML::TagNames::tbody, HTML::TagNames::td, HTML::TagNames::tfoot, HTML::TagNames::th, HTML::TagNames::thead, HTML::TagNames::tr))
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
 }
 
 void HTMLParser::close_a_p_element()
@@ -1056,7 +1057,7 @@ HTMLParser::AdoptionAgencyAlgorithmOutcome HTMLParser::run_the_adoption_agency_a
     // and the current node is not in the list of active formatting elements,
     // then pop the current node off the stack of open elements, and return.
     if (current_node().local_name() == subject && !m_list_of_active_formatting_elements.contains(current_node())) {
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         return AdoptionAgencyAlgorithmOutcome::DoNothing;
     }
 
@@ -1083,8 +1084,8 @@ HTMLParser::AdoptionAgencyAlgorithmOutcome HTMLParser::run_the_adoption_agency_a
 
     if (!furthest_block) {
         while (&current_node() != formatting_element)
-            (void)m_stack_of_open_elements.pop();
-        (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
+        discard(m_stack_of_open_elements.pop());
 
         m_list_of_active_formatting_elements.remove(*formatting_element);
         return AdoptionAgencyAlgorithmOutcome::DoNothing;
@@ -1330,7 +1331,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::address, HTML::TagNames::article, HTML::TagNames::aside, HTML::TagNames::blockquote, HTML::TagNames::center, HTML::TagNames::details, HTML::TagNames::dialog, HTML::TagNames::dir, HTML::TagNames::div, HTML::TagNames::dl, HTML::TagNames::fieldset, HTML::TagNames::figcaption, HTML::TagNames::figure, HTML::TagNames::footer, HTML::TagNames::header, HTML::TagNames::hgroup, HTML::TagNames::main, HTML::TagNames::menu, HTML::TagNames::nav, HTML::TagNames::ol, HTML::TagNames::p, HTML::TagNames::section, HTML::TagNames::summary, HTML::TagNames::ul)) {
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
@@ -1339,9 +1340,9 @@ void HTMLParser::handle_in_body(HTMLToken& token)
             close_a_p_element();
         if (current_node().local_name().is_one_of(HTML::TagNames::h1, HTML::TagNames::h2, HTML::TagNames::h3, HTML::TagNames::h4, HTML::TagNames::h5, HTML::TagNames::h6)) {
             log_parse_error();
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
         }
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
@@ -1349,7 +1350,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
 
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
 
         m_frameset_ok = false;
 
@@ -1400,7 +1401,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
 
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
@@ -1429,14 +1430,14 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         }
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::plaintext) {
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_tokenizer.switch_to({}, HTMLTokenizer::State::PLAINTEXT);
         return;
     }
@@ -1448,7 +1449,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
             m_stack_of_open_elements.pop_until_an_element_with_tag_name_has_been_popped(HTML::TagNames::button);
         }
         reconstruct_the_active_formatting_elements();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_frameset_ok = false;
         return;
     }
@@ -1499,7 +1500,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::p) {
         if (!m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p)) {
             log_parse_error();
-            (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::p));
+            discard(insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::p)));
         }
         close_a_p_element();
         return;
@@ -1599,7 +1600,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::applet, HTML::TagNames::marquee, HTML::TagNames::object)) {
         reconstruct_the_active_formatting_elements();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_list_of_active_formatting_elements.add_marker();
         m_frameset_ok = false;
         return;
@@ -1625,7 +1626,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
             if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
                 close_a_p_element();
         }
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_frameset_ok = false;
         m_insertion_mode = InsertionMode::InTable;
         return;
@@ -1639,8 +1640,8 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::area, HTML::TagNames::br, HTML::TagNames::embed, HTML::TagNames::img, HTML::TagNames::keygen, HTML::TagNames::wbr)) {
     BRStartTag:
         reconstruct_the_active_formatting_elements();
-        (void)insert_html_element(token);
-        (void)m_stack_of_open_elements.pop();
+        discard(insert_html_element(token));
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         m_frameset_ok = false;
         return;
@@ -1648,8 +1649,8 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::input) {
         reconstruct_the_active_formatting_elements();
-        (void)insert_html_element(token);
-        (void)m_stack_of_open_elements.pop();
+        discard(insert_html_element(token));
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         auto type_attribute = token.attribute(HTML::AttributeNames::type);
         if (type_attribute.is_null() || !type_attribute.equals_ignoring_case("hidden")) {
@@ -1659,8 +1660,8 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::param, HTML::TagNames::source, HTML::TagNames::track)) {
-        (void)insert_html_element(token);
-        (void)m_stack_of_open_elements.pop();
+        discard(insert_html_element(token));
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
@@ -1668,8 +1669,8 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::hr) {
         if (m_stack_of_open_elements.has_in_button_scope(HTML::TagNames::p))
             close_a_p_element();
-        (void)insert_html_element(token);
-        (void)m_stack_of_open_elements.pop();
+        discard(insert_html_element(token));
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         m_frameset_ok = false;
         return;
@@ -1684,7 +1685,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::textarea) {
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
 
         m_tokenizer.switch_to({}, HTMLTokenizer::State::RCDATA);
 
@@ -1728,7 +1729,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::select) {
         reconstruct_the_active_formatting_elements();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_frameset_ok = false;
         switch (m_insertion_mode) {
         case InsertionMode::InTable:
@@ -1747,9 +1748,9 @@ void HTMLParser::handle_in_body(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::optgroup, HTML::TagNames::option)) {
         if (current_node().local_name() == HTML::TagNames::option)
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
         reconstruct_the_active_formatting_elements();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
@@ -1760,7 +1761,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         if (current_node().local_name() != HTML::TagNames::ruby)
             log_parse_error();
 
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
@@ -1771,7 +1772,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         if (current_node().local_name() != HTML::TagNames::rtc || current_node().local_name() != HTML::TagNames::ruby)
             log_parse_error();
 
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
@@ -1780,10 +1781,10 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         adjust_mathml_attributes(token);
         adjust_foreign_attributes(token);
 
-        (void)insert_foreign_element(token, Namespace::MathML);
+        discard(insert_foreign_element(token, Namespace::MathML));
 
         if (token.is_self_closing()) {
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
             token.acknowledge_self_closing_flag_if_set();
         }
         return;
@@ -1794,10 +1795,10 @@ void HTMLParser::handle_in_body(HTMLToken& token)
         adjust_svg_attributes(token);
         adjust_foreign_attributes(token);
 
-        (void)insert_foreign_element(token, Namespace::SVG);
+        discard(insert_foreign_element(token, Namespace::SVG));
 
         if (token.is_self_closing()) {
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
             token.acknowledge_self_closing_flag_if_set();
         }
         return;
@@ -1811,7 +1812,7 @@ void HTMLParser::handle_in_body(HTMLToken& token)
     // Any other start tag
     if (token.is_start_tag()) {
         reconstruct_the_active_formatting_elements();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
@@ -1826,9 +1827,9 @@ void HTMLParser::handle_in_body(HTMLToken& token)
                     log_parse_error();
                 }
                 while (&current_node() != node) {
-                    (void)m_stack_of_open_elements.pop();
+                    discard(m_stack_of_open_elements.pop());
                 }
-                (void)m_stack_of_open_elements.pop();
+                discard(m_stack_of_open_elements.pop());
                 break;
             }
             if (is_special_tag(node->local_name(), node->namespace_())) {
@@ -1983,7 +1984,7 @@ void HTMLParser::handle_text(HTMLToken& token)
         log_parse_error();
         if (current_node().local_name() == HTML::TagNames::script)
             verify_cast<HTMLScriptElement>(current_node()).set_already_started({}, true);
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = m_original_insertion_mode;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -1993,7 +1994,7 @@ void HTMLParser::handle_text(HTMLToken& token)
         flush_character_insertions();
 
         NonnullRefPtr<HTMLScriptElement> script = verify_cast<HTMLScriptElement>(current_node());
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = m_original_insertion_mode;
         // FIXME: Handle tokenizer insertion point stuff here.
         increment_script_nesting_level();
@@ -2053,7 +2054,7 @@ void HTMLParser::handle_text(HTMLToken& token)
     }
 
     if (token.is_end_tag()) {
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = m_original_insertion_mode;
         return;
     }
@@ -2063,7 +2064,7 @@ void HTMLParser::handle_text(HTMLToken& token)
 void HTMLParser::clear_the_stack_back_to_a_table_context()
 {
     while (!current_node().local_name().is_one_of(HTML::TagNames::table, HTML::TagNames::template_, HTML::TagNames::html))
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
 
     if (current_node().local_name() == HTML::TagNames::html)
         VERIFY(m_parsing_fragment);
@@ -2072,7 +2073,7 @@ void HTMLParser::clear_the_stack_back_to_a_table_context()
 void HTMLParser::clear_the_stack_back_to_a_table_row_context()
 {
     while (!current_node().local_name().is_one_of(HTML::TagNames::tr, HTML::TagNames::template_, HTML::TagNames::html))
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
 
     if (current_node().local_name() == HTML::TagNames::html)
         VERIFY(m_parsing_fragment);
@@ -2081,7 +2082,7 @@ void HTMLParser::clear_the_stack_back_to_a_table_row_context()
 void HTMLParser::clear_the_stack_back_to_a_table_body_context()
 {
     while (!current_node().local_name().is_one_of(HTML::TagNames::tbody, HTML::TagNames::tfoot, HTML::TagNames::thead, HTML::TagNames::template_, HTML::TagNames::html))
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
 
     if (current_node().local_name() == HTML::TagNames::html)
         VERIFY(m_parsing_fragment);
@@ -2091,7 +2092,7 @@ void HTMLParser::handle_in_row(HTMLToken& token)
 {
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::th, HTML::TagNames::td)) {
         clear_the_stack_back_to_a_table_row_context();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_insertion_mode = InsertionMode::InCell;
         m_list_of_active_formatting_elements.add_marker();
         return;
@@ -2103,7 +2104,7 @@ void HTMLParser::handle_in_row(HTMLToken& token)
             return;
         }
         clear_the_stack_back_to_a_table_row_context();
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = InsertionMode::InTableBody;
         return;
     }
@@ -2115,7 +2116,7 @@ void HTMLParser::handle_in_row(HTMLToken& token)
             return;
         }
         clear_the_stack_back_to_a_table_row_context();
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = InsertionMode::InTableBody;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2130,7 +2131,7 @@ void HTMLParser::handle_in_row(HTMLToken& token)
             return;
         }
         clear_the_stack_back_to_a_table_row_context();
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = InsertionMode::InTableBody;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2151,8 +2152,8 @@ void HTMLParser::close_the_cell()
         log_parse_error();
     }
     while (!current_node().local_name().is_one_of(HTML::TagNames::td, HTML::TagNames::th))
-        (void)m_stack_of_open_elements.pop();
-    (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
+    discard(m_stack_of_open_elements.pop());
     m_list_of_active_formatting_elements.clear_up_to_the_last_marker();
     m_insertion_mode = InsertionMode::InRow;
 }
@@ -2246,7 +2247,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
 {
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::tr) {
         clear_the_stack_back_to_a_table_body_context();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_insertion_mode = InsertionMode::InRow;
         return;
     }
@@ -2254,7 +2255,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::th, HTML::TagNames::td)) {
         log_parse_error();
         clear_the_stack_back_to_a_table_body_context();
-        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tr));
+        discard(insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tr)));
         m_insertion_mode = InsertionMode::InRow;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2266,7 +2267,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
             return;
         }
         clear_the_stack_back_to_a_table_body_context();
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = InsertionMode::InTable;
         return;
     }
@@ -2282,7 +2283,7 @@ void HTMLParser::handle_in_table_body(HTMLToken& token)
         }
 
         clear_the_stack_back_to_a_table_body_context();
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = InsertionMode::InTable;
         process_using_the_rules_for(InsertionMode::InTable, token);
         return;
@@ -2316,32 +2317,32 @@ void HTMLParser::handle_in_table(HTMLToken& token)
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::caption) {
         clear_the_stack_back_to_a_table_context();
         m_list_of_active_formatting_elements.add_marker();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_insertion_mode = InsertionMode::InCaption;
         return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::colgroup) {
         clear_the_stack_back_to_a_table_context();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_insertion_mode = InsertionMode::InColumnGroup;
         return;
     }
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::col) {
         clear_the_stack_back_to_a_table_context();
-        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::colgroup));
+        discard(insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::colgroup)));
         m_insertion_mode = InsertionMode::InColumnGroup;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
     }
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::tbody, HTML::TagNames::tfoot, HTML::TagNames::thead)) {
         clear_the_stack_back_to_a_table_context();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         m_insertion_mode = InsertionMode::InTableBody;
         return;
     }
     if (token.is_start_tag() && token.tag_name().is_one_of(HTML::TagNames::td, HTML::TagNames::th, HTML::TagNames::tr)) {
         clear_the_stack_back_to_a_table_context();
-        (void)insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tbody));
+        discard(insert_html_element(HTMLToken::make_start_tag(HTML::TagNames::tbody)));
         m_insertion_mode = InsertionMode::InTableBody;
         process_using_the_rules_for(m_insertion_mode, token);
         return;
@@ -2384,12 +2385,12 @@ void HTMLParser::handle_in_table(HTMLToken& token)
         }
 
         log_parse_error();
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
 
         // FIXME: Is this the correct interpretation of "Pop that input element off the stack of open elements."?
         //        Because this wording is the first time it's seen in the spec.
         //        Other times it's worded as: "Immediately pop the current node off the stack of open elements."
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
@@ -2402,7 +2403,7 @@ void HTMLParser::handle_in_table(HTMLToken& token)
         m_form_element = verify_cast<HTMLFormElement>(*insert_html_element(token));
 
         // FIXME: See previous FIXME, as this is the same situation but for form.
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         return;
     }
     if (token.is_end_of_file()) {
@@ -2470,29 +2471,29 @@ void HTMLParser::handle_in_select(HTMLToken& token)
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::option) {
         if (current_node().local_name() == HTML::TagNames::option) {
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
         }
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::optgroup) {
         if (current_node().local_name() == HTML::TagNames::option) {
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
         }
         if (current_node().local_name() == HTML::TagNames::optgroup) {
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
         }
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::optgroup) {
         if (current_node().local_name() == HTML::TagNames::option && node_before_current_node().local_name() == HTML::TagNames::optgroup)
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
 
         if (current_node().local_name() == HTML::TagNames::optgroup) {
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
         } else {
             log_parse_error();
             return;
@@ -2502,7 +2503,7 @@ void HTMLParser::handle_in_select(HTMLToken& token)
 
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::option) {
         if (current_node().local_name() == HTML::TagNames::option) {
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
         } else {
             log_parse_error();
             return;
@@ -2639,8 +2640,8 @@ void HTMLParser::handle_in_column_group(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::col) {
-        (void)insert_html_element(token);
-        (void)m_stack_of_open_elements.pop();
+        discard(insert_html_element(token));
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
@@ -2651,7 +2652,7 @@ void HTMLParser::handle_in_column_group(HTMLToken& token)
             return;
         }
 
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         m_insertion_mode = InsertionMode::InTable;
         return;
     }
@@ -2676,7 +2677,7 @@ void HTMLParser::handle_in_column_group(HTMLToken& token)
         return;
     }
 
-    (void)m_stack_of_open_elements.pop();
+    discard(m_stack_of_open_elements.pop());
     m_insertion_mode = InsertionMode::InTable;
     process_using_the_rules_for(m_insertion_mode, token);
 }
@@ -2782,14 +2783,14 @@ void HTMLParser::handle_in_frameset(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::frameset) {
-        (void)insert_html_element(token);
+        discard(insert_html_element(token));
         return;
     }
 
     if (token.is_end_tag() && token.tag_name() == HTML::TagNames::frameset) {
         // FIXME: If the current node is the root html element, then this is a parse error; ignore the token. (fragment case)
 
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
 
         if (!m_parsing_fragment && current_node().local_name() != HTML::TagNames::frameset) {
             m_insertion_mode = InsertionMode::AfterFrameset;
@@ -2798,8 +2799,8 @@ void HTMLParser::handle_in_frameset(HTMLToken& token)
     }
 
     if (token.is_start_tag() && token.tag_name() == HTML::TagNames::frame) {
-        (void)insert_html_element(token);
-        (void)m_stack_of_open_elements.pop();
+        discard(insert_html_element(token));
+        discard(m_stack_of_open_elements.pop());
         token.acknowledge_self_closing_flag_if_set();
         return;
     }
@@ -2921,7 +2922,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
         while (!is_mathml_text_integration_point(current_node())
             && !is_html_integration_point(current_node())
             && current_node().namespace_() != Namespace::HTML) {
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
         }
 
         // Reprocess the token according to the rules given in the section corresponding to the current insertion mode in HTML content.
@@ -2939,7 +2940,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
         }
 
         adjust_foreign_attributes(token);
-        (void)insert_foreign_element(token, adjusted_current_node().namespace_());
+        discard(insert_foreign_element(token, adjusted_current_node().namespace_()));
 
         if (token.is_self_closing()) {
             if (token.tag_name() == SVG::TagNames::script && current_node().namespace_() == Namespace::SVG) {
@@ -2947,7 +2948,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
                 goto ScriptEndTag;
             }
 
-            (void)m_stack_of_open_elements.pop();
+            discard(m_stack_of_open_elements.pop());
             token.acknowledge_self_closing_flag_if_set();
         }
 
@@ -2956,7 +2957,7 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
 
     if (token.is_end_tag() && current_node().namespace_() == Namespace::SVG && current_node().tag_name() == SVG::TagNames::script) {
     ScriptEndTag:
-        (void)m_stack_of_open_elements.pop();
+        discard(m_stack_of_open_elements.pop());
         TODO();
     }
 
@@ -2973,8 +2974,8 @@ void HTMLParser::process_using_the_rules_for_foreign_content(HTMLToken& token)
             // FIXME: See the above FIXME
             if (node->tag_name().to_lowercase() == token.tag_name()) {
                 while (current_node() != node)
-                    (void)m_stack_of_open_elements.pop();
-                (void)m_stack_of_open_elements.pop();
+                    discard(m_stack_of_open_elements.pop());
+                discard(m_stack_of_open_elements.pop());
                 return;
             }
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/StackOfOpenElements.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
 #include <LibWeb/HTML/Parser/StackOfOpenElements.h>
@@ -96,8 +97,8 @@ bool StackOfOpenElements::contains(const FlyString& tag_name) const
 void StackOfOpenElements::pop_until_an_element_with_tag_name_has_been_popped(const FlyString& tag_name)
 {
     while (m_elements.last().local_name() != tag_name)
-        (void)pop();
-    (void)pop();
+        discard(pop());
+    discard(pop());
 }
 
 DOM::Element* StackOfOpenElements::topmost_special_node_below(const DOM::Element& formatting_element)

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Unused.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibJS/Interpreter.h>
 #include <LibWeb/HTML/Scripting/ClassicScript.h>
@@ -66,7 +67,7 @@ JS::Value ClassicScript::run(RethrowErrors rethrow_errors)
     }
 
     dbgln("ClassicScript: Running script {}", filename());
-    (void)rethrow_errors;
+    unused(rethrow_errors);
 
     auto timer = Core::ElapsedTimer::start_new();
 

--- a/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
+++ b/Userland/Libraries/LibWeb/IntersectionObserver/IntersectionObserver.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Unused.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/IntersectionObserver/IntersectionObserver.h>
 
@@ -13,9 +14,9 @@ namespace Web::IntersectionObserver {
 NonnullRefPtr<IntersectionObserver> IntersectionObserver::create_with_global_object(JS::GlobalObject& global_object, JS::Value callback, IntersectionObserverInit const& options)
 {
     // FIXME: Implement
-    (void)global_object;
-    (void)callback;
-    (void)options;
+    unused(global_object);
+    unused(callback);
+    unused(options);
 
     return adopt_ref(*new IntersectionObserver);
 }
@@ -24,14 +25,14 @@ NonnullRefPtr<IntersectionObserver> IntersectionObserver::create_with_global_obj
 void IntersectionObserver::observe(DOM::Element& target)
 {
     // FIXME: Implement
-    (void)target;
+    unused(target);
 }
 
 // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-unobserve
 void IntersectionObserver::unobserve(DOM::Element& target)
 {
     // FIXME: Implement
-    (void)target;
+    unused(target);
 }
 
 // https://w3c.github.io/IntersectionObserver/#dom-intersectionobserver-disconnect

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/HTML/BrowsingContext.h>
@@ -410,7 +411,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer& block_c
         if (is<ReplacedBox>(child_box) || is<BlockContainer>(child_box))
             place_block_level_element_in_normal_flow_vertically(child_box, block_container);
 
-        (void)layout_inside(child_box, layout_mode);
+        discard(layout_inside(child_box, layout_mode));
         compute_height(child_box);
 
         if (child_box.computed_values().position() == CSS::Position::Relative)
@@ -565,7 +566,7 @@ void BlockFormattingContext::layout_floating_child(Box& box, BlockContainer cons
     VERIFY(box.is_floating());
 
     compute_width(box);
-    (void)layout_inside(box, LayoutMode::Default);
+    discard(layout_inside(box, LayoutMode::Default));
     compute_height(box);
 
     // First we place the box normally (to get the right y coordinate.)

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "InlineFormattingContext.h"
+#include <AK/Discard.h>
 #include <AK/Function.h>
 #include <AK/StdLibExtras.h>
 #include <LibWeb/Layout/BlockContainer.h>
@@ -156,7 +157,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
     }
 
     flex_container().for_each_child_of_type<Box>([&](Box& child_box) {
-        (void)layout_inside(child_box, LayoutMode::Default);
+        discard(layout_inside(child_box, LayoutMode::Default));
         // Skip anonymous text runs that are only whitespace.
         if (child_box.is_anonymous() && !child_box.first_child_of_type<BlockContainer>()) {
             bool contains_only_white_space = true;
@@ -466,7 +467,7 @@ float FlexFormattingContext::layout_for_maximum_main_size(Box& box)
         }
     }
     if (is_row_layout()) {
-        (void)layout_inside(box, LayoutMode::OnlyRequiredLineBreaks);
+        discard(layout_inside(box, LayoutMode::OnlyRequiredLineBreaks));
         return box.width();
     } else {
         return BlockFormattingContext::compute_theoretical_height(box);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibWeb/Dump.h>
 #include <LibWeb/Layout/BlockFormattingContext.h>
 #include <LibWeb/Layout/Box.h>
@@ -137,13 +138,13 @@ FormattingContext::ShrinkToFitResult FormattingContext::calculate_shrink_to_fit_
 {
     // Calculate the preferred width by formatting the content without breaking lines
     // other than where explicit line breaks occur.
-    (void)layout_inside(box, LayoutMode::OnlyRequiredLineBreaks);
+    discard(layout_inside(box, LayoutMode::OnlyRequiredLineBreaks));
     float preferred_width = greatest_child_width(box);
 
     // Also calculate the preferred minimum width, e.g., by trying all possible line breaks.
     // CSS 2.2 does not define the exact algorithm.
 
-    (void)layout_inside(box, LayoutMode::AllPossibleLineBreaks);
+    discard(layout_inside(box, LayoutMode::AllPossibleLineBreaks));
     float preferred_minimum_width = greatest_child_width(box);
 
     return { preferred_width, preferred_minimum_width };
@@ -616,7 +617,7 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     auto specified_width = box.computed_values().width().resolved(width_of_containing_block).resolved_or_auto(box);
 
     compute_width_for_absolutely_positioned_element(box);
-    (void)layout_inside(box, LayoutMode::Default);
+    discard(layout_inside(box, LayoutMode::Default));
     compute_height_for_absolutely_positioned_element(box);
 
     box_model.margin.left = box.computed_values().margin().left.resolved(width_of_containing_block).resolved_or_auto(box).to_px(box);

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/Dump.h>
@@ -141,7 +142,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             auto container_width = CSS::Length::make_px(containing_block().width());
             inline_block.set_width(inline_block.computed_values().width().resolved(container_width).resolved_or_zero(inline_block).to_px(inline_block));
         }
-        (void)layout_inside(inline_block, layout_mode);
+        discard(layout_inside(inline_block, layout_mode));
 
         if (inline_block.computed_values().height().is_length() && inline_block.computed_values().height().length().is_undefined_or_auto()) {
             // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibWeb/DOM/Node.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Layout/Box.h>
@@ -76,9 +77,9 @@ void TableFormattingContext::calculate_column_widths(Box& row, Vector<float>& co
     row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
         compute_width(cell);
         if (use_auto_layout) {
-            (void)layout_inside(cell, LayoutMode::OnlyRequiredLineBreaks);
+            discard(layout_inside(cell, LayoutMode::OnlyRequiredLineBreaks));
         } else {
-            (void)layout_inside(cell, LayoutMode::Default);
+            discard(layout_inside(cell, LayoutMode::Default));
         }
         column_widths[column_index] = max(column_widths[column_index], cell.width());
         column_index += cell.colspan();
@@ -98,9 +99,9 @@ void TableFormattingContext::layout_row(Box& row, Vector<float>& column_widths)
 
         // Layout the cell contents a second time, now that we know its final width.
         if (use_auto_layout) {
-            (void)layout_inside(cell, LayoutMode::OnlyRequiredLineBreaks);
+            discard(layout_inside(cell, LayoutMode::OnlyRequiredLineBreaks));
         } else {
-            (void)layout_inside(cell, LayoutMode::Default);
+            discard(layout_inside(cell, LayoutMode::Default));
         }
 
         size_t cell_colspan = cell.colspan();

--- a/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
+++ b/Userland/Libraries/LibWeb/ResizeObserver/ResizeObserver.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Unused.h>
 #include <LibWeb/DOM/Element.h>
 #include <LibWeb/ResizeObserver/ResizeObserver.h>
 
@@ -13,8 +14,8 @@ namespace Web::ResizeObserver {
 NonnullRefPtr<ResizeObserver> ResizeObserver::create_with_global_object(JS::GlobalObject& global_object, JS::Value callback)
 {
     // FIXME: Implement
-    (void)global_object;
-    (void)callback;
+    unused(global_object);
+    unused(callback);
     return adopt_ref(*new ResizeObserver);
 }
 
@@ -22,15 +23,15 @@ NonnullRefPtr<ResizeObserver> ResizeObserver::create_with_global_object(JS::Glob
 void ResizeObserver::observe(DOM::Element& target, ResizeObserverOptions options)
 {
     // FIXME: Implement
-    (void)target;
-    (void)options;
+    unused(target);
+    unused(options);
 }
 
 // https://drafts.csswg.org/resize-observer/#dom-resizeobserver-unobserve
 void ResizeObserver::unobserve(DOM::Element& target)
 {
     // FIXME: Implement
-    (void)target;
+    unused(target);
 }
 
 // https://drafts.csswg.org/resize-observer/#dom-resizeobserver-disconnect

--- a/Userland/Libraries/LibWeb/Selection/Selection.cpp
+++ b/Userland/Libraries/LibWeb/Selection/Selection.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Unused.h>
 #include <LibWeb/Selection/Selection.h>
 
 namespace Web::Selection {
@@ -50,7 +51,7 @@ String Selection::type() const
 
 NonnullRefPtr<DOM::Range> Selection::get_range_at(unsigned index)
 {
-    (void)index;
+    unused(index);
     TODO();
 }
 
@@ -76,13 +77,13 @@ void Selection::empty()
 
 void Selection::collapse(DOM::Node*, unsigned offset)
 {
-    (void)offset;
+    unused(offset);
     TODO();
 }
 
 void Selection::set_position(DOM::Node*, unsigned offset)
 {
-    (void)offset;
+    unused(offset);
     TODO();
 }
 
@@ -98,16 +99,16 @@ void Selection::collapse_to_end()
 
 void Selection::extend(DOM::Node&, unsigned offset)
 {
-    (void)offset;
+    unused(offset);
     TODO();
 }
 
 void Selection::set_base_and_extent(DOM::Node& anchor_node, unsigned anchor_offset, DOM::Node& focus_node, unsigned focus_offset)
 {
-    (void)anchor_node;
-    (void)anchor_offset;
-    (void)focus_node;
-    (void)focus_offset;
+    unused(anchor_node);
+    unused(anchor_offset);
+    unused(focus_node);
+    unused(focus_offset);
     TODO();
 }
 
@@ -123,7 +124,7 @@ void Selection::delete_from_document()
 
 bool Selection::contains_node(DOM::Node&, bool allow_partial_containment) const
 {
-    (void)allow_partial_containment;
+    unused(allow_partial_containment);
     TODO();
 }
 

--- a/Userland/Libraries/LibWeb/TreeNode.h
+++ b/Userland/Libraries/LibWeb/TreeNode.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
+#include <AK/Discard.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/TypeCasts.h>
 #include <AK/Weakable.h>
@@ -495,7 +496,7 @@ inline void TreeNode<T>::append_child(NonnullRefPtr<T> node)
     m_last_child = node.ptr();
     if (!m_first_child)
         m_first_child = m_last_child;
-    [[maybe_unused]] auto& rc = node.leak_ref();
+    discard(node.leak_ref());
 }
 
 template<typename T>
@@ -519,7 +520,7 @@ inline void TreeNode<T>::insert_before(NonnullRefPtr<T> node, RefPtr<T> child)
     child->m_previous_sibling = node;
 
     node->m_parent = static_cast<T*>(this);
-    [[maybe_unused]] auto& rc = node.leak_ref();
+    discard(node.leak_ref());
 }
 
 template<typename T>
@@ -538,7 +539,7 @@ inline void TreeNode<T>::prepend_child(NonnullRefPtr<T> node)
     if (!m_last_child)
         m_last_child = m_first_child;
     node->inserted_into(static_cast<T&>(*this));
-    [[maybe_unused]] auto& rc = node.leak_ref();
+    discard(node.leak_ref());
 
     static_cast<T*>(this)->children_changed();
 }

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyObject.cpp
@@ -11,6 +11,7 @@
 #include "WebAssemblyModulePrototype.h"
 #include "WebAssemblyTableObject.h"
 #include "WebAssemblyTablePrototype.h"
+#include <AK/Discard.h>
 #include <AK/ScopeGuard.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
@@ -104,7 +105,7 @@ JS_DEFINE_NATIVE_FUNCTION(WebAssemblyObject::validate)
     // Drop the module from the cache, we're never going to refer to it.
     ScopeGuard drop_from_cache {
         [&] {
-            (void)s_compiled_modules.take_last();
+            discard(s_compiled_modules.take_last());
         }
     };
 

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Mixer.h"
+#include <AK/Discard.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/System.h>
@@ -28,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     server->on_accept = [&](NonnullOwnPtr<Core::Stream::LocalSocket> client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
-        (void)IPC::new_client_connection<AudioServer::ClientConnection>(move(client_socket), client_id, *mixer);
+        discard(IPC::new_client_connection<AudioServer::ClientConnection>(move(client_socket), client_id, *mixer));
     };
 
     TRY(Core::System::pledge("stdio recvfd thread accept cpath rpath wpath"));

--- a/Userland/Services/InspectorServer/InspectableProcess.cpp
+++ b/Userland/Services/InspectorServer/InspectableProcess.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "InspectableProcess.h"
+#include <AK/Discard.h>
 #include <AK/JsonObject.h>
 
 namespace InspectorServer {
@@ -25,7 +26,7 @@ InspectableProcess::InspectableProcess(pid_t pid, NonnullOwnPtr<Core::Stream::Lo
 
     m_socket->on_ready_to_read = [this] {
         char c;
-        [[maybe_unused]] auto buffer = m_socket->read({ &c, 1 });
+        discard(m_socket->read({ &c, 1 }));
         if (m_socket->is_eof()) {
             g_processes.remove(m_pid);
             return;

--- a/Userland/Services/RequestServer/ClientConnection.cpp
+++ b/Userland/Services/RequestServer/ClientConnection.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Badge.h>
+#include <AK/Discard.h>
 #include <RequestServer/ClientConnection.h>
 #include <RequestServer/Protocol.h>
 #include <RequestServer/Request.h>
@@ -121,7 +122,7 @@ void ClientConnection::ensure_connection(URL const& url, ::RequestServer::CacheL
     if (cache_level == CacheLevel::ResolveOnly) {
         return Core::deferred_invoke([host = url.host()] {
             dbgln("EnsureConnection: DNS-preload for {}", host);
-            (void)gethostbyname(host.characters());
+            discard(gethostbyname(host.characters()));
         });
     }
 

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/OwnPtr.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
@@ -24,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::pledge("stdio inet accept unix rpath sendfd recvfd"));
 
     // Ensure the certificates are read out here.
-    [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
+    discard(DefaultRootCACertificates::the());
 
     Core::EventLoop event_loop;
     // FIXME: Establish a connection to LookupServer and then drop "unix"?
@@ -32,9 +33,9 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    [[maybe_unused]] auto gemini = make<RequestServer::GeminiProtocol>();
-    [[maybe_unused]] auto http = make<RequestServer::HttpProtocol>();
-    [[maybe_unused]] auto https = make<RequestServer::HttpsProtocol>();
+    discard(make<RequestServer::GeminiProtocol>());
+    discard(make<RequestServer::HttpProtocol>());
+    discard(make<RequestServer::HttpsProtocol>());
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<RequestServer::ClientConnection>());
 

--- a/Userland/Services/TelnetServer/main.cpp
+++ b/Userland/Services/TelnetServer/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "Client.h"
+#include <AK/Discard.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
 #include <AK/Types.h>
@@ -35,13 +36,13 @@ static void run_command(int ptm_fd, String command)
         }
 
         // NOTE: It's okay if this fails.
-        [[maybe_unused]] auto rc = ioctl(0, TIOCNOTTY);
+        discard(ioctl(0, TIOCNOTTY));
 
         close(0);
         close(1);
         close(2);
 
-        rc = dup2(pts_fd, 0);
+        int rc = dup2(pts_fd, 0);
         if (rc < 0) {
             perror("dup2");
             exit(1);

--- a/Userland/Services/WebSocket/main.cpp
+++ b/Userland/Services/WebSocket/main.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/LocalServer.h>
 #include <LibCore/System.h>
@@ -17,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::pledge("stdio inet unix rpath sendfd recvfd"));
 
     // Ensure the certificates are read out here.
-    [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
+    discard(DefaultRootCACertificates::the());
 
     Core::EventLoop event_loop;
     // FIXME: Establish a connection to LookupServer and then drop "unix"?

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -14,6 +14,7 @@
 #include "Window.h"
 #include "WindowManager.h"
 #include <AK/Debug.h>
+#include <AK/Discard.h>
 #include <AK/Memory.h>
 #include <AK/ScopeGuard.h>
 #include <LibCore/Timer.h>
@@ -807,7 +808,7 @@ bool Compositor::set_wallpaper_mode(const String& mode)
 
 bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callback)
 {
-    (void)Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
+    discard(Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
         [path](auto&) {
             return Gfx::Bitmap::try_load_from_file(path);
         },
@@ -824,7 +825,7 @@ bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callba
                 m_wallpaper = bitmap.release_value();
             invalidate_screen();
             callback(true);
-        });
+        }));
     return true;
 }
 

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -7,6 +7,7 @@
 #include "AST.h"
 #include "Shell.h"
 #include "Shell/Formatter.h"
+#include <AK/Discard.h>
 #include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
 #include <AK/Statistics.h>
@@ -844,7 +845,7 @@ int Shell::builtin_shift(int argc, const char** argv)
     }
 
     for (auto i = 0; i < count; ++i)
-        (void)values.take_first();
+        discard(values.take_first());
 
     return 0;
 }

--- a/Userland/Utilities/matroska.cpp
+++ b/Userland/Utilities/matroska.cpp
@@ -45,7 +45,6 @@ int main(int, char**)
 
         outln("\tCluster has {} blocks", cluster.blocks().size());
         for (auto const& block : cluster.blocks()) {
-            (void)block;
             outln("\t\tBlock for track #{} has {} frames", block.track_number(), block.frame_count());
             outln("\t\tBlock's timestamp is {}", block.timestamp());
             outln("\t\tBlock has lacing {}", static_cast<u8>(block.lacing()));

--- a/Userland/Utilities/profile.cpp
+++ b/Userland/Utilities/profile.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <LibCore/ArgsParser.h>
 #include <serenity.h>
 #include <stdio.h>
@@ -94,7 +95,7 @@ int main(int argc, char** argv)
 
         if (wait) {
             outln("Profiling enabled, waiting for user input to disable...");
-            (void)getchar();
+            discard(getchar());
         }
 
         if (wait || disable) {

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Discard.h>
 #include <AK/LexicalPath.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
@@ -235,9 +236,9 @@ FileResult TestRunner::run_test_file(const String& test_path)
     String dirname = path_for_test.dirname();
     String basename = path_for_test.basename();
 
-    (void)posix_spawn_file_actions_adddup2(&file_actions, child_out_err_file, STDOUT_FILENO);
-    (void)posix_spawn_file_actions_adddup2(&file_actions, child_out_err_file, STDERR_FILENO);
-    (void)posix_spawn_file_actions_addchdir(&file_actions, dirname.characters());
+    discard(posix_spawn_file_actions_adddup2(&file_actions, child_out_err_file, STDOUT_FILENO));
+    discard(posix_spawn_file_actions_adddup2(&file_actions, child_out_err_file, STDERR_FILENO));
+    discard(posix_spawn_file_actions_addchdir(&file_actions, dirname.characters()));
 
     Vector<const char*, 4> argv;
     argv.append(basename.characters());

--- a/Userland/Utilities/test-pthread.cpp
+++ b/Userland/Utilities/test-pthread.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/Discard.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <LibThreading/Thread.h>
 #include <errno.h>
@@ -31,7 +32,7 @@ static void test_once()
         threads.last().start();
     }
     for (auto& thread : threads)
-        [[maybe_unused]] auto res = thread.join();
+        discard(thread.join());
 
     VERIFY(v.size() == 1);
 }
@@ -59,7 +60,7 @@ static void test_mutex()
         threads.last().start();
     }
     for (auto& thread : threads)
-        [[maybe_unused]] auto res = thread.join();
+        discard(thread.join());
 
     VERIFY(v.size() == threads_count * num_times);
     VERIFY(pthread_mutex_trylock(&mutex) == 0);
@@ -90,7 +91,7 @@ static void test_semaphore_as_lock()
         threads.last().start();
     }
     for (auto& thread : threads)
-        [[maybe_unused]] auto res = thread.join();
+        discard(thread.join());
 
     VERIFY(v.size() == threads_count * num_times);
     VERIFY(sem_trywait(&semaphore) == 0);
@@ -118,8 +119,8 @@ static void test_semaphore_as_event()
     });
     writer->start();
 
-    [[maybe_unused]] auto r1 = reader->join();
-    [[maybe_unused]] auto r2 = writer->join();
+    discard(reader->join());
+    discard(writer->join());
 
     VERIFY(sem_trywait(&semaphore) == EAGAIN);
 }
@@ -155,7 +156,7 @@ static void test_semaphore_nonbinary()
     }
 
     for (auto& thread : threads)
-        [[maybe_unused]] auto res = thread.join();
+        discard(thread.join());
 
     VERIFY(value.load() == 0);
     VERIFY(seen_more_than_two.load());


### PR DESCRIPTION
Currently in the code, the C void cast `(void)` trick is used in the code to hide some warnings.
I propose to add of this header to centralize attributes modifiers. Here, it adds some helper functions/macros that helps to make the code auto document the different usage of the void casting trick and package them in a nice searchable names.

