### PR TITLE
PixelPaint: Fix crash on applying with no filter selected

### DIFF
--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -56,8 +56,10 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
     };
 
     apply_button->on_click = [this](auto) {
-        if (!m_selected_filter)
+        if (!m_selected_filter) {
             done(ExecResult::ExecAborted);
+            return;
+        }
 
         m_selected_filter->apply();
         done(ExecResult::ExecOK);


### PR DESCRIPTION
The wrong conception that done() would stop the program flow right there
lead to the lambda not properly aborting when no filter was selected.

The ExecAborted would be processed and then the nullptr that was
m_selected_filter would be happily dereferenced.

This patch fixes that.

Thanks to @AtkinsSJ for finding the bug :^)