### PR TITLE
AK+LibJS: Parse negative zeros in Json data as a double

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/JSON/JSON.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/JSON/JSON.parse.js
@@ -35,3 +35,11 @@ test("syntax errors", () => {
         }).toThrow(SyntaxError);
     });
 });
+
+test("negative zero", () => {
+    ["-0", " \n-0", "-0  \t", "\n\t -0\n   ", "-0.0"].forEach(testCase => {
+        expect(JSON.parse(testCase)).toEqual(-0.0);
+    });
+
+    expect(JSON.parse(-0)).toEqual(0);
+});


### PR DESCRIPTION
The code handling parsing of Json numbers used integers throughout to represent pieces of the data and then conservatively chooses which underlying data type to store the value in.

~These integers cannot encode the case of a negative zero which floating point numbers can. Javascript encodes all numbers as 64 bit floats so requires this behavior for spec compliance. However the usage of `JsonValue` throughout the codebase relies on being able to trust that a value is of some integer type instead.~

~By having a special parse mode for JS and stashing the sign ahead of further parsing, any number parsing done from within JS can be forced to be represented with a double and with the correct sign applied.~

This should fix `built-ins/JSON/parse/text-negative-zero` in test262. I've added an in-tree test to `JSON.parse.js` which mirrors the test cases of the test262 test in question.