### PR TITLE
Userland: Modernize the construction of singletons

### DIFF
--- a/Userland/Libraries/LibCore/Object.cpp
+++ b/Userland/Libraries/LibCore/Object.cpp
@@ -258,10 +258,8 @@ void Object::set_event_filter(Function<bool(Core::Event&)> filter)
 
 static HashMap<StringView, ObjectClassRegistration*>& object_classes()
 {
-    static HashMap<StringView, ObjectClassRegistration*>* map;
-    if (!map)
-        map = new HashMap<StringView, ObjectClassRegistration*>;
-    return *map;
+    static HashMap<StringView, ObjectClassRegistration*> s_map;
+    return s_map;
 }
 
 ObjectClassRegistration::ObjectClassRegistration(StringView class_name, Function<RefPtr<Object>()> factory, ObjectClassRegistration* parent_class)

--- a/Userland/Libraries/LibGUI/Clipboard.cpp
+++ b/Userland/Libraries/LibGUI/Clipboard.cpp
@@ -44,10 +44,8 @@ void Clipboard::initialize(Badge<Application>)
 
 Clipboard& Clipboard::the()
 {
-    static Clipboard* s_the;
-    if (!s_the)
-        s_the = new Clipboard;
-    return *s_the;
+    static Clipboard s_the;
+    return s_the;
 }
 
 Clipboard::DataAndType Clipboard::fetch_data_and_type() const

