### PR TITLE
LibGL+LibSoftGPU: Implement the stencil buffer

### DIFF
--- a/AK/SIMDExtras.h
+++ b/AK/SIMDExtras.h
@@ -109,6 +109,17 @@ ALWAYS_INLINE static f32x4 load4_masked(float const* a, float const* b, float co
     };
 }
 
+ALWAYS_INLINE static i32x4 load4_masked(u8 const* a, u8 const* b, u8 const* c, u8 const* d, i32x4 mask)
+{
+    int bits = maskbits(mask);
+    return i32x4 {
+        bits & 1 ? *a : 0,
+        bits & 2 ? *b : 0,
+        bits & 4 ? *c : 0,
+        bits & 8 ? *d : 0,
+    };
+}
+
 ALWAYS_INLINE static u32x4 load4_masked(u32 const* a, u32 const* b, u32 const* c, u32 const* d, i32x4 mask)
 {
     int bits = maskbits(mask);

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -98,6 +98,7 @@ extern "C" {
 #define GL_COLOR_MATERIAL 0x0B57
 #define GL_FOG_START 0x0B63
 #define GL_FOG_END 0x0B64
+#define GL_STENCIL_CLEAR_VALUE 0x0B91
 #define GL_MATRIX_MODE 0x0BA0
 #define GL_NORMALIZE 0x0BA1
 #define GL_VIEWPORT 0x0BA2
@@ -605,9 +606,10 @@ GLAPI void glLightModelfv(GLenum pname, GLfloat const* params);
 GLAPI void glLightModeli(GLenum pname, GLint param);
 GLAPI void glStencilFunc(GLenum func, GLint ref, GLuint mask);
 GLAPI void glStencilFuncSeparate(GLenum face, GLenum func, GLint ref, GLuint mask);
+GLAPI void glStencilMask(GLuint mask);
+GLAPI void glStencilMaskSeparate(GLenum face, GLuint mask);
 GLAPI void glStencilOp(GLenum sfail, GLenum dpfail, GLenum dppass);
 GLAPI void glStencilOpSeparate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass);
-GLAPI void glStencilMask(GLuint mask);
 GLAPI void glNormal3f(GLfloat nx, GLfloat ny, GLfloat nz);
 GLAPI void glNormal3fv(GLfloat const* v);
 GLAPI void glNormalPointer(GLenum type, GLsizei stride, void const* pointer);

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -97,6 +97,7 @@ public:
     virtual void gl_pixel_storei(GLenum pname, GLint param) = 0;
     virtual void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height) = 0;
     virtual void gl_stencil_func_separate(GLenum face, GLenum func, GLint ref, GLuint mask) = 0;
+    virtual void gl_stencil_mask_separate(GLenum face, GLuint mask) = 0;
     virtual void gl_stencil_op_separate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass) = 0;
     virtual void gl_normal(GLfloat nx, GLfloat ny, GLfloat nz) = 0;
     virtual void gl_normal_pointer(GLenum type, GLsizei stride, void const* pointer) = 0;

