### PR TITLE
Kernel: Use the DMA helper everywhere

### DIFF
--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -20,13 +20,6 @@ static constexpr u16 pcm_fixed_sample_rate = 48000;
 static constexpr u16 pcm_sample_rate_minimum = 8000;
 static constexpr u16 pcm_sample_rate_maximum = 48000;
 
-static ErrorOr<OwnPtr<Memory::Region>> allocate_physical_buffer(size_t size, StringView name)
-{
-    auto rounded_size = TRY(Memory::page_round_up(size));
-    auto vmobject = TRY(Memory::AnonymousVMObject::try_create_physically_contiguous_with_size(rounded_size));
-    return TRY(MM.allocate_kernel_region_with_vmobject(move(vmobject), vmobject->size(), name, Memory::Region::Access::Write));
-}
-
 UNMAP_AFTER_INIT void AC97::detect()
 {
     PCI::enumerate([&](PCI::DeviceIdentifier const& device_identifier) {
@@ -204,11 +197,11 @@ void AC97::set_pcm_output_volume(u8 left_channel, u8 right_channel, Muted mute)
 ErrorOr<size_t> AC97::write(OpenFileDescription&, u64, UserOrKernelBuffer const& data, size_t length)
 {
     if (!m_output_buffer) {
-        m_output_buffer = TRY(allocate_physical_buffer(m_output_buffer_page_count * PAGE_SIZE, "AC97 Output buffer"sv));
+        m_output_buffer = TRY(MM.allocate_dma_buffer_pages(m_output_buffer_page_count * PAGE_SIZE, "AC97 Output buffer"sv, Memory::Region::Access::Write));
     }
     if (!m_buffer_descriptor_list) {
         constexpr size_t buffer_descriptor_list_size = buffer_descriptor_list_max_entries * sizeof(BufferDescriptorListEntry);
-        m_buffer_descriptor_list = TRY(allocate_physical_buffer(buffer_descriptor_list_size, "AC97 Buffer Descriptor List"sv));
+        m_buffer_descriptor_list = TRY(MM.allocate_dma_buffer_pages(buffer_descriptor_list_size, "AC97 Buffer Descriptor List"sv, Memory::Region::Access::Write));
     }
 
     auto remaining = length;

--- a/Kernel/Devices/Audio/SB16.cpp
+++ b/Kernel/Devices/Audio/SB16.cpp
@@ -252,12 +252,7 @@ void SB16::wait_for_irq()
 ErrorOr<size_t> SB16::write(OpenFileDescription&, u64, UserOrKernelBuffer const& data, size_t length)
 {
     if (!m_dma_region) {
-        auto page = MM.allocate_supervisor_physical_page();
-        if (!page)
-            return ENOMEM;
-        auto nonnull_page = page.release_nonnull();
-        auto vmobject = TRY(Memory::AnonymousVMObject::try_create_with_physical_pages({ &nonnull_page, 1 }));
-        m_dma_region = TRY(MM.allocate_kernel_region_with_vmobject(move(vmobject), PAGE_SIZE, "SB16 DMA buffer", Memory::Region::Access::Write));
+        m_dma_region = TRY(MM.allocate_dma_buffer_page("SB16 DMA buffer", Memory::Region::Access::Write));
     }
 
     dbgln_if(SB16_DEBUG, "SB16: Writing buffer of {} bytes", length);

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -753,6 +753,13 @@ ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_page(S
     return region_or_error;
 }
 
+ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_page(StringView name, Memory::Region::Access access)
+{
+    RefPtr<Memory::PhysicalPage> dma_buffer_page;
+
+    return allocate_dma_buffer_page(name, access, dma_buffer_page);
+}
+
 ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_pages(size_t size, StringView name, Memory::Region::Access access, NonnullRefPtrVector<Memory::PhysicalPage>& dma_buffer_pages)
 {
     VERIFY(!(size % PAGE_SIZE));
@@ -762,6 +769,14 @@ ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_pages(
     // Do not enable Cache for this region as physical memory transfers are performed (Most architectures have this behaviour by default)
     auto region_or_error = allocate_kernel_region(dma_buffer_pages.first().paddr(), size, name, access, Region::Cacheable::No);
     return region_or_error;
+}
+
+ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_pages(size_t size, StringView name, Memory::Region::Access access)
+{
+    VERIFY(!(size % PAGE_SIZE));
+    NonnullRefPtrVector<Memory::PhysicalPage> dma_buffer_pages;
+
+    return allocate_dma_buffer_pages(size, name, access, dma_buffer_pages);
 }
 
 ErrorOr<NonnullOwnPtr<Region>> MemoryManager::allocate_kernel_region(size_t size, StringView name, Region::Access access, AllocationStrategy strategy, Region::Cacheable cacheable)

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -748,7 +748,8 @@ ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_page(S
     dma_buffer_page = allocate_supervisor_physical_page();
     if (dma_buffer_page.is_null())
         return ENOMEM;
-    auto region_or_error = allocate_kernel_region(dma_buffer_page->paddr(), PAGE_SIZE, name, access);
+    // Do not enable Cache for this region as physical memory transfers are performed (Most architectures have this behaviour by default)
+    auto region_or_error = allocate_kernel_region(dma_buffer_page->paddr(), PAGE_SIZE, name, access, Region::Cacheable::No);
     return region_or_error;
 }
 
@@ -758,7 +759,8 @@ ErrorOr<NonnullOwnPtr<Memory::Region>> MemoryManager::allocate_dma_buffer_pages(
     dma_buffer_pages = allocate_contiguous_supervisor_physical_pages(size);
     if (dma_buffer_pages.is_empty())
         return ENOMEM;
-    auto region_or_error = allocate_kernel_region(dma_buffer_pages.first().paddr(), size, name, access);
+    // Do not enable Cache for this region as physical memory transfers are performed (Most architectures have this behaviour by default)
+    auto region_or_error = allocate_kernel_region(dma_buffer_pages.first().paddr(), size, name, access, Region::Cacheable::No);
     return region_or_error;
 }
 

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -176,7 +176,9 @@ public:
 
     ErrorOr<NonnullOwnPtr<Region>> allocate_contiguous_kernel_region(size_t, StringView name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
     ErrorOr<NonnullOwnPtr<Memory::Region>> allocate_dma_buffer_page(StringView name, Memory::Region::Access access, RefPtr<Memory::PhysicalPage>& dma_buffer_page);
+    ErrorOr<NonnullOwnPtr<Memory::Region>> allocate_dma_buffer_page(StringView name, Memory::Region::Access access);
     ErrorOr<NonnullOwnPtr<Memory::Region>> allocate_dma_buffer_pages(size_t size, StringView name, Memory::Region::Access access, NonnullRefPtrVector<Memory::PhysicalPage>& dma_buffer_pages);
+    ErrorOr<NonnullOwnPtr<Memory::Region>> allocate_dma_buffer_pages(size_t size, StringView name, Memory::Region::Access access);
     ErrorOr<NonnullOwnPtr<Region>> allocate_kernel_region(size_t, StringView name, Region::Access access, AllocationStrategy strategy = AllocationStrategy::Reserve, Region::Cacheable = Region::Cacheable::Yes);
     ErrorOr<NonnullOwnPtr<Region>> allocate_kernel_region(PhysicalAddress, size_t, StringView name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);
     ErrorOr<NonnullOwnPtr<Region>> allocate_kernel_region_with_vmobject(VMObject&, size_t, StringView name, Region::Access access, Region::Cacheable = Region::Cacheable::Yes);

--- a/Kernel/Storage/ATA/BMIDEChannel.cpp
+++ b/Kernel/Storage/ATA/BMIDEChannel.cpp
@@ -40,18 +40,14 @@ UNMAP_AFTER_INIT void BMIDEChannel::initialize()
     VERIFY(m_io_group.bus_master_base().has_value());
     // Let's try to set up DMA transfers.
     PCI::enable_bus_mastering(m_parent_controller->pci_address());
-    m_prdt_page = MM.allocate_supervisor_physical_page();
-    m_dma_buffer_page = MM.allocate_supervisor_physical_page();
-    if (m_dma_buffer_page.is_null() || m_prdt_page.is_null())
-        return;
     {
-        auto region_or_error = MM.allocate_kernel_region(m_prdt_page->paddr(), PAGE_SIZE, "IDE PRDT", Memory::Region::Access::ReadWrite);
+        auto region_or_error = MM.allocate_dma_buffer_page("IDE PRDT", Memory::Region::Access::ReadWrite, m_prdt_page);
         if (region_or_error.is_error())
             TODO();
         m_prdt_region = region_or_error.release_value();
     }
     {
-        auto region_or_error = MM.allocate_kernel_region(m_dma_buffer_page->paddr(), PAGE_SIZE, "IDE DMA region", Memory::Region::Access::ReadWrite);
+        auto region_or_error = MM.allocate_dma_buffer_page("IDE DMA region", Memory::Region::Access::ReadWrite, m_dma_buffer_page);
         if (region_or_error.is_error())
             TODO();
         m_dma_buffer_region = region_or_error.release_value();


### PR DESCRIPTION
Use the DMA helper in SB16, BMIDE and AHCIPort.

When I did a quick grep on `allocate_supervisor_physical_page`, I could find only these drivers that were using DMA. Is there any other driver that I am missing here which uses DMA? 