### PR TITLE
KeyboardMapper: clean up codebase & minor fixes

### DIFF
--- a/Userland/Applications/KeyboardMapper/CMakeLists.txt
+++ b/Userland/Applications/KeyboardMapper/CMakeLists.txt
@@ -11,4 +11,4 @@ set(SOURCES
 )
 
 serenity_app(KeyboardMapper ICON app-keyboard-mapper)
-target_link_libraries(KeyboardMapper LibGUI LibKeyboard)
+target_link_libraries(KeyboardMapper LibGUI LibKeyboard LibMain)

--- a/Userland/Applications/KeyboardMapper/KeyButton.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyButton.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Hüseyin Aslıtürk <asliturk@hotmail.com>
+ * Copyright (c) 2021, Rasmus Nylander <RasmusNylander.SerenityOS@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Applications/KeyboardMapper/KeyButton.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyButton.cpp
@@ -22,23 +22,27 @@ void KeyButton::paint_event(GUI::PaintEvent& event)
     auto cont_rect = rect();
     auto& font = this->font();
 
-    Color color;
+    Color face_color;
     if (m_pressed) {
-        color = Color::Cyan;
+        face_color = Color::Cyan;
     } else if (!is_enabled()) {
-        color = Color::LightGray;
+        face_color = Color::LightGray;
     } else {
-        color = Color::White;
+        face_color = Color::White;
     }
 
-    painter.fill_rect(cont_rect, Color::Black);
-    painter.fill_rect({ cont_rect.x() + 1, cont_rect.y() + 1, cont_rect.width() - 2, cont_rect.height() - 2 }, Color::from_rgb(0x999999));
-    painter.fill_rect({ cont_rect.x() + 6, cont_rect.y() + 3, cont_rect.width() - 12, cont_rect.height() - 12 }, Color::from_rgb(0x8C7272));
-    painter.fill_rect({ cont_rect.x() + 7, cont_rect.y() + 4, cont_rect.width() - 14, cont_rect.height() - 14 }, color);
+    Gfx::IntRect key_cap_side_rect = { cont_rect.x() + 1, cont_rect.y() + 1, cont_rect.width() - 2, cont_rect.height() - 2 };
+    Gfx::IntRect key_cap_face_border_rect = { cont_rect.x() + 6, cont_rect.y() + 3, cont_rect.width() - 12, cont_rect.height() - 12 };
+    Gfx::IntRect key_cap_face_rect = { cont_rect.x() + 7, cont_rect.y() + 4, cont_rect.width() - 14, cont_rect.height() - 14 };
+
+    painter.draw_rect(cont_rect, Color::Black); // Key cap border
+    painter.fill_rect(key_cap_side_rect, Color::from_rgb(0x999999));
+    painter.draw_rect(key_cap_face_border_rect, Color::from_rgb(0x8C7272), false);
+    painter.fill_rect(key_cap_face_rect, face_color);
 
     if (!text().is_empty()) {
         Gfx::IntRect text_rect { 0, 0, font.width(text()), font.glyph_height() };
-        text_rect.align_within({ cont_rect.x() + 7, cont_rect.y() + 4, cont_rect.width() - 14, cont_rect.height() - 14 }, Gfx::TextAlignment::Center);
+        text_rect.align_within(key_cap_face_rect, Gfx::TextAlignment::Center);
 
         painter.draw_text(text_rect, text(), font, Gfx::TextAlignment::Center, Color::Black, Gfx::TextElision::Right);
         if (is_focused())
@@ -57,9 +61,9 @@ void KeyButton::mousemove_event(GUI::MouseEvent& event)
     if (!is_enabled())
         return;
 
-    Gfx::IntRect c = { rect().x() + 7, rect().y() + 4, rect().width() - 14, rect().height() - 14 };
+    Gfx::IntRect key_cap_face_rect = { rect().x() + 7, rect().y() + 4, rect().width() - 14, rect().height() - 14 };
 
-    if (c.contains(event.position())) {
+    if (key_cap_face_rect.contains(event.position())) {
         window()->set_cursor(Gfx::StandardCursor::Hand);
         return;
     }

--- a/Userland/Applications/KeyboardMapper/KeyButton.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyButton.cpp
@@ -40,14 +40,15 @@ void KeyButton::paint_event(GUI::PaintEvent& event)
     painter.draw_rect(key_cap_face_border_rect, Color::from_rgb(0x8C7272), false);
     painter.fill_rect(key_cap_face_rect, face_color);
 
-    if (!text().is_empty()) {
-        Gfx::IntRect text_rect { 0, 0, font.width(text()), font.glyph_height() };
-        text_rect.align_within(key_cap_face_rect, Gfx::TextAlignment::Center);
+    if (text().is_empty() || text().starts_with('\0'))
+        return;
 
-        painter.draw_text(text_rect, text(), font, Gfx::TextAlignment::Center, Color::Black, Gfx::TextElision::Right);
-        if (is_focused())
-            painter.draw_rect(text_rect.inflated(6, 4), palette().focus_outline());
-    }
+    Gfx::IntRect text_rect { 0, 0, font.width(text()), font.glyph_height() };
+    text_rect.align_within(key_cap_face_rect, Gfx::TextAlignment::Center);
+
+    painter.draw_text(text_rect, text(), font, Gfx::TextAlignment::Center, Color::Black, Gfx::TextElision::Right);
+    if (is_focused())
+        painter.draw_rect(text_rect.inflated(6, 4), palette().focus_outline());
 }
 
 void KeyButton::click(unsigned)

--- a/Userland/Applications/KeyboardMapper/KeyButton.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyButton.cpp
@@ -53,7 +53,7 @@ void KeyButton::paint_event(GUI::PaintEvent& event)
 
 void KeyButton::click(unsigned)
 {
-    if (on_click)
+    if (on_click && m_face_hovered)
         on_click();
 }
 
@@ -64,17 +64,22 @@ void KeyButton::mousemove_event(GUI::MouseEvent& event)
 
     Gfx::IntRect key_cap_face_rect = { rect().x() + 7, rect().y() + 4, rect().width() - 14, rect().height() - 14 };
 
-    if (key_cap_face_rect.contains(event.position())) {
-        window()->set_cursor(Gfx::StandardCursor::Hand);
-        return;
-    }
-    window()->set_cursor(Gfx::StandardCursor::Arrow);
+    set_face_hovered(key_cap_face_rect.contains(event.position()));
 
     AbstractButton::mousemove_event(event);
 }
 
 void KeyButton::leave_event(Core::Event& event)
 {
-    window()->set_cursor(Gfx::StandardCursor::Arrow);
+    set_face_hovered(false);
     AbstractButton::leave_event(event);
+}
+
+void KeyButton::set_face_hovered(bool value)
+{
+    m_face_hovered = value;
+    if (m_face_hovered)
+        set_override_cursor(Gfx::StandardCursor::Hand);
+    else
+        set_override_cursor(Gfx::StandardCursor::None);
 }

