### PR TITLE
LibCore+Userland: Make IODevice::write return ErrorOr<void>

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -630,7 +630,7 @@ Optional<Script> script_from_string(StringView script);
 }
 )~~~");
 
-    VERIFY(file.write(generator.as_string_view()));
+    MUST(file.write(generator.as_string_view()));
 }
 
 static void generate_unicode_data_implementation(Core::File& file, UnicodeData const& unicode_data)
@@ -960,7 +960,7 @@ bool code_point_has_@enum_snake@(u32 code_point, @enum_title@ @enum_snake@)
 }
 )~~~");
 
-    VERIFY(file.write(generator.as_string_view()));
+    MUST(file.write(generator.as_string_view()));
 }
 
 static Vector<u32> flatten_code_point_ranges(Vector<CodePointRange> const& code_points)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -1542,7 +1542,7 @@ Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone,
 }
 )~~~");
 
-    VERIFY(file.write(generator.as_string_view()));
+    MUST(file.write(generator.as_string_view()));
 }
 
 static void generate_unicode_locale_implementation(Core::File& file, UnicodeLocaleData& locale_data)
@@ -2069,7 +2069,7 @@ Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone,
 }
 )~~~");
 
-    VERIFY(file.write(generator.as_string_view()));
+    MUST(file.write(generator.as_string_view()));
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
@@ -790,7 +790,7 @@ Optional<String> resolve_most_likely_territory(Unicode::LanguageID const& langua
 }
 )~~~");
 
-    VERIFY(file.write(generator.as_string_view()));
+    MUST(file.write(generator.as_string_view()));
 }
 
 static void generate_unicode_locale_implementation(Core::File& file, UnicodeLocaleData& locale_data)
@@ -1253,7 +1253,7 @@ Optional<String> resolve_most_likely_territory(Unicode::LanguageID const& langua
 }
 )~~~");
 
-    VERIFY(file.write(generator.as_string_view()));
+    MUST(file.write(generator.as_string_view()));
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
@@ -739,7 +739,7 @@ Optional<NumericSymbol> numeric_symbol_from_string(StringView numeric_symbol);
 }
 )~~~");
 
-    VERIFY(file.write(generator.as_string_view()));
+    MUST(file.write(generator.as_string_view()));
 }
 
 static void generate_unicode_locale_implementation(Core::File& file, UnicodeLocaleData& locale_data)
@@ -1004,7 +1004,7 @@ Vector<Unicode::NumberFormat> get_unit_formats(StringView locale, StringView uni
 }
 )~~~");
 
-    VERIFY(file.write(generator.as_string_view()));
+    MUST(file.write(generator.as_string_view()));
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)

--- a/Tests/LibCore/TestLibCoreIODevice.cpp
+++ b/Tests/LibCore/TestLibCoreIODevice.cpp
@@ -29,8 +29,8 @@ TEST_CASE(file_readline)
     auto outfile_or_error = Core::File::open(output_path, Core::OpenMode::WriteOnly);
     auto outputfile = outfile_or_error.release_value();
     while (file->can_read_line()) {
-        outputfile->write(file->read_line());
-        outputfile->write("\n");
+        MUST(outputfile->write(file->read_line()));
+        MUST(outputfile->write("\n"));
     }
     file->close();
     outputfile->close();
@@ -81,10 +81,12 @@ TEST_CASE(file_lines_range)
     auto output_path = "/tmp/output.txt";
     auto outfile_or_error = Core::File::open(output_path, Core::OpenMode::WriteOnly);
     auto outputfile = outfile_or_error.release_value();
+    StringBuilder builder;
     for (auto line : file->lines()) {
-        outputfile->write(line);
-        outputfile->write("\n");
+        builder.append(line);
+        builder.append("\n");
     }
+    MUST(outputfile->write(builder.build()));
     file->close();
     outputfile->close();
     VERIFY(files_have_same_contents(path, output_path));

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -295,7 +295,7 @@ TEST_CASE(local_socket_read)
     EXPECT(local_server->listen("/tmp/test-socket"));
 
     local_server->on_accept = [&](NonnullRefPtr<Core::LocalSocket> server_socket) {
-        EXPECT(server_socket->write(sent_data));
+        EXPECT(!server_socket->write(sent_data).is_error());
 
         event_loop.quit(0);
         event_loop.pump();

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -203,8 +203,8 @@ void KeyboardMapperWidget::save_to_file(StringView filename)
         return;
     }
 
