### PR TITLE
AK+LibJS: Implement BigInt string processing according to the spec

### DIFF
--- a/AK/CharacterTypes.h
+++ b/AK/CharacterTypes.h
@@ -44,6 +44,16 @@ constexpr bool is_ascii_alphanumeric(u32 code_point)
     return is_ascii_alpha(code_point) || is_ascii_digit(code_point);
 }
 
+constexpr bool is_ascii_binary_digit(u32 code_point)
+{
+    return code_point == '0' || code_point == '1';
+}
+
+constexpr bool is_ascii_octal_digit(u32 code_point)
+{
+    return code_point >= '0' && code_point <= '7';
+}
+
 constexpr bool is_ascii_hex_digit(u32 code_point)
 {
     return is_ascii_digit(code_point) || (code_point >= 'A' && code_point <= 'F') || (code_point >= 'a' && code_point <= 'f');
@@ -164,6 +174,7 @@ constexpr u32 to_ascii_base36_digit(u32 digit)
 using AK::is_ascii;
 using AK::is_ascii_alpha;
 using AK::is_ascii_alphanumeric;
+using AK::is_ascii_binary_digit;
 using AK::is_ascii_blank;
 using AK::is_ascii_c0_control;
 using AK::is_ascii_control;
@@ -171,6 +182,7 @@ using AK::is_ascii_digit;
 using AK::is_ascii_graphical;
 using AK::is_ascii_hex_digit;
 using AK::is_ascii_lower_alpha;
+using AK::is_ascii_octal_digit;
 using AK::is_ascii_printable;
 using AK::is_ascii_punctuation;
 using AK::is_ascii_space;

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -67,7 +67,7 @@ size_t UnsignedBigInteger::export_data(Bytes data, bool remove_leading_zeros) co
     return out;
 }
 
