### PR TITLE
Replace osxfuse with macfuse in macOS build instructions

### DIFF
--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -17,7 +17,7 @@ brew install coreutils e2fsprogs qemu bash gcc@11 imagemagick ninja cmake ccache
 
 # (option 1) fuse + ext2
 brew install m4 autoconf automake libtool
-brew install --cask osxfuse
+brew install --cask macfuse
 Toolchain/BuildFuseExt2.sh
 
 # (option 2) genext2fs
@@ -26,5 +26,5 @@ brew install genext2fs
 
 Notes:
 
-- Installing osxfuse for the first time requires enabling its system extension in System Preferences and then restarting
-  your machine. The output from installing osxfuse with brew says this, but it's easy to miss.
+- Installing macfuse for the first time requires enabling its system extension in System Preferences and then restarting
+  your machine. The output from installing macfuse with brew says this, but it's easy to miss.


### PR DESCRIPTION
`osxfuse` has been succeeded by `macfuse` as of version 4.0.0.