### PR TITLE
Documentation: Recommend using Xcode's command line tools on macOS

### DIFF
--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -2,7 +2,12 @@
 
 # Prerequisites
 
-This installation guide assumes that you have Homebrew, Xcode and `xcode-tools` installed.
+This installation guide assumes that you have [Homebrew](https://brew.sh) and Xcode installed. You need to open Xcode atleast once for it to install the required tools.
+
+Before you build, you must set your command line tools to Xcode's tools instead of the ones installed via Homebrew:
+```console
+sudo xcode-select --switch /Applications/Xcode.app
+```
 
 Make sure you also have all the following dependencies installed:
 


### PR DESCRIPTION
After taking a look at compiling serenity on my mac today, I realised that the xcode tools installed via Homebrew and other applications via ``sudo xcode-select --install`` isn't good enough for compiling serenity in certain cases. 

We should use Xcode's tools as they are more capable than the "default" tools.

Using Xcode's tools made the toolchain (and the project) build on my M1 Macbook Air with 0 issues.