### PR TITLE
Meta: Add instructions on using Lagom in an external project

### DIFF
--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -130,3 +130,29 @@ You may run into annoying issues with the stacktrace:
 
 That means it couldn't find the executable `llvm-symbolizer`, which could be in your OS's package `llvm`.
 `llvm-symbolizer-11` will [not be recognized](https://stackoverflow.com/a/42845444/).
+
+## Using Lagom in an External Project
+It is possible to use Lagom for your own projects outside of Serenity too!
+
+An example of this in use can be found [on Linus' LibJS test262 runner](https://github.com/linusg/libjs-test262).
+
+To implement this yourself:
+- Download a copy of [linusg/libjs-test262/cmake/FetchLagom.cmake](https://github.com/linusg/libjs-test262/blob/7832c333c1504eecf1c5f9e4247aa6b34a52a3be/cmake/FetchLagom.cmake) and place it wherever you wish
+- In your root `CMakeLists.txt`, add the following commands:
+  ```cmake
+  include(FetchContent)
+  include(cmake/FetchLagom.cmake) # If you've placed the file downloaded above differently, be sure to reflect that in this command :^)
+  ```
+- In addition, you will need to also add some compile options that Serenity uses to ensure no warnings or errors:
+  ```cmake
+  add_compile_options(-Wno-literal-suffix) # AK::StringView defines operator"" sv, which GCC complains does not have an underscore.
+  add_compile_options(-fno-gnu-keywords)   # JS::Value has a method named typeof, which also happens to be a GNU keyword.
+  ```
+
+Now, you can link against Lagom libraries.
+
+Things to keep in mind:
+- You should prefer to use a library's `Lagom::` alias when linking
+  - Example: `Lagom::Core` vs `LibCore`
+- If you still _need_ to use the standard library, you may have to compile with the `AK_DONT_REPLACE_STD` macro.
+  - Serenity defines its own `move` and `forward` functions inside of `AK/StdLibExtras.h` that will clash with the standard library's definitions. This macro will make Serenity use the standard library's `move` and `forward` instead.


### PR DESCRIPTION
Things to note:
- I've given the link to a specific commit of `linusg/libjs-test262/cmake/FetchLagom.cmake` (the current latest), in the event it is updated in the future and would make this documentation incorrect. Let me know if this isn't desired!
- There are two spaces at the end of line `135` (extraneous whitespace), which tells Markdown to insert a line break.
- You _should_ scrutinize every line to the fullest! Please nitpick.