### PR TITLE
Shell: Use strncmp() instead of string.compare() for name completions

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1453,7 +1453,12 @@ Vector<Line::CompletionSuggestion> Shell::complete_program_name(StringView name,
         cached_path.span(),
         name,
         nullptr,
-        [](auto& name, auto& program) { return name.compare(program.view()); });
+        [](auto& name, auto& program) {
+            return strncmp(
+                name.characters_without_null_termination(),
+                program.characters(),
+                name.length());
+        });
 
     if (!match)
         return complete_path("", name, offset, ExecutableOnly::Yes);


### PR DESCRIPTION
The "at most n bytes" behaviour of strncmp is required for this logic to
work, this was overlooked in 5b64abe when converting Strings to
StringViews, which lead to broken autocomplete.