### PR TITLE
KeyboardMapper: Add support for dynamic keyboard visualization

### DIFF
--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -199,6 +199,10 @@ void KeyboardMapperWidget::keydown_event(GUI::KeyEvent& event)
         tmp_button->update();
         break;
     }
+
+    if (m_automatic_modifier && event.modifiers() > 0) {
+        update_modifier_radio_buttons(event);
+    }
 }
 
 void KeyboardMapperWidget::keyup_event(GUI::KeyEvent& event)
@@ -210,6 +214,10 @@ void KeyboardMapperWidget::keyup_event(GUI::KeyEvent& event)
         tmp_button->set_pressed(false);
         tmp_button->update();
         break;
+    }
+
+    if (m_automatic_modifier) {
+        update_modifier_radio_buttons(event);
     }
 }
 
@@ -246,4 +254,28 @@ void KeyboardMapperWidget::update_window_title()
 void KeyboardMapperWidget::show_error_to_user(Error error)
 {
     GUI::MessageBox::show_error(window(), error.string_literal());
+}
+
+void KeyboardMapperWidget::set_automatic_modifier(bool checked)
+{
+    m_automatic_modifier = checked;
+}
+
+void KeyboardMapperWidget::update_modifier_radio_buttons(GUI::KeyEvent& event)
+{
+    GUI::RadioButton* radio_button;
+    if (event.shift() && event.altgr()) {
+        radio_button = m_map_group->find_child_of_type_named<GUI::RadioButton>("shift_altgr_map");
+    } else if (event.altgr()) {
+        radio_button = m_map_group->find_child_of_type_named<GUI::RadioButton>("altgr_map");
+    } else if (event.alt()) {
+        radio_button = m_map_group->find_child_of_type_named<GUI::RadioButton>("alt_map");
+    } else if (event.shift()) {
+        radio_button = m_map_group->find_child_of_type_named<GUI::RadioButton>("shift_map");
+    } else {
+        radio_button = m_map_group->find_child_of_type_named<GUI::RadioButton>("map");
+    }
+
+    if (radio_button)
+        radio_button->set_checked(true);
 }

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.h
@@ -22,6 +22,7 @@ public:
     ErrorOr<void> save();
     ErrorOr<void> save_to_file(StringView);
     void show_error_to_user(Error);
+    void set_automatic_modifier(bool checked);
 
 protected:
     virtual void keydown_event(GUI::KeyEvent&) override;
@@ -37,9 +38,11 @@ private:
     RefPtr<GUI::Widget> m_map_group;
     void add_map_radio_button(const StringView map_name, const StringView button_text);
     u32* map_from_name(const StringView map_name);
+    void update_modifier_radio_buttons(GUI::KeyEvent&);
 
     String m_filename;
     Keyboard::CharacterMapData m_character_map;
     String m_current_map_name;
     bool m_modified { false };
+    bool m_automatic_modifier { false };
 };

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -80,12 +80,22 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             app->quit();
         });
 
+    auto auto_modifier_action = GUI::Action::create("Auto Modifier", [&](auto& act) {
+        keyboard_mapper_widget->set_automatic_modifier(act.is_checked());
+    });
+    auto_modifier_action->set_status_tip("Toggle automatic modifier");
+    auto_modifier_action->set_checkable(true);
+    auto_modifier_action->set_checked(false);
+
     auto& file_menu = window->add_menu("&File");
     file_menu.add_action(open_action);
     file_menu.add_action(save_action);
     file_menu.add_action(save_as_action);
     file_menu.add_separator();
     file_menu.add_action(quit_action);
+
+    auto& settings_menu = window->add_menu("&Settings");
+    settings_menu.add_action(auto_modifier_action);
 
     auto& help_menu = window->add_menu("&Help");
     help_menu.add_action(GUI::CommonActions::make_about_action("Keyboard Mapper", app_icon, window));

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -332,6 +332,7 @@ public:
     KeyCode key() const { return m_key; }
     bool ctrl() const { return m_modifiers & Mod_Ctrl; }
     bool alt() const { return m_modifiers & Mod_Alt; }
+    bool altgr() const { return m_modifiers & Mod_AltGr; }
     bool shift() const { return m_modifiers & Mod_Shift; }
     bool super() const { return m_modifiers & Mod_Super; }
     u8 modifiers() const { return m_modifiers; }


### PR DESCRIPTION
This PR adds support for dynamically changing the keyboard visualization based on the modifier key that is held down. It is default off and can be activated by checking the `Auto Modifier` menu item in the brand new `Settings` menu.