### PR TITLE
Kernel/PCI: Expose PCI option ROM data from the sysfs interface

### DIFF
--- a/Kernel/Arch/x86_64/PCI/IDELegacyModeController.cpp
+++ b/Kernel/Arch/x86_64/PCI/IDELegacyModeController.cpp
@@ -18,9 +18,9 @@ namespace Kernel {
 UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<PCIIDELegacyModeController>> PCIIDELegacyModeController::initialize(PCI::DeviceIdentifier const& device_identifier, bool force_pio)
 {
     auto controller = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) PCIIDELegacyModeController(device_identifier)));
-    PCI::enable_io_space(device_identifier.address());
-    PCI::enable_memory_space(device_identifier.address());
-    PCI::enable_bus_mastering(device_identifier.address());
+    PCI::enable_io_space(device_identifier);
+    PCI::enable_memory_space(device_identifier);
+    PCI::enable_bus_mastering(device_identifier);
     ArmedScopeGuard disable_interrupts_on_failure([&] {
         controller->disable_pin_based_interrupts();
     });
@@ -31,7 +31,7 @@ UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<PCIIDELegacyModeController>> PCIIDELe
 }
 
 UNMAP_AFTER_INIT PCIIDELegacyModeController::PCIIDELegacyModeController(PCI::DeviceIdentifier const& device_identifier)
-    : PCI::Device(device_identifier.address())
+    : PCI::Device(const_cast<PCI::DeviceIdentifier&>(device_identifier))
     , m_prog_if(device_identifier.prog_if())
     , m_interrupt_line(device_identifier.interrupt_line())
 {
@@ -84,11 +84,11 @@ static char const* detect_controller_type(u8 programming_value)
 
 UNMAP_AFTER_INIT ErrorOr<void> PCIIDELegacyModeController::initialize_and_enumerate_channels(bool force_pio)
 {
-    dbgln("IDE controller @ {}: interrupt line was set to {}", pci_address(), m_interrupt_line.value());
-    dbgln("IDE controller @ {}: {}", pci_address(), detect_controller_type(m_prog_if.value()));
+    dbgln("IDE controller @ {}: interrupt line was set to {}", device_identifier().address(), m_interrupt_line.value());
+    dbgln("IDE controller @ {}: {}", device_identifier().address(), detect_controller_type(m_prog_if.value()));
     {
-        auto bus_master_base = IOAddress(PCI::get_BAR4(pci_address()) & (~1));
-        dbgln("IDE controller @ {}: bus master base was set to {}", pci_address(), bus_master_base);
+        auto bus_master_base = IOAddress(PCI::get_BAR4(device_identifier()) & (~1));
+        dbgln("IDE controller @ {}: bus master base was set to {}", device_identifier().address(), bus_master_base);
     }
 
     auto initialize_and_enumerate = [&force_pio](IDEChannel& channel) -> ErrorOr<void> {
@@ -106,8 +106,8 @@ UNMAP_AFTER_INIT ErrorOr<void> PCIIDELegacyModeController::initialize_and_enumer
         primary_base_io_window = TRY(IOWindow::create_for_io_space(IOAddress(0x1F0), 8));
         primary_control_io_window = TRY(IOWindow::create_for_io_space(IOAddress(0x3F6), 4));
     } else {
-        auto primary_base_io_window = TRY(IOWindow::create_for_pci_device_bar(pci_address(), PCI::HeaderType0BaseRegister::BAR0));
-        auto pci_primary_control_io_window = TRY(IOWindow::create_for_pci_device_bar(pci_address(), PCI::HeaderType0BaseRegister::BAR1));
+        auto primary_base_io_window = TRY(IOWindow::create_for_pci_device_bar(device_identifier(), PCI::HeaderType0BaseRegister::BAR0));
+        auto pci_primary_control_io_window = TRY(IOWindow::create_for_pci_device_bar(device_identifier(), PCI::HeaderType0BaseRegister::BAR1));
         // Note: the PCI IDE specification says we should access the IO address with an offset of 2
         // on native PCI IDE controllers.
         primary_control_io_window = TRY(pci_primary_control_io_window->create_from_io_window_with_offset(2, 4));
@@ -123,8 +123,8 @@ UNMAP_AFTER_INIT ErrorOr<void> PCIIDELegacyModeController::initialize_and_enumer
         secondary_base_io_window = TRY(IOWindow::create_for_io_space(IOAddress(0x170), 8));
         secondary_control_io_window = TRY(IOWindow::create_for_io_space(IOAddress(0x376), 4));
     } else {
-        secondary_base_io_window = TRY(IOWindow::create_for_pci_device_bar(pci_address(), PCI::HeaderType0BaseRegister::BAR2));
-        auto pci_secondary_control_io_window = TRY(IOWindow::create_for_pci_device_bar(pci_address(), PCI::HeaderType0BaseRegister::BAR3));
+        secondary_base_io_window = TRY(IOWindow::create_for_pci_device_bar(device_identifier(), PCI::HeaderType0BaseRegister::BAR2));
+        auto pci_secondary_control_io_window = TRY(IOWindow::create_for_pci_device_bar(device_identifier(), PCI::HeaderType0BaseRegister::BAR3));
         // Note: the PCI IDE specification says we should access the IO address with an offset of 2
         // on native PCI IDE controllers.
         secondary_control_io_window = TRY(pci_secondary_control_io_window->create_from_io_window_with_offset(2, 4));
@@ -132,7 +132,7 @@ UNMAP_AFTER_INIT ErrorOr<void> PCIIDELegacyModeController::initialize_and_enumer
     VERIFY(secondary_base_io_window);
     VERIFY(secondary_control_io_window);
 
-    auto primary_bus_master_io = TRY(IOWindow::create_for_pci_device_bar(pci_address(), PCI::HeaderType0BaseRegister::BAR4, 16));
+    auto primary_bus_master_io = TRY(IOWindow::create_for_pci_device_bar(device_identifier(), PCI::HeaderType0BaseRegister::BAR4, 16));
     auto secondary_bus_master_io = TRY(primary_bus_master_io->create_from_io_window_with_offset(8));
 
     // FIXME: On IOAPIC based system, this value might be completely wrong

--- a/Kernel/Bus/PCI/API.cpp
+++ b/Kernel/Bus/PCI/API.cpp
@@ -10,106 +10,141 @@
 
 namespace Kernel::PCI {
 
-void write8(Address address, PCI::RegisterOffset field, u8 value) { Access::the().write8_field(address, to_underlying(field), value); }
-void write16(Address address, PCI::RegisterOffset field, u16 value) { Access::the().write16_field(address, to_underlying(field), value); }
-void write32(Address address, PCI::RegisterOffset field, u32 value) { Access::the().write32_field(address, to_underlying(field), value); }
-u8 read8(Address address, PCI::RegisterOffset field) { return Access::the().read8_field(address, to_underlying(field)); }
-u16 read16(Address address, PCI::RegisterOffset field) { return Access::the().read16_field(address, to_underlying(field)); }
-u32 read32(Address address, PCI::RegisterOffset field) { return Access::the().read32_field(address, to_underlying(field)); }
+void write8_locked(DeviceIdentifier const& identifier, PCI::RegisterOffset field, u8 value)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    Access::the().write8_field(identifier, to_underlying(field), value);
+}
+void write16_locked(DeviceIdentifier const& identifier, PCI::RegisterOffset field, u16 value)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    Access::the().write16_field(identifier, to_underlying(field), value);
+}
+void write32_locked(DeviceIdentifier const& identifier, PCI::RegisterOffset field, u32 value)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    Access::the().write32_field(identifier, to_underlying(field), value);
+}
+
+u8 read8_locked(DeviceIdentifier const& identifier, PCI::RegisterOffset field)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    return Access::the().read8_field(identifier, to_underlying(field));
+}
+u16 read16_locked(DeviceIdentifier const& identifier, PCI::RegisterOffset field)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    return Access::the().read16_field(identifier, to_underlying(field));
+}
+u32 read32_locked(DeviceIdentifier const& identifier, PCI::RegisterOffset field)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    return Access::the().read32_field(identifier, to_underlying(field));
+}
 
 ErrorOr<void> enumerate(Function<void(DeviceIdentifier const&)> callback)
 {
     return Access::the().fast_enumerate(callback);
 }
 
