### PR TITLE
AK: Use a full-period xorshift PRNG for double_hash

### DIFF
--- a/AK/HashFunctions.h
+++ b/AK/HashFunctions.h
@@ -21,11 +21,15 @@ constexpr unsigned int_hash(u32 key)
 
 constexpr unsigned double_hash(u32 key)
 {
-    key = ~key + (key >> 23);
-    key ^= (key << 12);
-    key ^= (key >> 7);
-    key ^= (key << 2);
-    key ^= (key >> 20);
+    const unsigned magic = 0xBA5EDB01;
+    if (key == magic)
+        return 0u;
+    if (key == 0u)
+        key = magic;
+
+    key ^= key << 13;
+    key ^= key >> 17;
+    key ^= key << 5;
     return key;
 }
 

--- a/Tests/AK/TestHashFunctions.cpp
+++ b/Tests/AK/TestHashFunctions.cpp
@@ -17,8 +17,9 @@ TEST_CASE(int_hash)
 
 TEST_CASE(double_hash)
 {
-    static_assert(double_hash(42) == 524450u);
-    static_assert(double_hash(0) == 12384u);
+    static_assert(double_hash(666) == 171644115u);
+    static_assert(double_hash(0) == 1189591134u);
+    static_assert(double_hash(0xBA5EDB01) == 0u);
 }
 
 TEST_CASE(pair_int_hash)


### PR DESCRIPTION
The previous xorshift-based solution had some pretty short cycles and two fixed points (`1711463637u` and `2389024350u`). If two keys hashed to one of these values, table / map insertions and lookups would loop forever.
This could happen randomly with non-negligible probability, and since the hash space is only 32 bits adversarial inputs are very easy to generate. 
This linear congruential generator has a full period of 2**32. It's less random-looking but I don't think that really matters for the current use. CPython seems to use the same one for some of their applications.
If you really want to use xorshift it's possible to use one of Marsaglia's original generators (see Wikipedia), which only requires special care with the all-zero state.