### PR TITLE
Kernel/Bus: Some Clang-tidy fixes

### DIFF
--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -458,7 +458,7 @@ void Access::fast_enumerate(Function<void(DeviceIdentifier const&)>& callback) c
 {
     MutexLocker locker(m_access_lock);
     VERIFY(!m_device_identifiers.is_empty());
-    for (auto& device_identifier : m_device_identifiers) {
+    for (auto const& device_identifier : m_device_identifiers) {
         callback(device_identifier);
     }
 }

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -22,7 +22,6 @@ public:
         Memory,
     };
 
-public:
     static bool initialize_for_memory_access(PhysicalAddress mcfg_table);
     static bool initialize_for_io_access();
 

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -234,7 +234,7 @@ TYPEDEF_DISTINCT_ORDERED_ID(u8, InterruptPin);
 class Access;
 class DeviceIdentifier {
 public:
-    DeviceIdentifier(Address address, HardwareID hardware_id, RevisionID revision_id, ClassCode class_code, SubclassCode subclass_code, ProgrammingInterface prog_if, SubsystemID subsystem_id, SubsystemVendorID subsystem_vendor_id, InterruptLine interrupt_line, InterruptPin interrupt_pin, Vector<Capability> capabilities)
+    DeviceIdentifier(Address address, HardwareID hardware_id, RevisionID revision_id, ClassCode class_code, SubclassCode subclass_code, ProgrammingInterface prog_if, SubsystemID subsystem_id, SubsystemVendorID subsystem_vendor_id, InterruptLine interrupt_line, InterruptPin interrupt_pin, Vector<Capability> const& capabilities)
         : m_address(address)
         , m_hardware_id(hardware_id)
         , m_revision_id(revision_id)
@@ -253,9 +253,9 @@ public:
         }
     }
 
-    Vector<Capability> capabilities() const { return m_capabilities; }
-    const HardwareID& hardware_id() const { return m_hardware_id; }
-    const Address& address() const { return m_address; }
+    Vector<Capability> const& capabilities() const { return m_capabilities; }
+    HardwareID const& hardware_id() const { return m_hardware_id; }
+    Address const& address() const { return m_address; }
 
     RevisionID revision_id() const { return m_revision_id; }
     ClassCode class_code() const { return m_class_code; }

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -159,13 +159,7 @@ public:
     {
     }
 
-    Address(const Address& address)
-        : m_domain(address.domain())
-        , m_bus(address.bus())
-        , m_device(address.device())
-        , m_function(address.function())
-    {
-    }
+    Address(const Address& address) = default;
 
     bool is_null() const { return !m_bus && !m_device && !m_function; }
     operator bool() const { return !is_null(); }

--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/AnyOf.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Device.h>
 
@@ -17,19 +18,15 @@ Device::Device(Address address)
 
 bool Device::is_msi_capable() const
 {
-    for (const auto& capability : PCI::get_device_identifier(pci_address()).capabilities()) {
-        if (capability.id().value() == PCI::Capabilities::ID::MSI)
-            return true;
-    }
-    return false;
+    return AK::any_of(
+        PCI::get_device_identifier(pci_address()).capabilities(),
+        [](auto const& capability) { return capability.id().value() == PCI::Capabilities::ID::MSI; });
 }
 bool Device::is_msix_capable() const
 {
-    for (const auto& capability : PCI::get_device_identifier(pci_address()).capabilities()) {
-        if (capability.id().value() == PCI::Capabilities::ID::MSIX)
-            return true;
-    }
-    return false;
+    return AK::any_of(
+        PCI::get_device_identifier(pci_address()).capabilities(),
+        [](auto const& capability) { return capability.id().value() == PCI::Capabilities::ID::MSIX; });
 }
 
 void Device::enable_pin_based_interrupts() const

