### PR TITLE
SoundPlayer+AudioServer: Fix AudioServer remaining samples undeflow and SoundPlayer GUI state desynchronization

### DIFF
--- a/Userland/Applications/SoundPlayer/Player.cpp
+++ b/Userland/Applications/SoundPlayer/Player.cpp
@@ -48,7 +48,7 @@ void Player::play_file_path(String const& path)
         return;
     }
 
-    if (path.ends_with(".m3u", AK::CaseSensitivity::CaseInsensitive) || path.ends_with(".m3u8", AK::CaseSensitivity::CaseInsensitive)) {
+    if (is_playlist(path)) {
         playlist_loaded(path, m_playlist.load(path));
         return;
     }
@@ -67,6 +67,12 @@ void Player::play_file_path(String const& path)
     m_playback_manager.set_loader(move(loader));
 
     play();
+}
+
+bool Player::is_playlist(String const& path)
+{
+    return (path.ends_with(".m3u", AK::CaseSensitivity::CaseInsensitive)
+        || path.ends_with(".m3u8", AK::CaseSensitivity::CaseInsensitive));
 }
 
 void Player::set_play_state(PlayState state)

--- a/Userland/Applications/SoundPlayer/Player.h
+++ b/Userland/Applications/SoundPlayer/Player.h
@@ -33,6 +33,7 @@ public:
     virtual ~Player() { }
 
     void play_file_path(String const& path);
+    bool is_playlist(String const& path);
 
     Playlist& playlist() { return m_playlist; }
     String const& loaded_filename() const { return m_loaded_filename; }

--- a/Userland/Services/AudioServer/Mixer.h
+++ b/Userland/Services/AudioServer/Mixer.h
@@ -52,7 +52,8 @@ public:
             return false;
 
         sample = m_current->samples()[m_position++];
-        --m_remaining_samples;
+        if (m_remaining_samples > 0)
+            --m_remaining_samples;
         ++m_played_samples;
 
         if (m_position >= m_current->sample_count()) {


### PR DESCRIPTION
These two changes are primarily focused on the Userland application SoundPlayer.

The first change fixes a few cases where the GUI state was not set with correct values on startup and differed from the state of the Player.

The second change fixes a bug which caused the SoundPlayer to not recognize when an audio stream was completed, and so it would not be able to move on to the next song in the playlist. This bug was due to an integer underflow of the number of remaining samples left in the audio stream.

See commit messages for more information. Or just leave a comment, and I'll do my best to answer any questions you may have :)