### PR TITLE
AK: Ensure negative predicate in TestHashMap could run unsuccessfully

### DIFF
--- a/Tests/AK/TestHashMap.cpp
+++ b/Tests/AK/TestHashMap.cpp
@@ -83,8 +83,11 @@ TEST_CASE(remove_all_matching)
     EXPECT_EQ(map.size(), 4u);
 
     EXPECT_EQ(map.remove_all_matching([&](int key, String const& value) { return key == 1 || value == "Two"; }), true);
-
     EXPECT_EQ(map.size(), 2u);
+
+    EXPECT_EQ(map.remove_all_matching([&](int, String const&) { return false; }), false);
+    EXPECT_EQ(map.size(), 2u);
+
     EXPECT(map.contains(3));
     EXPECT(map.contains(4));
 


### PR DESCRIPTION
As it was, negative predicate test for remove_all_matching was
run on empty hash map, and could not remove anything, so test always
returned true. By duplicating it in state where hash maps contains
elements, we make sure that negative predicate has something to
do nothing on.