### PR TITLE
Everywhere: Various bit manipulations improvements

### DIFF
--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -268,7 +268,7 @@ public:
                     }
 
                     // Deleting trailing ones.
-                    u32 trailing_ones = count_trailing_zeroes(~bucket);
+                    u32 trailing_ones = count_trailing_ones(bucket);
                     bucket >>= trailing_ones;
                     viewed_bits += trailing_ones;
                     free_chunks = 0;

--- a/AK/BitmapView.h
+++ b/AK/BitmapView.h
@@ -205,7 +205,7 @@ public:
             return {};
         }
 
-        size_t bit_size = 8 * sizeof(size_t);
+        size_t bit_size = bit_sizeof(size_t);
 
         size_t* bitmap = (size_t*)m_data;
 

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -58,6 +58,12 @@ inline constexpr int count_trailing_zeroes(IntType value)
 #endif
 }
 
+template<Unsigned IntType>
+inline constexpr int count_trailing_ones(IntType value)
+{
+    return count_trailing_zeroes(static_cast<IntType>(~value));
+}
+
 // The function will return the number of leading zeroes in the type. If
 // the given number is zero, this function will return the number of bits
 // in the IntType.

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -97,6 +97,12 @@ inline constexpr int count_leading_zeroes(IntType value)
 #endif
 }
 
+template<Unsigned IntType>
+inline constexpr int count_leading_ones(IntType value)
+{
+    return count_leading_zeroes(static_cast<IntType>(~value));
+}
+
 // The function will return the index of leading one bit in the type. If
 // the given number is zero, this function will return zero.
 template<Integral IntType>

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -31,6 +31,12 @@ inline constexpr int popcount(IntType value)
 #endif
 }
 
+template<Unsigned IntType>
+inline constexpr int count_ones(IntType value)
+{
+    return popcount(value);
+}
+
 // The function will return the number of trailing zeroes in the type. If
 // the given number is zero, this function will return the number of bits
 // bits in the IntType.

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -32,13 +32,13 @@ inline constexpr int popcount(IntType value)
 }
 
 // The function will return the number of trailing zeroes in the type. If
-// the given number if zero, this function may contain undefined
-// behavior, or it may return the number of bits in the number. If
-// this function can be called with zero, the use of
-// count_trailing_zeroes_safe is preferred.
+// the given number is zero, this function will return the number of bits
+// bits in the IntType.
 template<Unsigned IntType>
 inline constexpr int count_trailing_zeroes(IntType value)
 {
+    if (value == 0) [[unlikely]]
+        return 8 * sizeof(IntType);
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -108,9 +108,8 @@ inline constexpr int count_leading_zeroes_safe(IntType value)
     return count_leading_zeroes(value);
 }
 
-// The function will return the number of leading zeroes in the type. If
-// the given number is zero, this function will return the number of bits
-// in the IntType.
+// The function will return the index of leading one bit in the type. If
+// the given number is zero, this function will return zero.
 template<Integral IntType>
 inline constexpr int bit_scan_forward(IntType value)
 {

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -37,6 +37,12 @@ inline constexpr int count_ones(IntType value)
     return popcount(value);
 }
 
+template<Unsigned IntType>
+inline constexpr int count_zeroes(IntType value)
+{
+    return popcount(static_cast<IntType>(~value));
+}
+
 // The function will return the number of trailing zeroes in the type. If
 // the given number is zero, this function will return the number of bits
 // bits in the IntType.

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -70,13 +70,13 @@ inline constexpr int count_trailing_zeroes_safe(IntType value)
 }
 
 // The function will return the number of leading zeroes in the type. If
-// the given number if zero, this function may contain undefined
-// behavior, or it may return the number of bits in the number. If
-// this function can be called with zero, the use of
-// count_leading_zeroes_safe is preferred.
+// the given number is zero, this function will return the number of bits
+// in the IntType.
 template<Unsigned IntType>
 inline constexpr int count_leading_zeroes(IntType value)
 {
+    if (value == 0) [[unlikely]]
+        return 8 * sizeof(IntType);
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -58,17 +58,6 @@ inline constexpr int count_trailing_zeroes(IntType value)
 #endif
 }
 
