### PR TITLE
Kernel: Add support for QEMU ISA-PC & QEMU MicroVM machine types

### DIFF
--- a/Base/usr/share/man/man7/boot_parameters.md
+++ b/Base/usr/share/man/man7/boot_parameters.md
@@ -56,7 +56,8 @@ List of options:
 
 * **`panic`** - This parameter expects **`halt`** or **`shutdown`**. This is particularly useful in CI contexts.
 
-* **`pci_ecam`** - This parameter expects **`on`** or **`off`**.
+* **`pci`** - This parameter expects **`ecam`**, **`io`** or **`none`**. When selecting **`none`**
+  the kernel will not use PCI resources/devices.
 
 * **`root`** - This parameter configures the device to use as the root file system. It defaults to **`/dev/hda`** if unspecified.
 

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -17,6 +17,7 @@
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/Region.h>
 #include <Kernel/Memory/TypedMapping.h>
+#include <Kernel/ProcessExposed.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel::PCI {
@@ -95,6 +96,7 @@ UNMAP_AFTER_INIT bool Access::find_and_register_pci_host_bridges_from_acpi_mcfg_
 UNMAP_AFTER_INIT bool Access::initialize_for_multiple_pci_domains(PhysicalAddress mcfg_table)
 {
     VERIFY(!Access::is_initialized());
+    ProcFSComponentRegistry::the().root_directory().add_pci_node({});
     auto* access = new Access();
     if (!access->find_and_register_pci_host_bridges_from_acpi_mcfg_table(mcfg_table))
         return false;
@@ -106,6 +108,7 @@ UNMAP_AFTER_INIT bool Access::initialize_for_multiple_pci_domains(PhysicalAddres
 UNMAP_AFTER_INIT bool Access::initialize_for_one_pci_domain()
 {
     VERIFY(!Access::is_initialized());
+    ProcFSComponentRegistry::the().root_directory().add_pci_node({});
     auto* access = new Access();
     auto host_bridge = HostBridge::must_create_with_io_access();
     access->add_host_controller(move(host_bridge));

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -11,6 +11,7 @@
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/Bus/PCI/Controller/HostBridge.h>
 #include <Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.h>
+#include <Kernel/Bus/PCI/Initializer.h>
 #include <Kernel/Debug.h>
 #include <Kernel/Firmware/ACPI/Definitions.h>
 #include <Kernel/Memory/MemoryManager.h>
@@ -35,6 +36,11 @@ Access& Access::the()
 bool Access::is_initialized()
 {
     return (s_access != nullptr);
+}
+
+bool Access::is_disabled()
+{
+    return g_pci_access_is_disabled_from_commandline || g_pci_access_io_probe_failed;
 }
 
 UNMAP_AFTER_INIT bool Access::find_and_register_pci_host_bridges_from_acpi_mcfg_table(PhysicalAddress mcfg_table)

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -26,6 +26,7 @@ public:
 
     static Access& the();
     static bool is_initialized();
+    static bool is_disabled();
 
     void write8_field(Address address, u32 field, u8 value);
     void write16_field(Address address, u32 field, u16 value);

--- a/Kernel/Bus/PCI/Initializer.cpp
+++ b/Kernel/Bus/PCI/Initializer.cpp
@@ -36,6 +36,7 @@ UNMAP_AFTER_INIT static PCIAccessLevel detect_optimal_access_type()
 
 UNMAP_AFTER_INIT void initialize()
 {
+    VERIFY(kernel_command_line().pci_access_level() != PCIAccessLevel::None);
     switch (detect_optimal_access_type()) {
     case PCIAccessLevel::MemoryAddressing: {
         auto mcfg = ACPI::Parser::the()->find_table("MCFG");

--- a/Kernel/Bus/PCI/Initializer.h
+++ b/Kernel/Bus/PCI/Initializer.h
@@ -9,6 +9,9 @@
 namespace Kernel {
 namespace PCI {
 
+extern bool g_pci_access_io_probe_failed;
+extern bool g_pci_access_is_disabled_from_commandline;
+
 void initialize();
 
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -96,6 +96,8 @@ set(KERNEL_SOURCES
     Storage/ATA/ATADiskDevice.cpp
     Storage/ATA/ATAPIDiscDevice.cpp
     Storage/ATA/BMIDEChannel.cpp
+    Storage/ATA/ISAIDEController.cpp
+    Storage/ATA/PCIIDEController.cpp
     Storage/ATA/IDEController.cpp
     Storage/ATA/IDEChannel.cpp
     Storage/Partition/DiskPartition.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -82,10 +82,11 @@ set(KERNEL_SOURCES
     Graphics/FramebufferDevice.cpp
     Graphics/GraphicsManagement.cpp
     Graphics/Intel/NativeGraphicsAdapter.cpp
+    Graphics/VGA/ISAAdapter.cpp
+    Graphics/VGA/PCIAdapter.cpp
     Graphics/VirtIOGPU/FramebufferDevice.cpp
     Graphics/VirtIOGPU/Console.cpp
     Graphics/VirtIOGPU/GraphicsAdapter.cpp
-    Graphics/VGACompatibleAdapter.cpp
     Graphics/GenericFramebufferDevice.cpp
     SanCov.cpp
     Storage/ATA/AHCIController.cpp

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -142,12 +142,19 @@ UNMAP_AFTER_INIT bool CommandLine::is_vmmouse_enabled() const
 
 UNMAP_AFTER_INIT PCIAccessLevel CommandLine::pci_access_level() const
 {
-    auto value = lookup("pci_ecam"sv).value_or("on"sv);
-    if (value == "on"sv)
+    auto value = lookup("pci"sv).value_or("ecam"sv);
+    if (value == "ecam"sv)
         return PCIAccessLevel::MemoryAddressing;
-    if (value == "off"sv)
+    if (value == "io"sv)
         return PCIAccessLevel::IOAddressing;
+    if (value == "none"sv)
+        return PCIAccessLevel::None;
     PANIC("Unknown PCI ECAM setting: {}", value);
+}
+
+UNMAP_AFTER_INIT bool CommandLine::is_pci_disabled() const
+{
+    return lookup("pci"sv).value_or("ecam"sv) == "none"sv;
 }
 
 UNMAP_AFTER_INIT bool CommandLine::is_legacy_time_enabled() const

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -31,6 +31,7 @@ enum class AcpiFeatureLevel {
 };
 
 enum class PCIAccessLevel {
+    None,
     IOAddressing,
     MemoryAddressing,
 };
@@ -70,6 +71,7 @@ public:
     [[nodiscard]] bool is_physical_networking_disabled() const;
     [[nodiscard]] bool is_vmmouse_enabled() const;
     [[nodiscard]] PCIAccessLevel pci_access_level() const;
+    [[nodiscard]] bool is_pci_disabled() const;
     [[nodiscard]] bool is_legacy_time_enabled() const;
     [[nodiscard]] bool is_pc_speaker_enabled() const;
     [[nodiscard]] FrameBufferDevices are_framebuffer_devices_enabled() const;

--- a/Kernel/Devices/Audio/Management.cpp
+++ b/Kernel/Devices/Audio/Management.cpp
@@ -38,21 +38,23 @@ UNMAP_AFTER_INIT AudioManagement::AudioManagement()
 
 UNMAP_AFTER_INIT void AudioManagement::enumerate_hardware_controllers()
 {
-    PCI::enumerate([&](PCI::DeviceIdentifier const& device_identifier) {
-        // Note: Only consider PCI audio controllers
-        if (device_identifier.class_code().value() != to_underlying(PCI::ClassID::Multimedia)
-            || device_identifier.subclass_code().value() != to_underlying(PCI::Multimedia::SubclassID::AudioController))
-            return;
+    if (!PCI::Access::is_disabled()) {
+        PCI::enumerate([&](PCI::DeviceIdentifier const& device_identifier) {
+            // Note: Only consider PCI audio controllers
+            if (device_identifier.class_code().value() != to_underlying(PCI::ClassID::Multimedia)
+                || device_identifier.subclass_code().value() != to_underlying(PCI::Multimedia::SubclassID::AudioController))
+                return;
 
-        dbgln("AC97: found audio controller at {}", device_identifier.address());
-        auto ac97_device = AC97::try_create(device_identifier);
-        if (ac97_device.is_error()) {
-            // FIXME: Propagate errors properly
-            dbgln("AudioManagement: failed to initialize AC97 device: {}", ac97_device.error());
-            return;
-        }
-        m_controllers_list.append(ac97_device.release_value());
-    });
+            dbgln("AC97: found audio controller at {}", device_identifier.address());
+            auto ac97_device = AC97::try_create(device_identifier);
+            if (ac97_device.is_error()) {
+                // FIXME: Propagate errors properly
+                dbgln("AudioManagement: failed to initialize AC97 device: {}", ac97_device.error());
+                return;
+            }
+            m_controllers_list.append(ac97_device.release_value());
+        });
+    }
 }
 
 UNMAP_AFTER_INIT void AudioManagement::enumerate_hardware_audio_channels()

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -9,6 +9,7 @@
 #include <Kernel/Arch/x86/InterruptDisabler.h>
 #include <Kernel/Arch/x86/ProcessorInfo.h>
 #include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/CommandLine.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/HID/HIDManagement.h>
@@ -949,6 +950,11 @@ UNMAP_AFTER_INIT ProcFSSystemDirectory::ProcFSSystemDirectory(const ProcFSRootDi
 {
 }
 
+UNMAP_AFTER_INIT void ProcFSRootDirectory::add_pci_node(Badge<PCI::Access>)
+{
+    m_components.append(ProcFSPCI::must_create());
+}
+
 UNMAP_AFTER_INIT NonnullRefPtr<ProcFSRootDirectory> ProcFSRootDirectory::must_create()
 {
     auto directory = adopt_ref(*new (nothrow) ProcFSRootDirectory);
@@ -961,7 +967,6 @@ UNMAP_AFTER_INIT NonnullRefPtr<ProcFSRootDirectory> ProcFSRootDirectory::must_cr
     directory->m_components.append(ProcFSDmesg::must_create());
     directory->m_components.append(ProcFSInterrupts::must_create());
     directory->m_components.append(ProcFSKeymap::must_create());
-    directory->m_components.append(ProcFSPCI::must_create());
     directory->m_components.append(ProcFSDevices::must_create());
     directory->m_components.append(ProcFSUptime::must_create());
     directory->m_components.append(ProcFSCommandLine::must_create());

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2021-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -42,6 +42,7 @@ public:
 
 private:
     bool determine_and_initialize_graphics_device(PCI::DeviceIdentifier const&);
+    bool determine_and_initialize_isa_graphics_device();
     NonnullRefPtrVector<GenericGraphicsAdapter> m_graphics_devices;
     RefPtr<Graphics::Console> m_console;
 

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -178,7 +178,7 @@ Optional<IntelNativeGraphicsAdapter::PLLSettings> IntelNativeGraphicsAdapter::cr
 }
 
 IntelNativeGraphicsAdapter::IntelNativeGraphicsAdapter(PCI::Address address)
-    : VGACompatibleAdapter(address)
+    : PCIVGACompatibleAdapter(address)
     , m_registers(PCI::get_BAR0(address) & 0xfffffffc)
     , m_framebuffer_addr(PCI::get_BAR2(address) & 0xfffffffc)
 {

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -10,7 +10,7 @@
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Definitions.h>
 #include <Kernel/Graphics/FramebufferDevice.h>
-#include <Kernel/Graphics/VGACompatibleAdapter.h>
+#include <Kernel/Graphics/VGA/PCIAdapter.h>
 #include <Kernel/PhysicalAddress.h>
 #include <LibEDID/EDID.h>
 
@@ -47,7 +47,7 @@ enum RegisterIndex {
 }
 
 class IntelNativeGraphicsAdapter final
-    : public VGACompatibleAdapter {
+    : public PCIVGACompatibleAdapter {
 public:
     struct PLLSettings {
         bool is_valid() const { return (n != 0 && m1 != 0 && m2 != 0 && p1 != 0 && p2 != 0); }

--- a/Kernel/Graphics/VGA/ISAAdapter.cpp
+++ b/Kernel/Graphics/VGA/ISAAdapter.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Graphics/Console/ContiguousFramebufferConsole.h>
+#include <Kernel/Graphics/Console/TextModeConsole.h>
+#include <Kernel/Graphics/GraphicsManagement.h>
+#include <Kernel/Graphics/VGA/ISAAdapter.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT NonnullRefPtr<ISAVGAAdapter> ISAVGAAdapter::initialize()
+{
+    return adopt_ref(*new ISAVGAAdapter());
+}
+
+UNMAP_AFTER_INIT ISAVGAAdapter::ISAVGAAdapter()
+{
+    m_framebuffer_console = Graphics::TextModeConsole::initialize();
+    GraphicsManagement::the().set_console(*m_framebuffer_console);
+}
+
+void ISAVGAAdapter::enable_consoles()
+{
+    VERIFY(m_framebuffer_console);
+    m_framebuffer_console->enable();
+}
+void ISAVGAAdapter::disable_consoles()
+{
+    VERIFY(m_framebuffer_console);
+    m_framebuffer_console->disable();
+}
+
+void ISAVGAAdapter::initialize_framebuffer_devices()
+{
+}
+
+bool ISAVGAAdapter::try_to_set_resolution(size_t, size_t, size_t)
+{
+    return false;
+}
+bool ISAVGAAdapter::set_y_offset(size_t, size_t)
+{
+    return false;
+}
+
+}

--- a/Kernel/Graphics/VGA/ISAAdapter.h
+++ b/Kernel/Graphics/VGA/ISAAdapter.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Graphics/Console/Console.h>
+#include <Kernel/Graphics/FramebufferDevice.h>
+#include <Kernel/Graphics/GenericGraphicsAdapter.h>
+#include <Kernel/PhysicalAddress.h>
+
+namespace Kernel {
+
+class ISAVGAAdapter final : public VGACompatibleAdapter {
+    friend class GraphicsManagement;
+
+public:
+    static NonnullRefPtr<ISAVGAAdapter> initialize();
+
+    // Note: We simply don't support old VGA framebuffer modes (like the 320x200 256-colors one)
+    virtual bool framebuffer_devices_initialized() const override { return false; }
+
+    virtual bool try_to_set_resolution(size_t output_port_index, size_t width, size_t height) override;
+    virtual bool set_y_offset(size_t output_port_index, size_t y) override;
+
+private:
+    ISAVGAAdapter();
+
+    // ^GenericGraphicsAdapter
+    virtual void initialize_framebuffer_devices() override;
+
+    virtual void enable_consoles() override;
+    virtual void disable_consoles() override;
+
+    RefPtr<Graphics::Console> m_framebuffer_console;
+};
+}

--- a/Kernel/Graphics/VGA/PCIAdapter.h
+++ b/Kernel/Graphics/VGA/PCIAdapter.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Graphics/Console/Console.h>
+#include <Kernel/Graphics/FramebufferDevice.h>
+#include <Kernel/Graphics/GenericGraphicsAdapter.h>
+#include <Kernel/PhysicalAddress.h>
+
+namespace Kernel {
+
+class PCIVGACompatibleAdapter : public VGACompatibleAdapter
+    , public PCI::Device {
+public:
+    static NonnullRefPtr<PCIVGACompatibleAdapter> initialize_with_preset_resolution(PCI::DeviceIdentifier const&, PhysicalAddress, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch);
+    static NonnullRefPtr<PCIVGACompatibleAdapter> initialize(PCI::DeviceIdentifier const&);
+
+    virtual bool framebuffer_devices_initialized() const override { return !m_framebuffer_device.is_null(); }
+
+protected:
+    explicit PCIVGACompatibleAdapter(PCI::Address);
+
+private:
+    PCIVGACompatibleAdapter(PCI::Address, PhysicalAddress, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch);
+
+    // ^GenericGraphicsAdapter
+    virtual void initialize_framebuffer_devices() override;
+
+    virtual void enable_consoles() override;
+    virtual void disable_consoles() override;
+
+protected:
+    PhysicalAddress m_framebuffer_address;
+    size_t m_framebuffer_width { 0 };
+    size_t m_framebuffer_height { 0 };
+    size_t m_framebuffer_pitch { 0 };
+
+    RefPtr<FramebufferDevice> m_framebuffer_device;
+};
+}

--- a/Kernel/Graphics/VGACompatibleAdapter.h
+++ b/Kernel/Graphics/VGACompatibleAdapter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2021-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,43 +15,21 @@
 
 namespace Kernel {
 
-class VGACompatibleAdapter : public GenericGraphicsAdapter
-    , public PCI::Device {
+class VGACompatibleAdapter : public GenericGraphicsAdapter {
 public:
-    static NonnullRefPtr<VGACompatibleAdapter> initialize_with_preset_resolution(PCI::DeviceIdentifier const&, PhysicalAddress, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch);
-    static NonnullRefPtr<VGACompatibleAdapter> initialize(PCI::DeviceIdentifier const&);
-
-    virtual bool framebuffer_devices_initialized() const override { return !m_framebuffer_device.is_null(); }
-
     virtual bool modesetting_capable() const override { return false; }
     virtual bool double_framebuffering_capable() const override { return false; }
 
     virtual bool vga_compatible() const override final { return true; }
 
-    virtual bool try_to_set_resolution(size_t output_port_index, size_t width, size_t height) override;
-    virtual bool set_y_offset(size_t output_port_index, size_t y) override;
+    virtual bool try_to_set_resolution(size_t, size_t, size_t) override { return false; }
+    virtual bool set_y_offset(size_t, size_t) override { return false; }
 
-    ErrorOr<ByteBuffer> get_edid(size_t output_port_index) const override;
-
-protected:
-    explicit VGACompatibleAdapter(PCI::Address);
-
-private:
-    VGACompatibleAdapter(PCI::Address, PhysicalAddress, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch);
-
-    // ^GenericGraphicsAdapter
-    virtual void initialize_framebuffer_devices() override;
-
-    virtual void enable_consoles() override;
-    virtual void disable_consoles() override;
+    ErrorOr<ByteBuffer> get_edid(size_t) const override { return Error::from_errno(ENOTSUP); }
 
 protected:
-    PhysicalAddress m_framebuffer_address;
-    size_t m_framebuffer_width { 0 };
-    size_t m_framebuffer_height { 0 };
-    size_t m_framebuffer_pitch { 0 };
+    VGACompatibleAdapter() = default;
 
-    RefPtr<FramebufferDevice> m_framebuffer_device;
     RefPtr<Graphics::Console> m_framebuffer_console;
 };
 }

--- a/Kernel/Net/NetworkingManagement.cpp
+++ b/Kernel/Net/NetworkingManagement.cpp
@@ -111,7 +111,7 @@ UNMAP_AFTER_INIT RefPtr<NetworkAdapter> NetworkingManagement::determine_network_
 
 bool NetworkingManagement::initialize()
 {
-    if (!kernel_command_line().is_physical_networking_disabled()) {
+    if (!kernel_command_line().is_physical_networking_disabled() && !PCI::Access::is_disabled()) {
         PCI::enumerate([&](PCI::DeviceIdentifier const& device_identifier) {
             // Note: PCI class 2 is the class of Network devices
             if (device_identifier.class_code().value() != 0x02)

--- a/Kernel/ProcessExposed.h
+++ b/Kernel/ProcessExposed.h
@@ -138,12 +138,18 @@ protected:
     mutable Mutex m_lock { "ProcFSLink" };
 };
 
+namespace PCI {
+class Access;
+}
+
 class ProcFSRootDirectory final : public ProcFSExposedDirectory {
     friend class ProcFSComponentRegistry;
 
 public:
     virtual ErrorOr<NonnullRefPtr<ProcFSExposedComponent>> lookup(StringView name) override;
     static NonnullRefPtr<ProcFSRootDirectory> must_create();
+
+    void add_pci_node(Badge<PCI::Access>);
     virtual ~ProcFSRootDirectory();
 
 private:

--- a/Kernel/Storage/ATA/BMIDEChannel.cpp
+++ b/Kernel/Storage/ATA/BMIDEChannel.cpp
@@ -39,7 +39,6 @@ UNMAP_AFTER_INIT void BMIDEChannel::initialize()
 {
     VERIFY(m_io_group.bus_master_base().has_value());
     // Let's try to set up DMA transfers.
-    PCI::enable_bus_mastering(m_parent_controller->pci_address());
     {
         auto region_or_error = MM.allocate_dma_buffer_page("IDE PRDT", Memory::Region::Access::ReadWrite, m_prdt_page);
         if (region_or_error.is_error())

--- a/Kernel/Storage/ATA/IDEChannel.cpp
+++ b/Kernel/Storage/ATA/IDEChannel.cpp
@@ -51,7 +51,6 @@ UNMAP_AFTER_INIT void IDEChannel::initialize()
         dbgln_if(PATA_DEBUG, "IDEChannel: {} bus master base: {}", channel_type_string(), m_io_group.bus_master_base().value());
     else
         dbgln_if(PATA_DEBUG, "IDEChannel: {} bus master base disabled", channel_type_string());
-    m_parent_controller->enable_pin_based_interrupts();
 
     // reset the channel
     u8 device_control = m_io_group.control_base().in<u8>();

--- a/Kernel/Storage/ATA/IDEController.cpp
+++ b/Kernel/Storage/ATA/IDEController.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,9 +16,9 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullRefPtr<IDEController> IDEController::initialize(PCI::DeviceIdentifier const& device_identifier, bool force_pio)
+UNMAP_AFTER_INIT NonnullRefPtr<IDEController> IDEController::initialize()
 {
-    return adopt_ref(*new IDEController(device_identifier, force_pio));
+    return adopt_ref(*new IDEController());
 }
 
 bool IDEController::reset()
@@ -61,119 +61,12 @@ void IDEController::complete_current_request(AsyncDeviceRequest::RequestResult)
     VERIFY_NOT_REACHED();
 }
 
-UNMAP_AFTER_INIT IDEController::IDEController(PCI::DeviceIdentifier const& device_identifier, bool force_pio)
-    : ATAController()
-    , PCI::Device(device_identifier.address())
-    , m_prog_if(device_identifier.prog_if())
-    , m_interrupt_line(device_identifier.interrupt_line())
+UNMAP_AFTER_INIT IDEController::IDEController()
 {
-    PCI::enable_io_space(device_identifier.address());
-    PCI::enable_memory_space(device_identifier.address());
-    initialize(force_pio);
 }
 
 UNMAP_AFTER_INIT IDEController::~IDEController()
 {
-}
-
-bool IDEController::is_pci_native_mode_enabled() const
-{
-    return (m_prog_if.value() & 0x05) != 0;
-}
-
-bool IDEController::is_pci_native_mode_enabled_on_primary_channel() const
-{
-    return (m_prog_if.value() & 0x1) == 0x1;
-}
-
-bool IDEController::is_pci_native_mode_enabled_on_secondary_channel() const
-{
-    return (m_prog_if.value() & 0x4) == 0x4;
-}
-
-bool IDEController::is_bus_master_capable() const
-{
-    return m_prog_if.value() & (1 << 7);
-}
-
-static const char* detect_controller_type(u8 programming_value)
-{
-    switch (programming_value) {
-    case 0x00:
-        return "ISA Compatibility mode-only controller";
-    case 0x05:
-        return "PCI native mode-only controller";
-    case 0x0A:
-        return "ISA Compatibility mode controller, supports both channels switched to PCI native mode";
-    case 0x0F:
-        return "PCI native mode controller, supports both channels switched to ISA compatibility mode";
-    case 0x80:
-        return "ISA Compatibility mode-only controller, supports bus mastering";
-    case 0x85:
-        return "PCI native mode-only controller, supports bus mastering";
-    case 0x8A:
-        return "ISA Compatibility mode controller, supports both channels switched to PCI native mode, supports bus mastering";
-    case 0x8F:
-        return "PCI native mode controller, supports both channels switched to ISA compatibility mode, supports bus mastering";
-    default:
-        VERIFY_NOT_REACHED();
-    }
-    VERIFY_NOT_REACHED();
-}
-
-UNMAP_AFTER_INIT void IDEController::initialize(bool force_pio)
-{
-    auto bus_master_base = IOAddress(PCI::get_BAR4(pci_address()) & (~1));
-    dbgln("IDE controller @ {}: bus master base was set to {}", pci_address(), bus_master_base);
-    dbgln("IDE controller @ {}: interrupt line was set to {}", pci_address(), m_interrupt_line.value());
-    dbgln("IDE controller @ {}: {}", pci_address(), detect_controller_type(m_prog_if.value()));
-    dbgln("IDE controller @ {}: primary channel DMA capable? {}", pci_address(), ((bus_master_base.offset(2).in<u8>() >> 5) & 0b11));
-    dbgln("IDE controller @ {}: secondary channel DMA capable? {}", pci_address(), ((bus_master_base.offset(2 + 8).in<u8>() >> 5) & 0b11));
-
-    if (!is_bus_master_capable())
-        force_pio = true;
-
-    auto bar0 = PCI::get_BAR0(pci_address());
-    auto primary_base_io = (bar0 == 0x1 || bar0 == 0) ? IOAddress(0x1F0) : IOAddress(bar0 & (~1));
-    auto bar1 = PCI::get_BAR1(pci_address());
-    auto primary_control_io = (bar1 == 0x1 || bar1 == 0) ? IOAddress(0x3F6) : IOAddress(bar1 & (~1));
-    auto bar2 = PCI::get_BAR2(pci_address());
-    auto secondary_base_io = (bar2 == 0x1 || bar2 == 0) ? IOAddress(0x170) : IOAddress(bar2 & (~1));
-    auto bar3 = PCI::get_BAR3(pci_address());
-    auto secondary_control_io = (bar3 == 0x1 || bar3 == 0) ? IOAddress(0x376) : IOAddress(bar3 & (~1));
-
-    auto irq_line = m_interrupt_line.value();
-    if (is_pci_native_mode_enabled()) {
-        VERIFY(irq_line != 0);
-    }
-
-    if (is_pci_native_mode_enabled_on_primary_channel()) {
-        if (force_pio)
-            m_channels.append(IDEChannel::create(*this, irq_line, { primary_base_io, primary_control_io }, IDEChannel::ChannelType::Primary));
-        else
-            m_channels.append(BMIDEChannel::create(*this, irq_line, { primary_base_io, primary_control_io, bus_master_base }, IDEChannel::ChannelType::Primary));
-    } else {
-        if (force_pio)
-            m_channels.append(IDEChannel::create(*this, { primary_base_io, primary_control_io }, IDEChannel::ChannelType::Primary));
-        else
-            m_channels.append(BMIDEChannel::create(*this, { primary_base_io, primary_control_io, bus_master_base }, IDEChannel::ChannelType::Primary));
-    }
-
-    m_channels[0].enable_irq();
-
-    if (is_pci_native_mode_enabled_on_secondary_channel()) {
-        if (force_pio)
-            m_channels.append(IDEChannel::create(*this, irq_line, { secondary_base_io, secondary_control_io }, IDEChannel::ChannelType::Secondary));
-        else
-            m_channels.append(BMIDEChannel::create(*this, irq_line, { secondary_base_io, secondary_control_io, bus_master_base.offset(8) }, IDEChannel::ChannelType::Secondary));
-    } else {
-        if (force_pio)
-            m_channels.append(IDEChannel::create(*this, { secondary_base_io, secondary_control_io }, IDEChannel::ChannelType::Secondary));
-        else
-            m_channels.append(BMIDEChannel::create(*this, { secondary_base_io, secondary_control_io, bus_master_base.offset(8) }, IDEChannel::ChannelType::Secondary));
-    }
-
-    m_channels[1].enable_irq();
 }
 
 RefPtr<StorageDevice> IDEController::device_by_channel_and_position(u32 index) const

--- a/Kernel/Storage/ATA/IDEController.h
+++ b/Kernel/Storage/ATA/IDEController.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,34 +17,22 @@ namespace Kernel {
 
 class AsyncBlockDeviceRequest;
 
-class IDEController final : public ATAController
-    , public PCI::Device {
+class IDEController : public ATAController {
 public:
-    static NonnullRefPtr<IDEController> initialize(PCI::DeviceIdentifier const&, bool force_pio);
+    static NonnullRefPtr<IDEController> initialize();
     virtual ~IDEController() override;
 
-    virtual RefPtr<StorageDevice> device(u32 index) const override;
-    virtual bool reset() override;
-    virtual bool shutdown() override;
-    virtual size_t devices_count() const override;
-    virtual void start_request(const ATADevice&, AsyncBlockDeviceRequest&) override;
-    virtual void complete_current_request(AsyncDeviceRequest::RequestResult) override;
+    virtual RefPtr<StorageDevice> device(u32 index) const override final;
+    virtual bool reset() override final;
+    virtual bool shutdown() override final;
+    virtual size_t devices_count() const override final;
+    virtual void start_request(const ATADevice&, AsyncBlockDeviceRequest&) override final;
+    virtual void complete_current_request(AsyncDeviceRequest::RequestResult) override final;
 
-    bool is_bus_master_capable() const;
-    bool is_pci_native_mode_enabled() const;
-
-private:
-    bool is_pci_native_mode_enabled_on_primary_channel() const;
-    bool is_pci_native_mode_enabled_on_secondary_channel() const;
-    IDEController(PCI::DeviceIdentifier const&, bool force_pio);
+protected:
+    IDEController();
 
     RefPtr<StorageDevice> device_by_channel_and_position(u32 index) const;
-    void initialize(bool force_pio);
-    void detect_disks();
-
     NonnullRefPtrVector<IDEChannel> m_channels;
-    // FIXME: Find a better way to get the ProgrammingInterface
-    PCI::ProgrammingInterface m_prog_if;
-    PCI::InterruptLine m_interrupt_line;
 };
 }

--- a/Kernel/Storage/ATA/ISAIDEController.cpp
+++ b/Kernel/Storage/ATA/ISAIDEController.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/FileSystem/ProcFS.h>
+#include <Kernel/Sections.h>
+#include <Kernel/Storage/ATA/ATADiskDevice.h>
+#include <Kernel/Storage/ATA/BMIDEChannel.h>
+#include <Kernel/Storage/ATA/ISAIDEController.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT NonnullRefPtr<ISAIDEController> ISAIDEController::initialize()
+{
+    return adopt_ref(*new ISAIDEController());
+}
+
+UNMAP_AFTER_INIT ISAIDEController::ISAIDEController()
+{
+    initialize_channels();
+}
+
+UNMAP_AFTER_INIT void ISAIDEController::initialize_channels()
+{
+    auto primary_base_io = IOAddress(0x1F0);
+    auto primary_control_io = IOAddress(0x3F6);
+    auto secondary_base_io = IOAddress(0x170);
+    auto secondary_control_io = IOAddress(0x376);
+
+    m_channels.append(IDEChannel::create(*this, { primary_base_io, primary_control_io }, IDEChannel::ChannelType::Primary));
+    m_channels[0].enable_irq();
+
+    m_channels.append(IDEChannel::create(*this, { secondary_base_io, secondary_control_io }, IDEChannel::ChannelType::Secondary));
+    m_channels[1].enable_irq();
+    dbgln("ISA IDE controller detected and initialized");
+}
+
+}

--- a/Kernel/Storage/ATA/ISAIDEController.h
+++ b/Kernel/Storage/ATA/ISAIDEController.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <Kernel/Storage/ATA/IDEChannel.h>
+#include <Kernel/Storage/ATA/IDEController.h>
+#include <Kernel/Storage/StorageDevice.h>
+
+namespace Kernel {
+
+class AsyncBlockDeviceRequest;
+
+class ISAIDEController final : public IDEController {
+public:
+    static NonnullRefPtr<ISAIDEController> initialize();
+
+private:
+    ISAIDEController();
+
+    RefPtr<StorageDevice> device_by_channel_and_position(u32 index) const;
+    void initialize_channels();
+};
+}

--- a/Kernel/Storage/ATA/PCIIDEController.cpp
+++ b/Kernel/Storage/ATA/PCIIDEController.cpp
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/FileSystem/ProcFS.h>
+#include <Kernel/Sections.h>
+#include <Kernel/Storage/ATA/ATADiskDevice.h>
+#include <Kernel/Storage/ATA/BMIDEChannel.h>
+#include <Kernel/Storage/ATA/PCIIDEController.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT NonnullRefPtr<PCIIDEController> PCIIDEController::initialize(PCI::DeviceIdentifier const& device_identifier, bool force_pio)
+{
+    return adopt_ref(*new PCIIDEController(device_identifier, force_pio));
+}
+
+UNMAP_AFTER_INIT PCIIDEController::PCIIDEController(PCI::DeviceIdentifier const& device_identifier, bool force_pio)
+    : PCI::Device(device_identifier.address())
+    , m_prog_if(device_identifier.prog_if())
+    , m_interrupt_line(device_identifier.interrupt_line())
+{
+    PCI::enable_io_space(device_identifier.address());
+    PCI::enable_memory_space(device_identifier.address());
+    PCI::enable_bus_mastering(device_identifier.address());
+    enable_pin_based_interrupts();
+    initialize(force_pio);
+}
+
+bool PCIIDEController::is_pci_native_mode_enabled() const
+{
+    return (m_prog_if.value() & 0x05) != 0;
+}
+
+bool PCIIDEController::is_pci_native_mode_enabled_on_primary_channel() const
+{
+    return (m_prog_if.value() & 0x1) == 0x1;
+}
+
+bool PCIIDEController::is_pci_native_mode_enabled_on_secondary_channel() const
+{
+    return (m_prog_if.value() & 0x4) == 0x4;
+}
+
+bool PCIIDEController::is_bus_master_capable() const
+{
+    return m_prog_if.value() & (1 << 7);
+}
+
+static const char* detect_controller_type(u8 programming_value)
+{
+    switch (programming_value) {
+    case 0x00:
+        return "ISA Compatibility mode-only controller";
+    case 0x05:
+        return "PCI native mode-only controller";
+    case 0x0A:
+        return "ISA Compatibility mode controller, supports both channels switched to PCI native mode";
+    case 0x0F:
+        return "PCI native mode controller, supports both channels switched to ISA compatibility mode";
+    case 0x80:
+        return "ISA Compatibility mode-only controller, supports bus mastering";
+    case 0x85:
+        return "PCI native mode-only controller, supports bus mastering";
+    case 0x8A:
+        return "ISA Compatibility mode controller, supports both channels switched to PCI native mode, supports bus mastering";
+    case 0x8F:
+        return "PCI native mode controller, supports both channels switched to ISA compatibility mode, supports bus mastering";
+    default:
+        VERIFY_NOT_REACHED();
+    }
+    VERIFY_NOT_REACHED();
+}
+
+UNMAP_AFTER_INIT void PCIIDEController::initialize(bool force_pio)
+{
+    auto bus_master_base = IOAddress(PCI::get_BAR4(pci_address()) & (~1));
+    dbgln("IDE controller @ {}: bus master base was set to {}", pci_address(), bus_master_base);
+    dbgln("IDE controller @ {}: interrupt line was set to {}", pci_address(), m_interrupt_line.value());
+    dbgln("IDE controller @ {}: {}", pci_address(), detect_controller_type(m_prog_if.value()));
+    dbgln("IDE controller @ {}: primary channel DMA capable? {}", pci_address(), ((bus_master_base.offset(2).in<u8>() >> 5) & 0b11));
+    dbgln("IDE controller @ {}: secondary channel DMA capable? {}", pci_address(), ((bus_master_base.offset(2 + 8).in<u8>() >> 5) & 0b11));
+
+    if (!is_bus_master_capable())
+        force_pio = true;
+
+    auto bar0 = PCI::get_BAR0(pci_address());
+    auto primary_base_io = (bar0 == 0x1 || bar0 == 0) ? IOAddress(0x1F0) : IOAddress(bar0 & (~1));
+    auto bar1 = PCI::get_BAR1(pci_address());
+    auto primary_control_io = (bar1 == 0x1 || bar1 == 0) ? IOAddress(0x3F6) : IOAddress(bar1 & (~1));
+    auto bar2 = PCI::get_BAR2(pci_address());
+    auto secondary_base_io = (bar2 == 0x1 || bar2 == 0) ? IOAddress(0x170) : IOAddress(bar2 & (~1));
+    auto bar3 = PCI::get_BAR3(pci_address());
+    auto secondary_control_io = (bar3 == 0x1 || bar3 == 0) ? IOAddress(0x376) : IOAddress(bar3 & (~1));
+
+    auto irq_line = m_interrupt_line.value();
+    if (is_pci_native_mode_enabled()) {
+        VERIFY(irq_line != 0);
+    }
+
+    if (is_pci_native_mode_enabled_on_primary_channel()) {
+        if (force_pio)
+            m_channels.append(IDEChannel::create(*this, irq_line, { primary_base_io, primary_control_io }, IDEChannel::ChannelType::Primary));
+        else
+            m_channels.append(BMIDEChannel::create(*this, irq_line, { primary_base_io, primary_control_io, bus_master_base }, IDEChannel::ChannelType::Primary));
+    } else {
+        if (force_pio)
+            m_channels.append(IDEChannel::create(*this, { primary_base_io, primary_control_io }, IDEChannel::ChannelType::Primary));
+        else
+            m_channels.append(BMIDEChannel::create(*this, { primary_base_io, primary_control_io, bus_master_base }, IDEChannel::ChannelType::Primary));
+    }
+
+    m_channels[0].enable_irq();
+
+    if (is_pci_native_mode_enabled_on_secondary_channel()) {
+        if (force_pio)
+            m_channels.append(IDEChannel::create(*this, irq_line, { secondary_base_io, secondary_control_io }, IDEChannel::ChannelType::Secondary));
+        else
+            m_channels.append(BMIDEChannel::create(*this, irq_line, { secondary_base_io, secondary_control_io, bus_master_base.offset(8) }, IDEChannel::ChannelType::Secondary));
+    } else {
+        if (force_pio)
+            m_channels.append(IDEChannel::create(*this, { secondary_base_io, secondary_control_io }, IDEChannel::ChannelType::Secondary));
+        else
+            m_channels.append(BMIDEChannel::create(*this, { secondary_base_io, secondary_control_io, bus_master_base.offset(8) }, IDEChannel::ChannelType::Secondary));
+    }
+
+    m_channels[1].enable_irq();
+}
+
+}

--- a/Kernel/Storage/ATA/PCIIDEController.h
+++ b/Kernel/Storage/ATA/PCIIDEController.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Types.h>
+#include <Kernel/Storage/ATA/IDEChannel.h>
+#include <Kernel/Storage/ATA/IDEController.h>
+#include <Kernel/Storage/StorageDevice.h>
+
+namespace Kernel {
+
+class AsyncBlockDeviceRequest;
+
+class PCIIDEController final : public IDEController
+    , public PCI::Device {
+public:
+    static NonnullRefPtr<PCIIDEController> initialize(PCI::DeviceIdentifier const&, bool force_pio);
+
+    bool is_bus_master_capable() const;
+    bool is_pci_native_mode_enabled() const;
+
+private:
+    bool is_pci_native_mode_enabled_on_primary_channel() const;
+    bool is_pci_native_mode_enabled_on_secondary_channel() const;
+    PCIIDEController(PCI::DeviceIdentifier const&, bool force_pio);
+
+    RefPtr<StorageDevice> device_by_channel_and_position(u32 index) const;
+    void initialize(bool force_pio);
+    void detect_disks();
+
+    // FIXME: Find a better way to get the ProgrammingInterface
+    PCI::ProgrammingInterface m_prog_if;
+    PCI::InterruptLine m_interrupt_line;
+};
+}

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -16,7 +16,8 @@
 #include <Kernel/FileSystem/Ext2FileSystem.h>
 #include <Kernel/Panic.h>
 #include <Kernel/Storage/ATA/AHCIController.h>
-#include <Kernel/Storage/ATA/IDEController.h>
+#include <Kernel/Storage/ATA/ISAIDEController.h>
+#include <Kernel/Storage/ATA/PCIIDEController.h>
 #include <Kernel/Storage/NVMe/NVMeController.h>
 #include <Kernel/Storage/Partition/EBRPartitionTable.h>
 #include <Kernel/Storage/Partition/GUIDPartitionTable.h>
@@ -45,7 +46,7 @@ bool StorageManagement::boot_argument_contains_partition_uuid()
     return m_boot_argument.starts_with(partition_uuid_prefix);
 }
 
-UNMAP_AFTER_INIT void StorageManagement::enumerate_controllers(bool force_pio, bool nvme_poll)
+UNMAP_AFTER_INIT void StorageManagement::enumerate_pci_controllers(bool force_pio, bool nvme_poll)
 {
     VERIFY(m_controllers.is_empty());
 
@@ -77,7 +78,7 @@ UNMAP_AFTER_INIT void StorageManagement::enumerate_controllers(bool force_pio, b
 
             auto subclass_code = static_cast<SubclassID>(device_identifier.subclass_code().value());
             if (subclass_code == SubclassID::IDEController && kernel_command_line().is_ide_enabled()) {
-                m_controllers.append(IDEController::initialize(device_identifier, force_pio));
+                m_controllers.append(PCIIDEController::initialize(device_identifier, force_pio));
             }
 
             if (subclass_code == SubclassID::SATAController
@@ -94,7 +95,6 @@ UNMAP_AFTER_INIT void StorageManagement::enumerate_controllers(bool force_pio, b
             }
         });
     }
-    m_controllers.append(RamdiskController::initialize());
 }
 
 UNMAP_AFTER_INIT void StorageManagement::enumerate_storage_devices()
@@ -273,7 +273,16 @@ UNMAP_AFTER_INIT void StorageManagement::initialize(StringView root_device, bool
 {
     VERIFY(s_device_minor_number == 0);
     m_boot_argument = root_device;
-    enumerate_controllers(force_pio, poll);
+    if (PCI::Access::is_disabled()) {
+        // Note: If PCI is disabled, we assume that at least we have an ISA IDE controller
+        // to probe and use
+        m_controllers.append(ISAIDEController::initialize());
+    } else {
+        enumerate_pci_controllers(force_pio, poll);
+    }
+    // Note: Whether PCI bus is present on the system or not, always try to attach
+    // a given ramdisk.
+    m_controllers.append(RamdiskController::initialize());
     enumerate_storage_devices();
     enumerate_disk_partitions();
     if (!boot_argument_contains_partition_uuid()) {

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -36,7 +36,7 @@ public:
 private:
     bool boot_argument_contains_partition_uuid();
 
-    void enumerate_controllers(bool force_pio, bool nvme_poll);
+    void enumerate_pci_controllers(bool force_pio, bool nvme_poll);
     void enumerate_storage_devices();
     void enumerate_disk_partitions();
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -299,8 +299,8 @@ void init_stage2(void*)
     }
 
     // Initialize the PCI Bus as early as possible, for early boot (PCI based) serial logging
-    if (!kernel_command_line().is_pci_disabled()) {
-        PCI::initialize();
+    PCI::initialize();
+    if (!PCI::Access::is_disabled()) {
         PCISerialDevice::detect();
     }
 
@@ -323,12 +323,12 @@ void init_stage2(void*)
 
     auto boot_profiling = kernel_command_line().is_boot_profiling_enabled();
 
-    if (!kernel_command_line().is_pci_disabled()) {
+    if (!PCI::Access::is_disabled()) {
         USB::USBManagement::initialize();
     }
     FirmwareSysFSDirectory::initialize();
 
-    if (!kernel_command_line().is_pci_disabled()) {
+    if (!PCI::Access::is_disabled()) {
         VirtIO::detect();
     }
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -299,8 +299,10 @@ void init_stage2(void*)
     }
 
     // Initialize the PCI Bus as early as possible, for early boot (PCI based) serial logging
-    PCI::initialize();
-    PCISerialDevice::detect();
+    if (!kernel_command_line().is_pci_disabled()) {
+        PCI::initialize();
+        PCISerialDevice::detect();
+    }
 
     VirtualFileSystem::initialize();
 
@@ -321,10 +323,14 @@ void init_stage2(void*)
 
     auto boot_profiling = kernel_command_line().is_boot_profiling_enabled();
 
-    USB::USBManagement::initialize();
+    if (!kernel_command_line().is_pci_disabled()) {
+        USB::USBManagement::initialize();
+    }
     FirmwareSysFSDirectory::initialize();
 
-    VirtIO::detect();
+    if (!kernel_command_line().is_pci_disabled()) {
+        VirtIO::detect();
+    }
 
     NetworkingManagement::the().initialize();
     Syscall::initialize();

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -277,6 +277,17 @@ if [ "$SERENITY_ARCH" != "aarch64" ]; then
     fi
 fi
 
+[ -z "$SERENITY_COMMON_QEMU_ISA_PC_ARGS" ] && SERENITY_COMMON_QEMU_ISA_PC_ARGS="
+$SERENITY_EXTRA_QEMU_ARGS
+-m $SERENITY_RAM_SIZE
+-cpu pentium3
+-machine isapc
+-d guest_errors
+-chardev stdio,id=stdout,mux=on
+-device isa-debugcon,chardev=stdout
+$SERENITY_BOOT_DRIVE
+"
+
 [ -z "$SERENITY_COMMON_QEMU_Q35_ARGS" ] && SERENITY_COMMON_QEMU_Q35_ARGS="
 $SERENITY_EXTRA_QEMU_ARGS
 -m $SERENITY_RAM_SIZE
@@ -370,6 +381,17 @@ elif [ "$SERENITY_RUN" = "q35" ]; then
         $SERENITY_VIRT_TECH_ARG \
         -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
         -device $SERENITY_ETHERNET_DEVICE_TYPE,netdev=breh \
+        -kernel Kernel/Prekernel/Prekernel \
+        -initrd Kernel/Kernel \
+        -append "${SERENITY_KERNEL_CMDLINE}"
+elif [ "$SERENITY_RUN" = "isapc" ]; then
+    # Meta/run.sh q35: qemu (q35 chipset) with SerenityOS
+    echo "Starting SerenityOS with QEMU ISA-PC machine, Commandline: ${SERENITY_KERNEL_CMDLINE}"
+    "$SERENITY_QEMU_BIN" \
+        $SERENITY_COMMON_QEMU_ISA_PC_ARGS \
+        $SERENITY_VIRT_TECH_ARG \
+        -netdev user,id=breh,hostfwd=tcp:127.0.0.1:8888-10.0.2.15:8888,hostfwd=tcp:127.0.0.1:8823-10.0.2.15:23 \
+        -device ne2k_isa,netdev=breh \
         -kernel Kernel/Prekernel/Prekernel \
         -initrd Kernel/Kernel \
         -append "${SERENITY_KERNEL_CMDLINE}"


### PR DESCRIPTION
This PR sets a goal to create basic abstractions in the kernel to allow us to boot SerenityOS on a pure ISA-PC machine type.