### PR TITLE
LibCore: Remove time zone from default format string

### DIFF
--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -83,7 +83,7 @@ void DateTime::set_time(int year, int month, int day, int hour, int minute, int 
     m_second = tm.tm_sec;
 }
 
-String DateTime::to_string(const String& format) const
+String DateTime::to_string(StringView format) const
 {
     const char wday_short_names[7][4] = {
         "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
@@ -261,7 +261,7 @@ String DateTime::to_string(const String& format) const
     return builder.build();
 }
 
-Optional<DateTime> DateTime::parse(const String& format, const String& string)
+Optional<DateTime> DateTime::parse(StringView format, const String& string)
 {
     unsigned format_pos = 0;
     unsigned string_pos = 0;

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <LibIPC/Forward.h>
 #include <time.h>
 
@@ -30,12 +31,12 @@ public:
     bool is_leap_year() const;
 
     void set_time(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
-    String to_string(const String& format = "%Y-%m-%d %H:%M:%S") const;
+    String to_string(StringView format = "%Y-%m-%d %H:%M:%S"sv) const;
 
     static DateTime create(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
     static DateTime now();
     static DateTime from_timestamp(time_t);
-    static Optional<DateTime> parse(const String& format, const String& string);
+    static Optional<DateTime> parse(StringView format, const String& string);
 
     bool operator<(const DateTime& other) const { return m_timestamp < other.m_timestamp; }
 

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -30,7 +30,7 @@ public:
     bool is_leap_year() const;
 
     void set_time(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
-    String to_string(const String& format = "%Y-%m-%d %H:%M:%S %Z") const;
+    String to_string(const String& format = "%Y-%m-%d %H:%M:%S") const;
 
     static DateTime create(int year, int month = 1, int day = 1, int hour = 0, int minute = 0, int second = 0);
     static DateTime now();

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -60,7 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     } else if (print_rfc_3339) {
         outln("{}", date.to_string("%Y-%m-%d %H:%M:%S%:z"));
     } else {
-        outln("{}", date.to_string());
+        outln("{}", date.to_string("%Y-%m-%d %H:%M:%S %Z"));
     }
     return 0;
 }


### PR DESCRIPTION
Now that time zone is set everywhere, displaying it everywhere feels a bit in-your-face. If others disagree, I can close this, but looking at FileManager makes me think "bruh I know where I live" :) (The format string change to include zones was recent, 29c8ec5eb6fa86657cc15ffd5d2fb868128611b4)

![lmt](https://user-images.githubusercontent.com/5600524/151586096-eea36173-8458-4c64-9bca-23a9a513bef7.png)
