### PR TITLE
LibC: The Widest Of All Wide Chars

### DIFF
--- a/Userland/Applications/Spreadsheet/CellType/Format.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Format.cpp
@@ -19,8 +19,8 @@ struct SingleEntryListNext {
     }
 };
 
-template<typename PutChFunc, typename ArgumentListRefT, template<typename T, typename U = ArgumentListRefT> typename NextArgument>
-struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument> {
+template<typename PutChFunc, typename ArgumentListRefT, template<typename T, typename U = ArgumentListRefT> typename NextArgument, typename CharType>
+struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument, CharType> {
     ALWAYS_INLINE PrintfImpl(PutChFunc& putch, char*& bufptr, const int& nwritten)
         : PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument>(putch, bufptr, nwritten)
     {

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -66,6 +66,7 @@ set(LIBC_SOURCES
     utsname.cpp
     wchar.cpp
     wctype.cpp
+    wstdio.cpp
 )
 
 file(GLOB AK_SOURCES CONFIGURE_DEPENDS "../../../AK/*.cpp")

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -44,7 +44,6 @@ set(LIBC_SOURCES
     string.cpp
     strings.cpp
     stubs.cpp
-    syslog.cpp
     sys/auxv.cpp
     sys/file.cpp
     sys/mman.cpp
@@ -52,10 +51,11 @@ set(LIBC_SOURCES
     sys/ptrace.cpp
     sys/select.cpp
     sys/socket.cpp
+    sys/statvfs.cpp
     sys/uio.cpp
     sys/wait.cpp
-    sys/statvfs.cpp
     sys/xattr.cpp
+    syslog.cpp
     termcap.cpp
     termios.cpp
     time.cpp

--- a/Userland/Libraries/LibC/bits/stdio_file_implementation.h
+++ b/Userland/Libraries/LibC/bits/stdio_file_implementation.h
@@ -40,7 +40,9 @@ public:
     size_t read(u8*, size_t);
     size_t write(const u8*, size_t);
 
-    bool gets(u8*, size_t);
+    template<typename CharType>
+    bool gets(CharType*, size_t);
+
     bool ungetc(u8 byte) { return m_buffer.enqueue_front(byte); }
 
     int seek(off_t offset, int whence);

--- a/Userland/Libraries/LibC/bits/stdio_file_implementation.h
+++ b/Userland/Libraries/LibC/bits/stdio_file_implementation.h
@@ -70,7 +70,7 @@ private:
         void realize(int fd);
         void drop();
 
-        bool may_use() const { return m_ungotten || m_mode != _IONBF; }
+        bool may_use() const;
         bool is_not_empty() const { return m_ungotten || !m_empty; }
         size_t buffered_size() const;
 

--- a/Userland/Libraries/LibC/bits/stdio_file_implementation.h
+++ b/Userland/Libraries/LibC/bits/stdio_file_implementation.h
@@ -4,9 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/Types.h>
 #include <LibC/bits/FILE.h>
 #include <LibC/bits/pthread_integration.h>
+#include <LibC/bits/wchar.h>
 #include <sys/types.h>
 
 #pragma once
@@ -85,6 +87,9 @@ private:
         bool enqueue_front(u8 byte);
 
     private:
+        constexpr static auto unget_buffer_size = MB_CUR_MAX;
+        constexpr static u32 ungotten_mask = ((u32)0xffffffff) >> (sizeof(u32) * 8 - unget_buffer_size);
+
         // Note: the fields here are arranged this way
         // to make sizeof(Buffer) smaller.
         u8* m_data { nullptr };
@@ -93,8 +98,8 @@ private:
         size_t m_end { 0 };
 
         int m_mode { -1 };
-        u8 m_unget_buffer { 0 };
-        bool m_ungotten : 1 { false };
+        Array<u8, unget_buffer_size> m_unget_buffer { 0 };
+        u32 m_ungotten : unget_buffer_size { 0 };
         bool m_data_is_malloced : 1 { false };
         // When m_begin == m_end, we want to distinguish whether
         // the buffer is full or empty.

--- a/Userland/Libraries/LibC/bits/stdio_file_implementation.h
+++ b/Userland/Libraries/LibC/bits/stdio_file_implementation.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Types.h>
+#include <LibC/bits/FILE.h>
+#include <LibC/bits/pthread_integration.h>
+#include <sys/types.h>
+
+#pragma once
+
+struct FILE {
+public:
+    FILE(int fd, int mode)
+        : m_fd(fd)
+        , m_mode(mode)
+    {
+        __pthread_mutex_init(&m_mutex, nullptr);
+    }
+    ~FILE();
+
+    static FILE* create(int fd, int mode);
+
+    void setbuf(u8* data, int mode, size_t size) { m_buffer.setbuf(data, mode, size); }
+
+    bool flush();
+    void purge();
+    bool close();
+
+    int fileno() const { return m_fd; }
+    bool eof() const { return m_eof; }
+    int mode() const { return m_mode; }
+    u8 flags() const { return m_flags; }
+
+    int error() const { return m_error; }
+    void clear_err() { m_error = 0; }
+
+    size_t read(u8*, size_t);
+    size_t write(const u8*, size_t);
+
+    bool gets(u8*, size_t);
+    bool ungetc(u8 byte) { return m_buffer.enqueue_front(byte); }
+
+    int seek(off_t offset, int whence);
+    off_t tell();
+
+    pid_t popen_child() { return m_popen_child; }
+    void set_popen_child(pid_t child_pid) { m_popen_child = child_pid; }
+
+    void reopen(int fd, int mode);
+
+    enum Flags : u8 {
+        None = 0,
+        LastRead = 1,
+        LastWrite = 2,
+    };
+
+private:
+    struct Buffer {
+        // A ringbuffer that also transparently implements ungetc().
+    public:
+        ~Buffer();
+
+        int mode() const { return m_mode; }
+        void setbuf(u8* data, int mode, size_t size);
+        // Make sure to call realize() before enqueuing any data.
+        // Dequeuing can be attempted without it.
+        void realize(int fd);
+        void drop();
+
+        bool may_use() const { return m_ungotten || m_mode != _IONBF; }
+        bool is_not_empty() const { return m_ungotten || !m_empty; }
+        size_t buffered_size() const;
+
+        const u8* begin_dequeue(size_t& available_size) const;
+        void did_dequeue(size_t actual_size);
+
+        u8* begin_enqueue(size_t& available_size) const;
+        void did_enqueue(size_t actual_size);
+
+        bool enqueue_front(u8 byte);
+
+    private:
+        // Note: the fields here are arranged this way
+        // to make sizeof(Buffer) smaller.
+        u8* m_data { nullptr };
+        size_t m_capacity { BUFSIZ };
+        size_t m_begin { 0 };
+        size_t m_end { 0 };
+
+        int m_mode { -1 };
+        u8 m_unget_buffer { 0 };
+        bool m_ungotten : 1 { false };
+        bool m_data_is_malloced : 1 { false };
+        // When m_begin == m_end, we want to distinguish whether
+        // the buffer is full or empty.
+        bool m_empty : 1 { true };
+    };
+
+    // Read or write using the underlying fd, bypassing the buffer.
+    ssize_t do_read(u8*, size_t);
+    ssize_t do_write(const u8*, size_t);
+
+    // Read some data into the buffer.
+    bool read_into_buffer();
+    // Flush *some* data from the buffer.
+    bool write_from_buffer();
+
+    void lock();
+    void unlock();
+
+    int m_fd { -1 };
+    int m_mode { 0 };
+    u8 m_flags { Flags::None };
+    int m_error { 0 };
+    bool m_eof { false };
+    pid_t m_popen_child { -1 };
+    Buffer m_buffer;
+    __pthread_mutex_t m_mutex;
+
+    friend class ScopedFileLock;
+};
+
+class ScopedFileLock {
+public:
+    ScopedFileLock(FILE* file)
+        : m_file(file)
+    {
+        m_file->lock();
+    }
+
+    ~ScopedFileLock()
+    {
+        m_file->unlock();
+    }
+
+private:
+    FILE* m_file;
+};

--- a/Userland/Libraries/LibC/bits/wchar.h
+++ b/Userland/Libraries/LibC/bits/wchar.h
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define MB_CUR_MAX 4
+#define MB_LEN_MAX 16

--- a/Userland/Libraries/LibC/limits.h
+++ b/Userland/Libraries/LibC/limits.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <bits/stdint.h>
+#include <bits/wchar.h>
 
 #ifndef PAGE_SIZE
 #    define PAGE_SIZE 4096
@@ -72,8 +73,6 @@
 
 #define LLONG_WIDTH 64
 #define ULLONG_WIDTH 64
-
-#define MB_LEN_MAX 16
 
 #define ARG_MAX 65536
 

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -341,6 +341,11 @@ FILE::Buffer::~Buffer()
         free(m_data);
 }
 
+bool FILE::Buffer::may_use() const
+{
+    return m_ungotten || m_mode != _IONBF;
+}
+
 void FILE::Buffer::realize(int fd)
 {
     if (m_mode == -1)

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -10,7 +10,7 @@
 #include <AK/ScopedValueRollback.h>
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
-#include <LibC/bits/pthread_integration.h>
+#include <LibC/bits/stdio_file_implementation.h>
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -24,118 +24,6 @@
 #include <sys/wait.h>
 #include <syscall.h>
 #include <unistd.h>
-
-struct FILE {
-public:
-    FILE(int fd, int mode)
-        : m_fd(fd)
-        , m_mode(mode)
-    {
-        __pthread_mutex_init(&m_mutex, nullptr);
-    }
-    ~FILE();
-
-    static FILE* create(int fd, int mode);
-
-    void setbuf(u8* data, int mode, size_t size) { m_buffer.setbuf(data, mode, size); }
-
-    bool flush();
-    void purge();
-    bool close();
-
-    int fileno() const { return m_fd; }
-    bool eof() const { return m_eof; }
-    int mode() const { return m_mode; }
-    u8 flags() const { return m_flags; }
-
-    int error() const { return m_error; }
-    void clear_err() { m_error = 0; }
-
-    size_t read(u8*, size_t);
-    size_t write(const u8*, size_t);
-
-    bool gets(u8*, size_t);
-    bool ungetc(u8 byte) { return m_buffer.enqueue_front(byte); }
-
-    int seek(off_t offset, int whence);
-    off_t tell();
-
-    pid_t popen_child() { return m_popen_child; }
-    void set_popen_child(pid_t child_pid) { m_popen_child = child_pid; }
-
-    void reopen(int fd, int mode);
-
-    enum Flags : u8 {
-        None = 0,
-        LastRead = 1,
-        LastWrite = 2,
-    };
-
-private:
-    struct Buffer {
-        // A ringbuffer that also transparently implements ungetc().
-    public:
-        ~Buffer();
-
-        int mode() const { return m_mode; }
-        void setbuf(u8* data, int mode, size_t size);
-        // Make sure to call realize() before enqueuing any data.
-        // Dequeuing can be attempted without it.
-        void realize(int fd);
-        void drop();
-
-        bool may_use() const { return m_ungotten || m_mode != _IONBF; }
-        bool is_not_empty() const { return m_ungotten || !m_empty; }
-        size_t buffered_size() const;
-
-        const u8* begin_dequeue(size_t& available_size) const;
-        void did_dequeue(size_t actual_size);
-
-        u8* begin_enqueue(size_t& available_size) const;
-        void did_enqueue(size_t actual_size);
-
-        bool enqueue_front(u8 byte);
-
-    private:
-        // Note: the fields here are arranged this way
-        // to make sizeof(Buffer) smaller.
-        u8* m_data { nullptr };
-        size_t m_capacity { BUFSIZ };
-        size_t m_begin { 0 };
-        size_t m_end { 0 };
-
-        int m_mode { -1 };
-        u8 m_unget_buffer { 0 };
-        bool m_ungotten : 1 { false };
-        bool m_data_is_malloced : 1 { false };
-        // When m_begin == m_end, we want to distinguish whether
-        // the buffer is full or empty.
-        bool m_empty : 1 { true };
-    };
-
-    // Read or write using the underlying fd, bypassing the buffer.
-    ssize_t do_read(u8*, size_t);
-    ssize_t do_write(const u8*, size_t);
-
-    // Read some data into the buffer.
-    bool read_into_buffer();
-    // Flush *some* data from the buffer.
-    bool write_from_buffer();
-
-    void lock();
-    void unlock();
-
-    int m_fd { -1 };
-    int m_mode { 0 };
-    u8 m_flags { Flags::None };
-    int m_error { 0 };
-    bool m_eof { false };
-    pid_t m_popen_child { -1 };
-    Buffer m_buffer;
-    __pthread_mutex_t m_mutex;
-
-    friend class ScopedFileLock;
-};
 
 FILE::~FILE()
 {
@@ -594,23 +482,6 @@ void FILE::unlock()
 {
     __pthread_mutex_unlock(&m_mutex);
 }
-
-class ScopedFileLock {
-public:
-    ScopedFileLock(FILE* file)
-        : m_file(file)
-    {
-        m_file->lock();
-    }
-
-    ~ScopedFileLock()
-    {
-        m_file->unlock();
-    }
-
-private:
-    FILE* m_file;
-};
 
 extern "C" {
 

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <bits/wchar.h>
 #include <stddef.h>
 #include <sys/cdefs.h>
 #include <sys/types.h>
@@ -14,7 +15,6 @@ __BEGIN_DECLS
 
 #define EXIT_SUCCESS 0
 #define EXIT_FAILURE 1
-#define MB_CUR_MAX 4
 
 __attribute__((noreturn)) void _abort();
 

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -479,12 +479,6 @@ long double wcstold(wchar_t const*, wchar_t**)
     TODO();
 }
 
-int swprintf(wchar_t*, size_t, wchar_t const*, ...)
-{
-    dbgln("TODO: Implement swprintf()");
-    TODO();
-}
-
 int wcwidth(wchar_t wc)
 {
     if (wc == L'\0')

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -45,7 +45,7 @@ static unsigned int mbstate_expected_bytes(mbstate_t* state)
 
 extern "C" {
 
-size_t wcslen(const wchar_t* str)
+size_t wcslen(wchar_t const* str)
 {
     size_t len = 0;
     while (*(str++))
@@ -53,7 +53,7 @@ size_t wcslen(const wchar_t* str)
     return len;
 }
 
-wchar_t* wcscpy(wchar_t* dest, const wchar_t* src)
+wchar_t* wcscpy(wchar_t* dest, wchar_t const* src)
 {
     wchar_t* original_dest = dest;
     while ((*dest++ = *src++) != '\0')
@@ -62,7 +62,7 @@ wchar_t* wcscpy(wchar_t* dest, const wchar_t* src)
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsdup.html
-wchar_t* wcsdup(const wchar_t* str)
+wchar_t* wcsdup(wchar_t const* str)
 {
     size_t length = wcslen(str);
     wchar_t* new_str = (wchar_t*)malloc(sizeof(wchar_t) * (length + 1));
@@ -75,7 +75,7 @@ wchar_t* wcsdup(const wchar_t* str)
     return wcscpy(new_str, str);
 }
 
-wchar_t* wcsncpy(wchar_t* dest, const wchar_t* src, size_t num)
+wchar_t* wcsncpy(wchar_t* dest, wchar_t const* src, size_t num)
 {
     wchar_t* original_dest = dest;
     while (((*dest++ = *src++) != '\0') && ((size_t)(dest - original_dest) < num))
@@ -83,7 +83,7 @@ wchar_t* wcsncpy(wchar_t* dest, const wchar_t* src, size_t num)
     return original_dest;
 }
 
-size_t wcslcpy(wchar_t* dest, const wchar_t* src, size_t n)
+size_t wcslcpy(wchar_t* dest, wchar_t const* src, size_t n)
 {
     size_t i;
     for (i = 0; i + 1 < n && src[i] != L'\0'; ++i)
@@ -95,28 +95,28 @@ size_t wcslcpy(wchar_t* dest, const wchar_t* src, size_t n)
     return i;
 }
 
-int wcscmp(const wchar_t* s1, const wchar_t* s2)
+int wcscmp(wchar_t const* s1, wchar_t const* s2)
 {
     while (*s1 == *s2++)
         if (*s1++ == 0)
             return 0;
-    return *(const wchar_t*)s1 - *(const wchar_t*)--s2;
+    return *(wchar_t const*)s1 - *(wchar_t const*)--s2;
 }
 
-int wcsncmp(const wchar_t* s1, const wchar_t* s2, size_t n)
+int wcsncmp(wchar_t const* s1, wchar_t const* s2, size_t n)
 {
     if (!n)
         return 0;
     do {
         if (*s1 != *s2++)
-            return *(const wchar_t*)s1 - *(const wchar_t*)--s2;
+            return *(wchar_t const*)s1 - *(wchar_t const*)--s2;
         if (*s1++ == 0)
             break;
     } while (--n);
     return 0;
 }
 
-wchar_t* wcschr(const wchar_t* str, int c)
+wchar_t* wcschr(wchar_t const* str, int c)
 {
     wchar_t ch = c;
     for (;; ++str) {
@@ -127,7 +127,7 @@ wchar_t* wcschr(const wchar_t* str, int c)
     }
 }
 
-wchar_t* wcsrchr(const wchar_t* str, wchar_t wc)
+wchar_t* wcsrchr(wchar_t const* str, wchar_t wc)
 {
     wchar_t* last = nullptr;
     wchar_t c;
@@ -138,7 +138,7 @@ wchar_t* wcsrchr(const wchar_t* str, wchar_t wc)
     return last;
 }
 
-wchar_t* wcscat(wchar_t* dest, const wchar_t* src)
+wchar_t* wcscat(wchar_t* dest, wchar_t const* src)
 {
     size_t dest_length = wcslen(dest);
     size_t i;
@@ -148,7 +148,7 @@ wchar_t* wcscat(wchar_t* dest, const wchar_t* src)
     return dest;
 }
 
-wchar_t* wcsncat(wchar_t* dest, const wchar_t* src, size_t n)
+wchar_t* wcsncat(wchar_t* dest, wchar_t const* src, size_t n)
 {
     size_t dest_length = wcslen(dest);
     size_t i;
@@ -158,7 +158,7 @@ wchar_t* wcsncat(wchar_t* dest, const wchar_t* src, size_t n)
     return dest;
 }
 
-wchar_t* wcstok(wchar_t* str, const wchar_t* delim, wchar_t** ptr)
+wchar_t* wcstok(wchar_t* str, wchar_t const* delim, wchar_t** ptr)
 {
     wchar_t* used_str = str;
     if (!used_str) {
@@ -203,13 +203,13 @@ wchar_t* wcstok(wchar_t* str, const wchar_t* delim, wchar_t** ptr)
     return &used_str[token_start];
 }
 
-long wcstol(const wchar_t*, wchar_t**, int)
+long wcstol(wchar_t const*, wchar_t**, int)
 {
     dbgln("FIXME: Implement wcstol()");
     TODO();
 }
 
-long long wcstoll(const wchar_t*, wchar_t**, int)
+long long wcstoll(wchar_t const*, wchar_t**, int)
 {
     dbgln("FIXME: Implement wcstoll()");
     TODO();
@@ -229,7 +229,7 @@ wint_t btowc(int c)
     return c;
 }
 
-size_t mbrtowc(wchar_t* pwc, const char* s, size_t n, mbstate_t* state)
+size_t mbrtowc(wchar_t* pwc, char const* s, size_t n, mbstate_t* state)
 {
     static mbstate_t _anonymous_state = {};
 
@@ -314,7 +314,7 @@ size_t mbrtowc(wchar_t* pwc, const char* s, size_t n, mbstate_t* state)
     return consumed_bytes;
 }
 
-size_t mbrlen(const char* s, size_t n, mbstate_t* ps)
+size_t mbrlen(char const* s, size_t n, mbstate_t* ps)
 {
     static mbstate_t anonymous_state = {};
 
@@ -342,14 +342,14 @@ size_t wcrtomb(char* s, wchar_t wc, mbstate_t*)
     }
 }
 
-int wcscoll(const wchar_t* ws1, const wchar_t* ws2)
+int wcscoll(wchar_t const* ws1, wchar_t const* ws2)
 {
     // TODO: Actually implement a sensible sort order for this,
     // because right now we are doing what LC_COLLATE=C would do.
     return wcscmp(ws1, ws2);
 }
 
-size_t wcsxfrm(wchar_t* dest, const wchar_t* src, size_t n)
+size_t wcsxfrm(wchar_t* dest, wchar_t const* src, size_t n)
 {
     // TODO: This needs to be changed when wcscoll is not just doing wcscmp
     return wcslcpy(dest, src, n);
@@ -363,7 +363,7 @@ int wctob(wint_t c)
     return static_cast<unsigned char>(c);
 }
 
-int mbsinit(const mbstate_t* state)
+int mbsinit(mbstate_t const* state)
 {
     if (!state) {
         return 1;
@@ -376,9 +376,9 @@ int mbsinit(const mbstate_t* state)
     return 1;
 }
 
-wchar_t* wcspbrk(const wchar_t* wcs, const wchar_t* accept)
+wchar_t* wcspbrk(wchar_t const* wcs, wchar_t const* accept)
 {
-    for (const wchar_t* cur = accept; *cur; cur++) {
+    for (wchar_t const* cur = accept; *cur; cur++) {
         wchar_t* res = wcschr(wcs, *cur);
         if (res)
             return res;
@@ -387,7 +387,7 @@ wchar_t* wcspbrk(const wchar_t* wcs, const wchar_t* accept)
     return nullptr;
 }
 
-wchar_t* wcsstr(const wchar_t* haystack, const wchar_t* needle)
+wchar_t* wcsstr(wchar_t const* haystack, wchar_t const* needle)
 {
     size_t nlen = wcslen(needle);
 
@@ -407,7 +407,7 @@ wchar_t* wcsstr(const wchar_t* haystack, const wchar_t* needle)
     return nullptr;
 }
 
-wchar_t* wmemchr(const wchar_t* s, wchar_t c, size_t n)
+wchar_t* wmemchr(wchar_t const* s, wchar_t c, size_t n)
 {
     for (size_t i = 0; i < n; i++) {
         if (s[i] == c)
@@ -417,7 +417,7 @@ wchar_t* wmemchr(const wchar_t* s, wchar_t c, size_t n)
     return nullptr;
 }
 
-wchar_t* wmemcpy(wchar_t* dest, const wchar_t* src, size_t n)
+wchar_t* wmemcpy(wchar_t* dest, wchar_t const* src, size_t n)
 {
     for (size_t i = 0; i < n; i++)
         dest[i] = src[i];
@@ -434,7 +434,7 @@ wchar_t* wmemset(wchar_t* wcs, wchar_t wc, size_t n)
     return wcs;
 }
 
-wchar_t* wmemmove(wchar_t* dest, const wchar_t* src, size_t n)
+wchar_t* wmemmove(wchar_t* dest, wchar_t const* src, size_t n)
 {
     if (dest > src) {
         for (size_t i = 1; i <= n; i++) {
@@ -449,37 +449,37 @@ wchar_t* wmemmove(wchar_t* dest, const wchar_t* src, size_t n)
     return dest;
 }
 
-unsigned long wcstoul(const wchar_t*, wchar_t**, int)
+unsigned long wcstoul(wchar_t const*, wchar_t**, int)
 {
     dbgln("TODO: Implement wcstoul()");
     TODO();
 }
 
-unsigned long long wcstoull(const wchar_t*, wchar_t**, int)
+unsigned long long wcstoull(wchar_t const*, wchar_t**, int)
 {
     dbgln("TODO: Implement wcstoull()");
     TODO();
 }
 
-float wcstof(const wchar_t*, wchar_t**)
+float wcstof(wchar_t const*, wchar_t**)
 {
     dbgln("TODO: Implement wcstof()");
     TODO();
 }
 
-double wcstod(const wchar_t*, wchar_t**)
+double wcstod(wchar_t const*, wchar_t**)
 {
     dbgln("TODO: Implement wcstod()");
     TODO();
 }
 
-long double wcstold(const wchar_t*, wchar_t**)
+long double wcstold(wchar_t const*, wchar_t**)
 {
     dbgln("TODO: Implement wcstold()");
     TODO();
 }
 
-int swprintf(wchar_t*, size_t, const wchar_t*, ...)
+int swprintf(wchar_t*, size_t, wchar_t const*, ...)
 {
     dbgln("TODO: Implement swprintf()");
     TODO();
@@ -502,7 +502,7 @@ int wcwidth(wchar_t wc)
     return 1;
 }
 
-size_t wcsnrtombs(char* dest, const wchar_t** src, size_t nwc, size_t len, mbstate_t* ps)
+size_t wcsnrtombs(char* dest, wchar_t const** src, size_t nwc, size_t len, mbstate_t* ps)
 {
     static mbstate_t _anonymous_state = {};
 
@@ -548,7 +548,7 @@ size_t wcsnrtombs(char* dest, const wchar_t** src, size_t nwc, size_t len, mbsta
     return written;
 }
 
-size_t mbsnrtowcs(wchar_t* dst, const char** src, size_t nms, size_t len, mbstate_t* ps)
+size_t mbsnrtowcs(wchar_t* dst, char const** src, size_t nms, size_t len, mbstate_t* ps)
 {
     static mbstate_t _anonymous_state = {};
 
@@ -596,7 +596,7 @@ size_t mbsnrtowcs(wchar_t* dst, const char** src, size_t nms, size_t len, mbstat
     return written;
 }
 
-int wmemcmp(const wchar_t* s1, const wchar_t* s2, size_t n)
+int wmemcmp(wchar_t const* s1, wchar_t const* s2, size_t n)
 {
     while (n-- > 0) {
         if (*s1++ != *s2++)
@@ -605,7 +605,7 @@ int wmemcmp(const wchar_t* s1, const wchar_t* s2, size_t n)
     return 0;
 }
 
-size_t wcsrtombs(char* dest, const wchar_t** src, size_t len, mbstate_t* ps)
+size_t wcsrtombs(char* dest, wchar_t const** src, size_t len, mbstate_t* ps)
 {
     static mbstate_t anonymous_state = {};
 
@@ -616,7 +616,7 @@ size_t wcsrtombs(char* dest, const wchar_t** src, size_t len, mbstate_t* ps)
     return wcsnrtombs(dest, src, SIZE_MAX, len, ps);
 }
 
-size_t mbsrtowcs(wchar_t* dst, const char** src, size_t len, mbstate_t* ps)
+size_t mbsrtowcs(wchar_t* dst, char const** src, size_t len, mbstate_t* ps)
 {
     static mbstate_t anonymous_state = {};
 

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -45,6 +45,7 @@ static unsigned int mbstate_expected_bytes(mbstate_t* state)
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcslen.html
 size_t wcslen(wchar_t const* str)
 {
     size_t len = 0;
@@ -53,6 +54,7 @@ size_t wcslen(wchar_t const* str)
     return len;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcscpy.html
 wchar_t* wcscpy(wchar_t* dest, wchar_t const* src)
 {
     wchar_t* original_dest = dest;
@@ -75,6 +77,7 @@ wchar_t* wcsdup(wchar_t const* str)
     return wcscpy(new_str, str);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsncpy.html
 wchar_t* wcsncpy(wchar_t* dest, wchar_t const* src, size_t num)
 {
     wchar_t* original_dest = dest;
@@ -95,6 +98,7 @@ size_t wcslcpy(wchar_t* dest, wchar_t const* src, size_t n)
     return i;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcscmp.html
 int wcscmp(wchar_t const* s1, wchar_t const* s2)
 {
     while (*s1 == *s2++)
@@ -103,6 +107,7 @@ int wcscmp(wchar_t const* s1, wchar_t const* s2)
     return *(wchar_t const*)s1 - *(wchar_t const*)--s2;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsncmp.html
 int wcsncmp(wchar_t const* s1, wchar_t const* s2, size_t n)
 {
     if (!n)
@@ -116,6 +121,7 @@ int wcsncmp(wchar_t const* s1, wchar_t const* s2, size_t n)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcschr.html
 wchar_t* wcschr(wchar_t const* str, int c)
 {
     wchar_t ch = c;
@@ -127,6 +133,7 @@ wchar_t* wcschr(wchar_t const* str, int c)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsrchr.html
 wchar_t* wcsrchr(wchar_t const* str, wchar_t wc)
 {
     wchar_t* last = nullptr;
@@ -138,6 +145,7 @@ wchar_t* wcsrchr(wchar_t const* str, wchar_t wc)
     return last;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcscat.html
 wchar_t* wcscat(wchar_t* dest, wchar_t const* src)
 {
     size_t dest_length = wcslen(dest);
@@ -148,6 +156,7 @@ wchar_t* wcscat(wchar_t* dest, wchar_t const* src)
     return dest;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsncat.html
 wchar_t* wcsncat(wchar_t* dest, wchar_t const* src, size_t n)
 {
     size_t dest_length = wcslen(dest);
@@ -158,6 +167,7 @@ wchar_t* wcsncat(wchar_t* dest, wchar_t const* src, size_t n)
     return dest;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstok.html
 wchar_t* wcstok(wchar_t* str, wchar_t const* delim, wchar_t** ptr)
 {
     wchar_t* used_str = str;
@@ -203,18 +213,21 @@ wchar_t* wcstok(wchar_t* str, wchar_t const* delim, wchar_t** ptr)
     return &used_str[token_start];
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstol.html
 long wcstol(wchar_t const*, wchar_t**, int)
 {
     dbgln("FIXME: Implement wcstol()");
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstoll.html
 long long wcstoll(wchar_t const*, wchar_t**, int)
 {
     dbgln("FIXME: Implement wcstoll()");
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/btowc.html
 wint_t btowc(int c)
 {
     if (c == EOF) {
@@ -229,6 +242,7 @@ wint_t btowc(int c)
     return c;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mbrtowc.html
 size_t mbrtowc(wchar_t* pwc, char const* s, size_t n, mbstate_t* state)
 {
     static mbstate_t _anonymous_state = {};
@@ -314,6 +328,7 @@ size_t mbrtowc(wchar_t* pwc, char const* s, size_t n, mbstate_t* state)
     return consumed_bytes;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mbrlen.html
 size_t mbrlen(char const* s, size_t n, mbstate_t* ps)
 {
     static mbstate_t anonymous_state = {};
@@ -324,6 +339,7 @@ size_t mbrlen(char const* s, size_t n, mbstate_t* ps)
     return mbrtowc(nullptr, s, n, ps);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcrtomb.html
 size_t wcrtomb(char* s, wchar_t wc, mbstate_t*)
 {
     if (s == nullptr)
@@ -342,6 +358,7 @@ size_t wcrtomb(char* s, wchar_t wc, mbstate_t*)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcscoll.html
 int wcscoll(wchar_t const* ws1, wchar_t const* ws2)
 {
     // TODO: Actually implement a sensible sort order for this,
@@ -349,12 +366,14 @@ int wcscoll(wchar_t const* ws1, wchar_t const* ws2)
     return wcscmp(ws1, ws2);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsxfrm.html
 size_t wcsxfrm(wchar_t* dest, wchar_t const* src, size_t n)
 {
     // TODO: This needs to be changed when wcscoll is not just doing wcscmp
     return wcslcpy(dest, src, n);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wctob.html
 int wctob(wint_t c)
 {
     if (c > 0x7f)
@@ -363,6 +382,7 @@ int wctob(wint_t c)
     return static_cast<unsigned char>(c);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mbsinit.html
 int mbsinit(mbstate_t const* state)
 {
     if (!state) {
@@ -376,6 +396,7 @@ int mbsinit(mbstate_t const* state)
     return 1;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcspbrk.html
 wchar_t* wcspbrk(wchar_t const* wcs, wchar_t const* accept)
 {
     for (wchar_t const* cur = accept; *cur; cur++) {
@@ -387,6 +408,7 @@ wchar_t* wcspbrk(wchar_t const* wcs, wchar_t const* accept)
     return nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsstr.html
 wchar_t* wcsstr(wchar_t const* haystack, wchar_t const* needle)
 {
     size_t nlen = wcslen(needle);
@@ -407,6 +429,7 @@ wchar_t* wcsstr(wchar_t const* haystack, wchar_t const* needle)
     return nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wmemchr.html
 wchar_t* wmemchr(wchar_t const* s, wchar_t c, size_t n)
 {
     for (size_t i = 0; i < n; i++) {
@@ -417,6 +440,7 @@ wchar_t* wmemchr(wchar_t const* s, wchar_t c, size_t n)
     return nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wmemcpy.html
 wchar_t* wmemcpy(wchar_t* dest, wchar_t const* src, size_t n)
 {
     for (size_t i = 0; i < n; i++)
@@ -425,6 +449,7 @@ wchar_t* wmemcpy(wchar_t* dest, wchar_t const* src, size_t n)
     return dest;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wmemset.html
 wchar_t* wmemset(wchar_t* wcs, wchar_t wc, size_t n)
 {
     for (size_t i = 0; i < n; i++) {
@@ -434,6 +459,7 @@ wchar_t* wmemset(wchar_t* wcs, wchar_t wc, size_t n)
     return wcs;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wmemmove.html
 wchar_t* wmemmove(wchar_t* dest, wchar_t const* src, size_t n)
 {
     if (dest > src) {
@@ -449,36 +475,42 @@ wchar_t* wmemmove(wchar_t* dest, wchar_t const* src, size_t n)
     return dest;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstoul.html
 unsigned long wcstoul(wchar_t const*, wchar_t**, int)
 {
     dbgln("TODO: Implement wcstoul()");
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstoull.html
 unsigned long long wcstoull(wchar_t const*, wchar_t**, int)
 {
     dbgln("TODO: Implement wcstoull()");
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstof.html
 float wcstof(wchar_t const*, wchar_t**)
 {
     dbgln("TODO: Implement wcstof()");
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstod.html
 double wcstod(wchar_t const*, wchar_t**)
 {
     dbgln("TODO: Implement wcstod()");
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstold.html
 long double wcstold(wchar_t const*, wchar_t**)
 {
     dbgln("TODO: Implement wcstold()");
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcwidth.html
 int wcwidth(wchar_t wc)
 {
     if (wc == L'\0')
@@ -496,6 +528,7 @@ int wcwidth(wchar_t wc)
     return 1;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsnrtombs.html
 size_t wcsnrtombs(char* dest, wchar_t const** src, size_t nwc, size_t len, mbstate_t* ps)
 {
     static mbstate_t _anonymous_state = {};
@@ -542,6 +575,7 @@ size_t wcsnrtombs(char* dest, wchar_t const** src, size_t nwc, size_t len, mbsta
     return written;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mbsnrtowcs.html
 size_t mbsnrtowcs(wchar_t* dst, char const** src, size_t nms, size_t len, mbstate_t* ps)
 {
     static mbstate_t _anonymous_state = {};
@@ -590,6 +624,7 @@ size_t mbsnrtowcs(wchar_t* dst, char const** src, size_t nms, size_t len, mbstat
     return written;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wmemcmp.html
 int wmemcmp(wchar_t const* s1, wchar_t const* s2, size_t n)
 {
     while (n-- > 0) {
@@ -599,6 +634,7 @@ int wmemcmp(wchar_t const* s1, wchar_t const* s2, size_t n)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsrtombs.html
 size_t wcsrtombs(char* dest, wchar_t const** src, size_t len, mbstate_t* ps)
 {
     static mbstate_t anonymous_state = {};
@@ -610,6 +646,7 @@ size_t wcsrtombs(char* dest, wchar_t const** src, size_t len, mbstate_t* ps)
     return wcsnrtombs(dest, src, SIZE_MAX, len, ps);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mbsrtowcs.html
 size_t mbsrtowcs(wchar_t* dst, char const** src, size_t len, mbstate_t* ps)
 {
     static mbstate_t anonymous_state = {};
@@ -621,6 +658,7 @@ size_t mbsrtowcs(wchar_t* dst, char const** src, size_t len, mbstate_t* ps)
     return mbsnrtowcs(dst, src, SIZE_MAX, len, ps);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcscspn.html
 size_t wcscspn(wchar_t const* wcs, wchar_t const* reject)
 {
     for (auto const* wc_pointer = wcs;;) {
@@ -634,6 +672,7 @@ size_t wcscspn(wchar_t const* wcs, wchar_t const* reject)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsspn.html
 size_t wcsspn(wchar_t const* wcs, wchar_t const* accept)
 {
     for (auto const* wc_pointer = wcs;;) {
@@ -647,6 +686,7 @@ size_t wcsspn(wchar_t const* wcs, wchar_t const* accept)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcsftime.html
 size_t wcsftime(wchar_t* __restrict wcs, size_t maxsize, wchar_t const* __restrict format, const struct tm* __restrict timeptr)
 {
     (void)wcs;

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -646,4 +646,14 @@ size_t wcsspn(wchar_t const* wcs, wchar_t const* accept)
         } while (rc != 0);
     }
 }
+
+size_t wcsftime(wchar_t* __restrict wcs, size_t maxsize, wchar_t const* __restrict format, const struct tm* __restrict timeptr)
+{
+    (void)wcs;
+    (void)maxsize;
+    (void)format;
+    (void)timeptr;
+    dbgln("FIXME: Implement wcsftime()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wchar.cpp
+++ b/Userland/Libraries/LibC/wchar.cpp
@@ -626,4 +626,30 @@ size_t mbsrtowcs(wchar_t* dst, char const** src, size_t len, mbstate_t* ps)
     // SIZE_MAX is as close as we are going to get to "unlimited".
     return mbsnrtowcs(dst, src, SIZE_MAX, len, ps);
 }
+
+size_t wcscspn(wchar_t const* wcs, wchar_t const* reject)
+{
+    for (auto const* wc_pointer = wcs;;) {
+        auto c = *wc_pointer++;
+        wchar_t rc;
+        auto const* reject_copy = reject;
+        do {
+            if ((rc = *reject_copy++) == c)
+                return wc_pointer - 1 - wcs;
+        } while (rc != 0);
+    }
+}
+
+size_t wcsspn(wchar_t const* wcs, wchar_t const* accept)
+{
+    for (auto const* wc_pointer = wcs;;) {
+        auto c = *wc_pointer++;
+        wchar_t rc;
+        auto const* accept_copy = accept;
+        do {
+            if ((rc = *accept_copy++) != c)
+                return wc_pointer - 1 - wcs;
+        } while (rc != 0);
+    }
+}
 }

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -95,4 +95,6 @@ int vfwscanf(FILE* __restrict stream, const wchar_t* __restrict format, va_list 
 int vswscanf(const wchar_t* __restrict ws, const wchar_t* __restrict format, va_list arg);
 int vwscanf(const wchar_t* __restrict format, va_list arg);
 
+size_t wcsftime(wchar_t* __restrict wcs, size_t maxsize, const wchar_t* __restrict format, const struct tm* __restrict timeptr);
+
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -77,5 +77,6 @@ wint_t getwchar(void);
 wint_t fputwc(wchar_t wc, FILE* stream);
 wint_t putwc(wchar_t wc, FILE* stream);
 wint_t putwchar(wchar_t wc);
+int fwide(FILE* stream, int mode);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -13,8 +13,13 @@
 
 __BEGIN_DECLS
 
+// Note: wint_t is unsigned on gcc, and signed on clang.
 #ifndef WEOF
-#    define WEOF (0xffffffffu)
+#    ifdef __clang__
+#        define WEOF (-1)
+#    else
+#        define WEOF (0xffffffffu)
+#    endif
 #endif
 
 #undef WCHAR_MAX

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -87,4 +87,11 @@ int vwprintf(const wchar_t* __restrict format, va_list args);
 int vfwprintf(FILE* __restrict stream, const wchar_t* __restrict format, va_list args);
 int vswprintf(wchar_t* __restrict wcs, size_t maxlen, const wchar_t* __restrict format, va_list args);
 
+int fwscanf(FILE* __restrict stream, const wchar_t* __restrict format, ...);
+int swscanf(const wchar_t* __restrict ws, const wchar_t* __restrict format, ...);
+int wscanf(const wchar_t* __restrict format, ...);
+int vfwscanf(FILE* __restrict stream, const wchar_t* __restrict format, va_list arg);
+int vswscanf(const wchar_t* __restrict ws, const wchar_t* __restrict format, va_list arg);
+int vwscanf(const wchar_t* __restrict format, va_list arg);
+
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -61,7 +61,6 @@ unsigned long long wcstoull(const wchar_t*, wchar_t**, int);
 float wcstof(const wchar_t*, wchar_t**);
 double wcstod(const wchar_t*, wchar_t**);
 long double wcstold(const wchar_t*, wchar_t**);
-int swprintf(wchar_t*, size_t, const wchar_t*, ...);
 int wcwidth(wchar_t);
 size_t wcsrtombs(char*, const wchar_t**, size_t, mbstate_t*);
 size_t mbsrtowcs(wchar_t*, const char**, size_t, mbstate_t*);
@@ -80,5 +79,12 @@ wint_t putwchar(wchar_t wc);
 wchar_t* fgetws(wchar_t* __restrict ws, int n, FILE* __restrict stream);
 int fputws(const wchar_t* __restrict ws, FILE* __restrict stream);
 int fwide(FILE* stream, int mode);
+
+int wprintf(const wchar_t* __restrict format, ...);
+int fwprintf(FILE* __restrict stream, const wchar_t* __restrict format, ...);
+int swprintf(wchar_t* __restrict wcs, size_t maxlen, const wchar_t* __restrict format, ...);
+int vwprintf(const wchar_t* __restrict format, va_list args);
+int vfwprintf(FILE* __restrict stream, const wchar_t* __restrict format, va_list args);
+int vswprintf(wchar_t* __restrict wcs, size_t maxlen, const wchar_t* __restrict format, va_list args);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -78,6 +78,7 @@ wint_t putwc(wchar_t wc, FILE* stream);
 wint_t putwchar(wchar_t wc);
 wchar_t* fgetws(wchar_t* __restrict ws, int n, FILE* __restrict stream);
 int fputws(const wchar_t* __restrict ws, FILE* __restrict stream);
+wint_t ungetwc(wint_t wc, FILE* stream);
 int fwide(FILE* stream, int mode);
 
 int wprintf(const wchar_t* __restrict format, ...);

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <bits/FILE.h>
+#include <stdarg.h>
 #include <stddef.h>
 #include <sys/cdefs.h>
 
@@ -68,5 +70,8 @@ size_t wcsnrtombs(char*, const wchar_t**, size_t, size_t, mbstate_t*);
 size_t mbsnrtowcs(wchar_t*, const char**, size_t, size_t, mbstate_t*);
 size_t wcscspn(const wchar_t* wcs, const wchar_t* reject);
 size_t wcsspn(const wchar_t* wcs, const wchar_t* accept);
+
+wint_t fgetwc(FILE* stream);
+wint_t getwc(FILE* stream);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -73,5 +73,6 @@ size_t wcsspn(const wchar_t* wcs, const wchar_t* accept);
 
 wint_t fgetwc(FILE* stream);
 wint_t getwc(FILE* stream);
+wint_t getwchar(void);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -66,5 +66,7 @@ size_t mbsrtowcs(wchar_t*, const char**, size_t, mbstate_t*);
 int wmemcmp(const wchar_t*, const wchar_t*, size_t);
 size_t wcsnrtombs(char*, const wchar_t**, size_t, size_t, mbstate_t*);
 size_t mbsnrtowcs(wchar_t*, const char**, size_t, size_t, mbstate_t*);
+size_t wcscspn(const wchar_t* wcs, const wchar_t* reject);
+size_t wcsspn(const wchar_t* wcs, const wchar_t* accept);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -77,6 +77,8 @@ wint_t getwchar(void);
 wint_t fputwc(wchar_t wc, FILE* stream);
 wint_t putwc(wchar_t wc, FILE* stream);
 wint_t putwchar(wchar_t wc);
+wchar_t* fgetws(wchar_t* __restrict ws, int n, FILE* __restrict stream);
+int fputws(const wchar_t* __restrict ws, FILE* __restrict stream);
 int fwide(FILE* stream, int mode);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -74,5 +74,8 @@ size_t wcsspn(const wchar_t* wcs, const wchar_t* accept);
 wint_t fgetwc(FILE* stream);
 wint_t getwc(FILE* stream);
 wint_t getwchar(void);
+wint_t fputwc(wchar_t wc, FILE* stream);
+wint_t putwc(wchar_t wc, FILE* stream);
+wint_t putwchar(wchar_t wc);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -17,6 +17,16 @@ __BEGIN_DECLS
 #    define WEOF (0xffffffffu)
 #endif
 
+#undef WCHAR_MAX
+#undef WCHAR_MIN
+#define WCHAR_MAX __WCHAR_MAX__
+#ifdef __WCHAR_MIN__
+#    define WCHAR_MIN __WCHAR_MIN__
+#else
+// Note: This assumes that wchar_t is a signed type.
+#    define WCHAR_MIN (-WCHAR_MAX - 1)
+#endif
+
 typedef __WINT_TYPE__ wint_t;
 typedef unsigned long int wctype_t;
 

--- a/Userland/Libraries/LibC/wstdio.cpp
+++ b/Userland/Libraries/LibC/wstdio.cpp
@@ -98,4 +98,24 @@ wint_t putwchar(wchar_t wc)
 {
     return fputwc(wc, stdout);
 }
+
+wchar_t* fgetws(wchar_t* __restrict buffer, int size, FILE* __restrict stream)
+{
+    VERIFY(stream);
+    ScopedFileLock lock(stream);
+    bool ok = stream->gets(bit_cast<u32*>(buffer), size);
+    return ok ? buffer : nullptr;
+}
+
+int fputws(wchar_t const* __restrict ws, FILE* __restrict stream)
+{
+    VERIFY(stream);
+    ScopedFileLock lock(stream);
+    int size = 0;
+    for (auto const* p = ws; *p != 0; ++p, ++size) {
+        if (putwc(*p, stream) == WEOF)
+            return WEOF;
+    }
+    return size;
+}
 }

--- a/Userland/Libraries/LibC/wstdio.cpp
+++ b/Userland/Libraries/LibC/wstdio.cpp
@@ -174,4 +174,57 @@ int vswprintf(wchar_t* __restrict wcs, size_t max_length, wchar_t const* __restr
         wcs, fmt, args);
     return static_cast<int>(length_so_far);
 }
+
+int fwscanf(FILE* __restrict stream, wchar_t const* __restrict format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    auto rc = vfwscanf(stream, format, ap);
+    va_end(ap);
+    return rc;
+}
+
+int swscanf(wchar_t const* __restrict ws, wchar_t const* __restrict format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    auto rc = vswscanf(ws, format, ap);
+    va_end(ap);
+    return rc;
+}
+
+int wscanf(wchar_t const* __restrict format, ...)
+{
+    va_list ap;
+    va_start(ap, format);
+    auto rc = vfwscanf(stdout, format, ap);
+    va_end(ap);
+    return rc;
+}
+
+int vfwscanf(FILE* __restrict stream, wchar_t const* __restrict format, va_list arg)
+{
+    (void)stream;
+    (void)format;
+    (void)arg;
+    dbgln("FIXME: Implement vfwscanf()");
+    TODO();
+}
+
+int vswscanf(wchar_t const* __restrict ws, wchar_t const* __restrict format, va_list arg)
+{
+    (void)ws;
+    (void)format;
+    (void)arg;
+    dbgln("FIXME: Implement vswscanf()");
+    TODO();
+}
+
+int vwscanf(wchar_t const* __restrict format, va_list arg)
+{
+    (void)format;
+    (void)arg;
+    dbgln("FIXME: Implement vwscanf()");
+    TODO();
+}
 }

--- a/Userland/Libraries/LibC/wstdio.cpp
+++ b/Userland/Libraries/LibC/wstdio.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <AK/StringBuilder.h>
+#include <AK/Types.h>
+#include <bits/stdio_file_implementation.h>
+#include <errno.h>
+#include <stdio.h>
+#include <wchar.h>
+
+static_assert(AssertSize<wchar_t, sizeof(u32)>());
+
+extern "C" {
+
+wint_t fgetwc(FILE* stream)
+{
+    VERIFY(stream);
+    Array<u8, 4> underlying;
+    auto underlying_bytes = underlying.span();
+    size_t encoded_length = 0;
+    size_t bytes_read = 0;
+    do {
+        size_t nread = fread(underlying_bytes.offset_pointer(bytes_read), 1, 1, stream);
+        if (nread != 1) {
+            errno = EILSEQ;
+            return WEOF;
+        }
+        ++bytes_read;
+        if (bytes_read == 1) {
+            if (underlying[0] >> 7 == 0) {
+                encoded_length = 1;
+            } else if (underlying[0] >> 5 == 6) {
+                encoded_length = 2;
+            } else if (underlying[0] >> 4 == 0xe) {
+                encoded_length = 3;
+            } else if (underlying[0] >> 3 == 0x1e) {
+                encoded_length = 4;
+            } else {
+                errno = EILSEQ;
+                return WEOF;
+            }
+        }
+    } while (bytes_read < encoded_length);
+
+    wchar_t code_point;
+    auto read_bytes = mbrtowc(&code_point, bit_cast<char const*>(underlying.data()), encoded_length, nullptr);
+    VERIFY(read_bytes == encoded_length);
+    return code_point;
+}
+
+wint_t getwc(FILE* stream)
+{
+    return fgetwc(stream);
+}
+}

--- a/Userland/Libraries/LibC/wstdio.cpp
+++ b/Userland/Libraries/LibC/wstdio.cpp
@@ -56,4 +56,9 @@ wint_t getwc(FILE* stream)
 {
     return fgetwc(stream);
 }
+
+wint_t getwchar()
+{
+    return getwc(stdin);
+}
 }

--- a/Userland/Libraries/LibC/wstdio.cpp
+++ b/Userland/Libraries/LibC/wstdio.cpp
@@ -18,12 +18,14 @@ static_assert(AssertSize<wchar_t, sizeof(u32)>());
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fwide.html
 int fwide(FILE*, int mode)
 {
     // Nope Nope Nope.
     return mode;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fgetwc.html
 wint_t fgetwc(FILE* stream)
 {
     VERIFY(stream);
@@ -60,16 +62,19 @@ wint_t fgetwc(FILE* stream)
     return code_point;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getwc.html
 wint_t getwc(FILE* stream)
 {
     return fgetwc(stream);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getwchar.html
 wint_t getwchar()
 {
     return getwc(stdin);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fputwc.html
 wint_t fputwc(wchar_t wc, FILE* stream)
 {
     VERIFY(stream);
@@ -90,16 +95,19 @@ wint_t fputwc(wchar_t wc, FILE* stream)
     return wc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/putwc.html
 wint_t putwc(wchar_t wc, FILE* stream)
 {
     return fputwc(wc, stream);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/putwchar.html
 wint_t putwchar(wchar_t wc)
 {
     return fputwc(wc, stdout);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fgetws.html
 wchar_t* fgetws(wchar_t* __restrict buffer, int size, FILE* __restrict stream)
 {
     VERIFY(stream);
@@ -108,6 +116,7 @@ wchar_t* fgetws(wchar_t* __restrict buffer, int size, FILE* __restrict stream)
     return ok ? buffer : nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fputws.html
 int fputws(wchar_t const* __restrict ws, FILE* __restrict stream)
 {
     VERIFY(stream);
@@ -120,6 +129,7 @@ int fputws(wchar_t const* __restrict ws, FILE* __restrict stream)
     return size;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/ungetwc.html
 wint_t ungetwc(wint_t wc, FILE* stream)
 {
     VERIFY(stream);
@@ -139,6 +149,7 @@ wint_t ungetwc(wint_t wc, FILE* stream)
     return wc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wprintf.html
 int wprintf(wchar_t const* __restrict format, ...)
 {
     va_list ap;
@@ -148,6 +159,7 @@ int wprintf(wchar_t const* __restrict format, ...)
     return rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fwprintf.html
 int fwprintf(FILE* __restrict stream, wchar_t const* __restrict format, ...)
 {
     va_list ap;
@@ -157,6 +169,7 @@ int fwprintf(FILE* __restrict stream, wchar_t const* __restrict format, ...)
     return rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/swprintf.html
 int swprintf(wchar_t* __restrict wcs, size_t max_length, wchar_t const* __restrict format, ...)
 {
     va_list ap;
@@ -166,11 +179,13 @@ int swprintf(wchar_t* __restrict wcs, size_t max_length, wchar_t const* __restri
     return rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vwprintf.html
 int vwprintf(wchar_t const* __restrict format, va_list args)
 {
     return vfwprintf(stdout, format, args);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vfwprintf.html
 int vfwprintf(FILE* __restrict stream, wchar_t const* __restrict format, va_list args)
 {
     auto const* fmt = bit_cast<wchar_t const*>(format);
@@ -180,6 +195,7 @@ int vfwprintf(FILE* __restrict stream, wchar_t const* __restrict format, va_list
         nullptr, fmt, args);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vswprintf.html
 int vswprintf(wchar_t* __restrict wcs, size_t max_length, wchar_t const* __restrict format, va_list args)
 {
     auto const* fmt = bit_cast<wchar_t const*>(format);
@@ -194,6 +210,7 @@ int vswprintf(wchar_t* __restrict wcs, size_t max_length, wchar_t const* __restr
     return static_cast<int>(length_so_far);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fwscanf.html
 int fwscanf(FILE* __restrict stream, wchar_t const* __restrict format, ...)
 {
     va_list ap;
@@ -203,6 +220,7 @@ int fwscanf(FILE* __restrict stream, wchar_t const* __restrict format, ...)
     return rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/swscanf.html
 int swscanf(wchar_t const* __restrict ws, wchar_t const* __restrict format, ...)
 {
     va_list ap;
@@ -212,6 +230,7 @@ int swscanf(wchar_t const* __restrict ws, wchar_t const* __restrict format, ...)
     return rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wscanf.html
 int wscanf(wchar_t const* __restrict format, ...)
 {
     va_list ap;
@@ -221,6 +240,7 @@ int wscanf(wchar_t const* __restrict format, ...)
     return rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vfwscanf.html
 int vfwscanf(FILE* __restrict stream, wchar_t const* __restrict format, va_list arg)
 {
     (void)stream;
@@ -230,6 +250,7 @@ int vfwscanf(FILE* __restrict stream, wchar_t const* __restrict format, va_list 
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vswscanf.html
 int vswscanf(wchar_t const* __restrict ws, wchar_t const* __restrict format, va_list arg)
 {
     (void)ws;
@@ -239,6 +260,7 @@ int vswscanf(wchar_t const* __restrict ws, wchar_t const* __restrict format, va_
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vwscanf.html
 int vwscanf(wchar_t const* __restrict format, va_list arg)
 {
     (void)format;

--- a/Userland/Libraries/LibC/wstdio.cpp
+++ b/Userland/Libraries/LibC/wstdio.cpp
@@ -17,6 +17,12 @@ static_assert(AssertSize<wchar_t, sizeof(u32)>());
 
 extern "C" {
 
+int fwide(FILE*, int mode)
+{
+    // Nope Nope Nope.
+    return mode;
+}
+
 wint_t fgetwc(FILE* stream)
 {
     VERIFY(stream);

--- a/Userland/Utilities/printf.cpp
+++ b/Userland/Utilities/printf.cpp
@@ -20,8 +20,8 @@
     exit(1);
 }
 
-template<typename PutChFunc, typename ArgumentListRefT, template<typename T, typename U = ArgumentListRefT> typename NextArgument>
-struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument> {
+template<typename PutChFunc, typename ArgumentListRefT, template<typename T, typename U = ArgumentListRefT> typename NextArgument, typename CharType>
+requires(IsSame<CharType, char>) struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument, CharType> {
     ALWAYS_INLINE PrintfImpl(PutChFunc& putch, char*& bufptr, const int& nwritten)
         : PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument>(putch, bufptr, nwritten)
     {
@@ -273,7 +273,7 @@ int main(int argc, char** argv)
     auto previous_argc = 0;
     do {
         previous_argc = argc;
-        PrintfImplementation::printf_internal<decltype(putch), PrintfImpl, ArgvWithCount, ArgvNextArgument>(putch, nullptr, format_string, arg);
+        PrintfImplementation::printf_internal<decltype(putch), PrintfImpl, ArgvWithCount, ArgvNextArgument, char>(putch, nullptr, format_string, arg);
     } while (argc && previous_argc != argc);
 
     return 0;


### PR DESCRIPTION
Please prepare yourself for a toolchain rebuild, we haven't had one of those in a while!
Are you sick of not having `wstring` support in libstdc++? more importantly, are you sick of patching out `wstring`?
well, no more! With this futuristic, super amazing PR equipped, you may now wield (some of) the power of `std::wstring` (in ports).
Behold!
![Magic](https://cdn.discordapp.com/attachments/831544568767578162/922279453906829312/unknown.png)

<details>
<summary>The source for that little test program</summary>

```c++
#include <string>
#include <iostream>

int main() {
    std::wstring ws = L"Hello world";
    std::wcout << ws << L'\n' << L"Say something? ";
    std::wcin >> ws;
    std::wcout << L"You said: " << ws << L'\n';
}
```

</details>

<sup>Sidenote, is that a `hexdump` bug I see?</sup>