### PR TITLE
Documentation: Rework VSCode configuration

### DIFF
--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -1,331 +1,91 @@
-# Visual Studio Code Project Configuration
+Visual Studio Code Project Configuration
+===
 
-Visual Studio Code does not work optimally for Serenity development, and there's a bunch of configuring and fiddling around you'll have to do.
+Visual Studio Code does not work optimally for Serenity development, though we can convince it to be more understanding of our needs. This document attempts to outline a minimal configuration that is satisfying enough that you don't feel compelled to use another editor, unless you want to. `:^)`
 
-The WSL Remote extension allows you to use VSCode in Windows while using the normal WSL workflow. This works surprisingly well, but for code comprehension speed you should put the Serenity directory on your WSL root partition.
 
-## Code comprehension
+Prerequisites
+---
+The path of least resistance is to build using Serenity's clang-toolchain which provides `clang-tidy`, followed by manually building `clangd`:
 
-Both C++ comprehension tools listed below report fake errors.
+```sh
+./Meta/serenity.sh rebuild-world i686 Clang &&
+cmake Toolchain/Build/clang/llvm -DCLANG_ENABLE_CLANGD=ON &&
+ninja -C Toolchain/Build/clang/llvm &&
+ninja -C Toolchain/Build/clang/llvm install
+```
 
-### clangd
-
-The official clangd extension can be used for C++ comprehension. You'll have to use the following .clangd:
-
+If you would prefer to use the GCC toolchain, use the following `.clangd` configuration and change all future references to `i686clang` with `i686`, or the TARGET of your choosing:
 ```yaml
+---
 CompileFlags:
-  CompilationDatabase: Build/i686
+   Add:
+      [
+         -D__serenity__,
+         -isystem../../Toolchain/Local/i686/i686-pc-serenity/include/c++/11.2.0,
+         -isystem../../Toolchain/Local/i686/i686-pc-serenity/include/c++/11.2.0/bits,
+         -isystem../../Toolchain/Local/i686/i686-pc-serenity/include/c++/11.2.0/i686-pc-serenity,
+      ]
+   CompilationDatabase: Build/i686
 ```
 
-Run cmake at least once for this to work. clangd has difficulty finding specific methods and types, especially with inheritance trees. Also, include errors are wrong in 90% of cases.
 
-### Microsoft C/C++ tools
+Extensions
+---
+Required extensions:
+* llvm-vs-code-extensions.vscode-clangd
+* notskm.clang-tidy
 
