### PR TITLE
[RFC] Improve `TypedTransfer`

### DIFF
--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -187,6 +187,8 @@ private:
 template<typename T, typename ChunkType = Vector<T>>
 class DisjointChunks {
 public:
+    using Transfer = TypedTransfer<T>;
+
     DisjointChunks() = default;
     ~DisjointChunks() = default;
     DisjointChunks(DisjointChunks const&) = default;
@@ -313,7 +315,7 @@ public:
                 ChunkType new_chunk;
                 if constexpr (IsTriviallyConstructible<T>) {
                     new_chunk.resize(wanted_slice.size());
-                    TypedTransfer<T>::move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
+                    Transfer::move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
                 } else {
                     new_chunk.ensure_capacity(wanted_slice.size());
                     for (auto& entry : wanted_slice)

--- a/AK/DisjointChunks.h
+++ b/AK/DisjointChunks.h
@@ -315,7 +315,7 @@ public:
                 ChunkType new_chunk;
                 if constexpr (IsTriviallyConstructible<T>) {
                     new_chunk.resize(wanted_slice.size());
-                    Transfer::move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
+                    Transfer::uninitialized_move(new_chunk.data(), wanted_slice.data(), wanted_slice.size());
                 } else {
                     new_chunk.ensure_capacity(wanted_slice.size());
                     for (auto& entry : wanted_slice)

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -24,8 +24,7 @@ public:
     {
         if (m_size != 0) {
             m_elements = static_cast<T*>(kmalloc_array(m_size, sizeof(T)));
-            for (size_t i = 0; i < m_size; ++i)
-                new (&m_elements[i]) T();
+            Transfer::construct(m_elements, m_size);
         }
     }
     ~FixedArray()

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -38,7 +38,7 @@ public:
     {
         if (m_size != 0) {
             m_elements = static_cast<T*>(kmalloc_array(m_size, sizeof(T)));
-            Transfer::copy(data(), other.data(), other.size());
+            Transfer::uninitialized_copy(data(), other.data(), other.size());
         }
     }
 

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -55,8 +55,7 @@ public:
     {
         if (!m_elements)
             return;
-        for (size_t i = 0; i < m_size; ++i)
-            m_elements[i].~T();
+        Transfer::destroy(m_elements, m_size);
         kfree_sized(m_elements, sizeof(T) * m_size);
         m_elements = nullptr;
         m_size = 0;

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -8,6 +8,7 @@
 
 #include <AK/Iterator.h>
 #include <AK/Span.h>
+#include <AK/TypedTransfer.h>
 #include <AK/kmalloc.h>
 
 namespace AK {
@@ -15,6 +16,8 @@ namespace AK {
 template<typename T>
 class FixedArray {
 public:
+    using Transfer = TypedTransfer<T>;
+
     FixedArray() = default;
     explicit FixedArray(size_t size)
         : m_size(size)
@@ -35,8 +38,7 @@ public:
     {
         if (m_size != 0) {
             m_elements = static_cast<T*>(kmalloc_array(m_size, sizeof(T)));
-            for (size_t i = 0; i < m_size; ++i)
-                new (&m_elements[i]) T(other[i]);
+            Transfer::copy(data(), other.data(), other.size());
         }
     }
 

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -152,14 +152,14 @@ public:
     ALWAYS_INLINE constexpr size_t copy_to(Span<RemoveConst<T>> other) const
     {
         VERIFY(other.size() >= size());
-        decltype(other)::Transfer::copy(other.data(), data(), size());
+        decltype(other)::Transfer::uninitialized_copy(other.data(), data(), size());
         return size();
     }
 
     ALWAYS_INLINE constexpr size_t copy_trimmed_to(Span<RemoveConst<T>> other) const
     {
         auto const count = min(size(), other.size());
-        decltype(other)::Transfer::copy(other.data(), data(), count);
+        decltype(other)::Transfer::uninitialized_copy(other.data(), data(), count);
         return count;
     }
 

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -90,6 +90,8 @@ protected:
 template<typename T>
 class Span : public Detail::Span<T> {
 public:
+    using Transfer = TypedTransfer<T>;
+
     using Detail::Span<T>::Span;
 
     constexpr Span() = default;
@@ -150,13 +152,13 @@ public:
     ALWAYS_INLINE constexpr size_t copy_to(Span<RemoveConst<T>> other) const
     {
         VERIFY(other.size() >= size());
-        return TypedTransfer<RemoveConst<T>>::copy(other.data(), data(), size());
+        return decltype(other)::Transfer::copy(other.data(), data(), size());
     }
 
     ALWAYS_INLINE constexpr size_t copy_trimmed_to(Span<RemoveConst<T>> other) const
     {
         auto const count = min(size(), other.size());
-        return TypedTransfer<RemoveConst<T>>::copy(other.data(), data(), count);
+        return decltype(other)::Transfer::copy(other.data(), data(), count);
     }
 
     ALWAYS_INLINE constexpr size_t fill(T const& value)
@@ -181,7 +183,7 @@ public:
         if (size() < other.size())
             return false;
 
-        return TypedTransfer<T>::compare(data(), other.data(), other.size());
+        return Transfer::compare(data(), other.data(), other.size());
     }
 
     [[nodiscard]] ALWAYS_INLINE constexpr T const& at(size_t index) const
@@ -211,7 +213,7 @@ public:
         if (size() != other.size())
             return false;
 
-        return TypedTransfer<T>::compare(data(), other.data(), size());
+        return Transfer::compare(data(), other.data(), size());
     }
 
     ALWAYS_INLINE constexpr operator Span<T const>() const

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -152,13 +152,15 @@ public:
     ALWAYS_INLINE constexpr size_t copy_to(Span<RemoveConst<T>> other) const
     {
         VERIFY(other.size() >= size());
-        return decltype(other)::Transfer::copy(other.data(), data(), size());
+        decltype(other)::Transfer::copy(other.data(), data(), size());
+        return size();
     }
 
     ALWAYS_INLINE constexpr size_t copy_trimmed_to(Span<RemoveConst<T>> other) const
     {
         auto const count = min(size(), other.size());
-        return decltype(other)::Transfer::copy(other.data(), data(), count);
+        decltype(other)::Transfer::copy(other.data(), data(), count);
+        return count;
     }
 
     ALWAYS_INLINE constexpr size_t fill(T const& value)

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -185,7 +185,7 @@ public:
         if (size() < other.size())
             return false;
 
-        return Transfer::compare(data(), other.data(), other.size());
+        return Transfer::equals(data(), other.data(), other.size());
     }
 
     [[nodiscard]] ALWAYS_INLINE constexpr T const& at(size_t index) const
@@ -215,7 +215,7 @@ public:
         if (size() != other.size())
             return false;
 
-        return Transfer::compare(data(), other.data(), size());
+        return Transfer::equals(data(), other.data(), size());
     }
 
     ALWAYS_INLINE constexpr operator Span<T const>() const

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -31,17 +31,17 @@ public:
         }
     }
 
-    static size_t copy(T* destination, const T* source, size_t count)
+    static void copy(T* destination, const T* source, size_t count)
     {
         if (count == 0)
-            return 0;
+            return;
 
         if constexpr (Traits<T>::is_trivial()) {
             if (count == 1)
                 *destination = *source;
             else
                 __builtin_memmove(destination, source, count * sizeof(T));
-            return count;
+            return;
         }
 
         for (size_t i = 0; i < count; ++i) {
@@ -50,8 +50,6 @@ public:
             else
                 new (&destination[count - i - 1]) T(source[count - i - 1]);
         }
-
-        return count;
     }
 
     static bool compare(const T* a, const T* b, size_t count)

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -36,7 +36,7 @@ private:
     }
 
 public:
-    static void copy(T* destination, auto const* source, size_t count)
+    static void uninitialized_copy(T* destination, auto const* source, size_t count)
     {
         move_impl(destination, source, count, [](T* destination, auto const* source) { ::new (destination) T(*source); });
     }

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -64,6 +64,17 @@ public:
         move_impl(destination, source, count, [](T* destination, auto* source) { construct_at(destination, std::move(*source)); });
     }
 
