### PR TITLE
LibWeb: Capture <script> element's node document on execution

### DIFF
--- a/Userland/Libraries/LibWeb/Tests/HTML/document.currentScript.js
+++ b/Userland/Libraries/LibWeb/Tests/HTML/document.currentScript.js
@@ -1,0 +1,36 @@
+describe("currentScript", () => {
+    loadLocalPage("/res/html/misc/blank.html");
+
+    beforeInitialPageLoad(page => {
+        expect(page.document.currentScript).toBeNull();
+    });
+
+    afterInitialPageLoad(page => {
+        test("reset to null even if currentScript is adopted into another document", () => {
+            const script = page.document.createElement("script");
+            script.id = "test";
+            script.innerText = `
+                const newDocument = globalThis.pageObject.document.implementation.createHTMLDocument();
+                const thisScript = globalThis.pageObject.document.getElementById("test");
+                
+                // currentScript should stay the same even across adoption.
+                expect(globalThis.pageObject.document.currentScript).toBe(thisScript);
+                newDocument.adoptNode(thisScript);
+                expect(globalThis.pageObject.document.currentScript).toBe(thisScript);
+            `;
+
+            // currentScript should be null before and after running the script on insertion.
+            expect(page.document.currentScript).toBeNull();
+            expect(script.ownerDocument).toBe(page.document);
+
+            globalThis.pageObject = page;
+            page.document.body.appendChild(script);
+            globalThis.pageObject = undefined;
+
+            expect(page.document.currentScript).toBeNull();
+            expect(script.ownerDocument).not.toBe(page.document);
+        });
+    });
+
+    waitForPageToLoad();
+});


### PR DESCRIPTION
Step 1 of the spec is to capture the <script> element's node document
into a local variable.

When I originally implemented this, I thought this was not necessary.
However, I realised that the script that runs can adopt the current
script element into a different document, meaning step 5.4 and 6 then
operate on the incorrect document.

Covered by this WPT: https://github.com/web-platform-tests/wpt/blob/7b0ebaccc62b566a1965396e5be7bb2bc06f841f/html/semantics/scripting-1/the-script-element/moving-between-documents-during-evaluation.html