### PR TITLE
LibSoftGPU: Dispatch based on ClipPlane enum at compile-time

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Clipper.cpp
+++ b/Userland/Libraries/LibSoftGPU/Clipper.cpp
@@ -1,54 +1,57 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Format.h>
-#include <AK/ScopeGuard.h>
+#include <AK/Vector.h>
+#include <LibGfx/Vector4.h>
 #include <LibSoftGPU/Clipper.h>
+#include <LibSoftGPU/Vertex.h>
 
 namespace SoftGPU {
 
-static constexpr FloatVector4 clip_plane_normals[] = {
-    { 1, 0, 0, 0 },  // Left Plane
-    { -1, 0, 0, 0 }, // Right Plane
-    { 0, -1, 0, 0 }, // Top Plane
-    { 0, 1, 0, 0 },  // Bottom plane
-    { 0, 0, 1, 0 },  // Near Plane
-    { 0, 0, -1, 0 }  // Far Plane
-};
-
-static constexpr bool point_within_clip_plane(FloatVector4 const& vertex, Clipper::ClipPlane plane)
+template<Clipper::ClipPlane plane>
+static constexpr bool point_within_clip_plane(FloatVector4 const& vertex)
 {
-    switch (plane) {
-    case Clipper::ClipPlane::LEFT:
+    if constexpr (plane == Clipper::ClipPlane::LEFT) {
         return vertex.x() >= -vertex.w();
-    case Clipper::ClipPlane::RIGHT:
+    } else if constexpr (plane == Clipper::ClipPlane::RIGHT) {
         return vertex.x() <= vertex.w();
-    case Clipper::ClipPlane::TOP:
+    } else if constexpr (plane == Clipper::ClipPlane::TOP) {
         return vertex.y() <= vertex.w();
-    case Clipper::ClipPlane::BOTTOM:
+    } else if constexpr (plane == Clipper::ClipPlane::BOTTOM) {
         return vertex.y() >= -vertex.w();
-    case Clipper::ClipPlane::NEAR:
+    } else if constexpr (plane == Clipper::ClipPlane::NEAR) {
         return vertex.z() >= -vertex.w();
-    case Clipper::ClipPlane::FAR:
+    } else if constexpr (plane == Clipper::ClipPlane::FAR) {
         return vertex.z() <= vertex.w();
     }
-
     return false;
 }
 
-static Vertex clip_intersection_point(Vertex const& p1, Vertex const& p2, Clipper::ClipPlane plane)
+template<Clipper::ClipPlane plane>
+static constexpr Vertex clip_intersection_point(Vertex const& p1, Vertex const& p2)
 {
+    constexpr FloatVector4 clip_plane_normals[] = {
+        { 1, 0, 0, 0 },  // Left Plane
+        { -1, 0, 0, 0 }, // Right Plane
+        { 0, -1, 0, 0 }, // Top Plane
+        { 0, 1, 0, 0 },  // Bottom plane
+        { 0, 0, 1, 0 },  // Near Plane
+        { 0, 0, -1, 0 }  // Far Plane
+    };
+    constexpr auto clip_plane_normal = clip_plane_normals[to_underlying(plane)];
+
     // See https://www.microsoft.com/en-us/research/wp-content/uploads/1978/01/p245-blinn.pdf
     // "Clipping Using Homogeneous Coordinates" Blinn/Newell, 1978
 
     float const w1 = p1.clip_coordinates.w();
     float const w2 = p2.clip_coordinates.w();
-    float const x1 = clip_plane_normals[to_underlying(plane)].dot(p1.clip_coordinates);
-    float const x2 = clip_plane_normals[to_underlying(plane)].dot(p2.clip_coordinates);
+    float const x1 = clip_plane_normal.dot(p1.clip_coordinates);
+    float const x2 = clip_plane_normal.dot(p2.clip_coordinates);
     float const a = (w1 + x1) / ((w1 + x1) - (w2 + x2));
 
     Vertex out;
@@ -62,21 +65,21 @@ static Vertex clip_intersection_point(Vertex const& p1, Vertex const& p2, Clippe
     return out;
 }
 
-static void clip_plane(Vector<Vertex>& read_list, Vector<Vertex>& write_list, Clipper::ClipPlane plane)
+template<Clipper::ClipPlane plane>
+FLATTEN static constexpr void clip_plane(Vector<Vertex>& read_list, Vector<Vertex>& write_list)
 {
     auto read_from = &read_list;
     auto write_to = &write_list;
 
     write_to->clear_with_capacity();
-    // FIXME C++23. Static reflection will provide looping over all enum values.
     for (size_t i = 0; i < read_from->size(); i++) {
         auto const& curr_vec = read_from->at((i + 1) % read_from->size());
         auto const& prev_vec = read_from->at(i);
 
-        bool const is_curr_point_within_clip_plane = point_within_clip_plane(curr_vec.clip_coordinates, plane);
-        bool const is_prev_point_within_clip_plane = point_within_clip_plane(prev_vec.clip_coordinates, plane);
+        bool const is_curr_point_within_clip_plane = point_within_clip_plane<plane>(curr_vec.clip_coordinates);
+        bool const is_prev_point_within_clip_plane = point_within_clip_plane<plane>(prev_vec.clip_coordinates);
         if (is_curr_point_within_clip_plane != is_prev_point_within_clip_plane) {
-            auto const intersect = clip_intersection_point(prev_vec, curr_vec, plane);
+            auto const intersect = clip_intersection_point<plane>(prev_vec, curr_vec);
             write_to->append(intersect);
         }
 
@@ -91,10 +94,15 @@ void Clipper::clip_triangle_against_frustum(Vector<Vertex>& input_verts)
     list_a = input_verts;
     list_b.clear_with_capacity();
 
-    for (size_t plane = 0; plane < NUMBER_OF_CLIPPING_PLANES; plane++) {
-        clip_plane(list_a, list_b, static_cast<ClipPlane>(plane));
-    }
+    // FIXME C++23. Static reflection will provide looping over all enum values.
+    clip_plane<ClipPlane::LEFT>(list_a, list_b);
+    clip_plane<ClipPlane::RIGHT>(list_a, list_b);
+    clip_plane<ClipPlane::TOP>(list_a, list_b);
+    clip_plane<ClipPlane::BOTTOM>(list_a, list_b);
+    clip_plane<ClipPlane::NEAR>(list_a, list_b);
+    clip_plane<ClipPlane::FAR>(list_a, list_b);
 
     input_verts = list_a;
 }
+
 }

--- a/Userland/Libraries/LibSoftGPU/Clipper.h
+++ b/Userland/Libraries/LibSoftGPU/Clipper.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,8 +14,6 @@
 namespace SoftGPU {
 
 class Clipper final {
-    static constexpr u8 NUMBER_OF_CLIPPING_PLANES = 6;
-
 public:
     enum class ClipPlane : u8 {
         LEFT = 0,


### PR DESCRIPTION
The `ClipPlane` enum is being looped over at run-time performing
run-time dispatch to determine the comparison operation in
`point_within_clip_plane`.

Change this `for` loop to be linear code which dispatches using a
template parameter. This allows for the `point_within_clip_plane`
function to do compile-time dispatch.

Note: This linear code can become a compile-time loop when static
reflection lands in C++2[y|z] allowing looping over the reflected
`enum class`.

For an example of how thischanges the generated code take a
look here:
- GCC https://serenityos.godbolt.org/z/nWo96nv43
- Clang https://serenityos.godbolt.org/z/P74dxd3bf
(left is original, right contains this change)