### PR TITLE
LibGfx: Remove VERIFY in draw_rect_with_thickness (HOTFIX)

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -593,8 +593,6 @@ void Painter::draw_rect(IntRect const& a_rect, Color color, bool rough)
 
 void Painter::draw_rect_with_thickness(IntRect const& rect, Color color, int thickness)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
     if (thickness <= 0)
         return;
 


### PR DESCRIPTION
draw_line with thickness already supports scaling so that verify isn't needed anymore. This fixes a scaling crash introduced in 8a1d77f.