### PR TITLE
LibJS+LibTimeZone: Respect the user-provided time zone in Intl.DateTimeFormat

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -1468,7 +1468,7 @@ static ErrorOr<void> parse_time_zone_names(String locale_time_zone_names_path, U
     time_zone_formats.gmt_zero_format = locale_data.unique_strings.ensure(gmt_zero_format_string.as_string());
 
     auto parse_time_zone = [&](StringView meta_zone, JsonObject const& meta_zone_object) {
-        constexpr auto standard_keys = Array { "daylight"sv, "standard"sv };
+        constexpr auto standard_keys = Array { "standard"sv, "daylight"sv };
         constexpr auto generic_keys = Array { "generic"sv };
 
         auto golden_zones = locale_data.meta_zones.find(meta_zone);

--- a/Tests/LibUnicode/TestUnicodeDateTimeFormat.cpp
+++ b/Tests/LibUnicode/TestUnicodeDateTimeFormat.cpp
@@ -31,22 +31,22 @@ TEST_CASE(time_zone_name)
         TestData { "ar"sv, Unicode::CalendarPatternStyle::LongGeneric, "UTC"sv, "غرينتش"sv },
         TestData { "ar"sv, Unicode::CalendarPatternStyle::ShortGeneric, "UTC"sv, "غرينتش"sv },
 
-        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "America/Los_Angeles"sv, "Pacific Daylight Time"sv },
-        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "America/Los_Angeles"sv, "PDT"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "America/Los_Angeles"sv, "Pacific Standard Time"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "America/Los_Angeles"sv, "PST"sv },
         TestData { "en"sv, Unicode::CalendarPatternStyle::LongGeneric, "America/Los_Angeles"sv, "Pacific Time"sv },
         TestData { "en"sv, Unicode::CalendarPatternStyle::ShortGeneric, "America/Los_Angeles"sv, "PT"sv },
 
-        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "America/Los_Angeles"sv, "توقيت المحيط الهادي الصيفي"sv },
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "America/Los_Angeles"sv, "توقيت المحيط الهادي الرسمي"sv },
         TestData { "ar"sv, Unicode::CalendarPatternStyle::Short, "America/Los_Angeles"sv, "غرينتش-٨"sv },
         TestData { "ar"sv, Unicode::CalendarPatternStyle::LongGeneric, "America/Los_Angeles"sv, "توقيت المحيط الهادي"sv },
         TestData { "ar"sv, Unicode::CalendarPatternStyle::ShortGeneric, "America/Los_Angeles"sv, "غرينتش-٨"sv },
 
-        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "America/Vancouver"sv, "Pacific Daylight Time"sv },
-        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "America/Vancouver"sv, "PDT"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "America/Vancouver"sv, "Pacific Standard Time"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "America/Vancouver"sv, "PST"sv },
         TestData { "en"sv, Unicode::CalendarPatternStyle::LongGeneric, "America/Vancouver"sv, "Pacific Time"sv },
         TestData { "en"sv, Unicode::CalendarPatternStyle::ShortGeneric, "America/Vancouver"sv, "PT"sv },
 
-        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "America/Vancouver"sv, "توقيت المحيط الهادي الصيفي"sv },
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "America/Vancouver"sv, "توقيت المحيط الهادي الرسمي"sv },
         TestData { "ar"sv, Unicode::CalendarPatternStyle::Short, "America/Vancouver"sv, "غرينتش-٨"sv },
         TestData { "ar"sv, Unicode::CalendarPatternStyle::LongGeneric, "America/Vancouver"sv, "توقيت المحيط الهادي"sv },
         TestData { "ar"sv, Unicode::CalendarPatternStyle::ShortGeneric, "America/Vancouver"sv, "غرينتش-٨"sv },

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -104,6 +104,7 @@ u8 min_from_time(double);
 u8 sec_from_time(double);
 u16 ms_from_time(double);
 u8 week_day(double);
+double local_tza(double time, bool is_utc, Optional<StringView> time_zone_override = {});
 double day(double);
 Value make_time(GlobalObject& global_object, Value hour, Value min, Value sec, Value ms);
 Value make_day(GlobalObject& global_object, Value year, Value month, Value date);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -1492,15 +1492,14 @@ ThrowCompletionOr<Array*> format_date_time_range_to_parts(GlobalObject& global_o
 }
 
 // 11.1.14 ToLocalTime ( t, calendar, timeZone ), https://tc39.es/ecma402/#sec-tolocaltime
