### PR TITLE
LibJS: Fix the Now.plainDateTime in case they go over a year boundary

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
@@ -10,7 +10,26 @@ describe("correct behavior", () => {
         expect(plainDateTime.calendar).toBe(calendar);
     });
 
-    test("custom time zone", () => {
+    const plainDateTimeToEpochSeconds = plainDateTime =>
+        (plainDateTime.year - 1970) * 31_556_952 +
+        plainDateTime.dayOfYear * 86_400 +
+        plainDateTime.hour * 3_600 +
+        plainDateTime.minute * 60 +
+        plainDateTime.second +
+        plainDateTime.millisecond / 1_000 +
+        plainDateTime.microsecond / 1_000_000 +
+        plainDateTime.nanosecond / 1_000_000_000;
+
+    let timeZoneTested = false;
+
+    // Note: We test both positive and negative timezones because one might cross a year boundary.
+    //       Since a year does not have a fixed amount of seconds because it can be a leap year,
+    //       we cannot have a correct constant for seconds per year which is always correct.
+    //       However, by assuming years are at least 2 days long we can simply try the positive
+    //       and negative timezones and skip one if we jump the year. To ensure at least one is
+    //       tested we have the timeZoneTested which is only set to true if one of the tests passed.
+
+    test("custom time zone positive", () => {
         const calendar = new Temporal.Calendar("iso8601");
         const timeZone = {
             getOffsetNanosecondsFor() {
@@ -18,24 +37,41 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTimeToEpochSeconds = plainDateTime =>
-            (plainDateTime.year - 1970) * 31_556_952 +
-            plainDateTime.dayOfYear * 86_400 +
-            plainDateTime.hour * 3_600 +
-            plainDateTime.minute * 60 +
-            plainDateTime.second +
-            plainDateTime.millisecond / 1_000 +
-            plainDateTime.microsecond / 1_000_000 +
-            plainDateTime.nanosecond / 1_000_000_000;
-
         const plainDateTime = Temporal.Now.plainDateTime(calendar);
         const plainDateTimeWithOffset = Temporal.Now.plainDateTime(calendar, timeZone);
+
+        if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
+
         // Let's hope the duration between the above two lines is less than a second :^)
         const differenceSeconds =
             plainDateTimeToEpochSeconds(plainDateTimeWithOffset) -
             plainDateTimeToEpochSeconds(plainDateTime);
         expect(Math.floor(differenceSeconds)).toBe(86400);
+        timeZoneTested = true;
     });
+
+    test("custom time zone negative", () => {
+        const calendar = new Temporal.Calendar("iso8601");
+        const timeZone = {
+            getOffsetNanosecondsFor() {
+                return -86400000000000;
+            },
+        };
+
+        const plainDateTime = Temporal.Now.plainDateTime(calendar);
+        const plainDateTimeWithOffset = Temporal.Now.plainDateTime(calendar, timeZone);
+
+        if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
+
+        // Let's hope the duration between the above two lines is less than a second :^)
+        const differenceSeconds =
+            plainDateTimeToEpochSeconds(plainDateTimeWithOffset) -
+            plainDateTimeToEpochSeconds(plainDateTime);
+        expect(Math.floor(differenceSeconds)).toBe(-86400);
+        timeZoneTested = true;
+    });
+
+    expect(timeZoneTested).toBeTrue();
 });
 
 describe("errors", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
@@ -9,31 +9,66 @@ describe("correct behavior", () => {
         expect(plainDateTime.calendar.id).toBe("iso8601");
     });
 
-    test("custom time zone", () => {
+    const plainDateTimeToEpochSeconds = plainDateTime =>
+        (plainDateTime.year - 1970) * 31_556_952 +
+        plainDateTime.dayOfYear * 86_400 +
+        plainDateTime.hour * 3_600 +
+        plainDateTime.minute * 60 +
+        plainDateTime.second +
+        plainDateTime.millisecond / 1_000 +
+        plainDateTime.microsecond / 1_000_000 +
+        plainDateTime.nanosecond / 1_000_000_000;
+
+    let timeZoneTested = false;
+
+    // Note: We test both positive and negative timezones because one might cross a year boundary.
+    //       Since a year does not have a fixed amount of seconds because it can be a leap year,
+    //       we cannot have a correct constant for seconds per year which is always correct.
+    //       However, by assuming years are at least 2 days long we can simply try the positive
+    //       and negative timezones and skip one if we jump the year. To ensure at least one is
+    //       tested we have the timeZoneTested which is only set to true if one of the tests passed.
+
+    test("custom time zone positive", () => {
         const timeZone = {
             getOffsetNanosecondsFor() {
                 return 86400000000000;
             },
         };
 
-        const plainDateTimeToEpochSeconds = plainDateTime =>
-            (plainDateTime.year - 1970) * 31_556_952 +
-            plainDateTime.dayOfYear * 86_400 +
-            plainDateTime.hour * 3_600 +
-            plainDateTime.minute * 60 +
-            plainDateTime.second +
-            plainDateTime.millisecond / 1_000 +
-            plainDateTime.microsecond / 1_000_000 +
-            plainDateTime.nanosecond / 1_000_000_000;
-
         const plainDateTime = Temporal.Now.plainDateTimeISO();
         const plainDateTimeWithOffset = Temporal.Now.plainDateTimeISO(timeZone);
+
+        if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
+
         // Let's hope the duration between the above two lines is less than a second :^)
         const differenceSeconds =
             plainDateTimeToEpochSeconds(plainDateTimeWithOffset) -
             plainDateTimeToEpochSeconds(plainDateTime);
         expect(Math.floor(differenceSeconds)).toBe(86400);
+        timeZoneTested = true;
     });
+
+    test("custom time zone negative", () => {
+        const timeZone = {
+            getOffsetNanosecondsFor() {
+                return -86400000000000;
+            },
+        };
+
+        const plainDateTime = Temporal.Now.plainDateTimeISO();
+        const plainDateTimeWithOffset = Temporal.Now.plainDateTimeISO(timeZone);
+
+        if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
+
+        // Let's hope the duration between the above two lines is less than a second :^)
+        const differenceSeconds =
+            plainDateTimeToEpochSeconds(plainDateTimeWithOffset) -
+            plainDateTimeToEpochSeconds(plainDateTime);
+        expect(Math.floor(differenceSeconds)).toBe(-86400);
+        timeZoneTested = true;
+    });
+
+    expect(timeZoneTested).toBeTrue();
 });
 
 describe("errors", () => {


### PR DESCRIPTION
Since years don't have a constant amount of seconds because they can be
leap years no constant will work in all cases. We now test a timezone in
both the positive and negative direction and check that at least one
worked. Assuming years are at least 2 days long this will always pass
at least one test.

I also added a big comment as to why and how we test it now