### PR TITLE
LibJS: Implement ECMA-402 `Date.prototype.toLocale*String`

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -681,17 +681,29 @@ static ThrowCompletionOr<Intl::DateTimeFormat*> construct_date_time_format(Globa
     return static_cast<Intl::DateTimeFormat*>(date_time_format);
 }
 
-// 21.4.4.38 Date.prototype.toLocaleDateString ( [ reserved1 [ , reserved2 ] ] ), https://tc39.es/ecma262/#sec-date.prototype.tolocaledatestring
+// 18.4.2 Date.prototype.toLocaleDateString ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sup-date.prototype.tolocaledatestring
 JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_locale_date_string)
 {
+    auto locales = vm.argument(0);
+    auto options = vm.argument(1);
+
+    // 1. Let x be ? thisTimeValue(this value).
     auto* this_object = TRY(typed_this_object(global_object));
+    auto time = this_object->is_invalid() ? js_nan() : this_object->value_of();
 
-    if (this_object->is_invalid())
-        return js_string(vm, "Invalid Date");
+    // 2. If x is NaN, return "Invalid Date".
+    if (time.is_nan())
+        return js_string(vm, "Invalid Date"sv);
 
-    // FIXME: Optional locales, options params.
-    auto string = this_object->locale_date_string();
-    return js_string(vm, move(string));
+    // 3. Let options be ? ToDateTimeOptions(options, "date", "date").
+    options = Value(TRY(Intl::to_date_time_options(global_object, options, Intl::OptionRequired::Date, Intl::OptionDefaults::Date)));
+
+    // 4. Let dateFormat be ? Construct(%DateTimeFormat%, « locales, options »).
+    auto* date_format = TRY(construct_date_time_format(global_object, locales, options));
+
+    // 5. Return ? FormatDateTime(dateFormat, x).
+    auto formatted = TRY(Intl::format_date_time(global_object, *date_format, time));
+    return js_string(vm, move(formatted));
 }
 
 // 18.4.1 Date.prototype.toLocaleString ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sup-date.prototype.tolocalestring

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.toLocaleDateString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.toLocaleDateString.js
@@ -1,0 +1,57 @@
+describe("errors", () => {
+    test("called on non-Date object", () => {
+        expect(() => {
+            Date.prototype.toLocaleDateString();
+        }).toThrowWithMessage(TypeError, "Not an object of type Date");
+    });
+
+    test("called with value that cannot be converted to a number", () => {
+        expect(() => {
+            new Date(Symbol.hasInstance).toLocaleDateString();
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            new Date(1n).toLocaleDateString();
+        }).toThrowWithMessage(TypeError, "Cannot convert BigInt to number");
+    });
+
+    test("time value cannot be clipped", () => {
+        expect(() => {
+            new Date(-8.65e15).toLocaleDateString();
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+    });
+
+    test("timeStyle may not be specified", () => {
+        expect(() => {
+            new Date().toLocaleDateString([], { timeStyle: "short" });
+        }).toThrowWithMessage(TypeError, "Option timeStyle cannot be set when also providing date");
+    });
+});
+
+describe("correct behavior", () => {
+    test("NaN", () => {
+        const d = new Date(NaN);
+        expect(d.toLocaleDateString()).toBe("Invalid Date");
+    });
+
+    const d0 = new Date(Date.UTC(2021, 11, 7, 17, 40, 50, 456));
+    const d1 = new Date(Date.UTC(1989, 0, 23, 7, 8, 9, 45));
+
+    test("defaults to date", () => {
+        expect(d0.toLocaleDateString("en")).toBe("12/7/2021");
+        expect(d1.toLocaleDateString("en")).toBe("1/23/1989");
+
+        expect(d0.toLocaleDateString("ar")).toBe("٧‏/١٢‏/٢٠٢١");
+        expect(d1.toLocaleDateString("ar")).toBe("٢٣‏/١‏/١٩٨٩");
+    });
+
+    test("dateStyle may be set", () => {
+        expect(d0.toLocaleDateString("en", { dateStyle: "full" })).toBe(
+            "Tuesday, December 7, 2021"
+        );
+        expect(d1.toLocaleDateString("en", { dateStyle: "full" })).toBe("Monday, January 23, 1989");
+
+        expect(d0.toLocaleDateString("ar", { dateStyle: "full" })).toBe("الثلاثاء، ٧ ديسمبر ٢٠٢١");
+        expect(d1.toLocaleDateString("ar", { dateStyle: "full" })).toBe("الاثنين، ٢٣ يناير ١٩٨٩");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.toLocaleString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.toLocaleString.js
@@ -1,0 +1,61 @@
+describe("errors", () => {
+    test("called on non-Date object", () => {
+        expect(() => {
+            Date.prototype.toLocaleString();
+        }).toThrowWithMessage(TypeError, "Not an object of type Date");
+    });
+
+    test("called with value that cannot be converted to a number", () => {
+        expect(() => {
+            new Date(Symbol.hasInstance).toLocaleString();
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            new Date(1n).toLocaleString();
+        }).toThrowWithMessage(TypeError, "Cannot convert BigInt to number");
+    });
+
+    test("time value cannot be clipped", () => {
+        expect(() => {
+            new Date(-8.65e15).toLocaleString();
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+    });
+});
+
+describe("correct behavior", () => {
+    test("NaN", () => {
+        const d = new Date(NaN);
+        expect(d.toLocaleString()).toBe("Invalid Date");
+    });
+
+    const d0 = new Date(Date.UTC(2021, 11, 7, 17, 40, 50, 456));
+    const d1 = new Date(Date.UTC(1989, 0, 23, 7, 8, 9, 45));
+
+    test("defaults to date and time", () => {
+        expect(d0.toLocaleString("en", { timeZone: "UTC" })).toBe("12/7/2021, 5:40:50 PM");
+        expect(d1.toLocaleString("en", { timeZone: "UTC" })).toBe("1/23/1989, 7:08:09 AM");
+
+        expect(d0.toLocaleString("ar", { timeZone: "UTC" })).toBe("٧‏/١٢‏/٢٠٢١, ٥:٤٠:٥٠ م");
+        expect(d1.toLocaleString("ar", { timeZone: "UTC" })).toBe("٢٣‏/١‏/١٩٨٩, ٧:٠٨:٠٩ ص");
+    });
+
+    test("dateStyle may be set", () => {
+        expect(d0.toLocaleString("en", { dateStyle: "short", timeZone: "UTC" })).toBe("12/7/21");
+        expect(d1.toLocaleString("en", { dateStyle: "short", timeZone: "UTC" })).toBe("1/23/89");
+
+        expect(d0.toLocaleString("ar", { dateStyle: "short", timeZone: "UTC" })).toBe(
+            "٧‏/١٢‏/٢٠٢١"
+        );
+        expect(d1.toLocaleString("ar", { dateStyle: "short", timeZone: "UTC" })).toBe(
+            "٢٣‏/١‏/١٩٨٩"
+        );
+    });
+
+    test("timeStyle may be set", () => {
+        expect(d0.toLocaleString("en", { timeStyle: "short", timeZone: "UTC" })).toBe("5:40 PM");
+        expect(d1.toLocaleString("en", { timeStyle: "short", timeZone: "UTC" })).toBe("7:08 AM");
+
+        expect(d0.toLocaleString("ar", { timeStyle: "short", timeZone: "UTC" })).toBe("٥:٤٠ م");
+        expect(d1.toLocaleString("ar", { timeStyle: "short", timeZone: "UTC" })).toBe("٧:٠٨ ص");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.toLocaleTimeString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.toLocaleTimeString.js
@@ -1,0 +1,63 @@
+describe("errors", () => {
+    test("called on non-Date object", () => {
+        expect(() => {
+            Date.prototype.toLocaleTimeString();
+        }).toThrowWithMessage(TypeError, "Not an object of type Date");
+    });
+
+    test("called with value that cannot be converted to a number", () => {
+        expect(() => {
+            new Date(Symbol.hasInstance).toLocaleTimeString();
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+
+        expect(() => {
+            new Date(1n).toLocaleTimeString();
+        }).toThrowWithMessage(TypeError, "Cannot convert BigInt to number");
+    });
+
+    test("time value cannot be clipped", () => {
+        expect(() => {
+            new Date(-8.65e15).toLocaleTimeString();
+        }).toThrowWithMessage(RangeError, "Time value must be between -8.64E15 and 8.64E15");
+    });
+
+    test("dateStyle may not be specified", () => {
+        expect(() => {
+            new Date().toLocaleTimeString([], { dateStyle: "short" });
+        }).toThrowWithMessage(TypeError, "Option dateStyle cannot be set when also providing time");
+    });
+});
+
+describe("correct behavior", () => {
+    test("NaN", () => {
+        const d = new Date(NaN);
+        expect(d.toLocaleTimeString()).toBe("Invalid Date");
+    });
+
+    const d0 = new Date(Date.UTC(2021, 11, 7, 17, 40, 50, 456));
+    const d1 = new Date(Date.UTC(1989, 0, 23, 7, 8, 9, 45));
+
+    test("defaults to time", () => {
+        expect(d0.toLocaleTimeString("en", { timeZone: "UTC" })).toBe("5:40:50 PM");
+        expect(d1.toLocaleTimeString("en", { timeZone: "UTC" })).toBe("7:08:09 AM");
+
+        expect(d0.toLocaleTimeString("ar", { timeZone: "UTC" })).toBe("٥:٤٠:٥٠ م");
+        expect(d1.toLocaleTimeString("ar", { timeZone: "UTC" })).toBe("٧:٠٨:٠٩ ص");
+    });
+
+    test("timeStyle may be set", () => {
+        expect(d0.toLocaleTimeString("en", { timeStyle: "long", timeZone: "UTC" })).toBe(
+            "5:40:50 PM UTC"
+        );
+        expect(d1.toLocaleTimeString("en", { timeStyle: "long", timeZone: "UTC" })).toBe(
+            "7:08:09 AM UTC"
+        );
+
+        expect(d0.toLocaleTimeString("ar", { timeStyle: "long", timeZone: "UTC" })).toBe(
+            "٥:٤٠:٥٠ م UTC"
+        );
+        expect(d1.toLocaleTimeString("ar", { timeStyle: "long", timeZone: "UTC" })).toBe(
+            "٧:٠٨:٠٩ ص UTC"
+        );
+    });
+});


### PR DESCRIPTION
Fixes like 2 whole test262 tests :sunglasses: 