### PR TITLE
LibRegex: Some clang-tidy fixes

### DIFF
--- a/Userland/Libraries/LibRegex/C/Regex.cpp
+++ b/Userland/Libraries/LibRegex/C/Regex.cpp
@@ -142,12 +142,12 @@ int regexec(const regex_t* reg, const char* string, size_t nmatch, regmatch_t pm
             }
         }
         return REG_NOERR;
-    } else {
-        if (nmatch && pmatch) {
-            pmatch[0].rm_so = -1;
-            pmatch[0].rm_eo = -1;
-            pmatch[0].rm_cnt = 0;
-        }
+    }
+
+    if (nmatch && pmatch) {
+        pmatch[0].rm_so = -1;
+        pmatch[0].rm_eo = -1;
+        pmatch[0].rm_cnt = 0;
     }
 
     return REG_NOMATCH;

--- a/Userland/Libraries/LibRegex/C/Regex.cpp
+++ b/Userland/Libraries/LibRegex/C/Regex.cpp
@@ -52,7 +52,7 @@ int regcomp(regex_t* reg, const char* pattern, int cflags)
     // This could've been prevented if libc provided a reginit() or similar, but it does not.
     reg->__data = new internal_regex_t { 0, 0, {}, 0, ReError::REG_NOERR, {} };
 
-    auto preg = impl_from(reg);
+    auto* preg = impl_from(reg);
     bool is_extended = cflags & REG_EXTENDED;
 
     preg->cflags = cflags;
