### PR TITLE
FileSystemAccessClient: Return `Core::File` instead of raw file descriptors

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -36,8 +36,7 @@ class GLContextWidget final : public GUI::Frame {
 
 public:
     bool load_path(String const& fname);
-    bool load_fd_and_close(int fd, String const& fname);
-    bool load_file(Core::File& file, String const& fname);
+    bool load_file(Core::File& file);
     void toggle_rotate_x() { m_rotate_x = !m_rotate_x; }
     void toggle_rotate_y() { m_rotate_y = !m_rotate_y; }
     void toggle_rotate_z() { m_rotate_z = !m_rotate_z; }
@@ -248,23 +247,12 @@ bool GLContextWidget::load_path(String const& filename)
         return false;
     }
 
-    return load_file(file, filename);
+    return load_file(file);
 }
 
-bool GLContextWidget::load_fd_and_close(int fd, String const& filename)
+bool GLContextWidget::load_file(Core::File& file)
 {
-    auto file = Core::File::construct();
-
-    if (!file->open(fd, Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes) && file->error() != ENOENT) {
-        GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: {}", filename, strerror(errno)), "Error", GUI::MessageBox::Type::Error);
-        return false;
-    }
-
-    return load_file(file, filename);
-}
-
-bool GLContextWidget::load_file(Core::File& file, String const& filename)
-{
+    auto const& filename = file.filename();
     if (!filename.ends_with(".obj")) {
         GUI::MessageBox::show(window(), String::formatted("Opening \"{}\" failed: invalid file type", filename), "Error", GUI::MessageBox::Type::Error);
         return false;
@@ -300,13 +288,12 @@ bool GLContextWidget::load_file(Core::File& file, String const& filename)
         if (!bitmap_or_error.is_error())
             texture_image = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
     } else {
-        auto result = FileSystemAccessClient::Client::the().request_file(window()->window_id(), builder.string_view(), Core::OpenMode::ReadOnly);
-
-        if (result.error != 0) {
+        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), builder.string_view(), Core::OpenMode::ReadOnly);
+        if (response.is_error())
             return false;
-        }
 
-        auto bitmap_or_error = Gfx::Bitmap::try_load_from_fd_and_close(*result.fd, *result.chosen_file);
+        auto texture_file = response.value();
+        auto bitmap_or_error = Gfx::Bitmap::try_load_from_fd_and_close(texture_file->leak_fd(), texture_file->filename());
         if (!bitmap_or_error.is_error())
             texture_image = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
     }
@@ -360,13 +347,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& file_menu = window->add_menu("&File");
 
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        auto result = FileSystemAccessClient::Client::the().open_file(window->window_id());
-
-        if (result.error != 0)
+        auto response = FileSystemAccessClient::Client::the().try_open_file(window);
+        if (response.is_error())
             return;
 
-        if (widget->load_fd_and_close(*result.fd, *result.chosen_file)) {
-            auto canonical_path = Core::File::absolute_path(*result.chosen_file);
+        auto file = response.value();
+        if (widget->load_file(*file)) {
+            auto canonical_path = Core::File::absolute_path(file->filename());
             window->set_title(String::formatted("{} - 3D File Viewer", canonical_path));
         }
     }));

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -115,13 +115,8 @@ void HexEditor::set_position(size_t position)
     update_status();
 }
 
-bool HexEditor::save_as(int fd)
+bool HexEditor::save_as(NonnullRefPtr<Core::File> new_file)
 {
-    auto new_file = Core::File::construct();
-    if (!new_file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes)) {
-        return false;
-    }
-
     if (m_document->type() == HexDocument::Type::File) {
         HexDocumentFile* fileDocument = static_cast<HexDocumentFile*>(m_document.ptr());
         if (!fileDocument->write_to_file(new_file))

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -37,7 +37,7 @@ public:
     bool open_new_file(size_t size);
     void open_file(NonnullRefPtr<Core::File> file);
     void fill_selection(u8 fill_byte);
-    bool save_as(int fd);
+    bool save_as(NonnullRefPtr<Core::File>);
     bool save();
 
     void select_all();

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -22,7 +22,7 @@ class HexEditorWidget final : public GUI::Widget {
     C_OBJECT(HexEditorWidget)
 public:
     virtual ~HexEditorWidget() override;
-    void open_file(int fd, String const& path);
+    void open_file(NonnullRefPtr<Core::File>);
     void initialize_menubar(GUI::Window&);
     bool request_close();
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -48,15 +48,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     if (arguments.argc > 1) {
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), arguments.strings[1]);
-
-        if (response.error != 0) {
-            if (response.error != -1)
-                GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", *response.chosen_file, strerror(response.error)));
+        // FIXME: Using `try_request_file_read_only_approved` doesn't work here since the file stored in the editor is only readable.
+        auto response = FileSystemAccessClient::Client::the().try_request_file(window, arguments.strings[1], Core::OpenMode::ReadWrite);
+        if (response.is_error())
             return 1;
-        }
-
-        hex_editor_widget->open_file(*response.fd, *response.chosen_file);
+        hex_editor_widget->open_file(response.value());
     }
 
     return app->exec();

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -23,7 +23,7 @@ public:
 
     void initialize_menubar(GUI::Window&);
     void create_toolbar();
