### PR TITLE
 HackStudio+LibDiff+Utilities: Fix crash when viewing a diff of non-committed file

### DIFF
--- a/Userland/Libraries/LibDiff/Generator.cpp
+++ b/Userland/Libraries/LibDiff/Generator.cpp
@@ -83,7 +83,7 @@ Vector<Hunk> from_text(StringView old_text, StringView new_text)
             if (cur_hunk.added_lines.size() > 0)
                 cur_hunk.target_start_line++;
             if (cur_hunk.removed_lines.size() > 0)
-                cur_hunk.original_start_line++;
+                cur_hunk.original_start_line.value()++;
             hunks.append(cur_hunk);
             in_hunk = false;
         }

--- a/Userland/Libraries/LibDiff/Hunks.cpp
+++ b/Userland/Libraries/LibDiff/Hunks.cpp
@@ -110,13 +110,20 @@ HunkLocation parse_hunk_location(const String& location_line)
 
     auto original_pair = parse_start_and_length_pair(location_line.substring(original_location_start_index, original_location_end_index - original_location_start_index + 1));
     auto target_pair = parse_start_and_length_pair(location_line.substring(target_location_start_index, target_location_end_index - target_location_start_index + 1));
+
+    if (original_pair.start == (size_t)-1) {
+        return { {}, original_pair.length, target_pair.start, target_pair.length };
+    }
+
     return { original_pair.start, original_pair.length, target_pair.start, target_pair.length };
 }
 
 void HunkLocation::apply_offset(size_t offset, HunkLocation::LocationType type)
 {
     if (type == LocationType::Original || type == LocationType::Both) {
-        original_start_line += offset;
+        if (original_start_line.has_value())
+            original_start_line = original_start_line.value() + offset;
+
         original_length -= offset;
     }
     if (type == LocationType::Target || type == LocationType::Both) {

--- a/Userland/Libraries/LibDiff/Hunks.h
+++ b/Userland/Libraries/LibDiff/Hunks.h
@@ -12,7 +12,7 @@
 namespace Diff {
 
 struct HunkLocation {
-    size_t original_start_line { 0 };
+    Optional<size_t> original_start_line { 0 };
     size_t original_length { 0 };
     size_t target_start_line { 0 };
     size_t target_length { 0 };
@@ -26,7 +26,7 @@ struct HunkLocation {
 };
 
 struct Hunk {
-    size_t original_start_line { 0 };
+    Optional<size_t> original_start_line { 0 };
     size_t target_start_line { 0 };
     Vector<String> removed_lines;
     Vector<String> added_lines;

--- a/Userland/Utilities/diff.cpp
+++ b/Userland/Utilities/diff.cpp
@@ -35,9 +35,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         StringBuilder sb;
         // Source line(s)
-        sb.appendff("{}", original_start);
+        sb.appendff("{}", original_start.value());
         if (num_removed > 1)
-            sb.appendff(",{}", original_start + num_removed - 1);
+            sb.appendff(",{}", original_start.value() + num_removed - 1);
 
         // Action
         if (num_added > 0 && num_removed > 0)


### PR DESCRIPTION
This commit fixes a crash when viewing the diff of a new file which was caused by attempting to loop over the lines of an empty hunk (indicated by the ``original_start_line`` being ``-1``).

Instead, we now draw a string to the left side of the screen indicating that this file is new to the git repository.

<img src="https://user-images.githubusercontent.com/71222289/147611005-0ceb8a35-18af-49e3-a66e-451f0700b16a.png" width="600" />