### PR TITLE
LibJS: Support BigInt number formatting with Intl.NumberFormat

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -899,7 +899,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObjec
             value = floor(value * pow(10, static_cast<int>(*fractional_second_digits) - 3));
 
             // iii. Let fv be FormatNumeric(nf3, v).
-            auto formatted_value = format_numeric(*number_format3, value);
+            auto formatted_value = format_numeric(global_object, *number_format3, Value(value));
 
             // iv. Append a new Record { [[Type]]: "fractionalSecond", [[Value]]: fv } as the last element of result.
             result.append({ "fractionalSecond"sv, move(formatted_value) });
@@ -983,13 +983,13 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObjec
             // viii. If f is "numeric", then
             case Unicode::CalendarPatternStyle::Numeric:
                 // 1. Let fv be FormatNumeric(nf, v).
-                formatted_value = format_numeric(*number_format, value);
+                formatted_value = format_numeric(global_object, *number_format, Value(value));
                 break;
 
             // ix. Else if f is "2-digit", then
             case Unicode::CalendarPatternStyle::TwoDigit:
                 // 1. Let fv be FormatNumeric(nf2, v).
-                formatted_value = format_numeric(*number_format2, value);
+                formatted_value = format_numeric(global_object, *number_format2, Value(value));
 
                 // 2. If the "length" property of fv is greater than 2, let fv be the substring of fv containing the last two characters.
                 // NOTE: The first length check here isn't enough, but lets us avoid UTF-16 transcoding when the formatted value is ASCII.

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -212,8 +212,8 @@ private:
 };
 
 struct FormatResult {
-    String formatted_string;       // [[FormattedString]]
-    double rounded_number { 0.0 }; // [[RoundedNumber]]
+    String formatted_string;      // [[FormattedString]]
+    Value rounded_number { 0.0 }; // [[RoundedNumber]]
 };
 
 struct RawFormatResult : public FormatResult {
@@ -223,17 +223,17 @@ struct RawFormatResult : public FormatResult {
 ThrowCompletionOr<void> set_number_format_digit_options(GlobalObject& global_object, NumberFormatBase& intl_object, Object const& options, int default_min_fraction_digits, int default_max_fraction_digits, NumberFormat::Notation notation);
 ThrowCompletionOr<NumberFormat*> initialize_number_format(GlobalObject& global_object, NumberFormat& number_format, Value locales_value, Value options_value);
 int currency_digits(StringView currency);
-FormatResult format_numeric_to_string(NumberFormatBase& intl_object, double number);
-Vector<PatternPartition> partition_number_pattern(NumberFormat& number_format, double number);
-Vector<PatternPartition> partition_notation_sub_pattern(NumberFormat& number_format, double number, String formatted_string, int exponent);
-String format_numeric(NumberFormat& number_format, double number);
-Array* format_numeric_to_parts(GlobalObject& global_object, NumberFormat& number_format, double number);
-RawFormatResult to_raw_precision(double number, int min_precision, int max_precision);
-RawFormatResult to_raw_fixed(double number, int min_fraction, int max_fraction);
+FormatResult format_numeric_to_string(GlobalObject& global_object, NumberFormatBase& intl_object, Value number);
+Vector<PatternPartition> partition_number_pattern(GlobalObject& global_object, NumberFormat& number_format, Value number);
+Vector<PatternPartition> partition_notation_sub_pattern(GlobalObject& global_object, NumberFormat& number_format, Value number, String formatted_string, int exponent);
+String format_numeric(GlobalObject& global_object, NumberFormat& number_format, Value number);
+Array* format_numeric_to_parts(GlobalObject& global_object, NumberFormat& number_format, Value number);
+RawFormatResult to_raw_precision(GlobalObject& global_object, Value number, int min_precision, int max_precision);
+RawFormatResult to_raw_fixed(GlobalObject& global_object, Value number, int min_fraction, int max_fraction);
 ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_object, NumberFormat& intl_object, Object const& options);
-Optional<Variant<StringView, String>> get_number_format_pattern(NumberFormat& number_format, double number, Unicode::NumberFormat& found_pattern);
+Optional<Variant<StringView, String>> get_number_format_pattern(NumberFormat& number_format, Value number, Unicode::NumberFormat& found_pattern);
 Optional<StringView> get_notation_sub_pattern(NumberFormat& number_format, int exponent);
-int compute_exponent(NumberFormat& number_format, double number);
+int compute_exponent(GlobalObject& global_object, NumberFormat& number_format, Value number);
 int compute_exponent_for_magnitude(NumberFormat& number_format, int magnitude);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
@@ -44,10 +44,6 @@ ThrowCompletionOr<Value> NumberFormatFunction::call()
     // 4. Let x be ? ToNumeric(value).
     value = TRY(value.to_numeric(global_object));
 
-    // FIXME: Support BigInt number formatting.
-    if (value.is_bigint())
-        return vm.throw_completion<InternalError>(global_object, ErrorType::NotImplemented, "BigInt number formatting");
-
     // 5. Return ? FormatNumeric(nf, x).
     // Note: Our implementation of FormatNumeric does not throw.
     auto formatted = format_numeric(global_object, m_number_format, value);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
@@ -50,8 +50,7 @@ ThrowCompletionOr<Value> NumberFormatFunction::call()
 
     // 5. Return ? FormatNumeric(nf, x).
     // Note: Our implementation of FormatNumeric does not throw.
-    auto formatted = format_numeric(m_number_format, value.as_double());
-
+    auto formatted = format_numeric(global_object, m_number_format, value);
     return js_string(vm, move(formatted));
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -70,10 +70,6 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_to_parts)
     // 3. Let x be ? ToNumeric(value).
     value = TRY(value.to_numeric(global_object));
 
