### PR TITLE
Everywhere: Convert `(*foo).bar` to `foo->bar`

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -138,7 +138,7 @@ public:
         auto it = find(key);
         if (it == end())
             return {};
-        return (*it).value;
+        return it->value;
     }
 
     Optional<typename Traits<V>::ConstPeekType> get(const K& key) const requires(IsPointer<typename Traits<V>::PeekType>)
@@ -146,7 +146,7 @@ public:
         auto it = find(key);
         if (it == end())
             return {};
-        return (*it).value;
+        return it->value;
     }
 
     Optional<typename Traits<V>::PeekType> get(const K& key) requires(!IsConst<typename Traits<V>::PeekType>)
@@ -154,7 +154,7 @@ public:
         auto it = find(key);
         if (it == end())
             return {};
-        return (*it).value;
+        return it->value;
     }
 
     template<Concepts::HashCompatible<K> Key>
@@ -163,7 +163,7 @@ public:
         auto it = find(key);
         if (it == end())
             return {};
-        return (*it).value;
+        return it->value;
     }
 
     template<Concepts::HashCompatible<K> Key>
@@ -172,7 +172,7 @@ public:
         auto it = find(key);
         if (it == end())
             return {};
-        return (*it).value;
+        return it->value;
     }
 
     template<Concepts::HashCompatible<K> Key>
@@ -181,7 +181,7 @@ public:
         auto it = find(key);
         if (it == end())
             return {};
-        return (*it).value;
+        return it->value;
     }
 
     [[nodiscard]] bool contains(const K& key) const

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -64,7 +64,7 @@ public:
         auto it = m_members.find(key);
         if (it == m_members.end())
             return nullptr;
-        return &(*it).value;
+        return &it->value;
     }
 
     [[nodiscard]] [[nodiscard]] bool has(StringView key) const

--- a/AK/MemMem.h
+++ b/AK/MemMem.h
@@ -43,7 +43,7 @@ inline constexpr const void* bitap_bitwise(const void* haystack, size_t haystack
 }
 
 template<typename HaystackIterT>
-inline Optional<size_t> memmem(const HaystackIterT& haystack_begin, const HaystackIterT& haystack_end, Span<const u8> needle) requires(requires { (*haystack_begin).data(); (*haystack_begin).size(); })
+inline Optional<size_t> memmem(const HaystackIterT& haystack_begin, const HaystackIterT& haystack_end, Span<const u8> needle) requires(requires { haystack_begin->data(); haystack_begin->size(); })
 {
     auto prepare_kmp_partial_table = [&] {
         Vector<int, 64> table;

--- a/AK/Trie.h
+++ b/AK/Trie.h
@@ -58,7 +58,7 @@ class Trie {
             if (current_state.it == current_state.end)
                 return pop_and_get_next();
 
-            m_current_node = &*(*current_state.it).value;
+            m_current_node = &*current_state.it->value;
 
             // FIXME: Figure out how to OOM harden this iterator.
             MUST(m_state.try_empend(false, m_current_node->m_children.begin(), m_current_node->m_children.end()));
@@ -102,7 +102,7 @@ public:
             auto next_it = node->m_children.find(*it);
             if (next_it == node->m_children.end())
                 return static_cast<BaseType&>(*node);
-            node = &*(*next_it).value;
+            node = &*next_it->value;
         }
         return static_cast<BaseType&>(*node);
     }

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -124,7 +124,7 @@ UNMAP_AFTER_INIT void Access::rescan_hardware()
     SpinlockLocker scan_locker(m_scan_lock);
     VERIFY(m_device_identifiers.is_empty());
     for (auto it = m_host_controllers.begin(); it != m_host_controllers.end(); ++it) {
-        (*it).value->enumerate_attached_devices([this](DeviceIdentifier device_identifier) -> void {
+        it->value->enumerate_attached_devices([this](DeviceIdentifier device_identifier) -> void {
             m_device_identifiers.append(device_identifier);
         });
     }

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -1188,7 +1188,7 @@ ErrorOr<void> Ext2FSInode::remove_child(StringView name)
     auto it = m_lookup_cache.find(name);
     if (it == m_lookup_cache.end())
         return ENOENT;
-    auto child_inode_index = (*it).value;
+    auto child_inode_index = it->value;
 
     InodeIdentifier child_id { fsid(), child_inode_index };
 

--- a/Kernel/FileSystem/FileSystem.cpp
+++ b/Kernel/FileSystem/FileSystem.cpp
@@ -38,7 +38,7 @@ FileSystem* FileSystem::from_fsid(FileSystemID id)
 {
     auto it = all_file_systems().find(id);
     if (it != all_file_systems().end())
-        return (*it).value;
+        return it->value;
     return nullptr;
 }
 

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -35,7 +35,7 @@ RefPtr<UDPSocket> UDPSocket::from_port(u16 port)
         auto it = table.find(port);
         if (it == table.end())
             return {};
-        return (*it).value;
+        return it->value;
     });
 }
 

