### PR TITLE
UserspaceEmulator: More ioctls + getppid + sigprocmask + signal masking

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/Emulator.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.cpp
@@ -593,6 +593,9 @@ void Emulator::dispatch_one_pending_signal()
     VERIFY(signum != -1);
     m_pending_signals &= ~(1 << signum);
 
+    if (((1 << (signum - 1)) & m_signal_mask) != 0)
+        return;
+
     auto& handler = m_signal_handler[signum];
 
     if (handler.handler == 0) {

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -225,6 +225,7 @@ private:
     int virt$setuid(uid_t);
     int virt$shutdown(int sockfd, int how);
     int virt$sigaction(int, FlatPtr, FlatPtr);
+    int virt$sigprocmask(int how, FlatPtr set, FlatPtr old_set);
     int virt$sigreturn();
     int virt$socket(int, int, int);
     int virt$stat(FlatPtr);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -170,6 +170,7 @@ private:
     int virt$getpgid(pid_t);
     int virt$getpgrp();
     u32 virt$getpid();
+    pid_t virt$getppid();
     ssize_t virt$getrandom(FlatPtr buffer, size_t buffer_size, unsigned int flags);
     int virt$getsid(pid_t);
     int virt$getsockname(FlatPtr);

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -121,6 +121,8 @@ u32 Emulator::virt_syscall(u32 function, u32 arg1, u32 arg2, u32 arg3)
         return virt$getpgrp();
     case SC_getpid:
         return virt$getpid();
+    case SC_getppid:
+        return virt$getppid();
     case SC_getrandom:
         return virt$getrandom(arg1, arg2, arg3);
     case SC_getsid:
@@ -971,6 +973,11 @@ u32 Emulator::virt$gettid()
 u32 Emulator::virt$getpid()
 {
     return getpid();
+}
+
+pid_t Emulator::virt$getppid()
+{
+    return getppid();
 }
 
 u32 Emulator::virt$pledge(u32)

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1154,6 +1154,8 @@ int Emulator::virt$ioctl([[maybe_unused]] int fd, unsigned request, [[maybe_unus
         mmu().copy_from_vm(&termios, arg, sizeof(termios));
         return syscall(SC_ioctl, fd, request, &termios);
     }
+    case TCFLSH:
+        return syscall(SC_ioctl, fd, request, arg);
     case TIOCNOTTY:
     case TIOCSCTTY:
         return syscall(SC_ioctl, fd, request, 0);

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1159,6 +1159,8 @@ int Emulator::virt$ioctl([[maybe_unused]] int fd, unsigned request, [[maybe_unus
     case TIOCNOTTY:
     case TIOCSCTTY:
         return syscall(SC_ioctl, fd, request, 0);
+    case TIOCSTI:
+        return -EIO;
     case FB_IOCTL_GET_PROPERTIES: {
         size_t size = 0;
         auto rc = syscall(SC_ioctl, fd, request, &size);

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1117,6 +1117,11 @@ int Emulator::virt$ioctl([[maybe_unused]] int fd, unsigned request, [[maybe_unus
         mmu().copy_to_vm(arg, &ws, sizeof(winsize));
         return 0;
     }
+    case TIOCSWINSZ: {
+        struct winsize ws;
+        mmu().copy_from_vm(&ws, arg, sizeof(winsize));
+        return syscall(SC_ioctl, fd, request, &ws);
+    }
     case TIOCSPGRP:
         return syscall(SC_ioctl, fd, request, arg);
     case TCGETS: {

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Rummskartoffel <Rummskartoffel@protonmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -1151,6 +1152,11 @@ int Emulator::virt$ioctl([[maybe_unused]] int fd, unsigned request, [[maybe_unus
     }
     case FB_IOCTL_SET_HEAD_VERTICAL_OFFSET_BUFFER:
         return syscall(SC_ioctl, fd, request, arg);
+    case FIONBIO: {
+        int enabled;
+        mmu().copy_from_vm(&enabled, arg, sizeof(int));
+        return syscall(SC_ioctl, fd, request, &enabled);
+    }
     default:
         reportln("Unsupported ioctl: {}", request);
         dump_backtrace();

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1122,6 +1122,12 @@ int Emulator::virt$ioctl([[maybe_unused]] int fd, unsigned request, [[maybe_unus
         mmu().copy_from_vm(&ws, arg, sizeof(winsize));
         return syscall(SC_ioctl, fd, request, &ws);
     }
+    case TIOCGPGRP: {
+        pid_t pgid;
+        auto rc = syscall(SC_ioctl, fd, request, &pgid);
+        mmu().copy_to_vm(arg, &pgid, sizeof(pgid));
+        return rc;
+    }
     case TIOCSPGRP:
         return syscall(SC_ioctl, fd, request, arg);
     case TCGETS: {


### PR DESCRIPTION
This PR makes it possible to run TextEditor, `stty`, and Bash in UE.

Required by TextEditor:
* ioctl `FIONBIO`

Required by `stty`:
* ioctl `TIOCSWINSZ`

Required by Bash:
* ioctl `TIOCGPGRP`
* `getppid`
* `sigprocmask`
* signal masking

Just for completeness' sake:
* ioctls `TCFLSH` and `TIOCSTI`