### PR TITLE
LibCoredump: Fix backtraces

### DIFF
--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -19,7 +19,7 @@ namespace Coredump {
 
 ELFObjectInfo const* Backtrace::object_info_for_region(MemoryRegionInfo const& region)
 {
-    auto path = region.object_name();
+    String path = region.object_name();
     if (!path.starts_with('/') && Core::File::looks_like_shared_library(path))
         path = LexicalPath::join("/usr/lib", path).string();
 

--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -117,8 +117,10 @@ void Backtrace::add_entry(const Reader& coredump, FlatPtr ip)
     // in the object file.
     auto region = coredump.first_region_for_object(object_name);
     auto object_info = object_info_for_region(*region);
-    if (!object_info)
+    if (!object_info) {
+        m_entries.append({ ip, object_name, {}, {} });
         return;
+    }
 
     auto function_name = object_info->debug_info->elf().symbolicate(ip - region->region_start);
     auto source_position = object_info->debug_info->get_source_position_with_inlines(ip - region->region_start);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/42967349/152585860-97cc4595-b271-4585-9544-c19635888dec.png)

**LibCoredump: Fix use-after-free in Backtrace::object_info_for_region()**
The first line was creating a StringView object with region name. Then,
if the path didn't start with '/', it had assigned a String made from a
temporary LexicalPath join result.

This fixes the bug that only main executable's frames were displayed.

**LibCoredump: Add stack frame entry even if there is no object info**
We know the object name and are able to include it. Function name and
source position are still unknown and will just be displayed as "??? ()"