### PR TITLE
AK+LibJS+LibTimeZone+LibUnicode: Stop pretending DST isn't a thing :^)

### DIFF
--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -44,6 +44,7 @@ Time Time::from_timespec(const struct timespec& ts)
     i32 extra_secs = sane_mod(nsecs, 1'000'000'000);
     return Time::from_half_sanitized(ts.tv_sec, extra_secs, nsecs);
 }
+
 Time Time::from_timeval(const struct timeval& tv)
 {
     i32 usecs = tv.tv_usec;
@@ -61,6 +62,7 @@ i64 Time::to_truncated_seconds() const
     }
     return m_seconds;
 }
+
 i64 Time::to_truncated_milliseconds() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
@@ -79,6 +81,7 @@ i64 Time::to_truncated_milliseconds() const
         return milliseconds.value();
     return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
 }
+
 i64 Time::to_truncated_microseconds() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
@@ -97,6 +100,7 @@ i64 Time::to_truncated_microseconds() const
         return microseconds.value();
     return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
 }
+
 i64 Time::to_seconds() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
@@ -107,6 +111,7 @@ i64 Time::to_seconds() const
     }
     return m_seconds;
 }
+
 i64 Time::to_milliseconds() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
@@ -123,6 +128,7 @@ i64 Time::to_milliseconds() const
         return milliseconds.value();
     return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
 }
+
 i64 Time::to_microseconds() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
@@ -139,6 +145,7 @@ i64 Time::to_microseconds() const
         return microseconds.value();
     return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
 }
+
 i64 Time::to_nanoseconds() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
@@ -153,11 +160,13 @@ i64 Time::to_nanoseconds() const
         return nanoseconds.value();
     return m_seconds < 0 ? -0x8000'0000'0000'0000LL : 0x7fff'ffff'ffff'ffffLL;
 }
+
 timespec Time::to_timespec() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
     return { static_cast<time_t>(m_seconds), static_cast<long>(m_nanoseconds) };
 }
