### PR TITLE
Remove redundant pledges, update idiom

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -218,8 +218,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         termination_signal = coredump->process_termination_signal();
     }
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath proc exec"));
-
     TRY(Core::System::unveil(executable_path.characters(), "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -146,10 +146,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
     remote_process.update();
 
-    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
-
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
     return app->exec();
 }

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -65,8 +65,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath unix"));
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath unix"));
-
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/Playground.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 


### PR DESCRIPTION
Following #11207 here are two more instances of redundant `pledge()` calls, and an outdated version that can be updated to use `TRY()`.