### PR TITLE
CrashReporter: Capture backtrace progress callback's arguments by value

### DIFF
--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -277,7 +277,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             coredump->for_each_thread_info([&](auto& thread_info) {
                 results.thread_backtraces.append(build_backtrace(*coredump, thread_info, thread_index, [&](size_t frame_index, size_t frame_count) {
                     Core::EventLoop::with_main_locked([&](auto& main) {
-                        main->deferred_invoke([&] {
+                        main->deferred_invoke([&, frame_index, frame_count] {
                             window->set_progress(100.0f * (float)(frame_index + 1) / (float)frame_count);
                             progressbar.set_value(frame_index + 1);
                             progressbar.set_max(frame_count);


### PR DESCRIPTION
Previously we captured them by reference, but when the deferred code finally runs from an event loop, the references may be stale.
In that case, value and max of the progressbar are set with random numbers.
If we were especially unlucky, the `frame_count` turned into a negative int, and would crash at `VERIFY(min <= max)`.