### PR TITLE
SystemMonitor: Add back accidentally removed veil lock

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -125,6 +125,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/bin/Profiler", "rx"));
     TRY(Core::System::unveil("/bin/Inspector", "rx"));
+    TRY(Core::System::unveil(nullptr, nullptr));
 
     StringView args_tab = "processes"sv;
     Core::ArgsParser parser;


### PR DESCRIPTION
Since the call to lock the veil was missing, the protections provided by unveil() were not actually enabled.