### PR TITLE
AK+Tests: Make null strings compare less than non-null strings

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -206,8 +206,14 @@ public:
 
     [[nodiscard]] constexpr int compare(StringView other) const
     {
-        size_t rlen = min(length(), other.length());
-        int c = (rlen != 0) ? __builtin_memcmp(m_characters, other.m_characters, rlen) : 0;
+        if (m_characters == nullptr)
+            return other.m_characters ? -1 : 0;
+
+        if (other.m_characters == nullptr)
+            return 1;
+
+        size_t rlen = min(m_length, other.m_length);
+        int c = __builtin_memcmp(m_characters, other.m_characters, rlen);
         if (c == 0) {
             if (length() < other.length())
                 return -1;

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -42,10 +42,7 @@ TEST_CASE(construct_contents)
 
 TEST_CASE(equal)
 {
-    // FIXME: Enable this as soon as it's fixed.
-#if 0
     EXPECT_NE(String::empty(), String {});
-#endif
 }
 
 TEST_CASE(compare)


### PR DESCRIPTION
This behavior regressed in ca58c71faa6e31721b6094d380732d2aa6f3d791.

Fixes #12213