### PR TITLE
WindowServer+LibGUI+DisplaySettings+pape: Improve wallpapers

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -140,9 +140,7 @@ void BackgroundSettingsWidget::load_current_settings()
 
 void BackgroundSettingsWidget::apply_settings()
 {
-    if (GUI::Desktop::the().set_wallpaper(m_monitor_widget->wallpaper()))
-        Config::write_string("WindowManager", "Background", "Wallpaper", m_monitor_widget->wallpaper());
-    else
+    if (!GUI::Desktop::the().set_wallpaper(m_monitor_widget->wallpaper_bitmap(), m_monitor_widget->wallpaper()))
         GUI::MessageBox::show_error(window(), String::formatted("Unable to load file {} as wallpaper", m_monitor_widget->wallpaper()));
 
     GUI::Desktop::the().set_background_color(m_color_input->text());

--- a/Userland/Applications/DisplaySettings/MonitorWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.cpp
@@ -58,7 +58,7 @@ bool MonitorWidget::set_wallpaper(String path)
     return true;
 }
 
-String MonitorWidget::wallpaper()
+StringView MonitorWidget::wallpaper() const
 {
     return m_desktop_wallpaper_path;
 }
@@ -72,7 +72,7 @@ void MonitorWidget::set_wallpaper_mode(String mode)
     update();
 }
 
-String MonitorWidget::wallpaper_mode()
+StringView MonitorWidget::wallpaper_mode() const
 {
     return m_desktop_wallpaper_mode;
 }

