### PR TITLE
LibSQL: Introduce ResultOr<ValueType> and use it for both SQL statement and expression evaluation

### DIFF
--- a/Tests/LibSQL/TestSqlStatementExecution.cpp
+++ b/Tests/LibSQL/TestSqlStatementExecution.cpp
@@ -11,6 +11,7 @@
 #include <LibSQL/AST/Parser.h>
 #include <LibSQL/Database.h>
 #include <LibSQL/Result.h>
+#include <LibSQL/ResultSet.h>
 #include <LibSQL/Row.h>
 #include <LibSQL/Value.h>
 #include <LibTest/TestCase.h>
@@ -19,43 +20,46 @@ namespace {
 
 constexpr const char* db_name = "/tmp/test.db";
 
-SQL::Result execute(NonnullRefPtr<SQL::Database> database, String const& sql)
+SQL::ResultOr<SQL::ResultSet> try_execute(NonnullRefPtr<SQL::Database> database, String const& sql)
 {
     auto parser = SQL::AST::Parser(SQL::AST::Lexer(sql));
     auto statement = parser.next_statement();
     EXPECT(!parser.has_errors());
     if (parser.has_errors())
         outln("{}", parser.errors()[0].to_string());
-    auto result = statement->execute(move(database));
-    if (result.is_error())
-        outln("{}", result.error_string());
-    return result;
+    return statement->execute(move(database));
+}
+
+SQL::ResultSet execute(NonnullRefPtr<SQL::Database> database, String const& sql)
+{
+    auto result = try_execute(move(database), sql);
+    if (result.is_error()) {
+        outln("{}", result.release_error().error_string());
+        VERIFY_NOT_REACHED();
+    }
+    return result.release_value();
 }
 
 void create_schema(NonnullRefPtr<SQL::Database> database)
 {
     auto result = execute(database, "CREATE SCHEMA TestSchema;");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 1);
+    EXPECT_EQ(result.command(), SQL::SQLCommand::Create);
 }
 
 void create_table(NonnullRefPtr<SQL::Database> database)
 {
     create_schema(database);
     auto result = execute(database, "CREATE TABLE TestSchema.TestTable ( TextColumn text, IntColumn integer );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 1);
+    EXPECT_EQ(result.command(), SQL::SQLCommand::Create);
 }
 
 void create_two_tables(NonnullRefPtr<SQL::Database> database)
 {
     create_schema(database);
     auto result = execute(database, "CREATE TABLE TestSchema.TestTable1 ( TextColumn1 text, IntColumn integer );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 1);
+    EXPECT_EQ(result.command(), SQL::SQLCommand::Create);
     result = execute(database, "CREATE TABLE TestSchema.TestTable2 ( TextColumn2 text, IntColumn integer );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 1);
+    EXPECT_EQ(result.command(), SQL::SQLCommand::Create);
 }
 
 TEST_CASE(create_schema)
@@ -87,8 +91,7 @@ TEST_CASE(insert_into_table)
     EXPECT(!database->open().is_error());
     create_table(database);
     auto result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test', 42 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 1);
+    EXPECT(result.size() == 1);
 
     auto table_or_error = database->get_table("TESTSCHEMA", "TESTTABLE");
     EXPECT(!table_or_error.is_error());
@@ -111,9 +114,9 @@ TEST_CASE(insert_into_table_wrong_data_types)
     auto database = SQL::Database::construct(db_name);
     EXPECT(!database->open().is_error());
     create_table(database);
-    auto result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES (43, 'Test_2');");
-    EXPECT(result.inserted() == 0);
-    EXPECT(result.error() == SQL::SQLErrorCode::InvalidValueType);
+    auto result = try_execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES (43, 'Test_2');");
+    EXPECT(result.is_error());
+    EXPECT(result.release_error().error() == SQL::SQLErrorCode::InvalidValueType);
 }
 
 TEST_CASE(insert_into_table_multiple_tuples_wrong_data_types)
@@ -122,9 +125,9 @@ TEST_CASE(insert_into_table_multiple_tuples_wrong_data_types)
     auto database = SQL::Database::construct(db_name);
     EXPECT(!database->open().is_error());
     create_table(database);
-    auto result = execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ('Test_1', 42), (43, 'Test_2');");
-    EXPECT(result.inserted() == 0);
-    EXPECT(result.error() == SQL::SQLErrorCode::InvalidValueType);
+    auto result = try_execute(database, "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ('Test_1', 42), (43, 'Test_2');");
+    EXPECT(result.is_error());
+    EXPECT(result.release_error().error() == SQL::SQLErrorCode::InvalidValueType);
 }
 
 TEST_CASE(insert_wrong_number_of_values)
@@ -133,9 +136,9 @@ TEST_CASE(insert_wrong_number_of_values)
     auto database = SQL::Database::construct(db_name);
     EXPECT(!database->open().is_error());
     create_table(database);
-    auto result = execute(database, "INSERT INTO TestSchema.TestTable VALUES ( 42 );");
-    EXPECT(result.error() == SQL::SQLErrorCode::InvalidNumberOfValues);
-    EXPECT(result.inserted() == 0);
+    auto result = try_execute(database, "INSERT INTO TestSchema.TestTable VALUES ( 42 );");
+    EXPECT(result.is_error());
+    EXPECT(result.release_error().error() == SQL::SQLErrorCode::InvalidNumberOfValues);
 }
 
 TEST_CASE(insert_identifier_as_value)
