### PR TITLE
LibC: Fixing `assert`

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -6,12 +6,16 @@
 
 #pragma once
 
-#if defined(KERNEL)
-#    include <Kernel/Assertions.h>
-#else
-#    include <assert.h>
-#    define VERIFY assert
-#    define VERIFY_NOT_REACHED() assert(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
-static constexpr bool TODO = false;
-#    define TODO() VERIFY(TODO)
-#endif
+extern "C" {
+[[noreturn]] void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func);
+}
+
+#define _VERIFY(expr, msg)                                                      \
+    do {                                                                        \
+        if (!static_cast<bool>(expr)) [[unlikely]]                              \
+            __assertion_failed((msg), __FILE__, __LINE__, __PRETTY_FUNCTION__); \
+    } while (0)
+
+#define VERIFY(expr) _VERIFY((expr), #expr)
+#define VERIFY_NOT_REACHED() _VERIFY(false, "Should not be reachable")
+#define TODO() _VERIFY(false, "TODO")

--- a/Kernel/Assertions.h
+++ b/Kernel/Assertions.h
@@ -6,27 +6,16 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/Platform.h>
 
 #define __STRINGIFY_HELPER(x) #x
 #define __STRINGIFY(x) __STRINGIFY_HELPER(x)
 
-[[noreturn]] void __assertion_failed(const char* msg, const char* file, unsigned line, const char* func);
-#define VERIFY(expr)                                                            \
-    do {                                                                        \
-        if (!static_cast<bool>(expr)) [[unlikely]]                              \
-            __assertion_failed(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__); \
-    } while (0)
-
-#define VERIFY_NOT_REACHED() VERIFY(false)
-
 extern "C" {
 [[noreturn]] void _abort();
 [[noreturn]] void abort();
 }
-
-static constexpr bool TODO = false;
-#define TODO() VERIFY(TODO)
 
 #if ARCH(I386) || ARCH(X86_64)
 #    define VERIFY_INTERRUPTS_DISABLED() VERIFY(!(cpu_flags() & 0x200))

