### PR TITLE
Ports: add interactive mode to .port_include.sh

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -547,8 +547,12 @@ parse_arguments() {
             shift
             parse_arguments $@
             ;;
+        interactive)
+            export PS1="(serenity):\w$ "
+            bash --norc
+            ;;
         *)
-            >&2 echo "I don't understand $1! Supported arguments: fetch, patch, configure, build, install, installdepends, clean, clean_dist, clean_all, uninstall, showproperty."
+            >&2 echo "I don't understand $1! Supported arguments: fetch, patch, configure, build, install, installdepends, interactive, clean, clean_dist, clean_all, uninstall, showproperty."
             exit 1
             ;;
     esac


### PR DESCRIPTION
Running `./package.sh interactive` in a port directory will
spawn a new shell with the serenity build environment set up.
This makes porting software much easier as build commands can
be run interactively instead of having to modify package.sh
just to test things.