+
 timeval Time::to_timeval() const
 {
     VERIFY(m_nanoseconds < 1'000'000'000);
@@ -239,14 +248,17 @@ bool Time::operator<(const Time& other) const
 {
     return m_seconds < other.m_seconds || (m_seconds == other.m_seconds && m_nanoseconds < other.m_nanoseconds);
 }
+
 bool Time::operator<=(const Time& other) const
 {
     return m_seconds < other.m_seconds || (m_seconds == other.m_seconds && m_nanoseconds <= other.m_nanoseconds);
 }
+
 bool Time::operator>(const Time& other) const
 {
     return m_seconds > other.m_seconds || (m_seconds == other.m_seconds && m_nanoseconds > other.m_nanoseconds);
 }
+
 bool Time::operator>=(const Time& other) const
 {
     return m_seconds > other.m_seconds || (m_seconds == other.m_seconds && m_nanoseconds >= other.m_nanoseconds);
@@ -283,6 +295,7 @@ static Time now_time_from_clock(clockid_t clock_id)
     return Time::from_timespec(now_spec);
 }
 }
+
 Time Time::now_realtime()
 {
     return now_time_from_clock(CLOCK_REALTIME);

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -10,6 +10,7 @@
 #include <AK/Assertions.h>
 #include <AK/Platform.h>
 #include <AK/Types.h>
+#include <math.h>
 
 // Kernel and Userspace pull in the definitions from different places.
 // Avoid trying to figure out which one.
@@ -76,6 +77,14 @@ constexpr int years_to_days_since_epoch(int year)
 constexpr int days_since_epoch(int year, int month, int day)
 {
     return years_to_days_since_epoch(year) + day_of_year(year, month, day);
+}
+
+constexpr i64 seconds_since_epoch_to_year(i64 seconds)
+{
+    constexpr double seconds_per_year = 60.0 * 60.0 * 24.0 * 365.2425;
+
+    auto years_since_epoch = static_cast<double>(seconds) / seconds_per_year;
+    return 1970 + static_cast<i64>(floor(years_since_epoch));
 }
 
 /*
@@ -338,6 +347,7 @@ using AK::days_in_month;
 using AK::days_in_year;
 using AK::days_since_epoch;
 using AK::is_leap_year;
+using AK::seconds_since_epoch_to_year;
 using AK::Time;
 using AK::timespec_add;
 using AK::timespec_add_timeval;

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -2207,17 +2207,17 @@ static TimeZoneNames const* find_time_zone_names(StringView locale, StringView t
     return &s_time_zones[time_zone_index];
 }
 
-Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone, CalendarPatternStyle style)
+Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone, CalendarPatternStyle style, TimeZone::InDST in_dst)
 {
     if (auto const* data = find_time_zone_names(locale, time_zone); data != nullptr) {
         size_t name_index = 0;
 
         switch (style) {
         case CalendarPatternStyle::Short:
-            name_index = data->short_standard_name;
+            name_index = (in_dst == TimeZone::InDST::No) ? data->short_standard_name : data->short_daylight_name;
             break;
         case CalendarPatternStyle::Long:
-            name_index = data->long_standard_name;
+            name_index = (in_dst == TimeZone::InDST::No) ? data->long_standard_name : data->long_daylight_name;
             break;
         case CalendarPatternStyle::ShortGeneric:
             name_index = data->short_generic_name;

--- a/Tests/LibTimeZone/TestTimeZone.cpp
+++ b/Tests/LibTimeZone/TestTimeZone.cpp
@@ -85,18 +85,20 @@ TEST_CASE(canonicalize_time_zone)
     EXPECT(!TimeZone::canonicalize_time_zone("I don't exist"sv).has_value());
 }
 
+static i64 offset(i64 sign, i64 hours, i64 minutes, i64 seconds)
+{
+    return sign * ((hours * 3600) + (minutes * 60) + seconds);
+}
+
+static void test_offset(StringView time_zone, i64 time, i64 expected_offset)
+{
+    auto actual_offset = TimeZone::get_time_zone_offset(time_zone, AK::Time::from_seconds(time));
+    VERIFY(actual_offset.has_value());
+    EXPECT_EQ(*actual_offset, expected_offset);
+}
+
 TEST_CASE(get_time_zone_offset)
 {
-    auto offset = [](i64 sign, i64 hours, i64 minutes, i64 seconds) {
-        return sign * ((hours * 3600) + (minutes * 60) + seconds);
-    };
-
-    auto test_offset = [](auto time_zone, i64 time, i64 expected_offset) {
-        auto actual_offset = TimeZone::get_time_zone_offset(time_zone, AK::Time::from_seconds(time));
-        VERIFY(actual_offset.has_value());
-        EXPECT_EQ(*actual_offset, expected_offset);
-    };
-
     test_offset("America/Chicago"sv, -2717668237, offset(-1, 5, 50, 36)); // Sunday, November 18, 1883 12:09:23 PM
     test_offset("America/Chicago"sv, -2717668236, offset(-1, 6, 00, 00)); // Sunday, November 18, 1883 12:09:24 PM
     test_offset("America/Chicago"sv, -1067810460, offset(-1, 6, 00, 00)); // Sunday, March 1, 1936 1:59:00 AM
@@ -124,6 +126,24 @@ TEST_CASE(get_time_zone_offset)
     test_offset("Etc/GMT-14"sv, 1641846268, offset(+1, 14, 00, 00));
 
     EXPECT(!TimeZone::get_time_zone_offset("I don't exist"sv, {}).has_value());
+}
+
+TEST_CASE(get_time_zone_offset_with_dst)
+{
+    test_offset("America/New_York"sv, 1642558528, offset(-1, 5, 00, 00)); // Wednesday, January 19, 2022 2:15:28 AM
+    test_offset("America/New_York"sv, 1663553728, offset(-1, 4, 00, 00)); // Monday, September 19, 2022 2:15:28 AM
+    test_offset("America/New_York"sv, 1671453238, offset(-1, 5, 00, 00)); // Monday, December 19, 2022 12:33:58 PM
+
+    // Phoenix does not observe DST.
+    test_offset("America/Phoenix"sv, 1642558528, offset(-1, 7, 00, 00)); // Wednesday, January 19, 2022 2:15:28 AM
+    test_offset("America/Phoenix"sv, 1663553728, offset(-1, 7, 00, 00)); // Monday, September 19, 2022 2:15:28 AM
+    test_offset("America/Phoenix"sv, 1671453238, offset(-1, 7, 00, 00)); // Monday, December 19, 2022 12:33:58 PM
+
+    // Moscow's observed DST changed several times in 1919.
+    test_offset("Europe/Moscow"sv, -1609459200, offset(+1, 2, 31, 19)); // Wednesday, January 1, 1919 12:00:00 AM
+    test_offset("Europe/Moscow"sv, -1596412800, offset(+1, 4, 31, 19)); // Sunday, June 1, 1919 12:00:00 AM
+    test_offset("Europe/Moscow"sv, -1592611200, offset(+1, 4, 00, 00)); // Tuesday, July 15, 1919 12:00:00 AM
+    test_offset("Europe/Moscow"sv, -1589068800, offset(+1, 3, 00, 00)); // Monday, August 25, 1919 12:00:00 AM
 }
 
 #else

--- a/Tests/LibTimeZone/TestTimeZone.cpp
+++ b/Tests/LibTimeZone/TestTimeZone.cpp
@@ -10,6 +10,8 @@
 #include <AK/Time.h>
 #include <LibTimeZone/TimeZone.h>
 
+using enum TimeZone::InDST;
+
 #if ENABLE_TIME_ZONE_DATA
 
 #    include <LibTimeZone/TimeZoneData.h>
@@ -90,60 +92,61 @@ static i64 offset(i64 sign, i64 hours, i64 minutes, i64 seconds)
     return sign * ((hours * 3600) + (minutes * 60) + seconds);
 }
 
-static void test_offset(StringView time_zone, i64 time, i64 expected_offset)
+static void test_offset(StringView time_zone, i64 time, i64 expected_offset, TimeZone::InDST expected_in_dst)
 {
     auto actual_offset = TimeZone::get_time_zone_offset(time_zone, AK::Time::from_seconds(time));
     VERIFY(actual_offset.has_value());
-    EXPECT_EQ(*actual_offset, expected_offset);
+    EXPECT_EQ(actual_offset->seconds, expected_offset);
+    EXPECT_EQ(actual_offset->in_dst, expected_in_dst);
 }
 
 TEST_CASE(get_time_zone_offset)
 {
-    test_offset("America/Chicago"sv, -2717668237, offset(-1, 5, 50, 36)); // Sunday, November 18, 1883 12:09:23 PM
-    test_offset("America/Chicago"sv, -2717668236, offset(-1, 6, 00, 00)); // Sunday, November 18, 1883 12:09:24 PM
-    test_offset("America/Chicago"sv, -1067810460, offset(-1, 6, 00, 00)); // Sunday, March 1, 1936 1:59:00 AM
-    test_offset("America/Chicago"sv, -1067810400, offset(-1, 5, 00, 00)); // Sunday, March 1, 1936 2:00:00 AM
-    test_offset("America/Chicago"sv, -1045432860, offset(-1, 5, 00, 00)); // Sunday, November 15, 1936 1:59:00 AM
-    test_offset("America/Chicago"sv, -1045432800, offset(-1, 6, 00, 00)); // Sunday, November 15, 1936 2:00:00 AM
+    test_offset("America/Chicago"sv, -2717668237, offset(-1, 5, 50, 36), No); // Sunday, November 18, 1883 12:09:23 PM
+    test_offset("America/Chicago"sv, -2717668236, offset(-1, 6, 00, 00), No); // Sunday, November 18, 1883 12:09:24 PM
+    test_offset("America/Chicago"sv, -1067810460, offset(-1, 6, 00, 00), No); // Sunday, March 1, 1936 1:59:00 AM
+    test_offset("America/Chicago"sv, -1067810400, offset(-1, 5, 00, 00), No); // Sunday, March 1, 1936 2:00:00 AM
+    test_offset("America/Chicago"sv, -1045432860, offset(-1, 5, 00, 00), No); // Sunday, November 15, 1936 1:59:00 AM
+    test_offset("America/Chicago"sv, -1045432800, offset(-1, 6, 00, 00), No); // Sunday, November 15, 1936 2:00:00 AM
 
-    test_offset("Europe/London"sv, -3852662401, offset(-1, 0, 01, 15)); // Tuesday, November 30, 1847 11:59:59 PM
-    test_offset("Europe/London"sv, -3852662400, offset(+1, 0, 00, 00)); // Wednesday, December 1, 1847 12:00:00 AM
-    test_offset("Europe/London"sv, -37238401, offset(+1, 0, 00, 00));   // Saturday, October 26, 1968 11:59:59 PM
-    test_offset("Europe/London"sv, -37238400, offset(+1, 1, 00, 00));   // Sunday, October 27, 1968 12:00:00 AM
-    test_offset("Europe/London"sv, 57722399, offset(+1, 1, 00, 00));    // Sunday, October 31, 1971 1:59:59 AM
-    test_offset("Europe/London"sv, 57722400, offset(+1, 0, 00, 00));    // Sunday, October 31, 1971 2:00:00 AM
+    test_offset("Europe/London"sv, -3852662401, offset(-1, 0, 01, 15), No); // Tuesday, November 30, 1847 11:59:59 PM
+    test_offset("Europe/London"sv, -3852662400, offset(+1, 0, 00, 00), No); // Wednesday, December 1, 1847 12:00:00 AM
+    test_offset("Europe/London"sv, -37238401, offset(+1, 0, 00, 00), No);   // Saturday, October 26, 1968 11:59:59 PM
+    test_offset("Europe/London"sv, -37238400, offset(+1, 1, 00, 00), No);   // Sunday, October 27, 1968 12:00:00 AM
+    test_offset("Europe/London"sv, 57722399, offset(+1, 1, 00, 00), No);    // Sunday, October 31, 1971 1:59:59 AM
+    test_offset("Europe/London"sv, 57722400, offset(+1, 0, 00, 00), No);    // Sunday, October 31, 1971 2:00:00 AM
 
-    test_offset("UTC"sv, -1641846268, offset(+1, 0, 00, 00));
-    test_offset("UTC"sv, 0, offset(+1, 0, 00, 00));
-    test_offset("UTC"sv, 1641846268, offset(+1, 0, 00, 00));
+    test_offset("UTC"sv, -1641846268, offset(+1, 0, 00, 00), No);
+    test_offset("UTC"sv, 0, offset(+1, 0, 00, 00), No);
+    test_offset("UTC"sv, 1641846268, offset(+1, 0, 00, 00), No);
 
-    test_offset("Etc/GMT+4"sv, -1641846268, offset(-1, 4, 00, 00));
-    test_offset("Etc/GMT+5"sv, 0, offset(-1, 5, 00, 00));
-    test_offset("Etc/GMT+6"sv, 1641846268, offset(-1, 6, 00, 00));
+    test_offset("Etc/GMT+4"sv, -1641846268, offset(-1, 4, 00, 00), No);
+    test_offset("Etc/GMT+5"sv, 0, offset(-1, 5, 00, 00), No);
+    test_offset("Etc/GMT+6"sv, 1641846268, offset(-1, 6, 00, 00), No);
 
-    test_offset("Etc/GMT-12"sv, -1641846268, offset(+1, 12, 00, 00));
-    test_offset("Etc/GMT-13"sv, 0, offset(+1, 13, 00, 00));
-    test_offset("Etc/GMT-14"sv, 1641846268, offset(+1, 14, 00, 00));
+    test_offset("Etc/GMT-12"sv, -1641846268, offset(+1, 12, 00, 00), No);
+    test_offset("Etc/GMT-13"sv, 0, offset(+1, 13, 00, 00), No);
+    test_offset("Etc/GMT-14"sv, 1641846268, offset(+1, 14, 00, 00), No);
 
     EXPECT(!TimeZone::get_time_zone_offset("I don't exist"sv, {}).has_value());
 }
 
 TEST_CASE(get_time_zone_offset_with_dst)
 {
-    test_offset("America/New_York"sv, 1642558528, offset(-1, 5, 00, 00)); // Wednesday, January 19, 2022 2:15:28 AM
-    test_offset("America/New_York"sv, 1663553728, offset(-1, 4, 00, 00)); // Monday, September 19, 2022 2:15:28 AM
-    test_offset("America/New_York"sv, 1671453238, offset(-1, 5, 00, 00)); // Monday, December 19, 2022 12:33:58 PM
+    test_offset("America/New_York"sv, 1642558528, offset(-1, 5, 00, 00), No);  // Wednesday, January 19, 2022 2:15:28 AM
+    test_offset("America/New_York"sv, 1663553728, offset(-1, 4, 00, 00), Yes); // Monday, September 19, 2022 2:15:28 AM
+    test_offset("America/New_York"sv, 1671453238, offset(-1, 5, 00, 00), No);  // Monday, December 19, 2022 12:33:58 PM
 
     // Phoenix does not observe DST.
-    test_offset("America/Phoenix"sv, 1642558528, offset(-1, 7, 00, 00)); // Wednesday, January 19, 2022 2:15:28 AM
-    test_offset("America/Phoenix"sv, 1663553728, offset(-1, 7, 00, 00)); // Monday, September 19, 2022 2:15:28 AM
-    test_offset("America/Phoenix"sv, 1671453238, offset(-1, 7, 00, 00)); // Monday, December 19, 2022 12:33:58 PM
+    test_offset("America/Phoenix"sv, 1642558528, offset(-1, 7, 00, 00), No); // Wednesday, January 19, 2022 2:15:28 AM
+    test_offset("America/Phoenix"sv, 1663553728, offset(-1, 7, 00, 00), No); // Monday, September 19, 2022 2:15:28 AM
+    test_offset("America/Phoenix"sv, 1671453238, offset(-1, 7, 00, 00), No); // Monday, December 19, 2022 12:33:58 PM
 
     // Moscow's observed DST changed several times in 1919.
-    test_offset("Europe/Moscow"sv, -1609459200, offset(+1, 2, 31, 19)); // Wednesday, January 1, 1919 12:00:00 AM
-    test_offset("Europe/Moscow"sv, -1596412800, offset(+1, 4, 31, 19)); // Sunday, June 1, 1919 12:00:00 AM
-    test_offset("Europe/Moscow"sv, -1592611200, offset(+1, 4, 00, 00)); // Tuesday, July 15, 1919 12:00:00 AM
-    test_offset("Europe/Moscow"sv, -1589068800, offset(+1, 3, 00, 00)); // Monday, August 25, 1919 12:00:00 AM
+    test_offset("Europe/Moscow"sv, -1609459200, offset(+1, 2, 31, 19), No);  // Wednesday, January 1, 1919 12:00:00 AM
+    test_offset("Europe/Moscow"sv, -1596412800, offset(+1, 4, 31, 19), Yes); // Sunday, June 1, 1919 12:00:00 AM
+    test_offset("Europe/Moscow"sv, -1592611200, offset(+1, 4, 00, 00), Yes); // Tuesday, July 15, 1919 12:00:00 AM
+    test_offset("Europe/Moscow"sv, -1589068800, offset(+1, 3, 00, 00), No);  // Monday, August 25, 1919 12:00:00 AM
 }
 
 #else
@@ -159,7 +162,7 @@ TEST_CASE(time_zone_from_string)
 
 TEST_CASE(get_time_zone_offset)
 {
-    EXPECT_EQ(TimeZone::get_time_zone_offset("UTC", AK::Time::from_seconds(123456)), 0);
+    EXPECT_EQ(TimeZone::get_time_zone_offset("UTC", AK::Time::from_seconds(123456)), { 0, No });
 
     EXPECT(!TimeZone::get_time_zone_offset("Europe/Paris"sv, {}).has_value());
     EXPECT(!TimeZone::get_time_zone_offset("Etc/UTC"sv, {}).has_value());

--- a/Tests/LibUnicode/TestUnicodeDateTimeFormat.cpp
+++ b/Tests/LibUnicode/TestUnicodeDateTimeFormat.cpp
@@ -80,6 +80,56 @@ TEST_CASE(time_zone_name)
     }
 }
 
+TEST_CASE(time_zone_name_dst)
+{
+    struct TestData {
+        StringView locale;
+        Unicode::CalendarPatternStyle style;
+        StringView time_zone;
+        StringView expected_result;
+    };
+
+    constexpr auto test_data = Array {
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "UTC"sv, "Coordinated Universal Time"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "UTC"sv, "UTC"sv },
+
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "UTC"sv, "التوقيت العالمي المنسق"sv },
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Short, "UTC"sv, "UTC"sv },
+
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "America/Los_Angeles"sv, "Pacific Daylight Time"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "America/Los_Angeles"sv, "PDT"sv },
+
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "America/Los_Angeles"sv, "توقيت المحيط الهادي الصيفي"sv },
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Short, "America/Los_Angeles"sv, "غرينتش-٧"sv },
+
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "America/Vancouver"sv, "Pacific Daylight Time"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "America/Vancouver"sv, "PDT"sv },
+
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "America/Vancouver"sv, "توقيت المحيط الهادي الصيفي"sv },
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Short, "America/Vancouver"sv, "غرينتش-٧"sv },
+
+        // FIXME: This should be "British Summer Time", but the CLDR puts that one name in a section we aren't parsing.
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "Europe/London"sv, "GMT+01:00"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "Europe/London"sv, "GMT+1"sv },
+
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "Europe/London"sv, "غرينتش+٠١:٠٠"sv },
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Short, "Europe/London"sv, "غرينتش+١"sv },
+
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Long, "Africa/Accra"sv, "Greenwich Mean Time"sv },
+        TestData { "en"sv, Unicode::CalendarPatternStyle::Short, "Africa/Accra"sv, "GMT"sv },
+
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Long, "Africa/Accra"sv, "توقيت غرينتش"sv },
+        TestData { "ar"sv, Unicode::CalendarPatternStyle::Short, "Africa/Accra"sv, "غرينتش"sv },
+    };
+
+    constexpr auto sep_19_2022 = AK::Time::from_seconds(1663553728); // Monday, September 19, 2022 2:15:28 AM
+
+    for (auto const& test : test_data) {
+        auto time_zone = Unicode::format_time_zone(test.locale, test.time_zone, test.style, sep_19_2022);
+        EXPECT_EQ(time_zone, test.expected_result);
+    }
+}
+
 TEST_CASE(format_time_zone_offset)
 {
     constexpr auto jan_1_1833 = AK::Time::from_seconds(-4323283200); // Tuesday, January 1, 1833 12:00:00 AM

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -286,7 +286,8 @@ double local_tza(double time, [[maybe_unused]] bool is_utc, Optional<StringView>
 
     auto time_since_epoch = Value(time).is_finite_number() ? AK::Time::from_milliseconds(time) : AK::Time::max();
     auto maybe_offset = TimeZone::get_time_zone_offset(time_zone, time_since_epoch);
-    return maybe_offset.value_or(0) * 1000;
+
+    return maybe_offset.has_value() ? static_cast<double>(maybe_offset->seconds) * 1000 : 0;
 }
 
 // 21.4.1.8 LocalTime ( t ), https://tc39.es/ecma262/#sec-localtime

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -1057,8 +1057,10 @@ String time_zone_string(double time)
     auto tz_name = TimeZone::current_time_zone();
 
     // Most implementations seem to prefer the long-form display name of the time zone. Not super important, but we may as well match that behavior.
-    if (auto long_name = Unicode::get_time_zone_name(Unicode::default_locale(), tz_name, Unicode::CalendarPatternStyle::Long); long_name.has_value())
-        tz_name = long_name.release_value();
+    if (auto maybe_offset = TimeZone::get_time_zone_offset(tz_name, AK::Time::from_milliseconds(time)); maybe_offset.has_value()) {
+        if (auto long_name = Unicode::get_time_zone_name(Unicode::default_locale(), tz_name, Unicode::CalendarPatternStyle::Long, maybe_offset->in_dst); long_name.has_value())
+            tz_name = long_name.release_value();
+    }
 
     // 7. Return the string-concatenation of offsetSign, offsetHour, offsetMin, and tzName.
     return String::formatted("{}{:02}{:02} ({})", offset_sign, offset_hour, offset_min, tz_name);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -937,7 +937,6 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObjec
             // iii. Let fv be a String value representing v in the form given by f; the String value depends upon the implementation and the effective locale of dateTimeFormat.
             //      The String value may also depend on the value of the [[InDST]] field of tm if f is "short", "long", "shortOffset", or "longOffset".
             //      If the implementation does not have a localized representation of f, then use the String value of v itself.
-            // FIXME: This should take [[InDST]] into account.
             auto formatted_value = Unicode::format_time_zone(data_locale, value, style, local_time.time_since_epoch());
 
             // iv. Append a new Record { [[Type]]: p, [[Value]]: fv } as the last element of the list result.
@@ -1530,9 +1529,6 @@ ThrowCompletionOr<LocalTime> to_local_time(GlobalObject& global_object, double t
             .second = sec_from_time(zoned_time),
             // msFromTime(tz) specified in es2022's Hours, Minutes, Second, and Milliseconds.
             .millisecond = ms_from_time(zoned_time),
-            // Calculate true or false using the best available information about the specified calendar and timeZone, including current and historical information about time zone offsets from UTC and daylight saving time rules.
-            // FIXME: Implement this.
-            .in_dst = false,
         };
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -161,6 +161,7 @@ enum class OptionDefaults {
 };
 
 // Table 5: Record returned by ToLocalTime, https://tc39.es/ecma402/#table-datetimeformat-tolocaltime-record
+// Note: [[InDST]] is not included here - it is handled by LibUnicode / LibTimeZone.
 struct LocalTime {
     AK::Time time_since_epoch() const
     {
@@ -178,7 +179,6 @@ struct LocalTime {
     u8 minute { 0 };       // [[Minute]]
     u8 second { 0 };       // [[Second]]
     u16 millisecond { 0 }; // [[Millisecond]]
-    bool in_dst { false }; // [[InDST]]
 };
 
 struct PatternPartitionWithSource : public PatternPartition {

--- a/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/TimeZone.cpp
@@ -175,10 +175,10 @@ i64 get_iana_time_zone_offset_nanoseconds(BigInt const& epoch_nanoseconds, Strin
     else
         time = Time::from_seconds(*seconds.to_base(10).to_int<i64>());
 
-    auto offset_seconds = ::TimeZone::get_time_zone_offset(*time_zone, time);
-    VERIFY(offset_seconds.has_value());
+    auto offset = ::TimeZone::get_time_zone_offset(*time_zone, time);
+    VERIFY(offset.has_value());
 
-    return *offset_seconds * 1'000'000'000;
+    return offset->seconds * 1'000'000'000;
 }
 
 // 11.6.5 GetIANATimeZoneNextTransition ( epochNanoseconds, timeZoneIdentifier ), https://tc39.es/proposal-temporal/#sec-temporal-getianatimezonenexttransition

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.getOffsetStringFor.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/TimeZone/TimeZone.prototype.getOffsetStringFor.js
@@ -9,15 +9,15 @@ describe("correct behavior", () => {
             ["GMT", "+00:00"],
             ["Etc/GMT+12", "-12:00"],
             ["Etc/GMT-12", "+12:00"],
-            ["Europe/London", "+00:00"],
-            ["Europe/Berlin", "+01:00"],
-            ["America/New_York", "-05:00"],
-            ["America/Los_Angeles", "-08:00"],
+            ["Europe/London", "+01:00"],
+            ["Europe/Berlin", "+02:00"],
+            ["America/New_York", "-04:00"],
+            ["America/Los_Angeles", "-07:00"],
             ["+00:00", "+00:00"],
             ["+01:30", "+01:30"],
         ];
         for (const [arg, expected] of values) {
-            const instant = new Temporal.Instant(1600000000000000000n);
+            const instant = new Temporal.Instant(1600000000000000000n); // Sunday, September 13, 2020 12:26:40 PM
             expect(new Temporal.TimeZone(arg).getOffsetStringFor(instant)).toBe(expected);
         }
     });

--- a/Userland/Libraries/LibTimeZone/Forward.h
+++ b/Userland/Libraries/LibTimeZone/Forward.h
@@ -10,6 +10,7 @@
 
 namespace TimeZone {
 
+enum class DaylightSavingsRule : u8;
 enum class TimeZone : u16;
 
 }

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -63,6 +63,9 @@ Optional<StringView> canonicalize_time_zone(StringView time_zone)
     return canonical_time_zone;
 }
 
+Optional<DaylightSavingsRule> __attribute__((weak)) daylight_savings_rule_from_string(StringView) { return {}; }
+StringView __attribute__((weak)) daylight_savings_rule_to_string(DaylightSavingsRule) { return {}; }
+
 Optional<i64> __attribute__((weak)) get_time_zone_offset([[maybe_unused]] TimeZone time_zone, AK::Time)
 {
 #if !ENABLE_TIME_ZONE_DATA

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -66,17 +66,17 @@ Optional<StringView> canonicalize_time_zone(StringView time_zone)
 Optional<DaylightSavingsRule> __attribute__((weak)) daylight_savings_rule_from_string(StringView) { return {}; }
 StringView __attribute__((weak)) daylight_savings_rule_to_string(DaylightSavingsRule) { return {}; }
 
-Optional<i64> __attribute__((weak)) get_time_zone_offset([[maybe_unused]] TimeZone time_zone, AK::Time)
+Optional<Offset> __attribute__((weak)) get_time_zone_offset([[maybe_unused]] TimeZone time_zone, AK::Time)
 {
 #if !ENABLE_TIME_ZONE_DATA
     VERIFY(time_zone == TimeZone::UTC);
-    return 0;
+    return Offset {};
 #else
     return {};
 #endif
 }
 
-Optional<i64> get_time_zone_offset(StringView time_zone, AK::Time time)
+Optional<Offset> get_time_zone_offset(StringView time_zone, AK::Time time)
 {
     if (auto maybe_time_zone = time_zone_from_string(time_zone); maybe_time_zone.has_value())
         return get_time_zone_offset(*maybe_time_zone, time);

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -14,6 +14,16 @@
 
 namespace TimeZone {
 
+enum class InDST {
+    No,
+    Yes,
+};
+
+struct Offset {
+    i64 seconds { 0 };
+    InDST in_dst { InDST::No };
+};
+
 StringView current_time_zone();
 
 Optional<TimeZone> time_zone_from_string(StringView time_zone);
@@ -23,7 +33,7 @@ Optional<StringView> canonicalize_time_zone(StringView time_zone);
 Optional<DaylightSavingsRule> daylight_savings_rule_from_string(StringView daylight_savings_rule);
 StringView daylight_savings_rule_to_string(DaylightSavingsRule daylight_savings_rule);
 
-Optional<i64> get_time_zone_offset(TimeZone time_zone, AK::Time time);
-Optional<i64> get_time_zone_offset(StringView time_zone, AK::Time time);
+Optional<Offset> get_time_zone_offset(TimeZone time_zone, AK::Time time);
+Optional<Offset> get_time_zone_offset(StringView time_zone, AK::Time time);
 
 }

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -20,6 +20,9 @@ Optional<TimeZone> time_zone_from_string(StringView time_zone);
 StringView time_zone_to_string(TimeZone time_zone);
 Optional<StringView> canonicalize_time_zone(StringView time_zone);
 
+Optional<DaylightSavingsRule> daylight_savings_rule_from_string(StringView daylight_savings_rule);
+StringView daylight_savings_rule_to_string(DaylightSavingsRule daylight_savings_rule);
+
 Optional<i64> get_time_zone_offset(TimeZone time_zone, AK::Time time);
 Optional<i64> get_time_zone_offset(StringView time_zone, AK::Time time);
 

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -12,6 +12,7 @@
 #include <AK/Time.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
+#include <LibTimeZone/TimeZone.h>
 #include <LibUnicode/Forward.h>
 
 namespace Unicode {
@@ -210,7 +211,7 @@ Optional<StringView> get_calendar_day_period_symbol(StringView locale, StringVie
 Optional<StringView> get_calendar_day_period_symbol_for_hour(StringView locale, StringView calendar, CalendarPatternStyle style, u8 hour);
 
 String format_time_zone(StringView locale, StringView time_zone, CalendarPatternStyle style, AK::Time time);
-Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone, CalendarPatternStyle style);
+Optional<StringView> get_time_zone_name(StringView locale, StringView time_zone, CalendarPatternStyle style, TimeZone::InDST in_dst);
 Optional<TimeZoneFormat> get_time_zone_format(StringView locale);
 
 }


### PR DESCRIPTION
This adds initial support for handling DST within LibTimeZone and its consumers. It's certainly not complete (there are RULE variants we don't yet handle), but it's a start.

I'll just leave you with this absolute gem from directly from the TZDB:
> I don't really care how time is reckoned so long as there is some
agreement about it, but I object to being told that I am saving
daylight when my reason tells me that I am doing nothing of the kind.
I even object to the implication that I am wasting something
valuable if I stay in bed after the sun has risen.  As an admirer
of moonlight I resent the bossy insistence of those who want to
reduce my time for enjoying it.  At the back of the Daylight Saving
scheme I detect the bony, blue-fingered hand of Puritanism, eager
to push people into bed earlier, and get them up earlier, to make
them healthy, wealthy and wise in spite of themselves.