--- a/Userland/Applications/KeyboardMapper/KeyButton.h
+++ b/Userland/Applications/KeyboardMapper/KeyButton.h
@@ -28,4 +28,6 @@ private:
     KeyButton() = default;
 
     bool m_pressed { false };
+    bool m_face_hovered { false };
+    void set_face_hovered(bool value);
 };

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -13,7 +13,6 @@
 #include <LibGUI/RadioButton.h>
 #include <LibKeyboard/CharacterMap.h>
 #include <LibKeyboard/CharacterMapFile.h>
-#include <string.h>
 
 KeyboardMapperWidget::KeyboardMapperWidget()
 {
@@ -92,33 +91,21 @@ void KeyboardMapperWidget::create_frame()
     m_map_group->set_layout<GUI::HorizontalBoxLayout>();
     m_map_group->set_fixed_width(450);
 
-    auto& radio_map = m_map_group->add<GUI::RadioButton>("Default");
-    radio_map.set_name("map");
-    radio_map.on_checked = [&](bool) {
-        set_current_map("map");
-    };
-    auto& radio_shift = m_map_group->add<GUI::RadioButton>("Shift");
-    radio_shift.set_name("shift_map");
-    radio_shift.on_checked = [this](bool) {
-        set_current_map("shift_map");
-    };
-    auto& radio_altgr = m_map_group->add<GUI::RadioButton>("AltGr");
-    radio_altgr.set_name("altgr_map");
-    radio_altgr.on_checked = [this](bool) {
-        set_current_map("altgr_map");
-    };
-    auto& radio_alt = m_map_group->add<GUI::RadioButton>("Alt");
-    radio_alt.set_name("alt_map");
-    radio_alt.on_checked = [this](bool) {
-        set_current_map("alt_map");
-    };
-    auto& radio_shift_altgr = m_map_group->add<GUI::RadioButton>("Shift+AltGr");
-    radio_shift_altgr.set_name("shift_altgr_map");
-    radio_shift_altgr.on_checked = [this](bool) {
-        set_current_map("shift_altgr_map");
-    };
+    add_map_radio_button("map", "Default");
+    add_map_radio_button("shift_map", "Shift");
+    add_map_radio_button("altgr_map", "AltGr");
+    add_map_radio_button("alt_map", "Alt");
+    add_map_radio_button("shift_altgr_map", "Shift+AltGr");
 
     bottom_widget.layout()->add_spacer();
+}
+
+void KeyboardMapperWidget::add_map_radio_button(const StringView map_name, const StringView button_text) {
+    auto& map_radio_button = m_map_group->add<GUI::RadioButton>(button_text);
+    map_radio_button.set_name(map_name);
+    map_radio_button.on_checked = [map_name, this](bool){
+        set_current_map(map_name);
+    };
 }
 
 void KeyboardMapperWidget::load_from_file(String filename)

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -215,21 +215,24 @@ void KeyboardMapperWidget::save_to_file(StringView filename)
 void KeyboardMapperWidget::keydown_event(GUI::KeyEvent& event)
 {
     for (int i = 0; i < KEY_COUNT; i++) {
+        if (keys[i].scancode != event.scancode())
+            continue;
         auto& tmp_button = m_keys.at(i);
-        tmp_button->set_pressed(keys[i].scancode == event.scancode());
+        tmp_button->set_pressed(true);
         tmp_button->update();
+        break;
     }
 }
 
 void KeyboardMapperWidget::keyup_event(GUI::KeyEvent& event)
 {
     for (int i = 0; i < KEY_COUNT; i++) {
-        if (keys[i].scancode == event.scancode()) {
-            auto& tmp_button = m_keys.at(i);
-            tmp_button->set_pressed(false);
-            tmp_button->update();
-            break;
-        }
+        if (keys[i].scancode != event.scancode())
+            continue;
+        auto& tmp_button = m_keys.at(i);
+        tmp_button->set_pressed(false);
+        tmp_button->update();
+        break;
     }
 }
 

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -52,21 +52,7 @@ void KeyboardMapperWidget::create_frame()
                 VERIFY(index > 0);
 
                 tmp_button.set_text(value);
