### PR TITLE
LibGUI: Flash menubar when using command palette

### DIFF
--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -135,12 +135,10 @@ void Action::activate(Core::Object* activator)
     m_activator = nullptr;
 }
 
-void Action::flash_menubar_menu()
+void Action::flash_menubar_menu(GUI::Window& window)
 {
-    if (auto* app = Application::the())
-        if (auto* window = app->active_window())
-            for (auto& menu_item : m_menu_items)
-                window->flash_menubar_menu_for(*menu_item);
+    for (auto& menu_item : m_menu_items)
+        window.flash_menubar_menu_for(*menu_item);
 }
 
 void Action::register_button(Badge<Button>, Button& button)

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -92,7 +92,7 @@ public:
     Function<void(Action&)> on_activation;
 
     void activate(Core::Object* activator = nullptr);
-    void flash_menubar_menu();
+    void flash_menubar_menu(GUI::Window& window);
 
     bool is_enabled() const { return m_enabled; }
     void set_enabled(bool);

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -173,7 +173,7 @@ void WindowServerConnection::key_down(i32 window_id, u32 code_point, u32 key, u3
 
     if (auto* action = action_for_key_event(*window, *key_event)) {
         if (action->is_enabled()) {
-            action->flash_menubar_menu();
+            action->flash_menubar_menu(*window);
             action->activate();
             return;
         }
@@ -202,6 +202,7 @@ void WindowServerConnection::key_down(i32 window_id, u32 code_point, u32 key, u3
             return;
         auto* action = command_palette->selected_action();
         VERIFY(action);
+        action->flash_menubar_menu(*window);
         action->activate();
         return;
     }


### PR DESCRIPTION
@awesomekling wanted something flashy. Here's something flashy.

Invoking actions from the command palette feels similar to using keyboard shortcuts (see #9536), so let's give users the same guidance, comfort and reward for using the system efficiently.