### PR TITLE
Kernel: Replace String with NonnullOwnPtr<KString> in sys$getkeymap

### DIFF
--- a/Kernel/Syscalls/keymap.cpp
+++ b/Kernel/Syscalls/keymap.cpp
@@ -43,7 +43,7 @@ ErrorOr<FlatPtr> Process::sys$getkeymap(Userspace<const Syscall::SC_getkeymap_pa
     TRY(require_promise(Pledge::getkeymap));
     auto params = TRY(copy_typed_from_user(user_params));
 
-    String keymap_name = HIDManagement::the().keymap_name();
+    auto keymap_name = TRY(KString::try_create(HIDManagement::the().keymap_name()));
     Keyboard::CharacterMapData const& character_maps = HIDManagement::the().character_map();
 
     TRY(copy_to_user(params.map, character_maps.map, CHAR_MAP_SIZE * sizeof(u32)));
@@ -52,9 +52,9 @@ ErrorOr<FlatPtr> Process::sys$getkeymap(Userspace<const Syscall::SC_getkeymap_pa
     TRY(copy_to_user(params.altgr_map, character_maps.altgr_map, CHAR_MAP_SIZE * sizeof(u32)));
     TRY(copy_to_user(params.shift_altgr_map, character_maps.shift_altgr_map, CHAR_MAP_SIZE * sizeof(u32)));
 
-    if (params.map_name.size < keymap_name.length())
+    if (params.map_name.size < keymap_name->length())
         return ENAMETOOLONG;
-    TRY(copy_to_user(params.map_name.data, keymap_name.characters(), keymap_name.length()));
+    TRY(copy_to_user(params.map_name.data, keymap_name->characters(), keymap_name->length()));
     return 0;
 }
 


### PR DESCRIPTION
I accidentally forgot this one in my last PR :facepalm: