### PR TITLE
LibGUI: Rename Close to Discard in MessageBox::ask_about_unsaved_changes()

### DIFF
--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -49,7 +49,7 @@ int MessageBox::ask_about_unsaved_changes(Window* parent_window, StringView path
         box->set_icon(parent_window->icon());
 
     box->m_yes_button->set_text(path.is_empty() ? "Save As..." : "Save");
-    box->m_no_button->set_text("Close");
+    box->m_no_button->set_text("Discard");
     box->m_cancel_button->set_text("Cancel");
 
     return box->exec();


### PR DESCRIPTION
The Close and Cancel buttons do very different things, yet their labels look very similar and they're right next to each other. Renaming Close to Discard should convey the action of the button more clearly and should be easier and faster to spot :^)