### PR TITLE
AK+Everywhere+Kernel: Make Bitmap OOM-aware, use this to propagate more errors in the Kernel

### DIFF
--- a/Kernel/Bus/PCI/Controller/HostBridge.cpp
+++ b/Kernel/Bus/PCI/Controller/HostBridge.cpp
@@ -19,7 +19,7 @@ NonnullOwnPtr<HostBridge> HostBridge::must_create_with_io_access()
 
 HostBridge::HostBridge(PCI::Domain const& domain)
     : HostController(domain)
-    , m_enumerated_buses(256, false)
+    , m_enumerated_buses(Bitmap::must_create_but_fixme_should_propagate_errors(256, false))
 {
 }
 

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -254,7 +254,7 @@ NonnullRefPtr<PhysicalPage> AnonymousVMObject::allocate_committed_page(Badge<Reg
 Bitmap& AnonymousVMObject::ensure_cow_map()
 {
     if (m_cow_map.is_null())
-        m_cow_map = Bitmap { page_count(), true };
+        m_cow_map = Bitmap::must_create_but_fixme_should_propagate_errors(page_count(), true);
     return m_cow_map;
 }
 

--- a/Kernel/Memory/AnonymousVMObject.h
+++ b/Kernel/Memory/AnonymousVMObject.h
@@ -54,8 +54,8 @@ private:
 
     virtual bool is_anonymous() const override { return true; }
 
-    Bitmap& ensure_cow_map();
-    void ensure_or_reset_cow_map();
+    ErrorOr<Bitmap*> try_ensure_cow_map();
+    ErrorOr<void> try_ensure_or_reset_cow_map();
 
     Optional<CommittedPhysicalPageSet> m_unused_committed_pages;
     Bitmap m_cow_map;

--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -12,14 +12,14 @@ namespace Kernel::Memory {
 InodeVMObject::InodeVMObject(Inode& inode, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
     : VMObject(move(new_physical_pages))
     , m_inode(inode)
-    , m_dirty_pages(page_count(), false)
+    , m_dirty_pages(Bitmap::must_create_but_fixme_should_propagate_errors(page_count(), false))
 {
 }
 
 InodeVMObject::InodeVMObject(InodeVMObject const& other, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
     : VMObject(move(new_physical_pages))
     , m_inode(other.m_inode)
-    , m_dirty_pages(page_count(), false)
+    , m_dirty_pages(Bitmap::must_create_but_fixme_should_propagate_errors(page_count(), false))
 {
     for (size_t i = 0; i < page_count(); ++i)
         m_dirty_pages.set(i, other.m_dirty_pages.get(i));

--- a/Tests/AK/TestBitmap.cpp
+++ b/Tests/AK/TestBitmap.cpp
@@ -16,14 +16,14 @@ TEST_CASE(construct_empty)
 
 TEST_CASE(find_first_set)
 {
-    Bitmap bitmap(128, false);
+    Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(128, false);
     bitmap.set(69, true);
     EXPECT_EQ(bitmap.find_first_set().value(), 69u);
 }
 
 TEST_CASE(find_first_unset)
 {
-    Bitmap bitmap(128, true);
+    Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(128, true);
     bitmap.set(51, false);
     EXPECT_EQ(bitmap.find_first_unset().value(), 51u);
 }
@@ -31,7 +31,7 @@ TEST_CASE(find_first_unset)
 TEST_CASE(find_one_anywhere_set)
 {
     {
-        Bitmap bitmap(168, false);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(168, false);
         bitmap.set(34, true);
         bitmap.set(97, true);
         EXPECT_EQ(bitmap.find_one_anywhere_set(0).value(), 34u);
@@ -48,7 +48,7 @@ TEST_CASE(find_one_anywhere_set)
         EXPECT_EQ(bitmap.find_one_anywhere_set(128).value(), 34u);
     }
     {
-        Bitmap bitmap(128 + 24, false);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(128 + 24, false);
         bitmap.set(34, true);
         bitmap.set(126, true);
         EXPECT_EQ(bitmap.find_one_anywhere_set(0).value(), 34u);
@@ -56,7 +56,7 @@ TEST_CASE(find_one_anywhere_set)
         EXPECT_EQ(bitmap.find_one_anywhere_set(64).value(), 126u);
     }
     {
-        Bitmap bitmap(32, false);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(32, false);
         bitmap.set(12, true);
         bitmap.set(24, true);
         auto got = bitmap.find_one_anywhere_set(0).value();
@@ -67,7 +67,7 @@ TEST_CASE(find_one_anywhere_set)
 TEST_CASE(find_one_anywhere_unset)
 {
     {
-        Bitmap bitmap(168, true);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(168, true);
         bitmap.set(34, false);
         bitmap.set(97, false);
         EXPECT_EQ(bitmap.find_one_anywhere_unset(0).value(), 34u);
@@ -84,7 +84,7 @@ TEST_CASE(find_one_anywhere_unset)
         EXPECT_EQ(bitmap.find_one_anywhere_unset(128).value(), 34u);
     }
     {
-        Bitmap bitmap(128 + 24, true);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(128 + 24, true);
         bitmap.set(34, false);
         bitmap.set(126, false);
         EXPECT_EQ(bitmap.find_one_anywhere_unset(0).value(), 34u);
@@ -92,7 +92,7 @@ TEST_CASE(find_one_anywhere_unset)
         EXPECT_EQ(bitmap.find_one_anywhere_unset(64).value(), 126u);
     }
     {
-        Bitmap bitmap(32, true);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(32, true);
         bitmap.set(12, false);
         bitmap.set(24, false);
         auto got = bitmap.find_one_anywhere_unset(0).value();
@@ -102,7 +102,7 @@ TEST_CASE(find_one_anywhere_unset)
 
 TEST_CASE(find_first_range)
 {
-    Bitmap bitmap(128, true);
+    Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(128, true);
     bitmap.set(47, false);
     bitmap.set(48, false);
     bitmap.set(49, false);
@@ -118,7 +118,7 @@ TEST_CASE(find_first_range)
 TEST_CASE(set_range)
 {
     {
-        Bitmap bitmap(128, false);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(128, false);
         bitmap.set_range(41, 10, true);
         EXPECT_EQ(bitmap.get(40), false);
         EXPECT_EQ(bitmap.get(41), true);
@@ -134,7 +134,7 @@ TEST_CASE(set_range)
         EXPECT_EQ(bitmap.get(51), false);
     }
     {
-        Bitmap bitmap(288, false);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(288, false);
         bitmap.set_range(48, 32, true);
         bitmap.set_range(94, 39, true);
         bitmap.set_range(190, 71, true);
@@ -152,12 +152,12 @@ TEST_CASE(set_range)
 TEST_CASE(find_first_fit)
 {
     {
-        Bitmap bitmap(32, true);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(32, true);
         auto fit = bitmap.find_first_fit(1);
         EXPECT_EQ(fit.has_value(), false);
     }
     {
-        Bitmap bitmap(32, true);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(32, true);
         bitmap.set(31, false);
         auto fit = bitmap.find_first_fit(1);
         EXPECT_EQ(fit.has_value(), true);
@@ -165,7 +165,7 @@ TEST_CASE(find_first_fit)
     }
 
     for (size_t i = 0; i < 128; ++i) {
-        Bitmap bitmap(128, true);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(128, true);
         bitmap.set(i, false);
         auto fit = bitmap.find_first_fit(1);
         EXPECT_EQ(fit.has_value(), true);
@@ -173,7 +173,7 @@ TEST_CASE(find_first_fit)
     }
 
     for (size_t i = 0; i < 127; ++i) {
-        Bitmap bitmap(128, true);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(128, true);
         bitmap.set(i, false);
         bitmap.set(i + 1, false);
         auto fit = bitmap.find_first_fit(2);
@@ -184,7 +184,7 @@ TEST_CASE(find_first_fit)
     size_t bitmap_size = 1024;
     for (size_t chunk_size = 1; chunk_size < 64; ++chunk_size) {
         for (size_t i = 0; i < bitmap_size - chunk_size; ++i) {
-            Bitmap bitmap(bitmap_size, true);
+            Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(bitmap_size, true);
             for (size_t c = 0; c < chunk_size; ++c)
                 bitmap.set(i + c, false);
             auto fit = bitmap.find_first_fit(chunk_size);
@@ -196,7 +196,7 @@ TEST_CASE(find_first_fit)
 
 TEST_CASE(find_longest_range_of_unset_bits_edge)
 {
-    Bitmap bitmap(36, true);
+    Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(36, true);
     bitmap.set_range(32, 4, false);
     size_t found_range_size = 0;
     auto result = bitmap.find_longest_range_of_unset_bits(1, found_range_size);
@@ -206,7 +206,7 @@ TEST_CASE(find_longest_range_of_unset_bits_edge)
 
 TEST_CASE(count_in_range)
 {
-    Bitmap bitmap(256, false);
+    Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(256, false);
     bitmap.set(14, true);
     bitmap.set(17, true);
     bitmap.set(19, true);
@@ -252,14 +252,14 @@ TEST_CASE(count_in_range)
 TEST_CASE(byte_aligned_access)
 {
     {
-        Bitmap bitmap(16, true);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(16, true);
         EXPECT_EQ(bitmap.count_in_range(0, 16, true), 16u);
         EXPECT_EQ(bitmap.count_in_range(8, 8, true), 8u);
         EXPECT_EQ(bitmap.count_in_range(0, 8, true), 8u);
         EXPECT_EQ(bitmap.count_in_range(4, 8, true), 8u);
     }
     {
-        Bitmap bitmap(16, false);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(16, false);
         bitmap.set_range(4, 8, true);
         EXPECT_EQ(bitmap.count_in_range(0, 16, true), 8u);
         EXPECT_EQ(bitmap.count_in_range(8, 8, true), 4u);
@@ -267,7 +267,7 @@ TEST_CASE(byte_aligned_access)
         EXPECT_EQ(bitmap.count_in_range(4, 8, true), 8u);
     }
     {
-        Bitmap bitmap(8, false);
+        Bitmap bitmap = Bitmap::must_create_but_fixme_should_propagate_errors(8, false);
         bitmap.set(2, true);
         bitmap.set(4, true);
         EXPECT_EQ(bitmap.count_in_range(0, 2, true), 0u);

--- a/Userland/DevTools/Profiler/Profile.h
+++ b/Userland/DevTools/Profiler/Profile.h
@@ -47,7 +47,7 @@ public:
     void will_track_seen_events(size_t profile_event_count)
     {
         if (m_seen_events.size() != profile_event_count)
-            m_seen_events = Bitmap { profile_event_count, false };
+            m_seen_events = Bitmap::must_create_but_fixme_should_propagate_errors(profile_event_count, false);
     }
     bool has_seen_event(size_t event_index) const { return m_seen_events.get(event_index); }
     void did_see_event(size_t event_index) { m_seen_events.set(event_index, true); }


### PR DESCRIPTION
The first commit makes the allocating constructor of Bitmap into a fallible factory function. Note that the other constructor is still a normal constructor as it can't fail since it doesn't allocate. It's basically only a wrapper around the BitmapView constructor.

The second commit uses the new API to allow for Bitmap allocation to fail when cloning an AnonymousVMObject, thereby increasing OOM safety.

This is work towards #6369.