### PR TITLE
Libcore: Do not leak FILE pointer + Use AK_OS_BSD_GENERIC to hide Group::add_group()

### DIFF
--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/ScopeGuard.h>
 #include <LibCore/Group.h>
 #include <LibCore/System.h>
 
@@ -48,10 +49,12 @@ ErrorOr<void> Group::add_group(Group& group)
     if (!file)
         return Error::from_errno(errno);
 
+    ScopeGuard file_guard { [&] {
+        fclose(file);
+    } };
+
     if (putgrent(&gr, file) < 0)
         return Error::from_errno(errno);
-
-    fclose(file);
 
     return {};
 }

--- a/Userland/Libraries/LibCore/Group.cpp
+++ b/Userland/Libraries/LibCore/Group.cpp
@@ -10,7 +10,7 @@
 
 namespace Core {
 
-#ifndef AK_OS_MACOS
+#ifndef AK_OS_BSD_GENERIC
 ErrorOr<void> Group::add_group(Group& group)
 {
     if (group.name().is_empty())

--- a/Userland/Libraries/LibCore/Group.h
+++ b/Userland/Libraries/LibCore/Group.h
@@ -15,7 +15,7 @@ namespace Core {
 
 class Group {
 public:
-#ifndef AK_OS_MACOS
+#ifndef AK_OS_BSD_GENERIC
     static ErrorOr<void> add_group(Group& group);
 #endif
 


### PR DESCRIPTION
This PR contains the following fixes:

#### LibCore: Use generic AK_OS_BSD_GENERIC to hide Group::add_group()
This hides the method Group::add_group() on both MacOS and OpenBSD since
the function putgrent(), which is essential for add_group() to work, is
not available on these OSes.

#### LibCore: Do not leak FILE pointer in Group::add_group()
By using a ScopeGuard we make sure that we always close the FILE, also
on early returns.