### PR TITLE
Sepia color filter

### DIFF
--- a/Userland/Applications/PixelPaint/CMakeLists.txt
+++ b/Userland/Applications/PixelPaint/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
     Filters/Invert.cpp
     Filters/LaplaceCardinal.cpp
     Filters/LaplaceDiagonal.cpp
+    Filters/Sepia.cpp
     Filters/Sharpen.cpp
     Image.cpp
     ImageEditor.cpp

--- a/Userland/Applications/PixelPaint/FilterModel.cpp
+++ b/Userland/Applications/PixelPaint/FilterModel.cpp
@@ -17,6 +17,7 @@
 #include "Filters/Invert.h"
 #include "Filters/LaplaceCardinal.h"
 #include "Filters/LaplaceDiagonal.h"
+#include "Filters/Sepia.h"
 #include "Filters/Sharpen.h"
 #include "Layer.h"
 #include <LibGUI/FileIconProvider.h>
@@ -48,6 +49,7 @@ FilterModel::FilterModel(ImageEditor* editor)
     auto color_category = FilterInfo::create_category("Color");
     auto grayscale_filter = FilterInfo::create_filter<Filters::Grayscale>(editor, color_category);
     auto invert_filter = FilterInfo::create_filter<Filters::Invert>(editor, color_category);
+    auto sepia_filter = FilterInfo::create_filter<Filters::Sepia>(editor, color_category);
 
     m_filters.append(color_category);
 

--- a/Userland/Applications/PixelPaint/FilterParams.h
+++ b/Userland/Applications/PixelPaint/FilterParams.h
@@ -19,6 +19,7 @@
 #include <LibGfx/Filters/GrayscaleFilter.h>
 #include <LibGfx/Filters/InvertFilter.h>
 #include <LibGfx/Filters/LaplacianFilter.h>
+#include <LibGfx/Filters/SepiaFilter.h>
 #include <LibGfx/Filters/SharpenFilter.h>
 #include <LibGfx/Filters/SpatialGaussianBlurFilter.h>
 

--- a/Userland/Applications/PixelPaint/Filters/Sepia.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Xavier Defrang <xavier.defrang@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Sepia.h"
+#include "../FilterParams.h"
+#include <LibGUI/Label.h>
+#include <LibGUI/ValueSlider.h>
+
+namespace PixelPaint::Filters {
+
+void Sepia::apply() const
+{
+    if (!m_editor)
+        return;
+    if (auto* layer = m_editor->active_layer()) {
+        Gfx::SepiaFilter filter(m_amount);
+        filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
+        layer->did_modify_bitmap(layer->rect());
+        m_editor->did_complete_action();
+    }
+}
+
+RefPtr<GUI::Widget> Sepia::get_settings_widget()
+{
+    if (!m_settings_widget) {
+        m_settings_widget = GUI::Widget::construct();
+        m_settings_widget->set_layout<GUI::VerticalBoxLayout>();
+
+        auto& name_label = m_settings_widget->add<GUI::Label>("Sepia Filter");
+        name_label.set_font_weight(Gfx::FontWeight::Bold);
+        name_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        name_label.set_fixed_height(20);
+
+        auto& amount_container = m_settings_widget->add<GUI::Widget>();
+        amount_container.set_fixed_height(20);
+        amount_container.set_layout<GUI::HorizontalBoxLayout>();
+        amount_container.layout()->set_margins({ 4, 0, 4, 0 });
+
+        auto& amount_label = amount_container.add<GUI::Label>("Amount:");
+        amount_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        amount_label.set_fixed_size(50, 20);
+
+        auto& amount_slider = amount_container.add<GUI::ValueSlider>(Orientation::Horizontal, "%");
+        amount_slider.set_range(0, 100);
+        amount_slider.set_value(m_amount * 100);
+        amount_slider.on_change = [&](int value) {
+            m_amount = value * 0.01f;
+        };
+    }
+
+    return m_settings_widget;
+}
+
+}

--- a/Userland/Applications/PixelPaint/Filters/Sepia.h
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Xavier Defrang <xavier.defrang@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Filter.h"
+
+namespace PixelPaint::Filters {
+
+class Sepia final : public Filter {
+public:
+    virtual void apply() const override;
+    virtual RefPtr<GUI::Widget> get_settings_widget() override;
+
+    virtual StringView filter_name() override { return "Sepia"sv; }
+
+    Sepia(ImageEditor* editor)
+        : Filter(editor) {};
+
+private:
+    float m_amount { 1.0f };
+};
+
+}

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -232,6 +232,33 @@ public:
         return Color(gray, gray, gray, alpha());
     }
 
