### PR TITLE
Calculator: Make double construction and conversion private

### DIFF
--- a/Userland/Applications/Calculator/Calculator.cpp
+++ b/Userland/Applications/Calculator/Calculator.cpp
@@ -38,7 +38,7 @@ KeypadValue Calculator::begin_operation(Operation operation, KeypadValue argumen
             m_has_error = true;
             return argument;
         }
-        res = KeypadValue { AK::sqrt((double)argument) };
+        res = argument.sqrt();
         clear_operation();
         break;
     case Operation::Inverse:
@@ -46,7 +46,7 @@ KeypadValue Calculator::begin_operation(Operation operation, KeypadValue argumen
             m_has_error = true;
             return argument;
         }
-        res = KeypadValue { 1.0 / (double)argument };
+        res = argument.invert();
         clear_operation();
         break;
     case Operation::Percent:
@@ -98,7 +98,7 @@ KeypadValue Calculator::finish_operation(KeypadValue argument)
             m_has_error = true;
             return argument;
         }
-        res = KeypadValue { (double)m_saved_argument / (double)argument };
+        res = m_saved_argument / argument;
         break;
 
     case Operation::Sqrt:

--- a/Userland/Applications/Calculator/KeypadValue.cpp
+++ b/Userland/Applications/Calculator/KeypadValue.cpp
@@ -68,6 +68,21 @@ KeypadValue KeypadValue::operator-(void) const
     return { -m_value, m_decimal_places };
 }
 
+KeypadValue KeypadValue::sqrt(void) const
+{
+    return KeypadValue { AK::sqrt((double)(*this)) };
+}
+
+KeypadValue KeypadValue::invert(void) const
+{
+    return KeypadValue { 1.0 / (double)(*this) };
+}
+
+KeypadValue KeypadValue::operator/(KeypadValue const& rhs)
+{
+    return KeypadValue { (double)(*this) / (double)rhs };
+}
+
 bool KeypadValue::operator<(KeypadValue const& rhs)
 {
     return operator_helper<bool>(*this, rhs, [](KeypadValue const&, KeypadValue const&, i64 less_decimal_places_equalized, i64 more_decimal_places_equalized, bool lhs_is_less) {
@@ -139,7 +154,7 @@ KeypadValue::KeypadValue(double d)
     m_value = negative ? (-m_value) : m_value;
 }
 
-KeypadValue::operator double()
+KeypadValue::operator double() const
 {
     double res = (double)m_value / AK::pow(10.0, (double)m_decimal_places);
     return res;

--- a/Userland/Applications/Calculator/KeypadValue.h
+++ b/Userland/Applications/Calculator/KeypadValue.h
@@ -27,10 +27,14 @@ public:
     bool operator>(KeypadValue const&);
     bool operator==(KeypadValue const&);
 
-    explicit KeypadValue(double);
-    explicit operator double();
+    KeypadValue sqrt() const;
+    KeypadValue invert() const;
+    KeypadValue operator/(KeypadValue const&);
 
 private:
+    explicit KeypadValue(double);
+    explicit operator double() const;
+
     template<typename T, typename F>
     T operator_helper(KeypadValue const& lhs, KeypadValue const& rhs, F callback);
 


### PR DESCRIPTION
At this point, the double conversions should really only be
implementation details of the KeypadValue class. Therefore,
the constructor-from double and conversion-operator-to
double of KeypadValue are made private. Instead, the
required functionality is provided by KeypadValue itself.
The internal implementation is still done using doubles.
However, this opens us up to the possibility of having
loss-free square root, inversion and division in the future.