### PR TITLE
LibGUI+Settings: Allow Label::icon to be set in GML

### DIFF
--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.cpp
@@ -59,14 +59,8 @@ BrowserSettingsWidget::BrowserSettingsWidget()
 {
     load_from_gml(browser_settings_widget_gml);
 
-    auto& homepage_image_label = *find_descendant_of_type_named<GUI::Label>("homepage_image_label");
-    homepage_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/home.png").release_value_but_fixme_should_propagate_errors());
-
     m_homepage_url_textbox = find_descendant_of_type_named<GUI::TextBox>("homepage_url_textbox");
     m_homepage_url_textbox->set_text(Config::read_string("Browser", "Preferences", "Home", default_homepage_url));
-
-    auto& appearance_image_label = *find_descendant_of_type_named<GUI::Label>("appearance_image_label");
-    appearance_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/color-chooser.png").release_value_but_fixme_should_propagate_errors());
 
     m_color_scheme_combobox = find_descendant_of_type_named<GUI::ComboBox>("color_scheme_combobox");
     m_color_scheme_combobox->set_only_allow_values_from_model(true);
@@ -76,9 +70,6 @@ BrowserSettingsWidget::BrowserSettingsWidget()
 
     m_show_bookmarks_bar_checkbox = find_descendant_of_type_named<GUI::CheckBox>("show_bookmarks_bar_checkbox");
     m_show_bookmarks_bar_checkbox->set_checked(Config::read_bool("Browser", "Preferences", "ShowBookmarksBar", default_show_bookmarks_bar), GUI::AllowCallback::No);
-
-    auto& search_engine_image_label = *find_descendant_of_type_named<GUI::Label>("search_engine_image_label");
-    search_engine_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/search-engine.png").release_value_but_fixme_should_propagate_errors());
 
     m_enable_search_engine_checkbox = find_descendant_of_type_named<GUI::CheckBox>("enable_search_engine_checkbox");
     m_search_engine_combobox_group = find_descendant_of_type_named<GUI::Widget>("search_engine_combobox_group");
@@ -109,9 +100,6 @@ BrowserSettingsWidget::BrowserSettingsWidget()
         m_custom_search_engine_group->set_enabled(m_is_custom_search_engine);
     };
     set_search_engine_url(Config::read_string("Browser", "Preferences", "SearchEngine", default_search_engine));
-
-    auto& download_image_label = *find_descendant_of_type_named<GUI::Label>("download_image_label");
-    download_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/downloads.png").release_value_but_fixme_should_propagate_errors());
 
     m_auto_close_download_windows_checkbox = find_descendant_of_type_named<GUI::CheckBox>("auto_close_download_windows_checkbox");
     m_auto_close_download_windows_checkbox->set_checked(Config::read_bool("Browser", "Preferences", "CloseDownloadWidgetOnFinish", default_auto_close_download_windows), GUI::AllowCallback::No);

