### PR TITLE
Ports/libuv: Fix build failure due to missing statfs() function

### DIFF
--- a/Ports/libuv/patches/0002-fs-Stub-out-unsupported-syscalls.patch
+++ b/Ports/libuv/patches/0002-fs-Stub-out-unsupported-syscalls.patch
@@ -1,17 +1,47 @@
-From ef46efb9fb0a1faa306fb1e74a0b44faf6c6d41f Mon Sep 17 00:00:00 2001
+From a697c23403039b835526011561bbe4182e4d00fc Mon Sep 17 00:00:00 2001
 From: Ali Mohammad Pur <ali.mpfard@gmail.com>
 Date: Fri, 9 Jul 2021 04:56:55 +0430
 Subject: [PATCH 2/7] fs: Stub out unsupported syscalls
 
 ---
- src/unix/fs.c | 24 +++++++++++++++++++++++-
- 1 file changed, 23 insertions(+), 1 deletion(-)
+ src/unix/fs.c | 13 ++++++++++---
+ 1 file changed, 10 insertions(+), 3 deletions(-)
 
 diff --git a/src/unix/fs.c b/src/unix/fs.c
-index eb17fb4..93b457b 100644
+index eb17fb4..cdc57a7 100644
 --- a/src/unix/fs.c
 +++ b/src/unix/fs.c
-@@ -1666,7 +1680,9 @@ static void uv__fs_work(struct uv__work* w) {
+@@ -88,7 +88,8 @@
+       defined(__MVS__)    || \
+       defined(__NetBSD__) || \
+       defined(__HAIKU__)  || \
+-      defined(__QNX__)
++      defined(__QNX__)    || \
++      defined(__serenity__)
+ # include <sys/statvfs.h>
+ #else
+ # include <sys/statfs.h>
+@@ -655,7 +656,8 @@ static int uv__fs_statfs(uv_fs_t* req) {
+     defined(__MVS__)    || \
+     defined(__NetBSD__) || \
+     defined(__HAIKU__)  || \
+-    defined(__QNX__)
++    defined(__QNX__)    || \
++    defined(__serenity__)
+   struct statvfs buf;
+ 
+   if (0 != statvfs(req->path, &buf))
+@@ -677,7 +679,8 @@ static int uv__fs_statfs(uv_fs_t* req) {
+     defined(__OpenBSD__)  || \
+     defined(__NetBSD__)   || \
+     defined(__HAIKU__)    || \
+-    defined(__QNX__)
++    defined(__QNX__)      || \
++    defined(__serenity__)
+   stat_fs->f_type = 0;  /* f_type is not supported. */
+ #else
+   stat_fs->f_type = buf.f_type;
+@@ -1666,7 +1669,9 @@ static void uv__fs_work(struct uv__work* w) {
      X(COPYFILE, uv__fs_copyfile(req));
      X(FCHMOD, fchmod(req->file, req->mode));
      X(FCHOWN, fchown(req->file, req->uid, req->gid));
@@ -21,7 +51,7 @@ index eb17fb4..93b457b 100644
      X(FDATASYNC, uv__fs_fdatasync(req));
      X(FSTAT, uv__fs_fstat(req->file, &req->statbuf));
      X(FSYNC, uv__fs_fsync(req));
-@@ -1805,7 +1823,9 @@ int uv_fs_lchown(uv_loop_t* loop,
+@@ -1805,7 +1810,9 @@ int uv_fs_lchown(uv_loop_t* loop,
                   uv_uid_t uid,
                   uv_gid_t gid,
                   uv_fs_cb cb) {
@@ -32,5 +62,5 @@ index eb17fb4..93b457b 100644
    req->uid = uid;
    req->gid = gid;
 -- 
-2.32.0
+2.34.1
 


### PR DESCRIPTION
In 43c27e8, I mistakenly deleted the patch that removed calls to the
statfs() function, which we do not have. This made building the port
with a clean source tree fail.

This commit changes `libuv` to use our statvfs() function instead.