### PR TITLE
Meta: Don't override KVM_SUPPORT if it is already set

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -17,8 +17,14 @@ SCRIPT_DIR="$(dirname "${0}")"
 #SERENITY_PACKET_LOGGING_ARG="-object filter-dump,id=hue,netdev=breh,file=e1000.pcap"
 
 # FIXME: Enable for SERENITY_ARCH=aarch64 if on an aarch64 host?
-KVM_SUPPORT="0"
-[ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ] && [ "$SERENITY_ARCH" != "aarch64" ] && KVM_SUPPORT="1"
+
+# Check if SERENITY_KVM_SUPPORT is unset
+if [ -z ${SERENITY_KVM_SUPPORT+x} ]; then
+    KVM_SUPPORT="0"
+    [ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ] && [ "$SERENITY_ARCH" != "aarch64" ] && KVM_SUPPORT="1"
+else
+    KVM_SUPPORT="$SERENITY_KVM_SUPPORT"
+fi
 
 [ -z "$SERENITY_BOCHS_BIN" ] && SERENITY_BOCHS_BIN="bochs"
 


### PR DESCRIPTION
I've seen how @awesomekling changes the script to disable KVM, so
that's a useful thing to have.

An example how to use it:
  SERENITY_KVM_SUPPORT='0' ./Meta/serenity.sh run x86_64

My first commit btw :^)