### PR TITLE
LibJS+LibUnicode: Implement Intl.DisplayNames v2

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -294,6 +294,7 @@ namespace JS {
     P(keyFor)                                \
     P(keys)                                  \
     P(language)                              \
+    P(languageDisplay)                       \
     P(largestUnit)                           \
     P(lastIndex)                             \
     P(lastIndexOf)                           \

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -53,6 +53,10 @@ void DisplayNames::set_type(StringView type)
         m_type = Type::Script;
     else if (type == "currency"sv)
         m_type = Type::Currency;
+    else if (type == "calendar"sv)
+        m_type = Type::Calendar;
+    else if (type == "dateTimeField"sv)
+        m_type = Type::DateTimeField;
     else
         VERIFY_NOT_REACHED();
 }
@@ -68,6 +72,10 @@ StringView DisplayNames::type_string() const
         return "script"sv;
     case Type::Currency:
         return "currency"sv;
+    case Type::Calendar:
+        return "calendar"sv;
+    case Type::DateTimeField:
+        return "dateTimeField"sv;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -90,6 +98,30 @@ StringView DisplayNames::fallback_string() const
         return "none"sv;
     case Fallback::Code:
         return "code"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+void DisplayNames::set_language_display(StringView language_display)
+{
+    if (language_display == "dialect"sv)
+        m_language_display = LanguageDisplay::Dialect;
+    else if (language_display == "standard"sv)
+        m_language_display = LanguageDisplay::Standard;
+    else
+        VERIFY_NOT_REACHED();
+}
+
+StringView DisplayNames::language_display_string() const
+{
+    VERIFY(m_language_display.has_value());
+
+    switch (*m_language_display) {
+    case LanguageDisplay::Dialect:
+        return "dialect"sv;
+    case LanguageDisplay::Standard:
+        return "standard"sv;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -19,15 +19,14 @@ DisplayNames::DisplayNames(Object& prototype)
 
 void DisplayNames::set_style(StringView style)
 {
-    if (style == "narrow"sv) {
+    if (style == "narrow"sv)
         m_style = Style::Narrow;
-    } else if (style == "short"sv) {
+    else if (style == "short"sv)
         m_style = Style::Short;
-    } else if (style == "long"sv) {
+    else if (style == "long"sv)
         m_style = Style::Long;
-    } else {
+    else
         VERIFY_NOT_REACHED();
-    }
 }
 
 StringView DisplayNames::style_string() const
@@ -46,17 +45,16 @@ StringView DisplayNames::style_string() const
 
 void DisplayNames::set_type(StringView type)
 {
-    if (type == "language"sv) {
+    if (type == "language"sv)
         m_type = Type::Language;
-    } else if (type == "region"sv) {
+    else if (type == "region"sv)
         m_type = Type::Region;
-    } else if (type == "script"sv) {
+    else if (type == "script"sv)
         m_type = Type::Script;
-    } else if (type == "currency"sv) {
+    else if (type == "currency"sv)
         m_type = Type::Currency;
-    } else {
+    else
         VERIFY_NOT_REACHED();
-    }
 }
 
 StringView DisplayNames::type_string() const
@@ -77,13 +75,12 @@ StringView DisplayNames::type_string() const
 
 void DisplayNames::set_fallback(StringView fallback)
 {
-    if (fallback == "none"sv) {
+    if (fallback == "none"sv)
         m_fallback = Fallback::None;
-    } else if (fallback == "code"sv) {
+    else if (fallback == "code"sv)
         m_fallback = Fallback::Code;
-    } else {
+    else
         VERIFY_NOT_REACHED();
-    }
 }
 
 StringView DisplayNames::fallback_string() const

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibJS/Runtime/Object.h>
@@ -28,12 +29,19 @@ class DisplayNames final : public Object {
         Region,
         Script,
         Currency,
+        Calendar,
+        DateTimeField,
     };
 
     enum class Fallback {
         Invalid,
         None,
         Code,
+    };
+
+    enum class LanguageDisplay {
+        Dialect,
+        Standard,
     };
 
 public:
@@ -55,11 +63,17 @@ public:
     void set_fallback(StringView fallback);
     StringView fallback_string() const;
 
+    bool has_language_display() const { return m_language_display.has_value(); }
+    LanguageDisplay language_display() const { return *m_language_display; }
+    void set_language_display(StringView language_display);
+    StringView language_display_string() const;
+
 private:
-    String m_locale;                           // [[Locale]]
-    Style m_style { Style::Invalid };          // [[Style]]
-    Type m_type { Type::Invalid };             // [[Type]]
-    Fallback m_fallback { Fallback::Invalid }; // [[Fallback]]
+    String m_locale;                                 // [[Locale]]
+    Style m_style { Style::Invalid };                // [[Style]]
+    Type m_type { Type::Invalid };                   // [[Type]]
+    Fallback m_fallback { Fallback::Invalid };       // [[Fallback]]
+    Optional<LanguageDisplay> m_language_display {}; // [[LanguageDisplay]]
 };
 
 ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_object, DisplayNames::Type type, StringView code);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
