### PR TITLE
LibSoftGPU: Configurable stats overlay period

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -16,6 +16,7 @@ namespace SoftGPU {
 
 static constexpr bool ENABLE_STATISTICS_OVERLAY = false;
 static constexpr int NUM_SAMPLERS = 2;
+static constexpr int MILLISECONDS_PER_STATISTICS_PERIOD = 500;
 static constexpr int SUBPIXEL_BITS = 5;
 static constexpr int NUM_LIGHTS = 8;
 

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1224,7 +1224,7 @@ void Device::draw_statistics_overlay(Gfx::Bitmap& target)
 
     Gfx::Painter painter { target };
 
-    if (milliseconds > 500) {
+    if (milliseconds > MILLISECONDS_PER_STATISTICS_PERIOD) {
 
         int num_rendertarget_pixels = m_render_target->width() * m_render_target->height();
 


### PR DESCRIPTION
Problem:
- The statistics overlay period is hardcoded to 500 ms. This time is
  very short and can result in the values being very "jumpy".

Solution:
- Increasing this value can result in more steady values which is
  useful when trying to evaluate the performance impact of a change. A
  new config value is offered in `Config.h` to let the developer
  change to any value desired.