-// The function will return the number of trailing zeroes in the type. If
-// the given number is zero, this function will return the number of bits
-// bits in the IntType.
-template<Unsigned IntType>
-inline constexpr int count_trailing_zeroes_safe(IntType value)
-{
-    if (value == 0)
-        return 8 * sizeof(IntType);
-    return count_trailing_zeroes(value);
-}
-
 // The function will return the number of leading zeroes in the type. If
 // the given number is zero, this function will return the number of bits
 // in the IntType.

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -22,7 +22,7 @@ inline constexpr int popcount(IntType value)
     VERIFY_NOT_REACHED();
 #else
     int ones = 0;
-    for (size_t i = 0; i < 8 * sizeof(IntType); ++i) {
+    for (size_t i = 0; i < bit_sizeof(IntType); ++i) {
         if ((val >> i) & 1) {
             ++ones;
         }
@@ -50,7 +50,7 @@ template<Unsigned IntType>
 inline constexpr int count_trailing_zeroes(IntType value)
 {
     if (value == 0) [[unlikely]]
-        return 8 * sizeof(IntType);
+        return bit_sizeof(IntType);
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
@@ -61,12 +61,12 @@ inline constexpr int count_trailing_zeroes(IntType value)
         return __builtin_ctzll(value);
     VERIFY_NOT_REACHED();
 #else
-    for (size_t i = 0; i < 8 * sizeof(IntType); ++i) {
+    for (size_t i = 0; i < bit_sizeof(IntType); ++i) {
         if ((val >> i) & 1) {
             return i;
         }
     }
-    return 8 * sizeof(IntType);
+    return bit_sizeof(IntType);
 #endif
 }
 
@@ -83,11 +83,11 @@ template<Unsigned IntType>
 inline constexpr int count_leading_zeroes(IntType value)
 {
     if (value == 0) [[unlikely]]
-        return 8 * sizeof(IntType);
+        return bit_sizeof(IntType);
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
     if constexpr (sizeof(IntType) <= sizeof(unsigned int))
-        return __builtin_clz(value) - (32 - (8 * sizeof(IntType)));
+        return __builtin_clz(value) - (bit_sizeof(unsigned int) - bit_sizeof(IntType));
     if constexpr (sizeof(IntType) == sizeof(unsigned long))
         return __builtin_clzl(value);
     if constexpr (sizeof(IntType) == sizeof(unsigned long long))
@@ -95,12 +95,12 @@ inline constexpr int count_leading_zeroes(IntType value)
     VERIFY_NOT_REACHED();
 #else
     // Wrap around, catch going past zero by noticing that i is greater than the number of bits in the number
-    for (size_t i = (8 * sizeof(IntType)) - 1; i < 8 * sizeof(IntType); --i) {
+    for (size_t i = (bit_sizeof(IntType)) - 1; i < bit_sizeof(IntType); --i) {
         if ((val >> i) & 1) {
             return i;
         }
     }
-    return 8 * sizeof(IntType);
+    return bit_sizeof(IntType);
 #endif
 }
 

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -9,7 +9,7 @@
 #include "Concepts.h"
 
 template<Unsigned IntType>
-inline constexpr int popcount(IntType value)
+inline constexpr size_t popcount(IntType value)
 {
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
@@ -21,7 +21,7 @@ inline constexpr int popcount(IntType value)
         return __builtin_popcountll(value);
     VERIFY_NOT_REACHED();
 #else
-    int ones = 0;
+    size_t ones = 0;
     for (size_t i = 0; i < bit_sizeof(IntType); ++i) {
         if ((val >> i) & 1) {
             ++ones;
@@ -32,13 +32,13 @@ inline constexpr int popcount(IntType value)
 }
 
 template<Unsigned IntType>
-inline constexpr int count_ones(IntType value)
+inline constexpr size_t count_ones(IntType value)
 {
     return popcount(value);
 }
 
 template<Unsigned IntType>
-inline constexpr int count_zeroes(IntType value)
+inline constexpr size_t count_zeroes(IntType value)
 {
     return popcount(static_cast<IntType>(~value));
 }
@@ -47,7 +47,7 @@ inline constexpr int count_zeroes(IntType value)
 // the given number is zero, this function will return the number of bits
 // bits in the IntType.
 template<Unsigned IntType>
-inline constexpr int count_trailing_zeroes(IntType value)
+inline constexpr size_t count_trailing_zeroes(IntType value)
 {
     if (value == 0) [[unlikely]]
         return bit_sizeof(IntType);
@@ -71,7 +71,7 @@ inline constexpr int count_trailing_zeroes(IntType value)
 }
 
 template<Unsigned IntType>
-inline constexpr int count_trailing_ones(IntType value)
+inline constexpr size_t count_trailing_ones(IntType value)
 {
     return count_trailing_zeroes(static_cast<IntType>(~value));
 }
@@ -80,7 +80,7 @@ inline constexpr int count_trailing_ones(IntType value)
 // the given number is zero, this function will return the number of bits
 // in the IntType.
 template<Unsigned IntType>
-inline constexpr int count_leading_zeroes(IntType value)
+inline constexpr size_t count_leading_zeroes(IntType value)
 {
     if (value == 0) [[unlikely]]
         return bit_sizeof(IntType);
@@ -105,7 +105,7 @@ inline constexpr int count_leading_zeroes(IntType value)
 }
 
 template<Unsigned IntType>
-inline constexpr int count_leading_ones(IntType value)
+inline constexpr size_t count_leading_ones(IntType value)
 {
     return count_leading_zeroes(static_cast<IntType>(~value));
 }
@@ -113,7 +113,7 @@ inline constexpr int count_leading_ones(IntType value)
 // The function will return the index of leading one bit in the type. If
 // the given number is zero, this function will return zero.
 template<Integral IntType>
-inline constexpr int bit_scan_forward(IntType value)
+inline constexpr size_t bit_scan_forward(IntType value)
 {
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));

--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -97,17 +97,6 @@ inline constexpr int count_leading_zeroes(IntType value)
 #endif
 }
 
-// The function will return the number of leading zeroes in the type. If
-// the given number is zero, this function will return the number of bits
-// in the IntType.
-template<Unsigned IntType>
-inline constexpr int count_leading_zeroes_safe(IntType value)
-{
-    if (value == 0)
-        return 8 * sizeof(IntType);
-    return count_leading_zeroes(value);
-}
-
 // The function will return the index of leading one bit in the type. If
 // the given number is zero, this function will return zero.
 template<Integral IntType>

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -108,7 +108,7 @@ public:
 
     constexpr bool signbit() const requires(IsSigned<Underlying>)
     {
-        return m_value >> (sizeof(Underlying) * 8 - 1);
+        return m_value >> (bit_sizeof(Underlying) - 1);
     }
 
     constexpr This operator-() const requires(IsSigned<Underlying>)

--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -36,7 +36,7 @@ struct LEB128 {
                 return false;
 
             ValueType masked_byte = byte & ~(1 << 7);
-            const bool shift_too_large_for_result = (num_bytes * 7 > sizeof(ValueType) * 8) && (masked_byte != 0);
+            const bool shift_too_large_for_result = (num_bytes * 7 > bit_sizeof(ValueType)) && (masked_byte != 0);
             if (shift_too_large_for_result)
                 return false;
 

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -298,7 +298,7 @@ constexpr T log2(T x)
 template<Integral T>
 constexpr T log2(T x)
 {
-    return 8 * sizeof(T) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x));
+    return bit_sizeof(T) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x));
 }
 
 template<FloatingPoint T>

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -298,7 +298,7 @@ constexpr T log2(T x)
 template<Integral T>
 constexpr T log2(T x)
 {
-    return x ? 8 * sizeof(T) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x)) : 0;
+    return 8 * sizeof(T) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x));
 }
 
 template<FloatingPoint T>

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -110,3 +110,5 @@ extern "C" {
 #    define CLOCK_MONOTONIC_COARSE CLOCK_MONOTONIC
 #    define CLOCK_REALTIME_COARSE CLOCK_REALTIME
 #endif
+
+#define bit_sizeof(x) (8u * sizeof(x))

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -254,8 +254,7 @@ String String::bijective_base_from(size_t value, unsigned base, StringView map)
 
     VERIFY(base >= 2 && base <= map.length());
 
-    // The '8 bits per byte' assumption may need to go?
-    Array<char, round_up_to_power_of_two(sizeof(size_t) * 8 + 1, 2)> buffer;
+    Array<char, round_up_to_power_of_two(bit_sizeof(size_t) + 1, 2)> buffer;
     size_t i = 0;
     do {
         buffer[i++] = map[value % base];

--- a/Tests/AK/TestBuiltinWrappers.cpp
+++ b/Tests/AK/TestBuiltinWrappers.cpp
@@ -11,44 +11,44 @@
 
 TEST_CASE(wrapped_popcount)
 {
-    EXPECT_EQ(popcount(NumericLimits<u8>::max()), 8);
-    EXPECT_EQ(popcount(NumericLimits<u16>::max()), 16);
-    EXPECT_EQ(popcount(NumericLimits<u32>::max()), 32);
-    EXPECT_EQ(popcount(NumericLimits<u64>::max()), 64);
-    EXPECT_EQ(popcount(NumericLimits<size_t>::max()), static_cast<int>(8 * sizeof(size_t)));
-    EXPECT_EQ(popcount(0u), 0);
-    EXPECT_EQ(popcount(0b01010101ULL), 4);
+    EXPECT_EQ(popcount(NumericLimits<u8>::max()), 8u);
+    EXPECT_EQ(popcount(NumericLimits<u16>::max()), 16u);
+    EXPECT_EQ(popcount(NumericLimits<u32>::max()), 32u);
+    EXPECT_EQ(popcount(NumericLimits<u64>::max()), 64u);
+    EXPECT_EQ(popcount(NumericLimits<size_t>::max()), bit_sizeof(size_t));
+    EXPECT_EQ(popcount(0u), 0u);
+    EXPECT_EQ(popcount(0b01010101ULL), 4u);
 }
 
 TEST_CASE(wrapped_count_leading_zeroes)
 {
-    EXPECT_EQ(count_leading_zeroes(NumericLimits<u8>::max()), 0);
-    EXPECT_EQ(count_leading_zeroes(static_cast<u8>(0x20)), 2);
-    EXPECT_EQ(count_leading_zeroes(static_cast<u8>(0)), 8);
-    EXPECT_EQ(count_leading_zeroes(NumericLimits<u16>::max()), 0);
-    EXPECT_EQ(count_leading_zeroes(static_cast<u16>(0x20)), 10);
-    EXPECT_EQ(count_leading_zeroes(static_cast<u16>(0)), 16);
-    EXPECT_EQ(count_leading_zeroes(NumericLimits<u32>::max()), 0);
-    EXPECT_EQ(count_leading_zeroes(static_cast<u32>(0x20)), 26);
-    EXPECT_EQ(count_leading_zeroes(static_cast<u32>(0)), 32);
-    EXPECT_EQ(count_leading_zeroes(NumericLimits<u64>::max()), 0);
+    EXPECT_EQ(count_leading_zeroes(NumericLimits<u8>::max()), 0u);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u8>(0x20)), 2u);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u8>(0)), 8u);
+    EXPECT_EQ(count_leading_zeroes(NumericLimits<u16>::max()), 0u);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u16>(0x20)), 10u);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u16>(0)), 16u);
+    EXPECT_EQ(count_leading_zeroes(NumericLimits<u32>::max()), 0u);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u32>(0x20)), 26u);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u32>(0)), 32u);
+    EXPECT_EQ(count_leading_zeroes(NumericLimits<u64>::max()), 0u);
 }
 
 TEST_CASE(wrapped_count_trailing_zeroes)
 {
-    EXPECT_EQ(count_trailing_zeroes(NumericLimits<u8>::max()), 0);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(1)), 0);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(2)), 1);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(0)), 8);
-    EXPECT_EQ(count_trailing_zeroes(NumericLimits<u16>::max()), 0);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(1)), 0);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(2)), 1);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(0)), 16);
-    EXPECT_EQ(count_trailing_zeroes(NumericLimits<u32>::max()), 0);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(1)), 0);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(2)), 1);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(0)), 32);
-    EXPECT_EQ(count_trailing_zeroes(NumericLimits<u64>::max()), 0);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u64>(1)), 0);
-    EXPECT_EQ(count_trailing_zeroes(static_cast<u64>(2)), 1);
+    EXPECT_EQ(count_trailing_zeroes(NumericLimits<u8>::max()), 0u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(1)), 0u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(2)), 1u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(0)), 8u);
+    EXPECT_EQ(count_trailing_zeroes(NumericLimits<u16>::max()), 0u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(1)), 0u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(2)), 1u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(0)), 16u);
+    EXPECT_EQ(count_trailing_zeroes(NumericLimits<u32>::max()), 0u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(1)), 0u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(2)), 1u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(0)), 32u);
+    EXPECT_EQ(count_trailing_zeroes(NumericLimits<u64>::max()), 0u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u64>(1)), 0u);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u64>(2)), 1u);
 }

