### PR TITLE
Utilities: Add fontdump, a font glyph dumping utility

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -480,6 +480,10 @@ if (BUILD_LAGOM)
         set_target_properties(disasm_lagom PROPERTIES OUTPUT_NAME disasm)
         target_link_libraries(disasm_lagom LagomCore LagomELF LagomX86 LagomMain)
 
+        add_executable(fontdump_lagom ../../Userland/Utilities/fontdump.cpp)
+        set_target_properties(fontdump_lagom PROPERTIES OUTPUT_NAME fontdump)
+        target_link_libraries(fontdump_lagom LagomCore LagomMain LagomGfx)
+
         add_executable(gml-format_lagom ../../Userland/Utilities/gml-format.cpp)
         set_target_properties(gml-format_lagom PROPERTIES OUTPUT_NAME gml-format)
         target_link_libraries(gml-format_lagom LagomCore LagomGML LagomMain)

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND REQUIRED_TARGETS
     touch tr true umount uname uniq uptime w wc which whoami xargs yes less
 )
 list(APPEND RECOMMENDED_TARGETS
-    adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip init keymap lsirq lsof lspci man mknod mktemp
+    adjtime aplay abench asctl bt checksum chres cksum copy fontdump fortune gunzip gzip init keymap lsirq lsof lspci man mknod mktemp
     nc netstat notify ntpquery open pape passwd pls printf pro shot tar tt unzip zip
 )
 
@@ -97,6 +97,7 @@ target_link_libraries(fgrep LibMain)
 target_link_libraries(file LibGfx LibIPC LibCompress LibMain)
 target_link_libraries(find LibMain)
 target_link_libraries(flock LibMain)
+target_link_libraries(fontdump LibMain LibGfx)
 target_link_libraries(fortune LibMain)
 target_link_libraries(functrace LibDebug LibX86 LibMain)
 target_link_libraries(gml-format LibGUI LibMain)

--- a/Userland/Utilities/fontdump.cpp
+++ b/Userland/Utilities/fontdump.cpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/JsonArray.h>
+#include <AK/Vector.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/System.h>
+#include <LibGfx/BitmapFont.h>
+#include <LibMain/Main.h>
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+#ifdef __serenity__
+    TRY(Core::System::pledge("stdio rpath"));
+#endif
+
+    StringView font_path;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("Dump information about a font");
+    args_parser.add_positional_argument(font_path, "Font path", "path", Core::ArgsParser::Required::Yes);
+    args_parser.parse(arguments);
+
+    auto maybe_font = Gfx::BitmapFont::load_from_file(font_path);
+    if (maybe_font.is_null()) {
+        auto error = String::formatted("Error: font {} could not be loaded.", font_path);
+        return Error::from_string_literal(error);
+    }
+    auto font = maybe_font.release_nonnull();
+
+    size_t total_glyphs = font->glyph_count();
+    size_t treated_glyphs = 0;
+    u32 current_codepoint = 0;
+    Vector<u32> defined_glyphs;
+    TRY(defined_glyphs.try_ensure_capacity(total_glyphs));
+
+    // FIXME: Is this the highest possible number of a code point?
+    while (treated_glyphs < total_glyphs && current_codepoint <= 0x10FFFF) {
+        if (font->contains_glyph(current_codepoint)) {
+            TRY(defined_glyphs.try_append(current_codepoint));
+            ++treated_glyphs;
+        }
+        ++current_codepoint;
+    }
+
+    auto json_codepoint_list = JsonArray(defined_glyphs).to_string();
+    outln(json_codepoint_list);
+
+    return 0;
+}


### PR DESCRIPTION
As per @xexxa's wish, the fontdump utility outputs a JSON array of all the codepoints of the glyphs defined in a font. This commit also adds support for running the utility on Lagom.