### PR TITLE
LibJS: Avoid crashing when the Unicode data generators are disabled

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -135,13 +135,16 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
 
     // 19. Let calendar be r.[[ca]].
     // 20. Set dateTimeFormat.[[Calendar]] to calendar.
-    date_time_format.set_calendar(result.ca.release_value());
+    if (result.ca.has_value())
+        date_time_format.set_calendar(result.ca.release_value());
 
     // 21. Set dateTimeFormat.[[HourCycle]] to r.[[hc]].
-    date_time_format.set_hour_cycle(result.hc.release_value());
+    if (result.hc.has_value())
+        date_time_format.set_hour_cycle(result.hc.release_value());
 
     // 22. Set dateTimeFormat.[[NumberingSystem]] to r.[[nu]].
-    date_time_format.set_numbering_system(result.nu.release_value());
+    if (result.nu.has_value())
+        date_time_format.set_numbering_system(result.nu.release_value());
 
     // 23. Let dataLocale be r.[[dataLocale]].
     auto data_locale = move(result.data_locale);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -437,7 +437,8 @@ ThrowCompletionOr<NumberFormat*> initialize_number_format(GlobalObject& global_o
     number_format.set_data_locale(move(result.data_locale));
 
     // 13. Set numberFormat.[[NumberingSystem]] to r.[[nu]].
-    number_format.set_numbering_system(result.nu.release_value());
+    if (result.nu.has_value())
+        number_format.set_numbering_system(result.nu.release_value());
 
     // 14. Perform ? SetNumberFormatUnitOptions(numberFormat, options).
     TRY(set_number_format_unit_options(global_object, number_format, *options));


### PR DESCRIPTION
The general idea when ENABLE_UNICODE_DATABASE_DOWNLOAD is OFF has been
that the Intl APIs will provide obviously incorrect results, but should
not crash. This regressed a bit with NumberFormat and DateTimeFormat.