### PR TITLE
PixelPaint: Handle closing of inactive tabs properly

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -14,7 +14,9 @@
 #include "Tools/Tool.h"
 #include <AK/LexicalPath.h>
 #include <LibConfig/Client.h>
+#include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Command.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/DisjointRectSet.h>
 #include <LibGfx/Palette.h>
@@ -696,6 +698,37 @@ void ImageEditor::image_did_change_rect(Gfx::IntRect const& new_image_rect)
 void ImageEditor::image_select_layer(Layer* layer)
 {
     set_active_layer(layer);
+}
+
+void ImageEditor::save_project()
+{
+    if (path().is_empty()) {
+        save_project_as();
+        return;
+    }
+    auto response = FileSystemAccessClient::Client::the().request_file(window()->window_id(), path(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
+    if (response.error != 0)
+        return;
+    auto result = save_project_to_fd_and_close(*response.fd);
+    if (result.is_error()) {
+        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", *response.chosen_file, result.error()));
+        return;
+    }
+    undo_stack().set_current_unmodified();
+}
+
+void ImageEditor::save_project_as()
+{
+    auto save_result = FileSystemAccessClient::Client::the().save_file(window()->window_id(), "untitled", "pp");
+    if (save_result.error != 0)
+        return;
+    auto result = save_project_to_fd_and_close(*save_result.fd);
+    if (result.is_error()) {
+        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", *save_result.chosen_file, result.error()));
+        return;
+    }
+    set_path(*save_result.chosen_file);
+    undo_stack().set_current_unmodified();
 }
 
 Result<void, String> ImageEditor::save_project_to_fd_and_close(int fd) const

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -700,6 +700,24 @@ void ImageEditor::image_select_layer(Layer* layer)
     set_active_layer(layer);
 }
 
+bool ImageEditor::request_close()
+{
+    if (!undo_stack().is_current_modified())
+        return true;
+
+    auto result = GUI::MessageBox::ask_about_unsaved_changes(window(), path(), undo_stack().last_unmodified_timestamp());
+
+    if (result == GUI::MessageBox::ExecYes) {
+        save_project();
+        return true;
+    }
+
+    if (result == GUI::MessageBox::ExecNo)
+        return true;
+
+    return false;
+}
+
 void ImageEditor::save_project()
 {
     if (path().is_empty()) {

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -109,6 +109,8 @@ public:
     Gfx::FloatPoint image_position_to_editor_position(Gfx::IntPoint const&) const;
     Gfx::FloatPoint editor_position_to_image_position(Gfx::IntPoint const&) const;
 
+    bool request_close();
+
     void save_project_as();
     void save_project();
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -109,7 +109,8 @@ public:
     Gfx::FloatPoint image_position_to_editor_position(Gfx::IntPoint const&) const;
     Gfx::FloatPoint editor_position_to_image_position(Gfx::IntPoint const&) const;
 
-    Result<void, String> save_project_to_fd_and_close(int fd) const;
+    void save_project_as();
+    void save_project();
 
     NonnullRefPtrVector<Guide> const& guides() const { return m_guides; }
     bool guide_visibility() { return m_show_guides; }
@@ -148,6 +149,8 @@ private:
 
     GUI::MouseEvent event_adjusted_for_layer(GUI::MouseEvent const&, Layer const&) const;
     GUI::MouseEvent event_with_pan_and_scale_applied(GUI::MouseEvent const&) const;
+
+    Result<void, String> save_project_to_fd_and_close(int fd) const;
 
     void clamped_scale_by(float, bool do_relayout);
     void relayout();

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -133,38 +133,13 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     });
 
     m_save_image_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        auto save_result = FileSystemAccessClient::Client::the().save_file(window.window_id(), "untitled", "pp");
-        if (save_result.error != 0)
-            return;
-        auto result = editor->save_project_to_fd_and_close(*save_result.fd);
-        if (result.is_error()) {
-            GUI::MessageBox::show_error(&window, String::formatted("Could not save {}: {}", *save_result.chosen_file, result.error()));
-            return;
-        }
-        editor->set_path(*save_result.chosen_file);
-        editor->undo_stack().set_current_unmodified();
+        if (auto* editor = current_image_editor())
+            editor->save_project_as();
     });
 
     m_save_image_action = GUI::CommonActions::make_save_action([&](auto&) {
-        auto* editor = current_image_editor();
-        if (!editor)
-            return;
-        if (editor->path().is_empty()) {
-            m_save_image_as_action->activate();
-            return;
-        }
-        auto response = FileSystemAccessClient::Client::the().request_file(window.window_id(), editor->path(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
-        if (response.error != 0)
-            return;
-        auto result = editor->save_project_to_fd_and_close(*response.fd);
-        if (result.is_error()) {
-            GUI::MessageBox::show_error(&window, String::formatted("Could not save {}: {}", *response.chosen_file, result.error()));
-            return;
-        }
-        editor->undo_stack().set_current_unmodified();
+        if (auto* editor = current_image_editor())
+            editor->save_project();
     });
 
     file_menu.add_action(*m_new_image_action);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -68,7 +68,7 @@ MainWidget::MainWidget()
         if (image_editor.request_close()) {
             m_tab_widget->deferred_invoke([&] {
                 m_tab_widget->remove_tab(image_editor);
-                if (m_tab_widget->children().size() == 1) {
+                if (m_tab_widget->children().size() == 0) {
                     m_layer_list_widget->set_image(nullptr);
                     m_layer_properties_widget->set_layer(nullptr);
                 }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -64,8 +64,8 @@ MainWidget::MainWidget()
     };
 
     m_tab_widget->on_tab_close_click = [&](auto& widget) {
-        if (request_close_editor()) {
-            auto& image_editor = verify_cast<PixelPaint::ImageEditor>(widget);
+        auto& image_editor = verify_cast<PixelPaint::ImageEditor>(widget);
+        if (image_editor.request_close()) {
             m_tab_widget->deferred_invoke([&] {
                 m_tab_widget->remove_tab(image_editor);
                 if (m_tab_widget->children().size() == 1) {
@@ -726,32 +726,12 @@ void MainWidget::create_image_from_clipboard()
     m_layer_list_widget->set_selected_layer(layer);
 }
 
-bool MainWidget::request_close_editor()
-{
-    auto* editor = current_image_editor();
-    VERIFY(editor);
-
-    if (!editor->undo_stack().is_current_modified()) {
-        return true;
-    }
-
-    auto result = GUI::MessageBox::ask_about_unsaved_changes(window(), editor->path(), editor->undo_stack().last_unmodified_timestamp());
-
-    if (result == GUI::MessageBox::ExecYes) {
-        m_save_image_action->activate();
-        return true;
-    }
-
-    if (result == GUI::MessageBox::ExecNo)
-        return true;
-
-    return false;
-}
-
 bool MainWidget::request_close()
 {
     while (!m_tab_widget->children().is_empty()) {
-        if (!request_close_editor())
+        auto* editor = current_image_editor();
+        VERIFY(editor);
+        if (!editor->request_close())
             return false;
         m_tab_widget->remove_tab(*m_tab_widget->active_widget());
     }

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -37,7 +37,6 @@ public:
     void open_image_fd(int fd, String const& path);
     void create_default_image();
 
-    bool request_close_editor();
     bool request_close();
 
 private:


### PR DESCRIPTION
We didn't handle closing inactive tabs properly earlier since some in `MainWidget` only acted on the currently active tab. So, the application would only prompt a user for unsaved changes for the _active editor_, and discard any unsaved changes in the editor actually being closed. This PR moves more of the logic for saving / closing inside each editor itself, so `MainWidget` is just redirecting the functionality to the correct editor (as I think it should be).