### PR TITLE
LibCore/System: Add anon_create syscall wrapper

### DIFF
--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -64,6 +64,7 @@ ErrorOr<struct stat> fstat(int fd);
 ErrorOr<int> fcntl(int fd, int command, ...);
 ErrorOr<void*> mmap(void* address, size_t, int protection, int flags, int fd, off_t, size_t alignment = 0, StringView name = {});
 ErrorOr<void> munmap(void* address, size_t);
+ErrorOr<int> anon_create(size_t size, int options);
 ErrorOr<int> open(StringView path, int options, ...);
 ErrorOr<void> close(int fd);
 ErrorOr<void> ftruncate(int fd, off_t length);


### PR DESCRIPTION
This wrapper is particularly helpful as we use a combination of similar syscalls on Linux to simulate the behavior of the Serenity-exclusive anon_create syscall. Users therefore won't have to worry about the platform anymore :^)