-ThrowCompletionOr<LocalTime> to_local_time(GlobalObject& global_object, double time, StringView calendar, [[maybe_unused]] StringView time_zone)
+ThrowCompletionOr<LocalTime> to_local_time(GlobalObject& global_object, double time, StringView calendar, StringView time_zone)
 {
     // 1. Assert: Type(t) is Number.
 
     // 2. If calendar is "gregory", then
     if (calendar == "gregory"sv) {
         // a. Let timeZoneOffset be the value calculated according to LocalTZA(t, true) where the local time zone is replaced with timezone timeZone.
-        // FIXME: Implement LocalTZA when timezones other than UTC are supported.
-        double time_zone_offset = 0;
+        double time_zone_offset = local_tza(time, true, time_zone);
 
         // b. Let tz be the time value t + timeZoneOffset.
         double zoned_time = time + time_zone_offset;

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
@@ -56,11 +56,11 @@ String canonicalize_time_zone_name(String const& time_zone)
 }
 
 // 11.1.3 DefaultTimeZone ( ), https://tc39.es/proposal-temporal/#sec-defaulttimezone
-// NOTE: This is the minimum implementation of DefaultTimeZone, supporting only the "UTC" time zone.
+// 15.1.3 DefaultTimeZone ( ), https://tc39.es/proposal-temporal/#sup-defaulttimezone
 String default_time_zone()
 {
-    // 1. Return "UTC".
-    return "UTC";
+    // The DefaultTimeZone abstract operation returns a String value representing the valid (11.1.1) and canonicalized (11.1.2) time zone name for the host environment's current time zone.
+    return ::TimeZone::current_time_zone();
 }
 
 // 11.6.1 ParseTemporalTimeZone ( string ), https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezone

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -389,10 +389,34 @@ describe("timeZoneName", () => {
         { timeZone: "UTC", timeZoneName: "longOffset", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
         { timeZone: "UTC", timeZoneName: "shortGeneric", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
         { timeZone: "UTC", timeZoneName: "longGeneric", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
+
+        { timeZone: "America/New_York", timeZoneName: "short", en0: "12/7/2021, 12:40 PM EST", en1: "1/23/1989, 2:08 AM EST", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م غرينتش-٥", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص غرينتش-٥" },
+        { timeZone: "America/New_York", timeZoneName: "long", en0: "12/7/2021, 12:40 PM Eastern Standard Time", en1: "1/23/1989, 2:08 AM Eastern Standard Time", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م التوقيت الرسمي الشرقي لأمريكا الشمالية", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص التوقيت الرسمي الشرقي لأمريكا الشمالية" },
         { timeZone: "America/New_York", timeZoneName: "shortOffset", en0: "12/7/2021, 12:40 PM GMT-5", en1: "1/23/1989, 2:08 AM GMT-5", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م غرينتش-٥", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص غرينتش-٥" },
         { timeZone: "America/New_York", timeZoneName: "longOffset", en0: "12/7/2021, 12:40 PM GMT-05:00", en1: "1/23/1989, 2:08 AM GMT-05:00", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م غرينتش-٠٥:٠٠", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص غرينتش-٠٥:٠٠" },
         { timeZone: "America/New_York", timeZoneName: "shortGeneric", en0: "12/7/2021, 12:40 PM ET", en1: "1/23/1989, 2:08 AM ET", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م غرينتش-٥", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص غرينتش-٥" },
         { timeZone: "America/New_York", timeZoneName: "longGeneric", en0: "12/7/2021, 12:40 PM Eastern Time", en1: "1/23/1989, 2:08 AM Eastern Time", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م التوقيت الشرقي لأمريكا الشمالية", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص التوقيت الشرقي لأمريكا الشمالية" },
+
+        { timeZone: "Europe/London", timeZoneName: "short", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
+        { timeZone: "Europe/London", timeZoneName: "long", en0: "12/7/2021, 5:40 PM Greenwich Mean Time", en1: "1/23/1989, 7:08 AM Greenwich Mean Time", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م توقيت غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص توقيت غرينتش" },
+        { timeZone: "Europe/London", timeZoneName: "shortOffset", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
+        { timeZone: "Europe/London", timeZoneName: "longOffset", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
+        { timeZone: "Europe/London", timeZoneName: "shortGeneric", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
+        { timeZone: "Europe/London", timeZoneName: "longGeneric", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
+
+        { timeZone: "America/Los_Angeles", timeZoneName: "short", en0: "12/7/2021, 9:40 AM PST", en1: "1/22/1989, 11:08 PM PST", ar0: "٧‏/١٢‏/٢٠٢١, ٩:٤٠ ص غرينتش-٨", ar1: "٢٢‏/١‏/١٩٨٩, ١١:٠٨ م غرينتش-٨" },
+        { timeZone: "America/Los_Angeles", timeZoneName: "long", en0: "12/7/2021, 9:40 AM Pacific Standard Time", en1: "1/22/1989, 11:08 PM Pacific Standard Time", ar0: "٧‏/١٢‏/٢٠٢١, ٩:٤٠ ص توقيت المحيط الهادي الرسمي", ar1: "٢٢‏/١‏/١٩٨٩, ١١:٠٨ م توقيت المحيط الهادي الرسمي" },
+        { timeZone: "America/Los_Angeles", timeZoneName: "shortOffset", en0: "12/7/2021, 9:40 AM GMT-8", en1: "1/22/1989, 11:08 PM GMT-8", ar0: "٧‏/١٢‏/٢٠٢١, ٩:٤٠ ص غرينتش-٨", ar1: "٢٢‏/١‏/١٩٨٩, ١١:٠٨ م غرينتش-٨" },
+        { timeZone: "America/Los_Angeles", timeZoneName: "longOffset", en0: "12/7/2021, 9:40 AM GMT-08:00", en1: "1/22/1989, 11:08 PM GMT-08:00", ar0: "٧‏/١٢‏/٢٠٢١, ٩:٤٠ ص غرينتش-٠٨:٠٠", ar1: "٢٢‏/١‏/١٩٨٩, ١١:٠٨ م غرينتش-٠٨:٠٠" },
+        { timeZone: "America/Los_Angeles", timeZoneName: "shortGeneric", en0: "12/7/2021, 9:40 AM PT", en1: "1/22/1989, 11:08 PM PT", ar0: "٧‏/١٢‏/٢٠٢١, ٩:٤٠ ص غرينتش-٨", ar1: "٢٢‏/١‏/١٩٨٩, ١١:٠٨ م غرينتش-٨" },
+        { timeZone: "America/Los_Angeles", timeZoneName: "longGeneric", en0: "12/7/2021, 9:40 AM Pacific Time", en1: "1/22/1989, 11:08 PM Pacific Time", ar0: "٧‏/١٢‏/٢٠٢١, ٩:٤٠ ص توقيت المحيط الهادي", ar1: "٢٢‏/١‏/١٩٨٩, ١١:٠٨ م توقيت المحيط الهادي" },
+
+        { timeZone: "Asia/Kathmandu", timeZoneName: "short", en0: "12/7/2021, 11:25 PM GMT+5:45", en1: "1/23/1989, 12:53 PM GMT+5:45", ar0: "٧‏/١٢‏/٢٠٢١, ١١:٢٥ م غرينتش+٥:٤٥", ar1: "٢٣‏/١‏/١٩٨٩, ١٢:٥٣ م غرينتش+٥:٤٥" },
+        { timeZone: "Asia/Kathmandu", timeZoneName: "long", en0: "12/7/2021, 11:25 PM Nepal Time", en1: "1/23/1989, 12:53 PM Nepal Time", ar0: "٧‏/١٢‏/٢٠٢١, ١١:٢٥ م توقيت نيبال", ar1: "٢٣‏/١‏/١٩٨٩, ١٢:٥٣ م توقيت نيبال" },
+        { timeZone: "Asia/Kathmandu", timeZoneName: "shortOffset", en0: "12/7/2021, 11:25 PM GMT+5:45", en1: "1/23/1989, 12:53 PM GMT+5:45", ar0: "٧‏/١٢‏/٢٠٢١, ١١:٢٥ م غرينتش+٥:٤٥", ar1: "٢٣‏/١‏/١٩٨٩, ١٢:٥٣ م غرينتش+٥:٤٥" },
+        { timeZone: "Asia/Kathmandu", timeZoneName: "longOffset", en0: "12/7/2021, 11:25 PM GMT+05:45", en1: "1/23/1989, 12:53 PM GMT+05:45", ar0: "٧‏/١٢‏/٢٠٢١, ١١:٢٥ م غرينتش+٠٥:٤٥", ar1: "٢٣‏/١‏/١٩٨٩, ١٢:٥٣ م غرينتش+٠٥:٤٥" },
+        { timeZone: "Asia/Kathmandu", timeZoneName: "shortGeneric", en0: "12/7/2021, 11:25 PM GMT+5:45", en1: "1/23/1989, 12:53 PM GMT+5:45", ar0: "٧‏/١٢‏/٢٠٢١, ١١:٢٥ م غرينتش+٥:٤٥", ar1: "٢٣‏/١‏/١٩٨٩, ١٢:٥٣ م غرينتش+٥:٤٥" },
+        { timeZone: "Asia/Kathmandu", timeZoneName: "longGeneric", en0: "12/7/2021, 11:25 PM GMT+05:45", en1: "1/23/1989, 12:53 PM GMT+05:45", ar0: "٧‏/١٢‏/٢٠٢١, ١١:٢٥ م غرينتش+٠٥:٤٥", ar1: "٢٣‏/١‏/١٩٨٩, ١٢:٥٣ م غرينتش+٠٥:٤٥" },
     ];
 
     test("all", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.format.js
@@ -389,13 +389,10 @@ describe("timeZoneName", () => {
         { timeZone: "UTC", timeZoneName: "longOffset", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
         { timeZone: "UTC", timeZoneName: "shortGeneric", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
         { timeZone: "UTC", timeZoneName: "longGeneric", en0: "12/7/2021, 5:40 PM GMT", en1: "1/23/1989, 7:08 AM GMT", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش" },
-
-        // FIXME: The time stamps on the below cases are incorrect as they do not adjust the time based on the GMT offset.
-        //        Update these once the LocalTZA AO is implemented and ToLocalTime uses it.
-        { timeZone: "America/New_York", timeZoneName: "shortOffset", en0: "12/7/2021, 5:40 PM GMT-5", en1: "1/23/1989, 7:08 AM GMT-5", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش-٥", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش-٥" },
-        { timeZone: "America/New_York", timeZoneName: "longOffset", en0: "12/7/2021, 5:40 PM GMT-05:00", en1: "1/23/1989, 7:08 AM GMT-05:00", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش-٠٥:٠٠", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش-٠٥:٠٠" },
-        { timeZone: "America/New_York", timeZoneName: "shortGeneric", en0: "12/7/2021, 5:40 PM ET", en1: "1/23/1989, 7:08 AM ET", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م غرينتش-٥", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص غرينتش-٥" },
-        { timeZone: "America/New_York", timeZoneName: "longGeneric", en0: "12/7/2021, 5:40 PM Eastern Time", en1: "1/23/1989, 7:08 AM Eastern Time", ar0: "٧‏/١٢‏/٢٠٢١, ٥:٤٠ م التوقيت الشرقي لأمريكا الشمالية", ar1: "٢٣‏/١‏/١٩٨٩, ٧:٠٨ ص التوقيت الشرقي لأمريكا الشمالية" },
+        { timeZone: "America/New_York", timeZoneName: "shortOffset", en0: "12/7/2021, 12:40 PM GMT-5", en1: "1/23/1989, 2:08 AM GMT-5", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م غرينتش-٥", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص غرينتش-٥" },
+        { timeZone: "America/New_York", timeZoneName: "longOffset", en0: "12/7/2021, 12:40 PM GMT-05:00", en1: "1/23/1989, 2:08 AM GMT-05:00", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م غرينتش-٠٥:٠٠", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص غرينتش-٠٥:٠٠" },
+        { timeZone: "America/New_York", timeZoneName: "shortGeneric", en0: "12/7/2021, 12:40 PM ET", en1: "1/23/1989, 2:08 AM ET", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م غرينتش-٥", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص غرينتش-٥" },
+        { timeZone: "America/New_York", timeZoneName: "longGeneric", en0: "12/7/2021, 12:40 PM Eastern Time", en1: "1/23/1989, 2:08 AM Eastern Time", ar0: "٧‏/١٢‏/٢٠٢١, ١٢:٤٠ م التوقيت الشرقي لأمريكا الشمالية", ar1: "٢٣‏/١‏/١٩٨٩, ٢:٠٨ ص التوقيت الشرقي لأمريكا الشمالية" },
     ];
 
     test("all", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.formatRangeToParts.js
@@ -347,7 +347,7 @@ describe("timeStyle", () => {
     // FIXME: These results should include the date, even though it isn't requested, because the start/end dates
     //        are more than just hours apart. See the FIXME in PartitionDateTimeRangePattern.
     test("full", () => {
-        const en = new Intl.DateTimeFormat("en", { timeStyle: "full" });
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "full", timeZone: "UTC" });
         expect(en.formatRangeToParts(d0, d1)).toEqual([
             { type: "hour", value: "7", source: "startRange" },
             { type: "literal", value: ":", source: "startRange" },
@@ -370,7 +370,7 @@ describe("timeStyle", () => {
             { type: "timeZoneName", value: "Coordinated Universal Time", source: "endRange" },
         ]);
 
-        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "full" });
+        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "full", timeZone: "UTC" });
         expect(ja.formatRangeToParts(d0, d1)).toEqual([
             { type: "hour", value: "7", source: "startRange" },
             { type: "literal", value: "時", source: "startRange" },
@@ -391,7 +391,7 @@ describe("timeStyle", () => {
     });
 
     test("long", () => {
-        const en = new Intl.DateTimeFormat("en", { timeStyle: "long" });
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "long", timeZone: "UTC" });
         expect(en.formatRangeToParts(d0, d1)).toEqual([
             { type: "hour", value: "7", source: "startRange" },
             { type: "literal", value: ":", source: "startRange" },
@@ -414,7 +414,7 @@ describe("timeStyle", () => {
             { type: "timeZoneName", value: "UTC", source: "endRange" },
         ]);
 
-        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "long" });
+        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "long", timeZone: "UTC" });
         expect(ja.formatRangeToParts(d0, d1)).toEqual([
             { type: "hour", value: "7", source: "startRange" },
             { type: "literal", value: ":", source: "startRange" },
@@ -435,7 +435,7 @@ describe("timeStyle", () => {
     });
 
     test("medium", () => {
-        const en = new Intl.DateTimeFormat("en", { timeStyle: "medium" });
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "medium", timeZone: "UTC" });
         expect(en.formatRangeToParts(d0, d1)).toEqual([
             { type: "hour", value: "7", source: "startRange" },
             { type: "literal", value: ":", source: "startRange" },
@@ -454,7 +454,7 @@ describe("timeStyle", () => {
             { type: "dayPeriod", value: "PM", source: "endRange" },
         ]);
 
-        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "medium" });
+        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "medium", timeZone: "UTC" });
         expect(ja.formatRangeToParts(d0, d1)).toEqual([
             { type: "hour", value: "7", source: "startRange" },
             { type: "literal", value: ":", source: "startRange" },
@@ -471,7 +471,7 @@ describe("timeStyle", () => {
     });
 
     test("short", () => {
-        const en = new Intl.DateTimeFormat("en", { timeStyle: "short" });
+        const en = new Intl.DateTimeFormat("en", { timeStyle: "short", timeZone: "UTC" });
         expect(en.formatRangeToParts(d0, d1)).toEqual([
             { type: "hour", value: "7", source: "startRange" },
             { type: "literal", value: ":", source: "startRange" },
@@ -486,7 +486,7 @@ describe("timeStyle", () => {
             { type: "dayPeriod", value: "PM", source: "endRange" },
         ]);
 
-        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "short" });
+        const ja = new Intl.DateTimeFormat("ja", { timeStyle: "short", timeZone: "UTC" });
         expect(ja.formatRangeToParts(d0, d1)).toEqual([
             { type: "hour", value: "7", source: "startRange" },
             { type: "literal", value: ":", source: "startRange" },

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
@@ -86,8 +86,8 @@ describe("correct behavior", () => {
     });
 
     test("style", () => {
-        const en = new Intl.DateTimeFormat("en");
-        expect(en.resolvedOptions().timeZone).toBe("UTC");
+        const en = new Intl.DateTimeFormat("en", { timeZone: "EST" });
+        expect(en.resolvedOptions().timeZone).toBe("EST");
 
         const el = new Intl.DateTimeFormat("el", { timeZone: "UTC" });
         expect(el.resolvedOptions().timeZone).toBe("UTC");

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDate.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDate.js
@@ -17,7 +17,7 @@ describe("correct behavior", () => {
                 return 86400000000000;
             },
         };
-        const plainDate = Temporal.Now.plainDate(calendar);
+        const plainDate = Temporal.Now.plainDate(calendar, "UTC");
         const plainDateWithOffset = Temporal.Now.plainDate(calendar, timeZone);
         if (plainDate.dayOfYear === plainDate.daysInYear) {
             expect(plainDateWithOffset.year).toBe(plainDate.year + 1);

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateISO.js
@@ -15,7 +15,7 @@ describe("correct behavior", () => {
                 return 86400000000000;
             },
         };
-        const plainDate = Temporal.Now.plainDateISO();
+        const plainDate = Temporal.Now.plainDateISO("UTC");
         const plainDateWithOffset = Temporal.Now.plainDateISO(timeZone);
         if (plainDate.dayOfYear === plainDate.daysInYear) {
             expect(plainDateWithOffset.year).toBe(plainDate.year + 1);

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTime.js
@@ -37,7 +37,7 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTime = Temporal.Now.plainDateTime(calendar);
+        const plainDateTime = Temporal.Now.plainDateTime(calendar, "UTC");
         const plainDateTimeWithOffset = Temporal.Now.plainDateTime(calendar, timeZone);
 
         if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
@@ -58,7 +58,7 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTime = Temporal.Now.plainDateTime(calendar);
+        const plainDateTime = Temporal.Now.plainDateTime(calendar, "UTC");
         const plainDateTimeWithOffset = Temporal.Now.plainDateTime(calendar, timeZone);
 
         if (plainDateTime.year !== plainDateTimeWithOffset.year) return;

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainDateTimeISO.js
@@ -35,7 +35,7 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTime = Temporal.Now.plainDateTimeISO();
+        const plainDateTime = Temporal.Now.plainDateTimeISO("UTC");
         const plainDateTimeWithOffset = Temporal.Now.plainDateTimeISO(timeZone);
 
         if (plainDateTime.year !== plainDateTimeWithOffset.year) return;
@@ -55,7 +55,7 @@ describe("correct behavior", () => {
             },
         };
 
-        const plainDateTime = Temporal.Now.plainDateTimeISO();
+        const plainDateTime = Temporal.Now.plainDateTimeISO("UTC");
         const plainDateTimeWithOffset = Temporal.Now.plainDateTimeISO(timeZone);
 
         if (plainDateTime.year !== plainDateTimeWithOffset.year) return;

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainTimeISO.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Now/Now.plainTimeISO.js
@@ -15,7 +15,7 @@ describe("correct behavior", () => {
                 return 86400000000000;
             },
         };
-        const plainTime = Temporal.Now.plainTimeISO();
+        const plainTime = Temporal.Now.plainTimeISO("UTC");
         const plainTimeWithOffset = Temporal.Now.plainTimeISO(timeZone);
         // FIXME: Compare these in a sensible way
     });

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibTimeZone/TimeZone.h>
+#include <time.h>
 
 namespace TimeZone {
 
@@ -18,6 +19,17 @@ enum class TimeZone : u16 {
     UTC,
 };
 #endif
+
+StringView current_time_zone()
+{
+    static bool initialized_time_zone = false;
+    if (!initialized_time_zone) {
+        initialized_time_zone = true;
+        tzset();
+    }
+
+    return tzname[0];
+}
 
 Optional<TimeZone> __attribute__((weak)) time_zone_from_string([[maybe_unused]] StringView time_zone)
 {

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -14,6 +14,8 @@
 
 namespace TimeZone {
 
+StringView current_time_zone();
+
 Optional<TimeZone> time_zone_from_string(StringView time_zone);
 StringView time_zone_to_string(TimeZone time_zone);
 Optional<StringView> canonicalize_time_zone(StringView time_zone);


### PR DESCRIPTION
```js
> Intl.DateTimeFormat([], { timeZoneName: "long", timeZone: "America/New_York" }).format()
"1/12/2022, 8:29 AM Eastern Standard Time"
> Intl.DateTimeFormat([], { timeZoneName: "long", timeZone: "UTC" }).format()
"1/12/2022, 1:29 PM Coordinated Universal Time"
> Intl.DateTimeFormat([], { timeZoneName: "long", timeZone: "Australia/Sydney" }).format()
"1/12/2022, 11:29 PM Australian Eastern Standard Time"
```