### PR TITLE
Kernel/Memory: Clang-Tidy fixes

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -37,6 +37,7 @@ Checks: >
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-uppercase-literal-suffix,
+  -readability-use-anyofallof,
 WarningsAsErrors: ''
 HeaderFilterRegex: 'AK|Userland|Kernel|Tests'
 FormatStyle: none

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -261,7 +261,7 @@ void AnonymousVMObject::ensure_or_reset_cow_map()
 
 bool AnonymousVMObject::should_cow(size_t page_index, bool is_shared) const
 {
-    auto& page = physical_pages()[page_index];
+    auto const& page = physical_pages()[page_index];
     if (page && (page->is_shared_zero_page() || page->is_lazy_committed_page()))
         return true;
     if (is_shared)

--- a/Kernel/Memory/PhysicalZone.cpp
+++ b/Kernel/Memory/PhysicalZone.cpp
@@ -186,7 +186,7 @@ void PhysicalZone::dump() const
 {
     dbgln("(( {} used, {} available, page_count: {} ))", m_used_chunks, available(), m_page_count);
     for (size_t i = 0; i <= max_order; ++i) {
-        auto& bucket = m_buckets[i];
+        auto const& bucket = m_buckets[i];
         dbgln("[{:2} / {:4}] ", i, (size_t)(2u << i));
         auto entry = bucket.freelist;
         while (entry != -1) {

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -132,7 +132,7 @@ size_t Region::amount_resident() const
 {
     size_t bytes = 0;
     for (size_t i = 0; i < page_count(); ++i) {
-        auto* page = physical_page(i);
+        auto const* page = physical_page(i);
         if (page && !page->is_shared_zero_page() && !page->is_lazy_committed_page())
             bytes += PAGE_SIZE;
     }
@@ -143,7 +143,7 @@ size_t Region::amount_shared() const
 {
     size_t bytes = 0;
     for (size_t i = 0; i < page_count(); ++i) {
-        auto* page = physical_page(i);
+        auto const* page = physical_page(i);
         if (page && page->ref_count() > 1 && !page->is_shared_zero_page() && !page->is_lazy_committed_page())
             bytes += PAGE_SIZE;
     }


### PR DESCRIPTION
This part of the code base was surprisingly clean...

Main thing to check is the logic in the second commit.