-UnsignedBigInteger UnsignedBigInteger::from_base(u16 N, const String& str)
+UnsignedBigInteger UnsignedBigInteger::from_base(u16 N, StringView str)
 {
     VERIFY(N <= 36);
     UnsignedBigInteger result;

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -53,7 +53,7 @@ public:
 
     size_t export_data(Bytes, bool remove_leading_zeros = false) const;
 
-    static UnsignedBigInteger from_base(u16 N, const String& str);
+    static UnsignedBigInteger from_base(u16 N, StringView str);
     String to_base(u16 N) const;
 
     u64 to_u64() const;

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -333,6 +333,7 @@ public:
     ThrowCompletionOr<FunctionObject*> get_method(GlobalObject&, PropertyKey const&) const;
 
     String to_string_without_side_effects() const;
+    Optional<BigInt*> string_to_bigint(GlobalObject& global_object) const;
 
     Value value_or(Value fallback) const
     {

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.js
@@ -29,6 +29,40 @@ describe("correct behavior", () => {
     test("constructor with objects", () => {
         expect(BigInt([])).toBe(0n);
     });
+
+    test("base-2 strings", () => {
+        expect(BigInt("0b0")).toBe(0n);
+        expect(BigInt("0B0")).toBe(0n);
+        expect(BigInt("0b1")).toBe(1n);
+        expect(BigInt("0B1")).toBe(1n);
+        expect(BigInt("0b10")).toBe(2n);
+        expect(BigInt("0B10")).toBe(2n);
+        expect(BigInt(`0b${"1".repeat(100)}`)).toBe(1267650600228229401496703205375n);
+    });
+
+    test("base-8 strings", () => {
+        expect(BigInt("0o0")).toBe(0n);
+        expect(BigInt("0O0")).toBe(0n);
+        expect(BigInt("0o1")).toBe(1n);
+        expect(BigInt("0O1")).toBe(1n);
+        expect(BigInt("0o7")).toBe(7n);
+        expect(BigInt("0O7")).toBe(7n);
+        expect(BigInt("0o10")).toBe(8n);
+        expect(BigInt("0O10")).toBe(8n);
+        expect(BigInt(`0o1${"7".repeat(33)}`)).toBe(1267650600228229401496703205375n);
+    });
+
+    test("base-16 strings", () => {
+        expect(BigInt("0x0")).toBe(0n);
+        expect(BigInt("0X0")).toBe(0n);
+        expect(BigInt("0x1")).toBe(1n);
+        expect(BigInt("0X1")).toBe(1n);
+        expect(BigInt("0xf")).toBe(15n);
+        expect(BigInt("0Xf")).toBe(15n);
+        expect(BigInt("0x10")).toBe(16n);
+        expect(BigInt("0X10")).toBe(16n);
+        expect(BigInt(`0x${"f".repeat(25)}`)).toBe(1267650600228229401496703205375n);
+    });
 });
 
 describe("errors", () => {
@@ -63,6 +97,32 @@ describe("errors", () => {
             expect(() => {
                 BigInt(value);
             }).toThrowWithMessage(RangeError, "Cannot convert non-integral number to BigInt");
+        });
+    });
+
+    test("invalid string for base", () => {
+        ["0b", "0b2", "0B02", "-0b1", "-0B1"].forEach(value => {
+            expect(() => {
+                BigInt(value);
+            }).toThrowWithMessage(SyntaxError, `Invalid value for BigInt: ${value}`);
+        });
+
+        ["0o", "0o8", "0O08", "-0o1", "-0O1"].forEach(value => {
+            expect(() => {
+                BigInt(value);
+            }).toThrowWithMessage(SyntaxError, `Invalid value for BigInt: ${value}`);
+        });
+
+        ["0x", "0xg", "0X0g", "-0x1", "-0X1"].forEach(value => {
+            expect(() => {
+                BigInt(value);
+            }).toThrowWithMessage(SyntaxError, `Invalid value for BigInt: ${value}`);
+        });
+
+        ["a", "-1a"].forEach(value => {
+            expect(() => {
+                BigInt(value);
+            }).toThrowWithMessage(SyntaxError, `Invalid value for BigInt: ${value}`);
         });
     });
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
@@ -99,6 +99,16 @@ describe("correct behavior", () => {
         expect(Object(2n) == 1n).toBeFalse();
         expect(1n != Object(2n)).toBeTrue();
         expect(Object(2n) != 1n).toBeTrue();
+
+        expect(2n == "2").toBeTrue();
+        expect(2n == "0b10").toBeTrue();
+        expect(2n == "0o2").toBeTrue();
+        expect(2n == "0x2").toBeTrue();
+
+        expect(1n == "2").toBeFalse();
+        expect(1n == "0b10").toBeFalse();
+        expect(1n == "0o2").toBeFalse();
+        expect(1n == "0x2").toBeFalse();
     });
 
     test("strong equality operators", () => {

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/bigint-basic.js
@@ -129,6 +129,70 @@ describe("correct behavior", () => {
         expect(a === a).toBeTrue();
         expect(a === b).toBeFalse();
     });
+
+    test("less-than operators", () => {
+        expect(1n < 1n).toBeFalse();
+        expect(1n < 1).toBeFalse();
+        expect(1 < 1n).toBeFalse();
+        expect(1n < 2n).toBeTrue();
+        expect(1n < 2).toBeTrue();
+        expect(1 < 2n).toBeTrue();
+        expect(1n < 1.23).toBeTrue();
+        expect(1.23 < 1n).toBeFalse();
+
+        expect(1n <= 1n).toBeTrue();
+        expect(1n <= 1).toBeTrue();
+        expect(1 <= 1n).toBeTrue();
+        expect(1n <= 2n).toBeTrue();
+        expect(1n <= 2).toBeTrue();
+        expect(1 <= 2n).toBeTrue();
+        expect(1n <= 1.23).toBeTrue();
+        expect(1.23 <= 1n).toBeFalse();
+
+        expect(1n < "1").toBeFalse();
+        expect(1n < "2").toBeTrue();
+        expect(1n < "1.23").toBeFalse();
+
+        expect(1n <= "1").toBeTrue();
+        expect(1n <= "2").toBeTrue();
+        expect(1n <= "1.23").toBeFalse();
+
+        expect(1n < "0b1").toBeFalse();
+        expect(1n < "0B10").toBeTrue();
+        expect(1n < "0o1").toBeFalse();
+        expect(1n < "0O2").toBeTrue();
+        expect(1n < "0x1").toBeFalse();
+        expect(1n < "0X2").toBeTrue();
+
+        expect(1n <= "0b1").toBeTrue();
+        expect(1n <= "0B10").toBeTrue();
+        expect(1n <= "0o1").toBeTrue();
+        expect(1n <= "0O2").toBeTrue();
+        expect(1n <= "0x1").toBeTrue();
+        expect(1n <= "0X2").toBeTrue();
+
+        expect("1" < 1n).toBeFalse();
+        expect("1" < 2n).toBeTrue();
+        expect("1.23" < 1n).toBeFalse();
+
+        expect("1" <= 1n).toBeTrue();
+        expect("1" <= 2n).toBeTrue();
+        expect("1.23" <= 1n).toBeFalse();
+
+        expect("0b1" < 1n).toBeFalse();
+        expect("0B1" < 2n).toBeTrue();
+        expect("0o1" < 1n).toBeFalse();
+        expect("0O1" < 2n).toBeTrue();
+        expect("0x1" < 1n).toBeFalse();
+        expect("0X1" < 2n).toBeTrue();
+
+        expect("0b1" <= 1n).toBeTrue();
+        expect("0B10" <= 2n).toBeTrue();
+        expect("0o1" <= 1n).toBeTrue();
+        expect("0O2" <= 2n).toBeTrue();
+        expect("0x1" <= 1n).toBeTrue();
+        expect("0X2" <= 2n).toBeTrue();
+    });
 });
 
 describe("errors", () => {


### PR DESCRIPTION
We were only parsing base-10 strings, but the spec allows for base-2, -8, and -16 as well.