### PR TITLE
LibJS: Bring console.foo() methods to spec, and implement more of them

### DIFF
--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -111,6 +111,12 @@ void ConsoleWidget::handle_console_messages(i32 start_index, const Vector<String
             print_html(message);
         } else if (type == "clear") {
             clear_output();
+        } else if (type == "group") {
+            begin_group(message, true);
+        } else if (type == "groupCollapsed") {
+            begin_group(message, false);
+        } else if (type == "groupEnd") {
+            end_group();
         } else {
             VERIFY_NOT_REACHED();
         }
@@ -138,24 +144,83 @@ void ConsoleWidget::print_source_line(StringView source)
 void ConsoleWidget::print_html(StringView line)
 {
     StringBuilder builder;
+
+    int parent_id = m_group_stack.is_empty() ? 0 : m_group_stack.last().id;
+    if (parent_id == 0) {
+        builder.append(R"~~~(
+        var parentGroup = document.body;
+)~~~");
+    } else {
+        builder.appendff(R"~~~(
+        var parentGroup = document.getElementById("group_{}");
+)~~~",
+            parent_id);
+    }
+
     builder.append(R"~~~(
         var p = document.createElement("p");
         p.innerHTML = ")~~~");
     builder.append_escaped_for_json(line);
     builder.append(R"~~~("
-        document.body.appendChild(p);
+        parentGroup.appendChild(p);
 )~~~");
     m_output_view->run_javascript(builder.string_view());
     // FIXME: Make it scroll to the bottom, using `window.scrollTo()` in the JS above.
     //        We used to call `m_output_view->scroll_to_bottom();` here, but that does not work because
     //        it runs synchronously, meaning it happens before the HTML is output via IPC above.
+    //        (See also: begin_group())
 }
 
 void ConsoleWidget::clear_output()
 {
+    m_group_stack.clear();
     m_output_view->run_javascript(R"~~~(
         document.body.innerHTML = "";
     )~~~");
+}
+
+void ConsoleWidget::begin_group(StringView label, bool start_expanded)
+{
+    StringBuilder builder;
+    int parent_id = m_group_stack.is_empty() ? 0 : m_group_stack.last().id;
+    if (parent_id == 0) {
+        builder.append(R"~~~(
+        var parentGroup = document.body;
+)~~~");
+    } else {
+        builder.appendff(R"~~~(
+        var parentGroup = document.getElementById("group_{}");
+)~~~",
+            parent_id);
+    }
+
+    Group group;
+    group.id = m_next_group_id++;
+    group.label = label;
+
+    builder.appendff(R"~~~(
+        var group = document.createElement("details");
+        group.id = "group_{}";
+        var label = document.createElement("summary");
+        label.innerText = ")~~~",
+        group.id);
+    builder.append_escaped_for_json(label);
+    builder.append(R"~~~(";
+        group.appendChild(label);
+        parentGroup.appendChild(group);
+)~~~");
+
+    if (start_expanded)
+        builder.append("group.open = true;");
+
+    m_output_view->run_javascript(builder.string_view());
+    // FIXME: Scroll console to bottom - see note in print_html()
+    m_group_stack.append(group);
+}
+
+void ConsoleWidget::end_group()
+{
+    m_group_stack.take_last();
 }
 
 void ConsoleWidget::reset()

--- a/Userland/Applications/Browser/ConsoleWidget.h
+++ b/Userland/Applications/Browser/ConsoleWidget.h
@@ -33,6 +33,8 @@ private:
 
     void request_console_messages();
     void clear_output();
+    void begin_group(StringView label, bool start_expanded);
+    void end_group();
 
     RefPtr<GUI::TextBox> m_input;
     RefPtr<Web::OutOfProcessWebView> m_output_view;
@@ -40,6 +42,13 @@ private:
     i32 m_highest_notified_message_index { -1 };
     i32 m_highest_received_message_index { -1 };
     bool m_waiting_for_messages { false };
+
+    struct Group {
+        int id { 0 };
+        String label;
+    };
+    Vector<Group> m_group_stack;
+    int m_next_group_id { 1 };
 };
 
 }

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -76,10 +76,14 @@ ThrowCompletionOr<Value> Console::warn()
     return js_undefined();
 }
 
+// 1.1.2. clear(), https://console.spec.whatwg.org/#clear
 Value Console::clear()
 {
+    // 1. TODO: Empty the appropriate group stack.
+
+    // 2. If possible for the environment, clear the console. (Otherwise, do nothing.)
     if (m_client)
-        return m_client->clear();
+        m_client->clear();
     return js_undefined();
 }
 

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Emanuele Torre <torreemanuele6@gmail.com>
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,53 +21,58 @@ VM& Console::vm()
     return m_global_object.vm();
 }
 
