### PR TITLE
Kernel: Wait for NVMe controller to change enabled state

### DIFF
--- a/Kernel/Storage/NVMe/NVMeController.h
+++ b/Kernel/Storage/NVMe/NVMeController.h
@@ -10,6 +10,7 @@
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/OwnPtr.h>
 #include <AK/RefPtr.h>
+#include <AK/Time.h>
 #include <AK/Tuple.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
@@ -63,6 +64,7 @@ private:
     {
         m_dbl_stride = (m_controller_regs->cap >> CAP_DBL_SHIFT) & CAP_DBL_MASK;
     }
+    bool wait_for_ready(bool);
 
 private:
     PCI::DeviceIdentifier m_pci_device_id;
@@ -72,6 +74,7 @@ private:
     Memory::TypedMapping<volatile ControllerRegister> m_controller_regs;
     bool m_admin_queue_ready { false };
     size_t m_device_count {};
+    AK::Time m_ready_timeout;
     u32 m_bar;
     u8 m_dbl_stride;
     static Atomic<u8> controller_id;

--- a/Kernel/Storage/NVMe/NVMeDefinitions.h
+++ b/Kernel/Storage/NVMe/NVMeDefinitions.h
@@ -46,16 +46,30 @@ static constexpr u8 DBL_REG_SIZE = 8;
 // CAP
 static constexpr u8 CAP_DBL_SHIFT = 32;
 static constexpr u8 CAP_DBL_MASK = 0xf;
+static constexpr u8 CAP_TO_SHIFT = 24;
+static constexpr u64 CAP_TO_MASK = 0xff << CAP_TO_SHIFT;
 static constexpr u16 MQES(u64 cap)
 {
     return (cap & 0xffff) + 1;
 }
 
+static constexpr u32 CAP_TO(u64 cap)
+{
+    return (cap & CAP_TO_MASK) >> CAP_TO_SHIFT;
+}
+
 // CC – Controller Configuration
 static constexpr u8 CC_EN_BIT = 0x0;
 static constexpr u8 CSTS_RDY_BIT = 0x0;
+static constexpr u8 CSTS_SHST_SHIFT = 2;
+static constexpr u32 CSTS_SHST_MASK = 0x3 << CSTS_SHST_SHIFT;
 static constexpr u8 CC_IOSQES_BIT = 16;
 static constexpr u8 CC_IOCQES_BIT = 20;
+
+static constexpr u32 CSTS_SHST(u32 x)
+{
+    return (x & CSTS_SHST_MASK) >> CSTS_SHST_SHIFT;
+}
 
 static constexpr u16 CC_AQA_MASK = (0xfff);
 static constexpr u16 ACQ_SIZE(u32 x)


### PR DESCRIPTION
We need to wait up to CAP.TO units of 500ms when changing CC.EN to
enable or disable the controller.

_This makes the NVME controller reset succeed on my HP Pavilion laptop_