### PR TITLE
rm: Check before removing '/'

### DIFF
--- a/Userland/Utilities/rm.cpp
+++ b/Userland/Utilities/rm.cpp
@@ -21,12 +21,14 @@ int main(int argc, char** argv)
     bool recursive = false;
     bool force = false;
     bool verbose = false;
-    Vector<const char*> paths;
+    bool no_preserve_root = false;
+    Vector<StringView> paths;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(recursive, "Delete directories recursively", "recursive", 'r');
     args_parser.add_option(force, "Force", "force", 'f');
     args_parser.add_option(verbose, "Verbose", "verbose", 'v');
+    args_parser.add_option(no_preserve_root, "Do not consider '/' specially", "no-preserve-root", 0);
     args_parser.add_positional_argument(paths, "Path(s) to remove", "path", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
@@ -37,6 +39,11 @@ int main(int argc, char** argv)
 
     bool had_errors = false;
     for (auto& path : paths) {
+        if (!no_preserve_root && path == "/") {
+            warnln("rm: '/' is protected, try with --no-preserve-root to override this behavior");
+            continue;
+        }
+
         auto result = Core::File::remove(path, recursive ? Core::File::RecursionMode::Allowed : Core::File::RecursionMode::Disallowed, force);
 
         if (result.is_error()) {


### PR DESCRIPTION
A simple check to not erase by mistake.

As discussed in #5253.
