### PR TITLE
Prekernel+Kernel+Lagom: Restore netboot functionality

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -523,10 +523,11 @@ add_custom_command(
     COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
     COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
     COMMAND $<TARGET_FILE:Lagom::ELFBaker> Kernel Kernel.drow
+    COMMAND gzip -fk Kernel.drow
     BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.drow ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
 )
 
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel.drow.gz" DESTINATION boot)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel.debug" DESTINATION boot)
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/kernel.map" DESTINATION res)
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -522,7 +522,8 @@ add_custom_command(
     COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
     COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel
     COMMAND ${CMAKE_OBJCOPY} --add-gnu-debuglink=Kernel.debug Kernel
-    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
+    COMMAND $<TARGET_FILE:Lagom::ELFBaker> Kernel Kernel.drow
+    BYPRODUCTS ${CMAKE_CURRENT_BINARY_DIR}/Kernel.drow ${CMAKE_CURRENT_BINARY_DIR}/kernel.map
 )
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/Kernel" DESTINATION boot)

--- a/Kernel/Storage/RamdiskController.cpp
+++ b/Kernel/Storage/RamdiskController.cpp
@@ -44,12 +44,7 @@ RamdiskController::RamdiskController()
     for (auto& used_memory_range : MM.used_memory_ranges()) {
         if (used_memory_range.type == Memory::UsedMemoryRangeType::BootModule) {
             size_t length = Memory::page_round_up(used_memory_range.end.get()).release_value_but_fixme_should_propagate_errors() - used_memory_range.start.get();
-            auto region_or_error = MM.allocate_kernel_region(used_memory_range.start, length, "Ramdisk", Memory::Region::Access::ReadWrite);
-            if (region_or_error.is_error()) {
-                dmesgln("RamdiskController: Failed to allocate kernel region of size {}", length);
-            } else {
-                m_devices.append(RamdiskDevice::create(*this, region_or_error.release_value(), 6, count));
-            }
+            m_devices.append(RamdiskDevice::create(*this, used_memory_range.start, length, 6, count));
             count++;
         }
     }

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -8,28 +8,30 @@
 #include <AK/StringView.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/FileSystem/OpenFileDescription.h>
