### PR TITLE
Kernel: Harden Socket::pseudo_path(..) implementations against OOM

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -474,24 +474,24 @@ ErrorOr<NonnullOwnPtr<KString>> IPv4Socket::pseudo_path(const OpenFileDescriptio
         return KString::try_create("socket"sv);
 
     StringBuilder builder;
-    builder.append("socket:");
+    TRY(builder.try_append("socket:"));
 
-    builder.appendff("{}:{}", m_local_address.to_string(), m_local_port);
+    TRY(builder.try_appendff("{}:{}", m_local_address.to_string(), m_local_port));
     if (m_role == Role::Accepted || m_role == Role::Connected)
-        builder.appendff(" / {}:{}", m_peer_address.to_string(), m_peer_port);
+        TRY(builder.try_appendff(" / {}:{}", m_peer_address.to_string(), m_peer_port));
 
     switch (m_role) {
     case Role::Listener:
-        builder.append(" (listening)");
+        TRY(builder.try_append(" (listening)"));
         break;
     case Role::Accepted:
-        builder.append(" (accepted)");
+        TRY(builder.try_append(" (accepted)"));
         break;
     case Role::Connected:
-        builder.append(" (connected)");
+        TRY(builder.try_append(" (connected)"));
         break;
     case Role::Connecting:
-        builder.append(" (connecting)");
+        TRY(builder.try_append(" (connecting)"));
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -358,21 +358,21 @@ StringView LocalSocket::socket_path() const
 ErrorOr<NonnullOwnPtr<KString>> LocalSocket::pseudo_path(const OpenFileDescription& description) const
 {
     StringBuilder builder;
-    builder.append("socket:");
-    builder.append(socket_path());
+    TRY(builder.try_append("socket:"));
+    TRY(builder.try_append(socket_path()));
 
     switch (role(description)) {
     case Role::Listener:
-        builder.append(" (listening)");
+        TRY(builder.try_append(" (listening)"));
         break;
     case Role::Accepted:
-        builder.appendff(" (accepted from pid {})", origin_pid());
+        TRY(builder.try_appendff(" (accepted from pid {})", origin_pid()));
         break;
     case Role::Connected:
-        builder.appendff(" (connected to pid {})", acceptor_pid());
+        TRY(builder.try_appendff(" (connected to pid {})", acceptor_pid()));
         break;
     case Role::Connecting:
-        builder.append(" (connecting)");
+        TRY(builder.try_append(" (connecting)"));
         break;
     default:
         break;


### PR DESCRIPTION
Use the try variants of AK::StringBuilder append APIs to harden these
functions against OOM.