+    constexpr Color sepia(float amount = 1.0f) const
+    {
+        auto blend_factor = 1.0f - amount;
+
+        auto r1 = 0.393f + 0.607f * blend_factor;
+        auto r2 = 0.769f - 0.769f * blend_factor;
+        auto r3 = 0.189f - 0.189f * blend_factor;
+
+        auto g1 = 0.349f - 0.349f * blend_factor;
+        auto g2 = 0.686f + 0.314f * blend_factor;
+        auto g3 = 0.168f - 0.168f * blend_factor;
+
+        auto b1 = 0.272f - 0.272f * blend_factor;
+        auto b2 = 0.534f - 0.534f * blend_factor;
+        auto b3 = 0.131f + 0.869f * blend_factor;
+
+        auto r = red();
+        auto g = green();
+        auto b = blue();
+
+        return Color(
+            clamp(lroundf(r * r1 + g * r2 + b * r3), 0, 255),
+            clamp(lroundf(r * g1 + g * g2 + b * g3), 0, 255),
+            clamp(lroundf(r * b1 + g * b2 + b * b3), 0, 255),
+            alpha());
+    }
+
     constexpr Color darkened(float amount = 0.5f) const
     {
         return Color(red() * amount, green() * amount, blue() * amount, alpha());

--- a/Userland/Libraries/LibGfx/Filters/GrayscaleFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GrayscaleFilter.h
@@ -6,40 +6,19 @@
 
 #pragma once
 
-#include <LibGfx/Filters/Filter.h>
+#include <LibGfx/Filters/ColorFilter.h>
 
 namespace Gfx {
 
-class GrayscaleFilter : public Filter {
+class GrayscaleFilter : public ColorFilter {
 public:
     GrayscaleFilter() { }
     virtual ~GrayscaleFilter() { }
 
     virtual char const* class_name() const override { return "GrayscaleFilter"; }
 
-    virtual void apply(Bitmap& target_bitmap, IntRect const& target_rect, Bitmap const& source_bitmap, IntRect const& source_rect) override
-    {
-        // source_rect should be describing the pixels that can be accessed
-        // to apply this filter, while target_rect should describe the area
-        // where to apply the filter on.
-        VERIFY(source_rect.size() == target_rect.size());
-        VERIFY(target_bitmap.rect().contains(target_rect));
-        VERIFY(source_bitmap.rect().contains(source_rect));
-
-        for (auto y = 0; y < source_rect.height(); ++y) {
-            ssize_t source_y = y + source_rect.y();
-            ssize_t target_y = y + target_rect.y();
-            for (auto x = 0; x < source_rect.width(); ++x) {
-                ssize_t source_x = x + source_rect.x();
-                ssize_t target_x = x + target_rect.x();
-
-                auto source_pixel = source_bitmap.get_pixel(source_x, source_y);
-                auto target_color = source_pixel.to_grayscale();
-
-                target_bitmap.set_pixel(target_x, target_y, target_color);
-            }
-        }
-    }
+protected:
+    Color convert_color(Color original) override { return original.to_grayscale(); };
 };
 
 }

--- a/Userland/Libraries/LibGfx/Filters/InvertFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/InvertFilter.h
@@ -6,40 +6,19 @@
 
 #pragma once
 
-#include <LibGfx/Filters/Filter.h>
+#include <LibGfx/Filters/ColorFilter.h>
 
 namespace Gfx {
 
-class InvertFilter : public Filter {
+class InvertFilter : public ColorFilter {
 public:
     InvertFilter() { }
     virtual ~InvertFilter() { }
 
     virtual char const* class_name() const override { return "InvertFilter"; }
 
-    virtual void apply(Bitmap& target_bitmap, IntRect const& target_rect, Bitmap const& source_bitmap, IntRect const& source_rect) override
-    {
-        // source_rect should be describing the pixels that can be accessed
-        // to apply this filter, while target_rect should describe the area
-        // where to apply the filter on.
-        VERIFY(source_rect.size() == target_rect.size());
-        VERIFY(target_bitmap.rect().contains(target_rect));
-        VERIFY(source_bitmap.rect().contains(source_rect));
-
-        for (auto y = 0; y < source_rect.height(); ++y) {
-            ssize_t source_y = y + source_rect.y();
-            ssize_t target_y = y + target_rect.y();
-            for (auto x = 0; x < source_rect.width(); ++x) {
-                ssize_t source_x = x + source_rect.x();
-                ssize_t target_x = x + target_rect.x();
-
-                auto source_pixel = source_bitmap.get_pixel(source_x, source_y);
-                auto target_color = source_pixel.inverted();
-
-                target_bitmap.set_pixel(target_x, target_y, target_color);
-            }
-        }
-    }
+protected:
+    Color convert_color(Color original) override { return original.inverted(); };
 };
 
 }

--- a/Userland/Libraries/LibGfx/Filters/SepiaFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/SepiaFilter.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Xavier Defrang <xavier.defrang@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StdLibExtras.h>
+#include <LibGfx/Filters/ColorFilter.h>
+#include <math.h>
+
+namespace Gfx {
+
+class SepiaFilter : public ColorFilter {
+public:
+    SepiaFilter(float amount = 1.0f)
+        : m_amount(amount)
+    {
+    }
+    virtual ~SepiaFilter() { }
+
+    virtual char const* class_name() const override { return "SepiaFilter"; }
+
+protected:
+    Color convert_color(Color original) override { return original.sepia(m_amount); };
+
+private:
+    float m_amount;
+};
+
+}


### PR DESCRIPTION
In addition to adding a new sepia color filter to LibGfx and PixelPaint, this PR simplifies the implementation of grayscale/invert color filters by inheriting from `ColorFilter` recently introduced to support color-blindness accessibility features.