### PR TITLE
Calculator: Fix crash caused by small numbers

### DIFF
--- a/Userland/Applications/Calculator/Calculator.h
+++ b/Userland/Applications/Calculator/Calculator.h
@@ -47,6 +47,22 @@ public:
     void clear_error() { m_has_error = false; }
 
 private:
+    static bool should_be_rounded(KeypadValue);
+    static void round(KeypadValue&);
+
+    static constexpr auto rounding_threshold = []() consteval
+    {
+        using used_type = u64;
+
+        auto count = 1;
+        used_type res = 10;
+        while (!__builtin_mul_overflow(res, (used_type)10, &res)) {
+            count++;
+        }
+        return count;
+    }
+    ();
+
     Operation m_operation_in_progress { Operation::None };
     KeypadValue m_saved_argument { (i64)0 };
     KeypadValue m_mem { (i64)0 };

--- a/Userland/Applications/Calculator/KeypadValue.cpp
+++ b/Userland/Applications/Calculator/KeypadValue.cpp
@@ -10,7 +10,7 @@
 
 KeypadValue::KeypadValue(i64 value, u8 decimal_places)
     : m_value(value)
-    , m_decimal_places(decimal_places)
+    , m_decimal_places(value == 0 ? 0 : decimal_places)
 {
 }
 

--- a/Userland/Applications/Calculator/KeypadValue.h
+++ b/Userland/Applications/Calculator/KeypadValue.h
@@ -24,7 +24,6 @@ public:
     KeypadValue operator*(KeypadValue const&);
     KeypadValue operator-(void) const;
     bool operator<(KeypadValue const&);
-    bool operator>(KeypadValue const&);
     bool operator==(KeypadValue const&);
 
     KeypadValue sqrt() const;

--- a/Userland/Applications/Calculator/KeypadValue.h
+++ b/Userland/Applications/Calculator/KeypadValue.h
@@ -12,6 +12,7 @@
 
 class KeypadValue {
     friend class Keypad;
+    friend class Calculator;
 
 public:
     KeypadValue(i64, u8);


### PR DESCRIPTION
As mentioned in #10685, the Calculator encounters some crash when dealing with edge values.

This patch should handle small values by rounding them.



