### PR TITLE
Userland: Use try_create_default_icon some more

### DIFF
--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    auto app_icon = GUI::Icon::default_icon("edit-copy");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("edit-copy"));
 
     auto main_window = TRY(GUI::Window::try_create());
     main_window->set_title("Clipboard history");

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto app_icon = GUI::Icon::default_icon("app-catdog");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-catdog"));
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -56,7 +56,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         extra_columns = num_eyes % max_in_row;
     }
 
-    auto app_icon = GUI::Icon::default_icon("app-eyes");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-eyes"));
 
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Eyes");

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -201,7 +201,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); })));
 
-    auto app_icon = GUI::Icon::default_icon("app-libgfx-demo");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-libgfx-demo"));
     window->set_icon(app_icon.bitmap_for_size(16));
     (void)TRY(window->try_set_main_widget<Canvas>());
     window->show();

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -120,7 +120,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); })));
 
-    auto app_icon = GUI::Icon::default_icon("app-libgfx-demo");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-libgfx-demo"));
     window->set_icon(app_icon.bitmap_for_size(16));
     (void)TRY(window->try_set_main_widget<Canvas>());
     window->show();

--- a/Userland/Demos/ModelGallery/main.cpp
+++ b/Userland/Demos/ModelGallery/main.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
 
-    auto app_icon = GUI::Icon::default_icon("app-model-gallery");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-model-gallery"));
 
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Model Gallery");

--- a/Userland/Demos/Mouse/main.cpp
+++ b/Userland/Demos/Mouse/main.cpp
@@ -160,7 +160,7 @@ private:
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto app_icon = GUI::Icon::default_icon("app-mouse");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-mouse"));
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/home/anon", "r"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    auto app_icon = GUI::Icon::default_icon("app-widget-gallery");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-widget-gallery"));
 
     auto window = TRY(GUI::Window::try_create());
     window->resize(430, 480);

