### PR TITLE
LibJS: Fix some memory tracking issues

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -17,6 +17,7 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibJS/Forward.h>
+#include <LibJS/Heap/Handle.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/EnvironmentCoordinate.h>
 #include <LibJS/Runtime/FunctionKind.h>
@@ -1225,7 +1226,7 @@ public:
 
     struct ClassFieldDefinition {
         ClassElementName name;
-        ECMAScriptFunctionObject* initializer { nullptr };
+        Handle<ECMAScriptFunctionObject> initializer;
     };
 
     // We use the Completion also as a ClassStaticBlockDefinition Record.

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -24,18 +24,9 @@ public:
     bool is_marked() const { return m_mark; }
     void set_marked(bool b) { m_mark = b; }
 
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    virtual void did_become_zombie()
-    {
-    }
-#endif
-
     enum class State {
         Live,
         Dead,
-#ifdef JS_TRACK_ZOMBIE_CELLS
-        Zombie,
-#endif
     };
 
     State state() const { return m_state; }

--- a/Userland/Libraries/LibJS/Heap/Heap.h
+++ b/Userland/Libraries/LibJS/Heap/Heap.h
@@ -63,13 +63,6 @@ public:
     bool should_collect_on_every_allocation() const { return m_should_collect_on_every_allocation; }
     void set_should_collect_on_every_allocation(bool b) { m_should_collect_on_every_allocation = b; }
 
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    void set_zombify_dead_cells(bool b)
-    {
-        m_zombify_dead_cells = b;
-    }
-#endif
-
     void did_create_handle(Badge<HandleImpl>, HandleImpl&);
     void did_destroy_handle(Badge<HandleImpl>, HandleImpl&);
 
@@ -132,10 +125,6 @@ private:
     bool m_should_gc_when_deferral_ends { false };
 
     bool m_collecting_garbage { false };
-
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    bool m_zombify_dead_cells { false };
-#endif
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
@@ -35,13 +35,6 @@ public:
 private:
     virtual void visit_edges(Visitor& visitor) override;
 
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    virtual void did_become_zombie() override
-    {
-        deregister();
-    }
-#endif
-
     FunctionObject* m_cleanup_callback { nullptr };
 
     struct FinalizationRecord {

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.cpp
@@ -13,6 +13,13 @@
 
 namespace JS {
 
+void PromiseValueList::visit_edges(Visitor& visitor)
+{
+    Cell::visit_edges(visitor);
+    for (auto& val : m_values)
+        visitor.visit(val);
+}
+
 PromiseResolvingElementFunction::PromiseResolvingElementFunction(size_t index, PromiseValueList& values, PromiseCapability capability, RemainingElements& remaining_elements, Object& prototype)
     : NativeFunction(prototype)
     , m_index(index)

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -35,6 +35,7 @@ public:
 
 private:
     virtual const char* class_name() const override { return "PromiseValueList"; }
+    virtual void visit_edges(Visitor&) override;
 
     Vector<Value> m_values;
 };

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -247,11 +247,4 @@ FLATTEN void Shape::add_property_without_transition(PropertyKey const& property_
     add_property_without_transition(property_name.to_string_or_symbol(), attributes);
 }
 
-#ifdef JS_TRACK_ZOMBIE_CELLS
-void Shape::did_become_zombie()
-{
-    revoke_weak_ptrs();
-}
-#endif
-
 }

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -89,10 +89,6 @@ private:
     virtual const char* class_name() const override { return "Shape"; }
     virtual void visit_edges(Visitor&) override;
 
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    virtual void did_become_zombie() override;
-#endif
-
     Shape* get_or_prune_cached_forward_transition(TransitionKey const&);
     Shape* get_or_prune_cached_prototype_transition(Object* prototype);
 

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -989,7 +989,7 @@ void VM::finish_dynamic_import(ScriptOrModule referencing_script_or_module, Modu
     dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] finish_dynamic_import on {}", module_request.module_specifier);
 
     // 1. Let fulfilledClosure be a new Abstract Closure with parameters (result) that captures referencingScriptOrModule, specifier, and promiseCapability and performs the following steps when called:
