### PR TITLE
LibAudio+SoundPlayer: Optimizing FlacLoader, The Third

### DIFF
--- a/Userland/Applications/SoundPlayer/PlaybackManager.h
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Queue.h>
 #include <AK/Vector.h>
 #include <LibAudio/Buffer.h>
 #include <LibAudio/ClientConnection.h>
@@ -39,6 +40,9 @@ public:
     Function<void()> on_finished_playing;
 
 private:
+    // Number of buffers we want to always keep enqueued.
+    static constexpr size_t always_enqueued_buffer_count = 2;
+
     void next_buffer();
     void set_paused(bool);
 
@@ -52,12 +56,12 @@ private:
     RefPtr<Audio::Loader> m_loader { nullptr };
     NonnullRefPtr<Audio::ClientConnection> m_connection;
     RefPtr<Audio::Buffer> m_current_buffer;
+    Queue<i32, always_enqueued_buffer_count + 1> m_enqueued_buffers;
     Optional<Audio::ResampleHelper<double>> m_resampler;
     RefPtr<Core::Timer> m_timer;
 
     // Controls the GUI update rate. A smaller value makes the visualizations nicer.
     static constexpr u32 update_rate_ms = 50;
-
     // Number of milliseconds of audio data contained in each audio buffer
     static constexpr u32 buffer_size_ms = 100;
 };

--- a/Userland/Applications/SoundPlayer/PlaybackManager.h
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.h
@@ -46,7 +46,6 @@ private:
     bool m_loop = { false };
     size_t m_last_seek { 0 };
     float m_total_length { 0 };
-    // FIXME: Get this from the audio server
     size_t m_device_sample_rate { 44100 };
     size_t m_device_samples_per_buffer { 0 };
     size_t m_source_buffer_size_bytes { 0 };

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Debug.h>
+#include <AK/FixedArray.h>
 #include <AK/FlyString.h>
 #include <AK/Format.h>
 #include <AK/Math.h>
@@ -13,6 +14,7 @@
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Try.h>
+#include <AK/TypedTransfer.h>
 #include <AK/UFixedBigInt.h>
 #include <LibAudio/Buffer.h>
 #include <LibAudio/FlacLoader.h>
