### PR TITLE
UserspaceEmulator: Two mmap fixes

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -866,6 +866,7 @@ u32 Emulator::virt$mmap(u32 params_addr)
 {
     Syscall::SC_mmap_params params;
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
+    params.alignment = params.alignment ? params.alignment : PAGE_SIZE;
 
     u32 requested_size = round_up_to_power_of_two(params.size, PAGE_SIZE);
     FlatPtr final_address;

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -868,6 +868,9 @@ u32 Emulator::virt$mmap(u32 params_addr)
     mmu().copy_from_vm(&params, params_addr, sizeof(params));
     params.alignment = params.alignment ? params.alignment : PAGE_SIZE;
 
+    if (params.size == 0)
+        return -EINVAL;
+
     u32 requested_size = round_up_to_power_of_two(params.size, PAGE_SIZE);
     FlatPtr final_address;
 


### PR DESCRIPTION
This PR fixes two issues in UserspaceEmulator:
- a crash I ran into while debugging gzip where UE was trying to allocate memory outside of the available range when asked to mmap with alignment 0,
- a posixly-incorrect error reported by mmap, which would fail with ENOMEM when called with size 0 instead of the correct EINVAL.