### PR TITLE
LibGUI: Add existing children widgets when layout manager changed

### DIFF
--- a/Userland/Libraries/LibGUI/Layout.cpp
+++ b/Userland/Libraries/LibGUI/Layout.cpp
@@ -46,12 +46,17 @@ void Layout::notify_adopted(Badge<Widget>, Widget& widget)
     if (m_owner == &widget)
         return;
     m_owner = widget;
+    m_owner->for_each_child_widget([&](Widget& child) {
+        add_widget(child);
+        return IterationDecision::Continue;
+    });
 }
 
 void Layout::notify_disowned(Badge<Widget>, Widget& widget)
 {
     VERIFY(m_owner == &widget);
     m_owner.clear();
+    m_entries.clear();
 }
 
 ErrorOr<void> Layout::try_add_entry(Entry&& entry)


### PR DESCRIPTION
(This is my first PR in this project.  I apologize in advance for any process mistakes.  Please let me know—thanks!)

If a widget gains a layout manager after it already has child widgets, the existing widgets are unknown to the layout.  Additionally, if a layout is reused, it may end up managing children of multiple different widgets.

To simplify this, clear the entries of a layout manager when its owner changes, and add any existing children when a new owner comes along.