### PR TITLE
Terminal: Add the ability to control scrollbar visibility

### DIFF
--- a/Base/home/anon/.config/Terminal.ini
+++ b/Base/home/anon/.config/Terminal.ini
@@ -1,6 +1,7 @@
 [Startup]
 Command=
 [Terminal]
+ShowScrollBar=true
 MaxHistorySize=1024
 [Window]
 Opacity=255

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -51,6 +51,15 @@ public:
     {
     }
 
+    virtual void config_bool_did_change(String const& domain, String const& group, String const& key, bool value) override
+    {
+        VERIFY(domain == "Terminal");
+
+        if (group == "Terminal" && key == "ShowScrollBar") {
+            m_parent_terminal.set_show_scrollbar(value);
+        }
+    }
+
     virtual void config_string_did_change(String const& domain, String const& group, String const& key, String const& value) override
     {
         VERIFY(domain == "Terminal");
@@ -310,6 +319,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto new_scrollback_size = Config::read_i32("Terminal", "Terminal", "MaxHistorySize", terminal->max_history_size());
     terminal->set_max_history_size(new_scrollback_size);
+
+    auto show_scroll_bar = Config::read_bool("Terminal", "Terminal", "ShowScrollBar", true);
+    terminal->set_show_scrollbar(show_scroll_bar);
 
     auto open_settings_action = GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png").release_value_but_fixme_should_propagate_errors(),
         [&](auto&) {

--- a/Userland/Applications/TerminalSettings/TerminalSettingsMain.gml
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsMain.gml
@@ -53,6 +53,11 @@
             margins: [16, 8, 8]
         }
 
+       @GUI::CheckBox {
+            name: "terminal_show_scrollbar"
+            text: "Show scrollbar"
+        }
+
         @GUI::SpinBox {
             name: "history_size_spinbox"
             min: 0

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
@@ -74,6 +74,15 @@ TerminalSettingsMainWidget::TerminalSettingsMainWidget()
         m_max_history_size = value;
         Config::write_i32("Terminal", "Terminal", "MaxHistorySize", static_cast<i32>(m_max_history_size));
     };
+
+    m_show_scrollbar = Config::read_bool("Terminal", "Terminal", "ShowScrollBar", true);
+    m_orignal_show_scrollbar = m_show_scrollbar;
+    auto& show_scrollbar_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("terminal_show_scrollbar");
+    show_scrollbar_checkbox.on_checked = [&](bool show_scrollbar) {
+        m_show_scrollbar = show_scrollbar;
+        Config::write_bool("Terminal", "Terminal", "ShowScrollBar", show_scrollbar);
+    };
+    show_scrollbar_checkbox.set_checked(m_show_scrollbar);
 }
 
 TerminalSettingsViewWidget::TerminalSettingsViewWidget()
@@ -175,12 +184,14 @@ String TerminalSettingsMainWidget::stringify_bell(VT::TerminalWidget::BellMode b
 void TerminalSettingsMainWidget::apply_settings()
 {
     m_original_max_history_size = m_max_history_size;
+    m_orignal_show_scrollbar = m_show_scrollbar;
     m_original_bell_mode = m_bell_mode;
     write_back_settings();
 }
 void TerminalSettingsMainWidget::write_back_settings() const
 {
     Config::write_i32("Terminal", "Terminal", "MaxHistorySize", static_cast<i32>(m_original_max_history_size));
+    Config::write_bool("Terminal", "Terminal", "ShowScrollBar", m_orignal_show_scrollbar);
     Config::write_string("Terminal", "Window", "Bell", stringify_bell(m_original_bell_mode));
 }
 

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
@@ -28,9 +28,11 @@ private:
 
     VT::TerminalWidget::BellMode m_bell_mode = VT::TerminalWidget::BellMode::Disabled;
     size_t m_max_history_size;
+    bool m_show_scrollbar { true };
 
     VT::TerminalWidget::BellMode m_original_bell_mode;
     size_t m_original_max_history_size;
+    bool m_orignal_show_scrollbar { true };
 };
 
 class TerminalSettingsViewWidget final : public GUI::SettingsWindow::Tab {

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -548,6 +548,11 @@ void TerminalWidget::set_opacity(u8 new_opacity)
     update();
 }
 
+void TerminalWidget::set_show_scrollbar(bool show_scrollbar)
+{
+    m_scrollbar->set_visible(show_scrollbar);
+}
+
 bool TerminalWidget::has_selection() const
 {
     return m_selection.is_valid();

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -43,6 +43,8 @@ public:
     void set_opacity(u8);
     float opacity() { return m_opacity; };
 
+    void set_show_scrollbar(bool);
+
     enum class BellMode {
         Visible,
         AudibleBeep,


### PR DESCRIPTION
I always keep the terminal scrollbar hidden on my host systems, so lets make that possible in serenity as well. 

![image](https://user-images.githubusercontent.com/1212/149612424-05f9f482-7785-4e36-beba-d613adc6fb1d.png)
