### PR TITLE
LibJS: Increase margin in check for stack space limit

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -83,11 +83,9 @@ public:
 
     bool did_reach_stack_space_limit() const
     {
-#ifdef HAS_ADDRESS_SANITIZER
+        // Address sanitizer (ASAN) used to check for more space but
+        // currently we can't detect the stack size with it enabled.
         return m_stack_info.size_free() < 32 * KiB;
-#else
-        return m_stack_info.size_free() < 16 * KiB;
-#endif
     }
 
     ThrowCompletionOr<void> push_execution_context(ExecutionContext& context, GlobalObject& global_object)


### PR DESCRIPTION
test-js crashes with a segmentation fault when running on macOS on Arm.
Increasing the margin in the test in did_reach_stack_space_limit() to
32 * KiB makes the tests pass. To simplify the code, this is applied
independently of platform, and the previous test for use of an address
sanitizer is removed.