--- a/Userland/Libraries/LibGL/GLStencil.cpp
+++ b/Userland/Libraries/LibGL/GLStencil.cpp
@@ -36,5 +36,10 @@ void glStencilOpSeparate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass
 
 void glStencilMask(GLuint mask)
 {
-    dbgln("(STUBBED) glStencilMask(0x{:08x})", mask);
+    g_gl_context->gl_stencil_mask_separate(GL_FRONT_AND_BACK, mask);
+}
+
+void glStencilMaskSeparate(GLenum face, GLuint mask)
+{
+    g_gl_context->gl_stencil_mask_separate(face, mask);
 }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -3249,7 +3249,7 @@ void SoftwareGLContext::gl_lightf(GLenum light, GLenum pname, GLfloat param)
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_lightf, light, pname, param);
 
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
-    RETURN_WITH_ERROR_IF(light < GL_LIGHT0 || light >= (GL_LIGHT0 + m_rasterizer.info().num_lights), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(light < GL_LIGHT0 || light >= (GL_LIGHT0 + m_device_info.num_lights), GL_INVALID_ENUM);
     RETURN_WITH_ERROR_IF(!(pname == GL_CONSTANT_ATTENUATION || pname == GL_LINEAR_ATTENUATION || pname == GL_QUADRATIC_ATTENUATION || pname != GL_SPOT_EXPONENT || pname != GL_SPOT_CUTOFF), GL_INVALID_ENUM);
 
     auto& light_state = m_light_states.at(light - GL_LIGHT0);
@@ -3281,7 +3281,7 @@ void SoftwareGLContext::gl_lightfv(GLenum light, GLenum pname, GLfloat const* pa
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_lightfv, light, pname, params);
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
-    RETURN_WITH_ERROR_IF(light < GL_LIGHT0 || light >= (GL_LIGHT0 + m_rasterizer.info().num_lights), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(light < GL_LIGHT0 || light >= (GL_LIGHT0 + m_device_info.num_lights), GL_INVALID_ENUM);
     RETURN_WITH_ERROR_IF(!(pname == GL_AMBIENT || pname == GL_DIFFUSE || pname == GL_SPECULAR || pname == GL_POSITION || pname == GL_CONSTANT_ATTENUATION || pname == GL_LINEAR_ATTENUATION || pname == GL_QUADRATIC_ATTENUATION || pname == GL_SPOT_CUTOFF || pname == GL_SPOT_EXPONENT || pname == GL_SPOT_DIRECTION), GL_INVALID_ENUM);
 
     auto& light_state = m_light_states.at(light - GL_LIGHT0);

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -2635,9 +2635,9 @@ void SoftwareGLContext::gl_stencil_func_separate(GLenum face, GLenum func, GLint
 
     StencilFunctionOptions new_options = { func, ref, mask };
     if (face == GL_FRONT || face == GL_FRONT_AND_BACK)
-        m_stencil_frontfacing_func = new_options;
+        m_stencil_function[Face::Front] = new_options;
     if (face == GL_BACK || face == GL_FRONT_AND_BACK)
-        m_stencil_backfacing_func = new_options;
+        m_stencil_function[Face::Back] = new_options;
 }
 
 void SoftwareGLContext::gl_stencil_op_separate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass)
@@ -2677,9 +2677,9 @@ void SoftwareGLContext::gl_stencil_op_separate(GLenum face, GLenum sfail, GLenum
 
     StencilOperationOptions new_options = { sfail, dpfail, dppass };
     if (face == GL_FRONT || face == GL_FRONT_AND_BACK)
-        m_stencil_frontfacing_op = new_options;
+        m_stencil_operation[Face::Front] = new_options;
     if (face == GL_BACK || face == GL_FRONT_AND_BACK)
-        m_stencil_backfacing_op = new_options;
+        m_stencil_operation[Face::Back] = new_options;
 }
 
 void SoftwareGLContext::gl_normal(GLfloat nx, GLfloat ny, GLfloat nz)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -165,7 +165,9 @@ Optional<ContextParameter> SoftwareGLContext::get_context_parameter(GLenum name)
         return ContextParameter { .type = GL_BOOL, .is_capability = true, .value = { .boolean_value = scissor_enabled } };
     }
     case GL_STENCIL_BITS:
-        return ContextParameter { .type = GL_INT, .value = { .integer_value = sizeof(float) * 8 } };
+        return ContextParameter { .type = GL_INT, .value = { .integer_value = m_device_info.stencil_bits } };
+    case GL_STENCIL_CLEAR_VALUE:
+        return ContextParameter { .type = GL_INT, .value = { .integer_value = m_clear_stencil } };
     case GL_STENCIL_TEST:
         return ContextParameter { .type = GL_BOOL, .is_capability = true, .value = { .boolean_value = m_stencil_test_enabled } };
     case GL_TEXTURE_1D:
@@ -239,9 +241,8 @@ void SoftwareGLContext::gl_clear(GLbitfield mask)
     if (mask & GL_DEPTH_BUFFER_BIT)
         m_rasterizer.clear_depth(static_cast<float>(m_clear_depth));
 
-    // FIXME: implement GL_STENCIL_BUFFER_BIT
     if (mask & GL_STENCIL_BUFFER_BIT)
-        dbgln_if(GL_DEBUG, "gl_clear(): GL_STENCIL_BUFFER_BIT is unimplemented");
+        m_rasterizer.clear_stencil(m_clear_stencil);
 }
 
 void SoftwareGLContext::gl_clear_color(GLclampf red, GLclampf green, GLclampf blue, GLclampf alpha)
