### PR TITLE
SystemMonitor: Show unknown in PCI devices

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -650,14 +650,14 @@ NonnullRefPtr<GUI::Widget> build_hardware_tab()
                 [db](const JsonObject& object) {
                     auto class_id = object.get("class").to_u32();
                     String class_name = db ? db->get_class(class_id) : nullptr;
-                    return class_name.is_empty() ? String::formatted("{:04x}", class_id) : class_name;
+                    return class_name.is_empty() ? String::formatted("Unknown class: {:04x}", class_id) : class_name;
                 });
             pci_fields.empend(
                 "Vendor", Gfx::TextAlignment::CenterLeft,
                 [db](const JsonObject& object) {
                     auto vendor_id = object.get("vendor_id").to_u32();
                     String vendor_name = db ? db->get_vendor(vendor_id) : nullptr;
-                    return vendor_name.is_empty() ? String::formatted("{:02x}", vendor_id) : vendor_name;
+                    return vendor_name.is_empty() ? String::formatted("Unknown vendor: {:02x}", vendor_id) : vendor_name;
                 });
             pci_fields.empend(
                 "Device", Gfx::TextAlignment::CenterLeft,
@@ -665,7 +665,7 @@ NonnullRefPtr<GUI::Widget> build_hardware_tab()
                     auto vendor_id = object.get("vendor_id").to_u32();
                     auto device_id = object.get("device_id").to_u32();
                     String device_name = db ? db->get_device(vendor_id, device_id) : nullptr;
-                    return device_name.is_empty() ? String::formatted("{:02x}", device_id) : device_name;
+                    return device_name.is_empty() ? String::formatted("Unknown device: {:02x}", device_id) : device_name;
                 });
             pci_fields.empend(
                 "Revision", Gfx::TextAlignment::CenterRight,


### PR DESCRIPTION
In case when the PCI class, device or vendor is unknown, show that it is unknown instead of just putting the ID.