### PR TITLE
LibJS: Add missing `RequireInternalSlot`s in Calendar and TimeZone

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -575,10 +575,11 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::to_string)
 JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::to_json)
 {
     // 1. Let calendar be the this value.
-    auto calendar = vm.this_value(global_object);
+    // 2. Perform ? RequireInternalSlot(calendar, [[InitializedTemporalCalendar]]).
+    auto* calendar = TRY(typed_this_object(global_object));
 
-    // 2. Return ? ToString(calendar).
-    return js_string(vm, TRY(calendar.to_string(global_object)));
+    // 3. Return ? ToString(calendar).
+    return js_string(vm, TRY(Value(calendar).to_string(global_object)));
 }
 
 // 15.6.2.6 Temporal.Calendar.prototype.era ( temporalDateLike ), https://tc39.es/proposal-temporal/#sec-temporal.calendar.prototype.era

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -230,10 +230,11 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::to_string)
 JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::to_json)
 {
     // 1. Let timeZone be the this value.
-    auto time_zone = vm.this_value(global_object);
+    // 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
+    auto* time_zone = TRY(typed_this_object(global_object));
 
-    // 2. Return ? ToString(timeZone).
-    return js_string(vm, TRY(time_zone.to_string(global_object)));
+    // 3. Return ? ToString(timeZone).
+    return js_string(vm, TRY(Value(time_zone).to_string(global_object)));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -48,10 +48,11 @@ void TimeZonePrototype::initialize(GlobalObject& global_object)
 JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::id_getter)
 {
     // 1. Let timeZone be the this value.
-    auto time_zone = vm.this_value(global_object);
+    // 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
+    auto* time_zone = TRY(typed_this_object(global_object));
 
-    // 2. Return ? ToString(timeZone).
-    return js_string(vm, TRY(time_zone.to_string(global_object)));
+    // 3. Return ? ToString(timeZone).
+    return js_string(vm, TRY(Value(time_zone).to_string(global_object)));
 }
 
 // 11.4.4 Temporal.TimeZone.prototype.getOffsetNanosecondsFor ( instant ), https://tc39.es/proposal-temporal/#sec-temporal.timezone.prototype.getoffsetnanosecondsfor

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZonePrototype.cpp
@@ -92,15 +92,16 @@ JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_offset_string_for)
 JS_DEFINE_NATIVE_FUNCTION(TimeZonePrototype::get_plain_date_time_for)
 {
     // 1. Let timeZone be the this value.
-    auto time_zone = vm.this_value(global_object);
+    // 2. Perform ? RequireInternalSlot(timeZone, [[InitializedTemporalTimeZone]]).
+    auto* time_zone = TRY(typed_this_object(global_object));
 
-    // 2. Set instant to ? ToTemporalInstant(instant).
+    // 3. Set instant to ? ToTemporalInstant(instant).
     auto* instant = TRY(to_temporal_instant(global_object, vm.argument(0)));
 
-    // 3. Let calendar be ? ToTemporalCalendarWithISODefault(calendarLike).
+    // 4. Let calendar be ? ToTemporalCalendarWithISODefault(calendarLike).
     auto* calendar = TRY(to_temporal_calendar_with_iso_default(global_object, vm.argument(1)));
 
-    // 4. Return ? BuiltinTimeZoneGetPlainDateTimeFor(timeZone, instant, calendar).
+    // 5. Return ? BuiltinTimeZoneGetPlainDateTimeFor(timeZone, instant, calendar).
     return TRY(builtin_time_zone_get_plain_date_time_for(global_object, time_zone, *instant, *calendar));
 }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Calendar/Calendar.prototype.toJSON.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Calendar/Calendar.prototype.toJSON.js
@@ -7,8 +7,12 @@ describe("correct behavior", () => {
         const calendar = new Temporal.Calendar("iso8601");
         expect(calendar.toJSON()).toBe("iso8601");
     });
+});
 