--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     pid_t pid;
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto app_icon = GUI::Icon::default_icon("app-inspector");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-inspector"));
     if (gui_mode) {
     choose_pid:
         auto process_chooser = TRY(GUI::ProcessChooser::try_create("Inspector", "Inspect", app_icon.bitmap_for_size(16)));

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -75,21 +76,21 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(path, "GML file to edit", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto app_icon = GUI::Icon::default_icon("app-playground");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-playground"));
     auto window = TRY(GUI::Window::try_create());
     window->set_title("GML Playground");
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(800, 600);
 
-    auto& splitter = window->set_main_widget<GUI::HorizontalSplitter>();
+    auto splitter = TRY(window->try_set_main_widget<GUI::HorizontalSplitter>());
 
-    auto& editor = splitter.add<GUI::TextEditor>();
-    auto& preview = splitter.add<GUI::Frame>();
+    auto editor = TRY(splitter->try_add<GUI::TextEditor>());
+    auto preview = TRY(splitter->try_add<GUI::Frame>());
 
-    editor.set_syntax_highlighter(make<GUI::GMLSyntaxHighlighter>());
-    editor.set_autocomplete_provider(make<GUI::GMLAutocompleteProvider>());
-    editor.set_should_autocomplete_automatically(true);
-    editor.set_automatic_indentation_enabled(true);
+    editor->set_syntax_highlighter(make<GUI::GMLSyntaxHighlighter>());
+    editor->set_autocomplete_provider(make<GUI::GMLAutocompleteProvider>());
+    editor->set_should_autocomplete_automatically(true);
+    editor->set_automatic_indentation_enabled(true);
 
     String file_path;
     auto update_title = [&] {
@@ -107,14 +108,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     if (String(path).is_empty()) {
-        editor.set_text(R"~~~(@GUI::Frame {
+        editor->set_text(R"~~~(@GUI::Frame {
     layout: @GUI::VerticalBoxLayout {
     }
 
     // Now add some widgets!
 }
 )~~~");
-        editor.set_cursor(4, 28); // after "...widgets!"
+        editor->set_cursor(4, 28); // after "...widgets!"
         update_title();
     } else {
         auto file = Core::File::construct(path);
@@ -127,30 +128,30 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return 1;
         }
         file_path = path;
-        editor.set_text(file->read_all());
+        editor->set_text(file->read_all());
         update_title();
     }
 
-    editor.on_change = [&] {
-        preview.remove_all_children();
-        preview.load_from_gml(editor.text(), [](const String& class_name) -> RefPtr<Core::Object> {
+    editor->on_change = [&] {
+        preview->remove_all_children();
+        preview->load_from_gml(editor->text(), [](const String& class_name) -> RefPtr<Core::Object> {
             return UnregisteredWidget::construct(class_name);
         });
     };
 
-    editor.on_modified_change = [&](bool modified) {
+    editor->on_modified_change = [&](bool modified) {
         window->set_modified(modified);
         update_title();
     };
 
-    auto& file_menu = window->add_menu("&File");
+    auto file_menu = TRY(window->try_add_menu("&File"));
 
     auto save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
         Optional<String> new_save_path = GUI::FilePicker::get_save_filepath(window, "Untitled", "gml");
         if (!new_save_path.has_value())
             return;
 
-        if (!editor.write_to_file(new_save_path.value())) {
+        if (!editor->write_to_file(new_save_path.value())) {
             GUI::MessageBox::show(window, "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
             return;
         }
@@ -160,7 +161,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto save_action = GUI::CommonActions::make_save_action([&](auto&) {
         if (!file_path.is_empty()) {
-            if (!editor.write_to_file(file_path)) {
+            if (!editor->write_to_file(file_path)) {
                 GUI::MessageBox::show(window, "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
                 return;
             }
@@ -171,7 +172,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         save_as_action->activate();
     });
 
-    file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
+    TRY(file_menu->try_add_action(GUI::CommonActions::make_open_action([&](auto&) {
         Optional<String> open_path = GUI::FilePicker::get_open_filepath(window);
 
         if (!open_path.has_value())
@@ -196,23 +197,23 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
         }
         file_path = open_path.value();
-        editor.set_text(file->read_all());
-        editor.set_focus(true);
+        editor->set_text(file->read_all());
+        editor->set_focus(true);
         update_title();
-    }));
+    })));
 
-    file_menu.add_action(save_action);
-    file_menu.add_action(save_as_action);
-    file_menu.add_separator();
+    TRY(file_menu->try_add_action(save_action));
+    TRY(file_menu->try_add_action(save_as_action));
+    TRY(file_menu->try_add_separator());
 
-    file_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) {
+    TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) {
         if (window->on_close_request() == GUI::Window::CloseRequestDecision::Close)
             app->quit();
-    }));
+    })));
 
