### PR TITLE
PDFViewer/LibGUI: Various UI improvements

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -335,11 +335,11 @@ FontEditorWidget::FontEditorWidget()
     glyph_mode_toolbar.add_action(*m_paint_glyph_action);
     glyph_mode_toolbar.add_action(*m_move_glyph_action);
 
-    m_rotate_counterclockwise_action = GUI::Action::create("Rotate Counterclockwise", { Mod_Ctrl | Mod_Shift, Key_Z }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-ccw.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+    m_rotate_counterclockwise_action = GUI::CommonActions::make_rotate_counterclockwise_action([&](auto&) {
         m_glyph_editor_widget->rotate_90(GlyphEditorWidget::Counterclockwise);
     });
 
-    m_rotate_clockwise_action = GUI::Action::create("Rotate Clockwise", { Mod_Ctrl | Mod_Shift, Key_X }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-cw.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+    m_rotate_clockwise_action = GUI::CommonActions::make_rotate_clockwise_action([&](auto&) {
         m_glyph_editor_widget->rotate_90(GlyphEditorWidget::Clockwise);
     });
 

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -149,15 +149,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             app->quit();
         });
 
-    auto rotate_left_action = GUI::Action::create("Rotate &Left", { Mod_None, Key_L },
-        [&](auto&) {
-            widget->rotate(Gfx::RotationDirection::CounterClockwise);
-        });
+    auto rotate_counterclockwise_action = GUI::CommonActions::make_rotate_counterclockwise_action([&](auto&) {
+        widget->rotate(Gfx::RotationDirection::CounterClockwise);
+    });
 
-    auto rotate_right_action = GUI::Action::create("Rotate &Right", { Mod_None, Key_R },
-        [&](auto&) {
-            widget->rotate(Gfx::RotationDirection::Clockwise);
-        });
+    auto rotate_clockwise_action = GUI::CommonActions::make_rotate_clockwise_action([&](auto&) {
+        widget->rotate(Gfx::RotationDirection::Clockwise);
+    });
 
     auto vertical_flip_action = GUI::Action::create("Flip &Vertically", { Mod_None, Key_V },
         [&](auto&) {
@@ -247,8 +245,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         bool should_enable_forward_actions = (widget->is_next_available() && should_enable_image_actions);
         bool should_enable_backward_actions = (widget->is_previous_available() && should_enable_image_actions);
         delete_action->set_enabled(should_enable_image_actions);
-        rotate_left_action->set_enabled(should_enable_image_actions);
-        rotate_right_action->set_enabled(should_enable_image_actions);
+        rotate_counterclockwise_action->set_enabled(should_enable_image_actions);
+        rotate_clockwise_action->set_enabled(should_enable_image_actions);
         vertical_flip_action->set_enabled(should_enable_image_actions);
         horizontal_flip_action->set_enabled(should_enable_image_actions);
         desktop_wallpaper_action->set_enabled(should_enable_image_actions);
@@ -285,8 +283,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(file_menu->try_add_action(quit_action));
 
     auto image_menu = TRY(window->try_add_menu("&Image"));
-    TRY(image_menu->try_add_action(rotate_left_action));
-    TRY(image_menu->try_add_action(rotate_right_action));
+    TRY(image_menu->try_add_action(rotate_counterclockwise_action));
+    TRY(image_menu->try_add_action(rotate_clockwise_action));
     TRY(image_menu->try_add_action(vertical_flip_action));
     TRY(image_menu->try_add_action(horizontal_flip_action));
     TRY(image_menu->try_add_separator());

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -109,9 +109,8 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
                 scrollbar.decrease_slider_by(20);
             }
         }
+        update();
     }
-
-    update();
 }
 
 void PDFViewer::timer_event(Core::TimerEvent&)
@@ -125,14 +124,24 @@ void PDFViewer::timer_event(Core::TimerEvent&)
 
 void PDFViewer::zoom_in()
 {
-    if (m_zoom_level < number_of_zoom_levels - 1)
+    if (m_zoom_level < number_of_zoom_levels - 1) {
         m_zoom_level++;
+        update();
+    }
 }
 
 void PDFViewer::zoom_out()
 {
-    if (m_zoom_level > 0)
+    if (m_zoom_level > 0) {
         m_zoom_level--;
+        update();
+    }
+}
+
+void PDFViewer::reset_zoom()
+{
+    m_zoom_level = initial_zoom_level;
+    update();
 }
 
 RefPtr<Gfx::Bitmap> PDFViewer::render_page(const PDF::Page& page)

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -113,6 +113,29 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
     }
 }
 
