### PR TITLE
SerenityOS: Remove semicolons from C_OBJECT macros

### DIFF
--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -26,7 +26,7 @@ enum class GraphType {
 };
 
 class GraphWidget final : public GUI::Frame {
-    C_OBJECT(GraphWidget);
+    C_OBJECT(GraphWidget)
 
 public:
     static constexpr size_t history_size = 24;

--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
@@ -12,7 +12,7 @@
 #include <LibGfx/Palette.h>
 
 class DesktopStatusWidget : public GUI::Widget {
-    C_OBJECT(DesktopStatusWidget);
+    C_OBJECT(DesktopStatusWidget)
 
 public:
     virtual ~DesktopStatusWidget() override

--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.h
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.h
@@ -11,7 +11,7 @@
 class DesktopStatusWidget;
 
 class DesktopStatusWindow : public GUI::Window {
-    C_OBJECT(DesktopStatusWindow);
+    C_OBJECT(DesktopStatusWindow)
 
 public:
     virtual ~DesktopStatusWindow() override;

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -32,7 +32,7 @@ static constexpr u16 RENDER_WIDTH = 640;
 static constexpr u16 RENDER_HEIGHT = 480;
 
 class GLContextWidget final : public GUI::Frame {
-    C_OBJECT(GLContextWidget);
+    C_OBJECT(GLContextWidget)
 
 public:
     bool load_path(String const& fname);

--- a/Userland/Applications/Browser/BookmarksBarWidget.h
+++ b/Userland/Applications/Browser/BookmarksBarWidget.h
@@ -15,7 +15,7 @@ namespace Browser {
 class BookmarksBarWidget final
     : public GUI::Widget
     , private GUI::ModelClient {
-    C_OBJECT(BookmarksBarWidget);
+    C_OBJECT(BookmarksBarWidget)
 
 public:
     static BookmarksBarWidget& the();

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -18,7 +18,7 @@ class CookieJar;
 class Tab;
 
 class BrowserWindow final : public GUI::Window {
-    C_OBJECT(BrowserWindow);
+    C_OBJECT(BrowserWindow)
 
 public:
     virtual ~BrowserWindow() override;

--- a/Userland/Applications/Browser/DownloadWidget.h
+++ b/Userland/Applications/Browser/DownloadWidget.h
@@ -17,7 +17,7 @@
 namespace Browser {
 
 class DownloadWidget final : public GUI::Widget {
-    C_OBJECT(DownloadWidget);
+    C_OBJECT(DownloadWidget)
 
 public:
     virtual ~DownloadWidget() override;

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -26,7 +26,7 @@ class InspectorWidget;
 class ConsoleWidget;
 
 class Tab final : public GUI::Widget {
-    C_OBJECT(Tab);
+    C_OBJECT(Tab)
 
     // FIXME: This should go away eventually.
     friend class BrowserWindow;

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.h
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.h
@@ -11,7 +11,7 @@
 #include <LibGUI/Statusbar.h>
 
 class CharacterMapWidget final : public GUI::Widget {
-    C_OBJECT(CharacterMapWidget);
+    C_OBJECT(CharacterMapWidget)
 
 public:
     virtual ~CharacterMapWidget() override;

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.h
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.h
@@ -12,7 +12,7 @@
 #include <LibGUI/TextBox.h>
 
 class CharacterSearchWidget final : public GUI::Widget {
-    C_OBJECT(CharacterSearchWidget);
+    C_OBJECT(CharacterSearchWidget)
 
 public:
     virtual ~CharacterSearchWidget() override;

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
@@ -18,7 +18,7 @@
 namespace DisplaySettings {
 
 class BackgroundSettingsWidget : public GUI::SettingsWindow::Tab {
-    C_OBJECT(BackgroundSettingsWidget);
+    C_OBJECT(BackgroundSettingsWidget)
 
 public:
     virtual ~BackgroundSettingsWidget() override;

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.h
@@ -13,7 +13,7 @@
 namespace DisplaySettings {
 
 class DesktopSettingsWidget : public GUI::SettingsWindow::Tab {
-    C_OBJECT(DesktopSettingsWidget);
+    C_OBJECT(DesktopSettingsWidget)
 
 public:
     virtual ~DesktopSettingsWidget() override;

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.h
@@ -12,7 +12,7 @@
 namespace DisplaySettings {
 
 class FontSettingsWidget final : public GUI::SettingsWindow::Tab {
-    C_OBJECT(FontSettingsWidget);
+    C_OBJECT(FontSettingsWidget)
 
 public:
     virtual ~FontSettingsWidget() override;

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.h
@@ -17,7 +17,7 @@
 namespace DisplaySettings {
 
 class MonitorSettingsWidget final : public GUI::SettingsWindow::Tab {
-    C_OBJECT(MonitorSettingsWidget);
+    C_OBJECT(MonitorSettingsWidget)
 
 public:
     ~MonitorSettingsWidget() override

--- a/Userland/Applications/DisplaySettings/MonitorWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.h
@@ -11,7 +11,7 @@
 namespace DisplaySettings {
 
 class MonitorWidget final : public GUI::Widget {
-    C_OBJECT(MonitorWidget);
+    C_OBJECT(MonitorWidget)
 
 public:
     bool set_wallpaper(String path);

--- a/Userland/Applications/FileManager/DesktopWidget.h
+++ b/Userland/Applications/FileManager/DesktopWidget.h
@@ -11,7 +11,7 @@
 namespace FileManager {
 
 class DesktopWidget final : public GUI::Widget {
-    C_OBJECT(DesktopWidget);
+    C_OBJECT(DesktopWidget)
 
 public:
     virtual ~DesktopWidget() override;

--- a/Userland/Applications/FileManager/DirectoryView.h
+++ b/Userland/Applications/FileManager/DirectoryView.h
@@ -41,7 +41,7 @@ class DirectoryView final
     : public GUI::StackWidget
     , private GUI::ModelClient
     , public Config::Listener {
-    C_OBJECT(DirectoryView);
+    C_OBJECT(DirectoryView)
 
 public:
     enum class Mode {

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.h
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.h
@@ -13,7 +13,7 @@
 namespace FileManager {
 
 class FileOperationProgressWidget : public GUI::Widget {
-    C_OBJECT(FileOperationProgressWidget);
+    C_OBJECT(FileOperationProgressWidget)
 
 public:
     virtual ~FileOperationProgressWidget() override;

--- a/Userland/Applications/FileManager/PropertiesWindow.h
+++ b/Userland/Applications/FileManager/PropertiesWindow.h
@@ -15,7 +15,7 @@
 #include <LibGUI/TextBox.h>
 
 class PropertiesWindow final : public GUI::Window {
-    C_OBJECT(PropertiesWindow);
+    C_OBJECT(PropertiesWindow)
 
 public:
     virtual ~PropertiesWindow() override;

--- a/Userland/Applications/FontEditor/NewFontDialog.h
+++ b/Userland/Applications/FontEditor/NewFontDialog.h
@@ -12,7 +12,7 @@
 #include <LibGfx/BitmapFont.h>
 
 class NewFontDialog final : public GUI::WizardDialog {
-    C_OBJECT(NewFontDialog);
+    C_OBJECT(NewFontDialog)
 
 public:
     auto new_font_metadata()

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -17,7 +17,7 @@ enum OptionId {
 };
 
 class FindDialog : public GUI::Dialog {
-    C_OBJECT(FindDialog);
+    C_OBJECT(FindDialog)
 
 public:
     static int show(GUI::Window* parent_window, String& out_tex, ByteBuffer& out_buffer, bool& find_all);

--- a/Userland/Applications/HexEditor/GoToOffsetDialog.h
+++ b/Userland/Applications/HexEditor/GoToOffsetDialog.h
@@ -11,7 +11,7 @@
 #include <LibGUI/Dialog.h>
 
 class GoToOffsetDialog : public GUI::Dialog {
-    C_OBJECT(GoToOffsetDialog);
+    C_OBJECT(GoToOffsetDialog)
 
 public:
     static int show(GUI::Window* parent_window, int& history_offset, int& out_offset, int selection_offset, int end);

--- a/Userland/Applications/Magnifier/MagnifierWidget.h
+++ b/Userland/Applications/Magnifier/MagnifierWidget.h
@@ -11,7 +11,7 @@
 #include <LibGfx/Filters/ColorBlindnessFilter.h>
 
 class MagnifierWidget final : public GUI::Frame {
-    C_OBJECT(MagnifierWidget);
+    C_OBJECT(MagnifierWidget)
 
 public:
     virtual ~MagnifierWidget();

--- a/Userland/Applications/MouseSettings/DoubleClickArrowWidget.h
+++ b/Userland/Applications/MouseSettings/DoubleClickArrowWidget.h
@@ -13,7 +13,7 @@
 namespace MouseSettings {
 
 class DoubleClickArrowWidget final : public GUI::Widget {
-    C_OBJECT(DoubleClickArrowWidget);
+    C_OBJECT(DoubleClickArrowWidget)
 
 public:
     virtual ~DoubleClickArrowWidget() override;

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Dropdown.h
@@ -16,7 +16,7 @@
 
 template<typename EnumT>
 requires(IsEnum<EnumT>) class ProcessorParameterDropdown : public GUI::ComboBox {
-    C_OBJECT(ProcessorParameterDropdown);
+    C_OBJECT(ProcessorParameterDropdown)
 
 public:
     ProcessorParameterDropdown(LibDSP::ProcessorEnumParameter<EnumT>& parameter, Vector<String> modes)

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
@@ -15,7 +15,7 @@
 class ProcessorParameterSlider
     : public GUI::Slider
     , public WidgetWithLabel {
-    C_OBJECT(ProcessorParameterSlider);
+    C_OBJECT(ProcessorParameterSlider)
 
 public:
     ProcessorParameterSlider(Orientation, LibDSP::ProcessorRangeParameter&, RefPtr<GUI::Label>);

--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.h
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.h
@@ -11,7 +11,7 @@
 namespace PixelPaint {
 
 class CreateNewLayerDialog final : public GUI::Dialog {
-    C_OBJECT(CreateNewLayerDialog);
+    C_OBJECT(CreateNewLayerDialog)
 
 public:
     Gfx::IntSize const& layer_size() const { return m_layer_size; }

--- a/Userland/Applications/PixelPaint/EditGuideDialog.h
+++ b/Userland/Applications/PixelPaint/EditGuideDialog.h
@@ -13,7 +13,7 @@
 namespace PixelPaint {
 
 class EditGuideDialog final : public GUI::Dialog {
-    C_OBJECT(EditGuideDialog);
+    C_OBJECT(EditGuideDialog)
 
 public:
     String const offset() const { return m_offset; }

--- a/Userland/Applications/PixelPaint/FilterGallery.h
+++ b/Userland/Applications/PixelPaint/FilterGallery.h
@@ -13,7 +13,7 @@
 namespace PixelPaint {
 
 class FilterGallery final : public GUI::Dialog {
-    C_OBJECT(FilterGallery);
+    C_OBJECT(FilterGallery)
 
 private:
     FilterGallery(GUI::Window* parent_window, ImageEditor*);

--- a/Userland/Applications/PixelPaint/FilterParams.h
+++ b/Userland/Applications/PixelPaint/FilterParams.h
@@ -31,7 +31,7 @@ struct FilterParameters {
 
 template<size_t N>
 class GenericConvolutionFilterInputDialog : public GUI::Dialog {
-    C_OBJECT(GenericConvolutionFilterInputDialog);
+    C_OBJECT(GenericConvolutionFilterInputDialog)
 
 public:
     Matrix<N, float> const& matrix() const { return m_matrix; }

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -25,7 +25,7 @@ class Tool;
 class ImageEditor final
     : public GUI::AbstractZoomPanWidget
     , public ImageClient {
-    C_OBJECT(ImageEditor);
+    C_OBJECT(ImageEditor)
 
 public:
     virtual ~ImageEditor() override;

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -15,7 +15,7 @@ namespace PixelPaint {
 class LayerListWidget final
     : public GUI::AbstractScrollableWidget
     , ImageClient {
-    C_OBJECT(LayerListWidget);
+    C_OBJECT(LayerListWidget)
 
 public:
     virtual ~LayerListWidget() override;

--- a/Userland/Applications/PixelPaint/LayerPropertiesWidget.h
+++ b/Userland/Applications/PixelPaint/LayerPropertiesWidget.h
@@ -13,7 +13,7 @@ namespace PixelPaint {
 class Layer;
 
 class LayerPropertiesWidget final : public GUI::Widget {
-    C_OBJECT(LayerPropertiesWidget);
+    C_OBJECT(LayerPropertiesWidget)
 
 public:
     virtual ~LayerPropertiesWidget() override;

--- a/Userland/Applications/PixelPaint/MainWidget.h
+++ b/Userland/Applications/PixelPaint/MainWidget.h
@@ -28,7 +28,7 @@
 namespace PixelPaint {
 
 class MainWidget : public GUI::Widget {
-    C_OBJECT(MainWidget);
+    C_OBJECT(MainWidget)
 
 public:
     virtual ~MainWidget() {};

--- a/Userland/Applications/PixelPaint/PaletteWidget.cpp
+++ b/Userland/Applications/PixelPaint/PaletteWidget.cpp
@@ -22,7 +22,7 @@ REGISTER_WIDGET(PixelPaint, PaletteWidget);
 namespace PixelPaint {
 
 class ColorWidget : public GUI::Frame {
-    C_OBJECT(ColorWidget);
+    C_OBJECT(ColorWidget)
 
 public:
     virtual ~ColorWidget() override
@@ -63,7 +63,7 @@ private:
 };
 
 class SelectedColorWidget : public GUI::Frame {
-    C_OBJECT(SelectedColorWidget);
+    C_OBJECT(SelectedColorWidget)
 
 public:
     virtual ~SelectedColorWidget() override { }

--- a/Userland/Applications/PixelPaint/PaletteWidget.h
+++ b/Userland/Applications/PixelPaint/PaletteWidget.h
@@ -18,7 +18,7 @@ class ImageEditor;
 class SelectedColorWidget;
 
 class PaletteWidget final : public GUI::Frame {
-    C_OBJECT(PaletteWidget);
+    C_OBJECT(PaletteWidget)
 
 public:
     virtual ~PaletteWidget() override;

--- a/Userland/Applications/PixelPaint/ToolPropertiesWidget.h
+++ b/Userland/Applications/PixelPaint/ToolPropertiesWidget.h
@@ -16,7 +16,7 @@ namespace PixelPaint {
 class Tool;
 
 class ToolPropertiesWidget final : public GUI::Widget {
-    C_OBJECT(ToolPropertiesWidget);
+    C_OBJECT(ToolPropertiesWidget)
 
 public:
     virtual ~ToolPropertiesWidget() override;

--- a/Userland/Applications/PixelPaint/ToolboxWidget.h
+++ b/Userland/Applications/PixelPaint/ToolboxWidget.h
@@ -15,7 +15,7 @@ namespace PixelPaint {
 class Tool;
 
 class ToolboxWidget final : public GUI::Widget {
-    C_OBJECT(ToolboxWidget);
+    C_OBJECT(ToolboxWidget)
 
 public:
     virtual ~ToolboxWidget() override;

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.h
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.h
@@ -14,7 +14,7 @@
 namespace Spreadsheet {
 
 class CellTypeDialog : public GUI::Dialog {
-    C_OBJECT(CellTypeDialog);
+    C_OBJECT(CellTypeDialog)
 
 public:
     CellTypeMetadata metadata() const;

--- a/Userland/Applications/Spreadsheet/HelpWindow.h
+++ b/Userland/Applications/Spreadsheet/HelpWindow.h
@@ -15,7 +15,7 @@
 namespace Spreadsheet {
 
 class HelpWindow : public GUI::Window {
-    C_OBJECT(HelpWindow);
+    C_OBJECT(HelpWindow)
 
 public:
     static NonnullRefPtr<HelpWindow> the(GUI::Window* window)

--- a/Userland/Applications/Spreadsheet/Spreadsheet.h
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.h
@@ -23,7 +23,7 @@
 namespace Spreadsheet {
 
 class Sheet : public Core::Object {
-    C_OBJECT(Sheet);
+    C_OBJECT(Sheet)
 
 public:
     constexpr static size_t default_row_count = 100;

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -17,7 +17,7 @@
 namespace Spreadsheet {
 
 class CellEditor final : public GUI::TextEditor {
-    C_OBJECT(CellEditor);
+    C_OBJECT(CellEditor)
 
 public:
     virtual ~CellEditor() { }
@@ -86,7 +86,7 @@ private:
 };
 
 class SpreadsheetView final : public GUI::Widget {
-    C_OBJECT(SpreadsheetView);
+    C_OBJECT(SpreadsheetView)
 
 public:
     ~SpreadsheetView();

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -14,7 +14,7 @@
 namespace Spreadsheet {
 
 class SpreadsheetWidget final : public GUI::Widget {
-    C_OBJECT(SpreadsheetWidget);
+    C_OBJECT(SpreadsheetWidget)
 
 public:
     ~SpreadsheetWidget();

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.h
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.h
@@ -9,7 +9,7 @@
 #include <LibGUI/Widget.h>
 
 class ProcessFileDescriptorMapWidget final : public GUI::Widget {
-    C_OBJECT(ProcessFileDescriptorMapWidget);
+    C_OBJECT(ProcessFileDescriptorMapWidget)
 
 public:
     virtual ~ProcessFileDescriptorMapWidget() override;

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.h
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.h
@@ -9,7 +9,7 @@
 #include <LibGUI/Widget.h>
 
 class ProcessMemoryMapWidget final : public GUI::Widget {
-    C_OBJECT(ProcessMemoryMapWidget);
+    C_OBJECT(ProcessMemoryMapWidget)
 
 public:
     virtual ~ProcessMemoryMapWidget() override;

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.h
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.h
@@ -9,7 +9,7 @@
 #include <LibGUI/Widget.h>
 
 class ProcessStateWidget final : public GUI::Widget {
-    C_OBJECT(ProcessStateWidget);
+    C_OBJECT(ProcessStateWidget)
 
 public:
     virtual ~ProcessStateWidget() override;

--- a/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.h
+++ b/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.h
@@ -9,7 +9,7 @@
 #include <LibGUI/Widget.h>
 
 class ProcessUnveiledPathsWidget final : public GUI::Widget {
-    C_OBJECT(ProcessUnveiledPathsWidget);
+    C_OBJECT(ProcessUnveiledPathsWidget)
 
 public:
     virtual ~ProcessUnveiledPathsWidget() override;

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -20,7 +20,7 @@
 namespace TextEditor {
 
 class MainWidget final : public GUI::Widget {
-    C_OBJECT(MainWidget);
+    C_OBJECT(MainWidget)
 
 public:
     virtual ~MainWidget() override;

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -26,7 +26,7 @@
 namespace ThemeEditor {
 
 class MiniWidgetGallery final : public GUI::Widget {
-    C_OBJECT(MiniWidgetGallery);
+    C_OBJECT(MiniWidgetGallery)
 
 public:
     void set_preview_palette(const Gfx::Palette& palette)

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -18,7 +18,7 @@ namespace ThemeEditor {
 class MiniWidgetGallery;
 
 class PreviewWidget final : public GUI::Frame {
-    C_OBJECT(PreviewWidget);
+    C_OBJECT(PreviewWidget)
 
 public:
     virtual ~PreviewWidget() override;

--- a/Userland/Applications/Welcome/WelcomeWidget.h
+++ b/Userland/Applications/Welcome/WelcomeWidget.h
@@ -10,7 +10,7 @@
 #include <LibWeb/OutOfProcessWebView.h>
 
 class WelcomeWidget final : public GUI::Widget {
-    C_OBJECT(WelcomeWidget);
+    C_OBJECT(WelcomeWidget)
 
 public:
     virtual ~WelcomeWidget() override;

--- a/Userland/Demos/CatDog/CatDog.h
+++ b/Userland/Demos/CatDog/CatDog.h
@@ -14,7 +14,7 @@
 
 class CatDog final : public GUI::Widget
     , GUI::MouseTracker {
-    C_OBJECT(CatDog);
+    C_OBJECT(CatDog)
 
 public:
     virtual void timer_event(Core::TimerEvent&) override;

--- a/Userland/Demos/CatDog/SpeechBubble.h
+++ b/Userland/Demos/CatDog/SpeechBubble.h
@@ -9,7 +9,7 @@
 #include <LibGUI/Widget.h>
 
 class SpeechBubble final : public GUI::Widget {
-    C_OBJECT(SpeechBubble);
+    C_OBJECT(SpeechBubble)
 
 public:
     virtual void paint_event(GUI::PaintEvent&) override;

--- a/Userland/Demos/Fire/Fire.cpp
+++ b/Userland/Demos/Fire/Fire.cpp
@@ -58,7 +58,7 @@ static const Color s_palette[] = {
 };
 
 class Fire : public GUI::Frame {
-    C_OBJECT(Fire);
+    C_OBJECT(Fire)
 
 public:
     virtual ~Fire() override;

--- a/Userland/Demos/Mouse/main.cpp
+++ b/Userland/Demos/Mouse/main.cpp
@@ -24,7 +24,7 @@
 #include <unistd.h>
 
 class MainFrame final : public GUI::Frame {
-    C_OBJECT(MainFrame);
+    C_OBJECT(MainFrame)
 
 public:
     virtual void timer_event(Core::TimerEvent&) override

--- a/Userland/Demos/WidgetGallery/DemoWizardDialog.h
+++ b/Userland/Demos/WidgetGallery/DemoWizardDialog.h
@@ -14,7 +14,7 @@
 #include <LibGUI/Wizards/WizardPage.h>
 
 class DemoWizardDialog : public GUI::WizardDialog {
-    C_OBJECT(DemoWizardDialog);
+    C_OBJECT(DemoWizardDialog)
 
 public:
     String page_1_location() { return m_page_1_location_text_box->get_text(); }

--- a/Userland/DevTools/HackStudio/Debugger/EvaluateExpressionDialog.h
+++ b/Userland/DevTools/HackStudio/Debugger/EvaluateExpressionDialog.h
@@ -12,7 +12,7 @@
 namespace HackStudio {
 
 class EvaluateExpressionDialog : public GUI::Dialog {
-    C_OBJECT(EvaluateExpressionDialog);
+    C_OBJECT(EvaluateExpressionDialog)
 
 private:
     explicit EvaluateExpressionDialog(Window* parent_window);

--- a/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.h
+++ b/Userland/DevTools/HackStudio/Dialogs/Git/GitCommitDialog.h
@@ -18,7 +18,7 @@ namespace HackStudio {
 using OnCommitCallback = Function<void(String const& message)>;
 
 class GitCommitDialog final : public GUI::Dialog {
-    C_OBJECT(GitCommitDialog);
+    C_OBJECT(GitCommitDialog)
 
 public:
     OnCommitCallback on_commit;

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.h
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.h
@@ -19,7 +19,7 @@
 namespace HackStudio {
 
 class NewProjectDialog : public GUI::Dialog {
-    C_OBJECT(NewProjectDialog);
+    C_OBJECT(NewProjectDialog)
 
 public:
     static int show(GUI::Window* parent_window);

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/ClientConnection.h
@@ -12,7 +12,7 @@
 namespace LanguageServers::Cpp {
 
 class ClientConnection final : public LanguageServers::ClientConnection {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 private:
     ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/ClientConnection.h
@@ -13,7 +13,7 @@
 namespace LanguageServers::Shell {
 
 class ClientConnection final : public LanguageServers::ClientConnection {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 private:
     ClientConnection(NonnullOwnPtr<Core::Stream::LocalSocket> socket)

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -33,7 +33,7 @@
 namespace {
 
 class UnregisteredWidget final : public GUI::Widget {
-    C_OBJECT(UnregisteredWidget);
+    C_OBJECT(UnregisteredWidget)
 
 private:
     UnregisteredWidget(const String& class_name);

--- a/Userland/DevTools/Profiler/FlameGraphView.h
+++ b/Userland/DevTools/Profiler/FlameGraphView.h
@@ -18,7 +18,7 @@ namespace Profiler {
 
 class FlameGraphView final : public GUI::Widget
     , GUI::ModelClient {
-    C_OBJECT(FlameGraphView);
+    C_OBJECT(FlameGraphView)
 
 public:
     virtual ~FlameGraphView() override = default;

--- a/Userland/DevTools/Profiler/TimelineContainer.h
+++ b/Userland/DevTools/Profiler/TimelineContainer.h
@@ -13,7 +13,7 @@ namespace Profiler {
 class TimelineView;
 
 class TimelineContainer : public GUI::AbstractScrollableWidget {
-    C_OBJECT(TimelineContainer);
+    C_OBJECT(TimelineContainer)
 
 public:
     virtual ~TimelineContainer();

--- a/Userland/DevTools/Profiler/TimelineHeader.h
+++ b/Userland/DevTools/Profiler/TimelineHeader.h
@@ -14,7 +14,7 @@ class Profile;
 struct Process;
 
 class TimelineHeader final : public GUI::Frame {
-    C_OBJECT(TimelineHeader);
+    C_OBJECT(TimelineHeader)
 
 public:
     virtual ~TimelineHeader();

--- a/Userland/DevTools/Profiler/TimelineTrack.h
+++ b/Userland/DevTools/Profiler/TimelineTrack.h
@@ -16,7 +16,7 @@ class Profile;
 class TimelineView;
 
 class TimelineTrack final : public GUI::Frame {
-    C_OBJECT(TimelineTrack);
+    C_OBJECT(TimelineTrack)
 
 public:
     virtual ~TimelineTrack() override;

--- a/Userland/DevTools/Profiler/TimelineView.h
+++ b/Userland/DevTools/Profiler/TimelineView.h
@@ -14,7 +14,7 @@ class Profile;
 class TimelineTrack;
 
 class TimelineView final : public GUI::Widget {
-    C_OBJECT(TimelineView);
+    C_OBJECT(TimelineView)
 
 public:
     virtual ~TimelineView() override;

--- a/Userland/Games/2048/BoardView.h
+++ b/Userland/Games/2048/BoardView.h
@@ -10,7 +10,7 @@
 #include <LibGUI/Frame.h>
 
 class BoardView final : public GUI::Frame {
-    C_OBJECT(BoardView);
+    C_OBJECT(BoardView)
 
 public:
     virtual ~BoardView() override;

--- a/Userland/Games/Breakout/Game.h
+++ b/Userland/Games/Breakout/Game.h
@@ -12,7 +12,7 @@
 namespace Breakout {
 
 class Game final : public GUI::Widget {
-    C_OBJECT(Game);
+    C_OBJECT(Game)
 
 public:
     static const int game_width = 480;

--- a/Userland/Games/Chess/ChessWidget.h
+++ b/Userland/Games/Chess/ChessWidget.h
@@ -15,7 +15,7 @@
 #include <LibGfx/Bitmap.h>
 
 class ChessWidget final : public GUI::Frame {
-    C_OBJECT(ChessWidget);
+    C_OBJECT(ChessWidget)
 
 public:
     virtual ~ChessWidget() override;

--- a/Userland/Games/FlappyBug/Game.h
+++ b/Userland/Games/FlappyBug/Game.h
@@ -19,7 +19,7 @@
 namespace FlappyBug {
 
 class Game final : public GUI::Frame {
-    C_OBJECT(Game);
+    C_OBJECT(Game)
 
 public:
     static const int game_width = 560;

--- a/Userland/Games/GameOfLife/BoardWidget.h
+++ b/Userland/Games/GameOfLife/BoardWidget.h
@@ -19,7 +19,7 @@
 #include <LibGUI/Widget.h>
 
 class BoardWidget final : public GUI::Widget {
-    C_OBJECT(BoardWidget);
+    C_OBJECT(BoardWidget)
 
 public:
     virtual void paint_event(GUI::PaintEvent&) override;

--- a/Userland/Games/Hearts/ScoreCard.h
+++ b/Userland/Games/Hearts/ScoreCard.h
@@ -13,7 +13,7 @@
 namespace Hearts {
 
 class ScoreCard : public GUI::Frame {
-    C_OBJECT(ScoreCard);
+    C_OBJECT(ScoreCard)
 
     Gfx::IntSize recommended_size();
 

--- a/Userland/Games/Minesweeper/CustomGameDialog.h
+++ b/Userland/Games/Minesweeper/CustomGameDialog.h
@@ -13,7 +13,7 @@
 class Field;
 
 class CustomGameDialog : public GUI::Dialog {
-    C_OBJECT(CustomGameDialog);
+    C_OBJECT(CustomGameDialog)
 
 public:
     static int show(GUI::Window* parent_window, Field& field);

--- a/Userland/Games/Minesweeper/Field.cpp
+++ b/Userland/Games/Minesweeper/Field.cpp
@@ -16,7 +16,7 @@
 #include <LibGfx/Palette.h>
 
 class SquareButton final : public GUI::Button {
-    C_OBJECT(SquareButton);
+    C_OBJECT(SquareButton)
 
 public:
     Function<void()> on_secondary_click;
@@ -43,7 +43,7 @@ private:
 };
 
 class SquareLabel final : public GUI::Label {
-    C_OBJECT(SquareLabel);
+    C_OBJECT(SquareLabel)
 
 public:
     Function<void()> on_chord_click;

--- a/Userland/Games/Pong/Game.h
+++ b/Userland/Games/Pong/Game.h
@@ -20,7 +20,7 @@ namespace Pong {
 
 class Game final : public GUI::Widget
     , GUI::MouseTracker {
-    C_OBJECT(Game);
+    C_OBJECT(Game)
 
 public:
     static const int game_width = 560;

--- a/Userland/Games/Snake/SnakeGame.h
+++ b/Userland/Games/Snake/SnakeGame.h
@@ -11,7 +11,7 @@
 #include <LibGUI/Frame.h>
 
 class SnakeGame : public GUI::Frame {
-    C_OBJECT(SnakeGame);
+    C_OBJECT(SnakeGame)
 
 public:
     virtual ~SnakeGame() override;

--- a/Userland/Libraries/LibCore/MimeData.h
+++ b/Userland/Libraries/LibCore/MimeData.h
@@ -14,7 +14,7 @@
 namespace Core {
 
 class MimeData : public Object {
-    C_OBJECT(MimeData);
+    C_OBJECT(MimeData)
 
 public:
     virtual ~MimeData() { }

--- a/Userland/Libraries/LibCore/Promise.h
+++ b/Userland/Libraries/LibCore/Promise.h
@@ -12,7 +12,7 @@
 namespace Core {
 template<typename Result>
 class Promise : public Object {
-    C_OBJECT(Promise);
+    C_OBJECT(Promise)
 
 public:
     Function<void(Result&)> on_resolved;

--- a/Userland/Libraries/LibCore/Timer.h
+++ b/Userland/Libraries/LibCore/Timer.h
@@ -12,7 +12,7 @@
 namespace Core {
 
 class Timer final : public Object {
-    C_OBJECT(Timer);
+    C_OBJECT(Timer)
 
 public:
     static NonnullRefPtr<Timer> create_repeating(int interval_ms, Function<void()>&& timeout_handler, Object* parent = nullptr)

--- a/Userland/Libraries/LibDSP/Processor.h
+++ b/Userland/Libraries/LibDSP/Processor.h
@@ -18,7 +18,7 @@ namespace LibDSP {
 
 // A processor processes notes or audio into notes or audio. Processors are e.g. samplers, synthesizers, effects, arpeggiators etc.
 class Processor : public Core::Object {
-    C_OBJECT_ABSTRACT(Processor);
+    C_OBJECT_ABSTRACT(Processor)
 
 public:
     virtual ~Processor()

--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -12,7 +12,7 @@
 namespace GUI {
 
 class AbstractButton : public Widget {
-    C_OBJECT_ABSTRACT(AbstractButton);
+    C_OBJECT_ABSTRACT(AbstractButton)
 
 public:
     virtual ~AbstractButton() override;

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -12,7 +12,7 @@
 namespace GUI {
 
 class AbstractScrollableWidget : public Frame {
-    C_OBJECT_ABSTRACT(AbstractScrollableWidget);
+    C_OBJECT_ABSTRACT(AbstractScrollableWidget)
 
 public:
     virtual ~AbstractScrollableWidget() override;
@@ -81,7 +81,7 @@ protected:
 
 private:
     class AbstractScrollableWidgetScrollbar final : public Scrollbar {
-        C_OBJECT(AbstractScrollableWidgetScrollbar);
+        C_OBJECT(AbstractScrollableWidgetScrollbar)
 
     private:
         explicit AbstractScrollableWidgetScrollbar(AbstractScrollableWidget& owner, Gfx::Orientation orientation)

--- a/Userland/Libraries/LibGUI/AbstractSlider.h
+++ b/Userland/Libraries/LibGUI/AbstractSlider.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class AbstractSlider : public Widget {
-    C_OBJECT_ABSTRACT(AbstractSlider);
+    C_OBJECT_ABSTRACT(AbstractSlider)
 
 public:
     virtual ~AbstractSlider() override;

--- a/Userland/Libraries/LibGUI/AbstractView.h
+++ b/Userland/Libraries/LibGUI/AbstractView.h
@@ -18,7 +18,7 @@ class AbstractView
     : public AbstractScrollableWidget
     , public ModelClient {
 
-    C_OBJECT_ABSTRACT(AbstractView);
+    C_OBJECT_ABSTRACT(AbstractView)
 
 public:
     enum class CursorMovement {

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.h
@@ -13,7 +13,7 @@
 namespace GUI {
 
 class AbstractZoomPanWidget : public GUI::Frame {
-    C_OBJECT(AbstractZoomPanWidget);
+    C_OBJECT(AbstractZoomPanWidget)
 
 public:
     void set_scale(float scale);

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -21,7 +21,7 @@
 namespace GUI {
 
 class Application::TooltipWindow final : public Window {
-    C_OBJECT(TooltipWindow);
+    C_OBJECT(TooltipWindow)
 
 public:
     void set_tooltip(const String& tooltip)

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -21,7 +21,7 @@
 namespace GUI {
 
 class Application : public Core::Object {
-    C_OBJECT(Application);
+    C_OBJECT(Application)
 
 public:
     static Application* the();

--- a/Userland/Libraries/LibGUI/BoxLayout.h
+++ b/Userland/Libraries/LibGUI/BoxLayout.h
@@ -13,7 +13,7 @@
 namespace GUI {
 
 class BoxLayout : public Layout {
-    C_OBJECT(BoxLayout);
+    C_OBJECT(BoxLayout)
 
 public:
     virtual ~BoxLayout() override { }
@@ -34,7 +34,7 @@ private:
 };
 
 class VerticalBoxLayout final : public BoxLayout {
-    C_OBJECT(VerticalBoxLayout);
+    C_OBJECT(VerticalBoxLayout)
 
 private:
     explicit VerticalBoxLayout()
@@ -45,7 +45,7 @@ private:
 };
 
 class HorizontalBoxLayout final : public BoxLayout {
-    C_OBJECT(HorizontalBoxLayout);
+    C_OBJECT(HorizontalBoxLayout)
 
 private:
     explicit HorizontalBoxLayout()

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -17,7 +17,7 @@ REGISTER_WIDGET(GUI, Breadcrumbbar)
 namespace GUI {
 
 class BreadcrumbButton : public Button {
-    C_OBJECT(BreadcrumbButton);
+    C_OBJECT(BreadcrumbButton)
 
 public:
     virtual ~BreadcrumbButton() override { }

--- a/Userland/Libraries/LibGUI/Breadcrumbbar.h
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class Breadcrumbbar : public GUI::Widget {
-    C_OBJECT(Breadcrumbbar);
+    C_OBJECT(Breadcrumbbar)
 
 public:
     virtual ~Breadcrumbbar() override;

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -15,7 +15,7 @@
 namespace GUI {
 
 class Button : public AbstractButton {
-    C_OBJECT(Button);
+    C_OBJECT(Button)
 
 public:
     virtual ~Button() override;

--- a/Userland/Libraries/LibGUI/CheckBox.h
+++ b/Userland/Libraries/LibGUI/CheckBox.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class CheckBox : public AbstractButton {
-    C_OBJECT(CheckBox);
+    C_OBJECT(CheckBox)
 
 public:
     virtual ~CheckBox() override;

--- a/Userland/Libraries/LibGUI/ColorInput.h
+++ b/Userland/Libraries/LibGUI/ColorInput.h
@@ -12,7 +12,7 @@
 namespace GUI {
 
 class ColorInput final : public TextEditor {
-    C_OBJECT(ColorInput);
+    C_OBJECT(ColorInput)
 
 public:
     virtual ~ColorInput() override;

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -19,7 +19,7 @@
 namespace GUI {
 
 class ColorButton : public AbstractButton {
-    C_OBJECT(ColorButton);
+    C_OBJECT(ColorButton)
 
 public:
     virtual ~ColorButton() override;
@@ -43,7 +43,7 @@ private:
 };
 
 class ColorField final : public GUI::Frame {
-    C_OBJECT(ColorField);
+    C_OBJECT(ColorField)
 
 public:
     Function<void(Color)> on_pick;
@@ -74,7 +74,7 @@ private:
 };
 
 class ColorSlider final : public GUI::Frame {
-    C_OBJECT(ColorSlider);
+    C_OBJECT(ColorSlider)
 
 public:
     Function<void(double)> on_pick;
@@ -100,7 +100,7 @@ private:
 };
 
 class ColorPreview final : public GUI::Widget {
-    C_OBJECT(ColorPreview);
+    C_OBJECT(ColorPreview)
 
 public:
     void set_color(Color);
@@ -113,7 +113,7 @@ private:
 };
 
 class CustomColorWidget final : public GUI::Widget {
-    C_OBJECT(CustomColorWidget);
+    C_OBJECT(CustomColorWidget)
 
 public:
     Function<void(Color)> on_pick;

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -20,7 +20,7 @@ REGISTER_WIDGET(GUI, ComboBox)
 namespace GUI {
 
 class ComboBoxEditor final : public TextEditor {
-    C_OBJECT(ComboBoxEditor);
+    C_OBJECT(ComboBoxEditor)
 
 public:
     Function<void(int delta)> on_mousewheel;

--- a/Userland/Libraries/LibGUI/ComboBox.h
+++ b/Userland/Libraries/LibGUI/ComboBox.h
@@ -15,7 +15,7 @@ namespace GUI {
 class ComboBoxEditor;
 
 class ComboBox : public Frame {
-    C_OBJECT(ComboBox);
+    C_OBJECT(ComboBox)
 
 public:
     virtual ~ComboBox() override;

--- a/Userland/Libraries/LibGUI/EmojiInputDialog.h
+++ b/Userland/Libraries/LibGUI/EmojiInputDialog.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class EmojiInputDialog final : public Dialog {
-    C_OBJECT(EmojiInputDialog);
+    C_OBJECT(EmojiInputDialog)
 
 public:
     const String& selected_emoji_text() const { return m_selected_emoji_text; }

--- a/Userland/Libraries/LibGUI/FilePicker.h
+++ b/Userland/Libraries/LibGUI/FilePicker.h
@@ -18,7 +18,7 @@ namespace GUI {
 class FilePicker final
     : public Dialog
     , private ModelClient {
-    C_OBJECT(FilePicker);
+    C_OBJECT(FilePicker)
 
 public:
     enum class Mode {

--- a/Userland/Libraries/LibGUI/FontPicker.h
+++ b/Userland/Libraries/LibGUI/FontPicker.h
@@ -13,7 +13,7 @@
 namespace GUI {
 
 class FontPicker final : public GUI::Dialog {
-    C_OBJECT(FontPicker);
+    C_OBJECT(FontPicker)
 
 public:
     virtual ~FontPicker() override;

--- a/Userland/Libraries/LibGUI/HeaderView.h
+++ b/Userland/Libraries/LibGUI/HeaderView.h
@@ -12,7 +12,7 @@
 namespace GUI {
 
 class HeaderView final : public Widget {
-    C_OBJECT(HeaderView);
+    C_OBJECT(HeaderView)
 
 public:
     virtual ~HeaderView() override;

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -13,7 +13,7 @@
 namespace GUI {
 
 class Label : public Frame {
-    C_OBJECT(Label);
+    C_OBJECT(Label)
 
 public:
     virtual ~Label() override;

--- a/Userland/Libraries/LibGUI/Layout.h
+++ b/Userland/Libraries/LibGUI/Layout.h
@@ -31,7 +31,7 @@ extern Core::ObjectClassRegistration registration_Layout;
 namespace GUI {
 
 class Layout : public Core::Object {
-    C_OBJECT_ABSTRACT(Layout);
+    C_OBJECT_ABSTRACT(Layout)
 
 public:
     virtual ~Layout();

--- a/Userland/Libraries/LibGUI/LinkLabel.h
+++ b/Userland/Libraries/LibGUI/LinkLabel.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class LinkLabel : public Label {
-    C_OBJECT(LinkLabel);
+    C_OBJECT(LinkLabel)
 
 public:
     Function<void()> on_click;

--- a/Userland/Libraries/LibGUI/Menubar.h
+++ b/Userland/Libraries/LibGUI/Menubar.h
@@ -17,7 +17,7 @@
 namespace GUI {
 
 class Menubar : public Core::Object {
-    C_OBJECT(Menubar);
+    C_OBJECT(Menubar)
 
 public:
     virtual ~Menubar() override;

--- a/Userland/Libraries/LibGUI/Notification.h
+++ b/Userland/Libraries/LibGUI/Notification.h
@@ -14,7 +14,7 @@ namespace GUI {
 class NotificationServerConnection;
 
 class Notification : public Core::Object {
-    C_OBJECT(Notification);
+    C_OBJECT(Notification)
 
     friend class NotificationServerConnection;
 

--- a/Userland/Libraries/LibGUI/OpacitySlider.h
+++ b/Userland/Libraries/LibGUI/OpacitySlider.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class OpacitySlider : public AbstractSlider {
-    C_OBJECT(OpacitySlider);
+    C_OBJECT(OpacitySlider)
 
 public:
     virtual ~OpacitySlider() override;

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.h
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class PasswordInputDialog : public Dialog {
-    C_OBJECT(PasswordInputDialog);
+    C_OBJECT(PasswordInputDialog)
 
 public:
     virtual ~PasswordInputDialog() override;

--- a/Userland/Libraries/LibGUI/ProcessChooser.h
+++ b/Userland/Libraries/LibGUI/ProcessChooser.h
@@ -13,7 +13,7 @@
 namespace GUI {
 
 class ProcessChooser final : public GUI::Dialog {
-    C_OBJECT(ProcessChooser);
+    C_OBJECT(ProcessChooser)
 
 public:
     virtual ~ProcessChooser() override;

--- a/Userland/Libraries/LibGUI/Progressbar.h
+++ b/Userland/Libraries/LibGUI/Progressbar.h
@@ -53,7 +53,7 @@ private:
 };
 
 class VerticalProgressbar final : public Progressbar {
-    C_OBJECT(VerticalProgressbar);
+    C_OBJECT(VerticalProgressbar)
 
 public:
     virtual ~VerticalProgressbar() override { }
@@ -66,7 +66,7 @@ private:
 };
 
 class HorizontalProgressbar final : public Progressbar {
-    C_OBJECT(HorizontalProgressbar);
+    C_OBJECT(HorizontalProgressbar)
 
 public:
     virtual ~HorizontalProgressbar() override { }

--- a/Userland/Libraries/LibGUI/RadioButton.h
+++ b/Userland/Libraries/LibGUI/RadioButton.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class RadioButton : public AbstractButton {
-    C_OBJECT(RadioButton);
+    C_OBJECT(RadioButton)
 
 public:
     virtual ~RadioButton() override;

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class ScrollableContainerWidget : public GUI::AbstractScrollableWidget {
-    C_OBJECT(ScrollableContainerWidget);
+    C_OBJECT(ScrollableContainerWidget)
 
 public:
     virtual ~ScrollableContainerWidget();

--- a/Userland/Libraries/LibGUI/Scrollbar.h
+++ b/Userland/Libraries/LibGUI/Scrollbar.h
@@ -12,7 +12,7 @@
 namespace GUI {
 
 class Scrollbar : public AbstractSlider {
-    C_OBJECT(Scrollbar);
+    C_OBJECT(Scrollbar)
 
 public:
     virtual ~Scrollbar() override;

--- a/Userland/Libraries/LibGUI/SeparatorWidget.h
+++ b/Userland/Libraries/LibGUI/SeparatorWidget.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class SeparatorWidget : public Widget {
-    C_OBJECT(SeparatorWidget);
+    C_OBJECT(SeparatorWidget)
 
 public:
     virtual ~SeparatorWidget() override;

--- a/Userland/Libraries/LibGUI/Slider.h
+++ b/Userland/Libraries/LibGUI/Slider.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class Slider : public AbstractSlider {
-    C_OBJECT(Slider);
+    C_OBJECT(Slider)
 
 public:
     enum class KnobSizeMode {
@@ -61,7 +61,7 @@ private:
 };
 
 class VerticalSlider final : public Slider {
-    C_OBJECT(VerticalSlider);
+    C_OBJECT(VerticalSlider)
 
 public:
     virtual ~VerticalSlider() override { }
@@ -74,7 +74,7 @@ private:
 };
 
 class HorizontalSlider final : public Slider {
-    C_OBJECT(HorizontalSlider);
+    C_OBJECT(HorizontalSlider)
 
 public:
     virtual ~HorizontalSlider() override { }

--- a/Userland/Libraries/LibGUI/Splitter.h
+++ b/Userland/Libraries/LibGUI/Splitter.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class Splitter : public Widget {
-    C_OBJECT(Splitter);
+    C_OBJECT(Splitter)
 
 public:
     virtual ~Splitter() override;

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -28,7 +28,7 @@ class TextEditor
     , public TextDocument::Client
     , public Syntax::HighlighterClient
     , public Clipboard::ClipboardClient {
-    C_OBJECT(TextEditor);
+    C_OBJECT(TextEditor)
 
 public:
     enum Type {

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -40,7 +40,7 @@ Toolbar::~Toolbar()
 }
 
 class ToolbarButton final : public Button {
-    C_OBJECT(ToolbarButton);
+    C_OBJECT(ToolbarButton)
 
 public:
     virtual ~ToolbarButton() override { }

--- a/Userland/Libraries/LibGUI/ToolbarContainer.h
+++ b/Userland/Libraries/LibGUI/ToolbarContainer.h
@@ -12,7 +12,7 @@
 namespace GUI {
 
 class ToolbarContainer : public Frame {
-    C_OBJECT(ToolbarContainer);
+    C_OBJECT(ToolbarContainer)
 
 public:
 private:

--- a/Userland/Libraries/LibGUI/Tray.h
+++ b/Userland/Libraries/LibGUI/Tray.h
@@ -12,7 +12,7 @@
 namespace GUI {
 
 class Tray : public GUI::Frame {
-    C_OBJECT(Tray);
+    C_OBJECT(Tray)
 
 public:
     virtual ~Tray() override;

--- a/Userland/Libraries/LibGUI/ValueSlider.h
+++ b/Userland/Libraries/LibGUI/ValueSlider.h
@@ -11,7 +11,7 @@
 namespace GUI {
 
 class ValueSlider : public AbstractSlider {
-    C_OBJECT(ValueSlider);
+    C_OBJECT(ValueSlider)
 
 public:
     enum class KnobStyle {

--- a/Userland/Libraries/LibGUI/Wizards/AbstractWizardPage.h
+++ b/Userland/Libraries/LibGUI/Wizards/AbstractWizardPage.h
@@ -12,7 +12,7 @@
 namespace GUI {
 
 class AbstractWizardPage : public Widget {
-    C_OBJECT_ABSTRACT(AbstractWizardPage);
+    C_OBJECT_ABSTRACT(AbstractWizardPage)
 
 public:
     virtual ~AbstractWizardPage() override;

--- a/Userland/Libraries/LibGUI/Wizards/CoverWizardPage.h
+++ b/Userland/Libraries/LibGUI/Wizards/CoverWizardPage.h
@@ -14,7 +14,7 @@
 namespace GUI {
 
 class CoverWizardPage : public AbstractWizardPage {
-    C_OBJECT(CoverWizardPage);
+    C_OBJECT(CoverWizardPage)
 
     ImageWidget& banner_image_widget() { return *m_banner_image_widget; }
 

--- a/Userland/Libraries/LibGUI/Wizards/WizardPage.h
+++ b/Userland/Libraries/LibGUI/Wizards/WizardPage.h
@@ -14,7 +14,7 @@
 namespace GUI {
 
 class WizardPage : public AbstractWizardPage {
-    C_OBJECT(WizardPage);
+    C_OBJECT(WizardPage)
 
     Widget& body_widget() { return *m_body_widget; };
 

--- a/Userland/Libraries/LibIPC/Connection.h
+++ b/Userland/Libraries/LibIPC/Connection.h
@@ -27,7 +27,7 @@
 namespace IPC {
 
 class ConnectionBase : public Core::Object {
-    C_OBJECT_ABSTRACT(ConnectionBase);
+    C_OBJECT_ABSTRACT(ConnectionBase)
 
 public:
     virtual ~ConnectionBase() override;

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -132,7 +132,7 @@ struct Configuration {
     [](auto& editor) { editor.name();  return false; }
 
 class Editor : public Core::Object {
-    C_OBJECT(Editor);
+    C_OBJECT(Editor)
 
 public:
     enum class Error {

--- a/Userland/Libraries/LibSQL/BTree.h
+++ b/Userland/Libraries/LibSQL/BTree.h
@@ -94,7 +94,7 @@ private:
 };
 
 class BTree : public Index {
-    C_OBJECT(BTree);
+    C_OBJECT(BTree)
 
 public:
     ~BTree() override = default;

--- a/Userland/Libraries/LibSQL/Database.h
+++ b/Userland/Libraries/LibSQL/Database.h
@@ -21,7 +21,7 @@ namespace SQL {
  * of tables, columns, indexes, and other SQL objects.
  */
 class Database : public Core::Object {
-    C_OBJECT(Database);
+    C_OBJECT(Database)
 
 public:
     ~Database() override;

--- a/Userland/Libraries/LibSQL/HashIndex.h
+++ b/Userland/Libraries/LibSQL/HashIndex.h
@@ -58,7 +58,7 @@ private:
 };
 
 class HashIndex : public Index {
-    C_OBJECT(HashIndex);
+    C_OBJECT(HashIndex)
 
 public:
     ~HashIndex() override = default;

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -30,7 +30,7 @@ constexpr static u32 BLOCKSIZE = 1024;
  * Currently only B-Trees and tuple stores are implemented.
  */
 class Heap : public Core::Object {
-    C_OBJECT(Heap);
+    C_OBJECT(Heap)
 
 public:
     virtual ~Heap() override;

--- a/Userland/Libraries/LibSQL/Index.h
+++ b/Userland/Libraries/LibSQL/Index.h
@@ -31,7 +31,7 @@ private:
 };
 
 class Index : public Core::Object {
-    C_OBJECT_ABSTRACT(Index);
+    C_OBJECT_ABSTRACT(Index)
 
 public:
     ~Index() override = default;

--- a/Userland/Libraries/LibSQL/Meta.h
+++ b/Userland/Libraries/LibSQL/Meta.h
@@ -25,7 +25,7 @@ namespace SQL {
  */
 
 class Relation : public Core::Object {
-    C_OBJECT_ABSTRACT(Relation);
+    C_OBJECT_ABSTRACT(Relation)
 
 public:
     u32 hash() const;
@@ -55,7 +55,7 @@ private:
 };
 
 class SchemaDef : public Relation {
-    C_OBJECT(SchemaDef);
+    C_OBJECT(SchemaDef)
 
 public:
     Key key() const override;
@@ -68,7 +68,7 @@ private:
 };
 
 class ColumnDef : public Relation {
-    C_OBJECT(ColumnDef);
+    C_OBJECT(ColumnDef)
 
 public:
     Key key() const override;
@@ -93,7 +93,7 @@ private:
 };
 
 class KeyPartDef : public ColumnDef {
-    C_OBJECT(KeyPartDef);
+    C_OBJECT(KeyPartDef)
 
 public:
     Order sort_order() const { return m_sort_order; }
@@ -105,7 +105,7 @@ private:
 };
 
 class IndexDef : public Relation {
-    C_OBJECT(IndexDef);
+    C_OBJECT(IndexDef)
 
 public:
     ~IndexDef() override = default;
@@ -130,7 +130,7 @@ private:
 };
 
 class TableDef : public Relation {
-    C_OBJECT(TableDef);
+    C_OBJECT(TableDef)
 
 public:
     Key key() const override;

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -35,7 +35,7 @@ private:
 template<typename Result>
 class BackgroundAction final : public Core::Object
     , private BackgroundActionBase {
-    C_OBJECT(BackgroundAction);
+    C_OBJECT(BackgroundAction)
 
 public:
     void cancel()

--- a/Userland/Libraries/LibThreading/Thread.h
+++ b/Userland/Libraries/LibThreading/Thread.h
@@ -19,7 +19,7 @@ namespace Threading {
 TYPEDEF_DISTINCT_ORDERED_ID(intptr_t, ThreadError);
 
 class Thread final : public Core::Object {
-    C_OBJECT(Thread);
+    C_OBJECT(Thread)
 
 public:
     virtual ~Thread();

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -24,7 +24,7 @@ class TerminalWidget final
     : public GUI::Frame
     , public VT::TerminalClient
     , public GUI::Clipboard::ClipboardClient {
-    C_OBJECT(TerminalWidget);
+    C_OBJECT(TerminalWidget)
 
 public:
     virtual ~TerminalWidget() override;

--- a/Userland/Libraries/LibWeb/InProcessWebView.h
+++ b/Userland/Libraries/LibWeb/InProcessWebView.h
@@ -19,7 +19,7 @@ class InProcessWebView final
     : public GUI::AbstractScrollableWidget
     , public WebViewHooks
     , public PageClient {
-    C_OBJECT(InProcessWebView);
+    C_OBJECT(InProcessWebView)
 
 public:
     virtual ~InProcessWebView() override;

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -19,7 +19,7 @@ class WebContentClient;
 class OutOfProcessWebView final
     : public GUI::AbstractScrollableWidget
     , public Web::WebViewHooks {
-    C_OBJECT(OutOfProcessWebView);
+    C_OBJECT(OutOfProcessWebView)
 
 public:
     virtual ~OutOfProcessWebView() override;

--- a/Userland/Libraries/LibWebSocket/Impl/AbstractWebSocketImpl.h
+++ b/Userland/Libraries/LibWebSocket/Impl/AbstractWebSocketImpl.h
@@ -15,7 +15,7 @@
 namespace WebSocket {
 
 class AbstractWebSocketImpl : public Core::Object {
-    C_OBJECT_ABSTRACT(AbstractWebSocketImpl);
+    C_OBJECT_ABSTRACT(AbstractWebSocketImpl)
 
 public:
     virtual ~AbstractWebSocketImpl() override;

--- a/Userland/Libraries/LibWebSocket/Impl/TCPWebSocketConnectionImpl.h
+++ b/Userland/Libraries/LibWebSocket/Impl/TCPWebSocketConnectionImpl.h
@@ -18,7 +18,7 @@
 namespace WebSocket {
 
 class TCPWebSocketConnectionImpl final : public AbstractWebSocketImpl {
-    C_OBJECT(TCPWebSocketConnectionImpl);
+    C_OBJECT(TCPWebSocketConnectionImpl)
 
 public:
     virtual ~TCPWebSocketConnectionImpl() override;

--- a/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.h
+++ b/Userland/Libraries/LibWebSocket/Impl/TLSv12WebSocketConnectionImpl.h
@@ -17,7 +17,7 @@
 namespace WebSocket {
 
 class TLSv12WebSocketConnectionImpl final : public AbstractWebSocketImpl {
-    C_OBJECT(TLSv12WebSocketConnectionImpl);
+    C_OBJECT(TLSv12WebSocketConnectionImpl)
 
 public:
     virtual ~TLSv12WebSocketConnectionImpl() override;

--- a/Userland/Services/Clipboard/ClientConnection.h
+++ b/Userland/Services/Clipboard/ClientConnection.h
@@ -15,7 +15,7 @@ namespace Clipboard {
 
 class ClientConnection final
     : public IPC::ClientConnection<ClipboardClientEndpoint, ClipboardServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     virtual ~ClientConnection() override;

--- a/Userland/Services/FileSystemAccessServer/ClientConnection.h
+++ b/Userland/Services/FileSystemAccessServer/ClientConnection.h
@@ -17,7 +17,7 @@ namespace FileSystemAccessServer {
 
 class ClientConnection final
     : public IPC::ClientConnection<FileSystemAccessClientEndpoint, FileSystemAccessServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     ~ClientConnection() override;

--- a/Userland/Services/ImageDecoder/ClientConnection.h
+++ b/Userland/Services/ImageDecoder/ClientConnection.h
@@ -17,7 +17,7 @@ namespace ImageDecoder {
 
 class ClientConnection final
     : public IPC::ClientConnection<ImageDecoderClientEndpoint, ImageDecoderServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     ~ClientConnection() override;

--- a/Userland/Services/InspectorServer/ClientConnection.h
+++ b/Userland/Services/InspectorServer/ClientConnection.h
@@ -15,7 +15,7 @@ namespace InspectorServer {
 
 class ClientConnection final
     : public IPC::ClientConnection<InspectorClientEndpoint, InspectorServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     ~ClientConnection() override;

--- a/Userland/Services/LoginServer/LoginWindow.h
+++ b/Userland/Services/LoginServer/LoginWindow.h
@@ -12,7 +12,7 @@
 #pragma once
 
 class LoginWindow final : public GUI::Window {
-    C_OBJECT(LoginWindow);
+    C_OBJECT(LoginWindow)
 
 public:
     virtual ~LoginWindow() override { }

--- a/Userland/Services/LookupServer/ClientConnection.h
+++ b/Userland/Services/LookupServer/ClientConnection.h
@@ -15,7 +15,7 @@ namespace LookupServer {
 
 class ClientConnection final
     : public IPC::ClientConnection<LookupClientEndpoint, LookupServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     virtual ~ClientConnection() override;

--- a/Userland/Services/LookupServer/LookupServer.h
+++ b/Userland/Services/LookupServer/LookupServer.h
@@ -20,7 +20,7 @@ namespace LookupServer {
 class DNSAnswer;
 
 class LookupServer final : public Core::Object {
-    C_OBJECT(LookupServer);
+    C_OBJECT(LookupServer)
 
 public:
     static LookupServer& the();

--- a/Userland/Services/NotificationServer/NotificationWindow.h
+++ b/Userland/Services/NotificationServer/NotificationWindow.h
@@ -12,7 +12,7 @@
 namespace NotificationServer {
 
 class NotificationWindow final : public GUI::Window {
-    C_OBJECT(NotificationWindow);
+    C_OBJECT(NotificationWindow)
 
 public:
     virtual ~NotificationWindow() override;

--- a/Userland/Services/RequestServer/ClientConnection.h
+++ b/Userland/Services/RequestServer/ClientConnection.h
@@ -16,7 +16,7 @@ namespace RequestServer {
 
 class ClientConnection final
     : public IPC::ClientConnection<RequestClientEndpoint, RequestServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     ~ClientConnection() override;

--- a/Userland/Services/SQLServer/ClientConnection.h
+++ b/Userland/Services/SQLServer/ClientConnection.h
@@ -15,7 +15,7 @@ namespace SQLServer {
 
 class ClientConnection final
     : public IPC::ClientConnection<SQLClientEndpoint, SQLServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     virtual ~ClientConnection() override;

--- a/Userland/Services/Taskbar/ClockWidget.h
+++ b/Userland/Services/Taskbar/ClockWidget.h
@@ -19,7 +19,7 @@
 namespace Taskbar {
 
 class ClockWidget final : public GUI::Frame {
-    C_OBJECT(ClockWidget);
+    C_OBJECT(ClockWidget)
 
 public:
     virtual ~ClockWidget() override;

--- a/Userland/Services/Taskbar/QuickLaunchWidget.h
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.h
@@ -15,7 +15,7 @@ namespace Taskbar {
 
 class QuickLaunchWidget : public GUI::Frame
     , public Config::Listener {
-    C_OBJECT(QuickLaunchWidget);
+    C_OBJECT(QuickLaunchWidget)
 
 public:
     virtual ~QuickLaunchWidget() override;

--- a/Userland/Services/Taskbar/ShutdownDialog.h
+++ b/Userland/Services/Taskbar/ShutdownDialog.h
@@ -10,7 +10,7 @@
 #include <LibGUI/Dialog.h>
 
 class ShutdownDialog : public GUI::Dialog {
-    C_OBJECT(ShutdownDialog);
+    C_OBJECT(ShutdownDialog)
 
 public:
     static Vector<char const*> show();

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -27,7 +27,7 @@
 #include <stdio.h>
 
 class TaskbarWidget final : public GUI::Widget {
-    C_OBJECT(TaskbarWidget);
+    C_OBJECT(TaskbarWidget)
 
 public:
     virtual ~TaskbarWidget() override { }

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -15,7 +15,7 @@
 #include <Services/WindowServer/ScreenLayout.h>
 
 class TaskbarWindow final : public GUI::Window {
-    C_OBJECT(TaskbarWindow);
+    C_OBJECT(TaskbarWindow)
 
 public:
     virtual ~TaskbarWindow() override;

--- a/Userland/Services/WebContent/ClientConnection.h
+++ b/Userland/Services/WebContent/ClientConnection.h
@@ -22,7 +22,7 @@ namespace WebContent {
 
 class ClientConnection final
     : public IPC::ClientConnection<WebContentClientEndpoint, WebContentServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     ~ClientConnection() override;

--- a/Userland/Services/WebServer/Client.h
+++ b/Userland/Services/WebServer/Client.h
@@ -14,7 +14,7 @@
 namespace WebServer {
 
 class Client final : public Core::Object {
-    C_OBJECT(Client);
+    C_OBJECT(Client)
 
 public:
     void start();

--- a/Userland/Services/WebSocket/ClientConnection.h
+++ b/Userland/Services/WebSocket/ClientConnection.h
@@ -16,7 +16,7 @@ namespace WebSocket {
 
 class ClientConnection final
     : public IPC::ClientConnection<WebSocketClientEndpoint, WebSocketServerEndpoint> {
-    C_OBJECT(ClientConnection);
+    C_OBJECT(ClientConnection)
 
 public:
     ~ClientConnection() override;

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -25,7 +25,7 @@ class Menubar;
 class Window;
 
 class Menu final : public Core::Object {
-    C_OBJECT(Menu);
+    C_OBJECT(Menu)
 
 public:
     virtual ~Menu() override;

--- a/Userland/Services/WindowServer/MenuManager.h
+++ b/Userland/Services/WindowServer/MenuManager.h
@@ -15,7 +15,7 @@
 namespace WindowServer {
 
 class MenuManager final : public Core::Object {
-    C_OBJECT(MenuManager);
+    C_OBJECT(MenuManager)
 
 public:
     static MenuManager& the();

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -76,7 +76,7 @@ enum class WindowMinimizedState : u32 {
 };
 
 class Window final : public Core::Object {
-    C_OBJECT(Window);
+    C_OBJECT(Window)
 
 public:
     virtual ~Window() override;

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -69,7 +69,7 @@ namespace Shell {
 class Shell;
 
 class Shell : public Core::Object {
-    C_OBJECT(Shell);
+    C_OBJECT(Shell)
 
 public:
     constexpr static auto local_init_file_path = "~/.shellrc";


### PR DESCRIPTION
C_OBJECT and C_OBJECT_ABSTRACT macros included an unnecessary semicolon
at their end which basically did nothing at all; therefore I removed it.