### PR TITLE
Kernel: Remove the KString::try_create(String::formatted(...)) pattern

### DIFF
--- a/Kernel/Bus/PCI/SysFSPCI.cpp
+++ b/Kernel/Bus/PCI/SysFSPCI.cpp
@@ -16,7 +16,7 @@ namespace Kernel::PCI {
 UNMAP_AFTER_INIT NonnullRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirectory::create(const SysFSDirectory& parent_directory, Address address)
 {
     // FIXME: Handle allocation failure gracefully
-    auto device_name = MUST(KString::try_create(String::formatted("{:04x}:{:02x}:{:02x}.{}", address.domain(), address.bus(), address.device(), address.function())));
+    auto device_name = MUST(KString::formatted("{:04x}:{:02x}:{:02x}.{}", address.domain(), address.bus(), address.device(), address.function()));
     return adopt_ref(*new (nothrow) PCIDeviceSysFSDirectory(move(device_name), parent_directory, address));
 }
 

--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -16,7 +16,7 @@ namespace Kernel {
 NonnullRefPtr<SysFSDeviceComponent> SysFSDeviceComponent::must_create(Device const& device)
 {
     // FIXME: Handle allocation failure gracefully
-    auto device_name = MUST(KString::try_create(String::formatted("{}:{}", device.major(), device.minor())));
+    auto device_name = MUST(KString::formatted("{}:{}", device.major(), device.minor()));
     return adopt_ref_if_nonnull(new SysFSDeviceComponent(move(device_name), device)).release_nonnull();
 }
 SysFSDeviceComponent::SysFSDeviceComponent(NonnullOwnPtr<KString> major_minor_formatted_device_name, Device const& device)

--- a/Kernel/Net/NetworkingManagement.cpp
+++ b/Kernel/Net/NetworkingManagement.cpp
@@ -78,10 +78,9 @@ ErrorOr<NonnullOwnPtr<KString>> NetworkingManagement::generate_interface_name_fr
 {
     VERIFY(device_identifier.class_code().value() == 0x2);
     // Note: This stands for e - "Ethernet", p - "Port" as for PCI bus, "s" for slot as for PCI slot
-    auto name = String::formatted("ep{}s{}", device_identifier.address().bus(), device_identifier.address().device());
-    VERIFY(!NetworkingManagement::the().lookup_by_name(name));
-    // TODO: We need some way to to format data into a `KString`.
-    return KString::try_create(name.view());
+    auto name = TRY(KString::formatted("ep{}s{}", device_identifier.address().bus(), device_identifier.address().device()));
+    VERIFY(!NetworkingManagement::the().lookup_by_name(name->view()));
+    return name;
 }
 
 UNMAP_AFTER_INIT RefPtr<NetworkAdapter> NetworkingManagement::determine_network_device(PCI::DeviceIdentifier const& device_identifier) const

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -438,7 +438,7 @@ UNMAP_AFTER_INIT Thread* Scheduler::create_ap_idle_thread(u32 cpu)
     VERIFY(Processor::is_bootstrap_processor());
 
     VERIFY(s_colonel_process);
-    Thread* idle_thread = s_colonel_process->create_kernel_thread(idle_loop, nullptr, THREAD_PRIORITY_MIN, KString::must_create(String::formatted("idle thread #{}", cpu)), 1 << cpu, false);
+    Thread* idle_thread = s_colonel_process->create_kernel_thread(idle_loop, nullptr, THREAD_PRIORITY_MIN, MUST(KString::formatted("idle thread #{}", cpu)), 1 << cpu, false);
     VERIFY(idle_thread);
     return idle_thread;
 }

--- a/Kernel/Storage/ATA/ATADiskDevice.cpp
+++ b/Kernel/Storage/ATA/ATADiskDevice.cpp
@@ -18,11 +18,9 @@ NonnullRefPtr<ATADiskDevice> ATADiskDevice::create(const ATAController& controll
 {
     auto minor_device_number = StorageManagement::generate_storage_minor_number();
 
-    // FIXME: We need a way of formatting strings with KString.
-    auto device_name = String::formatted("hd{:c}", 'a' + minor_device_number.value());
-    auto device_name_kstring = KString::must_create(device_name.view());
+    auto device_name = MUST(KString::formatted("hd{:c}", 'a' + minor_device_number.value()));
 
-    auto disk_device_or_error = DeviceManagement::try_create_device<ATADiskDevice>(controller, ata_address, minor_device_number, capabilities, logical_sector_size, max_addressable_block, move(device_name_kstring));
+    auto disk_device_or_error = DeviceManagement::try_create_device<ATADiskDevice>(controller, ata_address, minor_device_number, capabilities, logical_sector_size, max_addressable_block, move(device_name));
     // FIXME: Find a way to propagate errors
     VERIFY(!disk_device_or_error.is_error());
     return disk_device_or_error.release_value();

--- a/Kernel/Storage/ATA/ATAPIDiscDevice.cpp
+++ b/Kernel/Storage/ATA/ATAPIDiscDevice.cpp
@@ -18,11 +18,9 @@ NonnullRefPtr<ATAPIDiscDevice> ATAPIDiscDevice::create(const ATAController& cont
 {
     auto minor_device_number = StorageManagement::generate_storage_minor_number();
 
-    // FIXME: We need a way of formatting strings with KString.
-    auto device_name = String::formatted("hd{:c}", 'a' + minor_device_number.value());
-    auto device_name_kstring = KString::must_create(device_name.view());
+    auto device_name = MUST(KString::formatted("hd{:c}", 'a' + minor_device_number.value()));
 
-    auto disc_device_or_error = DeviceManagement::try_create_device<ATAPIDiscDevice>(controller, ata_address, minor_device_number.value(), capabilities, max_addressable_block, move(device_name_kstring));
+    auto disc_device_or_error = DeviceManagement::try_create_device<ATAPIDiscDevice>(controller, ata_address, minor_device_number.value(), capabilities, max_addressable_block, move(device_name));
     // FIXME: Find a way to propagate errors
     VERIFY(!disc_device_or_error.is_error());
     return disc_device_or_error.release_value();

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -17,11 +17,9 @@ NonnullRefPtr<RamdiskDevice> RamdiskDevice::create(const RamdiskController& cont
 {
     // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
     size_t drive_index = minor / 16;
-    // FIXME: We need a way of formatting strings with KString!
-    auto device_name = String::formatted("ramdisk{}", drive_index);
-    auto device_name_kstring = KString::must_create(device_name.view());
+    auto device_name = MUST(KString::formatted("ramdisk{}", drive_index));
 
-    auto device_or_error = DeviceManagement::try_create_device<RamdiskDevice>(controller, move(region), major, minor, move(device_name_kstring));
+    auto device_or_error = DeviceManagement::try_create_device<RamdiskDevice>(controller, move(region), major, minor, move(device_name));
     // FIXME: Find a way to propagate errors
     VERIFY(!device_or_error.is_error());
     return device_or_error.release_value();

--- a/Kernel/Syscalls/thread.cpp
+++ b/Kernel/Syscalls/thread.cpp
@@ -43,8 +43,7 @@ ErrorOr<FlatPtr> Process::sys$create_thread(void* (*entry)(void*), Userspace<con
 
     // We know this thread is not the main_thread,
     // So give it a unique name until the user calls $set_thread_name on it
-    // FIXME: Don't make a temporary String here
-    auto new_thread_name = TRY(KString::try_create(String::formatted("{} [{}]", m_name, thread->tid().value())));
+    auto new_thread_name = TRY(KString::formatted("{} [{}]", m_name, thread->tid().value()));
     thread->set_name(move(new_thread_name));
 
     if (!is_thread_joinable)

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -18,8 +18,7 @@ namespace Kernel {
 
 ErrorOr<NonnullRefPtr<MasterPTY>> MasterPTY::try_create(unsigned int index)
 {
-    // FIXME: Don't make a temporary String here
-    auto pts_name = TRY(KString::try_create(String::formatted("/dev/pts/{}", index)));
+    auto pts_name = TRY(KString::formatted("/dev/pts/{}", index));
     auto tty_name = TRY(pts_name->try_clone());
 
     auto buffer = TRY(DoubleBuffer::try_create());
@@ -133,8 +132,7 @@ ErrorOr<void> MasterPTY::ioctl(OpenFileDescription& description, unsigned reques
 
 ErrorOr<NonnullOwnPtr<KString>> MasterPTY::pseudo_path(const OpenFileDescription&) const
 {
-    // FIXME: Replace this and others of this pattern by KString::formatted()
-    return KString::try_create(String::formatted("ptm:{}", m_pts_name));
+    return KString::formatted("ptm:{}", m_pts_name);
 }
 
 }

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -103,10 +103,7 @@ void VirtualConsole::set_graphical(bool graphical)
 
 UNMAP_AFTER_INIT NonnullRefPtr<VirtualConsole> VirtualConsole::create(size_t index)
 {
-    // FIXME: Don't make a temporary String here
-    auto pts_name_or_error = KString::try_create(String::formatted("/dev/tty/{}", index));
-    VERIFY(!pts_name_or_error.is_error());
-    auto pts_name = pts_name_or_error.release_value();
+    auto pts_name = MUST(KString::formatted("/dev/tty/{}", index));
 
     auto virtual_console_or_error = DeviceManagement::try_create_device<VirtualConsole>(index, move(pts_name));
     // FIXME: Find a way to propagate errors

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -65,12 +65,8 @@ Thread::Thread(NonnullRefPtr<Process> process, NonnullOwnPtr<Memory::Region> ker
         m_tid = Process::allocate_pid().value();
     }
 
-    {
-        // FIXME: Go directly to KString
-        auto string = String::formatted("Kernel stack (thread {})", m_tid.value());
-        // FIXME: Handle KString allocation failure.
-        m_kernel_stack_region->set_name(KString::try_create(string).release_value());
-    }
+    // FIXME: Handle KString allocation failure.
+    m_kernel_stack_region->set_name(MUST(KString::formatted("Kernel stack (thread {})", m_tid.value())));
 
     Thread::all_instances().with([&](auto& list) {
         list.append(*this);


### PR DESCRIPTION
We can now directly create formatted KStrings with KString::formatted.

:^)