### PR TITLE
AK: Fix log2 calculation for Integers

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -298,7 +298,7 @@ constexpr T log2(T x)
 template<Integral T>
 constexpr T log2(T x)
 {
-    return x ? 8 * sizeof(T) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x)) : 0;
+    return x ? (8 * sizeof(T) - 1) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x)) : 0;
 }
 
 template<FloatingPoint T>


### PR DESCRIPTION
For a `N` bit integer X, the log2 calculation should be as follows:
(N - 1) - ctz(X)

I didn't see any uses of Interger log2 in the Kernel anywhere. Probably the reason why this bug was not noticed until now. 
Userland always uses the FloatPoint variant which uses inline assembly. 