### PR TITLE
LibGL: Implement glIsTexture

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -547,6 +547,7 @@ GLAPI void glTexParameterf(GLenum target, GLenum pname, GLfloat param);
 GLAPI void glTexEnvf(GLenum target, GLenum pname, GLfloat param);
 GLAPI void glTexEnvi(GLenum target, GLenum pname, GLint param);
 GLAPI void glBindTexture(GLenum target, GLuint texture);
+GLAPI GLboolean glIsTexture(GLuint texture);
 GLAPI void glActiveTexture(GLenum texture);
 GLAPI void glGetBooleanv(GLenum pname, GLboolean* data);
 GLAPI void glGetDoublev(GLenum pname, GLdouble* params);

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -71,6 +71,7 @@ public:
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) = 0;
     virtual void gl_tex_env(GLenum target, GLenum pname, GLfloat param) = 0;
     virtual void gl_bind_texture(GLenum target, GLuint texture) = 0;
+    virtual GLboolean gl_is_texture(GLuint texture) = 0;
     virtual void gl_active_texture(GLenum texture) = 0;
     virtual void gl_depth_mask(GLboolean flag) = 0;
     virtual void gl_enable_client_state(GLenum cap) = 0;

--- a/Userland/Libraries/LibGL/GLTexture.cpp
+++ b/Userland/Libraries/LibGL/GLTexture.cpp
@@ -47,6 +47,11 @@ void glBindTexture(GLenum target, GLuint texture)
     g_gl_context->gl_bind_texture(target, texture);
 }
 
+GLboolean glIsTexture(GLuint texture)
+{
+    return g_gl_context->gl_is_texture(texture);
+}
+
 // Note: This is an _extremely_ misleading API name. This sets the active
 // texture unit, NOT the active texture itself...
 void glActiveTexture(GLenum texture)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1797,6 +1797,20 @@ void SoftwareGLContext::gl_bind_texture(GLenum target, GLuint texture)
     m_sampler_config_is_dirty = true;
 }
 
+GLboolean SoftwareGLContext::gl_is_texture(GLuint texture)
+{
+    RETURN_VALUE_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION, GL_FALSE);
+
+    if (texture == 0)
+        return GL_FALSE;
+
+    auto it = m_allocated_textures.find(texture);
+    if (it == m_allocated_textures.end())
+        return GL_FALSE;
+
+    return it->value.is_null() ? GL_FALSE : GL_TRUE;
+}
+
 void SoftwareGLContext::gl_active_texture(GLenum texture)
 {
     RETURN_WITH_ERROR_IF(texture < GL_TEXTURE0 || texture > GL_TEXTURE31, GL_INVALID_ENUM);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -102,6 +102,7 @@ public:
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) override;
     virtual void gl_tex_env(GLenum target, GLenum pname, GLfloat param) override;
     virtual void gl_bind_texture(GLenum target, GLuint texture) override;
+    virtual GLboolean gl_is_texture(GLuint texture) override;
     virtual void gl_active_texture(GLenum texture) override;
     virtual void gl_depth_mask(GLboolean flag) override;
     virtual void gl_enable_client_state(GLenum cap) override;


### PR DESCRIPTION
Required by Xash3D for the r_showtextures command, where it shows every
allocated texture on screen.

Description of glIsTexture from the spec:
"glIsTexture returns GL_TRUE if texture is currently the name of a
texture. If texture is zero, or is a non-zero value that is not
currently the name of a texture, or if an error occurs, glIsTexture
returns GL_FALSE.

A name returned by glGenTextures, but not yet associated with a texture
by calling glBindTexture, is not the name of a texture."

https://www.khronos.org/registry/OpenGL-Refpages/gl4/html/glIsTexture.xhtml

![Screenshot from 2022-01-13 06-08-08](https://user-images.githubusercontent.com/25595356/149275215-cae36a5a-ecac-49d0-971e-1864da0eb853.png)