### PR TITLE
Kernel: Use the toolchain's `nm` in mkmap.sh

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -517,7 +517,7 @@ endif()
 
 add_custom_command(
     TARGET Kernel POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E env CXXFILT=${SERENITY_CXXFILT} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
+    COMMAND ${CMAKE_COMMAND} -E env NM=${CMAKE_NM} sh ${CMAKE_CURRENT_SOURCE_DIR}/mkmap.sh
     COMMAND ${CMAKE_COMMAND} -E env OBJCOPY=${CMAKE_OBJCOPY} sh ${CMAKE_CURRENT_SOURCE_DIR}/embedmap.sh
     COMMAND ${CMAKE_OBJCOPY} --only-keep-debug Kernel Kernel.debug
     COMMAND ${CMAKE_OBJCOPY} --strip-debug Kernel

--- a/Kernel/mkmap.sh
+++ b/Kernel/mkmap.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 tmp=$(mktemp)
-nm -n Kernel | grep -vE \\.Lubsan_data | awk '{ if ($2 != "a") print; }' | uniq > "$tmp"
+NM="${NM:-nm}"
+"$NM" -C -n Kernel | grep -vE \\.Lubsan_data | awk '{ if ($2 != "a") print; }' | uniq > "$tmp"
 printf "%08x\n" "$(wc -l "$tmp" | awk '{print $1}')" > kernel.map
-CXXFILT="${CXXFILT:-c++filt}"
-"$CXXFILT" < "$tmp" >> kernel.map
+cat "$tmp" >> kernel.map
 rm -f "$tmp"


### PR DESCRIPTION
By using the binary from our build of binutils, we can be sure that `nm`
supports demangling symbols, so we can avoid spawning a separate
`c++filt` process.

---
This will be needed when we finally add support for `DT_RELR` relocations to the Clang toolchain, as the `nm` from GNU Binutils would print a warning about the unsupported relocation in the Kernel binary.