### PR TITLE
Help: Scroll to the top of page when opening a new link

### DIFF
--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -160,6 +160,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto url = URL::create_with_file_protocol(path);
         page_view->load_html(html, url);
+        page_view->scroll_to_top();
 
         app->deferred_invoke([&, path] {
             auto tree_view_index = manual_model->index_from_path(path);


### PR DESCRIPTION
Previously the scroll position would not reset when loading a new
page. This caused various problems such as opening the page at the
previous pages scroll position and in some instances not even
showing the new page at all.