### PR TITLE
LibCore: Don't manually close the fd when connection fails in sockets

### DIFF
--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -140,6 +140,18 @@ TEST_CASE(file_adopt_invalid_fd)
 
 // TCPSocket tests
 
+TEST_CASE(should_error_when_connection_fails)
+{
+    // NOTE: This is required here because Core::TCPSocket requires
+    //       Core::EventLoop through Core::Notifier.
+    Core::EventLoop event_loop;
+
+    auto maybe_tcp_socket = Core::Stream::TCPSocket::connect({ { 127, 0, 0, 1 }, 1234 });
+    EXPECT(maybe_tcp_socket.is_error());
+    EXPECT(maybe_tcp_socket.error().is_syscall());
+    EXPECT(maybe_tcp_socket.error().code() == ECONNREFUSED);
+}
+
 constexpr auto sent_data = "Mr. Watson, come here. I want to see you."sv;
 
 TEST_CASE(tcp_socket_read)

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -459,11 +459,7 @@ ErrorOr<NonnullOwnPtr<TCPSocket>> TCPSocket::connect(SocketAddress const& addres
     auto fd = TRY(create_fd(SocketDomain::Inet, SocketType::Stream));
     socket->m_helper.set_fd(fd);
 
-    auto result = connect_inet(fd, address);
-    if (result.is_error()) {
-        ::close(fd);
-        return result.release_error();
-    }
+    TRY(connect_inet(fd, address));
 
     socket->setup_notifier();
     return socket;
@@ -509,11 +505,7 @@ ErrorOr<NonnullOwnPtr<UDPSocket>> UDPSocket::connect(SocketAddress const& addres
     auto fd = TRY(create_fd(SocketDomain::Inet, SocketType::Datagram));
     socket->m_helper.set_fd(fd);
 
-    auto result = connect_inet(fd, address);
-    if (result.is_error()) {
-        ::close(fd);
-        return result.release_error();
-    }
+    TRY(connect_inet(fd, address));
 
     socket->setup_notifier();
     return socket;
@@ -526,11 +518,7 @@ ErrorOr<NonnullOwnPtr<LocalSocket>> LocalSocket::connect(String const& path)
     auto fd = TRY(create_fd(SocketDomain::Local, SocketType::Stream));
     socket->m_helper.set_fd(fd);
 
-    auto result = connect_local(fd, path);
-    if (result.is_error()) {
-        ::close(fd);
-        return result.release_error();
-    }
+    TRY(connect_local(fd, path));
 
     socket->setup_notifier();
     return socket;

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -540,6 +540,14 @@ ErrorOr<pid_t> posix_spawnp(StringView const path, posix_spawn_file_actions_t* c
     return child_pid;
 }
 
+ErrorOr<off_t> lseek(int fd, off_t offset, int whence)
+{
+    off_t rc = ::lseek(fd, offset, whence);
+    if (rc < 0)
+        return Error::from_syscall("lseek", -errno);
+    return rc;
+}
+
 ErrorOr<WaitPidResult> waitpid(pid_t waitee, int options)
 {
     int wstatus;

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -87,6 +87,7 @@ ErrorOr<Optional<struct passwd>> getpwuid(uid_t);
 ErrorOr<Optional<struct group>> getgrgid(gid_t);
 ErrorOr<void> clock_settime(clockid_t clock_id, struct timespec* ts);
 ErrorOr<pid_t> posix_spawnp(StringView const path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);
+ErrorOr<off_t> lseek(int fd, off_t, int whence);
 
 struct WaitPidResult {
     pid_t pid;


### PR DESCRIPTION
This is wrong because we have already set the fd in the
PosixSocketHelper, and the destructor of the respective Socket class
will close the fd for us. With the manual closing of the fd, we attempt
to close the same fd twice which results in a crash.

Thanks to stelar7 for noticing this bug.

This PR also cleans up error returns a little bit and adds a test for the behavior that was corrected in the first commit.