### PR TITLE
Kernel/Memory: Remove needless VERIFY in /dev/mem mmap validation method

### DIFF
--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -211,7 +211,6 @@ UNMAP_AFTER_INIT void MemoryManager::register_reserved_ranges()
 
 bool MemoryManager::is_allowed_to_mmap_to_userspace(PhysicalAddress start_address, VirtualRange const& range) const
 {
-    VERIFY(!m_reserved_memory_ranges.is_empty());
     // Note: Guard against overflow in case someone tries to mmap on the edge of
     // the RAM
     if (start_address.offset_addition_would_overflow(range.size()))


### PR DESCRIPTION
As it was pointed by @IdanHo, the rest of the method doesn't assume we
have any reserved ranges to allow mmap(2) to work on them, so the VERIFY
is not needed at all.