### PR TITLE
Base: Use GML file type icon

### DIFF
--- a/Base/etc/FileIconProvider.ini
+++ b/Base/etc/FileIconProvider.ini
@@ -12,6 +12,7 @@ library=*.so,*.so.*,*.a
 markdown=*.md
 music=*.midi
 object=*.o,*.obj
+gml=*.gml
 palette=*.palette
 pdf=*.pdf
 python=*.py


### PR DESCRIPTION
Start using the GML file type icon.