-    auto fulfilled_closure = [referencing_script_or_module, module_request = move(module_request), promise_capability](VM& vm, GlobalObject& global_object) -> ThrowCompletionOr<Value> {
+    auto fulfilled_closure = [referencing_script_or_module, module_request = move(module_request), resolve_function = make_handle(promise_capability.resolve), reject_function = make_handle(promise_capability.reject)](VM& vm, GlobalObject& global_object) -> ThrowCompletionOr<Value> {
         auto result = vm.argument(0);
         // a. Assert: result is undefined.
         VERIFY(result.is_undefined());
@@ -1006,12 +1006,12 @@ void VM::finish_dynamic_import(ScriptOrModule referencing_script_or_module, Modu
         // e. If namespace is an abrupt completion, then
         if (namespace_.is_throw_completion()) {
             // i. Perform ! Call(promiseCapability.[[Reject]], undefined, « namespace.[[Value]] »).
-            MUST(call(global_object, promise_capability.reject, js_undefined(), *namespace_.throw_completion().value()));
+            MUST(call(global_object, reject_function.cell(), js_undefined(), *namespace_.throw_completion().value()));
         }
         // f. Else,
         else {
             // i. Perform ! Call(promiseCapability.[[Resolve]], undefined, « namespace.[[Value]] »).
-            MUST(call(global_object, promise_capability.resolve, js_undefined(), namespace_.release_value()));
+            MUST(call(global_object, resolve_function.cell(), js_undefined(), namespace_.release_value()));
         }
         // g. Return undefined.
         return js_undefined();
@@ -1021,10 +1021,10 @@ void VM::finish_dynamic_import(ScriptOrModule referencing_script_or_module, Modu
     auto* on_fulfilled = NativeFunction::create(current_realm()->global_object(), "", move(fulfilled_closure));
 
     // 3. Let rejectedClosure be a new Abstract Closure with parameters (error) that captures promiseCapability and performs the following steps when called:
-    auto rejected_closure = [promise_capability](VM& vm, GlobalObject& global_object) -> ThrowCompletionOr<Value> {
+    auto rejected_closure = [rejected_function = make_handle(promise_capability.reject)](VM& vm, GlobalObject& global_object) -> ThrowCompletionOr<Value> {
         auto error = vm.argument(0);
         // a. Perform ! Call(promiseCapability.[[Reject]], undefined, « error »).
-        MUST(call(global_object, promise_capability.reject, js_undefined(), error));
+        MUST(call(global_object, rejected_function.cell(), js_undefined(), error));
         // b. Return undefined.
         return js_undefined();
     };

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -766,10 +766,9 @@ ThrowCompletionOr<void> VM::link_and_eval_module(Module& module)
 
     if (module_or_end.is_end()) {
         dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] Warning introducing module via link_and_eval_module {}", module.filename());
-        if (m_loaded_modules.size() > 0) {
-            dbgln("Using link_and_eval module as entry point is not allowed if it is not the first module!");
-            VERIFY_NOT_REACHED();
-        }
+        if (m_loaded_modules.size() > 0)
+            dbgln("Warning: Using multiple modules as entry point can lead to unexpected results");
+
         m_loaded_modules.empend(
             &module,
             module.filename(),

--- a/Userland/Libraries/LibJS/Runtime/WeakMap.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMap.h
@@ -30,13 +30,6 @@ public:
     virtual void remove_dead_cells(Badge<Heap>) override;
 
 private:
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    virtual void did_become_zombie() override
-    {
-        deregister();
-    }
-#endif
-
     void visit_edges(Visitor&) override;
 
     HashMap<Cell*, Value> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.h
@@ -32,13 +32,6 @@ public:
 private:
     virtual void visit_edges(Visitor&) override;
 
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    virtual void did_become_zombie() override
-    {
-        deregister();
-    }
-#endif
-
     Object* m_value { nullptr };
     u32 m_last_execution_generation { 0 };
 };

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.h
@@ -30,13 +30,6 @@ public:
     virtual void remove_dead_cells(Badge<Heap>) override;
 
 private:
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    virtual void did_become_zombie() override
-    {
-        deregister();
-    }
-#endif
-
     HashTable<Cell*> m_values; // This stores Cell pointers instead of Object pointers to aide with sweeping
 };
 

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -116,9 +116,6 @@ static consteval size_t __testjs_last()
 static constexpr auto TOP_LEVEL_TEST_NAME = "__$$TOP_LEVEL$$__";
 extern RefPtr<JS::VM> g_vm;
 extern bool g_collect_on_every_allocation;
-#ifdef JS_TRACK_ZOMBIE_CELLS
-extern bool g_zombify_dead_cells;
-#endif
 extern bool g_run_bytecode;
 extern String g_currently_running_test;
 struct FunctionWithLength {
@@ -290,10 +287,6 @@ inline JSFileResult TestRunner::run_file_test(const String& test_path)
     JS::VM::InterpreterExecutionScope scope(*interpreter);
 
     interpreter->heap().set_should_collect_on_every_allocation(g_collect_on_every_allocation);
-
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    interpreter->heap().set_zombify_dead_cells(g_zombify_dead_cells);
-#endif
 
     if (g_run_file) {
         auto result = g_run_file(test_path, *interpreter);

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -19,9 +19,6 @@ namespace JS {
 
 RefPtr<::JS::VM> g_vm;
 bool g_collect_on_every_allocation = false;
-#ifdef JS_TRACK_ZOMBIE_CELLS
-bool g_zombify_dead_cells = false;
-#endif
 bool g_run_bytecode = false;
 String g_currently_running_test;
 HashMap<String, FunctionWithLength> s_exposed_global_functions;
@@ -112,9 +109,6 @@ int main(int argc, char** argv)
     });
     args_parser.add_option(print_json, "Show results as JSON", "json", 'j');
     args_parser.add_option(g_collect_on_every_allocation, "Collect garbage after every allocation", "collect-often", 'g');
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    args_parser.add_option(g_zombify_dead_cells, "Zombify dead cells (to catch missing GC marks)", "zombify-dead-cells", 'z');
-#endif
     args_parser.add_option(g_run_bytecode, "Use the bytecode interpreter", "run-bytecode", 'b');
     args_parser.add_option(JS::Bytecode::g_dump_bytecode, "Dump the bytecode", "dump-bytecode", 'd');
     args_parser.add_option(test_glob, "Only run tests matching the given glob", "filter", 'f', "glob");

--- a/Userland/Libraries/LibWeb/Bindings/Wrapper.h
+++ b/Userland/Libraries/LibWeb/Bindings/Wrapper.h
@@ -24,13 +24,6 @@ protected:
         : Object(prototype)
     {
     }
-
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    virtual void did_become_zombie() override
-    {
-        revoke_weak_ptrs();
-    }
-#endif
 };
 
 }

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1370,10 +1370,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(s_strip_ansi, "Disable ANSI colors", "disable-ansi-colors", 'c');
     args_parser.add_option(s_disable_source_location_hints, "Disable source location hints", "disable-source-location-hints", 'h');
     args_parser.add_option(gc_on_every_allocation, "GC on every allocation", "gc-on-every-allocation", 'g');
-#ifdef JS_TRACK_ZOMBIE_CELLS
-    bool zombify_dead_cells = false;
-    args_parser.add_option(zombify_dead_cells, "Zombify dead cells (to catch missing GC marks)", "zombify-dead-cells", 'z');
-#endif
     args_parser.add_option(disable_syntax_highlight, "Disable live syntax highlighting", "no-syntax-highlight", 's');
     args_parser.add_positional_argument(script_paths, "Path to script files", "scripts", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
@@ -1416,9 +1412,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         ReplConsoleClient console_client(interpreter->global_object().console());
         interpreter->global_object().console().set_client(console_client);
         interpreter->heap().set_should_collect_on_every_allocation(gc_on_every_allocation);
-#ifdef JS_TRACK_ZOMBIE_CELLS
-        interpreter->heap().set_zombify_dead_cells(zombify_dead_cells);
-#endif
 
         auto& global_environment = interpreter->realm().global_environment();
 
@@ -1630,9 +1623,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         ReplConsoleClient console_client(interpreter->global_object().console());
         interpreter->global_object().console().set_client(console_client);
         interpreter->heap().set_should_collect_on_every_allocation(gc_on_every_allocation);
-#ifdef JS_TRACK_ZOMBIE_CELLS
-        interpreter->heap().set_zombify_dead_cells(zombify_dead_cells);
-#endif
 
         signal(SIGINT, [](int) {
             sigint_handler();


### PR DESCRIPTION
`test-js -g` now works again! :tada:
Just for reference it takes about ~100 times as much time as the normal `test-js` on serenity.
So although it is a good test we probably still don't want it in CI.

Also remove crashing for modules in the REPL and remove the somewhat bitrotted JS_TRACK_ZOMBIE_CELLS option.