### PR TITLE
HackStudio: Add a new commit dialog and use String instead of LexicalPath

### DIFF
--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -9,6 +9,7 @@ add_subdirectory(LanguageServers)
 add_subdirectory(LanguageClients)
 
 compile_gml(Dialogs/NewProjectDialog.gml Dialogs/NewProjectDialogGML.h new_project_dialog_gml)
+compile_gml(Dialogs/Git/GitCommitDialog.gml Dialogs/Git/GitCommitDialogGML.h git_commit_dialog_gml)
 
 set(SOURCES
     CodeDocument.cpp
@@ -23,6 +24,8 @@ set(SOURCES
     Debugger/EvaluateExpressionDialog.cpp
     Debugger/RegistersModel.cpp
     Debugger/VariablesModel.cpp
+    Dialogs/Git/GitCommitDialog.cpp
+    Dialogs/Git/GitCommitDialogGML.h
     Dialogs/NewProjectDialog.cpp
     Dialogs/NewProjectDialogGML.h
     Dialogs/ProjectTemplatesModel.cpp

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, Conor Byrne <conor@cbyrne.dev>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GitCommitDialog.h"
+#include <DevTools/HackStudio/Dialogs/Git/GitCommitDialogGML.h>
+
+namespace HackStudio {
+
+GitCommitDialog::GitCommitDialog(GUI::Window* parent)
+    : Dialog(parent)
+{
+    resize(400, 260);
+    center_within(*parent);
+    set_modal(true);
+    set_title("Commit");
+    set_icon(parent->icon());
+
+    auto& widget = set_main_widget<GUI::Widget>();
+    widget.load_from_gml(git_commit_dialog_gml);
+
+    m_message_editor = widget.find_descendant_of_type_named<GUI::TextEditor>("message_editor");
+    m_cancel_button = widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_commit_button = widget.find_descendant_of_type_named<GUI::Button>("commit_button");
+    m_line_and_col_label = widget.find_descendant_of_type_named<GUI::Label>("line_and_col_label");
+
+    m_message_editor->on_change = [this]() {
+        m_commit_button->set_enabled(!m_message_editor->text().is_empty() && on_commit);
+    };
+    m_message_editor->on_cursor_change = [this]() {
+        auto line = m_message_editor->cursor().line() + 1;
+        auto col = m_message_editor->cursor().column();
+
+        m_line_and_col_label->set_text(String::formatted("Line: {}, Col: {}", line, col));
+    };
+
+    m_commit_button->set_enabled(!m_message_editor->text().is_empty() && on_commit);
+    m_commit_button->on_click = [this](auto) {
+        on_commit(m_message_editor->text());
+        done(ExecResult::ExecOK);
+    };
+
+    m_cancel_button->on_click = [this](auto) {
+        done(ExecResult::ExecCancel);
+    };
+}
+
+}

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.gml
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.gml
@@ -1,0 +1,42 @@
+@GUI::Frame {
+    fill_with_background_color: true
+
+    layout: @GUI::VerticalBoxLayout {
+        spacing: 4
+        margins: [4, 4, 4, 4]
+    }
+
+    @GUI::Label {
+        text: "Enter commit message:"
+        text_alignment: "CenterLeft"
+        fixed_height: 20
+    }
+
+    @GUI::TextEditor {
+        name: "message_editor"
+    }
+
+    @GUI::Widget {
+        layout: @GUI::HorizontalBoxLayout
+        shrink_to_fit: true
+
+        @GUI::Label {
+            name: "line_and_col_label"
+            text: "Line: 1, Col: 0"
+            text_alignment: "CenterLeft"
+            fixed_height: 20
+        }
+
+        @GUI::Button {
+            name: "commit_button"
+            text: "Commit"
+            fixed_width: 75
+        }
+
+        @GUI::Button {
+            name: "cancel_button"
+            text: "Cancel"
+            fixed_width: 75
+        }
+    }
+}

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.h
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021, Conor Byrne <conor@cbyrne.dev>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Dialog.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/TextEditor.h>
+#include <LibGUI/Window.h>
+
+namespace HackStudio {
+
+using OnCommitCallback = Function<void(String const& message)>;
+
+class GitCommitDialog final : public GUI::Dialog {
+    C_OBJECT(GitCommitDialog);
+
+public:
+    OnCommitCallback on_commit;
+
+private:
+    GitCommitDialog(GUI::Window* parent);
+
+    RefPtr<GUI::Button> m_commit_button;
+    RefPtr<GUI::Button> m_cancel_button;
+    RefPtr<GUI::TextEditor> m_message_editor;
+    RefPtr<GUI::Label> m_line_and_col_label;
+};
+
+}

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -38,7 +38,7 @@ EditorWrapper::EditorWrapper()
         set_current_editor_wrapper(this);
     };
 
-    m_editor->on_open = [](String path) {
+    m_editor->on_open = [](String const& path) {
         open_file(path);
     };
 
@@ -93,10 +93,10 @@ void EditorWrapper::save()
 void EditorWrapper::update_diff()
 {
     if (m_git_repo)
-        m_hunks = Diff::parse_hunks(m_git_repo->unstaged_diff(LexicalPath(filename())).value());
+        m_hunks = Diff::parse_hunks(m_git_repo->unstaged_diff(filename()).value());
 }
 
-void EditorWrapper::set_project_root(LexicalPath const& project_root)
+void EditorWrapper::set_project_root(String const& project_root)
 {
     m_project_root = project_root;
     auto result = GitRepo::try_to_create(*m_project_root);

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -43,8 +43,8 @@ public:
     void set_filename(const String&);
     const String& filename() const { return m_filename; }
 
-    Optional<LexicalPath> const& project_root() const { return m_project_root; }
-    void set_project_root(LexicalPath const& project_root);
+    Optional<String> const& project_root() const { return m_project_root; }
+    void set_project_root(String const& project_root);
 
     GitRepo const* git_repo() const { return m_git_repo; }
 
@@ -64,7 +64,7 @@ private:
     RefPtr<GUI::Label> m_filename_label;
     RefPtr<Editor> m_editor;
 
-    Optional<LexicalPath> m_project_root;
+    Optional<String> m_project_root;
     RefPtr<GitRepo> m_git_repo;
     Vector<Diff::Hunk> m_hunks;
 };

--- a/Userland/DevTools/HackStudio/Git/GitFilesModel.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitFilesModel.cpp
@@ -8,12 +8,12 @@
 
 namespace HackStudio {
 
-NonnullRefPtr<GitFilesModel> GitFilesModel::create(Vector<LexicalPath>&& files)
+NonnullRefPtr<GitFilesModel> GitFilesModel::create(Vector<String>&& files)
 {
     return adopt_ref(*new GitFilesModel(move(files)));
 }
 
-GitFilesModel::GitFilesModel(Vector<LexicalPath>&& files)
+GitFilesModel::GitFilesModel(Vector<String>&& files)
     : m_files(move(files))
 {
 }
@@ -21,7 +21,7 @@ GitFilesModel::GitFilesModel(Vector<LexicalPath>&& files)
 GUI::Variant GitFilesModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
 {
     if (role == GUI::ModelRole::Display) {
-        return m_files.at(index.row()).string();
+        return m_files.at(index.row());
     }
     return {};
 }

--- a/Userland/DevTools/HackStudio/Git/GitFilesModel.h
+++ b/Userland/DevTools/HackStudio/Git/GitFilesModel.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "GitRepo.h"
-#include <AK/LexicalPath.h>
 #include <AK/NonnullRefPtr.h>
 #include <LibGUI/Model.h>
 
@@ -15,7 +14,7 @@ namespace HackStudio {
 
 class GitFilesModel final : public GUI::Model {
 public:
-    static NonnullRefPtr<GitFilesModel> create(Vector<LexicalPath>&& files);
+    static NonnullRefPtr<GitFilesModel> create(Vector<String>&& files);
 
     virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return m_files.size(); }
     virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
@@ -30,7 +29,7 @@ public:
     virtual GUI::ModelIndex index(int row, int column, const GUI::ModelIndex&) const override;
 
 private:
-    explicit GitFilesModel(Vector<LexicalPath>&& files);
-    Vector<LexicalPath> m_files;
+    explicit GitFilesModel(Vector<String>&& files);
+    Vector<String> m_files;
 };
 }

--- a/Userland/DevTools/HackStudio/Git/GitFilesView.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitFilesView.cpp
@@ -56,7 +56,7 @@ void GitFilesView::mousedown_event(GUI::MouseEvent& event)
     auto data = model()->index(item_index, model_column()).data();
 
     VERIFY(data.is_string());
-    m_action_callback(LexicalPath(data.to_string()));
+    m_action_callback(data.to_string());
 }
 
 };

