### PR TITLE
Kernel+Utilities/lspci: Iterate over /sys/bus/pci instead of reading /proc/pci

### DIFF
--- a/Base/usr/share/man/man8/lspci.md
+++ b/Base/usr/share/man/man8/lspci.md
@@ -15,7 +15,7 @@ and devices connected to them. It shows a brief list of devices.
 
 ## Files
 
-* `/proc/pci` - source of the PCI devices list.
+* `/sys/bus/pci` - source of the PCI devices list.
 * `/res/pci.ids` - a database of PCI identifiers used to match available devices to their vendor, device and class names.
 
 ## Examples

--- a/Kernel/Bus/PCI/SysFSPCI.cpp
+++ b/Kernel/Bus/PCI/SysFSPCI.cpp
@@ -32,6 +32,13 @@ UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(NonnullOwnPtr<
     m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::PROG_IF, 1));
     m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::SUBSYSTEM_VENDOR_ID, 2));
     m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::SUBSYSTEM_ID, 2));
+
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::BAR0, 4));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::BAR1, 4));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::BAR2, 4));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::BAR3, 4));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::BAR4, 4));
+    m_components.append(PCIDeviceAttributeSysFSComponent::create(*this, PCI::RegisterOffset::BAR5, 4));
 }
 
 UNMAP_AFTER_INIT void PCIBusSysFSDirectory::initialize()
@@ -68,6 +75,18 @@ StringView PCIDeviceAttributeSysFSComponent::name() const
         return "subsystem_vendor"sv;
     case PCI::RegisterOffset::SUBSYSTEM_ID:
         return "subsystem_id"sv;
+    case PCI::RegisterOffset::BAR0:
+        return "bar0"sv;
+    case PCI::RegisterOffset::BAR1:
+        return "bar1"sv;
+    case PCI::RegisterOffset::BAR2:
+        return "bar2"sv;
+    case PCI::RegisterOffset::BAR3:
+        return "bar3"sv;
+    case PCI::RegisterOffset::BAR4:
+        return "bar4"sv;
+    case PCI::RegisterOffset::BAR5:
+        return "bar5"sv;
     default:
         VERIFY_NOT_REACHED();
     }


### PR DESCRIPTION
This opens many opportunities to add more data printed in lspci in a
flexible manner - so instead of reading an ever-expanding JSON encoded
file, we can add more features and let the utility read the directory
entries from sysfs.

This also allows not only filtering data on devices but to easily filter
non-wanted devices when printing the output.

----

This is a preparation to remove the `/proc/pci` node in the near future and to rely on the sysfs interface which is much more flexible. I work on migrating the `SystemMonitor` code too but it is quite hard for me as a Serenity userspace newcomer :)