### PR TITLE
Kernel: Add tracing to help catch thread blocking with incorrect state

### DIFF
--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -166,6 +166,7 @@ void Thread::block(Kernel::Mutex& lock, SpinlockLocker<Spinlock>& lock_lock, u32
         VERIFY(m_blocker == nullptr);
         break;
     default:
+        dbgln("Error: Attempting to block with invalid thread state - {}", state_string());
         VERIFY_NOT_REACHED();
     }
 
@@ -1319,7 +1320,6 @@ void Thread::track_lock_release(LockRank rank)
 
     m_lock_rank_mask ^= rank;
 }
-
 }
 
 ErrorOr<void> AK::Formatter<Kernel::Thread>::format(FormatBuilder& builder, Kernel::Thread const& value)


### PR DESCRIPTION
A number of crashes in this `VERIFY_NOT_REACHED` case have been
reported on discord. Lets add some tracing to gather more information
and help diagnose what is the cause of these crashes.