--- a/Userland/DevTools/HackStudio/Git/GitFilesView.h
+++ b/Userland/DevTools/HackStudio/Git/GitFilesView.h
@@ -6,14 +6,13 @@
 
 #pragma once
 
-#include <AK/LexicalPath.h>
 #include <LibGUI/ListView.h>
 #include <LibGfx/Bitmap.h>
 
 namespace HackStudio {
 
 // A "GitFileAction" is either the staging or the unstaging of a file.
-using GitFileActionCallback = Function<void(const LexicalPath& file)>;
+using GitFileActionCallback = Function<void(String const& file)>;
 
 class GitFilesView : public GUI::ListView {
     C_OBJECT(GitFilesView)

--- a/Userland/DevTools/HackStudio/Git/GitRepo.h
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2021, Conor Byrne <conor@cbyrne.dev>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -27,35 +28,37 @@ public:
         RefPtr<GitRepo> repo;
     };
 
-    static CreateResult try_to_create(const LexicalPath& repository_root);
-    static RefPtr<GitRepo> initialize_repository(const LexicalPath& repository_root);
+    static CreateResult try_to_create(String const& repository_root);
+    static RefPtr<GitRepo> initialize_repository(String const& repository_root);
 
-    Vector<LexicalPath> unstaged_files() const;
-    Vector<LexicalPath> staged_files() const;
-    bool stage(const LexicalPath& file);
-    bool unstage(const LexicalPath& file);
-    bool commit(const String& message);
-    Optional<String> original_file_content(const LexicalPath& file) const;
-    Optional<String> unstaged_diff(const LexicalPath& file) const;
-    bool is_tracked(const LexicalPath& file) const;
+    bool stage(String const& file);
+    bool unstage(String const& file);
+    bool commit(String const& message);
+    bool is_tracked(String const& file) const;
+
+    Vector<String> unstaged_files() const;
+    Vector<String> staged_files() const;
+    Optional<String> original_file_content(String const& file) const;
+    Optional<String> unstaged_diff(String const& file) const;
 
 private:
-    static String command_wrapper(const Vector<String>& command_parts, const LexicalPath& chdir);
     static bool git_is_installed();
-    static bool git_repo_exists(const LexicalPath& repo_root);
-    static Vector<LexicalPath> parse_files_list(const String&);
+    static bool git_repo_exists(String const& repo_root);
 
-    explicit GitRepo(const LexicalPath& repository_root)
+    static String command_wrapper(Vector<String> const& command_parts, String const& chdir);
+    static Vector<String> parse_files_list(String const&);
+
+    explicit GitRepo(String const& repository_root)
         : m_repository_root(repository_root)
     {
     }
 
-    Vector<LexicalPath> modified_files() const;
-    Vector<LexicalPath> untracked_files() const;
+    Vector<String> modified_files() const;
+    Vector<String> untracked_files() const;
 
-    String command(const Vector<String>& command_parts) const;
+    String command(Vector<String> const& command_parts) const;
 
-    LexicalPath m_repository_root;
+    String m_repository_root;
 };
 
 }

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "GitWidget.h"
+#include "../Dialogs/Git/GitCommitDialog.h"
 #include "GitFilesModel.h"
 #include <LibCore/File.h>
 #include <LibDiff/Format.h>
