### PR TITLE
AK: Zero-pad automatically if formatting with precision

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -443,6 +443,7 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
                 } else {
                     if (!state.has_fraction_length) {
                         state.has_fraction_length = true;
+                        state.zero_pad = true;
                         state.fraction_length = 0;
                     }
                     state.fraction_length *= 10;
@@ -454,6 +455,7 @@ ALWAYS_INLINE int printf_internal(PutChFunc putch, char* buffer, const char*& fm
             if (*p == '*') {
                 if (state.dot) {
                     state.has_fraction_length = true;
+                    state.zero_pad = true;
                     state.fraction_length = NextArgument<int>()(ap);
                 } else {
                     state.field_width = NextArgument<int>()(ap);


### PR DESCRIPTION
Previously, the `git clone` progress indicator (printed by `%u.%2.2u`) would look like this, since we haven't enabled zero-padding when a precision is given:

```
Unpacking objects: 100% (4/4), 398 bytes | 9. 9 KiB/s, done.
```

Now, it looks like this:

```
Unpacking objects: 100% (4/4), 398 bytes | 9.09 KiB/s, done.
```