### PR TITLE
Kernel: Configure CPACR_EL1 in aarch64 prekernel

### DIFF
--- a/Kernel/Prekernel/Arch/aarch64/boot.S
+++ b/Kernel/Prekernel/Arch/aarch64/boot.S
@@ -15,6 +15,12 @@ start:
   and x13, x13, 0xff
   cbnz x13, _ZN9Prekernel4haltEv
 
+  // Enable the use of va_list in EL1
+  // by disabling the trap of accessing FP and SIMD registers.
+  mrs x0, CPACR_EL1
+  orr x0, x0, #(0b11 << 20)
+  msr CPACR_EL1, x0
+
   // Let stack start before .text for now.
   // 512 kiB (0x80000) of stack are probably not sufficient, especially once we give the other cores some stack too,
   // but for now it's ok.


### PR DESCRIPTION
This commit enables the use of variadic functions in EL1.

On aarch64, when we want to format messages via something like printf(),
the underlying va_list will use the SIMD & FP registers to store parameters.
So, we have to disable the trap of accessing SIMD & FP registers
to make va_list use SIMD & FP registers properly.

Signed-off-by: Marco Wang \<m.aesophor@gmail.com\>