-DeviceIdentifier get_device_identifier(Address address)
+HardwareID get_hardware_id(DeviceIdentifier const& identifier)
 {
-    return Access::the().get_device_identifier(address);
+    SpinlockLocker locker(identifier.operation_lock());
+    return { read16_locked(identifier, PCI::RegisterOffset::VENDOR_ID), read16_locked(identifier, PCI::RegisterOffset::DEVICE_ID) };
 }
 
-HardwareID get_hardware_id(Address address)
+void enable_io_space(DeviceIdentifier const& identifier)
 {
-    return { read16(address, PCI::RegisterOffset::VENDOR_ID), read16(address, PCI::RegisterOffset::DEVICE_ID) };
+    SpinlockLocker locker(identifier.operation_lock());
+    write16_locked(identifier, PCI::RegisterOffset::COMMAND, read16_locked(identifier, PCI::RegisterOffset::COMMAND) | (1 << 0));
+}
+void disable_io_space(DeviceIdentifier const& identifier)
+{
+    SpinlockLocker locker(identifier.operation_lock());
+    write16_locked(identifier, PCI::RegisterOffset::COMMAND, read16_locked(identifier, PCI::RegisterOffset::COMMAND) & ~(1 << 0));
 }
 
-void enable_io_space(Address address)
+void enable_memory_space(DeviceIdentifier const& identifier)
 {
-    write16(address, PCI::RegisterOffset::COMMAND, read16(address, PCI::RegisterOffset::COMMAND) | (1 << 0));
+    SpinlockLocker locker(identifier.operation_lock());
+    write16_locked(identifier, PCI::RegisterOffset::COMMAND, read16_locked(identifier, PCI::RegisterOffset::COMMAND) | (1 << 1));
 }
-void disable_io_space(Address address)
+void disable_memory_space(DeviceIdentifier const& identifier)
 {
-    write16(address, PCI::RegisterOffset::COMMAND, read16(address, PCI::RegisterOffset::COMMAND) & ~(1 << 0));
-}
-
-void enable_memory_space(Address address)
-{
-    write16(address, PCI::RegisterOffset::COMMAND, read16(address, PCI::RegisterOffset::COMMAND) | (1 << 1));
-}
-void disable_memory_space(Address address)
-{
-    write16(address, PCI::RegisterOffset::COMMAND, read16(address, PCI::RegisterOffset::COMMAND) & ~(1 << 1));
-}
-bool is_io_space_enabled(Address address)
-{
-    return (read16(address, PCI::RegisterOffset::COMMAND) & 1) != 0;
+    SpinlockLocker locker(identifier.operation_lock());
+    write16_locked(identifier, PCI::RegisterOffset::COMMAND, read16_locked(identifier, PCI::RegisterOffset::COMMAND) & ~(1 << 1));
 }
 
-void enable_interrupt_line(Address address)
+bool is_io_space_enabled(DeviceIdentifier const& identifier)
 {
-    write16(address, PCI::RegisterOffset::COMMAND, read16(address, PCI::RegisterOffset::COMMAND) & ~(1 << 10));
+    SpinlockLocker locker(identifier.operation_lock());
+    return (read16_locked(identifier, PCI::RegisterOffset::COMMAND) & 1) != 0;
 }
 
-void disable_interrupt_line(Address address)
+void enable_interrupt_line(DeviceIdentifier const& identifier)
 {
-    write16(address, PCI::RegisterOffset::COMMAND, read16(address, PCI::RegisterOffset::COMMAND) | 1 << 10);
+    SpinlockLocker locker(identifier.operation_lock());
+    write16_locked(identifier, PCI::RegisterOffset::COMMAND, read16_locked(identifier, PCI::RegisterOffset::COMMAND) & ~(1 << 10));
 }
 
-u32 get_BAR0(Address address)
+void disable_interrupt_line(DeviceIdentifier const& identifier)
 {
-    return read32(address, PCI::RegisterOffset::BAR0);
+    SpinlockLocker locker(identifier.operation_lock());
+    write16_locked(identifier, PCI::RegisterOffset::COMMAND, read16_locked(identifier, PCI::RegisterOffset::COMMAND) | 1 << 10);
 }
 
-u32 get_BAR1(Address address)
+u32 get_BAR0(DeviceIdentifier const& identifier)
 {
-    return read32(address, PCI::RegisterOffset::BAR1);
+    SpinlockLocker locker(identifier.operation_lock());
+    return read32_locked(identifier, PCI::RegisterOffset::BAR0);
 }
 
-u32 get_BAR2(Address address)
+u32 get_BAR1(DeviceIdentifier const& identifier)
 {
-    return read32(address, PCI::RegisterOffset::BAR2);
+    SpinlockLocker locker(identifier.operation_lock());
+    return read32_locked(identifier, PCI::RegisterOffset::BAR1);
 }
 
-u32 get_BAR3(Address address)
+u32 get_BAR2(DeviceIdentifier const& identifier)
 {
-    return read16(address, PCI::RegisterOffset::BAR3);
+    SpinlockLocker locker(identifier.operation_lock());
+    return read32_locked(identifier, PCI::RegisterOffset::BAR2);
 }
 
-u32 get_BAR4(Address address)
+u32 get_BAR3(DeviceIdentifier const& identifier)
 {
-    return read32(address, PCI::RegisterOffset::BAR4);
+    SpinlockLocker locker(identifier.operation_lock());
+    return read32_locked(identifier, PCI::RegisterOffset::BAR3);
 }
 
-u32 get_BAR5(Address address)
+u32 get_BAR4(DeviceIdentifier const& identifier)
 {
-    return read32(address, PCI::RegisterOffset::BAR5);
+    SpinlockLocker locker(identifier.operation_lock());
+    return read32_locked(identifier, PCI::RegisterOffset::BAR4);
 }
 
-u32 get_BAR(Address address, HeaderType0BaseRegister pci_bar)
+u32 get_BAR5(DeviceIdentifier const& identifier)
+{
+    SpinlockLocker locker(identifier.operation_lock());
+    return read32_locked(identifier, PCI::RegisterOffset::BAR5);
+}
+
+u32 get_BAR(DeviceIdentifier const& identifier, HeaderType0BaseRegister pci_bar)
 {
     VERIFY(to_underlying(pci_bar) <= 5);
     switch (to_underlying(pci_bar)) {
     case 0:
-        return get_BAR0(address);
+        return get_BAR0(identifier);
     case 1:
-        return get_BAR1(address);
+        return get_BAR1(identifier);
     case 2:
-        return get_BAR2(address);
+        return get_BAR2(identifier);
     case 3:
-        return get_BAR3(address);
+        return get_BAR3(identifier);
     case 4:
-        return get_BAR4(address);
+        return get_BAR4(identifier);
     case 5:
-        return get_BAR5(address);
+        return get_BAR5(identifier);
     default:
         VERIFY_NOT_REACHED();
     }
@@ -133,89 +168,113 @@ BARSpaceType get_BAR_space_type(u32 pci_bar_value)
     }
 }
 
-void enable_bus_mastering(Address address)
+void enable_bus_mastering(DeviceIdentifier const& identifier)
 {
-    auto value = read16(address, PCI::RegisterOffset::COMMAND);
+    SpinlockLocker locker(identifier.operation_lock());
+    auto value = read16_locked(identifier, PCI::RegisterOffset::COMMAND);
     value |= (1 << 2);
     value |= (1 << 0);
-    write16(address, PCI::RegisterOffset::COMMAND, value);
+    write16_locked(identifier, PCI::RegisterOffset::COMMAND, value);
 }
 
-void disable_bus_mastering(Address address)
+void disable_bus_mastering(DeviceIdentifier const& identifier)
 {
-    auto value = read16(address, PCI::RegisterOffset::COMMAND);
+    SpinlockLocker locker(identifier.operation_lock());
+    auto value = read16_locked(identifier, PCI::RegisterOffset::COMMAND);
     value &= ~(1 << 2);
     value |= (1 << 0);
-    write16(address, PCI::RegisterOffset::COMMAND, value);
+    write16_locked(identifier, PCI::RegisterOffset::COMMAND, value);
 }
 
