### PR TITLE
Kernel: Add ability to audiate syscalls

### DIFF
--- a/Base/usr/share/man/man7/boot_parameters.md
+++ b/Base/usr/share/man/man7/boot_parameters.md
@@ -21,6 +21,10 @@ List of options:
 * **`ahci_reset_mode`** - This parameter expects one of the following values. **`controller`** - Reset just the AHCI controller on boot.
    **`none`** - Don't perform any AHCI reset.  **`complete`** - Reset the AHCI controller, and all AHCI ports on boot.
 
+* **`audiate_syscalls`** - This parameter expects a binary value of **`on`** or **`off`**. If enabled, *every single syscall* will emit a beep.
+   The frequency of the beep depends on the syscall function used. Because this eats a lot of resources, it is best used in a text-only environment, like this:
+   `./Meta/serenity.sh run i686 "fbdev=no audiate_syscalls=on"`
+
 * **`boot_prof`** - If present on the command line, global system profiling will be enabled
    as soon as possible during the boot sequence. Allowing you to profile startup of all applications.
 

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -84,6 +84,7 @@ UNMAP_AFTER_INIT CommandLine::CommandLine(const String& cmdline_from_bootloader)
     const auto& args = m_string.split_view(' ');
     m_params.ensure_capacity(args.size());
     add_arguments(args);
+    m_cached_audiate_syscalls = lookup("audiate_syscalls"sv) == Optional<StringView>("on"sv);
 }
 
 Optional<StringView> CommandLine::lookup(StringView key) const

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -57,6 +57,7 @@ public:
     Optional<StringView> lookup(StringView key) const;
     [[nodiscard]] bool contains(StringView key) const;
 
+    [[nodiscard]] bool is_audiate_syscalls_enabled_cached() const { return m_cached_audiate_syscalls; };
     [[nodiscard]] bool is_boot_profiling_enabled() const;
     [[nodiscard]] bool is_ide_enabled() const;
     [[nodiscard]] bool is_ioapic_enabled() const;
@@ -91,6 +92,7 @@ private:
 
     String m_string;
     HashMap<StringView, StringView> m_params;
+    bool m_cached_audiate_syscalls;
 };
 
 const CommandLine& kernel_command_line();


### PR DESCRIPTION
Inspired by CxByte's and Lubrsi's versions. This PR uses exponential
frequencies that in theory should sound more reasonable.

![Syscall-audiation in action](https://user-images.githubusercontent.com/2690845/147389477-be759c05-5c3e-4e81-b7cb-9e0a897453d9.mp4)

Isn't that just *awesome*?! :D

At the *end* of each program, there are a lot of syscalls. Maybe a regression of #10821? Who knows, let's see in a different PR! :D