### PR TITLE
Kernel: Make the construction of VMObject and its child classes OOM-aware

### DIFF
--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -55,6 +55,19 @@ public:
         return FixedArray<T>(N, elements);
     }
 
+    template<typename U>
+    static ErrorOr<FixedArray<T>> try_create(Span<U> span)
+    {
+        if (span.size() == 0)
+            return FixedArray<T>();
+        T* elements = static_cast<T*>(kmalloc_array(span.size(), sizeof(T)));
+        if (!elements)
+            return Error::from_errno(ENOMEM);
+        for (size_t i = 0; i < span.size(); ++i)
+            new (&elements[i]) T(span[i]);
+        return FixedArray<T>(span.size(), elements);
+    }
+
     ErrorOr<FixedArray<T>> try_clone() const
     {
         if (m_size == 0)

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -38,6 +38,23 @@ public:
         return MUST(try_create(size));
     }
 
+    // NOTE:
+    // Even though it may look like there will be a template instantiation of this function for every size,
+    // the compiler will inline this anyway and therefore not generate any duplicate code.
+
+    template<size_t N>
+    static ErrorOr<FixedArray<T>> try_create(T(&&array)[N])
+    {
+        if (N == 0)
+            return FixedArray<T>();
+        T* elements = static_cast<T*>(kmalloc_array(N, sizeof(T)));
+        if (!elements)
+            return Error::from_errno(ENOMEM);
+        for (size_t i = 0; i < N; ++i)
+            new (&elements[i]) T(move(array[i]));
+        return FixedArray<T>(N, elements);
+    }
+
     ErrorOr<FixedArray<T>> try_clone() const
     {
         if (m_size == 0)

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -43,7 +43,8 @@ ErrorOr<NonnullRefPtr<VMObject>> AnonymousVMObject::try_clone()
     // one and this one, as well as the clone have sufficient resources
     // to cow all pages as needed
     auto new_shared_committed_cow_pages = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SharedCommittedCowPages(move(committed_pages))));
-    auto clone = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(*this, *new_shared_committed_cow_pages)));
+    auto new_physical_pages = TRY(this->try_clone_physical_pages());
+    auto clone = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(*this, *new_shared_committed_cow_pages, move(new_physical_pages))));
 
     m_shared_committed_cow_pages = move(new_shared_committed_cow_pages);
 
@@ -73,7 +74,9 @@ ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_with_siz
         committed_pages = TRY(MM.commit_user_physical_pages(ceil_div(size, static_cast<size_t>(PAGE_SIZE))));
     }
 
-    return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(size, strategy, move(committed_pages)));
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
+
+    return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(move(new_physical_pages), strategy, move(committed_pages)));
 }
 
 ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_physically_contiguous_with_size(size_t size)
@@ -82,7 +85,9 @@ ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_physical
     if (contiguous_physical_pages.is_empty())
         return ENOMEM;
 
-    return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(contiguous_physical_pages.span()));
+    auto new_physical_pages = TRY(FixedArray<RefPtr<PhysicalPage>>::try_create(contiguous_physical_pages.span()));
+
+    return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(move(new_physical_pages)));
 }
 
 ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_purgeable_with_size(size_t size, AllocationStrategy strategy)
@@ -92,14 +97,17 @@ ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_purgeabl
         committed_pages = TRY(MM.commit_user_physical_pages(ceil_div(size, static_cast<size_t>(PAGE_SIZE))));
     }
 
-    auto vmobject = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(size, strategy, move(committed_pages))));
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
+
+    auto vmobject = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(move(new_physical_pages), strategy, move(committed_pages))));
     vmobject->m_purgeable = true;
     return vmobject;
 }
 
 ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_with_physical_pages(Span<NonnullRefPtr<PhysicalPage>> physical_pages)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(physical_pages));
+    auto new_physical_pages = TRY(FixedArray<RefPtr<PhysicalPage>>::try_create(physical_pages));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(move(new_physical_pages)));
 }
 
 ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_for_physical_range(PhysicalAddress paddr, size_t size)
