### PR TITLE
Meta: Declare issues "stale" after 100 days of no activity within them

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,12 +1,5 @@
 # Configuration for probot-stale - https://github.com/probot/stale
 
-# Number of days of inactivity before an Issue or Pull Request becomes stale
-daysUntilStale: 21
-
-# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
-# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
-daysUntilClose: 7
-
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels: []
 
@@ -28,36 +21,31 @@ exemptAssignees: false
 # Label to use when marking as stale
 staleLabel: stale
 
-# Comment to post when marking as stale. Set to `false` to disable
-markComment: >
-  This pull request has been automatically marked as stale because it has not had
-  recent activity. It will be closed in 7 days if no further activity occurs.
-  Thank you for your contributions!
-
 # Comment to post when removing the stale label.
 # unmarkComment: >
 #   Your comment here.
 
 # Comment to post when closing a stale Issue or Pull Request.
-closeComment: >
-  This pull request has been closed because it has not had recent activity.
-  Feel free to re-open if you wish to still contribute these changes.
-  Thank you for your contributions!
+
 
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 30
 
-# Limit to only `issues` or `pulls`
-only: pulls
-
 # Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
-# pulls:
-#   daysUntilStale: 30
-#   markComment: >
-#     This pull request has been automatically marked as stale because it has not had
-#     recent activity. It will be closed if no further activity occurs. Thank you
-#     for your contributions.
+pulls:
+   daysUntilStale: 21
+   daysUntilClose: 7
+   markComment: >
+     This pull request has been automatically marked as stale because it has not had
+     recent activity. It will be closed in 7 days if no further activity occurs.
+     Thank you for your contributions!
+   closeComment: >
+      This pull request has been closed because it has not had recent activity.
+      Feel free to re-open if you wish to still contribute these changes.
+      Thank you for your contributions!
 
-# issues:
-#   exemptLabels:
-#     - confirmeda
+issues:
+   daysUntilStale: 100
+   markComment: >
+     This issue has been automatically marked as stale because it has not had
+     recent activity.


### PR DESCRIPTION
Recently it became observable to me that long-age issues might reflect
an outdated state of the project and therefore should be declared stale.
We are not closing stale issues as they might have some value in them,
but it's easier to spot them right now so the viewer can filter them out
if wanted to.