### PR TITLE
LibGL+LibSoftGPU+3DFileViewer: Implement Fixed Function OpenGL Lighting

### DIFF
--- a/Userland/Applications/3DFileViewer/Mesh.cpp
+++ b/Userland/Applications/3DFileViewer/Mesh.cpp
@@ -33,13 +33,6 @@ Mesh::Mesh(Vector<Vertex> vertices, Vector<TexCoord> tex_coords, Vector<Vertex> 
 
 void Mesh::draw(float uv_scale)
 {
-    // Light direction
-    const FloatVector3 light_direction(1.f, 1.f, 1.f);
-
-    // Mesh color
-    const FloatVector4 mesh_ambient_color(0.2f, 0.2f, 0.2f, 1.f);
-    const FloatVector4 mesh_diffuse_color(0.6f, 0.6f, 0.6f, 1.f);
-
     for (u32 i = 0; i < m_triangle_list.size(); i++) {
         const auto& triangle = m_triangle_list[i];
 
@@ -83,16 +76,13 @@ void Mesh::draw(float uv_scale)
             normal = vec_ab.cross(vec_ac).normalized();
         }
 
-        // Compute lighting with a Lambertian color model
-        const auto light_intensity = max(light_direction.dot(normal), 0.f);
-        const FloatVector4 color = mesh_ambient_color
-            + mesh_diffuse_color * light_intensity;
-
         glBegin(GL_TRIANGLES);
-        glColor4f(color.x(), color.y(), color.z(), color.w());
 
         if (is_textured())
             glTexCoord2f(m_tex_coords.at(triangle.tex_coord_index0).u * uv_scale, (1.0f - m_tex_coords.at(triangle.tex_coord_index0).v) * uv_scale);
+
+        // Upload the face normal
+        glNormal3f(normal.x(), normal.y(), normal.z());
 
         // Vertex 1
         glVertex3f(

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -69,6 +69,12 @@ private:
         glEnable(GL_CULL_FACE);
         glEnable(GL_DEPTH_TEST);
 
+        // Enable lighting
+        glEnable(GL_LIGHTING);
+        glEnable(GL_LIGHT0);
+        glEnable(GL_LIGHT1);
+        glEnable(GL_LIGHT2);
+
         // Set projection matrix
         glMatrixMode(GL_PROJECTION);
         glLoadIdentity();
@@ -159,6 +165,7 @@ void GLContextWidget::mousewheel_event(GUI::MouseEvent& event)
 void GLContextWidget::timer_event(Core::TimerEvent&)
 {
     auto timer = Core::ElapsedTimer::start_new();
+    static unsigned int light_counter = 0;
 
     glCallList(m_init_list);
 
@@ -174,6 +181,23 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
     glRotatef(m_angle_x, 1, 0, 0);
     glRotatef(m_angle_y, 0, 1, 0);
     glRotatef(m_angle_z, 0, 0, 1);
+
+    glPushMatrix();
+    glLoadIdentity();
+    // Disco time ;)
+    GLfloat const light0_position[4] = { -4.0f, 0.0f, 0.0f, 0.0f };
+    GLfloat const light0_diffuse[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+    GLfloat const light1_position[4] = { 4.0f, 0.0f, 0.0f, 0.0f };
+    GLfloat const light1_diffuse[4] = { 0.0f, 1.0f, 0.0f, 0.0f };
+    GLfloat const light2_position[4] = { 0.0f, 5.0f, 0.0f, 0.0f };
+    GLfloat const light2_diffuse[4] = { 0.0f, 0.0f, 1.0f, 0.0f };
+    glLightfv(GL_LIGHT0, GL_POSITION, &light0_position[0]);
+    glLightfv(GL_LIGHT0, GL_DIFFUSE, &light0_diffuse[0]);
+    glLightfv(GL_LIGHT1, GL_POSITION, &light1_position[0]);
+    glLightfv(GL_LIGHT1, GL_DIFFUSE, &light1_diffuse[0]);
+    glLightfv(GL_LIGHT2, GL_POSITION, &light2_position[0]);
+    glLightfv(GL_LIGHT2, GL_DIFFUSE, &light2_diffuse[0]);
+    glPopMatrix();
 
     if (m_texture_enabled) {
         glEnable(GL_TEXTURE_2D);
@@ -195,6 +219,18 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
         auto frame_rate = render_time > 0 ? 1000 / render_time : 0;
         m_stats->set_text(String::formatted("{:.0f} fps, {:.1f} ms", frame_rate, render_time));
         m_accumulated_time = 0;
+
+        glEnable(GL_LIGHT0);
+        glEnable(GL_LIGHT1);
+        glEnable(GL_LIGHT2);
+        light_counter++;
+
+        if ((light_counter % 3) == 0)
+            glDisable(GL_LIGHT0);
+        else if ((light_counter % 3) == 1)
+            glDisable(GL_LIGHT1);
+        else
+            glDisable(GL_LIGHT2);
     }
 
     update();

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -571,7 +571,7 @@ GLAPI void glFogi(GLenum pname, GLint param);
 GLAPI void glPixelStorei(GLenum pname, GLint param);
 GLAPI void glScissor(GLint x, GLint y, GLsizei width, GLsizei height);
 GLAPI void glLightf(GLenum light, GLenum pname, GLfloat param);
-GLAPI void glLightfv(GLenum light, GLenum pname, GLfloat* param);
+GLAPI void glLightfv(GLenum light, GLenum pname, GLfloat const* param);
 GLAPI void glLightModelf(GLenum pname, GLfloat param);
 GLAPI void glLightModelfv(GLenum pname, GLfloat const* params);
 GLAPI void glLightModeli(GLenum pname, GLint param);

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -121,6 +121,8 @@ public:
     virtual void gl_rect(GLdouble x1, GLdouble y1, GLdouble x2, GLdouble y2) = 0;
     virtual void gl_tex_gen(GLenum coord, GLenum pname, GLint param) = 0;
     virtual void gl_tex_gen_floatv(GLenum coord, GLenum pname, GLfloat const* params) = 0;
+    virtual void gl_lightf(GLenum light, GLenum pname, GLfloat param) = 0;
+    virtual void gl_lightfv(GLenum light, GLenum pname, GLfloat const* params) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -110,7 +110,6 @@ public:
     virtual void gl_normal(GLfloat nx, GLfloat ny, GLfloat nz) = 0;
     virtual void gl_normal_pointer(GLenum type, GLsizei stride, void const* pointer) = 0;
     virtual void gl_raster_pos(GLfloat x, GLfloat y, GLfloat z, GLfloat w) = 0;
-    virtual void gl_materialv(GLenum face, GLenum pname, GLfloat const* params) = 0;
     virtual void gl_line_width(GLfloat width) = 0;
     virtual void gl_push_attrib(GLbitfield mask) = 0;
     virtual void gl_pop_attrib() = 0;
@@ -123,6 +122,8 @@ public:
     virtual void gl_tex_gen_floatv(GLenum coord, GLenum pname, GLfloat const* params) = 0;
     virtual void gl_lightf(GLenum light, GLenum pname, GLfloat param) = 0;
     virtual void gl_lightfv(GLenum light, GLenum pname, GLfloat const* params) = 0;
+    virtual void gl_materialf(GLenum face, GLenum pname, GLfloat param) = 0;
+    virtual void gl_materialfv(GLenum face, GLenum pname, GLfloat const* params) = 0;
 
     virtual void present() = 0;
 };

--- a/Userland/Libraries/LibGL/GLLights.cpp
+++ b/Userland/Libraries/LibGL/GLLights.cpp
@@ -51,12 +51,12 @@ void glLightModeli(GLenum pname, GLint param)
 
 void glMaterialf(GLenum face, GLenum pname, GLfloat param)
 {
-    g_gl_context->gl_materialv(face, pname, &param);
+    g_gl_context->gl_materialf(face, pname, param);
 }
 
 void glMaterialfv(GLenum face, GLenum pname, GLfloat const* params)
 {
-    g_gl_context->gl_materialv(face, pname, params);
+    g_gl_context->gl_materialfv(face, pname, params);
 }
 
 void glShadeModel(GLenum mode)

--- a/Userland/Libraries/LibGL/GLLights.cpp
+++ b/Userland/Libraries/LibGL/GLLights.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
  * Copyright (c) 2021, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2022, Jesse Buhagiar <jooster669@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,14 +20,12 @@ void glColorMaterial(GLenum face, GLenum mode)
 
 void glLightf(GLenum light, GLenum pname, GLfloat param)
 {
-    // FIXME: implement
-    dbgln_if(GL_DEBUG, "glLightf({}, {}, {}): unimplemented", light, pname, param);
+    g_gl_context->gl_lightf(light, pname, param);
 }
 
-void glLightfv(GLenum light, GLenum pname, GLfloat* param)
+void glLightfv(GLenum light, GLenum pname, GLfloat const* param)
 {
-    // FIXME: implement
-    dbgln_if(GL_DEBUG, "glLightfv({}, {}, {}): unimplemented", light, pname, param);
+    g_gl_context->gl_lightfv(light, pname, param);
 }
 
 void glLightModelf(GLenum pname, GLfloat param)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -2685,17 +2685,25 @@ void SoftwareGLContext::gl_light_model(GLenum pname, GLfloat x, GLfloat y, GLflo
                              || pname == GL_LIGHT_MODEL_TWO_SIDE),
         GL_INVALID_ENUM);
 
+    auto lighting_params = m_rasterizer.light_model();
+    bool update_lighting_model = false;
+
     switch (pname) {
     case GL_LIGHT_MODEL_AMBIENT:
-        m_light_model_ambient = { x, y, z, w };
+        lighting_params.scene_ambient_color = { x, y, z, w };
+        update_lighting_model = true;
         break;
     case GL_LIGHT_MODEL_TWO_SIDE:
         VERIFY(y == 0.0f && z == 0.0f && w == 0.0f);
-        m_light_model_two_side = x;
+        lighting_params.two_sided_lighting = x;
+        update_lighting_model = true;
         break;
     default:
         VERIFY_NOT_REACHED();
     }
+
+    if (update_lighting_model)
+        m_rasterizer.set_light_model_params(lighting_params);
 }
 
 void SoftwareGLContext::gl_bitmap(GLsizei width, GLsizei height, GLfloat xorig, GLfloat yorig, GLfloat xmove, GLfloat ymove, GLubyte const* bitmap)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -98,6 +98,8 @@ Optional<ContextParameter> SoftwareGLContext::get_context_parameter(GLenum name)
         return ContextParameter { .type = GL_INT, .value = { .integer_value = sizeof(float) * 8 } };
     case GL_LIGHTING:
         return ContextParameter { .type = GL_BOOL, .is_capability = true, .value = { .boolean_value = m_lighting_enabled } };
+    case GL_MAX_LIGHTS:
+        return ContextParameter { .type = GL_INT, .value = { .integer_value = static_cast<GLint>(m_device_info.num_lights) } };
     case GL_MAX_MODELVIEW_STACK_DEPTH:
         return ContextParameter { .type = GL_INT, .value = { .integer_value = MODELVIEW_MATRIX_STACK_LIMIT } };
     case GL_MAX_PROJECTION_STACK_DEPTH:

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -669,6 +669,8 @@ void SoftwareGLContext::gl_enable(GLenum capability)
         break;
     case GL_LIGHTING:
         m_lighting_enabled = true;
+        rasterizer_options.lighting_enabled = true;
+        update_rasterizer_options = true;
         break;
     case GL_NORMALIZE:
         m_normalize = true;
@@ -763,6 +765,8 @@ void SoftwareGLContext::gl_disable(GLenum capability)
         break;
     case GL_LIGHTING:
         m_lighting_enabled = false;
+        rasterizer_options.lighting_enabled = false;
+        update_rasterizer_options = true;
         break;
     case GL_LIGHT0:
     case GL_LIGHT1:

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -698,6 +698,17 @@ void SoftwareGLContext::gl_enable(GLenum capability)
         m_active_texture_unit->set_texture_cube_map_enabled(true);
         m_sampler_config_is_dirty = true;
         break;
+    case GL_LIGHT0:
+    case GL_LIGHT1:
+    case GL_LIGHT2:
+    case GL_LIGHT3:
+    case GL_LIGHT4:
+    case GL_LIGHT5:
+    case GL_LIGHT6:
+    case GL_LIGHT7:
+        m_light_states.at(capability - GL_LIGHT0).is_enabled = true;
+        m_light_state_is_dirty = true;
+        break;
     case GL_TEXTURE_GEN_Q:
     case GL_TEXTURE_GEN_R:
     case GL_TEXTURE_GEN_S:
@@ -752,6 +763,17 @@ void SoftwareGLContext::gl_disable(GLenum capability)
         break;
     case GL_LIGHTING:
         m_lighting_enabled = false;
+        break;
+    case GL_LIGHT0:
+    case GL_LIGHT1:
+    case GL_LIGHT2:
+    case GL_LIGHT3:
+    case GL_LIGHT4:
+    case GL_LIGHT5:
+    case GL_LIGHT6:
+    case GL_LIGHT7:
+        m_light_states.at(capability - GL_LIGHT0).is_enabled = false;
+        m_light_state_is_dirty = true;
         break;
     case GL_NORMALIZE:
         m_normalize = false;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -2650,47 +2650,6 @@ void SoftwareGLContext::gl_raster_pos(GLfloat x, GLfloat y, GLfloat z, GLfloat w
     m_current_raster_position.clip_coordinate_value = w;
 }
 
-void SoftwareGLContext::gl_materialv(GLenum face, GLenum pname, GLfloat const* params)
-{
-    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_materialv, face, pname, params);
-
-    RETURN_WITH_ERROR_IF(!(face == GL_FRONT || face == GL_BACK || face == GL_FRONT_AND_BACK), GL_INVALID_ENUM);
-
-    RETURN_WITH_ERROR_IF(!(pname == GL_AMBIENT
-                             || pname == GL_DIFFUSE
-                             || pname == GL_SPECULAR
-                             || pname == GL_EMISSION
-                             || pname == GL_SHININESS
-                             || pname == GL_AMBIENT_AND_DIFFUSE
-                             || pname == GL_COLOR_INDEXES),
-        GL_INVALID_ENUM);
-
-    GLfloat x, y, z, w;
-
-    switch (pname) {
-    case GL_SHININESS:
-        x = params[0];
-        y = 0.0f;
-        z = 0.0f;
-        w = 0.0f;
-        break;
-    case GL_COLOR_INDEXES:
-        x = params[0];
-        y = params[1];
-        z = params[2];
-        w = 0.0f;
-        break;
-    default:
-        x = params[0];
-        y = params[1];
-        z = params[2];
-        w = params[3];
-    }
-
-    // FIXME: implement this method
-    dbgln_if(GL_DEBUG, "gl_materialv({}, {}, {}, {}, {}, {}): unimplemented", face, pname, x, y, z, w);
-}
-
 void SoftwareGLContext::gl_line_width(GLfloat width)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_line_width, width);
