### PR TITLE
FileSystemAccessClient: Return `Core::File` instead of raw file descriptor

### DIFF
--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -88,13 +88,9 @@ HexEditorWidget::HexEditorWidget()
     });
 
     m_open_action = GUI::CommonActions::make_open_action([this](auto&) {
-        auto response = FileSystemAccessClient::Client::the().open_file(window()->window_id(), {}, Core::StandardPaths::home_directory(), Core::OpenMode::ReadWrite);
-
-        if (response.error != 0) {
-            if (response.error != -1)
-                GUI::MessageBox::show_error(window(), String::formatted("Opening \"{}\" failed: {}", *response.chosen_file, strerror(response.error)));
+        auto response = FileSystemAccessClient::Client::the().try_open_file(window(), {}, Core::StandardPaths::home_directory(), Core::OpenMode::ReadWrite);
+        if (response.is_error())
             return;
-        }
 
         if (m_document_dirty) {
             auto save_document_first_result = GUI::MessageBox::show(window(), "Save changes to current document first?", "Warning", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::YesNoCancel);
@@ -104,7 +100,7 @@ HexEditorWidget::HexEditorWidget()
                 return;
         }
 
-        open_file(*response.fd, *response.chosen_file);
+        open_file(response.value());
     });
 
     m_save_action = GUI::CommonActions::make_save_action([&](auto&) {
@@ -343,29 +339,11 @@ void HexEditorWidget::update_title()
     window()->set_title(builder.to_string());
 }
 
-void HexEditorWidget::open_file(int fd, String const& path)
+void HexEditorWidget::open_file(NonnullRefPtr<Core::File> file)
 {
-    VERIFY(path.starts_with("/"sv));
-    auto file = Core::File::construct();
-
-    if (!file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes) && file->error() != ENOENT) {
-        GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: {}", path, strerror(errno)), "Error", GUI::MessageBox::Type::Error);
-        return;
-    }
-
-    if (file->is_device()) {
-        GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: Can't open device files", path), "Error", GUI::MessageBox::Type::Error);
-        return;
-    }
-
-    if (file->is_directory()) {
-        GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: Can't open directories", path), "Error", GUI::MessageBox::Type::Error);
-        return;
-    }
-
     m_document_dirty = false;
     m_editor->open_file(file);
-    set_path(path);
+    set_path(file->filename());
 }
 
 bool HexEditorWidget::request_close()
@@ -400,11 +378,9 @@ void HexEditorWidget::drop_event(GUI::DropEvent& event)
         window()->move_to_front();
 
         // TODO: A drop event should be considered user consent for opening a file
-        auto file_response = FileSystemAccessClient::Client::the().request_file(window()->window_id(), urls.first().path(), Core::OpenMode::ReadOnly);
-
-        if (file_response.error != 0)
+        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), urls.first().path(), Core::OpenMode::ReadOnly);
+        if (response.is_error())
             return;
-
-        open_file(*file_response.fd, urls.first().path());
+        open_file(response.value());
     }
 }

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -22,7 +22,7 @@ class HexEditorWidget final : public GUI::Widget {
     C_OBJECT(HexEditorWidget)
 public:
     virtual ~HexEditorWidget() override;
-    void open_file(int fd, String const& path);
+    void open_file(NonnullRefPtr<Core::File>);
     void initialize_menubar(GUI::Window&);
     bool request_close();
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -48,15 +48,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     if (arguments.argc > 1) {
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), arguments.strings[1]);
-
-        if (response.error != 0) {
-            if (response.error != -1)
-                GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", *response.chosen_file, strerror(response.error)));
+        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, arguments.strings[1]);
+        if (response.is_error())
             return 1;
-        }
-
-        hex_editor_widget->open_file(*response.fd, *response.chosen_file);
+        hex_editor_widget->open_file(response.value());
     }
 
     return app->exec();

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -173,38 +173,28 @@ RefPtr<Gfx::Bitmap> Image::try_copy_bitmap(Selection const& selection) const
     return cropped_bitmap_or_error.release_value_but_fixme_should_propagate_errors();
 }
 
-ErrorOr<void> Image::export_bmp_to_fd_and_close(int fd, bool preserve_alpha_channel)
+ErrorOr<void> Image::export_bmp_to_file(Core::File& file, bool preserve_alpha_channel)
 {
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return Error::from_errno(file->error());
-
     auto bitmap_format = preserve_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
     auto bitmap = TRY(try_compose_bitmap(bitmap_format));
 
     Gfx::BMPWriter dumper;
     auto encoded_data = dumper.dump(bitmap);
 
-    if (!file->write(encoded_data.data(), encoded_data.size()))
-        return Error::from_errno(file->error());
+    if (!file.write(encoded_data.data(), encoded_data.size()))
+        return Error::from_errno(file.error());
 
     return {};
 }
 
