### PR TITLE
LibM: Count fractions when exponent < -1 with mantissa == 0

### DIFF
--- a/Tests/LibM/test-math.cpp
+++ b/Tests/LibM/test-math.cpp
@@ -267,3 +267,25 @@ TEST_CASE(acos)
     EXPECT_APPROXIMATE(acos(1), 0);
     EXPECT(isnan(acos(1.1)));
 }
+
+TEST_CASE(floor)
+{
+    EXPECT_EQ(floor(0.125), 0);
+    EXPECT_EQ(floor(-0.125), -1.0);
+    EXPECT_EQ(floor(0.5), 0);
+    EXPECT_EQ(floor(-0.5), -1.0);
+    EXPECT_EQ(floor(0.25), 0);
+    EXPECT_EQ(floor(-0.25), -1.0);
+    EXPECT_EQ(floor(-3.0 / 2.0), -2.0);
+}
+
+TEST_CASE(ceil)
+{
+    EXPECT_EQ(ceil(0.125), 1.0);
+    EXPECT_EQ(ceil(-0.125), 0);
+    EXPECT_EQ(ceil(0.5), 1.0);
+    EXPECT_EQ(ceil(-0.5), 0);
+    EXPECT_EQ(ceil(0.25), 1.0);
+    EXPECT_EQ(ceil(-0.25), 0);
+    EXPECT_EQ(ceil(-3.0 / 2.0), -1.0);
+}


### PR DESCRIPTION
**LibM: Count fractions when exponent < -1 with mantissa == 0**

Without this change, floor(-0.125) returned 0.
This is because the number has a fraction part even if mantissa is zero
while the unbiased exponent is negative.

The names of some variables were also made clearer.

**Tests: Add floor and ceil tests to test-math**