### PR TITLE
UserspaceEmulator: Support ioctls TCSETSF and TCSETSW

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1126,7 +1126,7 @@ int Emulator::virt$ioctl([[maybe_unused]] int fd, unsigned request, [[maybe_unus
         mmu().copy_to_vm(arg, &termios, sizeof(termios));
         return rc;
     }
-    if (request == TCSETS) {
+    if (request == TCSETS || request == TCSETSF || request == TCSETSW) {
         struct termios termios;
         mmu().copy_from_vm(&termios, arg, sizeof(termios));
         return syscall(SC_ioctl, fd, request, &termios);


### PR DESCRIPTION
This makes it possible to run `less` in UE and find out it leaks a hell lot of memory 🥳 