### PR TITLE
Kernel+AK: Be more conservative about String allocations

### DIFF
--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -184,7 +184,7 @@ void StringBuilder::append_escaped_for_json(StringView string)
             break;
         default:
             if (ch >= 0 && ch <= 0x1f)
-                append(String::formatted("\\u{:04x}", ch));
+                appendff("\\u{:04x}", ch);
             else
                 append(ch);
         }

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -7,7 +7,7 @@
 #include <AK/BuiltinWrappers.h>
 #include <AK/Format.h>
 #include <AK/StdLibExtras.h>
-#include <AK/String.h>
+#include <AK/StringBuilder.h>
 #include <AK/Types.h>
 
 #include <Kernel/Interrupts/APIC.h>

--- a/Kernel/Bus/PCI/SysFSPCI.cpp
+++ b/Kernel/Bus/PCI/SysFSPCI.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/String.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/SysFSPCI.h>

--- a/Kernel/FileSystem/Inode.cpp
+++ b/Kernel/FileSystem/Inode.cpp
@@ -7,7 +7,6 @@
 
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/Singleton.h>
-#include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <Kernel/API/InodeWatcherEvent.h>
 #include <Kernel/FileSystem/Custody.h>

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -931,10 +931,10 @@ ErrorOr<NonnullRefPtr<Custody>> VirtualFileSystem::resolve_path_without_veil(Str
             // We prepend a "." to it to ensure that it's not empty and that
             // any initial slashes it might have get interpreted properly.
             StringBuilder remaining_path;
-            remaining_path.append('.');
-            remaining_path.append(path.substring_view_starting_after_substring(part));
+            TRY(remaining_path.try_append('.'));
+            TRY(remaining_path.try_append(path.substring_view_starting_after_substring(part)));
 
-            return resolve_path_without_veil(remaining_path.to_string(), symlink_target, out_parent, options, symlink_recursion_level + 1);
+            return resolve_path_without_veil(remaining_path.string_view(), symlink_target, out_parent, options, symlink_recursion_level + 1);
         }
     }
 

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -131,7 +131,7 @@ private:
         JsonArraySerializer array { builder };
         LocalSocket::for_each([&array](auto& socket) {
             auto obj = array.add_object();
-            obj.add("path", String(socket.socket_path()));
+            obj.add("path", socket.socket_path());
             obj.add("origin_pid", socket.origin_pid().value());
             obj.add("origin_uid", socket.origin_uid().value());
             obj.add("origin_gid", socket.origin_gid().value());
@@ -463,7 +463,7 @@ private:
                 ENUMERATE_PLEDGE_PROMISES
 #undef __ENUMERATE_PLEDGE_PROMISE
 
-                process_object.add("pledge", pledge_builder.to_string());
+                process_object.add("pledge", pledge_builder.string_view());
 
                 switch (process.veil_state()) {
                 case VeilState::None:
@@ -756,7 +756,7 @@ private:
     {
         if (!Process::current().is_superuser())
             return EPERM;
-        return builder.append(String::number(kernel_load_base));
+        return builder.appendff("{}", kernel_load_base);
     }
 };
 

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -372,7 +372,7 @@ private:
                     result = pseudo_path_or_error.release_error();
                     return IterationDecision::Break;
                 }
-                fs_object.add("source", pseudo_path_or_error.value()->characters());
+                fs_object.add("source", pseudo_path_or_error.value()->view());
             } else {
                 fs_object.add("source", "none");
             }

--- a/Kernel/KBufferBuilder.cpp
+++ b/Kernel/KBufferBuilder.cpp
@@ -121,7 +121,7 @@ ErrorOr<void> KBufferBuilder::append_escaped_for_json(StringView string)
             break;
         default:
             if (ch >= 0 && ch <= 0x1f)
-                TRY(append(String::formatted("\\u{:04x}", ch)));
+                TRY(appendff("\\u{:04x}", ch));
             else
                 TRY(append(ch));
         }

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -497,7 +497,7 @@ ErrorOr<NonnullOwnPtr<KString>> IPv4Socket::pseudo_path(const OpenFileDescriptio
         VERIFY_NOT_REACHED();
     }
 
