### PR TITLE
LibJS+LibUnicode: Implement Intl.DateTimeFormat.prototype.formatRange[ToParts]

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -381,7 +381,7 @@ static Optional<CalendarPatternIndexType> parse_date_time_pattern(String pattern
                 format.day = CalendarPatternStyle::Numeric;
             else
                 format.day = CalendarPatternStyle::TwoDigit;
-        } else if (all_of(segment, is_any_of("DFG"sv))) {
+        } else if (all_of(segment, is_any_of("DFg"sv))) {
             builder.append("{day}");
             format.day = CalendarPatternStyle::Numeric;
         }

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -180,6 +180,7 @@ namespace JS {
     P(format)                                \
     P(formatMatcher)                         \
     P(formatRange)                           \
+    P(formatRangeToParts)                    \
     P(formatToParts)                         \
     P(fractionalSecondDigits)                \
     P(freeze)                                \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -179,6 +179,7 @@ namespace JS {
     P(forEach)                               \
     P(format)                                \
     P(formatMatcher)                         \
+    P(formatRange)                           \
     P(formatToParts)                         \
     P(fractionalSecondDigits)                \
     P(freeze)                                \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -38,6 +38,7 @@
     M(IntlInvalidDateTimeFormatOption, "Option {} cannot be set when also providing {}")                                                \
     M(IntlInvalidLanguageTag, "{} is not a structurally valid language tag")                                                            \
     M(IntlInvalidTime, "Time value must be between -8.64E15 and 8.64E15")                                                               \
+    M(IntlStartTimeAfterEndTime, "Start time {} is after end time {}")                                                                  \
     M(IntlMinimumExceedsMaximum, "Minimum value {} is larger than maximum value {}")                                                    \
     M(IntlNumberIsNaNOrOutOfRange, "Value {} is NaN or is not between {} and {}")                                                       \
     M(IntlOptionUndefined, "Option {} must be defined when option {} is {}")                                                            \

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -711,32 +711,42 @@ Optional<Unicode::CalendarPattern> best_fit_format_matcher(Unicode::CalendarPatt
 }
 
 struct StyleAndValue {
+    StringView name {};
     Unicode::CalendarPatternStyle style {};
     i32 value { 0 };
 };
 
 static Optional<StyleAndValue> find_calendar_field(StringView name, DateTimeFormat const& date_time_format, LocalTime const& local_time)
 {
-    auto make_style_and_value = [](auto style, auto value) {
-        return StyleAndValue { style, static_cast<i32>(value) };
+    auto make_style_and_value = [](auto name, auto style, auto value) {
+        return StyleAndValue { name, style, static_cast<i32>(value) };
     };
 
-    if (name == "weekday"sv)
-        return make_style_and_value(date_time_format.weekday(), local_time.weekday);
-    if (name == "era"sv)
-        return make_style_and_value(date_time_format.era(), local_time.era);
-    if (name == "year"sv)
-        return make_style_and_value(date_time_format.year(), local_time.year);
-    if (name == "month"sv)
-        return make_style_and_value(date_time_format.month(), local_time.month);
-    if (name == "day"sv)
-        return make_style_and_value(date_time_format.day(), local_time.day);
-    if (name == "hour"sv)
-        return make_style_and_value(date_time_format.hour(), local_time.hour);
-    if (name == "minute"sv)
-        return make_style_and_value(date_time_format.minute(), local_time.minute);
-    if (name == "second"sv)
-        return make_style_and_value(date_time_format.second(), local_time.second);
+    constexpr auto weekday = "weekday"sv;
+    constexpr auto era = "era"sv;
+    constexpr auto year = "year"sv;
+    constexpr auto month = "month"sv;
+    constexpr auto day = "day"sv;
+    constexpr auto hour = "hour"sv;
+    constexpr auto minute = "minute"sv;
+    constexpr auto second = "second"sv;
+
+    if (name == weekday)
+        return make_style_and_value(weekday, date_time_format.weekday(), local_time.weekday);
+    if (name == era)
+        return make_style_and_value(era, date_time_format.era(), local_time.era);
+    if (name == year)
+        return make_style_and_value(year, date_time_format.year(), local_time.year);
+    if (name == month)
+        return make_style_and_value(month, date_time_format.month(), local_time.month);
+    if (name == day)
+        return make_style_and_value(day, date_time_format.day(), local_time.day);
+    if (name == hour)
+        return make_style_and_value(hour, date_time_format.hour(), local_time.hour);
+    if (name == minute)
+        return make_style_and_value(minute, date_time_format.minute(), local_time.minute);
+    if (name == second)
+        return make_style_and_value(second, date_time_format.second(), local_time.second);
     return {};
 }
 
@@ -969,7 +979,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObjec
             }
 
             // xi. Append a new Record { [[Type]]: p, [[Value]]: fv } as the last element of the list result.
-            result.append({ part, move(formatted_value) });
+            result.append({ style_and_value->name, move(formatted_value) });
         }
 
         // g. Else if p is equal to "ampm", then

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -1404,6 +1404,45 @@ ThrowCompletionOr<String> format_date_time_range(GlobalObject& global_object, Da
     return result.build();
 }
 
+// 11.1.13 FormatDateTimeRangeToParts ( dateTimeFormat, x, y ), https://tc39.es/ecma402/#sec-formatdatetimerangetoparts
+ThrowCompletionOr<Array*> format_date_time_range_to_parts(GlobalObject& global_object, DateTimeFormat& date_time_format, Value start, Value end)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Let parts be ? PartitionDateTimeRangePattern(dateTimeFormat, x, y).
+    auto parts = TRY(partition_date_time_range_pattern(global_object, date_time_format, start, end));
+
+    // 2. Let result be ArrayCreate(0).
+    auto* result = MUST(Array::create(global_object, 0));
+
+    // 3. Let n be 0.
+    size_t n = 0;
+
+    // 4. For each Record { [[Type]], [[Value]], [[Source]] } part in parts, do
+    for (auto& part : parts) {
+        // a. Let O be OrdinaryObjectCreate(%ObjectPrototype%).
+        auto* object = Object::create(global_object, global_object.object_prototype());
+
+        // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
+        MUST(object->create_data_property_or_throw(vm.names.type, js_string(vm, part.type)));
+
+        // c. Perform ! CreateDataPropertyOrThrow(O, "value", part.[[Value]]).
+        MUST(object->create_data_property_or_throw(vm.names.value, js_string(vm, move(part.value))));
+
+        // d. Perform ! CreateDataPropertyOrThrow(O, "source", part.[[Source]]).
+        MUST(object->create_data_property_or_throw(vm.names.source, js_string(vm, part.source)));
+
+        // e. Perform ! CreateDataProperty(result, ! ToString(n), O).
+        MUST(result->create_data_property_or_throw(n, object));
+
+        // f. Increment n by 1.
+        ++n;
+    }
+
+    // 5. Return result.
+    return result;
+}
+
 // 11.1.14 ToLocalTime ( t, calendar, timeZone ), https://tc39.es/ecma402/#sec-tolocaltime
 ThrowCompletionOr<LocalTime> to_local_time(GlobalObject& global_object, double time, StringView calendar, [[maybe_unused]] StringView time_zone)
 {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -205,6 +205,7 @@ ThrowCompletionOr<String> format_date_time(GlobalObject& global_object, DateTime
 ThrowCompletionOr<Array*> format_date_time_to_parts(GlobalObject& global_object, DateTimeFormat& date_time_format, Value time);
 ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_pattern(GlobalObject& global_object, DateTimeFormat& date_time_format, Value start, Value end);
 ThrowCompletionOr<String> format_date_time_range(GlobalObject& global_object, DateTimeFormat& date_time_format, Value start, Value end);
+ThrowCompletionOr<Array*> format_date_time_range_to_parts(GlobalObject& global_object, DateTimeFormat& date_time_format, Value start, Value end);
 ThrowCompletionOr<LocalTime> to_local_time(GlobalObject& global_object, double time, StringView calendar, StringView time_zone);
 
 template<typename Callback>

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -79,6 +79,9 @@ public:
     String const& pattern() const { return Patterns::pattern; };
     void set_pattern(String pattern) { Patterns::pattern = move(pattern); }
 
+    Span<Unicode::CalendarRangePattern const> range_patterns() const { return m_range_patterns.span(); };
+    void set_range_patterns(Vector<Unicode::CalendarRangePattern> range_patterns) { m_range_patterns = move(range_patterns); }
+
     bool has_era() const { return Patterns::era.has_value(); }
     Unicode::CalendarPatternStyle era() const { return *Patterns::era; };
     StringView era_string() const { return Unicode::calendar_pattern_style_to_string(*Patterns::era); }
@@ -131,14 +134,15 @@ private:
 
     virtual void visit_edges(Visitor&) override;
 
-    String m_locale;                            // [[Locale]]
-    String m_calendar;                          // [[Calendar]]
-    String m_numbering_system;                  // [[NumberingSystem]]
-    Optional<Unicode::HourCycle> m_hour_cycle;  // [[HourCycle]]
-    String m_time_zone;                         // [[TimeZone]]
-    Optional<Style> m_date_style;               // [[DateStyle]]
-    Optional<Style> m_time_style;               // [[TimeStyle]]
-    NativeFunction* m_bound_format { nullptr }; // [[BoundFormat]]
+    String m_locale;                                        // [[Locale]]
+    String m_calendar;                                      // [[Calendar]]
+    String m_numbering_system;                              // [[NumberingSystem]]
+    Optional<Unicode::HourCycle> m_hour_cycle;              // [[HourCycle]]
+    String m_time_zone;                                     // [[TimeZone]]
+    Optional<Style> m_date_style;                           // [[DateStyle]]
+    Optional<Style> m_time_style;                           // [[TimeStyle]]
+    Vector<Unicode::CalendarRangePattern> m_range_patterns; // [[RangePatterns]]
+    NativeFunction* m_bound_format { nullptr };             // [[BoundFormat]]
 
     String m_data_locale;
 };

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -175,15 +175,36 @@ struct LocalTime {
     bool in_dst { false }; // [[InDST]]
 };
 
+struct PatternPartitionWithSource : public PatternPartition {
+    static Vector<PatternPartitionWithSource> create_from_parent_list(Vector<PatternPartition> partitions)
+    {
+        Vector<PatternPartitionWithSource> result;
+        result.ensure_capacity(partitions.size());
+
+        for (auto& partition : partitions) {
+            PatternPartitionWithSource partition_with_source {};
+            partition_with_source.type = partition.type;
+            partition_with_source.value = move(partition.value);
+            result.append(move(partition_with_source));
+        }
+
+        return result;
+    }
+
+    StringView source;
+};
+
 ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& global_object, DateTimeFormat& date_time_format, Value locales_value, Value options_value);
 ThrowCompletionOr<Object*> to_date_time_options(GlobalObject& global_object, Value options_value, OptionRequired, OptionDefaults);
 Optional<Unicode::CalendarPattern> date_time_style_format(StringView data_locale, DateTimeFormat& date_time_format);
 Optional<Unicode::CalendarPattern> basic_format_matcher(Unicode::CalendarPattern const& options, Vector<Unicode::CalendarPattern> formats);
 Optional<Unicode::CalendarPattern> best_fit_format_matcher(Unicode::CalendarPattern const& options, Vector<Unicode::CalendarPattern> formats);
-ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObject& global_object, DateTimeFormat& date_time_format, Vector<PatternPartition> pattern_parts, Value time, Value range_format_options);
+ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObject& global_object, DateTimeFormat& date_time_format, Vector<PatternPartition> pattern_parts, Value time, Unicode::CalendarPattern const* range_format_options);
 ThrowCompletionOr<Vector<PatternPartition>> partition_date_time_pattern(GlobalObject& global_object, DateTimeFormat& date_time_format, Value time);
 ThrowCompletionOr<String> format_date_time(GlobalObject& global_object, DateTimeFormat& date_time_format, Value time);
 ThrowCompletionOr<Array*> format_date_time_to_parts(GlobalObject& global_object, DateTimeFormat& date_time_format, Value time);
+ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_pattern(GlobalObject& global_object, DateTimeFormat& date_time_format, Value start, Value end);
+ThrowCompletionOr<String> format_date_time_range(GlobalObject& global_object, DateTimeFormat& date_time_format, Value start, Value end);
 ThrowCompletionOr<LocalTime> to_local_time(GlobalObject& global_object, double time, StringView calendar, StringView time_zone);
 
 template<typename Callback>

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
@@ -32,6 +32,7 @@ void DateTimeFormatPrototype::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.formatToParts, format_to_parts, 1, attr);
+    define_native_function(vm.names.formatRange, format_range, 2, attr);
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
@@ -80,6 +81,33 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_to_parts)
 
     // 5. Return ? FormatDateTimeToParts(dtf, x).
     return TRY(format_date_time_to_parts(global_object, *date_time_format, date));