--- a/Tests/AK/TestBuiltinWrappers.cpp
+++ b/Tests/AK/TestBuiltinWrappers.cpp
@@ -24,13 +24,13 @@ TEST_CASE(wrapped_count_leading_zeroes)
 {
     EXPECT_EQ(count_leading_zeroes(NumericLimits<u8>::max()), 0);
     EXPECT_EQ(count_leading_zeroes(static_cast<u8>(0x20)), 2);
-    EXPECT_EQ(count_leading_zeroes_safe(static_cast<u8>(0)), 8);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u8>(0)), 8);
     EXPECT_EQ(count_leading_zeroes(NumericLimits<u16>::max()), 0);
     EXPECT_EQ(count_leading_zeroes(static_cast<u16>(0x20)), 10);
-    EXPECT_EQ(count_leading_zeroes_safe(static_cast<u16>(0)), 16);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u16>(0)), 16);
     EXPECT_EQ(count_leading_zeroes(NumericLimits<u32>::max()), 0);
     EXPECT_EQ(count_leading_zeroes(static_cast<u32>(0x20)), 26);
-    EXPECT_EQ(count_leading_zeroes_safe(static_cast<u32>(0)), 32);
+    EXPECT_EQ(count_leading_zeroes(static_cast<u32>(0)), 32);
     EXPECT_EQ(count_leading_zeroes(NumericLimits<u64>::max()), 0);
 }
 

