### PR TITLE
LibWeb: Make StyleValue::to_string() return valid CSS

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2498,7 +2498,7 @@ RefPtr<StyleValue> Parser::parse_comma_separated_value_list(Vector<StyleComponen
         return {};
     }
 
-    return StyleValueList::create(move(values));
+    return StyleValueList::create(move(values), StyleValueList::Separator::Comma);
 }
 
 RefPtr<StyleValue> Parser::parse_simple_comma_separated_value_list(Vector<StyleComponentValueRule> const& component_values)
@@ -2670,13 +2670,13 @@ RefPtr<StyleValue> Parser::parse_background_value(Vector<StyleComponentValueRule
             background_color = property_initial_value(PropertyID::BackgroundColor);
         return BackgroundStyleValue::create(
             background_color.release_nonnull(),
-            StyleValueList::create(move(background_images)),
-            StyleValueList::create(move(background_positions)),
-            StyleValueList::create(move(background_sizes)),
-            StyleValueList::create(move(background_repeats)),
-            StyleValueList::create(move(background_attachments)),
-            StyleValueList::create(move(background_origins)),
-            StyleValueList::create(move(background_clips)));
+            StyleValueList::create(move(background_images), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_positions), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_sizes), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_repeats), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_attachments), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_origins), StyleValueList::Separator::Comma),
+            StyleValueList::create(move(background_clips), StyleValueList::Separator::Comma));
     }
 
     if (!background_color)
@@ -3127,7 +3127,7 @@ RefPtr<StyleValue> Parser::parse_border_radius_shorthand_value(Vector<StyleCompo
     border_radii.append(BorderRadiusStyleValue::create(bottom_left(horizontal_radii),
         vertical_radii.is_empty() ? bottom_left(horizontal_radii) : bottom_left(vertical_radii)));
 
-    return StyleValueList::create(move(border_radii));
+    return StyleValueList::create(move(border_radii), StyleValueList::Separator::Space);
 }
 
 RefPtr<StyleValue> Parser::parse_box_shadow_value(Vector<StyleComponentValueRule> const& component_values)
@@ -3457,7 +3457,7 @@ RefPtr<StyleValue> Parser::parse_font_family_value(Vector<StyleComponentValueRul
 
     if (font_families.is_empty())
         return nullptr;
-    return StyleValueList::create(move(font_families));
+    return StyleValueList::create(move(font_families), StyleValueList::Separator::Comma);
 }
 
 RefPtr<StyleValue> Parser::parse_list_style_value(Vector<StyleComponentValueRule> const& component_values)
@@ -3648,7 +3648,7 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<StyleComponentValueRule>
 
         transformations.append(TransformationStyleValue::create(maybe_function.value(), move(values)));
     }
-    return StyleValueList::create(move(transformations));
+    return StyleValueList::create(move(transformations), StyleValueList::Separator::Space);
 }
 
 RefPtr<StyleValue> Parser::parse_as_css_value(PropertyID property_id)
@@ -3816,7 +3816,7 @@ Result<NonnullRefPtr<StyleValue>, Parser::ParsingResult> Parser::parse_css_value
             parsed_values.append(parsed_value.release_nonnull());
         }
         if (!parsed_values.is_empty() && parsed_values.size() <= property_maximum_value_count(property_id))
-            return { StyleValueList::create(move(parsed_values)) };
+            return { StyleValueList::create(move(parsed_values), StyleValueList::Separator::Space) };
     }
 
     return ParsingResult::SyntaxError;

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -83,7 +83,7 @@ static RefPtr<StyleValue> style_value_for_display(CSS::Display display)
             break;
         }
 
-        return StyleValueList::create(move(values));
+        return StyleValueList::create(move(values), StyleValueList::Separator::Space);
     }
 
     if (display.is_internal()) {
@@ -550,7 +550,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         values.append(style_value_for_length_percentage(margin.right));
         values.append(style_value_for_length_percentage(margin.bottom));
         values.append(style_value_for_length_percentage(margin.left));
-        return StyleValueList::create(move(values));
+        return StyleValueList::create(move(values), StyleValueList::Separator::Space);
     }
     case CSS::PropertyID::MarginTop:
         return style_value_for_length_percentage(layout_node.computed_values().margin().top);
