### PR TITLE
Kernel: Always remove PageDirectories from the cr3 map on destruction

### DIFF
--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -151,8 +151,7 @@ UNMAP_AFTER_INIT void PageDirectory::allocate_kernel_directory()
 PageDirectory::~PageDirectory()
 {
     SpinlockLocker lock(s_mm_lock);
-    if (m_space)
-        cr3_map().remove(cr3());
+    cr3_map().remove(cr3());
 }
 
 }


### PR DESCRIPTION
Previously we would only remove them from the map if they were attached to an AddressSpace, even though we would always add them to the map on construction.
This results in an assertion failure on destruction if the page directory was never attached to an AddressSpace. (for example,
on an allocation failure of said AddressSpace)