### PR TITLE
Applications: Change static constexpr variables to constexpr

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,9 +29,6 @@
 #include "Mesh.h"
 #include "WavefrontOBJLoader.h"
 
-static constexpr u16 RENDER_WIDTH = 640;
-static constexpr u16 RENDER_HEIGHT = 480;
-
 class GLContextWidget final : public GUI::Frame {
     C_OBJECT(GLContextWidget);
 
@@ -58,6 +56,8 @@ private:
     GLContextWidget()
         : m_mesh_loader(adopt_own(*new WavefrontOBJLoader()))
     {
+        constexpr u16 RENDER_WIDTH = 640;
+        constexpr u16 RENDER_HEIGHT = 480;
         m_bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { RENDER_WIDTH, RENDER_HEIGHT }).release_value_but_fixme_should_propagate_errors();
         m_context = GL::create_context(*m_bitmap);
 

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +8,7 @@
 #include "CookieJar.h"
 #include <AK/IPv4Address.h>
 #include <AK/StringBuilder.h>
+#include <AK/StringView.h>
 #include <AK/URL.h>
 #include <AK/Vector.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
@@ -48,9 +50,9 @@ void CookieJar::set_cookie(const URL& url, const Web::Cookie::ParsedCookie& pars
 
 void CookieJar::dump_cookies() const
 {
-    static const char* key_color = "\033[34;1m";
-    static const char* attribute_color = "\033[33m";
-    static const char* no_color = "\033[0m";
+    constexpr StringView key_color = "\033[34;1m";
+    constexpr StringView attribute_color = "\033[33m";
+    constexpr StringView no_color = "\033[0m";
 
     StringBuilder builder;
     builder.appendff("{} cookies stored\n", m_cookies.size());

--- a/Userland/Applications/Calendar/AddEventDialog.cpp
+++ b/Userland/Applications/Calendar/AddEventDialog.cpp
@@ -19,11 +19,6 @@
 #include <LibGfx/Color.h>
 #include <LibGfx/FontDatabase.h>
 
-static const char* short_month_names[] = {
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-};
-
 AddEventDialog::AddEventDialog(Core::DateTime date_time, Window* parent_window)
     : Dialog(parent_window)
     , m_date_time(date_time)
@@ -104,6 +99,11 @@ String AddEventDialog::MonthListModel::column_name(int column) const
 
 GUI::Variant AddEventDialog::MonthListModel::data(const GUI::ModelIndex& index, GUI::ModelRole role) const
 {
+    constexpr Array short_month_names = {
+        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    };
+
     auto& month = short_month_names[index.row()];
     if (role == GUI::ModelRole::Display) {
         switch (index.column()) {

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -322,7 +323,7 @@ bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, DirectoryView c
 
 ErrorOr<int> run_in_desktop_mode()
 {
-    static constexpr char const* process_name = "FileManager (Desktop)";
+    constexpr char const* process_name = "FileManager (Desktop)";
     set_process_name(process_name, strlen(process_name));
     pthread_setname_np(pthread_self(), process_name);
 

--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -8,6 +8,7 @@
 #include "FontEditor.h"
 #include "GlyphEditorWidget.h"
 #include "NewFontDialog.h"
+#include <AK/Array.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringUtils.h>
 #include <Applications/FontEditor/FontEditorWindowGML.h>
@@ -42,18 +43,6 @@
 #include <LibGfx/TextDirection.h>
 #include <LibUnicode/CharacterTypes.h>
 
-static constexpr int s_pangram_count = 8;
-static char const* pangrams[s_pangram_count] = {
-    "quick fox jumps nightly above wizard",
-    "five quacking zephyrs jolt my wax bed",
-    "pack my box with five dozen liquor jugs",
-    "quick brown fox jumps over the lazy dog",
-    "waxy and quivering jocks fumble the pizza",
-    "~#:[@_1%]*{$2.3}/4^(5'6\")-&|7+8!=<9,0\\>?;",
-    "byxfjärmat föl gick på duvshowen",
-    "         "
-};
-
 static RefPtr<GUI::Window> create_font_preview_window(FontEditorWidget& editor)
 {
     auto window = GUI::Window::construct(&editor);
@@ -84,6 +73,17 @@ static RefPtr<GUI::Window> create_font_preview_window(FontEditorWidget& editor)
     textbox_button_container.set_layout<GUI::HorizontalBoxLayout>();
     textbox_button_container.set_fixed_height(22);
 
+    constexpr Array pangrams = {
+        "quick fox jumps nightly above wizard",
+        "five quacking zephyrs jolt my wax bed",
+        "pack my box with five dozen liquor jugs",
+        "quick brown fox jumps over the lazy dog",
+        "waxy and quivering jocks fumble the pizza",
+        "~#:[@_1%]*{$2.3}/4^(5'6\")-&|7+8!=<9,0\\>?;",
+        "byxfjärmat föl gick på duvshowen",
+        "         "
+    };
+
     auto& preview_textbox = textbox_button_container.add<GUI::TextBox>();
     preview_textbox.set_text(pangrams[0]);
     preview_textbox.set_placeholder("Preview text");
@@ -99,8 +99,8 @@ static RefPtr<GUI::Window> create_font_preview_window(FontEditorWidget& editor)
     reload_button.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/reload.png").release_value_but_fixme_should_propagate_errors());
     reload_button.set_fixed_width(22);
     reload_button.on_click = [&](auto) {
-        static int i = 1;
-        if (i >= s_pangram_count)
+        static size_t i = 1;
+        if (i >= pangrams.size())
             i = 0;
         preview_textbox.set_text(pangrams[i]);
         i++;

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -8,6 +8,7 @@
 #include <AK/Array.h>
 #include <AK/Hex.h>
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <Applications/HexEditor/FindDialogGML.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -17,17 +18,10 @@
 #include <LibGUI/Widget.h>
 
 struct Option {
-    String title;
+    StringView title;
     OptionId opt;
     bool enabled;
     bool default_action;
-};
-
-static const Array<Option, 2> options = {
-    {
-        { "ASCII String", OPTION_ASCII_STRING, true, true },
-        { "Hex value", OPTION_HEX_VALUE, true, false },
-    }
 };
 
 int FindDialog::show(GUI::Window* parent_window, String& out_text, ByteBuffer& out_buffer, bool& find_all)
@@ -107,6 +101,13 @@ FindDialog::FindDialog()
     m_find_all_button = *main_widget.find_descendant_of_type_named<GUI::Button>("find_all_button");
     m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
 
+    constexpr Array<Option, 2> options = {
+        {
+            { "ASCII String", OPTION_ASCII_STRING, true, true },
+            { "Hex value", OPTION_HEX_VALUE, true, false },
+        }
+    };
+
     auto& radio_container = *main_widget.find_descendant_of_type_named<GUI::Widget>("radio_container");
     for (size_t i = 0; i < options.size(); i++) {
         auto action = options[i];
@@ -114,7 +115,7 @@ FindDialog::FindDialog()
         radio.set_enabled(action.enabled);
         radio.set_text(action.title);
 
-        radio.on_checked = [this, i](auto) {
+        radio.on_checked = [this, i, &options](auto) {
             m_selected_option = options[i].opt;
         };
 

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -1,15 +1,37 @@
 /*
  * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "PDFViewer.h"
+#include <AK/Array.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Painter.h>
 #include <LibPDF/Renderer.h>
 
 static constexpr int PAGE_PADDING = 25;
+
+static constexpr Array zoom_levels = {
+    17,
+    21,
+    26,
+    33,
+    41,
+    51,
+    64,
+    80,
+    100,
+    120,
+    144,
+    173,
+    207,
+    249,
+    299,
+    358,
+    430
+};
 
 PDFViewer::PDFViewer()
 {
@@ -147,7 +169,7 @@ void PDFViewer::timer_event(Core::TimerEvent&)
 
 void PDFViewer::zoom_in()
 {
-    if (m_zoom_level < number_of_zoom_levels - 1) {
+    if (m_zoom_level < zoom_levels.size() - 1) {
         m_zoom_level++;
         update();
     }

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Matthew Olsson <mattco@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,28 +11,6 @@
 #include <LibGUI/AbstractScrollableWidget.h>
 #include <LibGfx/Bitmap.h>
 #include <LibPDF/Document.h>
-
-static constexpr u16 zoom_levels[] = {
-    17,
-    21,
-    26,
-    33,
-    41,
-    51,
-    64,
-    80,
-    100,
-    120,
-    144,
-    173,
-    207,
-    249,
-    299,
-    358,
-    430
-};
-
-static constexpr size_t number_of_zoom_levels = sizeof(zoom_levels) / sizeof(zoom_levels[0]);
 
 static constexpr size_t initial_zoom_level = 8;
 

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "TreeMapWidget.h"
+#include <AK/Array.h>
 #include <AK/NumberFormat.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/WindowServerConnection.h>
@@ -15,7 +16,7 @@ REGISTER_WIDGET(SpaceAnalyzer, TreeMapWidget)
 
 namespace SpaceAnalyzer {
 
-static const Color colors[] = {
+static constexpr Array colors = {
     Color(253, 231, 37),
     Color(148, 216, 64),
     Color(60, 188, 117),

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -8,6 +8,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/Queue.h>
 #include <AK/QuickSort.h>
+#include <AK/StringView.h>
 #include <AK/URL.h>
 #include <Applications/SpaceAnalyzer/SpaceAnalyzerGML.h>
 #include <LibCore/DirIterator.h>
@@ -29,7 +30,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-static const char* APP_NAME = "Space Analyzer";
+static constexpr StringView APP_NAME = "Space Analyzer";
 static constexpr size_t FILES_ENCOUNTERED_UPDATE_STEP_SIZE = 25;
 
 struct TreeNode : public SpaceAnalyzer::TreeMapNode {


### PR DESCRIPTION
Function-local `static constexpr` variables can be `constexpr`. This
can reduce memory consumption, binary size, and offer additional
compiler optimizations.