-    auto& edit_menu = window->add_menu("&Edit");
-    edit_menu.add_action(GUI::Action::create("&Format GML", { Mod_Ctrl | Mod_Shift, Key_I }, [&](auto&) {
-        auto source = editor.text();
+    auto edit_menu = TRY(window->try_add_menu("&Edit"));
+    TRY(edit_menu->try_add_action(GUI::Action::create("&Format GML", { Mod_Ctrl | Mod_Shift, Key_I }, [&](auto&) {
+        auto source = editor->text();
         GUI::GMLLexer lexer(source);
         for (auto& token : lexer.lex()) {
             if (token.m_type == GUI::GMLToken::Type::Comment) {
@@ -229,7 +230,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         auto formatted_gml = GUI::format_gml(source);
         if (!formatted_gml.is_null()) {
-            editor.set_text(formatted_gml);
+            editor->set_text(formatted_gml);
         } else {
             GUI::MessageBox::show(
                 window,
@@ -237,22 +238,22 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 "Error",
                 GUI::MessageBox::Type::Error);
         }
-    }));
+    })));
 
     auto vim_emulation_setting_action = GUI::Action::create_checkable("&Vim Emulation", { Mod_Ctrl | Mod_Shift | Mod_Alt, Key_V }, [&](auto& action) {
         if (action.is_checked())
-            editor.set_editing_engine(make<GUI::VimEditingEngine>());
+            editor->set_editing_engine(make<GUI::VimEditingEngine>());
         else
-            editor.set_editing_engine(make<GUI::RegularEditingEngine>());
+            editor->set_editing_engine(make<GUI::RegularEditingEngine>());
     });
     vim_emulation_setting_action->set_checked(false);
-    edit_menu.add_action(vim_emulation_setting_action);
+    TRY(edit_menu->try_add_action(vim_emulation_setting_action));
 
-    auto& help_menu = window->add_menu("&Help");
-    help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
+    auto help_menu = TRY(window->try_add_menu("&Help"));
+    TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
         Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Playground.md"), "/bin/Help");
-    }));
-    help_menu.add_action(GUI::CommonActions::make_about_action("GML Playground", app_icon, window));
+    })));
+    TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("GML Playground", app_icon, window)));
 
     window->on_close_request = [&] {
         if (!window->is_modified())

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -57,7 +58,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto app_icon = GUI::Icon::default_icon("app-profiler");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-profiler"));
 
     String perfcore_file;
     if (!perfcore_file_arg) {
@@ -85,9 +86,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(800, 600);
 
-    auto& main_widget = window->set_main_widget<GUI::Widget>();
-    main_widget.set_fill_with_background_color(true);
-    main_widget.set_layout<GUI::VerticalBoxLayout>();
+    auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    main_widget->set_fill_with_background_color(true);
+    main_widget->set_layout<GUI::VerticalBoxLayout>();
 
     auto timeline_header_container = TRY(GUI::Widget::try_create());
     timeline_header_container->set_layout<GUI::VerticalBoxLayout>();
@@ -105,9 +106,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         if (!matching_event_found)
             continue;
-        auto& timeline_header = timeline_header_container->add<TimelineHeader>(*profile, process);
-        timeline_header.set_shrink_to_fit(true);
-        timeline_header.on_selection_change = [&](bool selected) {
+        auto timeline_header = TRY(timeline_header_container->try_add<TimelineHeader>(*profile, process));
+        timeline_header->set_shrink_to_fit(true);
+        timeline_header->on_selection_change = [&](bool selected) {
             auto end_valid = process.end_valid == EventSerialNumber {} ? EventSerialNumber::max_valid_serial() : process.end_valid;
             if (selected)
                 profile->add_process_filter(process.pid, process.start_valid, end_valid);
@@ -119,82 +120,83 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 return IterationDecision::Continue;
             });
         };
-        timeline_view->add<TimelineTrack>(*timeline_view, *profile, process);
+
+        (void)TRY(timeline_view->try_add<TimelineTrack>(*timeline_view, *profile, process));
     }
 
-    auto& main_splitter = main_widget.add<GUI::VerticalSplitter>();
+    auto main_splitter = TRY(main_widget->try_add<GUI::VerticalSplitter>());
 
-    [[maybe_unused]] auto& timeline_container = main_splitter.add<TimelineContainer>(*timeline_header_container, *timeline_view);
+    [[maybe_unused]] auto timeline_container = TRY(main_splitter->try_add<TimelineContainer>(*timeline_header_container, *timeline_view));
 
-    auto& tab_widget = main_splitter.add<GUI::TabWidget>();
+    auto tab_widget = TRY(main_splitter->try_add<GUI::TabWidget>());
 
-    auto& tree_tab = tab_widget.add_tab<GUI::Widget>("Call Tree");
-    tree_tab.set_layout<GUI::VerticalBoxLayout>();
-    tree_tab.layout()->set_margins(4);
-    auto& bottom_splitter = tree_tab.add<GUI::VerticalSplitter>();
+    auto tree_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Call Tree"));
+    tree_tab->set_layout<GUI::VerticalBoxLayout>();
+    tree_tab->layout()->set_margins(4);
+    auto bottom_splitter = TRY(tree_tab->try_add<GUI::VerticalSplitter>());
 
