### PR TITLE
AK+Libraries: Add metadata to Error, use it

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -21,37 +21,41 @@ namespace AK {
 
 class Error {
 public:
-    static Error from_errno(int code) { return Error(code); }
+    static Error from_errno(int code, StringView where = __builtin_FUNCTION()) { return Error(code, where); }
     static Error from_syscall(StringView syscall_name, int rc) { return Error(syscall_name, rc); }
-    static Error from_string_literal(StringView string_literal) { return Error(string_literal); }
+    static Error from_string_literal(StringView string_literal, StringView where = __builtin_FUNCTION()) { return Error(string_literal, where); }
 
     bool is_errno() const { return m_code != 0; }
     bool is_syscall() const { return m_syscall; }
 
     int code() const { return m_code; }
     StringView string_literal() const { return m_string_literal; }
+    StringView where() const { return m_where; }
 
 protected:
-    Error(int code)
+    Error(int code, StringView where)
         : m_code(code)
+        , m_where(where)
     {
     }
 
 private:
-    Error(StringView string_literal)
+    Error(StringView string_literal, StringView where)
         : m_string_literal(string_literal)
+        , m_where(where)
     {
     }
 
     Error(StringView syscall_name, int rc)
         : m_code(-rc)
-        , m_string_literal(syscall_name)
+        , m_where(syscall_name)
         , m_syscall(true)
     {
     }
 
     int m_code { 0 };
     StringView m_string_literal;
+    StringView m_where;
     bool m_syscall { false };
 };
 

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -62,8 +62,8 @@ public:
     };
 
     struct CopyError : public Error {
-        CopyError(int error_code, bool t)
-            : Error(error_code)
+        CopyError(int error_code, bool t, StringView where = __builtin_FUNCTION())
+            : Error(error_code, where)
             , tried_recursing(t)
         {
         }
@@ -79,8 +79,8 @@ public:
     static ErrorOr<void> link_file(String const& dst_path, String const& src_path);
 
     struct RemoveError : public Error {
-        RemoveError(String f, int error_code)
-            : Error(error_code)
+        RemoveError(String f, int error_code, StringView where = __builtin_FUNCTION())
+            : Error(error_code, where)
             , file(move(f))
         {
         }

--- a/Userland/Libraries/LibMain/Main.cpp
+++ b/Userland/Libraries/LibMain/Main.cpp
@@ -24,12 +24,10 @@ int main(int argc, char** argv)
     });
     if (result.is_error()) {
         auto error = result.release_error();
-        if (error.is_syscall())
-            warnln("Runtime error: {}: {} (errno={})", error.string_literal(), strerror(error.code()), error.code());
-        else if (error.is_errno())
-            warnln("Runtime error: {} (errno={})", strerror(error.code()), error.code());
+        if (error.is_errno())
+            warnln("Runtime error: {}: {} (errno={})", error.where(), strerror(error.code()), error.code());
         else
-            warnln("Runtime error: {}", error.string_literal());
+            warnln("Runtime error: {}: {}", error.where(), error.string_literal());
         return 1;
     }
     return result.value();

--- a/Userland/Libraries/LibWasm/AbstractMachine/Validator.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Validator.h
@@ -32,8 +32,8 @@ struct Context {
 };
 
 struct ValidationError : public Error {
-    ValidationError(String error)
-        : Error(Error::from_string_literal(error))
+    ValidationError(String error, StringView where = __builtin_FUNCTION())
+        : Error(Error::from_string_literal(error, where))
         , error_string(move(error))
     {
     }


### PR DESCRIPTION
This patch adds `where` metadata to Error, which says where the error
was constructed. This is done automatically via `__builtin_FUNCTION()`

This patch also modifies the constructors of derived types to include the
`where` parameter and uses the new member in LibMain.