-These extensions can be used as-is, but you need to point them to the custom Serenity compilers. Use the following cpp-preferences to circumvent some errors:
+Recommended extensions:
+* kleinesfilmroellchen.serenity-dsl-syntaxhighlight ([marketplace.visualstudio.com](https://marketplace.visualstudio.com/items?itemName=kleinesfilmroellchen.serenity-dsl-syntaxhighlight) | [open-vsx.org](https://open-vsx.org/extension/kleinesfilmroellchen/serenity-dsl-syntaxhighlight))
+* twxs.cmake
+* wayou.vscode-todo-highlight
 
-<details>
-<summary>.vscode/c_cpp_properties.json</summary>
-
-```json
-{
-    "configurations": [
-        {
-            "name": "userland-i386-gcc",
-            "includePath": [
-                "${workspaceFolder}",
-                "${workspaceFolder}/Build/i686/",
-                "${workspaceFolder}/Build/i686/Userland",
-                "${workspaceFolder}/Build/i686/Userland/Applications",
-                "${workspaceFolder}/Build/i686/Userland/Libraries",
-                "${workspaceFolder}/Build/i686/Userland/Services",
-                "${workspaceFolder}/Build/i686/Root/usr/include/**",
-                "${workspaceFolder}/Userland",
-                "${workspaceFolder}/Userland/Libraries",
-                "${workspaceFolder}/Userland/Libraries/LibC",
-                "${workspaceFolder}/Userland/Libraries/LibM",
-                "${workspaceFolder}/Userland/Libraries/LibPthread",
-                "${workspaceFolder}/Userland/Services",
-                "${workspaceFolder}/Toolchain/Local/i686/i686-pc-serenity/include/c++/**"
-            ],
-            "defines": [
-                "DEBUG",
-                "__serenity__"
-            ],
-            "compilerPath": "${workspaceFolder}/Toolchain/Local/i686/bin/i686-pc-serenity-g++",
-            "cStandard": "c17",
-            "cppStandard": "c++20",
-            "intelliSenseMode": "linux-gcc-x86",
-            "compileCommands": "Build/i686/compile_commands.json",
-            "compilerArgs": [
-                "-wall",
-                "-wextra",
-                "-werror"
-            ],
-            "browse": {
-                "path": [
-                    "${workspaceFolder}",
-                    "${workspaceFolder}/Build/i686/",
-                    "${workspaceFolder}/Build/i686/Userland",
-                    "${workspaceFolder}/Build/i686/Userland/Applications",
-                    "${workspaceFolder}/Build/i686/Userland/Libraries",
-                    "${workspaceFolder}/Build/i686/Userland/Services",
-                    "${workspaceFolder}/Build/i686/Root/usr/include/**",
-                    "${workspaceFolder}/Userland",
-                    "${workspaceFolder}/Userland/Libraries",
-                    "${workspaceFolder}/Userland/Libraries/LibC",
-                    "${workspaceFolder}/Userland/Libraries/LibM",
-                    "${workspaceFolder}/Userland/Libraries/LibPthread",
-                    "${workspaceFolder}/Userland/Services",
-                    "${workspaceFolder}/Toolchain/Local/i686/i686-pc-serenity/include/c++/**"
-                ],
-                "limitSymbolsToIncludedHeaders": true,
-                "databaseFilename": "${workspaceFolder}/Build/i686/"
-            }
-        }
-    ],
-    "version": 4
-}
+### .clangd
+```yaml
+---
+CompileFlags:
+  CompilationDatabase: Build/i686clang
 ```
-</details>
 
-Most nonsensical errors from the extension also involve not finding methods, types etc.
-
-### DSL syntax highlighting
-
-There's a syntax highlighter extension for both IPC and GML called "SerenityOS DSL Syntax Highlight", available [here](https://marketplace.visualstudio.com/items?itemName=kleinesfilmroellchen.serenity-dsl-syntaxhighlight) or [here](https://open-vsx.org/extension/kleinesfilmroellchen/serenity-dsl-syntaxhighlight).
-
-## Formatting
-
-clang-format is included with the Microsoft tools (see above). The settings below include a key that makes it use the proper style. Alternatively, you can use the clang-format extension itself, which should work out of the box.
-
-## Settings
-
-These belong in the `.vscode/settings.json` of Serenity.
-
-```json
+### .vscode/settings.json
+```jsonc
 {
-    // Excluding the generated directories keeps your file view clean and speeds up search.
-    "files.exclude": {
-        "**/.git": true,
-        "Toolchain/Local/**": true,
-        "Toolchain/Tarballs/**": true,
-        "Toolchain/Build/**": true,
-        "Build/**": true,
-        "build/**": true,
-    },
-    "search.exclude": {
-        "**/.git": true,
-        "Toolchain/Local/**": true,
-        "Toolchain/Tarballs/**": true,
-        "Toolchain/Build/**": true,
-        "Build/**": true,
-        "build/**": true,
-    },
-    // Force clang-format to respect Serenity's .clang-format style file.
-    "C_Cpp.clang_format_style": "file",
-    // Tab settings
-    "editor.tabSize": 4,
-    "editor.useTabStops": false
+  // Pass additional arguments to clangd
+  "clangd.arguments": [
+    // Inform clangd of where our TARGET `compile_commands.json` lives
+    "--compile-commands-dir=${workspaceFolder}/Build/i686clang"
+  ],
+  // Use the clangd binary built by clang-toolchain
+  "clangd.path": "${workspaceFolder}/Toolchain/Local/clang/bin/clangd",
+  // Inform clang-tidy of where our TARGET `compile_commands.json` lives
+  "clang-tidy.buildPath": "${workspaceFolder}/Build/i686clang",
+  // Use the clang-tidy binary built by clang-toolchain
+  "clang-tidy.executable": "${workspaceFolder}/Toolchain/Local/clang/bin/clang-tidy",
+  // File paths to exclude from the explorer, which are also implicitly excluded from search
+  "files.exclude": {
+    "**/.git": true,
+    "Build/**": true,
+    "Toolchain/Build/**": true,
+    "Toolchain/Local/**": true,
+    "Toolchain/Tarballs/**": true,
+  },
+  // Set our tab size to 4 columns
+  "editor.tabSize": 4,
+  // Disable the use of tab stops
+  "editor.useTabStops": false,
+  // Disable word wrap because Serenity does not define a maximum column width
+  "editor.wordWrap": "off",
 }
 ```
 
-## Customization
+Code Snippets
+---
 
-### Custom Tasks
-
-You can create custom tasks (`.vscode/tasks.json`) to quickly compile Serenity.
-The following three example tasks should suffice in most situations, and allow you to specify the build system to use, as well as give you error highlighting.
-
-Note: The Assertion und KUBSan Problem matchers will only run after you have closed qemu.
-
-<details>
-<summary>tasks.json</summary>
-
-```json
-{
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "build lagom",
-            "type": "shell",
-            "problemMatcher": [
-                {
-                    "base": "$gcc",
-                    "fileLocation": [
-                        "relative",
-                        "${workspaceFolder}/Build/lagom"
-                    ]
-                }
-            ],
-            "command": [
-                "bash"
-            ],
-            "args": [
-                "-c",
-                "\"Meta/serenity.sh build lagom\""
-            ],
-            "presentation": {
-                "echo": true,
-                "reveal": "always",
-                "focus": false,
-                "group": "build",
-                "panel": "shared",
-                "showReuseMessage": true,
-                "clear": true
-            }
-        },
-        {
-            "label": "build",
-            "type": "shell",
-            "command": "bash",
-            "args": [
-                "-c",
-                "Meta/serenity.sh build ${input:arch} ${input:compiler}"
-            ],
-            "problemMatcher": [
-                {
-                    "base": "$gcc",
-                    "fileLocation": [
-                        "relative",
-                        // FIXME: Clang uses ${input:arch}clang
-                        "${workspaceFolder}/Build/${input:arch}"
-                    ]
-                },
-                {
-                    "source": "gcc",
-                    "fileLocation": [
-                        "relative",
-                        // FIXME: Clang uses ${input:arch}clang
-                        "${workspaceFolder}/Build/${input:arch}"
-                    ],
-                    "pattern": [
-                        {
-                            "regexp": "^([^\\s]*\\.S):(\\d*): (.*)$",
-                            "file": 1,
-                            "location": 2,
-                            "message": 3
-                        }
-                    ]
-                }
-            ],
-            "group": {
-                "kind": "build",
-                "isDefault": true
-            }
-        },
-        {
-            "label": "launch",
-            "type": "shell",
-            "command": "bash",
-            "args": [
-                "-c",
-                "Meta/serenity.sh run ${input:arch} ${input:compiler}"
-            ],
-            "options": {
-                "env": {
-                    // Put your custom run configuration here, e.g. SERENITY_RAM_SIZE
-                }
-            },
-            "problemMatcher": [
-                {
-                    "base": "$gcc",
-                    "fileLocation": [
-                        "relative",
-                        // FIXME: Clang uses ${input:arch}clang
-                        "${workspaceFolder}/Build/${input:arch}"
-                    ]
-                },
-                {
-                    "source": "gcc",
-                    "fileLocation": [
-                        "relative",
-                        // FIXME: Clang uses ${input:arch}clang
-                        "${workspaceFolder}/Build/${input:arch}"
-                    ],
-                    "pattern": [
-                        {
-                            "regexp": "^([^\\s]*\\.S):(\\d*): (.*)$",
-                            "file": 1,
-                            "location": 2,
-                            "message": 3
-                        }
-                    ]
-                },
-                {
-                    "source": "KUBSan",
-                    "owner": "cpp",
-                    "fileLocation": [
-                        "relative",
-                        "${workspaceFolder}"
-                    ],
-                    "pattern": [
-                        {
-                            "regexp": "KUBSAN: (.*)",
-                            "message": 0
-                        },
-                        {
-                            "regexp": "KUBSAN: at ../(.*), line (\\d*), column: (\\d*)",
-                            "file": 1,
-                            "line": 2,
-                            "column": 3
-                        }
-                    ]
-                },
-                {
-                    "source": "Assertion Failed",
-                    "owner": "cpp",
-                    "pattern": [
-                        {
-                            "regexp": "ASSERTION FAILED: (.*)$",
-                            "message": 1
-                        },
-                        {
-                            "regexp": "^((?:.*)\\.(h|cpp|c|S)):(\\d*)$",
-                            "file": 1,
-                            "location": 3
-                        }
-                    ],
-                    "fileLocation": [
-                        "relative",
-                        // FIXME: Clang uses ${input:arch}clang
-                        "${workspaceFolder}/Build/${input:arch}"
-                    ]
-                }
-            ]
-        }
-    ],
-    "inputs": [
-        {
-            "id": "compiler",
-            "description": "Compiler to use",
-            "type": "pickString",
-            "default": "GNU",
-            "options": [
-                "GNU",
-                "Clang"
-            ]
-        },
-        {
-            "id": "arch",
-            "description": "Architecture to compile for",
-            "type": "pickString",
-            "default": "i686",
-            "options": [
-                "i686",
-                "x86_64",
-                "aarch64"
-            ]
-        }
-    ]
-}
-```
-
-</details>
-
-### License snippet
-
-The following snippet may be useful if you want to quickly generate a license header, put it in `.vscode/serenity.code-snippets`:
-```json
+### License Header
+The following snippet may be useful if you want to quickly generate a license header:
+```jsonc
+// .vscode/license.code-snippets
 {
     "License": {
         "scope": "cpp,c",
@@ -337,7 +97,7 @@ The following snippet may be useful if you want to quickly generate a license he
             " * SPDX-License-Identifier: BSD-2-Clause",
             " */"
         ],
-        "description": "License header"
+        "description": "Generate license header"
     }
 }
 ```


### PR DESCRIPTION
Previously this document outlined a few different strategies, though the end results were unsatisfying as imports are missing. The focus will instead be to provide a best-effort minimal configuration where the intent is to make VS Code work well enough that you don't feel compelled to use another editor.

To this end, I've performed the following:
1. Outline *_only_* a working configuration, not multiple configurations that all have import errors. I did leave suggestions for those that would prefer to use the gcc-toolchain.
2. Remove references to `launch.json` and `tasks.json` as they would need to be reworked to be included, though I personally have no interest in reworking them.

At this stage I'm looking for feedback. The main areas that I'm concerned about is the heavy reliance on Serenity's clang-toolchain but this frees us from having to manually track/update `.clangd` and other files with our compiler version. This should mean that the new instructions are relatively stable and less prone to rot, though maybe this isn't solid enough reasoning.

