### PR TITLE
SoundPlayer: BarsVisualizationWidget should now update after changing virtual desktops

### DIFF
--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -61,8 +61,6 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
         current_xpos += pixel_per_group_width + pixels_inbetween_groups;
         m_gfx_falling_bars[g] += 3;
     }
-
-    m_is_using_last = false;
 }
 
 BarsVisualizationWidget::~BarsVisualizationWidget()
@@ -71,7 +69,6 @@ BarsVisualizationWidget::~BarsVisualizationWidget()
 
 BarsVisualizationWidget::BarsVisualizationWidget()
     : m_last_id(-1)
-    , m_is_using_last(false)
     , m_adjust_frequencies(false)
 {
     m_context_menu = GUI::Menu::construct();
@@ -93,9 +90,6 @@ u32 round_previous_power_of_2(u32 x)
 
 void BarsVisualizationWidget::set_buffer(RefPtr<Audio::Buffer> buffer, int samples_to_use)
 {
-    if (m_is_using_last)
-        return;
-    m_is_using_last = true;
     // FIXME: We should dynamically adapt to the sample count and e.g. perform the fft over multiple buffers.
     // For now, the visualizer doesn't work with extremely low global sample rates.
     if (buffer->sample_count() < 256)

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.h
@@ -31,7 +31,6 @@ private:
     int m_last_id;
     int m_sample_count;
     int m_samplerate;
-    bool m_is_using_last;
     bool m_adjust_frequencies;
     RefPtr<GUI::Menu> m_context_menu;
 };


### PR DESCRIPTION
This pull request should close issue #9824.

It seems that while drawing the visualizer, the draw instruction can be interrupted while switching workspaces and it never turns `m_is_using_last` off.
There might be some performance reason why `m_is_using_last` might be used to prevent rendering too many times unnecessarily, I assume, so I can understand why simply removing it can be bad.