### PR TITLE
Kernel+SystemServer: Create foundations for Userspace hotplug handling capabilities

### DIFF
--- a/Kernel/API/DeviceEvent.h
+++ b/Kernel/API/DeviceEvent.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+struct DeviceEvent {
+    int state;
+    int is_block_device;
+    unsigned major_number;
+    unsigned minor_number;
+
+    enum State {
+        Removed = 0x01,
+        Inserted = 0x02,
+        Recovered = 0x03,
+        FatalError = 0x04,
+    };
+};

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -50,6 +50,7 @@ set(KERNEL_SOURCES
     Devices/CharacterDevice.cpp
     Devices/ConsoleDevice.cpp
     Devices/Device.cpp
+    Devices/DeviceControlDevice.cpp
     Devices/DeviceManagement.cpp
     Devices/FullDevice.cpp
     Devices/KCOVDevice.cpp

--- a/Kernel/Devices/DeviceControlDevice.cpp
+++ b/Kernel/Devices/DeviceControlDevice.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Devices/DeviceControlDevice.h>
+#include <Kernel/Devices/DeviceManagement.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT NonnullRefPtr<DeviceControlDevice> DeviceControlDevice::must_create()
+{
+    auto device_control_device_or_error = DeviceManagement::try_create_device<DeviceControlDevice>();
+    // FIXME: Find a way to propagate errors
+    VERIFY(!device_control_device_or_error.is_error());
+    return device_control_device_or_error.release_value();
+}
+
+bool DeviceControlDevice::can_read(const OpenFileDescription&, size_t) const
+{
+    return true;
+}
+
+UNMAP_AFTER_INIT DeviceControlDevice::DeviceControlDevice()
+    : CharacterDevice(2, 10)
+{
+}
+
+UNMAP_AFTER_INIT DeviceControlDevice::~DeviceControlDevice()
+{
+}
+
+ErrorOr<size_t> DeviceControlDevice::read(OpenFileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
+{
+    auto device_event = DeviceManagement::the().dequeue_top_device_event({});
+    if (!device_event.has_value())
+        return 0;
+
+    if (size < sizeof(DeviceEvent))
+        return Error::from_errno(EOVERFLOW);
+    size_t nread = 0;
+    TRY(buffer.write(&device_event.value(), nread, sizeof(DeviceEvent)));
+    nread += sizeof(DeviceEvent);
+    return nread;
+}
+
+ErrorOr<void> DeviceControlDevice::ioctl(OpenFileDescription&, unsigned, Userspace<void*>)
+{
+    return Error::from_errno(ENOTSUP);
+}
+
+}

--- a/Kernel/Devices/DeviceControlDevice.h
+++ b/Kernel/Devices/DeviceControlDevice.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Devices/CharacterDevice.h>
+
+namespace Kernel {
+
+class DeviceControlDevice final : public CharacterDevice {
+    friend class DeviceManagement;
+
+public:
+    static NonnullRefPtr<DeviceControlDevice> must_create();
+    virtual ~DeviceControlDevice() override;
+
+private:
+    DeviceControlDevice();
+
+    // ^CharacterDevice
+    virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg) override;
+    virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual ErrorOr<size_t> write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t) override { return Error::from_errno(ENOTSUP); }
+    virtual bool can_read(const OpenFileDescription&, size_t) const override;
+    virtual bool can_write(const OpenFileDescription&, size_t) const override { return false; }
+    virtual StringView class_name() const override { return "DeviceControlDevice"sv; }
+};
+
+}

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -15,6 +15,7 @@
 #include <Kernel/CommandLine.h>
 #include <Kernel/Devices/Audio/AC97.h>
 #include <Kernel/Devices/Audio/SB16.h>
+#include <Kernel/Devices/DeviceControlDevice.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/FullDevice.h>
 #include <Kernel/Devices/HID/HIDManagement.h>
@@ -185,6 +186,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     SysFSComponentRegistry::initialize();
     DeviceManagement::the().attach_null_device(*NullDevice::must_initialize());
     DeviceManagement::the().attach_console_device(*ConsoleDevice::must_create());
