### PR TITLE
LibMain: Don't `dbgln` runtime errors if not on Serenity

### DIFF
--- a/Userland/Libraries/LibMain/Main.cpp
+++ b/Userland/Libraries/LibMain/Main.cpp
@@ -25,7 +25,9 @@ int main(int argc, char** argv)
     if (result.is_error()) {
         auto error = result.release_error();
         warnln("Runtime error: {}", error);
+#ifdef __serenity__
         dbgln("\033[31;1mExiting with runtime error\033[0m: {}", error);
+#endif
         return 1;
     }
     return result.value();


### PR DESCRIPTION
When on Lagom, `warnln` and `dbgln` both output to `stderr`. This makes
runtime errors duplicated and more verbose than necessary.