### PR TITLE
Manpages for games

### DIFF
--- a/Base/usr/share/man/man6/2048.md
+++ b/Base/usr/share/man/man6/2048.md
@@ -1,0 +1,21 @@
+## Name
+
+2048
+
+## Synopsis
+
+```**sh
+$ 2048
+```
+
+## Description
+
+2048 is a game where the goal is to combine tiles by sliding them together until making a tile with the number 2048 on it.
+
+The tiles can be moved by pressing the arrow keys and they will combine when they are next to each other.
+
+## Settings
+
+The game size, goal and difficulty can be changed in the settings.
+
+The Evil AI setting will allow the game engine to choose the worst possible square to place the new tile. Normal mode will place it at a random spot.

--- a/Base/usr/share/man/man6/Breakout.md
+++ b/Base/usr/share/man/man6/Breakout.md
@@ -1,0 +1,15 @@
+## Name
+
+Breakout
+
+## Synopsis
+
+```**sh
+$ Breakout
+```
+
+## Description
+
+Breakout is an arcade game from 1976 where the goal is to remove all blocks by hitting them with a ball bouncing it of a pad.
+
+The pad can be moved by either using the mouse or the left and right arrow keys.

--- a/Base/usr/share/man/man6/Chess.md
+++ b/Base/usr/share/man/man6/Chess.md
@@ -1,0 +1,15 @@
+## Name
+
+Chess
+
+## Synopsis
+
+```**sh
+$ Chess
+```
+
+## Description
+
+Chess is an implementation of the 15th century board game. 
+
+The game can either be played against another human or against the ChessEngine service.

--- a/Base/usr/share/man/man6/FlappyBug.md
+++ b/Base/usr/share/man/man6/FlappyBug.md
@@ -1,0 +1,15 @@
+## Name
+
+Flappy Bug
+
+## Synopsis
+
+```**sh
+$ FlappyBug
+```
+
+## Description
+
+Flappy Bug is a SerenityOS themed version of the 2013 game Flappy Bird.
+
+The goal of the game is to survive with Buggie as long as possible by avoiding obstacles. Buggie automatically decends by gravity and to ascend by clicking any key. Press the escape key to give up.

--- a/Base/usr/share/man/man6/GameOfLife.md
+++ b/Base/usr/share/man/man6/GameOfLife.md
@@ -1,0 +1,21 @@
+## Name
+
+GameOfLife
+
+## Synopsis
+
+```**sh
+$ GameOfLife
+```
+
+## Description
+
+GameOfLife is an implementation of John Conway's Game of Life.
+
+The game is a cellular automaton where each cell is either dead (grey) or alive (yellow) and will change state in the next tick if any of the following rules are fulfilled:
+
+* An alive cell will die by underpopulation if it has fewer than two neighbors.
+* An alive cell will die by overpopulation if it has more than three neighbors.
+* A dead cell will come alive by reproduction if it has exactly three neighbors.
+
+Otherwise, it will keep its old state.

--- a/Base/usr/share/man/man6/Hearts.md
+++ b/Base/usr/share/man/man6/Hearts.md
@@ -1,0 +1,19 @@
+## Name
+
+Hearts - The Hearts card game
+
+## Synopsis
+
+```**sh
+$ Hearts
+```
+
+## Description
+
+Hearts is an implementation of the 19th century card game.
+
+The round starts by each player passing three of their cards to a neighbor. Afterwards, that a number of tricks is played. The player with the two of clubs starts the first trick.
+
+In each trick, the first player freely chooses a card to play (except the first trick where two of clubs is required), after which the other players each need to play a card in the same suit. If a player does not have a card in the same suit, they can throw any card. The player who played the highest ranked card in the correct suit wins the trick and gets to start the next trick.
+
+The winner is the player who wins the last trick.

