### PR TITLE
Everywhere: Remove redundant inline keyword

### DIFF
--- a/AK/BuiltinWrappers.h
+++ b/AK/BuiltinWrappers.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Nick Johnson <sylvyrfysh@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,7 +10,7 @@
 #include "Concepts.h"
 
 template<Unsigned IntType>
-inline constexpr int popcount(IntType value)
+constexpr int popcount(IntType value)
 {
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
@@ -37,7 +38,7 @@ inline constexpr int popcount(IntType value)
 // this function can be called with zero, the use of
 // count_trailing_zeroes_safe is preferred.
 template<Unsigned IntType>
-inline constexpr int count_trailing_zeroes(IntType value)
+constexpr int count_trailing_zeroes(IntType value)
 {
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
@@ -62,7 +63,7 @@ inline constexpr int count_trailing_zeroes(IntType value)
 // the given number is zero, this function will return the number of bits
 // bits in the IntType.
 template<Unsigned IntType>
-inline constexpr int count_trailing_zeroes_safe(IntType value)
+constexpr int count_trailing_zeroes_safe(IntType value)
 {
     if (value == 0)
         return 8 * sizeof(IntType);
@@ -75,7 +76,7 @@ inline constexpr int count_trailing_zeroes_safe(IntType value)
 // this function can be called with zero, the use of
 // count_leading_zeroes_safe is preferred.
 template<Unsigned IntType>
-inline constexpr int count_leading_zeroes(IntType value)
+constexpr int count_leading_zeroes(IntType value)
 {
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));
@@ -101,7 +102,7 @@ inline constexpr int count_leading_zeroes(IntType value)
 // the given number is zero, this function will return the number of bits
 // in the IntType.
 template<Unsigned IntType>
-inline constexpr int count_leading_zeroes_safe(IntType value)
+constexpr int count_leading_zeroes_safe(IntType value)
 {
     if (value == 0)
         return 8 * sizeof(IntType);
@@ -112,7 +113,7 @@ inline constexpr int count_leading_zeroes_safe(IntType value)
 // the given number is zero, this function will return the number of bits
 // in the IntType.
 template<Integral IntType>
-inline constexpr int bit_scan_forward(IntType value)
+constexpr int bit_scan_forward(IntType value)
 {
 #if defined(__GNUC__) || defined(__clang__)
     static_assert(sizeof(IntType) <= sizeof(unsigned long long));

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -34,10 +35,10 @@ struct Formatter {
 };
 
 template<typename T, typename = void>
-inline constexpr bool HasFormatter = true;
+constexpr bool HasFormatter = true;
 
 template<typename T>
-inline constexpr bool HasFormatter<T, typename Formatter<T>::__no_formatter_defined> = false;
+constexpr bool HasFormatter<T, typename Formatter<T>::__no_formatter_defined> = false;
 
 constexpr size_t max_format_arguments = 256;
 

--- a/AK/Function.h
+++ b/AK/Function.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016 Apple Inc. All rights reserved.
  * Copyright (c) 2021, Gunnar Beutner <gbeutner@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -40,11 +41,11 @@ template<typename>
 class Function;
 
 template<typename F>
-inline constexpr bool IsFunctionPointer = (IsPointer<F> && IsFunction<RemovePointer<F>>);
+constexpr bool IsFunctionPointer = (IsPointer<F> && IsFunction<RemovePointer<F>>);
 
 // Not a function pointer, and not an lvalue reference.
 template<typename F>
-inline constexpr bool IsFunctionObject = (!IsFunctionPointer<F> && IsRvalueReference<F&&>);
+constexpr bool IsFunctionObject = (!IsFunctionPointer<F> && IsRvalueReference<F&&>);
 
 template<typename Out, typename... In>
 class Function<Out(In...)> {

--- a/AK/MemMem.h
+++ b/AK/MemMem.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,7 +16,7 @@
 namespace AK {
 
 namespace Detail {
-inline constexpr const void* bitap_bitwise(const void* haystack, size_t haystack_length, const void* needle, size_t needle_length)
+constexpr const void* bitap_bitwise(const void* haystack, size_t haystack_length, const void* needle, size_t needle_length)
 {
     VERIFY(needle_length < 32);
 

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
  * Copyright (c) 2021, Daniel Bertalan <dani@danielbertalan.dev>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -65,75 +66,75 @@ template<typename...>
 using VoidType = void;
 
 template<class T>
-inline constexpr bool IsLvalueReference = false;
+constexpr bool IsLvalueReference = false;
 
 template<class T>
-inline constexpr bool IsLvalueReference<T&> = true;
+constexpr bool IsLvalueReference<T&> = true;
 
 template<class T>
-inline constexpr bool __IsPointerHelper = false;
+constexpr bool __IsPointerHelper = false;
 
 template<class T>
-inline constexpr bool __IsPointerHelper<T*> = true;
+constexpr bool __IsPointerHelper<T*> = true;
 
 template<class T>
-inline constexpr bool IsPointer = __IsPointerHelper<RemoveCV<T>>;
+constexpr bool IsPointer = __IsPointerHelper<RemoveCV<T>>;
 
 template<class>
-inline constexpr bool IsFunction = false;
+constexpr bool IsFunction = false;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...)> = true;
+constexpr bool IsFunction<Ret(Args...)> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...)> = true;
+constexpr bool IsFunction<Ret(Args..., ...)> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) const> = true;
+constexpr bool IsFunction<Ret(Args...) const> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) const> = true;
+constexpr bool IsFunction<Ret(Args..., ...) const> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) volatile> = true;
+constexpr bool IsFunction<Ret(Args...) volatile> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) volatile> = true;
+constexpr bool IsFunction<Ret(Args..., ...) volatile> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) const volatile> = true;
+constexpr bool IsFunction<Ret(Args...) const volatile> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) const volatile> = true;
+constexpr bool IsFunction<Ret(Args..., ...) const volatile> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...)&> = true;
+constexpr bool IsFunction<Ret(Args...)&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...)&> = true;
+constexpr bool IsFunction<Ret(Args..., ...)&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) const&> = true;
+constexpr bool IsFunction<Ret(Args...) const&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) const&> = true;
+constexpr bool IsFunction<Ret(Args..., ...) const&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) volatile&> = true;
+constexpr bool IsFunction<Ret(Args...) volatile&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) volatile&> = true;
+constexpr bool IsFunction<Ret(Args..., ...) volatile&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) const volatile&> = true;
+constexpr bool IsFunction<Ret(Args...) const volatile&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) const volatile&> = true;
+constexpr bool IsFunction<Ret(Args..., ...) const volatile&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) &&> = true;
+constexpr bool IsFunction<Ret(Args...) &&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) &&> = true;
+constexpr bool IsFunction<Ret(Args..., ...) &&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) const&&> = true;
+constexpr bool IsFunction<Ret(Args...) const&&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) const&&> = true;
+constexpr bool IsFunction<Ret(Args..., ...) const&&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) volatile&&> = true;
+constexpr bool IsFunction<Ret(Args...) volatile&&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) volatile&&> = true;
+constexpr bool IsFunction<Ret(Args..., ...) volatile&&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args...) const volatile&&> = true;
+constexpr bool IsFunction<Ret(Args...) const volatile&&> = true;
 template<class Ret, class... Args>
