### PR TITLE
Browser: Convert file access to Core::Stream

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -16,6 +16,7 @@
 #include <Applications/Browser/BrowserWindowGML.h>
 #include <LibConfig/Client.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCore/Stream.h>
 #include <LibGUI/AboutDialog.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Clipboard.h>
@@ -247,74 +248,9 @@ void BrowserWindow::build_menus()
 
     settings_menu.add_action(*m_change_homepage_action);
 
-    m_search_engine_actions.set_exclusive(true);
-    auto& search_engine_menu = settings_menu.add_submenu("&Search Engine");
-    search_engine_menu.set_icon(g_icon_bag.find);
-    bool search_engine_set = false;
-
-    m_disable_search_engine_action = GUI::Action::create_checkable(
-        "Disable", [](auto&) {
-            g_search_engine = {};
-            Config::write_string("Browser", "Preferences", "SearchEngine", g_search_engine);
-        },
-        this);
-    search_engine_menu.add_action(*m_disable_search_engine_action);
-    m_search_engine_actions.add_action(*m_disable_search_engine_action);
-    m_disable_search_engine_action->set_checked(true);
-
-    auto search_engines_file = Core::File::construct(Browser::search_engines_file_path());
-    if (search_engines_file->open(Core::OpenMode::ReadOnly)) {
-        if (auto maybe_json = JsonValue::from_string(search_engines_file->read_all()); !maybe_json.is_error() && maybe_json.value().is_array()) {
-            auto json = maybe_json.release_value().as_array();
-            for (auto& json_item : json.values()) {
-                if (!json_item.is_object())
-                    continue;
-                auto search_engine = json_item.as_object();
-                auto name = search_engine.get("title").to_string();
-                auto url_format = search_engine.get("url_format").to_string();
-
-                auto action = GUI::Action::create_checkable(
-                    name, [&, url_format](auto&) {
-                        g_search_engine = url_format;
-                        Config::write_string("Browser", "Preferences", "SearchEngine", g_search_engine);
-                    },
-                    this);
-                search_engine_menu.add_action(action);
-                m_search_engine_actions.add_action(action);
-
-                if (g_search_engine == url_format) {
-                    action->set_checked(true);
-                    search_engine_set = true;
-                }
-                action->set_status_tip(url_format);
-            }
-        }
-    }
-
-    auto custom_search_engine_action = GUI::Action::create_checkable("Custom...", [&](auto& action) {
-        String search_engine;
-        if (GUI::InputBox::show(this, search_engine, "Enter URL template:", "Custom Search Engine", "https://host/search?q={}") != GUI::InputBox::ExecOK || search_engine.is_empty()) {
-            m_disable_search_engine_action->activate();
-            return;
-        }
-
-        auto argument_count = search_engine.count("{}"sv);
-        if (argument_count != 1) {
-            GUI::MessageBox::show(this, "Invalid format, must contain '{}' once!", "Error", GUI::MessageBox::Type::Error);
-            m_disable_search_engine_action->activate();
-            return;
-        }
-
-        g_search_engine = search_engine;
-        Config::write_string("Browser", "Preferences", "SearchEngine", g_search_engine);
-        action.set_status_tip(search_engine);
-    });
-    search_engine_menu.add_action(custom_search_engine_action);
-    m_search_engine_actions.add_action(custom_search_engine_action);
-
-    if (!search_engine_set && !g_search_engine.is_empty()) {
-        custom_search_engine_action->set_checked(true);
-        custom_search_engine_action->set_status_tip(g_search_engine);
+    auto load_search_engines_result = load_search_engines(settings_menu);
+    if (load_search_engines_result.is_error()) {
+        dbgln("Failed to open search-engines file: {}", load_search_engines_result.error());
     }
 
     auto& color_scheme_menu = settings_menu.add_submenu("&Color Scheme");
@@ -430,6 +366,88 @@ void BrowserWindow::build_menus()
 
     auto& help_menu = add_menu("&Help");
     help_menu.add_action(WindowActions::the().about_action());
+}
+
+ErrorOr<void> BrowserWindow::load_search_engines(GUI::Menu& settings_menu)
+{
+    m_search_engine_actions.set_exclusive(true);
+    auto& search_engine_menu = settings_menu.add_submenu("&Search Engine");
+    search_engine_menu.set_icon(g_icon_bag.find);
+    bool search_engine_set = false;
+
+    m_disable_search_engine_action = GUI::Action::create_checkable(
+        "Disable", [](auto&) {
+            g_search_engine = {};
+            Config::write_string("Browser", "Preferences", "SearchEngine", g_search_engine);
+        },
+        this);
+    search_engine_menu.add_action(*m_disable_search_engine_action);
+    m_search_engine_actions.add_action(*m_disable_search_engine_action);
+    m_disable_search_engine_action->set_checked(true);
+
+    auto search_engines_file = TRY(Core::Stream::File::open(Browser::search_engines_file_path(), Core::Stream::OpenMode::Read));
+    auto file_size = TRY(search_engines_file->size());
+    auto maybe_buffer = ByteBuffer::create_uninitialized(file_size);
+    if (!maybe_buffer.has_value())
+        return Error::from_string_literal("Unable to allocate buffer for reading search-engines file.");
+
+    auto buffer = maybe_buffer.release_value();
+    if (search_engines_file->read_or_error(buffer)) {
+        StringView buffer_contents { buffer.bytes() };
+        if (auto json = TRY(JsonValue::from_string(buffer_contents)); json.is_array()) {
+            auto json_array = json.as_array();
+            for (auto& json_item : json_array.values()) {
+                if (!json_item.is_object())
+                    continue;
+                auto search_engine = json_item.as_object();
+                auto name = search_engine.get("title").to_string();
+                auto url_format = search_engine.get("url_format").to_string();
+
+                auto action = GUI::Action::create_checkable(
+                    name, [&, url_format](auto&) {
+                        g_search_engine = url_format;
+                        Config::write_string("Browser", "Preferences", "SearchEngine", g_search_engine);
+                    },
+                    this);
+                search_engine_menu.add_action(action);
+                m_search_engine_actions.add_action(action);
+
+                if (g_search_engine == url_format) {
+                    action->set_checked(true);
+                    search_engine_set = true;
+                }
+                action->set_status_tip(url_format);
+            }
+        }
+    }
+
+    auto custom_search_engine_action = GUI::Action::create_checkable("Custom...", [&](auto& action) {
+        String search_engine;
+        if (GUI::InputBox::show(this, search_engine, "Enter URL template:", "Custom Search Engine", "https://host/search?q={}") != GUI::InputBox::ExecOK || search_engine.is_empty()) {
+            m_disable_search_engine_action->activate();
+            return;
+        }
+
+        auto argument_count = search_engine.count("{}"sv);
+        if (argument_count != 1) {
+            GUI::MessageBox::show(this, "Invalid format, must contain '{}' once!", "Error", GUI::MessageBox::Type::Error);
+            m_disable_search_engine_action->activate();
+            return;
+        }
+
+        g_search_engine = search_engine;
+        Config::write_string("Browser", "Preferences", "SearchEngine", g_search_engine);
+        action.set_status_tip(search_engine);
+    });
+    search_engine_menu.add_action(custom_search_engine_action);
+    m_search_engine_actions.add_action(custom_search_engine_action);
+
+    if (!search_engine_set && !g_search_engine.is_empty()) {
+        custom_search_engine_action->set_checked(true);
+        custom_search_engine_action->set_status_tip(g_search_engine);
+    }
+
+    return {};
 }
 
 GUI::TabWidget& BrowserWindow::tab_widget()

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -41,6 +41,7 @@ private:
     explicit BrowserWindow(CookieJar&, URL);
 
     void build_menus();