-    test("works with any this value", () => {
-        expect(Temporal.Calendar.prototype.toJSON.call("foo")).toBe("foo");
+describe("errors", () => {
+    test("this value must be a Temporal.Calendar object", () => {
+        expect(() => {
+            Temporal.Calendar.prototype.toJSON.call("foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.Calendar");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.getPlainDateTimeFor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.getPlainDateTimeFor.js
@@ -26,35 +26,21 @@ describe("correct behavior", () => {
         const plainDateTime = timeZone.getPlainDateTimeFor(instant, calendar);
         expect(plainDateTime.calendar).toBe(calendar);
     });
-
-    test("non-TimeZone this value", () => {
-        const timeZoneLike = {
-            getOffsetNanosecondsFor() {
-                return 123;
-            },
-        };
-        const instant = new Temporal.Instant(0n);
-        const plainDateTime = Temporal.TimeZone.prototype.getPlainDateTimeFor.call(
-            timeZoneLike,
-            instant
-        );
-        expect(plainDateTime.year).toBe(1970);
-        expect(plainDateTime.month).toBe(1);
-        expect(plainDateTime.day).toBe(1);
-        expect(plainDateTime.hour).toBe(0);
-        expect(plainDateTime.minute).toBe(0);
-        expect(plainDateTime.second).toBe(0);
-        expect(plainDateTime.millisecond).toBe(0);
-        expect(plainDateTime.microsecond).toBe(0);
-        expect(plainDateTime.nanosecond).toBe(123);
-    });
 });
 
 describe("errors", () => {
-    test("custom time zone doesn't have a getOffsetNanosecondsFor function", () => {
+    test("time zone doesn't have a getOffsetNanosecondsFor function", () => {
+        const timeZone = new Temporal.TimeZone("UTC");
+        timeZone.getOffsetNanosecondsFor = undefined;
         const instant = new Temporal.Instant(1n);
         expect(() => {
-            Temporal.TimeZone.prototype.getPlainDateTimeFor.call({}, instant);
+            timeZone.getPlainDateTimeFor(instant);
         }).toThrowWithMessage(TypeError, "null is not a function");
+    });
+
+    test("this value must be a Temporal.TimeZone object", () => {
+        expect(() => {
+            Temporal.TimeZone.prototype.getPlainDateTimeFor.call("foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.TimeZone");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.id.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.id.js
@@ -3,8 +3,12 @@ describe("correct behavior", () => {
         const timeZone = new Temporal.TimeZone("UTC");
         expect(timeZone.id).toBe("UTC");
     });
+});
 
-    test("works with any this value", () => {
-        expect(Reflect.get(Temporal.TimeZone.prototype, "id", "foo")).toBe("foo");
+describe("errors", () => {
+    test("this value must be a Temporal.TimeZone object", () => {
+        expect(() => {
+            Reflect.get(Temporal.TimeZone.prototype, "id", "foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.TimeZone");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.toJSON.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.toJSON.js
@@ -7,8 +7,12 @@ describe("correct behavior", () => {
         const timeZone = new Temporal.TimeZone("UTC");
         expect(timeZone.toJSON()).toBe("UTC");
     });
+});
 
-    test("works with any this value", () => {
-        expect(Temporal.TimeZone.prototype.toJSON.call("foo")).toBe("foo");
+describe("errors", () => {
+    test("this value must be a Temporal.TimeZone object", () => {
+        expect(() => {
+            Temporal.TimeZone.prototype.toJSON.call("foo");
+        }).toThrowWithMessage(TypeError, "Not an object of type Temporal.TimeZone");
     });
 });


### PR DESCRIPTION
These were missed in https://github.com/SerenityOS/serenity/commit/247d2f7cc4d0fafe82dd5d48532f3afee9ce4dc2 which only adds `RequireInternalSlot` to `Calendar#id`

The commit subjects are a bit inconsistent to fit the 72 character limit.