### PR TITLE
Ports: Reinstate `config.sub` patch for`libogg`

### DIFF
--- a/Ports/libogg/patches/config.sub.patch
+++ b/Ports/libogg/patches/config.sub.patch
@@ -1,0 +1,11 @@
+--- libogg-1.3.5/config.sub	2021-06-04 01:15:56.000000000 +0200
++++ libogg-1.3.5-patched/config.sub	2022-01-08 00:05:41.813876348 +0100
+@@ -1363,7 +1363,7 @@
+ 	# The portable systems comes first.
+ 	# Each alternative MUST end in a * to match a version number.
+ 	# -sysv* is not here because it comes later, after sysvr4.
+-	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -irix* \
++	-gnu* | -bsd* | -mach* | -minix* | -genix* | -ultrix* | -serenity* | -irix* \
+ 	      | -*vms* | -sco* | -esix* | -isc* | -aix* | -cnk* | -sunos | -sunos[34]*\
+ 	      | -hpux* | -unos* | -osf* | -luna* | -dgux* | -auroraux* | -solaris* \
+ 	      | -sym* | -kopensolaris* | -plan9* \


### PR DESCRIPTION
Originally removed in PR #11655, we still need the `config.sub` patch to build the port.