--- a/Kernel/Storage/ATA/AHCIPortHandler.cpp
+++ b/Kernel/Storage/ATA/AHCIPortHandler.cpp
@@ -59,7 +59,7 @@ RefPtr<AHCIPort> AHCIPortHandler::port_at_index(u32 port_index) const
     auto it = m_handled_ports.find(port_index);
     if (it == m_handled_ports.end())
         return nullptr;
-    return (*it).value;
+    return it->value;
 }
 
 PhysicalAddress AHCIPortHandler::get_identify_metadata_physical_region(u32 port_index) const

--- a/Tests/AK/TestNeverDestroyed.cpp
+++ b/Tests/AK/TestNeverDestroyed.cpp
@@ -69,7 +69,7 @@ TEST_CASE(should_provide_dereference_operator)
 TEST_CASE(should_provide_indirection_operator)
 {
     AK::NeverDestroyed<Counter> n {};
-    EXPECT_EQ(0, (*n).num_destroys);
+    EXPECT_EQ(0, n->num_destroys);
 }
 
 TEST_CASE(should_provide_basic_getter)

--- a/Userland/Applications/Spreadsheet/Readers/XSV.h
+++ b/Userland/Applications/Spreadsheet/Readers/XSV.h
@@ -136,8 +136,24 @@ public:
         {
         }
 
-        Row operator*() const { return Row { m_xsv, m_index }; }
+        Row const operator*() const { return Row { m_xsv, m_index }; }
         Row operator*() requires(!const_) { return Row { m_xsv, m_index }; }
+
+        class RowPointer {
+        public:
+            RowPointer(Row row)
+                : m_row(row)
+            {
+            }
+            Row* operator->() { return &m_row; }
+            Row const* operator->() const { return &m_row; }
+
+        private:
+            Row m_row;
+        };
+
+        RowPointer const operator->() const { return Row { m_xsv, m_index }; }
+        RowPointer operator->() requires(!const_) { return Row { m_xsv, m_index }; }
 
         RowIterator& operator++()
         {

--- a/Userland/Applications/SystemMonitor/ProcessModel.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessModel.cpp
@@ -169,7 +169,7 @@ GUI::Variant ProcessModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
     }
 
     auto it = m_threads.find(m_tids[index.row()]);
-    auto& thread = *(*it).value;
+    auto& thread = *it->value;
 
     if (role == GUI::ModelRole::Sort) {
         switch (index.column()) {

--- a/Userland/Libraries/LibC/termcap.cpp
+++ b/Userland/Libraries/LibC/termcap.cpp
@@ -82,7 +82,7 @@ char* __attribute__((weak)) tgetstr(const char* id, char** area)
     auto it = caps->find(id);
     if (it != caps->end()) {
         char* ret = *area;
-        const char* val = (*it).value;
+        const char* val = it->value;
         strcpy(*area, val);
         *area += strlen(val) + 1;
         return ret;
@@ -107,7 +107,7 @@ int __attribute__((weak)) tgetnum(const char* id)
     warnln_if(TERMCAP_DEBUG, "tgetnum: '{}'", id);
     auto it = caps->find(id);
     if (it != caps->end())
-        return atoi((*it).value);
+        return atoi(it->value);
     return -1;
 }
 

--- a/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
+++ b/Userland/Libraries/LibCore/ProcessStatisticsReader.cpp
@@ -119,7 +119,7 @@ String ProcessStatisticsReader::username_from_uid(uid_t uid)
 
     auto it = s_usernames.find(uid);
     if (it != s_usernames.end())
-        return (*it).value;
+        return it->value;
     return String::number(uid);
 }
 }

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -141,7 +141,7 @@ Action* Application::action_for_key_event(const KeyEvent& event)
     auto it = m_global_shortcut_actions.find(Shortcut(event.modifiers(), (KeyCode)event.key()));
     if (it == m_global_shortcut_actions.end())
         return nullptr;
-    return (*it).value;
+    return it->value;
 }
 
 void Application::show_tooltip(String tooltip, const Widget* tooltip_source_widget)

--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -280,7 +280,7 @@ String FileSystemModel::name_for_uid(uid_t uid) const
     auto it = m_user_names.find(uid);
     if (it == m_user_names.end())
         return String::number(uid);
-    return (*it).value;
+    return it->value;
 }
 
 String FileSystemModel::name_for_gid(gid_t gid) const
@@ -288,7 +288,7 @@ String FileSystemModel::name_for_gid(gid_t gid) const
     auto it = m_group_names.find(gid);
     if (it == m_group_names.end())
         return String::number(gid);
-    return (*it).value;
+    return it->value;
 }
 
 static String permission_string(mode_t mode)
