### PR TITLE
HexEditor: Port HexEditor to LibMain

### DIFF
--- a/Userland/Applications/HexEditor/CMakeLists.txt
+++ b/Userland/Applications/HexEditor/CMakeLists.txt
@@ -21,4 +21,4 @@ set(SOURCES
 )
 
 serenity_app(HexEditor ICON app-hex-editor)
-target_link_libraries(HexEditor LibGUI LibConfig LibFileSystemAccessClient)
+target_link_libraries(HexEditor LibGUI LibConfig LibFileSystemAccessClient LibMain)

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -1,65 +1,54 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
+ * Copyright (c) 2021, Conor Byrne <conor@cbyrne.dev>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "HexEditorWidget.h"
 #include <LibConfig/Client.h>
+#include <LibCore/System.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
+#include <LibMain/Main.h>
 #include <stdio.h>
 #include <unistd.h>
 
-int main(int argc, char** argv)
+ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    if (pledge("stdio recvfd sendfd rpath unix cpath wpath thread", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath thread"));
 
-    auto app = GUI::Application::construct(argc, argv);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domains("HexEditor");
 
-    auto app_icon = GUI::Icon::default_icon("app-hex-editor");
+    auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-hex-editor"));
 
-    auto window = GUI::Window::construct();
+    auto window = TRY(GUI::Window::try_create());
     window->set_title("Hex Editor");
     window->resize(640, 400);
 
-    auto& hex_editor_widget = window->set_main_widget<HexEditorWidget>();
+    auto hex_editor_widget = TRY(window->try_set_main_widget<HexEditorWidget>());
 
     window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
-        if (hex_editor_widget.request_close())
+        if (hex_editor_widget->request_close())
             return GUI::Window::CloseRequestDecision::Close;
         return GUI::Window::CloseRequestDecision::StayOpen;
     };
 
-    if (unveil("/res", "r") < 0) {
-        perror("unveil");
-        return 1;
-    }
+    TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
+    TRY(Core::System::unveil(nullptr, nullptr));
 
-    if (unveil("/tmp/portal/filesystemaccess", "rw") < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    if (unveil(nullptr, nullptr) < 0) {
-        perror("unveil");
-        return 1;
-    }
-
-    hex_editor_widget.initialize_menubar(*window);
+    hex_editor_widget->initialize_menubar(*window);
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    if (argc > 1) {
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), argv[1]);
+    if (arguments.argc > 1) {
+        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), arguments.strings[1]);
 
         if (response.error != 0) {
             if (response.error != -1)
@@ -67,7 +56,7 @@ int main(int argc, char** argv)
             return 1;
         }
 
-        hex_editor_widget.open_file(*response.fd, *response.chosen_file);
+        hex_editor_widget->open_file(*response.fd, *response.chosen_file);
     }
 
     return app->exec();


### PR DESCRIPTION
HexEditor was previously using the old ``int main(...)`` function, I've ported it to LibMain, so we can use that sweet ``TRY()`` macro :^)