### PR TITLE
LibGUI+LibGfx: Fix emoji scaling

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -170,7 +170,7 @@ TextPosition TextEditor::text_position_at_content_position(Gfx::IntPoint const& 
                 int glyph_x = 0;
                 size_t i = 0;
                 for (; i < view.length(); ++i) {
-                    int advance = font().glyph_width(view.code_points()[i]) + font().glyph_spacing();
+                    int advance = font().glyph_or_emoji_width(view.code_points()[i]) + font().glyph_spacing();
                     if ((glyph_x + (advance / 2)) >= position.x())
                         break;
                     glyph_x += advance;

--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -314,7 +314,7 @@ int BitmapFont::glyph_or_emoji_width_for_variable_width_font(u32 code_point) con
     auto* emoji = Emoji::emoji_for_code_point(code_point);
     if (emoji == nullptr)
         return glyph_width(0xFFFD);
-    return emoji->size().width();
+    return glyph_height() * emoji->width() / emoji->height();
 }
 
 int BitmapFont::width(StringView view) const { return unicode_view_width(Utf8View(view)); }

--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -114,8 +114,8 @@ NonnullRefPtr<BitmapFont> BitmapFont::masked_character_set() const
 }
 
 BitmapFont::BitmapFont(String name, String family, u8* rows, u8* widths, bool is_fixed_width, u8 glyph_width, u8 glyph_height, u8 glyph_spacing, u16 range_mask_size, u8* range_mask, u8 baseline, u8 mean_line, u8 presentation_size, u16 weight, u8 slope, bool owns_arrays)
-    : m_name(name)
-    , m_family(family)
+    : m_name(move(name))
+    , m_family(move(family))
     , m_range_mask_size(range_mask_size)
     , m_range_mask(range_mask)
     , m_rows(rows)
@@ -171,9 +171,9 @@ BitmapFont::~BitmapFont()
     }
 }
 
-RefPtr<BitmapFont> BitmapFont::load_from_memory(const u8* data)
+RefPtr<BitmapFont> BitmapFont::load_from_memory(u8 const* data)
 {
-    auto& header = *reinterpret_cast<const FontFileHeader*>(data);
+    auto const& header = *reinterpret_cast<const FontFileHeader*>(data);
     if (memcmp(header.magic, "!Fnt", 4)) {
         dbgln("header.magic != '!Fnt', instead it's '{:c}{:c}{:c}{:c}'", header.magic[0], header.magic[1], header.magic[2], header.magic[3]);
         return nullptr;
@@ -207,7 +207,7 @@ RefPtr<BitmapFont> BitmapFont::load_from_file(String const& path)
     if (file_or_error.is_error())
         return nullptr;
 
-    auto font = load_from_memory((const u8*)file_or_error.value()->data());
+    auto font = load_from_memory((u8 const*)file_or_error.value()->data());
     if (!font)
         return nullptr;
 
@@ -245,10 +245,7 @@ bool BitmapFont::write_to_file(String const& path)
     stream << ReadonlyBytes { m_glyph_widths, m_glyph_count };
 
     stream.flush();
-    if (stream.handle_any_error())
-        return false;
-
-    return true;
+    return !stream.handle_any_error();
 }
 
 Glyph BitmapFont::glyph(u32 code_point) const
@@ -311,7 +308,7 @@ int BitmapFont::glyph_or_emoji_width_for_variable_width_font(u32 code_point) con
         return glyph_width(0xFFFD);
     }
 
-    auto* emoji = Emoji::emoji_for_code_point(code_point);
+    auto const* emoji = Emoji::emoji_for_code_point(code_point);
     if (emoji == nullptr)
         return glyph_width(0xFFFD);
     return glyph_height() * emoji->width() / emoji->height();
@@ -355,7 +352,7 @@ String BitmapFont::variant() const
 {
     StringBuilder builder;
     builder.append(weight_to_name(weight()));
-    if (slope()) {
+    if (slope() != 0) {
         if (builder.string_view() == "Regular"sv)
             builder.clear();
         else

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1226,17 +1226,13 @@ FLATTEN void Painter::draw_glyph(IntPoint const& point, u32 code_point, Font con
 
 void Painter::draw_emoji(IntPoint const& point, Gfx::Bitmap const& emoji, Font const& font)
 {
-    if (!font.is_fixed_width())
-        blit(point, emoji, emoji.rect());
-    else {
-        IntRect dst_rect {
-            point.x(),
-            point.y(),
-            font.glyph_width('x'),
-            font.glyph_height()
-        };
-        draw_scaled_bitmap(dst_rect, emoji, emoji.rect());
-    }
+    IntRect dst_rect {
+        point.x(),
+        point.y(),
+        font.glyph_height() * emoji.width() / emoji.height(),
+        font.glyph_height()
+    };
+    draw_scaled_bitmap(dst_rect, emoji, emoji.rect());
 }
 
 void Painter::draw_glyph_or_emoji(IntPoint const& point, u32 code_point, Font const& font, Color color)


### PR DESCRIPTION
Fixes #12001.
This still have issues for fixed-width fonts (and in FontEditor) when emoji is bigger than glyph width. I'm not sure how it should be handled.

This PR doesn't touch any of the emojis itself (they are not upscaled)

![image](https://user-images.githubusercontent.com/42967349/150585852-66e73ceb-c51c-4985-aaea-b786da198d64.png)
![image](https://user-images.githubusercontent.com/42967349/150586035-2b0e780b-6a68-45ec-98d7-16864c1fe44a.png)


**LibGfx: Always scale emojis to fit font height**

**LibGUI: Use Font::glyph_or_emoji_width() in TextEditor**

This fixes selection of text containing emoji when variable-width font
is set.

**LibGfx: Fix stylistic issues in BitmapFont**

* Apply some clang-tidy suggestions
* Convert to east-const