### PR TITLE
LibCore: Callback error propagation via EventLoop

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -122,6 +122,8 @@ public:
     ErrorType release_error() { return m_error.release_value(); }
     void release_value() { }
 
+    void fixme_should_propagate_errors() { VERIFY(!is_error()); }
+
 private:
     Optional<ErrorType> m_error;
 };

--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -1,8 +1,9 @@
 set(TEST_SOURCES
     TestLibCoreArgsParser.cpp
+    TestLibCoreDeferredInvoke.cpp
+    TestLibCoreEventLoopErrors.cpp
     TestLibCoreFileWatcher.cpp
     TestLibCoreIODevice.cpp
-    TestLibCoreDeferredInvoke.cpp
     TestLibCoreStream.cpp
 )
 

--- a/Tests/LibCore/TestLibCoreDeferredInvoke.cpp
+++ b/Tests/LibCore/TestLibCoreDeferredInvoke.cpp
@@ -21,5 +21,5 @@ TEST_CASE(deferred_invoke)
         event_loop.quit(0);
     });
 
-    event_loop.exec();
+    event_loop.exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Tests/LibCore/TestLibCoreEventLoopErrors.cpp
+++ b/Tests/LibCore/TestLibCoreEventLoopErrors.cpp
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Timer.h>
+#include <LibTest/TestCase.h>
+
+TEST_CASE(event_loop_error_handling)
+{
+    Core::EventLoop event_loop;
+
+    auto some_callback_which_might_error = []() -> ErrorOr<void> {
+        return Error::from_string_literal("Oh noes!"sv);
+    };
+
+    Core::deferred_invoke([&] {
+        Core::EventLoop::current().try_callback(some_callback_which_might_error());
+    });
+
+    auto reaper = Core::Timer::create_single_shot(250, [] {
+        warnln("I waited for the event loop to exit with an error, but it never did!");
+        VERIFY_NOT_REACHED();
+    });
+
+    auto result = event_loop.exec();
+    EXPECT(result.is_error());
+    EXPECT_EQ(result.error().string_literal(), "Oh noes!"sv);
+}

--- a/Tests/LibCore/TestLibCoreFileWatcher.cpp
+++ b/Tests/LibCore/TestLibCoreFileWatcher.cpp
@@ -56,5 +56,5 @@ TEST_CASE(file_watcher_child_events)
     });
     catchall_timer->start();
 
-    event_loop.exec();
+    event_loop.exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -298,7 +298,7 @@ TEST_CASE(local_socket_read)
         EXPECT(server_socket->write(sent_data));
 
         event_loop.quit(0);
-        event_loop.pump();
+        event_loop.pump().fixme_should_propagate_errors();
     };
 
     // NOTE: Doing this on another thread, because otherwise we're at an
@@ -329,7 +329,7 @@ TEST_CASE(local_socket_read)
         },
         [](int) {});
 
-    event_loop.exec();
+    event_loop.exec().release_value_but_fixme_should_propagate_errors();
     ::unlink("/tmp/test-socket");
 }
 
@@ -351,7 +351,7 @@ TEST_CASE(local_socket_write)
         EXPECT_EQ(sent_data, received_data);
 
         event_loop.quit(0);
-        event_loop.pump();
+        event_loop.pump().fixme_should_propagate_errors();
     };
 
     // NOTE: Same reason as in the local_socket_read test.
@@ -368,7 +368,7 @@ TEST_CASE(local_socket_write)
         },
         [](int) {});
 
-    event_loop.exec();
+    event_loop.exec().release_value_but_fixme_should_propagate_errors();
     ::unlink("/tmp/test-socket");
 }
 

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -113,5 +113,5 @@ TEST_CASE(test_TLS_hello_handshake)
         FAIL("connect() failed");
         return;
     }
-    loop.exec();
+    loop.exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -320,5 +320,5 @@ int main(int argc, char** argv)
     window->move_to(window->x(), window->y() - (GUI::Desktop::the().rect().height() * 0.33));
     window->show();
 
