### PR TITLE
AK: Fix const-correctness issue with Vector of references

### DIFF
--- a/AK/Iterator.h
+++ b/AK/Iterator.h
@@ -52,11 +52,11 @@ public:
         return SimpleIterator { m_container, m_index + 1 };
     }
 
-    ALWAYS_INLINE constexpr const ValueType& operator*() const { return m_container[m_index]; }
+    ALWAYS_INLINE constexpr ValueType const& operator*() const { return m_container[m_index]; }
     ALWAYS_INLINE constexpr ValueType& operator*() { return m_container[m_index]; }
 
-    constexpr auto operator->() const { return &m_container[m_index]; }
-    constexpr auto operator->() { return &m_container[m_index]; }
+    ALWAYS_INLINE constexpr ValueType const* operator->() const { return &m_container[m_index]; }
+    ALWAYS_INLINE constexpr ValueType* operator->() { return &m_container[m_index]; }
 
     SimpleIterator& operator=(const SimpleIterator& other)
     {

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -299,7 +299,7 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
             m_should_change_selected_cells = false;
             m_cell_value_editor->on_focusin = [this] { m_should_change_selected_cells = true; };
             m_cell_value_editor->on_focusout = [this] { m_should_change_selected_cells = false; };
-            m_cell_value_editor->on_change = [cells = move(cells), this] {
+            m_cell_value_editor->on_change = [cells = move(cells), this]() mutable {
                 if (m_should_change_selected_cells) {
                     auto* sheet_ptr = m_selected_view->sheet_if_available();
                     if (!sheet_ptr)

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -698,7 +698,7 @@ NonnullRefPtr<GUI::Widget> build_performance_tab()
             cpu_graphs.append(cpu_graph);
         }
     }
-    ProcessModel::the().on_cpu_info_change = [cpu_graphs](const NonnullOwnPtrVector<ProcessModel::CpuInfo>& cpus) {
+    ProcessModel::the().on_cpu_info_change = [cpu_graphs](const NonnullOwnPtrVector<ProcessModel::CpuInfo>& cpus) mutable {
         float sum_cpu = 0;
         for (size_t i = 0; i < cpus.size(); ++i) {
             cpu_graphs[i].add_value({ static_cast<size_t>(cpus[i].total_cpu_percent), static_cast<size_t>(cpus[i].total_cpu_percent_kernel) });

--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -235,7 +235,7 @@ void MenuManager::close_everyone_not_in_lineage(Menu& menu)
     close_menus(menus_to_close);
 }
 
-void MenuManager::close_menus(const Vector<Menu&>& menus)
+void MenuManager::close_menus(Vector<Menu&>& menus)
 {
     for (auto& menu : menus) {
         if (&menu == m_current_menu)

--- a/Userland/Services/WindowServer/MenuManager.h
+++ b/Userland/Services/WindowServer/MenuManager.h
@@ -49,7 +49,7 @@ public:
 private:
     MenuManager();
 
-    void close_menus(const Vector<Menu&>&);
+    void close_menus(Vector<Menu&>&);
 
     virtual void event(Core::Event&) override;
     void handle_mouse_event(MouseEvent&);


### PR DESCRIPTION
A const Vector should not be able to hold mutable references. The commit description further elaborates on the reasoning for this.

This issue was found in #11742.

In these particular cases, `auto` caused a const-correctness error.