### PR TITLE
LibSoftGPU: Vectorize fragment pipeline

### DIFF
--- a/AK/SIMDExtras.h
+++ b/AK/SIMDExtras.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/SIMD.h>
+
+// Returning a vector on i686 target generates warning "psabi".
+// This prevents the CI, treating this as an error, from running to completion.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wpsabi"
+
+namespace AK::SIMD {
+
+// SIMD Vector Expansion
+
+ALWAYS_INLINE static constexpr f32x4 expand4(float f)
+{
+    return f32x4 { f, f, f, f };
+}
+
+ALWAYS_INLINE static constexpr i32x4 expand4(i32 i)
+{
+    return i32x4 { i, i, i, i };
+}
+
+ALWAYS_INLINE static constexpr u32x4 expand4(u32 u)
+{
+    return u32x4 { u, u, u, u };
+}
+
+// Casting
+
+template<typename TSrc>
+ALWAYS_INLINE static u32x4 to_u32x4(TSrc v)
+{
+    return __builtin_convertvector(v, u32x4);
+}
+
+template<typename TSrc>
+ALWAYS_INLINE static i32x4 to_i32x4(TSrc v)
+{
+    return __builtin_convertvector(v, i32x4);
+}
+
+template<typename TSrc>
+ALWAYS_INLINE static f32x4 to_f32x4(TSrc v)
+{
+    return __builtin_convertvector(v, f32x4);
+}
+
+// Masking
+
+ALWAYS_INLINE static i32 maskbits(i32x4 mask)
+{
+#if defined(__SSE__)
+    return __builtin_ia32_movmskps((f32x4)mask);
+#else
+    return ((mask[0] & 0x80000000) >> 31) | ((mask[1] & 0x80000000) >> 30) | ((mask[2] & 0x80000000) >> 29) | ((mask[3] & 0x80000000) >> 28);
+#endif
+}
+
+ALWAYS_INLINE static bool all(i32x4 mask)
+{
+    return maskbits(mask) == 15;
+}
+
+ALWAYS_INLINE static bool any(i32x4 mask)
+{
+    return maskbits(mask) != 0;
+}
+
+ALWAYS_INLINE static bool none(i32x4 mask)
+{
+    return maskbits(mask) == 0;
+}
+
+ALWAYS_INLINE static int maskcount(i32x4 mask)
+{
+    constexpr static int count_lut[16] { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 };
+    return count_lut[maskbits(mask)];
+}
+
+// Load / Store
+
+ALWAYS_INLINE static f32x4 load4(float const* a, float const* b, float const* c, float const* d)
+{
+    return f32x4 { *a, *b, *c, *d };
+}
+
+ALWAYS_INLINE static u32x4 load4(u32 const* a, u32 const* b, u32 const* c, u32 const* d)
+{
+    return u32x4 { *a, *b, *c, *d };
+}
+
+ALWAYS_INLINE static f32x4 load4_masked(float const* a, float const* b, float const* c, float const* d, i32x4 mask)
+{
+    int bits = maskbits(mask);
+    return f32x4 {
+        bits & 1 ? *a : 0.f,
+        bits & 2 ? *b : 0.f,
+        bits & 4 ? *c : 0.f,
+        bits & 8 ? *d : 0.f,
+    };
+}
+
+ALWAYS_INLINE static u32x4 load4_masked(u32 const* a, u32 const* b, u32 const* c, u32 const* d, i32x4 mask)
+{
+    int bits = maskbits(mask);
+    return u32x4 {
+        bits & 1 ? *a : 0u,
+        bits & 2 ? *b : 0u,
+        bits & 4 ? *c : 0u,
+        bits & 8 ? *d : 0u,
+    };
+}
+
+template<typename VectorType, typename UnderlyingType = decltype(declval<VectorType>()[0])>
+ALWAYS_INLINE static void store4(VectorType v, UnderlyingType* a, UnderlyingType* b, UnderlyingType* c, UnderlyingType* d)
+{
+    *a = v[0];
+    *b = v[1];
+    *c = v[2];
+    *d = v[3];
+}
+
+template<typename VectorType, typename UnderlyingType = decltype(declval<VectorType>()[0])>
+ALWAYS_INLINE static void store4_masked(VectorType v, UnderlyingType* a, UnderlyingType* b, UnderlyingType* c, UnderlyingType* d, i32x4 mask)
+{
+    int bits = maskbits(mask);
+    if (bits & 1)
+        *a = v[0];
+    if (bits & 2)
+        *b = v[1];
+    if (bits & 4)
+        *c = v[2];
+    if (bits & 8)
+        *d = v[3];
+}
+
+#pragma GCC diagnostic pop
+
+}

