### PR TITLE
LibC: Implement wcsdup

### DIFF
--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -61,6 +61,20 @@ wchar_t* wcscpy(wchar_t* dest, const wchar_t* src)
     return original_dest;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsdup.html
+wchar_t* wcsdup(const wchar_t* str)
+{
+    size_t length = wcslen(str);
+    wchar_t* new_str = (wchar_t*)malloc(sizeof(wchar_t) * (length + 1));
+
+    if (!new_str) {
+        errno = ENOMEM;
+        return nullptr;
+    }
+
+    return wcscpy(new_str, str);
+}
+
 wchar_t* wcsncpy(wchar_t* dest, const wchar_t* src, size_t num)
 {
     wchar_t* original_dest = dest;

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -28,6 +28,7 @@ struct tm;
 
 size_t wcslen(const wchar_t*);
 wchar_t* wcscpy(wchar_t*, const wchar_t*);
+wchar_t* wcsdup(const wchar_t*);
 wchar_t* wcsncpy(wchar_t*, const wchar_t*, size_t);
 __attribute__((warn_unused_result)) size_t wcslcpy(wchar_t*, const wchar_t*, size_t);
 int wcscmp(const wchar_t*, const wchar_t*);


### PR DESCRIPTION
One less missing wchar function!

This will be needed by CMake once we try to remove the wstring patch.