### PR TITLE
LibC+LibPthread: Add POSIX spec comments to function implementations

### DIFF
--- a/Userland/Libraries/LibC/poll.cpp
+++ b/Userland/Libraries/LibC/poll.cpp
@@ -11,6 +11,7 @@
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/poll.html
 int poll(pollfd* fds, nfds_t nfds, int timeout_ms)
 {
     timespec timeout;

--- a/Userland/Libraries/LibC/qsort.cpp
+++ b/Userland/Libraries/LibC/qsort.cpp
@@ -59,6 +59,7 @@ private:
     size_t m_element_size;
 };
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/qsort.html
 void qsort(void* bot, size_t nmemb, size_t size, int (*compar)(const void*, const void*))
 {
     if (nmemb <= 1) {

--- a/Userland/Libraries/LibC/sched.cpp
+++ b/Userland/Libraries/LibC/sched.cpp
@@ -10,28 +10,33 @@
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_yield.html
 int sched_yield()
 {
     int rc = syscall(SC_yield);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_get_priority_min.html
 int sched_get_priority_min([[maybe_unused]] int policy)
 {
     return 0; // Idle
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_get_priority_max.html
 int sched_get_priority_max([[maybe_unused]] int policy)
 {
     return 3; // High
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_setparam.html
 int sched_setparam(pid_t pid, const struct sched_param* param)
 {
     int rc = syscall(SC_sched_setparam, pid, param);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sched_getparam.html
 int sched_getparam(pid_t pid, struct sched_param* param)
 {
     int rc = syscall(SC_sched_getparam, pid, param);

--- a/Userland/Libraries/LibC/search.cpp
+++ b/Userland/Libraries/LibC/search.cpp
@@ -36,6 +36,7 @@ void delete_node_recursive(struct search_tree_node* node)
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/tsearch.html
 void* tsearch(const void* key, void** rootp, int (*comparator)(const void*, const void*))
 {
     if (!rootp)
@@ -69,6 +70,7 @@ void* tsearch(const void* key, void** rootp, int (*comparator)(const void*, cons
     VERIFY_NOT_REACHED();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/tfind.html
 void* tfind(const void* key, void* const* rootp, int (*comparator)(const void*, const void*))
 {
     if (!rootp)
@@ -90,6 +92,7 @@ void* tfind(const void* key, void* const* rootp, int (*comparator)(const void*, 
     return nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/tdelete.html
 void* tdelete(const void*, void**, int (*)(const void*, const void*))
 {
     dbgln("FIXME: Implement tdelete()");
@@ -113,6 +116,7 @@ static void twalk_internal(const struct search_tree_node* node, void (*action)(c
     action(node, endorder, depth);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/twalk.html
 void twalk(const void* rootp, void (*action)(const void*, VISIT, int))
 {
     auto node = static_cast<const struct search_tree_node*>(rootp);

--- a/Userland/Libraries/LibC/signal.cpp
+++ b/Userland/Libraries/LibC/signal.cpp
@@ -16,24 +16,28 @@
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/kill.html
 int kill(pid_t pid, int sig)
 {
     int rc = syscall(SC_kill, pid, sig);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/killpg.html
 int killpg(int pgrp, int sig)
 {
     int rc = syscall(SC_killpg, pgrp, sig);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/raise.html
 int raise(int sig)
 {
     // FIXME: Support multi-threaded programs.
     return kill(getpid(), sig);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/signal.html
 sighandler_t signal(int signum, sighandler_t handler)
 {
     struct sigaction new_act;
@@ -47,24 +51,28 @@ sighandler_t signal(int signum, sighandler_t handler)
     return old_act.sa_handler;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaction.html
 int sigaction(int signum, const struct sigaction* act, struct sigaction* old_act)
 {
     int rc = syscall(SC_sigaction, signum, act, old_act);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigemptyset.html
 int sigemptyset(sigset_t* set)
 {
     *set = 0;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigfillset.html
 int sigfillset(sigset_t* set)
 {
     *set = 0xffffffff;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaddset.html
 int sigaddset(sigset_t* set, int sig)
 {
     if (sig < 1 || sig > 32) {
@@ -75,12 +83,14 @@ int sigaddset(sigset_t* set, int sig)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigaltstack.html
 int sigaltstack(const stack_t* ss, stack_t* old_ss)
 {
     int rc = syscall(SC_sigaltstack, ss, old_ss);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigdelset.html
 int sigdelset(sigset_t* set, int sig)
 {
     if (sig < 1 || sig > 32) {
@@ -91,6 +101,7 @@ int sigdelset(sigset_t* set, int sig)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigismember.html
 int sigismember(const sigset_t* set, int sig)
 {
     if (sig < 1 || sig > 32) {
@@ -102,12 +113,14 @@ int sigismember(const sigset_t* set, int sig)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigprocmask.html
 int sigprocmask(int how, const sigset_t* set, sigset_t* old_set)
 {
     int rc = syscall(SC_sigprocmask, how, set, old_set);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigpending.html
 int sigpending(sigset_t* set)
 {
     int rc = syscall(SC_sigpending, set);
@@ -149,6 +162,7 @@ const char* sys_siglist[NSIG] = {
     "Bad system call",
 };
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/siglongjmp.html
 void siglongjmp(jmp_buf env, int val)
 {
     if (env->did_save_signal_mask) {
@@ -158,6 +172,7 @@ void siglongjmp(jmp_buf env, int val)
     longjmp(env, val);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigsuspend.html
 int sigsuspend(const sigset_t* set)
 {
     return pselect(0, nullptr, nullptr, nullptr, nullptr, set);
@@ -180,6 +195,7 @@ int sigwaitinfo(sigset_t const* set, siginfo_t* info)
     return sigtimedwait(set, info, nullptr);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sigtimedwait.html
 int sigtimedwait(sigset_t const* set, siginfo_t* info, struct timespec const* timeout)
 {
     int rc = syscall(Syscall::SC_sigtimedwait, set, info, timeout);

--- a/Userland/Libraries/LibC/spawn.cpp
+++ b/Userland/Libraries/LibC/spawn.cpp
@@ -99,6 +99,7 @@ extern "C" {
     _exit(127);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn.html
 int posix_spawn(pid_t* out_pid, const char* path, const posix_spawn_file_actions_t* file_actions, const posix_spawnattr_t* attr, char* const argv[], char* const envp[])
 {
     pid_t child_pid = fork();
@@ -113,6 +114,7 @@ int posix_spawn(pid_t* out_pid, const char* path, const posix_spawn_file_actions
     posix_spawn_child(path, file_actions, attr, argv, envp, execve);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnp.html
 int posix_spawnp(pid_t* out_pid, const char* path, const posix_spawn_file_actions_t* file_actions, const posix_spawnattr_t* attr, char* const argv[], char* const envp[])
 {
     pid_t child_pid = fork();
@@ -127,6 +129,7 @@ int posix_spawnp(pid_t* out_pid, const char* path, const posix_spawn_file_action
     posix_spawn_child(path, file_actions, attr, argv, envp, execvpe);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn_file_actions_addchdir.html
 int posix_spawn_file_actions_addchdir(posix_spawn_file_actions_t* actions, const char* path)
 {
     actions->state->actions.append([path]() { return chdir(path); });
@@ -139,18 +142,21 @@ int posix_spawn_file_actions_addfchdir(posix_spawn_file_actions_t* actions, int 
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn_file_actions_addclose.html
 int posix_spawn_file_actions_addclose(posix_spawn_file_actions_t* actions, int fd)
 {
     actions->state->actions.append([fd]() { return close(fd); });
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn_file_actions_adddup2.html
 int posix_spawn_file_actions_adddup2(posix_spawn_file_actions_t* actions, int old_fd, int new_fd)
 {
     actions->state->actions.append([old_fd, new_fd]() { return dup2(old_fd, new_fd); });
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn_file_actions_addopen.html
 int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t* actions, int want_fd, const char* path, int flags, mode_t mode)
 {
     actions->state->actions.append([want_fd, path, flags, mode]() {
@@ -164,59 +170,69 @@ int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t* actions, int wa
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn_file_actions_destroy.html
 int posix_spawn_file_actions_destroy(posix_spawn_file_actions_t* actions)
 {
     delete actions->state;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawn_file_actions_init.html
 int posix_spawn_file_actions_init(posix_spawn_file_actions_t* actions)
 {
     actions->state = new posix_spawn_file_actions_state;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_destroy.html
 int posix_spawnattr_destroy(posix_spawnattr_t*)
 {
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_getflags.html
 int posix_spawnattr_getflags(const posix_spawnattr_t* attr, short* out_flags)
 {
     *out_flags = attr->flags;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_getpgroup.html
 int posix_spawnattr_getpgroup(const posix_spawnattr_t* attr, pid_t* out_pgroup)
 {
     *out_pgroup = attr->pgroup;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_getschedparam.html
 int posix_spawnattr_getschedparam(const posix_spawnattr_t* attr, struct sched_param* out_schedparam)
 {
     *out_schedparam = attr->schedparam;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_getschedpolicy.html
 int posix_spawnattr_getschedpolicy(const posix_spawnattr_t* attr, int* out_schedpolicty)
 {
     *out_schedpolicty = attr->schedpolicy;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_getsigdefault.html
 int posix_spawnattr_getsigdefault(const posix_spawnattr_t* attr, sigset_t* out_sigdefault)
 {
     *out_sigdefault = attr->sigdefault;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_getsigmask.html
 int posix_spawnattr_getsigmask(const posix_spawnattr_t* attr, sigset_t* out_sigmask)
 {
     *out_sigmask = attr->sigmask;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_init.html
 int posix_spawnattr_init(posix_spawnattr_t* attr)
 {
     attr->flags = 0;
@@ -228,6 +244,7 @@ int posix_spawnattr_init(posix_spawnattr_t* attr)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_setflags.html
 int posix_spawnattr_setflags(posix_spawnattr_t* attr, short flags)
 {
     if (flags & ~(POSIX_SPAWN_RESETIDS | POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_SETSCHEDPARAM | POSIX_SPAWN_SETSCHEDULER | POSIX_SPAWN_SETSIGDEF | POSIX_SPAWN_SETSIGMASK | POSIX_SPAWN_SETSID))
@@ -237,30 +254,35 @@ int posix_spawnattr_setflags(posix_spawnattr_t* attr, short flags)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_setpgroup.html
 int posix_spawnattr_setpgroup(posix_spawnattr_t* attr, pid_t pgroup)
 {
     attr->pgroup = pgroup;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_setschedparam.html
 int posix_spawnattr_setschedparam(posix_spawnattr_t* attr, const struct sched_param* schedparam)
 {
     attr->schedparam = *schedparam;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_setschedpolicy.html
 int posix_spawnattr_setschedpolicy(posix_spawnattr_t* attr, int schedpolicy)
 {
     attr->schedpolicy = schedpolicy;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_setsigdefault.html
 int posix_spawnattr_setsigdefault(posix_spawnattr_t* attr, const sigset_t* sigdefault)
 {
     attr->sigdefault = *sigdefault;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_spawnattr_setsigmask.html
 int posix_spawnattr_setsigmask(posix_spawnattr_t* attr, const sigset_t* sigmask)
 {
     attr->sigmask = *sigmask;

--- a/Userland/Libraries/LibC/stat.cpp
+++ b/Userland/Libraries/LibC/stat.cpp
@@ -15,11 +15,13 @@
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/umask.html
 mode_t umask(mode_t mask)
 {
     return syscall(SC_umask, mask);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdir.html
 int mkdir(const char* pathname, mode_t mode)
 {
     if (!pathname) {
@@ -30,6 +32,7 @@ int mkdir(const char* pathname, mode_t mode)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/chmod.html
 int chmod(const char* pathname, mode_t mode)
 {
     if (!pathname) {
@@ -40,12 +43,14 @@ int chmod(const char* pathname, mode_t mode)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fchmod.html
 int fchmod(int fd, mode_t mode)
 {
     int rc = syscall(SC_fchmod, fd, mode);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkfifo.html
 int mkfifo(const char* pathname, mode_t mode)
 {
     return mknod(pathname, mode | S_IFIFO, 0);
@@ -62,22 +67,26 @@ static int do_stat(int dirfd, const char* path, struct stat* statbuf, bool follo
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/lstat.html
 int lstat(const char* path, struct stat* statbuf)
 {
     return do_stat(AT_FDCWD, path, statbuf, false);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/stat.html
 int stat(const char* path, struct stat* statbuf)
 {
     return do_stat(AT_FDCWD, path, statbuf, true);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fstat.html
 int fstat(int fd, struct stat* statbuf)
 {
     int rc = syscall(SC_fstat, fd, statbuf);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fstatat.html
 int fstatat(int fd, const char* path, struct stat* statbuf, int flags)
 {
     return do_stat(fd, path, statbuf, !(flags & AT_SYMLINK_NOFOLLOW));

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -628,6 +628,7 @@ void __stdio_init()
     __stdio_is_initialized = true;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/setvbuf.html
 int setvbuf(FILE* stream, char* buf, int mode, size_t size)
 {
     VERIFY(stream);
@@ -640,6 +641,7 @@ int setvbuf(FILE* stream, char* buf, int mode, size_t size)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/setbuf.html
 void setbuf(FILE* stream, char* buf)
 {
     setvbuf(stream, buf, buf ? _IOFBF : _IONBF, BUFSIZ);
@@ -650,6 +652,7 @@ void setlinebuf(FILE* stream)
     setvbuf(stream, nullptr, _IOLBF, 0);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fileno.html
 int fileno(FILE* stream)
 {
     VERIFY(stream);
@@ -657,6 +660,7 @@ int fileno(FILE* stream)
     return stream->fileno();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/feof.html
 int feof(FILE* stream)
 {
     VERIFY(stream);
@@ -664,6 +668,7 @@ int feof(FILE* stream)
     return stream->eof();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fflush.html
 int fflush(FILE* stream)
 {
     if (!stream) {
@@ -674,6 +679,7 @@ int fflush(FILE* stream)
     return stream->flush() ? 0 : EOF;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fgets.html
 char* fgets(char* buffer, int size, FILE* stream)
 {
     VERIFY(stream);
@@ -682,6 +688,7 @@ char* fgets(char* buffer, int size, FILE* stream)
     return ok ? buffer : nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fgetc.html
 int fgetc(FILE* stream)
 {
     VERIFY(stream);
@@ -702,6 +709,7 @@ int fgetc_unlocked(FILE* stream)
     return EOF;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getc.html
 int getc(FILE* stream)
 {
     return fgetc(stream);
@@ -712,11 +720,13 @@ int getc_unlocked(FILE* stream)
     return fgetc_unlocked(stream);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getchar.html
 int getchar()
 {
     return getc(stdin);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getdelim.html
 ssize_t getdelim(char** lineptr, size_t* n, int delim, FILE* stream)
 {
     if (!lineptr || !n) {
@@ -763,11 +773,13 @@ ssize_t getdelim(char** lineptr, size_t* n, int delim, FILE* stream)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getline.html
 ssize_t getline(char** lineptr, size_t* n, FILE* stream)
 {
     return getdelim(lineptr, n, '\n', stream);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/ungetc.html
 int ungetc(int c, FILE* stream)
 {
     VERIFY(stream);
@@ -776,6 +788,7 @@ int ungetc(int c, FILE* stream)
     return ok ? c : EOF;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fputc.html
 int fputc(int ch, FILE* stream)
 {
     VERIFY(stream);
@@ -788,16 +801,19 @@ int fputc(int ch, FILE* stream)
     return byte;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/putc.html
 int putc(int ch, FILE* stream)
 {
     return fputc(ch, stream);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/putchar.html
 int putchar(int ch)
 {
     return putc(ch, stdout);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fputs.html
 int fputs(const char* s, FILE* stream)
 {
     VERIFY(stream);
@@ -809,6 +825,7 @@ int fputs(const char* s, FILE* stream)
     return 1;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/puts.html
 int puts(const char* s)
 {
     int rc = fputs(s, stdout);
@@ -817,6 +834,7 @@ int puts(const char* s)
     return fputc('\n', stdout);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/clearerr.html
 void clearerr(FILE* stream)
 {
     VERIFY(stream);
@@ -824,6 +842,7 @@ void clearerr(FILE* stream)
     stream->clear_err();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/ferror.html
 int ferror(FILE* stream)
 {
     VERIFY(stream);
@@ -842,6 +861,7 @@ size_t fread_unlocked(void* ptr, size_t size, size_t nmemb, FILE* stream)
     return nread / size;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fread.html
 size_t fread(void* ptr, size_t size, size_t nmemb, FILE* stream)
 {
     VERIFY(stream);
@@ -849,6 +869,7 @@ size_t fread(void* ptr, size_t size, size_t nmemb, FILE* stream)
     return fread_unlocked(ptr, size, nmemb, stream);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fwrite.html
 size_t fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream)
 {
     VERIFY(stream);
@@ -861,6 +882,7 @@ size_t fwrite(const void* ptr, size_t size, size_t nmemb, FILE* stream)
     return nwritten / size;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fseek.html
 int fseek(FILE* stream, long offset, int whence)
 {
     VERIFY(stream);
@@ -868,6 +890,7 @@ int fseek(FILE* stream, long offset, int whence)
     return stream->seek(offset, whence);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fseeko.html
 int fseeko(FILE* stream, off_t offset, int whence)
 {
     VERIFY(stream);
@@ -875,6 +898,7 @@ int fseeko(FILE* stream, off_t offset, int whence)
     return stream->seek(offset, whence);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/ftell.html
 long ftell(FILE* stream)
 {
     VERIFY(stream);
@@ -882,6 +906,7 @@ long ftell(FILE* stream)
     return stream->tell();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/ftello.html
 off_t ftello(FILE* stream)
 {
     VERIFY(stream);
@@ -889,6 +914,7 @@ off_t ftello(FILE* stream)
     return stream->tell();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fgetpos.html
 int fgetpos(FILE* stream, fpos_t* pos)
 {
     VERIFY(stream);
@@ -903,6 +929,7 @@ int fgetpos(FILE* stream, fpos_t* pos)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fsetpos.html
 int fsetpos(FILE* stream, const fpos_t* pos)
 {
     VERIFY(stream);
@@ -912,6 +939,7 @@ int fsetpos(FILE* stream, const fpos_t* pos)
     return stream->seek(*pos, SEEK_SET);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/rewind.html
 void rewind(FILE* stream)
 {
     fseek(stream, 0, SEEK_SET);
@@ -929,12 +957,14 @@ ALWAYS_INLINE static void stream_putch(char*&, char ch)
     fputc(ch, __current_stream);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vfprintf.html
 int vfprintf(FILE* stream, const char* fmt, va_list ap)
 {
     __current_stream = stream;
     return printf_internal(stream_putch, nullptr, fmt, ap);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fprintf.html
 int fprintf(FILE* stream, const char* fmt, ...)
 {
     va_list ap;
@@ -944,11 +974,13 @@ int fprintf(FILE* stream, const char* fmt, ...)
     return ret;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vprintf.html
 int vprintf(const char* fmt, va_list ap)
 {
     return printf_internal(stdout_putch, nullptr, fmt, ap);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/printf.html
 int printf(const char* fmt, ...)
 {
     va_list ap;
@@ -958,6 +990,7 @@ int printf(const char* fmt, ...)
     return ret;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vasprintf.html
 int vasprintf(char** strp, const char* fmt, va_list ap)
 {
     StringBuilder builder;
@@ -968,6 +1001,7 @@ int vasprintf(char** strp, const char* fmt, va_list ap)
     return length;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/asprintf.html
 int asprintf(char** strp, const char* fmt, ...)
 {
     StringBuilder builder;
@@ -986,6 +1020,7 @@ static void buffer_putch(char*& bufptr, char ch)
     *bufptr++ = ch;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vsprintf.html
 int vsprintf(char* buffer, const char* fmt, va_list ap)
 {
     int ret = printf_internal(buffer_putch, buffer, fmt, ap);
@@ -993,6 +1028,7 @@ int vsprintf(char* buffer, const char* fmt, va_list ap)
     return ret;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sprintf.html
 int sprintf(char* buffer, const char* fmt, ...)
 {
     va_list ap;
@@ -1011,6 +1047,7 @@ ALWAYS_INLINE void sized_buffer_putch(char*& bufptr, char ch)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vsnprintf.html
 int vsnprintf(char* buffer, size_t size, const char* fmt, va_list ap)
 {
     if (size) {
@@ -1027,6 +1064,7 @@ int vsnprintf(char* buffer, size_t size, const char* fmt, va_list ap)
     return ret;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/snprintf.html
 int snprintf(char* buffer, size_t size, const char* fmt, ...)
 {
     va_list ap;
@@ -1036,6 +1074,7 @@ int snprintf(char* buffer, size_t size, const char* fmt, ...)
     return ret;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/perror.html
 void perror(const char* s)
 {
     int saved_errno = errno;
@@ -1080,6 +1119,7 @@ static int parse_mode(const char* mode)
     return flags;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fopen.html
 FILE* fopen(const char* pathname, const char* mode)
 {
     int flags = parse_mode(mode);
@@ -1089,6 +1129,7 @@ FILE* fopen(const char* pathname, const char* mode)
     return FILE::create(fd, flags);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/freopen.html
 FILE* freopen(const char* pathname, const char* mode, FILE* stream)
 {
     VERIFY(stream);
@@ -1106,6 +1147,7 @@ FILE* freopen(const char* pathname, const char* mode, FILE* stream)
     return stream;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fdopen.html
 FILE* fdopen(int fd, const char* mode)
 {
     int flags = parse_mode(mode);
@@ -1120,6 +1162,7 @@ static inline bool is_default_stream(FILE* stream)
     return stream == stdin || stream == stdout || stream == stderr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fclose.html
 int fclose(FILE* stream)
 {
     VERIFY(stream);
@@ -1138,6 +1181,7 @@ int fclose(FILE* stream)
     return ok ? 0 : EOF;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/rename.html
 int rename(const char* oldpath, const char* newpath)
 {
     if (!oldpath || !newpath) {
@@ -1154,12 +1198,14 @@ void dbgputstr(const char* characters, size_t length)
     syscall(SC_dbgputstr, characters, length);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/tmpnam.html
 char* tmpnam(char*)
 {
     dbgln("FIXME: Implement tmpnam()");
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/popen.html
 FILE* popen(const char* command, const char* type)
 {
     if (!type || (*type != 'r' && *type != 'w')) {
@@ -1217,6 +1263,7 @@ FILE* popen(const char* command, const char* type)
     return file;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/pclose.html
 int pclose(FILE* stream)
 {
     VERIFY(stream);
@@ -1229,6 +1276,7 @@ int pclose(FILE* stream)
     return wstatus;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/remove.html
 int remove(const char* pathname)
 {
     if (unlink(pathname) < 0) {
@@ -1239,6 +1287,7 @@ int remove(const char* pathname)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/scanf.html
 int scanf(const char* fmt, ...)
 {
     va_list ap;
@@ -1248,6 +1297,7 @@ int scanf(const char* fmt, ...)
     return count;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/fscanf.html
 int fscanf(FILE* stream, const char* fmt, ...)
 {
     va_list ap;
@@ -1257,6 +1307,7 @@ int fscanf(FILE* stream, const char* fmt, ...)
     return count;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sscanf.html
 int sscanf(const char* buffer, const char* fmt, ...)
 {
     va_list ap;
@@ -1266,6 +1317,7 @@ int sscanf(const char* buffer, const char* fmt, ...)
     return count;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vfscanf.html
 int vfscanf(FILE* stream, const char* fmt, va_list ap)
 {
     char buffer[BUFSIZ];
@@ -1274,21 +1326,25 @@ int vfscanf(FILE* stream, const char* fmt, va_list ap)
     return vsscanf(buffer, fmt, ap);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/vscanf.html
 int vscanf(const char* fmt, va_list ap)
 {
     return vfscanf(stdin, fmt, ap);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/flockfile.html
 void flockfile([[maybe_unused]] FILE* filehandle)
 {
     dbgln("FIXME: Implement flockfile()");
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/funlockfile.html
 void funlockfile([[maybe_unused]] FILE* filehandle)
 {
     dbgln("FIXME: Implement funlockfile()");
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/tmpfile.html
 FILE* tmpfile()
 {
     char tmp_path[] = "/tmp/XXXXXX";

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -263,6 +263,7 @@ char* secure_getenv(const char* name)
     return getenv(name);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/unsetenv.html
 int unsetenv(const char* name)
 {
     auto new_var_len = strlen(name);
@@ -303,6 +304,7 @@ int clearenv()
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/setenv.html
 int setenv(const char* name, const char* value, int overwrite)
 {
     if (!overwrite && getenv(name))
@@ -314,6 +316,7 @@ int setenv(const char* name, const char* value, int overwrite)
     return putenv(var);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/putenv.html
 int putenv(char* new_var)
 {
     char* new_eq = strchr(new_var, '=');
@@ -383,6 +386,7 @@ void setprogname(const char* progname)
     __progname = progname;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtod.html
 double strtod(const char* str, char** endptr)
 {
     // Parse spaces, sign, and base
@@ -664,22 +668,26 @@ double strtod(const char* str, char** endptr)
     return value;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtold.html
 long double strtold(const char* str, char** endptr)
 {
     assert(sizeof(double) == sizeof(long double));
     return strtod(str, endptr);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtof.html
 float strtof(const char* str, char** endptr)
 {
     return strtod(str, endptr);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/atof.html
 double atof(const char* str)
 {
     return strtod(str, nullptr);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/atoi.html
 int atoi(const char* str)
 {
     long value = strtol(str, nullptr, 10);
@@ -689,17 +697,20 @@ int atoi(const char* str)
     return value;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/atol.html
 long atol(const char* str)
 {
     return strtol(str, nullptr, 10);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/atoll.html
 long long atoll(const char* str)
 {
     return strtoll(str, nullptr, 10);
 }
 
 static char ptsname_buf[32];
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/ptsname.html
 char* ptsname(int fd)
 {
     if (ptsname_r(fd, ptsname_buf, sizeof(ptsname_buf)) < 0)
@@ -715,42 +726,50 @@ int ptsname_r(int fd, char* buffer, size_t size)
 
 static unsigned long s_next_rand = 1;
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/rand.html
 int rand()
 {
     s_next_rand = s_next_rand * 1103515245 + 12345;
     return ((unsigned)(s_next_rand / ((RAND_MAX + 1) * 2)) % (RAND_MAX + 1));
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/srand.html
 void srand(unsigned seed)
 {
     s_next_rand = seed;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/abs.html
 int abs(int i)
 {
     return i < 0 ? -i : i;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/labs.html
 long int labs(long int i)
 {
     return i < 0 ? -i : i;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/llabs.html
 long long int llabs(long long int i)
 {
     return i < 0 ? -i : i;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/random.html
 long int random()
 {
     return rand();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/srandom.html
 void srandom(unsigned seed)
 {
     srand(seed);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/system.html
 int system(const char* command)
 {
     if (!command)
@@ -765,6 +784,7 @@ int system(const char* command)
     return WEXITSTATUS(wstatus);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mktemp.html
 char* mktemp(char* pattern)
 {
     auto error = generate_unique_filename(pattern, [&] {
@@ -781,6 +801,7 @@ char* mktemp(char* pattern)
     return pattern;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkstemp.html
 int mkstemp(char* pattern)
 {
     int fd = -1;
@@ -797,6 +818,7 @@ int mkstemp(char* pattern)
     return fd;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mkdtemp.html
 char* mkdtemp(char* pattern)
 {
     auto error = generate_unique_filename(pattern, [&] {
@@ -811,6 +833,7 @@ char* mkdtemp(char* pattern)
     return pattern;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/bsearch.html
 void* bsearch(const void* key, const void* base, size_t nmemb, size_t size, int (*compar)(const void*, const void*))
 {
     char* start = static_cast<char*>(const_cast<void*>(base));
@@ -829,6 +852,7 @@ void* bsearch(const void* key, const void* base, size_t nmemb, size_t size, int 
     return nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/div.html
 div_t div(int numerator, int denominator)
 {
     div_t result;
@@ -842,6 +866,7 @@ div_t div(int numerator, int denominator)
     return result;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/ldiv.html
 ldiv_t ldiv(long numerator, long denominator)
 {
     ldiv_t result;
@@ -855,6 +880,7 @@ ldiv_t ldiv(long numerator, long denominator)
     return result;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/lldiv.html
 lldiv_t lldiv(long long numerator, long long denominator)
 {
     lldiv_t result;
@@ -868,6 +894,7 @@ lldiv_t lldiv(long long numerator, long long denominator)
     return result;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mblen.html
 int mblen(char const* s, size_t n)
 {
     // POSIX: Equivalent to mbtowc(NULL, s, n), but we mustn't change the state of mbtowc.
@@ -890,12 +917,14 @@ int mblen(char const* s, size_t n)
     return ret;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mbstowcs.html
 size_t mbstowcs(wchar_t* pwcs, const char* s, size_t n)
 {
     static mbstate_t state = {};
     return mbsrtowcs(pwcs, &s, n, &state);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mbtowc.html
 int mbtowc(wchar_t* pwc, const char* s, size_t n)
 {
     static mbstate_t internal_state = {};
@@ -918,6 +947,7 @@ int mbtowc(wchar_t* pwc, const char* s, size_t n)
     return ret;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wctomb.html
 int wctomb(char* s, wchar_t wc)
 {
     static mbstate_t _internal_state = {};
@@ -929,6 +959,7 @@ int wctomb(char* s, wchar_t wc)
     return static_cast<int>(wcrtomb(s, wc, &_internal_state));
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/wcstombs.html
 size_t wcstombs(char* dest, const wchar_t* src, size_t max)
 {
     char* original_dest = dest;
@@ -951,6 +982,7 @@ size_t wcstombs(char* dest, const wchar_t* src, size_t max)
     return max;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtol.html
 long strtol(const char* str, char** endptr, int base)
 {
     long long value = strtoll(str, endptr, base);
@@ -964,6 +996,7 @@ long strtol(const char* str, char** endptr, int base)
     return value;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtoul.html
 unsigned long strtoul(const char* str, char** endptr, int base)
 {
     unsigned long long value = strtoull(str, endptr, base);
@@ -974,6 +1007,7 @@ unsigned long strtoul(const char* str, char** endptr, int base)
     return value;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtoll.html
 long long strtoll(const char* str, char** endptr, int base)
 {
     // Parse spaces and sign
@@ -1051,6 +1085,7 @@ long long strtoll(const char* str, char** endptr, int base)
     return digits.number();
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtoull.html
 unsigned long long strtoull(const char* str, char** endptr, int base)
 {
     // Parse spaces and sign
@@ -1153,6 +1188,7 @@ uint32_t arc4random_uniform(uint32_t max_bounds)
     return AK::get_random_uniform(max_bounds);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/realpath.html
 char* realpath(const char* pathname, char* buffer)
 {
     if (!pathname) {
@@ -1202,6 +1238,7 @@ char* realpath(const char* pathname, char* buffer)
     return buffer;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_openpt.html
 int posix_openpt(int flags)
 {
     if (flags & ~(O_RDWR | O_NOCTTY | O_CLOEXEC)) {
@@ -1212,17 +1249,20 @@ int posix_openpt(int flags)
     return open("/dev/ptmx", flags);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/grantpt.html
 int grantpt([[maybe_unused]] int fd)
 {
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlockpt.html
 int unlockpt([[maybe_unused]] int fd)
 {
     return 0;
 }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/_Exit.html
 void _Exit(int status)
 {
     _exit(status);

--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -20,6 +20,7 @@
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strspn.html
 size_t strspn(const char* s, const char* accept)
 {
     const char* p = s;
@@ -33,6 +34,7 @@ cont:
     return p - 1 - s;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strcspn.html
 size_t strcspn(const char* s, const char* reject)
 {
     for (auto* p = s;;) {
@@ -46,6 +48,7 @@ size_t strcspn(const char* s, const char* reject)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strlen.html
 size_t strlen(const char* str)
 {
     size_t len = 0;
@@ -54,6 +57,7 @@ size_t strlen(const char* str)
     return len;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strnlen.html
 size_t strnlen(const char* str, size_t maxlen)
 {
     size_t len = 0;
@@ -62,6 +66,7 @@ size_t strnlen(const char* str, size_t maxlen)
     return len;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strdup.html
 char* strdup(const char* str)
 {
     size_t len = strlen(str);
@@ -71,6 +76,7 @@ char* strdup(const char* str)
     return new_str;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strndup.html
 char* strndup(const char* str, size_t maxlen)
 {
     size_t len = strnlen(str, maxlen);
@@ -80,6 +86,7 @@ char* strndup(const char* str, size_t maxlen)
     return new_str;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strcmp.html
 int strcmp(const char* s1, const char* s2)
 {
     while (*s1 == *s2++)
@@ -88,6 +95,7 @@ int strcmp(const char* s1, const char* s2)
     return *(const unsigned char*)s1 - *(const unsigned char*)--s2;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strncmp.html
 int strncmp(const char* s1, const char* s2, size_t n)
 {
     if (!n)
@@ -101,6 +109,7 @@ int strncmp(const char* s1, const char* s2, size_t n)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/memcmp.html
 int memcmp(const void* v1, const void* v2, size_t n)
 {
     auto* s1 = (const uint8_t*)v1;
@@ -112,6 +121,7 @@ int memcmp(const void* v1, const void* v2, size_t n)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/memcpy.html
 void* memcpy(void* dest_ptr, const void* src_ptr, size_t n)
 {
     void* original_dest = dest_ptr;
@@ -121,6 +131,7 @@ void* memcpy(void* dest_ptr, const void* src_ptr, size_t n)
     return original_dest;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/memset.html
 void* memset(void* dest_ptr, int c, size_t n)
 {
     size_t dest = (size_t)dest_ptr;
@@ -153,6 +164,7 @@ void* memset(void* dest_ptr, int c, size_t n)
     return dest_ptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/memmove.html
 void* memmove(void* dest, const void* src, size_t n)
 {
     if (((FlatPtr)dest - (FlatPtr)src) >= n)
@@ -170,6 +182,7 @@ const void* memmem(const void* haystack, size_t haystack_length, const void* nee
     return AK::memmem(haystack, haystack_length, needle, needle_length);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strcpy.html
 char* strcpy(char* dest, const char* src)
 {
     char* original_dest = dest;
@@ -178,6 +191,7 @@ char* strcpy(char* dest, const char* src)
     return original_dest;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strncpy.html
 char* strncpy(char* dest, const char* src, size_t n)
 {
     size_t i;
@@ -201,6 +215,7 @@ size_t strlcpy(char* dest, const char* src, size_t n)
     return i;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strchr.html
 char* strchr(const char* str, int c)
 {
     char ch = c;
@@ -221,6 +236,7 @@ char* strchrnul(const char* str, int c)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/memchr.html
 void* memchr(const void* ptr, int c, size_t size)
 {
     char ch = c;
@@ -232,6 +248,7 @@ void* memchr(const void* ptr, int c, size_t size)
     return nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strrchr.html
 char* strrchr(const char* str, int ch)
 {
     char* last = nullptr;
@@ -243,6 +260,7 @@ char* strrchr(const char* str, int ch)
     return last;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strcat.html
 char* strcat(char* dest, const char* src)
 {
     size_t dest_length = strlen(dest);
@@ -253,6 +271,7 @@ char* strcat(char* dest, const char* src)
     return dest;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strncat.html
 char* strncat(char* dest, const char* src, size_t n)
 {
     size_t dest_length = strlen(dest);
@@ -272,6 +291,7 @@ static_assert(array_size(sys_errlist) == (EMAXERRNO + 1));
 
 int sys_nerr = EMAXERRNO;
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strerror_r.html
 int strerror_r(int errnum, char* buf, size_t buflen)
 {
     auto saved_errno = errno;
@@ -292,6 +312,7 @@ int strerror_r(int errnum, char* buf, size_t buflen)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strerror.html
 char* strerror(int errnum)
 {
     if (errnum < 0 || errnum >= EMAXERRNO) {
@@ -300,6 +321,7 @@ char* strerror(int errnum)
     return const_cast<char*>(sys_errlist[errnum]);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strsignal.html
 char* strsignal(int signum)
 {
     if (signum >= NSIG) {
@@ -309,6 +331,7 @@ char* strsignal(int signum)
     return const_cast<char*>(sys_siglist[signum]);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strstr.html
 char* strstr(const char* haystack, const char* needle)
 {
     char nch;
@@ -327,6 +350,7 @@ char* strstr(const char* haystack, const char* needle)
     return const_cast<char*>(haystack);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strpbrk.html
 char* strpbrk(const char* s, const char* accept)
 {
     while (*s)
@@ -335,6 +359,7 @@ char* strpbrk(const char* s, const char* accept)
     return nullptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtok_r.html
 char* strtok_r(char* str, const char* delim, char** saved_str)
 {
     if (!str) {
@@ -387,17 +412,20 @@ char* strtok_r(char* str, const char* delim, char** saved_str)
     return &str[token_start];
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strtok.html
 char* strtok(char* str, const char* delim)
 {
     static char* saved_str;
     return strtok_r(str, delim, &saved_str);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strcoll.html
 int strcoll(const char* s1, const char* s2)
 {
     return strcmp(s1, s2);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strxfrm.html
 size_t strxfrm(char* dest, const char* src, size_t n)
 {
     size_t i;

--- a/Userland/Libraries/LibC/strings.cpp
+++ b/Userland/Libraries/LibC/strings.cpp
@@ -28,6 +28,7 @@ static char foldcase(char ch)
     return ch;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strcasecmp.html
 int strcasecmp(const char* s1, const char* s2)
 {
     for (; foldcase(*s1) == foldcase(*s2); ++s1, ++s2) {
@@ -37,6 +38,7 @@ int strcasecmp(const char* s1, const char* s2)
     return foldcase(*(const unsigned char*)s1) < foldcase(*(const unsigned char*)s2) ? -1 : 1;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strncasecmp.html
 int strncasecmp(const char* s1, const char* s2, size_t n)
 {
     if (!n)

--- a/Userland/Libraries/LibC/sys/mman.cpp
+++ b/Userland/Libraries/LibC/sys/mman.cpp
@@ -24,6 +24,7 @@ void* serenity_mmap(void* addr, size_t size, int prot, int flags, int fd, off_t 
     return (void*)rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mmap.html
 void* mmap(void* addr, size_t size, int prot, int flags, int fd, off_t offset)
 {
     return serenity_mmap(addr, size, prot, flags, fd, offset, PAGE_SIZE, nullptr);
@@ -45,12 +46,14 @@ void* mremap(void* old_address, size_t old_size, size_t new_size, int flags)
     return (void*)rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/munmap.html
 int munmap(void* addr, size_t size)
 {
     int rc = syscall(SC_munmap, addr, size);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mprotect.html
 int mprotect(void* addr, size_t size, int prot)
 {
     int rc = syscall(SC_mprotect, addr, size, prot);
@@ -84,12 +87,14 @@ void* allocate_tls(const char* initial_data, size_t size)
     return (void*)rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/mlock.html
 int mlock(const void*, size_t)
 {
     dbgln("FIXME: Implement mlock()");
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/msync.html
 int msync(void* address, size_t size, int flags)
 {
     int rc = syscall(SC_msync, address, size, flags);

--- a/Userland/Libraries/LibC/sys/select.cpp
+++ b/Userland/Libraries/LibC/sys/select.cpp
@@ -15,6 +15,7 @@
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/select.html
 int select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, timeval* timeout_tv)
 {
     timespec* timeout_ts = nullptr;
@@ -26,6 +27,7 @@ int select(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, timev
     return pselect(nfds, readfds, writefds, exceptfds, timeout_ts, nullptr);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/pselect.html
 int pselect(int nfds, fd_set* readfds, fd_set* writefds, fd_set* exceptfds, const timespec* timeout, const sigset_t* sigmask)
 {
     Vector<pollfd, FD_SETSIZE> fds;

--- a/Userland/Libraries/LibC/sys/socket.cpp
+++ b/Userland/Libraries/LibC/sys/socket.cpp
@@ -14,24 +14,28 @@
 
 extern "C" {
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/socket.html
 int socket(int domain, int type, int protocol)
 {
     int rc = syscall(SC_socket, domain, type, protocol);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/bind.html
 int bind(int sockfd, const sockaddr* addr, socklen_t addrlen)
 {
     int rc = syscall(SC_bind, sockfd, addr, addrlen);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/listen.html
 int listen(int sockfd, int backlog)
 {
     int rc = syscall(SC_listen, sockfd, backlog);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/accept.html
 int accept(int sockfd, sockaddr* addr, socklen_t* addrlen)
 {
     return accept4(sockfd, addr, addrlen, 0);
@@ -44,24 +48,28 @@ int accept4(int sockfd, sockaddr* addr, socklen_t* addrlen, int flags)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/connect.html
 int connect(int sockfd, const sockaddr* addr, socklen_t addrlen)
 {
     int rc = syscall(SC_connect, sockfd, addr, addrlen);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/shutdown.html
 int shutdown(int sockfd, int how)
 {
     int rc = syscall(SC_shutdown, sockfd, how);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendmsg.html
 ssize_t sendmsg(int sockfd, const struct msghdr* msg, int flags)
 {
     int rc = syscall(SC_sendmsg, sockfd, msg, flags);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/sendto.html
 ssize_t sendto(int sockfd, const void* data, size_t data_length, int flags, const struct sockaddr* addr, socklen_t addr_length)
 {
     iovec iov = { const_cast<void*>(data), data_length };
@@ -69,17 +77,20 @@ ssize_t sendto(int sockfd, const void* data, size_t data_length, int flags, cons
     return sendmsg(sockfd, &msg, flags);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html
 ssize_t send(int sockfd, const void* data, size_t data_length, int flags)
 {
     return sendto(sockfd, data, data_length, flags, nullptr, 0);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvmsg.html
 ssize_t recvmsg(int sockfd, struct msghdr* msg, int flags)
 {
     int rc = syscall(SC_recvmsg, sockfd, msg, flags);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/recvfrom.html
 ssize_t recvfrom(int sockfd, void* buffer, size_t buffer_length, int flags, struct sockaddr* addr, socklen_t* addr_length)
 {
     if (!addr_length && addr) {
@@ -98,11 +109,13 @@ ssize_t recvfrom(int sockfd, void* buffer, size_t buffer_length, int flags, stru
     return rc;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html
 ssize_t recv(int sockfd, void* buffer, size_t buffer_length, int flags)
 {
     return recvfrom(sockfd, buffer, buffer_length, flags, nullptr, nullptr);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockopt.html
 int getsockopt(int sockfd, int level, int option, void* value, socklen_t* value_size)
 {
     Syscall::SC_getsockopt_params params { sockfd, level, option, value, value_size };
@@ -110,6 +123,7 @@ int getsockopt(int sockfd, int level, int option, void* value, socklen_t* value_
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/setsockopt.html
 int setsockopt(int sockfd, int level, int option, const void* value, socklen_t value_size)
 {
     Syscall::SC_setsockopt_params params { value, sockfd, level, option, value_size };
@@ -117,6 +131,7 @@ int setsockopt(int sockfd, int level, int option, const void* value, socklen_t v
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getsockname.html
 int getsockname(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
 {
     Syscall::SC_getsockname_params params { sockfd, addr, addrlen };
@@ -124,6 +139,7 @@ int getsockname(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/getpeername.html
 int getpeername(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
 {
     Syscall::SC_getpeername_params params { sockfd, addr, addrlen };
@@ -131,6 +147,7 @@ int getpeername(int sockfd, struct sockaddr* addr, socklen_t* addrlen)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/socketpair.html
 int socketpair(int domain, int type, int protocol, int sv[2])
 {
     Syscall::SC_socketpair_params params { domain, type, protocol, sv };

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -94,11 +94,13 @@ static int create_thread(pthread_t* thread, void* (*entry)(void*), void* argumen
     VERIFY_NOT_REACHED();
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_self.html
 int pthread_self()
 {
     return __pthread_self();
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_create.html
 int pthread_create(pthread_t* thread, pthread_attr_t* attributes, void* (*start_routine)(void*), void* argument_to_start_routine)
 {
     if (!thread)
@@ -130,33 +132,39 @@ int pthread_create(pthread_t* thread, pthread_attr_t* attributes, void* (*start_
     return create_thread(thread, start_routine, argument_to_start_routine, used_attributes);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_exit.html
 void pthread_exit(void* value_ptr)
 {
     exit_thread(value_ptr, s_stack_location, s_stack_size);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_cleanup_push.html
 void pthread_cleanup_push([[maybe_unused]] void (*routine)(void*), [[maybe_unused]] void* arg)
 {
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_cleanup_pop.html
 void pthread_cleanup_pop([[maybe_unused]] int execute)
 {
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_join.html
 int pthread_join(pthread_t thread, void** exit_value_ptr)
 {
     int rc = syscall(SC_join_thread, thread, exit_value_ptr);
     __RETURN_PTHREAD_ERROR(rc);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_kill.html
 int pthread_kill(pthread_t thread, int sig)
 {
     int rc = syscall(SC_kill_thread, thread, sig);
     __RETURN_PTHREAD_ERROR(rc);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_detach.html
 int pthread_detach(pthread_t thread)
 {
     int rc = syscall(SC_detach_thread, thread);
@@ -169,38 +177,44 @@ int pthread_sigmask(int how, const sigset_t* set, sigset_t* old_set)
         return errno;
     return 0;
 }
-
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_init.html
 int pthread_mutex_init(pthread_mutex_t* mutex, const pthread_mutexattr_t* attributes)
 {
     return __pthread_mutex_init(mutex, attributes);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_destroy.html
 int pthread_mutex_destroy(pthread_mutex_t*)
 {
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_lock.html
 int pthread_mutex_lock(pthread_mutex_t* mutex)
 {
     return __pthread_mutex_lock(mutex);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_trylock.html
 int pthread_mutex_trylock(pthread_mutex_t* mutex)
 {
     return __pthread_mutex_trylock(mutex);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_unlock.html
 int pthread_mutex_unlock(pthread_mutex_t* mutex)
 {
     return __pthread_mutex_unlock(mutex);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutexattr_init.html
 int pthread_mutexattr_init(pthread_mutexattr_t* attr)
 {
     attr->type = PTHREAD_MUTEX_NORMAL;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutexattr_destroy.html
 int pthread_mutexattr_destroy(pthread_mutexattr_t*)
 {
     return 0;
@@ -216,12 +230,14 @@ int pthread_mutexattr_settype(pthread_mutexattr_t* attr, int type)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutexattr_gettype.html
 int pthread_mutexattr_gettype(pthread_mutexattr_t* attr, int* type)
 {
     *type = attr->type;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_init.html
 int pthread_attr_init(pthread_attr_t* attributes)
 {
     auto* impl = new PthreadAttrImpl {};
@@ -238,6 +254,7 @@ int pthread_attr_init(pthread_attr_t* attributes)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_destroy.html
 int pthread_attr_destroy(pthread_attr_t* attributes)
 {
     auto* attributes_impl = *(reinterpret_cast<PthreadAttrImpl**>(attributes));
@@ -245,6 +262,7 @@ int pthread_attr_destroy(pthread_attr_t* attributes)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_getdetachstate.html
 int pthread_attr_getdetachstate(const pthread_attr_t* attributes, int* p_detach_state)
 {
     auto* attributes_impl = *(reinterpret_cast<const PthreadAttrImpl* const*>(attributes));
@@ -256,6 +274,7 @@ int pthread_attr_getdetachstate(const pthread_attr_t* attributes, int* p_detach_
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_setdetachstate.html
 int pthread_attr_setdetachstate(pthread_attr_t* attributes, int detach_state)
 {
     auto* attributes_impl = *(reinterpret_cast<PthreadAttrImpl**>(attributes));
@@ -279,6 +298,7 @@ int pthread_attr_setdetachstate(pthread_attr_t* attributes, int detach_state)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_getguardsize.html
 int pthread_attr_getguardsize(const pthread_attr_t* attributes, size_t* p_guard_size)
 {
     auto* attributes_impl = *(reinterpret_cast<const PthreadAttrImpl* const*>(attributes));
@@ -290,6 +310,7 @@ int pthread_attr_getguardsize(const pthread_attr_t* attributes, size_t* p_guard_
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_setguardsize.html
 int pthread_attr_setguardsize(pthread_attr_t* attributes, size_t guard_size)
 {
     auto* attributes_impl = *(reinterpret_cast<PthreadAttrImpl**>(attributes));
@@ -321,6 +342,7 @@ int pthread_attr_setguardsize(pthread_attr_t* attributes, size_t guard_size)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_getschedparam.html
 int pthread_attr_getschedparam(const pthread_attr_t* attributes, struct sched_param* p_sched_param)
 {
     auto* attributes_impl = *(reinterpret_cast<const PthreadAttrImpl* const*>(attributes));
@@ -332,6 +354,7 @@ int pthread_attr_getschedparam(const pthread_attr_t* attributes, struct sched_pa
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_setschedparam.html
 int pthread_attr_setschedparam(pthread_attr_t* attributes, const struct sched_param* p_sched_param)
 {
     auto* attributes_impl = *(reinterpret_cast<PthreadAttrImpl**>(attributes));
@@ -354,6 +377,7 @@ int pthread_attr_setschedparam(pthread_attr_t* attributes, const struct sched_pa
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_getstack.html
 int pthread_attr_getstack(const pthread_attr_t* attributes, void** p_stack_ptr, size_t* p_stack_size)
 {
     auto* attributes_impl = *(reinterpret_cast<const PthreadAttrImpl* const*>(attributes));
@@ -367,6 +391,7 @@ int pthread_attr_getstack(const pthread_attr_t* attributes, void** p_stack_ptr, 
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_setstack.html
 int pthread_attr_setstack(pthread_attr_t* attributes, void* p_stack, size_t stack_size)
 {
     auto* attributes_impl = *(reinterpret_cast<PthreadAttrImpl**>(attributes));
@@ -397,6 +422,7 @@ int pthread_attr_setstack(pthread_attr_t* attributes, void* p_stack, size_t stac
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_getstacksize.html
 int pthread_attr_getstacksize(const pthread_attr_t* attributes, size_t* p_stack_size)
 {
     auto* attributes_impl = *(reinterpret_cast<const PthreadAttrImpl* const*>(attributes));
@@ -408,6 +434,7 @@ int pthread_attr_getstacksize(const pthread_attr_t* attributes, size_t* p_stack_
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_setstacksize.html
 int pthread_attr_setstacksize(pthread_attr_t* attributes, size_t stack_size)
 {
     auto* attributes_impl = *(reinterpret_cast<PthreadAttrImpl**>(attributes));
@@ -431,53 +458,62 @@ int pthread_attr_setstacksize(pthread_attr_t* attributes, size_t stack_size)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_getscope.html
 int pthread_attr_getscope([[maybe_unused]] const pthread_attr_t* attributes, [[maybe_unused]] int* contention_scope)
 {
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_attr_setscope.html
 int pthread_attr_setscope([[maybe_unused]] pthread_attr_t* attributes, [[maybe_unused]] int contention_scope)
 {
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_getschedparam.html
 int pthread_getschedparam([[maybe_unused]] pthread_t thread, [[maybe_unused]] int* policy, [[maybe_unused]] struct sched_param* param)
 {
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_setschedparam.html
 int pthread_setschedparam([[maybe_unused]] pthread_t thread, [[maybe_unused]] int policy, [[maybe_unused]] const struct sched_param* param)
 {
     return 0;
 }
 
-// libgcc expects this function to exist in libpthread, even
-// if it is not implemented.
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_cancel.html
+// NOTE: libgcc expects this function to exist in libpthread, even if it is not implemented.
 int pthread_cancel(pthread_t)
 {
     TODO();
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_key_create.html
 int pthread_key_create(pthread_key_t* key, KeyDestructor destructor)
 {
     return __pthread_key_create(key, destructor);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_key_delete.html
 int pthread_key_delete(pthread_key_t key)
 {
     return __pthread_key_delete(key);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_getspecific.html
 void* pthread_getspecific(pthread_key_t key)
 {
     return __pthread_getspecific(key);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_setspecific.html
 int pthread_setspecific(pthread_key_t key, const void* value)
 {
     return __pthread_setspecific(key, value);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_setname_np.html
 int pthread_setname_np(pthread_t thread, const char* name)
 {
     if (!name)
@@ -486,12 +522,14 @@ int pthread_setname_np(pthread_t thread, const char* name)
     __RETURN_PTHREAD_ERROR(rc);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_getname_np.html
 int pthread_getname_np(pthread_t thread, char* buffer, size_t buffer_size)
 {
     int rc = syscall(SC_get_thread_name, thread, buffer, buffer_size);
     __RETURN_PTHREAD_ERROR(rc);
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_setcancelstate.html
 int pthread_setcancelstate(int state, int* oldstate)
 {
     if (oldstate)
@@ -502,6 +540,7 @@ int pthread_setcancelstate(int state, int* oldstate)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_setcanceltype.html
 int pthread_setcanceltype(int type, int* oldtype)
 {
     if (oldtype)
@@ -513,6 +552,7 @@ int pthread_setcanceltype(int type, int* oldtype)
 }
 
 constexpr static pid_t spinlock_unlock_sentinel = 0;
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_spin_destroy.html
 int pthread_spin_destroy(pthread_spinlock_t* lock)
 {
     auto current = AK::atomic_load(&lock->m_lock);
@@ -523,12 +563,14 @@ int pthread_spin_destroy(pthread_spinlock_t* lock)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_spin_init.html
 int pthread_spin_init(pthread_spinlock_t* lock, [[maybe_unused]] int shared)
 {
     lock->m_lock = spinlock_unlock_sentinel;
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_spin_lock.html
 int pthread_spin_lock(pthread_spinlock_t* lock)
 {
     const auto desired = gettid();
@@ -545,6 +587,7 @@ int pthread_spin_lock(pthread_spinlock_t* lock)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_spin_trylock.html
 int pthread_spin_trylock(pthread_spinlock_t* lock)
 {
     // We expect the current value to be unlocked, as the specification
@@ -559,6 +602,7 @@ int pthread_spin_trylock(pthread_spinlock_t* lock)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_spin_unlock.html
 int pthread_spin_unlock(pthread_spinlock_t* lock)
 {
     auto current = AK::atomic_load(&lock->m_lock);
@@ -570,6 +614,7 @@ int pthread_spin_unlock(pthread_spinlock_t* lock)
     return 0;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_equal.html
 int pthread_equal(pthread_t t1, pthread_t t2)
 {
     return t1 == t2;
@@ -577,6 +622,7 @@ int pthread_equal(pthread_t t1, pthread_t t2)
 
 // FIXME: Use the fancy futex mechanism above to write an rw lock.
 //        For the time being, let's just use a less-than-good lock to get things working.
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_destroy.html
 int pthread_rwlock_destroy(pthread_rwlock_t* rl)
 {
     if (!rl)
@@ -596,6 +642,7 @@ constexpr static u32 reader_wake_mask = 1 << 30;
 constexpr static u32 writer_wake_mask = 1 << 31;
 constexpr static u32 writer_locked_mask = 1 << 17;
 constexpr static u32 writer_intent_mask = 1 << 16;
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_init.html
 int pthread_rwlock_init(pthread_rwlock_t* __restrict lockp, const pthread_rwlockattr_t* __restrict attr)
 {
     // Just ignore the attributes. use defaults for now.
@@ -702,6 +749,7 @@ static int rwlock_wrlock_maybe_timed(pthread_rwlock_t* lockval_p, const struct t
     return value_if_timeout;
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_rdlock.html
 int pthread_rwlock_rdlock(pthread_rwlock_t* lockp)
 {
     if (!lockp)
@@ -709,6 +757,8 @@ int pthread_rwlock_rdlock(pthread_rwlock_t* lockp)
 
     return rwlock_rdlock_maybe_timed(reinterpret_cast<u32*>(lockp), nullptr, false, 0, 0);
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_timedrdlock.html
 int pthread_rwlock_timedrdlock(pthread_rwlock_t* __restrict lockp, const struct timespec* __restrict timespec)
 {
     if (!lockp)
@@ -721,6 +771,8 @@ int pthread_rwlock_timedrdlock(pthread_rwlock_t* __restrict lockp, const struct 
         return 1;
     return rc;
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_timedwrlock.html
 int pthread_rwlock_timedwrlock(pthread_rwlock_t* __restrict lockp, const struct timespec* __restrict timespec)
 {
     if (!lockp)
@@ -733,6 +785,8 @@ int pthread_rwlock_timedwrlock(pthread_rwlock_t* __restrict lockp, const struct 
         return 1;
     return rc;
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_tryrdlock.html
 int pthread_rwlock_tryrdlock(pthread_rwlock_t* lockp)
 {
     if (!lockp)
@@ -740,6 +794,8 @@ int pthread_rwlock_tryrdlock(pthread_rwlock_t* lockp)
 
     return rwlock_rdlock_maybe_timed(reinterpret_cast<u32*>(lockp), nullptr, true, EBUSY, 0);
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_trywrlock.html
 int pthread_rwlock_trywrlock(pthread_rwlock_t* lockp)
 {
     if (!lockp)
@@ -747,6 +803,8 @@ int pthread_rwlock_trywrlock(pthread_rwlock_t* lockp)
 
     return rwlock_wrlock_maybe_timed(lockp, nullptr, true, EBUSY, 0);
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_unlock.html
 int pthread_rwlock_unlock(pthread_rwlock_t* lockval_p)
 {
     if (!lockval_p)
@@ -789,6 +847,8 @@ int pthread_rwlock_unlock(pthread_rwlock_t* lockval_p)
     // Finally, unlocked at last!
     return 0;
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlock_wrlock.html
 int pthread_rwlock_wrlock(pthread_rwlock_t* lockp)
 {
     if (!lockp)
@@ -796,23 +856,32 @@ int pthread_rwlock_wrlock(pthread_rwlock_t* lockp)
 
     return rwlock_wrlock_maybe_timed(lockp, nullptr, false, 0, 0);
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlockattr_destroy.html
 int pthread_rwlockattr_destroy(pthread_rwlockattr_t*)
 {
     return 0;
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlockattr_getpshared.html
 int pthread_rwlockattr_getpshared(const pthread_rwlockattr_t* __restrict, int* __restrict)
 {
     VERIFY_NOT_REACHED();
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlockattr_init.html
 int pthread_rwlockattr_init(pthread_rwlockattr_t*)
 {
     VERIFY_NOT_REACHED();
 }
+
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_rwlockattr_setpshared.html
 int pthread_rwlockattr_setpshared(pthread_rwlockattr_t*, int)
 {
     VERIFY_NOT_REACHED();
 }
 
+// https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_atfork.html
 int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(void))
 {
     if (prepare)


### PR DESCRIPTION
Following the pattern that we use in `LibWeb` and `LibJS`, we are starting to add spec comments to our `Userland` libraries which follow public specs, like `POSIX `for our `LibC` and `LibPthread` implementations.

This PR back fills comments for a bunch of LibC and LibPthread functions.