### PR TITLE
LibGUI: Table View navigating with arrow keys continuity after update

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -276,12 +276,16 @@ void AbstractTableView::scroll_into_view(const ModelIndex& index, bool scroll_ho
     Gfx::IntRect rect;
     switch (selection_behavior()) {
     case SelectionBehavior::SelectItems:
-        rect = cell_rect(index.row(), index.column());
+        rect = content_rect(index);
+        if (row_header().is_visible())
+            rect.set_left(rect.left() - row_header().width());
         break;
     case SelectionBehavior::SelectRows:
         rect = row_rect(index.row());
         break;
     }
+    if (column_header().is_visible())
+        rect.set_top(rect.top() - column_header().height());
     AbstractScrollableWidget::scroll_into_view(rect, scroll_horizontally, scroll_vertically);
 }
 
@@ -322,17 +326,6 @@ Gfx::IntRect AbstractTableView::content_rect(int row, int column) const
 Gfx::IntRect AbstractTableView::content_rect(const ModelIndex& index) const
 {
     return content_rect(index.row(), index.column());
-}
-
-Gfx::IntRect AbstractTableView::cell_rect(int row, int column) const
-{
-    auto cell_rect = this->content_rect(row, column);
-    if (row_header().is_visible())
-        cell_rect.set_left(cell_rect.left() - row_header().width());
-    if (column_header().is_visible())
-        cell_rect.set_top(cell_rect.top() - column_header().height());
-
-    return cell_rect;
 }
 
 Gfx::IntRect AbstractTableView::row_rect(int item_index) const

--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -51,7 +51,6 @@ public:
 
     virtual Gfx::IntRect content_rect(const ModelIndex&) const override;
     Gfx::IntRect content_rect(int row, int column) const;
-    Gfx::IntRect cell_rect(int row, int column) const;
     Gfx::IntRect row_rect(int item_index) const;
 
     virtual Gfx::IntRect paint_invalidation_rect(ModelIndex const& index) const override;

--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -190,18 +190,6 @@ void SortingProxyModel::sort_mapping(Mapping& mapping, int column, SortOrder sor
 
     // FIXME: I really feel like this should be done at the view layer somehow.
     for_each_view([&](AbstractView& view) {
-        // Update the view's cursor.
-        auto cursor = view.cursor_index();
-        if (cursor.is_valid() && cursor.parent() == mapping.source_parent) {
-            for (size_t i = 0; i < mapping.source_rows.size(); ++i) {
-                if (mapping.source_rows[i] == view.cursor_index().row()) {
-                    auto new_source_index = this->index(i, view.cursor_index().column(), mapping.source_parent);
-                    view.set_cursor(new_source_index, AbstractView::SelectionUpdate::None, false);
-                    break;
-                }
-            }
-        }
-
         // Update the view's selection.
         view.selection().change_from_model({}, [&](ModelSelection& selection) {
             Vector<ModelIndex> selected_indices_in_source;
@@ -222,6 +210,10 @@ void SortingProxyModel::sort_mapping(Mapping& mapping, int column, SortOrder sor
                     if (mapping.source_rows[i] == index.row()) {
                         auto new_source_index = this->index(i, index.column(), mapping.source_parent);
                         selection.add(new_source_index);
+                        // Update the view's cursor.
+                        auto cursor = view.cursor_index();
+                        if (cursor.is_valid() && cursor.parent() == mapping.source_parent)
+                            view.set_cursor(new_source_index, AbstractView::SelectionUpdate::None, false);
                         break;
                     }
                 }


### PR DESCRIPTION
When navigating a table view with navigation keys (like the arrow keys) and there is an update, then the currently selected row's index needs to be recomputed. This makes sure that this recalculation is done after the update and not before.

Also included is that when calculating the position of the desired row for the scroll_into_view function then the column headers are taken into account so that the entire row is brought into the view.