@@ -268,9 +269,7 @@ void SoftwareGLContext::gl_clear_stencil(GLint s)
 
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
-    // FIXME: "s is masked with 2^m - 1 , where m is the number of bits in the stencil buffer"
-
-    m_clear_stencil = s;
+    m_clear_stencil = static_cast<u8>(s & ((1 << m_device_info.stencil_bits) - 1));
 }
 
 void SoftwareGLContext::gl_color(GLdouble r, GLdouble g, GLdouble b, GLdouble a)
@@ -697,6 +696,8 @@ void SoftwareGLContext::gl_enable(GLenum capability)
         break;
     case GL_STENCIL_TEST:
         m_stencil_test_enabled = true;
+        rasterizer_options.enable_stencil_test = true;
+        update_rasterizer_options = true;
         break;
     case GL_TEXTURE_1D:
         m_active_texture_unit->set_texture_1d_enabled(true);
@@ -808,6 +809,8 @@ void SoftwareGLContext::gl_disable(GLenum capability)
         break;
     case GL_STENCIL_TEST:
         m_stencil_test_enabled = false;
+        rasterizer_options.enable_stencil_test = false;
+        update_rasterizer_options = true;
         break;
     case GL_TEXTURE_1D:
         m_active_texture_unit->set_texture_1d_enabled(false);
@@ -2631,13 +2634,28 @@ void SoftwareGLContext::gl_stencil_func_separate(GLenum face, GLenum func, GLint
                              || func == GL_ALWAYS),
         GL_INVALID_ENUM);
 
-    // FIXME: "ref is clamped to the range 02^n - 1 , where n is the number of bitplanes in the stencil buffer"
+    ref = clamp(ref, 0, (1 << m_device_info.stencil_bits) - 1);
 
     StencilFunctionOptions new_options = { func, ref, mask };
     if (face == GL_FRONT || face == GL_FRONT_AND_BACK)
         m_stencil_function[Face::Front] = new_options;
     if (face == GL_BACK || face == GL_FRONT_AND_BACK)
         m_stencil_function[Face::Back] = new_options;
+
+    m_stencil_configuration_dirty = true;
+}
+
+void SoftwareGLContext::gl_stencil_mask_separate(GLenum face, GLuint mask)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_stencil_mask_separate, face, mask);
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+
+    if (face == GL_FRONT || face == GL_FRONT_AND_BACK)
+        m_stencil_operation[Face::Front].write_mask = mask;
+    if (face == GL_BACK || face == GL_FRONT_AND_BACK)
+        m_stencil_operation[Face::Back].write_mask = mask;
+
+    m_stencil_configuration_dirty = true;
 }
 
 void SoftwareGLContext::gl_stencil_op_separate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass)
@@ -2647,39 +2665,26 @@ void SoftwareGLContext::gl_stencil_op_separate(GLenum face, GLenum sfail, GLenum
 
     RETURN_WITH_ERROR_IF(!(face == GL_FRONT || face == GL_BACK || face == GL_FRONT_AND_BACK), GL_INVALID_ENUM);
 
-    RETURN_WITH_ERROR_IF(!(sfail == GL_KEEP
-                             || sfail == GL_ZERO
-                             || sfail == GL_REPLACE
-                             || sfail == GL_INCR
-                             || sfail == GL_INCR_WRAP
-                             || sfail == GL_DECR
-                             || sfail == GL_DECR_WRAP
-                             || sfail == GL_INVERT),
-        GL_INVALID_ENUM);
-    RETURN_WITH_ERROR_IF(!(dpfail == GL_KEEP
-                             || dpfail == GL_ZERO
-                             || dpfail == GL_REPLACE
-                             || dpfail == GL_INCR
-                             || dpfail == GL_INCR_WRAP
-                             || dpfail == GL_DECR
-                             || dpfail == GL_DECR_WRAP
-                             || dpfail == GL_INVERT),
-        GL_INVALID_ENUM);
-    RETURN_WITH_ERROR_IF(!(dppass == GL_KEEP
-                             || dppass == GL_ZERO
-                             || dppass == GL_REPLACE
-                             || dppass == GL_INCR
-                             || dppass == GL_INCR_WRAP
-                             || dppass == GL_DECR
-                             || dppass == GL_DECR_WRAP
-                             || dppass == GL_INVERT),
-        GL_INVALID_ENUM);
+    auto is_valid_op = [](GLenum op) -> bool {
+        return op == GL_KEEP || op == GL_ZERO || op == GL_REPLACE || op == GL_INCR || op == GL_INCR_WRAP
+            || op == GL_DECR || op == GL_DECR_WRAP || op == GL_INVERT;
+    };
+    RETURN_WITH_ERROR_IF(!is_valid_op(sfail), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(!is_valid_op(dpfail), GL_INVALID_ENUM);
+    RETURN_WITH_ERROR_IF(!is_valid_op(dppass), GL_INVALID_ENUM);
 
-    StencilOperationOptions new_options = { sfail, dpfail, dppass };
+    auto update_stencil_operation = [&](Face face, GLenum sfail, GLenum dpfail, GLenum dppass) {
+        auto& stencil_operation = m_stencil_operation[face];
+        stencil_operation.op_fail = sfail;
+        stencil_operation.op_depth_fail = dpfail;
+        stencil_operation.op_pass = dppass;
+    };
     if (face == GL_FRONT || face == GL_FRONT_AND_BACK)
-        m_stencil_operation[Face::Front] = new_options;
+        update_stencil_operation(Face::Front, sfail, dpfail, dppass);
     if (face == GL_BACK || face == GL_FRONT_AND_BACK)
-        m_stencil_operation[Face::Back] = new_options;
+        update_stencil_operation(Face::Back, sfail, dpfail, dppass);
+
+    m_stencil_configuration_dirty = true;
 }
 
 void SoftwareGLContext::gl_normal(GLfloat nx, GLfloat ny, GLfloat nz)
@@ -2908,6 +2913,7 @@ void SoftwareGLContext::sync_device_config()
     sync_device_sampler_config();
     sync_device_texcoord_config();
     sync_light_state();
+    sync_stencil_configuration();
 }
 
 void SoftwareGLContext::sync_device_sampler_config()