-    void open_file(int fd, const String& path);
+    void open_file(Core::File&);
 
 private:
     PDFViewerWidget();

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -38,14 +38,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     if (arguments.argc >= 2) {
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), arguments.argv[1]);
-
-        if (response.error != 0) {
-            if (response.error != -1)
-                GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", *response.chosen_file, strerror(response.error)));
+        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, arguments.argv[1]);
+        if (response.is_error())
             return 1;
-        }
-        pdf_viewer_widget->open_file(*response.fd, *response.chosen_file);
+        pdf_viewer_widget->open_file(*response.value());
     }
 
     return app->exec();

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -173,38 +173,28 @@ RefPtr<Gfx::Bitmap> Image::try_copy_bitmap(Selection const& selection) const
     return cropped_bitmap_or_error.release_value_but_fixme_should_propagate_errors();
 }
 
-ErrorOr<void> Image::export_bmp_to_fd_and_close(int fd, bool preserve_alpha_channel)
+ErrorOr<void> Image::export_bmp_to_file(Core::File& file, bool preserve_alpha_channel)
 {
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return Error::from_errno(file->error());
-
     auto bitmap_format = preserve_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
     auto bitmap = TRY(try_compose_bitmap(bitmap_format));
 
     Gfx::BMPWriter dumper;
     auto encoded_data = dumper.dump(bitmap);
 
-    if (!file->write(encoded_data.data(), encoded_data.size()))
-        return Error::from_errno(file->error());
+    if (!file.write(encoded_data.data(), encoded_data.size()))
+        return Error::from_errno(file.error());
 
     return {};
 }
 
-ErrorOr<void> Image::export_png_to_fd_and_close(int fd, bool preserve_alpha_channel)
+ErrorOr<void> Image::export_png_to_file(Core::File& file, bool preserve_alpha_channel)
 {
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return Error::from_errno(file->error());
-
     auto bitmap_format = preserve_alpha_channel ? Gfx::BitmapFormat::BGRA8888 : Gfx::BitmapFormat::BGRx8888;
     auto bitmap = TRY(try_compose_bitmap(bitmap_format));
 
     auto encoded_data = Gfx::PNGWriter::encode(*bitmap);
-    if (!file->write(encoded_data.data(), encoded_data.size()))
-        return Error::from_errno(file->error());
+    if (!file.write(encoded_data.data(), encoded_data.size()))
+        return Error::from_errno(file.error());
 
     return {};
 }

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -70,8 +70,8 @@ public:
 
     void serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const;
     ErrorOr<void> write_to_file(String const& file_path) const;
-    ErrorOr<void> export_bmp_to_fd_and_close(int fd, bool preserve_alpha_channel);
-    ErrorOr<void> export_png_to_fd_and_close(int fd, bool preserve_alpha_channel);
+    ErrorOr<void> export_bmp_to_file(Core::File&, bool preserve_alpha_channel);
+    ErrorOr<void> export_png_to_file(Core::File&, bool preserve_alpha_channel);
 
     void move_layer_to_front(Layer&);
     void move_layer_to_back(Layer&);

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -589,12 +589,12 @@ void ImageEditor::save_project()
         save_project_as();
         return;
     }
