### PR TITLE
LibGUI: Allow navigating back/forward using side mouse buttons

### DIFF
--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -136,9 +136,9 @@ void Application::unregister_global_shortcut_action(Badge<Action>, Action& actio
     m_global_shortcut_actions.remove(action.alternate_shortcut());
 }
 
-Action* Application::action_for_key_event(KeyEvent const& event)
+Action* Application::action_for_shortcut(Shortcut const& shortcut) const
 {
-    auto it = m_global_shortcut_actions.find(Shortcut(event.modifiers(), (KeyCode)event.key()));
+    auto it = m_global_shortcut_actions.find(shortcut);
     if (it == m_global_shortcut_actions.end())
         return nullptr;
     return (*it).value;

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -33,7 +33,7 @@ public:
     int exec();
     void quit(int = 0);
 
-    Action* action_for_key_event(KeyEvent const&);
+    Action* action_for_shortcut(Shortcut const&) const;
 
     void register_global_shortcut_action(Badge<Action>, Action&);
     void unregister_global_shortcut_action(Badge<Action>, Action&);

--- a/Userland/Libraries/LibGUI/CommonActions.cpp
+++ b/Userland/Libraries/LibGUI/CommonActions.cpp
@@ -120,14 +120,14 @@ NonnullRefPtr<Action> make_help_action(Function<void(Action&)> callback, Core::O
 
 NonnullRefPtr<Action> make_go_back_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("Go &Back", { Mod_Alt, Key_Left }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-back.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("Go &Back", { Mod_Alt, Key_Left }, { MouseButton::Backward }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-back.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Move one step backward in history");
     return action;
 }
 
 NonnullRefPtr<Action> make_go_forward_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("Go &Forward", { Mod_Alt, Key_Right }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-forward.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("Go &Forward", { Mod_Alt, Key_Right }, { MouseButton::Forward }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-forward.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Move one step forward in history");
     return action;
 }

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -546,4 +546,24 @@ private:
     NonnullRefPtr<Action> m_action;
 };
 
+inline StringView mouse_button_to_string(MouseButton key)
+{
+    switch (key) {
+    case MouseButton::None:
+        return "None";
+    case MouseButton::Primary:
+        return "Primary";
+    case MouseButton::Secondary:
+        return "Secondary";
+    case MouseButton::Middle:
+        return "Middle";
+    case MouseButton::Backward:
+        return "Backward";
+    case MouseButton::Forward:
+        return "Forward";
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 }

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -60,6 +60,7 @@ class ResizeEvent;
 class ScreenRectsChangeEvent;
 class Scrollbar;
 class AbstractScrollableWidget;
+class Shortcut;
 class Slider;
 class SortingProxyModel;
 class SpinBox;

--- a/Userland/Libraries/LibGUI/Shortcut.cpp
+++ b/Userland/Libraries/LibGUI/Shortcut.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Geordie Hall <me@geordiehall.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -24,10 +25,17 @@ String Shortcut::to_string() const
     if (m_modifiers & Mod_Super)
         parts.append("Super");
 
-    if (auto* key_name = key_code_to_string(m_key))
-        parts.append(key_name);
-    else
-        parts.append("(Invalid)");
+    if (m_type == Type::Keyboard) {
+        if (auto* key_name = key_code_to_string(m_keyboard_key))
+            parts.append(key_name);
+        else
+            parts.append("(Invalid)");
+    } else {
+        if (m_mouse_button != MouseButton::None)
+            parts.append(String::formatted("Mouse {}", mouse_button_to_string(m_mouse_button)));
+        else
+            parts.append("(Invalid)");
+    }
 
     StringBuilder builder;
     builder.join('+', parts);

--- a/Userland/Libraries/LibGUI/Shortcut.h
+++ b/Userland/Libraries/LibGUI/Shortcut.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Geordie Hall <me@geordiehall.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,7 @@
 
 #include <AK/Traits.h>
 #include <Kernel/API/KeyCode.h>
+#include <LibGUI/Event.h>
 
 namespace GUI {
 
@@ -15,30 +17,62 @@ class Shortcut {
 public:
     Shortcut() = default;
     Shortcut(u8 modifiers, KeyCode key)
-        : m_modifiers(modifiers)
-        , m_key(key)
+        : m_type(Type::Keyboard)
+        , m_modifiers(modifiers)
+        , m_keyboard_key(key)
     {
     }
     Shortcut(KeyCode key)
-        : m_modifiers(0)
-        , m_key(key)
+        : m_type(Type::Keyboard)
+        , m_modifiers(0)
+        , m_keyboard_key(key)
+    {
+    }
+    Shortcut(u8 modifiers, MouseButton button)
+        : m_type(Type::Mouse)
+        , m_modifiers(modifiers)
+        , m_mouse_button(button)
+    {
+    }
+    Shortcut(MouseButton button)
+        : m_type(Type::Mouse)
+        , m_modifiers(0)
+        , m_mouse_button(button)
     {
     }
 
-    bool is_valid() const { return m_key != KeyCode::Key_Invalid; }
-    u8 modifiers() const { return m_modifiers; }
-    KeyCode key() const { return m_key; }
+    enum class Type : u8 {
+        Keyboard,
+        Mouse,
+    };
+
     String to_string() const;
+    Type type() const { return m_type; }
+    bool is_valid() const { return m_type == Type::Keyboard ? (m_keyboard_key != Key_Invalid) : (m_mouse_button != MouseButton::None); }
+    u8 modifiers() const { return m_modifiers; }
+
+    KeyCode key() const
+    {
+        VERIFY(m_type == Type::Keyboard);
+        return m_keyboard_key;
+    }
+
+    MouseButton mouse_button() const
+    {
+        VERIFY(m_type == Type::Mouse);
+        return m_mouse_button;
+    }
 
     bool operator==(Shortcut const& other) const
     {
-        return m_modifiers == other.m_modifiers
-            && m_key == other.m_key;
+        return m_modifiers == other.m_modifiers && m_type == other.m_type && m_keyboard_key == other.m_keyboard_key && m_mouse_button == other.m_mouse_button;
     }
 
 private:
+    Type m_type { Type::Keyboard };
     u8 m_modifiers { 0 };
-    KeyCode m_key { KeyCode::Key_Invalid };
+    KeyCode m_keyboard_key { KeyCode::Key_Invalid };
+    MouseButton m_mouse_button { MouseButton::None };
 };
 
 }
@@ -49,7 +83,12 @@ template<>
 struct Traits<GUI::Shortcut> : public GenericTraits<GUI::Shortcut> {
     static unsigned hash(const GUI::Shortcut& shortcut)
     {
-        return pair_int_hash(shortcut.modifiers(), shortcut.key());
+        auto base_hash = pair_int_hash(shortcut.modifiers(), (u32)shortcut.type());
+        if (shortcut.type() == GUI::Shortcut::Type::Keyboard) {
+            return pair_int_hash(base_hash, shortcut.key());
+        } else {
+            return pair_int_hash(base_hash, shortcut.mouse_button());
+        }
     }
 };
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -904,14 +904,8 @@ bool Widget::is_backmost() const
     return &parent->children().first() == this;
 }
 
-Action* Widget::action_for_key_event(KeyEvent const& event)
+Action* Widget::action_for_shortcut(Shortcut const& shortcut)
 {
-    Shortcut shortcut(event.modifiers(), (KeyCode)event.key());
-
-    if (!shortcut.is_valid()) {
-        return nullptr;
-    }
-
     Action* found_action = nullptr;
     for_each_child_of_type<Action>([&](auto& action) {
         if (action.shortcut() == shortcut || action.alternate_shortcut() == shortcut) {

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -259,7 +259,7 @@ public:
     bool is_frontmost() const;
     bool is_backmost() const;
 
-    Action* action_for_key_event(KeyEvent const&);
+    Action* action_for_shortcut(Shortcut const&);
 
     template<typename Callback>
     void for_each_child_widget(Callback callback)

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -1090,9 +1090,8 @@ void Window::notify_state_changed(Badge<ConnectionToWindowServer>, bool minimize
     }
 }
 
-Action* Window::action_for_key_event(KeyEvent const& event)
+Action* Window::action_for_shortcut(Shortcut const& shortcut)
 {
-    Shortcut shortcut(event.modifiers(), (KeyCode)event.key());
     Action* found_action = nullptr;
     for_each_child_of_type<Action>([&](auto& action) {
         if (action.shortcut() == shortcut || action.alternate_shortcut() == shortcut) {

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -196,7 +196,7 @@ public:
 
     virtual bool is_visible_for_timer_purposes() const override { return m_visible_for_timer_purposes; }
 
-    Action* action_for_key_event(KeyEvent const&);
+    Action* action_for_shortcut(Shortcut const&);
 
     void did_add_widget(Badge<Widget>, Widget&);
     void did_remove_widget(Badge<Widget>, Widget&);


### PR DESCRIPTION
`Shortcut`s can now have mouse bindings, and the `CommonActions`' back and forward actions now have the side mouse buttons as alternate shortcuts. This means you can press "back" on your mouse and have FileManager/Browser etc. actually go back.

The `WindowServerConnection` will now consume any mouse-down events that match an action's shortcut, using the same action resolution logic as for key-down events. To avoid duplicating the `action_for_key_event` search code in `Widget`/`Window`/`Application` for mouse events, I made them take a `Shortcut` to search for instead (given they each constructed one internally from the `KeyEvent` anyway).

I suspect binding mouse shortcuts will probably be fairly rare (maybe only side buttons?), so wasn't entirely sure on the best design. I went with just adding an extra "mouse binding" field to the existing `Shortcut` class, since figured subclassing into keyboard/mouse shortcut classes wouldn't really improve much (and wouldn't allow for constructing as easily). It does mean callers need to be a bit careful before calling `.key()` etc. without first checking the type, but with subclasses you'd need to do that before casting anyway.

We search for shortcuts bound to the primary/secondary mouse buttons too, so if we decide those should never be bindable then could save some cycles. Similarly, I noticed that the modifier keys generate shortcut searches with them as both the key and modifier (`Ctrl+Ctrl`), which could be worth ignoring if we decide it's a non-sensical binding.

--

Although I've been watching Andreas' videos for quite a while now, this is my first time contributing, so please let me know if you'd like me to make any changes. Hopefully this wasn't too big a change to tackle as my first PR!

Cheers :^)