### PR TITLE
LibGUI: Improvements to CommandPalette

### DIFF
--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -40,6 +40,11 @@ TEST_CASE(construct_contents)
     EXPECT(test_string != "ABCDEFG");
 }
 
+TEST_CASE(equal)
+{
+    EXPECT_NE(String::empty(), String {});
+}
+
 TEST_CASE(compare)
 {
     EXPECT("a" < String("b"));

--- a/Userland/Libraries/LibGUI/Action.h
+++ b/Userland/Libraries/LibGUI/Action.h
@@ -118,6 +118,8 @@ public:
     const ActionGroup* group() const { return m_action_group.ptr(); }
     void set_group(Badge<ActionGroup>, ActionGroup*);
 
+    HashTable<MenuItem*> menu_items() const { return m_menu_items; }
+
 private:
     Action(String, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);
     Action(String, const Shortcut&, Function<void(Action&)> = nullptr, Core::Object* = nullptr, bool checkable = false);

--- a/Userland/Libraries/LibGUI/CommandPalette.cpp
+++ b/Userland/Libraries/LibGUI/CommandPalette.cpp
@@ -169,7 +169,7 @@ CommandPalette::CommandPalette(GUI::Window& parent_window, ScreenPosition screen
     : GUI::Dialog(&parent_window, screen_position)
 {
     set_frameless(true);
-    resize(400, 300);
+    resize(450, 300);
 
     collect_actions(parent_window);
 

--- a/Userland/Libraries/LibGUI/Menu.h
+++ b/Userland/Libraries/LibGUI/Menu.h
@@ -51,6 +51,8 @@ public:
 
     bool is_visible() const { return m_visible; }
 
+    NonnullOwnPtrVector<MenuItem> const& items() const { return m_items; }
+
 private:
     friend class Menubar;
 

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -219,6 +219,9 @@ public:
 
     void flush_pending_paints_immediately();
 
+    Menubar& menubar() { return *m_menubar; }
+    Menubar const& menubar() const { return *m_menubar; }
+
 protected:
     Window(Core::Object* parent = nullptr);
     virtual void wm_event(WMEvent&);


### PR DESCRIPTION
This pull request adds a new column showing the menu an action is located in,
collects more actions from window menus and adds a (currently regressed) test to
AK/String that asserts a condition required for CommandPalette to have a working
initial filter :^)

![image](https://user-images.githubusercontent.com/42888162/151703703-df5f3dcf-8499-4f76-9394-a7b0a3688e4c.png)