-    auto response = FileSystemAccessClient::Client::the().request_file(window()->window_id(), path(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
-    if (response.error != 0)
+    auto response = FileSystemAccessClient::Client::the().try_request_file(window(), path(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
+    if (response.is_error())
         return;
-    auto result = save_project_to_fd_and_close(*response.fd);
+    auto result = save_project_to_file(*response.value());
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", *response.chosen_file, result.error()));
+        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", path(), result.error()));
         return;
     }
     undo_stack().set_current_unmodified();
@@ -602,19 +602,20 @@ void ImageEditor::save_project()
 
 void ImageEditor::save_project_as()
 {
-    auto save_result = FileSystemAccessClient::Client::the().save_file(window()->window_id(), "untitled", "pp");
-    if (save_result.error != 0)
+    auto response = FileSystemAccessClient::Client::the().try_save_file(window(), "untitled", "pp");
+    if (response.is_error())
         return;
-    auto result = save_project_to_fd_and_close(*save_result.fd);
+    auto file = response.value();
+    auto result = save_project_to_file(*file);
     if (result.is_error()) {
-        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", *save_result.chosen_file, result.error()));
+        GUI::MessageBox::show_error(window(), String::formatted("Could not save {}: {}", file->filename(), result.error()));
         return;
     }
-    set_path(*save_result.chosen_file);
+    set_path(file->filename());
     undo_stack().set_current_unmodified();
 }
 
-Result<void, String> ImageEditor::save_project_to_fd_and_close(int fd) const
+Result<void, String> ImageEditor::save_project_to_file(Core::File& file) const
 {
     StringBuilder builder;
     JsonObjectSerializer json(builder);
@@ -632,13 +633,8 @@ Result<void, String> ImageEditor::save_project_to_fd_and_close(int fd) const
     json_guides.finish();
     json.finish();
 
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return String { file->error_string() };
-
-    if (!file->write(builder.string_view()))
-        return String { file->error_string() };
+    if (!file.write(builder.string_view()))
+        return String { file.error_string() };
     return {};
 }
 

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -135,7 +135,7 @@ private:
     GUI::MouseEvent event_adjusted_for_layer(GUI::MouseEvent const&, Layer const&) const;
     GUI::MouseEvent event_with_pan_and_scale_applied(GUI::MouseEvent const&) const;
 
-    Result<void, String> save_project_to_fd_and_close(int fd) const;
+    Result<void, String> save_project_to_file(Core::File&) const;
 
     int calculate_ruler_step_size() const;
     Gfx::IntRect mouse_indicator_rect_x() const;

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -131,11 +131,10 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         });
 
     m_open_image_action = GUI::CommonActions::make_open_action([&](auto&) {
-        auto result = FileSystemAccessClient::Client::the().open_file(window.window_id());
-        if (result.error != 0)
+        auto response = FileSystemAccessClient::Client::the().try_open_file(&window);
+        if (response.is_error())
             return;
-
-        open_image_fd(*result.fd, *result.chosen_file);
+        open_image(response.value());
     });
 
     m_save_image_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
@@ -163,11 +162,11 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             "As &BMP", [&](auto&) {
                 auto* editor = current_image_editor();
                 VERIFY(editor);
-                auto save_result = FileSystemAccessClient::Client::the().save_file(window.window_id(), "untitled", "bmp");
-                if (save_result.error != 0)
+                auto response = FileSystemAccessClient::Client::the().try_save_file(&window, "untitled", "bmp");
+                if (response.is_error())
                     return;
                 auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
-                auto result = editor->image().export_bmp_to_fd_and_close(*save_result.fd, preserve_alpha_channel == GUI::MessageBox::ExecYes);
+                auto result = editor->image().export_bmp_to_file(response.value(), preserve_alpha_channel == GUI::MessageBox::ExecYes);
                 if (result.is_error())
                     GUI::MessageBox::show_error(&window, String::formatted("Export to BMP failed: {}", result.error()));
             }));
@@ -177,11 +176,12 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             "As &PNG", [&](auto&) {
                 auto* editor = current_image_editor();
                 VERIFY(editor);
-                auto save_result = FileSystemAccessClient::Client::the().save_file(window.window_id(), "untitled", "png");
-                if (save_result.error != 0)
+                // TODO: fix bmp on line below?
+                auto response = FileSystemAccessClient::Client::the().try_save_file(&window, "untitled", "png");
+                if (response.is_error())
                     return;
                 auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
-                auto result = editor->image().export_png_to_fd_and_close(*save_result.fd, preserve_alpha_channel == GUI::MessageBox::ExecYes);
+                auto result = editor->image().export_png_to_file(response.value(), preserve_alpha_channel == GUI::MessageBox::ExecYes);
                 if (result.is_error())
                     GUI::MessageBox::show_error(&window, String::formatted("Export to PNG failed: {}", result.error()));
             }));
