### PR TITLE
LibGUI: Adjust focus rect for Buttons with icons

### DIFF
--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -89,7 +89,7 @@ void Button::paint_event(PaintEvent& event)
     if (is_focused()) {
         Gfx::IntRect focus_rect;
         if (m_icon && !text().is_empty())
-            focus_rect = text_rect.inflated(6, 6);
+            focus_rect = text_rect.inflated(4, 4);
         else
             focus_rect = rect().shrunken(8, 8);
         painter.draw_focus_rect(focus_rect, palette().focus_outline());


### PR DESCRIPTION
Reduced focus rect inflation value for buttons with icons
to match the expected focus rect for buttons without icons.

As mentioned in 'SerenityOS Office Hours / Q&A (2021-12-17)'