### PR TITLE
LibGUI: Consume initial spaces when going to next/prev word break

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -654,6 +654,8 @@ TextPosition TextDocument::first_word_break_before(const TextPosition& position,
     if (target.column() == line.length())
         modifier = 1;
 
+    while (target.column() > 0 && is_ascii_blank(line.code_points()[target.column() - modifier]))
+        target.set_column(target.column() - 1);
     auto is_start_alphanumeric = is_ascii_alphanumeric(line.code_points()[target.column() - modifier]);
 
     while (target.column() > 0) {
@@ -678,6 +680,8 @@ TextPosition TextDocument::first_word_break_after(const TextPosition& position) 
         return TextPosition(position.line() + 1, 0);
     }
 
+    while (target.column() < line.length() && is_ascii_space(line.code_points()[target.column()]))
+        target.set_column(target.column() + 1);
     auto is_start_alphanumeric = is_ascii_alphanumeric(line.code_points()[target.column()]);
 
     while (target.column() < line.length()) {


### PR DESCRIPTION
Make `Document::first_word_break_(after|before)` consume the initial white spaces, and then keep same logic. This makes ctrl+left, ctrl+backspace, etc behave a bit more nicely IMO.

[pressing `ctrl+shift+left` each time here]

Before:

![before](https://user-images.githubusercontent.com/15224242/148139849-e4bf238b-f2d4-4e33-8a9d-3fbc6a54a907.gif)

After:

![after](https://user-images.githubusercontent.com/15224242/148139861-2f294a62-451d-42eb-854c-f910f52e8e99.gif)

