### PR TITLE
LibJS: Update spec numbers/links for error cause proposal merge

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -43,7 +43,7 @@ ThrowCompletionOr<Value> require_object_coercible(GlobalObject& global_object, V
     return value;
 }
 
-// 7.3.13 Call ( F, V [ , argumentsList ] ), https://tc39.es/ecma262/#sec-call
+// 7.3.14 Call ( F, V [ , argumentsList ] ), https://tc39.es/ecma262/#sec-call
 ThrowCompletionOr<Value> call_impl(GlobalObject& global_object, Value function, Value this_value, Optional<MarkedValueList> arguments_list)
 {
     auto& vm = global_object.vm();
@@ -60,7 +60,7 @@ ThrowCompletionOr<Value> call_impl(GlobalObject& global_object, Value function, 
     return function.as_function().internal_call(this_value, move(*arguments_list));
 }
 
-// 7.3.14 Construct ( F [ , argumentsList [ , newTarget ] ] ), https://tc39.es/ecma262/#sec-construct
+// 7.3.15 Construct ( F [ , argumentsList [ , newTarget ] ] ), https://tc39.es/ecma262/#sec-construct
 ThrowCompletionOr<Object*> construct(GlobalObject& global_object, FunctionObject& function, Optional<MarkedValueList> arguments_list, FunctionObject* new_target)
 {
     // 1. If newTarget is not present, set newTarget to F.
@@ -75,7 +75,7 @@ ThrowCompletionOr<Object*> construct(GlobalObject& global_object, FunctionObject
     return function.internal_construct(move(*arguments_list), *new_target);
 }
 
-// 7.3.18 LengthOfArrayLike ( obj ), https://tc39.es/ecma262/#sec-lengthofarraylike
+// 7.3.19 LengthOfArrayLike ( obj ), https://tc39.es/ecma262/#sec-lengthofarraylike
 ThrowCompletionOr<size_t> length_of_array_like(GlobalObject& global_object, Object const& object)
 {
     auto& vm = global_object.vm();
@@ -83,7 +83,7 @@ ThrowCompletionOr<size_t> length_of_array_like(GlobalObject& global_object, Obje
     return result.to_length(global_object);
 }
 
-// 7.3.19 CreateListFromArrayLike ( obj [ , elementTypes ] ), https://tc39.es/ecma262/#sec-createlistfromarraylike
+// 7.3.20 CreateListFromArrayLike ( obj [ , elementTypes ] ), https://tc39.es/ecma262/#sec-createlistfromarraylike
 ThrowCompletionOr<MarkedValueList> create_list_from_array_like(GlobalObject& global_object, Value value, Function<ThrowCompletionOr<void>(Value)> check_value)
 {
     auto& vm = global_object.vm();
@@ -124,7 +124,7 @@ ThrowCompletionOr<MarkedValueList> create_list_from_array_like(GlobalObject& glo
     return ThrowCompletionOr(move(list));
 }
 
-// 7.3.22 SpeciesConstructor ( O, defaultConstructor ), https://tc39.es/ecma262/#sec-speciesconstructor
+// 7.3.23 SpeciesConstructor ( O, defaultConstructor ), https://tc39.es/ecma262/#sec-speciesconstructor
 ThrowCompletionOr<FunctionObject*> species_constructor(GlobalObject& global_object, Object const& object, FunctionObject& default_constructor)
 {
     auto& vm = global_object.vm();
@@ -155,7 +155,7 @@ ThrowCompletionOr<FunctionObject*> species_constructor(GlobalObject& global_obje
     return vm.throw_completion<TypeError>(global_object, ErrorType::NotAConstructor, species.to_string_without_side_effects());
 }
 
-// 7.3.24 GetFunctionRealm ( obj ), https://tc39.es/ecma262/#sec-getfunctionrealm
+// 7.3.25 GetFunctionRealm ( obj ), https://tc39.es/ecma262/#sec-getfunctionrealm
 ThrowCompletionOr<Realm*> get_function_realm(GlobalObject& global_object, FunctionObject const& function)
 {
     auto& vm = global_object.vm();

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -49,7 +49,7 @@ ThrowCompletionOr<Value> perform_eval(Value, GlobalObject&, CallerMode, EvalMode
 
 ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, GlobalObject& global_object, Program const& program, Environment* variable_environment, Environment* lexical_environment, PrivateEnvironment* private_environment, bool strict);
 
-// 7.3.13 Call ( F, V [ , argumentsList ] ), https://tc39.es/ecma262/#sec-call
+// 7.3.14 Call ( F, V [ , argumentsList ] ), https://tc39.es/ecma262/#sec-call
 template<typename... Args>
 ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Value function, Value this_value, MarkedValueList arguments_list)
 {

--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -26,7 +26,7 @@ ThrowCompletionOr<Array*> Array::create(GlobalObject& global_object, size_t leng
     return array;
 }
 
-// 7.3.17 CreateArrayFromList ( elements ), https://tc39.es/ecma262/#sec-createarrayfromlist
+// 7.3.18 CreateArrayFromList ( elements ), https://tc39.es/ecma262/#sec-createarrayfromlist
 Array* Array::create_from(GlobalObject& global_object, Vector<Value> const& elements)
 {
     // 1. Assert: elements is a List whose elements are all ECMAScript language values.

--- a/Userland/Libraries/LibJS/Runtime/Error.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Error.cpp
@@ -30,7 +30,7 @@ Error::Error(Object& prototype)
 {
 }
 
-// 20.5.8.1 InstallErrorCause ( O, options ), https://tc39.es/proposal-error-cause/#sec-errorobjects-install-error-cause
+// 20.5.8.1 InstallErrorCause ( O, options ), https://tc39.es/ecma262/#sec-installerrorcause
 ThrowCompletionOr<void> Error::install_error_cause(Value options)
 {
     auto& vm = this->vm();
@@ -44,7 +44,7 @@ ThrowCompletionOr<void> Error::install_error_cause(Value options)
         MUST(create_non_enumerable_data_property_or_throw(vm.names.cause, cause));
     }
 
-    // Return NormalCompletion(undefined).
+    // 2. Return NormalCompletion(undefined).
     return {};
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -182,7 +182,7 @@ ThrowCompletionOr<bool> Object::create_data_property_or_throw(PropertyKey const&
     return success;
 }
 
-// 7.3.6 CreateNonEnumerableDataPropertyOrThrow ( O, P, V ), https://tc39.es/proposal-error-cause/#sec-createnonenumerabledatapropertyorthrow
+// 7.3.8 CreateNonEnumerableDataPropertyOrThrow ( O, P, V ), https://tc39.es/ecma262/#sec-createnonenumerabledatapropertyorthrow
 ThrowCompletionOr<bool> Object::create_non_enumerable_data_property_or_throw(PropertyKey const& property_name, Value value)
 {
     VERIFY(!value.is_empty());
@@ -195,7 +195,7 @@ ThrowCompletionOr<bool> Object::create_non_enumerable_data_property_or_throw(Pro
     return define_property_or_throw(property_name, new_description);
 }
 
-// 7.3.8 DefinePropertyOrThrow ( O, P, desc ), https://tc39.es/ecma262/#sec-definepropertyorthrow
+// 7.3.9 DefinePropertyOrThrow ( O, P, desc ), https://tc39.es/ecma262/#sec-definepropertyorthrow
 ThrowCompletionOr<bool> Object::define_property_or_throw(PropertyKey const& property_name, PropertyDescriptor const& property_descriptor)
 {
     auto& vm = this->vm();
@@ -218,7 +218,7 @@ ThrowCompletionOr<bool> Object::define_property_or_throw(PropertyKey const& prop
     return success;
 }
 
-// 7.3.9 DeletePropertyOrThrow ( O, P ), https://tc39.es/ecma262/#sec-deletepropertyorthrow
+// 7.3.10 DeletePropertyOrThrow ( O, P ), https://tc39.es/ecma262/#sec-deletepropertyorthrow
 ThrowCompletionOr<bool> Object::delete_property_or_throw(PropertyKey const& property_name)
 {
     auto& vm = this->vm();
@@ -241,7 +241,7 @@ ThrowCompletionOr<bool> Object::delete_property_or_throw(PropertyKey const& prop
     return success;
 }
 
-// 7.3.11 HasProperty ( O, P ), https://tc39.es/ecma262/#sec-hasproperty
+// 7.3.12 HasProperty ( O, P ), https://tc39.es/ecma262/#sec-hasproperty
 ThrowCompletionOr<bool> Object::has_property(PropertyKey const& property_name) const
 {
     // 1. Assert: Type(O) is Object.
@@ -253,7 +253,7 @@ ThrowCompletionOr<bool> Object::has_property(PropertyKey const& property_name) c
     return internal_has_property(property_name);
 }
 
-// 7.3.12 HasOwnProperty ( O, P ), https://tc39.es/ecma262/#sec-hasownproperty
+// 7.3.13 HasOwnProperty ( O, P ), https://tc39.es/ecma262/#sec-hasownproperty
 ThrowCompletionOr<bool> Object::has_own_property(PropertyKey const& property_name) const
 {
     // 1. Assert: Type(O) is Object.
@@ -272,7 +272,7 @@ ThrowCompletionOr<bool> Object::has_own_property(PropertyKey const& property_nam
     return true;
 }
 
-// 7.3.15 SetIntegrityLevel ( O, level ), https://tc39.es/ecma262/#sec-setintegritylevel
+// 7.3.16 SetIntegrityLevel ( O, level ), https://tc39.es/ecma262/#sec-setintegritylevel
 ThrowCompletionOr<bool> Object::set_integrity_level(IntegrityLevel level)
 {
     auto& global_object = this->global_object();
@@ -339,7 +339,7 @@ ThrowCompletionOr<bool> Object::set_integrity_level(IntegrityLevel level)
     return true;
 }
 
-// 7.3.16 TestIntegrityLevel ( O, level ), https://tc39.es/ecma262/#sec-testintegritylevel
+// 7.3.17 TestIntegrityLevel ( O, level ), https://tc39.es/ecma262/#sec-testintegritylevel
 ThrowCompletionOr<bool> Object::test_integrity_level(IntegrityLevel level) const
 {
     // 1. Assert: Type(O) is Object.
@@ -384,7 +384,7 @@ ThrowCompletionOr<bool> Object::test_integrity_level(IntegrityLevel level) const
     return true;
 }
 
-// 7.3.23 EnumerableOwnPropertyNames ( O, kind ), https://tc39.es/ecma262/#sec-enumerableownpropertynames
+// 7.3.24 EnumerableOwnPropertyNames ( O, kind ), https://tc39.es/ecma262/#sec-enumerableownpropertynames
 ThrowCompletionOr<MarkedValueList> Object::enumerable_own_property_names(PropertyKind kind) const
 {
     // NOTE: This has been flattened for readability, so some `else` branches in the
@@ -444,7 +444,7 @@ ThrowCompletionOr<MarkedValueList> Object::enumerable_own_property_names(Propert
     return { move(properties) };
 }
 
-// 7.3.25 CopyDataProperties ( target, source, excludedItems ), https://tc39.es/ecma262/#sec-copydataproperties
+// 7.3.26 CopyDataProperties ( target, source, excludedItems ), https://tc39.es/ecma262/#sec-copydataproperties
 ThrowCompletionOr<Object*> Object::copy_data_properties(Value source, HashTable<PropertyKey> const& seen_names, GlobalObject& global_object)
 {
     if (source.is_nullish())
@@ -467,7 +467,7 @@ ThrowCompletionOr<Object*> Object::copy_data_properties(Value source, HashTable<
     return this;
 }
 
-// 7.3.26 PrivateElementFind ( O, P ), https://tc39.es/ecma262/#sec-privateelementfind
+// 7.3.27 PrivateElementFind ( O, P ), https://tc39.es/ecma262/#sec-privateelementfind
 PrivateElement* Object::private_element_find(PrivateName const& name)
 {
     if (!m_private_elements)
@@ -483,7 +483,7 @@ PrivateElement* Object::private_element_find(PrivateName const& name)
     return &(*element);
 }
 
-// 7.3.27 PrivateFieldAdd ( O, P, value ), https://tc39.es/ecma262/#sec-privatefieldadd
+// 7.3.28 PrivateFieldAdd ( O, P, value ), https://tc39.es/ecma262/#sec-privatefieldadd
 ThrowCompletionOr<void> Object::private_field_add(PrivateName const& name, Value value)
 {
     if (auto* entry = private_element_find(name); entry)
@@ -494,7 +494,7 @@ ThrowCompletionOr<void> Object::private_field_add(PrivateName const& name, Value
     return {};
 }
 
-// 7.3.28 PrivateMethodOrAccessorAdd ( O, method ), https://tc39.es/ecma262/#sec-privatemethodoraccessoradd
+// 7.3.29 PrivateMethodOrAccessorAdd ( O, method ), https://tc39.es/ecma262/#sec-privatemethodoraccessoradd
 ThrowCompletionOr<void> Object::private_method_or_accessor_add(PrivateElement element)
 {
     VERIFY(element.kind == PrivateElement::Kind::Method || element.kind == PrivateElement::Kind::Accessor);
@@ -506,7 +506,7 @@ ThrowCompletionOr<void> Object::private_method_or_accessor_add(PrivateElement el
     return {};
 }
 
-// 7.3.29 PrivateGet ( O, P ), https://tc39.es/ecma262/#sec-privateget
+// 7.3.30 PrivateGet ( O, P ), https://tc39.es/ecma262/#sec-privateget
 ThrowCompletionOr<Value> Object::private_get(PrivateName const& name)
 {
     auto* entry = private_element_find(name);
@@ -527,7 +527,7 @@ ThrowCompletionOr<Value> Object::private_get(PrivateName const& name)
     return TRY(vm().call(*getter, this));
 }
 
-// 7.3.30 PrivateSet ( O, P, value ), https://tc39.es/ecma262/#sec-privateset
+// 7.3.31 PrivateSet ( O, P, value ), https://tc39.es/ecma262/#sec-privateset
 ThrowCompletionOr<void> Object::private_set(PrivateName const& name, Value value)
 {
     auto* entry = private_element_find(name);
@@ -553,7 +553,7 @@ ThrowCompletionOr<void> Object::private_set(PrivateName const& name, Value value
     return {};
 }
 
-// 7.3.31 DefineField ( receiver, fieldRecord ), https://tc39.es/ecma262/#sec-definefield
+// 7.3.32 DefineField ( receiver, fieldRecord ), https://tc39.es/ecma262/#sec-definefield
 ThrowCompletionOr<void> Object::define_field(Variant<PropertyKey, PrivateName> name, ECMAScriptFunctionObject* initializer)
 {
     Value init_value = js_undefined();

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -462,7 +462,7 @@ Reference VM::resolve_binding(FlyString const& name, Environment* environment)
     return get_identifier_reference(environment, name, strict);
 }
 
-// 7.3.32 InitializeInstanceElements ( O, constructor ), https://tc39.es/ecma262/#sec-initializeinstanceelements
+// 7.3.33 InitializeInstanceElements ( O, constructor ), https://tc39.es/ecma262/#sec-initializeinstanceelements
 ThrowCompletionOr<void> VM::initialize_instance_elements(Object& object, ECMAScriptFunctionObject& constructor)
 {
     for (auto& method : constructor.private_methods())

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -747,7 +747,7 @@ ThrowCompletionOr<Value> Value::get(GlobalObject& global_object, PropertyKey con
     return TRY(object->internal_get(property_name, *this));
 }
 
-// 7.3.10 GetMethod ( V, P ), https://tc39.es/ecma262/#sec-getmethod
+// 7.3.11 GetMethod ( V, P ), https://tc39.es/ecma262/#sec-getmethod
 ThrowCompletionOr<FunctionObject*> Value::get_method(GlobalObject& global_object, PropertyKey const& property_name) const
 {
     auto& vm = global_object.vm();
@@ -1157,7 +1157,7 @@ ThrowCompletionOr<Value> instance_of(GlobalObject& global_object, Value lhs, Val
     return TRY(ordinary_has_instance(global_object, lhs, rhs));
 }
 
-// 7.3.21 OrdinaryHasInstance ( C, O ), https://tc39.es/ecma262/#sec-ordinaryhasinstance
+// 7.3.22 OrdinaryHasInstance ( C, O ), https://tc39.es/ecma262/#sec-ordinaryhasinstance
 ThrowCompletionOr<Value> ordinary_has_instance(GlobalObject& global_object, Value lhs, Value rhs)
 {
     auto& vm = global_object.vm();
@@ -1468,7 +1468,7 @@ ThrowCompletionOr<TriState> is_less_than(GlobalObject& global_object, bool left_
         return TriState::False;
 }
 
-// 7.3.20 Invoke ( V, P [ , argumentsList ] ), https://tc39.es/ecma262/#sec-invoke
+// 7.3.21 Invoke ( V, P [ , argumentsList ] ), https://tc39.es/ecma262/#sec-invoke
 ThrowCompletionOr<Value> Value::invoke_internal(GlobalObject& global_object, JS::PropertyKey const& property_name, Optional<MarkedValueList> arguments)
 {
     auto& vm = global_object.vm();


### PR DESCRIPTION
I saw this proposal got merged in ECMA-262 and thought we would have a new spec to implement, turns out we had already implemented the proposal :grinning: 
So this just updates spec numbers/links that changed after the merge.