### PR TITLE
LibJS: Implement `BigInt.asIntN` and `BigInt.asUintN`

### DIFF
--- a/Tests/LibCrypto/TestBigInteger.cpp
+++ b/Tests/LibCrypto/TestBigInteger.cpp
@@ -642,3 +642,19 @@ TEST_CASE(test_signed_multiplication_with_two_big_numbers)
     EXPECT_EQ(result.unsigned_value().words(), expected_results);
     EXPECT(result.is_negative());
 }
+
+TEST_CASE(test_negative_zero_is_not_allowed)
+{
+    Crypto::SignedBigInteger zero(Crypto::UnsignedBigInteger(0), true);
+    EXPECT(!zero.is_negative());
+
+    zero.negate();
+    EXPECT(!zero.is_negative());
+
+    Crypto::SignedBigInteger positive_five(Crypto::UnsignedBigInteger(5), false);
+    Crypto::SignedBigInteger negative_five(Crypto::UnsignedBigInteger(5), true);
+    zero = positive_five.plus(negative_five);
+
+    EXPECT(zero.unsigned_value().is_zero());
+    EXPECT(!zero.is_negative());
+}

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -25,6 +25,7 @@ public:
         : m_sign(sign)
         , m_unsigned_data(move(unsigned_data))
     {
+        ensure_sign_is_valid();
     }
 
     explicit SignedBigInteger(UnsignedBigInteger unsigned_data)
@@ -72,9 +73,18 @@ public:
     const Vector<u32, STARTING_WORD_SIZE> words() const { return m_unsigned_data.words(); }
     bool is_negative() const { return m_sign; }
 
-    void negate() { m_sign = !m_sign; }
+    void negate()
+    {
+        if (!m_unsigned_data.is_zero())
+            m_sign = !m_sign;
+    }
 
-    void set_to_0() { m_unsigned_data.set_to_0(); }
+    void set_to_0()
+    {
+        m_unsigned_data.set_to_0();
+        m_sign = false;
+    }
+
     void set_to(i32 other)
     {
         m_unsigned_data.set_to((u32)other);
@@ -129,6 +139,12 @@ public:
     bool operator>(const UnsignedBigInteger& other) const;
 
 private:
+    void ensure_sign_is_valid()
+    {
+        if (m_sign && m_unsigned_data.is_zero())
+            m_sign = false;
+    }
+
     bool m_sign { false };
     UnsignedBigInteger m_unsigned_data;
 };

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -145,6 +145,16 @@ void UnsignedBigInteger::set_to(const UnsignedBigInteger& other)
     m_cached_hash = 0;
 }
 
