### PR TITLE
AK+Userland: Less Vector-ism

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -41,6 +41,32 @@ concept HashCompatible = IsHashCompatible<Detail::Decay<T>, Detail::Decay<U>>;
 
 // FIXME: remove once Clang formats these properly.
 // clang-format off
+
+// Any indexable, sized, contiguous data structure.
+template<typename ArrayT, typename ContainedT, typename SizeT = size_t>
+concept ArrayLike = requires(ArrayT array, SizeT index)
+{
+    {
+        array[index]
+    }
+    -> SameAs<RemoveReference<ContainedT>&>;
+
+    {
+        array.size()
+    }
+    -> SameAs<SizeT>;
+
+    {
+        array.span()
+    }
+    -> SameAs<Span<RemoveReference<ContainedT>>>;
+
+    {
+        array.data()
+    }
+    -> SameAs<RemoveReference<ContainedT>*>;
+};
+
 template<typename Func, typename... Args>
 concept VoidFunction = requires(Func func, Args... args)
 {
@@ -77,6 +103,7 @@ concept IterableContainer = requires
 }
 
 using AK::Concepts::Arithmetic;
+using AK::Concepts::ArrayLike;
 using AK::Concepts::Enum;
 using AK::Concepts::FloatingPoint;
 using AK::Concepts::Integral;

--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/JsonArraySerializer.h>
 #include <AK/JsonValue.h>
 #include <AK/Vector.h>
@@ -27,10 +28,10 @@ public:
     {
     }
 
-    template<typename T>
-    JsonArray(Vector<T> const& vector)
+    template<IterableContainer ContainerT>
+    JsonArray(ContainerT const& source)
     {
-        for (auto& value : vector)
+        for (auto& value : source)
             m_values.append(move(value));
     }
 

--- a/AK/JsonValue.cpp
+++ b/AK/JsonValue.cpp
@@ -7,6 +7,7 @@
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/JsonValue.h>
+#include <AK/StringView.h>
 
 #ifndef KERNEL
 #    include <AK/JsonParser.h>
@@ -182,6 +183,11 @@ JsonValue::JsonValue(const String& value)
         m_value.as_string = const_cast<StringImpl*>(value.impl());
         m_value.as_string->ref();
     }
+}
+
+JsonValue::JsonValue(StringView value)
+    : JsonValue(value.to_string())
+{
 }
 
 JsonValue::JsonValue(const JsonObject& value)

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -54,6 +54,7 @@ public:
     JsonValue(bool);
     JsonValue(const char*);
     JsonValue(const String&);
