### PR TITLE
AK: Add `size`

### DIFF
--- a/AK/Size.h
+++ b/AK/Size.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+
+namespace AK {
+
+namespace Detail {
+
+// clang-format off
+template<typename T>
+concept SizeQueryable = requires
+{
+    {
+        declval<AddConst<T>>().size()
+    } -> Unsigned;
+};
+// clang-format on
+
+}
+
+constexpr size_t size(auto begin, auto const& end) requires IteratorPairWith<decltype(begin), decltype(end)>
+{
+    size_t size = 0;
+    while (begin != end) {
+        ++begin;
+        ++size;
+    }
+    return size;
+}
+
+template<typename T, size_t N>
+constexpr size_t size(T (&)[N])
+{
+    return N;
+}
+
+constexpr auto size(auto const& container) requires IterableContainer<decltype(container)> || Detail::SizeQueryable<decltype(container)>
+{
+    if constexpr (Detail::SizeQueryable<decltype(container)>)
+        return container.size();
+    if constexpr (IterableContainer<decltype(container)>)
+        return size(container.begin(), container.end());
+    VERIFY_NOT_REACHED();
+}
+
+}
+
+using AK::size;

--- a/AK/Utf16View.cpp
+++ b/AK/Utf16View.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/Size.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
 #include <AK/Utf16View.h>
@@ -218,10 +219,7 @@ bool Utf16View::validate(size_t& valid_code_units) const
 
 size_t Utf16View::calculate_length_in_code_points() const
 {
-    size_t code_points = 0;
-    for ([[maybe_unused]] auto code_point : *this)
-        ++code_points;
-    return code_points;
+    return size(*this);
 }
 
 bool Utf16View::equals_ignoring_case(Utf16View const& other) const

--- a/AK/Utf8View.cpp
+++ b/AK/Utf8View.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/Format.h>
+#include <AK/Size.h>
 #include <AK/Utf8View.h>
 
 namespace AK {
@@ -122,11 +123,7 @@ bool Utf8View::validate(size_t& valid_bytes) const
 
 size_t Utf8View::calculate_length() const
 {
-    size_t length = 0;
-    for ([[maybe_unused]] auto code_point : *this) {
-        ++length;
-    }
-    return length;
+    return size(*this);
 }
 
 bool Utf8View::starts_with(const Utf8View& start) const

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -50,6 +50,7 @@ set(AK_TEST_SOURCES
     TestRedBlackTree.cpp
     TestRefPtr.cpp
     TestSinglyLinkedList.cpp
+    TestSize.cpp
     TestSourceGenerator.cpp
     TestSourceLocation.cpp
     TestSpan.cpp

--- a/Tests/AK/TestSize.cpp
+++ b/Tests/AK/TestSize.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/Array.h>
+#include <AK/SinglyLinkedList.h>
+#include <AK/Size.h>
+#include <AK/Vector.h>
+
+STATICTEST_CASE(size_of_array)
+{
+    int array[8] {};
+    EXPECT_EQ(size(array), 8u);
+}
+RUN_STATICTEST_CASE(size_of_array);
+
+STATICTEST_CASE(size_of_Array)
+{
+    Array<int, 8> array {};
+    EXPECT_EQ(size(array), 8u);
+}
+RUN_STATICTEST_CASE(size_of_Array);
+
+TEST_CASE(size_of_SinglyLinkedList)
+{
+    SinglyLinkedList<int> list {};
+    EXPECT_EQ(size(list), 0u);
+
+    list.append(42);
+    EXPECT_EQ(size(list), 1u);
+}
+
+TEST_CASE(size_of_Vector)
+{
+    Vector<int> vector {};
+    EXPECT_EQ(size(vector), 0u);
+
+    vector.append(42);
+    EXPECT_EQ(size(vector), 1u);
+}

--- a/Tests/AK/TestTrie.cpp
+++ b/Tests/AK/TestTrie.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
+#include <AK/Size.h>
 #include <AK/StringView.h>
 #include <AK/Trie.h>
 
@@ -19,10 +20,7 @@ TEST_CASE(normal_behavior)
         dictionary.insert(it, view.end(), view, [](auto& parent, auto& it) -> Optional<String> { return String::formatted("{}{}", parent.metadata_value(), *it); });
     }
 
-    size_t i = 0;
-    for ([[maybe_unused]] auto& node : dictionary)
-        ++i;
-    EXPECT_EQ(i, total_chars);
+    EXPECT_EQ(size(dictionary), total_chars);
 
     for (auto& view : data) {
         auto it = view.begin();

--- a/Userland/Libraries/LibTest/TestCase.h
+++ b/Userland/Libraries/LibTest/TestCase.h
@@ -62,6 +62,18 @@ void set_suite_setup_function(Function<void()> setup);
     static struct __TESTCASE_TYPE(x) __TESTCASE_TYPE(x);                                                \
     static void __TESTCASE_FUNC(x)()
 
+#define STATICTEST_CASE(x)                                                                              \
+    static constexpr void __TESTCASE_FUNC(x)();                                                         \
+    struct __TESTCASE_TYPE(x) {                                                                         \
+        __TESTCASE_TYPE(x)                                                                              \
+        () { add_test_case_to_suite(adopt_ref(*new ::Test::TestCase(#x, __TESTCASE_FUNC(x), false))); } \
+    };                                                                                                  \
+    static struct __TESTCASE_TYPE(x) __TESTCASE_TYPE(x);                                                \
+    static constexpr void __TESTCASE_FUNC(x)()
+
+#define RUN_STATICTEST_CASE(x) \
+    static_assert([]() {__TESTCASE_FUNC(x)();return true; }())
+
 #define __BENCHMARK_FUNC(x) __benchmark_##x
 #define __BENCHMARK_TYPE(x) __BenchmarkCase_##x
 


### PR DESCRIPTION
Hi,
There are some types that I detected that count the number of elements of `IterableContainer`s.
The following patch adds the trivial facility to ~`count`~ `size` them.

This change is a different implementation of #12168 with (what I think is better) `static_assert` checks, and without removing `std::array_size`.