-Value Console::debug()
+// 1.1.3. debug(...data), https://console.spec.whatwg.org/#debug
+ThrowCompletionOr<Value> Console::debug()
 {
-#ifdef __serenity__
-    dbgln("\033[32;1m(js debug)\033[0m {}", vm().join_arguments());
-#endif
-    if (m_client)
-        return m_client->debug();
+    // 1. Perform Logger("debug", data).
+    if (m_client) {
+        auto data = vm_arguments();
+        return m_client->logger(LogLevel::Debug, data);
+    }
     return js_undefined();
 }
 
-Value Console::error()
+// 1.1.4. error(...data), https://console.spec.whatwg.org/#error
+ThrowCompletionOr<Value> Console::error()
 {
-#ifdef __serenity__
-    dbgln("\033[32;1m(js error)\033[0m {}", vm().join_arguments());
-#endif
-    if (m_client)
-        return m_client->error();
+    // 1. Perform Logger("error", data).
+    if (m_client) {
+        auto data = vm_arguments();
+        return m_client->logger(LogLevel::Error, data);
+    }
     return js_undefined();
 }
 
-Value Console::info()
+// 1.1.5. info(...data), https://console.spec.whatwg.org/#info
+ThrowCompletionOr<Value> Console::info()
 {
-#ifdef __serenity__
-    dbgln("\033[32;1m(js info)\033[0m {}", vm().join_arguments());
-#endif
-    if (m_client)
-        return m_client->info();
+    // 1. Perform Logger("info", data).
+    if (m_client) {
+        auto data = vm_arguments();
+        return m_client->logger(LogLevel::Info, data);
+    }
     return js_undefined();
 }
 
-Value Console::log()
+// 1.1.6. log(...data), https://console.spec.whatwg.org/#log
+ThrowCompletionOr<Value> Console::log()
 {
-#ifdef __serenity__
-    dbgln("\033[32;1m(js log)\033[0m {}", vm().join_arguments());
-#endif
-    if (m_client)
-        return m_client->log();
+    // 1. Perform Logger("log", data).
+    if (m_client) {
+        auto data = vm_arguments();
+        return m_client->logger(LogLevel::Log, data);
+    }
     return js_undefined();
 }
 
-Value Console::warn()
+// 1.1.9. warn(...data), https://console.spec.whatwg.org/#warn
+ThrowCompletionOr<Value> Console::warn()
 {
-#ifdef __serenity__
-    dbgln("\033[32;1m(js warn)\033[0m {}", vm().join_arguments());
-#endif
-    if (m_client)
-        return m_client->warn();
+    // 1. Perform Logger("warn", data).
+    if (m_client) {
+        auto data = vm_arguments();
+        return m_client->logger(LogLevel::Warn, data);
+    }
     return js_undefined();
 }
 
@@ -127,6 +133,42 @@ bool Console::counter_reset(String label)
     return true;
 }
 
+Vector<Value> Console::vm_arguments()
+{
+    Vector<Value> arguments;
+    arguments.ensure_capacity(vm().argument_count());
+    for (size_t i = 0; i < vm().argument_count(); ++i) {
+        arguments.append(vm().argument(i));
+    }
+    return arguments;
+}
+
+void Console::output_debug_message([[maybe_unused]] LogLevel log_level, [[maybe_unused]] String output) const
+{
+#ifdef __serenity__
+    switch (log_level) {
+    case JS::Console::LogLevel::Debug:
+        dbgln("\033[32;1m(js debug)\033[0m {}", output);
+        break;
+    case JS::Console::LogLevel::Error:
+        dbgln("\033[32;1m(js error)\033[0m {}", output);
+        break;
+    case JS::Console::LogLevel::Info:
+        dbgln("\033[32;1m(js info)\033[0m {}", output);
+        break;
+    case JS::Console::LogLevel::Log:
+        dbgln("\033[32;1m(js log)\033[0m {}", output);
+        break;
+    case JS::Console::LogLevel::Warn:
+        dbgln("\033[32;1m(js warn)\033[0m {}", output);
+        break;
+    default:
+        dbgln("\033[32;1m(js)\033[0m {}", output);
+        break;
+    }
+#endif
+}
+
 VM& ConsoleClient::vm()
 {
     return global_object().vm();
@@ -140,6 +182,47 @@ Vector<String> ConsoleClient::get_trace() const
     for (ssize_t i = execution_context_stack.size() - 2; i >= 0; --i)
         trace.append(execution_context_stack[i]->function_name);
     return trace;
+}
+
+// 2.1. Logger(logLevel, args), https://console.spec.whatwg.org/#logger
+ThrowCompletionOr<Value> ConsoleClient::logger(Console::LogLevel log_level, Vector<Value>& args)
+{
+    auto& global_object = this->global_object();
+
+    // 1. If args is empty, return.
+    if (args.is_empty())
+        return js_undefined();
+
+    // 2. Let first be args[0].
+    auto first = args[0];
+
+    // 3. Let rest be all elements following first in args.
+    size_t rest_size = args.size() - 1;
+
+    // 4. If rest is empty, perform Printer(logLevel, « first ») and return.
+    if (rest_size == 0) {
+        auto first_as_vector = Vector { first };
+        return printer(log_level, first_as_vector);
+    }
+
+    // 5. If first does not contain any format specifiers, perform Printer(logLevel, args).
+    if (!TRY(first.to_string(global_object)).contains('%')) {
+        TRY(printer(log_level, args));
+    } else {
+        // 6. Otherwise, perform Printer(logLevel, Formatter(args)).
+        auto formatted = TRY(formatter(args));
+        TRY(printer(log_level, formatted));
+    }
+
+    // 7. Return undefined.
+    return js_undefined();
+}
+
+// 2.2. Formatter(args), https://console.spec.whatwg.org/#formatter
+ThrowCompletionOr<Vector<Value>> ConsoleClient::formatter(Vector<Value>& args)
+{
+    // TODO: Actually implement formatting
+    return args;
 }
 
 }

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -87,7 +87,7 @@ public:
     ThrowCompletionOr<Vector<Value>> formatter(Vector<Value>& args);
     virtual ThrowCompletionOr<Value> printer(Console::LogLevel log_level, Vector<Value>&) = 0;
 
