### PR TITLE
Meta/serenity.sh: Wrap pick_gcc in an if

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -172,7 +172,7 @@ pick_gcc() {
 cmd_with_target() {
     is_valid_target || ( >&2 echo "Unknown target: $TARGET"; usage )
     if [ "$TOOLCHAIN_TYPE" == "GNU" ]; then
-	pick_gcc
+        pick_gcc
     fi
 
     if [ ! -d "$SERENITY_SOURCE_DIR" ]; then

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -171,7 +171,9 @@ pick_gcc() {
 
 cmd_with_target() {
     is_valid_target || ( >&2 echo "Unknown target: $TARGET"; usage )
-    pick_gcc
+    if [ "$TOOLCHAIN_TYPE" == "GNU" ]; then
+	pick_gcc
+    fi
 
     if [ ! -d "$SERENITY_SOURCE_DIR" ]; then
         SERENITY_SOURCE_DIR="$(get_top_dir)"


### PR DESCRIPTION
Meta/ serenity.sh calls pick_gcc unconditionally. Add an if to check $TOOLCHAIN_TYPE.

Fixes #11915.