### PR TITLE
LibGL+LibSoftGPU: Implement multitexturing and non-power-of-two textures

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -577,6 +577,7 @@ GLAPI void glTexEnvf(GLenum target, GLenum pname, GLfloat param);
 GLAPI void glTexEnvi(GLenum target, GLenum pname, GLint param);
 GLAPI void glBindTexture(GLenum target, GLuint texture);
 GLAPI GLboolean glIsTexture(GLuint texture);
+GLAPI void glActiveTextureARB(GLenum texture);
 GLAPI void glActiveTexture(GLenum texture);
 GLAPI void glGetBooleanv(GLenum pname, GLboolean* data);
 GLAPI void glGetDoublev(GLenum pname, GLdouble* params);

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -571,6 +571,8 @@ GLAPI void glTexCoord3f(GLfloat s, GLfloat t, GLfloat r);
 GLAPI void glTexCoord3fv(GLfloat const* v);
 GLAPI void glTexCoord4f(GLfloat s, GLfloat t, GLfloat r, GLfloat q);
 GLAPI void glTexCoord4fv(const GLfloat* v);
+GLAPI void glMultiTexCoord2fARB(GLenum target, GLfloat s, GLfloat t);
+GLAPI void glMultiTexCoord2f(GLenum target, GLfloat s, GLfloat t);
 GLAPI void glTexParameteri(GLenum target, GLenum pname, GLint param);
 GLAPI void glTexParameterf(GLenum target, GLenum pname, GLfloat param);
 GLAPI void glTexEnvf(GLenum target, GLenum pname, GLfloat param);
@@ -586,6 +588,9 @@ GLAPI void glGetIntegerv(GLenum pname, GLint* data);
 GLAPI void glDepthMask(GLboolean flag);
 GLAPI void glEnableClientState(GLenum cap);
 GLAPI void glDisableClientState(GLenum cap);
+GLAPI void glClientActiveTextureARB(GLenum target);
+GLAPI void glClientActiveTexture(GLenum target);
+
 GLAPI void glVertexPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 GLAPI void glColorPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);
 GLAPI void glTexCoordPointer(GLint size, GLenum type, GLsizei stride, const void* pointer);

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -69,6 +69,7 @@ public:
     virtual void gl_tex_sub_image_2d(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* data) = 0;
     virtual void gl_tex_parameter(GLenum target, GLenum pname, GLfloat param) = 0;
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) = 0;
+    virtual void gl_multi_tex_coord(GLenum target, GLfloat s, GLfloat t, GLfloat r, GLfloat q) = 0;
     virtual void gl_tex_env(GLenum target, GLenum pname, GLfloat param) = 0;
     virtual void gl_bind_texture(GLenum target, GLuint texture) = 0;
     virtual GLboolean gl_is_texture(GLuint texture) = 0;
@@ -76,6 +77,7 @@ public:
     virtual void gl_depth_mask(GLboolean flag) = 0;
     virtual void gl_enable_client_state(GLenum cap) = 0;
     virtual void gl_disable_client_state(GLenum cap) = 0;
+    virtual void gl_client_active_texture(GLenum target) = 0;
     virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
     virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;
     virtual void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) = 0;

--- a/Userland/Libraries/LibGL/GLTexture.cpp
+++ b/Userland/Libraries/LibGL/GLTexture.cpp
@@ -52,8 +52,11 @@ GLboolean glIsTexture(GLuint texture)
     return g_gl_context->gl_is_texture(texture);
 }
 
-// Note: This is an _extremely_ misleading API name. This sets the active
-// texture unit, NOT the active texture itself...
+void glActiveTextureARB(GLenum texture)
+{
+    glActiveTexture(texture);
+}
+
 void glActiveTexture(GLenum texture)
 {
     g_gl_context->gl_active_texture(texture);

--- a/Userland/Libraries/LibGL/GLUtils.cpp
+++ b/Userland/Libraries/LibGL/GLUtils.cpp
@@ -135,6 +135,16 @@ void glDisableClientState(GLenum cap)
     g_gl_context->gl_disable_client_state(cap);
 }
 
+void glClientActiveTextureARB(GLenum target)
+{
+    glClientActiveTexture(target);
+}
+
+void glClientActiveTexture(GLenum target)
+{
+    g_gl_context->gl_client_active_texture(target);
+}
+
 void glDepthRange(GLdouble min, GLdouble max)
 {
     g_gl_context->gl_depth_range(min, max);

--- a/Userland/Libraries/LibGL/GLVert.cpp
+++ b/Userland/Libraries/LibGL/GLVert.cpp
@@ -195,6 +195,16 @@ void glTexCoord4fv(const GLfloat* v)
     g_gl_context->gl_tex_coord(v[0], v[1], v[2], v[3]);
 }
 
