### PR TITLE
LibCore: FilePermissionsMask

### DIFF
--- a/Base/usr/share/man/man1/mkdir.md
+++ b/Base/usr/share/man/man1/mkdir.md
@@ -15,13 +15,15 @@ Create a new empty directory for each of the given *directories*.
 ## Options
 
 * `-p`, `--parents`: Create parent directories if they don't exist
-* `-m`, `--mode`: Sets the permissions for the final directory (possibly altered by the process umask). The mode argument must be given in octal format.
+* `-m`, `--mode`: Sets the permissions for the final directory (possibly altered by the process umask). The mode argument can be given in any of the formats
+accepted by the chmod(1) command. Addition and removal of permissions is relative to a default permission of 0777.
 
 ## Examples
 
 ```sh
 $ mkdir -p /tmp/foo/bar
 $ mkdir -m 0700 /tmp/owner-only
+$ mkdir -m a=rx /tmp/foo/bar
 ```
 
 ## See also

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -4,6 +4,7 @@ set(TEST_SOURCES
     TestLibCoreIODevice.cpp
     TestLibCoreDeferredInvoke.cpp
     TestLibCoreStream.cpp
+    TestLibCoreFilePermissionsMask.cpp
 )
 
 foreach(source IN LISTS TEST_SOURCES)

--- a/Tests/LibCore/TestLibCoreFilePermissionsMask.cpp
+++ b/Tests/LibCore/TestLibCoreFilePermissionsMask.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2021, Xavier Defrang <xavier.defrang@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/FilePermissionsMask.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(file_permission_mask_from_symbolic_notation)
+{
+    auto mask = Core::FilePermissionsMask::from_symbolic_notation(""sv);
+    EXPECT(!mask.is_error());
+    EXPECT_EQ(mask.value().clear_mask(), 0);
+    EXPECT_EQ(mask.value().write_mask(), 0);
+    EXPECT_EQ(mask.value().apply(0), 0);
+    EXPECT_EQ(mask.value().apply(0664), 0664);
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("u+rwx"sv);
+    EXPECT(!mask.is_error());
+    EXPECT_EQ(mask.value().clear_mask(), 0);
+    EXPECT_EQ(mask.value().write_mask(), 0700);
+    EXPECT_EQ(mask.value().apply(0), 0700);
+    EXPECT_EQ(mask.value().apply(0664), 0764);
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("g+rwx"sv);
+    EXPECT(!mask.is_error());
+    EXPECT_EQ(mask.value().clear_mask(), 0);
+    EXPECT_EQ(mask.value().write_mask(), 0070);
+    EXPECT_EQ(mask.value().apply(0), 0070);
+    EXPECT_EQ(mask.value().apply(0664), 0674);
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("o+rwx"sv);
+    EXPECT(!mask.is_error());
+    EXPECT_EQ(mask.value().clear_mask(), 0);
+    EXPECT_EQ(mask.value().write_mask(), 0007);
+    EXPECT_EQ(mask.value().apply(0), 0007);
+    EXPECT_EQ(mask.value().apply(0664), 0667);
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("a=rx"sv);
+    EXPECT(!mask.is_error());
+    EXPECT_EQ(mask.value().clear_mask(), 0777);
+    EXPECT_EQ(mask.value().write_mask(), 0555);
+    EXPECT_EQ(mask.value().apply(0), 0555);
+    EXPECT_EQ(mask.value().apply(0664), 0555);
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("u+rw,g=rx,o-rwx"sv);
+    EXPECT(!mask.is_error());
+    EXPECT_EQ(mask.value().clear_mask(), 0077);
+    EXPECT_EQ(mask.value().write_mask(), 0650);
+    EXPECT_EQ(mask.value().apply(0), 0650);
+    EXPECT_EQ(mask.value().apply(0177), 0750);
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("z+rw"sv);
+    EXPECT(mask.is_error());
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("u*rw"sv);
+    EXPECT(mask.is_error());
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("u+rz"sv);
+    EXPECT(mask.is_error());
+
+    mask = Core::FilePermissionsMask::from_symbolic_notation("u+rw;g+rw"sv);
+    EXPECT(mask.is_error());
+}
+
+TEST_CASE(file_permission_mask_parse)
+{
+    auto numeric_mask = Core::FilePermissionsMask::parse("750"sv);
+    auto symbolic_mask = Core::FilePermissionsMask::parse("u=rwx,g=rx,o-rwx"sv);
+
+    EXPECT_EQ(numeric_mask.value().apply(0), 0750);
+    EXPECT_EQ(symbolic_mask.value().apply(0), 0750);
+
+    EXPECT_EQ(numeric_mask.value().clear_mask(), symbolic_mask.value().clear_mask());
+    EXPECT_EQ(numeric_mask.value().write_mask(), symbolic_mask.value().write_mask());
+
+    auto mask = Core::FilePermissionsMask::parse("888");
+    EXPECT(mask.is_error());
+
+    mask = Core::FilePermissionsMask::parse("z+rw");
+    EXPECT(mask.is_error());
+}

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SOURCES
     EventLoop.cpp
     FileWatcher.cpp
     File.cpp
