### PR TITLE
CI: Add statement to ensure workflow runs only on serenity

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -15,6 +15,7 @@ concurrency:
 jobs:
   build_and_test_serenity:
     runs-on: ${{ matrix.os }}
+    if: always() && github.repository == 'SerenityOS/serenity' 
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Ensure that the `cmake.yml` workflow runs only on SerenityOS repository.