### PR TITLE
LibC: Make `<assert.h>` more ISO-C conform

### DIFF
--- a/Meta/check-style.py
+++ b/Meta/check-style.py
@@ -31,6 +31,7 @@ LICENSE_HEADER_CHECK_EXCLUDES = {
 # We check that "#pragma once" is present
 PRAGMA_ONCE_STRING = '#pragma once'
 PRAGMA_ONCE_CHECK_EXCLUDES = {
+    'Userland/Libraries/LibC/assert.h',
 }
 
 # We make sure that there's a blank line before and after pragma once

--- a/Meta/check-style.py
+++ b/Meta/check-style.py
@@ -30,6 +30,8 @@ LICENSE_HEADER_CHECK_EXCLUDES = {
 
 # We check that "#pragma once" is present
 PRAGMA_ONCE_STRING = '#pragma once'
+PRAGMA_ONCE_CHECK_EXCLUDES = {
+}
 
 # We make sure that there's a blank line before and after pragma once
 GOOD_PRAGMA_ONCE_PATTERN = re.compile('(^|\\S\n\n)#pragma once(\n\n\\S.|$)')
@@ -58,7 +60,10 @@ def run():
         if LIBM_MATH_H_INCLUDE_STRING in file_content:
             errors_libm_math_h.append(filename)
         if filename.endswith('.h'):
-            if GOOD_PRAGMA_ONCE_PATTERN.search(file_content):
+            if any(filename.startswith(forbidden_prefix) for forbidden_prefix in PRAGMA_ONCE_CHECK_EXCLUDES):
+                # File was excluded
+                pass
+            elif GOOD_PRAGMA_ONCE_PATTERN.search(file_content):
                 # Excellent, the formatting is correct.
                 pass
             elif PRAGMA_ONCE_STRING in file_content:

--- a/Tests/LibC/TestAssert.cpp
+++ b/Tests/LibC/TestAssert.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
+#undef NDEBUG
 #include <assert.h>
 #include <signal.h>
 
@@ -16,6 +17,28 @@ TEST_CASE(assert)
         return Test::Crash::Failure::DidNotCrash;
     });
     EXPECT_CRASH_WITH_SIGNAL("This should assert with SIGABRT signal", SIGABRT, [] {
+        assert(!"This should assert");
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}
+
+#define NDEBUG
+#include <assert.h>
+
+TEST_CASE(assert_reinclude)
+{
+    EXPECT_NO_CRASH("This should not assert", [] {
+        assert(!"This should not assert");
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}
+
+#undef NDEBUG
+#include <assert.h>
+
+TEST_CASE(assert_rereinclude)
+{
+    EXPECT_CRASH("This should assert", [] {
         assert(!"This should assert");
         return Test::Crash::Failure::DidNotCrash;
     });

--- a/Userland/Libraries/LibC/assert.h
+++ b/Userland/Libraries/LibC/assert.h
@@ -4,16 +4,25 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#pragma once
+#ifndef _ASSERT_H
+#    define _ASSERT_H
+
+#    define __stringify_helper(x) #    x
+#    define __stringify(x) __stringify_helper(x)
+
+#    ifndef __cplusplus
+#        define static_assert _Static_assert
+#    endif
+#endif
 
 #include <sys/cdefs.h>
+
+#undef assert
 
 __BEGIN_DECLS
 
 #ifndef NDEBUG
 __attribute__((noreturn)) void __assertion_failed(const char* msg);
-#    define __stringify_helper(x) #    x
-#    define __stringify(x) __stringify_helper(x)
 #    define assert(expr)                                                            \
         (__builtin_expect(!(expr), 0)                                               \
                 ? __assertion_failed(#expr "\n" __FILE__ ":" __stringify(__LINE__)) \
@@ -21,10 +30,6 @@ __attribute__((noreturn)) void __assertion_failed(const char* msg);
 
 #else
 #    define assert(expr) ((void)(0))
-#endif
-
-#ifndef __cplusplus
-#    define static_assert _Static_assert
 #endif
 
 __END_DECLS


### PR DESCRIPTION
Hi,
With the help of my previously adopted pull request, `<assert.h>` can be made more ISO-C conform.
It export fewer symbols, and it is quite trivial to allow and test multiple inclusion of it.