### PR TITLE
Help: Fix memory leak given ambiguous man page title on command line

### DIFF
--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -331,6 +331,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     history.push(path);
                     open_page(path);
                     set_start_page = true;
+                    break;
                 }
             }
 


### PR DESCRIPTION
I recently built Serenity for the first time and quickly found the following problem when trying to read the man page on `uname`:

https://user-images.githubusercontent.com/20257197/147419961-859c35cb-739a-4480-b83e-ccdb636a7354.mp4

This PR fixes that.