### PR TITLE
AK+Kernel: Alphabetize debug macros

### DIFF
--- a/AK/Debug.h.in
+++ b/AK/Debug.h.in
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#ifndef AWAVLOADER_DEBUG
-#cmakedefine01 AWAVLOADER_DEBUG
-#endif
-
 #ifndef AFLACLOADER_DEBUG
 #cmakedefine01 AFLACLOADER_DEBUG
+#endif
+
+#ifndef AWAVLOADER_DEBUG
+#cmakedefine01 AWAVLOADER_DEBUG
 #endif
 
 #ifndef BMP_DEBUG
@@ -34,12 +34,12 @@
 #cmakedefine01 COPY_DEBUG
 #endif
 
-#ifndef CPP_LANGUAGE_SERVER_DEBUG
-#cmakedefine01 CPP_LANGUAGE_SERVER_DEBUG
-#endif
-
 #ifndef CPP_DEBUG
 #cmakedefine01 CPP_DEBUG
+#endif
+
+#ifndef CPP_LANGUAGE_SERVER_DEBUG
+#cmakedefine01 CPP_LANGUAGE_SERVER_DEBUG
 #endif
 
 #ifndef CRYPTO_DEBUG
@@ -74,12 +74,12 @@
 #cmakedefine01 DEFERRED_INVOKE_DEBUG
 #endif
 
-#ifndef DHCPV4CLIENT_DEBUG
-#cmakedefine01 DHCPV4CLIENT_DEBUG
-#endif
-
 #ifndef DHCPV4_DEBUG
 #cmakedefine01 DHCPV4_DEBUG
+#endif
+
+#ifndef DHCPV4CLIENT_DEBUG
+#cmakedefine01 DHCPV4CLIENT_DEBUG
 #endif
 
 #ifndef DIFF_DEBUG

--- a/Kernel/Debug.h.in
+++ b/Kernel/Debug.h.in
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Paul Scharnofske
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,6 +9,10 @@
 
 #ifndef AC97_DEBUG
 #cmakedefine01 AC97_DEBUG
+#endif
+
+#ifndef AHCI_DEBUG
+#cmakedefine01 AHCI_DEBUG
 #endif
 
 #ifndef ACPI_DEBUG
@@ -74,12 +79,12 @@
 #cmakedefine01 EXT2_DEBUG
 #endif
 
-#ifndef FRAMEBUFFER_DEVICE_DEBUG
-#cmakedefine01 FRAMEBUFFER_DEVICE_DEBUG
-#endif
-
 #ifndef EXT2_VERY_DEBUG
 #cmakedefine01 EXT2_VERY_DEBUG
+#endif
+
+#ifndef FRAMEBUFFER_DEVICE_DEBUG
+#cmakedefine01 FRAMEBUFFER_DEVICE_DEBUG
 #endif
 
 #ifndef FILEDESCRIPTION_DEBUG
@@ -122,12 +127,12 @@
 #cmakedefine01 INTERRUPT_DEBUG
 #endif
 
-#ifndef IOAPIC_DEBUG
-#cmakedefine01 IOAPIC_DEBUG
-#endif
-
 #ifndef IO_DEBUG
 #cmakedefine01 IO_DEBUG
+#endif
+
+#ifndef IOAPIC_DEBUG
+#cmakedefine01 IOAPIC_DEBUG
 #endif
 
 #ifndef ISO9660_DEBUG
@@ -228,10 +233,6 @@
 
 #ifndef PATA_DEBUG
 #cmakedefine01 PATA_DEBUG
-#endif
-
-#ifndef AHCI_DEBUG
-#cmakedefine01 AHCI_DEBUG
 #endif
 
 #ifndef PCI_DEBUG


### PR DESCRIPTION
This is not ASCII-betical because `_` comes after all the uppercase
characters. Treating `_` as a ` ` (space character), these lists are
now alphabetical.