### PR TITLE
LibWeb: Implement support for sequences and unions as parameters and make use of them

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -80,6 +80,7 @@ set(SOURCES
     DOM/LiveNodeList.cpp
     DOM/NamedNodeMap.cpp
     DOM/Node.cpp
+    DOM/NodeOperations.cpp
     DOM/ParentNode.cpp
     DOM/Position.cpp
     DOM/ProcessingInstruction.cpp

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.idl
@@ -6,7 +6,8 @@ interface CharacterData : Node {
     readonly attribute Element? nextElementSibling;
     readonly attribute Element? previousElementSibling;
 
-    // FIXME: This should come from a ChildNode mixin
+    // FIXME: These should come from a ChildNode mixin
+    [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.idl
@@ -9,6 +9,7 @@ interface CharacterData : Node {
     // FIXME: These should come from a ChildNode mixin
     [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
     [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/CharacterData.idl
+++ b/Userland/Libraries/LibWeb/DOM/CharacterData.idl
@@ -8,6 +8,7 @@ interface CharacterData : Node {
 
     // FIXME: These should come from a ChildNode mixin
     [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2021-2022, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.h
@@ -81,6 +81,46 @@ public:
         return {};
     }
 
+    // https://dom.spec.whatwg.org/#dom-childnode-replacewith
+    ExceptionOr<void> replace_with(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes)
+    {
+        auto* node = static_cast<NodeType*>(this);
+
+        // 1. Let parent be this’s parent.
+        auto* parent = node->parent();
+
+        // 2. If parent is null, then return.
+        if (!parent)
+            return {};
+
+        // 3. Let viableNextSibling be this’s first following sibling not in nodes; otherwise null.
+        auto viable_next_sibling = viable_nest_sibling_for_insertion(nodes);
+
+        // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
+        auto node_or_exception = convert_nodes_to_single_node(nodes, node->document());
+        if (node_or_exception.is_exception())
+            return node_or_exception.exception();
+
+        auto node_to_insert = node_or_exception.release_value();
+
+        // 5. If this’s parent is parent, replace this with node within parent.
+        // Note: This could have been inserted into node.
+        if (node->parent() == parent) {
+            auto result = parent->replace_child(node_to_insert, *node);
+            if (result.is_exception())
+                return result.exception();
+
+            return {};
+        }
+
+        // 6. Otherwise, pre-insert node into parent before viableNextSibling.
+        auto result = parent->pre_insert(node_to_insert, viable_next_sibling);
+        if (result.is_exception())
+            return result.exception();
+
+        return {};
+    }
+
     // https://dom.spec.whatwg.org/#dom-childnode-remove
     void remove_binding()
     {

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.h
@@ -6,12 +6,51 @@
 
 #pragma once
 
+#include <LibWeb/DOM/ExceptionOr.h>
+#include <LibWeb/DOM/NodeOperations.h>
+
 namespace Web::DOM {
 
 // https://dom.spec.whatwg.org/#childnode
 template<typename NodeType>
 class ChildNode {
 public:
+    // https://dom.spec.whatwg.org/#dom-childnode-before
+    ExceptionOr<void> before(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes)
+    {
+        auto* node = static_cast<NodeType*>(this);
+
+        // 1. Let parent be this’s parent.
+        auto* parent = node->parent();
+
+        // 2. If parent is null, then return.
+        if (!parent)
+            return {};
+
+        // 3. Let viablePreviousSibling be this’s first preceding sibling not in nodes; otherwise null.
+        auto viable_previous_sibling = viable_previous_sibling_for_insertion(nodes);
+
+        // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
+        auto node_or_exception = convert_nodes_to_single_node(nodes, node->document());
+        if (node_or_exception.is_exception())
+            return node_or_exception.exception();
+
+        auto node_to_insert = node_or_exception.release_value();
+
+        // 5. If viablePreviousSibling is null, then set it to parent’s first child; otherwise to viablePreviousSibling’s next sibling.
+        if (!viable_previous_sibling)
+            viable_previous_sibling = parent->first_child();
+        else
+            viable_previous_sibling = viable_previous_sibling->next_sibling();
+
+        // 6. Pre-insert node into parent before viablePreviousSibling.
+        auto result = parent->pre_insert(node_to_insert, viable_previous_sibling);
+        if (result.is_exception())
+            return result.exception();
+
+        return {};
+    }
+
     // https://dom.spec.whatwg.org/#dom-childnode-remove
     void remove_binding()
     {
@@ -27,6 +66,32 @@ public:
 
 protected:
     ChildNode() = default;
+
+private:
+    RefPtr<Node> viable_previous_sibling_for_insertion(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes) const
+    {
+        auto* node = static_cast<NodeType const*>(this);
+
+        while (auto* previous_sibling = node->previous_sibling()) {
+            bool contained_in_nodes = false;
+
+            for (auto const& node_or_string : nodes) {
+                if (!node_or_string.template has<NonnullRefPtr<Node>>())
+                    continue;
+
+                auto node_in_vector = node_or_string.template get<NonnullRefPtr<Node>>();
+                if (node_in_vector.ptr() == previous_sibling) {
+                    contained_in_nodes = true;
+                    break;
+                }
+            }
+
+            if (!contained_in_nodes)
+                return previous_sibling;
+        }
+
+        return nullptr;
+    }
 };
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ChildNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ChildNode.h
@@ -51,6 +51,36 @@ public:
         return {};
     }
 
+    // https://dom.spec.whatwg.org/#dom-childnode-after
+    ExceptionOr<void> after(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes)
+    {
+        auto* node = static_cast<NodeType*>(this);
+
+        // 1. Let parent be this’s parent.
+        auto* parent = node->parent();
+
+        // 2. If parent is null, then return.
+        if (!parent)
+            return {};
+
+        // 3. Let viableNextSibling be this’s first following sibling not in nodes; otherwise null.
+        auto viable_next_sibling = viable_nest_sibling_for_insertion(nodes);
+
+        // 4. Let node be the result of converting nodes into a node, given nodes and this’s node document.
+        auto node_or_exception = convert_nodes_to_single_node(nodes, node->document());
+        if (node_or_exception.is_exception())
+            return node_or_exception.exception();
+
+        auto node_to_insert = node_or_exception.release_value();
+
+        // 5. Pre-insert node into parent before viableNextSibling.
+        auto result = parent->pre_insert(node_to_insert, viable_next_sibling);
+        if (result.is_exception())
+            return result.exception();
+
+        return {};
+    }
+
     // https://dom.spec.whatwg.org/#dom-childnode-remove
     void remove_binding()
     {
@@ -88,6 +118,31 @@ private:
 
             if (!contained_in_nodes)
                 return previous_sibling;
+        }
+
+        return nullptr;
+    }
+
+    RefPtr<Node> viable_nest_sibling_for_insertion(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes) const
+    {
+        auto* node = static_cast<NodeType const*>(this);
+
+        while (auto* next_sibling = node->next_sibling()) {
+            bool contained_in_nodes = false;
+
+            for (auto const& node_or_string : nodes) {
+                if (!node_or_string.template has<NonnullRefPtr<Node>>())
+                    continue;
+
+                auto node_in_vector = node_or_string.template get<NonnullRefPtr<Node>>();
+                if (node_in_vector.ptr() == next_sibling) {
+                    contained_in_nodes = true;
+                    break;
+                }
+            }
+
+            if (!contained_in_nodes)
+                return next_sibling;
         }
 
         return nullptr;

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -65,6 +65,8 @@ interface Document : Node {
     readonly attribute Element? lastElementChild;
     readonly attribute unsigned long childElementCount;
 
+    [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
+
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -66,6 +66,7 @@ interface Document : Node {
     readonly attribute unsigned long childElementCount;
 
     [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -67,6 +67,7 @@ interface Document : Node {
 
     [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
     [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -10,6 +10,7 @@ interface DocumentFragment : Node {
     readonly attribute unsigned long childElementCount;
 
     [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -11,6 +11,7 @@ interface DocumentFragment : Node {
 
     [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
     [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentFragment.idl
@@ -9,6 +9,8 @@ interface DocumentFragment : Node {
     readonly attribute Element? lastElementChild;
     readonly attribute unsigned long childElementCount;
 
+    [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
+
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);
 

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.idl
@@ -6,6 +6,7 @@ interface DocumentType : Node {
 
     // FIXME: These should come from a ChildNode mixin
     [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.idl
@@ -7,6 +7,7 @@ interface DocumentType : Node {
     // FIXME: These should come from a ChildNode mixin
     [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
     [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/DocumentType.idl
+++ b/Userland/Libraries/LibWeb/DOM/DocumentType.idl
@@ -4,7 +4,8 @@ interface DocumentType : Node {
     readonly attribute DOMString publicId;
     readonly attribute DOMString systemId;
 
-    // FIXME: This should come from a ChildNode mixin
+    // FIXME: These should come from a ChildNode mixin
+    [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -54,7 +54,8 @@ interface Element : Node {
     readonly attribute long clientWidth;
     readonly attribute long clientHeight;
 
-    // FIXME: This should come from a ChildNode mixin
+    // FIXME: These should come from a ChildNode mixin
+    [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -40,6 +40,7 @@ interface Element : Node {
 
     [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
     [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceChildren((Node or DOMString)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -39,6 +39,7 @@ interface Element : Node {
     readonly attribute unsigned long childElementCount;
 
     [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined append((Node or DOMString)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -33,10 +33,12 @@ interface Element : Node {
 
     [ImplementedAs=style_for_bindings] readonly attribute CSSStyleDeclaration style;
 
-    // FIXME: These should all come from a ParentNode mixin
+    // FIXME: These should all come from a ParentNode mixin (up to and including children)
     readonly attribute Element? firstElementChild;
     readonly attribute Element? lastElementChild;
     readonly attribute unsigned long childElementCount;
+
+    [CEReactions, Unscopable] undefined prepend((Node or DOMString)... nodes);
 
     Element? querySelector(DOMString selectors);
     [NewObject] NodeList querySelectorAll(DOMString selectors);

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -56,6 +56,7 @@ interface Element : Node {
 
     // FIXME: These should come from a ChildNode mixin
     [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -57,6 +57,7 @@ interface Element : Node {
     // FIXME: These should come from a ChildNode mixin
     [CEReactions, Unscopable] undefined before((Node or DOMString)... nodes);
     [CEReactions, Unscopable] undefined after((Node or DOMString)... nodes);
+    [CEReactions, Unscopable] undefined replaceWith((Node or DOMString)... nodes);
     [CEReactions, Unscopable, ImplementedAs=remove_binding] undefined remove();
 
 };

--- a/Userland/Libraries/LibWeb/DOM/NodeOperations.cpp
+++ b/Userland/Libraries/LibWeb/DOM/NodeOperations.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibWeb/DOM/DocumentFragment.h>
+#include <LibWeb/DOM/NodeOperations.h>
+#include <LibWeb/DOM/Text.h>
+
+namespace Web::DOM {
+
+// https://dom.spec.whatwg.org/#converting-nodes-into-a-node
+ExceptionOr<NonnullRefPtr<Node>> convert_nodes_to_single_node(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes, DOM::Document& document)
+{
+    // 1. Let node be null.
+    // 2. Replace each string in nodes with a new Text node whose data is the string and node document is document.
+    // 3. If nodes contains one node, then set node to nodes[0].
+    // 4. Otherwise, set node to a new DocumentFragment node whose node document is document, and then append each node in nodes, if any, to it.
+    // 5. Return node.
+
+    auto potentially_convert_string_to_text_node = [&document](Variant<NonnullRefPtr<Node>, String> const& node) -> NonnullRefPtr<Node> {
+        if (node.has<NonnullRefPtr<Node>>())
+            return node.get<NonnullRefPtr<Node>>();
+
+        return adopt_ref(*new Text(document, node.get<String>()));
+    };
+
+    if (nodes.size() == 1)
+        return potentially_convert_string_to_text_node(nodes.first());
+
+    // This is NNRP<Node> instead of NNRP<DocumentFragment> to be compatible with the return type.
+    NonnullRefPtr<Node> document_fragment = adopt_ref(*new DocumentFragment(document));
+    for (auto& unconverted_node : nodes) {
+        auto node = potentially_convert_string_to_text_node(unconverted_node);
+        auto result = document_fragment->append_child(node);
+        if (result.is_exception())
+            return result.exception();
+    }
+
+    return document_fragment;
+}
+
+}

--- a/Userland/Libraries/LibWeb/DOM/NodeOperations.h
+++ b/Userland/Libraries/LibWeb/DOM/NodeOperations.h
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::DOM {
+
+ExceptionOr<NonnullRefPtr<Node>> convert_nodes_to_single_node(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes, DOM::Document& document);
+
+}

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -174,4 +174,21 @@ ExceptionOr<void> ParentNode::prepend(Vector<Variant<NonnullRefPtr<Node>, String
     return {};
 }
 
+ExceptionOr<void> ParentNode::append(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes)
+{
+    // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
+    auto node_or_exception = convert_nodes_to_single_node(nodes, document());
+    if (node_or_exception.is_exception())
+        return node_or_exception.exception();
+
+    auto node = node_or_exception.release_value();
+
+    // 2. Append node to this.
+    auto result = append_child(node);
+    if (result.is_exception())
+        return result.exception();
+
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -191,4 +191,23 @@ ExceptionOr<void> ParentNode::append(Vector<Variant<NonnullRefPtr<Node>, String>
     return {};
 }
 
+ExceptionOr<void> ParentNode::replace_children(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes)
+{
+    // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
+    auto node_or_exception = convert_nodes_to_single_node(nodes, document());
+    if (node_or_exception.is_exception())
+        return node_or_exception.exception();
+
+    auto node = node_or_exception.release_value();
+
+    // 2. Ensure pre-insertion validity of node into this before null.
+    auto validity_exception = ensure_pre_insertion_validity(node, nullptr);
+    if (validity_exception.is_exception())
+        return validity_exception.exception();
+
+    // 3. Replace all with node within this.
+    replace_all(node);
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.cpp
@@ -7,6 +7,7 @@
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/SelectorEngine.h>
 #include <LibWeb/DOM/HTMLCollection.h>
+#include <LibWeb/DOM/NodeOperations.h>
 #include <LibWeb/DOM/ParentNode.h>
 #include <LibWeb/DOM/StaticNodeList.h>
 #include <LibWeb/Dump.h>
@@ -153,6 +154,24 @@ NonnullRefPtr<HTMLCollection> ParentNode::get_elements_by_tag_name_ns(FlyString 
     return HTMLCollection::create(*this, [this, namespace_, local_name](Element const& element) {
         return element.is_descendant_of(*this) && element.namespace_() == namespace_ && element.local_name() == local_name;
     });
+}
+
+// https://dom.spec.whatwg.org/#dom-parentnode-prepend
+ExceptionOr<void> ParentNode::prepend(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes)
+{
+    // 1. Let node be the result of converting nodes into a node given nodes and this’s node document.
+    auto node_or_exception = convert_nodes_to_single_node(nodes, document());
+    if (node_or_exception.is_exception())
+        return node_or_exception.exception();
+
+    auto node = node_or_exception.release_value();
+
+    // 2. Pre-insert node into this before this’s first child.
+    auto result = pre_insert(node, first_child());
+    if (result.is_exception())
+        return result.exception();
+
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.h
@@ -31,6 +31,7 @@ public:
     NonnullRefPtr<HTMLCollection> get_elements_by_tag_name_ns(FlyString const&, FlyString const&);
 
     ExceptionOr<void> prepend(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes);
+    ExceptionOr<void> append(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes);
 
 protected:
     ParentNode(Document& document, NodeType type)

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.h
@@ -30,6 +30,8 @@ public:
     NonnullRefPtr<HTMLCollection> get_elements_by_tag_name(FlyString const&);
     NonnullRefPtr<HTMLCollection> get_elements_by_tag_name_ns(FlyString const&, FlyString const&);
 
+    ExceptionOr<void> prepend(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes);
+
 protected:
     ParentNode(Document& document, NodeType type)
         : Node(document, type)

--- a/Userland/Libraries/LibWeb/DOM/ParentNode.h
+++ b/Userland/Libraries/LibWeb/DOM/ParentNode.h
@@ -32,6 +32,7 @@ public:
 
     ExceptionOr<void> prepend(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes);
     ExceptionOr<void> append(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes);
+    ExceptionOr<void> replace_children(Vector<Variant<NonnullRefPtr<Node>, String>> const& nodes);
 
 protected:
     ParentNode(Document& document, NodeType type)

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
@@ -66,24 +66,45 @@ Vector<QueryParam> url_decode(StringView input)
     return output;
 }
 
-DOM::ExceptionOr<NonnullRefPtr<URLSearchParams>> URLSearchParams::create_with_global_object(Bindings::WindowObject&, String const& init)
+DOM::ExceptionOr<NonnullRefPtr<URLSearchParams>> URLSearchParams::create_with_global_object(Bindings::WindowObject&, Variant<Vector<Vector<String>>, String> const& init)
 {
     // 1. If init is a string and starts with U+003F (?), then remove the first code point from init.
-    StringView stripped_init = init.substring_view(init.starts_with('?'));
+    // NOTE: We do this when we know that it's a string on step 3 of initialization.
+
     // 2. Initialize this with init.
 
     // URLSearchParams init from this point forward
 
-    // TODO
     // 1. If init is a sequence, then for each pair in init:
-    // a. If pair does not contain exactly two items, then throw a TypeError.
-    // b. Append a new name-value pair whose name is pair’s first item, and value is pair’s second item, to query’s list.
+    if (init.has<Vector<Vector<String>>>()) {
+        auto const& init_sequence = init.get<Vector<Vector<String>>>();
+
+        Vector<QueryParam> list;
+        list.ensure_capacity(init_sequence.size());
+
+        for (auto const& pair : init_sequence) {
+            // a. If pair does not contain exactly two items, then throw a TypeError.
+            if (pair.size() != 2)
+                return DOM::SimpleException { DOM::SimpleExceptionType::TypeError, String::formatted("Expected only 2 items in pair, got {}", pair.size()) };
+
+            // b. Append a new name-value pair whose name is pair’s first item, and value is pair’s second item, to query’s list.
+            list.append(QueryParam { .name = pair[0], .value = pair[1] });
+        }
+
+        return URLSearchParams::create(move(list));
+    }
 
     // TODO
     // 2. Otherwise, if init is a record, then for each name → value of init, append a new name-value pair whose name is name and value is value, to query’s list.
 
     // 3. Otherwise:
     // a. Assert: init is a string.
+    // NOTE: `get` performs `VERIFY(has<T>())`
+    auto const& init_string = init.get<String>();
+
+    // See NOTE at the start of this function.
+    StringView stripped_init = init_string.substring_view(init_string.starts_with('?'));
+
     // b. Set query’s list to the result of parsing init.
     return URLSearchParams::create(url_decode(stripped_init));
 }

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.h
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.h
@@ -30,7 +30,7 @@ public:
         return adopt_ref(*new URLSearchParams(move(list)));
     }
 
-    static DOM::ExceptionOr<NonnullRefPtr<URLSearchParams>> create_with_global_object(Bindings::WindowObject&, const String& init);
+    static DOM::ExceptionOr<NonnullRefPtr<URLSearchParams>> create_with_global_object(Bindings::WindowObject&, Variant<Vector<Vector<String>>, String> const& init);
 
     void append(String const& name, String const& value);
     void delete_(String const& name);

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.idl
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.idl
@@ -1,7 +1,7 @@
 interface URLSearchParams {
 
   // FIXME: the real type of init is (sequence<sequence<USVString>> or record<USVString, USVString> or USVString)
-  constructor(optional USVString init = "");
+  constructor(optional (sequence<sequence<USVString>> or USVString) init = "");
 
   undefined append(USVString name, USVString value);
   undefined delete(USVString name);


### PR DESCRIPTION
URLSearchParams can now accept array pairs:
![Screenshot from 2021-12-27 23-35-51](https://user-images.githubusercontent.com/25595356/151680653-a6cf924e-45b2-43a8-8a2b-76af6308d0e9.png)

We now have all the ParentNode and ChildNode node mutation functions:
![Screenshot from 2022-01-29 22-09-05](https://user-images.githubusercontent.com/25595356/151680662-1ed357a2-5db7-49d5-8ca9-048799a1099e.png)
![Screenshot from 2022-01-29 22-12-08](https://user-images.githubusercontent.com/25595356/151680663-774c4727-4246-43a6-9399-15ae2e08fc6f.png)
