### PR TITLE
LibUnicode: Dynamically load the generated Unicode symbols

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -427,6 +427,7 @@ if (BUILD_LAGOM)
         SOURCES ${LIBUNICODE_SOURCES} ${UNICODE_DATA_SOURCES}
     )
     target_compile_definitions(LagomUnicode PRIVATE ENABLE_UNICODE_DATA=$<BOOL:${ENABLE_UNICODE_DATABASE_DOWNLOAD}>)
+    target_link_libraries(LagomUnicode -ldl)
 
     # WASM
     file(GLOB LIBWASM_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibWasm/*/*.cpp")

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -921,7 +921,7 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
         for (auto const& alias : aliases)
             hashes.set(alias.alias.hash(), alias.alias);
 
-        generate_value_from_string_for_dynamic_loading(generator, "{}_from_string"sv, enum_title, enum_snake, move(hashes));
+        generate_value_from_string(generator, "{}_from_string"sv, enum_title, enum_snake, move(hashes));
     };
 
     append_prop_search("GeneralCategory"sv, "general_category"sv, "s_general_categories"sv);

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
@@ -1068,7 +1068,7 @@ Optional<StringView> get_locale_@enum_snake@_mapping(StringView locale, StringVi
         for (auto const& alias : aliases)
             hashes.set(alias.alias.hash(), format_identifier(enum_title, alias.alias));
 
-        generate_value_from_string_for_dynamic_loading(generator, "{}_from_string"sv, enum_title, enum_snake, move(hashes));
+        generate_value_from_string(generator, "{}_from_string"sv, enum_title, enum_snake, move(hashes));
     };
 
     auto append_alias_search = [&](StringView enum_snake, auto const& aliases) {
@@ -1078,7 +1078,7 @@ Optional<StringView> get_locale_@enum_snake@_mapping(StringView locale, StringVi
         for (auto const& alias : aliases)
             hashes.set(alias.key.hash(), alias.value);
 
-        generate_value_from_string_for_dynamic_loading(generator, "resolve_{}_alias"sv, s_string_index_type, enum_snake, move(hashes), "StringView"sv, "s_string_list[{}]"sv);
+        generate_value_from_string(generator, "resolve_{}_alias"sv, s_string_index_type, enum_snake, move(hashes), "StringView"sv, "s_string_list[{}]"sv);
     };
 
     append_from_string("Locale"sv, "locale"sv, locale_data.locales.keys(), locale_data.locale_aliases);

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
@@ -727,11 +727,7 @@ static void generate_unicode_locale_header(Core::File& file, UnicodeLocaleData& 
     generator.append(R"~~~(
 #pragma once
 
-#include <AK/Optional.h>
-#include <AK/StringView.h>
 #include <AK/Types.h>
-#include <AK/Vector.h>
-#include <LibUnicode/Forward.h>
 
 namespace Unicode {
 )~~~");
@@ -748,45 +744,6 @@ namespace Unicode {
     generate_enum(generator, format_identifier, "ListPatternStyle"sv, {}, locale_data.list_pattern_styles);
 
     generator.append(R"~~~(
-namespace Detail {
-
-Optional<Locale> locale_from_string(StringView locale);
-
-Optional<StringView> get_locale_language_mapping(StringView locale, StringView language);
-Optional<Language> language_from_string(StringView language);
-Optional<StringView> resolve_language_alias(StringView language);
-
-Optional<StringView> get_locale_territory_mapping(StringView locale, StringView territory);
-Optional<Territory> territory_from_string(StringView territory);
-Optional<StringView> resolve_territory_alias(StringView territory);
-
-Optional<StringView> get_locale_script_tag_mapping(StringView locale, StringView script_tag);
-Optional<ScriptTag> script_tag_from_string(StringView script_tag);
-Optional<StringView> resolve_script_tag_alias(StringView script_tag);
-
-Optional<StringView> get_locale_long_currency_mapping(StringView locale, StringView currency);
-Optional<StringView> get_locale_short_currency_mapping(StringView locale, StringView currency);
-Optional<StringView> get_locale_narrow_currency_mapping(StringView locale, StringView currency);
-Optional<StringView> get_locale_numeric_currency_mapping(StringView locale, StringView currency);
-Optional<Currency> currency_from_string(StringView currency);
-
-Optional<StringView> get_locale_key_mapping(StringView locale, StringView key);
-Optional<Key> key_from_string(StringView key);
-
-Optional<ListPatterns> get_locale_list_pattern_mapping(StringView locale, StringView list_pattern_type, StringView list_pattern_style);
-Optional<ListPatternType> list_pattern_type_from_string(StringView list_pattern_type);
-Optional<ListPatternStyle> list_pattern_style_from_string(StringView list_pattern_style);
-
-Optional<StringView> resolve_variant_alias(StringView variant);
-Optional<StringView> resolve_subdivision_alias(StringView subdivision);
-
-void resolve_complex_language_aliases(Unicode::LanguageID& language_id);
-
-Optional<Unicode::LanguageID> add_likely_subtags(Unicode::LanguageID const& language_id);
-Optional<String> resolve_most_likely_territory(Unicode::LanguageID const& language_id);
-
-}
-
 }
 )~~~");
 
@@ -805,7 +762,10 @@ static void generate_unicode_locale_implementation(Core::File& file, UnicodeLoca
     generator.append(R"~~~(
 #include <AK/Array.h>
 #include <AK/BinarySearch.h>
+#include <AK/Optional.h>
 #include <AK/Span.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/UnicodeLocale.h>
 
@@ -1072,6 +1032,7 @@ static LanguageMapping const* resolve_likely_subtag(Unicode::LanguageID const& l
         generator.set("unique_list", unique_list);
 
         generator.append(R"~~~(
+Optional<StringView> get_locale_@enum_snake@_mapping(StringView locale, StringView @enum_snake@) asm("unicode_get_locale_@enum_snake@_mapping");
 Optional<StringView> get_locale_@enum_snake@_mapping(StringView locale, StringView @enum_snake@)
 {
     auto locale_value = locale_from_string(locale);
@@ -1107,7 +1068,7 @@ Optional<StringView> get_locale_@enum_snake@_mapping(StringView locale, StringVi
         for (auto const& alias : aliases)
             hashes.set(alias.alias.hash(), format_identifier(enum_title, alias.alias));
 
-        generate_value_from_string(generator, "{}_from_string"sv, enum_title, enum_snake, move(hashes));
+        generate_value_from_string_for_dynamic_loading(generator, "{}_from_string"sv, enum_title, enum_snake, move(hashes));
     };
 
     auto append_alias_search = [&](StringView enum_snake, auto const& aliases) {
@@ -1117,31 +1078,31 @@ Optional<StringView> get_locale_@enum_snake@_mapping(StringView locale, StringVi
         for (auto const& alias : aliases)
             hashes.set(alias.key.hash(), alias.value);
 
-        generate_value_from_string(generator, "resolve_{}_alias"sv, s_string_index_type, enum_snake, move(hashes), "StringView"sv, "s_string_list[{}]"sv);
+        generate_value_from_string_for_dynamic_loading(generator, "resolve_{}_alias"sv, s_string_index_type, enum_snake, move(hashes), "StringView"sv, "s_string_list[{}]"sv);
     };
 
     append_from_string("Locale"sv, "locale"sv, locale_data.locales.keys(), locale_data.locale_aliases);
 
-    append_mapping_search("language"sv, "language"sv, "s_languages"sv, "s_language_lists"sv);
     append_from_string("Language"sv, "language"sv, locale_data.languages);
+    append_mapping_search("language"sv, "language"sv, "s_languages"sv, "s_language_lists"sv);
     append_alias_search("language"sv, locale_data.language_aliases);
 
-    append_mapping_search("territory"sv, "territory"sv, "s_territories"sv, "s_territory_lists"sv);
     append_from_string("Territory"sv, "territory"sv, locale_data.territories);
+    append_mapping_search("territory"sv, "territory"sv, "s_territories"sv, "s_territory_lists"sv);
     append_alias_search("territory"sv, locale_data.territory_aliases);
 
-    append_mapping_search("script_tag"sv, "script_tag"sv, "s_scripts"sv, "s_script_lists"sv);
     append_from_string("ScriptTag"sv, "script_tag"sv, locale_data.scripts);
+    append_mapping_search("script_tag"sv, "script_tag"sv, "s_scripts"sv, "s_script_lists"sv);
     append_alias_search("script_tag"sv, locale_data.script_aliases);
 
+    append_from_string("Currency"sv, "currency"sv, locale_data.currencies);
     append_mapping_search("long_currency"sv, "currency"sv, "s_long_currencies"sv, "s_currency_lists"sv);
     append_mapping_search("short_currency"sv, "currency"sv, "s_short_currencies"sv, "s_currency_lists"sv);
     append_mapping_search("narrow_currency"sv, "currency"sv, "s_narrow_currencies"sv, "s_currency_lists"sv);
     append_mapping_search("numeric_currency"sv, "currency"sv, "s_numeric_currencies"sv, "s_currency_lists"sv);
-    append_from_string("Currency"sv, "currency"sv, locale_data.currencies);
 
-    append_mapping_search("key"sv, "key"sv, "s_keywords"sv, "s_keyword_lists"sv);
     append_from_string("Key"sv, "key"sv, locale_data.keywords);
+    append_mapping_search("key"sv, "key"sv, "s_keywords"sv, "s_keyword_lists"sv);
 
     append_alias_search("variant"sv, locale_data.variant_aliases);
     append_alias_search("subdivision"sv, locale_data.subdivision_aliases);
@@ -1150,6 +1111,7 @@ Optional<StringView> get_locale_@enum_snake@_mapping(StringView locale, StringVi
     append_from_string("ListPatternStyle"sv, "list_pattern_style"sv, locale_data.list_pattern_styles);
 
     generator.append(R"~~~(
+Optional<ListPatterns> get_locale_list_pattern_mapping(StringView locale, StringView list_pattern_type, StringView list_pattern_style) asm("unicode_get_locale_list_pattern_mapping");
 Optional<ListPatterns> get_locale_list_pattern_mapping(StringView locale, StringView list_pattern_type, StringView list_pattern_style)
 {
     auto locale_value = locale_from_string(locale);
@@ -1185,6 +1147,7 @@ Optional<ListPatterns> get_locale_list_pattern_mapping(StringView locale, String
     return {};
 }
 
+void resolve_complex_language_aliases(Unicode::LanguageID& language_id) asm("unicode_resolve_complex_language_aliases");
 void resolve_complex_language_aliases(Unicode::LanguageID& language_id)
 {
     for (auto const& map : s_complex_alias) {
@@ -1217,6 +1180,7 @@ void resolve_complex_language_aliases(Unicode::LanguageID& language_id)
     }
 }
 
+Optional<Unicode::LanguageID> add_likely_subtags(Unicode::LanguageID const& language_id) asm("unicode_add_likely_subtags");
 Optional<Unicode::LanguageID> add_likely_subtags(Unicode::LanguageID const& language_id)
 {
     // https://www.unicode.org/reports/tr35/#Likely_Subtags
@@ -1243,6 +1207,7 @@ Optional<Unicode::LanguageID> add_likely_subtags(Unicode::LanguageID const& lang
     return maximized;
 }
 
+Optional<String> resolve_most_likely_territory(Unicode::LanguageID const& language_id) asm("unicode_resolve_most_likely_territory");
 Optional<String> resolve_most_likely_territory(Unicode::LanguageID const& language_id)
 {
     if (auto const* likely_subtag = resolve_likely_subtag(language_id); likely_subtag != nullptr)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
@@ -713,30 +713,9 @@ static void generate_unicode_locale_header(Core::File& file, UnicodeLocaleData&)
     StringBuilder builder;
     SourceGenerator generator { builder };
 
+    // FIXME: Update unicode_data.cmake to not require a header.
     generator.append(R"~~~(
 #pragma once
-
-#include <AK/Optional.h>
-#include <AK/StringView.h>
-#include <AK/Vector.h>
-#include <LibUnicode/Forward.h>
-
-namespace Unicode {
-)~~~");
-
-    generator.append(R"~~~(
-namespace Detail {
-
-Optional<StringView> get_number_system_symbol(StringView locale, StringView system, Unicode::NumericSymbol symbol);
-Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system);
-Optional<NumberFormat> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type);
-Vector<NumberFormat> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type);
-Vector<Unicode::NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style);
-Optional<NumericSymbol> numeric_symbol_from_string(StringView numeric_symbol);
-
-}
-
-}
 )~~~");
 
     VERIFY(file.write(generator.as_string_view()));
@@ -755,7 +734,10 @@ static void generate_unicode_locale_implementation(Core::File& file, UnicodeLoca
     generator.append(R"~~~(
 #include <AK/Array.h>
 #include <AK/BinarySearch.h>
+#include <AK/Optional.h>
 #include <AK/Span.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/NumberFormat.h>
 #include <LibUnicode/UnicodeNumberFormat.h>
@@ -868,6 +850,7 @@ static NumberSystem const* find_number_system(StringView locale, StringView syst
     return nullptr;
 }
 
+Optional<StringView> get_number_system_symbol(StringView locale, StringView system, Unicode::NumericSymbol symbol) asm("unicode_get_number_system_symbol");
 Optional<StringView> get_number_system_symbol(StringView locale, StringView system, Unicode::NumericSymbol symbol)
 {
     if (auto const* number_system = find_number_system(locale, system); number_system != nullptr) {
@@ -883,6 +866,7 @@ Optional<StringView> get_number_system_symbol(StringView locale, StringView syst
     return {};
 }
 
+Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system) asm("unicode_get_number_system_groupings");
 Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system)
 {
     if (auto const* number_system = find_number_system(locale, system); number_system != nullptr)
@@ -890,6 +874,7 @@ Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringV
     return {};
 }
 
+Optional<Unicode::NumberFormat> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type) asm("unicode_get_standard_number_system_format");
 Optional<Unicode::NumberFormat> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type)
 {
     if (auto const* number_system = find_number_system(locale, system); number_system != nullptr) {
@@ -919,6 +904,7 @@ Optional<Unicode::NumberFormat> get_standard_number_system_format(StringView loc
     return {};
 }
 
+Vector<Unicode::NumberFormat> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type) asm("unicode_get_compact_number_system_formats");
 Vector<Unicode::NumberFormat> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type)
 {
     Vector<Unicode::NumberFormat> formats;
@@ -970,6 +956,7 @@ static Unit const* find_units(StringView locale, StringView unit)
     return nullptr;
 }
 
+Vector<Unicode::NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style) asm("unicode_get_unit_formats");
 Vector<Unicode::NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style)
 {
     Vector<Unicode::NumberFormat> formats;

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -305,59 +305,6 @@ void generate_value_from_string(SourceGenerator& generator, StringView method_na
     generator.set("size", String::number(hashes.size()));
 
     generator.append(R"~~~(
-Optional<@return_type@> @method_name@(StringView key)
-{
-    constexpr Array<HashValuePair<@value_type@>, @size@> hash_pairs { {
-        )~~~");
-
-    auto hash_keys = hashes.keys();
-    quick_sort(hash_keys);
-
-    constexpr size_t max_values_per_row = 10;
-    size_t values_in_current_row = 0;
-
-    for (auto hash_key : hash_keys) {
-        if (values_in_current_row++ > 0)
-            generator.append(" ");
-
-        if constexpr (IsIntegral<ValueType>)
-            generator.set("value"sv, String::number(hashes.get(hash_key).value()));
-        else
-            generator.set("value"sv, String::formatted("{}::{}", value_type, hashes.get(hash_key).value()));
-
-        generator.set("hash"sv, String::number(hash_key));
-        generator.append("{ @hash@U, @value@ },"sv);
-
-        if (values_in_current_row == max_values_per_row) {
-            generator.append("\n        ");
-            values_in_current_row = 0;
-        }
-    }
-
-    generator.set("return_statement", String::formatted(return_format, "value->value"sv));
-    generator.append(R"~~~(
-    } };
-
-    if (auto const* value = binary_search(hash_pairs, key.hash(), nullptr, HashValueComparator<@value_type@> {}))
-        return @return_statement@;
-    return {};
-}
-)~~~");
-}
-
-// This is a temporary duplicate of generate_value_from_string() until all generators support dynamic loading.
-template<typename ValueType>
-void generate_value_from_string_for_dynamic_loading(SourceGenerator& generator, StringView method_name_format, StringView value_type, StringView value_name, HashValueMap<ValueType> hashes, Optional<StringView> return_type = {}, StringView return_format = "{}"sv)
-{
-    ensure_from_string_types_are_generated(generator);
-
-    generator.set("method_name", String::formatted(method_name_format, value_name));
-    generator.set("value_type", value_type);
-    generator.set("value_name", value_name);
-    generator.set("return_type", return_type.has_value() ? *return_type : value_type);
-    generator.set("size", String::number(hashes.size()));
-
-    generator.append(R"~~~(
 Optional<@return_type@> @method_name@(StringView key) asm("unicode_@method_name@");
 Optional<@return_type@> @method_name@(StringView key)
 {

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -345,6 +345,60 @@ Optional<@return_type@> @method_name@(StringView key)
 )~~~");
 }
 
+// This is a temporary duplicate of generate_value_from_string() until all generators support dynamic loading.
+template<typename ValueType>
+void generate_value_from_string_for_dynamic_loading(SourceGenerator& generator, StringView method_name_format, StringView value_type, StringView value_name, HashValueMap<ValueType> hashes, Optional<StringView> return_type = {}, StringView return_format = "{}"sv)
+{
+    ensure_from_string_types_are_generated(generator);
+
+    generator.set("method_name", String::formatted(method_name_format, value_name));
+    generator.set("value_type", value_type);
+    generator.set("value_name", value_name);
+    generator.set("return_type", return_type.has_value() ? *return_type : value_type);
+    generator.set("size", String::number(hashes.size()));
+
+    generator.append(R"~~~(
+Optional<@return_type@> @method_name@(StringView key) asm("unicode_@method_name@");
+Optional<@return_type@> @method_name@(StringView key)
+{
+    constexpr Array<HashValuePair<@value_type@>, @size@> hash_pairs { {
+        )~~~");
+
+    auto hash_keys = hashes.keys();
+    quick_sort(hash_keys);
+
+    constexpr size_t max_values_per_row = 10;
+    size_t values_in_current_row = 0;
+
+    for (auto hash_key : hash_keys) {
+        if (values_in_current_row++ > 0)
+            generator.append(" ");
+
+        if constexpr (IsIntegral<ValueType>)
+            generator.set("value"sv, String::number(hashes.get(hash_key).value()));
+        else
+            generator.set("value"sv, String::formatted("{}::{}", value_type, hashes.get(hash_key).value()));
+
+        generator.set("hash"sv, String::number(hash_key));
+        generator.append("{ @hash@U, @value@ },"sv);
+
+        if (values_in_current_row == max_values_per_row) {
+            generator.append("\n        ");
+            values_in_current_row = 0;
+        }
+    }
+
+    generator.set("return_statement", String::formatted(return_format, "value->value"sv));
+    generator.append(R"~~~(
+    } };
+
+    if (auto const* value = binary_search(hash_pairs, key.hash(), nullptr, HashValueComparator<@value_type@> {}))
+        return @return_statement@;
+    return {};
+}
+)~~~");
+}
+
 template<typename IdentifierFormatter>
 void generate_enum(SourceGenerator& generator, IdentifierFormatter&& format_identifier, StringView name, StringView default_, Vector<String>& values, Vector<Alias> aliases = {})
 {

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -188,7 +188,7 @@ static constexpr size_t MAX_SEARCH_RESULTS = 6;
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio recvfd sendfd rpath cpath unix proc exec thread", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd rpath cpath unix proc exec thread prot_exec", nullptr) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TRY(Core::System::pledge("stdio recvfd sendfd unix cpath rpath wpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd unix cpath rpath wpath prot_exec"));
 
     const char* specified_url = nullptr;
 
@@ -63,6 +63,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/request", "rw"));
+    TRY(Core::System::unveil("/usr/lib/libunicodedata.so.serenity", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = GUI::Icon::default_icon("app-browser");

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -20,14 +20,14 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath unix cpath wpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath unix cpath wpath prot_exec"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/FontEditor.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath prot_exec"));
 
     char const* path = nullptr;
     Core::ArgsParser args_parser;

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -22,7 +22,7 @@
 
 int main(int argc, char* argv[])
 {
-    if (pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread", nullptr) < 0) {
+    if (pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread prot_exec", nullptr) < 0) {
         perror("pledge");
         return 1;
     }
@@ -65,6 +65,11 @@ int main(int argc, char* argv[])
     }
 
     if (unveil("/res", "r") < 0) {
+        perror("unveil");
+        return 1;
+    }
+
+    if (unveil("/usr/lib/libunicodedata.so.serenity", "r") < 0) {
         perror("unveil");
         return 1;
     }

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -18,7 +18,7 @@ using namespace TextEditor;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix"));
+    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix prot_exec"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -35,6 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil("/usr/lib/libunicodedata.so.serenity", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     StringView preview_mode_view = preview_mode;

--- a/Userland/Libraries/LibUnicode/CMakeLists.txt
+++ b/Userland/Libraries/LibUnicode/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     DateTimeFormat.cpp
     Locale.cpp
     NumberFormat.cpp
+    UnicodeSymbols.cpp
 )
 
 serenity_lib(LibUnicode unicode)

--- a/Userland/Libraries/LibUnicode/CMakeLists.txt
+++ b/Userland/Libraries/LibUnicode/CMakeLists.txt
@@ -21,5 +21,5 @@ target_link_libraries(LibUnicode LibCore)
 target_compile_definitions(LibUnicode PRIVATE ENABLE_UNICODE_DATA=$<BOOL:${ENABLE_UNICODE_DATABASE_DOWNLOAD}>)
 
 if (DEFINED UNICODE_DATA_SOURCES)
-    target_link_libraries(LibUnicode LibUnicodeData)
+    add_dependencies(LibUnicode LibUnicodeData)
 endif()

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -8,10 +8,7 @@
 #include <AK/StringBuilder.h>
 #include <LibUnicode/DateTimeFormat.h>
 #include <LibUnicode/Locale.h>
-
-#if ENABLE_UNICODE_DATA
-#    include <LibUnicode/UnicodeDateTimeFormat.h>
-#endif
+#include <LibUnicode/UnicodeSymbols.h>
 
 namespace Unicode {
 
@@ -78,17 +75,14 @@ StringView calendar_pattern_style_to_string(CalendarPatternStyle style)
 }
 
 // https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table
-Vector<Unicode::HourCycle> get_regional_hour_cycles([[maybe_unused]] StringView locale)
+Vector<Unicode::HourCycle> get_regional_hour_cycles(StringView locale)
 {
-#if ENABLE_UNICODE_DATA
-    if (auto hour_cycles = Detail::get_regional_hour_cycles(locale); !hour_cycles.is_empty())
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+
+    if (auto hour_cycles = symbols.get_regional_hour_cycles(locale); !hour_cycles.is_empty())
         return hour_cycles;
 
-    auto return_default_hour_cycles = []() {
-        auto hour_cycles = Detail::get_regional_hour_cycles("001"sv);
-        VERIFY(!hour_cycles.is_empty());
-        return hour_cycles;
-    };
+    auto return_default_hour_cycles = [&]() { return symbols.get_regional_hour_cycles("001"sv); };
 
     auto language = parse_unicode_language_id(locale);
     if (!language.has_value())
@@ -99,13 +93,10 @@ Vector<Unicode::HourCycle> get_regional_hour_cycles([[maybe_unused]] StringView 
     if (!language.has_value() || !language->region.has_value())
         return return_default_hour_cycles();
 
-    if (auto hour_cycles = Detail::get_regional_hour_cycles(*language->region); !hour_cycles.is_empty())
+    if (auto hour_cycles = symbols.get_regional_hour_cycles(*language->region); !hour_cycles.is_empty())
         return hour_cycles;
 
     return return_default_hour_cycles();
-#else
-    return {};
-#endif
 }
 
 Optional<Unicode::HourCycle> get_default_regional_hour_cycle(StringView locale)
@@ -156,112 +147,80 @@ String combine_skeletons(StringView first, StringView second)
     return builder.build();
 }
 
-Optional<CalendarFormat> get_calendar_format([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarFormatType type)
+Optional<CalendarFormat> get_calendar_format(StringView locale, StringView calendar, CalendarFormatType type)
 {
-#if ENABLE_UNICODE_DATA
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+
     switch (type) {
     case CalendarFormatType::Date:
-        return Detail::get_calendar_date_format(locale, calendar);
+        return symbols.get_calendar_date_format(locale, calendar);
     case CalendarFormatType::Time:
-        return Detail::get_calendar_time_format(locale, calendar);
+        return symbols.get_calendar_time_format(locale, calendar);
     case CalendarFormatType::DateTime:
-        return Detail::get_calendar_date_time_format(locale, calendar);
+        return symbols.get_calendar_date_time_format(locale, calendar);
     default:
         VERIFY_NOT_REACHED();
     }
-#else
-    return {};
-#endif
 }
 
-Vector<CalendarPattern> get_calendar_available_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar)
+Vector<CalendarPattern> get_calendar_available_formats(StringView locale, StringView calendar)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_available_formats(locale, calendar);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_available_formats(locale, calendar);
 }
 
-Optional<Unicode::CalendarRangePattern> get_calendar_default_range_format([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar)
+Optional<Unicode::CalendarRangePattern> get_calendar_default_range_format(StringView locale, StringView calendar)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_default_range_format(locale, calendar);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_default_range_format(locale, calendar);
 }
 
-Vector<Unicode::CalendarRangePattern> get_calendar_range_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] StringView skeleton)
+Vector<Unicode::CalendarRangePattern> get_calendar_range_formats(StringView locale, StringView calendar, StringView skeleton)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_range_formats(locale, calendar, skeleton);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_range_formats(locale, calendar, skeleton);
 }
 
-Vector<Unicode::CalendarRangePattern> get_calendar_range12_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] StringView skeleton)
+Vector<Unicode::CalendarRangePattern> get_calendar_range12_formats(StringView locale, StringView calendar, StringView skeleton)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_range12_formats(locale, calendar, skeleton);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_range12_formats(locale, calendar, skeleton);
 }
 
-Optional<StringView> get_calendar_era_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::Era value)
+Optional<StringView> get_calendar_era_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Era value)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_era_symbol(locale, calendar, style, value);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_era_symbol(locale, calendar, style, value);
 }
 
-Optional<StringView> get_calendar_month_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::Month value)
+Optional<StringView> get_calendar_month_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Month value)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_month_symbol(locale, calendar, style, value);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_month_symbol(locale, calendar, style, value);
 }
 
-Optional<StringView> get_calendar_weekday_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::Weekday value)
+Optional<StringView> get_calendar_weekday_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::Weekday value)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_weekday_symbol(locale, calendar, style, value);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_weekday_symbol(locale, calendar, style, value);
 }
 
-Optional<StringView> get_calendar_day_period_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] Unicode::DayPeriod value)
+Optional<StringView> get_calendar_day_period_symbol(StringView locale, StringView calendar, CalendarPatternStyle style, Unicode::DayPeriod value)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_day_period_symbol(locale, calendar, style, value);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_day_period_symbol(locale, calendar, style, value);
 }
 
-Optional<StringView> get_calendar_day_period_symbol_for_hour([[maybe_unused]] StringView locale, [[maybe_unused]] StringView calendar, [[maybe_unused]] CalendarPatternStyle style, [[maybe_unused]] u8 hour)
+Optional<StringView> get_calendar_day_period_symbol_for_hour(StringView locale, StringView calendar, CalendarPatternStyle style, u8 hour)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_calendar_day_period_symbol_for_hour(locale, calendar, style, hour);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_calendar_day_period_symbol_for_hour(locale, calendar, style, hour);
 }
 
-Optional<StringView> get_time_zone_name([[maybe_unused]] StringView locale, [[maybe_unused]] StringView time_zone, [[maybe_unused]] CalendarPatternStyle style)
+Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone, CalendarPatternStyle style)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_time_zone_name(locale, time_zone, style);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_time_zone_name(locale, time_zone, style);
 }
 
 }

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -10,25 +10,38 @@
 
 namespace Unicode {
 
+enum class Calendar : u8;
 enum class CalendarFormatType : u8;
 enum class CalendarPatternStyle : u8;
+enum class CalendarSymbol : u8;
 enum class CompactNumberFormatType : u8;
 enum class Condition : u8;
+enum class Currency : u16;
+enum class DayPeriod : u8;
+enum class Era : u8;
 enum class GeneralCategory : u8;
 enum class HourCycle : u8;
+enum class HourCycleRegion : u8;
+enum class Key : u8;
 enum class Language : u8;
 enum class ListPatternStyle : u8;
 enum class ListPatternType : u8;
 enum class Locale : u16;
+enum class Month : u8;
+enum class NumericSymbol : u8;
 enum class Property : u8;
 enum class Script : u8;
+enum class ScriptTag : u8;
 enum class StandardNumberFormatType : u8;
 enum class Style : u8;
 enum class Territory : u8;
+enum class TimeZone : u8;
+enum class Weekday : u8;
 enum class WordBreakProperty : u8;
 
 struct CalendarFormat;
 struct CalendarPattern;
+struct CalendarRangePattern;
 struct CurrencyCode;
 struct Keyword;
 struct LanguageID;

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -147,7 +147,7 @@ Optional<StringView> get_locale_territory_mapping(StringView locale, StringView 
 Optional<StringView> get_locale_script_mapping(StringView locale, StringView script);
 Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency, Style style);
 Vector<StringView> get_locale_key_mapping(StringView locale, StringView keyword);
-Optional<StringView> get_number_system_symbol(StringView locale, StringView system, StringView symbol);
+
 Optional<ListPatterns> get_locale_list_patterns(StringView locale, StringView type, StringView style);
 
 Optional<StringView> resolve_language_alias(StringView language);

--- a/Userland/Libraries/LibUnicode/NumberFormat.cpp
+++ b/Userland/Libraries/LibUnicode/NumberFormat.cpp
@@ -8,57 +8,42 @@
 #include <LibUnicode/CharacterTypes.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/NumberFormat.h>
+#include <LibUnicode/UnicodeSymbols.h>
 
 #if ENABLE_UNICODE_DATA
 #    include <LibUnicode/UnicodeData.h>
-#    include <LibUnicode/UnicodeNumberFormat.h>
 #endif
 
 namespace Unicode {
 
-Optional<StringView> get_number_system_symbol([[maybe_unused]] StringView locale, [[maybe_unused]] StringView system, [[maybe_unused]] NumericSymbol symbol)
+Optional<StringView> get_number_system_symbol(StringView locale, StringView system, NumericSymbol symbol)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_number_system_symbol(locale, system, symbol);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_number_system_symbol(locale, system, symbol);
 }
 
-Optional<NumberGroupings> get_number_system_groupings([[maybe_unused]] StringView locale, [[maybe_unused]] StringView system)
+Optional<NumberGroupings> get_number_system_groupings(StringView locale, StringView system)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_number_system_groupings(locale, system);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_number_system_groupings(locale, system);
 }
 
-Optional<NumberFormat> get_standard_number_system_format([[maybe_unused]] StringView locale, [[maybe_unused]] StringView system, [[maybe_unused]] StandardNumberFormatType type)
+Optional<NumberFormat> get_standard_number_system_format(StringView locale, StringView system, StandardNumberFormatType type)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_standard_number_system_format(locale, system, type);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_standard_number_system_format(locale, system, type);
 }
 
-Vector<NumberFormat> get_compact_number_system_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView system, [[maybe_unused]] CompactNumberFormatType type)
+Vector<NumberFormat> get_compact_number_system_formats(StringView locale, StringView system, CompactNumberFormatType type)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_compact_number_system_formats(locale, system, type);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_compact_number_system_formats(locale, system, type);
 }
 
-Vector<NumberFormat> get_unit_formats([[maybe_unused]] StringView locale, [[maybe_unused]] StringView unit, [[maybe_unused]] Style style)
+Vector<NumberFormat> get_unit_formats(StringView locale, StringView unit, Style style)
 {
-#if ENABLE_UNICODE_DATA
-    return Detail::get_unit_formats(locale, unit, style);
-#else
-    return {};
-#endif
+    static auto const& symbols = Detail::Symbols::ensure_loaded();
+    return symbols.get_unit_formats(locale, unit, style);
 }
 
 Optional<NumberFormat> select_pattern_with_plurality(Vector<NumberFormat> const& formats, double number)

--- a/Userland/Libraries/LibUnicode/UnicodeSymbols.cpp
+++ b/Userland/Libraries/LibUnicode/UnicodeSymbols.cpp
@@ -15,6 +15,7 @@
 #    endif
 #else
 #    include <AK/Function.h>
+#    include <LibUnicode/Locale.h>
 #endif
 
 namespace Unicode::Detail {
@@ -28,7 +29,10 @@ template<typename ReturnType, typename... ParameterTypes>
 struct FunctionStub<Function<ReturnType(ParameterTypes...)>> {
     static constexpr auto make_stub()
     {
-        return [](ParameterTypes...) -> ReturnType { return {}; };
+        if constexpr (IsVoid<ReturnType>)
+            return [](ParameterTypes...) {};
+        else
+            return [](ParameterTypes...) -> ReturnType { return {}; };
     }
 };
 
@@ -86,6 +90,25 @@ Symbols const& Symbols::ensure_loaded()
     load_symbol(symbols.script_from_string, "unicode_script_from_string");
     load_symbol(symbols.code_point_has_script, "unicode_code_point_has_script");
     load_symbol(symbols.code_point_has_script_extension, "unicode_code_point_has_script_extension");
+
+    load_symbol(symbols.locale_from_string, "unicode_locale_from_string");
+    load_symbol(symbols.get_locale_language_mapping, "unicode_get_locale_language_mapping");
+    load_symbol(symbols.get_locale_territory_mapping, "unicode_get_locale_territory_mapping");
+    load_symbol(symbols.get_locale_script_tag_mapping, "unicode_get_locale_script_tag_mapping");
+    load_symbol(symbols.get_locale_long_currency_mapping, "unicode_get_locale_long_currency_mapping");
+    load_symbol(symbols.get_locale_short_currency_mapping, "unicode_get_locale_short_currency_mapping");
+    load_symbol(symbols.get_locale_narrow_currency_mapping, "unicode_get_locale_narrow_currency_mapping");
+    load_symbol(symbols.get_locale_numeric_currency_mapping, "unicode_get_locale_numeric_currency_mapping");
+    load_symbol(symbols.get_locale_key_mapping, "unicode_get_locale_key_mapping");
+    load_symbol(symbols.get_locale_list_pattern_mapping, "unicode_get_locale_list_pattern_mapping");
+    load_symbol(symbols.resolve_language_alias, "unicode_resolve_language_alias");
+    load_symbol(symbols.resolve_territory_alias, "unicode_resolve_territory_alias");
+    load_symbol(symbols.resolve_script_tag_alias, "unicode_resolve_script_tag_alias");
+    load_symbol(symbols.resolve_variant_alias, "unicode_resolve_variant_alias");
+    load_symbol(symbols.resolve_subdivision_alias, "unicode_resolve_subdivision_alias");
+    load_symbol(symbols.resolve_complex_language_aliases, "unicode_resolve_complex_language_aliases");
+    load_symbol(symbols.add_likely_subtags, "unicode_add_likely_subtags");
+    load_symbol(symbols.resolve_most_likely_territory, "unicode_resolve_most_likely_territory");
 
     initialized = true;
     return symbols;

--- a/Userland/Libraries/LibUnicode/UnicodeSymbols.cpp
+++ b/Userland/Libraries/LibUnicode/UnicodeSymbols.cpp
@@ -16,6 +16,7 @@
 #else
 #    include <AK/Function.h>
 #    include <LibUnicode/Locale.h>
+#    include <LibUnicode/NumberFormat.h>
 #endif
 
 namespace Unicode::Detail {
@@ -109,6 +110,12 @@ Symbols const& Symbols::ensure_loaded()
     load_symbol(symbols.resolve_complex_language_aliases, "unicode_resolve_complex_language_aliases");
     load_symbol(symbols.add_likely_subtags, "unicode_add_likely_subtags");
     load_symbol(symbols.resolve_most_likely_territory, "unicode_resolve_most_likely_territory");
+
+    load_symbol(symbols.get_number_system_symbol, "unicode_get_number_system_symbol");
+    load_symbol(symbols.get_number_system_groupings, "unicode_get_number_system_groupings");
+    load_symbol(symbols.get_standard_number_system_format, "unicode_get_standard_number_system_format");
+    load_symbol(symbols.get_compact_number_system_formats, "unicode_get_compact_number_system_formats");
+    load_symbol(symbols.get_unit_formats, "unicode_get_unit_formats");
 
     initialized = true;
     return symbols;

--- a/Userland/Libraries/LibUnicode/UnicodeSymbols.cpp
+++ b/Userland/Libraries/LibUnicode/UnicodeSymbols.cpp
@@ -15,6 +15,7 @@
 #    endif
 #else
 #    include <AK/Function.h>
+#    include <LibUnicode/DateTimeFormat.h>
 #    include <LibUnicode/Locale.h>
 #    include <LibUnicode/NumberFormat.h>
 #endif
@@ -116,6 +117,21 @@ Symbols const& Symbols::ensure_loaded()
     load_symbol(symbols.get_standard_number_system_format, "unicode_get_standard_number_system_format");
     load_symbol(symbols.get_compact_number_system_formats, "unicode_get_compact_number_system_formats");
     load_symbol(symbols.get_unit_formats, "unicode_get_unit_formats");
+
+    load_symbol(symbols.get_regional_hour_cycles, "unicode_get_regional_hour_cycles");
+    load_symbol(symbols.get_calendar_date_format, "unicode_get_calendar_date_format");
+    load_symbol(symbols.get_calendar_time_format, "unicode_get_calendar_time_format");
+    load_symbol(symbols.get_calendar_date_time_format, "unicode_get_calendar_date_time_format");
+    load_symbol(symbols.get_calendar_available_formats, "unicode_get_calendar_available_formats");
+    load_symbol(symbols.get_calendar_default_range_format, "unicode_get_calendar_default_range_format");
+    load_symbol(symbols.get_calendar_range_formats, "unicode_get_calendar_range_formats");
+    load_symbol(symbols.get_calendar_range12_formats, "unicode_get_calendar_range12_formats");
+    load_symbol(symbols.get_calendar_era_symbol, "unicode_get_calendar_era_symbol");
+    load_symbol(symbols.get_calendar_month_symbol, "unicode_get_calendar_month_symbol");
+    load_symbol(symbols.get_calendar_weekday_symbol, "unicode_get_calendar_weekday_symbol");
+    load_symbol(symbols.get_calendar_day_period_symbol, "unicode_get_calendar_day_period_symbol");
+    load_symbol(symbols.get_calendar_day_period_symbol_for_hour, "unicode_get_calendar_day_period_symbol_for_hour");
+    load_symbol(symbols.get_time_zone_name, "unicode_get_time_zone_name");
 
     initialized = true;
     return symbols;

--- a/Userland/Libraries/LibUnicode/UnicodeSymbols.cpp
+++ b/Userland/Libraries/LibUnicode/UnicodeSymbols.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibUnicode/UnicodeSymbols.h>
+
+#if ENABLE_UNICODE_DATA
+#    if defined(__serenity__)
+#        include <LibDl/dlfcn.h>
+#        include <LibDl/dlfcn_integration.h>
+#    else
+#        include <dlfcn.h>
+#    endif
+#else
+#    include <AK/Function.h>
+#endif
+
+namespace Unicode::Detail {
+
+#if !ENABLE_UNICODE_DATA
+
+template<typename T>
+struct FunctionStub;
+
+template<typename ReturnType, typename... ParameterTypes>
+struct FunctionStub<Function<ReturnType(ParameterTypes...)>> {
+    static constexpr auto make_stub()
+    {
+        return [](ParameterTypes...) -> ReturnType { return {}; };
+    }
+};
+
+#endif
+
+// This loader supports 3 modes:
+//
+// 1. When the Unicode data generators are enabled, and the target is Serenity, the symbols are
+//    dynamically loaded from the shared library containing them.
+//
+// 2. When the Unicode data generators are enabled, and the target is Lagom, the symbols are
+//    dynamically loaded from the main program.
+//
+// 3. When the Unicode data generators are disabled, the symbols are stubbed out to empty lambdas.
+//    This allows callers to remain agnostic as to whether the generators are enabled.
+Symbols const& Symbols::ensure_loaded()
+{
+    static Symbols symbols {};
+
+    static bool initialized = false;
+    if (initialized)
+        return symbols;
+
+#if ENABLE_UNICODE_DATA
+#    if defined(__serenity__)
+    static void* libunicodedata = MUST(__dlopen("libunicodedata.so.serenity", RTLD_NOW));
+
+    auto load_symbol = [&]<typename T>(T& dest, char const* name) {
+        dest = reinterpret_cast<T>(MUST(__dlsym(libunicodedata, name)));
+    };
+#    else
+    static void* libunicodedata = dlopen(nullptr, RTLD_NOW);
+    VERIFY(libunicodedata);
+
+    auto load_symbol = [&]<typename T>(T& dest, char const* name) {
+        dest = reinterpret_cast<T>(dlsym(libunicodedata, name));
+        VERIFY(dest);
+    };
+#    endif
+#else
+    auto load_symbol = []<typename T>(T& dest, char const*) {
+        dest = +FunctionStub<Function<RemovePointer<T>>>::make_stub();
+    };
+#endif
+
+    load_symbol(symbols.code_point_display_name, "unicode_code_point_display_name");
+    load_symbol(symbols.canonical_combining_class, "unicode_canonical_combining_class");
+    load_symbol(symbols.simple_uppercase_mapping, "unicode_simple_uppercase_mapping");
+    load_symbol(symbols.simple_lowercase_mapping, "unicode_simple_lowercase_mapping");
+    load_symbol(symbols.special_case_mapping, "unicode_special_case_mapping");
+    load_symbol(symbols.general_category_from_string, "unicode_general_category_from_string");
+    load_symbol(symbols.code_point_has_general_category, "unicode_code_point_has_general_category");
+    load_symbol(symbols.property_from_string, "unicode_property_from_string");
+    load_symbol(symbols.code_point_has_property, "unicode_code_point_has_property");
+    load_symbol(symbols.script_from_string, "unicode_script_from_string");
+    load_symbol(symbols.code_point_has_script, "unicode_code_point_has_script");
+    load_symbol(symbols.code_point_has_script_extension, "unicode_code_point_has_script_extension");
+
+    initialized = true;
+    return symbols;
+}
+
+}

--- a/Userland/Libraries/LibUnicode/UnicodeSymbols.h
+++ b/Userland/Libraries/LibUnicode/UnicodeSymbols.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Optional.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+#include <LibUnicode/Forward.h>
+
+namespace Unicode::Detail {
+
+struct Symbols {
+    static Symbols const& ensure_loaded();
+
+    // Loaded from UnicodeData.cpp:
+
+    Optional<String> (*code_point_display_name)(u32) { nullptr };
+
+    u32 (*canonical_combining_class)(u32 code_point) { nullptr };
+
+    u32 (*simple_uppercase_mapping)(u32) { nullptr };
+    u32 (*simple_lowercase_mapping)(u32) { nullptr };
+    Span<SpecialCasing const* const> (*special_case_mapping)(u32 code_point) { nullptr };
+
+    Optional<GeneralCategory> (*general_category_from_string)(StringView) { nullptr };
+    bool (*code_point_has_general_category)(u32, GeneralCategory) { nullptr };
+
+    Optional<Property> (*property_from_string)(StringView) { nullptr };
+    bool (*code_point_has_property)(u32, Property) { nullptr };
+
+    Optional<Script> (*script_from_string)(StringView) { nullptr };
+    bool (*code_point_has_script)(u32, Script) { nullptr };
+    bool (*code_point_has_script_extension)(u32, Script) { nullptr };
+
+private:
+    Symbols() = default;
+};
+
+}

--- a/Userland/Libraries/LibUnicode/UnicodeSymbols.h
+++ b/Userland/Libraries/LibUnicode/UnicodeSymbols.h
@@ -10,6 +10,7 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 #include <LibUnicode/Forward.h>
 
 namespace Unicode::Detail {
@@ -36,6 +37,32 @@ struct Symbols {
     Optional<Script> (*script_from_string)(StringView) { nullptr };
     bool (*code_point_has_script)(u32, Script) { nullptr };
     bool (*code_point_has_script_extension)(u32, Script) { nullptr };
+
+    // Loaded from UnicodeLocale.cpp:
+
+    Optional<Locale> (*locale_from_string)(StringView) { nullptr };
+
+    Optional<StringView> (*get_locale_language_mapping)(StringView, StringView) { nullptr };
+    Optional<StringView> (*get_locale_territory_mapping)(StringView, StringView) { nullptr };
+    Optional<StringView> (*get_locale_script_tag_mapping)(StringView, StringView) { nullptr };
+    Optional<StringView> (*get_locale_long_currency_mapping)(StringView, StringView) { nullptr };
+    Optional<StringView> (*get_locale_short_currency_mapping)(StringView, StringView) { nullptr };
+    Optional<StringView> (*get_locale_narrow_currency_mapping)(StringView, StringView) { nullptr };
+    Optional<StringView> (*get_locale_numeric_currency_mapping)(StringView, StringView) { nullptr };
+    Optional<StringView> (*get_locale_key_mapping)(StringView, StringView) { nullptr };
+
+    Optional<ListPatterns> (*get_locale_list_pattern_mapping)(StringView, StringView, StringView) { nullptr };
+
+    Optional<StringView> (*resolve_language_alias)(StringView) { nullptr };
+    Optional<StringView> (*resolve_territory_alias)(StringView) { nullptr };
+    Optional<StringView> (*resolve_script_tag_alias)(StringView) { nullptr };
+    Optional<StringView> (*resolve_variant_alias)(StringView) { nullptr };
+    Optional<StringView> (*resolve_subdivision_alias)(StringView) { nullptr };
+
+    void (*resolve_complex_language_aliases)(LanguageID&);
+
+    Optional<LanguageID> (*add_likely_subtags)(LanguageID const&);
+    Optional<String> (*resolve_most_likely_territory)(LanguageID const&);
 
 private:
     Symbols() = default;

--- a/Userland/Libraries/LibUnicode/UnicodeSymbols.h
+++ b/Userland/Libraries/LibUnicode/UnicodeSymbols.h
@@ -64,6 +64,14 @@ struct Symbols {
     Optional<LanguageID> (*add_likely_subtags)(LanguageID const&);
     Optional<String> (*resolve_most_likely_territory)(LanguageID const&);
 
+    // Loaded from UnicodeNumberFormat.cpp:
+
+    Optional<StringView> (*get_number_system_symbol)(StringView, StringView, NumericSymbol);
+    Optional<NumberGroupings> (*get_number_system_groupings)(StringView, StringView);
+    Optional<NumberFormat> (*get_standard_number_system_format)(StringView, StringView, StandardNumberFormatType);
+    Vector<NumberFormat> (*get_compact_number_system_formats)(StringView, StringView, CompactNumberFormatType);
+    Vector<NumberFormat> (*get_unit_formats)(StringView, StringView, Style);
+
 private:
     Symbols() = default;
 };

--- a/Userland/Libraries/LibUnicode/UnicodeSymbols.h
+++ b/Userland/Libraries/LibUnicode/UnicodeSymbols.h
@@ -72,6 +72,27 @@ struct Symbols {
     Vector<NumberFormat> (*get_compact_number_system_formats)(StringView, StringView, CompactNumberFormatType);
     Vector<NumberFormat> (*get_unit_formats)(StringView, StringView, Style);
 
+    // Loaded from UnicodeDateTimeFormat.cpp:
+
+    Vector<HourCycle> (*get_regional_hour_cycles)(StringView) { nullptr };
+
+    Optional<CalendarFormat> (*get_calendar_date_format)(StringView, StringView) { nullptr };
+    Optional<CalendarFormat> (*get_calendar_time_format)(StringView, StringView) { nullptr };
+    Optional<CalendarFormat> (*get_calendar_date_time_format)(StringView, StringView) { nullptr };
+    Vector<CalendarPattern> (*get_calendar_available_formats)(StringView, StringView) { nullptr };
+
+    Optional<CalendarRangePattern> (*get_calendar_default_range_format)(StringView, StringView) { nullptr };
+    Vector<CalendarRangePattern> (*get_calendar_range_formats)(StringView, StringView, StringView) { nullptr };
+    Vector<CalendarRangePattern> (*get_calendar_range12_formats)(StringView, StringView, StringView) { nullptr };
+
+    Optional<StringView> (*get_calendar_era_symbol)(StringView, StringView, CalendarPatternStyle, Era) { nullptr };
+    Optional<StringView> (*get_calendar_month_symbol)(StringView, StringView, CalendarPatternStyle, Month) { nullptr };
+    Optional<StringView> (*get_calendar_weekday_symbol)(StringView, StringView, CalendarPatternStyle, Weekday) { nullptr };
+    Optional<StringView> (*get_calendar_day_period_symbol)(StringView, StringView, CalendarPatternStyle, DayPeriod) { nullptr };
+    Optional<StringView> (*get_calendar_day_period_symbol_for_hour)(StringView, StringView, CalendarPatternStyle, u8) { nullptr };
+
+    Optional<StringView> (*get_time_zone_name)(StringView, StringView, CalendarPatternStyle) { nullptr };
+
 private:
     Symbols() = default;
 };

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -14,11 +14,12 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
-    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath"));
+    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath prot_exec"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/request", "rw"));
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/portal/websocket", "rw"));
+    TRY(Core::System::unveil("/usr/lib/libunicodedata.so.serenity", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<WebContent::ClientConnection>());

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1207,7 +1207,7 @@ public:
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
 #ifdef __serenity__
-    TRY(Core::System::pledge("stdio rpath wpath cpath tty sigaction"));
+    TRY(Core::System::pledge("stdio rpath wpath cpath tty sigaction prot_exec"));
 #endif
 
     bool gc_on_every_allocation = false;


### PR DESCRIPTION
Loading the generated Unicode data is not free. On my system, I've measured LibElf taking upwards of 1.5 seconds to map and link libunicodedata.so. Nearly every application on the system indirectly depends on Unicode by way of LibRegex, so this cost can be quite heavy.

This change reduces this cost by deferring loading of libunicodedata.so until it is needed with `dlopen`.

As a quick measurement on boot impact, the time to reach this log point at the end of booting:
```
ResourceGraph.Applet(29:29): Create applet: 1 with spec 'MemoryGraph,#00bbbb'
```
Decreased from 3.509s to 2.817s on my system.