@@ -567,7 +567,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         values.append(style_value_for_length_percentage(padding.right));
         values.append(style_value_for_length_percentage(padding.bottom));
         values.append(style_value_for_length_percentage(padding.left));
-        return StyleValueList::create(move(values));
+        return StyleValueList::create(move(values), StyleValueList::Separator::Space);
     }
     case CSS::PropertyID::PaddingTop:
         return style_value_for_length_percentage(layout_node.computed_values().padding().top);

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -260,7 +260,7 @@ String BackgroundSizeStyleValue::to_string() const
 
 String BorderStyleValue::to_string() const
 {
-    return String::formatted("Border border_width: {}, border_style: {}, border_color: {}", m_border_width->to_string(), m_border_style->to_string(), m_border_color->to_string());
+    return String::formatted("{} {} {}", m_border_width->to_string(), m_border_style->to_string(), m_border_color->to_string());
 }
 
 String BorderRadiusStyleValue::to_string() const
@@ -270,7 +270,7 @@ String BorderRadiusStyleValue::to_string() const
 
 String BoxShadowStyleValue::to_string() const
 {
-    return String::formatted("BoxShadow offset_x: {}, offset_y: {}, blur_radius: {}, color: {}", m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string());
+    return String::formatted("{} {} {} {}", m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string());
 }
 
 // https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
@@ -288,17 +288,17 @@ String CombinedBorderRadiusStyleValue::to_string() const
 
 String FlexStyleValue::to_string() const
 {
-    return String::formatted("Flex grow: {}, shrink: {}, basis: {}", m_grow->to_string(), m_shrink->to_string(), m_basis->to_string());
+    return String::formatted("{} {} {}", m_grow->to_string(), m_shrink->to_string(), m_basis->to_string());
 }
 
 String FlexFlowStyleValue::to_string() const
 {
-    return String::formatted("FlexFlow flex_direction: {}, flex_wrap: {}", m_flex_direction->to_string(), m_flex_wrap->to_string());
+    return String::formatted("{} {}", m_flex_direction->to_string(), m_flex_wrap->to_string());
 }
 
 String FontStyleValue::to_string() const
 {
-    return String::formatted("Font style: {}, weight: {}, size: {}, line_height: {}, families: {}", m_font_style->to_string(), m_font_weight->to_string(), m_font_size->to_string(), m_line_height->to_string(), m_font_families->to_string());
+    return String::formatted("{} {} {} / {} {}", m_font_style->to_string(), m_font_weight->to_string(), m_font_size->to_string(), m_line_height->to_string(), m_font_families->to_string());
 }
 
 String IdentifierStyleValue::to_string() const
@@ -527,12 +527,12 @@ void ImageStyleValue::resource_did_load()
 
 String ImageStyleValue::to_string() const
 {
-    return String::formatted("Image({})", m_url.to_string());
+    return serialize_a_url(m_url.to_string());
 }
 
 String ListStyleStyleValue::to_string() const
 {
-    return String::formatted("ListStyle position: {}, image: {}, style_type: {}", m_position->to_string(), m_image->to_string(), m_style_type->to_string());
+    return String::formatted("{} {} {}", m_position->to_string(), m_image->to_string(), m_style_type->to_string());
 }
 
 String NumericStyleValue::to_string() const
@@ -577,7 +577,7 @@ String PositionStyleValue::to_string() const
 
 String TextDecorationStyleValue::to_string() const
 {
-    return String::formatted("TextDecoration line: {}, style: {}, color: {}", m_line->to_string(), m_style->to_string(), m_color->to_string());
+    return String::formatted("{} {} {}", m_line->to_string(), m_style->to_string(), m_color->to_string());
 }
 
 String TransformationStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/ByteBuffer.h>
 #include <LibGfx/Palette.h>
+#include <LibWeb/CSS/Serialize.h>
 #include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/BrowsingContext.h>
@@ -247,6 +248,59 @@ String BackgroundStyleValue::to_string() const
     return builder.to_string();
 }
 
