### PR TITLE
BrowserSettings+MailSettings+MouseSettings: Use standard check box text placement

### DIFF
--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
@@ -79,14 +79,9 @@
                 fixed_width: 32
             }
 
-            @GUI::Label {
-                text: "Show bookmarks:"
-                text_alignment: "CenterLeft"
-                fixed_width: 110
-            }
-
             @GUI::CheckBox {
                 name: "show_bookmarks_bar_checkbox"
+                text: "Show bookmarks"
             }
         }
     }

--- a/Userland/Applications/MailSettings/MailSettingsWidget.gml
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.gml
@@ -81,17 +81,9 @@
                 fixed_width: 32
             }
 
-            @GUI::Label {
-                text: "Use TLS:"
-                fixed_width: 80
-                text_alignment: "CenterLeft"
-                name: "tls_label"
-            }
-
             @GUI::CheckBox {
                 name: "tls_input"
-                fixed_width: 14
-
+                text: "Use TLS"
             }
         }
     }

--- a/Userland/Applications/MouseSettings/Mouse.gml
+++ b/Userland/Applications/MouseSettings/Mouse.gml
@@ -179,18 +179,10 @@
                 name: "switch_buttons_image_label"
             }
 
-            @GUI::Label {
-                text: "Switch primary and secondary buttons"
-                fixed_width: 201
-                text_alignment: "CenterLeft"
-                name: "switch_buttons_label"
-            }
-
             @GUI::CheckBox {
                 name: "switch_buttons_input"
-                fixed_width: 14
-
+                text: "Switch primary and secondary buttons"
             }
         }
-    }    
+    }
 }


### PR DESCRIPTION
This is a redo of #11371 (which I completely forgot about after visiting my parents for the holidays!)

This changes the text for check boxes in these settings apps to be attached to the check box itself, to avoid awkward situations like this focus rect outlining dead space:
![awkward](https://user-images.githubusercontent.com/5600524/147108868-fddc11c1-e822-46b2-8595-7bd62386292a.png)

I considered making this a hard rule with a `VERIFY` in `GUI::CheckBox` itself, but that blows up things like GML Playground, so let's not.

The apps now look like:

BrowserSettings:
![BrowserSettings](https://user-images.githubusercontent.com/5600524/151451679-bef267d6-6e0f-4c6b-939b-5ec647a99ba0.png)

MailSettings:
![MailSettings](https://user-images.githubusercontent.com/5600524/151451691-8c3c5ca2-ab6b-4390-b344-20d1b445a953.png)

MouseSettings:
![MouseSettings](https://user-images.githubusercontent.com/5600524/151451700-51b5e748-fdbd-42a0-8548-abe9120c4476.png)

