### PR TITLE
PixelPaint: Move out common logic from Filters into base class

### DIFF
--- a/Userland/Applications/PixelPaint/Filters/Bloom.h
+++ b/Userland/Applications/PixelPaint/Filters/Bloom.h
@@ -12,7 +12,8 @@ namespace PixelPaint::Filters {
 
 class Bloom final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
+
     virtual RefPtr<GUI::Widget> get_settings_widget() override;
 
     virtual StringView filter_name() override { return "Bloom Filter"sv; }

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur3.cpp
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur3.cpp
@@ -9,18 +9,11 @@
 
 namespace PixelPaint::Filters {
 
-void BoxBlur3::apply() const
+void BoxBlur3::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::BoxBlurFilter<3> filter;
-        if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<3>>::get()) {
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-            layer->did_modify_bitmap(layer->rect());
-            m_editor->did_complete_action();
-        }
-    }
+    Gfx::BoxBlurFilter<3> filter;
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<3>>::get())
+        filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur3.h
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur3.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class BoxBlur3 final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Box Blur (3x3)"sv; }
 
     BoxBlur3(ImageEditor* editor)

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur5.cpp
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur5.cpp
@@ -9,18 +9,11 @@
 
 namespace PixelPaint::Filters {
 
-void BoxBlur5::apply() const
+void BoxBlur5::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::BoxBlurFilter<5> filter;
-        if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<5>>::get()) {
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-            layer->did_modify_bitmap(layer->rect());
-            m_editor->did_complete_action();
-        }
-    }
+    Gfx::BoxBlurFilter<5> filter;
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::BoxBlurFilter<5>>::get())
+        filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/BoxBlur5.h
+++ b/Userland/Applications/PixelPaint/Filters/BoxBlur5.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class BoxBlur5 final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Box Blur (5x5)"sv; }
 
     BoxBlur5(ImageEditor* editor)

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class FastBoxBlur final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual RefPtr<GUI::Widget> get_settings_widget() override;
 
     virtual StringView filter_name() override { return "Fast Box Blur (& Gauss)"sv; }

--- a/Userland/Applications/PixelPaint/Filters/Filter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Filter.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,6 +24,17 @@ RefPtr<GUI::Widget> Filter::get_settings_widget()
     }
 
     return m_settings_widget.ptr();
+}
+
+void Filter::apply() const
+{
+    if (!m_editor)
+        return;
+    if (auto* layer = m_editor->active_layer()) {
+        apply(layer->bitmap(), layer->bitmap());
+        layer->did_modify_bitmap(layer->rect());
+        m_editor->did_complete_action();
+    }
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/Filter.h
+++ b/Userland/Applications/PixelPaint/Filters/Filter.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,7 +15,9 @@ namespace PixelPaint {
 
 class Filter {
 public:
-    virtual void apply() const = 0;
+    virtual void apply() const;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const = 0;
+
     virtual RefPtr<GUI::Widget> get_settings_widget();
 
     virtual StringView filter_name() = 0;

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur3.cpp
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur3.cpp
@@ -9,18 +9,11 @@
 
 namespace PixelPaint::Filters {
 
-void GaussBlur3::apply() const
+void GaussBlur3::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::SpatialGaussianBlurFilter<3> filter;
-        if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<3>>::get()) {
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-            layer->did_modify_bitmap(layer->rect());
-            m_editor->did_complete_action();
-        }
-    }
+    Gfx::SpatialGaussianBlurFilter<3> filter;
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<3>>::get())
+        filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur3.h
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur3.h
@@ -13,7 +13,7 @@ namespace PixelPaint::Filters {
 // FIXME: Make a generic gaussian blur that does not need the templated radius
 class GaussBlur3 final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Gaussian Blur (3x3)"sv; }
 
     GaussBlur3(ImageEditor* editor)

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur5.cpp
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur5.cpp
@@ -9,18 +9,11 @@
 
 namespace PixelPaint::Filters {
 
-void GaussBlur5::apply() const
+void GaussBlur5::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::SpatialGaussianBlurFilter<5> filter;
-        if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<5>>::get()) {
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-            layer->did_modify_bitmap(layer->rect());
-            m_editor->did_complete_action();
-        }
-    }
+    Gfx::SpatialGaussianBlurFilter<5> filter;
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::SpatialGaussianBlurFilter<5>>::get())
+        filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/GaussBlur5.h
+++ b/Userland/Applications/PixelPaint/Filters/GaussBlur5.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class GaussBlur5 final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Gaussian Blur (5x5)"sv; }
 
     GaussBlur5(ImageEditor* editor)

