### PR TITLE
js: Improve usage of `TRY` when executing a file program

### DIFF
--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1493,11 +1493,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         StringBuilder builder;
         for (auto& path : script_paths) {
-            auto file = Core::File::construct(path);
-            if (!file->open(Core::OpenMode::ReadOnly)) {
-                warnln("Failed to open {}: {}", path, file->error_string());
-                return 1;
-            }
+            auto file = TRY(Core::File::open(path, Core::OpenMode::ReadOnly));
             auto file_contents = file->read_all();
             auto source = StringView { file_contents };
             builder.append(source);


### PR DESCRIPTION
Just a small thing I noticed when reading through. By using the `Core::File::open` helper, we get an `ErrorOr<NonnullRefPtr<File>>` which we can `TRY`, instead of constructing the object and then trying to open it.