### PR TITLE
AK+Everywhere: Change [dbg,out,warn]ln_if from macro to function

### DIFF
--- a/AK/Format.h
+++ b/AK/Format.h
@@ -594,6 +594,14 @@ void dbgln(CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... par
 
 inline void dbgln() { dbgln(""); }
 
+template<bool flag, typename... Parameters>
+inline void dbgln_if(Parameters&&... parameters)
+{
+    if constexpr (flag) {
+        dbgln(forward<Parameters...>(parameters...));
+    }
+}
+
 void set_debug_enabled(bool);
 
 #ifdef KERNEL
@@ -707,13 +715,8 @@ using AK::warnln;
 #endif
 
 using AK::dbgln;
+using AK::dbgln_if;
 
 using AK::CheckedFormatString;
 using AK::FormatIfSupported;
 using AK::FormatString;
-
-#define dbgln_if(flag, fmt, ...)       \
-    do {                               \
-        if constexpr (flag)            \
-            dbgln(fmt, ##__VA_ARGS__); \
-    } while (0)

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -558,11 +558,13 @@ void outln(CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... par
 
 inline void outln() { outln(stdout); }
 
-#    define outln_if(flag, fmt, ...)       \
-        do {                               \
-            if constexpr (flag)            \
-                outln(fmt, ##__VA_ARGS__); \
-        } while (0)
+template<bool flag, typename... Parameters>
+inline void outln_if(Parameters&&... parameters)
+{
+    if constexpr (flag) {
+        outln(forward<Parameters...>(parameters...));
+    }
+}
 
 template<typename... Parameters>
 void warn(CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... parameters)
@@ -709,6 +711,7 @@ using AK::dmesgln;
 #else
 using AK::out;
 using AK::outln;
+using AK::outln_if;
 
 using AK::warn;
 using AK::warnln;

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -577,11 +577,13 @@ void warnln(CheckedFormatString<Parameters...>&& fmtstr, const Parameters&... pa
 
 inline void warnln() { outln(stderr); }
 
-#    define warnln_if(flag, fmt, ...)      \
-        do {                               \
-            if constexpr (flag)            \
-                outln(fmt, ##__VA_ARGS__); \
-        } while (0)
+template<bool flag, typename... Parameters>
+inline void warnln_if(Parameters&&... parameters)
+{
+    if constexpr (flag) {
+        warnln(forward<Parameters...>(parameters...));
+    }
+}
 
 #endif
 
@@ -715,6 +717,7 @@ using AK::outln_if;
 
 using AK::warn;
 using AK::warnln;
+using AK::warnln_if;
 #endif
 
 using AK::dbgln;

--- a/AK/URLParser.cpp
+++ b/AK/URLParser.cpp
@@ -27,7 +27,7 @@ constexpr bool is_url_code_point(u32 code_point)
 
 static void report_validation_error(SourceLocation const& location = SourceLocation::current())
 {
-    dbgln_if(URL_PARSER_DEBUG, "URLParser::parse: Validation error! {}", location);
+    dbgln_if<URL_PARSER_DEBUG>("URLParser::parse: Validation error! {}", location);
 }
 
 static Optional<String> parse_opaque_host(StringView input)
@@ -119,7 +119,7 @@ constexpr bool is_double_dot_path_segment(StringView input)
 // FIXME: This only loosely follows the spec, as we use the same class for "regular" and data URLs, unlike the spec.
 Optional<URL> URLParser::parse_data_url(StringView raw_input)
 {
-    dbgln_if(URL_PARSER_DEBUG, "URLParser::parse_data_url: Parsing '{}'.", raw_input);
+    dbgln_if<URL_PARSER_DEBUG>("URLParser::parse_data_url: Parsing '{}'.", raw_input);
     VERIFY(raw_input.starts_with("data:"));
     auto input = raw_input.substring_view(5);
     auto comma_offset = input.find(',');
@@ -147,7 +147,7 @@ Optional<URL> URLParser::parse_data_url(StringView raw_input)
 
     // FIXME: Parse the MIME type's components according to https://mimesniff.spec.whatwg.org/#parse-a-mime-type
     URL url { StringUtils::trim(mime_type, "\n\r\t ", TrimMode::Both), move(body), is_base64_encoded };
-    dbgln_if(URL_PARSER_DEBUG, "URLParser::parse_data_url: Parsed data URL to be '{}'.", url.serialize());
+    dbgln_if<URL_PARSER_DEBUG>("URLParser::parse_data_url: Parsed data URL to be '{}'.", url.serialize());
     return url;
 }
 
@@ -163,7 +163,7 @@ Optional<URL> URLParser::parse_data_url(StringView raw_input)
 //       everything before setting the member variables.
 URL URLParser::parse(StringView raw_input, URL const* base_url, Optional<URL> url, Optional<State> state_override)
 {
-    dbgln_if(URL_PARSER_DEBUG, "URLParser::parse: Parsing '{}'", raw_input);
+    dbgln_if<URL_PARSER_DEBUG>("URLParser::parse: Parsing '{}'", raw_input);
     if (raw_input.is_empty())
         return {};
 
@@ -675,7 +675,7 @@ URL URLParser::parse(StringView raw_input, URL const* base_url, Optional<URL> ur
     }
 
     url->m_valid = true;
-    dbgln_if(URL_PARSER_DEBUG, "URLParser::parse: Parsed URL to be '{}'.", url->serialize());
+    dbgln_if<URL_PARSER_DEBUG>("URLParser::parse: Parsed URL to be '{}'.", url->serialize());
     return url.release_value();
 }
 

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -408,7 +408,7 @@ void page_fault_handler(TrapFrame* trap)
 
         return handle_crash(regs, "Page Fault", SIGSEGV, response == PageFaultResponse::OutOfMemory);
     } else if (response == PageFaultResponse::Continue) {
-        dbgln_if(PAGE_FAULT_DEBUG, "Continuing after resolved page fault");
+        dbgln_if<PAGE_FAULT_DEBUG>("Continuing after resolved page fault");
     } else {
         VERIFY_NOT_REACHED();
     }

--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -909,7 +909,7 @@ bool Processor::smp_process_pending_messages()
             next_msg = cur_msg->next;
             auto msg = cur_msg->msg;
 
-            dbgln_if(SMP_DEBUG, "SMP[{}]: Processing message {}", current_id(), VirtualAddress(msg));
+            dbgln_if<SMP_DEBUG>("SMP[{}]: Processing message {}", current_id(), VirtualAddress(msg));
 
             switch (msg->type) {
             case ProcessorMessage::Callback:
@@ -921,7 +921,7 @@ bool Processor::smp_process_pending_messages()
                     VERIFY(Memory::is_user_range(VirtualAddress(msg->flush_tlb.ptr), msg->flush_tlb.page_count * PAGE_SIZE));
                     if (read_cr3() != msg->flush_tlb.page_directory->cr3()) {
                         // This processor isn't using this page directory right now, we can ignore this request
-                        dbgln_if(SMP_DEBUG, "SMP[{}]: No need to flush {} pages at {}", current_id(), msg->flush_tlb.page_count, VirtualAddress(msg->flush_tlb.ptr));
+                        dbgln_if<SMP_DEBUG>("SMP[{}]: No need to flush {} pages at {}", current_id(), msg->flush_tlb.page_count, VirtualAddress(msg->flush_tlb.ptr));
                         break;
                     }
                 }
@@ -977,7 +977,7 @@ void Processor::smp_broadcast_message(ProcessorMessage& msg)
 {
     auto& current_processor = Processor::current();
 
-    dbgln_if(SMP_DEBUG, "SMP[{}]: Broadcast message {} to cpus: {} processor: {}", current_processor.id(), VirtualAddress(&msg), count(), VirtualAddress(&current_processor));
+    dbgln_if<SMP_DEBUG>("SMP[{}]: Broadcast message {} to cpus: {} processor: {}", current_processor.id(), VirtualAddress(&msg), count(), VirtualAddress(&current_processor));
 
     msg.refs.store(count() - 1, AK::MemoryOrder::memory_order_release);
     VERIFY(msg.refs > 0);
@@ -1021,7 +1021,7 @@ void Processor::smp_unicast_message(u32 cpu, ProcessorMessage& msg, bool async)
     auto& target_processor = processors()[cpu];
     msg.async = async;
 
-    dbgln_if(SMP_DEBUG, "SMP[{}]: Send message {} to cpu #{} processor: {}", current_processor.id(), VirtualAddress(&msg), cpu, VirtualAddress(&target_processor));
+    dbgln_if<SMP_DEBUG>("SMP[{}]: Send message {} to cpu #{} processor: {}", current_processor.id(), VirtualAddress(&msg), cpu, VirtualAddress(&target_processor));
 
     msg.refs.store(1u, AK::MemoryOrder::memory_order_release);
     if (target_processor->smp_enqueue_message(msg)) {
@@ -1281,7 +1281,7 @@ extern "C" void context_first_init([[maybe_unused]] Thread* from_thread, [[maybe
     VERIFY(!are_interrupts_enabled());
     VERIFY(is_kernel_mode());
 
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context <-- from {} {} to {} {} (context_first_init)", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
+    dbgln_if<CONTEXT_SWITCH_DEBUG>("switch_context <-- from {} {} to {} {} (context_first_init)", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
 
     VERIFY(to_thread == Thread::current());
 
@@ -1373,7 +1373,7 @@ extern "C" FlatPtr do_init_context(Thread* thread, u32 flags)
 
 void Processor::assume_context(Thread& thread, FlatPtr flags)
 {
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "Assume context for thread {} {}", VirtualAddress(&thread), thread);
+    dbgln_if<CONTEXT_SWITCH_DEBUG>("Assume context for thread {} {}", VirtualAddress(&thread), thread);
 
     VERIFY_INTERRUPTS_DISABLED();
     Scheduler::prepare_after_exec();

--- a/Kernel/Arch/x86/i386/Processor.cpp
+++ b/Kernel/Arch/x86/i386/Processor.cpp
@@ -185,7 +185,7 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
     VERIFY(m_in_critical == 1);
     VERIFY(is_kernel_mode());
 
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context --> switching out of: {} {}", VirtualAddress(from_thread), *from_thread);
+    dbgln_if<CONTEXT_SWITCH_DEBUG>("switch_context --> switching out of: {} {}", VirtualAddress(from_thread), *from_thread);
 
     // m_in_critical is restored in enter_thread_context
     from_thread->save_critical(m_in_critical);
@@ -232,7 +232,7 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
     );
     // clang-format on
 
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context <-- from {} {} to {} {}", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
+    dbgln_if<CONTEXT_SWITCH_DEBUG>("switch_context <-- from {} {} to {} {}", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
 }
 
 UNMAP_AFTER_INIT void Processor::initialize_context_switching(Thread& initial_thread)

--- a/Kernel/Arch/x86/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86/x86_64/Processor.cpp
@@ -169,7 +169,7 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
     VERIFY(m_in_critical == 1);
     VERIFY(is_kernel_mode());
 
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context --> switching out of: {} {}", VirtualAddress(from_thread), *from_thread);
+    dbgln_if<CONTEXT_SWITCH_DEBUG>("switch_context --> switching out of: {} {}", VirtualAddress(from_thread), *from_thread);
 
     // m_in_critical is restored in enter_thread_context
     from_thread->save_critical(m_in_critical);
@@ -240,7 +240,7 @@ void Processor::switch_context(Thread*& from_thread, Thread*& to_thread)
     );
     // clang-format on
 
-    dbgln_if(CONTEXT_SWITCH_DEBUG, "switch_context <-- from {} {} to {} {}", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
+    dbgln_if<CONTEXT_SWITCH_DEBUG>("switch_context <-- from {} {} to {} {}", VirtualAddress(from_thread), *from_thread, VirtualAddress(to_thread), *to_thread);
 }
 
 UNMAP_AFTER_INIT void Processor::initialize_context_switching(Thread& initial_thread)

--- a/Kernel/Bus/PCI/Access.cpp
+++ b/Kernel/Bus/PCI/Access.cpp
@@ -71,7 +71,7 @@ UNMAP_AFTER_INIT bool Access::find_and_register_pci_host_bridges_from_acpi_mcfg_
     if (mcfg_region_or_error.is_error())
         return false;
     auto& mcfg = *(ACPI::Structures::MCFG*)mcfg_region_or_error.value()->vaddr().offset(mcfg_table.offset_in_page()).as_ptr();
-    dbgln_if(PCI_DEBUG, "PCI: Checking MCFG @ {}, {}", VirtualAddress(&mcfg), mcfg_table);
+    dbgln_if<PCI_DEBUG>("PCI: Checking MCFG @ {}, {}", VirtualAddress(&mcfg), mcfg_table);
     for (u32 index = 0; index < ((mcfg.header.length - sizeof(ACPI::Structures::MCFG)) / sizeof(ACPI::Structures::PCI_MMIO_Descriptor)); index++) {
         u8 start_bus = mcfg.descriptors[index].start_pci_bus;
         u8 end_bus = mcfg.descriptors[index].end_pci_bus;
@@ -93,7 +93,7 @@ UNMAP_AFTER_INIT bool Access::initialize_for_multiple_pci_domains(PhysicalAddres
     if (!access->find_and_register_pci_host_bridges_from_acpi_mcfg_table(mcfg_table))
         return false;
     access->rescan_hardware();
-    dbgln_if(PCI_DEBUG, "PCI: access for multiple PCI domain initialised.");
+    dbgln_if<PCI_DEBUG>("PCI: access for multiple PCI domain initialised.");
     return true;
 }
 
@@ -104,7 +104,7 @@ UNMAP_AFTER_INIT bool Access::initialize_for_one_pci_domain()
     auto host_bridge = HostBridge::must_create_with_io_access();
     access->add_host_controller(move(host_bridge));
     access->rescan_hardware();
-    dbgln_if(PCI_DEBUG, "PCI: access for one PCI domain initialised.");
+    dbgln_if<PCI_DEBUG>("PCI: access for one PCI domain initialised.");
     return true;
 }
 

--- a/Kernel/Bus/PCI/Controller/HostBridge.cpp
+++ b/Kernel/Bus/PCI/Controller/HostBridge.cpp
@@ -52,7 +52,7 @@ UNMAP_AFTER_INIT Vector<Capability> HostBridge::get_capabilities_for_function(Bu
 
 UNMAP_AFTER_INIT void HostBridge::enumerate_functions(Function<void(DeviceIdentifier)> const& callback, BusNumber bus, DeviceNumber device, FunctionNumber function, bool recursive_search_into_bridges)
 {
-    dbgln_if(PCI_DEBUG, "PCI: Enumerating function, bus={}, device={}, function={}", bus, device, function);
+    dbgln_if<PCI_DEBUG>("PCI: Enumerating function, bus={}, device={}, function={}", bus, device, function);
     Address address(domain_number(), bus.value(), device.value(), function.value());
     auto pci_class = (read8_field(bus, device, function, PCI::RegisterOffset::CLASS) << 8u) | read8_field(bus, device, function, PCI::RegisterOffset::SUBCLASS);
 
@@ -72,7 +72,7 @@ UNMAP_AFTER_INIT void HostBridge::enumerate_functions(Function<void(DeviceIdenti
         && recursive_search_into_bridges
         && (!m_enumerated_buses.get(read8_field(bus, device, function, PCI::RegisterOffset::SECONDARY_BUS)))) {
         u8 secondary_bus = read8_field(bus, device, function, PCI::RegisterOffset::SECONDARY_BUS);
-        dbgln_if(PCI_DEBUG, "PCI: Found secondary bus: {}", secondary_bus);
+        dbgln_if<PCI_DEBUG>("PCI: Found secondary bus: {}", secondary_bus);
         VERIFY(secondary_bus != bus);
         m_enumerated_buses.set(secondary_bus, true);
         enumerate_bus(callback, secondary_bus, recursive_search_into_bridges);
@@ -81,7 +81,7 @@ UNMAP_AFTER_INIT void HostBridge::enumerate_functions(Function<void(DeviceIdenti
 
 UNMAP_AFTER_INIT void HostBridge::enumerate_device(Function<void(DeviceIdentifier)> const& callback, BusNumber bus, DeviceNumber device, bool recursive_search_into_bridges)
 {
-    dbgln_if(PCI_DEBUG, "PCI: Enumerating device in bus={}, device={}", bus, device);
+    dbgln_if<PCI_DEBUG>("PCI: Enumerating device in bus={}, device={}", bus, device);
     if (read16_field(bus, device, 0, PCI::RegisterOffset::VENDOR_ID) == PCI::none_value)
         return;
     enumerate_functions(callback, bus, device, 0, recursive_search_into_bridges);
@@ -95,7 +95,7 @@ UNMAP_AFTER_INIT void HostBridge::enumerate_device(Function<void(DeviceIdentifie
 
 UNMAP_AFTER_INIT void HostBridge::enumerate_bus(Function<void(DeviceIdentifier)> const& callback, BusNumber bus, bool recursive_search_into_bridges)
 {
-    dbgln_if(PCI_DEBUG, "PCI: Enumerating bus {}", bus);
+    dbgln_if<PCI_DEBUG>("PCI: Enumerating bus {}", bus);
     for (u8 device = 0; device < 32; ++device)
         enumerate_device(callback, bus, device, recursive_search_into_bridges);
 }

--- a/Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.cpp
+++ b/Kernel/Bus/PCI/Controller/MemoryBackedHostBridge.cpp
@@ -75,7 +75,7 @@ void MemoryBackedHostBridge::map_bus_region(BusNumber bus)
         VERIFY_NOT_REACHED();
     m_mapped_bus_region = region_or_error.release_value();
     m_mapped_bus = bus;
-    dbgln_if(PCI_DEBUG, "PCI: New PCI ECAM Mapped region for bus {} @ {} {}", bus, m_mapped_bus_region->vaddr(), m_mapped_bus_region->physical_page(0)->paddr());
+    dbgln_if<PCI_DEBUG>("PCI: New PCI ECAM Mapped region for bus {} @ {} {}", bus, m_mapped_bus_region->vaddr(), m_mapped_bus_region->physical_page(0)->paddr());
 }
 
 VirtualAddress MemoryBackedHostBridge::get_device_configuration_memory_mapped_space(BusNumber bus, DeviceNumber device, FunctionNumber function)

--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -66,7 +66,7 @@ ErrorOr<void> SysFSUSBDeviceInformation::refresh_data(OpenFileDescription& descr
 
 ErrorOr<size_t> SysFSUSBDeviceInformation::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, OpenFileDescription* description) const
 {
-    dbgln_if(PROCFS_DEBUG, "SysFSUSBDeviceInformation @ {}: read_bytes offset: {} count: {}", name(), offset, count);
+    dbgln_if<PROCFS_DEBUG>("SysFSUSBDeviceInformation @ {}: read_bytes offset: {} count: {}", name(), offset, count);
 
     VERIFY(offset >= 0);
     VERIFY(buffer.user_or_kernel_ptr());

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -362,7 +362,7 @@ ErrorOr<size_t> UHCIController::submit_control_transfer(Transfer& transfer)
     Pipe& pipe = transfer.pipe(); // Short circuit the pipe related to this transfer
     bool direction_in = (transfer.request().request_type & USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST) == USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST;
 
-    dbgln_if(UHCI_DEBUG, "UHCI: Received control transfer for address {}. Root Hub is at address {}.", pipe.device_address(), m_root_hub->device_address());
+    dbgln_if<UHCI_DEBUG>("UHCI: Received control transfer for address {}. Root Hub is at address {}.", pipe.device_address(), m_root_hub->device_address());
 
     // Short-circuit the root hub.
     if (pipe.device_address() == m_root_hub->device_address())
@@ -450,7 +450,7 @@ size_t UHCIController::poll_transfer_queue(QueueHead& transfer_queue)
         if (status & TransferDescriptor::StatusBits::ErrorMask) {
             transfer->set_complete();
             transfer->set_error_occurred();
-            dbgln_if(UHCI_DEBUG, "UHCIController: Transfer failed! Reason: {:08x}", status);
+            dbgln_if<UHCI_DEBUG>("UHCIController: Transfer failed! Reason: {:08x}", status);
             return 0;
         }
 
@@ -533,7 +533,7 @@ void UHCIController::get_port_status(Badge<UHCIRootHub>, u8 port, HubStatus& hub
     // UHCI ports are always powered.
     hub_port_status.status |= PORT_STATUS_PORT_POWER;
 
-    dbgln_if(UHCI_DEBUG, "UHCI: get_port_status status=0x{:04x} change=0x{:04x}", hub_port_status.status, hub_port_status.change);
+    dbgln_if<UHCI_DEBUG>("UHCI: get_port_status status=0x{:04x} change=0x{:04x}", static_cast<u16>(hub_port_status.status), static_cast<u16>(hub_port_status.change));
 }
 
 void UHCIController::reset_port(u8 port)
@@ -577,7 +577,7 @@ void UHCIController::reset_port(u8 port)
     else
         write_portsc2(port_data);
 
-    dbgln_if(UHCI_DEBUG, "UHCI: Port should be enabled now: {:#04x}", port == 0 ? read_portsc1() : read_portsc2());
+    dbgln_if<UHCI_DEBUG>("UHCI: Port should be enabled now: {:#04x}", port == 0 ? read_portsc1() : read_portsc2());
     m_port_reset_change_statuses |= (1 << port);
 }
 
@@ -586,7 +586,7 @@ ErrorOr<void> UHCIController::set_port_feature(Badge<UHCIRootHub>, u8 port, HubF
     // The check is done by UHCIRootHub.
     VERIFY(port < NUMBER_OF_ROOT_PORTS);
 
-    dbgln_if(UHCI_DEBUG, "UHCI: set_port_feature: port={} feature_selector={}", port, (u8)feature_selector);
+    dbgln_if<UHCI_DEBUG>("UHCI: set_port_feature: port={} feature_selector={}", port, (u8)feature_selector);
 
     switch (feature_selector) {
     case HubFeatureSelector::PORT_POWER:
@@ -621,7 +621,7 @@ ErrorOr<void> UHCIController::clear_port_feature(Badge<UHCIRootHub>, u8 port, Hu
     // The check is done by UHCIRootHub.
     VERIFY(port < NUMBER_OF_ROOT_PORTS);
 
-    dbgln_if(UHCI_DEBUG, "UHCI: clear_port_feature: port={} feature_selector={}", port, (u8)feature_selector);
+    dbgln_if<UHCI_DEBUG>("UHCI: clear_port_feature: port={} feature_selector={}", port, (u8)feature_selector);
 
     u16 port_data = port == 0 ? read_portsc1() : read_portsc2();
     port_data &= UHCI_PORTSC_NON_WRITE_CLEAR_BIT_MASK;
@@ -655,7 +655,7 @@ ErrorOr<void> UHCIController::clear_port_feature(Badge<UHCIRootHub>, u8 port, Hu
         return EINVAL;
     }
 
-    dbgln_if(UHCI_DEBUG, "UHCI: clear_port_feature: writing 0x{:04x} to portsc{}.", port_data, port + 1);
+    dbgln_if<UHCI_DEBUG>("UHCI: clear_port_feature: writing 0x{:04x} to portsc{}.", port_data, port + 1);
 
     if (port == 0)
         write_portsc1(port_data);

--- a/Kernel/Bus/USB/UHCI/UHCIDescriptorPool.h
+++ b/Kernel/Bus/USB/UHCI/UHCIDescriptorPool.h
@@ -42,7 +42,7 @@ public:
         if (m_free_descriptor_stack.is_empty())
             return nullptr;
 
-        dbgln_if(UHCI_VERBOSE_DEBUG, "Got a free UHCI Descriptor @ {} from pool {}", m_free_descriptor_stack.top(), m_pool_name);
+        dbgln_if<UHCI_VERBOSE_DEBUG>("Got a free UHCI Descriptor @ {} from pool {}", m_free_descriptor_stack.top(), m_pool_name);
         T* descriptor = m_free_descriptor_stack.top();
         m_free_descriptor_stack.pop();
 
@@ -51,7 +51,7 @@ public:
 
     void release_to_pool(T* ptr)
     {
-        dbgln_if(UHCI_VERBOSE_DEBUG, "Returning descriptor @ {} to pool {}", ptr, m_pool_name);
+        dbgln_if<UHCI_VERBOSE_DEBUG>("Returning descriptor @ {} to pool {}", ptr, m_pool_name);
         if (!m_free_descriptor_stack.push(ptr))
             dbgln("Failed to return descriptor to pool {}. Stack overflow!", m_pool_name);
     }

--- a/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIRootHub.cpp
@@ -179,7 +179,7 @@ ErrorOr<size_t> UHCIRootHub::handle_control_transfer(Transfer& transfer)
         break;
     }
     case USB_REQUEST_SET_ADDRESS:
-        dbgln_if(UHCI_DEBUG, "UHCIRootHub: Attempt to set address to {}, ignoring.", request.value);
+        dbgln_if<UHCI_DEBUG>("UHCIRootHub: Attempt to set address to {}, ignoring.", request.value);
         if (request.value > USB_MAX_ADDRESS)
             return EINVAL;
         // Ignore SET_ADDRESS requests. USBDevice sets its internal address to the new allocated address that it just sent to us.

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -114,7 +114,7 @@ ErrorOr<void> Device::enumerate_device()
     m_address = new_address;
     m_default_pipe->set_device_address(new_address);
 
-    dbgln_if(USB_DEBUG, "USB Device: Set address to {}", m_address);
+    dbgln_if<USB_DEBUG>("USB Device: Set address to {}", m_address);
 
     memcpy(&m_device_descriptor, &dev_descriptor, sizeof(USBDeviceDescriptor));
     return {};

--- a/Kernel/Bus/USB/USBPipe.cpp
+++ b/Kernel/Bus/USB/USBPipe.cpp
@@ -60,14 +60,14 @@ ErrorOr<size_t> Pipe::control_transfer(u8 request_type, u8 request, u16 value, u
     auto transfer = TRY(Transfer::try_create(*this, length));
     transfer->set_setup_packet(usb_request);
 
-    dbgln_if(USB_DEBUG, "Pipe: Transfer allocated @ {}", transfer->buffer_physical());
+    dbgln_if<USB_DEBUG>("Pipe: Transfer allocated @ {}", transfer->buffer_physical());
     auto transfer_length = TRY(m_controller->submit_control_transfer(*transfer));
 
     // TODO: Check transfer for completion and copy data from transfer buffer into data
     if (length > 0)
         memcpy(reinterpret_cast<u8*>(data), transfer->buffer().as_ptr() + sizeof(USBRequestData), length);
 
-    dbgln_if(USB_DEBUG, "Pipe: Control Transfer complete!");
+    dbgln_if<USB_DEBUG>("Pipe: Control Transfer complete!");
     return transfer_length;
 }
 

--- a/Kernel/Bus/VirtIO/Console.cpp
+++ b/Kernel/Bus/VirtIO/Console.cpp
@@ -76,7 +76,7 @@ bool Console::handle_device_config_change()
 
 void Console::handle_queue_update(u16 queue_index)
 {
-    dbgln_if(VIRTIO_DEBUG, "VirtIO::Console: Handle queue update {}", queue_index);
+    dbgln_if<VIRTIO_DEBUG>("VirtIO::Console: Handle queue update {}", queue_index);
 
     if (queue_index == CONTROL_RECEIVEQ) {
         SpinlockLocker ringbuffer_lock(m_control_receive_buffer->lock());

--- a/Kernel/Bus/VirtIO/ConsolePort.cpp
+++ b/Kernel/Bus/VirtIO/ConsolePort.cpp
@@ -44,7 +44,7 @@ void ConsolePort::init_receive_buffer(Badge<VirtIO::Console>)
 
 void ConsolePort::handle_queue_update(Badge<VirtIO::Console>, u16 queue_index)
 {
-    dbgln_if(VIRTIO_DEBUG, "VirtIO::ConsolePort: Handle queue update for port {}", m_port);
+    dbgln_if<VIRTIO_DEBUG>("VirtIO::ConsolePort: Handle queue update for port {}", m_port);
     VERIFY(queue_index == m_transmit_queue || queue_index == m_receive_queue);
     if (queue_index == m_receive_queue) {
         auto& queue = m_console.get_queue(m_receive_queue);

--- a/Kernel/Bus/VirtIO/RNG.cpp
+++ b/Kernel/Bus/VirtIO/RNG.cpp
@@ -59,7 +59,7 @@ void RNG::handle_queue_update(u16 queue_index)
         });
         chain.release_buffer_slots_to_queue();
     }
-    dbgln_if(VIRTIO_DEBUG, "VirtIO::RNG: received {} bytes of entropy!", available_entropy);
+    dbgln_if<VIRTIO_DEBUG>("VirtIO::RNG: received {} bytes of entropy!", available_entropy);
     for (auto i = 0u; i < available_entropy; i++) {
         m_entropy_source.add_random_event(m_entropy_buffer->vaddr().as_ptr()[i]);
     }

--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -57,7 +57,7 @@ bool AC97::handle_irq(RegisterState const&)
 {
     auto pcm_out_status_register = m_pcm_out_channel.reg(AC97Channel::Register::Status);
     auto pcm_out_status = pcm_out_status_register.in<u16>();
-    dbgln_if(AC97_DEBUG, "AC97 @ {}: interrupt received - stat: {:#b}", pci_address(), pcm_out_status);
+    dbgln_if<AC97_DEBUG>("AC97 @ {}: interrupt received - stat: {:#b}", pci_address(), pcm_out_status);
 
     bool is_dma_halted = (pcm_out_status & AudioStatusRegisterFlag::DMAControllerHalted) > 0;
     bool is_completion_interrupt = (pcm_out_status & AudioStatusRegisterFlag::BufferCompletionInterruptStatus) > 0;
@@ -86,8 +86,8 @@ bool AC97::handle_irq(RegisterState const&)
 
 UNMAP_AFTER_INIT void AC97::initialize()
 {
-    dbgln_if(AC97_DEBUG, "AC97 @ {}: mixer base: {:#04x}", pci_address(), m_io_mixer_base.get());
-    dbgln_if(AC97_DEBUG, "AC97 @ {}: bus base: {:#04x}", pci_address(), m_io_bus_base.get());
+    dbgln_if<AC97_DEBUG>("AC97 @ {}: mixer base: {:#04x}", pci_address(), m_io_mixer_base.get());
+    dbgln_if<AC97_DEBUG>("AC97 @ {}: bus base: {:#04x}", pci_address(), m_io_bus_base.get());
 
     enable_pin_based_interrupts();
     PCI::enable_bus_mastering(pci_address());
@@ -237,7 +237,7 @@ ErrorOr<void> AC97::write_single_buffer(UserOrKernelBuffer const& data, size_t o
         if (head_distance < m_output_buffer_page_count)
             break;
 
-        dbgln_if(AC97_DEBUG, "AC97 @ {}: waiting on interrupt - stat: {:#b} CI: {} LVI: {}", pci_address(), pcm_out_status, current_index, last_valid_index);
+        dbgln_if<AC97_DEBUG>("AC97 @ {}: waiting on interrupt - stat: {:#b} CI: {} LVI: {}", pci_address(), pcm_out_status, current_index, last_valid_index);
         m_irq_queue.wait_forever("AC97"sv);
     } while (m_pcm_out_channel.dma_running());
     sti();
@@ -284,7 +284,7 @@ void AC97::AC97Channel::reset()
 
 void AC97::AC97Channel::set_last_valid_index(u32 buffer_address, u8 last_valid_index)
 {
-    dbgln_if(AC97_DEBUG, "AC97 @ {}: setting LVI - address: {:#x} LVI: {}", m_device.pci_address(), buffer_address, last_valid_index);
+    dbgln_if<AC97_DEBUG>("AC97 @ {}: setting LVI - address: {:#x} LVI: {}", m_device.pci_address(), buffer_address, last_valid_index);
 
     reg(Register::BufferDescriptorListBaseAddress).out(buffer_address);
     reg(Register::LastValidIndex).out(last_valid_index);

--- a/Kernel/Devices/Audio/SB16.cpp
+++ b/Kernel/Devices/Audio/SB16.cpp
@@ -255,7 +255,7 @@ ErrorOr<size_t> SB16::write(OpenFileDescription&, u64, UserOrKernelBuffer const&
         m_dma_region = TRY(MM.allocate_dma_buffer_page("SB16 DMA buffer", Memory::Region::Access::Write));
     }
 
-    dbgln_if(SB16_DEBUG, "SB16: Writing buffer of {} bytes", length);
+    dbgln_if<SB16_DEBUG>("SB16: Writing buffer of {} bytes", length);
 
     VERIFY(length <= PAGE_SIZE);
     int const BLOCK_SIZE = 32 * 1024;

--- a/Kernel/Devices/HID/MouseDevice.cpp
+++ b/Kernel/Devices/HID/MouseDevice.cpp
@@ -34,9 +34,9 @@ ErrorOr<size_t> MouseDevice::read(OpenFileDescription&, u64, UserOrKernelBuffer&
         auto packet = m_queue.dequeue();
         lock.unlock();
 
-        dbgln_if(MOUSE_DEBUG, "Mouse Read: Buttons {:x}", packet.buttons);
-        dbgln_if(MOUSE_DEBUG, "PS2 Mouse: X {}, Y {}, Z {}, W {}, Relative {}", packet.x, packet.y, packet.z, packet.w, packet.buttons);
-        dbgln_if(MOUSE_DEBUG, "PS2 Mouse Read: Filter packets");
+        dbgln_if<MOUSE_DEBUG>("Mouse Read: Buttons {:x}", packet.buttons);
+        dbgln_if<MOUSE_DEBUG>("PS2 Mouse: X {}, Y {}, Z {}, W {}, Relative {}", packet.x, packet.y, packet.z, packet.w, packet.buttons);
+        dbgln_if<MOUSE_DEBUG>("PS2 Mouse Read: Filter packets");
 
         size_t bytes_read_from_packet = min(remaining_space_in_buffer, sizeof(MousePacket));
         TRY(buffer.write(&packet, nread, bytes_read_from_packet));

--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -38,7 +38,7 @@ void PS2KeyboardDevice::irq_handle_byte_read(u8 byte)
         Scheduler::dump_scheduler_state(m_modifiers == (Mod_Ctrl | Mod_Alt | Mod_Shift));
     }
 
-    dbgln_if(KEYBOARD_DEBUG, "Keyboard::irq_handle_byte_read: {:#02x} {}", ch, (pressed ? "down" : "up"));
+    dbgln_if<KEYBOARD_DEBUG>("Keyboard::irq_handle_byte_read: {:#02x} {}", ch, (pressed ? "down" : "up"));
     switch (ch) {
     case 0x38:
         if (m_has_e0_prefix)

--- a/Kernel/Devices/HID/PS2MouseDevice.cpp
+++ b/Kernel/Devices/HID/PS2MouseDevice.cpp
@@ -41,7 +41,7 @@ void PS2MouseDevice::irq_handle_byte_read(u8 byte)
 {
     auto commit_packet = [&] {
         m_data_state = 0;
-        dbgln_if(PS2MOUSE_DEBUG, "PS2Mouse: {}, {} {} {}",
+        dbgln_if<PS2MOUSE_DEBUG>("PS2Mouse: {}, {} {} {}",
             m_data.bytes[1],
             m_data.bytes[2],
             (m_data.bytes[0] & 1) ? "Left" : "",
@@ -134,8 +134,8 @@ MousePacket PS2MouseDevice::parse_data_packet(const RawPacket& raw_packet)
     }
 
     packet.is_relative = true;
-    dbgln_if(PS2MOUSE_DEBUG, "PS2 Relative Mouse: Buttons {:x}", packet.buttons);
-    dbgln_if(PS2MOUSE_DEBUG, "Mouse: X {}, Y {}, Z {}, W {}", packet.x, packet.y, packet.z, packet.w);
+    dbgln_if<PS2MOUSE_DEBUG>("PS2 Relative Mouse: Buttons {:x}", packet.buttons);
+    dbgln_if<PS2MOUSE_DEBUG>("Mouse: X {}, Y {}, Z {}, W {}", packet.x, packet.y, packet.z, packet.w);
     return packet;
 }
 

--- a/Kernel/Devices/VMWareBackdoor.cpp
+++ b/Kernel/Devices/VMWareBackdoor.cpp
@@ -154,7 +154,7 @@ void VMWareBackdoor::send_high_bandwidth(VMWareCommand& command)
 {
     vmware_high_bandwidth_send(command);
 
-    dbgln_if(VMWARE_BACKDOOR_DEBUG, "VMWareBackdoor Command High bandwidth Send Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
+    dbgln_if<VMWARE_BACKDOOR_DEBUG>("VMWareBackdoor Command High bandwidth Send Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
         command.ax,
         command.bx,
         command.cx,
@@ -165,7 +165,7 @@ void VMWareBackdoor::get_high_bandwidth(VMWareCommand& command)
 {
     vmware_high_bandwidth_get(command);
 
-    dbgln_if(VMWARE_BACKDOOR_DEBUG, "VMWareBackdoor Command High bandwidth Get Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
+    dbgln_if<VMWARE_BACKDOOR_DEBUG>("VMWareBackdoor Command High bandwidth Get Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
         command.ax,
         command.bx,
         command.cx,
@@ -176,7 +176,7 @@ void VMWareBackdoor::send(VMWareCommand& command)
 {
     vmware_out(command);
 
-    dbgln_if(VMWARE_BACKDOOR_DEBUG, "VMWareBackdoor Command Send Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
+    dbgln_if<VMWARE_BACKDOOR_DEBUG>("VMWareBackdoor Command Send Results: EAX {:#x} EBX {:#x} ECX {:#x} EDX {:#x}",
         command.ax,
         command.bx,
         command.cx,
@@ -191,7 +191,7 @@ u16 VMWareBackdoor::read_mouse_status_queue_size()
     send(command);
 
     if (command.ax == 0xFFFF0000) {
-        dbgln_if(PS2MOUSE_DEBUG, "PS2MouseDevice: Resetting VMWare mouse");
+        dbgln_if<PS2MOUSE_DEBUG>("PS2MouseDevice: Resetting VMWare mouse");
         disable_absolute_vmmouse();
         enable_absolute_vmmouse();
         return 0;

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -135,7 +135,7 @@ ErrorOr<void> BlockBasedFileSystem::write_block(BlockIndex index, const UserOrKe
 {
     VERIFY(m_logical_block_size);
     VERIFY(offset + count <= block_size());
-    dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::write_block {}, size={}", index, count);
+    dbgln_if<BBFS_DEBUG>("BlockBasedFileSystem::write_block {}, size={}", index, count);
 
     // NOTE: We copy the `data` to write into a local buffer before taking the cache lock.
     //       This makes sure any page faults caused by accessing the data will occur before
@@ -205,7 +205,7 @@ ErrorOr<void> BlockBasedFileSystem::raw_write_blocks(BlockIndex index, size_t co
 ErrorOr<void> BlockBasedFileSystem::write_blocks(BlockIndex index, unsigned count, const UserOrKernelBuffer& data, bool allow_cache)
 {
     VERIFY(m_logical_block_size);
-    dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::write_blocks {}, count={}", index, count);
+    dbgln_if<BBFS_DEBUG>("BlockBasedFileSystem::write_blocks {}, count={}", index, count);
     for (unsigned i = 0; i < count; ++i) {
         TRY(write_block(BlockIndex { index.value() + i }, data.offset(i * block_size()), block_size(), 0, allow_cache));
     }
@@ -216,7 +216,7 @@ ErrorOr<void> BlockBasedFileSystem::read_block(BlockIndex index, UserOrKernelBuf
 {
     VERIFY(m_logical_block_size);
     VERIFY(offset + count <= block_size());
-    dbgln_if(BBFS_DEBUG, "BlockBasedFileSystem::read_block {}", index);
+    dbgln_if<BBFS_DEBUG>("BlockBasedFileSystem::read_block {}", index);
 
     return m_cache.with_exclusive([&](auto& cache) -> ErrorOr<void> {
         if (!allow_cache) {

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -237,7 +237,7 @@ ErrorOr<void> Ext2FSInode::grow_doubly_indirect_block(BlockBasedFileSystem::Bloc
         stream << static_cast<u32>(block_as_pointers[i]);
     for (unsigned i = old_indirect_blocks_length; i < new_indirect_blocks_length; i++) {
         auto new_block = new_meta_blocks.take_last().value();
-        dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::grow_doubly_indirect_block(): Allocating indirect block {} at index {}", identifier(), new_block, i);
+        dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::grow_doubly_indirect_block(): Allocating indirect block {} at index {}", identifier(), new_block, i);
         stream << static_cast<u32>(new_block);
         meta_blocks++;
     }
@@ -270,14 +270,14 @@ ErrorOr<void> Ext2FSInode::shrink_doubly_indirect_block(BlockBasedFileSystem::Bl
 
     // Free the unused indirect blocks.
     for (unsigned i = new_indirect_blocks_length; i < old_indirect_blocks_length; i++) {
-        dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::shrink_doubly_indirect_block(): Freeing indirect block {} at index {}", identifier(), block_as_pointers[i], i);
+        dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::shrink_doubly_indirect_block(): Freeing indirect block {} at index {}", identifier(), block_as_pointers[i], i);
         TRY(fs().set_block_allocation_state(block_as_pointers[i], false));
         meta_blocks--;
     }
 
     // Free the doubly indirect block if no longer needed.
     if (new_blocks_length == 0) {
-        dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::shrink_doubly_indirect_block(): Freeing doubly indirect block {}", identifier(), block);
+        dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::shrink_doubly_indirect_block(): Freeing doubly indirect block {}", identifier(), block);
         TRY(fs().set_block_allocation_state(block, false));
         meta_blocks--;
     }
@@ -310,7 +310,7 @@ ErrorOr<void> Ext2FSInode::grow_triply_indirect_block(BlockBasedFileSystem::Bloc
         stream << static_cast<u32>(block_as_pointers[i]);
     for (unsigned i = old_doubly_indirect_blocks_length; i < new_doubly_indirect_blocks_length; i++) {
         auto new_block = new_meta_blocks.take_last().value();
-        dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::grow_triply_indirect_block(): Allocating doubly indirect block {} at index {}", identifier(), new_block, i);
+        dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::grow_triply_indirect_block(): Allocating doubly indirect block {} at index {}", identifier(), new_block, i);
         stream << static_cast<u32>(new_block);
         meta_blocks++;
     }
@@ -349,13 +349,13 @@ ErrorOr<void> Ext2FSInode::shrink_triply_indirect_block(BlockBasedFileSystem::Bl
         const auto processed_blocks = i * entries_per_doubly_indirect_block;
         const auto old_doubly_indirect_blocks_length = min(old_blocks_length > processed_blocks ? old_blocks_length - processed_blocks : 0, entries_per_doubly_indirect_block);
         const auto new_doubly_indirect_blocks_length = min(new_blocks_length > processed_blocks ? new_blocks_length - processed_blocks : 0, entries_per_doubly_indirect_block);
-        dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::shrink_triply_indirect_block(): Shrinking doubly indirect block {} at index {}", identifier(), block_as_pointers[i], i);
+        dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::shrink_triply_indirect_block(): Shrinking doubly indirect block {} at index {}", identifier(), block_as_pointers[i], i);
         TRY(shrink_doubly_indirect_block(block_as_pointers[i], old_doubly_indirect_blocks_length, new_doubly_indirect_blocks_length, meta_blocks));
     }
 
     // Free the triply indirect block if no longer needed.
     if (new_blocks_length == 0) {
-        dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::shrink_triply_indirect_block(): Freeing triply indirect block {}", identifier(), block);
+        dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::shrink_triply_indirect_block(): Freeing triply indirect block {}", identifier(), block);
         TRY(fs().set_block_allocation_state(block, false));
         meta_blocks--;
     }
@@ -386,7 +386,7 @@ ErrorOr<void> Ext2FSInode::flush_block_list()
     }
 
     m_raw_inode.i_blocks = (m_block_list.size() + new_shape.meta_blocks) * (fs().block_size() / 512);
-    dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::flush_block_list(): Old shape=({};{};{};{}:{}), new shape=({};{};{};{}:{})", identifier(), old_shape.direct_blocks, old_shape.indirect_blocks, old_shape.doubly_indirect_blocks, old_shape.triply_indirect_blocks, old_shape.meta_blocks, new_shape.direct_blocks, new_shape.indirect_blocks, new_shape.doubly_indirect_blocks, new_shape.triply_indirect_blocks, new_shape.meta_blocks);
+    dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::flush_block_list(): Old shape=({};{};{};{}:{}), new shape=({};{};{};{}:{})", identifier(), old_shape.direct_blocks, old_shape.indirect_blocks, old_shape.doubly_indirect_blocks, old_shape.triply_indirect_blocks, old_shape.meta_blocks, new_shape.direct_blocks, new_shape.indirect_blocks, new_shape.doubly_indirect_blocks, new_shape.triply_indirect_blocks, new_shape.meta_blocks);
 
     unsigned output_block_index = 0;
     unsigned remaining_blocks = m_block_list.size();
@@ -425,7 +425,7 @@ ErrorOr<void> Ext2FSInode::flush_block_list()
             // Write out the indirect block.
             if (old_shape.indirect_blocks == 0) {
                 auto new_block = new_meta_blocks.take_last().value();
-                dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::flush_block_list(): Allocating indirect block: {}", identifier(), new_block);
+                dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::flush_block_list(): Allocating indirect block: {}", identifier(), new_block);
                 m_raw_inode.i_block[EXT2_IND_BLOCK] = new_block;
                 set_metadata_dirty(true);
                 old_shape.meta_blocks++;
@@ -433,7 +433,7 @@ ErrorOr<void> Ext2FSInode::flush_block_list()
 
             TRY(write_indirect_block(m_raw_inode.i_block[EXT2_IND_BLOCK], m_block_list.span().slice(output_block_index, new_shape.indirect_blocks)));
         } else if ((new_shape.indirect_blocks == 0) && (old_shape.indirect_blocks != 0)) {
-            dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::flush_block_list(): Freeing indirect block: {}", identifier(), m_raw_inode.i_block[EXT2_IND_BLOCK]);
+            dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::flush_block_list(): Freeing indirect block: {}", identifier(), m_raw_inode.i_block[EXT2_IND_BLOCK]);
             TRY(fs().set_block_allocation_state(m_raw_inode.i_block[EXT2_IND_BLOCK], false));
             old_shape.meta_blocks--;
             m_raw_inode.i_block[EXT2_IND_BLOCK] = 0;
@@ -448,7 +448,7 @@ ErrorOr<void> Ext2FSInode::flush_block_list()
         if (new_shape.doubly_indirect_blocks > old_shape.doubly_indirect_blocks) {
             if (old_shape.doubly_indirect_blocks == 0) {
                 auto new_block = new_meta_blocks.take_last().value();
-                dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::flush_block_list(): Allocating doubly indirect block: {}", identifier(), new_block);
+                dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::flush_block_list(): Allocating doubly indirect block: {}", identifier(), new_block);
                 m_raw_inode.i_block[EXT2_DIND_BLOCK] = new_block;
                 set_metadata_dirty(true);
                 old_shape.meta_blocks++;
@@ -469,7 +469,7 @@ ErrorOr<void> Ext2FSInode::flush_block_list()
         if (new_shape.triply_indirect_blocks > old_shape.triply_indirect_blocks) {
             if (old_shape.triply_indirect_blocks == 0) {
                 auto new_block = new_meta_blocks.take_last().value();
-                dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::flush_block_list(): Allocating triply indirect block: {}", identifier(), new_block);
+                dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::flush_block_list(): Allocating triply indirect block: {}", identifier(), new_block);
                 m_raw_inode.i_block[EXT2_TIND_BLOCK] = new_block;
                 set_metadata_dirty(true);
                 old_shape.meta_blocks++;
@@ -485,7 +485,7 @@ ErrorOr<void> Ext2FSInode::flush_block_list()
     remaining_blocks -= new_shape.triply_indirect_blocks;
     output_block_index += new_shape.triply_indirect_blocks;
 
-    dbgln_if(EXT2_BLOCKLIST_DEBUG, "Ext2FSInode[{}]::flush_block_list(): New meta blocks count at {}, expecting {}", identifier(), old_shape.meta_blocks, new_shape.meta_blocks);
+    dbgln_if<EXT2_BLOCKLIST_DEBUG>("Ext2FSInode[{}]::flush_block_list(): New meta blocks count at {}, expecting {}", identifier(), old_shape.meta_blocks, new_shape.meta_blocks);
     VERIFY(new_meta_blocks.size() == 0);
     VERIFY(old_shape.meta_blocks == new_shape.meta_blocks);
     if (!remaining_blocks)
@@ -528,7 +528,7 @@ ErrorOr<Vector<Ext2FS::BlockIndex>> Ext2FSInode::compute_block_list_impl_interna
     if (::is_symlink(e2inode.i_mode) && e2inode.i_blocks == 0)
         block_count = 0;
 
-    dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::block_list_for_inode(): i_size={}, i_blocks={}, block_count={}", identifier(), e2inode.i_size, e2inode.i_blocks, block_count);
+    dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::block_list_for_inode(): i_size={}, i_blocks={}, block_count={}", identifier(), e2inode.i_size, e2inode.i_blocks, block_count);
 
     unsigned blocks_remaining = block_count;
 
@@ -612,7 +612,7 @@ ErrorOr<void> Ext2FS::free_inode(Ext2FSInode& inode)
 {
     MutexLocker locker(m_lock);
     VERIFY(inode.m_raw_inode.i_links_count == 0);
-    dbgln_if(EXT2_DEBUG, "Ext2FS[{}]::free_inode(): Inode {} has no more links, time to delete!", fsid(), inode.index());
+    dbgln_if<EXT2_DEBUG>("Ext2FS[{}]::free_inode(): Inode {} has no more links, time to delete!", fsid(), inode.index());
 
     // Mark all blocks used by this inode as free.
     {
@@ -628,7 +628,7 @@ ErrorOr<void> Ext2FS::free_inode(Ext2FSInode& inode)
     if (inode.is_directory()) {
         auto& bgd = const_cast<ext2_group_desc&>(group_descriptor(group_index_from_inode(inode.index())));
         --bgd.bg_used_dirs_count;
-        dbgln_if(EXT2_DEBUG, "Ext2FS[{}]::free_inode(): Decremented bg_used_dirs_count to {} for inode {}", fsid(), bgd.bg_used_dirs_count, inode.index());
+        dbgln_if<EXT2_DEBUG>("Ext2FS[{}]::free_inode(): Decremented bg_used_dirs_count to {} for inode {}", fsid(), bgd.bg_used_dirs_count, inode.index());
         m_block_group_descriptors_dirty = true;
     }
 
@@ -677,7 +677,7 @@ void Ext2FS::flush_writes()
                     dbgln("Ext2FS[{}]::flush_writes(): Failed to write blocks: {}", fsid(), result.error());
                 }
                 cached_bitmap->dirty = false;
-                dbgln_if(EXT2_DEBUG, "Ext2FS[{}]::flush_writes(): Flushed bitmap block {}", fsid(), cached_bitmap->bitmap_block_index);
+                dbgln_if<EXT2_DEBUG>("Ext2FS[{}]::flush_writes(): Flushed bitmap block {}", fsid(), cached_bitmap->bitmap_block_index);
             }
         }
 
@@ -752,7 +752,7 @@ InodeMetadata Ext2FSInode::metadata() const
 ErrorOr<void> Ext2FSInode::flush_metadata()
 {
     MutexLocker locker(m_inode_lock);
-    dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::flush_metadata(): Flushing inode", identifier());
+    dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::flush_metadata(): Flushing inode", identifier());
     TRY(fs().write_ext2_inode(index(), m_raw_inode));
     if (is_directory()) {
         // Unless we're about to go away permanently, invalidate the lookup cache.
@@ -841,7 +841,7 @@ ErrorOr<size_t> Ext2FSInode::read_bytes(off_t offset, size_t count, UserOrKernel
     size_t nread = 0;
     auto remaining_count = min((off_t)count, (off_t)size() - offset);
 
-    dbgln_if(EXT2_VERY_DEBUG, "Ext2FSInode[{}]::read_bytes(): Reading up to {} bytes, {} bytes into inode to {}", identifier(), count, offset, buffer.user_or_kernel_ptr());
+    dbgln_if<EXT2_VERY_DEBUG>("Ext2FSInode[{}]::read_bytes(): Reading up to {} bytes, {} bytes into inode to {}", identifier(), count, offset, buffer.user_or_kernel_ptr());
 
     for (auto bi = first_block_logical_index; remaining_count && bi <= last_block_logical_index; bi = bi.value() + 1) {
         auto block_index = m_block_list[bi.value()];
@@ -951,7 +951,7 @@ ErrorOr<size_t> Ext2FSInode::write_bytes(off_t offset, size_t count, const UserO
     if (is_symlink()) {
         VERIFY(offset == 0);
         if (max((size_t)(offset + count), (size_t)m_raw_inode.i_size) < max_inline_symlink_length) {
-            dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::write_bytes(): Poking into i_block array for inline symlink ({} bytes)", identifier(), count);
+            dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::write_bytes(): Poking into i_block array for inline symlink ({} bytes)", identifier(), count);
             TRY(data.read(((u8*)m_raw_inode.i_block) + offset, count));
             if ((size_t)(offset + count) > (size_t)m_raw_inode.i_size)
                 m_raw_inode.i_size = offset + count;
@@ -985,12 +985,12 @@ ErrorOr<size_t> Ext2FSInode::write_bytes(off_t offset, size_t count, const UserO
     size_t nwritten = 0;
     auto remaining_count = min((off_t)count, (off_t)new_size - offset);
 
-    dbgln_if(EXT2_VERY_DEBUG, "Ext2FSInode[{}]::write_bytes(): Writing {} bytes, {} bytes into inode from {}", identifier(), count, offset, data.user_or_kernel_ptr());
+    dbgln_if<EXT2_VERY_DEBUG>("Ext2FSInode[{}]::write_bytes(): Writing {} bytes, {} bytes into inode from {}", identifier(), count, offset, data.user_or_kernel_ptr());
 
     for (auto bi = first_block_logical_index; remaining_count && bi <= last_block_logical_index; bi = bi.value() + 1) {
         size_t offset_into_block = (bi == first_block_logical_index) ? offset_into_first_block : 0;
         size_t num_bytes_to_copy = min((size_t)block_size - offset_into_block, (size_t)remaining_count);
-        dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::write_bytes(): Writing block {} (offset_into_block: {})", identifier(), m_block_list[bi.value()], offset_into_block);
+        dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::write_bytes(): Writing block {} (offset_into_block: {})", identifier(), m_block_list[bi.value()], offset_into_block);
         if (auto result = fs().write_block(m_block_list[bi.value()], data.offset(nwritten), num_bytes_to_copy, offset_into_block, allow_cache); result.is_error()) {
             dbgln("Ext2FSInode[{}]::write_bytes(): Failed to write block {} (index {})", identifier(), m_block_list[bi.value()], bi);
             return result.release_error();
@@ -1001,7 +1001,7 @@ ErrorOr<size_t> Ext2FSInode::write_bytes(off_t offset, size_t count, const UserO
 
     did_modify_contents();
 
-    dbgln_if(EXT2_VERY_DEBUG, "Ext2FSInode[{}]::write_bytes(): After write, i_size={}, i_blocks={} ({} blocks in list)", identifier(), size(), m_raw_inode.i_blocks, m_block_list.size());
+    dbgln_if<EXT2_VERY_DEBUG>("Ext2FSInode[{}]::write_bytes(): After write, i_size={}, i_blocks={} ({} blocks in list)", identifier(), size(), m_raw_inode.i_blocks, m_block_list.size());
     return nwritten;
 }
 
@@ -1054,7 +1054,7 @@ ErrorOr<void> Ext2FSInode::traverse_as_directory(Function<ErrorOr<void>(FileSyst
         auto* entries_end = reinterpret_cast<ext2_dir_entry_2*>(buffer + block_size);
         while (entry < entries_end) {
             if (entry->inode != 0) {
-                dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::traverse_as_directory(): inode {}, name_len: {}, rec_len: {}, file_type: {}, name: {}", identifier(), entry->inode, entry->name_len, entry->rec_len, entry->file_type, StringView(entry->name, entry->name_len));
+                dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::traverse_as_directory(): inode {}, name_len: {}, rec_len: {}, file_type: {}, name: {}", identifier(), entry->inode, entry->name_len, entry->rec_len, entry->file_type, StringView(entry->name, entry->name_len));
                 TRY(callback({ { entry->name, entry->name_len }, { fsid(), entry->inode }, entry->file_type }));
             }
             entry = (ext2_dir_entry_2*)((char*)entry + entry->rec_len);
@@ -1091,13 +1091,13 @@ ErrorOr<void> Ext2FSInode::write_directory(Vector<Ext2FSDirectoryEntry>& entries
         directory_size += entry.record_length;
     }
 
-    dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::write_directory(): New directory contents to write (size {}):", identifier(), directory_size);
+    dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::write_directory(): New directory contents to write (size {}):", identifier(), directory_size);
 
     auto directory_data = TRY(ByteBuffer::create_uninitialized(directory_size));
     OutputMemoryStream stream { directory_data };
 
     for (auto& entry : entries) {
-        dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::write_directory(): Writing inode: {}, name_len: {}, rec_len: {}, file_type: {}, name: {}", identifier(), entry.inode_index, u16(entry.name->length()), u16(entry.record_length), u8(entry.file_type), entry.name);
+        dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::write_directory(): Writing inode: {}, name_len: {}, rec_len: {}, file_type: {}, name: {}", identifier(), entry.inode_index, u16(entry.name->length()), u16(entry.record_length), u8(entry.file_type), entry.name);
 
         stream << u32(entry.inode_index.value());
         stream << u16(entry.record_length);
@@ -1136,7 +1136,7 @@ ErrorOr<void> Ext2FSInode::add_child(Inode& child, StringView name, mode_t mode)
     if (name.length() > EXT2_NAME_LEN)
         return ENAMETOOLONG;
 
-    dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::add_child(): Adding inode {} with name '{}' and mode {:o} to directory {}", identifier(), child.index(), name, mode, index());
+    dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::add_child(): Adding inode {} with name '{}' and mode {:o} to directory {}", identifier(), child.index(), name, mode, index());
 
     Vector<Ext2FSDirectoryEntry> entries;
     TRY(traverse_as_directory([&](auto& entry) -> ErrorOr<void> {
@@ -1164,7 +1164,7 @@ ErrorOr<void> Ext2FSInode::add_child(Inode& child, StringView name, mode_t mode)
 ErrorOr<void> Ext2FSInode::remove_child(StringView name)
 {
     MutexLocker locker(m_inode_lock);
-    dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]::remove_child(): Removing '{}'", identifier(), name);
+    dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]::remove_child(): Removing '{}'", identifier(), name);
     VERIFY(is_directory());
 
     TRY(populate_lookup_cache());
@@ -1227,7 +1227,7 @@ ErrorOr<void> Ext2FS::write_ext2_inode(InodeIndex inode, ext2_inode const& e2ino
 
 auto Ext2FS::allocate_blocks(GroupIndex preferred_group_index, size_t count) -> ErrorOr<Vector<BlockIndex>>
 {
-    dbgln_if(EXT2_DEBUG, "Ext2FS: allocate_blocks(preferred group: {}, count {})", preferred_group_index, count);
+    dbgln_if<EXT2_DEBUG>("Ext2FS: allocate_blocks(preferred group: {}, count {})", preferred_group_index, count);
     if (count == 0)
         return Vector<BlockIndex> {};
 
@@ -1268,12 +1268,12 @@ auto Ext2FS::allocate_blocks(GroupIndex preferred_group_index, size_t count) -> 
         size_t free_region_size = 0;
         auto first_unset_bit_index = block_bitmap.find_longest_range_of_unset_bits(count - blocks.size(), free_region_size);
         VERIFY(first_unset_bit_index.has_value());
-        dbgln_if(EXT2_DEBUG, "Ext2FS: allocating free region of size: {} [{}]", free_region_size, group_index);
+        dbgln_if<EXT2_DEBUG>("Ext2FS: allocating free region of size: {} [{}]", free_region_size, group_index);
         for (size_t i = 0; i < free_region_size; ++i) {
             BlockIndex block_index = (first_unset_bit_index.value() + i) + first_block_in_group.value();
             TRY(set_block_allocation_state(block_index, true));
             blocks.unchecked_append(block_index);
-            dbgln_if(EXT2_DEBUG, "  allocated > {}", block_index);
+            dbgln_if<EXT2_DEBUG>("  allocated > {}", block_index);
         }
     }
 
@@ -1283,7 +1283,7 @@ auto Ext2FS::allocate_blocks(GroupIndex preferred_group_index, size_t count) -> 
 
 ErrorOr<InodeIndex> Ext2FS::allocate_inode(GroupIndex preferred_group)
 {
-    dbgln_if(EXT2_DEBUG, "Ext2FS: allocate_inode(preferred_group: {})", preferred_group);
+    dbgln_if<EXT2_DEBUG>("Ext2FS: allocate_inode(preferred_group: {})", preferred_group);
     MutexLocker locker(m_lock);
 
     // FIXME: We shouldn't refuse to allocate an inode if there is no group that can house the whole thing.
@@ -1310,7 +1310,7 @@ ErrorOr<InodeIndex> Ext2FS::allocate_inode(GroupIndex preferred_group)
         return ENOSPC;
     }
 
-    dbgln_if(EXT2_DEBUG, "Ext2FS: allocate_inode: found suitable group [{}] for new inode :^)", group_index);
+    dbgln_if<EXT2_DEBUG>("Ext2FS: allocate_inode: found suitable group [{}] for new inode :^)", group_index);
 
     auto const& bgd = group_descriptor(group_index);
     unsigned inodes_in_group = min(inodes_per_group(), super_block().s_inodes_count);
@@ -1400,7 +1400,7 @@ ErrorOr<void> Ext2FS::set_inode_allocation_state(InodeIndex inode_index, bool ne
     unsigned index_in_group = inode_index.value() - ((group_index.value() - 1) * inodes_per_group());
     unsigned bit_index = (index_in_group - 1) % inodes_per_group();
 
-    dbgln_if(EXT2_DEBUG, "Ext2FS: set_inode_allocation_state: Inode {} -> {}", inode_index, new_state);
+    dbgln_if<EXT2_DEBUG>("Ext2FS: set_inode_allocation_state: Inode {} -> {}", inode_index, new_state);
     auto& bgd = const_cast<ext2_group_desc&>(group_descriptor(group_index));
     return update_bitmap_block(bgd.bg_inode_bitmap, bit_index, new_state, m_super_block.s_free_inodes_count, bgd.bg_free_inodes_count);
 }
@@ -1435,7 +1435,7 @@ ErrorOr<void> Ext2FS::set_block_allocation_state(BlockIndex block_index, bool ne
     unsigned bit_index = index_in_group % blocks_per_group();
     auto& bgd = const_cast<ext2_group_desc&>(group_descriptor(group_index));
 
-    dbgln_if(EXT2_DEBUG, "Ext2FS: Block {} state -> {} (in bitmap block {})", block_index, new_state, bgd.bg_block_bitmap);
+    dbgln_if<EXT2_DEBUG>("Ext2FS: Block {} state -> {} (in bitmap block {})", block_index, new_state, bgd.bg_block_bitmap);
     return update_bitmap_block(bgd.bg_block_bitmap, bit_index, new_state, m_super_block.s_free_blocks_count, bgd.bg_free_blocks_count);
 }
 
@@ -1446,7 +1446,7 @@ ErrorOr<NonnullRefPtr<Inode>> Ext2FS::create_directory(Ext2FSInode& parent_inode
 
     auto inode = TRY(create_inode(parent_inode, name, mode, 0, uid, gid));
 
-    dbgln_if(EXT2_DEBUG, "Ext2FS: create_directory: created new directory named '{} with inode {}", name, inode->index());
+    dbgln_if<EXT2_DEBUG>("Ext2FS: create_directory: created new directory named '{} with inode {}", name, inode->index());
 
     Vector<Ext2FSDirectoryEntry> entries;
     auto current_directory_name = TRY(KString::try_create("."sv));
@@ -1494,12 +1494,12 @@ ErrorOr<NonnullRefPtr<Inode>> Ext2FS::create_inode(Ext2FSInode& parent_inode, St
 
     auto inode_id = TRY(allocate_inode());
 
-    dbgln_if(EXT2_DEBUG, "Ext2FS: writing initial metadata for inode {}", inode_id.value());
+    dbgln_if<EXT2_DEBUG>("Ext2FS: writing initial metadata for inode {}", inode_id.value());
     TRY(write_ext2_inode(inode_id, e2inode));
 
     auto new_inode = TRY(get_inode({ fsid(), inode_id }));
 
-    dbgln_if(EXT2_DEBUG, "Ext2FS: Adding inode '{}' (mode {:o}) to parent directory {}", name, mode, parent_inode.index());
+    dbgln_if<EXT2_DEBUG>("Ext2FS: Adding inode '{}' (mode {:o}) to parent directory {}", name, mode, parent_inode.index());
     TRY(parent_inode.add_child(*new_inode, name, mode));
     return new_inode;
 }
@@ -1525,7 +1525,7 @@ ErrorOr<void> Ext2FSInode::populate_lookup_cache() const
 ErrorOr<NonnullRefPtr<Inode>> Ext2FSInode::lookup(StringView name)
 {
     VERIFY(is_directory());
-    dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]:lookup(): Looking up '{}'", identifier(), name);
+    dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]:lookup(): Looking up '{}'", identifier(), name);
     TRY(populate_lookup_cache());
 
     InodeIndex inode_index;
@@ -1533,7 +1533,7 @@ ErrorOr<NonnullRefPtr<Inode>> Ext2FSInode::lookup(StringView name)
         MutexLocker locker(m_inode_lock);
         auto it = m_lookup_cache.find(name);
         if (it == m_lookup_cache.end()) {
-            dbgln_if(EXT2_DEBUG, "Ext2FSInode[{}]:lookup(): '{}' not found", identifier(), name);
+            dbgln_if<EXT2_DEBUG>("Ext2FSInode[{}]:lookup(): '{}' not found", identifier(), name);
             return ENOENT;
         }
         inode_index = it->value;

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -484,7 +484,7 @@ ErrorOr<void> ProcFSProcessPropertyInode::traverse_as_directory(Function<ErrorOr
 }
 ErrorOr<size_t> ProcFSProcessPropertyInode::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, OpenFileDescription* description) const
 {
-    dbgln_if(PROCFS_DEBUG, "ProcFS ProcessInformation: read_bytes offset: {} count: {}", offset, count);
+    dbgln_if<PROCFS_DEBUG>("ProcFS ProcessInformation: read_bytes offset: {} count: {}", offset, count);
 
     VERIFY(offset >= 0);
     VERIFY(buffer.user_or_kernel_ptr());

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -313,7 +313,7 @@ ErrorOr<void> VirtualFileSystem::mknod(StringView path, mode_t mode, dev_t dev, 
         return EROFS;
 
     auto basename = KLexicalPath::basename(path);
-    dbgln_if(VFS_DEBUG, "VirtualFileSystem::mknod: '{}' mode={} dev={} in {}", basename, mode, dev, parent_inode.identifier());
+    dbgln_if<VFS_DEBUG>("VirtualFileSystem::mknod: '{}' mode={} dev={} in {}", basename, mode, dev, parent_inode.identifier());
     (void)TRY(parent_inode.create_child(basename, mode, dev, current_process.euid(), current_process.egid()));
     return {};
 }
@@ -337,7 +337,7 @@ ErrorOr<NonnullRefPtr<OpenFileDescription>> VirtualFileSystem::create(StringView
     if (parent_custody.is_readonly())
         return EROFS;
 
-    dbgln_if(VFS_DEBUG, "VirtualFileSystem::create: '{}' in {}", basename, parent_inode.identifier());
+    dbgln_if<VFS_DEBUG>("VirtualFileSystem::create: '{}' in {}", basename, parent_inode.identifier());
     auto uid = owner.has_value() ? owner.value().uid : current_process.euid();
     auto gid = owner.has_value() ? owner.value().gid : current_process.egid();
 
@@ -379,7 +379,7 @@ ErrorOr<void> VirtualFileSystem::mkdir(StringView path, mode_t mode, Custody& ba
         return EROFS;
 
     auto basename = KLexicalPath::basename(path);
-    dbgln_if(VFS_DEBUG, "VirtualFileSystem::mkdir: '{}' in {}", basename, parent_inode.identifier());
+    dbgln_if<VFS_DEBUG>("VirtualFileSystem::mkdir: '{}' in {}", basename, parent_inode.identifier());
     (void)TRY(parent_inode.create_child(basename, S_IFDIR | mode, 0, current_process.euid(), current_process.egid()));
     return {};
 }
@@ -554,10 +554,10 @@ ErrorOr<void> VirtualFileSystem::chown(Custody& custody, UserID a_uid, GroupID a
     if (custody.is_readonly())
         return EROFS;
 
-    dbgln_if(VFS_DEBUG, "VirtualFileSystem::chown(): inode {} <- uid={} gid={}", inode.identifier(), new_uid, new_gid);
+    dbgln_if<VFS_DEBUG>("VirtualFileSystem::chown(): inode {} <- uid={} gid={}", inode.identifier(), new_uid, new_gid);
 
     if (metadata.is_setuid() || metadata.is_setgid()) {
-        dbgln_if(VFS_DEBUG, "VirtualFileSystem::chown(): Stripping SUID/SGID bits from {}", inode.identifier());
+        dbgln_if<VFS_DEBUG>("VirtualFileSystem::chown(): Stripping SUID/SGID bits from {}", inode.identifier());
         TRY(inode.chmod(metadata.mode & ~(04000 | 02000)));
     }
 
@@ -668,7 +668,7 @@ ErrorOr<void> VirtualFileSystem::symlink(StringView target, StringView linkpath,
         return EROFS;
 
     auto basename = KLexicalPath::basename(linkpath);
-    dbgln_if(VFS_DEBUG, "VirtualFileSystem::symlink: '{}' (-> '{}') in {}", basename, target, parent_inode.identifier());
+    dbgln_if<VFS_DEBUG>("VirtualFileSystem::symlink: '{}' (-> '{}') in {}", basename, target, parent_inode.identifier());
 
     auto inode = TRY(parent_inode.create_child(basename, S_IFLNK | 0644, 0, current_process.euid(), current_process.egid()));
 

--- a/Kernel/Firmware/ACPI/Parser.cpp
+++ b/Kernel/Firmware/ACPI/Parser.cpp
@@ -127,16 +127,16 @@ UNMAP_AFTER_INIT void Parser::locate_static_data()
 
 UNMAP_AFTER_INIT Optional<PhysicalAddress> Parser::find_table(StringView signature)
 {
-    dbgln_if(ACPI_DEBUG, "ACPI: Calling Find Table method!");
+    dbgln_if<ACPI_DEBUG>("ACPI: Calling Find Table method!");
     for (auto p_sdt : m_sdt_pointers) {
         auto sdt_or_error = Memory::map_typed<Structures::SDTHeader>(p_sdt);
         if (sdt_or_error.is_error()) {
-            dbgln_if(ACPI_DEBUG, "ACPI: Failed mapping Table @ {}", p_sdt);
+            dbgln_if<ACPI_DEBUG>("ACPI: Failed mapping Table @ {}", p_sdt);
             continue;
         }
-        dbgln_if(ACPI_DEBUG, "ACPI: Examining Table @ {}", p_sdt);
+        dbgln_if<ACPI_DEBUG>("ACPI: Examining Table @ {}", p_sdt);
         if (!strncmp(sdt_or_error.value()->sig, signature.characters_without_null_termination(), 4)) {
-            dbgln_if(ACPI_DEBUG, "ACPI: Found Table @ {}", p_sdt);
+            dbgln_if<ACPI_DEBUG>("ACPI: Found Table @ {}", p_sdt);
             return p_sdt;
         }
     }
@@ -159,7 +159,7 @@ UNMAP_AFTER_INIT void Parser::process_fadt_data()
     dmesgln("ACPI: Initializing Fixed ACPI data");
 
     VERIFY(!m_fadt.is_null());
-    dbgln_if(ACPI_DEBUG, "ACPI: FADT @ {}", m_fadt);
+    dbgln_if<ACPI_DEBUG>("ACPI: FADT @ {}", m_fadt);
 
     auto sdt = Memory::map_typed<Structures::FADT>(m_fadt).release_value_but_fixme_should_propagate_errors();
     dmesgln("ACPI: Fixed ACPI data, Revision {}, length: {} bytes", (size_t)sdt->h.revision, (size_t)sdt->h.length);
@@ -289,7 +289,7 @@ void Parser::try_acpi_reboot()
         dmesgln("ACPI: Reboot not supported!");
         return;
     }
-    dbgln_if(ACPI_DEBUG, "ACPI: Rebooting, probing FADT ({})", m_fadt);
+    dbgln_if<ACPI_DEBUG>("ACPI: Rebooting, probing FADT ({})", m_fadt);
 
     auto fadt_or_error = Memory::map_typed<Structures::FADT>(m_fadt);
     if (fadt_or_error.is_error()) {
@@ -310,20 +310,20 @@ void Parser::try_acpi_shutdown()
 size_t Parser::get_table_size(PhysicalAddress table_header)
 {
     InterruptDisabler disabler;
-    dbgln_if(ACPI_DEBUG, "ACPI: Checking SDT Length");
+    dbgln_if<ACPI_DEBUG>("ACPI: Checking SDT Length");
     return Memory::map_typed<Structures::SDTHeader>(table_header).release_value_but_fixme_should_propagate_errors()->length;
 }
 
 u8 Parser::get_table_revision(PhysicalAddress table_header)
 {
     InterruptDisabler disabler;
-    dbgln_if(ACPI_DEBUG, "ACPI: Checking SDT Revision");
+    dbgln_if<ACPI_DEBUG>("ACPI: Checking SDT Revision");
     return Memory::map_typed<Structures::SDTHeader>(table_header).release_value_but_fixme_should_propagate_errors()->revision;
 }
 
 UNMAP_AFTER_INIT void Parser::initialize_main_system_description_table()
 {
-    dbgln_if(ACPI_DEBUG, "ACPI: Checking Main SDT Length to choose the correct mapping size");
+    dbgln_if<ACPI_DEBUG>("ACPI: Checking Main SDT Length to choose the correct mapping size");
     VERIFY(!m_main_system_description_table.is_null());
     auto length = get_table_size(m_main_system_description_table);
     auto revision = get_table_revision(m_main_system_description_table);
@@ -336,18 +336,18 @@ UNMAP_AFTER_INIT void Parser::initialize_main_system_description_table()
         auto& xsdt = (const Structures::XSDT&)*sdt;
         dmesgln("ACPI: Using XSDT, enumerating tables @ {}", m_main_system_description_table);
         dmesgln("ACPI: XSDT revision {}, total length: {}", revision, length);
-        dbgln_if(ACPI_DEBUG, "ACPI: XSDT pointer @ {}", VirtualAddress { &xsdt });
+        dbgln_if<ACPI_DEBUG>("ACPI: XSDT pointer @ {}", VirtualAddress { &xsdt });
         for (u32 i = 0; i < ((length - sizeof(Structures::SDTHeader)) / sizeof(u64)); i++) {
-            dbgln_if(ACPI_DEBUG, "ACPI: Found new table [{0}], @ V{1:p} - P{1:p}", i, &xsdt.table_ptrs[i]);
+            dbgln_if<ACPI_DEBUG>("ACPI: Found new table [{0}], @ V{1:p} - P{1:p}", i, &xsdt.table_ptrs[i]);
             m_sdt_pointers.append(PhysicalAddress(xsdt.table_ptrs[i]));
         }
     } else {
         auto& rsdt = (const Structures::RSDT&)*sdt;
         dmesgln("ACPI: Using RSDT, enumerating tables @ {}", m_main_system_description_table);
         dmesgln("ACPI: RSDT revision {}, total length: {}", revision, length);
-        dbgln_if(ACPI_DEBUG, "ACPI: RSDT pointer @ V{}", &rsdt);
+        dbgln_if<ACPI_DEBUG>("ACPI: RSDT pointer @ V{}", &rsdt);
         for (u32 i = 0; i < ((length - sizeof(Structures::SDTHeader)) / sizeof(u32)); i++) {
-            dbgln_if(ACPI_DEBUG, "ACPI: Found new table [{0}], @ V{1:p} - P{1:p}", i, &rsdt.table_ptrs[i]);
+            dbgln_if<ACPI_DEBUG>("ACPI: Found new table [{0}], @ V{1:p} - P{1:p}", i, &rsdt.table_ptrs[i]);
             m_sdt_pointers.append(PhysicalAddress(rsdt.table_ptrs[i]));
         }
     }

--- a/Kernel/Firmware/MultiProcessor/Parser.cpp
+++ b/Kernel/Firmware/MultiProcessor/Parser.cpp
@@ -49,7 +49,7 @@ UNMAP_AFTER_INIT void MultiProcessorParser::parse_configuration_table()
     size_t entry_count = config_table->entry_count;
     auto* entry = config_table->entries;
     while (entry_count > 0) {
-        dbgln_if(MULTIPROCESSOR_DEBUG, "MultiProcessor: Entry Type {} detected.", entry->entry_type);
+        dbgln_if<MULTIPROCESSOR_DEBUG>("MultiProcessor: Entry Type {} detected.", entry->entry_type);
         switch (entry->entry_type) {
         case ((u8)MultiProcessor::ConfigurationTableEntryType::Processor):
             entry = (MultiProcessor::EntryHeader*)(FlatPtr)entry + sizeof(MultiProcessor::ProcessorEntry);

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -80,7 +80,7 @@ UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initi
 
 void BochsGraphicsAdapter::set_framebuffer_to_big_endian_format()
 {
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter set_framebuffer_to_big_endian_format");
+    dbgln_if<BXVGA_DEBUG>("BochsGraphicsAdapter set_framebuffer_to_big_endian_format");
     full_memory_barrier();
     if (m_registers->extension_regs.region_size == 0xFFFFFFFF || m_registers->extension_regs.region_size == 0)
         return;
@@ -91,7 +91,7 @@ void BochsGraphicsAdapter::set_framebuffer_to_big_endian_format()
 
 void BochsGraphicsAdapter::set_framebuffer_to_little_endian_format()
 {
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter set_framebuffer_to_little_endian_format");
+    dbgln_if<BXVGA_DEBUG>("BochsGraphicsAdapter set_framebuffer_to_little_endian_format");
     full_memory_barrier();
     if (m_registers->extension_regs.region_size == 0xFFFFFFFF || m_registers->extension_regs.region_size == 0)
         return;
@@ -172,7 +172,7 @@ BochsGraphicsAdapter::IndexID BochsGraphicsAdapter::index_id() const
 
 void BochsGraphicsAdapter::set_resolution_registers_via_io(size_t width, size_t height)
 {
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter resolution registers set to - {}x{}", width, height);
+    dbgln_if<BXVGA_DEBUG>("BochsGraphicsAdapter resolution registers set to - {}x{}", width, height);
 
     set_register_with_io(to_underlying(BochsDISPIRegisters::ENABLE), 0);
     set_register_with_io(to_underlying(BochsDISPIRegisters::XRES), (u16)width);
@@ -186,7 +186,7 @@ void BochsGraphicsAdapter::set_resolution_registers_via_io(size_t width, size_t 
 
 void BochsGraphicsAdapter::set_resolution_registers(size_t width, size_t height)
 {
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter resolution registers set to - {}x{}", width, height);
+    dbgln_if<BXVGA_DEBUG>("BochsGraphicsAdapter resolution registers set to - {}x{}", width, height);
     m_registers->bochs_regs.enable = 0;
     full_memory_barrier();
     m_registers->bochs_regs.xres = width;
@@ -215,7 +215,7 @@ bool BochsGraphicsAdapter::try_to_set_resolution(size_t output_port_index, size_
         set_resolution_registers_via_io(width, height);
     else
         set_resolution_registers(width, height);
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter resolution test - {}x{}", width, height);
+    dbgln_if<BXVGA_DEBUG>("BochsGraphicsAdapter resolution test - {}x{}", width, height);
     if (m_io_required) {
         if (!validate_setup_resolution_with_io(width, height))
             return false;

--- a/Kernel/Graphics/VirtIOGPU/FramebufferDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/FramebufferDevice.cpp
@@ -394,7 +394,7 @@ void FramebufferDevice::draw_ntsc_test_pattern(Buffer& buffer)
             }
         }
     }
-    dbgln_if(VIRTIO_DEBUG, "Finish drawing the pattern");
+    dbgln_if<VIRTIO_DEBUG>("Finish drawing the pattern");
 }
 
 u8* FramebufferDevice::framebuffer_data()

--- a/Kernel/Heap/kmalloc.cpp
+++ b/Kernel/Heap/kmalloc.cpp
@@ -184,7 +184,7 @@ struct KmallocGlobalData {
 
     void add_subheap(u8* storage, size_t storage_size)
     {
-        dbgln_if(KMALLOC_DEBUG, "Adding kmalloc subheap @ {} with size {}", storage, storage_size);
+        dbgln_if<KMALLOC_DEBUG>("Adding kmalloc subheap @ {} with size {}", storage, storage_size);
         static_assert(sizeof(KmallocSubheap) <= PAGE_SIZE);
         auto* subheap = new (storage) KmallocSubheap(storage + PAGE_SIZE, storage_size - PAGE_SIZE);
         subheaps.append(*subheap);
@@ -269,7 +269,7 @@ struct KmallocGlobalData {
         }
         size_t new_subheap_size = max(minimum_subheap_size, rounded_allocation_request.value());
 
-        dbgln_if(KMALLOC_DEBUG, "Unable to allocate {}, expanding kmalloc heap", allocation_request);
+        dbgln_if<KMALLOC_DEBUG>("Unable to allocate {}, expanding kmalloc heap", allocation_request);
 
         if (!expansion_data->virtual_range.contains(new_subheap_base, new_subheap_size)) {
             // FIXME: Dare to return false and allow kmalloc() to fail!

--- a/Kernel/Interrupts/IOAPIC.cpp
+++ b/Kernel/Interrupts/IOAPIC.cpp
@@ -298,13 +298,13 @@ void IOAPIC::write_register(u32 index, u32 value) const
     m_regs->select = index;
     m_regs->window = value;
 
-    dbgln_if(IOAPIC_DEBUG, "IOAPIC Writing, Value {:#x} @ offset {:#x}", (u32)m_regs->window, (u32)m_regs->select);
+    dbgln_if<IOAPIC_DEBUG>("IOAPIC Writing, Value {:#x} @ offset {:#x}", (u32)m_regs->window, (u32)m_regs->select);
 }
 u32 IOAPIC::read_register(u32 index) const
 {
     InterruptDisabler disabler;
     m_regs->select = index;
-    dbgln_if(IOAPIC_DEBUG, "IOAPIC Reading, Value {:#x} @ offset {:#x}", (u32)m_regs->window, (u32)m_regs->select);
+    dbgln_if<IOAPIC_DEBUG>("IOAPIC Reading, Value {:#x} @ offset {:#x}", (u32)m_regs->window, (u32)m_regs->select);
     return m_regs->window;
 }
 

--- a/Kernel/Interrupts/IRQHandler.cpp
+++ b/Kernel/Interrupts/IRQHandler.cpp
@@ -25,7 +25,7 @@ IRQHandler::~IRQHandler()
 
 bool IRQHandler::eoi()
 {
-    dbgln_if(IRQ_DEBUG, "EOI IRQ {}", interrupt_number());
+    dbgln_if<IRQ_DEBUG>("EOI IRQ {}", interrupt_number());
     if (!m_shared_with_others) {
         VERIFY(!m_responsible_irq_controller.is_null());
         m_responsible_irq_controller->eoi(*this);
@@ -36,7 +36,7 @@ bool IRQHandler::eoi()
 
 void IRQHandler::enable_irq()
 {
-    dbgln_if(IRQ_DEBUG, "Enable IRQ {}", interrupt_number());
+    dbgln_if<IRQ_DEBUG>("Enable IRQ {}", interrupt_number());
     if (!is_registered())
         register_interrupt_handler();
     m_enabled = true;
@@ -46,7 +46,7 @@ void IRQHandler::enable_irq()
 
 void IRQHandler::disable_irq()
 {
-    dbgln_if(IRQ_DEBUG, "Disable IRQ {}", interrupt_number());
+    dbgln_if<IRQ_DEBUG>("Disable IRQ {}", interrupt_number());
     m_enabled = false;
     if (!m_shared_with_others)
         m_responsible_irq_controller->disable(*this);

--- a/Kernel/Interrupts/SharedIRQHandler.cpp
+++ b/Kernel/Interrupts/SharedIRQHandler.cpp
@@ -23,13 +23,13 @@ UNMAP_AFTER_INIT void SharedIRQHandler::initialize(u8 interrupt_number)
 
 void SharedIRQHandler::register_handler(GenericInterruptHandler& handler)
 {
-    dbgln_if(INTERRUPT_DEBUG, "Interrupt Handler registered @ Shared Interrupt Handler {}", interrupt_number());
+    dbgln_if<INTERRUPT_DEBUG>("Interrupt Handler registered @ Shared Interrupt Handler {}", interrupt_number());
     m_handlers.append(handler);
     enable_interrupt_vector();
 }
 void SharedIRQHandler::unregister_handler(GenericInterruptHandler& handler)
 {
-    dbgln_if(INTERRUPT_DEBUG, "Interrupt Handler unregistered @ Shared Interrupt Handler {}", interrupt_number());
+    dbgln_if<INTERRUPT_DEBUG>("Interrupt Handler unregistered @ Shared Interrupt Handler {}", interrupt_number());
     m_handlers.remove(handler);
     if (m_handlers.is_empty())
         disable_interrupt_vector();
@@ -37,7 +37,7 @@ void SharedIRQHandler::unregister_handler(GenericInterruptHandler& handler)
 
 bool SharedIRQHandler::eoi()
 {
-    dbgln_if(INTERRUPT_DEBUG, "EOI IRQ {}", interrupt_number());
+    dbgln_if<INTERRUPT_DEBUG>("EOI IRQ {}", interrupt_number());
     m_responsible_irq_controller->eoi(*this);
     return true;
 }
@@ -53,12 +53,12 @@ SharedIRQHandler::SharedIRQHandler(u8 irq)
     : GenericInterruptHandler(irq)
     , m_responsible_irq_controller(InterruptManagement::the().get_responsible_irq_controller(irq))
 {
-    dbgln_if(INTERRUPT_DEBUG, "Shared Interrupt Handler registered @ {}", interrupt_number());
+    dbgln_if<INTERRUPT_DEBUG>("Shared Interrupt Handler registered @ {}", interrupt_number());
 }
 
 SharedIRQHandler::~SharedIRQHandler()
 {
-    dbgln_if(INTERRUPT_DEBUG, "Shared Interrupt Handler unregistered @ {}", interrupt_number());
+    dbgln_if<INTERRUPT_DEBUG>("Shared Interrupt Handler unregistered @ {}", interrupt_number());
     disable_interrupt_vector();
 }
 
@@ -73,12 +73,12 @@ bool SharedIRQHandler::handle_interrupt(const RegisterState& regs)
     int i = 0;
     bool was_handled = false;
     for (auto& handler : m_handlers) {
-        dbgln_if(INTERRUPT_DEBUG, "Going for Interrupt Handling @ {}, Shared Interrupt {}", i, interrupt_number());
+        dbgln_if<INTERRUPT_DEBUG>("Going for Interrupt Handling @ {}, Shared Interrupt {}", i, interrupt_number());
         if (handler.handle_interrupt(regs)) {
             handler.increment_invoking_counter();
             was_handled = true;
         }
-        dbgln_if(INTERRUPT_DEBUG, "Going for Interrupt Handling @ {}, Shared Interrupt {} - End", i, interrupt_number());
+        dbgln_if<INTERRUPT_DEBUG>("Going for Interrupt Handling @ {}, Shared Interrupt {} - End", i, interrupt_number());
         i++;
     }
     return was_handled;

--- a/Kernel/Locking/Mutex.cpp
+++ b/Kernel/Locking/Mutex.cpp
@@ -29,7 +29,7 @@ void Mutex::lock(Mode mode, [[maybe_unused]] LockLocation const& location)
     Mode current_mode = m_mode;
     switch (current_mode) {
     case Mode::Unlocked: {
-        dbgln_if(LOCK_TRACE_DEBUG, "Mutex::lock @ ({}) {}: acquire {}, currently unlocked", this, m_name, mode_to_string(mode));
+        dbgln_if<LOCK_TRACE_DEBUG>("Mutex::lock @ ({}) {}: acquire {}, currently unlocked", this, m_name, mode_to_string(mode));
         m_mode = mode;
         VERIFY(!m_holder);
         VERIFY(m_shared_holders == 0);
@@ -92,7 +92,7 @@ void Mutex::lock(Mode mode, [[maybe_unused]] LockLocation const& location)
     case Mode::Shared: {
         VERIFY(!m_holder);
         if (mode == Mode::Exclusive) {
-            dbgln_if(LOCK_TRACE_DEBUG, "Mutex::lock @ {} ({}): blocking for exclusive access, currently shared, locks held {}", this, m_name, m_times_locked);
+            dbgln_if<LOCK_TRACE_DEBUG>("Mutex::lock @ {} ({}): blocking for exclusive access, currently shared, locks held {}", this, m_name, m_times_locked);
 #if LOCK_SHARED_UPGRADE_DEBUG
             VERIFY(m_shared_holders_map.size() != 1 || m_shared_holders_map.begin()->key != current_thread);
 #endif
@@ -105,7 +105,7 @@ void Mutex::lock(Mode mode, [[maybe_unused]] LockLocation const& location)
             VERIFY(m_mode == mode);
         }
 
-        dbgln_if(LOCK_TRACE_DEBUG, "Mutex::lock @ {} ({}): acquire {}, currently shared, locks held {}", this, m_name, mode_to_string(mode), m_times_locked);
+        dbgln_if<LOCK_TRACE_DEBUG>("Mutex::lock @ {} ({}): acquire {}, currently shared, locks held {}", this, m_name, mode_to_string(mode), m_times_locked);
 
         VERIFY(m_times_locked > 0);
         if (m_mode == Mode::Shared) {
@@ -210,9 +210,9 @@ void Mutex::block(Thread& current_thread, Mode mode, SpinlockLocker<Spinlock>& l
     VERIFY(!blocked_thread_list.contains(current_thread));
     blocked_thread_list.append(current_thread);
 
-    dbgln_if(LOCK_TRACE_DEBUG, "Mutex::lock @ {} ({}) waiting...", this, m_name);
+    dbgln_if<LOCK_TRACE_DEBUG>("Mutex::lock @ {} ({}) waiting...", this, m_name);
     current_thread.block(*this, lock, requested_locks);
-    dbgln_if(LOCK_TRACE_DEBUG, "Mutex::lock @ {} ({}) waited", this, m_name);
+    dbgln_if<LOCK_TRACE_DEBUG>("Mutex::lock @ {} ({}) waited", this, m_name);
 
     VERIFY(blocked_thread_list.contains(current_thread));
     blocked_thread_list.remove(current_thread);
@@ -275,7 +275,7 @@ auto Mutex::force_unlock_exclusive_if_locked(u32& lock_count_to_restore) -> Mode
             return Mode::Unlocked;
         }
 
-        dbgln_if(LOCK_RESTORE_DEBUG, "Mutex::force_unlock_exclusive_if_locked @ {}: unlocking exclusive with lock count: {}", this, m_times_locked);
+        dbgln_if<LOCK_RESTORE_DEBUG>("Mutex::force_unlock_exclusive_if_locked @ {}: unlocking exclusive with lock count: {}", this, m_times_locked);
 #if LOCK_DEBUG
         m_holder->holding_lock(*this, -(int)m_times_locked, {});
 #endif
@@ -312,7 +312,7 @@ void Mutex::restore_exclusive_lock(u32 lock_count, [[maybe_unused]] LockLocation
         VERIFY(m_mode == Mode::Exclusive);
     }
 
-    dbgln_if(LOCK_RESTORE_DEBUG, "Mutex::restore_exclusive_lock @ {}: restoring exclusive with lock count {}, was {}", this, lock_count, mode_to_string(previous_mode));
+    dbgln_if<LOCK_RESTORE_DEBUG>("Mutex::restore_exclusive_lock @ {}: restoring exclusive with lock count {}, was {}", this, lock_count, mode_to_string(previous_mode));
 
     VERIFY(m_mode != Mode::Shared);
     VERIFY(m_shared_holders == 0);

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -33,7 +33,7 @@ ErrorOr<NonnullRefPtr<VMObject>> AnonymousVMObject::try_clone()
     // non-volatile memory available.
     size_t new_cow_pages_needed = page_count();
 
-    dbgln_if(COMMIT_DEBUG, "Cloning {:p}, need {} committed cow pages", this, new_cow_pages_needed);
+    dbgln_if<COMMIT_DEBUG>("Cloning {:p}, need {} committed cow pages", this, new_cow_pages_needed);
 
     auto committed_pages = TRY(MM.commit_user_physical_pages(new_cow_pages_needed));
 
@@ -306,7 +306,7 @@ PageFaultResponse AnonymousVMObject::handle_cow_fault(size_t page_index, Virtual
         m_shared_committed_cow_pages = nullptr;
 
     if (page_slot->ref_count() == 1) {
-        dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a COW page but nobody is sharing it anymore. Remap r/w");
+        dbgln_if<PAGE_FAULT_DEBUG>("    >> It's a COW page but nobody is sharing it anymore. Remap r/w");
         set_should_cow(page_index, false);
 
         if (m_shared_committed_cow_pages) {
@@ -319,10 +319,10 @@ PageFaultResponse AnonymousVMObject::handle_cow_fault(size_t page_index, Virtual
 
     RefPtr<PhysicalPage> page;
     if (m_shared_committed_cow_pages) {
-        dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a committed COW page and it's time to COW!");
+        dbgln_if<PAGE_FAULT_DEBUG>("    >> It's a committed COW page and it's time to COW!");
         page = m_shared_committed_cow_pages->take_one();
     } else {
-        dbgln_if(PAGE_FAULT_DEBUG, "    >> It's a COW page and it's time to COW!");
+        dbgln_if<PAGE_FAULT_DEBUG>("    >> It's a COW page and it's time to COW!");
         auto page_or_error = MM.allocate_user_physical_page(MemoryManager::ShouldZeroFill::No);
         if (page_or_error.is_error()) {
             dmesgln("MM: handle_cow_fault was unable to allocate a physical page");
@@ -331,7 +331,7 @@ PageFaultResponse AnonymousVMObject::handle_cow_fault(size_t page_index, Virtual
         page = page_or_error.release_value();
     }
 
-    dbgln_if(PAGE_FAULT_DEBUG, "      >> COW {} <- {}", page->paddr(), page_slot->paddr());
+    dbgln_if<PAGE_FAULT_DEBUG>("      >> COW {} <- {}", page->paddr(), page_slot->paddr());
     {
         SpinlockLocker mm_locker(s_mm_lock);
         u8* dest_ptr = MM.quickmap_page(*page);

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -743,7 +743,7 @@ PageFaultResponse MemoryManager::handle_page_fault(PageFault const& fault)
         dump_kernel_regions();
         return PageFaultResponse::ShouldCrash;
     }
-    dbgln_if(PAGE_FAULT_DEBUG, "MM: CPU[{}] handle_page_fault({:#04x}) at {}", Processor::current_id(), fault.code(), fault.vaddr());
+    dbgln_if<PAGE_FAULT_DEBUG>("MM: CPU[{}] handle_page_fault({:#04x}) at {}", Processor::current_id(), fault.code(), fault.vaddr());
     auto* region = find_region_from_vaddr(fault.vaddr());
     if (!region) {
         return PageFaultResponse::ShouldCrash;

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -62,7 +62,7 @@ IPv4Socket::IPv4Socket(int type, int protocol, NonnullOwnPtr<DoubleBuffer> recei
     , m_receive_buffer(move(receive_buffer))
     , m_scratch_buffer(move(optional_scratch_buffer))
 {
-    dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket({}) created with type={}, protocol={}", this, type, protocol);
+    dbgln_if<IPV4_SOCKET_DEBUG>("IPv4Socket({}) created with type={}, protocol={}", this, type, protocol);
     m_buffer_mode = type == SOCK_STREAM ? BufferMode::Bytes : BufferMode::Packets;
     if (m_buffer_mode == BufferMode::Bytes) {
         VERIFY(m_scratch_buffer);
@@ -117,7 +117,7 @@ ErrorOr<void> IPv4Socket::bind(Userspace<const sockaddr*> user_address, socklen_
     m_local_address = IPv4Address((const u8*)&address.sin_addr.s_addr);
     m_local_port = requested_local_port;
 
-    dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket::bind {}({}) to {}:{}", class_name(), this, m_local_address, m_local_port);
+    dbgln_if<IPV4_SOCKET_DEBUG>("IPv4Socket::bind {}({}) to {}:{}", class_name(), this, m_local_address, m_local_port);
 
     return protocol_bind();
 }
@@ -133,7 +133,7 @@ ErrorOr<void> IPv4Socket::listen(size_t backlog)
     set_role(Role::Listener);
     evaluate_block_conditions();
 
-    dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket({}) listening with backlog={}", this, backlog);
+    dbgln_if<IPV4_SOCKET_DEBUG>("IPv4Socket({}) listening with backlog={}", this, backlog);
 
     return protocol_listen(result.did_allocate);
 }
@@ -221,7 +221,7 @@ ErrorOr<size_t> IPv4Socket::sendto(OpenFileDescription&, const UserOrKernelBuffe
     if (auto result = allocate_local_port_if_needed(); result.error_or_port.is_error() && result.error_or_port.error().code() != ENOPROTOOPT)
         return result.error_or_port.release_error();
 
-    dbgln_if(IPV4_SOCKET_DEBUG, "sendto: destination={}:{}", m_peer_address, m_peer_port);
+    dbgln_if<IPV4_SOCKET_DEBUG>("sendto: destination={}:{}", m_peer_address, m_peer_port);
 
     if (type() == SOCK_RAW) {
         auto ipv4_payload_offset = routing_decision.adapter->ipv4_payload_offset();
@@ -310,7 +310,7 @@ ErrorOr<size_t> IPv4Socket::receive_packet_buffered(OpenFileDescription& descrip
 
             set_can_read(!m_receive_queue.is_empty());
 
-            dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket({}): recvfrom without blocking {} bytes, packets in queue: {}",
+            dbgln_if<IPV4_SOCKET_DEBUG>("IPv4Socket({}): recvfrom without blocking {} bytes, packets in queue: {}",
                 this,
                 packet->data->size(),
                 m_receive_queue.size());
@@ -347,7 +347,7 @@ ErrorOr<size_t> IPv4Socket::receive_packet_buffered(OpenFileDescription& descrip
 
         set_can_read(!m_receive_queue.is_empty());
 
-        dbgln_if(IPV4_SOCKET_DEBUG, "IPv4Socket({}): recvfrom with blocking {} bytes, packets in queue: {}",
+        dbgln_if<IPV4_SOCKET_DEBUG>("IPv4Socket({}): recvfrom with blocking {} bytes, packets in queue: {}",
             this,
             packet->data->size(),
             m_receive_queue.size());
@@ -357,7 +357,7 @@ ErrorOr<size_t> IPv4Socket::receive_packet_buffered(OpenFileDescription& descrip
     packet_timestamp = packet->timestamp;
 
     if (addr) {
-        dbgln_if(IPV4_SOCKET_DEBUG, "Incoming packet is from: {}:{}", packet->peer_address, packet->peer_port);
+        dbgln_if<IPV4_SOCKET_DEBUG>("Incoming packet is from: {}:{}", packet->peer_address, packet->peer_port);
 
         sockaddr_in out_addr {};
         memcpy(&out_addr.sin_addr, &packet->peer_address, sizeof(IPv4Address));
@@ -389,7 +389,7 @@ ErrorOr<size_t> IPv4Socket::recvfrom(OpenFileDescription& description, UserOrKer
             return set_so_error(EINVAL);
     }
 
-    dbgln_if(IPV4_SOCKET_DEBUG, "recvfrom: type={}, local_port={}", type(), local_port());
+    dbgln_if<IPV4_SOCKET_DEBUG>("recvfrom: type={}, local_port={}", type(), local_port());
 
     ErrorOr<size_t> total_nreceived = 0;
     do {

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -259,7 +259,7 @@ bool E1000NetworkAdapter::handle_irq(const RegisterState&)
         // Threshold OK?
     }
     if (status & INTERRUPT_RXO) {
-        dbgln_if(E1000_DEBUG, "E1000: RX buffer overrun");
+        dbgln_if<E1000_DEBUG>("E1000: RX buffer overrun");
     }
     if (status & INTERRUPT_RXT0) {
         receive();
@@ -370,7 +370,7 @@ UNMAP_AFTER_INIT void E1000NetworkAdapter::initialize_tx_descriptors()
 
 void E1000NetworkAdapter::out8(u16 address, u8 data)
 {
-    dbgln_if(E1000_DEBUG, "E1000: OUT8 {:#02x} @ {:#04x}", data, address);
+    dbgln_if<E1000_DEBUG>("E1000: OUT8 {:#02x} @ {:#04x}", data, address);
     if (m_use_mmio) {
         auto* ptr = (volatile u8*)(m_mmio_base.get() + address);
         *ptr = data;
@@ -381,7 +381,7 @@ void E1000NetworkAdapter::out8(u16 address, u8 data)
 
 void E1000NetworkAdapter::out16(u16 address, u16 data)
 {
-    dbgln_if(E1000_DEBUG, "E1000: OUT16 {:#04x} @ {:#04x}", data, address);
+    dbgln_if<E1000_DEBUG>("E1000: OUT16 {:#04x} @ {:#04x}", data, address);
     if (m_use_mmio) {
         auto* ptr = (volatile u16*)(m_mmio_base.get() + address);
         *ptr = data;
@@ -392,7 +392,7 @@ void E1000NetworkAdapter::out16(u16 address, u16 data)
 
 void E1000NetworkAdapter::out32(u16 address, u32 data)
 {
-    dbgln_if(E1000_DEBUG, "E1000: OUT32 {:#08x} @ {:#04x}", data, address);
+    dbgln_if<E1000_DEBUG>("E1000: OUT32 {:#08x} @ {:#04x}", data, address);
     if (m_use_mmio) {
         auto* ptr = (volatile u32*)(m_mmio_base.get() + address);
         *ptr = data;
@@ -403,7 +403,7 @@ void E1000NetworkAdapter::out32(u16 address, u32 data)
 
 u8 E1000NetworkAdapter::in8(u16 address)
 {
-    dbgln_if(E1000_DEBUG, "E1000: IN8 @ {:#04x}", address);
+    dbgln_if<E1000_DEBUG>("E1000: IN8 @ {:#04x}", address);
     if (m_use_mmio)
         return *(volatile u8*)(m_mmio_base.get() + address);
     return m_io_base.offset(address).in<u8>();
@@ -411,7 +411,7 @@ u8 E1000NetworkAdapter::in8(u16 address)
 
 u16 E1000NetworkAdapter::in16(u16 address)
 {
-    dbgln_if(E1000_DEBUG, "E1000: IN16 @ {:#04x}", address);
+    dbgln_if<E1000_DEBUG>("E1000: IN16 @ {:#04x}", address);
     if (m_use_mmio)
         return *(volatile u16*)(m_mmio_base.get() + address);
     return m_io_base.offset(address).in<u16>();
@@ -419,7 +419,7 @@ u16 E1000NetworkAdapter::in16(u16 address)
 
 u32 E1000NetworkAdapter::in32(u16 address)
 {
-    dbgln_if(E1000_DEBUG, "E1000: IN32 @ {:#04x}", address);
+    dbgln_if<E1000_DEBUG>("E1000: IN32 @ {:#04x}", address);
     if (m_use_mmio)
         return *(volatile u32*)(m_mmio_base.get() + address);
     return m_io_base.offset(address).in<u32>();
@@ -429,7 +429,7 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
 {
     disable_irq();
     size_t tx_current = in32(REG_TXDESCTAIL) % number_of_tx_descriptors;
-    dbgln_if(E1000_DEBUG, "E1000: Sending packet ({} bytes)", payload.size());
+    dbgln_if<E1000_DEBUG>("E1000: Sending packet ({} bytes)", payload.size());
     auto* tx_descriptors = (e1000_tx_desc*)m_tx_descriptors_region->vaddr().as_ptr();
     auto& descriptor = tx_descriptors[tx_current];
     VERIFY(payload.size() <= 8192);
@@ -438,7 +438,7 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
     descriptor.length = payload.size();
     descriptor.status = 0;
     descriptor.cmd = CMD_EOP | CMD_IFCS | CMD_RS;
-    dbgln_if(E1000_DEBUG, "E1000: Using tx descriptor {} (head is at {})", tx_current, in32(REG_TXDESCHEAD));
+    dbgln_if<E1000_DEBUG>("E1000: Using tx descriptor {} (head is at {})", tx_current, in32(REG_TXDESCHEAD));
     tx_current = (tx_current + 1) % number_of_tx_descriptors;
     cli();
     enable_irq();
@@ -450,7 +450,7 @@ void E1000NetworkAdapter::send_raw(ReadonlyBytes payload)
         }
         m_wait_queue.wait_forever("E1000NetworkAdapter");
     }
-    dbgln_if(E1000_DEBUG, "E1000: Sent packet, status is now {:#02x}!", (u8)descriptor.status);
+    dbgln_if<E1000_DEBUG>("E1000: Sent packet, status is now {:#02x}!", (u8)descriptor.status);
 }
 
 void E1000NetworkAdapter::receive()
@@ -465,7 +465,7 @@ void E1000NetworkAdapter::receive()
         auto* buffer = m_rx_buffers[rx_current];
         u16 length = rx_descriptors[rx_current].length;
         VERIFY(length <= 8192);
-        dbgln_if(E1000_DEBUG, "E1000: Received 1 packet @ {:p} ({} bytes)", buffer, length);
+        dbgln_if<E1000_DEBUG>("E1000: Received 1 packet @ {:p} ({} bytes)", buffer, length);
         did_receive({ buffer, length });
         rx_descriptors[rx_current].status = 0;
         out32(REG_RXDESCTAIL, rx_current);

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -79,7 +79,7 @@ LocalSocket::LocalSocket(int type, NonnullOwnPtr<DoubleBuffer> client_buffer, No
         list.append(*this);
     });
 
-    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) created with type={}", this, type);
+    dbgln_if<LOCAL_SOCKET_DEBUG>("LocalSocket({}) created with type={}", this, type);
 }
 
 LocalSocket::~LocalSocket()
@@ -119,7 +119,7 @@ ErrorOr<void> LocalSocket::bind(Userspace<const sockaddr*> user_address, socklen
         return set_so_error(EINVAL);
 
     auto path = SOCKET_TRY(KString::try_create(StringView { address.sun_path, strnlen(address.sun_path, sizeof(address.sun_path)) }));
-    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) bind({})", this, path);
+    dbgln_if<LOCAL_SOCKET_DEBUG>("LocalSocket({}) bind({})", this, path);
 
     mode_t mode = S_IFSOCK | (m_prebind_mode & 0777);
     UidAndGid owner { m_prebind_uid, m_prebind_gid };
@@ -167,7 +167,7 @@ ErrorOr<void> LocalSocket::connect(OpenFileDescription& description, Userspace<c
     }
 
     auto path = maybe_path.release_nonnull();
-    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) connect({})", this, *path);
+    dbgln_if<LOCAL_SOCKET_DEBUG>("LocalSocket({}) connect({})", this, *path);
 
     auto file = SOCKET_TRY(VirtualFileSystem::the().open(path->view(), O_RDWR, 0, Process::current().current_directory()));
     auto inode = file->inode();
@@ -201,7 +201,7 @@ ErrorOr<void> LocalSocket::connect(OpenFileDescription& description, Userspace<c
         return set_so_error(EINTR);
     }
 
-    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) connect({}) status is {}", this, *m_path, to_string(setup_state()));
+    dbgln_if<LOCAL_SOCKET_DEBUG>("LocalSocket({}) connect({}) status is {}", this, *m_path, to_string(setup_state()));
 
     if (!has_flag(unblock_flags, Thread::OpenFileDescriptionBlocker::BlockFlags::Connect)) {
         set_connect_side_role(Role::None);
@@ -221,7 +221,7 @@ ErrorOr<void> LocalSocket::listen(size_t backlog)
     set_role(Role::Listener);
     set_connect_side_role(Role::Listener, previous_role != m_role);
 
-    dbgln_if(LOCAL_SOCKET_DEBUG, "LocalSocket({}) listening with backlog={}", this, backlog);
+    dbgln_if<LOCAL_SOCKET_DEBUG>("LocalSocket({}) listening with backlog={}", this, backlog);
 
     return {};
 }

--- a/Kernel/Net/NE2000/NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000/NetworkAdapter.cpp
@@ -195,16 +195,16 @@ bool NE2000NetworkAdapter::handle_irq(const RegisterState&)
 
     m_entropy_source.add_random_event(status);
 
-    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Got interrupt, status={:#02x}", status);
+    dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: Got interrupt, status={:#02x}", status);
     if (status == 0) {
         return false;
     }
 
     if (status & BIT_INTERRUPTMASK_PRX) {
-        dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Interrupt for packet received");
+        dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: Interrupt for packet received");
     }
     if (status & BIT_INTERRUPTMASK_PTX) {
-        dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Interrupt for packet sent");
+        dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: Interrupt for packet sent");
     }
     if (status & BIT_INTERRUPTMASK_RXE) {
         u8 fae = in8(REG_RD_FAE_TALLY);
@@ -267,9 +267,9 @@ UNMAP_AFTER_INIT int NE2000NetworkAdapter::ram_test()
         for (size_t j = 0; j < buffer.size(); ++j) {
             if (buffer[j] != patterns[i]) {
                 if (errors < 16)
-                    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Bad adapter RAM @ {} expected={} got={}", PhysicalAddress(NE2K_RAM_BEGIN + j), patterns[i], buffer[j]);
+                    dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: Bad adapter RAM @ {} expected={} got={}", PhysicalAddress(NE2K_RAM_BEGIN + j), patterns[i], buffer[j]);
                 else if (errors == 16)
-                    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Too many RAM errors, silencing further output");
+                    dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: Too many RAM errors, silencing further output");
                 errors++;
             }
         }
@@ -319,7 +319,7 @@ void NE2000NetworkAdapter::reset()
 
 void NE2000NetworkAdapter::rdma_read(size_t address, Bytes payload)
 {
-    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: DMA read @ {} length={}", PhysicalAddress(address), payload.size());
+    dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: DMA read @ {} length={}", PhysicalAddress(address), payload.size());
 
     u8 command = in8(REG_RW_COMMAND) & ~(BIT_COMMAND_PAGE_FIELD | BIT_COMMAND_DMA_FIELD);
     out8(REG_RW_COMMAND, command | BIT_COMMAND_DMA_ABORT);
@@ -346,7 +346,7 @@ void NE2000NetworkAdapter::rdma_read(size_t address, Bytes payload)
 
 void NE2000NetworkAdapter::rdma_write(size_t address, ReadonlyBytes payload)
 {
-    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: DMA write @ {} length={}", PhysicalAddress(address), payload.size());
+    dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: DMA write @ {} length={}", PhysicalAddress(address), payload.size());
 
     u8 command = in8(REG_RW_COMMAND) & ~(BIT_COMMAND_PAGE_FIELD | BIT_COMMAND_DMA_FIELD);
     out8(REG_RW_COMMAND, command | BIT_COMMAND_DMA_ABORT);
@@ -373,7 +373,7 @@ void NE2000NetworkAdapter::rdma_write(size_t address, ReadonlyBytes payload)
 
 void NE2000NetworkAdapter::send_raw(ReadonlyBytes payload)
 {
-    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Sending packet length={}", payload.size());
+    dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: Sending packet length={}", payload.size());
 
     if (payload.size() > NE2K_RAM_SEND_SIZE) {
         dmesgln("NE2000NetworkAdapter: Packet to send was too big; discarding");
@@ -393,7 +393,7 @@ void NE2000NetworkAdapter::send_raw(ReadonlyBytes payload)
     out8(REG_WR_TRANSMITBYTECOUNT1, packet_size >> 8);
     out8(REG_RW_COMMAND, BIT_COMMAND_DMA_ABORT | BIT_COMMAND_TXP | BIT_COMMAND_START);
 
-    dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Packet submitted for transmission");
+    dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: Packet submitted for transmission");
 
     enable_irq();
 }
@@ -412,7 +412,7 @@ void NE2000NetworkAdapter::receive()
         rdma_read(header_address, Bytes(reinterpret_cast<u8*>(&header), sizeof(header)));
 
         bool packet_ok = header.status & BIT_RECEIVESTATUS_PRX;
-        dbgln_if(NE2000_DEBUG, "NE2000NetworkAdapter: Packet received {} length={}", (packet_ok ? "intact" : "damaged"), header.length);
+        dbgln_if<NE2000_DEBUG>("NE2000NetworkAdapter: Packet received {} length={}", (packet_ok ? "intact" : "damaged"), static_cast<u16>(header.length));
 
         if (packet_ok) {
             size_t bytes_in_packet = sizeof(received_packet_header) + header.length;

--- a/Kernel/Net/Realtek/RTL8139NetworkAdapter.cpp
+++ b/Kernel/Net/Realtek/RTL8139NetworkAdapter.cpp
@@ -175,14 +175,14 @@ bool RTL8139NetworkAdapter::handle_irq(const RegisterState&)
 
         m_entropy_source.add_random_event(status);
 
-        dbgln_if(RTL8139_DEBUG, "RTL8139: handle_irq status={:#04x}", status);
+        dbgln_if<RTL8139_DEBUG>("RTL8139: handle_irq status={:#04x}", status);
 
         if ((status & (INT_RXOK | INT_RXERR | INT_TXOK | INT_TXERR | INT_RX_BUFFER_OVERFLOW | INT_LINK_CHANGE | INT_RX_FIFO_OVERFLOW | INT_LENGTH_CHANGE | INT_SYSTEM_ERROR)) == 0)
             break;
 
         was_handled = true;
         if (status & INT_RXOK) {
-            dbgln_if(RTL8139_DEBUG, "RTL8139: RX ready");
+            dbgln_if<RTL8139_DEBUG>("RTL8139: RX ready");
             receive();
         }
         if (status & INT_RXERR) {
@@ -190,7 +190,7 @@ bool RTL8139NetworkAdapter::handle_irq(const RegisterState&)
             reset();
         }
         if (status & INT_TXOK) {
-            dbgln_if(RTL8139_DEBUG, "RTL8139: TX complete");
+            dbgln_if<RTL8139_DEBUG>("RTL8139: TX complete");
         }
         if (status & INT_TXERR) {
             dmesgln("RTL8139: TX error - resetting device");
@@ -280,7 +280,7 @@ UNMAP_AFTER_INIT void RTL8139NetworkAdapter::read_mac_address()
 
 void RTL8139NetworkAdapter::send_raw(ReadonlyBytes payload)
 {
-    dbgln_if(RTL8139_DEBUG, "RTL8139: send_raw length={}", payload.size());
+    dbgln_if<RTL8139_DEBUG>("RTL8139: send_raw length={}", payload.size());
 
     if (payload.size() > PACKET_SIZE_MAX) {
         dmesgln("RTL8139: Packet was too big; discarding");
@@ -303,7 +303,7 @@ void RTL8139NetworkAdapter::send_raw(ReadonlyBytes payload)
         return;
     }
 
-    dbgln_if(RTL8139_DEBUG, "RTL8139: Chose buffer {}", hw_buffer);
+    dbgln_if<RTL8139_DEBUG>("RTL8139: Chose buffer {}", hw_buffer);
     m_tx_next_buffer = (hw_buffer + 1) % 4;
 
     memcpy(m_tx_buffers[hw_buffer]->vaddr().as_ptr(), payload.data(), payload.size());
@@ -315,7 +315,7 @@ void RTL8139NetworkAdapter::send_raw(ReadonlyBytes payload)
     // 60 bytes if necessary to make sure the whole thing is large enough.
     auto length = payload.size();
     if (length < 60) {
-        dbgln_if(RTL8139_DEBUG, "RTL8139: adjusting payload size from {} to 60", length);
+        dbgln_if<RTL8139_DEBUG>("RTL8139: adjusting payload size from {} to 60", length);
         length = 60;
     }
 
@@ -329,7 +329,7 @@ void RTL8139NetworkAdapter::receive()
     u16 status = *(const u16*)(start_of_packet + 0);
     u16 length = *(const u16*)(start_of_packet + 2);
 
-    dbgln_if(RTL8139_DEBUG, "RTL8139: receive, status={:#04x}, length={}, offset={}", status, length, m_rx_buffer_offset);
+    dbgln_if<RTL8139_DEBUG>("RTL8139: receive, status={:#04x}, length={}, offset={}", status, length, m_rx_buffer_offset);
 
     if (!(status & RX_OK) || (status & (RX_INVALID_SYMBOL_ERROR | RX_CRC_ERROR | RX_FRAME_ALIGNMENT_ERROR)) || (length >= PACKET_SIZE_MAX) || (length < PACKET_SIZE_MIN)) {
         dmesgln("RTL8139: receive got bad packet, status={:#04x}, length={}", status, length);

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -43,7 +43,7 @@ Socket::~Socket()
 
 void Socket::set_setup_state(SetupState new_setup_state)
 {
-    dbgln_if(SOCKET_DEBUG, "Socket({}) setup state moving from {} to {}", this, to_string(m_setup_state), to_string(new_setup_state));
+    dbgln_if<SOCKET_DEBUG>("Socket({}) setup state moving from {} to {}", this, to_string(m_setup_state), to_string(new_setup_state));
     m_setup_state = new_setup_state;
     evaluate_block_conditions();
 }
@@ -53,7 +53,7 @@ RefPtr<Socket> Socket::accept()
     MutexLocker locker(mutex());
     if (m_pending.is_empty())
         return nullptr;
-    dbgln_if(SOCKET_DEBUG, "Socket({}) de-queueing connection", this);
+    dbgln_if<SOCKET_DEBUG>("Socket({}) de-queueing connection", this);
     auto client = m_pending.take_first();
     VERIFY(!client->is_connected());
     auto& process = Process::current();
@@ -67,7 +67,7 @@ RefPtr<Socket> Socket::accept()
 
 ErrorOr<void> Socket::queue_connection_from(NonnullRefPtr<Socket> peer)
 {
-    dbgln_if(SOCKET_DEBUG, "Socket({}) queueing connection", this);
+    dbgln_if<SOCKET_DEBUG>("Socket({}) queueing connection", this);
     MutexLocker locker(mutex());
     if (m_pending.size() >= m_backlog)
         return set_so_error(ECONNREFUSED);

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -243,7 +243,7 @@ Process::Process(NonnullOwnPtr<KString> name, UserID uid, GroupID gid, ProcessID
     m_protected_values.suid = uid;
     m_protected_values.sgid = gid;
 
-    dbgln_if(PROCESS_DEBUG, "Created new process {}({})", m_name, this->pid().value());
+    dbgln_if<PROCESS_DEBUG>("Created new process {}({})", m_name, this->pid().value());
 }
 
 ErrorOr<void> Process::attach_resources(NonnullOwnPtr<Memory::AddressSpace>&& preallocated_space, RefPtr<Thread>& first_thread, Process* fork_parent)
@@ -567,7 +567,7 @@ void Process::finalize()
 {
     VERIFY(Thread::current() == g_finalizer);
 
-    dbgln_if(PROCESS_DEBUG, "Finalizing process {}", *this);
+    dbgln_if<PROCESS_DEBUG>("Finalizing process {}", *this);
 
     if (veil_state() == VeilState::Dropped)
         dbgln("\x1b[01;31mProcess '{}' exited with the veil left open\x1b[0m", name());
@@ -673,7 +673,7 @@ void Process::die()
             auto& process = *it;
             ++it;
             if (process.has_tracee_thread(pid())) {
-                dbgln_if(PROCESS_DEBUG, "Process {} ({}) is attached by {} ({}) which will exit", process.name(), process.pid(), name(), pid());
+                dbgln_if<PROCESS_DEBUG>("Process {} ({}) is attached by {} ({}) which will exit", process.name(), process.pid(), name(), pid());
                 process.stop_tracing();
                 auto err = process.send_signal(SIGSTOP, this);
                 if (err.is_error())

--- a/Kernel/ProcessExposed.cpp
+++ b/Kernel/ProcessExposed.cpp
@@ -109,7 +109,7 @@ ProcFSExposedLink::ProcFSExposedLink(StringView name)
 }
 ErrorOr<size_t> ProcFSGlobalInformation::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, OpenFileDescription* description) const
 {
-    dbgln_if(PROCFS_DEBUG, "ProcFSGlobalInformation @ {}: read_bytes offset: {} count: {}", name(), offset, count);
+    dbgln_if<PROCFS_DEBUG>("ProcFSGlobalInformation @ {}: read_bytes offset: {} count: {}", name(), offset, count);
 
     VERIFY(offset >= 0);
     VERIFY(buffer.user_or_kernel_ptr());

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -249,7 +249,7 @@ void Scheduler::yield()
     InterruptDisabler disabler;
 
     auto const* current_thread = Thread::current();
-    dbgln_if(SCHEDULER_DEBUG, "Scheduler[{}]: yielding thread {} in_irq={}", Processor::current_id(), *current_thread, Processor::current_in_irq());
+    dbgln_if<SCHEDULER_DEBUG>("Scheduler[{}]: yielding thread {} in_irq={}", Processor::current_id(), *current_thread, Processor::current_in_irq());
     VERIFY(current_thread != nullptr);
     if (Processor::current_in_irq() || Processor::in_critical()) {
         // If we're handling an IRQ we can't switch context, or we're in
@@ -460,7 +460,7 @@ void Scheduler::timer_tick(const RegisterState& regs)
 
     if (current_thread->previous_mode() == Thread::PreviousMode::UserMode && current_thread->should_die() && !current_thread->is_blocked()) {
         SpinlockLocker scheduler_lock(g_scheduler_lock);
-        dbgln_if(SCHEDULER_DEBUG, "Scheduler[{}]: Terminating user mode thread {}", Processor::current_id(), *current_thread);
+        dbgln_if<SCHEDULER_DEBUG>("Scheduler[{}]: Terminating user mode thread {}", Processor::current_id(), *current_thread);
         current_thread->set_state(Thread::State::Dying);
         Processor::current().invoke_scheduler_async();
         return;
@@ -475,7 +475,7 @@ void Scheduler::timer_tick(const RegisterState& regs)
         // time slice and let it run!
         current_thread->set_ticks_left(time_slice_for(*current_thread));
         current_thread->did_schedule();
-        dbgln_if(SCHEDULER_DEBUG, "Scheduler[{}]: No other threads ready, give {} another timeslice", Processor::current_id(), *current_thread);
+        dbgln_if<SCHEDULER_DEBUG>("Scheduler[{}]: No other threads ready, give {} another timeslice", Processor::current_id(), *current_thread);
         return;
     }
 

--- a/Kernel/Storage/ATA/AHCIController.cpp
+++ b/Kernel/Storage/ATA/AHCIController.cpp
@@ -25,7 +25,7 @@ bool AHCIController::reset()
 {
     hba().control_regs.ghc = 1;
 
-    dbgln_if(AHCI_DEBUG, "{}: AHCI Controller reset", pci_address());
+    dbgln_if<AHCI_DEBUG>("{}: AHCI Controller reset", pci_address());
 
     full_memory_barrier();
     size_t retry = 0;
@@ -98,7 +98,7 @@ AHCI::HBADefinedCapabilities AHCIController::capabilities() const
     u32 capabilities = hba().control_regs.cap;
     u32 extended_capabilities = hba().control_regs.cap2;
 
-    dbgln_if(AHCI_DEBUG, "{}: AHCI Controller Capabilities = {:#08x}, Extended Capabilities = {:#08x}", pci_address(), capabilities, extended_capabilities);
+    dbgln_if<AHCI_DEBUG>("{}: AHCI Controller Capabilities = {:#08x}, Extended Capabilities = {:#08x}", pci_address(), capabilities, extended_capabilities);
 
     return (AHCI::HBADefinedCapabilities) {
         (capabilities & 0b11111) + 1,
@@ -149,7 +149,7 @@ void AHCIController::initialize_hba(PCI::DeviceIdentifier const& pci_device_iden
     dbgln("{}: AHCI command list entries count - {}", pci_address(), hba_capabilities().max_command_list_entries_count);
 
     u32 version = hba().control_regs.version;
-    dbgln_if(AHCI_DEBUG, "{}: AHCI Controller Version = {:#08x}", pci_address(), version);
+    dbgln_if<AHCI_DEBUG>("{}: AHCI Controller Version = {:#08x}", pci_address(), version);
 
     hba().control_regs.ghc = 0x80000000; // Ensure that HBA knows we are AHCI aware.
     PCI::enable_interrupt_line(pci_address());
@@ -188,7 +188,7 @@ RefPtr<StorageDevice> AHCIController::device(u32 index) const
     u32 pi = hba().control_regs.pi;
     u32 bit = bit_scan_forward(pi);
     while (bit) {
-        dbgln_if(AHCI_DEBUG, "Checking implemented port {}, pi {:b}", bit - 1, pi);
+        dbgln_if<AHCI_DEBUG>("Checking implemented port {}, pi {:b}", bit - 1, pi);
         pi &= ~(1u << (bit - 1));
         auto checked_device = device_by_port(bit - 1);
         bit = bit_scan_forward(pi);
@@ -196,7 +196,7 @@ RefPtr<StorageDevice> AHCIController::device(u32 index) const
             continue;
         connected_devices.append(checked_device.release_nonnull());
     }
-    dbgln_if(AHCI_DEBUG, "Connected device count: {}, Index: {}", connected_devices.size(), index);
+    dbgln_if<AHCI_DEBUG>("Connected device count: {}, Index: {}", connected_devices.size(), index);
     if (index >= connected_devices.size())
         return nullptr;
     return connected_devices[index];

--- a/Kernel/Storage/ATA/AHCIPort.cpp
+++ b/Kernel/Storage/ATA/AHCIPort.cpp
@@ -48,20 +48,20 @@ AHCIPort::AHCIPort(const AHCIPortHandler& handler, volatile AHCI::PortRegisters&
 
     m_command_list_region = MM.allocate_dma_buffer_page("AHCI Port Command List", Memory::Region::Access::ReadWrite, m_command_list_page).release_value_but_fixme_should_propagate_errors();
 
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Command list page at {}", representative_port_index(), m_command_list_page->paddr());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: FIS receive page at {}", representative_port_index(), m_fis_receive_page->paddr());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Command list region at {}", representative_port_index(), m_command_list_region->vaddr());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Command list page at {}", representative_port_index(), m_command_list_page->paddr());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: FIS receive page at {}", representative_port_index(), m_fis_receive_page->paddr());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Command list region at {}", representative_port_index(), m_command_list_region->vaddr());
 }
 
 void AHCIPort::clear_sata_error_register() const
 {
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Clearing SATA error register.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Clearing SATA error register.", representative_port_index());
     m_port_registers.serr = m_port_registers.serr;
 }
 
 void AHCIPort::handle_interrupt()
 {
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Interrupt handled, PxIS {}", representative_port_index(), m_interrupt_status.raw_value());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Interrupt handled, PxIS {}", representative_port_index(), m_interrupt_status.raw_value());
     if (m_interrupt_status.raw_value() == 0) {
         return;
     }
@@ -104,28 +104,28 @@ void AHCIPort::handle_interrupt()
         // This is important so that we can safely access the buffers, which could
         // trigger page faults
         if (!m_current_request) {
-            dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request handled, probably identify request", representative_port_index());
+            dbgln_if<AHCI_DEBUG>("AHCI Port {}: Request handled, probably identify request", representative_port_index());
         } else {
             g_io_work->queue([this]() {
-                dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request handled", representative_port_index());
+                dbgln_if<AHCI_DEBUG>("AHCI Port {}: Request handled", representative_port_index());
                 MutexLocker locker(m_lock);
                 VERIFY(m_current_request);
                 VERIFY(m_current_scatter_list);
                 if (!m_connected_device) {
-                    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request success", representative_port_index());
+                    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Request success", representative_port_index());
                     complete_current_request(AsyncDeviceRequest::Failure);
                     return;
                 }
                 if (m_current_request->request_type() == AsyncBlockDeviceRequest::Read) {
                     if (auto result = m_current_request->write_to_buffer(m_current_request->buffer(), m_current_scatter_list->dma_region().as_ptr(), m_connected_device->block_size() * m_current_request->block_count()); result.is_error()) {
-                        dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request failure, memory fault occurred when reading in data.", representative_port_index());
+                        dbgln_if<AHCI_DEBUG>("AHCI Port {}: Request failure, memory fault occurred when reading in data.", representative_port_index());
                         m_current_scatter_list = nullptr;
                         complete_current_request(AsyncDeviceRequest::MemoryFault);
                         return;
                     }
                 }
                 m_current_scatter_list = nullptr;
-                dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request success", representative_port_index());
+                dbgln_if<AHCI_DEBUG>("AHCI Port {}: Request success", representative_port_index());
                 complete_current_request(AsyncDeviceRequest::Success);
             });
         }
@@ -214,7 +214,7 @@ void AHCIPort::eject()
 
     while (1) {
         if (m_port_registers.serr != 0) {
-            dbgln_if(AHCI_DEBUG, "AHCI Port {}: Eject Drive failed, SError {:#08x}", representative_port_index(), (u32)m_port_registers.serr);
+            dbgln_if<AHCI_DEBUG>("AHCI Port {}: Eject Drive failed, SError {:#08x}", representative_port_index(), (u32)m_port_registers.serr);
             try_disambiguate_sata_error();
             VERIFY_NOT_REACHED();
         }
@@ -228,7 +228,7 @@ bool AHCIPort::reset()
     MutexLocker locker(m_lock);
     SpinlockLocker lock(m_hard_lock);
 
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Resetting", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Resetting", representative_port_index());
 
     if (m_disabled_by_firmware) {
         dmesgln("AHCI Port {}: Disabled by firmware ", representative_port_index());
@@ -259,13 +259,13 @@ bool AHCIPort::initialize_without_reset()
 bool AHCIPort::initialize()
 {
     VERIFY(m_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Initialization. Signature = {:#08x}", representative_port_index(), static_cast<u32>(m_port_registers.sig));
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Initialization. Signature = {:#08x}", representative_port_index(), static_cast<u32>(m_port_registers.sig));
     if (!is_phy_enabled()) {
         // Note: If PHY is not enabled, just clear the interrupt status and enable interrupts, in case
         // we are going to hotplug a device later.
         m_interrupt_status.clear();
         m_interrupt_enable.set_all();
-        dbgln_if(AHCI_DEBUG, "AHCI Port {}: Bailing initialization, Phy is not enabled.", representative_port_index());
+        dbgln_if<AHCI_DEBUG>("AHCI Port {}: Bailing initialization, Phy is not enabled.", representative_port_index());
         return false;
     }
     rebase();
@@ -393,7 +393,7 @@ void AHCIPort::rebase()
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
     VERIFY(!m_command_list_page.is_null() && !m_fis_receive_page.is_null());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Rebasing.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Rebasing.", representative_port_index());
     full_memory_barrier();
     stop_command_list_processing();
     stop_fis_receiving();
@@ -423,7 +423,7 @@ void AHCIPort::set_active_state() const
 {
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Switching to active state.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Switching to active state.", representative_port_index());
     m_port_registers.cmd = (m_port_registers.cmd & 0x0ffffff) | (1 << 28);
 }
 
@@ -466,7 +466,7 @@ Optional<AsyncDeviceRequest::RequestResult> AHCIPort::prepare_and_set_scatter_li
 void AHCIPort::start_request(AsyncBlockDeviceRequest& request)
 {
     MutexLocker locker(m_lock);
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request start", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Request start", representative_port_index());
     VERIFY(!m_current_request);
     VERIFY(!m_current_scatter_list);
 
@@ -474,7 +474,7 @@ void AHCIPort::start_request(AsyncBlockDeviceRequest& request)
 
     auto result = prepare_and_set_scatter_list(request);
     if (result.has_value()) {
-        dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request failure.", representative_port_index());
+        dbgln_if<AHCI_DEBUG>("AHCI Port {}: Request failure.", representative_port_index());
         locker.unlock();
         complete_current_request(result.value());
         return;
@@ -482,7 +482,7 @@ void AHCIPort::start_request(AsyncBlockDeviceRequest& request)
 
     auto success = access_device(request.request_type(), request.block_index(), request.block_count());
     if (!success) {
-        dbgln_if(AHCI_DEBUG, "AHCI Port {}: Request failure.", representative_port_index());
+        dbgln_if<AHCI_DEBUG>("AHCI Port {}: Request failure.", representative_port_index());
         locker.unlock();
         complete_current_request(AsyncDeviceRequest::Failure);
         return;
@@ -501,13 +501,13 @@ bool AHCIPort::spin_until_ready() const
 {
     VERIFY(m_lock.is_locked());
     size_t spin = 0;
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Spinning until ready.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Spinning until ready.", representative_port_index());
     while ((m_port_registers.tfd & (ATA_SR_BSY | ATA_SR_DRQ)) && spin <= 100) {
         IO::delay(1000);
         spin++;
     }
     if (spin == 100) {
-        dbgln_if(AHCI_DEBUG, "AHCI Port {}: SPIN exceeded 100 milliseconds threshold", representative_port_index());
+        dbgln_if<AHCI_DEBUG>("AHCI Port {}: SPIN exceeded 100 milliseconds threshold", representative_port_index());
         return false;
     }
     return true;
@@ -521,7 +521,7 @@ bool AHCIPort::access_device(AsyncBlockDeviceRequest::RequestType direction, u64
     VERIFY(m_current_scatter_list);
     SpinlockLocker lock(m_hard_lock);
 
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Do a {}, lba {}, block count {}", representative_port_index(), direction == AsyncBlockDeviceRequest::RequestType::Write ? "write" : "read", lba, block_count);
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Do a {}, lba {}, block count {}", representative_port_index(), direction == AsyncBlockDeviceRequest::RequestType::Write ? "write" : "read", lba, block_count);
     if (!spin_until_ready())
         return false;
 
@@ -539,12 +539,12 @@ bool AHCIPort::access_device(AsyncBlockDeviceRequest::RequestType direction, u64
     // handshake error bit in PxSERR register if CFL is incorrect.
     command_list_entries[unused_command_header.value()].attributes = (size_t)FIS::DwordCount::RegisterHostToDevice | AHCI::CommandHeaderAttributes::P | (is_atapi_attached() ? AHCI::CommandHeaderAttributes::A : 0) | (direction == AsyncBlockDeviceRequest::RequestType::Write ? AHCI::CommandHeaderAttributes::W : 0);
 
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: CLE: ctba={:#08x}, ctbau={:#08x}, prdbc={:#08x}, prdtl={:#04x}, attributes={:#04x}", representative_port_index(), (u32)command_list_entries[unused_command_header.value()].ctba, (u32)command_list_entries[unused_command_header.value()].ctbau, (u32)command_list_entries[unused_command_header.value()].prdbc, (u16)command_list_entries[unused_command_header.value()].prdtl, (u16)command_list_entries[unused_command_header.value()].attributes);
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: CLE: ctba={:#08x}, ctbau={:#08x}, prdbc={:#08x}, prdtl={:#04x}, attributes={:#04x}", representative_port_index(), (u32)command_list_entries[unused_command_header.value()].ctba, (u32)command_list_entries[unused_command_header.value()].ctbau, (u32)command_list_entries[unused_command_header.value()].prdbc, (u16)command_list_entries[unused_command_header.value()].prdtl, (u16)command_list_entries[unused_command_header.value()].attributes);
 
     auto command_table_region = MM.allocate_kernel_region(m_command_table_pages[unused_command_header.value()].paddr().page_base(), Memory::page_round_up(sizeof(AHCI::CommandTable)).value(), "AHCI Command Table", Memory::Region::Access::ReadWrite, Memory::Region::Cacheable::No).release_value();
     auto& command_table = *(volatile AHCI::CommandTable*)command_table_region->vaddr().as_ptr();
 
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Allocated command table at {}", representative_port_index(), command_table_region->vaddr());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Allocated command table at {}", representative_port_index(), command_table_region->vaddr());
 
     memset(const_cast<u8*>(command_table.command_fis), 0, 64);
 
@@ -553,7 +553,7 @@ bool AHCIPort::access_device(AsyncBlockDeviceRequest::RequestType direction, u64
     for (auto scatter_page : m_current_scatter_list->vmobject().physical_pages()) {
         VERIFY(data_transfer_count != 0);
         VERIFY(scatter_page);
-        dbgln_if(AHCI_DEBUG, "AHCI Port {}: Add a transfer scatter entry @ {}", representative_port_index(), scatter_page->paddr());
+        dbgln_if<AHCI_DEBUG>("AHCI Port {}: Add a transfer scatter entry @ {}", representative_port_index(), scatter_page->paddr());
         command_table.descriptors[scatter_entry_index].base_high = 0;
         command_table.descriptors[scatter_entry_index].base_low = scatter_page->paddr().get();
         if (data_transfer_count <= PAGE_SIZE) {
@@ -602,7 +602,7 @@ bool AHCIPort::access_device(AsyncBlockDeviceRequest::RequestType direction, u64
     mark_command_header_ready_to_process(unused_command_header.value());
     full_memory_barrier();
 
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Do a {}, lba {}, block count {} @ {}, ended", representative_port_index(), direction == AsyncBlockDeviceRequest::RequestType::Write ? "write" : "read", lba, block_count, m_dma_buffers[0].paddr());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Do a {}, lba {}, block count {} @ {}, ended", representative_port_index(), direction == AsyncBlockDeviceRequest::RequestType::Write ? "write" : "read", lba, block_count, m_dma_buffers[0].paddr());
     return true;
 }
 
@@ -646,7 +646,7 @@ bool AHCIPort::identify_device()
     m_interrupt_status.clear();
 
     full_memory_barrier();
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Marking command header at index {} as ready to identify device", representative_port_index(), unused_command_header.value());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Marking command header at index {} as ready to identify device", representative_port_index(), unused_command_header.value());
     m_port_registers.ci = 1 << unused_command_header.value();
     full_memory_barrier();
 
@@ -706,7 +706,7 @@ Optional<u8> AHCIPort::try_to_find_unused_command_header()
     u32 commands_issued = m_port_registers.ci;
     for (size_t index = 0; index < 32; index++) {
         if (!(commands_issued & 1)) {
-            dbgln_if(AHCI_DEBUG, "AHCI Port {}: unused command header at index {}", representative_port_index(), index);
+            dbgln_if<AHCI_DEBUG>("AHCI Port {}: unused command header at index {}", representative_port_index(), index);
             return index;
         }
         commands_issued >>= 1;
@@ -719,7 +719,7 @@ void AHCIPort::start_command_list_processing() const
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
     VERIFY(is_operable());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Starting command list processing.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Starting command list processing.", representative_port_index());
     m_port_registers.cmd = m_port_registers.cmd | 1;
 }
 
@@ -730,7 +730,7 @@ void AHCIPort::mark_command_header_ready_to_process(u8 command_header_index) con
     VERIFY(is_operable());
     VERIFY(!m_wait_for_completion);
     m_wait_for_completion = true;
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Marking command header at index {} as ready to process.", representative_port_index(), command_header_index);
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Marking command header at index {} as ready to process.", representative_port_index(), command_header_index);
     m_port_registers.ci = 1 << command_header_index;
 }
 
@@ -738,7 +738,7 @@ void AHCIPort::stop_command_list_processing() const
 {
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Stopping command list processing.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Stopping command list processing.", representative_port_index());
     m_port_registers.cmd = m_port_registers.cmd & 0xfffffffe;
 }
 
@@ -746,7 +746,7 @@ void AHCIPort::start_fis_receiving() const
 {
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Starting FIS receiving.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Starting FIS receiving.", representative_port_index());
     m_port_registers.cmd = m_port_registers.cmd | (1 << 4);
 }
 
@@ -754,10 +754,10 @@ void AHCIPort::power_on() const
 {
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Power on. Cold presence detection? {}", representative_port_index(), (bool)(m_port_registers.cmd & (1 << 20)));
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Power on. Cold presence detection? {}", representative_port_index(), (bool)(m_port_registers.cmd & (1 << 20)));
     if (!(m_port_registers.cmd & (1 << 20)))
         return;
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Powering on device.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Powering on device.", representative_port_index());
     m_port_registers.cmd = m_port_registers.cmd | (1 << 2);
 }
 
@@ -765,10 +765,10 @@ void AHCIPort::spin_up() const
 {
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Spin up. Staggered spin up? {}", representative_port_index(), m_parent_handler->hba_capabilities().staggered_spin_up_supported);
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Spin up. Staggered spin up? {}", representative_port_index(), m_parent_handler->hba_capabilities().staggered_spin_up_supported);
     if (!m_parent_handler->hba_capabilities().staggered_spin_up_supported)
         return;
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Spinning up device.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Spinning up device.", representative_port_index());
     m_port_registers.cmd = m_port_registers.cmd | (1 << 1);
 }
 
@@ -776,7 +776,7 @@ void AHCIPort::stop_fis_receiving() const
 {
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Stopping FIS receiving.", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Stopping FIS receiving.", representative_port_index());
     m_port_registers.cmd = m_port_registers.cmd & 0xFFFFFFEF;
 }
 
@@ -784,7 +784,7 @@ bool AHCIPort::initiate_sata_reset()
 {
     VERIFY(m_lock.is_locked());
     VERIFY(m_hard_lock.is_locked());
-    dbgln_if(AHCI_DEBUG, "AHCI Port {}: Initiate SATA reset", representative_port_index());
+    dbgln_if<AHCI_DEBUG>("AHCI Port {}: Initiate SATA reset", representative_port_index());
     stop_command_list_processing();
     full_memory_barrier();
 

--- a/Kernel/Storage/ATA/AHCIPortHandler.cpp
+++ b/Kernel/Storage/ATA/AHCIPortHandler.cpp
@@ -25,7 +25,7 @@ AHCIPortHandler::AHCIPortHandler(AHCIController& controller, u8 irq, AHCI::Maske
         m_identify_metadata_pages.append(MM.allocate_supervisor_physical_page().release_value_but_fixme_should_propagate_errors());
     }
 
-    dbgln_if(AHCI_DEBUG, "AHCI Port Handler: IRQ {}", irq);
+    dbgln_if<AHCI_DEBUG>("AHCI Port Handler: IRQ {}", irq);
 
     // Clear pending interrupts, if there are any!
     m_pending_ports_interrupts.set_all();
@@ -64,7 +64,7 @@ RefPtr<AHCIPort> AHCIPortHandler::port_at_index(u32 port_index) const
 
 PhysicalAddress AHCIPortHandler::get_identify_metadata_physical_region(u32 port_index) const
 {
-    dbgln_if(AHCI_DEBUG, "AHCI Port Handler: Get identify metadata physical address of port {} - {}", port_index, (port_index * 512) / PAGE_SIZE);
+    dbgln_if<AHCI_DEBUG>("AHCI Port Handler: Get identify metadata physical address of port {} - {}", port_index, (port_index * 512) / PAGE_SIZE);
     return m_identify_metadata_pages[(port_index * 512) / PAGE_SIZE].paddr().offset((port_index * 512) % PAGE_SIZE);
 }
 
@@ -84,13 +84,13 @@ AHCIPortHandler::~AHCIPortHandler()
 
 bool AHCIPortHandler::handle_irq(const RegisterState&)
 {
-    dbgln_if(AHCI_DEBUG, "AHCI Port Handler: IRQ received");
+    dbgln_if<AHCI_DEBUG>("AHCI Port Handler: IRQ received");
     if (m_pending_ports_interrupts.is_zeroed())
         return false;
     for (auto port_index : m_pending_ports_interrupts.to_vector()) {
         auto port = m_handled_ports.get(port_index);
         VERIFY(port.has_value());
-        dbgln_if(AHCI_DEBUG, "AHCI Port Handler: Handling IRQ for port {}", port_index);
+        dbgln_if<AHCI_DEBUG>("AHCI Port Handler: Handling IRQ for port {}", port_index);
         port.value()->handle_interrupt();
         // We do this to clear the pending interrupt after we handled it.
         m_pending_ports_interrupts.set_at(port_index);

--- a/Kernel/Storage/ATA/BMIDEChannel.cpp
+++ b/Kernel/Storage/ATA/BMIDEChannel.cpp
@@ -82,14 +82,14 @@ bool BMIDEChannel::handle_irq(const RegisterState&)
     u8 bstatus = m_io_group.bus_master_base().value().offset(2).in<u8>();
     if (!(bstatus & 0x4)) {
         // interrupt not from this device, ignore
-        dbgln_if(PATA_DEBUG, "BMIDEChannel: ignore interrupt");
+        dbgln_if<PATA_DEBUG>("BMIDEChannel: ignore interrupt");
         return false;
     }
     // clear bus master interrupt status
     m_io_group.bus_master_base().value().offset(2).out<u8>(m_io_group.bus_master_base().value().offset(2).in<u8>() | 4);
 
     SpinlockLocker lock(m_request_lock);
-    dbgln_if(PATA_DEBUG, "BMIDEChannel: interrupt: DRQ={}, BSY={}, DRDY={}",
+    dbgln_if<PATA_DEBUG>("BMIDEChannel: interrupt: DRQ={}, BSY={}, DRDY={}",
         (status & ATA_SR_DRQ) != 0,
         (status & ATA_SR_BSY) != 0,
         (status & ATA_SR_DRDY) != 0);
@@ -123,7 +123,7 @@ void BMIDEChannel::complete_current_request(AsyncDeviceRequest::RequestResult re
     // which could cause page faults. Note that this may be called immediately
     // before Processor::deferred_call_queue returns!
     g_io_work->queue([this, result]() {
-        dbgln_if(PATA_DEBUG, "BMIDEChannel::complete_current_request result: {}", (int)result);
+        dbgln_if<PATA_DEBUG>("BMIDEChannel::complete_current_request result: {}", (int)result);
         SpinlockLocker lock(m_request_lock);
         VERIFY(m_current_request);
         auto current_request = m_current_request;
@@ -155,7 +155,7 @@ void BMIDEChannel::ata_write_sectors(bool slave_request, u16 capabilities)
     VERIFY(m_current_request->block_count() <= 256);
 
     SpinlockLocker m_lock(m_request_lock);
-    dbgln_if(PATA_DEBUG, "BMIDEChannel::ata_write_sectors ({} x {})", m_current_request->block_index(), m_current_request->block_count());
+    dbgln_if<PATA_DEBUG>("BMIDEChannel::ata_write_sectors ({} x {})", m_current_request->block_index(), m_current_request->block_count());
 
     prdt().offset = m_dma_buffer_page->paddr().get();
     prdt().size = 512 * m_current_request->block_count();
@@ -203,7 +203,7 @@ void BMIDEChannel::ata_read_sectors(bool slave_request, u16 capabilities)
     VERIFY(m_current_request->block_count() <= 256);
 
     SpinlockLocker m_lock(m_request_lock);
-    dbgln_if(PATA_DEBUG, "BMIDEChannel::ata_read_sectors ({} x {})", m_current_request->block_index(), m_current_request->block_count());
+    dbgln_if<PATA_DEBUG>("BMIDEChannel::ata_read_sectors ({} x {})", m_current_request->block_index(), m_current_request->block_count());
 
     // Note: This is a fix for a quirk for an IDE controller on ICH7 machine.
     // We need to select the drive and then we wait 10 microseconds... and it doesn't hurt anything

--- a/Kernel/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Storage/NVMe/NVMeController.cpp
@@ -58,7 +58,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::initialize(bool is_queue_polled)
     VERIFY(m_admin_queue_ready == true);
 
     VERIFY(IO_QUEUE_SIZE < MQES(caps));
-    dbgln_if(NVME_DEBUG, "NVMe: IO queue depth is: {}", IO_QUEUE_SIZE);
+    dbgln_if<NVME_DEBUG>("NVMe: IO queue depth is: {}", IO_QUEUE_SIZE);
 
     // Create an IO queue per core
     for (u32 cpuid = 0; cpuid < nr_of_queues; ++cpuid) {
@@ -80,7 +80,7 @@ bool NVMeController::wait_for_ready(bool expected_ready_bit_value)
 
         if (--wait_iterations == 0) {
             if (((m_controller_regs->csts >> CSTS_RDY_BIT) & 0x1) != expected_rdy) {
-                dbgln_if(NVME_DEBUG, "NVMEController: CSTS.RDY still not set to {} after {} ms", expected_rdy, m_ready_timeout.to_milliseconds());
+                dbgln_if<NVME_DEBUG>("NVMEController: CSTS.RDY still not set to {} after {} ms", expected_rdy, m_ready_timeout.to_milliseconds());
                 return false;
             }
             break;
@@ -144,7 +144,7 @@ UNMAP_AFTER_INIT u32 NVMeController::get_admin_q_dept()
     u32 aqa = m_controller_regs->aqa;
     // Queue depth is 0 based
     u32 q_depth = min(ACQ_SIZE(aqa), ASQ_SIZE(aqa)) + 1;
-    dbgln_if(NVME_DEBUG, "NVMe: Admin queue depth is {}", q_depth);
+    dbgln_if<NVME_DEBUG>("NVMe: Admin queue depth is {}", q_depth);
     return q_depth;
 }
 
@@ -204,11 +204,11 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::identify_and_init_namespaces()
             auto block_counts = val.get<0>();
             auto block_size = 1 << val.get<1>();
 
-            dbgln_if(NVME_DEBUG, "NVMe: Block count is {} and Block size is {}", block_counts, block_size);
+            dbgln_if<NVME_DEBUG>("NVMe: Block count is {} and Block size is {}", block_counts, block_size);
 
             m_namespaces.append(TRY(NVMeNameSpace::try_create(m_queues, controller_id.load(), nsid, block_counts, block_size)));
             m_device_count++;
-            dbgln_if(NVME_DEBUG, "NVMe: Initialized namespace with NSID: {}", nsid);
+            dbgln_if<NVME_DEBUG>("NVMe: Initialized namespace with NSID: {}", nsid);
         }
     }
     return {};
@@ -292,7 +292,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_admin_queue(Optional<u8> i
     set_admin_queue_ready_flag();
     m_admin_queue = TRY(NVMeQueue::try_create(0, irq, qdepth, move(cq_dma_region), cq_dma_pages, move(sq_dma_region), sq_dma_pages, move(doorbell_regs)));
 
-    dbgln_if(NVME_DEBUG, "NVMe: Admin queue created");
+    dbgln_if<NVME_DEBUG>("NVMe: Admin queue created");
     return {};
 }
 
@@ -351,7 +351,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::create_io_queue(u8 qid, Optional<
     auto doorbell_regs = TRY(Memory::map_typed_writable<volatile DoorbellRegister>(PhysicalAddress(m_bar + queue_doorbell_offset)));
 
     m_queues.append(TRY(NVMeQueue::try_create(qid, irq, IO_QUEUE_SIZE, move(cq_dma_region), cq_dma_pages, move(sq_dma_region), sq_dma_pages, move(doorbell_regs))));
-    dbgln_if(NVME_DEBUG, "NVMe: Created IO Queue with QID{}", m_queues.size());
+    dbgln_if<NVME_DEBUG>("NVMe: Created IO Queue with QID{}", m_queues.size());
     return {};
 }
 }

--- a/Kernel/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeQueue.cpp
@@ -70,7 +70,7 @@ u32 NVMeQueue::process_cq()
         ++nr_of_processed_cqes;
         status = CQ_STATUS_FIELD(m_cqe_array[m_cq_head].status);
         cmdid = m_cqe_array[m_cq_head].command_id;
-        dbgln_if(NVME_DEBUG, "NVMe: Completion with status {:x} and command identifier {}. CQ_HEAD: {}", status, cmdid, m_cq_head);
+        dbgln_if<NVME_DEBUG>("NVMe: Completion with status {:x} and command identifier {}. CQ_HEAD: {}", status, cmdid, m_cq_head);
         // TODO: We don't use AsyncBlockDevice requests for admin queue as it is only applicable for a block device (NVMe namespace)
         //  But admin commands precedes namespace creation. Unify requests to avoid special conditions
         if (m_admin_queue == false) {
@@ -106,7 +106,7 @@ void NVMeQueue::submit_sqe(NVMeSubmission& sub)
             m_sq_tail = temp_sq_tail;
     }
 
-    dbgln_if(NVME_DEBUG, "NVMe: Submission with command identifier {}. SQ_TAIL: {}", sub.cmdid, m_sq_tail);
+    dbgln_if<NVME_DEBUG>("NVMe: Submission with command identifier {}. SQ_TAIL: {}", sub.cmdid, m_sq_tail);
     full_memory_barrier();
     update_sq_doorbell();
 }

--- a/Kernel/Storage/Partition/DiskPartition.cpp
+++ b/Kernel/Storage/Partition/DiskPartition.cpp
@@ -50,28 +50,28 @@ void DiskPartition::start_request(AsyncBlockDeviceRequest& request)
 ErrorOr<size_t> DiskPartition::read(OpenFileDescription& fd, u64 offset, UserOrKernelBuffer& outbuf, size_t len)
 {
     u64 adjust = m_metadata.start_block() * block_size();
-    dbgln_if(OFFD_DEBUG, "DiskPartition::read offset={}, adjust={}, len={}", fd.offset(), adjust, len);
+    dbgln_if<OFFD_DEBUG>("DiskPartition::read offset={}, adjust={}, len={}", fd.offset(), adjust, len);
     return m_device.strong_ref()->read(fd, offset + adjust, outbuf, len);
 }
 
 bool DiskPartition::can_read(const OpenFileDescription& fd, u64 offset) const
 {
     u64 adjust = m_metadata.start_block() * block_size();
-    dbgln_if(OFFD_DEBUG, "DiskPartition::can_read offset={}, adjust={}", offset, adjust);
+    dbgln_if<OFFD_DEBUG>("DiskPartition::can_read offset={}, adjust={}", offset, adjust);
     return m_device.strong_ref()->can_read(fd, offset + adjust);
 }
 
 ErrorOr<size_t> DiskPartition::write(OpenFileDescription& fd, u64 offset, const UserOrKernelBuffer& inbuf, size_t len)
 {
     u64 adjust = m_metadata.start_block() * block_size();
-    dbgln_if(OFFD_DEBUG, "DiskPartition::write offset={}, adjust={}, len={}", offset, adjust, len);
+    dbgln_if<OFFD_DEBUG>("DiskPartition::write offset={}, adjust={}, len={}", offset, adjust, len);
     return m_device.strong_ref()->write(fd, offset + adjust, inbuf, len);
 }
 
 bool DiskPartition::can_write(const OpenFileDescription& fd, u64 offset) const
 {
     u64 adjust = m_metadata.start_block() * block_size();
-    dbgln_if(OFFD_DEBUG, "DiskPartition::can_write offset={}, adjust={}", offset, adjust);
+    dbgln_if<OFFD_DEBUG>("DiskPartition::can_write offset={}, adjust={}", offset, adjust);
     return m_device.strong_ref()->can_write(fd, offset + adjust);
 }
 

--- a/Kernel/Storage/Partition/GUIDPartitionTable.cpp
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.cpp
@@ -81,7 +81,7 @@ bool GUIDPartitionTable::initialize()
         return false;
     }
 
-    dbgln_if(GPT_DEBUG, "GUIDPartitionTable: signature - {:#08x} {:#08x}", header().sig[1], header().sig[0]);
+    dbgln_if<GPT_DEBUG>("GUIDPartitionTable: signature - {:#08x} {:#08x}", header().sig[1], header().sig[0]);
 
     if (header().sig[0] != GPT_SIGNATURE && header().sig[1] != GPT_SIGNATURE2) {
         dbgln("GUIDPartitionTable: bad signature {:#08x} {:#08x}", header().sig[1], header().sig[0]);

--- a/Kernel/Storage/Partition/MBRPartitionTable.cpp
+++ b/Kernel/Storage/Partition/MBRPartitionTable.cpp
@@ -96,7 +96,7 @@ const MBRPartitionTable::Header& MBRPartitionTable::header() const
 bool MBRPartitionTable::initialize()
 {
     auto& header = this->header();
-    dbgln_if(MBR_DEBUG, "Master Boot Record: mbr_signature={:#08x}", header.mbr_signature);
+    dbgln_if<MBR_DEBUG>("Master Boot Record: mbr_signature={:#08x}", header.mbr_signature);
     if (header.mbr_signature != MBR_SIGNATURE) {
         dbgln("Master Boot Record: invalid signature");
         return false;

--- a/Kernel/Storage/StorageDevice.cpp
+++ b/Kernel/Storage/StorageDevice.cpp
@@ -40,7 +40,7 @@ ErrorOr<size_t> StorageDevice::read(OpenFileDescription&, u64 offset, UserOrKern
         remaining = 0;
     }
 
-    dbgln_if(STORAGE_DEVICE_DEBUG, "StorageDevice::read() index={}, whole_blocks={}, remaining={}", index, whole_blocks, remaining);
+    dbgln_if<STORAGE_DEVICE_DEBUG>("StorageDevice::read() index={}, whole_blocks={}, remaining={}", index, whole_blocks, remaining);
 
     if (whole_blocks > 0) {
         auto read_request = TRY(try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Read, index, whole_blocks, outbuf, whole_blocks * block_size()));
@@ -108,7 +108,7 @@ ErrorOr<size_t> StorageDevice::write(OpenFileDescription&, u64 offset, const Use
     if (remaining > 0)
         partial_write_block = TRY(ByteBuffer::create_zeroed(block_size()));
 
-    dbgln_if(STORAGE_DEVICE_DEBUG, "StorageDevice::write() index={}, whole_blocks={}, remaining={}", index, whole_blocks, remaining);
+    dbgln_if<STORAGE_DEVICE_DEBUG>("StorageDevice::write() index={}, whole_blocks={}, remaining={}", index, whole_blocks, remaining);
 
     if (whole_blocks > 0) {
         auto write_request = TRY(try_make_request<AsyncBlockDeviceRequest>(AsyncBlockDeviceRequest::Write, index, whole_blocks, inbuf, whole_blocks * block_size()));

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -452,7 +452,7 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     // a custody (e.g. BlockDevice or RandomDevice) is pretty suspicious anyway.
     auto path = TRY(main_program_description->original_absolute_path());
 
-    dbgln_if(EXEC_DEBUG, "do_exec: {}", path);
+    dbgln_if<EXEC_DEBUG>("do_exec: {}", path);
 
     // FIXME: How much stack space does process startup need?
     if (!validate_stack_size(arguments, environment))
@@ -720,7 +720,7 @@ ErrorOr<RefPtr<OpenFileDescription>> Process::find_elf_interpreter_for_executabl
     auto interpreter_path = interpreter_path_builder.string_view();
 
     if (!interpreter_path.is_empty()) {
-        dbgln_if(EXEC_DEBUG, "exec({}): Using program interpreter {}", path, interpreter_path);
+        dbgln_if<EXEC_DEBUG>("exec({}): Using program interpreter {}", path, interpreter_path);
         auto interpreter_description = TRY(VirtualFileSystem::the().open(interpreter_path, O_EXEC, 0, current_directory()));
         auto interp_metadata = interpreter_description->metadata();
 

--- a/Kernel/Syscalls/fcntl.cpp
+++ b/Kernel/Syscalls/fcntl.cpp
@@ -14,7 +14,7 @@ ErrorOr<FlatPtr> Process::sys$fcntl(int fd, int cmd, u32 arg)
 {
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
     TRY(require_promise(Pledge::stdio));
-    dbgln_if(IO_DEBUG, "sys$fcntl: fd={}, cmd={}, arg={}", fd, cmd, arg);
+    dbgln_if<IO_DEBUG>("sys$fcntl: fd={}, cmd={}, arg={}", fd, cmd, arg);
     auto description = TRY(open_file_description(fd));
     // NOTE: The FD flags are not shared between OpenFileDescription objects.
     //       This means that dup() doesn't copy the FD_CLOEXEC flag!

--- a/Kernel/Syscalls/fork.cpp
+++ b/Kernel/Syscalls/fork.cpp
@@ -44,7 +44,7 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
         child->m_protected_values.dumpable = m_protected_values.dumpable;
     }
 
-    dbgln_if(FORK_DEBUG, "fork: child={}", child);
+    dbgln_if<FORK_DEBUG>("fork: child={}", child);
     child->address_space().set_enforces_syscall_regions(address_space().enforces_syscall_regions());
 
     // A child created via fork(2) inherits a copy of its parent's signal mask
@@ -73,7 +73,7 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     child_regs.gs = regs.gs;
     child_regs.ss = regs.userspace_ss;
 
-    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:#04x}:{:p} with stack {:#04x}:{:p}, kstack {:#04x}:{:p}",
+    dbgln_if<FORK_DEBUG>("fork: child will begin executing at {:#04x}:{:p} with stack {:#04x}:{:p}, kstack {:#04x}:{:p}",
         child_regs.cs, child_regs.eip, child_regs.ss, child_regs.esp, child_regs.ss0, child_regs.esp0);
 #else
     auto& child_regs = child_first_thread->m_regs;
@@ -97,14 +97,14 @@ ErrorOr<FlatPtr> Process::sys$fork(RegisterState& regs)
     child_regs.rip = regs.rip;
     child_regs.cs = regs.cs;
 
-    dbgln_if(FORK_DEBUG, "fork: child will begin executing at {:#04x}:{:p} with stack {:p}, kstack {:p}",
+    dbgln_if<FORK_DEBUG>("fork: child will begin executing at {:#04x}:{:p} with stack {:p}, kstack {:p}",
         child_regs.cs, child_regs.rip, child_regs.rsp, child_regs.rsp0);
 #endif
 
     {
         SpinlockLocker lock(address_space().get_lock());
         for (auto& region : address_space().regions()) {
-            dbgln_if(FORK_DEBUG, "fork: cloning Region({}) '{}' @ {}", region, region->name(), region->vaddr());
+            dbgln_if<FORK_DEBUG>("fork: cloning Region({}) '{}' @ {}", region, region->name(), region->vaddr());
             auto region_clone = TRY(region->try_clone());
             auto* child_region = TRY(child->address_space().add_region(move(region_clone)));
             TRY(child_region->map(child->address_space().page_directory(), Memory::ShouldFlushTLB::No));

--- a/Kernel/Syscalls/futex.cpp
+++ b/Kernel/Syscalls/futex.cpp
@@ -107,7 +107,7 @@ ErrorOr<FlatPtr> Process::sys$futex(Userspace<const Syscall::SC_futex_params*> u
             if (!user_value.has_value())
                 return EFAULT;
             if (user_value.value() != params.val) {
-                dbgln_if(FUTEX_DEBUG, "futex wait: EAGAIN. user value: {:p} @ {:p} != val: {}", user_value.value(), params.userspace_address, params.val);
+                dbgln_if<FUTEX_DEBUG>("futex wait: EAGAIN. user value: {:p} @ {:p} != val: {}", user_value.value(), params.userspace_address, params.val);
                 return EAGAIN;
             }
             atomic_thread_fence(AK::MemoryOrder::memory_order_acquire);

--- a/Kernel/Syscalls/open.cpp
+++ b/Kernel/Syscalls/open.cpp
@@ -40,7 +40,7 @@ ErrorOr<FlatPtr> Process::sys$open(Userspace<const Syscall::SC_open_params*> use
 
     auto path = TRY(get_syscall_path_argument(params.path));
 
-    dbgln_if(IO_DEBUG, "sys$open(dirfd={}, path='{}', options={}, mode={})", dirfd, path->view(), options, mode);
+    dbgln_if<IO_DEBUG>("sys$open(dirfd={}, path='{}', options={}, mode={})", dirfd, path->view(), options, mode);
 
     auto fd_allocation = TRY(allocate_fd());
     RefPtr<Custody> base;

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -79,7 +79,7 @@ ErrorOr<FlatPtr> Process::sys$read(int fd, Userspace<u8*> buffer, size_t size)
         return 0;
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
-    dbgln_if(IO_DEBUG, "sys$read({}, {}, {})", fd, buffer.ptr(), size);
+    dbgln_if<IO_DEBUG>("sys$read({}, {}, {})", fd, buffer.ptr(), size);
     auto description = TRY(open_readable_file_description(fds(), fd));
     TRY(check_blocked_read(description));
     auto user_buffer = TRY(UserOrKernelBuffer::for_user_buffer(buffer, size));
@@ -99,7 +99,7 @@ ErrorOr<FlatPtr> Process::sys$pread(int fd, Userspace<u8*> buffer, size_t size, 
     auto offset = TRY(copy_typed_from_user(userspace_offset));
     if (offset < 0)
         return EINVAL;
-    dbgln_if(IO_DEBUG, "sys$pread({}, {}, {}, {})", fd, buffer.ptr(), size, offset);
+    dbgln_if<IO_DEBUG>("sys$pread({}, {}, {}, {})", fd, buffer.ptr(), size, offset);
     auto description = TRY(open_readable_file_description(fds(), fd));
     if (!description->file().is_seekable())
         return EINVAL;

--- a/Kernel/Syscalls/waitid.cpp
+++ b/Kernel/Syscalls/waitid.cpp
@@ -52,7 +52,7 @@ ErrorOr<FlatPtr> Process::sys$waitid(Userspace<const Syscall::SC_waitid_params*>
         return EINVAL;
     }
 
-    dbgln_if(PROCESS_DEBUG, "sys$waitid({}, {}, {}, {})", params.idtype, params.id, params.infop, params.options);
+    dbgln_if<PROCESS_DEBUG>("sys$waitid({}, {}, {}, {})", params.idtype, params.id, params.infop, params.options);
 
     auto siginfo = TRY(do_waitid(move(waitee), params.options));
     TRY(copy_to_user(params.infop, &siginfo));

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -96,7 +96,7 @@ ErrorOr<FlatPtr> Process::sys$write(int fd, Userspace<const u8*> data, size_t si
     if (size > NumericLimits<ssize_t>::max())
         return EINVAL;
 
-    dbgln_if(IO_DEBUG, "sys$write({}, {}, {})", fd, data.ptr(), size);
+    dbgln_if<IO_DEBUG>("sys$write({}, {}, {})", fd, data.ptr(), size);
     auto description = TRY(open_file_description(fd));
     if (!description->is_writable())
         return EBADF;

--- a/Kernel/TTY/ConsoleManagement.cpp
+++ b/Kernel/TTY/ConsoleManagement.cpp
@@ -78,7 +78,7 @@ void ConsoleManagement::switch_to(unsigned index)
     bool was_graphical = m_active_console->is_graphical();
     m_active_console->set_active(false);
     m_active_console = &m_consoles[index];
-    dbgln_if(VIRTUAL_CONSOLE_DEBUG, "Console: Switch to {}", index);
+    dbgln_if<VIRTUAL_CONSOLE_DEBUG>("Console: Switch to {}", index);
 
     // Before setting current console to be "active", switch between graphical mode to "textual" mode
     // if needed. This will ensure we clear the screen and also that WindowServer won't print anything

--- a/Kernel/TTY/MasterPTY.cpp
+++ b/Kernel/TTY/MasterPTY.cpp
@@ -48,7 +48,7 @@ MasterPTY::MasterPTY(unsigned index, NonnullOwnPtr<DoubleBuffer> buffer, Nonnull
 
 MasterPTY::~MasterPTY()
 {
-    dbgln_if(MASTERPTY_DEBUG, "~MasterPTY({})", m_index);
+    dbgln_if<MASTERPTY_DEBUG>("~MasterPTY({})", m_index);
     PTYMultiplexer::the().notify_master_destroyed({}, m_index);
 }
 
@@ -86,7 +86,7 @@ bool MasterPTY::can_write(const OpenFileDescription&, u64) const
 
 void MasterPTY::notify_slave_closed(Badge<SlavePTY>)
 {
-    dbgln_if(MASTERPTY_DEBUG, "MasterPTY({}): slave closed, my retains: {}, slave retains: {}", m_index, ref_count(), m_slave->ref_count());
+    dbgln_if<MASTERPTY_DEBUG>("MasterPTY({}): slave closed, my retains: {}, slave retains: {}", m_index, ref_count(), m_slave->ref_count());
     // +1 ref for my MasterPTY::m_slave
     // +1 ref for OpenFileDescription::m_device
     if (m_slave->ref_count() == 2)

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -48,7 +48,7 @@ ErrorOr<NonnullRefPtr<OpenFileDescription>> PTYMultiplexer::open(int options)
 
         auto master_index = freelist.take_last();
         auto master = TRY(MasterPTY::try_create(master_index));
-        dbgln_if(PTMX_DEBUG, "PTYMultiplexer::open: Vending master {}", master->index());
+        dbgln_if<PTMX_DEBUG>("PTYMultiplexer::open: Vending master {}", master->index());
         auto description = TRY(OpenFileDescription::try_create(*master));
         description->set_rw_mode(options);
         description->set_file_flags(options);
@@ -60,7 +60,7 @@ void PTYMultiplexer::notify_master_destroyed(Badge<MasterPTY>, unsigned index)
 {
     m_freelist.with([&](auto& freelist) {
         freelist.append(index);
-        dbgln_if(PTMX_DEBUG, "PTYMultiplexer: {} added to freelist", index);
+        dbgln_if<PTMX_DEBUG>("PTYMultiplexer: {} added to freelist", index);
     });
 }
 

--- a/Kernel/TTY/SlavePTY.cpp
+++ b/Kernel/TTY/SlavePTY.cpp
@@ -52,7 +52,7 @@ SlavePTY::SlavePTY(MasterPTY& master, unsigned index, NonnullOwnPtr<KString> tty
 
 SlavePTY::~SlavePTY()
 {
-    dbgln_if(SLAVEPTY_DEBUG, "~SlavePTY({})", m_index);
+    dbgln_if<SLAVEPTY_DEBUG>("~SlavePTY({})", m_index);
 }
 
 KString const& SlavePTY::tty_name() const

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -362,10 +362,10 @@ void TTY::generate_signal(int signal)
         return;
     if (should_flush_on_signal())
         flush_input();
-    dbgln_if(TTY_DEBUG, "{}: Send signal {} to everyone in pgrp {}", tty_name(), signal, pgid().value());
+    dbgln_if<TTY_DEBUG>("{}: Send signal {} to everyone in pgrp {}", tty_name(), signal, pgid().value());
     InterruptDisabler disabler; // FIXME: Iterate over a set of process handles instead?
     Process::for_each_in_pgrp(pgid(), [&](auto& process) {
-        dbgln_if(TTY_DEBUG, "{}: Send signal {} to {}", tty_name(), signal, process);
+        dbgln_if<TTY_DEBUG>("{}: Send signal {} to {}", tty_name(), signal, process);
         // FIXME: Should this error be propagated somehow?
         [[maybe_unused]] auto rc = process.send_signal(signal, nullptr);
     });
@@ -383,7 +383,7 @@ ErrorOr<void> TTY::set_termios(const termios& t)
     ErrorOr<void> rc;
     m_termios = t;
 
-    dbgln_if(TTY_DEBUG, "{} set_termios: ECHO={}, ISIG={}, ICANON={}, ECHOE={}, ECHOK={}, ECHONL={}, ISTRIP={}, ICRNL={}, INLCR={}, IGNCR={}, OPOST={}, ONLCR={}",
+    dbgln_if<TTY_DEBUG>("{} set_termios: ECHO={}, ISIG={}, ICANON={}, ECHOE={}, ECHOK={}, ECHONL={}, ISTRIP={}, ICRNL={}, INLCR={}, IGNCR={}, OPOST={}, ONLCR={}",
         tty_name(),
         should_echo_input(),
         should_generate_signals(),

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -522,9 +522,9 @@ void Thread::WaitBlockerSet::try_unblock(Thread::WaitBlocker& blocker)
             if (blocker.is_wait()) {
                 if (info.flags == Thread::WaitBlocker::UnblockFlags::Terminated) {
                     m_processes.remove(i);
-                    dbgln_if(WAITBLOCK_DEBUG, "WaitBlockerSet[{}] terminated, remove {}", m_process, *info.process);
+                    dbgln_if<WAITBLOCK_DEBUG>("WaitBlockerSet[{}] terminated, remove {}", m_process, *info.process);
                 } else {
-                    dbgln_if(WAITBLOCK_DEBUG, "WaitBlockerSet[{}] terminated, mark as waited {}", m_process, *info.process);
+                    dbgln_if<WAITBLOCK_DEBUG>("WaitBlockerSet[{}] terminated, mark as waited {}", m_process, *info.process);
                     info.was_waited = true;
                 }
             }
@@ -548,7 +548,7 @@ void Thread::WaitBlockerSet::disowned_by_waiter(Process& process)
                 VERIFY(did_unblock); // disowning must unblock everyone
                 return true;
             });
-            dbgln_if(WAITBLOCK_DEBUG, "WaitBlockerSet[{}] disowned {}", m_process, *info.process);
+            dbgln_if<WAITBLOCK_DEBUG>("WaitBlockerSet[{}] disowned {}", m_process, *info.process);
             m_processes.remove(i);
             continue;
         }
@@ -601,13 +601,13 @@ bool Thread::WaitBlockerSet::unblock(Process& process, WaitBlocker::UnblockFlags
                 info.flags = flags;
                 info.signal = signal;
                 info.was_waited = did_wait;
-                dbgln_if(WAITBLOCK_DEBUG, "WaitBlockerSet[{}] update {} flags={}, waited={}", m_process, process, (int)flags, info.was_waited);
+                dbgln_if<WAITBLOCK_DEBUG>("WaitBlockerSet[{}] update {} flags={}, waited={}", m_process, process, (int)flags, info.was_waited);
                 updated_existing = true;
                 break;
             }
         }
         if (!updated_existing) {
-            dbgln_if(WAITBLOCK_DEBUG, "WaitBlockerSet[{}] add {} flags: {}", m_process, process, (int)flags);
+            dbgln_if<WAITBLOCK_DEBUG>("WaitBlockerSet[{}] add {} flags: {}", m_process, process, (int)flags);
             m_processes.append(ProcessBlockInfo(process, flags, signal));
         }
     }

--- a/Kernel/Time/HPET.cpp
+++ b/Kernel/Time/HPET.cpp
@@ -211,7 +211,7 @@ void HPET::update_periodic_comparator_value()
             // and we can only write the period into the comparator value...
             timer.capabilities = timer.capabilities | (u32)HPETFlags::TimerConfiguration::ValueSet;
             u64 value = ns_to_raw_counter_ticks(1000000000ull / comparator.ticks_per_second());
-            dbgln_if(HPET_DEBUG, "HPET: Update periodic comparator {} comparator value to {} main value was: {}",
+            dbgln_if<HPET_DEBUG>("HPET: Update periodic comparator {} comparator value to {} main value was: {}",
                 comparator.comparator_number(),
                 value,
                 previous_main_value);
@@ -224,7 +224,7 @@ void HPET::update_periodic_comparator_value()
             // Set the new target comparator value to the delta to the remaining ticks
             u64 current_value = (u64)timer.comparator_value.low | ((u64)timer.comparator_value.high << 32);
             u64 value = current_value - previous_main_value;
-            dbgln_if(HPET_DEBUG, "HPET: Update non-periodic comparator {} comparator value from {} to {} main value was: {}",
+            dbgln_if<HPET_DEBUG>("HPET: Update non-periodic comparator {} comparator value from {} to {} main value was: {}",
                 comparator.comparator_number(),
                 current_value,
                 value,
@@ -308,7 +308,7 @@ u64 HPET::read_main_counter() const
 
 void HPET::enable_periodic_interrupt(const HPETComparator& comparator)
 {
-    dbgln_if(HPET_DEBUG, "HPET: Set comparator {} to be periodic.", comparator.comparator_number());
+    dbgln_if<HPET_DEBUG>("HPET: Set comparator {} to be periodic.", comparator.comparator_number());
     disable(comparator);
     VERIFY(comparator.comparator_number() <= m_comparators.size());
     auto& timer = registers().timers[comparator.comparator_number()];
@@ -320,7 +320,7 @@ void HPET::enable_periodic_interrupt(const HPETComparator& comparator)
 }
 void HPET::disable_periodic_interrupt(const HPETComparator& comparator)
 {
-    dbgln_if(HPET_DEBUG, "HPET: Disable periodic interrupt in comparator {}", comparator.comparator_number());
+    dbgln_if<HPET_DEBUG>("HPET: Disable periodic interrupt in comparator {}", comparator.comparator_number());
     disable(comparator);
     VERIFY(comparator.comparator_number() <= m_comparators.size());
     auto& timer = registers().timers[comparator.comparator_number()];
@@ -333,14 +333,14 @@ void HPET::disable_periodic_interrupt(const HPETComparator& comparator)
 
 void HPET::disable(const HPETComparator& comparator)
 {
-    dbgln_if(HPET_DEBUG, "HPET: Disable comparator {}", comparator.comparator_number());
+    dbgln_if<HPET_DEBUG>("HPET: Disable comparator {}", comparator.comparator_number());
     VERIFY(comparator.comparator_number() <= m_comparators.size());
     auto& timer = registers().timers[comparator.comparator_number()];
     timer.capabilities = timer.capabilities & ~(u32)HPETFlags::TimerConfiguration::InterruptEnable;
 }
 void HPET::enable(const HPETComparator& comparator)
 {
-    dbgln_if(HPET_DEBUG, "HPET: Enable comparator {}", comparator.comparator_number());
+    dbgln_if<HPET_DEBUG>("HPET: Enable comparator {}", comparator.comparator_number());
     VERIFY(comparator.comparator_number() <= m_comparators.size());
     auto& timer = registers().timers[comparator.comparator_number()];
     timer.capabilities = timer.capabilities | (u32)HPETFlags::TimerConfiguration::InterruptEnable;

--- a/Kernel/Time/HPETComparator.cpp
+++ b/Kernel/Time/HPETComparator.cpp
@@ -95,7 +95,7 @@ bool HPETComparator::try_to_set_frequency(size_t frequency)
     m_frequency = frequency;
     m_enabled = true;
 
-    dbgln_if(HPET_COMPARATOR_DEBUG, "HPET Comparator: Max frequency {} Hz, want to set {} Hz, periodic: {}", hpet_frequency, frequency, is_periodic());
+    dbgln_if<HPET_COMPARATOR_DEBUG>("HPET Comparator: Max frequency {} Hz, want to set {} Hz, periodic: {}", hpet_frequency, frequency, is_periodic());
 
     if (is_periodic()) {
         HPET::the().update_periodic_comparator_value();

--- a/Kernel/WaitQueue.cpp
+++ b/Kernel/WaitQueue.cpp
@@ -16,10 +16,10 @@ bool WaitQueue::should_add_blocker(Thread::Blocker& b, void*)
     VERIFY(b.blocker_type() == Thread::Blocker::Type::Queue);
     if (m_wake_requested) {
         m_wake_requested = false;
-        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: do not block thread {}", this, b.thread());
+        dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: do not block thread {}", this, b.thread());
         return false;
     }
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: should block thread {}", this, b.thread());
+    dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: should block thread {}", this, b.thread());
     return true;
 }
 
@@ -27,11 +27,11 @@ u32 WaitQueue::wake_one()
 {
     u32 did_wake = 0;
     SpinlockLocker lock(m_lock);
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one", this);
+    dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_one", this);
     bool did_unblock_one = unblock_all_blockers_whose_conditions_are_met_locked([&](Thread::Blocker& b, void*, bool& stop_iterating) {
         VERIFY(b.blocker_type() == Thread::Blocker::Type::Queue);
         auto& blocker = static_cast<Thread::WaitQueueBlocker&>(b);
-        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one unblocking {}", this, blocker.thread());
+        dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_one unblocking {}", this, blocker.thread());
         if (blocker.unblock()) {
             stop_iterating = true;
             did_wake = 1;
@@ -40,7 +40,7 @@ u32 WaitQueue::wake_one()
         return false;
     });
     m_wake_requested = !did_unblock_one;
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_one woke {} threads", this, did_wake);
+    dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_one woke {} threads", this, did_wake);
     return did_wake;
 }
 
@@ -49,13 +49,13 @@ u32 WaitQueue::wake_n(u32 wake_count)
     if (wake_count == 0)
         return 0; // should we assert instead?
     SpinlockLocker lock(m_lock);
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n({})", this, wake_count);
+    dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_n({})", this, wake_count);
     u32 did_wake = 0;
 
     bool did_unblock_some = unblock_all_blockers_whose_conditions_are_met_locked([&](Thread::Blocker& b, void*, bool& stop_iterating) {
         VERIFY(b.blocker_type() == Thread::Blocker::Type::Queue);
         auto& blocker = static_cast<Thread::WaitQueueBlocker&>(b);
-        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n unblocking {}", this, blocker.thread());
+        dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_n unblocking {}", this, blocker.thread());
         VERIFY(did_wake < wake_count);
         if (blocker.unblock()) {
             if (++did_wake >= wake_count)
@@ -65,7 +65,7 @@ u32 WaitQueue::wake_n(u32 wake_count)
         return false;
     });
     m_wake_requested = !did_unblock_some;
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_n({}) woke {} threads", this, wake_count, did_wake);
+    dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_n({}) woke {} threads", this, wake_count, did_wake);
     return did_wake;
 }
 
@@ -73,14 +73,14 @@ u32 WaitQueue::wake_all()
 {
     SpinlockLocker lock(m_lock);
 
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all", this);
+    dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_all", this);
     u32 did_wake = 0;
 
     bool did_unblock_any = unblock_all_blockers_whose_conditions_are_met_locked([&](Thread::Blocker& b, void*, bool&) {
         VERIFY(b.blocker_type() == Thread::Blocker::Type::Queue);
         auto& blocker = static_cast<Thread::WaitQueueBlocker&>(b);
 
-        dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all unblocking {}", this, blocker.thread());
+        dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_all unblocking {}", this, blocker.thread());
 
         if (blocker.unblock()) {
             did_wake++;
@@ -89,7 +89,7 @@ u32 WaitQueue::wake_all()
         return false;
     });
     m_wake_requested = !did_unblock_any;
-    dbgln_if(WAITQUEUE_DEBUG, "WaitQueue @ {}: wake_all woke {} threads", this, did_wake);
+    dbgln_if<WAITQUEUE_DEBUG>("WaitQueue @ {}: wake_all woke {} threads", this, did_wake);
     return did_wake;
 }
 

--- a/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzGIFLoader.cpp
@@ -18,18 +18,18 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     if (!bitmap_or_error.is_error()) {
         auto const& bitmap = bitmap_or_error.value().image;
         // Looks like a valid GIF. Try to load the other frames:
-        dbgln_if(GIF_DEBUG, "bitmap size: {}", bitmap->size());
-        dbgln_if(GIF_DEBUG, "codec size: {}", gif_decoder.size());
-        dbgln_if(GIF_DEBUG, "is_sniff: {}", gif_decoder.sniff());
-        dbgln_if(GIF_DEBUG, "is_animated: {}", gif_decoder.is_animated());
-        dbgln_if(GIF_DEBUG, "loop_count: {}", gif_decoder.loop_count());
-        dbgln_if(GIF_DEBUG, "frame_count: {}", gif_decoder.frame_count());
+        dbgln_if<GIF_DEBUG>("bitmap size: {}", bitmap->size());
+        dbgln_if<GIF_DEBUG>("codec size: {}", gif_decoder.size());
+        dbgln_if<GIF_DEBUG>("is_sniff: {}", gif_decoder.sniff());
+        dbgln_if<GIF_DEBUG>("is_animated: {}", gif_decoder.is_animated());
+        dbgln_if<GIF_DEBUG>("loop_count: {}", gif_decoder.loop_count());
+        dbgln_if<GIF_DEBUG>("frame_count: {}", gif_decoder.frame_count());
         for (size_t i = 0; i < gif_decoder.frame_count(); ++i) {
             auto ifd = gif_decoder.frame(i).release_value_but_fixme_should_propagate_errors();
-            dbgln_if(GIF_DEBUG, "frame #{} size: {}", i, ifd.image->size());
-            dbgln_if(GIF_DEBUG, "frame #{} duration: {}", i, ifd.duration);
+            dbgln_if<GIF_DEBUG>("frame #{} size: {}", i, ifd.image->size());
+            dbgln_if<GIF_DEBUG>("frame #{} duration: {}", i, ifd.duration);
         }
-        dbgln_if(GIF_DEBUG, "Done.");
+        dbgln_if<GIF_DEBUG>("Done.");
     }
 
     return 0;

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -520,7 +520,7 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
 
     new_tab.load(url);
 
-    dbgln_if(SPAM_DEBUG, "Added new tab {:p}, loading {}", &new_tab, url);
+    dbgln_if<SPAM_DEBUG>("Added new tab {:p}, loading {}", &new_tab, url);
 
     if (activate)
         m_tab_widget->set_active_widget(&new_tab);

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -249,7 +249,7 @@ void HexEditor::mousedown_event(GUI::MouseEvent& event)
         if (offset >= m_document->size())
             return;
 
-        dbgln_if(HEX_DEBUG, "HexEditor::mousedown_event(hex): offset={}", offset);
+        dbgln_if<HEX_DEBUG>("HexEditor::mousedown_event(hex): offset={}", offset);
 
         m_edit_mode = EditMode::Hex;
         m_cursor_at_low_nibble = false;
@@ -272,7 +272,7 @@ void HexEditor::mousedown_event(GUI::MouseEvent& event)
         if (offset >= m_document->size())
             return;
 
-        dbgln_if(HEX_DEBUG, "HexEditor::mousedown_event(text): offset={}", offset);
+        dbgln_if<HEX_DEBUG>("HexEditor::mousedown_event(text): offset={}", offset);
 
         m_position = offset;
         m_cursor_at_low_nibble = false;
@@ -378,7 +378,7 @@ void HexEditor::scroll_position_into_view(size_t position)
 
 void HexEditor::keydown_event(GUI::KeyEvent& event)
 {
-    dbgln_if(HEX_DEBUG, "HexEditor::keydown_event key={}", static_cast<u8>(event.key()));
+    dbgln_if<HEX_DEBUG>("HexEditor::keydown_event key={}", static_cast<u8>(event.key()));
 
     if (event.key() == KeyCode::Key_Up) {
         if (m_position >= bytes_per_row()) {

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -326,7 +326,7 @@ void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Posi
         auto& target = to.first();
 
         for (auto& position : from) {
-            dbgln_if(COPY_DEBUG, "Paste from '{}' to '{}'", position.to_url(*this), target.to_url(*this));
+            dbgln_if<COPY_DEBUG>("Paste from '{}' to '{}'", position.to_url(*this), target.to_url(*this));
             copy_to(position, resolve_relative_to.has_value() ? offset_relative_to(target, position, resolve_relative_to.value()) : target);
         }
 
@@ -337,7 +337,7 @@ void Sheet::copy_cells(Vector<Position> from, Vector<Position> to, Optional<Posi
         // Fill the target selection with the single cell.
         auto& source = from.first();
         for (auto& position : to) {
-            dbgln_if(COPY_DEBUG, "Paste from '{}' to '{}'", source.to_url(*this), position.to_url(*this));
+            dbgln_if<COPY_DEBUG>("Paste from '{}' to '{}'", source.to_url(*this), position.to_url(*this));
             copy_to(source, resolve_relative_to.has_value() ? offset_relative_to(position, source, resolve_relative_to.value()) : position);
         }
         return;

--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -204,7 +204,7 @@ void Editor::show_documentation_tooltip_if_available(const String& hovered_token
 {
     auto it = man_paths().find(hovered_token);
     if (it == man_paths().end()) {
-        dbgln_if(EDITOR_DEBUG, "no man path for {}", hovered_token);
+        dbgln_if<EDITOR_DEBUG>("no man path for {}", hovered_token);
         m_documentation_tooltip_window->hide();
         return;
     }
@@ -213,7 +213,7 @@ void Editor::show_documentation_tooltip_if_available(const String& hovered_token
         return;
     }
 
-    dbgln_if(EDITOR_DEBUG, "opening {}", it->value);
+    dbgln_if<EDITOR_DEBUG>("opening {}", it->value);
     auto file = Core::File::construct(it->value);
     if (!file->open(Core::OpenMode::ReadOnly)) {
         dbgln("failed to open {}, {}", it->value, file->error_string());
@@ -283,7 +283,7 @@ void Editor::mousemove_event(GUI::MouseEvent& event)
             auto end_line_length = document().line(span.range.end().line()).length();
             adjusted_range.end().set_column(min(end_line_length, adjusted_range.end().column() + 1));
             auto hovered_span_text = document().text_in_range(adjusted_range);
-            dbgln_if(EDITOR_DEBUG, "Hovering: {} \"{}\"", adjusted_range, hovered_span_text);
+            dbgln_if<EDITOR_DEBUG>("Hovering: {} \"{}\"", adjusted_range, hovered_span_text);
 
             if (is_clickable) {
                 is_over_clickable = true;
@@ -394,7 +394,7 @@ static HashMap<String, String>& include_paths()
             auto path = it.next_full_path();
             if (!Core::File::is_directory(path)) {
                 auto key = path.substring(base.length() + 1, path.length() - base.length() - 1);
-                dbgln_if(EDITOR_DEBUG, "Adding header \"{}\" in path \"{}\"", key, path);
+                dbgln_if<EDITOR_DEBUG>("Adding header \"{}\" in path \"{}\"", key, path);
                 paths.set(key, path);
             } else {
                 handle_directory(base, path, handle_directory);
@@ -416,7 +416,7 @@ void Editor::navigate_to_include_if_available(String path)
 {
     auto it = include_paths().find(path);
     if (it == include_paths().end()) {
-        dbgln_if(EDITOR_DEBUG, "no header {} found.", path);
+        dbgln_if<EDITOR_DEBUG>("no header {} found.", path);
         return;
     }
 
@@ -578,7 +578,7 @@ void Editor::on_navigatable_link_click(const GUI::TextDocumentSpan& span)
 {
     auto span_text = document().text_in_range(span.range);
     auto header_path = span_text.substring(1, span_text.length() - 2);
-    dbgln_if(EDITOR_DEBUG, "Ctrl+click: {} \"{}\"", span.range, header_path);
+    dbgln_if<EDITOR_DEBUG>("Ctrl+click: {} \"{}\"", span.range, header_path);
     navigate_to_include_if_available(header_path);
 }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/ClientConnection.cpp
@@ -54,24 +54,24 @@ void ClientConnection::file_opened(String const& filename, IPC::File const& file
 
 void ClientConnection::file_edit_insert_text(String const& filename, String const& text, i32 start_line, i32 start_column)
 {
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "InsertText for file: {}", filename);
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "Text: {}", text);
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "[{}:{}]", start_line, start_column);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("InsertText for file: {}", filename);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("Text: {}", text);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("[{}:{}]", start_line, start_column);
     m_filedb.on_file_edit_insert_text(filename, text, start_line, start_column);
     m_autocomplete_engine->on_edit(filename);
 }
 
 void ClientConnection::file_edit_remove_text(String const& filename, i32 start_line, i32 start_column, i32 end_line, i32 end_column)
 {
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "RemoveText for file: {}", filename);
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "[{}:{} - {}:{}]", start_line, start_column, end_line, end_column);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("RemoveText for file: {}", filename);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("[{}:{} - {}:{}]", start_line, start_column, end_line, end_column);
     m_filedb.on_file_edit_remove_text(filename, start_line, start_column, end_line, end_column);
     m_autocomplete_engine->on_edit(filename);
 }
 
 void ClientConnection::auto_complete_suggestions(GUI::AutocompleteProvider::ProjectLocation const& location)
 {
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "AutoCompleteSuggestions for: {} {}:{}", location.file, location.line, location.column);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("AutoCompleteSuggestions for: {} {}:{}", location.file, location.line, location.column);
 
     auto document = m_filedb.get(location.file);
     if (!document) {
@@ -86,7 +86,7 @@ void ClientConnection::auto_complete_suggestions(GUI::AutocompleteProvider::Proj
 
 void ClientConnection::set_file_content(String const& filename, String const& content)
 {
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "SetFileContent: {}", filename);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("SetFileContent: {}", filename);
     auto document = m_filedb.get(filename);
     if (!document) {
         m_filedb.add(filename, content);
@@ -100,7 +100,7 @@ void ClientConnection::set_file_content(String const& filename, String const& co
 
 void ClientConnection::find_declaration(GUI::AutocompleteProvider::ProjectLocation const& location)
 {
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "FindDeclaration: {} {}:{}", location.file, location.line, location.column);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("FindDeclaration: {} {}:{}", location.file, location.line, location.column);
     auto document = m_filedb.get(location.file);
     if (!document) {
         dbgln("file {} has not been opened", location.file);
@@ -114,13 +114,13 @@ void ClientConnection::find_declaration(GUI::AutocompleteProvider::ProjectLocati
         return;
     }
 
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "declaration location: {} {}:{}", decl_location.value().file, decl_location.value().line, decl_location.value().column);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("declaration location: {} {}:{}", decl_location.value().file, decl_location.value().line, decl_location.value().column);
     async_declaration_location(GUI::AutocompleteProvider::ProjectLocation { decl_location.value().file, decl_location.value().line, decl_location.value().column });
 }
 
 void ClientConnection::get_parameters_hint(GUI::AutocompleteProvider::ProjectLocation const& location)
 {
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "GetFunctionParams: {} {}:{}", location.file, location.line, location.column);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("GetFunctionParams: {} {}:{}", location.file, location.line, location.column);
     auto document = m_filedb.get(location.file);
     if (!document) {
         dbgln("file {} has not been opened", location.file);
@@ -134,11 +134,11 @@ void ClientConnection::get_parameters_hint(GUI::AutocompleteProvider::ProjectLoc
         return;
     }
 
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "parameters hint:");
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("parameters hint:");
     for (auto& param : params->params) {
-        dbgln_if(LANGUAGE_SERVER_DEBUG, "{}", param);
+        dbgln_if<LANGUAGE_SERVER_DEBUG>("{}", param);
     }
-    dbgln_if(LANGUAGE_SERVER_DEBUG, "Parameter index: {}", params->current_index);
+    dbgln_if<LANGUAGE_SERVER_DEBUG>("Parameter index: {}", params->current_index);
 
     async_parameters_hint_result(params->params, params->current_index);
 }

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -65,7 +65,7 @@ Vector<GUI::AutocompleteProvider::Entry> CppComprehensionEngine::get_suggestions
 {
     Cpp::Position position { autocomplete_position.line(), autocomplete_position.column() > 0 ? autocomplete_position.column() - 1 : 0 };
 
-    dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "CppComprehensionEngine position {}:{}", position.line, position.column);
+    dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("CppComprehensionEngine position {}:{}", position.line, position.column);
 
     const auto* document_ptr = get_or_create_document_data(file);
     if (!document_ptr)
@@ -82,12 +82,12 @@ Vector<GUI::AutocompleteProvider::Entry> CppComprehensionEngine::get_suggestions
 
     auto node = document.parser().node_at(position);
     if (!node) {
-        dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "no node at position {}:{}", position.line, position.column);
+        dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("no node at position {}:{}", position.line, position.column);
         return {};
     }
 
     if (node->parent() && node->parent()->parent())
-        dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "node: {}, parent: {}, grandparent: {}", node->class_name(), node->parent()->class_name(), node->parent()->parent()->class_name());
+        dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("node: {}, parent: {}, grandparent: {}", node->class_name(), node->parent()->class_name(), node->parent()->parent()->class_name());
 
     if (!node->parent())
         return {};
@@ -208,7 +208,7 @@ Vector<GUI::AutocompleteProvider::Entry> CppComprehensionEngine::autocomplete_pr
     VERIFY(parent.object());
     auto type = type_of(document, *parent.object());
     if (type.is_null()) {
-        dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "Could not infer type of object");
+        dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("Could not infer type of object");
         return {};
     }
 
@@ -403,7 +403,7 @@ Optional<GUI::AutocompleteProvider::ProjectLocation> CppComprehensionEngine::fin
     const auto& document = *document_ptr;
     auto node = document.parser().node_at(Cpp::Position { identifier_position.line(), identifier_position.column() });
     if (!node) {
-        dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "no node at position {}:{}", identifier_position.line(), identifier_position.column());
+        dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("no node at position {}:{}", identifier_position.line(), identifier_position.column());
         return {};
     }
     auto decl = find_declaration_of(document, *node);
@@ -442,7 +442,7 @@ struct TargetDeclaration {
 static Optional<TargetDeclaration> get_target_declaration(const ASTNode& node)
 {
     if (!node.is_identifier()) {
-        dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "node is not an identifier");
+        dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("node is not an identifier");
         return {};
     }
 
@@ -463,7 +463,7 @@ static Optional<TargetDeclaration> get_target_declaration(const ASTNode& node)
 
 RefPtr<Declaration> CppComprehensionEngine::find_declaration_of(const DocumentData& document_data, const ASTNode& node) const
 {
-    dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "find_declaration_of: {} ({})", document_data.parser().text_of_node(node), node.class_name());
+    dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("find_declaration_of: {} ({})", document_data.parser().text_of_node(node), node.class_name());
     if (!node.is_identifier()) {
         dbgln("node is not an identifier, can't find declaration");
         return {};
@@ -678,7 +678,7 @@ Optional<Vector<GUI::AutocompleteProvider::Entry>> CppComprehensionEngine::try_a
     }
 
     auto full_dir = LexicalPath::join(include_root, include_dir).string();
-    dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "searching path: {}, partial_basename: {}", full_dir, partial_basename);
+    dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("searching path: {}, partial_basename: {}", full_dir, partial_basename);
 
     Core::DirIterator it(full_dir, Core::DirIterator::Flags::SkipDots);
     Vector<GUI::AutocompleteProvider::Entry> options;
@@ -780,11 +780,11 @@ Optional<CodeComprehensionEngine::FunctionParamsHint> CppComprehensionEngine::ge
     Cpp::Position cpp_position { identifier_position.line(), identifier_position.column() };
     auto node = document.parser().node_at(cpp_position);
     if (!node) {
-        dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "no node at position {}:{}", identifier_position.line(), identifier_position.column());
+        dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("no node at position {}:{}", identifier_position.line(), identifier_position.column());
         return {};
     }
 
-    dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "node type: {}", node->class_name());
+    dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("node type: {}", node->class_name());
 
     FunctionCall* call_node { nullptr };
 
@@ -822,11 +822,11 @@ Optional<CodeComprehensionEngine::FunctionParamsHint> CppComprehensionEngine::ge
         }
     }
     if (!invoked_arg_index.has_value()) {
-        dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "could not find argument index, defaulting to the last argument");
+        dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("could not find argument index, defaulting to the last argument");
         invoked_arg_index = call_node->arguments().is_empty() ? 0 : call_node->arguments().size() - 1;
     }
 
-    dbgln_if(CPP_LANGUAGE_SERVER_DEBUG, "arg index: {}", invoked_arg_index.value());
+    dbgln_if<CPP_LANGUAGE_SERVER_DEBUG>("arg index: {}", invoked_arg_index.value());
     return get_function_params_hint(document, *call_node, invoked_arg_index.value());
 }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/FileDB.cpp
@@ -128,7 +128,7 @@ void FileDB::on_file_edit_insert_text(const String& filename, const String& inse
     GUI::TextPosition start_position { start_line, start_column };
     document->insert_at(start_position, inserted_text, &s_default_document_client);
 
-    dbgln_if(FILE_CONTENT_DEBUG, "{}", document->text());
+    dbgln_if<FILE_CONTENT_DEBUG>("{}", document->text());
 }
 
 void FileDB::on_file_edit_remove_text(const String& filename, size_t start_line, size_t start_column, size_t end_line, size_t end_column)
@@ -145,7 +145,7 @@ void FileDB::on_file_edit_remove_text(const String& filename, size_t start_line,
     };
 
     document->remove(range);
-    dbgln_if(FILE_CONTENT_DEBUG, "{}", document->text());
+    dbgln_if<FILE_CONTENT_DEBUG>("{}", document->text());
 }
 
 RefPtr<GUI::TextDocument> FileDB::create_with_content(const String& content)

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/ShellComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/ShellComprehensionEngine.cpp
@@ -135,14 +135,14 @@ size_t ShellComprehensionEngine::resolve(const ShellComprehensionEngine::Documen
 
 Vector<GUI::AutocompleteProvider::Entry> ShellComprehensionEngine::get_suggestions(const String& file, const GUI::TextPosition& position)
 {
-    dbgln_if(SH_LANGUAGE_SERVER_DEBUG, "ShellComprehensionEngine position {}:{}", position.line(), position.column());
+    dbgln_if<SH_LANGUAGE_SERVER_DEBUG>("ShellComprehensionEngine position {}:{}", position.line(), position.column());
 
     const auto& document = get_or_create_document_data(file);
     size_t offset_in_file = resolve(document, position);
 
     ::Shell::AST::HitTestResult hit_test = document.node->hit_test_position(offset_in_file);
     if (!hit_test.matching_node) {
-        dbgln_if(SH_LANGUAGE_SERVER_DEBUG, "no node at position {}:{}", position.line(), position.column());
+        dbgln_if<SH_LANGUAGE_SERVER_DEBUG>("no node at position {}:{}", position.line(), position.column());
         return {};
     }
 
@@ -166,17 +166,17 @@ void ShellComprehensionEngine::file_opened([[maybe_unused]] const String& file)
 
 Optional<GUI::AutocompleteProvider::ProjectLocation> ShellComprehensionEngine::find_declaration_of(const String& filename, const GUI::TextPosition& identifier_position)
 {
-    dbgln_if(SH_LANGUAGE_SERVER_DEBUG, "find_declaration_of({}, {}:{})", filename, identifier_position.line(), identifier_position.column());
+    dbgln_if<SH_LANGUAGE_SERVER_DEBUG>("find_declaration_of({}, {}:{})", filename, identifier_position.line(), identifier_position.column());
     const auto& document = get_or_create_document_data(filename);
     auto position = resolve(document, identifier_position);
     auto result = document.node->hit_test_position(position);
     if (!result.matching_node) {
-        dbgln_if(SH_LANGUAGE_SERVER_DEBUG, "no node at position {}:{}", identifier_position.line(), identifier_position.column());
+        dbgln_if<SH_LANGUAGE_SERVER_DEBUG>("no node at position {}:{}", identifier_position.line(), identifier_position.column());
         return {};
     }
 
     if (!result.matching_node->is_bareword()) {
-        dbgln_if(SH_LANGUAGE_SERVER_DEBUG, "no bareword at position {}:{}", identifier_position.line(), identifier_position.column());
+        dbgln_if<SH_LANGUAGE_SERVER_DEBUG>("no bareword at position {}:{}", identifier_position.line(), identifier_position.column());
         return {};
     }
 

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -112,7 +112,7 @@ ValueWithShadow<u8> SoftCPU::read_memory8(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read8(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory8: @{:#04x}:{:p} -> {:#02x} ({:#02x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mread_memory8: @{:#04x}:{:p} -> {:#02x} ({:#02x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
@@ -120,7 +120,7 @@ ValueWithShadow<u16> SoftCPU::read_memory16(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read16(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory16: @{:#04x}:{:p} -> {:#04x} ({:#04x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mread_memory16: @{:#04x}:{:p} -> {:#04x} ({:#04x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
@@ -128,7 +128,7 @@ ValueWithShadow<u32> SoftCPU::read_memory32(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read32(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory32: @{:#04x}:{:p} -> {:#08x} ({:#08x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mread_memory32: @{:#04x}:{:p} -> {:#08x} ({:#08x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
@@ -136,7 +136,7 @@ ValueWithShadow<u64> SoftCPU::read_memory64(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read64(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory64: @{:#04x}:{:p} -> {:#016x} ({:#016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mread_memory64: @{:#04x}:{:p} -> {:#016x} ({:#016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
@@ -144,56 +144,56 @@ ValueWithShadow<u128> SoftCPU::read_memory128(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read128(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory128: @{:#04x}:{:p} -> {:#032x} ({:#032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mread_memory128: @{:#04x}:{:p} -> {:#032x} ({:#032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 ValueWithShadow<u256> SoftCPU::read_memory256(X86::LogicalAddress address)
 {
     VERIFY(address.selector() == 0x1b || address.selector() == 0x23 || address.selector() == 0x2b);
     auto value = m_emulator.mmu().read256(address);
-    outln_if(MEMORY_DEBUG, "\033[36;1mread_memory256: @{:#04x}:{:p} -> {:#064x} ({:#064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mread_memory256: @{:#04x}:{:p} -> {:#064x} ({:#064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     return value;
 }
 
 void SoftCPU::write_memory8(X86::LogicalAddress address, ValueWithShadow<u8> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory8: @{:#04x}:{:p} <- {:#02x} ({:#02x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mwrite_memory8: @{:#04x}:{:p} <- {:#02x} ({:#02x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write8(address, value);
 }
 
 void SoftCPU::write_memory16(X86::LogicalAddress address, ValueWithShadow<u16> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory16: @{:#04x}:{:p} <- {:#04x} ({:#04x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mwrite_memory16: @{:#04x}:{:p} <- {:#04x} ({:#04x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write16(address, value);
 }
 
 void SoftCPU::write_memory32(X86::LogicalAddress address, ValueWithShadow<u32> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory32: @{:#04x}:{:p} <- {:#08x} ({:#08x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mwrite_memory32: @{:#04x}:{:p} <- {:#08x} ({:#08x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write32(address, value);
 }
 
 void SoftCPU::write_memory64(X86::LogicalAddress address, ValueWithShadow<u64> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory64: @{:#04x}:{:p} <- {:#016x} ({:#016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mwrite_memory64: @{:#04x}:{:p} <- {:#016x} ({:#016x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write64(address, value);
 }
 
 void SoftCPU::write_memory128(X86::LogicalAddress address, ValueWithShadow<u128> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory128: @{:#04x}:{:p} <- {:#032x} ({:#032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mwrite_memory128: @{:#04x}:{:p} <- {:#032x} ({:#032x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write128(address, value);
 }
 
 void SoftCPU::write_memory256(X86::LogicalAddress address, ValueWithShadow<u256> value)
 {
     VERIFY(address.selector() == 0x23 || address.selector() == 0x2b);
-    outln_if(MEMORY_DEBUG, "\033[36;1mwrite_memory256: @{:#04x}:{:p} <- {:#064x} ({:#064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
+    outln_if<MEMORY_DEBUG>("\033[36;1mwrite_memory256: @{:#04x}:{:p} <- {:#064x} ({:#064x})\033[0m", address.selector(), address.offset(), value, value.shadow());
     m_emulator.mmu().write256(address, value);
 }
 

--- a/Userland/Games/Hearts/Game.cpp
+++ b/Userland/Games/Hearts/Game.cpp
@@ -25,7 +25,7 @@ namespace Hearts {
 Game::Game()
 {
     m_delay_timer = Core::Timer::create_single_shot(0, [this] {
-        dbgln_if(HEARTS_DEBUG, "Continuing game after delay...");
+        dbgln_if<HEARTS_DEBUG>("Continuing game after delay...");
         advance_game();
     });
 
@@ -98,8 +98,8 @@ Game::~Game()
 
 void Game::reset()
 {
-    dbgln_if(HEARTS_DEBUG, "=====");
-    dbgln_if(HEARTS_DEBUG, "Resetting game");
+    dbgln_if<HEARTS_DEBUG>("=====");
+    dbgln_if<HEARTS_DEBUG>("Resetting game");
 
     stop_animation();
 
@@ -446,7 +446,7 @@ Player& Game::current_player()
     VERIFY(m_trick.size() < 4);
     auto player_index = m_leading_player - m_players;
     auto current_player_index = (player_index + m_trick.size()) % 4;
-    dbgln_if(HEARTS_DEBUG, "Leading player: {}, current player: {}", *m_leading_player, m_players[current_player_index]);
+    dbgln_if<HEARTS_DEBUG>("Leading player: {}, current player: {}", *m_leading_player, m_players[current_player_index]);
     return m_players[current_player_index];
 }
 
@@ -550,11 +550,11 @@ void Game::advance_game()
     auto leading_player_index = player_index(*m_leading_player);
     auto taking_player_index = (leading_player_index + taker_index) % 4;
     auto& taking_player = m_players[taking_player_index];
-    dbgln_if(HEARTS_DEBUG, "{} takes the trick", taking_player);
+    dbgln_if<HEARTS_DEBUG>("{} takes the trick", taking_player);
     for (auto& card : m_trick) {
         if (hearts_card_points(card) == 0)
             continue;
-        dbgln_if(HEARTS_DEBUG, "{} takes card {}", taking_player, card);
+        dbgln_if<HEARTS_DEBUG>("{} takes card {}", taking_player, card);
         taking_player.cards_taken.append(card);
     }
 
@@ -570,7 +570,7 @@ void Game::advance_game()
 
             m_trick.clear_with_capacity();
             m_leading_player = &taking_player;
-            dbgln_if(HEARTS_DEBUG, "-----");
+            dbgln_if<HEARTS_DEBUG>("-----");
             advance_game();
         },
         750);
@@ -603,7 +603,7 @@ void Game::play_card(Player& player, size_t card_index)
     VERIFY(m_trick.size() < 4);
     RefPtr<Card> card;
     swap(player.hand[card_index], card);
-    dbgln_if(HEARTS_DEBUG, "{} plays {}", player, *card);
+    dbgln_if<HEARTS_DEBUG>("{} plays {}", player, *card);
     VERIFY(is_valid_play(player, *card));
     card->set_upside_down(false);
     m_trick.append(*card);

--- a/Userland/Games/Hearts/Player.cpp
+++ b/Userland/Games/Hearts/Player.cpp
@@ -63,7 +63,7 @@ size_t Player::pick_lead_card(Function<bool(Card&)> valid_play, Function<bool(Ca
         if (!valid_play(*cwi.card))
             continue;
         if (prefer_card(*cwi.card)) {
-            dbgln_if(HEARTS_DEBUG, "Preferring card {}", *cwi.card);
+            dbgln_if<HEARTS_DEBUG>("Preferring card {}", *cwi.card);
             return cwi.index;
         }
         last_index = cwi.index;

--- a/Userland/Libraries/LibAudio/WavLoader.cpp
+++ b/Userland/Libraries/LibAudio/WavLoader.cpp
@@ -65,7 +65,7 @@ LoaderSamples WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_in
     int samples_to_read = min(max_samples_to_read, remaining_samples);
     size_t bytes_to_read = samples_to_read * bytes_per_sample;
 
-    dbgln_if(AWAVLOADER_DEBUG, "Read {} bytes WAV with num_channels {} sample rate {}, "
+    dbgln_if<AWAVLOADER_DEBUG>("Read {} bytes WAV with num_channels {} sample rate {}, "
                                "bits per sample {}, sample format {}",
         bytes_to_read, m_num_channels, m_sample_rate,
         pcm_bits_per_sample(m_sample_format), sample_format_name(m_sample_format));
@@ -93,7 +93,7 @@ LoaderSamples WavLoaderPlugin::get_more_samples(size_t max_bytes_to_read_from_in
 
 MaybeLoaderError WavLoaderPlugin::seek(const int sample_index)
 {
-    dbgln_if(AWAVLOADER_DEBUG, "seek sample_index {}", sample_index);
+    dbgln_if<AWAVLOADER_DEBUG>("seek sample_index {}", sample_index);
     if (sample_index < 0 || sample_index >= m_total_samples)
         return LoaderError { LoaderError::Category::Internal, static_cast<size_t>(m_loaded_samples), "Seek outside the sample range" };
 
@@ -238,7 +238,7 @@ MaybeLoaderError WavLoaderPlugin::parse_header()
     ok = ok && (block_size_bytes == (m_num_channels * (bits_per_sample / 8)));
     CHECK_OK(LoaderError::Category::Format, "Block size sanity check");
 
-    dbgln_if(AWAVLOADER_DEBUG, "WAV format {} at {} bit, {} channels, rate {}Hz ",
+    dbgln_if<AWAVLOADER_DEBUG>("WAV format {} at {} bit, {} channels, rate {}Hz ",
         sample_format_name(m_sample_format), pcm_bits_per_sample(m_sample_format), m_num_channels, m_sample_rate);
 
     // Read chunks until we find DATA
@@ -274,7 +274,7 @@ MaybeLoaderError WavLoaderPlugin::parse_header()
 
     m_total_samples = data_sz / block_size_bytes;
 
-    dbgln_if(AWAVLOADER_DEBUG, "WAV data size {}, bytes per sample {}, total samples {}",
+    dbgln_if<AWAVLOADER_DEBUG>("WAV data size {}, bytes per sample {}, total samples {}",
         data_sz,
         block_size_bytes,
         m_total_samples);

--- a/Userland/Libraries/LibC/cxxabi.cpp
+++ b/Userland/Libraries/LibC/cxxabi.cpp
@@ -96,7 +96,7 @@ int __cxa_atexit(AtExitFunction exit_function, void* parameter, void* dso_handle
     if (atexit_entry_count >= atexit_entry_region_capacity) {
         size_t new_capacity = atexit_next_capacity();
         size_t new_atexit_region_size = atexit_region_bytes(new_capacity);
-        dbgln_if(GLOBAL_DTORS_DEBUG, "__cxa_atexit: Growing exit handler region from {} entries to {} entries", atexit_entry_region_capacity, new_capacity);
+        dbgln_if<GLOBAL_DTORS_DEBUG>("__cxa_atexit: Growing exit handler region from {} entries to {} entries", atexit_entry_region_capacity, new_capacity);
 
         auto* new_atexit_entries = (AtExitEntry*)mmap(nullptr, new_atexit_region_size, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, 0, 0);
         if (new_atexit_entries == MAP_FAILED) {
@@ -139,13 +139,13 @@ void __cxa_finalize(void* dso_handle)
 
     ssize_t entry_index = atexit_entry_count;
 
-    dbgln_if(GLOBAL_DTORS_DEBUG, "__cxa_finalize: {} entries in the finalizer list", entry_index);
+    dbgln_if<GLOBAL_DTORS_DEBUG>("__cxa_finalize: {} entries in the finalizer list", entry_index);
 
     while (--entry_index >= 0) {
         auto& exit_entry = atexit_entries[entry_index];
         bool needs_calling = !atexit_called_entries->get(entry_index) && (!dso_handle || dso_handle == exit_entry.dso_handle);
         if (needs_calling) {
-            dbgln_if(GLOBAL_DTORS_DEBUG, "__cxa_finalize: calling entry[{}] {:p}({:p}) dso: {:p}", entry_index, exit_entry.method, exit_entry.parameter, exit_entry.dso_handle);
+            dbgln_if<GLOBAL_DTORS_DEBUG>("__cxa_finalize: calling entry[{}] {:p}({:p}) dso: {:p}", entry_index, exit_entry.method, exit_entry.parameter, exit_entry.dso_handle);
             atexit_called_entries->set(entry_index, true);
             __pthread_mutex_unlock(&atexit_mutex);
             exit_entry.method(exit_entry.parameter);

--- a/Userland/Libraries/LibC/termcap.cpp
+++ b/Userland/Libraries/LibC/termcap.cpp
@@ -20,7 +20,7 @@ char* BC;
 
 int __attribute__((weak)) tgetent([[maybe_unused]] char* bp, [[maybe_unused]] const char* name)
 {
-    warnln_if(TERMCAP_DEBUG, "tgetent: bp={:p}, name='{}'", bp, name);
+    warnln_if<TERMCAP_DEBUG>("tgetent: bp={:p}, name='{}'", bp, name);
     PC = '\0';
     BC = const_cast<char*>("\033[D");
     UP = const_cast<char*>("\033[A");
@@ -78,7 +78,7 @@ static void ensure_caps()
 char* __attribute__((weak)) tgetstr(const char* id, char** area)
 {
     ensure_caps();
-    warnln_if(TERMCAP_DEBUG, "tgetstr: id='{}'", id);
+    warnln_if<TERMCAP_DEBUG>("tgetstr: id='{}'", id);
     auto it = caps->find(id);
     if (it != caps->end()) {
         char* ret = *area;
@@ -87,7 +87,7 @@ char* __attribute__((weak)) tgetstr(const char* id, char** area)
         *area += strlen(val) + 1;
         return ret;
     }
-    warnln_if(TERMCAP_DEBUG, "tgetstr: missing cap id='{}'", id);
+    warnln_if<TERMCAP_DEBUG>("tgetstr: missing cap id='{}'", id);
     return nullptr;
 }
 
@@ -95,7 +95,7 @@ char* __attribute__((weak)) tgetstr(const char* id, char** area)
 
 int __attribute__((weak)) tgetflag([[maybe_unused]] const char* id)
 {
-    warnln_if(TERMCAP_DEBUG, "tgetflag: '{}'", id);
+    warnln_if<TERMCAP_DEBUG>("tgetflag: '{}'", id);
     auto it = caps->find(id);
     if (it != caps->end())
         return 1;
@@ -104,7 +104,7 @@ int __attribute__((weak)) tgetflag([[maybe_unused]] const char* id)
 
 int __attribute__((weak)) tgetnum(const char* id)
 {
-    warnln_if(TERMCAP_DEBUG, "tgetnum: '{}'", id);
+    warnln_if<TERMCAP_DEBUG>("tgetnum: '{}'", id);
     auto it = caps->find(id);
     if (it != caps->end())
         return atoi((*it).value);

--- a/Userland/Libraries/LibChess/UCIEndpoint.cpp
+++ b/Userland/Libraries/LibChess/UCIEndpoint.cpp
@@ -23,7 +23,7 @@ Endpoint::Endpoint(NonnullRefPtr<Core::IODevice> in, NonnullRefPtr<Core::IODevic
 
 void Endpoint::send_command(const Command& command)
 {
-    dbgln_if(UCI_DEBUG, "{} Sent UCI Command: {}", class_name(), String(command.to_string().characters(), Chomp));
+    dbgln_if<UCI_DEBUG>("{} Sent UCI Command: {}", class_name(), String(command.to_string().characters(), Chomp));
     m_out->write(command.to_string());
 }
 
@@ -72,7 +72,7 @@ NonnullOwnPtr<Command> Endpoint::read_command()
 {
     String line(ReadonlyBytes(m_in->read_line(4096).bytes()), Chomp);
 
-    dbgln_if(UCI_DEBUG, "{} Received UCI Command: {}", class_name(), line);
+    dbgln_if<UCI_DEBUG>("{} Received UCI Command: {}", class_name(), line);
 
     if (line == "uci") {
         return make<UCICommand>(UCICommand::from_string(line));

--- a/Userland/Libraries/LibCore/NetworkJob.cpp
+++ b/Userland/Libraries/LibCore/NetworkJob.cpp
@@ -37,7 +37,7 @@ void NetworkJob::did_finish(NonnullRefPtr<NetworkResponse>&& response)
     NonnullRefPtr<NetworkJob> protector(*this);
 
     m_response = move(response);
-    dbgln_if(NETWORKJOB_DEBUG, "{} job did_finish", *this);
+    dbgln_if<NETWORKJOB_DEBUG>("{} job did_finish", *this);
     VERIFY(on_finish);
     on_finish(true);
     shutdown(ShutdownMode::DetachFromSocket);
@@ -53,7 +53,7 @@ void NetworkJob::did_fail(Error error)
     NonnullRefPtr<NetworkJob> protector(*this);
 
     m_error = error;
-    dbgln_if(NETWORKJOB_DEBUG, "{}{{{:p}}} job did_fail! error: {} ({})", class_name(), this, (unsigned)error, to_string(error));
+    dbgln_if<NETWORKJOB_DEBUG>("{}{{{:p}}} job did_fail! error: {} ({})", class_name(), this, (unsigned)error, to_string(error));
     VERIFY(on_finish);
     on_finish(false);
     shutdown(ShutdownMode::DetachFromSocket);

--- a/Userland/Libraries/LibCore/Socket.cpp
+++ b/Userland/Libraries/LibCore/Socket.cpp
@@ -59,7 +59,7 @@ bool Socket::connect(const String& hostname, int port)
     // On macOS, the pointer in the hostent structure is misaligned. Load it using ByteReader to avoid UB
     auto* host_addr = AK::ByteReader::load_pointer<u8 const>(reinterpret_cast<u8 const*>(&hostent->h_addr_list[0]));
     IPv4Address host_address(host_addr);
-    dbgln_if(CSOCKET_DEBUG, "Socket::connect: Resolved '{}' to {}", hostname, host_address);
+    dbgln_if<CSOCKET_DEBUG>("Socket::connect: Resolved '{}' to {}", hostname, host_address);
     return connect(host_address, port);
 }
 
@@ -78,7 +78,7 @@ bool Socket::connect(const SocketAddress& address, int port)
 {
     VERIFY(!is_connected());
     VERIFY(address.type() == SocketAddress::Type::IPv4);
-    dbgln_if(CSOCKET_DEBUG, "{} connecting to {}...", *this, address);
+    dbgln_if<CSOCKET_DEBUG>("{} connecting to {}...", *this, address);
 
     VERIFY(port > 0 && port <= 65535);
 
@@ -99,7 +99,7 @@ bool Socket::connect(const SocketAddress& address)
 {
     VERIFY(!is_connected());
     VERIFY(address.type() == SocketAddress::Type::Local);
-    dbgln_if(CSOCKET_DEBUG, "{} connecting to {}...", *this, address);
+    dbgln_if<CSOCKET_DEBUG>("{} connecting to {}...", *this, address);
 
     sockaddr_un saddr;
     saddr.sun_family = AF_LOCAL;
@@ -123,20 +123,20 @@ bool Socket::common_connect(const struct sockaddr* addr, socklen_t addrlen)
 
         int rc = getsockopt(fd(), SOL_SOCKET, SO_ERROR, &so_error, &so_error_len);
         if (rc < 0) {
-            dbgln_if(CSOCKET_DEBUG, "Failed to check the status of SO_ERROR");
+            dbgln_if<CSOCKET_DEBUG>("Failed to check the status of SO_ERROR");
             m_connected = false;
             if (on_error)
                 on_error();
         }
 
         if (so_error == 0) {
-            dbgln_if(CSOCKET_DEBUG, "{} connected!", *this);
+            dbgln_if<CSOCKET_DEBUG>("{} connected!", *this);
             m_connected = true;
             ensure_read_notifier();
             if (on_connected)
                 on_connected();
         } else {
-            dbgln_if(CSOCKET_DEBUG, "Failed to connect to {}", *this);
+            dbgln_if<CSOCKET_DEBUG>("Failed to connect to {}", *this);
             m_connected = false;
             if (on_error)
                 on_error();
@@ -150,7 +150,7 @@ bool Socket::common_connect(const struct sockaddr* addr, socklen_t addrlen)
     int rc = ::connect(fd(), addr, addrlen);
     if (rc < 0) {
         if (errno == EINPROGRESS) {
-            dbgln_if(CSOCKET_DEBUG, "{} connection in progress (EINPROGRESS)", *this);
+            dbgln_if<CSOCKET_DEBUG>("{} connection in progress (EINPROGRESS)", *this);
             m_notifier = Notifier::construct(fd(), Notifier::Event::Write, this);
             m_notifier->on_ready_to_write = move(connected);
             return true;
@@ -160,7 +160,7 @@ bool Socket::common_connect(const struct sockaddr* addr, socklen_t addrlen)
         errno = saved_errno;
         return false;
     }
-    dbgln_if(CSOCKET_DEBUG, "{} connected ok!", *this);
+    dbgln_if<CSOCKET_DEBUG>("{} connected ok!", *this);
     connected();
     return true;
 }

--- a/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibCpp/SyntaxHighlighter.cpp
@@ -63,7 +63,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
     Vector<GUI::TextDocumentSpan> spans;
     lexer.lex_iterable([&](auto token) {
         // FIXME: The +1 for the token end column is a quick hack due to not wanting to modify the lexer (which is also used by the parser). Maybe there's a better way to do this.
-        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{} @ {}:{} - {}:{}", token.type_as_string(), token.start().line, token.start().column, token.end().line, token.end().column + 1);
+        dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("{} @ {}:{} - {}:{}", token.type_as_string(), token.start().line, token.start().column, token.end().line, token.end().column + 1);
         GUI::TextDocumentSpan span;
         span.range.set_start({ token.start().line, token.start().column });
         span.range.set_end({ token.end().line, token.end().column + 1 });

--- a/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
+++ b/Userland/Libraries/LibCrypto/Authentication/GHash.cpp
@@ -79,7 +79,7 @@ GHash::TagType GHash::process(ReadonlyBytes aad, ReadonlyBytes cipher)
     tag[2] ^= high(cipher_bits);
     tag[3] ^= low(cipher_bits);
 
-    dbgln_if(GHASH_PROCESS_DEBUG, "Tag bits: {} : {} : {} : {}", tag[0], tag[1], tag[2], tag[3]);
+    dbgln_if<GHASH_PROCESS_DEBUG>("Tag bits: {} : {} : {} : {}", tag[0], tag[1], tag[2], tag[3]);
 
     galois_multiply(tag, m_key, tag);
 

--- a/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
+++ b/Userland/Libraries/LibCrypto/NumberTheory/ModularFunctions.cpp
@@ -100,7 +100,7 @@ UnsignedBigInteger LCM(const UnsignedBigInteger& a, const UnsignedBigInteger& b)
 
     UnsignedBigIntegerAlgorithms::destructive_GCD_without_allocation(temp_a, temp_b, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder, gcd_output);
     if (gcd_output == 0) {
-        dbgln_if(NT_DEBUG, "GCD is zero");
+        dbgln_if<NT_DEBUG>("GCD is zero");
         return output;
     }
 
@@ -108,7 +108,7 @@ UnsignedBigInteger LCM(const UnsignedBigInteger& a, const UnsignedBigInteger& b)
     UnsignedBigIntegerAlgorithms::divide_without_allocation(a, gcd_output, temp_1, temp_2, temp_3, temp_4, temp_quotient, temp_remainder);
     UnsignedBigIntegerAlgorithms::multiply_without_allocation(temp_quotient, b, temp_1, temp_2, temp_3, output);
 
-    dbgln_if(NT_DEBUG, "quot: {} rem: {} out: {}", temp_quotient, temp_remainder, output);
+    dbgln_if<NT_DEBUG>("quot: {} rem: {} out: {}", temp_quotient, temp_remainder, output);
 
     return output;
 }

--- a/Userland/Libraries/LibCrypto/PK/RSA.cpp
+++ b/Userland/Libraries/LibCrypto/PK/RSA.cpp
@@ -34,12 +34,12 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         auto result = decoder.peek();
         if (result.is_error()) {
             // Bad data.
-            dbgln_if(RSA_PARSE_DEBUG, "RSA key parse failed: {}", result.error());
+            dbgln_if<RSA_PARSE_DEBUG>("RSA key parse failed: {}", result.error());
             return keypair;
         }
         auto tag = result.value();
         if (tag.kind != ASN1::Kind::Sequence) {
-            dbgln_if(RSA_PARSE_DEBUG, "RSA key parse failed: Expected a Sequence but got {}", ASN1::kind_name(tag.kind));
+            dbgln_if<RSA_PARSE_DEBUG>("RSA key parse failed: Expected a Sequence but got {}", ASN1::kind_name(tag.kind));
             return keypair;
         }
     }
@@ -49,7 +49,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         auto error = decoder.enter();
         if (error.has_value()) {
             // Something was weird with the input.
-            dbgln_if(RSA_PARSE_DEBUG, "RSA key parse failed: {}", error.value());
+            dbgln_if<RSA_PARSE_DEBUG>("RSA key parse failed: {}", error.value());
             return keypair;
         }
     }
@@ -61,14 +61,14 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         auto tag_result = decoder.peek();
         if (tag_result.is_error()) {
             // Decode error :shrug:
-            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#8 public key parse failed: {}", tag_result.error());
+            dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#8 public key parse failed: {}", tag_result.error());
             return false;
         }
 
         auto tag = tag_result.value();
         if (tag.kind != ASN1::Kind::Sequence) {
             // We don't know what this is, but it sure isn't a PKCS#8 key.
-            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#8 public key parse failed: Expected a Sequence but got {}", ASN1::kind_name(tag.kind));
+            dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#8 public key parse failed: Expected a Sequence but got {}", ASN1::kind_name(tag.kind));
             return false;
         }
 
@@ -76,14 +76,14 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         auto error = decoder.enter();
         if (error.has_value()) {
             // Shenanigans!
-            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#8 public key parse failed: {}", error.value());
+            dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#8 public key parse failed: {}", error.value());
             return false;
         }
 
         ScopeGuard leave { [&] {
             auto error = decoder.leave();
             if (error.has_value()) {
-                dbgln_if(RSA_PARSE_DEBUG, "RSA key parse failed: {}", error.value());
+                dbgln_if<RSA_PARSE_DEBUG>("RSA key parse failed: {}", error.value());
                 has_read_error = true;
             }
         } };
@@ -91,7 +91,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         // Now let's read the OID.
         auto oid_result = decoder.read<Vector<int>>();
         if (oid_result.is_error()) {
-            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#8 public key parse failed: {}", oid_result.error());
+            dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#8 public key parse failed: {}", oid_result.error());
             return false;
         }
 
@@ -99,7 +99,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         // Now let's check that the OID matches "RSA key"
         if (oid != pkcs8_rsa_key_oid) {
             // Oh well. not an RSA key at all.
-            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#8 public key parse failed: Not an RSA key");
+            dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#8 public key parse failed: Not an RSA key");
             return false;
         }
 
@@ -119,7 +119,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
             // Now read the private key, which is actually an octet string containing the PKCS#1 encoded private key.
             auto data_result = decoder.read<StringView>();
             if (data_result.is_error()) {
-                dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#8 private key parse failed: {}", data_result.error());
+                dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#8 private key parse failed: {}", data_result.error());
                 return keypair;
             }
             return parse_rsa_key(data_result.value().bytes());
@@ -134,21 +134,21 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
             // This is a private key, parse the rest.
             auto modulus_result = decoder.read<UnsignedBigInteger>();
             if (modulus_result.is_error()) {
-                dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#1 private key parse failed: {}", modulus_result.error());
+                dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#1 private key parse failed: {}", modulus_result.error());
                 return keypair;
             }
             auto modulus = modulus_result.release_value();
 
             auto public_exponent_result = decoder.read<UnsignedBigInteger>();
             if (public_exponent_result.is_error()) {
-                dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#1 private key parse failed: {}", public_exponent_result.error());
+                dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#1 private key parse failed: {}", public_exponent_result.error());
                 return keypair;
             }
             auto public_exponent = public_exponent_result.release_value();
 
             auto private_exponent_result = decoder.read<UnsignedBigInteger>();
             if (private_exponent_result.is_error()) {
-                dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#1 private key parse failed: {}", private_exponent_result.error());
+                dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#1 private key parse failed: {}", private_exponent_result.error());
                 return keypair;
             }
             auto private_exponent = private_exponent_result.release_value();
@@ -161,7 +161,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
             return keypair;
         } else if (first_integer == 1) {
             // This is a multi-prime key, we don't support that.
-            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#1 private key parse failed: Multi-prime key not supported");
+            dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#1 private key parse failed: Multi-prime key not supported");
             return keypair;
         } else {
             auto&& modulus = move(first_integer);
@@ -170,7 +170,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
             auto public_exponent_result = decoder.read<UnsignedBigInteger>();
             if (public_exponent_result.is_error()) {
                 // Bad public key.
-                dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#1 public key parse failed: {}", public_exponent_result.error());
+                dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#1 public key parse failed: {}", public_exponent_result.error());
                 return keypair;
             }
 
@@ -191,7 +191,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         // Now we have a bit string, which contains the PKCS#1 encoded public key.
         auto data_result = decoder.read<BitmapView>();
         if (data_result.is_error()) {
-            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#8 public key parse failed: {}", data_result.error());
+            dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#8 public key parse failed: {}", data_result.error());
             return keypair;
         }
 
@@ -200,7 +200,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
         // FIXME: This is pretty awkward, maybe just generate a zero'd out ByteBuffer from the parser instead?
         auto padded_data_result = ByteBuffer::create_zeroed(data.size_in_bytes());
         if (padded_data_result.is_error()) {
-            dbgln_if(RSA_PARSE_DEBUG, "RSA PKCS#1 key parse failed: Not enough memory");
+            dbgln_if<RSA_PARSE_DEBUG>("RSA PKCS#1 key parse failed: Not enough memory");
             return keypair;
         }
         auto padded_data = padded_data_result.release_value();
@@ -212,7 +212,7 @@ RSA::KeyPairType RSA::parse_rsa_key(ReadonlyBytes der)
 
 void RSA::encrypt(ReadonlyBytes in, Bytes& out)
 {
-    dbgln_if(CRYPTO_DEBUG, "in size: {}", in.size());
+    dbgln_if<CRYPTO_DEBUG>("in size: {}", in.size());
     auto in_integer = UnsignedBigInteger::import_data(in.data(), in.size());
     if (!(in_integer < m_public_key.modulus())) {
         dbgln("value too large for key");
@@ -328,7 +328,7 @@ VerificationConsistency RSA_EMSA_PSS<HashFunction>::verify(ReadonlyBytes in)
 void RSA_PKCS1_EME::encrypt(ReadonlyBytes in, Bytes& out)
 {
     auto mod_len = (m_public_key.modulus().trimmed_length() * sizeof(u32) * 8 + 7) / 8;
-    dbgln_if(CRYPTO_DEBUG, "key size: {}", mod_len);
+    dbgln_if<CRYPTO_DEBUG>("key size: {}", mod_len);
     if (in.size() > mod_len - 11) {
         dbgln("message too long :(");
         out = out.trim(0);
@@ -358,7 +358,7 @@ void RSA_PKCS1_EME::encrypt(ReadonlyBytes in, Bytes& out)
     out.overwrite(3 + ps_length, in.data(), in.size());
     out = out.trim(3 + ps_length + in.size()); // should be a single block
 
-    dbgln_if(CRYPTO_DEBUG, "padded output size: {} buffer size: {}", 3 + ps_length + in.size(), out.size());
+    dbgln_if<CRYPTO_DEBUG>("padded output size: {} buffer size: {}", 3 + ps_length + in.size(), out.size());
 
     RSA::encrypt(out, out);
 }

--- a/Userland/Libraries/LibDebug/DebugInfo.cpp
+++ b/Userland/Libraries/LibDebug/DebugInfo.cpp
@@ -42,11 +42,11 @@ void DebugInfo::parse_scopes_impl(Dwarf::DIE const& die)
             return;
 
         if (child.get_attribute(Dwarf::Attribute::Inline).has_value()) {
-            dbgln_if(SPAM_DEBUG, "DWARF inlined functions are not supported");
+            dbgln_if<SPAM_DEBUG>("DWARF inlined functions are not supported");
             return;
         }
         if (child.get_attribute(Dwarf::Attribute::Ranges).has_value()) {
-            dbgln_if(SPAM_DEBUG, "DWARF ranges are not supported");
+            dbgln_if<SPAM_DEBUG>("DWARF ranges are not supported");
             return;
         }
         auto name = child.get_attribute(Dwarf::Attribute::Name);
@@ -57,7 +57,7 @@ void DebugInfo::parse_scopes_impl(Dwarf::DIE const& die)
             scope.name = name.value().as_string();
 
         if (!child.get_attribute(Dwarf::Attribute::LowPc).has_value()) {
-            dbgln_if(SPAM_DEBUG, "DWARF: Couldn't find attribute LowPc for scope");
+            dbgln_if<SPAM_DEBUG>("DWARF: Couldn't find attribute LowPc for scope");
             return;
         }
         scope.address_low = child.get_attribute(Dwarf::Attribute::LowPc).value().as_addr();

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -150,10 +150,10 @@ static Vector<String> get_dependencies(const String& name)
 
 static Result<void, DlErrorMessage> map_dependencies(const String& name)
 {
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "mapping dependencies for: {}", name);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("mapping dependencies for: {}", name);
 
     for (const auto& needed_name : get_dependencies(name)) {
-        dbgln_if(DYNAMIC_LOAD_DEBUG, "needed library: {}", needed_name.characters());
+        dbgln_if<DYNAMIC_LOAD_DEBUG>("needed library: {}", needed_name.characters());
         String library_name = get_library_name(needed_name);
 
         if (!s_loaders.contains(library_name) && !s_global_objects.contains(library_name)) {
@@ -167,7 +167,7 @@ static Result<void, DlErrorMessage> map_dependencies(const String& name)
             }
         }
     }
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "mapped dependencies for {}", name);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("mapped dependencies for {}", name);
     return {};
 }
 
@@ -175,7 +175,7 @@ static void allocate_tls()
 {
     s_total_tls_size = 0;
     for (const auto& data : s_loaders) {
-        dbgln_if(DYNAMIC_LOAD_DEBUG, "{}: TLS Size: {}", data.key, data.value->tls_size_of_current_object());
+        dbgln_if<DYNAMIC_LOAD_DEBUG>("{}: TLS Size: {}", data.key, data.value->tls_size_of_current_object());
         s_total_tls_size += data.value->tls_size_of_current_object();
     }
 
@@ -198,7 +198,7 @@ static void allocate_tls()
 
     void* master_tls = ::allocate_tls((char*)initial_tls_data.data(), initial_tls_data.size());
     VERIFY(master_tls != (void*)-1);
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "from userspace, master_tls: {:p}", master_tls);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("from userspace, master_tls: {:p}", master_tls);
 
     s_allocated_tls_block_size = initial_tls_data.size();
 }
@@ -348,7 +348,7 @@ static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> load_main_library(co
 
 static Result<void, DlErrorMessage> __dlclose(void* handle)
 {
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "__dlclose: {}", handle);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("__dlclose: {}", handle);
 
     __pthread_mutex_lock(&s_loader_lock);
     ScopeGuard unlock_guard = [] { __pthread_mutex_unlock(&s_loader_lock); };
@@ -398,7 +398,7 @@ static Result<void*, DlErrorMessage> __dlopen(const char* filename, int flags)
     flags &= ~RTLD_LOCAL;
     flags |= RTLD_GLOBAL;
 
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "__dlopen invoked, filename={}, flags={}", filename, flags);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("__dlopen invoked, filename={}, flags={}", filename, flags);
 
     auto library_name = get_library_name(filename ? filename : s_main_program_name);
 
@@ -445,7 +445,7 @@ static Result<void*, DlErrorMessage> __dlopen(const char* filename, int flags)
 
 static Result<void*, DlErrorMessage> __dlsym(void* handle, const char* symbol_name)
 {
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "__dlsym: {}, {}", handle, symbol_name);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("__dlsym: {}, {}", handle, symbol_name);
 
     __pthread_mutex_lock(&s_loader_lock);
     ScopeGuard unlock_guard = [] { __pthread_mutex_unlock(&s_loader_lock); };
@@ -549,9 +549,9 @@ void ELF::DynamicLinker::linker_main(String&& main_program_name, int main_progra
         _exit(1);
     }
 
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "loaded all dependencies");
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("loaded all dependencies");
     for ([[maybe_unused]] auto& lib : s_loaders) {
-        dbgln_if(DYNAMIC_LOAD_DEBUG, "{} - tls size: {}, tls offset: {}", lib.key, lib.value->tls_size_of_current_object(), lib.value->tls_offset());
+        dbgln_if<DYNAMIC_LOAD_DEBUG>("{} - tls size: {}, tls offset: {}", lib.key, lib.value->tls_size_of_current_object(), lib.value->tls_offset());
     }
 
     allocate_tls();
@@ -577,7 +577,7 @@ void ELF::DynamicLinker::linker_main(String&& main_program_name, int main_progra
         VERIFY_NOT_REACHED();
     }
 
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "Jumping to entry point: {:p}", entry_point_function);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("Jumping to entry point: {:p}", entry_point_function);
     if (s_do_breakpoint_trap_before_entry) {
         asm("int3");
     }

--- a/Userland/Libraries/LibELF/DynamicObject.cpp
+++ b/Userland/Libraries/LibELF/DynamicObject.cpp
@@ -56,8 +56,8 @@ void DynamicObject::dump() const
     if (m_has_runpath)
         builder.appendff("DT_RUNPATH: {}\n", runpath());
 
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "Dynamic section at address {} contains {} entries:", m_dynamic_address.as_ptr(), num_dynamic_sections);
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "{}", builder.string_view());
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("Dynamic section at address {} contains {} entries:", m_dynamic_address.as_ptr(), num_dynamic_sections);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("{}", builder.string_view());
 }
 
 void DynamicObject::parse()
@@ -265,7 +265,7 @@ auto DynamicObject::HashSection::lookup_sysv_symbol(StringView name, u32 hash_va
     for (u32 i = buckets[hash_value % num_buckets]; i; i = chains[i]) {
         auto symbol = m_dynamic.symbol(i);
         if (name == symbol.raw_name()) {
-            dbgln_if(DYNAMIC_LOAD_DEBUG, "Returning SYSV dynamic symbol with index {} for {}: {}", i, symbol.name(), symbol.address().as_ptr());
+            dbgln_if<DYNAMIC_LOAD_DEBUG>("Returning SYSV dynamic symbol with index {} for {}: {}", i, symbol.name(), symbol.address().as_ptr());
             return symbol;
         }
     }
@@ -478,7 +478,7 @@ VirtualAddress DynamicObject::patch_plt_entry(u32 relocation_offset)
         VERIFY_NOT_REACHED();
     }
 
-    dbgln_if(DYNAMIC_LOAD_DEBUG, "DynamicLoader: Jump slot relocation: putting {} ({}) into PLT at {}", symbol.name(), symbol_location, (void*)relocation_address);
+    dbgln_if<DYNAMIC_LOAD_DEBUG>("DynamicLoader: Jump slot relocation: putting {} ({}) into PLT at {}", symbol.name(), symbol_location, (void*)relocation_address);
 
     *relocation_address = symbol_location.get();
 

--- a/Userland/Libraries/LibELF/Image.cpp
+++ b/Userland/Libraries/LibELF/Image.cpp
@@ -255,7 +255,7 @@ Optional<Image::RelocationSection> Image::Section::relocations() const
     if (!relocation_section.has_value())
         return {};
 
-    dbgln_if(ELF_IMAGE_DEBUG, "Found relocations for {} in {}", name(), relocation_section.value().name());
+    dbgln_if<ELF_IMAGE_DEBUG>("Found relocations for {} in {}", name(), relocation_section.value().name());
     return static_cast<RelocationSection>(relocation_section.value());
 }
 

--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -16,7 +16,7 @@ namespace GL {
 
 GLContext::~GLContext()
 {
-    dbgln_if(GL_DEBUG, "GLContext::~GLContext() {:p}", this);
+    dbgln_if<GL_DEBUG>("GLContext::~GLContext() {:p}", this);
     if (g_gl_context == this)
         make_context_current(nullptr);
 }
@@ -24,7 +24,7 @@ GLContext::~GLContext()
 NonnullOwnPtr<GLContext> create_context(Gfx::Bitmap& bitmap)
 {
     auto context = make<SoftwareGLContext>(bitmap);
-    dbgln_if(GL_DEBUG, "GL::create_context({}) -> {:p}", bitmap.size(), context.ptr());
+    dbgln_if<GL_DEBUG>("GL::create_context({}) -> {:p}", bitmap.size(), context.ptr());
 
     if (!g_gl_context)
         make_context_current(context);
@@ -37,7 +37,7 @@ void make_context_current(GLContext* context)
     if (g_gl_context == context)
         return;
 
-    dbgln_if(GL_DEBUG, "GL::make_context_current({:p})", context);
+    dbgln_if<GL_DEBUG>("GL::make_context_current({:p})", context);
     g_gl_context = context;
 }
 

--- a/Userland/Libraries/LibGL/GLDraw.cpp
+++ b/Userland/Libraries/LibGL/GLDraw.cpp
@@ -28,7 +28,7 @@ void glLineWidth(GLfloat width)
 void glPointSize(GLfloat size)
 {
     // FIXME: implement
-    dbgln_if(GL_DEBUG, "glPointSize({}): unimplemented", size);
+    dbgln_if<GL_DEBUG>("glPointSize({}): unimplemented", size);
 }
 
 void glRasterPos2i(GLint x, GLint y)

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -45,7 +45,7 @@ static constexpr size_t TEXTURE_MATRIX_STACK_LIMIT = 8;
 
 #define RETURN_WITH_ERROR_IF(condition, error)                    \
     if (condition) {                                              \
-        dbgln_if(GL_DEBUG, "{}(): error {:#x}", __func__, error); \
+        dbgln_if<GL_DEBUG>("{}(): error {:#x}", __func__, error); \
         if (m_error == GL_NO_ERROR)                               \
             m_error = error;                                      \
         return;                                                   \
@@ -53,7 +53,7 @@ static constexpr size_t TEXTURE_MATRIX_STACK_LIMIT = 8;
 
 #define RETURN_VALUE_WITH_ERROR_IF(condition, error, return_value) \
     if (condition) {                                               \
-        dbgln_if(GL_DEBUG, "{}(): error {:#x}", __func__, error);  \
+        dbgln_if<GL_DEBUG>("{}(): error {:#x}", __func__, error);  \
         if (m_error == GL_NO_ERROR)                                \
             m_error = error;                                       \
         return return_value;                                       \
@@ -240,7 +240,7 @@ Optional<ContextParameter> SoftwareGLContext::get_context_parameter(GLenum name)
                 } }
         };
     default:
-        dbgln_if(GL_DEBUG, "get_context_parameter({:#x}): unknown context parameter", name);
+        dbgln_if<GL_DEBUG>("get_context_parameter({:#x}): unknown context parameter", name);
         return {};
     }
 }
@@ -330,7 +330,7 @@ void SoftwareGLContext::gl_end()
         && m_current_draw_mode != GL_POLYGON) {
 
         m_vertex_list.clear_with_capacity();
-        dbgln_if(GL_DEBUG, "gl_end: draw mode {:#x} unsupported", m_current_draw_mode);
+        dbgln_if<GL_DEBUG>("gl_end: draw mode {:#x} unsupported", m_current_draw_mode);
         RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
     }
 
@@ -463,7 +463,7 @@ GLubyte* SoftwareGLContext::gl_get_string(GLenum name)
     case GL_SHADING_LANGUAGE_VERSION:
         return reinterpret_cast<GLubyte*>(const_cast<char*>("0.0"));
     default:
-        dbgln_if(GL_DEBUG, "gl_get_string({:#x}): unknown name", name);
+        dbgln_if<GL_DEBUG>("gl_get_string({:#x}): unknown name", name);
         break;
     }
 
@@ -776,7 +776,7 @@ void SoftwareGLContext::gl_enable(GLenum capability)
         m_texcoord_generation_dirty = true;
         break;
     default:
-        dbgln_if(GL_DEBUG, "gl_enable({:#x}): unknown parameter", capability);
+        dbgln_if<GL_DEBUG>("gl_enable({:#x}): unknown parameter", capability);
         RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
     }
 
@@ -883,7 +883,7 @@ void SoftwareGLContext::gl_disable(GLenum capability)
         m_texcoord_generation_dirty = true;
         break;
     default:
-        dbgln_if(GL_DEBUG, "gl_disable({:#x}): unknown parameter", capability);
+        dbgln_if<GL_DEBUG>("gl_disable({:#x}): unknown parameter", capability);
         RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
     }
 
@@ -2160,7 +2160,7 @@ void SoftwareGLContext::gl_tex_env(GLenum target, GLenum pname, GLfloat param)
         break;
     default:
         // FIXME: We currently only support a subset of possible param values. Implement the rest!
-        dbgln_if(GL_DEBUG, "gl_tex_env({:#x}, {:#x}, {}): param unimplemented", target, pname, param);
+        dbgln_if<GL_DEBUG>("gl_tex_env({:#x}, {:#x}, {}): param unimplemented", target, pname, param);
         RETURN_WITH_ERROR_IF(true, GL_INVALID_ENUM);
     }
 }
@@ -2320,7 +2320,7 @@ void SoftwareGLContext::gl_draw_pixels(GLsizei width, GLsizei height, GLenum for
 
     // FIXME: we only support RGBA + UNSIGNED_BYTE and DEPTH_COMPONENT + UNSIGNED_SHORT, implement all combinations!
     if (!((format == GL_RGBA && type == GL_UNSIGNED_BYTE) || (format == GL_DEPTH_COMPONENT && type == GL_UNSIGNED_SHORT))) {
-        dbgln_if(GL_DEBUG, "gl_draw_pixels(): support for format {:#x} and/or type {:#x} not implemented", format, type);
+        dbgln_if<GL_DEBUG>("gl_draw_pixels(): support for format {:#x} and/or type {:#x} not implemented", format, type);
         return;
     }
 
@@ -2551,7 +2551,7 @@ void SoftwareGLContext::gl_polygon_mode(GLenum face, GLenum mode)
 
     // FIXME: This must support different polygon modes for front- and backside
     if (face == GL_BACK) {
-        dbgln_if(GL_DEBUG, "gl_polygon_mode(GL_BACK, {:#x}): unimplemented", mode);
+        dbgln_if<GL_DEBUG>("gl_polygon_mode(GL_BACK, {:#x}): unimplemented", mode);
         return;
     }
 
@@ -2775,7 +2775,7 @@ void SoftwareGLContext::gl_normal_pointer(GLenum type, GLsizei stride, void cons
         GL_INVALID_ENUM);
     RETURN_WITH_ERROR_IF(stride < 0, GL_INVALID_VALUE);
 
-    dbgln_if(GL_DEBUG, "gl_normal_pointer({:#x}, {}, {:p}): unimplemented", type, stride, pointer);
+    dbgln_if<GL_DEBUG>("gl_normal_pointer({:#x}, {}, {:p}): unimplemented", type, stride, pointer);
 }
 
 void SoftwareGLContext::gl_raster_pos(GLfloat x, GLfloat y, GLfloat z, GLfloat w)
@@ -2801,7 +2801,7 @@ void SoftwareGLContext::gl_push_attrib(GLbitfield mask)
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
     // FIXME: implement
-    dbgln_if(GL_DEBUG, "SoftwareGLContext FIXME: implement gl_push_attrib({})", mask);
+    dbgln_if<GL_DEBUG>("SoftwareGLContext FIXME: implement gl_push_attrib({})", mask);
 }
 
 void SoftwareGLContext::gl_pop_attrib()
@@ -2810,7 +2810,7 @@ void SoftwareGLContext::gl_pop_attrib()
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
     // FIXME: implement
-    dbgln_if(GL_DEBUG, "SoftwareGLContext FIXME: implement gl_pop_attrib()");
+    dbgln_if<GL_DEBUG>("SoftwareGLContext FIXME: implement gl_pop_attrib()");
 }
 
 void SoftwareGLContext::gl_light_model(GLenum pname, GLfloat x, GLfloat y, GLfloat z, GLfloat w)
@@ -2855,7 +2855,7 @@ void SoftwareGLContext::gl_bitmap(GLsizei width, GLsizei height, GLfloat xorig, 
 
     if (bitmap != nullptr) {
         // FIXME: implement
-        dbgln_if(GL_DEBUG, "gl_bitmap({}, {}, {}, {}, {}, {}, {}): unimplemented", width, height, xorig, yorig, xmove, ymove, bitmap);
+        dbgln_if<GL_DEBUG>("gl_bitmap({}, {}, {}, {}, {}, {}, {}): unimplemented", width, height, xorig, yorig, xmove, ymove, bitmap);
     }
 
     auto raster_position = m_rasterizer.raster_position();
@@ -2869,7 +2869,7 @@ void SoftwareGLContext::gl_copy_tex_image_2d(GLenum target, GLint level, GLenum 
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
     // FIXME: implement
-    dbgln_if(GL_DEBUG, "SoftwareGLContext FIXME: implement gl_copy_tex_image_2d({:#x}, {}, {:#x}, {}, {}, {}, {}, {})",
+    dbgln_if<GL_DEBUG>("SoftwareGLContext FIXME: implement gl_copy_tex_image_2d({:#x}, {}, {:#x}, {}, {}, {}, {}, {})",
         target, level, internalformat, x, y, width, height, border);
 }
 

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -307,7 +307,7 @@ void AbstractView::mousemove_event(MouseEvent& event)
     // Prevent this by just ignoring later drag initiations (until the current drag operation ends).
     TemporaryChange dragging { m_is_dragging, true };
 
-    dbgln_if(DRAG_DEBUG, "Initiate drag!");
+    dbgln_if<DRAG_DEBUG>("Initiate drag!");
     auto drag_operation = DragOperation::construct();
 
     drag_operation->set_mime_data(m_model->mime_data(m_selection));
@@ -316,10 +316,10 @@ void AbstractView::mousemove_event(MouseEvent& event)
 
     switch (outcome) {
     case DragOperation::Outcome::Accepted:
-        dbgln_if(DRAG_DEBUG, "Drag was accepted!");
+        dbgln_if<DRAG_DEBUG>("Drag was accepted!");
         break;
     case DragOperation::Outcome::Cancelled:
-        dbgln_if(DRAG_DEBUG, "Drag was cancelled!");
+        dbgln_if<DRAG_DEBUG>("Drag was cancelled!");
         m_might_drag = false;
         break;
     default:
@@ -754,7 +754,7 @@ void AbstractView::drag_enter_event(DragEvent& event)
     //       We might be able to reduce event traffic by communicating the set of drag-accepting
     //       rects in this widget to the windowing system somehow.
     event.accept();
-    dbgln_if(DRAG_DEBUG, "accepting drag of {}", event.mime_types().first());
+    dbgln_if<DRAG_DEBUG>("accepting drag of {}", event.mime_types().first());
 }
 
 void AbstractView::drag_move_event(DragEvent& event)

--- a/Userland/Libraries/LibGUI/Menu.cpp
+++ b/Userland/Libraries/LibGUI/Menu.cpp
@@ -128,7 +128,7 @@ int Menu::realize_menu(RefPtr<Action> default_action)
 
     WindowServerConnection::the().async_create_menu(m_menu_id, m_name);
 
-    dbgln_if(MENU_DEBUG, "GUI::Menu::realize_menu(): New menu ID: {}", m_menu_id);
+    dbgln_if<MENU_DEBUG>("GUI::Menu::realize_menu(): New menu ID: {}", m_menu_id);
     VERIFY(m_menu_id > 0);
     m_current_default_action = default_action;
 

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -562,7 +562,7 @@ void TextEditor::paint_event(PaintEvent& event)
                         continue;
                     }
                     if (span.range.end().line() < line_index) {
-                        dbgln_if(TEXTEDITOR_DEBUG, "spans not sorted (span end {}:{} is before current line {}) => ignoring", span.range.end().line(), span.range.end().column(), line_index);
+                        dbgln_if<TEXTEDITOR_DEBUG>("spans not sorted (span end {}:{} is before current line {}) => ignoring", span.range.end().line(), span.range.end().column(), line_index);
                         ++span_index;
                         continue;
                     }
@@ -572,12 +572,12 @@ void TextEditor::paint_event(PaintEvent& event)
                         break;
                     }
                     if (span.range.start().line() == span.range.end().line() && span.range.end().column() < span.range.start().column()) {
-                        dbgln_if(TEXTEDITOR_DEBUG, "span from {}:{} to {}:{} has negative length => ignoring", span.range.start().line(), span.range.start().column(), span.range.end().line(), span.range.end().column());
+                        dbgln_if<TEXTEDITOR_DEBUG>("span from {}:{} to {}:{} has negative length => ignoring", span.range.start().line(), span.range.start().column(), span.range.end().line(), span.range.end().column());
                         ++span_index;
                         continue;
                     }
                     if (span.range.end().line() == line_index && span.range.end().column() < start_of_visual_line + next_column) {
-                        dbgln_if(TEXTEDITOR_DEBUG, "spans not sorted (span end {}:{} is before current position {}:{}) => ignoring",
+                        dbgln_if<TEXTEDITOR_DEBUG>("spans not sorted (span end {}:{} is before current position {}:{}) => ignoring",
                             span.range.end().line(), span.range.end().column(), line_index, start_of_visual_line + next_column);
                         ++span_index;
                         continue;
@@ -589,7 +589,7 @@ void TextEditor::paint_event(PaintEvent& event)
                         span_start = span.range.start().column() - start_of_visual_line;
                     }
                     if (span_start < next_column) {
-                        dbgln_if(TEXTEDITOR_DEBUG, "span started before the current position, maybe two spans overlap? (span start {} is before current position {}) => ignoring", span_start, next_column);
+                        dbgln_if<TEXTEDITOR_DEBUG>("span started before the current position, maybe two spans overlap? (span start {} is before current position {}) => ignoring", span_start, next_column);
                         ++span_index;
                         continue;
                     }
@@ -1430,7 +1430,7 @@ void TextEditor::cut()
     if (!is_editable())
         return;
     auto selected_text = this->selected_text();
-    dbgln_if(TEXTEDITOR_DEBUG, "Cut: \"{}\"", selected_text);
+    dbgln_if<TEXTEDITOR_DEBUG>("Cut: \"{}\"", selected_text);
     Clipboard::the().set_plain_text(selected_text);
     delete_selection();
 }
@@ -1438,7 +1438,7 @@ void TextEditor::cut()
 void TextEditor::copy()
 {
     auto selected_text = this->selected_text();
-    dbgln_if(TEXTEDITOR_DEBUG, "Copy: \"{}\"\n", selected_text);
+    dbgln_if<TEXTEDITOR_DEBUG>("Copy: \"{}\"\n", selected_text);
     Clipboard::the().set_plain_text(selected_text);
 }
 
@@ -1454,7 +1454,7 @@ void TextEditor::paste()
     if (data.is_empty())
         return;
 
-    dbgln_if(TEXTEDITOR_DEBUG, "Paste: \"{}\"", String::copy(data));
+    dbgln_if<TEXTEDITOR_DEBUG>("Paste: \"{}\"", String::copy(data));
 
     TemporaryChange change(m_automatic_indentation_enabled, false);
     insert_at_cursor_or_replace_selection(data);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -558,17 +558,17 @@ void Widget::drag_enter_event(DragEvent& event)
 {
     StringBuilder builder;
     builder.join(',', event.mime_types());
-    dbgln_if(DRAG_DEBUG, "{} {:p} DRAG ENTER @ {}, {}", class_name(), this, event.position(), builder.string_view());
+    dbgln_if<DRAG_DEBUG>("{} {:p} DRAG ENTER @ {}, {}", class_name(), this, event.position(), builder.string_view());
 }
 
 void Widget::drag_leave_event(Event&)
 {
-    dbgln_if(DRAG_DEBUG, "{} {:p} DRAG LEAVE", class_name(), this);
+    dbgln_if<DRAG_DEBUG>("{} {:p} DRAG LEAVE", class_name(), this);
 }
 
 void Widget::drop_event(DropEvent& event)
 {
-    dbgln_if(DRAG_DEBUG, "{} {:p} DROP @ {}, '{}'", class_name(), this, event.position(), event.text());
+    dbgln_if<DRAG_DEBUG>("{} {:p} DROP @ {}, '{}'", class_name(), this, event.position(), event.text());
     event.ignore();
 }
 

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -695,7 +695,7 @@ void Window::update(const Gfx::IntRect& a_rect)
 
     for (auto& pending_rect : m_pending_paint_event_rects) {
         if (pending_rect.contains(a_rect)) {
-            dbgln_if(UPDATE_COALESCING_DEBUG, "Ignoring {} since it's contained by pending rect {}", a_rect, pending_rect);
+            dbgln_if<UPDATE_COALESCING_DEBUG>("Ignoring {} since it's contained by pending rect {}", a_rect, pending_rect);
             return;
         }
     }

--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -138,24 +138,24 @@ static Action* action_for_key_event(Window& window, KeyEvent const& event)
     if (event.key() == KeyCode::Key_Invalid)
         return nullptr;
 
-    dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "Looking up action for {}", event.to_string());
+    dbgln_if<KEYBOARD_SHORTCUTS_DEBUG>("Looking up action for {}", event.to_string());
 
     for (auto* widget = window.focused_widget(); widget; widget = widget->parent_widget()) {
         if (auto* action = widget->action_for_key_event(event)) {
-            dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "  > Focused widget {} gave action: {}", *widget, action);
+            dbgln_if<KEYBOARD_SHORTCUTS_DEBUG>("  > Focused widget {} gave action: {}", *widget, action);
             return action;
         }
     }
 
     if (auto* action = window.action_for_key_event(event)) {
-        dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "  > Asked window {}, got action: {}", window, action);
+        dbgln_if<KEYBOARD_SHORTCUTS_DEBUG>("  > Asked window {}, got action: {}", window, action);
         return action;
     }
 
     // NOTE: Application-global shortcuts are ignored while a modal window is up.
     if (!window.is_modal()) {
         if (auto* action = Application::the()->action_for_key_event(event)) {
-            dbgln_if(KEYBOARD_SHORTCUTS_DEBUG, "  > Asked application, got action: {}", action);
+            dbgln_if<KEYBOARD_SHORTCUTS_DEBUG>("  > Asked application, got action: {}", action);
             return action;
         }
     }

--- a/Userland/Libraries/LibGemini/Job.cpp
+++ b/Userland/Libraries/LibGemini/Job.cpp
@@ -199,7 +199,7 @@ void Job::on_socket_connected()
         }
 
         if (!m_socket->is_open() || m_socket->is_eof()) {
-            dbgln_if(JOB_DEBUG, "Connection appears to have closed, finishing up");
+            dbgln_if<JOB_DEBUG>("Connection appears to have closed, finishing up");
             finish_up();
         }
     });

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -277,7 +277,7 @@ static u8 get_scaled_color(u32 data, u8 mask_size, i8 mask_shift)
 //   to scale the values in order to reach the proper value of 255.
 static u32 int_to_scaled_rgb(BMPLoadingContext& context, u32 data)
 {
-    dbgln_if(BMP_DEBUG, "DIB info sizes before access: #masks={}, #mask_sizes={}, #mask_shifts={}",
+    dbgln_if<BMP_DEBUG>("DIB info sizes before access: #masks={}, #mask_sizes={}, #mask_shifts={}",
         context.dib.info.masks.size(),
         context.dib.info.mask_sizes.size(),
         context.dib.info.mask_shifts.size());
@@ -431,7 +431,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
         return true;
 
     if (!context.file_bytes || context.file_size < bmp_header_size) {
-        dbgln_if(BMP_DEBUG, "Missing BMP header");
+        dbgln_if<BMP_DEBUG>("Missing BMP header");
         context.state = BMPLoadingContext::State::Error;
         return false;
     }
@@ -440,7 +440,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
 
     u16 header = streamer.read_u16();
     if (header != 0x4d42) {
-        dbgln_if(BMP_DEBUG, "BMP has invalid magic header number: {:#04x}", header);
+        dbgln_if<BMP_DEBUG>("BMP has invalid magic header number: {:#04x}", header);
         context.state = BMPLoadingContext::State::Error;
         return false;
     }
@@ -462,7 +462,7 @@ static bool decode_bmp_header(BMPLoadingContext& context)
     }
 
     if (context.data_offset >= context.file_size) {
-        dbgln_if(BMP_DEBUG, "BMP data offset is beyond file end?!");
+        dbgln_if<BMP_DEBUG>("BMP data offset is beyond file end?!");
         return false;
     }
 
@@ -685,12 +685,12 @@ static bool decode_bmp_v3_dib(BMPLoadingContext& context, InputStreamer& streame
     // suite results.
     if (context.dib.info.compression == Compression::ALPHABITFIELDS) {
         context.dib.info.masks.append(streamer.read_u32());
-        dbgln_if(BMP_DEBUG, "BMP alpha mask: {:#08x}", context.dib.info.masks[3]);
+        dbgln_if<BMP_DEBUG>("BMP alpha mask: {:#08x}", context.dib.info.masks[3]);
     } else if (context.dib_size() >= 56 && context.dib.core.bpp >= 16) {
         auto mask = streamer.read_u32();
         if ((context.dib.core.bpp == 32 && mask != 0) || context.dib.core.bpp == 16) {
             context.dib.info.masks.append(mask);
-            dbgln_if(BMP_DEBUG, "BMP alpha mask: {:#08x}", mask);
+            dbgln_if<BMP_DEBUG>("BMP alpha mask: {:#08x}", mask);
         }
     } else {
         streamer.drop_bytes(4);
@@ -767,7 +767,7 @@ static bool decode_bmp_dib(BMPLoadingContext& context)
 
     streamer = InputStreamer(context.file_bytes + bmp_header_size + 4, context.data_offset - bmp_header_size - 4);
 
-    dbgln_if(BMP_DEBUG, "BMP dib size: {}", dib_size);
+    dbgln_if<BMP_DEBUG>("BMP dib size: {}", dib_size);
 
     bool error = false;
 
@@ -897,7 +897,7 @@ static bool uncompress_bmp_rle_data(BMPLoadingContext& context, ByteBuffer& buff
 {
     // RLE-compressed images cannot be stored top-down
     if (context.dib.core.height < 0) {
-        dbgln_if(BMP_DEBUG, "BMP is top-down and RLE compressed");
+        dbgln_if<BMP_DEBUG>("BMP is top-down and RLE compressed");
         context.state = BMPLoadingContext::State::Error;
         return false;
     }

--- a/Userland/Libraries/LibGfx/DDSLoader.cpp
+++ b/Userland/Libraries/LibGfx/DDSLoader.cpp
@@ -704,7 +704,7 @@ static bool decode_dds(DDSLoadingContext& context)
 
     // All valid DDS files are at least 128 bytes long.
     if (stream.remaining() < 128) {
-        dbgln_if(DDS_DEBUG, "File is too short for DDS");
+        dbgln_if<DDS_DEBUG>("File is too short for DDS");
         context.state = DDSLoadingContext::State::Error;
         return false;
     }
@@ -713,7 +713,7 @@ static bool decode_dds(DDSLoadingContext& context)
     stream >> magic;
 
     if (magic != create_four_cc('D', 'D', 'S', ' ')) {
-        dbgln_if(DDS_DEBUG, "Missing magic number");
+        dbgln_if<DDS_DEBUG>("Missing magic number");
         context.state = DDSLoadingContext::State::Error;
         return false;
     }
@@ -742,12 +742,12 @@ static bool decode_dds(DDSLoadingContext& context)
     stream >> context.header.reserved2;
 
     if (context.header.size != 124) {
-        dbgln_if(DDS_DEBUG, "Header size is malformed");
+        dbgln_if<DDS_DEBUG>("Header size is malformed");
         context.state = DDSLoadingContext::State::Error;
         return false;
     }
     if (context.header.pixel_format.size != 32) {
-        dbgln_if(DDS_DEBUG, "Pixel format size is malformed");
+        dbgln_if<DDS_DEBUG>("Pixel format size is malformed");
         context.state = DDSLoadingContext::State::Error;
         return false;
     }
@@ -755,7 +755,7 @@ static bool decode_dds(DDSLoadingContext& context)
     if ((context.header.pixel_format.flags & PixelFormatFlags::DDPF_FOURCC) == PixelFormatFlags::DDPF_FOURCC) {
         if (context.header.pixel_format.four_cc == create_four_cc('D', 'X', '1', '0')) {
             if (stream.bytes().size() < 148) {
-                dbgln_if(DDS_DEBUG, "DX10 header is too short");
+                dbgln_if<DDS_DEBUG>("DX10 header is too short");
                 context.state = DDSLoadingContext::State::Error;
                 return false;
             }
@@ -778,7 +778,7 @@ static bool decode_dds(DDSLoadingContext& context)
 
     Vector<u32> supported_formats = { DXGI_FORMAT_BC1_UNORM, DXGI_FORMAT_BC2_UNORM, DXGI_FORMAT_BC3_UNORM };
     if (!supported_formats.contains_slow(format)) {
-        dbgln_if(DDS_DEBUG, "Format of type {} is not supported at the moment", static_cast<u32>(format));
+        dbgln_if<DDS_DEBUG>("Format of type {} is not supported at the moment", static_cast<u32>(format));
         context.state = DDSLoadingContext::State::Error;
         return false;
     }
@@ -789,7 +789,7 @@ static bool decode_dds(DDSLoadingContext& context)
         u64 height = get_height(context.header, mipmap_level);
 
         u64 needed_bytes = get_minimum_bytes_for_mipmap(format, width, height);
-        dbgln_if(DDS_DEBUG, "There are {} bytes remaining, we need {} for mipmap level {} of the image", stream.remaining(), needed_bytes, mipmap_level);
+        dbgln_if<DDS_DEBUG>("There are {} bytes remaining, we need {} for mipmap level {} of the image", stream.remaining(), needed_bytes, mipmap_level);
         VERIFY(stream.remaining() >= needed_bytes);
 
         context.bitmap = Bitmap::try_create(BitmapFormat::BGRA8888, { width, height }).release_value_but_fixme_should_propagate_errors();

--- a/Userland/Libraries/LibGfx/FillPathImplementation.h
+++ b/Userland/Libraries/LibGfx/FillPathImplementation.h
@@ -135,7 +135,7 @@ void fill_path(Painter& painter, Path const& path, Color color, Gfx::Painter::Wi
                         // The points between this segment and the previous are
                         // inside the shape
 
-                        dbgln_if(FILL_PATH_DEBUG, "y={}: {} at {}: {} -- {}", scanline, winding_number, i, from, to);
+                        dbgln_if<FILL_PATH_DEBUG>("y={}: {} at {}: {} -- {}", scanline, winding_number, i, from, to);
                         draw_line(from, to, color, 1);
                     }
 

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -168,13 +168,13 @@ public:
         }
 
         if (m_current_code > m_code_table.size()) {
-            dbgln_if(GIF_DEBUG, "Corrupted LZW stream, invalid code: {} at bit index {}, code table size: {}",
+            dbgln_if<GIF_DEBUG>("Corrupted LZW stream, invalid code: {} at bit index {}, code table size: {}",
                 m_current_code,
                 m_current_bit_index,
                 m_code_table.size());
             return {};
         } else if (m_current_code == m_code_table.size() && m_output.is_empty()) {
-            dbgln_if(GIF_DEBUG, "Corrupted LZW stream, valid new code but output buffer is empty: {} at bit index {}, code table size: {}",
+            dbgln_if<GIF_DEBUG>("Corrupted LZW stream, valid new code but output buffer is empty: {} at bit index {}, code table size: {}",
                 m_current_code,
                 m_current_bit_index,
                 m_code_table.size());
@@ -334,7 +334,7 @@ static bool decode_frame(GIFLoadingContext& context, size_t frame_index)
         while (true) {
             Optional<u16> code = decoder.next_code();
             if (!code.has_value()) {
-                dbgln_if(GIF_DEBUG, "Unexpectedly reached end of gif frame data");
+                dbgln_if<GIF_DEBUG>("Unexpectedly reached end of gif frame data");
                 return false;
             }
 
@@ -481,7 +481,7 @@ static bool load_gif_frame_descriptors(GIFLoadingContext& context)
 
             if (extension_type == 0xF9) {
                 if (sub_block.size() != 4) {
-                    dbgln_if(GIF_DEBUG, "Unexpected graphic control size");
+                    dbgln_if<GIF_DEBUG>("Unexpected graphic control size");
                     continue;
                 }
 
@@ -502,12 +502,12 @@ static bool load_gif_frame_descriptors(GIFLoadingContext& context)
 
             if (extension_type == 0xFF) {
                 if (sub_block.size() != 14) {
-                    dbgln_if(GIF_DEBUG, "Unexpected application extension size: {}", sub_block.size());
+                    dbgln_if<GIF_DEBUG>("Unexpected application extension size: {}", sub_block.size());
                     continue;
                 }
 
                 if (sub_block[11] != 1) {
-                    dbgln_if(GIF_DEBUG, "Unexpected application extension format");
+                    dbgln_if<GIF_DEBUG>("Unexpected application extension format");
                     continue;
                 }
 

--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -144,17 +144,17 @@ static bool load_ico_directory(ICOLoadingContext& context)
     for (size_t i = 0; i < image_count.value(); ++i) {
         auto maybe_desc = decode_ico_direntry(stream);
         if (!maybe_desc.has_value()) {
-            dbgln_if(ICO_DEBUG, "load_ico_directory: error loading entry: {}", i);
+            dbgln_if<ICO_DEBUG>("load_ico_directory: error loading entry: {}", i);
             return false;
         }
 
         auto& desc = maybe_desc.value();
         if (desc.offset + desc.size < desc.offset // detect integer overflow
             || (desc.offset + desc.size) > context.data_size) {
-            dbgln_if(ICO_DEBUG, "load_ico_directory: offset: {} size: {} doesn't fit in ICO size: {}", desc.offset, desc.size, context.data_size);
+            dbgln_if<ICO_DEBUG>("load_ico_directory: offset: {} size: {} doesn't fit in ICO size: {}", desc.offset, desc.size, context.data_size);
             return false;
         }
-        dbgln_if(ICO_DEBUG, "load_ico_directory: index {} width: {} height: {} offset: {} size: {}", i, desc.width, desc.height, desc.offset, desc.size);
+        dbgln_if<ICO_DEBUG>("load_ico_directory: index {} width: {} height: {} offset: {} size: {}", i, desc.width, desc.height, desc.offset, desc.size);
         context.images.append(desc);
     }
     context.largest_index = find_largest_image(context);
@@ -170,17 +170,17 @@ static bool load_ico_bmp(ICOLoadingContext& context, ICOImageDescriptor& desc)
 
     memcpy(&info, context.data + desc.offset, sizeof(info));
     if (info.size != sizeof(info)) {
-        dbgln_if(ICO_DEBUG, "load_ico_bmp: info size: {}, expected: {}", info.size, sizeof(info));
+        dbgln_if<ICO_DEBUG>("load_ico_bmp: info size: {}, expected: {}", info.size, sizeof(info));
         return false;
     }
 
     if (info.width < 0) {
-        dbgln_if(ICO_DEBUG, "load_ico_bmp: width {} < 0", info.width);
+        dbgln_if<ICO_DEBUG>("load_ico_bmp: width {} < 0", info.width);
         return false;
     }
 
     if (info.height == NumericLimits<i32>::min()) {
-        dbgln_if(ICO_DEBUG, "load_ico_bmp: height == NumericLimits<i32>::min()");
+        dbgln_if<ICO_DEBUG>("load_ico_bmp: height == NumericLimits<i32>::min()");
         return false;
     }
 
@@ -191,25 +191,25 @@ static bool load_ico_bmp(ICOLoadingContext& context, ICOImageDescriptor& desc)
     }
 
     if (info.planes != 1) {
-        dbgln_if(ICO_DEBUG, "load_ico_bmp: planes: {} != 1", info.planes);
+        dbgln_if<ICO_DEBUG>("load_ico_bmp: planes: {} != 1", info.planes);
         return false;
     }
 
     if (info.bpp != 32) {
-        dbgln_if(ICO_DEBUG, "load_ico_bmp: unsupported bpp: {}", info.bpp);
+        dbgln_if<ICO_DEBUG>("load_ico_bmp: unsupported bpp: {}", info.bpp);
         return false;
     }
 
-    dbgln_if(ICO_DEBUG, "load_ico_bmp: width: {} height: {} direction: {} bpp: {} size_image: {}",
+    dbgln_if<ICO_DEBUG>("load_ico_bmp: width: {} height: {} direction: {} bpp: {} size_image: {}",
         info.width, info.height, topdown ? "TopDown" : "BottomUp", info.bpp, info.size_image);
 
     if (info.compression != 0 || info.palette_size != 0 || info.important_colors != 0) {
-        dbgln_if(ICO_DEBUG, "load_ico_bmp: following fields must be 0: compression: {} palette_size: {} important_colors: {}", info.compression, info.palette_size, info.important_colors);
+        dbgln_if<ICO_DEBUG>("load_ico_bmp: following fields must be 0: compression: {} palette_size: {} important_colors: {}", info.compression, info.palette_size, info.important_colors);
         return false;
     }
 
     if (info.width != desc.width || info.height != 2 * desc.height) {
-        dbgln_if(ICO_DEBUG, "load_ico_bmp: size mismatch: ico {}x{}, bmp {}x{}", desc.width, desc.height, info.width, info.height);
+        dbgln_if<ICO_DEBUG>("load_ico_bmp: size mismatch: ico {}x{}, bmp {}x{}", desc.width, desc.height, info.width, info.height);
         return false;
     }
 
@@ -218,7 +218,7 @@ static bool load_ico_bmp(ICOLoadingContext& context, ICOImageDescriptor& desc)
     size_t required_len = desc.height * (desc.width * sizeof(BMP_ARGB) + mask_row_len);
     size_t available_len = desc.size - sizeof(info);
     if (required_len > available_len) {
-        dbgln_if(ICO_DEBUG, "load_ico_bmp: required_len: {} > available_len: {}", required_len, available_len);
+        dbgln_if<ICO_DEBUG>("load_ico_bmp: required_len: {} > available_len: {}", required_len, available_len);
         return false;
     }
 
@@ -265,14 +265,14 @@ static bool load_ico_bitmap(ICOLoadingContext& context, Optional<size_t> index)
     if (png_decoder.sniff()) {
         auto decoded_png_frame = png_decoder.frame(0);
         if (decoded_png_frame.is_error() || !decoded_png_frame.value().image) {
-            dbgln_if(ICO_DEBUG, "load_ico_bitmap: failed to load PNG encoded image index: {}", real_index);
+            dbgln_if<ICO_DEBUG>("load_ico_bitmap: failed to load PNG encoded image index: {}", real_index);
             return false;
         }
         desc.bitmap = decoded_png_frame.value().image;
         return true;
     } else {
         if (!load_ico_bmp(context, desc)) {
-            dbgln_if(ICO_DEBUG, "load_ico_bitmap: failed to load BMP encoded image index: {}", real_index);
+            dbgln_if<ICO_DEBUG>("load_ico_bitmap: failed to load BMP encoded image index: {}", real_index);
             return false;
         }
         return true;

--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -203,13 +203,13 @@ static void generate_huffman_codes(HuffmanTableSpec& table)
 static Optional<size_t> read_huffman_bits(HuffmanStreamState& hstream, size_t count = 1)
 {
     if (count > (8 * sizeof(size_t))) {
-        dbgln_if(JPG_DEBUG, "Can't read {} bits at once!", count);
+        dbgln_if<JPG_DEBUG>("Can't read {} bits at once!", count);
         return {};
     }
     size_t value = 0;
     while (count--) {
         if (hstream.byte_offset >= hstream.stream.size()) {
-            dbgln_if(JPG_DEBUG, "Huffman stream exhausted. This could be an error!");
+            dbgln_if<JPG_DEBUG>("Huffman stream exhausted. This could be an error!");
             return {};
         }
         u8 current_byte = hstream.stream[hstream.byte_offset];
@@ -240,7 +240,7 @@ static Optional<u8> get_next_symbol(HuffmanStreamState& hstream, const HuffmanTa
         }
     }
 
-    dbgln_if(JPG_DEBUG, "If you're seeing this...the jpeg decoder needs to support more kinds of JPEGs!");
+    dbgln_if<JPG_DEBUG>("If you're seeing this...the jpeg decoder needs to support more kinds of JPEGs!");
     return {};
 }
 
@@ -296,7 +296,7 @@ static bool build_macroblocks(JPGLoadingContext& context, Vector<Macroblock>& ma
                 // For DC coefficients, symbol encodes the length of the coefficient.
                 auto dc_length = symbol_or_error.release_value();
                 if (dc_length > 11) {
-                    dbgln_if(JPG_DEBUG, "DC coefficient too long: {}!", dc_length);
+                    dbgln_if<JPG_DEBUG>("DC coefficient too long: {}!", dc_length);
                     return false;
                 }
 
@@ -333,13 +333,13 @@ static bool build_macroblocks(JPGLoadingContext& context, Vector<Macroblock>& ma
                     j += run_length;
 
                     if (j >= 64) {
-                        dbgln_if(JPG_DEBUG, "Run-length exceeded boundaries. Cursor: {}, Skipping: {}!", j, run_length);
+                        dbgln_if<JPG_DEBUG>("Run-length exceeded boundaries. Cursor: {}, Skipping: {}!", j, run_length);
                         return false;
                     }
 
                     u8 coeff_length = ac_symbol & 0x0F;
                     if (coeff_length > 10) {
-                        dbgln_if(JPG_DEBUG, "AC coefficient too long: {}!", coeff_length);
+                        dbgln_if<JPG_DEBUG>("AC coefficient too long: {}!", coeff_length);
                         return false;
                     }
 
@@ -428,7 +428,7 @@ static inline bool is_valid_marker(const Marker marker)
     if (marker >= JPG_APPN0 && marker <= JPG_APPNF) {
 
         if (marker != JPG_APPN0)
-            dbgln_if(JPG_DEBUG, "{:#04x} not supported yet. The decoder may fail!", marker);
+            dbgln_if<JPG_DEBUG>("{:#04x} not supported yet. The decoder may fail!", marker);
         return true;
     }
     if (marker >= JPG_RESERVED1 && marker <= JPG_RESERVEDD)
@@ -450,7 +450,7 @@ static inline bool is_valid_marker(const Marker marker)
 
     if (marker >= 0xFFC0 && marker <= 0xFFCF) {
         if (marker != 0xFFC4 && marker != 0xFFC8 && marker != 0xFFCC) {
-            dbgln_if(JPG_DEBUG, "Decoding this frame-type (SOF{}) is not currently supported. Decoder will fail!", marker & 0xf);
+            dbgln_if<JPG_DEBUG>("Decoding this frame-type (SOF{}) is not currently supported. Decoder will fail!", marker & 0xf);
             return false;
         }
     }
@@ -487,7 +487,7 @@ static inline Marker read_marker_at_cursor(InputMemoryStream& stream)
 static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& context)
 {
     if (context.state < JPGLoadingContext::State::FrameDecoded) {
-        dbgln_if(JPG_DEBUG, "{}: SOS found before reading a SOF!", stream.offset());
+        dbgln_if<JPG_DEBUG>("{}: SOS found before reading a SOF!", stream.offset());
         return false;
     }
 
@@ -502,7 +502,7 @@ static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& con
     if (stream.handle_any_error())
         return false;
     if (component_count != context.component_count) {
-        dbgln_if(JPG_DEBUG, "{}: Unsupported number of components: {}!", stream.offset(), component_count);
+        dbgln_if<JPG_DEBUG>("{}: Unsupported number of components: {}!", stream.offset(), component_count);
         return false;
     }
 
@@ -527,17 +527,17 @@ static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& con
         component.ac_destination_id = table_ids & 0x0F;
 
         if (context.dc_tables.size() != context.ac_tables.size()) {
-            dbgln_if(JPG_DEBUG, "{}: DC & AC table count mismatch!", stream.offset());
+            dbgln_if<JPG_DEBUG>("{}: DC & AC table count mismatch!", stream.offset());
             return false;
         }
 
         if (!context.dc_tables.contains(component.dc_destination_id)) {
-            dbgln_if(JPG_DEBUG, "DC table (id: {}) does not exist!", component.dc_destination_id);
+            dbgln_if<JPG_DEBUG>("DC table (id: {}) does not exist!", component.dc_destination_id);
             return false;
         }
 
         if (!context.ac_tables.contains(component.ac_destination_id)) {
-            dbgln_if(JPG_DEBUG, "AC table (id: {}) does not exist!", component.ac_destination_id);
+            dbgln_if<JPG_DEBUG>("AC table (id: {}) does not exist!", component.ac_destination_id);
             return false;
         }
     }
@@ -556,7 +556,7 @@ static bool read_start_of_scan(InputMemoryStream& stream, JPGLoadingContext& con
         return false;
     // The three values should be fixed for baseline JPEGs utilizing sequential DCT.
     if (spectral_selection_start != 0 || spectral_selection_end != 63 || successive_approximation != 0) {
-        dbgln_if(JPG_DEBUG, "{}: ERROR! Start of Selection: {}, End of Selection: {}, Successive Approximation: {}!",
+        dbgln_if<JPG_DEBUG>("{}: ERROR! Start of Selection: {}, End of Selection: {}, Successive Approximation: {}!",
             stream.offset(),
             spectral_selection_start,
             spectral_selection_end,
@@ -573,7 +573,7 @@ static bool read_reset_marker(InputMemoryStream& stream, JPGLoadingContext& cont
         return false;
     bytes_to_read -= 2;
     if (bytes_to_read != 2) {
-        dbgln_if(JPG_DEBUG, "{}: Malformed reset marker found!", stream.offset());
+        dbgln_if<JPG_DEBUG>("{}: Malformed reset marker found!", stream.offset());
         return false;
     }
     context.dc_reset_interval = read_be_word(stream);
@@ -599,11 +599,11 @@ static bool read_huffman_table(InputMemoryStream& stream, JPGLoadingContext& con
         u8 table_type = table_info >> 4;
         u8 table_destination_id = table_info & 0x0F;
         if (table_type > 1) {
-            dbgln_if(JPG_DEBUG, "{}: Unrecognized huffman table: {}!", stream.offset(), table_type);
+            dbgln_if<JPG_DEBUG>("{}: Unrecognized huffman table: {}!", stream.offset(), table_type);
             return false;
         }
         if (table_destination_id > 1) {
-            dbgln_if(JPG_DEBUG, "{}: Invalid huffman table destination id: {}!", stream.offset(), table_destination_id);
+            dbgln_if<JPG_DEBUG>("{}: Invalid huffman table destination id: {}!", stream.offset(), table_destination_id);
             return false;
         }
 
@@ -643,7 +643,7 @@ static bool read_huffman_table(InputMemoryStream& stream, JPGLoadingContext& con
     }
 
     if (bytes_to_read != 0) {
-        dbgln_if(JPG_DEBUG, "{}: Extra bytes detected in huffman header!", stream.offset());
+        dbgln_if<JPG_DEBUG>("{}: Extra bytes detected in huffman header!", stream.offset());
         return false;
     }
     return true;
@@ -681,7 +681,7 @@ static inline void set_macroblock_metadata(JPGLoadingContext& context)
 static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& context)
 {
     if (context.state == JPGLoadingContext::FrameDecoded) {
-        dbgln_if(JPG_DEBUG, "{}: SOF repeated!", stream.offset());
+        dbgln_if<JPG_DEBUG>("{}: SOF repeated!", stream.offset());
         return false;
     }
 
@@ -697,7 +697,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
     if (stream.handle_any_error())
         return false;
     if (context.frame.precision != 8) {
-        dbgln_if(JPG_DEBUG, "{}: SOF precision != 8!", stream.offset());
+        dbgln_if<JPG_DEBUG>("{}: SOF precision != 8!", stream.offset());
         return false;
     }
 
@@ -708,7 +708,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
     if (stream.handle_any_error())
         return false;
     if (!context.frame.width || !context.frame.height) {
-        dbgln_if(JPG_DEBUG, "{}: ERROR! Image height: {}, Image width: {}!", stream.offset(), context.frame.height, context.frame.width);
+        dbgln_if<JPG_DEBUG>("{}: ERROR! Image height: {}, Image width: {}!", stream.offset(), context.frame.height, context.frame.width);
         return false;
     }
 
@@ -723,7 +723,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
     if (stream.handle_any_error())
         return false;
     if (context.component_count != 1 && context.component_count != 3) {
-        dbgln_if(JPG_DEBUG, "{}: Unsupported number of components in SOF: {}!", stream.offset(), context.component_count);
+        dbgln_if<JPG_DEBUG>("{}: Unsupported number of components in SOF: {}!", stream.offset(), context.component_count);
         return false;
     }
 
@@ -745,7 +745,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
             // By convention, downsampling is applied only on chroma components. So we should
             //  hope to see the maximum sampling factor in the luma component.
             if (!validate_luma_and_modify_context(component, context)) {
-                dbgln_if(JPG_DEBUG, "{}: Unsupported luma subsampling factors: horizontal: {}, vertical: {}",
+                dbgln_if<JPG_DEBUG>("{}: Unsupported luma subsampling factors: horizontal: {}, vertical: {}",
                     stream.offset(),
                     component.hsample_factor,
                     component.vsample_factor);
@@ -753,7 +753,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
             }
         } else {
             if (component.hsample_factor != 1 || component.vsample_factor != 1) {
-                dbgln_if(JPG_DEBUG, "{}: Unsupported chroma subsampling factors: horizontal: {}, vertical: {}",
+                dbgln_if<JPG_DEBUG>("{}: Unsupported chroma subsampling factors: horizontal: {}, vertical: {}",
                     stream.offset(),
                     component.hsample_factor,
                     component.vsample_factor);
@@ -765,7 +765,7 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
         if (stream.handle_any_error())
             return false;
         if (component.qtable_id > 1) {
-            dbgln_if(JPG_DEBUG, "{}: Unsupported quantization table id: {}!", stream.offset(), component.qtable_id);
+            dbgln_if<JPG_DEBUG>("{}: Unsupported quantization table id: {}!", stream.offset(), component.qtable_id);
             return false;
         }
 
@@ -790,12 +790,12 @@ static bool read_quantization_table(InputMemoryStream& stream, JPGLoadingContext
             return false;
         u8 element_unit_hint = info_byte >> 4;
         if (element_unit_hint > 1) {
-            dbgln_if(JPG_DEBUG, "{}: Unsupported unit hint in quantization table: {}!", stream.offset(), element_unit_hint);
+            dbgln_if<JPG_DEBUG>("{}: Unsupported unit hint in quantization table: {}!", stream.offset(), element_unit_hint);
             return false;
         }
         u8 table_id = info_byte & 0x0F;
         if (table_id > 1) {
-            dbgln_if(JPG_DEBUG, "{}: Unsupported quantization table id: {}!", stream.offset(), table_id);
+            dbgln_if<JPG_DEBUG>("{}: Unsupported quantization table id: {}!", stream.offset(), table_id);
             return false;
         }
         u32* table = table_id == 0 ? context.luma_table : context.chroma_table;
@@ -818,7 +818,7 @@ static bool read_quantization_table(InputMemoryStream& stream, JPGLoadingContext
         bytes_to_read -= 1 + (element_unit_hint == 0 ? 64 : 128);
     }
     if (bytes_to_read != 0) {
-        dbgln_if(JPG_DEBUG, "{}: Invalid length for one or more quantization tables!", stream.offset());
+        dbgln_if<JPG_DEBUG>("{}: Invalid length for one or more quantization tables!", stream.offset());
         return false;
     }
 
@@ -1087,7 +1087,7 @@ static bool parse_header(InputMemoryStream& stream, JPGLoadingContext& context)
     if (stream.handle_any_error())
         return false;
     if (marker != JPG_SOI) {
-        dbgln_if(JPG_DEBUG, "{}: SOI not found: {:x}!", stream.offset(), marker);
+        dbgln_if<JPG_DEBUG>("{}: SOI not found: {:x}!", stream.offset(), marker);
         return false;
     }
     for (;;) {
@@ -1115,7 +1115,7 @@ static bool parse_header(InputMemoryStream& stream, JPGLoadingContext& context)
         case JPG_RST7:
         case JPG_SOI:
         case JPG_EOI:
-            dbgln_if(JPG_DEBUG, "{}: Unexpected marker {:x}!", stream.offset(), marker);
+            dbgln_if<JPG_DEBUG>("{}: Unexpected marker {:x}!", stream.offset(), marker);
             return false;
         case JPG_SOF0:
             if (!read_start_of_frame(stream, context))
@@ -1138,7 +1138,7 @@ static bool parse_header(InputMemoryStream& stream, JPGLoadingContext& context)
             return read_start_of_scan(stream, context);
         default:
             if (!skip_marker_with_length(stream)) {
-                dbgln_if(JPG_DEBUG, "{}: Error skipping marker: {:x}!", stream.offset(), marker);
+                dbgln_if<JPG_DEBUG>("{}: Error skipping marker: {:x}!", stream.offset(), marker);
                 return false;
             }
             break;
@@ -1160,7 +1160,7 @@ static bool scan_huffman_stream(InputMemoryStream& stream, JPGLoadingContext& co
         last_byte = current_byte;
         stream >> current_byte;
         if (stream.handle_any_error()) {
-            dbgln_if(JPG_DEBUG, "{}: EOI not found!", stream.offset());
+            dbgln_if<JPG_DEBUG>("{}: EOI not found!", stream.offset());
             return false;
         }
 
@@ -1184,7 +1184,7 @@ static bool scan_huffman_stream(InputMemoryStream& stream, JPGLoadingContext& co
                     return false;
                 continue;
             }
-            dbgln_if(JPG_DEBUG, "{}: Invalid marker: {:x}!", stream.offset(), marker);
+            dbgln_if<JPG_DEBUG>("{}: Invalid marker: {:x}!", stream.offset(), marker);
             return false;
         } else {
             context.huffman_stream.stream.append(last_byte);
@@ -1205,7 +1205,7 @@ static bool decode_jpg(JPGLoadingContext& context)
 
     auto result = decode_huffman_stream(context);
     if (!result.has_value()) {
-        dbgln_if(JPG_DEBUG, "{}: Failed to decode Macroblocks!", stream.offset());
+        dbgln_if<JPG_DEBUG>("{}: Failed to decode Macroblocks!", stream.offset());
         return false;
     }
 

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -485,13 +485,13 @@ static bool decode_png_header(PNGLoadingContext& context)
         return true;
 
     if (!context.data || context.data_size < sizeof(png_header)) {
-        dbgln_if(PNG_DEBUG, "Missing PNG header");
+        dbgln_if<PNG_DEBUG>("Missing PNG header");
         context.state = PNGLoadingContext::State::Error;
         return false;
     }
 
     if (memcmp(context.data, png_header, sizeof(png_header)) != 0) {
-        dbgln_if(PNG_DEBUG, "Invalid PNG header");
+        dbgln_if<PNG_DEBUG>("Invalid PNG header");
         context.state = PNGLoadingContext::State::Error;
         return false;
     }
@@ -782,14 +782,14 @@ static bool process_IHDR(ReadonlyBytes data, PNGLoadingContext& context)
     context.filter_method = ihdr.filter_method;
     context.interlace_method = ihdr.interlace_method;
 
-    dbgln_if(PNG_DEBUG, "PNG: {}x{} ({} bpp)", context.width, context.height, context.bit_depth);
-    dbgln_if(PNG_DEBUG, "     Color type: {}", context.color_type);
-    dbgln_if(PNG_DEBUG, "Compress Method: {}", context.compression_method);
-    dbgln_if(PNG_DEBUG, "  Filter Method: {}", context.filter_method);
-    dbgln_if(PNG_DEBUG, " Interlace type: {}", context.interlace_method);
+    dbgln_if<PNG_DEBUG>("PNG: {}x{} ({} bpp)", context.width, context.height, context.bit_depth);
+    dbgln_if<PNG_DEBUG>("     Color type: {}", context.color_type);
+    dbgln_if<PNG_DEBUG>("Compress Method: {}", context.compression_method);
+    dbgln_if<PNG_DEBUG>("  Filter Method: {}", context.filter_method);
+    dbgln_if<PNG_DEBUG>(" Interlace type: {}", context.interlace_method);
 
     if (context.interlace_method != PngInterlaceMethod::Null && context.interlace_method != PngInterlaceMethod::Adam7) {
-        dbgln_if(PNG_DEBUG, "PNGLoader::process_IHDR: unknown interlace method: {}", context.interlace_method);
+        dbgln_if<PNG_DEBUG>("PNGLoader::process_IHDR: unknown interlace method: {}", context.interlace_method);
         return false;
     }
 
@@ -851,26 +851,26 @@ static bool process_chunk(Streamer& streamer, PNGLoadingContext& context)
 {
     u32 chunk_size;
     if (!streamer.read(chunk_size)) {
-        dbgln_if(PNG_DEBUG, "Bail at chunk_size");
+        dbgln_if<PNG_DEBUG>("Bail at chunk_size");
         return false;
     }
     u8 chunk_type[5];
     chunk_type[4] = '\0';
     if (!streamer.read_bytes(chunk_type, 4)) {
-        dbgln_if(PNG_DEBUG, "Bail at chunk_type");
+        dbgln_if<PNG_DEBUG>("Bail at chunk_type");
         return false;
     }
     ReadonlyBytes chunk_data;
     if (!streamer.wrap_bytes(chunk_data, chunk_size)) {
-        dbgln_if(PNG_DEBUG, "Bail at chunk_data");
+        dbgln_if<PNG_DEBUG>("Bail at chunk_data");
         return false;
     }
     u32 chunk_crc;
     if (!streamer.read(chunk_crc)) {
-        dbgln_if(PNG_DEBUG, "Bail at chunk_crc");
+        dbgln_if<PNG_DEBUG>("Bail at chunk_crc");
         return false;
     }
-    dbgln_if(PNG_DEBUG, "Chunk type: '{}', size: {}, crc: {:x}", chunk_type, chunk_size, chunk_crc);
+    dbgln_if<PNG_DEBUG>("Chunk type: '{}', size: {}, crc: {:x}", chunk_type, chunk_size, chunk_crc);
 
     if (!strcmp((const char*)chunk_type, "IHDR"))
         return process_IHDR(chunk_data, context);

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1246,7 +1246,7 @@ void Painter::draw_glyph_or_emoji(IntPoint const& point, u32 code_point, Font co
     // Perhaps it's an emoji?
     auto* emoji = Emoji::emoji_for_code_point(code_point);
     if (emoji == nullptr) {
-        dbgln_if(EMOJI_DEBUG, "Failed to find an emoji for code_point {}", code_point);
+        dbgln_if<EMOJI_DEBUG>("Failed to find an emoji for code_point {}", code_point);
         draw_glyph(point, 0xFFFD, font, color);
         return;
     }

--- a/Userland/Libraries/LibGfx/PortableImageLoaderCommon.h
+++ b/Userland/Libraries/LibGfx/PortableImageLoaderCommon.h
@@ -82,14 +82,14 @@ static bool read_magic_number(TContext& context, Streamer& streamer)
 
     if (!context.data || context.data_size < 2) {
         context.state = TContext::State::Error;
-        dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "There is no enough data for {}", TContext::image_type);
+        dbgln_if<PORTABLE_IMAGE_LOADER_DEBUG>("There is no enough data for {}", TContext::image_type);
         return false;
     }
 
     u8 magic_number[2] {};
     if (!streamer.read_bytes(magic_number, 2)) {
         context.state = TContext::State::Error;
-        dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "We can't read magic number for {}", TContext::image_type);
+        dbgln_if<PORTABLE_IMAGE_LOADER_DEBUG>("We can't read magic number for {}", TContext::image_type);
         return false;
     }
 
@@ -106,7 +106,7 @@ static bool read_magic_number(TContext& context, Streamer& streamer)
     }
 
     context.state = TContext::State::Error;
-    dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "Magic number is not valid for {}{}{}", magic_number[0], magic_number[1], TContext::image_type);
+    dbgln_if<PORTABLE_IMAGE_LOADER_DEBUG>("Magic number is not valid for {}{}{}", magic_number[0], magic_number[1], TContext::image_type);
     return false;
 }
 
@@ -164,7 +164,7 @@ static bool read_max_val(TContext& context, Streamer& streamer)
     }
 
     if (context.max_val > 255) {
-        dbgln_if(PORTABLE_IMAGE_LOADER_DEBUG, "We can't parse 2 byte color for {}", TContext::image_type);
+        dbgln_if<PORTABLE_IMAGE_LOADER_DEBUG>("We can't parse 2 byte color for {}", TContext::image_type);
         context.state = TContext::Error;
         return false;
     }

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -41,7 +41,7 @@ Interpreter::~Interpreter()
 
 Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable const& executable, BasicBlock const* entry_point)
 {
-    dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter will run unit {:p}", &executable);
+    dbgln_if<JS_BYTECODE_DEBUG>("Bytecode::Interpreter will run unit {:p}", &executable);
 
     TemporaryChange restore_executable { m_current_executable, &executable };
 
@@ -123,7 +123,7 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable const& e
             break;
     }
 
-    dbgln_if(JS_BYTECODE_DEBUG, "Bytecode::Interpreter did run unit {:p}", &executable);
+    dbgln_if<JS_BYTECODE_DEBUG>("Bytecode::Interpreter did run unit {:p}", &executable);
 
     if constexpr (JS_BYTECODE_DEBUG) {
         for (size_t i = 0; i < registers().size(); ++i) {

--- a/Userland/Libraries/LibJS/CyclicModule.cpp
+++ b/Userland/Libraries/LibJS/CyclicModule.cpp
@@ -20,7 +20,7 @@ CyclicModule::CyclicModule(Realm& realm, StringView filename, bool has_top_level
 // 16.2.1.5.1 Link ( ), https://tc39.es/ecma262/#sec-moduledeclarationlinking
 ThrowCompletionOr<void> CyclicModule::link(VM& vm)
 {
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] link[{}]()", this);
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] link[{}]()", this);
     // 1. Assert: module.[[Status]] is not linking or evaluating.
     VERIFY(m_status != ModuleStatus::Linking && m_status != ModuleStatus::Evaluating);
     // 2. Let stack be a new empty List.
@@ -67,7 +67,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
     //    b. Return index.
     // Note: Step 1, 1.a and 1.b are handled in Module.cpp
 
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] inner_module_linking[{}](vm, {}, {})", this, String::join(",", stack), index);
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] inner_module_linking[{}](vm, {}, {})", this, String::join(",", stack), index);
 
     // 2. If module.[[Status]] is linking, linked, evaluating-async, or evaluated, then
     if (m_status == ModuleStatus::Linking || m_status == ModuleStatus::Linked || m_status == ModuleStatus::EvaluatingAsync || m_status == ModuleStatus::Evaluated) {
@@ -99,7 +99,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
         request_module_names.append(module_request.module_specifier);
         request_module_names.append(", ");
     }
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] module: {} has requested modules: [{}]", filename(), request_module_names.string_view());
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] module: {} has requested modules: [{}]", filename(), request_module_names.string_view());
 #endif
 
     // 9. For each String required of module.[[RequestedModules]], do
@@ -143,7 +143,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
     // 12. Assert: module.[[DFSAncestorIndex]] ≤ module.[[DFSIndex]].
     VERIFY(m_dfs_ancestor_index.value() <= m_dfs_index.value());
 
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] module {} after inner_linking has dfs {} and ancestor dfs {}", filename(), m_dfs_index.value(), m_dfs_ancestor_index.value());
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] module {} after inner_linking has dfs {} and ancestor dfs {}", filename(), m_dfs_index.value(), m_dfs_ancestor_index.value());
 
     // 13. If module.[[DFSAncestorIndex]] = module.[[DFSIndex]], then
     if (m_dfs_ancestor_index == m_dfs_index) {
@@ -173,7 +173,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_linking(VM& vm, Vector<Module*
 // 16.2.1.5.2 Evaluate ( ), https://tc39.es/ecma262/#sec-moduleevaluation
 ThrowCompletionOr<Promise*> CyclicModule::evaluate(VM& vm)
 {
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] evaluate[{}](vm)", this);
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] evaluate[{}](vm)", this);
     // 1. Assert: This call to Evaluate is not happening at the same time as another call to Evaluate within the surrounding agent.
     // FIXME: Verify this somehow
 
@@ -184,7 +184,7 @@ ThrowCompletionOr<Promise*> CyclicModule::evaluate(VM& vm)
     if (m_status == ModuleStatus::EvaluatingAsync || m_status == ModuleStatus::Evaluated) {
         // Note: This will continue this function with module.[[CycleRoot]]
         VERIFY(m_cycle_root && m_cycle_root->m_status == ModuleStatus::Linked && this != m_cycle_root);
-        dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] evaluate[{}](vm) deferring to cycle root at {}", this, m_cycle_root);
+        dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] evaluate[{}](vm) deferring to cycle root at {}", this, m_cycle_root);
         return m_cycle_root->evaluate(vm);
     }
 
@@ -268,7 +268,7 @@ ThrowCompletionOr<Promise*> CyclicModule::evaluate(VM& vm)
 // 16.2.1.5.2.1 InnerModuleEvaluation ( module, stack, index ), https://tc39.es/ecma262/#sec-innermoduleevaluation
 ThrowCompletionOr<u32> CyclicModule::inner_module_evaluation(VM& vm, Vector<Module*>& stack, u32 index)
 {
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] inner_module_evaluation[{}](vm, {}, {})", this, String::join(", ", stack), index);
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] inner_module_evaluation[{}](vm, {}, {})", this, String::join(", ", stack), index);
     // Note: Step 1 is performed in Module.cpp
 
     // 2. If module.[[Status]] is evaluating-async or evaluated, then
@@ -355,7 +355,7 @@ ThrowCompletionOr<u32> CyclicModule::inner_module_evaluation(VM& vm, Vector<Modu
         }
     }
 
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] inner_module_evaluation on {} has tla: {} and pending async dep: {} dfs: {} ancestor dfs: {}", filename(), m_has_top_level_await, m_pending_async_dependencies.value(), m_dfs_index.value(), m_dfs_ancestor_index.value());
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] inner_module_evaluation on {} has tla: {} and pending async dep: {} dfs: {} ancestor dfs: {}", filename(), m_has_top_level_await, m_pending_async_dependencies.value(), m_dfs_index.value(), m_dfs_ancestor_index.value());
     // 12. If module.[[PendingAsyncDependencies]] > 0 or module.[[HasTLA]] is true, then
     if (m_pending_async_dependencies.value() > 0 || m_has_top_level_await) {
         // a. Assert: module.[[AsyncEvaluation]] is false and was never previously set to true.
@@ -440,7 +440,7 @@ Completion CyclicModule::execute_module(VM&, Optional<PromiseCapability>)
 // 16.2.1.5.2.2 ExecuteAsyncModule ( module ), https://tc39.es/ecma262/#sec-execute-async-module
 ThrowCompletionOr<void> CyclicModule::execute_async_module(VM& vm)
 {
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] executing async module {}", filename());
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] executing async module {}", filename());
     // 1. Assert: module.[[Status]] is evaluating or evaluating-async.
     VERIFY(m_status == ModuleStatus::Evaluating || m_status == ModuleStatus::EvaluatingAsync);
     // 2. Assert: module.[[HasTLA]] is true.

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -136,7 +136,7 @@ __attribute__((no_sanitize("address"))) void Heap::gather_conservative_roots(Has
 {
     FlatPtr dummy;
 
-    dbgln_if(HEAP_DEBUG, "gather_conservative_roots:");
+    dbgln_if<HEAP_DEBUG>("gather_conservative_roots:");
 
     jmp_buf buf;
     setjmp(buf);
@@ -165,15 +165,15 @@ __attribute__((no_sanitize("address"))) void Heap::gather_conservative_roots(Has
     for (auto possible_pointer : possible_pointers) {
         if (!possible_pointer)
             continue;
-        dbgln_if(HEAP_DEBUG, "  ? {}", (const void*)possible_pointer);
+        dbgln_if<HEAP_DEBUG>("  ? {}", (const void*)possible_pointer);
         auto* possible_heap_block = HeapBlock::from_cell(reinterpret_cast<const Cell*>(possible_pointer));
         if (all_live_heap_blocks.contains(possible_heap_block)) {
             if (auto* cell = possible_heap_block->cell_from_possible_pointer(possible_pointer)) {
                 if (cell->state() == Cell::State::Live) {
-                    dbgln_if(HEAP_DEBUG, "  ?-> {}", (const void*)cell);
+                    dbgln_if<HEAP_DEBUG>("  ?-> {}", (const void*)cell);
                     roots.set(cell);
                 } else {
-                    dbgln_if(HEAP_DEBUG, "  #-> {}", (const void*)cell);
+                    dbgln_if<HEAP_DEBUG>("  #-> {}", (const void*)cell);
                 }
             }
         }
@@ -188,7 +188,7 @@ public:
     {
         if (cell.is_marked())
             return;
-        dbgln_if(HEAP_DEBUG, "  ! {}", &cell);
+        dbgln_if<HEAP_DEBUG>("  ! {}", &cell);
 
         cell.set_marked(true);
         cell.visit_edges(*this);
@@ -197,7 +197,7 @@ public:
 
 void Heap::mark_live_cells(const HashTable<Cell*>& roots)
 {
-    dbgln_if(HEAP_DEBUG, "mark_live_cells:");
+    dbgln_if<HEAP_DEBUG>("mark_live_cells:");
 
     MarkingVisitor visitor;
     for (auto* root : roots)
@@ -211,7 +211,7 @@ void Heap::mark_live_cells(const HashTable<Cell*>& roots)
 
 void Heap::sweep_dead_cells(bool print_report, const Core::ElapsedTimer& measurement_timer)
 {
-    dbgln_if(HEAP_DEBUG, "sweep_dead_cells:");
+    dbgln_if<HEAP_DEBUG>("sweep_dead_cells:");
     Vector<HeapBlock*, 32> empty_blocks;
     Vector<HeapBlock*, 32> full_blocks_that_became_usable;
 
@@ -225,7 +225,7 @@ void Heap::sweep_dead_cells(bool print_report, const Core::ElapsedTimer& measure
         bool block_was_full = block.is_full();
         block.template for_each_cell_in_state<Cell::State::Live>([&](Cell* cell) {
             if (!cell->is_marked()) {
-                dbgln_if(HEAP_DEBUG, "  ~ {}", cell);
+                dbgln_if<HEAP_DEBUG>("  ~ {}", cell);
                 block.deallocate(cell);
                 ++collected_cells;
                 collected_cell_bytes += block.cell_size();
@@ -247,12 +247,12 @@ void Heap::sweep_dead_cells(bool print_report, const Core::ElapsedTimer& measure
         weak_container.remove_dead_cells({});
 
     for (auto* block : empty_blocks) {
-        dbgln_if(HEAP_DEBUG, " - HeapBlock empty @ {}: cell_size={}", block, block->cell_size());
+        dbgln_if<HEAP_DEBUG>(" - HeapBlock empty @ {}: cell_size={}", block, block->cell_size());
         allocator_for_size(block->cell_size()).block_did_become_empty({}, *block);
     }
 
     for (auto* block : full_blocks_that_became_usable) {
-        dbgln_if(HEAP_DEBUG, " - HeapBlock usable again @ {}: cell_size={}", block, block->cell_size());
+        dbgln_if<HEAP_DEBUG>(" - HeapBlock usable again @ {}: cell_size={}", block, block->cell_size());
         allocator_for_size(block->cell_size()).block_did_become_usable({}, *block);
     }
 

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -187,9 +187,9 @@ void Lexer::consume()
         if (!second_char_of_crlf) {
             m_line_number++;
             m_line_column = 1;
-            dbgln_if(LEXER_DEBUG, "Incremented line number, now at: line {}, column 1", m_line_number);
+            dbgln_if<LEXER_DEBUG>("Incremented line number, now at: line {}, column 1", m_line_number);
         } else {
-            dbgln_if(LEXER_DEBUG, "Previous was CR, this is LF - not incrementing line number again.");
+            dbgln_if<LEXER_DEBUG>("Previous was CR, this is LF - not incrementing line number again.");
         }
     } else if (is_unicode_character()) {
         size_t char_size = 1;

--- a/Userland/Libraries/LibJS/Runtime/Promise.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Promise.cpp
@@ -57,7 +57,7 @@ Promise::Promise(Object& prototype)
 // 27.2.1.3 CreateResolvingFunctions ( promise ), https://tc39.es/ecma262/#sec-createresolvingfunctions
 Promise::ResolvingFunctions Promise::create_resolving_functions()
 {
-    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / create_resolving_functions()]", this);
+    dbgln_if<PROMISE_DEBUG>("[Promise @ {} / create_resolving_functions()]", this);
     auto& vm = this->vm();
 
     // 1. Let alreadyResolved be the Record { [[Value]]: false }.
@@ -71,7 +71,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
 
     // 27.2.1.3.2 Promise Resolve Functions, https://tc39.es/ecma262/#sec-promise-resolve-functions
     auto* resolve_function = PromiseResolvingFunction::create(global_object(), *this, *already_resolved, [](auto& vm, auto& global_object, auto& promise, auto& already_resolved) {
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Resolve function was called", &promise);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Resolve function was called", &promise);
 
         auto resolution = vm.argument(0);
 
@@ -82,7 +82,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
         // 4. Let alreadyResolved be F.[[AlreadyResolved]].
         // 5. If alreadyResolved.[[Value]] is true, return undefined.
         if (already_resolved.value) {
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Promise is already resolved, returning undefined", &promise);
+            dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Promise is already resolved, returning undefined", &promise);
             return js_undefined();
         }
 
@@ -91,7 +91,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
 
         // 7. If SameValue(resolution, promise) is true, then
         if (resolution.is_object() && &resolution.as_object() == &promise) {
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Promise can't be resolved with itself, rejecting with error", &promise);
+            dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Promise can't be resolved with itself, rejecting with error", &promise);
 
             // a. Let selfResolutionError be a newly created TypeError object.
             auto* self_resolution_error = TypeError::create(global_object, "Cannot resolve promise with itself");
@@ -103,7 +103,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
         // 8. If Type(resolution) is not Object, then
         if (!resolution.is_object()) {
             // a. Return FulfillPromise(promise, resolution).
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Resolution is not an object, fulfilling with {}", &promise, resolution);
+            dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Resolution is not an object, fulfilling with {}", &promise, resolution);
             return promise.fulfill(resolution);
         }
 
@@ -113,7 +113,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
         // 10. If then is an abrupt completion, then
         if (then.is_throw_completion()) {
             // a. Return RejectPromise(promise, then.[[Value]]).
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Exception while getting 'then' property, rejecting with error", &promise);
+            dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Exception while getting 'then' property, rejecting with error", &promise);
             vm.clear_exception();
             return promise.reject(*then.throw_completion().value());
         }
@@ -124,20 +124,20 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
         // 12. If IsCallable(thenAction) is false, then
         if (!then_action.is_function()) {
             // a. Return FulfillPromise(promise, resolution).
-            dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Then action is not a function, fulfilling with {}", &promise, resolution);
+            dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Then action is not a function, fulfilling with {}", &promise, resolution);
             return promise.fulfill(resolution);
         }
 
         // 13. Let thenJobCallback be HostMakeJobCallback(thenAction).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Creating JobCallback for then action @ {}", &promise, &then_action.as_function());
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Creating JobCallback for then action @ {}", &promise, &then_action.as_function());
         auto then_job_callback = make_job_callback(then_action.as_function());
 
         // 14. Let job be NewPromiseResolveThenableJob(promise, resolution, thenJobCallback).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Creating PromiseResolveThenableJob for thenable {}", &promise, resolution);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Creating PromiseResolveThenableJob for thenable {}", &promise, resolution);
         auto* job = PromiseResolveThenableJob::create(global_object, promise, resolution, then_job_callback);
 
         // 15. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Enqueuing job @ {}", &promise, job);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Enqueuing job @ {}", &promise, job);
         vm.enqueue_promise_job(*job);
 
         // 16. Return undefined.
@@ -153,7 +153,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
 
     // 27.2.1.3.1 Promise Reject Functions, https://tc39.es/ecma262/#sec-promise-reject-functions
     auto* reject_function = PromiseResolvingFunction::create(global_object(), *this, *already_resolved, [](auto& vm, auto&, auto& promise, auto& already_resolved) {
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / PromiseResolvingFunction]: Reject function was called", &promise);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / PromiseResolvingFunction]: Reject function was called", &promise);
 
         auto reason = vm.argument(0);
 
@@ -181,7 +181,7 @@ Promise::ResolvingFunctions Promise::create_resolving_functions()
 // 27.2.1.4 FulfillPromise ( promise, value ), https://tc39.es/ecma262/#sec-fulfillpromise
 Value Promise::fulfill(Value value)
 {
-    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / fulfill()]: Fulfilling promise with value {}", this, value);
+    dbgln_if<PROMISE_DEBUG>("[Promise @ {} / fulfill()]: Fulfilling promise with value {}", this, value);
 
     // 1. Assert: The value of promise.[[PromiseState]] is pending.
     VERIFY(m_state == State::Pending);
@@ -210,7 +210,7 @@ Value Promise::fulfill(Value value)
 Value Promise::reject(Value reason)
 {
 
-    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / reject()]: Rejecting promise with reason {}", this, reason);
+    dbgln_if<PROMISE_DEBUG>("[Promise @ {} / reject()]: Rejecting promise with reason {}", this, reason);
     auto& vm = this->vm();
 
     // 1. Assert: The value of promise.[[PromiseState]] is pending.
@@ -252,11 +252,11 @@ void Promise::trigger_reactions() const
     // 1. For each element reaction of reactions, do
     for (auto& reaction : reactions) {
         // a. Let job be NewPromiseReactionJob(reaction, argument).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / trigger_reactions()]: Creating PromiseReactionJob for PromiseReaction @ {} with argument {}", this, &reaction, m_result);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / trigger_reactions()]: Creating PromiseReactionJob for PromiseReaction @ {} with argument {}", this, &reaction, m_result);
         auto* job = PromiseReactionJob::create(global_object(), *reaction, m_result);
 
         // b. Perform HostEnqueuePromiseJob(job.[[Job]], job.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / trigger_reactions()]: Enqueuing job @ {}", this, job);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / trigger_reactions()]: Enqueuing job @ {}", this, job);
         vm.enqueue_promise_job(*job);
     }
 
@@ -284,7 +284,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, Optional<Prom
     // 4. Else,
     if (on_fulfilled.is_function()) {
         // a. Let onFulfilledJobCallback be HostMakeJobCallback(onFulfilled).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Creating JobCallback for on_fulfilled function @ {}", this, &on_fulfilled.as_function());
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: Creating JobCallback for on_fulfilled function @ {}", this, &on_fulfilled.as_function());
         on_fulfilled_job_callback = make_job_callback(on_fulfilled.as_function());
     }
 
@@ -295,7 +295,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, Optional<Prom
     // 6. Else,
     if (on_rejected.is_function()) {
         // a. Let onRejectedJobCallback be HostMakeJobCallback(onRejected).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Creating JobCallback for on_rejected function @ {}", this, &on_rejected.as_function());
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: Creating JobCallback for on_rejected function @ {}", this, &on_rejected.as_function());
         on_rejected_job_callback = make_job_callback(on_rejected.as_function());
     }
 
@@ -308,7 +308,7 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, Optional<Prom
     switch (m_state) {
     // 9. If promise.[[PromiseState]] is pending, then
     case Promise::State::Pending:
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: state is State::Pending, adding fulfill/reject reactions", this);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: state is State::Pending, adding fulfill/reject reactions", this);
 
         // a. Append fulfillReaction as the last element of the List that is promise.[[PromiseFulfillReactions]].
         m_fulfill_reactions.append(fulfill_reaction);
@@ -322,11 +322,11 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, Optional<Prom
         auto value = m_result;
 
         // b. Let fulfillJob be NewPromiseReactionJob(fulfillReaction, value).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: State is State::Fulfilled, creating PromiseReactionJob for PromiseReaction @ {} with argument {}", this, fulfill_reaction, value);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: State is State::Fulfilled, creating PromiseReactionJob for PromiseReaction @ {} with argument {}", this, fulfill_reaction, value);
         auto* fulfill_job = PromiseReactionJob::create(global_object(), *fulfill_reaction, value);
 
         // c. Perform HostEnqueuePromiseJob(fulfillJob.[[Job]], fulfillJob.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Enqueuing job @ {}", this, fulfill_job);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: Enqueuing job @ {}", this, fulfill_job);
         vm.enqueue_promise_job(*fulfill_job);
         break;
     }
@@ -342,11 +342,11 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, Optional<Prom
             vm.promise_rejection_tracker(*this, RejectionOperation::Handle);
 
         // d. Let rejectJob be NewPromiseReactionJob(rejectReaction, reason).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: State is State::Rejected, creating PromiseReactionJob for PromiseReaction @ {} with argument {}", this, reject_reaction, reason);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: State is State::Rejected, creating PromiseReactionJob for PromiseReaction @ {} with argument {}", this, reject_reaction, reason);
         auto* reject_job = PromiseReactionJob::create(global_object(), *reject_reaction, reason);
 
         // e. Perform HostEnqueuePromiseJob(rejectJob.[[Job]], rejectJob.[[Realm]]).
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Enqueuing job @ {}", this, reject_job);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: Enqueuing job @ {}", this, reject_job);
         vm.enqueue_promise_job(*reject_job);
         break;
     }
@@ -360,14 +360,14 @@ Value Promise::perform_then(Value on_fulfilled, Value on_rejected, Optional<Prom
     // 13. If resultCapability is undefined, then
     if (!result_capability.has_value()) {
         // a. Return undefined.
-        dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: No ResultCapability, returning undefined", this);
+        dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: No ResultCapability, returning undefined", this);
         return js_undefined();
     }
 
     // 14. Else,
     //     a. Return resultCapability.[[Promise]].
     auto* promise = result_capability.value().promise;
-    dbgln_if(PROMISE_DEBUG, "[Promise @ {} / perform_then()]: Returning Promise @ {} from ResultCapability @ {}", this, promise, &result_capability.value());
+    dbgln_if<PROMISE_DEBUG>("[Promise @ {} / perform_then()]: Returning Promise @ {} from ResultCapability @ {}", this, promise, &result_capability.value());
     return promise;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/PromiseJobs.cpp
+++ b/Userland/Libraries/LibJS/Runtime/PromiseJobs.cpp
@@ -44,11 +44,11 @@ ThrowCompletionOr<Value> PromiseReactionJob::call()
 
     // d. If handler is empty, then
     if (!handler.has_value()) {
-        dbgln_if(PROMISE_DEBUG, "[PromiseReactionJob @ {}]: Handler is empty", this);
+        dbgln_if<PROMISE_DEBUG>("[PromiseReactionJob @ {}]: Handler is empty", this);
 
         // i. If type is Fulfill, let handlerResult be NormalCompletion(argument).
         if (type == PromiseReaction::Type::Fulfill) {
-            dbgln_if(PROMISE_DEBUG, "[PromiseReactionJob @ {}]: Reaction type is Type::Fulfill, setting handler result to {}", this, m_argument);
+            dbgln_if<PROMISE_DEBUG>("[PromiseReactionJob @ {}]: Reaction type is Type::Fulfill, setting handler result to {}", this, m_argument);
             handler_result = normal_completion(m_argument);
         }
         // ii. Else,
@@ -57,13 +57,13 @@ ThrowCompletionOr<Value> PromiseReactionJob::call()
             VERIFY(type == PromiseReaction::Type::Reject);
 
             // 2. Let handlerResult be ThrowCompletion(argument).
-            dbgln_if(PROMISE_DEBUG, "[PromiseReactionJob @ {}]: Reaction type is Type::Reject, throwing exception with argument {}", this, m_argument);
+            dbgln_if<PROMISE_DEBUG>("[PromiseReactionJob @ {}]: Reaction type is Type::Reject, throwing exception with argument {}", this, m_argument);
             handler_result = throw_completion(m_argument);
         }
     }
     // e. Else, let handlerResult be HostCallJobCallback(handler, undefined, « argument »).
     else {
-        dbgln_if(PROMISE_DEBUG, "[PromiseReactionJob @ {}]: Calling handler callback {} @ {} with argument {}", this, handler.value().callback->class_name(), handler.value().callback, m_argument);
+        dbgln_if<PROMISE_DEBUG>("[PromiseReactionJob @ {}]: Calling handler callback {} @ {} with argument {}", this, handler.value().callback->class_name(), handler.value().callback, m_argument);
         handler_result = call_job_callback(global_object, handler.value(), js_undefined(), m_argument);
     }
 
@@ -73,7 +73,7 @@ ThrowCompletionOr<Value> PromiseReactionJob::call()
         VERIFY(!vm.exception());
 
         // ii. Return NormalCompletion(empty).
-        dbgln_if(PROMISE_DEBUG, "[PromiseReactionJob @ {}]: Reaction has no PromiseCapability, returning empty value", this);
+        dbgln_if<PROMISE_DEBUG>("[PromiseReactionJob @ {}]: Reaction has no PromiseCapability, returning empty value", this);
         // TODO: This can't return an empty value at the moment, because the implicit conversion to Completion would fail.
         //       Change it back when this is using completions (`return normal_completion({})`)
         return js_undefined();
@@ -87,14 +87,14 @@ ThrowCompletionOr<Value> PromiseReactionJob::call()
 
         // i. Let status be Call(promiseCapability.[[Reject]], undefined, « handlerResult.[[Value]] »).
         auto* reject_function = promise_capability.value().reject;
-        dbgln_if(PROMISE_DEBUG, "[PromiseReactionJob @ {}]: Calling PromiseCapability's reject function @ {}", this, reject_function);
+        dbgln_if<PROMISE_DEBUG>("[PromiseReactionJob @ {}]: Calling PromiseCapability's reject function @ {}", this, reject_function);
         return JS::call(global_object, *reject_function, js_undefined(), *handler_result.value());
     }
     // i. Else,
     else {
         // i. Let status be Call(promiseCapability.[[Resolve]], undefined, « handlerResult.[[Value]] »).
         auto* resolve_function = promise_capability.value().resolve;
-        dbgln_if(PROMISE_DEBUG, "[PromiseReactionJob @ {}]: Calling PromiseCapability's resolve function @ {}", this, resolve_function);
+        dbgln_if<PROMISE_DEBUG>("[PromiseReactionJob @ {}]: Calling PromiseCapability's resolve function @ {}", this, resolve_function);
         return JS::call(global_object, *resolve_function, js_undefined(), *handler_result.value());
     }
 
@@ -132,7 +132,7 @@ ThrowCompletionOr<Value> PromiseResolveThenableJob::call()
     auto [resolve_function, reject_function] = m_promise_to_resolve.create_resolving_functions();
 
     // b. Let thenCallResult be HostCallJobCallback(then, thenable, « resolvingFunctions.[[Resolve]], resolvingFunctions.[[Reject]] »).
-    dbgln_if(PROMISE_DEBUG, "[PromiseResolveThenableJob @ {}]: Calling then job callback for thenable {}", this, &m_thenable);
+    dbgln_if<PROMISE_DEBUG>("[PromiseResolveThenableJob @ {}]: Calling then job callback for thenable {}", this, &m_thenable);
     auto then_call_result = call_job_callback(global_object, m_then, m_thenable, &resolve_function, &reject_function);
 
     // c. If thenCallResult is an abrupt completion, then
@@ -140,7 +140,7 @@ ThrowCompletionOr<Value> PromiseResolveThenableJob::call()
         vm.clear_exception();
 
         // i. Let status be Call(resolvingFunctions.[[Reject]], undefined, « thenCallResult.[[Value]] »).
-        dbgln_if(PROMISE_DEBUG, "[PromiseResolveThenableJob @ {}]: then_call_result is an abrupt completion, calling reject function with value {}", this, *then_call_result.throw_completion().value());
+        dbgln_if<PROMISE_DEBUG>("[PromiseResolveThenableJob @ {}]: then_call_result is an abrupt completion, calling reject function with value {}", this, *then_call_result.throw_completion().value());
         auto status = JS::call(global_object, &reject_function, js_undefined(), *then_call_result.throw_completion().value());
 
         // ii. Return Completion(status).
@@ -148,7 +148,7 @@ ThrowCompletionOr<Value> PromiseResolveThenableJob::call()
     }
 
     // d. Return Completion(thenCallResult).
-    dbgln_if(PROMISE_DEBUG, "[PromiseResolveThenableJob @ {}]: Returning then call result {}", this, then_call_result.value());
+    dbgln_if<PROMISE_DEBUG>("[PromiseResolveThenableJob @ {}]: Returning then call result {}", this, then_call_result.value());
     return then_call_result;
 }
 

--- a/Userland/Libraries/LibJS/SourceTextModule.cpp
+++ b/Userland/Libraries/LibJS/SourceTextModule.cpp
@@ -240,7 +240,7 @@ Result<NonnullRefPtr<SourceTextModule>, Vector<Parser::Error>> SourceTextModule:
 // 16.2.1.6.2 GetExportedNames ( [ exportStarSet ] ), https://tc39.es/ecma262/#sec-getexportednames
 ThrowCompletionOr<Vector<FlyString>> SourceTextModule::get_exported_names(VM& vm, Vector<Module*> export_star_set)
 {
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] get_export_names of {}", filename());
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] get_export_names of {}", filename());
     // 1. If exportStarSet is not present, set exportStarSet to a new empty List.
     // Note: This is done by default argument
 
@@ -476,7 +476,7 @@ Completion SourceTextModule::initialize_environment(VM& vm)
         auto const& statement = m_default_export->statement();
         if (!is<Declaration>(statement)) {
             auto const& name = m_default_export->entries()[0].local_or_import_name;
-            dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] Adding default export to lexical declarations: local name: {}, Expression: {}", name, statement.class_name());
+            dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] Adding default export to lexical declarations: local name: {}, Expression: {}", name, statement.class_name());
 
             // 1. Perform ! env.CreateMutableBinding(dn, false).
             MUST(environment->create_mutable_binding(global_object, name, false));
@@ -624,7 +624,7 @@ ThrowCompletionOr<ResolvedBinding> SourceTextModule::resolve_export(VM& vm, FlyS
 // 16.2.1.6.5 ExecuteModule ( [ capability ] ), https://tc39.es/ecma262/#sec-source-text-module-record-execute-module
 Completion SourceTextModule::execute_module(VM& vm, Optional<PromiseCapability> capability)
 {
-    dbgln_if(JS_MODULE_DEBUG, "[JS MODULE] SourceTextModule::execute_module({}, capability has value: {})", filename(), capability.has_value());
+    dbgln_if<JS_MODULE_DEBUG>("[JS MODULE] SourceTextModule::execute_module({}, capability has value: {})", filename(), capability.has_value());
 
     // 1. Let moduleContext be a new ECMAScript code execution context.
     ExecutionContext module_context { vm.heap() };

--- a/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -84,7 +84,7 @@ void SyntaxHighlighter::rehighlight(const Palette& palette)
         span.data = static_cast<u64>(type);
         spans.append(span);
 
-        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{}{} @ '{}' {}:{} - {}:{}",
+        dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("{}{} @ '{}' {}:{} - {}:{}",
             token.name(),
             is_trivia ? " (trivia)" : "",
             token.value(),

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -2049,7 +2049,7 @@ bool Editor::Spans::contains_up_to_offset(Spans const& other, size_t offset) con
                     }
                     return false;
                 } else if (value_it->value != left_entry.value) {
-                    dbgln_if(LINE_EDITOR_DEBUG, "Compare for {}-{} failed, different values: {} != {}", entry.key, left_entry.key, value_it->value.to_string(), left_entry.value.to_string());
+                    dbgln_if<LINE_EDITOR_DEBUG>("Compare for {}-{} failed, different values: {} != {}", entry.key, left_entry.key, value_it->value.to_string(), left_entry.value.to_string());
                     return false;
                 }
             }

--- a/Userland/Libraries/LibLine/KeyCallbackMachine.cpp
+++ b/Userland/Libraries/LibLine/KeyCallbackMachine.cpp
@@ -20,7 +20,7 @@ void KeyCallbackMachine::register_key_input_callback(Vector<Key> keys, Function<
 
 void KeyCallbackMachine::key_pressed(Editor& editor, Key key)
 {
-    dbgln_if(CALLBACK_MACHINE_DEBUG, "Key<{}, {}> pressed, seq_length={}, {} things in the matching vector", key.key, key.modifiers, m_sequence_length, m_current_matching_keys.size());
+    dbgln_if<CALLBACK_MACHINE_DEBUG>("Key<{}, {}> pressed, seq_length={}, {} things in the matching vector", key.key, key.modifiers, m_sequence_length, m_current_matching_keys.size());
     if (m_sequence_length == 0) {
         VERIFY(m_current_matching_keys.is_empty());
 

--- a/Userland/Libraries/LibMarkdown/Table.cpp
+++ b/Userland/Libraries/LibMarkdown/Table.cpp
@@ -189,7 +189,7 @@ OwnPtr<Table> Table::parse(LineIterator& lines)
         size_t relative_width = delimiter.length();
         for (auto ch : delimiter) {
             if (ch != '-') {
-                dbgln_if(MARKDOWN_DEBUG, "Invalid character _{}_ in table heading delimiter (ignored)", ch);
+                dbgln_if<MARKDOWN_DEBUG>("Invalid character _{}_ in table heading delimiter (ignored)", ch);
                 --relative_width;
             }
         }

--- a/Userland/Libraries/LibPthread/pthread.cpp
+++ b/Userland/Libraries/LibPthread/pthread.cpp
@@ -125,7 +125,7 @@ int pthread_create(pthread_t* thread, pthread_attr_t* attributes, void* (*start_
             return -1;
     }
 
-    dbgln_if(PTHREAD_DEBUG, "pthread_create: Creating thread with attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
+    dbgln_if<PTHREAD_DEBUG>("pthread_create: Creating thread with attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         used_attributes,
         (PTHREAD_CREATE_JOINABLE == used_attributes->detach_state) ? "joinable" : "detached",
         used_attributes->schedule_priority,
@@ -249,7 +249,7 @@ int pthread_attr_init(pthread_attr_t* attributes)
     auto* impl = new PthreadAttrImpl {};
     *attributes = impl;
 
-    dbgln_if(PTHREAD_DEBUG, "pthread_attr_init: New thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
+    dbgln_if<PTHREAD_DEBUG>("pthread_attr_init: New thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         impl,
         (PTHREAD_CREATE_JOINABLE == impl->detach_state) ? "joinable" : "detached",
         impl->schedule_priority,
@@ -293,7 +293,7 @@ int pthread_attr_setdetachstate(pthread_attr_t* attributes, int detach_state)
 
     attributes_impl->detach_state = detach_state;
 
-    dbgln_if(PTHREAD_DEBUG, "pthread_attr_setdetachstate: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
+    dbgln_if<PTHREAD_DEBUG>("pthread_attr_setdetachstate: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
         (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
         attributes_impl->schedule_priority,
@@ -337,7 +337,7 @@ int pthread_attr_setguardsize(pthread_attr_t* attributes, size_t guard_size)
     attributes_impl->guard_page_size = actual_guard_size;
     attributes_impl->reported_guard_page_size = guard_size; // POSIX, why?
 
-    dbgln_if(PTHREAD_DEBUG, "pthread_attr_setguardsize: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
+    dbgln_if<PTHREAD_DEBUG>("pthread_attr_setguardsize: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
         (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
         attributes_impl->schedule_priority,
@@ -372,7 +372,7 @@ int pthread_attr_setschedparam(pthread_attr_t* attributes, const struct sched_pa
 
     attributes_impl->schedule_priority = p_sched_param->sched_priority;
 
-    dbgln_if(PTHREAD_DEBUG, "pthread_attr_setschedparam: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
+    dbgln_if<PTHREAD_DEBUG>("pthread_attr_setschedparam: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
         (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
         attributes_impl->schedule_priority,
@@ -417,7 +417,7 @@ int pthread_attr_setstack(pthread_attr_t* attributes, void* p_stack, size_t stac
     attributes_impl->stack_size = stack_size;
     attributes_impl->stack_location = p_stack;
 
-    dbgln_if(PTHREAD_DEBUG, "pthread_attr_setstack: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
+    dbgln_if<PTHREAD_DEBUG>("pthread_attr_setstack: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
         (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
         attributes_impl->schedule_priority,
@@ -453,7 +453,7 @@ int pthread_attr_setstacksize(pthread_attr_t* attributes, size_t stack_size)
 
     attributes_impl->stack_size = stack_size;
 
-    dbgln_if(PTHREAD_DEBUG, "pthread_attr_setstacksize: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
+    dbgln_if<PTHREAD_DEBUG>("pthread_attr_setstacksize: Thread attributes at {}, detach state {}, priority {}, guard page size {}, stack size {}, stack location {}",
         attributes_impl,
         (PTHREAD_CREATE_JOINABLE == attributes_impl->detach_state) ? "joinable" : "detached",
         attributes_impl->schedule_priority,

--- a/Userland/Libraries/LibRegex/RegexLexer.cpp
+++ b/Userland/Libraries/LibRegex/RegexLexer.cpp
@@ -104,7 +104,7 @@ Token Lexer::next()
         case '\\':
             return 2;
         default:
-            dbgln_if(REGEX_DEBUG, "[LEXER] Found invalid escape sequence: \\{:c} (the parser will have to deal with this!)", peek(1));
+            dbgln_if<REGEX_DEBUG>("[LEXER] Found invalid escape sequence: \\{:c} (the parser will have to deal with this!)", peek(1));
             return 0;
         }
     };

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -137,7 +137,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
 
     if (input.regex_options.has_flag_set(AllFlags::Internal_Stateful)) {
         if (views.size() > 1 && input.start_offset > views.first().length()) {
-            dbgln_if(REGEX_DEBUG, "Started with start={}, goff={}, skip={}", input.start_offset, input.global_offset, lines_to_skip);
+            dbgln_if<REGEX_DEBUG>("Started with start={}, goff={}, skip={}", input.start_offset, input.global_offset, lines_to_skip);
             for (auto const& view : views) {
                 if (input.start_offset < view.length() + 1)
                     break;
@@ -145,7 +145,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
                 input.start_offset -= view.length() + 1;
                 input.global_offset += view.length() + 1;
             }
-            dbgln_if(REGEX_DEBUG, "Ended with start={}, goff={}, skip={}", input.start_offset, input.global_offset, lines_to_skip);
+            dbgln_if<REGEX_DEBUG>("Ended with start={}, goff={}, skip={}", input.start_offset, input.global_offset, lines_to_skip);
         }
     }
 
@@ -192,7 +192,7 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
             continue;
         }
         input.view = view;
-        dbgln_if(REGEX_DEBUG, "[match] Starting match with view ({}): _{}_", view.length(), view);
+        dbgln_if<REGEX_DEBUG>("[match] Starting match with view ({}): _{}_", view.length(), view);
 
         auto view_length = view.length();
         size_t view_index = m_pattern->start_offset;
@@ -263,8 +263,8 @@ RegexResult Matcher<Parser>::match(Vector<RegexStringView> const& views, Optiona
                     continue;
                 }
 
-                dbgln_if(REGEX_DEBUG, "state.string_position={}, view_index={}", state.string_position, view_index);
-                dbgln_if(REGEX_DEBUG, "[match] Found a match (length={}): '{}'", state.string_position - view_index, input.view.substring_view(view_index, state.string_position - view_index));
+                dbgln_if<REGEX_DEBUG>("state.string_position={}, view_index={}", state.string_position, view_index);
+                dbgln_if<REGEX_DEBUG>("[match] Found a match (length={}): '{}'", state.string_position - view_index, input.view.substring_view(view_index, state.string_position - view_index));
 
                 ++match_count;
 

--- a/Userland/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Userland/Libraries/LibRegex/RegexOptimizer.cpp
@@ -147,8 +147,8 @@ static AtomicRewritePreconditionResult block_satisfies_atomic_rewrite_preconditi
 
         state.instruction_position += opcode.size();
     }
-    dbgln_if(REGEX_DEBUG, "Found {} entries in reference", repeated_values.size());
-    dbgln_if(REGEX_DEBUG, "Found {} active capture groups", active_capture_groups.size());
+    dbgln_if<REGEX_DEBUG>("Found {} entries in reference", repeated_values.size());
+    dbgln_if<REGEX_DEBUG>("Found {} active capture groups", active_capture_groups.size());
 
     bool following_block_has_at_least_one_compare = false;
     // Find the first compare in the following block, it must NOT match any of the values in `repeated_values'.
@@ -341,9 +341,9 @@ void Regex<Parser>::attempt_rewrite_loops_as_atomic_groups(BasicBlockList const&
         }
     }
 
-    dbgln_if(REGEX_DEBUG, "Found {} candidate blocks", candidate_blocks.size());
+    dbgln_if<REGEX_DEBUG>("Found {} candidate blocks", candidate_blocks.size());
     if (candidate_blocks.is_empty()) {
-        dbgln_if(REGEX_DEBUG, "Failed to find anything for {}", pattern_value);
+        dbgln_if<REGEX_DEBUG>("Failed to find anything for {}", pattern_value);
         return;
     }
 
@@ -487,7 +487,7 @@ void Optimizer::append_alternation(ByteCode& target, ByteCode&& left, ByteCode&&
         left_skip = left_end;
     }
 
-    dbgln_if(REGEX_DEBUG, "Skipping {}/{} bytecode entries from {}/{}", left_skip, 0, left.size(), right.size());
+    dbgln_if<REGEX_DEBUG>("Skipping {}/{} bytecode entries from {}/{}", left_skip, 0, left.size(), right.size());
 
     if (left_skip > 0) {
         target.extend(left.release_slice(left_blocks.first().start, left_skip));

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -69,7 +69,7 @@ ALWAYS_INLINE Token Parser::consume(TokenType type, Error error)
 {
     if (m_parser_state.current_token.type() != type) {
         set_error(error);
-        dbgln_if(REGEX_DEBUG, "[PARSER] Error: Unexpected token {}. Expected: {}", m_parser_state.current_token.name(), Token::name(type));
+        dbgln_if<REGEX_DEBUG>("[PARSER] Error: Unexpected token {}. Expected: {}", m_parser_state.current_token.name(), Token::name(type));
     }
     return consume();
 }
@@ -186,7 +186,7 @@ Parser::Result Parser::parse(Optional<AllOptions> regex_options)
     else
         set_error(Error::InvalidPattern);
 
-    dbgln_if(REGEX_DEBUG, "[PARSER] Produced bytecode with {} entries (opcodes + arguments)", m_parser_state.bytecode.size());
+    dbgln_if<REGEX_DEBUG>("[PARSER] Produced bytecode with {} entries (opcodes + arguments)", m_parser_state.bytecode.size());
     return {
         move(m_parser_state.bytecode),
         move(m_parser_state.capture_groups_count),
@@ -734,7 +734,7 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_sub_expression(ByteCode& stack, si
         if (match(TokenType::EscapeSequence)) {
             length = 1;
             Token t = consume();
-            dbgln_if(REGEX_DEBUG, "[PARSER] EscapeSequence with substring {}", t.value());
+            dbgln_if<REGEX_DEBUG>("[PARSER] EscapeSequence with substring {}", t.value());
 
             bytecode.insert_bytecode_compare_values({ { CharacterCompareType::Char, (u32)t.value().characters_without_null_termination()[1] } });
             should_parse_repetition_symbol = true;

--- a/Userland/Libraries/LibSQL/AST/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibSQL/AST/SyntaxHighlighter.cpp
@@ -59,7 +59,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         span.data = static_cast<u64>(token.type());
         spans.append(span);
 
-        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "{} @ '{}' {}:{} - {}:{}",
+        dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("{} @ '{}' {}:{} - {}:{}",
             token.name(),
             token.value(),
             span.range.start().line(), span.range.start().column(),

--- a/Userland/Libraries/LibSQL/Heap.h
+++ b/Userland/Libraries/LibSQL/Heap.h
@@ -82,8 +82,8 @@ public:
 
     void add_to_wal(u32 block, ByteBuffer& buffer)
     {
-        dbgln_if(SQL_DEBUG, "Adding to WAL: block #{}, size {}", block, buffer.size());
-        dbgln_if(SQL_DEBUG, "{:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}",
+        dbgln_if<SQL_DEBUG>("Adding to WAL: block #{}, size {}", block, buffer.size());
+        dbgln_if<SQL_DEBUG>("{:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x} {:02x}",
             *buffer.offset_pointer(0), *buffer.offset_pointer(1),
             *buffer.offset_pointer(2), *buffer.offset_pointer(3),
             *buffer.offset_pointer(4), *buffer.offset_pointer(5),

--- a/Userland/Libraries/LibSQL/Tuple.cpp
+++ b/Userland/Libraries/LibSQL/Tuple.cpp
@@ -39,9 +39,9 @@ Tuple::Tuple(NonnullRefPtr<TupleDescriptor> const& descriptor, Serializer& seria
 
 void Tuple::deserialize(Serializer& serializer)
 {
-    dbgln_if(SQL_DEBUG, "deserialize tuple at offset {}", serializer.offset());
+    dbgln_if<SQL_DEBUG>("deserialize tuple at offset {}", serializer.offset());
     serializer.deserialize_to<u32>(m_pointer);
-    dbgln_if(SQL_DEBUG, "pointer: {}", m_pointer);
+    dbgln_if<SQL_DEBUG>("pointer: {}", m_pointer);
     auto sz = serializer.deserialize<u32>();
     m_data.clear();
     m_descriptor->clear();
@@ -54,7 +54,7 @@ void Tuple::deserialize(Serializer& serializer)
 void Tuple::serialize(Serializer& serializer) const
 {
     VERIFY(m_descriptor->size() == m_data.size());
-    dbgln_if(SQL_DEBUG, "Serializing tuple pointer {}", pointer());
+    dbgln_if<SQL_DEBUG>("Serializing tuple pointer {}", pointer());
     serializer.serialize<u32>(pointer());
     serializer.serialize<u32>((u32)m_descriptor->size());
     for (auto ix = 0u; ix < m_descriptor->size(); ix++) {

--- a/Userland/Libraries/LibTLS/HandshakeCertificate.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeCertificate.cpp
@@ -20,13 +20,13 @@ ssize_t TLSv12::handle_certificate(ReadonlyBytes buffer)
     ssize_t res = 0;
 
     if (buffer.size() < 3) {
-        dbgln_if(TLS_DEBUG, "not enough certificate header data");
+        dbgln_if<TLS_DEBUG>("not enough certificate header data");
         return (i8)Error::NeedMoreData;
     }
 
     u32 certificate_total_length = buffer[0] * 0x10000 + buffer[1] * 0x100 + buffer[2];
 
-    dbgln_if(TLS_DEBUG, "total length: {}", certificate_total_length);
+    dbgln_if<TLS_DEBUG>("total length: {}", certificate_total_length);
 
     if (certificate_total_length <= 4)
         return 3 * certificate_total_length;
@@ -34,7 +34,7 @@ ssize_t TLSv12::handle_certificate(ReadonlyBytes buffer)
     res += 3;
 
     if (certificate_total_length > buffer.size() - res) {
-        dbgln_if(TLS_DEBUG, "not enough data for claimed total cert length");
+        dbgln_if<TLS_DEBUG>("not enough data for claimed total cert length");
         return (i8)Error::NeedMoreData;
     }
     size_t size = certificate_total_length;
@@ -45,14 +45,14 @@ ssize_t TLSv12::handle_certificate(ReadonlyBytes buffer)
     while (size > 0) {
         ++index;
         if (buffer.size() - res < 3) {
-            dbgln_if(TLS_DEBUG, "not enough data for certificate length");
+            dbgln_if<TLS_DEBUG>("not enough data for certificate length");
             return (i8)Error::NeedMoreData;
         }
         size_t certificate_size = buffer[res] * 0x10000 + buffer[res + 1] * 0x100 + buffer[res + 2];
         res += 3;
 
         if (buffer.size() - res < certificate_size) {
-            dbgln_if(TLS_DEBUG, "not enough data for certificate body");
+            dbgln_if<TLS_DEBUG>("not enough data for certificate body");
             return (i8)Error::NeedMoreData;
         }
 

--- a/Userland/Libraries/LibTLS/HandshakeClient.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeClient.cpp
@@ -315,7 +315,7 @@ ByteBuffer TLSv12::build_certificate()
     builder.append((u8)HandshakeType::CertificateMessage);
 
     if (!total_certificate_size) {
-        dbgln_if(TLS_DEBUG, "No certificates, sending empty certificate message");
+        dbgln_if<TLS_DEBUG>("No certificates, sending empty certificate message");
         builder.append_u24(certificate_vector_header_size);
         builder.append_u24(total_certificate_size);
     } else {

--- a/Userland/Libraries/LibTLS/HandshakeServer.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeServer.cpp
@@ -79,7 +79,7 @@ ssize_t TLSv12::handle_server_hello(ReadonlyBytes buffer, WritePacketStage& writ
         return (i8)Error::NoCommonCipher;
     }
     m_context.cipher = cipher;
-    dbgln_if(TLS_DEBUG, "Cipher: {}", (u16)cipher);
+    dbgln_if<TLS_DEBUG>("Cipher: {}", (u16)cipher);
 
     // Simplification: We only support handshake hash functions via HMAC
     m_context.handshake_hash.initialize(hmac_hash());
@@ -101,7 +101,7 @@ ssize_t TLSv12::handle_server_hello(ReadonlyBytes buffer, WritePacketStage& writ
     // Presence of extensions is determined by availability of bytes after compression_method
     if (buffer.size() - res >= 2) {
         auto extensions_bytes_total = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res += 2)));
-        dbgln_if(TLS_DEBUG, "Extensions bytes total: {}", extensions_bytes_total);
+        dbgln_if<TLS_DEBUG>("Extensions bytes total: {}", extensions_bytes_total);
     }
 
     while (buffer.size() - res >= 4) {
@@ -110,7 +110,7 @@ ssize_t TLSv12::handle_server_hello(ReadonlyBytes buffer, WritePacketStage& writ
         u16 extension_length = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res)));
         res += 2;
 
-        dbgln_if(TLS_DEBUG, "Extension {} with length {}", (u16)extension_type, extension_length);
+        dbgln_if<TLS_DEBUG>("Extension {} with length {}", (u16)extension_type, extension_length);
 
         if (buffer.size() - res < extension_length)
             return (i8)Error::NeedMoreData;
@@ -122,7 +122,7 @@ ssize_t TLSv12::handle_server_hello(ReadonlyBytes buffer, WritePacketStage& writ
                 if (buffer.size() - res < 2)
                     return (i8)Error::NeedMoreData;
                 auto sni_name_list_bytes = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(res += 2)));
-                dbgln_if(TLS_DEBUG, "SNI: expecting ServerNameList of {} bytes", sni_name_list_bytes);
+                dbgln_if<TLS_DEBUG>("SNI: expecting ServerNameList of {} bytes", sni_name_list_bytes);
 
                 // Exactly one ServerName should be present
                 if (buffer.size() - res < 3)

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -55,7 +55,7 @@ String TLSv12::read_line(size_t max_size)
 ErrorOr<size_t> TLSv12::write(ReadonlyBytes bytes)
 {
     if (m_context.connection_status != ConnectionStatus::Established) {
-        dbgln_if(TLS_DEBUG, "write request while not connected");
+        dbgln_if<TLS_DEBUG>("write request while not connected");
         return AK::Error::from_string_literal("TLS write request while not connected");
     }
 
@@ -207,7 +207,7 @@ ErrorOr<void> TLSv12::read_from_socket()
 
 void TLSv12::write_into_socket()
 {
-    dbgln_if(TLS_DEBUG, "Flushing cached records: {} established? {}", m_context.tls_buffer.size(), is_established());
+    dbgln_if<TLS_DEBUG>("Flushing cached records: {} established? {}", m_context.tls_buffer.size(), is_established());
 
     m_has_scheduled_write_flush = false;
     if (!check_connection_state(false))
@@ -228,7 +228,7 @@ bool TLSv12::check_connection_state(bool read)
 
     if (!stream.is_open()) {
         // an abrupt closure (the server is a jerk)
-        dbgln_if(TLS_DEBUG, "Socket not open, assuming abrupt closure");
+        dbgln_if<TLS_DEBUG>("Socket not open, assuming abrupt closure");
         m_context.connection_finished = true;
         m_context.connection_status = ConnectionStatus::Disconnected;
         close();
@@ -245,7 +245,7 @@ bool TLSv12::check_connection_state(bool read)
     }
 
     if (m_context.critical_error) {
-        dbgln_if(TLS_DEBUG, "CRITICAL ERROR {} :(", m_context.critical_error);
+        dbgln_if<TLS_DEBUG>("CRITICAL ERROR {} :(", m_context.critical_error);
 
         m_context.has_invoked_finish_or_error_callback = true;
         if (on_tls_error)
@@ -263,7 +263,7 @@ bool TLSv12::check_connection_state(bool read)
                 on_tls_finished();
         }
         if (m_context.tls_buffer.size()) {
-            dbgln_if(TLS_DEBUG, "connection closed without finishing data transfer, {} bytes still in buffer and {} bytes in application buffer",
+            dbgln_if<TLS_DEBUG>("connection closed without finishing data transfer, {} bytes still in buffer and {} bytes in application buffer",
                 m_context.tls_buffer.size(),
                 m_context.application_buffer.size());
         }
@@ -307,7 +307,7 @@ ErrorOr<bool> TLSv12::flush()
 
     if (m_context.send_retries++ == 10) {
         // drop the records, we can't send
-        dbgln_if(TLS_DEBUG, "Dropping {} bytes worth of TLS records as max retries has been reached", m_context.tls_buffer.size());
+        dbgln_if<TLS_DEBUG>("Dropping {} bytes worth of TLS records as max retries has been reached", m_context.tls_buffer.size());
         m_context.tls_buffer.clear();
         m_context.send_retries = 0;
     }

--- a/Userland/Libraries/LibTLS/TLSv12.cpp
+++ b/Userland/Libraries/LibTLS/TLSv12.cpp
@@ -33,7 +33,7 @@ void TLSv12::consume(ReadonlyBytes record)
         return;
     }
 
-    dbgln_if(TLS_DEBUG, "Consuming {} bytes", record.size());
+    dbgln_if<TLS_DEBUG>("Consuming {} bytes", record.size());
 
     if (m_context.message_buffer.try_append(record).is_error()) {
         dbgln("Not enough space in message buffer, dropping the record");
@@ -46,12 +46,12 @@ void TLSv12::consume(ReadonlyBytes record)
     size_t size_offset { 3 }; // read the common record header
     size_t header_size { 5 };
 
-    dbgln_if(TLS_DEBUG, "message buffer length {}", buffer_length);
+    dbgln_if<TLS_DEBUG>("message buffer length {}", buffer_length);
 
     while (buffer_length >= 5) {
         auto length = AK::convert_between_host_and_network_endian(ByteReader::load16(m_context.message_buffer.offset_pointer(index + size_offset))) + header_size;
         if (length > buffer_length) {
-            dbgln_if(TLS_DEBUG, "Need more data: {} > {}", length, buffer_length);
+            dbgln_if<TLS_DEBUG>("Need more data: {} > {}", length, buffer_length);
             break;
         }
         auto consumed = handle_message(m_context.message_buffer.bytes().slice(index, length));
@@ -183,7 +183,7 @@ void TLSv12::set_root_certificates(Vector<Certificate> certificates)
         // FIXME: Figure out what we should do when our root certs are invalid.
     }
     m_context.root_certificates = move(certificates);
-    dbgln_if(TLS_DEBUG, "{}: Set {} root certificates", this, m_context.root_certificates.size());
+    dbgln_if<TLS_DEBUG>("{}: Set {} root certificates", this, m_context.root_certificates.size());
 }
 
 bool Context::verify_chain() const

--- a/Userland/Libraries/LibVT/EscapeSequenceParser.h
+++ b/Userland/Libraries/LibVT/EscapeSequenceParser.h
@@ -41,7 +41,7 @@ public:
 
     ALWAYS_INLINE void on_input(u8 byte)
     {
-        dbgln_if(ESCAPE_SEQUENCE_DEBUG, "on_input {:02x}", byte);
+        dbgln_if<ESCAPE_SEQUENCE_DEBUG>("on_input {:02x}", byte);
         m_state_machine.advance(byte);
     }
 

--- a/Userland/Libraries/LibVideo/MatroskaReader.h
+++ b/Userland/Libraries/LibVideo/MatroskaReader.h
@@ -66,9 +66,9 @@ private:
 
         Optional<u64> read_variable_size_integer(bool mask_length = true)
         {
-            dbgln_if(MATROSKA_TRACE_DEBUG, "Reading from offset {:p}", m_data_ptr);
+            dbgln_if<MATROSKA_TRACE_DEBUG>("Reading from offset {:p}", m_data_ptr);
             auto length_descriptor = read_octet();
-            dbgln_if(MATROSKA_TRACE_DEBUG, "Reading VINT, first byte is {:#02x}", length_descriptor);
+            dbgln_if<MATROSKA_TRACE_DEBUG>("Reading VINT, first byte is {:#02x}", length_descriptor);
             if (length_descriptor == 0)
                 return {};
             size_t length = 0;
@@ -77,7 +77,7 @@ private:
                     break;
                 length++;
             }
-            dbgln_if(MATROSKA_TRACE_DEBUG, "Reading VINT of total length {}", length);
+            dbgln_if<MATROSKA_TRACE_DEBUG>("Reading VINT of total length {}", length);
             if (length > 8)
                 return {};
 
@@ -86,16 +86,16 @@ private:
                 result = length_descriptor & ~(1u << (8 - length));
             else
                 result = length_descriptor;
-            dbgln_if(MATROSKA_TRACE_DEBUG, "Beginning of VINT is {:#02x}", result);
+            dbgln_if<MATROSKA_TRACE_DEBUG>("Beginning of VINT is {:#02x}", result);
             for (size_t i = 1; i < length; i++) {
                 if (!has_octet()) {
-                    dbgln_if(MATROSKA_TRACE_DEBUG, "Ran out of stream data");
+                    dbgln_if<MATROSKA_TRACE_DEBUG>("Ran out of stream data");
                     return {};
                 }
                 u8 next_octet = read_octet();
-                dbgln_if(MATROSKA_TRACE_DEBUG, "Read octet of {:#02x}", next_octet);
+                dbgln_if<MATROSKA_TRACE_DEBUG>("Read octet of {:#02x}", next_octet);
                 result = (result << 8u) | next_octet;
-                dbgln_if(MATROSKA_TRACE_DEBUG, "New result is {:#010x}", result);
+                dbgln_if<MATROSKA_TRACE_DEBUG>("New result is {:#010x}", result);
             }
             return result;
         }

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.cpp
@@ -17,7 +17,7 @@ namespace Wasm {
 #define TRAP_IF_NOT(x)                                                                         \
     do {                                                                                       \
         if (trap_if_not(x, #x##sv)) {                                                          \
-            dbgln_if(WASM_TRACE_DEBUG, "Trapped because {} failed, at line {}", #x, __LINE__); \
+            dbgln_if<WASM_TRACE_DEBUG>("Trapped because {} failed, at line {}", #x, __LINE__); \
             return;                                                                            \
         }                                                                                      \
     } while (false)
@@ -25,7 +25,7 @@ namespace Wasm {
 #define TRAP_IF_NOT_NORETURN(x)                                                                \
     do {                                                                                       \
         if (trap_if_not(x, #x##sv)) {                                                          \
-            dbgln_if(WASM_TRACE_DEBUG, "Trapped because {} failed, at line {}", #x, __LINE__); \
+            dbgln_if<WASM_TRACE_DEBUG>("Trapped because {} failed, at line {}", #x, __LINE__); \
         }                                                                                      \
     } while (false)
 
@@ -57,9 +57,9 @@ void BytecodeInterpreter::interpret(Configuration& configuration)
 
 void BytecodeInterpreter::branch_to_label(Configuration& configuration, LabelIndex index)
 {
-    dbgln_if(WASM_TRACE_DEBUG, "Branch to label with index {}...", index.value());
+    dbgln_if<WASM_TRACE_DEBUG>("Branch to label with index {}...", index.value());
     auto label = configuration.nth_label(index.value());
-    dbgln_if(WASM_TRACE_DEBUG, "...which is actually IP {}, and has {} result(s)", label->continuation().value(), label->arity());
+    dbgln_if<WASM_TRACE_DEBUG>("...which is actually IP {}, and has {} result(s)", label->continuation().value(), label->arity());
     auto results = pop_values(configuration, label->arity());
 
     size_t drop_count = index.value() + 1;
@@ -102,7 +102,7 @@ void BytecodeInterpreter::load_and_push(Configuration& configuration, Instructio
         dbgln("LibWasm: Memory access out of bounds (expected {} to be less than or equal to {})", instance_address + sizeof(ReadType), memory->size());
         return;
     }
-    dbgln_if(WASM_TRACE_DEBUG, "load({} : {}) -> stack", instance_address, sizeof(ReadType));
+    dbgln_if<WASM_TRACE_DEBUG>("load({} : {}) -> stack", instance_address, sizeof(ReadType));
     auto slice = memory->data().bytes().slice(instance_address, sizeof(ReadType));
     configuration.stack().peek() = Value(static_cast<PushType>(read_value<ReadType>(slice)));
 }
@@ -162,7 +162,7 @@ void BytecodeInterpreter::binary_numeric_operation(Configuration& configuration)
     } else {
         result = call_result;
     }
-    dbgln_if(WASM_TRACE_DEBUG, "{} {} {} = {}", lhs.value(), Operator::name(), rhs.value(), result);
+    dbgln_if<WASM_TRACE_DEBUG>("{} {} {} = {}", lhs.value(), Operator::name(), rhs.value(), result);
     lhs_entry = Value(result);
 }
 
@@ -183,7 +183,7 @@ void BytecodeInterpreter::unary_operation(Configuration& configuration)
     } else {
         result = call_result;
     }
-    dbgln_if(WASM_TRACE_DEBUG, "map({}) {} = {}", Operator::name(), *value, result);
+    dbgln_if<WASM_TRACE_DEBUG>("map({}) {} = {}", Operator::name(), *value, result);
     entry = Value(result);
 }
 
@@ -226,7 +226,7 @@ void BytecodeInterpreter::pop_and_store(Configuration& configuration, Instructio
 {
     auto entry = configuration.stack().pop();
     auto value = ConvertToRaw<StoreT> {}(*entry.get<Value>().to<PopT>());
-    dbgln_if(WASM_TRACE_DEBUG, "stack({}) -> temporary({}b)", value, sizeof(StoreT));
+    dbgln_if<WASM_TRACE_DEBUG>("stack({}) -> temporary({}b)", value, sizeof(StoreT));
     auto base_entry = configuration.stack().pop();
     auto base = base_entry.get<Value>().to<i32>();
     store_to_memory(configuration, instruction, { &value, sizeof(StoreT) }, *base);
@@ -245,7 +245,7 @@ void BytecodeInterpreter::store_to_memory(Configuration& configuration, Instruct
         dbgln("LibWasm: Memory access out of bounds (expected 0 <= {} and {} <= {})", instance_address, instance_address + data.size(), memory->size());
         return;
     }
-    dbgln_if(WASM_TRACE_DEBUG, "temporary({}b) -> store({})", data.size(), instance_address);
+    dbgln_if<WASM_TRACE_DEBUG>("temporary({}b) -> store({})", data.size(), instance_address);
     data.copy_to(memory->data().bytes().slice(instance_address, data.size()));
 }
 
@@ -302,7 +302,7 @@ MakeSigned<T> BytecodeInterpreter::checked_signed_truncate(V value)
     if (NumericLimits<SignedT>::min() <= truncated && static_cast<double>(NumericLimits<SignedT>::max()) >= truncated)
         return static_cast<SignedT>(truncated);
 
-    dbgln_if(WASM_TRACE_DEBUG, "Truncate out of range error");
+    dbgln_if<WASM_TRACE_DEBUG>("Truncate out of range error");
     m_trap = Trap { "Signed truncation out of range" };
     return true;
 }
@@ -324,7 +324,7 @@ MakeUnsigned<T> BytecodeInterpreter::checked_unsigned_truncate(V value)
     if (NumericLimits<UnsignedT>::min() <= truncated && static_cast<double>(NumericLimits<UnsignedT>::max()) >= truncated)
         return static_cast<UnsignedT>(truncated);
 
-    dbgln_if(WASM_TRACE_DEBUG, "Truncate out of range error");
+    dbgln_if<WASM_TRACE_DEBUG>("Truncate out of range error");
     m_trap = Trap { "Unsigned truncation out of range" };
     return true;
 }
@@ -346,7 +346,7 @@ Vector<Value> BytecodeInterpreter::pop_values(Configuration& configuration, size
 
 void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPointer& ip, Instruction const& instruction)
 {
-    dbgln_if(WASM_TRACE_DEBUG, "Executing instruction {} at ip {}", instruction_name(instruction.opcode()), ip.value());
+    dbgln_if<WASM_TRACE_DEBUG>("Executing instruction {} at ip {}", instruction_name(instruction.opcode()), ip.value());
 
     switch (instruction.opcode().value()) {
     case Instructions::unreachable.value():
@@ -500,7 +500,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
     case Instructions::call.value(): {
         auto index = instruction.arguments().get<FunctionIndex>();
         auto address = configuration.frame().module().functions()[index.value()];
-        dbgln_if(WASM_TRACE_DEBUG, "call({})", address.value());
+        dbgln_if<WASM_TRACE_DEBUG>("call({})", address.value());
         call_address(configuration, address);
         return;
     }
@@ -516,7 +516,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         TRAP_IF_NOT(element.has_value());
         TRAP_IF_NOT(element->ref().has<Reference::Func>());
         auto address = element->ref().get<Reference::Func>().address;
-        dbgln_if(WASM_TRACE_DEBUG, "call_indirect({} -> {})", index.value(), address.value());
+        dbgln_if<WASM_TRACE_DEBUG>("call_indirect({} -> {})", index.value(), address.value());
         call_address(configuration, address);
         return;
     }
@@ -570,14 +570,14 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         auto& entry = configuration.stack().peek();
         auto value = entry.get<Value>();
         auto local_index = instruction.arguments().get<LocalIndex>();
-        dbgln_if(WASM_TRACE_DEBUG, "stack:peek -> locals({})", local_index.value());
+        dbgln_if<WASM_TRACE_DEBUG>("stack:peek -> locals({})", local_index.value());
         configuration.frame().locals()[local_index.value()] = move(value);
         return;
     }
     case Instructions::global_get.value(): {
         auto global_index = instruction.arguments().get<GlobalIndex>();
         auto address = configuration.frame().module().globals()[global_index.value()];
-        dbgln_if(WASM_TRACE_DEBUG, "global({}) -> stack", address.value());
+        dbgln_if<WASM_TRACE_DEBUG>("global({}) -> stack", address.value());
         auto global = configuration.store().get(address);
         configuration.stack().push(Value(global->value()));
         return;
@@ -587,7 +587,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         auto address = configuration.frame().module().globals()[global_index.value()];
         auto entry = configuration.stack().pop();
         auto value = entry.get<Value>();
-        dbgln_if(WASM_TRACE_DEBUG, "stack -> global({})", address.value());
+        dbgln_if<WASM_TRACE_DEBUG>("stack -> global({})", address.value());
         auto global = configuration.store().get(address);
         global->set_value(move(value));
         return;
@@ -596,7 +596,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         auto address = configuration.frame().module().memories()[0];
         auto instance = configuration.store().get(address);
         auto pages = instance->size() / Constants::page_size;
-        dbgln_if(WASM_TRACE_DEBUG, "memory.size -> stack({})", pages);
+        dbgln_if<WASM_TRACE_DEBUG>("memory.size -> stack({})", pages);
         configuration.stack().push(Value((i32)pages));
         return;
     }
@@ -606,7 +606,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         i32 old_pages = instance->size() / Constants::page_size;
         auto& entry = configuration.stack().peek();
         auto new_pages = entry.get<Value>().to<i32>();
-        dbgln_if(WASM_TRACE_DEBUG, "memory.grow({}), previously {} pages...", *new_pages, old_pages);
+        dbgln_if<WASM_TRACE_DEBUG>("memory.grow({}), previously {} pages...", *new_pages, old_pages);
         if (instance->grow(new_pages.value() * Constants::page_size))
             configuration.stack().peek() = Value((i32)old_pages);
         else
@@ -643,7 +643,7 @@ void BytecodeInterpreter::interpret(Configuration& configuration, InstructionPoi
         // Note: The type seems to only be used for validation.
         auto entry = configuration.stack().pop();
         auto value = entry.get<Value>().to<i32>();
-        dbgln_if(WASM_TRACE_DEBUG, "select({})", value.value());
+        dbgln_if<WASM_TRACE_DEBUG>("select({})", value.value());
         auto rhs_entry = configuration.stack().pop();
         auto& lhs_entry = configuration.stack().peek();
         auto rhs = move(rhs_entry.get<Value>());

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -18,7 +18,7 @@ CSSImportRule::CSSImportRule(AK::URL url, DOM::Document& document)
     : m_url(move(url))
     , m_document(document)
 {
-    dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Loading import URL: {}", m_url);
+    dbgln_if<CSS_LOADER_DEBUG>("CSSImportRule: Loading import URL: {}", m_url);
     auto request = LoadRequest::create_for_url_on_page(m_url, document.page());
     set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, request));
     m_document_load_event_delayer.emplace(document);
@@ -53,7 +53,7 @@ String CSSImportRule::serialized() const
 
 void CSSImportRule::resource_did_fail()
 {
-    dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Resource did fail. URL: {}", resource()->url());
+    dbgln_if<CSS_LOADER_DEBUG>("CSSImportRule: Resource did fail. URL: {}", resource()->url());
 
     m_document_load_event_delayer.clear();
 }
@@ -68,14 +68,14 @@ void CSSImportRule::resource_did_load()
     m_document_load_event_delayer.clear();
 
     if (!resource()->has_encoded_data()) {
-        dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Resource did load, no encoded data. URL: {}", resource()->url());
+        dbgln_if<CSS_LOADER_DEBUG>("CSSImportRule: Resource did load, no encoded data. URL: {}", resource()->url());
     } else {
-        dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Resource did load, has encoded data. URL: {}", resource()->url());
+        dbgln_if<CSS_LOADER_DEBUG>("CSSImportRule: Resource did load, has encoded data. URL: {}", resource()->url());
     }
 
     auto sheet = parse_css(CSS::ParsingContext(*m_document), resource()->encoded_data());
     if (!sheet) {
-        dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Failed to parse stylesheet: {}", resource()->url());
+        dbgln_if<CSS_LOADER_DEBUG>("CSSImportRule: Failed to parse stylesheet: {}", resource()->url());
         return;
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -29,7 +29,7 @@
 
 static void log_parse_error(const SourceLocation& location = SourceLocation::current())
 {
-    dbgln_if(CSS_PARSER_DEBUG, "Parse error (CSS) {}", location);
+    dbgln_if<CSS_PARSER_DEBUG>("Parse error (CSS) {}", location);
 }
 
 namespace Web::CSS {
@@ -354,7 +354,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
 
     } else if (first_value.is(Token::Type::Hash)) {
         if (first_value.token().hash_type() != Token::HashType::Id) {
-            dbgln_if(CSS_PARSER_DEBUG, "Selector contains hash token that is not an id: {}", first_value.to_debug_string());
+            dbgln_if<CSS_PARSER_DEBUG>("Selector contains hash token that is not an id: {}", first_value.to_debug_string());
             return ParsingResult::SyntaxError;
         }
         return Selector::SimpleSelector {
@@ -368,7 +368,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
 
         auto& class_name_value = tokens.next_token();
         if (!class_name_value.is(Token::Type::Ident)) {
-            dbgln_if(CSS_PARSER_DEBUG, "Expected an ident after '.', got: {}", class_name_value.to_debug_string());
+            dbgln_if<CSS_PARSER_DEBUG>("Expected an ident after '.', got: {}", class_name_value.to_debug_string());
             return ParsingResult::SyntaxError;
         }
         return Selector::SimpleSelector {
@@ -388,14 +388,14 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
         attribute_tokens.skip_whitespace();
 
         if (!attribute_tokens.has_next_token()) {
-            dbgln_if(CSS_PARSER_DEBUG, "CSS attribute selector is empty!");
+            dbgln_if<CSS_PARSER_DEBUG>("CSS attribute selector is empty!");
             return ParsingResult::SyntaxError;
         }
 
         // FIXME: Handle namespace prefix for attribute name.
         auto& attribute_part = attribute_tokens.next_token();
         if (!attribute_part.is(Token::Type::Ident)) {
-            dbgln_if(CSS_PARSER_DEBUG, "Expected ident for attribute name, got: '{}'", attribute_part.to_debug_string());
+            dbgln_if<CSS_PARSER_DEBUG>("Expected ident for attribute name, got: '{}'", attribute_part.to_debug_string());
             return ParsingResult::SyntaxError;
         }
 
@@ -418,7 +418,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
 
         auto& delim_part = attribute_tokens.next_token();
         if (!delim_part.is(Token::Type::Delim)) {
-            dbgln_if(CSS_PARSER_DEBUG, "Expected a delim for attribute comparison, got: '{}'", delim_part.to_debug_string());
+            dbgln_if<CSS_PARSER_DEBUG>("Expected a delim for attribute comparison, got: '{}'", delim_part.to_debug_string());
             return ParsingResult::SyntaxError;
         }
 
@@ -426,13 +426,13 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
             simple_selector.attribute.match_type = Selector::SimpleSelector::Attribute::MatchType::ExactValueMatch;
         } else {
             if (!attribute_tokens.has_next_token()) {
-                dbgln_if(CSS_PARSER_DEBUG, "Attribute selector ended part way through a match type.");
+                dbgln_if<CSS_PARSER_DEBUG>("Attribute selector ended part way through a match type.");
                 return ParsingResult::SyntaxError;
             }
 
             auto& delim_second_part = attribute_tokens.next_token();
             if (!(delim_second_part.is(Token::Type::Delim) && delim_second_part.token().delim() == "=")) {
-                dbgln_if(CSS_PARSER_DEBUG, "Expected a double delim for attribute comparison, got: '{}{}'", delim_part.to_debug_string(), delim_second_part.to_debug_string());
+                dbgln_if<CSS_PARSER_DEBUG>("Expected a double delim for attribute comparison, got: '{}{}'", delim_part.to_debug_string(), delim_second_part.to_debug_string());
                 return ParsingResult::SyntaxError;
             }
 
@@ -453,13 +453,13 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
 
         attribute_tokens.skip_whitespace();
         if (!attribute_tokens.has_next_token()) {
-            dbgln_if(CSS_PARSER_DEBUG, "Attribute selector ended without a value to match.");
+            dbgln_if<CSS_PARSER_DEBUG>("Attribute selector ended without a value to match.");
             return ParsingResult::SyntaxError;
         }
 
         auto& value_part = attribute_tokens.next_token();
         if (!value_part.is(Token::Type::Ident) && !value_part.is(Token::Type::String)) {
-            dbgln_if(CSS_PARSER_DEBUG, "Expected a string or ident for the value to match attribute against, got: '{}'", value_part.to_debug_string());
+            dbgln_if<CSS_PARSER_DEBUG>("Expected a string or ident for the value to match attribute against, got: '{}'", value_part.to_debug_string());
             return ParsingResult::SyntaxError;
         }
         simple_selector.attribute.value = value_part.token().is(Token::Type::Ident) ? value_part.token().ident() : value_part.token().string();
@@ -488,7 +488,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
 
             auto& name_token = tokens.next_token();
             if (!name_token.is(Token::Type::Ident)) {
-                dbgln_if(CSS_PARSER_DEBUG, "Expected an ident for pseudo-element, got: '{}'", name_token.to_debug_string());
+                dbgln_if<CSS_PARSER_DEBUG>("Expected an ident for pseudo-element, got: '{}'", name_token.to_debug_string());
                 return ParsingResult::SyntaxError;
             }
 
@@ -505,7 +505,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
             } else if (pseudo_name.equals_ignoring_case("first-line")) {
                 simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLine;
             } else {
-                dbgln_if(CSS_PARSER_DEBUG, "Unrecognized pseudo-element: '::{}'", pseudo_name);
+                dbgln_if<CSS_PARSER_DEBUG>("Unrecognized pseudo-element: '::{}'", pseudo_name);
                 return ParsingResult::SyntaxError;
             }
 
@@ -573,7 +573,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                 simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
                 simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLine;
             } else {
-                dbgln_if(CSS_PARSER_DEBUG, "Unrecognized pseudo-class: ':{}'", pseudo_name);
+                dbgln_if<CSS_PARSER_DEBUG>("Unrecognized pseudo-class: ':{}'", pseudo_name);
                 return ParsingResult::SyntaxError;
             }
 
@@ -587,7 +587,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                 auto function_token_stream = TokenStream(pseudo_function.values());
                 auto not_selector = parse_a_selector(function_token_stream);
                 if (not_selector.is_error()) {
-                    dbgln_if(CSS_PARSER_DEBUG, "Invalid selector in :not() clause");
+                    dbgln_if<CSS_PARSER_DEBUG>("Invalid selector in :not() clause");
                     return ParsingResult::SyntaxError;
                 }
                 simple_selector.pseudo_class.not_selector = not_selector.release_value();
@@ -598,7 +598,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                 if (nth_child_pattern.has_value()) {
                     simple_selector.pseudo_class.nth_child_pattern = nth_child_pattern.value();
                 } else {
-                    dbgln_if(CSS_PARSER_DEBUG, "!!! Invalid nth-child format");
+                    dbgln_if<CSS_PARSER_DEBUG>("!!! Invalid nth-child format");
                     return ParsingResult::SyntaxError;
                 }
             } else if (pseudo_function.name().equals_ignoring_case("nth-last-child")) {
@@ -608,18 +608,18 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                 if (nth_child_pattern.has_value()) {
                     simple_selector.pseudo_class.nth_child_pattern = nth_child_pattern.value();
                 } else {
-                    dbgln_if(CSS_PARSER_DEBUG, "!!! Invalid nth-child format");
+                    dbgln_if<CSS_PARSER_DEBUG>("!!! Invalid nth-child format");
                     return ParsingResult::SyntaxError;
                 }
             } else {
-                dbgln_if(CSS_PARSER_DEBUG, "Unrecognized pseudo-class function: ':{}'()", pseudo_function.name());
+                dbgln_if<CSS_PARSER_DEBUG>("Unrecognized pseudo-class function: ':{}'()", pseudo_function.name());
                 return ParsingResult::SyntaxError;
             }
 
             return simple_selector;
 
         } else {
-            dbgln_if(CSS_PARSER_DEBUG, "Unexpected Block in pseudo-class name, expected a function or identifier. '{}'", pseudo_class_token.to_debug_string());
+            dbgln_if<CSS_PARSER_DEBUG>("Unexpected Block in pseudo-class name, expected a function or identifier. '{}'", pseudo_class_token.to_debug_string());
             return ParsingResult::SyntaxError;
         }
     }
@@ -634,7 +634,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
         }
     }
 
-    dbgln_if(CSS_PARSER_DEBUG, "!!! Invalid simple selector!");
+    dbgln_if<CSS_PARSER_DEBUG>("!!! Invalid simple selector!");
     return ParsingResult::SyntaxError;
 }
 
@@ -1677,7 +1677,7 @@ Vector<DeclarationOrAtRule> Parser::consume_a_list_of_declarations(TokenStream<T
             auto& peek = tokens.peek_token();
             if (peek.is(Token::Type::Semicolon) || peek.is(Token::Type::EndOfFile))
                 break;
-            dbgln_if(CSS_PARSER_DEBUG, "Discarding token: '{}'", peek.to_debug_string());
+            dbgln_if<CSS_PARSER_DEBUG>("Discarding token: '{}'", peek.to_debug_string());
             (void)consume_a_component_value(tokens);
         }
     }
@@ -1780,7 +1780,7 @@ RefPtr<PropertyOwningCSSStyleDeclaration> Parser::parse_a_list_of_declarations(T
 
     for (auto& declaration_or_at_rule : declarations_and_at_rules) {
         if (declaration_or_at_rule.is_at_rule()) {
-            dbgln_if(CSS_PARSER_DEBUG, "!!! CSS at-rule is not allowed here!");
+            dbgln_if<CSS_PARSER_DEBUG>("!!! CSS at-rule is not allowed here!");
             continue;
         }
 
@@ -1966,7 +1966,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
             if (url.has_value())
                 return CSSImportRule::create(url.value(), const_cast<DOM::Document&>(*m_context.document()));
             else
-                dbgln_if(CSS_PARSER_DEBUG, "Unable to parse url from @import rule");
+                dbgln_if<CSS_PARSER_DEBUG>("Unable to parse url from @import rule");
 
         } else if (rule->m_name.equals_ignoring_case("supports"sv)) {
 
@@ -1974,7 +1974,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
             auto supports = parse_a_supports(supports_tokens);
             if (!supports) {
                 if constexpr (CSS_PARSER_DEBUG) {
-                    dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @supports rule invalid; discarding.");
+                    dbgln_if<CSS_PARSER_DEBUG>("CSSParser: @supports rule invalid; discarding.");
                     supports_tokens.dump_all_tokens();
                 }
                 return {};
@@ -1991,7 +1991,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
             return CSSSupportsRule::create(supports.release_nonnull(), move(child_rules));
 
         } else {
-            dbgln_if(CSS_PARSER_DEBUG, "Unrecognized CSS at-rule: @{}", rule->m_name);
+            dbgln_if<CSS_PARSER_DEBUG>("Unrecognized CSS at-rule: @{}", rule->m_name);
         }
 
         // FIXME: More at rules!
@@ -2002,7 +2002,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
 
         if (selectors.is_error()) {
             if (selectors.error() != ParsingResult::IncludesIgnoredVendorPrefix) {
-                dbgln_if(CSS_PARSER_DEBUG, "CSSParser: style rule selectors invalid; discarding.");
+                dbgln_if<CSS_PARSER_DEBUG>("CSSParser: style rule selectors invalid; discarding.");
                 if constexpr (CSS_PARSER_DEBUG) {
                     prelude_stream.dump_all_tokens();
                 }
@@ -2011,13 +2011,13 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
         }
 
         if (selectors.value().is_empty()) {
-            dbgln_if(CSS_PARSER_DEBUG, "CSSParser: empty selector; discarding.");
+            dbgln_if<CSS_PARSER_DEBUG>("CSSParser: empty selector; discarding.");
             return {};
         }
 
         auto declaration = convert_to_declaration(*rule->m_block);
         if (!declaration) {
-            dbgln_if(CSS_PARSER_DEBUG, "CSSParser: style rule declaration invalid; discarding.");
+            dbgln_if<CSS_PARSER_DEBUG>("CSSParser: style rule declaration invalid; discarding.");
             return {};
         }
 
@@ -2047,7 +2047,7 @@ Optional<StyleProperty> Parser::convert_to_style_property(StyleDeclarationRule c
         } else if (has_ignored_vendor_prefix(property_name)) {
             return {};
         } else if (!property_name.starts_with("-")) {
-            dbgln_if(CSS_PARSER_DEBUG, "Unrecognized CSS property '{}'", property_name);
+            dbgln_if<CSS_PARSER_DEBUG>("Unrecognized CSS property '{}'", property_name);
             return {};
         }
     }
@@ -2056,7 +2056,7 @@ Optional<StyleProperty> Parser::convert_to_style_property(StyleDeclarationRule c
     auto value = parse_css_value(property_id, value_token_stream);
     if (value.is_error()) {
         if (value.error() != ParsingResult::IncludesIgnoredVendorPrefix) {
-            dbgln_if(CSS_PARSER_DEBUG, "Unable to parse value for CSS property '{}'.", property_name);
+            dbgln_if<CSS_PARSER_DEBUG>("Unable to parse value for CSS property '{}'.", property_name);
             if constexpr (CSS_PARSER_DEBUG) {
                 value_token_stream.dump_all_tokens();
             }
@@ -2095,7 +2095,7 @@ RefPtr<StyleValue> Parser::parse_calculated_value(Vector<StyleComponentValueRule
 
     auto calc_type = calc_expression->resolved_type();
     if (!calc_type.has_value()) {
-        dbgln_if(CSS_PARSER_DEBUG, "calc() resolved as invalid!!!");
+        dbgln_if<CSS_PARSER_DEBUG>("calc() resolved as invalid!!!");
         return nullptr;
     }
 
@@ -2118,7 +2118,7 @@ RefPtr<StyleValue> Parser::parse_calculated_value(Vector<StyleComponentValueRule
         }
         VERIFY_NOT_REACHED();
     };
-    dbgln_if(CSS_PARSER_DEBUG, "Deduced calc() resolved type as: {}", to_string(calc_type.value()));
+    dbgln_if<CSS_PARSER_DEBUG>("Deduced calc() resolved type as: {}", to_string(calc_type.value()));
 
     return CalculatedStyleValue::create(calc_expression.release_nonnull(), calc_type.release_value());
 }
@@ -3671,7 +3671,7 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<StyleComponentValueRule>
                 auto number = parse_numeric_value(value);
                 values.append(number.release_nonnull());
             } else {
-                dbgln_if(CSS_PARSER_DEBUG, "FIXME: Unsupported value type for transformation!");
+                dbgln_if<CSS_PARSER_DEBUG>("FIXME: Unsupported value type for transformation!");
                 return nullptr;
             }
         }
@@ -3889,7 +3889,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
 
     auto syntax_error = [&]() -> Optional<Selector::SimpleSelector::ANPlusBPattern> {
         if constexpr (CSS_PARSER_DEBUG) {
-            dbgln_if(CSS_PARSER_DEBUG, "Invalid An+B value:");
+            dbgln_if<CSS_PARSER_DEBUG>("Invalid An+B value:");
             values.dump_all_tokens();
         }
         return {};
@@ -3900,7 +3900,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         values.skip_whitespace();
         if (values.has_next_token()) {
             if constexpr (CSS_PARSER_DEBUG) {
-                dbgln_if(CSS_PARSER_DEBUG, "Extra tokens at end of An+B value:");
+                dbgln_if<CSS_PARSER_DEBUG>("Extra tokens at end of An+B value:");
                 values.dump_all_tokens();
             }
             return syntax_error();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -19,7 +19,7 @@ static const u32 TOKENIZER_EOF = 0xFFFFFFFF;
 
 static inline void log_parse_error(const SourceLocation& location = SourceLocation::current())
 {
-    dbgln_if(CSS_TOKENIZER_DEBUG, "Parse error (css tokenization) {} ", location);
+    dbgln_if<CSS_TOKENIZER_DEBUG>("Parse error (css tokenization) {} ", location);
 }
 
 static inline bool is_eof(u32 code_point)
@@ -270,7 +270,7 @@ u32 Tokenizer::next_code_point()
         m_position.column++;
     }
 
-    dbgln_if(CSS_TOKENIZER_DEBUG, "(Tokenizer) Next code_point: {:d}", code_point);
+    dbgln_if<CSS_TOKENIZER_DEBUG>("(Tokenizer) Next code_point: {:d}", code_point);
     return code_point;
 }
 
@@ -281,7 +281,7 @@ u32 Tokenizer::peek_code_point(size_t offset) const
         ++it;
     if (it == m_utf8_view.end())
         return TOKENIZER_EOF;
-    dbgln_if(CSS_TOKENIZER_DEBUG, "(Tokenizer) Peek code_point: {:d}", *m_prev_utf8_iterator);
+    dbgln_if<CSS_TOKENIZER_DEBUG>("(Tokenizer) Peek code_point: {:d}", *m_prev_utf8_iterator);
     return *it;
 }
 
@@ -293,7 +293,7 @@ U32Twin Tokenizer::peek_twin() const
         values.set(i, *it);
         ++it;
     }
-    dbgln_if(CSS_TOKENIZER_DEBUG, "(Tokenizer) Peek twin: {:d},{:d}", values.first, values.second);
+    dbgln_if<CSS_TOKENIZER_DEBUG>("(Tokenizer) Peek twin: {:d},{:d}", values.first, values.second);
     return values;
 }
 
@@ -305,7 +305,7 @@ U32Triplet Tokenizer::peek_triplet() const
         values.set(i, *it);
         ++it;
     }
-    dbgln_if(CSS_TOKENIZER_DEBUG, "(Tokenizer) Peek triplet: {:d},{:d},{:d}", values.first, values.second, values.third);
+    dbgln_if<CSS_TOKENIZER_DEBUG>("(Tokenizer) Peek triplet: {:d},{:d},{:d}", values.first, values.second, values.third);
     return values;
 }
 
@@ -1097,7 +1097,7 @@ Token Tokenizer::consume_a_token()
 
     // whitespace
     if (is_whitespace(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is whitespace");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is whitespace");
         // Consume as much whitespace as possible. Return a <whitespace-token>.
         consume_as_much_whitespace_as_possible();
         return create_new_token(Token::Type::Whitespace);
@@ -1105,14 +1105,14 @@ Token Tokenizer::consume_a_token()
 
     // U+0022 QUOTATION MARK (")
     if (is_quotation_mark(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is quotation mark");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is quotation mark");
         // Consume a string token and return it.
         return consume_string_token(input);
     }
 
     // U+0023 NUMBER SIGN (#)
     if (is_number_sign(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is number sign");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is number sign");
 
         // If the next input code point is a name code point or the next two input code points
         // are a valid escape, then:
@@ -1142,28 +1142,28 @@ Token Tokenizer::consume_a_token()
 
     // U+0027 APOSTROPHE (')
     if (is_apostrophe(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is apostrophe");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is apostrophe");
         // Consume a string token and return it.
         return consume_string_token(input);
     }
 
     // U+0028 LEFT PARENTHESIS (()
     if (is_left_paren(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is left paren");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is left paren");
         // Return a <(-token>.
         return create_new_token(Token::Type::OpenParen);
     }
 
     // U+0029 RIGHT PARENTHESIS ())
     if (is_right_paren(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is right paren");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is right paren");
         // Return a <)-token>.
         return create_new_token(Token::Type::CloseParen);
     }
 
     // U+002B PLUS SIGN (+)
     if (is_plus_sign(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is plus sign");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is plus sign");
         // If the input stream starts with a number, reconsume the current input code point,
         // consume a numeric token and return it.
         if (would_start_a_number(start_of_input_stream_triplet())) {
@@ -1177,14 +1177,14 @@ Token Tokenizer::consume_a_token()
 
     // U+002C COMMA (,)
     if (is_comma(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is comma");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is comma");
         // Return a <comma-token>.
         return create_new_token(Token::Type::Comma);
     }
 
     // U+002D HYPHEN-MINUS (-)
     if (is_hyphen_minus(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is hyphen minus");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is hyphen minus");
         // If the input stream starts with a number, reconsume the current input code point,
         // consume a numeric token, and return it.
         if (would_start_a_number(start_of_input_stream_triplet())) {
@@ -1215,7 +1215,7 @@ Token Tokenizer::consume_a_token()
 
     // U+002E FULL STOP (.)
     if (is_full_stop(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is full stop");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is full stop");
         // If the input stream starts with a number, reconsume the current input code point,
         // consume a numeric token, and return it.
         if (would_start_a_number(start_of_input_stream_triplet())) {
@@ -1229,21 +1229,21 @@ Token Tokenizer::consume_a_token()
 
     // U+003A COLON (:)
     if (is_colon(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is colon");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is colon");
         // Return a <colon-token>.
         return create_new_token(Token::Type::Colon);
     }
 
     // U+003B SEMICOLON (;)
     if (is_semicolon(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is semicolon");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is semicolon");
         // Return a <semicolon-token>.
         return create_new_token(Token::Type::Semicolon);
     }
 
     // U+003C LESS-THAN SIGN (<)
     if (is_less_than_sign(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is less than");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is less than");
         // If the next 3 input code points are U+0021 EXCLAMATION MARK U+002D HYPHEN-MINUS
         // U+002D HYPHEN-MINUS (!--), consume them and return a <CDO-token>.
         auto maybe_cdo = peek_triplet();
@@ -1261,7 +1261,7 @@ Token Tokenizer::consume_a_token()
 
     // U+0040 COMMERCIAL AT (@)
     if (is_at(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is at");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is at");
         // If the next 3 input code points would start an identifier, consume a name, create
         // an <at-keyword-token> with its value set to the returned value, and return it.
         if (would_start_an_identifier(peek_triplet())) {
@@ -1275,14 +1275,14 @@ Token Tokenizer::consume_a_token()
 
     // U+005B LEFT SQUARE BRACKET ([)
     if (is_open_square_bracket(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is open square");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is open square");
         // Return a <[-token>.
         return create_new_token(Token::Type::OpenSquare);
     }
 
     // U+005C REVERSE SOLIDUS (\)
     if (is_reverse_solidus(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is reverse solidus");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is reverse solidus");
         // If the input stream starts with a valid escape, reconsume the current input code point,
         // consume an ident-like token, and return it.
         if (is_valid_escape_sequence(start_of_input_stream_twin())) {
@@ -1298,28 +1298,28 @@ Token Tokenizer::consume_a_token()
 
     // U+005D RIGHT SQUARE BRACKET (])
     if (is_closed_square_bracket(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is closed square");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is closed square");
         // Return a <]-token>.
         return create_new_token(Token::Type::CloseSquare);
     }
 
     // U+007B LEFT CURLY BRACKET ({)
     if (is_open_curly_bracket(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is open curly");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is open curly");
         // Return a <{-token>.
         return create_new_token(Token::Type::OpenCurly);
     }
 
     // U+007D RIGHT CURLY BRACKET (})
     if (is_closed_curly_bracket(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is closed curly");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is closed curly");
         // Return a <}-token>.
         return create_new_token(Token::Type::CloseCurly);
     }
 
     // digit
     if (is_ascii_digit(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is digit");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is digit");
         // Reconsume the current input code point, consume a numeric token, and return it.
         reconsume_current_input_code_point();
         return consume_a_numeric_token();
@@ -1327,7 +1327,7 @@ Token Tokenizer::consume_a_token()
 
     // name-start code point
     if (is_name_start_code_point(input)) {
-        dbgln_if(CSS_TOKENIZER_DEBUG, "is name start");
+        dbgln_if<CSS_TOKENIZER_DEBUG>("is name start");
         // Reconsume the current input code point, consume an ident-like token, and return it.
         reconsume_current_input_code_point();
         return consume_an_ident_like_token();
@@ -1340,7 +1340,7 @@ Token Tokenizer::consume_a_token()
     }
 
     // anything else
-    dbgln_if(CSS_TOKENIZER_DEBUG, "is delimiter");
+    dbgln_if<CSS_TOKENIZER_DEBUG>("is delimiter");
     // Return a <delim-token> with its value set to the current input code point.
     return create_value_token(Token::Type::Delim, input);
 }

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -699,10 +699,10 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::Invalid:
         return IdentifierStyleValue::create(CSS::ValueID::Invalid);
     case CSS::PropertyID::Custom:
-        dbgln_if(LIBWEB_CSS_DEBUG, "Computed style for custom properties was requested (?)");
+        dbgln_if<LIBWEB_CSS_DEBUG>("Computed style for custom properties was requested (?)");
         return {};
     default:
-        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Computed style for the '{}' property was requested", string_from_property_id(property_id));
+        dbgln_if<LIBWEB_CSS_DEBUG>("FIXME: Computed style for the '{}' property was requested", string_from_property_id(property_id));
         return {};
     }
     }

--- a/Userland/Libraries/LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -22,17 +22,17 @@ bool SyntaxHighlighter::is_navigatable(u64) const
 
 void SyntaxHighlighter::rehighlight(Palette const& palette)
 {
-    dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "(CSS::SyntaxHighlighter) starting rehighlight");
+    dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("(CSS::SyntaxHighlighter) starting rehighlight");
     auto text = m_client->get_text();
 
     Vector<GUI::TextDocumentSpan> spans;
 
     auto highlight = [&](auto start_line, auto start_column, auto end_line, auto end_column, Gfx::TextAttributes attributes, CSS::Token::Type type) {
         if (start_line > end_line || (start_line == end_line && start_column >= end_column)) {
-            dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "(CSS::SyntaxHighlighter) discarding ({}-{}) to ({}-{}) because it has zero or negative length", start_line, start_column, end_line, end_column);
+            dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("(CSS::SyntaxHighlighter) discarding ({}-{}) to ({}-{}) because it has zero or negative length", start_line, start_column, end_line, end_column);
             return;
         }
-        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "(CSS::SyntaxHighlighter) highlighting ({}-{}) to ({}-{}) with color {}", start_line, start_column, end_line, end_column, attributes.color);
+        dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("(CSS::SyntaxHighlighter) highlighting ({}-{}) to ({}-{}) with color {}", start_line, start_column, end_line, end_column, attributes.color);
         spans.empend(
             GUI::TextRange {
                 { start_line, start_column },

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -31,7 +31,7 @@ void HTMLLinkElement::inserted()
 
     if (m_relationship & Relationship::Stylesheet && !(m_relationship & Relationship::Alternate)) {
         auto url = document().parse_url(href());
-        dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Loading import URL: {}", url);
+        dbgln_if<CSS_LOADER_DEBUG>("HTMLLinkElement: Loading import URL: {}", url);
         auto request = LoadRequest::create_for_url_on_page(url, document().page());
         set_resource(ResourceLoader::the().load_resource(Resource::Type::Generic, request));
         m_document_load_event_delayer.emplace(document());
@@ -71,7 +71,7 @@ void HTMLLinkElement::parse_attribute(const FlyString& name, const String& value
 
 void HTMLLinkElement::resource_did_fail()
 {
-    dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Resource did fail. URL: {}", resource()->url());
+    dbgln_if<CSS_LOADER_DEBUG>("HTMLLinkElement: Resource did fail. URL: {}", resource()->url());
 
     m_document_load_event_delayer.clear();
 }
@@ -83,14 +83,14 @@ void HTMLLinkElement::resource_did_load()
     m_document_load_event_delayer.clear();
 
     if (!resource()->has_encoded_data()) {
-        dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Resource did load, no encoded data. URL: {}", resource()->url());
+        dbgln_if<CSS_LOADER_DEBUG>("HTMLLinkElement: Resource did load, no encoded data. URL: {}", resource()->url());
     } else {
-        dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Resource did load, has encoded data. URL: {}", resource()->url());
+        dbgln_if<CSS_LOADER_DEBUG>("HTMLLinkElement: Resource did load, has encoded data. URL: {}", resource()->url());
     }
 
     auto sheet = parse_css(CSS::ParsingContext(document()), resource()->encoded_data());
     if (!sheet) {
-        dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Failed to parse stylesheet: {}", resource()->url());
+        dbgln_if<CSS_LOADER_DEBUG>("HTMLLinkElement: Failed to parse stylesheet: {}", resource()->url());
         return;
     }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -80,9 +80,9 @@ void HTMLScriptElement::execute_script()
             node_document->set_current_script({}, nullptr);
 
         if (m_from_an_external_file)
-            dbgln_if(HTML_SCRIPT_DEBUG, "HTMLScriptElement: Running script {}", attribute(HTML::AttributeNames::src));
+            dbgln_if<HTML_SCRIPT_DEBUG>("HTMLScriptElement: Running script {}", attribute(HTML::AttributeNames::src));
         else
-            dbgln_if(HTML_SCRIPT_DEBUG, "HTMLScriptElement: Running inline script");
+            dbgln_if<HTML_SCRIPT_DEBUG>("HTMLScriptElement: Running inline script");
 
         // 3. Run the classic script given by the script's script for scriptElement.
         verify_cast<ClassicScript>(*m_script).run();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -152,7 +152,7 @@ void HTMLParser::run(const AK::URL& url)
             break;
         auto& token = optional_token.value();
 
-        dbgln_if(PARSER_DEBUG, "[{}] {}", insertion_mode_name(), token.to_string());
+        dbgln_if<PARSER_DEBUG>("[{}] {}", insertion_mode_name(), token.to_string());
 
         // https://html.spec.whatwg.org/multipage/parsing.html#tree-construction-dispatcher
         // As each token is emitted from the tokenizer, the user agent must follow the appropriate steps from the following list, known as the tree construction dispatcher:
@@ -179,7 +179,7 @@ void HTMLParser::run(const AK::URL& url)
         }
 
         if (m_stop_parsing) {
-            dbgln_if(PARSER_DEBUG, "Stop parsing{}! :^)", m_parsing_fragment ? " fragment" : "");
+            dbgln_if<PARSER_DEBUG>("Stop parsing{}! :^)", m_parsing_fragment ? " fragment" : "");
             break;
         }
     }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -177,7 +177,7 @@ namespace Web::HTML {
 
 static inline void log_parse_error(SourceLocation const& location = SourceLocation::current())
 {
-    dbgln_if(TOKENIZER_TRACE_DEBUG, "Parse error (tokenization) {}", location);
+    dbgln_if<TOKENIZER_TRACE_DEBUG>("Parse error (tokenization) {}", location);
 }
 
 Optional<u32> HTMLTokenizer::next_code_point()
@@ -185,7 +185,7 @@ Optional<u32> HTMLTokenizer::next_code_point()
     if (m_utf8_iterator == m_utf8_view.end())
         return {};
     skip(1);
-    dbgln_if(TOKENIZER_TRACE_DEBUG, "(Tokenizer) Next code_point: {}", (char)*m_prev_utf8_iterator);
+    dbgln_if<TOKENIZER_TRACE_DEBUG>("(Tokenizer) Next code_point: {}", (char)*m_prev_utf8_iterator);
     return *m_prev_utf8_iterator;
 }
 
@@ -218,7 +218,7 @@ Optional<u32> HTMLTokenizer::peek_code_point(size_t offset) const
 HTMLToken::Position HTMLTokenizer::nth_last_position(size_t n)
 {
     if (n + 1 > m_source_positions.size()) {
-        dbgln_if(TOKENIZER_TRACE_DEBUG, "(Tokenizer::nth_last_position) Invalid position requested: {}th-last of {}. Returning (0-0).", n, m_source_positions.size());
+        dbgln_if<TOKENIZER_TRACE_DEBUG>("(Tokenizer::nth_last_position) Invalid position requested: {}th-last of {}. Returning (0-0).", n, m_source_positions.size());
         return HTMLToken::Position { 0, 0 };
     };
     return m_source_positions.at(m_source_positions.size() - 1 - n);
@@ -2690,17 +2690,17 @@ HTMLTokenizer::HTMLTokenizer(StringView input, String const& encoding)
 
 void HTMLTokenizer::will_switch_to([[maybe_unused]] State new_state)
 {
-    dbgln_if(TOKENIZER_TRACE_DEBUG, "[{}] Switch to {}", state_name(m_state), state_name(new_state));
+    dbgln_if<TOKENIZER_TRACE_DEBUG>("[{}] Switch to {}", state_name(m_state), state_name(new_state));
 }
 
 void HTMLTokenizer::will_reconsume_in([[maybe_unused]] State new_state)
 {
-    dbgln_if(TOKENIZER_TRACE_DEBUG, "[{}] Reconsume in {}", state_name(m_state), state_name(new_state));
+    dbgln_if<TOKENIZER_TRACE_DEBUG>("[{}] Reconsume in {}", state_name(m_state), state_name(new_state));
 }
 
 void HTMLTokenizer::switch_to(Badge<HTMLParser>, State new_state)
 {
-    dbgln_if(TOKENIZER_TRACE_DEBUG, "[{}] Parser switches tokenizer state to {}", state_name(m_state), state_name(new_state));
+    dbgln_if<TOKENIZER_TRACE_DEBUG>("[{}] Parser switches tokenizer state to {}", state_name(m_state), state_name(new_state));
     m_state = new_state;
 }
 

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -39,7 +39,7 @@ NonnullRefPtr<ClassicScript> ClassicScript::create(String filename, StringView s
     // 10. Let result be ParseScript(source, settings's Realm, script).
     auto parse_timer = Core::ElapsedTimer::start_new();
     auto result = JS::Script::parse(source, realm, script->filename());
-    dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Parsed {} in {}ms", script->filename(), parse_timer.elapsed());
+    dbgln_if<HTML_SCRIPT_DEBUG>("ClassicScript: Parsed {} in {}ms", script->filename(), parse_timer.elapsed());
 
     // 11. If result is a list of errors, then:
 
@@ -66,7 +66,7 @@ JS::Value ClassicScript::run(RethrowErrors rethrow_errors)
         return {};
     }
 
-    dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Running script {}", filename());
+    dbgln_if<HTML_SCRIPT_DEBUG>("ClassicScript: Running script {}", filename());
     (void)rethrow_errors;
 
     auto timer = Core::ElapsedTimer::start_new();
@@ -78,7 +78,7 @@ JS::Value ClassicScript::run(RethrowErrors rethrow_errors)
 
     // FIXME: If ScriptEvaluation does not complete because the user agent has aborted the running script, leave evaluationStatus as null.
 
-    dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Finished running script {}, Duration: {}ms", filename(), timer.elapsed());
+    dbgln_if<HTML_SCRIPT_DEBUG>("ClassicScript: Finished running script {}, Duration: {}ms", filename(), timer.elapsed());
     if (evaluation_status.is_error()) {
         // FIXME: Propagate error according to the spec.
         interpreter->vm().clear_exception();

--- a/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibWeb/HTML/SyntaxHighlighter/SyntaxHighlighter.cpp
@@ -37,17 +37,17 @@ bool SyntaxHighlighter::is_navigatable(u64) const
 
 void SyntaxHighlighter::rehighlight(Palette const& palette)
 {
-    dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "(HTML::SyntaxHighlighter) starting rehighlight");
+    dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("(HTML::SyntaxHighlighter) starting rehighlight");
     auto text = m_client->get_text();
     clear_nested_token_pairs();
 
     Vector<GUI::TextDocumentSpan> spans;
     auto highlight = [&](auto start_line, auto start_column, auto end_line, auto end_column, Gfx::TextAttributes attributes, AugmentedTokenKind kind) {
         if (start_line > end_line || (start_line == end_line && start_column >= end_column)) {
-            dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "(HTML::SyntaxHighlighter) discarding ({}-{}) to ({}-{}) because it has zero or negative length", start_line, start_column, end_line, end_column);
+            dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("(HTML::SyntaxHighlighter) discarding ({}-{}) to ({}-{}) because it has zero or negative length", start_line, start_column, end_line, end_column);
             return;
         }
-        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "(HTML::SyntaxHighlighter) highlighting ({}-{}) to ({}-{}) with color {}", start_line, start_column, end_line, end_column, attributes.color);
+        dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("(HTML::SyntaxHighlighter) highlighting ({}-{}) to ({}-{}) with color {}", start_line, start_column, end_line, end_column, attributes.color);
         spans.empend(
             GUI::TextRange {
                 { start_line, start_column },
@@ -71,7 +71,7 @@ void SyntaxHighlighter::rehighlight(Palette const& palette)
         auto token = tokenizer.next_token();
         if (!token.has_value() || token.value().is_end_of_file())
             break;
-        dbgln_if(SYNTAX_HIGHLIGHTING_DEBUG, "(HTML::SyntaxHighlighter) got token of type {}", token->to_string());
+        dbgln_if<SYNTAX_HIGHLIGHTING_DEBUG>("(HTML::SyntaxHighlighter) got token of type {}", token->to_string());
 
         if (token->is_start_tag()) {
             if (token->tag_name() == "script"sv) {

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -112,8 +112,8 @@ static bool build_gemini_document(DOM::Document& document, const ByteBuffer& dat
     auto gemini_document = Gemini::Document::parse(gemini_data, document.url());
     String html_data = gemini_document->render_to_html();
 
-    dbgln_if(GEMINI_DEBUG, "Gemini data:\n\"\"\"{}\"\"\"", gemini_data);
-    dbgln_if(GEMINI_DEBUG, "Converted to HTML:\n\"\"\"{}\"\"\"", html_data);
+    dbgln_if<GEMINI_DEBUG>("Gemini data:\n\"\"\"{}\"\"\"", gemini_data);
+    dbgln_if<GEMINI_DEBUG>("Converted to HTML:\n\"\"\"{}\"\"\"", html_data);
 
     HTML::HTMLParser parser(document, html_data, "utf-8");
     parser.run(document.url());
@@ -174,7 +174,7 @@ bool FrameLoader::load(LoadRequest& request, Type type)
         ResourceLoader::the().load(
             favicon_url,
             [this, favicon_url](auto data, auto&, auto) {
-                dbgln_if(SPAM_DEBUG, "Favicon downloaded, {} bytes from {}", data.size(), favicon_url);
+                dbgln_if<SPAM_DEBUG>("Favicon downloaded, {} bytes from {}", data.size(), favicon_url);
                 if (data.is_empty())
                     return;
                 RefPtr<Gfx::Bitmap> favicon_bitmap;
@@ -183,7 +183,7 @@ bool FrameLoader::load(LoadRequest& request, Type type)
                     dbgln("Could not decode favicon {}", favicon_url);
                 } else {
                     favicon_bitmap = decoded_image->frames[0].bitmap;
-                    dbgln_if(IMAGE_DECODER_DEBUG, "Decoded favicon, {}", favicon_bitmap->size());
+                    dbgln_if<IMAGE_DECODER_DEBUG>("Decoded favicon, {}", favicon_bitmap->size());
                 }
                 load_favicon(favicon_bitmap);
             },
@@ -199,7 +199,7 @@ bool FrameLoader::load(LoadRequest& request, Type type)
 
 bool FrameLoader::load(const AK::URL& url, Type type)
 {
-    dbgln_if(SPAM_DEBUG, "FrameLoader::load: {}", url);
+    dbgln_if<SPAM_DEBUG>("FrameLoader::load: {}", url);
 
     if (!url.is_valid()) {
         load_error_page(url, "Invalid URL");
@@ -277,9 +277,9 @@ void FrameLoader::resource_did_load()
     }
 
     if (resource()->has_encoding()) {
-        dbgln_if(RESOURCE_DEBUG, "This content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding().value());
+        dbgln_if<RESOURCE_DEBUG>("This content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding().value());
     } else {
-        dbgln_if(RESOURCE_DEBUG, "This content has MIME type '{}', encoding unknown", resource()->mime_type());
+        dbgln_if<RESOURCE_DEBUG>("This content has MIME type '{}', encoding unknown", resource()->mime_type());
     }
 
     auto document = DOM::Document::create();

--- a/Userland/Libraries/LibWeb/Loader/Resource.cpp
+++ b/Userland/Libraries/LibWeb/Loader/Resource.cpp
@@ -77,7 +77,7 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap
     auto content_type = headers.get("Content-Type");
 
     if (content_type.has_value()) {
-        dbgln_if(RESOURCE_DEBUG, "Content-Type header: '{}'", content_type.value());
+        dbgln_if<RESOURCE_DEBUG>("Content-Type header: '{}'", content_type.value());
         m_mime_type = mime_type_from_content_type(content_type.value());
         // FIXME: "The Quite OK Image Format" doesn't have an official mime type yet,
         //        and servers like nginx will send a generic octet-stream mime type instead.
@@ -85,7 +85,7 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap
         if (m_mime_type == "application/octet-stream" && url().path().ends_with(".qoi"))
             m_mime_type = "image/x-qoi";
     } else if (url().protocol() == "data" && !url().data_mime_type().is_empty()) {
-        dbgln_if(RESOURCE_DEBUG, "This is a data URL with mime-type _{}_", url().data_mime_type());
+        dbgln_if<RESOURCE_DEBUG>("This is a data URL with mime-type _{}_", url().data_mime_type());
         m_mime_type = url().data_mime_type();
     } else {
         auto content_type_options = headers.get("X-Content-Type-Options");
@@ -100,7 +100,7 @@ void Resource::did_load(Badge<ResourceLoader>, ReadonlyBytes data, const HashMap
     if (content_type.has_value()) {
         auto encoding = encoding_from_content_type(content_type.value());
         if (encoding.has_value()) {
-            dbgln_if(RESOURCE_DEBUG, "Set encoding '{}' from Content-Type", encoding.has_value());
+            dbgln_if<RESOURCE_DEBUG>("Set encoding '{}' from Content-Type", encoding.has_value());
             m_encoding = encoding.value();
         }
     }

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -84,7 +84,7 @@ RefPtr<Resource> ResourceLoader::load_resource(Resource::Type type, LoadRequest&
             if (it->value->type() != type) {
                 dbgln("FIXME: Not using cached resource for {} since there's a type mismatch.", request.url());
             } else {
-                dbgln_if(CACHE_DEBUG, "Reusing cached resource for: {}", request.url());
+                dbgln_if<CACHE_DEBUG>("Reusing cached resource for: {}", request.url());
                 return it->value;
             }
         }
@@ -145,7 +145,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, con
     }
 
     if (url.protocol() == "about") {
-        dbgln_if(SPAM_DEBUG, "Loading about: URL {}", url);
+        dbgln_if<SPAM_DEBUG>("Loading about: URL {}", url);
         log_success(request);
         deferred_invoke([success_callback = move(success_callback)] {
             success_callback(String::empty().to_byte_buffer(), {}, {});
@@ -154,7 +154,7 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, con
     }
 
     if (url.protocol() == "data") {
-        dbgln_if(SPAM_DEBUG, "ResourceLoader loading a data URL with mime-type: '{}', base64={}, payload='{}'",
+        dbgln_if<SPAM_DEBUG>("ResourceLoader loading a data URL with mime-type: '{}', base64={}, payload='{}'",
             url.data_mime_type(),
             url.data_payload_is_base64(),
             url.data_payload());
@@ -272,7 +272,7 @@ bool ResourceLoader::is_port_blocked(int port)
 
 void ResourceLoader::clear_cache()
 {
-    dbgln_if(CACHE_DEBUG, "Clearing {} items from ResourceLoader cache", s_resource_cache.size());
+    dbgln_if<CACHE_DEBUG>("Clearing {} items from ResourceLoader cache", s_resource_cache.size());
     s_resource_cache.clear();
 }
 

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -35,7 +35,7 @@ void WebContentClient::did_finish_loading(AK::URL const& url)
 
 void WebContentClient::did_invalidate_content_rect(Gfx::IntRect const& content_rect)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidInvalidateContentRect! content_rect={}", content_rect);
+    dbgln_if<SPAM_DEBUG>("handle: WebContentClient::DidInvalidateContentRect! content_rect={}", content_rect);
 
     // FIXME: Figure out a way to coalesce these messages to reduce unnecessary painting
     m_view.notify_server_did_invalidate_content_rect({}, content_rect);
@@ -43,7 +43,7 @@ void WebContentClient::did_invalidate_content_rect(Gfx::IntRect const& content_r
 
 void WebContentClient::did_change_selection()
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidChangeSelection!");
+    dbgln_if<SPAM_DEBUG>("handle: WebContentClient::DidChangeSelection!");
     m_view.notify_server_did_change_selection({});
 }
 
@@ -58,13 +58,13 @@ void WebContentClient::did_request_cursor_change(i32 cursor_type)
 
 void WebContentClient::did_layout(Gfx::IntSize const& content_size)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidLayout! content_size={}", content_size);
+    dbgln_if<SPAM_DEBUG>("handle: WebContentClient::DidLayout! content_size={}", content_size);
     m_view.notify_server_did_layout({}, content_size);
 }
 
 void WebContentClient::did_change_title(String const& title)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidChangeTitle! title={}", title);
+    dbgln_if<SPAM_DEBUG>("handle: WebContentClient::DidChangeTitle! title={}", title);
     m_view.notify_server_did_change_title({}, title);
 }
 
@@ -80,7 +80,7 @@ void WebContentClient::did_request_scroll_to(Gfx::IntPoint const& scroll_positio
 
 void WebContentClient::did_request_scroll_into_view(Gfx::IntRect const& rect)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidRequestScrollIntoView! rect={}", rect);
+    dbgln_if<SPAM_DEBUG>("handle: WebContentClient::DidRequestScrollIntoView! rect={}", rect);
     m_view.notify_server_did_request_scroll_into_view({}, rect);
 }
 
@@ -96,13 +96,13 @@ void WebContentClient::did_leave_tooltip_area()
 
 void WebContentClient::did_hover_link(AK::URL const& url)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidHoverLink! url={}", url);
+    dbgln_if<SPAM_DEBUG>("handle: WebContentClient::DidHoverLink! url={}", url);
     m_view.notify_server_did_hover_link({}, url);
 }
 
 void WebContentClient::did_unhover_link()
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentClient::DidUnhoverLink!");
+    dbgln_if<SPAM_DEBUG>("handle: WebContentClient::DidUnhoverLink!");
     m_view.notify_server_did_unhover_link({});
 }
 

--- a/Userland/Services/DHCPClient/DHCPv4.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4.cpp
@@ -24,7 +24,7 @@ ParsedDHCPv4Options DHCPv4Packet::parse_options() const
                 dbgln("Bogus option length {} assuming forgotten END", length);
                 break;
             }
-            dbgln_if(DHCPV4_DEBUG, "DHCP Option {} with length {}", (u8)opt_name, length);
+            dbgln_if<DHCPV4_DEBUG>("DHCP Option {} with length {}", (u8)opt_name, length);
             ++index;
             options.options.set(opt_name, { length, &m_options[index] });
             index += length - 1;

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -52,9 +52,9 @@ static bool send(const InterfaceDescriptor& iface, const DHCPv4Packet& packet, C
     dst.sin_addr.s_addr = IPv4Address { 255, 255, 255, 255 }.to_u32();
     memset(&dst.sin_zero, 0, sizeof(dst.sin_zero));
 
-    dbgln_if(DHCPV4CLIENT_DEBUG, "sendto({} bound to {}, ..., {} at {}) = ...?", fd, iface.ifname, dst.sin_addr.s_addr, dst.sin_port);
+    dbgln_if<DHCPV4CLIENT_DEBUG>("sendto({} bound to {}, ..., {} at {}) = ...?", fd, iface.ifname, dst.sin_addr.s_addr, dst.sin_port);
     auto rc = sendto(fd, &packet, sizeof(packet), 0, (sockaddr*)&dst, sizeof(dst));
-    dbgln_if(DHCPV4CLIENT_DEBUG, "sendto({}) = {}", fd, rc);
+    dbgln_if<DHCPV4CLIENT_DEBUG>("sendto({}) = {}", fd, rc);
     if (rc < 0) {
         dbgln("sendto failed with {}", strerror(errno));
         return false;
@@ -114,7 +114,7 @@ DHCPv4Client::DHCPv4Client()
     m_server = Core::UDPServer::construct(this);
     m_server->on_ready_to_receive = [this] {
         auto buffer = m_server->receive(sizeof(DHCPv4Packet));
-        dbgln_if(DHCPV4CLIENT_DEBUG, "Received {} bytes", buffer.size());
+        dbgln_if<DHCPV4CLIENT_DEBUG>("Received {} bytes", buffer.size());
         if (buffer.size() < sizeof(DHCPv4Packet) - DHCPV4_OPTION_FIELD_MAX_LENGTH + 1 || buffer.size() > sizeof(DHCPv4Packet)) {
             dbgln("we expected {}-{} bytes, this is a bad packet", sizeof(DHCPv4Packet) - DHCPV4_OPTION_FIELD_MAX_LENGTH + 1, sizeof(DHCPv4Packet));
             return;
@@ -187,10 +187,10 @@ ErrorOr<DHCPv4Client::Interfaces> DHCPv4Client::get_discoverable_interfaces()
         auto ipv4_addr_maybe = IPv4Address::from_string(if_object.get("ipv4_address").to_string());
         auto ipv4_addr = ipv4_addr_maybe.has_value() ? ipv4_addr_maybe.value() : IPv4Address { 0, 0, 0, 0 };
         if (is_up) {
-            dbgln_if(DHCPV4_DEBUG, "Found adapter '{}' with mac {}, and it was up!", name, mac);
+            dbgln_if<DHCPV4_DEBUG>("Found adapter '{}' with mac {}, and it was up!", name, mac);
             ifnames_to_immediately_discover.empend(name, mac_from_string(mac), ipv4_addr);
         } else {
-            dbgln_if(DHCPV4_DEBUG, "Found adapter '{}' with mac {}, but it was down", name, mac);
+            dbgln_if<DHCPV4_DEBUG>("Found adapter '{}' with mac {}, but it was down", name, mac);
             ifnames_to_attempt_later.empend(name, mac_from_string(mac), ipv4_addr);
         }
     });
@@ -279,7 +279,7 @@ void DHCPv4Client::process_incoming(const DHCPv4Packet& packet)
 {
     auto options = packet.parse_options();
 
-    dbgln_if(DHCPV4CLIENT_DEBUG, "Here are the options: {}", options.to_string());
+    dbgln_if<DHCPV4CLIENT_DEBUG>("Here are the options: {}", options.to_string());
 
     auto value_or_error = options.get<DHCPMessageType>(DHCPOption::DHCPMessageType);
     if (!value_or_error.has_value())

--- a/Userland/Services/ImageDecoder/ClientConnection.cpp
+++ b/Userland/Services/ImageDecoder/ClientConnection.cpp
@@ -29,19 +29,19 @@ void ClientConnection::die()
 Messages::ImageDecoderServer::DecodeImageResponse ClientConnection::decode_image(Core::AnonymousBuffer const& encoded_buffer)
 {
     if (!encoded_buffer.is_valid()) {
-        dbgln_if(IMAGE_DECODER_DEBUG, "Encoded data is invalid");
+        dbgln_if<IMAGE_DECODER_DEBUG>("Encoded data is invalid");
         return nullptr;
     }
 
     auto decoder = Gfx::ImageDecoder::try_create(ReadonlyBytes { encoded_buffer.data<u8>(), encoded_buffer.size() });
 
     if (!decoder) {
-        dbgln_if(IMAGE_DECODER_DEBUG, "Could not find suitable image decoder plugin for data");
+        dbgln_if<IMAGE_DECODER_DEBUG>("Could not find suitable image decoder plugin for data");
         return { false, 0, Vector<Gfx::ShareableBitmap> {}, Vector<u32> {} };
     }
 
     if (!decoder->frame_count()) {
-        dbgln_if(IMAGE_DECODER_DEBUG, "Could not decode image from encoded data");
+        dbgln_if<IMAGE_DECODER_DEBUG>("Could not decode image from encoded data");
         return { false, 0, Vector<Gfx::ShareableBitmap> {}, Vector<u32> {} };
     }
 

--- a/Userland/Services/LookupServer/DNSPacket.cpp
+++ b/Userland/Services/LookupServer/DNSPacket.cpp
@@ -104,11 +104,11 @@ Optional<DNSPacket> DNSPacket::from_raw_packet(const u8* raw_data, size_t raw_si
     }
 
     auto& header = *(const DNSPacketHeader*)(raw_data);
-    dbgln_if(LOOKUPSERVER_DEBUG, "Got packet (ID: {})", header.id());
-    dbgln_if(LOOKUPSERVER_DEBUG, "  Question count: {}", header.question_count());
-    dbgln_if(LOOKUPSERVER_DEBUG, "    Answer count: {}", header.answer_count());
-    dbgln_if(LOOKUPSERVER_DEBUG, " Authority count: {}", header.authority_count());
-    dbgln_if(LOOKUPSERVER_DEBUG, "Additional count: {}", header.additional_count());
+    dbgln_if<LOOKUPSERVER_DEBUG>("Got packet (ID: {})", header.id());
+    dbgln_if<LOOKUPSERVER_DEBUG>("  Question count: {}", header.question_count());
+    dbgln_if<LOOKUPSERVER_DEBUG>("    Answer count: {}", header.answer_count());
+    dbgln_if<LOOKUPSERVER_DEBUG>(" Authority count: {}", header.authority_count());
+    dbgln_if<LOOKUPSERVER_DEBUG>("Additional count: {}", header.additional_count());
 
     DNSPacket packet;
     packet.m_id = header.id();
@@ -133,7 +133,7 @@ Optional<DNSPacket> DNSPacket::from_raw_packet(const u8* raw_data, size_t raw_si
         packet.m_questions.empend(name, (DNSRecordType)(u16)record_and_class.record_type, (DNSRecordClass)class_code, mdns_wants_unicast_response);
         offset += 4;
         auto& question = packet.m_questions.last();
-        dbgln_if(LOOKUPSERVER_DEBUG, "Question #{}: name=_{}_, type={}, class={}", i, question.name(), question.record_type(), question.class_code());
+        dbgln_if<LOOKUPSERVER_DEBUG>("Question #{}: name=_{}_, type={}, class={}", i, question.name(), question.record_type(), question.class_code());
     }
 
     for (u16 i = 0; i < header.answer_count(); ++i) {
@@ -167,7 +167,7 @@ Optional<DNSPacket> DNSPacket::from_raw_packet(const u8* raw_data, size_t raw_si
             dbgln("data=(unimplemented record type {})", (u16)record.type());
         }
 
-        dbgln_if(LOOKUPSERVER_DEBUG, "Answer   #{}: name=_{}_, type={}, ttl={}, length={}, data=_{}_", i, name, record.type(), record.ttl(), record.data_length(), data);
+        dbgln_if<LOOKUPSERVER_DEBUG>("Answer   #{}: name=_{}_, type={}, ttl={}, length={}, data=_{}_", i, name, record.type(), record.ttl(), record.data_length(), data);
         u16 class_code = record.record_class() & ~MDNS_CACHE_FLUSH;
         bool mdns_cache_flush = record.record_class() & MDNS_CACHE_FLUSH;
         packet.m_answers.empend(name, (DNSRecordType)record.type(), (DNSRecordClass)class_code, record.ttl(), data, mdns_cache_flush);

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -133,7 +133,7 @@ static String get_hostname()
 
 Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, DNSRecordType record_type)
 {
-    dbgln_if(LOOKUPSERVER_DEBUG, "Got request for '{}'", name.as_string());
+    dbgln_if<LOOKUPSERVER_DEBUG>("Got request for '{}'", name.as_string());
 
     Vector<DNSAnswer> answers;
     auto add_answer = [&](const DNSAnswer& answer) {
@@ -173,7 +173,7 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, DNSRecordType record
         for (auto& answer : cached_answers->value) {
             // TODO: Actually remove expired answers from the cache.
             if (answer.type() == record_type && !answer.has_expired()) {
-                dbgln_if(LOOKUPSERVER_DEBUG, "Cache hit: {} -> {}", name.as_string(), answer.record_data());
+                dbgln_if<LOOKUPSERVER_DEBUG>("Cache hit: {} -> {}", name.as_string(), answer.record_data());
                 add_answer(answer);
             }
         }
@@ -191,7 +191,7 @@ Vector<DNSAnswer> LookupServer::lookup(const DNSName& name, DNSRecordType record
 
     // Fifth, ask the upstream nameservers.
     for (auto& nameserver : m_nameservers) {
-        dbgln_if(LOOKUPSERVER_DEBUG, "Doing lookup using nameserver '{}'", nameserver);
+        dbgln_if<LOOKUPSERVER_DEBUG>("Doing lookup using nameserver '{}'", nameserver);
         bool did_get_response = false;
         int retries = 3;
         Vector<DNSAnswer> upstream_answers;
@@ -338,7 +338,7 @@ void LookupServer::put_in_cache(const DNSAnswer& answer)
                 if (other_answer.received_time() >= now - 1)
                     return false;
 
-                dbgln_if(LOOKUPSERVER_DEBUG, "Removing cache entry: {}", other_answer.name());
+                dbgln_if<LOOKUPSERVER_DEBUG>("Removing cache entry: {}", other_answer.name());
                 return true;
             });
         }

--- a/Userland/Services/RequestServer/ConnectionCache.cpp
+++ b/Userland/Services/RequestServer/ConnectionCache.cpp
@@ -20,7 +20,7 @@ void request_did_finish(URL const& url, Core::Stream::Socket const* socket)
         return;
     }
 
-    dbgln_if(REQUESTSERVER_DEBUG, "Request for {} finished", url);
+    dbgln_if<REQUESTSERVER_DEBUG>("Request for {} finished", url);
 
     ConnectionKey key { url.host(), url.port_or_default() };
     auto fire_off_next_job = [&](auto& cache) {
@@ -44,7 +44,7 @@ void request_did_finish(URL const& url, Core::Stream::Socket const* socket)
                 connection->job_data = {};
                 connection->removal_timer->on_timeout = [ptr = connection.ptr(), &cache_entry, key = move(key), &cache]() mutable {
                     Core::deferred_invoke([&, key = move(key), ptr] {
-                        dbgln_if(REQUESTSERVER_DEBUG, "Removing no-longer-used connection {} (socket {})", ptr, ptr->socket);
+                        dbgln_if<REQUESTSERVER_DEBUG>("Removing no-longer-used connection {} (socket {})", ptr, ptr->socket);
                         auto did_remove = cache_entry.remove_first_matching([&](auto& entry) { return entry == ptr; });
                         VERIFY(did_remove);
                         if (cache_entry.is_empty())
@@ -60,7 +60,7 @@ void request_did_finish(URL const& url, Core::Stream::Socket const* socket)
                 return;
             }
             Core::deferred_invoke([&, url] {
-                dbgln_if(REQUESTSERVER_DEBUG, "Running next job in queue for connection {} @{}", &connection, connection->socket);
+                dbgln_if<REQUESTSERVER_DEBUG>("Running next job in queue for connection {} @{}", &connection, connection->socket);
                 connection->timer.start();
                 connection->current_url = url;
                 connection->job_data = connection->request_queue.take_first();

--- a/Userland/Services/RequestServer/ConnectionCache.h
+++ b/Userland/Services/RequestServer/ConnectionCache.h
@@ -136,7 +136,7 @@ ErrorOr<void> recreate_socket_if_needed(T& connection, URL const& url)
         } else {
             TRY(set_socket(TRY(SocketType::connect(url.host(), url.port_or_default()))));
         }
-        dbgln_if(REQUESTSERVER_DEBUG, "Creating a new socket for {} -> {}", url, connection.socket);
+        dbgln_if<REQUESTSERVER_DEBUG>("Creating a new socket for {} -> {}", url, connection.socket);
     }
     return {};
 }
@@ -207,7 +207,7 @@ decltype(auto) get_or_create_connection(auto& cache, URL const& url, auto& job)
             });
             return ReturnType { nullptr };
         }
-        dbgln_if(REQUESTSERVER_DEBUG, "Immediately start request for url {} in {} - {}", url, &connection, connection.socket);
+        dbgln_if<REQUESTSERVER_DEBUG>("Immediately start request for url {} in {} - {}", url, &connection, connection.socket);
         connection.has_started = true;
         connection.removal_timer->stop();
         connection.timer.start();
@@ -216,7 +216,7 @@ decltype(auto) get_or_create_connection(auto& cache, URL const& url, auto& job)
         connection.socket->set_notifications_enabled(true);
         connection.job_data.start(*connection.socket);
     } else {
-        dbgln_if(REQUESTSERVER_DEBUG, "Enqueue request for URL {} in {} - {}", url, &connection, connection.socket);
+        dbgln_if<REQUESTSERVER_DEBUG>("Enqueue request for URL {} in {} - {}", url, &connection, connection.socket);
         connection.request_queue.append(decltype(connection.job_data)::create(job));
     }
     return &connection;

--- a/Userland/Services/SQLServer/ClientConnection.cpp
+++ b/Userland/Services/SQLServer/ClientConnection.cpp
@@ -19,7 +19,7 @@ RefPtr<ClientConnection> ClientConnection::client_connection_for(int client_id)
 {
     if (s_connections.contains(client_id))
         return *s_connections.get(client_id).value();
-    dbgln_if(SQLSERVER_DEBUG, "Invalid client_id {}", client_id);
+    dbgln_if<SQLSERVER_DEBUG>("Invalid client_id {}", client_id);
     return nullptr;
 }
 
@@ -40,14 +40,14 @@ void ClientConnection::die()
 
 Messages::SQLServer::ConnectResponse ClientConnection::connect(String const& database_name)
 {
-    dbgln_if(SQLSERVER_DEBUG, "ClientConnection::connect(database_name: {})", database_name);
+    dbgln_if<SQLSERVER_DEBUG>("ClientConnection::connect(database_name: {})", database_name);
     auto database_connection = DatabaseConnection::construct(database_name, client_id());
     return { database_connection->connection_id() };
 }
 
 void ClientConnection::disconnect(int connection_id)
 {
-    dbgln_if(SQLSERVER_DEBUG, "ClientConnection::disconnect(connection_id: {})", connection_id);
+    dbgln_if<SQLSERVER_DEBUG>("ClientConnection::disconnect(connection_id: {})", connection_id);
     auto database_connection = DatabaseConnection::connection_for(connection_id);
     if (database_connection)
         database_connection->disconnect();
@@ -57,11 +57,11 @@ void ClientConnection::disconnect(int connection_id)
 
 Messages::SQLServer::SqlStatementResponse ClientConnection::sql_statement(int connection_id, String const& sql)
 {
-    dbgln_if(SQLSERVER_DEBUG, "ClientConnection::sql_statement(connection_id: {}, sql: '{}')", connection_id, sql);
+    dbgln_if<SQLSERVER_DEBUG>("ClientConnection::sql_statement(connection_id: {}, sql: '{}')", connection_id, sql);
     auto database_connection = DatabaseConnection::connection_for(connection_id);
     if (database_connection) {
         auto statement_id = database_connection->sql_statement(sql);
-        dbgln_if(SQLSERVER_DEBUG, "ClientConnection::sql_statement -> statement_id = {}", statement_id);
+        dbgln_if<SQLSERVER_DEBUG>("ClientConnection::sql_statement -> statement_id = {}", statement_id);
         return { statement_id };
     } else {
         dbgln("Database connection has disappeared");
@@ -71,12 +71,12 @@ Messages::SQLServer::SqlStatementResponse ClientConnection::sql_statement(int co
 
 void ClientConnection::statement_execute(int statement_id)
 {
-    dbgln_if(SQLSERVER_DEBUG, "ClientConnection::statement_execute_query(statement_id: {})", statement_id);
+    dbgln_if<SQLSERVER_DEBUG>("ClientConnection::statement_execute_query(statement_id: {})", statement_id);
     auto statement = SQLStatement::statement_for(statement_id);
     if (statement && statement->connection()->client_id() == client_id()) {
         statement->execute();
     } else {
-        dbgln_if(SQLSERVER_DEBUG, "Statement has disappeared");
+        dbgln_if<SQLSERVER_DEBUG>("Statement has disappeared");
         async_execution_error(statement_id, (int)SQL::SQLErrorCode::StatementUnavailable, String::formatted("{}", statement_id));
     }
 }

--- a/Userland/Services/SQLServer/DatabaseConnection.cpp
+++ b/Userland/Services/SQLServer/DatabaseConnection.cpp
@@ -17,7 +17,7 @@ RefPtr<DatabaseConnection> DatabaseConnection::connection_for(int connection_id)
 {
     if (s_connections.contains(connection_id))
         return *s_connections.get(connection_id).value();
-    dbgln_if(SQLSERVER_DEBUG, "Invalid connection_id {}", connection_id);
+    dbgln_if<SQLSERVER_DEBUG>("Invalid connection_id {}", connection_id);
     return nullptr;
 }
 
@@ -35,7 +35,7 @@ DatabaseConnection::DatabaseConnection(String database_name, int client_id)
         return;
     }
 
-    dbgln_if(SQLSERVER_DEBUG, "DatabaseConnection {} initiating connection with database '{}'", connection_id(), m_database_name);
+    dbgln_if<SQLSERVER_DEBUG>("DatabaseConnection {} initiating connection with database '{}'", connection_id(), m_database_name);
     s_connections.set(m_connection_id, *this);
     deferred_invoke([this]() {
         m_database = SQL::Database::construct(String::formatted("/home/anon/sql/{}.db", m_database_name));
@@ -54,7 +54,7 @@ DatabaseConnection::DatabaseConnection(String database_name, int client_id)
 
 void DatabaseConnection::disconnect()
 {
-    dbgln_if(SQLSERVER_DEBUG, "DatabaseConnection::disconnect(connection_id {}, database '{}'", connection_id(), m_database_name);
+    dbgln_if<SQLSERVER_DEBUG>("DatabaseConnection::disconnect(connection_id {}, database '{}'", connection_id(), m_database_name);
     m_accept_statements = false;
     deferred_invoke([this]() {
         m_database = nullptr;
@@ -69,7 +69,7 @@ void DatabaseConnection::disconnect()
 
 int DatabaseConnection::sql_statement(String const& sql)
 {
-    dbgln_if(SQLSERVER_DEBUG, "DatabaseConnection::sql_statement(connection_id {}, database '{}', sql '{}'", connection_id(), m_database_name, sql);
+    dbgln_if<SQLSERVER_DEBUG>("DatabaseConnection::sql_statement(connection_id {}, database '{}', sql '{}'", connection_id(), m_database_name, sql);
     auto client_connection = ClientConnection::client_connection_for(client_id());
     if (!client_connection) {
         warnln("Cannot notify client of database disconnection. Client disconnected");

--- a/Userland/Services/SQLServer/SQLStatement.cpp
+++ b/Userland/Services/SQLServer/SQLStatement.cpp
@@ -18,7 +18,7 @@ RefPtr<SQLStatement> SQLStatement::statement_for(int statement_id)
 {
     if (s_statements.contains(statement_id))
         return *s_statements.get(statement_id).value();
-    dbgln_if(SQLSERVER_DEBUG, "Invalid statement_id {}", statement_id);
+    dbgln_if<SQLSERVER_DEBUG>("Invalid statement_id {}", statement_id);
     return nullptr;
 }
 
@@ -29,13 +29,13 @@ SQLStatement::SQLStatement(DatabaseConnection& connection, String sql)
     , m_statement_id(s_next_statement_id++)
     , m_sql(move(sql))
 {
-    dbgln_if(SQLSERVER_DEBUG, "SQLStatement({}, {})", connection.connection_id(), sql);
+    dbgln_if<SQLSERVER_DEBUG>("SQLStatement({}, {})", connection.connection_id(), sql);
     s_statements.set(m_statement_id, *this);
 }
 
 void SQLStatement::report_error(SQL::SQLError error)
 {
-    dbgln_if(SQLSERVER_DEBUG, "SQLStatement::report_error(statement_id {}, error {}", statement_id(), error.to_string());
+    dbgln_if<SQLSERVER_DEBUG>("SQLStatement::report_error(statement_id {}, error {}", statement_id(), error.to_string());
     auto client_connection = ClientConnection::client_connection_for(connection()->client_id());
     m_statement = nullptr;
     m_result = nullptr;
@@ -53,7 +53,7 @@ void SQLStatement::report_error(SQL::SQLError error)
 
 void SQLStatement::execute()
 {
-    dbgln_if(SQLSERVER_DEBUG, "SQLStatement::execute(statement_id {}", statement_id());
+    dbgln_if<SQLSERVER_DEBUG>("SQLStatement::execute(statement_id {}", statement_id());
     auto client_connection = ClientConnection::client_connection_for(connection()->client_id());
     if (!client_connection) {
         warnln("Cannot yield next result. Client disconnected");

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -100,7 +100,7 @@ void Service::setup_notifier()
 void Service::handle_socket_connection()
 {
     VERIFY(m_sockets.size() == 1);
-    dbgln_if(SERVICE_DEBUG, "Ready to read on behalf of {}", name());
+    dbgln_if<SERVICE_DEBUG>("Ready to read on behalf of {}", name());
 
     int socket_fd = m_sockets[0].fd;
 
@@ -136,7 +136,7 @@ void Service::spawn(int socket_fd)
         return;
     }
 
-    dbgln_if(SERVICE_DEBUG, "Spawning {}", name());
+    dbgln_if<SERVICE_DEBUG>("Spawning {}", name());
 
     m_run_timer.start();
     pid_t pid = fork();

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -43,7 +43,7 @@ static void sigchld_handler(int)
         if (pid == 0)
             break;
 
-        dbgln_if(SYSTEMSERVER_DEBUG, "Reaped child with pid {}, exit status {}", pid, status);
+        dbgln_if<SYSTEMSERVER_DEBUG>("Reaped child with pid {}, exit status {}", pid, status);
 
         Service* service = Service::find_by_pid(pid);
         if (service == nullptr) {

--- a/Userland/Services/WebContent/ClientConnection.cpp
+++ b/Userland/Services/WebContent/ClientConnection.cpp
@@ -75,7 +75,7 @@ void ClientConnection::update_screen_rects(const Vector<Gfx::IntRect>& rects, u3
 
 void ClientConnection::load_url(const URL& url)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentServer::LoadURL: url={}", url);
+    dbgln_if<SPAM_DEBUG>("handle: WebContentServer::LoadURL: url={}", url);
 
     String process_name;
     if (url.host().is_empty())
@@ -90,13 +90,13 @@ void ClientConnection::load_url(const URL& url)
 
 void ClientConnection::load_html(const String& html, const URL& url)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentServer::LoadHTML: html={}, url={}", html, url);
+    dbgln_if<SPAM_DEBUG>("handle: WebContentServer::LoadHTML: html={}, url={}", html, url);
     page().load_html(html, url);
 }
 
 void ClientConnection::set_viewport_rect(const Gfx::IntRect& rect)
 {
-    dbgln_if(SPAM_DEBUG, "handle: WebContentServer::SetViewportRect: rect={}", rect);
+    dbgln_if<SPAM_DEBUG>("handle: WebContentServer::SetViewportRect: rect={}", rect);
     m_page_host->set_viewport_rect(rect);
 }
 

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -81,7 +81,7 @@ void Client::start()
         }
 
         auto request = builder.to_byte_buffer();
-        dbgln_if(WEBSERVER_DEBUG, "Got raw request: '{}'", String::copy(request));
+        dbgln_if<WEBSERVER_DEBUG>("Got raw request: '{}'", String::copy(request));
 
         auto maybe_did_handle = handle_request(request);
         if (maybe_did_handle.is_error()) {
@@ -121,7 +121,7 @@ ErrorOr<bool> Client::handle_request(ReadonlyBytes raw_request)
     }
 
     auto requested_path = LexicalPath::join("/", request.resource()).string();
-    dbgln_if(WEBSERVER_DEBUG, "Canonical requested path: '{}'", requested_path);
+    dbgln_if<WEBSERVER_DEBUG>("Canonical requested path: '{}'", requested_path);
 
     StringBuilder path_builder;
     path_builder.append(Configuration::the().root_path());

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -276,7 +276,7 @@ void Compositor::compose()
 
     auto prepare_rect = [&](Screen& screen, const Gfx::IntRect& rect) {
         auto& screen_data = screen.compositor_screen_data();
-        dbgln_if(COMPOSE_DEBUG, "    -> flush opaque: {}", rect);
+        dbgln_if<COMPOSE_DEBUG>("    -> flush opaque: {}", rect);
         VERIFY(!screen_data.m_flush_rects.intersects(rect));
         VERIFY(!screen_data.m_flush_transparent_rects.intersects(rect));
         screen_data.m_have_flush_rects = true;
@@ -286,7 +286,7 @@ void Compositor::compose()
 
     auto prepare_transparency_rect = [&](Screen& screen, const Gfx::IntRect& rect) {
         auto& screen_data = screen.compositor_screen_data();
-        dbgln_if(COMPOSE_DEBUG, "   -> flush transparent: {}", rect);
+        dbgln_if<COMPOSE_DEBUG>("   -> flush transparent: {}", rect);
         VERIFY(!screen_data.m_flush_rects.intersects(rect));
         for (auto& r : screen_data.m_flush_transparent_rects.rects()) {
             if (r == rect)
@@ -332,7 +332,7 @@ void Compositor::compose()
                 auto screen_rect = screen.rect();
                 auto screen_render_rect = screen_rect.intersected(render_rect);
                 if (!screen_render_rect.is_empty()) {
-                    dbgln_if(COMPOSE_DEBUG, "  render wallpaper opaque: {} on screen #{}", screen_render_rect, screen.index());
+                    dbgln_if<COMPOSE_DEBUG>("  render wallpaper opaque: {} on screen #{}", screen_render_rect, screen.index());
                     prepare_rect(screen, render_rect);
                     auto& back_painter = *screen.compositor_screen_data().m_back_painter;
                     paint_wallpaper(screen, back_painter, render_rect, screen_rect);
@@ -346,7 +346,7 @@ void Compositor::compose()
                 auto screen_rect = screen.rect();
                 auto screen_render_rect = screen_rect.intersected(render_rect);
                 if (!screen_render_rect.is_empty()) {
-                    dbgln_if(COMPOSE_DEBUG, "  render wallpaper transparent: {} on screen #{}", screen_render_rect, screen.index());
+                    dbgln_if<COMPOSE_DEBUG>("  render wallpaper transparent: {} on screen #{}", screen_render_rect, screen.index());
                     prepare_transparency_rect(screen, render_rect);
                     auto& temp_painter = *screen.compositor_screen_data().m_temp_painter;
                     paint_wallpaper(screen, temp_painter, render_rect, screen_rect);
@@ -367,7 +367,7 @@ void Compositor::compose()
         auto window_rect = window.rect().translated(transition_offset);
         auto frame_rects = frame_rect.shatter(window_rect);
 
-        dbgln_if(COMPOSE_DEBUG, "  window {} frame rect: {}", window.title(), frame_rect);
+        dbgln_if<COMPOSE_DEBUG>("  window {} frame rect: {}", window.title(), frame_rect);
 
         RefPtr<Gfx::Bitmap> backing_store = window.backing_store();
         auto compose_window_rect = [&](Screen& screen, Gfx::Painter& painter, const Gfx::IntRect& rect) {
@@ -376,7 +376,7 @@ void Compositor::compose()
                     Gfx::PainterStateSaver saver(painter);
                     painter.add_clip_rect(intersected_rect);
                     painter.translate(transition_offset);
-                    dbgln_if(COMPOSE_DEBUG, "    render frame: {}", intersected_rect);
+                    dbgln_if<COMPOSE_DEBUG>("    render frame: {}", intersected_rect);
                     window.frame().paint(screen, painter, intersected_rect.translated(-transition_offset));
                     return IterationDecision::Continue;
                 });
@@ -475,7 +475,7 @@ void Compositor::compose()
                     auto screen_render_rect = render_rect.intersected(screen->rect());
                     if (screen_render_rect.is_empty())
                         continue;
-                    dbgln_if(COMPOSE_DEBUG, "    render opaque: {} on screen #{}", screen_render_rect, screen->index());
+                    dbgln_if<COMPOSE_DEBUG>("    render opaque: {} on screen #{}", screen_render_rect, screen->index());
 
                     prepare_rect(*screen, screen_render_rect);
                     auto& back_painter = *screen->compositor_screen_data().m_back_painter;
@@ -497,7 +497,7 @@ void Compositor::compose()
                     auto screen_render_rect = render_rect.intersected(screen_rect);
                     if (screen_render_rect.is_empty())
                         continue;
-                    dbgln_if(COMPOSE_DEBUG, "    render wallpaper: {} on screen #{}", screen_render_rect, screen->index());
+                    dbgln_if<COMPOSE_DEBUG>("    render wallpaper: {} on screen #{}", screen_render_rect, screen->index());
 
                     auto& temp_painter = *screen->compositor_screen_data().m_temp_painter;
                     prepare_transparency_rect(*screen, screen_render_rect);
@@ -514,7 +514,7 @@ void Compositor::compose()
                     auto screen_render_rect = render_rect.intersected(screen_rect);
                     if (screen_render_rect.is_empty())
                         continue;
-                    dbgln_if(COMPOSE_DEBUG, "    render transparent: {} on screen #{}", screen_render_rect, screen->index());
+                    dbgln_if<COMPOSE_DEBUG>("    render transparent: {} on screen #{}", screen_render_rect, screen->index());
 
                     prepare_transparency_rect(*screen, screen_render_rect);
                     auto& temp_painter = *screen->compositor_screen_data().m_temp_painter;
@@ -612,7 +612,7 @@ void Compositor::flush(Screen& screen)
 
     bool device_can_flush_buffers = screen.can_device_flush_buffers();
     if (!screen_data.m_have_flush_rects && (!screen_data.m_screen_can_set_buffer || screen_data.m_has_flipped)) {
-        dbgln_if(COMPOSE_DEBUG, "Nothing to flush on screen #{} {}", screen.index(), screen_data.m_have_flush_rects);
+        dbgln_if<COMPOSE_DEBUG>("Nothing to flush on screen #{} {}", screen.index(), screen_data.m_have_flush_rects);
         return;
     }
     screen_data.m_have_flush_rects = false;

--- a/Userland/Services/WindowServer/EventLoop.cpp
+++ b/Userland/Services/WindowServer/EventLoop.cpp
@@ -64,7 +64,7 @@ void EventLoop::drain_mouse()
     bool state_is_sent = false;
     for (size_t i = 0; i < npackets; ++i) {
         auto& packet = packets[i];
-        dbgln_if(WSMESSAGELOOP_DEBUG, "EventLoop: Mouse X {}, Y {}, Z {}, W {}, relative={}", packet.x, packet.y, packet.z, packet.w, packet.is_relative);
+        dbgln_if<WSMESSAGELOOP_DEBUG>("EventLoop: Mouse X {}, Y {}, Z {}, W {}, relative={}", packet.x, packet.y, packet.z, packet.w, packet.is_relative);
 
         state.is_relative = packet.is_relative;
         if (packet.is_relative) {
@@ -80,7 +80,7 @@ void EventLoop::drain_mouse()
 
         if (packet.buttons != state.buttons) {
             state.buttons = packet.buttons;
-            dbgln_if(WSMESSAGELOOP_DEBUG, "EventLoop: Mouse Button Event");
+            dbgln_if<WSMESSAGELOOP_DEBUG>("EventLoop: Mouse Button Event");
 
             // Swap primary (1) and secondary (2) buttons if checked in Settings.
             // Doing the swap here avoids all emulator and hardware issues.

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -327,7 +327,7 @@ bool Screen::set_resolution(bool initial)
         rc = fb_set_resolution(m_framebuffer_fd, &physical_resolution);
     }
 
-    dbgln_if(WSSCREEN_DEBUG, "Screen #{}: fb_set_resolution() - return code {}", index(), rc);
+    dbgln_if<WSSCREEN_DEBUG>("Screen #{}: fb_set_resolution() - return code {}", index(), rc);
 
     auto on_change_resolution = [&]() {
         if (initial) {
@@ -427,10 +427,10 @@ void ScreenInput::on_receive_mouse_data(const MousePacket& packet)
     auto prev_location = m_cursor_location;
     if (packet.is_relative) {
         m_cursor_location.translate_by(packet.x * m_acceleration_factor, packet.y * m_acceleration_factor);
-        dbgln_if(WSSCREEN_DEBUG, "Screen: New Relative mouse point @ {}", m_cursor_location);
+        dbgln_if<WSSCREEN_DEBUG>("Screen: New Relative mouse point @ {}", m_cursor_location);
     } else {
         m_cursor_location = { packet.x * current_screen.width() / 0xffff, packet.y * current_screen.height() / 0xffff };
-        dbgln_if(WSSCREEN_DEBUG, "Screen: New Absolute mouse point @ {}", m_cursor_location);
+        dbgln_if<WSSCREEN_DEBUG>("Screen: New Absolute mouse point @ {}", m_cursor_location);
     }
 
     auto* moved_to_screen = Screen::find_by_location(m_cursor_location);

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -568,7 +568,7 @@ void WindowManager::notify_title_changed(Window& window)
     if (!window_type_has_title(window.type()))
         return;
 
-    dbgln_if(WINDOWMANAGER_DEBUG, "[WM] Window({}) title set to '{}'", &window, window.title());
+    dbgln_if<WINDOWMANAGER_DEBUG>("[WM] Window({}) title set to '{}'", &window, window.title());
 
     if (m_switcher->is_visible())
         m_switcher->refresh();
@@ -581,7 +581,7 @@ void WindowManager::notify_modal_unparented(Window& window)
     if (window.type() != WindowType::Normal)
         return;
 
-    dbgln_if(WINDOWMANAGER_DEBUG, "[WM] Window({}) was unparented", &window);
+    dbgln_if<WINDOWMANAGER_DEBUG>("[WM] Window({}) was unparented", &window);
 
     if (m_switcher->is_visible())
         m_switcher->refresh();
@@ -591,7 +591,7 @@ void WindowManager::notify_modal_unparented(Window& window)
 
 void WindowManager::notify_rect_changed(Window& window, Gfx::IntRect const& old_rect, Gfx::IntRect const& new_rect)
 {
-    dbgln_if(RESIZE_DEBUG, "[WM] Window({}) rect changed {} -> {}", &window, old_rect, new_rect);
+    dbgln_if<RESIZE_DEBUG>("[WM] Window({}) rect changed {} -> {}", &window, old_rect, new_rect);
 
     if (m_switcher->is_visible() && window.type() != WindowType::WindowSwitcher)
         m_switcher->refresh();
@@ -667,7 +667,7 @@ void WindowManager::start_window_move(Window& window, Gfx::IntPoint const& origi
 {
     MenuManager::the().close_everyone();
 
-    dbgln_if(MOVE_DEBUG, "[WM] Begin moving Window({})", &window);
+    dbgln_if<MOVE_DEBUG>("[WM] Begin moving Window({})", &window);
 
     move_to_front_and_make_active(window);
     m_move_window = window;
@@ -709,7 +709,7 @@ void WindowManager::start_window_resize(Window& window, Gfx::IntPoint const& pos
         return;
     }
 
-    dbgln_if(RESIZE_DEBUG, "[WM] Begin resizing Window({})", &window);
+    dbgln_if<RESIZE_DEBUG>("[WM] Begin resizing Window({})", &window);
 
     m_resizing_mouse_button = button;
     m_resize_window = window;
@@ -738,13 +738,13 @@ bool WindowManager::process_ongoing_window_move(MouseEvent& event)
         return false;
     if (event.type() == Event::MouseUp && event.button() == MouseButton::Primary) {
 
-        dbgln_if(MOVE_DEBUG, "[WM] Finish moving Window({})", m_move_window);
+        dbgln_if<MOVE_DEBUG>("[WM] Finish moving Window({})", m_move_window);
 
         m_move_window->invalidate(true, true);
         if (m_move_window->is_resizable()) {
             process_event_for_doubleclick(*m_move_window, event);
             if (event.type() == Event::MouseDoubleClick) {
-                dbgln_if(DOUBLECLICK_DEBUG, "[WM] Click up became doubleclick!");
+                dbgln_if<DOUBLECLICK_DEBUG>("[WM] Click up became doubleclick!");
                 m_move_window->set_maximized(!m_move_window->is_maximized());
             }
         }
@@ -822,14 +822,14 @@ bool WindowManager::process_ongoing_window_resize(MouseEvent const& event)
         return false;
 
     if (event.type() == Event::MouseUp && event.button() == m_resizing_mouse_button) {
-        dbgln_if(RESIZE_DEBUG, "[WM] Finish resizing Window({})", m_resize_window);
+        dbgln_if<RESIZE_DEBUG>("[WM] Finish resizing Window({})", m_resize_window);
 
         const int vertical_maximize_deadzone = 5;
         auto& cursor_screen = ScreenInput::the().cursor_location_screen();
         if (&cursor_screen == &Screen::closest_to_rect(m_resize_window->rect())) {
             auto desktop_rect = this->desktop_rect(cursor_screen);
             if (event.y() >= desktop_rect.bottom() - vertical_maximize_deadzone + 1 || event.y() <= desktop_rect.top() + vertical_maximize_deadzone - 1) {
-                dbgln_if(RESIZE_DEBUG, "Should Maximize vertically");
+                dbgln_if<RESIZE_DEBUG>("Should Maximize vertically");
                 m_resize_window->set_vertically_maximized();
                 m_resize_window = nullptr;
                 m_geometry_overlay = nullptr;
@@ -949,7 +949,7 @@ bool WindowManager::process_ongoing_window_resize(MouseEvent const& event)
         // border however is fine as long as the screen contains the entire window.
         m_resize_window->check_untile_due_to_resize(new_rect);
     }
-    dbgln_if(RESIZE_DEBUG, "[WM] Resizing, original: {}, now: {}", m_resize_window_original_rect, new_rect);
+    dbgln_if<RESIZE_DEBUG>("[WM] Resizing, original: {}, now: {}", m_resize_window_original_rect, new_rect);
 
     m_resize_window->set_rect(new_rect);
     m_geometry_overlay->window_rect_changed();
@@ -1063,7 +1063,7 @@ void WindowManager::start_menu_doubleclick(Window& window, MouseEvent const& eve
         // we either haven't clicked anywhere, or we haven't clicked on this
         // window. set the current click window, and reset the timers.
 
-        dbgln_if(DOUBLECLICK_DEBUG, "Initial mousedown on Window({}) for menus (previous was {})", &window, m_double_click_info.m_clicked_window);
+        dbgln_if<DOUBLECLICK_DEBUG>("Initial mousedown on Window({}) for menus (previous was {})", &window, m_double_click_info.m_clicked_window);
 
         m_double_click_info.m_clicked_window = window;
         m_double_click_info.reset();
@@ -1095,7 +1095,7 @@ void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& ev
     if (&window != m_double_click_info.m_clicked_window) {
         // we either haven't clicked anywhere, or we haven't clicked on this
         // window. set the current click window, and reset the timers.
-        dbgln_if(DOUBLECLICK_DEBUG, "Initial mouseup on Window({}) for menus (previous was {})", &window, m_double_click_info.m_clicked_window);
+        dbgln_if<DOUBLECLICK_DEBUG>("Initial mouseup on Window({}) for menus (previous was {})", &window, m_double_click_info.m_clicked_window);
 
         m_double_click_info.m_clicked_window = window;
         m_double_click_info.reset();
@@ -1110,7 +1110,7 @@ void WindowManager::process_event_for_doubleclick(Window& window, MouseEvent& ev
         // clock
         metadata.clock.start();
     } else {
-        dbgln_if(DOUBLECLICK_DEBUG, "Transforming MouseUp to MouseDoubleClick ({} < {})!", metadata.clock.elapsed(), m_double_click_speed);
+        dbgln_if<DOUBLECLICK_DEBUG>("Transforming MouseUp to MouseDoubleClick ({} < {})!", metadata.clock.elapsed(), m_double_click_speed);
 
         event = MouseEvent(Event::MouseDoubleClick, event.position(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
         // invalidate this now we've delivered a doubleclick, otherwise

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -48,7 +48,7 @@ void Shell::setup_signals()
 {
     if (m_should_reinstall_signal_handlers) {
         Core::EventLoop::register_signal(SIGCHLD, [this](int) {
-            dbgln_if(SH_DEBUG, "SIGCHLD!");
+            dbgln_if<SH_DEBUG>("SIGCHLD!");
             notify_child_event();
         });
 
@@ -485,7 +485,7 @@ String Shell::format(StringView source, ssize_t& cursor) const
 Shell::Frame Shell::push_frame(String name)
 {
     m_local_frames.append(make<LocalFrame>(name, decltype(LocalFrame::local_variables) {}));
-    dbgln_if(SH_DEBUG, "New frame '{}' at {:p}", name, &m_local_frames.last());
+    dbgln_if<SH_DEBUG>("New frame '{}' at {:p}", name, &m_local_frames.last());
     return { m_local_frames, m_local_frames.last() };
 }
 
@@ -637,7 +637,7 @@ ErrorOr<RefPtr<Job>> Shell::run_command(const AST::Command& command)
     auto apply_rewirings = [&]() -> ErrorOr<void> {
         for (auto& rewiring : rewirings) {
 
-            dbgln_if(SH_DEBUG, "in {}<{}>, dup2({}, {})", command.argv.is_empty() ? "(<Empty>)" : command.argv[0].characters(), getpid(), rewiring.old_fd, rewiring.new_fd);
+            dbgln_if<SH_DEBUG>("in {}<{}>, dup2({}, {})", command.argv.is_empty() ? "(<Empty>)" : command.argv[0].characters(), getpid(), rewiring.old_fd, rewiring.new_fd);
             int rc = dup2(rewiring.old_fd, rewiring.new_fd);
             if (rc < 0)
                 return Error::from_syscall("dup2"sv, rc);
@@ -732,7 +732,7 @@ ErrorOr<RefPtr<Job>> Shell::run_command(const AST::Command& command)
             }
         }
 
-        dbgln_if(SH_DEBUG, "Synced up with parent, we're good to exec()");
+        dbgln_if<SH_DEBUG>("Synced up with parent, we're good to exec()");
 
         close(sync_pipe[0]);
 
@@ -1734,9 +1734,9 @@ void Shell::notify_child_event()
             auto& job = *it.value;
 
             int wstatus = 0;
-            dbgln_if(SH_DEBUG, "waitpid({} = {}) = ...", job.pid(), job.cmd());
+            dbgln_if<SH_DEBUG>("waitpid({} = {}) = ...", job.pid(), job.cmd());
             auto child_pid = waitpid(job.pid(), &wstatus, WNOHANG | WUNTRACED);
-            dbgln_if(SH_DEBUG, "... = {} - exited: {}, suspended: {}", child_pid, WIFEXITED(wstatus), WIFSTOPPED(wstatus));
+            dbgln_if<SH_DEBUG>("... = {} - exited: {}, suspended: {}", child_pid, WIFEXITED(wstatus), WIFSTOPPED(wstatus));
 
             if (child_pid < 0) {
                 if (errno == ECHILD) {
@@ -1897,7 +1897,7 @@ void Shell::stop_all_jobs()
             printf("Killing active jobs\n");
         for (auto& entry : jobs) {
             if (entry.value->is_suspended()) {
-                dbgln_if(SH_DEBUG, "Job {} is suspended", entry.value->pid());
+                dbgln_if<SH_DEBUG>("Job {} is suspended", entry.value->pid());
                 kill_job(entry.value, SIGCONT);
             }
 
@@ -1907,7 +1907,7 @@ void Shell::stop_all_jobs()
         usleep(10000); // Wait for a bit before killing the job
 
         for (auto& entry : jobs) {
-            dbgln_if(SH_DEBUG, "Actively killing {} ({})", entry.value->pid(), entry.value->cmd());
+            dbgln_if<SH_DEBUG>("Actively killing {} ({})", entry.value->pid(), entry.value->cmd());
             kill_job(entry.value, SIGKILL);
         }
 

--- a/Userland/Utilities/syscall.cpp
+++ b/Userland/Utilities/syscall.cpp
@@ -94,7 +94,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    dbgln_if(SYSCALL_1_DEBUG, "Calling {} {:p} {:p} {:p}\n", arg[0], arg[1], arg[2], arg[3]);
+    dbgln_if<SYSCALL_1_DEBUG>("Calling {} {:p} {:p} {:p}\n", arg[0], arg[1], arg[2], arg[3]);
     int rc = syscall(arg[0], arg[1], arg[2], arg[3]);
     if (output_buffer)
         fwrite(outbuf, 1, sizeof(outbuf), stdout);
@@ -160,7 +160,7 @@ static FlatPtr parse_from(ArgIter& iter)
     // Is it a forced literal?
     if (this_arg[0] == ',') {
         this_arg += 1;
-        dbgln_if(SYSCALL_1_DEBUG, "Using (forced) string >>{}<< at {:p}", this_arg, (FlatPtr)this_arg);
+        dbgln_if<SYSCALL_1_DEBUG>("Using (forced) string >>{}<< at {:p}", this_arg, (FlatPtr)this_arg);
         return (FlatPtr)this_arg;
     }
 
@@ -183,7 +183,7 @@ static FlatPtr parse_from(ArgIter& iter)
     if (strcmp(this_arg, "]") == 0)
         fprintf(stderr, "Warning: Treating unmatched ']' as literal string\n");
 
-    dbgln_if(SYSCALL_1_DEBUG, "Using (detected) string >>{}<< at {:p}", this_arg, (FlatPtr)this_arg);
+    dbgln_if<SYSCALL_1_DEBUG>("Using (detected) string >>{}<< at {:p}", this_arg, (FlatPtr)this_arg);
 
     return (FlatPtr)this_arg;
 }


### PR DESCRIPTION
The interface to `[dbg,out,warn]ln_if` passes the `flag` argument
as if it is being passed to a function because it is a
macro. This is misleading because the `flag` is evaluated in a
`constexpr` context. Changing `[dbg,out,warn]ln_if` to be a
function template makes the `flag` into a template
parameter. This makes it clear from the interface that `flag` is
a compile-time variable.
