### PR TITLE
Kernel: Remove non existent friend class from Process.h

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -121,7 +121,6 @@ public:
 
     friend class Thread;
     friend class Coredump;
-    friend class ProcFSProcessOpenFileDescriptions;
 
     // Helper class to temporarily unprotect a process's protected data so you can write to it.
     class ProtectedDataMutationScope {


### PR DESCRIPTION
clang-tidy correctly flagged that `ProcFSProcessOpenFileDescriptions`
does not exist.