### PR TITLE
LibCore: Enforce pledge() to retract() promises

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -26,14 +26,11 @@
 namespace Core::System {
 
 #ifdef __serenity__
-ErrorOr<void> pledge(StringView promises, StringView execpromises)
+ErrorOr<void> retract(StringView promises)
 {
-    Syscall::SC_pledge_params params {
-        { promises.characters_without_null_termination(), promises.length() },
-        { execpromises.characters_without_null_termination(), execpromises.length() },
-    };
-    int rc = syscall(SC_pledge, &params);
-    HANDLE_SYSCALL_RETURN_VALUE("pledge"sv, rc, {});
+    // check internal structure if promises were actually pledged
+    // remove retracted promises from internal structure
+    // syscall pledge() with updated promises
 }
 
 ErrorOr<void> unveil(StringView path, StringView permissions)

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -18,7 +18,7 @@
 namespace Core::System {
 
 #ifdef __serenity__
-ErrorOr<void> pledge(StringView promises, StringView execpromises = {});
+ErrorOr<void> retract(StringView promises);
 ErrorOr<void> unveil(StringView path, StringView permissions);
 ErrorOr<Array<int, 2>> pipe2(int flags);
 ErrorOr<void> sendfd(int sockfd, int fd);

--- a/Userland/Libraries/LibMain/Main.cpp
+++ b/Userland/Libraries/LibMain/Main.cpp
@@ -12,6 +12,15 @@
 
 int main(int argc, char** argv)
 {
+    //
+    // This should set up an internal Core::System::xxx structure
+    // so Core::System::retract() knows which promises are pledged.
+    //
+    if (pledge(serenity_get_initial_promises(), nullptr) < 0) {
+        perror("pledge");
+        return 1;
+    }
+
     Vector<StringView> arguments;
     arguments.ensure_capacity(argc);
     for (int i = 0; i < argc; ++i)

--- a/Userland/Libraries/LibMain/Main.h
+++ b/Userland/Libraries/LibMain/Main.h
@@ -18,4 +18,5 @@ struct Arguments {
 
 }
 
+const char* serenity_get_initial_promises();
 ErrorOr<int> serenity_main(Main::Arguments);

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -11,10 +11,13 @@
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
+const char* serenity_get_initial_promises()
+{
+    return "stdio recvfd thread accept cpath rpath wpath unix";
+}
+
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd thread accept cpath rpath wpath unix"));
-
     auto config = Core::ConfigFile::open_for_app("Audio", Core::ConfigFile::AllowWriting::Yes);
     TRY(Core::System::unveil(config->filename(), "rwc"));
     TRY(Core::System::unveil("/dev/audio", "wc"));
@@ -31,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
         (void)IPC::new_client_connection<AudioServer::ClientConnection>(move(client_socket), client_id, *mixer);
     };
 
-    TRY(Core::System::pledge("stdio recvfd thread accept cpath rpath wpath"));
+    TRY(Core::System::retract("unix"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     return event_loop.exec();

--- a/Userland/Services/ChessEngine/main.cpp
+++ b/Userland/Services/ChessEngine/main.cpp
@@ -10,11 +10,15 @@
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
+const char* serenity_get_initial_promises()
+{
+    return "stdio recvfd sendfd unix rpath";
+}
+
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd unix rpath"));
     Core::EventLoop loop;
-    TRY(Core::System::pledge("stdio recvfd sendfd unix"));
+    TRY(Core::System::retract("rpath"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto engine = TRY(ChessEngine::try_create(Core::File::standard_input(), Core::File::standard_output()));

--- a/Userland/Services/Clipboard/main.cpp
+++ b/Userland/Services/Clipboard/main.cpp
@@ -11,9 +11,13 @@
 #include <LibIPC/MultiServer.h>
 #include <LibMain/Main.h>
 
+const char* serenity_get_initial_promises()
+{
+    return "stdio recvfd sendfd accept";
+}
+
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd accept"));
     Core::EventLoop event_loop;
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/DHCPClient/main.cpp
+++ b/Userland/Services/DHCPClient/main.cpp
@@ -9,16 +9,20 @@
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
+const char* serenity_get_initial_promises()
+{
+    return "stdio unix inet cpath rpath";
+}
+
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio unix inet cpath rpath"));
     Core::EventLoop event_loop;
 
     TRY(Core::System::unveil("/proc/net/", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto client = TRY(DHCPv4Client::try_create());
+    TRY(Core::System::retract("unix"));
 
-    TRY(Core::System::pledge("stdio inet cpath rpath"));
     return event_loop.exec();
 }

--- a/Userland/Services/LookupServer/main.cpp
+++ b/Userland/Services/LookupServer/main.cpp
@@ -10,13 +10,17 @@
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
+const char* serenity_get_initial_promises()
+{
+    return "stdio accept unix inet rpath";
+}
+
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio accept unix inet rpath"));
     Core::EventLoop event_loop;
     auto server = TRY(LookupServer::LookupServer::try_create());
+    TRY(Core::System::retract("unix"));
 
-    TRY(Core::System::pledge("stdio accept inet rpath"));
     TRY(Core::System::unveil("/proc/net/adapters", "r"));
     TRY(Core::System::unveil("/etc/hosts", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -17,18 +17,22 @@
 #include <RequestServer/HttpsProtocol.h>
 #include <signal.h>
 
+const char* serenity_get_initial_promises()
+{
+    return "stdio inet accept unix rpath sendfd recvfd sigaction";
+}
+
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio inet accept unix rpath sendfd recvfd sigaction"));
-
     signal(SIGINFO, [](int) { RequestServer::ConnectionCache::dump_jobs(); });
+    TRY(Core::System::retract("sigaction"));
 
     // Ensure the certificates are read out here.
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;
     // FIXME: Establish a connection to LookupServer and then drop "unix"?
-    TRY(Core::System::pledge("stdio inet accept unix sendfd recvfd"));
+    TRY(Core::System::retract("rpath"));
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/WebSocket/main.cpp
+++ b/Userland/Services/WebSocket/main.cpp
@@ -12,16 +12,19 @@
 #include <LibTLS/Certificate.h>
 #include <WebSocket/ClientConnection.h>
 
+const char* serenity_get_initial_promises()
+{
+    return "stdio inet unix rpath sendfd recvfd";
+}
+
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio inet unix rpath sendfd recvfd"));
-
     // Ensure the certificates are read out here.
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
 
     Core::EventLoop event_loop;
     // FIXME: Establish a connection to LookupServer and then drop "unix"?
-    TRY(Core::System::pledge("stdio inet unix sendfd recvfd"));
+    TRY(Core::System::retract("rpath"));
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
### Background
This patch reworks the `Core::System::pledge()` API (see #11140) to offer:
- a higher-level, more semantic abstraction for `pledge()`
- improved expressiveness of source code and backtraces
- compile-time promise checking and enforcement to prevent bugs like e815bf5d1f85fa91679bbd54b7d018a16359e6ca
- run-time error checking, for instance: duplicated promises like #11207 and #11211
- being able to find all uses of promises easily
- optionally enforce consistent promise order in function calls

### Current state (version 2.1)
As a draft, it's currently a non-functional straw man for public discussion as suggested by @bgianfo.

I see `pledge()` as a security risk in itself, leaving the possibility for dangling and stale promises without source code indicating programmer intent.

The current patch completely removes the ability for applications to `Core::System::pledge()`. Instead, applications supply an initial set of promises to `LibMain` and can only `Core::System::retract()` promises afterwards.

The 'forced initial `pledge()`' and subsequent `retract()` pattern offers two distinct advantages over the current situation:
- every SerenityOS program must provide an initial set of promises
- source code now conveys programmer intent to drop promises

### Previous state (version 1)
I focused on introducing `retract()` first, as a counterpart to `pledge()`. I've implemented a placeholder `Core::System::retract()` call and migrated some of the `Userland/Services` users over to this. I moved `retract()`s as closely to the calling code as possible to illustrate the fine-grained permission revocation. I'm pretty sure the original source code had promises span a few more lines than necessary (especially `signal`).

### TODO
- [ ] decide if a `pledge()`/`retract()` distinction makes sense
- [ ] implement `retract()`
- [ ] rework the `promises` argument to be a compile-time checked type like a `Span` of `enum`s or similar
- [ ] implement additional run-time checks for duplicated `pledge()` promises
- [ ] potentially implement enforced tracking of promise counts with a `retractExpect()` function

### Warning
The current patch lowers system security because API components aren't functionally implemented yet.