-ErrorOr<void> Image::export_png_to_fd_and_close(int fd, bool preserve_alpha_channel)
+ErrorOr<void> Image::export_png_to_file(Core::File& file, bool preserve_alpha_channel)
 {
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return Error::from_errno(file->error());
-
     auto bitmap_format = preserve_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
     auto bitmap = TRY(try_compose_bitmap(bitmap_format));
 
     auto encoded_data = Gfx::PNGWriter::encode(*bitmap);
-    if (!file->write(encoded_data.data(), encoded_data.size()))
-        return Error::from_errno(file->error());
+    if (!file.write(encoded_data.data(), encoded_data.size()))
+        return Error::from_errno(file.error());
 
     return {};
 }

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -70,8 +70,8 @@ public:
 
     void serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const;
     ErrorOr<void> write_to_file(String const& file_path) const;
-    ErrorOr<void> export_bmp_to_fd_and_close(int fd, bool preserve_alpha_channel);
-    ErrorOr<void> export_png_to_fd_and_close(int fd, bool preserve_alpha_channel);
+    ErrorOr<void> export_bmp_to_file(Core::File&, bool preserve_alpha_channel);
+    ErrorOr<void> export_png_to_file(Core::File&, bool preserve_alpha_channel);
 
     void move_layer_to_front(Layer&);
     void move_layer_to_back(Layer&);

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -584,12 +584,12 @@ void ImageEditor::save_project()
         save_project_as();
         return;
     }
