### PR TITLE
LibJS+LibUnicode: Use locale-aware day period time ranges to format period symbols

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -913,13 +913,13 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
             else if (key == "pm"sv)
                 symbols[to_underlying(Unicode::DayPeriod::PM)] = locale_data.unique_strings.ensure(move(symbol));
             else if (key == "morning1"sv)
-                symbols[to_underlying(Unicode::DayPeriod::Morning)] = locale_data.unique_strings.ensure(move(symbol));
+                symbols[to_underlying(Unicode::DayPeriod::Morning1)] = locale_data.unique_strings.ensure(move(symbol));
             else if (key == "afternoon1"sv)
-                symbols[to_underlying(Unicode::DayPeriod::Afternoon)] = locale_data.unique_strings.ensure(move(symbol));
+                symbols[to_underlying(Unicode::DayPeriod::Afternoon1)] = locale_data.unique_strings.ensure(move(symbol));
             else if (key == "evening1"sv)
-                symbols[to_underlying(Unicode::DayPeriod::Evening)] = locale_data.unique_strings.ensure(move(symbol));
+                symbols[to_underlying(Unicode::DayPeriod::Evening1)] = locale_data.unique_strings.ensure(move(symbol));
             else if (key == "night1"sv)
-                symbols[to_underlying(Unicode::DayPeriod::Night)] = locale_data.unique_strings.ensure(move(symbol));
+                symbols[to_underlying(Unicode::DayPeriod::Night1)] = locale_data.unique_strings.ensure(move(symbol));
         };
 
         narrow_symbols.for_each_member([&](auto const& key, JsonValue const& value) {

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -257,6 +257,31 @@ struct UnicodeLocaleData {
     Vector<String> symbols;
 };
 
+static Optional<Unicode::DayPeriod> day_period_from_string(StringView day_period)
+{
+    if (day_period == "am"sv)
+        return Unicode::DayPeriod::AM;
+    if (day_period == "pm"sv)
+        return Unicode::DayPeriod::PM;
+    if (day_period == "morning1"sv)
+        return Unicode::DayPeriod::Morning1;
+    if (day_period == "morning2"sv)
+        return Unicode::DayPeriod::Morning2;
+    if (day_period == "afternoon1"sv)
+        return Unicode::DayPeriod::Afternoon1;
+    if (day_period == "afternoon2"sv)
+        return Unicode::DayPeriod::Afternoon2;
+    if (day_period == "evening1"sv)
+        return Unicode::DayPeriod::Evening1;
+    if (day_period == "evening2"sv)
+        return Unicode::DayPeriod::Evening2;
+    if (day_period == "night1"sv)
+        return Unicode::DayPeriod::Night1;
+    if (day_period == "night2"sv)
+        return Unicode::DayPeriod::Night2;
+    return {};
+};
+
 static ErrorOr<void> parse_hour_cycles(String core_path, UnicodeLocaleData& locale_data)
 {
     // https://unicode.org/reports/tr35/tr35-dates.html#Time_Data
@@ -905,21 +930,11 @@ static void parse_calendar_symbols(Calendar& calendar, JsonObject const& calenda
         auto const& short_symbols = symbols_object.get("abbreviated"sv).as_object();
         auto const& long_symbols = symbols_object.get("wide"sv).as_object();
 
-        auto& day_period_symbols = ensure_symbols("dayPeriod"sv, 6);
+        auto& day_period_symbols = ensure_symbols("dayPeriod"sv, 10);
 
         auto append_symbol = [&](auto& symbols, auto const& key, auto symbol) {
-            if (key == "am"sv)
-                symbols[to_underlying(Unicode::DayPeriod::AM)] = locale_data.unique_strings.ensure(move(symbol));
-            else if (key == "pm"sv)
-                symbols[to_underlying(Unicode::DayPeriod::PM)] = locale_data.unique_strings.ensure(move(symbol));
-            else if (key == "morning1"sv)
-                symbols[to_underlying(Unicode::DayPeriod::Morning1)] = locale_data.unique_strings.ensure(move(symbol));
-            else if (key == "afternoon1"sv)
-                symbols[to_underlying(Unicode::DayPeriod::Afternoon1)] = locale_data.unique_strings.ensure(move(symbol));
-            else if (key == "evening1"sv)
-                symbols[to_underlying(Unicode::DayPeriod::Evening1)] = locale_data.unique_strings.ensure(move(symbol));
-            else if (key == "night1"sv)
-                symbols[to_underlying(Unicode::DayPeriod::Night1)] = locale_data.unique_strings.ensure(move(symbol));
+            if (auto day_period = day_period_from_string(key); day_period.has_value())
+                symbols[to_underlying(*day_period)] = locale_data.unique_strings.ensure(move(symbol));
         };
 
         narrow_symbols.for_each_member([&](auto const& key, JsonValue const& value) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -755,19 +755,6 @@ static Optional<StyleAndValue> find_calendar_field(StringView name, Unicode::Cal
     return {};
 }
 
-static Optional<StringView> day_period_for_hour(StringView locale, StringView calendar, Unicode::CalendarPatternStyle style, u8 hour)
-{
-    // FIXME: This isn't locale-aware. We should parse the CLDR's cldr-core/supplemental/dayPeriods.json file
-    //        to acquire day periods per-locale. For now, these are hard-coded to the en locale's values.
-    if ((hour >= 6) && (hour < 12))
-        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Morning1);
-    if ((hour >= 12) && (hour < 18))
-        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Afternoon1);
-    if ((hour >= 18) && (hour < 21))
-        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Evening1);
-    return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Night1);
-}
-
 // 11.1.7 FormatDateTimePattern ( dateTimeFormat, patternParts, x, rangeFormatOptions ), https://tc39.es/ecma402/#sec-formatdatetimepattern
 ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObject& global_object, DateTimeFormat& date_time_format, Vector<PatternPartition> pattern_parts, Value time, Unicode::CalendarPattern const* range_format_options)
 {
@@ -875,7 +862,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObjec
             auto style = date_time_format.day_period();
 
             // ii. Let fv be a String value representing the day period of tm in the form given by f; the String value depends upon the implementation and the effective locale of dateTimeFormat.
-            auto symbol = day_period_for_hour(data_locale, date_time_format.calendar(), style, local_time.hour);
+            auto symbol = Unicode::get_calendar_day_period_symbol_for_hour(data_locale, date_time_format.calendar(), style, local_time.hour);
             if (symbol.has_value())
                 formatted_value = *symbol;
 
@@ -1236,10 +1223,10 @@ ThrowCompletionOr<Vector<PatternPartitionWithSource>> partition_date_time_range_
             // iii. Else if fieldName is equal to [[DayPeriod]], then
             case Unicode::CalendarRangePattern::Field::DayPeriod: {
                 // 1. Let v1 be a String value representing the day period of tm1; the String value depends upon the implementation and the effective locale of dateTimeFormat.
-                auto start_period = day_period_for_hour(date_time_format.data_locale(), date_time_format.calendar(), Unicode::CalendarPatternStyle::Short, start_value);
+                auto start_period = Unicode::get_calendar_day_period_symbol_for_hour(date_time_format.data_locale(), date_time_format.calendar(), Unicode::CalendarPatternStyle::Short, start_value);
 
                 // 2. Let v2 be a String value representing the day period of tm2; the String value depends upon the implementation and the effective locale of dateTimeFormat.
-                auto end_period = day_period_for_hour(date_time_format.data_locale(), date_time_format.calendar(), Unicode::CalendarPatternStyle::Short, end_value);
+                auto end_period = Unicode::get_calendar_day_period_symbol_for_hour(date_time_format.data_locale(), date_time_format.calendar(), Unicode::CalendarPatternStyle::Short, end_value);
 
                 // 3. If v1 is not equal to v2, then
                 if (start_period != end_period) {

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -760,12 +760,12 @@ static Optional<StringView> day_period_for_hour(StringView locale, StringView ca
     // FIXME: This isn't locale-aware. We should parse the CLDR's cldr-core/supplemental/dayPeriods.json file
     //        to acquire day periods per-locale. For now, these are hard-coded to the en locale's values.
     if ((hour >= 6) && (hour < 12))
-        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Morning);
+        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Morning1);
     if ((hour >= 12) && (hour < 18))
-        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Afternoon);
+        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Afternoon1);
     if ((hour >= 18) && (hour < 21))