+}
+
+// 11.4.5 Intl.DateTimeFormat.prototype.formatRange ( startDate, endDate ), https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatRange
+JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_range)
+{
+    auto start_date = vm.argument(0);
+    auto end_date = vm.argument(1);
+
+    // 1. Let dtf be this value.
+    // 2. Perform ? RequireInternalSlot(dtf, [[InitializedDateTimeFormat]]).
+    auto* date_time_format = TRY(typed_this_object(global_object));
+
+    // 3. If startDate is undefined or endDate is undefined, throw a TypeError exception.
+    if (start_date.is_undefined())
+        return vm.throw_completion<TypeError>(global_object, ErrorType::IsUndefined, "startDate"sv);
+    if (end_date.is_undefined())
+        return vm.throw_completion<TypeError>(global_object, ErrorType::IsUndefined, "endDate"sv);
+
+    // 4. Let x be ? ToNumber(startDate).
+    start_date = TRY(start_date.to_number(global_object));
+
+    // 5. Let y be ? ToNumber(endDate).
+    end_date = TRY(end_date.to_number(global_object));
+
+    // 6. Return ? FormatDateTimeRange(dtf, x, y).
+    auto formatted = TRY(format_date_time_range(global_object, *date_time_format, start_date, end_date));
+    return js_string(vm, move(formatted));
 }
 
 // 11.4.7 Intl.DateTimeFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
@@ -33,6 +33,7 @@ void DateTimeFormatPrototype::initialize(GlobalObject& global_object)
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.formatToParts, format_to_parts, 1, attr);
     define_native_function(vm.names.formatRange, format_range, 2, attr);
+    define_native_function(vm.names.formatRangeToParts, format_range_to_parts, 2, attr);
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
@@ -108,6 +109,32 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_range)
     // 6. Return ? FormatDateTimeRange(dtf, x, y).
     auto formatted = TRY(format_date_time_range(global_object, *date_time_format, start_date, end_date));
     return js_string(vm, move(formatted));
+}
+
+// 11.4.6 Intl.DateTimeFormat.prototype.formatRangeToParts ( startDate, endDate ), https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.formatRangeToParts
+JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_range_to_parts)
+{
+    auto start_date = vm.argument(0);
+    auto end_date = vm.argument(1);
+
+    // 1. Let dtf be this value.
+    // 2. Perform ? RequireInternalSlot(dtf, [[InitializedDateTimeFormat]]).
+    auto* date_time_format = TRY(typed_this_object(global_object));
+
+    // 3. If startDate is undefined or endDate is undefined, throw a TypeError exception.
+    if (start_date.is_undefined())
+        return vm.throw_completion<TypeError>(global_object, ErrorType::IsUndefined, "startDate"sv);
+    if (end_date.is_undefined())
+        return vm.throw_completion<TypeError>(global_object, ErrorType::IsUndefined, "endDate"sv);
+
+    // 4. Let x be ? ToNumber(startDate).
+    start_date = TRY(start_date.to_number(global_object));
+
+    // 5. Let y be ? ToNumber(endDate).
+    end_date = TRY(end_date.to_number(global_object));
+
+    // 6. Return ? FormatDateTimeRangeToParts(dtf, x, y).
+    return TRY(format_date_time_range_to_parts(global_object, *date_time_format, start_date, end_date));
 }
 
 // 11.4.7 Intl.DateTimeFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