+    static void destroy(T* destination, size_t count)
+    {
+        for_each(destination, count, destroy_at);
+    }
+
+    static void destroy_at(T* destination)
+    {
+        if constexpr (!Traits<T>::is_trivial()) // FIXME: is_trivially_destructible
+            destination->~T();
+    }
+
     static bool equals(const T* a, const T* b, size_t count)
     {
         if (count == 0)

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -46,7 +46,7 @@ public:
         move_impl(destination, source, count, [](T* destination, auto* source) { ::new (destination) T(std::move(*source)); });
     }
 
-    static bool compare(const T* a, const T* b, size_t count)
+    static bool equals(const T* a, const T* b, size_t count)
     {
         if (count == 0)
             return true;

--- a/AK/TypedTransfer.h
+++ b/AK/TypedTransfer.h
@@ -41,7 +41,7 @@ public:
         move_impl(destination, source, count, [](T* destination, auto const* source) { ::new (destination) T(*source); });
     }
 
-    static void move(T* destination, auto* source, size_t count)
+    static void uninitialized_move(T* destination, auto* source, size_t count)
     {
         move_impl(destination, source, count, [](T* destination, auto* source) { ::new (destination) T(std::move(*source)); });
     }

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -460,7 +460,7 @@ public:
         TRY(try_grow_capacity(size() + 1));
         ++m_size;
         if constexpr (Traits<StorageType>::is_trivial()) {
-            Transfer::move(slot(index + 1), slot(index), m_size - index - 1);
+            Transfer::uninitialized_move(slot(index + 1), slot(index), m_size - index - 1);
         } else {
             for (size_t i = size() - 1; i > index; --i) {
                 new (slot(i)) StorageType(move(at(i - 1)));
@@ -500,7 +500,7 @@ public:
         auto other_size = other.size();
         Vector tmp = move(other);
         TRY(try_grow_capacity(size() + other_size));
-        Transfer::move(data() + m_size, tmp.data(), other_size);
+        Transfer::uninitialized_move(data() + m_size, tmp.data(), other_size);
         m_size += other_size;
         return {};
     }
@@ -573,7 +573,7 @@ public:
         }
 
         Vector tmp = move(other);
