### PR TITLE
LibLine: Take the prompt into account when adjusting for a scrolled view

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -628,6 +628,7 @@ void Editor::handle_resize_event(bool reset_origin)
 
     reposition_cursor(stderr_stream, true);
     m_suggestion_display->redisplay(m_suggestion_manager, m_num_lines, m_num_columns);
+    m_origin_row = m_suggestion_display->origin_row();
     reposition_cursor(stderr_stream);
 
     if (m_is_searching)

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -1121,17 +1121,15 @@ void Editor::handle_read_event()
                 break;
             }
 
-            if (m_times_tab_pressed > 1) {
-                if (m_suggestion_manager.count() > 0) {
-                    if (m_suggestion_display->cleanup())
-                        reposition_cursor(stderr_stream);
+            if (m_times_tab_pressed > 1 && m_suggestion_manager.count() > 0) {
+                if (m_suggestion_display->cleanup())
+                    reposition_cursor(stderr_stream);
 
-                    m_suggestion_display->set_initial_prompt_lines(m_prompt_lines_at_suggestion_initiation);
+                m_suggestion_display->set_initial_prompt_lines(m_prompt_lines_at_suggestion_initiation);
 
-                    m_suggestion_display->display(m_suggestion_manager);
+                m_suggestion_display->display(m_suggestion_manager);
 
-                    m_origin_row = m_suggestion_display->origin_row();
-                }
+                m_origin_row = m_suggestion_display->origin_row();
             }
 
             if (m_times_tab_pressed > 2) {

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -227,7 +227,7 @@ void Editor::get_terminal_size()
     }
 }
 
-void Editor::add_to_history(const String& line)
+void Editor::add_to_history(String const& line)
 {
     if (line.is_empty())
         return;
@@ -246,7 +246,7 @@ void Editor::add_to_history(const String& line)
     m_history_dirty = true;
 }
 
-bool Editor::load_history(const String& path)
+bool Editor::load_history(String const& path)
 {
     auto history_file = Core::File::construct(path);
     if (!history_file->open(Core::OpenMode::ReadOnly))
@@ -263,7 +263,7 @@ bool Editor::load_history(const String& path)
 }
 
 template<typename It0, typename It1, typename OutputT, typename MapperT, typename LessThan>
-static void merge(It0&& begin0, const It0& end0, It1&& begin1, const It1& end1, OutputT& output, MapperT left_mapper, LessThan less_than)
+static void merge(It0&& begin0, It0 const& end0, It1&& begin1, It1 const& end1, OutputT& output, MapperT left_mapper, LessThan less_than)
 {
     for (;;) {
         if (begin0 == end0 && begin1 == end1)
@@ -304,7 +304,7 @@ static void merge(It0&& begin0, const It0& end0, It1&& begin1, const It1& end1, 
     }
 }
 
-bool Editor::save_history(const String& path)
+bool Editor::save_history(String const& path)
 {
     Vector<HistoryEntry> final_history { { "", 0 } };
     {
@@ -320,7 +320,7 @@ bool Editor::save_history(const String& path)
                 auto string = str.substring_view(it == 0 ? it : it + 2);
                 return HistoryEntry { string, time };
             },
-            [](const HistoryEntry& left, const HistoryEntry& right) { return left.timestamp < right.timestamp; });
+            [](HistoryEntry const& left, HistoryEntry const& right) { return left.timestamp < right.timestamp; });
     }
 
     auto file_or_error = Core::File::open(path, Core::OpenMode::WriteOnly, 0600);
@@ -328,7 +328,7 @@ bool Editor::save_history(const String& path)
         return false;
     auto file = file_or_error.release_value();
     final_history.take_first();
-    for (const auto& entry : final_history)
+    for (auto const& entry : final_history)
         file->write(String::formatted("{}::{}\n\n", entry.timestamp, entry.entry));
 
     m_history_dirty = false;
@@ -347,13 +347,13 @@ void Editor::clear_line()
     m_inline_search_cursor = m_cursor;
 }
 
-void Editor::insert(const Utf32View& string)
+void Editor::insert(Utf32View const& string)
 {
     for (size_t i = 0; i < string.length(); ++i)
         insert(string.code_points()[i]);
 }
 
-void Editor::insert(const String& string)
+void Editor::insert(String const& string)
 {
     for (auto ch : Utf8View { string })
         insert(ch);
@@ -388,7 +388,7 @@ void Editor::insert(const u32 cp)
     m_inline_search_cursor = m_cursor;
 }
 