-    // FIXME: Support BigInt number formatting.
-    if (value.is_bigint())
-        return vm.throw_completion<InternalError>(global_object, ErrorType::NotImplemented, "BigInt number formatting");
-
     // 4. Return ? FormatNumericToParts(nf, x).
     // Note: Our implementation of FormatNumericToParts does not throw.
     return format_numeric_to_parts(global_object, *number_format, value);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -76,7 +76,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_to_parts)
 
     // 4. Return ? FormatNumericToParts(nf, x).
     // Note: Our implementation of FormatNumericToParts does not throw.
-    return format_numeric_to_parts(global_object, *number_format, value.as_double());
+    return format_numeric_to_parts(global_object, *number_format, value);
 }
 
 // 15.4.5 Intl.NumberFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -249,7 +249,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
     auto patterns = find_patterns_for_tense_or_number(tense);
 
     // 20. Let fv be ! PartitionNumberPattern(relativeTimeFormat.[[NumberFormat]], value).
-    auto value_partitions = partition_number_pattern(relative_time_format.number_format(), value);
+    auto value_partitions = partition_number_pattern(global_object, relative_time_format.number_format(), Value(value));
 
     // 21. Let pr be ! ResolvePlural(relativeTimeFormat.[[PluralRules]], value).
     // 22. Let pattern be po.[[<pr>]].

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -295,8 +295,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberPrototype::to_locale_string)
 
     // 3. Return ? FormatNumeric(numberFormat, x).
     // Note: Our implementation of FormatNumeric does not throw.
-    auto formatted = Intl::format_numeric(*number_format, number_value.as_double());
-
+    auto formatted = Intl::format_numeric(global_object, *number_format, number_value);
     return js_string(vm, move(formatted));
 }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.prototype.toLocaleString.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.prototype.toLocaleString.js
@@ -8,3 +8,82 @@ test("calling with non-BigInt |this|", () => {
         BigInt.prototype.toLocaleString.call("foo");
     }).toThrowWithMessage(TypeError, "Not an object of type BigInt");
 });
