### PR TITLE
LibGUI: Remove `Window` background color

### DIFF
--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -283,7 +283,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Terminal");
-    window->set_background_color(Color::Black);
     window->set_double_buffering_enabled(false);
 
     auto terminal = TRY(window->try_set_main_widget<VT::TerminalWidget>(ptm_fd, true));

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -137,7 +137,6 @@ public:
         auto window = Window::construct();
         window->set_main_widget(this);
         window->set_has_alpha_channel(true);
-        window->set_background_color(Color::Transparent);
         window->set_fullscreen(true);
         window->set_frameless(true);
         window->show();

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -15,7 +15,6 @@
 #include <LibGUI/FocusSource.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/WindowType.h>
-#include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/StandardCursor.h>
@@ -75,9 +74,6 @@ public:
 
     String title() const;
     void set_title(String);
-
-    Color background_color() const { return m_background_color; }
-    void set_background_color(Color color) { m_background_color = color; }
 
     enum class CloseRequestDecision {
         StayOpen,
@@ -283,7 +279,6 @@ private:
     Vector<Gfx::IntRect, 32> m_pending_paint_event_rects;
     Gfx::IntSize m_size_increment;
     Gfx::IntSize m_base_size;
-    Color m_background_color { Color::WarmGray };
     WindowType m_window_type { WindowType::Normal };
     AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_cursor { Gfx::StandardCursor::None };
     AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_effective_cursor { Gfx::StandardCursor::None };


### PR DESCRIPTION
The `m_background_color` field was not used anywhere. Both `Terminal` and the `ColorPicker` widget invoked `set_background_color()` to no avail.