### PR TITLE
LibC: Implement _setjmp and _longjmp

### DIFF
--- a/Userland/Libraries/LibC/arch/i386/setjmp.S
+++ b/Userland/Libraries/LibC/arch/i386/setjmp.S
@@ -14,7 +14,9 @@
     mov (%esp), %ebx
     ret
 
+.global _setjmp
 .global setjmp
+_setjmp:
 setjmp:
     xor %eax, %eax          // Grab val argument (hardcoded to zero)
     jmp .Lsigset_common
@@ -57,7 +59,9 @@ sigsetjmp:
     xor %eax, %eax
     ret
 
+.global _longjmp
 .global longjmp
+_longjmp:
 longjmp:
     mov 4(%esp), %ecx       // Grab jmp_buf argument
     mov 8(%esp), %eax       // Grab val argument

--- a/Userland/Libraries/LibC/setjmp.h
+++ b/Userland/Libraries/LibC/setjmp.h
@@ -79,4 +79,16 @@ __attribute__((noreturn)) void longjmp(jmp_buf, int val);
 int sigsetjmp(sigjmp_buf, int savesigs);
 __attribute__((noreturn)) void siglongjmp(sigjmp_buf, int val);
 
+/**
+ * _setjmp() and _longjmp() are specified as behaving the exactly the same as
+ * setjmp() and longjmp(), except they are not supposed to modify the signal mask.
+ *
+ * Our implementations already follow this restriction, so we just map them directly
+ * to the same functions.
+ *
+ * https://pubs.opengroup.org/onlinepubs/9699969599/functions/_setjmp.html
+ */
+int _setjmp(jmp_buf);
+__attribute__((noreturn)) void _longjmp(jmp_buf, int val);
+
 __END_DECLS


### PR DESCRIPTION
These are aliases to `setjmp()` and `longjmp()` on our system,
as our implementations don't modify the signal mask.

This is required for the syzkaller executor process.

Progress towards: #1025