### PR TITLE
CharacterMap: Change the search widget to display results in a TableView

### DIFF
--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
@@ -10,6 +10,7 @@
 
 struct SearchResult {
     u32 code_point;
+    String code_point_string;
     String display_text;
 };
 
@@ -18,13 +19,16 @@ public:
     CharacterSearchModel() { }
 
     int row_count(GUI::ModelIndex const&) const override { return m_data.size(); }
-    int column_count(GUI::ModelIndex const&) const override { return 1; }
+    int column_count(GUI::ModelIndex const&) const override { return 2; }
 
     GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role) const override
     {
         auto& result = m_data.at(index.row());
-        if (role == GUI::ModelRole::Display)
+        if (role == GUI::ModelRole::Display) {
+            if (index.column() == 0)
+                return result.code_point_string;
             return result.display_text;
+        }
         if (role == GUI::ModelRole::Custom)
             return result.code_point;
         return {};
@@ -52,15 +56,16 @@ CharacterSearchWidget::CharacterSearchWidget()
 
     m_search_input = find_descendant_of_type_named<GUI::TextBox>("search_input");
     m_search_button = find_descendant_of_type_named<GUI::Button>("search_button");
-    m_results_list = find_descendant_of_type_named<GUI::ListView>("results_list");
+    m_results_table = find_descendant_of_type_named<GUI::TableView>("results_table");
 
     m_search_input->on_return_pressed = [this] { search(); };
     m_search_button->on_click = [this](auto) { search(); };
 
-    m_results_list->horizontal_scrollbar().set_visible(false);
-    m_results_list->set_model(adopt_ref(*new CharacterSearchModel()));
-    m_results_list->on_activation = [&](GUI::ModelIndex const& index) {
-        auto& model = static_cast<CharacterSearchModel&>(*m_results_list->model());
+    m_results_table->horizontal_scrollbar().set_visible(false);
+    m_results_table->set_column_headers_visible(false);
+    m_results_table->set_model(adopt_ref(*new CharacterSearchModel()));
+    m_results_table->on_activation = [&](GUI::ModelIndex const& index) {
+        auto& model = static_cast<CharacterSearchModel&>(*m_results_table->model());
         auto code_point = model.data(index, GUI::ModelRole::Custom).as_u32();
         if (on_character_selected)
             on_character_selected(code_point);
@@ -75,7 +80,7 @@ void CharacterSearchWidget::search()
 {
     // TODO: Sort the results nicely. They're sorted by code-point for now, which is easy, but not the most useful.
     //       Sorting intelligently in a style similar to Assistant would be nicer.
-    auto& model = static_cast<CharacterSearchModel&>(*m_results_list->model());
+    auto& model = static_cast<CharacterSearchModel&>(*m_results_table->model());
     model.clear();
     auto query = m_search_input->text();
     if (query.is_empty())
@@ -83,9 +88,7 @@ void CharacterSearchWidget::search()
     for_each_character_containing(query, [&](auto code_point, auto& display_name) {
         StringBuilder builder;
         builder.append_code_point(code_point);
-        builder.append(" - ");
-        builder.append(display_name);
 
-        model.add_result({ code_point, builder.to_string() });
+        model.add_result({ code_point, builder.build(), display_name });
     });
 }

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.cpp
@@ -85,10 +85,10 @@ void CharacterSearchWidget::search()
     auto query = m_search_input->text();
     if (query.is_empty())
         return;
-    for_each_character_containing(query, [&](auto code_point, auto& display_name) {
+    for_each_character_containing(query, [&](auto code_point, auto display_name) {
         StringBuilder builder;
         builder.append_code_point(code_point);
 
-        model.add_result({ code_point, builder.build(), display_name });
+        model.add_result({ code_point, builder.build(), move(display_name) });
     });
 }

--- a/Userland/Applications/CharacterMap/CharacterSearchWidget.h
+++ b/Userland/Applications/CharacterMap/CharacterSearchWidget.h
@@ -8,7 +8,7 @@
 
 #include "CharacterMapWidget.h"
 #include <LibGUI/Button.h>
-#include <LibGUI/ListView.h>
+#include <LibGUI/TableView.h>
 #include <LibGUI/TextBox.h>
 
 class CharacterSearchWidget final : public GUI::Widget {
@@ -26,5 +26,5 @@ private:
 
     RefPtr<GUI::TextBox> m_search_input;
     RefPtr<GUI::Button> m_search_button;
-    RefPtr<GUI::ListView> m_results_list;
+    RefPtr<GUI::TableView> m_results_table;
 };

--- a/Userland/Applications/CharacterMap/CharacterSearchWindow.gml
+++ b/Userland/Applications/CharacterMap/CharacterSearchWindow.gml
@@ -15,7 +15,7 @@
         }
     }
 
-    @GUI::ListView {
-        name: "results_list"
+    @GUI::TableView {
+        name: "results_table"
     }
 }

--- a/Userland/Applications/CharacterMap/SearchCharacters.h
+++ b/Userland/Applications/CharacterMap/SearchCharacters.h
@@ -18,9 +18,9 @@ void for_each_character_containing(StringView query, Callback callback)
     // FIXME: There's probably a better way to do this than just looping, but it still only takes ~150ms to run for me!
     for (u32 code_point = 1; code_point <= maximum_code_point; ++code_point) {
         if (auto maybe_display_name = Unicode::code_point_display_name(code_point); maybe_display_name.has_value()) {
-            auto& display_name = maybe_display_name.value();
+            auto display_name = maybe_display_name.release_value();
             if (display_name.contains(uppercase_query_view, AK::CaseSensitivity::CaseSensitive))
-                callback(code_point, display_name);
+                callback(code_point, move(display_name));
         }
     }
 }

--- a/Userland/Applications/CharacterMap/main.cpp
+++ b/Userland/Applications/CharacterMap/main.cpp
@@ -21,7 +21,7 @@ static void search_and_print_results(String const& query)
 {
     outln("Searching for '{}'", query);
     u32 result_count = 0;
-    for_each_character_containing(query, [&](auto code_point, auto& display_name) {
+    for_each_character_containing(query, [&](auto code_point, auto display_name) {
         StringBuilder builder;
         builder.append_code_point(code_point);
         builder.append(" - ");


### PR DESCRIPTION
Noticed that in the CharacterMap search widget, some code points were displayed at the end of the description rather than the beginning, e.g. the `ARABIC SIGN SINDHI POSTPOSITION MEN` code point here:
![before](https://user-images.githubusercontent.com/222642/149346239-e78e2e1e-ddb8-4e67-98c9-756dab52aea2.png)

This is due to bidi text. To keep the view consistent, this breaks the results into two columns, so that the code point is always in the same place:
![after](https://user-images.githubusercontent.com/5600524/151565343-d4474667-40a7-42f5-8189-e6a09c3a0374.png)