@@ -134,13 +135,17 @@ void GitWidget::unstage_file(const LexicalPath& file)
 
 void GitWidget::commit()
 {
-    String message;
-    auto res = GUI::InputBox::show(window(), message, "Commit message:", "Commit");
-    if (res != GUI::InputBox::ExecOK || message.is_empty())
+    if (m_git_repo.is_null()) {
+        GUI::MessageBox::show(window(), "There is no git repository to commit to!", "Error", GUI::MessageBox::Type::Error);
         return;
-    dbgln("commit message: {}", message);
-    m_git_repo->commit(message);
-    refresh();
+    }
+
+    auto dialog = GitCommitDialog::construct(window());
+    dialog->on_commit = [this](auto& message) {
+        m_git_repo->commit(message);
+        refresh();
+    };
+    dialog->exec();
 }
 
 void GitWidget::set_view_diff_callback(ViewDiffCallback callback)

--- a/Userland/DevTools/HackStudio/Git/GitWidget.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.cpp
@@ -21,7 +21,7 @@
 
 namespace HackStudio {
 
-GitWidget::GitWidget(const LexicalPath& repo_root)
+GitWidget::GitWidget(String const& repo_root)
     : m_repo_root(repo_root)
 {
     set_layout<GUI::HorizontalBoxLayout>();
@@ -42,7 +42,7 @@ GitWidget::GitWidget(const LexicalPath& repo_root)
 
     unstaged_header.set_fixed_height(20);
     m_unstaged_files = unstaged.add<GitFilesView>(
-        [this](const auto& file) { stage_file(file); },
+        [this](auto const& file) { stage_file(file); },
         Gfx::Bitmap::try_load_from_file("/res/icons/16x16/plus.png").release_value_but_fixme_should_propagate_errors());
     m_unstaged_files->on_selection_change = [this] {
         const auto& index = m_unstaged_files->selection().first();
@@ -50,7 +50,7 @@ GitWidget::GitWidget(const LexicalPath& repo_root)
             return;
 
         const auto& selected = index.data().as_string();
-        show_diff(LexicalPath(selected));
+        show_diff(selected);
     };
 
     auto& staged = add<GUI::Widget>();
@@ -70,7 +70,7 @@ GitWidget::GitWidget(const LexicalPath& repo_root)
 
     staged_header.set_fixed_height(20);
     m_staged_files = staged.add<GitFilesView>(
-        [this](const auto& file) { unstage_file(file); },
+        [this](auto const& file) { unstage_file(file); },
         Gfx::Bitmap::try_load_from_file("/res/icons/16x16/minus.png").release_value_but_fixme_should_propagate_errors());
 }
 
@@ -117,7 +117,7 @@ void GitWidget::refresh()
     m_staged_files->set_model(GitFilesModel::create(m_git_repo->staged_files()));
 }
 
