### PR TITLE
LibWeb: Make calc() work for non-length types

### DIFF
--- a/Base/res/html/misc/fonts.html
+++ b/Base/res/html/misc/fonts.html
@@ -37,8 +37,8 @@
         <section>
             <p style="font-family: 'Liberation Serif', cursive; font-size: calc(120% + 10px);">font-family: 'Liberation Serif', cursive; font-size: calc(120% + 10px);</p>
             <p style="font: calc(120% + 10px) 'Liberation Serif', cursive;">font: calc(120% + 10px) 'Liberation Serif', cursive;</p>
-            <p style="font-family: 'Liberation Serif', cursive; font-weight: calc(200 * 4);">font-family: 'Liberation Serif', cursive; font-weight: calc(200 * 4);</p>
-            <p style="font: calc(200*4) 20px 'Liberation Serif', cursive;">font: calc(200 * 4) 20px 'Liberation Serif', cursive;</p>
+            <p style="font-family: 'Liberation Serif', cursive; font-weight: calc((200 * 3) + 100);">font-family: 'Liberation Serif', cursive; font-weight: calc((200 * 3) + 100);</p>
+            <p style="font: calc((200 * 3) + 100) 20px 'Liberation Serif', cursive;">font: calc((200 * 3) + 100) 20px 'Liberation Serif', cursive;</p>
         </section>
 
         <h2>Fallback</h2>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/Generate_CSS_PropertyID_cpp.cpp
