### PR TITLE
Calculator: Use Checked to perform safe calculation

### DIFF
--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -277,6 +277,11 @@ public:
         return old;
     }
 
+    constexpr Checked operator-() const
+    {
+        return Checked { -m_value };
+    }
+
     template<typename U, typename V>
     [[nodiscard]] static constexpr bool addition_would_overflow(U u, V v)
     {

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -469,7 +469,22 @@ constexpr Checked<T> make_checked(T value)
     return Checked<T>(value);
 }
 
+template<typename T>
+constexpr Checked<T> pow(Checked<T> base, Checked<T> exponent)
+{
+    if (exponent == T { 0 })
+        return { 1 };
+    VERIFY(exponent > T { 0 });
+
+    auto res = base;
+    for (T i = 0; i < (exponent - T { 1 }); i++)
+        res *= base;
+
+    return res;
+}
+
 }
 
 using AK::Checked;
 using AK::make_checked;
+using AK::pow;

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -423,6 +423,42 @@ constexpr bool operator!=(T a, const Checked<T>& b)
 }
 
 template<typename T>
+constexpr bool operator<(const Checked<T>& a, const Checked<T>& b)
+{
+    return a.value() < b.value();
+}
+
+template<typename T>
+constexpr bool operator>(const Checked<T>& a, const Checked<T>& b)
+{
+    return a.value() > b.value();
+}
+
+template<typename T>
+constexpr bool operator>=(const Checked<T>& a, const Checked<T>& b)
+{
+    return a.value() >= b.value();
+}
+
+template<typename T>
+constexpr bool operator<=(const Checked<T>& a, const Checked<T>& b)
+{
+    return a.value() <= b.value();
+}
+
+template<typename T>
+constexpr bool operator==(const Checked<T>& a, const Checked<T>& b)
+{
+    return a.value() == b.value();
+}
+
+template<typename T>
+constexpr bool operator!=(const Checked<T>& a, const Checked<T>& b)
+{
+    return a.value() != b.value();
+}
+
+template<typename T>
 constexpr Checked<T> make_checked(T value)
 {
     return Checked<T>(value);

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -183,6 +183,15 @@ public:
         m_overflow |= __builtin_mul_overflow(m_value, other, &m_value);
     }
 
+    constexpr void mod(T other)
+    {
+        if (other == 0) {
+            m_overflow = true;
+            return;
+        }
+        m_value %= other;
+    }
+
     constexpr void div(T other)
     {
         if constexpr (IsSigned<T>) {
@@ -352,6 +361,94 @@ constexpr Checked<T> operator/(const Checked<T>& a, const Checked<T>& b)
 {
     Checked<T> c { a };
     c.div(b.value());
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator%(const Checked<T>& a, const Checked<T>& b)
+{
+    Checked<T> c { a.value() };
+    c.mod(b.value());
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator+(T a, const Checked<T>& b)
+{
+    Checked<T> c { a };
+    c.add(b.value());
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator-(T a, const Checked<T>& b)
+{
+    Checked<T> c { a };
+    c.sub(b.value());
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator*(T a, const Checked<T>& b)
+{
+    Checked<T> c { a };
+    c.mul(b.value());
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator/(T a, const Checked<T>& b)
+{
+    Checked<T> c { a };
+    c.div(b.value());
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator%(T a, const Checked<T>& b)
+{
+    Checked<T> c { a };
+    c.mod(b.value());
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator+(const Checked<T>& a, T b)
+{
+    Checked<T> c { a };
+    c.add(b);
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator-(const Checked<T>& a, T b)
+{
+    Checked<T> c { a };
+    c.sub(b);
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator*(const Checked<T>& a, T b)
+{
+    Checked<T> c { a };
+    c.mul(b);
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator/(const Checked<T>& a, T b)
+{
+    Checked<T> c { a };
+    c.div(b);
+    return c;
+}
+
+template<typename T>
+constexpr Checked<T> operator%(const Checked<T>& a, T b)
+{
+    Checked<T> c { a };
+    c.mod(b);
     return c;
 }
 

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -29,8 +29,10 @@
 
 #include <AK/Assertions.h>
 #include <AK/Concepts.h>
+// #include <AK/Error.h> // FIXME
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtras.h>
+//#include <AK/StringView.h> // FIXME
 
 namespace AK {
 
@@ -165,6 +167,17 @@ public:
     ALWAYS_INLINE constexpr T value() const
     {
         VERIFY(!m_overflow);
+        return m_value;
+    }
+
+    // FIXME Use ErrorOr
+    // constexpr ErrorOr<T> try_value() const
+    constexpr T try_value() const
+    {
+        if (m_overflow)
+            // return Error::from_string_literals("Overflow Occurred");
+            return NumericLimits<T>::max();
+
         return m_value;
     }
 

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -32,6 +32,8 @@ private:
     Calculator m_calculator;
     Keypad m_keypad;
 
+    bool m_has_overflown = false;
+
     RefPtr<GUI::TextBox> m_entry;
     RefPtr<GUI::Label> m_label;
 

--- a/Userland/Applications/Calculator/Keypad.h
+++ b/Userland/Applications/Calculator/Keypad.h
@@ -21,12 +21,12 @@ public:
 
     void type_digit(int digit);
     void type_decimal_point();
-    void type_backspace();
+    ErrorOr<void> type_backspace();
 
     KeypadValue value() const;
-    void set_value(KeypadValue);
+    ErrorOr<void> set_value(KeypadValue);
 
-    String to_string() const;
+    ErrorOr<String> to_string() const;
 
 private:
     // Internal representation of the current decimal value.

--- a/Userland/Applications/Calculator/KeypadValue.h
+++ b/Userland/Applications/Calculator/KeypadValue.h
@@ -10,12 +10,23 @@
 #include <AK/String.h>
 #include <AK/Types.h>
 
+// This function is just a temporary workaround until try_value actually return an ErrorOr
+template<typename T>
+ErrorOr<T> WIP_HELPER(T a)
+{
+    if (a == NumericLimits<T>::max())
+        return Error::from_string_literal("Overflow Occurred");
+
+    return a;
+}
+
 class KeypadValue {
     friend class Keypad;
     friend class Calculator;
 
 public:
     KeypadValue(i64, u8);
+    KeypadValue(Checked<i64>, Checked<u8>);
     KeypadValue(i64);
 
     explicit KeypadValue(StringView);
@@ -43,6 +54,6 @@ private:
     // m_decimal_places would be 2, because when you shift -12355 2 digits to the right, you get -123.55.
     // This way, most operations don't have to be performed on doubles, but can be performed without loss of
     // precision on this class.
-    i64 m_value { 0 };
-    u8 m_decimal_places { 0 };
+    Checked<i64> m_value { 0 };
+    Checked<u8> m_decimal_places { 0 };
 };


### PR DESCRIPTION
The calculator use integrals types internally, whom can fail due to overflow.



Those changes introduce to things :

- Usage of Checked <T> in the calculator to ensure safety
- Enhancement of Checked <T> to be used in an error propagation context (return ErrorOr instead of asserting)


This is a draft because I can't return an ErrorOr in Checked.h due to circular dependency.
Maybe I'm heading a wrong direction 🤷.