### PR TITLE
Services: Tighten pledged promises

### DIFF
--- a/Userland/Services/ChessEngine/main.cpp
+++ b/Userland/Services/ChessEngine/main.cpp
@@ -12,9 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd unix rpath"));
-    Core::EventLoop loop;
     TRY(Core::System::pledge("stdio recvfd sendfd unix"));
+    Core::EventLoop loop;
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto engine = TRY(ChessEngine::try_create(Core::File::standard_input(), Core::File::standard_output()));

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -20,15 +20,15 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio inet accept unix rpath sendfd recvfd sigaction"));
-
     signal(SIGINFO, [](int) { RequestServer::ConnectionCache::dump_jobs(); });
+    TRY(Core::System::pledge("stdio inet accept unix rpath sendfd recvfd"));
 
     // Ensure the certificates are read out here.
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();
+    TRY(Core::System::pledge("stdio inet accept unix sendfd recvfd"));
 
     Core::EventLoop event_loop;
     // FIXME: Establish a connection to LookupServer and then drop "unix"?
-    TRY(Core::System::pledge("stdio inet accept unix sendfd recvfd"));
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -46,7 +46,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             ;
     });
 
-    // We need to obtain the WM connection here as well before the pledge shortening.
+    TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath unix"));
     GUI::WindowManagerServerConnection::the();
 
     TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath"));

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -31,6 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     act.sa_flags = SA_NOCLDWAIT;
     act.sa_handler = SIG_IGN;
     TRY(Core::System::sigaction(SIGCHLD, &act, nullptr));
+    TRY(Core::System::pledge("stdio video thread sendfd recvfd accept rpath wpath cpath unix proc"));
 
     auto wm_config = Core::ConfigFile::open("/etc/WindowServer.ini");
     auto theme_name = wm_config->read_entry("Theme", "Name", "Default");


### PR DESCRIPTION
This patch contains fixes for pledged promises in Services, found during work on https://github.com/SerenityOS/serenity/pull/11209#issuecomment-991941182.

If this patch is considered to be correct, I think it illustrates how hard it is to `pledge()` a minimal syscall surface area in programs. Especially given the adamant, but seemingly incorrect comment in `Userland/Services/Taskbar/main.cpp`.