### PR TITLE
Meta: Build without root

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -117,25 +117,25 @@ printf "mounting filesystem... "
 mkdir -p mnt
 use_genext2fs=0
 if [ "$(uname -s)" = "Darwin" ]; then
-  mount_cmd="fuse-ext2 _disk_image mnt -o rw+,allow_other,uid=501,gid=20"
+    mount_cmd="fuse-ext2 _disk_image mnt -o rw+,allow_other,uid=501,gid=20"
 elif [ "$(uname -s)" = "OpenBSD" ]; then
-  VND=$(vnconfig _disk_image)
-  mount_cmd="mount -t ext2fs "/dev/${VND}i" mnt/"
+    VND=$(vnconfig _disk_image)
+    mount_cmd="mount -t ext2fs "/dev/${VND}i" mnt/"
 elif [ "$(uname -s)" = "FreeBSD" ]; then
-  MD=$(mdconfig _disk_image)
-  mount_cmd="fuse-ext2 -o rw+,direct_io "/dev/${MD}" mnt/"
+    MD=$(mdconfig _disk_image)
+    mount_cmd="fuse-ext2 -o rw+,direct_io "/dev/${MD}" mnt/"
 else
-  mount_cmd="mount _disk_image mnt/"
+    mount_cmd="mount _disk_image mnt/"
 fi
 if ! eval "$mount_cmd"; then
-  if command -v genext2fs 1>/dev/null ; then
-    echo "mount failed but genext2fs exists, use it instead"
-    use_genext2fs=1
-  else
-    die "could not mount filesystem and genext2fs is missing"
-  fi
+    if command -v genext2fs 1>/dev/null ; then
+        echo "mount failed but genext2fs exists, use it instead"
+        use_genext2fs=1
+    else
+        die "could not mount filesystem and genext2fs is missing"
+    fi
 else
-  echo "done"
+    echo "done"
 fi
 
 cleanup() {

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -8,7 +8,8 @@ die() {
 }
 
 if [ "$(id -u)" != 0 ]; then
-    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
+    sudo -E -- "$0" "$@" || die "this script needs to run as root"
+    exit 0
 else
     : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
 fi

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -22,10 +22,6 @@ die() {
     exit 1
 }
 
-if [ "$(id -u)" != 0 ]; then
-    die "this script needs to run as root"
-fi
-
 [ -z "$SERENITY_SOURCE_DIR" ] && die "SERENITY_SOURCE_DIR is not set"
 [ -d "$SERENITY_SOURCE_DIR/Base" ] || die "$SERENITY_SOURCE_DIR/Base doesn't exist"
 


### PR DESCRIPTION
The fuse2fs tool that is part of e2fsprogs-1.46 has a 'fakeroot' mount option.  This allows a non-root users to modify file ownership and permissions without actually being root.  This package is available in Debian bullseye and buster-backports.
    
If fuse2fs is available, the script now assumes the user wants to use it.  Otherwise, it falls back to the usual root requirements.