--- a/Userland/Libraries/LibGUI/Desktop.cpp
+++ b/Userland/Libraries/LibGUI/Desktop.cpp
@@ -16,10 +16,8 @@ namespace GUI {
 
 Desktop& Desktop::the()
 {
-    static Desktop* the;
-    if (!the)
-        the = new Desktop;
-    return *the;
+    static Desktop s_the;
+    return s_the;
 }
 
 Desktop::Desktop()

--- a/Userland/Libraries/LibGUI/DisplayLink.cpp
+++ b/Userland/Libraries/LibGUI/DisplayLink.cpp
@@ -31,10 +31,8 @@ private:
 
 static HashMap<i32, RefPtr<DisplayLinkCallback>>& callbacks()
 {
-    static HashMap<i32, RefPtr<DisplayLinkCallback>>* map;
-    if (!map)
-        map = new HashMap<i32, RefPtr<DisplayLinkCallback>>;
-    return *map;
+    static HashMap<i32, RefPtr<DisplayLinkCallback>> s_map;
+    return s_map;
 }
 
 static i32 s_next_callback_id = 1;

--- a/Userland/Libraries/LibGUI/Menu.cpp
+++ b/Userland/Libraries/LibGUI/Menu.cpp
@@ -20,10 +20,8 @@ static IDAllocator s_menu_id_allocator;
 
 static HashMap<int, Menu*>& all_menus()
 {
-    static HashMap<int, Menu*>* map;
-    if (!map)
-        map = new HashMap<int, Menu*>();
-    return *map;
+    static HashMap<int, Menu*> s_map;
+    return s_map;
 }
 
 Menu* Menu::from_menu_id(int menu_id)

--- a/Userland/Libraries/LibGfx/FontDatabase.cpp
+++ b/Userland/Libraries/LibGfx/FontDatabase.cpp
@@ -15,13 +15,10 @@
 
 namespace Gfx {
 
-static FontDatabase* s_the;
-
 FontDatabase& FontDatabase::the()
 {
-    if (!s_the)
-        s_the = new FontDatabase;
-    return *s_the;
+    static FontDatabase s_the;
+    return s_the;
 }
 
 static RefPtr<Font> s_default_font;

--- a/Userland/Libraries/LibTextCodec/Decoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Decoder.cpp
@@ -11,78 +11,15 @@
 namespace TextCodec {
 
 namespace {
-Latin1Decoder& latin1_decoder()
-{
-    static Latin1Decoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new Latin1Decoder;
-    return *decoder;
-}
-
-UTF8Decoder& utf8_decoder()
-{
-    static UTF8Decoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new UTF8Decoder;
-    return *decoder;
-}
-
-UTF16BEDecoder& utf16be_decoder()
-{
-    static UTF16BEDecoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new UTF16BEDecoder;
-    return *decoder;
-}
-
-Latin2Decoder& latin2_decoder()
-{
-    static Latin2Decoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new Latin2Decoder;
-    return *decoder;
-}
-
-HebrewDecoder& hebrew_decoder()
-{
-    static HebrewDecoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new HebrewDecoder;
-    return *decoder;
-}
-
-CyrillicDecoder& cyrillic_decoder()
-{
-    static CyrillicDecoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new CyrillicDecoder;
-    return *decoder;
-}
-
-Koi8RDecoder& koi8r_decoder()
-{
-    static Koi8RDecoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new Koi8RDecoder;
-    return *decoder;
-}
-
-Latin9Decoder& latin9_decoder()
-{
-    static Latin9Decoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new Latin9Decoder;
-    return *decoder;
-}
-
-TurkishDecoder& turkish_decoder()
-{
-    static TurkishDecoder* decoder = nullptr;
-    if (!decoder)
-        decoder = new TurkishDecoder;
-    return *decoder;
-}
-
+Latin1Decoder s_latin1_decoder;
+UTF8Decoder s_utf8_decoder;
+UTF16BEDecoder s_utf16be_decoder;
+Latin2Decoder s_latin2_decoder;
+HebrewDecoder s_hebrew_decoder;
+CyrillicDecoder s_cyrillic_decoder;
+Koi8RDecoder s_koi8r_decoder;
+Latin9Decoder s_latin9_decoder;
+TurkishDecoder s_turkish_decoder;
 }
 
 Decoder* decoder_for(const String& a_encoding)
@@ -90,23 +27,23 @@ Decoder* decoder_for(const String& a_encoding)
     auto encoding = get_standardized_encoding(a_encoding);
     if (encoding.has_value()) {
         if (encoding.value().equals_ignoring_case("windows-1252"))
-            return &latin1_decoder();
+            return &s_latin1_decoder;
         if (encoding.value().equals_ignoring_case("utf-8"))
-            return &utf8_decoder();
+            return &s_utf8_decoder;
         if (encoding.value().equals_ignoring_case("utf-16be"))
-            return &utf16be_decoder();
+            return &s_utf16be_decoder;
         if (encoding.value().equals_ignoring_case("iso-8859-2"))
-            return &latin2_decoder();
+            return &s_latin2_decoder;
         if (encoding.value().equals_ignoring_case("windows-1255"))
-            return &hebrew_decoder();
+            return &s_hebrew_decoder;
         if (encoding.value().equals_ignoring_case("windows-1251"))
-            return &cyrillic_decoder();
+            return &s_cyrillic_decoder;
         if (encoding.value().equals_ignoring_case("koi8-r"))
-            return &koi8r_decoder();
+            return &s_koi8r_decoder;
         if (encoding.value().equals_ignoring_case("iso-8859-15"))
-            return &latin9_decoder();
+            return &s_latin9_decoder;
         if (encoding.value().equals_ignoring_case("windows-1254"))
-            return &turkish_decoder();
+            return &s_turkish_decoder;
     }
     dbgln("TextCodec: No decoder implemented for encoding '{}'", a_encoding);
     return nullptr;

--- a/Userland/Libraries/LibWeb/Loader/ContentFilter.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ContentFilter.cpp
@@ -11,8 +11,8 @@ namespace Web {
 
 ContentFilter& ContentFilter::the()
 {
-    static ContentFilter* filter = new ContentFilter;
-    return *filter;
+    static ContentFilter filter;
+    return filter;
 }
 
 ContentFilter::ContentFilter()

--- a/Userland/Services/Clipboard/Storage.cpp
+++ b/Userland/Services/Clipboard/Storage.cpp
@@ -10,10 +10,8 @@ namespace Clipboard {
 
 Storage& Storage::the()
 {
-    static Storage* s_the;
-    if (!s_the)
-        s_the = new Storage;
-    return *s_the;
+    static Storage s_the;
+    return s_the;
 }
 
 Storage::Storage()

--- a/Userland/Services/Taskbar/WindowList.cpp
+++ b/Userland/Services/Taskbar/WindowList.cpp
@@ -8,10 +8,8 @@
 
 WindowList& WindowList::the()
 {
-    static WindowList* s_the;
-    if (!s_the)
-        s_the = new WindowList;
-    return *s_the;
+    static WindowList s_the;
+    return s_the;
 }
 
 Window* WindowList::find_parent(const Window& window)


### PR DESCRIPTION
**Userland: Fix unnecessary heap allocation of singleton objects**

In order to avoid having multiple instances, we were keeping a pointer
to these singleton objects and only allocating them when it was null.

We have `__cxa_guard_{acquire,release}` in the userland, so there's no
need to do this dance, as the compiler will ensure that the constructors
are only called once.

**LibTextCodec: Do not allocate the various decoders**

These objects contain no data members, so there is no point in creating
1-byte heap allocations for them. We don't need to have them as static
local variables, as they are trivially constructible, so they can simply
be global variables.