### PR TITLE
Meta+CI+Documentation: Bump host gcc requirement up to gcc 11

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -39,15 +39,17 @@ jobs:
       # sudo apt-get update -qq
       - name: "Install Ubuntu dependencies"
         # These packages are already part of the ubuntu-20.04 image:
-        # cmake clang-format-11 gcc-10 g++-10 libstdc++-10-dev libgmp-dev npm shellcheck
+        # cmake clang-format-11 libgmp-dev npm shellcheck
         # Packages below aren't.
         #
         # We add the canonical-server/server-backports PPA to get updated QEMU releases without having to manage
         #    yet another cache in github actions
+        # We add the ubuntu-toolchain-r/test PPA to get gcc-11 on 20.04
         run: |
           sudo add-apt-repository ppa:canonical-server/server-backports
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 ccache unzip
+          sudo apt-get install ccache e2fsprogs gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build qemu-utils qemu-system-i386 unzip
       - name: Install JS dependencies
         run: sudo npm install -g prettier@2.4.1
       - name: Install Python dependencies
@@ -56,7 +58,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 requests
       - name: Check versions
-        run: set +e; g++ --version; g++-10 --version; clang-format --version; clang-format-11 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version; ccache --version; qemu-system-i386 --version
+        run: set +e; g++ --version; g++-11 --version; clang-format --version; clang-format-11 --version; prettier --version; python --version; python3 --version; ninja --version; flake8 --version; ccache --version; qemu-system-i386 --version
 
       # === PREPARE FOR BUILDING ===
 
@@ -140,8 +142,8 @@ jobs:
             -DSERENITY_ARCH=${{ matrix.arch }} \
             -DSERENITY_TOOLCHAIN=GNU \
             -DBUILD_LAGOM=ON \
-            -DCMAKE_C_COMPILER=gcc-10 \
-            -DCMAKE_CXX_COMPILER=g++-10 \
+            -DCMAKE_C_COMPILER=gcc-11 \
+            -DCMAKE_CXX_COMPILER=g++-11 \
             -DENABLE_ALL_DEBUG_FACILITIES=ON \
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF
@@ -155,8 +157,8 @@ jobs:
             -DENABLE_COMPILETIME_HEADER_CHECK=ON \
             -DSERENITY_ARCH=${{ matrix.arch }} \
             -DSERENITY_TOOLCHAIN=GNU \
-            -DCMAKE_C_COMPILER=gcc-10 \
-            -DCMAKE_CXX_COMPILER=g++-10 \
+            -DCMAKE_C_COMPILER=gcc-11 \
+            -DCMAKE_CXX_COMPILER=g++-11 \
             -DENABLE_UNDEFINED_SANITIZER=ON \
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -47,8 +47,9 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build unzip
+          sudo apt-get install ninja-build unzip gcc-11 g++-11
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -85,7 +86,7 @@ jobs:
         working-directory: libjs-test262
         run: |
           cd Build
-          cmake -GNinja -DCMAKE_C_COMPILER=gcc-10 -DCMAKE_CXX_COMPILER=g++-10 -DSERENITY_SOURCE_DIR=${{ env.SERENITY_SOURCE_DIR }} ..
+          cmake -GNinja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSERENITY_SOURCE_DIR=${{ env.SERENITY_SOURCE_DIR }} ..
           ninja libjs-test262-runner test-js
 
       - name: Run test262 and test262-parser-tests

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -21,15 +21,16 @@ jobs:
 
       - name: "Install Ubuntu dependencies"
         # These packages are already part of the ubuntu-20.04 image:
-        # cmake clang-format-11 gcc-10 g++-10 libstdc++-10-dev libgmp-dev npm shellcheck
+        # cmake clang-format-11 libgmp-dev npm shellcheck
         # Packages below aren't.
         #
         run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install libmpfr-dev libmpc-dev ninja-build unzip pvs-studio
+          sudo apt-get install gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build unzip pvs-studio
 
       - name: Check versions
-        run: set +e; g++ --version; g++-10 --version; ninja --version;
+        run: set +e; g++ --version; g++-11 --version; ninja --version;
 
       - name: Prepare useful stamps
         id: stamps
@@ -71,8 +72,8 @@ jobs:
           cmake -S Meta/CMake/Superbuild -B Build/superbuild -GNinja \
             -DSERENITY_ARCH=${{ env.PVS_STUDIO_ANALYSIS_ARCH }} \
             -DSERENITY_TOOLCHAIN=GNU \
-            -DCMAKE_C_COMPILER=gcc-10 \
-            -DCMAKE_CXX_COMPILER=g++-10 \
+            -DCMAKE_C_COMPILER=gcc-11 \
+            -DCMAKE_CXX_COMPILER=g++-11 \
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF
 

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -55,18 +55,15 @@ jobs:
 
       - name: "Install Ubuntu dependencies"
         # These packages are already part of the ubuntu-20.04 image:
