### PR TITLE
LibGL+LibSoftGPU: Implement Specular Highlighting and some minor fixes

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -187,16 +187,26 @@ void GLContextWidget::timer_event(Core::TimerEvent&)
     // Disco time ;)
     GLfloat const light0_position[4] = { -4.0f, 0.0f, 0.0f, 0.0f };
     GLfloat const light0_diffuse[4] = { 1.0f, 0.0f, 0.0f, 0.0f };
+    GLfloat const light0_specular[4] = { 0.75f, 0.75f, 0.75f };
     GLfloat const light1_position[4] = { 4.0f, 0.0f, 0.0f, 0.0f };
     GLfloat const light1_diffuse[4] = { 0.0f, 1.0f, 0.0f, 0.0f };
+    GLfloat const light1_specular[4] = { 0.75f, 0.75f, 0.75f };
     GLfloat const light2_position[4] = { 0.0f, 5.0f, 0.0f, 0.0f };
     GLfloat const light2_diffuse[4] = { 0.0f, 0.0f, 1.0f, 0.0f };
+    GLfloat const light2_specular[4] = { 0.75f, 0.75f, 0.75f };
     glLightfv(GL_LIGHT0, GL_POSITION, &light0_position[0]);
     glLightfv(GL_LIGHT0, GL_DIFFUSE, &light0_diffuse[0]);
+    glLightfv(GL_LIGHT0, GL_SPECULAR, &light0_specular[0]);
     glLightfv(GL_LIGHT1, GL_POSITION, &light1_position[0]);
     glLightfv(GL_LIGHT1, GL_DIFFUSE, &light1_diffuse[0]);
+    glLightfv(GL_LIGHT1, GL_SPECULAR, &light1_specular[0]);
     glLightfv(GL_LIGHT2, GL_POSITION, &light2_position[0]);
     glLightfv(GL_LIGHT2, GL_DIFFUSE, &light2_diffuse[0]);
