### PR TITLE
AK+LibJS: Prevent implicit pointer-to-bool conversion in Value constructor

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -83,6 +83,7 @@ using AK::Concepts::Integral;
 using AK::Concepts::IterableContainer;
 using AK::Concepts::IteratorFunction;
 using AK::Concepts::IteratorPairWith;
+using AK::Concepts::SameAs;
 using AK::Concepts::Signed;
 using AK::Concepts::Unsigned;
 using AK::Concepts::VoidFunction;

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -9,6 +9,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/BitCast.h>
+#include <AK/Concepts.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Function.h>
@@ -131,7 +132,8 @@ public:
     {
     }
 
-    explicit Value(bool value)
+    template<typename T>
+    requires(SameAs<RemoveCVReference<T>, bool>) explicit Value(T value)
         : m_type(Type::Boolean)
     {
         m_value.as_bool = value;


### PR DESCRIPTION
This has bitten me an embarrassingly large number of times, so let's just nip it in the bud :)

If we forget to include Array.h, we'll now get an error like:
```
error: no matching function for call to ‘JS::Value::Value(JS::Array*)’
```