### PR TITLE
Theming: Add alignment section

### DIFF
--- a/Base/res/themes/Basalt.ini
+++ b/Base/res/themes/Basalt.ini
@@ -72,9 +72,11 @@ TooltipText=white
 Tray=#171717
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=true
-IsTitleCenter=false
 
 [Metrics]
 TitleHeight=24

--- a/Base/res/themes/Coffee.ini
+++ b/Base/res/themes/Coffee.ini
@@ -68,9 +68,11 @@ TooltipText=black
 Tray=#9397a5
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Paths]
 TitleButtonIcons=/res/icons/themes/Coffee/16x16/

--- a/Base/res/themes/Cupertino.ini
+++ b/Base/res/themes/Cupertino.ini
@@ -69,9 +69,11 @@ TooltipText=white
 Tray=#212121
 TrayText=#fcfcfc
 
+[Alignments]
+TitleAlignment=Center
+
 [Flags]
 IsDark=true
-IsTitleCenter=true
 
 [Metrics]
 BorderRadius=8

--- a/Base/res/themes/Dark.ini
+++ b/Base/res/themes/Dark.ini
@@ -64,6 +64,8 @@ TooltipText=white
 Tray=#323232
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=true
-IsTitleCenter=false

--- a/Base/res/themes/Default.ini
+++ b/Base/res/themes/Default.ini
@@ -72,9 +72,11 @@ TooltipText=black
 Tray=#808080
 TrayText=#ffffff
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Metrics]
 BorderThickness=4

--- a/Base/res/themes/Desert.ini
+++ b/Base/res/themes/Desert.ini
@@ -72,9 +72,11 @@ TooltipText=black
 Tray=#a28d68
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Metrics]
 TitleHeight=19

--- a/Base/res/themes/Faux Pas.ini
+++ b/Base/res/themes/Faux Pas.ini
@@ -64,6 +64,8 @@ TooltipText=black
 Tray=#282828
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false

--- a/Base/res/themes/Light.ini
+++ b/Base/res/themes/Light.ini
@@ -72,9 +72,11 @@ TooltipText=#4b4b4b
 Tray=#3b3b3b
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Paths]
 MenuShadow=/res/icons/themes/Redmond/menu-shadow.png

--- a/Base/res/themes/Nord.ini
+++ b/Base/res/themes/Nord.ini
@@ -64,6 +64,8 @@ TooltipText=white
 Tray=#3b4252
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=true
-IsTitleCenter=false

--- a/Base/res/themes/Plum.ini
+++ b/Base/res/themes/Plum.ini
@@ -72,9 +72,11 @@ TooltipText=black
 Tray=#808080
 TrayText=#ffffff
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Metrics]
 TitleHeight=19

--- a/Base/res/themes/Redmond 2000.ini
+++ b/Base/res/themes/Redmond 2000.ini
@@ -68,9 +68,11 @@ TooltipText=black
 Tray=#808080
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Metrics]
 TitleButtonWidth=17

--- a/Base/res/themes/Redmond.ini
+++ b/Base/res/themes/Redmond.ini
@@ -68,9 +68,11 @@ TooltipText=black
 Tray=#808080
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Metrics]
 TitleButtonWidth=17

--- a/Base/res/themes/Silver.ini
+++ b/Base/res/themes/Silver.ini
@@ -64,9 +64,11 @@ TooltipText=black
 Tray=#3b3b3b
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Paths]
 TitleButtonIcons=/res/icons/themes/Silver/16x16/

--- a/Base/res/themes/Sunshine.ini
+++ b/Base/res/themes/Sunshine.ini
@@ -68,9 +68,11 @@ TooltipText=black
 Tray=#9397a5
 TrayText=white
 
+[Alignments]
+TitleAlignment=Left
+
 [Flags]
 IsDark=false
-IsTitleCenter=false
 
 [Paths]
 TitleButtonIcons=/res/icons/themes/Sunshine/16x16/

--- a/Userland/Applications/ThemeEditor/ThemeEditor.gml
+++ b/Userland/Applications/ThemeEditor/ThemeEditor.gml
@@ -30,6 +30,24 @@
             margins: [4, 4, 4, 4]
         }
         shrink_to_fit: true
