### PR TITLE
LibRegex: Make append_alternation() significantly faster 

### DIFF
--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -251,7 +251,7 @@ public:
         return sum;
     }
 
-    bool is_empty() const { return size() == 0; }
+    bool is_empty() const { return m_chunks.size() == 0 || size() == 0; }
 
     DisjointSpans<T> spans() const&
     {

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -186,10 +186,10 @@ ALWAYS_INLINE OpCode& ByteCode::get_opcode_by_id(OpCodeId id) const
 OpCode& ByteCode::get_opcode(MatchState& state) const
 {
     OpCodeId opcode_id;
-    if (state.instruction_position >= size())
-        opcode_id = OpCodeId::Exit;
+    if (auto opcode_ptr = static_cast<DisjointChunks<ByteCodeValueType> const&>(*this).find(state.instruction_position))
+        opcode_id = (OpCodeId)*opcode_ptr;
     else
-        opcode_id = (OpCodeId)at(state.instruction_position);
+        opcode_id = OpCodeId::Exit;
 
     auto& opcode = get_opcode_by_id(opcode_id);
     opcode.set_state(state);


### PR DESCRIPTION
...by flattening the underlying bytecode chunks first.
Also avoid calling DisjointChunks::size() inside a loop.
This is a very significant improvement in performance, making the
compilation of a large regex with lots of alternatives take only ~100ms
instead of many minutes (I ran out of patience waiting for it) :^)

cc @Lubrsi.