### PR TITLE
FontEditor: Add Klingon phrase to Preview Font :^)

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -42,7 +42,7 @@
 #include <LibUnicode/CharacterTypes.h>
 #include <stdlib.h>
 
-static constexpr int s_pangram_count = 7;
+static constexpr int s_pangram_count = 8;
 static char const* pangrams[s_pangram_count] = {
     "quick fox jumps nightly above wizard",
     "five quacking zephyrs jolt my wax bed",
@@ -50,7 +50,8 @@ static char const* pangrams[s_pangram_count] = {
     "quick brown fox jumps over the lazy dog",
     "waxy and quivering jocks fumble the pizza",
     "~#:[@_1%]*{$2.3}/4^(5'6\")-&|7+8!=<9,0\\>?;",
-    "byxfjärmat föl gick på duvshowen"
+    "byxfjärmat föl gick på duvshowen",
+    "         "
 };
 
 static RefPtr<GUI::Window> create_font_preview_window(FontEditorWidget& editor)


### PR DESCRIPTION
Based on https://twitter.com/wcools/status/1481269227302658056 this PR adds the Klingon translation of "The quick brown fox jumps over the lazy targ" to "Preview Font" in FontEditor

         

(Doq 'ej wovbe' qeSHoS Sup 'ej Dung buD targh tol)

I found the phrase so funny and so meta but the utility is obviously low.

![FontEditor-preview-Klingon](https://user-images.githubusercontent.com/93391300/149218257-d9c138ac-c3cd-4c93-a350-5e89e4245b6d.png)