### PR TITLE
Kernel: Add polling support to NVMe

### DIFF
--- a/Base/usr/share/man/man7/boot_parameters.md
+++ b/Base/usr/share/man/man7/boot_parameters.md
@@ -66,7 +66,9 @@ List of options:
   enable available APs (application processors) and use them with the BSP (Bootstrap processor) to
   schedule and run threads.
   This parameter defaults to **`off`**. This parameter requires **`enable_ioapic`** to be enabled
-  and and a `MADT` (APIC) table to be available.
+  and a `MADT` (APIC) table to be available.
+
+* **`nvme_poll`** - This parameter configures the NVMe drive to use polling instead of interrupt driven completion.
 
 * **`system_mode`** - This parameter is not interpreted by the Kernel, and is made available at `/proc/system_mode`. SystemServer uses it to select the set of services that should be started. Common values are:
   - **`graphical`** (default) - Boots the system in the normal graphical mode.

--- a/Documentation/BareMetalInstallation.md
+++ b/Documentation/BareMetalInstallation.md
@@ -8,7 +8,7 @@ Whilst it is possible to run Serenity on physical x86-compatible hardware, it is
 ## Hardware support and requirements
 
 Storage-wise Serenity requires a >= 2 GB parallel ATA or SATA IDE disk. Some older SATA chipsets already operate in IDE mode whilst some newer ones will depend upon adjusting a BIOS option to run your SATA controller in IDE (sometimes referred to as Legacy or PATA) mode. SATA AHCI is supported, but may not work on every controller due to bugs in the implementation.
-SCSI, SAS, eMMC and NVMe HBAs are all presently unsupported.
+NVMe drives are supported but it is recommended to use `nvme_poll` boot parameter in newer hardwares as we lack MSI(X) support at the moment. SCSI, SAS and eMMC HBAs are all presently unsupported.
 
 You must be willing to wipe your disk's contents to allow for writing the Serenity image so be sure to back up any important data on your disk first! Serenity uses the GRUB2 bootloader so it should be possible to multiboot it with any other OS that can be booted from GRUB2 post-installation.
 

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -103,6 +103,8 @@ set(KERNEL_SOURCES
     Storage/Partition/PartitionTable.cpp
     Storage/NVMe/NVMeController.cpp
     Storage/NVMe/NVMeNameSpace.cpp
+    Storage/NVMe/NVMeInterruptQueue.cpp
+    Storage/NVMe/NVMePollQueue.cpp
     Storage/NVMe/NVMeQueue.cpp
     Storage/StorageDevice.cpp
     Storage/RamdiskController.cpp

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -175,6 +175,11 @@ UNMAP_AFTER_INIT StringView CommandLine::root_device() const
     return lookup("root"sv).value_or("/dev/hda"sv);
 }
 