-    bool result = file->write(file_content);
-    if (!result) {
+    auto result = file->write(file_content);
+    if (result.is_error()) {
         int error_number = errno;
         StringBuilder sb;
         sb.append("Unable to save file. Error: ");

--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -54,7 +54,7 @@ void AudioPlayerLoop::enqueue_audio()
         m_track_manager.set_should_loop(false);
         do {
             m_track_manager.fill_buffer(m_buffer);
-            m_wav_writer.write_samples(reinterpret_cast<u8*>(m_buffer.data()), buffer_size);
+            MUST(m_wav_writer.write_samples(reinterpret_cast<u8*>(m_buffer.data()), buffer_size));
         } while (m_track_manager.time());
         m_track_manager.reset();
         m_track_manager.set_should_loop(true);

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -144,8 +144,8 @@ ErrorOr<void> Image::write_to_file(const String& file_path) const
     json.finish();
 
     auto file = TRY(Core::File::open(file_path, (Core::OpenMode)(Core::OpenMode::WriteOnly | Core::OpenMode::Truncate)));
-    if (!file->write(builder.string_view()))
-        return Error::from_errno(file->error());
+    TRY(file->write(builder.string_view()));
+
     return {};
 }
 
@@ -188,8 +188,7 @@ ErrorOr<void> Image::export_bmp_to_fd_and_close(int fd, bool preserve_alpha_chan
     Gfx::BMPWriter dumper;
     auto encoded_data = dumper.dump(bitmap);
 
-    if (!file->write(encoded_data.data(), encoded_data.size()))
-        return Error::from_errno(file->error());
+    TRY(file->write(encoded_data.data(), encoded_data.size()));
 
     return {};
 }
@@ -205,8 +204,7 @@ ErrorOr<void> Image::export_png_to_fd_and_close(int fd, bool preserve_alpha_chan
     auto bitmap = TRY(try_compose_bitmap(bitmap_format));
 
     auto encoded_data = Gfx::PNGWriter::encode(*bitmap);
-    if (!file->write(encoded_data.data(), encoded_data.size()))
-        return Error::from_errno(file->error());
+    TRY(file->write(encoded_data.data(), encoded_data.size()));
 
     return {};
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -714,7 +714,7 @@ Result<void, String> ImageEditor::save_project_to_fd_and_close(int fd) const
     if (file->has_error())
         return String { file->error_string() };
 
-    if (!file->write(builder.string_view()))
+    if (file->write(builder.string_view()).is_error())
         return String { file->error_string() };
     return {};
 }

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -277,8 +277,8 @@ Result<void, String> PaletteWidget::save_palette_fd_and_close(Vector<Color> pale
         return String { file->error_string() };
 
     for (auto& color : palette) {
-        file->write(color.to_string_without_alpha());
-        file->write("\n");
+        if (file->write(String::formatted("{}\n", color.to_string_without_alpha())).is_error())
+            return String { file->error_string() };
     }
 
     file->close();

--- a/Userland/Applications/Run/RunWindow.h
+++ b/Userland/Applications/Run/RunWindow.h
@@ -28,7 +28,7 @@ private:
 
     String history_file_path();
     void load_history();
-    void save_history();
+    ErrorOr<void> save_history();
 
     Vector<String> m_path_history;
     NonnullRefPtr<GUI::ItemListModel<String>> m_path_history_model;

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -277,15 +277,9 @@ Result<void, String> ExportDialog::make_and_run_for(StringView mime, Core::File&
             array.append(sheet.to_json());
 
         auto file_content = array.to_string();
-        bool result = file.write(file_content);
-        if (!result) {
-            int error_number = errno;
-            StringBuilder sb;
-            sb.append("Unable to save file. Error: ");
-            sb.append(strerror(error_number));
-
-            return sb.to_string();
-        }
+        auto result = file.write(file_content);
+        if (result.is_error())
+            return String::formatted("Unable to save file. Error: {}", file.error_string());
 
         return {};
     };

--- a/Userland/Libraries/LibAudio/WavWriter.cpp
+++ b/Userland/Libraries/LibAudio/WavWriter.cpp
@@ -40,10 +40,11 @@ void WavWriter::set_file(StringView path)
     m_finalized = false;
 }
 
-void WavWriter::write_samples(const u8* samples, size_t size)
+ErrorOr<void> WavWriter::write_samples(const u8* samples, size_t size)
 {
     m_data_sz += size;
-    m_file->write(samples, size);
+    TRY(m_file->write(samples, size));
+    return {};
 }
 
 void WavWriter::finalize()
@@ -52,55 +53,57 @@ void WavWriter::finalize()
     m_finalized = true;
     if (m_file) {
         m_file->seek(0);
-        write_header();
+        MUST(write_header());
         m_file->close();
     }
     m_data_sz = 0;
 }
 