+    FilePermissionsMask.cpp
     GetPassword.cpp
     IODevice.cpp
     LocalServer.cpp

--- a/Userland/Libraries/LibCore/FilePermissionsMask.cpp
+++ b/Userland/Libraries/LibCore/FilePermissionsMask.cpp
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2021, Xavier Defrang <xavier.defrang@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <AK/CharacterTypes.h>
+#include <AK/StringUtils.h>
+
+#include <LibCore/FilePermissionsMask.h>
+
+namespace Core {
+
+enum State {
+    Reference,
+    Mode
+};
+
+enum ClassFlag {
+    Other = 1,
+    Group = 2,
+    User = 4
+};
+
+enum Operation {
+    Add,
+    Remove,
+    Assign,
+};
+
+ErrorOr<FilePermissionsMask> FilePermissionsMask::parse(StringView string)
+{
+    return (!string.is_empty() && is_ascii_digit(string[0]))
+        ? from_numeric_notation(string)
+        : from_symbolic_notation(string);
+}
+
+ErrorOr<FilePermissionsMask> FilePermissionsMask::from_numeric_notation(StringView string)
+{
+    mode_t mode = AK::StringUtils::convert_to_uint_from_octal<u16>(string).value_or(01000);
+    if (mode > 0777)
+        return Error::from_string_literal("invalid octal representation"sv);
+    return FilePermissionsMask().assign_permissions(mode);
+}
+
+ErrorOr<FilePermissionsMask> FilePermissionsMask::from_symbolic_notation(StringView string)
+{
+    auto mask = FilePermissionsMask();
+
+    u8 state = State::Reference;
+    u8 classes = 0;
+    u8 operation = 0;
+
+    for (auto ch : string) {
+        switch (state) {
+        case State::Reference: {
+            // one or more [ugoa] terminated by one operator [+-=]
+            if (ch == 'u')
+                classes |= ClassFlag::User;
+            else if (ch == 'g')
+                classes |= ClassFlag::Group;
+            else if (ch == 'o')
+                classes |= ClassFlag::Other;
+            else if (ch == 'a')
+                classes = ClassFlag::User | ClassFlag::Group | ClassFlag::Other;
+            else {
+                if (classes == 0)
+                    return Error::from_string_literal("invalid access class: expected 'u', 'g', 'o' or 'a' "sv);
+
+                if (ch == '+')
+                    operation = Operation::Add;
+                else if (ch == '-')
+                    operation = Operation::Remove;
+                else if (ch == '=')
+                    operation = Operation::Assign;
+                else
+                    return Error::from_string_literal("invalid operation: expected '+', '-' or '='"sv);
+
+                state = State::Mode;
+            }
+
+            break;
+        }
+
+        case State::Mode: {
+            // one or more [rwx] terminated by a comma
+
+            // End of mode part, expect reference next
+            if (ch == ',') {
+                state = State::Reference;
+                classes = operation = 0;
+                continue;
+            }
+
+            mode_t write_bits = 0;
+
+            if (ch == 'r')
+                write_bits = 4;
+            else if (ch == 'w')
+                write_bits = 2;
+            else if (ch == 'x')
+                write_bits = 1;
+            else
+                return Error::from_string_literal("invalid symbolic permission"sv);
+
+            mode_t clear_bits = operation == Operation::Assign ? 7 : write_bits;
+
+            // Update masks one class at a time in other, group, user order
+            for (auto cls = classes; cls != 0; cls >>= 1) {
+                if (cls & 1) {
+                    if (operation == Operation::Add || operation == Operation::Assign)
+                        mask.add_permissions(write_bits);
+                    if (operation == Operation::Remove || operation == Operation::Assign)
+                        mask.remove_permissions(clear_bits);
+                }
+                write_bits <<= 3;
+                clear_bits <<= 3;
+            }
+
+            break;
+        }
+
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    return mask;
+}
+
+FilePermissionsMask& FilePermissionsMask::assign_permissions(mode_t mode)
+{
+    m_write_mask = mode;
+    m_clear_mask = 0777;
+    return *this;
+}
+
+FilePermissionsMask& FilePermissionsMask::add_permissions(mode_t mode)
+{
+    m_write_mask |= mode;
+    return *this;
+}
+
+FilePermissionsMask& FilePermissionsMask::remove_permissions(mode_t mode)
+{
+    m_clear_mask |= mode;
+    return *this;
+}
+
+}

--- a/Userland/Libraries/LibCore/FilePermissionsMask.h
+++ b/Userland/Libraries/LibCore/FilePermissionsMask.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2021, Xavier Defrang <xavier.defrang@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/String.h>
+#include <sys/stat.h>
+
+namespace Core {
+
+class FilePermissionsMask {
+public:
+    static ErrorOr<FilePermissionsMask> parse(StringView string);
+    static ErrorOr<FilePermissionsMask> from_numeric_notation(StringView string);
+    static ErrorOr<FilePermissionsMask> from_symbolic_notation(StringView string);
+
+    FilePermissionsMask()
+        : m_clear_mask(0)
+        , m_write_mask(0)
+    {
+    }
+
+    FilePermissionsMask& assign_permissions(mode_t mode);
+    FilePermissionsMask& add_permissions(mode_t mode);
+    FilePermissionsMask& remove_permissions(mode_t mode);
+
+    mode_t apply(mode_t mode) const { return m_write_mask | (mode & ~m_clear_mask); }
+    mode_t clear_mask() const { return m_clear_mask; }
+    mode_t write_mask() const { return m_write_mask; }
+
+private:
+    mode_t m_clear_mask; // the bits that will be cleared
+    mode_t m_write_mask; // the bits that will be set
+};
+
+}

--- a/Userland/Utilities/chmod.cpp
+++ b/Userland/Utilities/chmod.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Kenneth Myhra <kennethmyhra@gmail.com>
+ * Copyright (c) 2021, Xavier Defrang <xavier.defrang@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,61 +11,16 @@
 #include <AK/String.h>
 #include <AK/StringUtils.h>
 #include <AK/Vector.h>
+#include <LibCore/FilePermissionsMask.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 
-/* the new mode will be computed using the boolean function(for each bit):
-
-    |current mode|removal mask|applying mask|result |
-    |      0     |      0     |      0      |   0   |
-    |      0     |      0     |      1      |   1   |
-    |      0     |      1     |      0      |   0   |
-    |      0     |      1     |      1      |   1   | ---> find the CNF --> find the minimal CNF
-    |      1     |      0     |      0      |   1   |
-    |      1     |      0     |      1      |   1   |
-    |      1     |      1     |      0      |   0   |
-    |      1     |      1     |      1      |   1   |
-*/
-
-class Mask {
-private:
-    mode_t removal_mask;  // the bits that will be removed
-    mode_t applying_mask; // the bits that will be set
-
-public:
-    Mask()
-        : removal_mask(0)
-        , applying_mask(0)
-    {
-    }
-
-    Mask& operator|=(const Mask& other)
-    {
-        removal_mask |= other.removal_mask;
-        applying_mask |= other.applying_mask;
-
-        return *this;
-    }
-
-    mode_t& get_removal_mask() { return removal_mask; }
-    mode_t& get_applying_mask() { return applying_mask; }
-
-    void set_mode(mode_t mode)
-    {
-        this->applying_mask = mode;
-        this->removal_mask = ~mode;
-    }
-};
-
-Optional<Mask> string_to_mode(char access_scope, StringView access_string);
-Optional<Mask> apply_permission(char access_scope, char permission, char operation);
-
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath fattr", nullptr));
+    TRY(Core::System::pledge("stdio rpath fattr"));
 
     if (arguments.strings.size() < 3) {
         warnln("usage: chmod <octal-mode> <path...>");
@@ -72,174 +28,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    Mask mask;
+    auto mask = TRY(Core::FilePermissionsMask::parse(arguments.strings[1]));
 
-    /* compute a mask */
-
-    auto mode_string = arguments.strings[1];
-    if (mode_string[0] >= '0' && mode_string[0] <= '7') {
-        mode_t mode = AK::StringUtils::convert_to_uint_from_octal<u16>(mode_string).value_or(01000);
-        if (mode > 0777) {
-            warnln("chmod: invalid mode: {}", mode_string);
-            return 1;
-        }
-        mask.set_mode(mode);
-    } else {
-        auto access_strings = arguments.strings[1].split_view(',');
-        for (auto access_string : access_strings) {
-            Optional<Mask> tmp_mask;
-            switch (access_string[0]) {
-            case 'u':
-                tmp_mask = string_to_mode('u', access_string);
-                break;
-            case 'g':
-                tmp_mask = string_to_mode('g', access_string);
-                break;
-            case 'o':
-                tmp_mask = string_to_mode('o', access_string);
-                break;
-            case 'a':
-                tmp_mask = string_to_mode('a', access_string);
-                break;
-            case '=':
-            case '+':
-            case '-':
-                tmp_mask = string_to_mode('a', access_string);
-                break;
-            }
-            if (!tmp_mask.has_value()) {
-                warnln("chmod: invalid mode: {}", arguments.strings[1]);
-                return 1;
-            }
-            mask |= tmp_mask.value();
-        }
-    }
-
-    /* set the mask for each file's permissions */
-    size_t i = 2;
-    while (i < arguments.strings.size()) {
+    for (size_t i = 2; i < arguments.strings.size(); ++i) {
         auto current_access = TRY(Core::System::stat(arguments.strings[i]));
-        /* found the minimal CNF by The Quine–McCluskey algorithm and use it */
-        mode_t mode = mask.get_applying_mask()
-            | (current_access.st_mode & ~mask.get_removal_mask());
-        TRY(Core::System::chmod(arguments.strings[i++], mode));
+        TRY(Core::System::chmod(arguments.strings[i], mask.apply(current_access.st_mode)));
     }
 
     return 0;
-}
-
-Optional<Mask> string_to_mode(char access_scope, StringView access_string)
-{
-    auto get_operation = [](StringView s) {
-        for (auto c : s) {
-            if (c == '+' || c == '-' || c == '=')
-                return c;
-        }
-        return ' ';
-    };
-
-    auto operation = get_operation(access_string);
-    if (operation == ' ') {
-        return {};
-    }
-
-    Mask mask;
-    if (operation == '=') {
-        switch (access_scope) {
-        case 'u':
-            mask.get_removal_mask() = (S_IRUSR | S_IWUSR | S_IXUSR);
-            break;
-        case 'g':
-            mask.get_removal_mask() = (S_IRGRP | S_IWGRP | S_IXGRP);
-            break;
-        case 'o':
-            mask.get_removal_mask() = (S_IROTH | S_IWOTH | S_IXOTH);
-            break;
-        case 'a':
-            mask.get_removal_mask() = (S_IRUSR | S_IWUSR | S_IXUSR
-                | S_IRGRP | S_IWGRP | S_IXGRP
-                | S_IROTH | S_IWOTH | S_IXOTH);
-            break;
-        }
-        operation = '+';
-    }
-
-    for (size_t i = 1; i < access_string.length(); i++) {
-        char permission = access_string[i];
-        if (permission == '+' || permission == '-' || permission == '=')
-            continue;
-
-        Optional<Mask> tmp_mask;
-        tmp_mask = apply_permission(access_scope, permission, operation);
-        if (!tmp_mask.has_value()) {
-            return {};
-        }
-        mask |= tmp_mask.value();
-    }
-
-    return mask;
-}
-
-Optional<Mask> apply_permission(char access_scope, char permission, char operation)
-{
-    if (permission != 'r' && permission != 'w' && permission != 'x') {
-        return {};
-    }
-
-    Mask mask;
-    mode_t tmp_mask = 0;
-    switch (access_scope) {
-    case 'u':
-        switch (permission) {
-        case 'r':
-            tmp_mask = S_IRUSR;
-            break;
-        case 'w':
-            tmp_mask = S_IWUSR;
-            break;
-        case 'x':
-            tmp_mask = S_IXUSR;
-            break;
-        }
-        break;
-    case 'g':
-        switch (permission) {
-        case 'r':
-            tmp_mask = S_IRGRP;
-            break;
-        case 'w':
-            tmp_mask = S_IWGRP;
-            break;
-        case 'x':
-            tmp_mask = S_IXGRP;
-            break;
-        }
-        break;
-    case 'o':
-        switch (permission) {
-        case 'r':
-            tmp_mask = S_IROTH;
-            break;
-        case 'w':
-            tmp_mask = S_IWOTH;
-            break;
-        case 'x':
-            tmp_mask = S_IXOTH;
-            break;
-        }
-        break;
-    case 'a':
-        mask |= apply_permission('u', permission, operation).value();
-        mask |= apply_permission('g', permission, operation).value();
-        mask |= apply_permission('o', permission, operation).value();
-        break;
-    }
-
-    if (operation == '+') {
-        mask.get_applying_mask() |= tmp_mask;
-    } else {
-        mask.get_removal_mask() |= tmp_mask;
-    }
-
-    return mask;
 }

--- a/Userland/Utilities/mkdir.cpp
+++ b/Userland/Utilities/mkdir.cpp
@@ -1,14 +1,15 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2021, Xavier Defrang <xavier.defrang@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
-#include <AK/StringUtils.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/FilePermissionsMask.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 #include <errno.h>
@@ -25,19 +26,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.add_option(create_parents, "Create parent directories if they don't exist", "parents", 'p');
-    args_parser.add_option(mode_string, "Set new directory permissions", "mode", 'm', "octal-mode");
+    args_parser.add_option(mode_string, "Set new directory permissions", "mode", 'm', "mode");
     args_parser.add_positional_argument(directories, "Directories to create", "directories");
     args_parser.parse(arguments);
 
-    mode_t default_mode = 0755;
-    mode_t mode = default_mode;
+    mode_t const default_mode = 0755;
+    mode_t const mask_reference_mode = 0777;
 
-    if (!mode_string.is_empty()) {
-        mode = AK::StringUtils::convert_to_uint_from_octal<u16>(mode_string).value_or(01000);
-        if (mode > 0777) {
-            warnln("mkdir: invalid mode: {}", mode_string);
-            return 1;
-        }
+    Core::FilePermissionsMask mask;
+
+    if (mode_string.is_empty()) {
+        mask.assign_permissions(default_mode);
+    } else {
+        mask = TRY(Core::FilePermissionsMask::parse(mode_string));
     }
 
     bool has_errors = false;
@@ -45,7 +46,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     for (auto& directory : directories) {
         LexicalPath lexical_path(directory);
         if (!create_parents) {
-            if (mkdir(lexical_path.string().characters(), mode) < 0) {
+            if (mkdir(lexical_path.string().characters(), mask.apply(mask_reference_mode)) < 0) {
                 perror("mkdir");
                 has_errors = true;
             }
@@ -73,8 +74,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 }
 
                 bool is_final = (idx == (num_parts - 1));
+                mode_t mode = is_final ? mask.apply(mask_reference_mode) : default_mode;
 
-                if (mkdir(path.characters(), is_final ? mode : default_mode) < 0) {
+                if (mkdir(path.characters(), mode) < 0) {
                     perror("mkdir");
                     has_errors = true;
                     break;


### PR DESCRIPTION
This change introduces a Unix file permission parser class as discussed in https://github.com/SerenityOS/serenity/pull/11319.

I have rewritten the symbolic permission parsing algorithm to be FSM-based. It should now be more straightforward as it reduces the number of hoops and doesn't involve recursive calls anymore.

I have updated `mkdir` and `chmod` to use the new library, hence reducing the complexity of both utilities.