### PR TITLE
Taskbar: Span taskbar across multiple monitors

### DIFF
--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -111,7 +111,13 @@ void TaskbarWindow::show_desktop_button_clicked(unsigned)
 void TaskbarWindow::on_screen_rects_change(const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index)
 {
     const auto& rect = rects[main_screen_index];
-    Gfx::IntRect new_rect { rect.x(), rect.bottom() - taskbar_height() + 1, rect.width(), taskbar_height() };
+    auto width = 0;
+    for (size_t i = 0; i < rects.size(); i++) {
+        const auto& screen = rects[i];
+        width += screen.width();
+    }
+
+    Gfx::IntRect new_rect { rect.x(), rect.bottom() - taskbar_height() + 1, width, taskbar_height() };
     set_rect(new_rect);
     update_applet_area();
 }


### PR DESCRIPTION
In the future we might want to run a taskbar service or window instance
per screen, that'll require a bit of rearchitecting so this is a really
quick and simple fix to at least make some use of the second monitor.

![image](https://user-images.githubusercontent.com/1370209/148467538-5f4cb8cc-d730-4ac3-bfc6-1c2021e037df.png)
