### PR TITLE
Help: Make it more comfy to use

### DIFF
--- a/Base/usr/share/man/man1/Help.md
+++ b/Base/usr/share/man/man1/Help.md
@@ -1,0 +1,63 @@
+## Name
+
+Help
+
+## Synopsis
+
+```**sh
+$ Help
+$ Help [section] page
+$ Help search_query
+$ Help file
+```
+
+## Description
+
+`Help` is Serenity's digital manual, the GUI counterpart to `man`.
+It lets you search for and read manual pages (or "man pages").
+
+## Sections
+
+The SerenityOS manual is split into the following *sections*, or *chapters*:
+
+1. User programs
+2. System calls
+3. Libraries
+4. Special files
+5. File formats
+6. Games
+7. Miscellanea
+8. Sysadmin tools
+
+Sections are subject to change in the future.
+
+## Examples
+
+To open Help:
+```sh
+$ Help
+```
+
+To open documentation for the `echo` command:
+```sh
+$ Help echo
+```
+
+To open the documentation for the `mkdir` command:
+```sh
+$ Help 1 mkdir
+```
+Conversely, to open the documentation about the `mkdir()` syscall:
+```sh
+$ Help 2 mkdir
+```
+
+## Files
+
+`Help` looks for man pages under `/usr/share/man`. For example,
+this man page should be located at `/usr/share/man/man1/Help.md`.
+
+## See Also
+
+* [`man`(1)](man.md) To read these same man pages from the terminal
+

--- a/Userland/Applications/Help/ManualModel.cpp
+++ b/Userland/Applications/Help/ManualModel.cpp
@@ -8,10 +8,7 @@
 #include "ManualNode.h"
 #include "ManualPageNode.h"
 #include "ManualSectionNode.h"
-#include <AK/ByteBuffer.h>
 #include <AK/Try.h>
-#include <LibCore/File.h>
-#include <LibGUI/FilteringProxyModel.h>
 
 static ManualSectionNode s_sections[] = {
     { "1", "User programs" },
@@ -47,6 +44,17 @@ Optional<GUI::ModelIndex> ManualModel::index_from_path(StringView path) const
         }
     }
     return {};
+}
+
+String ManualModel::page_name(const GUI::ModelIndex& index) const
+{
+    if (!index.is_valid())
+        return {};
+    auto* node = static_cast<const ManualNode*>(index.internal_data());
+    if (!node->is_page())
+        return {};
+    auto* page = static_cast<const ManualPageNode*>(node);
+    return page->name();
 }
 
 String ManualModel::page_path(const GUI::ModelIndex& index) const
@@ -165,6 +173,10 @@ void ManualModel::update_section_node_on_toggle(const GUI::ModelIndex& index, co
 
 TriState ManualModel::data_matches(const GUI::ModelIndex& index, const GUI::Variant& term) const
 {
+    auto name = page_name(index);
+    if (name.contains(term.as_string()))
+        return TriState::True;
+
     auto view_result = page_view(page_path(index));
     if (view_result.is_error() || view_result.value().is_empty())
         return TriState::False;

--- a/Userland/Applications/Help/ManualModel.h
+++ b/Userland/Applications/Help/ManualModel.h
@@ -23,6 +23,7 @@ public:
 
     Optional<GUI::ModelIndex> index_from_path(StringView) const;
 
+    String page_name(const GUI::ModelIndex&) const;
     String page_path(const GUI::ModelIndex&) const;
     String page_and_section(const GUI::ModelIndex&) const;
     ErrorOr<StringView> page_view(String const& path) const;

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    const char* start_page = nullptr;
+    char const* start_page = nullptr;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(start_page, "Page to open at launch", "page", Core::ArgsParser::Required::No);
@@ -102,12 +102,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     RefPtr<GUI::Action> go_back_action;
     RefPtr<GUI::Action> go_forward_action;
 
-    auto update_actions = [&]() {
+    auto open_page = [&](String const& path) {
         go_back_action->set_enabled(history.can_go_back());
         go_forward_action->set_enabled(history.can_go_forward());
-    };
 
-    auto open_page = [&](const String& path) {
         if (path.is_null()) {
             window->set_title("Help");
             page_view->load_empty_document();
@@ -151,7 +149,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
 
         history.push(path);
-        update_actions();
         open_page(path);
     };
 
@@ -178,7 +175,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
         }
         auto& search_model = *static_cast<GUI::FilteringProxyModel*>(view_model);
-        const auto& mapped_index = search_model.map(index);
+        auto const& mapped_index = search_model.map(index);
         String path = manual_model->page_path(mapped_index);
         if (path.is_null()) {
             page_view->load_empty_document();
@@ -187,7 +184,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         tree_view->selection().clear();
         tree_view->selection().add(mapped_index);
         history.push(path);
-        update_actions();
         open_page(path);
     };
 
@@ -208,19 +204,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return;
         }
         history.push(path);
-        update_actions();
         open_page(path);
     };
 
     go_back_action = GUI::CommonActions::make_go_back_action([&](auto&) {
         history.go_back();
-        update_actions();
         open_page(history.current());
     });
 
     go_forward_action = GUI::CommonActions::make_go_forward_action([&](auto&) {
         history.go_forward();
-        update_actions();
         open_page(history.current());
     });
 
@@ -230,7 +223,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto go_home_action = GUI::CommonActions::make_go_home_action([&](auto&) {
         String path = "/usr/share/man/man7/Help-index.md";
         history.push(path);
-        update_actions();
         open_page(path);
     });
 
@@ -279,7 +271,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         URL url = URL::create_with_url_or_path(start_page);
         if (url.is_valid() && url.path().ends_with(".md")) {
             history.push(url.path());
-            update_actions();
             open_page(url.path());
             set_start_page = true;
         } else {

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -274,12 +274,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         context_menu->popup(screen_position);
     };
 
+    bool set_start_page = false;
     if (start_page) {
         URL url = URL::create_with_url_or_path(start_page);
         if (url.is_valid() && url.path().ends_with(".md")) {
             history.push(url.path());
             update_actions();
             open_page(url.path());
+            set_start_page = true;
         } else {
             left_tab_bar->set_active_widget(search_view);
             search_box->set_text(start_page);
@@ -288,9 +290,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 search_model.set_filter_term(search_box->text());
             }
         }
-    } else {
-        go_home_action->activate();
     }
+    if (!set_start_page)
+        go_home_action->activate();
 
     auto statusbar = TRY(widget->try_add<GUI::Statusbar>());
     app->on_action_enter = [&statusbar](GUI::Action const& action) {


### PR DESCRIPTION
A couple of changes here, but the big one is that you can now call `Help` in the same way as `man`, by passing an optional section number followed by a page name. eg, `Help 1 mkdir`