### PR TITLE
LibC+LibTimeZone+Userland: Implement `tzset` and related methods in accordance with POSIX

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -545,8 +545,14 @@ static Offset get_active_dst_offset(TimeZoneOffset const& time_zone_offset, AK::
     auto standard_time_in_effect = offsets[0]->time_in_effect(time);
     auto daylight_time_in_effect = offsets[1]->time_in_effect(time);
 
-    if ((time < daylight_time_in_effect) || (time >= standard_time_in_effect))
-        return { offsets[0]->offset, InDST::No };
+    if (daylight_time_in_effect < standard_time_in_effect) {
+        if ((time < daylight_time_in_effect) || (time >= standard_time_in_effect))
+            return { offsets[0]->offset, InDST::No };
+    } else {
+        if ((time >= standard_time_in_effect) && (time < daylight_time_in_effect))
+            return { offsets[0]->offset, InDST::No };
+    }
+
     return { offsets[1]->offset, InDST::Yes };
 }
 

--- a/Tests/LibC/TestLibCTime.cpp
+++ b/Tests/LibC/TestLibCTime.cpp
@@ -17,6 +17,12 @@ public:
     {
     }
 
+    explicit TimeZoneGuard(char const* tz)
+        : m_tz(getenv("TZ"))
+    {
+        setenv("TZ", tz, 1);
+    }
+
     ~TimeZoneGuard()
     {
         if (m_tz)
@@ -31,6 +37,8 @@ private:
 
 TEST_CASE(asctime)
 {
+    TimeZoneGuard guard("UTC");
+
     time_t epoch = 0;
     auto result = asctime(localtime(&epoch));
     EXPECT_EQ(expected_epoch, StringView(result));
@@ -38,6 +46,8 @@ TEST_CASE(asctime)
 
 TEST_CASE(asctime_r)
 {
+    TimeZoneGuard guard("UTC");
+
     char buffer[26] {};
     time_t epoch = 0;
     auto result = asctime_r(localtime(&epoch), buffer);
@@ -46,6 +56,8 @@ TEST_CASE(asctime_r)
 
 TEST_CASE(ctime)
 {
+    TimeZoneGuard guard("UTC");
+
     time_t epoch = 0;
     auto result = ctime(&epoch);
 
@@ -54,6 +66,8 @@ TEST_CASE(ctime)
 
 TEST_CASE(ctime_r)
 {
+    TimeZoneGuard guard("UTC");
+
     char buffer[26] {};
     time_t epoch = 0;
     auto result = ctime_r(&epoch, buffer);

--- a/Tests/LibC/TestLibCTime.cpp
+++ b/Tests/LibC/TestLibCTime.cpp
@@ -10,6 +10,25 @@
 
 const auto expected_epoch = "Thu Jan  1 00:00:00 1970\n"sv;
 
+class TimeZoneGuard {
+public:
+    TimeZoneGuard()
+        : m_tz(getenv("TZ"))
+    {
+    }
+
+    ~TimeZoneGuard()
+    {
+        if (m_tz)
+            setenv("TZ", m_tz, 1);
+        else
+            unsetenv("TZ");
+    }
+
+private:
+    char const* m_tz { nullptr };
+};
+
 TEST_CASE(asctime)
 {
     time_t epoch = 0;
@@ -40,4 +59,49 @@ TEST_CASE(ctime_r)
     auto result = ctime_r(&epoch, buffer);
 
     EXPECT_EQ(expected_epoch, StringView(result));
+}
+
+TEST_CASE(tzset)
+{
+    TimeZoneGuard guard;
+
+    auto set_tz = [](char const* tz) {
+        setenv("TZ", tz, 1);
+        tzset();
+    };
+
+    set_tz("UTC");
+    EXPECT_EQ(timezone, 0);
+    EXPECT_EQ(altzone, 0);
+    EXPECT_EQ(daylight, 0);
+    EXPECT_EQ(tzname[0], "UTC"sv);
+    EXPECT_EQ(tzname[1], "UTC"sv);
+
+    set_tz("America/New_York");
+    EXPECT_EQ(timezone, 5 * 60 * 60);
+    EXPECT_EQ(altzone, 4 * 60 * 60);
+    EXPECT_EQ(daylight, 1);
+    EXPECT_EQ(tzname[0], "EST"sv);
+    EXPECT_EQ(tzname[1], "EDT"sv);
+
+    set_tz("America/Phoenix");
+    EXPECT_EQ(timezone, 7 * 60 * 60);
+    EXPECT_EQ(altzone, 7 * 60 * 60);
+    EXPECT_EQ(daylight, 0);
+    EXPECT_EQ(tzname[0], "MST"sv);
+    EXPECT_EQ(tzname[1], "MST"sv);
+
+    set_tz("America/Asuncion");
+    EXPECT_EQ(timezone, 4 * 60 * 60);
+    EXPECT_EQ(altzone, 3 * 60 * 60);
+    EXPECT_EQ(daylight, 1);
+    EXPECT_EQ(tzname[0], "-04"sv);
+    EXPECT_EQ(tzname[1], "-03"sv);
+
+    set_tz("CET");
+    EXPECT_EQ(timezone, -1 * 60 * 60);
+    EXPECT_EQ(altzone, -2 * 60 * 60);
+    EXPECT_EQ(daylight, 1);
+    EXPECT_EQ(tzname[0], "CET"sv);
+    EXPECT_EQ(tzname[1], "CEST"sv);
 }

--- a/Tests/LibTimeZone/TestTimeZone.cpp
+++ b/Tests/LibTimeZone/TestTimeZone.cpp
@@ -149,6 +149,31 @@ TEST_CASE(get_time_zone_offset_with_dst)
     test_offset("Europe/Moscow"sv, -1589068800, offset(+1, 3, 00, 00), No);  // Monday, August 25, 1919 12:00:00 AM
 }
 
+TEST_CASE(get_named_time_zone_offsets)
+{
+    auto test_named_offsets = [](auto time_zone, i64 time, i64 expected_standard_offset, i64 expected_daylight_offset, auto expected_standard_name, auto expected_daylight_name) {
+        auto actual_offsets = TimeZone::get_named_time_zone_offsets(time_zone, AK::Time::from_seconds(time));
+        VERIFY(actual_offsets.has_value());
+
+        EXPECT_EQ(actual_offsets->at(0).seconds, expected_standard_offset);
+        EXPECT_EQ(actual_offsets->at(1).seconds, expected_daylight_offset);
+        EXPECT_EQ(actual_offsets->at(0).name, expected_standard_name);
+        EXPECT_EQ(actual_offsets->at(1).name, expected_daylight_name);
+    };
+
+    test_named_offsets("America/New_York"sv, 1642558528, offset(-1, 5, 00, 00), offset(-1, 4, 00, 00), "EST"sv, "EDT"sv); // Wednesday, January 19, 2022 2:15:28 AM
+    test_named_offsets("UTC"sv, 1642558528, offset(+1, 0, 00, 00), offset(+1, 0, 00, 00), "UTC"sv, "UTC"sv);              // Wednesday, January 19, 2022 2:15:28 AM
+    test_named_offsets("GMT"sv, 1642558528, offset(+1, 0, 00, 00), offset(+1, 0, 00, 00), "GMT"sv, "GMT"sv);              // Wednesday, January 19, 2022 2:15:28 AM
+
+    // Phoenix does not observe DST.
+    test_named_offsets("America/Phoenix"sv, 1642558528, offset(-1, 7, 00, 00), offset(-1, 7, 00, 00), "MST"sv, "MST"sv); // Wednesday, January 19, 2022 2:15:28 AM
+
+    // Moscow's observed DST changed several times in 1919.
+    test_named_offsets("Europe/Moscow"sv, -1609459200, offset(+1, 2, 31, 19), offset(+1, 3, 31, 19), "MSK"sv, "MSD"sv);  // Wednesday, January 1, 1919 12:00:00 AM
+    test_named_offsets("Europe/Moscow"sv, -1596412800, offset(+1, 2, 31, 19), offset(+1, 4, 31, 19), "MSK"sv, "MDST"sv); // Sunday, June 1, 1919 12:00:00 AM
+    test_named_offsets("Europe/Moscow"sv, -1589068800, offset(+1, 3, 00, 00), offset(+1, 4, 00, 00), "MSK"sv, "MSD"sv);  // Monday, August 25, 1919 12:00:00 AM
+}
+
 #else
 
 TEST_CASE(time_zone_from_string)

--- a/Tests/LibTimeZone/TestTimeZone.cpp
+++ b/Tests/LibTimeZone/TestTimeZone.cpp
@@ -147,6 +147,11 @@ TEST_CASE(get_time_zone_offset_with_dst)
     test_offset("Europe/Moscow"sv, -1596412800, offset(+1, 4, 31, 19), Yes); // Sunday, June 1, 1919 12:00:00 AM
     test_offset("Europe/Moscow"sv, -1592611200, offset(+1, 4, 00, 00), Yes); // Tuesday, July 15, 1919 12:00:00 AM
     test_offset("Europe/Moscow"sv, -1589068800, offset(+1, 3, 00, 00), No);  // Monday, August 25, 1919 12:00:00 AM
+
+    // Paraguay begins the year in DST.
+    test_offset("America/Asuncion"sv, 1642558528, offset(-1, 3, 00, 00), Yes); // Wednesday, January 19, 2022 2:15:28 AM
+    test_offset("America/Asuncion"sv, 1663553728, offset(-1, 4, 00, 00), No);  // Monday, September 19, 2022 2:15:28 AM
+    test_offset("America/Asuncion"sv, 1671453238, offset(-1, 3, 00, 00), Yes); // Monday, December 19, 2022 12:33:58 PM
 }
 
 TEST_CASE(get_named_time_zone_offsets)

--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -14,6 +14,7 @@
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
+#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -23,6 +24,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
+
+    tzset();
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-analog-clock"));
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -21,6 +21,7 @@
 #include <LibGUI/Icon.h>
 #include <LibGUI/TabWidget.h>
 #include <LibMain/Main.h>
+#include <time.h>
 #include <unistd.h>
 
 namespace Browser {
@@ -81,6 +82,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/request", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
+
+    tzset();
 
     auto app_icon = GUI::Icon::default_icon("app-browser");
 

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -19,6 +19,7 @@
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
+#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -30,6 +31,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
+
+    tzset();
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-calendar"));
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
@@ -20,7 +20,7 @@ ClockSettingsWidget::ClockSettingsWidget()
     load_from_gml(clock_settings_widget_gml);
 
     static auto time_zones = TimeZone::all_time_zones();
-    m_time_zone = TimeZone::current_time_zone();
+    m_time_zone = TimeZone::system_time_zone();
 
     m_time_zone_combo_box = *find_descendant_of_type_named<GUI::ComboBox>("time_zone_input");
     m_time_zone_combo_box->set_only_allow_values_from_model(true);

--- a/Userland/Libraries/LibC/limits.h
+++ b/Userland/Libraries/LibC/limits.h
@@ -82,6 +82,8 @@
 
 #define LINK_MAX 4096
 
+#define TZNAME_MAX 64
+
 #ifdef __USE_POSIX
 #    include <bits/posix1_lim.h>
 #endif

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -354,14 +354,14 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
     return fits ? str.length() : 0;
 }
 
-long timezone;
-long altzone;
-char* tzname[2];
-int daylight;
-
 static char __tzname_standard[TZNAME_MAX];
 static char __tzname_daylight[TZNAME_MAX];
 constexpr const char* __utc = "UTC";
+
+long timezone = 0;
+long altzone = 0;
+char* tzname[2] = { const_cast<char*>(__utc), const_cast<char*>(__utc) };
+int daylight = 0;
 
 void tzset()
 {

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -11,7 +11,9 @@
 #include <LibTimeZone/TimeZone.h>
 #include <assert.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/time.h>
 #include <sys/times.h>
@@ -358,15 +360,44 @@ long altzone;
 char* tzname[2];
 int daylight;
 
+static char __tzname_standard[TZNAME_MAX];
+static char __tzname_daylight[TZNAME_MAX];
 constexpr const char* __utc = "UTC";
 
 void tzset()
 {
-    // FIXME: Here we pretend we are in UTC+0.
-    timezone = 0;
-    daylight = 0;
-    tzname[0] = const_cast<char*>(__utc);
-    tzname[1] = const_cast<char*>(__utc);
+    // FIXME: Actually parse the TZ environment variable, described here:
+    // https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html#tag_08
+    StringView time_zone;
+
+    if (char* tz = getenv("TZ"); tz != nullptr)
+        time_zone = tz;
+    else
+        time_zone = TimeZone::current_time_zone();
+
+    auto set_default_values = []() {
+        timezone = 0;
+        altzone = 0;
+        daylight = 0;
+        tzname[0] = const_cast<char*>(__utc);
+        tzname[1] = const_cast<char*>(__utc);
+    };
+
+    if (auto offsets = TimeZone::get_named_time_zone_offsets(time_zone, AK::Time::now_realtime()); offsets.has_value()) {
+        if (!offsets->at(0).name.copy_characters_to_buffer(__tzname_standard, TZNAME_MAX))
+            return set_default_values();
+        if (!offsets->at(1).name.copy_characters_to_buffer(__tzname_daylight, TZNAME_MAX))
+            return set_default_values();
+
+        // timezone and altzone are seconds west of UTC, i.e. the offsets are negated.
+        timezone = -offsets->at(0).seconds;
+        altzone = -offsets->at(1).seconds;
+        daylight = timezone != altzone;
+        tzname[0] = __tzname_standard;
+        tzname[1] = __tzname_daylight;
+    } else {
+        set_default_values();
+    }
 }
 
 clock_t clock()

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -145,11 +145,14 @@ static time_t tm_to_time(struct tm* tm, long timezone_adjust_seconds)
 
 time_t mktime(struct tm* tm)
 {
+    tzset();
     return tm_to_time(tm, timezone);
 }
 
 struct tm* localtime(const time_t* t)
 {
+    tzset();
+
     static struct tm tm_buf;
     return localtime_r(t, &tm_buf);
 }
@@ -209,6 +212,8 @@ char* asctime_r(const struct tm* tm, char* buffer)
 // FIXME: Some formats are not supported.
 size_t strftime(char* destination, size_t max_size, const char* format, const struct tm* tm)
 {
+    tzset();
+
     const char wday_short_names[7][4] = {
         "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
     };

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -372,7 +372,7 @@ void tzset()
     if (char* tz = getenv("TZ"); tz != nullptr)
         time_zone = tz;
     else
-        time_zone = TimeZone::current_time_zone();
+        time_zone = TimeZone::system_time_zone();
 
     auto set_default_values = []() {
         timezone = 0;

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -162,13 +162,7 @@ struct tm* localtime_r(const time_t* t, struct tm* tm)
     if (!t)
         return nullptr;
 
-    auto time_zone = TimeZone::current_time_zone();
-    auto time = AK::Time::from_seconds(*t);
-
-    if (auto offset = TimeZone::get_time_zone_offset(time_zone, time); offset.has_value())
-        time += AK::Time::from_seconds(offset->seconds);
-
-    time_to_tm(tm, time.to_seconds());
+    time_to_tm(tm, *t - timezone);
     return tm;
 }
 

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
 #include <AK/String.h>
 #include <LibTimeZone/TimeZone.h>
 #include <stdio.h>
@@ -154,6 +153,27 @@ Optional<Offset> get_time_zone_offset(StringView time_zone, AK::Time time)
 {
     if (auto maybe_time_zone = time_zone_from_string(time_zone); maybe_time_zone.has_value())
         return get_time_zone_offset(*maybe_time_zone, time);
+    return {};
+}
+
+Optional<Array<NamedOffset, 2>> __attribute__((weak)) get_named_time_zone_offsets([[maybe_unused]] TimeZone time_zone, AK::Time)
+{
+#if !ENABLE_TIME_ZONE_DATA
+    VERIFY(time_zone == TimeZone::UTC);
+
+    NamedOffset utc_offset {};
+    utc_offset.name = "UTC"sv;
+
+    return Array { utc_offset, utc_offset };
+#else
+    return {};
+#endif
+}
+
+Optional<Array<NamedOffset, 2>> get_named_time_zone_offsets(StringView time_zone, AK::Time time)
+{
+    if (auto maybe_time_zone = time_zone_from_string(time_zone); maybe_time_zone.has_value())
+        return get_named_time_zone_offsets(*maybe_time_zone, time);
     return {};
 }
 

--- a/Userland/Libraries/LibTimeZone/TimeZone.cpp
+++ b/Userland/Libraries/LibTimeZone/TimeZone.cpp
@@ -7,6 +7,7 @@
 #include <AK/String.h>
 #include <LibTimeZone/TimeZone.h>
 #include <stdio.h>
+#include <time.h>
 
 namespace TimeZone {
 
@@ -68,7 +69,7 @@ private:
     FILE* m_file { nullptr };
 };
 
-StringView current_time_zone()
+StringView system_time_zone()
 {
     TimeZoneFile time_zone_file("r");
 
@@ -77,6 +78,11 @@ StringView current_time_zone()
         return canonicalize_time_zone(time_zone.value()).value_or("UTC"sv);
 
     return "UTC"sv;
+}
+
+StringView current_time_zone()
+{
+    return canonicalize_time_zone(tzname[0]).value_or("UTC"sv);
 }
 
 ErrorOr<void> change_time_zone([[maybe_unused]] StringView time_zone)

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -6,8 +6,10 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Error.h>
 #include <AK/Optional.h>
+#include <AK/String.h>
 #include <AK/StringView.h>
 #include <AK/Time.h>
 #include <AK/Types.h>
@@ -25,6 +27,10 @@ struct Offset {
     InDST in_dst { InDST::No };
 };
 
+struct NamedOffset : public Offset {
+    String name;
+};
+
 StringView current_time_zone();
 ErrorOr<void> change_time_zone(StringView time_zone);
 Span<StringView const> all_time_zones();
@@ -38,5 +44,8 @@ StringView daylight_savings_rule_to_string(DaylightSavingsRule daylight_savings_
 
 Optional<Offset> get_time_zone_offset(TimeZone time_zone, AK::Time time);
 Optional<Offset> get_time_zone_offset(StringView time_zone, AK::Time time);
+
+Optional<Array<NamedOffset, 2>> get_named_time_zone_offsets(TimeZone time_zone, AK::Time time);
+Optional<Array<NamedOffset, 2>> get_named_time_zone_offsets(StringView time_zone, AK::Time time);
 
 }

--- a/Userland/Libraries/LibTimeZone/TimeZone.h
+++ b/Userland/Libraries/LibTimeZone/TimeZone.h
@@ -31,6 +31,7 @@ struct NamedOffset : public Offset {
     String name;
 };
 
+StringView system_time_zone();
 StringView current_time_zone();
 ErrorOr<void> change_time_zone(StringView time_zone);
 Span<StringView const> all_time_zones();

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -16,6 +16,7 @@
 #include <RequestServer/HttpProtocol.h>
 #include <RequestServer/HttpsProtocol.h>
 #include <signal.h>
+#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
@@ -31,6 +32,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
+
+    tzset();
 
     [[maybe_unused]] auto gemini = make<RequestServer::GeminiProtocol>();
     [[maybe_unused]] auto http = make<RequestServer::HttpProtocol>();

--- a/Userland/Services/Taskbar/ClockWidget.h
+++ b/Userland/Services/Taskbar/ClockWidget.h
@@ -30,7 +30,11 @@ private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
 
-    void tick_clock() { update(); }
+    void tick_clock()
+    {
+        tzset();
+        update();
+    }
 
     void open();
     void close();

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -10,6 +10,7 @@
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
 #include <WebContent/ClientConnection.h>
+#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
@@ -21,6 +22,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/portal/websocket", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
+
+    tzset();
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<WebContent::ClientConnection>());
     return event_loop.exec();

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -29,6 +29,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(print_rfc_5322, "Print date in RFC 5322 format", "rfc-5322", 'R');
     args_parser.parse(arguments);
 
+    tzset();
+
     if (set_date != nullptr) {
         auto number = String(set_date).to_uint();
 

--- a/Userland/Utilities/ddate.cpp
+++ b/Userland/Utilities/ddate.cpp
@@ -8,6 +8,7 @@
 #include <LibCore/DateTime.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
+#include <time.h>
 #include <unistd.h>
 
 class DiscordianDate {
@@ -103,6 +104,8 @@ private:
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
+
+    tzset();
 
     auto date = Core::DateTime::now();
     outln("Today is {}", DiscordianDate(date).to_string());

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -17,6 +17,7 @@
 #include <LibMain/Main.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <time.h>
 #include <unistd.h>
 
 class Quote {
@@ -86,6 +87,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
+
+    tzset();
 
     auto file_contents = file->read_all();
     auto json = TRY(JsonValue::from_string(file_contents));

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -68,6 +68,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
+#include <time.h>
 #include <unistd.h>
 
 RefPtr<JS::VM> vm;
@@ -1286,6 +1287,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(disable_syntax_highlight, "Disable live syntax highlighting", "no-syntax-highlight", 's');
     args_parser.add_positional_argument(script_paths, "Path to script files", "scripts", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
+
+    tzset();
 
     bool syntax_highlight = !disable_syntax_highlight;
 

--- a/Userland/Utilities/timezone.cpp
+++ b/Userland/Utilities/timezone.cpp
@@ -18,10 +18,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil(nullptr, nullptr));
 
     StringView time_zone;
+    bool list_time_zones = false;
 
     Core::ArgsParser args_parser;
+    args_parser.add_option(list_time_zones, "List all available time zones", "list-time-zones", 'l');
     args_parser.add_positional_argument(time_zone, "The time zone to set", "time-zone", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
+
+    if (list_time_zones) {
+        for (auto time_zone : TimeZone::all_time_zones())
+            outln("{}", time_zone);
+        return 0;
+    }
 
     if (time_zone.is_empty()) {
         outln("{}", TimeZone::current_time_zone());

--- a/Userland/Utilities/timezone.cpp
+++ b/Userland/Utilities/timezone.cpp
@@ -32,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     if (time_zone.is_empty()) {
-        outln("{}", TimeZone::current_time_zone());
+        outln("{}", TimeZone::system_time_zone());
         return 0;
     }
 

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -25,6 +25,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/proc", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
+    tzset();
+
     auto file = TRY(Core::File::open("/var/run/utmp", Core::OpenMode::ReadOnly));
     auto json = TRY(JsonValue::from_string(file->read_all()));
     if (!json.is_object()) {


### PR DESCRIPTION
https://pubs.opengroup.org/onlinepubs/9699919799/functions/tzset.html

This updates our `tzset` implementation according to the above spec, and updates other LibC time.h functions to invoke tzset when required. To do this, LibTimeZone now supports generating "abbreviated" time zone names (e.g. EST and EDT), which is what 'tzname' is set to.