### PR TITLE
LibCore: Unconditionally report error in `EventLoop::wait_for_event`

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -642,7 +642,7 @@ try_select_again:
                 return;
             goto try_select_again;
         }
-        dbgln_if(EVENTLOOP_DEBUG, "Core::EventLoop::wait_for_event: {} ({}: {})", marked_fd_count, saved_errno, strerror(saved_errno));
+        dbgln("Core::EventLoop::wait_for_event: {} ({}: {})", marked_fd_count, saved_errno, strerror(saved_errno));
         VERIFY_NOT_REACHED();
     }
     if (FD_ISSET(s_wake_pipe_fds[0], &rfds)) {


### PR DESCRIPTION
When `select` fails and `VERIFY_NOT_REACHED()` is reached, it is wise
to always have a trace of what went wrong.