+        title: "Alignments"
+
+        @GUI::ComboBox {
+            name: "alignment_combo_box"
+            model_only: true
+            fixed_width: 230
+        }
+
+        @GUI::ComboBox {
+            name: "alignment_input"
+        }
+    }
+
+    @GUI::GroupBox {
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [4, 4, 4, 4]
+        }
+        shrink_to_fit: true
         title: "Flags"
 
         @GUI::ComboBox {

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -3,6 +3,7 @@
  * Copyright (c) 2021, Jakob-Niklas See <git@nwex.de>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -36,6 +37,58 @@ class ColorRoleModel final : public GUI::ItemListModel<Gfx::ColorRole> {
 public:
     explicit ColorRoleModel(const Vector<Gfx::ColorRole>& data)
         : ItemListModel<Gfx::ColorRole>(data)
+    {
+    }
+
+    virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role) const override
+    {
+        if (role == GUI::ModelRole::Display)
+            return Gfx::to_string(m_data[(size_t)index.row()]);
+        if (role == GUI::ModelRole::Custom)
+            return m_data[(size_t)index.row()];
+
+        return ItemListModel::data(index, role);
+    }
+};
+
+struct AlignmentValue {
+    String title;
+    Gfx::TextAlignment setting_value;
+};
+
+class AlignmentModel final : public GUI::Model {
+
+public:
+    AlignmentModel()
+    {
+        m_alignments.empend("Center", Gfx::TextAlignment::Center);
+        m_alignments.empend("Left", Gfx::TextAlignment::CenterLeft);
+        m_alignments.empend("Right", Gfx::TextAlignment::CenterRight);
+    }
+
+    virtual ~AlignmentModel() = default;
+
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return 3; }
+    virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return 2; }
+
+    virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role) const override
+    {
+        if (role == GUI::ModelRole::Display)
+            return m_alignments[index.row()].title;
+        if (role == GUI::ModelRole::Custom)
+            return m_alignments[index.row()].setting_value;
+
+        return {};
+    }
+
+private:
+    Vector<AlignmentValue> m_alignments;
+};
+
+class AlignmentRoleModel final : public GUI::ItemListModel<Gfx::AlignmentRole> {
+public:
+    explicit AlignmentRoleModel(Vector<Gfx::AlignmentRole> const& data)
+        : ItemListModel<Gfx::AlignmentRole>(data)
     {
     }
 
@@ -145,6 +198,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
 #undef __ENUMERATE_COLOR_ROLE
 
+    Vector<Gfx::AlignmentRole> alignment_roles;
+#define __ENUMERATE_ALIGNMENT_ROLE(role) alignment_roles.append(Gfx::AlignmentRole::role);
+    ENUMERATE_ALIGNMENT_ROLES(__ENUMERATE_ALIGNMENT_ROLE)
+#undef __ENUMERATE_ALIGNMENT_ROLE
+
     Vector<Gfx::FlagRole> flag_roles;
 #define __ENUMERATE_FLAG_ROLE(role) flag_roles.append(Gfx::FlagRole::role);
     ENUMERATE_FLAG_ROLES(__ENUMERATE_FLAG_ROLE)
@@ -167,10 +225,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                                ->add<ThemeEditor::PreviewWidget>(startup_preview_palette);
     auto& color_combo_box = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("color_combo_box");
     auto& color_input = *main_widget->find_descendant_of_type_named<GUI::ColorInput>("color_input");
+
+    auto& alignment_combo_box = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("alignment_combo_box");
+    auto& alignment_input = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("alignment_input");
+
     auto& flag_combo_box = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("flag_combo_box");
     auto& flag_input = *main_widget->find_descendant_of_type_named<GUI::CheckBox>("flag_input");
+
     auto& metric_combo_box = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("metric_combo_box");
     auto& metric_input = *main_widget->find_descendant_of_type_named<GUI::SpinBox>("metric_input");
+
     auto& path_combo_box = *main_widget->find_descendant_of_type_named<GUI::ComboBox>("path_combo_box");
     auto& path_input = *main_widget->find_descendant_of_type_named<GUI::TextBox>("path_input");
     auto& path_picker_button = *main_widget->find_descendant_of_type_named<GUI::Button>("path_picker_button");
@@ -189,6 +253,24 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         preview_widget.set_preview_palette(preview_palette);
     };
     color_input.set_color(startup_preview_palette.color(Gfx::ColorRole::Window));