@@ -144,9 +147,9 @@ TEST_CASE(insert_identifier_as_value)
     auto database = SQL::Database::construct(db_name);
     EXPECT(!database->open().is_error());
     create_table(database);
-    auto result = execute(database, "INSERT INTO TestSchema.TestTable VALUES ( identifier, 42 );");
-    EXPECT(result.error() == SQL::SQLErrorCode::SyntaxError);
-    EXPECT(result.inserted() == 0);
+    auto result = try_execute(database, "INSERT INTO TestSchema.TestTable VALUES ( identifier, 42 );");
+    EXPECT(result.is_error());
+    EXPECT(result.release_error().error() == SQL::SQLErrorCode::SyntaxError);
 }
 
 TEST_CASE(insert_quoted_identifier_as_value)
@@ -155,9 +158,9 @@ TEST_CASE(insert_quoted_identifier_as_value)
     auto database = SQL::Database::construct(db_name);
     EXPECT(!database->open().is_error());
     create_table(database);
-    auto result = execute(database, "INSERT INTO TestSchema.TestTable VALUES ( \"QuotedIdentifier\", 42 );");
-    EXPECT(result.error() == SQL::SQLErrorCode::SyntaxError);
-    EXPECT(result.inserted() == 0);
+    auto result = try_execute(database, "INSERT INTO TestSchema.TestTable VALUES ( \"QuotedIdentifier\", 42 );");
+    EXPECT(result.is_error());
+    EXPECT(result.release_error().error() == SQL::SQLErrorCode::SyntaxError);
 }
 
 TEST_CASE(insert_without_column_names)
@@ -167,8 +170,7 @@ TEST_CASE(insert_without_column_names)
     EXPECT(!database->open().is_error());
     create_table(database);
     auto result = execute(database, "INSERT INTO TestSchema.TestTable VALUES ('Test_1', 42), ('Test_2', 43);");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 2);
+    EXPECT(result.size() == 2);
 
     auto table_or_error = database->get_table("TESTSCHEMA", "TESTTABLE");
     EXPECT(!table_or_error.is_error());
@@ -184,8 +186,7 @@ TEST_CASE(select_from_empty_table)
     EXPECT(!database->open().is_error());
     create_table(database);
     auto result = execute(database, "SELECT * FROM TestSchema.TestTable;");
-    EXPECT(!result.is_error());
-    EXPECT(!result.has_results());
+    EXPECT(result.is_empty());
 }
 
 TEST_CASE(select_from_table)
@@ -201,12 +202,9 @@ TEST_CASE(select_from_table)
         "( 'Test_3', 44 ), "
         "( 'Test_4', 45 ), "
         "( 'Test_5', 46 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
     result = execute(database, "SELECT * FROM TestSchema.TestTable;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 5u);
+    EXPECT_EQ(result.size(), 5u);
 }
 
 TEST_CASE(select_with_column_names)
@@ -222,13 +220,10 @@ TEST_CASE(select_with_column_names)
         "( 'Test_3', 44 ), "
         "( 'Test_4', 45 ), "
         "( 'Test_5', 46 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 5u);
-    EXPECT_EQ(result.results()[0].row.size(), 1u);
+    EXPECT_EQ(result.size(), 5u);
+    EXPECT_EQ(result[0].row.size(), 1u);
 }
 
 TEST_CASE(select_with_nonexisting_column_name)
@@ -244,10 +239,11 @@ TEST_CASE(select_with_nonexisting_column_name)
         "( 'Test_3', 44 ), "
         "( 'Test_4', 45 ), "
         "( 'Test_5', 46 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
-    result = execute(database, "SELECT Bogus FROM TestSchema.TestTable;");
-    EXPECT(result.error() == SQL::SQLErrorCode::ColumnDoesNotExist);
+    EXPECT(result.size() == 5);
+
+    auto insert_result = try_execute(database, "SELECT Bogus FROM TestSchema.TestTable;");
+    EXPECT(insert_result.is_error());
+    EXPECT(insert_result.release_error().error() == SQL::SQLErrorCode::ColumnDoesNotExist);
 }
 
 TEST_CASE(select_with_where)
@@ -263,13 +259,10 @@ TEST_CASE(select_with_where)
         "( 'Test_3', 44 ), "
         "( 'Test_4', 45 ), "
         "( 'Test_5', 46 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
     result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable WHERE IntColumn > 44;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 2u);
-    for (auto& row : result.results()) {
+    EXPECT_EQ(result.size(), 2u);
+    for (auto& row : result) {
         EXPECT(row.row[1].to_int().value() > 44);
     }
 }
