### PR TITLE
LibSoftGPU: Compile-time determination of clipping plane

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Clipper.cpp
+++ b/Userland/Libraries/LibSoftGPU/Clipper.cpp
@@ -12,16 +12,16 @@
 
 namespace SoftGPU {
 
-Vertex Clipper::clip_intersection_point(const Vertex& p1, const Vertex& p2, ClipPlane plane)
+Vertex Clipper::clip_intersection_point(Vertex const& p1, Vertex const& p2, ClipPlane plane)
 {
     // See https://www.microsoft.com/en-us/research/wp-content/uploads/1978/01/p245-blinn.pdf
     // "Clipping Using Homogeneous Coordinates" Blinn/Newell, 1978
 
-    float w1 = p1.clip_coordinates.w();
-    float w2 = p2.clip_coordinates.w();
-    float x1 = clip_plane_normals[static_cast<u8>(plane)].dot(p1.clip_coordinates);
-    float x2 = clip_plane_normals[static_cast<u8>(plane)].dot(p2.clip_coordinates);
-    float a = (w1 + x1) / ((w1 + x1) - (w2 + x2));
+    float const w1 = p1.clip_coordinates.w();
+    float const w2 = p2.clip_coordinates.w();
+    float const x1 = clip_plane_normals[static_cast<u8>(plane)].dot(p1.clip_coordinates);
+    float const x2 = clip_plane_normals[static_cast<u8>(plane)].dot(p2.clip_coordinates);
+    float const a = (w1 + x1) / ((w1 + x1) - (w2 + x2));
 
     Vertex out;
     out.position = mix(p1.position, p2.position, a);

--- a/Userland/Libraries/LibSoftGPU/Clipper.cpp
+++ b/Userland/Libraries/LibSoftGPU/Clipper.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,35 +12,15 @@
 
 namespace SoftGPU {
 
-bool Clipper::point_within_clip_plane(const FloatVector4& vertex, ClipPlane plane)
-{
-    switch (plane) {
-    case ClipPlane::LEFT:
-        return vertex.x() >= -vertex.w();
-    case ClipPlane::RIGHT:
-        return vertex.x() <= vertex.w();
-    case ClipPlane::TOP:
-        return vertex.y() <= vertex.w();
-    case ClipPlane::BOTTOM:
-        return vertex.y() >= -vertex.w();
-    case ClipPlane::NEAR:
-        return vertex.z() >= -vertex.w();
-    case ClipPlane::FAR:
-        return vertex.z() <= vertex.w();
-    }
-
-    return false;
-}
-
-Vertex Clipper::clip_intersection_point(const Vertex& p1, const Vertex& p2, ClipPlane plane_index)
+Vertex Clipper::clip_intersection_point(const Vertex& p1, const Vertex& p2, ClipPlane plane)
 {
     // See https://www.microsoft.com/en-us/research/wp-content/uploads/1978/01/p245-blinn.pdf
     // "Clipping Using Homogeneous Coordinates" Blinn/Newell, 1978
 
     float w1 = p1.clip_coordinates.w();
     float w2 = p2.clip_coordinates.w();
-    float x1 = clip_plane_normals[plane_index].dot(p1.clip_coordinates);
-    float x2 = clip_plane_normals[plane_index].dot(p2.clip_coordinates);
+    float x1 = clip_plane_normals[static_cast<u8>(plane)].dot(p1.clip_coordinates);
+    float x2 = clip_plane_normals[static_cast<u8>(plane)].dot(p2.clip_coordinates);
     float a = (w1 + x1) / ((w1 + x1) - (w2 + x2));
 
     Vertex out;
@@ -59,26 +40,14 @@ void Clipper::clip_triangle_against_frustum(Vector<Vertex>& input_verts)
     auto read_from = &list_a;
     auto write_to = &list_b;
 
-    for (size_t plane = 0; plane < NUMBER_OF_CLIPPING_PLANES; plane++) {
-        write_to->clear_with_capacity();
-        // Save me, C++23
-        for (size_t i = 0; i < read_from->size(); i++) {
-            const auto& curr_vec = read_from->at((i + 1) % read_from->size());
-            const auto& prev_vec = read_from->at(i);
-
-            if (point_within_clip_plane(curr_vec.clip_coordinates, static_cast<ClipPlane>(plane))) {
-                if (!point_within_clip_plane(prev_vec.clip_coordinates, static_cast<ClipPlane>(plane))) {
-                    auto intersect = clip_intersection_point(prev_vec, curr_vec, static_cast<ClipPlane>(plane));
-                    write_to->append(intersect);
-                }
-                write_to->append(curr_vec);
-            } else if (point_within_clip_plane(prev_vec.clip_coordinates, static_cast<ClipPlane>(plane))) {
-                auto intersect = clip_intersection_point(prev_vec, curr_vec, static_cast<ClipPlane>(plane));
-                write_to->append(intersect);
-            }
-        }
-        swap(write_to, read_from);
-    }
+    // Save me, C++23. With enum reflection it will be possible to loop
+    // over all the available enum values.
+    clip_plane<ClipPlane::LEFT>(write_to, read_from);
+    clip_plane<ClipPlane::RIGHT>(write_to, read_from);
+    clip_plane<ClipPlane::TOP>(write_to, read_from);
+    clip_plane<ClipPlane::BOTTOM>(write_to, read_from);
+    clip_plane<ClipPlane::NEAR>(write_to, read_from);
+    clip_plane<ClipPlane::FAR>(write_to, read_from);
 
     input_verts = *read_from;
 }

--- a/Userland/Libraries/LibSoftGPU/Clipper.h
+++ b/Userland/Libraries/LibSoftGPU/Clipper.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,7 +14,7 @@
 namespace SoftGPU {
 
 class Clipper final {
-    enum ClipPlane : u8 {
+    enum class ClipPlane : u8 {
         LEFT = 0,
         RIGHT,
         TOP,
@@ -21,9 +22,6 @@ class Clipper final {
         NEAR,
         FAR
     };
-
-    static constexpr u8 NUMBER_OF_CLIPPING_PLANES = 6;
-    static constexpr u8 MAX_CLIPPED_VERTS = 6;
 
     static constexpr FloatVector4 clip_planes[] = {
         { -1, 0, 0, 1 }, // Left Plane
@@ -44,15 +42,57 @@ class Clipper final {
     };
 
 public:
-    Clipper() { }
+    Clipper() = default;
 
     void clip_triangle_against_frustum(Vector<Vertex>& input_vecs);
 
 private:
-    bool point_within_clip_plane(const FloatVector4& vertex, ClipPlane plane);
-    Vertex clip_intersection_point(const Vertex& vec, const Vertex& prev_vec, ClipPlane plane_index);
+    Vertex clip_intersection_point(const Vertex& vec, const Vertex& prev_vec, ClipPlane plane);
+
+    template<ClipPlane plane>
+    constexpr bool point_within_clip_plane(const FloatVector4& vertex)
+    {
+        if constexpr (plane == ClipPlane::LEFT) {
+            return vertex.x() >= -vertex.w();
+        } else if constexpr (plane == ClipPlane::RIGHT) {
+            return vertex.x() <= vertex.w();
+        } else if constexpr (plane == ClipPlane::TOP) {
+            return vertex.y() <= vertex.w();
+        } else if constexpr (plane == ClipPlane::BOTTOM) {
+            return vertex.y() >= -vertex.w();
+        } else if constexpr (plane == ClipPlane::NEAR) {
+            return vertex.z() >= -vertex.w();
+        } else if constexpr (plane == ClipPlane::FAR) {
+            return vertex.z() <= vertex.w();
+        }
+
+        return false;
+    }
+
+    template<ClipPlane plane>
+    void clip_plane(AK::Vector<SoftGPU::Vertex>* write_to, AK::Vector<SoftGPU::Vertex>* read_from)
+    {
+        write_to->clear_with_capacity();
+
+        for (size_t i = 0; i < read_from->size(); i++) {
+            const auto& curr_vec = read_from->at((i + 1) % read_from->size());
+            const auto& prev_vec = read_from->at(i);
+
+            if (point_within_clip_plane<plane>(curr_vec.clip_coordinates)) {
+                if (!point_within_clip_plane<plane>(prev_vec.clip_coordinates)) {
+                    auto intersect = clip_intersection_point(prev_vec, curr_vec, plane);
+                    write_to->append(intersect);
+                }
+                write_to->append(curr_vec);
+            } else if (point_within_clip_plane<plane>(prev_vec.clip_coordinates)) {
+                auto intersect = clip_intersection_point(prev_vec, curr_vec, plane);
+                write_to->append(intersect);
+            }
+        }
+        swap(write_to, read_from);
+    }
+
     Vector<Vertex> list_a;
     Vector<Vertex> list_b;
 };
-
 }

--- a/Userland/Libraries/LibSoftGPU/Clipper.h
+++ b/Userland/Libraries/LibSoftGPU/Clipper.h
@@ -47,10 +47,10 @@ public:
     void clip_triangle_against_frustum(Vector<Vertex>& input_vecs);
 
 private:
-    Vertex clip_intersection_point(const Vertex& vec, const Vertex& prev_vec, ClipPlane plane);
+    Vertex clip_intersection_point(Vertex const& vec, Vertex const& prev_vec, ClipPlane plane);
 
     template<ClipPlane plane>
-    constexpr bool point_within_clip_plane(const FloatVector4& vertex)
+    constexpr bool point_within_clip_plane(FloatVector4 const& vertex)
     {
         if constexpr (plane == ClipPlane::LEFT) {
             return vertex.x() >= -vertex.w();
@@ -75,17 +75,17 @@ private:
         write_to->clear_with_capacity();
 
         for (size_t i = 0; i < read_from->size(); i++) {
-            const auto& curr_vec = read_from->at((i + 1) % read_from->size());
-            const auto& prev_vec = read_from->at(i);
+            auto const& curr_vec = read_from->at((i + 1) % read_from->size());
+            auto const& prev_vec = read_from->at(i);
 
             if (point_within_clip_plane<plane>(curr_vec.clip_coordinates)) {
                 if (!point_within_clip_plane<plane>(prev_vec.clip_coordinates)) {
-                    auto intersect = clip_intersection_point(prev_vec, curr_vec, plane);
+                    auto const intersect = clip_intersection_point(prev_vec, curr_vec, plane);
                     write_to->append(intersect);
                 }
                 write_to->append(curr_vec);
             } else if (point_within_clip_plane<plane>(prev_vec.clip_coordinates)) {
-                auto intersect = clip_intersection_point(prev_vec, curr_vec, plane);
+                auto const intersect = clip_intersection_point(prev_vec, curr_vec, plane);
                 write_to->append(intersect);
             }
         }


### PR DESCRIPTION
When clipping points, the clip planes are looped over and plane index 
is passed at run-time to the comparison function which determines how 
to compare based on the plane index. This is inefficient because the  
plane index does not need to be determined twice.                     
                                                                      
The solution is to make the plane index be a non-type template        
parameter so that the comparison operation can be determined within   
the `constexpr` context and the run-time branching is eliminated.     
                                                                      
Additionally, making the `ClipPlane` `enum` into an `enum class` can  
enhance type safety. This change uses `ClipPlane` as a type everywhere
and casts to an integral value when needed as an index instead of     
doing it the opposite way.                                            
                                                                      
This change directly exposes the opportunity for using static         
reflection to loop over the enum values.                              