-    auto& tree_view = bottom_splitter.add<GUI::TreeView>();
-    tree_view.set_should_fill_selected_rows(true);
-    tree_view.set_column_headers_visible(true);
-    tree_view.set_selection_behavior(GUI::TreeView::SelectionBehavior::SelectRows);
-    tree_view.set_model(profile->model());
+    auto tree_view = TRY(bottom_splitter->try_add<GUI::TreeView>());
+    tree_view->set_should_fill_selected_rows(true);
+    tree_view->set_column_headers_visible(true);
+    tree_view->set_selection_behavior(GUI::TreeView::SelectionBehavior::SelectRows);
+    tree_view->set_model(profile->model());
 
-    auto& disassembly_view = bottom_splitter.add<GUI::TableView>();
-    disassembly_view.set_visible(false);
+    auto disassembly_view = TRY(bottom_splitter->try_add<GUI::TableView>());
+    disassembly_view->set_visible(false);
 
     auto update_disassembly_model = [&] {
-        if (disassembly_view.is_visible() && !tree_view.selection().is_empty()) {
-            profile->set_disassembly_index(tree_view.selection().first());
-            disassembly_view.set_model(profile->disassembly_model());
+        if (disassembly_view->is_visible() && !tree_view->selection().is_empty()) {
+            profile->set_disassembly_index(tree_view->selection().first());
+            disassembly_view->set_model(profile->disassembly_model());
         } else {
-            disassembly_view.set_model(nullptr);
+            disassembly_view->set_model(nullptr);
         }
     };
 
-    tree_view.on_selection_change = [&] {
+    tree_view->on_selection_change = [&] {
         update_disassembly_model();
     };
 
     auto disassembly_action = GUI::Action::create_checkable("Show &Disassembly", { Mod_Ctrl, Key_D }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/x86.png").release_value_but_fixme_should_propagate_errors(), [&](auto& action) {
-        disassembly_view.set_visible(action.is_checked());
+        disassembly_view->set_visible(action.is_checked());
         update_disassembly_model();
     });
 
-    auto& samples_tab = tab_widget.add_tab<GUI::Widget>("Samples");
-    samples_tab.set_layout<GUI::VerticalBoxLayout>();
-    samples_tab.layout()->set_margins(4);
+    auto samples_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Samples"));
+    samples_tab->set_layout<GUI::VerticalBoxLayout>();
+    samples_tab->layout()->set_margins(4);
 
-    auto& samples_splitter = samples_tab.add<GUI::HorizontalSplitter>();
-    auto& samples_table_view = samples_splitter.add<GUI::TableView>();
-    samples_table_view.set_model(profile->samples_model());
+    auto samples_splitter = TRY(samples_tab->try_add<GUI::HorizontalSplitter>());
+    auto samples_table_view = TRY(samples_splitter->try_add<GUI::TableView>());
+    samples_table_view->set_model(profile->samples_model());
 
-    auto& individual_sample_view = samples_splitter.add<GUI::TableView>();
-    samples_table_view.on_selection_change = [&] {
-        const auto& index = samples_table_view.selection().first();
+    auto individual_sample_view = TRY(samples_splitter->try_add<GUI::TableView>());
+    samples_table_view->on_selection_change = [&] {
+        const auto& index = samples_table_view->selection().first();
         auto model = IndividualSampleModel::create(*profile, index.data(GUI::ModelRole::Custom).to_integer<size_t>());
-        individual_sample_view.set_model(move(model));
+        individual_sample_view->set_model(move(model));
     };
 
-    auto& signposts_tab = tab_widget.add_tab<GUI::Widget>("Signposts");
-    signposts_tab.set_layout<GUI::VerticalBoxLayout>();
-    signposts_tab.layout()->set_margins(4);
+    auto signposts_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Signposts"));
+    signposts_tab->set_layout<GUI::VerticalBoxLayout>();
+    signposts_tab->layout()->set_margins(4);
 
-    auto& signposts_splitter = signposts_tab.add<GUI::HorizontalSplitter>();
-    auto& signposts_table_view = signposts_splitter.add<GUI::TableView>();
-    signposts_table_view.set_model(profile->signposts_model());
+    auto signposts_splitter = TRY(signposts_tab->try_add<GUI::HorizontalSplitter>());
+    auto signposts_table_view = TRY(signposts_splitter->try_add<GUI::TableView>());
+    signposts_table_view->set_model(profile->signposts_model());
 
-    auto& individual_signpost_view = signposts_splitter.add<GUI::TableView>();
-    signposts_table_view.on_selection_change = [&] {
-        const auto& index = signposts_table_view.selection().first();
+    auto individual_signpost_view = TRY(signposts_splitter->try_add<GUI::TableView>());
+    signposts_table_view->on_selection_change = [&] {
+        const auto& index = signposts_table_view->selection().first();
         auto model = IndividualSampleModel::create(*profile, index.data(GUI::ModelRole::Custom).to_integer<size_t>());
-        individual_signpost_view.set_model(move(model));
+        individual_signpost_view->set_model(move(model));
     };
 
-    auto& flamegraph_tab = tab_widget.add_tab<GUI::Widget>("Flame Graph");
-    flamegraph_tab.set_layout<GUI::VerticalBoxLayout>();
-    flamegraph_tab.layout()->set_margins({ 4, 4, 4, 4 });
+    auto flamegraph_tab = TRY(tab_widget->try_add_tab<GUI::Widget>("Flame Graph"));
+    flamegraph_tab->set_layout<GUI::VerticalBoxLayout>();
+    flamegraph_tab->layout()->set_margins({ 4, 4, 4, 4 });
 
-    auto& flamegraph_view = flamegraph_tab.add<FlameGraphView>(profile->model(), ProfileModel::Column::StackFrame, ProfileModel::Column::SampleCount);
+    auto flamegraph_view = TRY(flamegraph_tab->try_add<FlameGraphView>(profile->model(), ProfileModel::Column::StackFrame, ProfileModel::Column::SampleCount));
 
     const u64 start_of_trace = profile->first_timestamp();
     const u64 end_of_trace = start_of_trace + profile->length_in_ms();
@@ -202,12 +204,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return min(end_of_trace, max(timestamp, start_of_trace));
     };
 
-    auto& statusbar = main_widget.add<GUI::Statusbar>();
+    auto statusbar = TRY(main_widget->try_add<GUI::Statusbar>());
     auto statusbar_update = [&] {
         auto& view = *timeline_view;
         StringBuilder builder;
 
-        auto flamegraph_hovered_index = flamegraph_view.hovered_index();
+        auto flamegraph_hovered_index = flamegraph_view->hovered_index();
         if (flamegraph_hovered_index.is_valid()) {
             auto stack = profile->model().data(flamegraph_hovered_index.sibling_at_column(ProfileModel::Column::StackFrame)).to_string();
             auto sample_count = profile->model().data(flamegraph_hovered_index.sibling_at_column(ProfileModel::Column::SampleCount)).to_i32();
@@ -227,43 +229,43 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 builder.appendff(", Duration: {} ms", end - start);
             }
         }
-        statusbar.set_text(builder.to_string());
+        statusbar->set_text(builder.to_string());
     };
     timeline_view->on_selection_change = [&] { statusbar_update(); };
-    flamegraph_view.on_hover_change = [&] { statusbar_update(); };
+    flamegraph_view->on_hover_change = [&] { statusbar_update(); };
 
-    auto& file_menu = window->add_menu("&File");
-    file_menu.add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); }));
+    auto file_menu = TRY(window->try_add_menu("&File"));
+    TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) { app->quit(); })));
 
