### PR TITLE
ImageViewer: Allow choice between nearest neighbor and bilinear scaling

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -14,7 +14,6 @@
 #include <LibCore/MappedFile.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/MessageBox.h>
-#include <LibGUI/Painter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Orientation.h>
 #include <LibGfx/Palette.h>
@@ -178,7 +177,7 @@ void ViewWidget::paint_event(GUI::PaintEvent& event)
     Gfx::StylePainter::paint_transparency_grid(painter, frame_inner_rect(), palette());
 
     if (!m_bitmap.is_null())
-        painter.draw_scaled_bitmap(m_bitmap_rect, *m_bitmap, m_bitmap->rect());
+        painter.draw_scaled_bitmap(m_bitmap_rect, *m_bitmap, m_bitmap->rect(), 1.0f, m_scaling_mode);
 }
 
 void ViewWidget::mousedown_event(GUI::MouseEvent& event)
@@ -341,6 +340,12 @@ void ViewWidget::animate()
             m_timer->stop();
         }
     }
+}
+
+void ViewWidget::set_scaling_mode(Gfx::Painter::ScalingMode scaling_mode)
+{
+    m_scaling_mode = scaling_mode;
+    update();
 }
 
 }

--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -10,6 +10,7 @@
 
 #include <LibCore/Timer.h>
 #include <LibGUI/Frame.h>
+#include <LibGUI/Painter.h>
 #include <LibGfx/Point.h>
 #include <LibImageDecoderClient/Client.h>
 
@@ -37,6 +38,7 @@ public:
     void set_scaled_for_first_image(bool val) { m_scaled_for_first_image = val; }
     void set_path(const String& path);
     void resize_window();
+    void set_scaling_mode(Gfx::Painter::ScalingMode);
 
     bool is_next_available() const;
     bool is_previous_available() const;
@@ -86,6 +88,7 @@ private:
     Gfx::FloatPoint m_saved_pan_origin;
     Vector<String> m_files_in_same_dir;
     Optional<size_t> m_current_index;
+    Gfx::Painter::ScalingMode m_scaling_mode { Gfx::Painter::ScalingMode::NearestNeighbor };
 };
 
 }

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
+#include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Clipboard.h>
@@ -225,6 +226,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (widget.bitmap())
             GUI::Clipboard::the().set_bitmap(*widget.bitmap());
     });
+
+    auto nearest_neighbor_action = GUI::Action::create_checkable("&Nearest Neighbor", [&](auto&) {
+        widget.set_scaling_mode(Gfx::Painter::ScalingMode::NearestNeighbor);
+    });
+    nearest_neighbor_action->set_checked(true);
+
+    auto bilinear_action = GUI::Action::create_checkable("&Bilinear", [&](auto&) {
+        widget.set_scaling_mode(Gfx::Painter::ScalingMode::BilinearBlend);
+    });
+
     widget.on_image_change = [&](const Gfx::Bitmap* bitmap) {
         bool should_enable_image_actions = (bitmap != nullptr);
         bool should_enable_forward_actions = (widget.is_next_available() && should_enable_image_actions);
@@ -287,6 +298,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     view_menu.add_action(zoom_in_action);
     view_menu.add_action(reset_zoom_action);
     view_menu.add_action(zoom_out_action);
+    view_menu.add_separator();
+
+    auto& scaling_mode_menu = view_menu.add_submenu("&Scaling Mode");
+
+    auto scaling_mode_group = make<GUI::ActionGroup>();
+    scaling_mode_group->set_exclusive(true);
+    scaling_mode_group->add_action(*nearest_neighbor_action);
+    scaling_mode_group->add_action(*bilinear_action);
+
+    scaling_mode_menu.add_action(nearest_neighbor_action);
+    scaling_mode_menu.add_action(bilinear_action);
+
     view_menu.add_separator();
     view_menu.add_action(hide_show_toolbar_action);
 


### PR DESCRIPTION
Currently, ImageViewer always uses nearest neighbor scaling.
This allows the user to choose whether to use nearest neighbor
or bilinear scaling. It current defaults to nearest neighbor.

https://user-images.githubusercontent.com/25595356/147679061-6b6d752d-dbfb-4763-b6ff-f7c12497c793.mp4


