### PR TITLE
Aplay: Improve user experience by printing more (useful) stuff

### DIFF
--- a/Base/usr/share/man/man1/aplay.md
+++ b/Base/usr/share/man/man1/aplay.md
@@ -1,20 +1,21 @@
 ## Name
 
-aplay - play a sound
+aplay - play audio
 
 ## Synopsis
 
 ```**sh
-$ aplay [--loop] <path>
+$ aplay [--loop] [--sample-progress] <path>
 ```
 
 ## Description
 
-This program plays a sound specified in `path` through AudioServer.
+This program plays an audio file specified in `path` through AudioServer.
 
 ## Options
 
 * `-l`, `--loop`: Loop playback
+* `-s`, `--sample-progress`: Switch to (old-style) sample playback progress. By default, playback is printed as played, remaining and total length, all in minutes and seconds.
 
 ## Arguments
 
@@ -24,5 +25,5 @@ This program plays a sound specified in `path` through AudioServer.
 
 ```sh
 $ aplay ~/sound.wav
-$ aplay -l ~/music.wav
+$ aplay -l ~/music.flac
 ```

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -100,6 +100,7 @@ public:
     virtual int total_samples() override { return static_cast<int>(m_total_samples); }
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
+    virtual String format_name() override { return "FLAC (.flac)"; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
     virtual RefPtr<Core::File> file() override { return m_file; }
 

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -50,6 +50,8 @@ public:
     virtual u32 sample_rate() = 0;
     virtual u16 num_channels() = 0;
 
+    // Human-readable name of the file format, of the form <full abbreviation> (.<ending>)
+    virtual String format_name() = 0;
     virtual PcmSampleFormat pcm_format() = 0;
     virtual RefPtr<Core::File> file() = 0;
 };
@@ -68,6 +70,7 @@ public:
     int total_samples() const { return m_plugin->total_samples(); }
     u32 sample_rate() const { return m_plugin->sample_rate(); }
     u16 num_channels() const { return m_plugin->num_channels(); }
+    String format_name() const { return m_plugin->format_name(); }
     u16 bits_per_sample() const { return pcm_bits_per_sample(m_plugin->pcm_format()); }
     RefPtr<Core::File> file() const { return m_plugin->file(); }
 

--- a/Userland/Libraries/LibAudio/WavLoader.h
+++ b/Userland/Libraries/LibAudio/WavLoader.h
@@ -52,6 +52,7 @@ public:
     virtual int total_samples() override { return m_total_samples; }
     virtual u32 sample_rate() override { return m_sample_rate; }
     virtual u16 num_channels() override { return m_num_channels; }
+    virtual String format_name() override { return "RIFF WAVE (.wav)"; }
     virtual PcmSampleFormat pcm_format() override { return m_sample_format; }
     virtual RefPtr<Core::File> file() override { return m_file; }
 

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -37,7 +37,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto loader = maybe_loader.release_value();
 
     outln("\033[34;1m Playing\033[0m: {}", path);
-    outln("\033[34;1m  Format\033[0m: {} Hz, {}-bit, {}",
+    outln("\033[34;1m  Format\033[0m: {} {} Hz, {}-bit, {}",
+        loader->format_name(),
         loader->sample_rate(),
         loader->bits_per_sample(),
         loader->num_channels() == 1 ? "Mono" : "Stereo");

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +11,7 @@
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibMain/Main.h>
+#include <math.h>
 #include <stdio.h>
 
 // The Kernel has issues with very large anonymous buffers.
@@ -20,10 +22,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     const char* path = nullptr;
     bool should_loop = false;
+    bool show_sample_progress = false;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "Path to audio file", "path");
     args_parser.add_option(should_loop, "Loop playback", "loop", 'l');
+    args_parser.add_option(show_sample_progress, "Show playback progress in samples", "sample-progress", 's');
     args_parser.parse(arguments);
 
     Core::EventLoop loop;
@@ -59,7 +63,27 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (samples.value()->sample_count() > 0) {
                 // We can read and enqueue more samples
                 out("\033[u");
-                out("{}/{}", loader->loaded_samples(), loader->total_samples());
+                if (show_sample_progress) {
+                    out("{}/{}", loader->loaded_samples(), loader->total_samples());
+                } else {
+                    auto playing_seconds = static_cast<int>(floor(static_cast<double>(loader->loaded_samples()) / static_cast<double>(loader->sample_rate())));
+                    auto playing_minutes = playing_seconds / 60;
+                    auto playing_seconds_of_minute = playing_seconds % 60;
+
+                    auto total_seconds = static_cast<int>(floor(static_cast<double>(loader->total_samples()) / static_cast<double>(loader->sample_rate())));
+                    auto total_minutes = total_seconds / 60;
+                    auto total_seconds_of_minute = total_seconds % 60;
+
+                    auto remaining_seconds = total_seconds - playing_seconds;
+                    auto remaining_minutes = remaining_seconds / 60;
+                    auto remaining_seconds_of_minute = remaining_seconds % 60;
+
+                    out("\033[1m{:02d}:{:02d}\033[0m [{}{:02d}:{:02d}] -- {:02d}:{:02d}",
+                        playing_minutes, playing_seconds_of_minute,
+                        remaining_seconds == 0 ? " " : "-",
+                        remaining_minutes, remaining_seconds_of_minute,
+                        total_minutes, total_seconds_of_minute);
+                }
                 fflush(stdout);
                 resampler.reset();
                 auto resampled_samples = TRY(Audio::resample_buffer(resampler, *samples.value()));


### PR DESCRIPTION
Aplay now prints the file progress in minutes and seconds (reversible with the -s flag for sample display like before) and also outputs the format that is playing.