### PR TITLE
WindowServer: Pick font with glyphs for digits for ScreenNumberOverlay

### DIFF
--- a/Userland/Services/WindowServer/Overlays.cpp
+++ b/Userland/Services/WindowServer/Overlays.cpp
@@ -178,6 +178,12 @@ void ScreenNumberOverlay::pick_font()
         // with default_font.name(). But the default font currently does not provide larger sizes
         auto size = font.glyph_height();
         if (size * 2 <= screen_number_content_rect_size.height() && size > best_font_size) {
+            for (unsigned ch = '0'; ch <= '9'; ch++) {
+                if (!font.contains_glyph(ch)) {
+                    // Skip this font, it doesn't have glyphs for digits
+                    return;
+                }
+            }
             best_font_name = font.qualified_name();
             best_font_size = size;
         }


### PR DESCRIPTION
We want to make sure we pick a font that has at least glyphs defined
for all the digits that we may need to display.

_Fixes this odd looking overlay:_
![Screenshot from 2022-01-16 17-24-36](https://user-images.githubusercontent.com/10320822/149684962-b0d3ed83-b6e0-49e9-b561-2e43c350cd35.png)

