### PR TITLE
CI: Export per-file results of test262 runs and compare against last

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -97,6 +97,12 @@ jobs:
           cmake -GNinja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSERENITY_SOURCE_DIR=${{ env.SERENITY_SOURCE_DIR }} ..
           ninja libjs-test262-runner test-js
 
+      - name: Get previous results
+        working-directory: libjs-test262
+        run: |
+          cp -f ../libjs-website/test262/data/per-file-master.json . || :
+          cp -f ../libjs-website/test262/data/per-file-bytecode-master.json . || :
+
       - name: Run test262 and test262-parser-tests
         working-directory: libjs-test262
         run: |
@@ -104,7 +110,9 @@ jobs:
             --serenity .. \
             --test262 ../test262 \
             --test262-parser-tests ../test262-parser-tests \
-            --results-json ../libjs-website/test262/data/results.json
+            --results-json ../libjs-website/test262/data/results.json \
+            --per-file-output ../libjs-website/test262/data/per-file-master.json \
+            --per-file-bytecode-output ../libjs-website/test262/data/per-file-bytecode-master.json
 
       - name: Deploy to GitHub pages
         uses: JamesIves/github-pages-deploy-action@4.1.1
@@ -115,3 +123,13 @@ jobs:
           repository-name: linusg/libjs-website
           token: ${{ secrets.BUGGIEBOT }}
           folder: libjs-website
+
+      - name: Compare non-bytecode
+        continue-on-error: true
+        working-directory: libjs-test262
+        run: ./per_file_result_diff.py -o master.json -n ../libjs-website/test262/data/per-file-master.json
+
+      - name: Compare bytecode
+        continue-on-error: true
+        working-directory: libjs-test262
+        run: ./per_file_result_diff.py -o bytecode-master.json -n ../libjs-website/test262/data/per-file-bytecode-master.json


### PR DESCRIPTION
:heavy_check_mark:  This requires https://github.com/linusg/libjs-test262/pull/47 to be merged :heavy_check_mark: 

Since this is my first CI change there are a couple of things I'm not sure about:
- ~Will it be fine to upload-artifacts from a self hosted runner? I assume you upload them to github put I couldn't find anything about that~ Looking at upload-artifact it uses the github API so yes it seems fine.
- Is using an non default action: dawidd6/action-download-artifact potentially unsafe? I did hardcode the version with a hash but I saw that in other places we forked an action.

Then some bikeshedding which can be done: 
- ~How do we want to export the files? Right now we have two different artifacts for non-bytecode and bytecode for easy downloading but it's still in a zip.~ I switched to one artifact since for manually downloading you still have to extract it meaning there is no real gain in having to separate ones.
- Do we want to export the results to the website? Since this is done via git this didn't seem like a great option to me but 🤷.
- Finally what would be a good retention period? I picked 7 days just to have some previous results but since test262 gets triggered usually at least once a day we could shorten this. We could also just put it at the max of 90 days.

If you want to see how this looks check: https://github.com/davidot/serenity/runs/4661486640?check_suite_focus=true for an example with actually different tests
And https://github.com/davidot/serenity/actions/runs/1635154652 for an example where it could not find any previous results but still passed CI.