-    return app->exec();
+    return app->exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -145,5 +145,5 @@ int main(int argc, char** argv)
     help_menu.add_action(GUI::CommonActions::make_about_action("Calendar", app_icon, window));
 
     window->show();
-    app->exec();
+    return app->exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -85,7 +85,7 @@ static TitleAndText build_backtrace(Coredump::Reader const& coredump, ELF::Core:
         progress_window->set_progress(100.0f * (float)(frame_index + 1) / (float)frame_count);
         progressbar.set_value(frame_index + 1);
         progressbar.set_max(frame_count);
-        Core::EventLoop::current().pump(Core::EventLoop::WaitMode::PollForEvents);
+        Core::EventLoop::current().pump(Core::EventLoop::WaitMode::PollForEvents).fixme_should_propagate_errors();
     });
     progress_window->close();
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -70,5 +70,5 @@ int main(int argc, char** argv)
         hex_editor_widget.open_file(*response.fd, *response.chosen_file);
     }
 
-    return app->exec();
+    return app->exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -93,5 +93,5 @@ int main(int argc, char** argv)
 
     window->show();
 
-    return app->exec();
+    return app->exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -95,5 +95,5 @@ int main(int argc, char* argv[])
 
     window->show();
 
-    return app->exec();
+    return app->exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -368,7 +368,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil(nullptr, nullptr));
 
     window->show();
-    int result = app->exec();
+    int result = TRY(app->exec());
     dbgln("Exiting terminal, updating utmp");
     utmp_update(ptsname, 0, false);
     return result;

--- a/Userland/Applications/VideoPlayer/main.cpp
+++ b/Userland/Applications/VideoPlayer/main.cpp
@@ -50,5 +50,5 @@ int main(int argc, char** argv)
     }
 
     window->show();
-    return app->exec();
+    return app->exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Libraries/LibCore/Promise.h
+++ b/Userland/Libraries/LibCore/Promise.h
@@ -32,7 +32,7 @@ public:
     Result await()
     {
         while (!is_resolved()) {
-            Core::EventLoop::current().pump();
+            Core::EventLoop::current().pump().fixme_should_propagate_errors();
         }
         return m_pending.release_value();
     }

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -114,7 +114,7 @@ Application::~Application()
     revoke_weak_ptrs();
 }
 
-int Application::exec()
+ErrorOr<int> Application::exec()
 {
     return m_event_loop->exec();
 }

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -30,7 +30,7 @@ public:
 
     static bool in_teardown();
 
-    int exec();
+    ErrorOr<int> exec();
     void quit(int = 0);
 
     Action* action_for_key_event(const KeyEvent&);

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -142,7 +142,7 @@ public:
         window->set_frameless(true);
         window->show();
 
-        if (!m_event_loop->exec())
+        if (!m_event_loop->exec().release_value_but_fixme_should_propagate_errors())
             return {};
         return m_col;
     }

--- a/Userland/Libraries/LibGUI/Dialog.cpp
+++ b/Userland/Libraries/LibGUI/Dialog.cpp
@@ -86,7 +86,7 @@ int Dialog::exec()
 
     set_rect(window_rect);
     show();
-    auto result = m_event_loop->exec();
+    auto result = m_event_loop->exec().release_value_but_fixme_should_propagate_errors();
     m_event_loop = nullptr;
     dbgln("{}: Event loop returned with result {}", *this, result);
     remove_from_parent();

--- a/Userland/Libraries/LibJS/Runtime/Completion.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Completion.cpp
@@ -98,7 +98,7 @@ ThrowCompletionOr<Value> await(GlobalObject& global_object, Value value)
     //        running all queued promise jobs.
     // Note: This is not used by LibJS itself, and is performed for the embedder (i.e. LibWeb).
     if (Core::EventLoop::has_been_instantiated())