+String BackgroundRepeatStyleValue::to_string() const
+{
+    return String::formatted("{} {}", CSS::to_string(m_repeat_x), CSS::to_string(m_repeat_y));
+}
+
+String BackgroundSizeStyleValue::to_string() const
+{
+    return String::formatted("{} {}", m_size_x.to_string(), m_size_y.to_string());
+}
+
+String BorderStyleValue::to_string() const
+{
+    return String::formatted("Border border_width: {}, border_style: {}, border_color: {}", m_border_width->to_string(), m_border_style->to_string(), m_border_color->to_string());
+}
+
+String BorderRadiusStyleValue::to_string() const
+{
+    return String::formatted("{} / {}", m_horizontal_radius.to_string(), m_vertical_radius.to_string());
+}
+
+String BoxShadowStyleValue::to_string() const
+{
+    return String::formatted("BoxShadow offset_x: {}, offset_y: {}, blur_radius: {}, color: {}", m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string());
+}
+
+// https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
+String ColorStyleValue::to_string() const
+{
+    if (m_color.alpha() == 1)
+        return String::formatted("rgb({}, {}, {})", m_color.red(), m_color.green(), m_color.blue());
+    return String::formatted("rgba({}, {}, {}, {})", m_color.red(), m_color.green(), m_color.blue(), (float)(m_color.alpha()) / 255.0f);
+}
+
+String CombinedBorderRadiusStyleValue::to_string() const
+{
+    return String::formatted("{} {} {} {} / {} {} {} {}", m_top_left->horizontal_radius().to_string(), m_top_right->horizontal_radius().to_string(), m_bottom_right->horizontal_radius().to_string(), m_bottom_left->horizontal_radius().to_string(), m_top_left->vertical_radius().to_string(), m_top_right->vertical_radius().to_string(), m_bottom_right->vertical_radius().to_string(), m_bottom_left->vertical_radius().to_string());
+}
+
+String FlexStyleValue::to_string() const
+{
+    return String::formatted("Flex grow: {}, shrink: {}, basis: {}", m_grow->to_string(), m_shrink->to_string(), m_basis->to_string());
+}
+
+String FlexFlowStyleValue::to_string() const
+{
+    return String::formatted("FlexFlow flex_direction: {}, flex_wrap: {}", m_flex_direction->to_string(), m_flex_wrap->to_string());
+}
+
+String FontStyleValue::to_string() const
+{
+    return String::formatted("Font style: {}, weight: {}, size: {}, line_height: {}, families: {}", m_font_style->to_string(), m_font_weight->to_string(), m_font_size->to_string(), m_line_height->to_string(), m_font_families->to_string());
+}
+
 String IdentifierStyleValue::to_string() const
 {
     return CSS::string_from_value_id(m_id);
@@ -471,12 +525,35 @@ void ImageStyleValue::resource_did_load()
         m_document->browsing_context()->set_needs_display({});
 }
 
-// https://www.w3.org/TR/css-color-4/#serializing-sRGB-values
-String ColorStyleValue::to_string() const
+String ImageStyleValue::to_string() const
 {
-    if (m_color.alpha() == 1)
-        return String::formatted("rgb({}, {}, {})", m_color.red(), m_color.green(), m_color.blue());
-    return String::formatted("rgba({}, {}, {}, {})", m_color.red(), m_color.green(), m_color.blue(), (float)(m_color.alpha()) / 255.0f);
+    return String::formatted("Image({})", m_url.to_string());
+}
+
+String ListStyleStyleValue::to_string() const
+{
+    return String::formatted("ListStyle position: {}, image: {}, style_type: {}", m_position->to_string(), m_image->to_string(), m_style_type->to_string());
+}
+
+String NumericStyleValue::to_string() const
+{
+    return m_value.visit(
+        [](float value) {
+            return String::formatted("{}", value);
+        },
+        [](i64 value) {
+            return String::formatted("{}", value);
+        });
+}
+
+String OverflowStyleValue::to_string() const
+{
+    return String::formatted("{} {}", m_overflow_x->to_string(), m_overflow_y->to_string());
+}
+
+String PercentageStyleValue::to_string() const
+{
+    return m_percentage.to_string();
 }
 
 String PositionStyleValue::to_string() const
