### PR TITLE
LibCore: Make TCPServer propagate errors

### DIFF
--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -148,9 +148,11 @@ TEST_CASE(tcp_socket_read)
     //       Core::EventLoop through Core::Notifier.
     Core::EventLoop event_loop;
 
-    auto tcp_server = Core::TCPServer::construct();
-    EXPECT(tcp_server->listen({ 127, 0, 0, 1 }, 9090));
-    tcp_server->set_blocking(true);
+    auto maybe_tcp_server = Core::TCPServer::try_create();
+    EXPECT(!maybe_tcp_server.is_error());
+    auto tcp_server = maybe_tcp_server.release_value();
+    EXPECT(!tcp_server->listen({ 127, 0, 0, 1 }, 9090).is_error());
+    EXPECT(!tcp_server->set_blocking(true).is_error());
 
     auto maybe_client_socket = Core::Stream::TCPSocket::connect({ { 127, 0, 0, 1 }, 9090 });
     EXPECT(!maybe_client_socket.is_error());
@@ -181,9 +183,11 @@ TEST_CASE(tcp_socket_write)
 {
     Core::EventLoop event_loop;
 
-    auto tcp_server = Core::TCPServer::construct();
-    EXPECT(tcp_server->listen({ 127, 0, 0, 1 }, 9090));
-    tcp_server->set_blocking(true);
+    auto maybe_tcp_server = Core::TCPServer::try_create();
+    EXPECT(!maybe_tcp_server.is_error());
+    auto tcp_server = maybe_tcp_server.release_value();
+    EXPECT(!tcp_server->listen({ 127, 0, 0, 1 }, 9090).is_error());
+    EXPECT(!tcp_server->set_blocking(true).is_error());
 
     auto maybe_client_socket = Core::Stream::TCPSocket::connect({ { 127, 0, 0, 1 }, 9090 });
     EXPECT(!maybe_client_socket.is_error());
@@ -210,9 +214,11 @@ TEST_CASE(tcp_socket_eof)
 {
     Core::EventLoop event_loop;
 
-    auto tcp_server = Core::TCPServer::construct();
-    EXPECT(tcp_server->listen({ 127, 0, 0, 1 }, 9090));
-    tcp_server->set_blocking(true);
+    auto maybe_tcp_server = Core::TCPServer::try_create();
+    EXPECT(!maybe_tcp_server.is_error());
+    auto tcp_server = maybe_tcp_server.release_value();
+    EXPECT(!tcp_server->listen({ 127, 0, 0, 1 }, 9090).is_error());
+    EXPECT(!tcp_server->set_blocking(true).is_error());
 
     auto maybe_client_socket = Core::Stream::TCPSocket::connect({ { 127, 0, 0, 1 }, 9090 });
     EXPECT(!maybe_client_socket.is_error());
@@ -404,9 +410,11 @@ TEST_CASE(buffered_tcp_socket_read)
 {
     Core::EventLoop event_loop;
 
-    auto tcp_server = Core::TCPServer::construct();
-    EXPECT(tcp_server->listen({ 127, 0, 0, 1 }, 9090));
-    tcp_server->set_blocking(true);
+    auto maybe_tcp_server = Core::TCPServer::try_create();
+    EXPECT(!maybe_tcp_server.is_error());
+    auto tcp_server = maybe_tcp_server.release_value();
+    EXPECT(!tcp_server->listen({ 127, 0, 0, 1 }, 9090).is_error());
+    EXPECT(!tcp_server->set_blocking(true).is_error());
 
     auto maybe_client_socket = Core::Stream::TCPSocket::connect({ { 127, 0, 0, 1 }, 9090 });
     EXPECT(!maybe_client_socket.is_error());

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Kenneth Myhra <kennethmyhra@gmail.com>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,10 +9,13 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <fcntl.h>
 #include <grp.h>
 #include <pwd.h>
 #include <signal.h>
 #include <spawn.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <termios.h>
@@ -30,6 +34,10 @@ ErrorOr<void> ptrace_peekbuf(pid_t tid, void const* tracee_addr, Bytes destinati
 ErrorOr<void> setgroups(Span<gid_t const>);
 ErrorOr<void> mount(int source_fd, StringView target, StringView fs_type, int flags);
 ErrorOr<long> ptrace(int request, pid_t tid, void* address, void* data);
+#endif
+
+#ifndef AK_OS_MACOS
+ErrorOr<int> accept4(int sockfd, struct sockaddr*, socklen_t*, int flags);
 #endif
 
 ErrorOr<void> sigaction(int signal, struct sigaction const* action, struct sigaction* old_action);
@@ -77,5 +85,23 @@ ErrorOr<int> mkstemp(Span<char> pattern);
 ErrorOr<void> fchmod(int fd, mode_t mode);
 ErrorOr<void> rename(StringView old_path, StringView new_path);
 ErrorOr<void> utime(StringView path, Optional<struct utimbuf>);
+
+ErrorOr<int> socket(int domain, int type, int protocol);
+ErrorOr<void> bind(int sockfd, struct sockaddr const*, socklen_t);
+ErrorOr<void> listen(int sockfd, int backlog);
+ErrorOr<int> accept(int sockfd, struct sockaddr*, socklen_t*);
+ErrorOr<void> connect(int sockfd, struct sockaddr const*, socklen_t);
+ErrorOr<void> shutdown(int sockfd, int how);
+ErrorOr<ssize_t> send(int sockfd, void const*, size_t, int flags);
+ErrorOr<ssize_t> sendmsg(int sockfd, const struct msghdr*, int flags);
+ErrorOr<ssize_t> sendto(int sockfd, void const*, size_t, int flags, struct sockaddr const*, socklen_t);
+ErrorOr<ssize_t> recv(int sockfd, void*, size_t, int flags);
+ErrorOr<ssize_t> recvmsg(int sockfd, struct msghdr*, int flags);
+ErrorOr<ssize_t> recvfrom(int sockfd, void*, size_t, int flags, struct sockaddr*, socklen_t*);
+ErrorOr<void> getsockopt(int sockfd, int level, int option, void* value, socklen_t* value_size);
+ErrorOr<void> setsockopt(int sockfd, int level, int option, void const* value, socklen_t value_size);
+ErrorOr<void> getsockname(int sockfd, struct sockaddr*, socklen_t*);
+ErrorOr<void> getpeername(int sockfd, struct sockaddr*, socklen_t*);
+ErrorOr<void> socketpair(int domain, int type, int protocol, int sv[2]);
 
 }

--- a/Userland/Libraries/LibCore/TCPServer.h
+++ b/Userland/Libraries/LibCore/TCPServer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,13 +15,14 @@
 namespace Core {
 
 class TCPServer : public Object {
-    C_OBJECT(TCPServer)
+    C_OBJECT_ABSTRACT(TCPServer)
 public:
+    static ErrorOr<NonnullRefPtr<TCPServer>> try_create(Object* parent = nullptr);
     virtual ~TCPServer() override;
 
     bool is_listening() const { return m_listening; }
-    bool listen(const IPv4Address& address, u16 port);
-    void set_blocking(bool blocking);
+    ErrorOr<void> listen(IPv4Address const& address, u16 port);
+    ErrorOr<void> set_blocking(bool blocking);
 
     ErrorOr<Stream::TCPSocket> accept();
 
@@ -30,7 +32,7 @@ public:
     Function<void()> on_ready_to_accept;
 
 private:
-    explicit TCPServer(Object* parent = nullptr);
+    explicit TCPServer(int fd, Object* parent = nullptr);
 
     int m_fd { -1 };
     bool m_listening { false };

--- a/Userland/Services/EchoServer/CMakeLists.txt
+++ b/Userland/Services/EchoServer/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 )
 
 serenity_bin(EchoServer)
-target_link_libraries(EchoServer LibCore)
+target_link_libraries(EchoServer LibCore LibMain)

--- a/Userland/Services/EchoServer/main.cpp
+++ b/Userland/Services/EchoServer/main.cpp
@@ -31,12 +31,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::EventLoop event_loop;
 
-    auto server = Core::TCPServer::construct();
-
-    if (!server->listen({}, port)) {
-        warnln("Listening on 0.0.0.0:{} failed", port);
-        exit(1);
-    }
+    auto server = TRY(Core::TCPServer::try_create());
+    TRY(server->listen({}, port));
 
     HashMap<int, NonnullRefPtr<Client>> clients;
     int next_id = 0;

--- a/Userland/Services/EchoServer/main.cpp
+++ b/Userland/Services/EchoServer/main.cpp
@@ -9,28 +9,20 @@
 #include <AK/IPv4Address.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
+#include <LibCore/System.h>
 #include <LibCore/TCPServer.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
+#include <LibMain/Main.h>
 
-int main(int argc, char** argv)
+ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    if (pledge("stdio unix inet id accept", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
-
-    if (unveil(nullptr, nullptr) < 0) {
-        perror("unveil");
-        return 1;
-    }
+    TRY(Core::System::pledge("stdio unix inet id accept", nullptr));
+    TRY(Core::System::unveil(nullptr, nullptr));
 
     int port = 7;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(port, "Port to listen on", "port", 'p', "port");
-    args_parser.parse(argc, argv);
+    args_parser.parse(arguments);
 
     if ((u16)port != port) {
         warnln("Invalid port number: {}", port);

--- a/Userland/Services/TelnetServer/CMakeLists.txt
+++ b/Userland/Services/TelnetServer/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_bin(TelnetServer)
-target_link_libraries(TelnetServer LibCore)
+target_link_libraries(TelnetServer LibCore LibMain)

--- a/Userland/Services/TelnetServer/main.cpp
+++ b/Userland/Services/TelnetServer/main.cpp
@@ -97,12 +97,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     Core::EventLoop event_loop;
-    auto server = Core::TCPServer::construct();
-
-    if (!server->listen({}, port)) {
-        warnln("Listening on 0.0.0.0:{} failed", port);
-        exit(1);
-    }
+    auto server = TRY(Core::TCPServer::try_create());
+    TRY(server->listen({}, port));
 
     HashMap<int, NonnullRefPtr<Client>> clients;
     int next_id = 0;

--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -89,10 +89,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         client->start();
     };
 
-    if (!server->listen(ipv4_address.value(), port)) {
-        warnln("Failed to listen on {}:{}", ipv4_address.value(), port);
-        return 1;
-    }
+    TRY(server->listen(ipv4_address.value(), port));
 
     outln("Listening on {}:{}", ipv4_address.value(), port);
 


### PR DESCRIPTION
Most of this is fairly self-explanatory. All(?) the socket-related syscalls now have Core::System wrappers. TCPServer now returns ErrorOr from any methods that can fail. I've ported EchoServer and TelnetServer to LibMain, so that they can take advantage of this.

Then, I have the experimental commit which I'd really like some feedback on. It's an attempt to solve the problem of "how do you propagate errors that happen inside a callback lambda?" The solution here is, make the callback return an ErrorOr, then pass that error to a second error-handling callback. If that callback isn't set, just log the error and exit.

Also, we lose some of the more-detailed error messages by replacing everything with TRY. There's probably a way of getting the best of both worlds.