### PR TITLE
PixelPaint+LibGUI: Disable actions when no ImageEditor is open + related bug fixes

### DIFF
--- a/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerPropertiesWidget.cpp
@@ -75,7 +75,7 @@ void LayerPropertiesWidget::set_layer(Layer* layer)
         return;
 
     if (layer) {
-        m_layer = layer->make_weak_ptr();
+        m_layer = layer;
         m_name_textbox->set_text(layer->name());
         m_opacity_slider->set_value(layer->opacity_percent());
         m_visibility_checkbox->set_checked(layer->is_visible());

--- a/Userland/Applications/PixelPaint/LayerPropertiesWidget.h
+++ b/Userland/Applications/PixelPaint/LayerPropertiesWidget.h
@@ -27,7 +27,7 @@ private:
     RefPtr<GUI::OpacitySlider> m_opacity_slider;
     RefPtr<GUI::TextBox> m_name_textbox;
 
-    WeakPtr<Layer> m_layer;
+    RefPtr<Layer> m_layer;
 };
 
 }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -71,6 +71,7 @@ MainWidget::MainWidget()
                 if (m_tab_widget->children().size() == 0) {
                     m_layer_list_widget->set_image(nullptr);
                     m_layer_properties_widget->set_layer(nullptr);
+                    m_palette_widget->set_image_editor(nullptr);
                 }
             });
         }
@@ -78,7 +79,7 @@ MainWidget::MainWidget()
 
     m_tab_widget->on_change = [&](auto& widget) {
         auto& image_editor = verify_cast<PixelPaint::ImageEditor>(widget);
-        m_palette_widget->set_image_editor(image_editor);
+        m_palette_widget->set_image_editor(&image_editor);
         m_layer_list_widget->set_image(&image_editor.image());
         m_layer_properties_widget->set_layer(image_editor.active_layer());
         if (auto* active_tool = m_toolbox->active_tool())

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -20,6 +20,7 @@
 #include <LibGUI/Action.h>
 #include <LibGUI/ComboBox.h>
 #include <LibGUI/Forward.h>
+#include <LibGUI/Menu.h>
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/Widget.h>
@@ -46,6 +47,8 @@ private:
     ImageEditor& create_new_editor(NonnullRefPtr<Image>);
     void create_image_from_clipboard();
 
+    void set_actions_enabled(bool enabled);
+
     virtual void drop_event(GUI::DropEvent&) override;
 
     ProjectLoader m_loader;
@@ -59,11 +62,20 @@ private:
     RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<GUI::ComboBox> m_zoom_combobox;
 
+    RefPtr<GUI::Menu> m_export_submenu;
+    RefPtr<GUI::Menu> m_edit_menu;
+    RefPtr<GUI::Menu> m_view_menu;
+    RefPtr<GUI::Menu> m_tool_menu;
+    RefPtr<GUI::Menu> m_image_menu;
+    RefPtr<GUI::Menu> m_layer_menu;
+    RefPtr<GUI::Menu> m_filter_menu;
+
     RefPtr<GUI::Action> m_new_image_action;
     RefPtr<GUI::Action> m_new_image_from_clipboard_action;
     RefPtr<GUI::Action> m_open_image_action;
     RefPtr<GUI::Action> m_save_image_action;
     RefPtr<GUI::Action> m_save_image_as_action;
+    RefPtr<GUI::Action> m_close_image_action;
 
     RefPtr<GUI::Action> m_copy_action;
     RefPtr<GUI::Action> m_copy_merged_action;

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -143,17 +143,20 @@ PaletteWidget::PaletteWidget()
     display_color_list(result.value());
 }
 
