### PR TITLE
TextEditor: Support multi word selection with drag

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -353,6 +353,8 @@ private:
     size_t m_soft_tab_width { 4 };
     int m_horizontal_content_padding { 3 };
     TextRange m_selection;
+    bool m_select_by_word;
+    TextPosition m_select_by_word_origin;
 
     // NOTE: If non-zero, all glyphs will be substituted with this one.
     u32 m_substitution_code_point { 0 };

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1090,7 +1090,7 @@ bool WindowManager::is_menu_doubleclick(Window& window, MouseEvent const& event)
 void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& event)
 {
     // We only care about button presses (because otherwise it's not a doubleclick, duh!)
-    VERIFY(event.type() == Event::MouseUp);
+    VERIFY(event.type() == Event::MouseDown);
 
     if (&window != m_double_click_info.m_clicked_window) {
         // we either haven't clicked anywhere, or we haven't clicked on this
@@ -1125,7 +1125,7 @@ void WindowManager::deliver_mouse_event(Window& window, MouseEvent const& event,
 {
     auto translated_event = event.translated(-window.position());
     window.dispatch_event(translated_event);
-    if (process_double_click && translated_event.type() == Event::MouseUp) {
+    if (process_double_click && translated_event.type() == Event::MouseDown) {
         process_event_for_doubleclick(window, translated_event);
         if (translated_event.type() == Event::MouseDoubleClick)
             window.dispatch_event(translated_event);


### PR DESCRIPTION
Current doubleclick+drag behaviour in TextEditor is to (1) select the current word, and (2) do nothing. I think the expected behaviour is (1) select the current word, and (2) expand the selection with the beginning/ending of the selection restricted to word boundaries.

To support this behaviour I needed to modify what WindowManager considers a "double click" from two consecutive `MouseUp` events to two consecutive `MouseDown` events. I would argue that this is also generally expected behaviour. (I haven't considered or investigated how changing this behaviour may affect other apps.)

(Of course when I say "expected" I mean "typical in other GUI software". SerenityOS might _intentionally_ behave differently here, and that's fine -- happy to move on to my next change if that's the case 😄.)