### PR TITLE
Meta: Add support for the Limine bootloader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,11 @@ add_custom_target(grub-image
     BYPRODUCTS ${CMAKE_BINARY_DIR}/grub_disk_image
     USES_TERMINAL
 )
+add_custom_target(limine-image
+    COMMAND ${CMAKE_COMMAND} -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-image-limine.sh"
+    BYPRODUCTS ${CMAKE_BINARY_DIR}/limine_disk_image
+    USES_TERMINAL
+)
 add_custom_target(extlinux-image
     COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-image-extlinux.sh"
     BYPRODUCTS "${CMAKE_BINARY_DIR}/extlinux_disk_image"

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -29,6 +29,7 @@ The `Meta/serenity.sh` script provides an abstraction over the build targets whi
 following build targets cannot be accessed through the script and have to be used directly by changing the current
 directory to `Build/i686` and then running `ninja <target>`:
 
+- `ninja limine-image`: Builds a disk image (`limine_disk_image`) with Limine
 - `ninja grub-image`: Builds a disk image (`grub_disk_image`) with GRUB
 - `ninja extlinux-image`: Builds a disk image (`extlinux_disk_image`) with extlinux
 - `ninja check-style`: Runs the same linters the CI does to verify project style on changed files

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+
+set -e
+
+die() {
+    echo "die: $*"
+    exit 1
+}
+
+if [ ! -d "limine" ]; then
+    echo "limine not found, the script will now build it"
+    git clone --depth 1 --branch v2.74.6 --single-branch https://github.com/limine-bootloader/limine
+    make -C limine
+fi
+
+if [ "$(id -u)" != 0 ]; then
+    exec sudo -E -- "$0" "$@" || die "this script needs to run as root"
+else
+    : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
+fi
+
+disk_usage() {
+    if [ "$(uname -s)" = "Darwin" ]; then
+        du -sm "$1" | cut -f1
+    else
+        du -sm --apparent-size "$1" | cut -f1
+    fi
+}
+
+DISK_SIZE=$(($(disk_usage "$SERENITY_SOURCE_DIR/Base") + $(disk_usage Root) + 300))
+
+echo "setting up disk image..."
+dd if=/dev/zero of=limine_disk_image bs=1M count="${DISK_SIZE:-800}" status=none || die "couldn't create disk image"
+chown "$SUDO_UID":"$SUDO_GID" limine_disk_image || die "couldn't adjust permissions on disk image"
+echo "done"
+
+printf "creating loopback device... "
+dev=$(losetup --find --partscan --show limine_disk_image)
+if [ -z "$dev" ]; then
+    die "couldn't mount loopback device"
+fi
+echo "loopback device is at ${dev}"
+
+cleanup() {
+    if [ -d mnt ]; then
+        printf "unmounting root partition... "
+        umount -R mnt || ( sleep 1 && sync && umount -R mnt )
+        rmdir mnt
+        echo "done"
+    fi
+
+    if [ -d esp ]; then
+        printf "unmounting efi partition... "
+        umount -R esp || ( sleep 1 && sync && umount -R esp )
+        rmdir esp
+        echo "done"
+    fi
+
+    if [ -e "${dev}" ]; then
+        printf "cleaning up loopback device... "
+        losetup -d "${dev}"
+        echo "done"
+    fi
+}
+
+trap cleanup EXIT
+
+printf "creating partition table... "
+parted -s "${dev}" mklabel gpt mkpart EFI fat32 1MiB 10MiB mkpart ROOT ext2 10MiB 100% set 1 esp on || die "couldn't partition disk"
+echo "done"
+
+printf "creating new filesystems... "
+mkfs.vfat -F 32 "${dev}p1" || die "couldn't create efi filesystem"
+mke2fs -q -I 128 "${dev}p2" || die "couldn't create root filesystem"
+echo "done"
+
+printf "mounting filesystems... "
+mkdir -p esp
+mount "${dev}p1" esp || die "couldn't mount efi filesystem"
+mkdir -p mnt
+mount "${dev}p2" mnt || die "couldn't mount root filesystem"
+echo "done"
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+"$script_path/build-root-filesystem.sh"
+
+echo "installing limine"
+cp limine/build/bin/limine.sys esp
+cp "$SERENITY_SOURCE_DIR"/Meta/limine.cfg esp
+limine/build/bin/limine-install "${dev}"
+echo "done"

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -9,8 +9,11 @@ die() {
 
 if [ ! -d "limine" ]; then
     echo "limine not found, the script will now build it"
-    git clone --depth 1 --branch v2.74.6 --single-branch https://github.com/limine-bootloader/limine
-    make -C limine
+    git clone --depth 1 --branch v2.78.2 --single-branch https://github.com/limine-bootloader/limine
+    cd limine
+    ./autogen.sh
+    make all
+    cd ..
 fi
 
 if [ "$(id -u)" != 0 ]; then
@@ -86,8 +89,8 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 
 echo "installing limine"
 mkdir -p esp/EFI/BOOT
-cp limine/build/bin/limine.sys esp
-cp limine/build/bin/BOOTX64.EFI esp/EFI/BOOT
+cp limine/bin/limine.sys esp
+cp limine/bin/BOOTX64.EFI esp/EFI/BOOT
 cp "$SERENITY_SOURCE_DIR"/Meta/limine.cfg esp
-limine/build/bin/limine-install "${dev}"
+limine/bin/limine-install "${dev}"
 echo "done"

--- a/Meta/build-image-limine.sh
+++ b/Meta/build-image-limine.sh
@@ -85,7 +85,9 @@ script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 "$script_path/build-root-filesystem.sh"
 
 echo "installing limine"
+mkdir -p esp/EFI/BOOT
 cp limine/build/bin/limine.sys esp
+cp limine/build/bin/BOOTX64.EFI esp/EFI/BOOT
 cp "$SERENITY_SOURCE_DIR"/Meta/limine.cfg esp
 limine/build/bin/limine-install "${dev}"
 echo "done"

--- a/Meta/limine.cfg
+++ b/Meta/limine.cfg
@@ -1,0 +1,25 @@
+TIMEOUT=3
+
+:SerenityOS (normal)
+PROTOCOL=multiboot1
+CMDLINE=root=/dev/hda2
+KERNEL_PATH=boot://2/boot/Prekernel
+MODULE_PATH=boot://2/boot/Kernel
+
+:SerenityOS (text mode)
+PROTOCOL=multiboot1
+CMDLINE=fbdev=off root=/dev/hda2
+KERNEL_PATH=boot://2/boot/Prekernel
+MODULE_PATH=boot://2/boot/Kernel
+
+:SerenityOS (no ACPI)
+PROTOCOL=multiboot1
+CMDLINE=root=/dev/hda2 acpi=off
+KERNEL_PATH=boot://2/boot/Prekernel
+MODULE_PATH=boot://2/boot/Kernel
+
+:SerenityOS (with serial output)
+PROTOCOL=multiboot1
+CMDLINE=root=/dev/hda2
+KERNEL_PATH=boot://2/boot/Prekernel
+MODULE_PATH=boot://2/boot/Kernel

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -87,6 +87,8 @@ fi
 [ -z "$SERENITY_DISK_IMAGE" ] && {
     if [ "$SERENITY_RUN" = q35grub ] || [ "$SERENITY_RUN" = qgrub ]; then
         SERENITY_DISK_IMAGE="grub_disk_image"
+    elif [ "$SERENITY_RUN" = limine ]; then
+        SERENITY_DISK_IMAGE="limine_disk_image"
     elif [ "$SERENITY_RUN" = qextlinux ]; then
         SERENITY_DISK_IMAGE="extlinux_disk_image"
     else
@@ -368,6 +370,10 @@ elif [ "$SERENITY_RUN" = "q35grub" ]; then
         $SERENITY_VIRT_TECH_ARG \
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
         -device $SERENITY_ETHERNET_DEVICE_TYPE,netdev=breh
+elif [ "$SERENITY_RUN" = "limine" ]; then
+    "$SERENITY_QEMU_BIN" \
+        $SERENITY_COMMON_QEMU_ARGS \
+        $SERENITY_VIRT_TECH_ARG
 elif [ "$SERENITY_RUN" = "ci" ]; then
     # Meta/run.sh ci: qemu in text mode
     echo "Running QEMU in CI"

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -226,6 +226,14 @@ build_target() {
     fi
 }
 
+build_image() {
+    if [ "$SERENITY_RUN" = "limine" ]; then
+        build_target limine-image
+    else
+        build_target image
+    fi
+}
+
 delete_target() {
     [ ! -d "$BUILD_DIR" ] || rm -rf "$BUILD_DIR"
     [ ! -d "$SUPER_BUILD_DIR" ] || rm -rf "$SUPER_BUILD_DIR"
@@ -320,14 +328,14 @@ if [[ "$CMD" =~ ^(build|install|image|copy-src|run|gdb|test|rebuild|recreate|kad
             lagom_unsupported
             build_target
             build_target install
-            build_target image
+            build_image
             ;;
         copy-src)
           lagom_unsupported
           build_target
           build_target install
           export SERENITY_COPY_SOURCE=1
-          build_target image
+          build_image
           ;;
         run)
             if [ "$TARGET" = "lagom" ]; then
@@ -336,7 +344,7 @@ if [[ "$CMD" =~ ^(build|install|image|copy-src|run|gdb|test|rebuild|recreate|kad
             else
                 build_target
                 build_target install
-                build_target image
+                build_image
                 if [ -n "${CMD_ARGS[0]}" ]; then
                     export SERENITY_KERNEL_CMDLINE="${CMD_ARGS[0]}"
                 fi
@@ -352,7 +360,7 @@ if [[ "$CMD" =~ ^(build|install|image|copy-src|run|gdb|test|rebuild|recreate|kad
             else
                 build_target
                 build_target install
-                build_target image
+                build_image
                 tmux new-session "$ARG0" __tmux_cmd "$TARGET" run "${CMD_ARGS[@]}" \; set-option -t 0 mouse on \; split-window "$ARG0" __tmux_cmd "$TARGET" gdb "${CMD_ARGS[@]}" \;
             fi
             ;;
@@ -362,7 +370,7 @@ if [[ "$CMD" =~ ^(build|install|image|copy-src|run|gdb|test|rebuild|recreate|kad
                 run_tests "${CMD_ARGS[0]}"
             else
                 build_target install
-                build_target image
+                build_image
                 # In contrast to CI, we don't set 'panic=shutdown' here,
                 # in case the user wants to inspect qemu some more.
                 export SERENITY_KERNEL_CMDLINE="fbdev=off system_mode=self-test"


### PR DESCRIPTION
This pull request adds support for generating Serenity disk images that use the [Limine bootloader](https://github.com/limine-bootloader/limine). It may be not the best known bootloader, but it is well established and actively maintained. It supports multiboot1/2 protocols as well as it's own boot protocol called "stivale", you can read up more on that [over here](https://github.com/stivale/stivale) :^)

# Why?

That change will be a good starting point to making Serenity run on a wider variety of hardware configurations, for example UEFI-enabled machines. Currently the script that generates a GRUB disk image cannot handle generating a UEFI bootable disk image. With Limine it's trivial to create a single disk image that can be booted on both legacy and UEFI systems due to it's 2 stage design.

# How?

To generate a Limine disk image, export `SERENITY_RUN` with value of "limine", like so:
```
export SERENITY_RUN=limine
```
Now you can simply run `Meta/serenity.sh image` to generate the disk image or `Meta/serenity.sh run` to run the emulator. When running for the first time, the script `Meta/build-image-limine.sh` will clone and compile the bootloader, it's not big so it shouldn't take longer than 15-20 seconds. The generated image will be able to boot in both legacy and UEFI mode, but due to Serenity not playing well with UEFI (yet :eyes:) it's not possible to run the emulator with UEFI support.