### PR TITLE
LibJS: Fix spec comment in Temporal::PlainDate::balance_iso_date()

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/PlainDate.cpp
@@ -440,8 +440,8 @@ ISODate balance_iso_date(double year_, double month_, double day)
 
     // 9. NOTE: To deal with numbers of days greater than the number of days in a year, the following section adds years and subtracts days until the number of days is less than 366 or 365.
 
-    // 10. Let testYear be testYear + 1.
-    test_year += 1;
+    // 10. Set testYear to testYear + 1.
+    test_year++;
 
     // 11. Repeat, while day > ! ISODaysInYear(testYear),
     while (day > iso_days_in_year(test_year)) {


### PR DESCRIPTION
This matches the text of the spec, and is more correct since the variable is being updated, not defined it.

See: https://github.com/tc39/proposal-temporal/commit/5ab1822

\-\-\-

I also changed `test_year += 1` to `test_year++` for consistency with step 11.c that has the same description.

---

I noticed this while watching @linusg's <a href="https://youtu.be/tazwznTJUq4?t=710" title="Awesome video by the way :^)">video</a>. :^)
