### PR TITLE
Meta: Add install-native-partition CMake target installing to a real FS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,10 @@ add_custom_target(extlinux-image
     BYPRODUCTS "${CMAKE_BINARY_DIR}/extlinux_disk_image"
     USES_TERMINAL
 )
+add_custom_target(install-native-partition
+    COMMAND "${CMAKE_COMMAND}" -E env "SERENITY_SOURCE_DIR=${SerenityOS_SOURCE_DIR}" "SERENITY_ARCH=${SERENITY_ARCH}" "SERENITY_TOOLCHAIN=${CMAKE_CXX_COMPILER_ID}" "LLVM_VERSION=${CMAKE_CXX_COMPILER_VERSION}" "${SerenityOS_SOURCE_DIR}/Meta/build-native-partition.sh"
+    USES_TERMINAL
+)
 
 add_custom_target(lint-shell-scripts
     COMMAND "${SerenityOS_SOURCE_DIR}/Meta/lint-shell-scripts.sh"

--- a/Meta/build-native-partition.sh
+++ b/Meta/build-native-partition.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+set -e
+
+die() {
+    echo "die: $*"
+    exit 1
+}
+
+cleanup() {
+    if [ -d mnt ]; then
+        umount mnt || ( sleep 1 && sync && umount mnt )
+        rmdir mnt
+        echo "done"
+    fi
+}
+
+if [ "$(id -u)" != 0 ]; then
+    sudo -E -- "$0" "$@" || die "this script needs to run as root"
+    exit 0
+else
+    : "${SUDO_UID:=0}" "${SUDO_GID:=0}"
+fi
+
+if [ -z "$SERENITY_TARGET_INSTALL_PARTITION" ]; then
+    die "SERENITY_TARGET_INSTALL_PARTITION environment variable was not set!"
+fi
+
+printf "verifying partition %s is already ext2... " "$SERENITY_TARGET_INSTALL_PARTITION"
+if file -sL "$SERENITY_TARGET_INSTALL_PARTITION" 2>&1 | grep "ext2" > /dev/null; then
+    echo "done"
+else
+    die "$SERENITY_TARGET_INSTALL_PARTITION is not an ext2 partition!"
+fi
+
+trap cleanup EXIT
+
+printf "mounting filesystem on device %s... " "$SERENITY_TARGET_INSTALL_PARTITION"
+mkdir -p mnt
+if ! eval "mount $SERENITY_TARGET_INSTALL_PARTITION mnt/"; then
+    die "could not mount existing ext2 filesystem on $SERENITY_TARGET_INSTALL_PARTITION"
+else
+    echo "done"
+fi
+
+script_path=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
+"$script_path/build-root-filesystem.sh"


### PR DESCRIPTION
While playing around with getting serenity to run on my main desktop
machine I wanted a way of easily updating my physical serenity
partition.

To use it you just need to:
- Create and format your local partition to ext4
- Set `SERENITY_TARGET_INSTALL_PARTITION` 
- Run the `install-native-partition` build target.

Example:

    $ export SERENITY_TARGET_INSTALL_PARTITION=/dev/nvme1n1p3
    $ cd serenity/Build/x86_64
    $ ninja install-native-partition