-void PaletteWidget::set_image_editor(ImageEditor& editor)
+void PaletteWidget::set_image_editor(ImageEditor* editor)
 {
-    m_editor = &editor;
-    set_primary_color(editor.primary_color());
-    set_secondary_color(editor.secondary_color());
+    m_editor = editor;
+    if (!m_editor)
+        return;
 
-    editor.on_primary_color_change = [this](Color color) {
+    set_primary_color(editor->primary_color());
+    set_secondary_color(editor->secondary_color());
+
+    editor->on_primary_color_change = [this](Color color) {
         set_primary_color(color);
     };
 
-    editor.on_secondary_color_change = [this](Color color) {
+    editor->on_secondary_color_change = [this](Color color) {
         set_secondary_color(color);
     };
 }
@@ -164,13 +167,15 @@ PaletteWidget::~PaletteWidget()
 
 void PaletteWidget::set_primary_color(Color color)
 {
-    m_editor->set_primary_color(color);
+    if (m_editor)
+        m_editor->set_primary_color(color);
     m_primary_color_widget->set_background_color(color);
 }
 
 void PaletteWidget::set_secondary_color(Color color)
 {
-    m_editor->set_secondary_color(color);
+    if (m_editor)
+        m_editor->set_secondary_color(color);
     m_secondary_color_widget->set_background_color(color);
 }
 

--- a/Userland/Applications/PixelPaint/PaletteWidget.h
+++ b/Userland/Applications/PixelPaint/PaletteWidget.h
@@ -35,7 +35,7 @@ public:
     static Result<void, String> save_palette_fd_and_close(Vector<Color>, int);
     static Vector<Color> fallback_colors();
 
-    void set_image_editor(ImageEditor&);
+    void set_image_editor(ImageEditor*);
 
 private:
     static Result<Vector<Color>, String> load_palette_file(Core::File&);

--- a/Userland/Libraries/LibGUI/Menu.cpp
+++ b/Userland/Libraries/LibGUI/Menu.cpp
@@ -164,6 +164,14 @@ Action* Menu::action_at(size_t index)
     return m_items[index].action();
 }
 
+void Menu::set_children_actions_enabled(bool enabled)
+{
+    for (auto& item : m_items) {
+        if (item.action())
+            item.action()->set_enabled(enabled);
+    }
+}
+
 void Menu::visibility_did_change(Badge<WindowServerConnection>, bool visible)
 {
     if (m_visible == visible)

--- a/Userland/Libraries/LibGUI/Menu.h
+++ b/Userland/Libraries/LibGUI/Menu.h
@@ -45,6 +45,8 @@ public:
 
     void visibility_did_change(Badge<WindowServerConnection>, bool visible);
 
+    void set_children_actions_enabled(bool enabled);
+
     Function<void(bool)> on_visibility_change;
 
     bool is_visible() const { return m_visible; }


### PR DESCRIPTION
This PR adresses some issues with how PixelPaint handled not having an active ImageEditor open, ie when all tabs are closed.
Firstly it disables all actions that would need an ImageEditor and enables them when a new one is created.
Secondly it fixes some bugs where the LayerPropertiesWidget and PaletteWidget didn't handle not having having an ImageEditor properly.

A helper function is added in LibGUI to enable/disable multiple actions at the same time.

**PixelPaint: Make PaletteWidget::set_image_editor take a ImageEditor*** 
After closing the last open ImageEditor, selecting a color would try to dereference it causing a crash. Instead make `set_image_editor()` take a pointer to it and set it to nullptr when closing the last tab like we do with LayerListWidget and LayerPropertiesWidget.

**PixelPaint: Keep a RefPtr to layer in LayerPropertiesWidget** 
Using a WeakPtr to keep a reference to the active layer caused it to be destroyed when the last tab was closed, which made the `m_layer == layer` check in `set_layer()` return early since it was already null. Because of this the LayerPropertiesWidget was never disabled.

**LibGUI: Add Menu::set_children_actions_enabled() helper** 
This adds a helper function to Menu that allows us to set all the children enabled/disabled.

**PixelPaint: Disable actions when no ImageEditor is open** 
Disable all actions when the last tab is closed and enable them when a new ImageEditor is created.

**PixelPaint: Verify that we have an ImageEditor instead of returning** 
We should never be in a state where an action requiring an ImageEditor is enabled if all tabs are closed.