### PR TITLE
Kernel: Replace final loop in PhysicalRegion::return_page() with arithmetic

### DIFF
--- a/Kernel/Memory/PhysicalRegion.h
+++ b/Kernel/Memory/PhysicalRegion.h
@@ -46,6 +46,9 @@ private:
 
     NonnullOwnPtrVector<PhysicalZone> m_zones;
 
+    size_t m_large_zones;
+    size_t m_small_zones;
+
     PhysicalZone::List m_usable_zones;
     PhysicalZone::List m_full_zones;
 


### PR DESCRIPTION
Since it's possible to determine where the small zones will start to occur for each PhysicalRegion, we can use arithmetic so that the call time for both large and small zones is identical.