### PR TITLE
LibGfx: Handle malformed Platform ID during TTF parsing

### DIFF
--- a/Userland/Libraries/LibGfx/TrueTypeFont/Cmap.cpp
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Cmap.cpp
@@ -13,7 +13,7 @@ extern u16 be_u16(u8 const*);
 extern u32 be_u32(u8 const*);
 extern i16 be_i16(u8 const*);
 
-Cmap::Subtable::Platform Cmap::Subtable::platform_id() const
+Optional<Cmap::Subtable::Platform> Cmap::Subtable::platform_id() const
 {
     switch (m_raw_platform_id) {
     case 0:
@@ -25,7 +25,7 @@ Cmap::Subtable::Platform Cmap::Subtable::platform_id() const
     case 4:
         return Platform::Custom;
     default:
-        VERIFY_NOT_REACHED();
+        return {};
     }
 }
 

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Cmap.h
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Cmap.h
@@ -45,7 +45,7 @@ public:
         }
         // Returns 0 if glyph not found. This corresponds to the "missing glyph"
         u32 glyph_id_for_code_point(u32 code_point) const;
-        Platform platform_id() const;
+        Optional<Platform> platform_id() const;
         u16 encoding_id() const { return m_encoding_id; }
         Format format() const;
 

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
@@ -368,7 +368,11 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_offset(ReadonlyBytes buffer, u3
             continue;
         }
         auto subtable = opt_subtable.value();
-        if (subtable.platform_id() == Cmap::Subtable::Platform::Windows) {
+        auto platform = subtable.platform_id();
+        if (!platform.has_value())
+            return Error::from_string_literal("Invalid Platform ID"sv);
+
+        if (platform.value() == Cmap::Subtable::Platform::Windows) {
             if (subtable.encoding_id() == (u16)Cmap::Subtable::WindowsEncoding::UnicodeFullRepertoire) {
                 cmap.set_active_index(i);
                 break;


### PR DESCRIPTION
This should fix one of the OSS Fuzz crashes that occurs during
TTF file format parsing.

See: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=37263