### PR TITLE
AK: Fixate FixedArray's allocation contract and test it extensively

### DIFF
--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -55,7 +55,7 @@ public:
         return MUST(try_clone());
     }
 
-    // NOTE: Nobody can ever use these functions, since it would be impossible to make them OOM-safe due to their signatures. We just explicitly delete them.
+    // Nobody can ever use these functions, since it would be impossible to make them OOM-safe due to their signatures. We just explicitly delete them.
     FixedArray(FixedArray<T> const&) = delete;
     FixedArray<T>& operator=(FixedArray<T> const&) = delete;
 
@@ -66,7 +66,7 @@ public:
         other.m_size = 0;
         other.m_elements = nullptr;
     }
-    // NOTE: Nobody uses this function, so we just explicitly delete it.
+    // This function would violate the contract, as it would need to deallocate this FixedArray. As it also has no use case, we delete it.
     FixedArray<T>& operator=(FixedArray<T>&&) = delete;
 
     ~FixedArray()

--- a/AK/FixedArray.h
+++ b/AK/FixedArray.h
@@ -14,6 +14,8 @@
 
 namespace AK {
 
+// FixedArray is an Array with a size only known at run-time.
+// It guarantees to only allocate when being constructed, and to only deallocate when being destructed.
 template<typename T>
 class FixedArray {
 public:
@@ -69,16 +71,12 @@ public:
 
     ~FixedArray()
     {
-        clear();
-    }
-
-    void clear()
-    {
         if (!m_elements)
             return;
         for (size_t i = 0; i < m_size; ++i)
             m_elements[i].~T();
         kfree_sized(m_elements, sizeof(T) * m_size);
+        // NOTE: should prevent use-after-free early
         m_size = 0;
         m_elements = nullptr;
     }

--- a/AK/NoAllocationGuard.h
+++ b/AK/NoAllocationGuard.h
@@ -58,7 +58,7 @@ private:
 #endif
     }
 
-    bool m_allocation_enabled_previously;
+    bool m_allocation_enabled_previously { true };
 };
 
 }

--- a/AK/NoAllocationGuard.h
+++ b/AK/NoAllocationGuard.h
@@ -39,8 +39,11 @@ private:
     {
 #if defined(KERNEL)
         return Processor::current_thread()->get_allocation_enabled();
-#else
+#elif defined(__serenity__)
+        // This extern thread-local lives in our LibC, which doesn't exist on other systems.
         return s_allocation_enabled;
+#else
+        return true;
 #endif
     }
 
@@ -48,8 +51,10 @@ private:
     {
 #if defined(KERNEL)
         Processor::current_thread()->set_allocation_enabled(value);
-#else
+#elif defined(__serenity__)
         s_allocation_enabled = value;
+#else
+        (void)value;
 #endif
     }
 

--- a/Tests/AK/TestFixedArray.cpp
+++ b/Tests/AK/TestFixedArray.cpp
@@ -23,7 +23,4 @@ TEST_CASE(ints)
     EXPECT_EQ(ints[0], 0);
     EXPECT_EQ(ints[1], 1);
     EXPECT_EQ(ints[2], 2);
-
-    ints.clear();
-    EXPECT_EQ(ints.size(), 0u);
 }


### PR DESCRIPTION
FixedArray always *almost* had the following allocation guarantees: There is (possibly) one allocation in the constructor and one (or more) deallocation(s) in the destructor. No other operation allocates or deallocates. With this removal of the public clear() method, which nobody except the test used anyways, those guarantees are now completely true and furthermore fixated with an explanatory comment.

The second commit adds extensive tests to FixedArray in general, but these guarantees specifically.

cc @creator1creeper1