### PR TITLE
AK: Remove Variant<Ts...>::operator Variant<NewTs...>()

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -208,6 +208,18 @@ public:
     }
 
     template<typename... NewTs>
+    Variant(Variant<NewTs...>&& old) requires((can_contain<NewTs>() && ...))
+        : Variant(move(old).template downcast<Ts...>())
+    {
+    }
+
+    template<typename... NewTs>
+    Variant(const Variant<NewTs...>& old) requires((can_contain<NewTs>() && ...))
+        : Variant(old.template downcast<Ts...>())
+    {
+    }
+
+    template<typename... NewTs>
     friend struct Variant;
 
     Variant() requires(!can_contain<Empty>()) = delete;
@@ -387,18 +399,6 @@ public:
         });
         VERIFY(instance.m_index != instance.invalid_index);
         return instance;
-    }
-
-    template<typename... NewTs>
-    explicit operator Variant<NewTs...>() &&
-    {
-        return downcast<NewTs...>();
-    }
-
-    template<typename... NewTs>
-    explicit operator Variant<NewTs...>() const&
-    {
-        return downcast<NewTs...>();
     }
 
 private:


### PR DESCRIPTION
This is an interface to downcast(), which degrades errors into runtime
errors, and allows seemingly-correct-but-not-quite constructs like the
following to appear to compile, but fail at runtime:

    Variant<NonnullRefPtr<T>, U> foo = ...;
    Variant<RefPtr<T>, U> bar = foo;

The expectation here is that `foo` is converted to a RefPtr<T> if it
contains one, and remains a U otherwise, but in reality, the
NonnullRefPtr<T> variant is simply dropped on the floor, and the
resulting variant becomes invalid, failing the assertion in downcast().

This commit adds a Variant<Ts...>(Variant<NewTs...>) constructor that
ensures that no alternative can be left out at compiletime, for the
users that were using this interface for merely increasing the number of
alternatives (for instance, LibSQL's Value class).