### PR TITLE
Documentation: Swap 'Right' and 'Wrong' code practice in CodingStyle.md

### DIFF
--- a/Documentation/CodingStyle.md
+++ b/Documentation/CodingStyle.md
@@ -514,22 +514,6 @@ draw_jpg(); // TODO: Make this code handle jpg in addition to the png support.
 
 Explain *why* the code does something. The code itself should already say what is happening.
 
-###### Wrong:
-
-```cpp
-i++; // Increment i.
-```
-
-```cpp
-// If the user clicks, toggle the timer state.
-catdog_widget.on_click = [&] {
-    if (advice_timer->is_active())
-        advice_timer->stop();
-    else
-        advice_timer->start();
-};
-```
-
 ###### Right:
 
 ```cpp
@@ -550,6 +534,22 @@ catdog_widget.on_click = [&] {
 
 ```cpp
 page_index++;
+```
+
+###### Wrong:
+
+```cpp
+i++; // Increment i.
+```
+
+```cpp
+// If the user clicks, toggle the timer state.
+catdog_widget.on_click = [&] {
+    if (advice_timer->is_active())
+        advice_timer->stop();
+    else
+        advice_timer->start();
+};
 ```
 
 ### Overriding Virtual Methods


### PR DESCRIPTION
Hi! There's a coding style rule in Documentation/CodingStyle.md where the 'Wrong' code practice is **before** the 'Right' one, while everywhere else it's **after** the latter. I believe that it wasn't intended, so here's the fix.