+#include <Kernel/Memory/TypedMapping.h>
 #include <Kernel/Storage/RamdiskController.h>
 #include <Kernel/Storage/RamdiskDevice.h>
 
 namespace Kernel {
 
-NonnullRefPtr<RamdiskDevice> RamdiskDevice::create(const RamdiskController& controller, NonnullOwnPtr<Memory::Region>&& region, int major, int minor)
+NonnullRefPtr<RamdiskDevice> RamdiskDevice::create(const RamdiskController& controller, PhysicalAddress start_address, size_t length, int major, int minor)
 {
     // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
     size_t drive_index = minor / 16;
     auto device_name = MUST(KString::formatted("ramdisk{}", drive_index));
 
-    auto device_or_error = DeviceManagement::try_create_device<RamdiskDevice>(controller, move(region), major, minor, move(device_name));
+    auto device_or_error = DeviceManagement::try_create_device<RamdiskDevice>(controller, start_address, length, major, minor, move(device_name));
     // FIXME: Find a way to propagate errors
     VERIFY(!device_or_error.is_error());
     return device_or_error.release_value();
 }
 
-RamdiskDevice::RamdiskDevice(const RamdiskController&, NonnullOwnPtr<Memory::Region>&& region, int major, int minor, NonnullOwnPtr<KString> device_name)
-    : StorageDevice(major, minor, 512, region->size() / 512, move(device_name))
-    , m_region(move(region))
+RamdiskDevice::RamdiskDevice(const RamdiskController&, PhysicalAddress start_address, size_t length, int major, int minor, NonnullOwnPtr<KString> device_name)
+    : StorageDevice(major, minor, 512, length / 512, move(device_name))
+    , m_start_address(start_address)
+    , m_length(length)
 {
-    dmesgln("Ramdisk: Device #{} @ {}, Capacity={}", minor, m_region->vaddr(), max_addressable_block() * 512);
+    dmesgln("Ramdisk: Device #{} @ {}, Capacity={}", minor, start_address, max_addressable_block() * 512);
 }
 
 RamdiskDevice::~RamdiskDevice()
@@ -45,22 +47,52 @@ void RamdiskDevice::start_request(AsyncBlockDeviceRequest& request)
 {
     MutexLocker locker(m_lock);
 
-    u8* base = m_region->vaddr().as_ptr();
-    size_t size = m_region->size();
-    u8* offset = base + request.block_index() * 512;
-    size_t length = request.block_count() * 512;
+    size_t request_offset = request.block_index() * 512;
+    size_t request_length = request.block_count() * 512;
 
-    if ((offset + length > base + size) || (offset + length < base)) {
+    if (Checked<size_t>::addition_would_overflow(m_start_address.get(), request_offset)) {
         request.complete(AsyncDeviceRequest::Failure);
-    } else {
-        ErrorOr<void> result;
-        if (request.request_type() == AsyncBlockDeviceRequest::Read) {
-            result = request.buffer().write(offset, length);
-        } else {
-            result = request.buffer().read(offset, length);
-        }
-        request.complete(!result.is_error() ? AsyncDeviceRequest::Success : AsyncDeviceRequest::MemoryFault);
+        return;
     }
+
+    if (Checked<size_t>::addition_would_overflow(request_offset + m_start_address.get(), request_length)) {
+        request.complete(AsyncDeviceRequest::Failure);
+        return;
+    }
+
+    if (m_length < (request_length + request_offset)) {
+        request.complete(AsyncDeviceRequest::Failure);
+        return;
+    }
+
+    auto do_io_transaction = [](AsyncBlockDeviceRequest& request, Memory::Region const& region, size_t request_offset, size_t nprocessed, size_t length_to_map) -> ErrorOr<void> {
+        ErrorOr<void> result;
+        auto* ptr = region.vaddr().offset((request_offset + nprocessed) % PAGE_SIZE).as_ptr();
+        if (request.request_type() == AsyncBlockDeviceRequest::Read)
+            result = request.buffer().write(ptr, nprocessed, length_to_map);
+        else
+            result = request.buffer().read(ptr, nprocessed, length_to_map);
+        return result;
+    };
+
+    size_t remaining_length = request_length;
+    size_t nprocessed = 0;
+    ErrorOr<void> result;
+    while (remaining_length > 0) {
+        size_t length_to_map = min<size_t>(PAGE_SIZE, remaining_length);
+        auto mapping = Memory::map_typed<u8>(m_start_address.offset(request_offset + nprocessed), length_to_map, Memory::Region::Access::ReadWrite);
+        if (mapping.is_error()) {
+            result = mapping.release_error();
+            break;
+        }
+        result = do_io_transaction(request, *(mapping.value().region), request_offset, nprocessed, length_to_map);
+        nprocessed += length_to_map;
+        remaining_length -= length_to_map;
+        if (result.is_error())
+            break;
+    }
+
+    request.complete(!result.is_error() ? AsyncDeviceRequest::Success : AsyncDeviceRequest::MemoryFault);
 }
 
 }

--- a/Kernel/Storage/RamdiskDevice.h
+++ b/Kernel/Storage/RamdiskDevice.h
@@ -18,14 +18,14 @@ class RamdiskDevice final : public StorageDevice {
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<RamdiskDevice> create(const RamdiskController&, NonnullOwnPtr<Memory::Region>&& region, int major, int minor);
+    static NonnullRefPtr<RamdiskDevice> create(const RamdiskController&, PhysicalAddress start_address, size_t length, int major, int minor);
     virtual ~RamdiskDevice() override;
 
     // ^DiskDevice
     virtual StringView class_name() const override;
 
 private:
-    RamdiskDevice(const RamdiskController&, NonnullOwnPtr<Memory::Region>&&, int major, int minor, NonnullOwnPtr<KString> device_name);
+    RamdiskDevice(const RamdiskController&, PhysicalAddress start_address, size_t length, int major, int minor, NonnullOwnPtr<KString> device_name);
 
     // ^BlockDevice
     virtual void start_request(AsyncBlockDeviceRequest&) override;
@@ -35,7 +35,8 @@ private:
 
     Mutex m_lock { "RamdiskDevice" };
 
-    NonnullOwnPtr<Memory::Region> m_region;
+    PhysicalAddress m_start_address;
+    size_t m_length;
 };
 
 }