+void glMultiTexCoord2fARB(GLenum target, GLfloat s, GLfloat t)
+{
+    glMultiTexCoord2f(target, s, t);
+}
+
+void glMultiTexCoord2f(GLenum target, GLfloat s, GLfloat t)
+{
+    g_gl_context->gl_multi_tex_coord(target, s, t, 0.0f, 1.0f);
+}
+
 void glNormal3f(GLfloat nx, GLfloat ny, GLfloat nz)
 {
     g_gl_context->gl_normal(nx, ny, nz);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -1868,9 +1868,10 @@ GLboolean SoftwareGLContext::gl_is_texture(GLuint texture)
 
 void SoftwareGLContext::gl_active_texture(GLenum texture)
 {
-    RETURN_WITH_ERROR_IF(texture < GL_TEXTURE0 || texture > GL_TEXTURE31, GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(texture < GL_TEXTURE0 || texture >= GL_TEXTURE0 + m_device_info.num_texture_units, GL_INVALID_ENUM);
 
-    m_active_texture_unit = &m_texture_units.at(texture - GL_TEXTURE0);
+    m_active_texture_unit_index = texture - GL_TEXTURE0;
+    m_active_texture_unit = &m_texture_units.at(m_active_texture_unit_index);
 }
 
 void SoftwareGLContext::gl_get_booleanv(GLenum pname, GLboolean* data)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -621,10 +621,16 @@ void SoftwareGLContext::gl_vertex(GLdouble x, GLdouble y, GLdouble z, GLdouble w
     m_vertex_list.append(vertex);
 }
 
-// FIXME: We need to add `r` and `q` to our GLVertex?!
 void SoftwareGLContext::gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_tex_coord, s, t, r, q);
+
+    m_current_vertex_tex_coord = { s, t, r, q };
+}
+
+void SoftwareGLContext::gl_multi_tex_coord(GLenum target, GLfloat s, GLfloat t, GLfloat r, GLfloat q)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_multi_tex_coord, target, s, t, r, q);
 
     m_current_vertex_tex_coord = { s, t, r, q };
 }
@@ -2031,6 +2037,11 @@ void SoftwareGLContext::gl_disable_client_state(GLenum cap)
     }
 }
 