@@ -3021,6 +2980,23 @@ void SoftwareGLContext::sync_light_state()
 
         m_rasterizer.set_light_state(light_id, light);
     }
+
+    for (auto material_id = 0u; material_id < 2u; material_id++) {
+        SoftGPU::Material material;
+        auto const& current_material_state = m_material_states.at(material_id);
+
+        material.ambient = current_material_state.ambient;
+        material.diffuse = current_material_state.diffuse;
+        material.specular = current_material_state.specular;
+        material.emissive = current_material_state.emissive;
+        material.shininess = current_material_state.shininess;
+        material.specular_exponent = current_material_state.specular_exponent;
+        material.ambient_color_index = current_material_state.ambient_color_index;
+        material.diffuse_color_index = current_material_state.diffuse_color_index;
+        material.specular_color_index = current_material_state.specular_color_index;
+
+        m_rasterizer.set_material_state(material_id, material);
+    }
 }
 
 void SoftwareGLContext::sync_device_texcoord_config()
@@ -3169,4 +3145,77 @@ void SoftwareGLContext::gl_lightfv(GLenum light, GLenum pname, GLfloat const* pa
 
     m_light_state_is_dirty = true;
 }
+
+void SoftwareGLContext::gl_materialf(GLenum face, GLenum pname, GLfloat param)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_materialf, face, pname, param);
+    RETURN_WITH_ERROR_IF(!(face == GL_FRONT || face == GL_BACK || face == GL_FRONT_AND_BACK), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(pname != GL_SHININESS, GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(param > 128.0f, GL_INVALID_VALUE);
+
+    switch (face) {
+    case GL_FRONT:
+        m_material_states.at(to_underlying(MaterialFace::Front)).shininess = param;
+        break;
+    case GL_BACK:
+        m_material_states.at(to_underlying(MaterialFace::Back)).shininess = param;
+        break;
+    case GL_FRONT_AND_BACK:
+        m_material_states.at(to_underlying(MaterialFace::Front)).shininess = param;
+        m_material_states.at(to_underlying(MaterialFace::Back)).shininess = param;
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    m_light_state_is_dirty = true;
+}
+
+void SoftwareGLContext::gl_materialfv(GLenum face, GLenum pname, GLfloat const* params)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_materialfv, face, pname, params);
+    RETURN_WITH_ERROR_IF(!(face == GL_FRONT || face == GL_BACK || face == GL_FRONT_AND_BACK), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(!(pname == GL_AMBIENT || pname == GL_DIFFUSE || pname == GL_SPECULAR || pname == GL_EMISSION || pname == GL_SHININESS || pname == GL_AMBIENT_AND_DIFFUSE), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF((pname == GL_SHININESS && *params > 128.0f), GL_INVALID_VALUE);
+
+    auto update_material = [](SoftGPU::Material& material, GLenum pname, GLfloat const* params) {
+        switch (pname) {
+        case GL_AMBIENT:
+            material.ambient = { params[0], params[1], params[2], params[3] };
+            break;
+        case GL_DIFFUSE:
+            material.diffuse = { params[0], params[1], params[2], params[3] };
+            break;
+        case GL_SPECULAR:
+            material.specular = { params[0], params[1], params[2], params[3] };
+            break;
+        case GL_EMISSION:
+            material.emissive = { params[0], params[1], params[2], params[3] };
+            break;
+        case GL_SHININESS:
+            material.shininess = *params;
+            break;
+        case GL_AMBIENT_AND_DIFFUSE:
+            material.ambient = { params[0], params[1], params[2], params[3] };
+            material.diffuse = { params[0], params[1], params[2], params[3] };
+            break;
+        }
+    };
+
+    switch (face) {
+    case GL_FRONT:
+        update_material(m_material_states.at(to_underlying(MaterialFace::Front)), pname, params);
+        break;
+    case GL_BACK:
+        update_material(m_material_states.at(to_underlying(MaterialFace::Back)), pname, params);
+        break;
+    case GL_FRONT_AND_BACK:
+        update_material(m_material_states.at(to_underlying(MaterialFace::Front)), pname, params);
+        update_material(m_material_states.at(to_underlying(MaterialFace::Back)), pname, params);
+        break;
+    }
+
+    m_light_state_is_dirty = true;
+}
+
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -430,8 +430,6 @@ private:
 
     // Lighting configuration
     bool m_lighting_enabled { false };
-    FloatVector4 m_light_model_ambient { 0.2f, 0.2f, 0.2f, 1.0f };
-    GLfloat m_light_model_two_side { 0.0f };
 
     Vector<SoftGPU::Light> m_light_states;
     Array<SoftGPU::Material, 2u> m_material_states;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2021-2022, Jesse Buhagiar <jooster669@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -41,6 +41,11 @@ struct ContextParameter {
     } value;
 };
 
+enum class MaterialFace : u8 {
+    Front = 0,
+    Back = 1,
+};
+
 class SoftwareGLContext : public GLContext {
 public:
     SoftwareGLContext(Gfx::Bitmap&);
@@ -126,7 +131,6 @@ public:
     virtual void gl_normal(GLfloat nx, GLfloat ny, GLfloat nz) override;
     virtual void gl_normal_pointer(GLenum type, GLsizei stride, void const* pointer) override;
     virtual void gl_raster_pos(GLfloat x, GLfloat y, GLfloat z, GLfloat w) override;
-    virtual void gl_materialv(GLenum face, GLenum pname, GLfloat const* params) override;
     virtual void gl_line_width(GLfloat width) override;
     virtual void gl_push_attrib(GLbitfield mask) override;
     virtual void gl_pop_attrib() override;
@@ -139,7 +143,8 @@ public:
     virtual void gl_tex_gen_floatv(GLenum coord, GLenum pname, GLfloat const* params) override;
     virtual void gl_lightf(GLenum light, GLenum pname, GLfloat param) override;
     virtual void gl_lightfv(GLenum light, GLenum pname, GLfloat const* params) override;
-
+    virtual void gl_materialf(GLenum face, GLenum pname, GLfloat param) override;
+    virtual void gl_materialfv(GLenum face, GLenum pname, GLfloat const* params) override;
     virtual void present() override;
 
 private:
@@ -358,7 +363,6 @@ private:
             decltype(&SoftwareGLContext::gl_stencil_op_separate),
             decltype(&SoftwareGLContext::gl_normal),
             decltype(&SoftwareGLContext::gl_raster_pos),
-            decltype(&SoftwareGLContext::gl_materialv),
             decltype(&SoftwareGLContext::gl_line_width),
             decltype(&SoftwareGLContext::gl_push_attrib),
             decltype(&SoftwareGLContext::gl_pop_attrib),
@@ -372,7 +376,9 @@ private:
             decltype(&SoftwareGLContext::gl_fogfv),
             decltype(&SoftwareGLContext::gl_fogi),
             decltype(&SoftwareGLContext::gl_lightf),
-            decltype(&SoftwareGLContext::gl_lightfv)>;
+            decltype(&SoftwareGLContext::gl_lightfv),
+            decltype(&SoftwareGLContext::gl_materialf),
+            decltype(&SoftwareGLContext::gl_materialfv)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;
@@ -428,6 +434,7 @@ private:
     GLfloat m_light_model_two_side { 0.0f };
 
     Vector<SoftGPU::Light> m_light_states;
+    Array<SoftGPU::Material, 2u> m_material_states;
 };
 
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -23,6 +23,7 @@
 #include <LibGfx/Vector3.h>
 #include <LibSoftGPU/Clipper.h>
 #include <LibSoftGPU/Device.h>
+#include <LibSoftGPU/Light/Light.h>
 #include <LibSoftGPU/Vertex.h>
 
 namespace GL {
@@ -136,6 +137,8 @@ public:
     virtual void gl_rect(GLdouble x1, GLdouble y1, GLdouble x2, GLdouble y2) override;
     virtual void gl_tex_gen(GLenum coord, GLenum pname, GLint param) override;
     virtual void gl_tex_gen_floatv(GLenum coord, GLenum pname, GLfloat const* params) override;
+    virtual void gl_lightf(GLenum light, GLenum pname, GLfloat param) override;
+    virtual void gl_lightfv(GLenum light, GLenum pname, GLfloat const* params) override;
 
     virtual void present() override;
 
@@ -143,6 +146,7 @@ private:
     void sync_device_config();
     void sync_device_sampler_config();
     void sync_device_texcoord_config();
+    void sync_light_state();
 
     template<typename T>
     T* store_in_listing(T value)
@@ -286,6 +290,7 @@ private:
     SoftGPU::Device m_rasterizer;
     SoftGPU::DeviceInfo const m_device_info;
     bool m_sampler_config_is_dirty { true };
+    bool m_light_state_is_dirty { true };
 
     struct Listing {
 
@@ -365,7 +370,9 @@ private:
             decltype(&SoftwareGLContext::gl_tex_gen_floatv),
             decltype(&SoftwareGLContext::gl_fogf),
             decltype(&SoftwareGLContext::gl_fogfv),
-            decltype(&SoftwareGLContext::gl_fogi)>;
+            decltype(&SoftwareGLContext::gl_fogi),
+            decltype(&SoftwareGLContext::gl_lightf),
+            decltype(&SoftwareGLContext::gl_lightfv)>;
 
         using ExtraSavedArguments = Variant<
             FloatMatrix4x4>;
@@ -419,6 +426,8 @@ private:
     bool m_lighting_enabled { false };
     FloatVector4 m_light_model_ambient { 0.2f, 0.2f, 0.2f, 1.0f };
     GLfloat m_light_model_two_side { 0.0f };
+
+    Vector<SoftGPU::Light> m_light_states;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -17,6 +17,7 @@ namespace SoftGPU {
 static constexpr bool ENABLE_STATISTICS_OVERLAY = false;
 static constexpr int NUM_SAMPLERS = 32;
 static constexpr int SUBPIXEL_BITS = 5;
+static constexpr int NUM_LIGHTS = 8;
 
 // See: https://www.khronos.org/opengl/wiki/Common_Mistakes#Texture_edge_color_problem
 // FIXME: make this dynamically configurable through ConfigServer

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1009,4 +1009,9 @@ void Device::set_light_state(unsigned int light_id, Light const& light)
     m_lights.at(light_id) = light;
 }
 
+void Device::set_material_state(unsigned int material_id, Material const& material)
+{
+    m_materials.at(material_id) = material;
+}
+
 }

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -970,6 +970,15 @@ void Device::set_options(const RasterizerOptions& options)
     // FIXME: Recreate or reinitialize render threads here when multithreading is being implemented
 }
 
+void Device::set_light_model_params(const LightModelParameters& lighting_model)
+{
+    wait_for_all_threads();
+
+    m_lighting_model = lighting_model;
+
+    // FIXME: Recreate or reinitialize render threads here when multithreading is being implemented
+}
+
 Gfx::RGBA32 Device::get_backbuffer_pixel(int x, int y)
 {
     // FIXME: Reading individual pixels is very slow, rewrite this to transfer whole blocks

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -636,6 +636,11 @@ void Device::draw_primitives(PrimitiveType primitive_type, FloatMatrix4x4 const&
         triangle.vertices[1].eye_coordinates = model_view_transform * triangle.vertices[1].position;
         triangle.vertices[2].eye_coordinates = model_view_transform * triangle.vertices[2].position;
 
+        // Transform the vertex normals into eye-space
+        triangle.vertices[0].normal = transform_direction(model_view_transform, triangle.vertices[0].normal);
+        triangle.vertices[1].normal = transform_direction(model_view_transform, triangle.vertices[1].normal);
+        triangle.vertices[2].normal = transform_direction(model_view_transform, triangle.vertices[2].normal);
+
         // Transform eye coordinates into clip coordinates using the projection transform
         triangle.vertices[0].clip_coordinates = projection_transform * triangle.vertices[0].eye_coordinates;
         triangle.vertices[1].clip_coordinates = projection_transform * triangle.vertices[1].eye_coordinates;

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1004,4 +1004,9 @@ void Device::set_sampler_config(unsigned sampler, SamplerConfig const& config)
     m_samplers[sampler].set_config(config);
 }
 
+void Device::set_light_state(unsigned int light_id, Light const& light)
+{
+    m_lights.at(light_id) = light;
+}
+
 }

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -476,7 +476,8 @@ DeviceInfo Device::info() const
     return {
         .vendor_name = "SerenityOS",
         .device_name = "SoftGPU",
-        .num_texture_units = NUM_SAMPLERS
+        .num_texture_units = NUM_SAMPLERS,
+        .num_lights = NUM_LIGHTS
     };
 }
 

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -22,6 +22,7 @@
 #include <LibSoftGPU/Enums.h>
 #include <LibSoftGPU/Image.h>
 #include <LibSoftGPU/ImageFormat.h>