--- a/Kernel/Bus/PCI/SysFSPCI.cpp
+++ b/Kernel/Bus/PCI/SysFSPCI.cpp
@@ -21,14 +21,14 @@ UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(const SysFSDir
     : SysFSDirectory(String::formatted("{:04x}:{:02x}:{:02x}.{}", address.domain(), address.bus(), address.device(), address.function()), parent_directory)
     , m_address(address)
 {
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("vendor", *this, PCI::RegisterOffset::VENDOR_ID, 2));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("device_id", *this, PCI::RegisterOffset::DEVICE_ID, 2));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("class", *this, PCI::RegisterOffset::CLASS, 1));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("subclass", *this, PCI::RegisterOffset::SUBCLASS, 1));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("revision", *this, PCI::RegisterOffset::REVISION_ID, 1));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("progif", *this, PCI::RegisterOffset::PROG_IF, 1));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("subsystem_vendor", *this, PCI::RegisterOffset::SUBSYSTEM_VENDOR_ID, 2));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("subsystem_id", *this, PCI::RegisterOffset::SUBSYSTEM_ID, 2));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create("vendor"sv, *this, PCI::RegisterOffset::VENDOR_ID, 2));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create("device_id"sv, *this, PCI::RegisterOffset::DEVICE_ID, 2));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create("class"sv, *this, PCI::RegisterOffset::CLASS, 1));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create("subclass"sv, *this, PCI::RegisterOffset::SUBCLASS, 1));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create("revision"sv, *this, PCI::RegisterOffset::REVISION_ID, 1));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create("progif"sv, *this, PCI::RegisterOffset::PROG_IF, 1));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create("subsystem_vendor"sv, *this, PCI::RegisterOffset::SUBSYSTEM_VENDOR_ID, 2));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create("subsystem_id"sv, *this, PCI::RegisterOffset::SUBSYSTEM_ID, 2));
 }
 
 UNMAP_AFTER_INIT void PCIBusSysFSDirectory::initialize()
@@ -46,12 +46,12 @@ UNMAP_AFTER_INIT PCIBusSysFSDirectory::PCIBusSysFSDirectory()
     });
 }
 
-NonnullRefPtr<PCIDeviceAttributeSysFSComponent> PCIDeviceAttributeSysFSComponent::create(String name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width)
+NonnullRefPtr<PCIDeviceAttributeSysFSComponent> PCIDeviceAttributeSysFSComponent::create(StringView name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width)
 {
     return adopt_ref(*new (nothrow) PCIDeviceAttributeSysFSComponent(name, device, offset, field_bytes_width));
 }
 
-PCIDeviceAttributeSysFSComponent::PCIDeviceAttributeSysFSComponent(String name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width)
+PCIDeviceAttributeSysFSComponent::PCIDeviceAttributeSysFSComponent(StringView name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width)
     : SysFSComponent(name)
     , m_device(device)
     , m_offset(offset)