+    ErrorOr<void> load_search_engines(GUI::Menu& settings_menu);
     void set_window_title_for_tab(Tab const&);
 
     RefPtr<GUI::Action> m_go_back_action;

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -8,9 +8,8 @@
 #include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
 #include <LibConfig/Client.h>
-#include <LibCore/File.h>
-#include <LibCore/FileStream.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCore/Stream.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -46,13 +45,13 @@ DownloadWidget::DownloadWidget(const URL& url)
     };
 
     {
-        auto file_or_error = Core::File::open(m_destination_path, Core::OpenMode::WriteOnly);
+        auto file_or_error = Core::Stream::File::open(m_destination_path, Core::Stream::OpenMode::Write);
         if (file_or_error.is_error()) {
             GUI::MessageBox::show(window(), String::formatted("Cannot open {} for writing", m_destination_path), "Download failed", GUI::MessageBox::Type::Error);
             window()->close();
             return;
         }
-        m_output_file_stream = make<Core::OutputFileStream>(*file_or_error.value());
+        m_output_file_stream = file_or_error.release_value();
     }
 
     m_download->on_finish = [this](bool success, auto) { did_finish(success); };

--- a/Userland/Applications/Browser/DownloadWidget.h
+++ b/Userland/Applications/Browser/DownloadWidget.h
@@ -8,7 +8,7 @@
 
 #include <AK/URL.h>
 #include <LibCore/ElapsedTimer.h>
-#include <LibCore/FileStream.h>
+#include <LibCore/Stream.h>
 #include <LibGUI/ImageWidget.h>
 #include <LibGUI/Progressbar.h>
 #include <LibGUI/Widget.h>
@@ -37,7 +37,7 @@ private:
     RefPtr<GUI::Button> m_close_button;
     RefPtr<GUI::CheckBox> m_close_on_finish_checkbox;
     RefPtr<GUI::ImageWidget> m_browser_image;
-    OwnPtr<Core::OutputFileStream> m_output_file_stream;
+    OwnPtr<Core::Stream::File> m_output_file_stream;
     Core::ElapsedTimer m_elapsed_timer;
 };
 

--- a/Userland/Libraries/LibProtocol/Request.h
+++ b/Userland/Libraries/LibProtocol/Request.h
@@ -15,6 +15,7 @@
 #include <AK/String.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Notifier.h>
+#include <LibCore/Stream.h>
 #include <LibIPC/Forward.h>
 
 namespace Protocol {
@@ -38,6 +39,7 @@ public:
     bool stop();
 
     void stream_into(OutputStream&);
+    void stream_into(Core::Stream::Stream&);
 
     bool should_buffer_all_input() const { return m_should_buffer_all_input; }
     /// Note: Will override `on_finish', and `on_headers_received', and expects `on_buffered_request_finish' to be set!


### PR DESCRIPTION
Thought I should help out a bit with converting things, so here is a patch with all of Browser's Core::File usage replaced with Core::Stream.

cc: @sin-ack 