### PR TITLE
ls + stat: Fixes to the printed error messages

### DIFF
--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -148,8 +148,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         metadata.name = path;
 
         int rc = lstat(String(path).characters(), &metadata.stat);
-        if (rc < 0)
+        if (rc < 0) {
             perror("lstat");
+            continue;
+        }
 
         files.append(metadata);
     }

--- a/Userland/Utilities/stat.cpp
+++ b/Userland/Utilities/stat.cpp
@@ -99,7 +99,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     bool had_error = false;
     for (auto& file : files) {
-        had_error |= stat(file, should_follow_links).is_error();
+        auto r = stat(file, should_follow_links);
+        if (r.is_error()) {
+            had_error = true;
+            warnln("stat: cannot stat '{}': {}", file, strerror(r.error().code()));
+        }
     }
 
     return had_error;


### PR DESCRIPTION
**stat: Print an error if 'stat' fails**

Previously if we called `stat` with a file that doesn't exist nothing would happen (eg: `stat asdasdasd`). This change prints a simple error message

**ls: Fix duplicated error message when opening a directory fails**

Previously if we called `ls` with a non-existent directory 2 error messages would be printed. This commit fixes that