### PR TITLE
LibJS: Combine UTF-16 surrogate pairs when concatenating strings

### DIFF
--- a/Userland/Libraries/LibJS/Tests/string-concatenation.js
+++ b/Userland/Libraries/LibJS/Tests/string-concatenation.js
@@ -1,0 +1,30 @@
+test("adding strings", () => {
+    expect("" + "").toBe("");
+    expect("ab" + "").toBe("ab");
+    expect("" + "cd").toBe("cd");
+    expect("ab" + "cd").toBe("abcd");
+});
+
+test("adding strings with non-strings", () => {
+    expect("a" + 1).toBe("a1");
+    expect(1 + "a").toBe("1a");
+    expect("a" + {}).toBe("a[object Object]");
+    expect({} + "a").toBeNaN();
+    expect("a" + []).toBe("a");
+    expect([] + "a").toBe("a");
+    expect("a" + NaN).toBe("aNaN");
+    expect(NaN + "a").toBe("NaNa");
+    expect(Array(16).join([[][[]] + []][+[]][++[+[]][+[]]] - 1) + " Batman!").toBe(
+        "NaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaNNaN Batman!"
+    );
+});
+
+test("adding strings with dangling surrogates", () => {
+    expect("\ud834" + "").toBe("\ud834");
+    expect("" + "\udf06").toBe("\udf06");
+    expect("\ud834" + "\udf06").toBe("𝌆");
+    expect("\ud834" + "\ud834").toBe("\ud834\ud834");
+    expect("\udf06" + "\udf06").toBe("\udf06\udf06");
+    expect("\ud834a" + "\udf06").toBe("\ud834a\udf06");
+    expect("\ud834" + "a\udf06").toBe("\ud834a\udf06");
+});


### PR DESCRIPTION
In the following use case:
```js
"\ud834" + "\udf06"
```
We were previously combining these as two individual code points. When
concatenating strings, we must take care to combine the high surrogate
from the left-hand side with the low surrogate from the right-hand side.

I think this only fixes `test/built-ins/StringIteratorPrototype/next/next-iteration-surrogate-pairs.js`, kinda surprised test262 doesn't do this more often