### PR TITLE
LibC: Make sysbeep return int instead of void

### DIFF
--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -700,9 +700,10 @@ int gettid()
     return cached_tid;
 }
 
-void sysbeep()
+int sysbeep()
 {
-    syscall(SC_beep);
+    int rc = syscall(SC_beep);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
 int fsync(int fd)

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -34,7 +34,7 @@ int get_process_name(char* buffer, int buffer_size);
 int set_process_name(const char* name, size_t name_length);
 void dump_backtrace();
 int fsync(int fd);
-void sysbeep();
+int sysbeep();
 int gettid();
 int getpagesize();
 pid_t fork();


### PR DESCRIPTION
Since the beep syscall may fail, it is strange that the error is discarded by the LibC wrapper.

This is probably not a mission-critical change, unless someone really  _really_ wants to beep. :P