### PR TITLE
Base: Avoid running fuzz-syscalls on CI

### DIFF
--- a/Base/home/anon/.config/Tests.ini
+++ b/Base/home/anon/.config/Tests.ini
@@ -1,7 +1,7 @@
 [Global]
 SkipDirectories=Kernel/Legacy
 SkipRegex=^ue-.*$
-SkipTests=test-web TestCommonmark
+SkipTests=fuzz-syscalls test-web TestCommonmark
 NotTestsPattern=^.*(txt|frm|inc)$
 
 [test-js]


### PR DESCRIPTION
By design, it will frequently make weird syscalls that may disrupt the
environment. This can include, for example, deletion of important files,
or blocking operations like sleep or sigtimedwait. As such, this fuzzer
currently causes CI to fail sometimes, and fixing this issue would
simultaneously reduce the fuzzers capacity to find bugs. Hence, let's
disable it during CI.