### PR TITLE
PixelPaint: Add Fastboxblur and Bloom Filters

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     FilterGallery.cpp
     FilterGalleryGML.h
     FilterModel.cpp
+    Filters/Bloom.cpp
     Filters/BoxBlur3.cpp
     Filters/BoxBlur5.cpp
     Filters/Filter.cpp

--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -20,6 +20,7 @@ set(SOURCES
     Filters/BoxBlur3.cpp
     Filters/BoxBlur5.cpp
     Filters/Filter.cpp
+    Filters/FastBoxBlur.cpp
     Filters/GaussBlur3.cpp
     Filters/GaussBlur5.cpp
     Filters/Grayscale.cpp

--- a/Userland/Applications/PixelPaint/FilterModel.cpp
+++ b/Userland/Applications/PixelPaint/FilterModel.cpp
@@ -7,6 +7,7 @@
 
 #include "FilterModel.h"
 #include "FilterParams.h"
+#include "Filters/Bloom.h"
 #include "Filters/BoxBlur3.h"
 #include "Filters/BoxBlur5.h"
 #include "Filters/FastBoxBlur.h"
@@ -23,6 +24,11 @@
 namespace PixelPaint {
 FilterModel::FilterModel(ImageEditor* editor)
 {
+    auto artistic_category = FilterInfo::create_category("Artistic");
+    auto bloom_filter = FilterInfo::create_filter<Filters::Bloom>(editor, artistic_category);
+
+    m_filters.append(artistic_category);
+
     auto spatial_category = FilterInfo::create_category("Spatial");
 
     auto edge_detect_category = FilterInfo::create_category("Edge Detection", spatial_category);

--- a/Userland/Applications/PixelPaint/FilterModel.cpp
+++ b/Userland/Applications/PixelPaint/FilterModel.cpp
@@ -9,6 +9,7 @@
 #include "FilterParams.h"
 #include "Filters/BoxBlur3.h"
 #include "Filters/BoxBlur5.h"
+#include "Filters/FastBoxBlur.h"
 #include "Filters/GaussBlur3.h"
 #include "Filters/GaussBlur5.h"
 #include "Filters/Grayscale.h"
@@ -29,6 +30,7 @@ FilterModel::FilterModel(ImageEditor* editor)
     auto laplace_diagonal_filter = FilterInfo::create_filter<Filters::LaplaceDiagonal>(editor, edge_detect_category);
 
     auto blur_category = FilterInfo::create_category("Blur & Sharpen", spatial_category);
+    auto fast_box_filter = FilterInfo::create_filter<Filters::FastBoxBlur>(editor, blur_category);
     auto gaussian_blur_filter_3 = FilterInfo::create_filter<Filters::GaussBlur3>(editor, blur_category);
     auto gaussian_blur_filter_5 = FilterInfo::create_filter<Filters::GaussBlur5>(editor, blur_category);
     auto box_blur_filter_3 = FilterInfo::create_filter<Filters::BoxBlur3>(editor, blur_category);

--- a/Userland/Applications/PixelPaint/Filters/Bloom.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Bloom.h"
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/ValueSlider.h>
+#include <LibGUI/Widget.h>
+#include <LibGfx/BitmapMixer.h>
+#include <LibGfx/Filters/FastBoxBlurFilter.h>
+#include <LibGfx/Filters/LumaFilter.h>
+#include <LibGfx/FontDatabase.h>
+
+namespace PixelPaint::Filters {
+
+void Bloom::apply() const
+{
+    if (!m_editor)
+        return;
+    if (auto* layer = m_editor->active_layer()) {
+        auto intermediate_bitmap_or_error = layer->bitmap().clone();
+        if (intermediate_bitmap_or_error.is_error())
+            return;
+
+        auto intermediate_bitmap = intermediate_bitmap_or_error.release_value();
+
+        Gfx::LumaFilter luma_filter(intermediate_bitmap);
+        luma_filter.apply(m_luma_lower, 255);
+
+        Gfx::FastBoxBlurFilter blur_filter(intermediate_bitmap);
+        blur_filter.apply_three_passes(m_blur_radius);
+
+        Gfx::BitmapMixer mixer(layer->bitmap());
+        mixer.mix_with(intermediate_bitmap, Gfx::BitmapMixer::MixingMethod::Lightest);
+    }
+}
+RefPtr<GUI::Widget> Bloom::get_settings_widget()
+{
+    if (!m_settings_widget) {
+        m_settings_widget = GUI::Widget::construct();
+        m_settings_widget->set_layout<GUI::VerticalBoxLayout>();
+
+        auto& name_label = m_settings_widget->add<GUI::Label>("Bloom Filter");
+        name_label.set_font_weight(Gfx::FontWeight::Bold);
+        name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        name_label.set_fixed_height(20);
+
+        auto& luma_lower_container = m_settings_widget->add<GUI::Widget>();
+        luma_lower_container.set_fixed_height(50);
+        luma_lower_container.set_layout<GUI::VerticalBoxLayout>();
+        luma_lower_container.layout()->set_margins({ 4, 0, 4, 0 });
+
+        auto& luma_lower_label = luma_lower_container.add<GUI::Label>("Luma lower bound:");
+        luma_lower_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        luma_lower_label.set_fixed_height(20);
+
+        auto& luma_lower_slider = luma_lower_container.add<GUI::ValueSlider>(Orientation::Horizontal);
+        luma_lower_slider.set_range(0, 255);
+        luma_lower_slider.set_value(m_luma_lower);
+        luma_lower_slider.on_change = [&](int value) {
+            m_luma_lower = value;
+        };
+
+        auto& radius_container = m_settings_widget->add<GUI::Widget>();
+        radius_container.set_fixed_height(50);
+        radius_container.set_layout<GUI::VerticalBoxLayout>();
+        radius_container.layout()->set_margins({ 4, 0, 4, 0 });
+
+        auto& radius_label = radius_container.add<GUI::Label>("Blur Radius:");
+        radius_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        radius_label.set_fixed_height(20);
+
+        auto& radius_slider = radius_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
+        radius_slider.set_range(0, 50);
+        radius_slider.set_value(m_blur_radius);
+        radius_slider.on_change = [&](int value) {
+            m_blur_radius = value;
+        };
+    }
+
+    return m_settings_widget;
+}
+
+}

--- a/Userland/Applications/PixelPaint/Filters/Bloom.h
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Filter.h"
+
+namespace PixelPaint::Filters {
+
+class Bloom final : public Filter {
+public:
+    virtual void apply() const override;
+    virtual RefPtr<GUI::Widget> get_settings_widget() override;
+
+    virtual StringView filter_name() override { return "Bloom Filter"sv; }
+
+    Bloom(ImageEditor* editor)
+        : Filter(editor) {};
+
+private:
+    int m_luma_lower { 128 };
+    int m_blur_radius { 15 };
+};
+
+}

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "FastBoxBlur.h"
+#include "../FilterParams.h"
+#include <LibGUI/Label.h>
+#include <LibGUI/ValueSlider.h>
+#include <LibGfx/Filters/FastBoxBlurFilter.h>
+
+namespace PixelPaint::Filters {
+
+void FastBoxBlur::apply() const
+{
+    if (!m_editor)
+        return;
+    if (auto* layer = m_editor->active_layer()) {
+        Gfx::FastBoxBlurFilter filter(layer->bitmap());
+
+        if (m_approximate_gauss)
+            filter.apply_three_passes(m_radius);
+        else
+            filter.apply_single_pass(m_radius);
+
+        layer->did_modify_bitmap(layer->rect());
+        m_editor->did_complete_action();
+    }
+}
+
+RefPtr<GUI::Widget> FastBoxBlur::get_settings_widget()
+{
+    if (!m_settings_widget) {
+        m_settings_widget = GUI::Widget::construct();
+        m_settings_widget->set_layout<GUI::VerticalBoxLayout>();
+
+        auto& name_label = m_settings_widget->add<GUI::Label>("Fast Box Blur Filter");
+        name_label.set_font_weight(Gfx::FontWeight::Bold);
+        name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        name_label.set_fixed_height(20);
+
+        auto& radius_container = m_settings_widget->add<GUI::Widget>();
+        radius_container.set_fixed_height(20);
+        radius_container.set_layout<GUI::HorizontalBoxLayout>();
+        radius_container.layout()->set_margins({ 4, 0, 4, 0 });
+
+        auto& radius_label = radius_container.add<GUI::Label>("Radius:");
+        radius_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        radius_label.set_fixed_size(50, 20);
+
+        auto& radius_slider = radius_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
+        radius_slider.set_range(0, 25);
+        radius_slider.set_value(m_radius);
+        radius_slider.on_change = [&](int value) {
+            m_radius = value;
+        };
+
+        auto& gaussian_container = m_settings_widget->add<GUI::Widget>();
+        gaussian_container.set_fixed_height(20);
+        gaussian_container.set_layout<GUI::HorizontalBoxLayout>();
+        gaussian_container.layout()->set_margins({ 4, 0, 4, 0 });
+
+        auto& gaussian_checkbox = gaussian_container.add<GUI::CheckBox>("Approximate Gaussian Blur");
+        gaussian_checkbox.set_checked(m_approximate_gauss);
+        gaussian_checkbox.set_tooltip("A real gaussian blur can be approximated by running the box blur multiple times with different weights.");
+        gaussian_checkbox.on_checked = [this](bool checked) {
+            m_approximate_gauss = checked;
+        };
+    }
+
+    return m_settings_widget;
+}
+}

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Filter.h"
+
+namespace PixelPaint::Filters {
+
+class FastBoxBlur final : public Filter {
+public:
+    virtual void apply() const override;
+    virtual RefPtr<GUI::Widget> get_settings_widget() override;
+
+    virtual StringView filter_name() override { return "Fast Box Blur (& Gauss)"sv; }
+
+    FastBoxBlur(ImageEditor* editor)
+        : Filter(editor) {};
+
+private:
+    size_t m_radius { 5 };
+    bool m_approximate_gauss { false };
+};
+
+}

--- a/Userland/Libraries/LibGfx/BitmapMixer.cpp
+++ b/Userland/Libraries/LibGfx/BitmapMixer.cpp
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "BitmapMixer.h"
+
+namespace Gfx {
+
+void BitmapMixer::mix_with(Bitmap& other_bitmap, MixingMethod mixing_method)
+{
+    VERIFY(m_bitmap.size() == other_bitmap.size());
+
+    int height = m_bitmap.height();
+    int width = m_bitmap.width();
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            auto original_color = m_bitmap.get_pixel(x, y);
+            auto other_color = other_bitmap.get_pixel(x, y);
+
+            Color output_color = { 0, 0, 0, original_color.alpha() };
+            switch (mixing_method) {
+            case MixingMethod::Add:
+                output_color.set_red(original_color.red() + other_color.red());
+                output_color.set_green(original_color.green() + other_color.green());
+                output_color.set_blue(original_color.blue() + other_color.blue());
+                break;
+            case MixingMethod::Lightest:
+                auto original_lightness = original_color.red() + original_color.green() + original_color.blue();
+                auto other_lightness = other_color.red() + other_color.green() + other_color.blue();
+                if (original_lightness > other_lightness) {
+                    output_color = original_color;
+                } else {
+                    output_color.set_red(other_color.red());
+                    output_color.set_green(other_color.green());
+                    output_color.set_blue(other_color.blue());
+                }
+                break;
+            }
+            if (original_color != output_color)
+                m_bitmap.set_pixel(x, y, output_color);
+        }
+    }
+}
+
+}

--- a/Userland/Libraries/LibGfx/BitmapMixer.h
+++ b/Userland/Libraries/LibGfx/BitmapMixer.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Bitmap.h"
+
+namespace Gfx {
+
+class BitmapMixer {
+public:
+    enum class MixingMethod {
+        Add,
+        Lightest,
+    };
+
+    BitmapMixer(Bitmap& bitmap)
+        : m_bitmap(bitmap) {};
+
+    void mix_with(Bitmap&, MixingMethod);
+
+private:
+    Bitmap& m_bitmap;
+};
+
+}

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     AffineTransform.cpp
     AntiAliasingPainter.cpp
     Bitmap.cpp
+    BitmapMixer.cpp
     BitmapFont.cpp
     BMPLoader.cpp
     BMPWriter.cpp

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -16,6 +16,7 @@ set(SOURCES
     Emoji.cpp
     Filters/ColorBlindnessFilter.cpp
     Filters/FastBoxBlurFilter.cpp
+    Filters/LumaFilter.cpp
     FontDatabase.cpp
     GIFLoader.cpp
     ICOLoader.cpp

--- a/Userland/Libraries/LibGfx/Filters/LumaFilter.cpp
+++ b/Userland/Libraries/LibGfx/Filters/LumaFilter.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "LumaFilter.h"
+namespace Gfx {
+
+void LumaFilter::apply(u8 lower_bound, u8 upper_bound)
+{
+    if (upper_bound < lower_bound)
+        return;
+
+    int height = m_bitmap.height();
+    int width = m_bitmap.width();
+
+    auto format = m_bitmap.format();
+    VERIFY(format == BitmapFormat::BGRA8888 || format == BitmapFormat::BGRx8888);
+
+    for (int y = 0; y < height; ++y) {
+        for (int x = 0; x < width; ++x) {
+            Color color;
+            color = m_bitmap.get_pixel(x, y);
+
+            auto luma = color.luminosity();
+            if (lower_bound > luma || upper_bound < luma)
+                m_bitmap.set_pixel(x, y, { 0, 0, 0, color.alpha() });
+        }
+    }
+}
+
+}

--- a/Userland/Libraries/LibGfx/Filters/LumaFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/LumaFilter.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Bitmap.h>
+
+namespace Gfx {
+
+class LumaFilter {
+public:
+    LumaFilter(Bitmap& bitmap)
+        : m_bitmap(bitmap) {};
+
+    void apply(u8 lower_bound, u8 upper_bound);
+
+private:
+    Bitmap& m_bitmap;
+};
+
+}


### PR DESCRIPTION
This PR adds two new Filters to PixelPaint:
- FastBoxBlur: This filter lived inside LibGfx for a long time, now exposed to PixelPaint
![image](https://user-images.githubusercontent.com/6002167/148079685-1d067609-e9fe-4f33-950b-a2e8bb1f6b8b.png)
To get this filter to work, I extended the FBBF to also know what to do with the ImageFormat BGRx8888.

- Bloom: An artistic filter for mimicking bleeding of bright areas into dark ones in real cameras
![image](https://user-images.githubusercontent.com/6002167/148079790-f489fab9-cd2a-4d75-85b7-acf846855070.png)
For this filter, I added a LumaFilter to LibGfx, that lets you keep parts of an image that lie within a certain luminosity threshold. And  also a BitmapMixer I use to draw two Bitmaps onto each other, this is very naive but gets the job done for now.
This is what it looks like: left before, right after (done entirely in PixelPaint):
![bloom-example](https://user-images.githubusercontent.com/6002167/148081385-17630133-68b5-4c6c-ab31-82dc687e10e9.png)

