### PR TITLE
Ports: Fix dynamic load of libmodplug by SDL2_mixer

### DIFF
--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -7,12 +7,17 @@ auth_type=sha256
 depends=("libmodplug" "libvorbis" "SDL2")
 
 configure() {
+    export LIBS="-L${SERENITY_INSTALL_ROOT}/usr/local/lib"
     run ./configure \
         --host="${SERENITY_ARCH}-pc-serenity" \
         --with-sdl-prefix="${SERENITY_INSTALL_ROOT}/usr/local" \
         --enable-music-opus=false \
         --enable-music-opus-shared=false \
         EXTRA_LDFLAGS="-lgui -lgfx -lipc -lcore -lcompression"
+}
+
+post_configure() {
+    unset LIBS
 }
 
 build() {

--- a/Ports/libmodplug/package.sh
+++ b/Ports/libmodplug/package.sh
@@ -9,6 +9,8 @@ workdir="libmodplug-$version"
 
 install() {
     run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libmodplug.so -Wl,-soname,libmodplug.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libmodplug.a -Wl,--no-whole-archive
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libmodplug.la
+    MODPLUG_LIBDIR="${SERENITY_INSTALL_ROOT}/usr/local/lib"
+    ${CC} -shared -o ${MODPLUG_LIBDIR}/libmodplug.so.1 -Wl,-soname,libmodplug.so -Wl,--whole-archive ${MODPLUG_LIBDIR}/libmodplug.a -Wl,--no-whole-archive
+    ln -rsf ${MODPLUG_LIBDIR}/libmodplug.so.1 ${MODPLUG_LIBDIR}/libmodplug.so
+    rm -f ${MODPLUG_LIBDIR}/libmodplug.la
 }

--- a/Ports/tuxracer/package.sh
+++ b/Ports/tuxracer/package.sh
@@ -20,7 +20,7 @@ launcher_command="/usr/local/bin/tuxracer"
 pre_configure() {
     export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2"
     export CXXFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/SDL2"
-    export LIBS="-lmodplug -lSDL2"
+    export LIBS="-lSDL2"
 }
 
 post_configure() {


### PR DESCRIPTION
The configure script for `SDL2_mixer` was trying to find the shared library for `libmodplug` in the wrong directories and with the wrong filename. This installs the shared library as `libmodplug.so.1` and symlinks to it from `libmodplug.so`, and instructs the `SDL2_mixer` build to search for it in `/usr/local/lib`.

Fixes the build for ports Super-Mario, freeciv and dungeonrush.

Thanks to @timschumi for finding and reporting this issue!