### PR TITLE
LibGL+LibSoftGPU: Use static configuration options where possible

### DIFF
--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
  * Copyright (c) 2021-2022, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -212,7 +213,7 @@ private:
     u8 m_clear_stencil { 0 };
 
     FloatVector4 m_current_vertex_color = { 1.0f, 1.0f, 1.0f, 1.0f };
-    Vector<FloatVector4> m_current_vertex_tex_coord;
+    Array<FloatVector4, SoftGPU::Device::info.num_texture_units> m_current_vertex_tex_coord {};
     FloatVector3 m_current_vertex_normal = { 0.0f, 0.0f, 1.0f };
 
     Vector<SoftGPU::Vertex> m_vertex_list;
@@ -263,7 +264,7 @@ private:
     // Client side arrays
     bool m_client_side_vertex_array_enabled = false;
     bool m_client_side_color_array_enabled = false;
-    Vector<bool> m_client_side_texture_coord_array_enabled;
+    Array<bool, SoftGPU::Device::info.num_texture_units> m_client_side_texture_coord_array_enabled {};
     size_t m_client_active_texture = 0;
 
     NonnullRefPtr<Gfx::Bitmap> m_frontbuffer;
@@ -271,7 +272,7 @@ private:
     // Texture objects
     TextureNameAllocator m_name_allocator;
     HashMap<GLuint, RefPtr<Texture>> m_allocated_textures;
-    Vector<TextureUnit> m_texture_units;
+    Array<TextureUnit, SoftGPU::Device::info.num_texture_units> m_texture_units {};
     TextureUnit* m_active_texture_unit;
     size_t m_active_texture_unit_index { 0 };
 
@@ -282,7 +283,7 @@ private:
         FloatVector4 object_plane_coefficients { 0.0f, 0.0f, 0.0f, 0.0f };
         FloatVector4 eye_plane_coefficients { 0.0f, 0.0f, 0.0f, 0.0f };
     };
-    Vector<Array<TextureCoordinateGeneration, 4>> m_texture_coordinate_generation;
+    Array<Array<TextureCoordinateGeneration, 4>, SoftGPU::Device::info.num_texture_units> m_texture_coordinate_generation {};
     bool m_texcoord_generation_dirty { true };
 
     ALWAYS_INLINE TextureCoordinateGeneration& texture_coordinate_generation(size_t texture_unit, GLenum capability)
@@ -291,7 +292,6 @@ private:
     }
 
     SoftGPU::Device m_rasterizer;
-    SoftGPU::DeviceInfo const m_device_info;
     bool m_sampler_config_is_dirty { true };
     bool m_light_state_is_dirty { true };
 
@@ -412,7 +412,7 @@ private:
 
     VertexAttribPointer m_client_vertex_pointer;
     VertexAttribPointer m_client_color_pointer;
-    Vector<VertexAttribPointer> m_client_tex_coord_pointer;
+    Array<VertexAttribPointer, SoftGPU::Device::info.num_texture_units> m_client_tex_coord_pointer {};
 
     u8 m_pack_alignment { 4 };
     GLsizei m_unpack_row_length { 0 };
@@ -422,7 +422,7 @@ private:
 
     // Lighting configuration
     bool m_lighting_enabled { false };
-    Vector<SoftGPU::Light> m_light_states;
+    Array<SoftGPU::Light, SoftGPU::Device::info.num_lights> m_light_states {};
     Array<SoftGPU::Material, 2u> m_material_states;
 
     // Color material

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -587,18 +588,6 @@ Device::Device(const Gfx::IntSize& size)
 {
     m_options.scissor_box = m_render_target->rect();
     m_options.viewport = m_render_target->rect();
-}
-
-DeviceInfo Device::info() const
-{
-    return {
-        .vendor_name = "SerenityOS",
-        .device_name = "SoftGPU",
-        .num_texture_units = NUM_SAMPLERS,
-        .num_lights = NUM_LIGHTS,
-        .stencil_bits = sizeof(u8) * 8,
-        .supports_npot_textures = true,
-    };
 }
 
 static void generate_texture_coordinates(Vertex& vertex, RasterizerOptions const& options)

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
  * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -111,9 +112,16 @@ struct StencilConfiguration {
 
 class Device final {
 public:
-    Device(const Gfx::IntSize& min_size);
+    static constexpr DeviceInfo info {
+        .vendor_name = "SerenityOS",
+        .device_name = "SoftGPU",
+        .num_texture_units = NUM_SAMPLERS,
+        .num_lights = NUM_LIGHTS,
+        .stencil_bits = sizeof(u8) * 8,
+        .supports_npot_textures = true,
+    };
 
-    DeviceInfo info() const;
+    Device(const Gfx::IntSize& min_size);
 
     void draw_primitives(PrimitiveType, FloatMatrix4x4 const& model_view_transform, FloatMatrix3x3 const& normal_transform, FloatMatrix4x4 const& projection_transform, FloatMatrix4x4 const& texture_transform, Vector<Vertex> const& vertices, Vector<size_t> const& enabled_texture_units);
     void resize(const Gfx::IntSize& min_size);
@@ -169,5 +177,4 @@ private:
     RasterPosition m_raster_position;
     Array<StencilConfiguration, 2u> m_stencil_configuration;
 };
-
 }

--- a/Userland/Libraries/LibSoftGPU/DeviceInfo.h
+++ b/Userland/Libraries/LibSoftGPU/DeviceInfo.h
@@ -1,18 +1,17 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/String.h>
-
 namespace SoftGPU {
 
 struct DeviceInfo final {
-    String vendor_name;
-    String device_name;
+    char const* vendor_name;
+    char const* device_name;
     unsigned num_texture_units;
     unsigned num_lights;
     u8 stencil_bits;


### PR DESCRIPTION
Static configuration options `NUM_SAMPLERS`, `NUM_LIGHTS`,
`NUM_TEXTURE_UNITS`, and `SUPPORTS_NPOT_TEXTURES` are not being used
at compile-time.

This changes `SoftGPU::DeviceInfo` to be constructed at
compile-time. It allows a change from dynamic `Vector` to static
`Array` sizing. This not only eliminates the need to allocate memory
from the heap, but also ensures the data is on the stack eliminating
memory indirections.

`constexpr-if` is now possible in some spots so that branching can
happen in a compile-time context instead of at run-time.

Through compiler constant propogation, loops might also be unrolled
since the compiler can now see the number of loop iterations at
compile-time.

Performance:
- Running a profiler shows a difference in the
  `SoftwareGLContext`. Several calls do not show up at all.
- Also, the size of stripped object files `Device.cpp.o` and
  `SoftwareGLContext.cpp.o` decrease by 200 and 3872 bytes,
  respectively.
- Quake FPS shows a very small increase if any at all.