### PR TITLE
Lagom: Avoid declaring `Time` in the global namespace

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -13,6 +13,8 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 
+namespace {
+
 struct Time {
     i8 hour { 0 };
     u8 minute { 0 };
@@ -248,6 +250,8 @@ namespace TimeZone {
 )~~~");
 
     VERIFY(file.write(generator.as_string_view()));
+}
+
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)


### PR DESCRIPTION
Hi,

When compiled using clang, an ambiguity error is detected between `class AK::Time` aliased to `::Time` and the `struct ::Time` provided in `GenerateTimeZoneData.cpp`. Solve this by moving most of the code in an anonymous namespace.