### PR TITLE
LibJS: Add spec comments to RegExp.prototype and fix a couple bugs

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -257,7 +257,7 @@ ThrowCompletionOr<Value> regexp_exec(GlobalObject& global_object, Object& regexp
         auto result = TRY(vm.call(exec.as_function(), &regexp_object, js_string(vm, move(string))));
 
         if (!result.is_object() && !result.is_null())
-            vm.throw_exception<TypeError>(global_object, ErrorType::NotAnObjectOrNull, result.to_string_without_side_effects());
+            return vm.throw_completion<TypeError>(global_object, ErrorType::NotAnObjectOrNull, result.to_string_without_side_effects());
 
         return result;
     }

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -24,17 +24,16 @@ public:
     virtual ~RegExpPrototype() override;
 
 private:
-    JS_DECLARE_NATIVE_FUNCTION(flags);
-    JS_DECLARE_NATIVE_FUNCTION(source);
-
     JS_DECLARE_NATIVE_FUNCTION(exec);
-    JS_DECLARE_NATIVE_FUNCTION(test);
-    JS_DECLARE_NATIVE_FUNCTION(to_string);
+    JS_DECLARE_NATIVE_FUNCTION(flags);
     JS_DECLARE_NATIVE_FUNCTION(symbol_match);
     JS_DECLARE_NATIVE_FUNCTION(symbol_match_all);
     JS_DECLARE_NATIVE_FUNCTION(symbol_replace);
     JS_DECLARE_NATIVE_FUNCTION(symbol_search);
+    JS_DECLARE_NATIVE_FUNCTION(source);
     JS_DECLARE_NATIVE_FUNCTION(symbol_split);
+    JS_DECLARE_NATIVE_FUNCTION(test);
+    JS_DECLARE_NATIVE_FUNCTION(to_string);
     JS_DECLARE_NATIVE_FUNCTION(compile);
 
 #define __JS_ENUMERATE(_, flag_name, ...) \


### PR DESCRIPTION
Not a particularly glorious PR, but I was wondering if any of the RegExp.prototype methods had normative changes, which I think is just easier with spec comments. This did find a couple of bugs though:
* A `vm.throw_exception` invocation that should have been a `return vm.throw_completion`.
* Some non-spec `to_object` invocations (one of which was masking the above bug).
* Using `TRY` in places that should be using `MUST`.