### PR TITLE
Kernel: Port (almost) everything to ListedRefCounted

### DIFF
--- a/Kernel/Devices/Device.cpp
+++ b/Kernel/Devices/Device.cpp
@@ -131,7 +131,7 @@ void Device::after_inserting()
     });
 }
 
-void Device::before_removing()
+void Device::will_be_destroyed()
 {
     VERIFY(m_sysfs_component);
     SysFSComponentRegistry::the().devices_list().with_exclusive([&](auto& list) -> void {

--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -47,7 +47,7 @@ public:
     GroupID gid() const { return m_gid; }
 
     virtual bool is_device() const override { return true; }
-    virtual void before_removing() override;
+    virtual void will_be_destroyed() override;
     virtual void after_inserting();
     void process_next_queued_request(Badge<AsyncDeviceRequest>, const AsyncDeviceRequest&);
 

--- a/Kernel/FileSystem/Custody.h
+++ b/Kernel/FileSystem/Custody.h
@@ -8,20 +8,19 @@
 
 #include <AK/Error.h>
 #include <AK/IntrusiveList.h>
-#include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <Kernel/Forward.h>
 #include <Kernel/KString.h>
+#include <Kernel/Library/ListedRefCounted.h>
+#include <Kernel/Locking/MutexProtected.h>
 
 namespace Kernel {
 
 // FIXME: Custody needs some locking.
 
-class Custody : public RefCountedBase {
+class Custody : public ListedRefCounted<Custody, LockType::Mutex> {
 public:
-    bool unref() const;
-
     static ErrorOr<NonnullRefPtr<Custody>> try_create(Custody* parent, StringView name, Inode&, int mount_flags);
 
     ~Custody();
@@ -49,6 +48,7 @@ private:
 
 public:
     using AllCustodiesList = IntrusiveList<&Custody::m_all_custodies_list_node>;
+    static MutexProtected<Custody::AllCustodiesList>& all_instances();
 };
 
 }

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -20,15 +20,6 @@ File::~File()
 {
 }
 
-bool File::unref() const
-{
-    if (deref_base())
-        return false;
-    const_cast<File&>(*this).will_be_destroyed();
-    delete this;
-    return true;
-}
-
 ErrorOr<NonnullRefPtr<OpenFileDescription>> File::open(int options)
 {
     auto description = OpenFileDescription::try_create(*this);

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -24,7 +24,7 @@ bool File::unref() const
 {
     if (deref_base())
         return false;
-    const_cast<File&>(*this).before_removing();
+    const_cast<File&>(*this).will_be_destroyed();
     delete this;
     return true;
 }

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -71,10 +71,9 @@ public:
 //   - Should create a Region in the Process and return it if successful.
 
 class File
-    : public RefCountedBase
+    : public RefCounted<File>
     , public Weakable<File> {
 public:
-    virtual bool unref() const;
     virtual void will_be_destroyed() { }
     virtual ~File();
 

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -75,7 +75,7 @@ class File
     , public Weakable<File> {
 public:
     virtual bool unref() const;
-    virtual void before_removing() { }
+    virtual void will_be_destroyed() { }
     virtual ~File();
 
     virtual ErrorOr<NonnullRefPtr<OpenFileDescription>> open(int options);

--- a/Kernel/FileSystem/Inode.h
+++ b/Kernel/FileSystem/Inode.h
@@ -23,7 +23,7 @@
 
 namespace Kernel {
 
-class Inode : public ListedRefCounted<Inode>
+class Inode : public ListedRefCounted<Inode, LockType::Spinlock>
     , public Weakable<Inode> {
     friend class VirtualFileSystem;
     friend class FileSystem;

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -533,10 +533,11 @@ private:
         {
             {
                 auto array = json.add_array("processes");
-                auto processes = Process::all_processes();
                 build_process(array, *Scheduler::colonel());
-                for (auto& process : processes)
-                    build_process(array, process);
+                processes().with([&](auto& processes) {
+                    for (auto& process : processes)
+                        build_process(array, process);
+                });
             }
 
             auto total_time_scheduled = Scheduler::get_total_time_scheduled();

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -534,7 +534,7 @@ private:
             {
                 auto array = json.add_array("processes");
                 build_process(array, *Scheduler::colonel());
-                processes().with([&](auto& processes) {
+                Process::all_instances().with([&](auto& processes) {
                     for (auto& process : processes)
                         build_process(array, process);
                 });
@@ -942,7 +942,7 @@ ErrorOr<void> ProcFSRootDirectory::traverse_as_directory(FileSystemID fsid, Func
         TRY(callback({ component.name(), identifier, 0 }));
     }
 
-    return processes().with([&](auto& list) -> ErrorOr<void> {
+    return Process::all_instances().with([&](auto& list) -> ErrorOr<void> {
         for (auto& process : list) {
             VERIFY(!(process.pid() < 0));
             u64 process_id = (u64)process.pid().value();

--- a/Kernel/Library/ListedRefCounted.h
+++ b/Kernel/Library/ListedRefCounted.h
@@ -11,21 +11,32 @@
 namespace Kernel {
 
 // ListedRefCounted<T> is a slot-in replacement for RefCounted<T> to use in classes
-// that add themselves to a SpinlockProtected<IntrusiveList> when constructed.
-// The custom unref() implementation here ensures that the the list is locked during
+// that add themselves to a {Spinlock, Mutex}Protected<IntrusiveList> when constructed.
+// The custom unref() implementation here ensures that the list is locked during
 // unref(), and that the T is removed from the list before ~T() is invoked.
 
-template<typename T>
+enum class LockType {
+    Spinlock,
+    Mutex,
+};
+
+template<typename T, LockType Lock>
 class ListedRefCounted : public RefCountedBase {
 public:
     bool unref() const
     {
-        auto new_ref_count = T::all_instances().with([&](auto& list) {
+        auto callback = [&](auto& list) {
             auto new_ref_count = deref_base();
             if (new_ref_count == 0)
                 list.remove(const_cast<T&>(static_cast<T const&>(*this)));
             return new_ref_count;
-        });
+        };
+
+        RefCountType new_ref_count;
+        if constexpr (Lock == LockType::Spinlock)
+            new_ref_count = T::all_instances().with(callback);
+        else if constexpr (Lock == LockType::Mutex)
+            new_ref_count = T::all_instances().with_exclusive(callback);
         if (new_ref_count == 0) {
             call_will_be_destroyed_if_present(static_cast<const T*>(this));
             delete const_cast<T*>(static_cast<T const*>(this));

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -18,7 +18,7 @@
 namespace Kernel::Memory {
 
 class VMObject
-    : public ListedRefCounted<VMObject>
+    : public ListedRefCounted<VMObject, LockType::Spinlock>
     , public Weakable<VMObject> {
     friend class MemoryManager;
     friend class Region;

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -79,17 +79,6 @@ UNMAP_AFTER_INIT void Process::initialize()
     create_signal_trampoline();
 }
 
-NonnullRefPtrVector<Process> Process::all_processes()
-{
-    NonnullRefPtrVector<Process> output;
-    processes().with([&](const auto& list) {
-        output.ensure_capacity(list.size_slow());
-        for (const auto& process : list)
-            output.append(NonnullRefPtr<Process>(process));
-    });
-    return output;
-}
-
 bool Process::in_group(GroupID gid) const
 {
     return this->gid() == gid || extra_gids().contains_slow(gid);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -186,8 +186,6 @@ public:
     bool unref() const;
     ~Process();
 
-    static NonnullRefPtrVector<Process> all_processes();
-
     RefPtr<Thread> create_kernel_thread(void (*entry)(void*), void* entry_data, u32 priority, NonnullOwnPtr<KString> name, u32 affinity = THREAD_AFFINITY_DEFAULT, bool joinable = true);
 
     bool is_profiling() const { return m_profiling; }

--- a/Kernel/Storage/ATA/AHCIPort.cpp
+++ b/Kernel/Storage/ATA/AHCIPort.cpp
@@ -77,7 +77,6 @@ void AHCIPort::handle_interrupt()
             m_connected_device->prepare_for_unplug();
             StorageManagement::the().remove_device(*m_connected_device);
             g_io_work->queue([this]() {
-                m_connected_device->before_removing();
                 m_connected_device.clear();
             });
         } else {

--- a/Kernel/Syscalls/kill.cpp
+++ b/Kernel/Syscalls/kill.cpp
@@ -65,7 +65,7 @@ ErrorOr<void> Process::do_killall(int signal)
     ErrorOr<void> error;
 
     // Send the signal to all processes we have access to for.
-    processes().for_each([&](auto& process) {
+    Process::all_instances().for_each([&](auto& process) {
         ErrorOr<void> res;
         if (process.pid() == pid())
             res = do_killself(signal);

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -29,7 +29,7 @@ bool SlavePTY::unref() const
         return true;
     });
     if (did_hit_zero) {
-        const_cast<SlavePTY&>(*this).before_removing();
+        const_cast<SlavePTY&>(*this).will_be_destroyed();
         delete this;
     }
     return did_hit_zero;

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -15,7 +15,7 @@ class MasterPTY;
 
 class SlavePTY final : public TTY {
 public:
-    virtual bool unref() const override;
+    bool unref() const;
     virtual ~SlavePTY() override;
 
     void on_master_write(const UserOrKernelBuffer&, size_t);

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -146,7 +146,7 @@ struct ThreadRegisters {
 };
 
 class Thread
-    : public ListedRefCounted<Thread>
+    : public ListedRefCounted<Thread, LockType::Spinlock>
     , public Weakable<Thread> {
     AK_MAKE_NONCOPYABLE(Thread);
     AK_MAKE_NONMOVABLE(Thread);


### PR DESCRIPTION
There many implementions of ListedRefCounted's behaviour in the Kernel, which results in avoidable bugs caused by the fragmentation of the implementations. This PR replaces almost all of the custom implementations with ListedRefCounted.

The last remaining one is SlavePTY, which as far as I can tell cannot be converted cleanly, as it inherits from `File` which also inherits from RefCountedBase.