### PR TITLE
Kernel/PCI: Add basic support for the VMD PCI bridge device

### DIFF
--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -38,6 +38,8 @@ public:
     Spinlock const& scan_lock() const { return m_scan_lock; }
     Mutex const& access_lock() const { return m_access_lock; }
 
+    void add_host_controller_and_enumerate_attached_devices(NonnullOwnPtr<HostController>, Function<void(DeviceIdentifier const&)> callback);
+
 private:
     u8 read8_field(Address address, RegisterOffset field);
     u16 read16_field(Address address, RegisterOffset field);

--- a/Kernel/Bus/PCI/Controller/VolumeManagementDevice.cpp
+++ b/Kernel/Bus/PCI/Controller/VolumeManagementDevice.cpp
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/ByteReader.h>
+#include <Kernel/Arch/x86/IO.h>
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Bus/PCI/Controller/VolumeManagementDevice.h>
+
+namespace Kernel::PCI {
+
+static Atomic<u32> s_vmd_pci_domain_number = 0x10000;
+
+NonnullOwnPtr<VolumeManagementDevice> VolumeManagementDevice::must_create(PCI::DeviceIdentifier const& device_identifier)
+{
+    u8 start_bus = 0;
+    switch ((PCI::read16(device_identifier.address(), static_cast<PCI::RegisterOffset>(0x44)) >> 8) & 0x3) {
+    case 0:
+        break;
+    case 1:
+        start_bus = 128;
+        break;
+    case 2:
+        start_bus = 224;
+        break;
+    default:
+        dbgln("VMD @ {}: Unknown bus offset option was set to {}", device_identifier.address(),
+            ((PCI::read16(device_identifier.address(), static_cast<PCI::RegisterOffset>(0x44)) >> 8) & 0x3));
+        VERIFY_NOT_REACHED();
+    }
+
+    // FIXME: The end bus might not be 255, so we actually need to check it with the
+    // resource size of BAR0.
+    dbgln("VMD Host bridge @ {}: Start bus at {}, end bus {}", device_identifier.address(), start_bus, 0xff);
+    PCI::Domain domain { s_vmd_pci_domain_number++, start_bus, 0xff };
+    auto start_address = PhysicalAddress(PCI::get_BAR0(device_identifier.address())).page_base();
+    return adopt_own_if_nonnull(new (nothrow) VolumeManagementDevice(domain, start_address)).release_nonnull();
+}
+
+void VolumeManagementDevice::write8_field(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u8 value)
+{
+    SpinlockLocker locker(m_config_lock);
+    // Note: We must write then read to ensure completion before returning.
+    MemoryBackedHostBridge::write8_field(bus, device, function, field, value);
+    MemoryBackedHostBridge::read8_field(bus, device, function, field);
+}
+void VolumeManagementDevice::write16_field(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u16 value)
+{
+    SpinlockLocker locker(m_config_lock);
+    // Note: We must write then read to ensure completion before returning.
+    MemoryBackedHostBridge::write16_field(bus, device, function, field, value);
+    MemoryBackedHostBridge::read16_field(bus, device, function, field);
+}
+void VolumeManagementDevice::write32_field(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field, u32 value)
+{
+    SpinlockLocker locker(m_config_lock);
+    // Note: We must write then read to ensure completion before returning.
+    MemoryBackedHostBridge::write32_field(bus, device, function, field, value);
+    MemoryBackedHostBridge::read32_field(bus, device, function, field);
+}
+
+u8 VolumeManagementDevice::read8_field(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
+{
+    SpinlockLocker locker(m_config_lock);
+    return MemoryBackedHostBridge::read8_field(bus, device, function, field);
+}
+u16 VolumeManagementDevice::read16_field(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
+{
+    SpinlockLocker locker(m_config_lock);
+    return MemoryBackedHostBridge::read16_field(bus, device, function, field);
+}
+u32 VolumeManagementDevice::read32_field(BusNumber bus, DeviceNumber device, FunctionNumber function, u32 field)
+{
+    SpinlockLocker locker(m_config_lock);
+    return MemoryBackedHostBridge::read32_field(bus, device, function, field);
+}
+
+VolumeManagementDevice::VolumeManagementDevice(PCI::Domain const& domain, PhysicalAddress start_address)
+    : MemoryBackedHostBridge(domain, start_address)
+{
+}
+
+}

--- a/Kernel/Bus/PCI/Controller/VolumeManagementDevice.h
+++ b/Kernel/Bus/PCI/Controller/VolumeManagementDevice.h
@@ -8,35 +8,28 @@
 
 #include <AK/Bitmap.h>
 #include <AK/Vector.h>
-#include <Kernel/Bus/PCI/Controller/HostBridge.h>
+#include <Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.h>
 #include <Kernel/Locking/Spinlock.h>
 
 namespace Kernel::PCI {
 
-class MemoryBackedHostBridge : public HostBridge {
+class VolumeManagementDevice final : public MemoryBackedHostBridge {
 public:
-    static NonnullOwnPtr<MemoryBackedHostBridge> must_create(Domain const&, PhysicalAddress);
+    static NonnullOwnPtr<VolumeManagementDevice> must_create(PCI::DeviceIdentifier const& device_identifier);
+
+private:
+    VolumeManagementDevice(PCI::Domain const&, PhysicalAddress);
 
     virtual void write8_field(BusNumber, DeviceNumber, FunctionNumber, u32 field, u8 value) override;
     virtual void write16_field(BusNumber, DeviceNumber, FunctionNumber, u32 field, u16 value) override;
     virtual void write32_field(BusNumber, DeviceNumber, FunctionNumber, u32 field, u32 value) override;
-
     virtual u8 read8_field(BusNumber, DeviceNumber, FunctionNumber, u32 field) override;
     virtual u16 read16_field(BusNumber, DeviceNumber, FunctionNumber, u32 field) override;
     virtual u32 read32_field(BusNumber, DeviceNumber, FunctionNumber, u32 field) override;
 
-protected:
-    MemoryBackedHostBridge(PCI::Domain const&, PhysicalAddress);
-
-    // Memory-mapped access operations
-    void map_bus_region(BusNumber);
-    VirtualAddress get_device_configuration_memory_mapped_space(BusNumber, DeviceNumber, FunctionNumber);
-    PhysicalAddress determine_memory_mapped_bus_base_address(BusNumber) const;
-
-    // Data-members for accessing Memory mapped PCI devices' configuration spaces
-    BusNumber m_mapped_bus { 0 };
-    OwnPtr<Memory::Region> m_mapped_bus_region;
-    PhysicalAddress m_start_address;
+    // Note: All read and writes must be done with a spinlock because
+    // Linux says that CPU might deadlock otherwise if access is not serialized.
+    Spinlock m_config_lock;
 };
 
 }

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -21,6 +21,7 @@ set(KERNEL_SOURCES
     AddressSanitizer.cpp
     Bus/PCI/Controller/HostBridge.cpp
     Bus/PCI/Controller/MemoryBackedHostBridge.cpp
+    Bus/PCI/Controller/VolumeManagementDevice.cpp
     Bus/PCI/Access.cpp
     Bus/PCI/API.cpp
     Bus/PCI/Device.cpp


### PR DESCRIPTION
cc @tomuta 
We still don't support MSI interrupts from devices behind the vmd device, but we will get there too.
Another fix for #11594. It's not a full fix because we can't still use the devices behind the bridge.