@@ -287,8 +280,7 @@ TEST_CASE(select_cross_join)
         "( 'Test_3', 44 ), "
         "( 'Test_4', 45 ), "
         "( 'Test_5', 46 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
     result = execute(database,
         "INSERT INTO TestSchema.TestTable2 ( TextColumn2, IntColumn ) VALUES "
         "( 'Test_10', 40 ), "
@@ -296,13 +288,10 @@ TEST_CASE(select_cross_join)
         "( 'Test_12', 42 ), "
         "( 'Test_13', 47 ), "
         "( 'Test_14', 48 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
     result = execute(database, "SELECT * FROM TestSchema.TestTable1, TestSchema.TestTable2;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 25u);
-    for (auto& row : result.results()) {
+    EXPECT_EQ(result.size(), 25u);
+    for (auto& row : result) {
         EXPECT(row.row.size() == 4);
         EXPECT(row.row[1].to_int().value() >= 42);
         EXPECT(row.row[1].to_int().value() <= 46);
@@ -324,8 +313,7 @@ TEST_CASE(select_inner_join)
         "( 'Test_3', 44 ), "
         "( 'Test_4', 45 ), "
         "( 'Test_5', 46 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
     result = execute(database,
         "INSERT INTO TestSchema.TestTable2 ( TextColumn2, IntColumn ) VALUES "
         "( 'Test_10', 40 ), "
@@ -333,20 +321,16 @@ TEST_CASE(select_inner_join)
         "( 'Test_12', 42 ), "
         "( 'Test_13', 47 ), "
         "( 'Test_14', 48 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
     result = execute(database,
         "SELECT TestTable1.IntColumn, TextColumn1, TextColumn2 "
         "FROM TestSchema.TestTable1, TestSchema.TestTable2 "
         "WHERE TestTable1.IntColumn = TestTable2.IntColumn;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 1u);
-    auto& row = result.results()[0];
-    EXPECT_EQ(row.row.size(), 3u);
-    EXPECT_EQ(row.row[0].to_int().value(), 42);
-    EXPECT_EQ(row.row[1].to_string(), "Test_1");
-    EXPECT_EQ(row.row[2].to_string(), "Test_12");
+    EXPECT_EQ(result.size(), 1u);
+    EXPECT_EQ(result[0].row.size(), 3u);
+    EXPECT_EQ(result[0].row[0].to_int().value(), 42);
+    EXPECT_EQ(result[0].row[1].to_string(), "Test_1");
+    EXPECT_EQ(result[0].row[2].to_string(), "Test_12");
 }
 
 TEST_CASE(select_with_like)
@@ -363,63 +347,48 @@ TEST_CASE(select_with_like)
         "( 'Test+4', 45 ), "
         "( 'Test+5', 46 ), "
         "( 'Another+Test_6', 47 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 6);
+    EXPECT(result.size() == 6);
 
     // Simple match
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE 'Test+1';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 1u);
+    EXPECT_EQ(result.size(), 1u);
 
     // Use % to match most rows
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE 'T%';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 5u);
+    EXPECT_EQ(result.size(), 5u);
 
     // Same as above but invert the match
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn NOT LIKE 'T%';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 1u);
+    EXPECT_EQ(result.size(), 1u);
 
     // Use _ and % to match all rows
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE '%e_t%';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 6u);
+    EXPECT_EQ(result.size(), 6u);
 
     // Use escape to match a single row. The escape character happens to be a
     // Regex metacharacter, let's make sure we don't get confused by that.
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE '%Test^_%' ESCAPE '^';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 1u);
+    EXPECT_EQ(result.size(), 1u);
 
     // Same as above but escape the escape character happens to be a SQL
     // metacharacter - we want to make sure it's treated as an escape.
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE '%Test__%' ESCAPE '_';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 1u);
+    EXPECT_EQ(result.size(), 1u);
 
     // (Unnecessarily) escaping a character that happens to be a Regex
     // metacharacter should have no effect.
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE 'Test:+_' ESCAPE ':';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 5u);
+    EXPECT_EQ(result.size(), 5u);
 
     // Make sure we error out if the ESCAPE is empty
-    result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE '%' ESCAPE '';");
-    EXPECT(result.error() == SQL::SQLErrorCode::SyntaxError);
-    EXPECT(!result.has_results());
+    auto select_result = try_execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE '%' ESCAPE '';");
+    EXPECT(select_result.is_error());
+    EXPECT(select_result.release_error().error() == SQL::SQLErrorCode::SyntaxError);
 
     // Make sure we error out if the ESCAPE has more than a single character
-    result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE '%' ESCAPE 'whf';");
-    EXPECT(result.error() == SQL::SQLErrorCode::SyntaxError);
-    EXPECT(!result.has_results());
+    select_result = try_execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn LIKE '%' ESCAPE 'whf';");
+    EXPECT(select_result.is_error());
+    EXPECT(select_result.release_error().error() == SQL::SQLErrorCode::SyntaxError);
 }
 
 TEST_CASE(select_with_order)
@@ -435,30 +404,23 @@ TEST_CASE(select_with_order)
         "( 'Test_1', 47 ), "
         "( 'Test_3', 40 ), "
         "( 'Test_4', 41 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
 
     result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable ORDER BY IntColumn;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    auto rows = result.results();
-    EXPECT_EQ(rows.size(), 5u);
-    EXPECT_EQ(rows[0].row[1].to_int().value(), 40);
-    EXPECT_EQ(rows[1].row[1].to_int().value(), 41);
-    EXPECT_EQ(rows[2].row[1].to_int().value(), 42);
-    EXPECT_EQ(rows[3].row[1].to_int().value(), 44);
-    EXPECT_EQ(rows[4].row[1].to_int().value(), 47);
+    EXPECT_EQ(result.size(), 5u);
+    EXPECT_EQ(result[0].row[1].to_int().value(), 40);
+    EXPECT_EQ(result[1].row[1].to_int().value(), 41);
+    EXPECT_EQ(result[2].row[1].to_int().value(), 42);
+    EXPECT_EQ(result[3].row[1].to_int().value(), 44);
+    EXPECT_EQ(result[4].row[1].to_int().value(), 47);
 
     result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable ORDER BY TextColumn;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    rows = result.results();
