### PR TITLE
LibVT: Don't clip TerminalWidget's drawing to avoid scroller

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -265,9 +265,6 @@ void TerminalWidget::paint_event(GUI::PaintEvent& event)
 
     painter.add_clip_rect(event.rect());
 
-    Gfx::IntRect terminal_buffer_rect(frame_inner_rect().top_left(), { frame_inner_rect().width() - m_scrollbar->width(), frame_inner_rect().height() });
-    painter.add_clip_rect(terminal_buffer_rect);
-
     if (visual_beep_active)
         painter.clear_rect(frame_inner_rect(), terminal_color_to_rgb(VT::Color::named(VT::Color::ANSIColor::Red)));
     else


### PR DESCRIPTION
The scroller might be hidden or (in theory) non-opaque.

Addresses #11906.  There's more work to do here to adjust for a hidden scroller (e.g., to allow the terminal to make use of the unoccluded area), but here I'm just addressing the redraw issue.

Incidentally, the original problem actually isn't even avoided by resizing the window.  It's just that the black background of the default theme is also the default fill of the window, so it _looks_ like it goes away.  Changing the terminal theme reveals that resizing the window just replaces the scroller with a black bar:

![image](https://user-images.githubusercontent.com/1477437/149643860-bfec932b-693e-4f37-8171-4f04d228d671.png)