### PR TITLE
Kernel: SysFS OOM fixes

### DIFF
--- a/Kernel/Bus/PCI/SysFSPCI.cpp
+++ b/Kernel/Bus/PCI/SysFSPCI.cpp
@@ -15,21 +15,24 @@ namespace Kernel::PCI {
 
 UNMAP_AFTER_INIT NonnullRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirectory::create(const SysFSDirectory& parent_directory, Address address)
 {
-    return adopt_ref(*new (nothrow) PCIDeviceSysFSDirectory(parent_directory, address));
+    // FIXME: Handle allocation failure gracefully
+    auto device_name = MUST(KString::try_create(String::formatted("{:04x}:{:02x}:{:02x}.{}", address.domain(), address.bus(), address.device(), address.function())));
+    return adopt_ref(*new (nothrow) PCIDeviceSysFSDirectory(move(device_name), parent_directory, address));
 }
 
-UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(const SysFSDirectory& parent_directory, Address address)
-    : SysFSDirectory(String::formatted("{:04x}:{:02x}:{:02x}.{}", address.domain(), address.bus(), address.device(), address.function()), parent_directory)
+UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, const SysFSDirectory& parent_directory, Address address)
+    : SysFSDirectory(parent_directory)
     , m_address(address)
+    , m_device_directory_name(move(device_directory_name))
 {
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("vendor"sv, *this, PCI::RegisterOffset::VENDOR_ID, 2));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("device_id"sv, *this, PCI::RegisterOffset::DEVICE_ID, 2));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("class"sv, *this, PCI::RegisterOffset::CLASS, 1));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("subclass"sv, *this, PCI::RegisterOffset::SUBCLASS, 1));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("revision"sv, *this, PCI::RegisterOffset::REVISION_ID, 1));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("progif"sv, *this, PCI::RegisterOffset::PROG_IF, 1));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("subsystem_vendor"sv, *this, PCI::RegisterOffset::SUBSYSTEM_VENDOR_ID, 2));
-    m_components.append(PCIDeviceAttributeSysFSComponent::create("subsystem_id"sv, *this, PCI::RegisterOffset::SUBSYSTEM_ID, 2));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::VENDOR_ID, 2));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::DEVICE_ID, 2));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::CLASS, 1));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::SUBCLASS, 1));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::REVISION_ID, 1));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::PROG_IF, 1));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::SUBSYSTEM_VENDOR_ID, 2));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::SUBSYSTEM_ID, 2));
 }
 
 UNMAP_AFTER_INIT void PCIBusSysFSDirectory::initialize()
@@ -39,7 +42,7 @@ UNMAP_AFTER_INIT void PCIBusSysFSDirectory::initialize()
 }
 
 UNMAP_AFTER_INIT PCIBusSysFSDirectory::PCIBusSysFSDirectory()
-    : SysFSDirectory("pci", SysFSComponentRegistry::the().buses_directory())
+    : SysFSDirectory(SysFSComponentRegistry::the().buses_directory())
 {
     PCI::enumerate([&](DeviceIdentifier const& device_identifier) {
         auto pci_device = PCI::PCIDeviceSysFSDirectory::create(*this, device_identifier.address());
@@ -47,13 +50,37 @@ UNMAP_AFTER_INIT PCIBusSysFSDirectory::PCIBusSysFSDirectory()
     });
 }
 