-    EXPECT_EQ(rows.size(), 5u);
-    EXPECT_EQ(rows[0].row[0].to_string(), "Test_1");
-    EXPECT_EQ(rows[1].row[0].to_string(), "Test_2");
-    EXPECT_EQ(rows[2].row[0].to_string(), "Test_3");
-    EXPECT_EQ(rows[3].row[0].to_string(), "Test_4");
-    EXPECT_EQ(rows[4].row[0].to_string(), "Test_5");
+    EXPECT_EQ(result.size(), 5u);
+    EXPECT_EQ(result[0].row[0].to_string(), "Test_1");
+    EXPECT_EQ(result[1].row[0].to_string(), "Test_2");
+    EXPECT_EQ(result[2].row[0].to_string(), "Test_3");
+    EXPECT_EQ(result[3].row[0].to_string(), "Test_4");
+    EXPECT_EQ(result[4].row[0].to_string(), "Test_5");
 }
 
 TEST_CASE(select_with_regexp)
@@ -475,34 +437,25 @@ TEST_CASE(select_with_regexp)
         "( 'Test[4]', 45 ), "
         "( 'Test+5', 46 ), "
         "( 'Another-Test_6', 47 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 6);
+    EXPECT(result.size() == 6);
 
     // Simple match
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn REGEXP 'Test\\+1';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 1u);
+    EXPECT_EQ(result.size(), 1u);
 
     // Match all
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn REGEXP '.*';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 6u);
+    EXPECT_EQ(result.size(), 6u);
 
     // Match with wildcards
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn REGEXP '^Test.+';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 4u);
+    EXPECT_EQ(result.size(), 4u);
 
     // Match with case insensitive basic Latin and case sensitive Swedish ö
     // FIXME: If LibRegex is changed to support case insensitive matches of Unicode characters
     //        This test should be updated and changed to match 'PRÖV'.
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn REGEXP 'PRöV.*';");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 1u);
+    EXPECT_EQ(result.size(), 1u);
 }
 
 TEST_CASE(handle_regexp_errors)
@@ -514,13 +467,11 @@ TEST_CASE(handle_regexp_errors)
     auto result = execute(database,
         "INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES "
         "( 'Test', 0 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 1);
+    EXPECT(result.size() == 1);
 
     // Malformed regex, unmatched square bracket
-    result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn REGEXP 'Test\\+[0-9.*';");
-    EXPECT(result.is_error());
-    EXPECT(!result.has_results());
+    auto select_result = try_execute(database, "SELECT TextColumn FROM TestSchema.TestTable WHERE TextColumn REGEXP 'Test\\+[0-9.*';");
+    EXPECT(select_result.is_error());
 }
 
 TEST_CASE(select_with_order_two_columns)
@@ -536,24 +487,20 @@ TEST_CASE(select_with_order_two_columns)
         "( 'Test_1', 47 ), "
         "( 'Test_2', 40 ), "
         "( 'Test_4', 41 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
 
     result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable ORDER BY TextColumn, IntColumn;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    auto rows = result.results();
-    EXPECT_EQ(rows.size(), 5u);
-    EXPECT_EQ(rows[0].row[0].to_string(), "Test_1");
-    EXPECT_EQ(rows[0].row[1].to_int().value(), 47);
-    EXPECT_EQ(rows[1].row[0].to_string(), "Test_2");
-    EXPECT_EQ(rows[1].row[1].to_int().value(), 40);
-    EXPECT_EQ(rows[2].row[0].to_string(), "Test_2");
-    EXPECT_EQ(rows[2].row[1].to_int().value(), 42);
-    EXPECT_EQ(rows[3].row[0].to_string(), "Test_4");
-    EXPECT_EQ(rows[3].row[1].to_int().value(), 41);
-    EXPECT_EQ(rows[4].row[0].to_string(), "Test_5");
-    EXPECT_EQ(rows[4].row[1].to_int().value(), 44);
+    EXPECT_EQ(result.size(), 5u);
+    EXPECT_EQ(result[0].row[0].to_string(), "Test_1");
+    EXPECT_EQ(result[0].row[1].to_int().value(), 47);
+    EXPECT_EQ(result[1].row[0].to_string(), "Test_2");
+    EXPECT_EQ(result[1].row[1].to_int().value(), 40);
+    EXPECT_EQ(result[2].row[0].to_string(), "Test_2");
+    EXPECT_EQ(result[2].row[1].to_int().value(), 42);
+    EXPECT_EQ(result[3].row[0].to_string(), "Test_4");
+    EXPECT_EQ(result[3].row[1].to_int().value(), 41);
+    EXPECT_EQ(result[4].row[0].to_string(), "Test_5");
+    EXPECT_EQ(result[4].row[1].to_int().value(), 44);
 }
 
 TEST_CASE(select_with_order_by_column_not_in_result)
@@ -569,19 +516,15 @@ TEST_CASE(select_with_order_by_column_not_in_result)
         "( 'Test_1', 47 ), "
         "( 'Test_3', 40 ), "
         "( 'Test_4', 41 );");
