### PR TITLE
Pixelpaint: Add a Filter Gallery

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -7,12 +7,16 @@ serenity_component(
 
 compile_gml(PixelPaintWindow.gml PixelPaintWindowGML.h pixel_paint_window_gml)
 compile_gml(EditGuideDialog.gml EditGuideDialogGML.h edit_guide_dialog_gml)
+compile_gml(FilterGallery.gml FilterGalleryGML.h filter_gallery_gml)
 
 set(SOURCES
     CreateNewImageDialog.cpp
     CreateNewLayerDialog.cpp
     EditGuideDialog.cpp
     EditGuideDialogGML.h
+    FilterGallery.cpp
+    FilterGalleryGML.h
+    FilterModel.cpp
     Image.cpp
     ImageEditor.cpp
     Layer.cpp

--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -13,7 +13,7 @@
 
 namespace PixelPaint {
 
-FilterGallery::FilterGallery(GUI::Window* parent_window)
+FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
     : GUI::Dialog(parent_window)
 {
     set_title("Filter Gallery");
@@ -33,7 +33,7 @@ FilterGallery::FilterGallery(GUI::Window* parent_window)
     VERIFY(apply_button);
     VERIFY(cancel_button);
 
-    auto filter_model = FilterModel::create();
+    auto filter_model = FilterModel::create(editor);
     filter_tree->set_model(filter_model);
     filter_tree->expand_tree();
 

--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -37,9 +37,16 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
     filter_tree->set_model(filter_model);
     filter_tree->expand_tree();
 
-    apply_button->on_click = [this](auto) {
-        dbgln("Click!");
+    apply_button->on_click = [this, filter_tree](auto) {
+        auto selected_index = filter_tree->selection().first();
+        if (!selected_index.is_valid())
+            done(ExecResult::ExecAborted);
 
+        auto selected_filter = static_cast<const FilterModel::FilterInfo*>(selected_index.internal_data());
+        if (selected_filter->type != FilterModel::FilterInfo::Type::Filter)
+            done(ExecResult::ExecAborted);
+
+        selected_filter->apply_filter();
         done(ExecResult::ExecOK);
     };
 

--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "FilterGallery.h"
+#include "FilterModel.h"
+#include <Applications/PixelPaint/FilterGalleryGML.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/TreeView.h>
+#include <LibGUI/Widget.h>
+
+namespace PixelPaint {
+
+FilterGallery::FilterGallery(GUI::Window* parent_window)
+    : GUI::Dialog(parent_window)
+{
+    set_title("Filter Gallery");
+    set_icon(parent_window->icon());
+    resize(200, 250);
+    set_resizable(true);
+
+    auto& main_widget = set_main_widget<GUI::Widget>();
+    if (!main_widget.load_from_gml(filter_gallery_gml))
+        VERIFY_NOT_REACHED();
+
+    auto filter_tree = main_widget.find_descendant_of_type_named<GUI::TreeView>("tree_view");
+    auto apply_button = main_widget.find_descendant_of_type_named<GUI::Button>("apply_button");
+    auto cancel_button = main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+
+    VERIFY(filter_tree);
+    VERIFY(apply_button);
+    VERIFY(cancel_button);
+
+    auto filter_model = FilterModel::create();
+    filter_tree->set_model(filter_model);
+    filter_tree->expand_tree();
+
+    apply_button->on_click = [this](auto) {
+        dbgln("Click!");
+
+        done(ExecResult::ExecOK);
+    };
+
+    cancel_button->on_click = [this](auto) {
+        done(ExecResult::ExecCancel);
+    };
+}
+
+}

--- a/Userland/Applications/PixelPaint/FilterGallery.gml
+++ b/Userland/Applications/PixelPaint/FilterGallery.gml
@@ -1,0 +1,40 @@
+@GUI::Frame {
+    layout: @GUI::VerticalBoxLayout {
+    }
+
+    fill_with_background_color: true
+
+    @GUI::Widget {
+
+        layout:@GUI::HorizontalBoxLayout {
+            margins: [4]
+        }
+    
+        @GUI::TreeView {
+            name: "tree_view"
+        }
+
+    }
+
+    @GUI::Widget {
+        max_height: 24
+
+        layout:@GUI::HorizontalBoxLayout {
+            margins: [4]
+        }
+
+        @GUI::Widget {}
+
+        @GUI::Button {
+            name: "apply_button"
+            text: "Apply"
+            max_width: 75
+        }
+
+        @GUI::Button {
+            name: "cancel_button"
+            text: "Cancel"
+            max_width: 75
+        }
+    }
+}

--- a/Userland/Applications/PixelPaint/FilterGallery.h
+++ b/Userland/Applications/PixelPaint/FilterGallery.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "ImageEditor.h"
 #include <LibGUI/Dialog.h>
 
 namespace PixelPaint {
@@ -14,7 +15,7 @@ class FilterGallery final : public GUI::Dialog {
     C_OBJECT(FilterGallery);
 
 private:
-    FilterGallery(GUI::Window* parent_window);
+    FilterGallery(GUI::Window* parent_window, ImageEditor*);
 };
 
 }

--- a/Userland/Applications/PixelPaint/FilterGallery.h
+++ b/Userland/Applications/PixelPaint/FilterGallery.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Dialog.h>
+
+namespace PixelPaint {
+
+class FilterGallery final : public GUI::Dialog {
+    C_OBJECT(FilterGallery);
+
+private:
+    FilterGallery(GUI::Window* parent_window);
+};
+
+}

--- a/Userland/Applications/PixelPaint/FilterModel.cpp
+++ b/Userland/Applications/PixelPaint/FilterModel.cpp
@@ -6,10 +6,13 @@
  */
 
 #include "FilterModel.h"
+#include "FilterParams.h"
+#include "Layer.h"
 #include <LibGUI/FileIconProvider.h>
+#include <LibGfx/Filters/LaplacianFilter.h>
 
 namespace PixelPaint {
-FilterModel::FilterModel()
+FilterModel::FilterModel(ImageEditor* editor)
 {
 
     auto filter_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/filter.png").release_value_but_fixme_should_propagate_errors();

--- a/Userland/Applications/PixelPaint/FilterModel.cpp
+++ b/Userland/Applications/PixelPaint/FilterModel.cpp
@@ -14,6 +14,139 @@
 namespace PixelPaint {
 FilterModel::FilterModel(ImageEditor* editor)
 {
+    auto spatial_category = FilterInfo::create_category("Spatial");
+
+    auto edge_detect_category = FilterInfo::create_category("Edge Detect", spatial_category);
+    auto laplace_cardinal_filter = FilterInfo::create_filter(
+        "Laplacian (Cardinal)", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::LaplacianFilter filter;
+                if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(false)) {
+                    filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                    layer->did_modify_bitmap(layer->rect());
+                    editor->did_complete_action();
+                }
+            }
+        },
+        edge_detect_category);
+    auto laplace_diagonal_filter = FilterInfo::create_filter(
+        "Laplacian (Diagonal)", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::LaplacianFilter filter;
+                if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(true)) {
+                    filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                    layer->did_modify_bitmap(layer->rect());
+                    editor->did_complete_action();
+                }
+            }
+        },
+        edge_detect_category);
+
+    auto blur_category = FilterInfo::create_category("Blur & Sharpen", spatial_category);
+    auto gaussian_blur_filter_3 = FilterInfo::create_filter(
+        "Gaussian Blur (3x3)", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::SpatialGaussianBlurFilter<3> filter;
+                if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<3>>::get()) {
+                    filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                    layer->did_modify_bitmap(layer->rect());
+                    editor->did_complete_action();
+                }
+            }
+        },
+        blur_category);
+    auto gaussian_blur_filter_5 = FilterInfo::create_filter(
+        "Gaussian Blur (5x5)", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::SpatialGaussianBlurFilter<5> filter;
+                if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<3>>::get()) {
+                    filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                    layer->did_modify_bitmap(layer->rect());
+                    editor->did_complete_action();
+                }
+            }
+        },
+        blur_category);
+    auto box_blur_filter_3 = FilterInfo::create_filter(
+        "Box Blur (3x3)", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::BoxBlurFilter<3> filter;
+                if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<3>>::get()) {
+                    filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                    layer->did_modify_bitmap(layer->rect());
+                    editor->did_complete_action();
+                }
+            }
+        },
+        blur_category);
+    auto box_blur_filter_5 = FilterInfo::create_filter(
+        "Box Blur (5x5)", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::BoxBlurFilter<5> filter;
+                if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<3>>::get()) {
+                    filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                    layer->did_modify_bitmap(layer->rect());
+                    editor->did_complete_action();
+                }
+            }
+        },
+        blur_category);
+    auto sharpen_filter = FilterInfo::create_filter(
+        "Sharpen", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::SharpenFilter filter;
+                if (auto parameters = PixelPaint::FilterParameters<Gfx::SharpenFilter>::get()) {
+                    filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                    layer->did_modify_bitmap(layer->rect());
+                    editor->did_complete_action();
+                }
+            }
+        },
+        blur_category);
+
+    m_filters.append(spatial_category);
+
+    auto color_category = FilterInfo::create_category("Color");
+    auto grayscale_filter = FilterInfo::create_filter(
+        "Grayscale", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::GrayscaleFilter filter;
+                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
+                layer->did_modify_bitmap(layer->rect());
+                editor->did_complete_action();
+            }
+        },
+        color_category);
+    auto invert_filter = FilterInfo::create_filter(
+        "Invert", [editor]() {
+            if (!editor)
+                return;
+            if (auto* layer = editor->active_layer()) {
+                Gfx::InvertFilter filter;
+                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
+                layer->did_modify_bitmap(layer->rect());
+                editor->did_complete_action();
+            }
+        },
+        color_category);
+
+    m_filters.append(color_category);
 
     auto filter_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/filter.png").release_value_but_fixme_should_propagate_errors();
     m_filter_icon = GUI::Icon(filter_bitmap);