@@ -22,6 +22,7 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
+    JS_DECLARE_NATIVE_FUNCTION(format_range);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.h
@@ -23,6 +23,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(format);
     JS_DECLARE_NATIVE_FUNCTION(format_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(format_range);
+    JS_DECLARE_NATIVE_FUNCTION(format_range_to_parts);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRange.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRange.js
@@ -1,0 +1,220 @@
+describe("errors", () => {
+    test("called on non-DateTimeFormat object", () => {
+        expect(() => {
+            Intl.DateTimeFormat.prototype.formatRange(1, 2);
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.DateTimeFormat");
+    });
+
+    test("called with undefined values", () => {
+        expect(() => {
+            Intl.DateTimeFormat().formatRange();
+        }).toThrowWithMessage(TypeError, "startDate is undefined");
+
+        expect(() => {
+            Intl.DateTimeFormat().formatRange(1);
+        }).toThrowWithMessage(TypeError, "endDate is undefined");
+    });
+
+    test("called with values that cannot be converted to numbers", () => {
+        expect(() => {
+            Intl.DateTimeFormat().formatRange(1, Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            Intl.DateTimeFormat().formatRange(1n, 1);
+        }).toThrowWithMessage(TypeError, "Cannot convert BigInt to number");
+    });
+
+    test("time value cannot be clipped", () => {
+        [NaN, -8.65e15, 8.65e15].forEach(d => {
+            expect(() => {
+                Intl.DateTimeFormat().formatRange(d, 1);
+            }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+
+            expect(() => {
+                Intl.DateTimeFormat().formatRange(1, d);
+            }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+        });
+    });
+
+    test("called with values in bad order", () => {
+        expect(() => {
+            Intl.DateTimeFormat().formatRange(new Date(2021), new Date(1989));
+        }).toThrowWithMessage(RangeError, "Start time 2021 is after end time 1989");
+    });
+});
+
+const d0 = Date.UTC(1989, 0, 23, 7, 8, 9, 45);
+const d1 = Date.UTC(2021, 11, 7, 17, 40, 50, 456);
+
+describe("equal dates are squashed", () => {
+    test("with date fields", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            year: "numeric",
+            month: "long",
+            day: "2-digit",
+        });
+        expect(en.formatRange(d0, d0)).toBe("January 23, 1989");
+        expect(en.formatRange(d1, d1)).toBe("December 07, 2021");
+
+        const ja = new Intl.DateTimeFormat("ja", {
+            year: "numeric",
+            month: "long",
+            day: "2-digit",
+        });
+        expect(ja.formatRange(d0, d0)).toBe("1989/1月/23");
+        expect(ja.formatRange(d1, d1)).toBe("2021/12月/07");
+    });
+
+    test("with time fields", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZone: "UTC",
+        });
+        expect(en.formatRange(d0, d0)).toBe("7:08:09 AM");
+        expect(en.formatRange(d1, d1)).toBe("5:40:50 PM");
+
+        const ja = new Intl.DateTimeFormat("ja", {
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZone: "UTC",
+        });
+        expect(ja.formatRange(d0, d0)).toBe("7:08:09");
+        expect(ja.formatRange(d1, d1)).toBe("17:40:50");
+    });
+
+    test("with mixed fields", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            year: "numeric",
+            month: "long",
+            day: "2-digit",
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZone: "UTC",
+        });
+        expect(en.formatRange(d0, d0)).toBe("January 23, 1989 at 7:08:09 AM");
+        expect(en.formatRange(d1, d1)).toBe("December 07, 2021 at 5:40:50 PM");
+
+        const ja = new Intl.DateTimeFormat("ja", {
+            year: "numeric",
+            month: "long",
+            day: "2-digit",
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZone: "UTC",
+        });
+        expect(ja.formatRange(d0, d0)).toBe("1989/1月/23 7:08:09");
+        expect(ja.formatRange(d1, d1)).toBe("2021/12月/07 17:40:50");
+    });
+
+    test("with date/time style fields", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            dateStyle: "full",
+            timeStyle: "medium",
+            timeZone: "UTC",
+        });
+        expect(en.formatRange(d0, d0)).toBe("Monday, January 23, 1989 at 7:08:09 AM");
+        expect(en.formatRange(d1, d1)).toBe("Tuesday, December 7, 2021 at 5:40:50 PM");
+
+        const ja = new Intl.DateTimeFormat("ja", {
+            dateStyle: "full",
+            timeStyle: "medium",
+            timeZone: "UTC",
+        });
+        expect(ja.formatRange(d0, d0)).toBe("1989年1月23日月曜日 7:08:09");
+        expect(ja.formatRange(d1, d1)).toBe("2021年12月7日火曜日 17:40:50");
+    });
+});
+
+describe("dateStyle", () => {
+    // prettier-ignore
+    const data = [
+        { date: "full", en: "Monday, January 23, 1989 – Tuesday, December 7, 2021", ja: "1989年1月23日月曜日～2021年12月7日火曜日" },
+        { date: "long", en: "January 23, 1989 – December 7, 2021", ja: "1989/01/23～2021/12/07" },
+        { date: "medium", en: "Jan 23, 1989 – Dec 7, 2021", ja: "1989/01/23～2021/12/07" },
+        { date: "short", en: "1/23/89 – 12/7/21", ja: "1989/01/23～2021/12/07" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { dateStyle: d.date });
+            expect(en.formatRange(d0, d1)).toBe(d.en);
+
+            // If this test is to be changed, take care to note the "long" style for the ja locale is an intentionally
+            // chosen complex test case. The format pattern is "y年M月d日" and its skeleton is "yMd" - note that the
+            // month field has a numeric style. However, the interval patterns that match the "yMd" skeleton are all
+            // "y/MM/dd～y/MM/dd" - the month field there conflicts with a 2-digit style. This exercises the step in the
+            // FormatDateTimePattern AO to choose the style from rangeFormatOptions instead of dateTimeFormat (step 15.f.i
+            // as of when this test was written).
+            const ja = new Intl.DateTimeFormat("ja", { dateStyle: d.date });
+            expect(ja.formatRange(d0, d1)).toBe(d.ja);
+        });
+    });
+});
+
+describe("timeStyle", () => {
+    // prettier-ignore
+    const data = [
+        // FIXME: These results should include the date, even though it isn't requested, because the start/end dates
+        //        are more than just hours apart. See the FIXME in PartitionDateTimeRangePattern.
+        { time: "full", en: "7:08:09 AM Coordinated Universal Time – 5:40:50 PM Coordinated Universal Time", ja: "7時08分09秒 協定世界時～17時40分50秒 協定世界時" },
+        { time: "long", en: "7:08:09 AM UTC – 5:40:50 PM UTC", ja: "7:08:09 UTC～17:40:50 UTC" },
+        { time: "medium", en: "7:08:09 AM – 5:40:50 PM", ja: "7:08:09～17:40:50" },
+        { time: "short", en: "7:08 AM – 5:40 PM", ja: "7:08～17:40" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", { timeStyle: d.time, timeZone: "UTC" });
+            expect(en.formatRange(d0, d1)).toBe(d.en);
+
+            const ja = new Intl.DateTimeFormat("ja", { timeStyle: d.time, timeZone: "UTC" });
+            expect(ja.formatRange(d0, d1)).toBe(d.ja);
+        });
+    });
+});
+
+describe("dateStyle + timeStyle", () => {
+    // prettier-ignore
+    const data = [
+        { date: "full", time: "full", en: "Monday, January 23, 1989 at 7:08:09 AM Coordinated Universal Time – Tuesday, December 7, 2021 at 5:40:50 PM Coordinated Universal Time", ja: "1989年1月23日月曜日 7時08分09秒 協定世界時～2021年12月7日火曜日 17時40分50秒 協定世界時" },
+        { date: "full", time: "long", en: "Monday, January 23, 1989 at 7:08:09 AM UTC – Tuesday, December 7, 2021 at 5:40:50 PM UTC", ja: "1989年1月23日月曜日 7:08:09 UTC～2021年12月7日火曜日 17:40:50 UTC" },
+        { date: "full", time: "medium", en: "Monday, January 23, 1989 at 7:08:09 AM – Tuesday, December 7, 2021 at 5:40:50 PM", ja: "1989年1月23日月曜日 7:08:09～2021年12月7日火曜日 17:40:50" },
+        { date: "full", time: "short", en: "Monday, January 23, 1989 at 7:08 AM – Tuesday, December 7, 2021 at 5:40 PM", ja: "1989年1月23日月曜日 7:08～2021年12月7日火曜日 17:40" },
+        { date: "long", time: "full", en: "January 23, 1989 at 7:08:09 AM Coordinated Universal Time – December 7, 2021 at 5:40:50 PM Coordinated Universal Time", ja: "1989年1月23日 7時08分09秒 協定世界時～2021年12月7日 17時40分50秒 協定世界時" },
+        { date: "long", time: "long", en: "January 23, 1989 at 7:08:09 AM UTC – December 7, 2021 at 5:40:50 PM UTC", ja: "1989年1月23日 7:08:09 UTC～2021年12月7日 17:40:50 UTC" },
+        { date: "long", time: "medium", en: "January 23, 1989 at 7:08:09 AM – December 7, 2021 at 5:40:50 PM", ja: "1989年1月23日 7:08:09～2021年12月7日 17:40:50" },
+        { date: "long", time: "short", en: "January 23, 1989 at 7:08 AM – December 7, 2021 at 5:40 PM", ja: "1989年1月23日 7:08～2021年12月7日 17:40" },
+        { date: "medium", time: "full", en: "Jan 23, 1989, 7:08:09 AM Coordinated Universal Time – Dec 7, 2021, 5:40:50 PM Coordinated Universal Time", ja: "1989/01/23 7時08分09秒 協定世界時～2021/12/07 17時40分50秒 協定世界時" },
+        { date: "medium", time: "long", en: "Jan 23, 1989, 7:08:09 AM UTC – Dec 7, 2021, 5:40:50 PM UTC", ja: "1989/01/23 7:08:09 UTC～2021/12/07 17:40:50 UTC" },
+        { date: "medium", time: "medium", en: "Jan 23, 1989, 7:08:09 AM – Dec 7, 2021, 5:40:50 PM", ja: "1989/01/23 7:08:09～2021/12/07 17:40:50" },
+        { date: "medium", time: "short", en: "Jan 23, 1989, 7:08 AM – Dec 7, 2021, 5:40 PM", ja: "1989/01/23 7:08～2021/12/07 17:40" },
+        { date: "short", time: "full", en: "1/23/89, 7:08:09 AM Coordinated Universal Time – 12/7/21, 5:40:50 PM Coordinated Universal Time", ja: "1989/01/23 7時08分09秒 協定世界時～2021/12/07 17時40分50秒 協定世界時" },
+        { date: "short", time: "long", en: "1/23/89, 7:08:09 AM UTC – 12/7/21, 5:40:50 PM UTC", ja: "1989/01/23 7:08:09 UTC～2021/12/07 17:40:50 UTC" },
+        { date: "short", time: "medium", en: "1/23/89, 7:08:09 AM – 12/7/21, 5:40:50 PM", ja: "1989/01/23 7:08:09～2021/12/07 17:40:50" },
+        { date: "short", time: "short", en: "1/23/89, 7:08 AM – 12/7/21, 5:40 PM", ja: "1989/01/23 7:08～2021/12/07 17:40" },
+    ];
+
+    test("all", () => {
+        data.forEach(d => {
+            const en = new Intl.DateTimeFormat("en", {
+                dateStyle: d.date,
+                timeStyle: d.time,
+                timeZone: "UTC",
+            });
+            expect(en.formatRange(d0, d1)).toBe(d.en);
+
+            const ja = new Intl.DateTimeFormat("ja", {
+                dateStyle: d.date,
+                timeStyle: d.time,
+                timeZone: "UTC",
+            });
+            expect(ja.formatRange(d0, d1)).toBe(d.ja);
+        });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
@@ -1,0 +1,500 @@
+describe("errors", () => {
+    test("called on non-DateTimeFormat object", () => {
+        expect(() => {
+            Intl.DateTimeFormat.prototype.formatRangeToParts(1, 2);
+        }).toThrowWithMessage(TypeError, "Not an object of type Intl.DateTimeFormat");
+    });
+
+    test("called with undefined values", () => {
+        expect(() => {
+            Intl.DateTimeFormat().formatRangeToParts();
+        }).toThrowWithMessage(TypeError, "startDate is undefined");
+
+        expect(() => {
+            Intl.DateTimeFormat().formatRangeToParts(1);
+        }).toThrowWithMessage(TypeError, "endDate is undefined");
+    });
+
+    test("called with values that cannot be converted to numbers", () => {
+        expect(() => {
+            Intl.DateTimeFormat().formatRangeToParts(1, Symbol.hasInstance);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            Intl.DateTimeFormat().formatRangeToParts(1n, 1);
+        }).toThrowWithMessage(TypeError, "Cannot convert BigInt to number");
+    });
+
+    test("time value cannot be clipped", () => {
+        [NaN, -8.65e15, 8.65e15].forEach(d => {
+            expect(() => {
+                Intl.DateTimeFormat().formatRangeToParts(d, 1);
+            }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+
+            expect(() => {
+                Intl.DateTimeFormat().formatRangeToParts(1, d);
+            }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+        });
+    });
+
+    test("called with values in bad order", () => {
+        expect(() => {
+            Intl.DateTimeFormat().formatRangeToParts(new Date(2021), new Date(1989));
+        }).toThrowWithMessage(RangeError, "Start time 2021 is after end time 1989");
+    });
+});
+
+const d0 = Date.UTC(1989, 0, 23, 7, 8, 9, 45);
+const d1 = Date.UTC(2021, 11, 7, 17, 40, 50, 456);
+
+describe("equal dates are squashed", () => {
+    test("with date fields", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            year: "numeric",
+            month: "long",
+            day: "2-digit",
+        });
+        expect(en.formatRangeToParts(d0, d0)).toEqual([
+            { type: "month", value: "January", source: "shared" },
+            { type: "literal", value: " ", source: "shared" },
+            { type: "day", value: "23", source: "shared" },
+            { type: "literal", value: ", ", source: "shared" },
+            { type: "year", value: "1989", source: "shared" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", {
+            year: "numeric",
+            month: "long",
+            day: "2-digit",
+        });
+        expect(ja.formatRangeToParts(d0, d0)).toEqual([
+            { type: "year", value: "1989", source: "shared" },
+            { type: "literal", value: "/", source: "shared" },
+            { type: "month", value: "1月", source: "shared" },
+            { type: "literal", value: "/", source: "shared" },
+            { type: "day", value: "23", source: "shared" },
+        ]);
+    });
+
+    test("with time fields", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZone: "UTC",
+        });
+        expect(en.formatRangeToParts(d0, d0)).toEqual([
+            { type: "hour", value: "7", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "minute", value: "08", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "second", value: "09", source: "shared" },
+            { type: "literal", value: " ", source: "shared" },
+            { type: "dayPeriod", value: "AM", source: "shared" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", {
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZone: "UTC",
+        });
+        expect(ja.formatRangeToParts(d0, d0)).toEqual([
+            { type: "hour", value: "7", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "minute", value: "08", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "second", value: "09", source: "shared" },
+        ]);
+    });
+
+    test("with mixed fields", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            year: "numeric",
+            month: "long",
+            day: "2-digit",
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZone: "UTC",
+        });
+        expect(en.formatRangeToParts(d0, d0)).toEqual([
+            { type: "month", value: "January", source: "shared" },
+            { type: "literal", value: " ", source: "shared" },
+            { type: "day", value: "23", source: "shared" },
+            { type: "literal", value: ", ", source: "shared" },
+            { type: "year", value: "1989", source: "shared" },
+            { type: "literal", value: " at ", source: "shared" },
+            { type: "hour", value: "7", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "minute", value: "08", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "second", value: "09", source: "shared" },
+            { type: "literal", value: " ", source: "shared" },
+            { type: "dayPeriod", value: "AM", source: "shared" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", {
+            year: "numeric",
+            month: "long",
+            day: "2-digit",
+            hour: "numeric",
+            minute: "2-digit",
+            second: "2-digit",
+            timeZone: "UTC",
+        });
+        expect(ja.formatRangeToParts(d0, d0)).toEqual([
+            { type: "year", value: "1989", source: "shared" },
+            { type: "literal", value: "/", source: "shared" },
+            { type: "month", value: "1月", source: "shared" },
+            { type: "literal", value: "/", source: "shared" },
+            { type: "day", value: "23", source: "shared" },
+            { type: "literal", value: " ", source: "shared" },
+            { type: "hour", value: "7", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "minute", value: "08", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "second", value: "09", source: "shared" },
+        ]);
+    });
+
+    test("with date/time style fields", () => {
+        const en = new Intl.DateTimeFormat("en", {
+            dateStyle: "full",
+            timeStyle: "medium",
+            timeZone: "UTC",
+        });
+        expect(en.formatRangeToParts(d0, d0)).toEqual([
+            { type: "weekday", value: "Monday", source: "shared" },
+            { type: "literal", value: ", ", source: "shared" },
+            { type: "month", value: "January", source: "shared" },
+            { type: "literal", value: " ", source: "shared" },
+            { type: "day", value: "23", source: "shared" },
+            { type: "literal", value: ", ", source: "shared" },
+            { type: "year", value: "1989", source: "shared" },
+            { type: "literal", value: " at ", source: "shared" },
+            { type: "hour", value: "7", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "minute", value: "08", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "second", value: "09", source: "shared" },
+            { type: "literal", value: " ", source: "shared" },
+            { type: "dayPeriod", value: "AM", source: "shared" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", {
+            dateStyle: "full",
+            timeStyle: "medium",
+            timeZone: "UTC",
+        });
+        expect(ja.formatRangeToParts(d0, d0)).toEqual([
+            { type: "year", value: "1989", source: "shared" },
+            { type: "literal", value: "年", source: "shared" },
+            { type: "month", value: "1", source: "shared" },
+            { type: "literal", value: "月", source: "shared" },
+            { type: "day", value: "23", source: "shared" },
+            { type: "literal", value: "日", source: "shared" },
+            { type: "weekday", value: "月曜日", source: "shared" },
+            { type: "literal", value: " ", source: "shared" },
+            { type: "hour", value: "7", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "minute", value: "08", source: "shared" },
+            { type: "literal", value: ":", source: "shared" },
+            { type: "second", value: "09", source: "shared" },
+        ]);
+    });
+});
+
+describe("dateStyle", () => {
+    test("full", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "full" });
+        expect(en.formatRangeToParts(d0, d1)).toEqual([
+            { type: "weekday", value: "Monday", source: "startRange" },
+            { type: "literal", value: ", ", source: "startRange" },
+            { type: "month", value: "January", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
+            { type: "literal", value: ", ", source: "startRange" },
+            { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "weekday", value: "Tuesday", source: "endRange" },
+            { type: "literal", value: ", ", source: "endRange" },
+            { type: "month", value: "December", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "day", value: "7", source: "endRange" },
+            { type: "literal", value: ", ", source: "endRange" },
+            { type: "year", value: "2021", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { dateStyle: "full" });
+        expect(ja.formatRangeToParts(d0, d1)).toEqual([
+            { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: "年", source: "startRange" },
+            { type: "month", value: "1", source: "startRange" },
+            { type: "literal", value: "月", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
+            { type: "literal", value: "日", source: "startRange" },
+            { type: "weekday", value: "月曜日", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "year", value: "2021", source: "endRange" },
+            { type: "literal", value: "年", source: "endRange" },
+            { type: "month", value: "12", source: "endRange" },
+            { type: "literal", value: "月", source: "endRange" },
+            { type: "day", value: "7", source: "endRange" },
+            { type: "literal", value: "日", source: "endRange" },
+            { type: "weekday", value: "火曜日", source: "endRange" },
+        ]);
+    });
+
+    test("long", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "long" });
+        expect(en.formatRangeToParts(d0, d1)).toEqual([
+            { type: "month", value: "January", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
+            { type: "literal", value: ", ", source: "startRange" },
+            { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "month", value: "December", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "day", value: "7", source: "endRange" },
+            { type: "literal", value: ", ", source: "endRange" },
+            { type: "year", value: "2021", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { dateStyle: "long" });
+        expect(ja.formatRangeToParts(d0, d1)).toEqual([
+            { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: "/", source: "startRange" },
+            { type: "month", value: "01", source: "startRange" },
+            { type: "literal", value: "/", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "year", value: "2021", source: "endRange" },
+            { type: "literal", value: "/", source: "endRange" },
+            { type: "month", value: "12", source: "endRange" },
+            { type: "literal", value: "/", source: "endRange" },
+            { type: "day", value: "07", source: "endRange" },
+        ]);
+    });
+
+    test("medium", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "medium" });
+        expect(en.formatRangeToParts(d0, d1)).toEqual([
+            { type: "month", value: "Jan", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
+            { type: "literal", value: ", ", source: "startRange" },
+            { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "month", value: "Dec", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "day", value: "7", source: "endRange" },
+            { type: "literal", value: ", ", source: "endRange" },
+            { type: "year", value: "2021", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { dateStyle: "medium" });
+        expect(ja.formatRangeToParts(d0, d1)).toEqual([
+            { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: "/", source: "startRange" },
+            { type: "month", value: "01", source: "startRange" },
+            { type: "literal", value: "/", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "year", value: "2021", source: "endRange" },
+            { type: "literal", value: "/", source: "endRange" },
+            { type: "month", value: "12", source: "endRange" },
+            { type: "literal", value: "/", source: "endRange" },
+            { type: "day", value: "07", source: "endRange" },
+        ]);
+    });
+
+    test("short", () => {
+        const en = new Intl.DateTimeFormat("en", { dateStyle: "short" });
+        expect(en.formatRangeToParts(d0, d1)).toEqual([
+            { type: "month", value: "1", source: "startRange" },
+            { type: "literal", value: "/", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
+            { type: "literal", value: "/", source: "startRange" },
+            { type: "year", value: "89", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "month", value: "12", source: "endRange" },
+            { type: "literal", value: "/", source: "endRange" },
+            { type: "day", value: "7", source: "endRange" },
+            { type: "literal", value: "/", source: "endRange" },
+            { type: "year", value: "21", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { dateStyle: "short" });
+        expect(ja.formatRangeToParts(d0, d1)).toEqual([
+            { type: "year", value: "1989", source: "startRange" },
+            { type: "literal", value: "/", source: "startRange" },
+            { type: "month", value: "01", source: "startRange" },
+            { type: "literal", value: "/", source: "startRange" },
+            { type: "day", value: "23", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "year", value: "2021", source: "endRange" },
+            { type: "literal", value: "/", source: "endRange" },
+            { type: "month", value: "12", source: "endRange" },
+            { type: "literal", value: "/", source: "endRange" },
+            { type: "day", value: "07", source: "endRange" },
+        ]);
+    });
+});
+
+describe("timeStyle", () => {
+    // FIXME: These results should include the date, even though it isn't requested, because the start/end dates
+    //        are more than just hours apart. See the FIXME in PartitionDateTimeRangePattern.
+    test("full", () => {
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "full" });
+        expect(en.formatRangeToParts(d0, d1)).toEqual([
+            { type: "hour", value: "7", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "minute", value: "08", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "second", value: "09", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "dayPeriod", value: "AM", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "timeZoneName", value: "Coordinated Universal Time", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "hour", value: "5", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "minute", value: "40", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "second", value: "50", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "dayPeriod", value: "PM", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "timeZoneName", value: "Coordinated Universal Time", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "full" });
+        expect(ja.formatRangeToParts(d0, d1)).toEqual([
+            { type: "hour", value: "7", source: "startRange" },
+            { type: "literal", value: "時", source: "startRange" },
+            { type: "minute", value: "08", source: "startRange" },
+            { type: "literal", value: "分", source: "startRange" },
+            { type: "second", value: "09", source: "startRange" },
+            { type: "literal", value: "秒 ", source: "startRange" },
+            { type: "timeZoneName", value: "協定世界時", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "hour", value: "17", source: "endRange" },
+            { type: "literal", value: "時", source: "endRange" },
+            { type: "minute", value: "40", source: "endRange" },
+            { type: "literal", value: "分", source: "endRange" },
+            { type: "second", value: "50", source: "endRange" },
+            { type: "literal", value: "秒 ", source: "endRange" },
+            { type: "timeZoneName", value: "協定世界時", source: "endRange" },
+        ]);
+    });
+
+    test("long", () => {
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "long" });
+        expect(en.formatRangeToParts(d0, d1)).toEqual([
+            { type: "hour", value: "7", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "minute", value: "08", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "second", value: "09", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "dayPeriod", value: "AM", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "timeZoneName", value: "UTC", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "hour", value: "5", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "minute", value: "40", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "second", value: "50", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "dayPeriod", value: "PM", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "timeZoneName", value: "UTC", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "long" });
+        expect(ja.formatRangeToParts(d0, d1)).toEqual([
+            { type: "hour", value: "7", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "minute", value: "08", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "second", value: "09", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "timeZoneName", value: "UTC", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "hour", value: "17", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "minute", value: "40", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "second", value: "50", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "timeZoneName", value: "UTC", source: "endRange" },
+        ]);
+    });
+
+    test("medium", () => {
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "medium" });
+        expect(en.formatRangeToParts(d0, d1)).toEqual([
+            { type: "hour", value: "7", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "minute", value: "08", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "second", value: "09", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "dayPeriod", value: "AM", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "hour", value: "5", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "minute", value: "40", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "second", value: "50", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "dayPeriod", value: "PM", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "medium" });
+        expect(ja.formatRangeToParts(d0, d1)).toEqual([
+            { type: "hour", value: "7", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "minute", value: "08", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "second", value: "09", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "hour", value: "17", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "minute", value: "40", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "second", value: "50", source: "endRange" },
+        ]);
+    });
+
+    test("short", () => {
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "short" });
+        expect(en.formatRangeToParts(d0, d1)).toEqual([
+            { type: "hour", value: "7", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "minute", value: "08", source: "startRange" },
+            { type: "literal", value: " ", source: "startRange" },
+            { type: "dayPeriod", value: "AM", source: "startRange" },
+            { type: "literal", value: " – ", source: "shared" },
+            { type: "hour", value: "5", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "minute", value: "40", source: "endRange" },
+            { type: "literal", value: " ", source: "endRange" },
+            { type: "dayPeriod", value: "PM", source: "endRange" },
+        ]);
+
+        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "short" });
+        expect(ja.formatRangeToParts(d0, d1)).toEqual([
+            { type: "hour", value: "7", source: "startRange" },
+            { type: "literal", value: ":", source: "startRange" },
+            { type: "minute", value: "08", source: "startRange" },
+            { type: "literal", value: "～", source: "shared" },
+            { type: "hour", value: "17", source: "endRange" },
+            { type: "literal", value: ":", source: "endRange" },
+            { type: "minute", value: "40", source: "endRange" },
+        ]);
+    });
+});

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -140,6 +140,33 @@ Vector<CalendarPattern> get_calendar_available_formats([[maybe_unused]] StringVi
 #endif
 }
 
