### PR TITLE
LibAudio+LibCore: Convert FlacLoader to Core::Stream APIs :^)

### DIFF
--- a/AK/BitStream.h
+++ b/AK/BitStream.h
@@ -12,6 +12,7 @@
 
 namespace AK {
 
+// Obsoleted by LibCore/{Big, Little}EndianInputBitStream.
 class InputBitStream final : public InputStream {
 public:
     explicit InputBitStream(InputStream& stream)

--- a/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzWAVLoader.cpp
@@ -11,7 +11,7 @@
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 {
     auto wav_data = ByteBuffer::copy(data, size).release_value();
-    auto wav = make<Audio::WavLoaderPlugin>(wav_data);
+    auto wav = make<Audio::WavLoaderPlugin>(wav_data.bytes());
 
     for (;;) {
         auto samples = wav->get_more_samples();

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -9,62 +9,22 @@
 #include "Buffer.h"
 #include "FlacTypes.h"
 #include "Loader.h"
-#include <AK/BitStream.h>
-#include <AK/Buffered.h>
 #include <AK/Error.h>
-#include <AK/Stream.h>
+#include <AK/Span.h>
 #include <AK/Types.h>
-#include <AK/Variant.h>
-#include <LibCore/FileStream.h>
+#include <LibCore/InputBitStream.h>
+#include <LibCore/MemoryStream.h>
+#include <LibCore/Stream.h>
 
 namespace Audio {
+
+using Core::Stream::BigEndianInputBitStream;
 
 // Experimentally determined to be a decent buffer size on i686:
 // 4K (the default) is slightly worse, and 64K is much worse.
 // At sufficiently large buffer sizes, the advantage of infrequent read() calls is outweighed by the memmove() overhead.
 // There was no intensive fine-tuning done to determine this value, so improvements may definitely be possible.
 constexpr size_t FLAC_BUFFER_SIZE = 8 * KiB;
-
-template<size_t Size = FLAC_BUFFER_SIZE>
-class FlacInputStream : public Variant<Buffered<Core::InputFileStream, Size>, InputMemoryStream> {
-
-public:
-    using Variant<Buffered<Core::InputFileStream, Size>, InputMemoryStream>::Variant;
-
-    bool seek(size_t pos)
-    {
-        return this->visit(
-            [&](Buffered<Core::InputFileStream, Size>& buffered) {
-                // Discard the buffer, then seek normally.
-                if (!buffered.discard_or_error(buffered.buffered()))
-                    return false;
-                return buffered.underlying_stream().seek(pos);
-            },
-            [&](InputMemoryStream& stream) {
-                if (pos >= stream.bytes().size()) {
-                    return false;
-                }
-                stream.seek(pos);
-                return true;
-            });
-    }
-
-    bool handle_any_error()
-    {
-        return this->visit(
-            [&](auto& stream) {
-                return stream.handle_any_error();
-            });
-    }
-
-    InputBitStream bit_stream()
-    {
-        return this->visit(
-            [&](auto& stream) {
-                return InputBitStream(stream);
-            });
-    }
-};
 
 ALWAYS_INLINE u8 frame_channel_type_to_channel_count(FlacFrameChannelType channel_type);
 // Sign-extend an arbitrary-size signed number to 64 bit signed
@@ -75,18 +35,16 @@ ALWAYS_INLINE i32 rice_to_signed(u32 x);
 
 // decoders
 // read a UTF-8 encoded number, even if it is not a valid codepoint
-ALWAYS_INLINE u64 read_utf8_char(InputStream& input);
+ALWAYS_INLINE ErrorOr<u64> read_utf8_char(BigEndianInputBitStream& input);
 // decode a single number encoded with exponential golomb encoding of the specified order
-ALWAYS_INLINE i32 decode_unsigned_exp_golomb(u8 order, InputBitStream& bit_input);
+ALWAYS_INLINE ErrorOr<i32> decode_unsigned_exp_golomb(u8 order, BigEndianInputBitStream& bit_input);
 
 class FlacLoaderPlugin : public LoaderPlugin {
 public:
     explicit FlacLoaderPlugin(StringView path);
-    explicit FlacLoaderPlugin(const ByteBuffer& buffer);
+    explicit FlacLoaderPlugin(Bytes& buffer);
     ~FlacLoaderPlugin()
     {
-        if (m_stream)
-            m_stream->handle_any_error();
     }
 
     virtual MaybeLoaderError initialize() override;
@@ -110,20 +68,20 @@ private:
     MaybeLoaderError parse_header();
     // Either returns the metadata block or sets error message.
     // Additionally, increments m_data_start_location past the read meta block.
-    ErrorOr<FlacRawMetadataBlock, LoaderError> next_meta_block(InputBitStream& bit_input);
+    ErrorOr<FlacRawMetadataBlock, LoaderError> next_meta_block(BigEndianInputBitStream& bit_input);
     // Fetches and writes the next FLAC frame
     MaybeLoaderError next_frame(Span<Sample>);
     // Helper of next_frame that fetches a sub frame's header
-    ErrorOr<FlacSubframeHeader, LoaderError> next_subframe_header(InputBitStream& bit_input, u8 channel_index);
+    ErrorOr<FlacSubframeHeader, LoaderError> next_subframe_header(BigEndianInputBitStream& bit_input, u8 channel_index);
     // Helper of next_frame that decompresses a subframe
-    ErrorOr<Vector<i32>, LoaderError> parse_subframe(FlacSubframeHeader& subframe_header, InputBitStream& bit_input);
+    ErrorOr<Vector<i32>, LoaderError> parse_subframe(FlacSubframeHeader& subframe_header, BigEndianInputBitStream& bit_input);
     // Subframe-internal data decoders (heavy lifting)
-    ErrorOr<Vector<i32>, LoaderError> decode_fixed_lpc(FlacSubframeHeader& subframe, InputBitStream& bit_input);
-    ErrorOr<Vector<i32>, LoaderError> decode_verbatim(FlacSubframeHeader& subframe, InputBitStream& bit_input);
-    ErrorOr<Vector<i32>, LoaderError> decode_custom_lpc(FlacSubframeHeader& subframe, InputBitStream& bit_input);
-    MaybeLoaderError decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, InputBitStream& bit_input);
+    ErrorOr<Vector<i32>, LoaderError> decode_fixed_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    ErrorOr<Vector<i32>, LoaderError> decode_verbatim(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    ErrorOr<Vector<i32>, LoaderError> decode_custom_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    MaybeLoaderError decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
     // decode a single rice partition that has its own rice parameter
-    ALWAYS_INLINE Vector<i32> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, InputBitStream& bit_input);
+    ALWAYS_INLINE ErrorOr<Vector<i32>, LoaderError> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
 
     // Converters for special coding used in frame headers
     ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_count_code(u8 sample_count_code);
@@ -149,7 +107,7 @@ private:
 
     // keep track of the start of the data in the FLAC stream to seek back more easily
     u64 m_data_start_location { 0 };
-    OwnPtr<FlacInputStream<FLAC_BUFFER_SIZE>> m_stream;
+    OwnPtr<Core::Stream::SeekableStream> m_stream;
     Optional<FlacFrameHeader> m_current_frame;
     // Whatever the last get_more_samples() call couldn't return gets stored here.
     Vector<Sample, FLAC_BUFFER_SIZE> m_unread_data;

--- a/Userland/Libraries/LibAudio/Loader.cpp
+++ b/Userland/Libraries/LibAudio/Loader.cpp
@@ -30,7 +30,7 @@ Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(StringView p
     return LoaderError { "No loader plugin available" };
 }
 
-Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(ByteBuffer const& buffer)
+Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> Loader::try_create(Bytes& buffer)
 {
     NonnullOwnPtr<LoaderPlugin> plugin = adopt_own(*new WavLoaderPlugin(buffer));
     if (auto initstate = plugin->initialize(); !initstate.is_error())

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -6,12 +6,12 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Result.h>
+#include <AK/Span.h>
 #include <AK/StringView.h>
 #include <AK/Try.h>
 #include <LibAudio/Buffer.h>
@@ -57,7 +57,7 @@ public:
 class Loader : public RefCounted<Loader> {
 public:
     static Result<NonnullRefPtr<Loader>, LoaderError> create(StringView path) { return adopt_ref(*new Loader(TRY(try_create(path)))); }
-    static Result<NonnullRefPtr<Loader>, LoaderError> create(ByteBuffer const& buffer) { return adopt_ref(*new Loader(TRY(try_create(buffer)))); }
+    static Result<NonnullRefPtr<Loader>, LoaderError> create(Bytes& buffer) { return adopt_ref(*new Loader(TRY(try_create(buffer)))); }
 
     LoaderSamples get_more_samples(size_t max_bytes_to_read_from_input = 128 * KiB) const { return m_plugin->get_more_samples(max_bytes_to_read_from_input); }
 
@@ -73,7 +73,7 @@ public:
 
 private:
     static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> try_create(StringView path);
-    static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> try_create(ByteBuffer const& buffer);
+    static Result<NonnullOwnPtr<LoaderPlugin>, LoaderError> try_create(Bytes& buffer);
 
     explicit Loader(NonnullOwnPtr<LoaderPlugin>);
 

--- a/Userland/Libraries/LibAudio/LoaderError.h
+++ b/Userland/Libraries/LibAudio/LoaderError.h
@@ -64,3 +64,12 @@ struct LoaderError {
 };
 
 }
+
+// Convenience TRY-like macro to convert an Error to a LoaderError
+#define LOADER_TRY(expression)                                     \
+    ({                                                             \
+        auto _temporary_result = (expression);                     \
+        if (_temporary_result.is_error())                          \
+            return LoaderError(_temporary_result.release_error()); \
+        _temporary_result.release_value();                         \
+    })

--- a/Userland/Libraries/LibAudio/LoaderError.h
+++ b/Userland/Libraries/LibAudio/LoaderError.h
@@ -6,7 +6,9 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/FlyString.h>
+#include <errno.h>
 
 namespace Audio {
 
@@ -47,6 +49,18 @@ struct LoaderError {
 
     LoaderError(LoaderError&) = default;
     LoaderError(LoaderError&&) = default;
+
+    LoaderError(Error&& error)
+    {
+        if (error.is_errno()) {
+            auto code = error.code();
+            description = String::formatted("{} ({})", strerror(code), code);
+            if (code == EBADF || code == EBUSY || code == EEXIST || code == EIO || code == EISDIR || code == ENOENT || code == ENOMEM || code == EPIPE)
+                category = Category::IO;
+        } else {
+            description = error.string_literal();
+        }
+    }
 };
 
 }

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -36,7 +36,7 @@ MaybeLoaderError WavLoaderPlugin::initialize()
     return {};
 }
 
-WavLoaderPlugin::WavLoaderPlugin(const ByteBuffer& buffer)
+WavLoaderPlugin::WavLoaderPlugin(const Bytes& buffer)
 {
     m_stream = make<InputMemoryStream>(buffer);
     if (!m_stream) {

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -7,10 +7,10 @@
 
 #pragma once
 
-#include <AK/ByteBuffer.h>
 #include <AK/MemoryStream.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
+#include <AK/Span.h>
 #include <AK/Stream.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
@@ -34,7 +34,7 @@ class Buffer;
 class WavLoaderPlugin : public LoaderPlugin {
 public:
     explicit WavLoaderPlugin(StringView path);
-    explicit WavLoaderPlugin(const ByteBuffer& buffer);
+    explicit WavLoaderPlugin(const Bytes& buffer);
 
     virtual MaybeLoaderError initialize() override;
 

--- a/Userland/Libraries/LibCore/InputBitStream.h
+++ b/Userland/Libraries/LibCore/InputBitStream.h
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Concepts.h>
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/OwnPtr.h>
+#include <AK/Span.h>
+#include <AK/StdLibExtraDetails.h>
+#include <AK/Types.h>
+#include <LibCore/Stream.h>
+
+namespace Core::Stream {
+
+/// A stream wrapper class that allows you to read arbitrary amounts of bits
+/// in big-endian order from another stream.
+/// Note that this stream does not own its underlying stream, it merely takes a reference.
+class BigEndianInputBitStream : public Stream {
+public:
+    static ErrorOr<NonnullOwnPtr<BigEndianInputBitStream>> construct(Stream& stream)
+    {
+        return adopt_nonnull_own_or_enomem<BigEndianInputBitStream>(new BigEndianInputBitStream(stream));
+    }
+
+    // ^Stream
+    virtual bool is_readable() const override { return m_stream.is_readable(); }
+    virtual ErrorOr<size_t> read(Bytes bytes) override
+    {
+        if (m_current_byte.has_value() && is_aligned_to_byte_boundary()) {
+            bytes[0] = m_current_byte.release_value();
+            return m_stream.read(bytes.slice(1));
+        }
+        align_to_byte_boundary();
+        return m_stream.read(bytes);
+    }
+    virtual bool is_writable() const override { return m_stream.is_writable(); }
+    virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_stream.write(bytes); }
+    virtual bool write_or_error(ReadonlyBytes bytes) override { return m_stream.write_or_error(bytes); }
+    virtual bool is_eof() const override { return m_stream.is_eof() && !m_current_byte.has_value(); }
+    virtual bool is_open() const override { return m_stream.is_open(); }
+    virtual void close() override
+    {
+        m_stream.close();
+        align_to_byte_boundary();
+    }
+
+    ErrorOr<bool> read_bit()
+    {
+        return read_bits<bool>(1);
+    }
+    /// Depending on the number of bits to read, the return type can be chosen appropriately.
+    /// This avoids a bunch of static_cast<>'s for the user.
+    // TODO: Support u128, u256 etc. as well: The concepts would be quite complex.
+    template<Unsigned T = u64>
+    ErrorOr<T> read_bits(size_t count)
+    {
+        if constexpr (IsSame<bool, T>) {
+            VERIFY(count == 1);
+        }
+        T result = 0;
+
+        size_t nread = 0;
+        while (nread < count) {
+            if (m_current_byte.has_value()) {
+                if constexpr (!IsSame<bool, T> && !IsSame<u8, T>) {
+                    // read as many bytes as possible directly
+                    if (((count - nread) >= 8) && is_aligned_to_byte_boundary()) {
+                        // shift existing data over
+                        result <<= 8;
+                        result |= m_current_byte.value();
+                        nread += 8;
+                        m_current_byte.clear();
+                    } else {
+                        const auto bit = (m_current_byte.value() >> (7 - m_bit_offset)) & 1;
+                        result <<= 1;
+                        result |= bit;
+                        ++nread;
+                        if (m_bit_offset++ == 7)
+                            m_current_byte.clear();
+                    }
+                } else {
+                    // Always take this branch for booleans or u8: there's no purpose in reading more than a single bit
+                    const auto bit = (m_current_byte.value() >> (7 - m_bit_offset)) & 1;
+                    if constexpr (IsSame<bool, T>)
+                        result = bit;
+                    else {
+                        result <<= 1;
+                        result |= bit;
+                    }
+                    ++nread;
+                    if (m_bit_offset++ == 7)
+                        m_current_byte.clear();
+                }
+            } else {
+                // FIXME: This returns Optional so TRY is not useable
+                auto temp_buffer = ByteBuffer::create_uninitialized(1);
+                if (!temp_buffer.has_value())
+                    return Error::from_string_literal("Couldn't allocate temporary byte buffer"sv);
+
+                TRY(m_stream.read(temp_buffer->bytes()));
+                m_current_byte = (*temp_buffer)[0];
+                m_bit_offset = 0;
+            }
+        }
+
+        return result;
+    }
+
+    /// Discards any sub-byte stream positioning the input stream may be keeping track of.
+    /// Non-bitwise reads will implicitly call this.
+    void align_to_byte_boundary()
+    {
+        m_current_byte.clear();
+        m_bit_offset = 0;
+    }
+
+    /// Whether we are (accidentally or intentionally) at a byte boundary right now.
+    ALWAYS_INLINE bool is_aligned_to_byte_boundary() const { return m_bit_offset == 0; }
+
+private:
+    BigEndianInputBitStream(Stream& stream)
+        : m_stream(stream)
+    {
+    }
+
+    Optional<u8> m_current_byte;
+    size_t m_bit_offset { 0 };
+    Stream& m_stream;
+};
+
+}

--- a/Userland/Libraries/LibCore/MemoryStream.h
+++ b/Userland/Libraries/LibCore/MemoryStream.h
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/OwnPtr.h>
+#include <AK/Span.h>
+#include <AK/TypedTransfer.h>
+#include <LibCore/Stream.h>
+
+namespace Core::Stream {
+
+class MemoryStream final : public SeekableStream {
+public:
+    static ErrorOr<NonnullOwnPtr<MemoryStream>> construct(Bytes bytes)
+    {
+        return adopt_nonnull_own_or_enomem<MemoryStream>(new (nothrow) MemoryStream(bytes));
+    }
+
+    virtual bool is_eof() const override { return m_offset >= m_bytes.size(); }
+    virtual bool is_open() const override { return true; }
+    // FIXME: It doesn't make sense to close an memory stream. Therefore, we don't do anything here. Is that fine?
+    virtual void close() override { }
+
+    virtual ErrorOr<size_t> read(Bytes bytes) override
+    {
+        auto to_read = min(remaining(), bytes.size());
+        if (to_read == 0)
+            return 0;
+
+        m_bytes.slice(m_offset, to_read).copy_to(bytes);
+        m_offset += to_read;
+        return bytes.size();
+    }
+
+    virtual ErrorOr<off_t> seek(i64 offset, SeekMode seek_mode = SeekMode::SetPosition) override
+    {
+        switch (seek_mode) {
+        case SeekMode::SetPosition:
+            if (offset >= static_cast<i64>(m_bytes.size()))
+                return Error::from_string_literal("Offset past the end of the stream memory"sv);
+
+            m_offset = offset;
+            break;
+        case SeekMode::FromCurrentPosition:
+            if (offset + static_cast<i64>(m_offset) >= static_cast<i64>(m_bytes.size()))
+                return Error::from_string_literal("Offset past the end of the stream memory"sv);
+
+            m_offset += offset;
+            break;
+        case SeekMode::FromEndPosition:
+            if (offset >= static_cast<i64>(m_bytes.size()))
+                return Error::from_string_literal("Offset past the start of the stream memory"sv);
+
+            m_offset = m_bytes.size() - offset;
+            break;
+        }
+        return static_cast<off_t>(m_offset);
+    }
+
+    virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override
+    {
+        // FIXME: Can this not error?
+        const auto nwritten = bytes.copy_trimmed_to(m_bytes.slice(m_offset));
+        m_offset += nwritten;
+        return nwritten;
+    }
+    virtual bool write_or_error(ReadonlyBytes bytes) override
+    {
+        if (remaining() < bytes.size())
+            return false;
+
+        MUST(write(bytes));
+        return true;
+    }
+
+    Bytes bytes() { return m_bytes; }
+    ReadonlyBytes bytes() const { return m_bytes; }
+    size_t offset() const { return m_offset; }
+    size_t remaining() const { return m_bytes.size() - m_offset; }
+
+protected:
+    explicit MemoryStream(Bytes bytes)
+        : m_bytes(bytes)
+    {
+    }
+
+private:
+    Bytes m_bytes;
+    size_t m_offset { 0 };
+};
+
+}

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -516,6 +516,11 @@ public:
         // Otherwise, let's try an extra read just in case there's something
         // in our receive buffer.
         auto stream_nread = TRY(stream().read(buffer.slice(buffer_nread)));
+
+        // Fill the internal buffer if it has run dry.
+        if (m_buffered_size == 0)
+            TRY(populate_read_buffer());
+
         return buffer_nread + stream_nread;
     }
 


### PR DESCRIPTION
This includes supporting changes in Core::Stream, which ports over MemoryStream and BigEndianBitInputStream from AK and fixes some issues with other touched parts of the API. Performance for FlacLoader is identical but the code is much nicer :^)

@sin-ack please re-submit your complaints for MemoryStream here, it's easier that way