### PR TITLE
Kernel: Page-align AC'97 audio buffer descriptor list

### DIFF
--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -200,7 +200,8 @@ ErrorOr<size_t> AC97::write(OpenFileDescription&, u64, UserOrKernelBuffer const&
         m_output_buffer = TRY(MM.allocate_dma_buffer_pages(m_output_buffer_page_count * PAGE_SIZE, "AC97 Output buffer"sv, Memory::Region::Access::Write));
     }
     if (!m_buffer_descriptor_list) {
-        constexpr size_t buffer_descriptor_list_size = buffer_descriptor_list_max_entries * sizeof(BufferDescriptorListEntry);
+        size_t buffer_descriptor_list_size = buffer_descriptor_list_max_entries * sizeof(BufferDescriptorListEntry);
+        buffer_descriptor_list_size = TRY(Memory::page_round_up(buffer_descriptor_list_size));
         m_buffer_descriptor_list = TRY(MM.allocate_dma_buffer_pages(buffer_descriptor_list_size, "AC97 Buffer Descriptor List"sv, Memory::Region::Access::Write));
     }
 


### PR DESCRIPTION
This was broken in commit 0a1b34c753 / PR #11687 since the buffer descriptor list size was not page-aligned, and the new `MM.allocate_dma_buffer_pages` expects a page-aligned size.

Example crash:
```
[tuxracer(36:37)]: ASSERTION FAILED: !(size % PAGE_SIZE)
[tuxracer(36:37)]: ../../Kernel/Memory/MemoryManager.cpp:776 in AK::ErrorOr<AK::NonnullOwnPtr<Kernel::Memory::Region> > Kernel::Memory::MemoryManager::allocate_dma_buffer_pages(size_t, AK::StringView, Kernel::Memory::Region::Access)
[tuxracer(36:37)]: KERNEL PANIC! :^(
[tuxracer(36:37)]: Aborted
[tuxracer(36:37)]: at ../../Kernel/Arch/x86/common/CPU.cpp:35 in void abort()
[tuxracer(36:37)]: Kernel + 0x0000000000fbdf30  Kernel::__panic(char const*, unsigned int, char const*) +0x160
[tuxracer(36:37)]: Kernel + 0x00000000014bcc44  abort.localalias +0x382
[tuxracer(36:37)]: Kernel + 0x00000000014bc8c2  abort.localalias +0x0
[tuxracer(36:37)]: Kernel + 0x0000000000d14524  Kernel::Memory::MemoryManager::allocate_dma_buffer_pages(unsigned long, AK::StringView, Kernel::Memory::Region::Access) +0x474
[tuxracer(36:37)]: Kernel + 0x0000000000579e6b  Kernel::AC97::write(Kernel::OpenFileDescription&, unsigned long, Kernel::UserOrKernelBuffer const&, unsigned long) +0x5ab
```