### PR TITLE
Kernel: Stop using LibKeyboard's CharacterMap in HIDManagement

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -354,10 +354,6 @@ set(VT_SOURCES
     ../Userland/Libraries/LibVT/EscapeSequenceParser.cpp
 )
 
-set(KEYBOARD_SOURCES
-    ../Userland/Libraries/LibKeyboard/CharacterMap.cpp
-)
-
 set(CRYPTO_SOURCES
     ../Userland/Libraries/LibCrypto/Cipher/AES.cpp
     ../Userland/Libraries/LibCrypto/Hash/SHA2.cpp
@@ -372,7 +368,6 @@ if (NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
         ${SOURCES}
         ${ELF_SOURCES}
         ${VT_SOURCES}
-        ${KEYBOARD_SOURCES}
         ${CRYPTO_SOURCES}
     )
 else()

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -17,7 +17,7 @@
 #include <Kernel/API/MousePacket.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/UnixTypes.h>
-#include <LibKeyboard/CharacterMap.h>
+#include <LibKeyboard/CharacterMapData.h>
 
 namespace Kernel {
 
@@ -39,11 +39,12 @@ public:
 
     void enumerate();
 
-    const String& keymap_name() const { return m_character_map.character_map_name(); }
-    const Keyboard::CharacterMapData& character_maps() const { return m_character_map.character_map_data(); }
-    const Keyboard::CharacterMap& character_map() const { return m_character_map; }
+    StringView keymap_name() const { return m_character_map_name->view(); }
+    Keyboard::CharacterMapData const& character_map() const { return m_character_map; }
+    u32 get_char_from_character_map(KeyEvent) const;
+
     void set_client(KeyboardClient* client) { m_client = client; }
-    void set_maps(const Keyboard::CharacterMapData& character_map, const String& character_map_name);
+    void set_maps(NonnullOwnPtr<KString> character_map_name, Keyboard::CharacterMapData const& character_map);
 
 private:
     size_t generate_minor_device_number_for_mouse();
@@ -51,7 +52,8 @@ private:
 
     size_t m_mouse_minor_number { 0 };
     size_t m_keyboard_minor_number { 0 };
-    Keyboard::CharacterMap m_character_map;
+    NonnullOwnPtr<KString> m_character_map_name;
+    Keyboard::CharacterMapData m_character_map;
     KeyboardClient* m_client { nullptr };
     RefPtr<I8042Controller> m_i8042_controller;
     NonnullRefPtrVector<HIDDevice> m_hid_devices;

--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -234,7 +234,7 @@ void KeyboardDevice::key_state_changed(u8 scan_code, bool pressed)
     event.flags = m_modifiers;
     event.e0_prefix = m_has_e0_prefix;
     event.caps_lock_on = m_caps_lock_on;
-    event.code_point = HIDManagement::the().character_map().get_char(event);
+    event.code_point = HIDManagement::the().get_char_from_character_map(event);
 
     // If using a non-QWERTY layout, event.key needs to be updated to be the same as event.code_point
     KeyCode mapped_key = code_point_to_key_code(event.code_point);

--- a/Kernel/Syscalls/keymap.cpp
+++ b/Kernel/Syscalls/keymap.cpp
@@ -33,7 +33,7 @@ ErrorOr<FlatPtr> Process::sys$setkeymap(Userspace<const Syscall::SC_setkeymap_pa
     if (map_name->length() > map_name_max_size)
         return ENAMETOOLONG;
 
-    HIDManagement::the().set_maps(character_map_data, map_name->view());
+    HIDManagement::the().set_maps(move(map_name), character_map_data);
     return 0;
 }
 
@@ -44,7 +44,7 @@ ErrorOr<FlatPtr> Process::sys$getkeymap(Userspace<const Syscall::SC_getkeymap_pa
     auto params = TRY(copy_typed_from_user(user_params));
 
     String keymap_name = HIDManagement::the().keymap_name();
-    const Keyboard::CharacterMapData& character_maps = HIDManagement::the().character_maps();
+    Keyboard::CharacterMapData const& character_maps = HIDManagement::the().character_map();
 
     TRY(copy_to_user(params.map, character_maps.map, CHAR_MAP_SIZE * sizeof(u32)));
     TRY(copy_to_user(params.shift_map, character_maps.shift_map, CHAR_MAP_SIZE * sizeof(u32)));

--- a/Userland/Libraries/LibKeyboard/CharacterMap.cpp
+++ b/Userland/Libraries/LibKeyboard/CharacterMap.cpp
@@ -6,32 +6,24 @@
 
 #include "CharacterMap.h"
 #include <AK/StringBuilder.h>
-
-#ifndef KERNEL
-#    include <LibKeyboard/CharacterMapFile.h>
-#    include <serenity.h>
-#endif
+#include <LibKeyboard/CharacterMapFile.h>
+#include <errno.h>
+#include <serenity.h>
 
 namespace Keyboard {
 
-#ifndef KERNEL
-// The Kernel explicitly and exclusively links only this file into it.
-// Thus, we cannot even include a reference to the symbol `CharacterMapFile::load_from_file`.
 ErrorOr<CharacterMap> CharacterMap::load_from_file(const String& map_name)
 {
     auto result = TRY(CharacterMapFile::load_from_file(map_name));
 
     return CharacterMap(map_name, result);
 }
-#endif
 
 CharacterMap::CharacterMap(const String& map_name, const CharacterMapData& map_data)
     : m_character_map_data(map_data)
     , m_character_map_name(map_name)
 {
 }
-
-#ifndef KERNEL
 
 int CharacterMap::set_system_map()
 {
@@ -47,55 +39,6 @@ ErrorOr<CharacterMap> CharacterMap::fetch_system_map()
         return Error::from_errno(errno);
 
     return CharacterMap { keymap_name, map_data };
-}
-
-#endif
-
-u32 CharacterMap::get_char(KeyEvent event) const
-{
-    auto modifiers = event.modifiers();
-    auto index = event.scancode & 0xFF; // Index is last byte of scan code.
-    auto caps_lock_on = event.caps_lock_on;
-
-    u32 code_point;
-    if (modifiers & Mod_Alt)
-        code_point = m_character_map_data.alt_map[index];
-    else if ((modifiers & Mod_Shift) && (modifiers & Mod_AltGr))
-        code_point = m_character_map_data.shift_altgr_map[index];
-    else if (modifiers & Mod_Shift)
-        code_point = m_character_map_data.shift_map[index];
-    else if (modifiers & Mod_AltGr)
-        code_point = m_character_map_data.altgr_map[index];
-    else
-        code_point = m_character_map_data.map[index];
-
-    if (caps_lock_on && (modifiers == 0 || modifiers == Mod_Shift)) {
-        if (code_point >= 'a' && code_point <= 'z')
-            code_point &= ~0x20;
-        else if (code_point >= 'A' && code_point <= 'Z')
-            code_point |= 0x20;
-    }
-
-    if (event.e0_prefix && event.key == Key_Slash) {
-        // If Key_Slash (scancode = 0x35) mapped to other form "/", we fix num pad key of "/" with this case.
-        code_point = '/';
-    } else if (event.e0_prefix && event.key != Key_Return) {
-        // Except for `keypad-/` and 'keypad-return', all e0 scan codes are not actually characters. i.e., `keypad-0` and
-        // `Insert` have the same scancode except for the prefix, but insert should not have a code_point.
-        code_point = 0;
-    }
-
-    return code_point;
-}
-
-void CharacterMap::set_character_map_data(CharacterMapData character_map_data)
-{
-    m_character_map_data = character_map_data;
-}
-
-void CharacterMap::set_character_map_name(const String& character_map_name)
-{
-    m_character_map_name = character_map_name;
 }
 
 const String& CharacterMap::character_map_name() const

--- a/Userland/Libraries/LibKeyboard/CharacterMap.h
+++ b/Userland/Libraries/LibKeyboard/CharacterMap.h
@@ -6,11 +6,8 @@
 
 #pragma once
 
-#ifndef KERNEL
-#    include <AK/Error.h>
-#endif
+#include <AK/Error.h>
 #include <AK/String.h>
-#include <Kernel/API/KeyCode.h>
 #include <LibKeyboard/CharacterMapData.h>
 
 namespace Keyboard {
@@ -21,14 +18,8 @@ public:
     CharacterMap(const String& map_name, const CharacterMapData& map_data);
     static ErrorOr<CharacterMap> load_from_file(const String& filename);
 
-#ifndef KERNEL
     int set_system_map();
     static ErrorOr<CharacterMap> fetch_system_map();
-#endif
-
-    u32 get_char(KeyEvent) const;
-    void set_character_map_data(CharacterMapData character_map_data);
-    void set_character_map_name(const String& character_map_name);
 
     const CharacterMapData& character_map_data() const { return m_character_map_data; };
     const String& character_map_name() const;


### PR DESCRIPTION
This was easily done, as the Kernel and Userland don't actually share
any of the APIs exposed by it, so instead the Kernel APIs were moved to
the Kernel, and the Userland APIs stayed in LibKeyboard.

This has multiple advantages:
 * The non OOM-fallible String is not longer used for storing the
   character map name in the Kernel
 * The kernel no longer has to link to the userland LibKeyboard code
 * A lot of #ifdef KERNEL cruft can be removed from LibKeyboard