### PR TITLE
LibC: Include strings.h in string.h

### DIFF
--- a/Userland/Libraries/LibC/string.h
+++ b/Userland/Libraries/LibC/string.h
@@ -11,6 +11,11 @@
 
 __BEGIN_DECLS
 
+// A few C Standard Libraries include this header in <string.h>, and hence expect
+// `strcasecmp` etcetera to be available as part of a <string.h> include, so let's
+// do the same here to maintain compatibility
+#include <strings.h>
+
 size_t strlen(const char*);
 size_t strnlen(const char*, size_t maxlen);
 


### PR DESCRIPTION
Certain C Libraries have (unfortunately) included strings.h as a
part of string.h, which violates the POSIX spec for that specific
header. Some applications rely on this being the case, so let's
include it in our string.h