### PR TITLE
LibCore+date: Support time zone string formatting, and use it in `date`

### DIFF
--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -105,6 +105,23 @@ String DateTime::to_string(const String& format) const
     StringBuilder builder;
     const int format_len = format.length();
 
+    auto format_time_zone_offset = [&]() {
+        auto offset_seconds = -timezone;
+        StringView offset_sign;
+
+        if (offset_seconds >= 0) {
+            offset_sign = "+"sv;
+        } else {
+            offset_sign = "-"sv;
+            offset_seconds *= -1;
+        }
+
+        auto offset_hours = offset_seconds / 3600;
+        auto offset_minutes = (offset_seconds % 3600) / 60;
+
+        builder.appendff("{}{:02}{:02}", offset_sign, offset_hours, offset_minutes);
+    };
+
     for (int i = 0; i < format_len; ++i) {
         if (format[i] != '%') {
             builder.append(format[i]);
@@ -216,6 +233,9 @@ String DateTime::to_string(const String& format) const
                 break;
             case 'Y':
                 builder.appendff("{}", tm.tm_year + 1900);
+                break;
+            case 'z':
+                format_time_zone_offset();
                 break;
             case '%':
                 builder.append('%');

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -105,7 +105,7 @@ String DateTime::to_string(const String& format) const
     StringBuilder builder;
     const int format_len = format.length();
 
-    auto format_time_zone_offset = [&]() {
+    auto format_time_zone_offset = [&](bool with_separator) {
         auto offset_seconds = -timezone;
         StringView offset_sign;
 
@@ -118,8 +118,9 @@ String DateTime::to_string(const String& format) const
 
         auto offset_hours = offset_seconds / 3600;
         auto offset_minutes = (offset_seconds % 3600) / 60;
+        auto separator = with_separator ? ":"sv : ""sv;
 
-        builder.appendff("{}{:02}{:02}", offset_sign, offset_hours, offset_minutes);
+        builder.appendff("{}{:02}{}{:02}", offset_sign, offset_hours, separator, offset_minutes);
     };
 
     for (int i = 0; i < format_len; ++i) {
@@ -235,7 +236,15 @@ String DateTime::to_string(const String& format) const
                 builder.appendff("{}", tm.tm_year + 1900);
                 break;
             case 'z':
-                format_time_zone_offset();
+                format_time_zone_offset(false);
+                break;
+            case ':':
+                if (++i == format_len)
+                    return String::empty();
+                if (format[i] != 'z')
+                    return String::empty();
+
+                format_time_zone_offset(true);
                 break;
             case '%':
                 builder.append('%');

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -246,6 +246,9 @@ String DateTime::to_string(const String& format) const
 
                 format_time_zone_offset(true);
                 break;
+            case 'Z':
+                builder.append(tzname[0]);
+                break;
             case '%':
                 builder.append('%');
                 break;

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -30,7 +30,7 @@ public:
     bool is_leap_year() const;
 
     void set_time(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
-    String to_string(const String& format = "%Y-%m-%d %H:%M:%S") const;
+    String to_string(const String& format = "%Y-%m-%d %H:%M:%S %Z") const;
 
     static DateTime create(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
     static DateTime now();

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -56,11 +56,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (print_unix_date) {
         outln("{}", date.timestamp());
     } else if (print_iso_8601) {
-        outln("{}", date.to_string("%Y-%m-%dT%H:%M:%S-00:00"));
+        outln("{}", date.to_string("%Y-%m-%dT%H:%M:%S%:z"));
     } else if (print_rfc_5322) {
-        outln("{}", date.to_string("%a, %d %b %Y %H:%M:%S -0000"));
+        outln("{}", date.to_string("%a, %d %b %Y %H:%M:%S %z"));
     } else if (print_rfc_3339) {
-        outln("{}", date.to_string("%Y-%m-%d %H:%M:%S-00:00"));
+        outln("{}", date.to_string("%Y-%m-%d %H:%M:%S%:z"));
     } else {
         outln("{}", date.to_string());
     }


### PR DESCRIPTION
![tz](https://user-images.githubusercontent.com/5600524/151060739-fe36a639-a406-4afb-80c5-f911b9ab58c1.png)
