### PR TITLE
LibGUI: Bring entire cell into view after scroll_into_view

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -276,7 +276,7 @@ void AbstractTableView::scroll_into_view(const ModelIndex& index, bool scroll_ho
     Gfx::IntRect rect;
     switch (selection_behavior()) {
     case SelectionBehavior::SelectItems:
-        rect = content_rect(index);
+        rect = cell_rect(index.row(), index.column());
         break;
     case SelectionBehavior::SelectRows:
         rect = row_rect(index.row());
@@ -322,6 +322,17 @@ Gfx::IntRect AbstractTableView::content_rect(int row, int column) const
 Gfx::IntRect AbstractTableView::content_rect(const ModelIndex& index) const
 {
     return content_rect(index.row(), index.column());
+}
+
+Gfx::IntRect AbstractTableView::cell_rect(int row, int column) const
+{
+    auto cell_rect = this->content_rect(row, column);
+    if (row_header().is_visible())
+        cell_rect.set_left(cell_rect.left() - row_header().width());
+    if (column_header().is_visible())
+        cell_rect.set_top(cell_rect.top() - column_header().height());
+
+    return cell_rect;
 }
 
 Gfx::IntRect AbstractTableView::row_rect(int item_index) const

--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -51,6 +51,7 @@ public:
 
     virtual Gfx::IntRect content_rect(const ModelIndex&) const override;
     Gfx::IntRect content_rect(int row, int column) const;
+    Gfx::IntRect cell_rect(int row, int column) const;
     Gfx::IntRect row_rect(int item_index) const;
 
     virtual Gfx::IntRect paint_invalidation_rect(ModelIndex const& index) const override;


### PR DESCRIPTION
When navigating around the TableView, if the cell you navigate to is outside of the current view, this commit makes sure that the alignment will take into account the row and column headers.

In this manner, the entire cell is brought into view when you navigate to it.