### PR TITLE
Kernel: Use `try_create` not `must_create` in SysFSUSB::create

### DIFF
--- a/Kernel/Bus/USB/SysFSUSB.h
+++ b/Kernel/Bus/USB/SysFSUSB.h
@@ -19,7 +19,7 @@ class SysFSUSBDeviceInformation : public SysFSComponent {
 public:
     virtual ~SysFSUSBDeviceInformation() override;
 
-    static NonnullRefPtr<SysFSUSBDeviceInformation> create(USB::Device&);
+    static ErrorOr<NonnullRefPtr<SysFSUSBDeviceInformation>> create(USB::Device&);
     virtual StringView name() const override { return m_device_name->view(); }
 
     RefPtr<USB::Device> device() const { return m_device; }


### PR DESCRIPTION
The function `KString::must_create()` can only be enforced
during early boot (that is, when `g_in_early_boot` is true), hence
the use of this function during runtime causes a `VERIFY` to assert,
leading to a Kernel Panic.
We should instead use `TRY()` along with `try_create()` to prevent
this from crashing whenever a USB device is inserted into the system,
and we don't have enough memory to allocate the device's KString.