### PR TITLE
WebContent: Switch scroll direction on shift modifier

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -117,6 +117,9 @@ bool EventHandler::handle_mousewheel(const Gfx::IntPoint& position, unsigned int
     if (!layout_root())
         return false;
 
+    if (modifiers & KeyModifier::Mod_Shift)
+        swap(wheel_delta_x, wheel_delta_y);
+
     // FIXME: Support wheel events in subframes.
 
     auto result = layout_root()->hit_test(position, Layout::HitTestType::Exact);


### PR DESCRIPTION
This pull request changes web content component behavior to be in line with other scrollable areas - vertical mouse scroll turns horizontal in case shift modifier key is pressed.

To be honest, I'm not entirely sure I've put it on the right level, since I'm still yet to get familiar with the whole ipc / components structure and interactions. Will change if there is a better place