### PR TITLE
PixelPaint: Paint the correct color when multiple buttons are pressed

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -285,6 +285,9 @@ void ImageEditor::mousedown_event(GUI::MouseEvent& event)
         return;
     }
 
+    if (event.button() == GUI::MouseButton::Primary || event.button() == GUI::MouseButton::Secondary)
+        m_last_pressed_colour_indicating_button = event.button();
+
     if (!m_active_tool)
         return;
 
@@ -334,8 +337,18 @@ void ImageEditor::mouseup_event(GUI::MouseEvent& event)
         return;
     }
 
+    if (m_last_pressed_colour_indicating_button == event.button()) {
+        if (event.primary_currently_held())
+            m_last_pressed_colour_indicating_button = GUI::MouseButton::Primary;
+        else if (event.secondary_currently_held())
+            m_last_pressed_colour_indicating_button = GUI::MouseButton::Secondary;
+        else
+            m_last_pressed_colour_indicating_button = GUI::MouseButton::None;
+    }
+
     if (!m_active_tool)
         return;
+
     auto layer_event = m_active_layer ? event_adjusted_for_layer(event, *m_active_layer) : event;
     auto image_event = event_with_pan_and_scale_applied(event);
     Tool::MouseEvent tool_event(Tool::MouseEvent::Action::MouseDown, layer_event, image_event, event);
@@ -653,6 +666,11 @@ void ImageEditor::set_show_active_layer_boundary(bool show)
 void ImageEditor::set_loaded_from_image(bool loaded_from_image)
 {
     m_loaded_from_image = loaded_from_image;
+}
+
+Color ImageEditor::current_color() const
+{
+    return color_for(m_last_pressed_colour_indicating_button);
 }
 
 }

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -77,6 +77,8 @@ public:
     Color secondary_color() const { return m_secondary_color; }
     void set_secondary_color(Color);
 
+    Color current_color() const;
+
     Selection& selection() { return m_selection; }
     Selection const& selection() const { return m_selection; }
 
@@ -174,6 +176,8 @@ private:
     Selection m_selection;
 
     bool m_loaded_from_image { true };
+
+    GUI::MouseButton m_last_pressed_colour_indicating_button { GUI::MouseButton::None };
 };
 
 }

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -63,7 +63,7 @@ void BrushTool::on_mousemove(Layer* layer, MouseEvent& event)
     if (!(layer_event.buttons() & GUI::MouseButton::Primary || layer_event.buttons() & GUI::MouseButton::Secondary))
         return;
 
-    draw_line(layer->bitmap(), color_for(layer_event), m_last_position, layer_event.position());
+    draw_line(layer->bitmap(), m_editor->current_color(), m_last_position, layer_event.position());
 
     auto modified_rect = Gfx::IntRect::from_two_points(m_last_position, layer_event.position()).inflated(m_size * 2, m_size * 2);
 

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.h
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.h
@@ -35,7 +35,7 @@ public:
     }
 
 protected:
-    virtual Color color_for(GUI::MouseEvent const& event);
+    Color color_for(GUI::MouseEvent const& event);
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point);
     virtual void draw_line(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& start, Gfx::IntPoint const& end);
 

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.cpp
@@ -28,15 +28,14 @@ EraseTool::~EraseTool()
 {
 }
 
-Color EraseTool::color_for(GUI::MouseEvent const&)
+void EraseTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color const&, Gfx::IntPoint const& point)
 {
+    Color color;
     if (m_use_secondary_color)
-        return m_editor->secondary_color();
-    return Color(255, 255, 255, 0);
-}
+        color = m_editor->secondary_color();
+    else
+        color = Color(255, 255, 255, 0);
 
