### PR TITLE
Meta: Prevent Linux from using gdu

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -32,7 +32,7 @@ PATH="$SCRIPT_DIR/../Toolchain/Local/i686/bin:$PATH"
 
 # We depend on GNU coreutils du for the --apparent-size extension.
 # GNU coreutils is a build dependency.
-if type gdu > /dev/null 2>&1; then
+if command -v gdu > /dev/null 2>&1 && gdu --version | grep -q "GNU coreutils"; then
     GNUDU="gdu"
 else
     GNUDU="du"


### PR DESCRIPTION
This pull request solves issue #11431.

On Linux, gdu is typically not the same application as gdu on *BSD/Mac. gdu on Linux refers to a disk utility application that does not have the same flags as du. On *BSD, and perhaps Mac, gdu refers to GNU du, which is the same as du but a part of the GNU project.

To prevent build-image-qemu.sh from using gdu on Linux, an additional check is added to the predicate to force Linux to always use du.