### PR TITLE
Meta: Conditionally run QEMU with QMP

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -213,9 +213,13 @@ if [ -z "$SERENITY_MACHINE" ]; then
         -device i82801b11-bridge,id=bridge3 -device sdhci-pci,bus=bridge3
         -device ich9-ahci,bus=bridge3
         -chardev stdio,id=stdout,mux=on
-        -qmp unix:qmp-sock,server,nowait
         "
     fi
+fi
+
+if [ "$NATIVE_WINDOWS_QEMU" -ne "1" ]; then
+    SERENITY_MACHINE="$SERENITY_MACHINE
+    -qmp unix:qmp-sock,server,nowait"
 fi
 
 


### PR DESCRIPTION
Fixes #11235

QEMU can't create UNIX sockets on Windows. So, let's just tell QEMU to fire up QMP only if we're not using the Windows-native QEMU. In the future, if this proves to be useful, we could switch to using a TCP socket rather than a UNIX socket - but I don't want to presume what port we should be operating on. I think it might be a nice future enhancement to have some sort of command line flag to run Serenity and enable QMP only when needed, rather than always turn it on - but that's something that could be explored in the future.

So, this fix approach is simply to add the QMP command-line argument for QEMU when _not_ using Windows-native QEMU. If it's desired, more work could be done to switch to a TCP socket if we've got a port preference and continue always starting with QMP.