### PR TITLE
PixelPaint: Editing colors now defaults to the current color

### DIFF
--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -84,6 +84,7 @@ public:
         pal.set_color(ColorRole::Background, color);
         set_palette(pal);
         update();
+        m_color = color;
     }
 
     Function<void(Color const&)> on_color_change;


### PR DESCRIPTION
When editing a foreground/background color, the "Edit Color"
dialog's "Custom Color" will now default to the
foreground/background color that was clicked to open the
dialog.