### PR TITLE
Implement Optional<T&>, use it to reduce copying

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -118,6 +118,22 @@ public:
     void ensure_capacity(size_t capacity) { m_table.ensure_capacity(capacity); }
     ErrorOr<void> try_ensure_capacity(size_t capacity) { return m_table.try_ensure_capacity(capacity); }
 
+    Optional<V const&> get_ref(const K& key) const
+    {
+        auto it = find(key);
+        if (it == end())
+            return {};
+        return it->value;
+    }
+
+    Optional<V&> get_ref(const K& key)
+    {
+        auto it = find(key);
+        if (it == end())
+            return {};
+        return it->value;
+    }
+
     Optional<typename Traits<V>::PeekType> get(const K& key) const requires(!IsPointer<typename Traits<V>::PeekType>)
     {
         auto it = find(key);

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -61,10 +61,7 @@ public:
 
     [[nodiscard]] JsonValue const* get_ptr(StringView key) const
     {
-        auto it = m_members.find(key);
-        if (it == m_members.end())
-            return nullptr;
-        return &(*it).value;
+        return m_members.get_ref(key).value_ptr();
     }
 
     [[nodiscard]] [[nodiscard]] bool has(StringView key) const

--- a/AK/SourceGenerator.h
+++ b/AK/SourceGenerator.h
@@ -36,7 +36,7 @@ public:
     SourceGenerator fork() { return SourceGenerator { m_builder, m_mapping, m_opening, m_closing }; }
 
     void set(StringView key, String value) { m_mapping.set(key, value); }
-    String get(StringView key) const { return m_mapping.get(key).value(); }
+    String const& get(StringView key) const { return m_mapping.get_ref(key).value(); }
 
     StringView as_string_view() const { return m_builder.string_view(); }
     String as_string() const { return m_builder.build(); }

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -102,7 +102,7 @@ UNMAP_AFTER_INIT Access::Access(AccessType access_type)
 
 Optional<PhysicalAddress> Access::determine_memory_mapped_bus_base_address(u32 domain, u8 bus) const
 {
-    auto chosen_domain = m_domains.get(domain);
+    auto chosen_domain = m_domains.get_ref(domain);
     if (!chosen_domain.has_value())
         return {};
     if (!(chosen_domain.value().start_bus() <= bus && bus <= chosen_domain.value().end_bus()))

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -54,7 +54,7 @@ public:
     };
 
     [[nodiscard]] const String& string() const { return m_string; }
-    Optional<StringView> lookup(StringView key) const;
+    StringView lookup(StringView key, StringView fallback) const;
     [[nodiscard]] bool contains(StringView key) const;
 
     [[nodiscard]] bool is_boot_profiling_enabled() const;

--- a/Kernel/Devices/DeviceManagement.cpp
+++ b/Kernel/Devices/DeviceManagement.cpp
@@ -45,10 +45,7 @@ DeviceManagement& DeviceManagement::the()
 Device* DeviceManagement::get_device(unsigned major, unsigned minor)
 {
     return m_devices.with_exclusive([&](auto& map) -> Device* {
-        auto it = map.find(encoded_device(major, minor));
-        if (it == map.end())
-            return nullptr;
-        return it->value;
+        return map.get_ref(encoded_device(major, minor)).value_or(nullptr);
     });
 }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/CodeComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/CodeComprehensionEngine.cpp
@@ -24,7 +24,7 @@ void CodeComprehensionEngine::set_declarations_of_document(const String& filenam
         return;
 
     // Optimization - Only notify callback if declarations have changed
-    if (auto previous_declarations = m_all_declarations.get(filename); previous_declarations.has_value()) {
+    if (auto previous_declarations = m_all_declarations.get_ref(filename); previous_declarations.has_value()) {
         if (previous_declarations.value() == declarations)
             return;
     }

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -267,7 +267,7 @@ Icon FileIconProvider::icon_for_path(const String& path, mode_t mode)
         return s_filetype_image_icon;
 
     for (auto& filetype : s_filetype_icons.keys()) {
-        auto patterns = s_filetype_patterns.get(filetype).value();
+        auto& patterns = s_filetype_patterns.get_ref(filetype).value();
         for (auto& pattern : patterns) {
             if (path.matches(pattern, CaseSensitivity::CaseInsensitive))
                 return s_filetype_icons.get(filetype).value();

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -181,7 +181,7 @@ ErrorOr<void> Heap::flush()
     }
     quick_sort(blocks);
     for (auto& block : blocks) {
-        auto buffer_or_empty = m_write_ahead_log.get(block);
+        auto buffer_or_empty = m_write_ahead_log.get_ref(block);
         if (buffer_or_empty->is_empty()) {
             VERIFY_NOT_REACHED();
         }

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -149,7 +149,7 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, DNSRecordType record
     };
 
     // First, try /etc/hosts.
-    if (auto local_answers = m_etc_hosts.get(name); local_answers.has_value()) {
+    if (auto local_answers = m_etc_hosts.get_ref(name); local_answers.has_value()) {
         for (auto& answer : local_answers.value()) {
             if (answer.type() == record_type)
                 add_answer(answer);
@@ -169,7 +169,7 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, DNSRecordType record
     }
 
     // Third, try our cache.
-    if (auto cached_answers = m_lookup_cache.get(name); cached_answers.has_value()) {
+    if (auto cached_answers = m_lookup_cache.get_ref(name); cached_answers.has_value()) {
         for (auto& answer : cached_answers.value()) {
             // TODO: Actually remove expired answers from the cache.
             if (answer.type() == record_type && !answer.has_expired()) {


### PR DESCRIPTION
This continues the work of #11142: Make fewer pointless copies of "heavy" objects. In particular, `Optional<T&>` did not exist, making the `HashMap::get` interface unnecessarily complicated and copy-heavy. This PR introduces a new `HashMap::get_ref` which returns a `Option<V&>`, to avoid copying the returned value. This is particularly useful if we just want to modify a single value of an entry.

In theory, every use of `HashMap::get` can be replaced by `HashMap::get_ref().copy()`, which would then allow us to get rid of `::get` and the `Trait::PeekType` mechanism. However, such a change is too far-reaching for now, so this PR only introduces the tools necessary to avoid copying Vectors and HashMaps.

I found these instances by introducing a new `bool Traits<T>::is_heavy()` class method, and returning true for Vectors, HashMaps, ByteBuffers. I decided against including it in this PR, but you can view it here: https://github.com/BenWiederhake/serenity/tree/historic/detect-hashmap-copy
Feel free to read, use, modify, and/or redistribute the code.