### PR TITLE
LibWeb: Better box shadows

### DIFF
--- a/Base/res/html/misc/box-shadow.html
+++ b/Base/res/html/misc/box-shadow.html
@@ -37,5 +37,9 @@
   <p>box-shadow: 20px 10px 5px magenta</p>
 </div>
 
+<div class="box" style="box-shadow: 20px 10px 5px magenta, cyan -20px -10px 5px, yellow 10px -5px 5px 20px">
+  <p>box-shadow: 20px 10px 5px magenta, cyan -20px -10px 5px, yellow 10px -5px 5px 20px</p>
+</div>
+
 </body>
 </html>

--- a/Base/res/html/misc/box-shadow.html
+++ b/Base/res/html/misc/box-shadow.html
@@ -21,8 +21,8 @@
   <p>box-shadow: 20px 10px magenta</p>
 </div>
 
-<div class="box" style="box-shadow: -40px -20px magenta">
-  <p>box-shadow: -40px -20px magenta</p>
+<div class="box" style="box-shadow: magenta -40px -20px">
+  <p>box-shadow: magenta -40px -20px</p>
 </div>
 
 <div class="box" style="box-shadow: 20px 10px rgba(255,0,255,0.5)">

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -76,10 +76,12 @@ struct FlexBasisData {
 };
 
 struct BoxShadowData {
+    Color color {};
     CSS::Length offset_x {};
     CSS::Length offset_y {};
     CSS::Length blur_radius {};
-    Color color {};
+    CSS::Length spread_distance {};
+    CSS::BoxShadowPlacement placement { CSS::BoxShadowPlacement::Outer };
 };
 
 class ComputedValues {

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -104,7 +104,7 @@ public:
     CSS::AlignItems align_items() const { return m_noninherited.align_items; }
     float opacity() const { return m_noninherited.opacity; }
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
-    Optional<BoxShadowData> const& box_shadow() const { return m_noninherited.box_shadow; }
+    Vector<BoxShadowData> const& box_shadow() const { return m_noninherited.box_shadow; }
     CSS::BoxSizing box_sizing() const { return m_noninherited.box_sizing; }
     CSS::LengthPercentage const& width() const { return m_noninherited.width; }
     CSS::LengthPercentage const& min_width() const { return m_noninherited.min_width; }
@@ -201,7 +201,7 @@ protected:
         CSS::Overflow overflow_x { InitialValues::overflow() };
         CSS::Overflow overflow_y { InitialValues::overflow() };
         float opacity { InitialValues::opacity() };
-        Optional<BoxShadowData> box_shadow {};
+        Vector<BoxShadowData> box_shadow {};
         Vector<CSS::Transformation> transformations {};
         CSS::BoxSizing box_sizing { InitialValues::box_sizing() };
     } m_noninherited;
@@ -255,7 +255,7 @@ public:
     void set_align_items(CSS::AlignItems value) { m_noninherited.align_items = value; }
     void set_opacity(float value) { m_noninherited.opacity = value; }
     void set_justify_content(CSS::JustifyContent value) { m_noninherited.justify_content = value; }
-    void set_box_shadow(Optional<BoxShadowData> value) { m_noninherited.box_shadow = move(value); }
+    void set_box_shadow(Vector<BoxShadowData>&& value) { m_noninherited.box_shadow = move(value); }
     void set_transformations(Vector<CSS::Transformation> value) { m_noninherited.transformations = move(value); }
     void set_box_sizing(CSS::BoxSizing value) { m_noninherited.box_sizing = value; }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3170,42 +3170,62 @@ RefPtr<StyleValue> Parser::parse_box_shadow_value(Vector<StyleComponentValueRule
     }
 
     // FIXME: Also support inset, spread-radius and multiple comma-separated box-shadows
-    Length offset_x {};
-    Length offset_y {};
-    Length blur_radius {};
-    Color color {};
+    Optional<Color> color;
+    Optional<Length> offset_x;
+    Optional<Length> offset_y;
+    Optional<Length> blur_radius;
 
