### PR TITLE
Spider: Add functionality to automatically move cards to valid stacks

### DIFF
--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -72,6 +72,7 @@ private:
     void ensure_top_card_is_visible(NonnullRefPtr<CardStack> stack);
     void detect_full_stacks();
     void detect_victory();
+    void move_focused_cards(CardStack& stack);
 
     ALWAYS_INLINE CardStack& stack(StackLocation location)
     {


### PR DESCRIPTION
This commit adds the possibility to use the secondary mouse button to let the game move the selected card(s) to the next valid stack.