### PR TITLE
LibCore+Everywhere: Convert ConfigFile to Core::Stream API

### DIFF
--- a/AK/Error.h
+++ b/AK/Error.h
@@ -87,7 +87,11 @@ public:
     T release_value() { return move(value()); }
     ErrorType release_error() { return move(error()); }
 
-    T release_value_but_fixme_should_propagate_errors() { return release_value(); }
+    T release_value_but_fixme_should_propagate_errors()
+    {
+        VERIFY(!is_error());
+        return release_value();
+    }
 
 private:
     // 'downcast' is fishy in this context. Let's hide it by making it private.

--- a/Meta/Lagom/Tools/ConfigureComponents/main.cpp
+++ b/Meta/Lagom/Tools/ConfigureComponents/main.cpp
@@ -241,7 +241,7 @@ int main()
     }
 
     // Step 2: Open and parse the 'components.ini' file.
-    auto components_file = Core::ConfigFile::open("components.ini");
+    auto components_file = Core::ConfigFile::open("components.ini").release_value_but_fixme_should_propagate_errors();
     if (components_file->groups().is_empty()) {
         warnln("\e[31mError:\e[0m The 'components.ini' file is either not a valid ini file or contains no entries.");
         return 1;

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -135,6 +135,18 @@ TEST_CASE(file_adopt_invalid_fd)
     EXPECT_EQ(maybe_file.error().code(), EBADF);
 }
 
+TEST_CASE(file_truncate)
+{
+    auto maybe_file = Core::Stream::File::open("/tmp/file-truncate-test.txt", Core::Stream::OpenMode::Write);
+    auto file = maybe_file.release_value();
+
+    EXPECT(!file->truncate(999).is_error());
+    EXPECT_EQ(file->size().release_value(), 999);
+
+    EXPECT(!file->truncate(42).is_error());
+    EXPECT_EQ(file->size().release_value(), 42);
+}
+
 // TCPSocket tests
 
 TEST_CASE(should_error_when_connection_fails)

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -45,7 +45,7 @@ Vector<Certificate> load_certificates()
         return certificates;
     }
 
