### PR TITLE
AK: Free function for getting `.size()` from container

### DIFF
--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -63,14 +63,14 @@ struct _RawPtr {
 namespace AK {
 
 template<typename T, typename SizeType = decltype(sizeof(T)), SizeType N>
-constexpr SizeType array_size(T (&)[N])
+constexpr SizeType size(T (&)[N])
 {
     return N;
 }
 
 template<typename T>
-requires requires { Detail::Decay<T> {}.size(); }
-constexpr auto array_size(T&& t) -> decltype(Detail::Decay<T> {}.size())
+requires requires { Detail::RemoveReference<T> {}.size(); }
+constexpr auto size(T&& t) -> decltype(Detail::RemoveReference<T> {}.size())
 {
     return t.size();
 }
@@ -173,7 +173,6 @@ __DEFINE_GENERIC_ABS(long double, 0.0L, fabsl);
 
 }
 
-using AK::array_size;
 using AK::ceil_div;
 using AK::clamp;
 using AK::exchange;
@@ -182,5 +181,6 @@ using AK::max;
 using AK::min;
 using AK::mix;
 using AK::RawPtr;
+using AK::size;
 using AK::swap;
 using AK::to_underlying;

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -69,6 +69,13 @@ constexpr SizeType array_size(T (&)[N])
 }
 
 template<typename T>
