### PR TITLE
FileManager+LibGUI: Disable command palette and unwanted actions from desktop DirectoryView

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -225,6 +225,7 @@ void DirectoryView::setup_icon_view()
         m_icon_view->set_fill_with_background_color(false);
         m_icon_view->set_draw_item_text_with_shadow(true);
         m_icon_view->set_flow_direction(GUI::IconView::FlowDirection::TopToBottom);
+        m_icon_view->set_accepts_command_palette(false);
     }
 
     m_icon_view->set_model(m_sorting_model);

--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -612,6 +612,12 @@ void DirectoryView::setup_actions()
             Config::write_string("FileManager", "DirectoryView", "ViewMode", "Columns");
         },
         window());
+
+    if (m_mode == Mode::Desktop) {
+        m_view_as_icons_action->set_enabled(false);
+        m_view_as_table_action->set_enabled(false);
+        m_view_as_columns_action->set_enabled(false);
+    }
 }
 
 void DirectoryView::handle_drop(GUI::ModelIndex const& index, GUI::DropEvent const& event)

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -283,6 +283,9 @@ public:
     void set_accepts_emoji_input(bool b) { m_accepts_emoji_input = b; }
     bool accepts_emoji_input() const { return m_accepts_emoji_input; }
 
+    void set_accepts_command_palette(bool b) { m_accepts_command_palette = b; }
+    bool accepts_command_palette() const { return m_accepts_command_palette; }
+
     virtual Gfx::IntRect children_clip_rect() const;
 
     AK::Variant<Gfx::StandardCursor, NonnullRefPtr<Gfx::Bitmap>> override_cursor() const { return m_override_cursor; }
@@ -378,6 +381,7 @@ private:
     bool m_enabled { true };
     bool m_updates_enabled { true };
     bool m_accepts_emoji_input { false };
+    bool m_accepts_command_palette { true };
     bool m_shrink_to_fit { false };
     bool m_default_font { true };
 

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -196,7 +196,8 @@ void WindowServerConnection::key_down(i32 window_id, u32 code_point, u32 key, u3
     }
 
     // FIXME: This shortcut should be configurable.
-    if (!m_in_command_palette && modifiers == (Mod_Ctrl | Mod_Shift) && key == Key_A) {
+    bool focused_widget_accepts_command_palette = window->focused_widget() && window->focused_widget()->accepts_command_palette();
+    if (focused_widget_accepts_command_palette && !m_in_command_palette && modifiers == (Mod_Ctrl | Mod_Shift) && key == Key_A) {
         auto command_palette = CommandPalette::construct(*window);
         TemporaryChange change { m_in_command_palette, true };
         if (command_palette->exec() != GUI::Dialog::ExecOK)


### PR DESCRIPTION
Widgets opt-in to the command palette by default, since I think most will want to allow it.