-static void write8_offsetted(Address address, u32 field, u8 value) { Access::the().write8_field(address, field, value); }
-static void write16_offsetted(Address address, u32 field, u16 value) { Access::the().write16_field(address, field, value); }
-static void write32_offsetted(Address address, u32 field, u32 value) { Access::the().write32_field(address, field, value); }
-static u8 read8_offsetted(Address address, u32 field) { return Access::the().read8_field(address, field); }
-static u16 read16_offsetted(Address address, u32 field) { return Access::the().read16_field(address, field); }
-static u32 read32_offsetted(Address address, u32 field) { return Access::the().read32_field(address, field); }
-
-size_t get_BAR_space_size(Address address, HeaderType0BaseRegister pci_bar)
+static void write8_offsetted(DeviceIdentifier const& identifier, u32 field, u8 value)
 {
+    VERIFY(identifier.operation_lock().is_locked());
+    Access::the().write8_field(identifier, field, value);
+}
+static void write16_offsetted(DeviceIdentifier const& identifier, u32 field, u16 value)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    Access::the().write16_field(identifier, field, value);
+}
+static void write32_offsetted(DeviceIdentifier const& identifier, u32 field, u32 value)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    Access::the().write32_field(identifier, field, value);
+}
+static u8 read8_offsetted(DeviceIdentifier const& identifier, u32 field)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    return Access::the().read8_field(identifier, field);
+}
+static u16 read16_offsetted(DeviceIdentifier const& identifier, u32 field)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    return Access::the().read16_field(identifier, field);
+}
+static u32 read32_offsetted(DeviceIdentifier const& identifier, u32 field)
+{
+    VERIFY(identifier.operation_lock().is_locked());
+    return Access::the().read32_field(identifier, field);
+}
+
+size_t get_BAR_space_size(DeviceIdentifier const& identifier, HeaderType0BaseRegister pci_bar)
+{
+    SpinlockLocker locker(identifier.operation_lock());
     // See PCI Spec 2.3, Page 222
     VERIFY(to_underlying(pci_bar) < 6);
     u8 field = to_underlying(PCI::RegisterOffset::BAR0) + (to_underlying(pci_bar) << 2);
-    u32 bar_reserved = read32_offsetted(address, field);
-    write32_offsetted(address, field, 0xFFFFFFFF);
-    u32 space_size = read32_offsetted(address, field);
-    write32_offsetted(address, field, bar_reserved);
+    u32 bar_reserved = read32_offsetted(identifier, field);
+    write32_offsetted(identifier, field, 0xFFFFFFFF);
+    u32 space_size = read32_offsetted(identifier, field);
+    write32_offsetted(identifier, field, bar_reserved);
     space_size &= 0xfffffff0;
     space_size = (~space_size) + 1;
     return space_size;
 }
 
-void raw_access(Address address, u32 field, size_t access_size, u32 value)
+void raw_access(DeviceIdentifier const& identifier, u32 field, size_t access_size, u32 value)
 {
+    SpinlockLocker locker(identifier.operation_lock());
     VERIFY(access_size != 0);
     if (access_size == 1) {
-        write8_offsetted(address, field, value);
+        write8_offsetted(identifier, field, value);
         return;
     }
     if (access_size == 2) {
-        write16_offsetted(address, field, value);
+        write16_offsetted(identifier, field, value);
         return;
     }
     if (access_size == 4) {
-        write32_offsetted(address, field, value);
+        write32_offsetted(identifier, field, value);
         return;
     }
     VERIFY_NOT_REACHED();
 }
 
-u8 Capability::read8(u32 field) const
+u8 Capability::read8(size_t offset) const
 {
-    return read8_offsetted(m_address, m_ptr + field);
+    auto& identifier = get_device_identifier(m_address);
+    SpinlockLocker locker(identifier.operation_lock());
+    return read8_offsetted(identifier, m_ptr + offset);
 }
 
-u16 Capability::read16(u32 field) const
+u16 Capability::read16(size_t offset) const
 {
-    return read16_offsetted(m_address, m_ptr + field);
+    auto& identifier = get_device_identifier(m_address);
+    SpinlockLocker locker(identifier.operation_lock());
+    return read16_offsetted(identifier, m_ptr + offset);
 }
 
-u32 Capability::read32(u32 field) const
+u32 Capability::read32(size_t offset) const
 {
-    return read32_offsetted(m_address, m_ptr + field);
+    auto& identifier = get_device_identifier(m_address);
+    SpinlockLocker locker(identifier.operation_lock());
+    return read32_offsetted(identifier, m_ptr + offset);
 }
 
-void Capability::write8(u32 field, u8 value)
+DeviceIdentifier const& get_device_identifier(Address address)
 {
-    write8_offsetted(m_address, m_ptr + field, value);
-}
-
-void Capability::write16(u32 field, u16 value)
-{
-    write16_offsetted(m_address, m_ptr + field, value);
-}
-
-void Capability::write32(u32 field, u32 value)
-{
-    write32_offsetted(m_address, m_ptr + field, value);
+    return Access::the().get_device_identifier(address);
 }
 
 }

--- a/Kernel/Bus/PCI/API.cpp
+++ b/Kernel/Bus/PCI/API.cpp
@@ -232,6 +232,19 @@ size_t get_BAR_space_size(DeviceIdentifier const& identifier, HeaderType0BaseReg
     return space_size;
 }
 
