### PR TITLE
LibDebug+Everywhere: Avoid void* -> FlatPtr -> void* dance / Use ByteReader for unaligned reads

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -153,7 +153,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Vector<String> memory_regions;
     coredump->for_each_memory_region_info([&](auto& memory_region_info) {
-        memory_regions.append(String::formatted("{:p} - {:p}: {}", memory_region_info.region_start, memory_region_info.region_end, (const char*)memory_region_info.region_name));
+        memory_regions.append(String::formatted("{:p} - {:p}: {}", memory_region_info.region_start, memory_region_info.region_end, memory_region_info.region_name));
         return IterationDecision::Continue;
     });
 

--- a/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
@@ -113,7 +113,7 @@ RefPtr<GUI::Menu> DebugInfoWidget::get_context_menu_for_variable(const GUI::Mode
         }));
     }
 
-    auto variable_address = (FlatPtr*)variable->location_data.address;
+    auto variable_address = variable->location_data.address;
     if (Debugger::the().session()->watchpoint_exists(variable_address)) {
         context_menu->add_action(GUI::Action::create("Remove watchpoint", [variable_address](auto&) {
             Debugger::the().session()->remove_watchpoint(variable_address);

--- a/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/Debugger.cpp
@@ -69,10 +69,10 @@ void Debugger::on_breakpoint_change(const String& file, size_t line, BreakpointC
     }
 
     if (change_type == BreakpointChange::Added) {
-        bool success = session->insert_breakpoint(reinterpret_cast<void*>(address.value().address));
+        bool success = session->insert_breakpoint(address.value().address);
         VERIFY(success);
     } else {
-        bool success = session->remove_breakpoint(reinterpret_cast<void*>(address.value().address));
+        bool success = session->remove_breakpoint(address.value().address);
         VERIFY(success);
     }
 }
@@ -125,7 +125,7 @@ void Debugger::start()
         dbgln("inserting breakpoint at: {}:{}", breakpoint.file_path, breakpoint.line_number);
         auto address = m_debug_session->get_address_from_source_position(breakpoint.file_path, breakpoint.line_number);
         if (address.has_value()) {
-            bool success = m_debug_session->insert_breakpoint(reinterpret_cast<void*>(address.value().address));
+            bool success = m_debug_session->insert_breakpoint(address.value().address);
             VERIFY(success);
         } else {
             dbgln("couldn't insert breakpoint");
@@ -227,8 +227,8 @@ bool Debugger::DebuggingState::should_stop_single_stepping(const Debug::DebugInf
 void Debugger::remove_temporary_breakpoints()
 {
     for (auto breakpoint_address : m_state.temporary_breakpoints()) {
-        VERIFY(m_debug_session->breakpoint_exists((void*)breakpoint_address));
-        bool rc = m_debug_session->remove_breakpoint((void*)breakpoint_address);
+        VERIFY(m_debug_session->breakpoint_exists(breakpoint_address));
+        bool rc = m_debug_session->remove_breakpoint(breakpoint_address);
         VERIFY(rc);
     }
     m_state.clear_temporary_breakpoints();
@@ -281,9 +281,9 @@ void Debugger::insert_temporary_breakpoint_at_return_address(const PtraceRegiste
 
 void Debugger::insert_temporary_breakpoint(FlatPtr address)
 {
-    if (m_debug_session->breakpoint_exists((void*)address))
+    if (m_debug_session->breakpoint_exists(address))
         return;
-    bool success = m_debug_session->insert_breakpoint(reinterpret_cast<void*>(address));
+    bool success = m_debug_session->insert_breakpoint(address);
     VERIFY(success);
     m_state.add_temporary_breakpoint(address);
 }

--- a/Userland/DevTools/HackStudio/Debugger/DebuggerGlobalJSObject.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebuggerGlobalJSObject.cpp
@@ -53,7 +53,7 @@ JS::ThrowCompletionOr<bool> DebuggerGlobalJSObject::internal_set(JS::PropertyKey
     auto& target_variable = **it;
     auto debugger_value = js_to_debugger(value, target_variable);
     if (debugger_value.has_value())
-        return Debugger::the().session()->poke((u32*)target_variable.location_data.address, debugger_value.value());
+        return Debugger::the().session()->poke(target_variable.location_data.address, debugger_value.value());
     auto error_string = String::formatted("Cannot convert JS value {} to variable {} of type {}", value.to_string_without_side_effects(), property_name.as_string(), target_variable.type_name);
     return vm().throw_completion<JS::TypeError>(const_cast<DebuggerGlobalJSObject&>(*this), move(error_string));
 }
@@ -66,19 +66,19 @@ Optional<JS::Value> DebuggerGlobalJSObject::debugger_to_js(const Debug::DebugInf
     auto variable_address = variable.location_data.address;
 
     if (variable.is_enum_type() || variable.type_name == "int") {
-        auto value = Debugger::the().session()->peek((u32*)variable_address);
+        auto value = Debugger::the().session()->peek(variable_address);
         VERIFY(value.has_value());
         return JS::Value((i32)value.value());
     }
 
     if (variable.type_name == "char") {
-        auto value = Debugger::the().session()->peek((u32*)variable_address);
+        auto value = Debugger::the().session()->peek(variable_address);
         VERIFY(value.has_value());
         return JS::Value((char)value.value());
     }
 
     if (variable.type_name == "bool") {
-        auto value = Debugger::the().session()->peek((u32*)variable_address);
+        auto value = Debugger::the().session()->peek(variable_address);
         VERIFY(value.has_value());
         return JS::Value(value.value() != 0);
     }

--- a/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.cpp
@@ -49,7 +49,7 @@ JS::ThrowCompletionOr<bool> DebuggerVariableJSObject::internal_set(const JS::Pro
     if (!new_value.has_value())
         return vm.throw_completion<JS::TypeError>(global_object(), String::formatted("Cannot convert JS value {} to variable {} of type {}", value.to_string_without_side_effects(), name, member.type_name));
 
-    Debugger::the().session()->poke((u32*)member.location_data.address, new_value.value());
+    Debugger::the().session()->poke(member.location_data.address, new_value.value());
     return true;
 }
 

--- a/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/VariablesModel.cpp
@@ -63,7 +63,7 @@ static String variable_value_as_string(const Debug::DebugInfo::VariableInfo& var
     auto variable_address = variable.location_data.address;
 
     if (variable.is_enum_type()) {
-        auto value = Debugger::the().session()->peek((u32*)variable_address);
+        auto value = Debugger::the().session()->peek(variable_address);
         VERIFY(value.has_value());
         auto it = variable.type->members.find_if([&enumerator_value = value.value()](const auto& enumerator) {
             return enumerator->constant_data.as_u32 == enumerator_value;
@@ -74,19 +74,19 @@ static String variable_value_as_string(const Debug::DebugInfo::VariableInfo& var
     }
 
     if (variable.type_name == "int") {
-        auto value = Debugger::the().session()->peek((u32*)variable_address);
+        auto value = Debugger::the().session()->peek(variable_address);
         VERIFY(value.has_value());
         return String::formatted("{}", static_cast<int>(value.value()));
     }
 
     if (variable.type_name == "char") {
-        auto value = Debugger::the().session()->peek((u32*)variable_address);
+        auto value = Debugger::the().session()->peek(variable_address);
         VERIFY(value.has_value());
         return String::formatted("'{0:c}'", (char)value.value());
     }
 
     if (variable.type_name == "bool") {
-        auto value = Debugger::the().session()->peek((u32*)variable_address);
+        auto value = Debugger::the().session()->peek(variable_address);
         VERIFY(value.has_value());
         return (value.value() & 1) ? "true" : "false";
     }
@@ -136,7 +136,7 @@ void VariablesModel::set_variable_value(const GUI::ModelIndex& index, StringView
     auto value = string_to_variable_value(string_value, *variable);
 
     if (value.has_value()) {
-        auto success = Debugger::the().session()->poke((u32*)variable->location_data.address, value.value());
+        auto success = Debugger::the().session()->poke(variable->location_data.address, value.value());
         VERIFY(success);
         return;
     }

--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -46,32 +46,32 @@ Backtrace::Backtrace(const Reader& coredump, const ELF::Core::ThreadInfo& thread
     : m_thread_info(move(thread_info))
 {
 #if ARCH(I386)
-    auto* start_bp = (FlatPtr*)m_thread_info.regs.ebp;
-    auto* start_ip = (FlatPtr*)m_thread_info.regs.eip;
+    auto start_bp = m_thread_info.regs.ebp;
+    auto start_ip = m_thread_info.regs.eip;
 #else
-    auto* start_bp = (FlatPtr*)m_thread_info.regs.rbp;
-    auto* start_ip = (FlatPtr*)m_thread_info.regs.rip;
+    auto start_bp = m_thread_info.regs.rbp;
+    auto start_ip = m_thread_info.regs.rip;
 #endif
 
     // In order to provide progress updates, we first have to walk the
     // call stack to determine how many frames it has.
     size_t frame_count = 0;
     {
-        auto* bp = start_bp;
-        auto* ip = start_ip;
+        auto bp = start_bp;
+        auto ip = start_ip;
         while (bp && ip) {
             ++frame_count;
-            auto next_ip = coredump.peek_memory((FlatPtr)(bp + 1));
-            auto next_bp = coredump.peek_memory((FlatPtr)(bp));
+            auto next_ip = coredump.peek_memory(bp + sizeof(FlatPtr));
+            auto next_bp = coredump.peek_memory(bp);
             if (!next_ip.has_value() || !next_bp.has_value())
                 break;
-            ip = (FlatPtr*)next_ip.value();
-            bp = (FlatPtr*)next_bp.value();
+            ip = next_ip.value();
+            bp = next_bp.value();
         }
     }
 
-    auto* bp = start_bp;
-    auto* ip = start_ip;
+    auto bp = start_bp;
+    auto ip = start_ip;
     size_t frame_index = 0;
     while (bp && ip) {
         // We use eip - 1 because the return address from a function frame
@@ -79,17 +79,17 @@ Backtrace::Backtrace(const Reader& coredump, const ELF::Core::ThreadInfo& thread
         // However, because the first frame represents the faulting
         // instruction rather than the return address we don't subtract
         // 1 there.
-        VERIFY((FlatPtr)ip > 0);
-        add_entry(coredump, (FlatPtr)ip - ((frame_index == 0) ? 0 : 1));
+        VERIFY(ip > 0);
+        add_entry(coredump, ip - ((frame_index == 0) ? 0 : 1));
         if (on_progress)
             on_progress(frame_index, frame_count);
         ++frame_index;
-        auto next_ip = coredump.peek_memory((FlatPtr)(bp + 1));
-        auto next_bp = coredump.peek_memory((FlatPtr)(bp));
+        auto next_ip = coredump.peek_memory(bp + sizeof(FlatPtr));
+        auto next_bp = coredump.peek_memory(bp);
         if (!next_ip.has_value() || !next_bp.has_value())
             break;
-        ip = (FlatPtr*)next_ip.value();
-        bp = (FlatPtr*)next_bp.value();
+        ip = next_ip.value();
+        bp = next_bp.value();
     }
 }
 
@@ -99,7 +99,7 @@ Backtrace::~Backtrace()
 
 void Backtrace::add_entry(const Reader& coredump, FlatPtr ip)
 {
-    auto* ip_region = coredump.region_containing((FlatPtr)ip);
+    auto* ip_region = coredump.region_containing(ip);
     if (!ip_region) {
         m_entries.append({ ip, {}, {}, {} });
         return;

--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -17,7 +17,7 @@
 
 namespace Coredump {
 
-ELFObjectInfo const* Backtrace::object_info_for_region(ELF::Core::MemoryRegionInfo const& region)
+ELFObjectInfo const* Backtrace::object_info_for_region(MemoryRegionInfo const& region)
 {
     auto path = region.object_name();
     if (!path.starts_with('/') && Core::File::looks_like_shared_library(path))
@@ -99,8 +99,8 @@ Backtrace::~Backtrace()
 
 void Backtrace::add_entry(const Reader& coredump, FlatPtr ip)
 {
-    auto* ip_region = coredump.region_containing(ip);
-    if (!ip_region) {
+    auto ip_region = coredump.region_containing(ip);
+    if (!ip_region.has_value()) {
         m_entries.append({ ip, {}, {}, {} });
         return;
     }
@@ -116,7 +116,7 @@ void Backtrace::add_entry(const Reader& coredump, FlatPtr ip)
     // the PT_LOAD header for the .text segment isn't the first one
     // in the object file.
     auto region = coredump.first_region_for_object(object_name);
-    auto* object_info = object_info_for_region(*region);
+    auto object_info = object_info_for_region(*region);
     if (!object_info)
         return;
 

--- a/Userland/Libraries/LibCoredump/Backtrace.h
+++ b/Userland/Libraries/LibCoredump/Backtrace.h
@@ -45,7 +45,7 @@ public:
 
 private:
     void add_entry(const Reader&, FlatPtr ip);
-    ELFObjectInfo const* object_info_for_region(ELF::Core::MemoryRegionInfo const&);
+    ELFObjectInfo const* object_info_for_region(MemoryRegionInfo const&);
 
     bool m_skip_loader_so { false };
     ELF::Core::ThreadInfo m_thread_info;

--- a/Userland/Libraries/LibCoredump/Inspector.cpp
+++ b/Userland/Libraries/LibCoredump/Inspector.cpp
@@ -51,11 +51,11 @@ void Inspector::parse_loaded_libraries(Function<void(float)> on_progress)
     });
 }
 
-bool Inspector::poke(void*, FlatPtr) { return false; }
+bool Inspector::poke(FlatPtr, FlatPtr) { return false; }
 
-Optional<FlatPtr> Inspector::peek(void* address) const
+Optional<FlatPtr> Inspector::peek(FlatPtr address) const
 {
-    return m_reader->peek_memory((FlatPtr)address);
+    return m_reader->peek_memory(address);
 }
 
 PtraceRegisters Inspector::get_registers() const

--- a/Userland/Libraries/LibCoredump/Inspector.cpp
+++ b/Userland/Libraries/LibCoredump/Inspector.cpp
@@ -39,7 +39,7 @@ void Inspector::parse_loaded_libraries(Function<void(float)> on_progress)
     m_reader->for_each_library([this, number_of_libraries, &library_index, &on_progress](Coredump::Reader::LibraryInfo library) {
         ++library_index;
         if (on_progress)
-            on_progress(library_index / (float)number_of_libraries);
+            on_progress(library_index / static_cast<float>(number_of_libraries));
 
         auto file_or_error = Core::MappedFile::map(library.path);
         if (file_or_error.is_error())

--- a/Userland/Libraries/LibCoredump/Inspector.h
+++ b/Userland/Libraries/LibCoredump/Inspector.h
@@ -21,8 +21,8 @@ public:
     virtual ~Inspector() override = default;
 
     // ^Debug::ProcessInspector
-    virtual bool poke(void* address, FlatPtr data) override;
-    virtual Optional<FlatPtr> peek(void* address) const override;
+    virtual bool poke(FlatPtr address, FlatPtr data) override;
+    virtual Optional<FlatPtr> peek(FlatPtr address) const override;
     virtual PtraceRegisters get_registers() const override;
     virtual void set_registers(PtraceRegisters const&) override;
     virtual void for_each_loaded_library(Function<IterationDecision(Debug::LoadedLibrary const&)>) const override;

--- a/Userland/Libraries/LibCoredump/Reader.cpp
+++ b/Userland/Libraries/LibCoredump/Reader.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/ByteReader.h>
 #include <AK/HashTable.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
@@ -139,8 +140,10 @@ Optional<FlatPtr> Reader::peek_memory(FlatPtr address) const
         return {};
 
     FlatPtr offset_in_region = address - region->region_start;
-    const char* region_data = image().program_header(region->program_header_index).raw_data();
-    return *(const FlatPtr*)(&region_data[offset_in_region]);
+    auto* region_data = bit_cast<const u8*>(image().program_header(region->program_header_index).raw_data());
+    FlatPtr value { 0 };
+    ByteReader::load(region_data + offset_in_region, value);
+    return value;
 }
 
 const JsonObject Reader::process_info() const

--- a/Userland/Libraries/LibCoredump/Reader.h
+++ b/Userland/Libraries/LibCoredump/Reader.h
@@ -100,10 +100,11 @@ private:
 template<typename Func>
 void Reader::for_each_memory_region_info(Func func) const
 {
-    for (NotesEntryIterator it((const u8*)m_coredump_image.program_header(m_notes_segment_index).raw_data()); !it.at_end(); it.next()) {
+    NotesEntryIterator it(bit_cast<const u8*>(m_coredump_image.program_header(m_notes_segment_index).raw_data()));
+    for (; !it.at_end(); it.next()) {
         if (it.type() != ELF::Core::NotesEntryHeader::Type::MemoryRegionInfo)
             continue;
-        auto& memory_region_info = reinterpret_cast<const ELF::Core::MemoryRegionInfo&>(*it.current());
+        auto& memory_region_info = *bit_cast<const ELF::Core::MemoryRegionInfo*>(it.current());
         IterationDecision decision = func(memory_region_info);
         if (decision == IterationDecision::Break)
             return;
@@ -113,10 +114,11 @@ void Reader::for_each_memory_region_info(Func func) const
 template<typename Func>
 void Reader::for_each_thread_info(Func func) const
 {
-    for (NotesEntryIterator it((const u8*)m_coredump_image.program_header(m_notes_segment_index).raw_data()); !it.at_end(); it.next()) {
+    NotesEntryIterator it(bit_cast<const u8*>(m_coredump_image.program_header(m_notes_segment_index).raw_data()));
+    for (; !it.at_end(); it.next()) {
         if (it.type() != ELF::Core::NotesEntryHeader::Type::ThreadInfo)
             continue;
-        auto& thread_info = reinterpret_cast<const ELF::Core::ThreadInfo&>(*it.current());
+        auto& thread_info = *bit_cast<const ELF::Core::ThreadInfo*>(it.current());
         IterationDecision decision = func(thread_info);
         if (decision == IterationDecision::Break)
             return;

--- a/Userland/Libraries/LibCoredump/Reader.h
+++ b/Userland/Libraries/LibCoredump/Reader.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/ByteReader.h>
 #include <AK/HashMap.h>
 #include <AK/Noncopyable.h>
 #include <AK/OwnPtr.h>
@@ -14,6 +15,24 @@
 #include <LibELF/Image.h>
 
 namespace Coredump {
+
+struct MemoryRegionInfo {
+    ELF::Core::NotesEntryHeader header;
+    uint64_t region_start;
+    uint64_t region_end;
+    uint16_t program_header_index;
+    StringView region_name;
+
+    StringView object_name() const
+    {
+        if (region_name.contains("Loader.so"))
+            return "Loader.so"sv;
+        auto maybe_colon_index = region_name.find(':');
+        if (!maybe_colon_index.has_value())
+            return {};
+        return region_name.substring_view(0, *maybe_colon_index);
+    }
+};
 
 class Reader {
     AK_MAKE_NONCOPYABLE(Reader);
@@ -40,8 +59,8 @@ public:
     const ELF::Image& image() const { return m_coredump_image; }
 
     Optional<FlatPtr> peek_memory(FlatPtr address) const;
-    ELF::Core::MemoryRegionInfo const* first_region_for_object(StringView object_name) const;
-    const ELF::Core::MemoryRegionInfo* region_containing(FlatPtr address) const;
+    Optional<MemoryRegionInfo> first_region_for_object(StringView object_name) const;
+    Optional<MemoryRegionInfo> region_containing(FlatPtr address) const;
 
     struct LibraryData {
         String name;
@@ -104,7 +123,20 @@ void Reader::for_each_memory_region_info(Func func) const
     for (; !it.at_end(); it.next()) {
         if (it.type() != ELF::Core::NotesEntryHeader::Type::MemoryRegionInfo)
             continue;
-        auto& memory_region_info = *bit_cast<const ELF::Core::MemoryRegionInfo*>(it.current());
+        ELF::Core::MemoryRegionInfo raw_memory_region_info;
+        ReadonlyBytes raw_data {
+            it.current(),
+            sizeof(raw_memory_region_info),
+        };
+        ByteReader::load(raw_data.data(), raw_memory_region_info);
+
+        MemoryRegionInfo memory_region_info {
+            raw_memory_region_info.header,
+            raw_memory_region_info.region_start,
+            raw_memory_region_info.region_end,
+            raw_memory_region_info.program_header_index,
+            { bit_cast<const char*>(raw_data.offset_pointer(raw_data.size())) },
+        };
         IterationDecision decision = func(memory_region_info);
         if (decision == IterationDecision::Break)
             return;
@@ -118,7 +150,9 @@ void Reader::for_each_thread_info(Func func) const
     for (; !it.at_end(); it.next()) {
         if (it.type() != ELF::Core::NotesEntryHeader::Type::ThreadInfo)
             continue;
-        auto& thread_info = *bit_cast<const ELF::Core::ThreadInfo*>(it.current());
+        ELF::Core::ThreadInfo thread_info;
+        ByteReader::load(bit_cast<const u8*>(it.current()), thread_info);
+
         IterationDecision decision = func(thread_info);
         if (decision == IterationDecision::Break)
             return;

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -80,11 +80,11 @@ OwnPtr<DebugSession> DebugSession::exec_and_attach(String const& command,
 
         auto parts = command.split(' ');
         VERIFY(!parts.is_empty());
-        const char** args = (const char**)calloc(parts.size() + 1, sizeof(const char*));
+        const char** args = bit_cast<const char**>(calloc(parts.size() + 1, sizeof(const char*)));
         for (size_t i = 0; i < parts.size(); i++) {
             args[i] = parts[i].characters();
         }
-        const char** envp = (const char**)calloc(2, sizeof(const char*));
+        const char** envp = bit_cast<const char**>(calloc(2, sizeof(const char*)));
         // This causes loader to stop on a breakpoint before jumping to the entry point of the program.
         envp[0] = "_LOADER_BREAKPOINT=1";
         int rc = execvpe(args[0], const_cast<char**>(args), const_cast<char**>(envp));

--- a/Userland/Libraries/LibDebug/DebugSession.cpp
+++ b/Userland/Libraries/LibDebug/DebugSession.cpp
@@ -129,27 +129,27 @@ OwnPtr<DebugSession> DebugSession::exec_and_attach(String const& command,
     return debug_session;
 }
 
-bool DebugSession::poke(void* address, FlatPtr data)
+bool DebugSession::poke(FlatPtr address, FlatPtr data)
 {
-    if (ptrace(PT_POKE, m_debuggee_pid, (void*)address, (void*)data) < 0) {
+    if (ptrace(PT_POKE, m_debuggee_pid, bit_cast<void*>(address), bit_cast<void*>(data)) < 0) {
         perror("PT_POKE");
         return false;
     }
     return true;
 }
 
-Optional<FlatPtr> DebugSession::peek(void* address) const
+Optional<FlatPtr> DebugSession::peek(FlatPtr address) const
 {
     Optional<FlatPtr> result;
-    auto rc = ptrace(PT_PEEK, m_debuggee_pid, address, nullptr);
+    auto rc = ptrace(PT_PEEK, m_debuggee_pid, bit_cast<void*>(address), nullptr);
     if (errno == 0)
         result = static_cast<FlatPtr>(rc);
     return result;
 }
 
-bool DebugSession::poke_debug(u32 register_index, FlatPtr data)
+bool DebugSession::poke_debug(u32 register_index, FlatPtr data) const
 {
-    if (ptrace(PT_POKEDEBUG, m_debuggee_pid, reinterpret_cast<void*>(register_index), (void*)data) < 0) {
+    if (ptrace(PT_POKEDEBUG, m_debuggee_pid, bit_cast<void*>(static_cast<FlatPtr>(register_index)), bit_cast<void*>(data)) < 0) {
         perror("PT_POKEDEBUG");
         return false;
     }
@@ -158,14 +158,14 @@ bool DebugSession::poke_debug(u32 register_index, FlatPtr data)
 
 Optional<FlatPtr> DebugSession::peek_debug(u32 register_index) const
 {
-    Optional<FlatPtr> result;
-    int rc = ptrace(PT_PEEKDEBUG, m_debuggee_pid, reinterpret_cast<FlatPtr*>(register_index), nullptr);
+    auto rc = ptrace(PT_PEEKDEBUG, m_debuggee_pid, bit_cast<void*>(static_cast<FlatPtr>(register_index)), nullptr);
     if (errno == 0)
-        result = static_cast<FlatPtr>(rc);
-    return result;
+        return static_cast<FlatPtr>(rc);
+
+    return {};
 }
 
-bool DebugSession::insert_breakpoint(void* address)
+bool DebugSession::insert_breakpoint(FlatPtr address)
 {
     // We insert a software breakpoint by
     // patching the first byte of the instruction at 'address'
@@ -174,7 +174,7 @@ bool DebugSession::insert_breakpoint(void* address)
     if (m_breakpoints.contains(address))
         return false;
 
-    auto original_bytes = peek(reinterpret_cast<FlatPtr*>(address));
+    auto original_bytes = peek(address);
 
     if (!original_bytes.has_value())
         return false;
@@ -190,11 +190,11 @@ bool DebugSession::insert_breakpoint(void* address)
     return true;
 }
 
-bool DebugSession::disable_breakpoint(void* address)
+bool DebugSession::disable_breakpoint(FlatPtr address)
 {
     auto breakpoint = m_breakpoints.get(address);
     VERIFY(breakpoint.has_value());
-    if (!poke(reinterpret_cast<FlatPtr*>(reinterpret_cast<char*>(breakpoint.value().address)), breakpoint.value().original_first_word))
+    if (!poke(breakpoint.value().address, breakpoint.value().original_first_word))
         return false;
 
     auto bp = m_breakpoints.get(breakpoint.value().address).value();
@@ -203,14 +203,14 @@ bool DebugSession::disable_breakpoint(void* address)
     return true;
 }
 
-bool DebugSession::enable_breakpoint(void* address)
+bool DebugSession::enable_breakpoint(FlatPtr address)
 {
     auto breakpoint = m_breakpoints.get(address);
     VERIFY(breakpoint.has_value());
 
     VERIFY(breakpoint.value().state == BreakPointState::Disabled);
 
-    if (!poke(reinterpret_cast<FlatPtr*>(breakpoint.value().address), (breakpoint.value().original_first_word & ~(FlatPtr)0xff) | BREAKPOINT_INSTRUCTION))
+    if (!poke(breakpoint.value().address, (breakpoint.value().original_first_word & ~static_cast<FlatPtr>(0xff)) | BREAKPOINT_INSTRUCTION))
         return false;
 
     auto bp = m_breakpoints.get(breakpoint.value().address).value();
@@ -219,7 +219,7 @@ bool DebugSession::enable_breakpoint(void* address)
     return true;
 }
 
-bool DebugSession::remove_breakpoint(void* address)
+bool DebugSession::remove_breakpoint(FlatPtr address)
 {
     if (!disable_breakpoint(address))
         return false;
@@ -228,12 +228,12 @@ bool DebugSession::remove_breakpoint(void* address)
     return true;
 }
 
-bool DebugSession::breakpoint_exists(void* address) const
+bool DebugSession::breakpoint_exists(FlatPtr address) const
 {
     return m_breakpoints.contains(address);
 }
 
-bool DebugSession::insert_watchpoint(void* address, u32 ebp)
+bool DebugSession::insert_watchpoint(FlatPtr address, u32 ebp)
 {
     auto current_register_status = peek_debug(DEBUG_CONTROL_REGISTER);
     if (!current_register_status.has_value())
@@ -250,7 +250,7 @@ bool DebugSession::insert_watchpoint(void* address, u32 ebp)
         return false;
     WatchPoint watchpoint { address, next_available_index, ebp };
 
-    if (!poke_debug(next_available_index, reinterpret_cast<uintptr_t>(address)))
+    if (!poke_debug(next_available_index, bit_cast<FlatPtr>(address)))
         return false;
 
     dr7_value |= (1u << (next_available_index * 2)); // Enable local breakpoint for our index
@@ -268,14 +268,14 @@ bool DebugSession::insert_watchpoint(void* address, u32 ebp)
     return true;
 }
 
-bool DebugSession::remove_watchpoint(void* address)
+bool DebugSession::remove_watchpoint(FlatPtr address)
 {
     if (!disable_watchpoint(address))
         return false;
     return m_watchpoints.remove(address);
 }
 
-bool DebugSession::disable_watchpoint(void* address)
+bool DebugSession::disable_watchpoint(FlatPtr address)
 {
     VERIFY(watchpoint_exists(address));
     auto watchpoint = m_watchpoints.get(address).value();
@@ -291,7 +291,7 @@ bool DebugSession::disable_watchpoint(void* address)
     return true;
 }
 
-bool DebugSession::watchpoint_exists(void* address) const
+bool DebugSession::watchpoint_exists(FlatPtr address) const
 {
     return m_watchpoints.contains(address);
 }
@@ -308,7 +308,7 @@ PtraceRegisters DebugSession::get_registers() const
 
 void DebugSession::set_registers(PtraceRegisters const& regs)
 {
-    if (ptrace(PT_SETREGS, m_debuggee_pid, reinterpret_cast<void*>(&const_cast<PtraceRegisters&>(regs)), 0) < 0) {
+    if (ptrace(PT_SETREGS, m_debuggee_pid, bit_cast<void*>(&regs), 0) < 0) {
         perror("PT_SETREGS");
         VERIFY_NOT_REACHED();
     }
@@ -334,7 +334,7 @@ int DebugSession::continue_debuggee_and_wait(ContinueType type)
     return wstatus;
 }
 
-void* DebugSession::single_step()
+FlatPtr DebugSession::single_step()
 {
     // Single stepping works by setting the x86 TRAP flag bit in the eflags register.
     // This flag causes the cpu to enter single-stepping mode, which causes
@@ -365,7 +365,7 @@ void* DebugSession::single_step()
     regs.rflags &= ~(TRAP_FLAG);
 #endif
     set_registers(regs);
-    return (void*)regs.ip();
+    return regs.ip();
 }
 
 void DebugSession::detach()
@@ -390,8 +390,8 @@ Optional<DebugSession::InsertBreakpointAtSymbolResult> DebugSession::insert_brea
         if (!symbol.has_value())
             return IterationDecision::Continue;
 
-        auto breakpoint_address = symbol.value().value() + lib.base_address;
-        bool rc = this->insert_breakpoint(reinterpret_cast<void*>(breakpoint_address));
+        FlatPtr breakpoint_address = symbol->value() + lib.base_address;
+        bool rc = this->insert_breakpoint(breakpoint_address);
         if (!rc)
             return IterationDecision::Break;
 
@@ -408,7 +408,7 @@ Optional<DebugSession::InsertBreakpointAtSourcePositionResult> DebugSession::ins
         return {};
 
     auto address = address_and_source_position.value().address;
-    bool rc = this->insert_breakpoint(reinterpret_cast<void*>(address));
+    bool rc = this->insert_breakpoint(address);
     if (!rc)
         return {};
 

--- a/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AbbreviationsMap.cpp
@@ -62,7 +62,7 @@ void AbbreviationsMap::populate_map()
             }
         } while (current_attribute_specification.attribute != Attribute::None || current_attribute_specification.form != AttributeDataForm::None);
 
-        m_entries.set((u32)abbreviation_code, move(abbreviation_entry));
+        m_entries.set(static_cast<u32>(abbreviation_code), move(abbreviation_entry));
     }
 }
 

--- a/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/AddressRanges.cpp
@@ -80,7 +80,7 @@ void AddressRangesV5::for_each_range(Function<void(Range)> callback)
         case RangeListEntryType::EndOfList:
             return;
         default:
-            dbgln("unsupported range list entry type: 0x{:x}", (int)entry_type);
+            dbgln("unsupported range list entry type: 0x{:x}", entry_type);
             return;
         }
     }

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -84,7 +84,7 @@ AttributeValue DwarfInfo::get_attribute_value(AttributeDataForm form, ssize_t im
     value.m_compilation_unit = unit;
 
     auto assign_raw_bytes_value = [&](size_t length) {
-        value.m_data.as_raw_bytes = { reinterpret_cast<const u8*>(debug_info_data().data() + debug_info_stream.offset()), length };
+        value.m_data.as_raw_bytes = { debug_info_data().offset_pointer(debug_info_stream.offset()), length };
 
         debug_info_stream.discard_or_error(length);
         VERIFY(!debug_info_stream.has_any_error());
@@ -98,7 +98,7 @@ AttributeValue DwarfInfo::get_attribute_value(AttributeDataForm form, ssize_t im
         value.m_type = AttributeValue::Type::String;
 
         auto strings_data = debug_strings_data();
-        value.m_data.as_string = reinterpret_cast<const char*>(strings_data.data() + offset);
+        value.m_data.as_string = bit_cast<const char*>(strings_data.offset_pointer(offset));
         break;
     }
     case AttributeDataForm::Data1: {
@@ -199,7 +199,7 @@ AttributeValue DwarfInfo::get_attribute_value(AttributeDataForm form, ssize_t im
         debug_info_stream >> str;
         VERIFY(!debug_info_stream.has_any_error());
         value.m_type = AttributeValue::Type::String;
-        value.m_data.as_string = reinterpret_cast<const char*>(str_offset + debug_info_data().data());
+        value.m_data.as_string = bit_cast<const char*>(debug_info_data().offset_pointer(str_offset));
         break;
     }
     case AttributeDataForm::Block1: {
@@ -241,7 +241,7 @@ AttributeValue DwarfInfo::get_attribute_value(AttributeDataForm form, ssize_t im
         value.m_type = AttributeValue::Type::String;
 
         auto strings_data = debug_line_strings_data();
-        value.m_data.as_string = reinterpret_cast<const char*>(strings_data.data() + offset);
+        value.m_data.as_string = bit_cast<const char*>(strings_data.offset_pointer(offset));
         break;
     }
     case AttributeDataForm::ImplicitConst: {
@@ -323,7 +323,7 @@ AttributeValue DwarfInfo::get_attribute_value(AttributeDataForm form, ssize_t im
         break;
     }
     default:
-        dbgln("Unimplemented AttributeDataForm: {}", (u32)form);
+        dbgln("Unimplemented AttributeDataForm: {}", to_underlying(form));
         VERIFY_NOT_REACHED();
     }
     return value;

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfInfo.cpp
@@ -9,6 +9,7 @@
 #include "AttributeValue.h"
 #include "CompilationUnit.h"
 
+#include <AK/ByteReader.h>
 #include <AK/MemoryStream.h>
 #include <LibDebug/DebugInfo.h>
 
@@ -344,8 +345,8 @@ void DwarfInfo::build_cached_dies() const
                 auto index = ranges->as_unsigned();
                 auto base = die.compilation_unit().range_lists_base();
                 // FIXME: This assumes that the format is DWARf32
-                auto offsets = reinterpret_cast<u32 const*>(debug_range_lists_data().offset(base));
-                offset = offsets[index] + base;
+                auto offsets = debug_range_lists_data().slice(base);
+                offset = ByteReader::load32(offsets.offset_pointer(index * sizeof(u32))) + base;
             }
 
             Vector<DIERange> entries;

--- a/Userland/Libraries/LibDebug/Dwarf/DwarfTypes.h
+++ b/Userland/Libraries/LibDebug/Dwarf/DwarfTypes.h
@@ -47,7 +47,10 @@ struct [[gnu::packed]] CompilationUnitHeader {
 
     u32 length() const { return common.length; }
     u16 version() const { return common.version; }
-    CompilationUnitType unit_type() const { return (common.version <= 4) ? CompilationUnitType::Full : (CompilationUnitType)v5.unit_type; }
+    CompilationUnitType unit_type() const
+    {
+        return (common.version <= 4) ? CompilationUnitType::Full : static_cast<CompilationUnitType>(v5.unit_type);
+    }
     u32 abbrev_offset() const { return (common.version <= 4) ? v4.abbrev_offset : v5.abbrev_offset; }
     u8 address_size() const { return (common.version <= 4) ? v4.address_size : v5.address_size; }
 };

--- a/Userland/Libraries/LibDebug/Dwarf/Expression.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/Expression.cpp
@@ -36,8 +36,8 @@ Value evaluate(ReadonlyBytes bytes, [[maybe_unused]] PtraceRegisters const& regs
 #endif
 
         default:
-            dbgln("DWARF expr addr: {}", (const void*)bytes.data());
-            dbgln("unsupported opcode: {}", (u8)opcode);
+            dbgln("DWARF expr addr: {:p}", bytes.data());
+            dbgln("unsupported opcode: {}", opcode);
             VERIFY_NOT_REACHED();
         }
     }

--- a/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
+++ b/Userland/Libraries/LibDebug/Dwarf/LineProgram.cpp
@@ -42,13 +42,13 @@ void LineProgram::parse_path_entries(Function<void(PathEntry& entry)> callback, 
         Vector<PathEntryFormat> format_descriptions;
 
         for (u8 i = 0; i < path_entry_format_count; i++) {
-            size_t content_type = 0;
+            UnderlyingType<ContentType> content_type;
             m_stream.read_LEB128_unsigned(content_type);
 
-            size_t data_form = 0;
+            UnderlyingType<AttributeDataForm> data_form;
             m_stream.read_LEB128_unsigned(data_form);
 
-            format_descriptions.empend((ContentType)content_type, (AttributeDataForm)data_form);
+            format_descriptions.empend(static_cast<ContentType>(content_type), static_cast<AttributeDataForm>(data_form));
         }
 
         size_t paths_count = 0;
@@ -66,7 +66,7 @@ void LineProgram::parse_path_entries(Function<void(PathEntry& entry)> callback, 
                     entry.directory_index = value.as_unsigned();
                     break;
                 default:
-                    dbgln_if(DWARF_DEBUG, "Unhandled path list attribute: {}", (int)format_description.type);
+                    dbgln_if(DWARF_DEBUG, "Unhandled path list attribute: {}", to_underlying(format_description.type));
                 }
             }
             callback(entry);
@@ -280,7 +280,7 @@ void LineProgram::run_program()
 {
     reset_registers();
 
-    while ((size_t)m_stream.offset() < m_unit_offset + sizeof(u32) + m_unit_header.length()) {
+    while (m_stream.offset() < m_unit_offset + sizeof(u32) + m_unit_header.length()) {
         u8 opcode = 0;
         m_stream >> opcode;
 

--- a/Userland/Libraries/LibDebug/ProcessInspector.h
+++ b/Userland/Libraries/LibDebug/ProcessInspector.h
@@ -15,8 +15,8 @@ namespace Debug {
 class ProcessInspector {
 public:
     virtual ~ProcessInspector() { }
-    virtual bool poke(void* address, FlatPtr data) = 0;
-    virtual Optional<FlatPtr> peek(void* address) const = 0;
+    virtual bool poke(FlatPtr address, FlatPtr data) = 0;
+    virtual Optional<FlatPtr> peek(FlatPtr address) const = 0;
     virtual PtraceRegisters get_registers() const = 0;
     virtual void set_registers(PtraceRegisters const&) = 0;
     virtual void for_each_loaded_library(Function<IterationDecision(LoadedLibrary const&)>) const = 0;

--- a/Userland/Libraries/LibDebug/StackFrameUtils.cpp
+++ b/Userland/Libraries/LibDebug/StackFrameUtils.cpp
@@ -10,8 +10,8 @@ namespace Debug::StackFrameUtils {
 
 Optional<StackFrameInfo> get_info(ProcessInspector const& inspector, FlatPtr current_ebp)
 {
-    auto return_address = inspector.peek(reinterpret_cast<u32*>(current_ebp + sizeof(FlatPtr)));
-    auto next_ebp = inspector.peek(reinterpret_cast<u32*>(current_ebp));
+    auto return_address = inspector.peek(current_ebp + sizeof(FlatPtr));
+    auto next_ebp = inspector.peek(current_ebp);
     if (!return_address.has_value() || !next_ebp.has_value())
         return {};
 


### PR DESCRIPTION
This makes LibDebug actually usable under UBSAMA.
And...untangles some code, dear lord