@@ -635,9 +635,9 @@ bool FileSystemModel::fetch_thumbnail_for(Node const& node)
     auto path = node.full_path();
     auto it = s_thumbnail_cache.find(path);
     if (it != s_thumbnail_cache.end()) {
-        if (!(*it).value)
+        if (!it->value)
             return false;
-        node.thumbnail = (*it).value;
+        node.thumbnail = it->value;
         return true;
     }
 

--- a/Userland/Libraries/LibGUI/ItemListModel.h
+++ b/Userland/Libraries/LibGUI/ItemListModel.h
@@ -83,7 +83,7 @@ public:
         Vector<GUI::ModelIndex> found_indices;
         if constexpr (IsTwoDimensional) {
             for (auto it = m_data.begin(); it != m_data.end(); ++it) {
-                for (auto it2d = (*it).begin(); it2d != (*it).end(); ++it2d) {
+                for (auto it2d = it->begin(); it2d != it->end(); ++it2d) {
                     GUI::ModelIndex index = this->index(it.index(), it2d.index());
                     if (!string_matches(data(index, ModelRole::Display).to_string(), searching, flags))
                         continue;

--- a/Userland/Libraries/LibGUI/Menu.cpp
+++ b/Userland/Libraries/LibGUI/Menu.cpp
@@ -31,7 +31,7 @@ Menu* Menu::from_menu_id(int menu_id)
     auto it = all_menus().find(menu_id);
     if (it == all_menus().end())
         return nullptr;
-    return (*it).value;
+    return it->value;
 }
 
 Menu::Menu(String name)

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -61,7 +61,7 @@ Window* Window::from_window_id(int window_id)
 {
     auto it = reified_windows->find(window_id);
     if (it != reified_windows->end())
-        return (*it).value;
+        return it->value;
     return nullptr;
 }
 

--- a/Userland/Libraries/LibGfx/Emoji.cpp
+++ b/Userland/Libraries/LibGfx/Emoji.cpp
@@ -17,7 +17,7 @@ const Bitmap* Emoji::emoji_for_code_point(u32 code_point)
 {
     auto it = s_emojis.find(code_point);
     if (it != s_emojis.end())
-        return (*it).value.ptr();
+        return it->value.ptr();
 
     auto bitmap_or_error = Bitmap::try_load_from_file(String::formatted("/res/emoji/U+{:X}.png", code_point));
     if (bitmap_or_error.is_error()) {

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2153,7 +2153,7 @@ String parse_ampersand_string(StringView raw_text, Optional<size_t>* underline_o
             if (i != (raw_text.length() - 1) && raw_text[i + 1] == '&') {
                 builder.append(raw_text[i]);
                 ++i;
-            } else if (underline_offset && !(*underline_offset).has_value()) {
+            } else if (underline_offset && !underline_offset->has_value()) {
                 *underline_offset = i;
             }
             continue;

--- a/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/BasicBlock.cpp
@@ -53,7 +53,7 @@ void BasicBlock::dump(Bytecode::Executable const& executable) const
     if (!m_name.is_empty())
         warnln("{}:", m_name);
     while (!it.at_end()) {
-        warnln("[{:4x}] {}", it.offset(), (*it).to_string(executable));
+        warnln("[{:4x}] {}", it.offset(), it->to_string(executable));
         ++it;
     }
 }

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -125,6 +125,7 @@ public:
     }
 
     Instruction const& operator*() const { return dereference(); }
+    Instruction const* operator->() const { return &dereference(); }
 
     ALWAYS_INLINE void operator++()
     {

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -3875,7 +3875,7 @@ bool Parser::try_parse_arrow_function_expression_failed_at_position(const Positi
     if (it == m_token_memoizations.end())
         return false;
 
-    return (*it).value.try_parse_arrow_function_expression_failed;
+    return it->value.try_parse_arrow_function_expression_failed;
 }
 
 void Parser::set_try_parse_arrow_function_expression_failed_at_position(const Position& position, bool failed)

--- a/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
@@ -97,7 +97,7 @@ OwnPtr<ContainerBlock> ContainerBlock::parse(LineIterator& lines)
         if (lines.is_end())
             break;
 
-        if ((*lines).is_empty()) {
+        if (lines->is_empty()) {
             has_trailing_blank_lines = true;
             ++lines;
 

--- a/Userland/Libraries/LibSQL/BTree.h
+++ b/Userland/Libraries/LibSQL/BTree.h
@@ -171,10 +171,10 @@ public:
         return (*m_current)[m_index];
     }
 
-    Key const& operator->() const
+    Key const* operator->() const
     {
         VERIFY(!is_end());
-        return (*m_current)[m_index];
+        return &(*m_current)[m_index];
     }
 
     BTreeIterator& operator=(BTreeIterator const&);

--- a/Userland/Libraries/LibSQL/Database.cpp
+++ b/Userland/Libraries/LibSQL/Database.cpp
@@ -146,7 +146,7 @@ ErrorOr<RefPtr<TableDef>> Database::get_table(String const& schema, String const
         return Error::from_string_literal("Schema does not exist"sv);
     }
     auto ret = TableDef::construct(schema_def, name);
-    ret->set_pointer((*table_iterator).pointer());
+    ret->set_pointer(table_iterator->pointer());
     m_table_cache.set(key.hash(), ret);
     auto hash = ret->hash();
     auto column_key = ColumnDef::make_key(ret);

--- a/Userland/Libraries/LibSQL/HashIndex.cpp
+++ b/Userland/Libraries/LibSQL/HashIndex.cpp
@@ -446,7 +446,7 @@ bool HashIndexIterator::operator==(Key const& other) const
         return false;
     if (other.is_null())
         return false;
-    return (**this).compare(other);
+    return (*this)->compare(other);
 }
 
 }

--- a/Userland/Libraries/LibSQL/HashIndex.h
+++ b/Userland/Libraries/LibSQL/HashIndex.h
@@ -152,10 +152,10 @@ public:
         return (*m_current)[m_index];
     }
 
-    Key const& operator->() const
+    Key const* operator->() const
     {
         VERIFY(!is_end());
-        return (*m_current)[m_index];
+        return &(*m_current)[m_index];
     }
 
     HashIndexIterator& operator=(HashIndexIterator const&) = default;

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -26,7 +26,7 @@ Service* Service::find_by_pid(pid_t pid)
     auto it = s_service_map.find(pid);
     if (it == s_service_map.end())
         return nullptr;
-    return (*it).value;
+    return it->value;
 }
 
 void Service::setup_socket(SocketDescriptor& socket)

--- a/Userland/Services/WindowServer/WMClientConnection.cpp
+++ b/Userland/Services/WindowServer/WMClientConnection.cpp
@@ -62,7 +62,7 @@ void WMClientConnection::set_active_window(i32 client_id, i32 window_id)
         did_misbehave("SetActiveWindow: Bad window ID");
         return;
     }
-    auto& window = *(*it).value;
+    auto& window = *it->value;
     WindowManager::the().minimize_windows(window, false);
     WindowManager::the().move_to_front_and_make_active(window);
 }
