### PR TITLE
Userland: Fix hs crash when hitting esc on file save dialog

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -694,8 +694,8 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_action()
     return GUI::CommonActions::make_save_action([&](auto&) {
         if (active_file().is_empty())
             m_save_as_action->activate();
-
-        current_editor_wrapper().save();
+        else
+            current_editor_wrapper().save();
 
         if (m_git_widget->initialized())
             m_git_widget->refresh();


### PR DESCRIPTION
When one hits escape on an open file save dialog, hs just crashed
as it tried to write the file anyways.

Now we ensure that there always is a filename when saving a file to
disk.