### PR TITLE
Kernel: Implement and use the syscall/sysret instruction pair on x86_64

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -483,10 +483,17 @@ int sync();
 inline uintptr_t invoke(Function function)
 {
     uintptr_t result;
+#        if ARCH(I386)
     asm volatile("int $0x82"
                  : "=a"(result)
                  : "a"(function)
                  : "memory");
+#        else
+    asm volatile("syscall"
+                 : "=a"(result)
+                 : "a"(function)
+                 : "rcx", "r11", "memory");
+#        endif
     return result;
 }
 
@@ -494,10 +501,17 @@ template<typename T1>
 inline uintptr_t invoke(Function function, T1 arg1)
 {
     uintptr_t result;
+#        if ARCH(I386)
     asm volatile("int $0x82"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1)
                  : "memory");
+#        else
+    asm volatile("syscall"
+                 : "=a"(result)
+                 : "a"(function), "d"((uintptr_t)arg1)
+                 : "rcx", "r11", "memory");
+#        endif
     return result;
 }
 
@@ -505,10 +519,17 @@ template<typename T1, typename T2>
 inline uintptr_t invoke(Function function, T1 arg1, T2 arg2)
 {
     uintptr_t result;
+#        if ARCH(I386)
     asm volatile("int $0x82"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "c"((uintptr_t)arg2)
                  : "memory");
+#        else
+    asm volatile("syscall"
+                 : "=a"(result)
+                 : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2)
+                 : "rcx", "r11", "memory");
+#        endif
     return result;
 }
 
@@ -516,10 +537,17 @@ template<typename T1, typename T2, typename T3>
 inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3)
 {
     uintptr_t result;
+#        if ARCH(I386)
     asm volatile("int $0x82"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "c"((uintptr_t)arg2), "b"((uintptr_t)arg3)
                  : "memory");
+#        else
+    asm volatile("syscall"
+                 : "=a"(result)
+                 : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3)
+                 : "rcx", "r11", "memory");
+#        endif
     return result;
 }
 
@@ -527,10 +555,17 @@ template<typename T1, typename T2, typename T3, typename T4>
 inline uintptr_t invoke(Function function, T1 arg1, T2 arg2, T3 arg3, T4 arg4)
 {
     uintptr_t result;
+#        if ARCH(I386)
     asm volatile("int $0x82"
                  : "=a"(result)
                  : "a"(function), "d"((uintptr_t)arg1), "c"((uintptr_t)arg2), "b"((uintptr_t)arg3), "S"((uintptr_t)arg4)
                  : "memory");
+#        else
+    asm volatile("syscall"
+                 : "=a"(result)
+                 : "a"(function), "d"((uintptr_t)arg1), "D"((uintptr_t)arg2), "b"((uintptr_t)arg3), "S"((uintptr_t)arg4)
+                 : "memory");
+#        endif
     return result;
 }
 #    endif

--- a/Kernel/Arch/x86/DescriptorTable.h
+++ b/Kernel/Arch/x86/DescriptorTable.h
@@ -31,10 +31,11 @@ static_assert(GDT_SELECTOR_CODE0 + 16 == GDT_SELECTOR_CODE3); // CS3 = CS0 + 16
 static_assert(GDT_SELECTOR_CODE0 + 24 == GDT_SELECTOR_DATA3); // SS3 = CS0 + 32
 #else
 #    define GDT_SELECTOR_CODE0 0x08
-#    define GDT_SELECTOR_CODE3 0x10
+#    define GDT_SELECTOR_DATA0 0x10
 #    define GDT_SELECTOR_DATA3 0x18