@@ -306,11 +306,11 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
     m_edit_menu->add_action(GUI::Action::create(
         "&Load Color Palette", [&](auto&) {
-            auto open_result = FileSystemAccessClient::Client::the().open_file(window.window_id(), "Load Color Palette");
-            if (open_result.error != 0)
+            auto response = FileSystemAccessClient::Client::the().try_open_file(&window, "Load Color Palette");
+            if (response.is_error())
                 return;
 
-            auto result = PixelPaint::PaletteWidget::load_palette_fd_and_close(*open_result.fd);
+            auto result = PixelPaint::PaletteWidget::load_palette_file(*response.value());
             if (result.is_error()) {
                 GUI::MessageBox::show_error(&window, String::formatted("Loading color palette failed: {}", result.error()));
                 return;
@@ -320,11 +320,11 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
     m_edit_menu->add_action(GUI::Action::create(
         "Sa&ve Color Palette", [&](auto&) {
-            auto save_result = FileSystemAccessClient::Client::the().save_file(window.window_id(), "untitled", "palette");
-            if (save_result.error != 0)
+            auto response = FileSystemAccessClient::Client::the().try_save_file(&window, "untitled", "palette");
+            if (response.is_error())
                 return;
 
-            auto result = PixelPaint::PaletteWidget::save_palette_fd_and_close(m_palette_widget->colors(), *save_result.fd);
+            auto result = PixelPaint::PaletteWidget::save_palette_file(m_palette_widget->colors(), *response.value());
             if (result.is_error())
                 GUI::MessageBox::show_error(&window, String::formatted("Writing color palette failed: {}", result.error()));
         }));
@@ -701,18 +701,18 @@ void MainWidget::set_actions_enabled(bool enabled)
     m_zoom_combobox->set_enabled(enabled);
 }
 
-void MainWidget::open_image_fd(int fd, String const& path)
+void MainWidget::open_image(Core::File& file)
 {
-    auto try_load = m_loader.try_load_from_fd_and_close(fd, path);
+    auto try_load = m_loader.try_load_from_file(file);
 
     if (try_load.is_error()) {
-        GUI::MessageBox::show_error(window(), String::formatted("Unable to open file: {}, {}", path, try_load.error()));
+        GUI::MessageBox::show_error(window(), String::formatted("Unable to open file: {}, {}", file.filename(), try_load.error()));
         return;
     }
 
     auto& image = *m_loader.release_image();
     auto& editor = create_new_editor(image);
-    editor.set_path(path);
+    editor.set_path(file.filename());
     editor.undo_stack().set_current_unmodified();
     m_layer_list_widget->set_image(&image);
 }
@@ -863,11 +863,10 @@ void MainWidget::drop_event(GUI::DropEvent& event)
         if (url.protocol() != "file")
             continue;
 
-        auto result = FileSystemAccessClient::Client::the().request_file(window()->window_id(), url.path(), Core::OpenMode::ReadOnly);
-        if (result.error != 0)
-            continue;
-
-        open_image_fd(*result.fd, *result.chosen_file);
+        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), url.path(), Core::OpenMode::ReadOnly);
+        if (response.is_error())
+            return;
+        open_image(response.value());
     }
 }
 }

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -35,7 +35,7 @@ public:
 
     void initialize_menubar(GUI::Window&);
 
-    void open_image_fd(int fd, String const& path);
+    void open_image(Core::File&);
     void create_default_image();
 
     bool request_close();

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -255,16 +255,6 @@ Result<Vector<Color>, String> PaletteWidget::load_palette_file(Core::File& file)
     return palette;
 }
 
-Result<Vector<Color>, String> PaletteWidget::load_palette_fd_and_close(int fd)
-{
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::ReadOnly, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return String { file->error_string() };
-
-    return load_palette_file(file);
-}
-
 Result<Vector<Color>, String> PaletteWidget::load_palette_path(String const& file_path)
 {
     auto file_or_error = Core::File::open(file_path, Core::OpenMode::ReadOnly);
@@ -275,20 +265,12 @@ Result<Vector<Color>, String> PaletteWidget::load_palette_path(String const& fil
     return load_palette_file(file);
 }
 
-Result<void, String> PaletteWidget::save_palette_fd_and_close(Vector<Color> palette, int fd)
+Result<void, String> PaletteWidget::save_palette_file(Vector<Color> palette, Core::File& file)
 {
-    auto file = Core::File::construct();
-    file->open(fd, Core::OpenMode::WriteOnly, Core::File::ShouldCloseFileDescriptor::Yes);
-    if (file->has_error())
-        return String { file->error_string() };
-
     for (auto& color : palette) {
-        file->write(color.to_string_without_alpha());
-        file->write("\n");
+        file.write(color.to_string_without_alpha());
+        file.write("\n");
     }
-
-    file->close();
-
     return {};
 }
 

--- a/Userland/Applications/PixelPaint/PaletteWidget.h
+++ b/Userland/Applications/PixelPaint/PaletteWidget.h
@@ -30,16 +30,14 @@ public:
 
     Vector<Color> colors();
 
-    static Result<Vector<Color>, String> load_palette_fd_and_close(int);
+    static Result<Vector<Color>, String> load_palette_file(Core::File&);
     static Result<Vector<Color>, String> load_palette_path(String const&);
-    static Result<void, String> save_palette_fd_and_close(Vector<Color>, int);
+    static Result<void, String> save_palette_file(Vector<Color>, Core::File&);
     static Vector<Color> fallback_colors();
 
     void set_image_editor(ImageEditor*);
 
 private:
-    static Result<Vector<Color>, String> load_palette_file(Core::File&);
-
     explicit PaletteWidget();
 
     ImageEditor* m_editor { nullptr };

--- a/Userland/Applications/PixelPaint/ProjectLoader.h
+++ b/Userland/Applications/PixelPaint/ProjectLoader.h
@@ -18,7 +18,7 @@ public:
     ProjectLoader() = default;
     ~ProjectLoader() = default;
 
-    ErrorOr<void> try_load_from_fd_and_close(int fd, StringView path);
+    ErrorOr<void> try_load_from_file(Core::File&);
 
     bool is_raw_image() const { return m_is_raw_image; }
     bool has_image() const { return !m_image.is_null(); }

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -71,13 +71,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     if (image_file) {
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), image_file);
-        if (response.error != 0) {
-            if (response.error != -1)
-                GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", *response.chosen_file, strerror(response.error)));
+        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, image_file);
+        if (response.is_error())
             return 1;
