### PR TITLE
LibC: Remove deprecation warnings from "unsafe" string functions

### DIFF
--- a/Userland/Libraries/LibC/string.h
+++ b/Userland/Libraries/LibC/string.h
@@ -29,8 +29,8 @@ void explicit_bzero(void*, size_t) __attribute__((nonnull(1)));
 __attribute__((malloc)) char* strdup(const char*);
 __attribute__((malloc)) char* strndup(const char*, size_t);
 
-__attribute__((deprecated("use strlcpy or String::copy_characters_to_buffer"))) char* strcpy(char* dest, const char* src);
-__attribute__((deprecated("use strlcpy or String::copy_characters_to_buffer"))) char* strncpy(char* dest, const char* src, size_t);
+char* strcpy(char* dest, const char* src);
+char* strncpy(char* dest, const char* src, size_t);
 __attribute__((warn_unused_result)) size_t strlcpy(char* dest, const char* src, size_t);
 
 char* strchr(const char*, int c);
@@ -38,7 +38,7 @@ char* strchrnul(const char*, int c);
 char* strstr(const char* haystack, const char* needle);
 char* strrchr(const char*, int c);
 
-__attribute__((deprecated("use strncat"))) char* strcat(char* dest, const char* src);
+char* strcat(char* dest, const char* src);
 char* strncat(char* dest, const char* src, size_t);
 
 size_t strspn(const char*, const char* accept);


### PR DESCRIPTION
As already discussed in Discord some time ago, we have close to zero usages of the C string functions in our codebase (including the "safe" alternatives), so the deprecation warnings are unlikely to have an actual effect on preventing large-scale use of the "unsafe" functions.

Meanwhile, the deprecation warnings are causing issues for ports that are compiled using -Werror by default, and are generally a large source for logspam when compiling.