### PR TITLE
LibUnicode: Compile generated sources optimized for size

### DIFF
--- a/Userland/Libraries/LibUnicode/CMakeLists.txt
+++ b/Userland/Libraries/LibUnicode/CMakeLists.txt
@@ -1,7 +1,13 @@
 include(${SerenityOS_SOURCE_DIR}/Meta/CMake/unicode_data.cmake)
 
-SET(SOURCES
-    ${UNICODE_DATA_SOURCES}
+if (DEFINED UNICODE_DATA_SOURCES)
+    set(SOURCES ${UNICODE_DATA_SOURCES})
+    serenity_lib(LibUnicodeData unicodedata)
+    target_compile_options(LibUnicodeData PRIVATE -g0 -Os)
+    target_link_libraries(LibUnicodeData LibCore)
+endif()
+
+set(SOURCES
     CharacterTypes.cpp
     CurrencyCode.cpp
     DateTimeFormat.cpp
@@ -12,3 +18,7 @@ SET(SOURCES
 serenity_lib(LibUnicode unicode)
 target_link_libraries(LibUnicode LibCore)
 target_compile_definitions(LibUnicode PRIVATE ENABLE_UNICODE_DATA=$<BOOL:${ENABLE_UNICODE_DATABASE_DOWNLOAD}>)
+
+if (DEFINED UNICODE_DATA_SOURCES)
+    target_link_libraries(LibUnicode LibUnicodeData)
+endif()


### PR DESCRIPTION
This moves the generated Unicode data files into their own pseudo-private library, LibUnicodeData.so, to be optimized for size. This reduces the size of the library from 9.2MB to 8.2MB (~0.9MB of that is from the size optimizations).

I'm not sure if this is "the CMake way" of doing this. I think we could alternatively define LibUnicodeData.so as an object library rather than a shared library. But I'm thinking this way will also allow us to do some `dlopen` tricks to defer actually loading the large shared library until it's actually wanted.