### PR TITLE
Ports: Fix Lua not building

### DIFF
--- a/Ports/lua/package.sh
+++ b/Ports/lua/package.sh
@@ -3,5 +3,5 @@ port=lua
 version=5.3.6
 files="http://www.lua.org/ftp/lua-${version}.tar.gz lua-${version}.tar.gz fc5fd69bb8736323f026672b1b7235da613d7177e72558893a0bdcd320466d60"
 auth_type=sha256
-makeopts=("-j$(nproc)" "serenity" "CC=${CC}" "AR=${AR}" "RANLIB=${RANLIB}")
+makeopts=("-Csrc/" "-j$(nproc)" "serenity" "CC=${CC}" "AR=${AR}" "RANLIB=${RANLIB}" )
 installopts=("INSTALL_TOP=${SERENITY_INSTALL_ROOT}/usr/local")


### PR DESCRIPTION
Hello, this is my first pull request EVER. So please, please let me know if I've done something wrong. Thank you.

When running the `package.sh`, you will get an error from `make`. I added a `build` function, where I wrapped `cd` and `make` in a subshell. You will no longer get this error and the Lua port builds and runs successfully under Serenity. 