+Optional<Unicode::CalendarRangePattern> get_calendar_default_range_format([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_calendar_default_range_format(locale, calendar);
+#else
+    return {};
+#endif
+}
+
+Vector<Unicode::CalendarRangePattern> get_calendar_range_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] StringView skeleton)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_calendar_range_formats(locale, calendar, skeleton);
+#else
+    return {};
+#endif
+}
+
+Vector<Unicode::CalendarRangePattern> get_calendar_range12_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] StringView skeleton)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_calendar_range12_formats(locale, calendar, skeleton);
+#else
+    return {};
+#endif
+}
+
 Optional<StringView> get_calendar_era_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::Era value)
 {
 #if ENABLE_UNICODE_DATA

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -100,6 +100,7 @@ struct CalendarPattern {
         callback(time_zone_name, other.time_zone_name, Field::TimeZoneName);
     }
 
+    String skeleton {};
     String pattern {};
     Optional<String> pattern12 {};
 

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -157,6 +157,7 @@ CalendarPatternStyle calendar_pattern_style_from_string(StringView style);
 StringView calendar_pattern_style_to_string(CalendarPatternStyle style);
 Vector<Unicode::HourCycle> get_regional_hour_cycles(StringView locale);
 Optional<Unicode::HourCycle> get_default_regional_hour_cycle(StringView locale);
+String combine_skeletons(StringView first, StringView second);
 Optional<CalendarFormat> get_calendar_format(StringView locale, StringView calendar, CalendarFormatType type);
 Vector<CalendarPattern> get_calendar_available_formats(StringView locale, StringView calendar);
 Optional<Unicode::CalendarRangePattern> get_calendar_default_range_format(StringView locale, StringView calendar);

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -118,6 +118,26 @@ struct CalendarPattern {
     Optional<CalendarPatternStyle> time_zone_name {};
 };
 
+struct CalendarRangePattern : public CalendarPattern {
+    enum class Field {
+        Era,
+        Year,
+        Month,
+        Day,
+        AmPm,
+        DayPeriod,
+        Hour,
+        Minute,
+        Second,
+        FractionalSecondDigits,
+    };
+
+    Optional<Field> field {};
+    String start_range {};
+    StringView separator {};
+    String end_range {};
+};
+
 enum class CalendarFormatType : u8 {
     Date,
     Time,
@@ -139,6 +159,9 @@ Vector<Unicode::HourCycle> get_regional_hour_cycles(StringView locale);
 Optional<Unicode::HourCycle> get_default_regional_hour_cycle(StringView locale);
 Optional<CalendarFormat> get_calendar_format(StringView locale, StringView calendar, CalendarFormatType type);
 Vector<CalendarPattern> get_calendar_available_formats(StringView locale, StringView calendar);
+Optional<Unicode::CalendarRangePattern> get_calendar_default_range_format(StringView locale, StringView calendar);
+Vector<Unicode::CalendarRangePattern> get_calendar_range_formats(StringView locale, StringView calendar, StringView skeleton);
+Vector<Unicode::CalendarRangePattern> get_calendar_range12_formats(StringView locale, StringView calendar, StringView skeleton);
 Optional<StringView> get_calendar_era_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Era value);
 Optional<StringView> get_calendar_month_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Month value);
 Optional<StringView> get_calendar_weekday_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Weekday value);


