### PR TITLE
SoundPlayer: Correct wrong FFT visualization

### DIFF
--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -7,6 +7,7 @@
 #include "BarsVisualizationWidget.h"
 #include <AK/Math.h>
 #include <LibDSP/FFT.h>
+#include <LibDSP/Window.h>
 #include <LibGUI/Event.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Painter.h>
@@ -20,51 +21,49 @@ void BarsVisualizationWidget::render(GUI::PaintEvent& event, Vector<double> cons
     painter.add_clip_rect(event.rect());
     painter.fill_rect(frame_inner_rect(), Color::Black);
 
-    for (size_t i = 0; i < samples.size(); i++)
-        m_fft_samples[i] = samples[i];
+    assert(m_fft_samples.size() == FFTSize);
+    for (size_t i = 0; i < FFTSize; i++)
+        m_fft_samples[i] = samples[i] * m_fft_window[i];
 
     LibDSP::fft(m_fft_samples, false);
-    double max = AK::sqrt(samples.size() * 2.);
 
-    double freq_bin = m_samplerate / (double)samples.size();
+    Array<double, BinGroupCount> groups {};
 
-    constexpr int group_count = 60;
-    Vector<double, group_count> groups;
-    groups.resize(group_count);
-    if (m_gfx_falling_bars.size() != group_count) {
-        m_gfx_falling_bars.resize(group_count);
-        for (int& i : m_gfx_falling_bars)
-            i = 0;
+    for (size_t i = 0; i < FFTSize / 2; i += BinsPerGroup) {
+        double const magnitude = m_fft_samples[i].magnitude();
+        groups[i / BinsPerGroup] = magnitude;
+        for (size_t j = 0; j < BinsPerGroup; j++) {
+            double const magnitude = m_fft_samples[i + j].magnitude();
+            groups[i / BinsPerGroup] += magnitude;
+        }
+        groups[i / BinsPerGroup] /= BinsPerGroup;
     }
-    for (double& d : groups)
-        d = 0.;
 
-    int bins_per_group = ceil_div((samples.size() - 1) / 2, group_count);
-    for (size_t i = 1; i < samples.size() / 2; i++) {
-        groups[i / bins_per_group] += AK::abs(m_fft_samples[i].real());
+    double const max_peak_value = AK::sqrt(static_cast<double>(FFTSize));
+    for (size_t i = 0; i < BinGroupCount; i++) {
+        groups[i] = AK::log(groups[i] + 1) / AK::log(max_peak_value);
+        if (m_adjust_frequencies)
+            groups[i] *= 1 + 3.0 * i / BinGroupCount;
     }
-    for (int i = 0; i < group_count; i++)
-        groups[i] /= max * freq_bin / (m_adjust_frequencies ? (clamp(AK::pow(AK::E<double>, (double)i / group_count * 3.) - 1.75, 1., 15.)) : 1.);
 
-    const int horizontal_margin = 30;
-    const int top_vertical_margin = 15;
-    const int pixels_inbetween_groups = frame_inner_rect().width() > 350 ? 5 : 2;
-    int pixel_per_group_width = (frame_inner_rect().width() - horizontal_margin * 2 - pixels_inbetween_groups * (group_count - 1)) / group_count;
-    int max_height = frame_inner_rect().height() - top_vertical_margin;
+    int const horizontal_margin = 30;
+    int const top_vertical_margin = 15;
+    int const pixels_inbetween_groups = frame_inner_rect().width() > 350 ? 5 : 2;
+    int const pixel_per_group_width = (frame_inner_rect().width() - horizontal_margin * 2 - pixels_inbetween_groups * (BinGroupCount - 1)) / BinGroupCount;
+    int const max_height = frame_inner_rect().height() - top_vertical_margin;
     int current_xpos = horizontal_margin;
-    for (int g = 0; g < group_count; g++) {
+    for (size_t g = 0; g < BinGroupCount; g++) {
         m_gfx_falling_bars[g] = AK::min(clamp(max_height - (int)(groups[g] * max_height * 0.8), 0, max_height), m_gfx_falling_bars[g]);
         painter.fill_rect(Gfx::Rect(current_xpos, max_height - (int)(groups[g] * max_height * 0.8), pixel_per_group_width, (int)(groups[g] * max_height * 0.8)), Gfx::Color::from_rgb(0x95d437));
         painter.fill_rect(Gfx::Rect(current_xpos, m_gfx_falling_bars[g], pixel_per_group_width, 2), Gfx::Color::White);
         current_xpos += pixel_per_group_width + pixels_inbetween_groups;
         m_gfx_falling_bars[g] += 3;
     }
-
-    m_is_using_last = false;
 }
 
 BarsVisualizationWidget::BarsVisualizationWidget()
-    : m_is_using_last(false)
+    : m_gfx_falling_bars {}
+    , m_is_using_last(false)
     , m_adjust_frequencies(false)
 {
     m_context_menu = GUI::Menu::construct();
@@ -72,8 +71,11 @@ BarsVisualizationWidget::BarsVisualizationWidget()
         m_adjust_frequencies = action.is_checked();
     }));
 
-    set_render_sample_count(128);
-    m_fft_samples.resize(128);
+    m_fft_window = LibDSP::Window<double>::hann<FFTSize>();
+
+    set_render_sample_count(FFTSize);
+    m_fft_samples.resize(FFTSize);
+    assert(m_fft_samples.size() == FFTSize);
 }
 
 void BarsVisualizationWidget::context_menu_event(GUI::ContextMenuEvent& event)

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -12,9 +12,7 @@
 #include <LibGUI/Painter.h>
 #include <LibGUI/Window.h>
 
