### PR TITLE
Make "Meta/serenity.sh run aarch64" work on macOS

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -30,9 +30,13 @@ fi
 
 # To support virtualization acceleration on mac
 # we need to use 64-bit qemu
-if [ "$(uname)" = "Darwin" ] && [ "$(uname -m)" = "x86_64" ]; then
+if [ "$(uname)" = "Darwin" ]; then
 
-    [ -z "$SERENITY_QEMU_BIN" ] && SERENITY_QEMU_BIN="qemu-system-x86_64"
+    if [ "$SERENITY_ARCH" != "aarch64" ]; then
+        [ -z "$SERENITY_QEMU_BIN" ] && SERENITY_QEMU_BIN="qemu-system-x86_64"
+    else
+        [ -z "$SERENITY_QEMU_BIN" ] && SERENITY_QEMU_BIN="qemu-system-aarch64"
+    fi
 
     if $SERENITY_QEMU_BIN --accel help | grep -q hvf; then
         SERENITY_VIRT_TECH_ARG="--accel hvf"
@@ -212,7 +216,7 @@ fi
 
 if [ -z "$SERENITY_MACHINE" ]; then
     if [ "$SERENITY_ARCH" = "aarch64" ]; then
-        SERENITY_MACHINE="-M raspi3 -serial stdio"
+        SERENITY_MACHINE="-M raspi3b -serial stdio"
     else
         SERENITY_MACHINE="
         -m $SERENITY_RAM_SIZE


### PR DESCRIPTION
There was code to use qemu-system-x86_64 on Darwin-based OSes (macOS) but when running aarch64 SerenityOS we need to use qemu-system-aarch64 instead.
There was also code to use a machine named "raspi3" but that doesn't exist in home-brew's qemu.  raspi3b does though.  To not affect anyone else's flow, I left the value as it was for non-Darwin-based OSes, but if it works for everyone we could change it everywhere and simplify this script.