### PR TITLE
Base: Add more Terminal themes

### DIFF
--- a/Base/res/terminal-colors/C64.ini
+++ b/Base/res/terminal-colors/C64.ini
@@ -1,0 +1,32 @@
+[Options]
+; Specifies whether bold text is displayed using bright colors.
+ShowBoldTextAsBright=false
+
+; Default text and background colors
+[Primary]
+Background=#53489d
+Foreground=#7b7fcd
+
+; Normal named colors
+; These correspond to ANSI colors 0-7.
+[Normal]
+Black=#080200
+Red=#994c50
+Green=#67ac66
+Yellow=#cad488
+Blue=#ffffff
+Magenta=#9d59a5
+Cyan=#7cc2c8
+White=#ffffff
+
+; Bright named colors
+; These correspond to ANSI colors 8-15.
+[Bright]
+Black=#080200
+Red=#994c50
+Green=#67ac66
+Yellow=#cad488
+Blue=#ffffff
+Magenta=#9d59a5
+Cyan=#7cc2c8
+White=#ffffff

--- a/Base/res/terminal-colors/Octopus Cat.ini
+++ b/Base/res/terminal-colors/Octopus Cat.ini
@@ -1,0 +1,32 @@
+[Options]
+; Specifies whether bold text is displayed using bright colors.
+ShowBoldTextAsBright=false
+
+; Default text and background colors
+[Primary]
+Background=#ffffff
+Foreground=#141414
+
+; Normal named colors
+; These correspond to ANSI colors 0-7.
+[Normal]
+Black=#141414
+Red=#a71c21
+Green=#01a23d
+Yellow=#01a23d
+Blue=#152f65
+Magenta=#a0e5f9
+Cyan=#a0e5f9
+White=#eeeeee
+
+; Bright named colors
+; These correspond to ANSI colors 8-15.
+[Bright]
+Black=#4f4f4f
+Red=#e32113
+Green=#99dab2
+Yellow=#f9f4ef
+Blue=#214fa8
+Magenta=#a0e5f9
+Cyan=#30f9fd
+White=#ffffff


### PR DESCRIPTION
Commodore 64 theme and Github Light theme, each for Terminal.

<img width="592" alt="Screen Shot 2022-01-19 at 20 58 54" src="https://user-images.githubusercontent.com/4368524/150248758-a8c30a95-09f6-462d-8586-8ea8e2d328ed.png">
<img width="593" alt="Screen Shot 2022-01-19 at 20 45 14" src="https://user-images.githubusercontent.com/4368524/150248761-3cf09f39-7b90-4312-9d1c-312c12fc3f47.png">
