### PR TITLE
Kernel: Some more OOM fixes

### DIFF
--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -398,7 +398,7 @@ public:
     NEVER_INLINE void switch_context(Thread*& from_thread, Thread*& to_thread);
     [[noreturn]] static void assume_context(Thread& thread, FlatPtr flags);
     FlatPtr init_context(Thread& thread, bool leave_crit);
-    static Vector<FlatPtr> capture_stack_trace(Thread& thread, size_t max_frames = 0);
+    static Vector<FlatPtr, 32> capture_stack_trace(Thread& thread, size_t max_frames = 0);
 
     static StringView platform_string();
 };

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -398,7 +398,7 @@ public:
     NEVER_INLINE void switch_context(Thread*& from_thread, Thread*& to_thread);
     [[noreturn]] static void assume_context(Thread& thread, FlatPtr flags);
     FlatPtr init_context(Thread& thread, bool leave_crit);
-    static Vector<FlatPtr, 32> capture_stack_trace(Thread& thread, size_t max_frames = 0);
+    static ErrorOr<Vector<FlatPtr, 32>> capture_stack_trace(Thread& thread, size_t max_frames = 0);
 
     static StringView platform_string();
 };

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -491,7 +491,7 @@ const DescriptorTablePointer& Processor::get_gdtr()
     return m_gdtr;
 }
 
-Vector<FlatPtr> Processor::capture_stack_trace(Thread& thread, size_t max_frames)
+Vector<FlatPtr, 32> Processor::capture_stack_trace(Thread& thread, size_t max_frames)
 {
     FlatPtr frame_ptr = 0, ip = 0;
     Vector<FlatPtr, 32> stack_trace;

--- a/Kernel/ProcessSpecificExposed.cpp
+++ b/Kernel/ProcessSpecificExposed.cpp
@@ -27,7 +27,7 @@ ErrorOr<size_t> Process::procfs_get_thread_stack(ThreadID thread_id, KBufferBuil
         return Error::from_errno(ESRCH);
     bool show_kernel_addresses = Process::current().is_superuser();
     bool kernel_address_added = false;
-    for (auto address : Processor::capture_stack_trace(*thread, 1024)) {
+    for (auto address : TRY(Processor::capture_stack_trace(*thread, 1024))) {
         if (!show_kernel_addresses && !Memory::is_user_address(VirtualAddress { address })) {
             if (kernel_address_added)
                 continue;

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -18,6 +18,7 @@
 #include <Kernel/Scheduler.h>
 #include <Kernel/Sections.h>
 #include <Kernel/Time/TimeManagement.h>
+#include <Kernel/kstdio.h>
 
 // Remove this once SMP is stable and can be enabled by default
 #define SCHEDULE_ON_ALL_PROCESSORS 0
@@ -595,8 +596,14 @@ void dump_thread_list(bool with_stack_traces)
                 thread.times_scheduled());
             break;
         }
-        if (with_stack_traces)
-            dbgln("{}", thread.backtrace());
+        if (with_stack_traces) {
+            auto trace_or_error = thread.backtrace();
+            if (!trace_or_error.is_error()) {
+                auto trace = trace_or_error.release_value();
+                dbgln("Backtrace:");
+                kernelputstr(trace->characters(), trace->length());
+            }
+        }
         return IterationDecision::Continue;
     });
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -27,6 +27,7 @@
 #include <Kernel/Thread.h>
 #include <Kernel/ThreadTracer.h>
 #include <Kernel/TimerQueue.h>
+#include <Kernel/kstdio.h>
 #include <LibC/signal_numbers.h>
 
 namespace Kernel {
@@ -501,8 +502,14 @@ void Thread::finalize()
         m_join_blocker_set.thread_finalizing();
     }
 
-    if (m_dump_backtrace_on_finalization)
-        dbgln("{}", backtrace());
+    if (m_dump_backtrace_on_finalization) {
+        auto trace_or_error = backtrace();
+        if (!trace_or_error.is_error()) {
+            auto trace = trace_or_error.release_value();
+            dbgln("Backtrace:");
+            kernelputstr(trace->characters(), trace->length());
+        }
+    }
 
     drop_thread_count(false);
 }

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -1192,7 +1192,7 @@ ErrorOr<NonnullOwnPtr<KString>> Thread::backtrace()
     Vector<RecognizedSymbol, 128> recognized_symbols;
 
     auto& process = const_cast<Process&>(this->process());
-    auto stack_trace = Processor::capture_stack_trace(*this);
+    auto stack_trace = TRY(Processor::capture_stack_trace(*this));
     VERIFY(!g_scheduler_lock.is_locked_by_current_processor());
     ScopedAddressSpaceSwitcher switcher(process);
     for (auto& frame : stack_trace) {


### PR DESCRIPTION
With these patches applied, and with kmalloc patched to return null instead of panic on allocation failure, we are able to survive `loop { CatDog & }` for around ~5 minutes! (until either WindowServer locks up for some reason, or an infallible allocation somewhere crops up)