@@ -77,5 +77,6 @@ private:
 };
 
 ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_object, DisplayNames::Type type, StringView code);
+bool is_valid_date_time_field_code(StringView field);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -116,6 +116,10 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::resolved_options)
     MUST(options->create_data_property_or_throw(vm.names.type, js_string(vm, display_names->type_string())));
     MUST(options->create_data_property_or_throw(vm.names.fallback, js_string(vm, display_names->fallback_string())));
 
+    // NOTE: Step 4c indicates languageDisplay must not be undefined, but it is only set when the type option is language.
+    if (display_names->has_language_display())
+        MUST(options->create_data_property_or_throw(vm.names.languageDisplay, js_string(vm, display_names->language_display_string())));
+
     // 5. Return options.
     return options;
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -76,6 +76,10 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
         default:
             VERIFY_NOT_REACHED();
         }
+        break;
+    case DisplayNames::Type::Calendar:
+        break;
+    case DisplayNames::Type::DateTimeField:
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -65,13 +65,13 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
     case DisplayNames::Type::Currency:
         switch (display_names->style()) {
         case DisplayNames::Style::Long:
-            result = Unicode::get_locale_currency_mapping(display_names->locale(), code.as_string().string(), Unicode::Style::Long);
+            result = Unicode::get_locale_long_currency_mapping(display_names->locale(), code.as_string().string());
             break;
         case DisplayNames::Style::Short:
-            result = Unicode::get_locale_currency_mapping(display_names->locale(), code.as_string().string(), Unicode::Style::Short);
+            result = Unicode::get_locale_short_currency_mapping(display_names->locale(), code.as_string().string());
             break;
         case DisplayNames::Style::Narrow:
-            result = Unicode::get_locale_currency_mapping(display_names->locale(), code.as_string().string(), Unicode::Style::Narrow);
+            result = Unicode::get_locale_narrow_currency_mapping(display_names->locale(), code.as_string().string());
             break;
         default:
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -54,6 +54,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
 
     switch (display_names->type()) {
     case DisplayNames::Type::Language:
+        // FIXME: Handle the [[LanguageDisplay]] internal slot once we know where that data comes from.
         result = Unicode::get_locale_language_mapping(display_names->locale(), code.as_string().string());
         break;
     case DisplayNames::Type::Region:

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -79,8 +79,22 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
         }
         break;
     case DisplayNames::Type::Calendar:
+        result = Unicode::get_locale_calendar_mapping(display_names->locale(), code.as_string().string());
         break;
     case DisplayNames::Type::DateTimeField:
+        switch (display_names->style()) {
+        case DisplayNames::Style::Long:
+            result = Unicode::get_locale_long_date_field_mapping(display_names->locale(), code.as_string().string());
+            break;
+        case DisplayNames::Style::Short:
+            result = Unicode::get_locale_short_date_field_mapping(display_names->locale(), code.as_string().string());
+            break;
+        case DisplayNames::Style::Narrow:
+            result = Unicode::get_locale_narrow_date_field_mapping(display_names->locale(), code.as_string().string());
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -85,13 +85,13 @@ StringView NumberFormat::resolve_currency_display()
         m_resolved_currency_display = currency();
         break;
     case NumberFormat::CurrencyDisplay::Symbol:
-        m_resolved_currency_display = Unicode::get_locale_currency_mapping(data_locale(), currency(), Unicode::Style::Short);
+        m_resolved_currency_display = Unicode::get_locale_short_currency_mapping(data_locale(), currency());
         break;
     case NumberFormat::CurrencyDisplay::NarrowSymbol:
-        m_resolved_currency_display = Unicode::get_locale_currency_mapping(data_locale(), currency(), Unicode::Style::Narrow);
+        m_resolved_currency_display = Unicode::get_locale_narrow_currency_mapping(data_locale(), currency());
         break;
     case NumberFormat::CurrencyDisplay::Name:
-        m_resolved_currency_display = Unicode::get_locale_currency_mapping(data_locale(), currency(), Unicode::Style::Numeric);
+        m_resolved_currency_display = Unicode::get_locale_numeric_currency_mapping(data_locale(), currency());
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.js
@@ -35,6 +35,12 @@ describe("errors", () => {
         }).toThrowWithMessage(RangeError, "hello! is not a valid value for option fallback");
     });
 
