### PR TITLE
LibC: Implement ``flockfile`` and ``funlockfile``

### DIFF
--- a/Userland/Libraries/LibC/bits/stdio_file_implementation.h
+++ b/Userland/Libraries/LibC/bits/stdio_file_implementation.h
@@ -19,7 +19,8 @@ public:
         : m_fd(fd)
         , m_mode(mode)
     {
-        __pthread_mutex_init(&m_mutex, nullptr);
+        pthread_mutexattr_t attr = { __PTHREAD_MUTEX_RECURSIVE };
+        __pthread_mutex_init(&m_mutex, &attr);
     }
     ~FILE();
 
@@ -30,6 +31,9 @@ public:
     bool flush();
     void purge();
     bool close();
+
+    void lock();
+    void unlock();
 
     int fileno() const { return m_fd; }
     bool eof() const { return m_eof; }
@@ -115,9 +119,6 @@ private:
     // Flush *some* data from the buffer.
     bool write_from_buffer();
 
-    void lock();
-    void unlock();
-
     int m_fd { -1 };
     int m_mode { 0 };
     u8 m_flags { Flags::None };
@@ -126,8 +127,6 @@ private:
     pid_t m_popen_child { -1 };
     Buffer m_buffer;
     __pthread_mutex_t m_mutex;
-
-    friend class ScopedFileLock;
 };
 
 class ScopedFileLock {

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -1228,15 +1228,17 @@ int vscanf(const char* fmt, va_list ap)
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/flockfile.html
-void flockfile([[maybe_unused]] FILE* filehandle)
+void flockfile(FILE* filehandle)
 {
-    dbgln("FIXME: Implement flockfile()");
+    VERIFY(filehandle);
+    filehandle->lock();
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/funlockfile.html
-void funlockfile([[maybe_unused]] FILE* filehandle)
+void funlockfile(FILE* filehandle)
 {
-    dbgln("FIXME: Implement funlockfile()");
+    VERIFY(filehandle);
+    filehandle->unlock();
 }
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/tmpfile.html


### PR DESCRIPTION
To do this, we must set the type attribute when initializing a ``FILE``'s mutex to ``__PTHREAD_MUTEX_RECURSIVE``. ([``pthread_mutex_lock`` reference](https://pubs.opengroup.org/onlinepubs/009604499/functions/pthread_mutex_lock.html))
This is required because ``flockfile`` and ``funlockfile`` need the mutex to be recursive. ([``flockfile`` reference](https://pubs.opengroup.org/onlinepubs/9699919799/functions/funlockfile.html))
