### PR TITLE
Everywhere: Propagate ByteBuffer errors

### DIFF
--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -48,31 +48,24 @@ size_t calculate_base64_encoded_length(ReadonlyBytes input)
     return ((4 * input.size() / 3) + 3) & ~3;
 }
 
-Optional<ByteBuffer> decode_base64(StringView input)
+ErrorOr<ByteBuffer> decode_base64(StringView input)
 {
-    auto get = [&](const size_t offset, bool* is_padding) -> Optional<u8> {
+    auto get = [&](const size_t offset, bool* is_padding) -> ErrorOr<u8> {
         constexpr auto table = make_lookup_table();
         if (offset >= input.length())
             return 0;
         if (input[offset] == '=') {
             if (!is_padding)
-                return {};
+                return Error::from_string_literal("Invalid '=' character outside of padding in base64 data");
             *is_padding = true;
             return 0;
         }
         i16 result = table[static_cast<unsigned char>(input[offset])];
         if (result < 0)
-            return {};
+            return Error::from_string_literal("Invalid character in base64 data");
         VERIFY(result < 256);
         return { result };
     };
-#define TRY_GET(index, is_padding)                       \
-    ({                                                   \
-        auto _temporary_result = get(index, is_padding); \
-        if (!_temporary_result.has_value())              \
-            return {};                                   \
-        _temporary_result.value();                       \
-    })
 
     Vector<u8> output;
     output.ensure_capacity(calculate_base64_decoded_length(input));
@@ -81,10 +74,10 @@ Optional<ByteBuffer> decode_base64(StringView input)
         bool in2_is_padding = false;
         bool in3_is_padding = false;
 
-        const u8 in0 = TRY_GET(i, nullptr);
-        const u8 in1 = TRY_GET(i + 1, nullptr);
-        const u8 in2 = TRY_GET(i + 2, &in2_is_padding);
-        const u8 in3 = TRY_GET(i + 3, &in3_is_padding);
+        const u8 in0 = TRY(get(i, nullptr));
+        const u8 in1 = TRY(get(i + 1, nullptr));
+        const u8 in2 = TRY(get(i + 2, &in2_is_padding));
+        const u8 in3 = TRY(get(i + 3, &in3_is_padding));
 
         const u8 out0 = (in0 << 2) | ((in1 >> 4) & 3);
         const u8 out1 = ((in1 & 0xf) << 4) | ((in2 >> 2) & 0xf);
@@ -97,7 +90,7 @@ Optional<ByteBuffer> decode_base64(StringView input)
             output.append(out2);
     }
 
-    return ByteBuffer::copy(output).release_value_but_fixme_should_propagate_errors();
+    return ByteBuffer::copy(output);
 }
 
 String encode_base64(ReadonlyBytes input)

--- a/AK/Base64.cpp
+++ b/AK/Base64.cpp
@@ -97,7 +97,7 @@ Optional<ByteBuffer> decode_base64(StringView input)
             output.append(out2);
     }
 
-    return ByteBuffer::copy(output);
+    return ByteBuffer::copy(output).release_value_but_fixme_should_propagate_errors();
 }
 
 String encode_base64(ReadonlyBytes input)

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -17,7 +17,7 @@ size_t calculate_base64_decoded_length(StringView);
 
 size_t calculate_base64_encoded_length(ReadonlyBytes);
 
-Optional<ByteBuffer> decode_base64(StringView);
+ErrorOr<ByteBuffer> decode_base64(StringView);
 
 String encode_base64(ReadonlyBytes);
 

--- a/AK/Base64.h
+++ b/AK/Base64.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
-#include <AK/Optional.h>
+#include <AK/Error.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 

--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -1,44 +1,38 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/Array.h>
-#include <AK/ByteBuffer.h>
 #include <AK/Hex.h>
-#include <AK/String.h>
 #include <AK/StringBuilder.h>
-#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 
 namespace AK {
 
-Optional<ByteBuffer> decode_hex(StringView input)
+ErrorOr<ByteBuffer> decode_hex(StringView input)
 {
     if ((input.length() % 2) != 0)
-        return {};
+        return Error::from_string_literal("Hex string was not an even length");
 
-    auto output_result = ByteBuffer::create_zeroed(input.length() / 2);
-    if (output_result.is_error())
-        return {};
-
-    auto& output = output_result.value();
+    auto output = TRY(ByteBuffer::create_zeroed(input.length() / 2));
 
     for (size_t i = 0; i < input.length() / 2; ++i) {
         const auto c1 = decode_hex_digit(input[i * 2]);
         if (c1 >= 16)
-            return {};
+            return Error::from_string_literal("Hex string contains invalid digit");
 
         const auto c2 = decode_hex_digit(input[i * 2 + 1]);
         if (c2 >= 16)
-            return {};
+            return Error::from_string_literal("Hex string contains invalid digit");
 
         output[i] = (c1 << 4) + c2;
     }
 
-    return output_result.release_value();
+    return { move(output) };
 }
 
 String encode_hex(const ReadonlyBytes input)

--- a/AK/Hex.cpp
+++ b/AK/Hex.cpp
@@ -21,7 +21,7 @@ Optional<ByteBuffer> decode_hex(StringView input)
         return {};
 
     auto output_result = ByteBuffer::create_zeroed(input.length() / 2);
-    if (!output_result.has_value())
+    if (output_result.is_error())
         return {};
 
     auto& output = output_result.value();
@@ -38,7 +38,7 @@ Optional<ByteBuffer> decode_hex(StringView input)
         output[i] = (c1 << 4) + c2;
     }
 
-    return output_result;
+    return output_result.release_value();
 }
 
 String encode_hex(const ReadonlyBytes input)

--- a/AK/Hex.h
+++ b/AK/Hex.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
-#include <AK/Optional.h>
+#include <AK/Error.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
 
@@ -24,7 +24,7 @@ constexpr u8 decode_hex_digit(char digit)
     return 255;
 }
 
-Optional<ByteBuffer> decode_hex(StringView);
+ErrorOr<ByteBuffer> decode_hex(StringView);
 
 String encode_hex(ReadonlyBytes);
 

--- a/AK/MemoryStream.h
+++ b/AK/MemoryStream.h
@@ -224,7 +224,7 @@ public:
         size_t nwritten = 0;
         while (bytes.size() - nwritten > 0) {
             if ((m_write_offset + nwritten) % chunk_size == 0)
-                m_chunks.append(ByteBuffer::create_uninitialized(chunk_size).release_value()); // FIXME: Handle possible OOM situation.
+                m_chunks.append(ByteBuffer::create_uninitialized(chunk_size).release_value_but_fixme_should_propagate_errors()); // FIXME: Handle possible OOM situation.
 
             nwritten += bytes.slice(nwritten).copy_trimmed_to(m_chunks.last().bytes().slice((m_write_offset + nwritten) % chunk_size));
         }
@@ -242,7 +242,7 @@ public:
     ByteBuffer copy_into_contiguous_buffer() const
     {
         // FIXME: Handle possible OOM situation.
-        auto buffer = ByteBuffer::create_uninitialized(size()).release_value();
+        auto buffer = ByteBuffer::create_uninitialized(size()).release_value_but_fixme_should_propagate_errors();
 
         const auto nread = read_without_consuming(buffer);
         VERIFY(nread == buffer.size());

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -177,7 +177,7 @@ ByteBuffer String::to_byte_buffer() const
     if (!m_impl)
         return {};
     // FIXME: Handle OOM failure.
-    return ByteBuffer::copy(bytes()).release_value();
+    return ByteBuffer::copy(bytes()).release_value_but_fixme_should_propagate_errors();
 }
 
 template<typename T>

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -84,7 +84,7 @@ void StringBuilder::appendvf(char const* fmt, va_list ap)
 ByteBuffer StringBuilder::to_byte_buffer() const
 {
     // FIXME: Handle OOM failure.
-    return ByteBuffer::copy(data(), length()).release_value();
+    return ByteBuffer::copy(data(), length()).release_value_but_fixme_should_propagate_errors();
 }
 
 String StringBuilder::to_string() const