+void PDFViewer::mousedown_event(GUI::MouseEvent& event)
+{
+    if (event.button() == GUI::MouseButton::Middle) {
+        m_pan_starting_position = to_content_position(event.position());
+        set_override_cursor(Gfx::StandardCursor::Drag);
+    }
+}
+
+void PDFViewer::mouseup_event(GUI::MouseEvent&)
+{
+    set_override_cursor(Gfx::StandardCursor::None);
+}
+
+void PDFViewer::mousemove_event(GUI::MouseEvent& event)
+{
+    if (event.buttons() & GUI::MouseButton::Middle) {
+        auto delta = to_content_position(event.position()) - m_pan_starting_position;
+        horizontal_scrollbar().decrease_slider_by(delta.x());
+        vertical_scrollbar().decrease_slider_by(delta.y());
+        update();
+    }
+}
+
 void PDFViewer::timer_event(Core::TimerEvent&)
 {
     // Clear the bitmap vector of all pages except the current page

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -49,6 +49,10 @@ public:
 
     Function<void(u32 new_page)> on_page_change;
 
+    void zoom_in();
+    void zoom_out();
+    void reset_zoom();
+
 protected:
     PDFViewer();
 
@@ -59,9 +63,6 @@ protected:
 private:
     RefPtr<Gfx::Bitmap> get_rendered_page(u32 index);
     RefPtr<Gfx::Bitmap> render_page(const PDF::Page&);
-
-    void zoom_in();
-    void zoom_out();
 
     RefPtr<PDF::Document> m_document;
     u32 m_current_page_index { 0 };

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -58,6 +58,9 @@ protected:
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousewheel_event(GUI::MouseEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+    virtual void mouseup_event(GUI::MouseEvent&) override;
+    virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void timer_event(Core::TimerEvent&) override;
 
 private:
@@ -69,4 +72,6 @@ private:
     Vector<HashMap<u32, RefPtr<Gfx::Bitmap>>> m_rendered_page_list;
 
     u8 m_zoom_level { initial_zoom_level };
+
+    Gfx::IntPoint m_pan_starting_position;
 };

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -52,6 +52,7 @@ public:
     void zoom_in();
     void zoom_out();
     void reset_zoom();
+    void rotate(int degrees);
 
 protected:
     PDFViewer();
@@ -64,14 +65,20 @@ protected:
     virtual void timer_event(Core::TimerEvent&) override;
 
 private:
+    struct RenderedPage {
+        RefPtr<Gfx::Bitmap> bitmap;
+        int rotation;
+    };
+
     RefPtr<Gfx::Bitmap> get_rendered_page(u32 index);
     RefPtr<Gfx::Bitmap> render_page(const PDF::Page&);
 
     RefPtr<PDF::Document> m_document;
     u32 m_current_page_index { 0 };
-    Vector<HashMap<u32, RefPtr<Gfx::Bitmap>>> m_rendered_page_list;
+    Vector<HashMap<u32, RenderedPage>> m_rendered_page_list;
 
     u8 m_zoom_level { initial_zoom_level };
 
     Gfx::IntPoint m_pan_starting_position;
+    int m_rotations { 0 };
 };

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -58,6 +58,10 @@ void PDFViewerWidget::initialize_menubar(GUI::Window& window)
 
     auto& view_menu = window.add_menu("&View");
     view_menu.add_action(*m_toggle_sidebar_action);
+    view_menu.add_separator();
+    view_menu.add_action(*m_zoom_in_action);
+    view_menu.add_action(*m_zoom_out_action);
+    view_menu.add_action(*m_reset_zoom_action);
 
     auto& help_menu = window.add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("PDF Viewer", GUI::Icon::default_icon("app-pdf-viewer"), &window));
@@ -111,6 +115,28 @@ void PDFViewerWidget::create_toolbar()
     };
 
     m_total_page_label = toolbar.add<GUI::Label>();
+    m_total_page_label->set_fixed_width(30);
+    toolbar.add_separator();
+
+    m_zoom_in_action = GUI::CommonActions::make_zoom_in_action([&](auto&) {
+        m_viewer->zoom_in();
+    });
+
+    m_zoom_out_action = GUI::CommonActions::make_zoom_out_action([&](auto&) {
+        m_viewer->zoom_out();
+    });
+
+    m_reset_zoom_action = GUI::CommonActions::make_reset_zoom_action([&](auto&) {
+        m_viewer->reset_zoom();
+    });
+
+    m_zoom_in_action->set_enabled(false);
+    m_zoom_out_action->set_enabled(false);
+    m_reset_zoom_action->set_enabled(false);
+
+    toolbar.add_action(*m_zoom_in_action);
+    toolbar.add_action(*m_zoom_out_action);
+    toolbar.add_action(*m_reset_zoom_action);
 }
 
 void PDFViewerWidget::open_file(int fd, String const& path)
