### PR TITLE
Kernel: Implement Page Attribute Table (PAT) support and Write-Combine

### DIFF
--- a/Kernel/Arch/x86/CPUID.h
+++ b/Kernel/Arch/x86/CPUID.h
@@ -58,6 +58,7 @@ enum class CPUFeature : u32 {
     FXSR = (1 << 23),
     LM = (1 << 24),
     HYPERVISOR = (1 << 25),
+    PAT = (1 << 26),
 };
 
 }

--- a/Kernel/Arch/x86/PageDirectory.h
+++ b/Kernel/Arch/x86/PageDirectory.h
@@ -95,6 +95,7 @@ public:
         UserSupervisor = 1 << 2,
         WriteThrough = 1 << 3,
         CacheDisabled = 1 << 4,
+        PAT = 1 << 7,
         Global = 1 << 8,
         NoExecute = 0x8000000000000000ULL,
     };
@@ -119,6 +120,9 @@ public:
 
     bool is_execute_disabled() const { return (raw() & NoExecute) == NoExecute; }
     void set_execute_disabled(bool b) { set_bit(NoExecute, b); }
+
+    bool is_pat() const { return (raw() & PAT) == PAT; }
+    void set_pat(bool b) { set_bit(PAT, b); }
 
     bool is_null() const { return m_raw == 0; }
     void clear() { m_raw = 0; }

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -39,6 +39,7 @@ struct ProcessorMessageEntry;
 #    define MSR_GS_BASE 0xc0000101
 #endif
 #define MSR_IA32_EFER 0xc0000080
+#define MSR_IA32_PAT 0x277
 
 // FIXME: Find a better place for these
 extern "C" void thread_context_first_enter(void);

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -59,6 +59,8 @@ ErrorOr<Memory::Region*> FramebufferDevice::mmap(Process& process, OpenFileDescr
         "Framebuffer",
         prot,
         shared));
+    if (auto result = m_userspace_framebuffer_region->set_write_combine(true); result.is_error())
+        dbgln("FramebufferDevice: Failed to enable Write-Combine on Framebuffer: {}", result.error());
     return m_userspace_framebuffer_region;
 }
 

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -87,6 +87,9 @@ public:
     [[nodiscard]] bool is_mmap() const { return m_mmap; }
     void set_mmap(bool mmap) { m_mmap = mmap; }
 
+    [[nodiscard]] bool is_write_combine() const { return m_write_combine; }
+    ErrorOr<void> set_write_combine(bool);
+
     [[nodiscard]] bool is_user() const { return !is_kernel(); }
     [[nodiscard]] bool is_kernel() const { return vaddr().get() < USER_RANGE_BASE || vaddr().get() >= kernel_mapping_base; }
 
@@ -220,6 +223,7 @@ private:
     bool m_stack : 1 { false };
     bool m_mmap : 1 { false };
     bool m_syscall_region : 1 { false };
+    bool m_write_combine : 1 { false };
 
     IntrusiveRedBlackTreeNode<FlatPtr, Region, RawPtr<Region>> m_tree_node;
     IntrusiveListNode<Region> m_vmobject_list_node;


### PR DESCRIPTION
This allows us to enable Write-Combine on e.g. framebuffers,
significantly improving performance on bare metal.

To keep things simple we right now only use one of up to three bits
(bit 7 in the PTE), which maps to the PA4 entry in the PAT MSR, which
we set to the Write-Combine mode on each CPU at boot time.

@IdanHo 