@@ -307,12 +307,14 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
 )~~~");
                         } else if (type_name == "length") {
                             property_generator.append(R"~~~(
-        if (style_value.has_length() || style_value.is_calculated())
+        if (style_value.has_length()
+         || (style_value.is_calculated() && style_value.as_calculated().resolved_type() == CalculatedStyleValue::ResolvedType::Length))
             return true;
 )~~~");
                         } else if (type_name == "percentage") {
                             property_generator.append(R"~~~(
-        if (style_value.is_percentage() || style_value.is_calculated())
+        if (style_value.is_percentage()
+        || (style_value.is_calculated() && style_value.as_calculated().resolved_type() == CalculatedStyleValue::ResolvedType::Percentage))
             return true;
 )~~~");
                         } else if (type_name == "number" || type_name == "integer") {
@@ -327,7 +329,7 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                                 max_value = type_args.substring_view(comma_index + 1, type_args.length() - comma_index - 2);
                             }
                             test_generator.append(R"~~~(
-        if (style_value.has_@numbertype@())~~~");
+        if ((style_value.has_@numbertype@())~~~");
                             if (!min_value.is_empty()) {
                                 test_generator.set("minvalue", min_value);
                                 test_generator.append(" && (style_value.to_@numbertype@() >= @minvalue@)");
@@ -337,6 +339,10 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                                 test_generator.append(" && (style_value.to_@numbertype@() <= @maxvalue@)");
                             }
                             test_generator.append(R"~~~()
+        || (style_value.is_calculated() && (style_value.as_calculated().resolved_type() == CalculatedStyleValue::ResolvedType::Integer)~~~");
+                            if (type_name == "number")
+                                test_generator.append(R"~~~(|| style_value.as_calculated().resolved_type() == CalculatedStyleValue::ResolvedType::Number)~~~");
+                            test_generator.append(R"~~~()))
             return true;
 )~~~");
                         } else if (type_name == "string") {

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -37,6 +37,7 @@ set(SOURCES
     CSS/Parser/StyleRules.cpp
     CSS/Parser/Token.cpp
     CSS/Parser/Tokenizer.cpp
+    CSS/Percentage.cpp
     CSS/PreferredColorScheme.cpp
     CSS/PropertyID.cpp
     CSS/PropertyID.h

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -40,6 +40,13 @@ Length Length::make_px(float value)
     return Length(value, Type::Px);
 }
 
+Length Length::make_calculated(NonnullRefPtr<CalculatedStyleValue> calculated_style_value)
+{
+    Length length { 0, Type::Calculated };
+    length.m_calculated_style = move(calculated_style_value);
+    return length;
+}
+
 Length Length::percentage_of(Percentage const& percentage) const
 {
     if (is_undefined_or_auto()) {
@@ -69,11 +76,6 @@ Length Length::resolved_or_auto(Layout::Node const& layout_node) const
 Length Length::resolved_or_zero(Layout::Node const& layout_node) const
 {
     return resolved(make_px(0), layout_node);
-}
-
-void Length::set_calculated_style(CalculatedStyleValue* value)
-{
-    m_calculated_style = value;
 }
 
 float Length::relative_length_to_px(Gfx::IntRect const& viewport_rect, Gfx::FontMetrics const& font_metrics, float root_font_size) const

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -55,7 +55,7 @@ Length Length::resolved(Length const& fallback_for_undefined, Layout::Node const
     if (is_undefined())
         return fallback_for_undefined;
     if (is_calculated())
-        return Length(resolve_calculated_value(layout_node), Type::Px);
+        return m_calculated_style->resolve_length(layout_node).release_value();
     if (is_relative())
         return make_px(to_px(layout_node));
     return *this;
@@ -110,123 +110,6 @@ float Length::to_px(Layout::Node const& layout_node) const
     if (!root_element || !root_element->layout_node())
         return 0;
     return to_px(viewport_rect, layout_node.font().metrics('M'), root_element->layout_node()->font().presentation_size());
-}
-
-static float resolve_calc_value(CalculatedStyleValue::CalcValue const& calc_value, Layout::Node const& layout_node);
-static float resolve_calc_number_value(CalculatedStyleValue::CalcNumberValue const&);
-static float resolve_calc_product(NonnullOwnPtr<CalculatedStyleValue::CalcProduct> const& calc_product, Layout::Node const& layout_node);
-static float resolve_calc_sum(NonnullOwnPtr<CalculatedStyleValue::CalcSum> const& calc_sum, Layout::Node const& layout_node);
-static float resolve_calc_number_sum(NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const&);
-static float resolve_calc_number_product(NonnullOwnPtr<CalculatedStyleValue::CalcNumberProduct> const&);
-
-float Length::resolve_calculated_value(Layout::Node const& layout_node) const
-{
-    if (!m_calculated_style)
-        return 0.0f;
-
-    auto& expression = m_calculated_style->expression();
-
-    auto length = resolve_calc_sum(expression, layout_node);
-    return length;
-};
-
-static float resolve_calc_value(CalculatedStyleValue::CalcValue const& calc_value, Layout::Node const& layout_node)
-{
-    return calc_value.visit(
-        [](float value) { return value; },
-        [&](Length const& length) {
-            return length.resolved_or_zero(layout_node).to_px(layout_node);
-        },
-        [&](NonnullOwnPtr<CalculatedStyleValue::CalcSum> const& calc_sum) {
-            return resolve_calc_sum(calc_sum, layout_node);
-        },
-        [](auto&) {
-            VERIFY_NOT_REACHED();
-            return 0.0f;
-        });
-}
-
-static float resolve_calc_number_product(NonnullOwnPtr<CalculatedStyleValue::CalcNumberProduct> const& calc_number_product)
-{
-    auto value = resolve_calc_number_value(calc_number_product->first_calc_number_value);
-
-    for (auto& additional_number_value : calc_number_product->zero_or_more_additional_calc_number_values) {
-        auto additional_value = resolve_calc_number_value(additional_number_value.value);
-        if (additional_number_value.op == CalculatedStyleValue::CalcNumberProductPartWithOperator::Multiply)
-            value *= additional_value;
-        else if (additional_number_value.op == CalculatedStyleValue::CalcNumberProductPartWithOperator::Divide)
-            value /= additional_value;
-        else
-            VERIFY_NOT_REACHED();
-    }
-
-    return value;
-}
-
-static float resolve_calc_number_sum(NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const& calc_number_sum)
-{
-    auto value = resolve_calc_number_product(calc_number_sum->first_calc_number_product);
-
-    for (auto& additional_product : calc_number_sum->zero_or_more_additional_calc_number_products) {
-        auto additional_value = resolve_calc_number_product(additional_product.calc_number_product);
-        if (additional_product.op == CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Add)
-            value += additional_value;
-        else if (additional_product.op == CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Subtract)
-            value -= additional_value;
-        else
-            VERIFY_NOT_REACHED();
-    }
-
-    return value;
-}
-
-static float resolve_calc_number_value(CalculatedStyleValue::CalcNumberValue const& number_value)
-{
-    return number_value.visit(
-        [](float number) { return number; },
-        [](NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const& calc_number_sum) {
-            return resolve_calc_number_sum(calc_number_sum);
-        });
-}
-
-static float resolve_calc_product(NonnullOwnPtr<CalculatedStyleValue::CalcProduct> const& calc_product, Layout::Node const& layout_node)
-{
-    auto value = resolve_calc_value(calc_product->first_calc_value, layout_node);
-
-    for (auto& additional_value : calc_product->zero_or_more_additional_calc_values) {
-        additional_value.value.visit(
-            [&](CalculatedStyleValue::CalcValue const& calc_value) {
-                if (additional_value.op != CalculatedStyleValue::CalcProductPartWithOperator::Multiply)
-                    VERIFY_NOT_REACHED();
-                auto resolved_value = resolve_calc_value(calc_value, layout_node);
-                value *= resolved_value;
-            },
-            [&](CalculatedStyleValue::CalcNumberValue const& calc_number_value) {
-                if (additional_value.op != CalculatedStyleValue::CalcProductPartWithOperator::Divide)
-                    VERIFY_NOT_REACHED();
-                auto resolved_calc_number_value = resolve_calc_number_value(calc_number_value);
-                value /= resolved_calc_number_value;
-            });
-    }
-
-    return value;
-}
-
-static float resolve_calc_sum(NonnullOwnPtr<CalculatedStyleValue::CalcSum> const& calc_sum, Layout::Node const& layout_node)
-{
-    auto value = resolve_calc_product(calc_sum->first_calc_product, layout_node);
-
-    for (auto& additional_product : calc_sum->zero_or_more_additional_calc_products) {
-        auto additional_value = resolve_calc_product(additional_product.calc_product, layout_node);
-        if (additional_product.op == CalculatedStyleValue::CalcSumPartWithOperator::Operation::Add)
-            value += additional_value;
-        else if (additional_product.op == CalculatedStyleValue::CalcSumPartWithOperator::Operation::Subtract)
-            value -= additional_value;
-        else
-            VERIFY_NOT_REACHED();
-    }
-
-    return value;
 }
 
 const char* Length::unit_name() const

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -43,6 +43,7 @@ public:
 
     static Length make_auto();
     static Length make_px(float value);
+    static Length make_calculated(NonnullRefPtr<CalculatedStyleValue>);
     Length percentage_of(Percentage const&) const;
 
     Length resolved(Length const& fallback_for_undefined, Layout::Node const& layout_node) const;
@@ -130,8 +131,6 @@ public:
     {
         return !(*this == other);
     }
-
-    void set_calculated_style(CalculatedStyleValue* value);
 
     float relative_length_to_px(Gfx::IntRect const& viewport_rect, Gfx::FontMetrics const& font_metrics, float root_font_size) const;
 

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -136,8 +136,6 @@ public:
     float relative_length_to_px(Gfx::IntRect const& viewport_rect, Gfx::FontMetrics const& font_metrics, float root_font_size) const;
 
 private:
-    float resolve_calculated_value(Layout::Node const& layout_node) const;
-
     const char* unit_name() const;
 
     Type m_type { Type::Undefined };

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2124,8 +2124,7 @@ RefPtr<StyleValue> Parser::parse_calculated_value(Vector<StyleComponentValueRule
     };
     dbgln_if(CSS_PARSER_DEBUG, "Deduced calc() resolved type as: {}", to_string(calc_type.value()));
 
-    // FIXME: Either produce a string value of calc() here, or do so in CalculatedStyleValue::to_string().
-    return CalculatedStyleValue::create("(FIXME:calc to string)", calc_expression.release_nonnull(), calc_type.release_value());
+    return CalculatedStyleValue::create(calc_expression.release_nonnull(), calc_type.release_value());
 }
 
 RefPtr<StyleValue> Parser::parse_dynamic_value(StyleComponentValueRule const& component_value)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4207,7 +4207,11 @@ Optional<CalculatedStyleValue::CalcValue> Parser::parse_calc_value(TokenStream<S
     }
 
     if (current_token.is(Token::Type::Number))
-        return CalculatedStyleValue::CalcValue { static_cast<float>(current_token.token().number_value()) };
+        return CalculatedStyleValue::CalcValue {
+            CalculatedStyleValue::Number {
+                .is_integer = current_token.token().number_type() == Token::NumberType::Integer,
+                .value = static_cast<float>(current_token.token().number_value()) }
+        };
 
     if (current_token.is(Token::Type::Dimension) || current_token.is(Token::Type::Percentage)) {
         auto maybe_dimension = parse_dimension(current_token);
@@ -4230,7 +4234,7 @@ OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> Parser::parse_calc_pro
     // Note: The default value is not used or passed around.
     auto product_with_operator = make<CalculatedStyleValue::CalcProductPartWithOperator>(
         CalculatedStyleValue::ProductOperation::Multiply,
-        CalculatedStyleValue::CalcNumberValue { 0 });
+        CalculatedStyleValue::CalcNumberValue { CalculatedStyleValue::Number { false, 0 } });
 
     tokens.skip_whitespace();
 
@@ -4249,6 +4253,7 @@ OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> Parser::parse_calc_pro
         product_with_operator->value = { parsed_calc_value.release_value() };
 
     } else if (op == "/"sv) {
+        // FIXME: Detect divide-by-zero if possible
         tokens.next_token();
         tokens.skip_whitespace();
         product_with_operator->op = CalculatedStyleValue::ProductOperation::Divide;
@@ -4268,7 +4273,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> Parser::parse_ca
     // Note: The default value is not used or passed around.
     auto number_product_with_operator = make<CalculatedStyleValue::CalcNumberProductPartWithOperator>(
         CalculatedStyleValue::ProductOperation::Multiply,
-        CalculatedStyleValue::CalcNumberValue { 0 });
+        CalculatedStyleValue::CalcNumberValue { CalculatedStyleValue::Number { false, 0 } });
 
     tokens.skip_whitespace();
 
@@ -4282,6 +4287,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> Parser::parse_ca
         tokens.skip_whitespace();
         number_product_with_operator->op = CalculatedStyleValue::ProductOperation::Multiply;
     } else if (op == "/"sv) {
+        // FIXME: Detect divide-by-zero if possible
         tokens.next_token();
         tokens.skip_whitespace();
         number_product_with_operator->op = CalculatedStyleValue::ProductOperation::Divide;
@@ -4300,7 +4306,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> Parser::parse_ca
 OwnPtr<CalculatedStyleValue::CalcNumberProduct> Parser::parse_calc_number_product(TokenStream<StyleComponentValueRule>& tokens)
 {
     auto calc_number_product = make<CalculatedStyleValue::CalcNumberProduct>(
-        CalculatedStyleValue::CalcNumberValue { 0 },
+        CalculatedStyleValue::CalcNumberValue { CalculatedStyleValue::Number { false, 0 } },
         NonnullOwnPtrVector<CalculatedStyleValue::CalcNumberProductPartWithOperator> {});
 
     auto first_calc_number_value_or_error = parse_calc_number_value(tokens);
@@ -4378,13 +4384,17 @@ Optional<CalculatedStyleValue::CalcNumberValue> Parser::parse_calc_number_value(
         return {};
     tokens.next_token();
 
-    return CalculatedStyleValue::CalcNumberValue { static_cast<float>(first.token().number_value()) };
+    return CalculatedStyleValue::CalcNumberValue {
+        CalculatedStyleValue::Number {
+            .is_integer = first.token().number_type() == Token::NumberType::Integer,
+            .value = static_cast<float>(first.token().number_value()) }
+    };
 }
 
 OwnPtr<CalculatedStyleValue::CalcProduct> Parser::parse_calc_product(TokenStream<StyleComponentValueRule>& tokens)
 {
     auto calc_product = make<CalculatedStyleValue::CalcProduct>(
-        CalculatedStyleValue::CalcValue { 0 },
+        CalculatedStyleValue::CalcValue { CalculatedStyleValue::Number { false, 0 } },
         NonnullOwnPtrVector<CalculatedStyleValue::CalcProductPartWithOperator> {});
 
     auto first_calc_value_or_error = parse_calc_value(tokens);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4188,7 +4188,7 @@ OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> Parser::parse_calc_pro
 {
     // Note: The default value is not used or passed around.
     auto product_with_operator = make<CalculatedStyleValue::CalcProductPartWithOperator>(
-        CalculatedStyleValue::CalcProductPartWithOperator::Multiply,
+        CalculatedStyleValue::ProductOperation::Multiply,
         CalculatedStyleValue::CalcNumberValue(0));
 
     tokens.skip_whitespace();
@@ -4201,7 +4201,7 @@ OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> Parser::parse_calc_pro
     if (op == "*"sv) {
         tokens.next_token();
         tokens.skip_whitespace();
-        product_with_operator->op = CalculatedStyleValue::CalcProductPartWithOperator::Multiply;
+        product_with_operator->op = CalculatedStyleValue::ProductOperation::Multiply;
         auto parsed_calc_value = parse_calc_value(tokens);
         if (!parsed_calc_value.has_value())
             return nullptr;
@@ -4210,7 +4210,7 @@ OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> Parser::parse_calc_pro
     } else if (op == "/"sv) {
         tokens.next_token();
         tokens.skip_whitespace();
-        product_with_operator->op = CalculatedStyleValue::CalcProductPartWithOperator::Divide;
+        product_with_operator->op = CalculatedStyleValue::ProductOperation::Divide;
         auto parsed_calc_number_value = parse_calc_number_value(tokens);
         if (!parsed_calc_number_value.has_value())
             return nullptr;
@@ -4226,7 +4226,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> Parser::parse_ca
 {
     // Note: The default value is not used or passed around.
     auto number_product_with_operator = make<CalculatedStyleValue::CalcNumberProductPartWithOperator>(
-        CalculatedStyleValue::CalcNumberProductPartWithOperator::Multiply,
+        CalculatedStyleValue::ProductOperation::Multiply,
         CalculatedStyleValue::CalcNumberValue(0));
 
     tokens.skip_whitespace();
@@ -4239,11 +4239,11 @@ OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> Parser::parse_ca
     if (op == "*"sv) {
         tokens.next_token();
         tokens.skip_whitespace();
-        number_product_with_operator->op = CalculatedStyleValue::CalcNumberProductPartWithOperator::Multiply;
+        number_product_with_operator->op = CalculatedStyleValue::ProductOperation::Multiply;
     } else if (op == "/"sv) {
         tokens.next_token();
         tokens.skip_whitespace();
-        number_product_with_operator->op = CalculatedStyleValue::CalcNumberProductPartWithOperator::Divide;
+        number_product_with_operator->op = CalculatedStyleValue::ProductOperation::Divide;
     } else {
         return nullptr;
     }
@@ -4287,12 +4287,12 @@ OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> Parser::parse_calc_n
     auto& token = tokens.next_token();
     tokens.skip_whitespace();
 
-    CalculatedStyleValue::CalcNumberSumPartWithOperator::Operation op;
+    CalculatedStyleValue::SumOperation op;
     auto delim = token.token().delim();
     if (delim == "+"sv)
-        op = CalculatedStyleValue::CalcNumberSumPartWithOperator::Operation::Add;
+        op = CalculatedStyleValue::SumOperation::Add;
     else if (delim == "-"sv)
-        op = CalculatedStyleValue::CalcNumberSumPartWithOperator::Operation::Subtract;
+        op = CalculatedStyleValue::SumOperation::Subtract;
     else
         return nullptr;
 
@@ -4373,12 +4373,12 @@ OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> Parser::parse_calc_sum_par
     auto& token = tokens.next_token();
     tokens.skip_whitespace();
 
-    CalculatedStyleValue::CalcSumPartWithOperator::Operation op;
+    CalculatedStyleValue::SumOperation op;
     auto delim = token.token().delim();
     if (delim == "+"sv)
-        op = CalculatedStyleValue::CalcSumPartWithOperator::Operation::Add;
+        op = CalculatedStyleValue::SumOperation::Add;
     else if (delim == "-"sv)
-        op = CalculatedStyleValue::CalcSumPartWithOperator::Operation::Subtract;
+        op = CalculatedStyleValue::SumOperation::Subtract;
     else
         return nullptr;
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4210,10 +4210,16 @@ Optional<CalculatedStyleValue::CalcValue> Parser::parse_calc_value(TokenStream<S
         return CalculatedStyleValue::CalcValue { static_cast<float>(current_token.token().number_value()) };
 
     if (current_token.is(Token::Type::Dimension) || current_token.is(Token::Type::Percentage)) {
-        auto maybe_length = parse_length(current_token);
-        if (maybe_length.has_value() && !maybe_length.value().is_undefined())
-            return CalculatedStyleValue::CalcValue { maybe_length.value() };
-        return {};
+        auto maybe_dimension = parse_dimension(current_token);
+        if (!maybe_dimension.has_value())
+            return {};
+        auto& dimension = maybe_dimension.value();
+
+        if (dimension.is_length())
+            return CalculatedStyleValue::CalcValue { dimension.length() };
+        if (dimension.is_percentage())
+            return CalculatedStyleValue::CalcValue { dimension.percentage() };
+        VERIFY_NOT_REACHED();
     }
 
     return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -213,6 +213,7 @@ private:
     RefPtr<StyleValue> parse_css_value(StyleComponentValueRule const&);
     RefPtr<StyleValue> parse_builtin_value(StyleComponentValueRule const&);
     RefPtr<StyleValue> parse_dynamic_value(StyleComponentValueRule const&);
+    RefPtr<StyleValue> parse_calculated_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_dimension_value(StyleComponentValueRule const&);
     RefPtr<StyleValue> parse_numeric_value(StyleComponentValueRule const&);
     RefPtr<StyleValue> parse_identifier_value(StyleComponentValueRule const&);

--- a/Userland/Libraries/LibWeb/CSS/Percentage.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Percentage.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/CSS/Percentage.h>
+#include <LibWeb/CSS/StyleValue.h>
+
+namespace Web::CSS {
+
+Length LengthPercentage::resolve_calculated(NonnullRefPtr<CalculatedStyleValue> const& calculated, Layout::Node const& layout_node, Length const& reference_value) const
+{
+    return calculated->resolve_length_percentage(layout_node, reference_value)->resolved(layout_node, reference_value);
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -773,9 +773,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
             maybe_length = font_size->to_length();
 
         } else if (font_size->is_calculated()) {
-            Length length = Length(0, Length::Type::Calculated);
-            length.set_calculated_style(verify_cast<CalculatedStyleValue>(font_size.ptr()));
-            maybe_length = length;
+            maybe_length = Length::make_calculated(font_size->as_calculated());
         }
         if (maybe_length.has_value()) {
             // FIXME: Support font-size: calc(...)

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -714,8 +714,11 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
             weight = Gfx::FontWeight::Bold;
         else
             weight = Gfx::FontWeight::Black;
+    } else if (font_weight->is_calculated()) {
+        auto maybe_weight = font_weight->as_calculated().resolve_integer();
+        if (maybe_weight.has_value())
+            weight = maybe_weight.value();
     }
-    // FIXME: calc() for font-weight
 
     bool bold = weight > Gfx::FontWeight::Regular;
 
@@ -777,6 +780,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
         }
         if (maybe_length.has_value()) {
             // FIXME: Support font-size: calc(...)
+            //        Theoretically we can do this now, but to resolve it we need a layout_node which we might not have. :^(
             if (!maybe_length->is_calculated()) {
                 auto px = maybe_length.value().to_px(viewport_rect, font_metrics, root_font_size);
                 if (px != 0)

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -70,10 +70,8 @@ LengthPercentage StyleProperties::length_percentage_or_fallback(CSS::PropertyID 
         return fallback;
     auto& value = maybe_value.value();
 
-    if (value->is_calculated()) {
-        // FIXME: Handle percentages here
-        return Length::make_calculated(value->as_calculated());
-    }
+    if (value->is_calculated())
+        return LengthPercentage { value->as_calculated() };
 
     if (value->is_percentage())
         return value->as_percentage().percentage();

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -54,11 +54,8 @@ Length StyleProperties::length_or_fallback(CSS::PropertyID id, Length const& fal
         return fallback;
     auto& value = maybe_value.value();
 
-    if (value->is_calculated()) {
-        Length length = Length(0, Length::Type::Calculated);
-        length.set_calculated_style(&value->as_calculated());
-        return length;
-    }
+    if (value->is_calculated())
+        return Length::make_calculated(value->as_calculated());
 
     if (value->has_length())
         return value->to_length();
@@ -75,9 +72,7 @@ LengthPercentage StyleProperties::length_percentage_or_fallback(CSS::PropertyID 
 
     if (value->is_calculated()) {
         // FIXME: Handle percentages here
-        Length length = Length(0, Length::Type::Calculated);
-        length.set_calculated_style(&value->as_calculated());
-        return length;
+        return Length::make_calculated(value->as_calculated());
     }
 
     if (value->is_percentage())

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -164,13 +164,30 @@ float StyleProperties::opacity() const
         return 1.0f;
     auto& value = maybe_value.value();
 
-    if (value->has_number())
-        return clamp(value->to_number(), 0.0f, 1.0f);
+    float unclamped_opacity = 1.0f;
 
-    if (value->is_percentage())
-        return clamp(value->as_percentage().percentage().as_fraction(), 0.0f, 1.0f);
+    if (value->has_number()) {
+        unclamped_opacity = value->to_number();
+    } else if (value->is_calculated()) {
+        auto& calculated = value->as_calculated();
+        if (calculated.resolved_type() == CalculatedStyleValue::ResolvedType::Percentage) {
+            auto maybe_percentage = value->as_calculated().resolve_percentage();
+            if (maybe_percentage.has_value())
+                unclamped_opacity = maybe_percentage->as_fraction();
+            else
+                dbgln("Unable to resolve calc() as opacity (percentage): {}", value->to_string());
+        } else {
+            auto maybe_number = value->as_calculated().resolve_number();
+            if (maybe_number.has_value())
+                unclamped_opacity = maybe_number.value();
+            else
+                dbgln("Unable to resolve calc() as opacity (number): {}", value->to_string());
+        }
+    } else if (value->is_percentage()) {
+        unclamped_opacity = value->as_percentage().percentage().as_fraction();
+    }
 
-    return 1.0f;
+    return clamp(unclamped_opacity, 0.0f, 1.0f);
 }
 
 Optional<CSS::FlexDirection> StyleProperties::flex_direction() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -416,6 +416,30 @@ Optional<LengthPercentage> CalculatedStyleValue::resolve_length_percentage(Layou
         });
 }
 
+Optional<Percentage> CalculatedStyleValue::resolve_percentage() const
+{
+    auto result = m_expression->resolve(nullptr, {});
+    if (result.value().has<Percentage>())
+        return result.value().get<Percentage>();
+    return {};
+}
+
+Optional<float> CalculatedStyleValue::resolve_number()
+{
+    auto result = m_expression->resolve(nullptr, {});
+    if (result.value().has<float>())
+        return result.value().get<float>();
+    return {};
+}
+
+Optional<i64> CalculatedStyleValue::resolve_integer()
+{
+    auto result = m_expression->resolve(nullptr, {});
+    if (result.value().has<float>())
+        return lroundf(result.value().get<float>());
+    return {};
+}
+
 static bool is_number(CalculatedStyleValue::ResolvedType type)
 {
     return type == CalculatedStyleValue::ResolvedType::Number || type == CalculatedStyleValue::ResolvedType::Integer;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -309,9 +309,9 @@ static float resolve_calc_number_product(NonnullOwnPtr<CalculatedStyleValue::Cal
 
     for (auto& additional_number_value : calc_number_product->zero_or_more_additional_calc_number_values) {
         auto additional_value = resolve_calc_number_value(additional_number_value.value);
-        if (additional_number_value.op == CalculatedStyleValue::CalcNumberProductPartWithOperator::Multiply)
+        if (additional_number_value.op == CalculatedStyleValue::ProductOperation::Multiply)
             value *= additional_value;
-        else if (additional_number_value.op == CalculatedStyleValue::CalcNumberProductPartWithOperator::Divide)
+        else if (additional_number_value.op == CalculatedStyleValue::ProductOperation::Divide)
             value /= additional_value;
         else
             VERIFY_NOT_REACHED();
@@ -326,9 +326,9 @@ static float resolve_calc_number_sum(NonnullOwnPtr<CalculatedStyleValue::CalcNum
 
     for (auto& additional_product : calc_number_sum->zero_or_more_additional_calc_number_products) {
         auto additional_value = resolve_calc_number_product(additional_product.calc_number_product);
-        if (additional_product.op == CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Add)
+        if (additional_product.op == CSS::CalculatedStyleValue::SumOperation::Add)
             value += additional_value;
-        else if (additional_product.op == CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Subtract)
+        else if (additional_product.op == CSS::CalculatedStyleValue::SumOperation::Subtract)
             value -= additional_value;
         else
             VERIFY_NOT_REACHED();
@@ -353,13 +353,13 @@ static float resolve_calc_product(NonnullOwnPtr<CalculatedStyleValue::CalcProduc
     for (auto& additional_value : calc_product->zero_or_more_additional_calc_values) {
         additional_value.value.visit(
             [&](CalculatedStyleValue::CalcValue const& calc_value) {
-                if (additional_value.op != CalculatedStyleValue::CalcProductPartWithOperator::Multiply)
+                if (additional_value.op != CalculatedStyleValue::ProductOperation::Multiply)
                     VERIFY_NOT_REACHED();
                 auto resolved_value = resolve_calc_value(calc_value, layout_node);
                 value *= resolved_value;
             },
             [&](CalculatedStyleValue::CalcNumberValue const& calc_number_value) {
-                if (additional_value.op != CalculatedStyleValue::CalcProductPartWithOperator::Divide)
+                if (additional_value.op != CalculatedStyleValue::ProductOperation::Divide)
                     VERIFY_NOT_REACHED();
                 auto resolved_calc_number_value = resolve_calc_number_value(calc_number_value);
                 value /= resolved_calc_number_value;
@@ -375,9 +375,9 @@ static float resolve_calc_sum(NonnullOwnPtr<CalculatedStyleValue::CalcSum> const
 
     for (auto& additional_product : calc_sum->zero_or_more_additional_calc_products) {
         auto additional_value = resolve_calc_product(additional_product.calc_product, layout_node);
-        if (additional_product.op == CalculatedStyleValue::CalcSumPartWithOperator::Operation::Add)
+        if (additional_product.op == CalculatedStyleValue::SumOperation::Add)
             value += additional_value;
-        else if (additional_product.op == CalculatedStyleValue::CalcSumPartWithOperator::Operation::Subtract)
+        else if (additional_product.op == CalculatedStyleValue::SumOperation::Subtract)
             value -= additional_value;
         else
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -271,6 +272,118 @@ String BorderRadiusStyleValue::to_string() const
 String BoxShadowStyleValue::to_string() const
 {
     return String::formatted("{} {} {} {}", m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string());
+}
+
+static float resolve_calc_value(CalculatedStyleValue::CalcValue const& calc_value, Layout::Node const& layout_node);
+static float resolve_calc_number_value(CalculatedStyleValue::CalcNumberValue const&);
+static float resolve_calc_product(NonnullOwnPtr<CalculatedStyleValue::CalcProduct> const& calc_product, Layout::Node const& layout_node);
+static float resolve_calc_sum(NonnullOwnPtr<CalculatedStyleValue::CalcSum> const& calc_sum, Layout::Node const& layout_node);
+static float resolve_calc_number_sum(NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const&);
+static float resolve_calc_number_product(NonnullOwnPtr<CalculatedStyleValue::CalcNumberProduct> const&);
+
+Optional<Length> CalculatedStyleValue::resolve_length(Layout::Node const& layout_node) const
+{
+    auto length = resolve_calc_sum(m_expression, layout_node);
+    return Length::make_px(length);
+}
+
+static float resolve_calc_value(CalculatedStyleValue::CalcValue const& calc_value, Layout::Node const& layout_node)
+{
+    return calc_value.visit(
+        [](float value) { return value; },
+        [&](Length const& length) {
+            return length.resolved_or_zero(layout_node).to_px(layout_node);
+        },
+        [&](NonnullOwnPtr<CalculatedStyleValue::CalcSum> const& calc_sum) {
+            return resolve_calc_sum(calc_sum, layout_node);
+        },
+        [](auto&) {
+            VERIFY_NOT_REACHED();
+            return 0.0f;
+        });
+}
+
+static float resolve_calc_number_product(NonnullOwnPtr<CalculatedStyleValue::CalcNumberProduct> const& calc_number_product)
+{
+    auto value = resolve_calc_number_value(calc_number_product->first_calc_number_value);
+
+    for (auto& additional_number_value : calc_number_product->zero_or_more_additional_calc_number_values) {
+        auto additional_value = resolve_calc_number_value(additional_number_value.value);
+        if (additional_number_value.op == CalculatedStyleValue::CalcNumberProductPartWithOperator::Multiply)
+            value *= additional_value;
+        else if (additional_number_value.op == CalculatedStyleValue::CalcNumberProductPartWithOperator::Divide)
+            value /= additional_value;
+        else
+            VERIFY_NOT_REACHED();
+    }
+
+    return value;
+}
+
+static float resolve_calc_number_sum(NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const& calc_number_sum)
+{
+    auto value = resolve_calc_number_product(calc_number_sum->first_calc_number_product);
+
+    for (auto& additional_product : calc_number_sum->zero_or_more_additional_calc_number_products) {
+        auto additional_value = resolve_calc_number_product(additional_product.calc_number_product);
+        if (additional_product.op == CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Add)
+            value += additional_value;
+        else if (additional_product.op == CSS::CalculatedStyleValue::CalcNumberSumPartWithOperator::Subtract)
+            value -= additional_value;
+        else
+            VERIFY_NOT_REACHED();
+    }
+
+    return value;
+}
+
+static float resolve_calc_number_value(CalculatedStyleValue::CalcNumberValue const& number_value)
+{
+    return number_value.visit(
+        [](float number) { return number; },
+        [](NonnullOwnPtr<CalculatedStyleValue::CalcNumberSum> const& calc_number_sum) {
+            return resolve_calc_number_sum(calc_number_sum);
+        });
+}
+
+static float resolve_calc_product(NonnullOwnPtr<CalculatedStyleValue::CalcProduct> const& calc_product, Layout::Node const& layout_node)
+{
+    auto value = resolve_calc_value(calc_product->first_calc_value, layout_node);
+
+    for (auto& additional_value : calc_product->zero_or_more_additional_calc_values) {
+        additional_value.value.visit(
+            [&](CalculatedStyleValue::CalcValue const& calc_value) {
+                if (additional_value.op != CalculatedStyleValue::CalcProductPartWithOperator::Multiply)
+                    VERIFY_NOT_REACHED();
+                auto resolved_value = resolve_calc_value(calc_value, layout_node);
+                value *= resolved_value;
+            },
+            [&](CalculatedStyleValue::CalcNumberValue const& calc_number_value) {
+                if (additional_value.op != CalculatedStyleValue::CalcProductPartWithOperator::Divide)
+                    VERIFY_NOT_REACHED();
+                auto resolved_calc_number_value = resolve_calc_number_value(calc_number_value);
+                value /= resolved_calc_number_value;
+            });
+    }
+
+    return value;
+}
+
+static float resolve_calc_sum(NonnullOwnPtr<CalculatedStyleValue::CalcSum> const& calc_sum, Layout::Node const& layout_node)
+{
+    auto value = resolve_calc_product(calc_sum->first_calc_product, layout_node);
+
+    for (auto& additional_product : calc_sum->zero_or_more_additional_calc_products) {
+        auto additional_value = resolve_calc_product(additional_product.calc_product, layout_node);
+        if (additional_product.op == CalculatedStyleValue::CalcSumPartWithOperator::Operation::Add)
+            value += additional_value;
+        else if (additional_product.op == CalculatedStyleValue::CalcSumPartWithOperator::Operation::Subtract)
+            value -= additional_value;
+        else
+            VERIFY_NOT_REACHED();
+    }
+
+    return value;
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-sRGB-values

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -574,6 +574,7 @@ Optional<CalculatedStyleValue::ResolvedType> CalculatedStyleValue::CalcValue::re
     return value.visit(
         [](float) -> Optional<CalculatedStyleValue::ResolvedType> { return { ResolvedType::Number }; },
         [](Length const&) -> Optional<CalculatedStyleValue::ResolvedType> { return { ResolvedType::Length }; },
+        [](Percentage const&) -> Optional<CalculatedStyleValue::ResolvedType> { return { ResolvedType::Percentage }; },
         [](NonnullOwnPtr<CalcSum> const& sum) { return sum->resolved_type(); });
 }
 
@@ -603,6 +604,9 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcValue::resolve
         },
         [&](Length const& length) -> CalculatedStyleValue::CalculationResult {
             return CalculatedStyleValue::CalculationResult { length };
+        },
+        [&](Percentage const& percentage) -> CalculatedStyleValue::CalculationResult {
+            return CalculatedStyleValue::CalculationResult { percentage };
         },
         [&](NonnullOwnPtr<CalcSum> const& sum) -> CalculatedStyleValue::CalculationResult {
             return sum->resolve(layout_node, percentage_basis);

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -673,9 +673,14 @@ public:
         Divide,
     };
 
+    struct Number {
+        bool is_integer;
+        float value;
+    };
+
     class CalculationResult {
     public:
-        CalculationResult(Variant<float, Length, Percentage> value)
+        CalculationResult(Variant<Number, Length, Percentage> value)
             : m_value(move(value))
         {
         }
@@ -684,11 +689,11 @@ public:
         void multiply_by(CalculationResult const& other, Layout::Node const*);
         void divide_by(CalculationResult const& other, Layout::Node const*);
 
-        Variant<float, Length, Percentage> const& value() const { return m_value; }
+        Variant<Number, Length, Percentage> const& value() const { return m_value; }
 
     private:
         void add_or_subtract_internal(SumOperation op, CalculationResult const& other, Layout::Node const*, Length const& percentage_basis);
-        Variant<float, Length, Percentage> m_value;
+        Variant<Number, Length, Percentage> m_value;
     };
 
     struct CalcSum;
@@ -701,13 +706,13 @@ public:
     struct CalcNumberProductPartWithOperator;
 
     struct CalcNumberValue {
-        Variant<float, NonnullOwnPtr<CalcNumberSum>> value;
+        Variant<Number, NonnullOwnPtr<CalcNumberSum>> value;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcValue {
-        Variant<float, Length, Percentage, NonnullOwnPtr<CalcSum>> value;
+        Variant<Number, Length, Percentage, NonnullOwnPtr<CalcSum>> value;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -664,6 +664,33 @@ public:
         Time,
     };
 
+    enum class SumOperation {
+        Add,
+        Subtract,
+    };
+    enum class ProductOperation {
+        Multiply,
+        Divide,
+    };
+
+    class CalculationResult {
+    public:
+        CalculationResult(Variant<float, Length, Percentage> value)
+            : m_value(move(value))
+        {
+        }
+        void add(CalculationResult const& other, Layout::Node const*, Length const& percentage_basis);
+        void subtract(CalculationResult const& other, Layout::Node const*, Length const& percentage_basis);
+        void multiply_by(CalculationResult const& other, Layout::Node const*);
+        void divide_by(CalculationResult const& other, Layout::Node const*);
+
+        Variant<float, Length, Percentage> const& value() const { return m_value; }
+
+    private:
+        void add_or_subtract_internal(SumOperation op, CalculationResult const& other, Layout::Node const*, Length const& percentage_basis);
+        Variant<float, Length, Percentage> m_value;
+    };
+
     struct CalcSum;
     struct CalcSumPartWithOperator;
     struct CalcProduct;
@@ -681,15 +708,6 @@ public:
     struct CalcValue {
         Variant<float, CSS::Length, NonnullOwnPtr<CalcSum>> value;
         Optional<ResolvedType> resolved_type() const;
-    };
-
-    enum class SumOperation {
-        Add,
-        Subtract,
-    };
-    enum class ProductOperation {
-        Multiply,
-        Divide,
     };
 
     // This represents that: https://www.w3.org/TR/css-values-3/#calc-syntax

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -703,11 +703,13 @@ public:
     struct CalcNumberValue {
         Variant<float, NonnullOwnPtr<CalcNumberSum>> value;
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcValue {
         Variant<float, CSS::Length, NonnullOwnPtr<CalcSum>> value;
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     // This represents that: https://www.w3.org/TR/css-values-3/#calc-syntax
@@ -720,6 +722,7 @@ public:
         NonnullOwnPtrVector<CalcSumPartWithOperator> zero_or_more_additional_calc_products;
 
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcNumberSum {
@@ -731,6 +734,7 @@ public:
         NonnullOwnPtrVector<CalcNumberSumPartWithOperator> zero_or_more_additional_calc_number_products;
 
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcProduct {
@@ -738,6 +742,7 @@ public:
         NonnullOwnPtrVector<CalcProductPartWithOperator> zero_or_more_additional_calc_values;
 
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcSumPartWithOperator {
@@ -749,6 +754,7 @@ public:
         NonnullOwnPtr<CalcProduct> value;
 
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcProductPartWithOperator {
@@ -756,6 +762,7 @@ public:
         Variant<CalcValue, CalcNumberValue> value;
 
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcNumberProduct {
@@ -763,6 +770,7 @@ public:
         NonnullOwnPtrVector<CalcNumberProductPartWithOperator> zero_or_more_additional_calc_number_values;
 
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcNumberProductPartWithOperator {
@@ -770,6 +778,7 @@ public:
         CalcNumberValue value;
 
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcNumberSumPartWithOperator {
@@ -781,6 +790,7 @@ public:
         NonnullOwnPtr<CalcNumberProduct> value;
 
         Optional<ResolvedType> resolved_type() const;
+        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     static NonnullRefPtr<CalculatedStyleValue> create(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)
@@ -792,6 +802,7 @@ public:
     ResolvedType resolved_type() const { return m_resolved_type; }
     NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
     Optional<Length> resolve_length(Layout::Node const& layout_node) const;
+    Optional<LengthPercentage> resolve_length_percentage(Layout::Node const&, Length const& percentage_basis) const;
 
 private:
     explicit CalculatedStyleValue(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -707,7 +707,7 @@ public:
     };
 
     struct CalcValue {
-        Variant<float, CSS::Length, NonnullOwnPtr<CalcSum>> value;
+        Variant<float, Length, Percentage, NonnullOwnPtr<CalcSum>> value;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -707,12 +707,14 @@ public:
 
     struct CalcNumberValue {
         Variant<Number, NonnullOwnPtr<CalcNumberSum>> value;
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
     struct CalcValue {
         Variant<Number, Length, Percentage, NonnullOwnPtr<CalcSum>> value;
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
@@ -726,6 +728,7 @@ public:
         NonnullOwnPtr<CalcProduct> first_calc_product;
         NonnullOwnPtrVector<CalcSumPartWithOperator> zero_or_more_additional_calc_products;
 
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
@@ -738,6 +741,7 @@ public:
         NonnullOwnPtr<CalcNumberProduct> first_calc_number_product;
         NonnullOwnPtrVector<CalcNumberSumPartWithOperator> zero_or_more_additional_calc_number_products;
 
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
@@ -746,6 +750,7 @@ public:
         CalcValue first_calc_value;
         NonnullOwnPtrVector<CalcProductPartWithOperator> zero_or_more_additional_calc_values;
 
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
@@ -758,6 +763,7 @@ public:
         SumOperation op;
         NonnullOwnPtr<CalcProduct> value;
 
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
@@ -766,6 +772,7 @@ public:
         ProductOperation op;
         Variant<CalcValue, CalcNumberValue> value;
 
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
@@ -774,6 +781,7 @@ public:
         CalcNumberValue first_calc_number_value;
         NonnullOwnPtrVector<CalcNumberProductPartWithOperator> zero_or_more_additional_calc_number_values;
 
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
@@ -782,6 +790,7 @@ public:
         ProductOperation op;
         CalcNumberValue value;
 
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
@@ -794,16 +803,17 @@ public:
         SumOperation op;
         NonnullOwnPtr<CalcNumberProduct> value;
 
+        String to_string() const;
         Optional<ResolvedType> resolved_type() const;
         CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
     };
 
-    static NonnullRefPtr<CalculatedStyleValue> create(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)
+    static NonnullRefPtr<CalculatedStyleValue> create(NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)
     {
-        return adopt_ref(*new CalculatedStyleValue(expression_string, move(calc_sum), resolved_type));
+        return adopt_ref(*new CalculatedStyleValue(move(calc_sum), resolved_type));
     }
 
-    String to_string() const override { return m_expression_string; }
+    String to_string() const override;
     ResolvedType resolved_type() const { return m_resolved_type; }
     NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
     Optional<Length> resolve_length(Layout::Node const& layout_node) const;
@@ -813,16 +823,14 @@ public:
     Optional<i64> resolve_integer();
 
 private:
-    explicit CalculatedStyleValue(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)
+    explicit CalculatedStyleValue(NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)
         : StyleValue(Type::Calculated)
         , m_resolved_type(resolved_type)
-        , m_expression_string(expression_string)
         , m_expression(move(calc_sum))
     {
     }
 
     ResolvedType m_resolved_type;
-    String m_expression_string;
     NonnullOwnPtr<CalcSum> m_expression;
 };
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -803,6 +803,9 @@ public:
     NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
     Optional<Length> resolve_length(Layout::Node const& layout_node) const;
     Optional<LengthPercentage> resolve_length_percentage(Layout::Node const&, Length const& percentage_basis) const;
+    Optional<Percentage> resolve_percentage() const;
+    Optional<float> resolve_number();
+    Optional<i64> resolve_integer();
 
 private:
     explicit CalculatedStyleValue(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -746,6 +746,7 @@ public:
 
     String to_string() const override { return m_expression_string; }
     NonnullOwnPtr<CalcSum> const& expression() const { return m_expression; }
+    Optional<Length> resolve_length(Layout::Node const& layout_node) const;
 
 private:
     explicit CalculatedStyleValue(String const& expression_string, NonnullOwnPtr<CalcSum> calc_sum)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -666,6 +666,15 @@ public:
     using CalcNumberValue = Variant<float, NonnullOwnPtr<CalcNumberSum>>;
     using CalcValue = Variant<float, CSS::Length, NonnullOwnPtr<CalcSum>>;
 
+    enum class SumOperation {
+        Add,
+        Subtract,
+    };
+    enum class ProductOperation {
+        Multiply,
+        Divide,
+    };
+
     // This represents that: https://www.w3.org/TR/css-values-3/#calc-syntax
     struct CalcSum {
         CalcSum(NonnullOwnPtr<CalcProduct> first_calc_product, NonnullOwnPtrVector<CalcSumPartWithOperator> additional)
@@ -691,24 +700,16 @@ public:
     };
 
     struct CalcSumPartWithOperator {
-        enum Operation {
-            Add,
-            Subtract,
-        };
-
-        CalcSumPartWithOperator(Operation op, NonnullOwnPtr<CalcProduct> calc_product)
+        CalcSumPartWithOperator(SumOperation op, NonnullOwnPtr<CalcProduct> calc_product)
             : op(op)
             , calc_product(move(calc_product)) {};
 
-        Operation op;
+        SumOperation op;
         NonnullOwnPtr<CalcProduct> calc_product;
     };
 
     struct CalcProductPartWithOperator {
-        enum {
-            Multiply,
-            Divide,
-        } op;
+        ProductOperation op;
         Variant<CalcValue, CalcNumberValue> value;
     };
 
@@ -718,24 +719,16 @@ public:
     };
 
     struct CalcNumberProductPartWithOperator {
-        enum {
-            Multiply,
-            Divide,
-        } op;
+        ProductOperation op;
         CalcNumberValue value;
     };
 
     struct CalcNumberSumPartWithOperator {
-        enum Operation {
-            Add,
-            Subtract,
-        };
-
-        CalcNumberSumPartWithOperator(Operation op, NonnullOwnPtr<CalcNumberProduct> calc_number_product)
+        CalcNumberSumPartWithOperator(SumOperation op, NonnullOwnPtr<CalcNumberProduct> calc_number_product)
             : op(op)
             , calc_number_product(move(calc_number_product)) {};
 
-        Operation op;
+        SumOperation op;
         NonnullOwnPtr<CalcNumberProduct> calc_number_product;
     };
 

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -128,13 +128,13 @@ void BlockFormattingContext::compute_width(Box& box)
 
     auto margin_left = CSS::Length::make_auto();
     auto margin_right = CSS::Length::make_auto();
-    const auto padding_left = computed_values.padding().left.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
-    const auto padding_right = computed_values.padding().right.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
+    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
 
     auto try_compute_width = [&](const auto& a_width) {
         CSS::Length width = a_width;
-        margin_left = computed_values.margin().left.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
-        margin_right = computed_values.margin().right.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
+        margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+        margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
 
         float total_px = computed_values.border_left().width + computed_values.border_right().width;
         for (auto& value : { margin_left, padding_left, width, padding_right, margin_right }) {
@@ -208,14 +208,14 @@ void BlockFormattingContext::compute_width(Box& box)
         return width;
     };
 
-    auto specified_width = computed_values.width().resolved(width_of_containing_block_as_length).resolved_or_auto(box);
+    auto specified_width = computed_values.width().resolved(box, width_of_containing_block_as_length).resolved_or_auto(box);
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = try_compute_width(specified_width);
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    auto specified_max_width = computed_values.max_width().resolved(width_of_containing_block_as_length).resolved_or_auto(box);
+    auto specified_max_width = computed_values.max_width().resolved(box, width_of_containing_block_as_length).resolved_or_auto(box);
     if (!specified_max_width.is_auto()) {
         if (used_width.to_px(box) > specified_max_width.to_px(box)) {
             used_width = try_compute_width(specified_max_width);
@@ -224,7 +224,7 @@ void BlockFormattingContext::compute_width(Box& box)
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    auto specified_min_width = computed_values.min_width().resolved(width_of_containing_block_as_length).resolved_or_auto(box);
+    auto specified_min_width = computed_values.min_width().resolved(box, width_of_containing_block_as_length).resolved_or_auto(box);
     if (!specified_min_width.is_auto()) {
         if (used_width.to_px(box) < specified_min_width.to_px(box)) {
             used_width = try_compute_width(specified_min_width);
@@ -248,10 +248,10 @@ void BlockFormattingContext::compute_width_for_floating_box(Box& box)
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     auto zero_value = CSS::Length::make_px(0);
 
-    auto margin_left = computed_values.margin().left.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
-    auto margin_right = computed_values.margin().right.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
-    const auto padding_left = computed_values.padding().left.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
-    const auto padding_right = computed_values.padding().right.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
+    auto margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+    auto margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     if (margin_left.is_auto())
@@ -259,7 +259,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box& box)
     if (margin_right.is_auto())
         margin_right = zero_value;
 
-    auto width = computed_values.width().resolved(width_of_containing_block_as_length).resolved_or_auto(box);
+    auto width = computed_values.width().resolved(box, width_of_containing_block_as_length).resolved_or_auto(box);
 
     // If 'width' is computed as 'auto', the used value is the "shrink-to-fit" width.
     if (width.is_auto()) {
@@ -311,15 +311,15 @@ float BlockFormattingContext::compute_theoretical_height(Box const& box)
             || (computed_values.height().is_percentage() && !is_absolute(containing_block.computed_values().height()))) {
             height = compute_auto_height_for_block_level_element(box, ConsiderFloats::No);
         } else {
-            height = computed_values.height().resolved(containing_block_height).resolved_or_auto(box).to_px(box);
+            height = computed_values.height().resolved(box, containing_block_height).resolved_or_auto(box).to_px(box);
         }
     }
 
-    auto specified_max_height = computed_values.max_height().resolved(containing_block_height).resolved_or_auto(box);
+    auto specified_max_height = computed_values.max_height().resolved(box, containing_block_height).resolved_or_auto(box);
     if (!specified_max_height.is_auto()
         && !(computed_values.max_height().is_percentage() && !is_absolute(containing_block.computed_values().height())))
         height = min(height, specified_max_height.to_px(box));
-    auto specified_min_height = computed_values.min_height().resolved(containing_block_height).resolved_or_auto(box);
+    auto specified_min_height = computed_values.min_height().resolved(box, containing_block_height).resolved_or_auto(box);
     if (!specified_min_height.is_auto()
         && !(computed_values.min_height().is_percentage() && !is_absolute(containing_block.computed_values().height())))
         height = max(height, specified_min_height.to_px(box));
@@ -335,13 +335,13 @@ void BlockFormattingContext::compute_height(Box& box)
     // First, resolve the top/bottom parts of the surrounding box model.
 
     // FIXME: While negative values are generally allowed for margins, for now just ignore those for height calculation
-    box.box_model().margin.top = max(computed_values.margin().top.resolved(width_of_containing_block_as_length).resolved_or_zero(box).to_px(box), 0);
-    box.box_model().margin.bottom = max(computed_values.margin().bottom.resolved(width_of_containing_block_as_length).resolved_or_zero(box).to_px(box), 0);
+    box.box_model().margin.top = max(computed_values.margin().top.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box).to_px(box), 0);
+    box.box_model().margin.bottom = max(computed_values.margin().bottom.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box).to_px(box), 0);
 
     box.box_model().border.top = computed_values.border_top().width;
     box.box_model().border.bottom = computed_values.border_bottom().width;
-    box.box_model().padding.top = computed_values.padding().top.resolved(width_of_containing_block_as_length).resolved_or_zero(box).to_px(box);
-    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(width_of_containing_block_as_length).resolved_or_zero(box).to_px(box);
+    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box).to_px(box);
+    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box).to_px(box);
 
     auto height = compute_theoretical_height(box);
     box.set_height(height);
@@ -357,8 +357,8 @@ void BlockFormattingContext::compute_position(Box& box)
     float width_of_containing_block = box.containing_block()->width();
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
 
-    auto specified_left = computed_values.offset().left.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
-    auto specified_right = computed_values.offset().right.resolved(width_of_containing_block_as_length).resolved_or_zero(box);
+    auto specified_left = computed_values.offset().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+    auto specified_right = computed_values.offset().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
 
     if (specified_left.is_auto() && specified_right.is_auto()) {
         // If both 'left' and 'right' are 'auto' (their initial values), the used values are '0' (i.e., the boxes stay in their original position).
@@ -441,12 +441,12 @@ void BlockFormattingContext::compute_vertical_box_model_metrics(Box& child_box, 
     auto const& computed_values = child_box.computed_values();
     auto width_of_containing_block = CSS::Length::make_px(containing_block.width());
 
-    box_model.margin.top = computed_values.margin().top.resolved(width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
-    box_model.margin.bottom = computed_values.margin().bottom.resolved(width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
+    box_model.margin.top = computed_values.margin().top.resolved(child_box, width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
+    box_model.margin.bottom = computed_values.margin().bottom.resolved(child_box, width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
     box_model.border.top = computed_values.border_top().width;
     box_model.border.bottom = computed_values.border_bottom().width;
-    box_model.padding.top = computed_values.padding().top.resolved(width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
-    box_model.padding.bottom = computed_values.padding().bottom.resolved(width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
+    box_model.padding.top = computed_values.padding().top.resolved(child_box, width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
+    box_model.padding.bottom = computed_values.padding().bottom.resolved(child_box, width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
 }
 
 void BlockFormattingContext::place_block_level_element_in_normal_flow_vertically(Box& child_box, BlockContainer const& containing_block)

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -20,7 +20,7 @@ namespace Web::Layout {
 static float get_pixel_size(Box const& box, CSS::LengthPercentage const& length_percentage)
 {
     auto inner_main_size = CSS::Length::make_px(box.containing_block()->width());
-    return length_percentage.resolved(inner_main_size)
+    return length_percentage.resolved(box, inner_main_size)
         .resolved(CSS::Length::make_px(0), box)
         .to_px(box);
 }
@@ -118,15 +118,15 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     // FIXME: This should also take reverse-ness into account
     if (flex_direction == CSS::FlexDirection::Row || flex_direction == CSS::FlexDirection::RowReverse) {
-        item.margins.main_before = item.box.computed_values().margin().left.resolved(width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().right.resolved(width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().top.resolved(width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().bottom.resolved(width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.main_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.main_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.cross_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.cross_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
     } else {
-        item.margins.main_before = item.box.computed_values().margin().top.resolved(width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().bottom.resolved(width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().left.resolved(width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().right.resolved(width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.main_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.main_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.cross_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.cross_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
     }
 };
 
@@ -143,7 +143,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
         flex_container().set_width(flex_container().containing_block()->width());
     } else {
         auto container_width = flex_container().containing_block()->width();
-        auto width = flex_container().computed_values().width().resolved(CSS::Length::make_px(container_width)).resolved_or_zero(flex_container()).to_px(flex_container());
+        auto width = flex_container().computed_values().width().resolved(flex_container(), CSS::Length::make_px(container_width)).resolved_or_zero(flex_container()).to_px(flex_container());
         flex_container().set_width(width);
     }
 
@@ -151,7 +151,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
         flex_container().set_height(flex_container().containing_block()->height());
     } else {
         auto container_height = flex_container().containing_block()->height();
-        auto height = flex_container().computed_values().height().resolved(CSS::Length::make_px(container_height)).resolved_or_zero(flex_container()).to_px(flex_container());
+        auto height = flex_container().computed_values().height().resolved(flex_container(), CSS::Length::make_px(container_height)).resolved_or_zero(flex_container()).to_px(flex_container());
         flex_container().set_height(height);
     }
 
@@ -238,7 +238,7 @@ float FlexFormattingContext::specified_main_size_of_child_box(Box const& child_b
 {
     auto main_size_of_parent = specified_main_size(flex_container());
     auto value = is_row_layout() ? child_box.computed_values().width() : child_box.computed_values().height();
-    return value.resolved(CSS::Length::make_px(main_size_of_parent)).resolved_or_zero(child_box).to_px(child_box);
+    return value.resolved(child_box, CSS::Length::make_px(main_size_of_parent)).resolved_or_zero(child_box).to_px(child_box);
 }
 
 float FlexFormattingContext::specified_main_min_size(Box const& box) const

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -157,10 +157,10 @@ static Gfx::FloatSize solve_replaced_size_constraint(float w, float h, const Rep
     auto width_of_containing_block = CSS::Length::make_px(containing_block.width());
     auto height_of_containing_block = CSS::Length::make_px(containing_block.height());
 
-    auto specified_min_width = box.computed_values().min_width().resolved(width_of_containing_block).resolved_or_zero(box).to_px(box);
-    auto specified_max_width = box.computed_values().max_width().resolved(width_of_containing_block).resolved(CSS::Length::make_px(w), box).to_px(box);
-    auto specified_min_height = box.computed_values().min_height().resolved(height_of_containing_block).resolved_or_auto(box).to_px(box);
-    auto specified_max_height = box.computed_values().max_height().resolved(height_of_containing_block).resolved(CSS::Length::make_px(h), box).to_px(box);
+    auto specified_min_width = box.computed_values().min_width().resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
+    auto specified_max_width = box.computed_values().max_width().resolved(box, width_of_containing_block).resolved(CSS::Length::make_px(w), box).to_px(box);
+    auto specified_min_height = box.computed_values().min_height().resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
+    auto specified_max_height = box.computed_values().max_height().resolved(box, height_of_containing_block).resolved(CSS::Length::make_px(h), box).to_px(box);
 
     auto min_width = min(specified_min_width, specified_max_width);
     auto max_width = max(specified_min_width, specified_max_width);
@@ -252,7 +252,7 @@ float FormattingContext::tentative_width_for_replaced_element(ReplacedBox const&
 {
     auto& containing_block = *box.containing_block();
     auto height_of_containing_block = CSS::Length::make_px(containing_block.height());
-    auto computed_height = box.computed_values().height().resolved(height_of_containing_block).resolved_or_auto(box);
+    auto computed_height = box.computed_values().height().resolved(box, height_of_containing_block).resolved_or_auto(box);
 
     float used_width = computed_width.to_px(box);
 
@@ -314,8 +314,8 @@ float FormattingContext::compute_width_for_replaced_element(const ReplacedBox& b
     auto& containing_block = *box.containing_block();
     auto width_of_containing_block = CSS::Length::make_px(containing_block.width());
 
-    auto margin_left = box.computed_values().margin().left.resolved(width_of_containing_block).resolved_or_zero(box);
-    auto margin_right = box.computed_values().margin().right.resolved(width_of_containing_block).resolved_or_zero(box);
+    auto margin_left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved_or_zero(box);
+    auto margin_right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved_or_zero(box);
 
     // A computed value of 'auto' for 'margin-left' or 'margin-right' becomes a used value of '0'.
     if (margin_left.is_auto())
@@ -323,14 +323,14 @@ float FormattingContext::compute_width_for_replaced_element(const ReplacedBox& b
     if (margin_right.is_auto())
         margin_right = zero_value;
 
-    auto specified_width = box.computed_values().width().resolved(width_of_containing_block).resolved_or_auto(box);
+    auto specified_width = box.computed_values().width().resolved(box, width_of_containing_block).resolved_or_auto(box);
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = tentative_width_for_replaced_element(box, specified_width);
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    auto specified_max_width = box.computed_values().max_width().resolved(width_of_containing_block).resolved_or_auto(box);
+    auto specified_max_width = box.computed_values().max_width().resolved(box, width_of_containing_block).resolved_or_auto(box);
     if (!specified_max_width.is_auto()) {
         if (used_width > specified_max_width.to_px(box)) {
             used_width = tentative_width_for_replaced_element(box, specified_max_width);
@@ -339,7 +339,7 @@ float FormattingContext::compute_width_for_replaced_element(const ReplacedBox& b
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    auto specified_min_width = box.computed_values().min_width().resolved(width_of_containing_block).resolved_or_auto(box);
+    auto specified_min_width = box.computed_values().min_width().resolved(box, width_of_containing_block).resolved_or_auto(box);
     if (!specified_min_width.is_auto()) {
         if (used_width < specified_min_width.to_px(box)) {
             used_width = tentative_width_for_replaced_element(box, specified_min_width);
@@ -355,7 +355,7 @@ float FormattingContext::tentative_height_for_replaced_element(ReplacedBox const
 {
     auto& containing_block = *box.containing_block();
     auto width_of_containing_block = CSS::Length::make_px(containing_block.width());
-    auto computed_width = box.computed_values().width().resolved(width_of_containing_block).resolved_or_auto(box);
+    auto computed_width = box.computed_values().width().resolved(box, width_of_containing_block).resolved_or_auto(box);
 
     // If 'height' and 'width' both have computed values of 'auto' and the element also has
     // an intrinsic height, then that intrinsic height is the used value of 'height'.
@@ -389,8 +389,8 @@ float FormattingContext::compute_height_for_replaced_element(const ReplacedBox& 
     auto& containing_block = *box.containing_block();
     auto width_of_containing_block = CSS::Length::make_px(containing_block.width());
     auto height_of_containing_block = CSS::Length::make_px(containing_block.height());
-    auto specified_width = box.computed_values().width().resolved(width_of_containing_block).resolved_or_auto(box);
-    auto specified_height = box.computed_values().height().resolved(height_of_containing_block).resolved_or_auto(box);
+    auto specified_width = box.computed_values().width().resolved(box, width_of_containing_block).resolved_or_auto(box);
+    auto specified_height = box.computed_values().height().resolved(box, height_of_containing_block).resolved_or_auto(box);
 
     float used_height = tentative_height_for_replaced_element(box, specified_height);
 
@@ -414,15 +414,15 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     auto margin_right = CSS::Length::make_auto();
     const auto border_left = computed_values.border_left().width;
     const auto border_right = computed_values.border_right().width;
-    const auto padding_left = computed_values.padding().left.resolved(width_of_containing_block).resolved_or_zero(box);
-    const auto padding_right = computed_values.padding().right.resolved(width_of_containing_block).resolved_or_zero(box);
+    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block).resolved_or_zero(box);
+    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block).resolved_or_zero(box);
 
     auto try_compute_width = [&](const auto& a_width) {
-        margin_left = computed_values.margin().left.resolved(width_of_containing_block).resolved_or_zero(box);
-        margin_right = computed_values.margin().right.resolved(width_of_containing_block).resolved_or_zero(box);
+        margin_left = computed_values.margin().left.resolved(box, width_of_containing_block).resolved_or_zero(box);
+        margin_right = computed_values.margin().right.resolved(box, width_of_containing_block).resolved_or_zero(box);
 
-        auto left = computed_values.offset().left.resolved(width_of_containing_block).resolved_or_auto(box);
-        auto right = computed_values.offset().right.resolved(width_of_containing_block).resolved_or_auto(box);
+        auto left = computed_values.offset().left.resolved(box, width_of_containing_block).resolved_or_auto(box);
+        auto right = computed_values.offset().right.resolved(box, width_of_containing_block).resolved_or_auto(box);
         auto width = a_width;
 
         auto solve_for_left = [&] {
@@ -511,14 +511,14 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         return width;
     };
 
-    auto specified_width = computed_values.width().resolved(width_of_containing_block).resolved_or_auto(box);
+    auto specified_width = computed_values.width().resolved(box, width_of_containing_block).resolved_or_auto(box);
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = try_compute_width(specified_width);
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    auto specified_max_width = computed_values.max_width().resolved(width_of_containing_block).resolved_or_auto(box);
+    auto specified_max_width = computed_values.max_width().resolved(box, width_of_containing_block).resolved_or_auto(box);
     if (!specified_max_width.is_auto()) {
         if (used_width.to_px(box) > specified_max_width.to_px(box)) {
             used_width = try_compute_width(specified_max_width);
@@ -527,7 +527,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    auto specified_min_width = computed_values.min_width().resolved(width_of_containing_block).resolved_or_auto(box);
+    auto specified_min_width = computed_values.min_width().resolved(box, width_of_containing_block).resolved_or_auto(box);
     if (!specified_min_width.is_auto()) {
         if (used_width.to_px(box) < specified_min_width.to_px(box)) {
             used_width = try_compute_width(specified_min_width);
@@ -559,25 +559,25 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto width_of_containing_block = CSS::Length::make_px(containing_block.width());
     auto height_of_containing_block = CSS::Length::make_px(containing_block.height());
 
-    CSS::Length specified_top = computed_values.offset().top.resolved(height_of_containing_block).resolved_or_auto(box);
-    CSS::Length specified_bottom = computed_values.offset().bottom.resolved(height_of_containing_block).resolved_or_auto(box);
+    CSS::Length specified_top = computed_values.offset().top.resolved(box, height_of_containing_block).resolved_or_auto(box);
+    CSS::Length specified_bottom = computed_values.offset().bottom.resolved(box, height_of_containing_block).resolved_or_auto(box);
     CSS::Length specified_height;
 
     if (computed_values.height().is_percentage() && !(containing_block.computed_values().height().is_length() && containing_block.computed_values().height().length().is_absolute())) {
         specified_height = CSS::Length::make_auto();
     } else {
-        specified_height = computed_values.height().resolved(height_of_containing_block).resolved_or_auto(box);
+        specified_height = computed_values.height().resolved(box, height_of_containing_block).resolved_or_auto(box);
     }
 
-    auto specified_max_height = computed_values.max_height().resolved(height_of_containing_block).resolved_or_auto(box);
-    auto specified_min_height = computed_values.min_height().resolved(height_of_containing_block).resolved_or_auto(box);
+    auto specified_max_height = computed_values.max_height().resolved(box, height_of_containing_block).resolved_or_auto(box);
+    auto specified_min_height = computed_values.min_height().resolved(box, height_of_containing_block).resolved_or_auto(box);
 
-    box.box_model().margin.top = computed_values.margin().top.resolved(width_of_containing_block).resolved_or_zero(box).to_px(box);
-    box.box_model().margin.bottom = computed_values.margin().bottom.resolved(width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box.box_model().margin.top = computed_values.margin().top.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box.box_model().margin.bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
     box.box_model().border.top = computed_values.border_top().width;
     box.box_model().border.bottom = computed_values.border_bottom().width;
-    box.box_model().padding.top = computed_values.padding().top.resolved(width_of_containing_block).resolved_or_zero(box).to_px(box);
-    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
 
     if (specified_height.is_auto() && !specified_top.is_auto() && specified_bottom.is_auto()) {
         const auto& margin = box.box_model().margin;
@@ -613,26 +613,26 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     auto height_of_containing_block = CSS::Length::make_px(containing_block.height());
     auto& box_model = box.box_model();
 
-    auto specified_width = box.computed_values().width().resolved(width_of_containing_block).resolved_or_auto(box);
+    auto specified_width = box.computed_values().width().resolved(box, width_of_containing_block).resolved_or_auto(box);
 
     compute_width_for_absolutely_positioned_element(box);
     (void)layout_inside(box, LayoutMode::Default);
     compute_height_for_absolutely_positioned_element(box);
 
-    box_model.margin.left = box.computed_values().margin().left.resolved(width_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.margin.top = box.computed_values().margin().top.resolved(height_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.margin.right = box.computed_values().margin().right.resolved(width_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.margin.bottom = box.computed_values().margin().bottom.resolved(height_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.margin.top = box.computed_values().margin().top.resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.margin.bottom = box.computed_values().margin().bottom.resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
 
     box_model.border.left = box.computed_values().border_left().width;
     box_model.border.right = box.computed_values().border_right().width;
     box_model.border.top = box.computed_values().border_top().width;
     box_model.border.bottom = box.computed_values().border_bottom().width;
 
-    box_model.offset.left = box.computed_values().offset().left.resolved(width_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.offset.top = box.computed_values().offset().top.resolved(height_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.offset.right = box.computed_values().offset().right.resolved(width_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.offset.bottom = box.computed_values().offset().bottom.resolved(height_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.offset.left = box.computed_values().offset().left.resolved(box, width_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.offset.top = box.computed_values().offset().top.resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.offset.right = box.computed_values().offset().right.resolved(box, width_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.offset.bottom = box.computed_values().offset().bottom.resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
 
     auto is_auto = [](auto const& length_percentage) {
         return length_percentage.is_length() && length_percentage.length().is_auto();

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -119,13 +119,13 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             auto result = calculate_shrink_to_fit_widths(inline_block);
             auto width_of_containing_block = CSS::Length::make_px(containing_block().width());
 
-            auto margin_left = inline_block.computed_values().margin().left.resolved(width_of_containing_block).resolved_or_zero(inline_block).to_px(inline_block);
+            auto margin_left = inline_block.computed_values().margin().left.resolved(box, width_of_containing_block).resolved_or_zero(inline_block).to_px(inline_block);
             auto border_left_width = inline_block.computed_values().border_left().width;
-            auto padding_left = inline_block.computed_values().padding().left.resolved(width_of_containing_block).resolved_or_zero(inline_block).to_px(inline_block);
+            auto padding_left = inline_block.computed_values().padding().left.resolved(box, width_of_containing_block).resolved_or_zero(inline_block).to_px(inline_block);
 
-            auto margin_right = inline_block.computed_values().margin().right.resolved(width_of_containing_block).resolved_or_zero(inline_block).to_px(inline_block);
+            auto margin_right = inline_block.computed_values().margin().right.resolved(box, width_of_containing_block).resolved_or_zero(inline_block).to_px(inline_block);
             auto border_right_width = inline_block.computed_values().border_right().width;
-            auto padding_right = inline_block.computed_values().padding().right.resolved(width_of_containing_block).resolved_or_zero(inline_block).to_px(inline_block);
+            auto padding_right = inline_block.computed_values().padding().right.resolved(box, width_of_containing_block).resolved_or_zero(inline_block).to_px(inline_block);
 
             auto available_width = containing_block().width()
                 - margin_left
@@ -139,7 +139,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             inline_block.set_width(width);
         } else {
             auto container_width = CSS::Length::make_px(containing_block().width());
-            inline_block.set_width(inline_block.computed_values().width().resolved(container_width).resolved_or_zero(inline_block).to_px(inline_block));
+            inline_block.set_width(inline_block.computed_values().width().resolved(box, container_width).resolved_or_zero(inline_block).to_px(inline_block));
         }
         (void)layout_inside(inline_block, layout_mode);
 
@@ -147,7 +147,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.
         } else {
             auto container_height = CSS::Length::make_px(containing_block().height());
-            inline_block.set_height(inline_block.computed_values().height().resolved(container_height).resolved_or_zero(inline_block).to_px(inline_block));
+            inline_block.set_height(inline_block.computed_values().height().resolved(box, container_height).resolved_or_zero(inline_block).to_px(inline_block));
         }
         return;
     }

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -88,20 +88,20 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
                 width = image.width();
                 height = image.height();
             } else if (x_is_auto) {
-                height = layer.size_y.resolved(CSS::Length::make_px(background_positioning_area.height()))
+                height = layer.size_y.resolved(layout_node, CSS::Length::make_px(background_positioning_area.height()))
                              .resolved_or_zero(layout_node)
                              .to_px(layout_node);
                 width = roundf(image.width() * ((float)height / (float)image.height()));
             } else if (y_is_auto) {
-                width = layer.size_x.resolved(CSS::Length::make_px(background_positioning_area.width()))
+                width = layer.size_x.resolved(layout_node, CSS::Length::make_px(background_positioning_area.width()))
                             .resolved_or_zero(layout_node)
                             .to_px(layout_node);
                 height = roundf(image.height() * ((float)width / (float)image.width()));
             } else {
-                width = layer.size_x.resolved(CSS::Length::make_px(background_positioning_area.width()))
+                width = layer.size_x.resolved(layout_node, CSS::Length::make_px(background_positioning_area.width()))
                             .resolved_or_zero(layout_node)
                             .to_px(layout_node);
-                height = layer.size_y.resolved(CSS::Length::make_px(background_positioning_area.height()))
+                height = layer.size_y.resolved(layout_node, CSS::Length::make_px(background_positioning_area.height()))
                              .resolved_or_zero(layout_node)
                              .to_px(layout_node);
             }
@@ -143,7 +143,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         int space_y = background_positioning_area.height() - image_rect.height();
 
         // Position
-        int offset_x = layer.position_offset_x.resolved(CSS::Length::make_px(space_x))
+        int offset_x = layer.position_offset_x.resolved(layout_node, CSS::Length::make_px(space_x))
                            .resolved_or_zero(layout_node)
                            .to_px(layout_node);
         if (layer.position_edge_x == CSS::PositionEdge::Right) {
@@ -152,7 +152,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
             image_rect.set_left(background_positioning_area.left() + offset_x);
         }
 
-        int offset_y = layer.position_offset_y.resolved(CSS::Length::make_px(space_y))
+        int offset_y = layer.position_offset_y.resolved(layout_node, CSS::Length::make_px(space_y))
                            .resolved_or_zero(layout_node)
                            .to_px(layout_node);
         if (layer.position_edge_y == CSS::PositionEdge::Bottom) {

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -17,10 +17,10 @@ BorderRadiusData normalized_border_radius_data(Layout::Node const& node, Gfx::Fl
     //        Spec just says "Refer to corresponding dimension of the border box."
     //        For now, all relative values are relative to the width.
     auto width_length = CSS::Length::make_px(rect.width());
-    auto bottom_left_radius_px = bottom_left_radius.resolved(width_length).resolved_or_zero(node).to_px(node);
-    auto bottom_right_radius_px = bottom_right_radius.resolved(width_length).resolved_or_zero(node).to_px(node);
-    auto top_left_radius_px = top_left_radius.resolved(width_length).resolved_or_zero(node).to_px(node);
-    auto top_right_radius_px = top_right_radius.resolved(width_length).resolved_or_zero(node).to_px(node);
+    auto bottom_left_radius_px = bottom_left_radius.resolved(node, width_length).resolved_or_zero(node).to_px(node);
+    auto bottom_right_radius_px = bottom_right_radius.resolved(node, width_length).resolved_or_zero(node).to_px(node);
+    auto top_left_radius_px = top_left_radius.resolved(node, width_length).resolved_or_zero(node).to_px(node);
+    auto top_right_radius_px = top_right_radius.resolved(node, width_length).resolved_or_zero(node).to_px(node);
 
     // Scale overlapping curves according to https://www.w3.org/TR/css-backgrounds-3/#corner-overlap
     auto f = 1.0f;

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -62,7 +62,7 @@ Optional<float> SVGGraphicsElement::stroke_width() const
         // Resolved relative to the "Scaled viewport size": https://www.w3.org/TR/2017/WD-fill-stroke-3-20170413/#scaled-viewport-size
         // FIXME: This isn't right, but it's something.
         auto scaled_viewport_size = CSS::Length::make_px((client_width() + client_height()) * 0.5f);
-        return width->resolved(scaled_viewport_size).to_px(*layout_node());
+        return width->resolved(*layout_node(), scaled_viewport_size).to_px(*layout_node());
     }
     return {};
 }


### PR DESCRIPTION
Previously, CalculatedStyleValue always resolved as a number of pixels. However, as the spec says:
> A math expression has a resolved type, which is one of `<length>, <frequency>, <angle>, <time>, <percentage>, <number>, or <integer>`.

So, with this PR I've taken the first steps towards that. A CalculatedStyleValue can now be resolved as a Length, LengthPercentage, Percentage, Number or Integer. Hopefully it won't be too much work to add the other dimensions to this as they're implemented, but who knows!

LengthPercentage can store a CalculatedStyleValue, similar to how Length does. It gets resolved the same time that percentages did before, so user code doesn't have to know. Though, user code does have to initialise the LengthPercentage with the calc value so it's not entirely automatic. Probably a job for more `length_or_fallback()`-type helper methods.

Not done yet:
- [ ] Reject `calc()` containing any percentages if the property won't accept them.
- [ ] Detect divide-by-0 during parsing.
- [x] Actually distinguish between `<number>` and `<integer>` values inside `calc()`. Both are treated as `<number>` currently.