### PR TITLE
Spreadsheet: Background fill color after reaching vertical end

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -173,6 +173,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
             m_table_view->set_column_width(last_column_index, 50);
             m_table_view->set_default_column_width(last_column_index, 50);
             m_table_view->set_column_header_alignment(last_column_index, Gfx::TextAlignment::Center);
+            m_table_view->set_column_painting_delegate(last_column_index, make<TableCellPainter>(*m_table_view));
         }
         update_with_model();
     };


### PR DESCRIPTION
When selecting a cell in the spreadsheet that was added automatically as per the InfinitelyScrollableTableView implementation, the background color is now filled correctly.

Previously, when navigating horizontally in a spreadsheet, after a certain point the cells would not have the same background fill color as the user would have experienced in the previous column ranges (A-Z).