-    virtual Value clear() = 0;
+    virtual void clear() = 0;
     virtual Value trace() = 0;
     virtual Value assert_() = 0;
 

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -65,7 +65,7 @@ public:
     Value trace();
     ThrowCompletionOr<Value> count();
     ThrowCompletionOr<Value> count_reset();
-    Value assert_();
+    ThrowCompletionOr<Value> assert_();
 
     void output_debug_message(LogLevel log_level, String output) const;
 
@@ -89,7 +89,6 @@ public:
 
     virtual void clear() = 0;
     virtual Value trace() = 0;
-    virtual Value assert_() = 0;
 
 protected:
     virtual ~ConsoleClient() = default;

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -63,12 +63,9 @@ public:
     ThrowCompletionOr<Value> warn();
     Value clear();
     Value trace();
-    Value count();
-    Value count_reset();
+    ThrowCompletionOr<Value> count();
+    ThrowCompletionOr<Value> count_reset();
     Value assert_();
-
-    unsigned counter_increment(String label);
-    bool counter_reset(String label);
 
     void output_debug_message(LogLevel log_level, String output) const;
 
@@ -92,8 +89,6 @@ public:
 
     virtual Value clear() = 0;
     virtual Value trace() = 0;
-    virtual Value count() = 0;
-    virtual Value count_reset() = 0;
     virtual Value assert_() = 0;
 
 protected:

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -11,6 +11,7 @@
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/Vector.h>
+#include <LibCore/ElapsedTimer.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Runtime/Value.h>
 
@@ -78,17 +79,21 @@ public:
     ThrowCompletionOr<Value> group();
     ThrowCompletionOr<Value> group_collapsed();
     ThrowCompletionOr<Value> group_end();
+    ThrowCompletionOr<Value> time();
+    ThrowCompletionOr<Value> time_log();
+    ThrowCompletionOr<Value> time_end();
 
     void output_debug_message(LogLevel log_level, String output) const;
 
 private:
     ThrowCompletionOr<String> value_vector_to_string(Vector<Value>&);
+    ThrowCompletionOr<String> format_time_since(Core::ElapsedTimer timer);
 
     GlobalObject& m_global_object;
     ConsoleClient* m_client { nullptr };
 
     HashMap<String, unsigned> m_counters;
-
+    HashMap<String, Core::ElapsedTimer> m_timer_table;
     Vector<Group> m_group_stack;
 };
 

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -43,6 +43,10 @@ public:
         Warn,
     };
 