--- a/AK/SIMDMath.h
+++ b/AK/SIMDMath.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/SIMD.h>
+#include <math.h>
+
+// Returning a vector on i686 target generates warning "psabi".
+// This prevents the CI, treating this as an error, from running to completion.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic warning "-Wpsabi"
+
+namespace AK::SIMD {
+
+// Functions ending in "_int_range" only accept arguments within range [INT_MIN, INT_MAX].
+// Other inputs will generate unexpected results.
+
+ALWAYS_INLINE static f32x4 truncate_int_range(f32x4 v)
+{
+    return to_f32x4(to_i32x4(v));
+}
+
+ALWAYS_INLINE static f32x4 floor_int_range(f32x4 v)
+{
+    auto t = truncate_int_range(v);
+    return t > v ? t - 1.0f : t;
+}
+
+ALWAYS_INLINE static f32x4 ceil_int_range(f32x4 v)
+{
+    auto t = truncate_int_range(v);
+    return t < v ? t + 1.0f : t;
+}
+
+ALWAYS_INLINE static f32x4 frac_int_range(f32x4 v)
+{
+    return v - floor_int_range(v);
+}
+
+ALWAYS_INLINE static f32x4 clamp(f32x4 v, f32x4 min, f32x4 max)
+{
+    return v < min ? min : (v > max ? max : v);
+}
+
+ALWAYS_INLINE static f32x4 exp(f32x4 v)
+{
+    // FIXME: This should be replaced with a vectorized algorithm instead of calling the scalar expf 4 times
+    return f32x4 {
+        expf(v[0]),
+        expf(v[1]),
+        expf(v[2]),
+        expf(v[3]),
+    };
+}
+
+#pragma GCC diagnostic pop
+
+}

--- a/Userland/Libraries/LibGfx/Vector2.h
+++ b/Userland/Libraries/LibGfx/Vector2.h
@@ -60,12 +60,14 @@ public:
         return Vector2(m_x / other.m_x, m_y / other.m_y);
     }
 
-    constexpr Vector2 operator*(T f) const
+    template<typename U>
+    constexpr Vector2 operator*(U f) const
     {
         return Vector2(m_x * f, m_y * f);
     }
 
-    constexpr Vector2 operator/(T f) const
+    template<typename U>
+    constexpr Vector2 operator/(U f) const
     {
         return Vector2(m_x / f, m_y / f);
     }

--- a/Userland/Libraries/LibGfx/Vector3.h
+++ b/Userland/Libraries/LibGfx/Vector3.h
@@ -65,12 +65,14 @@ public:
         return Vector3(m_x / other.m_x, m_y / other.m_y, m_z / other.m_z);
     }
 
-    constexpr Vector3 operator*(T f) const
+    template<typename U>
+    constexpr Vector3 operator*(U f) const
     {
         return Vector3(m_x * f, m_y * f, m_z * f);
     }
 
-    constexpr Vector3 operator/(T f) const
+    template<typename U>
+    constexpr Vector3 operator/(U f) const
     {
         return Vector3(m_x / f, m_y / f, m_z / f);
     }

--- a/Userland/Libraries/LibGfx/Vector4.h
+++ b/Userland/Libraries/LibGfx/Vector4.h
@@ -70,12 +70,14 @@ public:
         return Vector4(m_x / other.m_x, m_y / other.m_y, m_z / other.m_z, m_w / other.m_w);
     }
 
-    constexpr Vector4 operator*(T f) const
+    template<typename U>
+    constexpr Vector4 operator*(U f) const
     {
         return Vector4(m_x * f, m_y * f, m_z * f, m_w * f);
     }
 
-    constexpr Vector4 operator/(T f) const
+    template<typename U>
+    constexpr Vector4 operator/(U f) const
     {
         return Vector4(m_x / f, m_y / f, m_z / f, m_w / f);
     }

--- a/Userland/Libraries/LibSoftGPU/AlphaBlendFactors.h
+++ b/Userland/Libraries/LibSoftGPU/AlphaBlendFactors.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Vector4.h>
+
+namespace SoftGPU {
+
+struct AlphaBlendFactors final {
+    FloatVector4 src_constant {};
+    float src_factor_src_alpha = 0;
+    float src_factor_dst_alpha = 0;
+    float src_factor_src_color = 0;
+    float src_factor_dst_color = 0;
+
+    FloatVector4 dst_constant {};
+    float dst_factor_src_alpha = 0;
+    float dst_factor_dst_alpha = 0;
+    float dst_factor_src_color = 0;
+    float dst_factor_dst_color = 0;
+};
+
+}

--- a/Userland/Libraries/LibSoftGPU/CMakeLists.txt
+++ b/Userland/Libraries/LibSoftGPU/CMakeLists.txt
@@ -6,5 +6,6 @@ set(SOURCES
     Sampler.cpp
 )
 
+add_compile_options(-Wno-psabi)
 serenity_lib(LibSoftGPU softgpu)
 target_link_libraries(LibSoftGPU LibM LibCore LibGfx)

--- a/Userland/Libraries/LibSoftGPU/Clipper.cpp
+++ b/Userland/Libraries/LibSoftGPU/Clipper.cpp
@@ -48,6 +48,7 @@ Vertex Clipper::clip_intersection_point(const Vertex& p1, const Vertex& p2, Clip
     out.clip_coordinates = mix(p1.clip_coordinates, p2.clip_coordinates, a);
     out.color = mix(p1.color, p2.color, a);
     out.tex_coord = mix(p1.tex_coord, p2.tex_coord, a);
+    out.normal = mix(p1.normal, p2.normal, a);
     return out;
 }
 