-void Editor::register_key_input_callback(const KeyBinding& binding)
+void Editor::register_key_input_callback(KeyBinding const& binding)
 {
     if (binding.kind == KeyBinding::Kind::InternalFunction) {
         auto internal_function = find_internal_function(binding.binding);
@@ -456,7 +456,7 @@ Editor::CodepointRange Editor::byte_offset_range_to_code_point_offset_range(size
     return range;
 }
 
-void Editor::stylize(const Span& span, const Style& style)
+void Editor::stylize(Span const& span, Style const& style)
 {
     if (style.is_empty())
         return;
@@ -657,7 +657,7 @@ void Editor::really_quit_event_loop()
     Core::EventLoop::current().quit(Exit);
 }
 
-auto Editor::get_line(const String& prompt) -> Result<String, Editor::Error>
+auto Editor::get_line(String const& prompt) -> Result<String, Editor::Error>
 {
     initialize();
     m_is_editing = true;
@@ -1575,7 +1575,7 @@ String Style::Hyperlink::to_vt_escape(bool starting) const
     return String::formatted("\e]8;;{}\e\\", starting ? m_link : String::empty());
 }
 
-void Style::unify_with(const Style& other, bool prefer_other)
+void Style::unify_with(Style const& other, bool prefer_other)
 {
     // Unify colors.
     if (prefer_other || m_background.is_default())
@@ -1641,7 +1641,7 @@ String Style::to_string() const
     return builder.build();
 }
 
-void VT::apply_style(const Style& style, OutputStream& stream, bool is_starting)
+void VT::apply_style(Style const& style, OutputStream& stream, bool is_starting)
 {
     if (is_starting) {
         stream.write(String::formatted("\033[{};{};{}m{}{}{}",
@@ -1713,7 +1713,7 @@ StringMetrics Editor::actual_rendered_string_metrics(StringView string)
     return metrics;
 }
 
-StringMetrics Editor::actual_rendered_string_metrics(const Utf32View& view)
+StringMetrics Editor::actual_rendered_string_metrics(Utf32View const& view)
 {
     StringMetrics metrics;
     StringMetrics::LineMetrics current_line;
@@ -1998,7 +1998,7 @@ void Editor::readjust_anchored_styles(size_t hint_index, ModificationKind modifi
     }
 }
 
-size_t StringMetrics::lines_with_addition(const StringMetrics& offset, size_t column_width) const
+size_t StringMetrics::lines_with_addition(StringMetrics const& offset, size_t column_width) const
 {
     size_t lines = 0;
 
@@ -2015,7 +2015,7 @@ size_t StringMetrics::lines_with_addition(const StringMetrics& offset, size_t co
     return lines;
 }
 
-size_t StringMetrics::offset_with_addition(const StringMetrics& offset, size_t column_width) const
+size_t StringMetrics::offset_with_addition(StringMetrics const& offset, size_t column_width) const
 {
     if (offset.line_metrics.size() > 1)
         return offset.line_metrics.last().total_length() % column_width;
@@ -2025,7 +2025,7 @@ size_t StringMetrics::offset_with_addition(const StringMetrics& offset, size_t c
     return last % column_width;
 }
 
-bool Editor::Spans::contains_up_to_offset(const Spans& other, size_t offset) const
+bool Editor::Spans::contains_up_to_offset(Spans const& other, size_t offset) const
 {
     auto compare = [&]<typename K, typename V>(const HashMap<K, HashMap<K, V>>& left, const HashMap<K, HashMap<K, V>>& right) -> bool {
         for (auto& entry : right) {

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -83,7 +83,7 @@ struct Configuration {
     void set(RefreshBehavior refresh) { refresh_behavior = refresh; }
     void set(OperationMode mode) { operation_mode = mode; }
     void set(SignalHandler mode) { m_signal_mode = mode; }
-    void set(const KeyBinding& binding) { keybindings.append(binding); }
+    void set(KeyBinding const& binding) { keybindings.append(binding); }
     void set(DefaultTextEditor editor) { m_default_text_editor = move(editor.command); }
     void set(Flags flags)
     {
@@ -143,26 +143,26 @@ public:
 
     ~Editor();
 
-    Result<String, Error> get_line(const String& prompt);
+    Result<String, Error> get_line(String const& prompt);
 
     void initialize();
 
     void refetch_default_termios();
 
-    void add_to_history(const String& line);
-    bool load_history(const String& path);
-    bool save_history(const String& path);
-    const auto& history() const { return m_history; }
+    void add_to_history(String const& line);
+    bool load_history(String const& path);
+    bool save_history(String const& path);
+    auto const& history() const { return m_history; }
     bool is_history_dirty() const { return m_history_dirty; }
 
-    void register_key_input_callback(const KeyBinding&);
+    void register_key_input_callback(KeyBinding const&);
     void register_key_input_callback(Vector<Key> keys, Function<bool(Editor&)> callback) { m_callback_machine.register_key_input_callback(move(keys), move(callback)); }
     void register_key_input_callback(Key key, Function<bool(Editor&)> callback) { register_key_input_callback(Vector<Key> { key }, move(callback)); }
 
     static StringMetrics actual_rendered_string_metrics(StringView);
-    static StringMetrics actual_rendered_string_metrics(const Utf32View&);
+    static StringMetrics actual_rendered_string_metrics(Utf32View const&);
 
-    Function<Vector<CompletionSuggestion>(const Editor&)> on_tab_complete;
+    Function<Vector<CompletionSuggestion>(Editor const&)> on_tab_complete;
     Function<void()> on_interrupt_handled;
     Function<void(Editor&)> on_display_refresh;
 
@@ -196,7 +196,7 @@ public:
     String line(size_t up_to_index) const;
 
     // Only makes sense inside a character_input callback or on_* callback.
-    void set_prompt(const String& prompt)
+    void set_prompt(String const& prompt)
     {
         if (m_cached_prompt_valid)
             m_old_prompt_metrics = m_cached_prompt_metrics;
@@ -206,11 +206,11 @@ public:
     }
 
     void clear_line();
-    void insert(const String&);
+    void insert(String const&);
     void insert(StringView);
-    void insert(const Utf32View&);
+    void insert(Utf32View const&);
     void insert(const u32);
-    void stylize(const Span&, const Style&);
+    void stylize(Span const&, Style const&);
     void strip_styles(bool strip_anchored = false);
 
     // Invariant Offset is an offset into the suggested data, hinting the editor what parts of the suggestion will not change
@@ -332,7 +332,7 @@ private:
             Core::EventLoop::unregister_signal(id);
     }
 
-    const StringMetrics& current_prompt_metrics() const
+    StringMetrics const& current_prompt_metrics() const
     {
         return m_cached_prompt_valid ? m_cached_prompt_metrics : m_old_prompt_metrics;
     }
@@ -486,7 +486,7 @@ private:
         HashMap<u32, HashMap<u32, Style>> m_anchored_spans_starting;
         HashMap<u32, HashMap<u32, Style>> m_anchored_spans_ending;
 
-        bool contains_up_to_offset(const Spans& other, size_t offset) const;
+        bool contains_up_to_offset(Spans const& other, size_t offset) const;
     } m_drawn_spans, m_current_spans;
 
     RefPtr<Core::Notifier> m_notifier;

--- a/Userland/Libraries/LibLine/KeyCallbackMachine.h
+++ b/Userland/Libraries/LibLine/KeyCallbackMachine.h
@@ -34,12 +34,12 @@ struct Key {
     {
     }
 
-    bool operator==(const Key& other) const
+    bool operator==(Key const& other) const
     {
         return other.key == key && other.modifiers == modifiers;
     }
 
-    bool operator!=(const Key& other) const
+    bool operator!=(Key const& other) const
     {
         return !(*this == other);
     }

--- a/Userland/Libraries/LibLine/StringMetrics.h
+++ b/Userland/Libraries/LibLine/StringMetrics.h
@@ -38,8 +38,8 @@ struct StringMetrics {
     size_t total_length { 0 };
     size_t max_line_length { 0 };
 
-    size_t lines_with_addition(const StringMetrics& offset, size_t column_width) const;
-    size_t offset_with_addition(const StringMetrics& offset, size_t column_width) const;
+    size_t lines_with_addition(StringMetrics const& offset, size_t column_width) const;
+    size_t offset_with_addition(StringMetrics const& offset, size_t column_width) const;
     void reset()
     {
         line_metrics.clear();

--- a/Userland/Libraries/LibLine/Style.h
+++ b/Userland/Libraries/LibLine/Style.h
@@ -15,7 +15,7 @@ namespace Line {
 
 class Style {
 public:
-    bool operator==(const Style&) const = default;
+    bool operator==(Style const&) const = default;
 
     enum class XtermColor : int {
         Default = 9,
@@ -39,7 +39,7 @@ public:
     struct ItalicTag {
     };
     struct Color {
-        bool operator==(const Color&) const = default;
+        bool operator==(Color const&) const = default;
 
         explicit Color(XtermColor color)
             : m_xterm_color(color)
@@ -88,7 +88,7 @@ public:
     };
 
     struct Hyperlink {
-        bool operator==(const Hyperlink&) const = default;
+        bool operator==(Hyperlink const&) const = default;
 
         explicit Hyperlink(StringView link)
             : m_link(link)
@@ -113,7 +113,7 @@ public:
 
     // Prepare for the horror of templates.
     template<typename T, typename... Rest>
-    Style(const T& style_arg, Rest... rest)
+    Style(T const& style_arg, Rest... rest)
         : Style(rest...)
     {
         set(style_arg);
@@ -126,14 +126,14 @@ public:
         return { Foreground(XtermColor::Default), Background(XtermColor::Default), Hyperlink("") };
     }
 
-    Style unified_with(const Style& other, bool prefer_other = true) const
+    Style unified_with(Style const& other, bool prefer_other = true) const
     {
         Style style = *this;
         style.unify_with(other, prefer_other);
         return style;
     }
 
-    void unify_with(const Style&, bool prefer_other = false);
+    void unify_with(Style const&, bool prefer_other = false);
 
     bool underline() const { return m_underline; }
     bool bold() const { return m_bold; }
@@ -142,13 +142,13 @@ public:
     Foreground foreground() const { return m_foreground; }
     Hyperlink hyperlink() const { return m_hyperlink; }
 
-    void set(const ItalicTag&) { m_italic = true; }
-    void set(const BoldTag&) { m_bold = true; }
-    void set(const UnderlineTag&) { m_underline = true; }
-    void set(const Background& bg) { m_background = bg; }
-    void set(const Foreground& fg) { m_foreground = fg; }
-    void set(const Hyperlink& link) { m_hyperlink = link; }
-    void set(const AnchoredTag&) { m_is_anchored = true; }
+    void set(ItalicTag const&) { m_italic = true; }
+    void set(BoldTag const&) { m_bold = true; }
+    void set(UnderlineTag const&) { m_underline = true; }
+    void set(Background const& bg) { m_background = bg; }
+    void set(Foreground const& fg) { m_foreground = fg; }
+    void set(Hyperlink const& link) { m_hyperlink = link; }
+    void set(AnchoredTag const&) { m_is_anchored = true; }
 
     bool is_anchored() const { return m_is_anchored; }
     bool is_empty() const { return m_is_empty; }

--- a/Userland/Libraries/LibLine/SuggestionDisplay.h
+++ b/Userland/Libraries/LibLine/SuggestionDisplay.h
@@ -19,12 +19,12 @@ class Editor;
 class SuggestionDisplay {
 public:
     virtual ~SuggestionDisplay() { }
-    virtual void display(const SuggestionManager&) = 0;
+    virtual void display(SuggestionManager const&) = 0;
     virtual bool cleanup() = 0;
     virtual void finish() = 0;
     virtual void set_initial_prompt_lines(size_t) = 0;
 
-    void redisplay(const SuggestionManager& manager, size_t lines, size_t columns)
+    void redisplay(SuggestionManager const& manager, size_t lines, size_t columns)
     {
         if (m_is_showing_suggestions) {
             cleanup();
@@ -63,7 +63,7 @@ public:
     {
     }
     virtual ~XtermSuggestionDisplay() override { }
-    virtual void display(const SuggestionManager&) override;
+    virtual void display(SuggestionManager const&) override;
     virtual bool cleanup() override;
     virtual void finish() override
     {

--- a/Userland/Libraries/LibLine/SuggestionManager.cpp
+++ b/Userland/Libraries/LibLine/SuggestionManager.cpp
@@ -75,7 +75,7 @@ void SuggestionManager::previous()
     m_next_suggestion_index--;
 }
 
-const CompletionSuggestion& SuggestionManager::suggest()
+CompletionSuggestion const& SuggestionManager::suggest()
 {
     m_last_shown_suggestion = m_suggestions[m_next_suggestion_index];
     m_selected_suggestion_index = m_next_suggestion_index;
@@ -158,7 +158,7 @@ SuggestionManager::CompletionAttemptResult SuggestionManager::attempt_completion
     return result;
 }
 
-size_t SuggestionManager::for_each_suggestion(Function<IterationDecision(const CompletionSuggestion&, size_t)> callback) const
+size_t SuggestionManager::for_each_suggestion(Function<IterationDecision(CompletionSuggestion const&, size_t)> callback) const
 {
     size_t start_index { 0 };
     for (auto& suggestion : m_suggestions) {

--- a/Userland/Libraries/LibLine/SuggestionManager.h
+++ b/Userland/Libraries/LibLine/SuggestionManager.h
@@ -26,12 +26,12 @@ public:
     static constexpr ForSearchTag ForSearch {};
 
     // Intentionally not explicit. (To allow suggesting bare strings)
-    CompletionSuggestion(const String& completion)
+    CompletionSuggestion(String const& completion)
         : CompletionSuggestion(completion, "", {})
     {
     }
 
-    CompletionSuggestion(const String& completion, ForSearchTag)
+    CompletionSuggestion(String const& completion, ForSearchTag)
         : text_string(completion)
     {
     }
@@ -43,7 +43,7 @@ public:
 
     CompletionSuggestion(StringView completion, StringView trailing_trivia, Style style);
 
-    bool operator==(const CompletionSuggestion& suggestion) const
+    bool operator==(CompletionSuggestion const& suggestion) const
     {
         return suggestion.text_string == text_string;
     }
@@ -73,7 +73,7 @@ public:
     size_t next_index() const { return m_next_suggestion_index; }
     void set_start_index(size_t index) const { m_last_displayed_suggestion_index = index; }
 
-    size_t for_each_suggestion(Function<IterationDecision(const CompletionSuggestion&, size_t)>) const;
+    size_t for_each_suggestion(Function<IterationDecision(CompletionSuggestion const&, size_t)>) const;
 
     enum CompletionMode {
         DontComplete,
@@ -109,8 +109,8 @@ public:
         m_next_suggestion_invariant_offset = invariant_offset;
     }
 
-    const CompletionSuggestion& suggest();
-    const CompletionSuggestion& current_suggestion() const { return m_last_shown_suggestion; }
+    CompletionSuggestion const& suggest();
+    CompletionSuggestion const& current_suggestion() const { return m_last_shown_suggestion; }
     bool is_current_suggestion_complete() const { return m_last_shown_suggestion_was_complete; }
 
     void reset()

--- a/Userland/Libraries/LibLine/VT.h
+++ b/Userland/Libraries/LibLine/VT.h
@@ -18,7 +18,7 @@ void clear_to_end_of_line(OutputStream&);
 void clear_lines(size_t count_above, size_t count_below, OutputStream&);
 void move_relative(int x, int y, OutputStream&);
 void move_absolute(u32 x, u32 y, OutputStream&);
-void apply_style(const Style&, OutputStream&, bool is_starting = true);
+void apply_style(Style const&, OutputStream&, bool is_starting = true);
 
 }
 }

--- a/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -14,7 +14,7 @@
 
 namespace Line {
 
-void XtermSuggestionDisplay::display(const SuggestionManager& manager)
+void XtermSuggestionDisplay::display(SuggestionManager const& manager)
 {
     did_display();
 

--- a/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
+++ b/Userland/Libraries/LibLine/XtermSuggestionDisplay.cpp
@@ -126,6 +126,9 @@ void XtermSuggestionDisplay::display(const SuggestionManager& manager)
 
     m_lines_used_for_last_suggestions = lines_used;
 
+    // The last line of the prompt is the same line as the first line of the buffer, so we need to subtract one here.
+    lines_used += m_prompt_lines_at_suggestion_initiation - 1;
+
     // If we filled the screen, move back the origin.
     if (m_origin_row + lines_used >= m_num_lines) {
         m_origin_row = m_num_lines - lines_used;


### PR DESCRIPTION
Do you wish that you could strangle the person responsible for the line editor because of the following behaviour?

https://user-images.githubusercontent.com/14001776/146014476-c88e24e8-2d1c-4d58-8c1c-ce4f90fdee8a.mp4

Do you want your pretty, normal prompt to not be borked when autocompleting things?
**YOU ARE NOT ALONE**, the author of this PR also agrees with you, and so...here, have a fix.

Also fixes a random bug noticed a few weeks ago by @ccapitalK, now you can use `foo{,bar}` and expect it to work correctly!