### PR TITLE
GMLPlayground: Call `GUI::Window::set_modified` after GML formatting

### DIFF
--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -165,6 +165,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 GUI::MessageBox::show(window, "Unable to save file.\n", "Error", GUI::MessageBox::Type::Error);
                 return;
             }
+            window->set_modified(false);
             update_title();
             return;
         }
@@ -229,8 +230,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
         }
         auto formatted_gml = GUI::format_gml(source);
-        if (!formatted_gml.is_null()) {
+        if (!formatted_gml.is_null() && formatted_gml != source) {
             editor->set_text(formatted_gml);
+            window->set_modified(true);
+            update_title();
         } else {
             GUI::MessageBox::show(
                 window,


### PR DESCRIPTION
Most notably this PR ensures the window is marked as modified _after_ we format a document (and the title is updated with `update_title()`).

With these changes, I also noticed that when requesting to close, clicking "Yes" in the `MessageBox` didn't save _and_ close the document – it just closed it. In this case, I explicitly mark the window as "not" modified after saving.

Closes #11810