### PR TITLE
HackStudio: Fix path to language-server IPC socket

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageClients/ServerConnections.h
+++ b/Userland/DevTools/HackStudio/LanguageClients/ServerConnections.h
@@ -15,7 +15,7 @@
 #define LANGUAGE_CLIENT(language_name_, socket_name)                                                  \
     namespace language_name_ {                                                                        \
     class ServerConnection final : public HackStudio::ServerConnection {                              \
-        IPC_CLIENT_CONNECTION(ServerConnection, "/tmp/portal/language" #socket_name)                  \
+        IPC_CLIENT_CONNECTION(ServerConnection, "/tmp/portal/language/" #socket_name)                 \
     public:                                                                                           \
         static const char* language_name() { return #language_name_; }                                \
                                                                                                       \


### PR DESCRIPTION
The path to the language server local socket was accidentally broken in 2e1bbcb.