### PR TITLE
AK: Fix `Complex` typos and make it usable in `constexpr` context

### DIFF
--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -145,7 +145,7 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
-    constexpr Complex<T> operator+(const U& a)
+    constexpr Complex<T> operator+(const U& a) const
     {
         Complex<T> x = *this;
         x += a;
@@ -153,7 +153,7 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
-    constexpr Complex<T> operator-(const Complex<U>& a)
+    constexpr Complex<T> operator-(const Complex<U>& a) const
     {
         Complex<T> x = *this;
         x -= a;
@@ -161,7 +161,7 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
-    constexpr Complex<T> operator-(const U& a)
+    constexpr Complex<T> operator-(const U& a) const
     {
         Complex<T> x = *this;
         x -= a;
@@ -177,7 +177,7 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
-    constexpr Complex<T> operator*(const U& a)
+    constexpr Complex<T> operator*(const U& a) const
     {
         Complex<T> x = *this;
         x *= a;
@@ -193,7 +193,7 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
-    constexpr Complex<T> operator/(const U& a)
+    constexpr Complex<T> operator/(const U& a) const
     {
         Complex<T> x = *this;
         x /= a;
@@ -207,17 +207,23 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
+    constexpr bool operator==(const U& a) const
+    {
+        return (this->real() == a) && (this->imag() == 0);
+    }
+
+    template<AK::Concepts::Arithmetic U>
     constexpr bool operator!=(const Complex<U>& a) const
     {
         return !(*this == a);
     }
 
-    constexpr Complex<T> operator+()
+    constexpr Complex<T> operator+() const
     {
         return *this;
     }
 
-    constexpr Complex<T> operator-()
+    constexpr Complex<T> operator-() const
     {
         return Complex<T>(-m_real, -m_imag);
     }

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -137,7 +137,7 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
-    constexpr Complex<T> operator+(const Complex<U>& a)
+    constexpr Complex<T> operator+(const Complex<U>& a) const
     {
         Complex<T> x = *this;
         x += a;
@@ -169,7 +169,7 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
-    constexpr Complex<T> operator*(const Complex<U>& a)
+    constexpr Complex<T> operator*(const Complex<U>& a) const
     {
         Complex<T> x = *this;
         x *= a;
@@ -185,7 +185,7 @@ public:
     }
 
     template<AK::Concepts::Arithmetic U>
-    constexpr Complex<T> operator/(const Complex<U>& a)
+    constexpr Complex<T> operator/(const Complex<U>& a) const
     {
         Complex<T> x = *this;
         x /= a;
@@ -262,9 +262,9 @@ constexpr Complex<T> operator/(const U& a, const Complex<T>& b)
 
 // some identities
 template<AK::Concepts::Arithmetic T>
-static constinit Complex<T> complex_real_unit = Complex<T>((T)1, (T)0);
+static constexpr Complex<T> complex_real_unit = Complex<T>((T)1, (T)0);
 template<AK::Concepts::Arithmetic T>
-static constinit Complex<T> complex_imag_unit = Complex<T>((T)0, (T)1);
+static constexpr Complex<T> complex_imag_unit = Complex<T>((T)0, (T)1);
 
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
 static constexpr bool approx_eq(const Complex<T>& a, const Complex<U>& b, const double margin = 0.000001)

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -232,7 +232,7 @@ private:
 
 // reverse associativity operators for scalars
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
-constexpr Complex<T> operator+(const U& b, const Complex<T>& a)
+constexpr Complex<T> operator+(const U& a, const Complex<T>& b)
 {
     Complex<T> x = a;
     x += b;
@@ -240,7 +240,7 @@ constexpr Complex<T> operator+(const U& b, const Complex<T>& a)
 }
 
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
-constexpr Complex<T> operator-(const U& b, const Complex<T>& a)
+constexpr Complex<T> operator-(const U& a, const Complex<T>& b)
 {
     Complex<T> x = a;
     x -= b;
@@ -248,7 +248,7 @@ constexpr Complex<T> operator-(const U& b, const Complex<T>& a)
 }
 
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
-constexpr Complex<T> operator*(const U& b, const Complex<T>& a)
+constexpr Complex<T> operator*(const U& a, const Complex<T>& b)
 {
     Complex<T> x = a;
     x *= b;
@@ -256,7 +256,7 @@ constexpr Complex<T> operator*(const U& b, const Complex<T>& a)
 }
 
 template<AK::Concepts::Arithmetic T, AK::Concepts::Arithmetic U>
-constexpr Complex<T> operator/(const U& b, const Complex<T>& a)
+constexpr Complex<T> operator/(const U& a, const Complex<T>& b)
 {
     Complex<T> x = a;
     x /= b;

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -127,7 +127,7 @@ public:
         const T real = m_real;
         const T divisor = x.real() * x.real() + x.imag() * x.imag();
         m_real = (real * x.real() + m_imag * x.imag()) / divisor;
-        m_imag = (m_imag * x.real() - x.real() * x.imag()) / divisor;
+        m_imag = (m_imag * x.real() - real * x.imag()) / divisor;
         return *this;
     }
 

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -19,14 +19,11 @@ template<AK::Concepts::Arithmetic T>
 class [[gnu::packed]] Complex {
 public:
     constexpr Complex()
-        : m_real(0)
-        , m_imag(0)
     {
     }
 
     constexpr Complex(T real)
         : m_real(real)
-        , m_imag((T)0)
     {
     }
 
@@ -226,8 +223,8 @@ public:
     }
 
 private:
-    T m_real;
-    T m_imag;
+    T m_real { 0 };
+    T m_imag { 0 };
 };
 
 // reverse associativity operators for scalars

--- a/AK/Complex.h
+++ b/AK/Complex.h
@@ -85,7 +85,7 @@ public:
     template<AK::Concepts::Arithmetic U>
     constexpr Complex<T> operator+=(const U& x)
     {
-        m_real += x.real();
+        m_real += x;
         return *this;
     }
 
@@ -100,7 +100,7 @@ public:
     template<AK::Concepts::Arithmetic U>
     constexpr Complex<T> operator-=(const U& x)
     {
-        m_real -= x.real();
+        m_real -= x;
         return *this;
     }
 

--- a/Tests/AK/TestComplex.cpp
+++ b/Tests/AK/TestComplex.cpp
@@ -8,6 +8,24 @@
 
 #include <AK/Complex.h>
 
+STATICTEST_CASE(Complex_basic_math)
+{
+    auto const z = Complex<double>();
+    auto const r = complex_real_unit<double>;
+    auto const i = complex_imag_unit<double>;
+
+    EXPECT(z == z);
+    EXPECT(z != r);
+    EXPECT(z != i);
+    EXPECT(r != z);
+    EXPECT(r == r);
+    EXPECT(r != i);
+    EXPECT(i != z);
+    EXPECT(i != r);
+    EXPECT(i == i);
+}
+RUN_STATICTEST_CASE(Complex_basic_math);
+
 TEST_CASE(Complex)
 {
     auto a = Complex<float> { 1.f, 1.f };

--- a/Tests/AK/TestComplex.cpp
+++ b/Tests/AK/TestComplex.cpp
@@ -23,6 +23,42 @@ STATICTEST_CASE(Complex_basic_math)
     EXPECT(i != z);
     EXPECT(i != r);
     EXPECT(i == i);
+
+    auto basic_math = [&](auto const& c) {
+        auto n = c;
+        EXPECT(c == c);
+        EXPECT(!(c != c));
+
+        EXPECT_EQ(c + c, 2 * c);
+        EXPECT_EQ(c + 0, c);
+        EXPECT_EQ(0 + c, +c);
+        EXPECT_EQ(n += 0, c);
+
+        EXPECT_EQ(c - c, 0);
+        EXPECT_EQ(c - 0, c);
+        EXPECT_EQ(0 - c, -c);
+        EXPECT_EQ(n -= 0, c);
+
+        EXPECT_EQ(c * r, c);
+        EXPECT_EQ(c * 1, c);
+        EXPECT_EQ(1 * c, c);
+        EXPECT_EQ(n *= 1, c);
+
+        EXPECT_EQ(c / r, c);
+        EXPECT_EQ(c / 1, c);
+        EXPECT_EQ(n /= 1, c);
+
+        EXPECT_EQ(+c, 0 + c);
+        EXPECT_EQ(-c, 0 - c);
+    };
+
+    basic_math(z);
+
+    basic_math(r);
+    EXPECT_EQ(1 / r, r);
+
+    basic_math(i);
+    EXPECT_EQ(1 / i, -i);
 }
 RUN_STATICTEST_CASE(Complex_basic_math);
 

--- a/Userland/Libraries/LibTest/TestCase.h
+++ b/Userland/Libraries/LibTest/TestCase.h
@@ -62,6 +62,18 @@ void set_suite_setup_function(Function<void()> setup);
     static struct __TESTCASE_TYPE(x) __TESTCASE_TYPE(x);                                                \
     static void __TESTCASE_FUNC(x)()
 
+#define STATICTEST_CASE(x)                                                                              \
+    static constexpr void __TESTCASE_FUNC(x)();                                                         \
+    struct __TESTCASE_TYPE(x) {                                                                         \
+        __TESTCASE_TYPE(x)                                                                              \
+        () { add_test_case_to_suite(adopt_ref(*new ::Test::TestCase(#x, __TESTCASE_FUNC(x), false))); } \
+    };                                                                                                  \
+    static struct __TESTCASE_TYPE(x) __TESTCASE_TYPE(x);                                                \
+    static constexpr void __TESTCASE_FUNC(x)()
+
+#define RUN_STATICTEST_CASE(x) \
+    static_assert([]() {__TESTCASE_FUNC(x)();return true; }())
+
 #define __BENCHMARK_FUNC(x) __benchmark_##x
 #define __BENCHMARK_TYPE(x) __BenchmarkCase_##x
 


### PR DESCRIPTION
Hi,
The `Consexpr` class contains several typos/thinkos and small errors (using `constinit` instead of `constexpr` does not produce a constant variable...). 
Ensure that basic math works in `constexpr` context as it is branded all around the code, using a static assert test case.

Maybe this will need to be factorized too `STATICTEST_CASE` so that it is checked both at compile-time and runtime...