### PR TITLE
LibWeb: Fix off-by-one error when highlighting unquoted HTML attributes

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1237,7 +1237,7 @@ _StartOfFunction:
                 ON_WHITESPACE
                 {
                     m_current_token.last_attribute().value = consume_current_builder();
-                    m_current_token.last_attribute().value_end_position = nth_last_position(2);
+                    m_current_token.last_attribute().value_end_position = nth_last_position(1);
                     SWITCH_TO(BeforeAttributeName);
                 }
                 ON('&')


### PR DESCRIPTION
This fixes #11166

![image](https://user-images.githubusercontent.com/222642/145614951-bbabbf92-a04f-4715-b5a7-d67004f11251.png)
