### PR TITLE
Userland/Notify: Check if optional icon arg is null before loading

### DIFF
--- a/Userland/Utilities/notify.cpp
+++ b/Userland/Utilities/notify.cpp
@@ -25,7 +25,8 @@ int main(int argc, char** argv)
     auto notification = GUI::Notification::construct();
     notification->set_text(message);
     notification->set_title(title);
-    notification->set_icon(Gfx::Bitmap::try_load_from_file(icon_path).release_value_but_fixme_should_propagate_errors());
+    if (icon_path)
+        notification->set_icon(Gfx::Bitmap::try_load_from_file(icon_path).release_value_but_fixme_should_propagate_errors());
     notification->show();
 
     return 0;


### PR DESCRIPTION
The commandline "notify" application was always attempting to load an
icon path from an optional argument, even when the argument was
omitted. In this case, the image icon argument would be a null pointer
and the notify program would crash.

This fix adds a conditional to only attempt to load the icon file if
the icon_path variable is not a null pointer.

![serenity-notify](https://user-images.githubusercontent.com/27985762/146668847-bb21212f-1948-4afb-9fcf-69d6d1053bf2.png)
*notify, before the fix*

![serenity-fixed](https://user-images.githubusercontent.com/27985762/146668875-6d714928-16ac-4eea-bc18-4adef97b0a61.png)
*notify, after the fix*

