### PR TITLE
LibGUI: Adjustments to ValueSlider & TextEditor painting when disabled

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -719,7 +719,7 @@ void TextEditor::paint_event(PaintEvent& event)
         painter.draw_scaled_bitmap(icon_rect, *m_icon, m_icon->rect());
     }
 
-    if (is_focused() && m_cursor_state && !is_displayonly())
+    if (is_enabled() && is_focused() && m_cursor_state && !is_displayonly())
         painter.fill_rect(cursor_content_rect(), palette().text_cursor());
 }
 

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -81,7 +81,11 @@ void ValueSlider::paint_event(PaintEvent& event)
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
-    painter.fill_rect_with_gradient(m_orientation, bar_rect(), palette().active_window_border1(), palette().active_window_border2());
+    if (is_enabled())
+        painter.fill_rect_with_gradient(m_orientation, bar_rect(), palette().active_window_border1(), palette().active_window_border2());
+    else
+        painter.fill_rect_with_gradient(m_orientation, bar_rect(), palette().inactive_window_border1(), palette().inactive_window_border2());
+
     auto unfilled_rect = bar_rect();
     unfilled_rect.set_left(knob_rect().right());
     painter.fill_rect(unfilled_rect, palette().base());


### PR DESCRIPTION
![Screenshot_20220111_115357](https://user-images.githubusercontent.com/69970419/148933913-2c394f5a-5e41-41a7-ae9d-b965b638aa4f.png)


Two really small gui fixes:

Make sure the text cursor isn't painted when disabling a focused TextEditor. This isn't something that's commonly done but it looked weird enough to warrant a fix. Also paint ValueSlider gradient in inactive colors when disabled to match other widgets and make it more obvious that it's disabled.