### PR TITLE
LibMain: Invoke tzset in LibMain so all apps can have time zone info

### DIFF
--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -14,7 +14,6 @@
 #include <LibGUI/Menubar.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
-#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -24,8 +23,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-
-    tzset();
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-analog-clock"));
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -21,7 +21,6 @@
 #include <LibGUI/Icon.h>
 #include <LibGUI/TabWidget.h>
 #include <LibMain/Main.h>
-#include <time.h>
 #include <unistd.h>
 
 namespace Browser {
@@ -82,8 +81,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/request", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
-
-    tzset();
 
     auto app_icon = GUI::Icon::default_icon("app-browser");
 

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -19,7 +19,6 @@
 #include <LibGUI/Toolbar.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
-#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -31,8 +30,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-
-    tzset();
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-calendar"));
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -50,7 +50,6 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/wait.h>
-#include <time.h>
 #include <unistd.h>
 
 using namespace FileManager;
@@ -88,7 +87,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath fattr proc exec unix"));
-    tzset();
 
     Config::pledge_domains({ "FileManager", "WindowManager" });
     Config::monitor_domain("FileManager");

--- a/Userland/Libraries/LibMain/Main.cpp
+++ b/Userland/Libraries/LibMain/Main.cpp
@@ -9,9 +9,12 @@
 #include <AK/Vector.h>
 #include <LibMain/Main.h>
 #include <string.h>
+#include <time.h>
 
 int main(int argc, char** argv)
 {
+    tzset();
+
     Vector<StringView> arguments;
     arguments.ensure_capacity(argc);
     for (int i = 0; i < argc; ++i)

--- a/Userland/Services/FileSystemAccessServer/main.cpp
+++ b/Userland/Services/FileSystemAccessServer/main.cpp
@@ -9,12 +9,10 @@
 #include <LibGUI/Application.h>
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
-#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath wpath unix thread"));
-    tzset();
 
     auto app = GUI::Application::construct(0, nullptr);
     app->set_quit_when_last_window_deleted(false);

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -16,7 +16,6 @@
 #include <RequestServer/HttpProtocol.h>
 #include <RequestServer/HttpsProtocol.h>
 #include <signal.h>
-#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
@@ -32,8 +31,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-
-    tzset();
 
     [[maybe_unused]] auto gemini = make<RequestServer::GeminiProtocol>();
     [[maybe_unused]] auto http = make<RequestServer::HttpProtocol>();

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -10,7 +10,6 @@
 #include <LibIPC/SingleServer.h>
 #include <LibMain/Main.h>
 #include <WebContent/ClientConnection.h>
-#include <time.h>
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
@@ -22,8 +21,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/portal/websocket", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
-
-    tzset();
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<WebContent::ClientConnection>());
     return event_loop.exec();

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -29,8 +29,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(print_rfc_5322, "Print date in RFC 5322 format", "rfc-5322", 'R');
     args_parser.parse(arguments);
 
-    tzset();
-
     if (set_date != nullptr) {
         auto number = String(set_date).to_uint();
 

--- a/Userland/Utilities/ddate.cpp
+++ b/Userland/Utilities/ddate.cpp
@@ -8,7 +8,6 @@
 #include <LibCore/DateTime.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <time.h>
 #include <unistd.h>
 
 class DiscordianDate {
@@ -104,8 +103,6 @@ private:
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
-
-    tzset();
 
     auto date = Core::DateTime::now();
     outln("Today is {}", DiscordianDate(date).to_string());

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -17,7 +17,6 @@
 #include <LibMain/Main.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <time.h>
 #include <unistd.h>
 
 class Quote {
@@ -87,8 +86,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-
-    tzset();
 
     auto file_contents = file->read_all();
     auto json = TRY(JsonValue::from_string(file_contents));

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -69,7 +69,6 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
-#include <time.h>
 #include <unistd.h>
 
 RefPtr<JS::VM> vm;
@@ -1304,8 +1303,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(disable_syntax_highlight, "Disable live syntax highlighting", "no-syntax-highlight", 's');
     args_parser.add_positional_argument(script_paths, "Path to script files", "scripts", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
-
-    tzset();
 
     bool syntax_highlight = !disable_syntax_highlight;
 

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -77,7 +77,6 @@ static bool is_a_tty = false;
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath tty"));
-    tzset();
 
     struct winsize ws;
     int rc = ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -25,8 +25,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/proc", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    tzset();
-
     auto file = TRY(Core::File::open("/var/run/utmp", Core::OpenMode::ReadOnly));
     auto json = TRY(JsonValue::from_string(file->read_all()));
     if (!json.is_object()) {


### PR DESCRIPTION
And `git revert` previous commits which invoked tzset in specific applications.

Side note, idk why, but it feels nice that this is a POSIX C thing and just works on Lagom apps like `js` without any extra fuss :)