### PR TITLE
LibWeb: Implement CanvasRenderingContext2D.measureText

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
@@ -937,6 +937,8 @@ static bool is_wrappable_type(IDL::Type const& type)
         return true;
     if (type.name == "NamedNodeMap")
         return true;
+    if (type.name == "TextMetrics")
+        return true;
     return false;
 }
 
@@ -1637,6 +1639,7 @@ void generate_implementation(IDL::Interface const& interface)
 #include <LibWeb/Bindings/MessagePortWrapper.h>
 #include <LibWeb/Bindings/NamedNodeMapWrapper.h>
 #include <LibWeb/Bindings/NodeWrapperFactory.h>
+#include <LibWeb/Bindings/TextMetricsWrapper.h>
 #include <LibWeb/Bindings/TextWrapper.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/DOM/Element.h>
@@ -2808,6 +2811,7 @@ void generate_prototype_implementation(IDL::Interface const& interface)
 #include <LibWeb/Bindings/RangeWrapper.h>
 #include <LibWeb/Bindings/StyleSheetListWrapper.h>
 #include <LibWeb/Bindings/SubtleCryptoWrapper.h>
+#include <LibWeb/Bindings/TextMetricsWrapper.h>
 #include <LibWeb/Bindings/TextWrapper.h>
 #include <LibWeb/Bindings/URLSearchParamsWrapper.h>
 #include <LibWeb/Bindings/WindowObject.h>

--- a/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
@@ -266,6 +266,8 @@
 #include <LibWeb/Bindings/TextConstructor.h>
 #include <LibWeb/Bindings/TextEncoderConstructor.h>
 #include <LibWeb/Bindings/TextEncoderPrototype.h>
+#include <LibWeb/Bindings/TextMetricsConstructor.h>
+#include <LibWeb/Bindings/TextMetricsPrototype.h>
 #include <LibWeb/Bindings/TextPrototype.h>
 #include <LibWeb/Bindings/UIEventConstructor.h>
 #include <LibWeb/Bindings/UIEventPrototype.h>
@@ -422,6 +424,7 @@
     ADD_WINDOW_OBJECT_INTERFACE(SVGSVGElement)             \
     ADD_WINDOW_OBJECT_INTERFACE(Text)                      \
     ADD_WINDOW_OBJECT_INTERFACE(TextEncoder)               \
+    ADD_WINDOW_OBJECT_INTERFACE(TextMetrics)               \
     ADD_WINDOW_OBJECT_INTERFACE(UIEvent)                   \
     ADD_WINDOW_OBJECT_INTERFACE(URLSearchParams)           \
     ADD_WINDOW_OBJECT_INTERFACE(URL)                       \

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -195,6 +195,7 @@ set(SOURCES
     HTML/Scripting/Script.cpp
     HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
     HTML/TagNames.cpp
+    HTML/TextMetrics.cpp
     HTML/WebSocket.cpp
     HighResolutionTime/Performance.cpp
     ImageDecoding.cpp
@@ -485,6 +486,7 @@ libweb_js_wrapper(HTML/MessagePort)
 libweb_js_wrapper(HTML/PageTransitionEvent)
 libweb_js_wrapper(HTML/PromiseRejectionEvent)
 libweb_js_wrapper(HTML/SubmitEvent)
+libweb_js_wrapper(HTML/TextMetrics)
 libweb_js_wrapper(HTML/WebSocket)
 libweb_js_wrapper(HighResolutionTime/Performance)
 libweb_js_wrapper(IntersectionObserver/IntersectionObserver)

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -208,6 +208,7 @@ class MessagePort;
 class PageTransitionEvent;
 class PromiseRejectionEvent;
 class SubmitEvent;
+class TextMetrics;
 class WebSocket;
 }
 
@@ -439,6 +440,7 @@ class SVGGraphicsElementWrapper;
 class SVGPathElementWrapper;
 class SVGSVGElementWrapper;
 class TextEncoderWrapper;
+class TextMetricsWrapper;
 class TextWrapper;
 class UIEventWrapper;
 class URLConstructor;

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.h
@@ -14,6 +14,8 @@
 #include <LibGfx/Path.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/ExceptionOr.h>
