### PR TITLE
Ports/fontconfig: Add freetype dependency

### DIFF
--- a/Ports/fontconfig/package.sh
+++ b/Ports/fontconfig/package.sh
@@ -3,7 +3,7 @@ port=fontconfig
 version=2.13.94
 useconfigure="true"
 use_fresh_config_sub="true"
-depends=("libxml2")
+depends=("libxml2" "freetype")
 files="https://www.freedesktop.org/software/fontconfig/release/fontconfig-${version}.tar.xz fontconfig-${version}.tar.xz a5f052cb73fd479ffb7b697980510903b563bbb55b8f7a2b001fcfb94026003c"
 auth_type="sha256"
 configopts=("--prefix=/usr/local" "--enable-libxml2" "LDFLAGS=-ldl -lxml2")


### PR DESCRIPTION
When I did a fresh build of ports, I got this while building fontconfig:

checking for FREETYPE... no
configure: error: Package requirements (freetype2 >= 21.0.15) were not met:

No package 'freetype2' found

Consider adjusting the PKG_CONFIG_PATH environment variable if you
installed software in a non-standard prefix.

Alternatively, you may set the environment variables FREETYPE_CFLAGS
and FREETYPE_LIBS to avoid the need to call pkg-config.
See the pkg-config man page for more details.