+    struct Group {
+        String label;
+    };
+
     struct Trace {
         String label;
         Vector<String> stack;
@@ -71,14 +75,21 @@ public:
     ThrowCompletionOr<Value> count();
     ThrowCompletionOr<Value> count_reset();
     ThrowCompletionOr<Value> assert_();
+    ThrowCompletionOr<Value> group();
+    ThrowCompletionOr<Value> group_collapsed();
+    ThrowCompletionOr<Value> group_end();
 
     void output_debug_message(LogLevel log_level, String output) const;
 
 private:
+    ThrowCompletionOr<String> value_vector_to_string(Vector<Value>&);
+
     GlobalObject& m_global_object;
     ConsoleClient* m_client { nullptr };
 
     HashMap<String, unsigned> m_counters;
+
+    Vector<Group> m_group_stack;
 };
 
 class ConsoleClient {
@@ -88,11 +99,14 @@ public:
     {
     }
 
+    using PrinterArguments = Variant<Console::Group, Console::Trace, Vector<Value>>;
+
     ThrowCompletionOr<Value> logger(Console::LogLevel log_level, Vector<Value>& args);
     ThrowCompletionOr<Vector<Value>> formatter(Vector<Value>& args);
-    virtual ThrowCompletionOr<Value> printer(Console::LogLevel log_level, Variant<Vector<Value>, Console::Trace>) = 0;
+    virtual ThrowCompletionOr<Value> printer(Console::LogLevel log_level, PrinterArguments) = 0;
 
     virtual void clear() = 0;
+    virtual void end_group() = 0;
 
 protected:
     virtual ~ConsoleClient() = default;

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Emanuele Torre <torreemanuele6@gmail.com>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,17 +10,39 @@
 #include <AK/Function.h>
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
+#include <AK/Vector.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Runtime/Value.h>
 
 namespace JS {
 
 class ConsoleClient;
 
+// https://console.spec.whatwg.org
 class Console {
     AK_MAKE_NONCOPYABLE(Console);
     AK_MAKE_NONMOVABLE(Console);
 
 public:
+    // These are not really levels, but that's the term used in the spec.
+    enum class LogLevel {
+        Assert,
+        Count,
+        CountReset,
+        Debug,
+        Dir,
+        DirXML,
+        Error,
+        Group,
+        GroupCollapsed,
+        Info,
+        Log,
+        TimeEnd,
+        TimeLog,
+        Trace,
+        Warn,
+    };
+
     explicit Console(GlobalObject&);
 
     void set_client(ConsoleClient& client) { m_client = &client; }
@@ -28,15 +51,16 @@ public:
     const GlobalObject& global_object() const { return m_global_object; }
 
     VM& vm();
+    Vector<Value> vm_arguments();
 
     HashMap<String, unsigned>& counters() { return m_counters; }
     const HashMap<String, unsigned>& counters() const { return m_counters; }
 
-    Value debug();
-    Value error();
-    Value info();
-    Value log();
-    Value warn();
+    ThrowCompletionOr<Value> debug();
+    ThrowCompletionOr<Value> error();
+    ThrowCompletionOr<Value> info();
+    ThrowCompletionOr<Value> log();
+    ThrowCompletionOr<Value> warn();
     Value clear();
     Value trace();
     Value count();
@@ -45,6 +69,8 @@ public:
 
     unsigned counter_increment(String label);
     bool counter_reset(String label);
+
+    void output_debug_message(LogLevel log_level, String output) const;
 
 private:
     GlobalObject& m_global_object;
@@ -60,11 +86,10 @@ public:
     {
     }
 
-    virtual Value debug() = 0;
-    virtual Value error() = 0;
-    virtual Value info() = 0;
-    virtual Value log() = 0;
-    virtual Value warn() = 0;
+    ThrowCompletionOr<Value> logger(Console::LogLevel log_level, Vector<Value>& args);
+    ThrowCompletionOr<Vector<Value>> formatter(Vector<Value>& args);
+    virtual ThrowCompletionOr<Value> printer(Console::LogLevel log_level, Vector<Value>&) = 0;
+
     virtual Value clear() = 0;
     virtual Value trace() = 0;
     virtual Value count() = 0;

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -43,6 +43,11 @@ public:
         Warn,
     };
 
+    struct Trace {
+        String label;
+        Vector<String> stack;
+    };
+
     explicit Console(GlobalObject&);
 
     void set_client(ConsoleClient& client) { m_client = &client; }
@@ -62,7 +67,7 @@ public:
     ThrowCompletionOr<Value> log();
     ThrowCompletionOr<Value> warn();
     Value clear();
-    Value trace();
+    ThrowCompletionOr<Value> trace();
     ThrowCompletionOr<Value> count();
     ThrowCompletionOr<Value> count_reset();
     ThrowCompletionOr<Value> assert_();
@@ -85,10 +90,9 @@ public:
 
     ThrowCompletionOr<Value> logger(Console::LogLevel log_level, Vector<Value>& args);
     ThrowCompletionOr<Vector<Value>> formatter(Vector<Value>& args);
-    virtual ThrowCompletionOr<Value> printer(Console::LogLevel log_level, Vector<Value>&) = 0;
+    virtual ThrowCompletionOr<Value> printer(Console::LogLevel log_level, Variant<Vector<Value>, Console::Trace>) = 0;
 
     virtual void clear() = 0;
-    virtual Value trace() = 0;
 
 protected:
     virtual ~ConsoleClient() = default;
@@ -97,8 +101,6 @@ protected:
 
     GlobalObject& global_object() { return m_console.global_object(); }
     const GlobalObject& global_object() const { return m_console.global_object(); }
-
-    Vector<String> get_trace() const;
 
     Console& m_console;
 };

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -240,6 +240,9 @@ namespace JS {
     P(getYear)                               \
     P(global)                                \
     P(globalThis)                            \
+    P(group)                                 \
+    P(groupCollapsed)                        \
+    P(groupEnd)                              \
     P(groups)                                \
     P(has)                                   \
     P(hasIndices)                            \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -445,6 +445,9 @@ namespace JS {
     P(tanh)                                  \
     P(test)                                  \
     P(then)                                  \
+    P(time)                                  \
+    P(timeEnd)                               \
+    P(timeLog)                               \
     P(timeStyle)                             \
     P(timeZone)                              \
     P(timeZoneName)                          \

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -32,6 +32,9 @@ void ConsoleObject::initialize(GlobalObject& global_object)
     define_native_function(vm.names.countReset, count_reset, 0, attr);
     define_native_function(vm.names.clear, clear, 0, attr);
     define_native_function(vm.names.assert, assert_, 0, attr);
+    define_native_function(vm.names.group, group, 0, attr);
+    define_native_function(vm.names.groupCollapsed, group_collapsed, 0, attr);
+    define_native_function(vm.names.groupEnd, group_end, 0, attr);
 }
 
 ConsoleObject::~ConsoleObject()
@@ -96,6 +99,24 @@ JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::clear)
 JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::assert_)
 {
     return global_object.console().assert_();
+}
+
+// 1.3.1. group(...data), https://console.spec.whatwg.org/#group
+JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::group)
+{
+    return global_object.console().group();
+}
+
+// 1.3.2. groupCollapsed(...data), https://console.spec.whatwg.org/#groupcollapsed
+JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::group_collapsed)
+{
+    return global_object.console().group_collapsed();
+}
+
+// 1.3.3. groupEnd(), https://console.spec.whatwg.org/#groupend
+JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::group_end)
+{
+    return global_object.console().group_end();
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -35,6 +35,9 @@ void ConsoleObject::initialize(GlobalObject& global_object)
     define_native_function(vm.names.group, group, 0, attr);
     define_native_function(vm.names.groupCollapsed, group_collapsed, 0, attr);
     define_native_function(vm.names.groupEnd, group_end, 0, attr);
+    define_native_function(vm.names.time, time, 0, attr);
+    define_native_function(vm.names.timeLog, time_log, 0, attr);
+    define_native_function(vm.names.timeEnd, time_end, 0, attr);
 }
 
 ConsoleObject::~ConsoleObject()