-    auto config = Core::ConfigFile::open(ca_certs_filepath);
+    auto config = Core::ConfigFile::open(ca_certs_filepath).release_value_but_fixme_should_propagate_errors();
     auto now = Core::DateTime::now();
     auto last_year = Core::DateTime::create(now.year() - 1);
     auto next_year = Core::DateTime::create(now.year() + 1);

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -105,7 +105,7 @@ void BackgroundSettingsWidget::create_frame()
 
 void BackgroundSettingsWidget::load_current_settings()
 {
-    auto ws_config = Core::ConfigFile::open("/etc/WindowServer.ini");
+    auto ws_config = Core::ConfigFile::open("/etc/WindowServer.ini").release_value_but_fixme_should_propagate_errors();
 
     auto selected_wallpaper = Config::read_string("WindowManager", "Background", "Wallpaper", "");
     if (!selected_wallpaper.is_empty()) {

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -144,7 +144,7 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     m_current_applied_keymap = keymap_object.get("keymap").to_string();
     dbgln("KeyboardSettings thinks the current keymap is: {}", m_current_applied_keymap);
 
-    auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini"));
+    auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini").release_value_but_fixme_should_propagate_errors());
     auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
 
     auto keymaps_vector = keymaps.split(',');

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -141,7 +141,7 @@ void PreviewWidget::set_preview_palette(const Gfx::Palette& palette)
 
 void PreviewWidget::set_theme_from_file(Core::File& file)
 {
-    auto config_file = Core::ConfigFile::open(file.filename(), file.leak_fd());
+    auto config_file = Core::ConfigFile::open(file.filename(), file.leak_fd()).release_value_but_fixme_should_propagate_errors();
     auto theme = Gfx::load_system_theme(config_file);
     VERIFY(theme.is_valid());
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -374,7 +374,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             theme->write_entry("Paths", to_string(role), preview_widget.preview_palette().path(role));
         }
 
-        theme->sync();
+        if (auto sync_result = theme->sync(); sync_result.is_error()) {
+            // FIXME: Expose this to the user, since failing to save is important to know about!
+            dbgln("Failed to save theme file: {}", sync_result.error());
+        }
     };
 
     TRY(file_menu->try_add_action(GUI::CommonActions::make_open_action([&](auto&) {

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -357,7 +357,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         update_window_title();
         auto file = response.value();
-        auto theme = Core::ConfigFile::open(file->filename(), file->leak_fd());
+        auto theme = Core::ConfigFile::open(file->filename(), file->leak_fd()).release_value_but_fixme_should_propagate_errors();
         for (auto role : color_roles) {
             theme->write_entry("Colors", to_string(role), preview_widget.preview_palette().color(role).to_string());
         }

--- a/Userland/DevTools/HackStudio/ProjectTemplate.cpp
+++ b/Userland/DevTools/HackStudio/ProjectTemplate.cpp
@@ -30,7 +30,10 @@ ProjectTemplate::ProjectTemplate(const String& id, const String& name, const Str
 
 RefPtr<ProjectTemplate> ProjectTemplate::load_from_manifest(const String& manifest_path)
 {
-    auto config = Core::ConfigFile::open(manifest_path);
+    auto maybe_config = Core::ConfigFile::open(manifest_path);
+    if (maybe_config.is_error())
+        return {};
+    auto config = maybe_config.release_value();
 
     if (!config->has_group("HackStudioTemplate")
         || !config->has_key("HackStudioTemplate", "Name")

--- a/Userland/DevTools/Profiler/SourceModel.cpp
+++ b/Userland/DevTools/Profiler/SourceModel.cpp
@@ -7,6 +7,7 @@
 #include "SourceModel.h"
 #include "Gradient.h"
 #include "Profile.h"
+#include <LibCore/File.h>
 #include <LibDebug/DebugInfo.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibSymbolication/Symbolication.h>

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -61,7 +61,7 @@ ConfigFile::ConfigFile(String const&, NonnullRefPtr<File> open_file)
 
 ConfigFile::~ConfigFile()
 {
-    sync();
+    MUST(sync());
 }
 
 void ConfigFile::reparse()
@@ -168,10 +168,10 @@ void ConfigFile::write_color_entry(String const& group, String const& key, Color
     write_entry(group, key, String::formatted("{},{},{},{}", value.red(), value.green(), value.blue(), value.alpha()));
 }
 
-bool ConfigFile::sync()
+ErrorOr<void> ConfigFile::sync()
 {
     if (!m_dirty)
-        return true;
+        return {};
 
     m_file->truncate(0);
     m_file->seek(0);
@@ -184,7 +184,7 @@ bool ConfigFile::sync()
     }
 
     m_dirty = false;
-    return true;
+    return {};
 }
 
 void ConfigFile::dump() const

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -14,35 +14,35 @@
 
 namespace Core {
 
-NonnullRefPtr<ConfigFile> ConfigFile::open_for_lib(String const& lib_name, AllowWriting allow_altering)
+ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open_for_lib(String const& lib_name, AllowWriting allow_altering)
 {
     String directory = StandardPaths::config_directory();
     auto path = String::formatted("{}/lib/{}.ini", directory, lib_name);
 
-    return adopt_ref(*new ConfigFile(path, allow_altering));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) ConfigFile(path, allow_altering));
 }
 
-NonnullRefPtr<ConfigFile> ConfigFile::open_for_app(String const& app_name, AllowWriting allow_altering)
+ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open_for_app(String const& app_name, AllowWriting allow_altering)
 {
     String directory = StandardPaths::config_directory();
     auto path = String::formatted("{}/{}.ini", directory, app_name);
-    return adopt_ref(*new ConfigFile(path, allow_altering));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) ConfigFile(path, allow_altering));
 }
 
-NonnullRefPtr<ConfigFile> ConfigFile::open_for_system(String const& app_name, AllowWriting allow_altering)
+ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open_for_system(String const& app_name, AllowWriting allow_altering)
 {
     auto path = String::formatted("/etc/{}.ini", app_name);
-    return adopt_ref(*new ConfigFile(path, allow_altering));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) ConfigFile(path, allow_altering));
 }
 
-NonnullRefPtr<ConfigFile> ConfigFile::open(String const& filename, AllowWriting allow_altering)
+ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open(String const& filename, AllowWriting allow_altering)
 {
-    return adopt_ref(*new ConfigFile(filename, allow_altering));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) ConfigFile(filename, allow_altering));
 }
 