-        Core::EventLoop::current().spin_until([&] { return promise->state() != Promise::State::Pending; });
+        MUST(Core::EventLoop::current().spin_until([&] { return promise->state() != Promise::State::Pending; }));
 
     // 8. Remove asyncContext from the execution context stack and restore the execution context that is at the top of the execution context stack as the running execution context.
     // NOTE: Since we don't push any EC, this step is not performed.

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -726,7 +726,7 @@ auto Editor::get_line(String const& prompt) -> Result<String, Editor::Error>
     if (!m_incomplete_data.is_empty())
         deferred_invoke([&] { try_update_once(); });
 
-    if (loop.exec() == Retry)
+    if (loop.exec().release_value_but_fixme_should_propagate_errors() == Retry)
         return get_line(prompt);
 
     return m_input_error.has_value() ? Result<String, Editor::Error> { m_input_error.value() } : Result<String, Editor::Error> { m_returned_line };

--- a/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
+++ b/Userland/Libraries/LibWeb/HTML/EventLoop/EventLoop.cpp
@@ -76,11 +76,12 @@ void EventLoop::spin_until(Function<bool()> goal_condition)
     //    1. Wait until the condition goal is met.
     Core::EventLoop loop;
     loop.spin_until([&]() -> bool {
-        if (goal_condition())
-            return true;
+            if (goal_condition())
+                return true;
 
-        return goal_condition();
-    });
+            return goal_condition();
+        })
+        .fixme_should_propagate_errors();
 
     // 7. Stop task, allowing whatever algorithm that invoked it to resume.
     // NOTE: This is achieved by returning from the function.

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -49,7 +49,7 @@ void ResourceLoader::load_sync(LoadRequest& request, Function<void(ReadonlyBytes
             loop.quit(0);
         });
 
-    loop.exec();
+    loop.exec().release_value_but_fixme_should_propagate_errors();
 }
 
 void ResourceLoader::prefetch_dns(AK::URL const& url)

--- a/Userland/Services/EchoServer/main.cpp
+++ b/Userland/Services/EchoServer/main.cpp
@@ -72,5 +72,5 @@ int main(int argc, char** argv)
 
     outln("Listening on 0.0.0.0:{}", port);
 
-    return event_loop.exec();
+    return event_loop.exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<RequestServer::ClientConnection>());
 
-    auto result = event_loop.exec();
+    auto result = TRY(event_loop.exec());
 
     // FIXME: We exit instead of returning, so that protocol destructors don't get called.
     //        The Protocol base class should probably do proper de-registration instead of

--- a/Userland/Services/TelnetServer/main.cpp
+++ b/Userland/Services/TelnetServer/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char** argv)
         clients.set(id, client);
     };
 
-    int rc = event_loop.exec();
+    int rc = event_loop.exec().release_value_but_fixme_should_propagate_errors();
     if (rc != 0) {
         fprintf(stderr, "event loop exited badly; rc=%d", rc);
         exit(1);

--- a/Userland/Services/WindowServer/EventLoop.h
+++ b/Userland/Services/WindowServer/EventLoop.h
@@ -22,7 +22,7 @@ public:
     EventLoop();
     virtual ~EventLoop();
 
-    int exec() { return m_event_loop.exec(); }
+    int exec() { return m_event_loop.exec().release_value_but_fixme_should_propagate_errors(); }
 
 private:
     void drain_mouse();

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1719,7 +1719,7 @@ void Execute::for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(Non
             }
         } };
 
-        auto exit_reason = loop.exec();
+        auto exit_reason = loop.exec().release_value_but_fixme_should_propagate_errors();
 
         notifier->on_ready_to_read = nullptr;
 

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1095,7 +1095,7 @@ void Shell::block_on_job(RefPtr<Job> job)
         return;
 
     while (!job_exited)
