### PR TITLE
AK: Fix logic in String::operator>(const String&)

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -58,10 +58,10 @@ bool String::operator<(const String& other) const
 
 bool String::operator>(const String& other) const
 {
-    if (!m_impl)
-        return other.m_impl;
-
     if (!other.m_impl)
+        return m_impl;
+
+    if (!m_impl)
         return false;
 
     return strcmp(characters(), other.characters()) > 0;

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -42,7 +42,6 @@ TEST_CASE(construct_contents)
 
 TEST_CASE(compare)
 {
-    String test_string = "ABCDEF";
     EXPECT("a" < String("b"));
     EXPECT(!("a" > String("b")));
     EXPECT("b" > String("a"));
@@ -51,6 +50,20 @@ TEST_CASE(compare)
     EXPECT(!("a" >= String("b")));
     EXPECT("a" <= String("a"));
     EXPECT(!("b" <= String("a")));
+
+    EXPECT(String("a") > String());
+    EXPECT(!(String() > String("a")));
+    EXPECT(String() < String("a"));
+    EXPECT(!(String("a") < String()));
+    EXPECT(String("a") >= String());
+    EXPECT(!(String() >= String("a")));
+    EXPECT(String() <= String("a"));
+    EXPECT(!(String("a") <= String()));
+
+    EXPECT(!(String() > String()));
+    EXPECT(!(String() < String()));
+    EXPECT(String() >= String());
+    EXPECT(String() <= String());
 }
 
 TEST_CASE(index_access)


### PR DESCRIPTION
Null strings should not compare greater than non-null strings.

Add tests for >, <, >=, and <= comparison involving null strings.