### PR TITLE
PixelPaint: Add delete selection behavior

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -405,6 +405,11 @@ void ImageEditor::resize_event(GUI::ResizeEvent& event)
 
 void ImageEditor::keydown_event(GUI::KeyEvent& event)
 {
+    if (event.key() == Key_Delete && !selection().is_empty() && active_layer()) {
+        active_layer()->erase_selection(selection());
+        return;
+    }
+
     if (m_active_tool)
         m_active_tool->on_keydown(event);
 }

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -10,6 +10,7 @@
 #include <AK/RefPtr.h>
 #include <AK/Try.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Painter.h>
 
 namespace PixelPaint {
 
@@ -127,6 +128,15 @@ RefPtr<Gfx::Bitmap> Layer::try_copy_bitmap(Selection const& selection) const
     }
 
     return result;
+}
+
+void Layer::erase_selection(Selection const& selection)
+{
+    Gfx::Painter painter { bitmap() };
+    auto const image_and_selection_intersection = m_image.rect().intersected(selection.bounding_rect());
+    auto const translated_to_layer_space = image_and_selection_intersection.translated(-location());
+    painter.clear_rect(translated_to_layer_space, Color::Transparent);
+    did_modify_bitmap(translated_to_layer_space);
 }
 
 }

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -61,6 +61,8 @@ public:
 
     Image const& image() const { return m_image; }
 
+    void erase_selection(Selection const&);
+
 private:
     Layer(Image&, NonnullRefPtr<Gfx::Bitmap>, String name);
 


### PR DESCRIPTION
The delete key can now be used to erase the pixels on the active layer
contained within the selection rectangle.

Closes #11861