### PR TITLE
LibGUI+ImageViewer+PixelPaint: Fitting images into view everywhere!

### DIFF
--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -215,6 +215,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         },
         window);
 
+    auto fit_image_to_view_action = GUI::Action::create(
+        "Fit Image To &View", [&](auto&) {
+            widget->fit_content_to_view();
+        });
+
     auto zoom_out_action = GUI::CommonActions::make_zoom_out_action(
         [&](auto&) {
             widget->set_scale(widget->scale() / 1.44f);
@@ -301,6 +306,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(view_menu->try_add_separator());
     TRY(view_menu->try_add_action(zoom_in_action));
     TRY(view_menu->try_add_action(reset_zoom_action));
+    TRY(view_menu->try_add_action(fit_image_to_view_action));
     TRY(view_menu->try_add_action(zoom_out_action));
     TRY(view_menu->try_add_separator());
 

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         window->set_title(String::formatted("{} {} {}% - Image Viewer", widget->path(), widget->bitmap()->size().to_string(), (int)(scale * 100)));
 
-        if (scale == 100 && !widget->scaled_for_first_image()) {
+        if (!widget->scaled_for_first_image()) {
             widget->set_scaled_for_first_image(true);
             widget->resize_window();
         }

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -527,28 +527,7 @@ void ImageEditor::fit_image_to_view(FitType type)
         };
     }
 
-    const float border_ratio = 0.95f;
-    auto image_size = image().size();
-    auto height_ratio = floorf(border_ratio * viewport_rect.height()) / (float)image_size.height();
-    auto width_ratio = floorf(border_ratio * viewport_rect.width()) / (float)image_size.width();
-
-    float new_scale = 1.0f;
-    switch (type) {
-    case FitType::Width:
-        new_scale = width_ratio;
-        break;
-    case FitType::Height:
-        new_scale = height_ratio;
-        break;
-    case FitType::Image:
-        new_scale = min(height_ratio, width_ratio);
-        break;
-    }
-
-    float offset = m_show_rulers ? -m_ruler_thickness / (scale() * 2.0f) : 0.0f;
-
-    set_origin(Gfx::FloatPoint(offset, offset));
-    set_scale(new_scale);
+    fit_content_to_rect(viewport_rect, type);
 }
 
 void ImageEditor::image_did_change(Gfx::IntRect const& modified_image_rect)

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -63,13 +63,7 @@ public:
 
     Layer* layer_at_editor_position(Gfx::IntPoint const&);
 
-    enum class FitType {
-        Width,
-        Height,
-        Image
-    };
-
-    void fit_image_to_view(FitType type = FitType::Image);
+    void fit_image_to_view(FitType type = FitType::Both);
 
     Color primary_color() const { return m_primary_color; }
     void set_primary_color(Color);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -658,7 +658,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 editor->fit_image_to_view(ImageEditor::FitType::Height);
                 return;
             case s_zoom_level_fit_image:
-                editor->fit_image_to_view(ImageEditor::FitType::Image);
+                editor->fit_image_to_view(ImageEditor::FitType::Both);
                 return;
             }
         }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -378,7 +378,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
     m_view_menu->add_action(*m_zoom_out_action);
     m_view_menu->add_action(*m_reset_zoom_action);
     m_view_menu->add_action(GUI::Action::create(
-        "&Fit Image To View", [&](auto&) {
+        "Fit Image To &View", [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
             editor->fit_image_to_view();

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.cpp
@@ -180,4 +180,29 @@ void AbstractZoomPanWidget::set_scale_bounds(float min_scale, float max_scale)
     m_max_scale = max_scale;
 }
 
+void AbstractZoomPanWidget::fit_content_to_rect(Gfx::IntRect const& viewport_rect, FitType type)
+{
+    const float border_ratio = 0.95f;
+    auto image_size = m_original_rect.size();
+    auto height_ratio = floorf(border_ratio * viewport_rect.height()) / (float)image_size.height();
+    auto width_ratio = floorf(border_ratio * viewport_rect.width()) / (float)image_size.width();
+
+    float new_scale = 1.0f;
+    switch (type) {
+    case FitType::Width:
+        new_scale = width_ratio;
+        break;
+    case FitType::Height:
+        new_scale = height_ratio;
+        break;
+    case FitType::Both:
+        new_scale = min(height_ratio, width_ratio);
+        break;
+    }
+
+    auto const& offset = rect().center() - viewport_rect.center();
+    set_origin(Gfx::FloatPoint(offset.x(), offset.y()));
+    set_scale(new_scale);
+}
+
 }

--- a/Userland/Libraries/LibGUI/AbstractZoomPanWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractZoomPanWidget.h
@@ -54,6 +54,17 @@ public:
 
     Function<void(float)> on_scale_change;
 
+    enum class FitType {
+        Width,
+        Height,
+        Both
+    };
+    void fit_content_to_rect(Gfx::IntRect const& rect, FitType = FitType::Both);
+    void fit_content_to_view(FitType fit_type = FitType::Both)
+    {
+        fit_content_to_rect(rect(), fit_type);
+    }
+
 private:
     Gfx::IntRect m_original_rect;
     Gfx::IntRect m_content_rect;


### PR DESCRIPTION
Previously `PixelPaint` had some code to fit an image into the viewport, which I find super handy and use all the time. I missed this in `ImageViewer` (sometimes I just want to see the whole image after zooming in for something!). This PR pulls out the functionality from `PixelPaint` into `AbstractZoomPanWidget` (where it belongs!), which now works for both applications.

Along the way, I also fixed a little bug in window resizing for `ImageViewer`, and made some menu shortcuts consistent so you feel right at home everywhere :^)