-void EraseTool::draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point)
-{
     if (m_draw_mode == DrawMode::Pencil) {
         int radius = size() / 2;
         Gfx::IntRect rect { point.x() - radius, point.y() - radius, size(), size() };

--- a/Userland/Applications/PixelPaint/Tools/EraseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EraseTool.h
@@ -22,7 +22,6 @@ public:
     virtual GUI::Widget* get_properties_widget() override;
 
 protected:
-    virtual Color color_for(GUI::MouseEvent const& event) override;
     virtual void draw_point(Gfx::Bitmap& bitmap, Gfx::Color const& color, Gfx::IntPoint const& point) override;
 
 private:

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
@@ -48,6 +48,7 @@ void SprayTool::paint_it()
     VERIFY(bitmap.bpp() == 32);
     const double minimal_radius = 2;
     const double base_radius = minimal_radius * m_thickness;
+    const Color color = m_editor->current_color();
     for (int i = 0; i < M_PI * base_radius * base_radius * (m_density / 100.0); i++) {
         double radius = base_radius * nrand();
         double angle = 2 * M_PI * nrand();
@@ -57,7 +58,7 @@ void SprayTool::paint_it()
             continue;
         if (ypos < 0 || ypos >= bitmap.height())
             continue;
-        bitmap.set_pixel<Gfx::StorageFormat::BGRA8888>(xpos, ypos, m_color);
+        bitmap.set_pixel<Gfx::StorageFormat::BGRA8888>(xpos, ypos, color);
     }
 
     layer->did_modify_bitmap(Gfx::IntRect::centered_on(m_last_pos, Gfx::IntSize(base_radius * 2, base_radius * 2)));
@@ -69,7 +70,6 @@ void SprayTool::on_mousedown(Layer* layer, MouseEvent& event)
         return;
 
     auto& layer_event = event.layer_event();
-    m_color = m_editor->color_for(layer_event);
     m_last_pos = layer_event.position();
     m_timer->start();
     paint_it();
@@ -87,10 +87,11 @@ void SprayTool::on_mousemove(Layer* layer, MouseEvent& event)
     }
 }
 
-void SprayTool::on_mouseup(Layer*, MouseEvent&)
+void SprayTool::on_mouseup(Layer*, MouseEvent& event)
 {
     if (m_timer->is_active()) {
-        m_timer->stop();
+        if (!event.layer_event().primary_currently_held() && !event.layer_event().secondary_currently_held())
+            m_timer->stop();
         m_editor->did_complete_action();
     }
 }

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.h
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.h
@@ -30,7 +30,6 @@ private:
     RefPtr<GUI::Widget> m_properties_widget;
     RefPtr<Core::Timer> m_timer;
     Gfx::IntPoint m_last_pos;
-    Color m_color;
     int m_thickness { 10 };
     int m_density { 40 };
 };

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -400,6 +400,8 @@ public:
     int x() const { return m_position.x(); }
     int y() const { return m_position.y(); }
     MouseButton button() const { return m_button; }
+    bool primary_currently_held() const { return m_buttons & GUI::MouseButton::Primary; }
+    bool secondary_currently_held() const { return m_buttons & GUI::MouseButton::Secondary; }
     unsigned buttons() const { return m_buttons; }
     bool ctrl() const { return m_modifiers & Mod_Ctrl; }
     bool alt() const { return m_modifiers & Mod_Alt; }


### PR DESCRIPTION
Centralize the storage of the most recently pressed button in the
ImageEditor to ensure that all tools display the same behavior when
multiple buttons are pressed on the mouse at the same time during
movement of the mouse.

This fixes that brush and spray tool wrongly interpreted this situation.

Example before:
![serenity_change_before](https://user-images.githubusercontent.com/83409229/152700089-124c6f32-febd-4bb3-9f03-ee440c4863b8.png)

Example after:
![serenity_change_after](https://user-images.githubusercontent.com/83409229/152700097-26606cc3-7ba7-41dc-bf31-06e0e3321eb9.png)


These examples show what happens with the brush tool when you:
First line:
push-primary
push-secondary
release-secondary
release-primary

Second line:
push-secondary
push-primary
release-primary
release-secondary

third line:
push-primary
push-secondary
release-primary
release-secondary

fourth line:
push-secondary
push-primary
release-secondary
release-primary
