### PR TITLE
mount: Do not print usage if executed without any arguments

### DIFF
--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -172,8 +172,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 0;
     }
 
-    if (source.is_empty() && mountpoint.is_empty())
+    if (source.is_empty() && mountpoint.is_empty()) {
         TRY(print_mounts());
+        return 0;
+    }
 
     if (!source.is_empty() && !mountpoint.is_empty()) {
         if (fs_type.is_empty())


### PR DESCRIPTION
If 'mount' is executed without any arguments we should print the mount
points and return early not printing the usage statement.

This fixes a regression introduced in commit: 9d48406