### PR TITLE
LibVT: Handle window resize after history overflow

### DIFF
--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -388,9 +388,14 @@ protected:
         if (max_history_size() == 0)
             return;
 
+        // If m_history can expand, add the new line to the end of the list.
+        // If there is an overflow wrap, the end is at the index before the start.
         if (m_history.size() < max_history_size()) {
-            VERIFY(m_history_start == 0);
-            m_history.append(move(line));
+            if (m_history_start == 0)
+                m_history.append(move(line));
+            else
+                m_history.insert(m_history_start - 1, move(line));
+
             return;
         }
         m_history.ptr_at(m_history_start) = move(line);


### PR DESCRIPTION
Addresses an issue in which a window resize event after history
overflow would cause the Terminal to crash due to a failed assertion.

The problematic assertion was removed and the logic updated to
support inserting lines even when the start of the history is at an
offset (due to an overflow).

Resolves #10987