### PR TITLE
LibJS: Use GetV to look up the toJSON property in SerializeJSONProperty

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/JSON/JSON.stringify.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/JSON/JSON.stringify.js
@@ -38,6 +38,19 @@ describe("correct behavior", () => {
         });
     });
 
+    test("serialize BigInt with a toJSON property", () => {
+        Object.defineProperty(BigInt.prototype, "toJSON", {
+            configurable: true, // Allows deleting this property at the end of this test case.
+            get() {
+                "use strict";
+                return () => typeof this;
+            },
+        });
+
+        expect(JSON.stringify(1n)).toBe('"bigint"');
+        delete BigInt.prototype.toJSON;
+    });
+
     test("ignores non-enumerable properties", () => {
         let o = { foo: "bar" };
         Object.defineProperty(o, "baz", { value: "qux", enumerable: false });


### PR DESCRIPTION
The current implementation of step 2a sort of manually implemented GetV
with a ToObject + Get combo. But in the call to Get, the receiver wasn't
the correct object. So when invoking toJSON, the receiver was an Object
type rather than a BigInt.

This also adds spec comments to SerializeJSONProperty.