### PR TITLE
Kernel: Set up an initial boot framebuffer console

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -73,6 +73,7 @@ set(KERNEL_SOURCES
     Devices/HID/VMWareMouseDevice.cpp
     GlobalProcessExposed.cpp
     Graphics/Bochs/GraphicsAdapter.cpp
+    Graphics/Console/BootFramebufferConsole.cpp
     Graphics/Console/GenericFramebufferConsole.cpp
     Graphics/Console/ContiguousFramebufferConsole.cpp
     Graphics/Console/TextModeConsole.cpp

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -107,8 +107,7 @@ UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::DeviceIdentifie
 {
     // We assume safe resolution is 1024x768x32
     m_framebuffer_console = Graphics::ContiguousFramebufferConsole::initialize(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), 1024, 768, 1024 * sizeof(u32));
-    // FIXME: This is a very wrong way to do this...
-    GraphicsManagement::the().m_console = m_framebuffer_console;
+    GraphicsManagement::the().set_console(*m_framebuffer_console);
 
     // Note: If we use VirtualBox graphics adapter (which is based on Bochs one), we need to use IO ports
     if (pci_device_identifier.hardware_id().vendor_id == 0x80ee && pci_device_identifier.hardware_id().device_id == 0xbeef)

--- a/Kernel/Graphics/Console/BootFramebufferConsole.cpp
+++ b/Kernel/Graphics/Console/BootFramebufferConsole.cpp
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Graphics/Console/BootFramebufferConsole.h>
+#include <Kernel/Locking/Spinlock.h>
+#include <Kernel/Memory/MemoryManager.h>
+
+namespace Kernel::Graphics {
+
+BootFramebufferConsole::BootFramebufferConsole(PhysicalAddress framebuffer_addr, size_t width, size_t height, size_t pitch)
+    : GenericFramebufferConsoleImpl(width, height, pitch)
+{
+    // NOTE: We're very early in the boot process, memory allocations shouldn't really fail
+    auto framebuffer_end = Memory::page_round_up(framebuffer_addr.offset(height * pitch * sizeof(u32)).get()).release_value();
+    m_framebuffer = MM.allocate_kernel_region(framebuffer_addr.page_base(), framebuffer_end - framebuffer_addr.page_base().get(), "Boot Framebuffer"sv, Memory::Region::Access::ReadWrite).release_value();
+    [[maybe_unused]] auto result = m_framebuffer->set_write_combine(true);
+    m_framebuffer_data = m_framebuffer->vaddr().offset(framebuffer_addr.offset_in_page()).as_ptr();
+    memset(m_framebuffer_data, 0, height * pitch * sizeof(u32));
+}
+
+void BootFramebufferConsole::clear(size_t x, size_t y, size_t length)
+{
+    SpinlockLocker lock(m_lock);
+    if (m_framebuffer_data)
+        GenericFramebufferConsoleImpl::clear(x, y, length);
+}
+
+void BootFramebufferConsole::clear_glyph(size_t x, size_t y)
+{
+    VERIFY(m_lock.is_locked());
+    GenericFramebufferConsoleImpl::clear_glyph(x, y);
+}
+
+void BootFramebufferConsole::enable()
+{
+    // Once disabled, ignore requests to re-enable
+}
+
+void BootFramebufferConsole::disable()
+{
+    SpinlockLocker lock(m_lock);
+    GenericFramebufferConsoleImpl::disable();
+    m_framebuffer = nullptr;
+    m_framebuffer_data = nullptr;
+}
+
+void BootFramebufferConsole::write(size_t x, size_t y, char ch, Color background, Color foreground, bool critical)
+{
+    SpinlockLocker lock(m_lock);
+    if (m_framebuffer_data)
+        GenericFramebufferConsoleImpl::write(x, y, ch, background, foreground, critical);
+}
+
+u8* BootFramebufferConsole::framebuffer_data()
+{
+    VERIFY(m_lock.is_locked());
+    VERIFY(m_framebuffer_data);
+    return m_framebuffer_data;
+}
+
+}

--- a/Kernel/Graphics/Console/BootFramebufferConsole.h
+++ b/Kernel/Graphics/Console/BootFramebufferConsole.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Forward.h>
+#include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
+
+namespace Kernel::Graphics {
+
+class BootFramebufferConsole : public GenericFramebufferConsoleImpl {
+public:
+    virtual void clear(size_t x, size_t y, size_t length) override;
+    virtual void write(size_t x, size_t y, char ch, Color background, Color foreground, bool critical = false) override;
+    using GenericFramebufferConsoleImpl::write;
+
+    virtual void enable() override;
+    virtual void disable() override;
+
+    virtual void flush(size_t, size_t, size_t, size_t) override { }
+    virtual void set_resolution(size_t, size_t, size_t) override { }
+
+    BootFramebufferConsole(PhysicalAddress framebuffer_addr, size_t width, size_t height, size_t pitch);
+
+protected:
+    virtual void clear_glyph(size_t x, size_t y) override;
+
+    virtual u8* framebuffer_data() override;
+
+    OwnPtr<Memory::Region> m_framebuffer;
+    u8* m_framebuffer_data {};
+    mutable Spinlock m_lock;
+};
+
+}

--- a/Kernel/Graphics/Console/GenericFramebufferConsole.h
+++ b/Kernel/Graphics/Console/GenericFramebufferConsole.h
@@ -13,7 +13,7 @@
 
 namespace Kernel::Graphics {
 
-class GenericFramebufferConsole : public Console {
+class GenericFramebufferConsoleImpl : public Console {
 public:
     virtual size_t bytes_per_base_glyph() const override;
     virtual size_t chars_per_line() const override;
@@ -39,14 +39,33 @@ public:
     virtual void set_resolution(size_t width, size_t height, size_t pitch) = 0;
 
 protected:
-    GenericFramebufferConsole(size_t width, size_t height, size_t pitch)
+    GenericFramebufferConsoleImpl(size_t width, size_t height, size_t pitch)
         : Console(width, height)
         , m_pitch(pitch)
     {
     }
     virtual u8* framebuffer_data() = 0;
-    void clear_glyph(size_t x, size_t y);
+    virtual void clear_glyph(size_t x, size_t y);
     size_t m_pitch;
+};
+
+class GenericFramebufferConsole : public GenericFramebufferConsoleImpl {
+public:
+    virtual void clear(size_t x, size_t y, size_t length) override;
+    virtual void write(size_t x, size_t y, char ch, Color background, Color foreground, bool critical = false) override;
+
+    virtual void enable() override;
+    virtual void disable() override;
+
+protected:
+    GenericFramebufferConsole(size_t width, size_t height, size_t pitch)
+        : GenericFramebufferConsoleImpl(width, height, pitch)
+    {
+    }
+
+    virtual void clear_glyph(size_t x, size_t y) override;
+
     mutable Spinlock m_lock;
 };
+
 }

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -19,14 +19,7 @@
 
 namespace Kernel {
 
-class BochsGraphicsAdapter;
-class IntelNativeGraphicsAdapter;
-class VGACompatibleAdapter;
 class GraphicsManagement {
-    friend class BochsGraphicsAdapter;
-    friend class IntelNativeGraphicsAdapter;
-    friend class VGACompatibleAdapter;
-    friend class Graphics::VirtIOGPU::GraphicsAdapter;
 
 public:
     static GraphicsManagement& the();
@@ -42,6 +35,7 @@ public:
 
     Spinlock& main_vga_lock() { return m_main_vga_lock; }
     RefPtr<Graphics::Console> console() const { return m_console; }
+    void set_console(Graphics::Console&);
 
     void deactivate_graphical_mode();
     void activate_graphical_mode();

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -209,8 +209,7 @@ IntelNativeGraphicsAdapter::IntelNativeGraphicsAdapter(PCI::Address address)
     VERIFY(m_framebuffer_height != 0);
     VERIFY(m_framebuffer_width != 0);
     m_framebuffer_console = Graphics::ContiguousFramebufferConsole::initialize(framebuffer_address, m_framebuffer_width, m_framebuffer_height, m_framebuffer_pitch);
-    // FIXME: This is a very wrong way to do this...
-    GraphicsManagement::the().m_console = m_framebuffer_console;
+    GraphicsManagement::the().set_console(*m_framebuffer_console);
 }
 
 void IntelNativeGraphicsAdapter::enable_vga_plane()

--- a/Kernel/Graphics/VGACompatibleAdapter.cpp
+++ b/Kernel/Graphics/VGACompatibleAdapter.cpp
@@ -40,8 +40,7 @@ UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address
     : PCI::Device(address)
 {
     m_framebuffer_console = Graphics::TextModeConsole::initialize(*this);
-    // FIXME: This is a very wrong way to do this...
-    GraphicsManagement::the().m_console = m_framebuffer_console;
+    GraphicsManagement::the().set_console(*m_framebuffer_console);
 }
 
 UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address, PhysicalAddress framebuffer_address, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch)
@@ -52,8 +51,7 @@ UNMAP_AFTER_INIT VGACompatibleAdapter::VGACompatibleAdapter(PCI::Address address
     , m_framebuffer_pitch(framebuffer_pitch)
 {
     m_framebuffer_console = Graphics::ContiguousFramebufferConsole::initialize(framebuffer_address, framebuffer_width, framebuffer_height, framebuffer_pitch);
-    // FIXME: This is a very wrong way to do this...
-    GraphicsManagement::the().m_console = m_framebuffer_console;
+    GraphicsManagement::the().set_console(*m_framebuffer_console);
 }
 
 void VGACompatibleAdapter::enable_consoles()

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -43,8 +43,7 @@ void GraphicsAdapter::initialize_framebuffer_devices()
     create_framebuffer_devices();
     m_created_framebuffer_devices = true;
 
-    // FIXME: This is a very wrong way to do this...
-    GraphicsManagement::the().m_console = default_console();
+    GraphicsManagement::the().set_console(*default_console());
 }
 
 void GraphicsAdapter::enable_consoles()


### PR DESCRIPTION
Instead of seeing a black screen until GraphicsManagement was fully
initialized, this allows us to see the console output much earlier.
So, if the bootloader provided us with a framebuffer, set up a console
as early as possible.