### PR TITLE
LibJS: Small module follow up including JSON modules

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -4231,12 +4231,17 @@ void ExportStatement::dump(int indent) const
 
     for (auto& entry : m_entries) {
         print_indent(indent + 2);
-        out("ModuleRequest: {}", entry.module_request.module_specifier);
-        dump_assert_clauses(entry.module_request);
-        outln(", ImportName: {}, LocalName: {}, ExportName: {}",
-            entry.kind == ExportEntry::Kind::ModuleRequest ? string_or_null(entry.local_or_import_name) : "null",
-            entry.kind != ExportEntry::Kind::ModuleRequest ? string_or_null(entry.local_or_import_name) : "null",
-            string_or_null(entry.export_name));
+        out("ExportName: {}, ImportName: {}, LocalName: {}, ModuleRequest: ",
+            string_or_null(entry.export_name),
+            entry.is_module_request() ? string_or_null(entry.local_or_import_name) : "null",
+            entry.is_module_request() ? "null" : string_or_null(entry.local_or_import_name));
+        if (entry.is_module_request()) {
+            out("{}", entry.m_module_request->module_specifier);
+            dump_assert_clauses(*entry.m_module_request);
+            outln();
+        } else {
+            outln("null");
+        }
     }
 
     if (m_statement) {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -257,6 +257,8 @@ struct ModuleRequest {
     {
     }
 
+    ModuleRequest(FlyString module_specifier, Vector<Assertion> assertions);
+
     void add_assertion(String key, String value)
     {
         assertions.empend(move(key), move(value));
@@ -309,6 +311,7 @@ public:
     bool has_bound_name(FlyString const& name) const;
     Vector<ImportEntry> const& entries() const { return m_entries; }
     ModuleRequest const& module_request() const { return m_module_request; }
+    ModuleRequest& module_request() { return m_module_request; }
 
 private:
     ModuleRequest m_module_request;
@@ -406,6 +409,12 @@ public:
         return *m_statement;
     }
 
+    ModuleRequest& module_request()
+    {
+        VERIFY(!m_module_request.module_specifier.is_null());
+        return m_module_request;
+    }
+
 private:
     RefPtr<ASTNode> m_statement;
     Vector<ExportEntry> m_entries;
@@ -447,6 +456,9 @@ public:
 
     NonnullRefPtrVector<ImportStatement> const& imports() const { return m_imports; }
     NonnullRefPtrVector<ExportStatement> const& exports() const { return m_exports; }
+
+    NonnullRefPtrVector<ImportStatement>& imports() { return m_imports; }
+    NonnullRefPtrVector<ExportStatement>& exports() { return m_exports; }
 
     bool has_top_level_await() const { return m_has_top_level_await; }
     void set_has_top_level_await() { m_has_top_level_await = true; }

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -268,19 +268,18 @@ struct ModuleRequest {
 
 class ImportStatement final : public Statement {
 public:
+    // ImportEntry Record, https://tc39.es/ecma262/#table-importentry-record-fields
     struct ImportEntry {
-        FlyString import_name;
-        FlyString local_name;
+        FlyString import_name;       // [[ImportName]] if a String
+        FlyString local_name;        // [[LocalName]]
+        bool is_namespace { false }; // [[ImportName]] if `namespace-object`
 
-        ImportEntry(FlyString import_name_, FlyString local_name_)
+        ImportEntry(FlyString import_name_, FlyString local_name_, bool is_namespace_ = false)
             : import_name(move(import_name_))
             , local_name(move(local_name_))
+            , is_namespace(is_namespace_)
         {
-        }
-
-        bool is_namespace() const
-        {
-            return import_name == "*"sv;
+            VERIFY(!is_namespace || import_name.is_null());
         }
 
         ModuleRequest const& module_request() const
@@ -291,7 +290,7 @@ public:
 
     private:
         friend ImportStatement;
-        ModuleRequest* m_module_request;
+        ModuleRequest* m_module_request; // [[ModuleRequest]]
     };
 
     explicit ImportStatement(SourceRange source_range, ModuleRequest from_module, Vector<ImportEntry> entries = {})
@@ -320,52 +319,74 @@ class ExportStatement final : public Statement {
 public:
     static FlyString local_name_for_default;
 
+    // ExportEntry Record, https://tc39.es/ecma262/#table-exportentry-records
     struct ExportEntry {
         enum class Kind {
-            ModuleRequest,
-            LocalExport
+            NamedExport,
+            ModuleRequestAll,
+            ModuleRequestAllButDefault,
         } kind;
-        // Can always have
-        FlyString export_name;
 
-        // Only if module request
-        ModuleRequest module_request;
+        FlyString export_name;          // [[ExportName]]
+        FlyString local_or_import_name; // Either [[ImportName]] or [[LocalName]]
 
-        // Has just one of ones below
-        FlyString local_or_import_name;
-
-        ExportEntry(FlyString export_name, FlyString local_name)
-            : kind(Kind::LocalExport)
-            , export_name(move(export_name))
-            , local_or_import_name(move(local_name))
-        {
-        }
-
-        ExportEntry(ModuleRequest module_request_, FlyString import_name, FlyString export_name_)
-            : kind(Kind::ModuleRequest)
+        ExportEntry(Kind export_kind, FlyString export_name_, FlyString local_or_import_name_)
+            : kind(export_kind)
             , export_name(move(export_name_))
-            , module_request(move(module_request_))
-            , local_or_import_name(move(import_name))
+            , local_or_import_name(move(local_or_import_name_))
         {
         }
 
-        bool is_all_but_default() const
+        bool is_module_request() const
         {
-            return kind == Kind::ModuleRequest && local_or_import_name == "*"sv && export_name.is_null();
+            return m_module_request != nullptr;
         }
 
-        bool is_all() const
+        static ExportEntry indirect_export_entry(ModuleRequest const& module_request, FlyString export_name, FlyString import_name)
         {
-            return kind == Kind::ModuleRequest && local_or_import_name == "*"sv && !export_name.is_empty();
+            ExportEntry entry { Kind::NamedExport, move(export_name), move(import_name) };
+            entry.m_module_request = &module_request;
+            return entry;
+        }
+
+        ModuleRequest const& module_request() const
+        {
+            VERIFY(m_module_request);
+            return *m_module_request;
+        }
+
+    private:
+        ModuleRequest const* m_module_request { nullptr }; // [[ModuleRequest]]
+        friend ExportStatement;
+
+    public:
+        static ExportEntry named_export(FlyString export_name, FlyString local_name)
+        {
+            return ExportEntry { Kind::NamedExport, move(export_name), move(local_name) };
+        }
+
+        static ExportEntry all_but_default_entry()
+        {
+            return ExportEntry { Kind::ModuleRequestAllButDefault, {}, {} };
+        }
+
+        static ExportEntry all_module_request(FlyString export_name)
+        {
+            return ExportEntry { Kind::ModuleRequestAll, move(export_name), {} };
         }
     };
 
-    explicit ExportStatement(SourceRange source_range, RefPtr<ASTNode> statement, Vector<ExportEntry> entries, bool is_default_export)
+    ExportStatement(SourceRange source_range, RefPtr<ASTNode> statement, Vector<ExportEntry> entries, bool is_default_export, ModuleRequest module_request)
         : Statement(source_range)
         , m_statement(move(statement))
         , m_entries(move(entries))
         , m_is_default_export(is_default_export)
+        , m_module_request(move(module_request))
     {
+        if (!m_module_request.module_specifier.is_null()) {
+            for (auto& entry : m_entries)
+                entry.m_module_request = &m_module_request;
+        }
     }
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
@@ -389,6 +410,7 @@ private:
     RefPtr<ASTNode> m_statement;
     Vector<ExportEntry> m_entries;
     bool m_is_default_export { false };
+    ModuleRequest m_module_request;
 };
 
 class Program final : public ScopeNode {

--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -227,6 +227,7 @@ set(SOURCES
     Script.cpp
     SourceTextModule.cpp
     SyntaxHighlighter.cpp
+    SyntheticModule.cpp
     Token.cpp
 )
 

--- a/Userland/Libraries/LibJS/CyclicModule.h
+++ b/Userland/Libraries/LibJS/CyclicModule.h
@@ -32,7 +32,7 @@ public:
     virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) override;
 
 protected:
-    CyclicModule(Realm& realm, StringView filename, bool has_top_level_await, Vector<FlyString> requested_modules);
+    CyclicModule(Realm& realm, StringView filename, bool has_top_level_await, Vector<ModuleRequest> requested_modules);
 
     virtual ThrowCompletionOr<u32> inner_module_linking(VM& vm, Vector<Module*>& stack, u32 index) override;
     virtual ThrowCompletionOr<u32> inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index) override;
@@ -49,7 +49,7 @@ protected:
     ThrowCompletionOr<void> m_evaluation_error;         // [[EvaluationError]]
     Optional<u32> m_dfs_index;                          // [[DFSIndex]]
     Optional<u32> m_dfs_ancestor_index;                 // [[DFSAncestorIndex]]
-    Vector<FlyString> m_requested_modules;              // [[RequestedModules]]
+    Vector<ModuleRequest> m_requested_modules;          // [[RequestedModules]]
     CyclicModule* m_cycle_root;                         // [[CycleRoot]]
     bool m_has_top_level_await { false };               // [[HasTLA]]
     bool m_async_evaluation { false };                  // [[AsyncEvaluation]]

--- a/Userland/Libraries/LibJS/Module.cpp
+++ b/Userland/Libraries/LibJS/Module.cpp
@@ -24,11 +24,7 @@ Module::~Module()
 // 16.2.1.5.1.1 InnerModuleLinking ( module, stack, index ), https://tc39.es/ecma262/#sec-InnerModuleLinking
 ThrowCompletionOr<u32> Module::inner_module_linking(VM& vm, Vector<Module*>&, u32 index)
 {
-    // Note: Until we have something extending module which is not SourceTextModule we crash.
-    VERIFY_NOT_REACHED();
-
     // 1. If module is not a Cyclic Module Record, then
-
     // a. Perform ? module.Link().
     TRY(link(vm));
     // b. Return index.
@@ -38,9 +34,6 @@ ThrowCompletionOr<u32> Module::inner_module_linking(VM& vm, Vector<Module*>&, u3
 // 16.2.1.5.2.1 InnerModuleEvaluation ( module, stack, index ), https://tc39.es/ecma262/#sec-innermoduleevaluation
 ThrowCompletionOr<u32> Module::inner_module_evaluation(VM& vm, Vector<Module*>&, u32 index)
 {
-    // Note: Until we have something extending module which is not SourceTextModule we crash.
-    VERIFY_NOT_REACHED();
-
     // 1. If module is not a Cyclic Module Record, then
     // a. Let promise be ! module.Evaluate().
     auto* promise = TRY(evaluate(vm));

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -304,6 +304,7 @@ void GlobalObject::initialize_global_object()
     m_array_prototype_values_function = &m_array_prototype->get_without_side_effects(vm.names.values).as_function();
     m_date_constructor_now_function = &m_date_constructor->get_without_side_effects(vm.names.now).as_function();
     m_eval_function = &get_without_side_effects(vm.names.eval).as_function();
+    m_json_parse_function = &get_without_side_effects(vm.names.JSON).as_object().get_without_side_effects(vm.names.parse).as_function();
 }
 
 GlobalObject::~GlobalObject()
@@ -324,6 +325,7 @@ void GlobalObject::visit_edges(Visitor& visitor)
     visitor.visit(m_date_constructor_now_function);
     visitor.visit(m_eval_function);
     visitor.visit(m_throw_type_error_function);
+    visitor.visit(m_json_parse_function);
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     visitor.visit(m_##snake_name##_constructor);                                         \

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -42,6 +42,7 @@ public:
     FunctionObject* date_constructor_now_function() const { return m_date_constructor_now_function; }
     FunctionObject* eval_function() const { return m_eval_function; }
     FunctionObject* throw_type_error_function() const { return m_throw_type_error_function; }
+    FunctionObject* json_parse_function() const { return m_json_parse_function; }
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     ConstructorName* snake_name##_constructor() { return m_##snake_name##_constructor; } \
@@ -109,6 +110,7 @@ private:
     FunctionObject* m_date_constructor_now_function { nullptr };
     FunctionObject* m_eval_function { nullptr };
     FunctionObject* m_throw_type_error_function { nullptr };
+    FunctionObject* m_json_parse_function { nullptr };
 
 #define __JS_ENUMERATE(ClassName, snake_name, PrototypeName, ConstructorName, ArrayType) \
     ConstructorName* m_##snake_name##_constructor { nullptr };                           \

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
@@ -38,6 +38,25 @@ struct PromiseCapability {
         _temporary_try_or_reject_result.release_value();                                                                                \
     })
 
+// 27.2.1.1.1 IfAbruptRejectPromise ( value, capability ), https://tc39.es/ecma262/#sec-ifabruptrejectpromise
+#define TRY_OR_REJECT_WITH_VALUE(global_object, capability, expression)                                                                 \
+    ({                                                                                                                                  \
+        auto _temporary_try_or_reject_result = (expression);                                                                            \
+        /* 1. If value is an abrupt completion, then */                                                                                 \
+        if (_temporary_try_or_reject_result.is_error()) {                                                                               \
+            global_object.vm().clear_exception();                                                                                       \
+                                                                                                                                        \
+            /* a. Perform ? Call(capability.[[Reject]], undefined, « value.[[Value]] »). */                                           \
+            TRY(JS::call(global_object, *capability.reject, js_undefined(), *_temporary_try_or_reject_result.release_error().value())); \
+                                                                                                                                        \
+            /* b. Return capability.[[Promise]]. */                                                                                     \
+            return Value { capability.promise };                                                                                        \
+        }                                                                                                                               \
+                                                                                                                                        \
+        /* 2. Else if value is a Completion Record, set value to value.[[Value]]. */                                                    \
+        _temporary_try_or_reject_result.release_value();                                                                                \
+    })
+
 // 27.2.1.5 NewPromiseCapability ( C ), https://tc39.es/ecma262/#sec-newpromisecapability
 ThrowCompletionOr<PromiseCapability> new_promise_capability(GlobalObject& global_object, Value constructor);
 

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -250,7 +250,7 @@ private:
     ThrowCompletionOr<void> iterator_binding_initialization(BindingPattern const& binding, Iterator& iterator_record, Environment* environment, GlobalObject& global_object);
 
     ThrowCompletionOr<NonnullRefPtr<Module>> resolve_imported_module(ScriptOrModule referencing_script_or_module, ModuleRequest const& module_request);
-    ThrowCompletionOr<void> link_and_eval_module(SourceTextModule& module);
+    ThrowCompletionOr<void> link_and_eval_module(Module& module);
 
     void import_module_dynamically(ScriptOrModule referencing_script_or_module, ModuleRequest module_request, PromiseCapability promise_capability);
     void finish_dynamic_import(ScriptOrModule referencing_script_or_module, ModuleRequest module_request, PromiseCapability promise_capability, Promise* inner_promise);
@@ -280,11 +280,12 @@ private:
     struct StoredModule {
         ScriptOrModule referencing_script_or_module;
         String filepath;
+        String type;
         NonnullRefPtr<Module> module;
         bool has_once_started_linking { false };
     };
 
-    StoredModule* get_stored_module(ScriptOrModule const& script_or_module, String const& filepath);
+    StoredModule* get_stored_module(ScriptOrModule const& script_or_module, String const& filepath, String const& type);
 
     Vector<StoredModule> m_loaded_modules;
 

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -233,11 +233,13 @@ public:
     ScriptOrModule get_active_script_or_module() const;
 
     Function<ThrowCompletionOr<NonnullRefPtr<Module>>(ScriptOrModule, ModuleRequest const&)> host_resolve_imported_module;
-    Function<void(ScriptOrModule, ModuleRequest const&, PromiseCapability)> host_import_module_dynamically;
+    Function<void(ScriptOrModule, ModuleRequest, PromiseCapability)> host_import_module_dynamically;
     Function<void(ScriptOrModule, ModuleRequest const&, PromiseCapability, Promise*)> host_finish_dynamic_import;
 
     Function<HashMap<PropertyKey, Value>(SourceTextModule const&)> host_get_import_meta_properties;
     Function<void(Object*, SourceTextModule const&)> host_finalize_import_meta;
+
+    Function<Vector<String>()> host_get_supported_import_assertions;
 
     void enable_default_host_import_module_dynamically_hook();
 
@@ -247,11 +249,11 @@ private:
     ThrowCompletionOr<void> property_binding_initialization(BindingPattern const& binding, Value value, Environment* environment, GlobalObject& global_object);
     ThrowCompletionOr<void> iterator_binding_initialization(BindingPattern const& binding, Iterator& iterator_record, Environment* environment, GlobalObject& global_object);
 
-    ThrowCompletionOr<NonnullRefPtr<Module>> resolve_imported_module(ScriptOrModule referencing_script_or_module, ModuleRequest const& specifier);
+    ThrowCompletionOr<NonnullRefPtr<Module>> resolve_imported_module(ScriptOrModule referencing_script_or_module, ModuleRequest const& module_request);
     ThrowCompletionOr<void> link_and_eval_module(SourceTextModule& module);
 
-    void import_module_dynamically(ScriptOrModule referencing_script_or_module, ModuleRequest const& specifier, PromiseCapability promise_capability);
-    void finish_dynamic_import(ScriptOrModule referencing_script_or_module, ModuleRequest const& specifier, PromiseCapability promise_capability, Promise* inner_promise);
+    void import_module_dynamically(ScriptOrModule referencing_script_or_module, ModuleRequest module_request, PromiseCapability promise_capability);
+    void finish_dynamic_import(ScriptOrModule referencing_script_or_module, ModuleRequest module_request, PromiseCapability promise_capability, Promise* inner_promise);
 
     Exception* m_exception { nullptr };
 

--- a/Userland/Libraries/LibJS/SourceTextModule.h
+++ b/Userland/Libraries/LibJS/SourceTextModule.h
@@ -44,7 +44,7 @@ protected:
     virtual Completion execute_module(VM& vm, Optional<PromiseCapability> capability) override;
 
 private:
-    SourceTextModule(Realm&, StringView filename, bool has_top_level_await, NonnullRefPtr<Program> body, Vector<FlyString> requested_modules,
+    SourceTextModule(Realm&, StringView filename, bool has_top_level_await, NonnullRefPtr<Program> body, Vector<ModuleRequest> requested_modules,
         Vector<ImportEntry> import_entries, Vector<ExportEntry> local_export_entries,
         Vector<ExportEntry> indirect_export_entries, Vector<ExportEntry> star_export_entries,
         RefPtr<ExportStatement> default_export);

--- a/Userland/Libraries/LibJS/SyntheticModule.cpp
+++ b/Userland/Libraries/LibJS/SyntheticModule.cpp
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2022, David Tuin <davidot@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/AbstractOperations.h>
+#include <LibJS/Runtime/Completion.h>
+#include <LibJS/Runtime/JSONObject.h>
+#include <LibJS/Runtime/ModuleEnvironment.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibJS/SyntheticModule.h>
+
+namespace JS {
+
+// 1.2.1 CreateSyntheticModule ( exportNames, evaluationSteps, realm, hostDefined ), https://tc39.es/proposal-json-modules/#sec-synthetic-module-records
+SyntheticModule::SyntheticModule(Vector<FlyString> export_names, SyntheticModule::EvaluationFunction evaluation_steps, Realm& realm, StringView filename)
+    : Module(realm, filename)
+    , m_export_names(move(export_names))
+    , m_evaluation_steps(move(evaluation_steps))
+{
+    // 1. Return Synthetic Module Record { [[Realm]]: realm, [[Environment]]: undefined, [[Namespace]]: undefined, [[HostDefined]]: hostDefined, [[ExportNames]]: exportNames, [[EvaluationSteps]]: evaluationSteps }.
+}
+
+// 1.2.3.1 GetExportedNames( exportStarSet ), https://tc39.es/proposal-json-modules/#sec-smr-getexportednames
+ThrowCompletionOr<Vector<FlyString>> JS::SyntheticModule::get_exported_names(VM&, Vector<Module*>)
+{
+    // 1. Return module.[[ExportNames]].
+    return m_export_names;
+}
+
+// 1.2.3.2 ResolveExport( exportName, resolveSet ), https://tc39.es/proposal-json-modules/#sec-smr-resolveexport
+ThrowCompletionOr<ResolvedBinding> JS::SyntheticModule::resolve_export(VM&, FlyString const& export_name, Vector<ResolvedBinding>)
+{
+    // 1. If module.[[ExportNames]] does not contain exportName, return null.
+    if (!m_export_names.contains_slow(export_name))
+        return ResolvedBinding::null();
+
+    // 2. Return ResolvedBinding Record { [[Module]]: module, [[BindingName]]: exportName }.
+    return ResolvedBinding { ResolvedBinding::BindingName, this, export_name };
+}
+
+// 1.2.3.3 Link ( ), https://tc39.es/proposal-json-modules/#sec-smr-instantiate
+ThrowCompletionOr<void> JS::SyntheticModule::link(VM& vm)
+{
+    // Note: Has some changes from PR: https://github.com/tc39/proposal-json-modules/pull/13.
+    //       Which includes renaming it from Instantiate ( ) to Link ( ).
+
+    // 1. Let realm be module.[[Realm]].
+    // 2. Assert: realm is not undefined.
+    // Note: This must be true because we use a reference.
+
+    auto& global_object = realm().global_object();
+
+    // 3. Let env be NewModuleEnvironment(realm.[[GlobalEnv]]).
+    auto* environment = vm.heap().allocate<ModuleEnvironment>(global_object, &realm().global_environment());
+
+    // 4. Set module.[[Environment]] to env.
+    set_environment(environment);
+
+    // 5. For each exportName in module.[[ExportNames]],
+    for (auto& export_name : m_export_names) {
+        // a. Perform ! envRec.CreateMutableBinding(exportName, false).
+        environment->create_mutable_binding(global_object, export_name, false);
+
+        // b. Perform ! envRec.InitializeBinding(exportName, undefined).
+        environment->initialize_binding(global_object, export_name, js_undefined());
+    }
+
+    // 6. Return undefined.
+    // Note: This return value is never visible to the outside so we use void.
+    return {};
+}
+
+// 1.2.3.4 Evaluate ( ), https://tc39.es/proposal-json-modules/#sec-smr-Evaluate
+ThrowCompletionOr<Promise*> JS::SyntheticModule::evaluate(VM& vm)
+{
+    // Note: Has some changes from PR: https://github.com/tc39/proposal-json-modules/pull/13.
+    // 1. Suspend the currently running execution context.
+    // FIXME: We don't have suspend yet.
+
+    // 2. Let moduleContext be a new ECMAScript code execution context.
+    ExecutionContext module_context { vm.heap() };
+
+    // 3. Set the Function of moduleContext to null.
+    // Note: This is the default value.
+
+    // 4. Set the Realm of moduleContext to module.[[Realm]].
+    module_context.realm = &realm();
+
+    // 5. Set the ScriptOrModule of moduleContext to module.
+    module_context.script_or_module = this;
+
+    // 6. Set the VariableEnvironment of moduleContext to module.[[Environment]].
+    module_context.variable_environment = environment();
+
+    // 7. Set the LexicalEnvironment of moduleContext to module.[[Environment]].
+    module_context.lexical_environment = environment();
+
+    // 8. Push moduleContext on to the execution context stack; moduleContext is now the running execution context.
+    vm.push_execution_context(module_context, realm().global_object());
+
+    // 9. Let result be the result of performing module.[[EvaluationSteps]](module).
+    auto result = m_evaluation_steps(*this);
+
+    // 10. Suspend moduleContext and remove it from the execution context stack.
+    vm.pop_execution_context();
+
+    // 11. Resume the context that is now on the top of the execution context stack as the running execution context.
+
+    // 12. Return Completion(result).
+    // Note: Because we expect it to return a promise we convert this here.
+    auto* promise = Promise::create(realm().global_object());
+    if (result.is_error()) {
+        VERIFY(result.throw_completion().value().has_value());
+        promise->reject(*result.throw_completion().value());
+    } else {
+        // Note: This value probably isn't visible to JS code? But undefined is fine anyway.
+        promise->fulfill(js_undefined());
+    }
+    return promise;
+}
+
+// 1.2.2 SetSyntheticModuleExport ( module, exportName, exportValue ), https://tc39.es/proposal-json-modules/#sec-setsyntheticmoduleexport
+ThrowCompletionOr<void> SyntheticModule::set_synthetic_module_export(FlyString const& export_name, Value export_value)
+{
+    // Note: Has some changes from PR: https://github.com/tc39/proposal-json-modules/pull/13.
+    // 1. Return ? module.[[Environment]].SetMutableBinding(name, value, true).
+    return environment()->set_mutable_binding(realm().global_object(), export_name, export_value, true);
+}
+
+// 1.3 CreateDefaultExportSyntheticModule ( defaultExport ), https://tc39.es/proposal-json-modules/#sec-create-default-export-synthetic-module
+NonnullRefPtr<SyntheticModule> SyntheticModule::create_default_export_synthetic_module(Value default_export, Realm& realm, StringView filename)
+{
+    // Note: Has some changes from PR: https://github.com/tc39/proposal-json-modules/pull/13.
+    // 1. Let closure be the a Abstract Closure with parameters (module) that captures defaultExport and performs the following steps when called:
+    auto closure = [default_export = make_handle(default_export)](SyntheticModule& module) -> ThrowCompletionOr<void> {
+        // a. Return ? module.SetSyntheticExport("default", defaultExport).
+        return module.set_synthetic_module_export("default", default_export.value());
+    };
+
+    // 2. Return CreateSyntheticModule("default", closure, realm)
+    return adopt_ref(*new SyntheticModule({ "default" }, move(closure), realm, filename));
+}
+
+// 1.4 ParseJSONModule ( source ), https://tc39.es/proposal-json-modules/#sec-parse-json-module
+ThrowCompletionOr<NonnullRefPtr<Module>> parse_json_module(StringView source_text, Realm& realm, StringView filename)
+{
+    // 1. Let jsonParse be realm's intrinsic object named "%JSON.parse%".
+    auto* json_parse = realm.global_object().json_parse_function();
+
+    // 2. Let json be ? Call(jsonParse, undefined, « sourceText »).
+    auto json = TRY(call(realm.global_object(), *json_parse, js_undefined(), js_string(realm.vm(), source_text)));
+
+    // 3. Return CreateDefaultExportSyntheticModule(json, realm, hostDefined).
+    return SyntheticModule::create_default_export_synthetic_module(json, realm, filename);
+}
+
+}

--- a/Userland/Libraries/LibJS/SyntheticModule.h
+++ b/Userland/Libraries/LibJS/SyntheticModule.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, David Tuin <davidot@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Module.h>
+
+namespace JS {
+
+// 1.2 Synthetic Module Records, https://tc39.es/proposal-json-modules/#sec-synthetic-module-records
+class SyntheticModule final : public Module {
+public:
+    using EvaluationFunction = Function<ThrowCompletionOr<void>(SyntheticModule&)>;
+
+    SyntheticModule(Vector<FlyString> export_names, EvaluationFunction evaluation_steps, Realm& realm, StringView filename);
+
+    static NonnullRefPtr<SyntheticModule> create_default_export_synthetic_module(Value default_export, Realm& realm, StringView filename);
+
+    ThrowCompletionOr<void> set_synthetic_module_export(FlyString const& export_name, Value export_value);
+
+    virtual ThrowCompletionOr<void> link(VM& vm) override;
+    virtual ThrowCompletionOr<Promise*> evaluate(VM& vm) override;
+    virtual ThrowCompletionOr<Vector<FlyString>> get_exported_names(VM& vm, Vector<Module*> export_star_set) override;
+    virtual ThrowCompletionOr<ResolvedBinding> resolve_export(VM& vm, FlyString const& export_name, Vector<ResolvedBinding> resolve_set) override;
+
+private:
+    Vector<FlyString> m_export_names;      // [[ExportNames]]
+    EvaluationFunction m_evaluation_steps; // [[EvaluationSteps]]
+};
+
+ThrowCompletionOr<NonnullRefPtr<Module>> parse_json_module(StringView source_text, Realm& realm, StringView filename);
+
+}

--- a/Userland/Libraries/LibJS/Tests/modules/basic-modules.js
+++ b/Userland/Libraries/LibJS/Tests/modules/basic-modules.js
@@ -9,14 +9,14 @@ function validTestModule(filename) {
     }
 }
 
-function expectModulePassed(filename) {
+function expectModulePassed(filename, options = undefined) {
     validTestModule(filename);
 
     let moduleLoaded = false;
     let moduleResult = null;
     let thrownError = null;
 
-    import(filename)
+    import(filename, options)
         .then(result => {
             moduleLoaded = true;
             moduleResult = result;
@@ -130,6 +130,11 @@ describe("testing behavior", () => {
     test("expectModulePassed works", () => {
         expectModulePassed("./single-const-export.mjs");
     });
+
+    test("can call expectModulePassed with options", () => {
+        expectModulePassed("./single-const-export.mjs", { key: "value" });
+        expectModulePassed("./single-const-export.mjs", { key1: "value1", key2: "value2" });
+    });
 });
 
 describe("in- and exports", () => {
@@ -172,6 +177,10 @@ describe("in- and exports", () => {
             "./indirect-export-without-default.mjs",
             "Invalid or ambiguous export entry 'default'"
         );
+    });
+
+    test("can import with (useless) assertions", () => {
+        expectModulePassed("./import-with-assertions.mjs");
     });
 });
 

--- a/Userland/Libraries/LibJS/Tests/modules/default-and-star-export-indirect.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/default-and-star-export-indirect.mjs
@@ -1,0 +1,2 @@
+// This is an all-but-default export and should thus only provide '*'.
+export * from "./default-and-star-export.mjs";

--- a/Userland/Libraries/LibJS/Tests/modules/default-and-star-export.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/default-and-star-export.mjs
@@ -1,0 +1,6 @@
+export default "defaultValue";
+
+const star = "starExportValue";
+const empty = "empty";
+
+export { star as "*", empty as "" };

--- a/Userland/Libraries/LibJS/Tests/modules/import-with-assertions.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/import-with-assertions.mjs
@@ -1,0 +1,4 @@
+import * as self from "./import-with-assertions.mjs" assert { "key": "value", key2: "value2", default: "shouldwork" };
+import "./import-with-assertions.mjs" assert { "key": "value", key2: "value2", default: "shouldwork" };
+
+export { passed } from "./module-with-default.mjs" assert { "key": "value", key2: "value2", default: "shouldwork" };

--- a/Userland/Libraries/LibJS/Tests/modules/indirect-export-without-default.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/indirect-export-without-default.mjs
@@ -1,0 +1,3 @@
+// Since 'default-and-star-export-indirect.mjs' only contains an all-but-default re export of
+// 'default-and-star-export.mjs' it should not have a default value.
+import defaultExportIndirect from "./default-and-star-export-indirect.mjs";

--- a/Userland/Libraries/LibJS/Tests/modules/json-module.json
+++ b/Userland/Libraries/LibJS/Tests/modules/json-module.json
@@ -1,0 +1,7 @@
+{
+    "value": "value",
+    "array": [1, 2, 3],
+    "map": {
+        "innerValue": "innerValue"
+    }
+}

--- a/Userland/Libraries/LibJS/Tests/modules/json-modules.js
+++ b/Userland/Libraries/LibJS/Tests/modules/json-modules.js
@@ -1,0 +1,34 @@
+describe("basic behavior", () => {
+    test("can import json modules", () => {
+        let passed = false;
+        let error = null;
+        let result = null;
+
+        import("./json-module.json", { assert: { type: "json" } })
+            .then(jsonObj => {
+                passed = true;
+                result = jsonObj;
+            })
+            .catch(err => {
+                error = err;
+            });
+
+        runQueuedPromiseJobs();
+
+        if (error) throw error;
+
+        console.log(JSON.stringify(result));
+        expect(passed).toBeTrue();
+
+        expect(result).not.toBeNull();
+        expect(result).not.toBeUndefined();
+
+        const jsonResult = result.default;
+        expect(jsonResult).not.toBeNull();
+        expect(jsonResult).not.toBeUndefined();
+
+        expect(jsonResult).toHaveProperty("value", "value");
+        expect(jsonResult).toHaveProperty("array", [1, 2, 3]);
+        expect(jsonResult).toHaveProperty("map", { innerValue: "innerValue" });
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/modules/string-import-names.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/string-import-names.mjs
@@ -1,0 +1,12 @@
+import { "*" as starImport, "" as emptyImport } from "./default-and-star-export.mjs";
+
+import {
+    "*" as starImportIndirect,
+    "" as emptyImportIndirect,
+} from "./default-and-star-export-indirect.mjs";
+
+export const passed =
+    starImport === "starExportValue" &&
+    starImportIndirect === "starExportValue" &&
+    emptyImport === "empty" &&
+    emptyImportIndirect === "empty";

--- a/Userland/Libraries/LibJS/Tests/modules/string-import-namespace-indirect.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/string-import-namespace-indirect.mjs
@@ -1,0 +1,6 @@
+import * as indirectNs from "./default-and-star-export-indirect.mjs";
+
+export const passed =
+    indirectNs["*"] === "starExportValue" &&
+    indirectNs[""] === "empty" &&
+    indirectNs.default === undefined;

--- a/Userland/Libraries/LibJS/Tests/modules/string-import-namespace.mjs
+++ b/Userland/Libraries/LibJS/Tests/modules/string-import-namespace.mjs
@@ -1,0 +1,8 @@
+import * as ns from "./default-and-star-export.mjs";
+import defaultExport from "./default-and-star-export.mjs";
+
+export const passed =
+    ns.default === "defaultValue" &&
+    ns["*"] === "starExportValue" &&
+    ns[""] === "empty" &&
+    defaultExport === "defaultValue";


### PR DESCRIPTION
Also fix parsing because as I said in the commit it was too fragile because of course you can do
```js
export {
   val as '',
   val2 as '*'
}
```
Which conflicted with our '*' -> means it's a namespace import logic.