### PR TITLE
LibGUI+Browser: Propagate errors when loading icons

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -4,7 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "BookmarksBarWidget.h"
+#include <Applications/Browser/BookmarksBarWidget.h>
+#include <Applications/Browser/Browser.h>
 #include <Applications/Browser/EditBookmarkGML.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/BoxLayout.h>
@@ -198,7 +199,7 @@ void BookmarksBarWidget::model_did_update(unsigned)
 
         button.set_button_style(Gfx::ButtonStyle::Coolbar);
         button.set_text(title);
-        button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-html.png").release_value_but_fixme_should_propagate_errors());
+        button.set_icon(g_icon_bag.filetype_html);
         button.set_fixed_size(font().width(title) + 32, 20);
         button.set_relative_rect(rect);
         button.set_focus_policy(GUI::FocusPolicy::TabFocus);
@@ -249,11 +250,7 @@ void BookmarksBarWidget::update_content_size()
         for (size_t i = m_last_visible_index; i < m_bookmarks.size(); ++i) {
             auto& bookmark = m_bookmarks.at(i);
             bookmark.set_visible(false);
-            m_additional_menu->add_action(GUI::Action::create(bookmark.text(),
-                Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-html.png").release_value_but_fixme_should_propagate_errors(),
-                [&](auto&) {
-                    bookmark.on_click(0);
-                }));
+            m_additional_menu->add_action(GUI::Action::create(bookmark.text(), g_icon_bag.filetype_html, [&](auto&) { bookmark.on_click(0); }));
         }
     }
 }

--- a/Userland/Applications/Browser/Browser.h
+++ b/Userland/Applications/Browser/Browser.h
@@ -7,11 +7,13 @@
 #pragma once
 
 #include <AK/String.h>
