### PR TITLE
Base: Add pastel color palette

### DIFF
--- a/Base/res/color-palettes/pastel.palette
+++ b/Base/res/color-palettes/pastel.palette
@@ -1,0 +1,14 @@
+#8f8f8f
+#d6d6d6
+#ffc3c3
+#ffc3a5
+#ffe7a6
+#d4ffa6
+#adffa5
+#a5ffd4
+#a5fff1
+#a6d2ff
+#a6aeff
+#caa6ff
+#f3a5ff
+#ffa6e9


### PR DESCRIPTION
Add pastel color palette for PixelPaint.

![Screen Shot 2022-02-09 at 18 45 47](https://user-images.githubusercontent.com/4368524/153309726-5a88e2f4-b188-4ac4-a8e8-88a4ecf3dad3.png)