### PR TITLE
Browser: Make underlined shortcuts in "Debug" menu unique

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -289,7 +289,7 @@ void BrowserWindow::build_menus()
         },
         this));
     debug_menu.add_action(GUI::Action::create(
-        "Dump &Stacking Context Tree", g_icon_bag.layers, [this](auto&) {
+        "Dump S&tacking Context Tree", g_icon_bag.layers, [this](auto&) {
             active_tab().m_web_content_view->debug_request("dump-stacking-context-tree");
         },
         this));
@@ -306,7 +306,7 @@ void BrowserWindow::build_menus()
         if (tab.on_dump_cookies)
             tab.on_dump_cookies();
     }));
-    debug_menu.add_action(GUI::Action::create("Dump &Local Storage", [this](auto&) {
+    debug_menu.add_action(GUI::Action::create("Dump Loc&al Storage", [this](auto&) {
         active_tab().m_web_content_view->debug_request("dump-local-storage");
     }));
     debug_menu.add_separator();
@@ -366,7 +366,7 @@ void BrowserWindow::build_menus()
 
     debug_menu.add_separator();
     auto same_origin_policy_action = GUI::Action::create_checkable(
-        "Enable Same &Origin Policy", [this](auto& action) {
+        "Enable Same Origin &Policy", [this](auto& action) {
             active_tab().m_web_content_view->debug_request("same-origin-policy", action.is_checked() ? "on" : "off");
         },
         this);


### PR DESCRIPTION
Noticed that the '&' annotated shortcuts in Debug menu actions repeat. I'm not 100% sure if assigning random letters instead is the right way to go about this.

![image](https://user-images.githubusercontent.com/25880357/153239862-873e0c47-3398-48a6-ae53-fa144e0ec1d6.png)