### PR TITLE
AK+Userland+Kernel: Fetch USB Device Configuration Descriptors and add ability to print them via `lsusb`

### DIFF
--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -91,6 +91,22 @@ public:
     u32 to_u32(u32 default_value = 0) const { return to_number<u32>(default_value); }
     u64 to_u64(u64 default_value = 0) const { return to_number<u64>(default_value); }
 
+    String to_bcd(u32 default_value = 0) const
+    {
+        StringBuilder bcd_result;
+        u32 as_u32 = to_number<u32>(default_value);
+
+        while (as_u32 != 0) {
+            u8 nybble = (as_u32 & 0xf);
+            bcd_result.append(nybble + '0');
+            as_u32 >>= 4;
+            if (as_u32 != 0)
+                bcd_result.append('.');
+        }
+
+        return bcd_result.to_string().reverse();
+    }
+
     FlatPtr to_addr(FlatPtr default_value = 0) const
     {
 #ifdef __LP64__

--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -43,6 +43,22 @@ ErrorOr<void> SysFSUSBDeviceInformation::try_generate(KBufferBuilder& builder)
     obj.add("product_string_descriptor_index", m_device->device_descriptor().product_string_descriptor_index);
     obj.add("serial_number_descriptor_index", m_device->device_descriptor().serial_number_descriptor_index);
     obj.add("num_configurations", m_device->device_descriptor().num_configurations);
+
+    auto configuration_descriptor_array = obj.add_array("configuration_descriptors");
+    for (auto index = 0; index < m_device->device_descriptor().num_configurations; index++) {
+        const auto* const configuration_descriptor = TRY(m_device->configuration_descriptor(index));
+        auto configuration_descriptor_element = configuration_descriptor_array.add_object();
+
+        configuration_descriptor_element.add("total_length", configuration_descriptor->total_length);
+        configuration_descriptor_element.add("number_of_interfaces", configuration_descriptor->number_of_interfaces);
+        configuration_descriptor_element.add("configuration_value", configuration_descriptor->configuration_value);
+        configuration_descriptor_element.add("configuration_string_descriptor_index", configuration_descriptor->configuration_string_descriptor_index);
+        configuration_descriptor_element.add("attributes_bitmap", configuration_descriptor->attributes_bitmap);
+        configuration_descriptor_element.add("max_power_in_ma", configuration_descriptor->max_power_in_ma);
+        configuration_descriptor_element.finish();
+    }
+    configuration_descriptor_array.finish();
+
     obj.finish();
     array.finish();
     return {};

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -8,6 +8,7 @@
 
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 #include <Kernel/Bus/USB/USBPipe.h>
 
 namespace Kernel::USB {
@@ -41,6 +42,8 @@ public:
 
     const USBDeviceDescriptor& device_descriptor() const { return m_device_descriptor; }
 
+    ErrorOr<const USBConfigurationDescriptor*> configuration_descriptor(u8 descriptor_index) const;
+
     USBController& controller() { return *m_controller; }
     USBController const& controller() const { return *m_controller; }
 
@@ -52,9 +55,11 @@ protected:
     u8 m_address { 0 };         // USB address assigned to this device
 
     // Device description
-    u16 m_vendor_id { 0 };                   // This device's vendor ID assigned by the USB group
-    u16 m_product_id { 0 };                  // This device's product ID assigned by the USB group
-    USBDeviceDescriptor m_device_descriptor; // Device Descriptor obtained from USB Device
+    u16 m_vendor_id { 0 };  // This device's vendor ID assigned by the USB group
+    u16 m_product_id { 0 }; // This device's product ID assigned by the USB group
+
+    USBDeviceDescriptor m_device_descriptor;                        // Device Descriptor obtained from USB Device
+    Vector<USBConfigurationDescriptor> m_configuration_descriptors; // List of configuration descriptors for Device Descriptor
 
     NonnullRefPtr<USBController> m_controller;
     NonnullOwnPtr<Pipe> m_default_pipe; // Default communication pipe (endpoint0) used during enumeration

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -236,11 +236,13 @@ if [ -z "$SERENITY_MACHINE" ]; then
     fi
 fi
 
-if [ "$NATIVE_WINDOWS_QEMU" -ne "1" ]; then
+# Enable QEMU QMP protocol only if we want to profile the kernel
+# via QMP. Enabling this otherwise removes the QEMU monitor, which
+# is required to debug things like USB
+if [ "$NATIVE_WINDOWS_QEMU" -ne "1" ] && [ "$SERENITY_PROFILE_KERNEL_QMP" -eq "1" ]; then
     SERENITY_MACHINE="$SERENITY_MACHINE
     -qmp unix:qmp-sock,server,nowait"
 fi
-
 
 
 [ -z "$SERENITY_COMMON_QEMU_ARGS" ] && SERENITY_COMMON_QEMU_ARGS="

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -73,18 +73,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (print_verbose) {
                 // Print out lots of information about the device
                 outln("Device Descriptor");
-                outln(" usb_spec_compliance_bcd: {: > 13}", device_json.get("usb_spec_compliance_bcd").to_i32());
+                outln(" usb_spec_compliance_bcd: {:>15}", device_json.get("usb_spec_compliance_bcd").to_bcd());
                 outln(" device_class: {:>22}", device_json.get("device_class").to_i32());
                 outln(" device_sub_class: {:>18}", device_json.get("device_sub_class").to_i32());
                 outln(" device_protocol: {:>19}", device_json.get("device_protocol").to_i32());
                 outln(" max_packet_size: {:>19}", device_json.get("max_packet_size").to_i32());
-                outln(" vendor_id: {: >24}{:04x} {}", "", device_json.get("vendor_id").to_u32(), vendor_string);
-                outln(" product_id: {: >23}{:04x} {}", "", device_json.get("product_id").to_u32(), device_string);
-                outln(" device_release_bcd: {: > 20}", device_json.get("device_release_bcd").to_i32());
-                outln(" manufacturer_id_descriptor_index: {: > 2}", device_json.get("manufacturer_id_descriptor_index").to_i32());
-                outln(" product_string_descriptor_index: {: > 3}", device_json.get("product_string_descriptor_index").to_i32());
-                outln(" serial_number_descriptor_index: {: > 4}", device_json.get("serial_number_descriptor_index").to_i32());
-                outln(" num_configurations: {: > 16}", device_json.get("num_configurations").to_i32());
+                outln(" vendor_id: {:>24}{:04x} {}", "", device_json.get("vendor_id").to_u32(), vendor_string);
+                outln(" product_id: {:>23}{:04x} {}", "", device_json.get("product_id").to_u32(), device_string);
+                outln(" device_release_bcd: {:>22}", device_json.get("device_release_bcd").to_bcd());
+                outln(" manufacturer_id_descriptor_index: {:>2}", device_json.get("manufacturer_id_descriptor_index").to_i32());
+                outln(" product_string_descriptor_index: {:>3}", device_json.get("product_string_descriptor_index").to_i32());
+                outln(" serial_number_descriptor_index: {:>4}", device_json.get("serial_number_descriptor_index").to_i32());
+                outln(" num_configurations: {:>16}", device_json.get("num_configurations").to_i32());
 
                 // Now print out the configuration descriptors
                 const auto& configuration_descriptors = device_json.get("configuration_descriptors").as_array();
@@ -92,11 +92,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     auto& descriptor_json_object = configuration_descriptor.as_object();
 
                     outln("Configuration Descriptor");
-                    outln(" number_of_interfaces: {: >18}", descriptor_json_object.get("number_of_interfaces").to_i32());
-                    outln(" configuration_value: {: >19}", descriptor_json_object.get("configuration_value").to_i32());
+                    outln(" number_of_interfaces: {:>18}", descriptor_json_object.get("number_of_interfaces").to_i32());
+                    outln(" configuration_value: {:>19}", descriptor_json_object.get("configuration_value").to_i32());
                     outln(" configuration_string_descriptor_index: {}", descriptor_json_object.get("configuration_string_descriptor_index"));
-                    outln(" attributes_bitmap: {: >20}{:08b}", "", descriptor_json_object.get("attributes_bitmap").to_u32()); // TODO: Decode bitmap ala Linux
-                    outln(" max_power_in_ma: {: >24}", descriptor_json_object.get("max_power_in_ma").to_u32());
+                    outln(" attributes_bitmap: {:>20}{:08b}", "", descriptor_json_object.get("attributes_bitmap").to_u32()); // TODO: Decode bitmap ala Linux
+                    outln(" max_power_in_ma: {:>24}", descriptor_json_object.get("max_power_in_ma").to_u32() * 2);           // This value is in 2mA steps
                 });
             }
         });

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -25,8 +25,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res/usb.ids", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
+    bool print_verbose = false;
+
     Core::ArgsParser args;
     args.set_general_help("List USB devices.");
