### PR TITLE
AK: Clang-Tidy and other fixes for our JSON interface

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -63,6 +63,17 @@ public:
         return false;
     }
 
+    template<Concepts::HashCompatible<K> Key>
+    requires(IsSame<KeyTraits, Traits<K>>) bool remove(Key const& key)
+    {
+        auto it = find(key);
+        if (it != end()) {
+            m_table.remove(it);
+            return true;
+        }
+        return false;
+    }
+
     using HashTableType = HashTable<Entry, EntryTraits, IsOrdered>;
     using IteratorType = typename HashTableType::Iterator;
     using ConstIteratorType = typename HashTableType::ConstIterator;

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -373,6 +373,17 @@ public:
         return false;
     }
 
+    template<Concepts::HashCompatible<T> K>
+    requires(IsSame<TraitsForT, Traits<T>>) bool remove(K const& value)
+    {
+        auto it = find(value);
+        if (it != end()) {
+            remove(it);
+            return true;
+        }
+        return false;
+    }
+
     void remove(Iterator iterator)
     {
         VERIFY(iterator.m_bucket);

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -69,7 +69,7 @@ public:
     template<typename Callback>
     void for_each(Callback callback) const
     {
-        for (auto& value : m_values)
+        for (auto const& value : m_values)
             callback(value);
     }
 

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -49,7 +49,7 @@ public:
 
     [[nodiscard]] JsonValue const& get(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         static JsonValue* s_null_value { nullptr };
         if (!value) {
             if (!s_null_value)
@@ -74,58 +74,58 @@ public:
 
     [[nodiscard]] bool has_null(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_null();
     }
     [[nodiscard]] bool has_bool(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_bool();
     }
     [[nodiscard]] bool has_string(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_string();
     }
     [[nodiscard]] bool has_i32(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_i32();
     }
     [[nodiscard]] bool has_u32(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_u32();
     }
     [[nodiscard]] bool has_i64(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_i64();
     }
     [[nodiscard]] bool has_u64(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_u64();
     }
     [[nodiscard]] bool has_number(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_number();
     }
     [[nodiscard]] bool has_array(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_array();
     }
     [[nodiscard]] bool has_object(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_object();
     }
 #ifndef KERNEL
     [[nodiscard]] [[nodiscard]] bool has_double(StringView key) const
     {
-        auto* value = get_ptr(key);
+        auto const* value = get_ptr(key);
         return value && value->is_double();
     }
 #endif
@@ -138,7 +138,7 @@ public:
     template<typename Callback>
     void for_each_member(Callback callback) const
     {
-        for (auto& member : m_members)
+        for (auto const& member : m_members)
             callback(member.key, member.value);
     }
 

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -142,7 +142,7 @@ public:
             callback(member.key, member.value);
     }
 
-    bool remove(String const& key)
+    bool remove(StringView key)
     {
         return m_members.remove(key);
     }

--- a/AK/JsonPath.cpp
+++ b/AK/JsonPath.cpp
@@ -16,7 +16,7 @@ JsonPathElement JsonPathElement::any_object_element { Kind::AnyKey };
 JsonValue JsonPath::resolve(const JsonValue& top_root) const
 {
     auto root = top_root;
-    for (auto& element : *this) {
+    for (auto const& element : *this) {
         switch (element.kind()) {
         case JsonPathElement::Kind::Key:
             root = JsonValue { root.as_object().get(element.key()) };
@@ -35,7 +35,7 @@ String JsonPath::to_string() const
 {
     StringBuilder builder;
     builder.append("{ .");
-    for (auto& el : *this) {
+    for (auto const& el : *this) {
         builder.append(" > ");
         builder.append(el.to_string());
     }

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -131,7 +131,7 @@ public:
         return m_value.as_u64;
     }
 
-    int as_bool() const
+    bool as_bool() const
     {
         VERIFY(is_bool());
         return m_value.as_bool;


### PR DESCRIPTION
#### AK: Return bool in JsonValue::as_bool()

#### AK: Use StringView as key-type to set/remove a Value in JsonObject

#### AK: Add implied const qualifiers to the Json interface
As specified by clang-tidy.