### PR TITLE
AK: Explicitly define copy and assignment operator for SinglyLinkedList

### DIFF
--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -80,6 +80,11 @@ private:
 
 public:
     SinglyLinkedList() = default;
+    SinglyLinkedList(const SinglyLinkedList& other) = delete;
+    SinglyLinkedList(SinglyLinkedList&&) = default;
+    SinglyLinkedList& operator=(const SinglyLinkedList& other) = delete;
+    SinglyLinkedList& operator=(SinglyLinkedList&&) = default;
+
     ~SinglyLinkedList() { clear(); }
 
     bool is_empty() const { return !head(); }


### PR DESCRIPTION
Fixes #11787 

Defined operators:
 - SinglyLinkedList(const SinglyLinkedList&) - deleted
 - SinglyLinkedList(SinglyLinkedList&&) - defaulted
 - SinglyLinkedList& operator=(const SinglyLinkedList&) - deleted
 - SinglyLinkedList& operator=(SinglyLinkedList&&) - defaulted