### PR TITLE
Base: Add missing FileTypes for PixelPaint

### DIFF
--- a/Base/res/apps/PixelPaint.af
+++ b/Base/res/apps/PixelPaint.af
@@ -4,4 +4,4 @@ Executable=/bin/PixelPaint
 Category=Graphics
 
 [Launcher]
-FileTypes=pp
+FileTypes=pp,bmp,pbm,pgm,png,ppm,gif,jpg,jpeg,dds,qoi


### PR DESCRIPTION
As mentioned in today's monthly update video, the Open With menu doesn't show Pixel Paint for most image file types.
This commit brings it in sync with Image Viewer, since everything seems to open correctly anyway :)

![image](https://user-images.githubusercontent.com/21368066/151909400-0ab39bb3-b3b8-4074-b988-7244fb38f678.png)
