### PR TITLE
Spreadsheet: Handle emptying of cell containing only an '='

### DIFF
--- a/Userland/Applications/Spreadsheet/Cell.cpp
+++ b/Userland/Applications/Spreadsheet/Cell.cpp
@@ -13,7 +13,8 @@ namespace Spreadsheet {
 
 void Cell::set_data(String new_data)
 {
-    if (m_data == new_data)
+    //If we are a formula, we do not save the beginning '=', if the new_data is "" it is different from us.
+    if (m_data == new_data && (m_kind != Formula || new_data.length() != 0))
         return;
 
     if (new_data.starts_with("=")) {


### PR DESCRIPTION
Cell::set_data(String new_data) now checks whether the cell is a
formula-cell and the new_data is an empty string. If this is case, it
will no longer simply return and will now instead actually set the
cell's contents to an empty string.

This fixes an error whereupon committing the string "=" to a cell, it
would not be possible to directly delete the cell's contents. Instead,
it first had to be overwritten with another string, which then could be
deleted.

This could probably be done more elegantly. Right now, I believe,
writing the string "=" to a (formula-)cell already containing an
identical string will result in the cell being marked as dirty, even
though nothing actually changed.