### PR TITLE
readelf: Fix failing to map interpreter for dynamic libraries

### DIFF
--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -311,7 +311,7 @@ int main(int argc, char** argv)
     RefPtr<ELF::DynamicObject> object = nullptr;
 
     if (elf_image.is_dynamic()) {
-        if (interpreter_path.is_null()) {
+        if (interpreter_path.is_empty()) {
             interpreter_path = "/usr/lib/Loader.so"sv;
             warnln("Warning: Dynamic ELF object has no interpreter path. Using: {}", interpreter_path);
         }


### PR DESCRIPTION
Noticed that readelf bailed on dynamic libraries with `Unable to map interpreter file  : `. This happened when an ELF did not have the PT_INTERP header. The `interpreter_path` StringView would then be of the inline capacity of the StringBuilder, not a null StringView. This would cause readelf not to fallback on the default interpreter path.