### PR TITLE
FileSystemAccessClient: Add `FSAC::the()` alias

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -298,7 +298,7 @@ bool GLContextWidget::load_file(Core::File& file)
         if (!bitmap_or_error.is_error())
             texture_image = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
     } else {
-        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), builder.string_view(), Core::OpenMode::ReadOnly);
+        auto response = FSAC::the().try_request_file(window(), builder.string_view(), Core::OpenMode::ReadOnly);
         if (response.is_error())
             return false;
 
@@ -357,7 +357,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& file_menu = window->add_menu("&File");
 
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file(window);
+        auto response = FSAC::the().try_open_file(window);
         if (response.is_error())
             return;
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -88,7 +88,7 @@ HexEditorWidget::HexEditorWidget()
     });
 
     m_open_action = GUI::CommonActions::make_open_action([this](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file(window(), {}, Core::StandardPaths::home_directory(), Core::OpenMode::ReadWrite);
+        auto response = FSAC::the().try_open_file(window(), {}, Core::StandardPaths::home_directory(), Core::OpenMode::ReadWrite);
         if (response.is_error())
             return;
 
@@ -118,7 +118,7 @@ HexEditorWidget::HexEditorWidget()
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_save_file(window(), m_name, m_extension, Core::OpenMode::ReadWrite | Core::OpenMode::Truncate);
+        auto response = FSAC::the().try_save_file(window(), m_name, m_extension, Core::OpenMode::ReadWrite | Core::OpenMode::Truncate);
         if (response.is_error())
             return;
         auto file = response.release_value();
@@ -374,7 +374,7 @@ void HexEditorWidget::drop_event(GUI::DropEvent& event)
         window()->move_to_front();
 
         // TODO: A drop event should be considered user consent for opening a file
-        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), urls.first().path(), Core::OpenMode::ReadOnly);
+        auto response = FSAC::the().try_request_file(window(), urls.first().path(), Core::OpenMode::ReadOnly);
         if (response.is_error())
             return;
         open_file(response.value());

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -49,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (arguments.argc > 1) {
         // FIXME: Using `try_request_file_read_only_approved` doesn't work here since the file stored in the editor is only readable.
-        auto response = FileSystemAccessClient::Client::the().try_request_file(window, arguments.strings[1], Core::OpenMode::ReadWrite);
+        auto response = FSAC::the().try_request_file(window, arguments.strings[1], Core::OpenMode::ReadWrite);
         if (response.is_error())
             return 1;
         hex_editor_widget->open_file(response.value());

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -41,7 +41,7 @@ void PDFViewerWidget::initialize_menubar(GUI::Window& window)
 {
     auto& file_menu = window.add_menu("&File");
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file(&window);
+        auto response = FSAC::the().try_open_file(&window);
         if (response.is_error())
             return;
         open_file(*response.value());

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
 
     if (arguments.argc >= 2) {
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, arguments.argv[1]);
+        auto response = FSAC::the().try_request_file_read_only_approved(window, arguments.argv[1]);
         if (response.is_error())
             return 1;
         pdf_viewer_widget->open_file(*response.value());

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -591,7 +591,7 @@ void ImageEditor::save_project()
         save_project_as();
         return;
     }
-    auto response = FileSystemAccessClient::Client::the().try_request_file(window(), path(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
+    auto response = FSAC::the().try_request_file(window(), path(), Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
     if (response.is_error())
         return;
     auto result = save_project_to_file(*response.value());
@@ -604,7 +604,7 @@ void ImageEditor::save_project()
 
 void ImageEditor::save_project_as()
 {
-    auto response = FileSystemAccessClient::Client::the().try_save_file(window(), "untitled", "pp");
+    auto response = FSAC::the().try_save_file(window(), "untitled", "pp");
     if (response.is_error())
         return;
     auto file = response.value();

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -131,7 +131,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         });
 
     m_open_image_action = GUI::CommonActions::make_open_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file(&window);
+        auto response = FSAC::the().try_open_file(&window);
         if (response.is_error())
             return;
         open_image(response.value());
@@ -162,7 +162,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
             "As &BMP", [&](auto&) {
                 auto* editor = current_image_editor();
                 VERIFY(editor);
-                auto response = FileSystemAccessClient::Client::the().try_save_file(&window, "untitled", "bmp");
+                auto response = FSAC::the().try_save_file(&window, "untitled", "bmp");
                 if (response.is_error())
                     return;
                 auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
@@ -177,7 +177,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 auto* editor = current_image_editor();
                 VERIFY(editor);
                 // TODO: fix bmp on line below?
-                auto response = FileSystemAccessClient::Client::the().try_save_file(&window, "untitled", "png");
+                auto response = FSAC::the().try_save_file(&window, "untitled", "png");
                 if (response.is_error())
                     return;
                 auto preserve_alpha_channel = GUI::MessageBox::show(&window, "Do you wish to preserve transparency?", "Preserve transparency?", GUI::MessageBox::Type::Question, GUI::MessageBox::InputType::YesNo);
@@ -306,7 +306,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
     m_edit_menu->add_action(GUI::Action::create(
         "&Load Color Palette", [&](auto&) {
-            auto response = FileSystemAccessClient::Client::the().try_open_file(&window, "Load Color Palette");
+            auto response = FSAC::the().try_open_file(&window, "Load Color Palette");
             if (response.is_error())
                 return;
 
@@ -320,7 +320,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
     m_edit_menu->add_action(GUI::Action::create(
         "Sa&ve Color Palette", [&](auto&) {
-            auto response = FileSystemAccessClient::Client::the().try_save_file(&window, "untitled", "palette");
+            auto response = FSAC::the().try_save_file(&window, "untitled", "palette");
             if (response.is_error())
                 return;
 
@@ -863,7 +863,7 @@ void MainWidget::drop_event(GUI::DropEvent& event)
         if (url.protocol() != "file")
             continue;
 
-        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), url.path(), Core::OpenMode::ReadOnly);
+        auto response = FSAC::the().try_request_file(window(), url.path(), Core::OpenMode::ReadOnly);
         if (response.is_error())
             return;
         open_image(response.value());

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -71,7 +71,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     if (image_file) {
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, image_file);
+        auto response = FSAC::the().try_request_file_read_only_approved(window, image_file);
         if (response.is_error())
             return 1;
         main_widget->open_image(response.value());

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -124,7 +124,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
         if (!load_path.has_value())
             return;
 
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window(), *load_path);
+        auto response = FSAC::the().try_request_file_read_only_approved(window(), *load_path);
         if (response.is_error())
             return;
         load_file(*response.value());

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -71,7 +71,7 @@ Result<bool, String> Workbook::open_file(Core::File& file)
 
 Result<bool, String> Workbook::load(StringView filename)
 {
-    auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(&m_parent_window, filename);
+    auto response = FSAC::the().try_request_file_read_only_approved(&m_parent_window, filename);
     if (response.is_error()) {
         StringBuilder sb;
         sb.append("Failed to open ");

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -94,7 +94,7 @@ int main(int argc, char* argv[])
     window->show();
 
     if (filename) {
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, filename);
+        auto response = FSAC::the().try_request_file_read_only_approved(window, filename);
         if (response.is_error())
             return 1;
         spreadsheet_widget.load_file(*response.value());

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -266,7 +266,7 @@ MainWidget::MainWidget()
     });
 
     m_open_action = GUI::CommonActions::make_open_action([this](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file(window());
+        auto response = FSAC::the().try_open_file(window());
         if (response.is_error())
             return;
 
@@ -282,7 +282,7 @@ MainWidget::MainWidget()
     });
 
     m_save_as_action = GUI::CommonActions::make_save_as_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_save_file(window(), m_name, m_extension);
+        auto response = FSAC::the().try_save_file(window(), m_name, m_extension);
         if (response.is_error())
             return;
 
@@ -301,7 +301,7 @@ MainWidget::MainWidget()
             m_save_as_action->activate();
             return;
         }
-        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), m_path, Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
+        auto response = FSAC::the().try_request_file(window(), m_path, Core::OpenMode::Truncate | Core::OpenMode::WriteOnly);
         if (response.is_error())
             return;
 
@@ -724,7 +724,7 @@ void MainWidget::drop_event(GUI::DropEvent& event)
         }
 
         // TODO: A drop event should be considered user consent for opening a file
-        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), urls.first().path(), Core::OpenMode::ReadOnly);
+        auto response = FSAC::the().try_request_file(window(), urls.first().path(), Core::OpenMode::ReadOnly);
         if (response.is_error())
             return;
         read_file(*response.value());

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -74,7 +74,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (file_to_edit) {
         FileArgument parsed_argument(file_to_edit);
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, parsed_argument.filename());
+        auto response = FSAC::the().try_request_file_read_only_approved(window, parsed_argument.filename());
 
         if (response.is_error()) {
             if (response.error().code() == ENOENT)

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -264,7 +264,7 @@ void PreviewWidget::drop_event(GUI::DropEvent& event)
             return;
         }
 
-        auto response = FileSystemAccessClient::Client::the().try_request_file(window(), urls.first().path(), Core::OpenMode::ReadOnly);
+        auto response = FSAC::the().try_request_file(window(), urls.first().path(), Core::OpenMode::ReadOnly);
         if (response.is_error())
             return;
         set_theme_from_file(*response.value());

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -378,7 +378,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     TRY(file_menu->try_add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file(window, "Select theme file", "/res/themes");
+        auto response = FSAC::the().try_open_file(window, "Select theme file", "/res/themes");
         if (response.is_error())
             return;
         preview_widget.set_theme_from_file(*response.value());
@@ -386,14 +386,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(file_menu->try_add_action(GUI::CommonActions::make_save_action([&](auto&) {
         if (path.has_value()) {
-            save_to_result(FileSystemAccessClient::Client::the().try_request_file(window, *path, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate));
+            save_to_result(FSAC::the().try_request_file(window, *path, Core::OpenMode::WriteOnly | Core::OpenMode::Truncate));
         } else {
-            save_to_result(FileSystemAccessClient::Client::the().try_save_file(window, "Theme", "ini"));
+            save_to_result(FSAC::the().try_save_file(window, "Theme", "ini"));
         }
     })));
 
     TRY(file_menu->try_add_action(GUI::CommonActions::make_save_as_action([&](auto&) {
-        save_to_result(FileSystemAccessClient::Client::the().try_save_file(window, "Theme", "ini"));
+        save_to_result(FSAC::the().try_save_file(window, "Theme", "ini"));
     })));
 
     TRY(file_menu->try_add_separator());

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -48,3 +48,12 @@ private:
 };
 
 }
+
+namespace FSAC {
+
+ALWAYS_INLINE FileSystemAccessClient::Client& the()
+{
+    return FileSystemAccessClient::Client::the();
+}
+
+}


### PR DESCRIPTION
Typing `FileSystemAccessClient::Client::the()` was very long, this is just making a alias to make it easier to write!