-    auto& view_menu = window->add_menu("&View");
+    auto view_menu = TRY(window->try_add_menu("&View"));
 
     auto invert_action = GUI::Action::create_checkable("&Invert Tree", { Mod_Ctrl, Key_I }, [&](auto& action) {
         profile->set_inverted(action.is_checked());
     });
     invert_action->set_checked(false);
-    view_menu.add_action(invert_action);
+    TRY(view_menu->try_add_action(invert_action));
 
     auto top_functions_action = GUI::Action::create_checkable("&Top Functions", { Mod_Ctrl, Key_T }, [&](auto& action) {
         profile->set_show_top_functions(action.is_checked());
     });
     top_functions_action->set_checked(false);
-    view_menu.add_action(top_functions_action);
+    TRY(view_menu->try_add_action(top_functions_action));
 
     auto percent_action = GUI::Action::create_checkable("Show &Percentages", { Mod_Ctrl, Key_P }, [&](auto& action) {
         profile->set_show_percentages(action.is_checked());
-        tree_view.update();
-        disassembly_view.update();
+        tree_view->update();
+        disassembly_view->update();
     });
     percent_action->set_checked(false);
-    view_menu.add_action(percent_action);
+    TRY(view_menu->try_add_action(percent_action));
 
-    view_menu.add_action(disassembly_action);
+    TRY(view_menu->try_add_action(disassembly_action));
 