-void WavWriter::write_header()
+ErrorOr<void> WavWriter::write_header()
 {
     // "RIFF"
     static u32 riff = 0x46464952;
-    m_file->write(reinterpret_cast<u8*>(&riff), sizeof(riff));
+    TRY(m_file->write(reinterpret_cast<u8*>(&riff), sizeof(riff)));
 
     // Size of data + (size of header - previous field - this field)
     u32 sz = m_data_sz + (44 - 4 - 4);
-    m_file->write(reinterpret_cast<u8*>(&sz), sizeof(sz));
+    TRY(m_file->write(reinterpret_cast<u8*>(&sz), sizeof(sz)));
 
     // "WAVE"
     static u32 wave = 0x45564157;
-    m_file->write(reinterpret_cast<u8*>(&wave), sizeof(wave));
+    TRY(m_file->write(reinterpret_cast<u8*>(&wave), sizeof(wave)));
 
     // "fmt "
     static u32 fmt_id = 0x20746D66;
-    m_file->write(reinterpret_cast<u8*>(&fmt_id), sizeof(fmt_id));
+    TRY(m_file->write(reinterpret_cast<u8*>(&fmt_id), sizeof(fmt_id)));
 
     // Size of the next 6 fields
     static u32 fmt_size = 16;
-    m_file->write(reinterpret_cast<u8*>(&fmt_size), sizeof(fmt_size));
+    TRY(m_file->write(reinterpret_cast<u8*>(&fmt_size), sizeof(fmt_size)));
 
     // 1 for PCM
     static u16 audio_format = 1;
-    m_file->write(reinterpret_cast<u8*>(&audio_format), sizeof(audio_format));
+    TRY(m_file->write(reinterpret_cast<u8*>(&audio_format), sizeof(audio_format)));
 
-    m_file->write(reinterpret_cast<u8*>(&m_num_channels), sizeof(m_num_channels));
+    TRY(m_file->write(reinterpret_cast<u8*>(&m_num_channels), sizeof(m_num_channels)));
 
-    m_file->write(reinterpret_cast<u8*>(&m_sample_rate), sizeof(m_sample_rate));
+    TRY(m_file->write(reinterpret_cast<u8*>(&m_sample_rate), sizeof(m_sample_rate)));
 
     u32 byte_rate = m_sample_rate * m_num_channels * (m_bits_per_sample / 8);
-    m_file->write(reinterpret_cast<u8*>(&byte_rate), sizeof(byte_rate));
+    TRY(m_file->write(reinterpret_cast<u8*>(&byte_rate), sizeof(byte_rate)));
 
     u16 block_align = m_num_channels * (m_bits_per_sample / 8);
-    m_file->write(reinterpret_cast<u8*>(&block_align), sizeof(block_align));
+    TRY(m_file->write(reinterpret_cast<u8*>(&block_align), sizeof(block_align)));
 
-    m_file->write(reinterpret_cast<u8*>(&m_bits_per_sample), sizeof(m_bits_per_sample));
+    TRY(m_file->write(reinterpret_cast<u8*>(&m_bits_per_sample), sizeof(m_bits_per_sample)));
 
     // "data"
     static u32 chunk_id = 0x61746164;
-    m_file->write(reinterpret_cast<u8*>(&chunk_id), sizeof(chunk_id));
+    TRY(m_file->write(reinterpret_cast<u8*>(&chunk_id), sizeof(chunk_id)));
 
-    m_file->write(reinterpret_cast<u8*>(&m_data_sz), sizeof(m_data_sz));
+    TRY(m_file->write(reinterpret_cast<u8*>(&m_data_sz), sizeof(m_data_sz)));
+
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibAudio/WavWriter.h
+++ b/Userland/Libraries/LibAudio/WavWriter.h
@@ -24,7 +24,7 @@ public:
     bool has_error() const { return !m_error_string.is_null(); }
     const char* error_string() const { return m_error_string.characters(); }
 
-    void write_samples(const u8* samples, size_t size);
+    ErrorOr<void> write_samples(const u8* samples, size_t size);
     void finalize(); // You can finalize manually or let the destructor do it.
 
     u32 sample_rate() const { return m_sample_rate; }
@@ -40,7 +40,7 @@ public:
     void clear_error() { m_error_string = String(); }
 
 private:
-    void write_header();
+    ErrorOr<void> write_header();
     RefPtr<Core::File> m_file;
     String m_error_string;
     bool m_finalized { false };

--- a/Userland/Libraries/LibChess/UCIEndpoint.cpp
+++ b/Userland/Libraries/LibChess/UCIEndpoint.cpp
@@ -24,7 +24,11 @@ Endpoint::Endpoint(NonnullRefPtr<Core::IODevice> in, NonnullRefPtr<Core::IODevic
 void Endpoint::send_command(const Command& command)
 {
     dbgln_if(UCI_DEBUG, "{} Sent UCI Command: {}", class_name(), String(command.to_string().characters(), Chomp));
-    m_out->write(command.to_string());
+    auto result = m_out->write(command.to_string());
+    if (result.is_error()) {
+        dbgln("Unhandled error: {}", result.error().string_literal());
+        VERIFY_NOT_REACHED();
+    }
 }
 
 void Endpoint::event(Core::Event& event)

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -165,11 +165,17 @@ bool ConfigFile::sync()
     m_file->truncate(0);
     m_file->seek(0);
 
+    StringBuilder builder;
     for (auto& it : m_groups) {
-        m_file->write(String::formatted("[{}]\n", it.key));
+        builder.append(String::formatted("[{}]\n", it.key));
         for (auto& jt : it.value)
-            m_file->write(String::formatted("{}={}\n", jt.key, jt.value));
-        m_file->write("\n");
+            builder.append(String::formatted("{}={}\n", jt.key, jt.value));
+        builder.append("\n");
+    }
+    auto result = m_file->write(builder.build());
+    if (result.is_error()) {
+        dbgln("Unhandled error: {}", result.error().string_literal());
+        VERIFY_NOT_REACHED();
     }
 
     m_dirty = false;

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -167,8 +167,8 @@ public:
     {
         auto serialized = response.to_string();
         u32 length = serialized.length();
-        m_socket->write((const u8*)&length, sizeof(length));
-        m_socket->write(serialized);
+        MUST(m_socket->write((const u8*)&length, sizeof(length)));
+        MUST(m_socket->write(serialized));
     }
 
     void handle_request(const JsonObject& request)

--- a/Userland/Libraries/LibCore/FileStream.h
+++ b/Userland/Libraries/LibCore/FileStream.h
@@ -111,7 +111,7 @@ public:
 
     size_t write(ReadonlyBytes bytes) override
     {
-        if (!m_file->write(bytes.data(), bytes.size())) {
+        if (m_file->write(bytes.data(), bytes.size()).is_error()) {
             set_fatal_error();
             return 0;
         }

--- a/Userland/Libraries/LibCore/IODevice.cpp
+++ b/Userland/Libraries/LibCore/IODevice.cpp
@@ -275,15 +275,19 @@ bool IODevice::truncate(off_t size)
     return true;
 }
 
-bool IODevice::write(const u8* data, int size)
+ErrorOr<void> IODevice::write(const u8* data, int size)
 {
     int rc = ::write(m_fd, data, size);
     if (rc < 0) {
         set_error(errno);
-        perror("IODevice::write: write");
-        return false;
+        return Error::from_errno(error());
     }
-    return rc == size;
+    return {};
+}
+
+ErrorOr<void> IODevice::write(StringView sv)
+{
+    return IODevice::write((const u8*)sv.characters_without_null_termination(), sv.length());
 }
 
 void IODevice::set_fd(int fd)
@@ -293,11 +297,6 @@ void IODevice::set_fd(int fd)
 
     m_fd = fd;
     did_update_fd(fd);
-}
-
-bool IODevice::write(StringView v)
-{
-    return write((const u8*)v.characters_without_null_termination(), v.length());
 }
 
 LineIterator::LineIterator(IODevice& device, bool is_end)

--- a/Userland/Libraries/LibCore/IODevice.h
+++ b/Userland/Libraries/LibCore/IODevice.h
@@ -90,8 +90,8 @@ public:
     ByteBuffer read_all();
     String read_line(size_t max_size = 16384);
 
-    bool write(const u8*, int size);
-    bool write(StringView);
+    ErrorOr<void> write(const u8*, int size);
+    ErrorOr<void> write(StringView);
 
     bool truncate(off_t);
 

--- a/Userland/Libraries/LibCpp/Tests/parser/strace.ast
+++ b/Userland/Libraries/LibCpp/Tests/parser/strace.ast
@@ -845,19 +845,21 @@ TranslationUnit[0:0->144:0]
               res
           IfStatement[137:8->141:4]
             Predicate:
-            UnaryExpression[137:12->137:38]
-              !
-              BinaryExpression[137:13->137:38]
-                Name[137:13->137:23]
-                trace_file
-                ->
-                FunctionCall[137:25->137:38]
-                  Name[137:25->137:30]
-                  write
-                  Name[137:31->137:37]
-                  string
+            BinaryExpression[137:12->137:48]
+              Name[137:12->137:22]
+              trace_file
+              ->
+              FunctionCall[137:24->137:48]
+                MemberExpression[137:24->137:46]
+                  FunctionCall[137:24->137:37]
+                    Name[137:24->137:29]
+                    write
+                    Name[137:30->137:36]
+                    string
+                  Identifier[137:38->137:45]
+                  is_error
             Then:
-            BlockStatement[137:40->141:4]
+            BlockStatement[137:50->141:4]
               FunctionCall[138:12->138:59]
                 Name[138:12->138:18]
                 warnln

--- a/Userland/Libraries/LibCpp/Tests/parser/strace.cpp
+++ b/Userland/Libraries/LibCpp/Tests/parser/strace.cpp
@@ -135,7 +135,7 @@ int main(int argc, char** argv)
             arg3,
             res);
 
-        if (!trace_file->write(string)) {
+        if (trace_file->write(string).is_error()) {
             warnln("write: {}", trace_file->error_string());
             return 1;
         }

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -36,9 +36,9 @@ bool JsonArrayModel::store()
         return false;
     }
 
-    file->write(m_array.to_string());
+    auto result = file->write(m_array.to_string());
     file->close();
-    return true;
+    return !result.is_error();
 }
 
 bool JsonArrayModel::add(const Vector<JsonValue>&& values)

