### PR TITLE
Tests: Fix the TestLibCoreStream local_socket_write test

### DIFF
--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -350,11 +350,12 @@ TEST_CASE(local_socket_write)
         // NOTE: For some reason LocalServer gives us a nonblocking socket..?
         MUST(server_socket->set_blocking(true));
 
+        EXPECT(MUST(server_socket->can_read_without_blocking(100)));
         auto pending_bytes = MUST(server_socket->pending_bytes());
         auto receive_buffer = ByteBuffer::create_uninitialized(pending_bytes).release_value();
         auto maybe_nread = server_socket->read(receive_buffer);
         EXPECT(!maybe_nread.is_error());
-        EXPECT(maybe_nread.value() == sent_data.length());
+        EXPECT_EQ(maybe_nread.value(), sent_data.length());
 
         StringView received_data { receive_buffer.data(), maybe_nread.value() };
         EXPECT_EQ(sent_data, received_data);


### PR DESCRIPTION
Accidentally regressed this test during the Core::LocalServer refactor,
and didn't catch it since TestLibCoreStream is disabled in the CI right
now. We have to wait for some data to become available, as pending_bytes
will immediately return 0 and a 0-sized read immediately returns.