### PR TITLE
CI: Create a js(1) release package

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -133,3 +133,16 @@ jobs:
         continue-on-error: true
         working-directory: libjs-test262
         run: ./per_file_result_diff.py -o per-file-bytecode-master.json -n ../libjs-website/test262/data/per-file-bytecode-master.json
+
+      - name: Build and package js
+        working-directory: libjs-test262/Build
+        run: |
+          ninja js
+          cpack -D CPACK_INSTALL_CMAKE_PROJECTS="$(pwd)/_deps/lagom-build;js;js;/"
+
+      - name: Upload js package
+        uses: actions/upload-artifact@v2
+        with:
+          name: serenity-js
+          path: libjs-test262/Build/serenity-js.tar.gz
+          retention-days: 7

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -304,7 +304,7 @@ if (BUILD_LAGOM)
     )
 
     # ELF
-    # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem 
+    # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem
     #        for Lagom on Apple M1
     if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
         file(GLOB LIBELF_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibELF/*.cpp")
@@ -462,7 +462,7 @@ if (BUILD_LAGOM)
     )
 
     # x86
-    # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem 
+    # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem
     #        for Lagom on Apple M1
     if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
         file(GLOB LIBX86_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibX86/*.cpp")
@@ -484,7 +484,7 @@ if (BUILD_LAGOM)
         set_target_properties(adjtime_lagom PROPERTIES OUTPUT_NAME adjtime)
         target_link_libraries(adjtime_lagom LagomCore LagomMain)
 
-        # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem 
+        # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem
         #        for Lagom on Apple M1
         if (NOT CMAKE_SYSTEM_PROCESSOR MATCHES "arm64")
             add_executable(disasm_lagom ../../Userland/Utilities/disasm.cpp)
@@ -658,6 +658,20 @@ if (BUILD_LAGOM)
                 PASS_REGULAR_EXPRESSION "PASS"
             )
         endforeach()
+
+        # FIXME: When we are using CMake >= 3.21, the library installations can be replaced with RUNTIME_DEPENDENCIES.
+        #        https://cmake.org/cmake/help/latest/command/install.html
+        include(get_linked_lagom_libraries.cmake)
+        get_linked_lagom_libraries(js_lagom js_lagom_libraries)
+
+        install(TARGETS js_lagom ${js_lagom_libraries} COMPONENT js)
+
+        set(CPACK_GENERATOR "TGZ")
+        set(CPACK_STRIP_FILES TRUE)
+        set(CPACK_ARCHIVE_COMPONENT_INSTALL ON)
+        set(CPACK_COMPONENTS_ALL js)
+        set(CPACK_PACKAGE_FILE_NAME serenity-js)
+        include(CPack)
     endif()
 endif()
 

--- a/Meta/Lagom/get_linked_lagom_libraries.cmake
+++ b/Meta/Lagom/get_linked_lagom_libraries.cmake
@@ -1,0 +1,34 @@
+function(add_lagom_library list item)
+    list(FIND "${list}" "${item}" item_is_present)
+
+    if (item_is_present EQUAL -1)
+        set("${list}" "${${list}}" "${item}" PARENT_SCOPE)
+     endif()
+endfunction()
+
+function(get_linked_lagom_libraries_impl target output)
+    if (NOT TARGET "${target}")
+        return()
+    endif()
+
+    get_target_property(target_type "${target}" TYPE)
+
+    if ("${target_type}" STREQUAL "SHARED_LIBRARY")
+        add_lagom_library("${output}" "${target}")
+    elseif ("${target_type}" STREQUAL "INTERFACE_LIBRARY")
+        return()
+    endif()
+
+    get_target_property(target_libraries "${target}" LINK_LIBRARIES)
+
+    foreach(target_library IN LISTS target_libraries)
+        get_linked_lagom_libraries_impl("${target_library}" "${output}")
+    endforeach()
+
+    set("${output}" "${${output}}" PARENT_SCOPE)
+endfunction()
+
+function(get_linked_lagom_libraries target output)
+    get_linked_lagom_libraries_impl(${target} ${output})
+    set("${output}" "${${output}}" PARENT_SCOPE)
+endfunction()


### PR DESCRIPTION
After this is merged, we can then create an "engine" script like this to find and download the latest release:
https://github.com/devsnek/esvu/blob/master/src/engines/javascriptcore.js

An example run of this pipeline is here, but of course not tested on the dedicated runner:
https://github.com/trflynn89/serenity/actions/runs/1813691949

![js](https://user-images.githubusercontent.com/5600524/152858789-46ab27a1-5196-41bf-921d-7e324fa20f2f.png)
