### PR TITLE
LibJS: Explicitly handle invalid Date objects in setter methods

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setDate.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setDate.js
@@ -30,3 +30,9 @@ test("Day as argument", () => {
     expect(date.getSeconds()).toBe(0);
     expect(date.getMilliseconds()).toBe(0);
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setDate(15)).toBeNaN();
+    expect(date.getDate()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setFullYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setFullYear.js
@@ -110,3 +110,9 @@ test("Make Invalid Date valid again", () => {
     expect(date.getSeconds()).toBe(0);
     expect(date.getMilliseconds()).toBe(0);
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    date.setFullYear(2022);
+    expect(date.getFullYear()).toBe(2022);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setHours.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setHours.js
@@ -25,3 +25,9 @@ test("basic functionality", () => {
     d.setHours("a");
     expect(d.getHours()).toBe(NaN);
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setHours(2)).toBeNaN();
+    expect(date.getHours()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setMilliseconds.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setMilliseconds.js
@@ -10,3 +10,9 @@ test("basic functionality", () => {
     d.setMilliseconds("a");
     expect(d.getMilliseconds()).toBe(NaN);
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setMilliseconds(2)).toBeNaN();
+    expect(date.getMilliseconds()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setMinutes.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setMinutes.js
@@ -19,3 +19,9 @@ test("basic functionality", () => {
     d.setMinutes("a");
     expect(d.getMinutes()).toBe(NaN);
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setMinutes(2)).toBeNaN();
+    expect(date.getMinutes()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setMonth.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setMonth.js
@@ -61,3 +61,9 @@ test("NaN or undefined in any arguments", () => {
     date.setMonth(2021, undefined);
     expect(date.getTime()).toBe(NaN);
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setMonth(2)).toBeNaN();
+    expect(date.getMonth()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setSeconds.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setSeconds.js
@@ -14,3 +14,9 @@ test("basic functionality", () => {
     d.setSeconds("a");
     expect(d.getSeconds()).toBe(NaN);
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setSeconds(2)).toBeNaN();
+    expect(date.getSeconds()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setTime.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setTime.js
@@ -45,3 +45,9 @@ test("Make Invalid Date valid again", () => {
     expect(date.getUTCSeconds()).toBe(46);
     expect(date.getUTCMilliseconds()).toBe(0);
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setTime(1622993746000)).toBe(1622993746000);
+    expect(date.getTime()).toBe(1622993746000);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCDate.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCDate.js
@@ -33,3 +33,9 @@ describe("correct behavior", () => {
         expect(d.getUTCDate()).toBeNaN();
     });
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setUTCDate(15)).toBeNaN();
+    expect(date.getUTCDate()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCFullYear.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCFullYear.js
@@ -53,3 +53,9 @@ describe("correct behavior", () => {
         expect(d.getUTCFullYear()).toBeNaN();
     });
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    date.setUTCFullYear(2022);
+    expect(date.getUTCFullYear()).toBe(2022);
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCHours.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCHours.js
@@ -63,3 +63,9 @@ describe("correct behavior", () => {
         expect(d.getUTCHours()).toBeNaN();
     });
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setUTCHours(2)).toBeNaN();
+    expect(date.getUTCHours()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCMilliseconds.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCMilliseconds.js
@@ -36,3 +36,9 @@ describe("correct behavior", () => {
         expect(d.getUTCMilliseconds()).toBeNaN();
     });
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setUTCMilliseconds(2)).toBeNaN();
+    expect(date.getUTCMilliseconds()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCMinutes.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCMinutes.js
@@ -49,3 +49,9 @@ describe("correct behavior", () => {
         expect(d.getUTCMinutes()).toBeNaN();
     });
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setUTCMinutes(2)).toBeNaN();
+    expect(date.getUTCMinutes()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCMonth.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCMonth.js
@@ -44,3 +44,9 @@ describe("correct behavior", () => {
         expect(d.getUTCMonth()).toBeNaN();
     });
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setUTCMonth(2)).toBeNaN();
+    expect(date.getUTCMonth()).toBeNaN();
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCSeconds.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.prototype.setUTCSeconds.js
@@ -44,3 +44,9 @@ describe("correct behavior", () => {
         expect(d.getUTCSeconds()).toBeNaN();
     });
 });
+
+test("invalid date", () => {
+    let date = new Date(NaN);
+    expect(date.setUTCSeconds(2)).toBeNaN();
+    expect(date.getUTCSeconds()).toBeNaN();
+});


### PR DESCRIPTION
This is a normative change in the ECMA-262 spec:
https://github.com/tc39/ecma262/commit/ca53334

I think this would have avoided the need for commits like 9be0a0fd28a295200f6e5377c37b8f454aab79db and efda1724e8914c2193718a4a60ee9129a1a80018. So those could probably be removed, but they also aren't doing any harm, so I just left them.