--- a/AK/UUID.cpp
+++ b/AK/UUID.cpp
@@ -19,21 +19,21 @@ UUID::UUID(Array<u8, 16> uuid_buffer)
 void UUID::convert_string_view_to_uuid(StringView uuid_string_view)
 {
     VERIFY(uuid_string_view.length() == 36);
-    auto first_unit = decode_hex(uuid_string_view.substring_view(0, 8));
-    auto second_unit = decode_hex(uuid_string_view.substring_view(9, 4));
-    auto third_unit = decode_hex(uuid_string_view.substring_view(14, 4));
-    auto fourth_unit = decode_hex(uuid_string_view.substring_view(19, 4));
-    auto fifth_unit = decode_hex(uuid_string_view.substring_view(24, 12));
+    auto first_unit = MUST(decode_hex(uuid_string_view.substring_view(0, 8)));
+    auto second_unit = MUST(decode_hex(uuid_string_view.substring_view(9, 4)));
+    auto third_unit = MUST(decode_hex(uuid_string_view.substring_view(14, 4)));
+    auto fourth_unit = MUST(decode_hex(uuid_string_view.substring_view(19, 4)));
+    auto fifth_unit = MUST(decode_hex(uuid_string_view.substring_view(24, 12)));
 
-    VERIFY(first_unit.value().size() == 4 && second_unit.value().size() == 2
-        && third_unit.value().size() == 2 && fourth_unit.value().size() == 2
-        && fifth_unit.value().size() == 6);
+    VERIFY(first_unit.size() == 4 && second_unit.size() == 2
+        && third_unit.size() == 2 && fourth_unit.size() == 2
+        && fifth_unit.size() == 6);
 
-    m_uuid_buffer.span().overwrite(0, first_unit.value().data(), first_unit.value().size());
-    m_uuid_buffer.span().overwrite(4, second_unit.value().data(), second_unit.value().size());
-    m_uuid_buffer.span().overwrite(6, third_unit.value().data(), third_unit.value().size());
-    m_uuid_buffer.span().overwrite(8, fourth_unit.value().data(), fourth_unit.value().size());
-    m_uuid_buffer.span().overwrite(10, fifth_unit.value().data(), fifth_unit.value().size());
+    m_uuid_buffer.span().overwrite(0, first_unit.data(), first_unit.size());
+    m_uuid_buffer.span().overwrite(4, second_unit.data(), second_unit.size());
+    m_uuid_buffer.span().overwrite(6, third_unit.data(), third_unit.size());
+    m_uuid_buffer.span().overwrite(8, fourth_unit.data(), fourth_unit.size());
+    m_uuid_buffer.span().overwrite(10, fifth_unit.data(), fifth_unit.size());
 }
 
 UUID::UUID(StringView uuid_string_view)

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -140,10 +140,7 @@ ErrorOr<void> BlockBasedFileSystem::write_block(BlockIndex index, const UserOrKe
     // NOTE: We copy the `data` to write into a local buffer before taking the cache lock.
     //       This makes sure any page faults caused by accessing the data will occur before
     //       we tie down the cache.
-    auto buffered_data_or_error = ByteBuffer::create_uninitialized(count);
-    if (!buffered_data_or_error.has_value())
-        return ENOMEM;
-    auto buffered_data = buffered_data_or_error.release_value();
+    auto buffered_data = TRY(ByteBuffer::create_uninitialized(count));
 
     TRY(data.read(buffered_data.bytes()));
 

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -201,10 +201,7 @@ ErrorOr<void> Ext2FSInode::write_indirect_block(BlockBasedFileSystem::BlockIndex
     const auto entries_per_block = EXT2_ADDR_PER_BLOCK(&fs().super_block());
     VERIFY(blocks_indices.size() <= entries_per_block);
 
-    auto block_contents_result = ByteBuffer::create_uninitialized(fs().block_size());
-    if (!block_contents_result.has_value())
-        return ENOMEM;
-    auto block_contents = block_contents_result.release_value();
+    auto block_contents = TRY(ByteBuffer::create_uninitialized(fs().block_size()));
     OutputMemoryStream stream { block_contents };
     auto buffer = UserOrKernelBuffer::for_kernel_buffer(stream.data());
 
@@ -226,10 +223,7 @@ ErrorOr<void> Ext2FSInode::grow_doubly_indirect_block(BlockBasedFileSystem::Bloc
     VERIFY(blocks_indices.size() > old_blocks_length);
     VERIFY(blocks_indices.size() <= entries_per_doubly_indirect_block);
 
-    auto block_contents_result = ByteBuffer::create_uninitialized(fs().block_size());
-    if (!block_contents_result.has_value())
-        return ENOMEM;
-    auto block_contents = block_contents_result.release_value();
+    auto block_contents = TRY(ByteBuffer::create_uninitialized(fs().block_size()));
     auto* block_as_pointers = (unsigned*)block_contents.data();
     OutputMemoryStream stream { block_contents };
     auto buffer = UserOrKernelBuffer::for_kernel_buffer(stream.data());
@@ -269,10 +263,7 @@ ErrorOr<void> Ext2FSInode::shrink_doubly_indirect_block(BlockBasedFileSystem::Bl
     VERIFY(old_blocks_length >= new_blocks_length);
     VERIFY(new_blocks_length <= entries_per_doubly_indirect_block);
 
-    auto block_contents_result = ByteBuffer::create_uninitialized(fs().block_size());
-    if (!block_contents_result.has_value())
-        return ENOMEM;
-    auto block_contents = block_contents_result.release_value();
+    auto block_contents = TRY(ByteBuffer::create_uninitialized(fs().block_size()));
     auto* block_as_pointers = (unsigned*)block_contents.data();
     auto buffer = UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<u8*>(block_as_pointers));
     TRY(fs().read_block(block, &buffer, fs().block_size()));
@@ -305,10 +296,7 @@ ErrorOr<void> Ext2FSInode::grow_triply_indirect_block(BlockBasedFileSystem::Bloc
     VERIFY(blocks_indices.size() > old_blocks_length);
     VERIFY(blocks_indices.size() <= entries_per_triply_indirect_block);
 
-    auto block_contents_result = ByteBuffer::create_uninitialized(fs().block_size());
-    if (!block_contents_result.has_value())
-        return ENOMEM;
-    auto block_contents = block_contents_result.release_value();
+    auto block_contents = TRY(ByteBuffer::create_uninitialized(fs().block_size()));
     auto* block_as_pointers = (unsigned*)block_contents.data();
     OutputMemoryStream stream { block_contents };
     auto buffer = UserOrKernelBuffer::for_kernel_buffer(stream.data());
@@ -351,10 +339,7 @@ ErrorOr<void> Ext2FSInode::shrink_triply_indirect_block(BlockBasedFileSystem::Bl
     VERIFY(old_blocks_length >= new_blocks_length);
     VERIFY(new_blocks_length <= entries_per_triply_indirect_block);
 
-    auto block_contents_result = ByteBuffer::create_uninitialized(fs().block_size());
-    if (!block_contents_result.has_value())
-        return ENOMEM;
-    auto block_contents = block_contents_result.release_value();
+    auto block_contents = TRY(ByteBuffer::create_uninitialized(fs().block_size()));
     auto* block_as_pointers = (unsigned*)block_contents.data();
     auto buffer = UserOrKernelBuffer::for_kernel_buffer(reinterpret_cast<u8*>(block_as_pointers));
     TRY(fs().read_block(block, &buffer, fs().block_size()));
@@ -587,10 +572,7 @@ ErrorOr<Vector<Ext2FS::BlockIndex>> Ext2FSInode::compute_block_list_impl_interna
         if (!count)
             return {};
         size_t read_size = count * sizeof(u32);
-        auto maybe_array_storage = ByteBuffer::create_uninitialized(read_size);
-        if (!maybe_array_storage.has_value())
-            return ENOMEM;
-        auto array_storage = maybe_array_storage.release_value();
+        auto array_storage = TRY(ByteBuffer::create_uninitialized(read_size));
         auto* array = (u32*)array_storage.data();
         auto buffer = UserOrKernelBuffer::for_kernel_buffer((u8*)array);
         TRY(fs().read_block(array_block_index, &buffer, read_size, 0));
@@ -1111,10 +1093,7 @@ ErrorOr<void> Ext2FSInode::write_directory(Vector<Ext2FSDirectoryEntry>& entries
 
     dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::write_directory(): New directory contents to write (size {}):", identifier(), directory_size);
 
-    auto directory_data_result = ByteBuffer::create_uninitialized(directory_size);
-    if (!directory_data_result.has_value())
-        return ENOMEM;
-    auto directory_data = directory_data_result.release_value();
+    auto directory_data = TRY(ByteBuffer::create_uninitialized(directory_size));
     OutputMemoryStream stream { directory_data };
 
     for (auto& entry : entries) {

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -281,10 +281,7 @@ ErrorOr<ByteBuffer> BochsGraphicsAdapter::get_edid(size_t output_port_index) con
     if (output_port_index != 0)
         return Error::from_errno(ENODEV);
 
-    auto bytes = ByteBuffer::copy(const_cast<u8 const*>(m_registers->edid_data), sizeof(m_registers->edid_data));
-    if (!bytes.has_value())
-        return Error::from_errno(ENOMEM);
-    return bytes.release_value();
+    return ByteBuffer::copy(const_cast<u8 const*>(m_registers->edid_data), sizeof(m_registers->edid_data));
 }
 
 }

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -661,12 +661,8 @@ ErrorOr<ByteBuffer> IntelNativeGraphicsAdapter::get_edid(size_t output_port_inde
         return Error::from_errno(ENODEV);
     }
 
-    if (m_crt_edid.has_value()) {
-        auto bytes = ByteBuffer::copy(m_crt_edid_bytes, sizeof(m_crt_edid_bytes));
-        if (!bytes.has_value())
-            return Error::from_errno(ENOMEM);
-        return bytes.release_value();
-    }
+    if (m_crt_edid.has_value())
+        return ByteBuffer::copy(m_crt_edid_bytes, sizeof(m_crt_edid_bytes));
 
     return ByteBuffer {};
 }

--- a/Kernel/Net/NE2000/NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000/NetworkAdapter.cpp
@@ -421,11 +421,11 @@ void NE2000NetworkAdapter::receive()
             u8 drop_buffer[NE2K_PAGE_SIZE];
             Bytes buffer { drop_buffer, array_size(drop_buffer) };
             bool will_drop { false };
-            if (!packet_result.has_value()) {
+            if (packet_result.is_error()) {
                 dbgln("NE2000NetworkAdapter: Not enough memory for packet with length = {}, dropping.", header.length);
                 will_drop = true;
             } else {
-                buffer = packet_result->bytes();
+                buffer = packet_result.value().bytes();
             }
 
             int current_offset = 0;

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -34,11 +34,11 @@ void NetworkAdapter::send(const MACAddress& destination, const ARPPacket& packet
 {
     size_t size_in_bytes = sizeof(EthernetFrameHeader) + sizeof(ARPPacket);
     auto buffer_result = NetworkByteBuffer::create_zeroed(size_in_bytes);
-    if (!buffer_result.has_value()) {
+    if (buffer_result.is_error()) {
         dbgln("Dropping ARP packet targeted at {} as there is not enough memory to buffer it", packet.target_hardware_address().to_string());
         return;
     }
-    auto* eth = (EthernetFrameHeader*)buffer_result->data();
+    auto* eth = (EthernetFrameHeader*)buffer_result.value().data();
     eth->set_source(mac_address());
     eth->set_destination(destination);
     eth->set_ether_type(EtherType::ARP);

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -29,9 +29,9 @@ public:
     using HashType = HashT;
     using DigestType = typename HashT::DigestType;
 
-    // FIXME: Do something other than VERIFY()'ing inside Optional in case of OOM.
+    // FIXME: Do something other than VERIFY()'ing in case of OOM.
     FortunaPRNG()
-        : m_counter(ByteBuffer::create_zeroed(BlockType::block_size()).release_value())
+        : m_counter(ByteBuffer::create_zeroed(BlockType::block_size()).release_value_but_fixme_should_propagate_errors())
     {
     }
 
@@ -101,7 +101,7 @@ private:
         } else {
             auto buffer_result = ByteBuffer::copy(digest.immutable_data(), digest.data_length());
             // If there's no memory left to copy this into, bail out.
-            if (!buffer_result.has_value())
+            if (buffer_result.is_error())
                 return;
 
             m_key = buffer_result.release_value();

--- a/Kernel/Storage/ATA/IDEChannel.cpp
+++ b/Kernel/Storage/ATA/IDEChannel.cpp
@@ -381,8 +381,8 @@ UNMAP_AFTER_INIT void IDEChannel::detect_disks()
         }
 
         // FIXME: Handle possible OOM situation here.
-        ByteBuffer wbuf = ByteBuffer::create_uninitialized(512).release_value();
-        ByteBuffer bbuf = ByteBuffer::create_uninitialized(512).release_value();
+        ByteBuffer wbuf = ByteBuffer::create_uninitialized(512).release_value_but_fixme_should_propagate_errors();
+        ByteBuffer bbuf = ByteBuffer::create_uninitialized(512).release_value_but_fixme_should_propagate_errors();
         u8* b = bbuf.data();
         u16* w = (u16*)wbuf.data();
 

--- a/Kernel/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Storage/NVMe/NVMeController.cpp
@@ -151,7 +151,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::identify_and_init_namespaces()
 
     RefPtr<Memory::PhysicalPage> prp_dma_buffer;
     OwnPtr<Memory::Region> prp_dma_region;
-    auto namespace_data_struct = ByteBuffer::create_zeroed(NVMe_IDENTIFY_SIZE).release_value();
+    auto namespace_data_struct = TRY(ByteBuffer::create_zeroed(NVMe_IDENTIFY_SIZE));
     u32 active_namespace_list[NVMe_IDENTIFY_SIZE / sizeof(u32)];
 
     {

--- a/Kernel/Storage/Partition/GUIDPartitionTable.cpp
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.cpp
@@ -59,7 +59,7 @@ GUIDPartitionTable::GUIDPartitionTable(const StorageDevice& device)
     : MBRPartitionTable(device)
 {
     // FIXME: Handle OOM failure here.
-    m_cached_header = ByteBuffer::create_zeroed(m_device->block_size()).release_value();
+    m_cached_header = ByteBuffer::create_zeroed(m_device->block_size()).release_value_but_fixme_should_propagate_errors();
     VERIFY(partitions_count() == 0);
     if (!initialize())
         m_valid = false;
@@ -89,7 +89,7 @@ bool GUIDPartitionTable::initialize()
     }
 
     auto entries_buffer_result = ByteBuffer::create_zeroed(m_device->block_size());
-    if (!entries_buffer_result.has_value()) {
+    if (entries_buffer_result.is_error()) {
         dbgln("GUIPartitionTable: not enough memory for entries buffer");
         return false;
     }

--- a/Kernel/Storage/Partition/MBRPartitionTable.cpp
+++ b/Kernel/Storage/Partition/MBRPartitionTable.cpp
@@ -47,7 +47,7 @@ bool MBRPartitionTable::read_boot_record()
 MBRPartitionTable::MBRPartitionTable(const StorageDevice& device, u32 start_lba)
     : PartitionTable(device)
     , m_start_lba(start_lba)
-    , m_cached_header(ByteBuffer::create_zeroed(m_device->block_size()).release_value()) // FIXME: Do something sensible if this fails because of OOM.
+    , m_cached_header(ByteBuffer::create_zeroed(m_device->block_size()).release_value_but_fixme_should_propagate_errors()) // FIXME: Do something sensible if this fails because of OOM.
 {
     if (!read_boot_record() || !initialize())
         return;
@@ -68,7 +68,7 @@ MBRPartitionTable::MBRPartitionTable(const StorageDevice& device, u32 start_lba)
 MBRPartitionTable::MBRPartitionTable(const StorageDevice& device)
     : PartitionTable(device)
     , m_start_lba(0)
-    , m_cached_header(ByteBuffer::create_zeroed(m_device->block_size()).release_value()) // FIXME: Do something sensible if this fails because of OOM.
+    , m_cached_header(ByteBuffer::create_zeroed(m_device->block_size()).release_value_but_fixme_should_propagate_errors()) // FIXME: Do something sensible if this fails because of OOM.
 {
     if (!read_boot_record() || contains_ebr() || is_protective_mbr() || !initialize())
         return;

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -62,10 +62,7 @@ ErrorOr<size_t> StorageDevice::read(OpenFileDescription&, u64 offset, UserOrKern
     off_t pos = whole_blocks * block_size();
 
     if (remaining > 0) {
-        auto data_result = ByteBuffer::create_uninitialized(block_size());
-        if (!data_result.has_value())
-            return ENOMEM;
-        auto data = data_result.release_value();
+        auto data = TRY(ByteBuffer::create_uninitialized(block_size()));
         auto data_buffer = UserOrKernelBuffer::for_kernel_buffer(data.data());
         auto read_request = TRY(try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read, index + whole_blocks, 1, data_buffer, block_size()));
         auto result = read_request->wait();
@@ -133,7 +130,7 @@ ErrorOr<size_t> StorageDevice::write(OpenFileDescription&, u64 offset, const Use
     // then write the whole block back to the disk.
     if (remaining > 0) {
         // FIXME: Do something sensible with this OOM scenario.
-        auto data = ByteBuffer::create_zeroed(block_size()).release_value();
+        auto data = ByteBuffer::create_zeroed(block_size()).release_value_but_fixme_should_propagate_errors();
         auto data_buffer = UserOrKernelBuffer::for_kernel_buffer(data.data());
 
         {

--- a/Tests/AK/TestBase64.cpp
+++ b/Tests/AK/TestBase64.cpp
@@ -14,7 +14,7 @@ TEST_CASE(test_decode)
 {
     auto decode_equal = [&](const char* input, const char* expected) {
         auto decoded_option = decode_base64(StringView(input));
-        EXPECT(decoded_option.has_value());
+        EXPECT(!decoded_option.is_error());
         auto decoded = decoded_option.release_value();
         EXPECT(String::copy(decoded) == String(expected));
         EXPECT(StringView(expected).length() <= calculate_base64_decoded_length(StringView(input).bytes()));
@@ -31,10 +31,10 @@ TEST_CASE(test_decode)
 
 TEST_CASE(test_decode_invalid)
 {
-    EXPECT(!decode_base64(StringView("asdf\xffqwe")).has_value());
-    EXPECT(!decode_base64(StringView("asdf\x80qwe")).has_value());
-    EXPECT(!decode_base64(StringView("asdf:qwe")).has_value());
-    EXPECT(!decode_base64(StringView("asdf=qwe")).has_value());
+    EXPECT(decode_base64(StringView("asdf\xffqwe")).is_error());
+    EXPECT(decode_base64(StringView("asdf\x80qwe")).is_error());
+    EXPECT(decode_base64(StringView("asdf:qwe")).is_error());
+    EXPECT(decode_base64(StringView("asdf=qwe")).is_error());
 }
 
 TEST_CASE(test_encode)

--- a/Tests/AK/TestByteBuffer.cpp
+++ b/Tests/AK/TestByteBuffer.cpp
@@ -43,8 +43,8 @@ TEST_CASE(equality_operator)
 #if COMPILE_NEGATIVE_TESTS
 TEST_CASE(negative_operator_lt)
 {
-    ByteBuffer a = ByteBuffer::copy("Hello, world", 10);
-    ByteBuffer b = ByteBuffer::copy("Hello, friend", 10);
+    ByteBuffer a = ByteBuffer::copy("Hello, world", 10).release_value();
+    ByteBuffer b = ByteBuffer::copy("Hello, friend", 10).release_value();
     [[maybe_unused]] auto res = a < b;
     // error: error: use of deleted function ‘bool AK::ByteBuffer::operator<(const AK::ByteBuffer&) const’
 }

--- a/Tests/Kernel/stress-writeread.cpp
+++ b/Tests/Kernel/stress-writeread.cpp
@@ -85,7 +85,7 @@ int main(int argc, char** argv)
     args_parser.parse(argc, argv);
 
     auto buffer_result = AK::ByteBuffer::create_zeroed(block_size);
-    if (!buffer_result.has_value()) {
+    if (buffer_result.is_error()) {
         warnln("Failed to allocate a buffer of {} bytes", block_size);
         return EXIT_FAILURE;
     }

--- a/Tests/LibIMAP/TestQuotedPrintable.cpp
+++ b/Tests/LibIMAP/TestQuotedPrintable.cpp
@@ -17,7 +17,7 @@ TEST_CASE(test_decode)
 
     auto decode_equal_byte_buffer = [](const char* input, const char* expected, size_t expected_length) {
         auto decoded = IMAP::decode_quoted_printable(StringView(input));
-        EXPECT(decoded == *ByteBuffer::copy(expected, expected_length));
+        EXPECT(decoded == ByteBuffer::copy(expected, expected_length).value());
     };
 
     decode_equal("hello world", "hello world");

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -387,11 +387,7 @@ ErrorOr<void> BrowserWindow::load_search_engines(GUI::Menu& settings_menu)
 
     auto search_engines_file = TRY(Core::Stream::File::open(Browser::search_engines_file_path(), Core::Stream::OpenMode::Read));
     auto file_size = TRY(search_engines_file->size());
-    auto maybe_buffer = ByteBuffer::create_uninitialized(file_size);
-    if (!maybe_buffer.has_value())
-        return Error::from_string_literal("Unable to allocate buffer for reading search-engines file.");
-
-    auto buffer = maybe_buffer.release_value();
+    auto buffer = TRY(ByteBuffer::create_uninitialized(file_size));
     if (search_engines_file->read_or_error(buffer)) {
         StringView buffer_contents { buffer.bytes() };
         if (auto json = TRY(JsonValue::from_string(buffer_contents)); json.is_array()) {

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -36,17 +36,13 @@ static ErrorOr<void> load_content_filters()
 {
     auto file = TRY(Core::Stream::File::open(String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory()), Core::Stream::OpenMode::Read));
     auto ad_filter_list = TRY(Core::Stream::BufferedFile::create(move(file)));
-    auto maybe_buffer = ByteBuffer::create_uninitialized(4096);
-    if (maybe_buffer.has_value()) {
-        auto buffer = maybe_buffer.release_value();
-
-        while (TRY(ad_filter_list->can_read_line())) {
-            auto length = TRY(ad_filter_list->read_line(buffer));
-            StringView line { buffer.data(), length };
-            dbgln("Content filter for {}", line);
-            if (!line.is_empty())
-                Browser::g_content_filters.append(line);
-        }
+    auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
+    while (TRY(ad_filter_list->can_read_line())) {
+        auto length = TRY(ad_filter_list->read_line(buffer));
+        StringView line { buffer.data(), length };
+        dbgln("Content filter for {}", line);
+        if (!line.is_empty())
+            Browser::g_content_filters.append(line);
     }
 
     return {};

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -77,8 +77,8 @@ Result<ByteBuffer, String> FindDialog::process_input(String text_value, OptionId
 
     case OPTION_HEX_VALUE: {
         auto decoded = decode_hex(text_value.replace(" ", "", true));
-        if (!decoded.has_value())
-            return String("Input contains invalid hex values.");
+        if (decoded.is_error())
+            return String::formatted("Input is invalid: {}", decoded.error().string_literal());
 
         return decoded.value();
     }

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -28,7 +28,7 @@
 
 HexEditor::HexEditor()
     : m_blink_timer(Core::Timer::construct())
-    , m_document(make<HexDocumentMemory>(ByteBuffer::create_zeroed(0).release_value()))
+    , m_document(make<HexDocumentMemory>(ByteBuffer::create_zeroed(0).release_value_but_fixme_should_propagate_errors()))
 {
     set_should_hide_unnecessary_scrollbars(true);
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
@@ -60,7 +60,7 @@ void HexEditor::set_readonly(bool readonly)
 bool HexEditor::open_new_file(size_t size)
 {
     auto maybe_buffer = ByteBuffer::create_zeroed(size);
-    if (!maybe_buffer.has_value()) {
+    if (maybe_buffer.is_error()) {
         return false;
     }
 

--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -499,7 +499,9 @@ void MailWidget::selected_email_to_load()
     if (selected_alternative_encoding.equals_ignoring_case("7bit") || selected_alternative_encoding.equals_ignoring_case("8bit")) {
         decoded_data = encoded_data;
     } else if (selected_alternative_encoding.equals_ignoring_case("base64")) {
-        decoded_data = decode_base64(encoded_data).value_or(ByteBuffer());
+        auto decoded_base64 = decode_base64(encoded_data);
+        if (!decoded_base64.is_error())
+            decoded_data = decoded_base64.release_value();
     } else if (selected_alternative_encoding.equals_ignoring_case("quoted-printable")) {
         decoded_data = IMAP::decode_quoted_printable(encoded_data);
     } else {

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -88,11 +88,8 @@ ErrorOr<NonnullRefPtr<Image>> Image::try_create_from_pixel_paint_json(JsonObject
         auto name = layer_object.get("name").as_string();
 
         auto bitmap_base64_encoded = layer_object.get("bitmap").as_string();
-        auto bitmap_data = decode_base64(bitmap_base64_encoded);
-        if (!bitmap_data.has_value())
-            return Error::from_string_literal("Base64 decode failed"sv);
-
-        auto bitmap = TRY(try_decode_bitmap(bitmap_data.value()));
+        auto bitmap_data = TRY(decode_base64(bitmap_base64_encoded));
+        auto bitmap = TRY(try_decode_bitmap(bitmap_data));
         auto layer = TRY(Layer::try_create_with_bitmap(*image, move(bitmap), name));
 
         auto width = layer_object.get("width").to_i32();

--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -36,7 +36,7 @@ CSVExportDialogPage::CSVExportDialogPage(const Sheet& sheet)
     m_headers.extend(m_data.take_first());
 
     auto temp_template = String::formatted("{}/spreadsheet-csv-export.{}.XXXXXX", Core::StandardPaths::tempfile_directory(), getpid());
-    auto temp_path = ByteBuffer::create_uninitialized(temp_template.length() + 1).release_value();
+    auto temp_path = ByteBuffer::create_uninitialized(temp_template.length() + 1).release_value_but_fixme_should_propagate_errors();
     auto buf = reinterpret_cast<char*>(temp_path.data());
     auto copy_ok = temp_template.copy_characters_to_buffer(buf, temp_path.size());
     VERIFY(copy_ok);

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -321,7 +321,7 @@ void SoftMMU::copy_from_vm(void* destination, const FlatPtr source, size_t size)
 
 ByteBuffer SoftMMU::copy_buffer_from_vm(const FlatPtr source, size_t size)
 {
-    auto buffer = ByteBuffer::create_uninitialized(size).release_value(); // FIXME: Handle possible OOM situation.
+    auto buffer = ByteBuffer::create_uninitialized(size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     copy_from_vm(buffer.data(), source, size);
     return buffer;
 }

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -144,7 +144,7 @@ ErrorOr<FlacRawMetadataBlock, LoaderError> FlacLoaderPlugin::next_meta_block(Big
     u32 block_length = LOADER_TRY(bit_input.read_bits<u32>(24));
     m_data_start_location += 3;
     auto block_data_result = ByteBuffer::create_uninitialized(block_length);
-    FLAC_VERIFY(block_data_result.has_value(), LoaderError::Category::IO, "Out of memory");
+    FLAC_VERIFY(!block_data_result.is_error(), LoaderError::Category::IO, "Out of memory");
     auto block_data = block_data_result.release_value();
     // Reads exactly the bytes necessary into the Bytes container
     LOADER_TRY(bit_input.read(block_data));

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -71,7 +71,7 @@ LoaderSamples WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_in
         pcm_bits_per_sample(m_sample_format), sample_format_name(m_sample_format));
 
     auto sample_data_result = ByteBuffer::create_zeroed(bytes_to_read);
-    if (!sample_data_result.has_value())
+    if (sample_data_result.is_error())
         return LoaderError { LoaderError::Category::IO, static_cast<size_t>(m_loaded_samples), "Couldn't allocate sample buffer" };
     auto sample_data = sample_data_result.release_value();
     m_stream->read_or_error(sample_data.bytes());

--- a/Userland/Libraries/LibCore/IODevice.cpp
+++ b/Userland/Libraries/LibCore/IODevice.cpp
@@ -49,7 +49,7 @@ ByteBuffer IODevice::read(size_t max_size)
 
     auto size = min(max_size, m_buffered_data.size());
     auto buffer_result = ByteBuffer::create_uninitialized(size);
-    if (!buffer_result.has_value()) {
+    if (buffer_result.is_error()) {
         dbgln("IODevice::read: Not enough memory to allocate a buffer of {} bytes", size);
         return {};
     }
@@ -149,7 +149,7 @@ ByteBuffer IODevice::read_all()
     }
 
     auto result = ByteBuffer::copy(data);
-    if (result.has_value())
+    if (!result.is_error())
         return result.release_value();
 
     set_error(ENOMEM);
@@ -174,7 +174,7 @@ String IODevice::read_line(size_t max_size)
         return line;
     }
     auto line_result = ByteBuffer::create_uninitialized(max_size + 1);
-    if (!line_result.has_value()) {
+    if (line_result.is_error()) {
         dbgln("IODevice::read_line: Not enough memory to allocate a buffer of {} bytes", max_size + 1);
         return {};
     }
@@ -202,7 +202,7 @@ bool IODevice::populate_read_buffer(size_t size) const
         return false;
 
     auto buffer_result = ByteBuffer::create_uninitialized(size);
-    if (!buffer_result.has_value()) {
+    if (buffer_result.is_error()) {
         dbgln("IODevice::populate_read_buffer: Not enough memory to allocate a buffer of {} bytes", size);
         return {};
     }

--- a/Userland/Libraries/LibCore/InputBitStream.h
+++ b/Userland/Libraries/LibCore/InputBitStream.h
@@ -99,13 +99,9 @@ public:
                         m_current_byte.clear();
                 }
             } else {
-                // FIXME: This returns Optional so TRY is not useable
-                auto temp_buffer = ByteBuffer::create_uninitialized(1);
-                if (!temp_buffer.has_value())
-                    return Error::from_string_literal("Couldn't allocate temporary byte buffer"sv);
-
-                TRY(m_stream.read(temp_buffer->bytes()));
-                m_current_byte = (*temp_buffer)[0];
+                auto temp_buffer = TRY(ByteBuffer::create_uninitialized(1));
+                TRY(m_stream.read(temp_buffer.bytes()));
+                m_current_byte = temp_buffer[0];
                 m_bit_offset = 0;
             }
         }

--- a/Userland/Libraries/LibCore/SecretString.cpp
+++ b/Userland/Libraries/LibCore/SecretString.cpp
@@ -12,14 +12,13 @@ namespace Core {
 
 SecretString SecretString::take_ownership(char*& cstring, size_t length)
 {
-    auto buffer = ByteBuffer::copy(cstring, length);
-    VERIFY(buffer.has_value());
+    auto buffer = ByteBuffer::copy(cstring, length).release_value_but_fixme_should_propagate_errors();
 
     secure_zero(cstring, length);
     free(cstring);
     cstring = nullptr;
 
-    return SecretString(buffer.release_value());
+    return SecretString(move(buffer));
 }
 
 SecretString SecretString::take_ownership(ByteBuffer&& buffer)

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -479,11 +479,9 @@ public:
         if (!stream->is_open())
             return Error::from_errno(ENOTCONN);
 
-        auto maybe_buffer = ByteBuffer::create_uninitialized(buffer_size);
-        if (!maybe_buffer.has_value())
-            return Error::from_errno(ENOMEM);
+        auto buffer = TRY(ByteBuffer::create_uninitialized(buffer_size));
 
-        return adopt_nonnull_own_or_enomem(new BufferedType<T>(move(stream), maybe_buffer.release_value()));
+        return adopt_nonnull_own_or_enomem(new BufferedType<T>(move(stream), move(buffer)));
     }
 
     T& stream() { return *m_stream; }

--- a/Userland/Libraries/LibCore/UDPServer.cpp
+++ b/Userland/Libraries/LibCore/UDPServer.cpp
@@ -64,7 +64,7 @@ bool UDPServer::bind(const IPv4Address& address, u16 port)
 ByteBuffer UDPServer::receive(size_t size, sockaddr_in& in)
 {
     // FIXME: Handle possible OOM situation.
-    auto buf = ByteBuffer::create_uninitialized(size).release_value();
+    auto buf = ByteBuffer::create_uninitialized(size).release_value_but_fixme_should_propagate_errors();
     socklen_t in_len = sizeof(in);
     ssize_t rlen = ::recvfrom(m_fd, buf.data(), size, 0, (sockaddr*)&in, &in_len);
     if (rlen < 0) {

--- a/Userland/Libraries/LibCoredump/Reader.cpp
+++ b/Userland/Libraries/LibCoredump/Reader.cpp
@@ -63,9 +63,14 @@ Reader::Reader(ReadonlyBytes coredump_bytes)
 Optional<ByteBuffer> Reader::decompress_coredump(ReadonlyBytes raw_coredump)
 {
     auto decompressed_coredump = Compress::GzipDecompressor::decompress_all(raw_coredump);
-    if (!decompressed_coredump.has_value())
-        return ByteBuffer::copy(raw_coredump); // if we didn't manage to decompress it, try and parse it as decompressed coredump
-    return decompressed_coredump;
+    if (decompressed_coredump.has_value())
+        return decompressed_coredump;
+
+    // If we didn't manage to decompress it, try and parse it as decompressed coredump
+    auto bytebuffer = ByteBuffer::copy(raw_coredump);
+    if (bytebuffer.is_error())
+        return {};
+    return bytebuffer.release_value();
 }
 
 Reader::~Reader()

--- a/Userland/Libraries/LibCrypto/ASN1/PEM.cpp
+++ b/Userland/Libraries/LibCrypto/ASN1/PEM.cpp
@@ -35,8 +35,8 @@ ByteBuffer decode_pem(ReadonlyBytes data)
                 break;
             }
             auto b64decoded = decode_base64(lexer.consume_line().trim_whitespace(TrimMode::Right));
-            if (!b64decoded.has_value()) {
-                dbgln("Failed to decode PEM, likely bad Base64");
+            if (b64decoded.is_error()) {
+                dbgln("Failed to decode PEM: {}", b64decoded.error().string_literal());
                 return {};
             }
             if (decoded.try_append(b64decoded.value().data(), b64decoded.value().size()).is_error()) {

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
@@ -68,12 +68,12 @@ public:
     {
         auto iv_buf_result = ByteBuffer::copy(iv_in);
         // Not enough memory to figure out :shrug:
-        if (!iv_buf_result.has_value()) {
+        if (iv_buf_result.is_error()) {
             dbgln("GCM::encrypt: Not enough memory to allocate {} bytes for IV", iv_in.size());
             return;
         }
 
-        auto iv = iv_buf_result->bytes();
+        auto iv = iv_buf_result.value().bytes();
 
         // Increment the IV for block 0
         CTR<T>::increment(iv);
@@ -98,10 +98,10 @@ public:
     {
         auto iv_buf_result = ByteBuffer::copy(iv_in);
         // Not enough memory to figure out :shrug:
-        if (!iv_buf_result.has_value())
+        if (iv_buf_result.is_error())
             return VerificationConsistency::Inconsistent;
 
-        auto iv = iv_buf_result->bytes();
+        auto iv = iv_buf_result.value().bytes();
 
         // Increment the IV for block 0
         CTR<T>::increment(iv);

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/Mode.h
@@ -26,7 +26,7 @@ public:
 
     const T& cipher() const { return m_cipher; }
 
-    Optional<ByteBuffer> create_aligned_buffer(size_t input_size) const
+    ErrorOr<ByteBuffer> create_aligned_buffer(size_t input_size) const
     {
         size_t remainder = (input_size + T::block_size()) % T::block_size();
         if (remainder == 0)

--- a/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
+++ b/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
@@ -165,7 +165,7 @@ UnsignedBigInteger random_number(const UnsignedBigInteger& min, const UnsignedBi
     UnsignedBigInteger base;
     auto size = range.trimmed_length() * sizeof(u32) + 2;
     // "+2" is intentional (see below).
-    auto buffer = ByteBuffer::create_uninitialized(size).release_value(); // FIXME: Handle possible OOM situation.
+    auto buffer = ByteBuffer::create_uninitialized(size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     auto* buf = buffer.data();
 
     fill_with_random(buf, size);

--- a/Userland/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Userland/Libraries/LibCrypto/PK/RSA.cpp
@@ -199,7 +199,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         auto data = data_result.release_value();
         // FIXME: This is pretty awkward, maybe just generate a zero'd out ByteBuffer from the parser instead?
         auto padded_data_result = ByteBuffer::create_zeroed(data.size_in_bytes());
-        if (!padded_data_result.has_value()) {
+        if (padded_data_result.is_error()) {
             dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#1 key parse failed: Not enough memory");
             return keypair;
         }

--- a/Userland/Libraries/LibEDID/EDID.cpp
+++ b/Userland/Libraries/LibEDID/EDID.cpp
@@ -359,25 +359,21 @@ ErrorOr<Parser> Parser::from_framebuffer_device(int framebuffer_fd, size_t head)
         int err = errno;
         if (err == EOVERFLOW) {
             // We need a bigger buffer with at least bytes_size bytes
-            auto edid_byte_buffer = ByteBuffer::create_zeroed(edid_info.bytes_size);
-            if (!edid_byte_buffer.has_value())
-                return Error::from_errno(ENOMEM);
-            edid_info.bytes = edid_byte_buffer.value().data();
+            auto edid_byte_buffer = TRY(ByteBuffer::create_zeroed(edid_info.bytes_size));
+            edid_info.bytes = edid_byte_buffer.data();
             if (fb_get_head_edid(framebuffer_fd, &edid_info) < 0) {
                 err = errno;
                 return Error::from_errno(err);
             }
 
-            return from_bytes(edid_byte_buffer.release_value());
+            return from_bytes(move(edid_byte_buffer));
         }
 
         return Error::from_errno(err);
     }
 
-    auto edid_byte_buffer = ByteBuffer::copy((void const*)edid_bytes, sizeof(edid_bytes));
-    if (!edid_byte_buffer.has_value())
-        return Error::from_errno(ENOMEM);
-    return from_bytes(edid_byte_buffer.release_value());
+    auto edid_byte_buffer = TRY(ByteBuffer::copy((void const*)edid_bytes, sizeof(edid_bytes)));
+    return from_bytes(move(edid_byte_buffer));
 }
 
 ErrorOr<Parser> Parser::from_framebuffer_device(String const& framebuffer_device, size_t head)

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -184,7 +184,7 @@ static void allocate_tls()
 
     auto page_aligned_size = align_up_to(s_total_tls_size, PAGE_SIZE);
     auto initial_tls_data_result = ByteBuffer::create_zeroed(page_aligned_size);
-    if (!initial_tls_data_result.has_value()) {
+    if (initial_tls_data_result.is_error()) {
         dbgln("Failed to allocate initial TLS data");
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -56,7 +56,7 @@ Clipboard::DataAndType Clipboard::fetch_data_and_type() const
     if (!response.data().is_valid())
         return {};
     auto data = ByteBuffer::copy(response.data().data<void>(), response.data().size());
-    if (!data.has_value())
+    if (data.is_error())
         return {};
 
     auto type = response.mime_type();

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -927,7 +927,7 @@ static bool uncompress_bmp_rle_data(BMPLoadingContext& context, ByteBuffer& buff
         return false;
     }
     auto buffer_result = ByteBuffer::create_zeroed(buffer_size);
-    if (!buffer_result.has_value()) {
+    if (buffer_result.is_error()) {
         dbgln("Not enough memory for buffer allocation");
         return false;
     }

--- a/Userland/Libraries/LibGfx/BMPWriter.cpp
+++ b/Userland/Libraries/LibGfx/BMPWriter.cpp
@@ -46,7 +46,7 @@ static ByteBuffer write_pixel_data(const RefPtr<Bitmap> bitmap, int pixel_row_da
 {
     int image_size = pixel_row_data_size * bitmap->height();
     auto buffer_result = ByteBuffer::create_uninitialized(image_size);
-    if (!buffer_result.has_value())
+    if (buffer_result.is_error())
         return {};
 
     auto buffer = buffer_result.release_value();
@@ -100,7 +100,7 @@ ByteBuffer BMPWriter::dump(const RefPtr<Bitmap> bitmap, DibHeader dib_header)
     int pixel_row_data_size = (m_bytes_per_pixel * 8 * bitmap->width() + 31) / 32 * 4;
     int image_size = pixel_row_data_size * bitmap->height();
     auto buffer_result = ByteBuffer::create_uninitialized(pixel_data_offset);
-    if (!buffer_result.has_value())
+    if (buffer_result.is_error())
         return {};
 
     auto buffer = buffer_result.release_value();

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -241,7 +241,7 @@ ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::try_create_from_serialized_byte_buffer(By
 ByteBuffer Bitmap::serialize_to_byte_buffer() const
 {
     // FIXME: Somehow handle possible OOM situation here.
-    auto buffer = ByteBuffer::create_uninitialized(sizeof(size_t) + 4 * sizeof(unsigned) + sizeof(BitmapFormat) + sizeof(RGBA32) * palette_size(m_format) + size_in_bytes()).release_value();
+    auto buffer = ByteBuffer::create_uninitialized(sizeof(size_t) + 4 * sizeof(unsigned) + sizeof(BitmapFormat) + sizeof(RGBA32) * palette_size(m_format) + size_in_bytes()).release_value_but_fixme_should_propagate_errors();
     OutputMemoryStream stream { buffer };
 
     auto write = [&]<typename T>(T value) {

--- a/Userland/Libraries/LibGfx/PNGWriter.cpp
+++ b/Userland/Libraries/LibGfx/PNGWriter.cpp
@@ -222,7 +222,7 @@ ByteBuffer PNGWriter::encode(Gfx::Bitmap const& bitmap)
     writer.add_IDAT_chunk(bitmap);
     writer.add_IEND_chunk();
     // FIXME: Handle OOM failure.
-    return ByteBuffer::copy(writer.m_data).release_value();
+    return ByteBuffer::copy(writer.m_data).release_value_but_fixme_should_propagate_errors();
 }
 
 }

--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -198,7 +198,7 @@ Optional<HttpRequest::BasicAuthenticationCredentials> HttpRequest::parse_http_ba
     if (token.is_empty())
         return {};
     auto decoded_token_bb = decode_base64(token);
-    if (!decoded_token_bb.has_value())
+    if (decoded_token_bb.is_error())
         return {};
     auto decoded_token = String::copy(decoded_token_bb.value());
     auto colon_index = decoded_token.find(':');

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -407,7 +407,7 @@ void Job::finish_up()
     VERIFY(!m_has_scheduled_finish);
     m_state = State::Finished;
     if (!m_can_stream_response) {
-        auto flattened_buffer = ByteBuffer::create_uninitialized(m_buffered_size).release_value(); // FIXME: Handle possible OOM situation.
+        auto flattened_buffer = ByteBuffer::create_uninitialized(m_buffered_size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
         u8* flat_ptr = flattened_buffer.data();
         for (auto& received_buffer : m_received_buffers) {
             memcpy(flat_ptr, received_buffer.data(), received_buffer.size());

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -8,14 +8,10 @@
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/DateTime.h>
-#include <LibCore/System.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Dictionary.h>
 #include <LibIPC/File.h>
-#include <errno.h>
 #include <fcntl.h>
-#include <string.h>
-#include <sys/socket.h>
 
 namespace IPC {
 
@@ -125,10 +121,7 @@ ErrorOr<void> Decoder::decode(ByteBuffer& value)
         return {};
     }
 
-    if (auto buffer_result = ByteBuffer::create_uninitialized(length); buffer_result.has_value())
-        value = buffer_result.release_value();
-    else
-        return Error::from_errno(ENOMEM);
+    value = TRY(ByteBuffer::create_uninitialized(length));
 
     m_stream >> value.bytes();
     return m_stream.try_handle_any_error();

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -13,7 +13,7 @@ namespace JS {
 ArrayBuffer* ArrayBuffer::create(GlobalObject& global_object, size_t byte_length)
 {
     auto buffer = ByteBuffer::create_zeroed(byte_length);
-    if (!buffer.has_value()) {
+    if (buffer.is_error()) {
         global_object.vm().throw_exception<RangeError>(global_object, ErrorType::NotEnoughMemoryToAllocate, byte_length);
         return nullptr;
     }
@@ -62,11 +62,11 @@ ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject& global_objec
 
     // 2. Let block be ? CreateByteDataBlock(byteLength).
     auto block = ByteBuffer::create_zeroed(byte_length);
-    if (!block.has_value())
+    if (block.is_error())
         return global_object.vm().throw_completion<RangeError>(global_object, ErrorType::NotEnoughMemoryToAllocate, byte_length);
 
     // 3. Set obj.[[ArrayBufferData]] to block.
-    obj->set_buffer(move(*block));
+    obj->set_buffer(block.release_value());
 
     // 4. Set obj.[[ArrayBufferByteLength]] to byteLength.
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -133,7 +133,7 @@ static ByteBuffer numeric_to_raw_bytes(GlobalObject& global_object, Value value,
 {
     VERIFY(value.is_number() || value.is_bigint());
     using UnderlyingBufferDataType = Conditional<IsSame<ClampedU8, T>, u8, T>;
-    ByteBuffer raw_bytes = ByteBuffer::create_uninitialized(sizeof(UnderlyingBufferDataType)).release_value(); // FIXME: Handle possible OOM situation.
+    ByteBuffer raw_bytes = ByteBuffer::create_uninitialized(sizeof(UnderlyingBufferDataType)).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     auto flip_if_needed = [&]() {
         if (is_little_endian)
             return;

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -39,8 +39,12 @@ Optional<ByteBuffer> Filter::decode(ReadonlyBytes bytes, FlyString const& encodi
 
 Optional<ByteBuffer> Filter::decode_ascii_hex(ReadonlyBytes bytes)
 {
-    if (bytes.size() % 2 == 0)
-        return decode_hex(bytes);
+    if (bytes.size() % 2 == 0) {
+        auto decode_result = decode_hex(bytes);
+        if (decode_result.is_error())
+            return {};
+        return decode_result.release_value();
+    }
 
     // FIXME: Integrate this padding into AK/Hex?
 

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -11,7 +11,7 @@
 
 namespace PDF {
 
-Optional<ByteBuffer> Filter::decode(ReadonlyBytes bytes, FlyString const& encoding_type)
+ErrorOr<ByteBuffer> Filter::decode(ReadonlyBytes bytes, FlyString const& encoding_type)
 {
     if (encoding_type == CommonNames::ASCIIHexDecode)
         return decode_ascii_hex(bytes);
@@ -34,34 +34,26 @@ Optional<ByteBuffer> Filter::decode(ReadonlyBytes bytes, FlyString const& encodi
     if (encoding_type == CommonNames::Crypt)
         return decode_crypt(bytes);
 
-    return {};
+    return Error::from_string_literal("Unrecognized filter encoding");
 }
 
-Optional<ByteBuffer> Filter::decode_ascii_hex(ReadonlyBytes bytes)
+ErrorOr<ByteBuffer> Filter::decode_ascii_hex(ReadonlyBytes bytes)
 {
-    if (bytes.size() % 2 == 0) {
-        auto decode_result = decode_hex(bytes);
-        if (decode_result.is_error())
-            return {};
-        return decode_result.release_value();
-    }
+    if (bytes.size() % 2 == 0)
+        return decode_hex(bytes);
 
     // FIXME: Integrate this padding into AK/Hex?
 
-    auto output_result = ByteBuffer::create_zeroed(bytes.size() / 2 + 1);
-    if (output_result.is_error())
-        return {};
-
-    auto output = output_result.release_value();
+    auto output = TRY(ByteBuffer::create_zeroed(bytes.size() / 2 + 1));
 
     for (size_t i = 0; i < bytes.size() / 2; ++i) {
         const auto c1 = decode_hex_digit(static_cast<char>(bytes[i * 2]));
         if (c1 >= 16)
-            return {};
+            return Error::from_string_literal("Hex string contains invalid digit");
 
         const auto c2 = decode_hex_digit(static_cast<char>(bytes[i * 2 + 1]));
         if (c2 >= 16)
-            return {};
+            return Error::from_string_literal("Hex string contains invalid digit");
 
         output[i] = (c1 << 4) + c2;
     }
@@ -72,7 +64,7 @@ Optional<ByteBuffer> Filter::decode_ascii_hex(ReadonlyBytes bytes)
     return { move(output) };
 };
 
-Optional<ByteBuffer> Filter::decode_ascii85(ReadonlyBytes bytes)
+ErrorOr<ByteBuffer> Filter::decode_ascii85(ReadonlyBytes bytes)
 {
     Vector<u8> buff;
     buff.ensure_capacity(bytes.size());
@@ -124,19 +116,16 @@ Optional<ByteBuffer> Filter::decode_ascii85(ReadonlyBytes bytes)
             buff.append(reinterpret_cast<u8*>(&number)[3 - i]);
     }
 
-    auto result = ByteBuffer::copy(buff.span());
-    if (result.is_error())
-        return {};
-    return result.release_value();
+    return ByteBuffer::copy(buff.span());
 };
 
-Optional<ByteBuffer> Filter::decode_lzw(ReadonlyBytes)
+ErrorOr<ByteBuffer> Filter::decode_lzw(ReadonlyBytes)
 {
     dbgln("LZW decoding is not supported");
     VERIFY_NOT_REACHED();
 };
 
-Optional<ByteBuffer> Filter::decode_flate(ReadonlyBytes bytes)
+ErrorOr<ByteBuffer> Filter::decode_flate(ReadonlyBytes bytes)
 {
     // FIXME: The spec says Flate decoding is "based on" zlib, does that mean they
     // aren't exactly the same?
@@ -146,37 +135,37 @@ Optional<ByteBuffer> Filter::decode_flate(ReadonlyBytes bytes)
     return buff.value();
 };
 
-Optional<ByteBuffer> Filter::decode_run_length(ReadonlyBytes)
+ErrorOr<ByteBuffer> Filter::decode_run_length(ReadonlyBytes)
 {
     // FIXME: Support RunLength decoding
     TODO();
 };
 
-Optional<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes)
+ErrorOr<ByteBuffer> Filter::decode_ccitt(ReadonlyBytes)
 {
     // FIXME: Support CCITT decoding
     TODO();
 };
 
-Optional<ByteBuffer> Filter::decode_jbig2(ReadonlyBytes)
+ErrorOr<ByteBuffer> Filter::decode_jbig2(ReadonlyBytes)
 {
     // FIXME: Support JBIG2 decoding
     TODO();
 };
 
-Optional<ByteBuffer> Filter::decode_dct(ReadonlyBytes)
+ErrorOr<ByteBuffer> Filter::decode_dct(ReadonlyBytes)
 {
     // FIXME: Support dct decoding
     TODO();
 };
 
-Optional<ByteBuffer> Filter::decode_jpx(ReadonlyBytes)
+ErrorOr<ByteBuffer> Filter::decode_jpx(ReadonlyBytes)
 {
     // FIXME: Support JPX decoding
     TODO();
 };
 
-Optional<ByteBuffer> Filter::decode_crypt(ReadonlyBytes)
+ErrorOr<ByteBuffer> Filter::decode_crypt(ReadonlyBytes)
 {
     // FIXME: Support Crypt decoding
     TODO();

--- a/Userland/Libraries/LibPDF/Filter.cpp
+++ b/Userland/Libraries/LibPDF/Filter.cpp
@@ -45,8 +45,8 @@ Optional<ByteBuffer> Filter::decode_ascii_hex(ReadonlyBytes bytes)
     // FIXME: Integrate this padding into AK/Hex?
 
     auto output_result = ByteBuffer::create_zeroed(bytes.size() / 2 + 1);
-    if (!output_result.has_value())
-        return output_result;
+    if (output_result.is_error())
+        return {};
 
     auto output = output_result.release_value();
 
@@ -120,7 +120,10 @@ Optional<ByteBuffer> Filter::decode_ascii85(ReadonlyBytes bytes)
             buff.append(reinterpret_cast<u8*>(&number)[3 - i]);
     }
 
-    return ByteBuffer::copy(buff.span());
+    auto result = ByteBuffer::copy(buff.span());
+    if (result.is_error())
+        return {};
+    return result.release_value();
 };
 
 Optional<ByteBuffer> Filter::decode_lzw(ReadonlyBytes)

--- a/Userland/Libraries/LibPDF/Filter.h
+++ b/Userland/Libraries/LibPDF/Filter.h
@@ -7,25 +7,26 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/Error.h>
 #include <AK/FlyString.h>
 
 namespace PDF {
 
 class Filter {
 public:
-    static Optional<ByteBuffer> decode(ReadonlyBytes bytes, FlyString const& encoding_type);
+    static ErrorOr<ByteBuffer> decode(ReadonlyBytes bytes, FlyString const& encoding_type);
 
 private:
-    static Optional<ByteBuffer> decode_ascii_hex(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_ascii85(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_lzw(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_flate(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_run_length(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_ccitt(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_jbig2(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_dct(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_jpx(ReadonlyBytes bytes);
-    static Optional<ByteBuffer> decode_crypt(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_ascii_hex(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_ascii85(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_lzw(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_flate(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_run_length(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_ccitt(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_jbig2(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_dct(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_jpx(ReadonlyBytes bytes);
+    static ErrorOr<ByteBuffer> decode_crypt(ReadonlyBytes bytes);
 };
 
 }

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -270,7 +270,7 @@ bool Parser::initialize_hint_tables()
         auto total_size = primary_size + overflow_size;
 
         auto buffer_result = ByteBuffer::create_uninitialized(total_size);
-        if (!buffer_result.has_value())
+        if (buffer_result.is_error())
             return false;
         possible_merged_stream_buffer = buffer_result.release_value();
         auto ok = !possible_merged_stream_buffer.try_append(primary_hint_stream->bytes()).is_error();

--- a/Userland/Libraries/LibPDF/Parser.cpp
+++ b/Userland/Libraries/LibPDF/Parser.cpp
@@ -1071,8 +1071,10 @@ RefPtr<StreamObject> Parser::parse_stream(NonnullRefPtr<DictObject> dict)
     if (dict->contains(CommonNames::Filter)) {
         auto filter_type = dict->get_name(m_document, CommonNames::Filter)->name();
         auto maybe_bytes = Filter::decode(bytes, filter_type);
-        if (!maybe_bytes.has_value())
+        if (maybe_bytes.is_error()) {
+            warnln("Failed to decode filter: {}", maybe_bytes.error().string_literal());
             return {};
+        }
         return make_object<EncodedStreamObject>(dict, move(maybe_bytes.value()));
     }
 

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -28,7 +28,7 @@ RefPtr<Request> RequestClient::start_request(String const& method, URL const& ur
         header_dictionary.add(it.key, it.value);
 
     auto body_result = ByteBuffer::copy(request_body);
-    if (!body_result.has_value())
+    if (body_result.is_error())
         return nullptr;
 
     auto response = IPCProxy::start_request(method, url, header_dictionary, body_result.release_value());

--- a/Userland/Libraries/LibProtocol/WebSocket.cpp
+++ b/Userland/Libraries/LibProtocol/WebSocket.cpp
@@ -27,9 +27,7 @@ void WebSocket::send(ByteBuffer binary_or_text_message, bool is_text)
 
 void WebSocket::send(StringView text_message)
 {
-    auto data_result = ByteBuffer::copy(text_message.bytes());
-    VERIFY(data_result.has_value());
-    send(data_result.release_value(), true);
+    send(ByteBuffer::copy(text_message.bytes()).release_value_but_fixme_should_propagate_errors(), true);
 }
 
 void WebSocket::close(u16 code, String reason)

--- a/Userland/Libraries/LibSQL/Heap.cpp
+++ b/Userland/Libraries/LibSQL/Heap.cpp
@@ -243,7 +243,7 @@ void Heap::update_zero_block()
     }
 
     // FIXME: Handle an OOM failure here.
-    auto buffer = ByteBuffer::create_zeroed(BLOCKSIZE).release_value();
+    auto buffer = ByteBuffer::create_zeroed(BLOCKSIZE).release_value_but_fixme_should_propagate_errors();
     buffer.overwrite(0, FILE_ID.characters_without_null_termination(), FILE_ID.length());
     buffer.overwrite(VERSION_OFFSET, &m_version, sizeof(u32));
     buffer.overwrite(SCHEMAS_ROOT_OFFSET, &m_schemas_root, sizeof(u32));

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -193,7 +193,7 @@ void TLSv12::build_rsa_pre_master_secret(PacketBuilder& builder)
     }
 
     auto premaster_key_result = ByteBuffer::copy(random_bytes, bytes);
-    if (!premaster_key_result.has_value()) {
+    if (premaster_key_result.is_error()) {
         dbgln("RSA premaster key generation failed, not enough memory");
         return;
     }
@@ -245,7 +245,7 @@ void TLSv12::build_dhe_rsa_pre_master_secret(PacketBuilder& builder)
     auto dh_random = Crypto::NumberTheory::random_number(0, dh_p);
     auto dh_Yc = Crypto::NumberTheory::ModularPower(dh_g, dh_random, dh_p);
     auto dh_Yc_bytes_result = ByteBuffer::create_uninitialized(dh_key_size);
-    if (!dh_Yc_bytes_result.has_value()) {
+    if (dh_Yc_bytes_result.is_error()) {
         dbgln("Failed to build DHE_RSA premaster secret: not enough memory");
         return;
     }
@@ -254,7 +254,7 @@ void TLSv12::build_dhe_rsa_pre_master_secret(PacketBuilder& builder)
 
     auto premaster_key = Crypto::NumberTheory::ModularPower(dh_Ys, dh_random, dh_p);
     auto premaster_key_result = ByteBuffer::create_uninitialized(dh_key_size);
-    if (!premaster_key_result.has_value()) {
+    if (premaster_key_result.is_error()) {
         dbgln("Failed to build DHE_RSA premaster secret: not enough memory");
         return;
     }

--- a/Userland/Libraries/LibTLS/HandshakeServer.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeServer.cpp
@@ -241,7 +241,7 @@ ssize_t TLSv12::handle_dhe_rsa_server_key_exchange(ReadonlyBytes buffer)
     auto dh_p_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(3)));
     auto dh_p = buffer.slice(5, dh_p_length);
     auto p_result = ByteBuffer::copy(dh_p);
-    if (!p_result.has_value()) {
+    if (p_result.is_error()) {
         dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
         return 0;
     }
@@ -250,7 +250,7 @@ ssize_t TLSv12::handle_dhe_rsa_server_key_exchange(ReadonlyBytes buffer)
     auto dh_g_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(5 + dh_p_length)));
     auto dh_g = buffer.slice(7 + dh_p_length, dh_g_length);
     auto g_result = ByteBuffer::copy(dh_g);
-    if (!g_result.has_value()) {
+    if (g_result.is_error()) {
         dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
         return 0;
     }
@@ -259,7 +259,7 @@ ssize_t TLSv12::handle_dhe_rsa_server_key_exchange(ReadonlyBytes buffer)
     auto dh_Ys_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(7 + dh_p_length + dh_g_length)));
     auto dh_Ys = buffer.slice(9 + dh_p_length + dh_g_length, dh_Ys_length);
     auto Ys_result = ByteBuffer::copy(dh_Ys);
-    if (!Ys_result.has_value()) {
+    if (Ys_result.is_error()) {
         dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
         return 0;
     }

--- a/Userland/Libraries/LibTLS/TLSPacketBuilder.h
+++ b/Userland/Libraries/LibTLS/TLSPacketBuilder.h
@@ -37,7 +37,7 @@ public:
     PacketBuilder(MessageType type, Version version, size_t size_hint = 0xfdf)
     {
         // FIXME: Handle possible OOM situation.
-        m_packet_data = ByteBuffer::create_uninitialized(size_hint + 16).release_value();
+        m_packet_data = ByteBuffer::create_uninitialized(size_hint + 16).release_value_but_fixme_should_propagate_errors();
         m_current_length = 5;
         m_packet_data[0] = (u8)type;
         ByteReader::store(m_packet_data.offset_pointer(1), AK::convert_between_host_and_network_endian((u16)version));

--- a/Userland/Libraries/LibVideo/MatroskaReader.cpp
+++ b/Userland/Libraries/LibVideo/MatroskaReader.cpp
@@ -405,7 +405,7 @@ OwnPtr<Block> MatroskaReader::parse_simple_block()
         for (int i = 0; i < frame_count; i++) {
             auto current_frame_size = frame_sizes.at(i);
             auto frame_result = ByteBuffer::copy(m_streamer.data(), current_frame_size);
-            if (!frame_result.has_value())
+            if (frame_result.is_error())
                 return {};
             block->add_frame(frame_result.release_value());
             m_streamer.drop_octets(current_frame_size);
@@ -415,14 +415,14 @@ OwnPtr<Block> MatroskaReader::parse_simple_block()
         auto individual_frame_size = total_frame_content_size / frame_count;
         for (int i = 0; i < frame_count; i++) {
             auto frame_result = ByteBuffer::copy(m_streamer.data(), individual_frame_size);
-            if (!frame_result.has_value())
+            if (frame_result.is_error())
                 return {};
             block->add_frame(frame_result.release_value());
             m_streamer.drop_octets(individual_frame_size);
         }
     } else {
         auto frame_result = ByteBuffer::copy(m_streamer.data(), total_frame_content_size);
-        if (!frame_result.has_value())
+        if (frame_result.is_error())
             return {};
         block->add_frame(frame_result.release_value());
         m_streamer.drop_octets(total_frame_content_size);

--- a/Userland/Libraries/LibWeb/Bindings/IDLAbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/IDLAbstractOperations.cpp
@@ -109,17 +109,17 @@ Optional<ByteBuffer> get_buffer_source_copy(JS::Object const& buffer_source)
 
     // 8. Let bytes be a new byte sequence of length equal to length.
     auto bytes = ByteBuffer::create_zeroed(length);
-    if (!bytes.has_value())
+    if (bytes.is_error())
         return {};
 
     // 9. For i in the range offset to offset + length − 1, inclusive, set bytes[i − offset] to ! GetValueFromBuffer(esArrayBuffer, i, Uint8, true, Unordered).
     for (u64 i = offset; i <= offset + length - 1; ++i) {
         auto value = es_array_buffer->get_value<u8>(i, true, JS::ArrayBuffer::Unordered);
-        (*bytes)[i - offset] = (u8)value.as_u32();
+        bytes.value()[i - offset] = (u8)value.as_u32();
     }
 
     // 10. Return bytes.
-    return bytes;
+    return bytes.release_value();
 }
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -340,7 +340,7 @@ JS_DEFINE_NATIVE_FUNCTION(WindowObject::atob)
         return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::BadArgCountOne, "atob");
     auto string = TRY(vm.argument(0).to_string(global_object));
     auto decoded = decode_base64(StringView(string));
-    if (!decoded.has_value())
+    if (decoded.is_error())
         return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::InvalidFormat, "Base64");
 
     // decode_base64() returns a byte string. LibJS uses UTF-8 for strings. Use Latin1Decoder to convert bytes 128-255 to UTF-8.

--- a/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
+++ b/Userland/Libraries/LibWeb/Crypto/SubtleCrypto.cpp
@@ -64,7 +64,7 @@ JS::Promise* SubtleCrypto::digest(String const& algorithm, JS::Handle<JS::Object
 
     auto digest = hash.digest();
     auto result_buffer = ByteBuffer::copy(digest.immutable_data(), hash.digest_size());
-    if (!result_buffer.has_value()) {
+    if (result_buffer.is_error()) {
         auto* error = wrap(wrapper()->global_object(), DOM::OperationError::create("Failed to create result buffer"));
         promise->reject(error);
         return promise;

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -69,7 +69,7 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap
 {
     VERIFY(!m_loaded);
     // FIXME: Handle OOM failure.
-    m_encoded_data = ByteBuffer::copy(data).release_value();
+    m_encoded_data = ByteBuffer::copy(data).release_value_but_fixme_should_propagate_errors();
     m_response_headers = headers;
     m_status_code = move(status_code);
     m_loaded = true;

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -162,8 +162,8 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, con
         ByteBuffer data;
         if (url.data_payload_is_base64()) {
             auto data_maybe = decode_base64(url.data_payload());
-            if (!data_maybe.has_value()) {
-                auto error_message = "Base64 data contains an invalid character"sv;
+            if (data_maybe.is_error()) {
+                auto error_message = data_maybe.error().string_literal();
                 log_failure(request, error_message);
                 error_callback(error_message, {});
                 return;

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -224,7 +224,7 @@ DOM::ExceptionOr<void> XMLHttpRequest::send(String body)
                     return;
                 auto& xhr = const_cast<XMLHttpRequest&>(*weak_this);
                 // FIXME: Handle OOM failure.
-                auto response_data = ByteBuffer::copy(data).release_value();
+                auto response_data = ByteBuffer::copy(data).release_value_but_fixme_should_propagate_errors();
                 // FIXME: There's currently no difference between transmitted and length.
                 u64 transmitted = response_data.size();
                 u64 length = response_data.size();

--- a/Userland/Libraries/LibWebSocket/Message.h
+++ b/Userland/Libraries/LibWebSocket/Message.h
@@ -16,7 +16,7 @@ class Message {
 public:
     explicit Message(String const& data)
         : m_is_text(true)
-        , m_data(ByteBuffer::copy(data.bytes()).release_value()) // FIXME: Handle possible OOM situation.
+        , m_data(ByteBuffer::copy(data.bytes()).release_value_but_fixme_should_propagate_errors()) // FIXME: Handle possible OOM situation.
     {
     }
 

--- a/Userland/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Userland/Libraries/LibWebSocket/WebSocket.cpp
@@ -96,7 +96,7 @@ void WebSocket::close(u16 code, String const& message)
     VERIFY(m_state == WebSocket::InternalState::Open);
     VERIFY(m_impl);
     auto message_bytes = message.bytes();
-    auto close_payload = ByteBuffer::create_uninitialized(message_bytes.size() + 2).release_value(); // FIXME: Handle possible OOM situation.
+    auto close_payload = ByteBuffer::create_uninitialized(message_bytes.size() + 2).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     close_payload.overwrite(0, (u8*)&code, 2);
     close_payload.overwrite(2, message_bytes.data(), message_bytes.size());
     send_frame(WebSocket::OpCode::ConnectionClose, close_payload, true);
@@ -426,7 +426,7 @@ void WebSocket::read_frame()
         masking_key[3] = masking_key_data[3];
     }
 
-    auto payload = ByteBuffer::create_uninitialized(payload_length).release_value(); // FIXME: Handle possible OOM situation.
+    auto payload = ByteBuffer::create_uninitialized(payload_length).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     u64 read_length = 0;
     while (read_length < payload_length) {
         auto payload_part = m_impl->read(payload_length - read_length);
@@ -544,7 +544,7 @@ void WebSocket::send_frame(WebSocket::OpCode op_code, ReadonlyBytes payload, boo
         m_impl->send(ReadonlyBytes(masking_key, 4));
         // Mask the payload
         auto buffer_result = ByteBuffer::create_uninitialized(payload.size());
-        if (buffer_result.has_value()) {
+        if (!buffer_result.is_error()) {
             auto& masked_payload = buffer_result.value();
             for (size_t i = 0; i < payload.size(); ++i) {
                 masked_payload[i] = payload[i] ^ (masking_key[i % 4]);

--- a/Userland/Services/EchoServer/Client.cpp
+++ b/Userland/Services/EchoServer/Client.cpp
@@ -27,10 +27,7 @@ ErrorOr<void> Client::drain_socket()
 {
     NonnullRefPtr<Client> protect(*this);
 
-    auto maybe_buffer = ByteBuffer::create_uninitialized(1024);
-    if (!maybe_buffer.has_value())
-        return ENOMEM;
-    auto buffer = maybe_buffer.release_value();
+    auto buffer = TRY(ByteBuffer::create_uninitialized(1024));
 
     while (TRY(m_socket->can_read_without_blocking())) {
         auto nread = TRY(m_socket->read(buffer));

--- a/Userland/Services/InspectorServer/InspectableProcess.cpp
+++ b/Userland/Services/InspectorServer/InspectableProcess.cpp
@@ -53,7 +53,7 @@ String InspectableProcess::wait_for_response()
         return {};
     }
 
-    auto data_buffer = ByteBuffer::create_uninitialized(length).release_value();
+    auto data_buffer = ByteBuffer::create_uninitialized(length).release_value_but_fixme_should_propagate_errors();
     auto remaining_data_buffer = data_buffer.bytes();
 
     while (!remaining_data_buffer.is_empty()) {

--- a/Userland/Services/RequestServer/HttpCommon.h
+++ b/Userland/Services/RequestServer/HttpCommon.h
@@ -75,7 +75,7 @@ OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ClientConnection& clie
     request.set_headers(headers);
 
     auto allocated_body_result = ByteBuffer::copy(body);
-    if (!allocated_body_result.has_value())
+    if (allocated_body_result.is_error())
         return {};
     request.set_body(allocated_body_result.release_value());
 

--- a/Userland/Services/SpiceAgent/SpiceAgent.cpp
+++ b/Userland/Services/SpiceAgent/SpiceAgent.cpp
@@ -59,7 +59,7 @@ void SpiceAgent::on_message_received()
 {
     ChunkHeader header {};
     read_n(&header, sizeof(header));
-    auto buffer = ByteBuffer::create_uninitialized(header.size).release_value(); // FIXME: Handle possible OOM situation.
+    auto buffer = ByteBuffer::create_uninitialized(header.size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     read_n(buffer.data(), buffer.size());
     auto* message = reinterpret_cast<Message*>(buffer.data());
     switch (message->type) {
@@ -118,7 +118,7 @@ void SpiceAgent::on_message_received()
     case (u32)MessageType::Clipboard: {
         auto* clipboard_message = reinterpret_cast<Clipboard*>(message->data);
         auto type = (ClipboardType)clipboard_message->type;
-        auto data_buffer = ByteBuffer::create_uninitialized(message->size - sizeof(u32)).release_value(); // FIXME: Handle possible OOM situation.
+        auto data_buffer = ByteBuffer::create_uninitialized(message->size - sizeof(u32)).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
 
         const auto total_bytes = message->size - sizeof(Clipboard);
         auto bytes_copied = header.size - sizeof(Message) - sizeof(Clipboard);
@@ -209,7 +209,7 @@ SpiceAgent::Message* SpiceAgent::initialize_headers(u8* data, size_t additional_
 ByteBuffer SpiceAgent::AnnounceCapabilities::make_buffer(bool request, const Vector<Capability>& capabilities)
 {
     size_t required_size = sizeof(ChunkHeader) + sizeof(Message) + sizeof(AnnounceCapabilities);
-    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value(); // FIXME: Handle possible OOM situation.
+    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     u8* data = buffer.data();
 
     auto* message = initialize_headers(data, sizeof(AnnounceCapabilities), MessageType::AnnounceCapabilities);
@@ -231,7 +231,7 @@ ByteBuffer SpiceAgent::ClipboardGrab::make_buffer(const Vector<ClipboardType>& t
     VERIFY(types.size() > 0);
     size_t variable_data_size = sizeof(u32) * types.size();
     size_t required_size = sizeof(ChunkHeader) + sizeof(Message) + variable_data_size;
-    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value(); // FIXME: Handle possible OOM situation.
+    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     u8* data = buffer.data();
 
     auto* message = initialize_headers(data, variable_data_size, MessageType::ClipboardGrab);
@@ -249,7 +249,7 @@ ByteBuffer SpiceAgent::Clipboard::make_buffer(ClipboardType type, ReadonlyBytes 
 {
     size_t data_size = sizeof(Clipboard) + contents.size();
     size_t required_size = sizeof(ChunkHeader) + sizeof(Message) + data_size;
-    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value(); // FIXME: Handle possible OOM situation.
+    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     u8* data = buffer.data();
 
     auto* message = initialize_headers(data, data_size, MessageType::Clipboard);
@@ -267,7 +267,7 @@ ByteBuffer SpiceAgent::ClipboardRequest::make_buffer(ClipboardType type)
 {
     size_t data_size = sizeof(ClipboardRequest);
     size_t required_size = sizeof(ChunkHeader) + sizeof(Message) + data_size;
-    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value(); // FIXME: Handle possible OOM situation.
+    auto buffer = ByteBuffer::create_uninitialized(required_size).release_value_but_fixme_should_propagate_errors(); // FIXME: Handle possible OOM situation.
     u8* data = buffer.data();
 
     auto* message = initialize_headers(data, data_size, MessageType::ClipboardRequest);

--- a/Userland/Services/TelnetServer/Client.cpp
+++ b/Userland/Services/TelnetServer/Client.cpp
@@ -73,10 +73,7 @@ ErrorOr<void> Client::drain_socket()
 {
     NonnullRefPtr<Client> protect(*this);
 
-    auto maybe_buffer = ByteBuffer::create_uninitialized(1024);
-    if (!maybe_buffer.has_value())
-        return ENOMEM;
-    auto buffer = maybe_buffer.release_value();
+    auto buffer = TRY(ByteBuffer::create_uninitialized(1024));
 
     while (TRY(m_socket->can_read_without_blocking())) {
         auto nread = TRY(m_socket->read(buffer));
@@ -196,10 +193,7 @@ ErrorOr<void> Client::send_command(Command command)
 
 ErrorOr<void> Client::send_commands(Vector<Command> commands)
 {
-    auto maybe_buffer = ByteBuffer::create_uninitialized(commands.size() * 3);
-    if (!maybe_buffer.has_value())
-        return ENOMEM;
-    auto buffer = maybe_buffer.release_value();
+    auto buffer = TRY(ByteBuffer::create_uninitialized(commands.size() * 3));
     OutputMemoryStream stream { buffer };
 
     for (auto& command : commands)

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -46,8 +46,8 @@ void Client::start()
         StringBuilder builder;
 
         auto maybe_buffer = ByteBuffer::create_uninitialized(m_socket->buffer_size());
-        if (!maybe_buffer.has_value()) {
-            warnln("Could not create buffer for client (possibly out of memory)");
+        if (maybe_buffer.is_error()) {
+            warnln("Could not create buffer for client: {}", maybe_buffer.error());
             die();
             return;
         }

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -1654,7 +1654,7 @@ void Execute::for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(Non
                         }
                 } else {
                     auto entry_result = ByteBuffer::create_uninitialized(line_end + ifs.length());
-                    if (!entry_result.has_value()) {
+                    if (entry_result.is_error()) {
                         loop.quit(Break);
                         notifier->set_enabled(false);
                         return Break;
@@ -1746,7 +1746,7 @@ void Execute::for_each_entry(RefPtr<Shell> shell, Function<IterationDecision(Non
 
             if (!stream.eof()) {
                 auto entry_result = ByteBuffer::create_uninitialized(stream.size());
-                if (!entry_result.has_value()) {
+                if (entry_result.is_error()) {
                     shell->raise_error(Shell::ShellError::OutOfMemory, {}, position());
                     return;
                 }

--- a/Userland/Utilities/base64.cpp
+++ b/Userland/Utilities/base64.cpp
@@ -46,12 +46,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio"));
 
     if (decode) {
-        auto decoded = decode_base64(StringView(buffer));
-        if (!decoded.has_value()) {
-            warnln("base64: invalid input");
-            return 1;
-        }
-        fwrite(decoded.value().data(), sizeof(u8), decoded.value().size(), stdout);
+        auto decoded = TRY(decode_base64(StringView(buffer)));
+        fwrite(decoded.data(), sizeof(u8), decoded.size(), stdout);
         return 0;
     }
 

--- a/Userland/Utilities/disk_benchmark.cpp
+++ b/Userland/Utilities/disk_benchmark.cpp
@@ -96,7 +96,7 @@ int main(int argc, char** argv)
                 continue;
 
             auto buffer_result = ByteBuffer::create_uninitialized(block_size);
-            if (!buffer_result.has_value()) {
+            if (buffer_result.is_error()) {
                 warnln("Not enough memory to allocate space for block size = {}", block_size);
                 continue;
             }
@@ -107,7 +107,7 @@ int main(int argc, char** argv)
             while (timer.elapsed() < time_per_benchmark * 1000) {
                 out(".");
                 fflush(stdout);
-                auto result = benchmark(filename, file_size, block_size, *buffer_result, allow_cache);
+                auto result = benchmark(filename, file_size, block_size, buffer_result.value(), allow_cache);
                 if (!result.has_value())
                     return 1;
                 results.append(result.release_value());

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -132,7 +132,7 @@ int main(int argc, char** argv)
 
     for (;;) {
         auto ping_packet_result = ByteBuffer::create_zeroed(sizeof(struct icmphdr) + payload_size);
-        if (!ping_packet_result.has_value()) {
+        if (ping_packet_result.is_error()) {
             warnln("failed to allocate a large enough buffer for the ping packet");
             return 1;
         }
@@ -167,7 +167,7 @@ int main(int argc, char** argv)
         for (;;) {
             auto pong_packet_result = ByteBuffer::create_uninitialized(
                 sizeof(struct ip) + max_optional_header_size_in_bytes + sizeof(struct icmphdr) + payload_size);
-            if (!pong_packet_result.has_value()) {
+            if (pong_packet_result.is_error()) {
                 warnln("failed to allocate a large enough buffer for the pong packet");
                 return 1;
             }

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -232,13 +232,9 @@ static ErrorOr<void> copy_from_process(const void* source, Bytes target)
 
 static ErrorOr<ByteBuffer> copy_from_process(const void* source, size_t length)
 {
-    auto buffer = ByteBuffer::create_uninitialized(length);
-    if (!buffer.has_value()) {
-        // Allocation failed. Inject an error:
-        return Error::from_errno(ENOMEM);
-    }
-    TRY(copy_from_process(source, buffer->bytes()));
-    return buffer.release_value();
+    auto buffer = TRY(ByteBuffer::create_uninitialized(length));
+    TRY(copy_from_process(source, buffer.bytes()));
+    return buffer;
 }
 
 template<typename T>

--- a/Userland/Utilities/telws.cpp
+++ b/Userland/Utilities/telws.cpp
@@ -119,10 +119,10 @@ int main(int argc, char** argv)
                 }
                 auto base64_data = line.substring(8);
                 auto buffer = decode_base64(base64_data);
-                if (buffer.has_value()) {
-                    socket->send(buffer.value(), false);
+                if (buffer.is_error()) {
+                    outln("Could not send message : {}", buffer.error().string_literal());
                 } else {
-                    outln("Could not send message : Base64 string contains an invalid character.");
+                    socket->send(buffer.value(), false);
                 }
                 continue;
             }


### PR DESCRIPTION
In code that makes use of `ErrorOr` already, dealing with `Optional<ByteBuffer>` is awkward, so I've changed the `ByteBuffer` factory methods to return `ErrorOr<ByteBuffer>` instead. Which meant modifying 70+ files in one go, sorry about that. :sweat_smile: 

After that, I converted a few other places that were returning optional ByteBuffers to also propagate their errors.