+
+    alignment_combo_box.set_model(adopt_ref(*new AlignmentRoleModel(alignment_roles)));
+    alignment_combo_box.on_change = [&](auto&, auto& index) {
+        auto role = index.model()->data(index, GUI::ModelRole::Custom).to_alignment_role();
+        alignment_input.set_selected_index((size_t)preview_widget.preview_palette().alignment(role), GUI::AllowCallback::No);
+    };
+    alignment_combo_box.set_selected_index((size_t)Gfx::AlignmentRole::TitleAlignment - 1);
+
+    alignment_input.set_only_allow_values_from_model(true);
+    alignment_input.set_model(adopt_ref(*new AlignmentModel()));
+    alignment_input.set_selected_index((size_t)startup_preview_palette.alignment(Gfx::AlignmentRole::TitleAlignment));
+    alignment_input.on_change = [&](auto&, auto& index) {
+        auto role = alignment_combo_box.model()->index(alignment_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_alignment_role();
+        auto preview_palette = preview_widget.preview_palette();
+
+        preview_palette.set_alignment(role, index.data(GUI::ModelRole::Custom).to_text_alignment(Gfx::TextAlignment::CenterLeft));
+        preview_widget.set_preview_palette(preview_palette);
+    };
 
     flag_combo_box.set_model(adopt_ref(*new FlagRoleModel(flag_roles)));
     flag_combo_box.on_change = [&](auto&, auto& index) {

--- a/Userland/Libraries/LibGUI/Variant.cpp
+++ b/Userland/Libraries/LibGUI/Variant.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -48,6 +49,8 @@ const char* to_string(Variant::Type type)
         return "TextAlignment";
     case Variant::Type::ColorRole:
         return "ColorRole";
+    case Variant::Type::AlignmentRole:
+        return "AlignmentRole";
     case Variant::Type::FlagRole:
         return "FlagRole";
     case Variant::Type::MetricRole:
@@ -97,6 +100,12 @@ Variant::Variant(Gfx::ColorRole value)
     : m_type(Type::ColorRole)
 {
     m_value.as_color_role = value;
+}
+
+Variant::Variant(Gfx::AlignmentRole value)
+    : m_type(Type::AlignmentRole)
+{
+    m_value.as_alignment_role = value;
 }
 
 Variant::Variant(Gfx::FlagRole value)
@@ -355,6 +364,9 @@ void Variant::copy_from(const Variant& other)
     case Type::ColorRole:
         m_value.as_color_role = other.m_value.as_color_role;
         break;
+    case Type::AlignmentRole:
+        m_value.as_alignment_role = other.m_value.as_alignment_role;
+        break;
     case Type::FlagRole:
         m_value.as_flag_role = other.m_value.as_flag_role;
         break;
@@ -406,6 +418,8 @@ bool Variant::operator==(const Variant& other) const
         return m_value.as_text_alignment == other.m_value.as_text_alignment;
     case Type::ColorRole:
         return m_value.as_color_role == other.m_value.as_color_role;
+    case Type::AlignmentRole:
+        return m_value.as_alignment_role == other.m_value.as_alignment_role;
     case Type::FlagRole:
         return m_value.as_flag_role == other.m_value.as_flag_role;
     case Type::MetricRole:
@@ -451,6 +465,7 @@ bool Variant::operator<(const Variant& other) const
     case Type::Font:
     case Type::TextAlignment:
     case Type::ColorRole:
+    case Type::AlignmentRole:
     case Type::FlagRole:
     case Type::MetricRole:
     case Type::PathRole:
@@ -512,6 +527,8 @@ String Variant::to_string() const
     }
     case Type::ColorRole:
         return String::formatted("Gfx::ColorRole::{}", Gfx::to_string(m_value.as_color_role));
+    case Type::AlignmentRole:
+        return String::formatted("Gfx::AlignmentRole::{}", Gfx::to_string(m_value.as_alignment_role));
     case Type::FlagRole:
         return String::formatted("Gfx::FlagRole::{}", Gfx::to_string(m_value.as_flag_role));
     case Type::MetricRole:

--- a/Userland/Libraries/LibGUI/Variant.h
+++ b/Userland/Libraries/LibGUI/Variant.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -35,6 +36,7 @@ public:
     Variant(const Gfx::Font&);
     Variant(const Gfx::TextAlignment);
     Variant(const Gfx::ColorRole);
+    Variant(const Gfx::AlignmentRole);
     Variant(const Gfx::FlagRole);
     Variant(const Gfx::MetricRole);
     Variant(const Gfx::PathRole);
@@ -68,6 +70,7 @@ public:
         Font,
         TextAlignment,
         ColorRole,
+        AlignmentRole,
         FlagRole,
         MetricRole,
         PathRole,
@@ -90,6 +93,7 @@ public:
     bool is_font() const { return m_type == Type::Font; }
     bool is_text_alignment() const { return m_type == Type::TextAlignment; }
     bool is_color_role() const { return m_type == Type::ColorRole; }
+    bool is_alignment_role() const { return m_type == Type::AlignmentRole; }
     bool is_flag_role() const { return m_type == Type::FlagRole; }
     bool is_metric_role() const { return m_type == Type::MetricRole; }
     bool is_path_role() const { return m_type == Type::PathRole; }
@@ -254,6 +258,13 @@ public:
         return m_value.as_color_role;
     }
 