@@ -82,7 +82,7 @@ int regcomp(regex_t* reg, const char* pattern, int cflags)
 
 int regexec(const regex_t* reg, const char* string, size_t nmatch, regmatch_t pmatch[], int eflags)
 {
-    auto preg = impl_from(reg);
+    auto const* preg = impl_from(reg);
 
     if (!preg->re.has_value() || preg->re_pat_err) {
         if (preg->re_pat_err)
@@ -213,7 +213,7 @@ inline static String get_error(ReError errcode)
 size_t regerror(int errcode, const regex_t* reg, char* errbuf, size_t errbuf_size)
 {
     String error;
-    auto preg = impl_from(reg);
+    auto const* preg = impl_from(reg);
 
     if (!preg)
         error = get_error((ReError)errcode);
@@ -231,7 +231,7 @@ size_t regerror(int errcode, const regex_t* reg, char* errbuf, size_t errbuf_siz
 
 void regfree(regex_t* reg)
 {
-    auto preg = impl_from(reg);
+    auto* preg = impl_from(reg);
     if (preg) {
         delete preg;
         reg->__data = nullptr;

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -284,16 +284,11 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(MatchInput const& in
     auto isword = [](auto ch) { return is_ascii_alphanumeric(ch) || ch == '_'; };
     auto is_word_boundary = [&] {
         if (state.string_position == input.view.length()) {
-            if (state.string_position > 0 && isword(input.view[state.string_position_in_code_units - 1]))
-                return true;
-            return false;
+            return (state.string_position > 0 && isword(input.view[state.string_position_in_code_units - 1]));
         }
 
         if (state.string_position == 0) {
-            if (isword(input.view[0]))
-                return true;
-
-            return false;
+            return (isword(input.view[0]));
         }
 
         return !!(isword(input.view[state.string_position_in_code_units]) ^ isword(input.view[state.string_position_in_code_units - 1]));

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -812,7 +812,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_script_extension(MatchInput const& in
     }
 }
 
-String const OpCode_Compare::arguments_string() const
+String OpCode_Compare::arguments_string() const
 {
     return String::formatted("argc={}, args={} ", arguments_count(), arguments_size());
 }
@@ -855,7 +855,7 @@ Vector<CompareTypeAndValuePair> OpCode_Compare::flat_compares() const
     return result;
 }
 
-Vector<String> const OpCode_Compare::variable_arguments_to_string(Optional<MatchInput> input) const
+Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<MatchInput> input) const
 {
     Vector<String> result;
 

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -502,7 +502,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
 
             auto ch = input.view.substring_view(state.string_position, 1)[0];
 
-            auto matching_range = binary_search(range_data, ch, nullptr, [insensitive = input.regex_options & AllFlags::Insensitive](auto needle, CharRange range) {
+            auto const* matching_range = binary_search(range_data, ch, nullptr, [insensitive = input.regex_options & AllFlags::Insensitive](auto needle, CharRange range) {
                 auto from = range.from;
                 auto to = range.to;
                 if (insensitive) {

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -538,7 +538,6 @@ char const* execution_result_name(ExecutionResult result);
 char const* opcode_id_name(OpCodeId opcode_id);
 char const* boundary_check_type_name(BoundaryCheckType);
 char const* character_compare_type_name(CharacterCompareType result);
-char const* execution_result_name(ExecutionResult result);
 
 class OpCode {
 public:

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -556,7 +556,7 @@ public:
     }
 
     ALWAYS_INLINE char const* name() const;
-    static char const* name(OpCodeId const);
+    static char const* name(OpCodeId);
 
     ALWAYS_INLINE void set_state(MatchState& state) { m_state = &state; }
 
@@ -568,12 +568,12 @@ public:
         return *m_state;
     }
 
-    String const to_string() const
+    String to_string() const
     {
         return String::formatted("[{:#02X}] {}", (int)opcode_id(), name(opcode_id()));
     }
 
-    virtual String const arguments_string() const = 0;
+    virtual String arguments_string() const = 0;
 
     ALWAYS_INLINE ByteCode const& bytecode() const { return *m_bytecode; }
 
@@ -587,7 +587,7 @@ public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Exit; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    String const arguments_string() const override { return ""; }
+    String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_FailForks final : public OpCode {
@@ -596,7 +596,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::FailForks; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t count() const { return argument(0); }
-    String const arguments_string() const override { return String::formatted("count={}", count()); }
+    String arguments_string() const override { return String::formatted("count={}", count()); }
 };
 
 class OpCode_Save final : public OpCode {
@@ -604,7 +604,7 @@ public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Save; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    String const arguments_string() const override { return ""; }
+    String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_Restore final : public OpCode {
@@ -612,7 +612,7 @@ public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Restore; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    String const arguments_string() const override { return ""; }
+    String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_GoBack final : public OpCode {
@@ -621,7 +621,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::GoBack; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t count() const { return argument(0); }
-    String const arguments_string() const override { return String::formatted("count={}", count()); }
+    String arguments_string() const override { return String::formatted("count={}", count()); }
 };
 
 class OpCode_Jump final : public OpCode {
@@ -630,7 +630,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Jump; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
-    String const arguments_string() const override
+    String arguments_string() const override
     {
         return String::formatted("offset={} [&{}]", offset(), state().instruction_position + size() + offset());
     }
@@ -642,7 +642,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkJump; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
-    String const arguments_string() const override
+    String arguments_string() const override
     {
         return String::formatted("offset={} [&{}], sp: {}", offset(), state().instruction_position + size() + offset(), state().string_position);
     }
@@ -660,7 +660,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkStay; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
-    String const arguments_string() const override
+    String arguments_string() const override
     {
         return String::formatted("offset={} [&{}], sp: {}", offset(), state().instruction_position + size() + offset(), state().string_position);
     }
@@ -677,7 +677,7 @@ public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBegin; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    String const arguments_string() const override { return ""; }
+    String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_CheckEnd final : public OpCode {
@@ -685,7 +685,7 @@ public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckEnd; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    String const arguments_string() const override { return ""; }
+    String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_CheckBoundary final : public OpCode {
@@ -695,7 +695,7 @@ public:
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t arguments_count() const { return 1; }
     ALWAYS_INLINE BoundaryCheckType type() const { return static_cast<BoundaryCheckType>(argument(0)); }
-    String const arguments_string() const override { return String::formatted("kind={} ({})", (long unsigned int)argument(0), boundary_check_type_name(type())); }
+    String arguments_string() const override { return String::formatted("kind={} ({})", (long unsigned int)argument(0), boundary_check_type_name(type())); }
 };
 
 class OpCode_ClearCaptureGroup final : public OpCode {
@@ -704,7 +704,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ClearCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
-    String const arguments_string() const override { return String::formatted("id={}", id()); }
+    String arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_SaveLeftCaptureGroup final : public OpCode {
@@ -713,7 +713,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveLeftCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
-    String const arguments_string() const override { return String::formatted("id={}", id()); }
+    String arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_SaveRightCaptureGroup final : public OpCode {
@@ -722,7 +722,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightCaptureGroup; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
-    String const arguments_string() const override { return String::formatted("id={}", id()); }
+    String arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_SaveRightNamedCaptureGroup final : public OpCode {
@@ -733,7 +733,7 @@ public:
     ALWAYS_INLINE StringView name() const { return { reinterpret_cast<char*>(argument(0)), length() }; }
     ALWAYS_INLINE size_t length() const { return argument(1); }
     ALWAYS_INLINE size_t id() const { return argument(2); }
-    String const arguments_string() const override
+    String arguments_string() const override
     {
         return String::formatted("name={}, length={}", name(), length());
     }
@@ -746,8 +746,8 @@ public:
     ALWAYS_INLINE size_t size() const override { return arguments_size() + 3; }
     ALWAYS_INLINE size_t arguments_count() const { return argument(0); }
     ALWAYS_INLINE size_t arguments_size() const { return argument(1); }
-    String const arguments_string() const override;
-    Vector<String> const variable_arguments_to_string(Optional<MatchInput> input = {}) const;
+    String arguments_string() const override;
+    Vector<String> variable_arguments_to_string(Optional<MatchInput> input = {}) const;
     Vector<CompareTypeAndValuePair> flat_compares() const;
 
 private:
@@ -769,7 +769,7 @@ public:
     ALWAYS_INLINE size_t offset() const { return argument(0); }
     ALWAYS_INLINE u64 count() const { return argument(1); }
     ALWAYS_INLINE size_t id() const { return argument(2); }
-    String const arguments_string() const override
+    String arguments_string() const override
     {
         auto reps = id() < state().repetition_marks.size() ? state().repetition_marks.at(id()) : 0;
         return String::formatted("offset={} count={} id={} rep={}, sp: {}", offset(), count() + 1, id(), reps + 1, state().string_position);
@@ -782,7 +782,7 @@ public:
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ResetRepeat; }
     ALWAYS_INLINE size_t size() const override { return 2; }
     ALWAYS_INLINE size_t id() const { return argument(0); }
-    String const arguments_string() const override
+    String arguments_string() const override
     {
         auto reps = id() < state().repetition_marks.size() ? state().repetition_marks.at(id()) : 0;
         return String::formatted("id={} rep={}", id(), reps + 1);
@@ -794,7 +794,7 @@ public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
     ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Checkpoint; }
     ALWAYS_INLINE size_t size() const override { return 1; }
-    String const arguments_string() const override { return ""; }
+    String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_JumpNonEmpty final : public OpCode {
@@ -805,7 +805,7 @@ public:
     ALWAYS_INLINE ssize_t offset() const { return argument(0); }
     ALWAYS_INLINE ssize_t checkpoint() const { return argument(1); }
     ALWAYS_INLINE OpCodeId form() const { return (OpCodeId)argument(2); }
-    String const arguments_string() const override
+    String arguments_string() const override
     {
         return String::formatted("{} offset={} [&{}], cp={} [&{}]",
             opcode_id_name(form()),

--- a/Userland/Libraries/LibRegex/RegexLexer.h
+++ b/Userland/Libraries/LibRegex/RegexLexer.h
@@ -56,7 +56,7 @@ public:
     size_t position() const { return m_position; }
 
     char const* name() const;
-    static char const* name(TokenType const);
+    static char const* name(TokenType);
 
 private:
     TokenType m_type { TokenType::Eof };
@@ -67,7 +67,7 @@ private:
 class Lexer : public GenericLexer {
 public:
     Lexer();
-    explicit Lexer(StringView const source);
+    explicit Lexer(StringView source);
     Token next();
     void reset();
     void back(size_t offset);

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -451,7 +451,7 @@ public:
     Match() = default;
     ~Match() = default;
 
-    Match(RegexStringView const view_, size_t const line_, size_t const column_, size_t const global_offset_)
+    Match(RegexStringView view_, size_t const line_, size_t const column_, size_t const global_offset_)
         : view(view_)
         , line(line_)
         , column(column_)
@@ -460,7 +460,7 @@ public:
     {
     }
 
-    Match(String const string_, size_t const line_, size_t const column_, size_t const global_offset_)
+    Match(String string_, size_t const line_, size_t const column_, size_t const global_offset_)
         : string(move(string_))
         , view(string.value().view())
         , line(line_)

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -121,9 +121,9 @@ public:
             [&](auto const&) {
                 if (code_point <= 0x7f)
                     return 1;
-                else if (code_point <= 0x07ff)
+                if (code_point <= 0x07ff)
                     return 2;
-                else if (code_point <= 0xffff)
+                if (code_point <= 0xffff)
                     return 3;
                 return 4;
             });

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -376,7 +376,7 @@ public:
 
     bool equals(RegexStringView other) const
     {
-        return other.m_view.visit([&](auto const& view) { return operator==(view); });
+        return other.m_view.visit([this](auto const& view) { return operator==(view); });
     }
 
     bool equals_ignoring_case(RegexStringView other) const

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -130,13 +130,13 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
     size_t lines_to_skip = 0;
 
     bool unicode = input.regex_options.has_flag_set(AllFlags::Unicode);
-    for (auto& view : views)
+    for (auto const& view : views)
         const_cast<RegexStringView&>(view).set_unicode(unicode);
 
     if (input.regex_options.has_flag_set(AllFlags::Internal_Stateful)) {
         if (views.size() > 1 && input.start_offset > views.first().length()) {
             dbgln_if(REGEX_DEBUG, "Started with start={}, goff={}, skip={}", input.start_offset, input.global_offset, lines_to_skip);
-            for (auto& view : views) {
+            for (auto const& view : views) {
                 if (input.start_offset < view.length() + 1)
                     break;
                 ++lines_to_skip;
@@ -181,7 +181,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
     if (input.regex_options.has_flag_set(AllFlags::Internal_Stateful))
         continue_search = false;
 
-    for (auto& view : views) {
+    for (auto const& view : views) {
         if (lines_to_skip != 0) {
             ++input.line;
             --lines_to_skip;

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -272,12 +272,12 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
                     bool has_zero_length = state.string_position == view_index;
                     view_index = state.string_position - (has_zero_length ? 0 : 1);
                     continue;
-
-                } else if (input.regex_options.has_flag_set(AllFlags::Internal_Stateful)) {
+                }
+                if (input.regex_options.has_flag_set(AllFlags::Internal_Stateful)) {
                     append_match(input, state, view_index);
                     break;
-
-                } else if (state.string_position < view_length) {
+                }
+                if (state.string_position < view_length) {
                     return { false, 0, {}, {}, {}, operations };
                 }
 

--- a/Userland/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Userland/Libraries/LibRegex/RegexOptimizer.cpp
@@ -211,7 +211,7 @@ void Regex<Parser>::attempt_rewrite_loops_as_atomic_groups(BasicBlockList const&
     if constexpr (REGEX_DEBUG) {
         RegexDebug dbg;
         dbg.print_bytecode(*this);
-        for (auto& block : basic_blocks)
+        for (auto const& block : basic_blocks)
             dbgln("block from {} to {}", block.start, block.end);
     }
 
@@ -262,7 +262,7 @@ void Regex<Parser>::attempt_rewrite_loops_as_atomic_groups(BasicBlockList const&
     auto is_an_eligible_jump = [](OpCode const& opcode, size_t ip, size_t block_start, AlternateForm alternate_form) {
         switch (opcode.opcode_id()) {
         case OpCodeId::JumpNonEmpty: {
-            auto& op = static_cast<OpCode_JumpNonEmpty const&>(opcode);
+            auto const& op = static_cast<OpCode_JumpNonEmpty const&>(opcode);
             auto form = op.form();
             if (form != OpCodeId::Jump && alternate_form == AlternateForm::DirectLoopWithHeader)
                 return false;

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -7,6 +7,7 @@
 
 #include "RegexParser.h"
 #include "RegexDebug.h"
+#include <AK/AnyOf.h>
 #include <AK/CharacterTypes.h>
 #include <AK/GenericLexer.h>
 #include <AK/String.h>
@@ -138,12 +139,7 @@ ALWAYS_INLINE bool Parser::try_skip(StringView str)
 
 ALWAYS_INLINE bool Parser::lookahead_any(StringView str)
 {
-    for (auto ch : str) {
-        if (match(ch))
-            return true;
-    }
-
-    return false;
+    return AK::any_of(str, [this](auto ch) { return match(ch); });
 }
 
 ALWAYS_INLINE unsigned char Parser::skip()

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1014,10 +1014,7 @@ bool ECMA262Parser::parse_term(ByteCode& stack, size_t& match_length_minimum, bo
             return false;
 
         VERIFY(did_parse_one);
-        if (!parse_quantifier(atom_stack, minimum_atom_length, unicode, named))
-            return false;
-
-        return true;
+        return parse_quantifier(atom_stack, minimum_atom_length, unicode, named);
     };
 
     if (!parse_with_quantifier())
@@ -1372,10 +1369,7 @@ bool ECMA262Parser::parse_extended_atom(ByteCode&, size_t&, bool)
     // Note: This includes only rules *not* present in parse_atom()
     VERIFY(m_should_use_browser_extended_grammar);
 
-    if (parse_invalid_braced_quantifier())
-        return true; // FAIL FAIL FAIL
-
-    return false;
+    return parse_invalid_braced_quantifier(); // FAIL FAIL FAIL
 }
 
 bool ECMA262Parser::parse_invalid_braced_quantifier()

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -641,8 +641,8 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_repetition_symbol(ByteCode& byteco
 
         consume(TokenType::RightCurly, Error::MismatchingBrace);
         return !has_error();
-
-    } else if (match(TokenType::Plus)) {
+    }
+    if (match(TokenType::Plus)) {
         consume();
 
         bool nongreedy = match(TokenType::Questionmark);
@@ -652,8 +652,8 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_repetition_symbol(ByteCode& byteco
         // Note: don't touch match_length_minimum, it's already correct
         ByteCode::transform_bytecode_repetition_min_one(bytecode_to_repeat, !nongreedy);
         return !has_error();
-
-    } else if (match(TokenType::Asterisk)) {
+    }
+    if (match(TokenType::Asterisk)) {
         consume();
         match_length_minimum = 0;
 
@@ -664,8 +664,8 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_repetition_symbol(ByteCode& byteco
         ByteCode::transform_bytecode_repetition_any(bytecode_to_repeat, !nongreedy);
 
         return !has_error();
-
-    } else if (match(TokenType::Questionmark)) {
+    }
+    if (match(TokenType::Questionmark)) {
         consume();
         match_length_minimum = 0;
 
@@ -933,22 +933,22 @@ bool ECMA262Parser::parse_internal(ByteCode& stack, size_t& match_length_minimum
 {
     if (m_parser_state.regex_options.has_flag_set(AllFlags::Unicode)) {
         return parse_pattern(stack, match_length_minimum, true, true);
-    } else {
-        ByteCode new_stack;
-        size_t new_match_length = 0;
-        auto res = parse_pattern(new_stack, new_match_length, false, false);
-        if (m_parser_state.named_capture_groups_count > 0) {
-            reset();
-            return parse_pattern(stack, match_length_minimum, false, true);
-        }
-
-        if (!res)
-            return false;
-
-        stack.extend(new_stack);
-        match_length_minimum = new_match_length;
-        return res;
     }
+
+    ByteCode new_stack;
+    size_t new_match_length = 0;
+    auto res = parse_pattern(new_stack, new_match_length, false, false);
+    if (m_parser_state.named_capture_groups_count > 0) {
+        reset();
+        return parse_pattern(stack, match_length_minimum, false, true);
+    }
+
+    if (!res)
+        return false;
+
+    stack.extend(new_stack);
+    match_length_minimum = new_match_length;
+    return res;
 }
 
 bool ECMA262Parser::parse_pattern(ByteCode& stack, size_t& match_length_minimum, bool unicode, bool named)
@@ -1352,9 +1352,8 @@ bool ECMA262Parser::parse_atom(ByteCode& stack, size_t& match_length_minimum, bo
             match_length_minimum += 1;
             stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (u8)token.value()[0] } });
             return true;
-        } else {
-            return false;
         }
+        return false;
     }
 
     if (match_ordinary_characters()) {
@@ -1525,15 +1524,16 @@ bool ECMA262Parser::parse_atom_escape(ByteCode& stack, size_t& match_length_mini
             match_length_minimum += 1;
             stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)hex_escape.value() } });
             return true;
-        } else if (!unicode) {
+        }
+        if (!unicode) {
             // '\x' is allowed in non-unicode mode, just matches 'x'.
             match_length_minimum += 1;
             stack.insert_bytecode_compare_values({ { CharacterCompareType::Char, (ByteCodeValueType)'x' } });
             return true;
-        } else {
-            set_error(Error::InvalidPattern);
-            return false;
         }
+
+        set_error(Error::InvalidPattern);
+        return false;
     }
 
     if (try_skip("u")) {
@@ -1874,8 +1874,8 @@ bool ECMA262Parser::parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&
                         [&](Script script) {
                             if (script.is_extension)
                                 return CharClassRangeElement { .script = script.script, .is_negated = negated, .is_character_class = true, .is_script_extension = true };
-                            else
-                                return CharClassRangeElement { .script = script.script, .is_negated = negated, .is_character_class = true, .is_script = true };
+
+                            return CharClassRangeElement { .script = script.script, .is_negated = negated, .is_character_class = true, .is_script = true };
                         },
                         [](Empty&) -> CharClassRangeElement { VERIFY_NOT_REACHED(); });
                 }
@@ -1973,10 +1973,10 @@ bool ECMA262Parser::parse_nonempty_class_ranges(Vector<CompareTypeAndValuePair>&
                     ranges.empend(CompareTypeAndValuePair { CharacterCompareType::Char, (ByteCodeValueType)'-' });
                     empend_atom(*second_atom);
                     continue;
-                } else {
-                    set_error(Error::InvalidRange);
-                    return false;
                 }
+
+                set_error(Error::InvalidRange);
+                return false;
             }
 
             if (first_atom.value().code_point > second_atom.value().code_point) {


### PR DESCRIPTION
All should be quite trivial to understand and check

The most controversial one should be the AnyOf one.

I am not quite sure about Userland/Libraries/LibRegex/RegexParser.cpp:1368 though formerly L1376.