@@ -117,6 +120,24 @@ JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::group_collapsed)
 JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::group_end)
 {
     return global_object.console().group_end();
+}
+
+// 1.4.1. time(label), https://console.spec.whatwg.org/#time
+JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::time)
+{
+    return global_object.console().time();
+}
+
+// 1.4.2. timeLog(label, ...data), https://console.spec.whatwg.org/#timelog
+JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::time_log)
+{
+    return global_object.console().time_log();
+}
+
+// 1.4.3. timeEnd(label), https://console.spec.whatwg.org/#timeend
+JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::time_end)
+{
+    return global_object.console().time_end();
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
@@ -32,6 +32,9 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(group);
     JS_DECLARE_NATIVE_FUNCTION(group_collapsed);
     JS_DECLARE_NATIVE_FUNCTION(group_end);
+    JS_DECLARE_NATIVE_FUNCTION(time);
+    JS_DECLARE_NATIVE_FUNCTION(time_log);
+    JS_DECLARE_NATIVE_FUNCTION(time_end);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
@@ -29,6 +29,9 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(count_reset);
     JS_DECLARE_NATIVE_FUNCTION(clear);
     JS_DECLARE_NATIVE_FUNCTION(assert_);
+    JS_DECLARE_NATIVE_FUNCTION(group);
+    JS_DECLARE_NATIVE_FUNCTION(group_collapsed);
+    JS_DECLARE_NATIVE_FUNCTION(group_end);
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -233,3 +233,13 @@ input[type=text] {
 option {
     display: none;
 }
+
+details {
+    display: block;
+    padding-left: 1em;
+}
+
+summary {
+    display: block;
+    font-weight: bold;
+}

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -134,27 +134,6 @@ JS::Value WebContentConsoleClient::trace()
     return JS::js_undefined();
 }
 
-JS::Value WebContentConsoleClient::assert_()
-{
-    auto& vm = this->vm();
-    if (!vm.argument(0).to_boolean()) {
-        StringBuilder html;
-        if (vm.argument_count() > 1) {
-            html.append("<span class=\"error\">");
-            html.append("Assertion failed:");
-            html.append("</span>");
-            html.append(" ");
-            html.append(escape_html_entities(vm.join_arguments(1)));
-        } else {
-            html.append("<span class=\"error\">");
-            html.append("Assertion failed");
-            html.append("</span>");
-        }
-        print_html(html.string_view());
-    }
-    return JS::js_undefined();
-}
-
 // 2.3. Printer(logLevel, args[, options]), https://console.spec.whatwg.org/#printer
 JS::ThrowCompletionOr<JS::Value> WebContentConsoleClient::printer(JS::Console::LogLevel log_level, Vector<JS::Value>& arguments)
 {
@@ -189,5 +168,4 @@ JS::ThrowCompletionOr<JS::Value> WebContentConsoleClient::printer(JS::Console::L
     print_html(html.string_view());
     return JS::js_undefined();
 }
-
 }

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -115,56 +115,6 @@ void WebContentConsoleClient::send_messages(i32 start_index)
     m_client.async_did_get_js_console_messages(start_index, message_types, messages);
 }
 
