### PR TITLE
EmojiInputDialog: Increase size of buttons and dialog

### DIFF
--- a/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.cpp
@@ -38,6 +38,8 @@ static Vector<u32> supported_emoji_code_points()
 EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     : Dialog(parent_window)
 {
+    // FIXME: Dialog should automatically adjust to content
+    set_minimum_size(190, 190);
     set_frameless(true);
 
     auto& main_widget = set_main_widget<Frame>();
@@ -51,7 +53,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
     auto code_points = supported_emoji_code_points();
 
     size_t index = 0;
-    size_t columns = 6;
+    size_t columns = 10;
     size_t rows = ceil_div(code_points.size(), columns);
 
     for (size_t row = 0; row < rows && index < code_points.size(); ++row) {
@@ -64,7 +66,7 @@ EmojiInputDialog::EmojiInputDialog(Window* parent_window)
                 builder.append(Utf32View(&code_points[index++], 1));
                 auto emoji_text = builder.to_string();
                 auto& button = horizontal_container.add<Button>(emoji_text);
-                button.set_fixed_size(16, 16);
+                button.set_fixed_size(18, 18);
                 button.set_button_style(Gfx::ButtonStyle::Coolbar);
                 button.on_click = [this, button = &button](auto) {
                     m_selected_emoji_text = button->text();


### PR DESCRIPTION
Display some emojis earlier hidden behind "..." and add spacing

Full disclosure, this PR is the result of a lot of love, guesswork and trail & error.

I just guessed set_minimum_size would not affect the widgets natural functionality (If I understand the code correctly I think the widget is suppose to grow vertically).

**Before**
![emoji-picker-b4](https://user-images.githubusercontent.com/93391300/149847570-a5ea6015-bd88-4389-be21-842f1e16cf75.png)

**After**
![emoji-picker-after](https://user-images.githubusercontent.com/93391300/149847571-a9551780-24d5-4a9b-9302-3189bd397bd4.png)
.