### PR TITLE
PixelPaint: Don't overwrite images with project file on save

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -587,7 +587,7 @@ bool ImageEditor::request_close()
 
 void ImageEditor::save_project()
 {
-    if (path().is_empty()) {
+    if (path().is_empty() || m_loaded_from_image) {
         save_project_as();
         return;
     }
@@ -614,6 +614,7 @@ void ImageEditor::save_project_as()
         return;
     }
     set_path(file->filename());
+    set_loaded_from_image(false);
     undo_stack().set_current_unmodified();
 }
 
@@ -647,6 +648,11 @@ void ImageEditor::set_show_active_layer_boundary(bool show)
 
     m_show_active_layer_boundary = show;
     update();
+}
+
+void ImageEditor::set_loaded_from_image(bool loaded_from_image)
+{
+    m_loaded_from_image = loaded_from_image;
 }
 
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -114,6 +114,8 @@ public:
     bool show_active_layer_boundary() const { return m_show_active_layer_boundary; }
     void set_show_active_layer_boundary(bool);
 
+    void set_loaded_from_image(bool);
+
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);
 
@@ -170,6 +172,8 @@ private:
     Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> m_active_cursor { Gfx::StandardCursor::None };
 
     Selection m_selection;
+
+    bool m_loaded_from_image { true };
 };
 
 }

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -712,6 +712,7 @@ void MainWidget::open_image(Core::File& file)
 
     auto& image = *m_loader.release_image();
     auto& editor = create_new_editor(image);
+    editor.set_loaded_from_image(m_loader.is_raw_image());
     editor.set_path(file.filename());
     editor.undo_stack().set_current_unmodified();
     m_layer_list_widget->set_image(&image);


### PR DESCRIPTION
The ImageEditor tracks whether it was loaded from an image
(the alternative being a project file.) If it was loaded from an image
file we redirect save project actions to save as instead.

(Fixes #11889 )