### PR TITLE
CrashReporter: Move progressbar into main window

### DIFF
--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -73,8 +73,14 @@
         }
     }
 
+    @GUI::Progressbar {
+        name: "progressbar"
+        text: "Generating crash report: "
+    }
+
     @GUI::TabWidget {
         name: "tab_widget"
+        visible: false
     }
 
     @GUI::Widget {


### PR DESCRIPTION
Previously we would create a temporary progress window to show a progressbar while the coredump is processed. Since we're only waiting on backtraces and CPU register states, we can move the progressbar into the main window and show everything else immediately while the slow parts are generated in a BackgroundAction.

https://user-images.githubusercontent.com/14025038/147727628-e7d9b785-ad87-450a-9f1e-18fac70895ad.mp4