@@ -131,7 +157,6 @@ void PDFViewerWidget::open_file(int fd, String const& path)
 
     m_viewer->set_document(document);
     m_total_page_label->set_text(String::formatted("of {}", document->get_page_count()));
-    m_total_page_label->set_fixed_width(30);
 
     m_page_text_box->set_enabled(true);
     m_page_text_box->set_current_number(1, false);
@@ -139,6 +164,9 @@ void PDFViewerWidget::open_file(int fd, String const& path)
     m_go_to_prev_page_action->set_enabled(false);
     m_go_to_next_page_action->set_enabled(document->get_page_count() > 1);
     m_toggle_sidebar_action->set_enabled(true);
+    m_zoom_in_action->set_enabled(true);
+    m_zoom_out_action->set_enabled(true);
+    m_reset_zoom_action->set_enabled(true);
 
     if (document->outline()) {
         auto outline = document->outline();

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -130,13 +130,25 @@ void PDFViewerWidget::create_toolbar()
         m_viewer->reset_zoom();
     });
 
+    m_rotate_counterclockwise_action = GUI::CommonActions::make_rotate_counterclockwise_action([&](auto&) {
+        m_viewer->rotate(-90);
+    });
+
+    m_rotate_clockwise_action = GUI::CommonActions::make_rotate_clockwise_action([&](auto&) {
+        m_viewer->rotate(90);
+    });
+
     m_zoom_in_action->set_enabled(false);
     m_zoom_out_action->set_enabled(false);
     m_reset_zoom_action->set_enabled(false);
+    m_rotate_counterclockwise_action->set_enabled(false);
+    m_rotate_clockwise_action->set_enabled(false);
 
     toolbar.add_action(*m_zoom_in_action);
     toolbar.add_action(*m_zoom_out_action);
     toolbar.add_action(*m_reset_zoom_action);
+    toolbar.add_action(*m_rotate_counterclockwise_action);
+    toolbar.add_action(*m_rotate_clockwise_action);
 }
 
 void PDFViewerWidget::open_file(int fd, String const& path)
@@ -167,6 +179,8 @@ void PDFViewerWidget::open_file(int fd, String const& path)
     m_zoom_in_action->set_enabled(true);
     m_zoom_out_action->set_enabled(true);
     m_reset_zoom_action->set_enabled(true);
+    m_rotate_counterclockwise_action->set_enabled(true);
+    m_rotate_clockwise_action->set_enabled(true);
 
     if (document->outline()) {
         auto outline = document->outline();

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -56,6 +56,9 @@ void PDFViewerWidget::initialize_menubar(GUI::Window& window)
         GUI::Application::the()->quit();
     }));
 
+    auto& view_menu = window.add_menu("&View");
+    view_menu.add_action(*m_toggle_sidebar_action);
+
     auto& help_menu = window.add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("PDF Viewer", GUI::Icon::default_icon("app-pdf-viewer"), &window));
 }
@@ -66,10 +69,9 @@ void PDFViewerWidget::create_toolbar()
     auto& toolbar = toolbar_container.add<GUI::Toolbar>();
 
     auto open_outline_action = GUI::Action::create(
-        "Open &Sidebar", { Mod_Ctrl, Key_O }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/sidebar.png").release_value_but_fixme_should_propagate_errors(), [&](auto& action) {
+        "Toggle &Sidebar", { Mod_Ctrl, Key_S }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/sidebar.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
             m_sidebar_open = !m_sidebar_open;
-            m_sidebar->set_fixed_width(m_sidebar_open ? 0 : 200);
-            action.set_text(m_sidebar_open ? "Open &Sidebar" : "Close &Sidebar");
+            m_sidebar->set_fixed_width(m_sidebar_open ? 200 : 0);
         },
         nullptr);
     open_outline_action->set_enabled(false);

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -35,6 +35,10 @@ private:
     RefPtr<GUI::Action> m_go_to_prev_page_action;
     RefPtr<GUI::Action> m_go_to_next_page_action;
     RefPtr<GUI::Action> m_toggle_sidebar_action;