-        }
-        main_widget->open_image_fd(*response.fd, *response.chosen_file);
+        main_widget->open_image(response.value());
     } else {
         main_widget->create_default_image();
     }

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -20,7 +20,7 @@ public:
     ~SpreadsheetWidget();
 
     void save(StringView filename);
-    void load_file(int fd, StringView filename);
+    void load_file(Core::File&);
     bool request_close();
     void add_sheet();
     void add_sheet(NonnullRefPtr<Sheet>&&);

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -19,7 +19,7 @@ public:
 
     Result<bool, String> save(StringView filename);
     Result<bool, String> load(StringView filename);
-    Result<bool, String> open_file(int fd, StringView filename);
+    Result<bool, String> open_file(Core::File&);
 
     const String& current_filename() const { return m_current_filename; }
     bool set_filename(const String& filename);

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -94,14 +94,10 @@ int main(int argc, char* argv[])
     window->show();
 
     if (filename) {
-        auto response = FileSystemAccessClient::Client::the().request_file_read_only_approved(window->window_id(), filename);
-
-        if (response.error != 0) {
-            if (response.error != -1)
-                GUI::MessageBox::show_error(window, String::formatted("Opening \"{}\" failed: {}", *response.chosen_file, strerror(response.error)));
+        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, filename);
+        if (response.is_error())
             return 1;
-        }
-        spreadsheet_widget.load_file(*response.fd, filename);
+        spreadsheet_widget.load_file(*response.value());
     }
 
     return app->exec();

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -24,7 +24,7 @@ class MainWidget final : public GUI::Widget {
 
 public:
     virtual ~MainWidget() override;
-    bool read_file_and_close(int fd, String const& path);
+    bool read_file(Core::File&);
     void open_nonexistent_file(String const& path);
     bool request_close();
 

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -25,7 +25,7 @@ public:
 
     const Gfx::Palette& preview_palette() const { return m_preview_palette; }
     void set_preview_palette(const Gfx::Palette&);
-    void set_theme_from_file(String const& path, int fd);
+    void set_theme_from_file(Core::File&);
 
     void set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter>);
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -11,6 +11,7 @@
 #include <AK/LexicalPath.h>
 #include <LibCore/File.h>
 #include <LibFileSystemAccessClient/Client.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/Window.h>
 
 namespace FileSystemAccessClient {
@@ -102,15 +103,143 @@ Result Client::save_file(i32 parent_window_id, String const& name, String const 
     return m_promise->await();
 }
 
-void Client::handle_prompt_end(i32 error, Optional<IPC::File> const& fd, Optional<String> const& chosen_file)
+FileResult Client::try_request_file_read_only_approved(GUI::Window* parent_window, String const& path)
 {
-    VERIFY(m_promise);
+    m_file_promise = Core::Promise<FileResult>::construct();
+    m_promise = nullptr;
+    m_parent_window = parent_window;
 
-    if (error == 0) {
-        m_promise->resolve({ error, fd->take_fd(), *chosen_file });
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    if (path.starts_with('/')) {
+        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, path);
     } else {
-        m_promise->resolve({ error, {}, chosen_file });
+        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
+        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, full_path);
     }
+
+    return m_file_promise->await();
+}
+
+FileResult Client::try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode)
+{
+    m_file_promise = Core::Promise<FileResult>::construct();
+    m_promise = nullptr;
+    m_parent_window = parent_window;
+
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    if (path.starts_with('/')) {
+        async_request_file(parent_window_server_client_id, parent_window_id, path, mode);
+    } else {
+        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
+        async_request_file(parent_window_server_client_id, parent_window_id, full_path, mode);
+    }
+
+    return m_file_promise->await();
+}
+
+FileResult Client::try_open_file(GUI::Window* parent_window, String const& window_title, StringView path, Core::OpenMode requested_access)
+{
+    m_file_promise = Core::Promise<FileResult>::construct();
+    m_promise = nullptr;
+    m_parent_window = parent_window;
+
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    async_prompt_open_file(parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
+
+    return m_file_promise->await();
+}
+
+FileResult Client::try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access)
+{
+    m_file_promise = Core::Promise<FileResult>::construct();
+    m_promise = nullptr;
+    m_parent_window = parent_window;
+
+    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
+    auto child_window_server_client_id = expose_window_server_client_id();
+    auto parent_window_id = parent_window->window_id();
+
+    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+
+    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
+        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
+    });
+
+    async_prompt_save_file(parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
+
+    return m_file_promise->await();
+}
+
+void Client::handle_prompt_end(i32 error, Optional<IPC::File> const& ipc_file, Optional<String> const& chosen_file)
+{
+    if (m_promise) {
+        if (error == 0) {
+            m_promise->resolve({ error, ipc_file->take_fd(), *chosen_file });
+        } else {
+            m_promise->resolve({ error, {}, chosen_file });
+        }
+        return;
+    }
+
+    VERIFY(m_file_promise);
+    if (error != 0) {
+        // We don't want to show an error message for non-existent files since some applications may want
+        // to handle it as opening a new, named file.
+        if (error != -1 && error != ENOENT)
+            GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
+        m_file_promise->resolve(Error::from_errno(error));
+        return;
+    }
+
+    auto file = Core::File::construct();
+    auto fd = ipc_file->take_fd();
+    if (!file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes) && file->error() != ENOENT) {
+        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
+        m_file_promise->resolve(Error::from_errno(file->error()));
+        return;
+    }
+
+    if (file->is_device()) {
+        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
+        m_file_promise->resolve(Error::from_string_literal("Cannot open device files"sv));
+        return;
+    }
+
+    if (file->is_directory()) {
+        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
+        m_file_promise->resolve(Error::from_string_literal("Cannot open directory"sv));
+        return;
+    }
+
+    file->set_filename(move(*chosen_file));
+    m_file_promise->resolve(file);
 }
 
 void Client::die()

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, timmot <tiwwot@protonmail.com>
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,88 +26,9 @@ Client& Client::the()
     return *s_the;
 }
 
