### PR TITLE
PixelPaint: Holding alt changes active tool to Color Picker in PixelPaint

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -11,6 +11,7 @@
 #include "Image.h"
 #include "Layer.h"
 #include "Tools/MoveTool.h"
+#include "Tools/PickerTool.h"
 #include "Tools/Tool.h"
 #include <AK/LexicalPath.h>
 #include <LibConfig/Client.h>
@@ -351,6 +352,11 @@ void ImageEditor::context_menu_event(GUI::ContextMenuEvent& event)
 
 void ImageEditor::keydown_event(GUI::KeyEvent& event)
 {
+    if (event.key() == Key_Alt) {
+        set_old_tool(m_active_tool);
+        set_active_tool(new PickerTool());
+    }
+
     if (event.key() == Key_Delete && !selection().is_empty() && active_layer()) {
         active_layer()->erase_selection(selection());
         return;
@@ -362,6 +368,15 @@ void ImageEditor::keydown_event(GUI::KeyEvent& event)
 
 void ImageEditor::keyup_event(GUI::KeyEvent& event)
 {
+    if (event.key() == Key_Alt) {
+        if (!m_old_tool) {
+            set_override_cursor(Gfx::StandardCursor::None);
+            return;
+        }
+
+        set_active_tool(m_old_tool);
+    }
+
     if (m_active_tool)
         m_active_tool->on_keyup(event);
 }
@@ -398,6 +413,11 @@ void ImageEditor::set_active_layer(Layer* layer)
         if (on_active_layer_change)
             on_active_layer_change({});
     }
+}
+
+void ImageEditor::set_old_tool(Tool* tool)
+{
+    m_old_tool = tool;
 }
 
 void ImageEditor::set_active_tool(Tool* tool)

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -354,7 +354,7 @@ void ImageEditor::keydown_event(GUI::KeyEvent& event)
 {
     if (event.key() == Key_Alt) {
         set_old_tool(m_active_tool);
-        set_active_tool(new PickerTool());
+        set_active_tool(m_hotkey_picker);
     }
 
     if (event.key() == Key_Delete && !selection().is_empty() && active_layer()) {

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -11,6 +11,7 @@
 #include "Guide.h"
 #include "Image.h"
 #include "Selection.h"
+#include "Tools/PickerTool.h"
 #include <AK/Variant.h>
 #include <LibGUI/AbstractZoomPanWidget.h>
 #include <LibGUI/Frame.h>
@@ -37,6 +38,7 @@ public:
     void set_active_layer(Layer*);
 
     Tool* active_tool() { return m_active_tool; }
+    PickerTool* hotkey_picker() { return m_hotkey_picker; }
 
     void set_old_tool(Tool*);
     void set_active_tool(Tool*);
@@ -159,6 +161,7 @@ private:
 
     Tool* m_active_tool { nullptr };
     Tool* m_old_tool { nullptr };
+    PickerTool* m_hotkey_picker { new PickerTool() };
 
     Color m_primary_color { Color::Black };
     Color m_secondary_color { Color::White };

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -37,6 +37,8 @@ public:
     void set_active_layer(Layer*);
 
     Tool* active_tool() { return m_active_tool; }
+
+    void set_old_tool(Tool*);
     void set_active_tool(Tool*);
     void update_tool_cursor();
 
@@ -156,6 +158,7 @@ private:
     bool m_show_active_layer_boundary { true };
 
     Tool* m_active_tool { nullptr };
+    Tool* m_old_tool { nullptr };
 
     Color m_primary_color { Color::Black };
     Color m_secondary_color { Color::White };


### PR DESCRIPTION
Holding the Alt key now changes the active tool to `PickerTool` while it is held. 
Keydown sets the active tool to `PickerTool` and keyup resets it to what it was before. 
Closes #11860