-    EXPECT(!result.is_error());
-    EXPECT(result.inserted() == 5);
+    EXPECT(result.size() == 5);
 
     result = execute(database, "SELECT TextColumn FROM TestSchema.TestTable ORDER BY IntColumn;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    auto rows = result.results();
-    EXPECT_EQ(rows.size(), 5u);
-    EXPECT_EQ(rows[0].row[0].to_string(), "Test_3");
-    EXPECT_EQ(rows[1].row[0].to_string(), "Test_4");
-    EXPECT_EQ(rows[2].row[0].to_string(), "Test_2");
-    EXPECT_EQ(rows[3].row[0].to_string(), "Test_5");
-    EXPECT_EQ(rows[4].row[0].to_string(), "Test_1");
+    EXPECT_EQ(result.size(), 5u);
+    EXPECT_EQ(result[0].row[0].to_string(), "Test_3");
+    EXPECT_EQ(result[1].row[0].to_string(), "Test_4");
+    EXPECT_EQ(result[2].row[0].to_string(), "Test_2");
+    EXPECT_EQ(result[3].row[0].to_string(), "Test_5");
+    EXPECT_EQ(result[4].row[0].to_string(), "Test_1");
 }
 
 TEST_CASE(select_with_limit)
@@ -593,13 +536,10 @@ TEST_CASE(select_with_limit)
     for (auto count = 0; count < 100; count++) {
         auto result = execute(database,
             String::formatted("INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test_{}', {} );", count, count));
-        EXPECT(!result.is_error());
-        EXPECT(result.inserted() == 1);
+        EXPECT(result.size() == 1);
     }
     auto result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable LIMIT 10;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    auto rows = result.results();
+    auto rows = result;
     EXPECT_EQ(rows.size(), 10u);
 }
 
@@ -612,14 +552,10 @@ TEST_CASE(select_with_limit_and_offset)
     for (auto count = 0; count < 100; count++) {
         auto result = execute(database,
             String::formatted("INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test_{}', {} );", count, count));
-        EXPECT(!result.is_error());
-        EXPECT(result.inserted() == 1);
+        EXPECT(result.size() == 1);
     }
     auto result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable LIMIT 10 OFFSET 10;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    auto rows = result.results();
-    EXPECT_EQ(rows.size(), 10u);
+    EXPECT_EQ(result.size(), 10u);
 }
 
 TEST_CASE(select_with_order_limit_and_offset)
@@ -631,24 +567,20 @@ TEST_CASE(select_with_order_limit_and_offset)
     for (auto count = 0; count < 100; count++) {
         auto result = execute(database,
             String::formatted("INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test_{}', {} );", count, count));
-        EXPECT(!result.is_error());
-        EXPECT(result.inserted() == 1);
+        EXPECT(result.size() == 1);
     }
     auto result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable ORDER BY IntColumn LIMIT 10 OFFSET 10;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    auto rows = result.results();
-    EXPECT_EQ(rows.size(), 10u);
-    EXPECT_EQ(rows[0].row[1].to_int().value(), 10);
-    EXPECT_EQ(rows[1].row[1].to_int().value(), 11);
-    EXPECT_EQ(rows[2].row[1].to_int().value(), 12);
-    EXPECT_EQ(rows[3].row[1].to_int().value(), 13);
-    EXPECT_EQ(rows[4].row[1].to_int().value(), 14);
-    EXPECT_EQ(rows[5].row[1].to_int().value(), 15);
-    EXPECT_EQ(rows[6].row[1].to_int().value(), 16);
-    EXPECT_EQ(rows[7].row[1].to_int().value(), 17);
-    EXPECT_EQ(rows[8].row[1].to_int().value(), 18);
-    EXPECT_EQ(rows[9].row[1].to_int().value(), 19);
+    EXPECT_EQ(result.size(), 10u);
+    EXPECT_EQ(result[0].row[1].to_int().value(), 10);
+    EXPECT_EQ(result[1].row[1].to_int().value(), 11);
+    EXPECT_EQ(result[2].row[1].to_int().value(), 12);
+    EXPECT_EQ(result[3].row[1].to_int().value(), 13);
+    EXPECT_EQ(result[4].row[1].to_int().value(), 14);
+    EXPECT_EQ(result[5].row[1].to_int().value(), 15);
+    EXPECT_EQ(result[6].row[1].to_int().value(), 16);
+    EXPECT_EQ(result[7].row[1].to_int().value(), 17);
+    EXPECT_EQ(result[8].row[1].to_int().value(), 18);
+    EXPECT_EQ(result[9].row[1].to_int().value(), 19);
 }
 
 TEST_CASE(select_with_limit_out_of_bounds)
@@ -660,14 +592,10 @@ TEST_CASE(select_with_limit_out_of_bounds)
     for (auto count = 0; count < 100; count++) {
         auto result = execute(database,
             String::formatted("INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test_{}', {} );", count, count));
-        EXPECT(!result.is_error());
-        EXPECT(result.inserted() == 1);
+        EXPECT(result.size() == 1);
     }
     auto result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable LIMIT 500;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    auto rows = result.results();
-    EXPECT_EQ(rows.size(), 100u);
+    EXPECT_EQ(result.size(), 100u);
 }
 
 TEST_CASE(select_with_offset_out_of_bounds)