--- a/Userland/Libraries/LibHTTP/HttpJob.cpp
+++ b/Userland/Libraries/LibHTTP/HttpJob.cpp
@@ -108,7 +108,7 @@ bool HttpJob::eof() const
 
 bool HttpJob::write(ReadonlyBytes bytes)
 {
-    return m_socket->write(bytes);
+    return !m_socket->write(bytes).is_error();
 }
 
 }

--- a/Userland/Libraries/LibIMAP/Client.cpp
+++ b/Userland/Libraries/LibIMAP/Client.cpp
@@ -172,12 +172,11 @@ static ReadonlyBytes command_byte_buffer(CommandType command)
 
 void Client::send_raw(StringView data)
 {
-    if (m_tls) {
-        m_tls_socket->write(data.bytes());
-        m_tls_socket->write("\r\n"sv.bytes());
-    } else {
-        m_socket->write(data.bytes());
-        m_socket->write("\r\n"sv.bytes());
+    RefPtr<Core::Socket> socket = m_tls ? m_tls_socket : m_socket;
+    auto result = socket->write(String::formatted("{}{}", data.bytes(), "\r\n"sv.bytes()));
+    if (result.is_error()) {
+        dbgln("Unhandled error: {}", result.error().string_literal());
+        VERIFY_NOT_REACHED();
     }
 }
 

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -328,9 +328,13 @@ bool Editor::save_history(String const& path)
         return false;
     auto file = file_or_error.release_value();
     final_history.take_first();
+    StringBuilder builder;
     for (auto const& entry : final_history)
-        file->write(String::formatted("{}::{}\n\n", entry.timestamp, entry.entry));
-
+        builder.append(String::formatted("{}::{}\n\n", entry.timestamp, entry.entry));
+    auto result = file->write(builder.build());
+    if (result.is_error()) {
+        return false;
+    }
     m_history_dirty = false;
     return true;
 }

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -122,7 +122,7 @@ ErrorOr<void> Heap::write_block(u32 block, ByteBuffer& buffer)
         *buffer.offset_pointer(2), *buffer.offset_pointer(3),
         *buffer.offset_pointer(4), *buffer.offset_pointer(5),
         *buffer.offset_pointer(6), *buffer.offset_pointer(7));