-Result Client::request_file_read_only_approved(i32 parent_window_id, String const& path)
+Result Client::try_request_file_read_only_approved(GUI::Window* parent_window, String const& path)
 {
     m_promise = Core::Promise<Result>::construct();
-    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-
-    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    if (path.starts_with('/')) {
-        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, path);
-    } else {
-        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
-        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, full_path);
-    }
-
-    return m_promise->await();
-}
-
-Result Client::request_file(i32 parent_window_id, String const& path, Core::OpenMode mode)
-{
-    m_promise = Core::Promise<Result>::construct();
-    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-
-    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    if (path.starts_with('/')) {
-        async_request_file(parent_window_server_client_id, parent_window_id, path, mode);
-    } else {
-        auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
-        async_request_file(parent_window_server_client_id, parent_window_id, full_path, mode);
-    }
-
-    return m_promise->await();
-}
-
-Result Client::open_file(i32 parent_window_id, String const& window_title, StringView path, Core::OpenMode requested_access)
-{
-    m_promise = Core::Promise<Result>::construct();
-    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-
-    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    async_prompt_open_file(parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
-
-    return m_promise->await();
-}
-
-Result Client::save_file(i32 parent_window_id, String const& name, String const ext, Core::OpenMode requested_access)
-{
-    m_promise = Core::Promise<Result>::construct();
-    auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
-    auto child_window_server_client_id = expose_window_server_client_id();
-
-    GUI::WindowServerConnection::the().async_add_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-
-    ScopeGuard guard([parent_window_id, child_window_server_client_id] {
-        GUI::WindowServerConnection::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
-    });
-
-    async_prompt_save_file(parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
-
-    return m_promise->await();
-}
-
-FileResult Client::try_request_file_read_only_approved(GUI::Window* parent_window, String const& path)
-{
-    m_file_promise = Core::Promise<FileResult>::construct();
-    m_promise = nullptr;
     m_parent_window = parent_window;
 
     auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
@@ -126,13 +48,12 @@ FileResult Client::try_request_file_read_only_approved(GUI::Window* parent_windo
         async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, full_path);
     }
 
-    return m_file_promise->await();
+    return m_promise->await();
 }
 
-FileResult Client::try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode)
+Result Client::try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode)
 {
-    m_file_promise = Core::Promise<FileResult>::construct();
-    m_promise = nullptr;
+    m_promise = Core::Promise<Result>::construct();
     m_parent_window = parent_window;
 
     auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
@@ -152,13 +73,12 @@ FileResult Client::try_request_file(GUI::Window* parent_window, String const& pa
         async_request_file(parent_window_server_client_id, parent_window_id, full_path, mode);
     }
 
-    return m_file_promise->await();
+    return m_promise->await();
 }
 
