### PR TITLE
Kernel: Support right super key

### DIFF
--- a/Kernel/Devices/HID/KeyboardDevice.h
+++ b/Kernel/Devices/HID/KeyboardDevice.h
@@ -58,6 +58,8 @@ protected:
     bool m_has_e0_prefix { false };
     bool m_left_shift_pressed { false };
     bool m_right_shift_pressed { false };
+    bool m_left_super_pressed { false };
+    bool m_right_super_pressed { false };
 
     void key_state_changed(u8 raw, bool pressed);
 };

--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -51,7 +51,12 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
         update_modifier(Mod_Ctrl, pressed);
         break;
     case 0x5b:
-        update_modifier(Mod_Super, pressed);
+        m_left_super_pressed = pressed;
+        update_modifier(Mod_Super, m_left_super_pressed || m_right_super_pressed);
+        break;
+    case 0x5c:
+        m_right_super_pressed = pressed;
+        update_modifier(Mod_Super, m_left_super_pressed || m_right_super_pressed);
         break;
     case 0x2a:
         m_left_shift_pressed = pressed;


### PR DESCRIPTION
We currently support the left super key. This poses an issue on keyboards that only have a right super key, such as my Steelseries 6G.

The implementation mirrors the left/right shift key logic and effectively considers the right super key identical to the left one.