### PR TITLE
LibCrypto+LibJS: Better bigint bitwise binops

### DIFF
--- a/Tests/LibCrypto/TestBigInteger.cpp
+++ b/Tests/LibCrypto/TestBigInteger.cpp
@@ -467,6 +467,12 @@ TEST_CASE(test_bigint_bitwise_and_different_lengths)
     EXPECT_EQ(num1.bitwise_and(num2), "1180290"_bigint);
 }
 
+TEST_CASE(test_signed_bigint_bitwise_not)
+{
+    EXPECT_EQ("3"_sbigint.bitwise_not(), "-4"_sbigint);
+    EXPECT_EQ("-1"_sbigint.bitwise_not(), "0"_sbigint);
+}
+
 TEST_CASE(test_signed_bigint_bitwise_and)
 {
     auto num1 = "-1234567"_sbigint;

--- a/Tests/LibCrypto/TestBigInteger.cpp
+++ b/Tests/LibCrypto/TestBigInteger.cpp
@@ -526,8 +526,8 @@ TEST_CASE(test_signed_bigint_bitwise_xor)
     auto num1 = "-3"_sbigint;
     auto num2 = "1"_sbigint;
     EXPECT_EQ(num1.bitwise_xor(num1), "0"_sbigint);
-    EXPECT_EQ(num1.bitwise_xor(num2), "-2"_sbigint);
-    EXPECT_EQ(num2.bitwise_xor(num1), "-2"_sbigint);
+    EXPECT_EQ(num1.bitwise_xor(num2), "-4"_sbigint);
+    EXPECT_EQ(num2.bitwise_xor(num1), "-4"_sbigint);
     EXPECT_EQ(num2.bitwise_xor(num2), "0"_sbigint);
 }
 

--- a/Tests/LibCrypto/TestBigInteger.cpp
+++ b/Tests/LibCrypto/TestBigInteger.cpp
@@ -427,6 +427,26 @@ TEST_CASE(test_bigint_big_endian_export)
     EXPECT(memcmp(exported + 3, "hello", 5) == 0);
 }
 
+TEST_CASE(test_bigint_one_based_index_of_highest_set_bit)
+{
+    auto num1 = "1234567"_bigint;
+    auto num2 = "1234567"_bigint;
+    EXPECT_EQ("0"_bigint.one_based_index_of_highest_set_bit(), 0u);
+    EXPECT_EQ("1"_bigint.one_based_index_of_highest_set_bit(), 1u);
+    EXPECT_EQ("7"_bigint.one_based_index_of_highest_set_bit(), 3u);
+    EXPECT_EQ("4294967296"_bigint.one_based_index_of_highest_set_bit(), 33u);
+}
+
+TEST_CASE(test_signed_bigint_bitwise_not_fill_to_one_based_index)
+{
+    EXPECT_EQ("0"_bigint.bitwise_not_fill_to_one_based_index(0), "0"_bigint);
+    EXPECT_EQ("0"_bigint.bitwise_not_fill_to_one_based_index(1), "1"_bigint);
+    EXPECT_EQ("0"_bigint.bitwise_not_fill_to_one_based_index(2), "3"_bigint);
+    EXPECT_EQ("0"_bigint.bitwise_not_fill_to_one_based_index(4), "15"_bigint);
+    EXPECT_EQ("0"_bigint.bitwise_not_fill_to_one_based_index(32), "4294967295"_bigint);
+    EXPECT_EQ("0"_bigint.bitwise_not_fill_to_one_based_index(33), "8589934591"_bigint);
+}
+
 TEST_CASE(test_bigint_bitwise_or)
 {
     auto num1 = "1234567"_bigint;
@@ -448,9 +468,11 @@ TEST_CASE(test_signed_bigint_bitwise_or)
     auto num1 = "-1234567"_sbigint;
     auto num2 = "1234567"_sbigint;
     EXPECT_EQ(num1.bitwise_or(num1), num1);
-    EXPECT_EQ(num1.bitwise_or(num2), num1);
-    EXPECT_EQ(num2.bitwise_or(num1), num1);
+    EXPECT_EQ(num1.bitwise_or(num2), "-1"_sbigint);
+    EXPECT_EQ(num2.bitwise_or(num1), "-1"_sbigint);
     EXPECT_EQ(num2.bitwise_or(num2), num2);
+
+    EXPECT_EQ("0"_sbigint.bitwise_or("-1"_sbigint), "-1"_sbigint);
 }
 
 TEST_CASE(test_bigint_bitwise_and)

