### PR TITLE
LibRegex: Merge alternations based on blocks and not instructions

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -899,7 +899,9 @@ TEST_CASE(optimizer_atomic_groups)
         // Alternative fuse
         Tuple { "(abcfoo|abcbar|abcbaz).*x"sv, "abcbarx"sv, true },
         Tuple { "(a|a)"sv, "a"sv, true },
-        Tuple { "(a|)"sv, ""sv, true }, // Ensure that empty alternatives are not outright removed
+        Tuple { "(a|)"sv, ""sv, true },                   // Ensure that empty alternatives are not outright removed
+        Tuple { "a{2,3}|a{5,8}"sv, "abc"sv, false },      // Optimiser should not mess up the instruction stream by ignoring inter-insn dependencies, see #11247.
+        Tuple { "^(a{2,3}|a{5,8})$"sv, "aaaa"sv, false }, // Optimiser should not mess up the instruction stream by ignoring inter-insn dependencies, see #11247.
         // ForkReplace shouldn't be applied where it would change the semantics
         Tuple { "(1+)\\1"sv, "11"sv, true },
         Tuple { "(1+)1"sv, "11"sv, true },

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -227,10 +227,11 @@ public:
         return result.success;
     }
 
+    using BasicBlockList = Vector<Detail::Block>;
+    static BasicBlockList split_basic_blocks(ByteCode const&);
+
 private:
     void run_optimization_passes();
-    using BasicBlockList = Vector<Detail::Block>;
-    BasicBlockList split_basic_blocks();
     void attempt_rewrite_loops_as_atomic_groups(BasicBlockList const&);
 };
 


### PR DESCRIPTION
The instructions can have dependencies (e.g. Repeat), so only unify
equal blocks instead of consecutive instructions.
Fixes #11247.