### PR TITLE
LibWeb: Do not set Content-Length headers twice for POST requests

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -117,7 +117,6 @@ void HTMLFormElement::submit_form(RefPtr<HTMLElement> submitter, bool from_submi
         auto body = url_encode(parameters, AK::URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded).to_byte_buffer();
         request.set_method("POST");
         request.set_header("Content-Type", "application/x-www-form-urlencoded");
-        request.set_header("Content-Length", String::number(body.size()));
         request.set_body(body);
     }
 


### PR DESCRIPTION
While trying to get http://lite.duckduckgo.com to work in the Browser I
noticed that we kept on getting 400 (Bad Request) errors when you click
the "Search" button for a request.

After turning on `JOB_DEBUG` to see what headers we were sending it
turned out that we were actually setting `Content-Length` twice once
in LibWeb, and again when the request is handled by LibHTTP.

Since LibHTTP transparently handles this now, we can avoid it in LibWeb.

Sweet Demo: 

![image](https://user-images.githubusercontent.com/1212/153144467-a80ac7a9-a219-4329-a984-2e61fc85bd16.png)
