### PR TITLE
LibWeb: Don't verify that a dimension unit isn't whitespace

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -841,7 +841,7 @@ Token Tokenizer::consume_a_numeric_token()
 
         // 2. Consume a name. Set the <dimension-token>’s unit to the returned value.
         auto unit = consume_a_name();
-        VERIFY(!unit.is_empty() && !unit.is_whitespace());
+        VERIFY(!unit.is_empty());
         token.m_unit = move(unit);
 
         // 3. Return the <dimension-token>.


### PR DESCRIPTION
Raw whitespace is not allowed inside a name, but escaped whitespace is,
for example `\9`, which is the tab character.

This stops yakzz.com from crashing the Browser, since it was using `\9`
in various places as a hack to only apply those properties to IE8/9.