--- a/Userland/Applications/PixelPaint/Filters/Grayscale.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Grayscale.cpp
@@ -9,16 +9,10 @@
 
 namespace PixelPaint::Filters {
 
-void Grayscale::apply() const
+void Grayscale::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::GrayscaleFilter filter;
-        filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
-        layer->did_modify_bitmap(layer->rect());
-        m_editor->did_complete_action();
-    }
+    Gfx::GrayscaleFilter filter;
+    filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect());
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/Grayscale.h
+++ b/Userland/Applications/PixelPaint/Filters/Grayscale.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class Grayscale final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Grayscale"sv; }
 
     Grayscale(ImageEditor* editor)

--- a/Userland/Applications/PixelPaint/Filters/Invert.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Invert.cpp
@@ -9,16 +9,10 @@
 
 namespace PixelPaint::Filters {
 
-void Invert::apply() const
+void Invert::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::InvertFilter filter;
-        filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
-        layer->did_modify_bitmap(layer->rect());
-        m_editor->did_complete_action();
-    }
+    Gfx::InvertFilter filter;
+    filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect());
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/Invert.h
+++ b/Userland/Applications/PixelPaint/Filters/Invert.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class Invert final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Invert"sv; }
 
     Invert(ImageEditor* editor)

--- a/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.cpp
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.cpp
@@ -9,18 +9,11 @@
 
 namespace PixelPaint::Filters {
 
-void LaplaceCardinal::apply() const
+void LaplaceCardinal::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::LaplacianFilter filter;
-        if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(false)) {
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-            layer->did_modify_bitmap(layer->rect());
-            m_editor->did_complete_action();
-        }
-    }
+    Gfx::LaplacianFilter filter;
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(false))
+        filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.h
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceCardinal.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class LaplaceCardinal final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Laplacian Cardinal"sv; }
 
     LaplaceCardinal(ImageEditor* editor)

--- a/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.cpp
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.cpp
@@ -9,18 +9,11 @@
 
 namespace PixelPaint::Filters {
 
-void LaplaceDiagonal::apply() const
+void LaplaceDiagonal::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::LaplacianFilter filter;
-        if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(true)) {
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-            layer->did_modify_bitmap(layer->rect());
-            m_editor->did_complete_action();
-        }
-    }
+    Gfx::LaplacianFilter filter;
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::LaplacianFilter>::get(true))
+        filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.h
+++ b/Userland/Applications/PixelPaint/Filters/LaplaceDiagonal.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class LaplaceDiagonal final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Laplacian Diagonal"sv; }
 
     LaplaceDiagonal(ImageEditor* editor)

--- a/Userland/Applications/PixelPaint/Filters/Sepia.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.cpp
@@ -11,16 +11,10 @@
 
 namespace PixelPaint::Filters {
 
-void Sepia::apply() const
+void Sepia::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::SepiaFilter filter(m_amount);
-        filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect());
-        layer->did_modify_bitmap(layer->rect());
-        m_editor->did_complete_action();
-    }
+    Gfx::SepiaFilter filter(m_amount);
+    filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect());
 }
 
 RefPtr<GUI::Widget> Sepia::get_settings_widget()

--- a/Userland/Applications/PixelPaint/Filters/Sepia.h
+++ b/Userland/Applications/PixelPaint/Filters/Sepia.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class Sepia final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual RefPtr<GUI::Widget> get_settings_widget() override;
 
     virtual StringView filter_name() override { return "Sepia"sv; }

--- a/Userland/Applications/PixelPaint/Filters/Sharpen.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Sharpen.cpp
@@ -9,18 +9,11 @@
 
 namespace PixelPaint::Filters {
 
-void Sharpen::apply() const
+void Sharpen::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const
 {
-    if (!m_editor)
-        return;
-    if (auto* layer = m_editor->active_layer()) {
-        Gfx::SharpenFilter filter;
-        if (auto parameters = PixelPaint::FilterParameters<Gfx::SharpenFilter>::get()) {
-            filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
-            layer->did_modify_bitmap(layer->rect());
-            m_editor->did_complete_action();
-        }
-    }
+    Gfx::SharpenFilter filter;
+    if (auto parameters = PixelPaint::FilterParameters<Gfx::SharpenFilter>::get())
+        filter.apply(target_bitmap, target_bitmap.rect(), source_bitmap, source_bitmap.rect(), *parameters);
 }
 
 }

--- a/Userland/Applications/PixelPaint/Filters/Sharpen.h
+++ b/Userland/Applications/PixelPaint/Filters/Sharpen.h
@@ -12,7 +12,7 @@ namespace PixelPaint::Filters {
 
 class Sharpen final : public Filter {
 public:
-    virtual void apply() const override;
+    virtual void apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bitmap) const override;
     virtual StringView filter_name() override { return "Sharpen"sv; }
 
     Sharpen(ImageEditor* editor)


### PR DESCRIPTION
With this patch, each new filter only has to describe how to actually change
the bitmaps, and the common logic of pulling out the bitmap from the layer, 
and marking the action as done, etc is all handled in the `Filter` base class.

This also makes it possible to apply filters to external bitmaps, which are not 
embedded in a `Layer` (which we can use to preview filters in the future!)