### PR TITLE
AK+Kernel: Block/Storage device fixes and improvements

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -298,7 +298,7 @@ constexpr T log2(T x)
 template<Integral T>
 constexpr T log2(T x)
 {
-    return x ? 8 * sizeof(T) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x)) : 0;
+    return x ? (8 * sizeof(T) - 1) - count_leading_zeroes(static_cast<MakeUnsigned<T>>(x)) : 0;
 }
 
 template<FloatingPoint T>

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -16,6 +16,12 @@ constexpr auto round_up_to_power_of_two(T value, U power_of_two) requires(IsInte
     return ((value - 1) & ~(power_of_two - 1)) + power_of_two;
 }
 
+template<typename T>
+constexpr bool is_power_of_two(T value) requires(IsIntegral<T>)
+{
+    return value && !((value) & (value - 1));
+}
+
 // HACK: clang-format does not format this correctly because of the requires clause above.
 // Disabling formatting for that doesn't help either.
 //

--- a/Kernel/Devices/BlockDevice.cpp
+++ b/Kernel/Devices/BlockDevice.cpp
@@ -30,7 +30,7 @@ BlockDevice::~BlockDevice()
 
 bool BlockDevice::read_block(u64 index, UserOrKernelBuffer& buffer)
 {
-    auto read_request_or_error = try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read, index, 1, buffer, 512);
+    auto read_request_or_error = try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read, index, 1, buffer, m_block_size);
     if (read_request_or_error.is_error()) {
         dbgln("BlockDevice::read_block({}): try_make_request failed", index);
         return false;
@@ -56,7 +56,7 @@ bool BlockDevice::read_block(u64 index, UserOrKernelBuffer& buffer)
 
 bool BlockDevice::write_block(u64 index, const UserOrKernelBuffer& buffer)
 {
-    auto write_request_or_error = try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Write, index, 1, buffer, 512);
+    auto write_request_or_error = try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Write, index, 1, buffer, m_block_size);
     if (write_request_or_error.is_error()) {
         dbgln("BlockDevice::write_block({}): try_make_request failed", index);
         return false;

--- a/Kernel/Devices/BlockDevice.h
+++ b/Kernel/Devices/BlockDevice.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Math.h>
 #include <AK/Weakable.h>
 #include <Kernel/Devices/Device.h>
 
@@ -56,6 +57,7 @@ public:
     virtual ~BlockDevice() override;
 
     size_t block_size() const { return m_block_size; }
+    u8 block_size_log() const { return m_block_size_log; }
     virtual bool is_seekable() const override { return true; }
 
     bool read_block(u64 index, UserOrKernelBuffer&);
@@ -70,12 +72,15 @@ protected:
     {
         // 512 is the minimum sector size in most block devices
         VERIFY(m_block_size >= 512);
+        VERIFY(is_power_of_two(m_block_size));
+        m_block_size_log = AK::log2(m_block_size);
     }
 
 private:
     virtual bool is_block_device() const final { return true; }
 
     size_t m_block_size { 0 };
+    u8 m_block_size_log { 0 };
 };
 
 }

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -29,9 +29,9 @@ StringView StorageDevice::class_name() const
 
 ErrorOr<size_t> StorageDevice::read(OpenFileDescription&, u64 offset, UserOrKernelBuffer& outbuf, size_t len)
 {
-    u64 index = offset / block_size();
-    size_t whole_blocks = len / block_size();
-    size_t remaining = len % block_size();
+    u64 index = offset >> block_size_log();
+    size_t whole_blocks = len >> block_size_log();
+    size_t remaining = len - (whole_blocks << block_size_log());
 
     // PATAChannel will chuck a wobbly if we try to read more than PAGE_SIZE
     // at a time, because it uses a single page for its DMA buffer.
@@ -91,9 +91,9 @@ bool StorageDevice::can_read(const OpenFileDescription&, u64 offset) const
 
 ErrorOr<size_t> StorageDevice::write(OpenFileDescription&, u64 offset, const UserOrKernelBuffer& inbuf, size_t len)
 {
-    u64 index = offset / block_size();
-    size_t whole_blocks = len / block_size();
-    size_t remaining = len % block_size();
+    u64 index = offset >> block_size_log();
+    size_t whole_blocks = len >> block_size_log();
+    size_t remaining = len - (whole_blocks << block_size_log());
 
     // PATAChannel will chuck a wobbly if we try to write more than PAGE_SIZE
     // at a time, because it uses a single page for its DMA buffer.

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -18,6 +18,7 @@ StorageDevice::StorageDevice(MajorNumber major, MinorNumber minor, size_t sector
     : BlockDevice(major, minor, sector_size)
     , m_early_storage_device_name(move(device_name))
     , m_max_addressable_block(max_addressable_block)
+    , m_blocks_per_page(PAGE_SIZE / block_size())
 {
 }
 
@@ -32,12 +33,10 @@ ErrorOr<size_t> StorageDevice::read(OpenFileDescription&, u64 offset, UserOrKern
     size_t whole_blocks = len / block_size();
     size_t remaining = len % block_size();
 
-    size_t blocks_per_page = PAGE_SIZE / block_size();
-
     // PATAChannel will chuck a wobbly if we try to read more than PAGE_SIZE
     // at a time, because it uses a single page for its DMA buffer.
-    if (whole_blocks >= blocks_per_page) {
-        whole_blocks = blocks_per_page;
+    if (whole_blocks >= m_blocks_per_page) {
+        whole_blocks = m_blocks_per_page;
         remaining = 0;
     }
 
@@ -96,12 +95,10 @@ ErrorOr<size_t> StorageDevice::write(OpenFileDescription&, u64 offset, const Use
     size_t whole_blocks = len / block_size();
     size_t remaining = len % block_size();
 
-    size_t blocks_per_page = PAGE_SIZE / block_size();
-
     // PATAChannel will chuck a wobbly if we try to write more than PAGE_SIZE
     // at a time, because it uses a single page for its DMA buffer.
-    if (whole_blocks >= blocks_per_page) {
-        whole_blocks = blocks_per_page;
+    if (whole_blocks >= m_blocks_per_page) {
+        whole_blocks = m_blocks_per_page;
         remaining = 0;
     }
 

--- a/Kernel/Storage/StorageDevice.h
+++ b/Kernel/Storage/StorageDevice.h
@@ -66,7 +66,8 @@ private:
 
     // FIXME: Remove this method after figuring out another scheme for naming.
     NonnullOwnPtr<KString> m_early_storage_device_name;
-    u64 m_max_addressable_block;
+    u64 m_max_addressable_block { 0 };
+    size_t m_blocks_per_page { 0 };
 };
 
 }


### PR DESCRIPTION
Fixed:
- 512 bytes assumption in BlockDevice read and write block functions
- Fixed log2 calculation for Integer

Improved:
- Made some improvements to Block and Storage device classes such as caching constant variable and using log and bit shifts to calculate index and block
