### PR TITLE
LibJS+LibUnicode: Implement (most of) Intl.DateTimeFormat.prototype.format[ToParts]

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -499,11 +499,11 @@ static void generate_missing_patterns(Calendar& calendar, Vector<CalendarPattern
                 format.pattern12_index = replace_pattern(format.pattern_index, time_format.pattern12_index, date_format.pattern_index);
             format.pattern_index = replace_pattern(format.pattern_index, time_format.pattern_index, date_format.pattern_index);
 
-            format.for_each_calendar_field_zipped_with(date_format, [](auto& field, auto const& date_field) {
+            format.for_each_calendar_field_zipped_with(date_format, [](auto& field, auto const& date_field, auto) {
                 if (date_field.has_value())
                     field = date_field;
             });
-            format.for_each_calendar_field_zipped_with(time_format, [](auto& field, auto const& time_field) {
+            format.for_each_calendar_field_zipped_with(time_format, [](auto& field, auto const& time_field, auto) {
                 if (time_field.has_value())
                     field = time_field;
             });

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -368,13 +368,6 @@ static Optional<CalendarPatternIndexType> parse_date_time_pattern(String pattern
         else if (all_of(segment, is_any_of("ab"sv))) {
             builder.append("{ampm}");
             hour12 = true;
-
-            if (segment.length() == 4)
-                format.day_period = CalendarPatternStyle::Long;
-            else if (segment.length() == 5)
-                format.day_period = CalendarPatternStyle::Narrow;
-            else
-                format.day_period = CalendarPatternStyle::Short;
         } else if (all_of(segment, is_char('B'))) {
             builder.append("{dayPeriod}");
             hour12 = true;

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -302,7 +302,7 @@ template<typename LocalesType, typename ListFormatter>
 void generate_mapping(SourceGenerator& generator, LocalesType const& locales, StringView type, StringView name, StringView format, ListFormatter&& format_list)
 {
     auto format_mapping_name = [](StringView format, StringView name) {
-        auto mapping_name = name.to_lowercase_string().replace("-"sv, "_"sv, true);
+        auto mapping_name = name.to_lowercase_string().replace("-"sv, "_"sv, true).replace("/"sv, "_"sv, true);
         return String::formatted(format, mapping_name);
     };
 

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCES
     Runtime/Intl/AbstractOperations.cpp
     Runtime/Intl/DateTimeFormat.cpp
     Runtime/Intl/DateTimeFormatConstructor.cpp
+    Runtime/Intl/DateTimeFormatFunction.cpp
     Runtime/Intl/DateTimeFormatPrototype.cpp
     Runtime/Intl/DisplayNames.cpp
     Runtime/Intl/DisplayNamesConstructor.cpp

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -389,4 +389,19 @@ Value make_date(Value day, Value time)
     return tv;
 }
 
+// 21.4.1.14 TimeClip ( time ), https://tc39.es/ecma262/#sec-timeclip
+Value time_clip(GlobalObject& global_object, Value time)
+{
+    // 1. If time is not finite, return NaN.
+    if (!time.is_finite_number())
+        return js_nan();
+
+    // 2. If abs(ℝ(time)) > 8.64 × 10^15, return NaN.
+    if (fabs(time.as_double()) > 8.64E15)
+        return js_nan();
+
+    // 3. Return 𝔽(! ToIntegerOrInfinity(time)).
+    return Value(MUST(time.to_integer_or_infinity(global_object)));
+}
+
 }

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -307,6 +307,13 @@ u16 ms_from_time(double t)
     return static_cast<u16>(modulo(t, MS_PER_SECOND));
 }
 
+// 21.4.1.6 Week Day, https://tc39.es/ecma262/#sec-week-day
+u8 week_day(double t)
+{
+    // 𝔽(ℝ(Day(t) + 4𝔽) modulo 7)
+    return static_cast<u8>(modulo(day(t) + 4, 7.0));
+}
+
 // 21.4.1.11 MakeTime ( hour, min, sec, ms ), https://tc39.es/ecma262/#sec-maketime
 Value make_time(GlobalObject& global_object, Value hour, Value min, Value sec, Value ms)
 {

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -102,5 +102,6 @@ double day(double);
 Value make_time(GlobalObject& global_object, Value hour, Value min, Value sec, Value ms);
 Value make_day(GlobalObject& global_object, Value year, Value month, Value date);
 Value make_date(Value day, Value time);
+Value time_clip(GlobalObject& global_object, Value time);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -98,6 +98,7 @@ u8 hour_from_time(double);
 u8 min_from_time(double);
 u8 sec_from_time(double);
 u16 ms_from_time(double);
+u8 week_day(double);
 double day(double);
 Value make_time(GlobalObject& global_object, Value hour, Value min, Value sec, Value ms);
 Value make_day(GlobalObject& global_object, Value year, Value month, Value date);

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -37,6 +37,7 @@
     M(InstanceOfOperatorBadPrototype, "'prototype' property of {} is not an object")                                                    \
     M(IntlInvalidDateTimeFormatOption, "Option {} cannot be set when also providing {}")                                                \
     M(IntlInvalidLanguageTag, "{} is not a structurally valid language tag")                                                            \
+    M(IntlInvalidTime, "Time value must be between -8.64E15 and 8.64E15")                                                               \
     M(IntlMinimumExceedsMaximum, "Minimum value {} is larger than maximum value {}")                                                    \
     M(IntlNumberIsNaNOrOutOfRange, "Value {} is NaN or is not between {} and {}")                                                       \
     M(IntlOptionUndefined, "Option {} must be defined when option {} is {}")                                                            \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -287,6 +287,7 @@ void GlobalObject::initialize_global_object()
     m_async_generator_function_prototype->define_direct_property(vm.names.constructor, m_async_generator_function_constructor, Attribute::Configurable);
 
     m_array_prototype_values_function = &m_array_prototype->get_without_side_effects(vm.names.values).as_function();
+    m_date_constructor_now_function = &m_date_constructor->get_without_side_effects(vm.names.now).as_function();
     m_eval_function = &get_without_side_effects(vm.names.eval).as_function();
 }
 
@@ -304,6 +305,7 @@ void GlobalObject::visit_edges(Visitor& visitor)
     visitor.visit(m_proxy_constructor);
     visitor.visit(m_generator_object_prototype);
     visitor.visit(m_array_prototype_values_function);
+    visitor.visit(m_date_constructor_now_function);
     visitor.visit(m_eval_function);
     visitor.visit(m_throw_type_error_function);
 

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -39,6 +39,7 @@ public:
     AsyncFromSyncIteratorPrototype* async_from_sync_iterator_prototype() { return m_async_from_sync_iterator_prototype; }
 
     FunctionObject* array_prototype_values_function() const { return m_array_prototype_values_function; }
+    FunctionObject* date_constructor_now_function() const { return m_date_constructor_now_function; }
     FunctionObject* eval_function() const { return m_eval_function; }
     FunctionObject* throw_type_error_function() const { return m_throw_type_error_function; }
 
@@ -105,6 +106,7 @@ private:
     AsyncFromSyncIteratorPrototype* m_async_from_sync_iterator_prototype { nullptr };
 
     FunctionObject* m_array_prototype_values_function { nullptr };
+    FunctionObject* m_date_constructor_now_function { nullptr };
     FunctionObject* m_eval_function { nullptr };
     FunctionObject* m_throw_type_error_function { nullptr };
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -666,6 +666,11 @@ Optional<Unicode::CalendarPattern> basic_format_matcher(Unicode::CalendarPattern
                 best_format_field = option_field;
             break;
 
+        case Unicode::CalendarPattern::Field::Hour:
+        case Unicode::CalendarPattern::Field::Minute:
+        case Unicode::CalendarPattern::Field::Second:
+            break;
+
         default:
             if (best_format_field.has_value() && option_field.has_value())
                 best_format_field = option_field;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -249,7 +249,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         return &date_time_format;
 
     // 38. For each row in Table 4, except the header row, in table order, do
-    date_time_format.for_each_calendar_field_zipped_with(*best_format, [&](auto& date_time_format_field, auto const& best_format_field) {
+    date_time_format.for_each_calendar_field_zipped_with(*best_format, [&](auto& date_time_format_field, auto const& best_format_field, auto) {
         // a. Let prop be the name given in the Property column of the row.
         // b. If bestFormat has a field [[<prop>]], then
         if (best_format_field.has_value()) {
@@ -490,12 +490,12 @@ Optional<Unicode::CalendarPattern> date_time_style_format(StringView data_locale
         Unicode::CalendarPattern format {};
 
         // b. Add to format all fields from dateFormat except [[pattern]] and [[rangePatterns]].
-        format.for_each_calendar_field_zipped_with(date_format, [](auto& format_field, auto const& date_format_field) {
+        format.for_each_calendar_field_zipped_with(date_format, [](auto& format_field, auto const& date_format_field, auto) {
             format_field = date_format_field;
         });
 
         // c. Add to format all fields from timeFormat except [[pattern]], [[rangePatterns]], [[pattern12]], and [[rangePatterns12]], if present.
-        format.for_each_calendar_field_zipped_with(time_format, [](auto& format_field, auto const& time_format_field) {
+        format.for_each_calendar_field_zipped_with(time_format, [](auto& format_field, auto const& time_format_field, auto) {
             if (time_format_field.has_value())
                 format_field = time_format_field;
         });
@@ -577,7 +577,7 @@ Optional<Unicode::CalendarPattern> basic_format_matcher(Unicode::CalendarPattern
         int score = 0;
 
         // b. For each property name property shown in Table 4, do
-        format.for_each_calendar_field_zipped_with(options, [&](auto const& format_prop, auto const& options_prop) {
+        format.for_each_calendar_field_zipped_with(options, [&](auto const& format_prop, auto const& options_prop, auto) {
             using ValueType = typename RemoveReference<decltype(options_prop)>::ValueType;
 
             // i. If options has a field [[<property>]], let optionsProp be options.[[<property>]]; else let optionsProp be undefined.
@@ -659,7 +659,7 @@ Optional<Unicode::CalendarPattern> basic_format_matcher(Unicode::CalendarPattern
     //
     // Rather than generating an prohibitively large amount of nearly-duplicate patterns, which only
     // differ by field length, we expand the field lengths here.
-    best_format->for_each_calendar_field_zipped_with(options, [](auto& best_format_field, auto const& option_field) {
+    best_format->for_each_calendar_field_zipped_with(options, [](auto& best_format_field, auto const& option_field, auto) {
         if (best_format_field.has_value() && option_field.has_value())
             best_format_field = option_field;
     });

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -659,9 +659,18 @@ Optional<Unicode::CalendarPattern> basic_format_matcher(Unicode::CalendarPattern
     //
     // Rather than generating an prohibitively large amount of nearly-duplicate patterns, which only
     // differ by field length, we expand the field lengths here.
-    best_format->for_each_calendar_field_zipped_with(options, [](auto& best_format_field, auto const& option_field, auto) {
-        if (best_format_field.has_value() && option_field.has_value())
-            best_format_field = option_field;
+    best_format->for_each_calendar_field_zipped_with(options, [&](auto& best_format_field, auto const& option_field, auto field_type) {
+        switch (field_type) {
+        case Unicode::CalendarPattern::Field::FractionalSecondDigits:
+            if (best_format->second.has_value() && option_field.has_value())
+                best_format_field = option_field;
+            break;
+
+        default:
+            if (best_format_field.has_value() && option_field.has_value())
+                best_format_field = option_field;
+            break;
+        }
     });
 
     // 11. Return bestFormat.

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -129,6 +129,9 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
     // 23. Let dataLocale be r.[[dataLocale]].
     auto data_locale = move(result.data_locale);
 
+    // Non-standard, the data locale is needed for LibUnicode lookups while formatting.
+    date_time_format.set_data_locale(data_locale);
+
     // 24. Let timeZone be ? Get(options, "timeZone").
     auto time_zone_value = TRY(options->get(vm.names.timeZone));
     String time_zone;

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -179,6 +179,7 @@ Optional<Unicode::CalendarPattern> best_fit_format_matcher(Unicode::CalendarPatt
 ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObject& global_object, DateTimeFormat& date_time_format, Vector<PatternPartition> pattern_parts, Value time, Value range_format_options);
 ThrowCompletionOr<Vector<PatternPartition>> partition_date_time_pattern(GlobalObject& global_object, DateTimeFormat& date_time_format, Value time);
 ThrowCompletionOr<String> format_date_time(GlobalObject& global_object, DateTimeFormat& date_time_format, Value time);
+ThrowCompletionOr<Array*> format_date_time_to_parts(GlobalObject& global_object, DateTimeFormat& date_time_format, Value time);
 ThrowCompletionOr<LocalTime> to_local_time(GlobalObject& global_object, double time, StringView calendar, StringView time_zone);
 
 template<typename Callback>

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -46,6 +46,9 @@ public:
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
 
+    String const& data_locale() const { return m_data_locale; }
+    void set_data_locale(String data_locale) { m_data_locale = move(data_locale); }
+
     String const& calendar() const { return m_calendar; }
     void set_calendar(String calendar) { m_calendar = move(calendar); }
 
@@ -129,6 +132,8 @@ private:
     String m_time_zone;                        // [[TimeZone]]
     Optional<Style> m_date_style;              // [[DateStyle]]
     Optional<Style> m_time_style;              // [[TimeStyle]]
+
+    String m_data_locale;
 };
 
 enum class OptionRequired {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Date.h>
+#include <LibJS/Runtime/DateConstructor.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/DateTimeFormat.h>
+#include <LibJS/Runtime/Intl/DateTimeFormatFunction.h>
+
+namespace JS::Intl {
+
+// 11.1.6 DateTime Format Functions, https://tc39.es/ecma402/#sec-datetime-format-functions
+DateTimeFormatFunction* DateTimeFormatFunction::create(GlobalObject& global_object, DateTimeFormat& date_time_format)
+{
+    return global_object.heap().allocate<DateTimeFormatFunction>(global_object, date_time_format, *global_object.function_prototype());
+}
+
+DateTimeFormatFunction::DateTimeFormatFunction(DateTimeFormat& date_time_format, Object& prototype)
+    : NativeFunction(prototype)
+    , m_date_time_format(date_time_format)
+{
+}
+
+void DateTimeFormatFunction::initialize(GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+
+    Base::initialize(global_object);
+    define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
+    define_direct_property(vm.names.name, js_string(vm, String::empty()), Attribute::Configurable);
+}
+
+ThrowCompletionOr<Value> DateTimeFormatFunction::call()
+{
+    auto& global_object = this->global_object();
+    auto& vm = global_object.vm();
+
+    auto date = vm.argument(0);
+
+    // 1. Let dtf be F.[[DateTimeFormat]].
+    // 2. Assert: Type(dtf) is Object and dtf has an [[InitializedDateTimeFormat]] internal slot.
+
+    // 3. If date is not provided or is undefined, then
+    if (date.is_undefined()) {
+        // a. Let x be Call(%Date.now%, undefined).
+        date = MUST(JS::call(global_object, global_object.date_constructor_now_function(), js_undefined()));
+    }
+    // 4. Else,
+    else {
+        // a. Let x be ? ToNumber(date).
+        date = TRY(date.to_number(global_object));
+    }
+
+    // 5. Return ? FormatDateTime(dtf, x).
+    auto formatted = TRY(format_date_time(global_object, m_date_time_format, date));
+    return js_string(vm, move(formatted));
+}
+
+void DateTimeFormatFunction::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(&m_date_time_format);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Forward.h>
+#include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS::Intl {
+
+class DateTimeFormatFunction final : public NativeFunction {
+    JS_OBJECT(DateTimeFormatFunction, NativeFunction);
+
+public:
+    static DateTimeFormatFunction* create(GlobalObject&, DateTimeFormat&);
+
+    explicit DateTimeFormatFunction(DateTimeFormat&, Object& prototype);
+    virtual ~DateTimeFormatFunction() override = default;
+    virtual void initialize(GlobalObject&) override;
+
+    virtual ThrowCompletionOr<Value> call() override;
+
+private:
+    virtual void visit_edges(Visitor&) override;
+
+    DateTimeFormat& m_date_time_format; // [[DateTimeFormat]]
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
@@ -21,6 +21,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(format);
+    JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
@@ -20,6 +20,7 @@ public:
     virtual ~DateTimeFormatPrototype() override = default;
 
 private:
+    JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -1,0 +1,387 @@
+describe("errors", () => {
+    test("called on non-DateTimeFormat object", () => {
+        expect(() => {
+            Intl.DateTimeFormat.prototype.format;
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.DateTimeFormat");
+
+        expect(() => {
+            Intl.DateTimeFormat.prototype.format(1);
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.DateTimeFormat");
+    });
+
+    test("called with value that cannot be converted to a number", () => {
+        expect(() => {
+            Intl.DateTimeFormat().format(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            Intl.DateTimeFormat().format(1n);
+        }).toThrowWithMessage(TypeError, "Cannot convert BigInt to number");
+    });
+
+    test("time value cannot be clipped", () => {
+        expect(() => {
+            Intl.DateTimeFormat().format(NaN);
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+
+        expect(() => {
+            Intl.DateTimeFormat().format(-8.65e15);
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+
+        expect(() => {
+            Intl.DateTimeFormat().format(8.65e15);
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+    });
+});
+
+const d0 = Date.UTC(2021, 11, 7, 17, 40, 50, 456);
+const d1 = Date.UTC(1989, 0, 23, 7, 8, 9, 45);
+
+describe("dateStyle", () => {
+    // prettier-ignore
+    const data = [
+        { date: "full", en0: "Tuesday, December 7, 2021", en1: "Monday, January 23, 1989", ar0: "الثلاثاء، ٧ ديسمبر ٢٠٢١", ar1: "الاثنين، ٢٣ يناير ١٩٨٩" },
+        { date: "long", en0: "December 7, 2021", en1: "January 23, 1989", ar0: "٧ ديسمبر ٢٠٢١", ar1: "٢٣ يناير ١٩٨٩" },
+        { date: "medium", en0: "Dec 7, 2021", en1: "Jan 23, 1989", ar0: "٠٧‏/١٢‏/٢٠٢١", ar1: "٢٣‏/٠١‏/١٩٨٩" },
+        { date: "short", en0: "12/7/21", en1: "1/23/89", ar0: "٧‏/١٢‏/٢٠٢١", ar1: "٢٣‏/١‏/١٩٨٩" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { dateStyle: d.date });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { dateStyle: d.date });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("timeStyle", () => {
+    // prettier-ignore
+    const data = [
+        { time: "full", en0: "5:40:50 PM Coordinated Universal Time", en1: "7:08:09 AM Coordinated Universal Time", ar0: "٥:٤٠:٥٠ م التوقيت العالمي المنسق", ar1: "٧:٠٨:٠٩ ص التوقيت العالمي المنسق" },
+        { time: "long", en0: "5:40:50 PM UTC", en1: "7:08:09 AM UTC", ar0: "٥:٤٠:٥٠ م UTC", ar1: "٧:٠٨:٠٩ ص UTC" },
+        { time: "medium", en0: "5:40:50 PM", en1: "7:08:09 AM", ar0: "٥:٤٠:٥٠ م", ar1: "٧:٠٨:٠٩ ص" },
+        { time: "short", en0: "5:40 PM", en1: "7:08 AM", ar0: "٥:٤٠ م", ar1: "٧:٠٨ ص" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { timeStyle: d.time, timeZone: "UTC" });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { timeStyle: d.time, timeZone: "UTC" });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("dateStyle + timeStyle", () => {
+    // prettier-ignore
+    const data = [
+        { date: "full", time: "full", en: "Tuesday, December 7, 2021 at 5:40:50 PM Coordinated Universal Time", ar: "الثلاثاء، ٧ ديسمبر ٢٠٢١ في ٥:٤٠:٥٠ م التوقيت العالمي المنسق" },
+        { date: "full", time: "long", en: "Tuesday, December 7, 2021 at 5:40:50 PM UTC", ar: "الثلاثاء، ٧ ديسمبر ٢٠٢١ في ٥:٤٠:٥٠ م UTC" },
+        { date: "full", time: "medium", en: "Tuesday, December 7, 2021 at 5:40:50 PM", ar: "الثلاثاء، ٧ ديسمبر ٢٠٢١ في ٥:٤٠:٥٠ م" },
+        { date: "full", time: "short", en: "Tuesday, December 7, 2021 at 5:40 PM", ar: "الثلاثاء، ٧ ديسمبر ٢٠٢١ في ٥:٤٠ م" },
+        { date: "long", time: "full", en: "December 7, 2021 at 5:40:50 PM Coordinated Universal Time", ar: "٧ ديسمبر ٢٠٢١ في ٥:٤٠:٥٠ م التوقيت العالمي المنسق" },
+        { date: "long", time: "long", en: "December 7, 2021 at 5:40:50 PM UTC", ar: "٧ ديسمبر ٢٠٢١ في ٥:٤٠:٥٠ م UTC" },
+        { date: "long", time: "medium", en: "December 7, 2021 at 5:40:50 PM", ar: "٧ ديسمبر ٢٠٢١ في ٥:٤٠:٥٠ م" },
+        { date: "long", time: "short", en: "December 7, 2021 at 5:40 PM", ar: "٧ ديسمبر ٢٠٢١ في ٥:٤٠ م" },
+        { date: "medium", time: "full", en: "Dec 7, 2021, 5:40:50 PM Coordinated Universal Time", ar: "٠٧‏/١٢‏/٢٠٢١, ٥:٤٠:٥٠ م التوقيت العالمي المنسق" },
+        { date: "medium", time: "long", en: "Dec 7, 2021, 5:40:50 PM UTC", ar: "٠٧‏/١٢‏/٢٠٢١, ٥:٤٠:٥٠ م UTC" },
+        { date: "medium", time: "medium", en: "Dec 7, 2021, 5:40:50 PM", ar: "٠٧‏/١٢‏/٢٠٢١, ٥:٤٠:٥٠ م" },
+        { date: "medium", time: "short", en: "Dec 7, 2021, 5:40 PM", ar: "٠٧‏/١٢‏/٢٠٢١, ٥:٤٠ م" },
+        { date: "short", time: "full", en: "12/7/21, 5:40:50 PM Coordinated Universal Time", ar: "٧‏/١٢‏/٢٠٢١, ٥:٤٠:٥٠ م التوقيت العالمي المنسق" },
+        { date: "short", time: "long", en: "12/7/21, 5:40:50 PM UTC", ar: "٧‏/١٢‏/٢٠٢١, ٥:٤٠:٥٠ م UTC" },
+        { date: "short", time: "medium", en: "12/7/21, 5:40:50 PM", ar: "٧‏/١٢‏/٢٠٢١, ٥:٤٠:٥٠ م" },
+        { date: "short", time: "short", en: "12/7/21, 5:40 PM", ar: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", {
+                dateStyle: d.date,
+                timeStyle: d.time,
+                timeZone: "UTC",
+            });
+            expect(en.format(d0)).toBe(d.en);
+
+            const ar = new Intl.DateTimeFormat("ar", {
+                dateStyle: d.date,
+                timeStyle: d.time,
+                timeZone: "UTC",
+            });
+            expect(ar.format(d0)).toBe(d.ar);
+        });
+    });
+});
+
+describe("weekday", () => {
+    // prettier-ignore
+    const data = [
+        { weekday: "narrow", en0: "T", en1: "M", ar0: "ث", ar1: "ن" },
+        { weekday: "short", en0: "Tue", en1: "Mon", ar0: "الثلاثاء", ar1: "الاثنين" },
+        { weekday: "long", en0: "Tuesday", en1: "Monday", ar0: "الثلاثاء", ar1: "الاثنين" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { weekday: d.weekday });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { weekday: d.weekday });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("era", () => {
+    // prettier-ignore
+    const data = [
+        { era: "narrow", en0: "12/7/2021 A", en1: "1/23/1989 A", ar0: "٧ ١٢ ٢٠٢١ م", ar1: "٢٣ ١ ١٩٨٩ م" },
+        { era: "short", en0: "12/7/2021 AD", en1: "1/23/1989 AD", ar0: "٧ ١٢ ٢٠٢١ م", ar1: "٢٣ ١ ١٩٨٩ م" },
+        { era: "long", en0: "12/7/2021 Anno Domini", en1: "1/23/1989 Anno Domini", ar0: "٧ ١٢ ٢٠٢١ ميلادي", ar1: "٢٣ ١ ١٩٨٩ ميلادي" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { era: d.era });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { era: d.era });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("year", () => {
+    // prettier-ignore
+    const data = [
+        { year: "2-digit", en0: "21", en1: "89", ar0: "٢١", ar1: "٨٩" },
+        { year: "numeric", en0: "2021", en1: "1989", ar0: "٢٠٢١", ar1: "١٩٨٩" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { year: d.year });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { year: d.year });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("month", () => {
+    // prettier-ignore
+    const data = [
+        { month: "2-digit", en0: "12", en1: "01", ar0: "١٢", ar1: "٠١" },
+        { month: "numeric", en0: "12", en1: "1", ar0: "١٢", ar1: "١" },
+        { month: "narrow", en0: "D", en1: "J", ar0: "د", ar1: "ي" },
+        { month: "short", en0: "Dec", en1: "Jan", ar0: "ديسمبر", ar1: "يناير" },
+        { month: "long", en0: "December", en1: "January", ar0: "ديسمبر", ar1: "يناير" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { month: d.month });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { month: d.month });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("day", () => {
+    // prettier-ignore
+    const data = [
+        { day: "2-digit", en0: "07", en1: "23", ar0: "٠٧", ar1: "٢٣" },
+        { day: "numeric", en0: "7", en1: "23", ar0: "٧", ar1: "٢٣" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { day: d.day });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { day: d.day });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("dayPeriod", () => {
+    // prettier-ignore
+    // FIXME: The ar formats aren't entirely correct. LibUnicode is only parsing e.g. "morning1" in the "dayPeriods"
+    //        CLDR object. It will need to parse "morning2", and figure out how to apply it.
+    const data = [
+        { dayPeriod: "narrow", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ ظهرًا", ar1: "٧ فجرًا" },
+        { dayPeriod: "short", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ ظهرًا", ar1: "٧ فجرًا" },
+        { dayPeriod: "long", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ ظهرًا", ar1: "٧ في الصباح" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", {
+                dayPeriod: d.dayPeriod,
+                hour: "numeric",
+                timeZone: "UTC",
+            });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", {
+                dayPeriod: d.dayPeriod,
+                hour: "numeric",
+                timeZone: "UTC",
+            });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("hour", () => {
+    // prettier-ignore
+    // FIXME: The 2-digit results are supposed to include {ampm}. These results are acheived from the "HH"
+    //        pattern, which should only be applied to 24-hour cycles.
+    const data = [
+        { hour: "2-digit", en0: "05", en1: "07", ar0: "٠٥", ar1: "٠٧" },
+        { hour: "numeric", en0: "5 PM", en1: "7 AM", ar0: "٥ م", ar1: "٧ ص" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { hour: d.hour, timeZone: "UTC" });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { hour: d.hour, timeZone: "UTC" });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("minute", () => {
+    // prettier-ignore
+    const data = [
+        { minute: "2-digit", en0: "5:40 PM", en1: "7:08 AM", ar0: "٥:٤٠ م", ar1: "٧:٠٨ ص" },
+        { minute: "numeric", en0: "5:40 PM", en1: "7:08 AM", ar0: "٥:٤٠ م", ar1: "٧:٠٨ ص" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", {
+                minute: d.minute,
+                hour: "numeric",
+                timeZone: "UTC",
+            });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", {
+                minute: d.minute,
+                hour: "numeric",
+                timeZone: "UTC",
+            });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("second", () => {
+    // prettier-ignore
+    const data = [
+        { second: "2-digit", en0: "40:50", en1: "08:09", ar0: "٤٠:٥٠", ar1: "٠٨:٠٩" },
+        { second: "numeric", en0: "40:50", en1: "08:09", ar0: "٤٠:٥٠", ar1: "٠٨:٠٩" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", {
+                second: d.second,
+                minute: "numeric",
+                timeZone: "UTC",
+            });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", {
+                second: d.second,
+                minute: "numeric",
+                timeZone: "UTC",
+            });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("fractionalSecondDigits", () => {
+    // prettier-ignore
+    const data = [
+        { fractionalSecondDigits: 1, en0: "40:50.4", en1: "08:09.0", ar0: "٤٠:٥٠٫٤", ar1: "٠٨:٠٩٫٠" },
+        { fractionalSecondDigits: 2, en0: "40:50.45", en1: "08:09.04", ar0: "٤٠:٥٠٫٤٥", ar1: "٠٨:٠٩٫٠٤" },
+        { fractionalSecondDigits: 3, en0: "40:50.456", en1: "08:09.045", ar0: "٤٠:٥٠٫٤٥٦", ar1: "٠٨:٠٩٫٠٤٥" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", {
+                fractionalSecondDigits: d.fractionalSecondDigits,
+                second: "numeric",
+                minute: "numeric",
+                timeZone: "UTC",
+            });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", {
+                fractionalSecondDigits: d.fractionalSecondDigits,
+                second: "numeric",
+                minute: "numeric",
+                timeZone: "UTC",
+            });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});
+
+describe("timeZoneName", () => {
+    // prettier-ignore
+    const data = [
+        { timeZoneName: "short", en0: "12/7/2021, 5:40 PM UTC", en1: "1/23/1989, 7:08 AM UTC", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م UTC", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص UTC" },
+        { timeZoneName: "long", en0: "12/7/2021, 5:40 PM Coordinated Universal Time", en1: "1/23/1989, 7:08 AM Coordinated Universal Time", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م التوقيت العالمي المنسق", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص التوقيت العالمي المنسق" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { timeZoneName: d.timeZoneName });
+            expect(en.format(d0)).toBe(d.en0);
+            expect(en.format(d1)).toBe(d.en1);
+
+            const ar = new Intl.DateTimeFormat("ar", { timeZoneName: d.timeZoneName });
+            expect(ar.format(d0)).toBe(d.ar0);
+            expect(ar.format(d1)).toBe(d.ar1);
+        });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatToParts.js
@@ -1,0 +1,279 @@
+describe("errors", () => {
+    test("called on non-DateTimeFormat object", () => {
+        expect(() => {
+            Intl.DateTimeFormat.prototype.formatToParts(1);
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.DateTimeFormat");
+    });
+
+    test("called with value that cannot be converted to a number", () => {
+        expect(() => {
+            Intl.DateTimeFormat().formatToParts(Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            Intl.DateTimeFormat().formatToParts(1n);
+        }).toThrowWithMessage(TypeError, "Cannot convert BigInt to number");
+    });
+
+    test("time value cannot be clipped", () => {
+        expect(() => {
+            Intl.DateTimeFormat().formatToParts(NaN);
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+
+        expect(() => {
+            Intl.DateTimeFormat().formatToParts(-8.65e15);
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+
+        expect(() => {
+            Intl.DateTimeFormat().formatToParts(8.65e15);
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+    });
+});
+
+const d = Date.UTC(1989, 0, 23, 7, 8, 9, 45);
+
+describe("dateStyle", () => {
+    test("full", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "full" });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "weekday", value: "Monday" },
+            { type: "literal", value: ", " },
+            { type: "month", value: "January" },
+            { type: "literal", value: " " },
+            { type: "day", value: "23" },
+            { type: "literal", value: ", " },
+            { type: "year", value: "1989" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", { dateStyle: "full" });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "weekday", value: "الاثنين" },
+            { type: "literal", value: "، " },
+            { type: "day", value: "٢٣" },
+            { type: "literal", value: " " },
+            { type: "month", value: "يناير" },
+            { type: "literal", value: " " },
+            { type: "year", value: "١٩٨٩" },
+        ]);
+    });
+
+    test("long", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "long" });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "month", value: "January" },
+            { type: "literal", value: " " },
+            { type: "day", value: "23" },
+            { type: "literal", value: ", " },
+            { type: "year", value: "1989" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", { dateStyle: "long" });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "day", value: "٢٣" },
+            { type: "literal", value: " " },
+            { type: "month", value: "يناير" },
+            { type: "literal", value: " " },
+            { type: "year", value: "١٩٨٩" },
+        ]);
+    });
+
+    test("medium", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "medium" });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "month", value: "Jan" },
+            { type: "literal", value: " " },
+            { type: "day", value: "23" },
+            { type: "literal", value: ", " },
+            { type: "year", value: "1989" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", { dateStyle: "medium" });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "day", value: "٢٣" },
+            { type: "literal", value: "‏/" },
+            { type: "month", value: "٠١" },
+            { type: "literal", value: "‏/" },
+            { type: "year", value: "١٩٨٩" },
+        ]);
+    });
+
+    test("short", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "short" });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "month", value: "1" },
+            { type: "literal", value: "/" },
+            { type: "day", value: "23" },
+            { type: "literal", value: "/" },
+            { type: "year", value: "89" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", { dateStyle: "short" });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "day", value: "٢٣" },
+            { type: "literal", value: "‏/" },
+            { type: "month", value: "١" },
+            { type: "literal", value: "‏/" },
+            { type: "year", value: "١٩٨٩" },
+        ]);
+    });
+});
+
+describe("timeStyle", () => {
+    test("full", () => {
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "full", timeZone: "UTC" });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "hour", value: "7" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "08" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "09" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "AM" },
+            { type: "literal", value: " " },
+            { type: "timeZoneName", value: "Coordinated Universal Time" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", { timeStyle: "full", timeZone: "UTC" });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "hour", value: "٧" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "٠٨" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "٠٩" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "ص" },
+            { type: "literal", value: " " },
+            { type: "timeZoneName", value: "التوقيت العالمي المنسق" },
+        ]);
+    });
+
+    test("long", () => {
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "long", timeZone: "UTC" });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "hour", value: "7" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "08" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "09" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "AM" },
+            { type: "literal", value: " " },
+            { type: "timeZoneName", value: "UTC" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", { timeStyle: "long", timeZone: "UTC" });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "hour", value: "٧" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "٠٨" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "٠٩" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "ص" },
+            { type: "literal", value: " " },
+            { type: "timeZoneName", value: "UTC" },
+        ]);
+    });
+
+    test("medium", () => {
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "medium", timeZone: "UTC" });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "hour", value: "7" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "08" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "09" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "AM" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", { timeStyle: "medium", timeZone: "UTC" });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "hour", value: "٧" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "٠٨" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "٠٩" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "ص" },
+        ]);
+    });
+
+    test("short", () => {
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "short", timeZone: "UTC" });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "hour", value: "7" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "08" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "AM" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", { timeStyle: "short", timeZone: "UTC" });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "hour", value: "٧" },
+            { type: "literal", value: ":" },
+            { type: "minute", value: "٠٨" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "ص" },
+        ]);
+    });
+});
+
+describe("special cases", () => {
+    test("dayPeriod", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            dayPeriod: "long",
+            hour: "numeric",
+            timeZone: "UTC",
+        });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "hour", value: "7" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "in the morning" },
+        ]);
+
+        // FIXME: The ar format isn't entirely correct. LibUnicode is only parsing e.g. "morning1" in the "dayPeriods"
+        //        CLDR object. It will need to parse "morning2", and figure out how to apply it.
+        const ar = new Intl.DateTimeFormat("ar", {
+            dayPeriod: "long",
+            hour: "numeric",
+            timeZone: "UTC",
+        });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "hour", value: "٧" },
+            { type: "literal", value: " " },
+            { type: "dayPeriod", value: "في الصباح" },
+        ]);
+    });
+
+    test("fractionalSecondDigits", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            fractionalSecondDigits: 3,
+            second: "numeric",
+            minute: "numeric",
+            timeZone: "UTC",
+        });
+        expect(en.formatToParts(d)).toEqual([
+            { type: "minute", value: "08" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "09" },
+            { type: "literal", value: "." },
+            { type: "fractionalSecond", value: "045" },
+        ]);
+
+        const ar = new Intl.DateTimeFormat("ar", {
+            fractionalSecondDigits: 3,
+            second: "numeric",
+            minute: "numeric",
+            timeZone: "UTC",
+        });
+        expect(ar.formatToParts(d)).toEqual([
+            { type: "minute", value: "٠٨" },
+            { type: "literal", value: ":" },
+            { type: "second", value: "٠٩" },
+            { type: "literal", value: "٫" },
+            { type: "fractionalSecond", value: "٠٤٥" },
+        ]);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
@@ -165,14 +165,14 @@ describe("correct behavior", () => {
     test("minute", () => {
         ["2-digit", "numeric"].forEach(minute => {
             const en = new Intl.DateTimeFormat("en", { minute: minute });
-            expect(en.resolvedOptions().minute).toBe(minute);
+            expect(en.resolvedOptions().minute).toBe("2-digit");
         });
     });
 
     test("second", () => {
         ["2-digit", "numeric"].forEach(second => {
             const en = new Intl.DateTimeFormat("en", { second: second });
-            expect(en.resolvedOptions().second).toBe(second);
+            expect(en.resolvedOptions().second).toBe("2-digit");
         });
     });
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
@@ -1,6 +1,3 @@
-// NOTE: We cannot yet test the fractionalSecondDigits option. There aren't any patterns in the CLDR
-//       with this field ('S' in https://unicode.org/reports/tr35/tr35-dates.html#dfst-second). We
-//       will need to figure out how this field should be generated.
 describe("correct behavior", () => {
     test("length is 0", () => {
         expect(Intl.DateTimeFormat.prototype.resolvedOptions).toHaveLength(0);
@@ -176,6 +173,15 @@ describe("correct behavior", () => {
         ["2-digit", "numeric"].forEach(second => {
             const en = new Intl.DateTimeFormat("en", { second: second });
             expect(en.resolvedOptions().second).toBe(second);
+        });
+    });
+
+    test("fractionalSecondDigits", () => {
+        [1, 2, 3].forEach(fractionalSecondDigits => {
+            const en = new Intl.DateTimeFormat("en", {
+                fractionalSecondDigits: fractionalSecondDigits,
+            });
+            expect(en.resolvedOptions().fractionalSecondDigits).toBe(fractionalSecondDigits);
         });
     });
 

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -176,4 +176,13 @@ Optional<StringView> get_calendar_day_period_symbol([[maybe_unused]] StringView 
 #endif
 }
 
+Optional<StringView> get_time_zone_name([[maybe_unused]] StringView locale, [[maybe_unused]] StringView time_zone, [[maybe_unused]] CalendarPatternStyle style)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_time_zone_name(locale, time_zone, style);
+#else
+    return {};
+#endif
+}
+
 }

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -140,4 +140,40 @@ Vector<CalendarPattern> get_calendar_available_formats([[maybe_unused]] StringVi
 #endif
 }
 
+Optional<StringView> get_calendar_era_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::Era value)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_calendar_era_symbol(locale, calendar, style, value);
+#else
+    return {};
+#endif
+}
+
+Optional<StringView> get_calendar_month_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::Month value)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_calendar_month_symbol(locale, calendar, style, value);
+#else
+    return {};
+#endif
+}
+
+Optional<StringView> get_calendar_weekday_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::Weekday value)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_calendar_weekday_symbol(locale, calendar, style, value);
+#else
+    return {};
+#endif
+}
+
+Optional<StringView> get_calendar_day_period_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::DayPeriod value)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_calendar_day_period_symbol(locale, calendar, style, value);
+#else
+    return {};
+#endif
+}
+
 }

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -15,6 +15,45 @@
 
 namespace Unicode {
 
+enum class Era : u8 {
+    BC,
+    AD,
+};
+
+enum class Month : u8 {
+    January,
+    February,
+    March,
+    April,
+    May,
+    June,
+    July,
+    August,
+    September,
+    October,
+    November,
+    December,
+};
+
+enum class Weekday : u8 {
+    Sunday,
+    Monday,
+    Tuesday,
+    Wednesday,
+    Thursday,
+    Friday,
+    Saturday,
+};
+
+enum class DayPeriod : u8 {
+    AM,
+    PM,
+    Morning,
+    Afternoon,
+    Evening,
+    Night,
+};
+
 enum class HourCycle : u8 {
     H11,
     H12,
@@ -99,5 +138,9 @@ Vector<Unicode::HourCycle> get_regional_hour_cycles(StringView locale);
 Optional<Unicode::HourCycle> get_default_regional_hour_cycle(StringView locale);
 Optional<CalendarFormat> get_calendar_format(StringView locale, StringView calendar, CalendarFormatType type);
 Vector<CalendarPattern> get_calendar_available_formats(StringView locale, StringView calendar);
+Optional<StringView> get_calendar_era_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Era value);
+Optional<StringView> get_calendar_month_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Month value);
+Optional<StringView> get_calendar_weekday_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Weekday value);
+Optional<StringView> get_calendar_day_period_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::DayPeriod value);
 
 }

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -31,20 +31,34 @@ enum class CalendarPatternStyle : u8 {
 };
 
 struct CalendarPattern {
+    enum class Field {
+        Era,
+        Year,
+        Month,
+        Weekday,
+        Day,
+        DayPeriod,
+        Hour,
+        Minute,
+        Second,
+        FractionalSecondDigits,
+        TimeZoneName,
+    };
+
     template<typename Callback>
     void for_each_calendar_field_zipped_with(CalendarPattern const& other, Callback&& callback)
     {
-        callback(era, other.era);
-        callback(year, other.year);
-        callback(month, other.month);
-        callback(weekday, other.weekday);
-        callback(day, other.day);
-        callback(day_period, other.day_period);
-        callback(hour, other.hour);
-        callback(minute, other.minute);
-        callback(second, other.second);
-        callback(fractional_second_digits, other.fractional_second_digits);
-        callback(time_zone_name, other.time_zone_name);
+        callback(era, other.era, Field::Era);
+        callback(year, other.year, Field::Year);
+        callback(month, other.month, Field::Month);
+        callback(weekday, other.weekday, Field::Weekday);
+        callback(day, other.day, Field::Day);
+        callback(day_period, other.day_period, Field::DayPeriod);
+        callback(hour, other.hour, Field::Hour);
+        callback(minute, other.minute, Field::Minute);
+        callback(second, other.second, Field::Second);
+        callback(fractional_second_digits, other.fractional_second_digits, Field::FractionalSecondDigits);
+        callback(time_zone_name, other.time_zone_name, Field::TimeZoneName);
     }
 
     String pattern {};

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -142,5 +142,6 @@ Optional<StringView> get_calendar_era_symbol(StringView locale, StringView calen
 Optional<StringView> get_calendar_month_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Month value);
 Optional<StringView> get_calendar_weekday_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Weekday value);
 Optional<StringView> get_calendar_day_period_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::DayPeriod value);
+Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone, CalendarPatternStyle style);
 
 }


### PR DESCRIPTION
```js
> new Intl.DateTimeFormat("en", { dateStyle: "full", timeStyle: "long" }).format();
"Tuesday, December 7, 2021 at 8:10:01 PM UTC"

> new Intl.DateTimeFormat("ar", { dateStyle: "full", timeStyle: "long" }).format();
"الثلاثاء، ٧ ديسمبر ٢٠٢١ في ٨:١٠:٠٥ م UTC"

> new Intl.DateTimeFormat("en", { era: "long", year: "numeric", month: "short", day: "2-digit", hour: "2-digit", minute: "numeric", second: "numeric", fractionalSecondDigits: 2, timeZoneName: "long" }).format();
"Dec 07, 2021 Anno Domini, 10:23:10.85 PM Coordinated Universal Time"

> new Intl.DateTimeFormat("ar", { era: "long", year: "numeric", month: "short", day: "2-digit", hour: "2-digit", minute: "numeric", second: "numeric", fractionalSecondDigits: 2, timeZoneName: "long" }).format();
"٠٧ ديسمبر ٢٠٢١ ميلادي, ١٠:٢٢:٠٦٫٠٧ م التوقيت العالمي المنسق"
```