-        Core::EventLoop::current().pump();
+        Core::EventLoop::current().pump().fixme_should_propagate_errors();
 
     // If the job is part of a pipeline, wait for the rest of the members too.
     if (auto command = job->command_ptr())

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -192,5 +192,5 @@ int main(int argc, char** argv)
 
     Core::EventLoop::current().post_event(*shell, make<Core::CustomEvent>(Shell::Shell::ShellEventType::ReadLine));
 
-    return loop.exec();
+    return loop.exec().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Utilities/paste.cpp
+++ b/Userland/Utilities/paste.cpp
@@ -85,7 +85,7 @@ int main(int argc, char* argv[])
         // Trigger it the first time immediately.
         clipboard.on_change({});
 
-        return app->exec();
+        return app->exec().release_value_but_fixme_should_propagate_errors();
     }
 
     auto data_and_type = clipboard.fetch_data_and_type();

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -278,7 +278,7 @@ int main(int argc, char** argv)
 
     dbgln("started request with id {}", request->id());
 
-    auto rc = loop.exec();
+    auto rc = loop.exec().release_value_but_fixme_should_propagate_errors();
     // FIXME: This shouldn't be needed.
     fclose(stdout);
     return rc;

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -117,7 +117,7 @@ int main(int argc, char** argv)
         window->set_has_alpha_channel(true);
         window->set_fullscreen(true);
         window->show();
-        app->exec();
+        app->exec().release_value_but_fixme_should_propagate_errors();
 
         crop_region = container.region();
         if (crop_region.value().is_empty()) {

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -346,5 +346,5 @@ int main(int argc, char** argv)
         repl.source_file(file_to_source);
     if (!file_to_read.is_empty())
         repl.read_file(file_to_read);
-    return repl.run();
+    return repl.run().release_value_but_fixme_should_propagate_errors();
 }

--- a/Userland/Utilities/test-crypto.cpp
+++ b/Userland/Utilities/test-crypto.cpp
@@ -112,10 +112,10 @@ static int run(Function<void(const char*, size_t)> fn)
             auto& line = line_result.value();
 
             if (line == ".wait") {
-                g_loop.exec();
+                g_loop.exec().release_value_but_fixme_should_propagate_errors();
             } else {
                 fn(line.characters(), line.length());
-                g_loop.pump();
+                g_loop.pump().fixme_should_propagate_errors();
             }
         }
     } else {
@@ -134,7 +134,7 @@ static int run(Function<void(const char*, size_t)> fn)
         }
         auto buffer = file.value()->read_all();
         fn((const char*)buffer.data(), buffer.size());
-        g_loop.exec();
+        g_loop.exec().release_value_but_fixme_should_propagate_errors();
     }
     return 0;
 }
@@ -2056,7 +2056,7 @@ static void tls_test_client_hello()
         FAIL(connect() failed);
         return;
     }
-    loop.exec();
+    loop.exec().release_value_but_fixme_should_propagate_errors();
 }
 
 static int adler32_tests()


### PR DESCRIPTION
This PR will allow callbacks as used in Serenity to be able to use the `TRY` construct, which makes error handling in callbacks quite a bit nicer, similar to what we did with `serenity_main`. When callers of callbacks want the error to propagate to the top level, they pass the error to the current `EventLoop` instance through the `try_callback` method:

```c++
// Function<ErrorOr<void>()> on_ready_to_read;
if (on_ready_to_read)
    Core::EventLoop::current().try_callback(on_ready_to_read());
```

If `on_ready_to_read` returns an error result, the error result will be stored in the event loop, and the very next pump will cause the error to be returned; at that point, the error will be handled by whoever executed the event loop (usually `{serenity_,}main`).

One thing I really dislike is the return type of `try_callback`. `Optional<Result>` requires us to specialize the template function, but `ErrorOr<Result>` due to `[[nodiscard]]` requires us to handle the return value explicitly on every caller site despite already handling the error through the use of `try_callback`. Suggestions on that are very welcome.