### PR TITLE
Revert "Base: Add icons to man pages for GUI applications"

### DIFF
--- a/Base/usr/share/man/man1/CharacterMap.md
+++ b/Base/usr/share/man/man1/CharacterMap.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-character-map.png) Character Map
+Character Map
 
 [Open](file:///bin/CharacterMap)
 
@@ -30,4 +30,3 @@ $ CharacterMap --search "yak"
 ## See Also
 
 * [`FontEditor`(1)](help://man/1/FontEditor) To edit the fonts instead of just viewing them.
-

--- a/Base/usr/share/man/man1/Eyes.md
+++ b/Base/usr/share/man/man1/Eyes.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-eyes.png) Eyes
+Eyes
 
 ## Synopsis
 
@@ -18,4 +18,3 @@ $ Eyes [--num-eyes number] [--max-in-row number] [--grid-rows number] [--grid-co
 * `-c number`, `--grid-cols number`: Number of columns in grid (incompatible with --number)
 
 <!-- Auto-generated through ArgsParser -->
-

--- a/Base/usr/share/man/man1/FontEditor.md
+++ b/Base/usr/share/man/man1/FontEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-font-editor.png) FontEditor - Serenity font editor
+FontEditor - Serenity font editor
 
 [Open](file:///bin/FontEditor)
 
@@ -19,4 +19,3 @@ FontEditor is a font editing application for Serenity.
 ```sh
 $ FontEditor /res/fonts/CsillaRegular10.font
 ```
-

--- a/Base/usr/share/man/man1/Help.md
+++ b/Base/usr/share/man/man1/Help.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-help.png) Help
+Help
 
 ## Synopsis
 

--- a/Base/usr/share/man/man1/ImageViewer.md
+++ b/Base/usr/share/man/man1/ImageViewer.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/filetype-image.png) Image Viewer - SerenityOS image viewer
+Image Viewer - SerenityOS image viewer
 
 [Open](file:///bin/ImageViewer)
 
@@ -23,4 +23,3 @@ ImageViewer is an image viewing application for SerenityOS.
 ```sh
 $ ImageViewer /res/graphics/buggie.png
 ```
-

--- a/Base/usr/share/man/man1/Inspector.md
+++ b/Base/usr/share/man/man1/Inspector.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-inspector.png) Inspector - Serenity process inspector
+Inspector - Serenity process inspector
 
 [Open](file:///bin/Inspector)
 
@@ -28,3 +28,4 @@ via UNIX socket.
 ```sh
 $ Inspector $(pidof Shell)
 ```
+

--- a/Base/usr/share/man/man1/Mail.md
+++ b/Base/usr/share/man/man1/Mail.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-mail.png)  Mail - Serenity e-mail client
+Mail - Serenity e-mail client
 
 [Open](file:///bin/Mail)
 

--- a/Base/usr/share/man/man1/Playground.md
+++ b/Base/usr/share/man/man1/Playground.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-playground.png) Playground - GUI Markup Language (GML) editor
+Playground - GUI Markup Language (GML) editor
 
 [Open](file:///bin/Playground)
 
@@ -32,4 +32,3 @@ $ Playground /home/anon/example.gml
 ## See also
 
 * [`gml-format`(1)](help://man/1/gml-format) For automated GML formatting
-

--- a/Base/usr/share/man/man1/Profiler.md
+++ b/Base/usr/share/man/man1/Profiler.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-profiler.png) Profiler - Serenity process profiler
+Profiler - Serenity process profiler
 
 [Open](file:///bin/Profiler)
 

--- a/Base/usr/share/man/man1/Terminal.md
+++ b/Base/usr/share/man/man1/Terminal.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-terminal.png) Terminal - Serenity terminal emulator
+Terminal - Serenity terminal emulator
 
 [Open](file:///bin/Terminal)
 

--- a/Base/usr/share/man/man1/TextEditor.md
+++ b/Base/usr/share/man/man1/TextEditor.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-text-editor.png) TextEditor - SerenityOS text editor
+TextEditor - SerenityOS text editor
 
 [Open](file:///bin/TextEditor)
 

--- a/Base/usr/share/man/man6/2048.md
+++ b/Base/usr/share/man/man6/2048.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-2048.png) 2048
+2048
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Breakout.md
+++ b/Base/usr/share/man/man6/Breakout.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-breakout.png) Breakout
+Breakout
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Chess.md
+++ b/Base/usr/share/man/man6/Chess.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-chess.png) Chess
+Chess
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/FlappyBug.md
+++ b/Base/usr/share/man/man6/FlappyBug.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-flappybug.png) Flappy Bug
+Flappy Bug
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/GameOfLife.md
+++ b/Base/usr/share/man/man6/GameOfLife.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-gameoflife.png) GameOfLife
+GameOfLife
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Hearts.md
+++ b/Base/usr/share/man/man6/Hearts.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-hearts.png) Hearts - The Hearts card game
+Hearts - The Hearts card game
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Minesweeper.md
+++ b/Base/usr/share/man/man6/Minesweeper.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-minesweeper.png) Minesweeper
+Minesweeper
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Pong.md
+++ b/Base/usr/share/man/man6/Pong.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-pong.png) Pong
+Pong
 
 ## Synopsis
 

--- a/Base/usr/share/man/man6/Snake.md
+++ b/Base/usr/share/man/man6/Snake.md
@@ -1,6 +1,6 @@
 ## Name
 
-![Icon](/res/icons/16x16/app-snake.png) Snake
+Snake
 
 ## Synopsis
 


### PR DESCRIPTION
Reverts SerenityOS/serenity#11953

This is breaking in CI with the following error, since the man page is auto generated.

```
Failed: There are missing and/or outdated manpages.
$ git status Base/usr/share/man
HEAD detached at pull/11801/merge
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git restore <file>..." to discard changes in working directory)
	modified:   Base/usr/share/man/man1/Eyes.md

no changes added to commit (use "git add" and/or "git commit -a")
$ git diff Base/usr/share/man
diff --git a/Base/usr/share/man/man1/Eyes.md b/Base/usr/share/man/man1/Eyes.md
index 57e5041..deaf371 100644
--- a/Base/usr/share/man/man1/Eyes.md
Command exited with non-zero status 1
69.15user 1.60system 1:17.55elapsed 91%CPU (0avgtext+0avgdata 1285032maxresident)k
71482inputs+2664outputs (453major+132825minor)pagefaults 0swaps
+++ b/Base/usr/share/man/man1/Eyes.md
@@ -1,6 +1,6 @@
 ## Name
 
(/res/icons/16x16/app-eyes.png) 
Eyes
+Eyes
 
 ## Synopsis
 
@@ -18,4 +18,3 @@ $ Eyes [--num-eyes number] [--max-in-row number] [--grid-rows number] [--grid-co
 * `-c number`, `--grid-cols number`: Number of columns in grid (incompatible with --number)
 
 <!-- Auto-generated through ArgsParser -->
-
You may need to run ./Meta/export-argsparser-manpages.sh on your system and commit/squash the resulting changes.
```