+    JsonValue(StringView);
     JsonValue(const JsonArray&);
     JsonValue(const JsonObject&);
 

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -6,6 +6,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <LibAudio/ClientConnection.h>
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
@@ -34,12 +35,12 @@ private:
 public:
     static ErrorOr<NonnullRefPtr<AudioWidget>> try_create()
     {
-        Vector<VolumeBitmapPair, 5> volume_level_bitmaps = {
-            { 66, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-high.png")) },
-            { 33, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-medium.png")) },
-            { 1, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-low.png")) },
-            { 0, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-zero.png")) },
-            { 0, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-muted.png")) }
+        Array<VolumeBitmapPair, 5> volume_level_bitmaps = {
+            { { 66, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-high.png")) },
+                { 33, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-medium.png")) },
+                { 1, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-low.png")) },
+                { 0, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-zero.png")) },
+                { 0, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/audio-volume-muted.png")) } }
         };
         auto audio_client = TRY(Audio::ClientConnection::try_create());
         NonnullRefPtr<AudioWidget> audio_widget = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) AudioWidget(move(audio_client), move(volume_level_bitmaps))));
@@ -48,7 +49,7 @@ public:
     }
 
 private:
-    AudioWidget(NonnullRefPtr<Audio::ClientConnection> audio_client, Vector<VolumeBitmapPair, 5> volume_level_bitmaps)
+    AudioWidget(NonnullRefPtr<Audio::ClientConnection> audio_client, Array<VolumeBitmapPair, 5> volume_level_bitmaps)
         : m_audio_client(move(audio_client))
         , m_volume_level_bitmaps(move(volume_level_bitmaps))
         , m_show_percent(Config::read_bool("AudioApplet", "Applet", "ShowPercent", false))
@@ -201,7 +202,7 @@ private:
     Gfx::Bitmap& choose_bitmap_from_volume()
     {
         if (m_audio_muted)
-            return *m_volume_level_bitmaps.last().bitmap;
+            return *m_volume_level_bitmaps.back().bitmap;
 
         for (auto& pair : m_volume_level_bitmaps) {
             if (m_audio_volume >= pair.volume_threshold)
@@ -217,7 +218,7 @@ private:
     }
 
     NonnullRefPtr<Audio::ClientConnection> m_audio_client;
-    Vector<VolumeBitmapPair, 5> m_volume_level_bitmaps;
+    Array<VolumeBitmapPair, 5> m_volume_level_bitmaps;
     bool m_show_percent { false };
     bool m_audio_muted { false };
     int m_audio_volume { 100 };

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -5,9 +5,9 @@
  */
 
 #include "FindDialog.h"
+#include <AK/Array.h>
 #include <AK/Hex.h>
 #include <AK/String.h>
-#include <AK/Vector.h>
 #include <Applications/HexEditor/FindDialogGML.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -23,9 +23,11 @@ struct Option {
     bool default_action;
 };
 
-static const Vector<Option> options = {
-    { "ASCII String", OPTION_ASCII_STRING, true, true },
-    { "Hex value", OPTION_HEX_VALUE, true, false },
+static const Array<Option, 2> options = {
+    {
+        { "ASCII String", OPTION_ASCII_STRING, true, true },
+        { "Hex value", OPTION_HEX_VALUE, true, false },
+    }
 };
 
 int FindDialog::show(GUI::Window* parent_window, String& out_text, ByteBuffer& out_buffer, bool& find_all)

--- a/Userland/Applications/HexEditor/FindDialog.h
+++ b/Userland/Applications/HexEditor/FindDialog.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Result.h>
-#include <AK/Vector.h>
 #include <LibGUI/Dialog.h>
 
 enum OptionId {

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -14,7 +14,6 @@
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/Result.h>
-#include <AK/Vector.h>
 #include <LibCore/File.h>
 #include <LibGUI/Command.h>
 #include <LibGUI/Forward.h>

--- a/Userland/DevTools/HackStudio/ClassViewWidget.h
+++ b/Userland/DevTools/HackStudio/ClassViewWidget.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/StringView.h>
-#include <AK/Vector.h>
 #include <LibGUI/AutocompleteProvider.h>
 #include <LibGUI/TreeView.h>
 #include <LibGUI/Widget.h>

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.h
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.h
@@ -10,7 +10,6 @@
 #include <DevTools/HackStudio/ProjectTemplate.h>
 
 #include <AK/Result.h>
-#include <AK/Vector.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Dialog.h>
 #include <LibGUI/Label.h>

--- a/Userland/DevTools/Inspector/RemoteObject.h
+++ b/Userland/DevTools/Inspector/RemoteObject.h
@@ -9,7 +9,6 @@
 #include <AK/JsonObject.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/String.h>
-#include <AK/Vector.h>
 
 namespace Inspector {
 

--- a/Userland/Games/Chess/PromotionDialog.cpp
+++ b/Userland/Games/Chess/PromotionDialog.cpp
@@ -22,7 +22,7 @@ PromotionDialog::PromotionDialog(ChessWidget& chess_widget)
     main_widget.set_fill_with_background_color(true);
     main_widget.set_layout<GUI::HorizontalBoxLayout>();
 
-    for (auto& type : Vector({ Chess::Type::Queen, Chess::Type::Knight, Chess::Type::Rook, Chess::Type::Bishop })) {
+    for (auto const& type : { Chess::Type::Queen, Chess::Type::Knight, Chess::Type::Rook, Chess::Type::Bishop }) {
         auto& button = main_widget.add<GUI::Button>("");
         button.set_fixed_height(70);
         button.set_icon(chess_widget.get_piece_graphic({ chess_widget.board().turn(), type }));

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -138,7 +138,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto board_theme_menu = TRY(style_menu->try_add_submenu("Board Theme"));
     board_theme_menu->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/chess/mini-board.png").release_value_but_fixme_should_propagate_errors());
 
-    for (auto& theme : Vector({ "Beige", "Green", "Blue" })) {
+    for (auto const& theme : { "Beige", "Green", "Blue" }) {
         auto action = GUI::Action::create_checkable(theme, [&](auto& action) {
             widget->set_board_theme(action.text());
             widget->update();
@@ -171,7 +171,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     GUI::ActionGroup engines_action_group;
     engines_action_group.set_exclusive(true);
     auto engine_submenu = TRY(engine_menu->try_add_submenu("&Engine"));
-    for (auto& engine : Vector({ "Human", "ChessEngine" })) {
+    for (auto const& engine : { "Human", "ChessEngine" }) {
         auto action = GUI::Action::create_checkable(engine, [&](auto& action) {
             if (action.text() == "Human") {
                 widget->set_engine(nullptr);

--- a/Userland/Libraries/LibCompress/Zlib.cpp
+++ b/Userland/Libraries/LibCompress/Zlib.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/Span.h>
 #include <AK/Types.h>
-#include <AK/Vector.h>
 #include <LibCompress/Deflate.h>
 #include <LibCompress/Zlib.h>
 

--- a/Userland/Libraries/LibCore/TempFile.cpp
+++ b/Userland/Libraries/LibCore/TempFile.cpp
@@ -6,7 +6,6 @@
 
 #include "TempFile.h"
 #include <AK/Random.h>
-#include <AK/Vector.h>
 #include <LibCore/File.h>
 #include <fcntl.h>
 #include <stdlib.h>

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
@@ -8,7 +8,6 @@
 #include <AK/Debug.h>
 #include <AK/MemoryStream.h>
 #include <AK/Types.h>
-#include <AK/Vector.h>
 #include <LibCrypto/Authentication/GHash.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 

--- a/Userland/Libraries/LibCrypto/PK/RSA.h
+++ b/Userland/Libraries/LibCrypto/PK/RSA.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <AK/Span.h>
-#include <AK/Vector.h>
 #include <LibCrypto/BigInt/UnsignedBigInteger.h>
 #include <LibCrypto/NumberTheory/ModularFunctions.h>
 #include <LibCrypto/PK/Code/EMSA_PSS.h>

--- a/Userland/Libraries/LibELF/Relocation.h
+++ b/Userland/Libraries/LibELF/Relocation.h
@@ -8,7 +8,6 @@
 
 #include <AK/Concepts.h>
 #include <AK/String.h>
-#include <AK/Vector.h>
 #include <Kernel/VirtualAddress.h>
 
 namespace ELF {

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Vector.h>
 #include <LibGUI/AbstractTableView.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Button.h>

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -7,7 +7,6 @@
 #include <AK/Debug.h>
 #include <AK/StringBuilder.h>
 #include <AK/Utf8View.h>
-#include <AK/Vector.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/AbstractView.h>
 #include <LibGUI/DragOperation.h>

--- a/Userland/Libraries/LibGUI/GlyphMapWidget.h
+++ b/Userland/Libraries/LibGUI/GlyphMapWidget.h
@@ -7,7 +7,6 @@
 
 #pragma once
 
-#include <AK/Vector.h>
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGUI/TextRange.h>
 #include <LibGfx/BitmapFont.h>

--- a/Userland/Libraries/LibGemini/Document.h
+++ b/Userland/Libraries/LibGemini/Document.h
@@ -10,7 +10,6 @@
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/String.h>
 #include <AK/URL.h>
-#include <AK/Vector.h>
 
 namespace Gemini {
 

--- a/Userland/Libraries/LibJS/Heap/CellAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/CellAllocator.h
@@ -8,7 +8,6 @@
 
 #include <AK/IntrusiveList.h>
 #include <AK/NonnullOwnPtr.h>
-#include <AK/Vector.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/HeapBlock.h>
 

--- a/Userland/Libraries/LibJS/Interpreter.h
+++ b/Userland/Libraries/LibJS/Interpreter.h
@@ -10,7 +10,6 @@
 #include <AK/FlyString.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
-#include <AK/Vector.h>
 #include <AK/Weakable.h>
 #include <LibJS/AST.h>
 #include <LibJS/Forward.h>


### PR DESCRIPTION
Vector is great and all, but often it's quite unnecessary: many situations don't need resizability and some of those even know container size at compile time. This PR is a collection of small changes that try to move as much away from Vector as possible.

The big selling feature of this PR is the ArrayLike concept. It should allow libraries to generalize over all array-like types whenever the container's size is not touched. I found a couple of obvious places in AK where this can be done, but please do expand on this and find more places.

Second, a couple of Vector uses were removed. Just simple stuff while scrolling through the 4000 search results for Vector O_o

And finally, there's a bunch of unnecessary Vector includes all over the code base. How silly :^)