--- a/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
+++ b/Userland/Applications/BrowserSettings/BrowserSettingsWidget.gml
@@ -23,7 +23,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "homepage_image_label"
+                icon: "/res/icons/32x32/home.png"
             }
 
             @GUI::Label {
@@ -56,7 +56,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "appearance_image_label"
+                icon: "/res/icons/32x32/color-chooser.png"
             }
 
             @GUI::Label {
@@ -103,7 +103,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "search_engine_image_label"
+                icon: "/res/icons/32x32/search-engine.png"
             }
 
             @GUI::CheckBox {
@@ -175,7 +175,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "download_image_label"
+                icon: "/res/icons/32x32/downloads.png"
             }
 
             @GUI::CheckBox {

--- a/Userland/Applications/DisplaySettings/DesktopSettings.gml
+++ b/Userland/Applications/DisplaySettings/DesktopSettings.gml
@@ -50,20 +50,24 @@
 
             layout: @GUI::HorizontalBoxLayout {
             }
+
             @GUI::Label {
-                name: "light_bulb_label"
                 fixed_height: 32
                 fixed_width: 32
+                icon: "/res/icons/32x32/app-welcome.png"
             }
+
             @GUI::Widget {
                 layout: @GUI::VerticalBoxLayout {
                     margins: [6]
                 }
+
                 @GUI::Label {
                     text: "Use the Ctrl+Alt+Arrow hotkeys to move between workspaces."
                     text_alignment: "TopLeft"
                     word_wrap: true
                 }
+
                 @GUI::Label {
                     text: "Use the Ctrl+Shift+Alt+Arrow hotkeys to move between\nworkspaces and move the active window."
                     text_alignment: "TopLeft"

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
@@ -29,9 +29,6 @@ void DesktopSettingsWidget::create_frame()
 {
     load_from_gml(desktop_settings_gml);
 
-    auto& light_bulb_label = *find_descendant_of_type_named<GUI::Label>("light_bulb_label");
-    light_bulb_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/app-welcome.png").release_value_but_fixme_should_propagate_errors());
-
     m_workspace_rows_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("workspace_rows_spinbox");
     m_workspace_columns_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("workspace_columns_spinbox");
 }

--- a/Userland/Applications/KeyboardSettings/Keyboard.gml
+++ b/Userland/Applications/KeyboardSettings/Keyboard.gml
@@ -23,7 +23,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "character_map_image_label"
+                icon: "/res/icons/32x32/app-keyboard-mapper.png"
             }
 
             @GUI::Widget
@@ -59,6 +59,7 @@
                     text: "Test your current keymap below"
                     text_alignment: "CenterLeft"
                 }
+
                 @GUI::Button {
                     text: "Clear"
                     name: "button_clear_test_typing_area"
@@ -85,7 +86,7 @@
         @GUI::Label {
             fixed_width: 32
             fixed_height: 32
-            name: "num_lock_image_label"
+            icon: "/res/icons/32x32/app-calculator.png"
         }
 
         @GUI::CheckBox {

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -52,9 +52,6 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     }
     VERIFY(initial_keymap_index < m_character_map_files.size());
 
-    auto& character_map_image_label = *find_descendant_of_type_named<GUI::Label>("character_map_image_label");
-    character_map_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/app-keyboard-mapper.png").release_value_but_fixme_should_propagate_errors());
-
     m_character_map_file_combo = find_descendant_of_type_named<GUI::ComboBox>("character_map_file_combo");
     m_character_map_file_combo->set_only_allow_values_from_model(true);
     m_character_map_file_combo->set_model(*GUI::ItemListModel<String>::create(m_character_map_files));
@@ -73,8 +70,6 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
         m_test_typing_area->set_focus(true);
     };
 
-    auto& num_lock_image_label = *find_descendant_of_type_named<GUI::Label>("num_lock_image_label");
-    num_lock_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/32x32/app-calculator.png").release_value_but_fixme_should_propagate_errors());
     m_num_lock_checkbox = find_descendant_of_type_named<GUI::CheckBox>("num_lock_checkbox");
     m_num_lock_checkbox->set_checked(Config::read_bool("KeyboardSettings", "StartupEnable", "NumLock", true));
 }

--- a/Userland/Applications/MailSettings/MailSettingsWidget.cpp
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.cpp
@@ -44,12 +44,6 @@ MailSettingsWidget::MailSettingsWidget()
 
     load_from_gml(mail_settings_widget_gml);
 
-    auto& server_settings_image_label = *find_descendant_of_type_named<GUI::Label>("server_settings_image_label");
-    server_settings_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/graphics/mail-server-settings.png").release_value_but_fixme_should_propagate_errors());
-
-    auto& user_settings_image_label = *find_descendant_of_type_named<GUI::Label>("user_settings_image_label");
-    user_settings_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/graphics/mail-user-settings.png").release_value_but_fixme_should_propagate_errors());
-
     m_server_inputbox = *find_descendant_of_type_named<GUI::TextBox>("server_input");
     m_server_inputbox->set_text(Config::read_string("Mail", "Connection", "Server", ""));
 

--- a/Userland/Applications/MailSettings/MailSettingsWidget.gml
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.gml
@@ -23,7 +23,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "server_settings_image_label"
+                icon: "/res/graphics/mail-server-settings.png"
             }
 
             @GUI::Label {
@@ -52,6 +52,7 @@
                 name: "server_input"
             }
         }
+
         @GUI::Widget {
             layout: @GUI::HorizontalBoxLayout {
                 spacing: 16
@@ -72,6 +73,7 @@
                 name: "port_input"
             }
         }
