### PR TITLE
LibGL+LibSoftGPU: Add support for 8-bit luminance (+ alpha) textures

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -239,7 +239,9 @@ extern "C" {
 #define GL_RGB 0x1907
 #define GL_RGBA 0x1908
 #define GL_LUMINANCE 0x1909
+#define GL_LUMINANCE8 0x8040
 #define GL_LUMINANCE_ALPHA 0x190A
+#define GL_LUMINANCE8_ALPHA8 0x8045
 #define GL_BGR 0x190B
 #define GL_BGRA 0x190C
 #define GL_BITMAP 0x1A00

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -915,7 +915,7 @@ void SoftwareGLContext::gl_tex_image_2d(GLenum target, GLint level, GLint intern
         internal_format = GL_RGBA;
 
     // We only support symbolic constants for now
-    RETURN_WITH_ERROR_IF(!(internal_format == GL_RGB || internal_format == GL_RGBA), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(!(internal_format == GL_RGB || internal_format == GL_RGBA || internal_format == GL_LUMINANCE8 || internal_format == GL_LUMINANCE8_ALPHA8), GL_INVALID_ENUM);
     RETURN_WITH_ERROR_IF(!(type == GL_UNSIGNED_BYTE || type == GL_UNSIGNED_SHORT_5_6_5), GL_INVALID_VALUE);
     RETURN_WITH_ERROR_IF(level < 0 || level > Texture2D::LOG2_MAX_TEXTURE_SIZE, GL_INVALID_VALUE);
     RETURN_WITH_ERROR_IF(width < 0 || height < 0 || width > (2 + Texture2D::MAX_TEXTURE_SIZE) || height > (2 + Texture2D::MAX_TEXTURE_SIZE), GL_INVALID_VALUE);
@@ -939,6 +939,14 @@ void SoftwareGLContext::gl_tex_image_2d(GLenum target, GLint level, GLint intern
 
         case GL_RGBA:
             device_format = SoftGPU::ImageFormat::RGBA8888;
+            break;
+
+        case GL_LUMINANCE8:
+            device_format = SoftGPU::ImageFormat::L8;
+            break;
+
+        case GL_LUMINANCE8_ALPHA8:
+            device_format = SoftGPU::ImageFormat::L8A8;
             break;
 
         default:


### PR DESCRIPTION
Used by Half-Life for single colour textures. The alpha variant is
especially used for UI textures.

Before:
![Screenshot from 2022-01-15 10-14-35](https://user-images.githubusercontent.com/25595356/149618332-8514138b-64c7-4c99-bc1d-82f5d5c4706e.png)
![Screenshot from 2022-01-15 10-19-30](https://user-images.githubusercontent.com/25595356/149618341-07171f10-e516-47e0-b83d-c982827f0b9e.png)

After:
![Screenshot from 2022-01-15 10-17-28](https://user-images.githubusercontent.com/25595356/149618353-00f4ffc2-3571-4c7a-a64d-9cd6f9428a2f.png)
![Screenshot from 2022-01-15 10-18-11](https://user-images.githubusercontent.com/25595356/149618357-432637e6-40a1-4680-ba19-6a1b4d88c1d0.png)

