### PR TITLE
Kernel: Mark PTYMultiplexer init & parse_hex_digit as UNMAP_AFTER_INIT

### DIFF
--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -25,7 +25,7 @@ __attribute__((section(".kernel_symbols"))) char kernel_symbols[5 * MiB] {};
 static KernelSymbol* s_symbols;
 static size_t s_symbol_count = 0;
 
-static u8 parse_hex_digit(char nibble)
+UNMAP_AFTER_INIT static u8 parse_hex_digit(char nibble)
 {
     if (nibble >= '0' && nibble <= '9')
         return nibble - '0';

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -149,7 +149,7 @@ void MemoryManager::unmap_text_after_init()
     dmesgln("Unmapped {} KiB of kernel text after init! :^)", (end - start) / KiB);
 }
 
-void MemoryManager::protect_ksyms_after_init()
+UNMAP_AFTER_INIT void MemoryManager::protect_ksyms_after_init()
 {
     SpinlockLocker mm_lock(s_mm_lock);
     SpinlockLocker page_lock(kernel_page_directory().get_lock());

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -35,7 +35,7 @@ UNMAP_AFTER_INIT PTYMultiplexer::~PTYMultiplexer()
 {
 }
 
-void PTYMultiplexer::initialize()
+UNMAP_AFTER_INIT void PTYMultiplexer::initialize()
 {
     the().after_inserting();
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -341,11 +341,11 @@ void init_stage2(void*)
     // NOTE: Everything marked READONLY_AFTER_INIT becomes non-writable after this point.
     MM.protect_readonly_after_init_memory();
 
-    // NOTE: Everything marked UNMAP_AFTER_INIT becomes inaccessible after this point.
-    MM.unmap_text_after_init();
-
     // NOTE: Everything in the .ksyms section becomes read-only after this point.
     MM.protect_ksyms_after_init();
+
+    // NOTE: Everything marked UNMAP_AFTER_INIT becomes inaccessible after this point.
+    MM.unmap_text_after_init();
 
     // FIXME: It would be nicer to set the mode from userspace.
     // FIXME: It would be smarter to not hardcode that the first tty is the only graphical one


### PR DESCRIPTION
These changes free up ~4 KiB of kernel memory.