### PR TITLE
AK+Tests: Use less space in ErrorOr

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -9,6 +9,7 @@
 #include <AK/Optional.h>
 #include <AK/StringView.h>
 #include <AK/Try.h>
+#include <AK/Variant.h>
 
 #if defined(__serenity__) && defined(KERNEL)
 #    include <LibC/errno_numbers.h>
@@ -55,58 +56,41 @@ private:
 };
 
 template<typename T, typename ErrorType>
-class [[nodiscard]] ErrorOr {
+class [[nodiscard]] ErrorOr final : public Variant<T, ErrorType> {
 public:
-    ErrorOr(T const& value)
-        : m_value(value)
-    {
-    }
-
-    ErrorOr(T&& value)
-        : m_value(move(value))
-    {
-    }
+    using Variant<T, ErrorType>::Variant;
 
     template<typename U>
     ALWAYS_INLINE ErrorOr(U&& value) requires(!IsSame<RemoveCVReference<U>, ErrorOr<T>>)
-        : m_value(forward<U>(value))
+        : Variant<T, ErrorType>(forward<U>(value))
     {
     }
 
 #ifdef __serenity__
     ErrorOr(ErrnoCode code)
-        : m_error(Error::from_errno(code))
+        : Variant<T, ErrorType>(Error::from_errno(code))
     {
     }
 #endif
 
-    ErrorOr(ErrorType&& error)
-        : m_error(move(error))
+    T& value()
     {
+        return this->template get<T>();
     }
+    T const& value() const { return this->template get<T>(); }
+    ErrorType& error() { return this->template get<ErrorType>(); }
+    ErrorType const& error() const { return this->template get<ErrorType>(); }
 
-    ErrorOr(ErrorOr&& other) = default;
-    ErrorOr(ErrorOr const& other) = default;
-    ~ErrorOr() = default;
+    bool is_error() const { return this->template has<ErrorType>(); }
 
-    ErrorOr& operator=(ErrorOr&& other) = default;
-    ErrorOr& operator=(ErrorOr const& other) = default;
-
-    T& value() { return m_value.value(); }
-    T const& value() const { return m_value.value(); }
-    ErrorType& error() { return m_error.value(); }
-    ErrorType const& error() const { return m_error.value(); }
-
-    bool is_error() const { return m_error.has_value(); }
-
-    T release_value() { return m_value.release_value(); }
-    ErrorType release_error() { return m_error.release_value(); }
+    T release_value() { return move(value()); }
+    ErrorType release_error() { return move(error()); }
 
     T release_value_but_fixme_should_propagate_errors() { return release_value(); }
 
 private:
-    Optional<T> m_value;
-    Optional<ErrorType> m_error;
+    // 'downcast' is fishy in this context. Let's hide it by making it private.
+    using Variant<T, ErrorType>::downcast;
 };
 
 // Partial specialization for void value type

--- a/Tests/AK/TestTypeTraits.cpp
+++ b/Tests/AK/TestTypeTraits.cpp
@@ -39,9 +39,6 @@
 #define EXPECT_VARIADIC_TRAIT_FALSE(trait, ...) \
     static_assert(!trait<__VA_ARGS__>)
 
-struct Empty {
-};
-
 enum class Enummer : u8 {
     Dummmy,
 };


### PR DESCRIPTION
Instead of keeping two disjoint `Optional`s around (which consumes at least `sizeof(T) + 1 + paddingT + sizeof(ErrorType) + 1 + paddingET` bytes), use a `Variant<T, ErrorType>`, which consumes only `max(sizeof(T), sizeof(ErrorType)) + 1 + padding` bytes.

I don't observe any speedups, but given that we pass ErrorOr objects all the time across stackframes, I'd guess that squeezing a few bytes out of these objects should have positive effects.

Also, this eliminates weird intermediate states: An ErrorOr object can no longer contain "neither", nor "both".

This is actually a functional change: `move`ing out of an ErrorOr now has slightly different behavior. The old behavior was:
- `move` out the actual content, let's say `T`
- Immediately call the destructor of the now-empty object
- Leave the ErrorOr object in a weird state where `has_value()` is false *and* `has_error()` is false
The new behavior is that the destructor of the now-empty object is called whenever the ErrorOr object is destroyed.

This difference is really minute. I would go so far to call any dependency on the old behavior a bug, should there have been any. (I didn't find any.)