### PR TITLE
Crypto: Fix some minor issues

### DIFF
--- a/Userland/Libraries/LibCrypto/Hash/HashFunction.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashFunction.h
@@ -13,11 +13,24 @@
 namespace Crypto {
 namespace Hash {
 
-template<size_t BlockS, typename DigestT>
+template<size_t DigestS>
+struct Digest {
+    static_assert(DigestS % 8 == 0);
+    constexpr static size_t Size = DigestS / 8;
+    u8 data[Size];
+
+    [[nodiscard]] ALWAYS_INLINE const u8* immutable_data() const { return data; }
+    [[nodiscard]] ALWAYS_INLINE size_t data_length() const { return Size; }
+};
+
+template<size_t BlockS, size_t DigestS, typename DigestT = Digest<DigestS>>
 class HashFunction {
 public:
+    static_assert(BlockS % 8 == 0);
     static constexpr auto BlockSize = BlockS / 8;
-    static constexpr auto DigestSize = DigestT::Size;
+
+    static_assert(DigestS % 8 == 0);
+    static constexpr auto DigestSize = DigestS / 8;
 
     using DigestType = DigestT;
 

--- a/Userland/Libraries/LibCrypto/Hash/HashFunction.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashFunction.h
@@ -21,6 +21,8 @@ struct Digest {
 
     [[nodiscard]] ALWAYS_INLINE const u8* immutable_data() const { return data; }
     [[nodiscard]] ALWAYS_INLINE size_t data_length() const { return Size; }
+
+    [[nodiscard]] ALWAYS_INLINE ReadonlyBytes bytes() const { return { immutable_data(), data_length() }; }
 };
 
 template<size_t BlockS, size_t DigestS, typename DigestT = Digest<DigestS>>

--- a/Userland/Libraries/LibCrypto/Hash/HashFunction.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashFunction.h
@@ -21,15 +21,15 @@ public:
 
     using DigestType = DigestT;
 
-    constexpr static size_t block_size() { return BlockSize; };
-    constexpr static size_t digest_size() { return DigestSize; };
+    constexpr static size_t block_size() { return BlockSize; }
+    constexpr static size_t digest_size() { return DigestSize; }
 
     virtual void update(const u8*, size_t) = 0;
 
-    void update(Bytes buffer) { update(buffer.data(), buffer.size()); };
-    void update(ReadonlyBytes buffer) { update(buffer.data(), buffer.size()); };
-    void update(const ByteBuffer& buffer) { update(buffer.data(), buffer.size()); };
-    void update(StringView string) { update((const u8*)string.characters_without_null_termination(), string.length()); };
+    void update(Bytes buffer) { update(buffer.data(), buffer.size()); }
+    void update(ReadonlyBytes buffer) { update(buffer.data(), buffer.size()); }
+    void update(const ByteBuffer& buffer) { update(buffer.data(), buffer.size()); }
+    void update(StringView string) { update((const u8*)string.characters_without_null_termination(), string.length()); }
 
     virtual DigestType peek() = 0;
     virtual DigestType digest() = 0;

--- a/Userland/Libraries/LibCrypto/Hash/HashManager.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashManager.h
@@ -59,14 +59,14 @@ struct MultiHashDigestVariant {
     {
     }
 
-    const u8* immutable_data() const
+    [[nodiscard]] const u8* immutable_data() const
     {
         return m_digest.visit(
             [&](const Empty&) -> const u8* { VERIFY_NOT_REACHED(); },
             [&](const auto& value) { return value.immutable_data(); });
     }
 
-    size_t data_length()
+    [[nodiscard]] size_t data_length() const
     {
         return m_digest.visit(
             [&](const Empty&) -> size_t { VERIFY_NOT_REACHED(); },

--- a/Userland/Libraries/LibCrypto/Hash/HashManager.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashManager.h
@@ -73,6 +73,13 @@ struct MultiHashDigestVariant {
             [&](const auto& value) { return value.data_length(); });
     }
 
+    [[nodiscard]] ReadonlyBytes bytes() const
+    {
+        return m_digest.visit(
+            [&](const Empty&) -> ReadonlyBytes { VERIFY_NOT_REACHED(); },
+            [&](const auto& value) { return value.bytes(); });
+    }
+
     using DigestVariant = Variant<Empty, MD5::DigestType, SHA1::DigestType, SHA256::DigestType, SHA384::DigestType, SHA512::DigestType>;
     DigestVariant m_digest {};
 };

--- a/Userland/Libraries/LibCrypto/Hash/HashManager.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashManager.h
@@ -77,7 +77,7 @@ struct MultiHashDigestVariant {
     DigestVariant m_digest {};
 };
 
-class Manager final : public HashFunction<0, MultiHashDigestVariant> {
+class Manager final : public HashFunction<0, 0, MultiHashDigestVariant> {
 public:
     using HashFunction::update;
 

--- a/Userland/Libraries/LibCrypto/Hash/MD5.h
+++ b/Userland/Libraries/LibCrypto/Hash/MD5.h
@@ -13,14 +13,6 @@
 namespace Crypto {
 namespace Hash {
 
-struct MD5Digest {
-    constexpr static size_t Size = 16;
-    u8 data[Size];
-
-    const u8* immutable_data() const { return data; }
-    size_t data_length() const { return Size; }
-};
-
 namespace MD5Constants {
 
 constexpr u32 init_A = 0x67452301;
@@ -53,7 +45,7 @@ constexpr u8 PADDING[] = {
 
 }
 
-class MD5 final : public HashFunction<512, MD5Digest> {
+class MD5 final : public HashFunction<512, 128> {
 public:
     using HashFunction::update;
 

--- a/Userland/Libraries/LibCrypto/Hash/SHA1.h
+++ b/Userland/Libraries/LibCrypto/Hash/SHA1.h
@@ -25,16 +25,7 @@ constexpr static u32 RoundConstants[4] {
 
 }
 
-template<size_t Bytes>
-struct SHA1Digest {
-    u8 data[Bytes];
-    constexpr static size_t Size = Bytes;
-
-    const u8* immutable_data() const { return data; }
-    size_t data_length() const { return Bytes; }
-};
-
-class SHA1 final : public HashFunction<512, SHA1Digest<160 / 8>> {
+class SHA1 final : public HashFunction<512, 160> {
 public:
     using HashFunction::update;
 

--- a/Userland/Libraries/LibCrypto/Hash/SHA1.h
+++ b/Userland/Libraries/LibCrypto/Hash/SHA1.h
@@ -61,7 +61,7 @@ public:
     virtual String class_name() const override
     {
         return "SHA1";
-    };
+    }
     inline virtual void reset() override
     {
         m_data_length = 0;

--- a/Userland/Libraries/LibCrypto/Hash/SHA2.h
+++ b/Userland/Libraries/LibCrypto/Hash/SHA2.h
@@ -72,16 +72,8 @@ constexpr static u64 InitializationHashes[8] = {
 };
 }
 
-template<size_t Bytes>
-struct SHA2Digest {
-    u8 data[Bytes];
-    constexpr static size_t Size = Bytes;
-    const u8* immutable_data() const { return data; }
-    size_t data_length() const { return Bytes; }
-};
-
 // FIXME: I want template<size_t BlockSize> but the compiler gets confused
-class SHA256 final : public HashFunction<512, SHA2Digest<256 / 8>> {
+class SHA256 final : public HashFunction<512, 256> {
 public:
     using HashFunction::update;
 
@@ -131,7 +123,7 @@ private:
     constexpr static auto Rounds = 64;
 };
 
-class SHA384 final : public HashFunction<1024, SHA2Digest<384 / 8>> {
+class SHA384 final : public HashFunction<1024, 384> {
 public:
     using HashFunction::update;
 
@@ -181,7 +173,7 @@ private:
     constexpr static auto Rounds = 80;
 };
 
-class SHA512 final : public HashFunction<1024, SHA2Digest<512 / 8>> {
+class SHA512 final : public HashFunction<1024, 512> {
 public:
     using HashFunction::update;
 

--- a/Userland/Utilities/checksum.cpp
+++ b/Userland/Utilities/checksum.cpp
@@ -64,8 +64,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         while (!file->eof() && !file->has_error())
             hash.update(file->read(PAGE_SIZE));
-        auto digest = hash.digest();
-        outln("{:hex-dump}  {}", ReadonlyBytes(digest.immutable_data(), digest.data_length()), path);
+        outln("{:hex-dump}  {}", hash.digest().bytes(), path);
     }
     return has_error ? 1 : 0;
 }

--- a/Userland/Utilities/checksum.cpp
+++ b/Userland/Utilities/checksum.cpp
@@ -65,12 +65,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         while (!file->eof() && !file->has_error())
             hash.update(file->read(PAGE_SIZE));
         auto digest = hash.digest();
-        auto digest_data = digest.immutable_data();
-        StringBuilder builder;
-        for (size_t i = 0; i < hash.digest_size(); ++i)
-            builder.appendff("{:02x}", digest_data[i]);
-        auto hash_sum_hex = builder.build();
-        outln("{}  {}", hash_sum_hex, path);
+        outln("{:hex-dump}  {}", ReadonlyBytes(digest.immutable_data(), digest.data_length()), path);
     }
     return has_error ? 1 : 0;
 }

--- a/Userland/Utilities/checksum.cpp
+++ b/Userland/Utilities/checksum.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/LexicalPath.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
@@ -15,7 +16,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath", nullptr));
 
-    auto program_name = arguments.strings[0];
+    auto program_name = LexicalPath::basename(arguments.strings[0]);
     auto hash_kind = Crypto::Hash::HashKind::None;
 
     if (program_name == "md5sum")


### PR DESCRIPTION
Hi,
The following change set simplify/clean up a little the libcrypto digest API, by unifying all the digest in a unique template.
Also simplify `checksum` code by using `AK::encode_hex`.