### PR TITLE
LoginServer+WindowServer+LibGUI: Prevent workspace switching at login

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -86,6 +86,7 @@ Window::Window(Core::Object* parent)
     REGISTER_BOOL_PROPERTY("minimizable", is_minimizable, set_minimizable);
     REGISTER_BOOL_PROPERTY("resizable", is_resizable, set_resizable);
     REGISTER_BOOL_PROPERTY("fullscreen", is_fullscreen, set_fullscreen);
+    REGISTER_BOOL_PROPERTY("prevents_workspace_switching", prevents_workspace_switching, set_prevents_workspace_switching);
     REGISTER_RECT_PROPERTY("rect", rect, set_rect);
     REGISTER_SIZE_PROPERTY("base_size", base_size, set_base_size);
     REGISTER_SIZE_PROPERTY("size_increment", size_increment, set_size_increment);
@@ -148,6 +149,7 @@ void Window::show()
         m_frameless,
         m_forced_shadow,
         m_accessory,
+        m_prevents_workspace_switching,
         m_opacity_when_windowless,
         m_alpha_hit_threshold,
         m_base_size,
@@ -806,6 +808,14 @@ void Window::set_alpha_hit_threshold(float threshold)
     if (!is_visible())
         return;
     WindowServerConnection::the().async_set_window_alpha_hit_threshold(m_window_id, threshold);
+}
+
+void Window::set_prevents_workspace_switching(bool prevents)
+{
+    m_prevents_workspace_switching = prevents;
+    if (!is_visible())
+        return;
+    WindowServerConnection::the().async_set_prevents_workspace_switching(m_window_id, prevents);
 }
 
 void Window::set_hovered_widget(Widget* widget)

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -66,6 +66,9 @@ public:
     void set_alpha_hit_threshold(float);
     float alpha_hit_threshold() const { return m_alpha_hit_threshold; }
 
+    bool prevents_workspace_switching() const { return m_prevents_workspace_switching; }
+    void set_prevents_workspace_switching(bool prevents);
+
     WindowType window_type() const { return m_window_type; }
     void set_window_type(WindowType);
 
@@ -286,6 +289,7 @@ private:
     Optional<Gfx::IntSize> m_resize_aspect_ratio {};
     bool m_minimizable { true };
     bool m_closeable { true };
+    bool m_prevents_workspace_switching { false };
     bool m_maximized_when_windowless { false };
     bool m_fullscreen { false };
     bool m_frameless { false };

--- a/Userland/Services/LoginServer/LoginWindow.cpp
+++ b/Userland/Services/LoginServer/LoginWindow.cpp
@@ -18,6 +18,7 @@ LoginWindow::LoginWindow(GUI::Window* parent)
     set_resizable(false);
     set_minimizable(false);
     set_closeable(false);
+    set_prevents_workspace_switching(true);
     set_icon(GUI::Icon::default_icon("ladyball").bitmap_for_size(16));
 
     auto& widget = set_main_widget<GUI::Widget>();

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -256,6 +256,16 @@ void ClientConnection::set_window_opacity(i32 window_id, float opacity)
     it->value->set_opacity(opacity);
 }
 
