### PR TITLE
LibCore: Stub pledge() for non-Serenity systems

### DIFF
--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -44,16 +44,6 @@ ErrorOr<void> beep()
     return {};
 }
 
-ErrorOr<void> pledge(StringView promises, StringView execpromises)
-{
-    Syscall::SC_pledge_params params {
-        { promises.characters_without_null_termination(), promises.length() },
-        { execpromises.characters_without_null_termination(), execpromises.length() },
-    };
-    int rc = syscall(SC_pledge, &params);
-    HANDLE_SYSCALL_RETURN_VALUE("pledge"sv, rc, {});
-}
-
 ErrorOr<void> unveil(StringView path, StringView permissions)
 {
     Syscall::SC_unveil_params params {
@@ -159,6 +149,22 @@ ErrorOr<int> accept4(int sockfd, sockaddr* address, socklen_t* address_length, i
     return fd;
 }
 #endif
+
+ErrorOr<void> pledge(StringView promises, StringView execpromises)
+{
+#ifdef __serenity__
+    Syscall::SC_pledge_params params {
+        { promises.characters_without_null_termination(), promises.length() },
+        { execpromises.characters_without_null_termination(), execpromises.length() },
+    };
+    int rc = syscall(SC_pledge, &params);
+    HANDLE_SYSCALL_RETURN_VALUE("pledge"sv, rc, {});
+#else
+    (void)promises;
+    (void)execpromises;
+    return {};
+#endif
+}
 
 ErrorOr<void> sigaction(int signal, struct sigaction const* action, struct sigaction* old_action)
 {

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -32,7 +32,6 @@ namespace Core::System {
 
 #ifdef __serenity__
 ErrorOr<void> beep();
-ErrorOr<void> pledge(StringView promises, StringView execpromises = {});
 ErrorOr<void> unveil(StringView path, StringView permissions);
 ErrorOr<void> sendfd(int sockfd, int fd);
 ErrorOr<int> recvfd(int sockfd, int options);
@@ -51,6 +50,7 @@ ErrorOr<Optional<struct spwd>> getspnam(StringView name);
 ErrorOr<int> accept4(int sockfd, struct sockaddr*, socklen_t*, int flags);
 #endif
 
+ErrorOr<void> pledge(StringView promises, StringView execpromises = {});
 ErrorOr<void> sigaction(int signal, struct sigaction const* action, struct sigaction* old_action);
 #if defined(__APPLE__) || defined(__OpenBSD__)
 ErrorOr<sig_t> signal(int signal, sig_t handler);

--- a/Userland/Utilities/gml-format.cpp
+++ b/Userland/Utilities/gml-format.cpp
@@ -44,9 +44,7 @@ ErrorOr<bool> format_file(StringView path, bool inplace)
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
-#ifdef __serenity__
     TRY(Core::System::pledge("stdio rpath wpath cpath", nullptr));
-#endif
 
     bool inplace = false;
     Vector<const char*> files;
@@ -57,10 +55,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     args_parser.add_positional_argument(files, "File(s) to process", "path", Core::ArgsParser::Required::No);
     args_parser.parse(args);
 
-#ifdef __serenity__
     if (!inplace)
         TRY(Core::System::pledge("stdio rpath", nullptr));
-#endif
 
     unsigned exit_code = 0;
 

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1220,9 +1220,7 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-#ifdef __serenity__
     TRY(Core::System::pledge("stdio rpath wpath cpath tty sigaction"));
-#endif
 
     bool gc_on_every_allocation = false;
     bool disable_syntax_highlight = false;


### PR DESCRIPTION
This commit stubs the implementation in `Core::System::pledge()` for systems other than Serenity so that we don't need the ifdefs around pledge() to keep Lagom compatibility.