### PR TITLE
AK: Introduce IMath.h for integral algorithms, starting with pow<I> and use it where applicable

### DIFF
--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -7,6 +7,7 @@
 #include <AK/CharacterTypes.h>
 #include <AK/Format.h>
 #include <AK/GenericLexer.h>
+#include <AK/IntegralMath.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/kstdio.h>
@@ -383,14 +384,7 @@ ErrorOr<void> FormatBuilder::put_fixed_point(
         // place to start would be the following video from CppCon 2019:
         // https://youtu.be/4P_kbF0EbZM (Stephan T. Lavavej “Floating-Point <charconv>: Making Your Code 10x Faster With C++17's Final Boss”)
 
-#ifdef KERNEL
-        // We don't have pow() in kernel land
-        u64 scale = 10;
-        for (size_t i = 0; i < precision - 1; i++) // TODO: not efficient
-            scale *= 10;
-#else
-        u64 scale = pow(10.0, (double)precision);
-#endif
+        u64 scale = pow<u64>(10, precision);
 
         auto fraction = (scale * fraction_value) / fraction_one; // TODO: overflows
         if (is_negative)

--- a/AK/IntegralMath.h
+++ b/AK/IntegralMath.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Leon Albrecht <leon2002.la@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/Types.h>
+
+#include <AK/Format.h>
+
+namespace AK {
+
+template<Integral I>
+constexpr I pow(I base, I exponent)
+{
+    // https://en.wikipedia.org/wiki/Exponentiation_by_squaring
+    if (exponent < 0)
+        return 0;
+    if (exponent == 0)
+        return 1;
+
+    I res = 1;
+    while (exponent > 0) {
+        if (exponent & 1)
+            res *= base;
+        base *= base;
+        exponent /= 2u;
+    }
+    return res;
+}
+
+}

--- a/AK/IntegralMath.h
+++ b/AK/IntegralMath.h
@@ -6,12 +6,25 @@
 
 #pragma once
 
+#include <AK/BuiltinWrappers.h>
 #include <AK/Concepts.h>
 #include <AK/Types.h>
 
 #include <AK/Format.h>
 
 namespace AK {
+
+template<Integral T>
+constexpr T exp2(T exponent)
+{
+    return 1u << exponent;
+}
+
+template<Integral T>
+constexpr T log2(T x)
+{
+    return x ? (8 * sizeof(T) - 1) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x)) : 0;
+}
 
 template<Integral I>
 constexpr I pow(I base, I exponent)

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -295,12 +295,6 @@ constexpr T log2(T x)
     return ret;
 }
 
-template<Integral T>
-constexpr T log2(T x)
-{
-    return x ? (8 * sizeof(T) - 1) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x)) : 0;
-}
-
 template<FloatingPoint T>
 constexpr T log10(T x)
 {
@@ -353,11 +347,7 @@ constexpr T exp2(T exponent)
         : "0"(exponent));
     return res;
 }
-template<Integral T>
-constexpr T exp2(T exponent)
-{
-    return 1u << exponent;
-}
+
 }
 
 using Exponentials::exp;

