### PR TITLE
LibAudio: Optimize the FLAC loader, again

### DIFF
--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -57,15 +57,13 @@ public:
         auto nread = buffer().trim(m_buffered).copy_trimmed_to(bytes);
 
         m_buffered -= nread;
-        buffer().slice(nread, m_buffered).copy_to(buffer());
+        if (m_buffered > 0)
+            buffer().slice(nread, m_buffered).copy_to(buffer());
 
         if (nread < bytes.size()) {
+            nread += m_stream.read(bytes.slice(nread));
+
             m_buffered = m_stream.read(buffer());
-
-            if (m_buffered == 0)
-                return nread;
-
-            nread += read(bytes.slice(nread));
         }
 
         return nread;

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -37,7 +37,10 @@ public:
             return 0;
 
         if constexpr (Traits<T>::is_trivial()) {
-            __builtin_memmove(destination, source, count * sizeof(T));
+            if (count == 1)
+                *destination = *source;
+            else
+                __builtin_memmove(destination, source, count * sizeof(T));
             return count;
         }
 

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -610,7 +610,6 @@ ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_custom_lpc(FlacSubfra
 
     dbgln_if(AFLACLOADER_DEBUG, "{}-bit {} shift coefficients: {}", lpc_precision, lpc_shift, coefficients);
 
-    // decode residual
     decoded = TRY(decode_residual(decoded, subframe, bit_input));
 
     // approximate the waveform with the predictor

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -610,7 +610,7 @@ ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_custom_lpc(FlacSubfra
 
     dbgln_if(AFLACLOADER_DEBUG, "{}-bit {} shift coefficients: {}", lpc_precision, lpc_shift, coefficients);
 
-    decoded = TRY(decode_residual(decoded, subframe, bit_input));
+    TRY(decode_residual(decoded, subframe, bit_input));
 
     // approximate the waveform with the predictor
     for (size_t i = subframe.order; i < m_current_frame->sample_count; ++i) {
@@ -680,7 +680,7 @@ ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_fixed_lpc(FlacSubfram
 }
 
 // Decode the residual, the "error" between the function approximation and the actual audio data
-ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, InputBitStream& bit_input)
+MaybeLoaderError FlacLoaderPlugin::decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, InputBitStream& bit_input)
 {
     u8 residual_mode = static_cast<u8>(bit_input.read_bits_big_endian(2));
     u8 partition_order = static_cast<u8>(bit_input.read_bits_big_endian(4));
@@ -701,7 +701,7 @@ ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_residual(Vector<i32>&
     } else
         return LoaderError { LoaderError::Category::Format, static_cast<size_t>(m_current_sample_or_frame), "Reserved residual coding method" };
 
-    return decoded;
+    return {};
 }
 
 // Decode a single Rice partition as part of the residual, every partition can have its own Rice parameter k

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -121,7 +121,7 @@ private:
     ErrorOr<Vector<i32>, LoaderError> decode_fixed_lpc(FlacSubframeHeader& subframe, InputBitStream& bit_input);
     ErrorOr<Vector<i32>, LoaderError> decode_verbatim(FlacSubframeHeader& subframe, InputBitStream& bit_input);
     ErrorOr<Vector<i32>, LoaderError> decode_custom_lpc(FlacSubframeHeader& subframe, InputBitStream& bit_input);
-    ErrorOr<Vector<i32>, LoaderError> decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, InputBitStream& bit_input);
+    MaybeLoaderError decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, InputBitStream& bit_input);
     // decode a single rice partition that has its own rice parameter
     ALWAYS_INLINE Vector<i32> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, InputBitStream& bit_input);
 


### PR DESCRIPTION
These are minor improvements to FlacLoader and some of the other libraries it directly uses. It mainly comes down to avoiding unnecessary copies, although more can definitely be done in the future.

The first commit (fc564ff4d4f2ec6964395330657619002c6a73f6) introduces an adjustable buffer size to FlacLoader, which may be tuned further to find the best-performing buffer size.

On some files, speedup, as measured by abench, is about +100%.

For reference: here's an approximation of how FlacLoader spends its time, based on multiple profiles:
* memcpy+memmove: 22%
* Waiting for the Kernel to read data: 46%
* Virtual function overhead for Buffered::has_any_error(): 8%
* Decoding and other work: everything else, about 24%