-inline constexpr bool IsFunction<Ret(Args..., ...) const volatile&&> = true;
+constexpr bool IsFunction<Ret(Args..., ...) const volatile&&> = true;
 
 template<class T>
-inline constexpr bool IsRvalueReference = false;
+constexpr bool IsRvalueReference = false;
 template<class T>
-inline constexpr bool IsRvalueReference<T&&> = true;
+constexpr bool IsRvalueReference<T&&> = true;
 
 template<class T>
 struct __RemovePointer {
@@ -159,10 +160,10 @@ template<typename T>
 using RemovePointer = typename __RemovePointer<T>::Type;
 
 template<typename T, typename U>
-inline constexpr bool IsSame = false;
+constexpr bool IsSame = false;
 
 template<typename T>
-inline constexpr bool IsSame<T, T> = true;
+constexpr bool IsSame<T, T> = true;
 
 template<bool condition, class TrueType, class FalseType>
 struct __Conditional {
@@ -178,7 +179,7 @@ template<bool condition, class TrueType, class FalseType>
 using Conditional = typename __Conditional<condition, TrueType, FalseType>::Type;
 
 template<typename T>
-inline constexpr bool IsNullPointer = IsSame<decltype(nullptr), RemoveCV<T>>;
+constexpr bool IsNullPointer = IsSame<decltype(nullptr), RemoveCV<T>>;
 
 template<typename T>
 struct __RemoveReference {
@@ -344,62 +345,62 @@ template<typename... Ts>
 using CommonType = typename __CommonType<Ts...>::Type;
 
 template<class T>
-inline constexpr bool IsVoid = IsSame<void, RemoveCV<T>>;
+constexpr bool IsVoid = IsSame<void, RemoveCV<T>>;
 
 template<class T>
-inline constexpr bool IsConst = false;
+constexpr bool IsConst = false;
 
 template<class T>
-inline constexpr bool IsConst<const T> = true;
+constexpr bool IsConst<const T> = true;
 
 template<typename T>
-inline constexpr bool IsEnum = __is_enum(T);
+constexpr bool IsEnum = __is_enum(T);
 
 template<typename T>
-inline constexpr bool IsUnion = __is_union(T);
+constexpr bool IsUnion = __is_union(T);
 
 template<typename T>
-inline constexpr bool IsClass = __is_class(T);
+constexpr bool IsClass = __is_class(T);
 
 template<typename Base, typename Derived>
-inline constexpr bool IsBaseOf = __is_base_of(Base, Derived);
+constexpr bool IsBaseOf = __is_base_of(Base, Derived);
 
 template<typename T>
-inline constexpr bool __IsIntegral = false;
+constexpr bool __IsIntegral = false;
 
 template<>
-inline constexpr bool __IsIntegral<bool> = true;
+constexpr bool __IsIntegral<bool> = true;
 template<>
-inline constexpr bool __IsIntegral<unsigned char> = true;
+constexpr bool __IsIntegral<unsigned char> = true;
 template<>
-inline constexpr bool __IsIntegral<char8_t> = true;
+constexpr bool __IsIntegral<char8_t> = true;
 template<>
-inline constexpr bool __IsIntegral<char16_t> = true;
+constexpr bool __IsIntegral<char16_t> = true;
 template<>
-inline constexpr bool __IsIntegral<char32_t> = true;
+constexpr bool __IsIntegral<char32_t> = true;
 template<>
-inline constexpr bool __IsIntegral<unsigned short> = true;
+constexpr bool __IsIntegral<unsigned short> = true;
 template<>
-inline constexpr bool __IsIntegral<unsigned int> = true;
+constexpr bool __IsIntegral<unsigned int> = true;
 template<>
-inline constexpr bool __IsIntegral<unsigned long> = true;
+constexpr bool __IsIntegral<unsigned long> = true;
 template<>
-inline constexpr bool __IsIntegral<unsigned long long> = true;
-
-template<typename T>
-inline constexpr bool IsIntegral = __IsIntegral<MakeUnsigned<RemoveCV<T>>>;
+constexpr bool __IsIntegral<unsigned long long> = true;
 
 template<typename T>
-inline constexpr bool __IsFloatingPoint = false;
-template<>
-inline constexpr bool __IsFloatingPoint<float> = true;
-template<>
-inline constexpr bool __IsFloatingPoint<double> = true;
-template<>
-inline constexpr bool __IsFloatingPoint<long double> = true;
+constexpr bool IsIntegral = __IsIntegral<MakeUnsigned<RemoveCV<T>>>;
 
 template<typename T>
-inline constexpr bool IsFloatingPoint = __IsFloatingPoint<RemoveCV<T>>;
+constexpr bool __IsFloatingPoint = false;
+template<>
+constexpr bool __IsFloatingPoint<float> = true;
+template<>
+constexpr bool __IsFloatingPoint<double> = true;
+template<>
+constexpr bool __IsFloatingPoint<long double> = true;
+
+template<typename T>
+constexpr bool IsFloatingPoint = __IsFloatingPoint<RemoveCV<T>>;
 
 template<typename ReferenceType, typename T>
 using CopyConst = Conditional<IsConst<ReferenceType>, AddConst<T>, RemoveConst<T>>;
@@ -411,16 +412,16 @@ template<typename... _Ignored>
 constexpr auto DependentFalse = false;
 
 template<typename T>
-inline constexpr bool IsSigned = IsSame<T, MakeSigned<T>>;
+constexpr bool IsSigned = IsSame<T, MakeSigned<T>>;
 
 template<typename T>
-inline constexpr bool IsUnsigned = IsSame<T, MakeUnsigned<T>>;
+constexpr bool IsUnsigned = IsSame<T, MakeUnsigned<T>>;
 
 template<typename T>
-inline constexpr bool IsArithmetic = IsIntegral<T> || IsFloatingPoint<T>;
+constexpr bool IsArithmetic = IsIntegral<T> || IsFloatingPoint<T>;
 
 template<typename T>
-inline constexpr bool IsFundamental = IsArithmetic<T> || IsVoid<T> || IsNullPointer<T>;
+constexpr bool IsFundamental = IsArithmetic<T> || IsVoid<T> || IsNullPointer<T>;
 
 template<typename T, T... Ts>
 struct IntegerSequence {
@@ -491,71 +492,71 @@ template<typename T, unsigned ExpectedSize>
 using AssertSize = __AssertSize<T, ExpectedSize, sizeof(T)>;
 
 template<typename T>
-inline constexpr bool IsPOD = __is_pod(T);
+constexpr bool IsPOD = __is_pod(T);
 
 template<typename T>
-inline constexpr bool IsTrivial = __is_trivial(T);
+constexpr bool IsTrivial = __is_trivial(T);
 
 template<typename T>
-inline constexpr bool IsTriviallyCopyable = __is_trivially_copyable(T);
+constexpr bool IsTriviallyCopyable = __is_trivially_copyable(T);
 
 template<typename T, typename... Args>
-inline constexpr bool IsCallableWithArguments = requires(T t) { t(declval<Args>()...); };
+constexpr bool IsCallableWithArguments = requires(T t) { t(declval<Args>()...); };
 
 template<typename T, typename... Args>
-inline constexpr bool IsConstructible = requires { ::new T(declval<Args>()...); };
+constexpr bool IsConstructible = requires { ::new T(declval<Args>()...); };
 
 template<typename T, typename... Args>
-inline constexpr bool IsTriviallyConstructible = __is_trivially_constructible(T, Args...);
+constexpr bool IsTriviallyConstructible = __is_trivially_constructible(T, Args...);
 
 template<typename From, typename To>
-inline constexpr bool IsConvertible = requires { declval<void (*)(To)>()(declval<From>()); };
+constexpr bool IsConvertible = requires { declval<void (*)(To)>()(declval<From>()); };
 
 template<typename T, typename U>
-inline constexpr bool IsAssignable = requires { declval<T>() = declval<U>(); };
+constexpr bool IsAssignable = requires { declval<T>() = declval<U>(); };
 
 template<typename T, typename U>
-inline constexpr bool IsTriviallyAssignable = __is_trivially_assignable(T, U);
+constexpr bool IsTriviallyAssignable = __is_trivially_assignable(T, U);
 
 template<typename T>
-inline constexpr bool IsDestructible = requires { declval<T>().~T(); };
+constexpr bool IsDestructible = requires { declval<T>().~T(); };
 
 template<typename T>
 #if defined(__clang__)
-inline constexpr bool IsTriviallyDestructible = __is_trivially_destructible(T);
+constexpr bool IsTriviallyDestructible = __is_trivially_destructible(T);
 #else
-inline constexpr bool IsTriviallyDestructible = __has_trivial_destructor(T) && IsDestructible<T>;
+constexpr bool IsTriviallyDestructible = __has_trivial_destructor(T) && IsDestructible<T>;
 #endif
 
 template<typename T>
-inline constexpr bool IsCopyConstructible = IsConstructible<T, AddLvalueReference<AddConst<T>>>;
+constexpr bool IsCopyConstructible = IsConstructible<T, AddLvalueReference<AddConst<T>>>;
 
 template<typename T>
-inline constexpr bool IsTriviallyCopyConstructible = IsTriviallyConstructible<T, AddLvalueReference<AddConst<T>>>;
+constexpr bool IsTriviallyCopyConstructible = IsTriviallyConstructible<T, AddLvalueReference<AddConst<T>>>;
 
 template<typename T>
-inline constexpr bool IsCopyAssignable = IsAssignable<AddLvalueReference<T>, AddLvalueReference<AddConst<T>>>;
+constexpr bool IsCopyAssignable = IsAssignable<AddLvalueReference<T>, AddLvalueReference<AddConst<T>>>;
 
 template<typename T>
-inline constexpr bool IsTriviallyCopyAssignable = IsTriviallyAssignable<AddLvalueReference<T>, AddLvalueReference<AddConst<T>>>;
+constexpr bool IsTriviallyCopyAssignable = IsTriviallyAssignable<AddLvalueReference<T>, AddLvalueReference<AddConst<T>>>;
 
 template<typename T>
-inline constexpr bool IsMoveConstructible = IsConstructible<T, AddRvalueReference<T>>;
+constexpr bool IsMoveConstructible = IsConstructible<T, AddRvalueReference<T>>;
 
 template<typename T>
-inline constexpr bool IsTriviallyMoveConstructible = IsTriviallyConstructible<T, AddRvalueReference<T>>;
+constexpr bool IsTriviallyMoveConstructible = IsTriviallyConstructible<T, AddRvalueReference<T>>;
 
 template<typename T>
-inline constexpr bool IsMoveAssignable = IsAssignable<AddLvalueReference<T>, AddRvalueReference<T>>;
+constexpr bool IsMoveAssignable = IsAssignable<AddLvalueReference<T>, AddRvalueReference<T>>;
 
 template<typename T>
-inline constexpr bool IsTriviallyMoveAssignable = IsTriviallyAssignable<AddLvalueReference<T>, AddRvalueReference<T>>;
+constexpr bool IsTriviallyMoveAssignable = IsTriviallyAssignable<AddLvalueReference<T>, AddRvalueReference<T>>;
 
 template<typename T, template<typename...> typename U>
-inline constexpr bool IsSpecializationOf = false;
+constexpr bool IsSpecializationOf = false;
 
 template<template<typename...> typename U, typename... Us>
-inline constexpr bool IsSpecializationOf<U<Us...>, U> = true;
+constexpr bool IsSpecializationOf<U<Us...>, U> = true;
 
 template<typename T>
 struct __decay {
@@ -574,12 +575,12 @@ template<typename T>
 using Decay = typename __decay<T>::type;
 
 template<typename T, typename U>
-inline constexpr bool IsPointerOfType = IsPointer<Decay<U>>&& IsSame<T, RemoveCV<RemovePointer<Decay<U>>>>;
+constexpr bool IsPointerOfType = IsPointer<Decay<U>>&& IsSame<T, RemoveCV<RemovePointer<Decay<U>>>>;
 
 template<typename T, typename U>
-inline constexpr bool IsHashCompatible = false;
+constexpr bool IsHashCompatible = false;
 template<typename T>
-inline constexpr bool IsHashCompatible<T, T> = true;
+constexpr bool IsHashCompatible<T, T> = true;
 
 }
 using AK::Detail::AddConst;

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2020, Fei Wu <f.eiwu@yahoo.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,7 +15,7 @@ namespace AK {
 
 namespace Detail {
 template<Concepts::AnyString T, Concepts::AnyString U>
-inline constexpr bool IsHashCompatible<T, U> = true;
+constexpr bool IsHashCompatible<T, U> = true;
 }
 
 enum class CaseSensitivity {

--- a/AK/UFixedBigInt.h
+++ b/AK/UFixedBigInt.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Leon Albrecht <leon2002.la@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,12 +24,12 @@ requires(sizeof(T) >= sizeof(u64) && IsUnsigned<T>) class UFixedBigInt;
 
 // FIXME: This breaks formatting
 // template<typename T>
-// constexpr inline bool Detail::IsIntegral<UFixedBigInt<T>> = true;
+// constexpr bool Detail::IsIntegral<UFixedBigInt<T>> = true;
 
 template<typename T>
-constexpr inline bool Detail::IsUnsigned<UFixedBigInt<T>> = true;
+constexpr bool Detail::IsUnsigned<UFixedBigInt<T>> = true;
 template<typename T>
-constexpr inline bool Detail::IsSigned<UFixedBigInt<T>> = false;
+constexpr bool Detail::IsSigned<UFixedBigInt<T>> = false;
 
 template<typename T>
 struct NumericLimits<UFixedBigInt<T>> {

--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -168,11 +169,11 @@ struct Blank {
 };
 
 template<typename A, typename P>
-inline constexpr bool IsTypeInPack = false;
+constexpr bool IsTypeInPack = false;
 
 // IsTypeInPack<T, Pack<Ts...>> will just return whether 'T' exists in 'Ts'.
 template<typename T, typename... Ts>
-inline constexpr bool IsTypeInPack<T, ParameterPack<Ts...>> = (IsSame<T, Ts> || ...);
+constexpr bool IsTypeInPack<T, ParameterPack<Ts...>> = (IsSame<T, Ts> || ...);
 
 // Replaces T with Blank<T> if it exists in Qs.
 template<typename T, typename... Qs>

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, James Mintram <me@jamesrm.com>
  * Copyright (c) 2021, Marcin Undak <mcinek@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -145,7 +146,7 @@ struct TCR_EL1 {
         return tcr_el1;
     }
 
-    static inline constexpr TCR_EL1 reset_value()
+    static constexpr TCR_EL1 reset_value()
     {
         return {};
     }
@@ -220,7 +221,7 @@ struct SCTLR_EL1 {
         return sctlr;
     }
 
-    static inline constexpr SCTLR_EL1 reset_value()
+    static constexpr SCTLR_EL1 reset_value()
     {
         SCTLR_EL1 system_control_register_el1 = {};
         system_control_register_el1.LSMAOE = 1;

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -234,7 +235,7 @@ public:
 
 AK_ENUM_BITWISE_OPERATORS(Region::Access)
 
-inline constexpr Region::Access prot_to_region_access_flags(int prot)
+constexpr Region::Access prot_to_region_access_flags(int prot)
 {
     Region::Access access = Region::Access::None;
     if ((prot & PROT_READ) == PROT_READ)
@@ -246,7 +247,7 @@ inline constexpr Region::Access prot_to_region_access_flags(int prot)
     return access;
 }
 
-inline constexpr int region_access_flags_to_prot(Region::Access access)
+constexpr int region_access_flags_to_prot(Region::Access access)
 {
     int prot = 0;
     if ((access & Region::Access::Read) == Region::Access::Read)

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Tim Flynn <trflynn89@pm.me>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,10 +23,10 @@
 #include <LibUnicode/Locale.h>
 
 template<class T>
-inline constexpr bool StorageTypeIsList = false;
+constexpr bool StorageTypeIsList = false;
 
 template<class T>
-inline constexpr bool StorageTypeIsList<Vector<T>> = true;
+constexpr bool StorageTypeIsList<Vector<T>> = true;
 
 template<typename T>
 concept IntegralOrEnum = Integral<T> || Enum<T>;

--- a/Userland/Libraries/LibSoftGPU/ImageFormat.h
+++ b/Userland/Libraries/LibSoftGPU/ImageFormat.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,7 +21,7 @@ enum class ImageFormat {
     L8A8,
 };
 
-inline static constexpr size_t element_size(ImageFormat format)
+static constexpr size_t element_size(ImageFormat format)
 {
     switch (format) {
     case ImageFormat::L8:

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -65,8 +66,8 @@ extern HashMap<ConnectionKey, NonnullOwnPtr<NonnullOwnPtrVector<Connection<TLS::
 void request_did_finish(URL const&, Core::Socket const*);
 void dump_jobs();
 
-constexpr static inline size_t MaxConcurrentConnectionsPerURL = 2;
-constexpr static inline size_t ConnectionKeepAliveTimeMilliseconds = 10'000;
+constexpr static size_t MaxConcurrentConnectionsPerURL = 2;
+constexpr static size_t ConnectionKeepAliveTimeMilliseconds = 10'000;
 
 template<typename T>
 void recreate_socket_if_needed(T& connection, URL const& url)


### PR DESCRIPTION
`constexpr` implies `inline` so when both are used it is redundant.