### PR TITLE
Kernel: Add missing #include <AK/Badge.h> to MemoryManager.h

### DIFF
--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/Concepts.h>
 #include <AK/HashTable.h>
 #include <AK/IntrusiveRedBlackTree.h>


### PR DESCRIPTION
This missing header broke the aarch64 build