@@ -679,14 +607,10 @@ TEST_CASE(select_with_offset_out_of_bounds)
     for (auto count = 0; count < 100; count++) {
         auto result = execute(database,
             String::formatted("INSERT INTO TestSchema.TestTable ( TextColumn, IntColumn ) VALUES ( 'Test_{}', {} );", count, count));
-        EXPECT(!result.is_error());
-        EXPECT(result.inserted() == 1);
+        EXPECT(result.size() == 1);
     }
     auto result = execute(database, "SELECT TextColumn, IntColumn FROM TestSchema.TestTable LIMIT 10 OFFSET 200;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    auto rows = result.results();
-    EXPECT_EQ(rows.size(), 0u);
+    EXPECT_EQ(result.size(), 0u);
 }
 
 TEST_CASE(describe_table)
@@ -696,18 +620,13 @@ TEST_CASE(describe_table)
     EXPECT(!database->open().is_error());
     create_table(database);
     auto result = execute(database, "DESCRIBE TABLE TestSchema.TestTable;");
-    EXPECT(!result.is_error());
-    EXPECT(result.has_results());
-    EXPECT_EQ(result.results().size(), 2u);
+    EXPECT_EQ(result.size(), 2u);
 
-    auto rows = result.results();
-    auto& row1 = rows[0];
-    EXPECT_EQ(row1.row[0].to_string(), "TEXTCOLUMN");
-    EXPECT_EQ(row1.row[1].to_string(), "text");
+    EXPECT_EQ(result[0].row[0].to_string(), "TEXTCOLUMN");
+    EXPECT_EQ(result[0].row[1].to_string(), "text");
 
-    auto& row2 = rows[1];
-    EXPECT_EQ(row2.row[0].to_string(), "INTCOLUMN");
-    EXPECT_EQ(row2.row[1].to_string(), "int");
+    EXPECT_EQ(result[1].row[0].to_string(), "INTCOLUMN");
+    EXPECT_EQ(result[1].row[1].to_string(), "int");
 }
 
 }

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -306,7 +306,7 @@ struct ExecutionContext {
 
 class Expression : public ASTNode {
 public:
-    virtual Value evaluate(ExecutionContext&) const;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const;
 };
 
 class ErrorExpression final : public Expression {
@@ -320,7 +320,7 @@ public:
     }
 
     double value() const { return m_value; }
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 
 private:
     double m_value;
@@ -334,7 +334,7 @@ public:
     }
 
     const String& value() const { return m_value; }
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 
 private:
     String m_value;
@@ -355,13 +355,13 @@ private:
 
 class NullLiteral : public Expression {
 public:
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 };
 
 class NestedExpression : public Expression {
 public:
     const NonnullRefPtr<Expression>& expression() const { return m_expression; }
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 
 protected:
     explicit NestedExpression(NonnullRefPtr<Expression> expression)
@@ -432,7 +432,7 @@ public:
     const String& schema_name() const { return m_schema_name; }
     const String& table_name() const { return m_table_name; }
     const String& column_name() const { return m_column_name; }
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 
 private:
     String m_schema_name;
@@ -475,7 +475,7 @@ public:
     }
 
     UnaryOperator type() const { return m_type; }
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 
 private:
     UnaryOperator m_type;
@@ -531,7 +531,7 @@ public:
     }
 
     BinaryOperator type() const { return m_type; }
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 
 private:
     BinaryOperator m_type;
@@ -545,7 +545,7 @@ public:
     }
 
     const NonnullRefPtrVector<Expression>& expressions() const { return m_expressions; }
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 
 private:
     NonnullRefPtrVector<Expression> m_expressions;
@@ -638,7 +638,7 @@ public:
 
     MatchOperator type() const { return m_type; }
     const RefPtr<Expression>& escape() const { return m_escape; }
-    virtual Value evaluate(ExecutionContext&) const override;
+    virtual ResultOr<Value> evaluate(ExecutionContext&) const override;
 
 private:
     MatchOperator m_type;

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -299,7 +299,6 @@ private:
 
 struct ExecutionContext {
     NonnullRefPtr<Database> database;
-    Optional<Result> result;
     class Statement const* statement;
     Tuple* current_row { nullptr };
 };

--- a/Userland/Libraries/LibSQL/AST/AST.h
+++ b/Userland/Libraries/LibSQL/AST/AST.h
@@ -15,6 +15,7 @@
 #include <LibSQL/AST/Token.h>
 #include <LibSQL/Forward.h>
 #include <LibSQL/Result.h>
