### PR TITLE
Persist EditingEngineType across Editor

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -54,7 +54,12 @@ MainWidget::MainWidget()
     m_editor = *find_descendant_of_type_named<GUI::TextEditor>("editor");
     m_editor->set_ruler_visible(true);
     m_editor->set_automatic_indentation_enabled(true);
-    m_editor->set_editing_engine(make<GUI::RegularEditingEngine>());
+    if (m_editor->editing_engine()->is_regular())
+        m_editor->set_editing_engine(make<GUI::RegularEditingEngine>());
+    else if (m_editor->editing_engine()->is_vim())
+        m_editor->set_editing_engine(make<GUI::VimEditingEngine>());
+    else
+        VERIFY_NOT_REACHED();
 
     m_editor->on_change = [this] {
         update_preview();

--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -17,6 +17,11 @@ enum CursorWidth {
     WIDE
 };
 
+enum EngineType {
+    Regular,
+    Vim,
+};
+
 class EditingEngine {
     AK_MAKE_NONCOPYABLE(EditingEngine);
     AK_MAKE_NONMOVABLE(EditingEngine);
@@ -36,6 +41,9 @@ public:
     }
 
     virtual bool on_key(const KeyEvent& event);
+
+    bool is_regular() const { return engine_type() == EngineType::Regular; }
+    bool is_vim() const { return engine_type() == EngineType::Vim; }
 
 protected:
     EditingEngine() { }
@@ -72,6 +80,8 @@ protected:
 
     void delete_line();
     void delete_char();
+
+    virtual EngineType engine_type() const = 0;
 
 private:
     void move_selected_lines_up();

--- a/Userland/Libraries/LibGUI/RegularEditingEngine.h
+++ b/Userland/Libraries/LibGUI/RegularEditingEngine.h
@@ -19,6 +19,7 @@ public:
 
 private:
     void sort_selected_lines();
+    virtual EngineType engine_type() const override { return EngineType::Regular; }
 };
 
 }

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -187,6 +187,8 @@ private:
     bool on_key_in_insert_mode(const KeyEvent& event);
     bool on_key_in_normal_mode(const KeyEvent& event);
     bool on_key_in_visual_mode(const KeyEvent& event);
+
+    virtual EngineType engine_type() const override { return EngineType::Vim; }
 };
 
 }


### PR DESCRIPTION
Persist EditingEngine mode in HackStudio and TextEditor when opening new files or editing splits. Previously, the EditingEngine defaulted to a RegularEditingEngine for a new Editor, even if Vim Emulation had been selected in the existing Editor. This utilizes a new `EditingEngine::EngineType` enum to determine the current EditingEngine type, and set the new Editor EditingEngine accordingly.