### PR TITLE
AK: Fix UFixedBigInt comparison operators

### DIFF
--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -135,32 +135,32 @@ public:
         return m_low || m_high;
     }
     template<Unsigned U>
-    requires(sizeof(T) >= sizeof(U)) constexpr bool operator==(const T& other) const
+    requires(sizeof(T) >= sizeof(U)) constexpr bool operator==(const U& other) const
     {
         return !m_high && m_low == other;
     }
     template<Unsigned U>
-    requires(sizeof(T) >= sizeof(U)) constexpr bool operator!=(const T& other) const
+    requires(sizeof(T) >= sizeof(U)) constexpr bool operator!=(const U& other) const
     {
         return m_high || m_low != other;
     }
     template<Unsigned U>
-    requires(sizeof(T) >= sizeof(U)) constexpr bool operator>(const T& other) const
+    requires(sizeof(T) >= sizeof(U)) constexpr bool operator>(const U& other) const
     {
         return m_high || m_low > other;
     }
     template<Unsigned U>
-    requires(sizeof(T) >= sizeof(U)) constexpr bool operator<(const T& other) const
+    requires(sizeof(T) >= sizeof(U)) constexpr bool operator<(const U& other) const
     {
         return !m_high && m_low < other;
     }
     template<Unsigned U>
-    requires(sizeof(T) >= sizeof(U)) constexpr bool operator>=(const T& other) const
+    requires(sizeof(T) >= sizeof(U)) constexpr bool operator>=(const U& other) const
     {
         return *this == other || *this > other;
     }
     template<Unsigned U>
-    requires(sizeof(T) >= sizeof(U)) constexpr bool operator<=(const T& other) const
+    requires(sizeof(T) >= sizeof(U)) constexpr bool operator<=(const U& other) const
     {
         return *this == other || *this < other;
     }


### PR DESCRIPTION
Instead of using the specified type U like we want, 
we were using the type T all along when comparing
with smaller integers. This is now fixed.