### PR TITLE
EmojiInputDialog: Ensure that all buttons are equal width

### DIFF
--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -64,7 +64,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
                 builder.append(Utf32View(&code_points[index++], 1));
                 auto emoji_text = builder.to_string();
                 auto& button = horizontal_container.add<Button>(emoji_text);
-                button.set_min_size(16, 16);
+                button.set_fixed_size(16, 16);
                 button.set_button_style(Gfx::ButtonStyle::Coolbar);
                 button.on_click = [this, button = &button](auto) {
                     m_selected_emoji_text = button->text();


### PR DESCRIPTION
Previously we only set the min size which meant that some emoji buttons
was larger than others :^)