### PR TITLE
Kernel: Assert that a KmallocSubheap fits inside a page

### DIFF
--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -58,6 +58,7 @@ struct KmallocGlobalData {
     void add_subheap(u8* storage, size_t storage_size)
     {
         dbgln("Adding kmalloc subheap @ {} with size {}", storage, storage_size);
+        static_assert(sizeof(KmallocSubheap) <= PAGE_SIZE);
         auto* subheap = new (storage) KmallocSubheap(storage + PAGE_SIZE, storage_size - PAGE_SIZE);
         subheaps.append(*subheap);
     }


### PR DESCRIPTION
Since we allocate the subheap in the first page of the given storage let's assert that the subheap can actually fit in a single page, to prevent the possible future headache of trying to debug the cause of random kernel memory corruption :^)