--- a/Userland/Applications/DisplaySettings/MonitorWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.h
@@ -15,10 +15,12 @@ class MonitorWidget final : public GUI::Widget {
 
 public:
     bool set_wallpaper(String path);
-    String wallpaper();
+    StringView wallpaper() const;
 
     void set_wallpaper_mode(String mode);
-    String wallpaper_mode();
+    StringView wallpaper_mode() const;
+
+    RefPtr<Gfx::Bitmap> wallpaper_bitmap() const { return m_wallpaper_bitmap; }
 
     void set_desktop_resolution(Gfx::IntSize resolution);
     Gfx::IntSize desktop_resolution();

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -169,8 +169,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto desktop_wallpaper_action = GUI::Action::create("Set as Desktop &Wallpaper", TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-display-settings.png")),
         [&](auto&) {
-            auto could_set_wallpaper = GUI::Desktop::the().set_wallpaper(widget->path());
-            if (!could_set_wallpaper) {
+            if (!GUI::Desktop::the().set_wallpaper(widget->bitmap(), widget->path())) {
                 GUI::MessageBox::show(window,
                     String::formatted("set_wallpaper({}) failed", widget->path()),
                     "Could not set wallpaper",

--- a/Userland/Libraries/LibGUI/Desktop.h
+++ b/Userland/Libraries/LibGUI/Desktop.h
@@ -29,8 +29,9 @@ public:
 
     void set_wallpaper_mode(StringView mode);
 
-    String wallpaper() const;
-    bool set_wallpaper(StringView path, bool save_config = true);
+    String wallpaper_path() const;
+    RefPtr<Gfx::Bitmap> wallpaper_bitmap() const;
+    bool set_wallpaper(RefPtr<Gfx::Bitmap> wallpaper_bitmap, Optional<String> path);
 
     Gfx::IntRect rect() const { return m_bounding_rect; }
     const Vector<Gfx::IntRect, 4>& rects() const { return m_rects; }
@@ -56,6 +57,7 @@ private:
     unsigned m_workspace_rows { 1 };
     unsigned m_workspace_columns { 1 };
     Vector<Function<void(Desktop&)>> m_receive_rects_callbacks;
+    bool m_is_setting_desktop_wallpaper { false };
 };
 
 }

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -292,11 +292,10 @@ void ClientConnection::set_window_opacity(i32 window_id, float opacity)
     it->value->set_opacity(opacity);
 }
 
-void ClientConnection::set_wallpaper(String const& path)
+void ClientConnection::set_wallpaper(Gfx::ShareableBitmap const& bitmap)
 {
-    Compositor::the().set_wallpaper(path, [&](bool success) {
-        async_set_wallpaper_finished(success);
-    });
+    Compositor::the().set_wallpaper(bitmap.bitmap());
+    async_set_wallpaper_finished(true);
 }
 
 void ClientConnection::set_background_color(String const& background_color)
@@ -311,7 +310,7 @@ void ClientConnection::set_wallpaper_mode(String const& mode)
 
 Messages::WindowServer::GetWallpaperResponse ClientConnection::get_wallpaper()
 {
-    return Compositor::the().wallpaper_path();
+    return Compositor::the().wallpaper_bitmap()->to_shareable_bitmap();
 }
 
 Messages::WindowServer::SetScreenLayoutResponse ClientConnection::set_screen_layout(ScreenLayout const& screen_layout, bool save)

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -123,7 +123,7 @@ private:
     virtual void set_fullscreen(i32, bool) override;
     virtual void set_frameless(i32, bool) override;
     virtual void set_forced_shadow(i32, bool) override;
-    virtual void set_wallpaper(String const&) override;
+    virtual void set_wallpaper(Gfx::ShareableBitmap const&) override;
     virtual void set_background_color(String const&) override;
     virtual void set_wallpaper_mode(String const&) override;
     virtual Messages::WindowServer::GetWallpaperResponse get_wallpaper() override;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -805,26 +805,14 @@ bool Compositor::set_wallpaper_mode(const String& mode)
     return ret_val;
 }
 
-bool Compositor::set_wallpaper(const String& path, Function<void(bool)>&& callback)
+bool Compositor::set_wallpaper(RefPtr<Gfx::Bitmap> bitmap)
 {
-    (void)Threading::BackgroundAction<ErrorOr<NonnullRefPtr<Gfx::Bitmap>>>::construct(
-        [path](auto&) {
-            return Gfx::Bitmap::try_load_from_file(path);
-        },
+    if (!bitmap)
+        m_wallpaper = nullptr;
+    else
+        m_wallpaper = bitmap;
+    invalidate_screen();
 
-        [this, path, callback = move(callback)](ErrorOr<NonnullRefPtr<Gfx::Bitmap>> bitmap) {
-            if (bitmap.is_error() && !path.is_empty()) {
-                callback(false);
-                return;
-            }
-            m_wallpaper_path = path;
-            if (bitmap.is_error())
-                m_wallpaper = nullptr;
-            else
-                m_wallpaper = bitmap.release_value();
-            invalidate_screen();
-            callback(true);
-        });
     return true;
 }
 

--- a/Userland/Services/WindowServer/Compositor.h
+++ b/Userland/Services/WindowServer/Compositor.h
@@ -105,8 +105,8 @@ public:
 
     bool set_wallpaper_mode(const String& mode);
 
-    bool set_wallpaper(const String& path, Function<void(bool)>&& callback);
-    String wallpaper_path() const { return m_wallpaper_path; }
+    bool set_wallpaper(RefPtr<Gfx::Bitmap>);
+    RefPtr<Gfx::Bitmap> wallpaper_bitmap() const { return m_wallpaper; }
 
     void invalidate_cursor(bool = false);
     Gfx::IntRect current_cursor_rect() const;
@@ -227,7 +227,6 @@ private:
     Gfx::DisjointRectSet m_opaque_wallpaper_rects;
     Gfx::DisjointRectSet m_transparent_wallpaper_rects;
 
-    String m_wallpaper_path { "" };
     WallpaperMode m_wallpaper_mode { WallpaperMode::Unchecked };
     RefPtr<Gfx::Bitmap> m_wallpaper;
 

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -91,7 +91,7 @@ endpoint WindowServer
     popup_menu(i32 menu_id, Gfx::IntPoint screen_position) =|
     dismiss_menu(i32 menu_id) =|
 
-    set_wallpaper(String path) =|
+    set_wallpaper(Gfx::ShareableBitmap wallpaper_bitmap) =|
 
     set_background_color(String background_color) =|
     set_wallpaper_mode(String mode) =|
@@ -106,7 +106,7 @@ endpoint WindowServer
 
     set_window_icon_bitmap(i32 window_id, Gfx::ShareableBitmap icon) =|
 
-    get_wallpaper() => (String path)
+    get_wallpaper() => (Gfx::ShareableBitmap wallpaper_bitmap)
     set_window_cursor(i32 window_id, i32 cursor_type) =|
     set_window_custom_cursor(i32 window_id, Gfx::ShareableBitmap cursor) =|
 

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -146,7 +146,7 @@ endpoint WindowServer
     get_double_click_speed() => (int speed)
 
     set_buttons_switched(bool switched) =|
-    get_buttons_switched() => (bool switched) 
+    get_buttons_switched() => (bool switched)
 
     get_desktop_display_scale(u32 screen_index) => (int desktop_display_scale)
 

--- a/Userland/Utilities/pape.cpp
+++ b/Userland/Utilities/pape.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, James Puleo <james@jame.xyz>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,7 +31,7 @@ static int handle_show_all()
 
 static int handle_show_current()
 {
-    outln("{}", GUI::Desktop::the().wallpaper());
+    outln("{}", GUI::Desktop::the().wallpaper_path());
     return 0;
 }
 
@@ -40,7 +41,7 @@ static int handle_set_pape(const String& name)
     builder.append("/res/wallpapers/");
     builder.append(name);
     String path = builder.to_string();
-    if (!GUI::Desktop::the().set_wallpaper(path)) {
+    if (!GUI::Desktop::the().set_wallpaper(MUST(Gfx::Bitmap::try_load_from_file(path)), path)) {
         warnln("pape: Failed to set wallpaper {}", path);
         return 1;
     }
@@ -58,13 +59,13 @@ static int handle_set_random()
     while (di.has_next()) {
         wallpapers.append(di.next_full_path());
     }
-    wallpapers.remove_all_matching([](const String& wallpaper) { return wallpaper == GUI::Desktop::the().wallpaper(); });
+    wallpapers.remove_all_matching([](const String& wallpaper) { return wallpaper == GUI::Desktop::the().wallpaper_path(); });
     if (wallpapers.is_empty()) {
         warnln("pape: No wallpapers found");
         return 1;
     }
     auto& wallpaper = wallpapers.at(get_random_uniform(wallpapers.size()));
-    if (!GUI::Desktop::the().set_wallpaper(wallpaper)) {
+    if (!GUI::Desktop::the().set_wallpaper(MUST(Gfx::Bitmap::try_load_from_file(wallpaper)), wallpaper)) {
         warnln("pape: Failed to set wallpaper {}", wallpaper);
         return 1;
     }

--- a/Userland/Utilities/pape.cpp
+++ b/Userland/Utilities/pape.cpp
@@ -14,86 +14,64 @@
 #include <LibGUI/Desktop.h>
 #include <LibMain/Main.h>
 
-static int handle_show_all()
-{
-    Core::DirIterator di("/res/wallpapers", Core::DirIterator::SkipDots);
-    if (di.has_error()) {
-        warnln("DirIterator: {}", di.error_string());
-        return 1;
-    }
-
-    while (di.has_next()) {
-        String name = di.next_path();
-        outln("{}", name);
-    }
-    return 0;
-}
-
-static int handle_show_current()
-{
-    outln("{}", GUI::Desktop::the().wallpaper_path());
-    return 0;
-}
-
-static int handle_set_pape(const String& name)
-{
-    StringBuilder builder;
-    builder.append("/res/wallpapers/");
-    builder.append(name);
-    String path = builder.to_string();
-    if (!GUI::Desktop::the().set_wallpaper(MUST(Gfx::Bitmap::try_load_from_file(path)), path)) {
-        warnln("pape: Failed to set wallpaper {}", path);
-        return 1;
-    }
-    return 0;
-};
-
-static int handle_set_random()
-{
-    Vector<String> wallpapers;
-    Core::DirIterator di("/res/wallpapers", Core::DirIterator::SkipDots);
-    if (di.has_error()) {
-        warnln("DirIterator: {}", di.error_string());
-        return 1;
-    }
-    while (di.has_next()) {
-        wallpapers.append(di.next_full_path());
-    }
-    wallpapers.remove_all_matching([](const String& wallpaper) { return wallpaper == GUI::Desktop::the().wallpaper_path(); });
-    if (wallpapers.is_empty()) {
-        warnln("pape: No wallpapers found");
-        return 1;
-    }
-    auto& wallpaper = wallpapers.at(get_random_uniform(wallpapers.size()));
-    if (!GUI::Desktop::the().set_wallpaper(MUST(Gfx::Bitmap::try_load_from_file(wallpaper)), wallpaper)) {
-        warnln("pape: Failed to set wallpaper {}", wallpaper);
-        return 1;
-    }
-    return 0;
-}
-
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     bool show_all = false;
     bool show_current = false;
     bool set_random = false;
-    const char* name = nullptr;
+    String path;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(show_all, "Show all wallpapers", "show-all", 'a');
     args_parser.add_option(show_current, "Show current wallpaper", "show-current", 'c');
     args_parser.add_option(set_random, "Set random wallpaper", "set-random", 'r');
-    args_parser.add_positional_argument(name, "Wallpaper to set", "name", Core::ArgsParser::Required::No);
+    args_parser.add_positional_argument(path, "Wallpaper to set", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto app = TRY(GUI::Application::try_create(arguments));
+    auto app = GUI::Application::construct(arguments);
 
-    if (show_all)
-        return handle_show_all();
-    else if (show_current)
-        return handle_show_current();
-    else if (set_random)
-        return handle_set_random();
+    if (show_all) {
+        Core::DirIterator wallpapers_directory_iterator("/res/wallpapers", Core::DirIterator::SkipDots);
+        if (wallpapers_directory_iterator.has_error())
+            return Error::from_string_literal("Unable to iterate /res/wallpapers directory");
 
-    return handle_set_pape(name);
+        while (wallpapers_directory_iterator.has_next()) {
+            auto name = wallpapers_directory_iterator.next_path();
+            outln("{}", name);
+        }
+    } else if (show_current) {
+        auto current_wallpaper_path = GUI::Desktop::the().wallpaper_path();
+        outln("{}", current_wallpaper_path);
+    } else if (set_random) {
+        Core::DirIterator wallpapers_directory_iterator("/res/wallpapers", Core::DirIterator::SkipDots);
+        if (wallpapers_directory_iterator.has_error())
+            return Error::from_string_literal("Unable to iterate /res/wallpapers directory");
+
+        Vector<String> wallpaper_paths;
+
+        auto current_wallpaper_path = GUI::Desktop::the().wallpaper_path();
+        while (wallpapers_directory_iterator.has_next()) {
+            auto next_full_path = wallpapers_directory_iterator.next_full_path();
+            if (next_full_path != current_wallpaper_path)
+                wallpaper_paths.append(move(next_full_path));
+        }
+
+        if (wallpaper_paths.is_empty())
+            return Error::from_string_literal("No wallpapers found");
+
+        auto& chosen_wallpaper_path = wallpaper_paths.at(get_random_uniform(wallpaper_paths.size()));
+        auto chosen_wallpaper_bitmap = TRY(Gfx::Bitmap::try_load_from_file(chosen_wallpaper_path));
+        if (!GUI::Desktop::the().set_wallpaper(chosen_wallpaper_bitmap, chosen_wallpaper_path))
+            return Error::from_string_literal("Failed to set wallpaper");
+
+        outln("Set wallpaper to {}", chosen_wallpaper_path);
+    } else {
+        if (path.is_null())
+            return Error::from_string_literal("Must provide a path to a wallpaper");
+
+        auto wallpaper_bitmap = TRY(Gfx::Bitmap::try_load_from_file(path));
+        if (!GUI::Desktop::the().set_wallpaper(wallpaper_bitmap, path))
+            return Error::from_string_literal("Failed to set wallpaper");
+    }
+    return 0;
 }


### PR DESCRIPTION
The existing way of setting wallpapers forces you to tell WindowServer of a filesystem path to the wallpaper to load and set it. This is weird (why should it care about some filesystem path?) and prevents it from loading from certain paths because of veils (see #11158)

The changes here completely remove any reference to a path in WindowServer, and instead put that responsibility solely on `GUI::Desktop`, who reads and writes it to a config. WindowServer now just expects a `RefPtr<Gfx::Bitmap>`, which allows us to set arbitrary backgrounds, without needing to unveil additional paths, and without needing to overwrite the existing config.

`pape` was rewritten to reflect modern Serenity style, improve error handling, and work with the new wallpaper mechanism.