### PR TITLE
HexEditor: Fix crash of copy action when is empty

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "HexEditor.h"
+#include "AK/Format.h"
 #include "SearchResultsModel.h"
 #include <AK/Debug.h>
 #include <AK/ScopeGuard.h>
@@ -157,7 +158,7 @@ bool HexEditor::copy_selected_hex_to_clipboard()
         return false;
 
     StringBuilder output_string_builder;
-    for (size_t i = m_selection_start; i <= m_selection_end; i++)
+    for (size_t i = m_selection_start; i < m_selection_end; i++)
         output_string_builder.appendff("{:02X} ", m_document->get(i).value);
 
     GUI::Clipboard::the().set_plain_text(output_string_builder.to_string());
@@ -170,7 +171,7 @@ bool HexEditor::copy_selected_text_to_clipboard()
         return false;
 
     StringBuilder output_string_builder;
-    for (size_t i = m_selection_start; i <= m_selection_end; i++)
+    for (size_t i = m_selection_start; i < m_selection_end; i++)
         output_string_builder.append(isprint(m_document->get(i).value) ? m_document->get(i).value : '.');
 
     GUI::Clipboard::the().set_plain_text(output_string_builder.to_string());
@@ -183,9 +184,9 @@ bool HexEditor::copy_selected_hex_to_clipboard_as_c_code()
         return false;
 
     StringBuilder output_string_builder;
-    output_string_builder.appendff("unsigned char raw_data[{}] = {{\n", (m_selection_end - m_selection_start) + 1);
+    output_string_builder.appendff("unsigned char raw_data[{}] = {{\n", m_selection_end - m_selection_start);
     output_string_builder.append("    ");
-    for (size_t i = m_selection_start, j = 1; i <= m_selection_end; i++, j++) {
+    for (size_t i = m_selection_start, j = 1; i < m_selection_end; i++, j++) {
         output_string_builder.appendff("{:#02X}", m_document->get(i).value);
         if (i != m_selection_end)
             output_string_builder.append(", ");

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -41,7 +41,7 @@ public:
     bool save();
 
     void select_all();
-    bool has_selection() const { return !((m_selection_end < m_selection_start) || m_document->size()); }
+    bool has_selection() const { return m_selection_start < m_selection_end && m_document->size() > 0; }
     size_t selection_size();
     size_t selection_start_offset() const { return m_selection_start; }
     bool copy_selected_text_to_clipboard();


### PR DESCRIPTION
Closes: #11925

At least the part related to the crash should be fine now.
