### PR TITLE
LibCore+Taskbar+LoginServer: Add a "Power off" button to login window

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -450,6 +450,14 @@ ErrorOr<void> clock_settime(clockid_t clock_id, struct timespec* ts)
 #endif
 }
 
+ErrorOr<pid_t> posix_spawn(StringView const path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[])
+{
+    pid_t child_pid;
+    if ((errno = ::posix_spawn(&child_pid, path.to_string().characters(), file_actions, attr, arguments, envp)))
+        return Error::from_syscall("posix_spawn"sv, -errno);
+    return child_pid;
+}
+
 ErrorOr<pid_t> posix_spawnp(StringView const path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[])
 {
     pid_t child_pid;

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -71,6 +71,7 @@ ErrorOr<void> chown(StringView pathname, uid_t uid, gid_t gid);
 ErrorOr<Optional<struct passwd>> getpwnam(StringView name);
 ErrorOr<Optional<struct group>> getgrnam(StringView name);
 ErrorOr<void> clock_settime(clockid_t clock_id, struct timespec* ts);
+ErrorOr<pid_t> posix_spawn(StringView const path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);
 ErrorOr<pid_t> posix_spawnp(StringView const path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);
 ErrorOr<pid_t> waitpid(pid_t waitee, int* wstatus, int options);
 ErrorOr<void> setuid(uid_t);

--- a/Userland/Services/LoginServer/CMakeLists.txt
+++ b/Userland/Services/LoginServer/CMakeLists.txt
@@ -9,6 +9,7 @@ compile_gml(LoginWindow.gml LoginWindowGML.h login_window_gml)
 set(SOURCES
     LoginWindowGML.h
     LoginWindow.cpp
+    ../Taskbar/ShutdownDialog.cpp
     main.cpp
 )
 

--- a/Userland/Services/LoginServer/LoginWindow.cpp
+++ b/Userland/Services/LoginServer/LoginWindow.cpp
@@ -4,10 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "../Taskbar/ShutdownDialog.h"
+#include <LibCore/System.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Widget.h>
 #include <Services/LoginServer/LoginWindow.h>
 #include <Services/LoginServer/LoginWindowGML.h>
+#include <serenity.h>
 
 LoginWindow::LoginWindow(GUI::Window* parent)
     : GUI::Window(parent)
@@ -34,6 +37,15 @@ LoginWindow::LoginWindow(GUI::Window* parent)
     m_log_in_button->on_click = [&](auto) {
         if (on_submit)
             on_submit();
+    };
+
+    m_power_button = *widget.find_descendant_of_type_named<GUI::Button>("power");
+    m_power_button->on_click = [](auto) {
+        auto command = ShutdownDialog::show(static_cast<int>(ShutdownDialog::ActionCode::Logout));
+        if (command.is_empty())
+            return;
+        auto child_pid = MUST(Core::System::posix_spawn(command[0], nullptr, nullptr, const_cast<char**>(command.data()), environ));
+        VERIFY(!disown(child_pid));
     };
 
     m_username->on_return_pressed = [&]() { m_log_in_button->click(); };

--- a/Userland/Services/LoginServer/LoginWindow.gml
+++ b/Userland/Services/LoginServer/LoginWindow.gml
@@ -33,6 +33,12 @@
                 text: "Log in"
                 fixed_width: 60
             }
+
+            @GUI::Button {
+                name: "power"
+                text: "Power..."
+                fixed_width: 60
+            }
         }
     }
 }

--- a/Userland/Services/LoginServer/LoginWindow.h
+++ b/Userland/Services/LoginServer/LoginWindow.h
@@ -32,4 +32,5 @@ private:
     RefPtr<GUI::TextBox> m_username;
     RefPtr<GUI::PasswordBox> m_password;
     RefPtr<GUI::Button> m_log_in_button;
+    RefPtr<GUI::Button> m_power_button;
 };

--- a/Userland/Services/LoginServer/main.cpp
+++ b/Userland/Services/LoginServer/main.cpp
@@ -61,6 +61,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/shadow", "r"));
     TRY(Core::System::unveil("/etc/group", "r"));
     TRY(Core::System::unveil("/bin/SystemServer", "x"));
+    TRY(Core::System::unveil("/bin/reboot", "x"));
+    TRY(Core::System::unveil("/bin/shutdown", "x"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/Taskbar/ShutdownDialog.h
+++ b/Userland/Services/Taskbar/ShutdownDialog.h
@@ -13,10 +13,17 @@ class ShutdownDialog : public GUI::Dialog {
     C_OBJECT(ShutdownDialog);
 
 public:
-    static Vector<char const*> show();
+    enum class ActionCode {
+        None = 0,
+        Shutdown = 1 << 0,
+        Reboot = 1 << 1,
+        Logout = 1 << 2,
+    };
+
+    static Vector<char const*> show(int disabled_actions = static_cast<int>(ActionCode::None));
 
 private:
-    ShutdownDialog();
+    ShutdownDialog(int disabled_actions = static_cast<int>(ActionCode::None));
     virtual ~ShutdownDialog() override;
 
     int m_selected_option { -1 };


### PR DESCRIPTION
I think it'd be nice to not have to log in in order to be able to turn off your machine.

https://user-images.githubusercontent.com/20257197/147890062-3e3f2b3d-8f4f-46e2-b703-6b5273e3095a.mp4

In order to call `/bin/shutdown` or `/bin/reboot` in LoginServer, this PR also adds an `ErrorOr` wrapper for `posix_spawn`. Taskbar's `ShutdownDialog` now takes an optional argument to allow specifying actions which should be disabled.