### PR TITLE
passwd: Remove redundant pledge()

### DIFF
--- a/Userland/Utilities/passwd.cpp
+++ b/Userland/Utilities/passwd.cpp
@@ -63,11 +63,6 @@ int main(int argc, char** argv)
 
     setpwent();
 
-    if (pledge("stdio wpath rpath cpath fattr tty", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
-
     // target_account is the account we are changing the password of.
     auto& target_account = account_or_error.value();
 


### PR DESCRIPTION
I noticed `passwd` has a redundant call to `pledge()`. Casually browsing the source it's not immediately obvious as you need to compare both strings of promises closely.

This would've been caught with a higher-level `Core::System::pledge()` API I'm trying to draft in #11140.