### PR TITLE
Spreadsheet: Drag, cut, and extend cells

### DIFF
--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -294,6 +294,10 @@ Position Sheet::offset_relative_to(const Position& base, const Position& offset,
 
 void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to, CopyOperation copy_operation)
 {
+    Vector<Position> target_cells;
+    for (auto& position : from)
+        target_cells.append(resolve_relative_to.has_value() ? offset_relative_to(to.first(), position, resolve_relative_to.value()) : to.first());
+
     auto copy_to = [&](auto& source_position, Position target_position) {
         auto& target_cell = ensure(target_position);
         auto* source_cell = at(source_position);
@@ -305,7 +309,8 @@ void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Posi
 
         target_cell.copy_from(*source_cell);
         if (copy_operation == CopyOperation::Cut)
-            source_cell->set_data("");
+            if (!target_cells.contains_slow(source_position))
+                source_cell->set_data("");
     };
 
     if (from.size() == to.size()) {

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -294,6 +294,12 @@ Position Sheet::offset_relative_to(const Position& base, const Position& offset,
 
 void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to, CopyOperation copy_operation)
 {
+    // Disallow misaligned copies.
+    if (to.size() > 1 && from.size() != to.size()) {
+        dbgln("Cannot copy {} cells to {} cells", from.size(), to.size());
+        return;
+    }
+
     Vector<Position> target_cells;
     for (auto& position : from)
         target_cells.append(resolve_relative_to.has_value() ? offset_relative_to(to.first(), position, resolve_relative_to.value()) : to.first());
@@ -313,39 +319,46 @@ void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Posi
                 source_cell->set_data("");
     };
 
-    if (from.size() == to.size()) {
-        auto from_it = from.begin();
-        // FIXME: Ordering.
-        for (auto& position : to)
-            copy_to(*from_it++, position);
+    // Resolve each index as relative to the first index offset from the selection.
+    auto& target = to.first();
 
-        return;
+    auto top_left_most_position_from = from.first();
+    auto bottom_right_most_position_from = from.first();
+    for (auto& position : from) {
+        if (position.row > bottom_right_most_position_from.row)
+            bottom_right_most_position_from = position;
+        else if (position.column > bottom_right_most_position_from.column)
+            bottom_right_most_position_from = position;
+
+        if (position.row < top_left_most_position_from.row)
+            top_left_most_position_from = position;
+        else if (position.column < top_left_most_position_from.column)
+            top_left_most_position_from = position;
     }
 
-    if (to.size() == 1) {
-        // Resolve each index as relative to the first index offset from the selection.
-        auto& target = to.first();
+    Vector<Position> ordered_from;
+    auto current_column = top_left_most_position_from.column;
+    auto current_row = top_left_most_position_from.row;
+    for ([[maybe_unused]] auto& position : from) {
+        for (auto& position : from)
+            if (position.row == current_row && position.column == current_column)
+                ordered_from.append(position);
 
-        for (auto& position : from) {
-            dbgln_if(COPY_DEBUG, "Paste from '{}' to '{}'", position.to_url(*this), target.to_url(*this));
-            copy_to(position, resolve_relative_to.has_value() ? offset_relative_to(target, position, resolve_relative_to.value()) : target);
+        if (current_column >= bottom_right_most_position_from.column) {
+            current_column = top_left_most_position_from.column;
+            current_row += 1;
+        } else {
+            current_column += 1;
         }
-
-        return;
     }
 
-    if (from.size() == 1) {
-        // Fill the target selection with the single cell.
-        auto& source = from.first();
-        for (auto& position : to) {
-            dbgln_if(COPY_DEBUG, "Paste from '{}' to '{}'", source.to_url(*this), position.to_url(*this));
-            copy_to(source, resolve_relative_to.has_value() ? offset_relative_to(position, source, resolve_relative_to.value()) : position);
-        }
-        return;
-    }
+    if (target.row > top_left_most_position_from.row || (target.row >= top_left_most_position_from.row && target.column > top_left_most_position_from.column))
+        ordered_from.reverse();
 
-    // Just disallow misaligned copies.
-    dbgln("Cannot copy {} cells to {} cells", from.size(), to.size());
+    for (auto& position : ordered_from) {
+        dbgln_if(COPY_DEBUG, "Paste from '{}' to '{}'", position.to_url(*this), target.to_url(*this));
+        copy_to(position, resolve_relative_to.has_value() ? offset_relative_to(target, position, resolve_relative_to.value()) : target);
+    }
 }
 
 RefPtr<Sheet> Sheet::from_json(const JsonObject& object, Workbook& workbook)

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -125,7 +125,7 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
             }
         }
 
-        if (m_is_hovering_cut_zone || m_is_dragging_for_copy)
+        if (m_is_hovering_cut_zone || m_is_dragging_for_cut)
             set_override_cursor(Gfx::StandardCursor::Drag);
         else if (m_is_hovering_extend_zone)
             set_override_cursor(Gfx::StandardCursor::Crosshair);
@@ -133,7 +133,7 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
             set_override_cursor(Gfx::StandardCursor::Arrow);
 
         auto holding_left_button = !!(event.buttons() & GUI::MouseButton::Primary);
-        if (m_is_dragging_for_copy) {
+        if (m_is_dragging_for_cut) {
             m_is_dragging_for_select = false;
             if (holding_left_button) {
                 m_has_committed_to_cutting = true;
@@ -176,7 +176,7 @@ void InfinitelyScrollableTableView::mousedown_event(GUI::MouseEvent& event)
     // when m_is_hovering_cut_zone as it can be the case that the user is targetting
     // a cell yet be outside of its bounding box due to the select_padding.
     if (m_is_hovering_cut_zone) {
-        m_is_dragging_for_copy = true;
+        m_is_dragging_for_cut = true;
         auto rect = content_rect(m_target_cell);
         GUI::MouseEvent adjusted_event = { (GUI::Event::Type)event.type(), rect.center(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y() };
         AbstractTableView::mousedown_event(adjusted_event);
@@ -190,7 +190,7 @@ void InfinitelyScrollableTableView::mousedown_event(GUI::MouseEvent& event)
 void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)
 {
     m_is_dragging_for_select = false;
-    m_is_dragging_for_copy = false;
+    m_is_dragging_for_cut = false;
     m_has_committed_to_cutting = false;
     if (m_is_hovering_cut_zone) {
         auto rect = content_rect(m_target_cell);
@@ -204,7 +204,7 @@ void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)
 void InfinitelyScrollableTableView::drop_event(GUI::DropEvent& event)
 {
     TableView::drop_event(event);
-    m_is_dragging_for_copy = false;
+    m_is_dragging_for_cut = false;
     set_override_cursor(Gfx::StandardCursor::Arrow);
     auto drop_index = index_at_event_position(event.position());
     if (selection().size() > 0) {
@@ -377,7 +377,7 @@ SpreadsheetView::SpreadsheetView(Sheet& sheet)
                 return;
 
             auto first_position = source_positions.take_first();
-            m_sheet->copy_cells(move(source_positions), move(target_positions), first_position);
+            m_sheet->copy_cells(move(source_positions), move(target_positions), first_position, Spreadsheet::Sheet::CopyOperation::Cut);
 
             return;
         }

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -246,9 +246,12 @@ void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)
 
 void InfinitelyScrollableTableView::drop_event(GUI::DropEvent& event)
 {
-    TableView::drop_event(event);
     m_is_dragging_for_cut = false;
     set_override_cursor(Gfx::StandardCursor::Arrow);
+    if (!index_at_event_position(event.position()).is_valid())
+        return;
+
+    TableView::drop_event(event);
     auto drop_index = index_at_event_position(event.position());
     if (selection().size() > 0) {
         // Get top left index position of previous selection

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -94,8 +94,8 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
                     top_left_most_index = index;
             });
 
-            auto top_left_rect = content_rect(top_left_most_index);
-            auto bottom_right_rect = content_rect(bottom_right_most_index);
+            auto top_left_rect = content_rect_minus_scrollbars(top_left_most_index);
+            auto bottom_right_rect = content_rect_minus_scrollbars(bottom_right_most_index);
             auto distance_tl = top_left_rect.center() - event.position();
             auto distance_br = bottom_right_rect.center() - event.position();
             auto is_over_top_line = false;
@@ -201,7 +201,7 @@ void InfinitelyScrollableTableView::mousedown_event(GUI::MouseEvent& event)
             m_is_dragging_for_cut = true;
         else if (m_is_hovering_extend_zone)
             m_is_dragging_for_extend = true;
-        auto rect = content_rect(m_target_cell);
+        auto rect = content_rect_minus_scrollbars(m_target_cell);
         GUI::MouseEvent adjusted_event = { (GUI::Event::Type)event.type(), rect.center(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y() };
         AbstractTableView::mousedown_event(adjusted_event);
     } else {
@@ -236,7 +236,7 @@ void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)
     m_has_committed_to_cutting = false;
     m_has_committed_to_extending = false;
     if (m_is_hovering_cut_zone || m_is_hovering_extend_zone) {
-        auto rect = content_rect(m_target_cell);
+        auto rect = content_rect_minus_scrollbars(m_target_cell);
         GUI::MouseEvent adjusted_event = { (GUI::Event::Type)event.type(), rect.center(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y() };
         TableView::mouseup_event(adjusted_event);
     } else {

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -79,7 +79,7 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
 
         m_is_hovering_cut_zone = false;
         m_is_hovering_extend_zone = false;
-        if (selection().size() > 0 && !m_should_intercept_drag) {
+        if (selection().size() > 0 && !m_is_dragging_for_select) {
             // Get top-left and bottom-right most cells of selection
             auto bottom_right_most_index = selection().first();
             auto top_left_most_index = selection().first();
@@ -134,20 +134,20 @@ void InfinitelyScrollableTableView::mousemove_event(GUI::MouseEvent& event)
 
         auto holding_left_button = !!(event.buttons() & GUI::MouseButton::Primary);
         if (m_is_dragging_for_copy) {
-            m_should_intercept_drag = false;
+            m_is_dragging_for_select = false;
             if (holding_left_button) {
-                m_has_committed_to_dragging = true;
+                m_has_committed_to_cutting = true;
             }
-        } else if (!m_should_intercept_drag) {
+        } else if (!m_is_dragging_for_select) {
             if (!holding_left_button) {
                 m_starting_selection_index = index;
             } else {
-                m_should_intercept_drag = true;
+                m_is_dragging_for_select = true;
                 m_might_drag = false;
             }
         }
 
-        if (holding_left_button && m_should_intercept_drag && !m_has_committed_to_dragging) {
+        if (holding_left_button && m_is_dragging_for_select && !m_has_committed_to_cutting) {
             if (!m_starting_selection_index.is_valid())
                 m_starting_selection_index = index;
 
@@ -189,9 +189,9 @@ void InfinitelyScrollableTableView::mousedown_event(GUI::MouseEvent& event)
 
 void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)
 {
-    m_should_intercept_drag = false;
-    m_has_committed_to_dragging = false;
+    m_is_dragging_for_select = false;
     m_is_dragging_for_copy = false;
+    m_has_committed_to_cutting = false;
     if (m_is_hovering_cut_zone) {
         auto rect = content_rect(m_target_cell);
         GUI::MouseEvent adjusted_event = { (GUI::Event::Type)event.type(), rect.center(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y() };

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -182,6 +182,8 @@ void InfinitelyScrollableTableView::mousedown_event(GUI::MouseEvent& event)
         AbstractTableView::mousedown_event(adjusted_event);
     } else {
         AbstractTableView::mousedown_event(event);
+        auto index = index_at_event_position(event.position());
+        AbstractTableView::set_cursor(index, SelectionUpdate::Set);
     }
 }
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -78,9 +78,9 @@ private:
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
-    bool m_should_intercept_drag { false };
-    bool m_has_committed_to_dragging { false };
+    bool m_is_dragging_for_select { false };
     bool m_is_dragging_for_copy { false };
+    bool m_has_committed_to_cutting { false };
     bool m_is_hovering_extend_zone { false };
     bool m_is_hovering_cut_zone { false };
     GUI::ModelIndex m_starting_selection_index;

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -76,6 +76,7 @@ private:
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
+    virtual void drop_event(GUI::DropEvent&) override;
 
     bool m_should_intercept_drag { false };
     bool m_has_committed_to_dragging { false };

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -83,6 +83,7 @@ private:
     bool m_is_hovering_extend_zone { false };
     bool m_is_hovering_cut_zone { false };
     GUI::ModelIndex m_starting_selection_index;
+    GUI::ModelIndex m_target_cell;
     RefPtr<Core::Timer> m_horizontal_scroll_end_timer;
     RefPtr<Core::Timer> m_vertical_scroll_end_timer;
 };

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -79,7 +79,7 @@ private:
     virtual void drop_event(GUI::DropEvent&) override;
 
     bool m_is_dragging_for_select { false };
-    bool m_is_dragging_for_copy { false };
+    bool m_is_dragging_for_cut { false };
     bool m_has_committed_to_cutting { false };
     bool m_is_hovering_extend_zone { false };
     bool m_is_hovering_cut_zone { false };

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -78,11 +78,13 @@ private:
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
-    bool m_is_dragging_for_select { false };
-    bool m_is_dragging_for_cut { false };
-    bool m_has_committed_to_cutting { false };
     bool m_is_hovering_extend_zone { false };
     bool m_is_hovering_cut_zone { false };
+    bool m_is_dragging_for_select { false };
+    bool m_is_dragging_for_cut { false };
+    bool m_is_dragging_for_extend { false };
+    bool m_has_committed_to_cutting { false };
+    bool m_has_committed_to_extending { false };
     GUI::ModelIndex m_starting_selection_index;
     GUI::ModelIndex m_target_cell;
     RefPtr<Core::Timer> m_horizontal_scroll_end_timer;

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -80,6 +80,8 @@ private:
     bool m_should_intercept_drag { false };
     bool m_has_committed_to_dragging { false };
     bool m_is_dragging_for_copy { false };
+    bool m_is_hovering_extend_zone { false };
+    bool m_is_hovering_cut_zone { false };
     GUI::ModelIndex m_starting_selection_index;
     RefPtr<Core::Timer> m_horizontal_scroll_end_timer;
     RefPtr<Core::Timer> m_vertical_scroll_end_timer;

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -329,6 +329,12 @@ Gfx::IntRect AbstractTableView::content_rect(const ModelIndex& index) const
     return content_rect(index.row(), index.column());
 }
 
+Gfx::IntRect AbstractTableView::content_rect_minus_scrollbars(const ModelIndex& index) const
+{
+    auto naive_content_rect = content_rect(index.row(), index.column());
+    return { naive_content_rect.x() - horizontal_scrollbar().value(), naive_content_rect.y() - vertical_scrollbar().value(), naive_content_rect.width(), naive_content_rect.height() };
+}
+
 Gfx::IntRect AbstractTableView::row_rect(int item_index) const
 {
     return { row_header().is_visible() ? row_header().width() : 0,

--- a/Userland/Libraries/LibGUI/AbstractTableView.h
+++ b/Userland/Libraries/LibGUI/AbstractTableView.h
@@ -52,6 +52,7 @@ public:
     Gfx::IntPoint adjusted_position(const Gfx::IntPoint&) const;
 
     virtual Gfx::IntRect content_rect(const ModelIndex&) const override;
+    Gfx::IntRect content_rect_minus_scrollbars(const ModelIndex&) const;
     Gfx::IntRect content_rect(int row, int column) const;
     Gfx::IntRect row_rect(int item_index) const;
 


### PR DESCRIPTION
These commits relate to the Spreadsheet application, dealing with different types of improvements relating to selected cells.
- Changes the copy functionality when dragging a cell to be cut so as to match other spreadsheet applications
- Adds different visual cues for dragging like selecting the pasted cells, changing the icon when hovering over the cell
- Adds the 'extend' functionality, which allows a user to click the bottom right of a cell and extend its contents in any direction. Currently it simply copies the target cell's contents but it could improved to find patterns and continue them.
- Fixes selection of a cell within a group of selected cells
