### PR TITLE
Taskbar: Arbitrary QuickLaunch entries

### DIFF
--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -76,6 +76,12 @@ void ConfigFile::reparse()
 
     while (m_file->can_read_line()) {
         auto line = m_file->read_line();
+
+        if (line.is_null()) {
+            m_groups.clear();
+            return;
+        }
+
         auto* cp = line.characters();
 
         while (*cp && (*cp == ' ' || *cp == '\t' || *cp == '\n'))

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -17,6 +17,10 @@
 #include <termios.h>
 #include <unistd.h>
 
+#ifdef __serenity__
+#    include <serenity.h>
+#endif
+
 #define HANDLE_SYSCALL_RETURN_VALUE(syscall_name, rc, success_value) \
     if ((rc) < 0) {                                                  \
         return Error::from_syscall(syscall_name, rc);                \
@@ -104,6 +108,12 @@ ErrorOr<long> ptrace(int request, pid_t tid, void* address, void* data)
     if (rc < 0)
         return Error::from_syscall("ptrace"sv, -errno);
     return rc;
+}
+
+ErrorOr<void> disown(pid_t pid)
+{
+    int rc = ::disown(pid);
+    HANDLE_SYSCALL_RETURN_VALUE("disown", rc, {});
 }
 #endif
 

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -38,6 +38,7 @@ ErrorOr<void> ptrace_peekbuf(pid_t tid, void const* tracee_addr, Bytes destinati
 ErrorOr<void> setgroups(Span<gid_t const>);
 ErrorOr<void> mount(int source_fd, StringView target, StringView fs_type, int flags);
 ErrorOr<long> ptrace(int request, pid_t tid, void* address, void* data);
+ErrorOr<void> disown(pid_t pid);
 #endif
 
 #ifndef AK_OS_BSD_GENERIC

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -50,6 +50,11 @@ static LaunchServerConnection& connection()
     return connection;
 }
 
+void Launcher::ensure_connection()
+{
+    [[maybe_unused]] auto& conn = connection();
+}
+
 ErrorOr<void> Launcher::add_allowed_url(URL const& url)
 {
     auto response_or_error = connection().try_add_allowed_url(url);

--- a/Userland/Libraries/LibDesktop/Launcher.h
+++ b/Userland/Libraries/LibDesktop/Launcher.h
@@ -31,6 +31,7 @@ public:
         static NonnullRefPtr<Details> from_details_str(const String&);
     };
 
+    static void ensure_connection();
     static ErrorOr<void> add_allowed_url(URL const&);
     static ErrorOr<void> add_allowed_handler_with_any_url(String const& handler);
     static ErrorOr<void> add_allowed_handler_with_only_specific_urls(String const& handler, Vector<URL> const&);

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -53,6 +53,20 @@ public:
 private:
     String m_path;
 };
