### PR TITLE
InspectorServer: Fix Inspector communication on 64-bit systems

### DIFF
--- a/Userland/Services/InspectorServer/InspectableProcess.cpp
+++ b/Userland/Services/InspectorServer/InspectableProcess.cpp
@@ -73,7 +73,7 @@ String InspectableProcess::wait_for_response()
 void InspectableProcess::send_request(JsonObject const& request)
 {
     auto serialized = request.to_string();
-    auto length = serialized.length();
+    u32 length = serialized.length();
     m_socket->write((u8 const*)&length, sizeof(length));
     m_socket->write(serialized);
 }


### PR DESCRIPTION
`length` was inheriting `size_t` type of the `String::length()`, while everywhere else in the Inspector we expect fixed 32-bit field.
On the architectures where `sizeof(size_t) != sizeof(u32)` this broke the Inspector communication completely.