### PR TITLE
WindowServer: Rename default_positioned() -> is_default_positioned()

### DIFF
--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -321,7 +321,7 @@ public:
     bool is_destroyed() const { return m_destroyed; }
     void destroy();
 
-    bool default_positioned() const { return m_default_positioned; }
+    bool is_default_positioned() const { return m_default_positioned; }
     void set_default_positioned(bool p) { m_default_positioned = p; }
 
     bool is_opaque() const

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -2012,7 +2012,7 @@ Gfx::IntPoint WindowManager::get_recommended_window_position(Gfx::IntPoint const
 
     Window const* overlap_window = nullptr;
     current_window_stack().for_each_visible_window_of_type_from_front_to_back(WindowType::Normal, [&](Window& window) {
-        if (window.default_positioned() && (!overlap_window || overlap_window->window_id() < window.window_id())) {
+        if (window.is_default_positioned() && (!overlap_window || overlap_window->window_id() < window.window_id())) {
             overlap_window = &window;
         }
         return IterationDecision::Continue;


### PR DESCRIPTION
Tiny change, but it really bothered me that this was the only function
not named like the rest.