### PR TITLE
LibGfx/QOI: Respect number of channels when creating the `Bitmap`s

### DIFF
--- a/Userland/Libraries/LibGfx/QOILoader.h
+++ b/Userland/Libraries/LibGfx/QOILoader.h
@@ -33,6 +33,7 @@ struct QOILoadingContext {
     State state { State::NotDecoded };
     u8 const* data { nullptr };
     size_t data_size { 0 };
+    Optional<u8> channels_override;
     QOIHeader header {};
     RefPtr<Bitmap> bitmap;
     Optional<Error> error;
@@ -41,7 +42,7 @@ struct QOILoadingContext {
 class QOIImageDecoderPlugin final : public ImageDecoderPlugin {
 public:
     virtual ~QOIImageDecoderPlugin() override = default;
-    QOIImageDecoderPlugin(u8 const*, size_t);
+    QOIImageDecoderPlugin(u8 const*, size_t, Optional<u8> channels_override = {});
 
     virtual IntSize size() override;
     virtual void set_volatile() override;


### PR DESCRIPTION
Hi,

When loading a `QOI` the header gives us the number of channels. Lets respect that.

In practice, it should not make any difference for serenity. While a conforming encoder should not allow to embed alpha channel data if the number of channel is 3, nothing forbids to use the alpha values in the format. (Though, the reference implementation is not protected against such abuse and will produce garbage and do a buffer overflow...)