### PR TITLE
LibRegex: Do not continue searching input when the sticky bit is set

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.match.js
@@ -70,3 +70,11 @@ test("escaped code points", () => {
     expect(string.match(re).groups.𝓑𝓻𝓸𝔀𝓷).toBe("brown");
     expect(string.match(re).groups.𝓑𝓻𝓸𝔀𝓷).toBe("brown");
 });
+
+test("sticky and global flag set", () => {
+    const string = "aaba";
+    expect(string.match(/a/)).toEqual(["a"]);
+    expect(string.match(/a/y)).toEqual(["a"]);
+    expect(string.match(/a/g)).toEqual(["a", "a", "a"]);
+    expect(string.match(/a/gy)).toEqual(["a", "a"]);
+});

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -180,6 +180,8 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
 #endif
 
     bool continue_search = input.regex_options.has_flag_set(AllFlags::Global) || input.regex_options.has_flag_set(AllFlags::Multiline);
+    if (input.regex_options.has_flag_set(AllFlags::Sticky))
+        continue_search = false;
 
     auto single_match_only = input.regex_options.has_flag_set(AllFlags::SingleMatch);
 
@@ -280,7 +282,11 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
                         break;
                     continue;
                 }
-                if (state.string_position < view_length && !input.regex_options.has_flag_set(AllFlags::Internal_Stateful)) {
+                if (input.regex_options.has_flag_set(AllFlags::Internal_Stateful)) {
+                    append_match(input, state, view_index);
+                    break;
+                }
+                if (state.string_position < view_length) {
                     return { false, 0, {}, {}, {}, operations };
                 }
 

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -216,14 +216,12 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
 
             auto success = execute(input, state, temp_operations);
             // This success is acceptable only if it doesn't read anything from the input (input length is 0).
-            if (state.string_position <= view_index) {
-                if (success.has_value() && success.value()) {
-                    operations = temp_operations;
-                    if (!match_count) {
-                        // Nothing was *actually* matched, so append an empty match.
-                        append_match(input, state, view_index);
-                        ++match_count;
-                    }
+            if (success && (state.string_position <= view_index)) {
+                operations = temp_operations;
+                if (!match_count) {
+                    // Nothing was *actually* matched, so append an empty match.
+                    append_match(input, state, view_index);
+                    ++match_count;
                 }
             }
         }
@@ -251,10 +249,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
             state.repetition_marks.clear();
 
             auto success = execute(input, state, operations);
-            if (!success.has_value())
-                return { false, 0, {}, {}, {}, operations };
-
-            if (success.value()) {
+            if (success) {
                 succeeded = true;
 
                 if (input.regex_options.has_flag_set(AllFlags::MatchNotEndOfLine) && state.string_position == input.view.length()) {
@@ -417,7 +412,7 @@ private:
 };
 
 template<class Parser>
-Optional<bool> Matcher<Parser>::execute(MatchInput const& input, MatchState& state, size_t& operations) const
+bool Matcher<Parser>::execute(MatchInput const& input, MatchState& state, size_t& operations) const
 {
     BumpAllocatedLinkedList<MatchState> states_to_try_next;
     size_t recursion_level = 0;

--- a/Userland/Libraries/LibRegex/RegexMatcher.h
+++ b/Userland/Libraries/LibRegex/RegexMatcher.h
@@ -74,7 +74,7 @@ public:
     }
 
 private:
-    Optional<bool> execute(MatchInput const& input, MatchState& state, size_t& operations) const;
+    bool execute(MatchInput const& input, MatchState& state, size_t& operations) const;
 
     Regex<Parser> const* m_pattern;
     typename ParserTraits<Parser>::OptionsType const m_regex_options;


### PR DESCRIPTION
This partially reverts commit a962ee020a6310b2d7c7479aa058c15484127418.

When the sticky bit is set, the global bit should basically be ignored
except by external callers who want their own special behavior. For
example, RegExp.prototype [ @@match ] will use the global flag to
accumulate consecutive matches. But on the first failure, the regex
loop should break.