-NonnullRefPtr<PCIDeviceAttributeSysFSComponent> PCIDeviceAttributeSysFSComponent::create(StringView name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width)
+StringView PCIDeviceAttributeSysFSComponent::name() const
 {
-    return adopt_ref(*new (nothrow) PCIDeviceAttributeSysFSComponent(name, device, offset, field_bytes_width));
+    switch (m_offset) {
+    case PCI::RegisterOffset::VENDOR_ID:
+        return "vendor"sv;
+    case PCI::RegisterOffset::DEVICE_ID:
+        return "device_id"sv;
+    case PCI::RegisterOffset::CLASS:
+        return "class"sv;
+    case PCI::RegisterOffset::SUBCLASS:
+        return "subclass"sv;
+    case PCI::RegisterOffset::REVISION_ID:
+        return "revision"sv;
+    case PCI::RegisterOffset::PROG_IF:
+        return "progif"sv;
+    case PCI::RegisterOffset::SUBSYSTEM_VENDOR_ID:
+        return "subsystem_vendor"sv;
+    case PCI::RegisterOffset::SUBSYSTEM_ID:
+        return "subsystem_id"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
 }
 
-PCIDeviceAttributeSysFSComponent::PCIDeviceAttributeSysFSComponent(StringView name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width)
-    : SysFSComponent(name)
+NonnullRefPtr<PCIDeviceAttributeSysFSComponent> PCIDeviceAttributeSysFSComponent::create(const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width)
+{
+    return adopt_ref(*new (nothrow) PCIDeviceAttributeSysFSComponent(device, offset, field_bytes_width));
+}
+
+PCIDeviceAttributeSysFSComponent::PCIDeviceAttributeSysFSComponent(const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width)
+    : SysFSComponent()
     , m_device(device)
     , m_offset(offset)
     , m_field_bytes_width(field_bytes_width)

--- a/Kernel/Bus/PCI/SysFSPCI.h
+++ b/Kernel/Bus/PCI/SysFSPCI.h
@@ -15,6 +15,7 @@ namespace Kernel::PCI {
 class PCIBusSysFSDirectory final : public SysFSDirectory {
 public:
     static void initialize();
+    virtual StringView name() const override { return "pci"sv; }
 
 private:
     PCIBusSysFSDirectory();
@@ -25,22 +26,28 @@ public:
     static NonnullRefPtr<PCIDeviceSysFSDirectory> create(const SysFSDirectory&, Address);
     const Address& address() const { return m_address; }
 
+    virtual StringView name() const override { return m_device_directory_name->view(); }
+
 private:
-    PCIDeviceSysFSDirectory(const SysFSDirectory&, Address);
+    PCIDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, const SysFSDirectory&, Address);
 
     Address m_address;
+
+    NonnullOwnPtr<KString> m_device_directory_name;
 };
 
 class PCIDeviceAttributeSysFSComponent : public SysFSComponent {
 public:
-    static NonnullRefPtr<PCIDeviceAttributeSysFSComponent> create(StringView name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width);
+    static NonnullRefPtr<PCIDeviceAttributeSysFSComponent> create(const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width);
 
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
     virtual ~PCIDeviceAttributeSysFSComponent() {};
 
+    virtual StringView name() const override;
+
 protected:
     ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer() const;
-    PCIDeviceAttributeSysFSComponent(StringView name, const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width);
+    PCIDeviceAttributeSysFSComponent(const PCIDeviceSysFSDirectory& device, PCI::RegisterOffset offset, size_t field_bytes_width);
     NonnullRefPtr<PCIDeviceSysFSDirectory> m_device;
     PCI::RegisterOffset m_offset;
     size_t m_field_bytes_width;

--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -13,9 +13,10 @@ namespace Kernel::USB {
 
 static SysFSUSBBusDirectory* s_procfs_usb_bus_directory;
 
-SysFSUSBDeviceInformation::SysFSUSBDeviceInformation(USB::Device& device)
-    : SysFSComponent(String::number(device.address()))
+SysFSUSBDeviceInformation::SysFSUSBDeviceInformation(NonnullOwnPtr<KString> device_name, USB::Device& device)
+    : SysFSComponent()
     , m_device(device)
+    , m_device_name(move(device_name))
 {
 }
 
@@ -150,7 +151,7 @@ SysFSUSBBusDirectory& SysFSUSBBusDirectory::the()
 }
 
 UNMAP_AFTER_INIT SysFSUSBBusDirectory::SysFSUSBBusDirectory(SysFSBusDirectory& buses_directory)
-    : SysFSDirectory("usb"sv, buses_directory)
+    : SysFSDirectory(buses_directory)
 {
 }
 
@@ -163,7 +164,8 @@ UNMAP_AFTER_INIT void SysFSUSBBusDirectory::initialize()
 
 NonnullRefPtr<SysFSUSBDeviceInformation> SysFSUSBDeviceInformation::create(USB::Device& device)
 {
-    return adopt_ref(*new SysFSUSBDeviceInformation(device));
+    auto device_name = KString::must_create(String::number(device.address()));
+    return adopt_ref(*new SysFSUSBDeviceInformation(move(device_name), device));
 }
 
 }

--- a/Kernel/Bus/USB/SysFSUSB.h
+++ b/Kernel/Bus/USB/SysFSUSB.h
@@ -20,11 +20,12 @@ public:
     virtual ~SysFSUSBDeviceInformation() override;
 
     static NonnullRefPtr<SysFSUSBDeviceInformation> create(USB::Device&);
+    virtual StringView name() const override { return m_device_name->view(); }
 
     RefPtr<USB::Device> device() const { return m_device; }
 
 protected:
-    explicit SysFSUSBDeviceInformation(USB::Device& device);
+    SysFSUSBDeviceInformation(NonnullOwnPtr<KString> device_name, USB::Device& device);
 
     virtual ErrorOr<size_t> read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, OpenFileDescription*) const override;
 
