### PR TITLE
WindowsServer+LibGUI: Avoid getting color under cursor outside screen

### DIFF
--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -160,9 +160,11 @@ private:
     virtual void mousemove_event(GUI::MouseEvent&) override
     {
         auto new_col = WindowServerConnection::the().get_color_under_cursor();
+        if (!new_col.has_value())
+            return;
         if (new_col == m_col)
             return;
-        m_col = new_col;
+        m_col = new_col.value();
         if (on_color_changed)
             on_color_changed(m_col);
     }

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -1080,8 +1080,11 @@ Messages::WindowServer::GetColorUnderCursorResponse ClientConnection::get_color_
     //        manual translation to avoid sampling the color on the actual cursor itself.
     auto cursor_location = ScreenInput::the().cursor_location().translated(-1, -1);
     auto& screen_with_cursor = ScreenInput::the().cursor_location_screen();
-    auto color = Compositor::the().color_at_position({}, screen_with_cursor, cursor_location);
-    return color;
+
+    if (!screen_with_cursor.rect().contains(cursor_location))
+        return Optional<Color> {};
+
+    return { Compositor::the().color_at_position({}, screen_with_cursor, cursor_location) };
 }
 
 Messages::WindowServer::IsWindowModifiedResponse ClientConnection::is_window_modified(i32 window_id)

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -137,7 +137,7 @@ endpoint WindowServer
 
     get_screen_bitmap(Optional<Gfx::IntRect> rect, Optional<u32> screen_index) => (Gfx::ShareableBitmap bitmap)
     get_screen_bitmap_around_cursor(Gfx::IntSize size) => (Gfx::ShareableBitmap bitmap)
-    get_color_under_cursor() => (Gfx::Color color)
+    get_color_under_cursor() => (Optional<Gfx::Color> color)
 
     pong() =|
 


### PR DESCRIPTION
This pull request fixes a crash in ColorPicker caused by the ColorSelectOverlay trying to request the color for a pixel outside the screen rect.
