### PR TITLE
LibGfx: Add QOI write ability

### DIFF
--- a/AK/Array.h
+++ b/AK/Array.h
@@ -46,6 +46,9 @@ struct Array {
     [[nodiscard]] constexpr T& operator[](size_t index) { return at(index); }
 
     template<typename T2, size_t Size2>
+    [[nodiscard]] constexpr bool operator==(T2 const (&other)[Size2]) const { return span() == Span(other); }
+
+    template<typename T2, size_t Size2>
     [[nodiscard]] constexpr bool operator==(Array<T2, Size2> const& other) const { return span() == other.span(); }
 
     using ConstIterator = SimpleIterator<Array const, T const>;

--- a/AK/Array.h
+++ b/AK/Array.h
@@ -112,7 +112,15 @@ constexpr static auto iota_array(T const offset = {})
     return Detail::integer_sequence_generate_array<T>(offset, MakeIntegerSequence<T, N>());
 }
 
+template<size_t Size>
+using ByteArray = Array<u8, Size>;
+
+template<size_t Size>
+using ReadonlyByteArray = Array<const u8, Size>;
+
 }
 
 using AK::Array;
+using AK::ByteArray;
 using AK::iota_array;
+using AK::ReadonlyByteArray;

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Assertions.h>
 #include <AK/BuiltinWrappers.h>
 #include <AK/Concepts.h>
 #include <AK/StdLibExtraDetails.h>
@@ -521,5 +522,21 @@ constexpr T pow(T x, T y)
 }
 
 #undef CONSTEXPR_STATE
+
+// Check that `value` is in `[min,max]`
+template<typename T>
+constexpr bool is_in_bounds(T const& value, T const& min, T const& max)
+{
+    VERIFY(min <= max);
+    return min <= value && value <= max;
+}
+
+// Check that `value` is in `[min,max)`
+template<typename T>
+constexpr bool is_in_range(T const& value, T const& min, T const& max)
+{
+    VERIFY(min <= max);
+    return min <= value && value < max;
+}
 
 }

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -27,28 +27,6 @@ public:
     {
     }
 
-    template<size_t size>
-    ALWAYS_INLINE constexpr Span(T (&values)[size])
-        : m_values(values)
-        , m_size(size)
-    {
-    }
-
-    template<size_t size>
-    ALWAYS_INLINE constexpr Span(Array<T, size>& array)
-        : m_values(array.data())
-        , m_size(size)
-    {
-    }
-
-    template<size_t size>
-    requires(IsConst<T>)
-        ALWAYS_INLINE constexpr Span(Array<T, size> const& array)
-        : m_values(array.data())
-        , m_size(size)
-    {
-    }
-
 protected:
     T* m_values { nullptr };
     size_t m_size { 0 };
@@ -109,6 +87,25 @@ public:
     using Detail::Span<T>::Span;
 
     constexpr Span() = default;
+
+    template<size_t size>
+    ALWAYS_INLINE constexpr Span(T (&values)[size])
+        : Span(values, size)
+    {
+    }
+
+    template<size_t size>
+    ALWAYS_INLINE constexpr Span(Array<T, size>& array)
+        : Span(array.data(), size)
+    {
+    }
+
+    template<size_t size>
+    requires(IsConst<T>)
+        ALWAYS_INLINE constexpr Span(Array<T, size> const& array)
+        : Span(array.data(), size)
+    {
+    }
 
     [[nodiscard]] ALWAYS_INLINE constexpr T const* data() const { return this->m_values; }
     [[nodiscard]] ALWAYS_INLINE constexpr T* data() { return this->m_values; }
@@ -248,6 +245,9 @@ struct Traits<Span<T>> : public GenericTraits<Span<T>> {
         return hash;
     }
 };
+
+template<typename T, size_t N>
+Span(T (&array)[N]) -> Span<T>;
 
 using ReadonlyBytes = Span<u8 const>;
 using Bytes = Span<u8>;

