### PR TITLE
RequestServer: Reenable socket notifications unconditionally

### DIFF
--- a/Userland/Services/RequestServer/ConnectionCache.cpp
+++ b/Userland/Services/RequestServer/ConnectionCache.cpp
@@ -64,6 +64,7 @@ void request_did_finish(URL const& url, Core::Stream::Socket const* socket)
                 connection->timer.start();
                 connection->current_url = url;
                 connection->job_data = connection->request_queue.take_first();
+                connection->socket->set_notifications_enabled(true);
                 connection->job_data.start(*connection->socket);
             });
         }


### PR DESCRIPTION
There's a possible window where the notifications are disabled, and any
request coming at that time will never get any data if it relies on
socket notifications.