-        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Evening);
-    return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Night);
+        return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Evening1);
+    return Unicode::get_calendar_day_period_symbol(locale, calendar, style, Unicode::DayPeriod::Night1);
 }
 
 // 11.1.7 FormatDateTimePattern ( dateTimeFormat, patternParts, x, rangeFormatOptions ), https://tc39.es/ecma402/#sec-formatdatetimepattern

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -228,12 +228,10 @@ describe("day", () => {
 
 describe("dayPeriod", () => {
     // prettier-ignore
-    // FIXME: The ar formats aren't entirely correct. LibUnicode is only parsing e.g. "morning1" in the "dayPeriods"
-    //        CLDR object. It will need to parse "morning2", and figure out how to apply it.
     const data = [
-        { dayPeriod: "narrow", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ ظهرًا", ar1: "٧ فجرًا" },
-        { dayPeriod: "short", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ ظهرًا", ar1: "٧ فجرًا" },
-        { dayPeriod: "long", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ ظهرًا", ar1: "٧ في الصباح" },
+        { dayPeriod: "narrow", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ صباحًا" },
+        { dayPeriod: "short", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ ص" },
+        { dayPeriod: "long", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ صباحًا" },
     ];
 
     test("all", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -229,9 +229,9 @@ describe("day", () => {
 describe("dayPeriod", () => {
     // prettier-ignore
     const data = [
-        { dayPeriod: "narrow", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ صباحًا" },
-        { dayPeriod: "short", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ ص" },
-        { dayPeriod: "long", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ صباحًا" },
+        { dayPeriod: "narrow", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ صباحًا", as0: "অপৰাহ্ন ৫", as1: "পূৰ্বাহ্ন ৭"},
+        { dayPeriod: "short", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ ص", as0: "অপৰাহ্ন ৫", as1: "পূৰ্বাহ্ন ৭"},
+        { dayPeriod: "long", en0: "5 in the afternoon", en1: "7 in the morning", ar0: "٥ بعد الظهر", ar1: "٧ صباحًا", as0: "অপৰাহ্ন ৫", as1: "পূৰ্বাহ্ন ৭"},
     ];
 
     test("all", () => {
@@ -251,6 +251,14 @@ describe("dayPeriod", () => {
             });
             expect(ar.format(d0)).toBe(d.ar0);
             expect(ar.format(d1)).toBe(d.ar1);
+
+            const as = new Intl.DateTimeFormat("as", {
+                dayPeriod: d.dayPeriod,
+                hour: "numeric",
+                timeZone: "UTC",
+            });
+            expect(as.format(d0)).toBe(d.as0);
+            expect(as.format(d1)).toBe(d.as1);
         });
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatToParts.js
@@ -233,8 +233,6 @@ describe("special cases", () => {
             { type: "dayPeriod", value: "in the morning" },
         ]);
 
-        // FIXME: The ar format isn't entirely correct. LibUnicode is only parsing e.g. "morning1" in the "dayPeriods"
-        //        CLDR object. It will need to parse "morning2", and figure out how to apply it.
         const ar = new Intl.DateTimeFormat("ar", {
             dayPeriod: "long",
             hour: "numeric",
@@ -243,7 +241,7 @@ describe("special cases", () => {
         expect(ar.formatToParts(d)).toEqual([
             { type: "hour", value: "٧" },
             { type: "literal", value: " " },
-            { type: "dayPeriod", value: "في الصباح" },
+            { type: "dayPeriod", value: "صباحًا" },
         ]);
     });
 

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -246,6 +246,15 @@ Optional<StringView> get_calendar_day_period_symbol([[maybe_unused]] StringView 
 #endif
 }
 
+Optional<StringView> get_calendar_day_period_symbol_for_hour([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] u8 hour)
+{
+#if ENABLE_UNICODE_DATA
+    return Detail::get_calendar_day_period_symbol_for_hour(locale, calendar, style, hour);
+#else
+    return {};
+#endif
+}
+
 Optional<StringView> get_time_zone_name([[maybe_unused]] StringView locale, [[maybe_unused]] StringView time_zone, [[maybe_unused]] CalendarPatternStyle style)
 {
 #if ENABLE_UNICODE_DATA

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -171,6 +171,7 @@ Optional<StringView> get_calendar_era_symbol(StringView locale, StringView calen
 Optional<StringView> get_calendar_month_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Month value);
 Optional<StringView> get_calendar_weekday_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Weekday value);
 Optional<StringView> get_calendar_day_period_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::DayPeriod value);
+Optional<StringView> get_calendar_day_period_symbol_for_hour(StringView locale, StringView calendar, CalendarPatternStyle style, u8 hour);
 Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone, CalendarPatternStyle style);
 
 }

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -49,9 +49,13 @@ enum class DayPeriod : u8 {
     AM,
     PM,
     Morning1,
+    Morning2,
     Afternoon1,
+    Afternoon2,
     Evening1,
+    Evening2,
     Night1,
+    Night2,
 };
 
 enum class HourCycle : u8 {

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -48,10 +48,10 @@ enum class Weekday : u8 {
 enum class DayPeriod : u8 {
     AM,
     PM,
-    Morning,
-    Afternoon,
-    Evening,
-    Night,
+    Morning1,
+    Afternoon1,
+    Evening1,
+    Night1,
 };
 
 enum class HourCycle : u8 {


### PR DESCRIPTION
No test262 coverage on this one, but removes a few FIXMEs.