### PR TITLE
Horizontal scroll support

### DIFF
--- a/Kernel/API/MousePacket.h
+++ b/Kernel/API/MousePacket.h
@@ -12,6 +12,7 @@ struct MousePacket {
     int x { 0 };
     int y { 0 };
     int z { 0 };
+    int w { 0 };
 
     enum Button {
         LeftButton = 0x01,

--- a/Kernel/Devices/HID/MouseDevice.cpp
+++ b/Kernel/Devices/HID/MouseDevice.cpp
@@ -35,7 +35,7 @@ ErrorOr<size_t> MouseDevice::read(OpenFileDescription&, u64, UserOrKernelBuffer&
         lock.unlock();
 
         dbgln_if(MOUSE_DEBUG, "Mouse Read: Buttons {:x}", packet.buttons);
-        dbgln_if(MOUSE_DEBUG, "PS2 Mouse: X {}, Y {}, Z {}, Relative {}", packet.x, packet.y, packet.z, packet.buttons);
+        dbgln_if(MOUSE_DEBUG, "PS2 Mouse: X {}, Y {}, Z {}, W {}, Relative {}", packet.x, packet.y, packet.z, packet.w, packet.buttons);
         dbgln_if(MOUSE_DEBUG, "PS2 Mouse Read: Filter packets");
 
         size_t bytes_read_from_packet = min(remaining_space_in_buffer, sizeof(MousePacket));

--- a/Kernel/Devices/HID/PS2MouseDevice.cpp
+++ b/Kernel/Devices/HID/PS2MouseDevice.cpp
@@ -89,6 +89,7 @@ MousePacket PS2MouseDevice::parse_data_packet(const RawPacket& raw_packet)
     int x = raw_packet.bytes[1];
     int y = raw_packet.bytes[2];
     int z = 0;
+    int w = 0;
     if (m_has_wheel) {
         // FIXME: For non-Intellimouse, this is a full byte.
         //        However, for now, m_has_wheel is only set for Intellimouse.
@@ -97,6 +98,14 @@ MousePacket PS2MouseDevice::parse_data_packet(const RawPacket& raw_packet)
         // -1 in 4 bits
         if (z == 15)
             z = -1;
+
+        if ((raw_packet.bytes[3] & 0xc0) == 0x40) {
+            // FIXME: Scroll only functions correctly when the sign is flipped there
+            w = -z;
+            z = 0;
+        } else {
+            w = 0;
+        }
     }
     bool x_overflow = raw_packet.bytes[0] & 0x40;
     bool y_overflow = raw_packet.bytes[0] & 0x80;
@@ -114,6 +123,7 @@ MousePacket PS2MouseDevice::parse_data_packet(const RawPacket& raw_packet)
     packet.x = x;
     packet.y = y;
     packet.z = z;
+    packet.w = w;
     packet.buttons = raw_packet.bytes[0] & 0x07;
 
     if (m_has_five_buttons) {
@@ -125,7 +135,7 @@ MousePacket PS2MouseDevice::parse_data_packet(const RawPacket& raw_packet)
 
     packet.is_relative = true;
     dbgln_if(PS2MOUSE_DEBUG, "PS2 Relative Mouse: Buttons {:x}", packet.buttons);
-    dbgln_if(PS2MOUSE_DEBUG, "Mouse: X {}, Y {}, Z {}", packet.x, packet.y, packet.z);
+    dbgln_if(PS2MOUSE_DEBUG, "Mouse: X {}, Y {}, Z {}, W {}", packet.x, packet.y, packet.z, packet.w);
     return packet;
 }
 

--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -211,16 +211,28 @@ MousePacket VMWareBackdoor::receive_mouse_packet()
     int x = command.bx;
     int y = command.cx;
     int z = static_cast<i8>(command.dx); // signed 8 bit value only!
+    int w = 0;
+
+    // horizontal scroll is reported as +-2 by qemu
+    // FIXME: Scroll only functions correctly when the sign is flipped there
+    if (z == 2) {
+        w = -1;
+        z = 0;
+    } else if (z == -2) {
+        w = 1;
+        z = 0;
+    }
 
     if constexpr (PS2MOUSE_DEBUG) {
         dbgln("Absolute Mouse: Buttons {:x}", buttons);
-        dbgln("Mouse: x={}, y={}, z={}", x, y, z);
+        dbgln("Mouse: x={}, y={}, z={}, w={}", x, y, z, w);
     }
 
     MousePacket packet;
     packet.x = x;
     packet.y = y;
     packet.z = z;
+    packet.w = w;
     if (buttons & VMMOUSE_LEFT_CLICK)
         packet.buttons |= MousePacket::LeftButton;
     if (buttons & VMMOUSE_RIGHT_CLICK)

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -214,6 +214,7 @@ if [ -z "$SERENITY_ETHERNET_DEVICE_TYPE" ]; then
   SERENITY_ETHERNET_DEVICE_TYPE="e1000"
 fi
 
+# add -machine vmport=off below to run the machine with ps/2 mouse
 if [ -z "$SERENITY_MACHINE" ]; then
     if [ "$SERENITY_ARCH" = "aarch64" ]; then
         SERENITY_MACHINE="-M raspi3b -serial stdio"

--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
@@ -76,7 +76,7 @@ public:
 
         auto vcols = desktop.workspace_columns();
         auto vrows = desktop.workspace_rows();
-        auto direction = event.wheel_delta() < 0 ? 1 : -1;
+        auto direction = event.wheel_delta_y() < 0 ? 1 : -1;
 
         if (event.modifiers() & Mod_Shift)
             col = abs((int)col + direction) % vcols;

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -156,7 +156,7 @@ void GLContextWidget::mousemove_event(GUI::MouseEvent& event)
 
 void GLContextWidget::mousewheel_event(GUI::MouseEvent& event)
 {
-    if (event.wheel_delta() > 0)
+    if (event.wheel_delta_y() > 0)
         m_zoom /= 1.1f;
     else
         m_zoom *= 1.1f;

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -75,7 +75,7 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
     if (!m_document)
         return;
 
-    bool scrolled_down = event.wheel_delta() > 0;
+    bool scrolled_down = event.wheel_delta_y() > 0;
 
     if (event.ctrl()) {
         if (scrolled_down) {

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -239,7 +239,12 @@ void RollWidget::mouseup_event([[maybe_unused]] GUI::MouseEvent& event)
 void RollWidget::mousewheel_event(GUI::MouseEvent& event)
 {
     if (event.modifiers() & KeyModifier::Mod_Shift) {
-        horizontal_scrollbar().increase_slider_by(event.wheel_delta() * horizontal_scroll_sensitivity);
+        horizontal_scrollbar().increase_slider_by(event.wheel_delta_y() * horizontal_scroll_sensitivity);
+        return;
+    }
+
+    if (event.wheel_delta_x() != 0) {
+        horizontal_scrollbar().increase_slider_by(event.wheel_delta_x() * horizontal_scroll_sensitivity);
         return;
     }
 
@@ -248,7 +253,7 @@ void RollWidget::mousewheel_event(GUI::MouseEvent& event)
         return;
     }
 
-    double multiplier = event.wheel_delta() >= 0 ? 0.5 : 2;
+    double multiplier = event.wheel_delta_y() >= 0 ? 0.5 : 2;
 
     if (m_zoom_level * multiplier > max_zoom)
         return;

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -257,7 +257,8 @@ GUI::MouseEvent ImageEditor::event_with_pan_and_scale_applied(GUI::MouseEvent co
         event.buttons(),
         event.button(),
         event.modifiers(),
-        event.wheel_delta()
+        event.wheel_delta_x(),
+        event.wheel_delta_y(),
     };
 }
 
@@ -271,7 +272,8 @@ GUI::MouseEvent ImageEditor::event_adjusted_for_layer(GUI::MouseEvent const& eve
         event.buttons(),
         event.button(),
         event.modifiers(),
-        event.wheel_delta()
+        event.wheel_delta_x(),
+        event.wheel_delta_y(),
     };
 }
 

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -316,8 +316,8 @@ void TreeMapWidget::doubleclick_event(GUI::MouseEvent& event)
 
 void TreeMapWidget::mousewheel_event(GUI::MouseEvent& event)
 {
-    int delta = event.wheel_delta();
-    // FIXME: The wheel_delta is premultiplied in the window server, we actually want a raw value here.
+    int delta = event.wheel_delta_y();
+    // FIXME: The wheel_delta_y is premultiplied in the window server, we actually want a raw value here.
     int step_size = GUI::WindowServerConnection::the().get_scroll_step_size();
     if (delta > 0) {
         size_t step_back = delta / step_size;

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -350,7 +350,7 @@ void Mandelbrot::mouseup_event(GUI::MouseEvent& event)
 
 void Mandelbrot::mousewheel_event(GUI::MouseEvent& event)
 {
-    zoom(event.wheel_delta() < 0 ? Zoom::In : Zoom::Out, event.position());
+    zoom(event.wheel_delta_y() < 0 ? Zoom::In : Zoom::Out, event.position());
 }
 
 void Mandelbrot::resize_event(GUI::ResizeEvent& event)

--- a/Userland/Demos/Mouse/main.cpp
+++ b/Userland/Demos/Mouse/main.cpp
@@ -138,7 +138,7 @@ public:
 
     void mousewheel_event(GUI::MouseEvent& event) override
     {
-        m_wheel_delta_acc = (m_wheel_delta_acc + event.wheel_delta() + 36) % 36;
+        m_wheel_delta_acc = (m_wheel_delta_acc + event.wheel_delta_y() + 36) % 36;
         m_show_scroll_wheel = true;
         update();
         if (!has_timer())

--- a/Userland/DevTools/Profiler/TimelineView.cpp
+++ b/Userland/DevTools/Profiler/TimelineView.cpp
@@ -67,7 +67,7 @@ void TimelineView::mousewheel_event(GUI::MouseEvent& event)
 {
     if (event.modifiers() == Mod_Ctrl) {
         event.accept();
-        m_scale += event.wheel_delta();
+        m_scale += event.wheel_delta_y();
         m_scale = clamp(m_scale, 1.0f, 100.0f);
         for_each_child_of_type<TimelineTrack>([&](auto& track) {
             track.set_scale(m_scale);

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -47,11 +47,26 @@ void AbstractScrollableWidget::handle_wheel_event(MouseEvent& event, Widget& eve
         event.ignore();
         return;
     }
-    // FIXME: The wheel delta multiplier should probably come from... somewhere?
+
+    int wheel_delta_x { 0 };
+    bool vertical_scroll_hijacked { false };
+
     if (event.shift() || &event_source == m_horizontal_scrollbar.ptr()) {
-        horizontal_scrollbar().increase_slider_by(event.wheel_delta() * 60);
-    } else {
-        vertical_scrollbar().increase_slider_by(event.wheel_delta() * 20);
+        wheel_delta_x = event.wheel_delta_y();
+        vertical_scroll_hijacked = true;
+    }
+
+    if (event.wheel_delta_x() != 0) {
+        wheel_delta_x = event.wheel_delta_x();
+    }
+
+    if (wheel_delta_x != 0) {
+        // FIXME: The wheel delta multiplier should probably come from... somewhere?
+        horizontal_scrollbar().increase_slider_by(wheel_delta_x * 60);
+    }
+
+    if (!vertical_scroll_hijacked && event.wheel_delta_y() != 0) {
+        vertical_scrollbar().increase_slider_by(event.wheel_delta_y() * 20);
     }
 }
 
@@ -283,5 +298,4 @@ Gfx::IntPoint AbstractScrollableWidget::to_widget_position(const Gfx::IntPoint& 
     widget_position.translate_by(frame_thickness(), frame_thickness());
     return widget_position;
 }
-
 }

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
@@ -111,7 +111,7 @@ Gfx::FloatRect AbstractZoomPanWidget::content_to_frame_rect(Gfx::IntRect const& 
 
 void AbstractZoomPanWidget::mousewheel_event(GUI::MouseEvent& event)
 {
-    float new_scale = scale() / AK::exp2(event.wheel_delta() / wheel_zoom_factor);
+    float new_scale = scale() / AK::exp2(event.wheel_delta_y() / wheel_zoom_factor);
     scale_centered(new_scale, event.position());
 }
 

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -36,7 +36,7 @@ private:
         if (!is_focused())
             set_focus(true);
         if (on_mousewheel)
-            on_mousewheel(event.wheel_delta());
+            on_mousewheel(event.wheel_delta_y());
     }
 
     virtual void keydown_event(KeyEvent& event) override

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -370,13 +370,14 @@ private:
 
 class MouseEvent final : public Event {
 public:
-    MouseEvent(Type type, const Gfx::IntPoint& position, unsigned buttons, MouseButton button, unsigned modifiers, int wheel_delta)
+    MouseEvent(Type type, const Gfx::IntPoint& position, unsigned buttons, MouseButton button, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)
         : Event(type)
         , m_position(position)
         , m_buttons(buttons)
         , m_button(button)
         , m_modifiers(modifiers)
-        , m_wheel_delta(wheel_delta)
+        , m_wheel_delta_x(wheel_delta_x)
+        , m_wheel_delta_y(wheel_delta_y)
     {
     }
 
@@ -390,14 +391,16 @@ public:
     bool shift() const { return m_modifiers & Mod_Shift; }
     bool super() const { return m_modifiers & Mod_Super; }
     unsigned modifiers() const { return m_modifiers; }
-    int wheel_delta() const { return m_wheel_delta; }
+    int wheel_delta_x() const { return m_wheel_delta_x; }
+    int wheel_delta_y() const { return m_wheel_delta_y; }
 
 private:
     Gfx::IntPoint m_position;
     unsigned m_buttons { 0 };
     MouseButton m_button { MouseButton::None };
     unsigned m_modifiers { 0 };
-    int m_wheel_delta { 0 };
+    int m_wheel_delta_x { 0 };
+    int m_wheel_delta_y { 0 };
 };
 
 class DragEvent final : public Event {

--- a/Userland/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Userland/Libraries/LibGUI/OpacitySlider.cpp
@@ -139,7 +139,7 @@ void OpacitySlider::mouseup_event(MouseEvent& event)
 
 void OpacitySlider::mousewheel_event(MouseEvent& event)
 {
-    decrease_slider_by(event.wheel_delta());
+    decrease_slider_by(event.wheel_delta_y());
 }
 
 }

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -299,7 +299,7 @@ void Scrollbar::mousewheel_event(MouseEvent& event)
 {
     if (!is_scrollable())
         return;
-    increase_slider_by_steps(event.wheel_delta());
+    increase_slider_by_steps(event.wheel_delta_y());
     Widget::mousewheel_event(event);
 }
 

--- a/Userland/Libraries/LibGUI/Slider.cpp
+++ b/Userland/Libraries/LibGUI/Slider.cpp
@@ -139,7 +139,7 @@ void Slider::mouseup_event(MouseEvent& event)
 void Slider::mousewheel_event(MouseEvent& event)
 {
     auto acceleration_modifier = step();
-    auto wheel_delta = event.wheel_delta();
+    auto wheel_delta = event.wheel_delta_y();
 
     if (event.modifiers() == KeyModifier::Mod_Ctrl)
         acceleration_modifier *= 6;

--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -87,7 +87,7 @@ void SpinBox::set_range(int min, int max, AllowCallback allow_callback)
 
 void SpinBox::mousewheel_event(MouseEvent& event)
 {
-    auto wheel_delta = event.wheel_delta() / abs(event.wheel_delta());
+    auto wheel_delta = event.wheel_delta_y() / abs(event.wheel_delta_y());
     if (event.modifiers() == KeyModifier::Mod_Ctrl)
         wheel_delta *= 6;
     set_value(m_value - wheel_delta);

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -162,7 +162,7 @@ void ValueSlider::leave_event(Core::Event&)
 
 void ValueSlider::mousewheel_event(MouseEvent& event)
 {
-    if (event.wheel_delta() < 0)
+    if (event.wheel_delta_y() < 0)
         increase_slider_by(1);
     else
         decrease_slider_by(1);

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -366,7 +366,7 @@ void Window::handle_mouse_event(MouseEvent& event)
     if (m_automatic_cursor_tracking_widget) {
         auto window_relative_rect = m_automatic_cursor_tracking_widget->window_relative_rect();
         Gfx::IntPoint local_point { event.x() - window_relative_rect.x(), event.y() - window_relative_rect.y() };
-        auto local_event = MouseEvent((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
+        auto local_event = MouseEvent((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
         m_automatic_cursor_tracking_widget->dispatch_event(local_event, this);
         if (event.buttons() == 0)
             m_automatic_cursor_tracking_widget = nullptr;
@@ -375,7 +375,7 @@ void Window::handle_mouse_event(MouseEvent& event)
     if (!m_main_widget)
         return;
     auto result = m_main_widget->hit_test(event.position());
-    auto local_event = MouseEvent((Event::Type)event.type(), result.local_position, event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
+    auto local_event = MouseEvent((Event::Type)event.type(), result.local_position, event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
     VERIFY(result.widget);
     set_hovered_widget(result.widget);
     if (event.buttons() != 0 && !m_automatic_cursor_tracking_widget)

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -228,38 +228,38 @@ static MouseButton to_mouse_button(u32 button)
     }
 }
 
-void WindowServerConnection::mouse_down(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta)
+void WindowServerConnection::mouse_down(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
 {
     if (auto* window = Window::from_window_id(window_id))
-        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDown, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDown, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
 }
 
-void WindowServerConnection::mouse_up(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta)
+void WindowServerConnection::mouse_up(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
 {
     if (auto* window = Window::from_window_id(window_id))
-        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseUp, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseUp, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
 }
 
-void WindowServerConnection::mouse_move(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta, bool is_drag, Vector<String> const& mime_types)
+void WindowServerConnection::mouse_move(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, bool is_drag, Vector<String> const& mime_types)
 {
     if (auto* window = Window::from_window_id(window_id)) {
         if (is_drag)
             Core::EventLoop::current().post_event(*window, make<DragEvent>(Event::DragMove, mouse_position, mime_types));
         else
-            Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseMove, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta));
+            Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseMove, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
     }
 }
 
-void WindowServerConnection::mouse_double_click(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta)
+void WindowServerConnection::mouse_double_click(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
 {
     if (auto* window = Window::from_window_id(window_id))
-        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDoubleClick, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDoubleClick, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
 }
 
-void WindowServerConnection::mouse_wheel(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta)
+void WindowServerConnection::mouse_wheel(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
 {
     if (auto* window = Window::from_window_id(window_id))
-        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseWheel, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseWheel, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
 }
 
 void WindowServerConnection::menu_visibility_did_change(i32 menu_id, bool visible)

--- a/Userland/Libraries/LibGUI/WindowServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.h
@@ -26,11 +26,11 @@ private:
 
     virtual void fast_greet(Vector<Gfx::IntRect> const&, u32, u32, u32, Core::AnonymousBuffer const&, String const&, String const&, i32) override;
     virtual void paint(i32, Gfx::IntSize const&, Vector<Gfx::IntRect> const&) override;
-    virtual void mouse_move(i32, Gfx::IntPoint const&, u32, u32, u32, i32, bool, Vector<String> const&) override;
-    virtual void mouse_down(i32, Gfx::IntPoint const&, u32, u32, u32, i32) override;
-    virtual void mouse_double_click(i32, Gfx::IntPoint const&, u32, u32, u32, i32) override;
-    virtual void mouse_up(i32, Gfx::IntPoint const&, u32, u32, u32, i32) override;
-    virtual void mouse_wheel(i32, Gfx::IntPoint const&, u32, u32, u32, i32) override;
+    virtual void mouse_move(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32, bool, Vector<String> const&) override;
+    virtual void mouse_down(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32) override;
+    virtual void mouse_double_click(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32) override;
+    virtual void mouse_up(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32) override;
+    virtual void mouse_wheel(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32) override;
     virtual void window_entered(i32) override;
     virtual void window_left(i32) override;
     virtual void key_down(i32, u32, u32, u32, u32) override;

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -918,7 +918,7 @@ void TerminalWidget::mousewheel_event(GUI::MouseEvent& event)
     if (!is_scrollable())
         return;
     set_auto_scroll_direction(AutoScrollDirection::None);
-    m_scrollbar->increase_slider_by(event.wheel_delta() * scroll_length());
+    m_scrollbar->increase_slider_by(event.wheel_delta_y() * scroll_length());
     GUI::Frame::mousewheel_event(event);
 }
 

--- a/Userland/Libraries/LibWeb/InProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/InProcessWebView.cpp
@@ -237,7 +237,7 @@ void InProcessWebView::mouseup_event(GUI::MouseEvent& event)
 
 void InProcessWebView::mousewheel_event(GUI::MouseEvent& event)
 {
-    page().handle_mousewheel(to_content_position(event.position()), event.button(), event.modifiers(), event.wheel_delta());
+    page().handle_mousewheel(to_content_position(event.position()), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
     GUI::AbstractScrollableWidget::mousewheel_event(event);
 }
 

--- a/Userland/Libraries/LibWeb/Layout/BlockContainer.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockContainer.cpp
@@ -136,12 +136,12 @@ void BlockContainer::set_scroll_offset(const Gfx::FloatPoint& offset)
     set_needs_display();
 }
 
-bool BlockContainer::handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned int, unsigned int, int wheel_delta)
+bool BlockContainer::handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned int, unsigned int, int wheel_delta_x, int wheel_delta_y)
 {
     if (!is_scrollable())
         return false;
     auto new_offset = m_scroll_offset;
-    new_offset.translate_by(0, wheel_delta);
+    new_offset.translate_by(wheel_delta_x, wheel_delta_y);
     set_scroll_offset(new_offset);
 
     return true;

--- a/Userland/Libraries/LibWeb/Layout/BlockContainer.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockContainer.h
@@ -50,7 +50,7 @@ protected:
 private:
     virtual bool is_block_container() const final { return true; }
     virtual bool wants_mouse_events() const override { return false; }
-    virtual bool handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers, int wheel_delta) override;
+    virtual bool handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y) override;
 
     bool should_clip_overflow() const;
 

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -504,13 +504,13 @@ void Node::handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned,
 {
 }
 
-bool Node::handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned, unsigned, int wheel_delta)
+bool Node::handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned, unsigned, int wheel_delta_x, int wheel_delta_y)
 {
     if (auto* containing_block = this->containing_block()) {
         if (!containing_block->is_scrollable())
             return false;
         auto new_offset = containing_block->scroll_offset();
-        new_offset.translate_by(0, wheel_delta);
+        new_offset.translate_by(wheel_delta_x, wheel_delta_y);
         containing_block->set_scroll_offset(new_offset);
         return true;
     }

--- a/Userland/Libraries/LibWeb/Layout/Node.h
+++ b/Userland/Libraries/LibWeb/Layout/Node.h
@@ -89,7 +89,7 @@ public:
     virtual void handle_mousedown(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers);
     virtual void handle_mouseup(Badge<EventHandler>, const Gfx::IntPoint&, unsigned button, unsigned modifiers);
     virtual void handle_mousemove(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers);
-    virtual bool handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers, int wheel_delta);
+    virtual bool handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
 
     virtual void before_children_paint(PaintContext&, PaintPhase) {};
     virtual void paint(PaintContext&, PaintPhase) = 0;

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -183,7 +183,7 @@ void OutOfProcessWebView::mousemove_event(GUI::MouseEvent& event)
 
 void OutOfProcessWebView::mousewheel_event(GUI::MouseEvent& event)
 {
-    client().async_mouse_wheel(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers(), event.wheel_delta());
+    client().async_mouse_wheel(to_content_position(event.position()), event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
 }
 
 void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -112,7 +112,7 @@ Layout::InitialContainingBlock* EventHandler::layout_root()
     return m_frame.active_document()->layout_node();
 }
 
-bool EventHandler::handle_mousewheel(const Gfx::IntPoint& position, unsigned int buttons, unsigned int modifiers, int wheel_delta)
+bool EventHandler::handle_mousewheel(const Gfx::IntPoint& position, unsigned int buttons, unsigned int modifiers, int wheel_delta_x, int wheel_delta_y)
 {
     if (!layout_root())
         return false;
@@ -121,12 +121,12 @@ bool EventHandler::handle_mousewheel(const Gfx::IntPoint& position, unsigned int
 
     auto result = layout_root()->hit_test(position, Layout::HitTestType::Exact);
     if (result.layout_node) {
-        if (result.layout_node->handle_mousewheel({}, position, buttons, modifiers, wheel_delta))
+        if (result.layout_node->handle_mousewheel({}, position, buttons, modifiers, wheel_delta_x, wheel_delta_y))
             return true;
     }
 
     if (auto* page = m_frame.page()) {
-        page->client().page_did_request_scroll(0, wheel_delta * 20);
+        page->client().page_did_request_scroll(wheel_delta_x * 20, wheel_delta_y * 20);
         return true;
     }
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.h
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.h
@@ -25,7 +25,7 @@ public:
     bool handle_mouseup(const Gfx::IntPoint&, unsigned button, unsigned modifiers);
     bool handle_mousedown(const Gfx::IntPoint&, unsigned button, unsigned modifiers);
     bool handle_mousemove(const Gfx::IntPoint&, unsigned buttons, unsigned modifiers);
-    bool handle_mousewheel(const Gfx::IntPoint&, unsigned buttons, unsigned modifiers, int wheel_delta);
+    bool handle_mousewheel(const Gfx::IntPoint&, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);

--- a/Userland/Libraries/LibWeb/Page/Page.cpp
+++ b/Userland/Libraries/LibWeb/Page/Page.cpp
@@ -61,9 +61,9 @@ CSS::PreferredColorScheme Page::preferred_color_scheme() const
     return m_client.preferred_color_scheme();
 }
 
-bool Page::handle_mousewheel(const Gfx::IntPoint& position, unsigned button, unsigned modifiers, int wheel_delta)
+bool Page::handle_mousewheel(const Gfx::IntPoint& position, unsigned button, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)
 {
-    return top_level_browsing_context().event_handler().handle_mousewheel(position, button, modifiers, wheel_delta);
+    return top_level_browsing_context().event_handler().handle_mousewheel(position, button, modifiers, wheel_delta_x, wheel_delta_y);
 }
 
 bool Page::handle_mouseup(const Gfx::IntPoint& position, unsigned button, unsigned modifiers)

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -50,7 +50,7 @@ public:
     bool handle_mouseup(const Gfx::IntPoint&, unsigned button, unsigned modifiers);
     bool handle_mousedown(const Gfx::IntPoint&, unsigned button, unsigned modifiers);
     bool handle_mousemove(const Gfx::IntPoint&, unsigned buttons, unsigned modifiers);
-    bool handle_mousewheel(const Gfx::IntPoint&, unsigned button, unsigned modifiers, int wheel_delta);
+    bool handle_mousewheel(const Gfx::IntPoint&, unsigned button, unsigned modifiers, int wheel_delta_x, int wheel_delta_y);
 
     bool handle_keydown(KeyCode, unsigned modifiers, u32 code_point);
     bool handle_keyup(KeyCode, unsigned modifiers, u32 code_point);

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -211,7 +211,7 @@ void TaskbarWindow::event(Core::Event& event)
 
         if (adjusted_point != mouse_event.position()) {
             GUI::WindowServerConnection::the().async_set_global_cursor_position(position() + adjusted_point);
-            GUI::MouseEvent adjusted_event = { (GUI::Event::Type)mouse_event.type(), adjusted_point, mouse_event.buttons(), mouse_event.button(), mouse_event.modifiers(), mouse_event.wheel_delta() };
+            GUI::MouseEvent adjusted_event = { (GUI::Event::Type)mouse_event.type(), adjusted_point, mouse_event.buttons(), mouse_event.button(), mouse_event.modifiers(), mouse_event.wheel_delta_x(), mouse_event.wheel_delta_y() };
             Window::event(adjusted_event);
             return;
         }

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -154,9 +154,9 @@ void ClientConnection::mouse_up(const Gfx::IntPoint& position, unsigned int butt
     page().handle_mouseup(position, button, modifiers);
 }
 
-void ClientConnection::mouse_wheel(const Gfx::IntPoint& position, unsigned int button, [[maybe_unused]] unsigned int buttons, unsigned int modifiers, i32 wheel_delta)
+void ClientConnection::mouse_wheel(const Gfx::IntPoint& position, unsigned int button, [[maybe_unused]] unsigned int buttons, unsigned int modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
 {
-    page().handle_mousewheel(position, button, modifiers, wheel_delta);
+    page().handle_mousewheel(position, button, modifiers, wheel_delta_x, wheel_delta_y);
 }
 
 void ClientConnection::key_down(i32 key, unsigned int modifiers, u32 code_point)

--- a/Userland/Services/WebContent/ClientConnection.h
+++ b/Userland/Services/WebContent/ClientConnection.h
@@ -47,7 +47,7 @@ private:
     virtual void mouse_down(Gfx::IntPoint const&, unsigned, unsigned, unsigned) override;
     virtual void mouse_move(Gfx::IntPoint const&, unsigned, unsigned, unsigned) override;
     virtual void mouse_up(Gfx::IntPoint const&, unsigned, unsigned, unsigned) override;
-    virtual void mouse_wheel(Gfx::IntPoint const&, unsigned, unsigned, unsigned, i32) override;
+    virtual void mouse_wheel(Gfx::IntPoint const&, unsigned, unsigned, unsigned, i32, i32) override;
     virtual void key_down(i32, unsigned, u32) override;
     virtual void key_up(i32, unsigned, u32) override;
     virtual void add_backing_store(i32, Gfx::ShareableBitmap const&) override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -21,7 +21,7 @@ endpoint WebContentServer
     mouse_down(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
     mouse_move(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
     mouse_up(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers) =|
-    mouse_wheel(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers, i32 wheel_delta) =|
+    mouse_wheel(Gfx::IntPoint position, unsigned button, unsigned buttons, unsigned modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
 
     key_down(i32 key, unsigned modifiers, u32 code_point) =|
     key_up(i32 key, unsigned modifiers, u32 code_point) =|

--- a/Userland/Services/WindowServer/Event.h
+++ b/Userland/Services/WindowServer/Event.h
@@ -88,13 +88,14 @@ private:
 
 class MouseEvent final : public Event {
 public:
-    MouseEvent(Type type, const Gfx::IntPoint& position, unsigned buttons, MouseButton button, unsigned modifiers, int wheel_delta = 0)
+    MouseEvent(Type type, const Gfx::IntPoint& position, unsigned buttons, MouseButton button, unsigned modifiers, int wheel_delta_x = 0, int wheel_delta_y = 0)
         : Event(type)
         , m_position(position)
         , m_buttons(buttons)
         , m_button(button)
         , m_modifiers(modifiers)
-        , m_wheel_delta(wheel_delta)
+        , m_wheel_delta_x(wheel_delta_x)
+        , m_wheel_delta_y(wheel_delta_y)
     {
     }
 
@@ -104,7 +105,8 @@ public:
     MouseButton button() const { return m_button; }
     unsigned buttons() const { return m_buttons; }
     unsigned modifiers() const { return m_modifiers; }
-    int wheel_delta() const { return m_wheel_delta; }
+    int wheel_delta_x() const { return m_wheel_delta_x; }
+    int wheel_delta_y() const { return m_wheel_delta_y; }
     bool is_drag() const { return m_drag; }
 
     Vector<String> mime_types() const
@@ -129,7 +131,8 @@ private:
     unsigned m_buttons { 0 };
     MouseButton m_button { MouseButton::None };
     unsigned m_modifiers { 0 };
-    int m_wheel_delta { 0 };
+    int m_wheel_delta_x { 0 };
+    int m_wheel_delta_y { 0 };
     bool m_drag { false };
     RefPtr<const Core::MimeData> m_mime_data;
 };

--- a/Userland/Services/WindowServer/EventLoop.cpp
+++ b/Userland/Services/WindowServer/EventLoop.cpp
@@ -64,7 +64,7 @@ void EventLoop::drain_mouse()
     bool state_is_sent = false;
     for (size_t i = 0; i < npackets; ++i) {
         auto& packet = packets[i];
-        dbgln_if(WSMESSAGELOOP_DEBUG, "EventLoop: Mouse X {}, Y {}, Z {}, relative={}", packet.x, packet.y, packet.z, packet.is_relative);
+        dbgln_if(WSMESSAGELOOP_DEBUG, "EventLoop: Mouse X {}, Y {}, Z {}, W {}, relative={}", packet.x, packet.y, packet.z, packet.w, packet.is_relative);
 
         state.is_relative = packet.is_relative;
         if (packet.is_relative) {
@@ -75,6 +75,7 @@ void EventLoop::drain_mouse()
             state.y = packet.y;
         }
         state.z += packet.z;
+        state.w += packet.w;
         state_is_sent = false;
 
         if (packet.buttons != state.buttons) {
@@ -100,12 +101,13 @@ void EventLoop::drain_mouse()
                 state.x = 0;
                 state.y = 0;
                 state.z = 0;
+                state.w = 0;
             }
         }
     }
     if (state_is_sent)
         return;
-    if (state.is_relative && (state.x || state.y || state.z))
+    if (state.is_relative && (state.x || state.y || state.z || state.w))
         screen_input.on_receive_mouse_data(state);
     if (!state.is_relative)
         screen_input.on_receive_mouse_data(state);

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -393,7 +393,7 @@ void Menu::event(Core::Event& event)
         VERIFY(menu_window());
         auto& mouse_event = static_cast<const MouseEvent&>(event);
         auto previous_scroll_offset = m_scroll_offset;
-        m_scroll_offset += mouse_event.wheel_delta();
+        m_scroll_offset += mouse_event.wheel_delta_y();
         m_scroll_offset = clamp(m_scroll_offset, 0, m_max_scroll_offset);
         if (m_scroll_offset != previous_scroll_offset)
             redraw();

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -461,8 +461,8 @@ void ScreenInput::on_receive_mouse_data(const MousePacket& packet)
         Core::EventLoop::current().post_event(WindowManager::the(), move(message));
     }
 
-    if (packet.z) {
-        auto message = make<MouseEvent>(Event::MouseWheel, m_cursor_location, buttons, MouseButton::None, m_modifiers, packet.z * m_scroll_step_size);
+    if (packet.z || packet.w) {
+        auto message = make<MouseEvent>(Event::MouseWheel, m_cursor_location, buttons, MouseButton::None, m_modifiers, packet.w * m_scroll_step_size, packet.z * m_scroll_step_size);
         Core::EventLoop::current().post_event(WindowManager::the(), move(message));
     }
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -264,19 +264,19 @@ void Window::handle_mouse_event(const MouseEvent& event)
 
     switch (event.type()) {
     case Event::MouseMove:
-        m_client->async_mouse_move(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta(), event.is_drag(), event.mime_types());
+        m_client->async_mouse_move(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.is_drag(), event.mime_types());
         break;
     case Event::MouseDown:
-        m_client->async_mouse_down(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta());
+        m_client->async_mouse_down(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
         break;
     case Event::MouseDoubleClick:
-        m_client->async_mouse_double_click(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta());
+        m_client->async_mouse_double_click(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
         break;
     case Event::MouseUp:
-        m_client->async_mouse_up(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta());
+        m_client->async_mouse_up(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
         break;
     case Event::MouseWheel:
-        m_client->async_mouse_wheel(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta());
+        m_client->async_mouse_wheel(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -6,11 +6,11 @@ endpoint WindowClient
     fast_greet(Vector<Gfx::IntRect> screen_rects, u32 main_screen_index, u32 workspace_rows, u32 workspace_columns, Core::AnonymousBuffer theme_buffer, String default_font_query, String fixed_width_font_query, i32 client_id) =|
 
     paint(i32 window_id, Gfx::IntSize window_size, Vector<Gfx::IntRect> rects) =|
-    mouse_move(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta, bool is_drag, Vector<String> mime_types) =|
-    mouse_down(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta) =|
-    mouse_double_click(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta) =|
-    mouse_up(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta) =|
-    mouse_wheel(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta) =|
+    mouse_move(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, bool is_drag, Vector<String> mime_types) =|
+    mouse_down(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
+    mouse_double_click(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
+    mouse_up(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
+    mouse_wheel(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
     window_entered(i32 window_id) =|
     window_left(i32 window_id) =|
     window_input_entered(i32 window_id) =|

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1099,7 +1099,7 @@ void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& ev
     } else {
         dbgln_if(DOUBLECLICK_DEBUG, "Transforming MouseUp to MouseDoubleClick ({} < {})!", metadata.clock.elapsed(), m_double_click_speed);
 
-        event = MouseEvent(Event::MouseDoubleClick, event.position(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta());
+        event = MouseEvent(Event::MouseDoubleClick, event.position(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
         // invalidate this now we've delivered a doubleclick, otherwise
         // tripleclick will deliver two doubleclick events (incorrectly).
         metadata.clock = {};


### PR DESCRIPTION
This pull request adds support for horizontal mouse scroll in serenity.  I'm not sure if that's the best or the most correct implementation, but it works.

Information on horizontal scroll for ps/2 mice: https://wiki.osdev.org/Mouse_Input#Formats_of_Optional_4th_Packet_Byte

In order to implement the support I had to hack qemu too since it also doesn't support horizontal scroll.

The branch with changes: https://gitlab.com/can3p/qemu/-/commits/mouse-horizontal-scroll

The way I ended up implementing it looks hackish to me (not sure where `0x3f` from `b = (dw1 & 0x3f) | 0x40;
` comes from. Anyway, it seems to be working for ubuntu vm which I used as a reference.

This pr works in bth gtk and sdl display modes, with and without vmware hack.

I haven't pushed submitted the patch to qemu project yet, planning to do that after testing the cocoa related code in the patch.

Limitation of this pr and qemu patch: scroll is only possible in one direction (horizontal or vertical) whereas ubuntu system which I take as a reference allows to scroll the window in combination of both if necessary