-u32 round_previous_power_of_2(u32 x);
-
-void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
+void BarsVisualizationWidget::render(GUI::PaintEvent& event, Vector<double> const& samples)
 {
     GUI::Frame::paint_event(event);
     GUI::Painter painter(*this);
@@ -22,13 +20,13 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
     painter.add_clip_rect(event.rect());
     painter.fill_rect(frame_inner_rect(), Color::Black);
 
-    if (m_sample_buffer.is_empty())
-        return;
+    for (size_t i = 0; i < samples.size(); i++)
+        m_fft_samples[i] = samples[i];
 
-    LibDSP::fft(m_sample_buffer, false);
-    double max = AK::sqrt(m_sample_count * 2.);
+    LibDSP::fft(m_fft_samples, false);
+    double max = AK::sqrt(samples.size() * 2.);
 
-    double freq_bin = m_samplerate / (double)m_sample_count;
+    double freq_bin = m_samplerate / (double)samples.size();
 
     constexpr int group_count = 60;
     Vector<double, group_count> groups;
@@ -41,9 +39,9 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
     for (double& d : groups)
         d = 0.;
 
-    int bins_per_group = ceil_div((m_sample_count - 1) / 2, group_count);
-    for (int i = 1; i < m_sample_count / 2; i++) {
-        groups[i / bins_per_group] += AK::fabs(m_sample_buffer.data()[i].real());
+    int bins_per_group = ceil_div((samples.size() - 1) / 2, group_count);
+    for (size_t i = 1; i < samples.size() / 2; i++) {
+        groups[i / bins_per_group] += AK::abs(m_fft_samples[i].real());
     }
     for (int i = 0; i < group_count; i++)
         groups[i] /= max * freq_bin / (m_adjust_frequencies ? (clamp(AK::pow(AK::E<double>, (double)i / group_count * 3.) - 1.75, 1., 15.)) : 1.);
@@ -65,65 +63,20 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
     m_is_using_last = false;
 }
 
-BarsVisualizationWidget::~BarsVisualizationWidget()
-{
-}
-
 BarsVisualizationWidget::BarsVisualizationWidget()
-    : m_last_id(-1)
-    , m_is_using_last(false)
+    : m_is_using_last(false)
     , m_adjust_frequencies(false)
 {
     m_context_menu = GUI::Menu::construct();
     m_context_menu->add_action(GUI::Action::create_checkable("Adjust frequency energy (for aesthetics)", [&](GUI::Action& action) {
         m_adjust_frequencies = action.is_checked();
     }));
-}
 
-// black magic from Hacker's delight
-u32 round_previous_power_of_2(u32 x)
-{
-    x = x | (x >> 1);
-    x = x | (x >> 2);
-    x = x | (x >> 4);
-    x = x | (x >> 8);
-    x = x | (x >> 16);
-    return x - (x >> 1);
-}
-
-void BarsVisualizationWidget::set_buffer(RefPtr<Audio::Buffer> buffer, int samples_to_use)
-{
-    if (m_is_using_last)
-        return;
-    m_is_using_last = true;
-    // FIXME: We should dynamically adapt to the sample count and e.g. perform the fft over multiple buffers.
-    // For now, the visualizer doesn't work with extremely low global sample rates.
-    if (buffer->sample_count() < 256)
-        return;
-    m_sample_count = round_previous_power_of_2(samples_to_use);
-    m_sample_buffer.resize(m_sample_count);
-    for (int i = 0; i < m_sample_count; i++) {
-        m_sample_buffer.data()[i] = (AK::fabs(buffer->samples()[i].left) + AK::fabs(buffer->samples()[i].right)) / 2.;
-    }
-
-    update();
-}
-
-void BarsVisualizationWidget::set_buffer(RefPtr<Audio::Buffer> buffer)
-{
-    if (buffer.is_null())
-        return;
-    if (m_last_id == buffer->id())
-        return;
-    set_buffer(buffer, buffer->sample_count());
+    set_render_sample_count(128);
+    m_fft_samples.resize(128);
 }
 
 void BarsVisualizationWidget::context_menu_event(GUI::ContextMenuEvent& event)
 {
     m_context_menu->popup(event.screen_position());
-}
-
-void BarsVisualizationWidget::set_samplerate(int samplerate)
-{
-    m_samplerate = samplerate;
 }

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.h
@@ -23,8 +23,13 @@ private:
     void render(GUI::PaintEvent&, Vector<double> const&) override;
     void context_menu_event(GUI::ContextMenuEvent& event) override;
 
+    static constexpr size_t FFTSize = 256;
+    static constexpr size_t BinGroupCount = 64;
+    static constexpr size_t BinsPerGroup = (FFTSize / 2) / BinGroupCount;
+
     Vector<Complex<double>> m_fft_samples;
-    Vector<int> m_gfx_falling_bars;
+    Array<double, FFTSize> m_fft_window;
+    Array<int, BinGroupCount> m_gfx_falling_bars;
     bool m_is_using_last;
     bool m_adjust_frequencies;
     RefPtr<GUI::Menu> m_context_menu;

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.h
@@ -15,22 +15,16 @@ class BarsVisualizationWidget final : public VisualizationWidget {
     C_OBJECT(BarsVisualizationWidget)
 
 public:
-    ~BarsVisualizationWidget() override;
-    void set_buffer(RefPtr<Audio::Buffer> buffer) override;
-    void set_samplerate(int samplerate) override;
+    ~BarsVisualizationWidget() override = default;
 
 private:
     BarsVisualizationWidget();
-    void set_buffer(RefPtr<Audio::Buffer> buffer, int samples_to_use);
 
-    void paint_event(GUI::PaintEvent&) override;
+    void render(GUI::PaintEvent&, Vector<double> const&) override;
     void context_menu_event(GUI::ContextMenuEvent& event) override;
 
-    Vector<Complex<double>> m_sample_buffer;
+    Vector<Complex<double>> m_fft_samples;
     Vector<int> m_gfx_falling_bars;
-    int m_last_id;
-    int m_sample_count;
-    int m_samplerate;
     bool m_is_using_last;
     bool m_adjust_frequencies;
     RefPtr<GUI::Menu> m_context_menu;

--- a/Userland/Applications/SoundPlayer/NoVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/NoVisualizationWidget.cpp
@@ -7,14 +7,6 @@
 #include "NoVisualizationWidget.h"
 #include <LibGUI/Painter.h>
 
-NoVisualizationWidget::NoVisualizationWidget()
-{
-}
-
-NoVisualizationWidget::~NoVisualizationWidget()
-{
-}
-
 void NoVisualizationWidget::paint_event(GUI::PaintEvent& event)
 {
     Frame::paint_event(event);
@@ -23,8 +15,4 @@ void NoVisualizationWidget::paint_event(GUI::PaintEvent& event)
     if (!m_serenity_bg)
         m_serenity_bg = Gfx::Bitmap::try_load_from_file("/res/wallpapers/sunset-retro.png").release_value_but_fixme_should_propagate_errors();
     painter.draw_scaled_bitmap(frame_inner_rect(), *m_serenity_bg, m_serenity_bg->rect(), 1.0f);
-}
-
-void NoVisualizationWidget::set_buffer(RefPtr<Audio::Buffer>)
-{
 }

--- a/Userland/Applications/SoundPlayer/NoVisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/NoVisualizationWidget.h
@@ -14,12 +14,12 @@ class NoVisualizationWidget final : public VisualizationWidget {
     C_OBJECT(NoVisualizationWidget)
 
 public:
-    ~NoVisualizationWidget() override;
-    void set_buffer(RefPtr<Audio::Buffer>) override;
+    ~NoVisualizationWidget() override = default;
 
 private:
+    void render(GUI::PaintEvent&, Vector<double> const&) override { }
     void paint_event(GUI::PaintEvent&) override;
-    NoVisualizationWidget();
+    NoVisualizationWidget() = default;
 
     RefPtr<Gfx::Bitmap> m_serenity_bg;
 };

--- a/Userland/Applications/SoundPlayer/SampleWidget.h
+++ b/Userland/Applications/SoundPlayer/SampleWidget.h
@@ -9,20 +9,12 @@
 #include "VisualizationWidget.h"
 #include <LibGUI/Frame.h>
 
-namespace Audio {
-class Buffer;
-}
-
 class SampleWidget final : public VisualizationWidget {
     C_OBJECT(SampleWidget)
 public:
-    virtual ~SampleWidget() override;
-
-    void set_buffer(RefPtr<Audio::Buffer>) override;
+    virtual ~SampleWidget() override = default;
 
 private:
     SampleWidget();
-    virtual void paint_event(GUI::PaintEvent&) override;
-
-    RefPtr<Audio::Buffer> m_buffer;
+    virtual void render(GUI::PaintEvent&, Vector<double> const& samples) override;
 };

--- a/Userland/Applications/SoundPlayer/VisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/VisualizationWidget.h
@@ -8,15 +8,88 @@
 
 #include <LibAudio/Buffer.h>
 #include <LibGUI/Frame.h>
+#include <LibGUI/Painter.h>
 
 class VisualizationWidget : public GUI::Frame {
     C_OBJECT(VisualizationWidget)
 
 public:
-    virtual void set_buffer(RefPtr<Audio::Buffer> buffer) = 0;
-    virtual void set_samplerate(int) { }
+    virtual void render(GUI::PaintEvent&, Vector<double> const& samples) = 0;
+
+    virtual void set_buffer(RefPtr<Audio::Buffer> buffer)
+    {
+        if (buffer.is_null())
+            return;
+        if (buffer->id() == m_last_buffer_id)
+            return;
+        m_last_buffer_id = buffer->id();
+
+        if (m_sample_buffer.size() != static_cast<size_t>(buffer->sample_count()))
+            m_sample_buffer.resize(buffer->sample_count());
+
+        for (size_t i = 0; i < static_cast<size_t>(buffer->sample_count()); i++)
+            m_sample_buffer.data()[i] = (buffer->samples()[i].left + buffer->samples()[i].right) / 2.;
+
+        m_frame_count = 0;
+    }
+
+    virtual void set_samplerate(int samplerate)
+    {
+        m_samplerate = samplerate;
+    }
+
+    virtual void paint_event(GUI::PaintEvent& event) override
+    {
+        if (m_sample_buffer.size() == 0) {
+            Frame::paint_event(event);
+            GUI::Painter painter(*this);
+            painter.add_clip_rect(event.rect());
+            painter.fill_rect(frame_inner_rect(), Color::Black);
+            return;
+        }
+
+        if (m_render_buffer.size() == 0)
+            return;
+
+        size_t buffer_position = (m_frame_count * RefreshTimeMilliseconds) * m_samplerate / 1000;
+        if (buffer_position + m_render_buffer.size() >= m_sample_buffer.size())
+            buffer_position = m_sample_buffer.size() - m_render_buffer.size();
+
+        for (size_t i = 0; i < m_render_buffer.size(); i++)
+            m_render_buffer[i] = m_sample_buffer[i + buffer_position];
+
+        render(event, m_render_buffer);
+    }
+
+    virtual void timer_event(Core::TimerEvent&) override
+    {
+        update();
+        m_frame_count++;
+    }
+
+    size_t frame_count() const { return m_frame_count; }
+
+    void set_render_sample_count(size_t count)
+    {
+        m_render_buffer.resize(count);
+    }
 
 protected:
-    VisualizationWidget() = default;
+    int m_samplerate;
+    int m_last_buffer_id;
+    size_t m_frame_count;
+    Vector<double> m_sample_buffer;
+    Vector<double> m_render_buffer;
+
+    static constexpr size_t RefreshTimeMilliseconds = 30;
+
+    VisualizationWidget()
+        : m_samplerate(-1)
+        , m_last_buffer_id(-1)
+        , m_frame_count(0)
+    {
+        start_timer(RefreshTimeMilliseconds);
+    }
+
     virtual ~VisualizationWidget() = default;
 };

--- a/Userland/Libraries/LibDSP/Window.h
+++ b/Userland/Libraries/LibDSP/Window.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, Arne Elster (arne@elster.li)
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Math.h>
+#include <AK/Vector.h>
+
+namespace LibDSP {
+
+template<typename T>
+class Window {
+public:
+    template<size_t size>
+    static Array<T, size> hamming() { return make_window<size>(calculate_hamming); }
+    static Vector<T> hamming(size_t size) { return make_window(size, calculate_hamming); }
+
+    template<size_t size>
+    static Array<T, size> hann() { return make_window<size>(calculate_hann); }
+    static Vector<T> hann(size_t size) { return make_window(size, calculate_hann); }
+
+    template<size_t size>
+    static Array<T, size> blackman_harris() { return make_window<size>(calculate_blackman_harris); }
+    static Vector<T> blackman_harris(size_t size) { return make_window(size, calculate_blackman_harris); }
+
+private:
+    double static calculate_hann(size_t index, size_t size)
+    {
+        return 0.5 * (1 - AK::cos((2 * AK::Pi<T> * index) / (size - 1)));
+    }
+
+    double static calculate_hamming(size_t index, size_t size)
+    {
+        return 0.54 - 0.46 * AK::cos((2 * AK::Pi<T> * index) / (size - 1));
+    }
+
+    double static calculate_blackman_harris(size_t index, size_t size)
+    {
+        T const a0 = 0.35875;
+        T const a1 = 0.48829;
+        T const a2 = 0.14128;
+        T const a3 = 0.01168;
+        return a0 - a1 * AK::cos(2 * AK::Pi<T> * index / size) + a2 * AK::cos(4 * AK::Pi<T> * index / size) - a3 * AK::cos(6 * AK::Pi<T> * index / size);
+    }
+
+    template<size_t size>
+    static Array<T, size> make_window(auto window_function)
+    {
+        Array<T, size> result;
+        for (size_t i = 0; i < size; i++) {
+            result[i] = window_function(i, size);
+        }
+        return result;
+    }
+
+    static Vector<T> make_window(size_t size, auto window_function)
+    {
+        Vector<T> result;
+        result.resize(size);
+        for (size_t i = 0; i < size; i++) {
+            result[i] = window_function(i, size);
+        }
+        return result;
+    }
+};
+
+}


### PR DESCRIPTION
Some small things:

- The time samples were `abs()`ed before being transformed, which just adds a DC offset and distorts the spectrum.
- Only the real part of the frequency bins were visualized, therefore encoding phase information in the spectrum. But if you play a single sine wave sound, you expect only a single bar to show in the spectrum, not a bunch.
- No window was applied to the time samples before transformation, so the spectrum had spectral leakage.
- Normalization of the spectrum energy was bogus.
- The FFT visualization would take a whole input buffer and transform it. That ment frames per second would depend on the size of the buffer and would possibly do very big FFTs which can become CPU intensive. So I took a stab at changing the architecture to make many little subsequent FFTs on the same buffer possible.
- Use log scale because it looks nice :-)