### PR TITLE
Everywhere: Avoid unnecessary copies

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/CodeComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/CodeComprehensionEngine.cpp
@@ -24,8 +24,8 @@ void CodeComprehensionEngine::set_declarations_of_document(const String& filenam
         return;
 
     // Optimization - Only notify callback if declarations have changed
-    if (auto previous_declarations = m_all_declarations.get(filename); previous_declarations.has_value()) {
-        if (previous_declarations.value() == declarations)
+    if (auto previous_declarations = m_all_declarations.find(filename); previous_declarations != m_all_declarations.end()) {
+        if (previous_declarations->value == declarations)
             return;
     }
     if (m_store_all_declarations)

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -267,8 +267,10 @@ Icon FileIconProvider::icon_for_path(const String& path, mode_t mode)
         return s_filetype_image_icon;
 
     for (auto& filetype : s_filetype_icons.keys()) {
-        auto patterns = s_filetype_patterns.get(filetype).value();
-        for (auto& pattern : patterns) {
+        auto pattern_it = s_filetype_patterns.find(filetype);
+        if (pattern_it == s_filetype_patterns.end())
+            continue;
+        for (auto& pattern : pattern_it->value) {
             if (path.matches(pattern, CaseSensitivity::CaseInsensitive))
                 return s_filetype_icons.get(filetype).value();
         }

--- a/Userland/Libraries/LibJS/Bytecode/Pass/MergeBlocks.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/MergeBlocks.cpp
@@ -43,9 +43,9 @@ void MergeBlocks::perform(PassPipelineExecutable& executable)
             }
         }
 
-        if (auto cfg_entry = inverted_cfg.get(*entry.value.begin()); cfg_entry.has_value()) {
-            auto& predecssor_entry = *cfg_entry;
-            if (predecssor_entry.size() != 1)
+        if (auto cfg_iter = inverted_cfg.find(*entry.value.begin()); cfg_iter != inverted_cfg.end()) {
+            auto& predecessor_entry = cfg_iter->value;
+            if (predecessor_entry.size() != 1)
                 continue;
         }
 
@@ -99,10 +99,10 @@ void MergeBlocks::perform(PassPipelineExecutable& executable)
         Vector<BasicBlock const*> successors { current_block };
         for (;;) {
             auto last = successors.last();
-            auto entry = cfg.get(last);
-            if (!entry.has_value())
+            auto entry = cfg.find(last);
+            if (entry == cfg.end())
                 break;
-            auto& successor = *entry->begin();
+            auto& successor = *entry->value.begin();
             successors.append(successor);
             auto it = blocks_to_merge.find(successor);
             if (it == blocks_to_merge.end())
@@ -112,10 +112,10 @@ void MergeBlocks::perform(PassPipelineExecutable& executable)
 
         auto blocks_to_merge_copy = blocks_to_merge;
         for (auto& last : blocks_to_merge) {
-            auto entry = cfg.get(last);
-            if (!entry.has_value())
+            auto entry = cfg.find(last);
+            if (entry == cfg.end())
                 continue;
-            auto successor = *entry->begin();
+            auto successor = *entry->value.begin();
             if (auto it = successors.find(successor); !it.is_end()) {
                 successors.insert(it.index(), last);
                 blocks_to_merge_copy.remove(last);

--- a/Userland/Libraries/LibJS/Bytecode/Pass/PlaceBlocks.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Pass/PlaceBlocks.cpp
@@ -26,7 +26,11 @@ void PlaceBlocks::perform(PassPipelineExecutable& executable)
         reachable_blocks.set(block);
         replaced_blocks.append(*const_cast<BasicBlock*>(block));
 
-        for (auto& entry : cfg.get(block).value_or({}))
+        auto children = cfg.find(block);
+        if (children == cfg.end())
+            return;
+
+        for (auto& entry : children->value)
             visit(entry);
     };
 

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -474,22 +474,15 @@ void Editor::stylize(Span const& span, Style const& style)
     auto& spans_starting = style.is_anchored() ? m_current_spans.m_anchored_spans_starting : m_current_spans.m_spans_starting;
     auto& spans_ending = style.is_anchored() ? m_current_spans.m_anchored_spans_ending : m_current_spans.m_spans_ending;
 
-    auto starting_map = spans_starting.get(start).value_or({});
-
+    auto& starting_map = spans_starting.ensure(start);
     if (!starting_map.contains(end))
         m_refresh_needed = true;
-
     starting_map.set(end, style);
 
-    spans_starting.set(start, starting_map);
-
-    auto ending_map = spans_ending.get(end).value_or({});
-
+    auto& ending_map = spans_ending.ensure(end);
     if (!ending_map.contains(start))
         m_refresh_needed = true;
     ending_map.set(start, style);
-
-    spans_ending.set(end, ending_map);
 }
 
 void Editor::suggest(size_t invariant_offset, size_t static_offset, Span::Mode offset_mode) const
@@ -2032,12 +2025,13 @@ bool Editor::Spans::contains_up_to_offset(Spans const& other, size_t offset) con
             if (entry.key > offset + 1)
                 continue;
 
-            auto left_map = left.get(entry.key);
-            if (!left_map.has_value())
+            auto left_map_it = left.find(entry.key);
+            if (left_map_it == left.end())
                 return false;
 
-            for (auto& left_entry : left_map.value()) {
-                if (auto value = entry.value.get(left_entry.key); !value.has_value()) {
+            for (auto& left_entry : left_map_it->value) {
+                auto value_it = entry.value.find(left_entry.key);
+                if (value_it == entry.value.end()) {
                     // Might have the same thing with a longer span
                     bool found = false;
                     for (auto& possibly_longer_span_entry : entry.value) {
@@ -2054,8 +2048,8 @@ bool Editor::Spans::contains_up_to_offset(Spans const& other, size_t offset) con
                             dbgln("Have: {}-{} = {}", entry.key, x.key, x.value.to_string());
                     }
                     return false;
-                } else if (value.value() != left_entry.value) {
-                    dbgln_if(LINE_EDITOR_DEBUG, "Compare for {}-{} failed, different values: {} != {}", entry.key, left_entry.key, value.value().to_string(), left_entry.value.to_string());
+                } else if (value_it->value != left_entry.value) {
+                    dbgln_if(LINE_EDITOR_DEBUG, "Compare for {}-{} failed, different values: {} != {}", entry.key, left_entry.key, value_it->value.to_string(), left_entry.value.to_string());
                     return false;
                 }
             }

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -181,12 +181,10 @@ ErrorOr<void> Heap::flush()
     }
     quick_sort(blocks);
     for (auto& block : blocks) {
-        auto buffer_or_empty = m_write_ahead_log.get(block);
-        if (buffer_or_empty->is_empty()) {
-            VERIFY_NOT_REACHED();
-        }
+        auto buffer_it = m_write_ahead_log.find(block);
+        VERIFY(buffer_it != m_write_ahead_log.end());
         dbgln_if(SQL_DEBUG, "Flushing block {} to {}", block, name());
-        TRY(write_block(block, buffer_or_empty.value()));
+        TRY(write_block(block, buffer_it->value));
     }
     m_write_ahead_log.clear();
     dbgln_if(SQL_DEBUG, "WAL flushed. Heap size = {}", size());

--- a/Userland/Libraries/LibWeb/CSS/StyleInvalidator.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleInvalidator.cpp
@@ -29,12 +29,12 @@ StyleInvalidator::~StyleInvalidator()
         return;
     auto& style_computer = m_document.style_computer();
     m_document.for_each_in_inclusive_subtree_of_type<DOM::Element>([&](auto& element) {
-        auto maybe_matching_rules_before = m_elements_and_matching_rules_before.get(&element);
-        if (!maybe_matching_rules_before.has_value()) {
+        auto matching_rules_before_iter = m_elements_and_matching_rules_before.find(&element);
+        if (matching_rules_before_iter == m_elements_and_matching_rules_before.end()) {
             element.set_needs_style_update(true);
             return IterationDecision::Continue;
         }
-        auto& matching_rules_before = maybe_matching_rules_before.value();
+        auto& matching_rules_before = matching_rules_before_iter->value;
         auto matching_rules_after = style_computer.collect_matching_rules(element);
         if (matching_rules_before.size() != matching_rules_after.size()) {
             element.set_needs_style_update(true);

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -149,8 +149,8 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, DNSRecordType record
     };
 
     // First, try /etc/hosts.
-    if (auto local_answers = m_etc_hosts.get(name); local_answers.has_value()) {
-        for (auto& answer : local_answers.value()) {
+    if (auto local_answers = m_etc_hosts.find(name); local_answers != m_etc_hosts.end()) {
+        for (auto& answer : local_answers->value) {
             if (answer.type() == record_type)
                 add_answer(answer);
         }
@@ -169,8 +169,8 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, DNSRecordType record
     }
 
     // Third, try our cache.
-    if (auto cached_answers = m_lookup_cache.get(name); cached_answers.has_value()) {
-        for (auto& answer : cached_answers.value()) {
+    if (auto cached_answers = m_lookup_cache.find(name); cached_answers != m_lookup_cache.end()) {
+        for (auto& answer : cached_answers->value) {
             // TODO: Actually remove expired answers from the cache.
             if (answer.type() == record_type && !answer.has_expired()) {
                 dbgln_if(LOOKUPSERVER_DEBUG, "Cache hit: {} -> {}", name.as_string(), answer.record_data());


### PR DESCRIPTION
The method `HashMap<K, V>::get` returns `Optional<V>`, which means it will happily copy the `V`. The cost of this may not be immediately obvious to the user, but if `V` is something like a `Vector` or a `Hashset` or a `HashMap`, this copying will be rather expensive. And obviously, if the copying is unnecessary, then it should be avoided entirely.

My previous attempt was to [change the return type to `Optional<V&>`](https://github.com/SerenityOS/serenity/pull/11193), which would "eliminate" the footgun entirely. For many reasons, the very concept of `Optional<V&>` turns out to be a lot of headaches, creating new footguns in the process.

The tests pass, I checked the code to make sure that they *really* don't need to make a copy, but they indeed all seem to be unnecessary. However: Hey @linusg, could you double-check the LibJS and LibWeb changes? Given the amount of `HashMap::get` usages, I wanna make extra-sure.

For historic purposes: I found these usages by just making `Traits<SomeHeavyType>::PeekType` something invalid, like `Void`. This way, all usages got turned into compilation errors, making them easy to find. I didn't include that code because it's ugly, maybe someone has a better idea: https://github.com/BenWiederhake/serenity/tree/historic/prevent-heavy-hashmap-get