### PR TITLE
TextEditor+HackStudio: Add and hookup git commit message detection and highlighting

### DIFF
--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -20,6 +20,7 @@
 #include <LibGUI/FilePicker.h>
 #include <LibGUI/FontPicker.h>
 #include <LibGUI/GMLSyntaxHighlighter.h>
+#include <LibGUI/GitCommitSyntaxHighlighter.h>
 #include <LibGUI/GroupBox.h>
 #include <LibGUI/INISyntaxHighlighter.h>
 #include <LibGUI/Menu.h>
@@ -586,6 +587,13 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     syntax_actions.add_action(*m_html_highlight);
     syntax_menu.add_action(*m_html_highlight);
 
+    m_git_highlight = GUI::Action::create_checkable("Git Commit", [&](auto&) {
+        m_editor->set_syntax_highlighter(make<GUI::GitCommitSyntaxHighlighter>());
+        m_editor->update();
+    });
+    syntax_actions.add_action(*m_git_highlight);
+    syntax_menu.add_action(*m_git_highlight);
+
     m_gml_highlight = GUI::Action::create_checkable("&GML", [&](auto&) {
         m_editor->set_syntax_highlighter(make<GUI::GMLSyntaxHighlighter>());
         m_editor->update();
@@ -639,6 +647,8 @@ void MainWidget::set_path(StringView path)
         m_cpp_highlight->activate();
     } else if (m_extension == "js" || m_extension == "mjs" || m_extension == "json") {
         m_js_highlight->activate();
+    } else if (m_name == "COMMIT_EDITMSG") {
+        m_git_highlight->activate();
     } else if (m_extension == "gml") {
         m_gml_highlight->activate();
     } else if (m_extension == "ini" || m_extension == "af") {

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -119,6 +119,7 @@ private:
     RefPtr<GUI::Action> m_css_highlight;
     RefPtr<GUI::Action> m_js_highlight;
     RefPtr<GUI::Action> m_html_highlight;
+    RefPtr<GUI::Action> m_git_highlight;
     RefPtr<GUI::Action> m_gml_highlight;
     RefPtr<GUI::Action> m_ini_highlight;
     RefPtr<GUI::Action> m_shell_highlight;

--- a/Userland/DevTools/HackStudio/CodeDocument.cpp
+++ b/Userland/DevTools/HackStudio/CodeDocument.cpp
@@ -22,8 +22,9 @@ CodeDocument::CodeDocument(const String& file_path, Client* client)
     : TextDocument(client)
     , m_file_path(file_path)
 {
-    m_language = language_from_file_extension(LexicalPath::extension(file_path));
-    m_language_name = language_name_from_file_extension(LexicalPath::extension(file_path));
+    auto lexical_path = LexicalPath(file_path);
+    m_language = language_from_file(lexical_path);
+    m_language_name = language_name_from_file(lexical_path);
 }
 
 CodeDocument::CodeDocument(Client* client)

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -21,6 +21,7 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/GMLAutocompleteProvider.h>
 #include <LibGUI/GMLSyntaxHighlighter.h>
+#include <LibGUI/GitCommitSyntaxHighlighter.h>
 #include <LibGUI/INISyntaxHighlighter.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
@@ -605,6 +606,9 @@ void Editor::set_syntax_highlighter_for(const CodeDocument& document)
         break;
     case Language::CSS:
         set_syntax_highlighter(make<Web::CSS::SyntaxHighlighter>());
+        break;
+    case Language::GitCommit:
+        set_syntax_highlighter(make<GUI::GitCommitSyntaxHighlighter>());
         break;
     case Language::GML:
         set_syntax_highlighter(make<GUI::GMLSyntaxHighlighter>());

--- a/Userland/DevTools/HackStudio/Language.cpp
+++ b/Userland/DevTools/HackStudio/Language.cpp
@@ -5,11 +5,16 @@
  */
 
 #include "Language.h"
+#include <AK/LexicalPath.h>
 
 namespace HackStudio {
 
-Language language_from_file_extension(const String& extension)
+Language language_from_file(const LexicalPath& file)
 {
+    if (file.title() == "COMMIT_EDITMSG")
+        return Language::GitCommit;
+
+    auto extension = file.extension();
     VERIFY(!extension.starts_with("."));
     if (extension == "c" || extension == "cc" || extension == "cxx" || extension == "cpp" || extension == "c++"
         || extension == "h" || extension == "hh" || extension == "hxx" || extension == "hpp" || extension == "h++")
@@ -40,12 +45,18 @@ Language language_from_name(const String& name)
         return Language::JavaScript;
     if (name == "Shell")
         return Language::Shell;
+    if (name == "GitCommit")
+        return Language::GitCommit;
 
     return Language::Unknown;
 }
 
-String language_name_from_file_extension(const String& extension)
+String language_name_from_file(const LexicalPath& file)
 {
+    if (file.title() == "COMMIT_EDITMSG")
+        return "GitCommit";
+
+    auto extension = file.extension();
     VERIFY(!extension.starts_with("."));
     if (extension == "c" || extension == "cc" || extension == "cxx" || extension == "cpp" || extension == "c++"
         || extension == "h" || extension == "hh" || extension == "hxx" || extension == "hpp" || extension == "h++")

--- a/Userland/DevTools/HackStudio/Language.h
+++ b/Userland/DevTools/HackStudio/Language.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/LexicalPath.h>
 #include <AK/String.h>
 
 namespace HackStudio {
@@ -15,14 +16,15 @@ enum class Language {
     CSS,
     JavaScript,
     HTML,
+    GitCommit,
     GML,
     Ini,
     Shell,
     SQL,
 };
 
-Language language_from_file_extension(const String&);
+Language language_from_file(const LexicalPath&);
 Language language_from_name(const String&);
-String language_name_from_file_extension(const String&);
+String language_name_from_file(const LexicalPath&);
 
 }

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -42,6 +42,8 @@ set(SOURCES
     FontPicker.cpp
     FontPickerDialogGML.h
     Frame.cpp
+    GitCommitLexer.cpp
+    GitCommitSyntaxHighlighter.cpp
     GlyphMapWidget.cpp
     GMLAutocompleteProvider.cpp
     GMLFormatter.cpp

--- a/Userland/Libraries/LibGUI/GitCommitLexer.cpp
+++ b/Userland/Libraries/LibGUI/GitCommitLexer.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2022, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/CharacterTypes.h>
+#include <AK/Vector.h>
+#include <LibGUI/GitCommitLexer.h>
+
+namespace GUI {
+
+GitCommitLexer::GitCommitLexer(StringView input)
+    : m_input(input)
+{
+}
+
+char GitCommitLexer::peek(size_t offset) const
+{
+    if ((m_index + offset) >= m_input.length())
+        return 0;
+    return m_input[m_index + offset];
+}
+
+char GitCommitLexer::consume()
+{
+    VERIFY(m_index < m_input.length());
+    char ch = m_input[m_index++];
+    if (ch == '\n') {
+        m_position.line++;
+        m_position.column = 0;
+    } else {
+        m_position.column++;
+    }
+    return ch;
+}
+
+Vector<GitCommitToken> GitCommitLexer::lex()
+{
+    Vector<GitCommitToken> tokens;
+
+    size_t token_start_index = 0;
+    GitCommitPosition token_start_position;
+
+    auto begin_token = [&] {
+        token_start_index = m_index;
+        token_start_position = m_position;
+    };
+
+    auto commit_token = [&](auto type) {
+        GitCommitToken token;
+        token.m_view = m_input.substring_view(token_start_index, m_index - token_start_index);
+        token.m_type = type;
+        token.m_start = token_start_position;
+        token.m_end = m_position;
+        tokens.append(token);
+    };
+
+    while (m_index < m_input.length()) {
+        if (is_ascii_space(peek(0))) {
+            begin_token();
+            while (is_ascii_space(peek()))
+                consume();
+            continue;
+        }
+
+        // Commit comments
+        if (peek(0) && peek(0) == '#') {
+            begin_token();
+            while (peek() && peek() != '\n')
+                consume();
+            commit_token(GitCommitToken::Type::Comment);
+            continue;
+        }
+
+        consume();
+        commit_token(GitCommitToken::Type::Unknown);
+    }
+    return tokens;
+}
+
+}

--- a/Userland/Libraries/LibGUI/GitCommitLexer.h
+++ b/Userland/Libraries/LibGUI/GitCommitLexer.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+
+namespace GUI {
+
+#define FOR_EACH_TOKEN_TYPE \
+    __TOKEN(Comment)        \
+    __TOKEN(Unknown)
+
+struct GitCommitPosition {
+    size_t line;
+    size_t column;
+};
+
+struct GitCommitToken {
+    enum class Type {
+#define __TOKEN(x) x,
+        FOR_EACH_TOKEN_TYPE
+#undef __TOKEN
+    };
+
+    char const* to_string() const
+    {
+        switch (m_type) {
+#define __TOKEN(x) \
+    case Type::x:  \
+        return #x;
+            FOR_EACH_TOKEN_TYPE
+#undef __TOKEN
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    Type m_type { Type::Unknown };
+    StringView m_view;
+    GitCommitPosition m_start;
+    GitCommitPosition m_end;
+};
+
+class GitCommitLexer {
+public:
+    GitCommitLexer(StringView);
+
+    Vector<GitCommitToken> lex();
+
+private:
+    char peek(size_t offset = 0) const;
+    char consume();
+
+    StringView m_input;
+    size_t m_index { 0 };
+    GitCommitPosition m_position { 0, 0 };
+};
+
+}

--- a/Userland/Libraries/LibGUI/GitCommitSyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibGUI/GitCommitSyntaxHighlighter.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGUI/GitCommitLexer.h>
+#include <LibGUI/GitCommitSyntaxHighlighter.h>
+#include <LibGfx/Palette.h>
+
+namespace GUI {
+static Syntax::TextStyle style_for_token_type(const Gfx::Palette& palette, GitCommitToken::Type type)
+{
+    switch (type) {
+    case GitCommitToken::Type::Comment:
+        return { palette.syntax_comment() };
+    default:
+        return { palette.base_text() };
+    }
+}
+
+void GitCommitSyntaxHighlighter::rehighlight(Palette const& palette)
+{
+    auto text = m_client->get_text();
+    GitCommitLexer lexer(text);
+    auto tokens = lexer.lex();
+
+    Vector<GUI::TextDocumentSpan> spans;
+    for (auto& token : tokens) {
+        GUI::TextDocumentSpan span;
+        span.range.set_start({ token.m_start.line, token.m_start.column });
+        span.range.set_end({ token.m_end.line, token.m_end.column });
+        auto style = style_for_token_type(palette, token.m_type);
+        span.attributes.color = style.color;
+        span.attributes.bold = style.bold;
+        span.is_skippable = false;
+        span.data = static_cast<u64>(token.m_type);
+        spans.append(span);
+    }
+    m_client->do_set_spans(move(spans));
+    m_client->do_update();
+}
+
+Vector<GitCommitSyntaxHighlighter::MatchingTokenPair> GitCommitSyntaxHighlighter::matching_token_pairs_impl() const
+{
+    static Vector<MatchingTokenPair> empty;
+    return empty;
+}
+
+bool GitCommitSyntaxHighlighter::token_types_equal(u64 token1, u64 token2) const
+{
+    return static_cast<GUI::GitCommitToken::Type>(token1) == static_cast<GUI::GitCommitToken::Type>(token2);
+}
+
+GitCommitSyntaxHighlighter::~GitCommitSyntaxHighlighter()
+{
+}
+
+}

--- a/Userland/Libraries/LibGUI/GitCommitSyntaxHighlighter.h
+++ b/Userland/Libraries/LibGUI/GitCommitSyntaxHighlighter.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022, Brian Gianforcaro <bgianf@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibSyntax/Highlighter.h>
+
+namespace GUI {
+
+class GitCommitSyntaxHighlighter final : public Syntax::Highlighter {
+public:
+    GitCommitSyntaxHighlighter() { }
+    virtual ~GitCommitSyntaxHighlighter() override;
+
+    virtual Syntax::Language language() const override { return Syntax::Language::GitCommit; }
+    virtual void rehighlight(Palette const&) override;
+
+protected:
+    virtual Vector<MatchingTokenPair> matching_token_pairs_impl() const override;
+    virtual bool token_types_equal(u64, u64) const override;
+};
+
+}

--- a/Userland/Libraries/LibSyntax/Highlighter.h
+++ b/Userland/Libraries/LibSyntax/Highlighter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, the SerenityOS developers.
+ * Copyright (c) 2020-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,6 +17,7 @@ namespace Syntax {
 enum class Language {
     Cpp,
     CSS,
+    GitCommit,
     GML,
     HTML,
     INI,


### PR DESCRIPTION
I was playing around with git inside serenity, and realized it would be nice to have `TextEditor` or `HexEditor` know about git commit messages.