### PR TITLE
Kernel+Toolchain: Unbreak aarch64 builds

### DIFF
--- a/Kernel/FileSystem/DeviceFileTypes.h
+++ b/Kernel/FileSystem/DeviceFileTypes.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Types.h>
+#include <AK/DistinctNumeric.h>
 
 namespace Kernel {
 

--- a/Ports/gcc/patches/gcc.patch
+++ b/Ports/gcc/patches/gcc.patch
@@ -46,7 +46,7 @@ index a75b44ee4..6fab7c3ca 100644
 +
  ; This comment is to ensure we retain the blank line above.
 diff --git a/gcc/config.gcc b/gcc/config.gcc
-index 357b0bed0..151d93312 100644
+index 357b0bed0..8e96b74e5 100644
 --- a/gcc/config.gcc
 +++ b/gcc/config.gcc
 @@ -686,6 +686,13 @@ x86_cpus="generic intel"
@@ -63,7 +63,7 @@ index 357b0bed0..151d93312 100644
  *-*-darwin*)
    tmake_file="t-darwin "
    tm_file="${tm_file} darwin.h"
-@@ -1084,6 +1091,18 @@ case ${target} in
+@@ -1084,6 +1091,19 @@ case ${target} in
  esac
  
  case ${target} in
@@ -78,6 +78,7 @@ index 357b0bed0..151d93312 100644
 +    ;;
 +aarch64-*-serenity*)
 +    tm_file="${tm_file} dbxelf.h elfos.h aarch64/aarch64-elf.h glibc-stdint.h serenity.h"
++    tmake_file="${tmake_file} aarch64/t-aarch64"
 +    ;;
  aarch64*-*-elf | aarch64*-*-fuchsia* | aarch64*-*-rtems*)
  	tm_file="${tm_file} dbxelf.h elfos.h newlib-stdint.h"

--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -46,7 +46,7 @@ index a75b44ee4..6fab7c3ca 100644
 +
  ; This comment is to ensure we retain the blank line above.
 diff --git a/gcc/config.gcc b/gcc/config.gcc
-index 357b0bed0..151d93312 100644
+index 357b0bed0..8e96b74e5 100644
 --- a/gcc/config.gcc
 +++ b/gcc/config.gcc
 @@ -686,6 +686,13 @@ x86_cpus="generic intel"
@@ -63,7 +63,7 @@ index 357b0bed0..151d93312 100644
  *-*-darwin*)
    tmake_file="t-darwin "
    tm_file="${tm_file} darwin.h"
-@@ -1084,6 +1091,18 @@ case ${target} in
+@@ -1084,6 +1091,19 @@ case ${target} in
  esac
  
  case ${target} in
@@ -78,6 +78,7 @@ index 357b0bed0..151d93312 100644
 +    ;;
 +aarch64-*-serenity*)
 +    tm_file="${tm_file} dbxelf.h elfos.h aarch64/aarch64-elf.h glibc-stdint.h serenity.h"
++    tmake_file="${tmake_file} aarch64/t-aarch64"
 +    ;;
  aarch64*-*-elf | aarch64*-*-fuchsia* | aarch64*-*-rtems*)
  	tm_file="${tm_file} dbxelf.h elfos.h newlib-stdint.h"


### PR DESCRIPTION
### Kernel: Include correct header for DistinctNumeric in DeviceFileTypes.h 
Fixes an aarch64 build failure.

### Toolchain: Fix building the aarch64 toolchain
The `aarch64/t-aarch64` makefile fragment needs to be included for the
aarch64-specific parts of GCC to be built. Before 738e52da5, this was
done implicitly, but now it is not. This caused the following error when
building the toolchain: "aarch64-builtins.o: No such file or directory".