-        Transfer::move(slot(0), tmp.data(), tmp.size());
+        Transfer::uninitialized_move(slot(0), tmp.data(), tmp.size());
         m_size += other_size;
         return {};
     }
@@ -583,7 +583,7 @@ public:
         if (count == 0)
             return {};
         TRY(try_grow_capacity(size() + count));
-        Transfer::move(slot(count), slot(0), m_size);
+        Transfer::uninitialized_move(slot(count), slot(0), m_size);
         Transfer::uninitialized_copy(slot(0), values, count);
         m_size += count;
         return {};

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -181,7 +181,7 @@ public:
     {
         if (m_size != other.size())
             return false;
-        return Transfer::compare(data(), other.data(), size());
+        return Transfer::equals(data(), other.data(), size());
     }
 
     bool contains_slow(T const& value) const

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -86,7 +86,7 @@ public:
     Vector(Vector const& other)
     {
         ensure_capacity(other.size());
-        Transfer::copy(data(), other.data(), other.size());
+        Transfer::uninitialized_copy(data(), other.data(), other.size());
         m_size = other.size();
     }
 
@@ -94,7 +94,7 @@ public:
     Vector(Vector<T, other_inline_capacity> const& other)
     {
         ensure_capacity(other.size());
-        Transfer::copy(data(), other.data(), other.size());
+        Transfer::uninitialized_copy(data(), other.data(), other.size());
         m_size = other.size();
     }
 
@@ -260,7 +260,7 @@ public:
         if (count == 0)
             return;
         VERIFY((size() + count) <= capacity());
-        Transfer::copy(slot(m_size), values, count);
+        Transfer::uninitialized_copy(slot(m_size), values, count);
         m_size += count;
     }
 
@@ -314,7 +314,7 @@ public:
         if (this != &other) {
             clear();
             ensure_capacity(other.size());
-            Transfer::copy(data(), other.data(), other.size());
+            Transfer::uninitialized_copy(data(), other.data(), other.size());
             m_size = other.size();
         }
         return *this;
@@ -325,7 +325,7 @@ public:
     {
         clear();
         ensure_capacity(other.size());
-        Transfer::copy(data(), other.data(), other.size());
+        Transfer::uninitialized_copy(data(), other.data(), other.size());
         m_size = other.size();
         return *this;
     }
