### PR TITLE
LibCore+LibIPC+Everywhere: Return Stream::LocalSocket from LocalServer

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/IPCCompiler/main.cpp
@@ -368,9 +368,9 @@ public:
     static i32 static_message_id() { return (int)MessageID::@message.pascal_name@; }
     virtual const char* message_name() const override { return "@endpoint.name@::@message.pascal_name@"; }
 
-    static OwnPtr<@message.pascal_name@> decode(InputMemoryStream& stream, [[maybe_unused]] int sockfd)
+    static OwnPtr<@message.pascal_name@> decode(InputMemoryStream& stream, Core::Stream::LocalSocket& socket)
     {
-        IPC::Decoder decoder { stream, sockfd };
+        IPC::Decoder decoder { stream, socket };
 )~~~");
 
             for (auto& parameter : parameters) {
@@ -632,7 +632,7 @@ public:
 
     static u32 static_magic() { return @endpoint.magic@; }
 
-    static OwnPtr<IPC::Message> decode_message(ReadonlyBytes buffer, [[maybe_unused]] int sockfd)
+    static OwnPtr<IPC::Message> decode_message(ReadonlyBytes buffer, [[maybe_unused]] Core::Stream::LocalSocket& socket)
     {
         InputMemoryStream stream { buffer };
         u32 message_endpoint_magic = 0;
@@ -685,7 +685,7 @@ public:
 
                 message_generator.append(R"~~~(
         case (int)Messages::@endpoint.name@::MessageID::@message.pascal_name@:
-            message = Messages::@endpoint.name@::@message.pascal_name@::decode(stream, sockfd);
+            message = Messages::@endpoint.name@::@message.pascal_name@::decode(stream, socket);
             break;
 )~~~");
             };

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -41,14 +41,15 @@ public:
             { 0, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-zero.png")) },
             { 0, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-muted.png")) }
         };
-        NonnullRefPtr<AudioWidget> audio_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AudioWidget(move(volume_level_bitmaps))));
+        auto audio_client = TRY(Audio::ClientConnection::try_create());
+        NonnullRefPtr<AudioWidget> audio_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AudioWidget(move(audio_client), move(volume_level_bitmaps))));
         TRY(audio_widget->try_initialize_graphical_elements());
         return audio_widget;
     }
 
 private:
-    AudioWidget(Vector<VolumeBitmapPair, 5> volume_level_bitmaps)
-        : m_audio_client(Audio::ClientConnection::construct())
+    AudioWidget(NonnullRefPtr<Audio::ClientConnection> audio_client, Vector<VolumeBitmapPair, 5> volume_level_bitmaps)
+        : m_audio_client(move(audio_client))
         , m_volume_level_bitmaps(move(volume_level_bitmaps))
         , m_show_percent(Config::read_bool("AudioApplet", "Applet", "ShowPercent", false))
     {

--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -169,7 +169,7 @@ void ViewWidget::load_from_file(const String& path)
     auto& mapped_file = *file_or_error.value();
 
     // Spawn a new ImageDecoder service process and connect to it.
-    auto client = ImageDecoderClient::Client::construct();
+    auto client = ImageDecoderClient::Client::try_create().release_value_but_fixme_should_propagate_errors();
 
     auto decoded_image_or_error = client->decode_image(mapped_file.bytes());
     if (!decoded_image_or_error.has_value()) {

--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -27,7 +27,7 @@ AudioPlayerLoop::AudioPlayerLoop(TrackManager& track_manager, bool& need_to_writ
     , m_need_to_write_wav(need_to_write_wav)
     , m_wav_writer(wav_writer)
 {
-    m_audio_client = Audio::ClientConnection::construct();
+    m_audio_client = Audio::ClientConnection::try_create().release_value_but_fixme_should_propagate_errors();
     m_audio_client->on_finish_playing_buffer = [this](int buffer_id) {
         (void)buffer_id;
         enqueue_audio();

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -56,7 +56,7 @@ void Image::paint_into(GUI::Painter& painter, Gfx::IntRect const& dest_rect) con
 ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Image::try_decode_bitmap(ReadonlyBytes bitmap_data)
 {
     // Spawn a new ImageDecoder service process and connect to it.
-    auto client = ImageDecoderClient::Client::construct();
+    auto client = TRY(ImageDecoderClient::Client::try_create());
 
     // FIXME: Find a way to avoid the memory copying here.
     auto maybe_decoded_image = client->decode_image(bitmap_data);

--- a/Userland/DevTools/HackStudio/LanguageClients/ServerConnections.h
+++ b/Userland/DevTools/HackStudio/LanguageClients/ServerConnections.h
@@ -12,19 +12,19 @@
 #include <DevTools/HackStudio/LanguageServers/LanguageServerEndpoint.h>
 #include <LibIPC/ServerConnection.h>
 
-#define LANGUAGE_CLIENT(language_name_, socket_name)                                           \
-    namespace language_name_ {                                                                 \
-    class ServerConnection final : public HackStudio::ServerConnection {                       \
-        C_OBJECT(ServerConnection)                                                             \
-    public:                                                                                    \
-        static const char* language_name() { return #language_name_; }                         \
-                                                                                               \
-    private:                                                                                   \
-        ServerConnection(const String& project_path)                                           \
-            : HackStudio::ServerConnection("/tmp/portal/language/" #socket_name, project_path) \
-        {                                                                                      \
-        }                                                                                      \
-    };                                                                                         \
+#define LANGUAGE_CLIENT(language_name_, socket_name)                                                  \
+    namespace language_name_ {                                                                        \
+    class ServerConnection final : public HackStudio::ServerConnection {                              \
+        IPC_CLIENT_CONNECTION(ServerConnection, "/tmp/portal/language" #socket_name)                  \
+    public:                                                                                           \
+        static const char* language_name() { return #language_name_; }                                \
+                                                                                                      \
+    private:                                                                                          \
+        ServerConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, const String& project_path) \
+            : HackStudio::ServerConnection(move(socket), project_path)                                \
+        {                                                                                             \
+        }                                                                                             \
+    };                                                                                                \
     }
 
 namespace LanguageClients {

--- a/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.cpp
@@ -14,7 +14,7 @@ namespace LanguageServers {
 
 static HashMap<int, RefPtr<ClientConnection>> s_connections;
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
     : IPC::ClientConnection<LanguageClientEndpoint, LanguageServerEndpoint>(*this, move(socket), 1)
 {
     s_connections.set(1, *this);

--- a/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.h
@@ -20,7 +20,7 @@ namespace LanguageServers {
 
 class ClientConnection : public IPC::ClientConnection<LanguageClientEndpoint, LanguageServerEndpoint> {
 public:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>);
     ~ClientConnection() override;
 
     virtual void die() override;

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
@@ -15,7 +15,7 @@ class ClientConnection final : public LanguageServers::ClientConnection {
     C_OBJECT(ClientConnection);
 
 private:
-    ClientConnection(NonnullRefPtr<Core::LocalSocket> socket)
+    ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
         : LanguageServers::ClientConnection(move(socket))
     {
         m_autocomplete_engine = make<CppComprehensionEngine>(m_filedb);

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
@@ -16,7 +16,7 @@ class ClientConnection final : public LanguageServers::ClientConnection {
     C_OBJECT(ClientConnection);
 
 private:
-    ClientConnection(NonnullRefPtr<Core::LocalSocket> socket)
+    ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
         : LanguageServers::ClientConnection(move(socket))
     {
         m_autocomplete_engine = make<ShellComprehensionEngine>(m_filedb);

--- a/Userland/DevTools/Inspector/InspectorServerClient.h
+++ b/Userland/DevTools/Inspector/InspectorServerClient.h
@@ -15,14 +15,14 @@ namespace Inspector {
 class InspectorServerClient final
     : public IPC::ServerConnection<InspectorClientEndpoint, InspectorServerEndpoint>
     , public InspectorClientEndpoint {
-    C_OBJECT(InspectorServerClient);
+    IPC_CLIENT_CONNECTION(InspectorServerClient, "/tmp/portal/inspector")
 
 public:
     virtual ~InspectorServerClient() override = default;
 
 private:
-    InspectorServerClient()
-        : IPC::ServerConnection<InspectorClientEndpoint, InspectorServerEndpoint>(*this, "/tmp/portal/inspector")
+    InspectorServerClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+        : IPC::ServerConnection<InspectorClientEndpoint, InspectorServerEndpoint>(*this, move(socket))
     {
     }
 };

--- a/Userland/DevTools/Inspector/RemoteProcess.cpp
+++ b/Userland/DevTools/Inspector/RemoteProcess.cpp
@@ -24,7 +24,7 @@ RemoteProcess::RemoteProcess(pid_t pid)
     , m_object_graph_model(RemoteObjectGraphModel::create(*this))
 {
     s_the = this;
-    m_client = InspectorServerClient::construct();
+    m_client = InspectorServerClient::try_create().release_value_but_fixme_should_propagate_errors();
 }
 
 void RemoteProcess::handle_identify_response(const JsonObject& response)

--- a/Userland/Libraries/LibAudio/ClientConnection.cpp
+++ b/Userland/Libraries/LibAudio/ClientConnection.cpp
@@ -14,8 +14,8 @@ namespace Audio {
 // Real-time audio may be improved with a lower value.
 static timespec g_enqueue_wait_time { 0, 10'000'000 };
 
-ClientConnection::ClientConnection()
-    : IPC::ServerConnection<AudioClientEndpoint, AudioServerEndpoint>(*this, "/tmp/portal/audio")
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+    : IPC::ServerConnection<AudioClientEndpoint, AudioServerEndpoint>(*this, move(socket))
 {
 }
 

--- a/Userland/Libraries/LibAudio/ClientConnection.h
+++ b/Userland/Libraries/LibAudio/ClientConnection.h
@@ -17,7 +17,7 @@ class Buffer;
 class ClientConnection final
     : public IPC::ServerConnection<AudioClientEndpoint, AudioServerEndpoint>
     , public AudioClientEndpoint {
-    C_OBJECT(ClientConnection)
+    IPC_CLIENT_CONNECTION(ClientConnection, "/tmp/portal/audio")
 public:
     void enqueue(Buffer const&);
     bool try_enqueue(Buffer const&);
@@ -29,7 +29,7 @@ public:
     Function<void(double volume)> on_client_volume_change;
 
 private:
-    ClientConnection();
+    ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual void finished_playing_buffer(i32) override;
     virtual void main_mix_muted_state_changed(bool) override;

--- a/Userland/Libraries/LibConfig/Client.cpp
+++ b/Userland/Libraries/LibConfig/Client.cpp
@@ -15,7 +15,7 @@ Client& Client::the()
 {
     if (!s_the || !s_the->is_open()) {
         VERIFY(Core::EventLoop::has_been_instantiated());
-        s_the = Client::construct();
+        s_the = Client::try_create().release_value_but_fixme_should_propagate_errors();
     }
     return *s_the;
 }

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -18,7 +18,7 @@ namespace Config {
 class Client final
     : public IPC::ServerConnection<ConfigClientEndpoint, ConfigServerEndpoint>
     , public ConfigClientEndpoint {
-    C_OBJECT(Client);
+    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/config")
 
 public:
     void pledge_domains(Vector<String> const&);
@@ -39,8 +39,8 @@ public:
     static Client& the();
 
 private:
-    explicit Client()
-        : IPC::ServerConnection<ConfigClientEndpoint, ConfigServerEndpoint>(*this, "/tmp/portal/config")
+    explicit Client(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+        : IPC::ServerConnection<ConfigClientEndpoint, ConfigServerEndpoint>(*this, move(socket))
     {
     }
 

--- a/Userland/Libraries/LibCore/LocalServer.h
+++ b/Userland/Libraries/LibCore/LocalServer.h
@@ -8,6 +8,7 @@
 
 #include <LibCore/Notifier.h>
 #include <LibCore/Object.h>
+#include <LibCore/Stream.h>
 
 namespace Core {
 
@@ -20,9 +21,9 @@ public:
     bool is_listening() const { return m_listening; }
     bool listen(const String& address);
 
-    RefPtr<LocalSocket> accept();
+    ErrorOr<NonnullOwnPtr<Stream::LocalSocket>> accept();
 
-    Function<void(NonnullRefPtr<Core::LocalSocket>)> on_accept;
+    Function<void(NonnullOwnPtr<Stream::LocalSocket>)> on_accept;
 
 private:
     explicit LocalServer(Object* parent = nullptr);

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "Stream.h"
+#include <LibCore/System.h>
 #include <fcntl.h>
 #include <netdb.h>
 #include <poll.h>
@@ -533,6 +534,26 @@ ErrorOr<NonnullOwnPtr<LocalSocket>> LocalSocket::connect(String const& path)
 
     socket->setup_notifier();
     return socket;
+}
+
+ErrorOr<int> LocalSocket::receive_fd(int flags)
+{
+#ifdef __serenity__
+    return Core::System::recvfd(m_helper.fd(), flags);
+#else
+    (void)flags;
+    return Error::from_string_literal("File descriptor passing not supported on this platform");
+#endif
+}
+
+ErrorOr<void> LocalSocket::send_fd(int fd)
+{
+#ifdef __serenity__
+    return Core::System::sendfd(m_helper.fd(), fd);
+#else
+    (void)fd;
+    return Error::from_string_literal("File descriptor passing not supported on this platform");
+#endif
 }
 
 }

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -536,6 +536,18 @@ ErrorOr<NonnullOwnPtr<LocalSocket>> LocalSocket::connect(String const& path)
     return socket;
 }
 
+ErrorOr<NonnullOwnPtr<LocalSocket>> LocalSocket::adopt_fd(int fd)
+{
+    if (fd < 0) {
+        return Error::from_errno(EBADF);
+    }
+
+    auto socket = TRY(adopt_nonnull_own_or_enomem(new (nothrow) LocalSocket()));
+    socket->m_helper.set_fd(fd);
+    socket->setup_notifier();
+    return socket;
+}
+
 ErrorOr<int> LocalSocket::receive_fd(int flags)
 {
 #ifdef __serenity__

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -413,6 +413,7 @@ public:
 
     ErrorOr<int> receive_fd(int flags);
     ErrorOr<void> send_fd(int fd);
+    ErrorOr<pid_t> peer_pid() const;
     ErrorOr<size_t> read_without_waiting(Bytes buffer);
 
     virtual ~LocalSocket() { close(); }

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -229,7 +229,7 @@ public:
     int fd() const { return m_fd; }
     void set_fd(int fd) { m_fd = fd; }
 
-    ErrorOr<size_t> read(Bytes);
+    ErrorOr<size_t> read(Bytes, int flags = 0);
     ErrorOr<size_t> write(ReadonlyBytes);
 
     bool is_eof() const { return !is_open() || m_last_read_was_eof; }
@@ -412,6 +412,7 @@ public:
 
     ErrorOr<int> receive_fd(int flags);
     ErrorOr<void> send_fd(int fd);
+    ErrorOr<size_t> read_without_waiting(Bytes buffer);
 
     virtual ~LocalSocket() { close(); }
 

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -410,6 +410,9 @@ public:
     virtual ErrorOr<void> set_blocking(bool enabled) override { return m_helper.set_blocking(enabled); }
     virtual ErrorOr<void> set_close_on_exec(bool enabled) override { return m_helper.set_close_on_exec(enabled); }
 
+    ErrorOr<int> receive_fd(int flags);
+    ErrorOr<void> send_fd(int fd);
+
     virtual ~LocalSocket() { close(); }
 
 private:

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -379,6 +379,7 @@ private:
 class LocalSocket final : public Socket {
 public:
     static ErrorOr<NonnullOwnPtr<LocalSocket>> connect(String const& path);
+    static ErrorOr<NonnullOwnPtr<LocalSocket>> adopt_fd(int fd);
 
     LocalSocket(LocalSocket&& other)
         : Socket(static_cast<Socket&&>(other))

--- a/Userland/Libraries/LibDesktop/Launcher.cpp
+++ b/Userland/Libraries/LibDesktop/Launcher.cpp
@@ -36,17 +36,17 @@ auto Launcher::Details::from_details_str(const String& details_str) -> NonnullRe
 class LaunchServerConnection final
     : public IPC::ServerConnection<LaunchClientEndpoint, LaunchServerEndpoint>
     , public LaunchClientEndpoint {
-    C_OBJECT(LaunchServerConnection)
+    IPC_CLIENT_CONNECTION(LaunchServerConnection, "/tmp/portal/launch")
 private:
-    LaunchServerConnection()
-        : IPC::ServerConnection<LaunchClientEndpoint, LaunchServerEndpoint>(*this, "/tmp/portal/launch")
+    LaunchServerConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+        : IPC::ServerConnection<LaunchClientEndpoint, LaunchServerEndpoint>(*this, move(socket))
     {
     }
 };
 
 static LaunchServerConnection& connection()
 {
-    static auto connection = LaunchServerConnection::construct();
+    static auto connection = LaunchServerConnection::try_create().release_value_but_fixme_should_propagate_errors();
     return connection;
 }
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -20,7 +20,7 @@ static RefPtr<Client> s_the = nullptr;
 Client& Client::the()
 {
     if (!s_the || !s_the->is_open())
-        s_the = Client::construct();
+        s_the = Client::try_create().release_value_but_fixme_should_propagate_errors();
     return *s_the;
 }
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -24,7 +24,7 @@ struct Result {
 class Client final
     : public IPC::ServerConnection<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
     , public FileSystemAccessClientEndpoint {
-    C_OBJECT(Client)
+    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/filesystemaccess")
 
 public:
     Result request_file_read_only_approved(i32 parent_window_id, String const& path);
@@ -38,8 +38,8 @@ protected:
     void die() override;
 
 private:
-    explicit Client()
-        : IPC::ServerConnection<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>(*this, "/tmp/portal/filesystemaccess")
+    explicit Client(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+        : IPC::ServerConnection<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>(*this, move(socket))
     {
     }
 

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
@@ -12,9 +12,9 @@ namespace GUI {
 
 WindowManagerServerConnection& WindowManagerServerConnection::the()
 {
-    static WindowManagerServerConnection* s_connection = nullptr;
+    static RefPtr<WindowManagerServerConnection> s_connection = nullptr;
     if (!s_connection)
-        s_connection = new WindowManagerServerConnection;
+        s_connection = WindowManagerServerConnection::try_create().release_value_but_fixme_should_propagate_errors();
     return *s_connection;
 }
 

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
@@ -16,13 +16,14 @@ namespace GUI {
 class WindowManagerServerConnection final
     : public IPC::ServerConnection<WindowManagerClientEndpoint, WindowManagerServerEndpoint>
     , public WindowManagerClientEndpoint {
-    C_OBJECT(WindowManagerServerConnection)
+    IPC_CLIENT_CONNECTION(WindowManagerServerConnection, "/tmp/portal/wm")
+
 public:
     static WindowManagerServerConnection& the();
 
 private:
-    WindowManagerServerConnection()
-        : IPC::ServerConnection<WindowManagerClientEndpoint, WindowManagerServerEndpoint>(*this, "/tmp/portal/wm")
+    WindowManagerServerConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+        : IPC::ServerConnection<WindowManagerClientEndpoint, WindowManagerServerEndpoint>(*this, move(socket))
     {
     }
 

--- a/Userland/Libraries/LibGUI/WindowServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.h
@@ -16,13 +16,13 @@ namespace GUI {
 class WindowServerConnection final
     : public IPC::ServerConnection<WindowClientEndpoint, WindowServerEndpoint>
     , public WindowClientEndpoint {
-    C_OBJECT(WindowServerConnection)
+    IPC_CLIENT_CONNECTION(WindowServerConnection, "/tmp/portal/window")
 public:
     static WindowServerConnection& the();
     i32 expose_client_id() { return m_client_id; }
 
 private:
-    WindowServerConnection();
+    WindowServerConnection(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual void fast_greet(Vector<Gfx::IntRect> const&, u32, u32, u32, Core::AnonymousBuffer const&, String const&, String const&, i32) override;
     virtual void paint(i32, Gfx::IntSize const&, Vector<Gfx::IntRect> const&) override;

--- a/Userland/Libraries/LibIPC/CMakeLists.txt
+++ b/Userland/Libraries/LibIPC/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     Encoder.cpp
     Message.cpp
     Stub.cpp
+    SystemServerTakeover.cpp
 )
 
 serenity_lib(LibIPC ipc)

--- a/Userland/Libraries/LibIPC/ClientConnection.h
+++ b/Userland/Libraries/LibIPC/ClientConnection.h
@@ -24,12 +24,12 @@ public:
     using ServerStub = typename ServerEndpoint::Stub;
     using IPCProxy = typename ClientEndpoint::template Proxy<ServerEndpoint>;
 
-    ClientConnection(ServerStub& stub, NonnullRefPtr<Core::LocalSocket> socket, int client_id)
+    ClientConnection(ServerStub& stub, NonnullOwnPtr<Core::Stream::LocalSocket> socket, int client_id)
         : IPC::Connection<ServerEndpoint, ClientEndpoint>(stub, move(socket))
         , ClientEndpoint::template Proxy<ServerEndpoint>(*this, {})
         , m_client_id(client_id)
     {
-        VERIFY(this->socket().is_connected());
+        VERIFY(this->socket().is_open());
         this->socket().on_ready_to_read = [this] {
             // FIXME: Do something about errors.
             (void)this->drain_messages_from_peer();

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -162,14 +162,9 @@ ErrorOr<void> Decoder::decode(Dictionary& dictionary)
 
 ErrorOr<void> Decoder::decode([[maybe_unused]] File& file)
 {
-#ifdef __serenity__
-    int fd = TRY(Core::System::recvfd(m_sockfd, O_CLOEXEC));
+    int fd = TRY(m_socket.receive_fd(O_CLOEXEC));
     file = File(fd, File::ConstructWithReceivedFileDescriptor);
     return {};
-#else
-    [[maybe_unused]] auto fd = m_sockfd;
-    return Error::from_string_literal("File descriptor passing not supported on this platform");
-#endif
 }
 
 ErrorOr<void> decode(Decoder& decoder, Core::AnonymousBuffer& buffer)

--- a/Userland/Libraries/LibIPC/Decoder.h
+++ b/Userland/Libraries/LibIPC/Decoder.h
@@ -11,6 +11,7 @@
 #include <AK/NumericLimits.h>
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
+#include <LibCore/Stream.h>
 #include <LibIPC/Forward.h>
 #include <LibIPC/Message.h>
 
@@ -25,9 +26,9 @@ inline ErrorOr<void> decode(Decoder&, T&)
 
 class Decoder {
 public:
-    Decoder(InputMemoryStream& stream, int sockfd)
+    Decoder(InputMemoryStream& stream, Core::Stream::LocalSocket& socket)
         : m_stream(stream)
-        , m_sockfd(sockfd)
+        , m_socket(socket)
     {
     }
 
@@ -115,7 +116,7 @@ public:
 
 private:
     InputMemoryStream& m_stream;
-    int m_sockfd { -1 };
+    Core::Stream::LocalSocket& m_socket;
 };
 
 }

--- a/Userland/Libraries/LibIPC/SingleServer.h
+++ b/Userland/Libraries/LibIPC/SingleServer.h
@@ -6,14 +6,16 @@
 
 #pragma once
 
+#include <LibCore/System.h>
 #include <LibIPC/ClientConnection.h>
+#include <LibIPC/SystemServerTakeover.h>
 
 namespace IPC {
 
 template<typename ClientConnectionType>
 ErrorOr<NonnullRefPtr<ClientConnectionType>> take_over_accepted_client_from_system_server()
 {
-    auto socket = TRY(Core::LocalSocket::take_over_accepted_socket_from_system_server());
+    auto socket = TRY(take_over_accepted_socket_from_system_server());
     return IPC::new_client_connection<ClientConnectionType>(move(socket));
 }
 

--- a/Userland/Libraries/LibIPC/SystemServerTakeover.cpp
+++ b/Userland/Libraries/LibIPC/SystemServerTakeover.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "SystemServerTakeover.h"
+#include <LibCore/System.h>
+
+HashMap<String, int> s_overtaken_sockets {};
+bool s_overtaken_sockets_parsed { false };
+
+void parse_sockets_from_system_server()
+{
+    VERIFY(!s_overtaken_sockets_parsed);
+
+    constexpr auto socket_takeover = "SOCKET_TAKEOVER";
+    const char* sockets = getenv(socket_takeover);
+    if (!sockets) {
+        s_overtaken_sockets_parsed = true;
+        return;
+    }
+
+    for (auto& socket : StringView(sockets).split_view(' ')) {
+        auto params = socket.split_view(':');
+        s_overtaken_sockets.set(params[0].to_string(), strtol(params[1].to_string().characters(), nullptr, 10));
+    }
+
+    s_overtaken_sockets_parsed = true;
+    // We wouldn't want our children to think we're passing
+    // them a socket either, so unset the env variable.
+    unsetenv(socket_takeover);
+}
+
+ErrorOr<NonnullOwnPtr<Core::Stream::LocalSocket>> take_over_accepted_socket_from_system_server(String const& socket_path)
+{
+    if (!s_overtaken_sockets_parsed)
+        parse_sockets_from_system_server();
+
+    int fd;
+    if (socket_path.is_null()) {
+        // We want the first (and only) socket.
+        VERIFY(s_overtaken_sockets.size() == 1);
+        fd = s_overtaken_sockets.begin()->value;
+    } else {
+        auto it = s_overtaken_sockets.find(socket_path);
+        if (it == s_overtaken_sockets.end())
+            return Error::from_string_literal("Non-existent socket requested"sv);
+        fd = it->value;
+    }
+
+    // Sanity check: it has to be a socket.
+    auto stat = TRY(Core::System::fstat(fd));
+
+    if (!S_ISSOCK(stat.st_mode))
+        return Error::from_string_literal("The fd we got from SystemServer is not a socket"sv);
+
+    auto socket = TRY(Core::Stream::LocalSocket::adopt_fd(fd));
+    // It had to be !CLOEXEC for obvious reasons, but we
+    // don't need it to be !CLOEXEC anymore, so set the
+    // CLOEXEC flag now.
+    TRY(socket->set_close_on_exec(true));
+
+    return socket;
+}

--- a/Userland/Libraries/LibIPC/SystemServerTakeover.h
+++ b/Userland/Libraries/LibIPC/SystemServerTakeover.h
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2022, sin-ack <sin-ack@protonmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Stream.h>
+
+void parse_sockets_from_system_server();
+ErrorOr<NonnullOwnPtr<Core::Stream::LocalSocket>> take_over_accepted_socket_from_system_server(String const& socket_path = {});

--- a/Userland/Libraries/LibImageDecoderClient/Client.cpp
+++ b/Userland/Libraries/LibImageDecoderClient/Client.cpp
@@ -9,8 +9,8 @@
 
 namespace ImageDecoderClient {
 
-Client::Client()
-    : IPC::ServerConnection<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, "/tmp/portal/image")
+Client::Client(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+    : IPC::ServerConnection<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, move(socket))
 {
 }
 

--- a/Userland/Libraries/LibImageDecoderClient/Client.h
+++ b/Userland/Libraries/LibImageDecoderClient/Client.h
@@ -27,7 +27,7 @@ struct DecodedImage {
 class Client final
     : public IPC::ServerConnection<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>
     , public ImageDecoderClientEndpoint {
-    C_OBJECT(Client);
+    IPC_CLIENT_CONNECTION(Client, "/tmp/portal/image");
 
 public:
     Optional<DecodedImage> decode_image(ReadonlyBytes);
@@ -35,7 +35,7 @@ public:
     Function<void()> on_death;
 
 private:
-    Client();
+    Client(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual void die() override;
 };

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -10,8 +10,8 @@
 
 namespace Protocol {
 
-RequestClient::RequestClient()
-    : IPC::ServerConnection<RequestClientEndpoint, RequestServerEndpoint>(*this, "/tmp/portal/request")
+RequestClient::RequestClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+    : IPC::ServerConnection<RequestClientEndpoint, RequestServerEndpoint>(*this, move(socket))
 {
 }
 

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -18,7 +18,7 @@ class Request;
 class RequestClient final
     : public IPC::ServerConnection<RequestClientEndpoint, RequestServerEndpoint>
     , public RequestClientEndpoint {
-    C_OBJECT(RequestClient);
+    IPC_CLIENT_CONNECTION(RequestClient, "/tmp/portal/request")
 
 public:
     template<typename RequestHashMapTraits = Traits<String>>
@@ -30,7 +30,7 @@ public:
     bool set_certificate(Badge<Request>, Request&, String, String);
 
 private:
-    RequestClient();
+    RequestClient(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual void request_progress(i32, Optional<u32> const&, u32) override;
     virtual void request_finished(i32, bool, u32) override;

--- a/Userland/Libraries/LibProtocol/WebSocketClient.cpp
+++ b/Userland/Libraries/LibProtocol/WebSocketClient.cpp
@@ -9,8 +9,8 @@
 
 namespace Protocol {
 
-WebSocketClient::WebSocketClient()
-    : IPC::ServerConnection<WebSocketClientEndpoint, WebSocketServerEndpoint>(*this, "/tmp/portal/websocket")
+WebSocketClient::WebSocketClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+    : IPC::ServerConnection<WebSocketClientEndpoint, WebSocketServerEndpoint>(*this, move(socket))
 {
 }
 

--- a/Userland/Libraries/LibProtocol/WebSocketClient.h
+++ b/Userland/Libraries/LibProtocol/WebSocketClient.h
@@ -18,7 +18,7 @@ class WebSocket;
 class WebSocketClient final
     : public IPC::ServerConnection<WebSocketClientEndpoint, WebSocketServerEndpoint>
     , public WebSocketClientEndpoint {
-    C_OBJECT(WebSocketClient);
+    IPC_CLIENT_CONNECTION(WebSocketClient, "/tmp/portal/websocket")
 
 public:
     RefPtr<WebSocket> connect(const URL&, const String& origin = {}, const Vector<String>& protocols = {}, const Vector<String>& extensions = {}, const HashMap<String, String>& request_headers = {});
@@ -29,7 +29,7 @@ public:
     bool set_certificate(Badge<WebSocket>, WebSocket&, String, String);
 
 private:
-    WebSocketClient();
+    WebSocketClient(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual void connected(i32) override;
     virtual void received(i32, bool, ByteBuffer const&) override;

--- a/Userland/Libraries/LibSQL/SQLClient.h
+++ b/Userland/Libraries/LibSQL/SQLClient.h
@@ -15,7 +15,7 @@ namespace SQL {
 class SQLClient
     : public IPC::ServerConnection<SQLClientEndpoint, SQLServerEndpoint>
     , public SQLClientEndpoint {
-    C_OBJECT(SQLClient);
+    IPC_CLIENT_CONNECTION(SQLClient, "/tmp/portal/sql")
     virtual ~SQLClient();
 
     Function<void(int, String const&)> on_connected;
@@ -27,8 +27,8 @@ class SQLClient
     Function<void(int, int)> on_results_exhausted;
 
 private:
-    SQLClient()
-        : IPC::ServerConnection<SQLClientEndpoint, SQLServerEndpoint>(*this, "/tmp/portal/sql")
+    SQLClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+        : IPC::ServerConnection<SQLClientEndpoint, SQLServerEndpoint>(*this, move(socket))
     {
     }
 

--- a/Userland/Libraries/LibWeb/HTML/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WebSocket.cpp
@@ -29,14 +29,20 @@ namespace Web::HTML {
 
 WebSocketClientManager& WebSocketClientManager::the()
 {
-    static WebSocketClientManager* s_the;
+    static RefPtr<WebSocketClientManager> s_the;
     if (!s_the)
-        s_the = &WebSocketClientManager::construct().leak_ref();
+        s_the = WebSocketClientManager::try_create().release_value_but_fixme_should_propagate_errors();
     return *s_the;
 }
 
-WebSocketClientManager::WebSocketClientManager()
-    : m_websocket_client(Protocol::WebSocketClient::construct())
+ErrorOr<NonnullRefPtr<WebSocketClientManager>> WebSocketClientManager::try_create()
+{
+    auto websocket_client = TRY(Protocol::WebSocketClient::try_create());
+    return adopt_nonnull_ref_or_enomem(new (nothrow) WebSocketClientManager(move(websocket_client)));
+}
+
+WebSocketClientManager::WebSocketClientManager(NonnullRefPtr<Protocol::WebSocketClient> websocket_client)
+    : m_websocket_client(move(websocket_client))
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/WebSocket.h
+++ b/Userland/Libraries/LibWeb/HTML/WebSocket.h
@@ -31,14 +31,16 @@ class WebSocket;
 namespace Web::HTML {
 
 class WebSocketClientManager : public Core::Object {
-    C_OBJECT(WebSocketClientManager)
+    C_OBJECT_ABSTRACT(WebSocketClientManager)
 public:
     static WebSocketClientManager& the();
 
     RefPtr<Protocol::WebSocket> connect(const AK::URL&);
 
 private:
-    WebSocketClientManager();
+    static ErrorOr<NonnullRefPtr<WebSocketClientManager>> try_create();
+    WebSocketClientManager(NonnullRefPtr<Protocol::WebSocketClient>);
+
     RefPtr<Protocol::WebSocketClient> m_websocket_client;
 };
 

--- a/Userland/Libraries/LibWeb/ImageDecoding.cpp
+++ b/Userland/Libraries/LibWeb/ImageDecoding.cpp
@@ -12,7 +12,7 @@ ImageDecoderClient::Client& image_decoder_client()
 {
     static RefPtr<ImageDecoderClient::Client> image_decoder_client;
     if (!image_decoder_client) {
-        image_decoder_client = ImageDecoderClient::Client::construct();
+        image_decoder_client = ImageDecoderClient::Client::try_create().release_value_but_fixme_should_propagate_errors();
         image_decoder_client->on_death = [&] {
             image_decoder_client = nullptr;
         };

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -21,14 +21,21 @@ namespace Web {
 
 ResourceLoader& ResourceLoader::the()
 {
-    static ResourceLoader* s_the;
+    static RefPtr<ResourceLoader> s_the;
     if (!s_the)
-        s_the = &ResourceLoader::construct().leak_ref();
+        s_the = ResourceLoader::try_create().release_value_but_fixme_should_propagate_errors();
     return *s_the;
 }
 
-ResourceLoader::ResourceLoader()
-    : m_protocol_client(Protocol::RequestClient::construct())
+ErrorOr<NonnullRefPtr<ResourceLoader>> ResourceLoader::try_create()
+{
+
+    auto protocol_client = TRY(Protocol::RequestClient::try_create());
+    return adopt_nonnull_ref_or_enomem(new (nothrow) ResourceLoader(move(protocol_client)));
+}
+
+ResourceLoader::ResourceLoader(NonnullRefPtr<Protocol::RequestClient> protocol_client)
+    : m_protocol_client(move(protocol_client))
     , m_user_agent(default_user_agent)
 {
 }

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -27,7 +27,7 @@ namespace Web {
 constexpr auto default_user_agent = "Mozilla/4.0 (SerenityOS; " CPU_STRING ") LibWeb+LibJS (Not KHTML, nor Gecko) LibWeb";
 
 class ResourceLoader : public Core::Object {
-    C_OBJECT(ResourceLoader)
+    C_OBJECT_ABSTRACT(ResourceLoader)
 public:
     static ResourceLoader& the();
 
@@ -52,7 +52,9 @@ public:
     void clear_cache();
 
 private:
-    ResourceLoader();
+    ResourceLoader(NonnullRefPtr<Protocol::RequestClient> protocol_client);
+    static ErrorOr<NonnullRefPtr<ResourceLoader>> try_create();
+
     static bool is_port_blocked(int port);
 
     int m_pending_loads { 0 };

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -62,7 +62,7 @@ void OutOfProcessWebView::create_client()
 {
     m_client_state = {};
 
-    m_client_state.client = WebContentClient::construct(*this);
+    m_client_state.client = WebContentClient::try_create(*this).release_value_but_fixme_should_propagate_errors();
     m_client_state.client->on_web_content_process_crash = [this] {
         deferred_invoke([this] {
             handle_web_content_process_crash();

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -11,8 +11,8 @@
 
 namespace Web {
 
-WebContentClient::WebContentClient(OutOfProcessWebView& view)
-    : IPC::ServerConnection<WebContentClientEndpoint, WebContentServerEndpoint>(*this, "/tmp/portal/webcontent")
+WebContentClient::WebContentClient(NonnullOwnPtr<Core::Stream::LocalSocket> socket, OutOfProcessWebView& view)
+    : IPC::ServerConnection<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(socket))
     , m_view(view)
 {
 }

--- a/Userland/Libraries/LibWeb/WebContentClient.h
+++ b/Userland/Libraries/LibWeb/WebContentClient.h
@@ -19,13 +19,13 @@ class OutOfProcessWebView;
 class WebContentClient final
     : public IPC::ServerConnection<WebContentClientEndpoint, WebContentServerEndpoint>
     , public WebContentClientEndpoint {
-    C_OBJECT(WebContentClient);
+    IPC_CLIENT_CONNECTION(WebContentClient, "/tmp/portal/webcontent");
 
 public:
     Function<void()> on_web_content_process_crash;
 
 private:
-    WebContentClient(OutOfProcessWebView&);
+    WebContentClient(NonnullOwnPtr<Core::Stream::LocalSocket>, OutOfProcessWebView&);
 
     virtual void die() override;
 

--- a/Userland/Services/AudioServer/ClientConnection.cpp
+++ b/Userland/Services/AudioServer/ClientConnection.cpp
@@ -22,7 +22,7 @@ void ClientConnection::for_each(Function<void(ClientConnection&)> callback)
         callback(connection);
 }
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id, Mixer& mixer)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> client_socket, int client_id, Mixer& mixer)
     : IPC::ClientConnection<AudioClientEndpoint, AudioServerEndpoint>(*this, move(client_socket), client_id)
     , m_mixer(mixer)
 {

--- a/Userland/Services/AudioServer/ClientConnection.h
+++ b/Userland/Services/AudioServer/ClientConnection.h
@@ -35,7 +35,7 @@ public:
     static void for_each(Function<void(ClientConnection&)>);
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id, Mixer& mixer);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id, Mixer& mixer);
 
     virtual Messages::AudioServer::GetMainMixVolumeResponse get_main_mix_volume() override;
     virtual void set_main_mix_volume(double) override;

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto server = TRY(Core::LocalServer::try_create());
     TRY(server->take_over_from_system_server());
 
-    server->on_accept = [&](NonnullRefPtr<Core::LocalSocket> client_socket) {
+    server->on_accept = [&](NonnullOwnPtr<Core::Stream::LocalSocket> client_socket) {
         static int s_next_client_id = 0;
         int client_id = ++s_next_client_id;
         (void)IPC::new_client_connection<AudioServer::ClientConnection>(move(client_socket), client_id, *mixer);

--- a/Userland/Services/Clipboard/ClientConnection.cpp
+++ b/Userland/Services/Clipboard/ClientConnection.cpp
@@ -19,7 +19,7 @@ void ClientConnection::for_each_client(Function<void(ClientConnection&)> callbac
     }
 }
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket, int client_id)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, int client_id)
     : IPC::ClientConnection<ClipboardClientEndpoint, ClipboardServerEndpoint>(*this, move(socket), client_id)
 {
     s_connections.set(client_id, *this);

--- a/Userland/Services/Clipboard/ClientConnection.h
+++ b/Userland/Services/Clipboard/ClientConnection.h
@@ -27,7 +27,7 @@ public:
     void notify_about_clipboard_change();
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     virtual Messages::ClipboardServer::GetClipboardDataResponse get_clipboard_data() override;
     virtual void set_clipboard_data(Core::AnonymousBuffer const&, String const&, IPC::Dictionary const&) override;

--- a/Userland/Services/ConfigServer/ClientConnection.cpp
+++ b/Userland/Services/ConfigServer/ClientConnection.cpp
@@ -74,7 +74,7 @@ static Core::ConfigFile& ensure_domain_config(String const& domain)
     return *config;
 }
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> client_socket, int client_id)
     : IPC::ClientConnection<ConfigClientEndpoint, ConfigServerEndpoint>(*this, move(client_socket), client_id)
     , m_sync_timer(Core::Timer::create_single_shot(s_disk_sync_delay_ms, [this]() { sync_dirty_domains_to_disk(); }))
 {

--- a/Userland/Services/ConfigServer/ClientConnection.h
+++ b/Userland/Services/ConfigServer/ClientConnection.h
@@ -23,7 +23,7 @@ public:
     bool is_monitoring_domain(String const& domain) const { return m_monitored_domains.contains(domain); }
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     virtual void pledge_domains(Vector<String> const&) override;
     virtual void monitor_domain(String const&) override;

--- a/Userland/Services/FileSystemAccessServer/ClientConnection.cpp
+++ b/Userland/Services/FileSystemAccessServer/ClientConnection.cpp
@@ -20,7 +20,7 @@ namespace FileSystemAccessServer {
 
 static HashMap<int, NonnullRefPtr<ClientConnection>> s_connections;
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
     : IPC::ClientConnection<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>(*this, move(socket), 1)
 {
     s_connections.set(1, *this);
@@ -72,7 +72,7 @@ void ClientConnection::request_file_handler(i32 window_server_client_id, i32 par
         else if (has_flag(requested_access, Core::OpenMode::WriteOnly))
             access_string = "write to";
 
-        auto pid = this->socket().peer_pid();
+        auto pid = this->socket().peer_pid().release_value_but_fixme_should_propagate_errors();
         auto exe_link = LexicalPath("/proc").append(String::number(pid)).append("exe").string();
         auto exe_path = Core::File::real_path_for(exe_link);
 

--- a/Userland/Services/FileSystemAccessServer/ClientConnection.h
+++ b/Userland/Services/FileSystemAccessServer/ClientConnection.h
@@ -25,7 +25,7 @@ public:
     virtual void die() override;
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual void request_file_read_only_approved(i32, i32, String const&) override;
     virtual void request_file(i32, i32, String const&, Core::OpenMode const&) override;

--- a/Userland/Services/ImageDecoder/ClientConnection.cpp
+++ b/Userland/Services/ImageDecoder/ClientConnection.cpp
@@ -12,7 +12,7 @@
 
 namespace ImageDecoder {
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
     : IPC::ClientConnection<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint>(*this, move(socket), 1)
 {
 }

--- a/Userland/Services/ImageDecoder/ClientConnection.h
+++ b/Userland/Services/ImageDecoder/ClientConnection.h
@@ -25,7 +25,7 @@ public:
     virtual void die() override;
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual Messages::ImageDecoderServer::DecodeImageResponse decode_image(Core::AnonymousBuffer const&) override;
 };

--- a/Userland/Services/InspectorServer/ClientConnection.cpp
+++ b/Userland/Services/InspectorServer/ClientConnection.cpp
@@ -12,7 +12,7 @@ namespace InspectorServer {
 
 static HashMap<int, RefPtr<ClientConnection>> s_connections;
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket, int client_id)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, int client_id)
     : IPC::ClientConnection<InspectorClientEndpoint, InspectorServerEndpoint>(*this, move(socket), client_id)
 {
     s_connections.set(client_id, *this);

--- a/Userland/Services/InspectorServer/ClientConnection.h
+++ b/Userland/Services/InspectorServer/ClientConnection.h
@@ -23,7 +23,7 @@ public:
     virtual void die() override;
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     virtual Messages::InspectorServer::GetAllObjectsResponse get_all_objects(pid_t) override;
     virtual Messages::InspectorServer::SetInspectedObjectResponse set_inspected_object(pid_t, u64 object_id) override;

--- a/Userland/Services/InspectorServer/InspectableProcess.h
+++ b/Userland/Services/InspectorServer/InspectableProcess.h
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include <LibCore/LocalSocket.h>
+#include <LibCore/Stream.h>
 
 namespace InspectorServer {
 
 class InspectableProcess {
 public:
-    InspectableProcess(pid_t, NonnullRefPtr<Core::LocalSocket>);
+    InspectableProcess(pid_t, NonnullOwnPtr<Core::Stream::LocalSocket>);
     ~InspectableProcess();
 
     void send_request(JsonObject const& request);
@@ -22,7 +22,7 @@ public:
 
 private:
     pid_t m_pid { 0 };
-    NonnullRefPtr<Core::LocalSocket> m_socket;
+    NonnullOwnPtr<Core::Stream::LocalSocket> m_socket;
 };
 
 extern HashMap<pid_t, NonnullOwnPtr<InspectorServer::InspectableProcess>> g_processes;

--- a/Userland/Services/InspectorServer/main.cpp
+++ b/Userland/Services/InspectorServer/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(inspectables_server->take_over_from_system_server("/tmp/portal/inspectables"));
 
     inspectables_server->on_accept = [&](auto client_socket) {
-        auto pid = client_socket->peer_pid();
+        auto pid = client_socket->peer_pid().release_value_but_fixme_should_propagate_errors();
         InspectorServer::g_processes.set(pid, make<InspectorServer::InspectableProcess>(pid, move(client_socket)));
     };
 

--- a/Userland/Services/LaunchServer/ClientConnection.cpp
+++ b/Userland/Services/LaunchServer/ClientConnection.cpp
@@ -13,7 +13,7 @@
 namespace LaunchServer {
 
 static HashMap<int, RefPtr<ClientConnection>> s_connections;
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> client_socket, int client_id)
     : IPC::ClientConnection<LaunchClientEndpoint, LaunchServerEndpoint>(*this, move(client_socket), client_id)
 {
     s_connections.set(client_id, *this);

--- a/Userland/Services/LaunchServer/ClientConnection.h
+++ b/Userland/Services/LaunchServer/ClientConnection.h
@@ -20,7 +20,7 @@ public:
     virtual void die() override;
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     virtual Messages::LaunchServer::OpenUrlResponse open_url(URL const&, String const&) override;
     virtual Messages::LaunchServer::GetHandlersForUrlResponse get_handlers_for_url(URL const&) override;

--- a/Userland/Services/LookupServer/ClientConnection.cpp
+++ b/Userland/Services/LookupServer/ClientConnection.cpp
@@ -13,7 +13,7 @@ namespace LookupServer {
 
 static HashMap<int, RefPtr<ClientConnection>> s_connections;
 
-ClientConnection::ClientConnection(AK::NonnullRefPtr<Core::LocalSocket> socket, int client_id)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, int client_id)
     : IPC::ClientConnection<LookupClientEndpoint, LookupServerEndpoint>(*this, move(socket), client_id)
 {
     s_connections.set(client_id, *this);

--- a/Userland/Services/LookupServer/ClientConnection.h
+++ b/Userland/Services/LookupServer/ClientConnection.h
@@ -23,7 +23,7 @@ public:
     virtual void die() override;
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     virtual Messages::LookupServer::LookupNameResponse lookup_name(String const&) override;
     virtual Messages::LookupServer::LookupAddressResponse lookup_address(String const&) override;

--- a/Userland/Services/NotificationServer/ClientConnection.cpp
+++ b/Userland/Services/NotificationServer/ClientConnection.cpp
@@ -13,7 +13,7 @@ namespace NotificationServer {
 
 static HashMap<int, RefPtr<ClientConnection>> s_connections;
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> client_socket, int client_id)
     : IPC::ClientConnection<NotificationClientEndpoint, NotificationServerEndpoint>(*this, move(client_socket), client_id)
 {
     s_connections.set(client_id, *this);

--- a/Userland/Services/NotificationServer/ClientConnection.h
+++ b/Userland/Services/NotificationServer/ClientConnection.h
@@ -23,7 +23,7 @@ public:
     virtual void die() override;
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     virtual void show_notification(String const&, String const&, Gfx::ShareableBitmap const&) override;
     virtual void close_notification() override;

--- a/Userland/Services/RequestServer/ClientConnection.cpp
+++ b/Userland/Services/RequestServer/ClientConnection.cpp
@@ -15,7 +15,7 @@ namespace RequestServer {
 
 static HashMap<int, RefPtr<ClientConnection>> s_connections;
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
     : IPC::ClientConnection<RequestClientEndpoint, RequestServerEndpoint>(*this, move(socket), 1)
 {
     s_connections.set(1, *this);

--- a/Userland/Services/RequestServer/ClientConnection.h
+++ b/Userland/Services/RequestServer/ClientConnection.h
@@ -29,7 +29,7 @@ public:
     void did_request_certificates(Badge<Request>, Request&);
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(String const&) override;
     virtual Messages::RequestServer::StartRequestResponse start_request(String const&, URL const&, IPC::Dictionary const&, ByteBuffer const&) override;

--- a/Userland/Services/SQLServer/ClientConnection.cpp
+++ b/Userland/Services/SQLServer/ClientConnection.cpp
@@ -23,7 +23,7 @@ RefPtr<ClientConnection> ClientConnection::client_connection_for(int client_id)
     return nullptr;
 }
 
-ClientConnection::ClientConnection(AK::NonnullRefPtr<Core::LocalSocket> socket, int client_id)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket, int client_id)
     : IPC::ClientConnection<SQLClientEndpoint, SQLServerEndpoint>(*this, move(socket), client_id)
 {
     s_connections.set(client_id, *this);

--- a/Userland/Services/SQLServer/ClientConnection.h
+++ b/Userland/Services/SQLServer/ClientConnection.h
@@ -25,7 +25,7 @@ public:
     static RefPtr<ClientConnection> client_connection_for(int client_id);
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     virtual Messages::SQLServer::ConnectResponse connect(String const&) override;
     virtual Messages::SQLServer::SqlStatementResponse sql_statement(int, String const&) override;

--- a/Userland/Services/SpiceAgent/ClipboardServerConnection.h
+++ b/Userland/Services/SpiceAgent/ClipboardServerConnection.h
@@ -15,7 +15,7 @@
 class ClipboardServerConnection final
     : public IPC::ServerConnection<ClipboardClientEndpoint, ClipboardServerEndpoint>
     , public ClipboardClientEndpoint {
-    C_OBJECT(ClipboardServerConnection);
+    IPC_CLIENT_CONNECTION(ClipboardServerConnection, "/tmp/portal/clipboard")
 
 public:
     Function<void()> on_data_changed;
@@ -23,8 +23,8 @@ public:
     void set_bitmap(Gfx::Bitmap const& bitmap);
 
 private:
-    ClipboardServerConnection()
-        : IPC::ServerConnection<ClipboardClientEndpoint, ClipboardServerEndpoint>(*this, "/tmp/portal/clipboard")
+    ClipboardServerConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
+        : IPC::ServerConnection<ClipboardClientEndpoint, ClipboardServerEndpoint>(*this, move(socket))
     {
     }
     virtual void clipboard_data_changed(String const&) override

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -29,7 +29,7 @@
 
 namespace WebContent {
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
     : IPC::ClientConnection<WebContentClientEndpoint, WebContentServerEndpoint>(*this, move(socket), 1)
     , m_page_host(PageHost::create(*this))
 {

--- a/Userland/Services/WebContent/ClientConnection.h
+++ b/Userland/Services/WebContent/ClientConnection.h
@@ -32,7 +32,7 @@ public:
     void initialize_js_console(Badge<PageHost>);
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     Web::Page& page();
     const Web::Page& page() const;

--- a/Userland/Services/WebSocket/ClientConnection.cpp
+++ b/Userland/Services/WebSocket/ClientConnection.cpp
@@ -13,7 +13,7 @@ namespace WebSocket {
 
 static HashMap<int, RefPtr<ClientConnection>> s_connections;
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> socket)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)
     : IPC::ClientConnection<WebSocketClientEndpoint, WebSocketServerEndpoint>(*this, move(socket), 1)
 {
     s_connections.set(1, *this);

--- a/Userland/Services/WebSocket/ClientConnection.h
+++ b/Userland/Services/WebSocket/ClientConnection.h
@@ -24,7 +24,7 @@ public:
     virtual void die() override;
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual Messages::WebSocketServer::ConnectResponse connect(URL const&, String const&, Vector<String> const&, Vector<String> const&, IPC::Dictionary const&) override;
     virtual Messages::WebSocketServer::ReadyStateResponse ready_state(i32) override;

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -45,7 +45,7 @@ ClientConnection* ClientConnection::from_client_id(int client_id)
     return (*it).value.ptr();
 }
 
-ClientConnection::ClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id)
+ClientConnection::ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> client_socket, int client_id)
     : IPC::ClientConnection<WindowClientEndpoint, WindowServerEndpoint>(*this, move(client_socket), client_id)
 {
     if (!s_connections)

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -81,7 +81,7 @@ public:
     void notify_display_link(Badge<Compositor>);
 
 private:
-    explicit ClientConnection(NonnullRefPtr<Core::LocalSocket>, int client_id);
+    explicit ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket>, int client_id);
 
     // ^ClientConnection
     virtual void die() override;

--- a/Userland/Services/WindowServer/WMClientConnection.cpp
+++ b/Userland/Services/WindowServer/WMClientConnection.cpp
@@ -13,7 +13,7 @@ namespace WindowServer {
 
 HashMap<int, NonnullRefPtr<WMClientConnection>> WMClientConnection::s_connections {};
 
-WMClientConnection::WMClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id)
+WMClientConnection::WMClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> client_socket, int client_id)
     : IPC::ClientConnection<WindowManagerClientEndpoint, WindowManagerServerEndpoint>(*this, move(client_socket), client_id)
 {
     s_connections.set(client_id, *this);

--- a/Userland/Services/WindowServer/WMClientConnection.h
+++ b/Userland/Services/WindowServer/WMClientConnection.h
@@ -36,7 +36,7 @@ public:
     int window_id() const { return m_window_id; }
 
 private:
-    explicit WMClientConnection(NonnullRefPtr<Core::LocalSocket> client_socket, int client_id);
+    explicit WMClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> client_socket, int client_id);
 
     // ^ClientConnection
     virtual void die() override;

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Core::EventLoop loop;
 
-    auto audio_client = Audio::ClientConnection::construct();
+    auto audio_client = TRY(Audio::ClientConnection::try_create());
     auto maybe_loader = Audio::Loader::create(path);
     if (maybe_loader.is_error()) {
         warnln("Failed to load audio file: {}", maybe_loader.error().description);

--- a/Userland/Utilities/asctl.cpp
+++ b/Userland/Utilities/asctl.cpp
@@ -29,7 +29,7 @@ enum AudioVariable : u32 {
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     Core::EventLoop loop;
-    auto audio_client = Audio::ClientConnection::construct();
+    auto audio_client = TRY(Audio::ClientConnection::try_create());
 
     String command = String::empty();
     Vector<StringView> command_arguments;

--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -188,7 +188,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     Core::EventLoop loop;
-    auto protocol_client = Protocol::RequestClient::construct();
+    auto protocol_client = TRY(Protocol::RequestClient::try_create());
 
     auto request = protocol_client->start_request(method, url, request_headers, data ? StringView { data }.bytes() : ReadonlyBytes {});
     if (!request) {

--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -71,7 +71,7 @@ public:
             m_editor->set_prompt(prompt_for_level(open_indents));
         };
 
-        m_sql_client = SQL::SQLClient::construct();
+        m_sql_client = SQL::SQLClient::try_create().release_value_but_fixme_should_propagate_errors();
 
         m_sql_client->on_connected = [this](int connection_id, String const& connected_to_database) {
             outln("Connected to \033[33;1m{}\033[0m", connected_to_database);

--- a/Userland/Utilities/telws.cpp
+++ b/Userland/Utilities/telws.cpp
@@ -40,9 +40,15 @@ int main(int argc, char** argv)
     }
 
     Core::EventLoop loop;
+
+    auto maybe_websocket_client = Protocol::WebSocketClient::try_create();
+    if (maybe_websocket_client.is_error()) {
+        warnln("Failed to connect to the websocket server: {}\n", maybe_websocket_client.error());
+    }
+    auto websocket_client = maybe_websocket_client.release_value();
+
     RefPtr<Line::Editor> editor = Line::Editor::construct();
     bool should_quit = false;
-    auto websocket_client = Protocol::WebSocketClient::construct();
     auto socket = websocket_client->connect(url, origin);
     if (!socket) {
         warnln("Failed to start socket for '{}'\n", url);


### PR DESCRIPTION
This is quite the chonky PR, here be dragons.

**LibCore: Implement LocalSocket::peer_pid**

Mostly a copy of Core::LocalSocket::peer_pid.

**LibCore: Implement LocalSocket::adopt_fd**

Similar to File::adopt_fd, this function creates a new LocalSocket with
an existing fd. The main use of this function is to create LocalSocket
objects from fds that have been passed to us by SystemServer to take
over.

**LibCore: Implement LocalSocket::read_without_waiting**

This uses recv with MSG_DONTWAIT to disable blocking operation for a
single call. LibIPC uses this to read in a non-blocking manner from an
otherwise blocking socket.

**LibCore: Implement LocalSocket::receive_fd and send_fd**

These are just wrappers over the sendfd and recvfd syscalls.

**LibCore+LibIPC+Everywhere: Return Stream::LocalSocket from LocalServer**

This change unfortunately cannot be atomically made without a single
commit changing everything.

Most of the important changes are in LibIPC/Connection.cpp,
LibIPC/ServerConnection.cpp and LibCore/LocalServer.cpp.

The notable changes are:
- IPCCompiler now generates the decode and decode_message functions such
  that they take a Core::Stream::LocalSocket instead of the socket fd.
- IPC::Decoder now uses the receive_fd method of LocalSocket instead of
  doing system calls directly on the fd.
- IPC::ConnectionBase and related classes now use the Stream API
  functions.
- IPC::ServerConnection no longer constructs the socket itself; instead,
  a convenience macro, IPC_CLIENT_CONNECTION, is used in place of
  C_OBJECT and will generate a static try_create factory function for
  the ServerConnection subclass. The subclass is now responsible for
  passing the socket constructed in this function to its
  ServerConnection base; the socket is passed as the first argument to
  the constructor (as a NonnullOwnPtr<Core::Stream::LocalServer>) before
  any other arguments.
- The functionality regarding taking over sockets from SystemServer has
  been moved to LibIPC/SystemServerTakeover.cpp. The Core::LocalSocket
  implementation of this functionality hasn't been deleted due to my
  intention of removing this class in the near future and to reduce
  noise on this (already quite noisy) PR.