--- a/Userland/Applications/PixelPaint/FilterModel.cpp
+++ b/Userland/Applications/PixelPaint/FilterModel.cpp
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021-2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "FilterModel.h"
+#include <LibGUI/FileIconProvider.h>
+
+namespace PixelPaint {
+FilterModel::FilterModel()
+{
+
+    auto filter_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/filter.png").release_value_but_fixme_should_propagate_errors();
+    m_filter_icon = GUI::Icon(filter_bitmap);
+}
+
+GUI::ModelIndex FilterModel::index(int row, int column, const GUI::ModelIndex& parent_index) const
+{
+    if (!parent_index.is_valid()) {
+        if (static_cast<size_t>(row) >= m_filters.size())
+            return {};
+        return create_index(row, column, &m_filters[row]);
+    }
+    auto* parent = static_cast<const FilterInfo*>(parent_index.internal_data());
+    if (static_cast<size_t>(row) >= parent->children.size())
+        return {};
+    auto* child = &parent->children[row];
+    return create_index(row, column, child);
+}
+
+GUI::ModelIndex FilterModel::parent_index(const GUI::ModelIndex& index) const
+{
+    if (!index.is_valid())
+        return {};
+
+    auto* child = static_cast<const FilterInfo*>(index.internal_data());
+    auto* parent = child->parent;
+    if (parent == nullptr)
+        return {};
+
+    if (parent->parent == nullptr) {
+        for (size_t row = 0; row < m_filters.size(); row++)
+            if (m_filters.ptr_at(row).ptr() == parent)
+                return create_index(row, 0, parent);
+        VERIFY_NOT_REACHED();
+    }
+    for (size_t row = 0; row < parent->parent->children.size(); row++) {
+        FilterInfo* child_at_row = parent->parent->children.ptr_at(row).ptr();
+        if (child_at_row == parent)
+            return create_index(row, 0, parent);
+    }
+    VERIFY_NOT_REACHED();
+}
+
+int FilterModel::row_count(const GUI::ModelIndex& index) const
+{
+    if (!index.is_valid())
+        return m_filters.size();
+    auto* node = static_cast<const FilterInfo*>(index.internal_data());
+    return node->children.size();
+}
+
+GUI::Variant FilterModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
+{
+    auto* filter = static_cast<const FilterInfo*>(index.internal_data());
+    switch (role) {
+    case GUI::ModelRole::Display:
+        return filter->text;
+    case GUI::ModelRole::Icon:
+        if (filter->type == FilterInfo::Type::Category)
+            return GUI::FileIconProvider::directory_icon();
+        return m_filter_icon;
+    default:
+        return {};
+    }
+}
+}