+
+test("default", () => {
+    expect(1n.toLocaleString("en")).toBe("1");
+    expect(12n.toLocaleString("en")).toBe("12");
+    expect(123n.toLocaleString("en")).toBe("123");
+    expect(123456789123456789123456789123456789n.toLocaleString("en")).toBe(
+        "123,456,789,123,456,789,123,456,789,123,456,789"
+    );
+
+    const ar = new Intl.NumberFormat("ar");
+    expect(1n.toLocaleString("ar")).toBe("\u0661");
+    expect(12n.toLocaleString("ar")).toBe("\u0661\u0662");
+    expect(123n.toLocaleString("ar")).toBe("\u0661\u0662\u0663");
+    expect(123456789123456789123456789123456789n.toLocaleString("ar")).toBe(
+        "\u0661\u0662\u0663\u066c\u0664\u0665\u0666\u066c\u0667\u0668\u0669\u066c\u0661\u0662\u0663\u066c\u0664\u0665\u0666\u066c\u0667\u0668\u0669\u066c\u0661\u0662\u0663\u066c\u0664\u0665\u0666\u066c\u0667\u0668\u0669\u066c\u0661\u0662\u0663\u066c\u0664\u0665\u0666\u066c\u0667\u0668\u0669"
+    );
+});
+
+test("integer digits", () => {
+    expect(1n.toLocaleString("en", { minimumIntegerDigits: 2 })).toBe("01");
+    expect(12n.toLocaleString("en", { minimumIntegerDigits: 2 })).toBe("12");
+    expect(123n.toLocaleString("en", { minimumIntegerDigits: 2 })).toBe("123");
+
+    expect(1n.toLocaleString("ar", { minimumIntegerDigits: 2 })).toBe("\u0660\u0661");
+    expect(12n.toLocaleString("ar", { minimumIntegerDigits: 2 })).toBe("\u0661\u0662");
+    expect(123n.toLocaleString("ar", { minimumIntegerDigits: 2 })).toBe("\u0661\u0662\u0663");
+});
+
+test("significant digits", () => {
+    expect(
+        1n.toLocaleString("en", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("1.000");
+    expect(
+        12n.toLocaleString("en", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("12.00");
+    expect(
+        123n.toLocaleString("en", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("123.0");
+    expect(
+        1234n.toLocaleString("en", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("1,234");
+    expect(
+        12345n.toLocaleString("en", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("12,345");
+    expect(
+        123456n.toLocaleString("en", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("123,456");
+    expect(
+        1234567n.toLocaleString("en", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("1,234,570");
+    expect(
+        1234561n.toLocaleString("en", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("1,234,560");
+
+    expect(
+        1n.toLocaleString("ar", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("\u0661\u066b\u0660\u0660\u0660");
+    expect(
+        12n.toLocaleString("ar", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("\u0661\u0662\u066b\u0660\u0660");
+    expect(
+        123n.toLocaleString("ar", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("\u0661\u0662\u0663\u066b\u0660");
+    expect(
+        1234n.toLocaleString("ar", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("\u0661\u066c\u0662\u0663\u0664");
+    expect(
+        12345n.toLocaleString("ar", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("\u0661\u0662\u066c\u0663\u0664\u0665");
+    expect(
+        123456n.toLocaleString("ar", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("\u0661\u0662\u0663\u066c\u0664\u0665\u0666");
+    expect(
+        1234567n.toLocaleString("ar", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("\u0661\u066c\u0662\u0663\u0664\u066c\u0665\u0667\u0660");
+    expect(
+        1234561n.toLocaleString("ar", { minimumSignificantDigits: 4, maximumSignificantDigits: 6 })
+    ).toBe("\u0661\u066c\u0662\u0663\u0664\u066c\u0665\u0666\u0660");
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.format.js
@@ -14,16 +14,6 @@ describe("errors", () => {
             Intl.NumberFormat().format(Symbol.hasInstance);
         }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
     });
-
-    // FIXME: Remove this and add BigInt tests when BigInt number formatting is supported.
-    test("bigint", () => {
-        expect(() => {
-            Intl.NumberFormat().format(1n);
-        }).toThrowWithMessage(
-            InternalError,
-            "BigInt number formatting is not implemented in LibJS"
-        );
-    });
 });
 
 describe("special values", () => {
@@ -1017,5 +1007,65 @@ describe("style=unit", () => {
         expect(ja.format(1)).toBe("1km/h");
         expect(ja.format(1.2)).toBe("1.2km/h");
         expect(ja.format(123)).toBe("123km/h");
+    });
+});
+
+describe("bigint", () => {
+    test("default", () => {
+        const en = new Intl.NumberFormat("en");
+        expect(en.format(1n)).toBe("1");
+        expect(en.format(12n)).toBe("12");
+        expect(en.format(123n)).toBe("123");
+        expect(en.format(123456789123456789123456789123456789n)).toBe(
+            "123,456,789,123,456,789,123,456,789,123,456,789"
+        );
+
+        const ar = new Intl.NumberFormat("ar");
+        expect(ar.format(1n)).toBe("\u0661");
+        expect(ar.format(12n)).toBe("\u0661\u0662");
+        expect(ar.format(123n)).toBe("\u0661\u0662\u0663");
+        expect(ar.format(123456789123456789123456789123456789n)).toBe(
+            "\u0661\u0662\u0663\u066c\u0664\u0665\u0666\u066c\u0667\u0668\u0669\u066c\u0661\u0662\u0663\u066c\u0664\u0665\u0666\u066c\u0667\u0668\u0669\u066c\u0661\u0662\u0663\u066c\u0664\u0665\u0666\u066c\u0667\u0668\u0669\u066c\u0661\u0662\u0663\u066c\u0664\u0665\u0666\u066c\u0667\u0668\u0669"
+        );
+    });
+
+    test("integer digits", () => {
+        const en = new Intl.NumberFormat("en", { minimumIntegerDigits: 2 });
+        expect(en.format(1n)).toBe("01");
+        expect(en.format(12n)).toBe("12");
+        expect(en.format(123n)).toBe("123");
+
+        const ar = new Intl.NumberFormat("ar", { minimumIntegerDigits: 2 });
+        expect(ar.format(1n)).toBe("\u0660\u0661");
+        expect(ar.format(12n)).toBe("\u0661\u0662");
+        expect(ar.format(123n)).toBe("\u0661\u0662\u0663");
+    });
+
+    test("significant digits", () => {
+        const en = new Intl.NumberFormat("en", {
+            minimumSignificantDigits: 4,
+            maximumSignificantDigits: 6,
+        });
+        expect(en.format(1n)).toBe("1.000");
+        expect(en.format(12n)).toBe("12.00");
+        expect(en.format(123n)).toBe("123.0");
+        expect(en.format(1234n)).toBe("1,234");
+        expect(en.format(12345n)).toBe("12,345");
+        expect(en.format(123456n)).toBe("123,456");
+        expect(en.format(1234567n)).toBe("1,234,570");
+        expect(en.format(1234561n)).toBe("1,234,560");
+
+        const ar = new Intl.NumberFormat("ar", {
+            minimumSignificantDigits: 4,
+            maximumSignificantDigits: 6,
+        });
+        expect(ar.format(1n)).toBe("\u0661\u066b\u0660\u0660\u0660");
+        expect(ar.format(12n)).toBe("\u0661\u0662\u066b\u0660\u0660");
+        expect(ar.format(123n)).toBe("\u0661\u0662\u0663\u066b\u0660");
+        expect(ar.format(1234n)).toBe("\u0661\u066c\u0662\u0663\u0664");
+        expect(ar.format(12345n)).toBe("\u0661\u0662\u066c\u0663\u0664\u0665");
+        expect(ar.format(123456n)).toBe("\u0661\u0662\u0663\u066c\u0664\u0665\u0666");
+        expect(ar.format(1234567n)).toBe("\u0661\u066c\u0662\u0663\u0664\u066c\u0665\u0667\u0660");
+        expect(ar.format(1234561n)).toBe("\u0661\u066c\u0662\u0663\u0664\u066c\u0665\u0666\u0660");
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/NumberFormat/NumberFormat.prototype.formatToParts.js
@@ -10,16 +10,6 @@ describe("errors", () => {
             Intl.NumberFormat().formatToParts(Symbol.hasInstance);
         }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
     });
-
-    // FIXME: Remove this and add BigInt tests when BigInt number formatting is supported.
-    test("bigint", () => {
-        expect(() => {
-            Intl.NumberFormat().formatToParts(1n);
-        }).toThrowWithMessage(
-            InternalError,
-            "BigInt number formatting is not implemented in LibJS"
-        );
-    });
 });
 
 describe("special values", () => {
@@ -1307,6 +1297,74 @@ describe("style=unit", () => {
             { type: "decimal", value: "." },
             { type: "fraction", value: "2" },
             { type: "unit", value: "km/h" },
+        ]);
+    });
+});
+
+describe("bigint", () => {
+    test("default", () => {
+        const en = new Intl.NumberFormat("en");
+        expect(en.formatToParts(123456n)).toEqual([
+            { type: "integer", value: "123" },
+            { type: "group", value: "," },
+            { type: "integer", value: "456" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar");
+        expect(ar.formatToParts(123456n)).toEqual([
+            { type: "integer", value: "\u0661\u0662\u0663" },
+            { type: "group", value: "\u066c" },
+            { type: "integer", value: "\u0664\u0665\u0666" },
+        ]);
+    });
+
+    test("useGrouping=false", () => {
+        const en = new Intl.NumberFormat("en", { useGrouping: false });
+        expect(en.formatToParts(123456n)).toEqual([{ type: "integer", value: "123456" }]);
+
+        const ar = new Intl.NumberFormat("ar", { useGrouping: false });
+        expect(ar.formatToParts(123456n)).toEqual([
+            { type: "integer", value: "\u0661\u0662\u0663\u0664\u0665\u0666" },
+        ]);
+    });
+
+    test("significant digits", () => {
+        const en = new Intl.NumberFormat("en", {
+            minimumSignificantDigits: 4,
+            maximumSignificantDigits: 6,
+        });
+        expect(en.formatToParts(1234567n)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "group", value: "," },
+            { type: "integer", value: "234" },
+            { type: "group", value: "," },
+            { type: "integer", value: "570" },
+        ]);
+        expect(en.formatToParts(1234561n)).toEqual([
+            { type: "integer", value: "1" },
+            { type: "group", value: "," },
+            { type: "integer", value: "234" },
+            { type: "group", value: "," },
+            { type: "integer", value: "560" },
+        ]);
+
+        const ar = new Intl.NumberFormat("ar", {
+            minimumSignificantDigits: 4,
+            maximumSignificantDigits: 6,
+        });
+        expect(ar.formatToParts(1234567n)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "group", value: "\u066c" },
+            { type: "integer", value: "\u0662\u0663\u0664" },
+            { type: "group", value: "\u066c" },
+            { type: "integer", value: "\u0665\u0667\u0660" },
+        ]);
+        expect(ar.formatToParts(1234561n)).toEqual([
+            { type: "integer", value: "\u0661" },
+            { type: "group", value: "\u066c" },
+            { type: "integer", value: "\u0662\u0663\u0664" },
+            { type: "group", value: "\u066c" },
+            { type: "integer", value: "\u0665\u0666\u0660" },
         ]);
     });
 });


### PR DESCRIPTION
This has been a todo for a while now:
```
test/intl402/BigInt    11/11    (100.00%) [ ✅ 11 ] 
```