### PR TITLE
AK/LibC: Some minor trivial fixes

### DIFF
--- a/AK/Demangle.h
+++ b/AK/Demangle.h
@@ -20,7 +20,7 @@ inline String demangle(StringView name)
     auto* demangled_name = abi::__cxa_demangle(name.to_string().characters(), nullptr, nullptr, &status);
     auto string = String(status == 0 ? demangled_name : name);
     if (status == 0)
-        kfree(demangled_name);
+        free(demangled_name);
     return string;
 }
 

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -15,7 +15,6 @@
 #    include <new>
 #    include <stdlib.h>
 
-#    define kcalloc calloc
 #    define kmalloc malloc
 #    define kmalloc_good_size malloc_good_size
 #    define kfree free

--- a/AK/kmalloc.h
+++ b/AK/kmalloc.h
@@ -17,11 +17,10 @@
 
 #    define kmalloc malloc
 #    define kmalloc_good_size malloc_good_size
-#    define kfree free
 
 inline void kfree_sized(void* ptr, size_t)
 {
-    kfree(ptr);
+    free(ptr);
 }
 #endif
 

--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -9,6 +9,7 @@ set(TEST_SOURCES
     TestLibCSetjmp.cpp
     TestLibCString.cpp
     TestLibCTime.cpp
+    TestMalloc.cpp
     TestMemmem.cpp
     TestQsort.cpp
     TestRaise.cpp

--- a/Tests/LibC/TestMalloc.cpp
+++ b/Tests/LibC/TestMalloc.cpp
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <LibC/mallocdefs.h>
+#include <errno.h>
+#include <stdlib.h>
+
+TEST_CASE(malloc_limits)
+{
+    EXPECT_NO_CRASH("Allocation of 0 size should succed at allocation and release", [] {
+        errno = 0;
+        void* ptr = malloc(0);
+        EXPECT_EQ(errno, 0);
+        free(ptr);
+        return Test::Crash::Failure::DidNotCrash;
+    });
+
+    EXPECT_NO_CRASH("Allocation of the maximum `size_t` value should fails with `ENOMEM`", [] {
+        errno = 0;
+        void* ptr = malloc(NumericLimits<size_t>::max());
+        EXPECT_EQ(errno, ENOMEM);
+        EXPECT_EQ(ptr, nullptr);
+        free(ptr);
+        return Test::Crash::Failure::DidNotCrash;
+    });
+
+    EXPECT_NO_CRASH("Allocation of the maximum `size_t` value that does not overflow should fails with `ENOMEM`", [] {
+        errno = 0;
+        void* ptr = malloc(NumericLimits<size_t>::max() - ChunkedBlock::block_size - sizeof(BigAllocationBlock));
+        EXPECT_EQ(errno, ENOMEM);
+        EXPECT_EQ(ptr, nullptr);
+        free(ptr);
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}

--- a/Userland/Libraries/LibC/dirent.cpp
+++ b/Userland/Libraries/LibC/dirent.cpp
@@ -278,6 +278,9 @@ int scandir(const char* dir_name,
 
     const int size = tmp_names.size();
     auto** names = static_cast<struct dirent**>(kmalloc_array(size, sizeof(struct dirent*)));
+    if (names == nullptr) {
+        return -1;
+    }
     for (auto i = 0; i < size; i++) {
         names[i] = tmp_names[i];
     }

--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -431,6 +431,7 @@ static void free_impl(void* ptr)
     }
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/malloc.html
 void* malloc(size_t size)
 {
     MemoryAuditingSuppressor suppressor;
@@ -471,6 +472,7 @@ void* _aligned_malloc(size_t size, size_t alignment)
     return aligned_ptr;
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/free.html
 void free(void* ptr)
 {
     MemoryAuditingSuppressor suppressor;
@@ -486,6 +488,7 @@ void _aligned_free(void* ptr)
         free(((void**)ptr)[-1]);
 }
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/calloc.html
 void* calloc(size_t count, size_t size)
 {
     MemoryAuditingSuppressor suppressor;

--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -183,7 +183,11 @@ static void* os_alloc(size_t size, const char* name)
     flags |= MAP_RANDOMIZED;
 #endif
     auto* ptr = serenity_mmap(nullptr, size, PROT_READ | PROT_WRITE, flags, 0, 0, ChunkedBlock::block_size, name);
-    VERIFY(ptr != MAP_FAILED);
+    VERIFY(ptr != nullptr);
+    if (ptr == MAP_FAILED) {
+        errno = ENOMEM;
+        return nullptr;
+    }
     return ptr;
 }
 
@@ -228,6 +232,11 @@ static void* malloc_impl(size_t size, CallerWillInitializeMemory caller_will_ini
 
     if (!allocator) {
         size_t real_size = round_up_to_power_of_two(sizeof(BigAllocationBlock) + size, ChunkedBlock::block_size);
+        if (real_size < size) {
+            dbgln_if(MALLOC_DEBUG, "LibC: Detected overflow trying to do big allocation of size {} for {}", real_size, size);
+            errno = ENOMEM;
+            return nullptr;
+        }
 #ifdef RECYCLE_BIG_ALLOCATIONS
         if (auto* allocator = big_allocator_for_size(real_size)) {
             if (!allocator->blocks.is_empty()) {
@@ -253,8 +262,12 @@ static void* malloc_impl(size_t size, CallerWillInitializeMemory caller_will_ini
             }
         }
 #endif
-        g_malloc_stats.number_of_big_allocs++;
         auto* block = (BigAllocationBlock*)os_alloc(real_size, "malloc: BigAllocationBlock");
+        if (block == nullptr) {
+            dbgln_if(MALLOC_DEBUG, "LibC: Failed to do big allocation of size {} for {}", real_size, size);
+            return nullptr;
+        }
+        g_malloc_stats.number_of_big_allocs++;
         new (block) BigAllocationBlock(real_size);
         ue_notify_malloc(&block->m_slot[0], size);
         return &block->m_slot[0];
@@ -309,6 +322,9 @@ static void* malloc_impl(size_t size, CallerWillInitializeMemory caller_will_ini
         char buffer[64];
         snprintf(buffer, sizeof(buffer), "malloc: ChunkedBlock(%zu)", good_size);
         block = (ChunkedBlock*)os_alloc(ChunkedBlock::block_size, buffer);
+        if (block == nullptr) {
+            return nullptr;
+        }
         new (block) ChunkedBlock(good_size);
         allocator->usable_blocks.append(*block);
         ++allocator->block_count;


### PR DESCRIPTION
Hi,

The following patch set removes `kcalloc` and `kfree`. They are not defined by the kernel, so it is pointless to make magic aliases to them in user-land.

Also fix an issue in `LibC` `scandir` where the allocation failure of the result buffer is not being checked.
