### PR TITLE
CI: Don't let APT ask for confirmation on package installation

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,7 +49,7 @@ jobs:
           sudo add-apt-repository ppa:canonical-server/server-backports
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ccache e2fsprogs gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build qemu-utils qemu-system-i386 unzip
+          sudo apt-get install -y ccache e2fsprogs gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build qemu-utils qemu-system-i386 unzip
       - name: Install JS dependencies
         run: sudo npm install -g prettier@2.4.1
       - name: Install Python dependencies

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install ninja-build unzip gcc-11 g++-11
+          sudo apt-get install -y ninja-build unzip gcc-11 g++-11
 
       - name: Setup Python
         uses: actions/setup-python@v2

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build unzip pvs-studio
+          sudo apt-get install -y gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build unzip pvs-studio
 
       - name: Check versions
         run: set +e; g++ --version; g++-11 --version; ninja --version;

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build unzip
+          sudo apt-get install -y gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build unzip
 
       - name: Check versions
         run: set +e; g++ --version; g++-11 --version; ninja --version;


### PR DESCRIPTION
APT tries to ask for confirmation even if its in non-interactive mode, which makes the installation abort immediately if there are  any actual changes.