@@ -498,11 +575,34 @@ String PositionStyleValue::to_string() const
     return String::formatted("{} {} {} {}", to_string(m_edge_x), m_offset_x.to_string(), to_string(m_edge_y), m_offset_y.to_string());
 }
 
+String TextDecorationStyleValue::to_string() const
+{
+    return String::formatted("TextDecoration line: {}, style: {}, color: {}", m_line->to_string(), m_style->to_string(), m_color->to_string());
+}
+
+String TransformationStyleValue::to_string() const
+{
+    return "TransformationStyleValue";
+}
+
 String UnresolvedStyleValue::to_string() const
 {
     StringBuilder builder;
     for (auto& value : m_values)
         builder.append(value.to_string());
+    return builder.to_string();
+}
+
+String StyleValueList::to_string() const
+{
+    StringBuilder builder;
+    builder.appendff("List[{}](", m_values.size());
+    for (size_t i = 0; i < m_values.size(); ++i) {
+        if (i)
+            builder.append(',');
+        builder.append(m_values[i].to_string());
+    }
+    builder.append(')');
     return builder.to_string();
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -595,15 +595,19 @@ String UnresolvedStyleValue::to_string() const
 
 String StyleValueList::to_string() const
 {
-    StringBuilder builder;
-    builder.appendff("List[{}](", m_values.size());
-    for (size_t i = 0; i < m_values.size(); ++i) {
-        if (i)
-            builder.append(',');
-        builder.append(m_values[i].to_string());
+    String separator = "";
+    switch (m_separator) {
+    case Separator::Space:
+        separator = " ";
+        break;
+    case Separator::Comma:
+        separator = ", ";
+        break;
+    default:
+        VERIFY_NOT_REACHED();
     }
-    builder.append(')');
-    return builder.to_string();
+
+    return String::join(separator, m_values);
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -582,7 +582,21 @@ String TextDecorationStyleValue::to_string() const
 
 String TransformationStyleValue::to_string() const
 {
-    return "TransformationStyleValue";
+    StringBuilder builder;
+
+    switch (m_transform_function) {
+    case TransformFunction::TranslateY:
+        builder.append("translateY");
+        break;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+
+    builder.append('(');
+    builder.join(", ", m_values);
+    builder.append(')');
+
+    return builder.to_string();
 }
 
 String UnresolvedStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1329,7 +1329,11 @@ private:
 
 class StyleValueList final : public StyleValue {
 public:
-    static NonnullRefPtr<StyleValueList> create(NonnullRefPtrVector<StyleValue>&& values) { return adopt_ref(*new StyleValueList(move(values))); }
+    enum class Separator {
+        Space,
+        Comma,
+    };
+    static NonnullRefPtr<StyleValueList> create(NonnullRefPtrVector<StyleValue>&& values, Separator separator) { return adopt_ref(*new StyleValueList(move(values), separator)); }
 
     size_t size() const { return m_values.size(); }
     NonnullRefPtrVector<StyleValue> const& values() const { return m_values; }
@@ -1343,13 +1347,23 @@ public:
     virtual String to_string() const override;
 
 private:
-    StyleValueList(NonnullRefPtrVector<StyleValue>&& values)
+    StyleValueList(NonnullRefPtrVector<StyleValue>&& values, Separator separator)
         : StyleValue(Type::ValueList)
+        , m_separator(separator)
         , m_values(move(values))
     {
     }
 
+    Separator m_separator;
     NonnullRefPtrVector<StyleValue> m_values;
 };
 
 }
+
+template<>
+struct AK::Formatter<Web::CSS::StyleValue> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Web::CSS::StyleValue const& style_value)
+    {
+        return Formatter<StringView>::format(builder, style_value.to_string());
+    }
+};

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Tobias Christiansen <tobyase@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -487,10 +487,7 @@ public:
     Repeat repeat_x() const { return m_repeat_x; }
     Repeat repeat_y() const { return m_repeat_y; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("{} {}", CSS::to_string(m_repeat_x), CSS::to_string(m_repeat_y));
-    }
+    virtual String to_string() const override;
 
 private:
     BackgroundRepeatStyleValue(Repeat repeat_x, Repeat repeat_y)
@@ -516,10 +513,7 @@ public:
     LengthPercentage size_x() const { return m_size_x; }
     LengthPercentage size_y() const { return m_size_y; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("{} {}", m_size_x.to_string(), m_size_y.to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     BackgroundSizeStyleValue(LengthPercentage size_x, LengthPercentage size_y)
@@ -548,10 +542,7 @@ public:
     NonnullRefPtr<StyleValue> border_style() const { return m_border_style; }
     NonnullRefPtr<StyleValue> border_color() const { return m_border_color; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("Border border_width: {}, border_style: {}, border_color: {}", m_border_width->to_string(), m_border_style->to_string(), m_border_color->to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     BorderStyleValue(
@@ -582,10 +573,7 @@ public:
     LengthPercentage const& vertical_radius() const { return m_vertical_radius; }
     bool is_elliptical() const { return m_is_elliptical; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("{} / {}", m_horizontal_radius.to_string(), m_vertical_radius.to_string());
-    }
+    virtual String to_string() const override;
 
     virtual bool equals(StyleValue const& other) const override
     {
@@ -633,13 +621,13 @@ public:
     }
     virtual ~BoxShadowStyleValue() override { }
 
+    // FIXME: Spread-distance and "inset" flag
     Length const& offset_x() const { return m_offset_x; }
     Length const& offset_y() const { return m_offset_y; }
     Length const& blur_radius() const { return m_blur_radius; }
     Color const& color() const { return m_color; }
 
-    String to_string() const override { return String::formatted("BoxShadow offset_x: {}, offset_y: {}, blur_radius: {}, color: {}",
-        m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string()); }
+    virtual String to_string() const override;
 
 private:
     explicit BoxShadowStyleValue(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
@@ -814,10 +802,7 @@ public:
     NonnullRefPtr<BorderRadiusStyleValue> bottom_right() const { return m_bottom_right; }
     NonnullRefPtr<BorderRadiusStyleValue> bottom_left() const { return m_bottom_left; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("{} {} {} {} / {} {} {} {}", m_top_left->horizontal_radius().to_string(), m_top_right->horizontal_radius().to_string(), m_bottom_right->horizontal_radius().to_string(), m_bottom_left->horizontal_radius().to_string(), m_top_left->vertical_radius().to_string(), m_top_right->vertical_radius().to_string(), m_bottom_right->vertical_radius().to_string(), m_bottom_left->vertical_radius().to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     CombinedBorderRadiusStyleValue(NonnullRefPtr<BorderRadiusStyleValue> top_left, NonnullRefPtr<BorderRadiusStyleValue> top_right, NonnullRefPtr<BorderRadiusStyleValue> bottom_right, NonnullRefPtr<BorderRadiusStyleValue> bottom_left)
@@ -850,10 +835,7 @@ public:
     NonnullRefPtr<StyleValue> shrink() const { return m_shrink; }
     NonnullRefPtr<StyleValue> basis() const { return m_basis; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("Flex grow: {}, shrink: {}, basis: {}", m_grow->to_string(), m_shrink->to_string(), m_basis->to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     FlexStyleValue(
@@ -883,10 +865,7 @@ public:
     NonnullRefPtr<StyleValue> flex_direction() const { return m_flex_direction; }
     NonnullRefPtr<StyleValue> flex_wrap() const { return m_flex_wrap; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("FlexFlow flex_direction: {}, flex_wrap: {}", m_flex_direction->to_string(), m_flex_wrap->to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     FlexFlowStyleValue(NonnullRefPtr<StyleValue> flex_direction, NonnullRefPtr<StyleValue> flex_wrap)
@@ -911,11 +890,7 @@ public:
     NonnullRefPtr<StyleValue> line_height() const { return m_line_height; }
     NonnullRefPtr<StyleValue> font_families() const { return m_font_families; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("Font style: {}, weight: {}, size: {}, line_height: {}, families: {}",
-            m_font_style->to_string(), m_font_weight->to_string(), m_font_size->to_string(), m_line_height->to_string(), m_font_families->to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     FontStyleValue(NonnullRefPtr<StyleValue> font_style, NonnullRefPtr<StyleValue> font_weight, NonnullRefPtr<StyleValue> font_size, NonnullRefPtr<StyleValue> line_height, NonnullRefPtr<StyleValue> font_families)
@@ -977,7 +952,7 @@ public:
     static NonnullRefPtr<ImageStyleValue> create(AK::URL const& url) { return adopt_ref(*new ImageStyleValue(url)); }
     virtual ~ImageStyleValue() override { }
 
-    String to_string() const override { return String::formatted("Image({})", m_url.to_string()); }
+    virtual String to_string() const override;
 
     void load_bitmap(DOM::Document& document);
     Gfx::Bitmap const* bitmap() const { return m_bitmap; }
@@ -1083,10 +1058,7 @@ public:
     NonnullRefPtr<StyleValue> image() const { return m_image; }
     NonnullRefPtr<StyleValue> style_type() const { return m_style_type; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("ListStyle position: {}, image: {}, style_type: {}", m_position->to_string(), m_image->to_string(), m_style_type->to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     ListStyleStyleValue(
@@ -1131,16 +1103,7 @@ public:
     virtual bool has_integer() const override { return m_value.has<i64>(); }
     virtual float to_integer() const override { return m_value.get<i64>(); }
 
-    String to_string() const override
-    {
-        return m_value.visit(
-            [](float value) {
-                return String::formatted("{}", value);
-            },
-            [](i64 value) {
-                return String::formatted("{}", value);
-            });
-    }
+    virtual String to_string() const override;
 
     virtual bool equals(StyleValue const& other) const override
     {
@@ -1174,10 +1137,7 @@ public:
     NonnullRefPtr<StyleValue> overflow_x() const { return m_overflow_x; }
     NonnullRefPtr<StyleValue> overflow_y() const { return m_overflow_y; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("{} {}", m_overflow_x->to_string(), m_overflow_y->to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     OverflowStyleValue(NonnullRefPtr<StyleValue> overflow_x, NonnullRefPtr<StyleValue> overflow_y)
@@ -1202,10 +1162,7 @@ public:
     Percentage const& percentage() const { return m_percentage; }
     Percentage& percentage() { return m_percentage; }
 
-    virtual String to_string() const override
-    {
-        return m_percentage.to_string();
-    }
+    virtual String to_string() const override;
 
 private:
     PercentageStyleValue(Percentage&& percentage)
@@ -1283,10 +1240,7 @@ public:
     NonnullRefPtr<StyleValue> style() const { return m_style; }
     NonnullRefPtr<StyleValue> color() const { return m_color; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("TextDecoration line: {}, style: {}, color: {}", m_line->to_string(), m_style->to_string(), m_color->to_string());
-    }
+    virtual String to_string() const override;
 
 private:
     TextDecorationStyleValue(
@@ -1316,10 +1270,7 @@ public:
     CSS::TransformFunction transform_function() const { return m_transform_function; }
     NonnullRefPtrVector<StyleValue> values() const { return m_values; }
 
-    virtual String to_string() const override
-    {
-        return String::formatted("TransformationStyleValue");
-    }
+    virtual String to_string() const override;
 
 private:
     TransformationStyleValue(CSS::TransformFunction transform_function, NonnullRefPtrVector<StyleValue>&& values)
@@ -1389,18 +1340,7 @@ public:
         return m_values[i];
     }
 
-    virtual String to_string() const override
-    {
-        StringBuilder builder;
-        builder.appendff("List[{}](", m_values.size());
-        for (size_t i = 0; i < m_values.size(); ++i) {
-            if (i)
-                builder.append(',');
-            builder.append(m_values[i].to_string());
-        }
-        builder.append(')');
-        return builder.to_string();
-    }
+    virtual String to_string() const override;
 
 private:
     StyleValueList(NonnullRefPtrVector<StyleValue>&& values)


### PR DESCRIPTION
This method is used in a lot of places for various things, most of which assume it is valid CSS, but some of the implementations included extra text for the sake of debugging. Outputting CSS is more useful so I've made them all do that. (Well, except CalculatedStyleValue since that's fixed in #12167... which might conflict, I'm not sure.)