### PR TITLE
AK: Fix HashMap remove_all_matching test

### DIFF
--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -82,6 +82,7 @@ TEST_CASE(remove_all_matching)
 
     EXPECT_EQ(map.size(), 4u);
 
+    EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return false; }), false);
     EXPECT_EQ(map.remove_all_matching([&](int key, String const& value) { return key == 1 || value == "Two"; }), true);
 
     EXPECT_EQ(map.size(), 2u);
@@ -89,8 +90,7 @@ TEST_CASE(remove_all_matching)
     EXPECT(map.contains(4));
 
     EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return true; }), true);
-    EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return false; }), false);
-
+    
     EXPECT(map.is_empty());
 
     EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return true; }), false);


### PR DESCRIPTION
Test on empty hash map removed nothing and passed always, whatever predicate was, and so test was useless.
Moved test to the stage where hash map was not empty, so test could fail.