### PR TITLE
CrashReporter: Stop attempting to lockdown the process veil

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -163,27 +163,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto pid = coredump->process_pid();
     auto termination_signal = coredump->process_termination_signal();
 
-    if (unlink_on_exit)
-        TRY(Core::System::unveil(coredump_path, "c"));
-
-    // If the executable is HackStudio, then the two unveil()s would conflict!
-    if (executable_path == "/bin/HackStudio") {
-        TRY(Core::System::unveil("/bin/HackStudio", "rx"));
-    } else {
-        TRY(Core::System::unveil(executable_path.characters(), "r"));
-        TRY(Core::System::unveil("/bin/HackStudio", "rx"));
-    }
-
-    TRY(Core::System::unveil("/res", "r"));
-    TRY(Core::System::unveil("/tmp/portal/launch", "rw"));
-    TRY(Core::System::unveil("/usr/lib", "r"));
-    coredump->for_each_library([&executable_path](auto library_info) {
-        // FIXME: Make for_each_library propagate ErrorOr values so we can use TRY.
-        if (library_info.path.starts_with('/') && library_info.path != executable_path)
-            MUST(Core::System::unveil(library_info.path, "r"));
-    });
-    TRY(Core::System::unveil(nullptr, nullptr));
-
     auto app_icon = GUI::Icon::default_icon("app-crash-reporter");
 
     auto window = TRY(GUI::Window::try_create());


### PR DESCRIPTION
The idea of locking the process veil in CrashReproter is well
intentioned, but ultimately frought with issues.

The fundamental premise is a bit flawed, as we are using the crashing
program as input to dynamically add new paths to the process veil.
This means that an attacker can potentially produce a custom or
malformed binary to trick CrashReporter into allowing an arbitrary
path to be read.