### PR TITLE
Spider: Redraw completely when drawing cards

### DIFF
--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -110,6 +110,7 @@ void Game::draw_cards()
     update_score(-1);
 
     m_draw_animation = true;
+    m_original_stock_rect = stock_pile.bounding_box();
     start_timer(s_timer_interval_ms);
 }
 
@@ -394,7 +395,7 @@ void Game::timer_event(Core::TimerEvent&)
             ++m_draw_animation_pile;
 
             if (m_draw_animation_pile == piles.size()) {
-                update(stock_pile.bounding_box());
+                update(m_original_stock_rect);
                 detect_full_stacks();
 
                 m_draw_animation = false;

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -102,6 +102,7 @@ private:
     bool m_draw_animation { false };
     uint8_t m_draw_animation_delay { 0 };
     uint8_t m_draw_animation_pile { 0 };
+    Gfx::IntRect m_original_stock_rect;
 
     uint32_t m_score { 500 };
 };


### PR DESCRIPTION
Spider was only updating the new bounding box area after drawing cards
from the deck - leaving behind a sliver of the old deck.

This was a regression, as the game previously used the old bounding
box, introduced by GH-11153.
