### PR TITLE
Meta: Remove kernel modules remains

### DIFF
--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -8,7 +8,7 @@ list(APPEND REQUIRED_TARGETS
 )
 list(APPEND RECOMMENDED_TARGETS
     adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip init keymap lsirq lsof lspci man mknod mktemp
-    modload modunload nc netstat notify ntpquery open pape passwd pls printf pro shot tar tt unzip zip
+    nc netstat notify ntpquery open pape passwd pls printf pro shot tar tt unzip zip
 )
 
 # FIXME: Support specifying component dependencies for utilities (e.g. WebSocket for telws)


### PR DESCRIPTION
Apparently Andreas found remains for that in the build system.
Let's remove them for completeness of that process of removing support
for kernel modules, which didn't work for many months before being
removed.

That was found during a livestream (office hours) today.