### PR TITLE
LibGUI: Make SortingProxyModel::create() return ErrorOr

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -132,7 +132,7 @@ void DirectoryView::handle_activation(GUI::ModelIndex const& index)
 DirectoryView::DirectoryView(Mode mode)
     : m_mode(mode)
     , m_model(GUI::FileSystemModel::create({}))
-    , m_sorting_model(GUI::SortingProxyModel::create(m_model))
+    , m_sorting_model(MUST(GUI::SortingProxyModel::create(m_model)))
 {
     set_active_widget(nullptr);
     set_grabbable_margins(2);

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -107,7 +107,7 @@ ThemeWidget::ThemeWidget()
     m_cursors_tableview->set_highlight_key_column(false);
 
     auto mouse_cursor_model = MouseCursorModel::create();
-    auto sorting_proxy_model = GUI::SortingProxyModel::create(mouse_cursor_model);
+    auto sorting_proxy_model = MUST(GUI::SortingProxyModel::create(mouse_cursor_model));
     sorting_proxy_model->set_sort_role(GUI::ModelRole::Display);
 
     m_cursors_tableview->set_model(sorting_proxy_model);

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -65,7 +65,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         net_adapters_fields.empend("bytes_in", "Bytes In", Gfx::TextAlignment::CenterRight);
         net_adapters_fields.empend("bytes_out", "Bytes Out", Gfx::TextAlignment::CenterRight);
         m_adapter_model = GUI::JsonArrayModel::create("/proc/net/adapters", move(net_adapters_fields));
-        m_adapter_table_view->set_model(GUI::SortingProxyModel::create(*m_adapter_model));
+        m_adapter_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_adapter_model)));
 
         auto& tcp_sockets_group_box = add<GUI::GroupBox>("TCP Sockets");
         tcp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();
@@ -86,7 +86,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         net_tcp_fields.empend("bytes_in", "Bytes In", Gfx::TextAlignment::CenterRight);
         net_tcp_fields.empend("bytes_out", "Bytes Out", Gfx::TextAlignment::CenterRight);
         m_tcp_socket_model = GUI::JsonArrayModel::create("/proc/net/tcp", move(net_tcp_fields));
-        m_tcp_socket_table_view->set_model(GUI::SortingProxyModel::create(*m_tcp_socket_model));
+        m_tcp_socket_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_tcp_socket_model)));
 
         auto& udp_sockets_group_box = add<GUI::GroupBox>("UDP Sockets");
         udp_sockets_group_box.set_layout<GUI::VerticalBoxLayout>();
@@ -100,7 +100,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
         net_udp_fields.empend("local_address", "Local", Gfx::TextAlignment::CenterLeft);
         net_udp_fields.empend("local_port", "Port", Gfx::TextAlignment::CenterRight);
         m_udp_socket_model = GUI::JsonArrayModel::create("/proc/net/udp", move(net_udp_fields));
-        m_udp_socket_table_view->set_model(GUI::SortingProxyModel::create(*m_udp_socket_model));
+        m_udp_socket_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_udp_socket_model)));
 
         m_update_timer = add<Core::Timer>(
             1000, [this] {

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
@@ -38,7 +38,7 @@ ProcessFileDescriptorMapWidget::ProcessFileDescriptorMapWidget()
     });
 
     m_model = GUI::JsonArrayModel::create({}, move(pid_fds_fields));
-    m_table_view->set_model(GUI::SortingProxyModel::create(*m_model));
+    m_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_model)));
 }
 
 ProcessFileDescriptorMapWidget::~ProcessFileDescriptorMapWidget()

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -99,7 +99,7 @@ ProcessMemoryMapWidget::ProcessMemoryMapWidget()
     pid_vm_fields.empend("cow_pages", "# CoW", Gfx::TextAlignment::CenterRight);
     pid_vm_fields.empend("name", "Name", Gfx::TextAlignment::CenterLeft);
     m_json_model = GUI::JsonArrayModel::create({}, move(pid_vm_fields));
-    m_table_view->set_model(GUI::SortingProxyModel::create(*m_json_model));
+    m_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_json_model)));
 
     m_table_view->set_column_painting_delegate(7, make<PagemapPaintingDelegate>());
 

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -10,7 +10,6 @@
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/HeaderView.h>
 #include <LibGUI/Painter.h>
-#include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/TableView.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>

--- a/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
@@ -21,7 +21,7 @@ ProcessUnveiledPathsWidget::ProcessUnveiledPathsWidget()
     pid_unveil_fields.empend("permissions", "Permissions", Gfx::TextAlignment::CenterLeft);
 
     m_model = GUI::JsonArrayModel::create({}, move(pid_unveil_fields));
-    m_table_view->set_model(GUI::SortingProxyModel::create(*m_model));
+    m_table_view->set_model(MUST(GUI::SortingProxyModel::create(*m_model)));
 }
 
 ProcessUnveiledPathsWidget::~ProcessUnveiledPathsWidget()

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -180,7 +180,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto& process_table_view = process_table_container.add<GUI::TableView>();
     process_table_view.set_column_headers_visible(true);
-    process_table_view.set_model(GUI::SortingProxyModel::create(process_model));
+    process_table_view.set_model(TRY(GUI::SortingProxyModel::create(process_model)));
     for (auto column = 0; column < ProcessModel::Column::__Count; ++column)
         process_table_view.set_column_visible(column, false);
     process_table_view.set_column_visible(ProcessModel::Column::Icon, true);
