### PR TITLE
AK: Implement `HashTable::try_ensure_capacity`, as used in `HashMap`

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -205,6 +205,12 @@ public:
         rehash(capacity * 2);
     }
 
+    ErrorOr<void> try_ensure_capacity(size_t capacity)
+    {
+        VERIFY(capacity >= size());
+        return try_rehash(capacity * 2);
+    }
+
     [[nodiscard]] bool contains(T const& value) const
     {
         return find(value) != end();


### PR DESCRIPTION
This was used in `HashMap::try_ensure_capacity`, but was missing from `HashTable`s implementation. No one had used `HashMap::try_ensure_capacity` before so it went unnoticed!

Found this by trying to use it, followed by being sad my `ErrorOr<T>` was being left behind :^(