### PR TITLE
AK+LibSoftGPU: Add and use `AK::mix`

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -92,6 +92,12 @@ constexpr T clamp(const T& value, const IdentityType<T>& min, const IdentityType
 }
 
 template<typename T, typename U>
+constexpr T mix(T const& v1, T const& v2, U const& interpolation)
+{
+    return v1 + (v2 - v1) * interpolation;
+}
+
+template<typename T, typename U>
 constexpr T ceil_div(T a, U b)
 {
     static_assert(sizeof(T) == sizeof(U));
@@ -167,6 +173,7 @@ using AK::exchange;
 using AK::is_constant_evaluated;
 using AK::max;
 using AK::min;
+using AK::mix;
 using AK::RawPtr;
 using AK::swap;
 using AK::to_underlying;

--- a/Tests/AK/TestStdLibExtras.cpp
+++ b/Tests/AK/TestStdLibExtras.cpp
@@ -12,6 +12,20 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 
+TEST_CASE(mix)
+{
+    double a = 1.0;
+    double b = 3.0;
+
+    EXPECT_APPROXIMATE(mix(a, b, 0.0), 1.0);
+    EXPECT_APPROXIMATE(mix(a, b, 0.5), 2.0);
+    EXPECT_APPROXIMATE(mix(a, b, 1.0), 3.0);
+
+    EXPECT_APPROXIMATE(mix(b, a, 0.0), 3.0);
+    EXPECT_APPROXIMATE(mix(b, a, 0.5), 2.0);
+    EXPECT_APPROXIMATE(mix(b, a, 1.0), 1.0);
+}
+
 TEST_CASE(swap)
 {
     int i = 4;

--- a/Userland/Libraries/LibSoftGPU/Clipper.cpp
+++ b/Userland/Libraries/LibSoftGPU/Clipper.cpp
@@ -43,11 +43,11 @@ Vertex Clipper::clip_intersection_point(const Vertex& p1, const Vertex& p2, Clip
     float a = (w1 + x1) / ((w1 + x1) - (w2 + x2));
 
     Vertex out;
-    out.position = p1.position * (1 - a) + p2.position * a;
-    out.eye_coordinates = p1.eye_coordinates * (1 - a) + p2.eye_coordinates * a;
-    out.clip_coordinates = p1.clip_coordinates * (1 - a) + p2.clip_coordinates * a;
-    out.color = p1.color * (1 - a) + p2.color * a;
-    out.tex_coord = p1.tex_coord * (1 - a) + p2.tex_coord * a;
+    out.position = mix(p1.position, p2.position, a);
+    out.eye_coordinates = mix(p1.eye_coordinates, p2.eye_coordinates, a);
+    out.clip_coordinates = mix(p1.clip_coordinates, p2.clip_coordinates, a);
+    out.color = mix(p1.color, p2.color, a);
+    out.tex_coord = mix(p1.tex_coord, p2.tex_coord, a);
     return out;
 }
 

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -35,12 +35,6 @@ constexpr static T interpolate(const T& v0, const T& v1, const T& v2, const Floa
     return v0 * barycentric_coords.x() + v1 * barycentric_coords.y() + v2 * barycentric_coords.z();
 }
 
-template<typename T>
-constexpr static T mix(const T& x, const T& y, float interp)
-{
-    return x * (1 - interp) + y * interp;
-}
-
 ALWAYS_INLINE constexpr static Gfx::RGBA32 to_rgba32(const FloatVector4& v)
 {
     auto clamped = v.clamped(0, 1);
@@ -821,10 +815,9 @@ void Device::submit_triangle(const Triangle& triangle, Vector<size_t> const& ena
                 break;
             case TextureEnvMode::Decal: {
                 float src_alpha = fragment.w();
-                float one_minus_src_alpha = 1 - src_alpha;
-                fragment.set_x(texel.x() * src_alpha + fragment.x() * one_minus_src_alpha);
-                fragment.set_y(texel.y() * src_alpha + fragment.y() * one_minus_src_alpha);
-                fragment.set_z(texel.z() * src_alpha + fragment.z() * one_minus_src_alpha);
+                fragment.set_x(mix(fragment.x(), texel.x(), src_alpha));
+                fragment.set_y(mix(fragment.y(), texel.y(), src_alpha));
+                fragment.set_z(mix(fragment.z(), texel.z(), src_alpha));
                 break;
             }
             default:

--- a/Userland/Libraries/LibSoftGPU/Sampler.cpp
+++ b/Userland/Libraries/LibSoftGPU/Sampler.cpp
@@ -86,8 +86,11 @@ FloatVector4 Sampler::sample_2d(FloatVector2 const& uv) const
         return image.texel(layer, level, i, j, 0);
     }
 
-    int i0 = m_config.texture_wrap_u == TextureWrapMode::Repeat ? static_cast<unsigned>(floorf(u - 0.5f)) % width : floorf(u - 0.5f);
-    int j0 = m_config.texture_wrap_v == TextureWrapMode::Repeat ? static_cast<unsigned>(floorf(v - 0.5f)) % height : floorf(v - 0.5f);
+    u -= 0.5f;
+    v -= 0.5f;
+
+    int i0 = m_config.texture_wrap_u == TextureWrapMode::Repeat ? static_cast<unsigned>(floorf(u)) % width : floorf(u);
+    int j0 = m_config.texture_wrap_v == TextureWrapMode::Repeat ? static_cast<unsigned>(floorf(v)) % height : floorf(v);
 
     int i1 = m_config.texture_wrap_u == TextureWrapMode::Repeat ? (i0 + 1) % width : i0 + 1;
     int j1 = m_config.texture_wrap_v == TextureWrapMode::Repeat ? (j0 + 1) % height : j0 + 1;
@@ -108,8 +111,8 @@ FloatVector4 Sampler::sample_2d(FloatVector2 const& uv) const
         t3 = (i1 < 0 || i1 >= w || j1 < 0 || j1 >= h) ? m_config.border_color : image.texel(layer, level, i1, j1, 0);
     }
 
-    float const alpha = fracf(u - 0.5f);
-    float const beta = fracf(v - 0.5f);
+    float const alpha = fracf(u);
+    float const beta = fracf(v);
 
     auto const lerp_0 = mix(t0, t1, alpha);
     auto const lerp_1 = mix(t2, t3, alpha);

--- a/Userland/Libraries/LibSoftGPU/Sampler.cpp
+++ b/Userland/Libraries/LibSoftGPU/Sampler.cpp
@@ -108,16 +108,12 @@ FloatVector4 Sampler::sample_2d(FloatVector2 const& uv) const
         t3 = (i1 < 0 || i1 >= w || j1 < 0 || j1 >= h) ? m_config.border_color : image.texel(layer, level, i1, j1, 0);
     }
 
-    float alpha = fracf(u - 0.5f);
-    float beta = fracf(v - 0.5f);
+    float const alpha = fracf(u - 0.5f);
+    float const beta = fracf(v - 0.5f);
 
-    float one_minus_alpha = 1 - alpha;
-    float one_minus_beta = 1 - beta;
-
-    auto lerp_0 = t0 * one_minus_alpha + t1 * alpha;
-    auto lerp_1 = t2 * one_minus_alpha + t3 * alpha;
-
-    return lerp_0 * one_minus_beta + lerp_1 * beta;
+    auto const lerp_0 = mix(t0, t1, alpha);
+    auto const lerp_1 = mix(t2, t3, alpha);
+    return mix(lerp_0, lerp_1, beta);
 }
 
 }


### PR DESCRIPTION
* Adds a convenience interpolation function `AK::mix` and replaces hand-rolled interpolation in `LibSoftGPU` by it;
* Removes two superfluous U/V coordinate subtractions from `LibSoftGPU`'s `Sampler`

Note that the interpolation form `A + (B - A) * interpolation` result in somewhat more efficient instructions than `A * (1 - interpolation) + B * interpolation` since it saves a multiplication, but the real-world performance improvements are negligible.