### PR TITLE
AK: Include `utility` from the STD if we aren't replacing STD

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -45,6 +45,8 @@ constexpr T&& move(T& arg)
 }
 
 }
+#else
+#include <utility>
 #endif
 // clang-format on
 


### PR DESCRIPTION
If we didn't define our own `move` and `forward` and inject it into the `std` namespace, then we would error just after trying to `using` those, if no one has included it before.
Now, we will include `utility` from the STD if we aren't replacing the `std`.