+size_t get_expansion_rom_space_size(DeviceIdentifier const& identifier)
+{
+    SpinlockLocker locker(identifier.operation_lock());
+    u8 field = to_underlying(PCI::RegisterOffset::EXPANSION_ROM_POINTER);
+    u32 bar_reserved = read32_offsetted(identifier, field);
+    write32_offsetted(identifier, field, 0xFFFFFFFF);
+    u32 space_size = read32_offsetted(identifier, field);
+    write32_offsetted(identifier, field, bar_reserved);
+    space_size &= 0xfffffff0;
+    space_size = (~space_size) + 1;
+    return space_size;
+}
+
 void raw_access(DeviceIdentifier const& identifier, u32 field, size_t access_size, u32 value)
 {
     SpinlockLocker locker(identifier.operation_lock());

--- a/Kernel/Bus/PCI/API.h
+++ b/Kernel/Bus/PCI/API.h
@@ -12,34 +12,37 @@
 
 namespace Kernel::PCI {
 
-void write8(Address address, PCI::RegisterOffset field, u8 value);
-void write16(Address address, PCI::RegisterOffset field, u16 value);
-void write32(Address address, PCI::RegisterOffset field, u32 value);
-u8 read8(Address address, PCI::RegisterOffset field);
-u16 read16(Address address, PCI::RegisterOffset field);
-u32 read32(Address address, PCI::RegisterOffset field);
+void write8_locked(DeviceIdentifier const&, PCI::RegisterOffset field, u8 value);
+void write16_locked(DeviceIdentifier const&, PCI::RegisterOffset field, u16 value);
+void write32_locked(DeviceIdentifier const&, PCI::RegisterOffset field, u32 value);
+u8 read8_locked(DeviceIdentifier const&, PCI::RegisterOffset field);
+u16 read16_locked(DeviceIdentifier const&, PCI::RegisterOffset field);
+u32 read32_locked(DeviceIdentifier const&, PCI::RegisterOffset field);
 
-HardwareID get_hardware_id(PCI::Address);
-bool is_io_space_enabled(Address);
+HardwareID get_hardware_id(DeviceIdentifier const&);
+bool is_io_space_enabled(DeviceIdentifier const&);
 ErrorOr<void> enumerate(Function<void(DeviceIdentifier const&)> callback);
-void enable_interrupt_line(Address);
-void disable_interrupt_line(Address);
-void raw_access(Address, u32, size_t, u32);
-u32 get_BAR0(Address);
-u32 get_BAR1(Address);
-u32 get_BAR2(Address);
-u32 get_BAR3(Address);
-u32 get_BAR4(Address);
-u32 get_BAR5(Address);
-u32 get_BAR(Address address, HeaderType0BaseRegister);
-size_t get_BAR_space_size(Address, HeaderType0BaseRegister);
-BARSpaceType get_BAR_space_type(u32 pci_bar_value);
-void enable_bus_mastering(Address);
-void disable_bus_mastering(Address);
-void enable_io_space(Address);
-void disable_io_space(Address);
-void enable_memory_space(Address);
-void disable_memory_space(Address);
-DeviceIdentifier get_device_identifier(Address address);
+void enable_interrupt_line(DeviceIdentifier const&);
+void disable_interrupt_line(DeviceIdentifier const&);
+void raw_access(DeviceIdentifier const&, u32, size_t, u32);
 
+u32 get_BAR0(DeviceIdentifier const&);
+u32 get_BAR1(DeviceIdentifier const&);
+u32 get_BAR2(DeviceIdentifier const&);
+u32 get_BAR3(DeviceIdentifier const&);
+u32 get_BAR4(DeviceIdentifier const&);
+u32 get_BAR5(DeviceIdentifier const&);
+u32 get_BAR(DeviceIdentifier const&, HeaderType0BaseRegister);
+size_t get_BAR_space_size(DeviceIdentifier const&, HeaderType0BaseRegister);
+BARSpaceType get_BAR_space_type(u32 pci_bar_value);
+void enable_bus_mastering(DeviceIdentifier const&);
+void disable_bus_mastering(DeviceIdentifier const&);
+void enable_io_space(DeviceIdentifier const&);
+void disable_io_space(DeviceIdentifier const&);
+void enable_memory_space(DeviceIdentifier const&);
+void disable_memory_space(DeviceIdentifier const&);
+
+// FIXME: Remove this once we can use PCI::Capability with inline buffer
+// so we don't need this method
+DeviceIdentifier const& get_device_identifier(Address address);
 }

--- a/Kernel/Bus/PCI/API.h
+++ b/Kernel/Bus/PCI/API.h
@@ -35,6 +35,8 @@ u32 get_BAR5(DeviceIdentifier const&);
 u32 get_BAR(DeviceIdentifier const&, HeaderType0BaseRegister);
 size_t get_BAR_space_size(DeviceIdentifier const&, HeaderType0BaseRegister);
 BARSpaceType get_BAR_space_type(u32 pci_bar_value);
+size_t get_expansion_rom_space_size(DeviceIdentifier const&);
+
 void enable_bus_mastering(DeviceIdentifier const&);
 void disable_bus_mastering(DeviceIdentifier const&);
 void enable_io_space(DeviceIdentifier const&);

--- a/Kernel/Bus/PCI/Access.h
+++ b/Kernel/Bus/PCI/Access.h
@@ -9,6 +9,7 @@
 #include <AK/Bitmap.h>
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtr.h>
+#include <AK/NonnullRefPtrVector.h>
 #include <AK/Try.h>
 #include <AK/Vector.h>
 #include <Kernel/Bus/PCI/Controller/HostController.h>
@@ -33,22 +34,25 @@ public:
     static bool is_disabled();
     static bool is_hardware_disabled();
 
-    void write8_field(Address address, u32 field, u8 value);
-    void write16_field(Address address, u32 field, u16 value);
-    void write32_field(Address address, u32 field, u32 value);
-    u8 read8_field(Address address, u32 field);
-    u16 read16_field(Address address, u32 field);
-    u32 read32_field(Address address, u32 field);
-    DeviceIdentifier get_device_identifier(Address address) const;
+    void write8_field(DeviceIdentifier const&, u32 field, u8 value);
+    void write16_field(DeviceIdentifier const&, u32 field, u16 value);
+    void write32_field(DeviceIdentifier const&, u32 field, u32 value);
+    u8 read8_field(DeviceIdentifier const&, u32 field);
+    u16 read16_field(DeviceIdentifier const&, u32 field);
+    u32 read32_field(DeviceIdentifier const&, u32 field);
+
+    // FIXME: Remove this once we can use PCI::Capability with inline buffer
+    // so we don't need this method
+    DeviceIdentifier const& get_device_identifier(Address address) const;
 
     Spinlock<LockRank::None> const& scan_lock() const { return m_scan_lock; }
     RecursiveSpinlock<LockRank::None> const& access_lock() const { return m_access_lock; }
 
-    ErrorOr<void> add_host_controller_and_enumerate_attached_devices(NonnullOwnPtr<HostController>, Function<void(DeviceIdentifier const&)> callback);
+    ErrorOr<void> add_host_controller_and_scan_for_devices(NonnullOwnPtr<HostController>);
 
 private:
-    u8 read8_field(Address address, RegisterOffset field);
-    u16 read16_field(Address address, RegisterOffset field);
+    u8 read8_field(DeviceIdentifier const&, RegisterOffset field);
+    u16 read16_field(DeviceIdentifier const&, RegisterOffset field);
 
     void add_host_controller(NonnullOwnPtr<HostController>);
     bool find_and_register_pci_host_bridges_from_acpi_mcfg_table(PhysicalAddress mcfg);
@@ -61,6 +65,6 @@ private:
     mutable Spinlock<LockRank::None> m_scan_lock {};
 
     HashMap<u32, NonnullOwnPtr<PCI::HostController>> m_host_controllers;
-    Vector<DeviceIdentifier> m_device_identifiers;
+    NonnullRefPtrVector<DeviceIdentifier> m_device_identifiers;
 };
 }

--- a/Kernel/Bus/PCI/Controller/HostController.cpp
+++ b/Kernel/Bus/PCI/Controller/HostController.cpp
@@ -54,7 +54,7 @@ u16 HostController::read16_field(BusNumber bus, DeviceNumber device, FunctionNum
     return read16_field(bus, device, function, to_underlying(field));
 }
 
