### PR TITLE
Meta: Do not allow undefined symbols in executables and shared objects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,10 +204,10 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
 
     # Clang doesn't add compiler_rt to the search path when compiling with -nostdlib.
     link_directories(${TOOLCHAIN_ROOT}/lib/clang/${CMAKE_CXX_COMPILER_VERSION}/lib/${SERENITY_ARCH}-pc-serenity/)
-    add_link_options(LINKER:--allow-shlib-undefined)
 endif()
 
 add_link_options(LINKER:-z,text)
+add_link_options(LINKER:--no-allow-shlib-undefined)
 
 add_compile_definitions(SANITIZE_PTRS)
 set(CMAKE_CXX_FLAGS_STATIC "${CMAKE_CXX_FLAGS} -static")

--- a/Userland/Libraries/LibCrypto/CMakeLists.txt
+++ b/Userland/Libraries/LibCrypto/CMakeLists.txt
@@ -25,4 +25,4 @@ set(SOURCES
 )
 
 serenity_lib(LibCrypto crypto)
-target_link_libraries(LibCrypto LibC)
+target_link_libraries(LibCrypto LibC LibCore)


### PR DESCRIPTION
The `--allow-shlib-undefined` option is a bit of a misnomer. It actually
controls whether we should be allowed to have undefined references after
symbols from all dependencies have been resolved, so it applies both to
shared libraries and executables.

LLD defaults to allowing undefined references in shared libraries, but
not in executables. Previously, we had to disable this check for
executables too, as it caused a build failure due to the
LibC-LibPthread-libc++ and the LibCore-LibCrypto circular dependencies.

Now that those have been resolved, we can enable this warning, in the
hopes that it will prevent us from introducing circular libraries and
missing dependencies that might cause unexpected breakage.