### PR TITLE
AK+Shell: Use `StringView` instead of `String const&` where feasible in Shell

### DIFF
--- a/AK/FlyString.cpp
+++ b/AK/FlyString.cpp
@@ -117,33 +117,17 @@ FlyString FlyString::to_lowercase() const
 
 bool FlyString::operator==(const String& other) const
 {
-    if (m_impl == other.impl())
-        return true;
-
-    if (!m_impl)
-        return !other.impl();
-
-    if (!other.impl())
-        return false;
-
-    if (length() != other.length())
-        return false;
-
-    return !__builtin_memcmp(characters(), other.characters(), length());
+    return m_impl == other.impl() || view() == other.view();
 }
 
 bool FlyString::operator==(StringView string) const
 {
-    return *this == String(string);
+    return view() == string;
 }
 
 bool FlyString::operator==(const char* string) const
 {
-    if (is_null())
-        return !string;
-    if (!string)
-        return false;
-    return !__builtin_strcmp(m_impl->characters(), string);
+    return view() == string;
 }
 
 }

--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -17,54 +17,27 @@ namespace AK {
 
 bool String::operator==(const FlyString& fly_string) const
 {
-    return *this == String(fly_string.impl());
+    return m_impl == fly_string.impl() || view() == fly_string.view();
 }
 
 bool String::operator==(const String& other) const
 {
-    if (!m_impl)
-        return !other.m_impl;
-
-    if (!other.m_impl)
-        return false;
-
-    return *m_impl == *other.m_impl;
+    return m_impl == other.impl() || view() == other.view();
 }
 
 bool String::operator==(StringView other) const
 {
-    if (!m_impl)
-        return !other.m_characters;
-
-    if (!other.m_characters)
-        return false;
-
-    if (length() != other.length())
-        return false;
-
-    return !memcmp(characters(), other.characters_without_null_termination(), length());
+    return view() == other;
 }
 
 bool String::operator<(const String& other) const
 {
-    if (!m_impl)
-        return other.m_impl;
-
-    if (!other.m_impl)
-        return false;
-
-    return strcmp(characters(), other.characters()) < 0;
+    return view() < other.view();
 }
 
 bool String::operator>(const String& other) const
 {
-    if (!other.m_impl)
-        return m_impl;
-
-    if (!m_impl)
-        return false;
-
-    return strcmp(characters(), other.characters()) > 0;
+    return view() > other.view();
 }
 
 bool String::copy_characters_to_buffer(char* buffer, size_t buffer_size) const
@@ -410,43 +383,27 @@ String String::to_titlecase() const
 
 bool operator<(const char* characters, const String& string)
 {
-    if (!characters)
-        return !string.is_null();
-
-    if (string.is_null())
-        return false;
-
-    return __builtin_strcmp(characters, string.characters()) < 0;
+    return string.view() > characters;
 }
 
 bool operator>=(const char* characters, const String& string)
 {
-    return !(characters < string);
+    return string.view() <= characters;
 }
 
 bool operator>(const char* characters, const String& string)
 {
-    if (!characters)
-        return !string.is_null();
-
-    if (string.is_null())
-        return false;
-
-    return __builtin_strcmp(characters, string.characters()) > 0;
+    return string.view() < characters;
 }
 
 bool operator<=(const char* characters, const String& string)
 {
-    return !(characters > string);
+    return string.view() >= characters;
 }
 
 bool String::operator==(const char* cstring) const
 {
-    if (is_null())
-        return !cstring;
-    if (!cstring)
-        return false;
-    return !__builtin_strcmp(characters(), cstring);
+    return view() == cstring;
 }
 
 InputStream& operator>>(InputStream& stream, String& string)

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -203,15 +203,7 @@ template Optional<long long> StringView::to_uint() const;
 
 bool StringView::operator==(const String& string) const
 {
-    if (string.is_null())
-        return !m_characters;
-    if (!m_characters)
-        return false;
-    if (m_length != string.length())
-        return false;
-    if (m_characters == string.characters())
-        return true;
-    return !__builtin_memcmp(m_characters, string.characters(), m_length);
+    return *this == string.view();
 }
 
 String StringView::to_string() const { return String { *this }; }

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -204,28 +204,37 @@ public:
 
     bool operator==(const String&) const;
 
+    [[nodiscard]] constexpr int compare(StringView other) const
+    {
+        size_t rlen = min(length(), other.length());
+        int c = (rlen != 0) ? __builtin_memcmp(m_characters, other.m_characters, rlen) : 0;
+        if (c == 0) {
+            if (length() < other.length())
+                return -1;
+            if (length() == other.length())
+                return 0;
+            return 1;
+        }
+        return c;
+    }
+
     constexpr bool operator==(StringView other) const
     {
-        if (is_null())
-            return other.is_null();
-        if (other.is_null())
-            return false;
-        if (length() != other.length())
-            return false;
-        return __builtin_memcmp(m_characters, other.m_characters, m_length) == 0;
+        return length() == other.length() && compare(other) == 0;
     }
 
     constexpr bool operator!=(StringView other) const
     {
-        return !(*this == other);
+        return length() != other.length() || compare(other) != 0;
     }
 
-    bool operator<(StringView other) const
-    {
-        if (int c = __builtin_memcmp(m_characters, other.m_characters, min(m_length, other.m_length)))
-            return c < 0;
-        return m_length < other.m_length;
-    }
+    constexpr bool operator<(StringView other) const { return compare(other) < 0; }
+
+    constexpr bool operator<=(StringView other) const { return compare(other) <= 0; }
+
+    constexpr bool operator>(StringView other) const { return compare(other) > 0; }
+
+    constexpr bool operator>=(StringView other) const { return compare(other) >= 0; }
 
     [[nodiscard]] String to_string() const;
 

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -106,7 +106,7 @@ ErrorOr<void> AK::Formatter<Shell::AST::Command>::format(FormatBuilder& builder,
 
 namespace Shell::AST {
 
-static inline void print_indented(const String& str, int indent)
+static inline void print_indented(StringView str, int indent)
 {
     dbgln("{}{}", String::repeated(' ', indent * 2), str);
 }

--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -124,7 +124,7 @@ int Shell::builtin_bg(int argc, const char** argv)
         .name = "job-id",
         .min_values = 0,
         .max_values = 1,
-        .accept_value = [&](const String& value) -> bool {
+        .accept_value = [&](StringView value) -> bool {
             // Check if it's a pid (i.e. literal integer)
             if (auto number = value.to_uint(); number.has_value()) {
                 job_id = number.value();
@@ -497,7 +497,7 @@ int Shell::builtin_fg(int argc, const char** argv)
         .name = "job-id",
         .min_values = 0,
         .max_values = 1,
-        .accept_value = [&](const String& value) -> bool {
+        .accept_value = [&](StringView value) -> bool {
             // Check if it's a pid (i.e. literal integer)
             if (auto number = value.to_uint(); number.has_value()) {
                 job_id = number.value();
@@ -568,7 +568,7 @@ int Shell::builtin_disown(int argc, const char** argv)
         .name = "job-id",
         .min_values = 0,
         .max_values = INT_MAX,
-        .accept_value = [&](const String& value) -> bool {
+        .accept_value = [&](StringView value) -> bool {
             // Check if it's a pid (i.e. literal integer)
             if (auto number = value.to_uint(); number.has_value()) {
                 job_ids.append(number.value());
@@ -977,7 +977,7 @@ int Shell::builtin_wait(int argc, const char** argv)
         .name = "job-id",
         .min_values = 0,
         .max_values = INT_MAX,
-        .accept_value = [&](const String& value) -> bool {
+        .accept_value = [&](StringView value) -> bool {
             // Check if it's a pid (i.e. literal integer)
             if (auto number = value.to_uint(); number.has_value()) {
                 job_ids.append(number.value());

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, the SerenityOS developers.
+ * Copyright (c) 2020-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,11 +8,13 @@
 
 #include "Job.h"
 #include "Parser.h"
+#include <AK/Array.h>
 #include <AK/CircularQueue.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtrVector.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
+#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <AK/Vector.h>
 #include <LibCore/Notifier.h>
@@ -99,25 +101,25 @@ public:
     void block_on_pipeline(RefPtr<AST::Pipeline>);
     String prompt() const;
 
-    static String expand_tilde(const String&);
+    static String expand_tilde(StringView expression);
     static Vector<String> expand_globs(StringView path, StringView base);
     static Vector<String> expand_globs(Vector<StringView> path_segments, StringView base);
     Vector<AST::Command> expand_aliases(Vector<AST::Command>);
     String resolve_path(String) const;
-    String resolve_alias(const String&) const;
+    String resolve_alias(StringView) const;
 
     static String find_in_path(StringView program_name);
 
     static bool has_history_event(StringView);
 
     RefPtr<AST::Value> get_argument(size_t) const;
-    RefPtr<AST::Value> lookup_local_variable(const String&) const;
-    String local_variable_or(const String&, const String&) const;
+    RefPtr<AST::Value> lookup_local_variable(StringView) const;
+    String local_variable_or(StringView, const String&) const;
     void set_local_variable(const String&, RefPtr<AST::Value>, bool only_in_current_frame = false);
-    void unset_local_variable(const String&, bool only_in_current_frame = false);
+    void unset_local_variable(StringView, bool only_in_current_frame = false);
 
     void define_function(String name, Vector<String> argnames, RefPtr<AST::Node> body);
-    bool has_function(const String&);
+    bool has_function(StringView);
     bool invoke_function(const AST::Command&, int& retval);
 
     String format(StringView, ssize_t& cursor) const;
@@ -154,10 +156,10 @@ public:
     [[nodiscard]] Frame push_frame(String name);
     void pop_frame();
 
-    static String escape_token_for_double_quotes(const String& token);
-    static String escape_token_for_single_quotes(const String& token);
-    static String escape_token(const String& token);
-    static String unescape_token(const String& token);
+    static String escape_token_for_double_quotes(StringView token);
+    static String escape_token_for_single_quotes(StringView token);
+    static String escape_token(StringView token);
+    static String unescape_token(StringView token);
     enum class SpecialCharacterEscapeMode {
         Untouched,
         Escaped,
@@ -176,12 +178,12 @@ public:
 
     void highlight(Line::Editor&) const;
     Vector<Line::CompletionSuggestion> complete();
-    Vector<Line::CompletionSuggestion> complete_path(const String& base, const String&, size_t offset, ExecutableOnly executable_only);
-    Vector<Line::CompletionSuggestion> complete_program_name(const String&, size_t offset);
-    Vector<Line::CompletionSuggestion> complete_variable(const String&, size_t offset);
-    Vector<Line::CompletionSuggestion> complete_user(const String&, size_t offset);
-    Vector<Line::CompletionSuggestion> complete_option(const String&, const String&, size_t offset);
-    Vector<Line::CompletionSuggestion> complete_immediate_function_name(const String&, size_t offset);
+    Vector<Line::CompletionSuggestion> complete_path(StringView base, StringView, size_t offset, ExecutableOnly executable_only);
+    Vector<Line::CompletionSuggestion> complete_program_name(StringView, size_t offset);
+    Vector<Line::CompletionSuggestion> complete_variable(StringView, size_t offset);
+    Vector<Line::CompletionSuggestion> complete_user(StringView, size_t offset);
+    Vector<Line::CompletionSuggestion> complete_option(StringView, StringView, size_t offset);
+    Vector<Line::CompletionSuggestion> complete_immediate_function_name(StringView, size_t offset);
 
     void restore_ios();
 
@@ -191,7 +193,7 @@ public:
     void kill_job(const Job*, int sig);
 
     String get_history_path();
-    void print_path(const String& path);
+    void print_path(StringView path);
 
     bool read_single_line();
 
@@ -293,14 +295,14 @@ private:
     void save_to(JsonObject&);
     void bring_cursor_to_beginning_of_a_line() const;
 
-    Optional<int> resolve_job_spec(const String&);
+    Optional<int> resolve_job_spec(StringView);
     void cache_path();
     void add_entry_to_cache(const String&);
-    void remove_entry_from_cache(const String&);
+    void remove_entry_from_cache(StringView);
     void stop_all_jobs();
     const Job* m_current_job { nullptr };
-    LocalFrame* find_frame_containing_local_variable(const String& name);
-    const LocalFrame* find_frame_containing_local_variable(const String& name) const
+    LocalFrame* find_frame_containing_local_variable(StringView name);
+    const LocalFrame* find_frame_containing_local_variable(StringView name) const
     {
         return const_cast<Shell*>(this)->find_frame_containing_local_variable(name);
     }
@@ -328,14 +330,14 @@ private:
 
 #undef __ENUMERATE_SHELL_BUILTIN
 
-    constexpr static const char* builtin_names[] = {
-#define __ENUMERATE_SHELL_BUILTIN(builtin) #builtin,
+    static constexpr Array builtin_names = {
+#define __ENUMERATE_SHELL_BUILTIN(builtin) #builtin##sv,
 
         ENUMERATE_SHELL_BUILTINS()
 
 #undef __ENUMERATE_SHELL_BUILTIN
 
-            ":", // POSIX-y name for "noop".
+            ":"sv, // POSIX-y name for "noop".
     };
 
     bool m_should_ignore_jobs_on_next_exit { false };
@@ -376,7 +378,7 @@ private:
     return c == '_' || (c <= 'Z' && c >= 'A') || (c <= 'z' && c >= 'a') || (c <= '9' && c >= '0');
 }
 
-inline size_t find_offset_into_node(const String& unescaped_text, size_t escaped_offset)
+inline size_t find_offset_into_node(StringView unescaped_text, size_t escaped_offset)
 {
     size_t unescaped_offset = 0;
     size_t offset = 0;


### PR DESCRIPTION
This PR simplifies and extends the comparison operators for `String{View,_}`, and with the help of those, changes various Shell methods to take `StringView` instead of `String const&`.