### PR TITLE
Taskbar: Include `ScreenLayout.h` from `Services` directory

### DIFF
--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -12,7 +12,7 @@
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/ShareableBitmap.h>
-#include <WindowServer/ScreenLayout.h>
+#include <Services/WindowServer/ScreenLayout.h>
 
 class TaskbarWindow final : public GUI::Window {
     C_OBJECT(TaskbarWindow);


### PR DESCRIPTION
While trying to include `Desktop.h` for the SDL2 port, compilation failed on finding this include. Specify the full include path to make it work.

Related SDL PR: https://github.com/SerenityPorts/SDL/pull/27