### PR TITLE
Base: Add icons to man pages for GUI applications

### DIFF
--- a/Base/usr/share/man/man1/Eyes.md
+++ b/Base/usr/share/man/man1/Eyes.md
@@ -1,6 +1,6 @@
 ## Name
 
-Eyes
+### ![Icon](/res/icons/16x16/app-eyes.png) Eyes
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/FontEditor.md
+++ b/Base/usr/share/man/man1/FontEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-FontEditor - Serenity font editor
+### ![Icon](/res/icons/16x16/app-font-editor.png) FontEditor - Serenity font editor
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Help.md
+++ b/Base/usr/share/man/man1/Help.md
@@ -1,6 +1,6 @@
 ## Name
 
-Help
+### ![Icon](/res/icons/16x16/app-help.png) Help
 
 ## Synopsis
 
@@ -59,5 +59,5 @@ this man page should be located at `/usr/share/man/man1/Help.md`.
 
 ## See Also
 
-* [`man`(1)](man.md) To read these same man pages from the terminal
+* [`man`(1)](help://man/1/man) To read these same man pages from the terminal
 

--- a/Base/usr/share/man/man1/ImageViewer.md
+++ b/Base/usr/share/man/man1/ImageViewer.md
@@ -1,6 +1,6 @@
 ## Name
 
-Image Viewer - SerenityOS image viewer
+### ![Icon](/res/icons/16x16/filetype-image.png) ImageViewer - SerenityOS image viewer
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Inspector.md
+++ b/Base/usr/share/man/man1/Inspector.md
@@ -1,6 +1,6 @@
 ## Name
 
-Inspector - Serenity process inspector
+### ![Icon](/res/icons/16x16/app-inspector.png) Inspector - Serenity process inspector
 
 ## Synopsis
 
@@ -26,4 +26,3 @@ via UNIX socket.
 ```sh
 $ Inspector $(pidof Shell)
 ```
-

--- a/Base/usr/share/man/man1/Mail.md
+++ b/Base/usr/share/man/man1/Mail.md
@@ -1,6 +1,6 @@
 ## Name
 
-Mail - Serenity e-mail client
+### ![Icon](/res/icons/16x16/app-mail.png) Mail - Serenity e-mail client
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Playground.md
+++ b/Base/usr/share/man/man1/Playground.md
@@ -1,6 +1,6 @@
 ## Name
 
-Playground - GUI Markup Language (GML) editor
+### ![Icon](/res/icons/16x16/app-playground.png) Playground - GUI Markup Language (GML) editor
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/Profiler.md
+++ b/Base/usr/share/man/man1/Profiler.md
@@ -1,6 +1,8 @@
 ## Name
 
-Profiler - Serenity process profiler
+### ![Icon](/res/icons/16x16/app-profiler.png) Profiler - Serenity process profiler
+
+[Open](file:///bin/Profiler)
 
 ## Synopsis
 
@@ -47,5 +49,5 @@ $ Profiler perfcore.123
 
 ## See also
 
-* [`perfcore`(5)](../man5/perfcore.md)
+* [`perfcore`(5)](help://man/5/perfcore)
 

--- a/Base/usr/share/man/man1/Terminal.md
+++ b/Base/usr/share/man/man1/Terminal.md
@@ -1,6 +1,6 @@
 ## Name
 
-Terminal - Serenity terminal emulator
+### ![Icon](/res/icons/16x16/app-terminal.png) Terminal - Serenity terminal emulator
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/TextEditor.md
+++ b/Base/usr/share/man/man1/TextEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-TextEditor - SerenityOS text editor
+### ![Icon](/res/icons/16x16/app-text-editor.png) TextEditor - SerenityOS text editor
 
 ## Synopsis
 


### PR DESCRIPTION
Differentiate terminal and GUI applications with icons next to the name of the application within the man pages of the Help application. I removed the short descriptions after the name of the application as they all seemed to be contained within the description and I feel it helps differentiate them better.

As suggested when @jntrnr revisited Serenity: https://youtu.be/_QAsHkEKvN0?t=480

Example of a GUI application:
<img width="578" alt="Screen Shot 2022-01-04 at 18 28 37" src="https://user-images.githubusercontent.com/4368524/148137740-f3e13823-64a8-45bb-aec7-1c56704061e8.png">

Verses a terminal application:
<img width="784" alt="Screen Shot 2022-01-02 at 01 44 22" src="https://user-images.githubusercontent.com/4368524/147868382-03b138d6-b1ad-41bf-8bc2-d14d5af1b912.png">