-void GitWidget::stage_file(const LexicalPath& file)
+void GitWidget::stage_file(String const& file)
 {
     dbgln("staging: {}", file);
     bool rc = m_git_repo->stage(file);
@@ -125,7 +125,7 @@ void GitWidget::stage_file(const LexicalPath& file)
     refresh();
 }
 
-void GitWidget::unstage_file(const LexicalPath& file)
+void GitWidget::unstage_file(String const& file)
 {
     dbgln("unstaging: {}", file);
     bool rc = m_git_repo->unstage(file);
@@ -153,10 +153,10 @@ void GitWidget::set_view_diff_callback(ViewDiffCallback callback)
     m_view_diff_callback = move(callback);
 }
 
-void GitWidget::show_diff(const LexicalPath& file_path)
+void GitWidget::show_diff(String const& file_path)
 {
     if (!m_git_repo->is_tracked(file_path)) {
-        auto file = Core::File::construct(file_path.string());
+        auto file = Core::File::construct(file_path);
         if (!file->open(Core::OpenMode::ReadOnly)) {
             perror("open");
             VERIFY_NOT_REACHED();
@@ -173,7 +173,7 @@ void GitWidget::show_diff(const LexicalPath& file_path)
     m_view_diff_callback(original_content.value(), diff.value());
 }
 
-void GitWidget::change_repo(LexicalPath const& repo_root)
+void GitWidget::change_repo(String const& repo_root)
 {
     m_repo_root = repo_root;
     m_git_repo = nullptr;

--- a/Userland/DevTools/HackStudio/Git/GitWidget.h
+++ b/Userland/DevTools/HackStudio/Git/GitWidget.h
@@ -24,19 +24,19 @@ public:
     void refresh();
     void set_view_diff_callback(ViewDiffCallback callback);
     bool initialized() const { return !m_git_repo.is_null(); };
-    void change_repo(LexicalPath const& repo_root);
+    void change_repo(String const& repo_root);
 
 private:
-    explicit GitWidget(const LexicalPath& repo_root);
+    explicit GitWidget(String const& repo_root);
 
     bool initialize();
     bool initialize_if_needed();
-    void stage_file(const LexicalPath&);
-    void unstage_file(const LexicalPath&);
+    void stage_file(String const&);
+    void unstage_file(String const&);
     void commit();
-    void show_diff(const LexicalPath&);
+    void show_diff(String const&);
 
-    LexicalPath m_repo_root;
+    String m_repo_root;
     RefPtr<GitFilesView> m_unstaged_files;
     RefPtr<GitFilesView> m_staged_files;
     RefPtr<GitRepo> m_git_repo;

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -208,7 +208,7 @@ void HackStudioWidget::open_project(const String& root_path)
         m_project_tree_view->update();
     }
     if (m_git_widget && m_git_widget->initialized()) {
-        m_git_widget->change_repo(LexicalPath(root_path));
+        m_git_widget->change_repo(root_path);
         m_git_widget->refresh();
     }
     if (Debugger::is_initialized()) {
@@ -217,7 +217,7 @@ void HackStudioWidget::open_project(const String& root_path)
         debugger.set_source_root(m_project->root_path());
     }
     for (auto& editor_wrapper : m_all_editor_wrappers)
-        editor_wrapper.set_project_root(LexicalPath(m_project->root_path()));
+        editor_wrapper.set_project_root(m_project->root_path());
 
     m_locations_history.clear();
     m_locations_history_end_index = 0;
@@ -597,7 +597,7 @@ void HackStudioWidget::add_new_editor(GUI::Widget& parent)
     m_all_editor_wrappers.append(wrapper);
     wrapper->editor().set_focus(true);
     wrapper->editor().set_font(*m_editor_font);
-    wrapper->set_project_root(LexicalPath(m_project->root_path()));
+    wrapper->set_project_root(m_project->root_path());
     wrapper->editor().on_cursor_change = [this] { on_cursor_change(); };
     wrapper->on_change = [this] { update_gml_preview(); };
     set_edit_mode(EditMode::Text);
@@ -1103,7 +1103,7 @@ void HackStudioWidget::create_action_tab(GUI::Widget& parent)
     };
 
     m_disassembly_widget = m_action_tab_widget->add_tab<DisassemblyWidget>("Disassembly");
-    m_git_widget = m_action_tab_widget->add_tab<GitWidget>("Git", LexicalPath(m_project->root_path()));
+    m_git_widget = m_action_tab_widget->add_tab<GitWidget>("Git", m_project->root_path());
     m_git_widget->set_view_diff_callback([this](const auto& original_content, const auto& diff) {
         m_diff_viewer->set_content(original_content, diff);
         set_edit_mode(EditMode::Diff);


### PR DESCRIPTION
### HackStudio: Add new multiline commit dialog
The previous commit dialog was quite lacking in terms of input, with a single input box without multiline editing support. This commit improves the dialog by adding a multiline text editor and a line and column counter.

*This commit dialog is mostly the same as the one which was featured in one of my previous PRs a few months ago!*

<img src="https://user-images.githubusercontent.com/71222289/147835378-a80f8252-33db-4c84-afd0-ee91200bc281.png" width="500px" />

### HackStudio: Use ``String`` instead of ``LexicalPath``
``LexicalPath`` is a 'heavier' object than a ``String`` that is mainly used for  path parsing and validation, we don't actually need any of that in ``GitRepo`` and its related files, so let's move to ``String``.