@@ -36,12 +37,15 @@ private:
     ErrorOr<void> try_generate(KBufferBuilder&);
     virtual ErrorOr<void> refresh_data(OpenFileDescription& description) const override;
     mutable Mutex m_lock { "SysFSUSBDeviceInformation" };
+    NonnullOwnPtr<KString> m_device_name;
 };
 
 class SysFSUSBBusDirectory final : public SysFSDirectory {
 public:
     static void initialize();
     static SysFSUSBBusDirectory& the();
+
+    virtual StringView name() const override { return "usb"sv; }
 
     void plug(USB::Device&);
     void unplug(USB::Device&);

--- a/Kernel/FileSystem/SysFS.cpp
+++ b/Kernel/FileSystem/SysFS.cpp
@@ -60,7 +60,6 @@ ErrorOr<void> SysFSRootDirectory::traverse_as_directory(FileSystemID fsid, Funct
 }
 
 SysFSRootDirectory::SysFSRootDirectory()
-    : SysFSDirectory(".")
 {
     auto buses_directory = SysFSBusDirectory::must_create(*this);
     auto devices_directory = SysFSDevicesDirectory::must_create(*this);
@@ -252,7 +251,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<SysFSBusDirectory> SysFSBusDirectory::must_create
 }
 
 UNMAP_AFTER_INIT SysFSBusDirectory::SysFSBusDirectory(SysFSRootDirectory const& parent_directory)
-    : SysFSDirectory("bus"sv, parent_directory)
+    : SysFSDirectory(parent_directory)
 {
 }
 

--- a/Kernel/FileSystem/SysFS.h
+++ b/Kernel/FileSystem/SysFS.h
@@ -18,6 +18,7 @@ class SysFSRootDirectory final : public SysFSDirectory {
     friend class SysFSComponentRegistry;
 
 public:
+    virtual StringView name() const override { return "."sv; }
     static NonnullRefPtr<SysFSRootDirectory> create();
     virtual ErrorOr<void> traverse_as_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)>) const override;
 
@@ -33,17 +34,20 @@ class SysFSDeviceComponent final
 
 public:
     static NonnullRefPtr<SysFSDeviceComponent> must_create(Device const&);
-
+    virtual StringView name() const override { return m_major_minor_formatted_device_name->view(); }
     bool is_block_device() const { return m_block_device; }
 
 private:
-    explicit SysFSDeviceComponent(Device const&);
+    SysFSDeviceComponent(NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const&);
     IntrusiveListNode<SysFSDeviceComponent, NonnullRefPtr<SysFSDeviceComponent>> m_list_node;
     bool m_block_device;
+
+    NonnullOwnPtr<KString> m_major_minor_formatted_device_name;
 };
 
 class SysFSDevicesDirectory final : public SysFSDirectory {
 public:
+    virtual StringView name() const override { return "dev"sv; }
     static NonnullRefPtr<SysFSDevicesDirectory> must_create(SysFSRootDirectory const&);
 
 private:
@@ -52,6 +56,7 @@ private:
 
 class SysFSBlockDevicesDirectory final : public SysFSDirectory {
 public:
+    virtual StringView name() const override { return "block"sv; }
     static NonnullRefPtr<SysFSBlockDevicesDirectory> must_create(SysFSDevicesDirectory const&);
     virtual ErrorOr<void> traverse_as_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)>) const override;
     virtual RefPtr<SysFSComponent> lookup(StringView name) override;
@@ -62,6 +67,7 @@ private:
 
 class SysFSCharacterDevicesDirectory final : public SysFSDirectory {
 public:
+    virtual StringView name() const override { return "char"sv; }
     static NonnullRefPtr<SysFSCharacterDevicesDirectory> must_create(SysFSDevicesDirectory const&);
     virtual ErrorOr<void> traverse_as_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)>) const override;
     virtual RefPtr<SysFSComponent> lookup(StringView name) override;
@@ -74,6 +80,7 @@ class SysFSBusDirectory : public SysFSDirectory {
     friend class SysFSComponentRegistry;
 
 public:
+    virtual StringView name() const override { return "bus"sv; }
     static NonnullRefPtr<SysFSBusDirectory> must_create(SysFSRootDirectory const&);
 
 private:

--- a/Kernel/FileSystem/SysFSComponent.cpp
+++ b/Kernel/FileSystem/SysFSComponent.cpp
@@ -20,9 +20,8 @@ static size_t allocate_inode_index()
     return s_next_inode_index.value();
 }
 
-SysFSComponent::SysFSComponent(StringView name)
-    : m_name(KString::try_create(name).release_value()) // FIXME: Handle KString allocation failure.
-    , m_component_index(allocate_inode_index())
+SysFSComponent::SysFSComponent()
+    : m_component_index(allocate_inode_index())
 {
 }
 
@@ -55,13 +54,8 @@ RefPtr<SysFSComponent> SysFSDirectory::lookup(StringView name)
     return {};
 }
 
-SysFSDirectory::SysFSDirectory(StringView name)
-    : SysFSComponent(name)
-{
-}
-
-SysFSDirectory::SysFSDirectory(StringView name, SysFSDirectory const& parent_directory)
-    : SysFSComponent(name)
+SysFSDirectory::SysFSDirectory(SysFSDirectory const& parent_directory)
+    : SysFSComponent()
     , m_parent_directory(parent_directory)
 {
 }

--- a/Kernel/FileSystem/SysFSComponent.h
+++ b/Kernel/FileSystem/SysFSComponent.h
@@ -25,7 +25,7 @@ struct SysFSInodeData : public OpenFileDescriptionData {
 
 class SysFSComponent : public RefCounted<SysFSComponent> {
 public:
-    virtual StringView name() const { return m_name->view(); }
+    virtual StringView name() const = 0;
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const { return Error::from_errno(ENOTIMPL); }
     virtual ErrorOr<void> traverse_as_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)>) const { VERIFY_NOT_REACHED(); }
     virtual RefPtr<SysFSComponent> lookup(StringView) { VERIFY_NOT_REACHED(); };
@@ -42,10 +42,9 @@ public:
     virtual ~SysFSComponent() = default;
 
 protected:
-    explicit SysFSComponent(StringView name);
+    SysFSComponent();
 
 private:
