### PR TITLE
AK: Fix erroneous move operators for SinglyLinkedList

### DIFF
--- a/AK/SinglyLinkedList.h
+++ b/AK/SinglyLinkedList.h
@@ -81,9 +81,15 @@ private:
 public:
     SinglyLinkedList() = default;
     SinglyLinkedList(const SinglyLinkedList& other) = delete;
-    SinglyLinkedList(SinglyLinkedList&&) = default;
+    SinglyLinkedList(SinglyLinkedList&& other)
+        : m_head(other.m_head)
+        , m_tail(other.m_tail)
+    {
+        other.m_head = nullptr;
+        other.m_tail = nullptr;
+    }
     SinglyLinkedList& operator=(const SinglyLinkedList& other) = delete;
-    SinglyLinkedList& operator=(SinglyLinkedList&&) = default;
+    SinglyLinkedList& operator=(SinglyLinkedList&&) = delete;
 
     ~SinglyLinkedList() { clear(); }
 


### PR DESCRIPTION
This patch provides a proper implementation of the move operator and
delete the move assignment operator.

Those operators were introduced in #11888