### PR TITLE
Shell: Avoid many single byte write() syscalls when printing the prompt

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1660,8 +1660,11 @@ void Shell::bring_cursor_to_beginning_of_a_line() const
 
     fputs(eol_mark.characters(), stderr);
 
-    for (auto i = eol_mark_length; i < ws.ws_col; ++i)
-        putc(' ', stderr);
+    // We write a line's worth of whitespace to the terminal. This way, we ensure that
+    // the prompt ends up on a new line even if there is dangling output on the current line.
+    size_t fill_count = ws.ws_col - eol_mark_length;
+    auto fill_buffer = String::repeated(' ', fill_count);
+    fwrite(fill_buffer.characters(), 1, fill_count, stderr);
 
     putc('\r', stderr);
 }


### PR DESCRIPTION
Whenever the prompt is printed, we write a line's worth of space
characters to the terminal to ensure that the prompt ends up on a new
line even if there is dangling output on the current line.

We write these to the stderr, which is unbuffered, so each putc() call
would come with the overhead of a system call. Let's use a buffer
\+ fwrite() instead, since heap allocation is much faster.

cc @alimpfard 