### PR TITLE
LibGL: Rasterizer performance improvements

### DIFF
--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -328,6 +328,12 @@ void SoftwareGLContext::gl_end()
         }
     }
 
+    m_bound_texture_units.clear();
+    for (auto& texture_unit : m_texture_units) {
+        if (texture_unit.is_bound())
+            m_bound_texture_units.append(texture_unit);
+    }
+
     for (size_t i = 0; i < processed_triangles.size(); i++) {
         GLTriangle& triangle = processed_triangles.at(i);
 
@@ -356,7 +362,7 @@ void SoftwareGLContext::gl_end()
             swap(triangle.vertices[0], triangle.vertices[1]);
         }
 
-        m_rasterizer.submit_triangle(triangle, m_texture_units);
+        m_rasterizer.submit_triangle(triangle, m_bound_texture_units);
     }
 }
 

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -234,6 +234,7 @@ private:
     HashMap<GLuint, RefPtr<Texture>> m_allocated_textures;
     Array<TextureUnit, 32> m_texture_units;
     TextureUnit* m_active_texture_unit { &m_texture_units[0] };
+    TextureUnit::BoundList m_bound_texture_units;
 
     SoftwareRasterizer m_rasterizer;
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -15,7 +15,7 @@ namespace GL {
 using IntVector2 = Gfx::Vector2<int>;
 using IntVector3 = Gfx::Vector3<int>;
 
-static constexpr int RASTERIZER_BLOCK_SIZE = 16;
+static constexpr int RASTERIZER_BLOCK_SIZE = 8;
 
 constexpr static int edge_function(const IntVector2& a, const IntVector2& b, const IntVector2& c)
 {
@@ -199,8 +199,8 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
     int const by1 = (min(render_bounds.bottom(), max(max(v0.y(), v1.y()), v2.y())) + block_padding) / RASTERIZER_BLOCK_SIZE;
     // clang-format on
 
-    static_assert(RASTERIZER_BLOCK_SIZE < sizeof(int) * 8, "RASTERIZER_BLOCK_SIZE must be smaller than the pixel_mask's width in bits");
-    int pixel_mask[RASTERIZER_BLOCK_SIZE];
+    u8 pixel_mask[RASTERIZER_BLOCK_SIZE];
+    static_assert(RASTERIZER_BLOCK_SIZE <= sizeof(decltype(*pixel_mask)) * 8, "RASTERIZER_BLOCK_SIZE must be smaller than the pixel_mask's width in bits");
 
     FloatVector4 pixel_buffer[RASTERIZER_BLOCK_SIZE][RASTERIZER_BLOCK_SIZE];
 

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.cpp
@@ -494,17 +494,12 @@ SoftwareRasterizer::SoftwareRasterizer(const Gfx::IntSize& min_size)
     m_options.scissor_box = m_render_target->rect();
 }
 
-void SoftwareRasterizer::submit_triangle(const GLTriangle& triangle, const Array<TextureUnit, 32>& texture_units)
+void SoftwareRasterizer::submit_triangle(GLTriangle const& triangle, TextureUnit::BoundList const& bound_texture_units)
 {
-    rasterize_triangle(m_options, *m_render_target, *m_depth_buffer, triangle, [this, &texture_units](const FloatVector2& uv, const FloatVector4& color, float z) -> FloatVector4 {
+    rasterize_triangle(m_options, *m_render_target, *m_depth_buffer, triangle, [this, &bound_texture_units](const FloatVector2& uv, const FloatVector4& color, float z) -> FloatVector4 {
         FloatVector4 fragment = color;
 
-        for (const auto& texture_unit : texture_units) {
-
-            // No texture is bound to this texture unit
-            if (!texture_unit.is_bound())
-                continue;
-
+        for (auto const& texture_unit : bound_texture_units) {
             // FIXME: implement GL_TEXTURE_1D, GL_TEXTURE_3D and GL_TEXTURE_CUBE_MAP
             FloatVector4 texel;
             switch (texture_unit.currently_bound_target()) {

--- a/Userland/Libraries/LibGL/SoftwareRasterizer.h
+++ b/Userland/Libraries/LibGL/SoftwareRasterizer.h
@@ -56,7 +56,7 @@ class SoftwareRasterizer final {
 public:
     SoftwareRasterizer(const Gfx::IntSize& min_size);
 
-    void submit_triangle(const GLTriangle& triangle, const Array<TextureUnit, 32>& texture_units);
+    void submit_triangle(GLTriangle const& triangle, TextureUnit::BoundList const& bound_texture_units);
     void resize(const Gfx::IntSize& min_size);
     void clear_color(const FloatVector4&);
     void clear_depth(float);

--- a/Userland/Libraries/LibGL/Tex/TextureUnit.h
+++ b/Userland/Libraries/LibGL/Tex/TextureUnit.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/IntrusiveList.h>
 #include <AK/OwnPtr.h>
 #include <LibGL/Tex/Texture2D.h>
 
@@ -34,6 +35,9 @@ public:
     void set_texture_3d_enabled(bool texture_3d_enabled) { m_texture_3d_enabled = texture_3d_enabled; }
     bool texture_cube_map_enabled() const { return m_texture_cube_map_enabled; };
     void set_texture_cube_map_enabled(bool texture_cube_map_enabled) { m_texture_cube_map_enabled = texture_cube_map_enabled; }
+
+    IntrusiveListNode<TextureUnit> m_bound_node;
+    using BoundList = IntrusiveList<&TextureUnit::m_bound_node>;
 
 private:
     mutable RefPtr<Texture2D> m_texture_target_2d { nullptr };


### PR DESCRIPTION
Two small changes that result in significant performance improvements for `LibGL` - most notably, GLQuake goes from 12 to 16 FPS on my machine.

I recognize that @sunverwerth is also working on a new software rasterizer in parallel, but until that PR lands this is a nice improvement to have.