### PR TITLE
LibSoftGPU: Add debug overlay

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -6,8 +6,15 @@
 
 #pragma once
 
+#define INCREASE_STATISTICS_COUNTER(stat, n)     \
+    do {                                         \
+        if constexpr (ENABLE_STATISTICS_OVERLAY) \
+            stat += (n);                         \
+    } while (0)
+
 namespace SoftGPU {
 
+static constexpr bool ENABLE_STATISTICS_OVERLAY = false;
 static constexpr int RASTERIZER_BLOCK_SIZE = 8;
 static constexpr int NUM_SAMPLERS = 32;
 

--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+namespace SoftGPU {
+
+static constexpr int RASTERIZER_BLOCK_SIZE = 8;
+static constexpr int NUM_SAMPLERS = 32;
+
+// See: https://www.khronos.org/opengl/wiki/Common_Mistakes#Texture_edge_color_problem
+// FIXME: make this dynamically configurable through ConfigServer
+static constexpr bool CLAMP_DEPRECATED_BEHAVIOR = false;
+
+}

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -9,14 +9,13 @@
 #include <LibGfx/Painter.h>
 #include <LibGfx/Vector2.h>
 #include <LibGfx/Vector3.h>
+#include <LibSoftGPU/Config.h>
 #include <LibSoftGPU/Device.h>
 
 namespace SoftGPU {
 
 using IntVector2 = Gfx::Vector2<int>;
 using IntVector3 = Gfx::Vector3<int>;
-
-static constexpr int RASTERIZER_BLOCK_SIZE = 8;
 
 constexpr static int edge_function(const IntVector2& a, const IntVector2& b, const IntVector2& c)
 {
@@ -529,7 +528,7 @@ DeviceInfo Device::info() const
     return {
         .vendor_name = "SerenityOS",
         .device_name = "SoftGPU",
-        .num_texture_units = num_samplers
+        .num_texture_units = NUM_SAMPLERS
     };
 }
 

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -91,6 +91,7 @@ public:
 
 private:
     void submit_triangle(Triangle const& triangle, Vector<size_t> const& enabled_texture_units);
+    void draw_statistics_overlay(Gfx::Bitmap&);
 
 private:
     RefPtr<Gfx::Bitmap> m_render_target;

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -15,6 +15,7 @@
 #include <LibGfx/Rect.h>
 #include <LibGfx/Vector4.h>
 #include <LibSoftGPU/Clipper.h>
+#include <LibSoftGPU/Config.h>
 #include <LibSoftGPU/DepthBuffer.h>
 #include <LibSoftGPU/DeviceInfo.h>
 #include <LibSoftGPU/Enums.h>
@@ -66,8 +67,6 @@ struct RasterizerOptions {
     Array<TexCoordGenerationConfig, 4> texcoord_generation_config {};
 };
 
-inline static constexpr size_t const num_samplers = 32;
-
 class Device final {
 public:
     Device(const Gfx::IntSize& min_size);
@@ -101,7 +100,7 @@ private:
     Vector<Triangle> m_triangle_list;
     Vector<Triangle> m_processed_triangles;
     Vector<Vertex> m_clipped_vertices;
-    Array<Sampler, num_samplers> m_samplers;
+    Array<Sampler, NUM_SAMPLERS> m_samplers;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/Sampler.cpp
+++ b/Userland/Libraries/LibSoftGPU/Sampler.cpp
@@ -4,15 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibSoftGPU/Config.h>
 #include <LibSoftGPU/Image.h>
 #include <LibSoftGPU/Sampler.h>
 #include <math.h>
 
 namespace SoftGPU {
-
-// See: https://www.khronos.org/opengl/wiki/Common_Mistakes#Texture_edge_color_problem
-// FIXME: make this dynamically configurable through ConfigServer
-static constexpr bool CLAMP_DEPRECATED_BEHAVIOR = false;
 
 static constexpr float fracf(float value)
 {


### PR DESCRIPTION
![Bildschirmfoto zu 2021-12-29 23-02-16](https://user-images.githubusercontent.com/2094371/147711858-048aee10-ca83-436d-ac3b-acd74552d96c.png)

This can be toggled by setting `ENABLE_STATISTICS_OVERLAY` in Config.h.

To clarify the numbers displayed here:

Timings are based on the time between `draw_debug_overlay()` invocations. This measures actual number of frames presented to the user vs. wall clock time so this also includes everything the app might do besides rendering.

Triangles are counted after clipping. This number might actually be higher than the number of triangles coming from LibGL.

Pixels are counted after the initial scissor and coverage test. Pixels rejected here are not counted. Shaded pixels is the percentage of all pixels that made it to the shading stage. Blended pixels is the percentage of shaded pixels that were alpha blended to the color buffer.

Overdraw measures how many pixels were shaded vs. how many pixels the  render target has. e.g. a 640x480 render target has 307200 pixels. If exactly that many pixels are shaded the overdraw number will read 0%. 614400 shaded pixels with read as an overdraw of 100%.   

Sampler calls is simply the number of times `sampler.sample_2d()` was called.