### PR TITLE
AK: Make `remove_all_matching` returns the number of entries removed

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -75,18 +75,18 @@ public:
     }
 
     template<typename TUnaryPredicate>
-    bool remove_all_matching(TUnaryPredicate predicate)
+    size_t remove_all_matching(TUnaryPredicate predicate)
     {
-        bool something_was_removed = false;
+        size_t entries_removed = 0;
         for (auto it = begin(); it != end();) {
             if (predicate(it->key, it->value)) {
                 it = remove(it);
-                something_was_removed = true;
+                ++entries_removed;
             } else {
                 ++it;
             }
         }
-        return something_was_removed;
+        return entries_removed;
     }
 
     using HashTableType = HashTable<Entry, EntryTraits, IsOrdered>;

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -419,18 +419,18 @@ public:
     }
 
     template<typename TUnaryPredicate>
-    bool remove_all_matching(TUnaryPredicate predicate)
+    size_t remove_all_matching(TUnaryPredicate predicate)
     {
-        bool something_was_removed = false;
+        size_t entries_removed = 0;
         for (auto it = begin(); it != end();) {
             if (predicate(*it)) {
                 it = remove(it);
-                something_was_removed = true;
+                ++entries_removed;
             } else {
                 ++it;
             }
         }
-        return something_was_removed;
+        return entries_removed;
     }
 
 private:

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -405,18 +405,18 @@ public:
     }
 
     template<typename TUnaryPredicate>
-    bool remove_all_matching(TUnaryPredicate predicate)
+    size_t remove_all_matching(TUnaryPredicate predicate)
     {
-        bool something_was_removed = false;
+        size_t entries_removed = 0;
         for (size_t i = 0; i < size();) {
             if (predicate(at(i))) {
                 remove(i);
-                something_was_removed = true;
+                ++entries_removed;
             } else {
                 ++i;
             }
         }
-        return something_was_removed;
+        return entries_removed;
     }
 
     ALWAYS_INLINE T take_last()

--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -82,21 +82,21 @@ TEST_CASE(remove_all_matching)
 
     EXPECT_EQ(map.size(), 4u);
 
-    EXPECT_EQ(map.remove_all_matching([&](int key, String const& value) { return key == 1 || value == "Two"; }), true);
+    EXPECT_EQ(map.remove_all_matching([](int key, String const& value) { return key == 1 || value == "Two"; }), 2u);
     EXPECT_EQ(map.size(), 2u);
 
-    EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return false; }), false);
+    EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return false; }), 0u);
     EXPECT_EQ(map.size(), 2u);
 
     EXPECT(map.contains(3));
     EXPECT(map.contains(4));
 
-    EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return true; }), true);
-    EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return false; }), false);
+    EXPECT_EQ(map.remove_all_matching([](int, String const&) { return true; }), 2u);
+    EXPECT_EQ(map.remove_all_matching([](int, String const&) { return false; }), 0u);
 
     EXPECT(map.is_empty());
 
-    EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return true; }), false);
+    EXPECT_EQ(map.remove_all_matching([](int, String const&) { return true; }), 0u);
 }
 
 TEST_CASE(case_insensitive)

--- a/Tests/AK/TestHashTable.cpp
+++ b/Tests/AK/TestHashTable.cpp
@@ -95,19 +95,19 @@ TEST_CASE(remove_all_matching)
 
     EXPECT_EQ(ints.size(), 4u);
 
-    EXPECT_EQ(ints.remove_all_matching([&](int value) { return value > 2; }), true);
-    EXPECT_EQ(ints.remove_all_matching([&](int) { return false; }), false);
+    EXPECT_EQ(ints.remove_all_matching([](int value) { return value > 2; }), 2u);
+    EXPECT_EQ(ints.remove_all_matching([](int) { return false; }), 0u);
 
     EXPECT_EQ(ints.size(), 2u);
 
     EXPECT(ints.contains(1));
     EXPECT(ints.contains(2));
 
-    EXPECT_EQ(ints.remove_all_matching([&](int) { return true; }), true);
+    EXPECT_EQ(ints.remove_all_matching([](int) { return true; }), 2u);
 
     EXPECT(ints.is_empty());
 
-    EXPECT_EQ(ints.remove_all_matching([&](int) { return true; }), false);
+    EXPECT_EQ(ints.remove_all_matching([](int) { return true; }), 0u);
 }
 
 TEST_CASE(case_insensitive)

--- a/Tests/AK/TestVector.cpp
+++ b/Tests/AK/TestVector.cpp
@@ -270,16 +270,16 @@ TEST_CASE(remove_all_matching)
 
     EXPECT_EQ(ints.size(), 4u);
 
-    EXPECT_EQ(ints.remove_all_matching([&](int value) { return value > 2; }), true);
-    EXPECT_EQ(ints.remove_all_matching([&](int) { return false; }), false);
+    EXPECT_EQ(ints.remove_all_matching([](int value) { return value > 2; }), 2u);
+    EXPECT_EQ(ints.remove_all_matching([](int) { return false; }), 0u);
 
     EXPECT_EQ(ints.size(), 2u);
 
-    EXPECT_EQ(ints.remove_all_matching([&](int) { return true; }), true);
+    EXPECT_EQ(ints.remove_all_matching([](int) { return true; }), 2u);
 
     EXPECT(ints.is_empty());
 
-    EXPECT_EQ(ints.remove_all_matching([&](int) { return true; }), false);
+    EXPECT_EQ(ints.remove_all_matching([](int) { return true; }), 0u);
 }
 
 TEST_CASE(nonnullownptrvector)


### PR DESCRIPTION
Hi,
It can be useful to know the number of removed entries without counting the elements in the structure. And it is better than returning a plain bool, and is still compatible with bool.