--- a/Tests/LibCrypto/TestBigInteger.cpp
+++ b/Tests/LibCrypto/TestBigInteger.cpp
@@ -478,9 +478,11 @@ TEST_CASE(test_signed_bigint_bitwise_and)
     auto num1 = "-1234567"_sbigint;
     auto num2 = "1234567"_sbigint;
     EXPECT_EQ(num1.bitwise_and(num1), num1);
-    EXPECT_EQ(num1.bitwise_and(num2), num2);
-    EXPECT_EQ(num2.bitwise_and(num1), num2);
+    EXPECT_EQ(num1.bitwise_and(num2), "1"_sbigint);
+    EXPECT_EQ(num2.bitwise_and(num1), "1"_sbigint);
     EXPECT_EQ(num2.bitwise_and(num2), num2);
+
+    EXPECT_EQ("-3"_sbigint.bitwise_and("-2"_sbigint), "-4"_sbigint);
 }
 
 TEST_CASE(test_bigint_bitwise_xor)

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/BitwiseOperations.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/BitwiseOperations.cpp
@@ -7,6 +7,7 @@
 
 #include "UnsignedBigIntegerAlgorithms.h"
 #include <AK/BuiltinWrappers.h>
+#include <AK/NumericLimits.h>
 
 namespace Crypto {
 
@@ -130,8 +131,9 @@ FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_xor_without_allocation(
 /**
  * Complexity: O(N) where N is the number of words
  */
-FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_without_allocation(
+FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_size_without_allocation(
     UnsignedBigInteger const& right,
+    size_t size,
     UnsignedBigInteger& output)
 {
     // If the value is invalid, the output value is invalid as well.
@@ -139,22 +141,17 @@ FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_without_allocation(
         output.invalidate();
         return;
     }
-    if (right.length() == 0) {
+    if (size == 0) {
         output.set_to_0();
         return;
     }
 
-    output.m_words.resize_and_keep_capacity(right.length());
-
-    if (right.length() > 1) {
-        for (size_t i = 0; i < right.length() - 1; ++i)
-            output.m_words[i] = ~right.words()[i];
-    }
-
-    auto last_word_index = right.length() - 1;
-    auto last_word = right.words()[last_word_index];
-
-    output.m_words[last_word_index] = ((u32)0xffffffffffffffff >> count_leading_zeroes(last_word)) & ~last_word;
+    output.m_words.resize_and_keep_capacity(size);
+    size_t i;
+    for (i = 0; i < min(size, right.length()); ++i)
+        output.m_words[i] = ~right.words()[i];
+    for (; i < size; ++i)
+        output.m_words[i] = NumericLimits<UnsignedBigInteger::Word>::max();
 }
 
 /**

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/BitwiseOperations.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/BitwiseOperations.cpp
@@ -131,9 +131,9 @@ FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_xor_without_allocation(
 /**
  * Complexity: O(N) where N is the number of words
  */
-FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_size_without_allocation(
+FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_one_based_index_without_allocation(
     UnsignedBigInteger const& right,
-    size_t size,
+    size_t index,
     UnsignedBigInteger& output)
 {
     // If the value is invalid, the output value is invalid as well.
@@ -141,17 +141,23 @@ FLATTEN void UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_size_without_allo
         output.invalidate();
         return;
     }
-    if (size == 0) {
+
+    if (index == 0) {
         output.set_to_0();
         return;
     }
+    size_t size = (index + UnsignedBigInteger::BITS_IN_WORD - 1) / UnsignedBigInteger::BITS_IN_WORD;
 
     output.m_words.resize_and_keep_capacity(size);
-    size_t i;
-    for (i = 0; i < min(size, right.length()); ++i)
-        output.m_words[i] = ~right.words()[i];
-    for (; i < size; ++i)
-        output.m_words[i] = NumericLimits<UnsignedBigInteger::Word>::max();
+    VERIFY(size > 0);
+    for (size_t i = 0; i < size - 1; ++i)
+        output.m_words[i] = ~(i < right.length() ? right.words()[i] : 0);
+
+    index -= (size - 1) * UnsignedBigInteger::BITS_IN_WORD;
+    auto last_word_index = size - 1;
+    auto last_word = last_word_index < right.length() ? right.words()[last_word_index] : 0;
+
+    output.m_words[last_word_index] = (NumericLimits<UnsignedBigInteger::Word>::max() >> (UnsignedBigInteger::BITS_IN_WORD - index)) & ~last_word;
 }
 
 /**

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
@@ -18,7 +18,7 @@ public:
     static void bitwise_or_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
     static void bitwise_and_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
     static void bitwise_xor_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
-    static void bitwise_not_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger& output);
+    static void bitwise_not_fill_to_size_without_allocation(UnsignedBigInteger const& left, size_t, UnsignedBigInteger& output);
     static void shift_left_without_allocation(UnsignedBigInteger const& number, size_t bits_to_shift_by, UnsignedBigInteger& temp_result, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
     static void multiply_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& output);
     static void divide_without_allocation(UnsignedBigInteger const& numerator, UnsignedBigInteger const& denominator, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_minus, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
@@ -18,7 +18,7 @@ public:
     static void bitwise_or_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
     static void bitwise_and_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
     static void bitwise_xor_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& output);
-    static void bitwise_not_fill_to_size_without_allocation(UnsignedBigInteger const& left, size_t, UnsignedBigInteger& output);
+    static void bitwise_not_fill_to_one_based_index_without_allocation(UnsignedBigInteger const& left, size_t, UnsignedBigInteger& output);
     static void shift_left_without_allocation(UnsignedBigInteger const& number, size_t bits_to_shift_by, UnsignedBigInteger& temp_result, UnsignedBigInteger& temp_plus, UnsignedBigInteger& output);
     static void multiply_without_allocation(UnsignedBigInteger const& left, UnsignedBigInteger const& right, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& output);
     static void divide_without_allocation(UnsignedBigInteger const& numerator, UnsignedBigInteger const& denominator, UnsignedBigInteger& temp_shift_result, UnsignedBigInteger& temp_shift_plus, UnsignedBigInteger& temp_shift, UnsignedBigInteger& temp_minus, UnsignedBigInteger& quotient, UnsignedBigInteger& remainder);

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -308,3 +308,10 @@ bool SignedBigInteger::operator>=(const SignedBigInteger& other) const
 }
 
 }
+
+ErrorOr<void> AK::Formatter<Crypto::SignedBigInteger>::format(FormatBuilder& fmtbuilder, const Crypto::SignedBigInteger& value)
+{
+    if (value.is_negative())
+        TRY(fmtbuilder.put_string("-"));
+    return Formatter<Crypto::UnsignedBigInteger>::format(fmtbuilder, value.unsigned_value());
+}

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -160,7 +160,12 @@ FLATTEN SignedBigInteger SignedBigInteger::bitwise_xor(const UnsignedBigInteger&
 
 FLATTEN SignedBigInteger SignedBigInteger::bitwise_not() const
 {
-    return { unsigned_value().bitwise_not(), !m_sign };
+    // Bitwise operators assume two's complement, while SignedBigInteger uses sign-magnitude.
+    // In two's complement, -x := ~x + 1.
+    // Hence, ~x == -x -1 == -(x + 1).
+    SignedBigInteger result = plus(SignedBigInteger { 1 });
+    result.negate();
+    return result;
 }
 
 FLATTEN SignedBigInteger SignedBigInteger::multiplied_by(UnsignedBigInteger const& other) const

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -143,21 +143,6 @@ FLATTEN SignedBigInteger SignedBigInteger::minus(const UnsignedBigInteger& other
     return { other.minus(m_unsigned_data), true };
 }
 
-FLATTEN SignedBigInteger SignedBigInteger::bitwise_or(const UnsignedBigInteger& other) const
-{
-    return { unsigned_value().bitwise_or(other), m_sign };
-}
-
-FLATTEN SignedBigInteger SignedBigInteger::bitwise_and(const UnsignedBigInteger& other) const
-{
-    return { unsigned_value().bitwise_and(other), false };
-}
-
-FLATTEN SignedBigInteger SignedBigInteger::bitwise_xor(const UnsignedBigInteger& other) const
-{
-    return { unsigned_value().bitwise_xor(other), m_sign };
-}
-
 FLATTEN SignedBigInteger SignedBigInteger::bitwise_not() const
 {
     // Bitwise operators assume two's complement, while SignedBigInteger uses sign-magnitude.

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.cpp
@@ -238,12 +238,7 @@ FLATTEN SignedBigInteger SignedBigInteger::bitwise_and(const SignedBigInteger& o
 
 FLATTEN SignedBigInteger SignedBigInteger::bitwise_xor(const SignedBigInteger& other) const
 {
-    auto result = bitwise_xor(other.unsigned_value());
-
-    // The sign bit will have to be XOR'd manually.
-    result.m_sign = is_negative() ^ other.is_negative();
-
-    return result;
+    return bitwise_or(other).minus(bitwise_and(other));
 }
 
 bool SignedBigInteger::operator==(const UnsignedBigInteger& other) const

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -143,6 +143,11 @@ struct SignedDivisionResult {
 
 }
 
+template<>
+struct AK::Formatter<Crypto::SignedBigInteger> : AK::Formatter<Crypto::UnsignedBigInteger> {
+    ErrorOr<void> format(FormatBuilder&, Crypto::SignedBigInteger const&);
+};
+
 inline Crypto::SignedBigInteger
 operator""_sbigint(const char* string, size_t length)
 {

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -109,9 +109,6 @@ public:
 
     SignedBigInteger plus(const UnsignedBigInteger& other) const;
     SignedBigInteger minus(const UnsignedBigInteger& other) const;
-    SignedBigInteger bitwise_or(const UnsignedBigInteger& other) const;
-    SignedBigInteger bitwise_and(const UnsignedBigInteger& other) const;
-    SignedBigInteger bitwise_xor(const UnsignedBigInteger& other) const;
     SignedBigInteger multiplied_by(const UnsignedBigInteger& other) const;
     SignedDivisionResult divided_by(const UnsignedBigInteger& divisor) const;
 

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "UnsignedBigInteger.h"
+#include <AK/BuiltinWrappers.h>
 #include <AK/CharacterTypes.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringHash.h>
@@ -173,6 +174,17 @@ void UnsignedBigInteger::resize_with_leading_zeros(size_t new_length)
     }
 }
 
+size_t UnsignedBigInteger::one_based_index_of_highest_set_bit() const
+{
+    size_t number_of_words = trimmed_length();
+    size_t index = 0;
+    if (number_of_words > 0) {
+        index += (number_of_words - 1) * BITS_IN_WORD;
+        index += BITS_IN_WORD - count_leading_zeroes(m_words[number_of_words - 1]);
+    }
+    return index;
+}
+
 FLATTEN UnsignedBigInteger UnsignedBigInteger::plus(const UnsignedBigInteger& other) const
 {
     UnsignedBigInteger result;
@@ -218,11 +230,11 @@ FLATTEN UnsignedBigInteger UnsignedBigInteger::bitwise_xor(const UnsignedBigInte
     return result;
 }
 
-FLATTEN UnsignedBigInteger UnsignedBigInteger::bitwise_not_fill_to_size(size_t size) const
+FLATTEN UnsignedBigInteger UnsignedBigInteger::bitwise_not_fill_to_one_based_index(size_t size) const
 {
     UnsignedBigInteger result;
 
-    UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_size_without_allocation(*this, size, result);
+    UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_one_based_index_without_allocation(*this, size, result);
 
     return result;
 }

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -218,11 +218,11 @@ FLATTEN UnsignedBigInteger UnsignedBigInteger::bitwise_xor(const UnsignedBigInte
     return result;
 }
 
-FLATTEN UnsignedBigInteger UnsignedBigInteger::bitwise_not() const
+FLATTEN UnsignedBigInteger UnsignedBigInteger::bitwise_not_fill_to_size(size_t size) const
 {
     UnsignedBigInteger result;
 
-    UnsignedBigIntegerAlgorithms::bitwise_not_without_allocation(*this, result);
+    UnsignedBigIntegerAlgorithms::bitwise_not_fill_to_size_without_allocation(*this, size, result);
 
     return result;
 }

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -87,7 +87,7 @@ public:
     UnsignedBigInteger bitwise_or(const UnsignedBigInteger& other) const;
     UnsignedBigInteger bitwise_and(const UnsignedBigInteger& other) const;
     UnsignedBigInteger bitwise_xor(const UnsignedBigInteger& other) const;
-    UnsignedBigInteger bitwise_not() const;
+    UnsignedBigInteger bitwise_not_fill_to_size(size_t) const;
     UnsignedBigInteger shift_left(size_t num_bits) const;
     UnsignedBigInteger multiplied_by(const UnsignedBigInteger& other) const;
     UnsignedDivisionResult divided_by(const UnsignedBigInteger& divisor) const;

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -82,12 +82,14 @@ public:
     void clamp_to_trimmed_length();
     void resize_with_leading_zeros(size_t num_words);
 
+    size_t one_based_index_of_highest_set_bit() const;
+
     UnsignedBigInteger plus(const UnsignedBigInteger& other) const;
     UnsignedBigInteger minus(const UnsignedBigInteger& other) const;
     UnsignedBigInteger bitwise_or(const UnsignedBigInteger& other) const;
     UnsignedBigInteger bitwise_and(const UnsignedBigInteger& other) const;
     UnsignedBigInteger bitwise_xor(const UnsignedBigInteger& other) const;
-    UnsignedBigInteger bitwise_not_fill_to_size(size_t) const;
+    UnsignedBigInteger bitwise_not_fill_to_one_based_index(size_t) const;
     UnsignedBigInteger shift_left(size_t num_bits) const;
     UnsignedBigInteger multiplied_by(const UnsignedBigInteger& other) const;
     UnsignedDivisionResult divided_by(const UnsignedBigInteger& divisor) const;

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -881,10 +881,7 @@ ThrowCompletionOr<Value> bitwise_not(GlobalObject& global_object, Value lhs)
     auto lhs_numeric = TRY(lhs.to_numeric(global_object));
     if (lhs_numeric.is_number())
         return Value(~TRY(lhs_numeric.to_i32(global_object)));
-    auto big_integer_bitwise_not = lhs_numeric.as_bigint().big_integer();
-    big_integer_bitwise_not = big_integer_bitwise_not.plus(Crypto::SignedBigInteger { 1 });
-    big_integer_bitwise_not.negate();
-    return Value(js_bigint(vm, big_integer_bitwise_not));
+    return Value(js_bigint(vm, lhs_numeric.as_bigint().big_integer().bitwise_not()));
 }
 
 // 13.5.4 Unary + Operator, https://tc39.es/ecma262/#sec-unary-plus-operator

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
@@ -44,6 +44,7 @@ describe("correct behavior", () => {
 
         expect(1n | 2n).toBe(3n);
         expect(0n | -1n).toBe(-1n);
+        expect(0n | -2n).toBe(-2n);
 
         expect(5n ^ 3n).toBe(6n);
 

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
@@ -40,6 +40,8 @@ describe("correct behavior", () => {
         expect(1n | 2n).toBe(3n);
         expect(5n ^ 3n).toBe(6n);
         expect(~1n).toBe(-2n);
+        expect(~-1n).toBe(0n);
+
         expect(5n << 2n).toBe(20n);
         expect(7n >> 1n).toBe(3n);
     });

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
@@ -40,8 +40,10 @@ describe("correct behavior", () => {
         expect(3n & -2n).toBe(2n);
         expect(-3n & -2n).toBe(-4n);
         expect(-3n & 2n).toBe(0n);
+        expect(0xffff_ffffn & -1n).toBe(0xffff_ffffn);
 
         expect(1n | 2n).toBe(3n);
+        expect(0n | -1n).toBe(-1n);
 
         expect(5n ^ 3n).toBe(6n);
 

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
@@ -37,8 +37,14 @@ describe("correct behavior", () => {
 
     test("bitwise operators", () => {
         expect(12n & 5n).toBe(4n);
+        expect(3n & -2n).toBe(2n);
+        expect(-3n & -2n).toBe(-4n);
+        expect(-3n & 2n).toBe(0n);
+
         expect(1n | 2n).toBe(3n);
+
         expect(5n ^ 3n).toBe(6n);
+
         expect(~1n).toBe(-2n);
         expect(~-1n).toBe(0n);
 

--- a/Userland/Utilities/test-crypto.cpp
+++ b/Userland/Utilities/test-crypto.cpp
@@ -2996,7 +2996,7 @@ static void bigint_signed_bitwise()
         I_TEST((Signed BigInteger | Bitwise or handles sign));
         auto num1 = "-1234567"_sbigint;
         auto num2 = "1234567"_sbigint;
-        if (num1.bitwise_or(num2) == num1) {
+        if (num1.bitwise_or(num2) == "-1"_sbigint) {
             PASS;
         } else {
             FAIL(Invalid value);


### PR DESCRIPTION
bitwise_foo() didn't do the right thing for negative numbers. At least it didn't have JS BigInt semantics, and LibJS is currently the only client of these methods.

Fixes test262/test/language/expressions/bitwise-*/bigint.js.