### PR TITLE
Base: Add icons to man pages for GUI applications

### DIFF
--- a/Base/usr/share/man/man1/CharacterMap.md
+++ b/Base/usr/share/man/man1/CharacterMap.md
@@ -1,6 +1,6 @@
 ## Name
 
-Character Map
+![Icon](/res/icons/16x16/app-character-map.png) Character Map
 
 [Open](file:///bin/CharacterMap)
 
@@ -30,3 +30,4 @@ $ CharacterMap --search "yak"
 ## See Also
 
 * [`FontEditor`(1)](help://man/1/FontEditor) To edit the fonts instead of just viewing them.
+

--- a/Base/usr/share/man/man1/Eyes.md
+++ b/Base/usr/share/man/man1/Eyes.md
@@ -1,6 +1,6 @@
 ## Name
 
-Eyes
+![Icon](/res/icons/16x16/app-eyes.png) Eyes
 
 ## Synopsis
 
@@ -18,3 +18,4 @@ $ Eyes [--num-eyes number] [--max-in-row number] [--grid-rows number] [--grid-co
 * `-c number`, `--grid-cols number`: Number of columns in grid (incompatible with --number)
 
 <!-- Auto-generated through ArgsParser -->
+

--- a/Base/usr/share/man/man1/FontEditor.md
+++ b/Base/usr/share/man/man1/FontEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-FontEditor - Serenity font editor
+![Icon](/res/icons/16x16/app-font-editor.png) FontEditor - Serenity font editor
 
 [Open](file:///bin/FontEditor)
 
@@ -19,3 +19,4 @@ FontEditor is a font editing application for Serenity.
 ```sh
 $ FontEditor /res/fonts/CsillaRegular10.font
 ```
+

--- a/Base/usr/share/man/man1/Help.md
+++ b/Base/usr/share/man/man1/Help.md
@@ -1,6 +1,6 @@
 ## Name
 
-Help
+![Icon](/res/icons/16x16/app-help.png) Help
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/ImageViewer.md
+++ b/Base/usr/share/man/man1/ImageViewer.md
@@ -1,6 +1,6 @@
 ## Name
 
-Image Viewer - SerenityOS image viewer
+![Icon](/res/icons/16x16/filetype-image.png) Image Viewer - SerenityOS image viewer
 
 [Open](file:///bin/ImageViewer)
 
@@ -23,3 +23,4 @@ ImageViewer is an image viewing application for SerenityOS.
 ```sh
 $ ImageViewer /res/graphics/buggie.png
 ```
+

--- a/Base/usr/share/man/man1/Inspector.md
+++ b/Base/usr/share/man/man1/Inspector.md
@@ -1,6 +1,6 @@
 ## Name
 
-Inspector - Serenity process inspector
+![Icon](/res/icons/16x16/app-inspector.png) Inspector - Serenity process inspector
 
 [Open](file:///bin/Inspector)
 
@@ -28,4 +28,3 @@ via UNIX socket.
 ```sh
 $ Inspector $(pidof Shell)
 ```
-

--- a/Base/usr/share/man/man1/Mail.md
+++ b/Base/usr/share/man/man1/Mail.md
@@ -1,6 +1,6 @@
 ## Name
 
-Mail - Serenity e-mail client
+![Icon](/res/icons/16x16/app-mail.png)  Mail - Serenity e-mail client
 
 [Open](file:///bin/Mail)
 

--- a/Base/usr/share/man/man1/Playground.md
+++ b/Base/usr/share/man/man1/Playground.md
@@ -1,6 +1,6 @@
 ## Name
 
-Playground - GUI Markup Language (GML) editor
+![Icon](/res/icons/16x16/app-playground.png) Playground - GUI Markup Language (GML) editor
 
 [Open](file:///bin/Playground)
 
@@ -32,3 +32,4 @@ $ Playground /home/anon/example.gml
 ## See also
 
 * [`gml-format`(1)](help://man/1/gml-format) For automated GML formatting
+

--- a/Base/usr/share/man/man1/Profiler.md
+++ b/Base/usr/share/man/man1/Profiler.md
@@ -1,6 +1,6 @@
 ## Name
 
-Profiler - Serenity process profiler
+![Icon](/res/icons/16x16/app-profiler.png) Profiler - Serenity process profiler
 
 [Open](file:///bin/Profiler)
 

--- a/Base/usr/share/man/man1/Terminal.md
+++ b/Base/usr/share/man/man1/Terminal.md
@@ -1,6 +1,6 @@
 ## Name
 
-Terminal - Serenity terminal emulator
+![Icon](/res/icons/16x16/app-terminal.png) Terminal - Serenity terminal emulator
 
 [Open](file:///bin/Terminal)
 

--- a/Base/usr/share/man/man1/TextEditor.md
+++ b/Base/usr/share/man/man1/TextEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-TextEditor - SerenityOS text editor
+![Icon](/res/icons/16x16/app-text-editor.png) TextEditor - SerenityOS text editor
 
 [Open](file:///bin/TextEditor)
 

--- a/Base/usr/share/man/man6/2048.md
+++ b/Base/usr/share/man/man6/2048.md
@@ -1,6 +1,6 @@
 ## Name
 
-2048
+![Icon](/res/icons/16x16/app-2048.png) 2048
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Breakout.md
+++ b/Base/usr/share/man/man6/Breakout.md
@@ -1,6 +1,6 @@
 ## Name
 
-Breakout
+![Icon](/res/icons/16x16/app-breakout.png) Breakout
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Chess.md
+++ b/Base/usr/share/man/man6/Chess.md
@@ -1,6 +1,6 @@
 ## Name
 
-Chess
+![Icon](/res/icons/16x16/app-chess.png) Chess
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/FlappyBug.md
+++ b/Base/usr/share/man/man6/FlappyBug.md
@@ -1,6 +1,6 @@
 ## Name
 
-Flappy Bug
+![Icon](/res/icons/16x16/app-flappybug.png) Flappy Bug
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/GameOfLife.md
+++ b/Base/usr/share/man/man6/GameOfLife.md
@@ -1,6 +1,6 @@
 ## Name
 
-GameOfLife
+![Icon](/res/icons/16x16/app-gameoflife.png) GameOfLife
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Hearts.md
+++ b/Base/usr/share/man/man6/Hearts.md
@@ -1,6 +1,6 @@
 ## Name
 
-Hearts - The Hearts card game
+![Icon](/res/icons/16x16/app-hearts.png) Hearts - The Hearts card game
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Minesweeper.md
+++ b/Base/usr/share/man/man6/Minesweeper.md
@@ -1,6 +1,6 @@
 ## Name
 
-Minesweeper
+![Icon](/res/icons/16x16/app-minesweeper.png) Minesweeper
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Pong.md
+++ b/Base/usr/share/man/man6/Pong.md
@@ -1,6 +1,6 @@
 ## Name
 
-Pong
+![Icon](/res/icons/16x16/app-pong.png) Pong
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Snake.md
+++ b/Base/usr/share/man/man6/Snake.md
@@ -1,6 +1,6 @@
 ## Name
 
-Snake
+![Icon](/res/icons/16x16/app-snake.png) Snake
 
 ## Synopsis
 


### PR DESCRIPTION
Differentiate terminal and GUI applications with icons next to the name of the application within the man pages of the Help application. I removed the short descriptions after the name of the application as they all seemed to be contained within the description and I feel it helps differentiate them better.

As suggested when @jntrnr revisited Serenity: https://youtu.be/_QAsHkEKvN0?t=480

Previous PR: https://github.com/SerenityOS/serenity/pull/11885

<img width="577" alt="Screen Shot 2022-01-13 at 20 51 31" src="https://user-images.githubusercontent.com/4368524/149437756-7ff0e91c-6653-4d25-93eb-38d3006ccf87.png">
<img width="575" alt="Screen Shot 2022-01-13 at 20 51 48" src="https://user-images.githubusercontent.com/4368524/149437765-778e77c8-d7a5-4bbb-a8d5-70eb612cb34a.png">