--- a/Tests/AK/TestSpan.cpp
+++ b/Tests/AK/TestSpan.cpp
@@ -27,7 +27,7 @@ TEST_CASE(implicit_conversion_to_const)
 TEST_CASE(span_works_with_constant_types)
 {
     static constexpr u8 buffer[4] { 1, 2, 3, 4 };
-    constexpr ReadonlyBytes bytes { buffer, 4 };
+    constexpr ReadonlyBytes bytes { buffer };
 
     static_assert(IsConst<RemoveReference<decltype(bytes[1])>>);
     static_assert(bytes[2] == 3);
@@ -36,7 +36,7 @@ TEST_CASE(span_works_with_constant_types)
 TEST_CASE(span_works_with_mutable_types)
 {
     u8 buffer[4] { 1, 2, 3, 4 };
-    Bytes bytes { buffer, 4 };
+    Bytes bytes { buffer };
 
     EXPECT_EQ(bytes[2], 3);
     ++bytes[2];
@@ -50,7 +50,7 @@ TEST_CASE(iterator_behaves_like_loop)
         buffer[idx] = static_cast<u8>(idx);
     }
 
-    Bytes bytes { buffer, 256 };
+    Bytes bytes { buffer };
     size_t idx = 0;
     for (auto iter = bytes.begin(); iter < bytes.end(); ++iter) {
         EXPECT_EQ(*iter, buffer[idx]);
@@ -64,7 +64,7 @@ TEST_CASE(modifying_is_possible)
     int values_before[8] = { 1, 2, 3, 4, 5, 6, 7, 8 };
     int values_after[8] = { 7, 6, 5, 4, 3, 2, 1, 0 };
 
-    Span<int> span { values_before, 8 };
+    Span<int> span { values_before };
     for (auto& value : span) {
         value = 8 - value;
     }
@@ -81,7 +81,7 @@ TEST_CASE(at_and_index_operator_return_same_value)
         buffer[idx] = static_cast<u8>(idx);
     }
 
-    Bytes bytes { buffer, 256 };
+    Bytes bytes { buffer };
     for (int idx = 0; idx < 256; ++idx) {
         EXPECT_EQ(buffer[idx], bytes[idx]);
         EXPECT_EQ(bytes[idx], bytes.at(idx));
@@ -91,7 +91,7 @@ TEST_CASE(at_and_index_operator_return_same_value)
 TEST_CASE(can_subspan_whole_span)
 {
     static constexpr u8 buffer[16] {};
-    constexpr ReadonlyBytes bytes { buffer, 16 };
+    constexpr ReadonlyBytes bytes { buffer };
 
     constexpr auto slice = bytes.slice(0, 16);
 
@@ -103,7 +103,7 @@ TEST_CASE(can_subspan_as_intended)
 {
     static constexpr u16 buffer[8] { 1, 2, 3, 4, 5, 6, 7, 8 };
 
-    constexpr Span<const u16> span { buffer, 8 };
+    constexpr Span<const u16> span { buffer };
     constexpr auto slice = span.slice(3, 2);
 
     static_assert(slice.size() == 2u);
@@ -136,6 +136,6 @@ TEST_CASE(starts_with)
     EXPECT(!bytes.starts_with(nah_bytes));
 
     const u8 hey_array[3] = { 'H', 'e', 'y' };
-    ReadonlyBytes hey_bytes_u8 { hey_array, 3 };
+    ReadonlyBytes hey_bytes_u8 { hey_array };
     EXPECT(bytes.starts_with(hey_bytes_u8));
 }

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -19,6 +19,7 @@
 #include <LibGfx/BMPWriter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/PNGWriter.h>
+#include <LibGfx/QOIWriter.h>
 #include <LibImageDecoderClient/Client.h>
 #include <stdio.h>
 
@@ -202,6 +203,18 @@ ErrorOr<void> Image::export_png_to_file(Core::File& file, bool preserve_alpha_ch
     auto bitmap = TRY(try_compose_bitmap(bitmap_format));
 
     auto encoded_data = Gfx::PNGWriter::encode(*bitmap);
+    if (!file.write(encoded_data.data(), encoded_data.size()))
+        return Error::from_errno(file.error());
+
+    return {};
+}
+
+ErrorOr<void> Image::export_qoi_to_file(Core::File& file, bool preserve_alpha_channel)
+{
+    auto bitmap_format = preserve_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
+    auto bitmap = TRY(try_compose_bitmap(bitmap_format));
+
+    auto encoded_data = TRY(Gfx::QOIWriter::encode(*bitmap));
     if (!file.write(encoded_data.data(), encoded_data.size()))
         return Error::from_errno(file.error());
 

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -71,6 +71,7 @@ public:
     ErrorOr<void> write_to_file(String const& file_path) const;
     ErrorOr<void> export_bmp_to_file(Core::File&, bool preserve_alpha_channel);
     ErrorOr<void> export_png_to_file(Core::File&, bool preserve_alpha_channel);
+    ErrorOr<void> export_qoi_to_file(Core::File&, bool preserve_alpha_channel);
 
     void move_layer_to_front(Layer&);
     void move_layer_to_back(Layer&);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -157,6 +157,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     file_menu.add_action(*m_save_image_as_action);
 
     m_export_submenu = file_menu.add_submenu("&Export");
+    m_export_submenu->set_icon(g_icon_bag.file_export);
 
     m_export_submenu->add_action(
         GUI::Action::create(
@@ -186,8 +187,6 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 if (result.is_error())
                     GUI::MessageBox::show_error(&window, String::formatted("Export to PNG failed: {}", result.error()));
             }));
-
-    m_export_submenu->set_icon(g_icon_bag.file_export);
 
     file_menu.add_separator();
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -188,6 +188,19 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                     GUI::MessageBox::show_error(&window, String::formatted("Export to PNG failed: {}", result.error()));
             }));
 