--- a/Tests/AK/TestBuiltinWrappers.cpp
+++ b/Tests/AK/TestBuiltinWrappers.cpp
@@ -39,15 +39,15 @@ TEST_CASE(wrapped_count_trailing_zeroes)
     EXPECT_EQ(count_trailing_zeroes(NumericLimits<u8>::max()), 0);
     EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(1)), 0);
     EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(2)), 1);
-    EXPECT_EQ(count_trailing_zeroes_safe(static_cast<u8>(0)), 8);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u8>(0)), 8);
     EXPECT_EQ(count_trailing_zeroes(NumericLimits<u16>::max()), 0);
     EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(1)), 0);
     EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(2)), 1);
-    EXPECT_EQ(count_trailing_zeroes_safe(static_cast<u16>(0)), 16);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u16>(0)), 16);
     EXPECT_EQ(count_trailing_zeroes(NumericLimits<u32>::max()), 0);
     EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(1)), 0);
     EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(2)), 1);
-    EXPECT_EQ(count_trailing_zeroes_safe(static_cast<u32>(0)), 32);
+    EXPECT_EQ(count_trailing_zeroes(static_cast<u32>(0)), 32);
     EXPECT_EQ(count_trailing_zeroes(NumericLimits<u64>::max()), 0);
     EXPECT_EQ(count_trailing_zeroes(static_cast<u64>(1)), 0);
     EXPECT_EQ(count_trailing_zeroes(static_cast<u64>(2)), 1);

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -328,7 +328,7 @@ static void populate_dib_mask_info_if_needed(BMPLoadingContext& context)
             continue;
         }
         int trailing_zeros = count_trailing_zeroes(mask);