--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -15,7 +15,6 @@
 namespace SoftGPU {
 
 static constexpr bool ENABLE_STATISTICS_OVERLAY = false;
-static constexpr int RASTERIZER_BLOCK_SIZE = 8;
 static constexpr int NUM_SAMPLERS = 32;
 static constexpr int SUBPIXEL_BITS = 5;
 

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -24,6 +24,7 @@ static long long g_num_pixels;
 static long long g_num_pixels_shaded;
 static long long g_num_pixels_blended;
 static long long g_num_sampler_calls;
+static long long g_num_quads;
 
 using IntVector2 = Gfx::Vector2<int>;
 using IntVector3 = Gfx::Vector3<int>;
@@ -271,6 +272,7 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
             if (none(quad.mask))
                 continue;
 
+            INCREASE_STATISTICS_COUNTER(g_num_quads, 1);
             INCREASE_STATISTICS_COUNTER(g_num_pixels, maskcount(quad.mask));
 
             // Calculate barycentric coordinates from previously calculated edge values
@@ -902,6 +904,7 @@ void Device::draw_statistics_overlay(Gfx::Bitmap& target)
             static_cast<double>(milliseconds) / frame_counter,
             (milliseconds > 0) ? 1000.0 * frame_counter / milliseconds : 9999.0));
         builder.append(String::formatted("Triangles    : {}\n", g_num_rasterized_triangles));
