### PR TITLE
LibGUI: Handle '#' comments in INILexer (and more INI syntax higlighting fixes)

### DIFF
--- a/Userland/Libraries/LibGUI/INILexer.cpp
+++ b/Userland/Libraries/LibGUI/INILexer.cpp
@@ -95,7 +95,7 @@ Vector<IniToken> IniLexer::lex()
             begin_token();
             while (peek() && !(peek() == ']' || peek() == '\n'))
                 consume();
-            commit_token(IniToken::Type::section);
+            commit_token(IniToken::Type::Section);
 
             // ] Token
             if (peek() && peek() == ']') {

--- a/Userland/Libraries/LibGUI/INILexer.cpp
+++ b/Userland/Libraries/LibGUI/INILexer.cpp
@@ -75,8 +75,8 @@ Vector<IniToken> IniLexer::lex()
             continue;
         }
 
-        // ;Comment
-        if (ch == ';') {
+        // ;Comment or #Comment
+        if (ch == ';' || ch == '#') {
             begin_token();
             while (peek() && peek() != '\n')
                 consume();

--- a/Userland/Libraries/LibGUI/INILexer.h
+++ b/Userland/Libraries/LibGUI/INILexer.h
@@ -14,7 +14,7 @@ namespace GUI {
     __TOKEN(Unknown)        \
     __TOKEN(Comment)        \
     __TOKEN(Whitespace)     \
-    __TOKEN(section)        \
+    __TOKEN(Section)        \
     __TOKEN(LeftBracket)    \
     __TOKEN(RightBracket)   \
     __TOKEN(Name)           \

--- a/Userland/Libraries/LibGUI/INISyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/INISyntaxHighlighter.cpp
@@ -15,7 +15,7 @@ static Syntax::TextStyle style_for_token_type(const Gfx::Palette& palette, IniTo
     switch (type) {
     case IniToken::Type::LeftBracket:
     case IniToken::Type::RightBracket:
-    case IniToken::Type::section:
+    case IniToken::Type::Section:
         return { palette.syntax_keyword(), true };
     case IniToken::Type::Name:
         return { palette.syntax_identifier() };

--- a/Userland/Libraries/LibGUI/INISyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/INISyntaxHighlighter.cpp
@@ -10,7 +10,7 @@
 
 namespace GUI {
 
-static Syntax::TextStyle style_for_token_type(const Gfx::Palette& palette, IniToken::Type type)
+static Syntax::TextStyle style_for_token_type(Gfx::Palette const& palette, IniToken::Type type)
 {
     switch (type) {
     case IniToken::Type::LeftBracket:
@@ -36,7 +36,7 @@ bool IniSyntaxHighlighter::is_identifier(u64 token) const
     return ini_token == GUI::IniToken::Type::Name;
 }
 
-void IniSyntaxHighlighter::rehighlight(const Palette& palette)
+void IniSyntaxHighlighter::rehighlight(Palette const& palette)
 {
     auto text = m_client->get_text();
     IniLexer lexer(text);

--- a/Userland/Libraries/LibGUI/INISyntaxHighlighter.h
+++ b/Userland/Libraries/LibGUI/INISyntaxHighlighter.h
@@ -18,7 +18,7 @@ public:
     virtual bool is_identifier(u64) const override;
 
     virtual Syntax::Language language() const override { return Syntax::Language::INI; }
-    virtual void rehighlight(const Palette&) override;
+    virtual void rehighlight(Palette const&) override;
 
 protected:
     virtual Vector<MatchingTokenPair> matching_token_pairs_impl() const override;


### PR DESCRIPTION
**LibGUI: Handle '#' comments in INILexer**

They are supported by LibCore's ConfigFile but were not higlighted.

**LibGUI: Use consistent naming scheme in INILexer**

**LibGUI: Convert INISyntaxHighlighter to east-const**