-                u32* map;
-
-                if (m_current_map_name == "map") {
-                    map = m_character_map.map;
-                } else if (m_current_map_name == "shift_map") {
-                    map = m_character_map.shift_map;
-                } else if (m_current_map_name == "alt_map") {
-                    map = m_character_map.alt_map;
-                } else if (m_current_map_name == "altgr_map") {
-                    map = m_character_map.altgr_map;
-                } else if (m_current_map_name == "shift_altgr_map") {
-                    map = m_character_map.shift_altgr_map;
-                } else {
-                    VERIFY_NOT_REACHED();
-                }
+                u32* map = map_from_name(m_current_map_name);
 
                 if (value.length() == 0)
                     map[index] = '\0'; // Empty string
@@ -100,12 +86,32 @@ void KeyboardMapperWidget::create_frame()
     bottom_widget.layout()->add_spacer();
 }
 
-void KeyboardMapperWidget::add_map_radio_button(const StringView map_name, const StringView button_text) {
+void KeyboardMapperWidget::add_map_radio_button(const StringView map_name, const StringView button_text)
+{
     auto& map_radio_button = m_map_group->add<GUI::RadioButton>(button_text);
     map_radio_button.set_name(map_name);
-    map_radio_button.on_checked = [map_name, this](bool){
+    map_radio_button.on_checked = [map_name, this](bool) {
         set_current_map(map_name);
     };
+}
+
+u32* KeyboardMapperWidget::map_from_name(const StringView map_name)
+{
+    u32* map;
+    if (map_name == "map"sv) {
+        map = m_character_map.map;
+    } else if (map_name == "shift_map"sv) {
+        map = m_character_map.shift_map;
+    } else if (map_name == "alt_map"sv) {
+        map = m_character_map.alt_map;
+    } else if (map_name == "altgr_map"sv) {
+        map = m_character_map.altgr_map;
+    } else if (map_name == "shift_altgr_map"sv) {
+        map = m_character_map.shift_altgr_map;
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+    return map;
 }
 
 void KeyboardMapperWidget::load_from_file(String filename)
@@ -230,21 +236,7 @@ void KeyboardMapperWidget::keyup_event(GUI::KeyEvent& event)
 void KeyboardMapperWidget::set_current_map(const String current_map)
 {
     m_current_map_name = current_map;
-    u32* map;
-
-    if (m_current_map_name == "map") {
-        map = m_character_map.map;
-    } else if (m_current_map_name == "shift_map") {
-        map = m_character_map.shift_map;
-    } else if (m_current_map_name == "alt_map") {
-        map = m_character_map.alt_map;
-    } else if (m_current_map_name == "altgr_map") {
-        map = m_character_map.altgr_map;
-    } else if (m_current_map_name == "shift_altgr_map") {
-        map = m_character_map.shift_altgr_map;
-    } else {
-        VERIFY_NOT_REACHED();
-    }
+    u32* map = map_from_name(m_current_map_name);
 
     for (unsigned k = 0; k < KEY_COUNT; k++) {
         auto index = keys[k].map_index;

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2020, Hüseyin Aslıtürk <asliturk@hotmail.com>
+ * Copyright (c) 2021, Rasmus Nylander <RasmusNylander.SerenityOS@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "KeyboardMapperWidget.h"
 #include "KeyPositions.h"
-#include <LibCore/File.h>
+#include <LibCore/Stream.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/InputBox.h>
 #include <LibGUI/MessageBox.h>
@@ -178,11 +179,9 @@ ErrorOr<void> KeyboardMapperWidget::save_to_file(StringView filename)
 
     // Write to file.
     String file_content = map_json.to_string();
-    auto file = TRY(Core::File::open(filename, Core::OpenMode::WriteOnly));
-
-    bool result = file->write(file_content);
-    if (!result)
-        return Error::from_errno(file->error());
+    auto file = TRY(Core::Stream::File::open(filename, Core::Stream::OpenMode::Write));
+    TRY(file.write(file_content.bytes()));
+    file.close();
 
     m_modified = false;
     m_filename = filename;
@@ -244,6 +243,7 @@ void KeyboardMapperWidget::update_window_title()
     window()->set_title(sb.to_string());
 }
 
-void KeyboardMapperWidget::show_error_to_user(Error error){
+void KeyboardMapperWidget::show_error_to_user(Error error)
+{
     GUI::MessageBox::show_error(window(), error.string_literal());
 }

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
@@ -35,6 +35,7 @@ private:
     Vector<KeyButton*> m_keys;
     RefPtr<GUI::Widget> m_map_group;
     void add_map_radio_button(const StringView map_name, const StringView button_text);
+    u32* map_from_name(const StringView map_name);
 
     String m_filename;
     Keyboard::CharacterMapData m_character_map;

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
@@ -34,6 +34,7 @@ private:
 
     Vector<KeyButton*> m_keys;
     RefPtr<GUI::Widget> m_map_group;
+    void add_map_radio_button(const StringView map_name, const StringView button_text);
 
     String m_filename;
     Keyboard::CharacterMapData m_character_map;

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
@@ -17,10 +17,11 @@ public:
     virtual ~KeyboardMapperWidget() override;
 
     void create_frame();
-    void load_from_file(const String);
-    void load_from_system();
-    void save();
-    void save_to_file(StringView);
+    ErrorOr<void> load_map_from_file(const String&);
+    ErrorOr<void> load_map_from_system();
+    ErrorOr<void> save();
+    ErrorOr<void> save_to_file(StringView);
+    void show_error_to_user(Error);
 
 protected:
     virtual void keydown_event(GUI::KeyEvent&) override;

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Hüseyin Aslıtürk <asliturk@hotmail.com>
+ * Copyright (c) 2021, Rasmus Nylander <RasmusNylander.SerenityOS@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -48,7 +49,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto open_action = GUI::CommonActions::make_open_action(
         [&](auto&) {
             Optional<String> path = GUI::FilePicker::get_open_filepath(window, "Open", "/res/keymaps/");
-            if (!path.has_value()) return;
+            if (!path.has_value())
+                return;
 
             ErrorOr<void> error_or = keyboard_mapper_widget->load_map_from_file(path.value());
             if (error_or.is_error())

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -6,32 +6,27 @@
 
 #include "KeyboardMapperWidget.h"
 #include <LibCore/ArgsParser.h>
+#include <LibCore/System.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
-#include <unistd.h>
+#include <LibMain/Main.h>
 
-int main(int argc, char** argv)
+ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     const char* path = nullptr;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "Keyboard character mapping file.", "file", Core::ArgsParser::Required::No);
-    args_parser.parse(argc, argv);
+    args_parser.parse(arguments);
 
-    if (pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd unix", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd unix"));
 
-    auto app = GUI::Application::construct(argc, argv);
+    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
 
-    if (pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd"));
 
     auto app_icon = GUI::Icon::default_icon("app-keyboard-mapper");
 
@@ -49,10 +44,7 @@ int main(int argc, char** argv)
         keyboard_mapper_widget->load_from_system();
     }
 
-    if (pledge("stdio thread rpath cpath wpath recvfd sendfd", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    TRY(Core::System::pledge("stdio thread rpath cpath wpath recvfd sendfd"));
 
     auto open_action = GUI::CommonActions::make_open_action(
         [&](auto&) {

--- a/Userland/Libraries/LibKeyboard/CharacterMap.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMap.cpp
@@ -17,13 +17,11 @@ namespace Keyboard {
 #ifndef KERNEL
 // The Kernel explicitly and exclusively links only this file into it.
 // Thus, we cannot even include a reference to the symbol `CharacterMapFile::load_from_file`.
-Optional<CharacterMap> CharacterMap::load_from_file(const String& map_name)
+ErrorOr<CharacterMap> CharacterMap::load_from_file(const String& map_name)
 {
-    auto result = CharacterMapFile::load_from_file(map_name);
-    if (!result.has_value())
-        return {};
+    auto result = TRY(CharacterMapFile::load_from_file(map_name));
 
-    return CharacterMap(map_name, result.value());
+    return CharacterMap(map_name, result);
 }
 #endif
 

--- a/Userland/Libraries/LibKeyboard/CharacterMap.h
+++ b/Userland/Libraries/LibKeyboard/CharacterMap.h
@@ -19,7 +19,7 @@ class CharacterMap {
 
 public:
     CharacterMap(const String& map_name, const CharacterMapData& map_data);
-    static Optional<CharacterMap> load_from_file(const String& filename);
+    static ErrorOr<CharacterMap> load_from_file(const String& filename);
 
 #ifndef KERNEL
     int set_system_map();

--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.cpp
@@ -11,7 +11,7 @@
 
 namespace Keyboard {
 
-Optional<CharacterMapData> CharacterMapFile::load_from_file(const String& filename)
+ErrorOr<CharacterMapData> CharacterMapFile::load_from_file(const String& filename)
 {
     auto path = filename;
     if (!path.ends_with(".json")) {
@@ -22,20 +22,10 @@ Optional<CharacterMapData> CharacterMapFile::load_from_file(const String& filena
         path = full_path.to_string();
     }
 
-    auto file = Core::File::construct(path);
-    file->open(Core::OpenMode::ReadOnly);
-    if (!file->is_open()) {
-        dbgln("Failed to open {}: {}", path, file->error_string());
-        return {};
-    }
-
+    auto file = TRY(Core::File::open(path, Core::OpenMode::ReadOnly));
     auto file_contents = file->read_all();
-    auto json_result = JsonValue::from_string(file_contents);
-    if (json_result.is_error()) {
-        dbgln("Failed to load character map from file {}", path);
-        return {};
-    }
-    auto json = json_result.value().as_object();
+    auto json_result = TRY(JsonValue::from_string(file_contents));
+    const auto& json = json_result.as_object();
 
     Vector<u32> map = read_map(json, "map");
     Vector<u32> shift_map = read_map(json, "shift_map");

--- a/Userland/Libraries/LibKeyboard/CharacterMapFile.h
+++ b/Userland/Libraries/LibKeyboard/CharacterMapFile.h
@@ -14,7 +14,7 @@ namespace Keyboard {
 class CharacterMapFile {
 
 public:
-    static Optional<CharacterMapData> load_from_file(const String& filename);
+    static ErrorOr<CharacterMapData> load_from_file(const String& filename);
 
 private:
     static Vector<u32> read_map(const JsonObject& json, const String& name);

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     auto character_map = Keyboard::CharacterMap::load_from_file(path);
-    if (!character_map.has_value()) {
+    if (character_map.is_error()) {
         warnln("Cannot read keymap {}", path);
         warnln("Hint: Must be either a keymap name (e.g. 'en-us') or a full path.");
         return 1;


### PR DESCRIPTION
General cleaning of the KeyboardMapper, fixing some minor bugs and making the code slightly more readable, at least in my opinon. Increased readablility has mostly been achieved by extracting methods, renaming variables, and implementing error propagation with ErrorOr.
KeyboardMapper has been ported to use as serenity_main, as well as the new Core::Stream rather than the now deprecated IODevice.

I was going to change it such that keyboard could be traversed using the arrow-keys, but got distracted by this, and then by changing IODevice::write to return ErrorOr. I might try actually doing this next, but I'll probably get distracted again :^)