### PR TITLE
Meta: Enable the "bugprone-dangling-handle" clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -41,6 +41,8 @@ WarningsAsErrors: ''
 HeaderFilterRegex: 'AK|Userland|Kernel|Tests'
 FormatStyle: none
 CheckOptions:
+  - key: bugprone-dangling-handle.HandleClasses
+    value: 'AK::StringView;AK::Span'
   - key: misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value: true
   - key: readability-implicit-bool-conversion.AllowPointerConditions


### PR DESCRIPTION
This should catch (the trivial cases of) construction of StringViews from temporary Strings:
![image](https://user-images.githubusercontent.com/16208640/145620278-1a92c995-565c-4fdb-a1ce-2ebd3cf3692a.png)
I wasn't able to actually find any cases of this (which is suspicious), but I don't see any downsides to enabling it anyways.