### PR TITLE
FlacLoader: Implement seek

### DIFF
--- a/Userland/Applications/SoundPlayer/PlaybackManager.cpp
+++ b/Userland/Applications/SoundPlayer/PlaybackManager.cpp
@@ -106,17 +106,14 @@ void PlaybackManager::next_buffer()
     if (m_paused)
         return;
 
-    u32 audio_server_remaining_samples = m_connection->get_remaining_samples();
-    bool all_samples_loaded = (m_loader->loaded_samples() >= m_loader->total_samples());
-    bool audio_server_done = (audio_server_remaining_samples == 0);
-
-    if (all_samples_loaded && audio_server_done) {
+    if (m_loader->stream_complete()) {
         stop();
         if (on_finished_playing)
             on_finished_playing();
         return;
     }
 
+    u32 audio_server_remaining_samples = m_connection->get_remaining_samples();
     if (audio_server_remaining_samples < m_device_samples_per_buffer) {
         auto maybe_buffer = m_loader->get_more_samples(m_source_buffer_size_bytes);
         if (!maybe_buffer.is_error()) {

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -102,6 +102,7 @@ public:
     virtual u16 num_channels() override { return m_num_channels; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
     virtual RefPtr<Core::File> file() override { return m_file; }
+    virtual bool stream_complete() override { return m_sample_index >= m_total_samples; }
 
     bool is_fixed_blocksize_stream() const { return m_min_block_size == m_max_block_size; }
     bool sample_count_unknown() const { return m_total_samples == 0; }
@@ -144,6 +145,7 @@ private:
     // Frames are units of encoded audio data, both of these are 24-bit
     u32 m_min_frame_size { 0 }; //24 bit
     u32 m_max_frame_size { 0 }; // 24 bit
+    u64 m_sample_index { 0 };
     u64 m_total_samples { 0 };  // 36 bit
     u8 m_md5_checksum[128 / 8]; // 128 bit (!)
     size_t m_loaded_samples { 0 };

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -124,6 +124,7 @@ private:
     MaybeLoaderError decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, InputBitStream& bit_input);
     // decode a single rice partition that has its own rice parameter
     ALWAYS_INLINE Vector<i32> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, InputBitStream& bit_input);
+    void load_seektable(FlacRawMetadataBlock&);
 
     // Converters for special coding used in frame headers
     ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_count_code(u8 sample_count_code);
@@ -153,6 +154,7 @@ private:
     Optional<FlacFrameHeader> m_current_frame;
     Vector<Sample> m_current_frame_data;
     u64 m_current_sample_or_frame { 0 };
+    Vector<FlacSeekPoint> m_seektable;
 };
 
 }

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -126,6 +126,7 @@ private:
     // decode a single rice partition that has its own rice parameter
     ALWAYS_INLINE Vector<i32> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, InputBitStream& bit_input);
     void load_seektable(FlacRawMetadataBlock&);
+    MaybeLoaderError seek_to_sample(FlacSeekPoint&, const int);
 
     // Converters for special coding used in frame headers
     ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_count_code(u8 sample_count_code);

--- a/Userland/Libraries/LibAudio/FlacTypes.h
+++ b/Userland/Libraries/LibAudio/FlacTypes.h
@@ -87,4 +87,10 @@ struct FlacSubframeHeader {
     u8 bits_per_sample;
 };
 
+struct FlacSeekPoint {
+    u64 sample_index;
+    u64 byte_offset;
+    u16 num_samples;
+};
+
 }

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -49,6 +49,7 @@ public:
     virtual int total_samples() = 0;
     virtual u32 sample_rate() = 0;
     virtual u16 num_channels() = 0;
+    virtual bool stream_complete() = 0;
 
     virtual PcmSampleFormat pcm_format() = 0;
     virtual RefPtr<Core::File> file() = 0;
@@ -68,6 +69,7 @@ public:
     int total_samples() const { return m_plugin->total_samples(); }
     u32 sample_rate() const { return m_plugin->sample_rate(); }
     u16 num_channels() const { return m_plugin->num_channels(); }
+    bool stream_complete() const { return m_plugin->stream_complete(); }
     u16 bits_per_sample() const { return pcm_bits_per_sample(m_plugin->pcm_format()); }
     RefPtr<Core::File> file() const { return m_plugin->file(); }
 

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -54,6 +54,7 @@ public:
     virtual u16 num_channels() override { return m_num_channels; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
     virtual RefPtr<Core::File> file() override { return m_file; }
+    virtual bool stream_complete() override { return m_loaded_samples >= m_total_samples; }
 
 private:
     MaybeLoaderError parse_header();


### PR DESCRIPTION
This PR implements seek for FLAC files. It uses a SeekTable when present, but otherwise will start its way at the beginning of the flac file and work forwards.

This seek is frame accurate.

Fix for #11339 