--- a/Tests/LibC/TestAssert.cpp
+++ b/Tests/LibC/TestAssert.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <assert.h>
+
+TEST_CASE(assert_include)
+{
+    EXPECT_CRASH("This should assert", [] {
+        assert(!"This should assert");
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}

--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -16,7 +16,7 @@
 extern "C" {
 
 extern bool __stdio_is_initialized;
-#ifndef NDEBUG
+
 void __assertion_failed(const char* msg)
 {
     if (__heap_is_stable) {
@@ -32,5 +32,4 @@ void __assertion_failed(const char* msg)
     syscall(SC_set_coredump_metadata, &params);
     abort();
 }
-#endif
 }

--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -34,9 +34,3 @@ void __assertion_failed(const char* msg)
 }
 #endif
 }
-
-void _abort()
-{
-    asm volatile("ud2");
-    __builtin_unreachable();
-}

--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Assertions.h>
 #include <AK/Format.h>
 #include <assert.h>
 #include <stdio.h>

--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -17,12 +17,12 @@ extern "C" {
 
 extern bool __stdio_is_initialized;
 
-void __assertion_failed(const char* msg)
+void __assertion_failed(const char* msg, const char* file, unsigned int line, const char* function)
 {
     if (__heap_is_stable) {
-        dbgln("ASSERTION FAILED: {}", msg);
+        dbgln("ASSERTION FAILED: {}\n{}:{} in ", msg, file, line, function);
         if (__stdio_is_initialized)
-            warnln("ASSERTION FAILED: {}", msg);
+            warnln("ASSERTION FAILED: {}\n{}:{}", msg, file, line, function);
     }
 
     Syscall::SC_set_coredump_metadata_params params {

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -21,7 +21,6 @@ __attribute__((noreturn)) void __assertion_failed(const char* msg);
 
 #else
 #    define assert(expr) ((void)(0))
-#    define VERIFY_NOT_REACHED() _abort()
 #endif
 
 __attribute__((noreturn)) void _abort();

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -23,8 +23,6 @@ __attribute__((noreturn)) void __assertion_failed(const char* msg);
 #    define assert(expr) ((void)(0))
 #endif
 
-__attribute__((noreturn)) void _abort();
-
 #ifndef __cplusplus
 #    define static_assert _Static_assert
 #endif

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -11,12 +11,12 @@
 __BEGIN_DECLS
 
 #ifndef NDEBUG
-__attribute__((noreturn)) void __assertion_failed(const char* msg);
-#    define __stringify_helper(x) #    x
-#    define __stringify(x) __stringify_helper(x)
-#    define assert(expr)                                                            \
-        (__builtin_expect(!(expr), 0)                                               \
-                ? __assertion_failed(#expr "\n" __FILE__ ":" __stringify(__LINE__)) \
+
+__attribute__((noreturn)) void __assertion_failed(const char* msg, const char* file, unsigned int line, const char* function);
+
+#    define assert(expr)                                                             \
+        (__builtin_expect(!(expr), 0)                                                \
+                ? __assertion_failed(#expr, __FILE__, __LINE__, __PRETTY_FUNCTION__) \
                 : (void)0)
 
 #else

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -209,6 +209,12 @@ int atexit(void (*handler)())
     return __cxa_atexit(__atexit_to_cxa_atexit, (void*)handler, nullptr);
 }
 
+void _abort()
+{
+    asm volatile("ud2");
+    __builtin_unreachable();
+}
+
 void abort()
 {
     // For starters, send ourselves a SIGABRT.

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -16,6 +16,8 @@ __BEGIN_DECLS
 #define EXIT_FAILURE 1
 #define MB_CUR_MAX 4
 
+__attribute__((noreturn)) void _abort();
+
 __attribute__((malloc)) __attribute__((alloc_size(1))) void* malloc(size_t);
 __attribute__((malloc)) __attribute__((alloc_size(1, 2))) void* calloc(size_t nmemb, size_t);
 size_t malloc_size(void*);

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -10,8 +10,6 @@
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
-__attribute__((warn_unused_result)) int __generate_unique_filename(char* pattern);
-
 __BEGIN_DECLS
 
 #define EXIT_SUCCESS 0

--- a/Userland/Libraries/LibTest/CrashTest.cpp
+++ b/Userland/Libraries/LibTest/CrashTest.cpp
@@ -49,28 +49,39 @@ bool Crash::run(RunType run_type)
             return do_report(Failure(WEXITSTATUS(status)));
         }
         if (WIFSIGNALED(status)) {
-            outln("\x1B[32mPASS\x1B[0m: Terminated with signal {}", WTERMSIG(status));
-            return true;
+            return do_report(WTERMSIG(status));
         }
         VERIFY_NOT_REACHED();
     }
 }
 
-bool Crash::do_report(Failure failure)
+bool Crash::do_report(report_type report)
 {
-    // If we got here something went wrong
-    out("\x1B[31mFAIL\x1B[0m: ");
-    switch (failure) {
-    case Failure::DidNotCrash:
-        outln("Did not crash!");
-        break;
-    case Failure::UnexpectedError:
-        outln("Unexpected error!");
-        break;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-    return false;
+    const bool pass = report.has<int>();
+
+    if (pass)
+        out("\x1B[32mPASS\x1B[0m: ");
+    else
+        out("\x1B[31mFAIL\x1B[0m: ");
+
+    report.visit(
+        [&](const Failure& failure) {
+            switch (failure) {
+            case Failure::DidNotCrash:
+                outln("Did not crash!");
+                break;
+            case Failure::UnexpectedError:
+                outln("Unexpected error!");
+                break;
+            default:
+                VERIFY_NOT_REACHED();
+            }
+        },
+        [&](const int& signal) {
+            outln("Terminated with signal {}", signal);
+        });
+
+    return pass;
 }
 
 }

--- a/Userland/Libraries/LibTest/CrashTest.cpp
+++ b/Userland/Libraries/LibTest/CrashTest.cpp
@@ -17,9 +17,11 @@
 
 namespace Test {
 
-Crash::Crash(String test_type, Function<Crash::Failure()> crash_function)
+Crash::Crash(String test_type, Function<Crash::Failure()> crash_function,
+    SuccessCondition success_condition)
     : m_type(move(test_type))
     , m_crash_function(move(crash_function))
+    , m_success_condition(success_condition)
 {
 }
 
@@ -57,7 +59,10 @@ bool Crash::run(RunType run_type)
 
 bool Crash::do_report(report_type report)
 {
-    const bool pass = report.has<int>();
+    bool pass = report.has<int>();
+    if (m_success_condition == SuccessCondition::DidCrash) {
+        pass = !pass;
+    }
 
     if (pass)
         out("\x1B[32mPASS\x1B[0m: ");

--- a/Userland/Libraries/LibTest/CrashTest.cpp
+++ b/Userland/Libraries/LibTest/CrashTest.cpp
@@ -27,26 +27,8 @@ bool Crash::run(RunType run_type)
 {
     outln("\x1B[33mTesting\x1B[0m: \"{}\"", m_type);
 
-    auto run_crash_and_print_if_error = [this]() -> bool {
-        auto failure = m_crash_function();
-
-        // If we got here something went wrong
-        out("\x1B[31mFAIL\x1B[0m: ");
-        switch (failure) {
-        case Failure::DidNotCrash:
-            outln("Did not crash!");
-            break;
-        case Failure::UnexpectedError:
-            outln("Unexpected error!");
-            break;
-        default:
-            VERIFY_NOT_REACHED();
-        }
-        return false;
-    };
-
     if (run_type == RunType::UsingCurrentProcess) {
-        return run_crash_and_print_if_error();
+        return print_report(m_crash_function());
     } else {
         // Run the test in a child process so that we do not crash the crash program :^)
         pid_t pid = fork();
@@ -58,7 +40,7 @@ bool Crash::run(RunType run_type)
             if (prctl(PR_SET_DUMPABLE, 0, 0) < 0)
                 perror("prctl(PR_SET_DUMPABLE)");
 #endif
-            run_crash_and_print_if_error();
+            return print_report(m_crash_function());
             exit(0);
         }
 
@@ -70,6 +52,23 @@ bool Crash::run(RunType run_type)
         }
         return false;
     }
+}
+
+bool Crash::do_report(Failure failure)
+{
+    // If we got here something went wrong
+    out("\x1B[31mFAIL\x1B[0m: ");
+    switch (failure) {
+    case Failure::DidNotCrash:
+        outln("Did not crash!");
+        break;
+    case Failure::UnexpectedError:
+        outln("Unexpected error!");
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+    return false;
 }
 
 }

--- a/Userland/Libraries/LibTest/CrashTest.cpp
+++ b/Userland/Libraries/LibTest/CrashTest.cpp
@@ -40,17 +40,19 @@ bool Crash::run(RunType run_type)
             if (prctl(PR_SET_DUMPABLE, 0, 0) < 0)
                 perror("prctl(PR_SET_DUMPABLE)");
 #endif
-            return print_report(m_crash_function());
-            exit(0);
+            exit(m_crash_function());
         }
 
         int status;
         waitpid(pid, &status, 0);
+        if (WIFEXITED(status)) {
+            return do_report(Failure(WEXITSTATUS(status)));
+        }
         if (WIFSIGNALED(status)) {
             outln("\x1B[32mPASS\x1B[0m: Terminated with signal {}", WTERMSIG(status));
             return true;
         }
-        return false;
+        VERIFY_NOT_REACHED();
     }
 }
 

--- a/Userland/Libraries/LibTest/CrashTest.h
+++ b/Userland/Libraries/LibTest/CrashTest.h
@@ -30,6 +30,8 @@ public:
     bool run(RunType run_type = RunType::UsingChildProcess);
 
 private:
+    bool do_report(Failure failure);
+
     String m_type;
     Function<Crash::Failure()> m_crash_function;
 };