-        int size = count_trailing_zeroes(~(mask >> trailing_zeros));
+        int size = count_trailing_ones(mask >> trailing_zeros);
         if (size > 8) {
             // Drop lowest bits if mask is longer than 8 bits.
             trailing_zeros += size - 8;

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -328,8 +328,7 @@ static void populate_dib_mask_info_if_needed(BMPLoadingContext& context)
             continue;
         }
         int trailing_zeros = count_trailing_zeroes(mask);
-        // If mask is exactly `0xFFFFFFFF`, then we might try to count the trailing zeros of 0x00000000 here, so we need the safe version:
-        int size = count_trailing_zeroes_safe(~(mask >> trailing_zeros));
+        int size = count_trailing_zeroes(~(mask >> trailing_zeros));
         if (size > 8) {
             // Drop lowest bits if mask is longer than 8 bits.
             trailing_zeros += size - 8;

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -485,7 +485,7 @@ static ThrowCompletionOr<String> decode(JS::GlobalObject& global_object, const S
         if (second_digit >= 16)
             return global_object.vm().throw_completion<URIError>(global_object, ErrorType::URIMalformed);
 
-        char decoded_code_unit = (first_digit << 4) | second_digit;
+        u8 decoded_code_unit = (first_digit << 4) | second_digit;
         k += 2;
         if (expected_continuation_bytes > 0) {
             decoded_builder.append(decoded_code_unit);
@@ -501,7 +501,7 @@ static ThrowCompletionOr<String> decode(JS::GlobalObject& global_object, const S
             continue;
         }
 
-        auto leading_ones = count_trailing_zeroes(static_cast<u32>(~decoded_code_unit)) - 24;
+        auto leading_ones = count_leading_ones(decoded_code_unit);
         if (leading_ones == 1 || leading_ones > 4)
             return global_object.vm().throw_completion<URIError>(global_object, ErrorType::URIMalformed);
 

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -501,7 +501,7 @@ static ThrowCompletionOr<String> decode(JS::GlobalObject& global_object, const S
             continue;
         }
 
-        auto leading_ones = count_trailing_zeroes_safe(static_cast<u32>(~decoded_code_unit)) - 24;
+        auto leading_ones = count_trailing_zeroes(static_cast<u32>(~decoded_code_unit)) - 24;
         if (leading_ones == 1 || leading_ones > 4)
             return global_object.vm().throw_completion<URIError>(global_object, ErrorType::URIMalformed);
 

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -302,8 +302,6 @@ JS_DEFINE_NATIVE_FUNCTION(MathObject::sign)
 JS_DEFINE_NATIVE_FUNCTION(MathObject::clz32)
 {
     auto number = TRY(vm.argument(0).to_u32(global_object));
-    if (number == 0)
-        return Value(32);
     return Value(count_leading_zeroes(number));
 }
 

--- a/Userland/Libraries/LibM/math.cpp
+++ b/Userland/Libraries/LibM/math.cpp
@@ -279,7 +279,7 @@ static FloatT internal_scalbn(FloatT x, int exponent) NOEXCEPT
         return extractor.d;
     }
 
-    unsigned leading_mantissa_zeroes = extractor.mantissa == 0 ? 32 : count_leading_zeroes(extractor.mantissa);
+    unsigned leading_mantissa_zeroes = count_leading_zeroes(extractor.mantissa);
     int shift = min((int)leading_mantissa_zeroes, exponent);
     exponent = max(exponent - shift, 0);
 

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -174,9 +174,6 @@ struct CountLeadingZeros {
     template<typename Lhs>
     i32 operator()(Lhs lhs) const
     {
-        if (lhs == 0)
-            return sizeof(Lhs) * CHAR_BIT;
-
         if constexpr (sizeof(Lhs) == 4 || sizeof(Lhs) == 8)
             return count_leading_zeroes(MakeUnsigned<Lhs>(lhs));
         else

--- a/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Operators.h
@@ -186,9 +186,6 @@ struct CountTrailingZeros {
     template<typename Lhs>
     i32 operator()(Lhs lhs) const
     {
-        if (lhs == 0)
-            return sizeof(Lhs) * CHAR_BIT;
-
         if constexpr (sizeof(Lhs) == 4 || sizeof(Lhs) == 8)
             return count_trailing_zeroes(MakeUnsigned<Lhs>(lhs));
         else


### PR DESCRIPTION
Hi,

The following patch sets tries to improve bit manipulations in wren, by providing a unified API, and making it safe by default.

I noticed that a lot of code was not correctly checking the conditions of `count_trailing_zeroes` which is not safe by default.
So better being safe than sorry, lets unify the bit API to be safe and if it become a real bottle neck, we could later reintroduce `*_unsafe(*)` of `*(unsafe, *)` versions of the API so unsafe functions document themselves.

Add `bit_sizeof` macro to help reducing the `8 * sizeof` hand coding.

Fix a `LibJS` issue when decoding UTF-8 encoded patterns, lower bits of the header byte are not always sets. The count the number of leading ones MUST be checked instead.