### PR TITLE
Kernel: Make msync return EINVAL when regions are too large

### DIFF
--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -31,10 +31,8 @@ constexpr bool page_round_up_would_wrap(FlatPtr x)
 
 constexpr FlatPtr page_round_up(FlatPtr x)
 {
-    FlatPtr rounded = (((FlatPtr)(x)) + PAGE_SIZE - 1) & (~(PAGE_SIZE - 1));
-    // Rounding up >0xfffff000 wraps back to 0. That's never what we want.
-    VERIFY(x == 0 || rounded != 0);
-    return rounded;
+    VERIFY(!page_round_up_would_wrap(x));
+    return (((FlatPtr)(x)) + PAGE_SIZE - 1) & (~(PAGE_SIZE - 1));
 }
 
 constexpr FlatPtr page_round_down(FlatPtr x)

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -587,6 +587,10 @@ ErrorOr<FlatPtr> Process::sys$msync(Userspace<void*> address, size_t size, int f
     if (address.ptr() % PAGE_SIZE != 0)
         return EINVAL;
 
+    if (Memory::page_round_up_would_wrap(size)) {
+        return EINVAL;
+    }
+
     // Note: This is not specified
     size = Memory::page_round_up(size);
 


### PR DESCRIPTION
As a small cleanup, this also makes `page_round_up` verify its precondition with `page_round_up_would_wrap` (which callers are expected to call), rather than having its own logic.

Fixes #11297.