@@ -3168,6 +3174,74 @@ void SoftwareGLContext::sync_device_texcoord_config()
     options.texcoord_generation_enabled_coordinates = enabled_coordinates;
 
     m_rasterizer.set_options(options);
+}
+
+void SoftwareGLContext::sync_stencil_configuration()
+{
+    if (!m_stencil_configuration_dirty)
+        return;
+    m_stencil_configuration_dirty = false;
+
+    auto set_device_stencil = [&](SoftGPU::Face face, StencilFunctionOptions func, StencilOperationOptions op) {
+        SoftGPU::StencilConfiguration device_configuration;
+
+        // Stencil test function
+        auto map_func = [](GLenum func) -> SoftGPU::StencilTestFunction {
+            switch (func) {
+            case GL_ALWAYS:
+                return SoftGPU::StencilTestFunction::Always;
+            case GL_EQUAL:
+                return SoftGPU::StencilTestFunction::Equal;
+            case GL_GEQUAL:
+                return SoftGPU::StencilTestFunction::GreaterOrEqual;
+            case GL_GREATER:
+                return SoftGPU::StencilTestFunction::Greater;
+            case GL_LESS:
+                return SoftGPU::StencilTestFunction::Less;
+            case GL_LEQUAL:
+                return SoftGPU::StencilTestFunction::LessOrEqual;
+            case GL_NEVER:
+                return SoftGPU::StencilTestFunction::Never;
+            case GL_NOTEQUAL:
+                return SoftGPU::StencilTestFunction::NotEqual;
+            }
+            VERIFY_NOT_REACHED();
+        };
+        device_configuration.test_function = map_func(func.func);
+        device_configuration.reference_value = func.reference_value;
+        device_configuration.test_mask = func.mask;
+
+        // Stencil operation
+        auto map_operation = [](GLenum operation) -> SoftGPU::StencilOperation {
+            switch (operation) {
+            case GL_DECR:
+                return SoftGPU::StencilOperation::Decrement;
+            case GL_DECR_WRAP:
+                return SoftGPU::StencilOperation::DecrementWrap;
+            case GL_INCR:
+                return SoftGPU::StencilOperation::Increment;
+            case GL_INCR_WRAP:
+                return SoftGPU::StencilOperation::IncrementWrap;
+            case GL_INVERT:
+                return SoftGPU::StencilOperation::Invert;
+            case GL_KEEP:
+                return SoftGPU::StencilOperation::Keep;
+            case GL_REPLACE:
+                return SoftGPU::StencilOperation::Replace;
+            case GL_ZERO:
+                return SoftGPU::StencilOperation::Zero;
+            }
+            VERIFY_NOT_REACHED();
+        };
+        device_configuration.on_stencil_test_fail = map_operation(op.op_fail);
+        device_configuration.on_depth_test_fail = map_operation(op.op_depth_fail);
+        device_configuration.on_pass = map_operation(op.op_pass);
+        device_configuration.write_mask = op.write_mask;
+
+        m_rasterizer.set_stencil_configuration(face, device_configuration);
+    };
+    set_device_stencil(SoftGPU::Face::Front, m_stencil_function[Face::Front], m_stencil_operation[Face::Front]);
+    set_device_stencil(SoftGPU::Face::Back, m_stencil_function[Face::Back], m_stencil_operation[Face::Back]);
 }
 
 void SoftwareGLContext::gl_lightf(GLenum light, GLenum pname, GLfloat param)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -41,7 +41,7 @@ struct ContextParameter {
     } value;
 };
 