--- a/Kernel/Devices/BlockDevice.h
+++ b/Kernel/Devices/BlockDevice.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <AK/Math.h>
+#include <AK/IntegralMath.h>
 #include <AK/Weakable.h>
 #include <Kernel/Devices/Device.h>
 

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -33,6 +33,7 @@ set(AK_TEST_SOURCES
     TestHex.cpp
     TestIPv4Address.cpp
     TestIndexSequence.cpp
+    TestIntegerMath.cpp
     TestIntrusiveList.cpp
     TestIntrusiveRedBlackTree.cpp
     TestJSON.cpp

--- a/Tests/AK/TestIntegerMath.cpp
+++ b/Tests/AK/TestIntegerMath.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/IntegralMath.h>
+
+TEST_CASE(pow)
+{
+    EXPECT_EQ(AK::pow<u64>(10, 0), 1ull);
+    EXPECT_EQ(AK::pow<u64>(10, 1), 10ull);
+    EXPECT_EQ(AK::pow<u64>(10, 2), 100ull);
+    EXPECT_EQ(AK::pow<u64>(10, 3), 1'000ull);
+    EXPECT_EQ(AK::pow<u64>(10, 4), 10'000ull);
+    EXPECT_EQ(AK::pow<u64>(10, 5), 100'000ull);
+    EXPECT_EQ(AK::pow<u64>(10, 6), 1'000'000ull);
+}

--- a/Userland/Applications/Calculator/Keypad.cpp
+++ b/Userland/Applications/Calculator/Keypad.cpp
@@ -7,7 +7,7 @@
 
 #include "Keypad.h"
 #include "KeypadValue.h"
-#include <AK/Math.h>
+#include <AK/IntegralMath.h>
 #include <AK/StringBuilder.h>
 
 Keypad::Keypad()
@@ -119,8 +119,8 @@ void Keypad::set_value(KeypadValue value)
     } else
         m_negative = false;
 
-    m_int_value = value.m_value / (u64)AK::pow(10.0, (double)value.m_decimal_places);
-    m_frac_value = value.m_value % (u64)AK::pow(10.0, (double)value.m_decimal_places);
+    m_int_value = value.m_value / AK::pow<u64>(10, value.m_decimal_places);
+    m_frac_value = value.m_value % AK::pow<u64>(10, value.m_decimal_places);
     m_frac_length = value.m_decimal_places;
 }
 

--- a/Userland/Applications/Calculator/KeypadValue.cpp
+++ b/Userland/Applications/Calculator/KeypadValue.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "KeypadValue.h"
+#include <AK/IntegralMath.h>
 #include <AK/Math.h>
 #include <AK/String.h>
 
@@ -119,7 +120,7 @@ ALWAYS_INLINE T KeypadValue::operator_helper(KeypadValue const& lhs, KeypadValue
     KeypadValue const& more_decimal_places = (lhs.m_decimal_places < rhs.m_decimal_places) ? rhs : lhs;
 
     i64 more_decimal_places_equalized = more_decimal_places.m_value;
-    i64 less_decimal_places_equalized = (i64)AK::pow(10.0, (double)(more_decimal_places.m_decimal_places - less_decimal_places.m_decimal_places)) * less_decimal_places.m_value;
+    i64 less_decimal_places_equalized = AK::pow<i64>(10, more_decimal_places.m_decimal_places - less_decimal_places.m_decimal_places) * less_decimal_places.m_value;
 
     bool lhs_is_less = (lhs.m_decimal_places < rhs.m_decimal_places);
 

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -8,7 +8,7 @@
 
 #include "RollWidget.h"
 #include "TrackManager.h"
-#include <AK/Math.h>
+#include <AK/IntegralMath.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Scrollbar.h>
 #include <LibGfx/Font.h>

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -12,6 +12,7 @@
 #include "Layer.h"
 #include "Tools/MoveTool.h"
 #include "Tools/Tool.h"
+#include <AK/IntegralMath.h>
 #include <AK/LexicalPath.h>
 #include <LibConfig/Client.h>
 #include <LibFileSystemAccessClient/Client.h>
@@ -218,14 +219,15 @@ int ImageEditor::calculate_ruler_step_size() const
     const auto step_target = 80 / scale();
     const auto max_factor = 5;
     for (int factor = 0; factor < max_factor; ++factor) {
-        if (step_target <= 1 * (float)pow(10, factor))
-            return 1 * pow(10, factor);
-        if (step_target <= 2 * (float)pow(10, factor))
-            return 2 * pow(10, factor);
-        if (step_target <= 5 * (float)pow(10, factor))
-            return 5 * pow(10, factor);
+        int ten_to_factor = AK::pow<int>(10, factor);
+        if (step_target <= 1 * ten_to_factor)
+            return 1 * ten_to_factor;
+        if (step_target <= 2 * ten_to_factor)
+            return 2 * ten_to_factor;
+        if (step_target <= 5 * ten_to_factor)
+            return 5 * ten_to_factor;
     }
-    return 1 * pow(10, max_factor);
+    return AK::pow<int>(10, max_factor);
 }
 
 Gfx::IntRect ImageEditor::mouse_indicator_rect_x() const

--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -46,7 +46,7 @@ void BarsVisualizationWidget::paint_event(GUI::PaintEvent& event)
         groups[i / bins_per_group] += AK::fabs(m_sample_buffer.data()[i].real());
     }
     for (int i = 0; i < group_count; i++)
-        groups[i] /= max * freq_bin / (m_adjust_frequencies ? (clamp(AK::pow(AK::E<double>, (double)i / group_count * 3.) - 1.75, 1., 15.)) : 1.);
+        groups[i] /= max * freq_bin / (m_adjust_frequencies ? (clamp(AK::exp((double)i / group_count * 3.) - 1.75, 1., 15.)) : 1.);
 
     const int horizontal_margin = 30;
     const int top_vertical_margin = 15;

--- a/Userland/Games/2048/GameSizeDialog.cpp
+++ b/Userland/Games/2048/GameSizeDialog.cpp
@@ -6,7 +6,7 @@
 
 #include "GameSizeDialog.h"
 #include "Game.h"
-#include <AK/Math.h>
+#include <AK/IntegralMath.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CheckBox.h>

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -8,6 +8,7 @@
 #include <AK/FixedArray.h>
 #include <AK/FlyString.h>
 #include <AK/Format.h>
+#include <AK/IntegralMath.h>
 #include <AK/Math.h>
 #include <AK/ScopeGuard.h>
 #include <AK/StdLibExtras.h>

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/Array.h>
 #include <AK/Debug.h>
-#include <AK/Math.h>
+#include <AK/IntegralMath.h>
 #include <AK/Memory.h>
 #include <AK/MemoryStream.h>
 #include <AK/NonnullOwnPtrVector.h>

--- a/Userland/Libraries/LibVideo/MatroskaReader.h
+++ b/Userland/Libraries/LibVideo/MatroskaReader.h
@@ -8,7 +8,7 @@
 
 #include "MatroskaDocument.h"
 #include <AK/Debug.h>
-#include <AK/Math.h>
+#include <AK/IntegralMath.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/Optional.h>
 #include <AK/OwnPtr.h>


### PR DESCRIPTION
This was mainly done to resolve:
```c++
#ifdef KERNEL
        // We don't have pow() in kernel land
        u64 scale = 10;
        for (size_t i = 0; i < precision - 1; i++) // TODO: not efficient
            scale *= 10;
#else
        u64 scale = pow(10.0, (double)precision);
#endif
```
But turns out we were doing the same in other parts of the code base aswell