### PR TITLE
Calculator: Visual feedback on keyboard input

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -106,13 +106,18 @@ CalculatorWidget::CalculatorWidget()
     };
 }
 
+void CalculatorWidget::perform_operation(Calculator::Operation operation)
+{
+    KeypadValue argument = m_keypad.value();
+    KeypadValue res = m_calculator.begin_operation(operation, argument);
+    m_keypad.set_value(res);
+    update_display();
+}
+
 void CalculatorWidget::add_operation_button(GUI::Button& button, Calculator::Operation operation)
 {
     button.on_click = [this, operation](auto) {
-        KeypadValue argument = m_keypad.value();
-        KeypadValue res = m_calculator.begin_operation(operation, argument);
-        m_keypad.set_value(res);
-        update_display();
+        perform_operation(operation);
     };
 }
 
@@ -170,13 +175,25 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
     } else if (event.code_point() == '.') {
         m_keypad.type_decimal_point();
         mimic_pressed_button(m_decimal_point_button);
-    } else if (event.key() == KeyCode::Key_Escape) {
+    } else if (event.key() == KeyCode::Key_Escape || event.key() == KeyCode::Key_Delete) {
         m_keypad.set_value(0.0);
         m_calculator.clear_operation();
         mimic_pressed_button(m_clear_button);
     } else if (event.key() == KeyCode::Key_Backspace) {
         m_keypad.type_backspace();
         mimic_pressed_button(m_backspace_button);
+    } else if (event.key() == KeyCode::Key_Backslash) {
+        perform_operation(Calculator::Operation::ToggleSign);
+        mimic_pressed_button(m_sign_button);
+    } else if (event.key() == KeyCode::Key_S) {
+        perform_operation(Calculator::Operation::Sqrt);
+        mimic_pressed_button(m_sqrt_button);
+    } else if (event.key() == KeyCode::Key_Percent) {
+        perform_operation(Calculator::Operation::Percent);
+        mimic_pressed_button(m_percent_button);
+    } else if (event.key() == KeyCode::Key_I) {
+        perform_operation(Calculator::Operation::Inverse);
+        mimic_pressed_button(m_inverse_button);
     } else {
         Calculator::Operation operation;
 

--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -160,10 +160,6 @@ void CalculatorWidget::update_display()
 
 void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
 {
-    //Clear button selection when we are typing
-    m_equals_button->set_focus(true);
-    m_equals_button->set_focus(false);
-
     if (event.key() == KeyCode::Key_Return || event.key() == KeyCode::Key_Equal) {
         m_keypad.set_value(m_calculator.finish_operation(m_keypad.value()));
         mimic_pressed_button(m_equals_button);

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -27,6 +27,7 @@ private:
     void add_digit_button(GUI::Button&, int digit);
 
     void mimic_pressed_button(RefPtr<GUI::Button>);
+    void perform_operation(Calculator::Operation operation);
     void update_display();
 
     virtual void keydown_event(GUI::KeyEvent&) override;

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -26,9 +26,11 @@ private:
     void add_operation_button(GUI::Button&, Calculator::Operation);
     void add_digit_button(GUI::Button&, int digit);
 
+    void mimic_pressed_button(RefPtr<GUI::Button>);
     void update_display();
 
     virtual void keydown_event(GUI::KeyEvent&) override;
+    virtual void timer_event(Core::TimerEvent&) override;
 
     Calculator m_calculator;
     Keypad m_keypad;
@@ -54,4 +56,6 @@ private:
     RefPtr<GUI::Button> m_inverse_button;
     RefPtr<GUI::Button> m_percent_button;
     RefPtr<GUI::Button> m_equals_button;
+
+    RefPtr<GUI::Button> m_mimic_pressed_button {};
 };

--- a/Userland/Applications/Calculator/CalculatorWindow.gml
+++ b/Userland/Applications/Calculator/CalculatorWindow.gml
@@ -40,6 +40,7 @@
                     fixed_width: 65
                     fixed_height: 28
                     foreground_color: "brown"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -48,6 +49,7 @@
                     fixed_width: 56
                     fixed_height: 28
                     foreground_color: "brown"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -56,6 +58,7 @@
                     fixed_width: 60
                     fixed_height: 28
                     foreground_color: "brown"
+                    focus_policy: "NoFocus"
                 }
             }
 
