### PR TITLE
Meta: Fix "Meta/serenity.sh run x86_64 Clang" on M1 Macs

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -38,8 +38,10 @@ if [ "$(uname)" = "Darwin" ]; then
         [ -z "$SERENITY_QEMU_BIN" ] && SERENITY_QEMU_BIN="qemu-system-aarch64"
     fi
 
-    if $SERENITY_QEMU_BIN --accel help | grep -q hvf; then
-        SERENITY_VIRT_TECH_ARG="--accel hvf"
+    if [ "$(uname -m)" = "x86_64" ]; then
+        if $SERENITY_QEMU_BIN --accel help | grep -q hvf; then
+            SERENITY_VIRT_TECH_ARG="--accel hvf"
+        fi
     fi
 fi
 


### PR DESCRIPTION
qemu crashes on M1 Macs when using "--accel hvf"
To solve this, detect the host's architecture and only add that parameter if it is "x86_64", not "arm64" like it is on M1 Macs.