### PR TITLE
LibWeb: Implement AbortSignal.{reason,throwIfAborted}

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/AbortController.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.cpp
@@ -20,9 +20,10 @@ AbortController::~AbortController()
 }
 
 // https://dom.spec.whatwg.org/#dom-abortcontroller-abort
-void AbortController::abort()
+void AbortController::abort(JS::Value reason)
 {
-    m_signal->signal_abort();
+    // The abort(reason) method steps are to signal abort on this’s signal with reason if it is given.
+    m_signal->signal_abort(reason);
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/AbortController.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.h
@@ -39,7 +39,7 @@ public:
     // https://dom.spec.whatwg.org/#dom-abortcontroller-signal
     NonnullRefPtr<AbortSignal> signal() const { return m_signal; }
 
-    void abort();
+    void abort(JS::Value reason);
 
 private:
     AbortController(Document& document);

--- a/Userland/Libraries/LibWeb/DOM/AbortController.idl
+++ b/Userland/Libraries/LibWeb/DOM/AbortController.idl
@@ -4,5 +4,5 @@ interface AbortController {
 
     [SameObject] readonly attribute AbortSignal signal;
 
-    undefined abort();
+    undefined abort(optional any reason);
 };

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.cpp
@@ -73,6 +73,22 @@ HTML::EventHandler AbortSignal::onabort()
     return event_handler_attribute(HTML::EventNames::abort);
 }
 
+// https://dom.spec.whatwg.org/#dom-abortsignal-throwifaborted
+JS::ThrowCompletionOr<void> AbortSignal::throw_if_aborted() const
+{
+    auto& global_object = wrapper()->global_object();
+    auto& vm = global_object.vm();
+
+    // The throwIfAborted() method steps are to throw this’s abort reason, if this is aborted.
+    if (!aborted())
+        return {};
+
+    // FIXME: Remove this once VM::exception() has been removed.
+    vm.throw_exception(global_object, m_abort_reason);
+
+    return JS::throw_completion(m_abort_reason);
+}
+
 void AbortSignal::visit_edges(JS::Cell::Visitor& visitor)
 {
     visitor.visit(m_abort_reason);

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -42,12 +42,18 @@ public:
     void add_abort_algorithm(Function<void()>);
 
     // https://dom.spec.whatwg.org/#dom-abortsignal-aborted
-    bool aborted() const { return m_aborted; }
+    // An AbortSignal object is aborted when its abort reason is not undefined.
+    bool aborted() const { return !m_abort_reason.is_undefined(); }
 
-    void signal_abort();
+    void signal_abort(JS::Value reason);
 
     void set_onabort(HTML::EventHandler);
     HTML::EventHandler onabort();
+
+    // https://dom.spec.whatwg.org/#dom-abortsignal-reason
+    JS::Value reason() const { return m_abort_reason; }
+
+    void visit_edges(JS::Cell::Visitor&);
 
     // ^EventTarget
     virtual void ref_event_target() override { ref(); }
@@ -57,8 +63,9 @@ public:
 private:
     AbortSignal(Document& document);
 
-    // https://dom.spec.whatwg.org/#abortsignal-aborted-flag
-    bool m_aborted { false };
+    // https://dom.spec.whatwg.org/#abortsignal-abort-reason
+    // An AbortSignal object has an associated abort reason, which is a JavaScript value. It is undefined unless specified otherwise.
+    JS::Value m_abort_reason { JS::js_undefined() };
 
     // https://dom.spec.whatwg.org/#abortsignal-abort-algorithms
     // FIXME: This should be a set.

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.h
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.h
@@ -53,6 +53,8 @@ public:
     // https://dom.spec.whatwg.org/#dom-abortsignal-reason
     JS::Value reason() const { return m_abort_reason; }
 
+    JS::ThrowCompletionOr<void> throw_if_aborted() const;
+
     void visit_edges(JS::Cell::Visitor&);
 
     // ^EventTarget

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
@@ -4,6 +4,7 @@ interface AbortSignal : EventTarget {
 
     readonly attribute boolean aborted;
     readonly attribute any reason;
+    undefined throwIfAborted();
 
     attribute EventHandler onabort;
 };

--- a/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
+++ b/Userland/Libraries/LibWeb/DOM/AbortSignal.idl
@@ -1,8 +1,9 @@
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker), CustomVisit]
 interface AbortSignal : EventTarget {
-    // FIXME: [NewObject] static AbortSignal abort();
+    // FIXME: [NewObject] static AbortSignal abort(optional any reason);
 
     readonly attribute boolean aborted;
+    readonly attribute any reason;
 
     attribute EventHandler onabort;
 };


### PR DESCRIPTION
LibWeb: Add support for AbortSignal.reason

-----

LibWeb: Implement AbortSignal.throwIfAborted

See: https://github.com/whatwg/dom/commit/cfe2f1e