### PR TITLE
Magnifier: Add timeline for easy checking of animations

### DIFF
--- a/Userland/Applications/Magnifier/MagnifierWidget.cpp
+++ b/Userland/Applications/Magnifier/MagnifierWidget.cpp
@@ -27,6 +27,22 @@ void MagnifierWidget::set_scale_factor(int scale_factor)
     update();
 }
 
+void MagnifierWidget::display_previous_frame()
+{
+    --m_frame_offset_from_head;
+    auto index = m_grabbed_bitmaps.head_index() + m_frame_offset_from_head;
+    m_grabbed_bitmap = m_grabbed_bitmaps.at(index);
+    update();
+}
+
+void MagnifierWidget::display_next_frame()
+{
+    ++m_frame_offset_from_head;
+    auto index = m_grabbed_bitmaps.head_index() + m_frame_offset_from_head;
+    m_grabbed_bitmap = m_grabbed_bitmaps.at(index);
+    update();
+}
+
 void MagnifierWidget::sync()
 {
     if (m_pause_capture)
@@ -35,6 +51,7 @@ void MagnifierWidget::sync()
     auto size = frame_inner_rect().size();
     Gfx::IntSize grab_size { size.width() / m_scale_factor, size.height() / m_scale_factor };
     m_grabbed_bitmap = GUI::WindowServerConnection::the().get_screen_bitmap_around_cursor(grab_size).bitmap();
+    m_grabbed_bitmaps.enqueue(m_grabbed_bitmap);
     update();
 }
 

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/CircularQueue.h>
 #include <LibGUI/Frame.h>
 
 class MagnifierWidget final : public GUI::Frame {
@@ -14,7 +15,14 @@ class MagnifierWidget final : public GUI::Frame {
 public:
     virtual ~MagnifierWidget();
     void set_scale_factor(int scale_factor);
-    void pause_capture(bool pause) { m_pause_capture = pause; }
+    void pause_capture(bool pause)
+    {
+        m_pause_capture = pause;
+        if (!pause)
+            m_frame_offset_from_head = 0;
+    }
+    void display_previous_frame();
+    void display_next_frame();
 
 private:
     MagnifierWidget();
@@ -25,5 +33,7 @@ private:
 
     int m_scale_factor { 2 };
     RefPtr<Gfx::Bitmap> m_grabbed_bitmap;
+    CircularQueue<RefPtr<Gfx::Bitmap>, 512> m_grabbed_bitmaps {};
+    ssize_t m_frame_offset_from_head { 0 };
     bool m_pause_capture { false };
 };

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -75,6 +75,22 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(view_menu->try_add_separator());
     TRY(view_menu->try_add_action(pause_action));
 
+    auto timeline_menu = TRY(window->try_add_menu("&Timeline"));
+    auto previous_frame_action = GUI::Action::create(
+        "&Previous frame", { Key_Left }, [&](auto&) {
+            pause_action->set_checked(true);
+            magnifier->pause_capture(true);
+            magnifier->display_previous_frame();
+        });
+    auto next_frame_action = GUI::Action::create(
+        "&Next frame", { Key_Right }, [&](auto&) {
+            pause_action->set_checked(true);
+            magnifier->pause_capture(true);
+            magnifier->display_next_frame();
+        });
+    TRY(timeline_menu->try_add_action(previous_frame_action));
+    TRY(timeline_menu->try_add_action(next_frame_action));
+
     auto help_menu = TRY(window->try_add_menu("&Help"));
     help_menu->add_action(GUI::CommonActions::make_about_action("Magnifier", app_icon, window));
 


### PR DESCRIPTION
This patch adds a 512 frame timeline to Magnifier and the ability to
step through it with the arrow keys.

This makes it easier to check Serenity animations frame by frame for
correctness etc.