### PR TITLE
FileManager: Show a GUI warning dialog if clicked file wasn't found

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -102,6 +102,7 @@ void DirectoryView::handle_activation(GUI::ModelIndex const& index)
     struct stat st;
     if (stat(path.characters(), &st) < 0) {
         perror("stat");
+        GUI::MessageBox::show_error(window(), "No such file or directory (Was it moved?)");
         return;
     }
 


### PR DESCRIPTION
It did print the error to the serial console, but a GUI error dialog
seems more friendly here.