### PR TITLE
Profiler: Add horizontal_scrollbar height to initial_height

### DIFF
--- a/Userland/DevTools/Profiler/TimelineContainer.cpp
+++ b/Userland/DevTools/Profiler/TimelineContainer.cpp
@@ -22,7 +22,7 @@ TimelineContainer::TimelineContainer(GUI::Widget& header_container, TimelineView
     update_widget_sizes();
     update_widget_positions();
 
-    int initial_height = min(300, timeline_view.height() + frame_thickness() * 2);
+    int initial_height = min(300, timeline_view.height() + horizontal_scrollbar().max_height() + frame_thickness() * 2);
     set_fixed_height(initial_height);
 
     m_timeline_view->on_scale_change = [this] {


### PR DESCRIPTION
**Previously the timeline would be covered up by the scrollbar if one was needed due to the length of the timeline.**
![image](https://user-images.githubusercontent.com/6303961/146949472-dac50e1b-9f99-4efa-9d52-6f73fe1f3ea0.png)

**Updated version, leaving space for the scrollbar, so it does not cover up the timeline on launch.**
![image](https://user-images.githubusercontent.com/6303961/146950102-dc084aa2-460b-40b9-996d-b7d189e5c6ea.png)


As far as I could tell, at the time that the `initial_height` is set, the `horizontal_scrollbar` will not know it's final state yet, so I was not able to only conditionally add the extra spacing. This means that for timelines without a scrollbar, there's some extra padding at the bottom now.
![image](https://user-images.githubusercontent.com/6303961/146947233-35a010da-37d5-4059-9f4f-60deba8c6030.png)
