### PR TITLE
LibGUI: Draw focus rect inside check box when it has no text

### DIFF
--- a/Userland/Libraries/LibGUI/CheckBox.cpp
+++ b/Userland/Libraries/LibGUI/CheckBox.cpp
@@ -37,12 +37,6 @@ void CheckBox::paint_event(PaintEvent& event)
     Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
-    auto text_rect = rect();
-    text_rect.set_left(s_box_width + s_horizontal_padding);
-    text_rect.set_width(font().width(text()));
-    text_rect.set_top(height() / 2 - font().glyph_height() / 2);
-    text_rect.set_height(font().glyph_height());
-
     if (fill_with_background_color())
         painter.fill_rect(rect(), palette().window());
 
@@ -55,6 +49,18 @@ void CheckBox::paint_event(PaintEvent& event)
     };
 
     Gfx::StylePainter::paint_check_box(painter, box_rect, palette(), is_enabled(), is_checked(), is_being_pressed());
+
+    if (text().is_empty()) {
+        if (is_focused())
+            painter.draw_focus_rect(box_rect.shrunken(4, 4), palette().focus_outline());
+        return;
+    }
+
+    auto text_rect = rect();
+    text_rect.set_left(s_box_width + s_horizontal_padding);
+    text_rect.set_width(font().width(text()));
+    text_rect.set_top(height() / 2 - font().glyph_height() / 2);
+    text_rect.set_height(font().glyph_height());
 
     paint_text(painter, text_rect, font(), Gfx::TextAlignment::TopLeft);
 


### PR DESCRIPTION
Noticed this while playing around with BrowserSettings, looked a bit awkward:
![before](https://user-images.githubusercontent.com/5600524/147108868-fddc11c1-e822-46b2-8595-7bd62386292a.png)
