### PR TITLE
LibCore: Make `EventLoop::pump()` return event count

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -42,7 +42,7 @@ public:
 
     // processe events, generally called by exec() in a loop.
     // this should really only be used for integrating with other event loops
-    void pump(WaitMode = WaitMode::WaitForEvents);
+    size_t pump(WaitMode = WaitMode::WaitForEvents);
 
     void spin_until(Function<bool()>);
 


### PR DESCRIPTION
Sometimes, pumping the event loop will cause new events to be generated. For example, an IPC message could be delivered which then dispatches a new event to be handled by the GUI. To the invoker of `EventLoop::pump()`, it is not obvious if any events were processed at all.

Libraries like SDL2 might not have the opportunity to run the event loop often enough that events can be processed swiftly, since it might spend time doing other things. This can result in stuttering GUI interactions.

This changes `EventLoop::pump()` to return the number of processed events, and is required for the following PR:
https://github.com/SerenityPorts/SDL/pull/26