### PR TITLE
LibJS: Don't coerce this value to an object in Function.prototype.{apply,call}

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/Function/Function.prototype.apply.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Function/Function.prototype.apply.js
@@ -49,3 +49,19 @@ test("basic functionality", () => {
 
     expect((() => this).apply("foo")).toBe(globalThis);
 });
+
+describe("errors", () => {
+    test("does not accept non-function values", () => {
+        expect(() => {
+            Function.prototype.apply.call("foo");
+        }).toThrowWithMessage(TypeError, "foo is not a function");
+
+        expect(() => {
+            Function.prototype.apply.call(undefined);
+        }).toThrowWithMessage(TypeError, "undefined is not a function");
+
+        expect(() => {
+            Function.prototype.apply.call(null);
+        }).toThrowWithMessage(TypeError, "null is not a function");
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/Function/Function.prototype.call.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Function/Function.prototype.call.js
@@ -51,3 +51,19 @@ test("basic functionality", () => {
 
     expect((() => this).call("foo")).toBe(globalThis);
 });
+
+describe("errors", () => {
+    test("does not accept non-function values", () => {
+        expect(() => {
+            Function.prototype.call.call("foo");
+        }).toThrowWithMessage(TypeError, "foo is not a function");
+
+        expect(() => {
+            Function.prototype.call.call(undefined);
+        }).toThrowWithMessage(TypeError, "undefined is not a function");
+
+        expect(() => {
+            Function.prototype.call.call(null);
+        }).toThrowWithMessage(TypeError, "null is not a function");
+    });
+});


### PR DESCRIPTION
As per the spec, as it does not perform ToObject on the this value.
This also adds spec comments to these functions.