### PR TITLE
Kernel: Send correct parameters when cleaning the text mode console

### DIFF
--- a/Kernel/Graphics/Console/TextModeConsole.cpp
+++ b/Kernel/Graphics/Console/TextModeConsole.cpp
@@ -155,7 +155,7 @@ void TextModeConsole::write(size_t x, size_t y, char ch, Color background, Color
 
 void TextModeConsole::clear_vga_row(u16 row)
 {
-    clear(row * width(), width(), width());
+    clear(0, row, width());
 }
 
 void TextModeConsole::write(char ch, bool critical)


### PR DESCRIPTION
The goal of this pull request is to fix two major issues I've seen while working on #12046.
It might also help some of us to work with text mode console when doing bare metal debugging, so let's ensure they can use it without these problems.