-NonnullRefPtr<ConfigFile> ConfigFile::open(String const& filename, int fd)
+ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open(String const& filename, int fd)
 {
-    return adopt_ref(*new ConfigFile(filename, fd));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) ConfigFile(filename, fd));
 }
 
 ConfigFile::ConfigFile(String const& filename, AllowWriting allow_altering)

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -52,7 +52,7 @@ public:
 
     bool is_dirty() const { return m_dirty; }
 
-    bool sync();
+    ErrorOr<void> sync();
 
     void remove_group(String const& group);
     void remove_entry(String const& group, String const& key);

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -60,8 +60,7 @@ public:
     String filename() const { return m_file->filename(); }
 
 private:
-    explicit ConfigFile(String const& filename, AllowWriting);
-    explicit ConfigFile(String const& filename, int fd);
+    ConfigFile(String const& filename, NonnullRefPtr<File> open_file);
 
     void reparse();
 

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -24,11 +24,11 @@ public:
         No,
     };
 
-    static NonnullRefPtr<ConfigFile> open_for_lib(String const& lib_name, AllowWriting = AllowWriting::No);
-    static NonnullRefPtr<ConfigFile> open_for_app(String const& app_name, AllowWriting = AllowWriting::No);
-    static NonnullRefPtr<ConfigFile> open_for_system(String const& app_name, AllowWriting = AllowWriting::No);
-    static NonnullRefPtr<ConfigFile> open(String const& filename, AllowWriting = AllowWriting::No);
-    static NonnullRefPtr<ConfigFile> open(String const& filename, int fd);
+    static ErrorOr<NonnullRefPtr<ConfigFile>> open_for_lib(String const& lib_name, AllowWriting = AllowWriting::No);
+    static ErrorOr<NonnullRefPtr<ConfigFile>> open_for_app(String const& app_name, AllowWriting = AllowWriting::No);
+    static ErrorOr<NonnullRefPtr<ConfigFile>> open_for_system(String const& app_name, AllowWriting = AllowWriting::No);
+    static ErrorOr<NonnullRefPtr<ConfigFile>> open(String const& filename, AllowWriting = AllowWriting::No);
+    static ErrorOr<NonnullRefPtr<ConfigFile>> open(String const& filename, int fd);
     ~ConfigFile();
 
     bool has_group(String const&) const;

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Jakob-Niklas See <git@nwex.de>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,7 +13,7 @@
 #include <AK/RefPtr.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <LibCore/File.h>
+#include <LibCore/Stream.h>
 #include <LibGfx/Color.h>
 
 namespace Core {
@@ -57,14 +58,15 @@ public:
     void remove_group(String const& group);
     void remove_entry(String const& group, String const& key);
 
-    String filename() const { return m_file->filename(); }
+    String const& filename() const { return m_filename; }
 
 private:
-    ConfigFile(String const& filename, NonnullRefPtr<File> open_file);
+    ConfigFile(String const& filename, OwnPtr<Stream::BufferedFile> open_file);
 
-    void reparse();
+    ErrorOr<void> reparse();
 
-    NonnullRefPtr<File> m_file;
+    String m_filename;
+    OwnPtr<Stream::BufferedFile> m_file;
     HashMap<String, HashMap<String, String>> m_groups;
     bool m_dirty { false };
 };

--- a/Userland/Libraries/LibCore/MemoryStream.h
+++ b/Userland/Libraries/LibCore/MemoryStream.h
@@ -26,6 +26,8 @@ public:
     virtual bool is_open() const override { return true; }
     // FIXME: It doesn't make sense to close an memory stream. Therefore, we don't do anything here. Is that fine?
     virtual void close() override { }
+    // FIXME: It doesn't make sense to truncate a memory stream. Therefore, we don't do anything here. Is that fine?
+    virtual ErrorOr<void> truncate(off_t) override { return Error::from_errno(ENOTSUP); }
 
     virtual ErrorOr<size_t> read(Bytes bytes) override
     {

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -215,6 +215,11 @@ ErrorOr<off_t> File::seek(i64 offset, SeekMode mode)
     return seek_result;
 }
 
