### PR TITLE
Ports: Correct the config.sub path for freetype

### DIFF
--- a/Ports/freetype/package.sh
+++ b/Ports/freetype/package.sh
@@ -3,6 +3,7 @@ port=freetype
 version=2.10.4
 useconfigure=true
 use_fresh_config_sub=true
+config_sub_path=builds/unix/config.sub
 files="https://download.savannah.gnu.org/releases/freetype/freetype-${version}.tar.gz freetype-${version}.tar.gz 5eab795ebb23ac77001cfb68b7d4d50b5d6c7469247b0b01b2c953269f658dac"
 auth_type=sha256
 configopts=("--with-brotli=no" "--with-bzip2=no" "--with-zlib=no" "--with-harfbuzz=no" "--with-png=no")


### PR DESCRIPTION
This regressed in cdd6d68, setting the correct path makes it build again.