### PR TITLE
PixelPaint: Refactor falloff computation and extend hardness range

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -95,7 +95,7 @@ void BrushTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::In
             if (distance >= size())
                 continue;
 
-            auto falloff = (1.0 - double { distance / size() }) * (1.0 / (100 - hardness()));
+            auto falloff = get_falloff(distance);
             auto pixel_color = color;
             pixel_color.set_alpha(falloff * 255);
             bitmap.set_pixel(x, y, bitmap.get_pixel(x, y).blend(pixel_color));
@@ -168,7 +168,7 @@ GUI::Widget* BrushTool::get_properties_widget()
         hardness_label.set_fixed_size(80, 20);
 
         auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
-        hardness_slider.set_range(1, 99);
+        hardness_slider.set_range(1, 100);
         hardness_slider.set_value(m_hardness);
 
         hardness_slider.on_change = [&](int value) {

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.h
@@ -28,6 +28,12 @@ public:
     void set_hardness(int hardness) { m_hardness = hardness; }
     int hardness() const { return m_hardness; }
 
+    double get_falloff(double distance)
+    {
+        double multiplicand = hardness() == 100 ? 1.0 : 1.0 / (100 - hardness());
+        return (1.0 - double { distance / size() }) * multiplicand;
+    }
+
 protected:
     virtual Color color_for(GUI::MouseEvent const& event);
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point);

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -37,7 +37,7 @@ void CloneTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color const&, Gfx::IntPoint
             if (source_x < 0 || source_x >= bitmap.width() || source_y < 0 || source_y >= bitmap.height())
                 continue;
 
-            auto falloff = (1.0 - double { distance / size() }) * (1.0 / (100 - hardness()));
+            auto falloff = get_falloff(distance);
             auto pixel_color = bitmap.get_pixel(source_x, source_y);
             pixel_color.set_alpha(falloff * 255);
             bitmap.set_pixel(target_x, target_y, bitmap.get_pixel(target_x, target_y).blend(pixel_color));
@@ -165,11 +165,11 @@ GUI::Widget* CloneTool::get_properties_widget()
         hardness_label.set_fixed_size(80, 20);
 
         auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
-        hardness_slider.set_range(1, 99);
+        hardness_slider.set_range(1, 100);
         hardness_slider.on_change = [&](int value) {
             set_hardness(value);
         };
-        hardness_slider.set_value(99);
+        hardness_slider.set_value(100);
         set_secondary_slider(&hardness_slider);
     }
 

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
@@ -50,8 +50,9 @@ void EraseTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::In
                     continue;
                 if (distance >= size())
                     continue;
+
                 auto old_color = bitmap.get_pixel(x, y);
-                auto falloff = (1.0 - double { distance / size() }) * (1.0 / (100 - hardness()));
+                auto falloff = get_falloff(distance);
                 auto new_color = old_color.interpolate(color, falloff);
                 bitmap.set_pixel(x, y, new_color);
             }
@@ -91,7 +92,7 @@ GUI::Widget* EraseTool::get_properties_widget()
         hardness_label.set_fixed_size(80, 20);
 
         auto& hardness_slider = hardness_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
-        hardness_slider.set_range(1, 99);
+        hardness_slider.set_range(1, 100);
         hardness_slider.set_value(hardness());
 
         hardness_slider.on_change = [&](int value) {


### PR DESCRIPTION
I was playing around with Pixel Paint and it bothered me that the hardness couldn't be 100%, so I extended the range and fixed the `inf` that could result because of that (because if `hardness()` is 100 then `1.0 / (100 - 100)` and so `1.0 / 0`).
While I was at it I refactored the falloff computation.