### PR TITLE
AK+LibJS: Implement Date.UTC according to the spec

### DIFF
--- a/AK/Time.h
+++ b/AK/Time.h
@@ -15,6 +15,8 @@
 struct timeval;
 struct timespec;
 
+namespace AK {
+
 // Concept to detect types which look like timespec without requiring the type.
 template<typename T>
 concept TimeSpecType = requires(T t)
@@ -22,10 +24,6 @@ concept TimeSpecType = requires(T t)
     t.tv_sec;
     t.tv_nsec;
 };
-
-// FIXME: remove once Clang formats these properly.
-// clang-format off
-namespace AK {
 
 // Month and day start at 1. Month must be >= 1 and <= 12.
 // The return value is 0-indexed, that is 0 is Sunday, 1 is Monday, etc.
@@ -298,7 +296,6 @@ inline bool operator!=(const T& a, const T& b)
 }
 
 }
-// clang-format on
 
 using AK::day_of_week;
 using AK::day_of_year;

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -61,6 +61,11 @@ inline int years_to_days_since_epoch(int year)
     return days;
 }
 
+inline int days_since_epoch(int year, int month, int day)
+{
+    return years_to_days_since_epoch(year) + day_of_year(year, month, day);
+}
+
 /*
  * Represents a time amount in a "safe" way.
  * Minimum: 0 seconds, 0 nanoseconds
@@ -301,6 +306,7 @@ using AK::day_of_week;
 using AK::day_of_year;
 using AK::days_in_month;
 using AK::days_in_year;
+using AK::days_since_epoch;
 using AK::is_leap_year;
 using AK::Time;
 using AK::timespec_add;

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -156,7 +156,7 @@ void DateConstructor::initialize(GlobalObject& global_object)
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.now, now, 0, attr);
     define_native_function(vm.names.parse, parse, 1, attr);
-    define_native_function(vm.names.UTC, utc, 1, attr);
+    define_native_function(vm.names.UTC, utc, 7, attr);
 
     define_direct_property(vm.names.length, Value(7), Attribute::Configurable);
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.UTC.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.UTC.js
@@ -1,3 +1,7 @@
+test("length is 7", () => {
+    expect(Date.UTC).toHaveLength(7);
+});
+
 test("basic functionality", () => {
     expect(Date.UTC(2020)).toBe(1577836800000);
     expect(Date.UTC(2000, 10)).toBe(973036800000);

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.UTC.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.UTC.js
@@ -53,3 +53,20 @@ test("out of range", () => {
     expect(Date.UTC(2020, 1, 15, 12, 30, 30, -2345)).toBe(1581769827655);
     expect(Date.UTC(2020, 1, 15, 12, 30, 30, 2345)).toBe(1581769832345);
 });
+
+test("special values", () => {
+    [Infinity, -Infinity, NaN].forEach(value => {
+        expect(Date.UTC(value)).toBeNaN();
+        expect(Date.UTC(0, value)).toBeNaN();
+        expect(Date.UTC(0, 0, value)).toBeNaN();
+        expect(Date.UTC(0, 0, 1, value)).toBeNaN();
+        expect(Date.UTC(0, 0, 1, 0, value)).toBeNaN();
+        expect(Date.UTC(0, 0, 1, 0, 0, value)).toBeNaN();
+        expect(Date.UTC(0, 0, 1, 0, 0, 0, value)).toBeNaN();
+    });
+});
+
+test("time clip", () => {
+    expect(Date.UTC(275760, 8, 13, 0, 0, 0, 0)).toBe(8.64e15);
+    expect(Date.UTC(275760, 8, 13, 0, 0, 0, 1)).toBeNaN();
+});


### PR DESCRIPTION
This fixes all failing Date.UTC test262 tests, which failed due to not
handling invalid input and evaluating inputs out of order. But this also
avoids using `timegm`, which doesn't work on macOS for years before 1900
(they simply return -1 for those years).

Partially addresses #4651. `Date.parse.js` still fails.