### PR TITLE
AK+Everywhere: Make Variant::visit() respect the Variant's constness

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -80,13 +80,41 @@ struct Variant<IndexType, InitialIndex> {
 
 template<typename IndexType, typename... Ts>
 struct VisitImpl {
+    template<typename RT, typename T, size_t I, typename Fn>
+    static consteval u64 get_explicitly_named_overload_if_exists()
+    {
+        // If we're not allowed to make a member function pointer and call it directly (without explicitly resolving it),
+        // we have a templated function on our hands (or a function overload set).
+        // in such cases, we don't have an explicitly named overload, and we would have to select it.
+        if constexpr (requires { (declval<Fn>().*(&Fn::operator()))(declval<T>()); })
+            return 1ull << I;
+
+        return 0;
+    }
+
+    template<typename ReturnType, typename T, typename Visitor, auto... Is>
+    static consteval bool should_invoke_const_overload(IndexSequence<Is...>)
+    {
+        // Scan over all the different visitor functions, if none of them are suitable for calling with `T const&`, avoid calling that first.
+        return ((get_explicitly_named_overload_if_exists<ReturnType, T, Is, typename Visitor::Types::template Type<Is>>()) | ...) != 0;
+    }
+
     template<typename Self, typename Visitor, IndexType CurrentIndex = 0>
     ALWAYS_INLINE static constexpr decltype(auto) visit(Self& self, IndexType id, const void* data, Visitor&& visitor) requires(CurrentIndex < sizeof...(Ts))
     {
         using T = typename TypeList<Ts...>::template Type<CurrentIndex>;
 
-        if (id == CurrentIndex)
+        if (id == CurrentIndex) {
+            // Check if Visitor::operator() is an explicitly typed function (as opposed to a templated function)
+            // if so, try to call that with `T const&` first before copying the Variant's const-ness.
+            // This emulates normal C++ call semantics where templated functions are considered last, after all non-templated overloads
+            // are checked and found to be unusable.
+            using ReturnType = decltype(visitor(*bit_cast<T*>(data)));
+            if constexpr (should_invoke_const_overload<ReturnType, T, Visitor>(MakeIndexSequence<Visitor::Types::size>()))
+                return visitor(*bit_cast<AddConst<T>*>(data));
+
             return visitor(*bit_cast<CopyConst<Self, T>*>(data));
+        }
 
         if constexpr ((CurrentIndex + 1) < sizeof...(Ts))
             return visit<Self, Visitor, CurrentIndex + 1>(self, id, data, forward<Visitor>(visitor));
@@ -424,6 +452,9 @@ private:
 
     template<typename... Fs>
     struct Visitor : Fs... {
+        using Types = TypeList<Fs...>;
+        static_assert(Types::size < 64, "Variant::visit() can take a maximum of 64 visit functions.");
+
         Visitor(Fs&&... args)
             : Fs(forward<Fs>(args))...
         {

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -31,9 +31,22 @@ TEST_CASE(visit)
     bool correct = false;
     Variant<int, String, float> the_value { 42.0f };
     the_value.visit(
-        [&](const int&) { correct = false; },
-        [&](const String&) { correct = false; },
-        [&](const float&) { correct = true; });
+        [&](int const&) { correct = false; },
+        [&](String const&) { correct = false; },
+        [&](float const&) { correct = true; });
+    EXPECT(correct);
+}
+
+TEST_CASE(visit_const)
+{
+    bool correct = false;
+    Variant<int, String> const the_value { "42"sv };
+
+    the_value.visit(
+        [&](String const&) { correct = true; },
+        [&](auto&) {},
+        [&](auto const&) {});
+
     EXPECT(correct);
 }
 
@@ -139,9 +152,9 @@ TEST_CASE(return_values)
         MyVariant the_value { 42.0f };
 
         float value = the_value.visit(
-            [&](const int&) { return 1.0f; },
-            [&](const String&) { return 2.0f; },
-            [&](const float& f) { return f; });
+            [&](int const&) { return 1.0f; },
+            [&](String const&) { return 2.0f; },
+            [&](float const& f) { return f; });
         EXPECT_EQ(value, 42.0f);
     }
     {
@@ -157,9 +170,9 @@ TEST_CASE(return_values)
         const MyVariant the_value { "str" };
 
         String value = the_value.visit(
-            [&](const int&) { return String { "wrong" }; },
-            [&](const String& s) { return s; },
-            [&](const float&) { return String { "wrong" }; });
+            [&](int const&) { return String { "wrong" }; },
+            [&](String const& s) { return s; },
+            [&](float const&) { return String { "wrong" }; });
         EXPECT_EQ(value, "str");
     }
 }
@@ -170,9 +183,9 @@ TEST_CASE(return_values_by_reference)
     Variant<int, String, float> the_value { 42.0f };
 
     auto& value = the_value.visit(
-        [&](const int&) -> RefPtr<Object>& { return ref; },
-        [&](const String&) -> RefPtr<Object>& { return ref; },
-        [&](const float&) -> RefPtr<Object>& { return ref; });
+        [&](int const&) -> RefPtr<Object>& { return ref; },
+        [&](String const&) -> RefPtr<Object>& { return ref; },
+        [&](float const&) -> RefPtr<Object>& { return ref; });
 
     EXPECT_EQ(ref, value);
     EXPECT_EQ(ref->ref_count(), 1u);

