### PR TITLE
ArgsParser+Utilities: Introduce TRY variants

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Sergey Bugaev <bugaevc@serenityos.org>
+ * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -333,10 +334,24 @@ void ArgsParser::print_version(FILE* file)
 
 void ArgsParser::add_option(Option&& option)
 {
-    m_options.append(move(option));
+    MUST(try_add_option(move(option)));
+}
+
+ErrorOr<void> ArgsParser::try_add_option(Option&& option)
+{
+    // NOTE: We grow the vector first, to get allocation failure handled immediately.
+    TRY(m_options.try_ensure_capacity(m_options.size() + 1));
+
+    m_options.unchecked_append(move(option));
+    return {};
 }
 
 void ArgsParser::add_ignored(const char* long_name, char short_name)
+{
+    MUST(try_add_ignored(long_name, short_name));
+}
+
+ErrorOr<void> ArgsParser::try_add_ignored(const char* long_name, char short_name)
 {
     Option option {
         false,
@@ -348,7 +363,9 @@ void ArgsParser::add_ignored(const char* long_name, char short_name)
             return true;
         }
     };
-    add_option(move(option));
+
+    TRY(try_add_option(move(option)));
+    return {};
 }
 
 void ArgsParser::add_option(bool& value, const char* help_string, const char* long_name, char short_name)