-    if (component_values.size() < 3 || component_values.size() > 4)
+    for (size_t i = 0; i < component_values.size(); ++i) {
+        if (auto maybe_color = parse_color(component_values[i]); maybe_color.has_value()) {
+            if (color.has_value())
+                return nullptr;
+            color = maybe_color.release_value();
+            continue;
+        }
+
+        if (auto maybe_offset_x = parse_length(component_values[i]); maybe_offset_x.has_value()) {
+            // horizontal offset
+            if (offset_x.has_value())
+                return nullptr;
+            offset_x = maybe_offset_x.release_value();
+
+            // vertical offset
+            if (++i >= component_values.size())
+                return nullptr;
+            auto maybe_offset_y = parse_length(component_values[i]);
+            if (!maybe_offset_y.has_value())
+                return nullptr;
+            offset_y = maybe_offset_y.release_value();
+
+            // blur radius (optional)
+            if (i + 1 >= component_values.size())
+                break;
+            auto maybe_blur_radius = parse_length(component_values[i + 1]);
+            if (!maybe_blur_radius.has_value())
+                continue;
+            ++i;
+            blur_radius = maybe_blur_radius.release_value();
+
+            continue;
+        }
+
+        // Unrecognized value
         return nullptr;
-
-    auto maybe_x = parse_length(component_values[0]);
-    if (!maybe_x.has_value())
-        return nullptr;
-    offset_x = maybe_x.value();
-
-    auto maybe_y = parse_length(component_values[1]);
-    if (!maybe_y.has_value())
-        return nullptr;
-    offset_y = maybe_y.value();
-
-    if (component_values.size() == 3) {
-        auto parsed_color = parse_color(component_values[2]);
-        if (!parsed_color.has_value())
-            return nullptr;
-        color = parsed_color.value();
-    } else if (component_values.size() == 4) {
-        auto maybe_blur_radius = parse_length(component_values[2]);
-        if (!maybe_blur_radius.has_value())
-            return nullptr;
-        blur_radius = maybe_blur_radius.value();
-
-        auto parsed_color = parse_color(component_values[3]);
-        if (!parsed_color.has_value())
-            return nullptr;
-        color = parsed_color.value();
     }
 
-    return BoxShadowStyleValue::create(offset_x, offset_y, blur_radius, color);
+    // FIXME: If color is absent, default to `currentColor`
+    if (!color.has_value())
+        color = Color::NamedColor::Black;
+
+    // x/y offsets are required
+    if (!offset_x.has_value() || !offset_y.has_value())
+        return nullptr;
+
+    // Other lengths default to 0
+    if (!blur_radius.has_value())
+        blur_radius = Length::make_px(0);
+
+    return BoxShadowStyleValue::create(offset_x.release_value(), offset_y.release_value(), blur_radius.release_value(), color.release_value());
 }
 
 RefPtr<StyleValue> Parser::parse_flex_value(Vector<StyleComponentValueRule> const& component_values)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -232,6 +232,7 @@ private:
     RefPtr<StyleValue> parse_border_radius_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_border_radius_shorthand_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_box_shadow_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_single_box_shadow_value(TokenStream<StyleComponentValueRule>&);
     RefPtr<StyleValue> parse_flex_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_flex_flow_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_font_value(Vector<StyleComponentValueRule> const&);

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -523,8 +523,7 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
             return {};
 
         auto make_box_shadow_style_value = [](BoxShadowData const& data) {
-            // FIXME: Add extra properties to BoxShadowData so we can include them here!
-            return BoxShadowStyleValue::create(data.color, data.offset_x, data.offset_y, data.blur_radius, Length::make_px(0), BoxShadowPlacement::Outer);
+            return BoxShadowStyleValue::create(data.color, data.offset_x, data.offset_y, data.blur_radius, data.spread_distance, data.placement);
         };
 
         if (box_shadow_layers.size() == 1)

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -522,7 +522,8 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         if (!maybe_box_shadow.has_value())
             return {};
         auto box_shadow_data = maybe_box_shadow.release_value();
