### PR TITLE
Meta: Add Icons to the Online man pages

### DIFF
--- a/Base/usr/share/man/man7/Help-index.md
+++ b/Base/usr/share/man/man7/Help-index.md
@@ -1,4 +1,4 @@
-![Help icon](file:///res/icons/32x32/app-help.png)
+![Help icon](/res/icons/32x32/app-help.png)
 
 ## Welcome to the SerenityOS on-line help system!
 

--- a/Meta/build-manpages-website.sh
+++ b/Meta/build-manpages-website.sh
@@ -105,3 +105,12 @@ pandoc -f gfm -t html5 -s \
 
 # Copy pre-made files
 cp Meta/Websites/man.serenityos.org/banner.png output/
+
+# Copy icons
+mkdir output/icons
+
+while read -r p; do
+  rsync -a --relative Base/res/icons/./"$p" output/icons/
+done < icons.txt
+
+rm icons.txt

--- a/Meta/convert-markdown-links.lua
+++ b/Meta/convert-markdown-links.lua
@@ -3,3 +3,14 @@ function Link(el)
     el.target = string.gsub(el.target, "help://man/([^/]*)/(.*)", "../man%1/%2.html")
     return el
 end
+
+function Image(el)
+    local pattern = "/res/icons/(.*)"
+    local image = string.gsub(el.src, pattern, "%1")
+
+    el.src = "../icons/" .. image
+    file = io.open("icons.txt", "a+")
+    file:write(image .. "\n")
+    file:close()
+    return el
+end


### PR DESCRIPTION
With this PR, icons used in the markdown for the man pages get copied over when building the HTML version.
:eyes: @electrikmilk