### PR TITLE
Everywhere: Remove redundant inline keyword

### DIFF
--- a/AK/MemMem.h
+++ b/AK/MemMem.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,7 +15,7 @@
 namespace AK {
 
 namespace Detail {
-inline constexpr const void* bitap_bitwise(const void* haystack, size_t haystack_length, const void* needle, size_t needle_length)
+constexpr const void* bitap_bitwise(const void* haystack, size_t haystack_length, const void* needle, size_t needle_length)
 {
     VERIFY(needle_length < 32);
 

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, James Mintram <me@jamesrm.com>
  * Copyright (c) 2021, Marcin Undak <mcinek@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -145,7 +146,7 @@ struct TCR_EL1 {
         return tcr_el1;
     }
 
-    static inline constexpr TCR_EL1 reset_value()
+    static constexpr TCR_EL1 reset_value()
     {
         return {};
     }
@@ -220,7 +221,7 @@ struct SCTLR_EL1 {
         return sctlr;
     }
 
-    static inline constexpr SCTLR_EL1 reset_value()
+    static constexpr SCTLR_EL1 reset_value()
     {
         SCTLR_EL1 system_control_register_el1 = {};
         system_control_register_el1.LSMAOE = 1;

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -234,7 +235,7 @@ public:
 
 AK_ENUM_BITWISE_OPERATORS(Region::Access)
 
-inline constexpr Region::Access prot_to_region_access_flags(int prot)
+constexpr Region::Access prot_to_region_access_flags(int prot)
 {
     Region::Access access = Region::Access::None;
     if ((prot & PROT_READ) == PROT_READ)
@@ -246,7 +247,7 @@ inline constexpr Region::Access prot_to_region_access_flags(int prot)
     return access;
 }
 
-inline constexpr int region_access_flags_to_prot(Region::Access access)
+constexpr int region_access_flags_to_prot(Region::Access access)
 {
     int prot = 0;
     if ((access & Region::Access::Read) == Region::Access::Read)

--- a/Userland/Libraries/LibSoftGPU/ImageFormat.h
+++ b/Userland/Libraries/LibSoftGPU/ImageFormat.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,7 +21,7 @@ enum class ImageFormat {
     L8A8,
 };
 
-inline static constexpr size_t element_size(ImageFormat format)
+static constexpr size_t element_size(ImageFormat format)
 {
     switch (format) {
     case ImageFormat::L8:

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Ali Mohammad Pur <mpfard@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -65,8 +66,8 @@ extern HashMap<ConnectionKey, NonnullOwnPtr<NonnullOwnPtrVector<Connection<TLS::
 void request_did_finish(URL const&, Core::Socket const*);
 void dump_jobs();
 
-constexpr static inline size_t MaxConcurrentConnectionsPerURL = 2;
-constexpr static inline size_t ConnectionKeepAliveTimeMilliseconds = 10'000;
+constexpr static size_t MaxConcurrentConnectionsPerURL = 2;
+constexpr static size_t ConnectionKeepAliveTimeMilliseconds = 10'000;
 
 template<typename T>
 void recreate_socket_if_needed(T& connection, URL const& url)


### PR DESCRIPTION
`constexpr` implies `inline` so when both are used it is redundant.