### PR TITLE
Help: Directly launch apps from their help page + Special help:// URL for better inter-help-page linking

### DIFF
--- a/Base/usr/share/man/man1/FontEditor.md
+++ b/Base/usr/share/man/man1/FontEditor.md
@@ -2,6 +2,8 @@
 
 FontEditor - Serenity font editor
 
+[Open](file:///bin/FontEditor)
+
 ## Synopsis
 
 ```**sh

--- a/Base/usr/share/man/man1/Help.md
+++ b/Base/usr/share/man/man1/Help.md
@@ -59,5 +59,5 @@ this man page should be located at `/usr/share/man/man1/Help.md`.
 
 ## See Also
 
-* [`man`(1)](man.md) To read these same man pages from the terminal
+* [`man`(1)](help://man/1/man) To read these same man pages from the terminal
 

--- a/Base/usr/share/man/man1/ImageViewer.md
+++ b/Base/usr/share/man/man1/ImageViewer.md
@@ -2,6 +2,8 @@
 
 Image Viewer - SerenityOS image viewer
 
+[Open](file:///bin/ImageViewer)
+
 ## Synopsis
 
 ```**sh

--- a/Base/usr/share/man/man1/Inspector.md
+++ b/Base/usr/share/man/man1/Inspector.md
@@ -19,8 +19,8 @@ $ Inspector [pid]
 Inspector facilitates process inspection via RPC.
 
 The inspected process must have previously allowed the
-[`accept`(2)](../man2/accept.md) system call with
-[`pledge`(2)](../man2/pledge.md) to allow inspection
+[`accept`(2)](help://man/2/accept) system call with
+[`pledge`(2)](help://man/2/pledge) to allow inspection
 via UNIX socket.
 
 ## Examples

--- a/Base/usr/share/man/man1/Inspector.md
+++ b/Base/usr/share/man/man1/Inspector.md
@@ -2,6 +2,8 @@
 
 Inspector - Serenity process inspector
 
+[Open](file:///bin/Inspector)
+
 ## Synopsis
 
 ```**sh

--- a/Base/usr/share/man/man1/Mail.md
+++ b/Base/usr/share/man/man1/Mail.md
@@ -2,6 +2,8 @@
 
 Mail - Serenity e-mail client
 
+[Open](file:///bin/Mail)
+
 ## Synopsis
 
 ```**sh

--- a/Base/usr/share/man/man1/Playground.md
+++ b/Base/usr/share/man/man1/Playground.md
@@ -2,6 +2,8 @@
 
 Playground - GUI Markup Language (GML) editor
 
+[Open](file:///bin/Playground)
+
 ## Synopsis
 
 ```**sh

--- a/Base/usr/share/man/man1/Playground.md
+++ b/Base/usr/share/man/man1/Playground.md
@@ -31,4 +31,4 @@ $ Playground /home/anon/example.gml
 
 ## See also
 
-* [`gml-format`(1)](../man1/gml-format.md) For automated GML formatting
+* [`gml-format`(1)](help://man/1/gml-format) For automated GML formatting

--- a/Base/usr/share/man/man1/Profiler.md
+++ b/Base/usr/share/man/man1/Profiler.md
@@ -2,6 +2,8 @@
 
 Profiler - Serenity process profiler
 
+[Open](file:///bin/Profiler)
+
 ## Synopsis
 
 ```**sh

--- a/Base/usr/share/man/man1/Profiler.md
+++ b/Base/usr/share/man/man1/Profiler.md
@@ -49,5 +49,5 @@ $ Profiler perfcore.123
 
 ## See also
 
-* [`perfcore`(5)](../man5/perfcore.md)
+* [`perfcore`(5)](help://man/5/perfcore)
 

--- a/Base/usr/share/man/man1/Shell.md
+++ b/Base/usr/share/man/man1/Shell.md
@@ -14,7 +14,7 @@ $ Shell [--skip-shellrc] --format command_file
 ## Description
 
 The `Shell` utility is a command language interpreter, which reads commands from either a command string, a specified file, or the standard input.
-The command language shall be described in [`Shell`(5)](../man5/Shell.md), _The Shell Command Language_.
+The command language shall be described in [`Shell`(5)](help://man/5/Shell), _The Shell Command Language_.
 
 Any extra arguments passed into `arguments` are placed in the local variable `$ARGV` and can also be accessed through the special variable `$*`.
 
@@ -44,4 +44,4 @@ Shell foo a b c
 
 ## See also
 
-* [`Shell-vars`(7)](../man7/Shell-vars.md) For details on local and environment variables used by the shell
+* [`Shell-vars`(7)](help://man/7/Shell-vars) For details on local and environment variables used by the shell

--- a/Base/usr/share/man/man1/Terminal.md
+++ b/Base/usr/share/man/man1/Terminal.md
@@ -2,6 +2,8 @@
 
 Terminal - Serenity terminal emulator
 
+[Open](file:///bin/Terminal)
+
 ## Synopsis
 
 ```**sh

--- a/Base/usr/share/man/man1/TextEditor.md
+++ b/Base/usr/share/man/man1/TextEditor.md
@@ -2,6 +2,8 @@
 
 TextEditor - SerenityOS text editor
 
+[Open](file:///bin/TextEditor)
+
 ## Synopsis
 
 ```**sh

--- a/Base/usr/share/man/man1/bt.md
+++ b/Base/usr/share/man/man1/bt.md
@@ -33,7 +33,7 @@ View all stacks of pid number 10:
 $ bt 10
 ```
 
-Use [`watch`(1)](watch.md) to emit a backtrace of pid 124, every second:
+Use [`watch`(1)](help://man/1/watch) to emit a backtrace of pid 124, every second:
 
 ```sh
 $ watch -n 1 -- bt 124
@@ -41,8 +41,8 @@ $ watch -n 1 -- bt 124
 
 ## See also
 
-* [`Inspector`(1)](Inspector.md)
+* [`Inspector`(1)](help://man/1/Inspector)
 
-* [`Profiler`(1)](Profiler.md)
+* [`Profiler`(1)](help://man/1/Profiler)
 
-* [`watch`(1)](watch.md)
+* [`watch`(1)](help://man/1/watch)

--- a/Base/usr/share/man/man1/chgrp.md
+++ b/Base/usr/share/man/man1/chgrp.md
@@ -25,5 +25,5 @@ $ chgrp <name> <path>
 
 ## See also
 
-* [`chmod`(1)](chmod.md)
-* [`chown`(1)](chown.md)
+* [`chmod`(1)](help://man/1/chmod)
+* [`chown`(1)](help://man/1/chown)

--- a/Base/usr/share/man/man1/chmod.md
+++ b/Base/usr/share/man/man1/chmod.md
@@ -44,5 +44,5 @@ $ chmod g=r script.sh
 
 ## See also
 
-* [`chgrp`(1)](chgrp.md)
-* [`chown`(1)](chown.md)
+* [`chgrp`(1)](help://man/1/chgrp)
+* [`chown`(1)](help://man/1/chown)

--- a/Base/usr/share/man/man1/chown.md
+++ b/Base/usr/share/man/man1/chown.md
@@ -27,5 +27,5 @@ $ chown anon:anon file
 
 ## See also
 
-* [`chgrp`(1)](chgrp.md)
-* [`chmod`(1)](chmod.md)
+* [`chgrp`(1)](help://man/1/chgrp)
+* [`chmod`(1)](help://man/1/chmod)

--- a/Base/usr/share/man/man1/find.md
+++ b/Base/usr/share/man/man1/find.md
@@ -72,4 +72,4 @@ $ find -name \*config\*
 
 ## See also
 
-* [`xargs`(1)](xargs.md)
+* [`xargs`(1)](help://man/1/xargs)

--- a/Base/usr/share/man/man1/id.md
+++ b/Base/usr/share/man/man1/id.md
@@ -36,4 +36,4 @@ $ id -G
 
 ## See also
 
-* [`whoami`(1)](whoami.md)
+* [`whoami`(1)](help://man/1/whoami)

--- a/Base/usr/share/man/man1/js.md
+++ b/Base/usr/share/man/man1/js.md
@@ -55,4 +55,4 @@ undefined
 
 ## See also
 
-* [`test-js`(1)](test-js.md)
+* [`test-js`(1)](help://man/1/test-js)

--- a/Base/usr/share/man/man1/less.md
+++ b/Base/usr/share/man/man1/less.md
@@ -74,5 +74,5 @@ All other characters are treated normally.
 
 ## See Also
 
-* [`more`(1)](more.md) For a simpler pager that less implements.
-* [`man`(1)](man.md) For serenity's manual pager, that uses less.
+* [`more`(1)](help://man/1/more) For a simpler pager that less implements.
+* [`man`(1)](help://man/1/man) For serenity's manual pager, that uses less.

--- a/Base/usr/share/man/man1/man.md
+++ b/Base/usr/share/man/man1/man.md
@@ -53,4 +53,4 @@ this man page should be located at `/usr/share/man/man1/man.md`.
 
 ## See Also
 
-* [`less`(1)](less.md) For the terminal pager that `man` uses by default
+* [`less`(1)](help://man/1/less) For the terminal pager that `man` uses by default

--- a/Base/usr/share/man/man1/mkdir.md
+++ b/Base/usr/share/man/man1/mkdir.md
@@ -28,4 +28,4 @@ $ mkdir -m a=rx /tmp/foo/bar
 
 ## See also
 
-* [`mkdir`(2)](../man2/mkdir.md)
+* [`mkdir`(2)](help://man/2/mkdir)

--- a/Base/usr/share/man/man1/more.md
+++ b/Base/usr/share/man/man1/more.md
@@ -11,7 +11,7 @@ $ more
 ## Description
 
 `more` reads data from standard input and prints it to standard output, screen by screen.
-`more` is a symlink for [`less`(1)](less.md), which has a more emulation mode.
+`more` is a symlink for [`less`(1)](help://man/1/less), which has a more emulation mode.
 
 ## Examples
 
@@ -23,4 +23,4 @@ $ more
 
 ## See Also
 
-* [`less`(1)](less.md) For the more advanced terminal pager that implements more.
+* [`less`(1)](help://man/1/less) For the more advanced terminal pager that implements more.

--- a/Base/usr/share/man/man1/pmap.md
+++ b/Base/usr/share/man/man1/pmap.md
@@ -24,4 +24,4 @@ $ pmap $$
 
 ## See also
 
-* [`ps`(1)](../man1/ps.md)
+* [`ps`(1)](help://man/1/ps)

--- a/Base/usr/share/man/man1/printf.md
+++ b/Base/usr/share/man/man1/printf.md
@@ -50,4 +50,4 @@ $ printf '%d%d%d' 1 2 3 4 x
 
 ## See also
 
-* [`echo`(1)](../man1/echo.md)
+* [`echo`(1)](help://man/1/echo)

--- a/Base/usr/share/man/man1/readlink.md
+++ b/Base/usr/share/man/man1/readlink.md
@@ -24,4 +24,4 @@ $ readlink /proc/self/cwd
 
 ## See also
 
-* [`readlink`(2)](../man2/readlink.md)
+* [`readlink`(2)](help://man/2/readlink)

--- a/Base/usr/share/man/man1/tar.md
+++ b/Base/usr/share/man/man1/tar.md
@@ -39,4 +39,4 @@ $ tar -x -f archive.tar
 
 ## See also
 
-* [`unzip`(1)](unzip.md)
+* [`unzip`(1)](help://man/1/unzip)

--- a/Base/usr/share/man/man1/test-js.md
+++ b/Base/usr/share/man/man1/test-js.md
@@ -43,4 +43,4 @@ describe("Examples from Gary Bernhardt's 'Wat' talk", () => {
 
 ## See also
 
-* [`js`(1)](js.md)
+* [`js`(1)](help://man/1/js)

--- a/Base/usr/share/man/man1/test.md
+++ b/Base/usr/share/man/man1/test.md
@@ -93,4 +93,4 @@ $ /bin/test \( 10 -gt 20 \) -o \( ! 10 -ne 10 \) && echo "magic numbers!"
 
 ## See Also
 
-* [`find`(1)](find.md)
+* [`find`(1)](help://man/1/find)

--- a/Base/usr/share/man/man1/uname.md
+++ b/Base/usr/share/man/man1/uname.md
@@ -30,4 +30,4 @@ Serenity i686
 
 ## See also
 
-* [`uname`(2)](../man2/uname.md)
+* [`uname`(2)](help://man/2/uname)

--- a/Base/usr/share/man/man1/whoami.md
+++ b/Base/usr/share/man/man1/whoami.md
@@ -23,4 +23,4 @@ root
 
 ## See also
 
-* [`id`(1)](id.md)
+* [`id`(1)](help://man/1/id)

--- a/Base/usr/share/man/man1/xargs.md
+++ b/Base/usr/share/man/man1/xargs.md
@@ -48,4 +48,4 @@ $ xargs -a stuff --null -s 1024
 
 ## See also
 
-* [`find`(1)](find.md)
+* [`find`(1)](help://man/1/find)

--- a/Base/usr/share/man/man2/get_process_name.md
+++ b/Base/usr/share/man/man2/get_process_name.md
@@ -25,4 +25,4 @@ In pledged programs, the `stdio` promise is required for this system call.
 
 ## See also
 
-* [`set_process_name`(2)](../man2/set_process_name.md)
+* [`set_process_name`(2)](help://man/2/set_process_name)

--- a/Base/usr/share/man/man2/geteuid.md
+++ b/Base/usr/share/man/man2/geteuid.md
@@ -17,9 +17,9 @@ Returns the effective user or group id.
 
 ## See also
 
-* [`setuid_overview`(7)](../man7/setuid_overview.md)
-* [`getuid`(2) / `getgid`(2)](getuid.md)
-* [`getresuid`(2) / `getresgid`(2)](getresuid.md)
-* [`seteuid`(2) / `setegid`(2)](seteuid.md)
-* [`setuid`(2) / `setgid`(2)](setuid.md)
-* [`setresuid`(2) / `setresgid`(2)](setresuid.md)
+* [`setuid_overview`(7)](help://man/7/setuid_overview)
+* [`getuid`(2) / `getgid`(2)](help://man/2/getuid)
+* [`getresuid`(2) / `getresgid`(2)](help://man/2/getresuid)
+* [`seteuid`(2) / `setegid`(2)](help://man/2/seteuid)
+* [`setuid`(2) / `setgid`(2)](help://man/2/setuid)
+* [`setresuid`(2) / `setresgid`(2)](help://man/2/setresuid)

--- a/Base/usr/share/man/man2/getpid.md
+++ b/Base/usr/share/man/man2/getpid.md
@@ -24,5 +24,5 @@ None.
 
 ## See also
 
-* [`getppid`(2)](getppid.md)
-* [`gettid`(2)](gettid.md)
+* [`getppid`(2)](help://man/2/getppid)
+* [`gettid`(2)](help://man/2/gettid)

--- a/Base/usr/share/man/man2/getppid.md
+++ b/Base/usr/share/man/man2/getppid.md
@@ -24,5 +24,5 @@ None.
 
 ## See also
 
-* [`getpid`(2)](getpid.md)
-* [`gettid`(2)](gettid.md)
+* [`getpid`(2)](help://man/2/getpid)
+* [`gettid`(2)](help://man/2/gettid)

--- a/Base/usr/share/man/man2/getresuid.md
+++ b/Base/usr/share/man/man2/getresuid.md
@@ -26,9 +26,9 @@ Otherwise, returns -1 and sets `errno` to describe the error.
 
 ## See also
 
-* [`setuid_overview`(7)](../man7/setuid_overview.md)
-* [`geteuid`(2) / `getegid`(2)](geteuid.md)
-* [`getuid`(2) / `getgid`(2)](getuid.md)
-* [`seteuid`(2) / `setegid`(2)](seteuid.md)
-* [`setuid`(2) / `setgid`(2)](setuid.md)
-* [`setresuid`(2) / `setresgid`(2)](setresuid.md)
+* [`setuid_overview`(7)](help://man/7/setuid_overview)
+* [`geteuid`(2) / `getegid`(2)](help://man/2/geteuid)
+* [`getuid`(2) / `getgid`(2)](help://man/2/getuid)
+* [`seteuid`(2) / `setegid`(2)](help://man/2/seteuid)
+* [`setuid`(2) / `setgid`(2)](help://man/2/setuid)
+* [`setresuid`(2) / `setresgid`(2)](help://man/2/setresuid)

--- a/Base/usr/share/man/man2/gettid.md
+++ b/Base/usr/share/man/man2/gettid.md
@@ -24,5 +24,5 @@ None.
 
 ## See also
 
-* [`getpid`(2)](getpid.md)
-* [`getppid`(2)](getppid.md)
+* [`getpid`(2)](help://man/2/getpid)
+* [`getppid`(2)](help://man/2/getppid)

--- a/Base/usr/share/man/man2/getuid.md
+++ b/Base/usr/share/man/man2/getuid.md
@@ -17,9 +17,9 @@ Returns the real user or group id.
 
 ## See also
 
-* [`setuid_overview`(7)](../man7/setuid_overview.md)
-* [`geteuid`(2) / `getegid`(2)](geteuid.md)
-* [`getresuid`(2) / `getresgid`(2)](getresuid.md)
-* [`seteuid`(2) / `setegid`(2)](seteuid.md)
-* [`setuid`(2) / `setgid`(2)](setuid.md)
-* [`setresuid`(2) / `setresgid`(2)](setresuid.md)
+* [`setuid_overview`(7)](help://man/7/setuid_overview)
+* [`geteuid`(2) / `getegid`(2)](help://man/2/geteuid)
+* [`getresuid`(2) / `getresgid`(2)](help://man/2/getresuid)
+* [`seteuid`(2) / `setegid`(2)](help://man/2/seteuid)
+* [`setuid`(2) / `setgid`(2)](help://man/2/setuid)
+* [`setresuid`(2) / `setresgid`(2)](help://man/2/setresuid)

--- a/Base/usr/share/man/man2/mkdir.md
+++ b/Base/usr/share/man/man2/mkdir.md
@@ -21,4 +21,4 @@ it returns -1 and sets `errno` to describe the error.
 
 ## See also
 
-* [`mkdir`(1)](../man1/mkdir.md)
+* [`mkdir`(1)](help://man/1/mkdir)

--- a/Base/usr/share/man/man2/mount.md
+++ b/Base/usr/share/man/man2/mount.md
@@ -95,4 +95,4 @@ All of the usual path resolution errors may also occur.
 
 ## See also
 
-* [`mount`(8)](../man8/mount.md)
+* [`mount`(8)](help://man/8/mount)

--- a/Base/usr/share/man/man2/pledge.md
+++ b/Base/usr/share/man/man2/pledge.md
@@ -18,9 +18,9 @@ Functionality is divided into a curated set of promises (described below), which
 
 Note that `pledge()` can be called repeatedly to remove previously-pledged promises, but it can never regain capabilities once lost.
 
-`promises` are applied to the current process, and will also be inherited by children created by [`fork`(2)](fork.md).
+`promises` are applied to the current process, and will also be inherited by children created by [`fork`(2)](help://man/2/fork).
 
-`execpromises` are applied if/when a new process image is created with [`exec`(2)](exec.md).
+`execpromises` are applied if/when a new process image is created with [`exec`(2)](help://man/2/exec).
 
 If `promises` or `execpromises` is null, the corresponding value is unchanged.
 
@@ -35,25 +35,25 @@ If the process later attempts to use any system functionality it has previously 
 * `id`: Ability to change UID/GID
 * `tty`: TTY related functionality
 * `proc`: Process and scheduling related functionality
-* `exec`: The [`exec`(2)](exec.md) syscall
+* `exec`: The [`exec`(2)](help://man/2/exec) syscall
 * `unix`: UNIX local domain sockets
 * `inet`: IPv4 domain sockets
-* `accept`: May use [`accept`(2)](accept.md) to accept incoming socket connections on already listening sockets (\*)
+* `accept`: May use [`accept`(2)](help://man/2/accept) to accept incoming socket connections on already listening sockets (\*)
 * `rpath`: "Read" filesystem access
 * `wpath`: "Write" filesystem access
 * `cpath`: "Create" filesystem access
 * `dpath`: Creating new device files
 * `chown`: Changing file owner/group
 * `fattr`: Changing file attributes/permissions
-* `video`: May use [`ioctl`(2)](ioctl.md) and [`mmap`(2)](mmap.md) on framebuffer video devices
+* `video`: May use [`ioctl`(2)](help://man/2/ioctl) and [`mmap`(2)](help://man/2/mmap) on framebuffer video devices
 * `settime`: Changing the system time and date
 * `setkeymap`: Changing the system keyboard layout (\*)
 * `sigaction`: Change signal handlers and dispositions (\*)
 * `sendfd`: Send file descriptors over a local socket
 * `recvfd`: Receive file descriptors over a local socket
-* `ptrace`: The [`ptrace`(2)](ptrace.md) syscall (\*)
-* `prot_exec`: [`mmap`(2)](mmap.md) and [`mprotect`(2)](mprotect.md) with `PROT_EXEC`
-* `map_fixed`: [`mmap`(2)](mmap.md) with `MAP_FIXED` or `MAP_FIXED_NOREPLACE` (\*)
+* `ptrace`: The [`ptrace`(2)](help://man/2/ptrace) syscall (\*)
+* `prot_exec`: [`mmap`(2)](help://man/2/mmap) and [`mprotect`(2)](help://man/2/mprotect) with `PROT_EXEC`
+* `map_fixed`: [`mmap`(2)](help://man/2/mmap) with `MAP_FIXED` or `MAP_FIXED_NOREPLACE` (\*)
 
 Promises marked with an asterisk (\*) are SerenityOS specific extensions not supported by the original OpenBSD `pledge()`.
 
@@ -69,5 +69,5 @@ The `pledge()` system call was first introduced by OpenBSD. The implementation i
 
 ## See also
 
-* [`unveil`(2)](unveil.md)
-* [`Mitigations`(7)](../man7/Mitigations.md)
+* [`unveil`(2)](help://man/2/unveil)
+* [`Mitigations`(7)](help://man/7/Mitigations)

--- a/Base/usr/share/man/man2/readlink.md
+++ b/Base/usr/share/man/man2/readlink.md
@@ -66,4 +66,4 @@ pid_t read_pid_using_core_file()
 
 ## See also
 
-* [`readlink`(1)](../man1/readlink.md)
+* [`readlink`(1)](help://man/1/readlink)

--- a/Base/usr/share/man/man2/recvfd.md
+++ b/Base/usr/share/man/man2/recvfd.md
@@ -18,7 +18,7 @@ File descriptors are sent out-of-band and do not affect the regular data streams
 
 The *options* argument accepts a bitmask of the following flags:
 
-* `O_CLOEXEC`: The opened fd shall be closed on [`exec`(2)](../man2/exec.md).
+* `O_CLOEXEC`: The opened fd shall be closed on [`exec`(2)](help://man/2/exec).
 
 ## Return value
 
@@ -38,4 +38,4 @@ If a file descriptor is successfully received, it is returned as a non-negative 
 
 ## See also
 
-* [`sendfd`(2)](sendfd.md)
+* [`sendfd`(2)](help://man/2/sendfd)

--- a/Base/usr/share/man/man2/sendfd.md
+++ b/Base/usr/share/man/man2/sendfd.md
@@ -35,4 +35,4 @@ If a file descriptor is successfully sent, `sendfd()` returns 0. Otherwise, -1 i
 
 ## See also
 
-* [`recvfd`(2)](recvfd.md)
+* [`recvfd`(2)](help://man/2/recvfd)

--- a/Base/usr/share/man/man2/set_process_name.md
+++ b/Base/usr/share/man/man2/set_process_name.md
@@ -25,4 +25,4 @@ In pledged programs, the `proc` promise is required for this system call.
 
 ## See also
 
-* [`get_process_name`(2)](../man2/get_process_name.md)
+* [`get_process_name`(2)](help://man/2/get_process_name)

--- a/Base/usr/share/man/man2/seteuid.md
+++ b/Base/usr/share/man/man2/seteuid.md
@@ -31,9 +31,9 @@ Otherwise, returns -1 and sets `errno` to describe the error.
 
 ## See also
 
-* [`setuid_overview`(7)](../man7/setuid_overview.md)
-* [`geteuid`(2) / `getegid`(2)](geteuid.md)
-* [`getuid`(2) / `getgid`(2)](getuid.md)
-* [`getresuid`(2) / `getresgid`(2)](getresuid.md)
-* [`setuid`(2) / `setgid`(2)](setuid.md)
-* [`setresuid`(2) / `setresgid`(2)](setresuid.md)
+* [`setuid_overview`(7)](help://man/7/setuid_overview)
+* [`geteuid`(2) / `getegid`(2)](help://man/2/geteuid)
+* [`getuid`(2) / `getgid`(2)](help://man/2/getuid)
+* [`getresuid`(2) / `getresgid`(2)](help://man/2/getresuid)
+* [`setuid`(2) / `setgid`(2)](help://man/2/setuid)
+* [`setresuid`(2) / `setresgid`(2)](help://man/2/setresuid)

--- a/Base/usr/share/man/man2/setresuid.md
+++ b/Base/usr/share/man/man2/setresuid.md
@@ -30,9 +30,9 @@ Otherwise, returns -1 and sets `errno` to describe the error.
 
 ## See also
 
-* [`setuid_overview`(7)](../man7/setuid_overview.md)
-* [`geteuid`(2) / `getegid`(2)](geteuid.md)
-* [`getuid`(2) / `getgid`(2)](getuid.md)
-* [`getresuid`(2) / `getresgid`(2)](getresuid.md)
-* [`seteuid`(2) / `setegid`(2)](seteuid.md)
-* [`setuid`(2) / `setgid`(2)](setuid.md)
+* [`setuid_overview`(7)](help://man/7/setuid_overview)
+* [`geteuid`(2) / `getegid`(2)](help://man/2/geteuid)
+* [`getuid`(2) / `getgid`(2)](help://man/2/getuid)
+* [`getresuid`(2) / `getresgid`(2)](help://man/2/getresuid)
+* [`seteuid`(2) / `setegid`(2)](help://man/2/seteuid)
+* [`setuid`(2) / `setgid`(2)](help://man/2/setuid)

--- a/Base/usr/share/man/man2/setuid.md
+++ b/Base/usr/share/man/man2/setuid.md
@@ -29,9 +29,9 @@ Otherwise, returns -1 and sets `errno` to describe the error.
 
 ## See also
 
-* [`setuid_overview`(7)](../man7/setuid_overview.md)
-* [`geteuid`(2) / `getegid`(2)](geteuid.md)
-* [`getuid`(2) / `getgid`(2)](getuid.md)
-* [`getresuid`(2) / `getresgid`(2)](getresuid.md)
-* [`seteuid`(2) / `setegid`(2)](seteuid.md)
-* [`setresuid`(2) / `setresgid`(2)](setresuid.md)
+* [`setuid_overview`(7)](help://man/7/setuid_overview)
+* [`geteuid`(2) / `getegid`(2)](help://man/2/geteuid)
+* [`getuid`(2) / `getgid`(2)](help://man/2/getuid)
+* [`getresuid`(2) / `getresgid`(2)](help://man/2/getresuid)
+* [`seteuid`(2) / `setegid`(2)](help://man/2/seteuid)
+* [`setresuid`(2) / `setresgid`(2)](help://man/2/setresuid)

--- a/Base/usr/share/man/man2/uname.md
+++ b/Base/usr/share/man/man2/uname.md
@@ -35,4 +35,4 @@ If successful, returns 0. Otherwise, returns -1 and sets `errno` to describe the
 
 ## See also
 
-* [`uname`(1)](../man1/uname.md)
+* [`uname`(1)](help://man/1/uname)

--- a/Base/usr/share/man/man2/unveil.md
+++ b/Base/usr/share/man/man2/unveil.md
@@ -96,5 +96,5 @@ unveil(nullptr, nullptr);
 
 ## See also
 
-* [`pledge`(2)](pledge.md)
-* [`Mitigations`(7)](../man7/Mitigations.md)
+* [`pledge`(2)](help://man/2/pledge)
+* [`Mitigations`(7)](help://man/7/Mitigations)

--- a/Base/usr/share/man/man3/basename.md
+++ b/Base/usr/share/man/man3/basename.md
@@ -50,4 +50,4 @@ int main()
 
 ## See also
 
-* [`dirname`(3)](dirname.md)
+* [`dirname`(3)](help://man/3/dirname)

--- a/Base/usr/share/man/man3/dirname.md
+++ b/Base/usr/share/man/man3/dirname.md
@@ -51,4 +51,4 @@ int main()
 
 ## See also
 
-* [`basename`(3)](basename.md)
+* [`basename`(3)](help://man/3/basename)

--- a/Base/usr/share/man/man3/getopt.md
+++ b/Base/usr/share/man/man3/getopt.md
@@ -27,7 +27,7 @@ int getopt_long(int argc, char** argv, const char* short_options, const struct o
 ## Description
 
 `getopt()` and `getopt_long()` parse options according to the syntax specified
-in [`getopt`(5)](../man5/getopt.md). `getopt()` only supports short options;
+in [`getopt`(5)](help://man/5/getopt). `getopt()` only supports short options;
 `getopt_long()` supports both short and long options.
 
 One invocation of either function extracts at most one option from command line
@@ -150,4 +150,4 @@ const char* file_name = argv[optind];
 
 ## See also
 
-* [`getopt`(5)](../man5/getopt.md)
+* [`getopt`(5)](help://man/5/getopt)

--- a/Base/usr/share/man/man3/posix_openpt.md
+++ b/Base/usr/share/man/man3/posix_openpt.md
@@ -19,7 +19,7 @@ The *flags* argument accepts a bitmask of the following flags:
 
 * `O_RDWR`: Open for both reading and writing.
 * `O_NOCTTY`: The opened pseudo-terminal will not be made the controlling TTY for the process.
-* `O_CLOEXEC`: The opened fd shall be closed on [`exec`(2)](../man2/exec.md).
+* `O_CLOEXEC`: The opened fd shall be closed on [`exec`(2)](help://man/2/exec).
 
 ## Return value
 
@@ -27,8 +27,8 @@ On success, a pseudo-terminal device is allocated and `posix_openpt()` returns a
 
 ## Errors
 
-Returns the same errors as [`open`(2)](../man2/open.md).
+Returns the same errors as [`open`(2)](help://man/2/open).
 
 ## See also
 
-* [`open`(2)](../man2/open.md)
+* [`open`(2)](help://man/2/open)

--- a/Base/usr/share/man/man3/posix_spawn.md
+++ b/Base/usr/share/man/man3/posix_spawn.md
@@ -21,15 +21,15 @@ If `executable_path` passed to `posix_spawn` is a relative path, it is resolved 
 
 If `executable_path` passed to `posix_spawnp` is a relative path, it is resolved by searching through directories specified in the `PATH` environment variable.
 
-The `posix_spawn_file_actions_t` and `posix_spawnattr_t` arguments may be `nullptr`. If they aren't, see [`posix_spawn_file_actions`(2)](posix_spawn_file_actions_init.md) and [`posix_spawnattr`(2)](posix_spawnattr_init.md) for what they do.
+The `posix_spawn_file_actions_t` and `posix_spawnattr_t` arguments may be `nullptr`. If they aren't, see [`posix_spawn_file_actions`(2)](help://man/3/posix_spawn_file_actions_init) and [`posix_spawnattr`(2)](help://man/3/posix_spawnattr_init) for what they do.
 
 The last entry in `argv` and `envp` has to be `nullptr`.
 
 The new process is started as if the following steps are executed in this order:
 
 1. A new process is started as if `fork()` was called.
-2. If the `posix_spawnattr_t` parameter is non-nullptr, it [takes effect](posix_spawnattr_init.md).
-3. If the `posix_spawn_file_actions_t` parameter is non-nullptr, it [takes effect](posix_spawn_file_actions_init.md).
+2. If the `posix_spawnattr_t` parameter is non-nullptr, it [takes effect](help://man/3/posix_spawnattr_init).
+3. If the `posix_spawn_file_actions_t` parameter is non-nullptr, it [takes effect](help://man/3/posix_spawn_file_actions_init).
 4. `executable_path` is loaded and starts running, as if `execve` or `execvpe` was called.
 
 ## Return value
@@ -62,5 +62,5 @@ int main()
 
 ## See also
 
-* [`posix_spawnattr`(2)](posix_spawnattr_init.md)
-* [`posix_spawn_file_actions`(2)](posix_spawn_file_actions_init.md)
+* [`posix_spawnattr`(2)](help://man/3/posix_spawnattr_init)
+* [`posix_spawn_file_actions`(2)](help://man/3/posix_spawn_file_actions_init)

--- a/Base/usr/share/man/man3/posix_spawn_file_actions_init.md
+++ b/Base/usr/share/man/man3/posix_spawn_file_actions_init.md
@@ -21,7 +21,7 @@ int posix_spawn_file_actions_addopen(posix_spawn_file_actions_t*, int fd, const 
 
 ## Description
 
-Configure a `posix_spawn_file_actions_t` object for use with [`posix_spawn`(2)](posix_spawn.md). This object can be used to let `posix_spawn()` set up file-related state for the spawned child process. The file actions are executed after creating the the new process but before loading its binary in the order they were added to the `posix_spawn_file_actions_t` object.
+Configure a `posix_spawn_file_actions_t` object for use with [`posix_spawn`(2)](help://man/3/posix_spawn). This object can be used to let `posix_spawn()` set up file-related state for the spawned child process. The file actions are executed after creating the the new process but before loading its binary in the order they were added to the `posix_spawn_file_actions_t` object.
 
 A `posix_spawn_file_actions_t` object is allocated on the stack but starts in an undefined state.
 
@@ -47,4 +47,4 @@ If the effect of a file action fails, the child will exit with exit code 127 bef
 
 ## See also
 
-* [`posix_spawn`(2)](posix_spawn.md)
+* [`posix_spawn`(2)](help://man/3/posix_spawn)

--- a/Base/usr/share/man/man3/posix_spawnattr_init.md
+++ b/Base/usr/share/man/man3/posix_spawnattr_init.md
@@ -36,7 +36,7 @@ int posix_spawnattr_setsigmask(posix_spawnattr_t*, const sigset_t*);
 
 ## Description
 
-Configures a `posix_spawnattr_t` object for use with [`posix_spawn`(2)](posix_spawn.md). This object can be used to let `posix_spawn()` set up process attributes for the spawned child process. The file actions are executed after creating the new process but before loading its binary.
+Configures a `posix_spawnattr_t` object for use with [`posix_spawn`(2)](help://man/3/posix_spawn). This object can be used to let `posix_spawn()` set up process attributes for the spawned child process. The file actions are executed after creating the new process but before loading its binary.
 
 A `posix_spawnattr_t` object is allocated on the stack but starts in an undefined state.
 
@@ -48,7 +48,7 @@ It is valid to alternatingly call `posix_spawnattr_init()` and `posix_spawnattr_
 
 `posix_spawnattr_setflags()` configures which attributes of the new child process `posix_spawn()` will set. It receives a bitmask that can contain:
 
-* `POSIX_SPAWN_RESETIDS`: If set, `posix_spawn()` will reset the effective uid and gid of the child process to the real uid and gid of the parent process. See also [`setuid_overview`(7)](../man7/setuid_overview.md).
+* `POSIX_SPAWN_RESETIDS`: If set, `posix_spawn()` will reset the effective uid and gid of the child process to the real uid and gid of the parent process. See also [`setuid_overview`(7)](help://man/7/setuid_overview).
 
 * `POSIX_SPAWN_SETPGROUP`: If set, `posix_spawn()` will set the process group ID of the child process to the process group ID configured with `posix_spawnattr_setpgroup()`, as if `setpgid(0, pgroup)` was called in the child process. The behavior if both this and `POSIX_SPAWN_SETSID` is set is undefined.
 
@@ -75,4 +75,4 @@ If the effect of an attr fails, the child will exit with exit code 127 before ev
 
 ## See also
 
-* [`posix_spawn`(2)](posix_spawn.md)
+* [`posix_spawn`(2)](help://man/3/posix_spawn)

--- a/Base/usr/share/man/man4/audio.md
+++ b/Base/usr/share/man/man4/audio.md
@@ -11,7 +11,7 @@ The `/dev/audio` character device file exposes the audio output device of the sy
 | Format | 16-bit signed | 16-bit signed |
 | Data | Left sample | Right sample |
 
-The sample rate of the samples is determined by the audio device's current sample rate, which may be accessed by an [ioctl](../man2/ioctl.md).
+The sample rate of the samples is determined by the audio device's current sample rate, which may be accessed by an [ioctl](help://man/2/ioctl).
 
 Note that for convenience, the audio device may not block the call to `write` and return before all the samples were actually transferred to the hardware and/or played by the hardware. For this reason, users need to be aware that the audio device driver's internal buffer may become full and calls to `write` may return `ENOSPC`.
 

--- a/Base/usr/share/man/man4/full.md
+++ b/Base/usr/share/man/man4/full.md
@@ -30,6 +30,6 @@ $ head -c 8 /dev/full | hexdump
 
 ## See also
 
-* [`null`(4)](../man4/null.md)
-* [`zero`(4)](../man4/zero.md)
+* [`null`(4)](help://man/4/null)
+* [`zero`(4)](help://man/4/zero)
 

--- a/Base/usr/share/man/man4/mem.md
+++ b/Base/usr/share/man/man4/mem.md
@@ -7,8 +7,8 @@ mem - physical system memory
 `/dev/mem` is a character device file that is used by other programs to examine
 the physical memory.
 
-Trying to [`mmap`(2)](../man2/mmap.md) a physical range results either with success,
-or with an error. When invoking [`mmap`(2)](../man2/mmap.md) on bad memory range,
+Trying to [`mmap`(2)](help://man/2/mmap) a physical range results either with success,
+or with an error. When invoking [`mmap`(2)](help://man/2/mmap) on bad memory range,
 the kernel will write a message about it to the kernel log.
 
 By default, the kernel limits the areas which can be accessed. The allowed areas
@@ -21,11 +21,11 @@ mknod /dev/mem c 1 1
 chmod 660 /dev/mem
 ```
 
-## Returned error values after [`mmap`(2)](../man2/mmap.md)
+## Returned error values after [`mmap`(2)](help://man/2/mmap)
 
 * `EINVAL`: An access violation was detected.
 * `ENOMEM`: The requested range would wrap around, creating an access violation.
 
 ## See also
 
-* [`mmap`(2)](../man2/mmap.md)
+* [`mmap`(2)](help://man/2/mmap)

--- a/Base/usr/share/man/man4/null.md
+++ b/Base/usr/share/man/man4/null.md
@@ -14,6 +14,6 @@ Reading from `/dev/null` returns end of file and exits with status 0.
 
 ## See also
 
-* [`full`(4)](../man4/full.md)
-* [`zero`(4)](../man4/zero.md)
+* [`full`(4)](help://man/4/full)
+* [`zero`(4)](help://man/4/zero)
 

--- a/Base/usr/share/man/man4/zero.md
+++ b/Base/usr/share/man/man4/zero.md
@@ -21,6 +21,6 @@ $ head -c 8 /dev/zero | hexdump
 
 ## See also
 
-* [`null`(4)](../man4/null.md)
-* [`full`(4)](../man4/full.md)
+* [`null`(4)](help://man/4/null)
+* [`full`(4)](help://man/4/full)
 

--- a/Base/usr/share/man/man5/Shell.md
+++ b/Base/usr/share/man/man5/Shell.md
@@ -6,7 +6,7 @@ The Shell Command Language
 
 The shell operates according to the following general steps:
 
-* Some string is read from a source, be it a file, the standard input, or a command string (see [`Shell`(1)](../man1/Shell.md))
+* Some string is read from a source, be it a file, the standard input, or a command string (see [`Shell`(1)](help://man/1/Shell))
 * The shell parses the input to an abstract syntax tree
 * The shell performs various expansions and/or resolutions on the nodes
 * The shell performs various type checks and syntactic checks

--- a/Base/usr/share/man/man5/SystemServer.md
+++ b/Base/usr/share/man/man5/SystemServer.md
@@ -28,7 +28,7 @@ describing how to launch and manage this service.
 * `SocketPermissions` - comma-separated list of (octal) file system permissions for the socket file. The default permissions are 0600. If the number of socket permissions defined is less than the number of sockets defined, then the last defined permission will be used for the remainder of the items in `Socket`.
 * `User` - a name of the user to run the service as. This impacts what UID, GID (and extra GIDs) the service processes have. By default, services are run as root.
 * `WorkingDirectory` - the working directory in which the service is spawned. By default, services are spawned in the root (`"/"`) directory.
-* `SystemModes` - a comma-separated list of system modes in which the service should be enabled. By default, services are only enabled in the "graphical" mode. The current system mode is read from the [kernel command line](../man7/boot_parameters.md#options), and is assumed to be "graphical" if not specified there.
+* `SystemModes` - a comma-separated list of system modes in which the service should be enabled. By default, services are only enabled in the "graphical" mode. The current system mode is read from the [kernel command line](help://man/7/boot_parameters#options), and is assumed to be "graphical" if not specified there.
 * `Environment` - a space-separated list of "variable=value" pairs to set in the environment for the service.
 * `MultiInstance` - whether multiple instances of the service can be running simultaneously.
 * `AcceptSocketConnections` - whether SystemServer should accept connections on the socket, and spawn an instance of the service for each client connection.
@@ -90,4 +90,4 @@ User=window
 
 ## See also
 
-* [`SystemServer`(7)](../man7/SystemServer.md)
+* [`SystemServer`(7)](help://man/7/SystemServer)

--- a/Base/usr/share/man/man5/getopt.md
+++ b/Base/usr/share/man/man5/getopt.md
@@ -88,4 +88,4 @@ $ command --force -- -argument --another-argument
 
 ## See also
 
-* [`getopt`(3)](../man3/getopt.md)
+* [`getopt`(3)](help://man/3/getopt)

--- a/Base/usr/share/man/man7/Audio-subsystem.md
+++ b/Base/usr/share/man/man7/Audio-subsystem.md
@@ -1,6 +1,6 @@
 ## Name
 
-Overview of the SerenityOS audio subsystem, including a brief description of [`/dev/audio`](../man4/audio.md), the AudioServer and their interfaces. 
+Overview of the SerenityOS audio subsystem, including a brief description of [`/dev/audio`](help://man/4/audio), the AudioServer and their interfaces. 
 
 ## Description
 
@@ -12,7 +12,7 @@ SerenityOS structures audio into three groups of responsibilities: Audio drivers
 
 AudioServer is responsible for handling userland audio clients and talking to the hardware. For this reason, no userland application should ever need to write to `/dev/audio` directly, except for special cases in which AudioServer is not present.
 
-As with all system servers, AudioServer provides an IPC interface on `/tmp/portal/audio`. For specifics on how to talk to AudioServer, the IPC interface specifications are the best source of information. Audio clients send audio buffers with the standard audio format (see [audio](../man4/audio.md)) to the server. They can then query the state of these buffers, pause buffer playback or clear the playing buffers. For controlling mixer functionality, clients have the ability to obtain and change their own volume, or the main volume and mute state.
+As with all system servers, AudioServer provides an IPC interface on `/tmp/portal/audio`. For specifics on how to talk to AudioServer, the IPC interface specifications are the best source of information. Audio clients send audio buffers with the standard audio format (see [audio](help://man/4/audio)) to the server. They can then query the state of these buffers, pause buffer playback or clear the playing buffers. For controlling mixer functionality, clients have the ability to obtain and change their own volume, or the main volume and mute state.
 
 In reverse, AudioServer has "event" calls that the client receives. These are: A client buffer finished playing (useful for queuing the next buffer), various mixer states changed (main volume, main mute, client volume).
 
@@ -37,7 +37,7 @@ This is a non-exhaustive list of applications that use audio. Most of these foll
 * **Piano** is a sequencer/tracker and synthesizer.
 * **aplay** is a command line audio file playback utility.
 * **SoundPlayer** is a UI audio file player with extra features such as playlist support and audio visualizations.
-* [**asctl**](../man1/asctl.md) is a command line audio server control utility.
+* [**asctl**](help://man/1/asctl) is a command line audio server control utility.
 * **Applets/Audio** (AudioApplet) is a taskbar applet for setting audio parameters through a UI.
 
 ### Volume
@@ -56,11 +56,11 @@ Although the sample rate can change at any time, it is considered a rarely-chang
 
 ## Files
 
-* [/dev/audio](../man4/audio.md)
+* [/dev/audio](help://man/4/audio)
 * AudioApplet and AudioServer have settings which are managed by ConfigServer.
 * `/tmp/portal/audio`: AudioServer's IPC socket
 
 ## See also
 
-* [asctl](../man1/asctl.md)
-* [aplay](../man1/aplay.md)
+* [asctl](help://man/1/asctl)
+* [aplay](help://man/1/aplay)

--- a/Base/usr/share/man/man7/Help-index.md
+++ b/Base/usr/share/man/man7/Help-index.md
@@ -2,7 +2,7 @@
 
 ## Welcome to the SerenityOS on-line help system!
 
-This is **Help**, the built-in documentation viewer for the SerenityOS desktop environment. If you prefer a command-line interface, the [man](../man1/man.md) command offers a text-only view of the same library.
+This is **Help**, the built-in documentation viewer for the SerenityOS desktop environment. If you prefer a command-line interface, the [man](help://man/1/man) command offers a text-only view of the same library.
 
 ---
 

--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -312,5 +312,5 @@ Build: Pass "-z separate-code" to linker
 
 ## See also
 
-* [`unveil`(2)](../man2/unveil.md)
-* [`pledge`(2)](../man2/pledge.md)
+* [`unveil`(2)](help://man/2/unveil)
+* [`pledge`(2)](help://man/2/pledge)

--- a/Base/usr/share/man/man7/Shell-vars.md
+++ b/Base/usr/share/man/man7/Shell-vars.md
@@ -26,7 +26,7 @@ The value of this variable is used to determine which entries are kept in the Sh
 - `ignoreboth`: The behavior of `ignorespace` and `ignoredups` is combined
 - If the variable is unset (this is the default) or has any other value than the above, no entries will be excluded from history.
 
-Note: This variable is respected by every program using `Line::Editor`, e.g. [`js`(1)](../man1/js.md).
+Note: This variable is respected by every program using `Line::Editor`, e.g. [`js`(1)](help://man/1/js).
 
 `HISTFILE`  (environment)
 

--- a/Base/usr/share/man/man7/SystemServer.md
+++ b/Base/usr/share/man/man7/SystemServer.md
@@ -23,11 +23,11 @@ between socket creation and the client trying to connect to those sockets.
 When a service is spawned, SystemServer passes it an open file descriptor to the
 configured socket as fd 3, and sets `SOCKET_TAKEOVER=1` in the environment to
 inform the service that socket takeover is happening. SystemServer calls
-[`listen`(2)](../man2/listen.md) on the file descriptor, so the service doesn't
+[`listen`(2)](help://man/2/listen) on the file descriptor, so the service doesn't
 need to do it again. The file descriptor does not have the `FD_CLOEXEC` flag set
 on it.
 
-The service is advised to set this flag using [`fcntl`(2)](../man2/fcntl.md) and
+The service is advised to set this flag using [`fcntl`(2)](help://man/2/fcntl) and
 unset `SOCKET_TAKEOVER` from the environment in order not to confuse its
 children.
 
@@ -48,4 +48,4 @@ the accepted socket to the service process.
 
 ## See also
 
-* [`SystemServer`(5)](../man5/SystemServer.md)
+* [`SystemServer`(5)](help://man/5/SystemServer)

--- a/Base/usr/share/man/man7/boot_parameters.md
+++ b/Base/usr/share/man/man7/boot_parameters.md
@@ -49,7 +49,7 @@ List of options:
   be configured in a periodic mode. **`nonperiodic`** - The High Precision Event Timer should eb configure din non-periodic mode.
 
 * **`init`** - This parameter expects the fully qualified path to the init program the Kernel should launch after boot.
-    This defaults to [`SystemServer`(7)](../man7/SystemServer.md).
+    This defaults to [`SystemServer`(7)](help://man/7/SystemServer).
 
 * **`init_args`** - This parameter expects a set of arguments to pass to the **`init`** program.
   The value should be a set of strings separated by `,` characters.
@@ -80,4 +80,4 @@ List of options:
 
 ## See also
 
-* [`SystemServer`(7)](../man7/SystemServer.md).
+* [`SystemServer`(7)](help://man/7/SystemServer).

--- a/Base/usr/share/man/man7/proc.md
+++ b/Base/usr/share/man/man7/proc.md
@@ -67,7 +67,7 @@ reset the the offset to 0.
 
 ## See also
 
-* [`mount`(2))](../man2/mount.md).
-* [`boot_parameters`(7))](boot_parameters.md).
-* [`pledge`(2))](../man2/pledge.md).
-* [`unveil`(2))](../man2/unveil.md).
+* [`mount`(2))](help://man/2/mount).
+* [`boot_parameters`(7))](help://man/7/boot_parameters).
+* [`pledge`(2))](help://man/2/pledge).
+* [`unveil`(2))](help://man/2/unveil).

--- a/Base/usr/share/man/man7/setuid_overview.md
+++ b/Base/usr/share/man/man7/setuid_overview.md
@@ -24,7 +24,7 @@ In some instances, it is useful for a SUID binary to either temporarily or perma
 
 To make this possible, each process has *three* user (and group) IDs: The (real) user ID, the *effective* user ID, and the *saved* user ID. When a process executes a normal binary, all three IDs are set to the parent process's user ID. However, when a process executes a SUID binary, the process runs with the parent process's ID as its real ID, but it takes its effective ID and saved ID from the binary. (Analogously for the group ID for SGID binaries.)
 
-The function [`setresuid`(2)](../man2/getresuid.md) can change the real, effective, and saved user ID of a process -- but for non-root processes it is only valid to set each new ID to the current value of real, effective, or saved user ID. Since SUID binaries start with the binary's owner as effective and saved user ID and with the current user's ID as real user ID, this allows switching the effective user ID between the SUID owner's ID and the current user's ID.
+The function [`setresuid`(2)](help://man/2/getresuid) can change the real, effective, and saved user ID of a process -- but for non-root processes it is only valid to set each new ID to the current value of real, effective, or saved user ID. Since SUID binaries start with the binary's owner as effective and saved user ID and with the current user's ID as real user ID, this allows switching the effective user ID between the SUID owner's ID and the current user's ID.
 
 Hence, to temporarily drop SUID privileges, set the effective ID to a less privileged user ID, and store the current effective user ID in the saved user ID so that it can be restored in a later call:
 
@@ -63,9 +63,9 @@ For historical reasons, there are many functions for setting and getting these I
 ## See also
 
 * "Setuid Demystified", Proceedings of the 11th USENIX Security Symposium, August 2002, Pages 171–190
-* [`getresuid`(2) / `getresgid`(2)](../man2/getresuid.md)
-* [`geteuid`(2) / `getegid`(2)](../man2/geteuid.md)
-* [`getuid`(2) / `getgid`(2)](../man2/getuid.md)
-* [`seteuid`(2) / `setegid`(2)](../man2/seteuid.md)
-* [`setuid`(2) / `setgid`(2)](../man2/setuid.md)
-* [`setresuid`(2) / `setresgid`(2)](../man2/setresuid.md)
+* [`getresuid`(2) / `getresgid`(2)](help://man/2/getresuid)
+* [`geteuid`(2) / `getegid`(2)](help://man/2/geteuid)
+* [`getuid`(2) / `getgid`(2)](help://man/2/getuid)
+* [`seteuid`(2) / `setegid`(2)](help://man/2/seteuid)
+* [`setuid`(2) / `setgid`(2)](help://man/2/setuid)
+* [`setresuid`(2) / `setresgid`(2)](help://man/2/setresuid)

--- a/Base/usr/share/man/man7/sys.md
+++ b/Base/usr/share/man/man7/sys.md
@@ -49,4 +49,4 @@ reset the the offset to 0.
 
 ## See also
 
-* [`mount`(2))](../man2/mount.md).
+* [`mount`(2))](help://man/2/mount).

--- a/Base/usr/share/man/man8/groupdel.md
+++ b/Base/usr/share/man/man8/groupdel.md
@@ -41,5 +41,5 @@ You should manually check all users to ensure that no user remain in this group.
 
 ## See Also
 
-* [`useradd`(8)](groupadd.md)
+* [`useradd`(8)](help://man/8/groupadd)
 

--- a/Base/usr/share/man/man8/mount.md
+++ b/Base/usr/share/man/man8/mount.md
@@ -17,16 +17,16 @@ filesystems.
 
 If invoked as `mount -a`, `mount` mounts all the filesystems configured in
 `/etc/fstab`. This is normally done on system startup by
-[`SystemServer`(7)](../man7/SystemServer.md).
+[`SystemServer`(7)](help://man/7/SystemServer).
 
 Otherwise, `mount` performs a single filesystem mount. Source should be a path
 to a file containing the filesystem image. Target and fstype have the same
-meaning as in the [`mount`(2)](../man2/mount.md) syscall (if not specified,
+meaning as in the [`mount`(2)](help://man/2/mount) syscall (if not specified,
 fstype defaults to `ext2`).
 
 A special source value "none" is recognized, in which case
-[`mount`(8)](mount.md) will not attempt to open the source as a file, and will
-pass an invalid file descriptor to [`mount`(2)](../man2/mount.md). This is
+[`mount`(8)](help://man/8/mount) will not attempt to open the source as a file, and will
+pass an invalid file descriptor to [`mount`(2)](help://man/2/mount). This is
 useful for mounting  pseudo filesystems.
 
 Options correspond to the mount flags, and should be specified as a
@@ -47,4 +47,4 @@ Additionally, the name `defaults` is accepted and ignored.
 
 ## See also
 
-* [`mount`(2)](../man2/mount.md)
+* [`mount`(2)](help://man/2/mount)

--- a/Base/usr/share/man/man8/umount.md
+++ b/Base/usr/share/man/man8/umount.md
@@ -23,4 +23,4 @@ $ umount <mountpoint>
 
 ## See also
 
-* [`mount`(8)](../man8/mount.md)
+* [`mount`(8)](help://man/8/mount)

--- a/Base/usr/share/man/man8/userdel.md
+++ b/Base/usr/share/man/man8/userdel.md
@@ -40,4 +40,4 @@ This program must be run as root.
 
 ## See Also
 
-* [`useradd`(8)](useradd.md)
+* [`useradd`(8)](help://man/8/useradd)

--- a/Meta/Websites/man.serenityos.org/cant-run-application.md
+++ b/Meta/Websites/man.serenityos.org/cant-run-application.md
@@ -1,0 +1,5 @@
+# Sorry :^(
+
+This is a link to open the application directly, but that only works in SerenityOS.
+
+[Go back to main page](index.html)

--- a/Meta/build-manpages-website.sh
+++ b/Meta/build-manpages-website.sh
@@ -97,6 +97,11 @@ pandoc -f gfm -t html5 -s \
     --metadata title="SerenityOS man pages" \
     -o output/index.html \
     Meta/Websites/man.serenityos.org/index.md
+pandoc -f gfm -t html5 -s \
+    -B Meta/Websites/man.serenityos.org/banner-preamble.inc \
+    --metadata title="Can't run applications" \
+    -o output/cant-run-application.html \
+    Meta/Websites/man.serenityos.org/cant-run-application.md
 
 # Copy pre-made files
 cp Meta/Websites/man.serenityos.org/banner.png output/

--- a/Meta/convert-markdown-links.lua
+++ b/Meta/convert-markdown-links.lua
@@ -1,4 +1,5 @@
 function Link(el)
-    el.target = string.gsub(el.target, "%.md", ".html") -- change .md to .html links
+    el.target = string.gsub(el.target, "file:///bin/.*", "../cant-run-application.html")
+    el.target = string.gsub(el.target, "help://man/([^/]*)/(.*)", "../man%1/%2.html")
     return el
 end

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -243,6 +243,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
             history.push(path);
             open_page(path);
+        } else if (url.protocol() == "help") {
+            if (url.host() == "man") {
+                if (url.paths().size() != 2) {
+                    dbgln("Bad help page URL '{}'", url);
+                    return;
+                }
+                auto const section = url.paths()[0];
+                auto const page = url.paths()[1];
+                open_url(URL::create_with_file_scheme(String::formatted("/usr/share/man/man{}/{}.md", section, page), url.fragment()));
+            } else {
+                dbgln("Bad help operation '{}' in URL '{}'", url.host(), url);
+            }
         } else {
             open_external(url);
         }

--- a/Userland/Utilities/markdown-check.cpp
+++ b/Userland/Utilities/markdown-check.cpp
@@ -47,6 +47,7 @@ static bool is_missing_file_acceptable(String const& filename)
         "/man6/index.html",
         "/man7/index.html",
         "/man8/index.html",
+        "index.html",
     };
     for (auto const& suffix : acceptable_missing_files) {
         if (filename.ends_with(suffix))


### PR DESCRIPTION
The main goal of this PR is to improve all kinds of linking from and in between help pages in Help. Some benefits trickle down to man but it's mostly unchanged.

First, the external link handling is improved in Help so that we can introduce direct links to the applications. Second, the new special help:// URL man improve the linking between man pages. This also requires adopting the link translation for the man page website.

# Help: Directly launch an app from its help page
Through links in the help page, the user can directly launch the app whose help page is currently viewed. The idea for this feature came up in the discussion of #11557. The intention is that the user can simply open the app they are currently trying to understand, and play around with it, learn by doing, or follow along with any guide that may be present in the help page. It
feels very great :^)

# Help: Add help://man URLs for links between man pages 
The URLs of the form `help://man/<section>/<page>` link to another help page inside the help application. All previous relative page links are replaced by this new form. This doesn't change any behavior but it looks much nicer :^)

Note that man doesn't handle these new links, but the previous relative links didn't work either.

Re: @linusg @bugreport0 @electrikmilk