+#include <LibWeb/Layout/InlineNode.h>
+#include <LibWeb/Layout/LineBox.h>
 
 namespace Web::HTML {
 
@@ -78,10 +80,24 @@ public:
 
     HTMLCanvasElement* canvas() { return m_element; }
 
+    RefPtr<TextMetrics> measure_text(String const& text);
+
 private:
     explicit CanvasRenderingContext2D(HTMLCanvasElement&);
 
+    struct PreparedTextGlyph {
+        unsigned int c;
+        Gfx::IntPoint position;
+    };
+
+    struct PreparedText {
+        Vector<PreparedTextGlyph> glyphs;
+        Gfx::TextAlignment physical_alignment;
+        Gfx::IntRect bounding_box;
+    };
+
     void did_draw(const Gfx::FloatRect&);
+    PreparedText prepare_text(String const& text, float max_width = INFINITY);
 
     OwnPtr<Gfx::Painter> painter();
 

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.idl
@@ -38,4 +38,5 @@ interface CanvasRenderingContext2D {
 
     readonly attribute HTMLCanvasElement canvas;
 
+    TextMetrics measureText(DOMString text);
 };

--- a/Userland/Libraries/LibWeb/HTML/TextMetrics.cpp
+++ b/Userland/Libraries/LibWeb/HTML/TextMetrics.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "TextMetrics.h"
+
+namespace Web::HTML {
+
+RefPtr<TextMetrics> TextMetrics::create()
+{
+    return adopt_ref(*new TextMetrics());
+}
+
+}

--- a/Userland/Libraries/LibWeb/HTML/TextMetrics.h
+++ b/Userland/Libraries/LibWeb/HTML/TextMetrics.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Heap/Handle.h>
+#include <LibWeb/Bindings/Wrappable.h>
+
+namespace Web::HTML {
+
+class TextMetrics
+    : public RefCounted<TextMetrics>
+    , public Bindings::Wrappable {
+public:
+    using WrapperType = Bindings::TextMetricsWrapper;
+
+    static RefPtr<TextMetrics> create();
+
+    double width() const { return m_width; }
+    double actual_bounding_box_left() const { return m_actual_bounding_box_left; }
+    double actual_bounding_box_right() const { return m_actual_bounding_box_right; }
+    double font_bounding_box_ascent() const { return m_font_bounding_box_ascent; }
+    double font_bounding_box_descent() const { return m_font_bounding_box_descent; }
+    double actual_bounding_box_ascent() const { return m_actual_bounding_box_ascent; }
+    double actual_bounding_box_descent() const { return m_actual_bounding_box_descent; }
+    double em_height_ascent() const { return m_em_height_ascent; }
+    double em_height_descent() const { return m_em_height_descent; }
+    double hanging_baseline() const { return m_hanging_baseline; }
+    double alphabetic_baseline() const { return m_alphabetic_baseline; }
+    double ideographic_baseline() const { return m_ideographic_baseline; }
+
+    void set_width(double width) { m_width = width; }
+    void set_actual_bounding_box_left(double left) { m_actual_bounding_box_left = left; }
+    void set_actual_bounding_box_right(double right) { m_actual_bounding_box_right = right; }
+    void set_font_bounding_box_ascent(double ascent) { m_font_bounding_box_ascent = ascent; }
+    void set_font_bounding_box_descent(double descent) { m_font_bounding_box_descent = descent; }
+    void set_actual_bounding_box_ascent(double ascent) { m_actual_bounding_box_ascent = ascent; }
+    void set_actual_bounding_box_descent(double descent) { m_actual_bounding_box_descent = descent; }
+    void set_em_height_ascent(double ascent) { m_em_height_ascent = ascent; }
+    void set_em_height_descent(double descent) { m_em_height_descent = descent; }
+    void set_hanging_baseline(double baseline) { m_hanging_baseline = baseline; }
+    void set_alphabetic_baseline(double baseline) { m_alphabetic_baseline = baseline; }
+    void set_ideographic_baseline(double baseline) { m_ideographic_baseline = baseline; }
+
+private:
+    explicit TextMetrics() { }
+
+    double m_width { 0 };
+    double m_actual_bounding_box_left { 0 };
+    double m_actual_bounding_box_right { 0 };
+
+    double m_font_bounding_box_ascent { 0 };
+    double m_font_bounding_box_descent { 0 };
+    double m_actual_bounding_box_ascent { 0 };
+    double m_actual_bounding_box_descent { 0 };
+    double m_em_height_ascent { 0 };
+    double m_em_height_descent { 0 };
+    double m_hanging_baseline { 0 };
+    double m_alphabetic_baseline { 0 };
+    double m_ideographic_baseline { 0 };
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/TextMetrics.idl
+++ b/Userland/Libraries/LibWeb/HTML/TextMetrics.idl
@@ -1,0 +1,17 @@
+interface TextMetrics {
+  // x-direction
+  readonly attribute double width; // advance width
+  readonly attribute double actualBoundingBoxLeft;
+  readonly attribute double actualBoundingBoxRight;
+
+  // y-direction
+  readonly attribute double fontBoundingBoxAscent;
+  readonly attribute double fontBoundingBoxDescent;
+  readonly attribute double actualBoundingBoxAscent;
+  readonly attribute double actualBoundingBoxDescent;
+  readonly attribute double emHeightAscent;
+  readonly attribute double emHeightDescent;
+  readonly attribute double hangingBaseline;
+  readonly attribute double alphabeticBaseline;
+  readonly attribute double ideographicBaseline;
+};


### PR DESCRIPTION
This requires an implementation of the "text preparation algorithm" as
specified here:

html.spec.whatwg.org/multipage/canvas.html#text-preparation-algorithm

However, we're missing a lot of things such as the
CanvasTextDrawingStyles interface, so most of the algorithm was not
implemented. Additionally, we also are not able to use a LineBox like
the algorithm suggests, because our layouting infra is not up to the
task yet. The prepare_text function does nothing other than figuring out
the width of the given text and return glyphs with offsets at the
moment.