+ErrorOr<void> File::truncate(off_t length)
+{
+    return System::ftruncate(m_fd, length);
+}
+
 ErrorOr<int> Socket::create_fd(SocketDomain domain, SocketType type)
 {
     int socket_domain;

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -81,6 +81,9 @@ public:
     /// Returns the total size of the stream, or an errno in the case of an
     /// error. May not preserve the original position on the stream on failure.
     virtual ErrorOr<off_t> size();
+    /// Shrinks or extends the stream to the given size. Returns an errno in
+    /// the case of an error.
+    virtual ErrorOr<void> truncate(off_t length) = 0;
 };
 
 /// The Socket class is the base class for all concrete BSD-style socket
@@ -197,6 +200,7 @@ public:
     virtual bool is_open() const override;
     virtual void close() override;
     virtual ErrorOr<off_t> seek(i64 offset, SeekMode) override;
+    virtual ErrorOr<void> truncate(off_t length) override;
 
     virtual ~File() override { close(); }
 
@@ -756,6 +760,10 @@ public:
         auto result = TRY(m_helper.stream().seek(offset, mode));
         m_helper.clear_buffer();
         return result;
+    }
+    virtual ErrorOr<void> truncate(off_t length) override
+    {
+        return m_helper.stream().truncate(length);
     }
 
     ErrorOr<size_t> read_line(Bytes buffer) { return m_helper.read_line(move(buffer)); }

