### PR TITLE
Ports: Set `config.sub` path for SDL2_mixer

### DIFF
--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -3,6 +3,7 @@ port=SDL2_mixer
 version=2.0.4
 useconfigure=true
 use_fresh_config_sub=true
+config_sub_path=build-scripts/config.sub
 files="https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${version}.tar.gz SDL2_mixer-${version}.tar.gz b4cf5a382c061cd75081cf246c2aa2f9df8db04bdda8dcdc6b6cca55bede2419"
 auth_type=sha256
 depends=("libmodplug" "libvorbis" "SDL2")


### PR DESCRIPTION
This path needs to be set, or otherwise SDL2_mixer will not build.