-        return BoxShadowStyleValue::create(box_shadow_data.offset_x, box_shadow_data.offset_y, box_shadow_data.blur_radius, box_shadow_data.color);
+        // FIXME: Add extra properties to BoxShadowData so we can include them here!
+        return BoxShadowStyleValue::create(box_shadow_data.color, box_shadow_data.offset_x, box_shadow_data.offset_y, box_shadow_data.blur_radius, Length::make_px(0), BoxShadowPlacement::Outer);
     }
     case CSS::PropertyID::Width:
         return style_value_for_length_percentage(layout_node.computed_values().width());

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -518,12 +518,23 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::JustifyContent:
         return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().justify_content()));
     case CSS::PropertyID::BoxShadow: {
-        auto maybe_box_shadow = layout_node.computed_values().box_shadow();
-        if (!maybe_box_shadow.has_value())
+        auto box_shadow_layers = layout_node.computed_values().box_shadow();
+        if (box_shadow_layers.is_empty())
             return {};
-        auto box_shadow_data = maybe_box_shadow.release_value();
-        // FIXME: Add extra properties to BoxShadowData so we can include them here!
-        return BoxShadowStyleValue::create(box_shadow_data.color, box_shadow_data.offset_x, box_shadow_data.offset_y, box_shadow_data.blur_radius, Length::make_px(0), BoxShadowPlacement::Outer);
+
+        auto make_box_shadow_style_value = [](BoxShadowData const& data) {
+            // FIXME: Add extra properties to BoxShadowData so we can include them here!
+            return BoxShadowStyleValue::create(data.color, data.offset_x, data.offset_y, data.blur_radius, Length::make_px(0), BoxShadowPlacement::Outer);
+        };
+
+        if (box_shadow_layers.size() == 1)
+            return make_box_shadow_style_value(box_shadow_layers.first());
+
+        NonnullRefPtrVector<StyleValue> box_shadow;
+        box_shadow.ensure_capacity(box_shadow_layers.size());
+        for (auto const& layer : box_shadow_layers)
+            box_shadow.append(make_box_shadow_style_value(layer));
+        return StyleValueList::create(move(box_shadow), StyleValueList::Separator::Comma);
     }
     case CSS::PropertyID::Width:
         return style_value_for_length_percentage(layout_node.computed_values().width());

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -778,7 +778,7 @@ Vector<BoxShadowData> StyleProperties::box_shadow() const
     auto value = value_or_error.value();
 
     auto make_box_shadow_data = [](BoxShadowStyleValue const& box) {
-        return BoxShadowData { box.offset_x(), box.offset_y(), box.blur_radius(), box.color() };
+        return BoxShadowData { box.color(), box.offset_x(), box.offset_y(), box.blur_radius(), box.spread_distance(), box.placement() };
     };
 
     if (value->is_value_list()) {

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -64,7 +64,7 @@ public:
     Optional<CSS::JustifyContent> justify_content() const;
     Optional<CSS::Overflow> overflow_x() const;
     Optional<CSS::Overflow> overflow_y() const;
-    Optional<CSS::BoxShadowData> box_shadow() const;
+    Vector<CSS::BoxShadowData> box_shadow() const;
     CSS::BoxSizing box_sizing() const;
     Optional<CSS::PointerEvents> pointer_events() const;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -271,7 +271,11 @@ String BorderRadiusStyleValue::to_string() const
 
 String BoxShadowStyleValue::to_string() const
 {
-    return String::formatted("{} {} {} {}", m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_color.to_string());
+    StringBuilder builder;
+    builder.appendff("{} {} {} {} {}", m_color.to_string(), m_offset_x.to_string(), m_offset_y.to_string(), m_blur_radius.to_string(), m_spread_distance.to_string());
+    if (m_placement == BoxShadowPlacement::Inner)
+        builder.append(" inset");
+    return builder.to_string();
 }
 
 void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, Length const& percentage_basis)

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -64,6 +64,11 @@ enum class BoxSizing {
     ContentBox,
 };
 