-JS::Value WebContentConsoleClient::log()
-{
-    print_html(escape_html_entities(vm().join_arguments()));
-    return JS::js_undefined();
-}
-
-JS::Value WebContentConsoleClient::info()
-{
-    StringBuilder html;
-    html.append("<span class=\"info\">");
-    html.append("(i) ");
-    html.append(escape_html_entities(vm().join_arguments()));
-    html.append("</span>");
-    print_html(html.string_view());
-    return JS::js_undefined();
-}
-
-JS::Value WebContentConsoleClient::debug()
-{
-    StringBuilder html;
-    html.append("<span class=\"debug\">");
-    html.append("(d) ");
-    html.append(escape_html_entities(vm().join_arguments()));
-    html.append("</span>");
-    print_html(html.string_view());
-    return JS::js_undefined();
-}
-
-JS::Value WebContentConsoleClient::warn()
-{
-    StringBuilder html;
-    html.append("<span class=\"warn\">");
-    html.append("(w) ");
-    html.append(escape_html_entities(vm().join_arguments()));
-    html.append("</span>");
-    print_html(html.string_view());
-    return JS::js_undefined();
-}
-
-JS::Value WebContentConsoleClient::error()
-{
-    StringBuilder html;
-    html.append("<span class=\"error\">");
-    html.append("(e) ");
-    html.append(escape_html_entities(vm().join_arguments()));
-    html.append("</span>");
-    print_html(html.string_view());
-    return JS::js_undefined();
-}
-
 JS::Value WebContentConsoleClient::clear()
 {
     clear_output();
@@ -222,6 +172,40 @@ JS::Value WebContentConsoleClient::assert_()
         }
         print_html(html.string_view());
     }
+    return JS::js_undefined();
+}
+
+// 2.3. Printer(logLevel, args[, options]), https://console.spec.whatwg.org/#printer
+JS::ThrowCompletionOr<JS::Value> WebContentConsoleClient::printer(JS::Console::LogLevel log_level, Vector<JS::Value>& arguments)
+{
+    auto output = String::join(" ", arguments);
+    m_console.output_debug_message(log_level, output);
+
+    StringBuilder html;
+    switch (log_level) {
+    case JS::Console::LogLevel::Debug:
+        html.append("<span class=\"debug\">(d) ");
+        break;
+    case JS::Console::LogLevel::Error:
+        html.append("<span class=\"error\">(e) ");
+        break;
+    case JS::Console::LogLevel::Info:
+        html.append("<span class=\"info\">(i) ");
+        break;
+    case JS::Console::LogLevel::Log:
+        html.append("<span class=\"log\"> ");
+        break;
+    case JS::Console::LogLevel::Warn:
+        html.append("<span class=\"warn\">(w) ");
+        break;
+    default:
+        html.append("<span>");
+        break;
+    }
+
+    html.append(escape_html_entities(output));
+    html.append("</span>");
+    print_html(html.string_view());
     return JS::js_undefined();
 }
 

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -115,10 +115,9 @@ void WebContentConsoleClient::send_messages(i32 start_index)
     m_client.async_did_get_js_console_messages(start_index, message_types, messages);
 }
 
-JS::Value WebContentConsoleClient::clear()
+void WebContentConsoleClient::clear()
 {
     clear_output();
-    return JS::js_undefined();
 }
 
 JS::Value WebContentConsoleClient::trace()

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -135,25 +135,6 @@ JS::Value WebContentConsoleClient::trace()
     return JS::js_undefined();
 }
 
