### PR TITLE
UserspaceEmulator: Execve fixes

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1225,6 +1225,11 @@ int Emulator::virt$execve(FlatPtr params_addr)
     for (auto& argument : arguments)
         reportln("=={}==    - {}", getpid(), argument);
 
+    if (access(path.characters(), X_OK) < 0) {
+        if (errno == ENOENT || errno == EACCES)
+            return -errno;
+    }
+
     Vector<char*> argv;
     Vector<char*> envp;
 

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1229,10 +1229,10 @@ int Emulator::virt$execve(FlatPtr params_addr)
     Vector<char*> envp;
 
     argv.append(const_cast<char*>("/bin/UserspaceEmulator"));
-    argv.append(const_cast<char*>(path.characters()));
     if (g_report_to_debug)
         argv.append(const_cast<char*>("--report-to-debug"));
     argv.append(const_cast<char*>("--"));
+    argv.append(const_cast<char*>(path.characters()));
 
     auto create_string_vector = [](auto& output_vector, auto& input_vector) {
         for (auto& string : input_vector)


### PR DESCRIPTION
This PR makes `Emulator::virt$execve()` behave somewhat more correctly, thereby indirectly making e.g. `ue sh` at least a bit more usable.