### PR TITLE
AK: Add `count{,_leading,_trailing}_{ones,zeros}`

### DIFF
--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -8,6 +8,7 @@
 
 #include <AK/Array.h>
 #include <AK/CountOnes.h>
+#include <AK/CountTrailingZeros.h>
 #include <AK/Optional.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
@@ -253,7 +254,7 @@ public:
                     free_chunks += 32 - viewed_bits;
                     viewed_bits = 32;
                 } else {
-                    trailing_zeroes = count_trailing_zeroes_32(bucket);
+                    trailing_zeroes = count_trailing_zeros(bucket);
                     bucket >>= trailing_zeroes;
 
                     if (free_chunks == 0) {
@@ -267,7 +268,7 @@ public:
                     }
 
                     // Deleting trailing ones.
-                    u32 trailing_ones = count_trailing_zeroes_32(~bucket);
+                    u32 trailing_ones = count_trailing_zeros(~bucket);
                     bucket >>= trailing_ones;
                     viewed_bits += trailing_ones;
                     free_chunks = 0;

--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Array.h>
+#include <AK/CountOnes.h>
 #include <AK/Optional.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
@@ -54,30 +55,30 @@ public:
         byte &= bitmask_first_byte[start % 8];
         if (first == last) {
             byte &= bitmask_last_byte[(start + len) % 8];
-            count = __builtin_popcount(byte);
+            count = count_ones(byte);
         } else {
-            count = __builtin_popcount(byte);
+            count = count_ones(byte);
             // Don't access *last if it's out of bounds
             if (last < &m_data[size_in_bytes()]) {
                 byte = *last;
                 byte &= bitmask_last_byte[(start + len) % 8];
-                count += __builtin_popcount(byte);
+                count += count_ones(byte);
             }
             if (++first < last) {
                 const u32* ptr32 = (const u32*)(((FlatPtr)first + sizeof(u32) - 1) & ~(sizeof(u32) - 1));
                 if ((const u8*)ptr32 > last)
                     ptr32 = (const u32*)last;
                 while (first < (const u8*)ptr32) {
-                    count += __builtin_popcount(*first);
+                    count += count_ones(*first);
                     first++;
                 }
                 const u32* last32 = (const u32*)((FlatPtr)last & ~(sizeof(u32) - 1));
                 while (ptr32 < last32) {
-                    count += __builtin_popcountl(*ptr32);
+                    count += count_ones(*ptr32);
                     ptr32++;
                 }
                 for (first = (const u8*)ptr32; first < last; first++)
-                    count += __builtin_popcount(*first);
+                    count += count_ones(*first);
             }
         }
 

--- a/AK/CountLeadingOnes.h
+++ b/AK/CountLeadingOnes.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/CountLeadingZeros.h>
+
+namespace AK {
+
+template<Integral T>
+ALWAYS_INLINE constexpr size_t count_leading_ones(T val)
+{
+    return AK::count_leading_zeros<T>(~val);
+}
+
+}
+
+using AK::count_leading_ones;

--- a/AK/CountLeadingZeros.h
+++ b/AK/CountLeadingZeros.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Concepts.h>
+#include <AK/Platform.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+template<Integral T>
+ALWAYS_INLINE constexpr size_t count_leading_zeros(T val)
+{
+    constexpr size_t char_bit = 8;
+    constexpr size_t T_bit = sizeof(T) * char_bit;
+
+    if (val == 0)
+        return T_bit;
+
+#if defined(__GNUC__) || defined(__clang__)
+    if constexpr (sizeof(T) == sizeof(int))
+        return __builtin_clz(val);
+    if constexpr (sizeof(T) == sizeof(long))
+        return __builtin_clzl(val);
+    if constexpr (sizeof(T) == sizeof(long long))
+        return __builtin_clzll(val);
+#endif
+
+    for (size_t count = 0; count < T_bit; ++count) {
+        if ((val >> (T_bit - count - 1)) & 1) {
+            return count;
+        }
+    }
+    VERIFY_NOT_REACHED();
+    return T_bit;
+}
+
+}
+
+using AK::count_leading_zeros;