-JS::Value WebContentConsoleClient::count()
-{
-    auto label = vm().argument_count() ? vm().argument(0).to_string_without_side_effects() : "default";
-    auto counter_value = m_console.counter_increment(label);
-    print_html(String::formatted("{}: {}", label, counter_value));
-    return JS::js_undefined();
-}
-
-JS::Value WebContentConsoleClient::count_reset()
-{
-    auto label = vm().argument_count() ? vm().argument(0).to_string_without_side_effects() : "default";
-    if (m_console.counter_reset(label)) {
-        print_html(String::formatted("{}: 0", label));
-    } else {
-        print_html(String::formatted("\"{}\" doesn't have a count", label));
-    }
-    return JS::js_undefined();
-}
-
 JS::Value WebContentConsoleClient::assert_()
 {
     auto& vm = this->vm();
@@ -196,6 +177,7 @@ JS::ThrowCompletionOr<JS::Value> WebContentConsoleClient::printer(JS::Console::L
         html.append("<span class=\"log\"> ");
         break;
     case JS::Console::LogLevel::Warn:
+    case JS::Console::LogLevel::CountReset:
         html.append("<span class=\"warn\">(w) ");
         break;
     default:

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -24,7 +24,7 @@ public:
     void send_messages(i32 start_index);
 
 private:
-    virtual JS::Value clear() override;
+    virtual void clear() override;
     virtual JS::Value trace() override;
     virtual JS::Value assert_() override;
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Vector<JS::Value>&) override;

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -25,8 +25,7 @@ public:
 
 private:
     virtual void clear() override;
-    virtual JS::Value trace() override;
-    virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Vector<JS::Value>&) override;
+    virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Variant<Vector<JS::Value>, JS::Console::Trace>) override;
 
     ClientConnection& m_client;
     WeakPtr<JS::Interpreter> m_interpreter;

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -25,7 +25,7 @@ public:
 
 private:
     virtual void clear() override;
-    virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Variant<Vector<JS::Value>, JS::Console::Trace>) override;
+    virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, PrinterArguments) override;
 
     ClientConnection& m_client;
     WeakPtr<JS::Interpreter> m_interpreter;
@@ -33,14 +33,19 @@ private:
 
     void clear_output();
     void print_html(String const& line);
+    void begin_group(String const& label, bool start_expanded);
+    virtual void end_group() override;
 
     struct ConsoleOutput {
         enum class Type {
             HTML,
-            Clear
+            Clear,
+            BeginGroup,
+            BeginGroupCollapsed,
+            EndGroup,
         };
         Type type;
-        String html;
+        String data;
     };
     Vector<ConsoleOutput> m_message_log;
 };

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -24,16 +24,12 @@ public:
     void send_messages(i32 start_index);
 
 private:
-    virtual JS::Value log() override;
-    virtual JS::Value info() override;
-    virtual JS::Value debug() override;
-    virtual JS::Value warn() override;
-    virtual JS::Value error() override;
     virtual JS::Value clear() override;
     virtual JS::Value trace() override;
     virtual JS::Value count() override;
     virtual JS::Value count_reset() override;
     virtual JS::Value assert_() override;
+    virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Vector<JS::Value>&) override;
 
     ClientConnection& m_client;
     WeakPtr<JS::Interpreter> m_interpreter;

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -26,8 +26,6 @@ public:
 private:
     virtual JS::Value clear() override;
     virtual JS::Value trace() override;
-    virtual JS::Value count() override;
-    virtual JS::Value count_reset() override;
     virtual JS::Value assert_() override;
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Vector<JS::Value>&) override;
 

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -26,7 +26,6 @@ public:
 private:
     virtual void clear() override;
     virtual JS::Value trace() override;
-    virtual JS::Value assert_() override;
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Vector<JS::Value>&) override;
 
     ClientConnection& m_client;

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1140,20 +1140,6 @@ public:
         return JS::js_undefined();
     }
 
