### PR TITLE
Profiler: Add source code view

### DIFF
--- a/Userland/DevTools/Profiler/CMakeLists.txt
+++ b/Userland/DevTools/Profiler/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
         ProfileModel.cpp
         SamplesModel.cpp
         SignpostsModel.cpp
+        SourceModel.cpp
         TimelineContainer.cpp
         TimelineHeader.cpp
         TimelineTrack.cpp

--- a/Userland/DevTools/Profiler/CMakeLists.txt
+++ b/Userland/DevTools/Profiler/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
         main.cpp
         IndividualSampleModel.cpp
         FlameGraphView.cpp
+        Gradient.cpp
         Process.cpp
         Profile.cpp
         ProfileModel.cpp

--- a/Userland/DevTools/Profiler/DisassemblyModel.cpp
+++ b/Userland/DevTools/Profiler/DisassemblyModel.cpp
@@ -5,34 +5,17 @@
  */
 
 #include "DisassemblyModel.h"
+#include "Gradient.h"
 #include "Profile.h"
 #include <LibCore/MappedFile.h>
 #include <LibDebug/DebugInfo.h>
 #include <LibELF/Image.h>
-#include <LibGUI/Painter.h>
 #include <LibSymbolication/Symbolication.h>
 #include <LibX86/Disassembler.h>
 #include <LibX86/ELFSymbolProvider.h>
 #include <stdio.h>
 
 namespace Profiler {
-
-static Gfx::Bitmap const& heat_gradient()
-{
-    static RefPtr<Gfx::Bitmap> bitmap;
-    if (!bitmap) {
-        bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { 101, 1 }).release_value_but_fixme_should_propagate_errors();
-        GUI::Painter painter(*bitmap);
-        painter.fill_rect_with_gradient(Orientation::Horizontal, bitmap->rect(), Color::from_rgb(0xffc080), Color::from_rgb(0xff3000));
-    }
-    return *bitmap;
-}
-
-static Color color_for_percent(int percent)
-{
-    VERIFY(percent >= 0 && percent <= 100);
-    return heat_gradient().get_pixel(percent, 0);
-}
 
 static Optional<MappedObject> s_kernel_binary;
 

