### PR TITLE
LibGUI: Print error when failing to load thumbnail in FileSystemModel

### DIFF
--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -657,9 +657,10 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
         [this, path, weak_this](auto thumbnail_or_error) {
             if (thumbnail_or_error.is_error()) {
                 s_thumbnail_cache.set(path, nullptr);
-                return;
+                dbgln("Failed to load thumbnail for {}: {}", path, thumbnail_or_error.error());
+            } else {
+                s_thumbnail_cache.set(path, thumbnail_or_error.release_value());
             }
-            s_thumbnail_cache.set(path, thumbnail_or_error.release_value());
 
             // The model was destroyed, no need to update
             // progress or call any event handlers.


### PR DESCRIPTION
Previously when failing to load a thumbnail the progress bar would get stuck without conveying any error message, instead print out a descriptive error message and increase the progress bar so that it goes away when done loading all the thumbnails.