### PR TITLE
PixelPaint: Replace conflicting "Clear Selection" keyboard shortcut with Escape

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -282,7 +282,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         editor->selection().merge(editor->active_layer()->relative_rect(), PixelPaint::Selection::MergeMode::Set);
     }));
     m_edit_menu->add_action(GUI::Action::create(
-        "Clear &Selection", { Mod_Ctrl | Mod_Shift, Key_A }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/clear-selection.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+        "Clear &Selection", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/clear-selection.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
             editor->selection().clear();

--- a/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleSelectTool.cpp
@@ -115,6 +115,13 @@ void RectangleSelectTool::on_keydown(GUI::KeyEvent& key_event)
         m_moving_mode = MovingMode::MovingOrigin;
     else if (key_event.key() == KeyCode::Key_Control)
         m_moving_mode = MovingMode::AroundCenter;
+
+    if (key_event.key() == KeyCode::Key_Escape) {
+        if (m_selecting)
+            m_selecting = false;
+        else
+            m_editor->selection().clear();
+    }
 }
 
 void RectangleSelectTool::on_keyup(GUI::KeyEvent& key_event)


### PR DESCRIPTION
The new CommandPalette feature conflicts with PixelPaint's "Clear Selection" action keyboard shortcut (Ctrl + Shift + A). I chose not to replace the action hotkey with `Key_Escape` directly as this breaks other tools that use Escape for canceling an action.

Now while dragging a new rectangular selection you can cancel it by hitting Escape. Existing selections are cleared by Escape as well if the RectangularSelectTool is active.

Fixes #12222