### PR TITLE
Playground: Enable line numbers in the GML editor

### DIFF
--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -91,6 +91,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     editor->set_autocomplete_provider(make<GUI::GMLAutocompleteProvider>());
     editor->set_should_autocomplete_automatically(true);
     editor->set_automatic_indentation_enabled(true);
+    editor->set_ruler_visible(true);
 
     String file_path;
     auto update_title = [&] {


### PR DESCRIPTION
Most folks expect line numbers when editing code, so lets enable them in
when editing GML in the Playground app.