+    RefPtr<GUI::Action> m_zoom_in_action;
+    RefPtr<GUI::Action> m_zoom_out_action;
+    RefPtr<GUI::Action> m_reset_zoom_action;
+
     bool m_sidebar_open { false };
     ByteBuffer m_buffer;
 };

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -38,6 +38,8 @@ private:
     RefPtr<GUI::Action> m_zoom_in_action;
     RefPtr<GUI::Action> m_zoom_out_action;
     RefPtr<GUI::Action> m_reset_zoom_action;
+    RefPtr<GUI::Action> m_rotate_counterclockwise_action;
+    RefPtr<GUI::Action> m_rotate_clockwise_action;
 
     bool m_sidebar_open { false };
     ByteBuffer m_buffer;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -455,15 +455,17 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             editor->image().flip(Gfx::Orientation::Horizontal);
         }));
     image_menu.add_separator();
-    image_menu.add_action(GUI::Action::create(
-        "Rotate &Left", [&](auto&) {
+
+    image_menu.add_action(GUI::CommonActions::make_rotate_counterclockwise_action(
+        [&](auto&) {
             auto* editor = current_image_editor();
             if (!editor)
                 return;
             editor->image().rotate(Gfx::RotationDirection::CounterClockwise);
         }));
-    image_menu.add_action(GUI::Action::create(
-        "Rotate &Right", [&](auto&) {
+
+    image_menu.add_action(GUI::CommonActions::make_rotate_clockwise_action(
+        [&](auto&) {
             auto* editor = current_image_editor();
             if (!editor)
                 return;

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -48,6 +48,8 @@ NonnullRefPtr<Action> make_properties_action(Function<void(Action&)>, Core::Obje
 NonnullRefPtr<Action> make_zoom_in_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_zoom_out_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 NonnullRefPtr<Action> make_reset_zoom_action(Function<void(Action&)>, Core::Object* parent = nullptr);
+NonnullRefPtr<Action> make_rotate_clockwise_action(Function<void(Action&)>, Core::Object* parent = nullptr);
+NonnullRefPtr<Action> make_rotate_counterclockwise_action(Function<void(Action&)>, Core::Object* parent = nullptr);
 
 };
 

--- a/Userland/Libraries/LibGUI/CommonActions.cpp
+++ b/Userland/Libraries/LibGUI/CommonActions.cpp
@@ -178,6 +178,16 @@ NonnullRefPtr<Action> make_zoom_out_action(Function<void(Action&)> callback, Cor
     return GUI::Action::create("Zoom &Out", { Mod_Ctrl, Key_Minus }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/zoom-out.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
+NonnullRefPtr<Action> make_rotate_clockwise_action(Function<void(Action&)> callback, Core::Object* parent)
+{
+    return GUI::Action::create("Rotate Clock&wise", { Mod_Ctrl | Mod_Shift, Key_X }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-cw.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+}
+
+NonnullRefPtr<Action> make_rotate_counterclockwise_action(Function<void(Action&)> callback, Core::Object* parent)
+{
+    return GUI::Action::create("Rotate &Counterclockwise", { Mod_Ctrl | Mod_Shift, Key_Z }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-ccw.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+}
+
 }
 
 }


### PR DESCRIPTION
This PR fixes a small bug, implements some small UI improvements to PDFViewer and makes the rotate cv/ccw action consistent across applications.

**PDFViewer: Fix sidebar toggle logic** 
The open_outline_action logic was backwards resulting in it being closed on the first click and opened on the second, and opposite if document->outline() was true. There was also a collision with the Ctrl+O shortcut for opening a document, this changes it to Ctrl+S instead.

This commit also changes the wording to 'Toogle' instead of 'Open/Close' since the text wasn't updated as expected, and lastly, add a View menu with the action.
 
**PDFViewer: Add zoom in/out/reset menu actions** 
Make PDFViewer::zoom_in() & ::zoom_out() public and add menu and toolbar actions. Also add an action for zoom reset.
 
**PDFViewer: Enable panning with middle mouse button** 
Enable the use of the middle mouse button for panning in PDFViewer.
 
**LibGUI/Everywhere: Move rotate cw/ccw to CommonActions** 
The rotate clockwise/rotate counterclockwise actions can be added to CommonActions since they are repeated in FontEditor, ImageViewer and PixelPaint. This keeps the shortcuts and icons consistent across applications.
 
**PDFViewer: Add actions to rotate the displayed PDF** 
This implements the rotate cw/ccw actions in PDFViewer. Since the rendered pages are stored in a HashMap for caching, the bitmap is wrapped in a struct with the current rotation. This way the caching works as expected while zooming/shifting pages for the given rotation, and only renders new bitmaps when the rotation changes.