--- a/Tests/AK/TestVariant.cpp
+++ b/Tests/AK/TestVariant.cpp
@@ -48,6 +48,20 @@ TEST_CASE(visit_const)
         [&](auto const&) {});
 
     EXPECT(correct);
+
+    correct = false;
+    auto the_value_but_not_const = the_value;
+    the_value_but_not_const.visit(
+        [&](String const&) { correct = true; },
+        [&](auto&) {});
+
+    EXPECT(correct);
+
+    correct = false;
+    the_value_but_not_const.visit(
+        [&]<typename T>(T&) { correct = !IsConst<T>; });
+
+    EXPECT(correct);
 }
 
 TEST_CASE(destructor)

--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -2507,7 +2507,7 @@ Completion AssignmentExpression::execute(Interpreter& interpreter, GlobalObject&
         // AssignmentExpression : LeftHandSideExpression = AssignmentExpression
         return m_lhs.visit(
             // 1. If LeftHandSideExpression is neither an ObjectLiteral nor an ArrayLiteral, then
-            [&](NonnullRefPtr<Expression>& lhs) -> ThrowCompletionOr<Value> {
+            [&](NonnullRefPtr<Expression> const& lhs) -> ThrowCompletionOr<Value> {
                 // a. Let lref be the result of evaluating LeftHandSideExpression.
                 // b. ReturnIfAbrupt(lref).
                 auto reference = TRY(lhs->to_reference(interpreter, global_object));
@@ -2534,7 +2534,7 @@ Completion AssignmentExpression::execute(Interpreter& interpreter, GlobalObject&
                 return rhs_result;
             },
             // 2. Let assignmentPattern be the AssignmentPattern that is covered by LeftHandSideExpression.
-            [&](NonnullRefPtr<BindingPattern>& pattern) -> ThrowCompletionOr<Value> {
+            [&](NonnullRefPtr<BindingPattern> const& pattern) -> ThrowCompletionOr<Value> {
                 // 3. Let rref be the result of evaluating AssignmentExpression.
                 // 4. Let rval be ? GetValue(rref).
                 auto rhs_result = TRY(m_rhs->execute(interpreter, global_object)).release_value();

--- a/Userland/Libraries/LibRegex/RegexMatch.h
+++ b/Userland/Libraries/LibRegex/RegexMatch.h
@@ -201,7 +201,7 @@ public:
                     views.empend(view);
                 return views;
             },
-            [](Utf8View& view) {
+            [](Utf8View const& view) {
                 Vector<RegexStringView> views;
                 auto it = view.begin();
                 auto previous_newline_position_it = it;

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -123,10 +123,10 @@ static float resolve_calc_value(CalculatedStyleValue::CalcValue const& calc_valu
 {
     return calc_value.visit(
         [](float value) { return value; },
-        [&](Length length) {
+        [&](Length const& length) {
             return length.resolved_or_zero(layout_node, reference_for_percent).to_px(layout_node);
         },
-        [&](NonnullOwnPtr<CalculatedStyleValue::CalcSum>& calc_sum) {
+        [&](NonnullOwnPtr<CalculatedStyleValue::CalcSum> const& calc_sum) {
             return resolve_calc_sum(calc_sum, layout_node, reference_for_percent);
         },
         [](auto&) {
@@ -173,7 +173,7 @@ static float resolve_calc_number_value(CalculatedStyleValue::CalcNumberValue con
 {
     return number_value.visit(
         [](float number) { return number; },
-        [](NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum>& calc_number_sum) {
+        [](NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const& calc_number_sum) {
             return resolve_calc_number_sum(calc_number_sum);
         });
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -23,16 +23,16 @@ NonnullRefPtr<MediaQuery> MediaQuery::create_not_all()
 String MediaFeatureValue::to_string() const
 {
     return m_value.visit(
-        [](String& ident) { return serialize_an_identifier(ident); },
-        [](Length& length) { return length.to_string(); },
+        [](String const& ident) { return serialize_an_identifier(ident); },
+        [](Length const& length) { return length.to_string(); },
         [](double number) { return String::number(number); });
 }
 
 bool MediaFeatureValue::is_same_type(MediaFeatureValue const& other) const
 {
     return m_value.visit(
-        [&](String&) { return other.is_ident(); },
-        [&](Length&) { return other.is_length(); },
+        [&](String const&) { return other.is_ident(); },
+        [&](Length const&) { return other.is_length(); },
         [&](double) { return other.is_number(); });
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Supports.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Supports.cpp
@@ -35,13 +35,13 @@ MatchResult Supports::Condition::evaluate() const
 MatchResult Supports::InParens::evaluate() const
 {
     return value.visit(
-        [&](NonnullOwnPtr<Condition>& condition) {
+        [&](NonnullOwnPtr<Condition> const& condition) {
             return condition->evaluate();
         },
-        [&](Feature& feature) {
+        [&](Feature const& feature) {
             return feature.evaluate();
         },
-        [&](GeneralEnclosed& general_enclosed) {
+        [&](GeneralEnclosed const& general_enclosed) {
             return general_enclosed.evaluate();
         });
 }


### PR DESCRIPTION
...and fix all the instances of visit() taking non-const arguments.