### PR TITLE
Kernel: Change static constexpr variables to constexpr where possible

### DIFF
--- a/Kernel/Arch/x86/common/Processor.cpp
+++ b/Kernel/Arch/x86/common/Processor.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -514,7 +515,7 @@ ErrorOr<Vector<FlatPtr, 32>> Processor::capture_stack_trace(Thread& thread, size
     Vector<FlatPtr, 32> stack_trace;
 
     auto walk_stack = [&](FlatPtr stack_ptr) -> ErrorOr<void> {
-        static constexpr size_t max_stack_frames = 4096;
+        constexpr size_t max_stack_frames = 4096;
         bool is_walking_userspace_stack = false;
         TRY(stack_trace.try_append(ip));
         size_t count = 1;

--- a/Kernel/Firmware/ACPI/Parser.cpp
+++ b/Kernel/Firmware/ACPI/Parser.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Liav A. <liavalb@hotmail.co.il>
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -395,7 +396,7 @@ static bool validate_table(const Structures::SDTHeader& v_header, size_t length)
 // https://uefi.org/specs/ACPI/6.4/05_ACPI_Software_Programming_Model/ACPI_Software_Programming_Model.html#finding-the-rsdp-on-ia-pc-systems
 UNMAP_AFTER_INIT Optional<PhysicalAddress> StaticParsing::find_rsdp()
 {
-    static constexpr auto signature = "RSD PTR "sv;
+    constexpr auto signature = "RSD PTR "sv;
     auto ebda_or_error = map_ebda();
     if (!ebda_or_error.is_error()) {
         auto rsdp = ebda_or_error.value().find_chunk_starting_with(signature, 16);

--- a/Kernel/Firmware/MultiProcessor/Parser.cpp
+++ b/Kernel/Firmware/MultiProcessor/Parser.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -86,7 +87,7 @@ UNMAP_AFTER_INIT void MultiProcessorParser::parse_configuration_table()
 
 UNMAP_AFTER_INIT Optional<PhysicalAddress> MultiProcessorParser::find_floating_pointer()
 {
-    static constexpr auto signature = "_MP_"sv;
+    constexpr auto signature = "_MP_"sv;
     auto ebda_or_error = map_ebda();
     if (!ebda_or_error.is_error()) {
         auto mp_floating_pointer = ebda_or_error.value().find_chunk_starting_with(signature, 16);

--- a/Kernel/Graphics/VirtIOGPU/FramebufferDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/FramebufferDevice.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Sahan Fernando <sahan.h.fernando@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -342,7 +343,7 @@ void FramebufferDevice::clear_to_black(Buffer& buffer)
 
 void FramebufferDevice::draw_ntsc_test_pattern(Buffer& buffer)
 {
-    static constexpr u8 colors[12][4] = {
+    constexpr u8 colors[12][4] = {
         { 0xff, 0xff, 0xff, 0xff }, // White
         { 0x00, 0xff, 0xff, 0xff }, // Primary + Composite colors
         { 0xff, 0xff, 0x00, 0xff },

--- a/Kernel/Memory/VirtualRangeAllocator.cpp
+++ b/Kernel/Memory/VirtualRangeAllocator.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -68,7 +69,7 @@ ErrorOr<VirtualRange> VirtualRangeAllocator::try_allocate_randomized(size_t size
     VERIFY((alignment % PAGE_SIZE) == 0);
 
     // FIXME: I'm sure there's a smarter way to do this.
-    static constexpr size_t maximum_randomization_attempts = 1000;
+    constexpr size_t maximum_randomization_attempts = 1000;
     for (size_t i = 0; i < maximum_randomization_attempts; ++i) {
         VirtualAddress random_address { round_up_to_power_of_two(get_fast_random<FlatPtr>() % m_total_range.end().get(), alignment) };
 

--- a/Kernel/Prekernel/Arch/aarch64/init.cpp
+++ b/Kernel/Prekernel/Arch/aarch64/init.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2021, Nico Weber <thakis@chromium.org>
  * Copyright (c) 2021, Marcin Undak <mcinek@gmail.com>
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -99,7 +100,7 @@ void __stack_chk_fail()
 
 extern "C" void exception_common(TrapFrame const* const trap_frame)
 {
-    static constexpr bool print_stack_frame = true;
+    constexpr bool print_stack_frame = true;
 
     if constexpr (print_stack_frame) {
         auto& uart = Prekernel::UART::the();

--- a/Kernel/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Storage/NVMe/NVMeController.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Pankaj R <pankydev8@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -71,7 +72,7 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::initialize(bool is_queue_polled)
 
 bool NVMeController::wait_for_ready(bool expected_ready_bit_value)
 {
-    static constexpr size_t one_ms_io_delay = 1000;
+    constexpr size_t one_ms_io_delay = 1000;
     auto wait_iterations = m_ready_timeout.to_milliseconds();
 
     u32 expected_rdy = expected_ready_bit_value ? 1 : 0;

--- a/Kernel/Storage/StorageManagement.cpp
+++ b/Kernel/Storage/StorageManagement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -57,7 +58,7 @@ UNMAP_AFTER_INIT void StorageManagement::enumerate_controllers(bool force_pio, b
             }
 
             {
-                static constexpr PCI::HardwareID vmd_device = { 0x8086, 0x9a0b };
+                constexpr PCI::HardwareID vmd_device = { 0x8086, 0x9a0b };
                 if (device_identifier.hardware_id() == vmd_device) {
                     auto controller = PCI::VolumeManagementDevice::must_create(device_identifier);
                     PCI::Access::the().add_host_controller_and_enumerate_attached_devices(move(controller), [this, nvme_poll](PCI::DeviceIdentifier const& device_identifier) -> void {

--- a/Kernel/Syscall.cpp
+++ b/Kernel/Syscall.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -196,7 +197,7 @@ NEVER_INLINE void syscall_handler(TrapFrame* trap)
     asm volatile(""
                  : "=m"(*ptr));
 
-    static constexpr FlatPtr iopl_mask = 3u << 12;
+    constexpr FlatPtr iopl_mask = 3u << 12;
 
     FlatPtr flags = regs.flags();
     if ((flags & (iopl_mask)) != 0) {

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -57,8 +58,8 @@ static bool validate_stack_size(NonnullOwnPtrVector<KString> const& arguments, N
     total_arguments_size += sizeof(char*) * (arguments.size() + 1);
     total_environment_size += sizeof(char*) * (environment.size() + 1);
 
-    static constexpr size_t max_arguments_size = Thread::default_userspace_stack_size / 8;
-    static constexpr size_t max_environment_size = Thread::default_userspace_stack_size / 8;
+    constexpr size_t max_arguments_size = Thread::default_userspace_stack_size / 8;
+    constexpr size_t max_environment_size = Thread::default_userspace_stack_size / 8;
 
     if (total_arguments_size > max_arguments_size)
         return false;

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -403,7 +404,7 @@ ErrorOr<void> TTY::set_termios(const termios& t)
         StringView name;
     };
 
-    static constexpr FlagDescription unimplemented_iflags[] = {
+    constexpr FlagDescription unimplemented_iflags[] = {
         { IGNBRK, "IGNBRK" },
         { BRKINT, "BRKINT" },
         { IGNPAR, "IGNPAR" },
@@ -424,7 +425,7 @@ ErrorOr<void> TTY::set_termios(const termios& t)
         }
     }
 
-    static constexpr FlagDescription unimplemented_oflags[] = {
+    constexpr FlagDescription unimplemented_oflags[] = {
         { OLCUC, "OLCUC" },
         { ONOCR, "ONOCR" },
         { ONLRET, "ONLRET" },
@@ -443,7 +444,7 @@ ErrorOr<void> TTY::set_termios(const termios& t)
         rc = ENOTIMPL;
     }
 
-    static constexpr FlagDescription unimplemented_cflags[] = {
+    constexpr FlagDescription unimplemented_cflags[] = {
         { CSTOPB, "CSTOPB" },
         { CREAD, "CREAD" },
         { PARENB, "PARENB" },
@@ -458,7 +459,7 @@ ErrorOr<void> TTY::set_termios(const termios& t)
         }
     }
 
-    static constexpr FlagDescription unimplemented_lflags[] = {
+    constexpr FlagDescription unimplemented_lflags[] = {
         { TOSTOP, "TOSTOP" },
         { IEXTEN, "IEXTEN" }
     };


### PR DESCRIPTION
Function-local `static constexpr` variables can be `constexpr`. This
can reduce memory consumption, binary size, and offer additional
compiler optimizations.

These changes result in a stripped x86_64 kernel binary size reduction
of 592 bytes.