### PR TITLE
LibGUI: Convert `FileIconProvider` into a Singleton

### DIFF
--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -77,7 +77,7 @@ void AppProvider::query(String const& query, Function<void(NonnullRefPtrVector<R
         if (!match_result.matched)
             return;
 
-        auto icon = GUI::FileIconProvider::icon_for_executable(app_file->executable());
+        auto icon = GUI::FileIconProvider::the().icon_for_executable(app_file->executable());
         results.append(adopt_ref(*new AppResult(icon.bitmap_for_size(16), app_file->name(), {}, app_file, match_result.score)));
     });
 
@@ -117,7 +117,7 @@ void CalculatorProvider::query(String const& query, Function<void(NonnullRefPtrV
 
 Gfx::Bitmap const* FileResult::bitmap() const
 {
-    return GUI::FileIconProvider::icon_for_path(title()).bitmap_for_size(16);
+    return GUI::FileIconProvider::the().icon_for_path(title()).bitmap_for_size(16);
 }
 
 FileProvider::FileProvider()

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -193,7 +193,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     widget->load_from_gml(crash_reporter_window_gml);
 
     auto& icon_image_widget = *widget->find_descendant_of_type_named<GUI::ImageWidget>("icon");
-    icon_image_widget.set_bitmap(GUI::FileIconProvider::icon_for_executable(executable_path).bitmap_for_size(32));
+    icon_image_widget.set_bitmap(GUI::FileIconProvider::the().icon_for_executable(executable_path).bitmap_for_size(32));
 
     auto app_name = LexicalPath::basename(executable_path);
     auto af = Desktop::AppFile::get_for_app(app_name);

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -46,7 +46,7 @@ void spawn_terminal(String const& directory)
 
 NonnullRefPtr<GUI::Action> LauncherHandler::create_launch_action(Function<void(LauncherHandler const&)> launch_handler)
 {
-    auto icon = GUI::FileIconProvider::icon_for_executable(details().executable).bitmap_for_size(16);
+    auto icon = GUI::FileIconProvider::the().icon_for_executable(details().executable).bitmap_for_size(16);
     return GUI::Action::create(details().name, move(icon), [this, launch_handler = move(launch_handler)](auto&) {
         launch_handler(*this);
     });

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -168,7 +168,7 @@ PropertiesWindow::~PropertiesWindow()
 
 void PropertiesWindow::update()
 {
-    m_icon->set_bitmap(GUI::FileIconProvider::icon_for_path(make_full_path(m_name), m_mode).bitmap_for_size(32));
+    m_icon->set_bitmap(GUI::FileIconProvider::the().icon_for_path(make_full_path(m_name), m_mode).bitmap_for_size(32));
     set_title(String::formatted("{} - Properties", m_name));
 }
 

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1017,7 +1017,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     (void)TRY(main_toolbar.try_add_action(directory_view->view_as_columns_action()));
 
     directory_view->on_path_change = [&](String const& new_path, bool can_read_in_path, bool can_write_in_path) {
-        auto icon = GUI::FileIconProvider::icon_for_path(new_path);
+        auto icon = GUI::FileIconProvider::the().icon_for_path(new_path);
         auto* bitmap = icon.bitmap_for_size(16);
         window->set_icon(bitmap);
         location_textbox.set_icon(bitmap);
@@ -1043,7 +1043,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
             } else {
                 breadcrumbbar.clear_segments();
 
-                breadcrumbbar.append_segment("/", GUI::FileIconProvider::icon_for_path("/").bitmap_for_size(16), "/", "/");
+                breadcrumbbar.append_segment("/", GUI::FileIconProvider::the().icon_for_path("/").bitmap_for_size(16), "/", "/");
                 StringBuilder builder;
 
                 for (auto& part : lexical_path.parts()) {
@@ -1051,7 +1051,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
                     builder.append('/');
                     builder.append(part);
 
-                    breadcrumbbar.append_segment(part, GUI::FileIconProvider::icon_for_path(builder.string_view()).bitmap_for_size(16), builder.string_view(), builder.string_view());
+                    breadcrumbbar.append_segment(part, GUI::FileIconProvider::the().icon_for_path(builder.string_view()).bitmap_for_size(16), builder.string_view(), builder.string_view());
                 }
 
                 breadcrumbbar.set_selected_segment(breadcrumbbar.segment_count() - 1);

--- a/Userland/Applications/PixelPaint/FilterModel.cpp
+++ b/Userland/Applications/PixelPaint/FilterModel.cpp
@@ -109,7 +109,7 @@ GUI::Variant FilterModel::data(const GUI::ModelIndex& index, GUI::ModelRole role
         return filter->text;
     case GUI::ModelRole::Icon:
         if (filter->type == FilterInfo::Type::Category)
-            return GUI::FileIconProvider::directory_icon();
+            return GUI::FileIconProvider::the().directory_icon();
         return m_filter_icon;
     default:
         return {};

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -393,7 +393,7 @@ int main(int argc, char* argv[])
         breadcrumbbar.clear_segments();
         for (size_t k = 0; k < treemapwidget.path_size(); k++) {
             if (k == 0) {
-                breadcrumbbar.append_segment("/", GUI::FileIconProvider::icon_for_path("/").bitmap_for_size(16), "/", "/");
+                breadcrumbbar.append_segment("/", GUI::FileIconProvider::the().icon_for_path("/").bitmap_for_size(16), "/", "/");
                 continue;
             }
 
@@ -402,7 +402,7 @@ int main(int argc, char* argv[])
             builder.append("/");
             builder.append(node->name());
 
-            breadcrumbbar.append_segment(node->name(), GUI::FileIconProvider::icon_for_path(builder.string_view()).bitmap_for_size(16), builder.string_view(), builder.string_view());
+            breadcrumbbar.append_segment(node->name(), GUI::FileIconProvider::the().icon_for_path(builder.string_view()).bitmap_for_size(16), builder.string_view(), builder.string_view());
         }
         breadcrumbbar.set_selected_segment(treemapwidget.viewpoint());
     };

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -242,7 +242,7 @@ GUI::Variant ProcessModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         case Column::Icon: {
             if (thread.current_state.kernel)
                 return m_kernel_process_icon;
-            return GUI::FileIconProvider::icon_for_executable(thread.current_state.executable);
+            return GUI::FileIconProvider::the().icon_for_executable(thread.current_state.executable);
         }
         case Column::PID:
             return thread.current_state.pid;

--- a/Userland/DevTools/HackStudio/Locator.cpp
+++ b/Userland/DevTools/HackStudio/Locator.cpp
@@ -55,7 +55,7 @@ public:
             if (index.column() == Column::Filename)
                 return "";
             if (index.column() == Column::Icon)
-                return GUI::FileIconProvider::icon_for_path(suggestion.as_filename.value());
+                return GUI::FileIconProvider::the().icon_for_path(suggestion.as_filename.value());
         }
         if (suggestion.is_symbol_declaration()) {
             if (index.column() == Column::Name) {

--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -104,7 +104,7 @@ GUI::Variant ProfileModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
     if (role == GUI::ModelRole::Icon) {
         if (index.column() == Column::StackFrame) {
             if (node->is_root()) {
-                return GUI::FileIconProvider::icon_for_executable(node->process().executable);
+                return GUI::FileIconProvider::the().icon_for_executable(node->process().executable);
             }
             auto maybe_kernel_base = Symbolication::kernel_base();
             if (maybe_kernel_base.has_value() && node->address() >= maybe_kernel_base.value())

--- a/Userland/DevTools/Profiler/TimelineHeader.cpp
+++ b/Userland/DevTools/Profiler/TimelineHeader.cpp
@@ -23,7 +23,7 @@ TimelineHeader::TimelineHeader(Profile& profile, Process const& process)
     set_fixed_size(200, 40);
     update_selection();
 
-    m_icon = GUI::FileIconProvider::icon_for_executable(m_process.executable).bitmap_for_size(32);
+    m_icon = GUI::FileIconProvider::the().icon_for_executable(m_process.executable).bitmap_for_size(32);
     m_text = String::formatted("{} ({})", LexicalPath::basename(m_process.executable), m_process.pid);
 }
 

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -95,9 +95,9 @@ GUI::Icon AppFile::icon() const
     auto override_icon = icon_path();
     // FIXME: support pointing to actual .ico files
     if (!override_icon.is_empty())
-        return GUI::FileIconProvider::icon_for_path(override_icon);
+        return GUI::FileIconProvider::the().icon_for_path(override_icon);
 
-    return GUI::FileIconProvider::icon_for_path(executable());
+    return GUI::FileIconProvider::the().icon_for_path(executable());
 }
 
 bool AppFile::run_in_terminal() const

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,7 +13,6 @@
 #include <LibCore/StandardPaths.h>
 #include <LibELF/Image.h>
 #include <LibGUI/FileIconProvider.h>
-#include <LibGUI/Icon.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/PNGLoader.h>
@@ -22,116 +22,44 @@
 
 namespace GUI {
 
-static Icon s_hard_disk_icon;
-static Icon s_directory_icon;
-static Icon s_directory_open_icon;
-static Icon s_inaccessible_directory_icon;
-static Icon s_desktop_directory_icon;
-static Icon s_home_directory_icon;
-static Icon s_home_directory_open_icon;
-static Icon s_file_icon;
-static Icon s_symlink_icon;
-static Icon s_socket_icon;
-static Icon s_executable_icon;
-static Icon s_filetype_image_icon;
-static RefPtr<Gfx::Bitmap> s_symlink_emblem;
-static RefPtr<Gfx::Bitmap> s_symlink_emblem_small;
-
-static HashMap<String, Icon> s_filetype_icons;
-static HashMap<String, Vector<String>> s_filetype_patterns;
-
-static void initialize_executable_icon_if_needed()
+FileIconProvider& FileIconProvider::the()
 {
-    static bool initialized = false;
-    if (initialized)
-        return;
-    initialized = true;
-    s_executable_icon = Icon::default_icon("filetype-executable");
+    static FileIconProvider s_the;
+    return s_the;
 }
 
-static void initialize_filetype_image_icon_if_needed()
+FileIconProvider::FileIconProvider()
 {
-    static bool initialized = false;
-    if (initialized)
-        return;
-    initialized = true;
-    s_filetype_image_icon = Icon::default_icon("filetype-image");
-}
-
-static void initialize_if_needed()
-{
-    static bool s_initialized = false;
-    if (s_initialized)
-        return;
-
     auto config = Core::ConfigFile::open("/etc/FileIconProvider.ini");
 
-    s_symlink_emblem = Gfx::Bitmap::try_load_from_file("/res/icons/symlink-emblem.png").release_value_but_fixme_should_propagate_errors();
-    s_symlink_emblem_small = Gfx::Bitmap::try_load_from_file("/res/icons/symlink-emblem-small.png").release_value_but_fixme_should_propagate_errors();
+    m_symlink_emblem = Gfx::Bitmap::try_load_from_file("/res/icons/symlink-emblem.png").release_value_but_fixme_should_propagate_errors();
+    m_symlink_emblem_small = Gfx::Bitmap::try_load_from_file("/res/icons/symlink-emblem-small.png").release_value_but_fixme_should_propagate_errors();
 
-    s_hard_disk_icon = Icon::default_icon("hard-disk");
-    s_directory_icon = Icon::default_icon("filetype-folder");
-    s_directory_open_icon = Icon::default_icon("filetype-folder-open");
-    s_inaccessible_directory_icon = Icon::default_icon("filetype-folder-inaccessible");
-    s_home_directory_icon = Icon::default_icon("home-directory");
-    s_home_directory_open_icon = Icon::default_icon("home-directory-open");
-    s_desktop_directory_icon = Icon::default_icon("desktop");
-    s_file_icon = Icon::default_icon("filetype-unknown");
-    s_symlink_icon = Icon::default_icon("filetype-symlink");
-    s_socket_icon = Icon::default_icon("filetype-socket");
+    m_hard_disk_icon = Icon::default_icon("hard-disk");
+    m_directory_icon = Icon::default_icon("filetype-folder");
+    m_directory_open_icon = Icon::default_icon("filetype-folder-open");
+    m_inaccessible_directory_icon = Icon::default_icon("filetype-folder-inaccessible");
+    m_home_directory_icon = Icon::default_icon("home-directory");
+    m_home_directory_open_icon = Icon::default_icon("home-directory-open");
+    m_desktop_directory_icon = Icon::default_icon("desktop");
+    m_file_icon = Icon::default_icon("filetype-unknown");
+    m_symlink_icon = Icon::default_icon("filetype-symlink");
+    m_socket_icon = Icon::default_icon("filetype-socket");
 
-    initialize_filetype_image_icon_if_needed();
-    initialize_executable_icon_if_needed();
+    m_executable_icon = Icon::default_icon("filetype-executable");
+    m_filetype_image_icon = Icon::default_icon("filetype-image");
 
     for (auto& filetype : config->keys("Icons")) {
-        s_filetype_icons.set(filetype, Icon::default_icon(String::formatted("filetype-{}", filetype)));
-        s_filetype_patterns.set(filetype, config->read_entry("Icons", filetype).split(','));
+        m_filetype_icons.set(filetype, Icon::default_icon(String::formatted("filetype-{}", filetype)));
+        m_filetype_patterns.set(filetype, config->read_entry("Icons", filetype).split(','));
     }
-
-    s_initialized = true;
-}
-
-Icon FileIconProvider::directory_icon()
-{
-    initialize_if_needed();
-    return s_directory_icon;
-}
-
-Icon FileIconProvider::directory_open_icon()
-{
-    initialize_if_needed();
-    return s_directory_open_icon;
-}
-
-Icon FileIconProvider::home_directory_icon()
-{
-    initialize_if_needed();
-    return s_home_directory_icon;
-}
-
-Icon FileIconProvider::desktop_directory_icon()
-{
-    initialize_if_needed();
-    return s_desktop_directory_icon;
-}
-
-Icon FileIconProvider::home_directory_open_icon()
-{
-    initialize_if_needed();
-    return s_home_directory_open_icon;
-}
-
-Icon FileIconProvider::filetype_image_icon()
-{
-    initialize_filetype_image_icon_if_needed();
-    return s_filetype_image_icon;
 }
 
 Icon FileIconProvider::icon_for_path(const String& path)
 {
     struct stat stat;
     if (::stat(path.characters(), &stat) < 0)
-        return s_file_icon;
+        return m_file_icon;
     return icon_for_path(path, stat.st_mode);
 }
 
@@ -142,33 +70,31 @@ Icon FileIconProvider::icon_for_executable(const String& path)
     if (auto it = app_icon_cache.find(path); it != app_icon_cache.end())
         return it->value;
 
-    initialize_executable_icon_if_needed();
-
     // If the icon for an app isn't in the cache we attempt to load the file as an ELF image and extract
     // the serenity_app_icon_* sections which should contain the icons as raw PNG data. In the future it would
     // be better if the binary signalled the image format being used or we deduced it, e.g. using magic bytes.
     auto file_or_error = Core::MappedFile::map(path);
     if (file_or_error.is_error()) {
-        app_icon_cache.set(path, s_executable_icon);
-        return s_executable_icon;
+        app_icon_cache.set(path, m_executable_icon);
+        return m_executable_icon;
     }
 
     auto& mapped_file = file_or_error.value();
 
     if (mapped_file->size() < SELFMAG) {
-        app_icon_cache.set(path, s_executable_icon);
-        return s_executable_icon;
+        app_icon_cache.set(path, m_executable_icon);
+        return m_executable_icon;
     }
 
     if (memcmp(mapped_file->data(), ELFMAG, SELFMAG) != 0) {
-        app_icon_cache.set(path, s_executable_icon);
-        return s_executable_icon;
+        app_icon_cache.set(path, m_executable_icon);
+        return m_executable_icon;
     }
 
     auto image = ELF::Image((const u8*)mapped_file->data(), mapped_file->size());
     if (!image.is_valid()) {
-        app_icon_cache.set(path, s_executable_icon);
-        return s_executable_icon;
+        app_icon_cache.set(path, m_executable_icon);
+        return m_executable_icon;
     }
 
     // If any of the required sections are missing then use the defaults
@@ -186,7 +112,7 @@ Icon FileIconProvider::icon_for_executable(const String& path)
 
         RefPtr<Gfx::Bitmap> bitmap;
         if (!section.has_value()) {
-            bitmap = s_executable_icon.bitmap_for_size(icon_section.image_size);
+            bitmap = m_executable_icon.bitmap_for_size(icon_section.image_size);
         } else {
             // FIXME: Use the ImageDecoder service.
             auto frame_or_error = Gfx::PNGImageDecoderPlugin(reinterpret_cast<u8 const*>(section->raw_data()), section->size()).frame(0);
@@ -205,8 +131,8 @@ Icon FileIconProvider::icon_for_executable(const String& path)
     }
 
     if (had_error) {
-        app_icon_cache.set(path, s_executable_icon);
-        return s_executable_icon;
+        app_icon_cache.set(path, m_executable_icon);
+        return m_executable_icon;
     }
     app_icon_cache.set(path, icon);
     return icon;
@@ -214,22 +140,21 @@ Icon FileIconProvider::icon_for_executable(const String& path)
 
 Icon FileIconProvider::icon_for_path(const String& path, mode_t mode)
 {
-    initialize_if_needed();
     if (path == "/")
-        return s_hard_disk_icon;
+        return m_hard_disk_icon;
     if (S_ISDIR(mode)) {
         if (path == Core::StandardPaths::home_directory())
-            return s_home_directory_icon;
+            return m_home_directory_icon;
         if (path == Core::StandardPaths::desktop_directory())
-            return s_desktop_directory_icon;
+            return m_desktop_directory_icon;
         if (access(path.characters(), R_OK | X_OK) < 0)
-            return s_inaccessible_directory_icon;
-        return s_directory_icon;
+            return m_inaccessible_directory_icon;
+        return m_directory_icon;
     }
     if (S_ISLNK(mode)) {
         auto raw_symlink_target = Core::File::read_link(path);
         if (raw_symlink_target.is_null())
-            return s_symlink_icon;
+            return m_symlink_icon;
 
         String target_path;
         if (raw_symlink_target.starts_with('/')) {
@@ -241,13 +166,13 @@ Icon FileIconProvider::icon_for_path(const String& path, mode_t mode)
 
         Icon generated_icon;
         for (auto size : target_icon.sizes()) {
-            auto& emblem = size < 32 ? *s_symlink_emblem_small : *s_symlink_emblem;
+            auto& emblem = size < 32 ? *m_symlink_emblem_small : *m_symlink_emblem;
             auto original_bitmap = target_icon.bitmap_for_size(size);
             VERIFY(original_bitmap);
             auto generated_bitmap_or_error = original_bitmap->clone();
             if (generated_bitmap_or_error.is_error()) {
                 dbgln("Failed to clone {}x{} icon for symlink variant", size, size);
-                return s_symlink_icon;
+                return m_symlink_icon;
             }
             auto generated_bitmap = generated_bitmap_or_error.release_value_but_fixme_should_propagate_errors();
             GUI::Painter painter(*generated_bitmap);
@@ -258,25 +183,25 @@ Icon FileIconProvider::icon_for_path(const String& path, mode_t mode)
         return generated_icon;
     }
     if (S_ISSOCK(mode))
-        return s_socket_icon;
+        return m_socket_icon;
 
     if (mode & (S_IXUSR | S_IXGRP | S_IXOTH))
         return icon_for_executable(path);
 
     if (Gfx::Bitmap::is_path_a_supported_image_format(path.view()))
-        return s_filetype_image_icon;
+        return m_filetype_image_icon;
 
-    for (auto& filetype : s_filetype_icons.keys()) {
-        auto pattern_it = s_filetype_patterns.find(filetype);
-        if (pattern_it == s_filetype_patterns.end())
+    for (auto& filetype : m_filetype_icons.keys()) {
+        auto pattern_it = m_filetype_patterns.find(filetype);
+        if (pattern_it == m_filetype_patterns.end())
             continue;
         for (auto& pattern : pattern_it->value) {
             if (path.matches(pattern, CaseSensitivity::CaseInsensitive))
-                return s_filetype_icons.get(filetype).value();
+                return m_filetype_icons.get(filetype).value();
         }
     }
 
-    return s_file_icon;
+    return m_file_icon;
 }
 
 }

--- a/Userland/Libraries/LibGUI/FileIconProvider.h
+++ b/Userland/Libraries/LibGUI/FileIconProvider.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,22 +9,46 @@
 
 #include <AK/Forward.h>
 #include <LibGUI/Forward.h>
+#include <LibGUI/Icon.h>
 #include <sys/types.h>
 
 namespace GUI {
 
 class FileIconProvider {
 public:
-    static Icon icon_for_path(const String&, mode_t);
-    static Icon icon_for_path(const String&);
-    static Icon icon_for_executable(const String&);
+    static FileIconProvider& the();
 
-    static Icon filetype_image_icon();
-    static Icon directory_icon();
-    static Icon directory_open_icon();
-    static Icon home_directory_icon();
-    static Icon home_directory_open_icon();
-    static Icon desktop_directory_icon();
+    Icon icon_for_path(const String&, mode_t);
+    Icon icon_for_path(const String&);
+    Icon icon_for_executable(const String&);
+
+    Icon filetype_image_icon() { return m_filetype_image_icon; }
+    Icon directory_icon() { return m_directory_icon; }
+    Icon directory_open_icon() { return m_directory_open_icon; }
+    Icon home_directory_icon() { return m_home_directory_icon; }
+    Icon home_directory_open_icon() { return m_home_directory_open_icon; }
+    Icon desktop_directory_icon() { return m_desktop_directory_icon; }
+
+private:
+    FileIconProvider();
+
+    Icon m_hard_disk_icon;
+    Icon m_directory_icon;
+    Icon m_directory_open_icon;
+    Icon m_inaccessible_directory_icon;
+    Icon m_desktop_directory_icon;
+    Icon m_home_directory_icon;
+    Icon m_home_directory_open_icon;
+    Icon m_file_icon;
+    Icon m_symlink_icon;
+    Icon m_socket_icon;
+    Icon m_executable_icon;
+    Icon m_filetype_image_icon;
+    RefPtr<Gfx::Bitmap> m_symlink_emblem;
+    RefPtr<Gfx::Bitmap> m_symlink_emblem_small;
+
+    HashMap<String, Icon> m_filetype_icons;
+    HashMap<String, Vector<String>> m_filetype_patterns;
 };
 
 }

--- a/Userland/Libraries/LibGUI/FilePicker.cpp
+++ b/Userland/Libraries/LibGUI/FilePicker.cpp
@@ -244,11 +244,11 @@ FilePicker::FilePicker(Window* parent_window, Mode mode, StringView filename, St
         set_path(path);
     };
     for (auto& location : CommonLocationsProvider::common_locations()) {
-        auto index = common_locations_tray.add_item(location.name, FileIconProvider::icon_for_path(location.path).bitmap_for_size(16), location.path);
+        auto index = common_locations_tray.add_item(location.name, FileIconProvider::the().icon_for_path(location.path).bitmap_for_size(16), location.path);
         m_common_location_buttons.append({ location.path, index });
     }
 
-    m_location_textbox->set_icon(FileIconProvider::icon_for_path(path).bitmap_for_size(16));
+    m_location_textbox->set_icon(FileIconProvider::the().icon_for_path(path).bitmap_for_size(16));
     m_model->on_complete();
 }
 
@@ -297,7 +297,7 @@ void FilePicker::set_path(const String& path)
     }
 
     auto new_path = LexicalPath(path).string();
-    m_location_textbox->set_icon(FileIconProvider::icon_for_path(new_path).bitmap_for_size(16));
+    m_location_textbox->set_icon(FileIconProvider::the().icon_for_path(new_path).bitmap_for_size(16));
     m_model->set_root_path(new_path);
 }
 

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -588,29 +588,29 @@ Variant FileSystemModel::data(ModelIndex const& index, ModelRole role) const
 Icon FileSystemModel::icon_for(Node const& node) const
 {
     if (node.full_path() == "/")
-        return FileIconProvider::icon_for_path("/");
+        return FileIconProvider::the().icon_for_path("/");
 
     if (Gfx::Bitmap::is_path_a_supported_image_format(node.name)) {
         if (!node.thumbnail) {
             if (!const_cast<FileSystemModel*>(this)->fetch_thumbnail_for(node))
-                return FileIconProvider::filetype_image_icon();
+                return FileIconProvider::the().filetype_image_icon();
         }
-        return GUI::Icon(FileIconProvider::filetype_image_icon().bitmap_for_size(16), *node.thumbnail);
+        return GUI::Icon(FileIconProvider::the().filetype_image_icon().bitmap_for_size(16), *node.thumbnail);
     }
 
     if (node.is_directory()) {
         if (node.full_path() == Core::StandardPaths::home_directory()) {
             if (node.is_selected())
-                return FileIconProvider::home_directory_open_icon();
-            return FileIconProvider::home_directory_icon();
+                return FileIconProvider::the().home_directory_open_icon();
+            return FileIconProvider::the().home_directory_icon();
         }
         if (node.full_path() == Core::StandardPaths::desktop_directory())
-            return FileIconProvider::desktop_directory_icon();
+            return FileIconProvider::the().desktop_directory_icon();
         if (node.is_selected() && node.is_accessible_directory)
-            return FileIconProvider::directory_open_icon();
+            return FileIconProvider::the().directory_open_icon();
     }
 
-    return FileIconProvider::icon_for_path(node.full_path(), node.mode);
+    return FileIconProvider::the().icon_for_path(node.full_path(), node.mode);
 }
 
 static HashMap<String, RefPtr<Gfx::Bitmap>> s_thumbnail_cache;

--- a/Userland/Libraries/LibGUI/RunningProcessesModel.cpp
+++ b/Userland/Libraries/LibGUI/RunningProcessesModel.cpp
@@ -33,7 +33,7 @@ void RunningProcessesModel::update()
             Process process;
             process.pid = it.pid;
             process.uid = it.uid;
-            process.icon = FileIconProvider::icon_for_executable(it.executable).bitmap_for_size(16);
+            process.icon = FileIconProvider::the().icon_for_executable(it.executable).bitmap_for_size(16);
             process.name = it.name;
             m_processes.append(move(process));
         }


### PR DESCRIPTION
Previously this was a class with only static methods, and all of the methods used static variables defined in the `.cpp` file, along with calling some sort of `intialize_*_if_needed()` methods. This patch converts the class to a Singleton, and all the icons are initialized in the constructor when `FileIconProvider::the()` is first called.

Note that in the previous implementation, certain methods could initialize only certain icons if needed, but now all of them are always initialized. Doing the former would still be possible with this implementation, but I don't think there would really be a significant performance penalty, and the code is much cleaner this way IMO. Happy to change this back if needed.