@@ -418,6 +435,11 @@ void ArgsParser::add_option(StringView& value, char const* help_string, char con
 
 void ArgsParser::add_option(int& value, const char* help_string, const char* long_name, char short_name, const char* value_name)
 {
+    MUST(try_add_option(value, help_string, long_name, short_name, value_name));
+}
+
+ErrorOr<void> ArgsParser::try_add_option(int& value, const char* help_string, const char* long_name, char short_name, const char* value_name)
+{
     Option option {
         true,
         help_string,
@@ -430,7 +452,9 @@ void ArgsParser::add_option(int& value, const char* help_string, const char* lon
             return opt.has_value();
         }
     };
-    add_option(move(option));
+
+    TRY(try_add_option(move(option)));
+    return {};
 }
 
 void ArgsParser::add_option(unsigned& value, const char* help_string, const char* long_name, char short_name, const char* value_name)
@@ -469,10 +493,24 @@ void ArgsParser::add_option(double& value, const char* help_string, const char* 
 
 void ArgsParser::add_positional_argument(Arg&& arg)
 {
-    m_positional_args.append(move(arg));
+    MUST(try_add_positional_argument(move(arg)));
+}
+
+ErrorOr<void> ArgsParser::try_add_positional_argument(Arg&& arg)
+{
+    // NOTE: We grow the vector first, to get allocation failure handled immediately.
+    TRY(m_positional_args.try_ensure_capacity(m_positional_args.size() + 1));
+
+    m_positional_args.unchecked_append(move(arg));
+    return {};
 }
 
 void ArgsParser::add_positional_argument(const char*& value, const char* help_string, const char* name, Required required)
+{
+    MUST(try_add_positional_argument(value, help_string, name, required));
+}
+
+ErrorOr<void> ArgsParser::try_add_positional_argument(const char*& value, const char* help_string, const char* name, Required required)
 {
     Arg arg {
         help_string,
@@ -484,7 +522,9 @@ void ArgsParser::add_positional_argument(const char*& value, const char* help_st
             return true;
         }
     };
-    add_positional_argument(move(arg));
+
+    TRY(try_add_positional_argument(move(arg)));
+    return {};
 }
 
 void ArgsParser::add_positional_argument(String& value, const char* help_string, const char* name, Required required)
@@ -567,6 +607,11 @@ void ArgsParser::add_positional_argument(double& value, const char* help_string,
 
 void ArgsParser::add_positional_argument(Vector<const char*>& values, const char* help_string, const char* name, Required required)
 {
+    MUST(try_add_positional_argument(values, help_string, name, required));
+}
+
+ErrorOr<void> ArgsParser::try_add_positional_argument(Vector<const char*>& values, const char* help_string, const char* name, Required required)
+{
     Arg arg {
         help_string,
         name,
@@ -577,10 +622,17 @@ void ArgsParser::add_positional_argument(Vector<const char*>& values, const char
             return true;
         }
     };
-    add_positional_argument(move(arg));
+
+    TRY(try_add_positional_argument(move(arg)));
+    return {};
 }
 
 void ArgsParser::add_positional_argument(Vector<StringView>& values, char const* help_string, char const* name, Required required)
+{
+    MUST(try_add_positional_argument(values, help_string, name, required));
+}
+
+ErrorOr<void> ArgsParser::try_add_positional_argument(Vector<StringView>& values, char const* help_string, char const* name, Required required)
 {
     Arg arg {
         help_string,
@@ -592,7 +644,9 @@ void ArgsParser::add_positional_argument(Vector<StringView>& values, char const*
             return true;
         }
     };
-    add_positional_argument(move(arg));
+
+    TRY(try_add_positional_argument(move(arg)));
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Sergey Bugaev <bugaevc@serenityos.org>
+ * Copyright (c) 2021, Julius Heijmen <julius.heijmen@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -78,6 +79,10 @@ public:
     void add_option(unsigned& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
     void add_option(double& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
 
+    ErrorOr<void> try_add_option(Option&&);
+    ErrorOr<void> try_add_ignored(const char* long_name, char short_name);
+    ErrorOr<void> try_add_option(int& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
+
     void add_positional_argument(Arg&&);
     void add_positional_argument(const char*& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(String& value, const char* help_string, const char* name, Required required = Required::Yes);
@@ -87,6 +92,11 @@ public:
     void add_positional_argument(double& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(Vector<const char*>& value, const char* help_string, const char* name, Required required = Required::Yes);
     void add_positional_argument(Vector<StringView>& value, char const* help_string, char const* name, Required required = Required::Yes);
+
+    ErrorOr<void> try_add_positional_argument(Arg&&);
+    ErrorOr<void> try_add_positional_argument(const char*& value, const char* help_string, const char* name, Required required = Required::Yes);
+    ErrorOr<void> try_add_positional_argument(Vector<const char*>& value, const char* help_string, const char* name, Required required = Required::Yes);
+    ErrorOr<void> try_add_positional_argument(Vector<StringView>& values, char const* help_string, char const* name, Required required = Required::Yes);
 
 private:
     Vector<Option> m_options;

--- a/Userland/Utilities/abench.cpp
+++ b/Userland/Utilities/abench.cpp
@@ -24,8 +24,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Benchmark audio loading");
-    args_parser.add_positional_argument(path, "Path to audio file", "path");
-    args_parser.add_option(sample_count, "How many samples to load at maximum", "sample-count", 's', "samples");
+    TRY(args_parser.try_add_positional_argument(path, "Path to audio file", "path"));
+    TRY(args_parser.try_add_option(sample_count, "How many samples to load at maximum", "sample-count", 's', "samples"));
     args_parser.parse(args);
 
     TRY(Core::System::unveil(Core::File::absolute_path(path), "r"));

--- a/Userland/Utilities/cat.cpp
+++ b/Userland/Utilities/cat.cpp
@@ -20,7 +20,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Concatenate files or pipes to stdout.");
-    args_parser.add_positional_argument(paths, "File path", "path", Core::ArgsParser::Required::No);
+    TRY(args_parser.try_add_positional_argument(paths, "File path", "path", Core::ArgsParser::Required::No));
     args_parser.parse(arguments);
 
     Vector<int> fds;

--- a/Userland/Utilities/touch.cpp
+++ b/Userland/Utilities/touch.cpp
@@ -38,8 +38,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Create a file, or update its mtime (time of last modification).");
-    args_parser.add_ignored(nullptr, 'f');
-    args_parser.add_positional_argument(paths, "Files to touch", "path", Core::ArgsParser::Required::Yes);
+    TRY(args_parser.try_add_ignored(nullptr, 'f'));
+    TRY(args_parser.try_add_positional_argument(paths, "Files to touch", "path", Core::ArgsParser::Required::Yes));
     args_parser.parse(arguments);
 
     for (auto path : paths) {


### PR DESCRIPTION
This is my attempt at introducing fallible variants for ArgsParser `add_option()`, and `add_positional_argument()`. I also implemented the new code in three existing utilities.

I'm specifically looking for feedback on two things:

- How to handle the original `add_ignored()`, since it only had a single usage in one of the utilities and is now dead code. Should I rename `try_add_ignored()` to it? (I believe awesomekling mentioned that this would be the end goal for these `try_()` methods.
- The creation of both the `Arg` and `Option` are not OOM safe, but I wasn't exactly sure how to tackle that, a suggestion for how to go about that would be appreciated.