### PR TITLE
Documentation: Add a method for 7zip and other archive tools

### DIFF
--- a/Documentation/TransferringFiles.md
+++ b/Documentation/TransferringFiles.md
@@ -17,10 +17,16 @@ Then we just open `localhost:8000` on our host machine :^)
 
 ## Method 2: Mount disk_image
 
-Another way is to mount Serenity's disk_image to your host machine by using the following command on *nix systems:
+Another way is to mount Serenity's disk_image to your host machine by using the following command on *nix systems (or inside WSL):
 
 ```console
 cd "Build/${SERENITY_ARCH}"
 mkdir mnt
 sudo mount -t ext2 _disk_image mnt
 ```
+
+## Method 3: Archiving tool with ext2 support
+
+Some archiving tools, like [7-Zip](https://www.7-zip.org/), are capable of directly opening ext2 images like Serenity's `_disk_image`. With these, you can open the disk image like any other archive and extract the files you need.
+
+For WSL users: If you have the image on your native WSL drive (recommended), this drive can be opened in Explorer by manually opening `\\wsl$` (not visible in the Network tab!) and then the "network share" corresponding to your distro.


### PR DESCRIPTION
Some archive tools can open ext2 images like an archive, which is very convenient for people that already have such tools like 7zip.

This also contains information for WSL users on where to find the _disk_image in Explorer.