### PR TITLE
test-crypto: Use correct secret_key

### DIFF
--- a/Userland/Utilities/test-crypto.cpp
+++ b/Userland/Utilities/test-crypto.cpp
@@ -28,7 +28,7 @@
 #include <stdio.h>
 #include <time.h>
 
-static const char* secret_key = "WellHelloFreinds";
+static const char* secret_key = "WellHelloFriends";
 static const char* suite = nullptr;
 static const char* filename = nullptr;
 static const char* server = nullptr;


### PR DESCRIPTION
Use `"WellHelloFriends"` as global `static const char* secret_key` instead of `"WellHelloFreinds"`