+class QuickLaunchEntryFile : public QuickLaunchEntry {
+public:
+    explicit QuickLaunchEntryFile(String path)
+        : m_path(move(path))
+    {
+    }
+
+    virtual ErrorOr<void> launch() const override;
+    virtual GUI::Icon icon() const override;
+    virtual String name() const override;
+
+private:
+    String m_path;
+};
 
 class QuickLaunchWidget : public GUI::Frame
     , public Config::Listener {

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibConfig/Listener.h>
+#include <LibCore/FileWatcher.h>
 #include <LibDesktop/AppFile.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Frame.h>
@@ -19,6 +20,7 @@ public:
     virtual ErrorOr<void> launch() const = 0;
     virtual GUI::Icon icon() const = 0;
     virtual String name() const = 0;
+    virtual String file_name_to_watch() const = 0;
 
     static OwnPtr<QuickLaunchEntry> create_from_config_value(StringView path);
     static OwnPtr<QuickLaunchEntry> create_from_path(StringView path);
@@ -34,6 +36,7 @@ public:
     virtual ErrorOr<void> launch() const override;
     virtual GUI::Icon icon() const override { return m_app_file->icon(); }
     virtual String name() const override { return m_app_file->name(); }
+    virtual String file_name_to_watch() const override { return {}; }
 
 private:
     NonnullRefPtr<Desktop::AppFile> m_app_file;
@@ -49,6 +52,7 @@ public:
     virtual ErrorOr<void> launch() const override;
     virtual GUI::Icon icon() const override;
     virtual String name() const override;
+    virtual String file_name_to_watch() const override { return m_path; }
 
 private:
     String m_path;
@@ -63,6 +67,7 @@ public:
     virtual ErrorOr<void> launch() const override;
     virtual GUI::Icon icon() const override;
     virtual String name() const override;
+    virtual String file_name_to_watch() const override { return m_path; }
 
 private:
     String m_path;
@@ -86,6 +91,7 @@ private:
     RefPtr<GUI::Menu> m_context_menu;
     RefPtr<GUI::Action> m_context_menu_default_action;
     String m_context_menu_app_name;
+    RefPtr<Core::FileWatcher> m_watcher;
 };
 
 }

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -13,6 +13,32 @@
 
 namespace Taskbar {
 
+class QuickLaunchEntry {
+public:
+    virtual ~QuickLaunchEntry() = default;
+    virtual ErrorOr<void> launch() const = 0;
+    virtual GUI::Icon icon() const = 0;
+    virtual String name() const = 0;
+
+    static OwnPtr<QuickLaunchEntry> create_from_config_value(StringView path);
+    static OwnPtr<QuickLaunchEntry> create_from_path(StringView path);
+};
+
+class QuickLaunchEntryAppFile : public QuickLaunchEntry {
+public:
+    explicit QuickLaunchEntryAppFile(NonnullRefPtr<Desktop::AppFile> file)
+        : m_app_file(move(file))
+    {
+    }
+
+    virtual ErrorOr<void> launch() const override;
+    virtual GUI::Icon icon() const override { return m_app_file->icon(); }
+    virtual String name() const override { return m_app_file->name(); }
+
+private:
+    NonnullRefPtr<Desktop::AppFile> m_app_file;
+};
+
 class QuickLaunchWidget : public GUI::Frame
     , public Config::Listener {
     C_OBJECT(QuickLaunchWidget);
@@ -27,7 +53,7 @@ public:
 
 private:
     QuickLaunchWidget();
-    void add_or_adjust_button(String const&, NonnullRefPtr<Desktop::AppFile>);
+    void add_or_adjust_button(String const&, NonnullOwnPtr<QuickLaunchEntry>&&);
     RefPtr<GUI::Menu> m_context_menu;
     RefPtr<GUI::Action> m_context_menu_default_action;
     String m_context_menu_app_name;

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -39,6 +39,21 @@ private:
     NonnullRefPtr<Desktop::AppFile> m_app_file;
 };
 
+class QuickLaunchEntryExecutable : public QuickLaunchEntry {
+public:
+    explicit QuickLaunchEntryExecutable(String path)
+        : m_path(move(path))
+    {
+    }
+
+    virtual ErrorOr<void> launch() const override;
+    virtual GUI::Icon icon() const override;
+    virtual String name() const override;
+
+private:
+    String m_path;
+};
+
 class QuickLaunchWidget : public GUI::Frame
     , public Config::Listener {
     C_OBJECT(QuickLaunchWidget);

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -17,6 +17,7 @@
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibDesktop/AppFile.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Menu.h>
@@ -47,7 +48,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     });
 
     TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath unix"));
+
     GUI::WindowManagerServerConnection::the();
+    Desktop::Launcher::ensure_connection();
 
     TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath"));
 


### PR DESCRIPTION
This PR adds support for arbitrary QuickLaunch entries to Taskbar. This is made by abstracting an entry into a QuickLaunchEntry class.

It's not ideal as doesn't work for some corner-cases (especially when there are e.g. `test=test` and `testtest` files).

We get also one wrapper in Core::System (disown) and nullptr dereference fix when trying to open binary files with Core::ConfigFile.

https://user-images.githubusercontent.com/42967349/147684566-41ce9363-8e53-44fa-9509-71c6ba2dd9b4.mp4