### PR TITLE
LibGUI+WindowServer: Usability improvements for checkable actions

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Jakob-Niklas See <git@nwex.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,6 +15,7 @@ class TableCellPaintingDelegate {
 public:
     virtual ~TableCellPaintingDelegate() { }
 
+    virtual bool should_paint(ModelIndex const&) { return true; }
     virtual void paint(Painter&, const Gfx::IntRect&, const Gfx::Palette&, const ModelIndex&) = 0;
 };
 

--- a/Userland/Libraries/LibGUI/TableView.cpp
+++ b/Userland/Libraries/LibGUI/TableView.cpp
@@ -98,7 +98,8 @@ void TableView::paint_event(PaintEvent& event)
                 painter.fill_rect(cell_rect_for_fill, key_column_background_color);
             auto cell_index = model()->index(row_index, column_index);
 
-            if (auto* delegate = column_painting_delegate(column_index)) {
+            auto* delegate = column_painting_delegate(column_index);
+            if (delegate && delegate->should_paint(cell_index)) {
                 delegate->paint(painter, cell_rect, palette(), cell_index);
             } else {
                 auto data = cell_index.data();

--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -291,7 +291,8 @@ void TreeView::paint_event(PaintEvent& event)
                 Gfx::IntRect cell_rect(horizontal_padding() + x_offset, rect.y(), column_width, row_height());
                 auto cell_index = model.index(index.row(), column_index, index.parent());
 
-                if (auto* delegate = column_painting_delegate(column_index)) {
+                auto* delegate = column_painting_delegate(column_index);
+                if (delegate && delegate->should_paint(cell_index)) {
                     delegate->paint(painter, cell_rect, palette(), cell_index);
                 } else {
                     auto data = cell_index.data();

--- a/Userland/Services/WindowServer/MenuManager.cpp
+++ b/Userland/Services/WindowServer/MenuManager.cpp
@@ -137,6 +137,17 @@ void MenuManager::event(Core::Event& event)
                     m_current_menu->open_hovered_item(key_event.modifiers() & KeyModifier::Mod_Ctrl);
                 return;
             }
+
+            if (key_event.key() == Key_Space) {
+                auto* hovered_item = m_current_menu->hovered_item();
+                if (!hovered_item || !hovered_item->is_enabled())
+                    return;
+                if (!hovered_item->is_checkable())
+                    return;
+
+                m_current_menu->open_hovered_item(true);
+            }
+
             m_current_menu->dispatch_event(event);
         }
     }


### PR DESCRIPTION
This pull request improves some checkable action user interface features.

Actions in menus can now be toggled without closing the menu by pressing space, in addition to the already existing Control + Enter for this purpose.

CommandPalette will now show a radio button as the icon for a checkable action if the action does not have an icon itself.

![image](https://user-images.githubusercontent.com/42888162/151585661-85b388f7-5d2d-46c5-a1d2-4c34e3f0db65.png)