-UNMAP_AFTER_INIT void HostController::enumerate_functions(Function<IterationDecision(DeviceIdentifier)> const& callback, BusNumber bus, DeviceNumber device, FunctionNumber function, bool recursive_search_into_bridges)
+UNMAP_AFTER_INIT void HostController::enumerate_functions(Function<IterationDecision(EnumerableDeviceIdentifier)> const& callback, BusNumber bus, DeviceNumber device, FunctionNumber function, bool recursive_search_into_bridges)
 {
     dbgln_if(PCI_DEBUG, "PCI: Enumerating function, bus={}, device={}, function={}", bus, device, function);
     Address address(domain_number(), bus.value(), device.value(), function.value());
@@ -70,7 +70,7 @@ UNMAP_AFTER_INIT void HostController::enumerate_functions(Function<IterationDeci
     InterruptLine interrupt_line = read8_field(bus, device, function, PCI::RegisterOffset::INTERRUPT_LINE);
     InterruptPin interrupt_pin = read8_field(bus, device, function, PCI::RegisterOffset::INTERRUPT_PIN);
     auto capabilities = get_capabilities_for_function(bus, device, function);
-    callback(DeviceIdentifier { address, id, revision_id, class_code, subclass_code, prog_if, subsystem_id, subsystem_vendor_id, interrupt_line, interrupt_pin, capabilities });
+    callback(EnumerableDeviceIdentifier { address, id, revision_id, class_code, subclass_code, prog_if, subsystem_id, subsystem_vendor_id, interrupt_line, interrupt_pin, capabilities });
 
     if (pci_class == (to_underlying(PCI::ClassID::Bridge) << 8 | to_underlying(PCI::Bridge::SubclassID::PCI_TO_PCI))
         && recursive_search_into_bridges
@@ -83,7 +83,7 @@ UNMAP_AFTER_INIT void HostController::enumerate_functions(Function<IterationDeci
     }
 }
 
-UNMAP_AFTER_INIT void HostController::enumerate_device(Function<IterationDecision(DeviceIdentifier)> const& callback, BusNumber bus, DeviceNumber device, bool recursive_search_into_bridges)
+UNMAP_AFTER_INIT void HostController::enumerate_device(Function<IterationDecision(EnumerableDeviceIdentifier)> const& callback, BusNumber bus, DeviceNumber device, bool recursive_search_into_bridges)
 {
     dbgln_if(PCI_DEBUG, "PCI: Enumerating device in bus={}, device={}", bus, device);
     if (read16_field(bus, device, 0, PCI::RegisterOffset::VENDOR_ID) == PCI::none_value)
@@ -97,14 +97,14 @@ UNMAP_AFTER_INIT void HostController::enumerate_device(Function<IterationDecisio
     }
 }
 
-UNMAP_AFTER_INIT void HostController::enumerate_bus(Function<IterationDecision(DeviceIdentifier)> const& callback, BusNumber bus, bool recursive_search_into_bridges)
+UNMAP_AFTER_INIT void HostController::enumerate_bus(Function<IterationDecision(EnumerableDeviceIdentifier)> const& callback, BusNumber bus, bool recursive_search_into_bridges)
 {
     dbgln_if(PCI_DEBUG, "PCI: Enumerating bus {}", bus);
     for (u8 device = 0; device < 32; ++device)
         enumerate_device(callback, bus, device, recursive_search_into_bridges);
 }
 
-UNMAP_AFTER_INIT void HostController::enumerate_attached_devices(Function<IterationDecision(DeviceIdentifier)> callback)
+UNMAP_AFTER_INIT void HostController::enumerate_attached_devices(Function<IterationDecision(EnumerableDeviceIdentifier)> callback)
 {
     VERIFY(Access::the().access_lock().is_locked());
     VERIFY(Access::the().scan_lock().is_locked());

--- a/Kernel/Bus/PCI/Controller/HostController.h
+++ b/Kernel/Bus/PCI/Controller/HostController.h
@@ -31,12 +31,12 @@ public:
 
     u32 domain_number() const { return m_domain.domain_number(); }
 
-    void enumerate_attached_devices(Function<IterationDecision(DeviceIdentifier)> callback);
+    void enumerate_attached_devices(Function<IterationDecision(EnumerableDeviceIdentifier)> callback);
 
 private:
-    void enumerate_bus(Function<IterationDecision(DeviceIdentifier)> const& callback, BusNumber, bool recursive);
-    void enumerate_functions(Function<IterationDecision(DeviceIdentifier)> const& callback, BusNumber, DeviceNumber, FunctionNumber, bool recursive);
-    void enumerate_device(Function<IterationDecision(DeviceIdentifier)> const& callback, BusNumber bus, DeviceNumber device, bool recursive);
+    void enumerate_bus(Function<IterationDecision(EnumerableDeviceIdentifier)> const& callback, BusNumber, bool recursive);
+    void enumerate_functions(Function<IterationDecision(EnumerableDeviceIdentifier)> const& callback, BusNumber, DeviceNumber, FunctionNumber, bool recursive);
+    void enumerate_device(Function<IterationDecision(EnumerableDeviceIdentifier)> const& callback, BusNumber bus, DeviceNumber device, bool recursive);
 
     u8 read8_field(BusNumber, DeviceNumber, FunctionNumber, RegisterOffset field);
     u16 read16_field(BusNumber, DeviceNumber, FunctionNumber, RegisterOffset field);

--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -10,31 +10,31 @@
 
 namespace Kernel::PCI {
 
-Device::Device(Address address)
-    : m_pci_address(address)
+Device::Device(DeviceIdentifier const& pci_identifier)
+    : m_pci_identifier(pci_identifier)
 {
 }
 
 bool Device::is_msi_capable() const
 {
     return AK::any_of(
-        PCI::get_device_identifier(pci_address()).capabilities(),
+        m_pci_identifier->capabilities(),
         [](auto const& capability) { return capability.id().value() == PCI::Capabilities::ID::MSI; });
 }
 bool Device::is_msix_capable() const
 {
     return AK::any_of(
-        PCI::get_device_identifier(pci_address()).capabilities(),
+        m_pci_identifier->capabilities(),
         [](auto const& capability) { return capability.id().value() == PCI::Capabilities::ID::MSIX; });
 }
 
 void Device::enable_pin_based_interrupts() const
 {
-    PCI::enable_interrupt_line(pci_address());
+    PCI::enable_interrupt_line(m_pci_identifier);
 }
 void Device::disable_pin_based_interrupts() const
 {
-    PCI::disable_interrupt_line(pci_address());
+    PCI::disable_interrupt_line(m_pci_identifier);
 }
 
 void Device::enable_message_signalled_interrupts()

--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Format.h>
+#include <AK/NonnullRefPtr.h>
 #include <AK/StringBuilder.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Definitions.h>
@@ -15,7 +16,7 @@ namespace Kernel::PCI {
 
 class Device {
 public:
-    Address pci_address() const { return m_pci_address; };
+    DeviceIdentifier& device_identifier() const { return *m_pci_identifier; };
 
     virtual ~Device() = default;
 
@@ -34,10 +35,10 @@ public:
     void disable_extended_message_signalled_interrupts();
 
 protected:
-    explicit Device(Address pci_address);
+    explicit Device(DeviceIdentifier const& pci_identifier);
 
 private:
-    Address m_pci_address;
+    NonnullRefPtr<DeviceIdentifier> m_pci_identifier;
 };
 
 template<typename... Parameters>
@@ -48,7 +49,7 @@ void dmesgln_pci(Device const& device, AK::CheckedFormatString<Parameters...>&& 
         return;
     if (builder.try_append(fmt.view()).is_error())
         return;
-    AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::Yes, StringView, Address, Parameters...> variadic_format_params { device.device_name(), device.pci_address(), parameters... };
+    AK::VariadicFormatParams<AK::AllowDebugOnlyFormatters::Yes, StringView, Address, Parameters...> variadic_format_params { device.device_name(), device.device_identifier().address(), parameters... };
     vdmesgln(builder.string_view(), variadic_format_params);
 }
 

--- a/Kernel/Bus/PCI/DeviceIdentifier.cpp
+++ b/Kernel/Bus/PCI/DeviceIdentifier.cpp
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/AnyOf.h>
+#include <AK/Error.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefPtr.h>
+#include <Kernel/Bus/PCI/Definitions.h>
+
+namespace Kernel::PCI {
+
+ErrorOr<NonnullRefPtr<DeviceIdentifier>> DeviceIdentifier::from_enumerable_identifier(EnumerableDeviceIdentifier const& other_identifier)
+{
+    return adopt_nonnull_ref_or_enomem(new (nothrow) DeviceIdentifier(other_identifier));
+}
+
+}

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -75,7 +75,7 @@ ErrorOr<NonnullLockRefPtr<UHCIController>> UHCIController::try_to_initialize(PCI
 
 ErrorOr<void> UHCIController::initialize()
 {
-    dmesgln_pci(*this, "Controller found {} @ {}", PCI::get_hardware_id(pci_address()), pci_address());
+    dmesgln_pci(*this, "Controller found {} @ {}", PCI::get_hardware_id(device_identifier()), device_identifier().address());
     dmesgln_pci(*this, "I/O base {}", m_registers_io_window);
     dmesgln_pci(*this, "Interrupt line: {}", interrupt_number());
 
@@ -87,7 +87,7 @@ ErrorOr<void> UHCIController::initialize()
 }
 
 UNMAP_AFTER_INIT UHCIController::UHCIController(PCI::DeviceIdentifier const& pci_device_identifier, NonnullOwnPtr<IOWindow> registers_io_window)
-    : PCI::Device(pci_device_identifier.address())
+    : PCI::Device(const_cast<PCI::DeviceIdentifier&>(pci_device_identifier))
     , IRQHandler(pci_device_identifier.interrupt_line().value())
     , m_registers_io_window(move(registers_io_window))
 {

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -150,6 +150,7 @@ set(KERNEL_SOURCES
     FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
     FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.cpp
     FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
+    FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.cpp
     FileSystem/SysFS/Subsystems/Bus/USB/BusDirectory.cpp
     FileSystem/SysFS/Subsystems/Bus/USB/DeviceInformation.cpp
     FileSystem/SysFS/Subsystems/Bus/Directory.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -23,6 +23,7 @@ set(KERNEL_SOURCES
     Bus/PCI/Access.cpp
     Bus/PCI/API.cpp
     Bus/PCI/Device.cpp
+    Bus/PCI/DeviceIdentifier.cpp
     Bus/USB/UHCI/UHCIController.cpp
     Bus/USB/UHCI/UHCIRootHub.cpp
     Bus/USB/USBConfiguration.cpp

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/BusDirectory.cpp
@@ -24,7 +24,7 @@ UNMAP_AFTER_INIT PCIBusSysFSDirectory::PCIBusSysFSDirectory()
 {
     MUST(m_child_components.with([&](auto& list) -> ErrorOr<void> {
         MUST(PCI::enumerate([&](PCI::DeviceIdentifier const& device_identifier) {
-            auto pci_device = PCIDeviceSysFSDirectory::create(*this, device_identifier.address());
+            auto pci_device = PCIDeviceSysFSDirectory::create(*this, device_identifier);
             list.append(pci_device);
         }));
         return {};

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.cpp
@@ -75,15 +75,16 @@ ErrorOr<size_t> PCIDeviceAttributeSysFSComponent::read_bytes(off_t offset, size_
 ErrorOr<NonnullOwnPtr<KBuffer>> PCIDeviceAttributeSysFSComponent::try_to_generate_buffer() const
 {
     OwnPtr<KString> value;
+    SpinlockLocker locker(m_device->device_identifier().operation_lock());
     switch (m_field_bytes_width) {
     case 1:
-        value = TRY(KString::formatted("{:#x}", PCI::read8(m_device->address(), m_offset)));
+        value = TRY(KString::formatted("{:#x}", PCI::read8_locked(m_device->device_identifier(), m_offset)));
         break;
     case 2:
-        value = TRY(KString::formatted("{:#x}", PCI::read16(m_device->address(), m_offset)));
+        value = TRY(KString::formatted("{:#x}", PCI::read16_locked(m_device->device_identifier(), m_offset)));
         break;
     case 4:
-        value = TRY(KString::formatted("{:#x}", PCI::read32(m_device->address(), m_offset)));
+        value = TRY(KString::formatted("{:#x}", PCI::read32_locked(m_device->device_identifier(), m_offset)));
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
@@ -12,11 +12,12 @@
 
 namespace Kernel {
 
-UNMAP_AFTER_INIT NonnullLockRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirectory::create(SysFSDirectory const& parent_directory, PCI::Address address)
+UNMAP_AFTER_INIT NonnullLockRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirectory::create(SysFSDirectory const& parent_directory, PCI::DeviceIdentifier const& device_identifier)
 {
     // FIXME: Handle allocation failure gracefully
+    auto& address = device_identifier.address();
     auto device_name = MUST(KString::formatted("{:04x}:{:02x}:{:02x}.{}", address.domain(), address.bus(), address.device(), address.function()));
-    auto directory = adopt_lock_ref(*new (nothrow) PCIDeviceSysFSDirectory(move(device_name), parent_directory, address));
+    auto directory = adopt_lock_ref(*new (nothrow) PCIDeviceSysFSDirectory(move(device_name), parent_directory, device_identifier));
     MUST(directory->m_child_components.with([&](auto& list) -> ErrorOr<void> {
         list.append(PCIDeviceAttributeSysFSComponent::create(*directory, PCI::RegisterOffset::VENDOR_ID, 2));
         list.append(PCIDeviceAttributeSysFSComponent::create(*directory, PCI::RegisterOffset::DEVICE_ID, 2));
@@ -38,9 +39,9 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirect
     return directory;
 }
 
-UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const& parent_directory, PCI::Address address)
+UNMAP_AFTER_INIT PCIDeviceSysFSDirectory::PCIDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const& parent_directory, PCI::DeviceIdentifier const& device_identifier)
     : SysFSDirectory(parent_directory)
-    , m_address(address)
+    , m_device_identifier(device_identifier)
     , m_device_directory_name(move(device_directory_name))
 {
 }

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.cpp
@@ -8,6 +8,7 @@
 #include <Kernel/Bus/PCI/Access.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceAttribute.h>
 #include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.h>
 #include <Kernel/Sections.h>
 
 namespace Kernel {
@@ -34,6 +35,7 @@ UNMAP_AFTER_INIT NonnullLockRefPtr<PCIDeviceSysFSDirectory> PCIDeviceSysFSDirect
         list.append(PCIDeviceAttributeSysFSComponent::create(*directory, PCI::RegisterOffset::BAR3, 4));
         list.append(PCIDeviceAttributeSysFSComponent::create(*directory, PCI::RegisterOffset::BAR4, 4));
         list.append(PCIDeviceAttributeSysFSComponent::create(*directory, PCI::RegisterOffset::BAR5, 4));
+        list.append(PCIDeviceExpansionROMSysFSComponent::create(*directory));
         return {};
     }));
     return directory;

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/NonnullRefPtr.h>
 #include <Kernel/Bus/PCI/Definitions.h>
 #include <Kernel/FileSystem/SysFS/Component.h>
 #include <Kernel/KString.h>
@@ -14,15 +15,15 @@ namespace Kernel {
 
 class PCIDeviceSysFSDirectory final : public SysFSDirectory {
 public:
-    static NonnullLockRefPtr<PCIDeviceSysFSDirectory> create(SysFSDirectory const&, PCI::Address);
-    PCI::Address const& address() const { return m_address; }
+    static NonnullLockRefPtr<PCIDeviceSysFSDirectory> create(SysFSDirectory const&, PCI::DeviceIdentifier const&);
+    PCI::DeviceIdentifier& device_identifier() const { return *m_device_identifier; }
 
     virtual StringView name() const override { return m_device_directory_name->view(); }
 
 private:
-    PCIDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const&, PCI::Address);
+    PCIDeviceSysFSDirectory(NonnullOwnPtr<KString> device_directory_name, SysFSDirectory const&, PCI::DeviceIdentifier const&);
 
-    PCI::Address m_address;
+    NonnullRefPtr<PCI::DeviceIdentifier> m_device_identifier;
 
     NonnullOwnPtr<KString> m_device_directory_name;
 };

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.cpp
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.h>
+#include <Kernel/Memory/TypedMapping.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+NonnullLockRefPtr<PCIDeviceExpansionROMSysFSComponent> PCIDeviceExpansionROMSysFSComponent::create(PCIDeviceSysFSDirectory const& device)
+{
+    auto option_rom_size = PCI::get_expansion_rom_space_size(device.device_identifier());
+    return adopt_lock_ref(*new (nothrow) PCIDeviceExpansionROMSysFSComponent(device, option_rom_size));
+}
+
+PCIDeviceExpansionROMSysFSComponent::PCIDeviceExpansionROMSysFSComponent(PCIDeviceSysFSDirectory const& device, size_t option_rom_size)
+    : SysFSComponent()
+    , m_device(device)
+    , m_option_rom_size(option_rom_size)
+{
+}
+
+ErrorOr<size_t> PCIDeviceExpansionROMSysFSComponent::read_bytes(off_t offset, size_t count, UserOrKernelBuffer& buffer, OpenFileDescription*) const
+{
+    // NOTE: It might be that the PCI option ROM size is zero, indicating non-existing ROM.
+    if (m_option_rom_size == 0)
+        return Error::from_errno(EIO);
+    // NOTE: This takes into account that `off_t offset` might be a negative number and
+    // there's no meaningful way to handle negative values, so just return with an error.
+    if (offset < 0)
+        return Error::from_errno(EINVAL);
+    auto unsigned_offset = static_cast<size_t>(offset);
+    // NOTE: If the offset is beyond the PCI option ROM size, return EOF.
+    if (unsigned_offset >= m_option_rom_size)
+        return 0;
+
+    auto blob = TRY(try_to_generate_buffer(unsigned_offset, count));
+    if (static_cast<size_t>(offset) >= blob->size())
+        return 0;
+
+    ssize_t nread = min(static_cast<off_t>(blob->size() - offset), static_cast<off_t>(count));
+    TRY(buffer.write(blob->data() + offset, nread));
+    return nread;
+}
+
+ErrorOr<NonnullOwnPtr<KBuffer>> PCIDeviceExpansionROMSysFSComponent::try_to_generate_buffer(size_t offset_in_rom, size_t count) const
+{
+    // NOTE: If the offset is beyond the PCI option ROM size, panic!.
+    VERIFY(offset_in_rom < m_option_rom_size);
+    auto temporary_buffer_size = TRY(Memory::page_round_up(count));
+    auto temporary_buffer = TRY(KBuffer::try_create_with_size("SysFS DeviceExpansionROM Device"sv, temporary_buffer_size, Memory::Region::Access::ReadWrite));
+
+    SpinlockLocker locker(m_device->device_identifier().operation_lock());
+    // NOTE: These checks takes into account a couple of cases:
+    // 1. Option ROM doesn't exist so the value of the ROM physical pointer is 0, and in that case
+    // we should not allow mapping.
+    // 2. Option ROM exists but for some (odd) reason, it is found in non-reserved (usable) physical memory
+    // region, so access to it should be forbidden from this sysfs node.
+    auto pci_option_rom_physical_pointer = PCI::read32_locked(m_device->device_identifier(), PCI::RegisterOffset::EXPANSION_ROM_POINTER);
+    if (pci_option_rom_physical_pointer == 0)
+        return Error::from_errno(EIO);
+
+    if (pci_option_rom_physical_pointer & 1)
+        dbgln("SysFS DeviceExpansionROM: Possible firmware bug! PCI option ROM was found already to be enabled.");
+
+    auto offested_option_rom_memory_mapped_start_address = PhysicalAddress(pci_option_rom_physical_pointer + offset_in_rom);
+    auto mapping_size = min(static_cast<off_t>(m_option_rom_size - offset_in_rom), static_cast<off_t>(count));
+    if (!MM.is_allowed_to_read_physical_memory_for_userspace(offested_option_rom_memory_mapped_start_address, mapping_size))
+        return Error::from_errno(EPERM);
+
+    ScopeGuard unmap_option_rom_on_return([&] {
+        // NOTE: In general, there's probably nothing wrong in leaving Option ROM being
+        // mapped into physical memory.
+        // For the sake of completeness, let's ensure we don't leave the Option ROM being
+        // mapped into physical memory.
+        // NOTE: It might be that in the future some driver will need to have the expansion ROM
+        // being present in the physical address space. If that's the case then we should add a flag
+        // to the PCI::DeviceIdentifier to indicate this condition!
+        PCI::write32_locked(m_device->device_identifier(), PCI::RegisterOffset::EXPANSION_ROM_POINTER, pci_option_rom_physical_pointer);
+    });
+    // Note: Write the original value ORed with 1 to enable mapping into physical memory
+    PCI::write32_locked(m_device->device_identifier(), PCI::RegisterOffset::EXPANSION_ROM_POINTER, pci_option_rom_physical_pointer | 1);
+
+    auto do_io_transaction = [](Bytes bytes_buffer, Memory::TypedMapping<u8> const& mapping, size_t length_to_map) {
+        VERIFY(length_to_map <= PAGE_SIZE);
+        memcpy(bytes_buffer.data(), mapping.region->vaddr().offset(mapping.offset).as_ptr(), length_to_map);
+    };
+
+    size_t remaining_length = count;
+    size_t nprocessed = 0;
+    while (remaining_length > 0) {
+        size_t length_to_map = min<size_t>(PAGE_SIZE, remaining_length);
+        auto mapping = TRY(Memory::map_typed<u8>(offested_option_rom_memory_mapped_start_address.offset(nprocessed), length_to_map, Memory::Region::Access::Read));
+        do_io_transaction(temporary_buffer->bytes().slice(nprocessed, length_to_map), mapping, length_to_map);
+        nprocessed += length_to_map;
+        remaining_length -= length_to_map;
+    }
+    return temporary_buffer;
+}
+}

--- a/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.h
+++ b/Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceExpansionROM.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <Kernel/Bus/PCI/Definitions.h>
+#include <Kernel/FileSystem/SysFS/Component.h>
+#include <Kernel/FileSystem/SysFS/Subsystems/Bus/PCI/DeviceDirectory.h>
+
+namespace Kernel {
+
+class PCIDeviceExpansionROMSysFSComponent : public SysFSComponent {
+public:
+    static NonnullLockRefPtr<PCIDeviceExpansionROMSysFSComponent> create(PCIDeviceSysFSDirectory const& device);
+
+    virtual ErrorOr<size_t> read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const override;
+    virtual ~PCIDeviceExpansionROMSysFSComponent() {};
+
+    virtual StringView name() const override { return "rom"sv; }
+
+protected:
+    ErrorOr<NonnullOwnPtr<KBuffer>> try_to_generate_buffer(size_t offset_in_rom, size_t count) const;
+    PCIDeviceExpansionROMSysFSComponent(PCIDeviceSysFSDirectory const& device, size_t option_rom_size);
+    NonnullLockRefPtr<PCIDeviceSysFSDirectory> m_device;
+    size_t const m_option_rom_size { 0 };
+};
+
+}

--- a/Kernel/Firmware/ACPI/Parser.cpp
+++ b/Kernel/Firmware/ACPI/Parser.cpp
@@ -290,7 +290,8 @@ void Parser::access_generic_address(Structures::GenericAddressStructure const& s
             VERIFY_NOT_REACHED();
         }
         VERIFY(structure.access_size != (u8)GenericAddressStructure::AccessSize::Undefined);
-        PCI::raw_access(pci_address, offset_in_pci_address, (1 << (structure.access_size - 1)), value);
+        auto& pci_device_identifier = PCI::get_device_identifier(pci_address);
+        PCI::raw_access(pci_device_identifier, offset_in_pci_address, (1 << (structure.access_size - 1)), value);
         return;
     }
     default:

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -32,7 +32,7 @@ public:
 private:
     ErrorOr<void> initialize_adapter(PCI::DeviceIdentifier const&);
 
-    explicit BochsGraphicsAdapter(PCI::Address const&);
+    explicit BochsGraphicsAdapter(PCI::DeviceIdentifier const&);
 
     LockRefPtr<DisplayConnector> m_display_connector;
 };

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -33,29 +33,28 @@ ErrorOr<bool> IntelNativeGraphicsAdapter::probe(PCI::DeviceIdentifier const& pci
 
 ErrorOr<NonnullLockRefPtr<GenericGraphicsAdapter>> IntelNativeGraphicsAdapter::create(PCI::DeviceIdentifier const& pci_device_identifier)
 {
-    auto adapter = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) IntelNativeGraphicsAdapter(pci_device_identifier.address())));
+    auto adapter = TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) IntelNativeGraphicsAdapter(pci_device_identifier)));
     TRY(adapter->initialize_adapter());
     return adapter;
 }
 
 ErrorOr<void> IntelNativeGraphicsAdapter::initialize_adapter()
 {
-    auto address = pci_address();
-    dbgln_if(INTEL_GRAPHICS_DEBUG, "Intel Native Graphics Adapter @ {}", address);
-    auto bar0_space_size = PCI::get_BAR_space_size(address, PCI::HeaderType0BaseRegister::BAR0);
+    dbgln_if(INTEL_GRAPHICS_DEBUG, "Intel Native Graphics Adapter @ {}", device_identifier().address());
+    auto bar0_space_size = PCI::get_BAR_space_size(device_identifier(), PCI::HeaderType0BaseRegister::BAR0);
     VERIFY(bar0_space_size == 0x80000);
-    auto bar2_space_size = PCI::get_BAR_space_size(address, PCI::HeaderType0BaseRegister::BAR2);
-    dmesgln_pci(*this, "MMIO @ {}, space size is {:x} bytes", PhysicalAddress(PCI::get_BAR0(address)), bar0_space_size);
-    dmesgln_pci(*this, "framebuffer @ {}", PhysicalAddress(PCI::get_BAR2(address)));
-    PCI::enable_bus_mastering(address);
+    auto bar2_space_size = PCI::get_BAR_space_size(device_identifier(), PCI::HeaderType0BaseRegister::BAR2);
+    dmesgln_pci(*this, "MMIO @ {}, space size is {:x} bytes", PhysicalAddress(PCI::get_BAR0(device_identifier())), bar0_space_size);
+    dmesgln_pci(*this, "framebuffer @ {}", PhysicalAddress(PCI::get_BAR2(device_identifier())));
+    PCI::enable_bus_mastering(device_identifier());
 
-    m_display_connector = TRY(IntelNativeDisplayConnector::try_create(PhysicalAddress(PCI::get_BAR2(address) & 0xfffffff0), bar2_space_size, PhysicalAddress(PCI::get_BAR0(address) & 0xfffffff0), bar0_space_size));
+    m_display_connector = TRY(IntelNativeDisplayConnector::try_create(PhysicalAddress(PCI::get_BAR2(device_identifier()) & 0xfffffff0), bar2_space_size, PhysicalAddress(PCI::get_BAR0(device_identifier()) & 0xfffffff0), bar0_space_size));
     return {};
 }
 
-IntelNativeGraphicsAdapter::IntelNativeGraphicsAdapter(PCI::Address address)
+IntelNativeGraphicsAdapter::IntelNativeGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)
     : GenericGraphicsAdapter()
-    , PCI::Device(address)
+    , PCI::Device(const_cast<PCI::DeviceIdentifier&>(pci_device_identifier))
 {
 }
 

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -30,7 +30,7 @@ public:
 private:
     ErrorOr<void> initialize_adapter();
 
-    explicit IntelNativeGraphicsAdapter(PCI::Address);
+    explicit IntelNativeGraphicsAdapter(PCI::DeviceIdentifier const&);
 
     LockRefPtr<IntelNativeDisplayConnector> m_display_connector;
 };

--- a/Kernel/IOWindow.h
+++ b/Kernel/IOWindow.h
@@ -38,9 +38,6 @@ public:
     static ErrorOr<NonnullOwnPtr<IOWindow>> create_for_pci_device_bar(PCI::DeviceIdentifier const&, PCI::HeaderType0BaseRegister, u64 space_length);
     static ErrorOr<NonnullOwnPtr<IOWindow>> create_for_pci_device_bar(PCI::DeviceIdentifier const&, PCI::HeaderType0BaseRegister);
 
-    static ErrorOr<NonnullOwnPtr<IOWindow>> create_for_pci_device_bar(PCI::Address const&, PCI::HeaderType0BaseRegister, u64 space_length);
-    static ErrorOr<NonnullOwnPtr<IOWindow>> create_for_pci_device_bar(PCI::Address const&, PCI::HeaderType0BaseRegister);
-
     ErrorOr<NonnullOwnPtr<IOWindow>> create_from_io_window_with_offset(u64 offset, u64 space_length);
     ErrorOr<NonnullOwnPtr<IOWindow>> create_from_io_window_with_offset(u64 offset);
 

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
@@ -199,7 +199,7 @@ UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<NetworkAdapter>> E1000ENetworkAdapter
     auto rx_descriptors_region = TRY(MM.allocate_contiguous_kernel_region(TRY(Memory::page_round_up(sizeof(e1000_rx_desc) * number_of_rx_descriptors)), "E1000 RX Descriptors"sv, Memory::Region::Access::ReadWrite));
     auto tx_descriptors_region = TRY(MM.allocate_contiguous_kernel_region(TRY(Memory::page_round_up(sizeof(e1000_tx_desc) * number_of_tx_descriptors)), "E1000 TX Descriptors"sv, Memory::Region::Access::ReadWrite));
 
-    return TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) E1000ENetworkAdapter(pci_device_identifier.address(),
+    return TRY(adopt_nonnull_lock_ref_or_enomem(new (nothrow) E1000ENetworkAdapter(pci_device_identifier,
         irq, move(registers_io_window),
         move(rx_buffer_region),
         move(tx_buffer_region),
@@ -210,8 +210,8 @@ UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<NetworkAdapter>> E1000ENetworkAdapter
 
 UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<NetworkingManagement>)
 {
-    dmesgln("E1000e: Found @ {}", pci_address());
-    enable_bus_mastering(pci_address());
+    dmesgln("E1000e: Found @ {}", device_identifier().address());
+    enable_bus_mastering(device_identifier());
 
     dmesgln("E1000e: IO base: {}", m_registers_io_window);
     dmesgln("E1000e: Interrupt line: {}", interrupt_number());
@@ -229,11 +229,11 @@ UNMAP_AFTER_INIT ErrorOr<void> E1000ENetworkAdapter::initialize(Badge<Networking
     return {};
 }
 
-UNMAP_AFTER_INIT E1000ENetworkAdapter::E1000ENetworkAdapter(PCI::Address address, u8 irq,
+UNMAP_AFTER_INIT E1000ENetworkAdapter::E1000ENetworkAdapter(PCI::DeviceIdentifier const& device_identifier, u8 irq,
     NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
     NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
     NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString> interface_name)
-    : E1000NetworkAdapter(address, irq, move(registers_io_window),
+    : E1000NetworkAdapter(device_identifier, irq, move(registers_io_window),
         move(rx_buffer_region),
         move(tx_buffer_region),
         move(rx_descriptors_region),

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.h
@@ -30,7 +30,7 @@ public:
     virtual StringView purpose() const override { return class_name(); }
 
 private:
-    E1000ENetworkAdapter(PCI::Address, u8 irq,
+    E1000ENetworkAdapter(PCI::DeviceIdentifier const&, u8 irq,
         NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
         NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
         NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString>);

--- a/Kernel/Net/Intel/E1000NetworkAdapter.h
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.h
@@ -42,7 +42,7 @@ protected:
     void setup_interrupts();
     void setup_link();
 
-    E1000NetworkAdapter(PCI::Address, u8 irq,
+    E1000NetworkAdapter(PCI::DeviceIdentifier const&, u8 irq,
         NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<Memory::Region> rx_buffer_region,
         NonnullOwnPtr<Memory::Region> tx_buffer_region, NonnullOwnPtr<Memory::Region> rx_descriptors_region,
         NonnullOwnPtr<Memory::Region> tx_descriptors_region, NonnullOwnPtr<KString>);

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.h
@@ -42,7 +42,7 @@ private:
     static constexpr size_t number_of_rx_descriptors = 64;
     static constexpr size_t number_of_tx_descriptors = 16;
 
-    RTL8168NetworkAdapter(PCI::Address, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);
+    RTL8168NetworkAdapter(PCI::DeviceIdentifier const&, u8 irq, NonnullOwnPtr<IOWindow> registers_io_window, NonnullOwnPtr<KString>);
 
     virtual bool handle_irq(RegisterState const&) override;
     virtual StringView class_name() const override { return "RTL8168NetworkAdapter"sv; }

--- a/Kernel/Storage/ATA/AHCI/Port.cpp
+++ b/Kernel/Storage/ATA/AHCI/Port.cpp
@@ -187,8 +187,8 @@ void AHCIPort::recover_from_fatal_error()
         return;
     }
 
-    dmesgln("{}: AHCI Port {} fatal error, shutting down!", controller->pci_address(), representative_port_index());
-    dmesgln("{}: AHCI Port {} fatal error, SError {}", controller->pci_address(), representative_port_index(), (u32)m_port_registers.serr);
+    dmesgln("{}: AHCI Port {} fatal error, shutting down!", controller->device_identifier().address(), representative_port_index());
+    dmesgln("{}: AHCI Port {} fatal error, SError {}", controller->device_identifier().address(), representative_port_index(), (u32)m_port_registers.serr);
     stop_command_list_processing();
     stop_fis_receiving();
     m_interrupt_enable.clear();

--- a/Kernel/Storage/NVMe/NVMeController.cpp
+++ b/Kernel/Storage/NVMe/NVMeController.cpp
@@ -27,9 +27,8 @@ UNMAP_AFTER_INIT ErrorOr<NonnullLockRefPtr<NVMeController>> NVMeController::try_
 }
 
 UNMAP_AFTER_INIT NVMeController::NVMeController(const PCI::DeviceIdentifier& device_identifier, u32 hardware_relative_controller_id)
-    : PCI::Device(device_identifier.address())
+    : PCI::Device(const_cast<PCI::DeviceIdentifier&>(device_identifier))
     , StorageController(hardware_relative_controller_id)
-    , m_pci_device_id(device_identifier)
 {
 }
 
@@ -37,11 +36,11 @@ UNMAP_AFTER_INIT ErrorOr<void> NVMeController::initialize(bool is_queue_polled)
 {
     // Nr of queues = one queue per core
     auto nr_of_queues = Processor::count();
-    auto irq = is_queue_polled ? Optional<u8> {} : m_pci_device_id.interrupt_line().value();
+    auto irq = is_queue_polled ? Optional<u8> {} : device_identifier().interrupt_line().value();
 
-    PCI::enable_memory_space(m_pci_device_id.address());
-    PCI::enable_bus_mastering(m_pci_device_id.address());
-    m_bar = PCI::get_BAR0(m_pci_device_id.address()) & BAR_ADDR_MASK;
+    PCI::enable_memory_space(device_identifier());
+    PCI::enable_bus_mastering(device_identifier());
+    m_bar = PCI::get_BAR0(device_identifier()) & BAR_ADDR_MASK;
     static_assert(sizeof(ControllerRegister) == REG_SQ0TDBL_START);
     static_assert(sizeof(NVMeSubmission) == (1 << SQ_WIDTH));
 

--- a/Kernel/Storage/NVMe/NVMeController.h
+++ b/Kernel/Storage/NVMe/NVMeController.h
@@ -69,7 +69,6 @@ private:
     bool wait_for_ready(bool);
 
 private:
-    PCI::DeviceIdentifier m_pci_device_id;
     LockRefPtr<NVMeQueue> m_admin_queue;
     NonnullLockRefPtrVector<NVMeQueue> m_queues;
     NonnullLockRefPtrVector<NVMeNameSpace> m_namespaces;


### PR DESCRIPTION
For each exposed PCI device in sysfs, there's a new node called "rom" and
by reading it, it exposes the raw data of PCI option ROM blob to a user
for examining the blob.