--- a/Userland/Applications/PixelPaint/FilterModel.h
+++ b/Userland/Applications/PixelPaint/FilterModel.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <LibGUI/Model.h>
+
+namespace PixelPaint {
+
+class FilterModel final : public GUI::Model {
+
+public:
+    class FilterInfo : public RefCounted {
+    public:
+        enum class Type {
+            Category,
+            Filter,
+        } type;
+
+        String text;
+
+        NonnullRefPtrVector<FilterInfo> children;
+        FilterInfo* parent;
+
+        static NonnullRefPtr<FilterInfo> create_filter(String const& text, FilterInfo* parent = nullptr)
+        {
+            auto filter = adopt_ref(*new FilterInfo(Type::Filter, text, parent));
+            filter->ref();
+
+            if (parent)
+                parent->children.append(filter);
+            return filter;
+        }
+
+        static NonnullRefPtr<FilterInfo> create_category(String const& text, FilterInfo* parent = nullptr)
+        {
+            auto category = adopt_ref(*new FilterInfo(Type::Category, text, parent));
+            category->ref();
+            if (parent)
+                parent->children.append(category);
+            return category;
+        }
+
+        FilterInfo(Type type, String text, FilterInfo* parent)
+            : type(type)
+            , text(move(text))
+            , parent(parent)
+        {
+        }
+    };
+
+    static NonnullRefPtr<FilterModel> create()
+    {
+        return adopt_ref(*new FilterModel());
+    }
+
+    virtual ~FilterModel() override {};
+
+    virtual int row_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+    virtual int column_count(const GUI::ModelIndex& = GUI::ModelIndex()) const override { return 1; }
+    virtual GUI::Variant data(const GUI::ModelIndex& index, GUI::ModelRole role) const override;
+    virtual GUI::ModelIndex parent_index(const GUI::ModelIndex&) const override;
+    virtual GUI::ModelIndex index(int row, int column = 0, const GUI::ModelIndex& = GUI::ModelIndex()) const override;
+
+private:
+    FilterModel();
+
+    NonnullRefPtrVector<FilterInfo> m_filters;
+    GUI::Icon m_filter_icon;
+};
+}

