### PR TITLE
Kernel+LibC+LibELF+UE+strace: Various improvements to mmap()

### DIFF
--- a/Base/usr/share/man/man2/pledge.md
+++ b/Base/usr/share/man/man2/pledge.md
@@ -53,7 +53,7 @@ If the process later attempts to use any system functionality it has previously 
 * `recvfd`: Receive file descriptors over a local socket
 * `ptrace`: The [`ptrace`(2)](ptrace.md) syscall (\*)
 * `prot_exec`: [`mmap`(2)](mmap.md) and [`mprotect`(2)](mprotect.md) with `PROT_EXEC`
-* `map_fixed`: [`mmap`(2)](mmap.md) with `MAP_FIXED` (\*)
+* `map_fixed`: [`mmap`(2)](mmap.md) with `MAP_FIXED` or `MAP_FIXED_NOREPLACE` (\*)
 
 Promises marked with an asterisk (\*) are SerenityOS specific extensions not supported by the original OpenBSD `pledge()`.
 

--- a/Kernel/API/POSIX/sys/mman.h
+++ b/Kernel/API/POSIX/sys/mman.h
@@ -23,6 +23,7 @@ extern "C" {
 #define MAP_NORESERVE 0x80
 #define MAP_RANDOMIZED 0x100
 #define MAP_PURGEABLE 0x200
+#define MAP_FIXED_NOREPLACE 0x400
 
 #define PROT_READ 0x1
 #define PROT_WRITE 0x2

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -239,7 +239,7 @@ struct StringListArgument {
 };
 
 struct SC_mmap_params {
-    uintptr_t addr;
+    void* addr;
     size_t size;
     size_t alignment;
     int32_t prot;
@@ -250,7 +250,7 @@ struct SC_mmap_params {
 };
 
 struct SC_mremap_params {
-    uintptr_t old_address;
+    void* old_address;
     size_t old_size;
     size_t new_size;
     int32_t flags;

--- a/Kernel/Memory/VirtualRangeAllocator.cpp
+++ b/Kernel/Memory/VirtualRangeAllocator.cpp
@@ -146,9 +146,9 @@ ErrorOr<VirtualRange> VirtualRangeAllocator::try_allocate_specific(VirtualAddres
     SpinlockLocker lock(m_lock);
     auto available_range = m_available_ranges.find_largest_not_above(base.get());
     if (!available_range)
-        return ENOMEM;
+        return EEXIST;
     if (!available_range->contains(allocated_range))
-        return ENOMEM;
+        return EEXIST;
     if (*available_range == allocated_range) {
         m_available_ranges.remove(available_range->base().get());
         return allocated_range;

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -123,7 +123,7 @@ ErrorOr<FlatPtr> Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> use
     REQUIRE_PROMISE(stdio);
     auto params = TRY(copy_typed_from_user(user_params));
 
-    FlatPtr addr = params.addr;
+    auto addr = (FlatPtr)params.addr;
     auto size = params.size;
     auto alignment = params.alignment ? params.alignment : PAGE_SIZE;
     auto prot = params.prot;

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -874,9 +874,11 @@ u32 Emulator::virt$mmap(u32 params_addr)
     if (params.flags & MAP_RANDOMIZED) {
         result = m_range_allocator.allocate_randomized(requested_size, params.alignment);
     } else if (params.flags & MAP_FIXED) {
-        if (params.addr)
+        if (params.addr) {
+            // If MAP_FIXED is specified, existing mappings that intersect the requested range are removed.
+            virt$munmap(params.addr, requested_size);
             result = m_range_allocator.allocate_specific(VirtualAddress { params.addr }, requested_size);
-        else {
+        } else {
             // mmap(nullptr, …, MAP_FIXED) is technically okay, but tends to be a bug.
             // Therefore, refuse to be helpful.
             reportln("\n=={}==  \033[31;1mTried to mmap at nullptr with MAP_FIXED.\033[0m, {:#x} bytes.", getpid(), params.size);

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -873,10 +873,11 @@ u32 Emulator::virt$mmap(u32 params_addr)
     Optional<Range> result;
     if (params.flags & MAP_RANDOMIZED) {
         result = m_range_allocator.allocate_randomized(requested_size, params.alignment);
-    } else if (params.flags & MAP_FIXED) {
+    } else if (params.flags & MAP_FIXED || params.flags & MAP_FIXED_NOREPLACE) {
         if (params.addr) {
             // If MAP_FIXED is specified, existing mappings that intersect the requested range are removed.
-            virt$munmap(params.addr, requested_size);
+            if (params.flags & MAP_FIXED)
+                virt$munmap(params.addr, requested_size);
             result = m_range_allocator.allocate_specific(VirtualAddress { params.addr }, requested_size);
         } else {
             // mmap(nullptr, …, MAP_FIXED) is technically okay, but tends to be a bug.

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -877,7 +877,7 @@ u32 Emulator::virt$mmap(u32 params_addr)
         if (params.addr) {
             // If MAP_FIXED is specified, existing mappings that intersect the requested range are removed.
             if (params.flags & MAP_FIXED)
-                virt$munmap(params.addr, requested_size);
+                virt$munmap((FlatPtr)params.addr, requested_size);
             result = m_range_allocator.allocate_specific(VirtualAddress { params.addr }, requested_size);
         } else {
             // mmap(nullptr, …, MAP_FIXED) is technically okay, but tends to be a bug.
@@ -926,7 +926,7 @@ FlatPtr Emulator::virt$mremap(FlatPtr params_addr)
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
 
     // FIXME: Support regions that have been split in the past (e.g. due to mprotect or munmap).
-    if (auto* region = mmu().find_region({ m_cpu.ds(), params.old_address })) {
+    if (auto* region = mmu().find_region({ m_cpu.ds(), (FlatPtr)params.old_address })) {
         if (!is<MmapRegion>(*region))
             return -EINVAL;
         VERIFY(region->size() == params.old_size);

--- a/Userland/DevTools/UserspaceEmulator/MmapRegion.cpp
+++ b/Userland/DevTools/UserspaceEmulator/MmapRegion.cpp
@@ -36,8 +36,8 @@ NonnullOwnPtr<MmapRegion> MmapRegion::create_anonymous(u32 base, u32 size, u32 p
 
 NonnullOwnPtr<MmapRegion> MmapRegion::create_file_backed(u32 base, u32 size, u32 prot, int flags, int fd, off_t offset, String name)
 {
-    // Since we put the memory to an arbitrary location, do not pass MAP_FIXED to the Kernel.
-    auto real_flags = flags & ~MAP_FIXED;
+    // Since we put the memory to an arbitrary location, do not pass MAP_FIXED and MAP_FIXED_NOREPLACE to the Kernel.
+    auto real_flags = flags & ~(MAP_FIXED | MAP_FIXED_NOREPLACE);
     auto* data = (u8*)mmap_with_name(nullptr, size, prot, real_flags, fd, offset, name.is_empty() ? nullptr : String::formatted("(UE) {}", name).characters());
     VERIFY(data != MAP_FAILED);
     auto* shadow_data = (u8*)mmap_initialized(size, 1, "MmapRegion ShadowData");

--- a/Userland/Libraries/LibC/sys/mman.cpp
+++ b/Userland/Libraries/LibC/sys/mman.cpp
@@ -15,7 +15,7 @@ extern "C" {
 
 void* serenity_mmap(void* addr, size_t size, int prot, int flags, int fd, off_t offset, size_t alignment, const char* name)
 {
-    Syscall::SC_mmap_params params { (uintptr_t)addr, size, alignment, prot, flags, fd, offset, { name, name ? strlen(name) : 0 } };
+    Syscall::SC_mmap_params params { addr, size, alignment, prot, flags, fd, offset, { name, name ? strlen(name) : 0 } };
     ptrdiff_t rc = syscall(SC_mmap, &params);
     if (rc < 0 && rc > -EMAXERRNO) {
         errno = -rc;
@@ -37,7 +37,7 @@ void* mmap_with_name(void* addr, size_t size, int prot, int flags, int fd, off_t
 
 void* mremap(void* old_address, size_t old_size, size_t new_size, int flags)
 {
-    Syscall::SC_mremap_params params { (uintptr_t)old_address, old_size, new_size, flags };
+    Syscall::SC_mremap_params params { old_address, old_size, new_size, flags };
     ptrdiff_t rc = syscall(SC_mremap, &params);
     if (rc < 0 && rc > -EMAXERRNO) {
         errno = -rc;

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -151,7 +151,7 @@ ErrorOr<int> fcntl(int fd, int command, ...)
 ErrorOr<void*> mmap(void* address, size_t size, int protection, int flags, int fd, off_t offset, [[maybe_unused]] size_t alignment, [[maybe_unused]] StringView name)
 {
 #ifdef __serenity__
-    Syscall::SC_mmap_params params { (uintptr_t)address, size, alignment, protection, flags, fd, offset, { name.characters_without_null_termination(), name.length() } };
+    Syscall::SC_mmap_params params { address, size, alignment, protection, flags, fd, offset, { name.characters_without_null_termination(), name.length() } };
     ptrdiff_t rc = syscall(SC_mmap, &params);
     if (rc < 0 && rc > -EMAXERRNO)
         return Error::from_syscall("mmap"sv, rc);

--- a/Userland/Libraries/LibELF/DynamicLoader.cpp
+++ b/Userland/Libraries/LibELF/DynamicLoader.cpp
@@ -292,8 +292,10 @@ void DynamicLoader::load_program_headers()
     int reservation_mmap_flags = MAP_ANON | MAP_PRIVATE | MAP_NORESERVE;
     if (m_elf_image.is_dynamic())
         reservation_mmap_flags |= MAP_RANDOMIZED;
+#ifdef MAP_FIXED_NOREPLACE
     else
-        reservation_mmap_flags |= MAP_FIXED;
+        reservation_mmap_flags |= MAP_FIXED_NOREPLACE;
+#endif
 
     // First, we make a dummy reservation mapping, in order to allocate enough VM
     // to hold all regions contiguously in the address space.
@@ -308,6 +310,8 @@ void DynamicLoader::load_program_headers()
         perror("mmap reservation");
         VERIFY_NOT_REACHED();
     }
+
+    VERIFY(requested_load_address == nullptr || reservation == requested_load_address);
 
     m_base_address = VirtualAddress { reservation };
 

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -452,10 +452,10 @@ static void format_getrandom(FormattedSyscallBuilder& builder, void* buffer, siz
     builder.add_arguments(buffer, size, flags);
 }
 
-static void format_realpath(FormattedSyscallBuilder& builder, Syscall::SC_realpath_params* params_p)
+static void format_realpath(FormattedSyscallBuilder& builder, Syscall::SC_realpath_params* params_p, size_t length)
 {
     auto params = copy_from_process(params_p).release_value_but_fixme_should_propagate_errors();
-    builder.add_arguments(StringArgument { params.path }, StringArgument { { params.buffer.data, params.buffer.size } });
+    builder.add_arguments(StringArgument { params.path }, StringArgument { { params.buffer.data, min(params.buffer.size, length) } });
 }
 
 static void format_exit(FormattedSyscallBuilder& builder, int status)
@@ -748,7 +748,7 @@ static void format_syscall(FormattedSyscallBuilder& builder, Syscall::Function s
         result_type = Ssize;
         break;
     case SC_realpath:
-        format_realpath(builder, (Syscall::SC_realpath_params*)arg1);
+        format_realpath(builder, (Syscall::SC_realpath_params*)arg1, (size_t)res);
         break;
     case SC_recvmsg:
         format_recvmsg(builder, (int)arg1, (struct msghdr*)arg2, (int)arg3);

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -634,7 +634,8 @@ static void format_recvmsg(FormattedSyscallBuilder& builder, int socket, struct 
 struct MmapFlags : BitflagBase {
     static constexpr auto options = {
         BITFLAG(MAP_SHARED), BITFLAG(MAP_PRIVATE), BITFLAG(MAP_FIXED), BITFLAG(MAP_ANONYMOUS),
-        BITFLAG(MAP_RANDOMIZED), BITFLAG(MAP_STACK), BITFLAG(MAP_NORESERVE), BITFLAG(MAP_PURGEABLE)
+        BITFLAG(MAP_RANDOMIZED), BITFLAG(MAP_STACK), BITFLAG(MAP_NORESERVE), BITFLAG(MAP_PURGEABLE),
+        BITFLAG(MAP_FIXED_NOREPLACE)
     };
     static constexpr StringView default_ = "MAP_FILE";
 };


### PR DESCRIPTION
This PR makes the following small tweaks:
- Changes UserspaceEmulator to match the Kernel's new `MAP_FIXED` behavior.
- Adds `MAP_FIXED_NOREPLACE`, which makes fixed memory mappings safer and will improve the Wine port's performance.
- Changes `SC_mmap_params` and `SC_mremap_params` to hold their address parameter as a `void*`.
- Makes `strace` format `mmap()`'s address argument in hex.
- Adds a drive-by fix for an out-of-bounds read in `strace`  when processing `realpath()` syscalls.