### PR TITLE
Applications: Port to LibMain

### DIFF
--- a/Userland/Applications/About/CMakeLists.txt
+++ b/Userland/Applications/About/CMakeLists.txt
@@ -15,4 +15,4 @@ execute_process(COMMAND "git diff-index --quiet HEAD -- && echo tracked || echo 
 add_definitions(-DGIT_COMMIT="${GIT_COMMIT}" -DGIT_BRANCH="${GIT_BRANCH}" -DGIT_CHANGES="${GIT_CHANGES}")
 
 serenity_bin(About)
-target_link_libraries(About LibGUI)
+target_link_libraries(About LibGUI LibMain)

--- a/Userland/Applications/AnalogClock/CMakeLists.txt
+++ b/Userland/Applications/AnalogClock/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
         )
 
 serenity_app(AnalogClock ICON app-analog-clock)
-target_link_libraries(AnalogClock LibGUI)
+target_link_libraries(AnalogClock LibGUI LibMain)

--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -1,53 +1,45 @@
 /*
  * Copyright (c) 2021, Erlend Høier <Erlend@ReasonablePanic.com>
+ * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "AnalogClock.h"
 #include <LibCore/DateTime.h>
+#include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Window.h>
-#include <unistd.h>
+#include <LibMain/Main.h>
 
-int main(int argc, char** argv)
+ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(argc, argv);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
-    if (pledge("stdio recvfd sendfd rpath", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil(nullptr, nullptr));
 
-    if (unveil("/res", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil(nullptr, nullptr) < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    auto app_icon = GUI::Icon::default_icon("app-analog-clock");
-    auto window = GUI::Window::construct();
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-analog-clock"));
+    auto window = TRY(GUI::Window::try_create());
     window->set_title(Core::DateTime::now().to_string("%Y-%m-%d"));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(170, 170);
     window->set_resizable(false);
-    auto& clock = window->set_main_widget<AnalogClock>();
+    auto clock = TRY(window->try_set_main_widget<AnalogClock>());
 
     auto show_window_frame_action = GUI::Action::create_checkable(
         "Show Window &Frame", { Mod_Alt, KeyCode::Key_F }, [&](auto& action) {
-            clock.set_show_window_frame(action.is_checked());
+            clock->set_show_window_frame(action.is_checked());
         });
-    show_window_frame_action->set_checked(clock.show_window_frame());
-    auto menu = GUI::Menu::construct();
-    menu->add_action(move(show_window_frame_action));
-    clock.on_context_menu_request = [&](auto& event) {
+    show_window_frame_action->set_checked(clock->show_window_frame());
+    auto menu = TRY(GUI::Menu::try_create());
+    TRY(menu->try_add_action(*show_window_frame_action));
+
+    clock->on_context_menu_request = [&](auto& event) {
         menu->popup(event.screen_position());
     };
 

--- a/Userland/Libraries/LibGUI/Icon.cpp
+++ b/Userland/Libraries/LibGUI/Icon.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -80,6 +81,14 @@ Icon Icon::default_icon(StringView name)
         bitmap16 = bitmap_or_error.release_value();
     if (auto bitmap_or_error = Gfx::Bitmap::try_load_from_file(String::formatted("/res/icons/32x32/{}.png", name)); !bitmap_or_error.is_error())
         bitmap32 = bitmap_or_error.release_value();
+    return Icon(move(bitmap16), move(bitmap32));
+}
+
+ErrorOr<Icon> Icon::try_create_default_icon(StringView name)
+{
+    RefPtr<Gfx::Bitmap> bitmap16 = TRY(Gfx::Bitmap::try_load_from_file(String::formatted("/res/icons/16x16/{}.png", name)));
+    RefPtr<Gfx::Bitmap> bitmap32 = TRY(Gfx::Bitmap::try_load_from_file(String::formatted("/res/icons/32x32/{}.png", name)));
+
     return Icon(move(bitmap16), move(bitmap32));
 }
 

--- a/Userland/Libraries/LibGUI/Icon.h
+++ b/Userland/Libraries/LibGUI/Icon.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -44,6 +45,7 @@ public:
     ~Icon() { }
 
     static Icon default_icon(StringView);
+    static ErrorOr<Icon> try_create_default_icon(StringView);
 
     Icon& operator=(const Icon& other)
     {


### PR DESCRIPTION
Hello friends, to get my toes wet I decided to port two applications to LibMain. I kept this PR purposely small, because I wanted to know if I'm on the right track as I am not too familiar with C++.

This introduces a new method `try_create_default_icon` which leverages the `TRY()` pattern when creating application icons. I hope that I have implemented this correctly.

It ports the applications `About` and `AnalogClock` to make use of `LibMain`.