--- a/AK/CountOnes.h
+++ b/AK/CountOnes.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Concepts.h>
+#include <AK/Platform.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+template<Integral T>
+ALWAYS_INLINE constexpr size_t count_ones(T val)
+{
+#if defined(__GNUC__) || defined(__clang__)
+    if constexpr (sizeof(T) == sizeof(int))
+        return __builtin_popcount(val);
+    if constexpr (sizeof(T) == sizeof(long))
+        return __builtin_popcountl(val);
+    if constexpr (sizeof(T) == sizeof(long long))
+        return __builtin_popcountll(val);
+#endif
+
+    size_t count = 0;
+    do {
+        if (val & 1) {
+            count++;
+        }
+    } while (val >>= 1);
+    return count;
+}
+
+}
+
+using AK::count_ones;

--- a/AK/CountTrailingOnes.h
+++ b/AK/CountTrailingOnes.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/CountTrailingZeros.h>
+
+namespace AK {
+
+template<Integral T>
+ALWAYS_INLINE constexpr size_t count_trailing_ones(T val)
+{
+    return AK::count_trailing_zeros<T>(~val);
+}
+
+}
+
+using AK::count_trailing_ones;

--- a/AK/CountTrailingZeros.h
+++ b/AK/CountTrailingZeros.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+#include <AK/Concepts.h>
+#include <AK/Platform.h>
+#include <AK/Types.h>
+
+namespace AK {
+
+template<Integral T>
+ALWAYS_INLINE constexpr size_t count_trailing_zeros(T val)
+{
+    constexpr size_t char_bit = 8;
+    constexpr size_t T_bit = sizeof(T) * char_bit;
+
+    if (val == 0)
+        return T_bit;
+
+#if defined(__GNUC__) || defined(__clang__)
+    if constexpr (sizeof(T) == sizeof(int))
+        return __builtin_ctz(val);
+    if constexpr (sizeof(T) == sizeof(long))
+        return __builtin_ctzl(val);
+    if constexpr (sizeof(T) == sizeof(long long))
+        return __builtin_ctzll(val);
+#endif
+
+    for (size_t count = 0; count < T_bit; ++count) {
+        if ((val >> count) & 1) {
+            return count;
+        }
+    }
+    VERIFY_NOT_REACHED();
+    return T_bit;
+}
+
+}
+
+using AK::count_trailing_zeros;

--- a/AK/CountZeros.h
+++ b/AK/CountZeros.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/CountOnes.h>
+
+namespace AK {
+
+template<Integral T>
+ALWAYS_INLINE constexpr size_t count_zeros(T val)
+{
+    return AK::count_ones<T>(~val);
+}
+
+}
+
+using AK::count_zeros;

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -57,8 +57,6 @@ constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
         return __builtin_##name(x);                   \
     }
 
-INTEGER_BUILTIN(ctz);
-
 namespace Division {
 template<FloatingPoint T>
 constexpr T fmod(T x, T y)

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -57,7 +57,6 @@ constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
         return __builtin_##name(x);                   \
     }
 
-INTEGER_BUILTIN(clz);
 INTEGER_BUILTIN(ctz);
 INTEGER_BUILTIN(popcnt);
 

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -58,7 +58,6 @@ constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
     }
 
 INTEGER_BUILTIN(ctz);
-INTEGER_BUILTIN(popcnt);
 
 namespace Division {
 template<FloatingPoint T>

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -46,17 +46,6 @@ constexpr size_t product_odd() { return value * product_odd<value - 2>(); }
             return __builtin_##function##f(args); \
     }
 
-#define INTEGER_BUILTIN(name)                         \
-    template<Integral T>                              \
-    constexpr T name(T x)                             \
-    {                                                 \
-        if constexpr (sizeof(T) == sizeof(long long)) \
-            return __builtin_##name##ll(x);           \
-        if constexpr (sizeof(T) == sizeof(long))      \
-            return __builtin_##name##l(x);            \
-        return __builtin_##name(x);                   \
-    }
-
 namespace Division {
 template<FloatingPoint T>
 constexpr T fmod(T x, T y)
@@ -465,6 +454,5 @@ constexpr T pow(T x, T y)
 }
 
 #undef CONSTEXPR_STATE
