### PR TITLE
ls+FileManager+FileSystemAccessServer: Display times in the local time zone

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -50,6 +50,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 using namespace FileManager;
@@ -87,6 +88,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath fattr proc exec unix"));
+    tzset();
 
     Config::pledge_domains({ "FileManager", "WindowManager" });
     Config::monitor_domain("FileManager");

--- a/Userland/Services/FileSystemAccessServer/main.cpp
+++ b/Userland/Services/FileSystemAccessServer/main.cpp
@@ -9,10 +9,12 @@
 #include <LibGUI/Application.h>
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
+#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath wpath unix thread"));
+    tzset();
 
     auto app = GUI::Application::construct(0, nullptr);
     app->set_quit_when_last_window_deleted(false);

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -77,6 +77,7 @@ static bool is_a_tty = false;
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath tty"));
+    tzset();
 
     struct winsize ws;
     int rc = ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);


### PR DESCRIPTION
There are other applications with open/save dialogs that could be updated to do the same, but it's probably better to change them over to using FileSystemAccessServer instead.

...how do we feel about just calling `tzset` in LibMain before invoking `serenity_main`?