+        builder.append(String::formatted("SIMD usage   : {}%\n", g_num_quads > 0 ? g_num_pixels_shaded * 25 / g_num_quads : 0));
         builder.append(String::formatted("Pixels       : {}, Shaded: {}%, Blended: {}%, Overdraw: {}%\n",
             g_num_pixels,
             g_num_pixels_shaded * 100 / g_num_pixels,
@@ -920,6 +923,7 @@ void Device::draw_statistics_overlay(Gfx::Bitmap& target)
     g_num_pixels_shaded = 0;
     g_num_pixels_blended = 0;
     g_num_sampler_calls = 0;
+    g_num_quads = 0;
 
     auto& font = Gfx::FontDatabase::default_fixed_width_font();
 

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -135,18 +135,17 @@ static constexpr void setup_blend_factors(BlendFactor mode, FloatVector4& consta
     }
 }
 
-template<typename PS>
-static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& render_target, DepthBuffer& depth_buffer, const Triangle& triangle, PS pixel_shader)
+void Device::rasterize_triangle(const Triangle& triangle)
 {
     INCREASE_STATISTICS_COUNTER(g_num_rasterized_triangles, 1);
 
     // Since the algorithm is based on blocks of uniform size, we need
-    // to ensure that our render_target size is actually a multiple of the block size
-    VERIFY((render_target.width() % 2) == 0);
-    VERIFY((render_target.height() % 2) == 0);
+    // to ensure that our m_render_target size is actually a multiple of the block size
+    VERIFY((m_render_target->width() % 2) == 0);
+    VERIFY((m_render_target->height() % 2) == 0);
 
     // Return if alpha testing is a no-op
-    if (options.enable_alpha_test && options.alpha_test_func == AlphaTestFunction::Never)
+    if (m_options.enable_alpha_test && m_options.alpha_test_func == AlphaTestFunction::Never)
         return;
 
     // Vertices
@@ -179,9 +178,9 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
     float dst_factor_src_color = 0;
     float dst_factor_dst_color = 0;
 
-    if (options.enable_blending) {
+    if (m_options.enable_blending) {
         setup_blend_factors(
-            options.blend_source_factor,
+            m_options.blend_source_factor,
             src_constant,
             src_factor_src_alpha,
             src_factor_dst_alpha,
@@ -189,7 +188,7 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
             src_factor_dst_color);
 
         setup_blend_factors(
-            options.blend_destination_factor,
+            m_options.blend_destination_factor,
             dst_constant,
             dst_factor_src_alpha,
             dst_factor_dst_alpha,
@@ -197,9 +196,9 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
             dst_factor_dst_color);
     }
 
-    auto render_bounds = render_target.rect();
-    auto window_scissor_rect = scissor_box_to_window_coordinates(options.scissor_box, render_target.rect());
-    if (options.scissor_enabled)
+    auto render_bounds = m_render_target->rect();
+    auto window_scissor_rect = scissor_box_to_window_coordinates(m_options.scissor_box, m_render_target->rect());
+    if (m_options.scissor_enabled)
         render_bounds.intersect(window_scissor_rect);
 
     // Obey top-left rule:
@@ -268,7 +267,7 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
 
             // Generate triangle coverage mask
             quad.mask = test_point4(edge_values);
-            if (options.scissor_enabled) {
+            if (m_options.scissor_enabled) {
                 quad.mask &= test_scissor4(quad.screen_coordinates);
             }
 
@@ -286,21 +285,21 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
             } * one_over_area;
 
             float* depth_ptrs[4] = {
-                &depth_buffer.scanline(by)[bx],
-                &depth_buffer.scanline(by)[bx + 1],
-                &depth_buffer.scanline(by + 1)[bx],
-                &depth_buffer.scanline(by + 1)[bx + 1],
+                &m_depth_buffer->scanline(by)[bx],
+                &m_depth_buffer->scanline(by)[bx + 1],
+                &m_depth_buffer->scanline(by + 1)[bx],
+                &m_depth_buffer->scanline(by + 1)[bx + 1],
             };
 
             // AND the depth mask onto the coverage mask
-            if (options.enable_depth_test) {
+            if (m_options.enable_depth_test) {
                 auto depth = load4_masked(depth_ptrs[0], depth_ptrs[1], depth_ptrs[2], depth_ptrs[3], quad.mask);
 
                 quad.depth = interpolate(vertex0.window_coordinates.z(), vertex1.window_coordinates.z(), vertex2.window_coordinates.z(), quad.barycentrics);
                 // FIXME: Also apply depth_offset_factor which depends on the depth gradient
-                quad.depth += options.depth_offset_constant * NumericLimits<float>::epsilon();
+                quad.depth += m_options.depth_offset_constant * NumericLimits<float>::epsilon();
 
-                switch (options.depth_func) {
+                switch (m_options.depth_func) {
                 case DepthTestFunction::Always:
                     break;
                 case DepthTestFunction::Never:
@@ -370,7 +369,7 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
             quad.barycentrics = quad.barycentrics * w_coordinates * interpolated_w;
 
             // FIXME: make this more generic. We want to interpolate more than just color and uv
-            if (options.shade_smooth) {
+            if (m_options.shade_smooth) {
                 quad.vertex_color = interpolate(expand4(vertex0.color), expand4(vertex1.color), expand4(vertex2.color), quad.barycentrics);
             } else {
                 quad.vertex_color = expand4(vertex0.color);
@@ -378,7 +377,7 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
 
             quad.uv = interpolate(expand4(vertex0.tex_coord), expand4(vertex1.tex_coord), expand4(vertex2.tex_coord), quad.barycentrics);
 
-            if (options.fog_enabled) {
+            if (m_options.fog_enabled) {
                 // Calculate depth of fragment for fog
                 //
                 // OpenGL 1.5 spec chapter 3.10: "An implementation may choose to approximate the
@@ -387,27 +386,27 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
                 quad.fog_depth = interpolate(expand4(vertex0_eye_absz), expand4(vertex1_eye_absz), expand4(vertex2_eye_absz), quad.barycentrics);
             }
 
-            pixel_shader(quad);
+            shade_fragments(quad);
 
-            if (options.enable_alpha_test && options.alpha_test_func != AlphaTestFunction::Always) {
-                switch (options.alpha_test_func) {
+            if (m_options.enable_alpha_test && m_options.alpha_test_func != AlphaTestFunction::Always) {
+                switch (m_options.alpha_test_func) {
                 case AlphaTestFunction::Less:
-                    quad.mask &= quad.out_color.w() < options.alpha_test_ref_value;
+                    quad.mask &= quad.out_color.w() < m_options.alpha_test_ref_value;
                     break;
                 case AlphaTestFunction::Equal:
-                    quad.mask &= quad.out_color.w() == options.alpha_test_ref_value;
+                    quad.mask &= quad.out_color.w() == m_options.alpha_test_ref_value;
                     break;
                 case AlphaTestFunction::LessOrEqual:
-                    quad.mask &= quad.out_color.w() <= options.alpha_test_ref_value;
+                    quad.mask &= quad.out_color.w() <= m_options.alpha_test_ref_value;
                     break;
                 case AlphaTestFunction::Greater:
-                    quad.mask &= quad.out_color.w() > options.alpha_test_ref_value;
+                    quad.mask &= quad.out_color.w() > m_options.alpha_test_ref_value;
                     break;
                 case AlphaTestFunction::NotEqual:
-                    quad.mask &= quad.out_color.w() != options.alpha_test_ref_value;
+                    quad.mask &= quad.out_color.w() != m_options.alpha_test_ref_value;
                     break;
                 case AlphaTestFunction::GreaterOrEqual:
-                    quad.mask &= quad.out_color.w() >= options.alpha_test_ref_value;
+                    quad.mask &= quad.out_color.w() >= m_options.alpha_test_ref_value;
                     break;
                 case AlphaTestFunction::Never:
                 case AlphaTestFunction::Always:
@@ -416,29 +415,29 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
             }
 
             // Write to depth buffer
-            if (options.enable_depth_test && options.enable_depth_write) {
+            if (m_options.enable_depth_test && m_options.enable_depth_write) {
                 store4_masked(quad.depth, depth_ptrs[0], depth_ptrs[1], depth_ptrs[2], depth_ptrs[3], quad.mask);
             }
 
             // We will not update the color buffer at all
-            if (!options.color_mask || !options.enable_color_write)
+            if (!m_options.color_mask || !m_options.enable_color_write)
                 continue;
 
             Gfx::RGBA32* color_ptrs[4] = {
-                &render_target.scanline(by)[bx],
-                &render_target.scanline(by)[bx + 1],
-                &render_target.scanline(by + 1)[bx],
-                &render_target.scanline(by + 1)[bx + 1],
+                &m_render_target->scanline(by)[bx],
+                &m_render_target->scanline(by)[bx + 1],
+                &m_render_target->scanline(by + 1)[bx],
+                &m_render_target->scanline(by + 1)[bx + 1],
             };
 
             u32x4 dst_u32;
-            if (options.enable_blending || options.color_mask != 0xffffffff)
+            if (m_options.enable_blending || m_options.color_mask != 0xffffffff)
                 dst_u32 = load4_masked(color_ptrs[0], color_ptrs[1], color_ptrs[2], color_ptrs[3], quad.mask);
 
-            if (options.enable_blending) {
+            if (m_options.enable_blending) {
                 INCREASE_STATISTICS_COUNTER(g_num_pixels_blended, maskcount(quad.mask));
 
-                // Blend color values from pixel_staging into render_target
+                // Blend color values from pixel_staging into m_render_target
                 Vector4<f32x4> const& src = quad.out_color;
                 auto dst = to_vec4(dst_u32);
 
@@ -457,10 +456,10 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
                 quad.out_color = src * src_factor + dst * dst_factor;
             }
 
-            if (options.color_mask == 0xffffffff)
+            if (m_options.color_mask == 0xffffffff)
                 store4_masked(to_rgba32(quad.out_color), color_ptrs[0], color_ptrs[1], color_ptrs[2], color_ptrs[3], quad.mask);
             else
-                store4_masked((to_rgba32(quad.out_color) & options.color_mask) | (dst_u32 & ~options.color_mask), color_ptrs[0], color_ptrs[1], color_ptrs[2], color_ptrs[3], quad.mask);
+                store4_masked((to_rgba32(quad.out_color) & m_options.color_mask) | (dst_u32 & ~m_options.color_mask), color_ptrs[0], color_ptrs[1], color_ptrs[2], color_ptrs[3], quad.mask);
         }
     }
 }
@@ -567,6 +566,8 @@ void Device::draw_primitives(PrimitiveType primitive_type, FloatMatrix4x4 const&
     // 4.   Each element of the vertex is then divided by w to bring the positions into NDC (Normalized Device Coordinates)
     // 5.   The vertices are sorted (for the rasteriser, how are we doing this? 3Dfx did this top to bottom in terms of vertex y coordinates)
     // 6.   The vertices are then sent off to the rasteriser and drawn to the screen
+
+    m_enabled_texture_units = enabled_texture_units;
 
     float scr_width = m_render_target->width();
     float scr_height = m_render_target->height();
@@ -737,72 +738,70 @@ void Device::draw_primitives(PrimitiveType primitive_type, FloatMatrix4x4 const&
         triangle.vertices[1].tex_coord = texture_transform * triangle.vertices[1].tex_coord;
         triangle.vertices[2].tex_coord = texture_transform * triangle.vertices[2].tex_coord;
 
-        submit_triangle(triangle, enabled_texture_units);
+        rasterize_triangle(triangle);
     }
 }
 
-void Device::submit_triangle(const Triangle& triangle, Vector<size_t> const& enabled_texture_units)
+ALWAYS_INLINE void Device::shade_fragments(PixelQuad& quad)
 {
-    rasterize_triangle(m_options, *m_render_target, *m_depth_buffer, triangle, [this, &enabled_texture_units](PixelQuad& quad) {
-        quad.out_color = quad.vertex_color;
+    quad.out_color = quad.vertex_color;
 
-        for (size_t i : enabled_texture_units) {
-            // FIXME: implement GL_TEXTURE_1D, GL_TEXTURE_3D and GL_TEXTURE_CUBE_MAP
-            auto const& sampler = m_samplers[i];
+    for (size_t i : m_enabled_texture_units) {
+        // FIXME: implement GL_TEXTURE_1D, GL_TEXTURE_3D and GL_TEXTURE_CUBE_MAP
+        auto const& sampler = m_samplers[i];
 
-            auto texel = sampler.sample_2d({ quad.uv.x(), quad.uv.y() });
-            INCREASE_STATISTICS_COUNTER(g_num_sampler_calls, 1);
+        auto texel = sampler.sample_2d({ quad.uv.x(), quad.uv.y() });
+        INCREASE_STATISTICS_COUNTER(g_num_sampler_calls, 1);
 
-            // FIXME: Implement more blend modes
-            switch (sampler.config().fixed_function_texture_env_mode) {
-            case TextureEnvMode::Modulate:
-                quad.out_color = quad.out_color * texel;
-                break;
-            case TextureEnvMode::Replace:
-                quad.out_color = texel;
-                break;
-            case TextureEnvMode::Decal: {
-                auto src_alpha = quad.out_color.w();
-                quad.out_color.set_x(mix(quad.out_color.x(), texel.x(), src_alpha));
-                quad.out_color.set_y(mix(quad.out_color.y(), texel.y(), src_alpha));
-                quad.out_color.set_z(mix(quad.out_color.z(), texel.z(), src_alpha));
-                break;
-            }
-            default:
-                VERIFY_NOT_REACHED();
-            }
+        // FIXME: Implement more blend modes
+        switch (sampler.config().fixed_function_texture_env_mode) {
+        case TextureEnvMode::Modulate:
+            quad.out_color = quad.out_color * texel;
+            break;
+        case TextureEnvMode::Replace:
+            quad.out_color = texel;
+            break;
+        case TextureEnvMode::Decal: {
+            auto src_alpha = quad.out_color.w();
+            quad.out_color.set_x(mix(quad.out_color.x(), texel.x(), src_alpha));
+            quad.out_color.set_y(mix(quad.out_color.y(), texel.y(), src_alpha));
+            quad.out_color.set_z(mix(quad.out_color.z(), texel.z(), src_alpha));
+            break;
+        }
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+    // Calculate fog
+    // Math from here: https://opengl-notes.readthedocs.io/en/latest/topics/texturing/aliasing.html
+
+    // FIXME: exponential fog is not vectorized, we should add a SIMD exp function that calculates an approximation.
+    if (m_options.fog_enabled) {
+        auto factor = expand4(0.0f);
+        switch (m_options.fog_mode) {
+        case FogMode::Linear:
+            factor = (m_options.fog_end - quad.fog_depth) / (m_options.fog_end - m_options.fog_start);
+            break;
+        case FogMode::Exp: {
+            auto argument = -m_options.fog_density * quad.fog_depth;
+            factor = exp(argument);
+        } break;
+        case FogMode::Exp2: {
+            auto argument = m_options.fog_density * quad.fog_depth;
+            argument *= -argument;
+            factor = exp(argument);
+        } break;
+        default:
+            VERIFY_NOT_REACHED();
         }
 
-        // Calculate fog
-        // Math from here: https://opengl-notes.readthedocs.io/en/latest/topics/texturing/aliasing.html
-
-        // FIXME: exponential fog is not vectorized, we should add a SIMD exp function that calculates an approximation.
-        if (m_options.fog_enabled) {
-            auto factor = expand4(0.0f);
-            switch (m_options.fog_mode) {
-            case FogMode::Linear:
-                factor = (m_options.fog_end - quad.fog_depth) / (m_options.fog_end - m_options.fog_start);
-                break;
-            case FogMode::Exp: {
-                auto argument = -m_options.fog_density * quad.fog_depth;
-                factor = exp(argument);
-            } break;
-            case FogMode::Exp2: {
-                auto argument = m_options.fog_density * quad.fog_depth;
-                argument *= -argument;
-                factor = exp(argument);
-            } break;
-            default:
-                VERIFY_NOT_REACHED();
-            }
-
-            // Mix texel's RGB with fog's RBG - leave alpha alone
-            auto fog_color = expand4(m_options.fog_color);
-            quad.out_color.set_x(mix(fog_color.x(), quad.out_color.x(), factor));
-            quad.out_color.set_y(mix(fog_color.y(), quad.out_color.y(), factor));
-            quad.out_color.set_z(mix(fog_color.z(), quad.out_color.z(), factor));
-        }
-    });
+        // Mix texel's RGB with fog's RBG - leave alpha alone
+        auto fog_color = expand4(m_options.fog_color);
+        quad.out_color.set_x(mix(fog_color.x(), quad.out_color.x(), factor));
+        quad.out_color.set_y(mix(fog_color.y(), quad.out_color.y(), factor));
+        quad.out_color.set_z(mix(fog_color.z(), quad.out_color.z(), factor));
+    }
 }
 
 void Device::resize(const Gfx::IntSize& min_size)

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -259,6 +259,11 @@ void Device::rasterize_triangle(const Triangle& triangle)
     int const render_bounds_top = render_bounds.y();
     int const render_bounds_bottom = render_bounds.y() + render_bounds.height();
 
+    auto const half_pixel_offset = Vector2<i32x4> {
+        expand4(subpixel_factor / 2),
+        expand4(subpixel_factor / 2),
+    };
+
     // Iterate over all blocks within the bounds of the triangle
     for (int by = by0; by < by1; by += 2) {
         for (int bx = bx0; bx < bx1; bx += 2) {
@@ -270,7 +275,7 @@ void Device::rasterize_triangle(const Triangle& triangle)
                 i32x4 { by, by, by + 1, by + 1 },
             };
 
-            auto edge_values = calculate_edge_values4(quad.screen_coordinates * subpixel_factor);
+            auto edge_values = calculate_edge_values4(quad.screen_coordinates * subpixel_factor + half_pixel_offset);
 
             // Generate triangle coverage mask
             quad.mask = test_point4(edge_values);

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -900,9 +900,6 @@ void Device::draw_statistics_overlay(Gfx::Bitmap& target)
 
     if (milliseconds > 500) {
 
-        if (g_num_pixels == 0)
-            g_num_pixels = 1;
-
         int num_rendertarget_pixels = m_render_target->width() * m_render_target->height();
 
         StringBuilder builder;
@@ -913,9 +910,9 @@ void Device::draw_statistics_overlay(Gfx::Bitmap& target)
         builder.append(String::formatted("SIMD usage   : {}%\n", g_num_quads > 0 ? g_num_pixels_shaded * 25 / g_num_quads : 0));
         builder.append(String::formatted("Pixels       : {}, Shaded: {}%, Blended: {}%, Overdraw: {}%\n",
             g_num_pixels,
-            g_num_pixels_shaded * 100 / g_num_pixels,
-            g_num_pixels_blended * 100 / g_num_pixels_shaded,
-            g_num_pixels_shaded * 100 / num_rendertarget_pixels - 100));
+            g_num_pixels > 0 ? g_num_pixels_shaded * 100 / g_num_pixels : 0,
+            g_num_pixels_shaded > 0 ? g_num_pixels_blended * 100 / g_num_pixels_shaded : 0,
+            num_rendertarget_pixels > 0 ? g_num_pixels_shaded * 100 / num_rendertarget_pixels - 100 : 0));
         builder.append(String::formatted("Sampler calls: {}\n", g_num_sampler_calls));
 
         debug_string = builder.to_string();

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -375,12 +375,14 @@ static void rasterize_triangle(const RasterizerOptions& options, Gfx::Bitmap& re
 
             quad.uv = interpolate(expand4(vertex0.tex_coord), expand4(vertex1.tex_coord), expand4(vertex2.tex_coord), quad.barycentrics);
 
-            // Calculate depth of fragment for fog
-            //
-            // OpenGL 1.5 spec chapter 3.10: "An implementation may choose to approximate the
-            // eye-coordinate distance from the eye to each fragment center by |Ze|."
+            if (options.fog_enabled) {
+                // Calculate depth of fragment for fog
+                //
+                // OpenGL 1.5 spec chapter 3.10: "An implementation may choose to approximate the
+                // eye-coordinate distance from the eye to each fragment center by |Ze|."
 
-            quad.fog_depth = interpolate(expand4(vertex0_eye_absz), expand4(vertex1_eye_absz), expand4(vertex2_eye_absz), quad.barycentrics);
+                quad.fog_depth = interpolate(expand4(vertex0_eye_absz), expand4(vertex1_eye_absz), expand4(vertex2_eye_absz), quad.barycentrics);
+            }
 
             pixel_shader(quad);
 

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -98,6 +98,7 @@ private:
     void rasterize_triangle(const Triangle& triangle);
     void setup_blend_factors();
     void shade_fragments(PixelQuad&);
+    bool test_alpha(PixelQuad&);
 
 private:
     RefPtr<Gfx::Bitmap> m_render_target;

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -67,6 +67,8 @@ struct RasterizerOptions {
     Array<TexCoordGenerationConfig, 4> texcoord_generation_config {};
 };
 
+struct PixelQuad;
+
 class Device final {
 public:
     Device(const Gfx::IntSize& min_size);
@@ -90,8 +92,10 @@ public:
     void set_sampler_config(unsigned, SamplerConfig const&);
 
 private:
-    void submit_triangle(Triangle const& triangle, Vector<size_t> const& enabled_texture_units);
     void draw_statistics_overlay(Gfx::Bitmap&);
+
+    void rasterize_triangle(const Triangle& triangle);
+    void shade_fragments(PixelQuad&);
 
 private:
     RefPtr<Gfx::Bitmap> m_render_target;
@@ -102,6 +106,7 @@ private:
     Vector<Triangle> m_processed_triangles;
     Vector<Vertex> m_clipped_vertices;
     Array<Sampler, NUM_SAMPLERS> m_samplers;
+    Vector<size_t> m_enabled_texture_units;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -14,6 +14,7 @@
 #include <LibGfx/Matrix4x4.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Vector4.h>
+#include <LibSoftGPU/AlphaBlendFactors.h>
 #include <LibSoftGPU/Clipper.h>
 #include <LibSoftGPU/Config.h>
 #include <LibSoftGPU/DepthBuffer.h>
@@ -95,6 +96,7 @@ private:
     void draw_statistics_overlay(Gfx::Bitmap&);
 
     void rasterize_triangle(const Triangle& triangle);
+    void setup_blend_factors();
     void shade_fragments(PixelQuad&);
 
 private:
@@ -107,6 +109,7 @@ private:
     Vector<Vertex> m_clipped_vertices;
     Array<Sampler, NUM_SAMPLERS> m_samplers;
     Vector<size_t> m_enabled_texture_units;
+    AlphaBlendFactors m_alpha_blend_factors;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/Image.cpp
+++ b/Userland/Libraries/LibSoftGPU/Image.cpp
@@ -21,6 +21,15 @@ Image::Image(ImageFormat format, unsigned width, unsigned height, unsigned depth
     VERIFY(levels > 0);
     VERIFY(layers > 0);
 
+    if ((width & (width - 1)) == 0)
+        m_width_is_power_of_two = true;
+
+    if ((height & (height - 1)) == 0)
+        m_height_is_power_of_two = true;
+
+    if ((depth & (depth - 1)) == 0)
+        m_depth_is_power_of_two = true;
+
     m_mipmap_sizes.append({ width, height, depth });
     m_mipmap_offsets.append(0);
 

--- a/Userland/Libraries/LibSoftGPU/Image.h
+++ b/Userland/Libraries/LibSoftGPU/Image.h
@@ -28,6 +28,9 @@ public:
     unsigned level_depth(unsigned level) const { return m_mipmap_sizes[level].z(); }
     unsigned num_levels() const { return m_num_levels; }
     unsigned num_layers() const { return m_num_layers; }
+    bool width_is_power_of_two() const { return m_width_is_power_of_two; }
+    bool height_is_power_of_two() const { return m_height_is_power_of_two; }
+    bool depth_is_power_of_two() const { return m_depth_is_power_of_two; }
 
     FloatVector4 texel(unsigned layer, unsigned level, unsigned x, unsigned y, unsigned z) const
     {
@@ -68,6 +71,9 @@ private:
     Vector<size_t, 16> m_mipmap_offsets;
     Vector<Vector3<unsigned>, 16> m_mipmap_sizes;
     Vector<u8> m_data;
+    bool m_width_is_power_of_two { false };
+    bool m_height_is_power_of_two { false };
+    bool m_depth_is_power_of_two { false };
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/PixelQuad.h
+++ b/Userland/Libraries/LibSoftGPU/PixelQuad.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/SIMD.h>
+#include <LibGfx/Vector2.h>
+#include <LibGfx/Vector3.h>
+#include <LibGfx/Vector4.h>
+
+namespace SoftGPU {
+
+struct PixelQuad final {
+    Vector2<AK::SIMD::i32x4> screen_coordinates;
+    Vector3<AK::SIMD::f32x4> barycentrics;
+    AK::SIMD::f32x4 depth;
+    Vector4<AK::SIMD::f32x4> vertex_color;
+    Vector4<AK::SIMD::f32x4> uv;
+    Vector4<AK::SIMD::f32x4> out_color;
+    AK::SIMD::f32x4 fog_depth;
+    AK::SIMD::i32x4 mask;
+};
+
+}

--- a/Userland/Libraries/LibSoftGPU/SIMD.h
+++ b/Userland/Libraries/LibSoftGPU/SIMD.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/SIMDExtras.h>
+#include <LibGfx/Vector2.h>
+#include <LibGfx/Vector3.h>
+#include <LibGfx/Vector4.h>
+
+namespace SoftGPU {
+
+ALWAYS_INLINE static constexpr Vector2<AK::SIMD::f32x4> expand4(Vector2<float> const& v)
+{
+    return Vector2<AK::SIMD::f32x4> {
+        AK::SIMD::expand4(v.x()),
+        AK::SIMD::expand4(v.y()),
+    };
+}
+
+ALWAYS_INLINE static constexpr Vector3<AK::SIMD::f32x4> expand4(Vector3<float> const& v)
+{
+    return Vector3<AK::SIMD::f32x4> {
+        AK::SIMD::expand4(v.x()),
+        AK::SIMD::expand4(v.y()),
+        AK::SIMD::expand4(v.z()),
+    };
+}
+
+ALWAYS_INLINE static constexpr Vector4<AK::SIMD::f32x4> expand4(Vector4<float> const& v)
+{
+    return Vector4<AK::SIMD::f32x4> {
+        AK::SIMD::expand4(v.x()),
+        AK::SIMD::expand4(v.y()),
+        AK::SIMD::expand4(v.z()),
+        AK::SIMD::expand4(v.w()),
+    };
+}
+
+ALWAYS_INLINE static constexpr Vector2<AK::SIMD::i32x4> expand4(Vector2<int> const& v)
+{
+    return Vector2<AK::SIMD::i32x4> {
+        AK::SIMD::expand4(v.x()),
+        AK::SIMD::expand4(v.y()),
+    };
+}
+
+ALWAYS_INLINE static constexpr Vector3<AK::SIMD::i32x4> expand4(Vector3<int> const& v)
+{
+    return Vector3<AK::SIMD::i32x4> {
+        AK::SIMD::expand4(v.x()),
+        AK::SIMD::expand4(v.y()),
+        AK::SIMD::expand4(v.z()),
+    };
+}
+
+ALWAYS_INLINE static constexpr Vector4<AK::SIMD::i32x4> expand4(Vector4<int> const& v)
+{
+    return Vector4<AK::SIMD::i32x4> {
+        AK::SIMD::expand4(v.x()),
+        AK::SIMD::expand4(v.y()),
+        AK::SIMD::expand4(v.z()),
+        AK::SIMD::expand4(v.w()),
+    };
+}
+
+}

--- a/Userland/Libraries/LibSoftGPU/Sampler.h
+++ b/Userland/Libraries/LibSoftGPU/Sampler.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/RefPtr.h>
+#include <AK/SIMD.h>
 #include <LibGfx/Vector2.h>
 #include <LibGfx/Vector4.h>
 #include <LibSoftGPU/Image.h>
@@ -52,7 +53,7 @@ struct SamplerConfig final {
 
 class Sampler final {
 public:
-    FloatVector4 sample_2d(FloatVector2 const& uv) const;
+    Vector4<AK::SIMD::f32x4> sample_2d(Vector2<AK::SIMD::f32x4> const& uv) const;
 
     void set_config(SamplerConfig const& config) { m_config = config; }
     SamplerConfig const& config() const { return m_config; }


### PR DESCRIPTION
Pixels are calculated as 2x2 pixel quads with each attribute stored in a AK::SIMD::f32x4 or i32x4 vector. Active pixels are tracked via i32x4 mask. Almoat all relevant methods have been rewritten to operate on 4 values at once.

The glquake port now runs at around 25 FPS, sometimes peaking at 33 FPS.

- [x] Make code fit for i686 target. Write scalar "emulation" for vector operations if necessary.
- [x] Separate the fragment pipeline into different functions.
- [x] Prepare an entry point where fragment shaders can be attached later.
- [x] Clean up code.