+    args.add_option(print_verbose, "Print verbose information about each device", "verbose", 'v');
     args.parse(arguments);
 
     Core::DirIterator usb_devices("/sys/bus/usb", Core::DirIterator::SkipDots);
@@ -53,12 +56,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
         auto json = json_or_error.release_value();
 
-        json.as_array().for_each([usb_db](auto& value) {
-            auto& device_descriptor = value.as_object();
+        json.as_array().for_each([usb_db, print_verbose](auto& value) {
+            auto& device_json = value.as_object();
 
-            auto device_address = device_descriptor.get("device_address").to_u32();
-            auto vendor_id = device_descriptor.get("vendor_id").to_u32();
-            auto product_id = device_descriptor.get("product_id").to_u32();
+            auto device_address = device_json.get("device_address").to_u32();
+            auto vendor_id = device_json.get("vendor_id").to_u32();
+            auto product_id = device_json.get("product_id").to_u32();
 
             StringView vendor_string = usb_db->get_vendor(vendor_id);
             StringView device_string = usb_db->get_device(vendor_id, product_id);
@@ -66,6 +69,36 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 device_string = "Unknown Device";
 
             outln("Device {}: ID {:04x}:{:04x} {} {}", device_address, vendor_id, product_id, vendor_string, device_string);
+
+            if (print_verbose) {
+                // Print out lots of information about the device
+                outln("Device Descriptor");
+                outln(" usb_spec_compliance_bcd: {: > 13}", device_json.get("usb_spec_compliance_bcd").to_i32());
+                outln(" device_class: {:>22}", device_json.get("device_class").to_i32());
+                outln(" device_sub_class: {:>18}", device_json.get("device_sub_class").to_i32());
+                outln(" device_protocol: {:>19}", device_json.get("device_protocol").to_i32());
+                outln(" max_packet_size: {:>19}", device_json.get("max_packet_size").to_i32());
+                outln(" vendor_id: {: >24}{:04x} {}", "", device_json.get("vendor_id").to_u32(), vendor_string);
+                outln(" product_id: {: >23}{:04x} {}", "", device_json.get("product_id").to_u32(), device_string);
+                outln(" device_release_bcd: {: > 20}", device_json.get("device_release_bcd").to_i32());
+                outln(" manufacturer_id_descriptor_index: {: > 2}", device_json.get("manufacturer_id_descriptor_index").to_i32());
+                outln(" product_string_descriptor_index: {: > 3}", device_json.get("product_string_descriptor_index").to_i32());
+                outln(" serial_number_descriptor_index: {: > 4}", device_json.get("serial_number_descriptor_index").to_i32());
+                outln(" num_configurations: {: > 16}", device_json.get("num_configurations").to_i32());
+
+                // Now print out the configuration descriptors
+                const auto& configuration_descriptors = device_json.get("configuration_descriptors").as_array();
+                configuration_descriptors.for_each([&](const JsonValue& configuration_descriptor) {
+                    auto& descriptor_json_object = configuration_descriptor.as_object();
+
+                    outln("Configuration Descriptor");
+                    outln(" number_of_interfaces: {: >18}", descriptor_json_object.get("number_of_interfaces").to_i32());
+                    outln(" configuration_value: {: >19}", descriptor_json_object.get("configuration_value").to_i32());
+                    outln(" configuration_string_descriptor_index: {}", descriptor_json_object.get("configuration_string_descriptor_index"));
+                    outln(" attributes_bitmap: {: >20}{:08b}", "", descriptor_json_object.get("attributes_bitmap").to_u32()); // TODO: Decode bitmap ala Linux
+                    outln(" max_power_in_ma: {: >24}", descriptor_json_object.get("max_power_in_ma").to_u32());
+                });
+            }
         });
     }
 


### PR DESCRIPTION
As the title says. The `lsusb` shipped with Linux contains a `-v` flag which prints a lot of information about the device. Considering we can't yet really "do" anything with our little USB stack, having this kind of information will be very handy when we eventually get around to implement driver probing/correct USB scheduling to get devices doing something on the bus :^) 