### PR TITLE
Kernel: Make File::unref virtual

### DIFF
--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -74,6 +74,7 @@ class File
     : public RefCounted<File>
     , public Weakable<File> {
 public:
+    virtual bool unref() const { return RefCounted<File>::unref(); }
     virtual void will_be_destroyed() { }
     virtual ~File();
 

--- a/Kernel/TTY/SlavePTY.h
+++ b/Kernel/TTY/SlavePTY.h
@@ -15,7 +15,7 @@ class MasterPTY;
 
 class SlavePTY final : public TTY {
 public:
-    bool unref() const;
+    virtual bool unref() const override;
     virtual ~SlavePTY() override;
 
     void on_master_write(const UserOrKernelBuffer&, size_t);


### PR DESCRIPTION
This is required for SlavePTY's custom unref handler to function correctly, as otherwise a SlavePTY held in a File RefPtr would call the base's (RefCounted<>) unref method instead of SlavePTY's version.