### PR TITLE
LibJS: Fix toFixed throwing on undefined, null and NaN fractionDigits

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -65,7 +65,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_fixed)
 {
     auto number_value = TRY(this_number_value(global_object, vm.this_value(global_object)));
     auto fraction_digits = TRY(vm.argument(0).to_integer_or_infinity(global_object));
-    if (!vm.argument(0).is_finite_number())
+    if (!Value(fraction_digits).is_finite_number())
         return vm.throw_completion<RangeError>(global_object, ErrorType::InvalidFractionDigits);
 
     if (fraction_digits < 0 || fraction_digits > 100)

--- a/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toFixed.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Number/Number.prototype.toFixed.js
@@ -15,6 +15,10 @@ describe("correct behavior", () => {
             // Numbers >= 1e+21
             [1e21, 5, "1e+21"],
             [1e22, 0, "1e+22"],
+            // undefined, null and NaN are treated as 0 due to toFixed using ToIntegerOrInfinity.
+            [1.1, undefined, "1"],
+            [1.1, null, "1"],
+            [1.1, NaN, "1"],
         ].forEach(testCase => {
             expect(testCase[0].toFixed(testCase[1])).toBe(testCase[2]);
         });
@@ -37,7 +41,7 @@ describe("errors", () => {
     });
 
     test("fixed digits RangeError", () => {
-        [-Infinity, -5, 105, Infinity, NaN].forEach(value => {
+        [-Infinity, -5, 105, Infinity].forEach(value => {
             expect(() => (0).toFixed(value)).toThrow(RangeError);
         });
     });


### PR DESCRIPTION
It was checking the original fractionDigits argument was a finite
number instead of the coerced fraction_digits.