### PR TITLE
LibJS+LibUnicode: Handle the [[LanguageDisplay]] tag when localizing languages

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/DisplayNames.h>
 #include <LibJS/Runtime/Intl/DisplayNamesPrototype.h>
 #include <LibUnicode/Locale.h>
@@ -51,11 +52,18 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
     // 5. Let fields be displayNames.[[Fields]].
     // 6. If fields has a field [[<code>]], return fields.[[<code>]].
     Optional<StringView> result;
+    Optional<String> formatted_result;
 
     switch (display_names->type()) {
     case DisplayNames::Type::Language:
-        // FIXME: Handle the [[LanguageDisplay]] internal slot once we know where that data comes from.
-        result = Unicode::get_locale_language_mapping(display_names->locale(), code.as_string().string());
+        if (display_names->language_display() == DisplayNames::LanguageDisplay::Dialect) {
+            result = Unicode::get_locale_language_mapping(display_names->locale(), code.as_string().string());
+            if (result.has_value())
+                break;
+        }
+
+        if (auto locale = is_structurally_valid_language_tag(code.as_string().string()); locale.has_value())
+            formatted_result = Unicode::format_locale_for_display(display_names->locale(), locale.release_value());
         break;
     case DisplayNames::Type::Region:
         result = Unicode::get_locale_territory_mapping(display_names->locale(), code.as_string().string());
@@ -102,6 +110,8 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
 
     if (result.has_value())
         return js_string(vm, result.release_value());
+    if (formatted_result.has_value())
+        return js_string(vm, formatted_result.release_value());
 
     // 7. If displayNames.[[Fallback]] is "code", return code.
     if (display_names->fallback() == DisplayNames::Fallback::Code)

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.of.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.of.js
@@ -41,19 +41,60 @@ describe("correct behavior", () => {
         expect(Intl.DisplayNames.prototype.of).toHaveLength(1);
     });
 
-    test("option type language", () => {
-        const en = new Intl.DisplayNames("en", { type: "language" });
-        expect(en.of("en")).toBe("English");
+    test("option type language, display dialect", () => {
+        // prettier-ignore
+        const data = [
+            { locale: "en", en: "English", es419: "inglés", zhHant: "英文" },
+            { locale: "en-US", en: "American English", es419: "inglés estadounidense", zhHant: "英文（美國）" },
+            { locale: "en-GB", en: "British English", es419: "inglés británico", zhHant: "英文（英國）" },
+            { locale: "sr", en: "Serbian", es419: "serbio", zhHant: "塞爾維亞文" },
+            { locale: "sr-Cyrl", en: "Serbian (Cyrillic)", es419: "serbio (cirílico)", zhHant: "塞爾維亞文（斯拉夫文）" },
+            { locale: "sr-Cyrl-BA", en: "Serbian (Cyrillic, Bosnia & Herzegovina)", es419: "serbio (cirílico, Bosnia-Herzegovina)", zhHant: "塞爾維亞文（斯拉夫文，波士尼亞與赫塞哥維納）" },
+        ];
 
-        const es419 = new Intl.DisplayNames("es-419", { type: "language" });
-        expect(es419.of("en")).toBe("inglés");
+        const en = new Intl.DisplayNames("en", { type: "language", languageDisplay: "dialect" });
+        const es419 = new Intl.DisplayNames("es-419", {
+            type: "language",
+            languageDisplay: "dialect",
+        });
+        const zhHant = new Intl.DisplayNames("zh-Hant", {
+            type: "language",
+            languageDisplay: "dialect",
+        });
 
-        const zhHant = new Intl.DisplayNames(["zh-Hant"], { type: "language" });
-        expect(zhHant.of("en")).toBe("英文");
+        data.forEach(d => {
+            expect(en.of(d.locale)).toBe(d.en);
+            expect(es419.of(d.locale)).toBe(d.es419);
+            expect(zhHant.of(d.locale)).toBe(d.zhHant);
+        });
+    });
 
-        expect(en.of("zz")).toBe("zz");
-        expect(es419.of("zz")).toBe("zz");
-        expect(zhHant.of("zz")).toBe("zz");
+    test("option type language, display standard", () => {
+        // prettier-ignore
+        const data = [
+            { locale: "en", en: "English", es419: "inglés", zhHant: "英文" },
+            { locale: "en-US", en: "English (United States)", es419: "inglés (Estados Unidos)", zhHant: "英文（美國）" },
+            { locale: "en-GB", en: "English (United Kingdom)", es419: "inglés (Reino Unido)", zhHant: "英文（英國）" },
+            { locale: "sr", en: "Serbian", es419: "serbio", zhHant: "塞爾維亞文" },
+            { locale: "sr-Cyrl", en: "Serbian (Cyrillic)", es419: "serbio (cirílico)", zhHant: "塞爾維亞文（斯拉夫文）" },
+            { locale: "sr-Cyrl-BA", en: "Serbian (Cyrillic, Bosnia & Herzegovina)", es419: "serbio (cirílico, Bosnia-Herzegovina)", zhHant: "塞爾維亞文（斯拉夫文，波士尼亞與赫塞哥維納）" },
+        ];
+
+        const en = new Intl.DisplayNames("en", { type: "language", languageDisplay: "standard" });
+        const es419 = new Intl.DisplayNames("es-419", {
+            type: "language",
+            languageDisplay: "standard",
+        });
+        const zhHant = new Intl.DisplayNames("zh-Hant", {
+            type: "language",
+            languageDisplay: "standard",
+        });
+
+        data.forEach(d => {
+            expect(en.of(d.locale)).toBe(d.en);
+            expect(es419.of(d.locale)).toBe(d.es419);
+            expect(zhHant.of(d.locale)).toBe(d.zhHant);
+        });
     });
 
     test("option type region", () => {

--- a/Userland/Libraries/LibUnicode/Forward.h
+++ b/Userland/Libraries/LibUnicode/Forward.h
@@ -25,7 +25,7 @@ enum class GeneralCategory : u8;
 enum class HourCycle : u8;
 enum class HourCycleRegion : u8;
 enum class Key : u8;
-enum class Language : u8;
+enum class Language : u16;
 enum class ListPatternStyle : u8;
 enum class ListPatternType : u8;
 enum class Locale : u16;

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -751,6 +751,7 @@ Optional<DateField> __attribute__((weak)) date_field_from_string(StringView) { r
 Optional<Key> __attribute__((weak)) key_from_string(StringView) { return {}; }
 Optional<ListPatternType> __attribute__((weak)) list_pattern_type_from_string(StringView) { return {}; }
 Optional<ListPatternStyle> __attribute__((weak)) list_pattern_style_from_string(StringView) { return {}; }
+Optional<DisplayPattern> __attribute__((weak)) get_locale_display_patterns(StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_language_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_territory_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_script_mapping(StringView, StringView) { return {}; }

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -85,6 +85,11 @@ enum class Style : u8 {
     Numeric,
 };
 
+struct DisplayPattern {
+    StringView locale_pattern;
+    StringView locale_separator;
+};
+
 struct ListPatterns {
     StringView start;
     StringView middle;
@@ -151,6 +156,8 @@ Optional<DateField> date_field_from_string(StringView calendar);
 Optional<Key> key_from_string(StringView key);
 Optional<ListPatternType> list_pattern_type_from_string(StringView list_pattern_type);
 Optional<ListPatternStyle> list_pattern_style_from_string(StringView list_pattern_style);
+
+Optional<DisplayPattern> get_locale_display_patterns(StringView locale);
 
 Optional<StringView> get_locale_language_mapping(StringView locale, StringView language);
 Optional<StringView> get_locale_territory_mapping(StringView locale, StringView territory);

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -158,6 +158,7 @@ Optional<ListPatternType> list_pattern_type_from_string(StringView list_pattern_
 Optional<ListPatternStyle> list_pattern_style_from_string(StringView list_pattern_style);
 
 Optional<DisplayPattern> get_locale_display_patterns(StringView locale);
+Optional<String> format_locale_for_display(StringView locale, LocaleID locale_id);
 
 Optional<StringView> get_locale_language_mapping(StringView locale, StringView language);
 Optional<StringView> get_locale_territory_mapping(StringView locale, StringView territory);


### PR DESCRIPTION
A bit more involved than I thought it'd be, but now we can do:

```js
> new Intl.DisplayNames([], { type:"language", languageDisplay: "dialect" }).of('en-GB')
"British English"
> new Intl.DisplayNames([], { type:"language", languageDisplay: "standard" }).of('en-GB')
"English (United Kingdom)"
> new Intl.DisplayNames([], { type:"language", languageDisplay: "dialect" }).of('en-US')
"American English"
> new Intl.DisplayNames([], { type:"language", languageDisplay: "standard" }).of('en-US')
"English (United States)"
```

And that's the last piece of Intl.DisplayNames v2!