-FileResult Client::try_open_file(GUI::Window* parent_window, String const& window_title, StringView path, Core::OpenMode requested_access)
+Result Client::try_open_file(GUI::Window* parent_window, String const& window_title, StringView path, Core::OpenMode requested_access)
 {
-    m_file_promise = Core::Promise<FileResult>::construct();
-    m_promise = nullptr;
+    m_promise = Core::Promise<Result>::construct();
     m_parent_window = parent_window;
 
     auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
@@ -173,13 +93,12 @@ FileResult Client::try_open_file(GUI::Window* parent_window, String const& windo
 
     async_prompt_open_file(parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
 
-    return m_file_promise->await();
+    return m_promise->await();
 }
 
-FileResult Client::try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access)
+Result Client::try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access)
 {
-    m_file_promise = Core::Promise<FileResult>::construct();
-    m_promise = nullptr;
+    m_promise = Core::Promise<Result>::construct();
     m_parent_window = parent_window;
 
     auto parent_window_server_client_id = GUI::WindowServerConnection::the().expose_client_id();
@@ -194,27 +113,18 @@ FileResult Client::try_save_file(GUI::Window* parent_window, String const& name,
 
     async_prompt_save_file(parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
 
-    return m_file_promise->await();
+    return m_promise->await();
 }
 
 void Client::handle_prompt_end(i32 error, Optional<IPC::File> const& ipc_file, Optional<String> const& chosen_file)
 {
-    if (m_promise) {
-        if (error == 0) {
-            m_promise->resolve({ error, ipc_file->take_fd(), *chosen_file });
-        } else {
-            m_promise->resolve({ error, {}, chosen_file });
-        }
-        return;
-    }
-
-    VERIFY(m_file_promise);
+    VERIFY(m_promise);
     if (error != 0) {
         // We don't want to show an error message for non-existent files since some applications may want
         // to handle it as opening a new, named file.
         if (error != -1 && error != ENOENT)
             GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
-        m_file_promise->resolve(Error::from_errno(error));
+        m_promise->resolve(Error::from_errno(error));
         return;
     }
 
@@ -222,24 +132,24 @@ void Client::handle_prompt_end(i32 error, Optional<IPC::File> const& ipc_file, O
     auto fd = ipc_file->take_fd();
     if (!file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes) && file->error() != ENOENT) {
         GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
-        m_file_promise->resolve(Error::from_errno(file->error()));
+        m_promise->resolve(Error::from_errno(file->error()));
         return;
     }
 
     if (file->is_device()) {
         GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
-        m_file_promise->resolve(Error::from_string_literal("Cannot open device files"sv));
+        m_promise->resolve(Error::from_string_literal("Cannot open device files"sv));
         return;
     }
 
     if (file->is_directory()) {
         GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
-        m_file_promise->resolve(Error::from_string_literal("Cannot open directory"sv));
+        m_promise->resolve(Error::from_string_literal("Cannot open directory"sv));
         return;
     }
 
     file->set_filename(move(*chosen_file));
-    m_file_promise->resolve(file);
+    m_promise->resolve(file);
 }
 
 void Client::die()

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, timmot <tiwwot@protonmail.com>
+ * Copyright (c) 2022, Mustafa Quraish <mustafa@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,13 +17,7 @@
 
 namespace FileSystemAccessClient {
 
-struct Result {
-    i32 error;
-    Optional<i32> fd;
-    Optional<String> chosen_file;
-};
-
-using FileResult = ErrorOr<NonnullRefPtr<Core::File>>;
+using Result = ErrorOr<NonnullRefPtr<Core::File>>;
 
 class Client final
     : public IPC::ServerConnection<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
@@ -30,15 +25,10 @@ class Client final
     IPC_CLIENT_CONNECTION(Client, "/tmp/portal/filesystemaccess")
 
 public:
-    Result request_file_read_only_approved(i32 parent_window_id, String const& path);
-    Result request_file(i32 parent_window_id, String const& path, Core::OpenMode mode);
-    Result open_file(i32 parent_window_id, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
-    Result save_file(i32 parent_window_id, String const& name, String const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
-
-    FileResult try_request_file_read_only_approved(GUI::Window* parent_window, String const& path);
-    FileResult try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode);
-    FileResult try_open_file(GUI::Window* parent_window, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
-    FileResult try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
+    Result try_request_file_read_only_approved(GUI::Window* parent_window, String const& path);
+    Result try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode);
+    Result try_open_file(GUI::Window* parent_window, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
+    Result try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
 
     static Client& the();
 
@@ -54,7 +44,6 @@ private:
     virtual void handle_prompt_end(i32 error, Optional<IPC::File> const& fd, Optional<String> const& chosen_file) override;
 
     RefPtr<Core::Promise<Result>> m_promise;
-    RefPtr<Core::Promise<FileResult>> m_file_promise;
     GUI::Window* m_parent_window { nullptr };
 };
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -11,6 +11,7 @@
 #include <LibCore/File.h>
 #include <LibCore/Promise.h>
 #include <LibCore/StandardPaths.h>
+#include <LibGUI/Window.h>
 #include <LibIPC/ServerConnection.h>
 
 namespace FileSystemAccessClient {
@@ -20,6 +21,8 @@ struct Result {
     Optional<i32> fd;
     Optional<String> chosen_file;
 };
+
+using FileResult = ErrorOr<NonnullRefPtr<Core::File>>;
 
 class Client final
     : public IPC::ServerConnection<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint>
@@ -31,6 +34,11 @@ public:
     Result request_file(i32 parent_window_id, String const& path, Core::OpenMode mode);
     Result open_file(i32 parent_window_id, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
     Result save_file(i32 parent_window_id, String const& name, String const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
+
+    FileResult try_request_file_read_only_approved(GUI::Window* parent_window, String const& path);
+    FileResult try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode);
+    FileResult try_open_file(GUI::Window* parent_window, String const& window_title = {}, StringView path = Core::StandardPaths::home_directory(), Core::OpenMode requested_access = Core::OpenMode::ReadOnly);
+    FileResult try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access = Core::OpenMode::WriteOnly | Core::OpenMode::Truncate);
 
     static Client& the();
 
@@ -46,6 +54,8 @@ private:
     virtual void handle_prompt_end(i32 error, Optional<IPC::File> const& fd, Optional<String> const& chosen_file) override;
 
     RefPtr<Core::Promise<Result>> m_promise;
+    RefPtr<Core::Promise<FileResult>> m_file_promise;
+    GUI::Window* m_parent_window { nullptr };
 };
 
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1260,19 +1260,17 @@ void TextEditor::timer_event(Core::TimerEvent&)
 
 bool TextEditor::write_to_file(String const& path)
 {
-    int fd = open(path.characters(), O_WRONLY | O_CREAT | O_TRUNC, 0666);
-    if (fd < 0) {
-        perror("open");
+    auto file = Core::File::construct(path);
+    if (!file->open(Core::OpenMode::WriteOnly | Core::OpenMode::Truncate)) {
+        warnln("Error opening {}: {}", path, strerror(file->error()));
         return false;
     }
 
-    return write_to_file_and_close(fd);
+    return write_to_file(*file);
 }
 
-bool TextEditor::write_to_file_and_close(int fd)
+bool TextEditor::write_to_file(Core::File& file)
 {
-    ScopeGuard fd_guard = [fd] { close(fd); };
-
     off_t file_size = 0;
     if (line_count() == 1 && line(0).is_empty()) {
         // Truncate to zero.
@@ -1284,7 +1282,7 @@ bool TextEditor::write_to_file_and_close(int fd)
         file_size += line_count();
     }
 
-    if (ftruncate(fd, file_size) < 0) {
+    if (!file.truncate(file_size)) {
         perror("ftruncate");
         return false;
     }
@@ -1296,14 +1294,14 @@ bool TextEditor::write_to_file_and_close(int fd)
             auto& line = this->line(i);
             if (line.length()) {
                 auto line_as_utf8 = line.to_utf8();
-                ssize_t nwritten = write(fd, line_as_utf8.characters(), line_as_utf8.length());
+                ssize_t nwritten = file.write(line_as_utf8);
                 if (nwritten < 0) {
                     perror("write");
                     return false;
                 }
             }
             char ch = '\n';
-            ssize_t nwritten = write(fd, &ch, 1);
+            ssize_t nwritten = file.write((u8*)&ch, 1);
             if (nwritten != 1) {
                 perror("write");
                 return false;

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -123,7 +123,7 @@ public:
 
     void insert_at_cursor_or_replace_selection(StringView);
     bool write_to_file(String const& path);
-    bool write_to_file_and_close(int fd);
+    bool write_to_file(Core::File&);
     bool has_selection() const { return m_selection.is_valid(); }
     String selected_text() const;
     size_t number_of_words() const;


### PR DESCRIPTION
Passing around raw file descriptors was a bit tedious, and caused each application to have different variants of functions that could handle reading from file descriptors. Most of these applications then manually created a `Core::File` from this file descriptor, and all of them performed essentially identical error checks.

This PR changes `FileSystemAccessClient` so it instead returns `ErrorOr<NonnullRefPtr<Core::File>>` as a result. Additionally, it also performs many of the common error checks (which should have been there were not in some applications) itself before returning to the user, to simplify usage. This makes using FSAC a little bit easier, as well as more robust since we now always check to make sure the opened files aren't actually directories / devices / etc.

Currently the `Error` from the `ErrorOr<...>` is passed back to user programs but never actually used, but it still seems sensible to not omit the information in case the user wants to handle certain errors manually (such as opening a new unsaved file if the file path provided does not exist).

There's still a few more places that can be cleaned up as a result of these changes, but they were not directly affected by this PR and since it's big enough already, I'll save those for another one down the line.

CC: @timmot since you're the original author of FSAC