+enum class BoxShadowPlacement {
+    Outer,
+    Inner,
+};
+
 enum class Clear {
     None,
     Left,
@@ -616,27 +621,31 @@ private:
 
 class BoxShadowStyleValue final : public StyleValue {
 public:
-    static NonnullRefPtr<BoxShadowStyleValue> create(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
+    static NonnullRefPtr<BoxShadowStyleValue>
+    create(Color const& color, Length const& offset_x, Length const& offset_y, Length const& blur_radius, Length const& spread_distance, BoxShadowPlacement placement)
     {
-        return adopt_ref(*new BoxShadowStyleValue(offset_x, offset_y, blur_radius, color));
+        return adopt_ref(*new BoxShadowStyleValue(color, offset_x, offset_y, blur_radius, spread_distance, placement));
     }
     virtual ~BoxShadowStyleValue() override { }
 
-    // FIXME: Spread-distance and "inset" flag
+    Color const& color() const { return m_color; }
     Length const& offset_x() const { return m_offset_x; }
     Length const& offset_y() const { return m_offset_y; }
     Length const& blur_radius() const { return m_blur_radius; }
-    Color const& color() const { return m_color; }
+    Length const& spread_distance() const { return m_spread_distance; }
+    BoxShadowPlacement placement() const { return m_placement; }
 
     virtual String to_string() const override;
 
 private:
-    explicit BoxShadowStyleValue(Length const& offset_x, Length const& offset_y, Length const& blur_radius, Color const& color)
+    explicit BoxShadowStyleValue(Color const& color, Length const& offset_x, Length const& offset_y, Length const& blur_radius, Length const& spread_distance, BoxShadowPlacement placement)
         : StyleValue(Type::BoxShadow)
+        , m_color(color)
         , m_offset_x(offset_x)
         , m_offset_y(offset_y)
         , m_blur_radius(blur_radius)
-        , m_color(color)
+        , m_spread_distance(spread_distance)
+        , m_placement(placement)
     {
     }
 
@@ -645,12 +654,15 @@ private:
         visitor(m_offset_x);
         visitor(m_offset_y);
         visitor(m_blur_radius);
+        visitor(m_spread_distance);
     }
 
+    Color m_color;
     Length m_offset_x;
     Length m_offset_y;
     Length m_blur_radius;
-    Color m_color;
+    Length m_spread_distance;
+    BoxShadowPlacement m_placement;
 };
 
 class CalculatedStyleValue : public StyleValue {

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -99,15 +99,18 @@ void Box::paint_background(PaintContext& context)
 void Box::paint_box_shadow(PaintContext& context)
 {
     auto box_shadow_data = computed_values().box_shadow();
-    if (!box_shadow_data.has_value())
+    if (box_shadow_data.is_empty())
         return;
 
-    auto resolved_box_shadow_data = Painting::BoxShadowData {
-        .offset_x = (int)box_shadow_data->offset_x.resolved_or_zero(*this).to_px(*this),
-        .offset_y = (int)box_shadow_data->offset_y.resolved_or_zero(*this).to_px(*this),
-        .blur_radius = (int)box_shadow_data->blur_radius.resolved_or_zero(*this).to_px(*this),
-        .color = box_shadow_data->color
-    };
+    Vector<Painting::BoxShadowData> resolved_box_shadow_data;
+    resolved_box_shadow_data.ensure_capacity(box_shadow_data.size());
+    for (auto const& layer : box_shadow_data) {
+        resolved_box_shadow_data.empend(
+            static_cast<int>(layer.offset_x.resolved_or_zero(*this).to_px(*this)),
+            static_cast<int>(layer.offset_y.resolved_or_zero(*this).to_px(*this)),
+            static_cast<int>(layer.blur_radius.resolved_or_zero(*this).to_px(*this)),
+            layer.color);
+    }
     Painting::paint_box_shadow(context, enclosing_int_rect(bordered_rect()), resolved_box_shadow_data);
 }
 

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -106,10 +106,12 @@ void Box::paint_box_shadow(PaintContext& context)
     resolved_box_shadow_data.ensure_capacity(box_shadow_data.size());
     for (auto const& layer : box_shadow_data) {
         resolved_box_shadow_data.empend(
+            layer.color,
             static_cast<int>(layer.offset_x.resolved_or_zero(*this).to_px(*this)),
             static_cast<int>(layer.offset_y.resolved_or_zero(*this).to_px(*this)),
             static_cast<int>(layer.blur_radius.resolved_or_zero(*this).to_px(*this)),
-            layer.color);
+            static_cast<int>(layer.spread_distance.resolved_or_zero(*this).to_px(*this)),
+            layer.placement == CSS::BoxShadowPlacement::Outer ? Painting::BoxShadowPlacement::Outer : Painting::BoxShadowPlacement::Inner);
     }
     Painting::paint_box_shadow(context, enclosing_int_rect(bordered_rect()), resolved_box_shadow_data);
 }

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -43,14 +43,17 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
             auto border_radius_data = Painting::normalized_border_radius_data(*this, absolute_fragment_rect, top_left_border_radius, top_right_border_radius, bottom_right_border_radius, bottom_left_border_radius);
             Painting::paint_background(context, *this, enclosing_int_rect(absolute_fragment_rect), computed_values().background_color(), &computed_values().background_layers(), border_radius_data);
 