+#include <LibSQL/ResultSet.h>
 #include <LibSQL/Type.h>
 
 namespace SQL::AST {
@@ -725,11 +726,11 @@ private:
 
 class Statement : public ASTNode {
 public:
-    Result execute(AK::NonnullRefPtr<Database> database) const;
+    ResultOr<ResultSet> execute(AK::NonnullRefPtr<Database> database) const;
 
-    virtual Result execute(ExecutionContext&) const
+    virtual ResultOr<ResultSet> execute(ExecutionContext&) const
     {
-        return { SQLCommand::Unknown, SQLErrorCode::NotYetImplemented };
+        return Result { SQLCommand::Unknown, SQLErrorCode::NotYetImplemented };
     }
 };
 
@@ -747,7 +748,7 @@ public:
     const String& schema_name() const { return m_schema_name; }
     bool is_error_if_schema_exists() const { return m_is_error_if_schema_exists; }
 
-    Result execute(ExecutionContext&) const override;
+    ResultOr<ResultSet> execute(ExecutionContext&) const override;
 
 private:
     String m_schema_name;
@@ -786,7 +787,7 @@ public:
     bool is_temporary() const { return m_is_temporary; }
     bool is_error_if_table_exists() const { return m_is_error_if_table_exists; }
 
-    Result execute(ExecutionContext&) const override;
+    ResultOr<ResultSet> execute(ExecutionContext&) const override;
 
 private:
     String m_schema_name;
@@ -949,7 +950,7 @@ public:
     bool has_selection() const { return !m_select_statement.is_null(); }
     const RefPtr<Select>& select_statement() const { return m_select_statement; }
 
-    virtual Result execute(ExecutionContext&) const override;
+    virtual ResultOr<ResultSet> execute(ExecutionContext&) const override;
 
 private:
     RefPtr<CommonTableExpressionList> m_common_table_expression_list;
@@ -1042,7 +1043,7 @@ public:
     const RefPtr<GroupByClause>& group_by_clause() const { return m_group_by_clause; }
     const NonnullRefPtrVector<OrderingTerm>& ordering_term_list() const { return m_ordering_term_list; }
     const RefPtr<LimitClause>& limit_clause() const { return m_limit_clause; }
-    Result execute(ExecutionContext&) const override;
+    ResultOr<ResultSet> execute(ExecutionContext&) const override;
 
 private:
     RefPtr<CommonTableExpressionList> m_common_table_expression_list;
@@ -1063,7 +1064,7 @@ public:
     }
 
     NonnullRefPtr<QualifiedTableName> qualified_table_name() const { return m_qualified_table_name; }
-    Result execute(ExecutionContext&) const override;
+    ResultOr<ResultSet> execute(ExecutionContext&) const override;
 
 private:
     NonnullRefPtr<QualifiedTableName> m_qualified_table_name;

--- a/Userland/Libraries/LibSQL/AST/CreateSchema.cpp
+++ b/Userland/Libraries/LibSQL/AST/CreateSchema.cpp
@@ -10,20 +10,20 @@
 
 namespace SQL::AST {
 
-Result CreateSchema::execute(ExecutionContext& context) const
+ResultOr<ResultSet> CreateSchema::execute(ExecutionContext& context) const
 {
     auto schema_def = TRY(context.database->get_schema(m_schema_name));
 
     if (schema_def) {
         if (m_is_error_if_schema_exists)
-            return { SQLCommand::Create, SQLErrorCode::SchemaExists, m_schema_name };
-        return { SQLCommand::Create };
+            return Result { SQLCommand::Create, SQLErrorCode::SchemaExists, m_schema_name };
+        return ResultSet { SQLCommand::Create };
     }
 
     schema_def = SchemaDef::construct(m_schema_name);
     TRY(context.database->add_schema(*schema_def));
 
-    return { SQLCommand::Create, 0, 1 };
+    return ResultSet { SQLCommand::Create };
 }
 
 }

--- a/Userland/Libraries/LibSQL/AST/Expression.cpp
+++ b/Userland/Libraries/LibSQL/AST/Expression.cpp
@@ -239,11 +239,12 @@ ResultOr<Value> MatchExpression::evaluate(ExecutionContext& context) const
         return Value(invert_expression() ? !result.success : result.success);
     }
     case MatchOperator::Glob:
+        return Result { SQLCommand::Unknown, SQLErrorCode::NotYetImplemented, "GLOB expression is not yet implemented"sv };
     case MatchOperator::Match:
+        return Result { SQLCommand::Unknown, SQLErrorCode::NotYetImplemented, "MATCH expression is not yet implemented"sv };
     default:
         VERIFY_NOT_REACHED();
     }
-    return Value::null();
 }
 
 }

--- a/Userland/Libraries/LibSQL/AST/Insert.cpp
+++ b/Userland/Libraries/LibSQL/AST/Insert.cpp
@@ -39,8 +39,6 @@ ResultOr<ResultSet> Insert::execute(ExecutionContext& context) const
     ResultSet result { SQLCommand::Insert };
     TRY(result.try_ensure_capacity(m_chained_expressions.size()));
 
-    context.result = Result { SQLCommand::Insert };
-
     for (auto& row_expr : m_chained_expressions) {
         for (auto& column_def : table_def->columns()) {
             if (!m_column_names.contains_slow(column_def.name()))

--- a/Userland/Libraries/LibSQL/AST/Insert.cpp
+++ b/Userland/Libraries/LibSQL/AST/Insert.cpp
@@ -47,10 +47,7 @@ ResultOr<ResultSet> Insert::execute(ExecutionContext& context) const
                 row[column_def.name()] = column_def.default_value();
         }
 
-        auto row_value = row_expr.evaluate(context);
-        if (context.result->is_error())
-            return context.result.release_value();
-
+        auto row_value = TRY(row_expr.evaluate(context));
         VERIFY(row_value.type() == SQLType::Tuple);
         auto values = row_value.to_vector().value();
 

--- a/Userland/Libraries/LibSQL/AST/Select.cpp
+++ b/Userland/Libraries/LibSQL/AST/Select.cpp
@@ -48,7 +48,6 @@ ResultOr<ResultSet> Select::execute(ExecutionContext& context) const
         }
     }
 
