### PR TITLE
Kernel: Add option to force using only the bootloader framebuffer

### DIFF
--- a/Base/usr/share/man/man7/boot_parameters.md
+++ b/Base/usr/share/man/man7/boot_parameters.md
@@ -41,7 +41,7 @@ List of options:
   but only if **`acpi`** is set to **`limited`** or **`on`**, and a `MADT` (APIC) table is available.
   Otherwise, the kernel will fallback to use the i8259 PICs.
 
-* **`fbdev`** - This parameter expects **`on`** or **`off`**.
+* **`fbdev`** - This parameter expects one of the following values. **`on`**- Boot into the graphical environment (default). **`off`** - Boot into text mode. **`bootloader`** - Boot into the graphical environment, but only use the frame buffer set up by the bootloader and do not initialize any other graphics cards.
 
 * **`force_pio`** - If present on the command line, the IDE controllers will be force into PIO mode when initialized IDE Channels on boot.
 

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -245,9 +245,14 @@ PanicMode CommandLine::panic_mode(Validate should_validate) const
     return PanicMode::Halt;
 }
 
-UNMAP_AFTER_INIT bool CommandLine::are_framebuffer_devices_enabled() const
+UNMAP_AFTER_INIT auto CommandLine::are_framebuffer_devices_enabled() const -> FrameBufferDevices
 {
-    return lookup("fbdev"sv).value_or("on"sv) == "on"sv;
+    const auto fbdev_value = lookup("fbdev"sv).value_or("on"sv);
+    if (fbdev_value == "on"sv)
+        return FrameBufferDevices::Enabled;
+    if (fbdev_value == "bootloader"sv)
+        return FrameBufferDevices::BootloaderOnly;
+    return FrameBufferDevices::ConsoleOnly;
 }
 
 StringView CommandLine::userspace_init() const

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -52,6 +52,12 @@ public:
         No,
     };
 
+    enum class FrameBufferDevices {
+        Enabled,
+        ConsoleOnly,
+        BootloaderOnly
+    };
+
     [[nodiscard]] const String& string() const { return m_string; }
     Optional<StringView> lookup(StringView key) const;
     [[nodiscard]] bool contains(StringView key) const;
@@ -65,7 +71,7 @@ public:
     [[nodiscard]] bool is_vmmouse_enabled() const;
     [[nodiscard]] PCIAccessLevel pci_access_level() const;
     [[nodiscard]] bool is_legacy_time_enabled() const;
-    [[nodiscard]] bool are_framebuffer_devices_enabled() const;
+    [[nodiscard]] FrameBufferDevices are_framebuffer_devices_enabled() const;
     [[nodiscard]] bool is_force_pio() const;
     [[nodiscard]] AcpiFeatureLevel acpi_feature_level() const;
     [[nodiscard]] StringView system_mode() const;

--- a/Kernel/Graphics/GraphicsManagement.cpp
+++ b/Kernel/Graphics/GraphicsManagement.cpp
@@ -88,7 +88,13 @@ UNMAP_AFTER_INIT bool GraphicsManagement::determine_and_initialize_graphics_devi
     RefPtr<GenericGraphicsAdapter> adapter;
 
     auto create_bootloader_framebuffer_device = [&]() {
-        if (multiboot_framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB) {
+        if (multiboot_framebuffer_addr.is_null()) {
+            // Prekernel sets the framebuffer address to 0 if MULTIBOOT_INFO_FRAMEBUFFER_INFO
+            // is not present, as there is likely never a valid framebuffer at this physical address.
+            dmesgln("Graphics: Bootloader did not set up a framebuffer, ignoring fbdev argument");
+        } else if (multiboot_framebuffer_type != MULTIBOOT_FRAMEBUFFER_TYPE_RGB) {
+            dmesgln("Graphics: The framebuffer set up by the bootloader is not RGB, ignoring fbdev argument");
+        } else {
             dmesgln("Graphics: Using a preset resolution from the bootloader");
             adapter = VGACompatibleAdapter::initialize_with_preset_resolution(device_identifier,
                 multiboot_framebuffer_addr,

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -36,7 +36,8 @@ public:
     unsigned allocate_minor_device_number() { return m_current_minor_number++; };
     GraphicsManagement();
 
-    bool framebuffer_devices_allowed() const;
+    bool framebuffer_devices_console_only() const;
+    bool framebuffer_devices_use_bootloader_framebuffer() const;
     bool framebuffer_devices_exist() const;
 
     Spinlock& main_vga_lock() { return m_main_vga_lock; }

--- a/Kernel/Multiboot.h
+++ b/Kernel/Multiboot.h
@@ -46,6 +46,8 @@ struct multiboot_mmap_entry {
 } __attribute__((packed));
 typedef struct multiboot_mmap_entry multiboot_memory_map_t;
 
+#define MULTIBOOT_INFO_FRAMEBUFFER_INFO (1 << 12)
+
 struct multiboot_info {
     // Multiboot info version number.
     u32 flags;

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -167,7 +167,7 @@ extern "C" [[noreturn]] void init()
         return (decltype(ptr))((FlatPtr)ptr + kernel_mapping_base);
     };
 
-    BootInfo info;
+    BootInfo info {};
     info.start_of_prekernel_image = (PhysicalPtr)start_of_prekernel_image;
     info.end_of_prekernel_image = (PhysicalPtr)end_of_prekernel_image;
     info.physical_to_virtual_offset = kernel_load_base - kernel_physical_base;
@@ -188,12 +188,14 @@ extern "C" [[noreturn]] void init()
     info.multiboot_memory_map_count = multiboot_info_ptr->mmap_length / sizeof(multiboot_memory_map_t);
     info.multiboot_modules = adjust_by_mapping_base((FlatPtr)multiboot_info_ptr->mods_addr);
     info.multiboot_modules_count = multiboot_info_ptr->mods_count;
-    info.multiboot_framebuffer_addr = multiboot_info_ptr->framebuffer_addr;
-    info.multiboot_framebuffer_pitch = multiboot_info_ptr->framebuffer_pitch;
-    info.multiboot_framebuffer_width = multiboot_info_ptr->framebuffer_width;
-    info.multiboot_framebuffer_height = multiboot_info_ptr->framebuffer_height;
-    info.multiboot_framebuffer_bpp = multiboot_info_ptr->framebuffer_bpp;
-    info.multiboot_framebuffer_type = multiboot_info_ptr->framebuffer_type;
+    if ((multiboot_info_ptr->flags & MULTIBOOT_INFO_FRAMEBUFFER_INFO) != 0) {
+        info.multiboot_framebuffer_addr = multiboot_info_ptr->framebuffer_addr;
+        info.multiboot_framebuffer_pitch = multiboot_info_ptr->framebuffer_pitch;
+        info.multiboot_framebuffer_width = multiboot_info_ptr->framebuffer_width;
+        info.multiboot_framebuffer_height = multiboot_info_ptr->framebuffer_height;
+        info.multiboot_framebuffer_bpp = multiboot_info_ptr->framebuffer_bpp;
+        info.multiboot_framebuffer_type = multiboot_info_ptr->framebuffer_type;
+    }
 
     asm(
 #if ARCH(I386)


### PR DESCRIPTION
This allows forcing the use of only the framebuffer set up by the
bootloader and skips instantiating devices for any other graphics
cards that may be present.