### PR TITLE
AK: Mark the error branch of the TRY() macro as unlikely

### DIFF
--- a/AK/Try.h
+++ b/AK/Try.h
@@ -9,12 +9,12 @@
 // NOTE: This macro works with any result type that has the expected APIs.
 //       It's designed with AK::Result and AK::Error in mind.
 
-#define TRY(expression)                               \
-    ({                                                \
-        auto _temporary_result = (expression);        \
-        if (_temporary_result.is_error())             \
-            return _temporary_result.release_error(); \
-        _temporary_result.release_value();            \
+#define TRY(expression)                                \
+    ({                                                 \
+        auto _temporary_result = (expression);         \
+        if (_temporary_result.is_error()) [[unlikely]] \
+            return _temporary_result.release_error();  \
+        _temporary_result.release_value();             \
     })
 
 #define MUST(expression)                       \


### PR DESCRIPTION
This results in a measurable (and free!) 2% improvement in test-js run time.