-    return KString::try_create(builder.to_string());
+    return KString::try_create(builder.string_view());
 }
 
 ErrorOr<void> IPv4Socket::setsockopt(int level, int option, Userspace<const void*> user_value, socklen_t user_value_size)

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -378,7 +378,7 @@ ErrorOr<NonnullOwnPtr<KString>> LocalSocket::pseudo_path(const OpenFileDescripti
         break;
     }
 
-    return KString::try_create(builder.to_string());
+    return KString::try_create(builder.string_view());
 }
 
 ErrorOr<void> LocalSocket::getsockopt(OpenFileDescription& description, int level, int option, Userspace<void*> value, Userspace<socklen_t*> value_size)

--- a/Kernel/Net/NE2000/NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000/NetworkAdapter.cpp
@@ -181,7 +181,7 @@ UNMAP_AFTER_INIT NE2000NetworkAdapter::NE2000NetworkAdapter(PCI::Address address
 
     reset();
     set_mac_address(m_mac_address);
-    dmesgln("NE2000: MAC address: {}", m_mac_address.to_string().characters());
+    dmesgln("NE2000: MAC address: {}", m_mac_address.to_string());
     enable_irq();
 }
 

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/StringBuilder.h>
 #include <Kernel/Arch/x86/InterruptDisabler.h>
 #include <Kernel/Heap/kmalloc.h>
 #include <Kernel/Net/EtherType.h>

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Singleton.h>
 #include <AK/StdLibExtras.h>
-#include <AK/StringBuilder.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
 #include <Kernel/API/Syscall.h>

--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -286,7 +286,7 @@ ErrorOr<void> Process::procfs_get_tty_link(KBufferBuilder& builder) const
 {
     if (m_tty.is_null())
         return Error::from_errno(ENOENT);
-    return builder.append(m_tty->tty_name().characters());
+    return builder.append(m_tty->tty_name().view());
 }
 
 }

--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -159,7 +159,7 @@ ErrorOr<void> Process::procfs_get_unveil_stats(KBufferBuilder& builder) const
             permissions_builder.append('c');
         if (unveiled_path.permissions() & UnveilAccess::Browse)
             permissions_builder.append('b');
-        obj.add("permissions", permissions_builder.to_string());
+        obj.add("permissions", permissions_builder.string_view());
     }
     array.finish();
     return {};
@@ -255,7 +255,7 @@ ErrorOr<void> Process::procfs_get_virtual_memory_stats(KBufferBuilder& builder) 
                 else
                     pagemap_builder.append('P');
             }
-            region_object.add("pagemap", pagemap_builder.to_string());
+            region_object.add("pagemap", pagemap_builder.string_view());
         }
     }
     array.finish();

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -520,7 +520,7 @@ ErrorOr<FlatPtr> Process::sys$allocate_tls(Userspace<const char*> initial_data, 
         return EINVAL;
 
     auto range = TRY(address_space().try_allocate_range({}, size));
-    auto* region = TRY(address_space().allocate_region(range, String("Master TLS"), PROT_READ | PROT_WRITE));
+    auto* region = TRY(address_space().allocate_region(range, "Master TLS"sv, PROT_READ | PROT_WRITE));
 
     m_master_tls_region = region->make_weak_ptr();
     m_master_tls_size = size;

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <AK/StdLibExtras.h>
-#include <AK/String.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/HID/HIDManagement.h>


### PR DESCRIPTION
This PR eliminates some of the unnecessary `String` allocations present in kernel code, and all `K?String(View)?` -> `char const*` conversions. It's my small contribution towards #6369.

### Kernel: Propagate allocation failure in resolve_path_without_veil

### Kernel+AK: Eliminate a couple of temporary String allocations

### Kernel: Remove redundant (K)String::characters() calls
We already know their lengths, no need to make the formatting code call
strlen() on them again.

### Kernel: Tighten String-related includes

