### PR TITLE
LibCore: Fix Serenity Stream OOB read in `BufferedSeekable::read_until_any_of`

### DIFF
--- a/Tests/LibCore/CMakeLists.txt
+++ b/Tests/LibCore/CMakeLists.txt
@@ -13,4 +13,4 @@ endforeach()
 # NOTE: Required because of the LocalServer tests
 target_link_libraries(TestLibCoreStream LibThreading)
 
-install(FILES long_lines.txt 10kb.txt DESTINATION usr/Tests/LibCore)
+install(FILES long_lines.txt 10kb.txt small.txt DESTINATION usr/Tests/LibCore)

--- a/Tests/LibCore/small.txt
+++ b/Tests/LibCore/small.txt
@@ -1,0 +1,4 @@
+Well
+hello
+friends!
+:^)

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -627,7 +627,7 @@ public:
             // user buffer.
             StringView remaining_buffer { m_buffer.span().offset(offset), maximum_offset - offset };
             for (auto candidate : candidates) {
-                if (candidate.length() > offset)
+                if (candidate.length() > remaining_buffer.length())
                     continue;
                 if (remaining_buffer.starts_with(candidate))
                     longest_match = max(longest_match, candidate.length());
@@ -639,6 +639,8 @@ public:
 
                 buffer_to_take.copy_to(buffer);
                 m_buffer.overwrite(0, buffer_to_shift.data(), buffer_to_shift.size());
+
+                m_buffered_size -= offset + longest_match;
 
                 return offset;
             }
@@ -653,6 +655,8 @@ public:
 
         buffer_to_take.copy_to(buffer);
         m_buffer.overwrite(0, buffer_to_shift.data(), buffer_to_shift.size());
+
+        m_buffered_size -= readable_size;
 
         return readable_size;
     }


### PR DESCRIPTION
### LibCore: Fix OOB read in Stream::BufferedSeekable::read_until_any_of 
If we do not decrement `m_buffered_size` whenever we read data from the
buffer, we end up saying that there are more lines available when we
reach the end of file. This bug caused callers to read garbage data.

This also fixes an incorrect condition in an if statement. The separator
candidate is searched for in `remaining_buffer`, so the separator's
length should be compared against that.

### Tests/LibCore: Add regression test for the read_until_any_of OOB read

---
This issue was found by @sunverwerth while he was working on #11436.
cc @sin-ack 