@@ -190,41 +192,41 @@ MaybeLoaderError FlacLoaderPlugin::seek(const int position)
 
 LoaderSamples FlacLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_input)
 {
-    Vector<Sample> samples;
     ssize_t remaining_samples = static_cast<ssize_t>(m_total_samples - m_loaded_samples);
     if (remaining_samples <= 0)
         return Buffer::create_empty();
 
     size_t samples_to_read = min(max_bytes_to_read_from_input, remaining_samples);
-    samples.ensure_capacity(samples_to_read);
-    while (samples_to_read > 0) {
-        if (!m_current_frame.has_value())
-            TRY(next_frame());
+    auto samples = FixedArray<Sample>(samples_to_read);
+    size_t sample_index = 0;
 
-        // Do a full vector extend if possible
-        if (m_current_frame_data.size() <= samples_to_read) {
-            samples_to_read -= m_current_frame_data.size();
-            samples.extend(move(m_current_frame_data));
-            m_current_frame_data.clear();
-            m_current_frame.clear();
-        } else {
-            samples.unchecked_append(m_current_frame_data.data(), samples_to_read);
-            m_current_frame_data.remove(0, samples_to_read);
-            if (m_current_frame_data.size() == 0) {
-                m_current_frame.clear();
-            }
-            samples_to_read = 0;
-        }
+    if (m_unread_data.size() > 0) {
+        size_t to_transfer = min(m_unread_data.size(), samples_to_read);
+        dbgln_if(AFLACLOADER_DEBUG, "Reading {} samples from unread sample buffer (size {})", to_transfer, m_unread_data.size());
+        AK::TypedTransfer<Sample>::move(samples.data(), m_unread_data.data(), to_transfer);
+        if (to_transfer < m_unread_data.size())
+            m_unread_data.remove(0, to_transfer);
+        else
+            m_unread_data.clear_with_capacity();
+
+        sample_index += to_transfer;
     }
 
-    m_loaded_samples += samples.size();
+    while (sample_index < samples_to_read) {
+        TRY(next_frame(samples.span().slice(sample_index)));
+        sample_index += m_current_frame->sample_count;
+        if (m_stream->handle_any_error())
+            return LoaderError { LoaderError::Category::IO, m_loaded_samples, "Unknown I/O error" };
+    }
+
+    m_loaded_samples += sample_index;
     auto maybe_buffer = Buffer::create_with_samples(move(samples));
     if (maybe_buffer.is_error())
         return LoaderError { LoaderError::Category::Internal, m_loaded_samples, "Couldn't allocate sample buffer" };
     return maybe_buffer.release_value();
 }
 
-MaybeLoaderError FlacLoaderPlugin::next_frame()
+MaybeLoaderError FlacLoaderPlugin::next_frame(Span<Sample> target_vector)
 {
 #define FLAC_VERIFY(check, category, msg)                                                                                               \
     do {                                                                                                                                \
@@ -293,13 +295,14 @@ MaybeLoaderError FlacLoaderPlugin::next_frame()
     for (u8 i = 0; i < subframe_count; ++i) {
         FlacSubframeHeader new_subframe = TRY(next_subframe_header(bit_stream, i));
         Vector<i32> subframe_samples = TRY(parse_subframe(new_subframe, bit_stream));
-        current_subframes.append(move(subframe_samples));
+        current_subframes.unchecked_append(move(subframe_samples));
     }
 
     bit_stream.align_to_byte_boundary();
 
     // TODO: check checksum, see above
     [[maybe_unused]] u16 footer_checksum = static_cast<u16>(bit_stream.read_bits_big_endian(16));
+    dbgln_if(AFLACLOADER_DEBUG, "Subframe footer checksum: {}", footer_checksum);
 
     Vector<i32> left;
     Vector<i32> right;
@@ -352,17 +355,25 @@ MaybeLoaderError FlacLoaderPlugin::next_frame()
         break;
     }
 
-    VERIFY(left.size() == right.size());
+    VERIFY(left.size() == right.size() && left.size() == m_current_frame->sample_count);
 
     double sample_rescale = static_cast<double>(1 << (pcm_bits_per_sample(m_current_frame->bit_depth) - 1));
     dbgln_if(AFLACLOADER_DEBUG, "Sample rescaled from {} bits: factor {:.1f}", pcm_bits_per_sample(m_current_frame->bit_depth), sample_rescale);
 
-    m_current_frame_data.clear_with_capacity();
-    m_current_frame_data.ensure_capacity(left.size());
     // zip together channels
-    for (size_t i = 0; i < left.size(); ++i) {
+    auto samples_to_directly_copy = min(target_vector.size(), m_current_frame->sample_count);
+    for (size_t i = 0; i < samples_to_directly_copy; ++i) {
         Sample frame = { left[i] / sample_rescale, right[i] / sample_rescale };
-        m_current_frame_data.unchecked_append(frame);
+        target_vector[i] = frame;
+    }
+    // move superflous data into the class buffer instead
+    auto result = m_unread_data.try_grow_capacity(m_current_frame->sample_count - samples_to_directly_copy);
+    if (result.is_error())
+        return LoaderError { LoaderError::Category::Internal, static_cast<size_t>(samples_to_directly_copy + m_current_sample_or_frame), "Couldn't allocate sample buffer for superflous data" };
+
+    for (size_t i = samples_to_directly_copy; i < m_current_frame->sample_count; ++i) {
+        Sample frame = { left[i] / sample_rescale, right[i] / sample_rescale };
+        m_unread_data.unchecked_append(frame);
     }
 
     return {};

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -111,8 +111,8 @@ private:
     // Either returns the metadata block or sets error message.
     // Additionally, increments m_data_start_location past the read meta block.
     ErrorOr<FlacRawMetadataBlock, LoaderError> next_meta_block(InputBitStream& bit_input);
-    // Fetches and sets the next FLAC frame
-    MaybeLoaderError next_frame();
+    // Fetches and writes the next FLAC frame
+    MaybeLoaderError next_frame(Span<Sample>);
     // Helper of next_frame that fetches a sub frame's header
     ErrorOr<FlacSubframeHeader, LoaderError> next_subframe_header(InputBitStream& bit_input, u8 channel_index);
     // Helper of next_frame that decompresses a subframe
@@ -151,7 +151,8 @@ private:
     u64 m_data_start_location { 0 };
     OwnPtr<FlacInputStream<FLAC_BUFFER_SIZE>> m_stream;
     Optional<FlacFrameHeader> m_current_frame;
-    Vector<Sample> m_current_frame_data;
+    // Whatever the last get_more_samples() call couldn't return gets stored here.
+    Vector<Sample, FLAC_BUFFER_SIZE> m_unread_data;
     u64 m_current_sample_or_frame { 0 };
 };
 


### PR DESCRIPTION
I'm at it again. More performance improvements, see below for a current profile.

I took this opportunity to improve the audio loading in SoundPlayer, which thereby can pass on the questionable title of application with the most terrible audio handling to Piano. (I'm working on that one, alright?) See the commit comment for details, but TL;DR: Moving around a SoundPlayer window won't (usually) stutter the audio anymore.

My (computation-heavy) test file can run at up to 1500% hot. Here's some profile data:

![image](https://user-images.githubusercontent.com/28656157/146612351-56bbb806-6f80-4a4f-8577-6d2a727c89e9.png)
![image](https://user-images.githubusercontent.com/28656157/146612389-022c86a9-6066-4c44-bdad-ce772a83a5fb.png)