-    if (m_file->write(buffer.data(), (int)buffer.size())) {
+    if (!m_file->write(buffer.data(), (int)buffer.size()).is_error()) {
         if (block == m_end_of_file)
             m_end_of_file++;
         return {};

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -261,7 +261,7 @@ bool TLSv12::flush()
         dbgln("SENDING...");
         print_buffer(out_buffer, out_buffer_length);
     }
-    if (Core::Socket::write(&out_buffer[out_buffer_index], out_buffer_length)) {
+    if (!Core::Socket::write(&out_buffer[out_buffer_index], out_buffer_length).is_error()) {
         write_buffer().clear();
         return true;
     }

--- a/Userland/Libraries/LibWebSocket/Impl/TCPWebSocketConnectionImpl.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/TCPWebSocketConnectionImpl.cpp
@@ -44,7 +44,8 @@ void TCPWebSocketConnectionImpl::connect(ConnectionInfo const& connection)
 
 bool TCPWebSocketConnectionImpl::send(ReadonlyBytes data)
 {
-    return m_socket->write(data);
+    // TODO: Propagate errno code
+    return m_socket->write(data).is_error();
 }
 
 bool TCPWebSocketConnectionImpl::can_read_line()

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -104,7 +104,7 @@ void Mixer::mix()
         }
 
         if (m_muted) {
-            m_device->write(m_zero_filled_buffer, sizeof(m_zero_filled_buffer));
+            MUST(m_device->write(m_zero_filled_buffer, sizeof(m_zero_filled_buffer)));
         } else {
             Array<u8, 4096> buffer;
             OutputMemoryStream stream { buffer };
@@ -129,7 +129,7 @@ void Mixer::mix()
 
             VERIFY(stream.is_end());
             VERIFY(!stream.has_any_error());
-            m_device->write(stream.data(), stream.size());
+            MUST(m_device->write(stream.data(), stream.size()));
         }
     }
 }

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -275,7 +275,7 @@ int execute_work_items(Vector<WorkItem> const& items)
                 auto buffer = source_file.read(65536);
                 if (buffer.is_empty())
                     break;
