### PR TITLE
Terminal: Fix broken selection after dbl/trp click

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -807,6 +807,7 @@ void TerminalWidget::mousedown_event(GUI::MouseEvent& event)
         else if (m_rectangle_selection)
             m_rectangle_selection = false;
 
+        m_triple_click_timer.reset();
         update_copy_action();
         update();
     }


### PR DESCRIPTION
This commit resets the terminal triple click timer when appropriate. 

Results in as-expected behavior in which a triple click results in selecting the whole line, a double click selects a word, and clicking and dragging results in a manual selection. 

Resolves #10591