### PR TITLE
Kernel: Stop user space from attempting to mmap a zero size inode

### DIFF
--- a/Kernel/Memory/PrivateInodeVMObject.cpp
+++ b/Kernel/Memory/PrivateInodeVMObject.cpp
@@ -11,7 +11,11 @@ namespace Kernel::Memory {
 
 ErrorOr<NonnullRefPtr<PrivateInodeVMObject>> PrivateInodeVMObject::try_create_with_inode(Inode& inode)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) PrivateInodeVMObject(inode, inode.size()));
+    auto size = inode.size();
+    if (size == 0)
+        return EINVAL;
+
+    return adopt_nonnull_ref_or_enomem(new (nothrow) PrivateInodeVMObject(inode, size));
 }
 
 ErrorOr<NonnullRefPtr<VMObject>> PrivateInodeVMObject::try_clone()

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -13,6 +13,9 @@ namespace Kernel::Memory {
 ErrorOr<NonnullRefPtr<SharedInodeVMObject>> SharedInodeVMObject::try_create_with_inode(Inode& inode)
 {
     size_t size = inode.size();
+    if (size == 0)
+        return EINVAL;
+
     if (auto shared_vmobject = inode.shared_vmobject())
         return shared_vmobject.release_nonnull();
     auto vmobject = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SharedInodeVMObject(inode, size)));


### PR DESCRIPTION
The `InodeVMObject` base class creates a Bitmap the size of VMObject.
In the case of a zero sized inode, the bitmap will then be zero, which
causes us to assert.

This was caught with `stress-ng`.