-#    define GDT_SELECTOR_TSS 0x20
-#    define GDT_SELECTOR_TSS_PART2 0x28
+#    define GDT_SELECTOR_CODE3 0x20
+#    define GDT_SELECTOR_TSS 0x28
+#    define GDT_SELECTOR_TSS_PART2 0x30
 #endif
 
 namespace Kernel {

--- a/Kernel/Arch/x86/RegisterState.h
+++ b/Kernel/Arch/x86/RegisterState.h
@@ -110,9 +110,10 @@ struct [[gnu::packed]] RegisterState {
         arg3 = ebx;
         arg4 = esi;
 #else
+        // The syscall instruction clobbers rcx, so we must use a different calling convention to 32-bit.
         function = rax;
         arg1 = rdx;
-        arg2 = rcx;
+        arg2 = rdi;
         arg3 = rbx;
         arg4 = rsi;
 #endif

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -1156,8 +1156,9 @@ UNMAP_AFTER_INIT void Processor::gdt_init()
     write_raw_gdt_entry(GDT_SELECTOR_DATA3, 0x0000ffff, 0x00cff200); // data3
 #else
     write_raw_gdt_entry(GDT_SELECTOR_CODE0, 0x0000ffff, 0x00af9a00); // code0
-    write_raw_gdt_entry(GDT_SELECTOR_CODE3, 0x0000ffff, 0x00affa00); // code3
+    write_raw_gdt_entry(GDT_SELECTOR_DATA0, 0x0000ffff, 0x00af9200); // data0
     write_raw_gdt_entry(GDT_SELECTOR_DATA3, 0x0000ffff, 0x008ff200); // data3
+    write_raw_gdt_entry(GDT_SELECTOR_CODE3, 0x0000ffff, 0x00affa00); // code3
 #endif
 
 #if ARCH(I386)

--- a/Kernel/Arch/x86/x86_64/SyscallEntry.cpp
+++ b/Kernel/Arch/x86/x86_64/SyscallEntry.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Owen Smith <yeeetari@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/x86/DescriptorTable.h>
+#include <Kernel/Arch/x86/Processor.h>
+#include <Kernel/Arch/x86/TrapFrame.h>
+
+extern "C" void syscall_entry();
+extern "C" [[gnu::naked]] void syscall_entry()
+{
+    // clang-format off
+    asm(
+        // Store the user stack, then switch to the kernel stack.
+        "    movq %%rsp, %%gs:%c[user_stack] \n"
+        "    movq %%gs:%c[kernel_stack], %%rsp \n"
+
+        // Build RegisterState.
+        "    pushq $0x1b \n" // User ss
+        "    pushq %%gs:%c[user_stack] \n" // User rsp
+        "    sti \n" // It's now safe to enable interrupts, but we can't index into gs after this point
+        "    pushq %%r11 \n" // The CPU preserves the user rflags in r11
+        "    pushq $0x23 \n" // User cs
+        "    pushq %%rcx \n" // The CPU preserves the user IP in rcx
+        "    pushq $0 \n"
+        "    pushq %%r15 \n"
+        "    pushq %%r14 \n"
+        "    pushq %%r13 \n"
+        "    pushq %%r12 \n"
+        "    pushq %%r11 \n"
+        "    pushq %%r10 \n"
+        "    pushq %%r9 \n"
+        "    pushq %%r8 \n"
+        "    pushq %%rax \n"
+        "    pushq %%rcx \n"
+        "    pushq %%rdx \n"
+        "    pushq %%rbx \n"
+        "    pushq %%rsp \n"
+        "    pushq %%rbp \n"
+        "    pushq %%rsi \n"
+        "    pushq %%rdi \n"
+
+        "    pushq %%rsp \n" // TrapFrame::regs
+        "    subq $" __STRINGIFY(TRAP_FRAME_SIZE - 8) ", %%rsp \n"
+        "    movq %%rsp, %%rdi \n"
+        "    call enter_trap_no_irq \n"
+        "    movq %%rsp, %%rdi \n"
+        "    call syscall_handler \n"
+        "    movq %%rsp, %%rdi \n"
+        "    call exit_trap \n"
+        "    addq $" __STRINGIFY(TRAP_FRAME_SIZE) ", %%rsp \n" // Pop TrapFrame
+
+        "    popq %%rdi \n"
+        "    popq %%rsi \n"
+        "    popq %%rbp \n"
+        "    addq $8, %%rsp \n" // Skip restoring kernel rsp
+        "    popq %%rbx \n"
+        "    popq %%rdx \n"
+        "    popq %%rcx \n"
+        "    popq %%rax \n"
+        "    popq %%r8 \n"
+        "    popq %%r9 \n"
+        "    popq %%r10 \n"
+        "    popq %%r11 \n"
+        "    popq %%r12 \n"
+        "    popq %%r13 \n"
+        "    popq %%r14 \n"
+        "    popq %%r15 \n"
+        "    addq $8, %%rsp \n"
+        "    popq %%rcx \n"
+        "    addq $16, %%rsp \n"
+
+        // Disable interrupts before we restore the user stack pointer. sysret will re-enable interrupts when it restores
+        // rflags.
+        "    cli \n"
+        "    popq %%rsp \n"
+        "    sysretq \n"
+    :: [user_stack] "i"(Kernel::Processor::user_stack_offset()), [kernel_stack] "i"(Kernel::Processor::kernel_stack_offset()));
+    // clang-format on
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -311,6 +311,13 @@ if ("${SERENITY_ARCH}" STREQUAL "i686" OR "${SERENITY_ARCH}" STREQUAL "x86_64")
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/SafeMem.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/TrapFrame.cpp
     )
+
+    if("${SERENITY_ARCH}" STREQUAL "x86_64")
+        set(KERNEL_SOURCES
+            ${KERNEL_SOURCES}
+            ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/${KERNEL_ARCH}/SyscallEntry.cpp
+        )
+    endif()
 endif()
 
 set(AK_SOURCES


### PR DESCRIPTION
This PR implements the syscall/sysret instruction pair to replace the use of interrupts for syscalls on 64-bit. From the AMD64 spec:
> SYSCALL and SYSRET are low-latency system call and return instructions. SYSCALL and SYSRET can take fewer than one-fourth the number of internal clock cycles to complete than the legacy CALL and RET instructions. SYSCALL and SYSRET are particularly well-suited for use in 64-bit mode, which requires implementation of a paged, flat-memory model.

Of course syscall/sysret doesn't magically make everything faster, but from some quick tests, `test-js` does seem to be a little faster:
```
Timing report (interrupts):
==============
Command:         test-js
Average time:    8902.2 ms (median: 8512, stddev: 791.50, min: 8446, max:10482)
Excluding first: 8507.25 ms (median: 8512, stddev: 56.32, min: 8446, max:8596)
```

```
Timing report (syscall/sysret):
==============
Command:         test-js
Average time:    8649.2 ms (median: 8320, stddev: 739.11, min: 8218, max:10125)
Excluding first: 8280.25 ms (median: 8320, stddev: 47.4, min: 8218, max:8332)
```