### PR TITLE
Meta: Add /sbin in PATH - Fixes problematic behavior of #11438

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # shellcheck disable=SC2086 # FIXME: fix these globing warnings
 
+export PATH=$PATH:/sbin
+
 set -e
 
 die() {


### PR DESCRIPTION
On Debian it complains that `ldconfig: not found` during boot procedure due to the nature of system's security; this PR fixes #11438 by temporary adding `/sbin` in `PATH`.