+bool CommandLine::is_nvme_polling_enabled() const
+{
+    return contains("nvme_poll"sv);
+}
+
 UNMAP_AFTER_INIT AcpiFeatureLevel CommandLine::acpi_feature_level() const
 {
     auto value = kernel_command_line().lookup("acpi"sv).value_or("limited"sv);

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -87,6 +87,7 @@ public:
     [[nodiscard]] StringView userspace_init() const;
     [[nodiscard]] NonnullOwnPtrVector<KString> userspace_init_args() const;
     [[nodiscard]] StringView root_device() const;
+    [[nodiscard]] bool is_nvme_polling_enabled() const;
     [[nodiscard]] size_t switch_to_tty() const;
 
 private:

--- a/Kernel/Interrupts/IRQHandler.cpp
+++ b/Kernel/Interrupts/IRQHandler.cpp
@@ -15,7 +15,8 @@ IRQHandler::IRQHandler(u8 irq)
     : GenericInterruptHandler(irq)
     , m_responsible_irq_controller(InterruptManagement::the().get_responsible_irq_controller(irq))
 {
-    disable_irq();
+    if (is_registered())
+        disable_irq();
 }
 
 IRQHandler::~IRQHandler()

--- a/Kernel/Storage/NVMe/NVMeController.h
+++ b/Kernel/Storage/NVMe/NVMeController.h
@@ -26,8 +26,8 @@ namespace Kernel {
 class NVMeController : public PCI::Device
     , public StorageController {
 public:
-    static ErrorOr<NonnullRefPtr<NVMeController>> try_initialize(PCI::DeviceIdentifier const&);
-    ErrorOr<void> initialize();
+    static ErrorOr<NonnullRefPtr<NVMeController>> try_initialize(PCI::DeviceIdentifier const&, bool is_queue_polled);
+    ErrorOr<void> initialize(bool is_queue_polled);
     explicit NVMeController(PCI::DeviceIdentifier const&);
     RefPtr<StorageDevice> device(u32 index) const override;
     size_t devices_count() const override;
@@ -58,8 +58,8 @@ public:
 private:
     ErrorOr<void> identify_and_init_namespaces();
     Tuple<u64, u8> get_ns_features(IdentifyNamespace& identify_data_struct);
-    ErrorOr<void> create_admin_queue(u8 irq);
-    ErrorOr<void> create_io_queue(u8 irq, u8 qid);
+    ErrorOr<void> create_admin_queue(Optional<u8> irq);
+    ErrorOr<void> create_io_queue(u8 qid, Optional<u8> irq);
     void calculate_doorbell_stride()
     {
         m_dbl_stride = (m_controller_regs->cap >> CAP_DBL_SHIFT) & CAP_DBL_MASK;

--- a/Kernel/Storage/NVMe/NVMeDefinitions.h
+++ b/Kernel/Storage/NVMe/NVMeDefinitions.h
@@ -125,6 +125,7 @@ enum IOCommandOpcode {
 // FLAGS
 static constexpr u8 QUEUE_PHY_CONTIGUOUS = (1 << 0);
 static constexpr u8 QUEUE_IRQ_ENABLED = (1 << 1);
+static constexpr u8 QUEUE_IRQ_DISABLED = (0 << 1);
 
 struct [[gnu::packed]] NVMeCompletion {
     LittleEndian<u32> cmd_spec;

--- a/Kernel/Storage/NVMe/NVMeInterruptQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeInterruptQueue.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2022, Pankaj R <pankydev8@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "NVMeInterruptQueue.h"
+#include "Kernel/Devices/BlockDevice.h"
+#include "NVMeDefinitions.h"
+#include <Kernel/WorkQueue.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT NVMeInterruptQueue::NVMeInterruptQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, NonnullRefPtrVector<Memory::PhysicalPage> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, NonnullRefPtrVector<Memory::PhysicalPage> sq_dma_page, Memory::TypedMapping<volatile DoorbellRegister> db_regs)
+    : NVMeQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))
+    , IRQHandler(irq)
+{
+    enable_irq();
+}
+
+bool NVMeInterruptQueue::handle_irq(const RegisterState&)
+{
+    SpinlockLocker lock(m_request_lock);
+    return process_cq() ? true : false;
+}
+
+void NVMeInterruptQueue::submit_sqe(NVMeSubmission& sub)
+{
+    NVMeQueue::submit_sqe(sub);
+}
+
+void NVMeInterruptQueue::complete_current_request(u16 status)
+{
+    VERIFY(m_request_lock.is_locked());
+
+    g_io_work->queue([this, status]() {
+        SpinlockLocker lock(m_request_lock);
+        auto current_request = m_current_request;
+        m_current_request.clear();
+        if (status) {
+            lock.unlock();
+            current_request->complete(AsyncBlockDeviceRequest::Failure);
+            return;
+        }
+        if (current_request->request_type() == AsyncBlockDeviceRequest::RequestType::Read) {
+            if (auto result = current_request->write_to_buffer(current_request->buffer(), m_rw_dma_region->vaddr().as_ptr(), 512 * current_request->block_count()); result.is_error()) {
+                lock.unlock();
+                current_request->complete(AsyncDeviceRequest::MemoryFault);
+                return;
+            }
+        }
+        lock.unlock();
+        current_request->complete(AsyncDeviceRequest::Success);
+        return;
+    });
+}
+}

--- a/Kernel/Storage/NVMe/NVMeInterruptQueue.h
+++ b/Kernel/Storage/NVMe/NVMeInterruptQueue.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Pankaj R <pankydev8@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Storage/NVMe/NVMeQueue.h>
+
+namespace Kernel {
+
+class NVMeInterruptQueue : public NVMeQueue
+    , public IRQHandler {
+public:
+    NVMeInterruptQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u8 irq, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, NonnullRefPtrVector<Memory::PhysicalPage> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, NonnullRefPtrVector<Memory::PhysicalPage> sq_dma_page, Memory::TypedMapping<volatile DoorbellRegister> db_regs);
+    void submit_sqe(NVMeSubmission& submission) override;
+    virtual ~NVMeInterruptQueue() override {};
+
+private:
+    virtual void complete_current_request(u16 status) override;
+    bool handle_irq(RegisterState const&) override;
+};
+}

--- a/Kernel/Storage/NVMe/NVMePollQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMePollQueue.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Pankaj R <pankydev8@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "NVMePollQueue.h"
+#include "Kernel/Arch/x86/IO.h"
+#include "Kernel/Devices/BlockDevice.h"
+#include "NVMeDefinitions.h"
+
+namespace Kernel {
+UNMAP_AFTER_INIT NVMePollQueue::NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, NonnullRefPtrVector<Memory::PhysicalPage> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, NonnullRefPtrVector<Memory::PhysicalPage> sq_dma_page, Memory::TypedMapping<volatile DoorbellRegister> db_regs)
+    : NVMeQueue(move(rw_dma_region), rw_dma_page, qid, q_depth, move(cq_dma_region), cq_dma_page, move(sq_dma_region), sq_dma_page, move(db_regs))
+{
+}
+
+void NVMePollQueue::submit_sqe(NVMeSubmission& sub)
+{
+    NVMeQueue::submit_sqe(sub);
+    SpinlockLocker lock_cq(m_cq_lock);
+    while (!process_cq()) {
+        IO::delay(1);
+    }
+}
+
+void NVMePollQueue::complete_current_request(u16 status)
+{
+    auto current_request = m_current_request;
+    m_current_request.clear();
+    if (status) {
+        current_request->complete(AsyncBlockDeviceRequest::Failure);
+        return;
+    }
+    if (current_request->request_type() == AsyncBlockDeviceRequest::RequestType::Read) {
+        if (auto result = current_request->write_to_buffer(current_request->buffer(), m_rw_dma_region->vaddr().as_ptr(), 512 * current_request->block_count()); result.is_error()) {
+            current_request->complete(AsyncDeviceRequest::MemoryFault);
+            return;
+        }
+    }
+    current_request->complete(AsyncDeviceRequest::Success);
+    return;
+}
+}

--- a/Kernel/Storage/NVMe/NVMePollQueue.h
+++ b/Kernel/Storage/NVMe/NVMePollQueue.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, Pankaj R <pankydev8@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Storage/NVMe/NVMeQueue.h>
+
+namespace Kernel {
+
+class NVMePollQueue : public NVMeQueue {
+public:
+    NVMePollQueue(NonnullOwnPtr<Memory::Region> rw_dma_region, Memory::PhysicalPage const& rw_dma_page, u16 qid, u32 q_depth, OwnPtr<Memory::Region> cq_dma_region, NonnullRefPtrVector<Memory::PhysicalPage> cq_dma_page, OwnPtr<Memory::Region> sq_dma_region, NonnullRefPtrVector<Memory::PhysicalPage> sq_dma_page, Memory::TypedMapping<volatile DoorbellRegister> db_regs);
+    void submit_sqe(NVMeSubmission& submission) override;
+    virtual ~NVMePollQueue() override {};
+
+private:
+    virtual void complete_current_request(u16 status) override;
+};
+}

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -23,7 +23,7 @@ class StorageManagement {
 public:
     StorageManagement();
     static bool initialized();
-    void initialize(StringView boot_argument, bool force_pio);
+    void initialize(StringView boot_argument, bool force_pio, bool nvme_poll);
     static StorageManagement& the();
 
     NonnullRefPtr<FileSystem> root_filesystem() const;
@@ -36,7 +36,7 @@ public:
 private:
     bool boot_argument_contains_partition_uuid();
 
-    void enumerate_controllers(bool force_pio);
+    void enumerate_controllers(bool force_pio, bool nvme_poll);
     void enumerate_storage_devices();
     void enumerate_disk_partitions();
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -330,7 +330,7 @@ void init_stage2(void*)
     (void)SB16::try_detect_and_create();
     AC97::detect();
 
-    StorageManagement::the().initialize(kernel_command_line().root_device(), kernel_command_line().is_force_pio());
+    StorageManagement::the().initialize(kernel_command_line().root_device(), kernel_command_line().is_force_pio(), kernel_command_line().is_nvme_polling_enabled());
     if (VirtualFileSystem::the().mount_root(StorageManagement::the().root_filesystem()).is_error()) {
         PANIC("VirtualFileSystem::mount_root failed");
     }


### PR DESCRIPTION
NVMe drives support polling mode where the host actively polls for completion. As we currently lack MSI(X) support in Serenity, polling option enables booting off a NVMe drive in newer hardware. @tomuta Already tested this in a Baremetal HW. 

Credits: Thanks to @supercomputer7 for the idea of adding this support and the suggestion to create inherited classes to NVMeQueue Base class (better pattern than my initial "C" style approach )