+#include <LibSoftGPU/Light/Light.h>
 #include <LibSoftGPU/Sampler.h>
 #include <LibSoftGPU/Triangle.h>
 #include <LibSoftGPU/Vertex.h>
@@ -92,6 +93,7 @@ public:
     NonnullRefPtr<Image> create_image(ImageFormat, unsigned width, unsigned height, unsigned depth, unsigned levels, unsigned layers);
 
     void set_sampler_config(unsigned, SamplerConfig const&);
+    void set_light_state(unsigned, Light const&);
 
 private:
     void draw_statistics_overlay(Gfx::Bitmap&);
@@ -112,6 +114,7 @@ private:
     Array<Sampler, NUM_SAMPLERS> m_samplers;
     Vector<size_t> m_enabled_texture_units;
     AlphaBlendFactors m_alpha_blend_factors;
+    Array<Light, NUM_LIGHTS> m_lights;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -71,6 +71,13 @@ struct RasterizerOptions {
     Gfx::IntRect viewport;
 };
 
+struct LightModelParameters {
+    FloatVector4 scene_ambient_color { 0.2f, 0.2f, 0.2f, 1.0f };
+    bool viewer_at_infinity { false };
+    unsigned int single_color { 0x81F9 }; // This is the value of `GL_SINGLE_COLOR`. Considering we definitely don't leak gl.h stuff into here, we fix it to the gl.h macro value.
+    bool two_sided_lighting { false };
+};
+
 struct PixelQuad;
 
 class Device final {
@@ -87,7 +94,9 @@ public:
     void blit_to(Gfx::Bitmap&);
     void wait_for_all_threads() const;
     void set_options(const RasterizerOptions&);
+    void set_light_model_params(const LightModelParameters&);
     RasterizerOptions options() const { return m_options; }
+    LightModelParameters light_model() const { return m_lighting_model; }
     Gfx::RGBA32 get_backbuffer_pixel(int x, int y);
     float get_depthbuffer_value(int x, int y);
 
@@ -109,6 +118,7 @@ private:
     RefPtr<Gfx::Bitmap> m_render_target;
     OwnPtr<DepthBuffer> m_depth_buffer;
     RasterizerOptions m_options;
+    LightModelParameters m_lighting_model;
     Clipper m_clipper;
     Vector<Triangle> m_triangle_list;
     Vector<Triangle> m_processed_triangles;

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -69,6 +69,7 @@ struct RasterizerOptions {
     u8 texcoord_generation_enabled_coordinates { TexCoordGenerationCoordinate::None };
     Array<TexCoordGenerationConfig, 4> texcoord_generation_config {};
     Gfx::IntRect viewport;
+    bool lighting_enabled { false };
 };
 
 struct LightModelParameters {

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -23,6 +23,7 @@
 #include <LibSoftGPU/Image.h>
 #include <LibSoftGPU/ImageFormat.h>
 #include <LibSoftGPU/Light/Light.h>
+#include <LibSoftGPU/Light/Material.h>
 #include <LibSoftGPU/Sampler.h>
 #include <LibSoftGPU/Triangle.h>
 #include <LibSoftGPU/Vertex.h>
@@ -94,6 +95,7 @@ public:
 
     void set_sampler_config(unsigned, SamplerConfig const&);
     void set_light_state(unsigned, Light const&);
+    void set_material_state(unsigned, Material const&);
 
 private:
     void draw_statistics_overlay(Gfx::Bitmap&);
@@ -115,6 +117,7 @@ private:
     Vector<size_t> m_enabled_texture_units;
     AlphaBlendFactors m_alpha_blend_factors;
     Array<Light, NUM_LIGHTS> m_lights;
+    Array<Material, 2u> m_materials;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/DeviceInfo.h
+++ b/Userland/Libraries/LibSoftGPU/DeviceInfo.h
@@ -14,6 +14,7 @@ struct DeviceInfo final {
     String vendor_name;
     String device_name;
     unsigned num_texture_units;
+    unsigned num_lights;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/Light/Light.h
+++ b/Userland/Libraries/LibSoftGPU/Light/Light.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Jesse Buhagiar <jooster669@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Vector3.h>
+#include <LibGfx/Vector4.h>
+
+namespace SoftGPU {
+
+struct Light {
+    bool is_enabled { false };
+
+    // According to the OpenGL 1.5 specification, page 56, all of the parameters
+    // for the following data members (positions, colors, and reals) are all
+    // floating point.
+    Vector4<float> ambient_intensity { 0.0f, 0.0f, 0.0f, 1.0f };
+    Vector4<float> diffuse_intensity { 0.0f, 0.0f, 0.0f, 1.0f };
+    Vector4<float> specular_intensity { 0.0f, 0.0f, 0.0f, 1.0f };
+    Vector4<float> position { 0.0f, 0.0f, 1.0f, 0.0f };
+    Vector3<float> spotlight_direction { 0.0f, 0.0f, -1.0f };
+
+    float spotlight_exponent { 0.0f };
+    float spotlight_cutoff_angle { 180.0f };
+    float constant_attenuation { 1.0f };  // This is referred to `k0i` in the OpenGL spec
+    float linear_attenuation { 0.0f };    // This is referred to `k1i` in the OpenGL spec
+    float quadratic_attenuation { 0.0f }; // This is referred to `k2i` in the OpenGL spec
+
+    float spotlight_cutoff_angle_rads { AK::Pi<float> / 180.0f };
+};
+
+}

--- a/Userland/Libraries/LibSoftGPU/Light/Material.h
+++ b/Userland/Libraries/LibSoftGPU/Light/Material.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Jesse Buhagiar <jooster669@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/Vector4.h>
+
+namespace SoftGPU {
+
+struct Material {
+    Vector4<float> ambient { 0.2f, 0.2f, 0.2f, 1.0f };
+    Vector4<float> diffuse { 0.8f, 0.8f, 0.8f, 1.0f };
+    Vector4<float> specular { 0.0f, 0.0f, 0.0f, 1.0f };
+    Vector4<float> emissive { 0.0f, 0.0f, 0.0f, 1.0f };
+    float shininess { 0.0f };
+    float specular_exponent { 0.0f };
+    float ambient_color_index { 0.0f };
+    float diffuse_color_index = { 1.0f };
+    float specular_color_index = { 1.0f };
+};
+
+}


### PR DESCRIPTION
Exactly what's on the box, we now have the "Lighting" part of "Transform & Lighting" implemented, minus specular highlights (the Blinn-Phong, which OpenGL Fixed Function Lighting is based on,  is composed of Ambient, Diffuse and Specular) as the math in the spec is a bit wonky and I don't feel too comfortable implementing it just now.