### PR TITLE
Userland: Fail Core::find_executable_in_path on empty inputs

### DIFF
--- a/Userland/Libraries/LibCore/DirIterator.cpp
+++ b/Userland/Libraries/LibCore/DirIterator.cpp
@@ -97,6 +97,9 @@ String DirIterator::next_full_path()
 
 String find_executable_in_path(String filename)
 {
+    if (filename.is_empty())
+        return {};
+
     if (filename.starts_with('/')) {
         if (access(filename.characters(), X_OK) == 0)
             return filename;

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -227,7 +227,7 @@ int Shell::builtin_type(int argc, const char** argv)
 
         // check if its an executable in PATH
         auto fullpath = Core::find_executable_in_path(command);
-        if (!fullpath.is_null()) {
+        if (!fullpath.is_empty()) {
             printf("%s is %s\n", command, escape_token(fullpath).characters());
             continue;
         }

--- a/Userland/Utilities/which.cpp
+++ b/Userland/Utilities/which.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     auto fullpath = Core::find_executable_in_path(filename);
-    if (fullpath.is_null()) {
+    if (fullpath.is_empty()) {
         warnln("no '{}' in path", filename);
         return 1;
     }


### PR DESCRIPTION
Before this patch, `which ""` or `type ""` would say that the empty
string is `/usr/local/bin/`.

Convert callers to consistently call is_empty() on the returned string
while we're at it, to support eventually removing the is_null() String
state in the future.