### PR TITLE
LibWeb: Stop skipping code points in CSS Tokenizer

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -309,6 +309,30 @@ U32Triplet Tokenizer::peek_triplet() const
     return values;
 }
 
+U32Twin Tokenizer::start_of_input_stream_twin()
+{
+    U32Twin twin;
+    // FIXME: Reconsuming just to read the current code point again is weird.
+    reconsume_current_input_code_point();
+    twin.first = next_code_point();
+    twin.second = peek_code_point();
+
+    return twin;
+}
+
+U32Triplet Tokenizer::start_of_input_stream_triplet()
+{
+    U32Triplet triplet;
+    // FIXME: Reconsuming just to read the current code point again is weird.
+    reconsume_current_input_code_point();
+    triplet.first = next_code_point();
+    auto next_two = peek_twin();
+    triplet.second = next_two.first;
+    triplet.third = next_two.second;
+
+    return triplet;
+}
+
 Token Tokenizer::create_new_token(Token::Type type)
 {
     Token token = {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -844,7 +844,7 @@ Token Tokenizer::consume_a_numeric_token()
     auto number = consume_a_number();
 
     // If the next 3 input code points would start an identifier, then:
-    if (would_start_an_identifier()) {
+    if (would_start_an_identifier(peek_triplet())) {
         // 1. Create a <dimension-token> with the same value and type flag as number,
         //    and a unit set initially to the empty string.
         auto token = create_new_token(Token::Type::Dimension);
@@ -946,11 +946,6 @@ bool Tokenizer::is_valid_escape_sequence(U32Twin values)
 
     // Otherwise, return true.
     return true;
-}
-
-bool Tokenizer::would_start_an_identifier()
-{
-    return would_start_an_identifier(peek_triplet());
 }
 
 // https://www.w3.org/TR/css-syntax-3/#would-start-an-identifier
@@ -1143,7 +1138,7 @@ Token Tokenizer::consume_a_token()
 
             // 2. If the next 3 input code points would start an identifier, set the <hash-token>’s
             //    type flag to "id".
-            if (would_start_an_identifier())
+            if (would_start_an_identifier(peek_triplet()))
                 token.m_hash_type = Token::HashType::Id;
 
             // 3. Consume a name, and set the <hash-token>’s value to the returned string.
@@ -1222,7 +1217,7 @@ Token Tokenizer::consume_a_token()
 
         // Otherwise, if the input stream starts with an identifier, reconsume the current
         // input code point, consume an ident-like token, and return it.
-        if (would_start_an_identifier()) {
+        if (would_start_an_identifier(start_of_input_stream_triplet())) {
             reconsume_current_input_code_point();
             return consume_an_ident_like_token();
         }
@@ -1282,7 +1277,7 @@ Token Tokenizer::consume_a_token()
         dbgln_if(CSS_TOKENIZER_DEBUG, "is at");
         // If the next 3 input code points would start an identifier, consume a name, create
         // an <at-keyword-token> with its value set to the returned value, and return it.
-        if (would_start_an_identifier()) {
+        if (would_start_an_identifier(peek_triplet())) {
             auto name = consume_a_name();
             return create_value_token(Token::Type::AtKeyword, name);
         }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -881,11 +881,6 @@ Token Tokenizer::consume_a_numeric_token()
     return token;
 }
 
-bool Tokenizer::would_start_a_number() const
-{
-    return would_start_a_number(peek_triplet());
-}
-
 // https://www.w3.org/TR/css-syntax-3/#starts-with-a-number
 bool Tokenizer::would_start_a_number(U32Triplet values)
 {
@@ -1189,7 +1184,7 @@ Token Tokenizer::consume_a_token()
         dbgln_if(CSS_TOKENIZER_DEBUG, "is plus sign");
         // If the input stream starts with a number, reconsume the current input code point,
         // consume a numeric token and return it.
-        if (would_start_a_number()) {
+        if (would_start_a_number(start_of_input_stream_triplet())) {
             reconsume_current_input_code_point();
             return consume_a_numeric_token();
         }
@@ -1210,7 +1205,7 @@ Token Tokenizer::consume_a_token()
         dbgln_if(CSS_TOKENIZER_DEBUG, "is hyphen minus");
         // If the input stream starts with a number, reconsume the current input code point,
         // consume a numeric token, and return it.
-        if (would_start_a_number()) {
+        if (would_start_a_number(start_of_input_stream_triplet())) {
             reconsume_current_input_code_point();
             return consume_a_numeric_token();
         }
@@ -1241,7 +1236,7 @@ Token Tokenizer::consume_a_token()
         dbgln_if(CSS_TOKENIZER_DEBUG, "is full stop");
         // If the input stream starts with a number, reconsume the current input code point,
         // consume a numeric token, and return it.
-        if (would_start_a_number()) {
+        if (would_start_a_number(start_of_input_stream_triplet())) {
             reconsume_current_input_code_point();
             return consume_a_numeric_token();
         }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -79,6 +79,9 @@ private:
     [[nodiscard]] U32Twin peek_twin() const;
     [[nodiscard]] U32Triplet peek_triplet() const;
 
+    [[nodiscard]] U32Twin start_of_input_stream_twin();
+    [[nodiscard]] U32Triplet start_of_input_stream_triplet();
+
     [[nodiscard]] static Token create_new_token(Token::Type);
     [[nodiscard]] static Token create_value_token(Token::Type, String value);
     [[nodiscard]] static Token create_value_token(Token::Type, u32 value);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -101,7 +101,6 @@ private:
     [[nodiscard]] static bool is_valid_escape_sequence(U32Twin);
     [[nodiscard]] bool would_start_an_identifier();
     [[nodiscard]] bool would_start_an_identifier(U32Triplet);
-    [[nodiscard]] bool would_start_a_number() const;
     [[nodiscard]] static bool would_start_a_number(U32Triplet);
 
     String m_decoded_input;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -99,8 +99,7 @@ private:
     void consume_as_much_whitespace_as_possible();
     void reconsume_current_input_code_point();
     [[nodiscard]] static bool is_valid_escape_sequence(U32Twin);
-    [[nodiscard]] bool would_start_an_identifier();
-    [[nodiscard]] bool would_start_an_identifier(U32Triplet);
+    [[nodiscard]] static bool would_start_an_identifier(U32Triplet);
     [[nodiscard]] static bool would_start_a_number(U32Triplet);
 
     String m_decoded_input;


### PR DESCRIPTION
This fixes the crash in the CSS Tokenizer that @Lubrsi found using Domato. Thanks Luke! :^)

The spec distinguishes between checking if the next X code points are something, and if the input stream starts with something. The difference is whether to include the current input code point, which we were incorrectly always skipping. 

This patch adds some functions to get a Triplet or Twin that includes the current input code point; makes use of those; and removes the parameterless function overloads of is_valid_escape_sequence(), would_start_an_identifier() and would_start_a_number() that were hiding this mistake.

The end result is, this used to send us into an infinite loop until we ran out of memory and crashed, and now it doesn't. :^)
```css
. foo {
    bar: .-1px;
}
```

I'm erring on the side of too-small commits here, since there's a decent chance I'm introducing new bugs and that should make it easier to bisect them if I do. :sweat_smile: 