### PR TITLE
Magnifier: Add colorblind preview options

### DIFF
--- a/Userland/Applications/Magnifier/CMakeLists.txt
+++ b/Userland/Applications/Magnifier/CMakeLists.txt
@@ -11,4 +11,4 @@ set(SOURCES
 )
 
 serenity_app(Magnifier ICON app-magnifier)
-target_link_libraries(Magnifier LibGUI LibMain)
+target_link_libraries(Magnifier LibGfx LibGUI LibMain)

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -8,6 +8,7 @@
 
 #include <AK/CircularQueue.h>
 #include <LibGUI/Frame.h>
+#include <LibGfx/Filters/ColorBlindnessFilter.h>
 
 class MagnifierWidget final : public GUI::Frame {
     C_OBJECT(MagnifierWidget);
@@ -15,6 +16,7 @@ class MagnifierWidget final : public GUI::Frame {
 public:
     virtual ~MagnifierWidget();
     void set_scale_factor(int scale_factor);
+    void set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter>);
     void pause_capture(bool pause)
     {
         m_pause_capture = pause;
@@ -28,10 +30,12 @@ private:
     MagnifierWidget();
 
     virtual void paint_event(GUI::PaintEvent&) override;
+    virtual void second_paint_event(GUI::PaintEvent&) override;
 
     void sync();
 
     int m_scale_factor { 2 };
+    OwnPtr<Gfx::ColorBlindnessFilter> m_color_filter;
     RefPtr<Gfx::Bitmap> m_grabbed_bitmap;
     CircularQueue<RefPtr<Gfx::Bitmap>, 512> m_grabbed_bitmaps {};
     ssize_t m_frame_offset_from_head { 0 };

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -12,6 +12,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Window.h>
+#include <LibGfx/Filters/ColorBlindnessFilter.h>
 #include <LibMain/Main.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -90,6 +91,67 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         });
     TRY(timeline_menu->try_add_action(previous_frame_action));
     TRY(timeline_menu->try_add_action(next_frame_action));
+
+    auto accessibility_menu = TRY(window->try_add_menu("&Accessibility"));
+
+    auto default_accessibility_action = GUI::Action::create_checkable("Default - non-impaired", { Mod_AltGr, Key_1 }, [&](auto&) {
+        magnifier->set_color_filter(nullptr);
+    });
+    default_accessibility_action->set_checked(true);
+
+    auto pratanopia_accessibility_action = GUI::Action::create_checkable("Protanopia", { Mod_AltGr, Key_2 }, [&](auto&) {
+        magnifier->set_color_filter(Gfx::ColorBlindnessFilter::create_protanopia());
+    });
+
+    auto pratanomaly_accessibility_action = GUI::Action::create_checkable("Protanomaly", { Mod_AltGr, Key_3 }, [&](auto&) {
+        magnifier->set_color_filter(Gfx::ColorBlindnessFilter::create_protanomaly());
+    });
+
+    auto tritanopia_accessibility_action = GUI::Action::create_checkable("Tritanopia", { Mod_AltGr, Key_4 }, [&](auto&) {
+        magnifier->set_color_filter(Gfx::ColorBlindnessFilter::create_tritanopia());
+    });
+
+    auto tritanomaly_accessibility_action = GUI::Action::create_checkable("Tritanomaly", { Mod_AltGr, Key_5 }, [&](auto&) {
+        magnifier->set_color_filter(Gfx::ColorBlindnessFilter::create_tritanomaly());
+    });
+
+    auto deuteranopia_accessibility_action = GUI::Action::create_checkable("Deuteranopia", { Mod_AltGr, Key_6 }, [&](auto&) {
+        magnifier->set_color_filter(Gfx::ColorBlindnessFilter::create_deuteranopia());
+    });
+
+    auto deuteranomaly_accessibility_action = GUI::Action::create_checkable("Deuteranomaly", { Mod_AltGr, Key_7 }, [&](auto&) {
+        magnifier->set_color_filter(Gfx::ColorBlindnessFilter::create_deuteranomaly());
+    });
+
+    auto achromatopsia_accessibility_action = GUI::Action::create_checkable("Achromatopsia", { Mod_AltGr, Key_8 }, [&](auto&) {
+        magnifier->set_color_filter(Gfx::ColorBlindnessFilter::create_achromatopsia());
+    });
+
+    auto achromatomaly_accessibility_action = GUI::Action::create_checkable("Achromatomaly", { Mod_AltGr, Key_9 }, [&](auto&) {
+        magnifier->set_color_filter(Gfx::ColorBlindnessFilter::create_achromatomaly());
+    });
+
+    auto preview_type_action_group = make<GUI::ActionGroup>();
+    preview_type_action_group->set_exclusive(true);
+    preview_type_action_group->add_action(*default_accessibility_action);
+    preview_type_action_group->add_action(*pratanopia_accessibility_action);
+    preview_type_action_group->add_action(*pratanomaly_accessibility_action);
+    preview_type_action_group->add_action(*tritanopia_accessibility_action);
+    preview_type_action_group->add_action(*tritanomaly_accessibility_action);
+    preview_type_action_group->add_action(*deuteranopia_accessibility_action);
+    preview_type_action_group->add_action(*deuteranomaly_accessibility_action);
+    preview_type_action_group->add_action(*achromatopsia_accessibility_action);
+    preview_type_action_group->add_action(*achromatomaly_accessibility_action);
+
+    TRY(accessibility_menu->try_add_action(default_accessibility_action));
+    TRY(accessibility_menu->try_add_action(pratanopia_accessibility_action));
+    TRY(accessibility_menu->try_add_action(pratanomaly_accessibility_action));
+    TRY(accessibility_menu->try_add_action(tritanopia_accessibility_action));
+    TRY(accessibility_menu->try_add_action(tritanomaly_accessibility_action));
+    TRY(accessibility_menu->try_add_action(deuteranopia_accessibility_action));
+    TRY(accessibility_menu->try_add_action(deuteranomaly_accessibility_action));
+    TRY(accessibility_menu->try_add_action(achromatopsia_accessibility_action));
+    TRY(accessibility_menu->try_add_action(achromatomaly_accessibility_action));
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     help_menu->add_action(GUI::CommonActions::make_about_action("Magnifier", app_icon, window));


### PR DESCRIPTION
Add the same preview options as the theme editor so you can test the accessibility of anything on your desktop. Both tools share the same shortcuts.

Follow-up to @linusg 's idea on #11295 :^) 