### PR TITLE
Everywhere: Add <Kernel/API/Device.h> to hold `serenity_dev_{makedev,major,minor}`

### DIFF
--- a/Kernel/API/Device.h
+++ b/Kernel/API/Device.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+#include <sys/cdefs.h>
+#include <sys/types.h>
+
+__BEGIN_DECLS
+
+ALWAYS_INLINE dev_t serenity_dev_makedev(unsigned major, unsigned minor)
+{
+    return (minor & 0xffu) | (major << 8u) | ((minor & ~0xffu) << 12u);
+}
+
+ALWAYS_INLINE unsigned int serenity_dev_major(dev_t dev)
+{
+    return (dev & 0xfff00u) >> 8u;
+}
+
+ALWAYS_INLINE unsigned int serenity_dev_minor(dev_t dev)
+{
+    return (dev & 0xffu) | ((dev >> 12u) & 0xfff00u);
+}
+
+__END_DECLS

--- a/Kernel/API/POSIX/sys/types.h
+++ b/Kernel/API/POSIX/sys/types.h
@@ -92,10 +92,6 @@ typedef struct __pthread_condattr_t {
     int clockid; // clockid_t
 } pthread_condattr_t;
 
-static inline dev_t makedev(unsigned major, unsigned minor) { return (minor & 0xffu) | (major << 8u) | ((minor & ~0xffu) << 12u); }
-static inline unsigned int major(dev_t dev) { return (dev & 0xfff00u) >> 8u; }
-static inline unsigned int minor(dev_t dev) { return (dev & 0xffu) | ((dev >> 12u) & 0xfff00u); }
-
 #ifdef __cplusplus
 }
 #endif

--- a/Userland/Libraries/LibC/sys/sysmacros.h
+++ b/Userland/Libraries/LibC/sys/sysmacros.h
@@ -5,3 +5,9 @@
  */
 
 #pragma once
+
+#include <Kernel/API/Device.h>
+
+#define makedev(major, minor) serenity_dev_makedev((major), (minor))
+#define major(dev) serenity_dev_major(dev)
+#define minor(dev) serenity_dev_minor(dev)

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -23,6 +23,7 @@
 #include <signal.h>
 #include <stdio.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -117,11 +118,6 @@ static void chown_all_matching_device_nodes(group* group, unsigned major_number)
     }
 }
 
-constexpr unsigned encoded_device(unsigned major, unsigned minor)
-{
-    return (minor & 0xff) | (major << 8) | ((minor & ~0xff) << 12);
-}
-
 inline char offset_character_with_number(char base_char, u8 offset)
 {
     char offsetted_char = base_char;
@@ -132,7 +128,7 @@ inline char offset_character_with_number(char base_char, u8 offset)
 
 static void create_devfs_block_device(String name, mode_t mode, unsigned major, unsigned minor)
 {
-    if (auto rc = mknod(name.characters(), mode | S_IFBLK, encoded_device(major, minor)); rc < 0)
+    if (auto rc = mknod(name.characters(), mode | S_IFBLK, makedev(major, minor)); rc < 0)
         VERIFY_NOT_REACHED();
 }
 
@@ -170,7 +166,7 @@ static void populate_devfs_block_devices()
 
 static void create_devfs_char_device(String name, mode_t mode, unsigned major, unsigned minor)
 {
-    if (auto rc = mknod(name.characters(), mode | S_IFCHR, encoded_device(major, minor)); rc < 0)
+    if (auto rc = mknod(name.characters(), mode | S_IFCHR, makedev(major, minor)); rc < 0)
         VERIFY_NOT_REACHED();
 }
 

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -30,6 +30,7 @@
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <time.h>
 #include <unistd.h>

--- a/Userland/Utilities/mknod.cpp
+++ b/Userland/Utilities/mknod.cpp
@@ -8,12 +8,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <sys/sysmacros.h>
 #include <unistd.h>
-
-constexpr unsigned encoded_device(unsigned major, unsigned minor)
-{
-    return (minor & 0xff) | (major << 8) | ((minor & ~0xff) << 12);
-}
 
 static int usage()
 {
@@ -63,7 +59,7 @@ int main(int argc, char** argv)
         minor = atoi(argv[4]);
     }
 
-    int rc = mknod(name, mode, encoded_device(major, minor));
+    int rc = mknod(name, mode, makedev(major, minor));
     if (rc < 0) {
         perror("mknod");
         return 1;

--- a/Userland/Utilities/stat.cpp
+++ b/Userland/Utilities/stat.cpp
@@ -12,6 +12,7 @@
 #include <LibMain/Main.h>
 #include <grp.h>
 #include <pwd.h>
+#include <sys/sysmacros.h>
 #include <time.h>
 
 static ErrorOr<int> stat(StringView file, bool should_follow_links)


### PR DESCRIPTION
Use these to provides `{makedev,major,minor}` in <sys/sysmacros.h> and be more compliant according to documentation, and  void duplicates in the wild.