### PR TITLE
Meta: Update to clang-13 in Lagom Fuzz builds

### DIFF
--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -18,10 +18,10 @@ steps:
         sudo apt-get purge -y clang-11 gcc-10
         sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         sudo apt-get update
-        sudo apt-get install ccache gcc-11 g++-11 libstdc++-11-dev ninja-build unzip
+        sudo apt-get install ccache clang-13 gcc-11 g++-11 libstdc++-11-dev ninja-build unzip
 
-        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-12 100
-        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-12 100
+        sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-13 100
+        sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-13 100
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 100
         sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 100
 

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -29,7 +29,7 @@ Lagom can be used to fuzz parts of SerenityOS's code base. This requires buildin
     # Or as a handy rebuild-rerun line:
     ninja FuzzJs && ./Fuzzers/FuzzJs
 
-(Note that we require clang >= 12, so depending on your package manager you may need to specify `clang++-12` and `clang-12` instead.)
+(Note that we require clang >= 13, so depending on your package manager you may need to specify `clang++-13` and `clang-13` instead.)
 
 Any fuzzing results (particularly slow inputs, crashes, etc.) will be dropped in the current directory.
 


### PR DESCRIPTION
Clang 12 does not support `using enum`, but Clang 13 does.