### PR TITLE
Kernel: Use ErrorOr in BlockBased and Ext2 filesystem raw read and write

### DIFF
--- a/Kernel/FileSystem/BlockBasedFileSystem.h
+++ b/Kernel/FileSystem/BlockBasedFileSystem.h
@@ -29,11 +29,11 @@ protected:
     ErrorOr<void> read_block(BlockIndex, UserOrKernelBuffer*, size_t count, size_t offset = 0, bool allow_cache = true) const;
     ErrorOr<void> read_blocks(BlockIndex, unsigned count, UserOrKernelBuffer&, bool allow_cache = true) const;
 
-    bool raw_read(BlockIndex, UserOrKernelBuffer&);
-    bool raw_write(BlockIndex, const UserOrKernelBuffer&);
+    ErrorOr<void> raw_read(BlockIndex, UserOrKernelBuffer&);
+    ErrorOr<void> raw_write(BlockIndex, const UserOrKernelBuffer&);
 
-    bool raw_read_blocks(BlockIndex index, size_t count, UserOrKernelBuffer&);
-    bool raw_write_blocks(BlockIndex index, size_t count, const UserOrKernelBuffer&);
+    ErrorOr<void> raw_read_blocks(BlockIndex index, size_t count, UserOrKernelBuffer&);
+    ErrorOr<void> raw_write_blocks(BlockIndex index, size_t count, const UserOrKernelBuffer&);
 
     ErrorOr<void> write_block(BlockIndex, const UserOrKernelBuffer&, size_t count, size_t offset = 0, bool allow_cache = true);
     ErrorOr<void> write_blocks(BlockIndex, unsigned count, const UserOrKernelBuffer&, bool allow_cache = true);

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -122,7 +122,7 @@ private:
     ErrorOr<void> write_ext2_inode(InodeIndex, ext2_inode const&);
     bool find_block_containing_inode(InodeIndex, BlockIndex& block_index, unsigned& offset) const;
 
-    bool flush_super_block();
+    ErrorOr<void> flush_super_block();
 
     virtual StringView class_name() const override { return "Ext2FS"sv; }
     virtual Ext2FSInode& root_inode() override;

--- a/Kernel/FileSystem/ISO9660FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FileSystem.cpp
@@ -234,10 +234,10 @@ ErrorOr<void> ISO9660FS::parse_volume_set()
 
     auto current_block_index = first_data_area_block;
     while (true) {
-        bool result = raw_read(BlockIndex { current_block_index }, block_buffer);
-        if (!result) {
-            dbgln_if(ISO9660_DEBUG, "Failed to read volume descriptor from ISO file");
-            return EIO;
+        auto result = raw_read(BlockIndex { current_block_index }, block_buffer);
+        if (result.is_error()) {
+            dbgln_if(ISO9660_DEBUG, "Failed to read volume descriptor from ISO file: {}", result.error());
+            return result;
         }
 
         auto const* header = reinterpret_cast<ISO::VolumeDescriptorHeader const*>(block->data());
@@ -387,11 +387,7 @@ ErrorOr<NonnullRefPtr<ISO9660FS::DirectoryEntry>> ISO9660FS::directory_entry_for
 
     auto blocks = TRY(KBuffer::try_create_with_size(data_length, Memory::Region::Access::Read | Memory::Region::Access::Write, "ISO9660FS: Directory traversal buffer"));
     auto blocks_buffer = UserOrKernelBuffer::for_kernel_buffer(blocks->data());
-    auto did_read = raw_read_blocks(BlockBasedFileSystem::BlockIndex { extent_location }, data_length / logical_block_size(), blocks_buffer);
-    if (!did_read) {
-        return EIO;
-    }
-
+    TRY(raw_read_blocks(BlockBasedFileSystem::BlockIndex { extent_location }, data_length / logical_block_size(), blocks_buffer));
     auto entry = TRY(DirectoryEntry::try_create(extent_location, data_length, move(blocks)));
     m_directory_entry_cache.set(key, entry);
 
@@ -428,10 +424,7 @@ ErrorOr<size_t> ISO9660Inode::read_bytes(off_t offset, size_t size, UserOrKernel
         auto buffer_offset = buffer.offset(nread);
         dbgln_if(ISO9660_VERY_DEBUG, "ISO9660Inode::read_bytes: Reading {} bytes into buffer offset {}/{}, logical block index: {}", bytes_to_read, nread, total_bytes, current_block_index.value());
 
-        if (bool result = const_cast<ISO9660FS&>(fs()).raw_read(current_block_index, block_buffer); !result) {
-            return EIO;
-        }
-
+        TRY(const_cast<ISO9660FS&>(fs()).raw_read(current_block_index, block_buffer));
         TRY(buffer_offset.write(block->data() + initial_offset, bytes_to_read));
 
         nread += bytes_to_read;


### PR DESCRIPTION
These functions were returning bools when internally they were suppressing `Error`s found. This patch converts the following functions to return `ErrorOr<void>`:

```cpp
// BlockBasedFileSystem
bool raw_read(BlockIndex, UserOrKernelBuffer&);
bool raw_write(BlockIndex, const UserOrKernelBuffer&);
bool raw_read_blocks(BlockIndex index, size_t count, UserOrKernelBuffer&);
bool raw_write_blocks(BlockIndex index, size_t count, const UserOrKernelBuffer&);

// Ext2FS
bool flush_super_block();
```