-    virtual JS::Value assert_() override
-    {
-        auto& vm = this->vm();
-        if (!vm.argument(0).to_boolean()) {
-            if (vm.argument_count() > 1) {
-                js_out("\033[31;1mAssertion failed:\033[0m");
-                js_outln(" {}", vm.join_arguments(1));
-            } else {
-                js_outln("\033[31;1mAssertion failed\033[0m");
-            }
-        }
-        return JS::js_undefined();
-    }
-
     virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Vector<JS::Value>& arguments) override
     {
         auto output = String::join(" ", arguments);
@@ -1164,6 +1150,7 @@ public:
             js_outln("\033[36;1m{}\033[0m", output);
             break;
         case JS::Console::LogLevel::Error:
+        case JS::Console::LogLevel::Assert:
             js_outln("\033[31;1m{}\033[0m", output);
             break;
         case JS::Console::LogLevel::Info:

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1122,11 +1122,10 @@ public:
     {
     }
 
-    virtual JS::Value clear() override
+    virtual void clear() override
     {
         js_out("\033[3J\033[H\033[2J");
         fflush(stdout);
-        return JS::js_undefined();
     }
 
     virtual JS::Value trace() override

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1122,36 +1122,6 @@ public:
     {
     }
 
-    virtual JS::Value log() override
-    {
-        js_outln("{}", vm().join_arguments());
-        return JS::js_undefined();
-    }
-
-    virtual JS::Value info() override
-    {
-        js_outln("(i) {}", vm().join_arguments());
-        return JS::js_undefined();
-    }
-
-    virtual JS::Value debug() override
-    {
-        js_outln("\033[36;1m{}\033[0m", vm().join_arguments());
-        return JS::js_undefined();
-    }
-
-    virtual JS::Value warn() override
-    {
-        js_outln("\033[33;1m{}\033[0m", vm().join_arguments());
-        return JS::js_undefined();
-    }
-
-    virtual JS::Value error() override
-    {
-        js_outln("\033[31;1m{}\033[0m", vm().join_arguments());
-        return JS::js_undefined();
-    }
-
     virtual JS::Value clear() override
     {
         js_out("\033[3J\033[H\033[2J");
@@ -1199,6 +1169,34 @@ public:
             } else {
                 js_outln("\033[31;1mAssertion failed\033[0m");
             }
+        }
+        return JS::js_undefined();
+    }
+
+    virtual JS::ThrowCompletionOr<JS::Value> printer(JS::Console::LogLevel log_level, Vector<JS::Value>& arguments) override
+    {
+        auto output = String::join(" ", arguments);
+        m_console.output_debug_message(log_level, output);
+
+        switch (log_level) {
+        case JS::Console::LogLevel::Debug:
+            js_outln("\033[36;1m{}\033[0m", output);
+            break;
+        case JS::Console::LogLevel::Error:
+            js_outln("\033[31;1m{}\033[0m", output);
+            break;
+        case JS::Console::LogLevel::Info:
+            js_outln("(i) {}", output);
+            break;
+        case JS::Console::LogLevel::Log:
+            js_outln("{}", output);
+            break;
+        case JS::Console::LogLevel::Warn:
+            js_outln("\033[33;1m{}\033[0m", output);
+            break;
+        default:
+            js_outln("{}", output);
+            break;
         }
         return JS::js_undefined();
     }

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1141,24 +1141,6 @@ public:
         return JS::js_undefined();
     }
 
-    virtual JS::Value count() override
-    {
-        auto label = vm().argument_count() ? vm().argument(0).to_string_without_side_effects() : "default";
-        auto counter_value = m_console.counter_increment(label);
-        js_outln("{}: {}", label, counter_value);
-        return JS::js_undefined();
-    }
-
-    virtual JS::Value count_reset() override
-    {
-        auto label = vm().argument_count() ? vm().argument(0).to_string_without_side_effects() : "default";
-        if (m_console.counter_reset(label))
-            js_outln("{}: 0", label);
-        else
-            js_outln("\033[33;1m\"{}\" doesn't have a count\033[0m", label);
-        return JS::js_undefined();
-    }
-
     virtual JS::Value assert_() override
     {
         auto& vm = this->vm();
@@ -1192,6 +1174,7 @@ public:
             js_outln("{}", output);
             break;
         case JS::Console::LogLevel::Warn:
+        case JS::Console::LogLevel::CountReset:
             js_outln("\033[33;1m{}\033[0m", output);
             break;
         default:


### PR DESCRIPTION
### Spec compliance!
`console.log()`, `console.debug()`, `console.info()`, `console.warn()`, `console.error()`, `console.assert()`, `console.trace()`, `console.count()`, and `console.countReset()` are all now to spec, using the *Logger*, *Formatter* and *Printer* abstract operations.

However, *Formatter* is just stubbed out for now since the spec has some issues: https://github.com/whatwg/console/issues/204

### New stuff!
- **Group things with console.group(), console.groupCollapsed() and console.groupEnd().** This is implemented with `<details>` in the Browser, which does not yet support closing; and with indentation in the REPL, which looks funky but it's how Node does it so it's probably fine. :^)
- **Time things with console.time(), console.timeLog() and console.timeEnd().** This uses some Temporal code for the duration calculation, but the formatting code is manual. Probably there's some way to hook into Temporal's formatter for that.

### Refactoring!
This also reduces the amount duplicated code between the Browser and REPL consoles. Currently they only have to implement `clear()`, the `Formatter` algorithm, and an `end_group()` callback.

### Incomplete stuff
Apart from *Formatter*, we're still missing:
- `console.table()`, which lacks a spec algorithm
- `console.dir()`
- `console.dirxml()`

I had a go at implementing these but just got myself confused. I think I need a break from this for a bit. :sweat_smile: 