--- a/Userland/Libraries/LibCore/Version.cpp
+++ b/Userland/Libraries/LibCore/Version.cpp
@@ -11,7 +11,7 @@ namespace Core::Version {
 
 String read_long_version_string()
 {
-    auto version_config = Core::ConfigFile::open("/res/version.ini");
+    auto version_config = Core::ConfigFile::open("/res/version.ini").release_value_but_fixme_should_propagate_errors();
     auto major_version = version_config->read_entry("Version", "Major", "0");
     auto minor_version = version_config->read_entry("Version", "Minor", "0");
 

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -43,7 +43,7 @@ void AppFile::for_each(Function<void(NonnullRefPtr<AppFile>)> callback, StringVi
 }
 
 AppFile::AppFile(StringView path)
-    : m_config(Core::ConfigFile::open(path))
+    : m_config(Core::ConfigFile::open(path).release_value_but_fixme_should_propagate_errors())
     , m_valid(validate())
 {
 }

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -64,7 +64,7 @@ static void initialize_if_needed()
     if (s_initialized)
         return;
 
-    auto config = Core::ConfigFile::open("/etc/FileIconProvider.ini");
+    auto config = Core::ConfigFile::open("/etc/FileIconProvider.ini").release_value_but_fixme_should_propagate_errors();
 
     s_symlink_emblem = Gfx::Bitmap::try_load_from_file("/res/icons/symlink-emblem.png").release_value_but_fixme_should_propagate_errors();
     s_symlink_emblem_small = Gfx::Bitmap::try_load_from_file("/res/icons/symlink-emblem-small.png").release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -10,6 +10,7 @@
 #include <AK/ScopeGuard.h>
 #include <AK/StringBuilder.h>
 #include <AK/TemporaryChange.h>
+#include <LibCore/File.h>
 #include <LibCore/Timer.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/AutocompleteProvider.h>

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -147,7 +147,7 @@ Core::AnonymousBuffer load_system_theme(Core::ConfigFile const& file)
 
 Core::AnonymousBuffer load_system_theme(String const& path)
 {
-    return load_system_theme(Core::ConfigFile::open(path));
+    return load_system_theme(Core::ConfigFile::open(path).release_value_but_fixme_should_propagate_errors());
 }
 
 }

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -40,7 +40,7 @@ namespace Line {
 Configuration Configuration::from_config(StringView libname)
 {
     Configuration configuration;
-    auto config_file = Core::ConfigFile::open_for_lib(libname);
+    auto config_file = Core::ConfigFile::open_for_lib(libname).release_value_but_fixme_should_propagate_errors();
 
     // Read behavior options.
     auto refresh = config_file->read_entry("behavior", "refresh", "lazy");

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -345,7 +345,7 @@ Singleton<DefaultRootCACertificates> DefaultRootCACertificates::s_the;
 DefaultRootCACertificates::DefaultRootCACertificates()
 {
     // FIXME: This might not be the best format, find a better way to represent CA certificates.
-    auto config = Core::ConfigFile::open_for_system("ca_certs");
+    auto config = Core::ConfigFile::open_for_system("ca_certs").release_value_but_fixme_should_propagate_errors();
     auto now = Core::DateTime::now();
     auto last_year = Core::DateTime::create(now.year() - 1);
     auto next_year = Core::DateTime::create(now.year() + 1);

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -1196,7 +1196,13 @@ void TerminalWidget::set_color_scheme(StringView name)
         "White"
     };
 
-    auto color_config = Core::ConfigFile::open(String::formatted("/res/terminal-colors/{}.ini", name));
+    auto path = String::formatted("/res/terminal-colors/{}.ini", name);
+    auto color_config_or_error = Core::ConfigFile::open(path);
+    if (color_config_or_error.is_error()) {
+        dbgln("Unable to read color scheme file '{}': {}", path, color_config_or_error.error());
+        return;
+    }
+    auto color_config = color_config_or_error.release_value();
 
     m_show_bold_text_as_bright = color_config->read_bool_entry("Options", "ShowBoldTextAsBright", true);
 

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -191,7 +191,8 @@ void Mixer::request_setting_sync()
         m_config_write_timer = Core::Timer::create_single_shot(
             AUDIO_CONFIG_WRITE_INTERVAL,
             [this] {
-                m_config->sync();
+                if (auto result = m_config->sync(); result.is_error())
+                    dbgln("Failed to write audio mixer config: {}", result.error());
             },
             this);
         m_config_write_timer->start();

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -15,7 +15,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio recvfd thread accept cpath rpath wpath unix"));
 
-    auto config = Core::ConfigFile::open_for_app("Audio", Core::ConfigFile::AllowWriting::Yes);
+    auto config = TRY(Core::ConfigFile::open_for_app("Audio", Core::ConfigFile::AllowWriting::Yes));
     TRY(Core::System::unveil(config->filename(), "rwc"));
     TRY(Core::System::unveil("/dev/audio", "wc"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Services/ConfigServer/ClientConnection.cpp
+++ b/Userland/Services/ConfigServer/ClientConnection.cpp
@@ -37,14 +37,14 @@ static Core::ConfigFile& ensure_domain_config(String const& domain)
     if (it != s_cache.end())
         return *it->value->config;
 
-    auto config = Core::ConfigFile::open_for_app(domain, Core::ConfigFile::AllowWriting::Yes);
+    auto config = Core::ConfigFile::open_for_app(domain, Core::ConfigFile::AllowWriting::Yes).release_value_but_fixme_should_propagate_errors();
     // FIXME: Use a single FileWatcher with multiple watches inside.
     auto watcher_or_error = Core::FileWatcher::create(InodeWatcherFlags::Nonblock);
     VERIFY(!watcher_or_error.is_error());
     auto result = watcher_or_error.value()->add_watch(config->filename(), Core::FileWatcherEvent::Type::ContentModified);
     VERIFY(!result.is_error());
     watcher_or_error.value()->on_change = [config, domain](auto&) {
-        auto new_config = Core::ConfigFile::open(config->filename(), Core::ConfigFile::AllowWriting::Yes);
+        auto new_config = Core::ConfigFile::open(config->filename(), Core::ConfigFile::AllowWriting::Yes).release_value_but_fixme_should_propagate_errors();
         for (auto& group : config->groups()) {
             for (auto& key : config->keys(group)) {
                 if (!new_config->has_key(group, key)) {

--- a/Userland/Services/ConfigServer/ClientConnection.cpp
+++ b/Userland/Services/ConfigServer/ClientConnection.cpp
@@ -131,7 +131,11 @@ void ClientConnection::sync_dirty_domains_to_disk()
     dbgln("Syncing {} dirty domains to disk", dirty_domains.size());
     for (auto domain : dirty_domains) {
         auto& config = ensure_domain_config(domain);
-        config.sync();
+        if (auto result = config.sync(); result.is_error()) {
+            dbgln("Failed to write config '{}' to disk: {}", domain, result.error());
+            // Put it back in the list since it's still dirty.
+            m_dirty_domains.set(domain);
+        }
     }
 }
 

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -17,13 +17,13 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio proc exec rpath"));
-    auto keyboard_settings_config = Core::ConfigFile::open_for_app("KeyboardSettings");
+    auto keyboard_settings_config = TRY(Core::ConfigFile::open_for_app("KeyboardSettings"));
 
     TRY(Core::System::unveil("/bin/keymap", "x"));
     TRY(Core::System::unveil("/etc/Keyboard.ini", "r"));
     TRY(Core::System::unveil("/dev/keyboard0", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini"));
+    auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini"));
     auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
 
     auto keymaps_vector = keymaps.split(',');

--- a/Userland/Services/LaunchServer/main.cpp
+++ b/Userland/Services/LaunchServer/main.cpp
@@ -19,7 +19,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     auto launcher = LaunchServer::Launcher();
     launcher.load_handlers();
-    launcher.load_config(Core::ConfigFile::open_for_app("LaunchServer"));
+    launcher.load_config(TRY(Core::ConfigFile::open_for_app("LaunchServer")));
 
     TRY(Core::System::pledge("stdio accept rpath proc exec"));
 

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -37,7 +37,7 @@ LookupServer::LookupServer()
     VERIFY(s_the == nullptr);
     s_the = this;
 
-    auto config = Core::ConfigFile::open_for_system("LookupServer");
+    auto config = Core::ConfigFile::open_for_system("LookupServer").release_value_but_fixme_should_propagate_errors();
     dbgln("Using network config file at {}", config->filename());
     m_nameservers = config->read_entry("DNS", "Nameservers", "1.1.1.1,1.0.0.1").split(',');
 

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -489,8 +489,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // This takes care of setting up sockets.
     NonnullRefPtrVector<Service> services;
     auto config = (user)
-        ? Core::ConfigFile::open_for_app("SystemServer")
-        : Core::ConfigFile::open_for_system("SystemServer");
+        ? TRY(Core::ConfigFile::open_for_app("SystemServer"))
+        : TRY(Core::ConfigFile::open_for_system("SystemServer"));
     for (auto name : config->groups()) {
         auto service = Service::construct(*config, name);
         if (service->is_enabled())

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -121,7 +121,7 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu()
     system_menu->add_separator();
 
     // First we construct all the necessary app category submenus.
-    auto category_icons = Core::ConfigFile::open("/res/icons/SystemMenu.ini");
+    auto category_icons = TRY(Core::ConfigFile::open("/res/icons/SystemMenu.ini"));
     HashMap<String, NonnullRefPtr<GUI::Menu>> app_category_menus;
 
     Function<void(String const&)> create_category_menu;

--- a/Userland/Services/WindowServer/AppletManager.cpp
+++ b/Userland/Services/WindowServer/AppletManager.cpp
@@ -20,7 +20,7 @@ AppletManager::AppletManager()
 {
     s_the = this;
 
-    auto wm_config = Core::ConfigFile::open("/etc/WindowServer.ini");
+    auto wm_config = Core::ConfigFile::open("/etc/WindowServer.ini").release_value_but_fixme_should_propagate_errors();
     auto order = wm_config->read_entry("Applet", "Order");
     order_vector = order.split(',');
 }

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -786,7 +786,7 @@ Messages::WindowServer::SetSystemThemeResponse ClientConnection::set_system_them
 
 Messages::WindowServer::GetSystemThemeResponse ClientConnection::get_system_theme()
 {
-    auto wm_config = Core::ConfigFile::open("/etc/WindowServer.ini");
+    auto wm_config = Core::ConfigFile::open("/etc/WindowServer.ini").release_value_but_fixme_should_propagate_errors();
     auto name = wm_config->read_entry("Theme", "Name");
     return name;
 }
@@ -798,7 +798,7 @@ void ClientConnection::apply_cursor_theme(String const& name)
 
 Messages::WindowServer::GetCursorThemeResponse ClientConnection::get_cursor_theme()
 {
-    auto config = Core::ConfigFile::open("/etc/WindowServer.ini");
+    auto config = Core::ConfigFile::open("/etc/WindowServer.ini").release_value_but_fixme_should_propagate_errors();
     auto name = config->read_entry("Mouse", "CursorTheme");
     return name;
 }
@@ -822,7 +822,12 @@ Messages::WindowServer::SetSystemFontsResponse ClientConnection::set_system_font
 
     WindowManager::the().invalidate_after_theme_or_font_change();
 
-    auto wm_config = Core::ConfigFile::open("/etc/WindowServer.ini", Core::ConfigFile::AllowWriting::Yes);
+    auto wm_config_or_error = Core::ConfigFile::open("/etc/WindowServer.ini", Core::ConfigFile::AllowWriting::Yes);
+    if (wm_config_or_error.is_error()) {
+        dbgln("Unable to open WindowServer.ini to set system fonts: {}", wm_config_or_error.error());
+        return false;
+    }
+    auto wm_config = wm_config_or_error.release_value();
     wm_config->write_entry("Fonts", "Default", default_font_query);
     wm_config->write_entry("Fonts", "FixedWidth", fixed_width_font_query);
     return true;

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -783,26 +783,26 @@ bool Compositor::set_background_color(const String& background_color)
 
     auto& wm = WindowManager::the();
     wm.config()->write_entry("Background", "Color", background_color);
-    bool ret_val = wm.config()->sync();
+    bool succeeded = !wm.config()->sync().is_error();
 
-    if (ret_val)
+    if (succeeded)
         Compositor::invalidate_screen();
 
-    return ret_val;
+    return succeeded;
 }
 
 bool Compositor::set_wallpaper_mode(const String& mode)
 {
     auto& wm = WindowManager::the();
     wm.config()->write_entry("Background", "Mode", mode);
-    bool ret_val = wm.config()->sync();
+    bool succeeded = !wm.config()->sync().is_error();
 
-    if (ret_val) {
+    if (succeeded) {
         m_wallpaper_mode = mode_to_enum(mode);
         Compositor::invalidate_screen();
     }
 
-    return ret_val;
+    return succeeded;
 }
 
 bool Compositor::set_wallpaper(RefPtr<Gfx::Bitmap> bitmap)

--- a/Userland/Services/WindowServer/KeymapSwitcher.cpp
+++ b/Userland/Services/WindowServer/KeymapSwitcher.cpp
@@ -34,7 +34,7 @@ void KeymapSwitcher::refresh()
 {
     m_keymaps.clear();
 
-    auto mapper_config(Core::ConfigFile::open(m_keyboard_config));
+    auto mapper_config(Core::ConfigFile::open(m_keyboard_config).release_value_but_fixme_should_propagate_errors());
     auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
 
     auto keymaps_vector = keymaps.split(',');

--- a/Userland/Services/WindowServer/ScreenLayout.ipp
+++ b/Userland/Services/WindowServer/ScreenLayout.ipp
@@ -271,7 +271,7 @@ bool ScreenLayout::save_config(Core::ConfigFile& config_file, bool sync) const
         config_file.remove_group(group_name);
     }
 
-    if (sync && !config_file.sync())
+    if (sync && config_file.sync().is_error())
         return false;
     return true;
 }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -254,7 +254,7 @@ bool WindowManager::apply_workspace_settings(unsigned rows, unsigned columns, bo
     if (save) {
         m_config->write_num_entry("Workspace", "Rows", window_stack_rows());
         m_config->write_num_entry("Workspace", "Columns", window_stack_columns());
-        return m_config->sync();
+        return !m_config->sync().is_error();
     }
     return true;
 }
@@ -264,7 +264,8 @@ void WindowManager::set_acceleration_factor(double factor)
     ScreenInput::the().set_acceleration_factor(factor);
     dbgln("Saving acceleration factor {} to config file at {}", factor, m_config->filename());
     m_config->write_entry("Mouse", "AccelerationFactor", String::formatted("{}", factor));
-    m_config->sync();
+    if (auto result = m_config->sync(); result.is_error())
+        dbgln("Failed to save config file: {}", result.error());
 }
 
 void WindowManager::set_scroll_step_size(unsigned step_size)
@@ -272,7 +273,8 @@ void WindowManager::set_scroll_step_size(unsigned step_size)
     ScreenInput::the().set_scroll_step_size(step_size);
     dbgln("Saving scroll step size {} to config file at {}", step_size, m_config->filename());
     m_config->write_entry("Mouse", "ScrollStepSize", String::number(step_size));
-    m_config->sync();
+    if (auto result = m_config->sync(); result.is_error())
+        dbgln("Failed to save config file: {}", result.error());
 }
 
 void WindowManager::set_double_click_speed(int speed)
@@ -281,7 +283,8 @@ void WindowManager::set_double_click_speed(int speed)
     m_double_click_speed = speed;
     dbgln("Saving double-click speed {} to config file at {}", speed, m_config->filename());
     m_config->write_entry("Input", "DoubleClickSpeed", String::number(speed));
-    m_config->sync();
+    if (auto result = m_config->sync(); result.is_error())
+        dbgln("Failed to save config file: {}", result.error());
 }
 
 int WindowManager::double_click_speed() const
@@ -294,7 +297,8 @@ void WindowManager::set_buttons_switched(bool switched)
     m_buttons_switched = switched;
     dbgln("Saving mouse buttons switched state {} to config file at {}", switched, m_config->filename());
     m_config->write_bool_entry("Mouse", "ButtonsSwitched", switched);
-    m_config->sync();
+    if (auto result = m_config->sync(); result.is_error())
+        dbgln("Failed to save config file: {}", result.error());
 }
 
 bool WindowManager::get_buttons_switched() const
@@ -2080,7 +2084,10 @@ bool WindowManager::update_theme(String theme_path, String theme_name)
     m_palette = Gfx::PaletteImpl::create_with_anonymous_buffer(new_theme);
     m_config->write_entry("Theme", "Name", theme_name);
     m_config->remove_entry("Background", "Color");
-    m_config->sync();
+    if (auto result = m_config->sync(); result.is_error()) {
+        dbgln("Failed to save config file: {}", result.error());
+        return false;
+    }
     invalidate_after_theme_or_font_change();
     return true;
 }

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -36,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::sigaction(SIGCHLD, &act, nullptr));
     TRY(Core::System::pledge("stdio video thread sendfd recvfd accept rpath wpath cpath unix proc exec"));
 
-    auto wm_config = Core::ConfigFile::open("/etc/WindowServer.ini");
+    auto wm_config = TRY(Core::ConfigFile::open("/etc/WindowServer.ini"));
     auto theme_name = wm_config->read_entry("Theme", "Name", "Default");
 
     auto theme = Gfx::load_system_theme(String::formatted("/res/themes/{}.ini", theme_name));

--- a/Userland/Utilities/ini.cpp
+++ b/Userland/Utilities/ini.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (value_to_write) {
         config->write_entry(group, key, value_to_write);
-        config->sync();
+        TRY(config->sync());
         return 0;
     }
 

--- a/Userland/Utilities/ini.cpp
+++ b/Userland/Utilities/ini.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    auto config = Core::ConfigFile::open(path, value_to_write ? Core::ConfigFile::AllowWriting::Yes : Core::ConfigFile::AllowWriting::No);
+    auto config = TRY(Core::ConfigFile::open(path, value_to_write ? Core::ConfigFile::AllowWriting::Yes : Core::ConfigFile::AllowWriting::No));
 
     if (value_to_write) {
         config->write_entry(group, key, value_to_write);

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -76,7 +76,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto keymaps = String::join(',', mappings_vector);
         mapper_config->write_entry("Mapping", "Keymaps", keymaps);
-        mapper_config->sync();
+        TRY(mapper_config->sync());
         rc = set_keymap(mappings_vector.first());
         if (rc != 0) {
             return rc;
@@ -90,7 +90,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         if (keymaps_vector.is_empty()) {
             warnln("No keymaps configured - writing default configurations (en-us)");
             mapper_config->write_entry("Mapping", "Keymaps", "en-us");
-            mapper_config->sync();
+            TRY(mapper_config->sync());
             keymaps_vector.append("en-us");
         }
 

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 0;
     }
 
-    auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini", Core::ConfigFile::AllowWriting::Yes));
+    auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini", Core::ConfigFile::AllowWriting::Yes));
 
     int rc = 0;
 

--- a/Userland/Utilities/run-tests.cpp
+++ b/Userland/Utilities/run-tests.cpp
@@ -376,7 +376,13 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    auto config = config_file.is_empty() ? Core::ConfigFile::open_for_app("Tests") : Core::ConfigFile::open(config_file);
+    auto config_or_error = config_file.is_empty() ? Core::ConfigFile::open_for_app("Tests") : Core::ConfigFile::open(config_file);
+    if (config_or_error.is_error()) {
+        warnln("Failed to open configuration file ({}): {}", config_file.is_empty() ? "User config for Tests" : config_file.characters(), config_or_error.error());
+        return 1;
+    }
+    auto config = config_or_error.release_value();
+
     if (config->num_groups() == 0)
         warnln("Empty configuration file ({}) loaded!", config_file.is_empty() ? "User config for Tests" : config_file.characters());
 


### PR DESCRIPTION
This is one small step towards removing `Core::File`! We also now propagate ConfigFile errors instead of silently ignoring them or crashing, and added `SeekableStream::truncate()`.