### PR TITLE
Reorder sections in BuildInstructions.md

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -32,17 +32,16 @@ Note that you might need additional dev packages:
 ```console
 sudo apt install libgtk-3-dev libpixman-1-dev libsdl2-dev libspice-server-dev
 ```
-
-### Windows
-
-If you're on Windows you can use WSL2 to build SerenityOS. Please have a look at the [Windows guide](BuildInstructionsWindows.md)
-for details.
-
 ### Arch Linux / Manjaro
 
 ```console
 sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu qemu-arch-extra ccache rsync unzip
 ```
+
+### Windows
+
+If you're on Windows you can use WSL2 to build SerenityOS. Please have a look at the [Windows guide](BuildInstructionsWindows.md)
+for details.
 
 ### Other systems
 


### PR DESCRIPTION
Old order: 
- Debian / Ubuntu
- Windows
- Arch Linux / Manjaro

New order: 
- Debian / Ubuntu
- Arch Linux / Manjaro
- Windows