### PR TITLE
LibWeb: Don't match the node querySelector(All) was called on

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -23,7 +23,8 @@ ExceptionOr<RefPtr<Element>> ParentNode::query_selector(StringView selector_text
     auto selectors = maybe_selectors.value();
 
     RefPtr<Element> result;
-    for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
+    // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
+    for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto& selector : selectors) {
             if (SelectorEngine::matches(selector, element)) {
                 result = element;
@@ -45,7 +46,8 @@ ExceptionOr<NonnullRefPtr<NodeList>> ParentNode::query_selector_all(StringView s
     auto selectors = maybe_selectors.value();
 
     NonnullRefPtrVector<Node> elements;
-    for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {
+    // FIXME: This should be shadow-including. https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
+    for_each_in_subtree_of_type<Element>([&](auto& element) {
         for (auto& selector : selectors) {
             if (SelectorEngine::matches(selector, element)) {
                 elements.append(element);


### PR DESCRIPTION
In querySelector(All)'s use of "Match a Selector Against a Tree", it
passes in the node the function was called on as the "optional scoping
root", which causes it and the nodes which aren't descendants of it 
to be excluded from the list of possible nodes to match against.
For us, this is the equivalent of using the non-inclusive variant of
`for_each_in_subtree_of_type`.

This was tripping up the node re-ordering logic of d3 and would cause
it to try and reinsert nodes into their parent, causing an exception
to be thrown.

Note that this should be shadow-including, but we don't currently have
shadow-including tree traversal as per https://dom.spec.whatwg.org/#concept-shadow-including-tree-order

https://drafts.csswg.org/selectors-4/#match-a-selector-against-a-tree
https://dom.spec.whatwg.org/#scope-match-a-selectors-string