### PR TITLE
AK+LibCrypto: Fix two small build errors when compiling with GCC 12

### DIFF
--- a/AK/CheckedFormatString.h
+++ b/AK/CheckedFormatString.h
@@ -8,6 +8,7 @@
 
 #include <AK/AllOf.h>
 #include <AK/AnyOf.h>
+#include <AK/Array.h>
 #include <AK/StdLibExtras.h>
 #include <AK/StringView.h>
 

--- a/Userland/Libraries/LibCrypto/Authentication/HMAC.h
+++ b/Userland/Libraries/LibCrypto/Authentication/HMAC.h
@@ -85,7 +85,6 @@ private:
         // Note: The block size of all the current hash functions is 512 bits.
         Vector<u8, 64> v_key;
         v_key.resize(block_size);
-        __builtin_memset(v_key.data(), 0, block_size);
         auto key_buffer = v_key.span();
         // m_key_data is zero'd, so copying the data in
         // the first few bytes leaves the rest zero, which


### PR DESCRIPTION
This PR fixes two build errors that I encountered when trying to build SerenityOS with GCC 12. Note that it's still not possible to build SerenityOS with it without resorting to dirty hacks, as the compiler ICEs in two places. One of these has already been reported; and I'm going to submit the other one too after the holidays.

### AK: Add missing Array.h include to CheckedFormatString.h

GCC 12 complains that iota_array is used before it's declared. GCC 11
works fine without it though.

### LibCrypto: Remove redundant __builtin_memset() call

This call caused GCC 12's static analyzer to think that we perform an
out-of-bounds write to the v_key Vector. This is obviously incorrect,
and comes from the fact that GCC doesn't properly track whether we use
the inline storage, or the Vector is allocated on the heap.

While searching for a workaround, Sam pointed out that this call is
redundant as `Vector::resize()` already zeroes out the elements, so we
can completely remove it.