+bool UnsignedBigInteger::is_zero() const
+{
+    for (size_t i = 0; i < length(); ++i) {
+        if (m_words[i] != 0)
+            return false;
+    }
+
+    return true;
+}
+
 size_t UnsignedBigInteger::trimmed_length() const
 {
     if (!m_cached_trimmed_length.has_value()) {

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -72,6 +72,7 @@ public:
         m_cached_hash = 0;
     }
 
+    bool is_zero() const;
     bool is_odd() const { return m_words.size() && (m_words[0] & 1); }
     bool is_invalid() const { return m_is_invalid; }
 

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -32,7 +32,7 @@ void BigIntConstructor::initialize(GlobalObject& global_object)
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.asIntN, as_int_n, 2, attr);
-    // define_native_function(vm.names.asUintN, as_uint_n, 2, attr);
+    define_native_function(vm.names.asUintN, as_uint_n, 2, attr);
 
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
@@ -95,7 +95,16 @@ JS_DEFINE_NATIVE_FUNCTION(BigIntConstructor::as_int_n)
 // 21.2.2.2 BigInt.asUintN ( bits, bigint ), https://tc39.es/ecma262/#sec-bigint.asuintn
 JS_DEFINE_NATIVE_FUNCTION(BigIntConstructor::as_uint_n)
 {
-    TODO();
+    // 1. Set bits to ? ToIndex(bits).
+    auto bits = TRY(vm.argument(0).to_index(global_object));
+
+    // 2. Set bigint to ? ToBigInt(bigint).
+    auto* bigint = TRY(vm.argument(1).to_bigint(global_object));
+
+    // 3. Return the BigInt value that represents ℝ(bigint) modulo 2bits.
+    // FIXME: For large values of `bits`, this can likely be improved with a SignedBigInteger API to
+    //        drop the most significant bits.
+    return js_bigint(vm, modulo(bigint->big_integer(), BIGINT_ONE.shift_left(bits)));
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/String.h>
+#include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/BigInt.h>
 #include <LibJS/Runtime/BigIntConstructor.h>
 #include <LibJS/Runtime/BigIntObject.h>
@@ -13,6 +14,8 @@
 #include <LibJS/Runtime/VM.h>
 
 namespace JS {
+
+static const Crypto::SignedBigInteger BIGINT_ONE { 1 };
 
 BigIntConstructor::BigIntConstructor(GlobalObject& global_object)
     : NativeFunction(vm().names.BigInt.as_string(), *global_object.function_prototype())
@@ -27,9 +30,8 @@ void BigIntConstructor::initialize(GlobalObject& global_object)
     // 21.2.2.3 BigInt.prototype, https://tc39.es/ecma262/#sec-bigint.prototype
     define_direct_property(vm.names.prototype, global_object.bigint_prototype(), 0);
 
-    // TODO: Implement these functions below and uncomment this.
-    // u8 attr = Attribute::Writable | Attribute::Configurable;
-    // define_native_function(vm.names.asIntN, as_int_n, 2, attr);
+    u8 attr = Attribute::Writable | Attribute::Configurable;
+    define_native_function(vm.names.asIntN, as_int_n, 2, attr);
     // define_native_function(vm.names.asUintN, as_uint_n, 2, attr);
 
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
@@ -67,7 +69,27 @@ ThrowCompletionOr<Object*> BigIntConstructor::construct(FunctionObject&)
 // 21.2.2.1 BigInt.asIntN ( bits, bigint ), https://tc39.es/ecma262/#sec-bigint.asintn
 JS_DEFINE_NATIVE_FUNCTION(BigIntConstructor::as_int_n)
 {
-    TODO();
+    // 1. Set bits to ? ToIndex(bits).
+    auto bits = TRY(vm.argument(0).to_index(global_object));
+
+    // 2. Set bigint to ? ToBigInt(bigint).
+    auto* bigint = TRY(vm.argument(1).to_bigint(global_object));
+
+    // 3. Let mod be ℝ(bigint) modulo 2^bits.
+    // FIXME: For large values of `bits`, this can likely be improved with a SignedBigInteger API to
+    //        drop the most significant bits.
+    auto bits_shift_left = BIGINT_ONE.shift_left(bits);
+    auto mod = modulo(bigint->big_integer(), bits_shift_left);
+
+    // 4. If mod ≥ 2^(bits-1), return ℤ(mod - 2^bits); otherwise, return ℤ(mod).
+    // NOTE: Some of the below conditionals are non-standard, but are to protect SignedBigInteger from
+    //       allocating an absurd amount of memory if `bits - 1` overflows to NumericLimits<size_t>::max.
+    if ((bits == 0) && (mod >= BIGINT_ONE))
+        return js_bigint(vm, mod.minus(bits_shift_left));
+    if ((bits > 0) && (mod >= BIGINT_ONE.shift_left(bits - 1)))
+        return js_bigint(vm, mod.minus(bits_shift_left));
+
+    return js_bigint(vm, mod);
 }
 
 // 21.2.2.2 BigInt.asUintN ( bits, bigint ), https://tc39.es/ecma262/#sec-bigint.asuintn

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asIntN.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asIntN.js
@@ -1,0 +1,79 @@
+describe("errors", () => {
+    test("invalid index", () => {
+        expect(() => {
+            BigInt.asIntN(-1, 0n);
+        }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+
+        expect(() => {
+            BigInt.asIntN(Symbol(), 0n);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+    });
+
+    test("invalid BigInt", () => {
+        expect(() => {
+            BigInt.asIntN(1, 1);
+        }).toThrowWithMessage(TypeError, "Cannot convert number to BigInt");
+
+        expect(() => {
+            BigInt.asIntN(1, Symbol());
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to BigInt");
+
+        expect(() => {
+            BigInt.asIntN(1, "foo");
+        }).toThrowWithMessage(SyntaxError, "Invalid value for BigInt: foo");
+    });
+});
+
+describe("correct behavior", () => {
+    test("length is 2", () => {
+        expect(BigInt.asIntN).toHaveLength(2);
+    });
+
+    test("basic functionality", () => {
+        expect(BigInt.asIntN(0, -2n)).toBe(0n);
+        expect(BigInt.asIntN(0, -1n)).toBe(0n);
+        expect(BigInt.asIntN(0, 0n)).toBe(0n);
+        expect(BigInt.asIntN(0, 1n)).toBe(0n);
+        expect(BigInt.asIntN(0, 2n)).toBe(0n);
+
+        expect(BigInt.asIntN(1, -3n)).toBe(-1n);
+        expect(BigInt.asIntN(1, -2n)).toBe(0n);
+        expect(BigInt.asIntN(1, -1n)).toBe(-1n);
+        expect(BigInt.asIntN(1, 0n)).toBe(0n);
+        expect(BigInt.asIntN(1, 1n)).toBe(-1n);
+        expect(BigInt.asIntN(1, 2n)).toBe(0n);
+        expect(BigInt.asIntN(1, 3n)).toBe(-1n);
+
+        expect(BigInt.asIntN(2, -3n)).toBe(1n);
+        expect(BigInt.asIntN(2, -2n)).toBe(-2n);
+        expect(BigInt.asIntN(2, -1n)).toBe(-1n);
+        expect(BigInt.asIntN(2, 0n)).toBe(0n);
+        expect(BigInt.asIntN(2, 1n)).toBe(1n);
+        expect(BigInt.asIntN(2, 2n)).toBe(-2n);
+        expect(BigInt.asIntN(2, 3n)).toBe(-1n);
+
+        expect(BigInt.asIntN(4, -3n)).toBe(-3n);
+        expect(BigInt.asIntN(4, -2n)).toBe(-2n);
+        expect(BigInt.asIntN(4, -1n)).toBe(-1n);
+        expect(BigInt.asIntN(4, 0n)).toBe(0n);
+        expect(BigInt.asIntN(4, 1n)).toBe(1n);
+        expect(BigInt.asIntN(4, 2n)).toBe(2n);
+        expect(BigInt.asIntN(4, 3n)).toBe(3n);
+
+        const extremelyBigInt = 123456789123456789123456789123456789123456789123456789n;
+
+        expect(BigInt.asIntN(0, extremelyBigInt)).toBe(0n);
+        expect(BigInt.asIntN(1, extremelyBigInt)).toBe(-1n);
+        expect(BigInt.asIntN(2, extremelyBigInt)).toBe(1n);
+        expect(BigInt.asIntN(4, extremelyBigInt)).toBe(5n);
+        expect(BigInt.asIntN(128, extremelyBigInt)).toBe(-99061374399389259395070030194384019691n);
+        expect(BigInt.asIntN(256, extremelyBigInt)).toBe(extremelyBigInt);
+
+        expect(BigInt.asIntN(0, -extremelyBigInt)).toBe(0n);
+        expect(BigInt.asIntN(1, -extremelyBigInt)).toBe(-1n);
+        expect(BigInt.asIntN(2, -extremelyBigInt)).toBe(-1n);
+        expect(BigInt.asIntN(4, -extremelyBigInt)).toBe(-5n);
+        expect(BigInt.asIntN(128, -extremelyBigInt)).toBe(99061374399389259395070030194384019691n);
+        expect(BigInt.asIntN(256, -extremelyBigInt)).toBe(-extremelyBigInt);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asUintN.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/BigInt/BigInt.asUintN.js
@@ -1,0 +1,77 @@
+describe("errors", () => {
+    test("invalid index", () => {
+        expect(() => {
+            BigInt.asUintN(-1, 0n);
+        }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+
+        expect(() => {
+            BigInt.asUintN(Symbol(), 0n);
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to number");
+    });
+
+    test("invalid BigInt", () => {
+        expect(() => {
+            BigInt.asUintN(1, 1);
+        }).toThrowWithMessage(TypeError, "Cannot convert number to BigInt");
+
+        expect(() => {
+            BigInt.asUintN(1, Symbol());
+        }).toThrowWithMessage(TypeError, "Cannot convert symbol to BigInt");
+
+        expect(() => {
+            BigInt.asUintN(1, "foo");
+        }).toThrowWithMessage(SyntaxError, "Invalid value for BigInt: foo");
+    });
+});
+
+describe("correct behavior", () => {
+    test("basic functionality", () => {
+        expect(BigInt.asUintN(0, -2n)).toBe(0n);
+        expect(BigInt.asUintN(0, -1n)).toBe(0n);
+        expect(BigInt.asUintN(0, 0n)).toBe(0n);
+        expect(BigInt.asUintN(0, 1n)).toBe(0n);
+        expect(BigInt.asUintN(0, 2n)).toBe(0n);
+
+        expect(BigInt.asUintN(1, -3n)).toBe(1n);
+        expect(BigInt.asUintN(1, -2n)).toBe(0n);
+        expect(BigInt.asUintN(1, -1n)).toBe(1n);
+        expect(BigInt.asUintN(1, 0n)).toBe(0n);
+        expect(BigInt.asUintN(1, 1n)).toBe(1n);
+        expect(BigInt.asUintN(1, 2n)).toBe(0n);
+        expect(BigInt.asUintN(1, 3n)).toBe(1n);
+
+        expect(BigInt.asUintN(2, -3n)).toBe(1n);
+        expect(BigInt.asUintN(2, -2n)).toBe(2n);
+        expect(BigInt.asUintN(2, -1n)).toBe(3n);
+        expect(BigInt.asUintN(2, 0n)).toBe(0n);
+        expect(BigInt.asUintN(2, 1n)).toBe(1n);
+        expect(BigInt.asUintN(2, 2n)).toBe(2n);
+        expect(BigInt.asUintN(2, 3n)).toBe(3n);
+
+        expect(BigInt.asUintN(4, -3n)).toBe(13n);
+        expect(BigInt.asUintN(4, -2n)).toBe(14n);
+        expect(BigInt.asUintN(4, -1n)).toBe(15n);
+        expect(BigInt.asUintN(4, 0n)).toBe(0n);
+        expect(BigInt.asUintN(4, 1n)).toBe(1n);
+        expect(BigInt.asUintN(4, 2n)).toBe(2n);
+        expect(BigInt.asUintN(4, 3n)).toBe(3n);
+
+        const extremelyBigInt = 123456789123456789123456789123456789123456789123456789n;
+
+        expect(BigInt.asUintN(0, extremelyBigInt)).toBe(0n);
+        expect(BigInt.asUintN(1, extremelyBigInt)).toBe(1n);
+        expect(BigInt.asUintN(2, extremelyBigInt)).toBe(1n);
+        expect(BigInt.asUintN(4, extremelyBigInt)).toBe(5n);
+        expect(BigInt.asUintN(128, extremelyBigInt)).toBe(241220992521549204068304577237384191765n);
+        expect(BigInt.asUintN(256, extremelyBigInt)).toBe(extremelyBigInt);
+
+        expect(BigInt.asUintN(0, -extremelyBigInt)).toBe(0n);
+        expect(BigInt.asUintN(1, -extremelyBigInt)).toBe(1n);
+        expect(BigInt.asUintN(2, -extremelyBigInt)).toBe(3n);
+        expect(BigInt.asUintN(4, -extremelyBigInt)).toBe(11n);
+        expect(BigInt.asUintN(128, -extremelyBigInt)).toBe(99061374399389259395070030194384019691n);
+        expect(BigInt.asUintN(256, -extremelyBigInt)).toBe(
+            115792089237316195423570861551898784396480861208851440582668460551124006183147n
+        );
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/Instant/Instant.prototype.epochMicroseconds.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/Instant/Instant.prototype.epochMicroseconds.js
@@ -11,10 +11,9 @@ describe("correct behavior", () => {
             8_640_000_000_000_000_000n
         );
 
-        // FIXME: These seemingly produce correct results in js(1s), but for some reason don't pass. Investigate.
-        // expect(new Temporal.Instant(-0n).epochMicroseconds).toBe(-0n);
-        // expect(new Temporal.Instant(-1n).epochMicroseconds).toBe(-0n);
-        // expect(new Temporal.Instant(-999n).epochMicroseconds).toBe(-0n);
+        expect(new Temporal.Instant(-0n).epochMicroseconds).toBe(-0n);
+        expect(new Temporal.Instant(-1n).epochMicroseconds).toBe(-0n);
+        expect(new Temporal.Instant(-999n).epochMicroseconds).toBe(-0n);
         expect(new Temporal.Instant(-1_000n).epochMicroseconds).toBe(-1n);
         expect(new Temporal.Instant(-1_500n).epochMicroseconds).toBe(-1n);
         expect(new Temporal.Instant(-1_999n).epochMicroseconds).toBe(-1n);


### PR DESCRIPTION
```
test/built-ins/BigInt                            74/74    (100.00%) [ ✅ 74 ]
test/built-ins/BigInt/asIntN                     14/14    (100.00%) [ ✅ 14 ]
test/built-ins/BigInt/asUintN                    14/14    (100.00%) [ ✅ 14 ]
test/built-ins/BigInt/parseInt                    1/1     (100.00%) [ ✅ 1  ]
test/built-ins/BigInt/prototype                  24/24    (100.00%) [ ✅ 24 ]
test/built-ins/BigInt/prototype/toLocaleString    1/1     (100.00%) [ ✅ 1  ]
test/built-ins/BigInt/prototype/toString         11/11    (100.00%) [ ✅ 11 ]
test/built-ins/BigInt/prototype/valueOf           8/8     (100.00%) [ ✅ 8  ]
```