### PR TITLE
LibJS: Add tests for all the unscopable Array prototype properties

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.at.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.at.js
@@ -13,3 +13,13 @@ test("basic functionality", () => {
     expect(array.at(-4)).toBeUndefined();
     expect(array.at(-Infinity)).toBeUndefined();
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].at).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            at;
+        }).toThrowWithMessage(ReferenceError, "'at' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.copyWithin.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.copyWithin.js
@@ -43,3 +43,13 @@ describe("normal behavior", () => {
         expect(array).toEqual([1, 2, 1]);
     });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].copyWithin).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            copyWithin;
+        }).toThrowWithMessage(ReferenceError, "'copyWithin' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.entries.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.entries.js
@@ -42,3 +42,13 @@ test("item added to array after exhaustion is inaccessible", () => {
     a.push("c");
     expect(it.next()).toEqual({ value: undefined, done: true });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].entries).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            entries;
+        }).toThrowWithMessage(ReferenceError, "'entries' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.fill.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.fill.js
@@ -18,3 +18,13 @@ test("basic functionality", () => {
     expect([1, 2, 3].fill(4, 3, 5)).toEqual([1, 2, 3]);
     expect(Array(3).fill(4)).toEqual([4, 4, 4]);
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].fill).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            fill;
+        }).toThrowWithMessage(ReferenceError, "'fill' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.find.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.find.js
@@ -57,3 +57,13 @@ describe("normal behavior", () => {
         expect(callbackCalled).toBe(2);
     });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].find).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            find;
+        }).toThrowWithMessage(ReferenceError, "'find' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.findIndex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.findIndex.js
@@ -57,3 +57,13 @@ describe("normal behavior", () => {
         expect(callbackCalled).toBe(2);
     });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].findIndex).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            findIndex;
+        }).toThrowWithMessage(ReferenceError, "'findIndex' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.findLast.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.findLast.js
@@ -59,3 +59,13 @@ describe("normal behavior", () => {
         expect(callbackCalled).toBe(2);
     });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].findLast).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            findLast;
+        }).toThrowWithMessage(ReferenceError, "'findLast' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.findLastIndex.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.findLastIndex.js
@@ -59,3 +59,13 @@ describe("normal behavior", () => {
         expect(callbackCalled).toBe(2);
     });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].findLastIndex).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            findLastIndex;
+        }).toThrowWithMessage(ReferenceError, "'findLastIndex' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.flat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.flat.js
@@ -51,3 +51,13 @@ describe("normal behavior", () => {
         expect(array1.flat({ depth: 2 })).toEqual([1, 2, [3, 4, [5, 6, [7, 8]]]]);
     });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].flat).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            flat;
+        }).toThrowWithMessage(ReferenceError, "'flat' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.flatMap.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.flatMap.js
@@ -69,3 +69,13 @@ describe("normal behavior", () => {
         expect(called).toBeFalse();
     });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].flatMap).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            flatMap;
+        }).toThrowWithMessage(ReferenceError, "'flatMap' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.includes.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.includes.js
@@ -16,3 +16,13 @@ test("basic functionality", () => {
     expect(array.includes(2, -100)).toBeTrue();
     expect(array.includes("friends", 100)).toBeFalse();
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].includes).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            includes;
+        }).toThrowWithMessage(ReferenceError, "'includes' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.keys.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.keys.js
@@ -42,3 +42,13 @@ test("item added to array after exhaustion is inaccessible", () => {
     a.push("c");
     expect(it.next()).toEqual({ value: undefined, done: true });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].keys).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            keys;
+        }).toThrowWithMessage(ReferenceError, "'keys' is not defined");
+    }
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.values.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Array/Array.prototype.values.js
@@ -42,3 +42,13 @@ test("item added to array after exhaustion is inaccessible", () => {
     a.push(3);
     expect(it.next()).toEqual({ value: undefined, done: true });
 });
+
+test("is unscopable", () => {
+    expect(Array.prototype[Symbol.unscopables].values).toBeTrue();
+    const array = [];
+    with (array) {
+        expect(() => {
+            values;
+        }).toThrowWithMessage(ReferenceError, "'values' is not defined");
+    }
+});


### PR DESCRIPTION
When I was writing for tests for groupBy and groupByToMap, I noticed
there were no tests for these.