### PR TITLE
LibTLS: Mark the socket as idle after a TLS-level disconnection

### DIFF
--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -173,8 +173,10 @@ void TLSv12::read_from_socket()
         }
     };
 
-    if (!check_connection_state(true))
+    if (!check_connection_state(true)) {
+        set_idle(true);
         return;
+    }
 
     consume(Core::Socket::read(4 * MiB));
 }


### PR DESCRIPTION
This fixes a bunch of RequestServer spins.
