### PR TITLE
LibJS+LibUnicode+LibTimeZone: Implement Intl.supportedValuesOf

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -619,22 +619,11 @@ Optional<Array<NamedOffset, 2>> get_named_time_zone_offsets(TimeZone time_zone, 
 
     return named_offsets;
 }
+)~~~");
 
-Span<StringView const> all_time_zones()
-{
-    static constexpr auto all_time_zones = Array {
-        )~~~");
-
-    for (auto const& time_zone : time_zone_data.time_zone_names) {
-        generator.set("time_zone", time_zone);
-        generator.append("\"@time_zone@\"sv, ");
-    }
+    generate_available_values(generator, "all_time_zones"sv, time_zone_data.time_zone_names);
 
     generator.append(R"~~~(
-    };
-
-    return all_time_zones;
-}
 
 }
 )~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeDateTimeFormat.cpp
@@ -1863,6 +1863,8 @@ struct DayPeriodData {
 };
 )~~~");
 
+    generate_available_values(generator, "get_available_calendars"sv, locale_data.calendars, locale_data.calendar_aliases);
+
     locale_data.unique_formats.generate(generator, "CalendarFormatImpl"sv, "s_calendar_formats"sv, 10);
     locale_data.unique_symbol_lists.generate(generator, s_string_index_type, "s_symbol_lists"sv);
     locale_data.unique_calendar_symbols.generate(generator, "CalendarSymbols"sv, "s_calendar_symbols"sv, 10);

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeLocale.cpp
@@ -986,6 +986,7 @@ static void generate_unicode_locale_implementation(Core::File& file, UnicodeLoca
 #include <AK/Span.h>
 #include <AK/StringView.h>
 #include <AK/Vector.h>
+#include <LibUnicode/CurrencyCode.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/UnicodeLocale.h>
 
@@ -1018,6 +1019,8 @@ struct Patterns {
     @string_index_type@ pair { 0 };
 };
 )~~~");
+
+    generate_available_values(generator, "get_available_currencies"sv, locale_data.currencies);
 
     locale_data.unique_display_patterns.generate(generator, "DisplayPatternImpl"sv, "s_display_patterns"sv, 30);
     locale_data.unique_language_lists.generate(generator, s_string_index_type, "s_language_lists"sv);

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
@@ -869,6 +869,8 @@ struct Unit {
 };
 )~~~");
 
+    generate_available_values(generator, "get_available_number_systems"sv, locale_data.number_systems);
+
     locale_data.unique_formats.generate(generator, "NumberFormatImpl"sv, "s_number_formats"sv, 10);
     locale_data.unique_format_lists.generate(generator, s_number_format_index_type, "s_number_format_lists"sv);
     locale_data.unique_symbols.generate(generator, s_string_index_type, "s_numeric_symbol_lists"sv);

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -488,3 +488,31 @@ static constexpr Array<Span<@type@ const>, @size@> @name@ { {
 } };
 )~~~");
 }