-#undef INTEGER_BUILTIN
 
 }

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Concepts.h>
+#include <AK/CountLeadingZeros.h>
 #include <AK/StdLibExtraDetails.h>
 #include <AK/Types.h>
 
@@ -312,7 +313,7 @@ constexpr T log2(T x)
 template<Integral T>
 constexpr T log2(T x)
 {
-    return x ? 8 * sizeof(T) - clz(x) : 0;
+    return x ? 8 * sizeof(T) - count_leading_zeros(x) : 0;
 }
 
 template<FloatingPoint T>

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -106,29 +106,6 @@ extern "C" {
 #    endif
 #endif
 
-#ifdef __cplusplus
-ALWAYS_INLINE int count_trailing_zeroes_32(unsigned int val)
-{
-#    if defined(__GNUC__) || defined(__clang__)
-    return __builtin_ctz(val);
-#    else
-    for (u8 i = 0; i < 32; ++i) {
-        if ((val >> i) & 1) {
-            return i;
-        }
-    }
-    return 0;
-#    endif
-}
-
-ALWAYS_INLINE int count_trailing_zeroes_32_safe(unsigned int val)
-{
-    if (val == 0)
-        return 32;
-    return count_trailing_zeroes_32(val);
-}
-#endif
-
 #ifdef AK_OS_BSD_GENERIC
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #    define CLOCK_REALTIME_COARSE CLOCK_REALTIME

--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -8,6 +8,7 @@
 
 #include <AK/Checked.h>
 #include <AK/Concepts.h>
+#include <AK/CountLeadingZeros.h>
 #include <AK/Format.h>
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtraDetails.h>
@@ -90,9 +91,9 @@ public:
     constexpr size_t clz() const requires(IsSame<T, u64>)
     {
         if (m_high)
-            return __builtin_clzll(m_high);
+            return count_leading_zeros(m_high);
         else
-            return sizeof(T) * 8 + __builtin_clzll(m_low);
+            return sizeof(T) * 8 + count_leading_zeros(m_low);
     }
     constexpr size_t clz() const requires(!IsSame<T, u64>)
     {
@@ -598,7 +599,7 @@ public:
         R x1 = *this;
         R x2 = *this * *this;
         u64 exp_copy = exp;
-        for (ssize_t i = sizeof(u64) * 8 - __builtin_clzll(exp) - 2; i >= 0; --i) {
+        for (ssize_t i = sizeof(u64) * 8 - count_leading_zeros(exp) - 2; i >= 0; --i) {
             if (exp_copy & 1u) {
                 x2 *= x1;
                 x1 *= x1;
@@ -642,7 +643,7 @@ public:
 
         U res = 1;
         u64 exp_copy = exp;
-        for (size_t i = sizeof(u64) - __builtin_clzll(exp) - 1u; i < exp; ++i) {
+        for (size_t i = sizeof(u64) - count_leading_zeros(exp) - 1u; i < exp; ++i) {
             res *= res;
             res %= mod;
             if (exp_copy & 1u) {
@@ -682,7 +683,7 @@ public:
     constexpr size_t logn(u64 base)
     {
         // FIXME: proper rounding
-        return log2() / (sizeof(u64) - __builtin_clzll(base));
+        return log2() / (sizeof(u64) - count_leading_zeros(base));
     }
     template<Unsigned U>
     requires(sizeof(U) > sizeof(u64)) constexpr size_t logn(U base)

--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -9,6 +9,7 @@
 #include <AK/Checked.h>
 #include <AK/Concepts.h>
 #include <AK/CountLeadingZeros.h>
+#include <AK/CountTrailingZeros.h>
 #include <AK/Format.h>
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtraDetails.h>
@@ -105,9 +106,9 @@ public:
     constexpr size_t ctz() const requires(IsSame<T, u64>)
     {
         if (m_low)
-            return __builtin_ctzll(m_low);
+            return count_trailing_zeros(m_low);
         else
-            return sizeof(T) * 8 + __builtin_ctzll(m_high);
+            return sizeof(T) * 8 + count_trailing_zeros(m_high);
     }
     constexpr size_t ctz() const requires(!IsSame<T, u64>)
     {

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CountOnes.h>
 #include <AK/Format.h>
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
@@ -761,7 +762,7 @@ u32 Processor::smp_wake_n_idle_processors(u32 wake_count)
     while (did_wake_count < wake_count) {
         // Try to get a set of idle CPUs and flip them to busy
         u32 idle_mask = s_idle_cpu_mask.load(AK::MemoryOrder::memory_order_relaxed) & ~(1u << current_id);
-        u32 idle_count = __builtin_popcountl(idle_mask);
+        u32 idle_count = count_ones(idle_mask);
         if (idle_count == 0)
             break; // No (more) idle processor available
 
@@ -775,7 +776,7 @@ u32 Processor::smp_wake_n_idle_processors(u32 wake_count)
         idle_mask = s_idle_cpu_mask.fetch_and(~found_mask, AK::MemoryOrder::memory_order_acq_rel) & found_mask;
         if (idle_mask == 0)
             continue; // All of them were flipped to busy, try again
-        idle_count = __builtin_popcountl(idle_mask);
+        idle_count = count_ones(idle_mask);
         for (u32 i = 0; i < idle_count; i++) {
             u32 cpu = __builtin_ffsl(idle_mask) - 1;
             idle_mask &= ~(1u << cpu);

--- a/Kernel/Memory/PhysicalRegion.cpp
+++ b/Kernel/Memory/PhysicalRegion.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CountTrailingZeros.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefPtr.h>
 #include <Kernel/Assertions.h>
@@ -80,7 +81,7 @@ OwnPtr<PhysicalRegion> PhysicalRegion::try_take_pages_from_beginning(unsigned pa
 NonnullRefPtrVector<PhysicalPage> PhysicalRegion::take_contiguous_free_pages(size_t count)
 {
     auto rounded_page_count = next_power_of_two(count);
-    auto order = __builtin_ctz(rounded_page_count);
+    auto order = count_trailing_zeros(rounded_page_count);
 
     Optional<PhysicalAddress> page_base;
     for (auto& zone : m_usable_zones) {

--- a/Kernel/Memory/PhysicalZone.cpp
+++ b/Kernel/Memory/PhysicalZone.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CountTrailingZeros.h>
 #include <AK/Format.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/PhysicalPage.h>
@@ -31,7 +32,7 @@ PhysicalZone::PhysicalZone(PhysicalAddress base_address, size_t page_count)
             bucket.bitmap.grow(bitmap_size_for_order, false);
     }
 
-    auto first_order = __builtin_ctz(page_count);
+    auto first_order = count_trailing_zeros(page_count);
     size_t block_size = 2u << first_order;
     auto& bucket = m_buckets[first_order];
     size_t remaining_chunk_count = chunk_count;

--- a/Tests/AK/TestCountLeadingZeros.cpp
+++ b/Tests/AK/TestCountLeadingZeros.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/CountLeadingZeros.h>
+
+TEST_CASE(CountTrailingZeros)
+{
+    {
+        static_assert(count_leading_zeros<u8>(0) == 8);
+        EXPECT_EQ(count_leading_zeros<u8>(0), 8u);
+
+        static_assert(count_leading_zeros<u8>(1) == 7);
+        EXPECT_EQ(count_leading_zeros<u8>(1), 7u);
+
+        static_assert(count_leading_zeros<u8>(1 << 7) == 0);
+        EXPECT_EQ(count_leading_zeros<u8>(1 << 7), 0u);
+    }
+
+    {
+        static_assert(count_leading_zeros<u16>(0) == 16);
+        EXPECT_EQ(count_leading_zeros<u16>(0), 16u);
+
+        static_assert(count_leading_zeros<u16>(1) == 15);
+        EXPECT_EQ(count_leading_zeros<u16>(1), 15u);
+
+        static_assert(count_leading_zeros<u16>(1 << 15) == 0);
+        EXPECT_EQ(count_leading_zeros<u16>(1 << 15), 0u);
+    }
+
+    {
+        static_assert(count_leading_zeros<u32>(0) == 32);
+        EXPECT_EQ(count_leading_zeros<u32>(0), 32u);
+
+        static_assert(count_leading_zeros<u32>(1) == 31);
+        EXPECT_EQ(count_leading_zeros<u32>(1), 31u);
+
+        static_assert(count_leading_zeros<u32>(u32(1) << 31) == 0);
+        EXPECT_EQ(count_leading_zeros<u32>(u32(1) << 31), 0u);
+    }
+
+    {
+        static_assert(count_leading_zeros<u64>(0) == 64);
+        EXPECT_EQ(count_leading_zeros<u64>(0), 64u);
+
+        static_assert(count_leading_zeros<u64>(1) == 63);
+        EXPECT_EQ(count_leading_zeros<u64>(1), 63u);
+
+        static_assert(count_leading_zeros<u64>(u64(1) << 63) == 0);
+        EXPECT_EQ(count_leading_zeros<u64>(u64(1) << 63), 0u);
+    }
+}

--- a/Tests/AK/TestCountOnes.cpp
+++ b/Tests/AK/TestCountOnes.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/CountOnes.h>
+
+TEST_CASE(CountTrailingZeros)
+{
+    {
+        static_assert(count_ones<u8>(0) == 0);
+        EXPECT_EQ(count_ones<u8>(0), 0u);
+
+        static_assert(count_ones<u8>(1) == 1);
+        EXPECT_EQ(count_ones<u8>(1), 1u);
+
+        static_assert(count_ones<u8>(1 << 7) == 1);
+        EXPECT_EQ(count_ones<u8>(1 << 7), 1u);
+    }
+
+    {
+        static_assert(count_ones<u16>(0) == 0);
+        EXPECT_EQ(count_ones<u16>(0), 0u);
+
+        static_assert(count_ones<u16>(1) == 1);
+        EXPECT_EQ(count_ones<u16>(1), 1u);
+
+        static_assert(count_ones<u16>(1 << 15) == 1);
+        EXPECT_EQ(count_ones<u16>(1 << 15), 1u);
+    }
+
+    {
+        static_assert(count_ones<u32>(0) == 0);
+        EXPECT_EQ(count_ones<u32>(0), 0u);
+
+        static_assert(count_ones<u32>(1) == 1);
+        EXPECT_EQ(count_ones<u32>(1), 1u);
+
+        static_assert(count_ones<u32>(u32(1) << 31) == 1);
+        EXPECT_EQ(count_ones<u32>(u32(1) << 31), 1u);
+    }
+
+    {
+        static_assert(count_ones<u64>(0) == 0);
+        EXPECT_EQ(count_ones<u64>(0), 0u);
+
+        static_assert(count_ones<u64>(1) == 1);
+        EXPECT_EQ(count_ones<u64>(1), 1u);
+
+        static_assert(count_ones<u64>(u64(1) << 63) == 1);
+        EXPECT_EQ(count_ones<u64>(u64(1) << 63), 1u);
+    }
+}

--- a/Tests/AK/TestCountTrailingZeros.cpp
+++ b/Tests/AK/TestCountTrailingZeros.cpp
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/CountTrailingZeros.h>
+
+TEST_CASE(CountTrailingZeros)
+{
+    {
+        static_assert(count_trailing_zeros<u8>(0) == 8);
+        EXPECT_EQ(count_trailing_zeros<u8>(0), 8u);
+
+        static_assert(count_trailing_zeros<u8>(1) == 0);
+        EXPECT_EQ(count_trailing_zeros<u8>(1), 0u);
+
+        static_assert(count_trailing_zeros<u8>(1 << 7) == 7);
+        EXPECT_EQ(count_trailing_zeros<u8>(1 << 7), 7u);
+    }
+
+    {
+        static_assert(count_trailing_zeros<u16>(0) == 16);
+        EXPECT_EQ(count_trailing_zeros<u16>(0), 16u);
+
+        static_assert(count_trailing_zeros<u16>(1) == 0);
+        EXPECT_EQ(count_trailing_zeros<u16>(1), 0u);
+
+        static_assert(count_trailing_zeros<u16>(1 << 15) == 15);
+        EXPECT_EQ(count_trailing_zeros<u16>(1 << 15), 15u);
+    }
+
+    {
+        static_assert(count_trailing_zeros<u32>(0) == 32);
+        EXPECT_EQ(count_trailing_zeros<u32>(0), 32u);
+
+        static_assert(count_trailing_zeros<u32>(1) == 0);
+        EXPECT_EQ(count_trailing_zeros<u32>(1), 0u);
+
+        static_assert(count_trailing_zeros<u32>(u32(1) << 31) == 31);
+        EXPECT_EQ(count_trailing_zeros<u32>(u32(1) << 31), 31u);
+    }
+
+    {
+        static_assert(count_trailing_zeros<u64>(0) == 64);
+        EXPECT_EQ(count_trailing_zeros<u64>(0), 64u);
+
+        static_assert(count_trailing_zeros<u64>(1) == 0);
+        EXPECT_EQ(count_trailing_zeros<u64>(1), 0u);
+
+        static_assert(count_trailing_zeros<u64>(u64(1) << 63) == 63);
+        EXPECT_EQ(count_trailing_zeros<u64>(u64(1) << 63), 63u);
+    }
+}

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -8,6 +8,7 @@
 #include "SoftCPU.h"
 #include "Emulator.h"
 #include <AK/Assertions.h>
+#include <AK/CountTrailingZeros.h>
 #include <AK/Debug.h>
 #include <stdio.h>
 #include <string.h>
@@ -978,7 +979,7 @@ void SoftCPU::BOUND(const X86::Instruction&) { TODO_INSN(); }
 template<typename T>
 ALWAYS_INLINE static T op_bsf(SoftCPU&, T value)
 {
-    return { (typename T::ValueType)__builtin_ctz(value.value()), value.shadow() };
+    return { (typename T::ValueType)count_trailing_zeros(value.value()), value.shadow() };
 }
 
 template<typename T>

--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CountOnes.h>
 #include <AK/Debug.h>
 #include <AK/ScopedValueRollback.h>
 #include <AK/Vector.h>
@@ -437,7 +438,7 @@ void* malloc(size_t size)
 // _aligned_free(), so it can be easily implemented on top of malloc().
 void* _aligned_malloc(size_t size, size_t alignment)
 {
-    if (__builtin_popcount(alignment) != 1) {
+    if (count_ones(alignment) != 1) {
         errno = EINVAL;
         return nullptr;
     }

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CountTrailingZeros.h>
 #include <AK/Debug.h>
 #include <AK/Function.h>
 #include <AK/String.h>
@@ -326,9 +327,9 @@ static void populate_dib_mask_info_if_needed(BMPLoadingContext& context)
             mask_sizes.append(0);
             continue;
         }
-        int trailing_zeros = count_trailing_zeroes_32(mask);
+        int trailing_zeros = count_trailing_zeros(mask);
         // If mask is exactly `0xFFFFFFFF`, then we might try to count the trailing zeros of 0x00000000 here, so we need the safe version:
-        int size = count_trailing_zeroes_32_safe(~(mask >> trailing_zeros));
+        int size = count_trailing_zeros(~(mask >> trailing_zeros));
         if (size > 8) {
             // Drop lowest bits if mask is longer than 8 bits.
             trailing_zeros += size - 8;

--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -6,6 +6,7 @@
 
 #include "BitmapFont.h"
 #include "Emoji.h"
+#include <AK/CountOnes.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
 #include <LibCore/FileStream.h>
@@ -95,7 +96,7 @@ NonnullRefPtr<BitmapFont> BitmapFont::masked_character_set() const
     }
     size_t new_glyph_count { 0 };
     for (size_t i = 0; i < new_range_mask_size; ++i) {
-        new_glyph_count += 256 * __builtin_popcount(new_range_mask[i]);
+        new_glyph_count += 256 * count_ones(new_range_mask[i]);
     }
     size_t bytes_per_glyph = sizeof(u32) * m_glyph_height;
     auto* new_rows = static_cast<u8*>(calloc(new_glyph_count, bytes_per_glyph));
@@ -191,7 +192,7 @@ RefPtr<BitmapFont> BitmapFont::load_from_memory(const u8* data)
     size_t glyph_count { 0 };
     u8* range_mask = const_cast<u8*>(data + sizeof(FontFileHeader));
     for (size_t i = 0; i < header.range_mask_size; ++i)
-        glyph_count += 256 * __builtin_popcount(range_mask[i]);
+        glyph_count += 256 * count_ones(range_mask[i]);
     u8* rows = range_mask + header.range_mask_size;
     u8* widths = (u8*)(rows) + glyph_count * bytes_per_glyph;
     return adopt_ref(*new BitmapFont(String(header.name), String(header.family), rows, widths, !header.is_variable_width, header.glyph_width, header.glyph_height, header.glyph_spacing, header.range_mask_size, range_mask, header.baseline, header.mean_line, header.presentation_size, header.weight, header.slope));

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -6,6 +6,7 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/CountLeadingOnes.h>
 #include <AK/Hex.h>
 #include <AK/Platform.h>
 #include <AK/Utf8View.h>
@@ -500,7 +501,7 @@ static ThrowCompletionOr<String> decode(JS::GlobalObject& global_object, const S
             continue;
         }
 
-        auto leading_ones = count_trailing_zeroes_32_safe(~decoded_code_unit) - 24;
+        auto leading_ones = count_leading_ones(decoded_code_unit);
         if (leading_ones == 1 || leading_ones > 4)
             return global_object.vm().throw_completion<URIError>(global_object, ErrorType::URIMalformed);
 

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CountLeadingZeros.h>
 #include <AK/Function.h>
 #include <AK/Random.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -301,9 +302,7 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::sign)
 JS_DEFINE_NATIVE_FUNCTION(MathObject::clz32)
 {
     auto number = TRY(vm.argument(0).to_u32(global_object));
-    if (number == 0)
-        return Value(32);
-    return Value(__builtin_clz(number));
+    return Value(count_leading_zeros(number));
 }
 
 // 21.3.2.2 Math.acos ( x ), https://tc39.es/ecma262/#sec-math.acos

--- a/Userland/Libraries/LibM/math.cpp
+++ b/Userland/Libraries/LibM/math.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CountLeadingZeros.h>
 #include <AK/ExtraMathConstants.h>
 #include <AK/Math.h>
 #include <AK/Platform.h>
@@ -278,7 +279,7 @@ static FloatT internal_scalbn(FloatT x, int exponent) NOEXCEPT
         return extractor.d;
     }
 
-    unsigned leading_mantissa_zeroes = extractor.mantissa == 0 ? 32 : __builtin_clz(extractor.mantissa);
+    unsigned leading_mantissa_zeroes = count_leading_zeros(extractor.mantissa);
     int shift = min((int)leading_mantissa_zeroes, exponent);
     exponent = max(exponent - shift, 0);
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -8,6 +8,7 @@
 
 #include <AK/BitCast.h>
 #include <AK/CountOnes.h>
+#include <AK/CountTrailingZeros.h>
 #include <AK/Result.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
@@ -191,15 +192,7 @@ struct CountTrailingZeros {
     template<typename Lhs>
     i32 operator()(Lhs lhs) const
     {
-        if (lhs == 0)
-            return sizeof(Lhs) * CHAR_BIT;
-
-        if constexpr (sizeof(Lhs) == 4)
-            return __builtin_ctz(lhs);
-        else if constexpr (sizeof(Lhs) == 8)
-            return __builtin_ctzll(lhs);
-        else
-            VERIFY_NOT_REACHED();
+        return count_trailing_zeros(lhs);
     }
 
     static StringView name() { return "ctz"; }

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/BitCast.h>
+#include <AK/CountOnes.h>
 #include <AK/Result.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
@@ -207,12 +208,7 @@ struct PopCount {
     template<typename Lhs>
     auto operator()(Lhs lhs) const
     {
-        if constexpr (sizeof(Lhs) == 4)
-            return __builtin_popcount(lhs);
-        else if constexpr (sizeof(Lhs) == 8)
-            return __builtin_popcountll(lhs);
-        else
-            VERIFY_NOT_REACHED();
+        return count_ones(lhs);
     }
 
     static StringView name() { return "popcnt"; }


### PR DESCRIPTION
In an effort to reduce the usage of compiler intrinsic in the code, move their usage to a single place.