+void SoftwareGLContext::gl_client_active_texture(GLenum target)
+{
+    (void)target;
+}
+
 void SoftwareGLContext::gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer)
 {
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
@@ -3263,6 +3274,9 @@ void SoftwareGLContext::build_extension_string()
     // and refuse to create a context if it doesn't.
     if (m_device_info.supports_npot_textures)
         extensions.append("GL_ARB_texture_non_power_of_two");
+
+    if (m_device_info.num_texture_units > 1)
+        extensions.append("GL_ARB_multitexture");
 
     m_extensions = String::join(" ", extensions);
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -615,7 +615,8 @@ void SoftwareGLContext::gl_vertex(GLdouble x, GLdouble y, GLdouble z, GLdouble w
 
     vertex.position = { static_cast<float>(x), static_cast<float>(y), static_cast<float>(z), static_cast<float>(w) };
     vertex.color = m_current_vertex_color;
-    vertex.tex_coord = m_current_vertex_tex_coord;
+    for (size_t i = 0; i < m_device_info.num_texture_units; ++i)
+        vertex.tex_coords[i] = m_current_vertex_tex_coord;
     vertex.normal = m_current_vertex_normal;
 
     m_vertex_list.append(vertex);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -204,7 +204,7 @@ private:
     u8 m_clear_stencil { 0 };
 
     FloatVector4 m_current_vertex_color = { 1.0f, 1.0f, 1.0f, 1.0f };
-    FloatVector4 m_current_vertex_tex_coord = { 0.0f, 0.0f, 0.0f, 1.0f };
+    Vector<FloatVector4> m_current_vertex_tex_coord;
     FloatVector3 m_current_vertex_normal = { 0.0f, 0.0f, 1.0f };
 
     Vector<SoftGPU::Vertex> m_vertex_list;
@@ -262,7 +262,7 @@ private:
     // Texture objects
     TextureNameAllocator m_name_allocator;
     HashMap<GLuint, RefPtr<Texture>> m_allocated_textures;
-    Vector<TextureUnit, 32> m_texture_units;
+    Vector<TextureUnit> m_texture_units;
     TextureUnit* m_active_texture_unit;
 
     // Texture coordinate generation state

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -157,6 +157,8 @@ private:
     void sync_light_state();
     void sync_stencil_configuration();
 
+    void build_extension_string();
+
     template<typename T>
     T* store_in_listing(T value)
     {
@@ -432,6 +434,9 @@ private:
     bool m_color_material_enabled { false };
     GLenum m_color_material_face { GL_FRONT_AND_BACK };
     GLenum m_color_material_mode { GL_AMBIENT_AND_DIFFUSE };
+
+    // GL Extension string
+    String m_extensions;
 };
 
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -254,7 +254,8 @@ private:
     // Client side arrays
     bool m_client_side_vertex_array_enabled = false;
     bool m_client_side_color_array_enabled = false;
-    bool m_client_side_texture_coord_array_enabled = false;
+    Vector<bool> m_client_side_texture_coord_array_enabled;
+    size_t m_client_active_texture = 0;
 
     NonnullRefPtr<Gfx::Bitmap> m_frontbuffer;
 
@@ -419,7 +420,7 @@ private:
 
     VertexAttribPointer m_client_vertex_pointer;
     VertexAttribPointer m_client_color_pointer;
-    VertexAttribPointer m_client_tex_coord_pointer;
+    Vector<VertexAttribPointer> m_client_tex_coord_pointer;
 
     u8 m_pack_alignment { 4 };
     GLsizei m_unpack_row_length { 0 };

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -264,6 +264,7 @@ private:
     HashMap<GLuint, RefPtr<Texture>> m_allocated_textures;
     Vector<TextureUnit> m_texture_units;
     TextureUnit* m_active_texture_unit;
+    size_t m_active_texture_unit_index { 0 };
 
     // Texture coordinate generation state
     struct TextureCoordinateGeneration {

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -270,36 +270,15 @@ private:
     struct TextureCoordinateGeneration {
         bool enabled { false };
         GLenum generation_mode { GL_EYE_LINEAR };
-        FloatVector4 object_plane_coefficients;
-        FloatVector4 eye_plane_coefficients;
+        FloatVector4 object_plane_coefficients { 0.0f, 0.0f, 0.0f, 0.0f };
+        FloatVector4 eye_plane_coefficients { 0.0f, 0.0f, 0.0f, 0.0f };
     };
-    Array<TextureCoordinateGeneration, 4> m_texture_coordinate_generation {
-        // S
-        TextureCoordinateGeneration {
-            .object_plane_coefficients = { 1.0f, 0.0f, 0.0f, 0.0f },
-            .eye_plane_coefficients = { 1.0f, 0.0f, 0.0f, 0.0f },
-        },
-        // T
-        TextureCoordinateGeneration {
-            .object_plane_coefficients = { 0.0f, 1.0f, 0.0f, 0.0f },
-            .eye_plane_coefficients = { 0.0f, 1.0f, 0.0f, 0.0f },
-        },
-        // R
-        TextureCoordinateGeneration {
-            .object_plane_coefficients = { 0.0f, 0.0f, 0.0f, 0.0f },
-            .eye_plane_coefficients = { 0.0f, 0.0f, 0.0f, 0.0f },
-        },
-        // Q
-        TextureCoordinateGeneration {
-            .object_plane_coefficients = { 0.0f, 0.0f, 0.0f, 0.0f },
-            .eye_plane_coefficients = { 0.0f, 0.0f, 0.0f, 0.0f },
-        },
-    };
+    Vector<Array<TextureCoordinateGeneration, 4>> m_texture_coordinate_generation;
     bool m_texcoord_generation_dirty { true };
 
-    ALWAYS_INLINE TextureCoordinateGeneration& texture_coordinate_generation(GLenum capability)
+    ALWAYS_INLINE TextureCoordinateGeneration& texture_coordinate_generation(size_t texture_unit, GLenum capability)
     {
-        return m_texture_coordinate_generation[capability - GL_TEXTURE_GEN_S];
+        return m_texture_coordinate_generation[texture_unit][capability - GL_TEXTURE_GEN_S];
     }
 
     SoftGPU::Device m_rasterizer;

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -100,6 +100,7 @@ public:
     virtual void gl_tex_sub_image_2d(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const GLvoid* data) override;
     virtual void gl_tex_parameter(GLenum target, GLenum pname, GLfloat param) override;
     virtual void gl_tex_coord(GLfloat s, GLfloat t, GLfloat r, GLfloat q) override;
+    virtual void gl_multi_tex_coord(GLenum target, GLfloat s, GLfloat t, GLfloat r, GLfloat q) override;
     virtual void gl_tex_env(GLenum target, GLenum pname, GLfloat param) override;
     virtual void gl_bind_texture(GLenum target, GLuint texture) override;
     virtual GLboolean gl_is_texture(GLuint texture) override;
@@ -107,6 +108,7 @@ public:
     virtual void gl_depth_mask(GLboolean flag) override;
     virtual void gl_enable_client_state(GLenum cap) override;
     virtual void gl_disable_client_state(GLenum cap) override;
+    virtual void gl_client_active_texture(GLenum target) override;
     virtual void gl_vertex_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
     virtual void gl_color_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;
     virtual void gl_tex_coord_pointer(GLint size, GLenum type, GLsizei stride, const void* pointer) override;

--- a/Userland/Libraries/LibSoftGPU/Clipper.cpp
+++ b/Userland/Libraries/LibSoftGPU/Clipper.cpp
@@ -47,7 +47,8 @@ Vertex Clipper::clip_intersection_point(const Vertex& p1, const Vertex& p2, Clip
     out.eye_coordinates = mix(p1.eye_coordinates, p2.eye_coordinates, a);
     out.clip_coordinates = mix(p1.clip_coordinates, p2.clip_coordinates, a);
     out.color = mix(p1.color, p2.color, a);
-    out.tex_coord = mix(p1.tex_coord, p2.tex_coord, a);
+    for (size_t i = 0; i < NUM_SAMPLERS; ++i)
+        out.tex_coords[i] = mix(p1.tex_coords[i], p2.tex_coords[i], a);
     out.normal = mix(p1.normal, p2.normal, a);
     return out;
 }

--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -15,7 +15,7 @@
 namespace SoftGPU {
 
 static constexpr bool ENABLE_STATISTICS_OVERLAY = false;
-static constexpr int NUM_SAMPLERS = 32;
+static constexpr int NUM_SAMPLERS = 2;
 static constexpr int SUBPIXEL_BITS = 5;
 static constexpr int NUM_LIGHTS = 8;
 

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -605,6 +605,7 @@ DeviceInfo Device::info() const
         .num_texture_units = NUM_SAMPLERS,
         .num_lights = NUM_LIGHTS,
         .stencil_bits = sizeof(u8) * 8,
+        .supports_npot_textures = true,
     };
 }
 

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -70,8 +70,8 @@ struct RasterizerOptions {
     WindingOrder front_face { WindingOrder::CounterClockwise };
     bool cull_back { true };
     bool cull_front { false };
-    u8 texcoord_generation_enabled_coordinates { TexCoordGenerationCoordinate::None };
-    Array<TexCoordGenerationConfig, 4> texcoord_generation_config {};
+    Array<u8, NUM_SAMPLERS> texcoord_generation_enabled_coordinates {};
+    Array<Array<TexCoordGenerationConfig, 4>, NUM_SAMPLERS> texcoord_generation_config {};
     Gfx::IntRect viewport;
     bool lighting_enabled { false };
     bool color_material_enabled { false };

--- a/Userland/Libraries/LibSoftGPU/DeviceInfo.h
+++ b/Userland/Libraries/LibSoftGPU/DeviceInfo.h
@@ -16,6 +16,7 @@ struct DeviceInfo final {
     unsigned num_texture_units;
     unsigned num_lights;
     u8 stencil_bits;
+    bool supports_npot_textures;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/PixelQuad.h
+++ b/Userland/Libraries/LibSoftGPU/PixelQuad.h
@@ -10,6 +10,7 @@
 #include <LibGfx/Vector2.h>
 #include <LibGfx/Vector3.h>
 #include <LibGfx/Vector4.h>
+#include <LibSoftGPU/Config.h>
 
 namespace SoftGPU {
 
@@ -18,7 +19,7 @@ struct PixelQuad final {
     Vector3<AK::SIMD::f32x4> barycentrics;
     AK::SIMD::f32x4 depth;
     Vector4<AK::SIMD::f32x4> vertex_color;
-    Vector4<AK::SIMD::f32x4> uv;
+    Array<Vector4<AK::SIMD::f32x4>, NUM_SAMPLERS> texture_coordinates;
     Vector4<AK::SIMD::f32x4> out_color;
     AK::SIMD::f32x4 fog_depth;
     AK::SIMD::i32x4 mask;

--- a/Userland/Libraries/LibSoftGPU/Vertex.h
+++ b/Userland/Libraries/LibSoftGPU/Vertex.h
@@ -7,8 +7,10 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <LibGfx/Vector3.h>
 #include <LibGfx/Vector4.h>
+#include <LibSoftGPU/Config.h>
 
 namespace SoftGPU {
 
@@ -18,7 +20,7 @@ struct Vertex {
     FloatVector4 clip_coordinates;
     FloatVector4 window_coordinates;
     FloatVector4 color;
-    FloatVector4 tex_coord;
+    Array<FloatVector4, NUM_SAMPLERS> tex_coords;
     FloatVector3 normal;
 };
 


### PR DESCRIPTION
This implements a subset of GL_ARB_multitexture that allows glquake to render its level geometry in one pass.
Also announces support for non-power-of-two textures via the GL_EXTENSION string returned by glGetString().