+requires requires { Detail::Decay<T> {}.size(); }
+constexpr auto array_size(T&& t) -> decltype(Detail::Decay<T> {}.size())
+{
+    return t.size();
+}
+
+template<typename T>
 constexpr T min(const T& a, const IdentityType<T>& b)
 {
     return b < a ? b : a;

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -54,7 +54,7 @@ static constexpr StringView UserMemoryRangeTypeNames[] {
     "Boot module",
     "Physical Pages"
 };
-static_assert(array_size(UserMemoryRangeTypeNames) == to_underlying(UsedMemoryRangeType::__Count));
+static_assert(size(UserMemoryRangeTypeNames) == to_underlying(UsedMemoryRangeType::__Count));
 
 struct UsedMemoryRange {
     UsedMemoryRangeType type {};

--- a/Kernel/Net/NE2000/NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000/NetworkAdapter.cpp
@@ -419,7 +419,7 @@ void NE2000NetworkAdapter::receive()
 
             auto packet_result = NetworkByteBuffer::create_uninitialized(bytes_in_packet);
             u8 drop_buffer[NE2K_PAGE_SIZE];
-            Bytes buffer { drop_buffer, array_size(drop_buffer) };
+            Bytes buffer { drop_buffer, size(drop_buffer) };
             bool will_drop { false };
             if (packet_result.is_error()) {
                 dbgln("NE2000NetworkAdapter: Not enough memory for packet with length = {}, dropping.", header.length);

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -78,7 +78,7 @@ extern "C" [[noreturn]] void init()
     // copy the ELF header and program headers because we might end up overwriting them
     ElfW(Ehdr) kernel_elf_header = *(ElfW(Ehdr)*)kernel_image;
     ElfW(Phdr) kernel_program_headers[16];
-    if (kernel_elf_header.e_phnum > array_size(kernel_program_headers))
+    if (kernel_elf_header.e_phnum > size(kernel_program_headers))
         halt();
     __builtin_memcpy(kernel_program_headers, kernel_image + kernel_elf_header.e_phoff, sizeof(ElfW(Phdr)) * kernel_elf_header.e_phnum);
 
@@ -124,7 +124,7 @@ extern "C" [[noreturn]] void init()
 
     __builtin_memset(boot_pd_kernel_pt0, 0, sizeof(boot_pd_kernel_pt0));
 
-    VERIFY((size_t)end_of_prekernel_image < array_size(boot_pd_kernel_pt0) * PAGE_SIZE);
+    VERIFY((size_t)end_of_prekernel_image < size(boot_pd_kernel_pt0) * PAGE_SIZE);
 
     /* pseudo-identity map 0M - end_of_prekernel_image */
     for (size_t i = 0; i < (FlatPtr)end_of_prekernel_image / PAGE_SIZE; i++)

--- a/Tests/AK/TestStdLibExtras.cpp
+++ b/Tests/AK/TestStdLibExtras.cpp
@@ -68,3 +68,23 @@ TEST_CASE(swap_same_complex_object)
     EXPECT(value1.has<Type2>());
     EXPECT(value2.has<Type1>());
 }
+
+TEST_CASE(array_size_of_array)
+{
+    constexpr Array<int, 8> array {};
+    static_assert(8u == array_size(array));
+    EXPECT_EQ(8u, array_size(array));
+}
+
+TEST_CASE(array_size_of_c_array)
+{
+    constexpr int array[8] {};
+    static_assert(8u == array_size(array));
+    EXPECT_EQ(8u, array_size(array));
+}
+
+TEST_CASE(array_size_of_vector)
+{
+    Vector<int> vec {};
+    EXPECT_EQ(0u, array_size(vec));
+}

--- a/Tests/AK/TestStdLibExtras.cpp
+++ b/Tests/AK/TestStdLibExtras.cpp
@@ -69,22 +69,22 @@ TEST_CASE(swap_same_complex_object)
     EXPECT(value2.has<Type1>());
 }
 
-TEST_CASE(array_size_of_array)
+TEST_CASE(size_of_array)
 {
     constexpr Array<int, 8> array {};
-    static_assert(8u == array_size(array));
-    EXPECT_EQ(8u, array_size(array));
+    static_assert(8u == size(array));
+    EXPECT_EQ(8u, size(array));
 }
 
-TEST_CASE(array_size_of_c_array)
+TEST_CASE(size_of_c_array)
 {
     constexpr int array[8] {};
-    static_assert(8u == array_size(array));
-    EXPECT_EQ(8u, array_size(array));
+    static_assert(8u == size(array));
+    EXPECT_EQ(8u, size(array));
 }
 
-TEST_CASE(array_size_of_vector)
+TEST_CASE(size_of_vector)
 {
     Vector<int> vec {};
-    EXPECT_EQ(0u, array_size(vec));
+    EXPECT_EQ(0u, size(vec));
 }

--- a/Tests/Kernel/fuzz-syscalls.cpp
+++ b/Tests/Kernel/fuzz-syscalls.cpp
@@ -140,7 +140,7 @@ static void do_random_tests()
     for (size_t i = 0; i < fuzz_syscall_count; ++i) {
         // Construct a nice syscall:
         int syscall_fn = get_random_uniform(Syscall::Function::__Count);
-        randomize_from(direct_sc_args, array_size(direct_sc_args), interesting_values);
+        randomize_from(direct_sc_args, size(direct_sc_args), interesting_values);
         randomize_from(fake_sc_params, fake_params_count, interesting_values);
 
         if (is_deadly_syscall(syscall_fn)

--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -299,7 +299,7 @@ const char* const sys_errlist[] = {
     ENUMERATE_ERRNO_CODES(__ENUMERATE_ERRNO_CODE)
 #undef __ENUMERATE_ERRNO_CODE
 };
-static_assert(array_size(sys_errlist) == (EMAXERRNO + 1));
+static_assert(size(sys_errlist) == (EMAXERRNO + 1));
 
 int sys_nerr = EMAXERRNO;
 

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -347,7 +347,7 @@ T* Object::find_descendant_of_type_named(String const& name) requires IsBaseOf<O
                 String string_value;                                         \
             } options[] = { __VA_ARGS__ };                                   \
             auto enum_value = getter();                                      \
-            for (size_t i = 0; i < array_size(options); ++i) {               \
+            for (size_t i = 0; i < AK::size(options); ++i) {                 \
                 auto& option = options[i];                                   \
                 if (enum_value == option.enum_value)                         \
                     return option.string_value;                              \
@@ -362,7 +362,7 @@ T* Object::find_descendant_of_type_named(String const& name) requires IsBaseOf<O
             if (!value.is_string())                                          \
                 return false;                                                \
             auto string_value = value.as_string();                           \
-            for (size_t i = 0; i < array_size(options); ++i) {               \
+            for (size_t i = 0; i < AK::size(options); ++i) {                 \
                 auto& option = options[i];                                   \
                 if (string_value == option.string_value) {                   \
                     setter(option.enum_value);                               \

--- a/Userland/Libraries/LibCpp/Lexer.cpp
+++ b/Userland/Libraries/LibCpp/Lexer.cpp
@@ -205,7 +205,7 @@ constexpr StringView s_known_types[] = {
 
 static bool is_keyword(StringView string)
 {
-    static HashTable<String> keywords(array_size(s_known_keywords));
+    static HashTable<String> keywords(size(s_known_keywords));
     if (keywords.is_empty()) {
         keywords.set_from(s_known_keywords);
     }
@@ -214,7 +214,7 @@ static bool is_keyword(StringView string)
 
 static bool is_known_type(StringView string)
 {
-    static HashTable<String> types(array_size(s_known_types));
+    static HashTable<String> types(size(s_known_types));
     if (types.is_empty()) {
         types.set_from(s_known_types);
     }

--- a/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
+++ b/Userland/Libraries/LibCrypto/Cipher/Mode/GCM.h
@@ -90,7 +90,7 @@ public:
             CTR<T>::encrypt(in, out, iv);
 
         auto auth_tag = m_ghash->process(aad, out);
-        block0.apply_initialization_vector({ auth_tag.data, array_size(auth_tag.data) });
+        block0.apply_initialization_vector({ auth_tag.data, size(auth_tag.data) });
         block0.bytes().copy_to(tag);
     }
 
@@ -113,7 +113,7 @@ public:
         CTR<T>::increment(iv);
 
         auto auth_tag = m_ghash->process(aad, in);
-        block0.apply_initialization_vector({ auth_tag.data, array_size(auth_tag.data) });
+        block0.apply_initialization_vector({ auth_tag.data, size(auth_tag.data) });
 
         auto test_consistency = [&] {
             if (block0.block_size() != tag.size() || __builtin_memcmp(block0.bytes().data(), tag.data(), tag.size()) != 0)

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -178,7 +178,7 @@ constexpr double note_frequencies[] = {
     3729.3100921447249,
     3951.0664100489994,
 };
-constexpr size_t note_count = array_size(note_frequencies);
+constexpr size_t note_count = size(note_frequencies);
 
 constexpr double middle_c = note_frequencies[36];
 

--- a/Userland/Libraries/LibGfx/QOILoader.cpp
+++ b/Userland/Libraries/LibGfx/QOILoader.cpp
@@ -27,7 +27,7 @@ static ErrorOr<QOIHeader> decode_qoi_header(InputMemoryStream& stream)
     stream >> Bytes { &header, sizeof(header) };
     if (stream.handle_any_error())
         return Error::from_string_literal("Invalid QOI image: end of stream while reading header"sv);
-    if (StringView { header.magic, array_size(header.magic) } != QOI_MAGIC)
+    if (StringView { header.magic, size(header.magic) } != QOI_MAGIC)
         return Error::from_string_literal("Invalid QOI image: incorrect header magic"sv);
     header.width = AK::convert_between_host_and_big_endian(header.width);
     header.height = AK::convert_between_host_and_big_endian(header.height);
@@ -37,7 +37,7 @@ static ErrorOr<QOIHeader> decode_qoi_header(InputMemoryStream& stream)
 static ErrorOr<Color> decode_qoi_op_rgb(InputMemoryStream& stream, Color pixel)
 {
     u8 bytes[4];
-    stream >> Bytes { &bytes, array_size(bytes) };
+    stream >> Bytes { &bytes, size(bytes) };
     if (stream.handle_any_error())
         return Error::from_string_literal("Invalid QOI image: end of stream while reading QOI_OP_RGB chunk"sv);
     VERIFY(bytes[0] == QOI_OP_RGB);
@@ -49,7 +49,7 @@ static ErrorOr<Color> decode_qoi_op_rgb(InputMemoryStream& stream, Color pixel)
 static ErrorOr<Color> decode_qoi_op_rgba(InputMemoryStream& stream)
 {
     u8 bytes[5];
-    stream >> Bytes { &bytes, array_size(bytes) };
+    stream >> Bytes { &bytes, size(bytes) };
     if (stream.handle_any_error())
         return Error::from_string_literal("Invalid QOI image: end of stream while reading QOI_OP_RGBA chunk"sv);
     VERIFY(bytes[0] == QOI_OP_RGBA);
@@ -92,7 +92,7 @@ static ErrorOr<Color> decode_qoi_op_diff(InputMemoryStream& stream, Color pixel)
 static ErrorOr<Color> decode_qoi_op_luma(InputMemoryStream& stream, Color pixel)
 {
     u8 bytes[2];
-    stream >> Bytes { &bytes, array_size(bytes) };
+    stream >> Bytes { &bytes, size(bytes) };
     if (stream.handle_any_error())
         return Error::from_string_literal("Invalid QOI image: end of stream while reading QOI_OP_LUMA chunk"sv);
     VERIFY((bytes[0] & QOI_MASK_2) == QOI_OP_LUMA);
@@ -131,13 +131,13 @@ static ErrorOr<u8> decode_qoi_op_run(InputMemoryStream& stream)
 
 static ErrorOr<void> decode_qoi_end_marker(InputMemoryStream& stream)
 {
-    u8 bytes[array_size(END_MARKER)];
-    stream >> Bytes { &bytes, array_size(bytes) };
+    u8 bytes[size(END_MARKER)];
+    stream >> Bytes { &bytes, size(bytes) };
     if (stream.handle_any_error())
         return Error::from_string_literal("Invalid QOI image: end of stream while reading end marker"sv);
     if (!stream.eof())
         return Error::from_string_literal("Invalid QOI image: expected end of stream but more bytes are available"sv);
-    if (memcmp(&END_MARKER, &bytes, array_size(bytes)) != 0)
+    if (memcmp(&END_MARKER, &bytes, size(bytes)) != 0)
         return Error::from_string_literal("Invalid QOI image: incorrect end marker"sv);
     return {};
 }

--- a/Userland/Libraries/LibJS/Parser.cpp
+++ b/Userland/Libraries/LibJS/Parser.cpp
@@ -281,7 +281,7 @@ public:
     constexpr OperatorPrecedenceTable()
         : m_token_precedence()
     {
-        for (size_t i = 0; i < array_size(m_operator_precedence); ++i) {
+        for (size_t i = 0; i < size(m_operator_precedence); ++i) {
             auto& op = m_operator_precedence[i];
             m_token_precedence[static_cast<size_t>(op.token)] = op.precedence;
         }


### PR DESCRIPTION
Problem:                                                           
- `AK::array_size(T)` only works for C-arrays.                     
- `array_size` is a misleading name since it is really the size of any
  container which provides `size()` or the number of elements in a    
  C-array.                         
                                                                   
Solution:                                                          
- Add an overload so that all objects which have a `.size()` member
  function can be called using the free function `array_size(T)`.  
- Change to just be `size()` so that it is a consistent name for      
  different types.                                                    
