### PR TITLE
man: Fix error handling when section is specified

### DIFF
--- a/Userland/Utilities/man.cpp
+++ b/Userland/Utilities/man.cpp
@@ -91,13 +91,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 break;
             }
         }
-        if (!section) {
-            warnln("No man page for {}", name);
-            exit(1);
-        }
     }
-
     auto filename = make_path(section);
+    if (section == nullptr) {
+        warnln("No man page for {}", name);
+        exit(1);
+    } else if (access(filename.characters(), R_OK) != 0) {
+        warnln("No man page for {} in section {}", name, section);
+        exit(1);
+    }
 
     String pager_command;
     if (pager)


### PR DESCRIPTION
Previously, man would only check if a path is not associated with a
manpage when no section was specified via the command line.

So `man gibberish` would fail with "no man page for gibberish", but `man
2 gibberish` would fail with a runtime error and still open a pipe to
  the pager leading to a nasty crash.

Moving the check outside the "if (!section)" block fixes this.