@@ -352,7 +352,7 @@ public:
         VERIFY(index < m_size);
 
         if constexpr (Traits<StorageType>::is_trivial()) {
-            Transfer::copy(slot(index), slot(index + 1), m_size - index - 1);
+            Transfer::uninitialized_copy(slot(index), slot(index + 1), m_size - index - 1);
         } else {
             at(index).~StorageType();
             for (size_t i = index + 1; i < m_size; ++i) {
@@ -372,7 +372,7 @@ public:
         VERIFY(index + count <= m_size);
 
         if constexpr (Traits<StorageType>::is_trivial()) {
-            Transfer::copy(slot(index), slot(index + count), m_size - index - count);
+            Transfer::uninitialized_copy(slot(index), slot(index + count), m_size - index - count);
         } else {
             for (size_t i = index; i < index + count; i++)
                 at(i).~StorageType();
@@ -508,7 +508,7 @@ public:
     ErrorOr<void> try_extend(Vector const& other)
     {
         TRY(try_grow_capacity(size() + other.size()));
-        Transfer::copy(data() + m_size, other.data(), other.size());
+        Transfer::uninitialized_copy(data() + m_size, other.data(), other.size());
         m_size += other.m_size;
         return {};
     }
@@ -534,7 +534,7 @@ public:
         if (count == 0)
             return {};
         TRY(try_grow_capacity(size() + count));
-        Transfer::copy(slot(m_size), values, count);
+        Transfer::uninitialized_copy(slot(m_size), values, count);
         m_size += count;
         return {};
     }
@@ -584,7 +584,7 @@ public:
             return {};
         TRY(try_grow_capacity(size() + count));
         Transfer::move(slot(count), slot(0), m_size);
-        Transfer::copy(slot(0), values, count);
+        Transfer::uninitialized_copy(slot(0), values, count);
         m_size += count;
         return {};
     }
@@ -606,7 +606,7 @@ public:
             return Error::from_errno(ENOMEM);
 
         if constexpr (Traits<StorageType>::is_trivial()) {
-            Transfer::copy(new_buffer, data(), m_size);
+            Transfer::uninitialized_copy(new_buffer, data(), m_size);
         } else {
             for (size_t i = 0; i < m_size; ++i) {
                 new (&new_buffer[i]) StorageType(move(at(i)));

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -371,11 +371,10 @@ public:
         VERIFY(index + count > index);
         VERIFY(index + count <= m_size);
 
+        TypedTransfer<StorageType>::destroy(slot(index), count);
         if constexpr (Traits<StorageType>::is_trivial()) {
             Transfer::uninitialized_copy(slot(index), slot(index + count), m_size - index - count);
         } else {
-            for (size_t i = index; i < index + count; i++)
-                at(i).~StorageType();
             for (size_t i = index + count; i < m_size; ++i) {
                 new (slot(i - count)) StorageType(move(at(i)));
                 at(i).~StorageType();
@@ -664,8 +663,7 @@ public:
             return;
         }
 
-        for (size_t i = new_size; i < size(); ++i)
-            at(i).~StorageType();
+        TypedTransfer<StorageType>::destroy(slot(new_size), size() - new_size);
         m_size = new_size;
     }
 

--- a/Tests/AK/TestTypedTransfer.cpp
+++ b/Tests/AK/TestTypedTransfer.cpp
@@ -23,7 +23,7 @@ TEST_CASE(overlapping_source_and_destination_1)
     const Array<NonPrimitiveIntWrapper, 6> expected { 3, 4, 5, 6, 5, 6 };
 
     Array<NonPrimitiveIntWrapper, 6> actual { 1, 2, 3, 4, 5, 6 };
-    AK::TypedTransfer<NonPrimitiveIntWrapper>::copy(actual.data(), actual.data() + 2, 4);
+    AK::TypedTransfer<NonPrimitiveIntWrapper>::uninitialized_copy(actual.data(), actual.data() + 2, 4);
 
     for (size_t i = 0; i < 6; ++i)
         EXPECT_EQ(actual[i].m_value, expected[i].m_value);
@@ -34,7 +34,7 @@ TEST_CASE(overlapping_source_and_destination_2)
     const Array<NonPrimitiveIntWrapper, 6> expected { 1, 2, 1, 2, 3, 4 };
 
     Array<NonPrimitiveIntWrapper, 6> actual { 1, 2, 3, 4, 5, 6 };
-    AK::TypedTransfer<NonPrimitiveIntWrapper>::copy(actual.data() + 2, actual.data(), 4);
+    AK::TypedTransfer<NonPrimitiveIntWrapper>::uninitialized_copy(actual.data() + 2, actual.data(), 4);
 
     for (size_t i = 0; i < 6; ++i)
         EXPECT_EQ(actual[i].m_value, expected[i].m_value);


### PR DESCRIPTION
Hi,

This is a preview of my effort at improving AK template library regarding `TypedTransfer`.
I think it use less confusing names, and adds more helper abstraction.

And here come the reason of the RFC: should I continue to extend the `TypedTransfer` API ?

I mean it is an interesting concepts but it has a major flow, it impose a raw pointer type to a contiguous memory block. If that functionality existed free functions we could use iterators instead. And by doing so, in what (new?) header should I move these functions?