-enum MaterialFace : u8 {
+enum Face {
     Front = 0,
     Back = 1,
 };

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -128,6 +128,7 @@ public:
     virtual void gl_pixel_storei(GLenum pname, GLint param) override;
     virtual void gl_scissor(GLint x, GLint y, GLsizei width, GLsizei height) override;
     virtual void gl_stencil_func_separate(GLenum face, GLenum func, GLint ref, GLuint mask) override;
+    virtual void gl_stencil_mask_separate(GLenum face, GLuint mask) override;
     virtual void gl_stencil_op_separate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass) override;
     virtual void gl_normal(GLfloat nx, GLfloat ny, GLfloat nz) override;
     virtual void gl_normal_pointer(GLenum type, GLsizei stride, void const* pointer) override;
@@ -154,6 +155,7 @@ private:
     void sync_device_sampler_config();
     void sync_device_texcoord_config();
     void sync_light_state();
+    void sync_stencil_configuration();
 
     template<typename T>
     T* store_in_listing(T value)
@@ -195,7 +197,7 @@ private:
 
     FloatVector4 m_clear_color { 0.0f, 0.0f, 0.0f, 0.0f };
     double m_clear_depth { 1.0 };
-    GLint m_clear_stencil { 0 };
+    u8 m_clear_stencil { 0 };
 
     FloatVector4 m_current_vertex_color = { 1.0f, 1.0f, 1.0f, 1.0f };
     FloatVector4 m_current_vertex_tex_coord = { 0.0f, 0.0f, 0.0f, 1.0f };
@@ -225,6 +227,7 @@ private:
 
     // Stencil configuration
     bool m_stencil_test_enabled { false };
+    bool m_stencil_configuration_dirty { true };
 
     struct StencilFunctionOptions {
         GLenum func { GL_ALWAYS };
@@ -237,6 +240,7 @@ private:
         GLenum op_fail { GL_KEEP };
         GLenum op_depth_fail { GL_KEEP };
         GLenum op_pass { GL_KEEP };
+        GLuint write_mask { NumericLimits<GLuint>::max() };
     };
     Array<StencilOperationOptions, 2u> m_stencil_operation;
 
@@ -360,6 +364,7 @@ private:
             decltype(&SoftwareGLContext::gl_polygon_offset),
             decltype(&SoftwareGLContext::gl_scissor),
             decltype(&SoftwareGLContext::gl_stencil_func_separate),
+            decltype(&SoftwareGLContext::gl_stencil_mask_separate),
             decltype(&SoftwareGLContext::gl_stencil_op_separate),
             decltype(&SoftwareGLContext::gl_normal),
             decltype(&SoftwareGLContext::gl_raster_pos),

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -231,16 +231,14 @@ private:
         GLint reference_value { 0 };
         GLuint mask { NumericLimits<GLuint>::max() };
     };
-    StencilFunctionOptions m_stencil_backfacing_func;
-    StencilFunctionOptions m_stencil_frontfacing_func;
+    Array<StencilFunctionOptions, 2u> m_stencil_function;
 
     struct StencilOperationOptions {
         GLenum op_fail { GL_KEEP };
         GLenum op_depth_fail { GL_KEEP };
         GLenum op_pass { GL_KEEP };
     };
-    StencilOperationOptions m_stencil_backfacing_op;
-    StencilOperationOptions m_stencil_frontfacing_op;
+    Array<StencilOperationOptions, 2u> m_stencil_operation;
 
     GLenum m_current_read_buffer = GL_BACK;
     GLenum m_current_draw_buffer = GL_BACK;

