### PR TITLE
Fix typo in FlappyBug documentation

### DIFF
--- a/Base/usr/share/man/man6/FlappyBug.md
+++ b/Base/usr/share/man/man6/FlappyBug.md
@@ -14,4 +14,4 @@ $ FlappyBug
 
 Flappy Bug is a SerenityOS themed version of the 2013 game Flappy Bird.
 
-The goal of the game is to survive with Buggie as long as possible by avoiding obstacles. Buggie automatically decends by gravity and to ascend by clicking any key. Press the escape key to give up.
+The goal of the game is to survive with Buggie as long as possible by avoiding obstacles. Buggie automatically descends by gravity and ascends when you press any key. Press the escape key to give up.


### PR DESCRIPTION
Typo noted in the YT video `SerenityOS update (January 2022)`