### PR TITLE
HackStudio: Attach debuggee to HackStudio's TerminalWrapper

### DIFF
--- a/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
@@ -112,7 +112,13 @@ void Debugger::stop()
 
 void Debugger::start()
 {
-    m_debug_session = Debug::DebugSession::exec_and_attach(m_executable_path, m_source_root);
+
+    auto child_setup_callback = [this]() {
+        if (m_child_setup_callback)
+            return m_child_setup_callback();
+        return ErrorOr<void> {};
+    };
+    m_debug_session = Debug::DebugSession::exec_and_attach(m_executable_path, m_source_root, move(child_setup_callback));
     VERIFY(!!m_debug_session);
 
     for (const auto& breakpoint : m_breakpoints) {

--- a/Userland/DevTools/HackStudio/Debugger/Debugger.h
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.h
@@ -60,6 +60,8 @@ public:
     void set_requested_debugger_action(DebuggerAction);
     void reset_breakpoints() { m_breakpoints.clear(); }
 
+    void set_child_setup_callback(Function<ErrorOr<void>()> callback) { m_child_setup_callback = move(callback); }
+
 private:
     class DebuggingState {
     public:
@@ -119,6 +121,7 @@ private:
     Function<HasControlPassedToUser(const PtraceRegisters&)> m_on_stopped_callback;
     Function<void()> m_on_continue_callback;
     Function<void()> m_on_exit_callback;
+    Function<ErrorOr<void>()> m_child_setup_callback;
 };
 
 }

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1081,7 +1081,7 @@ void HackStudioWidget::create_action_tab(GUI::Widget& parent)
 
     m_find_in_files_widget = m_action_tab_widget->add_tab<FindInFilesWidget>("Find in files");
     m_todo_entries_widget = m_action_tab_widget->add_tab<ToDoEntriesWidget>("TODO");
-    m_terminal_wrapper = m_action_tab_widget->add_tab<TerminalWrapper>("Build", false);
+    m_terminal_wrapper = m_action_tab_widget->add_tab<TerminalWrapper>("Console", false);
     m_debug_info_widget = m_action_tab_widget->add_tab<DebugInfoWidget>("Debug");
 
     m_debug_info_widget->on_backtrace_frame_selection = [this](Debug::DebugInfo::SourcePosition const& source_position) {

--- a/Userland/DevTools/HackStudio/TerminalWrapper.h
+++ b/Userland/DevTools/HackStudio/TerminalWrapper.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <LibGUI/Widget.h>
 #include <LibVT/TerminalWidget.h>
 
@@ -22,6 +23,13 @@ public:
 
     bool user_spawned() const { return m_user_spawned; }
     VT::TerminalWidget& terminal() { return *m_terminal_widget; }
+
+    enum class WaitForChildOnExit {
+        No,
+        Yes,
+    };
+    ErrorOr<int> setup_master_pseudoterminal(WaitForChildOnExit = WaitForChildOnExit::Yes);
+    static ErrorOr<void> setup_slave_pseudoterminal(int master_fd);
 
     Function<void()> on_command_exit;
 

--- a/Userland/Libraries/LibDebug/DebugSession.h
+++ b/Userland/Libraries/LibDebug/DebugSession.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Demangle.h>
+#include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
@@ -26,7 +27,7 @@ namespace Debug {
 
 class DebugSession : public ProcessInspector {
 public:
-    static OwnPtr<DebugSession> exec_and_attach(String const& command, String source_root = {});
+    static OwnPtr<DebugSession> exec_and_attach(String const& command, String source_root = {}, Function<ErrorOr<void>()> setup_child = {});
 
     virtual ~DebugSession() override;
 


### PR DESCRIPTION
Instead of using the same tty as the HackStudio process, the debuggee process is now attached to the `TerminalWrapper` of HackStudio.