### PR TITLE
Profiler: Add Flame Graph tooltips

### DIFF
--- a/Userland/DevTools/Profiler/FlameGraphView.cpp
+++ b/Userland/DevTools/Profiler/FlameGraphView.cpp
@@ -116,11 +116,7 @@ void FlameGraphView::paint_event(GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
 
     for (const auto& bar : m_bars) {
-        auto label_index = bar.index.sibling_at_column(m_text_column);
-        String label = "All";
-        if (label_index.is_valid()) {
-            label = m_model.data(label_index).to_string();
-        }
+        auto label = bar_label(bar);
 
         auto color = m_colors[label.hash() % m_colors.size()];
 
@@ -146,6 +142,16 @@ void FlameGraphView::paint_event(GUI::PaintEvent& event)
                 Gfx::TextElision::Right);
         }
     }
+}
+
+String FlameGraphView::bar_label(StackBar const& bar) const
+{
+    auto label_index = bar.index.sibling_at_column(m_text_column);
+    String label = "All";
+    if (label_index.is_valid()) {
+        label = m_model.data(label_index).to_string();
+    }
+    return label;
 }
 
 void FlameGraphView::layout_bars()

--- a/Userland/DevTools/Profiler/FlameGraphView.cpp
+++ b/Userland/DevTools/Profiler/FlameGraphView.cpp
@@ -9,6 +9,7 @@
 #include "LibGfx/Forward.h"
 #include <AK/Function.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/Widget.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
 
@@ -82,6 +83,13 @@ void FlameGraphView::mousemove_event(GUI::MouseEvent& event)
 
     if (on_hover_change)
         on_hover_change();
+
+    String label = "";
+    if (m_hovered_bar != nullptr && m_hovered_bar->index.is_valid()) {
+        label = bar_label(*m_hovered_bar);
+    }
+    set_tooltip(label);
+    show_or_hide_tooltip();
 
     update();
 }

--- a/Userland/DevTools/Profiler/FlameGraphView.h
+++ b/Userland/DevTools/Profiler/FlameGraphView.h
@@ -45,6 +45,7 @@ private:
         bool selected;
     };
 
+    String bar_label(StackBar const&) const;
     void layout_bars();
     void layout_children(GUI::ModelIndex& parent, int depth, int left, int right, Vector<GUI::ModelIndex>& selected);
 


### PR DESCRIPTION
It often happens that the label in some Profiler Flame Graph box doesn't fit in the box, making it not possible to see what function the box represents.

This patch adds displaying tool tips when hovering over Profiler's Flame Graph boxes. The tool tip simply contains the label text.