### PR TITLE
LibGUI+Applications: Add and use `AbstractZoomPanWidget` widget

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.h
+++ b/Userland/Applications/ImageViewer/ViewWidget.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
  * Copyright (c) 2021, Mohsan Ali <mohsan0073@gmail.com>
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,14 +10,13 @@
 #pragma once
 
 #include <LibCore/Timer.h>
-#include <LibGUI/Frame.h>
+#include <LibGUI/AbstractZoomPanWidget.h>
 #include <LibGUI/Painter.h>
-#include <LibGfx/Point.h>
 #include <LibImageDecoderClient/Client.h>
 
 namespace ImageViewer {
 
-class ViewWidget final : public GUI::Frame {
+class ViewWidget final : public GUI::AbstractZoomPanWidget {
     C_OBJECT(ViewWidget)
 public:
     enum Directions {
@@ -30,8 +30,6 @@ public:
 
     const Gfx::Bitmap* bitmap() const { return m_bitmap.ptr(); }
     const String& path() const { return m_path; }
-    void set_scale(float);
-    float scale() { return m_scale; }
     void set_toolbar_height(int height) { m_toolbar_height = height; }
     int toolbar_height() { return m_toolbar_height; }
     bool scaled_for_first_image() { return m_scaled_for_first_image; }
@@ -49,7 +47,6 @@ public:
     void navigate(Directions);
     void load_from_file(const String&);
 
-    Function<void(float)> on_scale_change;
     Function<void()> on_doubleclick;
     Function<void(const GUI::DropEvent&)> on_drop;
     Function<void(const Gfx::Bitmap*)> on_image_change;
@@ -58,34 +55,24 @@ private:
     ViewWidget();
     virtual void doubleclick_event(GUI::MouseEvent&) override;
     virtual void paint_event(GUI::PaintEvent&) override;
-    virtual void resize_event(GUI::ResizeEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
-    virtual void mousemove_event(GUI::MouseEvent&) override;
-    virtual void mousewheel_event(GUI::MouseEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
     void set_bitmap(const Gfx::Bitmap* bitmap);
-    void relayout();
-    void reset_view();
     void animate();
     Vector<String> load_files_from_directory(const String& path) const;
 
     String m_path;
     RefPtr<Gfx::Bitmap> m_bitmap;
-    Gfx::IntRect m_bitmap_rect;
     Optional<ImageDecoderClient::DecodedImage> m_decoded_image;
 
     size_t m_current_frame_index { 0 };
     size_t m_loops_completed { 0 };
     NonnullRefPtr<Core::Timer> m_timer;
 
-    float m_scale { -1 };
     int m_toolbar_height { 28 };
     bool m_scaled_for_first_image { false };
-    Gfx::FloatPoint m_pan_origin;
-    Gfx::IntPoint m_click_position;
-    Gfx::FloatPoint m_saved_pan_origin;
     Vector<String> m_files_in_same_dir;
     Optional<size_t> m_current_index;
     Gfx::Painter::ScalingMode m_scaling_mode { Gfx::Painter::ScalingMode::NearestNeighbor };

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -12,6 +12,7 @@
 #include "Image.h"
 #include "Selection.h"
 #include <AK/Variant.h>
+#include <LibGUI/AbstractZoomPanWidget.h>
 #include <LibGUI/Frame.h>
 #include <LibGUI/UndoStack.h>
 #include <LibGfx/Point.h>
@@ -22,7 +23,7 @@ class Layer;
 class Tool;
 
 class ImageEditor final
-    : public GUI::Frame
+    : public GUI::AbstractZoomPanWidget
     , public ImageClient {
     C_OBJECT(ImageEditor);
 
@@ -68,16 +69,7 @@ public:
         Image
     };
 
-    float scale() const { return m_scale; }
-    void scale_centered_on_position(Gfx::IntPoint const&, float);
     void fit_image_to_view(FitType type = FitType::Image);
-    void reset_scale_and_position();
-    void scale_by(float);
-    void set_absolute_scale(float, bool do_relayout = true);
-    Function<void(float)> on_scale_changed;
-
-    void set_pan_origin(Gfx::FloatPoint const&);
-    Gfx::FloatPoint pan_origin() const { return m_pan_origin; }
 
     Color primary_color() const { return m_primary_color; }
     void set_primary_color(Color);
@@ -101,13 +93,6 @@ public:
     Function<void(Gfx::IntPoint const&)> on_image_mouse_position_change;
 
     Function<void(void)> on_leave;
-
-    Gfx::FloatRect layer_rect_to_editor_rect(Layer const&, Gfx::IntRect const&) const;
-    Gfx::FloatRect image_rect_to_editor_rect(Gfx::IntRect const&) const;
-    Gfx::FloatRect editor_rect_to_image_rect(Gfx::IntRect const&) const;
-    Gfx::FloatPoint layer_position_to_editor_position(Layer const&, Gfx::IntPoint const&) const;
-    Gfx::FloatPoint image_position_to_editor_position(Gfx::IntPoint const&) const;
-    Gfx::FloatPoint editor_position_to_image_position(Gfx::IntPoint const&) const;
 
     bool request_close();
 
@@ -137,11 +122,9 @@ private:
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
-    virtual void mousewheel_event(GUI::MouseEvent&) override;
     virtual void keydown_event(GUI::KeyEvent&) override;
     virtual void keyup_event(GUI::KeyEvent&) override;
     virtual void context_menu_event(GUI::ContextMenuEvent&) override;
-    virtual void resize_event(GUI::ResizeEvent&) override;
     virtual void enter_event(Core::Event&) override;
     virtual void leave_event(Core::Event&) override;
 
@@ -153,9 +136,6 @@ private:
     GUI::MouseEvent event_with_pan_and_scale_applied(GUI::MouseEvent const&) const;
 
     Result<void, String> save_project_to_fd_and_close(int fd) const;
-
-    void clamped_scale_by(float, bool do_relayout);
-    void relayout();
 
     int calculate_ruler_step_size() const;
     Gfx::IntRect mouse_indicator_rect_x() const;
@@ -180,11 +160,6 @@ private:
     Color m_primary_color { Color::Black };
     Color m_secondary_color { Color::White };
 
-    Gfx::IntRect m_editor_image_rect;
-    float m_scale { 1 };
-    Gfx::FloatPoint m_pan_origin;
-    Gfx::FloatPoint m_saved_pan_origin;
-    Gfx::IntPoint m_click_position;
     Gfx::IntPoint m_mouse_position;
 
     int m_ruler_thickness { 20 };

--- a/Userland/Applications/PixelPaint/Selection.cpp
+++ b/Userland/Applications/PixelPaint/Selection.cpp
@@ -55,7 +55,7 @@ void Selection::draw_marching_ants(Gfx::Painter& painter, Mask const& mask) cons
 
     // Only check the visible selection area when drawing for performance
     auto rect = m_editor.rect();
-    rect = Gfx::enclosing_int_rect(m_editor.editor_rect_to_image_rect(rect));
+    rect = Gfx::enclosing_int_rect(m_editor.frame_to_content_rect(rect));
     rect.inflate(step * 2, step * 2); // prevent borders from having visible ants if the selection extends beyond it
 
     // Scan the image horizontally to find vertical borders
@@ -67,7 +67,7 @@ void Selection::draw_marching_ants(Gfx::Painter& painter, Mask const& mask) cons
 
             if (this_selected != previous_selected) {
                 Gfx::IntRect image_pixel { x, y, 1, 1 };
-                auto pixel = m_editor.image_rect_to_editor_rect(image_pixel).to_type<int>();
+                auto pixel = m_editor.content_to_frame_rect(image_pixel).to_type<int>();
                 auto end = max(pixel.top(), pixel.bottom()); // for when the zoom is < 100%
 
                 for (int pixel_y = pixel.top(); pixel_y <= end; pixel_y++) {
@@ -88,7 +88,7 @@ void Selection::draw_marching_ants(Gfx::Painter& painter, Mask const& mask) cons
 
             if (this_selected != previous_selected) {
                 Gfx::IntRect image_pixel { x, y, 1, 1 };
-                auto pixel = m_editor.image_rect_to_editor_rect(image_pixel).to_type<int>();
+                auto pixel = m_editor.content_to_frame_rect(image_pixel).to_type<int>();
                 auto end = max(pixel.left(), pixel.right()); // for when the zoom is < 100%
 
                 for (int pixel_x = pixel.left(); pixel_x <= end; pixel_x++) {

--- a/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/CloneTool.cpp
@@ -102,7 +102,7 @@ void CloneTool::on_second_paint(Layer const*, GUI::PaintEvent& event)
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
 
-    auto sample_pos = m_editor->image_position_to_editor_position(m_sample_location.value());
+    auto sample_pos = m_editor->content_to_frame_position(m_sample_location.value());
     // We don't want the marker to be a single pixel and hide the color.
     auto offset = AK::max(2, size() / 2);
     Gfx::IntRect rect = {

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -107,8 +107,8 @@ void EllipseTool::on_second_paint(Layer const* layer, GUI::PaintEvent& event)
 
     GUI::Painter painter(*m_editor);
     painter.add_clip_rect(event.rect());
-    auto preview_start = m_editor->layer_position_to_editor_position(*layer, m_ellipse_start_position).to_type<int>();
-    auto preview_end = m_editor->layer_position_to_editor_position(*layer, m_ellipse_end_position).to_type<int>();
+    auto preview_start = m_editor->content_to_frame_position(m_ellipse_start_position).to_type<int>();
+    auto preview_end = m_editor->content_to_frame_position(m_ellipse_end_position).to_type<int>();
     draw_using(painter, preview_start, preview_end, AK::max(m_thickness * m_editor->scale(), 1));
 }
 

--- a/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/GuideTool.cpp
@@ -171,7 +171,7 @@ void GuideTool::on_context_menu(Layer*, GUI::ContextMenuEvent& event)
             editor()));
     }
 
-    auto image_position = editor()->editor_position_to_image_position(event.position());
+    auto image_position = editor()->frame_to_content_position(event.position());
     m_context_menu_guide = closest_guide({ (int)image_position.x(), (int)image_position.y() });
     if (m_context_menu_guide)
         m_context_menu->popup(event.screen_position());

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.cpp
@@ -24,11 +24,8 @@ MoveTool::~MoveTool()
 
 void MoveTool::on_mousedown(Layer* layer, MouseEvent& event)
 {
-    if (event.image_event().button() == GUI::MouseButton::Secondary && !m_is_panning) {
-        m_is_panning = true;
-        m_event_origin = event.raw_event().position();
-        m_saved_pan_origin = m_editor->pan_origin();
-        m_editor->set_override_cursor(Gfx::StandardCursor::Drag);
+    if (event.image_event().button() == GUI::MouseButton::Secondary) {
+        m_editor->start_panning(event.raw_event().position());
         return;
     }
 
@@ -48,12 +45,8 @@ void MoveTool::on_mousedown(Layer* layer, MouseEvent& event)
 
 void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
 {
-    if (m_is_panning) {
-        auto& raw_event = event.raw_event();
-        auto delta = raw_event.position() - m_event_origin;
-        m_editor->set_pan_origin(m_saved_pan_origin.translated(
-            -delta.x(),
-            -delta.y()));
+    if (m_editor->is_panning()) {
+        m_editor->pan_to(event.raw_event().position());
         return;
     }
 
@@ -70,8 +63,8 @@ void MoveTool::on_mousemove(Layer* layer, MouseEvent& event)
 
 void MoveTool::on_mouseup(Layer* layer, MouseEvent& event)
 {
-    if (event.image_event().button() == GUI::MouseButton::Secondary && m_is_panning) {
-        m_is_panning = false;
+    if (event.image_event().button() == GUI::MouseButton::Secondary) {
+        m_editor->stop_panning();
         m_editor->set_override_cursor(cursor());
         return;
     }

--- a/Userland/Applications/PixelPaint/Tools/MoveTool.h
+++ b/Userland/Applications/PixelPaint/Tools/MoveTool.h
@@ -25,9 +25,6 @@ private:
     RefPtr<Layer> m_layer_being_moved;
     Gfx::IntPoint m_event_origin;
     Gfx::IntPoint m_layer_origin;
-
-    bool m_is_panning { false };
-    Gfx::FloatPoint m_saved_pan_origin;
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
@@ -134,7 +134,7 @@ void RectangleSelectTool::on_second_paint(Layer const*, GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
 
     auto rect_in_image = Gfx::IntRect::from_two_points(m_selection_start, m_selection_end);
-    auto rect_in_editor = m_editor->image_rect_to_editor_rect(rect_in_image);
+    auto rect_in_editor = m_editor->content_to_frame_rect(rect_in_image);
 
     m_editor->selection().draw_marching_ants(painter, rect_in_editor.to_type<int>());
 }

--- a/Userland/Applications/PixelPaint/Tools/Tool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/Tool.cpp
@@ -55,7 +55,7 @@ void Tool::on_keydown(GUI::KeyEvent& event)
 
 Gfx::IntPoint Tool::editor_stroke_position(Gfx::IntPoint const& pixel_coords, int stroke_thickness) const
 {
-    auto position = m_editor->image_position_to_editor_position(pixel_coords);
+    auto position = m_editor->content_to_frame_position(pixel_coords);
     auto offset = (stroke_thickness % 2 == 0) ? 0 : m_editor->scale() / 2;
     position = position.translated(offset, offset);
     return position.to_type<int>();

--- a/Userland/Applications/PixelPaint/Tools/ZoomTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/ZoomTool.cpp
@@ -27,7 +27,8 @@ void ZoomTool::on_mousedown(Layer*, MouseEvent& event)
         return;
 
     auto scale_factor = (raw_event.button() == GUI::MouseButton::Primary) ? m_sensitivity : -m_sensitivity;
-    m_editor->scale_centered_on_position(raw_event.position(), scale_factor);
+    auto new_scale = AK::exp2(scale_factor);
+    m_editor->scale_centered(new_scale, raw_event.position());
 }
 
 GUI::Widget* ZoomTool::get_properties_widget()

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
@@ -1,0 +1,183 @@
+/*
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "AbstractZoomPanWidget.h"
+
+namespace GUI {
+
+constexpr float wheel_zoom_factor = 8.0f;
+
+void AbstractZoomPanWidget::set_scale(float new_scale)
+{
+    if (m_original_rect.is_null())
+        return;
+
+    m_scale = clamp(new_scale, m_min_scale, m_max_scale);
+    Gfx::IntSize new_size;
+    new_size.set_width(m_original_rect.width() * m_scale);
+    new_size.set_height(m_original_rect.height() * m_scale);
+    m_content_rect.set_size(new_size);
+
+    if (on_scale_change)
+        on_scale_change(m_scale);
+
+    relayout();
+}
+
+void AbstractZoomPanWidget::scale_by(float delta)
+{
+    float new_scale = m_scale * AK::exp2(delta);
+    set_scale(new_scale);
+}
+
+void AbstractZoomPanWidget::scale_centered(float new_scale, Gfx::IntPoint const& center)
+{
+    if (m_original_rect.is_null())
+        return;
+
+    new_scale = clamp(new_scale, m_min_scale, m_max_scale);
+    if (new_scale == m_scale)
+        return;
+
+    Gfx::FloatPoint focus_point {
+        center.x() - width() / 2.0f,
+        center.y() - height() / 2.0f
+    };
+    m_origin = (m_origin + focus_point) * (new_scale / m_scale) - focus_point;
+    set_scale(new_scale);
+}
+
+void AbstractZoomPanWidget::start_panning(Gfx::IntPoint const& position)
+{
+    m_saved_cursor = override_cursor();
+    set_override_cursor(Gfx::StandardCursor::Drag);
+    m_pan_start = m_origin;
+    m_pan_mouse_pos = position;
+    m_is_panning = true;
+}
+
+void AbstractZoomPanWidget::stop_panning()
+{
+    m_is_panning = false;
+    set_override_cursor(m_saved_cursor);
+}
+
+void AbstractZoomPanWidget::pan_to(Gfx::IntPoint const& position)
+{
+    // NOTE: `position` here (and `m_pan_mouse_pos`) are both in frame coordinates, not
+    // content coordinates, by design. The derived class should not have to keep track of
+    // the (zoomed) content coordinates itself, but just pass along the mouse position.
+    auto delta = position - m_pan_mouse_pos;
+    m_origin = m_pan_start.translated(-delta.x(), -delta.y());
+    relayout();
+}
+
+Gfx::FloatPoint AbstractZoomPanWidget::frame_to_content_position(Gfx::IntPoint const& frame_position) const
+{
+    Gfx::FloatPoint content_position;
+    content_position.set_x(((float)frame_position.x() - (float)m_content_rect.x()) / m_scale);
+    content_position.set_y(((float)frame_position.y() - (float)m_content_rect.y()) / m_scale);
+    return content_position;
+}
+
+Gfx::FloatRect AbstractZoomPanWidget::frame_to_content_rect(Gfx::IntRect const& frame_rect) const
+{
+    Gfx::FloatRect content_rect;
+    content_rect.set_location(frame_to_content_position(frame_rect.location()));
+    content_rect.set_width((float)frame_rect.width() / m_scale);
+    content_rect.set_height((float)frame_rect.height() / m_scale);
+    return content_rect;
+}
+
+Gfx::FloatPoint AbstractZoomPanWidget::content_to_frame_position(Gfx::IntPoint const& content_position) const
+{
+    Gfx::FloatPoint frame_position;
+    frame_position.set_x(m_content_rect.x() + ((float)content_position.x() * m_scale));
+    frame_position.set_y(m_content_rect.y() + ((float)content_position.y() * m_scale));
+    return frame_position;
+}
+
+Gfx::FloatRect AbstractZoomPanWidget::content_to_frame_rect(Gfx::IntRect const& content_rect) const
+{
+    Gfx::FloatRect frame_rect;
+    frame_rect.set_location(content_to_frame_position(content_rect.location()));
+    frame_rect.set_width((float)content_rect.width() * m_scale);
+    frame_rect.set_height((float)content_rect.height() * m_scale);
+    return frame_rect;
+}
+
+void AbstractZoomPanWidget::mousewheel_event(GUI::MouseEvent& event)
+{
+    float new_scale = scale() / AK::exp2(event.wheel_delta() / wheel_zoom_factor);
+    scale_centered(new_scale, event.position());
+}
+
+void AbstractZoomPanWidget::mousedown_event(GUI::MouseEvent& event)
+{
+    if (!m_is_panning && event.button() == GUI::MouseButton::Middle) {
+        start_panning(event.position());
+        event.accept();
+        return;
+    }
+}
+
+void AbstractZoomPanWidget::resize_event(GUI::ResizeEvent& event)
+{
+    relayout();
+    GUI::Widget::resize_event(event);
+}
+
+void AbstractZoomPanWidget::mousemove_event(GUI::MouseEvent& event)
+{
+    if (!m_is_panning)
+        return;
+    pan_to(event.position());
+    event.accept();
+}
+
+void AbstractZoomPanWidget::mouseup_event(GUI::MouseEvent& event)
+{
+    if (m_is_panning && event.button() == GUI::MouseButton::Middle) {
+        stop_panning();
+        event.accept();
+        return;
+    }
+}
+
+void AbstractZoomPanWidget::relayout()
+{
+    if (m_original_rect.is_null())
+        return;
+
+    Gfx::IntSize new_size = m_content_rect.size();
+
+    Gfx::IntPoint new_location;
+    new_location.set_x((width() / 2) - (new_size.width() / 2) - m_origin.x());
+    new_location.set_y((height() / 2) - (new_size.height() / 2) - m_origin.y());
+    m_content_rect.set_location(new_location);
+
+    handle_relayout(m_content_rect);
+}
+
+void AbstractZoomPanWidget::reset_view()
+{
+    m_origin = { 0, 0 };
+    set_scale(1.0f);
+}
+
+void AbstractZoomPanWidget::set_content_rect(Gfx::IntRect const& content_rect)
+{
+    m_content_rect = enclosing_int_rect(content_to_frame_rect(content_rect));
+    update();
+}
+
+void AbstractZoomPanWidget::set_scale_bounds(float min_scale, float max_scale)
+{
+    m_min_scale = min_scale;
+    m_max_scale = max_scale;
+}
+
+}

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Frame.h>
+#include <LibGfx/Point.h>
+#include <LibGfx/Rect.h>
+
+namespace GUI {
+
+class AbstractZoomPanWidget : public GUI::Frame {
+    C_OBJECT(AbstractZoomPanWidget);
+
+public:
+    void set_scale(float scale);
+    float scale() const { return m_scale; }
+    void set_scale_bounds(float min_scale, float max_scale);
+
+    void scale_by(float amount);
+    void scale_centered(float new_scale, Gfx::IntPoint const& center);
+
+    bool is_panning() const { return m_is_panning; }
+    void start_panning(Gfx::IntPoint const& position);
+    void stop_panning();
+
+    void pan_to(Gfx::IntPoint const& position);
+
+    // Should be overridden by derived classes if they want updates.
+    virtual void handle_relayout(Gfx::IntRect const&) { update(); }
+    void relayout();
+
+    Gfx::FloatPoint frame_to_content_position(Gfx::IntPoint const& frame_position) const;
+    Gfx::FloatRect frame_to_content_rect(Gfx::IntRect const& frame_rect) const;
+    Gfx::FloatPoint content_to_frame_position(Gfx::IntPoint const& content_position) const;
+    Gfx::FloatRect content_to_frame_rect(Gfx::IntRect const& content_rect) const;
+
+    virtual void mousewheel_event(GUI::MouseEvent& event) override;
+    virtual void mousedown_event(GUI::MouseEvent& event) override;
+    virtual void resize_event(GUI::ResizeEvent& event) override;
+    virtual void mousemove_event(GUI::MouseEvent& event) override;
+    virtual void mouseup_event(GUI::MouseEvent& event) override;
+
+    void set_original_rect(Gfx::IntRect const& rect) { m_original_rect = rect; }
+    void set_content_rect(Gfx::IntRect const& content_rect);
+    void set_origin(Gfx::FloatPoint const& origin) { m_origin = origin; }
+
+    void reset_view();
+
+    Gfx::IntRect content_rect() const { return m_content_rect; }
+
+    Function<void(float)> on_scale_change;
+
+private:
+    Gfx::IntRect m_original_rect;
+    Gfx::IntRect m_content_rect;
+
+    Gfx::IntPoint m_pan_mouse_pos;
+    Gfx::FloatPoint m_origin;
+    Gfx::FloatPoint m_pan_start;
+    bool m_is_panning { false };
+
+    float m_min_scale { 0.1f };
+    float m_max_scale { 10.0f };
+    float m_scale { 1.0f };
+
+    AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_saved_cursor { Gfx::StandardCursor::None };
+};
+
+}

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -9,6 +9,7 @@ set(SOURCES
     AbstractSlider.cpp
     AbstractTableView.cpp
     AbstractView.cpp
+    AbstractZoomPanWidget.cpp
     Action.cpp
     ActionGroup.cpp
     Application.cpp


### PR DESCRIPTION
This is something I've been meaning to get to for a while, and finally got around to making a first draft implementation. The reason for this was to abstract away all the coordinate math for zooming / panning into a reusable class to avoid having it implemented separately in all the applications that need it. Previously, `ImageViewer`, `MandelBrot` and `PixelPaint` all had independent, and slightly different implementations for doing this, and [hard to debug when things went wrong](https://github.com/SerenityOS/serenity/pull/9989).

This PR adds the `AbstractZoomPanWidget` class, and uses it to handle all the panning / zooming for `ImageViewer` and `PixelPaint`. As far as I can see, all functionality seems to be preserved, but I still need to test it some more. The API for the new widget could also perhaps use some improvement, and I'm open to listen to any suggestions for how to make it more ergonomic.

I've not ported the `MandelBrot` application since it seems to be structured very differently, and I wasn't sure how to extract out the logic properly. 