-    NonnullOwnPtr<KString> m_name;
     InodeIndex m_component_index {};
 };
 
@@ -57,8 +56,8 @@ public:
     virtual ErrorOr<NonnullRefPtr<SysFSInode>> to_inode(SysFS const& sysfs_instance) const override final;
 
 protected:
-    explicit SysFSDirectory(StringView name);
-    SysFSDirectory(StringView name, SysFSDirectory const& parent_directory);
+    SysFSDirectory() = default;
+    explicit SysFSDirectory(SysFSDirectory const& parent_directory);
     NonnullRefPtrVector<SysFSComponent> m_components;
     RefPtr<SysFSDirectory> m_parent_directory;
 };

--- a/Kernel/Firmware/ACPI/Parser.cpp
+++ b/Kernel/Firmware/ACPI/Parser.cpp
@@ -67,9 +67,9 @@ UNMAP_AFTER_INIT ACPISysFSComponent::ACPISysFSComponent(NonnullOwnPtr<KString> t
 {
 }
 
-UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<ACPISysFSDirectory>> ACPISysFSDirectory::try_create(FirmwareSysFSDirectory& firmware_directory)
+UNMAP_AFTER_INIT NonnullRefPtr<ACPISysFSDirectory> ACPISysFSDirectory::must_create(FirmwareSysFSDirectory& firmware_directory)
 {
-    auto acpi_directory = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ACPISysFSDirectory(firmware_directory)));
+    auto acpi_directory = MUST(adopt_nonnull_ref_or_enomem(new (nothrow) ACPISysFSDirectory(firmware_directory)));
     return acpi_directory;
 }
 

--- a/Kernel/Firmware/ACPI/Parser.cpp
+++ b/Kernel/Firmware/ACPI/Parser.cpp
@@ -67,14 +67,7 @@ UNMAP_AFTER_INIT ACPISysFSComponent::ACPISysFSComponent(NonnullOwnPtr<KString> t
 {
 }
 
-UNMAP_AFTER_INIT NonnullRefPtr<ACPISysFSDirectory> ACPISysFSDirectory::must_create(FirmwareSysFSDirectory& firmware_directory)
-{
-    auto acpi_directory = MUST(adopt_nonnull_ref_or_enomem(new (nothrow) ACPISysFSDirectory(firmware_directory)));
-    return acpi_directory;
-}
-
-UNMAP_AFTER_INIT ACPISysFSDirectory::ACPISysFSDirectory(FirmwareSysFSDirectory& firmware_directory)
-    : SysFSDirectory(firmware_directory)
+UNMAP_AFTER_INIT void ACPISysFSDirectory::find_tables_and_register_them_as_components()
 {
     NonnullRefPtrVector<SysFSComponent> components;
     size_t ssdt_count = 0;
@@ -97,6 +90,18 @@ UNMAP_AFTER_INIT ACPISysFSDirectory::ACPISysFSDirectory(FirmwareSysFSDirectory& 
     } else {
         m_components.append(ACPISysFSComponent::create("RSDT", ACPI::Parser::the()->main_system_description_table(), main_system_description_table->length));
     }
+}
+
+UNMAP_AFTER_INIT NonnullRefPtr<ACPISysFSDirectory> ACPISysFSDirectory::must_create(FirmwareSysFSDirectory& firmware_directory)
+{
+    auto acpi_directory = MUST(adopt_nonnull_ref_or_enomem(new (nothrow) ACPISysFSDirectory(firmware_directory)));
+    acpi_directory->find_tables_and_register_them_as_components();
+    return acpi_directory;
+}
+
+UNMAP_AFTER_INIT ACPISysFSDirectory::ACPISysFSDirectory(FirmwareSysFSDirectory& firmware_directory)
+    : SysFSDirectory(firmware_directory)
+{
 }
 
 void Parser::enumerate_static_tables(Function<void(StringView, PhysicalAddress, size_t)> callback)

--- a/Kernel/Firmware/ACPI/Parser.h
+++ b/Kernel/Firmware/ACPI/Parser.h
@@ -26,6 +26,7 @@ public:
     static NonnullRefPtr<ACPISysFSDirectory> must_create(FirmwareSysFSDirectory& firmware_directory);
 
 private:
+    void find_tables_and_register_them_as_components();
     explicit ACPISysFSDirectory(FirmwareSysFSDirectory& firmware_directory);
 };
 