--- a/Userland/DevTools/Profiler/DisassemblyModel.cpp
+++ b/Userland/DevTools/Profiler/DisassemblyModel.cpp
@@ -17,7 +17,7 @@
 
 namespace Profiler {
 
-static const Gfx::Bitmap& heat_gradient()
+static Gfx::Bitmap const& heat_gradient()
 {
     static RefPtr<Gfx::Bitmap> bitmap;
     if (!bitmap) {
@@ -54,8 +54,8 @@ DisassemblyModel::DisassemblyModel(Profile& profile, ProfileNode& node)
     , m_node(node)
 {
     FlatPtr base_address = 0;
-    const Debug::DebugInfo* debug_info;
-    const ELF::Image* elf;
+    Debug::DebugInfo const* debug_info;
+    ELF::Image const* elf;
     if (auto maybe_kernel_base = Symbolication::kernel_base(); maybe_kernel_base.has_value() && m_node.address() >= *maybe_kernel_base) {
         if (!g_kernel_debuginfo_object.has_value())
             return;
@@ -107,7 +107,7 @@ DisassemblyModel::DisassemblyModel(Profile& profile, ProfileNode& node)
     auto view = symbol.value().raw_data().substring_view(symbol_offset_from_function_start);
 
     X86::ELFSymbolProvider symbol_provider(*elf, base_address);
-    X86::SimpleInstructionStream stream((const u8*)view.characters_without_null_termination(), view.length());
+    X86::SimpleInstructionStream stream((u8 const*)view.characters_without_null_termination(), view.length());
     X86::Disassembler disassembler(stream);
 
     size_t offset_into_symbol = 0;
@@ -143,7 +143,7 @@ DisassemblyModel::~DisassemblyModel()
 {
 }
 
-int DisassemblyModel::row_count(const GUI::ModelIndex&) const
+int DisassemblyModel::row_count(GUI::ModelIndex const&) const
 {
     return m_instructions.size();
 }
@@ -172,7 +172,7 @@ struct ColorPair {
     Color foreground;
 };
 
-static Optional<ColorPair> color_pair_for(const InstructionData& insn)
+static Optional<ColorPair> color_pair_for(InstructionData const& insn)
 {
     if (insn.percent == 0)
         return {};
@@ -186,7 +186,7 @@ static Optional<ColorPair> color_pair_for(const InstructionData& insn)
     return ColorPair { background, foreground };
 }
 
-GUI::Variant DisassemblyModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+GUI::Variant DisassemblyModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
     auto const& insn = m_instructions[index.row()];
 

--- a/Userland/DevTools/Profiler/DisassemblyModel.h
+++ b/Userland/DevTools/Profiler/DisassemblyModel.h
@@ -43,10 +43,10 @@ public:
 
     virtual ~DisassemblyModel() override;
 
-    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
-    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return Column::__Count; }
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int) const override;
-    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 
 private:

--- a/Userland/DevTools/Profiler/FlameGraphView.cpp
+++ b/Userland/DevTools/Profiler/FlameGraphView.cpp
@@ -123,7 +123,7 @@ void FlameGraphView::paint_event(GUI::PaintEvent& event)
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
-    for (const auto& bar : m_bars) {
+    for (auto const& bar : m_bars) {
         auto label = bar_label(bar);
 
         auto color = m_colors[label.hash() % m_colors.size()];

--- a/Userland/DevTools/Profiler/Gradient.cpp
+++ b/Userland/DevTools/Profiler/Gradient.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Gradient.h"
+#include <LibGUI/Painter.h>
+
+namespace Profiler {
+
+static Gfx::Bitmap const& heat_gradient()
+{
+    static RefPtr<Gfx::Bitmap> bitmap;
+    if (!bitmap) {
+        bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { 101, 1 }).release_value_but_fixme_should_propagate_errors();
+        GUI::Painter painter(*bitmap);
+        painter.fill_rect_with_gradient(Orientation::Horizontal, bitmap->rect(), Color::from_rgb(0xffc080), Color::from_rgb(0xff3000));
+    }
+    return *bitmap;
+}
+
+Color color_for_percent(u8 percent)
+{
+    VERIFY(percent <= 100);
+    return heat_gradient().get_pixel(percent, 0);
+}
+
+}

--- a/Userland/DevTools/Profiler/Gradient.h
+++ b/Userland/DevTools/Profiler/Gradient.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Color.h>
+
+namespace Profiler {
+
+Color color_for_percent(u8 percent);
+
+}

--- a/Userland/DevTools/Profiler/IndividualSampleModel.cpp
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.cpp
@@ -21,13 +21,13 @@ IndividualSampleModel::~IndividualSampleModel()
 {
 }
 
-int IndividualSampleModel::row_count(const GUI::ModelIndex&) const
+int IndividualSampleModel::row_count(GUI::ModelIndex const&) const
 {
     auto const& event = m_profile.events().at(m_event_index);
     return event.frames.size();
 }
 
-int IndividualSampleModel::column_count(const GUI::ModelIndex&) const
+int IndividualSampleModel::column_count(GUI::ModelIndex const&) const
 {
     return Column::__Count;
 }
@@ -46,7 +46,7 @@ String IndividualSampleModel::column_name(int column) const
     }
 }
 
-GUI::Variant IndividualSampleModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+GUI::Variant IndividualSampleModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
     auto const& event = m_profile.events().at(m_event_index);
     auto const& frame = event.frames[event.frames.size() - index.row() - 1];

--- a/Userland/DevTools/Profiler/IndividualSampleModel.h
+++ b/Userland/DevTools/Profiler/IndividualSampleModel.h
@@ -28,16 +28,16 @@ public:
 
     virtual ~IndividualSampleModel() override;
 
-    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
-    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual String column_name(int) const override;
-    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
 
 private:
     IndividualSampleModel(Profile&, size_t event_index);
 
     Profile& m_profile;
-    const size_t m_event_index { 0 };
+    size_t const m_event_index { 0 };
 };
 
 }

--- a/Userland/DevTools/Profiler/Process.cpp
+++ b/Userland/DevTools/Profiler/Process.cpp
@@ -43,7 +43,7 @@ void Process::handle_thread_exit(pid_t tid, EventSerialNumber serial)
 
 HashMap<String, OwnPtr<MappedObject>> g_mapped_object_cache;
 
-static MappedObject* get_or_create_mapped_object(const String& path)
+static MappedObject* get_or_create_mapped_object(String const& path)
 {
     if (auto it = g_mapped_object_cache.find(path); it != g_mapped_object_cache.end())
         return it->value.ptr();
@@ -67,7 +67,7 @@ static MappedObject* get_or_create_mapped_object(const String& path)
     return ptr;
 }
 
