### PR TITLE
AK: Suppress psabi warnings generated by SIMDExtras.h and SIMDMath.h

### DIFF
--- a/AK/SIMDExtras.h
+++ b/AK/SIMDExtras.h
@@ -8,10 +8,12 @@
 
 #include <AK/SIMD.h>
 
-// Returning a vector on i686 target generates warning "psabi".
-// This prevents the CI, treating this as an error, from running to completion.
+// Functions returning vectors or accepting vector arguments have different calling conventions
+// depending on whether the target architecture supports SSE or not. GCC generates warning "psabi"
+// when compiling for non-SSE architectures. We disable this warning because these functions
+// are static and should never be visible from outside the translation unit that includes this header.
 #pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wpsabi"
+#pragma GCC diagnostic ignored "-Wpsabi"
 
 namespace AK::SIMD {
 
@@ -141,6 +143,6 @@ ALWAYS_INLINE static void store4_masked(VectorType v, UnderlyingType* a, Underly
         *d = v[3];
 }
 
-#pragma GCC diagnostic pop
-
 }
+
+#pragma GCC diagnostic pop

--- a/AK/SIMDMath.h
+++ b/AK/SIMDMath.h
@@ -9,10 +9,12 @@
 #include <AK/SIMD.h>
 #include <math.h>
 
-// Returning a vector on i686 target generates warning "psabi".
-// This prevents the CI, treating this as an error, from running to completion.
+// Functions returning vectors or accepting vector arguments have different calling conventions
+// depending on whether the target architecture supports SSE or not. GCC generates warning "psabi"
+// when compiling for non-SSE architectures. We disable this warning because these functions
+// are static and should never be visible from outside the translation unit that includes this header.
 #pragma GCC diagnostic push
-#pragma GCC diagnostic warning "-Wpsabi"
+#pragma GCC diagnostic ignored "-Wpsabi"
 
 namespace AK::SIMD {
 
@@ -57,6 +59,6 @@ ALWAYS_INLINE static f32x4 exp(f32x4 v)
     };
 }
 
-#pragma GCC diagnostic pop
-
 }
+
+#pragma GCC diagnostic pop


### PR DESCRIPTION
Since we can't deal with those warnings we should also not show them.

This warning appears on i686 target and complains about ABI differences between 32-bit and 64-bit builds of the code.
On x86_64 the vectors will be passed via XMM registers which don't exist on 32-bit.
Since we don't mix 32-bit and 64-bit code this shouldn't cause any problems.