+
+template<typename T>
+void generate_available_values(SourceGenerator& generator, StringView name, Vector<T> const& values, Vector<Alias> const& aliases = {})
+{
+    generator.set("name", name);
+    generator.set("size", String::number(values.size()));
+
+    generator.append(R"~~~(
+Span<StringView const> @name@()
+{
+    static constexpr Array<StringView, @size@> values { {)~~~");
+
+    bool first = true;
+    for (auto const& value : values) {
+        generator.append(first ? " " : ", ");
+        first = false;
+
+        if (auto it = aliases.find_if([&](auto const& alias) { return alias.name == value; }); it != aliases.end())
+            generator.append(String::formatted("\"{}\"sv", it->alias));
+        else
+            generator.append(String::formatted("\"{}\"sv", value));
+    }
+
+    generator.append(R"~~~( } };
+    return values.span();
+}
+)~~~");
+}

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -8,6 +8,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/Function.h>
+#include <AK/Span.h>
 #include <AK/Vector.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/GlobalObject.h>
@@ -23,12 +24,12 @@ public:
     static Array* create_from(GlobalObject&, Vector<Value> const&);
     // Non-standard but equivalent to CreateArrayFromList.
     template<typename T>
-    static Array* create_from(GlobalObject& global_object, Vector<T>& elements, Function<Value(T&)> map_fn)
+    static Array* create_from(GlobalObject& global_object, Span<T const> elements, Function<Value(T const&)> map_fn)
     {
         auto& vm = global_object.vm();
         auto values = MarkedValueList { global_object.heap() };
         values.ensure_capacity(elements.size());
-        for (auto& element : elements) {
+        for (auto const& element : elements) {
             values.append(map_fn(element));
             VERIFY(!vm.exception());
         }

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -449,6 +449,7 @@ namespace JS {
     P(subtract)                              \
     P(sup)                                   \
     P(supportedLocalesOf)                    \
+    P(supportedValuesOf)                     \
     P(tan)                                   \
     P(tanh)                                  \
     P(test)                                  \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -37,6 +37,7 @@
     M(InOperatorWithObject, "'in' operator must be used on an object")                                                                  \
     M(InstanceOfOperatorBadPrototype, "'prototype' property of {} is not an object")                                                    \
     M(IntlInvalidDateTimeFormatOption, "Option {} cannot be set when also providing {}")                                                \
+    M(IntlInvalidKey, "{} is not a valid key")                                                                                          \
     M(IntlInvalidLanguageTag, "{} is not a structurally valid language tag")                                                            \
     M(IntlInvalidTime, "Time value must be between -8.64E15 and 8.64E15")                                                               \
     M(IntlInvalidUnit, "Unit {} is not a valid time unit")                                                                              \

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/AllOf.h>
 #include <AK/AnyOf.h>
-#include <AK/Array.h>
 #include <AK/CharacterTypes.h>
 #include <AK/Find.h>
 #include <AK/Function.h>
@@ -145,7 +144,7 @@ bool is_well_formed_unit_identifier(StringView unit_identifier)
     constexpr auto is_sanctioned_simple_unit_identifier = [](StringView unit_identifier) {
         // 1. If unitIdentifier is listed in Table 2 below, return true.
         // 2. Else, return false.
-        static constexpr auto sanctioned_units = AK::Array { "acre"sv, "bit"sv, "byte"sv, "celsius"sv, "centimeter"sv, "day"sv, "degree"sv, "fahrenheit"sv, "fluid-ounce"sv, "foot"sv, "gallon"sv, "gigabit"sv, "gigabyte"sv, "gram"sv, "hectare"sv, "hour"sv, "inch"sv, "kilobit"sv, "kilobyte"sv, "kilogram"sv, "kilometer"sv, "liter"sv, "megabit"sv, "megabyte"sv, "meter"sv, "mile"sv, "mile-scandinavian"sv, "milliliter"sv, "millimeter"sv, "millisecond"sv, "minute"sv, "month"sv, "ounce"sv, "percent"sv, "petabyte"sv, "pound"sv, "second"sv, "stone"sv, "terabit"sv, "terabyte"sv, "week"sv, "yard"sv, "year"sv };
+        static constexpr auto sanctioned_units = sanctioned_simple_unit_identifiers();
         return find(sanctioned_units.begin(), sanctioned_units.end(), unit_identifier) != sanctioned_units.end();
     };
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Span.h>
 #include <AK/String.h>
 #include <AK/Variant.h>
@@ -52,6 +53,11 @@ struct PatternPartition {
     StringView type;
     String value;
 };
+
+constexpr auto sanctioned_simple_unit_identifiers()
+{
+    return AK::Array { "acre"sv, "bit"sv, "byte"sv, "celsius"sv, "centimeter"sv, "day"sv, "degree"sv, "fahrenheit"sv, "fluid-ounce"sv, "foot"sv, "gallon"sv, "gigabit"sv, "gigabyte"sv, "gram"sv, "hectare"sv, "hour"sv, "inch"sv, "kilobit"sv, "kilobyte"sv, "kilogram"sv, "kilometer"sv, "liter"sv, "megabit"sv, "megabyte"sv, "meter"sv, "mile"sv, "mile-scandinavian"sv, "milliliter"sv, "millimeter"sv, "millisecond"sv, "minute"sv, "month"sv, "ounce"sv, "percent"sv, "petabyte"sv, "pound"sv, "second"sv, "stone"sv, "terabit"sv, "terabyte"sv, "week"sv, "yard"sv, "year"sv };
+}
 
 Optional<Unicode::LocaleID> is_structurally_valid_language_tag(StringView locale);
 String canonicalize_unicode_locale_id(Unicode::LocaleID& locale);

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.h
@@ -20,6 +20,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(get_canonical_locales);
+    JS_DECLARE_NATIVE_FUNCTION(supported_values_of);
 };
 
 }

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.supportedValuesOf.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Intl.supportedValuesOf.js
@@ -1,0 +1,63 @@
+describe("errors", () => {
+    test("invalid key", () => {
+        expect(() => {
+            Intl.supportedValuesOf("hello!");
+        }).toThrowWithMessage(RangeError, "hello! is not a valid key");
+    });
+});
+
+describe("normal behavior", () => {
+    const isSorted = array => {
+        return array.slice(1).every((item, i) => array[i] <= item);
+    };
+
+    test("length is 1", () => {
+        expect(Intl.supportedValuesOf).toHaveLength(1);
+    });
+
+    test("calendar", () => {
+        const values = Intl.supportedValuesOf("calendar");
+        expect(isSorted(values)).toBeTrue();
+
+        expect(values.indexOf("gregory")).not.toBe(-1);
+    });
+
+    test("collation", () => {
+        const values = Intl.supportedValuesOf("collation");
+        expect(isSorted(values)).toBeTrue();
+
+        expect(values.indexOf("default")).not.toBe(-1);
+    });
+
+    test("currency", () => {
+        const values = Intl.supportedValuesOf("currency");
+        expect(isSorted(values)).toBeTrue();
+
+        expect(values.indexOf("USD")).not.toBe(-1);
+        expect(values.indexOf("XXX")).not.toBe(-1);
+    });
+
+    test("numberingSystem", () => {
+        const values = Intl.supportedValuesOf("numberingSystem");
+        expect(isSorted(values)).toBeTrue();
+
+        expect(values.indexOf("latn")).not.toBe(-1);
+        expect(values.indexOf("arab")).not.toBe(-1);
+    });
+
+    test("timeZone", () => {
+        const values = Intl.supportedValuesOf("timeZone");
+        expect(isSorted(values)).toBeTrue();
+
+        expect(values.indexOf("UTC")).not.toBe(-1);
+        expect(values.indexOf("America/New_York")).not.toBe(-1);
+    });
+
+    test("unit", () => {
+        const values = Intl.supportedValuesOf("unit");
+        expect(isSorted(values)).toBeTrue();
+
+        expect(values.indexOf("acre")).not.toBe(-1);
+        expect(values.indexOf("fluid-ounce")).not.toBe(-1);
+    });
+});

--- a/Userland/Libraries/LibUnicode/CurrencyCode.cpp
+++ b/Userland/Libraries/LibUnicode/CurrencyCode.cpp
@@ -203,4 +203,6 @@ Optional<CurrencyCode> get_currency_code(StringView currency)
     return currency_codes.get(currency);
 }
 
+Span<StringView const> __attribute__((weak)) get_available_currencies() { return {}; }
+
 }

--- a/Userland/Libraries/LibUnicode/CurrencyCode.h
+++ b/Userland/Libraries/LibUnicode/CurrencyCode.h
@@ -8,6 +8,7 @@
 
 #include <AK/HashMap.h>
 #include <AK/Optional.h>
+#include <AK/Span.h>
 #include <AK/StringView.h>
 
 namespace Unicode {
@@ -17,5 +18,6 @@ struct CurrencyCode {
 };
 
 Optional<CurrencyCode> get_currency_code(StringView currency);
+Span<StringView const> get_available_currencies();
 
 }

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.cpp
@@ -93,6 +93,7 @@ StringView calendar_pattern_style_to_string(CalendarPatternStyle style)
 
 Optional<Calendar> __attribute__((weak)) calendar_from_string(StringView) { return {}; }
 Optional<HourCycleRegion> __attribute__((weak)) hour_cycle_region_from_string(StringView) { return {}; }
+Span<StringView const> __attribute__((weak)) get_available_calendars() { return {}; }
 Vector<HourCycle> __attribute__((weak)) get_regional_hour_cycles(StringView) { return {}; }
 
 // https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table

--- a/Userland/Libraries/LibUnicode/DateTimeFormat.h
+++ b/Userland/Libraries/LibUnicode/DateTimeFormat.h
@@ -189,6 +189,8 @@ StringView calendar_pattern_style_to_string(CalendarPatternStyle style);
 Optional<Calendar> calendar_from_string(StringView calendar);
 Optional<HourCycleRegion> hour_cycle_region_from_string(StringView hour_cycle_region);
 
+Span<StringView const> get_available_calendars();
+
 Vector<HourCycle> get_regional_hour_cycles(StringView region);
 Vector<Unicode::HourCycle> get_locale_hour_cycles(StringView locale);
 Optional<Unicode::HourCycle> get_default_regional_hour_cycle(StringView locale);

--- a/Userland/Libraries/LibUnicode/NumberFormat.cpp
+++ b/Userland/Libraries/LibUnicode/NumberFormat.cpp
@@ -16,6 +16,7 @@
 
 namespace Unicode {
 
+Span<StringView const> __attribute__((weak)) get_available_number_systems() { return {}; }
 Optional<NumberSystem> __attribute__((weak)) number_system_from_string(StringView) { return {}; }
 Optional<StringView> __attribute__((weak)) get_number_system_symbol(StringView, StringView, NumericSymbol) { return {}; }
 Optional<NumberGroupings> __attribute__((weak)) get_number_system_groupings(StringView, StringView) { return {}; }

--- a/Userland/Libraries/LibUnicode/NumberFormat.h
+++ b/Userland/Libraries/LibUnicode/NumberFormat.h
@@ -66,6 +66,8 @@ enum class NumericSymbol : u8 {
     PlusSign,
 };
 
+Span<StringView const> get_available_number_systems();
+
 Optional<NumberSystem> number_system_from_string(StringView system);
 Optional<StringView> get_default_number_system(StringView locale);
 


### PR DESCRIPTION
```
test/intl402/Intl/supportedValuesOf     19/23    ( 82.61%) [ ✅ 19    ❌ 4 ]
```

The tests we fail are because:
1. We don't support all calendars yet
2. It seems test262 expects that every locale can use every numbering system, not just the ones listed for that locale in the CLDR. I've run into NumberFormat failures due to this, so that might be worth tackling next.