-void LibraryMetadata::handle_mmap(FlatPtr base, size_t size, const String& name)
+void LibraryMetadata::handle_mmap(FlatPtr base, size_t size, String const& name)
 {
     StringView path;
     if (name.contains("Loader.so"sv))
@@ -107,7 +107,7 @@ void LibraryMetadata::handle_mmap(FlatPtr base, size_t size, const String& name)
     }
 }
 
-const Debug::DebugInfo& LibraryMetadata::Library::load_debug_info(FlatPtr base_address) const
+Debug::DebugInfo const& LibraryMetadata::Library::load_debug_info(FlatPtr base_address) const
 {
     if (debug_info == nullptr)
         debug_info = make<Debug::DebugInfo>(object->elf, String::empty(), base_address);
@@ -122,7 +122,7 @@ String LibraryMetadata::Library::symbolicate(FlatPtr ptr, u32* offset) const
     return object->elf.symbolicate(ptr - base, offset);
 }
 
-const LibraryMetadata::Library* LibraryMetadata::library_containing(FlatPtr ptr) const
+LibraryMetadata::Library const* LibraryMetadata::library_containing(FlatPtr ptr) const
 {
     for (auto& it : m_libraries) {
         auto& library = *it.value;

--- a/Userland/DevTools/Profiler/Process.h
+++ b/Userland/DevTools/Profiler/Process.h
@@ -34,11 +34,11 @@ public:
         mutable OwnPtr<Debug::DebugInfo> debug_info;
 
         String symbolicate(FlatPtr, u32* offset) const;
-        const Debug::DebugInfo& load_debug_info(FlatPtr base_address) const;
+        Debug::DebugInfo const& load_debug_info(FlatPtr base_address) const;
     };
 
-    void handle_mmap(FlatPtr base, size_t size, const String& name);
-    const Library* library_containing(FlatPtr) const;
+    void handle_mmap(FlatPtr base, size_t size, String const& name);
+    Library const* library_containing(FlatPtr) const;
 
 private:
     mutable HashMap<String, NonnullOwnPtr<Library>> m_libraries;

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -8,6 +8,7 @@
 #include "DisassemblyModel.h"
 #include "ProfileModel.h"
 #include "SamplesModel.h"
+#include "SourceModel.h"
 #include <AK/HashTable.h>
 #include <AK/LexicalPath.h>
 #include <AK/NonnullOwnPtrVector.h>
@@ -552,6 +553,23 @@ void Profile::set_disassembly_index(const GUI::ModelIndex& index)
 GUI::Model* Profile::disassembly_model()
 {
     return m_disassembly_model;
+}
+
+void Profile::set_source_index(GUI::ModelIndex const& index)
+{
+    if (m_source_index == index)
+        return;
+    m_source_index = index;
+    auto* node = static_cast<ProfileNode*>(index.internal_data());
+    if (!node)
+        m_source_model = nullptr;
+    else
+        m_source_model = SourceModel::create(*this, *node);
+}
+
+GUI::Model* Profile::source_model()
+{
+    return m_source_model;
 }
 
 ProfileNode::ProfileNode(Process const& process)

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -145,7 +145,7 @@ void Profile::rebuild_tree()
             ProfileNode* node = nullptr;
             auto& process_node = find_or_create_process_node(event.pid, event.serial);
             process_node.increment_event_count();
-            for_each_frame([&](const Frame& frame, bool is_innermost_frame) {
+            for_each_frame([&](Frame const& frame, bool is_innermost_frame) {
                 auto const& object_name = frame.object_name;
                 auto const& symbol = frame.symbol;
                 auto const& address = frame.address;
@@ -538,7 +538,7 @@ void Profile::set_show_percentages(bool show_percentages)
     m_show_percentages = show_percentages;
 }
 
-void Profile::set_disassembly_index(const GUI::ModelIndex& index)
+void Profile::set_disassembly_index(GUI::ModelIndex const& index)
 {
     if (m_disassembly_index == index)
         return;

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -52,8 +52,8 @@ public:
     bool has_seen_event(size_t event_index) const { return m_seen_events.get(event_index); }
     void did_see_event(size_t event_index) { m_seen_events.set(event_index, true); }
 
-    const FlyString& object_name() const { return m_object_name; }
-    const String& symbol() const { return m_symbol; }
+    FlyString const& object_name() const { return m_object_name; }
+    String const& symbol() const { return m_symbol; }
     FlatPtr address() const { return m_address; }
     u32 offset() const { return m_offset; }
     u64 timestamp() const { return m_timestamp; }
@@ -62,7 +62,7 @@ public:
     u32 self_count() const { return m_self_count; }
 
     int child_count() const { return m_children.size(); }
-    const Vector<NonnullRefPtr<ProfileNode>>& children() const { return m_children; }
+    Vector<NonnullRefPtr<ProfileNode>> const& children() const { return m_children; }
 
     void add_child(ProfileNode& child)
     {
@@ -87,14 +87,14 @@ public:
     };
 
     ProfileNode* parent() { return m_parent; }
-    const ProfileNode* parent() const { return m_parent; }
+    ProfileNode const* parent() const { return m_parent; }
 
     void increment_event_count() { ++m_event_count; }
     void increment_self_count() { ++m_self_count; }
 
     void sort_children();
 
-    const HashMap<FlatPtr, size_t>& events_per_address() const { return m_events_per_address; }
+    HashMap<FlatPtr, size_t> const& events_per_address() const { return m_events_per_address; }
     void add_event_address(FlatPtr address)
     {
         auto it = m_events_per_address.find(address);
@@ -150,7 +150,7 @@ public:
     GUI::Model* disassembly_model();
     GUI::Model* source_model();
 
-    const Process* find_process(pid_t pid, EventSerialNumber serial) const
+    Process const* find_process(pid_t pid, EventSerialNumber serial) const
     {
         auto it = m_processes.find_if([&pid, &serial](auto& entry) {
             return entry.pid == pid && entry.valid_at(serial);
@@ -158,10 +158,10 @@ public:
         return it.is_end() ? nullptr : &(*it);
     }
 
-    void set_disassembly_index(const GUI::ModelIndex&);
-    void set_source_index(const GUI::ModelIndex&);
+    void set_disassembly_index(GUI::ModelIndex const&);
+    void set_source_index(GUI::ModelIndex const&);
 
-    const Vector<NonnullRefPtr<ProfileNode>>& roots() const { return m_roots; }
+    Vector<NonnullRefPtr<ProfileNode>> const& roots() const { return m_roots; }
 
     struct Frame {
         FlyString object_name;
@@ -225,8 +225,8 @@ public:
     };
 
     Vector<Event> const& events() const { return m_events; }
-    const Vector<size_t>& filtered_event_indices() const { return m_filtered_event_indices; }
-    const Vector<size_t>& filtered_signpost_indices() const { return m_filtered_signpost_indices; }
+    Vector<size_t> const& filtered_event_indices() const { return m_filtered_event_indices; }
+    Vector<size_t> const& filtered_signpost_indices() const { return m_filtered_signpost_indices; }
 
     u64 length_in_ms() const { return m_last_timestamp - m_first_timestamp; }
     u64 first_timestamp() const { return m_first_timestamp; }
@@ -250,7 +250,7 @@ public:
     bool show_percentages() const { return m_show_percentages; }
     void set_show_percentages(bool);
 
-    const Vector<Process>& processes() const { return m_processes; }
+    Vector<Process> const& processes() const { return m_processes; }
 
     template<typename Callback>
     void for_each_event_in_filter_range(Callback callback)

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -12,6 +12,7 @@
 #include "ProfileModel.h"
 #include "SamplesModel.h"
 #include "SignpostsModel.h"
+#include "SourceModel.h"
 #include <AK/Bitmap.h>
 #include <AK/FlyString.h>
 #include <AK/JsonArray.h>
@@ -147,6 +148,7 @@ public:
     GUI::Model& samples_model();
     GUI::Model& signposts_model();
     GUI::Model* disassembly_model();
+    GUI::Model* source_model();
 
     const Process* find_process(pid_t pid, EventSerialNumber serial) const
     {
@@ -157,6 +159,7 @@ public:
     }
 
     void set_disassembly_index(const GUI::ModelIndex&);
+    void set_source_index(const GUI::ModelIndex&);
 
     const Vector<NonnullRefPtr<ProfileNode>>& roots() const { return m_roots; }
 
@@ -281,8 +284,10 @@ private:
     RefPtr<SamplesModel> m_samples_model;
     RefPtr<SignpostsModel> m_signposts_model;
     RefPtr<DisassemblyModel> m_disassembly_model;
+    RefPtr<SourceModel> m_source_model;
 
     GUI::ModelIndex m_disassembly_index;
+    GUI::ModelIndex m_source_index;
 
     Vector<NonnullRefPtr<ProfileNode>> m_roots;
     Vector<size_t> m_filtered_event_indices;

--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -23,7 +23,7 @@ ProfileModel::~ProfileModel()
 {
 }
 
-GUI::ModelIndex ProfileModel::index(int row, int column, const GUI::ModelIndex& parent) const
+GUI::ModelIndex ProfileModel::index(int row, int column, GUI::ModelIndex const& parent) const
 {
     if (!parent.is_valid()) {
         if (m_profile.roots().is_empty())
@@ -34,7 +34,7 @@ GUI::ModelIndex ProfileModel::index(int row, int column, const GUI::ModelIndex& 
     return create_index(row, column, remote_parent.children().at(row).ptr());
 }
 
-GUI::ModelIndex ProfileModel::parent_index(const GUI::ModelIndex& index) const
+GUI::ModelIndex ProfileModel::parent_index(GUI::ModelIndex const& index) const
 {
     if (!index.is_valid())
         return {};
@@ -62,7 +62,7 @@ GUI::ModelIndex ProfileModel::parent_index(const GUI::ModelIndex& index) const
     return {};
 }
 
-int ProfileModel::row_count(const GUI::ModelIndex& index) const
+int ProfileModel::row_count(GUI::ModelIndex const& index) const
 {
     if (!index.is_valid())
         return m_profile.roots().size();
@@ -70,7 +70,7 @@ int ProfileModel::row_count(const GUI::ModelIndex& index) const
     return node.children().size();
 }
 
-int ProfileModel::column_count(const GUI::ModelIndex&) const
+int ProfileModel::column_count(GUI::ModelIndex const&) const
 {
     return Column::__Count;
 }
@@ -94,7 +94,7 @@ String ProfileModel::column_name(int column) const
     }
 }
 
-GUI::Variant ProfileModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+GUI::Variant ProfileModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
     auto* node = static_cast<ProfileNode*>(index.internal_data());
     if (role == GUI::ModelRole::TextAlignment) {

--- a/Userland/DevTools/Profiler/ProfileModel.h
+++ b/Userland/DevTools/Profiler/ProfileModel.h
@@ -30,12 +30,12 @@ public:
 
     virtual ~ProfileModel() override;
 
-    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
-    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual String column_name(int) const override;
-    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
-    virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex& parent = GUI::ModelIndex()) const override;
-    virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
+    virtual GUI::ModelIndex index(int row, int column, GUI::ModelIndex const& parent = GUI::ModelIndex()) const override;
+    virtual GUI::ModelIndex parent_index(GUI::ModelIndex const&) const override;
     virtual int tree_column() const override { return Column::StackFrame; }
     virtual bool is_column_sortable(int) const override { return false; }
     virtual bool is_searchable() const override { return true; }

--- a/Userland/DevTools/Profiler/SamplesModel.cpp
+++ b/Userland/DevTools/Profiler/SamplesModel.cpp
@@ -21,12 +21,12 @@ SamplesModel::~SamplesModel()
 {
 }
 
-int SamplesModel::row_count(const GUI::ModelIndex&) const
+int SamplesModel::row_count(GUI::ModelIndex const&) const
 {
     return m_profile.filtered_event_indices().size();
 }
 
-int SamplesModel::column_count(const GUI::ModelIndex&) const
+int SamplesModel::column_count(GUI::ModelIndex const&) const
 {
     return Column::__Count;
 }
@@ -53,7 +53,7 @@ String SamplesModel::column_name(int column) const
     }
 }
 
-GUI::Variant SamplesModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+GUI::Variant SamplesModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
     u32 event_index = m_profile.filtered_event_indices()[index.row()];
     auto const& event = m_profile.events().at(event_index);

--- a/Userland/DevTools/Profiler/SamplesModel.h
+++ b/Userland/DevTools/Profiler/SamplesModel.h
@@ -32,10 +32,10 @@ public:
 
     virtual ~SamplesModel() override;
 
-    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
-    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual String column_name(int) const override;
-    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 
 private:

--- a/Userland/DevTools/Profiler/SignpostsModel.cpp
+++ b/Userland/DevTools/Profiler/SignpostsModel.cpp
@@ -19,12 +19,12 @@ SignpostsModel::~SignpostsModel()
 {
 }
 
-int SignpostsModel::row_count(const GUI::ModelIndex&) const
+int SignpostsModel::row_count(GUI::ModelIndex const&) const
 {
     return m_profile.filtered_signpost_indices().size();
 }
 
-int SignpostsModel::column_count(const GUI::ModelIndex&) const
+int SignpostsModel::column_count(GUI::ModelIndex const&) const
 {
     return Column::__Count;
 }
@@ -51,7 +51,7 @@ String SignpostsModel::column_name(int column) const
     }
 }
 
-GUI::Variant SignpostsModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+GUI::Variant SignpostsModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
     u32 event_index = m_profile.filtered_signpost_indices()[index.row()];
     auto const& event = m_profile.events().at(event_index);

--- a/Userland/DevTools/Profiler/SignpostsModel.h
+++ b/Userland/DevTools/Profiler/SignpostsModel.h
@@ -32,10 +32,10 @@ public:
 
     virtual ~SignpostsModel() override;
 
-    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
-    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual String column_name(int) const override;
-    virtual GUI::Variant data(const GUI::ModelIndex&, GUI::ModelRole) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
     virtual bool is_column_sortable(int) const override { return false; }
 
 private:

--- a/Userland/DevTools/Profiler/SourceModel.cpp
+++ b/Userland/DevTools/Profiler/SourceModel.cpp
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "SourceModel.h"
+#include "Profile.h"
+#include <LibDebug/DebugInfo.h>
+#include <LibGUI/Painter.h>
+#include <LibSymbolication/Symbolication.h>
+#include <stdio.h>
+
+namespace Profiler {
+
+class SourceFile final {
+public:
+    struct Line {
+        String content;
+        size_t num_samples { 0 };
+    };
+
+    static constexpr StringView source_root_path = "/usr/src/serenity/"sv;
+
+public:
+    SourceFile(StringView filename)
+    {
+        String source_file_name = filename.replace("../../", source_root_path);
+
+        auto maybe_file = Core::File::open(source_file_name, Core::OpenMode::ReadOnly);
+        if (maybe_file.is_error()) {
+            dbgln("Could not map source file \"{}\". Tried {}. {} (errno={})", filename, source_file_name, maybe_file.error().string_literal(), maybe_file.error().code());
+            return;
+        }
+
+        auto file = maybe_file.value();
+
+        while (!file->eof())
+            m_lines.append({ file->read_line(1024), 0 });
+    }
+
+    void try_add_samples(size_t line, size_t samples)
+    {
+        if (line < 1 || line - 1 >= m_lines.size())
+            return;
+
+        m_lines[line - 1].num_samples += samples;
+    }
+
+    Vector<Line> const& lines() const { return m_lines; }
+
+private:
+    Vector<Line> m_lines;
+};
+
+static Gfx::Bitmap const& heat_gradient()
+{
+    static RefPtr<Gfx::Bitmap> bitmap;
+    if (!bitmap) {
+        bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { 101, 1 }).release_value_but_fixme_should_propagate_errors();
+        GUI::Painter painter(*bitmap);
+        painter.fill_rect_with_gradient(Orientation::Horizontal, bitmap->rect(), Color::from_rgb(0xffc080), Color::from_rgb(0xff3000));
+    }
+    return *bitmap;
+}
+
+static Color color_for_percent(int percent)
+{
+    VERIFY(percent >= 0 && percent <= 100);
+    return heat_gradient().get_pixel(percent, 0);
+}
+
+SourceModel::SourceModel(Profile& profile, ProfileNode& node)
+    : m_profile(profile)
+    , m_node(node)
+{
+    FlatPtr base_address = 0;
+    Debug::DebugInfo const* debug_info;
+    if (auto maybe_kernel_base = Symbolication::kernel_base(); maybe_kernel_base.has_value() && m_node.address() >= *maybe_kernel_base) {
+        if (!g_kernel_debuginfo_object.has_value())
+            return;
+        base_address = maybe_kernel_base.release_value();
+        if (g_kernel_debug_info == nullptr)
+            g_kernel_debug_info = make<Debug::DebugInfo>(g_kernel_debuginfo_object->elf, String::empty(), base_address);
+        debug_info = g_kernel_debug_info.ptr();
+    } else {
+        auto const& process = node.process();
+        auto const* library_data = process.library_metadata.library_containing(node.address());
+        if (!library_data) {
+            dbgln("no library data for address {:p}", node.address());
+            return;
+        }
+        base_address = library_data->base;
+        debug_info = &library_data->load_debug_info(base_address);
+    }
+
+    VERIFY(debug_info != nullptr);
+
+    // Try to read all source files contributing to the selected function and aggregate the samples by line.
+    HashMap<String, SourceFile> source_files;
+    for (auto const& pair : node.events_per_address()) {
+        auto position = debug_info->get_source_position(pair.key - base_address);
+        if (position.has_value()) {
+            auto it = source_files.find(position.value().file_path);
+            if (it == source_files.end()) {
+                source_files.set(position.value().file_path, SourceFile(position.value().file_path));
+                it = source_files.find(position.value().file_path);
+            }
+
+            it->value.try_add_samples(position.value().line_number, pair.value);
+        }
+    }
+
+    // Process source file map and turn content into view model
+    for (auto const& file_iterator : source_files) {
+        u32 line_number = 0;
+        for (auto const& line_iterator : file_iterator.value.lines()) {
+            line_number++;
+
+            m_source_lines.append({
+                (u32)line_iterator.num_samples,
+                line_iterator.num_samples * 100.0f / node.event_count(),
+                file_iterator.key,
+                line_number,
+                line_iterator.content,
+            });
+        }
+    }
+}
+
+int SourceModel::row_count(GUI::ModelIndex const&) const
+{
+    return m_source_lines.size();
+}
+
+String SourceModel::column_name(int column) const
+{
+    switch (column) {
+    case Column::SampleCount:
+        return m_profile.show_percentages() ? "% Samples" : "# Samples";
+    case Column::SourceCode:
+        return "Source Code";
+    case Column::Location:
+        return "Location";
+    case Column::LineNumber:
+        return "Line";
+    default:
+        VERIFY_NOT_REACHED();
+        return {};
+    }
+}
+
+struct ColorPair {
+    Color background;
+    Color foreground;
+};
+
+static Optional<ColorPair> color_pair_for(SourceLineData const& line)
+{
+    if (line.percent == 0)
+        return {};
+
+    Color background = color_for_percent(line.percent);
+    Color foreground;
+    if (line.percent > 50)
+        foreground = Color::White;
+    else
+        foreground = Color::Black;
+    return ColorPair { background, foreground };
+}
+
+GUI::Variant SourceModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
+{
+    auto const& line = m_source_lines[index.row()];
+
+    if (role == GUI::ModelRole::BackgroundColor) {
+        auto colors = color_pair_for(line);
+        if (!colors.has_value())
+            return {};
+        return colors.value().background;
+    }
+
+    if (role == GUI::ModelRole::ForegroundColor) {
+        auto colors = color_pair_for(line);
+        if (!colors.has_value())
+            return {};
+        return colors.value().foreground;
+    }
+
+    if (role == GUI::ModelRole::Font) {
+        if (index.column() == Column::SourceCode)
+            return Gfx::FontDatabase::default_fixed_width_font();
+        return {};
+    }
+
+    if (role == GUI::ModelRole::Display) {
+        if (index.column() == Column::SampleCount) {
+            if (m_profile.show_percentages())
+                return ((float)line.event_count / (float)m_node.event_count()) * 100.0f;
+            return line.event_count;
+        }
+
+        if (index.column() == Column::Location)
+            return line.location;
+
+        if (index.column() == Column::LineNumber)
+            return line.line_number;
+
+        if (index.column() == Column::SourceCode)
+            return line.source_code;
+
+        return {};
+    }
+    return {};
+}
+
+}

--- a/Userland/DevTools/Profiler/SourceModel.cpp
+++ b/Userland/DevTools/Profiler/SourceModel.cpp
@@ -5,9 +5,10 @@
  */
 
 #include "SourceModel.h"
+#include "Gradient.h"
 #include "Profile.h"
 #include <LibDebug/DebugInfo.h>
-#include <LibGUI/Painter.h>
+#include <LibGfx/FontDatabase.h>
 #include <LibSymbolication/Symbolication.h>
 #include <stdio.h>
 
@@ -52,23 +53,6 @@ public:
 private:
     Vector<Line> m_lines;
 };
-
-static Gfx::Bitmap const& heat_gradient()
-{
-    static RefPtr<Gfx::Bitmap> bitmap;
-    if (!bitmap) {
-        bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { 101, 1 }).release_value_but_fixme_should_propagate_errors();
-        GUI::Painter painter(*bitmap);
-        painter.fill_rect_with_gradient(Orientation::Horizontal, bitmap->rect(), Color::from_rgb(0xffc080), Color::from_rgb(0xff3000));
-    }
-    return *bitmap;
-}
-
-static Color color_for_percent(int percent)
-{
-    VERIFY(percent >= 0 && percent <= 100);
-    return heat_gradient().get_pixel(percent, 0);
-}
 
 SourceModel::SourceModel(Profile& profile, ProfileNode& node)
     : m_profile(profile)

--- a/Userland/DevTools/Profiler/SourceModel.h
+++ b/Userland/DevTools/Profiler/SourceModel.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Model.h>
+
+namespace Profiler {
+
+class Profile;
+class ProfileNode;
+
+struct SourceLineData {
+    u32 event_count { 0 };
+    float percent { 0 };
+    String location;
+    u32 line_number { 0 };
+    String source_code;
+};
+
+class SourceModel final : public GUI::Model {
+public:
+    static NonnullRefPtr<SourceModel> create(Profile& profile, ProfileNode& node)
+    {
+        return adopt_ref(*new SourceModel(profile, node));
+    }
+
+    enum Column {
+        SampleCount,
+        Location,
+        LineNumber,
+        SourceCode,
+        __Count
+    };
+
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override;
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
+    virtual String column_name(int) const override;
+    virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
+    virtual bool is_column_sortable(int) const override { return false; }
+
+private:
+    SourceModel(Profile&, ProfileNode&);
+
+    Profile& m_profile;
+    ProfileNode& m_node;
+
+    Vector<SourceLineData> m_source_lines;
+};
+
+}

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -46,7 +46,7 @@ static bool generate_profile(pid_t& pid);
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     int pid = 0;
-    const char* perfcore_file_arg = nullptr;
+    char const* perfcore_file_arg = nullptr;
     Core::ArgsParser args_parser;
     args_parser.add_option(pid, "PID to profile", "pid", 'p', "PID");
     args_parser.add_positional_argument(perfcore_file_arg, "Path of perfcore file", "perfcore-file", Core::ArgsParser::Required::No);
@@ -190,7 +190,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto individual_sample_view = TRY(samples_splitter->try_add<GUI::TableView>());
     samples_table_view->on_selection_change = [&] {
-        const auto& index = samples_table_view->selection().first();
+        auto const& index = samples_table_view->selection().first();
         auto model = IndividualSampleModel::create(*profile, index.data(GUI::ModelRole::Custom).to_integer<size_t>());
         individual_sample_view->set_model(move(model));
     };
@@ -205,7 +205,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto individual_signpost_view = TRY(signposts_splitter->try_add<GUI::TableView>());
     signposts_table_view->on_selection_change = [&] {
-        const auto& index = signposts_table_view->selection().first();
+        auto const& index = signposts_table_view->selection().first();
         auto model = IndividualSampleModel::create(*profile, index.data(GUI::ModelRole::Custom).to_integer<size_t>());
         individual_signpost_view->set_model(move(model));
     };
@@ -216,9 +216,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto flamegraph_view = TRY(flamegraph_tab->try_add<FlameGraphView>(profile->model(), ProfileModel::Column::StackFrame, ProfileModel::Column::SampleCount));
 
-    const u64 start_of_trace = profile->first_timestamp();
-    const u64 end_of_trace = start_of_trace + profile->length_in_ms();
-    const auto clamp_timestamp = [start_of_trace, end_of_trace](u64 timestamp) -> u64 {
+    u64 const start_of_trace = profile->first_timestamp();
+    u64 const end_of_trace = start_of_trace + profile->length_in_ms();
+    auto const clamp_timestamp = [start_of_trace, end_of_trace](u64 timestamp) -> u64 {
         return min(end_of_trace, max(timestamp, start_of_trace));
     };
 
@@ -291,7 +291,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     return app->exec();
 }
 
-static bool prompt_to_stop_profiling(pid_t pid, const String& process_name)
+static bool prompt_to_stop_profiling(pid_t pid, String const& process_name)
 {
     auto window = GUI::Window::construct();
     window->set_title(String::formatted("Profiling {}({})", process_name, pid));


### PR DESCRIPTION
![Bildschirmfoto zu 2021-12-26 23-39-25](https://user-images.githubusercontent.com/2094371/147423624-e642ecbc-fe3a-4a13-828c-463493ce7cef.png)

This adds a new view mode to profiler which displays source lines and
samples that occured at those lines. This view can be opened via the
menu or by pressing CTRL-S.

It does this by mapping file names from DWARF to "/usr/src/serenity/..."
i.e. source code should be copied to /usr/src/serenity/Userland and
/usr/src/serenity/Kernel to be visible in this mode.

Currently *all* files contributing to the selected function are loaded
completely which could be a lot of data when dealing with lots of
inlined code.