@@ -110,11 +118,13 @@ ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_for_phys
         return ENOMEM;
     }
 
-    return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(paddr, size));
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
+
+    return adopt_nonnull_ref_or_enomem(new (nothrow) AnonymousVMObject(paddr, move(new_physical_pages)));
 }
 
-AnonymousVMObject::AnonymousVMObject(size_t size, AllocationStrategy strategy, Optional<CommittedPhysicalPageSet> committed_pages)
-    : VMObject(VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
+AnonymousVMObject::AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, AllocationStrategy strategy, Optional<CommittedPhysicalPageSet> committed_pages)
+    : VMObject(move(new_physical_pages))
     , m_unused_committed_pages(move(committed_pages))
 {
     if (strategy == AllocationStrategy::AllocateNow) {
@@ -128,24 +138,21 @@ AnonymousVMObject::AnonymousVMObject(size_t size, AllocationStrategy strategy, O
     }
 }
 
-AnonymousVMObject::AnonymousVMObject(PhysicalAddress paddr, size_t size)
-    : VMObject(VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
+AnonymousVMObject::AnonymousVMObject(PhysicalAddress paddr, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+    : VMObject(move(new_physical_pages))
 {
     VERIFY(paddr.page_base() == paddr);
     for (size_t i = 0; i < page_count(); ++i)
         physical_pages()[i] = PhysicalPage::create(paddr.offset(i * PAGE_SIZE), MayReturnToFreeList::No);
 }
 
-AnonymousVMObject::AnonymousVMObject(Span<NonnullRefPtr<PhysicalPage>> physical_pages)
-    : VMObject(VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(physical_pages.size() * PAGE_SIZE))
+AnonymousVMObject::AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+    : VMObject(move(new_physical_pages))
 {
-    for (size_t i = 0; i < physical_pages.size(); ++i) {
-        m_physical_pages[i] = physical_pages[i];
-    }
 }
 
-AnonymousVMObject::AnonymousVMObject(AnonymousVMObject const& other, NonnullRefPtr<SharedCommittedCowPages> shared_committed_cow_pages)
-    : VMObject(other.must_clone_physical_pages_but_fixme_should_propagate_errors())
+AnonymousVMObject::AnonymousVMObject(AnonymousVMObject const& other, NonnullRefPtr<SharedCommittedCowPages> shared_committed_cow_pages, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+    : VMObject(move(new_physical_pages))
     , m_shared_committed_cow_pages(move(shared_committed_cow_pages))
     , m_purgeable(other.m_purgeable)
 {

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -114,7 +114,7 @@ ErrorOr<NonnullRefPtr<AnonymousVMObject>> AnonymousVMObject::try_create_for_phys
 }
 
 AnonymousVMObject::AnonymousVMObject(size_t size, AllocationStrategy strategy, Optional<CommittedPhysicalPageSet> committed_pages)
-    : VMObject(size)
+    : VMObject(VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
     , m_unused_committed_pages(move(committed_pages))
 {
     if (strategy == AllocationStrategy::AllocateNow) {
@@ -129,7 +129,7 @@ AnonymousVMObject::AnonymousVMObject(size_t size, AllocationStrategy strategy, O
 }
 
 AnonymousVMObject::AnonymousVMObject(PhysicalAddress paddr, size_t size)
-    : VMObject(size)
+    : VMObject(VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
 {
     VERIFY(paddr.page_base() == paddr);
     for (size_t i = 0; i < page_count(); ++i)
@@ -137,7 +137,7 @@ AnonymousVMObject::AnonymousVMObject(PhysicalAddress paddr, size_t size)
 }
 
 AnonymousVMObject::AnonymousVMObject(Span<NonnullRefPtr<PhysicalPage>> physical_pages)
-    : VMObject(physical_pages.size() * PAGE_SIZE)
+    : VMObject(VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(physical_pages.size() * PAGE_SIZE))
 {
     for (size_t i = 0; i < physical_pages.size(); ++i) {
         m_physical_pages[i] = physical_pages[i];
@@ -145,7 +145,7 @@ AnonymousVMObject::AnonymousVMObject(Span<NonnullRefPtr<PhysicalPage>> physical_
 }
 
 AnonymousVMObject::AnonymousVMObject(AnonymousVMObject const& other, NonnullRefPtr<SharedCommittedCowPages> shared_committed_cow_pages)
-    : VMObject(other)
+    : VMObject(other.must_clone_physical_pages_but_fixme_should_propagate_errors())
     , m_shared_committed_cow_pages(move(shared_committed_cow_pages))
     , m_purgeable(other.m_purgeable)
 {

--- a/Kernel/Memory/AnonymousVMObject.h
+++ b/Kernel/Memory/AnonymousVMObject.h
@@ -41,10 +41,10 @@ public:
 private:
     class SharedCommittedCowPages;
 
-    explicit AnonymousVMObject(size_t, AllocationStrategy, Optional<CommittedPhysicalPageSet>);
-    explicit AnonymousVMObject(PhysicalAddress, size_t);
-    explicit AnonymousVMObject(Span<NonnullRefPtr<PhysicalPage>>);
-    explicit AnonymousVMObject(AnonymousVMObject const&, NonnullRefPtr<SharedCommittedCowPages>);
+    explicit AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&&, AllocationStrategy, Optional<CommittedPhysicalPageSet>);
+    explicit AnonymousVMObject(PhysicalAddress, FixedArray<RefPtr<PhysicalPage>>&&);
+    explicit AnonymousVMObject(FixedArray<RefPtr<PhysicalPage>>&&);
+    explicit AnonymousVMObject(AnonymousVMObject const&, NonnullRefPtr<SharedCommittedCowPages>, FixedArray<RefPtr<PhysicalPage>>&&);
 
     virtual StringView class_name() const override { return "AnonymousVMObject"sv; }
 

--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -10,14 +10,14 @@
 namespace Kernel::Memory {
 
 InodeVMObject::InodeVMObject(Inode& inode, size_t size)
-    : VMObject(size)
+    : VMObject(VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
     , m_inode(inode)
     , m_dirty_pages(page_count(), false)
 {
 }
 
 InodeVMObject::InodeVMObject(InodeVMObject const& other)
-    : VMObject(other)
+    : VMObject(other.must_clone_physical_pages_but_fixme_should_propagate_errors())
     , m_inode(other.m_inode)
     , m_dirty_pages(page_count(), false)
 {

--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -9,15 +9,15 @@
 
 namespace Kernel::Memory {
 
-InodeVMObject::InodeVMObject(Inode& inode, size_t size)
-    : VMObject(VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
+InodeVMObject::InodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+    : VMObject(move(new_physical_pages))
     , m_inode(inode)
     , m_dirty_pages(page_count(), false)
 {
 }
 
-InodeVMObject::InodeVMObject(InodeVMObject const& other)
-    : VMObject(other.must_clone_physical_pages_but_fixme_should_propagate_errors())
+InodeVMObject::InodeVMObject(InodeVMObject const& other, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+    : VMObject(move(new_physical_pages))
     , m_inode(other.m_inode)
     , m_dirty_pages(page_count(), false)
 {

--- a/Kernel/Memory/InodeVMObject.h
+++ b/Kernel/Memory/InodeVMObject.h
@@ -28,8 +28,8 @@ public:
     u32 executable_mappings() const;
 
 protected:
-    explicit InodeVMObject(Inode&, size_t);
-    explicit InodeVMObject(InodeVMObject const&);
+    explicit InodeVMObject(Inode&, FixedArray<RefPtr<PhysicalPage>>&&);
+    explicit InodeVMObject(InodeVMObject const&, FixedArray<RefPtr<PhysicalPage>>&&);
 
     InodeVMObject& operator=(InodeVMObject const&) = delete;
     InodeVMObject& operator=(InodeVMObject&&) = delete;

--- a/Kernel/Memory/PrivateInodeVMObject.cpp
+++ b/Kernel/Memory/PrivateInodeVMObject.cpp
@@ -20,12 +20,12 @@ ErrorOr<NonnullRefPtr<VMObject>> PrivateInodeVMObject::try_clone()
 }
 
 PrivateInodeVMObject::PrivateInodeVMObject(Inode& inode, size_t size)
-    : InodeVMObject(inode, size)
+    : InodeVMObject(inode, VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
 {
 }
 
 PrivateInodeVMObject::PrivateInodeVMObject(PrivateInodeVMObject const& other)
-    : InodeVMObject(other)
+    : InodeVMObject(other, other.must_clone_physical_pages_but_fixme_should_propagate_errors())
 {
 }
 

--- a/Kernel/Memory/PrivateInodeVMObject.h
+++ b/Kernel/Memory/PrivateInodeVMObject.h
@@ -23,8 +23,8 @@ public:
 private:
     virtual bool is_private_inode() const override { return true; }
 
-    explicit PrivateInodeVMObject(Inode&, size_t);
-    explicit PrivateInodeVMObject(PrivateInodeVMObject const&);
+    explicit PrivateInodeVMObject(Inode&, FixedArray<RefPtr<PhysicalPage>>&&);
+    explicit PrivateInodeVMObject(PrivateInodeVMObject const&, FixedArray<RefPtr<PhysicalPage>>&&);
 
     virtual StringView class_name() const override { return "PrivateInodeVMObject"sv; }
 

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -26,12 +26,12 @@ ErrorOr<NonnullRefPtr<VMObject>> SharedInodeVMObject::try_clone()
 }
 
 SharedInodeVMObject::SharedInodeVMObject(Inode& inode, size_t size)
-    : InodeVMObject(inode, size)
+    : InodeVMObject(inode, VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
 {
 }
 
 SharedInodeVMObject::SharedInodeVMObject(SharedInodeVMObject const& other)
-    : InodeVMObject(other)
+    : InodeVMObject(other, other.must_clone_physical_pages_but_fixme_should_propagate_errors())
 {
 }
 

--- a/Kernel/Memory/SharedInodeVMObject.cpp
+++ b/Kernel/Memory/SharedInodeVMObject.cpp
@@ -15,23 +15,25 @@ ErrorOr<NonnullRefPtr<SharedInodeVMObject>> SharedInodeVMObject::try_create_with
     size_t size = inode.size();
     if (auto shared_vmobject = inode.shared_vmobject())
         return shared_vmobject.release_nonnull();
-    auto vmobject = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SharedInodeVMObject(inode, size)));
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
+    auto vmobject = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SharedInodeVMObject(inode, move(new_physical_pages))));
     vmobject->inode().set_shared_vmobject(*vmobject);
     return vmobject;
 }
 
 ErrorOr<NonnullRefPtr<VMObject>> SharedInodeVMObject::try_clone()
 {
-    return adopt_nonnull_ref_or_enomem<VMObject>(new (nothrow) SharedInodeVMObject(*this));
+    auto new_physical_pages = TRY(this->try_clone_physical_pages());
+    return adopt_nonnull_ref_or_enomem<VMObject>(new (nothrow) SharedInodeVMObject(*this, move(new_physical_pages)));
 }
 
-SharedInodeVMObject::SharedInodeVMObject(Inode& inode, size_t size)
-    : InodeVMObject(inode, VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size))
+SharedInodeVMObject::SharedInodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+    : InodeVMObject(inode, move(new_physical_pages))
 {
 }
 
-SharedInodeVMObject::SharedInodeVMObject(SharedInodeVMObject const& other)
-    : InodeVMObject(other, other.must_clone_physical_pages_but_fixme_should_propagate_errors())
+SharedInodeVMObject::SharedInodeVMObject(SharedInodeVMObject const& other, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+    : InodeVMObject(other, move(new_physical_pages))
 {
 }
 

--- a/Kernel/Memory/SharedInodeVMObject.h
+++ b/Kernel/Memory/SharedInodeVMObject.h
@@ -23,8 +23,8 @@ public:
 private:
     virtual bool is_shared_inode() const override { return true; }
 
-    explicit SharedInodeVMObject(Inode&, size_t);
-    explicit SharedInodeVMObject(SharedInodeVMObject const&);
+    explicit SharedInodeVMObject(Inode&, FixedArray<RefPtr<PhysicalPage>>&&);
+    explicit SharedInodeVMObject(SharedInodeVMObject const&, FixedArray<RefPtr<PhysicalPage>>&&);
 
     virtual StringView class_name() const override { return "SharedInodeVMObject"sv; }
 

--- a/Kernel/Memory/VMObject.cpp
+++ b/Kernel/Memory/VMObject.cpp
@@ -22,19 +22,9 @@ ErrorOr<FixedArray<RefPtr<PhysicalPage>>> VMObject::try_clone_physical_pages() c
     return m_physical_pages.try_clone();
 }
 
-FixedArray<RefPtr<PhysicalPage>> VMObject::must_clone_physical_pages_but_fixme_should_propagate_errors() const
-{
-    return MUST(try_clone_physical_pages());
-}
-
 ErrorOr<FixedArray<RefPtr<PhysicalPage>>> VMObject::try_create_physical_pages(size_t size)
 {
     return FixedArray<RefPtr<PhysicalPage>>::try_create(ceil_div(size, static_cast<size_t>(PAGE_SIZE)));
-}
-
-FixedArray<RefPtr<PhysicalPage>> VMObject::must_create_physical_pages_but_fixme_should_propagate_errors(size_t size)
-{
-    return MUST(try_create_physical_pages(size));
 }
 
 VMObject::VMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -54,8 +54,11 @@ public:
     }
 
 protected:
-    explicit VMObject(size_t);
-    explicit VMObject(VMObject const&);
+    static ErrorOr<FixedArray<RefPtr<PhysicalPage>>> try_create_physical_pages(size_t);
+    static FixedArray<RefPtr<PhysicalPage>> must_create_physical_pages_but_fixme_should_propagate_errors(size_t);
+    ErrorOr<FixedArray<RefPtr<PhysicalPage>>> try_clone_physical_pages() const;
+    FixedArray<RefPtr<PhysicalPage>> must_clone_physical_pages_but_fixme_should_propagate_errors() const;
+    explicit VMObject(FixedArray<RefPtr<PhysicalPage>>&&);
 
     template<typename Callback>
     void for_each_region(Callback);

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -55,9 +55,7 @@ public:
 
 protected:
     static ErrorOr<FixedArray<RefPtr<PhysicalPage>>> try_create_physical_pages(size_t);
-    static FixedArray<RefPtr<PhysicalPage>> must_create_physical_pages_but_fixme_should_propagate_errors(size_t);
     ErrorOr<FixedArray<RefPtr<PhysicalPage>>> try_clone_physical_pages() const;
-    FixedArray<RefPtr<PhysicalPage>> must_clone_physical_pages_but_fixme_should_propagate_errors() const;
     explicit VMObject(FixedArray<RefPtr<PhysicalPage>>&&);
 
     template<typename Callback>


### PR DESCRIPTION
This PR forces the child classes of VMObject to allocate the resources it requires (a `FixedArray<RefPtr<PhysicalPage>>`) for it and pass them to it in its constructor. This resource allocation is done fallibly in their factory functions.

I know that the commits look like they should be squashed together, but I thought it would be more understandable for a reader of the commit history to have incremental atomic improvements in this way rather than one big commit.

The FixedArray changes are based on #11805.

This is work towards #6369.