### PR TITLE
AK: Make `Disjoint*::is_empty()` not call size.

### DIFF
--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/AllOf.h>
 #include <AK/Forward.h>
 #include <AK/Span.h>
 #include <AK/StdLibExtras.h>
@@ -124,7 +125,10 @@ public:
         return size;
     }
 
-    bool is_empty() const { return size() == 0; }
+    bool is_empty() const
+    {
+        return all_of(m_spans, [](auto& span) { return span.is_empty(); });
+    }
 
     DisjointSpans slice(size_t start, size_t length) const
     {
@@ -256,7 +260,10 @@ public:
         return sum;
     }
 
-    bool is_empty() const { return m_chunks.size() == 0 || size() == 0; }
+    bool is_empty() const
+    {
+        return all_of(m_chunks, [](auto& chunk) { return chunk.is_empty(); });
+    }
 
     DisjointSpans<T> spans() const&
     {

--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -200,6 +200,11 @@ public:
     ChunkType const& first_chunk() const { return m_chunks.first(); }
     ChunkType const& last_chunk() const { return m_chunks.last(); }
 
+    void ensure_capacity(size_t needed_capacity)
+    {
+        m_chunks.ensure_capacity(needed_capacity);
+    }
+
     void insert(size_t index, T value)
     {
         if (m_chunks.size() == 1)

--- a/Tests/AK/TestDisjointChunks.cpp
+++ b/Tests/AK/TestDisjointChunks.cpp
@@ -13,8 +13,11 @@
 TEST_CASE(basic)
 {
     DisjointChunks<size_t> chunks;
+    EXPECT(chunks.is_empty());
     chunks.append({});
+    EXPECT(chunks.is_empty());
     chunks.last_chunk().append(0);
+    EXPECT(!chunks.is_empty());
     chunks.append({});
     chunks.last_chunk().append(1);
     chunks.last_chunk().append(2);

--- a/Tests/AK/TestDisjointChunks.cpp
+++ b/Tests/AK/TestDisjointChunks.cpp
@@ -80,3 +80,59 @@ TEST_CASE(spans)
 
     EXPECT_EQ(it, cross_chunk_slice.end());
 }
+
+#define INIT_ITERATIONS (1'000'000)
+#define ITERATIONS (100)
+
+static DisjointChunks<int> basic_really_empty_chunks;
+
+BENCHMARK_CASE(basic_really_empty)
+{
+    DisjointChunks<int> chunks;
+    for (size_t i = 0; i < ITERATIONS; ++i)
+        EXPECT(chunks.is_empty());
+}
+
+static DisjointChunks<int> basic_really_empty_large_chunks = []() {
+    DisjointChunks<int> chunks;
+    chunks.ensure_capacity(INIT_ITERATIONS);
+    for (size_t i = 0; i < INIT_ITERATIONS; ++i)
+        chunks.append({});
+    return chunks;
+}();
+
+BENCHMARK_CASE(basic_really_empty_large)
+{
+    for (size_t i = 0; i < ITERATIONS; ++i)
+        EXPECT(basic_really_empty_large_chunks.is_empty());
+}
+
+static DisjointChunks<int> basic_mostly_empty_chunks = []() {
+    DisjointChunks<int> chunks;
+    chunks.ensure_capacity(INIT_ITERATIONS + 1);
+    for (size_t i = 0; i < INIT_ITERATIONS; ++i)
+        chunks.append({});
+    chunks.append({ 1, 2, 3 });
+    return chunks;
+}();
+
+BENCHMARK_CASE(basic_mostly_empty)
+{
+    for (size_t i = 0; i < ITERATIONS; ++i) {
+        EXPECT(!basic_mostly_empty_chunks.is_empty());
+    }
+}
+
+static DisjointChunks<int> basic_full_chunks = []() {
+    DisjointChunks<int> chunks;
+    chunks.ensure_capacity(INIT_ITERATIONS + 1);
+    for (size_t i = 0; i < INIT_ITERATIONS; ++i)
+        chunks.append({ 1, 2, 3 });
+    return chunks;
+}();
+
+BENCHMARK_CASE(basic_full)
+{
+    for (size_t i = 0; i < ITERATIONS; ++i)
+        EXPECT(!basic_full_chunks.is_empty());
+}


### PR DESCRIPTION
This is a raffinement of 49cbd4dcca037336ad5e2e4fcb1e3cc613b46cce.

Previously, the container was scanned to compute the size in the unhappy
path. Now, using `all_of` happy and unhappy path should be fast.