### PR TITLE
mount: Exit without error when handling mount all on system boot

### DIFF
--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -167,8 +167,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(should_mount_all, "Mount all file systems listed in /etc/fstab", nullptr, 'a');
     args_parser.parse(arguments);
 
-    if (should_mount_all)
+    if (should_mount_all) {
         TRY(mount_all());
+        return 0;
+    }
 
     if (source.is_empty() && mountpoint.is_empty())
         TRY(print_mounts());


### PR DESCRIPTION
At the point at which `mount -a` is executed by SystemServer, the
/proc fs is not yet mounted. That means that opening /proc/fd in
the `print_mounts()` function will always fail with an error.

    0.976 mount(8:8): Exiting with runtime error:
                      No such file or directory (errno=2)

The fix is simple, just return gracefully after we execute mount all.