--- a/Userland/Libraries/LibSoftGPU/CMakeLists.txt
+++ b/Userland/Libraries/LibSoftGPU/CMakeLists.txt
@@ -4,6 +4,7 @@ set(SOURCES
     Device.cpp
     Image.cpp
     Sampler.cpp
+    StencilBuffer.cpp
 )
 
 add_compile_options(-Wno-psabi)

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1143,9 +1143,9 @@ void Device::set_light_state(unsigned int light_id, Light const& light)
     m_lights.at(light_id) = light;
 }
 
-void Device::set_material_state(unsigned int material_id, Material const& material)
+void Device::set_material_state(Face face, Material const& material)
 {
-    m_materials.at(material_id) = material;
+    m_materials[face] = material;
 }
 
 void Device::set_raster_position(RasterPosition const& raster_position)

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -118,7 +119,7 @@ public:
 
     void set_sampler_config(unsigned, SamplerConfig const&);
     void set_light_state(unsigned, Light const&);
-    void set_material_state(unsigned, Material const&);
+    void set_material_state(Face, Material const&);
 
     RasterPosition raster_position() const { return m_raster_position; }
     void set_raster_position(RasterPosition const& raster_position);

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -10,6 +10,7 @@
 #include <AK/Array.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/OwnPtr.h>
+#include <AK/Vector.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Matrix3x3.h>
 #include <LibGfx/Matrix4x4.h>
@@ -26,6 +27,7 @@
 #include <LibSoftGPU/Light/Light.h>
 #include <LibSoftGPU/Light/Material.h>
 #include <LibSoftGPU/Sampler.h>
+#include <LibSoftGPU/StencilBuffer.h>
 #include <LibSoftGPU/Triangle.h>
 #include <LibSoftGPU/Vertex.h>
 