-    auto response = FileSystemAccessClient::Client::the().request_file(window()->window_id(), path(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
-    if (response.error != 0)
+    auto response = FileSystemAccessClient::Client::the().try_request_file(window(), path(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
+    if (response.is_error())
         return;
-    auto result = save_project_to_fd_and_close(*response.fd);
+    auto result = save_project_to_file(*response.value());
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", *response.chosen_file, result.error()));
+        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", path(), result.error()));
         return;
     }
     undo_stack().set_current_unmodified();
@@ -597,19 +597,20 @@ void ImageEditor::save_project()
 
 void ImageEditor::save_project_as()
 {
-    auto save_result = FileSystemAccessClient::Client::the().save_file(window()->window_id(), "untitled", "pp");
-    if (save_result.error != 0)
+    auto response = FileSystemAccessClient::Client::the().try_save_file(window(), "untitled", "pp");
+    if (response.is_error())
         return;
-    auto result = save_project_to_fd_and_close(*save_result.fd);
+    auto file = response.value();
+    auto result = save_project_to_file(*file);
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", *save_result.chosen_file, result.error()));
+        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", file->filename(), result.error()));
         return;
     }
-    set_path(*save_result.chosen_file);
+    set_path(file->filename());
     undo_stack().set_current_unmodified();
 }
 
-Result<void, String> ImageEditor::save_project_to_fd_and_close(int fd) const
+Result<void, String> ImageEditor::save_project_to_file(Core::File& file) const
 {
     StringBuilder builder;
     JsonObjectSerializer json(builder);
@@ -627,13 +628,8 @@ Result<void, String> ImageEditor::save_project_to_fd_and_close(int fd) const
     json_guides.finish();
     json.finish();
 
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return String { file->error_string() };
-
-    if (!file->write(builder.string_view()))
-        return String { file->error_string() };
+    if (!file.write(builder.string_view()))
+        return String { file.error_string() };
     return {};
 }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -135,7 +135,7 @@ private:
     GUI::MouseEvent event_adjusted_for_layer(GUI::MouseEvent const&, Layer const&) const;
     GUI::MouseEvent event_with_pan_and_scale_applied(GUI::MouseEvent const&) const;
 
-    Result<void, String> save_project_to_fd_and_close(int fd) const;
+    Result<void, String> save_project_to_file(Core::File&) const;
 
     int calculate_ruler_step_size() const;
     Gfx::IntRect mouse_indicator_rect_x() const;

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -35,7 +35,7 @@ public:
 
     void initialize_menubar(GUI::Window&);
 
-    void open_image_fd(int fd, String const& path);
+    void open_image(Core::File&);
     void create_default_image();
 
     bool request_close();

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -254,16 +254,6 @@ Result<Vector<Color>, String> PaletteWidget::load_palette_file(Core::File& file)
     return palette;
 }
 
-Result<Vector<Color>, String> PaletteWidget::load_palette_fd_and_close(int fd)
-{
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return String { file->error_string() };
-
-    return load_palette_file(file);
-}
-
 Result<Vector<Color>, String> PaletteWidget::load_palette_path(String const& file_path)
 {
     auto file_or_error = Core::File::open(file_path, Core::OpenMode::ReadOnly);
@@ -274,20 +264,12 @@ Result<Vector<Color>, String> PaletteWidget::load_palette_path(String const& fil
     return load_palette_file(file);
 }
 
-Result<void, String> PaletteWidget::save_palette_fd_and_close(Vector<Color> palette, int fd)
+Result<void, String> PaletteWidget::save_palette_file(Vector<Color> palette, Core::File& file)
 {
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return String { file->error_string() };
-
     for (auto& color : palette) {
-        file->write(color.to_string_without_alpha());
-        file->write("\n");
+        file.write(color.to_string_without_alpha());
+        file.write("\n");
     }
-
-    file->close();
-
     return {};
 }
 

--- a/Userland/Applications/PixelPaint/PaletteWidget.h
+++ b/Userland/Applications/PixelPaint/PaletteWidget.h
@@ -30,16 +30,14 @@ public:
 
     Vector<Color> colors();
 
-    static Result<Vector<Color>, String> load_palette_fd_and_close(int);
+    static Result<Vector<Color>, String> load_palette_file(Core::File&);
     static Result<Vector<Color>, String> load_palette_path(String const&);
-    static Result<void, String> save_palette_fd_and_close(Vector<Color>, int);
+    static Result<void, String> save_palette_file(Vector<Color>, Core::File&);
     static Vector<Color> fallback_colors();
 
     void set_image_editor(ImageEditor*);
 
 private:
-    static Result<Vector<Color>, String> load_palette_file(Core::File&);
-
     explicit PaletteWidget();
 
     ImageEditor* m_editor { nullptr };

--- a/Userland/Applications/PixelPaint/ProjectLoader.h
+++ b/Userland/Applications/PixelPaint/ProjectLoader.h
@@ -18,7 +18,7 @@ public:
     ProjectLoader() = default;
     ~ProjectLoader() = default;
 
-    ErrorOr<void> try_load_from_fd_and_close(int fd, StringView path);
+    ErrorOr<void> try_load_from_file(Core::File&);
 
     bool is_raw_image() const { return m_is_raw_image; }
     bool has_image() const { return !m_image.is_null(); }

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -71,13 +71,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     if (image_file) {
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), image_file);
-        if (response.error != 0) {
-            if (response.error != -1)
-                GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", *response.chosen_file, strerror(response.error)));
+        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, image_file);
+        if (response.is_error())
             return 1;
-        }
-        main_widget->open_image_fd(*response.fd, *response.chosen_file);
+        main_widget->open_image(response.value());
     } else {
         main_widget->create_default_image();
     }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -11,6 +11,7 @@
 #include <AK/LexicalPath.h>
 #include <LibCore/File.h>
 #include <LibFileSystemAccessClient/Client.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Window.h>
 
 namespace FileSystemAccessClient {
@@ -102,15 +103,141 @@ Result Client::save_file(i32 parent_window_id, String const& name, String const 
     return m_promise->await();
 }
 
-void Client::handle_prompt_end(i32 error, Optional<IPC::File> const& fd, Optional<String> const& chosen_file)
+FileResult Client::try_request_file_read_only_approved(GUI::Window* parent_window, String const& path)
 {
-    VERIFY(m_promise);
+    m_file_promise = Core::Promise<FileResult>::construct();
+    m_promise = nullptr;
+    m_parent_window = parent_window;
 
-    if (error == 0) {
-        m_promise->resolve({ error, fd->take_fd(), *chosen_file });
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    if (path.starts_with('/')) {
+        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, path);
     } else {
-        m_promise->resolve({ error, {}, chosen_file });
+        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
+        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, full_path);
     }
+
+    return m_file_promise->await();
+}
+
+FileResult Client::try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode)
+{
+    m_file_promise = Core::Promise<FileResult>::construct();
+    m_promise = nullptr;
+    m_parent_window = parent_window;
+
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    if (path.starts_with('/')) {
+        async_request_file(parent_window_server_client_id, parent_window_id, path, mode);
+    } else {
+        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
+        async_request_file(parent_window_server_client_id, parent_window_id, full_path, mode);
+    }
+
+    return m_file_promise->await();
+}
+
+FileResult Client::try_open_file(GUI::Window* parent_window, String const& window_title, StringView path, Core::OpenMode requested_access)
+{
+    m_file_promise = Core::Promise<FileResult>::construct();
+    m_promise = nullptr;
+    m_parent_window = parent_window;
+
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    async_prompt_open_file(parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
+
+    return m_file_promise->await();
+}
+
+FileResult Client::try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access)
+{
+    m_file_promise = Core::Promise<FileResult>::construct();
+    m_promise = nullptr;
+    m_parent_window = parent_window;
+
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    async_prompt_save_file(parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
+
+    return m_file_promise->await();
+}
+
+void Client::handle_prompt_end(i32 error, Optional<IPC::File> const& ipc_file, Optional<String> const& chosen_file)
+{
+    if (m_promise) {
+        if (error == 0) {
+            m_promise->resolve({ error, ipc_file->take_fd(), *chosen_file });
+        } else {
+            m_promise->resolve({ error, {}, chosen_file });
+        }
+        return;
+    }
+
+    VERIFY(m_file_promise);
+    if (error != 0) {
+        if (error != -1)
+            GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
+        m_file_promise->resolve(Error::from_errno(error));
+        return;
+    }
+
+    auto file = Core::File::construct();
+    auto fd = ipc_file->take_fd();
+    if (!file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes) && file->error() != ENOENT) {
+        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
+        m_file_promise->resolve(Error::from_errno(file->error()));
+        return;
+    }
+
+    if (file->is_device()) {
+        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
+        m_file_promise->resolve(Error::from_string_literal("Cannot open device files"sv));
+        return;
+    }
+
+    if (file->is_directory()) {
+        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
+        m_file_promise->resolve(Error::from_string_literal("Cannot open directory"sv));
+        return;
+    }
+
+    file->set_filename(move(*chosen_file));
+    m_file_promise->resolve(file);
 }
 
 void Client::die()

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -11,6 +11,7 @@
 #include <LibCore/File.h>
 #include <LibCore/Promise.h>
 #include <LibCore/StandardPaths.h>
