### PR TITLE
CI: Extract toolchain ccache in the Serenity build stage

### DIFF
--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -6,6 +6,10 @@ jobs:
     timeoutInMinutes: 0 # Setting to 0 means the maximum allowed timeout is used.
 
     variables:
+    - name: LLVM_CCACHE_DIR
+      value: $(Build.SourcesDirectory)/Toolchain/.ccache
+    - name: LLVM_CCACHE_MAXSIZE
+      value: 20GB
     - name: SERENITY_CCACHE_DIR
       value: $(Build.SourcesDirectory)/.ccache
 
@@ -22,9 +26,11 @@ jobs:
         arch: '${{ parameters.arch }}'
         toolchain: 'clang'
         build_directory: 'Build/${{ parameters.arch }}clang'
+        toolchain_ccache_path: '$(LLVM_CCACHE_DIR)'
+        toolchain_ccache_size: '$(LLVM_CCACHE_MAXSIZE)'
         serenity_ccache_path: '$(SERENITY_CCACHE_DIR)'
 
-    - script: ./Toolchain/BuildClang.sh
+    - script: ./Toolchain/BuildClang.sh --ci
       displayName: Extract Toolchain
       env:
         TRY_USE_LOCAL_TOOLCHAIN: 'y'


### PR DESCRIPTION
The toolchain is built in a previous stage, but once the Serenity stage
has begun, we have to re-pull the toolchain from the Azure cache. There
is a timing window where a cache-busting change can be commited between
these steps; to alleviate the affect this has, pull the toolchain ccache
so that the build only takes a few minutes instead of a couple hours.