### PR TITLE
LibCoredump: Respect coredump's LD_LIBRARY_PATH when searching libraries

### DIFF
--- a/Userland/Libraries/LibCoredump/Backtrace.cpp
+++ b/Userland/Libraries/LibCoredump/Backtrace.cpp
@@ -17,11 +17,9 @@
 
 namespace Coredump {
 
-ELFObjectInfo const* Backtrace::object_info_for_region(MemoryRegionInfo const& region)
+ELFObjectInfo const* Backtrace::object_info_for_region(Reader const& coredump, MemoryRegionInfo const& region)
 {
-    String path = region.object_name();
-    if (!path.starts_with('/') && Core::File::looks_like_shared_library(path))
-        path = LexicalPath::join("/usr/lib", path).string();
+    String path = coredump.resolve_object_path(region.object_name());
 
     auto maybe_ptr = m_debug_info_cache.get(path);
     if (maybe_ptr.has_value())
@@ -116,7 +114,7 @@ void Backtrace::add_entry(const Reader& coredump, FlatPtr ip)
     // the PT_LOAD header for the .text segment isn't the first one
     // in the object file.
     auto region = coredump.first_region_for_object(object_name);
-    auto object_info = object_info_for_region(*region);
+    auto object_info = object_info_for_region(coredump, *region);
     if (!object_info) {
         m_entries.append({ ip, object_name, {}, {} });
         return;

--- a/Userland/Libraries/LibCoredump/Backtrace.h
+++ b/Userland/Libraries/LibCoredump/Backtrace.h
@@ -45,7 +45,7 @@ public:
 
 private:
     void add_entry(const Reader&, FlatPtr ip);
-    ELFObjectInfo const* object_info_for_region(MemoryRegionInfo const&);
+    ELFObjectInfo const* object_info_for_region(Reader const&, MemoryRegionInfo const&);
 
     bool m_skip_loader_so { false };
     ELF::Core::ThreadInfo m_thread_info;

--- a/Userland/Libraries/LibCoredump/Reader.h
+++ b/Userland/Libraries/LibCoredump/Reader.h
@@ -70,6 +70,8 @@ public:
     };
     const LibraryData* library_containing(FlatPtr address) const;
 
+    String resolve_object_path(StringView object_name) const;
+
     int process_pid() const;
     u8 process_termination_signal() const;
     String process_executable_path() const;


### PR DESCRIPTION
Previously, we would only resolve libraries from `/usr/lib`, which is not the only path from which the crashed process could've loaded the libraries from.