### PR TITLE
Kernel: Improve enumerate_disk_partitions function

### DIFF
--- a/Kernel/Storage/StorageDevice.h
+++ b/Kernel/Storage/StorageDevice.h
@@ -48,6 +48,8 @@ public:
 
     NonnullRefPtrVector<DiskPartition> const& partitions() const { return m_partitions; }
 
+    void add_partition(NonnullRefPtr<DiskPartition> disk_partition) { MUST(m_partitions.try_append(disk_partition)); }
+
     virtual CommandSet command_set() const = 0;
 
     // ^File

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -110,10 +110,9 @@ UNMAP_AFTER_INIT OwnPtr<PartitionTable> StorageManagement::try_to_initialize_par
     return {};
 }
 
-UNMAP_AFTER_INIT void StorageManagement::enumerate_disk_partitions() const
+UNMAP_AFTER_INIT void StorageManagement::enumerate_disk_partitions()
 {
     VERIFY(!m_storage_devices.is_empty());
-    NonnullRefPtrVector<DiskPartition> partitions;
     size_t device_index = 0;
     for (auto& device : m_storage_devices) {
         auto partition_table = try_to_initialize_partition_table(device);
@@ -124,9 +123,8 @@ UNMAP_AFTER_INIT void StorageManagement::enumerate_disk_partitions() const
             if (!partition_metadata.has_value())
                 continue;
             // FIXME: Try to not hardcode a maximum of 16 partitions per drive!
-            auto disk_partition = DiskPartition::create(const_cast<StorageDevice&>(device), (partition_index + (16 * device_index)), partition_metadata.value());
-            MUST(partitions.try_append(disk_partition));
-            MUST(const_cast<StorageDevice&>(device).m_partitions.try_append(disk_partition));
+            auto disk_partition = DiskPartition::create(device, (partition_index + (16 * device_index)), partition_metadata.value());
+            device.add_partition(disk_partition);
         }
         device_index++;
     }

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -38,7 +38,7 @@ private:
 
     void enumerate_controllers(bool force_pio);
     void enumerate_storage_devices();
-    void enumerate_disk_partitions() const;
+    void enumerate_disk_partitions();
 
     void determine_boot_device();
     void determine_boot_device_with_partition_uuid();


### PR DESCRIPTION
The enumerate_disk_partitions function doesn't need to be const.
 Remove the constness and use the newly added `add_partition` function.

Tested with a grub-image which touches the `DiskPartition` functionality.