### PR TITLE
LibGUI: Don't skip non-skipable spans on ctrl+right

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -630,11 +630,11 @@ Optional<TextDocumentSpan> TextDocument::first_non_skippable_span_after(const Te
     }
     // Skip skippable spans
     for (; i < m_spans.size(); ++i) {
-        if (m_spans[i].is_skippable)
+        if (!m_spans[i].is_skippable)
             break;
     }
     if (i < m_spans.size())
-        return m_spans[i + 1];
+        return m_spans[i];
     return {};
 }
 


### PR DESCRIPTION
Just a couple of typos in `TextDocument::first_non_skippable_span_after`.