--- a/Meta/Lagom/Tools/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CMakeLists.txt
@@ -13,4 +13,5 @@ endfunction()
 
 add_subdirectory(CodeGenerators)
 add_subdirectory(ConfigureComponents)
+add_subdirectory(ELFBaker)
 add_subdirectory(IPCMagicLinter)

--- a/Meta/Lagom/Tools/ELFBaker/CMakeLists.txt
+++ b/Meta/Lagom/Tools/ELFBaker/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(SOURCES
+    main.cpp
+)
+
+lagom_tool(ELFBaker LIBS LagomMain)

--- a/Meta/Lagom/Tools/ELFBaker/main.cpp
+++ b/Meta/Lagom/Tools/ELFBaker/main.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2021, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Error.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <AK/Vector.h>
+#include <LibC/elf.h>
+#include <LibCore/File.h>
+#include <LibMain/Main.h>
+
+template<typename ElfHeader, typename ElfPhdr, typename ElfShdr>
+class ElfImage : public ByteBuffer {
+public:
+    using Header = ElfHeader;
+    using ProgramHeader = ElfPhdr;
+    using SectionHeader = ElfShdr;
+
+    ElfImage(ByteBuffer& image)
+        : m_image(image)
+    {
+    }
+
+    ElfHeader& get_header()
+    {
+        return *reinterpret_cast<ElfHeader*>(m_image.data());
+    }
+
+    Span<ElfPhdr> get_program_headers()
+    {
+        auto& header = get_header();
+        auto program_headers = reinterpret_cast<ElfPhdr*>(m_image.data() + header.e_phoff);
+        return Span<ElfPhdr>(program_headers, header.e_phnum);
+    }
+
+    Span<ElfShdr> get_sections()
+    {
+        auto& header = get_header();
+        auto sections = reinterpret_cast<ElfShdr*>(m_image.data() + header.e_shoff);
+        return Span<ElfShdr>(sections, header.e_shnum);
+    }
+
+private:
+    ByteBuffer& m_image;
+};
+
+using Elf32Image = ElfImage<Elf32_Ehdr, Elf32_Phdr, Elf32_Shdr>;
+using Elf64Image = ElfImage<Elf64_Ehdr, Elf64_Phdr, Elf64_Shdr>;
+
+template<typename T>
+class ElfBaker {
+public:
+    ElfBaker(ByteBuffer& input)
+        : m_input_data(input)
+        , m_input_image(m_input_data)
+        , m_input_header(m_input_image.get_header())
+        , m_input_program_headers(m_input_image.get_program_headers())
+        , m_input_sections(m_input_image.get_sections())
+        , m_program_loads_size(compute_program_load_sizes())
+        , m_relocated_sections_size(compute_relocated_sections_size())
+    {
+    }
+
+    ErrorOr<ByteBuffer> bake()
+    {
+        TRY(check_eligibility());
+
+        auto& input_header = m_input_image.get_header();
+        size_t section_table_size = input_header.e_shnum * input_header.e_shentsize;
+
+        auto result_or_null = ByteBuffer::create_zeroed(m_program_loads_size + section_table_size + m_relocated_sections_size);
+        if (!result_or_null.has_value())
+            return Error::from_errno(ENOMEM);
+        auto& result = result_or_null.value();
+
+        size_t offset = execute_program_headers(result);
+        offset += move_section_table(result, offset);
+        offset += move_sections(result, offset);
+
+        return result;
+    }
+
+private:
+    ErrorOr<void> check_eligibility() const
+    {
+        if (!(m_input_header.e_type == ET_EXEC || m_input_header.e_type == ET_DYN))
+            return Error::from_string_literal("Bad ELF type");
+        if (m_input_program_headers.is_empty())
+            return Error::from_string_literal("No program headers");
+
+        auto& first_program_header = m_input_program_headers[0];
+        if (first_program_header.p_type != PT_LOAD)
+            return Error::from_string_literal("First program header is not of PT_LOAD type");
+        if (first_program_header.p_offset != 0 || first_program_header.p_filesz < sizeof(typename T::Header))
+            return Error::from_string_literal("First program header does not contain ELF header, use FILEHDR flag in linker script");
+        if (first_program_header.p_filesz > (m_input_header.e_phoff + m_input_header.e_phentsize * m_input_header.e_phnum))
+            return Error::from_string_literal("First program header does not contain program header, use PHDRS flag in linker script");
+
+        return {};
+    }
+
+    size_t execute_program_headers(ByteBuffer& output)
+    {
+        T output_image(output);
+
+        for (auto& program_header : m_input_program_headers) {
+            if (program_header.p_type == PT_LOAD) {
+                auto src_span = m_input_data.span().slice(program_header.p_offset, program_header.p_filesz);
+                auto dst_span = output.span().slice(program_header.p_vaddr, program_header.p_filesz);
+                src_span.copy_to(dst_span);
+            }
+        }
+
+        for (auto& program_header : output_image.get_program_headers()) {
+            program_header.p_filesz = program_header.p_memsz;
+            program_header.p_offset = program_header.p_vaddr;
+        }
+
+        return m_program_loads_size;
+    }
+
+    size_t move_section_table(ByteBuffer& output, size_t offset)
+    {
+        T output_image(output);
+        auto& output_header = output_image.get_header();
+        size_t section_table_size = m_input_header.e_shnum * m_input_header.e_shentsize;
+
+        auto src_span = m_input_data.span().slice(m_input_header.e_shoff, section_table_size);
+        auto dst_span = output.span().slice(offset, section_table_size);
+        src_span.copy_to(dst_span);
+
+        output_header.e_shoff = offset;
+
+        return section_table_size;
+    }
+
+    size_t move_sections(ByteBuffer& output, size_t offset)
+    {
+        T output_image(output);
+
+        for (auto& section : output_image.get_sections()) {
+            if (section.sh_addr == 0 && section.sh_size > 0) {
+                auto src_span = m_input_data.span().slice(section.sh_offset, section.sh_size);
+                auto dst_span = output.span().slice(offset, section.sh_size);
+                src_span.copy_to(dst_span);
+
+                section.sh_offset = offset;
+
+                offset += section.sh_size;
+            } else {
+                section.sh_offset = section.sh_addr;
+            }
+        }
+
+        return offset;
+    }
+
+    size_t compute_program_load_sizes() const
+    {
+        size_t total = 0;
+
+        for (auto& program_header : m_input_program_headers) {
+            size_t program_end = program_header.p_vaddr + program_header.p_memsz;
+            total = max(total, program_end);
+        }
+
+        return total;
+    }
+
+    size_t compute_relocated_sections_size() const
+    {
+        size_t total = 0;
+
+        for (auto& section : m_input_sections) {
+            if (section.sh_addr == 0 && section.sh_size > 0) {
+                total += section.sh_size;
+            }
+        }
+
+        return total;
+    }
+
+    ByteBuffer& m_input_data;
+    T m_input_image;
+    typename T::Header m_input_header;
+    Span<typename T::ProgramHeader> m_input_program_headers;
+    Span<typename T::SectionHeader> m_input_sections;
+    size_t m_program_loads_size;
+    size_t m_relocated_sections_size;
+};
+
+using Elf32Baker = ElfBaker<Elf32Image>;
+using Elf64Baker = ElfBaker<Elf64Image>;
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    if (arguments.argc < 3) {
+        warnln("Usage: {} kernel.elf kernel.drow", arguments.argv[0]);
+        warnln("Bakes ELF into DROW for usage with prekernel.");
+        return 1;
+    }
+
+    auto src_file = TRY(Core::File::open(arguments.argv[1], Core::OpenMode::ReadOnly));
+
+    auto src_data = src_file->read_all();
+    auto& ehdr = *reinterpret_cast<const Elf32_Ehdr*>(src_data.data());
+    if (!IS_ELF(ehdr)) {
+        warnln("Error: '{}' is not an ELF file", arguments.argv[1]);
+        return 1;
+    }
+
+    ByteBuffer output;
+    switch (ehdr.e_ident[EI_CLASS]) {
+    case ELFCLASS32:
+        output = TRY(Elf32Baker(src_data).bake());
+        break;
+    case ELFCLASS64:
+        output = TRY(Elf64Baker(src_data).bake());
+        break;
+    default:
+        warnln("Error: '{}' has an unknown ELF class", arguments.argv[1]);
+        return 1;
+    }
+
+    auto dst_file = TRY(Core::File::open(arguments.argv[2], Core::OpenMode::Truncate | Core::OpenMode::WriteOnly));
+    if (!dst_file->write(output.data(), output.size())) {
+        warnln("Error: Failed to write '{}'", arguments.argv[2]);
+        return 1;
+    }
+
+    return 0;
+}