+    DeviceManagement::the().attach_device_control_device(*DeviceControlDevice::must_create());
     s_bsp_processor.initialize(0);
 
     CommandLine::initialize();

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -126,13 +126,13 @@ inline char offset_character_with_number(char base_char, u8 offset)
     return offsetted_char;
 }
 
-static void create_devfs_block_device(String name, mode_t mode, unsigned major, unsigned minor)
+static void create_devtmpfs_block_device(String name, mode_t mode, unsigned major, unsigned minor)
 {
     if (auto rc = mknod(name.characters(), mode | S_IFBLK, makedev(major, minor)); rc < 0)
         VERIFY_NOT_REACHED();
 }
 
-static void populate_devfs_block_devices()
+static void populate_devtmpfs_block_devices()
 {
     Core::DirIterator di("/sys/dev/block/", Core::DirIterator::SkipParentAndBaseDir);
     if (di.has_error()) {
@@ -146,15 +146,15 @@ static void populate_devfs_block_devices()
         auto minor_number = entry_name[1].to_uint<unsigned>().value();
         switch (major_number) {
         case 29: {
-            create_devfs_block_device(String::formatted("/dev/fb{}", minor_number), 0666, 29, minor_number);
+            create_devtmpfs_block_device(String::formatted("/dev/fb{}", minor_number), 0666, 29, minor_number);
             break;
         }
         case 30: {
-            create_devfs_block_device(String::formatted("/dev/kcov{}", minor_number), 0666, 30, minor_number);
+            create_devtmpfs_block_device(String::formatted("/dev/kcov{}", minor_number), 0666, 30, minor_number);
             break;
         }
         case 3: {
-            create_devfs_block_device(String::formatted("/dev/hd{}", offset_character_with_number('a', minor_number)), 0600, 3, minor_number);
+            create_devtmpfs_block_device(String::formatted("/dev/hd{}", offset_character_with_number('a', minor_number)), 0600, 3, minor_number);
             break;
         }
         default:
@@ -164,13 +164,13 @@ static void populate_devfs_block_devices()
     }
 }
 
-static void create_devfs_char_device(String name, mode_t mode, unsigned major, unsigned minor)
+static void create_devtmpfs_char_device(String name, mode_t mode, unsigned major, unsigned minor)
 {
     if (auto rc = mknod(name.characters(), mode | S_IFCHR, makedev(major, minor)); rc < 0)
         VERIFY_NOT_REACHED();
 }
 
-static void populate_devfs_char_devices()
+static void populate_devtmpfs_char_devices()
 {
     Core::DirIterator di("/sys/dev/char/", Core::DirIterator::SkipParentAndBaseDir);
     if (di.has_error()) {
@@ -186,7 +186,7 @@ static void populate_devfs_char_devices()
         case 42: {
             switch (minor_number) {
             case 42: {
-                create_devfs_char_device("/dev/audio", 0220, 42, 42);
+                create_devtmpfs_char_device("/dev/audio", 0220, 42, 42);
                 break;
             }
             default:
@@ -197,7 +197,7 @@ static void populate_devfs_char_devices()
         case 29: {
             switch (minor_number) {
             case 0: {
-                create_devfs_char_device("/dev/full", 0660, 29, 0);
+                create_devtmpfs_char_device("/dev/full", 0660, 29, 0);
                 break;
             }
             default:
@@ -206,17 +206,17 @@ static void populate_devfs_char_devices()
             break;
         }
         case 229: {
-            create_devfs_char_device(String::formatted("/dev/hvc0p{}", minor_number), 0666, major_number, minor_number);
+            create_devtmpfs_char_device(String::formatted("/dev/hvc0p{}", minor_number), 0666, major_number, minor_number);
             break;
         }
         case 10: {
             switch (minor_number) {
             case 0: {
-                create_devfs_char_device("/dev/mouse0", 0660, 10, 0);
+                create_devtmpfs_char_device("/dev/mouse0", 0660, 10, 0);
                 break;
             }
             case 183: {
-                create_devfs_char_device("/dev/hwrng", 0660, 10, 183);
+                create_devtmpfs_char_device("/dev/hwrng", 0660, 10, 183);
                 break;
             }
             default:
@@ -227,7 +227,7 @@ static void populate_devfs_char_devices()
         case 85: {
             switch (minor_number) {
             case 0: {
-                create_devfs_char_device("/dev/keyboard0", 0660, 85, 0);
+                create_devtmpfs_char_device("/dev/keyboard0", 0660, 85, 0);
                 break;
             }
             default:
@@ -238,19 +238,19 @@ static void populate_devfs_char_devices()
         case 1: {
             switch (minor_number) {
             case 5: {
-                create_devfs_char_device("/dev/zero", 0666, 1, 5);
+                create_devtmpfs_char_device("/dev/zero", 0666, 1, 5);
                 break;
             }
             case 1: {
-                create_devfs_char_device("/dev/mem", 0660, 1, 1);
+                create_devtmpfs_char_device("/dev/mem", 0660, 1, 1);
                 break;
             }
             case 3: {
-                create_devfs_char_device("/dev/null", 0666, 1, 3);
+                create_devtmpfs_char_device("/dev/null", 0666, 1, 3);
                 break;
             }
             case 8: {
-                create_devfs_char_device("/dev/random", 0666, 1, 8);
+                create_devtmpfs_char_device("/dev/random", 0666, 1, 8);
                 break;
             }
             default:
@@ -262,11 +262,11 @@ static void populate_devfs_char_devices()
         case 5: {
             switch (minor_number) {
             case 1: {
-                create_devfs_char_device("/dev/console", 0666, 5, 1);
+                create_devtmpfs_char_device("/dev/console", 0666, 5, 1);
                 break;
             }
             case 2: {
-                create_devfs_char_device("/dev/ptmx", 0666, 5, 2);
+                create_devtmpfs_char_device("/dev/ptmx", 0666, 5, 2);
                 break;
             }
             default:
@@ -277,35 +277,35 @@ static void populate_devfs_char_devices()
         case 4: {
             switch (minor_number) {
             case 0: {
-                create_devfs_char_device("/dev/tty0", 0620, 4, 0);
+                create_devtmpfs_char_device("/dev/tty0", 0620, 4, 0);
                 break;
             }
             case 1: {
-                create_devfs_char_device("/dev/tty1", 0620, 4, 1);
+                create_devtmpfs_char_device("/dev/tty1", 0620, 4, 1);
                 break;
             }
             case 2: {
-                create_devfs_char_device("/dev/tty2", 0620, 4, 2);
+                create_devtmpfs_char_device("/dev/tty2", 0620, 4, 2);
                 break;
             }
             case 3: {
-                create_devfs_char_device("/dev/tty3", 0620, 4, 3);
+                create_devtmpfs_char_device("/dev/tty3", 0620, 4, 3);
                 break;
             }
             case 64: {
-                create_devfs_char_device("/dev/ttyS0", 0620, 4, 64);
+                create_devtmpfs_char_device("/dev/ttyS0", 0620, 4, 64);
                 break;
             }
             case 65: {
-                create_devfs_char_device("/dev/ttyS1", 0620, 4, 65);
+                create_devtmpfs_char_device("/dev/ttyS1", 0620, 4, 65);
                 break;
             }
             case 66: {
-                create_devfs_char_device("/dev/ttyS2", 0620, 4, 66);
+                create_devtmpfs_char_device("/dev/ttyS2", 0620, 4, 66);
                 break;
             }
             case 67: {
-                create_devfs_char_device("/dev/ttyS3", 0666, 4, 67);
+                create_devtmpfs_char_device("/dev/ttyS3", 0666, 4, 67);
                 break;
             }
             default:
@@ -320,12 +320,12 @@ static void populate_devfs_char_devices()
     }
 }
 
-static void populate_devfs()
+static void populate_devtmpfs()
 {
     mode_t old_mask = umask(0);
     printf("Changing umask %#o\n", old_mask);
-    populate_devfs_char_devices();
-    populate_devfs_block_devices();
+    populate_devtmpfs_char_devices();
+    populate_devtmpfs_block_devices();
     umask(old_mask);
 }
 
@@ -341,7 +341,7 @@ static ErrorOr<void> prepare_synthetic_filesystems()
     TRY(Core::System::symlink("/proc/self/fd/2", "/dev/stderr"));
     TRY(Core::System::symlink("/proc/self/tty", "/dev/tty"));
 
-    populate_devfs();
+    populate_devtmpfs();
 
     TRY(Core::System::mkdir("/dev/pts", 0755));
 

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -9,6 +9,7 @@
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Debug.h>
+#include <Kernel/API/DeviceEvent.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/DirIterator.h>
@@ -132,45 +133,13 @@ static void create_devtmpfs_block_device(String name, mode_t mode, unsigned majo
         VERIFY_NOT_REACHED();
 }
 
-static void populate_devtmpfs_block_devices()
-{
-    Core::DirIterator di("/sys/dev/block/", Core::DirIterator::SkipParentAndBaseDir);
-    if (di.has_error()) {
-        warnln("Failed to open /sys/dev/block - {}", di.error());
-        VERIFY_NOT_REACHED();
-    }
-    while (di.has_next()) {
-        auto entry_name = di.next_path().split(':');
-        VERIFY(entry_name.size() == 2);
-        auto major_number = entry_name[0].to_uint<unsigned>().value();
-        auto minor_number = entry_name[1].to_uint<unsigned>().value();
-        switch (major_number) {
-        case 29: {
-            create_devtmpfs_block_device(String::formatted("/dev/fb{}", minor_number), 0666, 29, minor_number);
-            break;
-        }
-        case 30: {
-            create_devtmpfs_block_device(String::formatted("/dev/kcov{}", minor_number), 0666, 30, minor_number);
-            break;
-        }
-        case 3: {
-            create_devtmpfs_block_device(String::formatted("/dev/hd{}", offset_character_with_number('a', minor_number)), 0600, 3, minor_number);
-            break;
-        }
-        default:
-            warnln("Unknown block device {}:{}", major_number, minor_number);
-            break;
-        }
-    }
-}
-
 static void create_devtmpfs_char_device(String name, mode_t mode, unsigned major, unsigned minor)
 {
     if (auto rc = mknod(name.characters(), mode | S_IFCHR, makedev(major, minor)); rc < 0)
         VERIFY_NOT_REACHED();
 }
 
-static void populate_devtmpfs_char_devices()
+static void populate_devtmpfs_char_devices_based_on_sysfs()
 {
     Core::DirIterator di("/sys/dev/char/", Core::DirIterator::SkipParentAndBaseDir);
     if (di.has_error()) {
@@ -183,10 +152,10 @@ static void populate_devtmpfs_char_devices()
         auto major_number = entry_name[0].to_uint<unsigned>().value();
         auto minor_number = entry_name[1].to_uint<unsigned>().value();
         switch (major_number) {
-        case 42: {
+        case 2: {
             switch (minor_number) {
-            case 42: {
-                create_devtmpfs_char_device("/dev/audio", 0220, 42, 42);
+            case 10: {
+                create_devtmpfs_char_device("/dev/devctl", 0660, 2, 10);
                 break;
             }
             default:
@@ -194,7 +163,48 @@ static void populate_devtmpfs_char_devices()
             }
             break;
         }
+
+        default:
+            break;
+        }
+    }
+}
+
+static void populate_devtmpfs_devices_based_on_devctl()
+{
+    auto f = Core::File::construct("/dev/devctl");
+    if (!f->open(Core::OpenMode::ReadOnly)) {
+        warnln("Failed to open /dev/devctl - {}", f->error_string());
+        VERIFY_NOT_REACHED();
+    }
+
+    DeviceEvent event;
+    while (f->read((u8*)&event, sizeof(DeviceEvent)) > 0) {
+        if (event.state != DeviceEvent::Inserted)
+            continue;
+        auto major_number = event.major_number;
+        auto minor_number = event.minor_number;
+        bool is_block_device = (event.is_block_device == 1);
+        switch (major_number) {
+        case 42: {
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 42: {
+                    create_devtmpfs_char_device("/dev/audio", 0220, 42, 42);
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
+            }
+            break;
+        }
         case 29: {
+            if (is_block_device) {
+                create_devtmpfs_block_device(String::formatted("/dev/fb{}", minor_number), 0666, 29, minor_number);
+                break;
+            }
+
             switch (minor_number) {
             case 0: {
                 create_devtmpfs_char_device("/dev/full", 0660, 29, 0);
@@ -206,115 +216,142 @@ static void populate_devtmpfs_char_devices()
             break;
         }
         case 229: {
-            create_devtmpfs_char_device(String::formatted("/dev/hvc0p{}", minor_number), 0666, major_number, minor_number);
+            if (!is_block_device) {
+                create_devtmpfs_char_device(String::formatted("/dev/hvc0p{}", minor_number), 0666, major_number, minor_number);
+            }
             break;
         }
         case 10: {
-            switch (minor_number) {
-            case 0: {
-                create_devtmpfs_char_device("/dev/mouse0", 0660, 10, 0);
-                break;
-            }
-            case 183: {
-                create_devtmpfs_char_device("/dev/hwrng", 0660, 10, 183);
-                break;
-            }
-            default:
-                warnln("Unknown character device {}:{}", major_number, minor_number);
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 0: {
+                    create_devtmpfs_char_device("/dev/mouse0", 0660, 10, 0);
+                    break;
+                }
+                case 183: {
+                    create_devtmpfs_char_device("/dev/hwrng", 0660, 10, 183);
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
             }
             break;
         }
         case 85: {
-            switch (minor_number) {
-            case 0: {
-                create_devtmpfs_char_device("/dev/keyboard0", 0660, 85, 0);
-                break;
-            }
-            default:
-                warnln("Unknown character device {}:{}", major_number, minor_number);
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 0: {
+                    create_devtmpfs_char_device("/dev/keyboard0", 0660, 85, 0);
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
             }
             break;
         }
         case 1: {
-            switch (minor_number) {
-            case 5: {
-                create_devtmpfs_char_device("/dev/zero", 0666, 1, 5);
-                break;
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 5: {
+                    create_devtmpfs_char_device("/dev/zero", 0666, 1, 5);
+                    break;
+                }
+                case 1: {
+                    create_devtmpfs_char_device("/dev/mem", 0660, 1, 1);
+                    break;
+                }
+                case 3: {
+                    create_devtmpfs_char_device("/dev/null", 0666, 1, 3);
+                    break;
+                }
+                case 8: {
+                    create_devtmpfs_char_device("/dev/random", 0666, 1, 8);
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                    break;
+                }
             }
-            case 1: {
-                create_devtmpfs_char_device("/dev/mem", 0660, 1, 1);
-                break;
+            break;
+        }
+        case 30: {
+            if (is_block_device) {
+                create_devtmpfs_block_device(String::formatted("/dev/kcov{}", minor_number), 0666, 30, minor_number);
             }
-            case 3: {
-                create_devtmpfs_char_device("/dev/null", 0666, 1, 3);
-                break;
-            }
-            case 8: {
-                create_devtmpfs_char_device("/dev/random", 0666, 1, 8);
-                break;
-            }
-            default:
-                warnln("Unknown character device {}:{}", major_number, minor_number);
-                break;
+            break;
+        }
+        case 3: {
+            if (is_block_device) {
+                create_devtmpfs_block_device(String::formatted("/dev/hd{}", offset_character_with_number('a', minor_number)), 0600, 3, minor_number);
             }
             break;
         }
         case 5: {
-            switch (minor_number) {
-            case 1: {
-                create_devtmpfs_char_device("/dev/console", 0666, 5, 1);
-                break;
-            }
-            case 2: {
-                create_devtmpfs_char_device("/dev/ptmx", 0666, 5, 2);
-                break;
-            }
-            default:
-                warnln("Unknown character device {}:{}", major_number, minor_number);
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 1: {
+                    create_devtmpfs_char_device("/dev/console", 0666, 5, 1);
+                    break;
+                }
+                case 2: {
+                    create_devtmpfs_char_device("/dev/ptmx", 0666, 5, 2);
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
             }
             break;
         }
         case 4: {
-            switch (minor_number) {
-            case 0: {
-                create_devtmpfs_char_device("/dev/tty0", 0620, 4, 0);
-                break;
-            }
-            case 1: {
-                create_devtmpfs_char_device("/dev/tty1", 0620, 4, 1);
-                break;
-            }
-            case 2: {
-                create_devtmpfs_char_device("/dev/tty2", 0620, 4, 2);
-                break;
-            }
-            case 3: {
-                create_devtmpfs_char_device("/dev/tty3", 0620, 4, 3);
-                break;
-            }
-            case 64: {
-                create_devtmpfs_char_device("/dev/ttyS0", 0620, 4, 64);
-                break;
-            }
-            case 65: {
-                create_devtmpfs_char_device("/dev/ttyS1", 0620, 4, 65);
-                break;
-            }
-            case 66: {
-                create_devtmpfs_char_device("/dev/ttyS2", 0620, 4, 66);
-                break;
-            }
-            case 67: {
-                create_devtmpfs_char_device("/dev/ttyS3", 0666, 4, 67);
-                break;
-            }
-            default:
-                warnln("Unknown character device {}:{}", major_number, minor_number);
+            if (!is_block_device) {
+                switch (minor_number) {
+                case 0: {
+                    create_devtmpfs_char_device("/dev/tty0", 0620, 4, 0);
+                    break;
+                }
+                case 1: {
+                    create_devtmpfs_char_device("/dev/tty1", 0620, 4, 1);
+                    break;
+                }
+                case 2: {
+                    create_devtmpfs_char_device("/dev/tty2", 0620, 4, 2);
+                    break;
+                }
+                case 3: {
+                    create_devtmpfs_char_device("/dev/tty3", 0620, 4, 3);
+                    break;
+                }
+                case 64: {
+                    create_devtmpfs_char_device("/dev/ttyS0", 0620, 4, 64);
+                    break;
+                }
+                case 65: {
+                    create_devtmpfs_char_device("/dev/ttyS1", 0620, 4, 65);
+                    break;
+                }
+                case 66: {
+                    create_devtmpfs_char_device("/dev/ttyS2", 0620, 4, 66);
+                    break;
+                }
+                case 67: {
+                    create_devtmpfs_char_device("/dev/ttyS3", 0666, 4, 67);
+                    break;
+                }
+                default:
+                    warnln("Unknown character device {}:{}", major_number, minor_number);
+                }
             }
             break;
         }
         default:
-            warnln("Unknown character device {}:{}", major_number, minor_number);
+            if (!is_block_device)
+                warnln("Unknown character device {}:{}", major_number, minor_number);
+            else
+                warnln("Unknown block device {}:{}", major_number, minor_number);
             break;
         }
     }
@@ -324,8 +361,8 @@ static void populate_devtmpfs()
 {
     mode_t old_mask = umask(0);
     printf("Changing umask %#o\n", old_mask);
-    populate_devtmpfs_char_devices();
-    populate_devtmpfs_block_devices();
+    populate_devtmpfs_char_devices_based_on_sysfs();
+    populate_devtmpfs_devices_based_on_devctl();
     umask(old_mask);
 }
 


### PR DESCRIPTION
Intro - a message of mine in the discord server today:

> in the last few days I searched for an answer on how to implement a udev-like daemon for serenity and few ideas came:
> 1. Use inode watcher on SysFS to look for changes there
> 2. Implement a socket interface like what systemd-udev does, which is actually a linux netlink socket in /run/udev/control
> 3. I looked at how OpenBSD did that and apparently the simplest approach is here - merely a device file in devtmpfs called /dev/hotplug to be read from

Together with the discord user Muddmaker (@dykatz) we did a simple looking through, and I discarded the first two options quite quickly:

>[9:00 AM] supercomputer7: the first approach is somewhat problematic - we can't watch SysFS because there could be multiple instances of it corresponding to one SysFS data so sending inode notifications is almost impossible and will be very ugly to implement
[9:01 AM] supercomputer7: the second approach is more feasible but requires us to implement a new protocol like netlink in the kernel. the added complexity is hardly justified right now, and it's a door for a ton of exploits for sure

So, this pull request implemented the third option - a simple `/dev/devctl` node like in FreeBSD (in OpenBSD they have a `/dev/hotplug` device). Currently we just read from it when we start `SystemServer` until there's no more events to process.

In future PRs I will add a new daemon to read from this device to create and remove device nodes.