+    glLightfv(GL_LIGHT2, GL_SPECULAR, &light2_specular[0]);
+
+    GLfloat const material_specular_color[4] = { 1.0f, 1.0f, 1.0f, 1.0f };
+    glMaterialf(GL_FRONT, GL_SHININESS, 45.0f);
+    glMaterialfv(GL_FRONT, GL_SPECULAR, &material_specular_color[0]);
     glPopMatrix();
 
     if (m_texture_enabled) {

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -245,6 +245,7 @@ extern "C" {
 
 // Lighting related defines
 #define GL_LIGHTING 0x0B50
+#define GL_LIGHT_MODEL_LOCAL_VIEWER 0x0B51
 #define GL_LIGHT_MODEL_TWO_SIDE 0x0B52
 #define GL_LIGHT_MODEL_AMBIENT 0x0B53
 

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -2738,6 +2738,12 @@ void SoftwareGLContext::gl_light_model(GLenum pname, GLfloat x, GLfloat y, GLflo
         lighting_params.two_sided_lighting = x;
         update_lighting_model = true;
         break;
+    case GL_LIGHT_MODEL_LOCAL_VIEWER:
+        // 0 means the viewer is at infinity
+        // 1 means they're in local (eye) space
+        lighting_params.viewer_at_infinity = (x != 1.0f);
+        update_lighting_model = true;
+        break;
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -3072,7 +3072,6 @@ void SoftwareGLContext::sync_light_state()
         material.specular = current_material_state.specular;
         material.emissive = current_material_state.emissive;
         material.shininess = current_material_state.shininess;
-        material.specular_exponent = current_material_state.specular_exponent;
         material.ambient_color_index = current_material_state.ambient_color_index;
         material.diffuse_color_index = current_material_state.diffuse_color_index;
         material.specular_color_index = current_material_state.specular_color_index;

--- a/Userland/Libraries/LibGfx/Vector2.h
+++ b/Userland/Libraries/LibGfx/Vector2.h
@@ -50,6 +50,11 @@ public:
         return Vector2(m_x - other.m_x, m_y - other.m_y);
     }
 
+    constexpr Vector2 operator-() const
+    {
+        return Vector2(-m_x, -m_y);
+    }
+
     constexpr Vector2 operator*(const Vector2& other) const
     {
         return Vector2(m_x * other.m_x, m_y * other.m_y);

--- a/Userland/Libraries/LibGfx/Vector3.h
+++ b/Userland/Libraries/LibGfx/Vector3.h
@@ -55,6 +55,11 @@ public:
         return Vector3(m_x - other.m_x, m_y - other.m_y, m_z - other.m_z);
     }
 
+    constexpr Vector3 operator-() const
+    {
+        return Vector3(-m_x, -m_y, -m_z);
+    }
+
     constexpr Vector3 operator*(const Vector3& other) const
     {
         return Vector3(m_x * other.m_x, m_y * other.m_y, m_z * other.m_z);

--- a/Userland/Libraries/LibGfx/Vector4.h
+++ b/Userland/Libraries/LibGfx/Vector4.h
@@ -11,6 +11,9 @@
 
 namespace Gfx {
 template<typename T>
+class Vector3;
+
+template<typename T>
 class Vector4 final {
 public:
     constexpr Vector4() = default;
@@ -129,6 +132,11 @@ public:
     constexpr T length() const
     {
         return AK::sqrt(m_x * m_x + m_y * m_y + m_z * m_z + m_w * m_w);
+    }
+
+    constexpr Vector3<T> xyz() const
+    {
+        return Vector3<T>(m_x, m_y, m_z);
     }
 
     String to_string() const

--- a/Userland/Libraries/LibGfx/Vector4.h
+++ b/Userland/Libraries/LibGfx/Vector4.h
@@ -60,6 +60,11 @@ public:
         return Vector4(m_x - other.m_x, m_y - other.m_y, m_z - other.m_z, m_w - other.m_w);
     }
 
+    constexpr Vector4 operator-() const
+    {
+        return Vector4(-m_x, -m_y, -m_z, -m_w);
+    }
+
     constexpr Vector4 operator*(const Vector4& other) const
     {
         return Vector4(m_x * other.m_x, m_y * other.m_y, m_z * other.m_z, m_w * other.m_w);

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -681,19 +681,37 @@ void Device::draw_primitives(PrimitiveType primitive_type, FloatMatrix4x4 const&
                     if (!light.is_enabled)
                         continue;
 
-                    FloatVector4 vertex_to_light;
+                    // We need to save the length here because the attenuation factor requires a non
+                    // normalized vector!
+                    auto sgi_arrow_operator = [](FloatVector4 const& p1, FloatVector4 const& p2, float& saved_length) {
+                        if ((p1.w() != 0.0f) && (p2.w() == 0.0f)) {
+                            saved_length = p2.length();
+                            return (p2 / saved_length).xyz();
+                        } else if ((p1.w() == 0.0f) && (p2.w() != 0.0f)) {
+                            saved_length = p2.length();
+                            return -(p1 / saved_length).xyz();
+                        } else {
+                            // FIXME: The OpenGL 1.5 spec says nothing about the case where P1 and P2 BOTH have a w value of 1, which would
+                            // then mean the light position has an implicit value of (0, 0, 0, 0). This doesn't make any logical sense, and it most likely
+                            // a typographical error. Most other GL implementations seem to just fix it to the distance from the vertex to the light, which
+                            // seems to work just fine.
+                            // If somebody with more insight about this could clarify this eventually, that'd be great.
+                            auto distance = (p2 - p1);
+                            saved_length = distance.length();
+                            return (distance / saved_length).xyz();
+                        }
+                    };
+
+                    float vector_length = 0.0f;
+                    FloatVector3 vertex_to_light = sgi_arrow_operator(vertex.eye_coordinates, light.position, vector_length);
 
                     // Light attenuation value.
                     float light_attenuation_factor = 1.0f;
                     if (light.position.w() != 0.0f) {
-                        vertex_to_light = light.position - vertex.eye_coordinates;
                         auto const vertex_to_light_length = vertex_to_light.length();
                         auto const vertex_to_light_length_squared = vertex_to_light_length * vertex_to_light_length;
 
                         light_attenuation_factor = 1.0f / (light.constant_attenuation + (light.linear_attenuation * vertex_to_light_length) + (light.quadratic_attenuation * vertex_to_light_length_squared));
-                        vertex_to_light = vertex_to_light / vertex_to_light_length;
-                    } else {
-                        vertex_to_light = light.position.normalized();
                     }
 
                     // Spotlight factor

--- a/Userland/Libraries/LibSoftGPU/Light/Material.h
+++ b/Userland/Libraries/LibSoftGPU/Light/Material.h
@@ -16,7 +16,6 @@ struct Material {
     FloatVector4 specular { 0.0f, 0.0f, 0.0f, 1.0f };
     FloatVector4 emissive { 0.0f, 0.0f, 0.0f, 1.0f };
     float shininess { 0.0f };
-    float specular_exponent { 0.0f };
     float ambient_color_index { 0.0f };
     float diffuse_color_index = { 1.0f };
     float specular_color_index = { 1.0f };


### PR DESCRIPTION
Basically what's written on the box :^) There were a few minor issues that needed to be solved to get Specular lighting to work, but we now have specular highlights on materials! It's add quite a different feel and makes the lighting feel so much more "real", which is really neat. 

![image](https://user-images.githubusercontent.com/4768900/149610048-8138a89f-12cc-4f3c-abd9-be1d67f64d09.png)
![image](https://user-images.githubusercontent.com/4768900/149610080-4091c540-fe65-4c2d-a2e6-24e2907f1f56.png)

