### PR TITLE
LibJS+LibUnicode: Begin implementing `Intl.RelativeTimeFormat`

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -106,6 +106,9 @@ set(SOURCES
     Runtime/Intl/NumberFormatConstructor.cpp
     Runtime/Intl/NumberFormatFunction.cpp
     Runtime/Intl/NumberFormatPrototype.cpp
+    Runtime/Intl/RelativeTimeFormat.cpp
+    Runtime/Intl/RelativeTimeFormatConstructor.cpp
+    Runtime/Intl/RelativeTimeFormatPrototype.cpp
     Runtime/IteratorOperations.cpp
     Runtime/IteratorPrototype.cpp
     Runtime/JSONObject.cpp

--- a/Userland/Libraries/LibJS/Forward.h
+++ b/Userland/Libraries/LibJS/Forward.h
@@ -72,7 +72,8 @@
     __JS_ENUMERATE(DisplayNames, display_names, DisplayNamesPrototype, DisplayNamesConstructor)          \
     __JS_ENUMERATE(ListFormat, list_format, ListFormatPrototype, ListFormatConstructor)                  \
     __JS_ENUMERATE(Locale, locale, LocalePrototype, LocaleConstructor)                                   \
-    __JS_ENUMERATE(NumberFormat, number_format, NumberFormatPrototype, NumberFormatConstructor)
+    __JS_ENUMERATE(NumberFormat, number_format, NumberFormatPrototype, NumberFormatConstructor)          \
+    __JS_ENUMERATE(RelativeTimeFormat, relative_time_format, RelativeTimeFormatPrototype, RelativeTimeFormatConstructor)
 
 #define JS_ENUMERATE_TEMPORAL_OBJECTS                                                                    \
     __JS_ENUMERATE(Calendar, calendar, CalendarPrototype, CalendarConstructor)                           \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -61,6 +61,8 @@
 #include <LibJS/Runtime/Intl/LocalePrototype.h>
 #include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
 #include <LibJS/Runtime/Intl/NumberFormatPrototype.h>
+#include <LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h>
+#include <LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h>
 #include <LibJS/Runtime/IteratorPrototype.h>
 #include <LibJS/Runtime/JSONObject.h>
 #include <LibJS/Runtime/MapConstructor.h>

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -7,7 +7,6 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/DisplayNames.h>
-#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
@@ -15,32 +14,6 @@ namespace JS::Intl {
 DisplayNames::DisplayNames(Object& prototype)
     : Object(prototype)
 {
-}
-
-void DisplayNames::set_style(StringView style)
-{
-    if (style == "narrow"sv)
-        m_style = Style::Narrow;
-    else if (style == "short"sv)
-        m_style = Style::Short;
-    else if (style == "long"sv)
-        m_style = Style::Long;
-    else
-        VERIFY_NOT_REACHED();
-}
-
-StringView DisplayNames::style_string() const
-{
-    switch (m_style) {
-    case Style::Narrow:
-        return "narrow"sv;
-    case Style::Short:
-        return "short"sv;
-    case Style::Long:
-        return "long"sv;
-    default:
-        VERIFY_NOT_REACHED();
-    }
 }
 
 void DisplayNames::set_type(StringView type)

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.h
@@ -10,18 +10,12 @@
 #include <AK/String.h>
 #include <AK/StringView.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
 class DisplayNames final : public Object {
     JS_OBJECT(DisplayNames, Object);
-
-    enum class Style {
-        Invalid,
-        Narrow,
-        Short,
-        Long,
-    };
 
     enum class Type {
         Invalid,
@@ -51,9 +45,9 @@ public:
     String const& locale() const { return m_locale; }
     void set_locale(String locale) { m_locale = move(locale); }
 
-    Style style() const { return m_style; }
-    void set_style(StringView style);
-    StringView style_string() const;
+    Unicode::Style style() const { return m_style; }
+    void set_style(StringView style) { m_style = Unicode::style_from_string(style); }
+    StringView style_string() const { return Unicode::style_to_string(m_style); }
 
     Type type() const { return m_type; }
     void set_type(StringView type);
@@ -70,7 +64,7 @@ public:
 
 private:
     String m_locale;                                 // [[Locale]]
-    Style m_style { Style::Invalid };                // [[Style]]
+    Unicode::Style m_style { Unicode::Style::Long }; // [[Style]]
     Type m_type { Type::Invalid };                   // [[Type]]
     Fallback m_fallback { Fallback::Invalid };       // [[Fallback]]
     Optional<LanguageDisplay> m_language_display {}; // [[LanguageDisplay]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -73,13 +73,13 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
         break;
     case DisplayNames::Type::Currency:
         switch (display_names->style()) {
-        case DisplayNames::Style::Long:
+        case Unicode::Style::Long:
             result = Unicode::get_locale_long_currency_mapping(display_names->locale(), code.as_string().string());
             break;
-        case DisplayNames::Style::Short:
+        case Unicode::Style::Short:
             result = Unicode::get_locale_short_currency_mapping(display_names->locale(), code.as_string().string());
             break;
-        case DisplayNames::Style::Narrow:
+        case Unicode::Style::Narrow:
             result = Unicode::get_locale_narrow_currency_mapping(display_names->locale(), code.as_string().string());
             break;
         default:
@@ -91,13 +91,13 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
         break;
     case DisplayNames::Type::DateTimeField:
         switch (display_names->style()) {
-        case DisplayNames::Style::Long:
+        case Unicode::Style::Long:
             result = Unicode::get_locale_long_date_field_mapping(display_names->locale(), code.as_string().string());
             break;
-        case DisplayNames::Style::Short:
+        case Unicode::Style::Short:
             result = Unicode::get_locale_short_date_field_mapping(display_names->locale(), code.as_string().string());
             break;
-        case DisplayNames::Style::Narrow:
+        case Unicode::Style::Narrow:
             result = Unicode::get_locale_narrow_date_field_mapping(display_names->locale(), code.as_string().string());
             break;
         default:

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -13,6 +13,7 @@
 #include <LibJS/Runtime/Intl/ListFormatConstructor.h>
 #include <LibJS/Runtime/Intl/LocaleConstructor.h>
 #include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
+#include <LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h>
 
 namespace JS::Intl {
 
@@ -37,6 +38,7 @@ void Intl::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.ListFormat, global_object.intl_list_format_constructor(), attr);
     define_direct_property(vm.names.Locale, global_object.intl_locale_constructor(), attr);
     define_direct_property(vm.names.NumberFormat, global_object.intl_number_format_constructor(), attr);
+    define_direct_property(vm.names.RelativeTimeFormat, global_object.intl_relative_time_format_constructor(), attr);
 
     define_native_function(vm.names.getCanonicalLocales, get_canonical_locales, 1, attr);
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -9,7 +9,6 @@
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/ListFormat.h>
 #include <LibJS/Runtime/IteratorOperations.h>
-#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
@@ -41,33 +40,6 @@ StringView ListFormat::type_string() const
         return "disjunction"sv;
     case Type::Unit:
         return "unit"sv;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
-void ListFormat::set_style(StringView style)
-{
-    if (style == "narrow"sv) {
-        m_style = Style::Narrow;
-    } else if (style == "short"sv) {
-        m_style = Style::Short;
-    } else if (style == "long"sv) {
-        m_style = Style::Long;
-    } else {
-        VERIFY_NOT_REACHED();
-    }
-}
-
-StringView ListFormat::style_string() const
-{
-    switch (m_style) {
-    case Style::Narrow:
-        return "narrow"sv;
-    case Style::Short:
-        return "short"sv;
-    case Style::Long:
-        return "long"sv;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -123,7 +95,7 @@ Vector<PatternPartition> deconstruct_pattern(StringView pattern, Placeables plac
 // 13.1.2 CreatePartsFromList ( listFormat, list ), https://tc39.es/ecma402/#sec-createpartsfromlist
 Vector<PatternPartition> create_parts_from_list(ListFormat const& list_format, Vector<String> const& list)
 {
-    auto list_patterns = Unicode::get_locale_list_patterns(list_format.locale(), list_format.type_string(), list_format.style_string());
+    auto list_patterns = Unicode::get_locale_list_patterns(list_format.locale(), list_format.type_string(), list_format.style());
     if (!list_patterns.has_value())
         return {};
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.h
@@ -13,6 +13,7 @@
 #include <AK/Vector.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
@@ -27,13 +28,6 @@ public:
         Unit,
     };
 
-    enum class Style {
-        Invalid,
-        Narrow,
-        Short,
-        Long,
-    };
-
     ListFormat(Object& prototype);
     virtual ~ListFormat() override = default;
 
@@ -44,14 +38,14 @@ public:
     void set_type(StringView type);
     StringView type_string() const;
 
-    Style style() const { return m_style; }
-    void set_style(StringView style);
-    StringView style_string() const;
+    Unicode::Style style() const { return m_style; }
+    void set_style(StringView style) { m_style = Unicode::style_from_string(style); }
+    StringView style_string() const { return Unicode::style_to_string(m_style); }
 
 private:
-    String m_locale;                  // [[Locale]]
-    Type m_type { Type::Invalid };    // [[Type]]
-    Style m_style { Style::Invalid }; // [[Style]]
+    String m_locale;                                 // [[Locale]]
+    Type m_type { Type::Invalid };                   // [[Type]]
+    Unicode::Style m_style { Unicode::Style::Long }; // [[Style]]
 };
 
 using Placeables = HashMap<StringView, Variant<PatternPartition, Vector<PatternPartition>>>;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -10,7 +10,6 @@
 #include <LibJS/Runtime/Intl/NumberFormat.h>
 #include <LibJS/Runtime/Intl/NumberFormatFunction.h>
 #include <LibUnicode/CurrencyCode.h>
-#include <LibUnicode/Locale.h>
 #include <math.h>
 #include <stdlib.h>
 
@@ -140,34 +139,6 @@ StringView NumberFormat::currency_sign_string() const
         return "standard"sv;
     case CurrencySign::Accounting:
         return "accounting"sv;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
-void NumberFormat::set_unit_display(StringView unit_display)
-{
-    if (unit_display == "short"sv)
-        m_unit_display = UnitDisplay::Short;
-    else if (unit_display == "narrow"sv)
-        m_unit_display = UnitDisplay::Narrow;
-    else if (unit_display == "long"sv)
-        m_unit_display = UnitDisplay::Long;
-    else
-        VERIFY_NOT_REACHED();
-}
-
-StringView NumberFormat::unit_display_string() const
-{
-    VERIFY(m_unit_display.has_value());
-
-    switch (*m_unit_display) {
-    case UnitDisplay::Short:
-        return "short"sv;
-    case UnitDisplay::Narrow:
-        return "narrow"sv;
-    case UnitDisplay::Long:
-        return "long"sv;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -1293,20 +1264,7 @@ Optional<Variant<StringView, String>> get_number_format_pattern(NumberFormat& nu
         //     i. Let unit be "fallback".
         // e. Let patterns be patterns.[[<unit>]].
         // f. Let patterns be patterns.[[<unitDisplay>]].
-        Vector<Unicode::NumberFormat> formats;
-
-        switch (number_format.unit_display()) {
-        case NumberFormat::UnitDisplay::Long:
-            formats = Unicode::get_unit_formats(number_format.data_locale(), number_format.unit(), Unicode::Style::Long);
-            break;
-        case NumberFormat::UnitDisplay::Short:
-            formats = Unicode::get_unit_formats(number_format.data_locale(), number_format.unit(), Unicode::Style::Short);
-            break;
-        case NumberFormat::UnitDisplay::Narrow:
-            formats = Unicode::get_unit_formats(number_format.data_locale(), number_format.unit(), Unicode::Style::Narrow);
-            break;
-        }
-
+        auto formats = Unicode::get_unit_formats(number_format.data_locale(), number_format.unit(), number_format.unit_display());
         patterns = Unicode::select_pattern_with_plurality(formats, number);
         break;
     }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -11,6 +11,7 @@
 #include <AK/String.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibUnicode/Locale.h>
 #include <LibUnicode/NumberFormat.h>
 
 namespace JS::Intl {
@@ -37,12 +38,6 @@ public:
     enum class CurrencySign {
         Standard,
         Accounting,
-    };
-
-    enum class UnitDisplay {
-        Short,
-        Narrow,
-        Long,
     };
 
     enum class RoundingType {
@@ -116,9 +111,9 @@ public:
     void set_unit(String unit) { m_unit = move(unit); }
 
     bool has_unit_display() const { return m_unit_display.has_value(); }
-    UnitDisplay unit_display() const { return *m_unit_display; }
-    StringView unit_display_string() const;
-    void set_unit_display(StringView unit_display);
+    Unicode::Style unit_display() const { return *m_unit_display; }
+    StringView unit_display_string() const { return Unicode::style_to_string(*m_unit_display); }
+    void set_unit_display(StringView unit_display) { m_unit_display = Unicode::style_from_string(unit_display); }
 
     int min_integer_digits() const { return m_min_integer_digits; }
     void set_min_integer_digits(int min_integer_digits) { m_min_integer_digits = min_integer_digits; }
@@ -177,7 +172,7 @@ private:
     Optional<CurrencyDisplay> m_currency_display {};        // [[CurrencyDisplay]]
     Optional<CurrencySign> m_currency_sign {};              // [[CurrencySign]]
     Optional<String> m_unit {};                             // [[Unit]]
-    Optional<UnitDisplay> m_unit_display {};                // [[UnitDisplay]]
+    Optional<Unicode::Style> m_unit_display {};             // [[UnitDisplay]]
     int m_min_integer_digits { 0 };                         // [[MinimumIntegerDigits]]
     Optional<int> m_min_fraction_digits {};                 // [[MinimumFractionDigits]]
     Optional<int> m_max_fraction_digits {};                 // [[MaximumFractionDigits]]

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
+
+namespace JS::Intl {
+
+// 17 RelativeTimeFormat Objects, https://tc39.es/ecma402/#relativetimeformat-objects
+RelativeTimeFormat::RelativeTimeFormat(Object& prototype)
+    : Object(prototype)
+{
+}
+
+void RelativeTimeFormat::visit_edges(Cell::Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    if (m_number_format)
+        visitor.visit(m_number_format);
+}
+
+void RelativeTimeFormat::set_numeric(StringView numeric)
+{
+    if (numeric == "always"sv) {
+        m_numeric = Numeric::Always;
+    } else if (numeric == "auto"sv) {
+        m_numeric = Numeric::Auto;
+    } else {
+        VERIFY_NOT_REACHED();
+    }
+}
+
+StringView RelativeTimeFormat::numeric_string() const
+{
+    switch (m_numeric) {
+    case Numeric::Always:
+        return "always"sv;
+    case Numeric::Auto:
+        return "auto"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/AbstractOperations.h>
+#include <LibJS/Runtime/Intl/NumberFormat.h>
+#include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
 
 namespace JS::Intl {
@@ -42,6 +47,81 @@ StringView RelativeTimeFormat::numeric_string() const
     default:
         VERIFY_NOT_REACHED();
     }
+}
+
+ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, Value locales_value, Value options_value)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = TRY(canonicalize_locale_list(global_object, locales_value));
+
+    // 2. Set options to ? CoerceOptionsToObject(options).
+    auto* options = TRY(coerce_options_to_object(global_object, options_value));
+
+    // 3. Let opt be a new Record.
+    LocaleOptions opt {};
+
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    auto matcher = TRY(get_option(global_object, *options, vm.names.localeMatcher, Value::Type::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
+
+    // 5. Set opt.[[LocaleMatcher]] to matcher.
+    opt.locale_matcher = matcher;
+
+    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    auto numbering_system = TRY(get_option(global_object, *options, vm.names.numberingSystem, Value::Type::String, {}, Empty {}));
+
+    // 7. If numberingSystem is not undefined, then
+    if (!numbering_system.is_undefined()) {
+        // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
+        if (!Unicode::is_type_identifier(numbering_system.as_string().string()))
+            return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
+
+        // 8. Set opt.[[nu]] to numberingSystem.
+        opt.nu = numbering_system.as_string().string();
+    }
+
+    // 9. Let localeData be %RelativeTimeFormat%.[[LocaleData]].
+    // 10. Let r be ResolveLocale(%RelativeTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %RelativeTimeFormat%.[[RelevantExtensionKeys]], localeData).
+    auto result = resolve_locale(requested_locales, opt, RelativeTimeFormat::relevant_extension_keys());
+
+    // 11. Let locale be r.[[locale]].
+    auto locale = move(result.locale);
+
+    // 12. Set relativeTimeFormat.[[Locale]] to locale.
+    relative_time_format.set_locale(locale);
+
+    // 13. Set relativeTimeFormat.[[DataLocale]] to r.[[dataLocale]].
+    relative_time_format.set_data_locale(move(result.data_locale));
+
+    // 14. Set relativeTimeFormat.[[NumberingSystem]] to r.[[nu]].
+    if (result.nu.has_value())
+        relative_time_format.set_numbering_system(result.nu.release_value());
+
+    // 15. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow" », "long").
+    auto style = TRY(get_option(global_object, *options, vm.names.style, Value::Type::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));
+
+    // 16. Set relativeTimeFormat.[[Style]] to style.
+    relative_time_format.set_style(style.as_string().string());
+
+    // 17. Let numeric be ? GetOption(options, "numeric", "string", « "always", "auto" », "always").
+    auto numeric = TRY(get_option(global_object, *options, vm.names.numeric, Value::Type::String, { "always"sv, "auto"sv }, "always"sv));
+
+    // 18. Set relativeTimeFormat.[[Numeric]] to numeric.
+    relative_time_format.set_numeric(numeric.as_string().string());
+
+    MarkedValueList arguments { vm.heap() };
+    arguments.append(js_string(vm, locale));
+
+    // 19. Let relativeTimeFormat.[[NumberFormat]] be ! Construct(%NumberFormat%, « locale »).
+    auto* number_format = MUST(construct(global_object, *global_object.intl_number_format_constructor(), move(arguments)));
+    relative_time_format.set_number_format(static_cast<NumberFormat*>(number_format));
+
+    // 20. Let relativeTimeFormat.[[PluralRules]] be ! Construct(%PluralRules%, « locale »).
+    // FIXME: We do not yet support Intl.PluralRules.
+
+    // 21. Return relativeTimeFormat.
+    return &relative_time_format;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibUnicode/Locale.h>
+
+namespace JS::Intl {
+
+class RelativeTimeFormat final : public Object {
+    JS_OBJECT(RelativeTimeFormat, Object);
+
+public:
+    enum class Numeric {
+        Always,
+        Auto,
+    };
+
+    static constexpr auto relevant_extension_keys()
+    {
+        // 17.3.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat-internal-slots
+        // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
+        return AK::Array { "nu"sv };
+    }
+
+    RelativeTimeFormat(Object& prototype);
+    virtual ~RelativeTimeFormat() override = default;
+
+    String const& locale() const { return m_locale; }
+    void set_locale(String locale) { m_locale = move(locale); }
+
+    String const& data_locale() const { return m_data_locale; }
+    void set_data_locale(String data_locale) { m_data_locale = move(data_locale); }
+
+    String const& numbering_system() const { return m_numbering_system; }
+    void set_numbering_system(String numbering_system) { m_numbering_system = move(numbering_system); }
+
+    Unicode::Style style() const { return m_style; }
+    void set_style(StringView style) { m_style = Unicode::style_from_string(style); }
+    StringView style_string() const { return Unicode::style_to_string(m_style); }
+
+    Numeric numeric() const { return m_numeric; }
+    void set_numeric(StringView numeric);
+    StringView numeric_string() const;
+
+    NumberFormat* number_format() const { return m_number_format; }
+    void set_number_format(NumberFormat* number_format) { m_number_format = number_format; }
+
+private:
+    virtual void visit_edges(Cell::Visitor&) override;
+
+    String m_locale;                                 // [[Locale]]
+    String m_data_locale;                            // [[DataLocale]]
+    String m_numbering_system;                       // [[NumberingSystem]]
+    Unicode::Style m_style { Unicode::Style::Long }; // [[Style]]
+    Numeric m_numeric { Numeric::Always };           // [[Numeric]]
+    NumberFormat* m_number_format { nullptr };       // [[NumberFormat]]
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibUnicode/Locale.h>
 
@@ -63,5 +64,7 @@ private:
     Numeric m_numeric { Numeric::Always };           // [[Numeric]]
     NumberFormat* m_number_format { nullptr };       // [[NumberFormat]]
 };
+
+ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, Value locales_value, Value options_value);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -38,13 +38,17 @@ ThrowCompletionOr<Value> RelativeTimeFormatConstructor::call()
 // 17.2.1 Intl.RelativeTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
 ThrowCompletionOr<Object*> RelativeTimeFormatConstructor::construct(FunctionObject& new_target)
 {
+    auto& vm = this->vm();
     auto& global_object = this->global_object();
+
+    auto locales = vm.argument(0);
+    auto options = vm.argument(1);
 
     // 2. Let relativeTimeFormat be ? OrdinaryCreateFromConstructor(NewTarget, "%RelativeTimeFormat.prototype%", « [[InitializedRelativeTimeFormat]], [[Locale]], [[DataLocale]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] »).
     auto* relative_time_format = TRY(ordinary_create_from_constructor<RelativeTimeFormat>(global_object, new_target, &GlobalObject::intl_relative_time_format_prototype));
 
     // 3. Return ? InitializeRelativeTimeFormat(relativeTimeFormat, locales, options).
-    return relative_time_format;
+    return TRY(initialize_relative_time_format(global_object, *relative_time_format, locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -5,7 +5,9 @@
  */
 
 #include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h>
 
@@ -26,6 +28,9 @@ void RelativeTimeFormatConstructor::initialize(GlobalObject& global_object)
     // 17.3.1 Intl.RelativeTimeFormat.prototype, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype
     define_direct_property(vm.names.prototype, global_object.intl_relative_time_format_prototype(), 0);
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
+
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.supportedLocalesOf, supported_locales_of, 1, attr);
 }
 
 // 17.2.1 Intl.RelativeTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
@@ -49,6 +54,21 @@ ThrowCompletionOr<Object*> RelativeTimeFormatConstructor::construct(FunctionObje
 
     // 3. Return ? InitializeRelativeTimeFormat(relativeTimeFormat, locales, options).
     return TRY(initialize_relative_time_format(global_object, *relative_time_format, locales, options));
+}
+
+// 17.3.2 Intl.RelativeTimeFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.supportedLocalesOf
+JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatConstructor::supported_locales_of)
+{
+    auto locales = vm.argument(0);
+    auto options = vm.argument(1);
+
+    // 1. Let availableLocales be %RelativeTimeFormat%.[[AvailableLocales]].
+
+    // 2. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = TRY(canonicalize_locale_list(global_object, locales));
+
+    // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
+    return TRY(supported_locales(global_object, requested_locales, options));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
+#include <LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h>
+
+namespace JS::Intl {
+
+// 17.2 The Intl.RelativeTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor
+RelativeTimeFormatConstructor::RelativeTimeFormatConstructor(GlobalObject& global_object)
+    : NativeFunction(vm().names.RelativeTimeFormat.as_string(), *global_object.function_prototype())
+{
+}
+
+void RelativeTimeFormatConstructor::initialize(GlobalObject& global_object)
+{
+    NativeFunction::initialize(global_object);
+
+    auto& vm = this->vm();
+
+    // 17.3.1 Intl.RelativeTimeFormat.prototype, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype
+    define_direct_property(vm.names.prototype, global_object.intl_relative_time_format_prototype(), 0);
+    define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
+}
+
+// 17.2.1 Intl.RelativeTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
+ThrowCompletionOr<Value> RelativeTimeFormatConstructor::call()
+{
+    // 1. If NewTarget is undefined, throw a TypeError exception.
+    return vm().throw_completion<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Intl.RelativeTimeFormat");
+}
+
+// 17.2.1 Intl.RelativeTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
+ThrowCompletionOr<Object*> RelativeTimeFormatConstructor::construct(FunctionObject& new_target)
+{
+    auto& global_object = this->global_object();
+
+    // 2. Let relativeTimeFormat be ? OrdinaryCreateFromConstructor(NewTarget, "%RelativeTimeFormat.prototype%", « [[InitializedRelativeTimeFormat]], [[Locale]], [[DataLocale]], [[Style]], [[Numeric]], [[NumberFormat]], [[NumberingSystem]], [[PluralRules]] »).
+    auto* relative_time_format = TRY(ordinary_create_from_constructor<RelativeTimeFormat>(global_object, new_target, &GlobalObject::intl_relative_time_format_prototype));
+
+    // 3. Return ? InitializeRelativeTimeFormat(relativeTimeFormat, locales, options).
+    return relative_time_format;
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
@@ -23,6 +23,8 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
+
+    JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS::Intl {
+
+class RelativeTimeFormatConstructor final : public NativeFunction {
+    JS_OBJECT(RelativeTimeFormatConstructor, NativeFunction);
+
+public:
+    explicit RelativeTimeFormatConstructor(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~RelativeTimeFormatConstructor() override = default;
+
+    virtual ThrowCompletionOr<Value> call() override;
+    virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
@@ -23,6 +23,33 @@ void RelativeTimeFormatPrototype::initialize(GlobalObject& global_object)
 
     // 17.4.2 Intl.RelativeTimeFormat.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype-toStringTag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.RelativeTimeFormat"sv), Attribute::Configurable);
+
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
+}
+
+// 17.4.5 Intl.RelativeTimeFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.resolvedoptions
+JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::resolved_options)
+{
+    // 1. Let relativeTimeFormat be the this value.
+    // 2. Perform ? RequireInternalSlot(relativeTimeFormat, [[InitializedRelativeTimeFormat]]).
+    auto* relative_time_format = TRY(typed_this_object(global_object));
+
+    // 3. Let options be ! OrdinaryObjectCreate(%Object.prototype%).
+    auto* options = Object::create(global_object, global_object.object_prototype());
+
+    // 4. For each row of Table 15, except the header row, in table order, do
+    //     a. Let p be the Property value of the current row.
+    //     b. Let v be the value of relativeTimeFormat's internal slot whose name is the Internal Slot value of the current row.
+    //     c. Assert: v is not undefined.
+    //     d. Perform ! CreateDataPropertyOrThrow(options, p, v).
+    MUST(options->create_data_property_or_throw(vm.names.locale, js_string(vm, relative_time_format->locale())));
+    MUST(options->create_data_property_or_throw(vm.names.style, js_string(vm, relative_time_format->style_string())));
+    MUST(options->create_data_property_or_throw(vm.names.numeric, js_string(vm, relative_time_format->numeric_string())));
+    MUST(options->create_data_property_or_throw(vm.names.numberingSystem, js_string(vm, relative_time_format->numbering_system())));
+
+    // 5. Return options.
+    return options;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h>
+
+namespace JS::Intl {
+
+// 17.4 Properties of the Intl.RelativeTimeFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-relativetimeformat-prototype-object
+RelativeTimeFormatPrototype::RelativeTimeFormatPrototype(GlobalObject& global_object)
+    : PrototypeObject(*global_object.object_prototype())
+{
+}
+
+void RelativeTimeFormatPrototype::initialize(GlobalObject& global_object)
+{
+    Object::initialize(global_object);
+
+    auto& vm = this->vm();
+
+    // 17.4.2 Intl.RelativeTimeFormat.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype-toStringTag
+    define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.RelativeTimeFormat"sv), Attribute::Configurable);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, Tim Flynn <trflynn89@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
+#include <LibJS/Runtime/PrototypeObject.h>
+
+namespace JS::Intl {
+
+class RelativeTimeFormatPrototype final : public PrototypeObject<RelativeTimeFormatPrototype, RelativeTimeFormat> {
+    JS_PROTOTYPE_OBJECT(RelativeTimeFormatPrototype, RelativeTimeFormat, Intl.RelativeTimeFormat);
+
+public:
+    explicit RelativeTimeFormatPrototype(GlobalObject&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~RelativeTimeFormatPrototype() override = default;
+};
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.h
@@ -18,6 +18,9 @@ public:
     explicit RelativeTimeFormatPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
     virtual ~RelativeTimeFormatPrototype() override = default;
+
+private:
+    JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DateTimeFormat/DateTimeFormat.prototype.resolvedOptions.js
@@ -4,13 +4,13 @@ describe("correct behavior", () => {
     });
 
     test("locale only contains relevant extension keys", () => {
-        const en1 = Intl.NumberFormat("en-u-ca-islamicc");
+        const en1 = Intl.DateTimeFormat("en-u-co-case");
         expect(en1.resolvedOptions().locale).toBe("en");
 
-        const en2 = Intl.NumberFormat("en-u-nu-latn");
+        const en2 = Intl.DateTimeFormat("en-u-nu-latn");
         expect(en2.resolvedOptions().locale).toBe("en-u-nu-latn");
 
-        const en3 = Intl.NumberFormat("en-u-ca-islamicc-nu-latn");
+        const en3 = Intl.DateTimeFormat("en-u-co-case-nu-latn");
         expect(en3.resolvedOptions().locale).toBe("en-u-nu-latn");
     });
 
@@ -85,7 +85,7 @@ describe("correct behavior", () => {
         });
     });
 
-    test("style", () => {
+    test("timeZone", () => {
         const en = new Intl.DateTimeFormat("en", { timeZone: "EST" });
         expect(en.resolvedOptions().timeZone).toBe("EST");
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.@@toStringTag.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.@@toStringTag.js
@@ -1,0 +1,3 @@
+test("basic functionality", () => {
+    expect(Intl.RelativeTimeFormat.prototype[Symbol.toStringTag]).toBe("Intl.RelativeTimeFormat");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.js
@@ -1,0 +1,16 @@
+describe("errors", () => {
+    test("called without new", () => {
+        expect(() => {
+            Intl.RelativeTimeFormat();
+        }).toThrowWithMessage(
+            TypeError,
+            "Intl.RelativeTimeFormat constructor must be called with 'new'"
+        );
+    });
+});
+
+describe("normal behavior", () => {
+    test("length is 0", () => {
+        expect(Intl.RelativeTimeFormat).toHaveLength(0);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.js
@@ -7,10 +7,90 @@ describe("errors", () => {
             "Intl.RelativeTimeFormat constructor must be called with 'new'"
         );
     });
+
+    test("structurally invalid tag", () => {
+        expect(() => {
+            new Intl.RelativeTimeFormat("root");
+        }).toThrowWithMessage(RangeError, "root is not a structurally valid language tag");
+
+        expect(() => {
+            new Intl.RelativeTimeFormat("en-");
+        }).toThrowWithMessage(RangeError, "en- is not a structurally valid language tag");
+
+        expect(() => {
+            new Intl.RelativeTimeFormat("Latn");
+        }).toThrowWithMessage(RangeError, "Latn is not a structurally valid language tag");
+
+        expect(() => {
+            new Intl.RelativeTimeFormat("en-u-aa-U-aa");
+        }).toThrowWithMessage(RangeError, "en-u-aa-U-aa is not a structurally valid language tag");
+    });
+
+    test("options is an invalid type", () => {
+        expect(() => {
+            new Intl.RelativeTimeFormat("en", null);
+        }).toThrowWithMessage(TypeError, "ToObject on null or undefined");
+    });
+
+    test("localeMatcher option is invalid", () => {
+        expect(() => {
+            new Intl.RelativeTimeFormat("en", { localeMatcher: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option localeMatcher");
+    });
+
+    test("numberingSystem option is invalid", () => {
+        expect(() => {
+            new Intl.RelativeTimeFormat("en", { numberingSystem: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option numberingSystem");
+    });
+
+    test("style option is invalid", () => {
+        expect(() => {
+            new Intl.RelativeTimeFormat("en", { style: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option style");
+    });
+
+    test("numeric option is invalid", () => {
+        expect(() => {
+            new Intl.RelativeTimeFormat("en", { numeric: "hello!" });
+        }).toThrowWithMessage(RangeError, "hello! is not a valid value for option numeric");
+    });
 });
 
 describe("normal behavior", () => {
     test("length is 0", () => {
         expect(Intl.RelativeTimeFormat).toHaveLength(0);
+    });
+
+    test("all valid localeMatcher options", () => {
+        ["lookup", "best fit"].forEach(localeMatcher => {
+            expect(() => {
+                new Intl.RelativeTimeFormat("en", { localeMatcher: localeMatcher });
+            }).not.toThrow();
+        });
+    });
+
+    test("valid numberingSystem options", () => {
+        ["latn", "arab", "abc-def-ghi"].forEach(numberingSystem => {
+            expect(() => {
+                new Intl.RelativeTimeFormat("en", { numberingSystem: numberingSystem });
+            }).not.toThrow();
+        });
+    });
+
+    test("all valid style options", () => {
+        ["long", "short", "narrow"].forEach(style => {
+            expect(() => {
+                new Intl.RelativeTimeFormat("en", { style: style });
+            }).not.toThrow();
+        });
+    });
+
+    test("all valid numeric options", () => {
+        ["always", "auto"].forEach(numeric => {
+            expect(() => {
+                new Intl.RelativeTimeFormat("en", { numeric: numeric });
+            }).not.toThrow();
+        });
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.prototype.resolvedOptions.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.prototype.resolvedOptions.js
@@ -1,0 +1,79 @@
+describe("correct behavior", () => {
+    test("length is 0", () => {
+        expect(Intl.RelativeTimeFormat.prototype.resolvedOptions).toHaveLength(0);
+    });
+
+    test("locale only contains relevant extension keys", () => {
+        const en1 = new Intl.RelativeTimeFormat("en-u-ca-islamicc");
+        expect(en1.resolvedOptions().locale).toBe("en");
+
+        const en2 = new Intl.RelativeTimeFormat("en-u-nu-latn");
+        expect(en2.resolvedOptions().locale).toBe("en-u-nu-latn");
+
+        const en3 = new Intl.RelativeTimeFormat("en-u-ca-islamicc-nu-latn");
+        expect(en3.resolvedOptions().locale).toBe("en-u-nu-latn");
+    });
+
+    test("numberingSystem may be set by option", () => {
+        const en = new Intl.RelativeTimeFormat("en", { numberingSystem: "latn" });
+        expect(en.resolvedOptions().numberingSystem).toBe("latn");
+
+        const el = new Intl.RelativeTimeFormat("el", { numberingSystem: "latn" });
+        expect(el.resolvedOptions().numberingSystem).toBe("latn");
+    });
+
+    test("numberingSystem may be set by locale extension", () => {
+        const en = new Intl.RelativeTimeFormat("en-u-nu-latn");
+        expect(en.resolvedOptions().numberingSystem).toBe("latn");
+
+        const el = new Intl.RelativeTimeFormat("el-u-nu-latn");
+        expect(el.resolvedOptions().numberingSystem).toBe("latn");
+    });
+
+    test("numberingSystem option overrides locale extension", () => {
+        const el = new Intl.RelativeTimeFormat("el-u-nu-latn", { numberingSystem: "grek" });
+        expect(el.resolvedOptions().numberingSystem).toBe("grek");
+    });
+
+    test("numberingSystem option limited to known 'nu' values", () => {
+        ["latn", "arab"].forEach(numberingSystem => {
+            const en = new Intl.RelativeTimeFormat("en", { numberingSystem: numberingSystem });
+            expect(en.resolvedOptions().numberingSystem).toBe("latn");
+        });
+
+        ["latn", "arab"].forEach(numberingSystem => {
+            const en = new Intl.RelativeTimeFormat(`en-u-nu-${numberingSystem}`);
+            expect(en.resolvedOptions().numberingSystem).toBe("latn");
+        });
+
+        ["latn", "grek"].forEach(numberingSystem => {
+            const el = new Intl.RelativeTimeFormat("el", { numberingSystem: numberingSystem });
+            expect(el.resolvedOptions().numberingSystem).toBe(numberingSystem);
+        });
+
+        ["latn", "grek"].forEach(numberingSystem => {
+            const el = new Intl.RelativeTimeFormat(`el-u-nu-${numberingSystem}`);
+            expect(el.resolvedOptions().numberingSystem).toBe(numberingSystem);
+        });
+    });
+
+    test("style", () => {
+        const en1 = new Intl.RelativeTimeFormat("en");
+        expect(en1.resolvedOptions().style).toBe("long");
+
+        ["long", "short", "narrow"].forEach(style => {
+            const en2 = new Intl.RelativeTimeFormat("en", { style: style });
+            expect(en2.resolvedOptions().style).toBe(style);
+        });
+    });
+
+    test("numeric", () => {
+        const en1 = new Intl.RelativeTimeFormat("en");
+        expect(en1.resolvedOptions().numeric).toBe("always");
+
+        ["always", "auto"].forEach(numeric => {
+            const en2 = new Intl.RelativeTimeFormat("en", { numeric: numeric });
+            expect(en2.resolvedOptions().numeric).toBe(numeric);
+        });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.supportedLocalesOf.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/RelativeTimeFormat/RelativeTimeFormat.supportedLocalesOf.js
@@ -1,0 +1,45 @@
+describe("correct behavior", () => {
+    test("length is 1", () => {
+        expect(Intl.RelativeTimeFormat.supportedLocalesOf).toHaveLength(1);
+    });
+
+    test("basic functionality", () => {
+        // prettier-ignore
+        const values = [
+            [[], []],
+            [undefined, []],
+            ["en", ["en"]],
+            [new Intl.Locale("en"), ["en"]],
+            [["en"], ["en"]],
+            [["en", "en-gb", "en-us"], ["en", "en-GB", "en-US"]],
+            [["en", "de", "fr"], ["en", "de", "fr"]],
+            [["en-foobar"], ["en-foobar"]],
+            [["en-foobar-u-abc"], ["en-foobar-u-abc"]],
+            [["aa", "zz"], []],
+            [["en", "aa", "zz"], ["en"]],
+        ];
+        for (const [input, expected] of values) {
+            expect(Intl.RelativeTimeFormat.supportedLocalesOf(input)).toEqual(expected);
+            // "best fit" (implementation defined) just uses the same implementation as "lookup" at the moment
+            expect(
+                Intl.RelativeTimeFormat.supportedLocalesOf(input, { localeMatcher: "best fit" })
+            ).toEqual(
+                Intl.RelativeTimeFormat.supportedLocalesOf(input, { localeMatcher: "lookup" })
+            );
+        }
+    });
+});
+
+describe("errors", () => {
+    test("invalid value for localeMatcher option", () => {
+        expect(() => {
+            Intl.RelativeTimeFormat.supportedLocalesOf([], { localeMatcher: "foo" });
+        }).toThrowWithMessage(RangeError, "foo is not a valid value for option localeMatcher");
+    });
+
+    test("invalid language tag", () => {
+        expect(() => {
+            Intl.RelativeTimeFormat.supportedLocalesOf(["aaaaaaaaa"]);
+        }).toThrowWithMessage(RangeError, "aaaaaaaaa is not a structurally valid language tag");
+    });
+});

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -741,6 +741,31 @@ bool is_locale_available(StringView locale)
     return locale_from_string(locale).has_value();
 }
 
+Style style_from_string(StringView style)
+{
+    if (style == "narrow"sv)
+        return Style::Narrow;
+    if (style == "short"sv)
+        return Style::Short;
+    if (style == "long"sv)
+        return Style::Long;
+    VERIFY_NOT_REACHED();
+}
+
+StringView style_to_string(Style style)
+{
+    switch (style) {
+    case Style::Narrow:
+        return "narrow"sv;
+    case Style::Short:
+        return "short"sv;
+    case Style::Long:
+        return "long"sv;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 Optional<Locale> __attribute__((weak)) locale_from_string(StringView) { return {}; }
 Optional<Language> __attribute__((weak)) language_from_string(StringView) { return {}; }
 Optional<Territory> __attribute__((weak)) territory_from_string(StringView) { return {}; }

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -775,7 +775,6 @@ Optional<CalendarName> __attribute__((weak)) calendar_name_from_string(StringVie
 Optional<DateField> __attribute__((weak)) date_field_from_string(StringView) { return {}; }
 Optional<Key> __attribute__((weak)) key_from_string(StringView) { return {}; }
 Optional<ListPatternType> __attribute__((weak)) list_pattern_type_from_string(StringView) { return {}; }
-Optional<ListPatternStyle> __attribute__((weak)) list_pattern_style_from_string(StringView) { return {}; }
 Optional<DisplayPattern> __attribute__((weak)) get_locale_display_patterns(StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_language_mapping(StringView, StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_locale_territory_mapping(StringView, StringView) { return {}; }
@@ -844,7 +843,7 @@ Vector<StringView> get_locale_key_mapping_list(StringView locale, StringView key
     return {};
 }
 
-Optional<ListPatterns> __attribute__((weak)) get_locale_list_patterns(StringView, StringView, StringView) { return {}; }
+Optional<ListPatterns> __attribute__((weak)) get_locale_list_patterns(StringView, StringView, Style) { return {}; }
 Optional<StringView> __attribute__((weak)) resolve_language_alias(StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) resolve_territory_alias(StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) resolve_script_tag_alias(StringView) { return {}; }

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -145,6 +145,9 @@ Optional<String> canonicalize_unicode_locale_id(LocaleID&);
 String const& default_locale();
 bool is_locale_available(StringView locale);
 
+Style style_from_string(StringView style);
+StringView style_to_string(Style style);
+
 Optional<Locale> locale_from_string(StringView locale);
 Optional<Language> language_from_string(StringView language);
 Optional<Territory> territory_from_string(StringView territory);

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -82,7 +82,6 @@ enum class Style : u8 {
     Long,
     Short,
     Narrow,
-    Numeric,
 };
 
 struct DisplayPattern {

--- a/Userland/Libraries/LibUnicode/Locale.h
+++ b/Userland/Libraries/LibUnicode/Locale.h
@@ -157,7 +157,6 @@ Optional<CalendarName> calendar_name_from_string(StringView calendar);
 Optional<DateField> date_field_from_string(StringView calendar);
 Optional<Key> key_from_string(StringView key);
 Optional<ListPatternType> list_pattern_type_from_string(StringView list_pattern_type);
-Optional<ListPatternStyle> list_pattern_style_from_string(StringView list_pattern_style);
 
 Optional<DisplayPattern> get_locale_display_patterns(StringView locale);
 Optional<String> format_locale_for_display(StringView locale, LocaleID locale_id);
@@ -176,7 +175,7 @@ Optional<StringView> get_locale_narrow_date_field_mapping(StringView locale, Str
 Optional<StringView> get_locale_key_mapping(StringView locale, StringView keyword);
 Vector<StringView> get_locale_key_mapping_list(StringView locale, StringView keyword);
 
-Optional<ListPatterns> get_locale_list_patterns(StringView locale, StringView type, StringView style);
+Optional<ListPatterns> get_locale_list_patterns(StringView locale, StringView type, Style style);
 
 Optional<StringView> resolve_language_alias(StringView language);
 Optional<StringView> resolve_territory_alias(StringView territory);

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -37,6 +37,7 @@
 #include <LibJS/Runtime/Intl/ListFormat.h>
 #include <LibJS/Runtime/Intl/Locale.h>
 #include <LibJS/Runtime/Intl/NumberFormat.h>
+#include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
 #include <LibJS/Runtime/JSONObject.h>
 #include <LibJS/Runtime/Map.h>
 #include <LibJS/Runtime/NativeFunction.h>
@@ -763,6 +764,20 @@ static void print_intl_date_time_format(JS::Object& object, HashTable<JS::Object
     });
 }
 
+static void print_intl_relative_time_format(JS::Object& object, HashTable<JS::Object*>& seen_objects)
+{
+    auto& date_time_format = static_cast<JS::Intl::RelativeTimeFormat&>(object);
+    print_type("Intl.RelativeTimeFormat");
+    js_out("\n  locale: ");
+    print_value(js_string(object.vm(), date_time_format.locale()), seen_objects);
+    js_out("\n  numberingSystem: ");
+    print_value(js_string(object.vm(), date_time_format.numbering_system()), seen_objects);
+    js_out("\n  style: ");
+    print_value(js_string(object.vm(), date_time_format.style_string()), seen_objects);
+    js_out("\n  numeric: ");
+    print_value(js_string(object.vm(), date_time_format.numeric_string()), seen_objects);
+}
+
 static void print_primitive_wrapper_object(FlyString const& name, JS::Object const& object, HashTable<JS::Object*>& seen_objects)
 {
     // BooleanObject, NumberObject, StringObject
@@ -858,6 +873,8 @@ static void print_value(JS::Value value, HashTable<JS::Object*>& seen_objects)
             return print_intl_number_format(object, seen_objects);
         if (is<JS::Intl::DateTimeFormat>(object))
             return print_intl_date_time_format(object, seen_objects);
+        if (is<JS::Intl::RelativeTimeFormat>(object))
+            return print_intl_relative_time_format(object, seen_objects);
         return print_object(object, seen_objects);
     }
 


### PR DESCRIPTION
This implements the constructor and the common Intl methods `supportedLocalesOf` and `resolvedOptions`.

The first few commits remove some silly duplication between LibUnicode and some Intl objects, in order to prevent further duplication in `RelativeTimeFormat`.