### PR TITLE
2048: Miscellaneous improvements

### DIFF
--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -16,7 +16,7 @@
 GameSizeDialog::GameSizeDialog(GUI::Window* parent, size_t board_size, size_t target, bool evil_ai)
     : GUI::Dialog(parent)
     , m_board_size(board_size)
-    , m_target_tile_power(AK::log2(target))
+    , m_target_tile_power(AK::log2(target) - 1)
     , m_evil_ai(evil_ai)
 {
     set_rect({ 0, 0, 250, 150 });

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -165,7 +165,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto game_menu = TRY(window->try_add_menu("&Game"));
 
-    TRY(game_menu->try_add_action(GUI::Action::create("&New Game", { Mod_None, Key_F2 }, [&](auto&) {
+    TRY(game_menu->try_add_action(GUI::Action::create("&New Game", { Mod_None, Key_F2 }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/reload.png")), [&](auto&) {
         start_a_new_game();
     })));
 
@@ -186,7 +186,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     })));
 
     TRY(game_menu->try_add_separator());
-    TRY(game_menu->try_add_action(GUI::Action::create("&Settings...", [&](auto&) {
+    TRY(game_menu->try_add_action(GUI::Action::create("&Settings...", TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png")), [&](auto&) {
         change_settings();
     })));
 

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -141,19 +141,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             break;
         case Game::MoveOutcome::Won: {
             update();
-            auto message_box = GUI::MessageBox::construct(window, "Congratulations! You won the game, Do you still want to continue?",
-                "Want to continue?",
+            auto want_to_continue = GUI::MessageBox::show(window,
+                String::formatted("You won the game in {} turns with a score of {}. Would you like to continue?", game.turns(), game.score()),
+                "Congratulations!",
                 GUI::MessageBox::Type::Question,
                 GUI::MessageBox::InputType::YesNo);
-            if (message_box->exec() == GUI::MessageBox::ExecYes)
+            if (want_to_continue == GUI::MessageBox::ExecYes)
                 game.set_want_to_continue();
-            else {
-                GUI::MessageBox::show(window,
-                    String::formatted("You reached {} in {} turns with a score of {}", game.largest_tile(), game.turns(), game.score()),
-                    "You won!",
-                    GUI::MessageBox::Type::Information);
+            else
                 start_a_new_game();
-            }
             break;
         }
         case Game::MoveOutcome::GameOver:


### PR DESCRIPTION
This PR makes a few improvements to 2048.

1. There was a minor bug in the settings menu where opening it would load the target tile value as one power-of-2 larger than it should have been. This would result in the value increasing every time that the settings were opened and re-saved.
2. The dialog boxes for the win condition were a little bit janky. The player would be asked if they'd like to continue endlessly, and then only if they did not want to, they would get a second dialog with game statistics. I consolidated them into a single dialog.
3. The "New Game" and "Settings" actions were missing icons.