-                if (!destination_file.write(buffer)) {
+                if (destination_file.write(buffer).is_error()) {
                     report_warning(String::formatted("Failed to write to destination file: {}", destination_file.error_string()));
                     return false;
                 }

--- a/Userland/Services/InspectorServer/InspectableProcess.cpp
+++ b/Userland/Services/InspectorServer/InspectableProcess.cpp
@@ -74,8 +74,8 @@ void InspectableProcess::send_request(JsonObject const& request)
 {
     auto serialized = request.to_string();
     auto length = serialized.length();
-    m_socket->write((u8 const*)&length, sizeof(length));
-    m_socket->write(serialized);
+    MUST(m_socket->write((u8 const*)&length, sizeof(length)));
+    MUST(m_socket->write(serialized));
 }
 
 }

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -249,7 +249,7 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, const String& namese
     if (!udp_socket->connect(nameserver, 53))
         return {};
 
-    if (!udp_socket->write(buffer))
+    if (udp_socket->write(buffer).is_error())
         return {};
 
     u8 response_buffer[4096];

--- a/Userland/Utilities/gml-format.cpp
+++ b/Userland/Utilities/gml-format.cpp
@@ -36,7 +36,7 @@ bool format_file(StringView path, bool inplace)
             warnln("Could not truncate {}: {}", path, file->error_string());
             return false;
         }