-        # cmake clang-format-11 gcc-10 g++-10 libstdc++-10-dev libgmp-dev npm shellcheck
+        # cmake clang-format-11 libgmp-dev npm shellcheck
         # Packages below aren't.
-        #
-        # We add the canonical-server/server-backports PPA to get updated QEMU releases without having to manage
-        #    yet another cache in github actions
         run: |
-          sudo add-apt-repository ppa:canonical-server/server-backports
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install libmpfr-dev libmpc-dev ninja-build unzip
+          sudo apt-get install gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build unzip
 
       - name: Check versions
-        run: set +e; g++ --version; g++-10 --version; ninja --version;
+        run: set +e; g++ --version; g++-11 --version; ninja --version;
 
       - name: Prepare useful stamps
         id: stamps
@@ -108,8 +105,8 @@ jobs:
           cmake -S Meta/CMake/Superbuild -B Build/superbuild -GNinja \
             -DSERENITY_ARCH=${{ env.SONAR_ANALYSIS_ARCH }} \
             -DSERENITY_TOOLCHAIN=GNU \
-            -DCMAKE_C_COMPILER=gcc-10 \
-            -DCMAKE_CXX_COMPILER=g++-10 \
+            -DCMAKE_C_COMPILER=gcc-11 \
+            -DCMAKE_CXX_COMPILER=g++-11 \
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF
 

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -10,18 +10,18 @@ Make sure you have all the dependencies installed:
 sudo apt install build-essential cmake curl libmpfr-dev libmpc-dev libgmp-dev e2fsprogs ninja-build qemu-system-gui qemu-system-x86 qemu-utils ccache rsync unzip texinfo
 ```
 
-#### GCC 10
+#### GCC 11
 
-On Ubuntu gcc-10 is available in the repositories of 20.04 (Focal) and later - add the `ubuntu-toolchain-r/test` PPA if you're running an older version:
+On Ubuntu gcc-11 is available in the repositories of 21.04 (Hirsuite) and later - add the `ubuntu-toolchain-r/test` PPA if you're running an older version:
 
 ```console
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 ```
 
-Now on Ubuntu or Debian you can install gcc-10 with apt like this:
+Now on Ubuntu or Debian you can install gcc-11 with apt like this:
 
 ```console
-sudo apt install gcc-10 g++-10
+sudo apt install gcc-11 g++-11
 ```
 
 #### QEMU 5 or later

--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -36,7 +36,7 @@ with import <nixpkgs> {};
 stdenv.mkDerivation {
   name = "cpp-env";
   nativeBuildInputs = [
-    gcc10
+    gcc11
     curl
     cmake
     mpfr

--- a/Documentation/SelfHostedRunners.md
+++ b/Documentation/SelfHostedRunners.md
@@ -19,12 +19,13 @@ These instructions assume the OS installed is Ubuntu 20.04 (Focal), so they migh
 ### Install base dependencies
 ```shell
 add-apt-repository ppa:canonical-server/server-backports
+add-apt-repository ppa:ubuntu-toolchain-r/test
 apt update
-apt install git build-essential make cmake clang-format-11 gcc-10 g++-10 libstdc++-10-dev libgmp-dev ccache libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 wabt
+apt install git build-essential make cmake clang-format-11 gcc-11 g++-11 libstdc++-11-dev libgmp-dev ccache libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 wabt
 ```
-### Force usage of GCC 10
+### Force usage of GCC 11
 ```shell
-update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 100 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100 --slave /usr/bin/g++ g++ /usr/bin/g++-11
 ```
 ### Create a new user account named 'runner'
 ```shell

--- a/Documentation/Troubleshooting.md
+++ b/Documentation/Troubleshooting.md
@@ -16,7 +16,7 @@ install it. You can also build it using the `Toolchain/BuildQemu.sh` script.
 
 ### GCC is missing or is outdated
 
-Ensure your gcc version is >= 10 with `gcc --version`. Otherwise, install it. If your gcc binary is not
+Ensure your gcc version is >= 11 with `gcc --version`. Otherwise, install it. If your gcc binary is not
 called `gcc` you have to specify the names of your C and C++ compiler when you run cmake, e.g.
 `cmake ../.. -GNinja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11`.
 

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -15,7 +15,7 @@ jobs:
       ${{ if eq(parameters.os, 'Linux') }}:
         value: ubuntu-20.04
       ${{ if eq(parameters.os, 'macOS') }}:
-        value: macos-10.15
+        value: macos-11
 
     - name: toolchain
       ${{ if eq(parameters.fuzzer, 'Fuzz') }}:
@@ -74,8 +74,8 @@ jobs:
             -DENABLE_ADDRESS_SANITIZER=ON \
             -DENABLE_PCI_IDS_DOWNLOAD=OFF \
             -DENABLE_USB_IDS_DOWNLOAD=OFF \
