### PR TITLE
LibSoftGPU: Mark `wrap_clamp` as [[maybe_unused]]

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Sampler.cpp
+++ b/Userland/Libraries/LibSoftGPU/Sampler.cpp
@@ -24,7 +24,7 @@ static constexpr float wrap_repeat(float value)
     return fracf(value);
 }
 
-static constexpr float wrap_clamp(float value)
+[[maybe_unused]] static constexpr float wrap_clamp(float value)
 {
     return clamp(value, 0.0f, 1.0f);
 }


### PR DESCRIPTION
This was breaking the fuzzer build becaues the function is not used
if the `CLAMP_DEPRECATED_BEHAVIOR` constexpr is not `true` during
compile time.