### PR TITLE
Text editor fix line movement

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -103,7 +103,7 @@ public:
     virtual void document_did_remove_all_lines() override {};
     virtual void document_did_change(GUI::AllowCallback) override {};
     virtual void document_did_set_text(GUI::AllowCallback) override {};
-    virtual void document_did_set_cursor(const GUI::TextPosition&) override {};
+    virtual void document_did_set_selection(const GUI::TextRange&) override {};
     virtual void document_did_update_undo_stack() override { }
 
     virtual bool is_automatic_indentation_enabled() const override { return false; }

--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -275,18 +275,17 @@ void EditingEngine::move_to_logical_line_end()
 void EditingEngine::move_one_up(const KeyEvent& event)
 {
     if (m_editor->cursor().line() > 0 || m_editor->is_wrapping_enabled()) {
-        if (event.ctrl() && event.shift()) {
-            move_selected_lines_up();
-            return;
-        }
         TextPosition new_cursor;
-        if (m_editor->is_wrapping_enabled()) {
+        if (m_editor->is_wrapping_enabled() && !event.ctrl()) {
             auto position_above = m_editor->cursor_content_rect().location().translated(0, -m_editor->line_height());
             new_cursor = m_editor->text_position_at_content_position(position_above);
         } else {
             size_t new_line = m_editor->cursor().line() - 1;
             size_t new_column = min(m_editor->cursor().column(), m_editor->line(new_line).length());
             new_cursor = { new_line, new_column };
+        }
+        if (event.ctrl()) {
+            new_cursor.set_column(0);
         }
         m_editor->set_cursor(new_cursor);
     }
@@ -295,18 +294,17 @@ void EditingEngine::move_one_up(const KeyEvent& event)
 void EditingEngine::move_one_down(const KeyEvent& event)
 {
     if (m_editor->cursor().line() < (m_editor->line_count() - 1) || m_editor->is_wrapping_enabled()) {
-        if (event.ctrl() && event.shift()) {
-            move_selected_lines_down();
-            return;
-        }
         TextPosition new_cursor;
-        if (m_editor->is_wrapping_enabled()) {
+        if (m_editor->is_wrapping_enabled() && !event.ctrl()) {
             auto position_below = m_editor->cursor_content_rect().location().translated(0, m_editor->line_height());
             new_cursor = m_editor->text_position_at_content_position(position_below);
         } else {
             size_t new_line = m_editor->cursor().line() + 1;
             size_t new_column = min(m_editor->cursor().column(), m_editor->line(new_line).length());
             new_cursor = { new_line, new_column };
+        }
+        if (event.ctrl()) {
+            new_cursor.set_column(m_editor->line(new_cursor.line()).length());
         }
         m_editor->set_cursor(new_cursor);
     }

--- a/Userland/Libraries/LibGUI/EditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/EditingEngine.cpp
@@ -624,55 +624,6 @@ void EditingEngine::move_to_beginning_of_previous_word()
     m_editor->set_cursor(find_beginning_of_previous_word());
 }
 
-void EditingEngine::move_selected_lines_up()
-{
-    if (!m_editor->is_editable())
-        return;
-    size_t first_line;
-    size_t last_line;
-    get_selection_line_boundaries(first_line, last_line);
-
-    if (first_line == 0)
-        return;
-
-    auto& lines = m_editor->document().lines();
-    lines.insert((int)last_line, lines.take((int)first_line - 1));
-    m_editor->set_cursor({ first_line - 1, 0 });
-
-    if (m_editor->has_selection()) {
-        m_editor->selection().set_start({ first_line - 1, 0 });
-        m_editor->selection().set_end({ last_line - 1, m_editor->line(last_line - 1).length() });
-    }
-
-    m_editor->did_change();
-    m_editor->update();
-}
-
-void EditingEngine::move_selected_lines_down()
-{
-    if (!m_editor->is_editable())
-        return;
-    size_t first_line;
-    size_t last_line;
-    get_selection_line_boundaries(first_line, last_line);
-
-    auto& lines = m_editor->document().lines();
-    VERIFY(lines.size() != 0);
-    if (last_line >= lines.size() - 1)
-        return;
-
-    lines.insert((int)first_line, lines.take((int)last_line + 1));
-    m_editor->set_cursor({ first_line + 1, 0 });
-
-    if (m_editor->has_selection()) {
-        m_editor->selection().set_start({ first_line + 1, 0 });
-        m_editor->selection().set_end({ last_line + 1, m_editor->line(last_line + 1).length() });
-    }
-
-    m_editor->did_change();
-    m_editor->update();
-}
-
 void EditingEngine::delete_char()
 {
     if (!m_editor->is_editable())

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -320,9 +320,18 @@ void TextDocument::notify_did_change()
 
 void TextDocument::set_all_cursors(const TextPosition& position)
 {
+    VERIFY(position.is_valid());
     if (m_client_notifications_enabled) {
         for (auto* client : m_clients)
-            client->document_did_set_cursor(position);
+            client->document_did_set_selection(TextRange::from_position(position));
+    }
+}
+
+void TextDocument::set_all_selections(const TextRange& range)
+{
+    if (m_client_notifications_enabled) {
+        for (auto* client : m_clients)
+            client->document_did_set_selection(range);
     }
 }
 

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -80,6 +80,7 @@ public:
     void remove_line(size_t line_index);
     void remove_all_lines();
     void insert_line(size_t line_index, NonnullOwnPtr<TextDocumentLine>);
+    void swap_lines(size_t a, size_t b);
 
     void register_client(Client&);
     void unregister_client(Client&);
@@ -234,4 +235,19 @@ private:
     TextRange m_range;
 };
 
+class MoveLinesTextCommand : public TextDocumentUndoCommand {
+public:
+    MoveLinesTextCommand(TextDocument&, const TextRange&, const bool);
+    virtual void undo() override;
+    virtual void redo() override;
+    const TextRange& range() const { return m_range; }
+    virtual bool merge_with(GUI::Command const&) override;
+    virtual String action_text() const override;
+
+private:
+    virtual bool do_swap_lines(bool forward);
+    virtual void do_set_selection();
+    TextRange m_range;
+    const bool m_forward;
+};
 }

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -47,7 +47,8 @@ public:
         virtual void document_did_remove_all_lines() = 0;
         virtual void document_did_change(AllowCallback = AllowCallback::Yes) = 0;
         virtual void document_did_set_text(AllowCallback = AllowCallback::Yes) = 0;
-        virtual void document_did_set_cursor(const TextPosition&) = 0;
+        // to communicate cursor position, use a range with start() == end() == cursor
+        virtual void document_did_set_selection(const TextRange&) = 0;
         virtual void document_did_update_undo_stack() = 0;
 
         virtual bool is_automatic_indentation_enabled() const = 0;
@@ -120,6 +121,7 @@ public:
 
     void notify_did_change();
     void set_all_cursors(const TextPosition&);
+    void set_all_selections(const TextRange&);
 
     TextPosition insert_at(const TextPosition&, u32, const Client* = nullptr);
     TextPosition insert_at(const TextPosition&, StringView, const Client* = nullptr);

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1868,9 +1868,14 @@ void TextEditor::document_did_set_text(AllowCallback allow_callback)
     document_did_change(allow_callback);
 }
 
-void TextEditor::document_did_set_cursor(TextPosition const& position)
+void TextEditor::document_did_set_selection(TextRange const& range)
 {
-    set_cursor(position);
+    VERIFY(range.start().is_valid() && range.end().is_valid());
+    if (range.is_valid()) {
+        set_selection(range);
+    } else {
+        set_cursor(range.start());
+    }
 }
 
 void TextEditor::cursor_did_change()

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -815,6 +815,12 @@ void TextEditor::keydown_event(KeyEvent& event)
         }
     }
 
