### PR TITLE
Kernel: Ensure that CommandLine is initialized before choosing PanicMode

### DIFF
--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -27,6 +27,11 @@ UNMAP_AFTER_INIT void CommandLine::early_initialize(const char* cmd_line)
     s_cmd_line[length] = '\0';
 }
 
+bool CommandLine::was_initialized()
+{
+    return s_the != nullptr;
+}
+
 const CommandLine& kernel_command_line()
 {
     VERIFY(s_the);

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -45,6 +45,7 @@ class CommandLine {
 public:
     static void early_initialize(const char* cmd_line);
     static void initialize();
+    static bool was_initialized();
 
     enum class Validate {
         Yes,

--- a/Kernel/Panic.cpp
+++ b/Kernel/Panic.cpp
@@ -33,6 +33,8 @@ void __panic(const char* file, unsigned int line, const char* function)
 
     critical_dmesgln("at {}:{} in {}", file, line, function);
     dump_backtrace(PrintToScreen::Yes);
+    if (!CommandLine::was_initialized())
+        Processor::halt();
     switch (kernel_command_line().panic_mode()) {
     case PanicMode::Shutdown:
         __shutdown();


### PR DESCRIPTION
If the kernel commandline is not initialized, then just halt everything.