### PR TITLE
UserspaceEmulator: Exclude special ranges from RangeAllocator

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1533,7 +1533,9 @@ u32 Emulator::virt$allocate_tls(FlatPtr initial_data, size_t size)
     // TODO: This matches what Thread::make_thread_specific_region does. The kernel
     // ends up allocating one more page. Figure out if this is intentional.
     auto region_size = align_up_to(size, PAGE_SIZE) + PAGE_SIZE;
-    auto tcb_region = make<SimpleRegion>(0x20000000, region_size);
+    constexpr auto tls_location = VirtualAddress(0x20000000);
+    m_range_allocator.reserve_user_range(tls_location, region_size);
+    auto tcb_region = make<SimpleRegion>(tls_location.get(), region_size);
 
     size_t offset = 0;
     while (size - offset > 0) {

--- a/Userland/DevTools/UserspaceEmulator/RangeAllocator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/RangeAllocator.cpp
@@ -181,4 +181,11 @@ void RangeAllocator::deallocate(const Range& range)
     }
 }
 
+void RangeAllocator::reserve_user_range(VirtualAddress begin, size_t size)
+{
+    auto end = round_up_to_power_of_two(begin.offset(size).get(), PAGE_SIZE);
+    auto allocated_range = allocate_specific(begin.page_base(), end - begin.page_base().get());
+    VERIFY(allocated_range.has_value());
+}
+
 }

--- a/Userland/DevTools/UserspaceEmulator/RangeAllocator.h
+++ b/Userland/DevTools/UserspaceEmulator/RangeAllocator.h
@@ -22,6 +22,8 @@ public:
     Optional<Range> allocate_randomized(size_t, size_t alignment);
     void deallocate(const Range&);
 
+    void reserve_user_range(VirtualAddress, size_t);
+
     void dump() const;
 
     bool contains(const Range& range) const { return m_total_range.contains(range); }


### PR DESCRIPTION
If we do not mark these ranges as reserved, RangeAllocator might later
give us addresses that overlap these, which then causes an assertion
failure in the SoftMMU.  This behavior led to recurring CI failures, and
sometimes made programs as simple as `/bin/true` fail.

Fixes "Crash 1" reported in #9104