--- a/Kernel/Bus/PCI/SysFSPCI.h
+++ b/Kernel/Bus/PCI/SysFSPCI.h
@@ -34,14 +34,14 @@ private:
 
 class PCIDeviceAttributeSysFSComponent : public SysFSComponent {
 public:
-    static NonnullRefPtr<PCIDeviceAttributeSysFSComponent> create(String name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width);
+    static NonnullRefPtr<PCIDeviceAttributeSysFSComponent> create(StringView name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
     virtual ~PCIDeviceAttributeSysFSComponent() {};
 
 protected:
     ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer() const;
-    PCIDeviceAttributeSysFSComponent(String name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width);
+    PCIDeviceAttributeSysFSComponent(StringView name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width);
     NonnullRefPtr<PCIDeviceSysFSDirectory> m_device;
     PCI::RegisterOffset m_offset;
     size_t m_field_bytes_width;

--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -99,7 +99,7 @@ ErrorOr<void> SysFSUSBBusDirectory::traverse_as_directory(FileSystemID fsid, Fun
     TRY(callback({ ".", { fsid, component_index() }, 0 }));
     TRY(callback({ "..", { fsid, m_parent_directory->component_index() }, 0 }));
 
-    for (auto& device_node : m_device_nodes) {
+    for (auto const& device_node : m_device_nodes) {
         InodeIdentifier identifier = { fsid, device_node.component_index() };
         TRY(callback({ device_node.name(), identifier, 0 }));
     }

--- a/Kernel/Bus/USB/UHCI/UHCIController.h
+++ b/Kernel/Bus/USB/UHCI/UHCIController.h
@@ -88,7 +88,6 @@ private:
 
     void reset_port(u8);
 
-private:
     IOAddress m_io_base;
 
     OwnPtr<UHCIRootHub> m_root_hub;

--- a/Kernel/Bus/USB/UHCI/UHCIDescriptorPool.h
+++ b/Kernel/Bus/USB/UHCI/UHCIDescriptorPool.h
@@ -68,7 +68,7 @@ private:
     {
         // Go through the number of descriptors to create in the pool, and create a virtual/physical address mapping
         for (size_t i = 0; i < PAGE_SIZE / sizeof(T); i++) {
-            auto placement_address = reinterpret_cast<void*>(m_pool_region->vaddr().get() + (i * sizeof(T)));
+            auto* placement_address = reinterpret_cast<void*>(m_pool_region->vaddr().get() + (i * sizeof(T)));
             auto physical_address = static_cast<u32>(m_pool_region->physical_page(0)->paddr().get() + (i * sizeof(T)));
             auto* object = new (placement_address) T(physical_address);
             m_free_descriptor_stack.push(object); // Push the descriptor's pointer onto the free list

--- a/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
@@ -85,11 +85,11 @@ static USBHubDescriptor uhci_root_hub_hub_descriptor = {
 
 ErrorOr<NonnullOwnPtr<UHCIRootHub>> UHCIRootHub::try_create(NonnullRefPtr<UHCIController> uhci_controller)
 {
-    return adopt_nonnull_own_or_enomem(new (nothrow) UHCIRootHub(uhci_controller));
+    return adopt_nonnull_own_or_enomem(new (nothrow) UHCIRootHub(move(uhci_controller)));
 }
 
 UHCIRootHub::UHCIRootHub(NonnullRefPtr<UHCIController> uhci_controller)
-    : m_uhci_controller(uhci_controller)
+    : m_uhci_controller(move(uhci_controller))
 {
 }
 
@@ -109,7 +109,7 @@ ErrorOr<void> UHCIRootHub::setup(Badge<UHCIController>)
 
 ErrorOr<size_t> UHCIRootHub::handle_control_transfer(Transfer& transfer)
 {
-    auto& request = transfer.request();
+    auto const& request = transfer.request();
     auto* request_data = transfer.buffer().as_ptr() + sizeof(USBRequestData);
 
     if constexpr (UHCI_DEBUG) {

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -37,7 +37,7 @@ Device::Device(NonnullRefPtr<USBController> controller, u8 address, u8 port, Dev
     : m_device_port(port)
     , m_device_speed(speed)
     , m_address(address)
-    , m_controller(controller)
+    , m_controller(move(controller))
     , m_default_pipe(move(default_pipe))
 {
 }

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -26,7 +26,6 @@ public:
         LowSpeed
     };
 
-public:
     static ErrorOr<NonnullRefPtr<Device>> try_create(USBController const&, u8, DeviceSpeed);
 
     Device(USBController const&, u8, DeviceSpeed, NonnullOwnPtr<Pipe> default_pipe);

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -40,7 +40,6 @@ public:
         FullSpeed
     };
 
-public:
     static ErrorOr<NonnullOwnPtr<Pipe>> try_create_pipe(USBController const& controller, Type type, Direction direction, u8 endpoint_address, u16 max_packet_size, i8 device_address, u8 poll_interval = 0);
 
     Type type() const { return m_type; }

--- a/Kernel/Bus/USB/USBTransfer.h
+++ b/Kernel/Bus/USB/USBTransfer.h
@@ -21,9 +21,7 @@ class Transfer : public RefCounted<Transfer> {
 public:
     static ErrorOr<NonnullRefPtr<Transfer>> try_create(Pipe&, u16 length);
 
-public:
     Transfer() = delete;
-    Transfer(Pipe& pipe, u16 len, NonnullOwnPtr<Memory::Region>);
     ~Transfer();
 
     void set_setup_packet(const USBRequestData& request);
@@ -41,6 +39,7 @@ public:
     bool error_occurred() const { return m_error_occurred; }
 
 private:
+    Transfer(Pipe& pipe, u16 len, NonnullOwnPtr<Memory::Region>);
     Pipe& m_pipe;                                // Pipe that initiated this transfer
     USBRequestData m_request;                    // USB request
     NonnullOwnPtr<Memory::Region> m_data_buffer; // DMA Data buffer for transaction

--- a/Kernel/Bus/VirtIO/Console.cpp
+++ b/Kernel/Bus/VirtIO/Console.cpp
@@ -22,7 +22,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<Console> Console::must_create(PCI::DeviceIdentifi
 UNMAP_AFTER_INIT void Console::initialize()
 {
     Device::initialize();
-    if (auto cfg = get_config(ConfigurationType::Device)) {
+    if (auto const* cfg = get_config(ConfigurationType::Device)) {
         bool success = negotiate_features([&](u64 supported_features) {
             u64 negotiated = 0;
             if (is_feature_set(supported_features, VIRTIO_CONSOLE_F_SIZE))
@@ -156,7 +156,8 @@ void Console::process_control_message(ControlMessage message)
             if (id >= m_ports.size()) {
                 dbgln("Device provided an invalid port number {}. max_nr_ports: {}", id, m_ports.size());
                 return;
-            } else if (!m_ports.at(id).is_null()) {
+            }
+            if (!m_ports.at(id).is_null()) {
                 dbgln("Device tried to add port {} which was already added!", id);
                 return;
             }
@@ -178,7 +179,8 @@ void Console::process_control_message(ControlMessage message)
         if (message.id >= m_ports.size()) {
             dbgln("Device provided an invalid port number {}. max_nr_ports: {}", message.id, m_ports.size());
             return;
-        } else if (m_ports.at(message.id).is_null()) {
+        }
+        if (m_ports.at(message.id).is_null()) {
             dbgln("Device tried to open port {} which was not added!", message.id);
             return;
         }

--- a/Kernel/Bus/VirtIO/Device.cpp
+++ b/Kernel/Bus/VirtIO/Device.cpp
@@ -46,7 +46,7 @@ UNMAP_AFTER_INIT void detect()
     });
 }
 
-static StringView const determine_device_class(PCI::DeviceIdentifier const& device_identifier)
+static StringView determine_device_class(PCI::DeviceIdentifier const& device_identifier)
 {
     if (device_identifier.revision_id().value() == 0) {
         // Note: If the device is a legacy (or transitional) device, therefore,

--- a/Kernel/Bus/VirtIO/Device.h
+++ b/Kernel/Bus/VirtIO/Device.h
@@ -121,7 +121,7 @@ protected:
 
     const Configuration* get_config(ConfigurationType cfg_type, u32 index = 0) const
     {
-        for (auto& cfg : m_configs) {
+        for (auto const& cfg : m_configs) {
             if (cfg.cfg_type != cfg_type)
                 continue;
             if (index > 0) {

--- a/Kernel/Bus/VirtIO/Queue.cpp
+++ b/Kernel/Bus/VirtIO/Queue.cpp
@@ -118,9 +118,9 @@ Optional<u16> Queue::take_free_slot()
         m_free_head = m_descriptors[descriptor_index].next;
         --m_free_buffers;
         return descriptor_index;
-    } else {
-        return {};
     }
+
+    return {};
 }
 
 bool Queue::should_notify() const

--- a/Kernel/Bus/VirtIO/Queue.h
+++ b/Kernel/Bus/VirtIO/Queue.h
@@ -116,8 +116,8 @@ public:
 
     QueueChain(QueueChain&& other)
         : m_queue(other.m_queue)
-        , m_start_of_chain_index(other.m_start_of_chain_index)
-        , m_end_of_chain_index(other.m_end_of_chain_index)
+        , m_start_of_chain_index(move(other.m_start_of_chain_index))
+        , m_end_of_chain_index(move(other.m_end_of_chain_index))
         , m_chain_length(other.m_chain_length)
         , m_chain_has_writable_pages(other.m_chain_has_writable_pages)
     {

--- a/Kernel/Firmware/ACPI/Parser.h
+++ b/Kernel/Firmware/ACPI/Parser.h
@@ -74,7 +74,7 @@ public:
     const FADTFlags::HardwareFeatures& hardware_features() const { return m_hardware_flags; }
     const FADTFlags::x86_Specific_Flags& x86_specific_flags() const { return m_x86_specific_flags; }
 
-    ~Parser() {};
+    ~Parser() = default;
 
 private:
     Parser(PhysicalAddress rsdp, PhysicalAddress fadt, u8 irq_number);

--- a/Kernel/Heap/SlabAllocator.h
+++ b/Kernel/Heap/SlabAllocator.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Function.h>
 #include <AK/Types.h>
 


### PR DESCRIPTION
As the title says, these are fixes clang-tidy pointed out (may include other -related- fixes),
including one free String removal from the Kernel!