+    Gfx::AlignmentRole to_alignment_role() const
+    {
+        if (type() != Type::AlignmentRole)
+            return Gfx::AlignmentRole::NoRole;
+        return m_value.as_alignment_role;
+    }
+
     Gfx::FlagRole to_flag_role() const
     {
         if (type() != Type::FlagRole)
@@ -325,6 +336,7 @@ private:
         Gfx::RGBA32 as_color;
         Gfx::TextAlignment as_text_alignment;
         Gfx::ColorRole as_color_role;
+        Gfx::AlignmentRole as_alignment_role;
         Gfx::FlagRole as_flag_role;
         Gfx::MetricRole as_metric_role;
         Gfx::PathRole as_path_role;

--- a/Userland/Libraries/LibGfx/Palette.cpp
+++ b/Userland/Libraries/LibGfx/Palette.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -55,6 +56,14 @@ void Palette::set_color(ColorRole role, Color color)
         m_impl = m_impl->clone();
     auto& theme = const_cast<SystemTheme&>(impl().theme());
     theme.color[(int)role] = color.value();
+}
+
+void Palette::set_alignment(AlignmentRole role, Gfx::TextAlignment value)
+{
+    if (m_impl->ref_count() != 1)
+        m_impl = m_impl->clone();
+    auto& theme = const_cast<SystemTheme&>(impl().theme());
+    theme.alignment[(int)role] = value;
 }
 
 void Palette::set_flag(FlagRole role, bool value)

--- a/Userland/Libraries/LibGfx/Palette.h
+++ b/Userland/Libraries/LibGfx/Palette.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -29,6 +30,12 @@ public:
     {
         VERIFY((int)role < (int)ColorRole::__Count);
         return Color::from_rgba(theme().color[(int)role]);
+    }
+
+    Gfx::TextAlignment alignment(AlignmentRole role) const
+    {
+        VERIFY((int)role < (int)AlignmentRole::__Count);
+        return theme().alignment[(int)role];
     }
 
     bool flag(FlagRole role) const
@@ -125,8 +132,9 @@ public:
     Color syntax_preprocessor_statement() const { return color(ColorRole::SyntaxPreprocessorStatement); }
     Color syntax_preprocessor_value() const { return color(ColorRole::SyntaxPreprocessorValue); }
 
+    Gfx::TextAlignment title_alignment() const { return alignment(AlignmentRole::TitleAlignment); }
+
     bool is_dark() const { return flag(FlagRole::IsDark); }
-    bool is_title_center() const { return flag(FlagRole::IsTitleCenter); }
 
     int window_border_thickness() const { return metric(MetricRole::BorderThickness); }
     int window_border_radius() const { return metric(MetricRole::BorderRadius); }
@@ -142,11 +150,13 @@ public:
     String tooltip_shadow_path() const { return path(PathRole::TooltipShadow); }
 
     Color color(ColorRole role) const { return m_impl->color(role); }
+    Gfx::TextAlignment alignment(AlignmentRole role) const { return m_impl->alignment(role); }
     bool flag(FlagRole role) const { return m_impl->flag(role); }
     int metric(MetricRole role) const { return m_impl->metric(role); }
     String path(PathRole role) const { return m_impl->path(role); }
 
     void set_color(ColorRole, Color);
+    void set_alignment(AlignmentRole, Gfx::TextAlignment);
     void set_flag(FlagRole, bool);
     void set_metric(MetricRole, int);
     void set_path(PathRole, String);

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -45,6 +46,29 @@ Core::AnonymousBuffer load_system_theme(Core::ConfigFile const& file)
         return file.read_bool_entry("Flags", name, false);
     };
 
