### PR TITLE
Ports: Correct GLtron patch and dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,3 +10,6 @@
 *.pgm binary
 *.png binary
 *.ppm binary
+
+# Prevent port patches from being normalized
+/Ports/**/patches/* -text

--- a/Ports/gltron/package.sh
+++ b/Ports/gltron/package.sh
@@ -4,7 +4,7 @@ useconfigure="true"
 version="0.70"
 files="http://mirror.sobukus.de/files/grimoire/games-arcade-2d/gltron-${version}-source.tar.gz gltron-${version}-source.tar.gz e0c8ebb41a18a1f8d7302a9c2cb466f5b1dd63e9a9966c769075e6b6bdad8bb0"
 auth_type=sha256
-depends=("SDL_sound" "SDL2")
+depends=("libpng" "SDL_sound" "SDL2" "zlib")
 configopts=(
     "--disable-warn"
 )

--- a/Ports/gltron/patches/nebu_video_system_c.patch
+++ b/Ports/gltron/patches/nebu_video_system_c.patch
@@ -1,5 +1,5 @@
 --- gltron-0.70/nebu/video/video_system.c	2003-07-21 08:18:57.000000000 +0000
-+++ gltron-0.70-patched/nebu/video/video_system.c	2022-01-10 00:39:53.078575380 +0000
++++ gltron-0.70-patched/nebu/video/video_system.c	2022-01-11 23:08:04.316789459 +0000
 @@ -1,16 +1,17 @@
  #include "Nebu_video.h"
  

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -317,8 +317,7 @@ void SoftwareGLContext::gl_end()
         mv_elements[0][0], mv_elements[1][0], mv_elements[2][0],
         mv_elements[0][1], mv_elements[1][1], mv_elements[2][1],
         mv_elements[0][2], mv_elements[1][2], mv_elements[2][2]);
-    auto normal_transform_or_error = model_view_transposed.inverse();
-    auto const& normal_transform = normal_transform_or_error.is_error() ? model_view_transposed : normal_transform_or_error.release_value();
+    auto const& normal_transform = model_view_transposed.inverse();
 
     m_rasterizer.draw_primitives(primitive_type, m_model_view_matrix, normal_transform, m_projection_matrix, m_texture_matrix, m_vertex_list, enabled_texture_units);
 
@@ -2810,9 +2809,7 @@ void SoftwareGLContext::gl_tex_gen_floatv(GLenum coord, GLenum pname, GLfloat co
         texture_coordinate_generation(capability).object_plane_coefficients = { params[0], params[1], params[2], params[3] };
         break;
     case GL_EYE_PLANE: {
-        auto inverse_matrix_or_error = m_model_view_matrix.inverse();
-        auto const& inverse_model_view_matrix = inverse_matrix_or_error.is_error() ? m_model_view_matrix : inverse_matrix_or_error.release_value();
-
+        auto const& inverse_model_view = m_model_view_matrix.inverse();
         auto input_coefficients = FloatVector4 { params[0], params[1], params[2], params[3] };
 
         // Note: we are allowed to store transformed coefficients here, according to the documentation on
@@ -2821,7 +2818,7 @@ void SoftwareGLContext::gl_tex_gen_floatv(GLenum coord, GLenum pname, GLfloat co
         // "The returned values are those maintained in eye coordinates. They are not equal to the values
         //  specified using glTexGen, unless the modelview matrix was identity when glTexGen was called."
 
-        texture_coordinate_generation(capability).eye_plane_coefficients = inverse_model_view_matrix * input_coefficients;
+        texture_coordinate_generation(capability).eye_plane_coefficients = inverse_model_view * input_coefficients;
         break;
     }
     default:

--- a/Userland/Libraries/LibGfx/Matrix.h
+++ b/Userland/Libraries/LibGfx/Matrix.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Error.h>
 #include <AK/Types.h>
 #include <initializer_list>
 
@@ -159,12 +158,9 @@ public:
         return result;
     }
 
-    [[nodiscard]] constexpr ErrorOr<Matrix> inverse() const
+    [[nodiscard]] constexpr Matrix inverse() const
     {
-        auto det = determinant();
-        if (det == 0)
-            return Error::from_string_literal("inverse of matrix does not exist"sv);
-        return adjugate() / det;
+        return adjugate() / determinant();
     }
 
     [[nodiscard]] constexpr Matrix transpose() const


### PR DESCRIPTION
Collection of changes and fixes that did not make the previous GLtron PR in time for the merge:

* Fix a GLtron patch that did not contain the right line endings;
* Fix our `.gitattributes` to not automatically nuke the line endings in our port patches;
* Add missing dependencies to the GLtron `package.sh`;
* Change `Matrix::inverse()` to always return a new matrix instead of possibly returning an error.

CC @Quaker762 @linusg 