### PR TITLE
Kernel: Remove unused String.h includes

### DIFF
--- a/Kernel/Arch/x86/IO.h
+++ b/Kernel/Arch/x86/IO.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/Assertions.h>
-#include <AK/String.h>
+#include <AK/Format.h>
 #include <AK/Types.h>
 
 #include <AK/Platform.h>

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Bitmap.h>
-#include <AK/String.h>
 #include <AK/Vector.h>
 #include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/FileSystem/SysFS.h>

--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -6,11 +6,13 @@
 
 #pragma once
 
+#include <AK/Badge.h>
+#include <AK/DistinctNumeric.h>
 #include <AK/Function.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/Debug.h>
+#include <Kernel/PhysicalAddress.h>
 
 namespace Kernel {
 

--- a/Kernel/Bus/PCI/SysFSPCI.cpp
+++ b/Kernel/Bus/PCI/SysFSPCI.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/String.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/SysFSPCI.h>

--- a/Kernel/Bus/PCI/SysFSPCI.h
+++ b/Kernel/Bus/PCI/SysFSPCI.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Vector.h>
 #include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/FileSystem/SysFS.h>

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/OwnPtr.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <Kernel/Bus/USB/USBController.h>

--- a/Kernel/Devices/KCOVInstance.cpp
+++ b/Kernel/Devices/KCOVInstance.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/String.h>
 #include <Kernel/Devices/KCOVInstance.h>
 
 namespace Kernel {

--- a/Kernel/Devices/MemoryDevice.h
+++ b/Kernel/Devices/MemoryDevice.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Devices/CharacterDevice.h>
 #include <Kernel/PhysicalAddress.h>

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -9,7 +9,7 @@
 #include <AK/Error.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
-#include <AK/String.h>
+#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Weakable.h>
 #include <Kernel/Forward.h>

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -13,7 +13,6 @@
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
-#include <AK/String.h>
 #include <Kernel/FileSystem/FileSystem.h>
 #include <Kernel/FileSystem/InodeIdentifier.h>
 #include <Kernel/FileSystem/InodeMetadata.h>

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Console/GenericFramebufferConsole.h>

--- a/Kernel/Graphics/Console/Console.h
+++ b/Kernel/Graphics/Console/Console.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/RefCounted.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Graphics/GenericGraphicsAdapter.h>
 

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/NonnullOwnPtr.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Graphics/GenericFramebufferDevice.h>
 #include <Kernel/Graphics/GenericGraphicsAdapter.h>

--- a/Kernel/Graphics/GenericFramebufferDevice.h
+++ b/Kernel/Graphics/GenericFramebufferDevice.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Error.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Devices/BlockDevice.h>
 #include <Kernel/Graphics/GenericGraphicsAdapter.h>

--- a/Kernel/Graphics/GenericGraphicsAdapter.h
+++ b/Kernel/Graphics/GenericGraphicsAdapter.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <AK/Weakable.h>
 #include <Kernel/Bus/PCI/Definitions.h>

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Definitions.h>

--- a/Kernel/Graphics/VGACompatibleAdapter.h
+++ b/Kernel/Graphics/VGACompatibleAdapter.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Console/Console.h>

--- a/Kernel/Interrupts/IRQController.h
+++ b/Kernel/Interrupts/IRQController.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/RefCounted.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 
 namespace Kernel {

--- a/Kernel/Interrupts/IRQHandler.h
+++ b/Kernel/Interrupts/IRQHandler.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/RefPtr.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
 #include <Kernel/Interrupts/IRQController.h>

--- a/Kernel/Interrupts/UnhandledInterruptHandler.h
+++ b/Kernel/Interrupts/UnhandledInterruptHandler.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Interrupts/GenericInterruptHandler.h>
 

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -10,7 +10,6 @@
 #include <AK/HashTable.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/NonnullRefPtrVector.h>
-#include <AK/String.h>
 #include <Kernel/Forward.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/AllocationStrategy.h>

--- a/Kernel/Net/IPv4.h
+++ b/Kernel/Net/IPv4.h
@@ -9,7 +9,6 @@
 #include <AK/Assertions.h>
 #include <AK/Endian.h>
 #include <AK/IPv4Address.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 
 namespace Kernel {

--- a/Kernel/ProcessExposed.h
+++ b/Kernel/ProcessExposed.h
@@ -10,7 +10,6 @@
 #include <AK/Function.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/FileSystem/File.h>
 #include <Kernel/FileSystem/FileSystem.h>

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Assertions.h>
 #include <AK/MemMem.h>
-#include <AK/String.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/SmapDisabler.h>
 #include <Kernel/Heap/kmalloc.h>

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -9,7 +9,6 @@
 
 #include <AK/Noncopyable.h>
 #include <AK/NonnullOwnPtrVector.h>
-#include <AK/String.h>
 #include <AK/Vector.h>
 #include <Kernel/API/KeyCode.h>
 #include <Kernel/Devices/ConsoleDevice.h>

--- a/Kernel/Time/HardwareTimer.h
+++ b/Kernel/Time/HardwareTimer.h
@@ -8,7 +8,6 @@
 
 #include <AK/Function.h>
 #include <AK/RefCounted.h>
-#include <AK/String.h>
 #include <Kernel/Interrupts/IRQHandler.h>
 #include <Kernel/Time/TimeManagement.h>
 


### PR DESCRIPTION
This makes searching for not yet OOM safe interfaces a bit easier.