--- a/Userland/Applications/PixelPaint/FilterModel.h
+++ b/Userland/Applications/PixelPaint/FilterModel.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "ImageEditor.h"
 #include <AK/NonnullRefPtr.h>
 #include <LibGUI/Model.h>
 
@@ -53,9 +54,9 @@ public:
         }
     };
 
-    static NonnullRefPtr<FilterModel> create()
+    static NonnullRefPtr<FilterModel> create(ImageEditor* editor)
     {
-        return adopt_ref(*new FilterModel());
+        return adopt_ref(*new FilterModel(editor));
     }
 
     virtual ~FilterModel() override {};
@@ -67,7 +68,7 @@ public:
     virtual GUI::ModelIndex index(int row, int column = 0, const GUI::ModelIndex& = GUI::ModelIndex()) const override;
 
 private:
-    FilterModel();
+    FilterModel(ImageEditor* editor);
 
     NonnullRefPtrVector<FilterInfo> m_filters;
     GUI::Icon m_filter_icon;

--- a/Userland/Applications/PixelPaint/FilterModel.h
+++ b/Userland/Applications/PixelPaint/FilterModel.h
@@ -24,14 +24,16 @@ public:
 
         String text;
 
+        Function<void()> apply_filter;
+
         NonnullRefPtrVector<FilterInfo> children;
         FilterInfo* parent;
 
-        static NonnullRefPtr<FilterInfo> create_filter(String const& text, FilterInfo* parent = nullptr)
+        static NonnullRefPtr<FilterInfo> create_filter(String const& text, Function<void()> apply_filter, FilterInfo* parent = nullptr)
         {
             auto filter = adopt_ref(*new FilterInfo(Type::Filter, text, parent));
             filter->ref();
-
+            filter->apply_filter = move(apply_filter);
             if (parent)
                 parent->children.append(filter);
             return filter;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -590,7 +590,10 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     auto& filter_menu = window.add_menu("&Filter");
 
     filter_menu.add_action(GUI::Action::create("Filter &Gallery", [&](auto&) {
-        auto dialog = PixelPaint::FilterGallery::construct(&window);
+        auto* editor = current_image_editor();
+        if (!editor)
+            return;
+        auto dialog = PixelPaint::FilterGallery::construct(&window, editor);
         if (dialog->exec() != GUI::Dialog::ExecOK)
             return;
     }));

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
- * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2021-2022, Tobias Christiansen <tobyase@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -598,104 +598,8 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             return;
     }));
 
