### PR TITLE
LibUnicode: Reduce libunicode.so size by unique-ifying UnicodeLocale and UnicodeDateTimeFormat

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
@@ -130,20 +130,6 @@ struct AK::Traits<NumberFormat> : public GenericTraits<NumberFormat> {
 };
 
 using NumberFormatList = Vector<NumberFormatIndexType>;
-
-template<>
-struct AK::Traits<NumberFormatList> : public GenericTraits<NumberFormatList> {
-    static unsigned hash(NumberFormatList const& formats)
-    {
-        auto hash = int_hash(static_cast<u32>(formats.size()));
-
-        for (auto format : formats)
-            hash = pair_int_hash(hash, format);
-
-        return hash;
-    }
-};
-
 using NumericSymbolList = Vector<StringIndexType>;
 
 struct NumberSystem {

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -155,6 +155,13 @@ struct CalendarFormat {
     CalendarPattern short_format {};
 };
 
+enum class CalendarSymbol : u8 {
+    DayPeriod,
+    Era,
+    Month,
+    Weekday,
+};
+
 HourCycle hour_cycle_from_string(StringView hour_cycle);
 StringView hour_cycle_to_string(HourCycle hour_cycle);
 CalendarPatternStyle calendar_pattern_style_from_string(StringView style);


### PR DESCRIPTION
Continuation of #11210, applying the same techniques on GenerateUnicodeLocale and GenerateUnicodeDateTimeFormat.

The number of commits kinda got away from me a bit here, but I wanted to be sure GenerateUnicodeDateTimeFormat was minimized as much as possible. This file will grow as more calendars are added (we only generate Gregorian currently), so any savings there should scale linearly with additional  calendars.

Overall, this reduces:
* libunicode.so size from 12 MB to 9.2 MB on x86
* The generated UnicodeLocale.cpp from 6.3 MB to 2.9 MB (41,944 lines to 5,090 lines)
* The generated UnicodeDateTimeFormat.cpp from 8.0 MB to 5.3 MB (20,064 lines to 7,761 lines)