@@ -68,6 +71,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "red"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Widget {
@@ -80,6 +84,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -88,6 +93,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -96,6 +102,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -103,6 +110,7 @@
                     text: "/"
                     fixed_width: 35
                     fixed_height: 28
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -111,6 +119,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
             }
 
@@ -123,6 +132,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "red"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Widget {
@@ -135,6 +145,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -143,6 +154,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -151,6 +163,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -158,6 +171,7 @@
                     text: "*"
                     fixed_width: 35
                     fixed_height: 28
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -166,6 +180,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
             }
 
@@ -178,6 +193,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "red"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Widget {
@@ -190,6 +206,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -198,6 +215,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -206,6 +224,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -213,6 +232,7 @@
                     text: "-"
                     fixed_width: 35
                     fixed_height: 28
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -221,6 +241,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
             }
 
@@ -233,6 +254,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "red"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Widget {
@@ -245,6 +267,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -253,6 +276,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -261,6 +285,7 @@
                     fixed_width: 35
                     fixed_height: 28
                     foreground_color: "blue"
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {
@@ -268,6 +293,7 @@
                     text: "+"
                     fixed_width: 35
                     fixed_height: 28
+                    focus_policy: "NoFocus"
                 }
 
                 @GUI::Button {

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -57,7 +57,7 @@ void Button::paint_event(PaintEvent& event)
 
     bool paint_pressed = is_being_pressed() || (m_menu && m_menu->is_visible());
 
-    Gfx::StylePainter::paint_button(painter, rect(), palette(), m_button_style, paint_pressed, is_hovered(), is_checked(), is_enabled(), is_focused(), is_default() & !another_button_has_focus());
+    Gfx::StylePainter::paint_button(painter, rect(), palette(), m_button_style, paint_pressed, is_hovered(), is_checked(), is_enabled(), is_focused(), is_default() && !another_button_has_focus());
 
     if (text().is_empty() && !m_icon)
         return;

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -55,7 +55,7 @@ void Button::paint_event(PaintEvent& event)
     Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
-    bool paint_pressed = is_being_pressed() || (m_menu && m_menu->is_visible());
+    bool paint_pressed = is_being_pressed() || is_mimic_pressed() || (m_menu && m_menu->is_visible());
 
     Gfx::StylePainter::paint_button(painter, rect(), palette(), m_button_style, paint_pressed, is_hovered(), is_checked(), is_enabled(), is_focused(), is_default() && !another_button_has_focus());
 
@@ -220,6 +220,12 @@ void Button::set_default(bool default_button)
         VERIFY(window());
         window()->set_default_return_key_widget(default_button ? this : nullptr);
     });
+}
+
+void Button::set_mimic_pressed(bool mimic_pressed)
+{
+    m_mimic_pressed = mimic_pressed;
+    update();
 }
 
 }

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -53,6 +53,9 @@ public:
 
     bool another_button_has_focus() const { return m_another_button_has_focus; }
 
+    void set_mimic_pressed(bool mimic_pressed);
+    bool is_mimic_pressed() const { return m_mimic_pressed; };
+
 protected:
     explicit Button(String text = {});
     virtual void mousedown_event(MouseEvent&) override;
@@ -67,6 +70,7 @@ private:
     WeakPtr<Action> m_action;
     int m_icon_spacing { 4 };
     bool m_another_button_has_focus { false };
+    bool m_mimic_pressed { false };
 };
 
 }


### PR DESCRIPTION
https://user-images.githubusercontent.com/30666851/152081816-30449a58-6d95-42d1-935b-5097eed02129.mp4

Adds the concept of a button being "ghosted" where it is painted as though it is being clicked regardless of if it actually is. This is used by Calculator to provide visual feedback on keyboard input.

I'm not the fondest of the term "ghosted" so suggestions in that regard are welcome.

All keypad buttons apart from the equal button have been prevented from gaining focus. This means that when the keypad is focused the return key will always perform the evaluation action instead of clicking a different focused key.

To augment these changes more calculator actions have had keyboard input support added. Every button apart from memory and clear error now have corresponding keyboard inputs. The keys used for square root and inverse are probably not ideal (currently `s` and `i` respectively).