-        if (!file->write(formatted_gml)) {
+        if (file->write(formatted_gml).is_error()) {
             warnln("Could not write to {}: {}", path, file->error_string());
             return false;
         }

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -158,7 +158,7 @@ int main(int argc, char** argv)
     }
 
     auto& file = *file_or_error.value();
-    if (!file.write(encoded_bitmap.data(), encoded_bitmap.size())) {
+    if (file.write(encoded_bitmap.data(), encoded_bitmap.size()).is_error()) {
         warnln("Failed to write PNG");
         return 1;
     }

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -949,7 +949,7 @@ int main(int argc, char** argv)
         FormattedSyscallBuilder builder(syscall_name);
         format_syscall(builder, syscall_function, arg1, arg2, arg3, res);
 
-        if (!trace_file->write(builder.string_view())) {
+        if (trace_file->write(builder.string_view()).is_error()) {
             warnln("write: {}", trace_file->error_string());
             return 1;
         }

--- a/Userland/Utilities/sysctl.cpp
+++ b/Userland/Utilities/sysctl.cpp
@@ -46,7 +46,7 @@ static bool write_variable(StringView name, StringView value)
         warnln("Failed to open {}: {}", path, file->error_string());
         return false;
     }
-    if (!file->write(value)) {
+    if (file->write(value).is_error()) {
         warnln("Failed to write {}: {}", path, file->error_string());
         return false;
     }

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -37,7 +37,7 @@ static bool unpack_zip_member(Archive::ZipMember zip_member, bool quiet)
     // TODO: verify CRC32s match!
     switch (zip_member.compression_method) {
     case Archive::ZipCompressionMethod::Store: {
-        if (!new_file->write(zip_member.compressed_data.data(), zip_member.compressed_data.size())) {
+        if (new_file->write(zip_member.compressed_data.data(), zip_member.compressed_data.size()).is_error()) {
             warnln("Can't write file contents in {}: {}", zip_member.name, new_file->error_string());
             return false;
         }
@@ -53,7 +53,7 @@ static bool unpack_zip_member(Archive::ZipMember zip_member, bool quiet)
             warnln("Failed decompressing file {}", zip_member.name);
             return false;
         }
-        if (!new_file->write(decompressed_data.value().data(), decompressed_data.value().size())) {
+        if (new_file->write(decompressed_data.value().data(), decompressed_data.value().size()).is_error()) {
             warnln("Can't write file contents in {}: {}", zip_member.name, new_file->error_string());
             return false;
         }

--- a/Userland/Utilities/utmpupdate.cpp
+++ b/Userland/Utilities/utmpupdate.cpp
@@ -80,7 +80,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    if (!file->write(json.to_string())) {
+    if (file->write(json.to_string()).is_error()) {
         dbgln("Write failed");
         return 1;
     }


### PR DESCRIPTION
This makes IODevice::write(StringView) and
IODevice::write(const u8*, int size) return ErrorOr<void> instead of a
boolean indicating success or failure.

Other than simply being inherently somewhat more pleasing, as the
boolean return merely functioned to approximate its new form, this also
forces callers to acknowledge the possibility of errors and actually
handle them.

Where easy and convenient, mostly where the caller already returned
ErrorOr, the IODevice::write calls have simply been wrapped in a TRY().
Generally, where the caller already were handling errors but did not
return ErrorOr, the check to see whether IODevice::write returned true
was replace with a check to see whether IODevice::write returned an
error. Elsewhere, they were for the most part just wrapped in a MUST().

A few places, using AK::StringBuilder, the caller was changed ever so
slightly to contain fewer calls to write.

This is my first semi-real commit and a rather snazzy one at that, if I
do say so myself. :^)