### PR TITLE
cp: Print proper error message with strerror

### DIFF
--- a/Userland/Utilities/cp.cpp
+++ b/Userland/Utilities/cp.cpp
@@ -57,7 +57,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (result.error().tried_recursing)
                 warnln("cp: -R not specified; omitting directory '{}'", source);
             else
-                warnln("cp: unable to copy '{}' to '{}': {}", source, destination_path, static_cast<Error const&>(result.error()));
+                warnln("cp: unable to copy '{}' to '{}': {}", source, destination_path, strerror(result.error().code()));
             return 1;
         }
 


### PR DESCRIPTION
When cp fails, now it prints an error string (strerror)
instead of an error code.