### PR TITLE
LibJS+LibUnicode: Handle flexible day periods that roll over midnight

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -2043,9 +2043,15 @@ Optional<StringView> get_calendar_day_period_symbol_for_hour(StringView locale, 
     auto day_periods = s_day_period_lists[day_periods_index];
 
     for (auto day_period_index : day_periods) {
-        auto const& day_period = s_day_periods[day_period_index];
+        auto day_period = s_day_periods[day_period_index];
+        auto h = hour;
 
-        if ((day_period.begin <= hour) && (hour < day_period.end)) {
+        if (day_period.begin > day_period.end) {
+            day_period.end += 24;
+            h += 24;
+        }
+
+        if ((day_period.begin <= h) && (h < day_period.end)) {
             auto period = static_cast<DayPeriod>(day_period.day_period);
             return get_calendar_day_period_symbol(locale, calendar, style, period);
         }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -261,6 +261,14 @@ describe("dayPeriod", () => {
             expect(as.format(d1)).toBe(d.as1);
         });
     });
+
+    test("flexible day period rolls over midnight", () => {
+        // For the en locale, this time (05:00) falls in the flexible day period range of [21:00, 06:00).
+        const date = Date.UTC(2017, 11, 12, 5, 0, 0, 0);
+
+        const en = new Intl.DateTimeFormat("en", { dayPeriod: "short", timeZone: "UTC" });
+        expect(en.format(date)).toBe("5 at night");
+    });
 });
 
 describe("hour", () => {


### PR DESCRIPTION
When searching for the locale-specific flexible day period for a given
hour, we were neglecting to handle cases where the period crosses 00:00.
For example, the en locale defines a day period range of [21:00, 06:00).
When given the hour of 05:00, we were checking if (21 <= 5 && 5 < 6),
thus not recognizing that the hour falls in that period.