--- a/Base/usr/share/man/man6/Minesweeper.md
+++ b/Base/usr/share/man/man6/Minesweeper.md
@@ -1,0 +1,17 @@
+## Name
+
+Minesweeper
+
+## Synopsis
+
+```**sh
+$ Minesweeper
+```
+
+## Description
+
+The goal is to find all the mines without detonating them.
+
+The player reveals what is underneath a tile by clicking on it. If it is a mine underneath the player loses. Otherwise the tile will show how many neighbouring mines there are to the tile. If there are no neighboring mines, all the neighboring tiles are revealed recursively.
+
+The player can mark a tile as being a mine by right-clicking the tile. This is then shown with a flag.

--- a/Base/usr/share/man/man6/Pong.md
+++ b/Base/usr/share/man/man6/Pong.md
@@ -1,0 +1,15 @@
+## Name
+
+Pong
+
+## Synopsis
+
+```**sh
+$ Pong
+```
+
+## Description
+
+Implementation of the 1972 Atari game Pong.
+
+Make the ball pass behind the opponent by bouncing the ball on the players paddle which can be controlled either by the mouse position or the up and down arrow keys.

--- a/Base/usr/share/man/man6/Snake.md
+++ b/Base/usr/share/man/man6/Snake.md
@@ -1,0 +1,13 @@
+## Name
+
+Snake
+
+## Synopsis
+
+```**sh
+$ Snake
+```
+
+## Description
+
+Grow the snake as large as possible by eating the fruits and not crashing into itself.

--- a/Userland/Games/2048/CMakeLists.txt
+++ b/Userland/Games/2048/CMakeLists.txt
@@ -12,4 +12,4 @@ set(SOURCES
 )
 
 serenity_app(2048 ICON app-2048)
-target_link_libraries(2048 LibConfig LibGUI LibMain)
+target_link_libraries(2048 LibConfig LibGUI LibMain LibDesktop)

--- a/Userland/Games/Breakout/CMakeLists.txt
+++ b/Userland/Games/Breakout/CMakeLists.txt
@@ -11,4 +11,4 @@ set(SOURCES
 )
 
 serenity_app(Breakout ICON app-breakout)
-target_link_libraries(Breakout LibGUI LibMain)
+target_link_libraries(Breakout LibGUI LibMain LibDesktop)

--- a/Userland/Games/Breakout/main.cpp
+++ b/Userland/Games/Breakout/main.cpp
@@ -5,7 +5,9 @@
  */
 
 #include "Game.h"
+#include <AK/URL.h>
 #include <LibCore/System.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
@@ -20,9 +22,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Breakout.md") }));
+    TRY(Desktop::Launcher::seal_allowlist());
+
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
 
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/tmp/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());
@@ -47,6 +53,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     })));
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
+    TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/Breakout.md"), "/bin/Help");
+    })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Breakout", app_icon, window)));
 
     window->show();

--- a/Userland/Games/Chess/CMakeLists.txt
+++ b/Userland/Games/Chess/CMakeLists.txt
@@ -13,4 +13,4 @@ set(SOURCES
 )
 
 serenity_app(Chess ICON app-chess)
-target_link_libraries(Chess LibChess LibConfig LibGUI LibCore LibMain)
+target_link_libraries(Chess LibChess LibConfig LibGUI LibCore LibMain LibDesktop)

--- a/Userland/Games/FlappyBug/CMakeLists.txt
+++ b/Userland/Games/FlappyBug/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_app(FlappyBug ICON app-flappybug)
-target_link_libraries(FlappyBug LibGUI LibConfig LibMain)
+target_link_libraries(FlappyBug LibGUI LibConfig LibMain LibDesktop)

--- a/Userland/Games/GameOfLife/CMakeLists.txt
+++ b/Userland/Games/GameOfLife/CMakeLists.txt
@@ -15,4 +15,4 @@ set(SOURCES
 )
 
 serenity_app(GameOfLife ICON app-gameoflife)