-    context.result = Result { SQLCommand::Select };
     ResultSet result { SQLCommand::Select };
 
     auto descriptor = adopt_ref(*new TupleDescriptor);

--- a/Userland/Libraries/LibSQL/AST/Statement.cpp
+++ b/Userland/Libraries/LibSQL/AST/Statement.cpp
@@ -13,7 +13,7 @@ namespace SQL::AST {
 
 ResultOr<ResultSet> Statement::execute(AK::NonnullRefPtr<Database> database) const
 {
-    ExecutionContext context { move(database), {}, this, nullptr };
+    ExecutionContext context { move(database), this, nullptr };
     return execute(context);
 }
 

--- a/Userland/Libraries/LibSQL/AST/Statement.cpp
+++ b/Userland/Libraries/LibSQL/AST/Statement.cpp
@@ -11,7 +11,7 @@
 
 namespace SQL::AST {
 
-Result Statement::execute(AK::NonnullRefPtr<Database> database) const
+ResultOr<ResultSet> Statement::execute(AK::NonnullRefPtr<Database> database) const
 {
     ExecutionContext context { move(database), {}, this, nullptr };
     return execute(context);

--- a/Userland/Libraries/LibSQL/Forward.h
+++ b/Userland/Libraries/LibSQL/Forward.h
@@ -23,6 +23,7 @@ class Key;
 class KeyPartDef;
 class Relation;
 class Result;
+class ResultSet;
 class Row;
 class SchemaDef;
 class Serializer;

--- a/Userland/Libraries/LibSQL/Result.cpp
+++ b/Userland/Libraries/LibSQL/Result.cpp
@@ -9,30 +9,6 @@
 
 namespace SQL {
 
-void Result::insert(Tuple const& row, Tuple const& sort_key)
-{
-    if (!m_result_set.has_value())
-        m_result_set = ResultSet {};
-    m_result_set->insert_row(row, sort_key);
-}
-
-void Result::limit(size_t offset, size_t limit)
-{
-    VERIFY(has_results());
-
-    if (offset > 0) {
-        if (offset > m_result_set->size()) {
-            m_result_set->clear();
-            return;
-        }
-
-        m_result_set->remove(0, offset);
-    }
-
-    if (m_result_set->size() > limit)
-        m_result_set->remove(limit, m_result_set->size() - limit);
-}
-
 String Result::error_string() const
 {
     VERIFY(is_error());

--- a/Userland/Libraries/LibSQL/ResultSet.cpp
+++ b/Userland/Libraries/LibSQL/ResultSet.cpp
@@ -35,4 +35,19 @@ void ResultSet::insert_row(Tuple const& row, Tuple const& sort_key)
     insert(ix, ResultRow { row, sort_key });
 }
 
+void ResultSet::limit(size_t offset, size_t limit)
+{
+    if (offset > 0) {
+        if (offset > size()) {
+            clear();
+            return;
+        }
+
+        remove(0, offset);
+    }
+
+    if (size() > limit)
+        remove(limit, size() - limit);
+}
+
 }

--- a/Userland/Libraries/LibSQL/ResultSet.h
+++ b/Userland/Libraries/LibSQL/ResultSet.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <LibSQL/Result.h>
 #include <LibSQL/Tuple.h>
 #include <LibSQL/Type.h>
 
@@ -19,11 +20,20 @@ struct ResultRow {
 
 class ResultSet : public Vector<ResultRow> {
 public:
-    ResultSet() = default;
+    ALWAYS_INLINE ResultSet(SQLCommand command)
+        : m_command(command)
+    {
+    }
+
+    SQLCommand command() const { return m_command; }
+
     void insert_row(Tuple const& row, Tuple const& sort_key);
+    void limit(size_t offset, size_t limit);
 
 private:
     size_t binary_search(Tuple const& sort_key, size_t low, size_t high);
+
+    SQLCommand m_command { SQLCommand::Unknown };
 };
 
 }

--- a/Userland/Services/SQLServer/SQLStatement.h
+++ b/Userland/Services/SQLServer/SQLStatement.h
@@ -11,6 +11,7 @@
 #include <LibCore/Object.h>
 #include <LibSQL/AST/AST.h>
 #include <LibSQL/Result.h>
+#include <LibSQL/ResultSet.h>
 #include <SQLServer/DatabaseConnection.h>
 #include <SQLServer/Forward.h>
 
@@ -30,15 +31,16 @@ public:
 
 private:
     SQLStatement(DatabaseConnection&, String sql);
-    Optional<SQL::Result> parse();
+    SQL::ResultOr<void> parse();
+    bool should_send_result_rows() const;
     void next();
-    void report_error();
+    void report_error(SQL::Result);
 
     int m_statement_id;
     String m_sql;
     size_t m_index { 0 };
     RefPtr<SQL::AST::Statement> m_statement { nullptr };
-    Optional<SQL::Result> m_result {};
+    Optional<SQL::ResultSet> m_result {};
 };
 
 }


### PR DESCRIPTION
This adds a `ResultOr` as an alias for `ErrorOr<ValueType, Result>`. SQL statement execution now returns `ResultOr<ResultSet>` (`ResultSet` is an existing class that represents rows inserted, selected, etc. from the database). SQL expression execution now return `ResultOr<Value>`. Cleans up a good amount of manual is_error / return error handling!