@@ -79,7 +79,7 @@ void WMClientConnection::popup_window_menu(i32 client_id, i32 window_id, Gfx::In
         did_misbehave("PopupWindowMenu: Bad window ID");
         return;
     }
-    auto& window = *(*it).value;
+    auto& window = *it->value;
     if (auto* modal_window = window.blocking_modal_window()) {
         modal_window->popup_window_menu(screen_position, WindowMenuDefaultAction::BasedOnWindowState);
     } else {
@@ -99,7 +99,7 @@ void WMClientConnection::start_window_resize(i32 client_id, i32 window_id)
         did_misbehave("WM_StartWindowResize: Bad window ID");
         return;
     }
-    auto& window = *(*it).value;
+    auto& window = *it->value;
     // FIXME: We are cheating a bit here by using the current cursor location and hard-coding the left button.
     //        Maybe the client should be allowed to specify what initiated this request?
     WindowManager::the().start_window_resize(window, ScreenInput::the().cursor_location(), MouseButton::Primary);
@@ -117,7 +117,7 @@ void WMClientConnection::set_window_minimized(i32 client_id, i32 window_id, bool
         did_misbehave("WM_SetWindowMinimized: Bad window ID");
         return;
     }
-    auto& window = *(*it).value;
+    auto& window = *it->value;
     WindowManager::the().minimize_windows(window, minimized);
 }
 
@@ -179,7 +179,7 @@ void WMClientConnection::set_window_taskbar_rect(i32 client_id, i32 window_id, G
     if (it == client->m_windows.end())
         return;
 
-    auto& window = *(*it).value;
+    auto& window = *it->value;
     window.set_taskbar_rect(rect);
 }
 

--- a/Userland/Utilities/top.cpp
+++ b/Userland/Utilities/top.cpp
@@ -222,7 +222,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto jt = prev.map.find(pid_and_tid);
             if (jt == prev.map.end())
                 continue;
-            auto time_scheduled_before = (*jt).value.time_scheduled;
+            auto time_scheduled_before = jt->value.time_scheduled;
             auto time_scheduled_diff = it.value.time_scheduled - time_scheduled_before;
             it.value.time_scheduled_since_prev = time_scheduled_diff;
             it.value.cpu_percent = total_scheduled_diff > 0 ? ((time_scheduled_diff * 100) / total_scheduled_diff) : 0;


### PR DESCRIPTION
This requires a few changes to classes that didn't implement `operator->()` or implemented it incorrectly.