### PR TITLE
Implement `sysconf(SC_SYMLOOP_MAX)`

### DIFF
--- a/Kernel/API/POSIX/unistd.h
+++ b/Kernel/API/POSIX/unistd.h
@@ -38,6 +38,7 @@ enum {
     _SC_PAGESIZE,
     _SC_GETPW_R_SIZE_MAX,
     _SC_CLK_TCK,
+    _SC_SYMLOOP_MAX,
 };
 
 #define _SC_MONOTONIC_CLOCK _SC_MONOTONIC_CLOCK
@@ -49,6 +50,7 @@ enum {
 #define _SC_TTY_NAME_MAX _SC_TTY_NAME_MAX
 #define _SC_GETPW_R_SIZE_MAX _SC_GETPW_R_SIZE_MAX
 #define _SC_CLK_TCK _SC_CLK_TCK
+#define _SC_SYMLOOP_MAX _SC_SYMLOOP_MAX
 
 #ifdef __cplusplus
 }

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -24,7 +24,6 @@
 namespace Kernel {
 
 static Singleton<VirtualFileSystem> s_the;
-static constexpr int symlink_recursion_limit { 5 }; // FIXME: increase?
 static constexpr int root_mount_flags = MS_NODEV | MS_NOSUID | MS_RDONLY;
 
 UNMAP_AFTER_INIT void VirtualFileSystem::initialize()

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -35,6 +35,10 @@ struct UidAndGid {
 class VirtualFileSystem {
     AK_MAKE_ETERNAL
 public:
+    // Required to be at least 8 by POSIX
+    // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/limits.h.html
+    static constexpr int symlink_recursion_limit = 8;
+
     static void initialize();
     static VirtualFileSystem& the();
 

--- a/Kernel/Syscalls/sysconf.cpp
+++ b/Kernel/Syscalls/sysconf.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/FileSystem/VirtualFileSystem.h>
 #include <Kernel/Process.h>
 #include <Kernel/Time/TimeManagement.h>
 
@@ -30,6 +31,8 @@ ErrorOr<FlatPtr> Process::sys$sysconf(int name)
         return 4096; // idk
     case _SC_CLK_TCK:
         return TimeManagement::the().ticks_per_second();
+    case _SC_SYMLOOP_MAX:
+        return Kernel::VirtualFileSystem::symlink_recursion_limit;
     default:
         return EINVAL;
     }


### PR DESCRIPTION
This PR does three things:
 - raises kernel symlink loop limit to 8 (because, as BertalanD pointed out, POSIX specifies it should be at least 8)
 - moves the limit constant to the header file
 - accesses the constant to implement the $subj sysconf call

I'll need this constant in #11275 so I figured (after burning a bit of your time with my naive changes) it'll be best to merge this one separately so i get my feet wet with the process here instead of straight up jumping in with that big chonker of a PR. 