### PR TITLE
AK: Simplify Variant's explicit overload detection mechanism a bit

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -81,22 +81,19 @@ struct Variant<IndexType, InitialIndex> {
 template<typename IndexType, typename... Ts>
 struct VisitImpl {
     template<typename RT, typename T, size_t I, typename Fn>
-    static consteval u64 get_explicitly_named_overload_if_exists()
+    static consteval bool has_explicitly_named_overload()
     {
         // If we're not allowed to make a member function pointer and call it directly (without explicitly resolving it),
         // we have a templated function on our hands (or a function overload set).
         // in such cases, we don't have an explicitly named overload, and we would have to select it.
-        if constexpr (requires { (declval<Fn>().*(&Fn::operator()))(declval<T>()); })
-            return 1ull << I;
-
-        return 0;
+        return requires { (declval<Fn>().*(&Fn::operator()))(declval<T>()); };
     }
 
     template<typename ReturnType, typename T, typename Visitor, auto... Is>
     static consteval bool should_invoke_const_overload(IndexSequence<Is...>)
     {
         // Scan over all the different visitor functions, if none of them are suitable for calling with `T const&`, avoid calling that first.
-        return ((get_explicitly_named_overload_if_exists<ReturnType, T, Is, typename Visitor::Types::template Type<Is>>()) | ...) != 0;
+        return ((has_explicitly_named_overload<ReturnType, T, Is, typename Visitor::Types::template Type<Is>>()) || ...);
     }
 
     template<typename Self, typename Visitor, IndexType CurrentIndex = 0>
@@ -453,7 +450,6 @@ private:
     template<typename... Fs>
     struct Visitor : Fs... {
         using Types = TypeList<Fs...>;
-        static_assert(Types::size < 64, "Variant::visit() can take a maximum of 64 visit functions.");
 
         Visitor(Fs&&... args)
             : Fs(forward<Fs>(args))...


### PR DESCRIPTION
This also allows us to remove the max-64-visitors restriction, and so removes that assertion.

Spinoff from #12081, I got tired of waiting 1hr+ for rebuilds because I touched AK.