+    auto get_alignment = [&](auto& name, auto role) {
+        auto alignment = file.read_entry("Alignments", name).to_lowercase();
+        if (alignment.is_empty()) {
+            switch (role) {
+            case (int)AlignmentRole::TitleAlignment:
+                return Gfx::TextAlignment::CenterLeft;
+            default:
+                dbgln("Alignment {} has no fallback value!", name);
+                return Gfx::TextAlignment::CenterLeft;
+            }
+        }
+
+        if (alignment == "left" || alignment == "centerleft")
+            return Gfx::TextAlignment::CenterLeft;
+        else if (alignment == "right" || alignment == "centerright")
+            return Gfx::TextAlignment::CenterRight;
+        else if (alignment == "center")
+            return Gfx::TextAlignment::Center;
+
+        dbgln("Alignment {} has an invalid value!", name);
+        return Gfx::TextAlignment::CenterLeft;
+    };
+
     auto get_metric = [&](auto& name, auto role) {
         int metric = file.read_num_entry("Metrics", name, -1);
         if (metric == -1) {
@@ -85,6 +109,12 @@ Core::AnonymousBuffer load_system_theme(Core::ConfigFile const& file)
     data->color[(int)ColorRole::role] = get_color(#role).value();
     ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
 #undef __ENUMERATE_COLOR_ROLE
+
+#undef __ENUMERATE_ALIGNMENT_ROLE
+#define __ENUMERATE_ALIGNMENT_ROLE(role) \
+    data->alignment[(int)AlignmentRole::role] = get_alignment(#role, (int)AlignmentRole::role);
+    ENUMERATE_ALIGNMENT_ROLES(__ENUMERATE_ALIGNMENT_ROLE)
+#undef __ENUMERATE_ALIGNMENT_ROLE
 
 #undef __ENUMERATE_FLAG_ROLE
 #define __ENUMERATE_FLAG_ROLE(role) \

--- a/Userland/Libraries/LibGfx/SystemTheme.h
+++ b/Userland/Libraries/LibGfx/SystemTheme.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,6 +14,7 @@
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ConfigFile.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/TextAlignment.h>
 
 namespace Gfx {
 
@@ -90,9 +92,11 @@ namespace Gfx {
     C(Window)                      \
     C(WindowText)
 
+#define ENUMERATE_ALIGNMENT_ROLES(C) \
+    C(TitleAlignment)
+
 #define ENUMERATE_FLAG_ROLES(C) \
-    C(IsDark)                   \
-    C(IsTitleCenter)
+    C(IsDark)
 
 #define ENUMERATE_METRIC_ROLES(C) \
     C(BorderThickness)            \
@@ -134,6 +138,33 @@ inline const char* to_string(ColorRole role)
         return #role;
         ENUMERATE_COLOR_ROLES(__ENUMERATE_COLOR_ROLE)
 #undef __ENUMERATE_COLOR_ROLE
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+enum class AlignmentRole {
+    NoRole,
+
+#undef __ENUMERATE_ALIGNMENT_ROLE
+#define __ENUMERATE_ALIGNMENT_ROLE(role) role,
+    ENUMERATE_ALIGNMENT_ROLES(__ENUMERATE_ALIGNMENT_ROLE)
+#undef __ENUMERATE_ALIGNMENT_ROLE
+
+        __Count,
+};
+
+inline const char* to_string(AlignmentRole role)
+{
+    switch (role) {
+    case AlignmentRole::NoRole:
+        return "NoRole";
+#undef __ENUMERATE_ALIGNMENT_ROLE
+#define __ENUMERATE_ALIGNMENT_ROLE(role) \
+    case AlignmentRole::role:            \
+        return #role;
+        ENUMERATE_ALIGNMENT_ROLES(__ENUMERATE_ALIGNMENT_ROLE)
+#undef __ENUMERATE_ALIGNMENT_ROLE
     default:
         VERIFY_NOT_REACHED();
     }
@@ -222,6 +253,7 @@ inline const char* to_string(PathRole role)
 
 struct SystemTheme {
     RGBA32 color[(int)ColorRole::__Count];
+    Gfx::TextAlignment alignment[(int)AlignmentRole::__Count];
     bool flag[(int)FlagRole::__Count];
     int metric[(int)MetricRole::__Count];
     char path[(int)PathRole::__Count][256]; // TODO: PATH_MAX?


### PR DESCRIPTION
This PR adds an `Alignment` section to the theming engine that supports `Left`, `Right` & `Center` as possible values.
It currently uses `Gfx::TextAlignment` but we might want to (in the future) instead add a `Gfx::Alignment` property only including `Left`, `Right` & `Center` that `Gfx::TextAlignment` can extend. I'll leave that up to one of my next PRs.

![image](https://user-images.githubusercontent.com/1370209/147857011-bc3fee7a-ce3c-4d71-ada6-80d724841188.png)
_for demonstration purposes only, the title for the default theme obviously remains left-aligned_

## TODOs
- [x] Add alignment functionality to the ThemeEditor