+    if (event.modifiers() == (Mod_Shift | Mod_Ctrl) && (event.key() == KeyCode::Key_Up || event.key() == KeyCode::Key_Down)) {
+        int forward = event.key() == Key_Down;
+        move_lines(forward);
+        return;
+    }
+
     if (m_editing_engine->on_key(event))
         return;
 
@@ -1427,6 +1433,21 @@ void TextEditor::insert_at_cursor_or_replace_selection(StringView text)
         execute<RemoveTextCommand>(document().text_in_range(erased_range), erased_range);
         set_cursor(original_cursor_position);
     }
+}
+
+void TextEditor::move_lines(bool forward)
+{
+    if (!is_editable())
+        return;
+
+    TextRange range;
+    if (has_selection()) {
+        range = normalized_selection();
+    } else {
+        range.set_start(m_cursor);
+        range.set_end(m_cursor);
+    }
+    execute<MoveLinesTextCommand>(range, forward);
 }
 
 void TextEditor::cut()

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -249,7 +249,7 @@ private:
     virtual void document_did_remove_all_lines() override;
     virtual void document_did_change(AllowCallback = AllowCallback::Yes) override;
     virtual void document_did_set_text(AllowCallback = AllowCallback::Yes) override;
-    virtual void document_did_set_cursor(TextPosition const&) override;
+    virtual void document_did_set_selection(TextRange const&) override;
     virtual void document_did_update_undo_stack() override;
 
     // ^Syntax::HighlighterClient

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -282,6 +282,7 @@ private:
     void force_update_autocomplete(Function<void()> callback = {});
     void hide_autocomplete_if_needed();
     void hide_autocomplete();
+    void move_lines(bool forward);
 
     int icon_size() const { return 16; }
     int icon_padding() const { return 2; }

--- a/Userland/Libraries/LibGUI/TextRange.h
+++ b/Userland/Libraries/LibGUI/TextRange.h
@@ -19,6 +19,11 @@ public:
     {
     }
 
+    static TextRange from_position(const TextPosition& position)
+    {
+        return TextRange(position, position);
+    }
+
     bool is_valid() const { return m_start.is_valid() && m_end.is_valid() && m_start != m_end; }
     void clear()
     {


### PR DESCRIPTION
Probably want to review this one commit by commit.

I took the liberty of generalizing `document_did_set_cursor` to `document_did_set_selection` because it seemed right to me, but I'm not sure what is preferred for this project. Open to feedback :)

![move-lines](https://user-images.githubusercontent.com/15224242/148299662-af83ec8f-7a31-49e9-b59b-bff439f46150.gif)