+#include <LibGUI/Window.h>
 #include <LibIPC/ServerConnection.h>
 
 namespace FileSystemAccessClient {
@@ -20,6 +21,8 @@ struct Result {
     Optional<i32> fd;
     Optional<String> chosen_file;
 };
+
+using FileResult = ErrorOr<NonnullRefPtr<Core::File>>;
 
 class Client final
     : public IPC::ServerConnection<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
@@ -31,6 +34,11 @@ public:
     Result request_file(i32 parent_window_id, String const& path, Core::OpenMode mode);
     Result open_file(i32 parent_window_id, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
     Result save_file(i32 parent_window_id, String const& name, String const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
+
+    FileResult try_request_file_read_only_approved(GUI::Window* parent_window, String const& path);
+    FileResult try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode);
+    FileResult try_open_file(GUI::Window* parent_window, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
+    FileResult try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
 
     static Client& the();
 
@@ -46,6 +54,8 @@ private:
     virtual void handle_prompt_end(i32 error, Optional<IPC::File> const& fd, Optional<String> const& chosen_file) override;
 
     RefPtr<Core::Promise<Result>> m_promise;
+    RefPtr<Core::Promise<FileResult>> m_file_promise;
+    GUI::Window* m_parent_window { nullptr };
 };
 
 }


### PR DESCRIPTION
## Not complete, want feedback on API changes

Passing around raw file descriptors was getting annoying, and all the applications created a `Core::File` object from this descriptor manually anyway, so this PR attempts to change that.

For now, to now break all applications using the older API, the implementation of the new functions is a bit hacky and repetitive, but that will be cleaned up once all existing applications are ported and the old functions are removed.

---

I've also ported `HexEditor` and `PixelPaint` to use these new APIs as an example before I go and port all the other applications, to get a general feel for what it would look like. Basically, with the new setup `FileSystemAccessClient` takes care of creating a dialog box to show the user error messages if there's any issues opening the file, which cleans stuff up nicely. 

Things I'm looking for feedback on before i work on porting more applications:

- Is `ErrorOr<NonnullRefPtr<Core::File>>` appropriate here? Since FSAC handles all the errors itself, perhaps even just `Optional<NonnullRefPtr<Core::File>>`, or maybe `RefPtr<Core::File>` with possible `nullptr` would work here, since we just want to express either of:
  1. There was an error, and it's been handled, so just return
  2. No errors, here's a `Core::File` you can use
  
- In the places where FSAC is used, I'm often seeing code that looks like below. It's *almost* a `TRY()` call, except we don't really want to return the error but just `return;`. Would there be something I can do to perhaps allow me to use `TRY()` (or something similar) that just returns? I feel like that would be super convenient.
```cpp
auto result = FileSystemAccessClient::...
if (result.is_error())
    return;
do_something(result.value())
```

- Any other general comments on the code so far?