+    m_export_submenu->add_action(
+        GUI::Action::create(
+            "As &QOI", [&](auto&) {
+                auto* editor = current_image_editor();
+                auto response = FileSystemAccessClient::Client::the().try_save_file(&window, "untitled", "qoi");
+                if (response.is_error())
+                    return;
+                auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
+                auto result = editor->image().export_qoi_to_file(response.value(), preserve_alpha_channel == GUI::MessageBox::ExecYes);
+                if (result.is_error())
+                    GUI::MessageBox::show_error(&window, String::formatted("Export to QOI failed: {}", result.error()));
+            }));
+
     file_menu.add_separator();
 
     m_close_image_action = GUI::Action::create("&Close Image", { Mod_Ctrl, Key_W }, g_icon_bag.close_image, [&](auto&) {

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
     PPMLoader.cpp
     Point.cpp
     QOILoader.cpp
+    QOIWriter.cpp
     Rect.cpp
     ShareableBitmap.cpp
     Size.cpp

--- a/Userland/Libraries/LibGfx/QOICommon.h
+++ b/Userland/Libraries/LibGfx/QOICommon.h
@@ -7,7 +7,7 @@
 
 #pragma once
 
-#include <AK/StringView.h>
+#include <AK/Array.h>
 #include <AK/Types.h>
 
 namespace Gfx {
@@ -15,7 +15,7 @@ namespace Gfx {
 // Implementation details for the "Quite OK Image" format (v1.0).
 // https://qoiformat.org/qoi-specification.pdf
 
-static constexpr auto QOI_MAGIC = "qoif"sv;
+static constexpr ReadonlyByteArray<4> QOI_MAGIC { 'q', 'o', 'i', 'f' };
 static constexpr u8 QOI_OP_RGB = 0b11111110;
 static constexpr u8 QOI_OP_RGBA = 0b11111111;
 static constexpr u8 QOI_OP_INDEX = 0b00000000;
@@ -23,10 +23,10 @@ static constexpr u8 QOI_OP_DIFF = 0b01000000;
 static constexpr u8 QOI_OP_LUMA = 0b10000000;
 static constexpr u8 QOI_OP_RUN = 0b11000000;
 static constexpr u8 QOI_MASK_2 = 0b11000000;
-static constexpr u8 END_MARKER[] = { 0, 0, 0, 0, 0, 0, 0, 1 };
+static constexpr ReadonlyByteArray<8> QOI_END_MARKER { 0, 0, 0, 0, 0, 0, 0, 1 };
 
 struct [[gnu::packed]] QOIHeader {
-    char magic[4];
+    u8 magic[QOI_MAGIC.size()];
     u32 width;
     u32 height;
     u8 channels;

--- a/Userland/Libraries/LibGfx/QOICommon.h
+++ b/Userland/Libraries/LibGfx/QOICommon.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+namespace Gfx {
+
+// Implementation details for the "Quite OK Image" format (v1.0).
+// https://qoiformat.org/qoi-specification.pdf
+
+static constexpr auto QOI_MAGIC = "qoif"sv;
+static constexpr u8 QOI_OP_RGB = 0b11111110;
+static constexpr u8 QOI_OP_RGBA = 0b11111111;
+static constexpr u8 QOI_OP_INDEX = 0b00000000;
+static constexpr u8 QOI_OP_DIFF = 0b01000000;
+static constexpr u8 QOI_OP_LUMA = 0b10000000;
+static constexpr u8 QOI_OP_RUN = 0b11000000;
+static constexpr u8 QOI_MASK_2 = 0b11000000;
+static constexpr u8 END_MARKER[] = { 0, 0, 0, 0, 0, 0, 0, 1 };
+
+struct [[gnu::packed]] QOIHeader {
+    char magic[4];
+    u32 width;
+    u32 height;
+    u8 channels;
+    u8 colorspace;
+};
+
+}

--- a/Userland/Libraries/LibGfx/QOICommon.h
+++ b/Userland/Libraries/LibGfx/QOICommon.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/Array.h>
+#include <AK/Math.h>
 #include <AK/Types.h>
 
 namespace Gfx {
@@ -22,6 +23,10 @@ static constexpr u8 QOI_OP_INDEX = 0b00000000;
 static constexpr u8 QOI_OP_DIFF = 0b01000000;
 static constexpr u8 QOI_OP_LUMA = 0b10000000;
 static constexpr u8 QOI_OP_RUN = 0b11000000;
+// Note that the run-lengths 63 and 64 encoded as (b111110 and b111111) are illegal
+// as they are occupied by the QOI_OP_RGB and QOI_OP_RGBA tags.
+static constexpr u8 QOI_RUN_MIN = 1;
+static constexpr u8 QOI_RUN_MAX = 62;
 static constexpr u8 QOI_MASK_2 = 0b11000000;
 static constexpr ReadonlyByteArray<8> QOI_END_MARKER { 0, 0, 0, 0, 0, 0, 0, 1 };
 
@@ -32,5 +37,10 @@ struct [[gnu::packed]] QOIHeader {
     u8 channels;
     u8 colorspace;
 };
+
+ALWAYS_INLINE static constexpr bool qoi_is_valid_run(u8 run)
+{
+    return AK::is_in_bounds(run, QOI_RUN_MIN, QOI_RUN_MAX);
+}
 
 }

--- a/Userland/Libraries/LibGfx/QOICommon.h
+++ b/Userland/Libraries/LibGfx/QOICommon.h
@@ -8,8 +8,10 @@
 #pragma once
 
 #include <AK/Array.h>
+#include <AK/Assertions.h>
 #include <AK/Math.h>
 #include <AK/Types.h>
+#include <LibGfx/Color.h>
 
 namespace Gfx {
 
@@ -42,5 +44,36 @@ ALWAYS_INLINE static constexpr bool qoi_is_valid_run(u8 run)
 {
     return AK::is_in_bounds(run, QOI_RUN_MIN, QOI_RUN_MAX);
 }
+
+class QOIState {
+public:
+    static constexpr u8 PREVIOUSLY_SEEN_PIXELS_SIZE = 64;
+
+    static inline u8 index_position(Color pixel)
+    {
+        return (pixel.red() * 3 + pixel.green() * 5 + pixel.blue() * 7 + pixel.alpha() * 11) % PREVIOUSLY_SEEN_PIXELS_SIZE;
+    }
+
+    void set_previous_pixel(Color pixel)
+    {
+        m_previous_pixel = pixel;
+        m_previously_seen_pixels[index_position(pixel)] = pixel;
+    }
+
+    Color previous_pixel() const
+    {
+        return m_previous_pixel;
+    }
+
+    Color previously_seen_pixel(u8 index)
+    {
+        VERIFY(index < PREVIOUSLY_SEEN_PIXELS_SIZE);
+        return m_previously_seen_pixels[index];
+    }
+
+protected:
+    Color m_previous_pixel { 0, 0, 0, 255 };
+    Color m_previously_seen_pixels[PREVIOUSLY_SEEN_PIXELS_SIZE] {};
+};
 
 }

--- a/Userland/Libraries/LibGfx/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/QOILoader.cpp
@@ -11,16 +11,6 @@
 
 namespace Gfx {
 
-static constexpr auto QOI_MAGIC = "qoif"sv;
-static constexpr u8 QOI_OP_RGB = 0b11111110;
-static constexpr u8 QOI_OP_RGBA = 0b11111111;
-static constexpr u8 QOI_OP_INDEX = 0b00000000;
-static constexpr u8 QOI_OP_DIFF = 0b01000000;
-static constexpr u8 QOI_OP_LUMA = 0b10000000;
-static constexpr u8 QOI_OP_RUN = 0b11000000;
-static constexpr u8 QOI_MASK_2 = 0b11000000;
-static constexpr u8 END_MARKER[] = { 0, 0, 0, 0, 0, 0, 0, 1 };
-
 static ErrorOr<QOIHeader> decode_qoi_header(InputMemoryStream& stream)
 {
     QOIHeader header;

--- a/Userland/Libraries/LibGfx/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/QOILoader.cpp
@@ -17,7 +17,7 @@ static ErrorOr<QOIHeader> decode_qoi_header(InputMemoryStream& stream)
     stream >> Bytes { &header, sizeof(header) };
     if (stream.handle_any_error())
         return Error::from_string_literal("Invalid QOI image: end of stream while reading header"sv);
-    if (StringView { header.magic, array_size(header.magic) } != QOI_MAGIC)
+    if (header.magic != QOI_MAGIC)
         return Error::from_string_literal("Invalid QOI image: incorrect header magic"sv);
     header.width = AK::convert_between_host_and_big_endian(header.width);
     header.height = AK::convert_between_host_and_big_endian(header.height);
@@ -121,13 +121,13 @@ static ErrorOr<u8> decode_qoi_op_run(InputMemoryStream& stream)
 
 static ErrorOr<void> decode_qoi_end_marker(InputMemoryStream& stream)
 {
-    u8 bytes[array_size(END_MARKER)];
+    u8 bytes[QOI_END_MARKER.size()];
     stream >> Bytes { &bytes, array_size(bytes) };
     if (stream.handle_any_error())
         return Error::from_string_literal("Invalid QOI image: end of stream while reading end marker"sv);
     if (!stream.eof())
         return Error::from_string_literal("Invalid QOI image: expected end of stream but more bytes are available"sv);
-    if (memcmp(&END_MARKER, &bytes, array_size(bytes)) != 0)
+    if (bytes != QOI_END_MARKER)
         return Error::from_string_literal("Invalid QOI image: incorrect end marker"sv);
     return {};
 }

--- a/Userland/Libraries/LibGfx/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/QOILoader.cpp
@@ -111,11 +111,9 @@ static ErrorOr<u8> decode_qoi_op_run(InputMemoryStream& stream)
     // The run-length is stored with a bias of -1.
     run += 1;
 
-    // Note that the run-lengths 63 and 64 (b111110 and b111111) are illegal as they are occupied by the QOI_OP_RGB and QOI_OP_RGBA tags.
-    if (run == QOI_OP_RGB || run == QOI_OP_RGBA)
+    if (!qoi_is_valid_run(run))
         return Error::from_string_literal("Invalid QOI image: illegal run length"sv);
 
-    VERIFY(run >= 1 && run <= 62);
     return run;
 }
 

--- a/Userland/Libraries/LibGfx/QOILoader.h
+++ b/Userland/Libraries/LibGfx/QOILoader.h
@@ -9,19 +9,12 @@
 #include <AK/Forward.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/ImageDecoder.h>
+#include <LibGfx/QOICommon.h>
 
 namespace Gfx {
 
 // Decoder for the "Quite OK Image" format (v1.0).
 // https://qoiformat.org/qoi-specification.pdf
-
-struct [[gnu::packed]] QOIHeader {
-    char magic[4];
-    u32 width;
-    u32 height;
-    u8 channels;
-    u8 colorspace;
-};
 
 struct QOILoadingContext {
     enum class State {

--- a/Userland/Libraries/LibGfx/QOIWriter.cpp
+++ b/Userland/Libraries/LibGfx/QOIWriter.cpp
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "QOIWriter.h"
+#include "QOICommon.h"
+#include <AK/ByteBuffer.h>
+#include <AK/Math.h>
+#include <AK/MemoryStream.h>
+#include <AK/TypedTransfer.h>
+#include <LibGfx/Bitmap.h>
+
+namespace Gfx {
+
+template<typename Stream = ByteBuffer>
+class QOIWriterState : public QOIState {
+public:
+    ErrorOr<void> start(u32 width, u32 height, bool has_alpha_channel)
+    {
+        if (m_pixels_to_encode != INVALID_PIXELS_TO_ENCODE)
+            return Error::from_string_literal("Trying to start an already initialized QOI writer"sv);
+
+        m_pixels_to_encode = static_cast<u64>(width) * static_cast<u64>(height);
+        VERIFY(m_pixels_to_encode != INVALID_PIXELS_TO_ENCODE);
+
+        // 5 is the worse case scenario where we need to encode QOI_OP_RGBA for all pixels
+        const u64 pixels_to_encode_size = m_pixels_to_encode * 5;
+        TRY(m_stream.try_ensure_capacity(sizeof(QOIHeader) + pixels_to_encode_size + sizeof(QOI_END_MARKER)));
+
+        TRY(try_encode_qoi_header(width, height, has_alpha_channel));
+        return {};
+    }
+
+    ErrorOr<void> encode(Color const pixel)
+    {
+        if (m_pixels_to_encode == INVALID_PIXELS_TO_ENCODE)
+            return Error::from_string_literal("Trying to encode using a not initialized QOI writer"sv);
+        if (m_pixels_to_encode == 0)
+            return Error::from_string_literal("Trying to encode using a QOI writer that should be finished instead"sv);
+        --m_pixels_to_encode;
+
+        const i8 dr = pixel.red() - previous_pixel().red();
+        const i8 dg = pixel.green() - previous_pixel().green();
+        const i8 db = pixel.blue() - previous_pixel().blue();
+        const i8 da = pixel.alpha() - previous_pixel().alpha();
+
+        false
+            || TRY(try_encode_qoi_op_run(dr, dg, db, da))
+            || TRY(try_encode_qoi_op_index(pixel))
+            || TRY(try_encode_qoi_op_diff(dr, dg, db, da))
+            || TRY(try_encode_qoi_op_luma(dr, dg, db, da))
+            || TRY(try_encode_qoi_op_rgb(pixel))
+            || TRY(try_encode_qoi_op_rgba(pixel));
+        set_previous_pixel(pixel);
+        return {};
+    }
+
+    ErrorOr<Stream> finish()
+    {
+        if (m_pixels_to_encode == INVALID_PIXELS_TO_ENCODE)
+            return Error::from_string_literal("Trying to finish a not initialized QOI writer"sv);
+        if (m_pixels_to_encode != 0)
+            return Error::from_string_literal("Prematurely trying to finish a QOI writer"sv);
+
+        m_pixels_to_encode = INVALID_PIXELS_TO_ENCODE;
+        TRY(try_encode_qoi_end_marker());
+        return m_stream;
+    }
+
+private:
+    ErrorOr<void> try_encode_qoi_header(u32 width, u32 height, bool has_alpha_channel)
+    {
+        QOIHeader header {
+            {},
+            AK::convert_between_host_and_big_endian(width),
+            AK::convert_between_host_and_big_endian(height),
+            static_cast<u8>(has_alpha_channel ? 4 : 3),
+            0,
+        };
+        QOI_MAGIC.span().copy_to(header.magic);
+        return m_stream.try_append(ReadonlyBytes { &header, sizeof(header) });
+    }
+
+    ErrorOr<bool> try_encode_qoi_op_run(i8 dr, i8 dg, i8 db, i8 da)
+    {
+        const bool is_equal = dr == 0 && dg == 0 && db == 0 && da == 0;
+
+        if (is_equal) {
+            ++m_run;
+            if (m_run < QOI_RUN_MAX && m_pixels_to_encode > 0)
+                return true;
+        } else if (m_run == 0) {
+            return false;
+        }
+
+        VERIFY(qoi_is_valid_run(m_run));
+        // The run-length is stored with a bias of -1.
+        ByteArray<1> bytes {
+            static_cast<u8>(QOI_OP_RUN | (m_run - 1))
+        };
+        TRY(m_stream.try_append(bytes));
+        m_run = 0;
+        return is_equal;
+    }
+
+    ErrorOr<bool> try_encode_qoi_op_index(Color pixel)
+    {
+        auto index = index_position(pixel);
+        VERIFY(AK::is_in_bounds<u8>(index, 0, 63));
+        if (previously_seen_pixel(index) != pixel)
+            return false;
+
+        ByteArray<1> bytes {
+            static_cast<u8>(QOI_OP_INDEX | index)
+        };
+        TRY(m_stream.try_append(bytes));
+        return true;
+    }
+
+    ErrorOr<bool> try_encode_qoi_op_diff(i8 dr, i8 dg, i8 db, i8 da)
+    {
+        if (!AK::is_in_bounds<i8>(dr, -2, 1)
+            || !AK::is_in_bounds<i8>(dg, -2, 1)
+            || !AK::is_in_bounds<i8>(db, -2, 1)
+            || da != 0)
+            return false;
+
+        ByteArray<1> bytes {
+            static_cast<u8>(QOI_OP_DIFF | (dr + 2) << 4 | (dg + 2) << 2 | (db + 2))
+        };
+        TRY(m_stream.try_append(bytes));
+        return true;
+    }
+
+    ErrorOr<bool> try_encode_qoi_op_luma(i8 dr, i8 dg, i8 db, i8 da)
+    {
+        const i8 dr_dg = dr - dg;
+        const i8 db_dg = db - dg;
+
+        if (!AK::is_in_bounds<i8>(dg, -32, 31)
+            || !AK::is_in_bounds<i8>(dr_dg, -8, 7)
+            || !AK::is_in_bounds<i8>(db_dg, -8, 7)
+            || da != 0)
+            return false;
+
+        ByteArray<2> bytes {
+            static_cast<u8>(QOI_OP_LUMA | (dg + 32)),
+            static_cast<u8>((dr_dg + 8) << 4 | (db_dg + 8))
+        };
+        TRY(m_stream.try_append(bytes));
+        return true;
+    }
+
+    ErrorOr<bool> try_encode_qoi_op_rgb(Color pixel)
+    {
+        if (pixel.alpha() != previous_pixel().alpha())
+            return false;
+
+        ByteArray<4> bytes {
+            QOI_OP_RGB,
+            pixel.red(),
+            pixel.green(),
+            pixel.blue()
+        };
+        TRY(m_stream.try_append(bytes));
+        return true;
+    }
+
+    ErrorOr<bool> try_encode_qoi_op_rgba(Color pixel)
+    {
+        ByteArray<5> bytes {
+            QOI_OP_RGBA,
+            pixel.red(),
+            pixel.green(),
+            pixel.blue(),
+            pixel.alpha()
+        };
+        TRY(m_stream.try_append(bytes));
+        return true;
+    }
+
+    ErrorOr<void> try_encode_qoi_end_marker()
+    {
+        return m_stream.try_append(QOI_END_MARKER);
+    }
+
+private:
+    static constexpr u64 INVALID_PIXELS_TO_ENCODE = NumericLimits<u64>::max();
+    u64 m_pixels_to_encode { INVALID_PIXELS_TO_ENCODE };
+    u8 m_run { 0 };
+    Stream m_stream;
+};
+
+ErrorOr<ByteBuffer> QOIWriter::encode(Gfx::Bitmap const& bitmap)
+{
+    const u32 width = static_cast<u32>(bitmap.width());
+    const u32 height = static_cast<u32>(bitmap.height());
+
+    QOIWriterState<> state;
+    TRY(state.start(width, height, bitmap.has_alpha_channel()));
+    for (u32 y = 0; y < height; ++y) {
+        for (u32 x = 0; x < width; ++x)
+            TRY(state.encode(bitmap.get_pixel(x, y)));
+    }
+    return TRY(state.finish());
+}
+
+}

--- a/Userland/Libraries/LibGfx/QOIWriter.h
+++ b/Userland/Libraries/LibGfx/QOIWriter.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibGfx/Forward.h>
+
+namespace Gfx {
+
+class QOIWriter final {
+public:
+    static ErrorOr<ByteBuffer> encode(Gfx::Bitmap const&);
+};
+
+}


### PR DESCRIPTION
Hi,

The following change set allows to export files to the QOI file format. When combined with #11642 it also to make exact copies of the reference files from the official site (verified with a test-suite don't think I can publish, since the reference files are quite large).

Some parts need to be polished before merging, but it is fully functional (Maybe it lacks the possibility to override channels like #11642 allow).