--- a/Userland/Libraries/LibTest/CrashTest.h
+++ b/Userland/Libraries/LibTest/CrashTest.h
@@ -10,6 +10,7 @@
 
 #include <AK/Function.h>
 #include <AK/String.h>
+#include <AK/Variant.h>
 
 namespace Test {
 
@@ -30,7 +31,8 @@ public:
     bool run(RunType run_type = RunType::UsingChildProcess);
 
 private:
-    bool do_report(Failure failure);
+    using report_type = Variant<Failure, int>;
+    bool do_report(report_type report);
 
     String m_type;
     Function<Crash::Failure()> m_crash_function;

--- a/Userland/Libraries/LibTest/CrashTest.h
+++ b/Userland/Libraries/LibTest/CrashTest.h
@@ -16,6 +16,11 @@ namespace Test {
 
 class Crash {
 public:
+    enum class SuccessCondition {
+        DidCrash,
+        DidNotCrash,
+    };
+
     enum class RunType {
         UsingChildProcess,
         UsingCurrentProcess,
@@ -26,7 +31,8 @@ public:
         UnexpectedError,
     };
 
-    Crash(String test_type, Function<Crash::Failure()> crash_function);
+    Crash(String test_type, Function<Crash::Failure()> crash_function,
+        SuccessCondition success_condition = SuccessCondition::DidCrash);
 
     bool run(RunType run_type = RunType::UsingChildProcess);
 
@@ -36,6 +42,7 @@ private:
 
     String m_type;
     Function<Crash::Failure()> m_crash_function;
+    SuccessCondition m_success_condition;
 };
 
 }

--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -127,3 +127,14 @@ void current_test_case_did_fail();
         if (!crash.run())                           \
             ::Test::current_test_case_did_fail();   \
     } while (false)
+
+// To use, specify the lambda to execute in a sub process and verify it exits:
+//  EXPECT_NOT_CRASH("This should not fail", []{
+//      return Test::Crash::Failure::DidNotCrash;
+//  });
+#define EXPECT_NOT_CRASH(test_message, test_func)                                         \
+    do {                                                                                  \
+        Test::Crash crash(test_message, test_func, SuccessCondition::SuccessDidNotCrash); \
+        if (!crash.run())                                                                 \
+            ::Test::current_test_case_did_fail();                                         \
+    } while (false)


### PR DESCRIPTION
Hi,
The following change set fix some issues in `LibC` `assert`:
- declare `_abort` as a C linkage
- Make private API always available even if `LibC` was compiled with `NDEBUG` set.
- remove `__stringify` macro by using a `__assert` private API more in part with what glibc provides (glibc headers mention that this is required for "standard compliance" but I was not able to find the standard...).