### PR TITLE
Ports: Don't return errno value as pointer in openssh port

### DIFF
--- a/Ports/openssh/patches/reimplement_read_passphrase.patch
+++ b/Ports/openssh/patches/reimplement_read_passphrase.patch
@@ -14,7 +14,7 @@ index 974d67f0..3496eebe 100644
  static char *
  ssh_askpass(char *askpass, const char *msg, const char *env_hint)
  {
-@@ -122,62 +126,33 @@ ssh_askpass(char *askpass, const char *msg, const char *env_hint)
+@@ -122,62 +126,35 @@ ssh_askpass(char *askpass, const char *msg, const char *env_hint)
  char *
  read_passphrase(const char *prompt, int flags)
  {
@@ -56,7 +56,8 @@ index 974d67f0..3496eebe 100644
 +	struct termios no_echo = original;
 +	no_echo.c_lflag &= ~ECHO;
 +	if (tcsetattr(STDIN_FILENO, TCSAFLUSH, &no_echo) < 0) {
-+		return errno;
++		perror("Failed to turn off echo for passphrase");
++		exit(errno);
  	}
  
 -	if ((flags & RP_USE_ASKPASS) && getenv("DISPLAY") == NULL)
@@ -79,7 +80,8 @@ index 974d67f0..3496eebe 100644
 +	tcsetattr(STDIN_FILENO, TCSAFLUSH, &original);
 +	putchar('\n');
 +	if (ret < 0) {
-+		return errno;
++		perror("Failed to read passphrase");
++		exit(errno);
  	}
  
 -	if (readpassphrase(prompt, buf, sizeof buf, rppflags) == NULL) {


### PR DESCRIPTION
This fixes a segmentation fault on an error path in openssh, which is caused by an errno value being coerced into a `char*` and then being dereferenced. We replace this with a more useful error message (+ an immediate program exit as per the function spec).

There is another underlying issue which is causing the error path to be taken in some cases (in particular using ssh through git on an unknown host), which would best be fixed by implementing `/dev/tty` as required by POSIX. This other issue is not fixed in this PR.