### PR TITLE
Documentation: Workaround for vscode clangd errors

### DIFF
--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -4,20 +4,57 @@ Visual Studio Code does not work optimally for Serenity development, and there's
 
 The WSL Remote extension allows you to use VSCode in Windows while using the normal WSL workflow. This works surprisingly well, but for code comprehension speed you should put the Serenity directory on your WSL root partition.
 
-## Code comprehension
+- [Visual Studio Code Project Configuration](#visual-studio-code-project-configuration)
+  - [Code comprehension](#code-comprehension)
+    - [clangd](#clangd)
+      - [GCC](#gcc)
+      - [Clang](#clang)
+    - [Microsoft C/C++ tools](#microsoft-cc-tools)
+  - [DSL syntax highlighting](#dsl-syntax-highlighting)
+  - [Formatting](#formatting)
+  - [Settings](#settings)
+  - [Customization](#customization)
+    - [Custom Tasks](#custom-tasks)
+    - [License snippet](#license-snippet)
 
-Both C++ comprehension tools listed below report fake errors.
+## Code comprehension
 
 ### clangd
 
-The official clangd extension can be used for C++ comprehension. You'll have to use the following .clangd:
+The clangd extension (`llvm-vs-code-extensions.vscode-clangd`) can be used for C++ comprehension.
+
+You'll have to use the following `.clangd` file for the toolchain you're using:
+
+#### GCC
 
 ```yaml
 CompileFlags:
-  CompilationDatabase: Build/i686
+   Add:
+      [
+         -D__serenity__,
+         -isystem../../Toolchain/Local/i686/i686-pc-serenity/include/c++/11.2.0,
+         -isystem../../Toolchain/Local/i686/i686-pc-serenity/include/c++/11.2.0/bits,
+         -isystem../../Toolchain/Local/i686/i686-pc-serenity/include/c++/11.2.0/i686-pc-serenity,
+      ]
+   CompilationDatabase: Build/i686
+
 ```
 
-Run cmake at least once for this to work. clangd has difficulty finding specific methods and types, especially with inheritance trees. Also, include errors are wrong in 90% of cases.
+#### Clang
+
+```yaml
+CompileFlags:
+   Add:
+      [
+         -D__serenity__,
+         -isystem../../Toolchain/Local/clang/include/c++/v1,
+         -isystem../../Toolchain/Local/clang/include/x86_64-pc-serenity/c++/v1,
+      ]
+   CompilationDatabase: Build/x86_64clang
+
+```
+
+Run cmake at least once for this to work.
 
 ### Microsoft C/C++ tools
 
@@ -90,7 +127,7 @@ These extensions can be used as-is, but you need to point them to the custom Ser
 
 Most nonsentical errors from the extension also involve not finding methods, types etc.
 
-### DSL syntax highlighting
+## DSL syntax highlighting
 
 There's a syntax highlighter extension for both IPC and GML called "SerenityOS DSL Syntax Highlight", available [here](https://marketplace.visualstudio.com/items?itemName=kleinesfilmroellchen.serenity-dsl-syntaxhighlight) or [here](https://open-vsx.org/extension/kleinesfilmroellchen/serenity-dsl-syntaxhighlight).
 


### PR DESCRIPTION
Added workaround for vscode clangd errors on
default (GCC) installations.

Also created a Table of Contents and rearranged
markdown headers.