-            -DCMAKE_C_COMPILER=gcc-10 \
-            -DCMAKE_CXX_COMPILER=g++-10 \
+            -DCMAKE_C_COMPILER=gcc-11 \
+            -DCMAKE_CXX_COMPILER=g++-11 \
             ..
         displayName: 'Create Build Environment'
         workingDirectory: $(Build.SourcesDirectory)/Meta/Lagom/Build

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -40,8 +40,8 @@ jobs:
           -DENABLE_UNDEFINED_SANITIZER=ON \
           -DENABLE_PCI_IDS_DOWNLOAD=OFF \
           -DENABLE_USB_IDS_DOWNLOAD=OFF \
-          -DCMAKE_C_COMPILER=gcc-10 \
-          -DCMAKE_CXX_COMPILER=g++-10
+          -DCMAKE_C_COMPILER=gcc-11 \
+          -DCMAKE_CXX_COMPILER=g++-11
       displayName: 'Create Build Environment'
       workingDirectory: $(Build.SourcesDirectory)
       env:

--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -8,18 +8,22 @@ steps:
   - ${{ if eq(parameters.os, 'Serenity') }}:
     - script: |
         sudo add-apt-repository ppa:canonical-server/server-backports
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
-        sudo apt-get install libmpfr-dev libmpc-dev ninja-build e2fsprogs qemu-utils qemu-system-i386 ccache unzip
+        sudo apt-get install ccache e2fsprogs gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build qemu-utils qemu-system-i386 unzip
       displayName: 'Install Dependencies'
 
   - ${{ if eq(parameters.os, 'Linux') }}:
     - script: |
-        sudo apt-get purge -y clang-11
+        sudo apt-get purge -y clang-11 gcc-10
+        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
-        sudo apt-get install ninja-build ccache unzip
+        sudo apt-get install ccache gcc-11 g++-11 libstdc++-11-dev ninja-build unzip
 
         sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100
         sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100
+        sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
 
         wget https://github.com/WebAssembly/wabt/releases/download/1.0.23/wabt-1.0.23-ubuntu.tar.gz
         tar -xzf ./wabt-1.0.23-ubuntu.tar.gz

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -8,9 +8,9 @@ project(
     LANGUAGES C CXX
 )
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "10.2")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "11")
   message(FATAL_ERROR
-      "A GCC version less than 10.2 was detected (${CMAKE_CXX_COMPILER_VERSION}), this is unsupported.\n"
+      "A GCC version less than 11 was detected (${CMAKE_CXX_COMPILER_VERSION}), this is unsupported.\n"
       "Please re-read the build instructions documentation, and upgrade your host compiler.\n")
 endif()
 

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -144,7 +144,7 @@ create_build_dir() {
 pick_gcc() {
     local BEST_VERSION=0
     local BEST_GCC_CANDIDATE=""
-    for GCC_CANDIDATE in egcc gcc gcc-10 gcc-11 gcc-12 /usr/local/bin/gcc-11 /opt/homebrew/bin/gcc-11; do
+    for GCC_CANDIDATE in egcc gcc gcc-11 gcc-12 /usr/local/bin/gcc-11 /opt/homebrew/bin/gcc-11; do
         if ! command -v $GCC_CANDIDATE >/dev/null 2>&1; then
             continue
         fi
@@ -164,8 +164,8 @@ pick_gcc() {
     done
     CMAKE_ARGS+=("-DCMAKE_C_COMPILER=$BEST_GCC_CANDIDATE")
     CMAKE_ARGS+=("-DCMAKE_CXX_COMPILER=${BEST_GCC_CANDIDATE/gcc/g++}")
-    if [ "$BEST_VERSION" -lt 10 ]; then
-        die "Please make sure that GCC version 10.2 or higher is installed."
+    if [ "$BEST_VERSION" -lt 11 ]; then
+        die "Please make sure that GCC version 11 or higher is installed."
     fi
 }
 

--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -553,10 +553,10 @@ void Editor::edit_in_external_editor()
     };
 
     Vector<const char*> args { editor_command, file_path, nullptr };
-    auto pid = vfork();
+    auto pid = fork();
 
     if (pid == -1) {
-        perror("vfork");
+        perror("fork");
         return;
     }
 


### PR DESCRIPTION
Bump macOS CI version to macOS 11 while we're here.

The time has come. 

We updated the Serenity GNU toolchain to gcc 11 back in April 2021, when 11.0.0 was first released. There's some neat features enabled in gcc 11 that we could be taking advantage of, and it's not like Canonical will be adding gcc-11 to 20.04 LTS, that ship has sailed. So, bite the bullet and use the ubuntu-toolchain-r/test PPA for ubuntu 20.04, and rely on the Microsoft virtual environment pre-installing gcc-11 from homebrew on macOS.