### PR TITLE
Meta: Add /sbin to PATH

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # shellcheck disable=SC2086 # FIXME: fix these globing warnings
 
+export PATH=$PATH:/sbin
+
 set -e
 
 die() {


### PR DESCRIPTION
On Debian it complains that `ldconfig: not found` during boot procedure
due to the nature of system's security; this PR fixes #11438 by
temporarily adding /sbin to PATH.

`TobyAsE` thank you for proof reading my gibberish and turn them to proper English :+1: 