-            if (auto computed_box_shadow = computed_values().box_shadow(); computed_box_shadow.has_value()) {
-                auto box_shadow_data = Painting::BoxShadowData {
-                    .offset_x = (int)computed_box_shadow->offset_x.resolved_or_zero(*this).to_px(*this),
-                    .offset_y = (int)computed_box_shadow->offset_y.resolved_or_zero(*this).to_px(*this),
-                    .blur_radius = (int)computed_box_shadow->blur_radius.resolved_or_zero(*this).to_px(*this),
-                    .color = computed_box_shadow->color
-                };
-                Painting::paint_box_shadow(context, enclosing_int_rect(absolute_fragment_rect), box_shadow_data);
+            if (auto computed_box_shadow = computed_values().box_shadow(); !computed_box_shadow.is_empty()) {
+                Vector<Painting::BoxShadowData> resolved_box_shadow_data;
+                resolved_box_shadow_data.ensure_capacity(computed_box_shadow.size());
+                for (auto const& layer : computed_box_shadow) {
+                    resolved_box_shadow_data.empend(
+                        static_cast<int>(layer.offset_x.resolved_or_zero(*this).to_px(*this)),
+                        static_cast<int>(layer.offset_y.resolved_or_zero(*this).to_px(*this)),
+                        static_cast<int>(layer.blur_radius.resolved_or_zero(*this).to_px(*this)),
+                        layer.color);
+                }
+                Painting::paint_box_shadow(context, enclosing_int_rect(absolute_fragment_rect), resolved_box_shadow_data);
             }
 
             return IterationDecision::Continue;

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -48,10 +48,12 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
                 resolved_box_shadow_data.ensure_capacity(computed_box_shadow.size());
                 for (auto const& layer : computed_box_shadow) {
                     resolved_box_shadow_data.empend(
+                        layer.color,
                         static_cast<int>(layer.offset_x.resolved_or_zero(*this).to_px(*this)),
                         static_cast<int>(layer.offset_y.resolved_or_zero(*this).to_px(*this)),
                         static_cast<int>(layer.blur_radius.resolved_or_zero(*this).to_px(*this)),
-                        layer.color);
+                        static_cast<int>(layer.spread_distance.resolved_or_zero(*this).to_px(*this)),
+                        layer.placement == CSS::BoxShadowPlacement::Outer ? Painting::BoxShadowPlacement::Outer : Painting::BoxShadowPlacement::Inner);
                 }
                 Painting::paint_box_shadow(context, enclosing_int_rect(absolute_fragment_rect), resolved_box_shadow_data);
             }

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,42 +13,50 @@
 
 namespace Web::Painting {
 
-void paint_box_shadow(PaintContext& context, Gfx::IntRect const& content_rect, BoxShadowData const& box_shadow_data)
+void paint_box_shadow(PaintContext& context, Gfx::IntRect const& content_rect, Vector<BoxShadowData> const& box_shadow_layers)
 {
-    Gfx::IntRect bitmap_rect = {
-        0,
-        0,
-        content_rect.width() + 4 * box_shadow_data.blur_radius,
-        content_rect.height() + 4 * box_shadow_data.blur_radius
-    };
-
-    Gfx::IntPoint blur_rect_position = {
-        content_rect.x() - 2 * box_shadow_data.blur_radius + box_shadow_data.offset_x,
-        content_rect.y() - 2 * box_shadow_data.blur_radius + box_shadow_data.offset_y
-    };
-
-    if (bitmap_rect.is_empty())
+    if (box_shadow_layers.is_empty())
         return;
 
-    auto bitmap_or_error = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, bitmap_rect.size());
-    if (bitmap_or_error.is_error()) {
-        dbgln("Unable to allocate temporary bitmap for box-shadow rendering: {}", bitmap_or_error.error());
-        return;
+    // Note: Box-shadow layers are ordered front-to-back, so we paint them in reverse
+    for (int layer_index = box_shadow_layers.size() - 1; layer_index >= 0; layer_index--) {
+        auto& box_shadow_data = box_shadow_layers[layer_index];
+
+        Gfx::IntRect bitmap_rect = {
+            0,
+            0,
+            content_rect.width() + 4 * box_shadow_data.blur_radius,
+            content_rect.height() + 4 * box_shadow_data.blur_radius
+        };
+
+        Gfx::IntPoint blur_rect_position = {
+            content_rect.x() - 2 * box_shadow_data.blur_radius + box_shadow_data.offset_x,
+            content_rect.y() - 2 * box_shadow_data.blur_radius + box_shadow_data.offset_y
+        };
+
+        if (bitmap_rect.is_empty())
+            return;
+
+        auto bitmap_or_error = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, bitmap_rect.size());
+        if (bitmap_or_error.is_error()) {
+            dbgln("Unable to allocate temporary bitmap for box-shadow rendering: {}", bitmap_or_error.error());
+            return;
+        }
+        auto new_bitmap = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
+
+        Gfx::Painter painter(*new_bitmap);
+        painter.fill_rect({ { 2 * box_shadow_data.blur_radius, 2 * box_shadow_data.blur_radius }, content_rect.size() }, box_shadow_data.color);
+
+        Gfx::FastBoxBlurFilter filter(*new_bitmap);
+        filter.apply_three_passes(box_shadow_data.blur_radius);
+
+        Gfx::DisjointRectSet rect_set;
+        rect_set.add(bitmap_rect);
+        auto shattered = rect_set.shatter({ content_rect.location() - blur_rect_position, content_rect.size() });
+
+        for (auto& rect : shattered.rects())
+            context.painter().blit(rect.location() + blur_rect_position, *new_bitmap, rect);
     }
-    auto new_bitmap = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
-
-    Gfx::Painter painter(*new_bitmap);
-    painter.fill_rect({ { 2 * box_shadow_data.blur_radius, 2 * box_shadow_data.blur_radius }, content_rect.size() }, box_shadow_data.color);
-
-    Gfx::FastBoxBlurFilter filter(*new_bitmap);
-    filter.apply_three_passes(box_shadow_data.blur_radius);
-
-    Gfx::DisjointRectSet rect_set;
-    rect_set.add(bitmap_rect);
-    auto shattered = rect_set.shatter({ content_rect.location() - blur_rect_position, content_rect.size() });
-
-    for (auto& rect : shattered.rects())
-        context.painter().blit(rect.location() + blur_rect_position, *new_bitmap, rect);
 }
 
 }

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -21,17 +21,20 @@ void paint_box_shadow(PaintContext& context, Gfx::IntRect const& content_rect, V
     // Note: Box-shadow layers are ordered front-to-back, so we paint them in reverse
     for (int layer_index = box_shadow_layers.size() - 1; layer_index >= 0; layer_index--) {
         auto& box_shadow_data = box_shadow_layers[layer_index];
+        // FIXME: Paint inset shadows.
+        if (box_shadow_data.placement != BoxShadowPlacement::Outer)
+            continue;
 
         Gfx::IntRect bitmap_rect = {
             0,
             0,
-            content_rect.width() + 4 * box_shadow_data.blur_radius,
-            content_rect.height() + 4 * box_shadow_data.blur_radius
+            content_rect.width() + (2 * box_shadow_data.spread_distance) + (4 * box_shadow_data.blur_radius),
+            content_rect.height() + (2 * box_shadow_data.spread_distance) + (4 * box_shadow_data.blur_radius)
         };
 
         Gfx::IntPoint blur_rect_position = {
-            content_rect.x() - 2 * box_shadow_data.blur_radius + box_shadow_data.offset_x,
-            content_rect.y() - 2 * box_shadow_data.blur_radius + box_shadow_data.offset_y
+            content_rect.x() - box_shadow_data.spread_distance - (2 * box_shadow_data.blur_radius) + box_shadow_data.offset_x,
+            content_rect.y() - box_shadow_data.spread_distance - (2 * box_shadow_data.blur_radius) + box_shadow_data.offset_y
         };
 
         if (bitmap_rect.is_empty())
@@ -45,7 +48,7 @@ void paint_box_shadow(PaintContext& context, Gfx::IntRect const& content_rect, V
         auto new_bitmap = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
 
         Gfx::Painter painter(*new_bitmap);
-        painter.fill_rect({ { 2 * box_shadow_data.blur_radius, 2 * box_shadow_data.blur_radius }, content_rect.size() }, box_shadow_data.color);
+        painter.fill_rect({ { 2 * box_shadow_data.blur_radius, 2 * box_shadow_data.blur_radius }, { content_rect.width() + (2 * box_shadow_data.spread_distance), content_rect.height() + (2 * box_shadow_data.spread_distance) } }, box_shadow_data.color);
 
         Gfx::FastBoxBlurFilter filter(*new_bitmap);
         filter.apply_three_passes(box_shadow_data.blur_radius);

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
@@ -11,11 +11,18 @@
 
 namespace Web::Painting {
 
+enum class BoxShadowPlacement {
+    Outer,
+    Inner,
+};
+
 struct BoxShadowData {
+    Gfx::Color color;
     int offset_x;
     int offset_y;
     int blur_radius;
-    Gfx::Color color;
+    int spread_distance;
+    BoxShadowPlacement placement;
 };
 
 void paint_box_shadow(PaintContext&, Gfx::IntRect const&, Vector<BoxShadowData> const&);

--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,6 +18,6 @@ struct BoxShadowData {
     Gfx::Color color;
 };
 
-void paint_box_shadow(PaintContext&, Gfx::IntRect const&, BoxShadowData const&);
+void paint_box_shadow(PaintContext&, Gfx::IntRect const&, Vector<BoxShadowData> const&);
 
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/153020792-ca4c620b-4fe4-4aa1-91fe-f906464683d5.png)

Motivated again by excessive CSS parser spam when loading Discord, here are some `box-shadow` improvements! This extends our parsing to include the "spread distance" parameter, the optional "inset" keyword, and multiple shadow definitions separated by commas. Then, modifying the painting code to make use of these for outer shadows.

`inset` shadows are just skipped over during painting for now. As noted, we may want to paint them separately from outer shadows, since the two kinds cannot overlap, and inset shadows need to be drawn on top of the element's background.

I hesitate to say that parsing is complete, since `calc()` inside a box-shadow does not work. I need to do a pass later over this and several other StyleValue classes to make that work everywhere.