### PR DESCRIPTION
`Intl.DateTimeFormat` should be good to go for `Temporal` integration now :)

```js
> const d0 = Date.UTC(1989, 0, 23, 7, 8, 9, 45);
> const d1 = Date.UTC(2021, 11, 7, 17, 40, 50, 456);

> new Intl.DateTimeFormat("en", { dateStyle: "full", timeStyle: "full" }).formatRange(d0, d1);
"Monday, January 23, 1989 at 7:08:09 AM Coordinated Universal Time – Tuesday, December 7, 2021 at 5:40:50 PM Coordinated Universal Time"

> new Intl.DateTimeFormat("ja", { dateStyle: "short", timeStyle: "short" }).formatRangeToParts(d0, d1);
[ { "type": "year", "value": "1989", "source": "startRange" }, { "type": "literal", "value": "/", "source": "startRange" }, { "type": "month", "value": "01", "source": "startRange" }, { "type": "literal", "value": "/", "source": "startRange" }, { "type": "day", "value": "23", "source": "startRange" }, { "type": "literal", "value": " ", "source": "startRange" }, { "type": "hour", "value": "7", "source": "startRange" }, { "type": "literal", "value": ":", "source": "startRange" }, { "type": "minute", "value": "08", "source": "startRange" }, { "type": "literal", "value": "～", "source": "shared" }, { "type": "year", "value": "2021", "source": "endRange" }, { "type": "literal", "value": "/", "source": "endRange" }, { "type": "month", "value": "12", "source": "endRange" }, { "type": "literal", "value": "/", "source": "endRange" }, { "type": "day", "value": "07", "source": "endRange" }, { "type": "literal", "value": " ", "source": "endRange" }, { "type": "hour", "value": "17", "source": "endRange" }, { "type": "literal", "value": ":", "source": "endRange" }, { "type": "minute", "value": "40", "source": "endRange" } ]
```