### PR TITLE
LibJS: Avoid potential signed integer overflow in CyclicModule.cpp

### DIFF
--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -126,7 +126,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
     (void)TRY(initialize_environment(vm));
 
     // 11. Assert: module occurs exactly once in stack.
-    auto count = 0;
+    size_t count = 0;
     for (auto* module : stack) {
         if (module == this)
             count++;


### PR DESCRIPTION
`auto count = 0;` will declare `count` as a `signed int`.

We don't want that since `count` is used to count the occurence of an element in an `AK::Vector` that can have up to `SIZE_MAX` elements; `SIZE_MAX` can overflow a `signed int` more than 4 billion times.

---

We could also rewrite this code as something like:
```cpp
    size_t count = 0;
    for (auto const* module : stack) {
        if (module == this && ++count >= 2) // or nested ifs?
            break;                          // or VERIFY_NOT_REACHED()?
    }
    VERIFY(count == 1);
```

Since we only need to verify that `count` is 1, and we don't really need the exact `count`.

Would we rather not do that and keep the code as is?

---

:upside_down_face:: <https://github.com/SerenityOS/serenity/pull/11957#discussion_r790083675>