@@ -38,6 +40,7 @@ struct TexCoordGenerationConfig {
 
 struct RasterizerOptions {
     bool shade_smooth { true };
+    bool enable_stencil_test { false };
     bool enable_depth_test { false };
     bool enable_depth_write { true };
     bool enable_alpha_test { false };
@@ -94,6 +97,17 @@ struct RasterPosition {
     FloatVector4 texture_coordinates { 0.0f, 0.0f, 0.0f, 1.0f };
 };
 
+struct StencilConfiguration {
+    StencilTestFunction test_function;
+    u8 reference_value;
+    u8 test_mask;
+
+    StencilOperation on_stencil_test_fail;
+    StencilOperation on_depth_test_fail;
+    StencilOperation on_pass;
+    u8 write_mask;
+};
+
 class Device final {
 public:
     Device(const Gfx::IntSize& min_size);
@@ -104,6 +118,7 @@ public:
     void resize(const Gfx::IntSize& min_size);
     void clear_color(const FloatVector4&);
     void clear_depth(float);
+    void clear_stencil(u8);
     void blit_to(Gfx::Bitmap&);
     void blit_to_color_buffer_at_raster_position(Gfx::Bitmap const&);
     void blit_to_depth_buffer_at_raster_position(Vector<float> const&, size_t, size_t);
@@ -120,6 +135,7 @@ public:
     void set_sampler_config(unsigned, SamplerConfig const&);
     void set_light_state(unsigned, Light const&);
     void set_material_state(Face, Material const&);
+    void set_stencil_configuration(Face, StencilConfiguration const&);
 
     RasterPosition raster_position() const { return m_raster_position; }
     void set_raster_position(RasterPosition const& raster_position);
@@ -128,15 +144,16 @@ public:
 private:
     void draw_statistics_overlay(Gfx::Bitmap&);
     Gfx::IntRect raster_rect_in_target_coordinates(Gfx::IntSize size);
+    Gfx::IntRect window_coordinates_to_target_coordinates(Gfx::IntRect const&);
 
     void rasterize_triangle(const Triangle& triangle);
     void setup_blend_factors();
     void shade_fragments(PixelQuad&);
     bool test_alpha(PixelQuad&);
 
-private:
     RefPtr<Gfx::Bitmap> m_render_target;
-    OwnPtr<DepthBuffer> m_depth_buffer;
+    NonnullOwnPtr<DepthBuffer> m_depth_buffer;
+    NonnullOwnPtr<StencilBuffer> m_stencil_buffer;
     RasterizerOptions m_options;
     LightModelParameters m_lighting_model;
     Clipper m_clipper;
@@ -149,6 +166,7 @@ private:
     Array<Light, NUM_LIGHTS> m_lights;
     Array<Material, 2u> m_materials;
     RasterPosition m_raster_position;
+    Array<StencilConfiguration, 2u> m_stencil_configuration;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/DeviceInfo.h
+++ b/Userland/Libraries/LibSoftGPU/DeviceInfo.h
@@ -15,6 +15,7 @@ struct DeviceInfo final {
     String device_name;
     unsigned num_texture_units;
     unsigned num_lights;
+    u8 stencil_bits;
 };
 
 }

--- a/Userland/Libraries/LibSoftGPU/Enums.h
+++ b/Userland/Libraries/LibSoftGPU/Enums.h
@@ -87,6 +87,28 @@ enum class PrimitiveType {
     Quads,
 };
 
+enum StencilOperation {
+    Decrement,
+    DecrementWrap,
+    Increment,
+    IncrementWrap,
+    Invert,
+    Keep,
+    Replace,
+    Zero,
+};
+
+enum StencilTestFunction {
+    Always,
+    Equal,
+    Greater,
+    GreaterOrEqual,
+    Less,
+    LessOrEqual,
+    Never,
+    NotEqual,
+};
+
 enum TexCoordGenerationCoordinate {
     None = 0x0,
     S = 0x1,

--- a/Userland/Libraries/LibSoftGPU/Enums.h
+++ b/Userland/Libraries/LibSoftGPU/Enums.h
@@ -58,6 +58,11 @@ enum class DepthTestFunction {
     Greater,
 };
 
+enum Face {
+    Front = 0,
+    Back = 1,
+};
+
 enum FogMode {
     Linear,
     Exp,

--- a/Userland/Libraries/LibSoftGPU/StencilBuffer.cpp
+++ b/Userland/Libraries/LibSoftGPU/StencilBuffer.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibSoftGPU/StencilBuffer.h>
+
+namespace SoftGPU {
+
+ErrorOr<NonnullOwnPtr<StencilBuffer>> StencilBuffer::try_create(Gfx::IntSize const& size)
+{
+    auto rect = Gfx::IntRect { 0, 0, size.width(), size.height() };
+    auto data = TRY(FixedArray<u8>::try_create(size.area()));
+    return adopt_own(*new StencilBuffer(rect, move(data)));
+}
+
+StencilBuffer::StencilBuffer(Gfx::IntRect const& rect, FixedArray<u8> data)
+    : m_data(move(data))
+    , m_rect(rect)
+{
+}
+
+void StencilBuffer::clear(Gfx::IntRect rect, u8 value)
+{
+    rect.intersect(m_rect);
+
+    for (int y = rect.top(); y <= rect.bottom(); ++y) {
+        auto* line = scanline(y);
+        for (int x = rect.left(); x <= rect.right(); ++x)
+            line[x] = value;
+    }
+}
+
+u8* StencilBuffer::scanline(int y)
+{
+    VERIFY(m_rect.contains_vertically(y));
+    return &m_data[y * m_rect.width()];
+}
+
+}

--- a/Userland/Libraries/LibSoftGPU/StencilBuffer.h
+++ b/Userland/Libraries/LibSoftGPU/StencilBuffer.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2021, Jelle Raaijmakers <jelle@gmta.nl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/FixedArray.h>
+#include <AK/NonnullOwnPtr.h>
+#include <AK/Try.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/Size.h>
+
+namespace SoftGPU {
+
+class StencilBuffer final {
+public:
+    static ErrorOr<NonnullOwnPtr<StencilBuffer>> try_create(Gfx::IntSize const& size);
+
+    void clear(Gfx::IntRect rect, u8 value);
+    Gfx::IntRect const& rect() const { return m_rect; }
+    u8* scanline(int y);
+
+private:
+    StencilBuffer(Gfx::IntRect const& rect, FixedArray<u8> data);
+
+    FixedArray<u8> m_data;
+    Gfx::IntRect m_rect;
+};
+
+}


### PR DESCRIPTION
Implement an 8-bit stencil buffer in LibGL and LibSoftGPU.

This allows Grim Fandango to cut off dynamic shadows where they should not be (see example below, set monitor brightness to full power).

Before stencil buffer support:
![image](https://user-images.githubusercontent.com/3210731/149685221-94ea0734-d41a-4669-b0a6-bb4f7a46ef54.png)

After stencil buffer support:
![image](https://user-images.githubusercontent.com/3210731/149685250-7268220a-12b5-425c-8547-0f8411edae44.png)
