### PR TITLE
LibWeb: Make attribute hidden have an effect; hide some other elements

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -7,15 +7,6 @@ a {
     cursor: pointer;
 }
 
-head,
-link,
-meta,
-script,
-style,
-title {
-    display: none;
-}
-
 body {
     margin: 8px;
 }
@@ -186,10 +177,6 @@ colgroup {
     display: table-column-group;
 }
 
-basefont {
-    display: block;
-}
-
 blockquote {
     margin-left: 25px;
     margin-right: 25px;
@@ -242,4 +229,23 @@ details {
 summary {
     display: block;
     font-weight: bold;
+}
+
+/* 15.3.1 Hidden elements
+ * https://html.spec.whatwg.org/multipage/rendering.html#hidden-elements
+ */
+/* FIXME: Add `noframes` once frames are implemented. */
+/* FIXME: Add `noembed` once <embed> is implemented. */
+/* FIXME: Add `rp` once <ruby> is implemented. */
+[hidden], area, base, basefont, datalist, head, link, meta, /*noembed,*/
+/*noframes,*/ param, /*rp,*/ script, style, template, title {
+  display: none;
+}
+
+embed[hidden] { display: inline; height: 0; width: 0; }
+
+input[type=hidden i] { display: none !important; }
+
+@media (scripting) {
+  noscript { display: none !important; }
 }


### PR DESCRIPTION
This LibWeb to using the list of hidden elements from the spec.

Concretely, the following things are now explicitly marked
`display: none` in addition to before:

- elements with the `hidden` attribute
- area
- base
- basefont
- datalist
- param
- rp

The spec also wants `noframes` and `noembed` to be `display: none`,
but since support for frames and embeds doesn't exist yet, these
are omitted for now.

With this, everyone's favorite website http://45.33.8.238/ no longer
displays spans with attribute hidden. (Whitespace handling still
looks a bit off though.)