-target_link_libraries(GameOfLife LibGUI LibMain)
+target_link_libraries(GameOfLife LibGUI LibMain LibDesktop)

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -6,8 +6,10 @@
  */
 
 #include "BoardWidget.h"
+#include <AK/URL.h>
 #include <Games/GameOfLife/GameOfLifeGML.h>
 #include <LibCore/System.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -29,9 +31,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/GameOfLife.md") }));
+    TRY(Desktop::Launcher::seal_allowlist());
+
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/tmp/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-gameoflife"));
@@ -133,6 +139,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     })));
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
+    TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/GameOfLife.md"), "/bin/Help");
+    })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Game Of Life", app_icon, window)));
 
     board_widget->on_running_state_change = [&]() {

--- a/Userland/Games/Hearts/CMakeLists.txt
+++ b/Userland/Games/Hearts/CMakeLists.txt
@@ -17,4 +17,4 @@ set(SOURCES
 )
 
 serenity_app(Hearts ICON app-hearts)
-target_link_libraries(Hearts LibCards LibGUI LibGfx LibCore LibConfig LibMain)
+target_link_libraries(Hearts LibCards LibGUI LibGfx LibCore LibConfig LibMain LibDesktop)

--- a/Userland/Games/Minesweeper/CMakeLists.txt
+++ b/Userland/Games/Minesweeper/CMakeLists.txt
@@ -14,4 +14,4 @@ set(SOURCES
 )
 
 serenity_app(Minesweeper ICON app-minesweeper)
-target_link_libraries(Minesweeper LibGUI LibConfig LibMain)
+target_link_libraries(Minesweeper LibGUI LibConfig LibMain LibDesktop)

--- a/Userland/Games/Pong/CMakeLists.txt
+++ b/Userland/Games/Pong/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_app(Pong ICON app-pong)
-target_link_libraries(Pong LibGUI LibMain)
+target_link_libraries(Pong LibGUI LibMain LibDesktop)

--- a/Userland/Games/Pong/main.cpp
+++ b/Userland/Games/Pong/main.cpp
@@ -5,7 +5,9 @@
  */
 
 #include "Game.h"
+#include <AK/URL.h>
 #include <LibCore/System.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menu.h>
@@ -20,9 +22,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Pong.md") }));
+    TRY(Desktop::Launcher::seal_allowlist());
+
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/tmp/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto window = TRY(GUI::Window::try_create());
@@ -40,6 +46,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     })));
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
+    TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/Pong.md"), "/bin/Help");
+    })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Pong", app_icon, window)));
 
     window->show();

--- a/Userland/Games/Snake/CMakeLists.txt
+++ b/Userland/Games/Snake/CMakeLists.txt
@@ -10,4 +10,4 @@ set(SOURCES
 )
 
 serenity_app(Snake ICON app-snake)
-target_link_libraries(Snake LibGUI LibConfig LibMain)
+target_link_libraries(Snake LibGUI LibConfig LibMain LibDesktop)

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -5,8 +5,10 @@
  */
 
 #include "SnakeGame.h"
+#include <AK/URL.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
+#include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/BoxLayout.h>
@@ -26,9 +28,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domains("Snake");
 
+    TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Snake.md") }));
+    TRY(Desktop::Launcher::seal_allowlist());
+
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
 
     TRY(Core::System::unveil("/res", "r"));
+    TRY(Core::System::unveil("/tmp/portal/launch", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-snake"));
@@ -52,6 +58,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     })));
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
+    TRY(help_menu->try_add_action(GUI::CommonActions::make_help_action([](auto&) {
+        Desktop::Launcher::open(URL::create_with_file_protocol("/usr/share/man/man6/Snake.md"), "/bin/Help");
+    })));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Snake", app_icon, window)));
 
     window->show();


### PR DESCRIPTION
This series of commits adds a man page for most of our games and also adding a menu item to open it in the Help app.

The descriptions are so far rather barebone and some stuff is still missing as I didn't really understand the rules yet (i.e the card games) but at least the section is not empty anymore in the Help app.