### PR TITLE
Kernel: Fix bug in TCP state handling in SynSent

### DIFF
--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -472,7 +472,7 @@ void handle_tcp(IPv4Packet const& ipv4_packet, Time const& packet_timestamp)
         switch (tcp_packet.flags()) {
         case TCPFlags::SYN:
             socket->set_ack_number(tcp_packet.sequence_number() + payload_size + 1);
-            (void)socket->send_ack(true);
+            (void)socket->send_tcp_packet(TCPFlags::SYN | TCPFlags::ACK);
             socket->set_state(TCPSocket::State::SynReceived);
             return;
         case TCPFlags::ACK | TCPFlags::SYN:


### PR DESCRIPTION
When receiving SYN while in SynSent, we now reply with SYN|ACK in
addition to the SynSent->SynReceived transition.