+void ClientConnection::set_prevents_workspace_switching(i32 window_id, bool prevents)
+{
+    auto it = m_windows.find(window_id);
+    if (it == m_windows.end()) {
+        did_misbehave("SetPreventsWorkspaceSwitching: Bad window ID");
+        return;
+    }
+    it->value->set_prevents_workspace_switching(prevents);
+}
+
 void ClientConnection::set_wallpaper(String const& path)
 {
     Compositor::the().set_wallpaper(path, [&](bool success) {
@@ -482,8 +492,8 @@ Window* ClientConnection::window_from_id(i32 window_id)
 
 void ClientConnection::create_window(i32 window_id, Gfx::IntRect const& rect,
     bool auto_position, bool has_alpha_channel, bool modal, bool minimizable, bool closeable, bool resizable,
-    bool fullscreen, bool frameless, bool forced_shadow, bool accessory, float opacity,
-    float alpha_hit_threshold, Gfx::IntSize const& base_size, Gfx::IntSize const& size_increment,
+    bool fullscreen, bool frameless, bool forced_shadow, bool accessory, bool prevents_workspace_switching,
+    float opacity, float alpha_hit_threshold, Gfx::IntSize const& base_size, Gfx::IntSize const& size_increment,
     Gfx::IntSize const& minimum_size, Optional<Gfx::IntSize> const& resize_aspect_ratio, i32 type,
     String const& title, i32 parent_window_id, Gfx::IntRect const& launch_origin_rect)
 {
@@ -537,6 +547,7 @@ void ClientConnection::create_window(i32 window_id, Gfx::IntRect const& rect,
     window->set_alpha_hit_threshold(alpha_hit_threshold);
     window->set_size_increment(size_increment);
     window->set_base_size(base_size);
+    window->set_prevents_workspace_switching(prevents_workspace_switching);
     if (resize_aspect_ratio.has_value() && !resize_aspect_ratio.value().is_null())
         window->set_resize_aspect_ratio(resize_aspect_ratio);
     window->invalidate(true, true);

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -98,7 +98,7 @@ private:
     virtual void add_menu_separator(i32) override;
     virtual void update_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&) override;
     virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool, bool, bool,
-        bool, bool, bool, bool, bool, float, float, Gfx::IntSize const&, Gfx::IntSize const&, Gfx::IntSize const&,
+        bool, bool, bool, bool, bool, bool, float, float, Gfx::IntSize const&, Gfx::IntSize const&, Gfx::IntSize const&,
         Optional<Gfx::IntSize> const&, i32, String const&, i32, Gfx::IntRect const&) override;
     virtual Messages::WindowServer::DestroyWindowResponse destroy_window(i32) override;
     virtual void set_window_title(i32, String const&) override;
@@ -172,6 +172,7 @@ private:
     virtual void remove_window_stealing_for_client(i32, i32) override;
     virtual void remove_window_stealing(i32) override;
     virtual Messages::WindowServer::GetColorUnderCursorResponse get_color_under_cursor() override;
+    virtual void set_prevents_workspace_switching(i32, bool) override;
 
     Window* window_from_id(i32 window_id);
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -1282,4 +1282,9 @@ String Window::computed_title() const
     return title;
 }
 
+void Window::set_prevents_workspace_switching(bool prevents)
+{
+    m_prevents_workspace_switching = prevents;
+}
+
 }

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -375,6 +375,9 @@ public:
     void remove_all_stealing() { m_stealable_by_client_ids.clear(); }
     bool is_stealable_by_client(i32 client_id) const { return m_stealable_by_client_ids.contains_slow(client_id); }
 
+    bool prevents_workspace_switching() const { return m_prevents_workspace_switching; }
+    void set_prevents_workspace_switching(bool);
+
 private:
     Window(ClientConnection&, WindowType, int window_id, bool modal, bool minimizable, bool closeable, bool frameless, bool resizable, bool fullscreen, bool accessory, Window* parent_window = nullptr);
     Window(Core::Object&, WindowType);
@@ -465,6 +468,7 @@ private:
     bool m_should_show_menubar { true };
     WindowStack* m_window_stack { nullptr };
     RefPtr<Animation> m_animation;
+    bool m_prevents_workspace_switching { false };
 
 public:
     using List = IntrusiveList<&Window::m_list_node>;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1399,6 +1399,13 @@ bool WindowManager::is_window_in_modal_stack(Window& window_in_modal_stack, Wind
 
 void WindowManager::switch_to_window_stack(WindowStack& window_stack, Window* carry_window, bool show_overlay)
 {
+    WindowStack& current_window_stack = WindowManager::the().current_window_stack();
+    for (auto& window : current_window_stack.windows()) {
+        if (window.prevents_workspace_switching()) {
+            return;
+        }
+    }
+
     m_carry_window_to_new_stack.clear();
     m_switching_to_window_stack = &window_stack;
     if (carry_window && !is_stationary_window_type(carry_window->type()) && &carry_window->window_stack() != &window_stack) {

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -38,6 +38,7 @@ endpoint WindowServer
         bool frameless,
         bool forced_shadow,
         bool accessory,
+        bool prevents_workspace_switching,
         float opacity,
         float alpha_hit_threshold,
         Gfx::IntSize base_size,
@@ -145,7 +146,7 @@ endpoint WindowServer
     get_double_click_speed() => (int speed)
 
     set_buttons_switched(bool switched) =|
-    get_buttons_switched() => (bool switched) 
+    get_buttons_switched() => (bool switched)
 
     get_desktop_display_scale(u32 screen_index) => (int desktop_display_scale)
 
@@ -156,4 +157,6 @@ endpoint WindowServer
     add_window_stealing_for_client(i32 client_id, i32 window_id) =|
     remove_window_stealing_for_client(i32 client_id, i32 window_id) =|
     remove_window_stealing(i32 window_id) =|
+
+    set_prevents_workspace_switching(i32 window_id, bool prevents) =|
 }


### PR DESCRIPTION
Previously, you could use the Ctrl+Alt+Arrow shortcut to switch workspaces on the login screen which doesn't make much sense. This PR prevents doing this.