-    auto& help_menu = window->add_menu("&Help");
-    help_menu.add_action(GUI::CommonActions::make_help_action([](auto&) {
+    auto help_menu = TRY(window->try_add_menu("&Help"));
+    TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
         Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man1/Profiler.md"), "/bin/Help");
-    }));
-    help_menu.add_action(GUI::CommonActions::make_about_action("Profiler", app_icon, window));
+    })));
+    TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Profiler", app_icon, window)));
 
     window->show();
     return app->exec();

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     srand(time(nullptr));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto app_icon = GUI::Icon::default_icon("app-2048");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-2048"));
 
     auto window = TRY(GUI::Window::try_create());
 

--- a/Userland/Games/Breakout/main.cpp
+++ b/Userland/Games/Breakout/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_double_buffering_enabled(false);
     window->set_title("Breakout");
 
-    auto app_icon = GUI::Icon::default_icon("app-breakout");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-breakout"));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto game = TRY(window->try_set_main_widget<Breakout::Game>());

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio rpath wpath cpath recvfd sendfd thread proc exec"));
 
-    auto app_icon = GUI::Icon::default_icon("app-chess");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-chess"));
 
     auto window = TRY(GUI::Window::try_create());
     auto widget = TRY(window->try_set_main_widget<ChessWidget>());

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -32,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::Window::try_create());
     window->resize(FlappyBug::Game::game_width, FlappyBug::Game::game_height);
-    auto app_icon = GUI::Icon::default_icon("app-flappybug");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-flappybug"));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Flappy Bug");
     window->set_double_buffering_enabled(false);

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto app_icon = GUI::Icon::default_icon("app-gameoflife");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-gameoflife"));
 
     auto window = TRY(GUI::Window::try_create());
     window->set_icon(app_icon.bitmap_for_size(16));

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -27,7 +27,7 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto app_icon = GUI::Icon::default_icon("app-hearts");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-hearts"));
 
     Config::pledge_domains("Hearts");
 

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto app_icon = GUI::Icon::default_icon("app-minesweeper");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-minesweeper"));
 
     auto window = TRY(GUI::Window::try_create());
     window->set_resizable(false);

--- a/Userland/Games/Pong/main.cpp
+++ b/Userland/Games/Pong/main.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::Window::try_create());
     window->resize(Pong::Game::game_width, Pong::Game::game_height);
-    auto app_icon = GUI::Icon::default_icon("app-pong");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-pong"));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->set_title("Pong");
     window->set_double_buffering_enabled(false);

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    auto app_icon = GUI::Icon::default_icon("app-snake");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-snake"));
 
     auto window = TRY(GUI::Window::try_create());
 

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -27,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto app_icon = GUI::Icon::default_icon("app-solitaire");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-solitaire"));
 
     Config::pledge_domains("Solitaire");
 

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -42,7 +42,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    auto app_icon = GUI::Icon::default_icon("app-spider");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-spider"));
 
     Config::pledge_domains("Spider");
 


### PR DESCRIPTION
This converts all the Applets, Demos, DevTools, and games to make use of `try_create_default_icon()` instead of `default_icon()` :^).

I also sprinkled in some more `TRY()` syntax in both `Playground` and `Profiler`.

I hope creating this many separate commits is acceptable, I read in the documentation that one should try to be as atomic as possible, but not sure if this is a bit overkill. Let me know if I should bundle it more.