### PR TITLE
Meta: Make check-symbols.sh use the correct build directory

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -180,6 +180,8 @@ jobs:
         run: ccache -s
       - name: Lint (Phase 2/2)
         working-directory: ${{ github.workspace }}/Meta
+        env:
+          SERENITY_ARCH: ${{ matrix.arch }}
         run: ./check-symbols.sh
 
       - name: Create Serenity Rootfs

--- a/Meta/check-symbols.sh
+++ b/Meta/check-symbols.sh
@@ -9,12 +9,13 @@ cd "$script_path/.." || exit 1
 # To eliminate the need for these symbols, avoid doing non-trivial construction of local statics in LibC.
 
 FORBIDDEN_SYMBOLS="__cxa_guard_acquire __cxa_guard_release"
-LIBC_PATH="Build/Userland/Libraries/LibC/libc.a"
+TARGET="${SERENITY_ARCH:-"i686"}"
+LIBC_PATH="Build/${TARGET}/Userland/Libraries/LibC/libc.a"
 for forbidden_symbol in $FORBIDDEN_SYMBOLS; do
     # check if there's an undefined reference to the symbol & it is not defined anywhere else in the library
-    nm $LIBC_PATH | grep "U $forbidden_symbol"
+    nm "$LIBC_PATH" | grep "U $forbidden_symbol"
     APPEARS_AS_UNDEFINED=$?
-    nm $LIBC_PATH | grep "T $forbidden_symbol"
+    nm "$LIBC_PATH" | grep "T $forbidden_symbol"
     APPEARS_AS_DEFINED=$?
     if [ $APPEARS_AS_UNDEFINED -eq 0 ] && [ ! $APPEARS_AS_DEFINED -eq 0 ]; then
         echo "Forbidden undefined symbol in LibC: $forbidden_symbol"


### PR DESCRIPTION
Since the build now happens in Build/$SERENITY_ARCH/ and not in Build/,
this updates check-symbols.sh to use the correct directory to check the
LibC symbols in. For some reason, the constant failures did not show
up as errors in CI.