### PR TITLE
AK: Fix preprocessor OS check

### DIFF
--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -25,7 +25,7 @@ StackInfo::StackInfo()
         perror("get_stack_bounds");
         VERIFY_NOT_REACHED();
     }
-#elif __linux__
+#elif defined(__linux__)
     int rc;
     pthread_attr_t attr = {};
     if ((rc = pthread_getattr_np(pthread_self(), &attr)) != 0) {


### PR DESCRIPTION
Instead of checking `__linux__` macro directly, the code should check if
this macro is defined. This is already done correctly a couple of lines above.

I ran into this when trying to build libjs-test262 on MacOS where I got
the following error message
        error: "`__linux__`" is not defined, evaluates to 0 [-Werror=undef]