+#include <Applications/Browser/IconBag.h>
 
 namespace Browser {
 
 extern String g_home_url;
 extern String g_search_engine;
 extern Vector<String> g_content_filters;
+extern IconBag g_icon_bag;
 
 }

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -197,21 +197,21 @@ void BrowserWindow::build_menus()
     });
 
     m_view_source_action = GUI::Action::create(
-        "View &Source", { Mod_Ctrl, Key_U }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/code.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "View &Source", { Mod_Ctrl, Key_U }, g_icon_bag.code, [this](auto&) {
             active_tab().m_web_content_view->get_source();
         },
         this);
     m_view_source_action->set_status_tip("View source code of the current page");
 
     m_inspect_dom_tree_action = GUI::Action::create(
-        "Inspect &DOM Tree", { Mod_None, Key_F12 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/tree.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "Inspect &DOM Tree", { Mod_None, Key_F12 }, g_icon_bag.tree, [this](auto&) {
             active_tab().show_inspector_window(Tab::InspectorTarget::Document);
         },
         this);
     m_inspect_dom_tree_action->set_status_tip("Open inspector window for this page");
 
     m_inspect_dom_node_action = GUI::Action::create(
-        "&Inspect Element", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/inspect.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "&Inspect Element", g_icon_bag.inspect, [this](auto&) {
             active_tab().show_inspector_window(Tab::InspectorTarget::HoveredElement);
         },
         this);
@@ -222,7 +222,7 @@ void BrowserWindow::build_menus()
     inspect_menu.add_action(*m_inspect_dom_tree_action);
 
     auto js_console_action = GUI::Action::create(
-        "Open &JS Console", { Mod_Ctrl, Key_I }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-javascript.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "Open &JS Console", { Mod_Ctrl, Key_I }, g_icon_bag.filetype_javascript, [this](auto&) {
             active_tab().show_console_window();
         },
         this);
@@ -249,7 +249,7 @@ void BrowserWindow::build_menus()
 
     m_search_engine_actions.set_exclusive(true);
     auto& search_engine_menu = settings_menu.add_submenu("&Search Engine");
-    search_engine_menu.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/find.png").release_value_but_fixme_should_propagate_errors());
+    search_engine_menu.set_icon(g_icon_bag.find);
     bool search_engine_set = false;
 
     m_disable_search_engine_action = GUI::Action::create_checkable(
@@ -318,7 +318,7 @@ void BrowserWindow::build_menus()
     }
 
     auto& color_scheme_menu = settings_menu.add_submenu("&Color Scheme");
-    color_scheme_menu.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/color-chooser.png").release_value_but_fixme_should_propagate_errors());
+    color_scheme_menu.set_icon(g_icon_bag.color_chooser);
     {
         auto current_setting = Web::CSS::preferred_color_scheme_from_string(Config::read_string("Browser", "Preferences", "ColorScheme", "auto"));
         m_color_scheme_actions.set_exclusive(true);
@@ -343,7 +343,7 @@ void BrowserWindow::build_menus()
 
     auto& debug_menu = add_menu("&Debug");
     debug_menu.add_action(GUI::Action::create(
-        "Dump &DOM Tree", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/tree.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "Dump &DOM Tree", g_icon_bag.tree, [this](auto&) {
             active_tab().m_web_content_view->debug_request("dump-dom-tree");
         },
         this));
@@ -360,7 +360,7 @@ void BrowserWindow::build_menus()
     debug_menu.add_action(GUI::Action::create("Dump &History", { Mod_Ctrl, Key_H }, [this](auto&) {
         active_tab().m_history.dump();
     }));
-    debug_menu.add_action(GUI::Action::create("Dump C&ookies", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/cookie.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+    debug_menu.add_action(GUI::Action::create("Dump C&ookies", g_icon_bag.cookie, [this](auto&) {
         auto& tab = active_tab();
         if (tab.on_dump_cookies)
             tab.on_dump_cookies();

--- a/Userland/Applications/Browser/CMakeLists.txt
+++ b/Userland/Applications/Browser/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SOURCES
     DownloadWidget.cpp
     EditBookmarkGML.h
     History.cpp
+    IconBag.cpp
     InspectorWidget.cpp
     Tab.cpp
     TabGML.h

--- a/Userland/Applications/Browser/ConsoleWidget.cpp
+++ b/Userland/Applications/Browser/ConsoleWidget.cpp
@@ -8,6 +8,7 @@
 
 #include "ConsoleWidget.h"
 #include <AK/StringBuilder.h>
+#include <Applications/Browser/Browser.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/TextBox.h>
@@ -60,7 +61,7 @@ ConsoleWidget::ConsoleWidget()
 
     auto& clear_button = bottom_container.add<GUI::Button>();
     clear_button.set_fixed_size(22, 22);
-    clear_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png").release_value_but_fixme_should_propagate_errors());
+    clear_button.set_icon(g_icon_bag.delete_icon);
     clear_button.set_tooltip("Clear the console output");
     clear_button.on_click = [this](auto) {
         clear_output();

--- a/Userland/Applications/Browser/IconBag.cpp
+++ b/Userland/Applications/Browser/IconBag.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, Dylan Katz <dykatz@uw.edu>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <Applications/Browser/IconBag.h>
+
+namespace Browser {
+ErrorOr<IconBag> IconBag::try_create()
+{
+    IconBag icon_bag;
+
+    icon_bag.filetype_html = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-html.png"));
+    icon_bag.filetype_text = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-text.png"));
+    icon_bag.filetype_javascript = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-javascript.png"));
+    icon_bag.bookmark_contour = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/bookmark-contour.png"));
+    icon_bag.bookmark_filled = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/bookmark-filled.png"));
+    icon_bag.inspector_object = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/inspector-object.png"));
+    icon_bag.find = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/find.png"));
+    icon_bag.color_chooser = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/color-chooser.png"));
+    icon_bag.delete_icon = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png"));
+    icon_bag.new_tab = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new-tab.png"));
+    icon_bag.duplicate_tab = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/duplicate-tab.png"));
+    icon_bag.code = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/code.png"));
+    icon_bag.tree = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/tree.png"));
+    icon_bag.inspect = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/inspect.png"));
+    icon_bag.cookie = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/cookie.png"));
+
+    return icon_bag;
+}
+}

--- a/Userland/Applications/Browser/IconBag.h
+++ b/Userland/Applications/Browser/IconBag.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Dylan Katz <dykatz@uw.edu>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <LibGfx/Bitmap.h>
+
+namespace Browser {
+struct IconBag final {
+    static ErrorOr<IconBag> try_create();
+
+    RefPtr<Gfx::Bitmap> filetype_html { nullptr };
+    RefPtr<Gfx::Bitmap> filetype_text { nullptr };
+    RefPtr<Gfx::Bitmap> filetype_javascript { nullptr };
+    RefPtr<Gfx::Bitmap> bookmark_contour { nullptr };
+    RefPtr<Gfx::Bitmap> bookmark_filled { nullptr };
+    RefPtr<Gfx::Bitmap> inspector_object { nullptr };
+    RefPtr<Gfx::Bitmap> find { nullptr };
+    RefPtr<Gfx::Bitmap> color_chooser { nullptr };
+    RefPtr<Gfx::Bitmap> delete_icon { nullptr };
+    RefPtr<Gfx::Bitmap> new_tab { nullptr };
+    RefPtr<Gfx::Bitmap> duplicate_tab { nullptr };
+    RefPtr<Gfx::Bitmap> code { nullptr };
+    RefPtr<Gfx::Bitmap> tree { nullptr };
+    RefPtr<Gfx::Bitmap> inspect { nullptr };
+    RefPtr<Gfx::Bitmap> cookie { nullptr };
+};
+}

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -74,7 +74,7 @@ void Tab::view_source(const URL& url, const String& source)
     editor.set_ruler_visible(true);
     window->resize(640, 480);
     window->set_title(url.to_string());
-    window->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-text.png").release_value_but_fixme_should_propagate_errors());
+    window->set_icon(g_icon_bag.filetype_text);
     window->show();
 }
 
@@ -98,9 +98,7 @@ Tab::Tab(BrowserWindow& window)
         m_go_back_context_menu = GUI::Menu::construct();
         for (auto& url : m_history.get_back_title_history()) {
             i++;
-            m_go_back_context_menu->add_action(GUI::Action::create(url.to_string(),
-                Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-html.png").release_value_but_fixme_should_propagate_errors(),
-                [this, i](auto&) { go_back(i); }));
+            m_go_back_context_menu->add_action(GUI::Action::create(url.to_string(), g_icon_bag.filetype_html, [this, i](auto&) { go_back(i); }));
         }
         m_go_back_context_menu->popup(context_menu_event.screen_position());
     };
@@ -113,9 +111,7 @@ Tab::Tab(BrowserWindow& window)
         m_go_forward_context_menu = GUI::Menu::construct();
         for (auto& url : m_history.get_forward_title_history()) {
             i++;
-            m_go_forward_context_menu->add_action(GUI::Action::create(url.to_string(),
-                Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-html.png").release_value_but_fixme_should_propagate_errors(),
-                [this, i](auto&) { go_forward(i); }));
+            m_go_forward_context_menu->add_action(GUI::Action::create(url.to_string(), g_icon_bag.filetype_html, [this, i](auto&) { go_forward(i); }));
         }
         m_go_forward_context_menu->popup(context_menu_event.screen_position());
     };
@@ -150,7 +146,7 @@ Tab::Tab(BrowserWindow& window)
     m_bookmark_button = toolbar.add<GUI::Button>();
     m_bookmark_button->set_button_style(Gfx::ButtonStyle::Coolbar);
     m_bookmark_button->set_focus_policy(GUI::FocusPolicy::TabFocus);
-    m_bookmark_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/bookmark-contour.png").release_value_but_fixme_should_propagate_errors());
+    m_bookmark_button->set_icon(g_icon_bag.bookmark_contour);
     m_bookmark_button->set_fixed_size(22, 22);
 
     m_bookmark_button->on_click = [this](auto) {
@@ -332,7 +328,7 @@ Tab::Tab(BrowserWindow& window)
     m_tab_context_menu->add_action(GUI::CommonActions::make_close_tab_action([this](auto&) {
         on_tab_close_request(*this);
     }));
-    m_tab_context_menu->add_action(GUI::Action::create("&Duplicate Tab", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/duplicate-tab.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+    m_tab_context_menu->add_action(GUI::Action::create("&Duplicate Tab", g_icon_bag.duplicate_tab, [this](auto&) {
         on_tab_open_request(url());
     }));
     m_tab_context_menu->add_action(GUI::Action::create("Close &Other Tabs", [this](auto&) {
@@ -413,10 +409,10 @@ void Tab::bookmark_current_url()
 void Tab::update_bookmark_button(const String& url)
 {
     if (BookmarksBarWidget::the().contains_bookmark(url)) {
-        m_bookmark_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/bookmark-filled.png").release_value_but_fixme_should_propagate_errors());
+        m_bookmark_button->set_icon(g_icon_bag.bookmark_filled);
         m_bookmark_button->set_tooltip("Remove Bookmark");
     } else {
-        m_bookmark_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/bookmark-contour.png").release_value_but_fixme_should_propagate_errors());
+        m_bookmark_button->set_icon(g_icon_bag.bookmark_contour);
         m_bookmark_button->set_tooltip("Add Bookmark");
     }
 }
@@ -485,7 +481,7 @@ void Tab::show_inspector_window(Browser::Tab::InspectorTarget inspector_target)
         auto window = GUI::Window::construct(&this->window());
         window->resize(300, 500);
         window->set_title("Inspector");
-        window->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/inspector-object.png").release_value_but_fixme_should_propagate_errors());
+        window->set_icon(g_icon_bag.inspector_object);
         window->on_close = [&]() {
             m_web_content_view->clear_inspected_dom_node();
         };
@@ -514,7 +510,7 @@ void Tab::show_console_window()
         auto console_window = GUI::Window::construct(&window());
         console_window->resize(500, 300);
         console_window->set_title("JS Console");
-        console_window->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/filetype-javascript.png").release_value_but_fixme_should_propagate_errors());
+        console_window->set_icon(g_icon_bag.filetype_javascript);
         m_console_widget = console_window->set_main_widget<ConsoleWidget>();
         m_console_widget->on_js_input = [this](String const& js_source) {
             m_web_content_view->js_console_input(js_source);

--- a/Userland/Applications/Browser/WindowActions.cpp
+++ b/Userland/Applications/Browser/WindowActions.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "WindowActions.h"
+#include <Applications/Browser/Browser.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Bitmap.h>
@@ -24,7 +25,7 @@ WindowActions::WindowActions(GUI::Window& window)
     VERIFY(!s_the);
     s_the = this;
     m_create_new_tab_action = GUI::Action::create(
-        "&New Tab", { Mod_Ctrl, Key_T }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new-tab.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
+        "&New Tab", { Mod_Ctrl, Key_T }, g_icon_bag.new_tab, [this](auto&) {
             if (on_create_new_tab)
                 on_create_new_tab();
         },

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "Browser.h"
-#include "BrowserWindow.h"
-#include "CookieJar.h"
-#include "Tab.h"
-#include "WindowActions.h"
 #include <AK/StringBuilder.h>
+#include <Applications/Browser/Browser.h>
+#include <Applications/Browser/BrowserWindow.h>
+#include <Applications/Browser/CookieJar.h>
+#include <Applications/Browser/Tab.h>
+#include <Applications/Browser/WindowActions.h>
 #include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
@@ -29,6 +29,7 @@ namespace Browser {
 String g_search_engine;
 String g_home_url;
 Vector<String> g_content_filters;
+IconBag g_icon_bag;
 
 }
 
@@ -69,6 +70,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Browser::g_home_url = Config::read_string("Browser", "Preferences", "Home", "file:///res/html/misc/welcome.html");
     Browser::g_search_engine = Config::read_string("Browser", "Preferences", "SearchEngine", {});
+
+    Browser::g_icon_bag = TRY(Browser::IconBag::try_create());
 
     auto ad_filter_list_or_error = Core::File::open(String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory()), Core::OpenMode::ReadOnly);
     if (!ad_filter_list_or_error.is_error()) {

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -134,7 +134,7 @@ void Button::set_action(Action& action)
         set_checked(action.is_checked());
 }
 
-void Button::set_icon(RefPtr<Gfx::Bitmap>&& icon)
+void Button::set_icon(RefPtr<Gfx::Bitmap> icon)
 {
     if (m_icon == icon)
         return;

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -20,7 +20,7 @@ class Button : public AbstractButton {
 public:
     virtual ~Button() override;
 
-    void set_icon(RefPtr<Gfx::Bitmap>&&);
+    void set_icon(RefPtr<Gfx::Bitmap>);
     void set_icon_from_path(String const&);
     const Gfx::Bitmap* icon() const { return m_icon.ptr(); }
     Gfx::Bitmap* icon() { return m_icon.ptr(); }


### PR DESCRIPTION
I was trying to get rid of error propagation fixmes in the browser when loading icons, and I noticed that the `GUI::Button::set_icon` method only accepted icons that were loaded as a temporary rvalue, which made it so that they could only be loaded inline. This made error propagation almost impossible to do correctly. The first commit changes this.

The second commit loads all the icons in the Browser earlier in the program, stores them as global values, and then passes them to the Buttons that need them without the need for inline error propagation.