### PR TITLE
LibWeb: Make SVG attributes inheritable

### DIFF
--- a/Base/res/html/misc/svg.html
+++ b/Base/res/html/misc/svg.html
@@ -33,12 +33,13 @@
              a 10,40 20 0,1 30,10 l 30,10"
           fill="orange" stroke="red" stroke-width="5"></path>
 
-    <path d="M 300,300 l 30,10
-             a 10,10 20 0,1 30,10 l 30,10
-             a 10,20 20 0,1 30,10 l 30,10
-             a 10,30 20 0,1 30,10 l 30,10
-             a 10,40 20 0,1 30,10 l 30,10 z"
-          fill="orange" stroke="red" stroke-width="5"></path>
+    <g fill="orange" stroke="red" stroke-width="5">
+        <path d="M 300,300 l 30,10
+                 a 10,10 20 0,1 30,10 l 30,10
+                 a 10,20 20 0,1 30,10 l 30,10
+                 a 10,30 20 0,1 30,10 l 30,10
+                 a 10,40 20 0,1 30,10 l 30,10 z"></path>
+    </g>
 </svg>
 </body>
 </html>

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -590,6 +590,9 @@
     "initial": "black",
     "valid-types": [
       "color"
+    ],
+    "valid-identifiers": [
+      "none"
     ]
   },
   "flex": {
@@ -1168,9 +1171,12 @@
   },
   "stroke": {
     "inherited": true,
-    "initial": "transparent",
+    "initial": "none",
     "valid-types": [
       "color"
+    ],
+    "valid-identifiers": [
+      "none"
     ]
   },
   "stroke-width": {

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Matthew Olsson <mattco@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,16 +20,11 @@ public:
 
     SVGGraphicsElement(DOM::Document&, QualifiedName);
 
-    virtual void parse_attribute(FlyString const& name, String const& value) override;
+    virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     Optional<Gfx::Color> fill_color() const;
     Optional<Gfx::Color> stroke_color() const;
     Optional<float> stroke_width() const;
-
-protected:
-    Optional<Gfx::Color> m_fill_color;
-    Optional<Gfx::Color> m_stroke_color;
-    Optional<float> m_stroke_width;
 };
 
 }


### PR DESCRIPTION
Rather than treat the attribute values separately and store them in the SVGGraphicsElement, let's make use of the CSS cascade to handle inheritance for us!

cc: @Lubrsi, this should fix the issue you had in your family tree app.