### PR TITLE
Fix a bunch of trivial things

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -1560,6 +1560,7 @@ static void generate_unicode_locale_implementation(Core::File& file, UnicodeLoca
     generator.set("calendar_symbols_list_index_type"sv, s_calendar_symbols_list_index_type);
     generator.set("calendar_index_type"sv, s_calendar_index_type);
     generator.set("time_zone_index_type"sv, s_time_zone_index_type);
+    generator.set("time_zone_list_index_type"sv, s_time_zone_list_index_type);
     generator.set("day_period_index_type"sv, s_day_period_index_type);
     generator.set("day_period_list_index_type"sv, s_day_period_list_index_type);
 

--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -33,9 +33,3 @@ void __assertion_failed(const char* msg)
     abort();
 }
 }
-
-void _abort()
-{
-    asm volatile("ud2");
-    __builtin_unreachable();
-}

--- a/Userland/Libraries/LibC/assert.cpp
+++ b/Userland/Libraries/LibC/assert.cpp
@@ -16,7 +16,7 @@
 extern "C" {
 
 extern bool __stdio_is_initialized;
-#ifndef NDEBUG
+
 void __assertion_failed(const char* msg)
 {
     if (__heap_is_stable) {
@@ -32,7 +32,6 @@ void __assertion_failed(const char* msg)
     syscall(SC_set_coredump_metadata, &params);
     abort();
 }
-#endif
 }
 
 void _abort()

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -21,7 +21,6 @@ __attribute__((noreturn)) void __assertion_failed(const char* msg);
 
 #else
 #    define assert(expr) ((void)(0))
-#    define VERIFY_NOT_REACHED() _abort()
 #endif
 
 __attribute__((noreturn)) void _abort();

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -23,8 +23,6 @@ __attribute__((noreturn)) void __assertion_failed(const char* msg);
 #    define assert(expr) ((void)(0))
 #endif
 
-__attribute__((noreturn)) void _abort();
-
 #ifndef __cplusplus
 #    define static_assert _Static_assert
 #endif

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -209,6 +209,12 @@ int atexit(void (*handler)())
     return __cxa_atexit(__atexit_to_cxa_atexit, (void*)handler, nullptr);
 }
 
+void _abort()
+{
+    asm volatile("ud2");
+    __builtin_unreachable();
+}
+
 void abort()
 {
     // For starters, send ourselves a SIGABRT.

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -16,6 +16,8 @@ __BEGIN_DECLS
 #define EXIT_FAILURE 1
 #define MB_CUR_MAX 4
 
+__attribute__((noreturn)) void _abort();
+
 __attribute__((malloc)) __attribute__((alloc_size(1))) void* malloc(size_t);
 __attribute__((malloc)) __attribute__((alloc_size(1, 2))) void* calloc(size_t nmemb, size_t);
 size_t malloc_size(void*);

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -10,8 +10,6 @@
 #include <sys/cdefs.h>
 #include <sys/types.h>
 
-__attribute__((warn_unused_result)) int __generate_unique_filename(char* pattern);
-
 __BEGIN_DECLS
 
 #define EXIT_SUCCESS 0


### PR DESCRIPTION
The following patch removes a bunch of trivial errors:
- Remove `__generate_unique_filename` declration without definition.
- Make `__assertion_failed` always defined so `<assert.h>` users can use it in userland, regardless of how serenity was compiled with or without NDEBUG.
- Remove `VERIFY_NOT_REACHED()` from `<assert.h>` since it would produce an error when used with `AK/Assertions.h` with `NDEBUG` set.
- Move `_abort` next to `abort` in LibC.
- Add missing binding to `time_zone_list_index_type` in the LibUnicode generator.