@@ -549,7 +549,7 @@ NonnullRefPtr<GUI::Widget> build_storage_widget()
         df_fields.empend("total_inode_count", "Total inodes", Gfx::TextAlignment::CenterRight);
         df_fields.empend("block_size", "Block size", Gfx::TextAlignment::CenterRight);
 
-        fs_table_view.set_model(GUI::SortingProxyModel::create(GUI::JsonArrayModel::create("/proc/df", move(df_fields))));
+        fs_table_view.set_model(MUST(GUI::SortingProxyModel::create(GUI::JsonArrayModel::create("/proc/df", move(df_fields)))));
 
         fs_table_view.set_column_painting_delegate(3, make<ProgressbarPaintingDelegate>());
 
@@ -647,7 +647,7 @@ NonnullRefPtr<GUI::Widget> build_hardware_tab()
                     return String::formatted("{:02x}", revision_id);
                 });
 
-            pci_table_view.set_model(GUI::SortingProxyModel::create(GUI::JsonArrayModel::create("/proc/pci", move(pci_fields))));
+            pci_table_view.set_model(MUST(GUI::SortingProxyModel::create(GUI::JsonArrayModel::create("/proc/pci", move(pci_fields)))));
             pci_table_view.model()->invalidate();
         }
     };

--- a/Userland/Demos/WidgetGallery/GalleryWidget.cpp
+++ b/Userland/Demos/WidgetGallery/GalleryWidget.cpp
@@ -296,7 +296,7 @@ GalleryWidget::GalleryWidget()
     m_cursors_tableview->set_column_headers_visible(false);
     m_cursors_tableview->set_highlight_key_column(false);
 
-    auto sorting_proxy_model = GUI::SortingProxyModel::create(MouseCursorModel::create());
+    auto sorting_proxy_model = MUST(GUI::SortingProxyModel::create(MouseCursorModel::create()));
     sorting_proxy_model->set_sort_role(GUI::ModelRole::Display);
 
     m_cursors_tableview->set_model(sorting_proxy_model);
@@ -319,7 +319,7 @@ GalleryWidget::GalleryWidget()
     m_icons_tableview->set_column_headers_visible(false);
     m_icons_tableview->set_highlight_key_column(false);
 
-    auto sorting_proxy_icons_model = GUI::SortingProxyModel::create(FileIconsModel::create());
+    auto sorting_proxy_icons_model = MUST(GUI::SortingProxyModel::create(FileIconsModel::create()));
     sorting_proxy_icons_model->set_sort_role(GUI::ModelRole::Display);
 
     m_icons_tableview->set_model(sorting_proxy_icons_model);

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -96,7 +96,7 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
 
     m_view = *widget.find_descendant_of_type_named<GUI::MultiView>("view");
     m_view->set_selection_mode(m_mode == Mode::OpenMultiple ? GUI::AbstractView::SelectionMode::MultiSelection : GUI::AbstractView::SelectionMode::SingleSelection);
-    m_view->set_model(SortingProxyModel::create(*m_model));
+    m_view->set_model(MUST(SortingProxyModel::create(*m_model)));
     m_view->set_model_column(FileSystemModel::Column::Name);
     m_view->set_key_column_and_sort_order(GUI::FileSystemModel::Column::Name, GUI::SortOrder::Ascending);
     m_view->set_column_visible(FileSystemModel::Column::User, true);

--- a/Userland/Libraries/LibGUI/ProcessChooser.cpp
+++ b/Userland/Libraries/LibGUI/ProcessChooser.cpp
@@ -36,7 +36,7 @@ ProcessChooser::ProcessChooser(StringView window_title, StringView button_label,
 
     m_table_view = widget.add<GUI::TableView>();
     auto process_model = RunningProcessesModel::create();
-    auto sorting_model = GUI::SortingProxyModel::create(process_model);
+    auto sorting_model = MUST(GUI::SortingProxyModel::create(process_model));
     sorting_model->set_sort_role(GUI::ModelRole::Display);
     m_table_view->set_model(sorting_model);
     m_table_view->set_key_column_and_sort_order(RunningProcessesModel::Column::PID, GUI::SortOrder::Descending);

--- a/Userland/Libraries/LibGUI/SortingProxyModel.h
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.h
@@ -14,7 +14,11 @@ class SortingProxyModel
     : public Model
     , private ModelClient {
 public:
-    static NonnullRefPtr<SortingProxyModel> create(NonnullRefPtr<Model> source) { return adopt_ref(*new SortingProxyModel(move(source))); }
+    static ErrorOr<NonnullRefPtr<SortingProxyModel>> create(NonnullRefPtr<Model> source)
+    {
+        return adopt_nonnull_ref_or_enomem(new (nothrow) SortingProxyModel(move(source)));
+    }
+
     virtual ~SortingProxyModel() override;
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;


### PR DESCRIPTION
A little while ago I noticed that while `FilteringProxyModel::create()` returned `ErrorOr`, `SortingProxyModel::create()` didn't. So, now it does. :^)

Unfortunately, most of the users are inside constructors, (and two others are inside callback lambdas) so the error can't propagate, but that can be improved later.

Also removed an unused include for `SortingProxyModel.h` that I noticed while searching for its uses.
