### PR TITLE
Kernel: Scan ACPI memory ranges for the RSDP table

### DIFF
--- a/Kernel/Firmware/BIOS.cpp
+++ b/Kernel/Firmware/BIOS.cpp
@@ -163,11 +163,10 @@ Memory::MappedROM map_bios()
 Memory::MappedROM map_ebda()
 {
     auto ebda_segment_ptr = Memory::map_typed<u16>(PhysicalAddress(0x40e));
-    auto ebda_length_ptr_b0 = Memory::map_typed<u8>(PhysicalAddress(0x413));
-    auto ebda_length_ptr_b1 = Memory::map_typed<u8>(PhysicalAddress(0x414));
-
-    PhysicalAddress ebda_paddr(*ebda_segment_ptr << 4);
-    size_t ebda_size = (*ebda_length_ptr_b1 << 8) | *ebda_length_ptr_b0;
+    PhysicalAddress ebda_paddr(PhysicalAddress(*ebda_segment_ptr).get() << 4);
+    // The EBDA size is stored in the first byte of the EBDA in 1K units
+    size_t ebda_size = *Memory::map_typed<u8>(ebda_paddr);
+    ebda_size *= 1024;
 
     Memory::MappedROM mapping;
     mapping.region = MM.allocate_kernel_region(ebda_paddr.page_base(), Memory::page_round_up(ebda_size).release_value_but_fixme_should_propagate_errors(), {}, Memory::Region::Access::Read).release_value();

--- a/Kernel/Memory/MappedROM.h
+++ b/Kernel/Memory/MappedROM.h
@@ -23,7 +23,10 @@ public:
 
     Optional<PhysicalAddress> find_chunk_starting_with(StringView prefix, size_t chunk_size) const
     {
-        for (auto* candidate = base(); candidate < end(); candidate += chunk_size) {
+        auto prefix_length = prefix.length();
+        if (size < prefix_length)
+            return {};
+        for (auto* candidate = base(); candidate <= end() - prefix_length; candidate += chunk_size) {
             if (!__builtin_memcmp(prefix.characters_without_null_termination(), candidate, prefix.length()))
                 return paddr_of(candidate);
         }

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -174,6 +174,17 @@ UNMAP_AFTER_INIT void MemoryManager::protect_ksyms_after_init()
     dmesgln("Write-protected kernel symbols after init.");
 }
 
+IterationDecision MemoryManager::for_each_physical_memory_range(Function<IterationDecision(PhysicalMemoryRange const&)> callback)
+{
+    VERIFY(!m_physical_memory_ranges.is_empty());
+    for (auto& current_range : m_physical_memory_ranges) {
+        IterationDecision decision = callback(current_range);
+        if (decision != IterationDecision::Continue)
+            return decision;
+    }
+    return IterationDecision::Continue;
+}
+
 UNMAP_AFTER_INIT void MemoryManager::register_reserved_ranges()
 {
     VERIFY(!m_physical_memory_ranges.is_empty());

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -237,6 +237,8 @@ public:
 
     void copy_physical_page(PhysicalPage&, u8 page_buffer[PAGE_SIZE]);
 
+    IterationDecision for_each_physical_memory_range(Function<IterationDecision(PhysicalMemoryRange const&)>);
+
 private:
     MemoryManager();
     ~MemoryManager();


### PR DESCRIPTION
On some systems the ACPI RSDP table may be located in ACPI reserved
memory ranges rather than in the EBDA or BIOS areas.

_This allows my HP Pavilion laptop (2021, 11th gen core) to actually find the RSDP, which happens to be located in the ACPI reclaimable physical memory region_