### PR TITLE
LibSoftGPU: Don't render triangle strip if there's less than 3 vertices

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -607,6 +607,8 @@ void Device::draw_primitives(PrimitiveType primitive_type, FloatMatrix4x4 const&
         }
     } else if (primitive_type == PrimitiveType::TriangleStrip) {
         Triangle triangle;
+        if (vertices.size() < 3)
+            return;
         for (size_t i = 0; i < vertices.size() - 2; i++) {
             if (i % 2 == 0) {
                 triangle.vertices[0] = vertices.at(i);


### PR DESCRIPTION
If there's less than 3 vertices, we cannot do triangle strip otherwise
we will go out-of-bounds of the vertices vector.

Required for Half-Life, which sometimes submits 0 vertices for triangle
strip when drawing the electric disks around the pillars in Xen.