+
         @GUI::Widget {
             layout: @GUI::HorizontalBoxLayout {
                 spacing: 16
@@ -105,7 +107,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "user_settings_image_label"
+                icon: "/res/graphics/mail-user-settings.png"
             }
 
             @GUI::Label {

--- a/Userland/Applications/MouseSettings/Mouse.gml
+++ b/Userland/Applications/MouseSettings/Mouse.gml
@@ -23,7 +23,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "cursor_speed_image_label"
+                icon: "/res/graphics/mouse-cursor-speed.png"
             }
 
             @GUI::Label {
@@ -72,7 +72,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "scroll_step_size_image_label"
+                icon: "/res/graphics/scroll-wheel-step-size.png"
             }
 
             @GUI::Label {
@@ -176,7 +176,7 @@
             @GUI::Label {
                 fixed_width: 32
                 fixed_height: 32
-                name: "switch_buttons_image_label"
+                icon: "/res/graphics/switch-mouse-buttons.png"
             }
 
             @GUI::CheckBox {

--- a/Userland/Applications/MouseSettings/MouseWidget.cpp
+++ b/Userland/Applications/MouseSettings/MouseWidget.cpp
@@ -31,12 +31,6 @@ MouseWidget::MouseWidget()
     int const slider_value = float { speed_slider_scale } * GUI::WindowServerConnection::the().get_mouse_acceleration();
     m_speed_slider->set_value(slider_value);
 
-    auto& cursor_speed_image_label = *find_descendant_of_type_named<GUI::Label>("cursor_speed_image_label");
-    cursor_speed_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/graphics/mouse-cursor-speed.png").release_value_but_fixme_should_propagate_errors());
-
-    auto& scroll_step_size_image_label = *find_descendant_of_type_named<GUI::Label>("scroll_step_size_image_label");
-    scroll_step_size_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/graphics/scroll-wheel-step-size.png").release_value_but_fixme_should_propagate_errors());
-
     m_scroll_length_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("scroll_length_spinbox");
     m_scroll_length_spinbox->set_min(WindowServer::scroll_step_size_min);
     m_scroll_length_spinbox->set_value(GUI::WindowServerConnection::the().get_scroll_step_size());
@@ -53,8 +47,6 @@ MouseWidget::MouseWidget()
     m_double_click_speed_slider->set_value(GUI::WindowServerConnection::the().get_double_click_speed());
     m_switch_buttons_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("switch_buttons_input");
     m_switch_buttons_checkbox->set_checked(GUI::WindowServerConnection::the().get_buttons_switched());
-    auto& switch_buttons_image_label = *find_descendant_of_type_named<GUI::Label>("switch_buttons_image_label");
-    switch_buttons_image_label.set_icon(Gfx::Bitmap::try_load_from_file("/res/graphics/switch-mouse-buttons.png").release_value_but_fixme_should_propagate_errors());
 }
 
 void MouseWidget::apply_settings()

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -30,6 +30,7 @@ Label::Label(String text)
 
     REGISTER_STRING_PROPERTY("text", text, set_text);
     REGISTER_BOOL_PROPERTY("autosize", is_autosize, set_autosize);
+    REGISTER_STRING_PROPERTY("icon", icon, set_icon_from_path);
 }
 
 Label::~Label()
@@ -51,6 +52,16 @@ void Label::set_icon(const Gfx::Bitmap* icon)
         return;
     m_icon = icon;
     update();
+}
+
+void Label::set_icon_from_path(String const& path)
+{
+    auto maybe_bitmap = Gfx::Bitmap::try_load_from_file(path);
+    if (maybe_bitmap.is_error()) {
+        dbgln("Unable to load bitmap `{}` for label icon", path);
+        return;
+    }
+    set_icon(maybe_bitmap.release_value());
 }
 
 void Label::set_text(String text)

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -22,6 +22,7 @@ public:
     void set_text(String);
 
     void set_icon(const Gfx::Bitmap*);
+    void set_icon_from_path(String const&);
     const Gfx::Bitmap* icon() const { return m_icon.ptr(); }
     Gfx::Bitmap* icon() { return m_icon.ptr(); }
 


### PR DESCRIPTION
A pattern in various Settings apps was to have empty labels, which would be given names from GML, and then its icon would get set from C++. There was recently a change to the Button widget which would allow its icon to be set directly from GML. This PR makes a similar change to the Label widget and makes use of the new functionality in all of the Settings apps that follow the pattern. In addition to being shorter, it also gets rid of a few `.release_value_but_fixme_should_propagate_errors()`.