### PR TITLE
HackStudio: Don't save file when filename is empty

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -693,7 +693,9 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_save_action()
         if (active_file().is_empty())
             m_save_as_action->activate();
 
-        current_editor_wrapper().save();
+        // NOTE active_file() could still be empty after a cancelled save_as_action
+        if (!active_file().is_empty())
+            current_editor_wrapper().save();
 
         if (m_git_widget->initialized())
             m_git_widget->refresh();


### PR DESCRIPTION
When saving a new file, save_as_action will return if the filename input was empty, but save_action would still try to save the file.

Added a guard to make sure we never try to save files with empty filenames.