-    auto& spatial_filters_menu = filter_menu.add_submenu("&Spatial");
-
-    auto& edge_detect_submenu = spatial_filters_menu.add_submenu("&Edge Detect");
-    edge_detect_submenu.add_action(GUI::Action::create("Laplacian (&Cardinal)", [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::LaplacianFilter filter;
-            if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(false)) {
-                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-                layer->did_modify_bitmap(layer->rect());
-                editor->did_complete_action();
-            }
-        }
-    }));
-    edge_detect_submenu.add_action(GUI::Action::create("Laplacian (&Diagonal)", [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::LaplacianFilter filter;
-            if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(true)) {
-                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-                layer->did_modify_bitmap(layer->rect());
-                editor->did_complete_action();
-            }
-        }
-    }));
-    auto& blur_submenu = spatial_filters_menu.add_submenu("&Blur and Sharpen");
-    blur_submenu.add_action(GUI::Action::create("&Gaussian Blur (3x3)", [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::SpatialGaussianBlurFilter<3> filter;
-            if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<3>>::get()) {
-                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-                layer->did_modify_bitmap(layer->rect());
-                editor->did_complete_action();
-            }
-        }
-    }));
-    blur_submenu.add_action(GUI::Action::create("G&aussian Blur (5x5)", [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::SpatialGaussianBlurFilter<5> filter;
-            if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<5>>::get()) {
-                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-                layer->did_modify_bitmap(layer->rect());
-                editor->did_complete_action();
-            }
-        }
-    }));
-    blur_submenu.add_action(GUI::Action::create("&Box Blur (3x3)", [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::BoxBlurFilter<3> filter;
-            if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<3>>::get()) {
-                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-                layer->did_modify_bitmap(layer->rect());
-                editor->did_complete_action();
-            }
-        }
-    }));
-    blur_submenu.add_action(GUI::Action::create("B&ox Blur (5x5)", [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::BoxBlurFilter<5> filter;
-            if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<5>>::get()) {
-                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-                layer->did_modify_bitmap(layer->rect());
-                editor->did_complete_action();
-            }
-        }
-    }));
-    blur_submenu.add_action(GUI::Action::create("&Sharpen", [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::SharpenFilter filter;
-            if (auto parameters = PixelPaint::FilterParameters<Gfx::SharpenFilter>::get()) {
-                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-                layer->did_modify_bitmap(layer->rect());
-                editor->did_complete_action();
-            }
-        }
-    }));
-
-    spatial_filters_menu.add_separator();
-    spatial_filters_menu.add_action(GUI::Action::create("Generic 5x5 &Convolution", [&](auto&) {
+    filter_menu.add_separator();
+    filter_menu.add_action(GUI::Action::create("Generic 5x5 &Convolution", [&](auto&) {
         auto* editor = current_image_editor();
         if (!editor)
             return;
@@ -706,30 +610,6 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
-        }
-    }));
-
-    auto& color_filters_menu = filter_menu.add_submenu("&Color");
-    color_filters_menu.add_action(GUI::Action::create("Grayscale", [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::GrayscaleFilter filter;
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
-            layer->did_modify_bitmap(layer->rect());
-            editor->did_complete_action();
-        }
-    }));
-    color_filters_menu.add_action(GUI::Action::create("Invert", { Mod_Ctrl, Key_I }, [&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (auto* layer = editor->active_layer()) {
-            Gfx::InvertFilter filter;
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
-            layer->did_modify_bitmap(layer->rect());
-            editor->did_complete_action();
         }
     }));
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -10,6 +10,7 @@
 #include "CreateNewImageDialog.h"
 #include "CreateNewLayerDialog.h"
 #include "EditGuideDialog.h"
+#include "FilterGallery.h"
 #include "FilterParams.h"
 #include <Applications/PixelPaint/PixelPaintWindowGML.h>
 #include <LibConfig/Client.h>
@@ -587,6 +588,13 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
 
     auto& filter_menu = window.add_menu("&Filter");
+
+    filter_menu.add_action(GUI::Action::create("Filter &Gallery", [&](auto&) {
+        auto dialog = PixelPaint::FilterGallery::construct(&window);
+        if (dialog->exec() != GUI::Dialog::ExecOK)
+            return;
+    }));
+
     auto& spatial_filters_menu = filter_menu.add_submenu("&Spatial");
 
     auto& edge_detect_submenu = spatial_filters_menu.add_submenu("&Edge Detect");


### PR DESCRIPTION
Happy new year everyone!

This PR adds a "Filter Gallery" to PixelPaint.
I'd like Filters to have settings the user can change in the future, which this PR does not achieve, However it is a great step towards supporting that.
All the functionality that lived in the MainWidget regarding Filters moved over to the FilterGallery in the process
(:eye: @mustafaquraish )


![image](https://user-images.githubusercontent.com/6002167/147841327-4e89e87e-54fb-4aaf-93ad-242857355a78.png)