--- a/Meta/build-root-filesystem.sh
+++ b/Meta/build-root-filesystem.sh
@@ -111,7 +111,7 @@ if [ -f mnt/usr/Tests/Kernel/TestProcFSWrite ]; then
 fi
 
 chmod 0400 mnt/res/kernel.map
-chmod 0400 mnt/boot/Kernel
+chmod 0400 mnt/boot/Kernel.drow.gz
 chmod 0400 mnt/boot/Kernel.debug
 chmod 600 mnt/etc/shadow
 chmod 755 mnt/res/devel/templates/*.postcreate

--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -48,7 +48,7 @@ exec $SERENITY_KERNEL_DEBUGGER \
     -ex "file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}/Kernel/Prekernel/$prekernel_image" \
     -ex "set confirm off" \
     -ex "directory $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}/" \
-    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}/Kernel/Kernel -o $kernel_base" \
+    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}/Kernel/Kernel.drow -o $kernel_base" \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \
     -ex "set print frame-arguments none" \

--- a/Meta/grub-ebr.cfg
+++ b/Meta/grub-ebr.cfg
@@ -3,24 +3,24 @@ timeout=1
 menuentry 'SerenityOS (normal)' {
   root=hd0,5
   multiboot /boot/Prekernel root=/dev/hda4
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (text mode)' {
   root=hd0,5
   multiboot /boot/Prekernel fbdev=off root=/dev/hda4
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (No ACPI)' {
   root=hd0,5
   multiboot /boot/Prekernel root=/dev/hda4 acpi=off
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (with serial debug)' {
   root=hd0,5
   multiboot /boot/Prekernel serial_debug root=/dev/hda4
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 

--- a/Meta/grub-gpt.cfg
+++ b/Meta/grub-gpt.cfg
@@ -3,23 +3,23 @@ timeout=1
 menuentry 'SerenityOS (normal)' {
   root=hd0,2
   multiboot /boot/Prekernel root=/dev/hda2
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (text mode)' {
   root=hd0,2
   multiboot /boot/Prekernel fbdev=off root=/dev/hda2
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (No ACPI)' {
   root=hd0,2
   multiboot /boot/Prekernel root=/dev/hda2 acpi=off
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (with serial debug)' {
   root=hd0,2
   multiboot /boot/Prekernel serial_debug root=/dev/hda2
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }

--- a/Meta/grub-mbr.cfg
+++ b/Meta/grub-mbr.cfg
@@ -3,23 +3,23 @@ timeout=1
 menuentry 'SerenityOS (normal)' {
   root=hd0,1
   multiboot /boot/Prekernel root=/dev/hda1
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (text mode)' {
   root=hd0,1
   multiboot /boot/Prekernel fbdev=off root=/dev/hda1
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (No ACPI)' {
   root=hd0,1
   multiboot /boot/Prekernel root=/dev/hda1 acpi=off
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }
 
 menuentry 'SerenityOS (with serial debug)' {
   root=hd0,1
   multiboot /boot/Prekernel serial_debug root=/dev/hda1
-  module /boot/Kernel
+  module /boot/Kernel.drow.gz
 }

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -327,7 +327,7 @@ elif [ "$SERENITY_RUN" = "qn" ]; then
         $SERENITY_COMMON_QEMU_ARGS \
         -device $SERENITY_ETHERNET_DEVICE_TYPE \
         -kernel Kernel/Prekernel/Prekernel \
-        -initrd Kernel/Kernel \
+        -initrd Kernel/Kernel.drow \
         -append "${SERENITY_KERNEL_CMDLINE}"
 elif [ "$SERENITY_RUN" = "qtap" ]; then
     # Meta/run.sh qtap: qemu with tap
@@ -340,7 +340,7 @@ elif [ "$SERENITY_RUN" = "qtap" ]; then
         -netdev tap,ifname=tap0,id=br0 \
         -device $SERENITY_ETHERNET_DEVICE_TYPE,netdev=br0 \
         -kernel Kernel/Prekernel/Prekernel \
-        -initrd Kernel/Kernel \
+        -initrd Kernel/Kernel.drow \
         -append "${SERENITY_KERNEL_CMDLINE}"
     sudo ip tuntap del dev tap0 mode tap
 elif [ "$SERENITY_RUN" = "qgrub" ] || [ "$SERENITY_RUN" = "qextlinux" ]; then
@@ -360,7 +360,7 @@ elif [ "$SERENITY_RUN" = "q35" ]; then
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
         -device $SERENITY_ETHERNET_DEVICE_TYPE,netdev=breh \
         -kernel Kernel/Prekernel/Prekernel \
-        -initrd Kernel/Kernel \
+        -initrd Kernel/Kernel.drow \
         -append "${SERENITY_KERNEL_CMDLINE}"
 elif [ "$SERENITY_RUN" = "q35grub" ]; then
     # Meta/run.sh q35grub: qemu (q35 chipset) with SerenityOS, using a grub disk image
@@ -386,7 +386,7 @@ elif [ "$SERENITY_RUN" = "ci" ]; then
         -display none \
         -debugcon file:debug.log \
         -kernel Kernel/Prekernel/Prekernel \
-        -initrd Kernel/Kernel \
+        -initrd Kernel/Kernel.drow \
         -append "${SERENITY_KERNEL_CMDLINE}"
 else
     # Meta/run.sh: qemu with user networking
@@ -404,6 +404,6 @@ else
         $SERENITY_PACKET_LOGGING_ARG \
         $SERENITY_NETFLAGS \
         -kernel Kernel/Prekernel/Prekernel \
-        -initrd Kernel/Kernel \
+        -initrd Kernel/Kernel.drow \
         -append "${SERENITY_KERNEL_CMDLINE}"
 fi


### PR DESCRIPTION
# The Good, the Bad and the ELF

Currently, the prekernel environment of SerenityOS has roughly the following responsibilities:
1. Perform some sanity checks on the CPU
2. Set up GDT and paging
3. Load ELF payload (kernel) into high virtual addresses
4. Set up `BootInfo` structure
5. Jump into kernel virtual entrypoint

This means that the prekernel is effectively a bootloader, as it _loads_ the kernel into high virtual addresses. This requires some degree of dynamic memory management in order to find free physical pages as targets of the `LOAD` program headers, but the  prekernel simply dumps it at physical address `0x200000` and hopes that:
* this is RAM,
* this is enough RAM to load the kernel in,
* nothing else important is there (did someone say ramdisk?).

This is an experiment to turn the prekernel into a Multiboot bootshim, one that does not require additional memory beyond itself to bootstrap the kernel. This relies on an ELF trick that I hereby call DROW.

# DROWs to the rescue

Simply put, a DROW is a baked ELF such as `vaddr == offset` for any byte in a segment. This implies several properties:
* all `LOAD` program headers must have `p_memsz == p_filesz`
* all `LOAD` program headers must have `p_vaddr == p_offset`

Further requirements include:
* the first `LOAD` program header must contain the ELF header and program headers
* all sections must be page-aligned

A DROW file is a valid ELF file and can be manipulated with ELF toolchains. It is also suitable for paging as-is, assuming it is loaded at a page-aligned address. This bypasses the need to load the ELF as is usually required and it can be mapped directly in-place. Therefore, the prekernel doesn't need to find free memory for loading the kernel, that responsibility is instead deferred to the bootloader.

Baking an ELF into a DROW is done with a Lagom utility called ELFBaker. As the result is quite large (over 30 MiB), it is gzip-compressed to save disk space and I/O (especially when netbooting) when using a bootloader capable of uncompressing it such as GRUB2.

The prekernel has been slightly simplified to take advantage of the DROW restrictions, as I do not know how to trick the linker into generating it directly. This should fix a number of boot failures because the ramdisk or something else important has been overwritten while loading the kernel.

# TODO
* [x] Working PoC
* [x] Write some documentation about this