### PR TITLE
Userland: Fix some silly bugs

### DIFF
--- a/Userland/Utilities/groups.cpp
+++ b/Userland/Utilities/groups.cpp
@@ -31,7 +31,6 @@ static void print_account_gids(const Core::Account& account)
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::unveil("/etc/passwd", "r"));
-    TRY(Core::System::unveil("/etc/shadow", "r"));
     TRY(Core::System::unveil("/etc/group", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
     TRY(Core::System::pledge("stdio rpath", nullptr));
@@ -44,12 +43,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     if (usernames.is_empty()) {
-        auto account = TRY(Core::Account::from_uid(geteuid()));
+        auto account = TRY(Core::Account::from_uid(geteuid(), Core::Account::Read::PasswdOnly));
         print_account_gids(account);
     }
 
     for (auto username : usernames) {
-        auto result = Core::Account::from_name(username);
+        auto result = Core::Account::from_name(username, Core::Account::Read::PasswdOnly);
         if (result.is_error()) {
             warnln("{} '{}'", result.error(), username);
             continue;

--- a/Userland/Utilities/pwd.cpp
+++ b/Userland/Utilities/pwd.cpp
@@ -11,7 +11,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio"));
+    TRY(Core::System::pledge("rpath stdio"));
     outln(TRY(Core::System::getcwd()));
     return 0;
 }


### PR DESCRIPTION
`pkgsrc` support on SerenityOS has gone from "not working" to "fall flat on one's face at the first bootstrap step".

Let's fall flat on one's face at the second bootstrap step instead.