### PR TITLE
HackStudio+LibDiff: Fix some common crashes

### DIFF
--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -45,6 +45,9 @@ GitWidget::GitWidget(const LexicalPath& repo_root)
         Gfx::Bitmap::try_load_from_file("/res/icons/16x16/plus.png").release_value_but_fixme_should_propagate_errors());
     m_unstaged_files->on_selection_change = [this] {
         const auto& index = m_unstaged_files->selection().first();
+        if (!index.is_valid())
+            return;
+
         const auto& selected = index.data().as_string();
         show_diff(LexicalPath(selected));
     };

--- a/Userland/Libraries/LibDiff/Hunks.cpp
+++ b/Userland/Libraries/LibDiff/Hunks.cpp
@@ -83,10 +83,16 @@ HunkLocation parse_hunk_location(const String& location_line)
     };
     auto parse_start_and_length_pair = [](const String& raw) {
         auto index_of_separator = raw.find(',').value();
-        auto start = raw.substring(0, index_of_separator);
-        auto length = raw.substring(index_of_separator + 1, raw.length() - index_of_separator - 1);
-        auto res = StartAndLength { start.to_uint().value() - 1, length.to_uint().value() - 1 };
-        return res;
+        auto start = raw.substring(0, index_of_separator).to_uint().value();
+        auto length = raw.substring(index_of_separator + 1, raw.length() - index_of_separator - 1).to_uint().value();
+
+        if (start != 0)
+            start--;
+
+        if (length != 0)
+            length--;
+
+        return StartAndLength { start, length };
     };
     while (char_index < location_line.length() && location_line[char_index++] != '-') {
     }


### PR DESCRIPTION
With both of the following fixes combined, the git panel in HackStudio is a lot less crashy!
This pull request closes #8979 :tada:

### HackStudio: Fix crash when clicking unstaged files
In certain cases, an index might be invalid in the unstaged files view. (usually when clicking the "Stage File" button)
We must check if this index is valid before attempting to read the index's data.

### LibDiff: Fix error when parsing a 'new' hunk location
If the location started at 0, and / or the length was 0, it would originally turn out to be a location of ``{ -1, -1 }`` when LibDiff was finished parsing, which was incorrect.
To fix this, we only subtract 1 if `start` or `length` isn't 0.