+    test("language display option is invalid ", () => {
+        expect(() => {
+            new Intl.DisplayNames("en", { type: "language", languageDisplay: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option languageDisplay");
+    });
+
     test("missing type options ", () => {
         expect(() => {
             new Intl.DisplayNames("en", {});
@@ -48,9 +54,17 @@ describe("normal behavior", () => {
     });
 
     test("all valid types", () => {
-        ["language", "region", "script", "currency"].forEach(type => {
+        ["language", "region", "script", "currency", "calendar", "dateTimeField"].forEach(type => {
             expect(() => {
                 new Intl.DisplayNames("en", { type: type });
+            }).not.toThrow();
+        });
+    });
+
+    test("all valid language displays", () => {
+        ["dialect", "standard"].forEach(languageDisplay => {
+            expect(() => {
+                new Intl.DisplayNames("en", { type: "language", languageDisplay: languageDisplay });
             }).not.toThrow();
         });
     });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.of.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.of.js
@@ -22,6 +22,18 @@ describe("errors", () => {
             new Intl.DisplayNames("en", { type: "currency" }).of("hello!");
         }).toThrowWithMessage(RangeError, "hello! is not a valid value for option currency");
     });
+
+    test("invalid calendar", () => {
+        expect(() => {
+            new Intl.DisplayNames("en", { type: "calendar" }).of("hello!");
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option calendar");
+    });
+
+    test("invalid dateTimeField", () => {
+        expect(() => {
+            new Intl.DisplayNames("en", { type: "dateTimeField" }).of("hello!");
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option dateTimeField");
+    });
 });
 
 describe("correct behavior", () => {
@@ -117,5 +129,123 @@ describe("correct behavior", () => {
         expect(en.of("AAA")).toBe("AAA");
         expect(es419.of("AAA")).toBe("AAA");
         expect(zhHant.of("AAA")).toBe("AAA");
+    });
+
+    test("option type calendar", () => {
+        // prettier-ignore
+        const data = [
+            { calendar: "buddhist", en: "Buddhist Calendar", es419: "calendario budista", zhHant: "佛曆" },
+            { calendar: "chinese", en: "Chinese Calendar", es419: "calendario chino", zhHant: "農曆" },
+            { calendar: "coptic", en: "Coptic Calendar", es419: "calendario cóptico", zhHant: "科普特曆" },
+            { calendar: "dangi", en: "Dangi Calendar", es419: "calendario dangi", zhHant: "檀紀曆" },
+            { calendar: "ethioaa", en: "Ethiopic Amete Alem Calendar", es419: "calendario etíope Amete Alem", zhHant: "衣索比亞曆 (Amete Alem)" },
+            { calendar: "ethiopic", en: "Ethiopic Calendar", es419: "calendario etíope", zhHant: "衣索比亞曆" },
+            { calendar: "gregory", en: "Gregorian Calendar", es419: "calendario gregoriano", zhHant: "公曆" },
+            { calendar: "hebrew", en: "Hebrew Calendar", es419: "calendario hebreo", zhHant: "希伯來曆" },
+            { calendar: "indian", en: "Indian National Calendar", es419: "calendario nacional hindú", zhHant: "印度國曆" },
+            { calendar: "islamic", en: "Islamic Calendar", es419: "calendario islámico", zhHant: "伊斯蘭曆" },
+            { calendar: "islamic-civil", en: "Islamic Calendar (tabular, civil epoch)", es419: "calendario civil islámico", zhHant: "伊斯蘭民用曆" },
+            { calendar: "islamic-rgsa", en: "Islamic Calendar (Saudi Arabia, sighting)", es419: "calendario islámico (Arabia Saudita)", zhHant: "伊斯蘭新月曆" },
+            { calendar: "islamic-tbla", en: "Islamic Calendar (tabular, astronomical epoch)", es419: "calendario islámico tabular", zhHant: "伊斯蘭天文曆" },
+            { calendar: "islamic-umalqura", en: "Islamic Calendar (Umm al-Qura)", es419: "calendario islámico umalqura", zhHant: "烏姆庫拉曆" },
+            { calendar: "iso8601", en: "ISO-8601 Calendar", es419: "calendario ISO-8601", zhHant: "ISO 8601 國際曆法" },
+            { calendar: "japanese", en: "Japanese Calendar", es419: "calendario japonés", zhHant: "日本曆" },
+            { calendar: "persian", en: "Persian Calendar", es419: "calendario persa", zhHant: "波斯曆" },
+            { calendar: "roc", en: "Minguo Calendar", es419: "calendario de la República de China", zhHant: "國曆" },
+        ];
+
+        const en = new Intl.DisplayNames("en", { type: "calendar" });
+        const es419 = new Intl.DisplayNames("es-419", { type: "calendar" });
+        const zhHant = new Intl.DisplayNames("zh-Hant", { type: "calendar" });
+
+        data.forEach(d => {
+            expect(en.of(d.calendar)).toBe(d.en);
+            expect(es419.of(d.calendar)).toBe(d.es419);
+            expect(zhHant.of(d.calendar)).toBe(d.zhHant);
+        });
+    });
+
+    test("option type dateTimeField, style long", () => {
+        // prettier-ignore
+        const data = [
+            { dateTimeField: "era", en: "era", es419: "era", zhHant: "年代" },
+            { dateTimeField: "year", en: "year", es419: "año", zhHant: "年" },
+            { dateTimeField: "quarter", en: "quarter", es419: "trimestre", zhHant: "季" },
+            { dateTimeField: "month", en: "month", es419: "mes", zhHant: "月" },
+            { dateTimeField: "weekOfYear", en: "week", es419: "semana", zhHant: "週" },
+            { dateTimeField: "weekday", en: "day of the week", es419: "día de la semana", zhHant: "週天" },
+            { dateTimeField: "day", en: "day", es419: "día", zhHant: "日" },
+            { dateTimeField: "dayPeriod", en: "AM/PM", es419: "a. m./p. m.", zhHant: "上午/下午" },
+            { dateTimeField: "hour", en: "hour", es419: "hora", zhHant: "小時" },
+            { dateTimeField: "minute", en: "minute", es419: "minuto", zhHant: "分鐘" },
+            { dateTimeField: "second", en: "second", es419: "segundo", zhHant: "秒" },
+            { dateTimeField: "timeZoneName", en: "time zone", es419: "zona horaria", zhHant: "時區" },
+        ];
+
+        const en = new Intl.DisplayNames("en", { type: "dateTimeField", style: "long" });
+        const es419 = new Intl.DisplayNames("es-419", { type: "dateTimeField", style: "long" });
+        const zhHant = new Intl.DisplayNames("zh-Hant", { type: "dateTimeField", style: "long" });
+
+        data.forEach(d => {
+            expect(en.of(d.dateTimeField)).toBe(d.en);
+            expect(es419.of(d.dateTimeField)).toBe(d.es419);
+            expect(zhHant.of(d.dateTimeField)).toBe(d.zhHant);
+        });
+    });
+
+    test("option type dateTimeField, style short", () => {
+        // prettier-ignore
+        const data = [
+            { dateTimeField: "era", en: "era", es419: "era", zhHant: "年代" },
+            { dateTimeField: "year", en: "yr.", es419: "a", zhHant: "年" },
+            { dateTimeField: "quarter", en: "qtr.", es419: "trim.", zhHant: "季" },
+            { dateTimeField: "month", en: "mo.", es419: "m", zhHant: "月" },
+            { dateTimeField: "weekOfYear", en: "wk.", es419: "sem.", zhHant: "週" },
+            { dateTimeField: "weekday", en: "day of wk.", es419: "día de sem.", zhHant: "週天" },
+            { dateTimeField: "day", en: "day", es419: "d", zhHant: "日" },
+            { dateTimeField: "dayPeriod", en: "AM/PM", es419: "a.m./p.m.", zhHant: "上午/下午" },
+            { dateTimeField: "hour", en: "hr.", es419: "h", zhHant: "小時" },
+            { dateTimeField: "minute", en: "min.", es419: "min", zhHant: "分鐘" },
+            { dateTimeField: "second", en: "sec.", es419: "s", zhHant: "秒" },
+            { dateTimeField: "timeZoneName", en: "zone", es419: "zona", zhHant: "時區" },
+        ];
+
+        const en = new Intl.DisplayNames("en", { type: "dateTimeField", style: "short" });
+        const es419 = new Intl.DisplayNames("es-419", { type: "dateTimeField", style: "short" });
+        const zhHant = new Intl.DisplayNames("zh-Hant", { type: "dateTimeField", style: "short" });
+
+        data.forEach(d => {
+            expect(en.of(d.dateTimeField)).toBe(d.en);
+            expect(es419.of(d.dateTimeField)).toBe(d.es419);
+            expect(zhHant.of(d.dateTimeField)).toBe(d.zhHant);
+        });
+    });
+
+    test("option type dateTimeField, style narrow", () => {
+        // prettier-ignore
+        const data = [
+            { dateTimeField: "era", en: "era", es419: "era", zhHant: "年代" },
+            { dateTimeField: "year", en: "yr.", es419: "a", zhHant: "年" },
+            { dateTimeField: "quarter", en: "qtr.", es419: "trim.", zhHant: "季" },
+            { dateTimeField: "month", en: "mo.", es419: "m", zhHant: "月" },
+            { dateTimeField: "weekOfYear", en: "wk.", es419: "sem.", zhHant: "週" },
+            { dateTimeField: "weekday", en: "day of wk.", es419: "día de sem.", zhHant: "週天" },
+            { dateTimeField: "day", en: "day", es419: "d", zhHant: "日" },
+            { dateTimeField: "dayPeriod", en: "AM/PM", es419: "a.m./p.m.", zhHant: "上午/下午" },
+            { dateTimeField: "hour", en: "hr.", es419: "h", zhHant: "小時" },
+            { dateTimeField: "minute", en: "min.", es419: "min", zhHant: "分鐘" },
+            { dateTimeField: "second", en: "sec.", es419: "s", zhHant: "秒" },
+            { dateTimeField: "timeZoneName", en: "zone", es419: "zona", zhHant: "時區" },
+        ];
+
+        const en = new Intl.DisplayNames("en", { type: "dateTimeField", style: "narrow" });
+        const es419 = new Intl.DisplayNames("es-419", { type: "dateTimeField", style: "narrow" });
+        const zhHant = new Intl.DisplayNames("zh-Hant", { type: "dateTimeField", style: "narrow" });
+
+        data.forEach(d => {
+            expect(en.of(d.dateTimeField)).toBe(d.en);
+            expect(es419.of(d.dateTimeField)).toBe(d.es419);
+            expect(zhHant.of(d.dateTimeField)).toBe(d.zhHant);
+        });
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.resolvedOptions.js
@@ -26,6 +26,58 @@ describe("correct behavior", () => {
             style: "short",
             type: "language",
             fallback: "code",
+            languageDisplay: "dialect",
+        });
+
+        const ar = new Intl.DisplayNames("ar", { type: "calendar" });
+        expect(ar.resolvedOptions()).toEqual({
+            locale: "ar",
+            style: "long",
+            type: "calendar",
+            fallback: "code",
+        });
+
+        const fr = new Intl.DisplayNames("fr", { type: "dateTimeField" });
+        expect(fr.resolvedOptions()).toEqual({
+            locale: "fr",
+            style: "long",
+            type: "dateTimeField",
+            fallback: "code",
+        });
+    });
+
+    test("all valid language displays", () => {
+        const en = new Intl.DisplayNames("en", { type: "language" });
+        expect(en.resolvedOptions()).toEqual({
+            locale: "en",
+            style: "long",
+            type: "language",
+            fallback: "code",
+            languageDisplay: "dialect",
+        });
+
+        const es419 = new Intl.DisplayNames("es-419", {
+            type: "language",
+            languageDisplay: "dialect",
+        });
+        expect(es419.resolvedOptions()).toEqual({
+            locale: "es-419",
+            style: "long",
+            type: "language",
+            fallback: "code",
+            languageDisplay: "dialect",
+        });
+
+        const zhHant = new Intl.DisplayNames(["zh-Hant"], {
+            type: "language",
+            languageDisplay: "standard",
+        });
+        expect(zhHant.resolvedOptions()).toEqual({
+            locale: "zh-Hant",
+            style: "long",
+            type: "language",
+            fallback: "code",
+            languageDisplay: "standard",
         });
     });
 

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -18,6 +18,7 @@ enum class CalendarSymbol : u8;
 enum class CompactNumberFormatType : u8;
 enum class Condition : u8;
 enum class Currency : u16;
+enum class DateField : u8;
 enum class DayPeriod : u8;
 enum class Era : u8;
 enum class GeneralCategory : u8;

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,6 +13,7 @@ namespace Unicode {
 enum class Calendar : u8;
 enum class CalendarFormatType : u8;
 enum class CalendarPatternStyle : u8;
+enum class CalendarName : u8;
 enum class CalendarSymbol : u8;
 enum class CompactNumberFormatType : u8;
 enum class Condition : u8;

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -747,6 +747,7 @@ Optional<Territory> __attribute__((weak)) territory_from_string(StringView) { re
 Optional<ScriptTag> __attribute__((weak)) script_tag_from_string(StringView) { return {}; }
 Optional<Currency> __attribute__((weak)) currency_from_string(StringView) { return {}; }
 Optional<CalendarName> __attribute__((weak)) calendar_name_from_string(StringView) { return {}; }
+Optional<DateField> __attribute__((weak)) date_field_from_string(StringView) { return {}; }
 Optional<Key> __attribute__((weak)) key_from_string(StringView) { return {}; }
 Optional<ListPatternType> __attribute__((weak)) list_pattern_type_from_string(StringView) { return {}; }
 Optional<ListPatternStyle> __attribute__((weak)) list_pattern_style_from_string(StringView) { return {}; }
@@ -758,6 +759,9 @@ Optional<StringView> __attribute__((weak)) get_locale_short_currency_mapping(Str
 Optional<StringView> __attribute__((weak)) get_locale_narrow_currency_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_numeric_currency_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_calendar_mapping(StringView, StringView) { return {}; }
+Optional<StringView> __attribute__((weak)) get_locale_long_date_field_mapping(StringView, StringView) { return {}; }
+Optional<StringView> __attribute__((weak)) get_locale_short_date_field_mapping(StringView, StringView) { return {}; }
+Optional<StringView> __attribute__((weak)) get_locale_narrow_date_field_mapping(StringView, StringView) { return {}; }
 
 Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency, Style style)
 {

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -746,6 +746,7 @@ Optional<Language> __attribute__((weak)) language_from_string(StringView) { retu
 Optional<Territory> __attribute__((weak)) territory_from_string(StringView) { return {}; }
 Optional<ScriptTag> __attribute__((weak)) script_tag_from_string(StringView) { return {}; }
 Optional<Currency> __attribute__((weak)) currency_from_string(StringView) { return {}; }
+Optional<CalendarName> __attribute__((weak)) calendar_name_from_string(StringView) { return {}; }
 Optional<Key> __attribute__((weak)) key_from_string(StringView) { return {}; }
 Optional<ListPatternType> __attribute__((weak)) list_pattern_type_from_string(StringView) { return {}; }
 Optional<ListPatternStyle> __attribute__((weak)) list_pattern_style_from_string(StringView) { return {}; }
@@ -756,6 +757,7 @@ Optional<StringView> __attribute__((weak)) get_locale_long_currency_mapping(Stri
 Optional<StringView> __attribute__((weak)) get_locale_short_currency_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_narrow_currency_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_numeric_currency_mapping(StringView, StringView) { return {}; }
+Optional<StringView> __attribute__((weak)) get_locale_calendar_mapping(StringView, StringView) { return {}; }
 
 Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency, Style style)
 {

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -762,23 +762,6 @@ Optional<StringView> __attribute__((weak)) get_locale_calendar_mapping(StringVie
 Optional<StringView> __attribute__((weak)) get_locale_long_date_field_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_short_date_field_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_narrow_date_field_mapping(StringView, StringView) { return {}; }
-
-Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency, Style style)
-{
-    switch (style) {
-    case Style::Long:
-        return get_locale_long_currency_mapping(locale, currency);
-    case Style::Short:
-        return get_locale_short_currency_mapping(locale, currency);
-    case Style::Narrow:
-        return get_locale_narrow_currency_mapping(locale, currency);
-    case Style::Numeric:
-        return get_locale_numeric_currency_mapping(locale, currency);
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
 Optional<StringView> __attribute__((weak)) get_locale_key_mapping(StringView, StringView) { return {}; }
 
 Vector<StringView> get_locale_key_mapping_list(StringView locale, StringView keyword)

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -159,7 +159,6 @@ Optional<StringView> get_locale_long_currency_mapping(StringView locale, StringV
 Optional<StringView> get_locale_short_currency_mapping(StringView locale, StringView currency);
 Optional<StringView> get_locale_narrow_currency_mapping(StringView locale, StringView currency);
 Optional<StringView> get_locale_numeric_currency_mapping(StringView locale, StringView currency);
-Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency, Style style);
 Optional<StringView> get_locale_calendar_mapping(StringView locale, StringView calendar);
 Optional<StringView> get_locale_long_date_field_mapping(StringView locale, StringView date_field);
 Optional<StringView> get_locale_short_date_field_mapping(StringView locale, StringView date_field);

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -147,6 +147,7 @@ Optional<Territory> territory_from_string(StringView territory);
 Optional<ScriptTag> script_tag_from_string(StringView script_tag);
 Optional<Currency> currency_from_string(StringView currency);
 Optional<CalendarName> calendar_name_from_string(StringView calendar);
+Optional<DateField> date_field_from_string(StringView calendar);
 Optional<Key> key_from_string(StringView key);
 Optional<ListPatternType> list_pattern_type_from_string(StringView list_pattern_type);
 Optional<ListPatternStyle> list_pattern_style_from_string(StringView list_pattern_style);
@@ -160,6 +161,9 @@ Optional<StringView> get_locale_narrow_currency_mapping(StringView locale, Strin
 Optional<StringView> get_locale_numeric_currency_mapping(StringView locale, StringView currency);
 Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency, Style style);
 Optional<StringView> get_locale_calendar_mapping(StringView locale, StringView calendar);
+Optional<StringView> get_locale_long_date_field_mapping(StringView locale, StringView date_field);
+Optional<StringView> get_locale_short_date_field_mapping(StringView locale, StringView date_field);
+Optional<StringView> get_locale_narrow_date_field_mapping(StringView locale, StringView date_field);
 Optional<StringView> get_locale_key_mapping(StringView locale, StringView keyword);
 Vector<StringView> get_locale_key_mapping_list(StringView locale, StringView keyword);
 

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@pm.me>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -146,6 +146,7 @@ Optional<Language> language_from_string(StringView language);
 Optional<Territory> territory_from_string(StringView territory);
 Optional<ScriptTag> script_tag_from_string(StringView script_tag);
 Optional<Currency> currency_from_string(StringView currency);
+Optional<CalendarName> calendar_name_from_string(StringView calendar);
 Optional<Key> key_from_string(StringView key);
 Optional<ListPatternType> list_pattern_type_from_string(StringView list_pattern_type);
 Optional<ListPatternStyle> list_pattern_style_from_string(StringView list_pattern_style);
@@ -158,6 +159,7 @@ Optional<StringView> get_locale_short_currency_mapping(StringView locale, String
 Optional<StringView> get_locale_narrow_currency_mapping(StringView locale, StringView currency);
 Optional<StringView> get_locale_numeric_currency_mapping(StringView locale, StringView currency);
 Optional<StringView> get_locale_currency_mapping(StringView locale, StringView currency, Style style);
+Optional<StringView> get_locale_calendar_mapping(StringView locale, StringView calendar);
 Optional<StringView> get_locale_key_mapping(StringView locale, StringView keyword);
 Vector<StringView> get_locale_key_mapping_list(StringView locale, StringView keyword);
 

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -601,6 +601,10 @@ static void print_intl_display_names(JS::Object const& object, HashTable<JS::Obj
     print_value(js_string(object.vm(), display_names.style_string()), seen_objects);
     js_out("\n  fallback: ");
     print_value(js_string(object.vm(), display_names.fallback_string()), seen_objects);
+    if (display_names.has_language_display()) {
+        js_out("\n  languageDisplay: ");
+        print_value(js_string(object.vm(), display_names.language_display_string()), seen_objects);
+    }
 }
 
 static void print_intl_locale(JS::Object const& object, HashTable<JS::Object*>& seen_objects)


### PR DESCRIPTION
This is a Stage 4 proposal that was recently merged into the ECMA-402 spec:
https://github.com/tc39/ecma402/commit/5b84c6f

This implements everything except handling the `[[LanguageDisplay]]` internal slot, which I want to read more about before implementing.

There's a couple of bugs with the spec I think, which I'll raise an issue about:
1. The [AO for IsValidDateTimeFieldCode](https://tc39.es/ecma402/#sec-isvaliddatetimefieldcode) looks to be in the wrong section. It currently is section `12.2` all by itself, but was likely meant to be `12.1.2` (the AO section). So I did not update the spec numbers of the sections that come after it, so that I don't have to undo that later.
2. [`Intl.DisplayNames.prototype.resolvedOptions`](https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.resolvedOptions) indicates that all fields must not be undefined, but the `[[LanguageDisplay]]` field is definitely undefined unless we have set `type: "language"` in the constructor.