--- a/Kernel/Firmware/ACPI/Parser.h
+++ b/Kernel/Firmware/ACPI/Parser.h
@@ -22,6 +22,7 @@ namespace Kernel::ACPI {
 
 class ACPISysFSDirectory : public SysFSDirectory {
 public:
+    virtual StringView name() const override { return "acpi"sv; }
     static ErrorOr<NonnullRefPtr<ACPISysFSDirectory>> try_create(FirmwareSysFSDirectory& firmware_directory);
 
 private:
@@ -30,16 +31,17 @@ private:
 
 class ACPISysFSComponent : public SysFSComponent {
 public:
-    static NonnullRefPtr<ACPISysFSComponent> create(String name, PhysicalAddress, size_t table_size);
-
+    static NonnullRefPtr<ACPISysFSComponent> create(StringView name, PhysicalAddress, size_t table_size);
+    virtual StringView name() const override { return m_table_name->view(); }
     virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
 
 protected:
     ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer() const;
-    ACPISysFSComponent(String name, PhysicalAddress, size_t table_size);
+    ACPISysFSComponent(NonnullOwnPtr<KString> table_name, PhysicalAddress, size_t table_size);
 
     PhysicalAddress m_paddr;
     size_t m_length;
+    NonnullOwnPtr<KString> m_table_name;
 };
 
 class Parser final : public IRQHandler {

--- a/Kernel/Firmware/ACPI/Parser.h
+++ b/Kernel/Firmware/ACPI/Parser.h
@@ -23,7 +23,7 @@ namespace Kernel::ACPI {
 class ACPISysFSDirectory : public SysFSDirectory {
 public:
     virtual StringView name() const override { return "acpi"sv; }
-    static ErrorOr<NonnullRefPtr<ACPISysFSDirectory>> try_create(FirmwareSysFSDirectory& firmware_directory);
+    static NonnullRefPtr<ACPISysFSDirectory> must_create(FirmwareSysFSDirectory& firmware_directory);
 
 private:
     explicit ACPISysFSDirectory(FirmwareSysFSDirectory& firmware_directory);

--- a/Kernel/Firmware/BIOS.cpp
+++ b/Kernel/Firmware/BIOS.cpp
@@ -24,8 +24,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<DMIEntryPointExposedBlob> DMIEntryPointExposedBlo
     return adopt_ref(*new (nothrow) DMIEntryPointExposedBlob(dmi_entry_point, blob_size));
 }
 
-UNMAP_AFTER_INIT BIOSSysFSComponent::BIOSSysFSComponent(StringView name)
-    : SysFSComponent(name)
+UNMAP_AFTER_INIT BIOSSysFSComponent::BIOSSysFSComponent()
 {
 }
 
@@ -42,7 +41,7 @@ ErrorOr<size_t> BIOSSysFSComponent::read_bytes(off_t offset, size_t count, UserO
 }
 
 UNMAP_AFTER_INIT DMIEntryPointExposedBlob::DMIEntryPointExposedBlob(PhysicalAddress dmi_entry_point, size_t blob_size)
-    : BIOSSysFSComponent("smbios_entry_point"sv)
+    : BIOSSysFSComponent()
     , m_dmi_entry_point(dmi_entry_point)
     , m_dmi_entry_point_length(blob_size)
 {
@@ -60,7 +59,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<SMBIOSExposedTable> SMBIOSExposedTable::create(Ph
 }
 
 UNMAP_AFTER_INIT SMBIOSExposedTable::SMBIOSExposedTable(PhysicalAddress smbios_structure_table, size_t smbios_structure_table_length)
-    : BIOSSysFSComponent("DMI"sv)
+    : BIOSSysFSComponent()
     , m_smbios_structure_table(smbios_structure_table)
     , m_smbios_structure_table_length(smbios_structure_table_length)
 {
@@ -127,7 +126,7 @@ UNMAP_AFTER_INIT void BIOSSysFSDirectory::initialize_dmi_exposer()
 }
 
 UNMAP_AFTER_INIT BIOSSysFSDirectory::BIOSSysFSDirectory(FirmwareSysFSDirectory& firmware_directory)
-    : SysFSDirectory("bios", firmware_directory)
+    : SysFSDirectory(firmware_directory)
 {
     auto entry_32bit = find_dmi_entry32bit_point();
     if (entry_32bit.has_value()) {

--- a/Kernel/Firmware/BIOS.h
+++ b/Kernel/Firmware/BIOS.h
@@ -72,7 +72,7 @@ protected:
 class DMIEntryPointExposedBlob : public BIOSSysFSComponent {
 public:
     virtual StringView name() const override { return "smbios_entry_point"sv; }
-    static NonnullRefPtr<DMIEntryPointExposedBlob> create(PhysicalAddress dmi_entry_point, size_t blob_size);
+    static NonnullRefPtr<DMIEntryPointExposedBlob> must_create(PhysicalAddress dmi_entry_point, size_t blob_size);
 
 private:
     DMIEntryPointExposedBlob(PhysicalAddress dmi_entry_point, size_t blob_size);
@@ -84,7 +84,7 @@ private:
 class SMBIOSExposedTable : public BIOSSysFSComponent {
 public:
     virtual StringView name() const override { return "DMI"sv; }
-    static NonnullRefPtr<SMBIOSExposedTable> create(PhysicalAddress, size_t blob_size);
+    static NonnullRefPtr<SMBIOSExposedTable> must_create(PhysicalAddress, size_t blob_size);
 
 private:
     SMBIOSExposedTable(PhysicalAddress dmi_entry_point, size_t blob_size);
@@ -97,7 +97,7 @@ private:
 class BIOSSysFSDirectory : public SysFSDirectory {
 public:
     virtual StringView name() const override { return "bios"sv; }
-    static ErrorOr<NonnullRefPtr<BIOSSysFSDirectory>> try_create(FirmwareSysFSDirectory&);
+    static NonnullRefPtr<BIOSSysFSDirectory> must_create(FirmwareSysFSDirectory&);
 
     void create_components();
 

--- a/Kernel/Firmware/BIOS.h
+++ b/Kernel/Firmware/BIOS.h
@@ -66,11 +66,12 @@ public:
 
 protected:
     virtual ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer() const = 0;
-    explicit BIOSSysFSComponent(StringView name);
+    BIOSSysFSComponent();
 };
 
 class DMIEntryPointExposedBlob : public BIOSSysFSComponent {
 public:
+    virtual StringView name() const override { return "smbios_entry_point"sv; }
     static NonnullRefPtr<DMIEntryPointExposedBlob> create(PhysicalAddress dmi_entry_point, size_t blob_size);
 
 private:
@@ -82,6 +83,7 @@ private:
 
 class SMBIOSExposedTable : public BIOSSysFSComponent {
 public:
+    virtual StringView name() const override { return "DMI"sv; }
     static NonnullRefPtr<SMBIOSExposedTable> create(PhysicalAddress, size_t blob_size);
 
 private:
@@ -94,6 +96,7 @@ private:
 
 class BIOSSysFSDirectory : public SysFSDirectory {
 public:
+    virtual StringView name() const override { return "bios"sv; }
     static ErrorOr<NonnullRefPtr<BIOSSysFSDirectory>> try_create(FirmwareSysFSDirectory&);
 
     void create_components();

--- a/Kernel/Firmware/PowerStateSwitch.cpp
+++ b/Kernel/Firmware/PowerStateSwitch.cpp
@@ -26,7 +26,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<PowerStateSwitchNode> PowerStateSwitchNode::must_
 }
 
 UNMAP_AFTER_INIT PowerStateSwitchNode::PowerStateSwitchNode(FirmwareSysFSDirectory&)
-    : SysFSComponent("power_state")
+    : SysFSComponent()
 {
 }
 

--- a/Kernel/Firmware/PowerStateSwitch.h
+++ b/Kernel/Firmware/PowerStateSwitch.h
@@ -22,6 +22,7 @@ namespace Kernel {
 
 class PowerStateSwitchNode final : public SysFSComponent {
 public:
+    virtual StringView name() const override { return "power_state"sv; }
     static NonnullRefPtr<PowerStateSwitchNode> must_create(FirmwareSysFSDirectory&);
     virtual mode_t permissions() const override;
     virtual ErrorOr<size_t> write_bytes(off_t, size_t, UserOrKernelBuffer const&, OpenFileDescription*) override;

--- a/Kernel/Firmware/SysFSFirmware.cpp
+++ b/Kernel/Firmware/SysFSFirmware.cpp
@@ -21,14 +21,9 @@ UNMAP_AFTER_INIT void FirmwareSysFSDirectory::initialize()
 
 void FirmwareSysFSDirectory::create_components()
 {
-    auto bios_directory_or_error = BIOSSysFSDirectory::try_create(*this);
-    VERIFY(!bios_directory_or_error.is_error());
-    auto acpi_directory_or_error = ACPI::ACPISysFSDirectory::try_create(*this);
-    VERIFY(!acpi_directory_or_error.is_error());
-    auto power_state_switch_node = PowerStateSwitchNode::must_create(*this);
-    m_components.append(bios_directory_or_error.release_value());
-    m_components.append(acpi_directory_or_error.release_value());
-    m_components.append(power_state_switch_node);
+    m_components.append(BIOSSysFSDirectory::must_create(*this));
+    m_components.append(ACPI::ACPISysFSDirectory::must_create(*this));
+    m_components.append(PowerStateSwitchNode::must_create(*this));
 }
 
 UNMAP_AFTER_INIT FirmwareSysFSDirectory::FirmwareSysFSDirectory()

--- a/Kernel/Firmware/SysFSFirmware.cpp
+++ b/Kernel/Firmware/SysFSFirmware.cpp
@@ -32,7 +32,7 @@ void FirmwareSysFSDirectory::create_components()
 }
 
 UNMAP_AFTER_INIT FirmwareSysFSDirectory::FirmwareSysFSDirectory()
-    : SysFSDirectory("firmware", SysFSComponentRegistry::the().root_directory())
+    : SysFSDirectory(SysFSComponentRegistry::the().root_directory())
 {
 }
 

--- a/Kernel/Firmware/SysFSFirmware.h
+++ b/Kernel/Firmware/SysFSFirmware.h
@@ -13,6 +13,7 @@ namespace Kernel {
 
 class FirmwareSysFSDirectory : public SysFSDirectory {
 public:
+    virtual StringView name() const override { return "firmware"sv; }
     static void initialize();
 
     void create_components();


### PR DESCRIPTION
The goal of this pull request is to implement some fixes to ensure we can allocate memory for SysFS components more safely.
What has been done so far:
- Allocation of the name is either done before constructing the SysFS component or prevented entirely.
- There's some added clarity to what objects must be created and what cannot fail under any circumstances.
- Deferring of allocation after the constructor in the ACPI sysfs directory, so we enumerate the found tables outside the constructor for the sake of keeping the kernel programming principle of "not allocating memory inside a constructor".