### PR TITLE
LibCore: EventLoop fixes

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -849,7 +849,7 @@ void HackStudioWidget::initialize_debugger()
                 m_disassembly_widget->update_state(*Debugger::the().session(), regs);
                 HackStudioWidget::reveal_action_tab(*m_debug_info_widget);
             });
-            Core::EventLoop::wake();
+            Core::EventLoop::wake_current();
 
             return Debugger::HasControlPassedToUser::Yes;
         },
@@ -859,7 +859,7 @@ void HackStudioWidget::initialize_debugger()
                 if (m_current_editor_in_execution)
                     m_current_editor_in_execution->editor().clear_execution_position();
             });
-            Core::EventLoop::wake();
+            Core::EventLoop::wake_current();
         },
         [this]() {
             deferred_invoke([this] {
@@ -879,7 +879,7 @@ void HackStudioWidget::initialize_debugger()
                 HackStudioWidget::hide_action_tabs();
                 GUI::MessageBox::show(window(), "Program Exited", "Debugger", GUI::MessageBox::Type::Information);
             });
-            Core::EventLoop::wake();
+            Core::EventLoop::wake_current();
         });
 }
 

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -396,14 +396,14 @@ public:
     EventLoopPusher(EventLoop& event_loop)
         : m_event_loop(event_loop)
     {
-        if (!is_main_event_loop()) {
+        if (EventLoop::has_been_instantiated()) {
             m_event_loop.take_pending_events_from(EventLoop::current());
             s_event_loop_stack->append(event_loop);
         }
     }
     ~EventLoopPusher()
     {
-        if (!is_main_event_loop()) {
+        if (EventLoop::has_been_instantiated()) {
             s_event_loop_stack->take_last();
             EventLoop::current().take_pending_events_from(m_event_loop);
         }

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -302,7 +302,8 @@ private:
 };
 
 EventLoop::EventLoop([[maybe_unused]] MakeInspectable make_inspectable)
-    : m_private(make<Private>())
+    : m_wake_pipe_fds(&s_wake_pipe_fds)
+    , m_private(make<Private>())
 {
 #ifdef __serenity__
     if (!s_global_initializers_ran) {
@@ -487,11 +488,13 @@ size_t EventLoop::pump(WaitMode mode)
     return processed_events;
 }
 
-void EventLoop::post_event(Object& receiver, NonnullOwnPtr<Event>&& event)
+void EventLoop::post_event(Object& receiver, NonnullOwnPtr<Event>&& event, ShouldWake should_wake)
 {
     Threading::MutexLocker lock(m_private->lock);
     dbgln_if(EVENTLOOP_DEBUG, "Core::EventLoop::post_event: ({}) << receiver={}, event={}", m_queued_events.size(), receiver, event);
     m_queued_events.empend(receiver, move(event));
+    if (should_wake == ShouldWake::Yes)
+        wake();
 }
 
 SignalHandlers::SignalHandlers(int signo, void (*handle_signal)(int))
@@ -839,10 +842,16 @@ void EventLoop::unregister_notifier(Badge<Notifier>, Notifier& notifier)
     s_notifiers->remove(&notifier);
 }
 
+void EventLoop::wake_current()
+{
+    EventLoop::current().wake();
+}
+
 void EventLoop::wake()
 {
+    dbgln_if(EVENTLOOP_DEBUG, "Core::EventLoop::wake()");
     int wake_event = 0;
-    int nwritten = write(s_wake_pipe_fds[1], &wake_event, sizeof(wake_event));
+    int nwritten = write((*m_wake_pipe_fds)[1], &wake_event, sizeof(wake_event));
     if (nwritten < 0) {
         perror("EventLoop::wake: write");
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibThreading/BackgroundAction.h
+++ b/Userland/Libraries/LibThreading/BackgroundAction.h
@@ -63,7 +63,7 @@ private:
                     m_on_complete(m_result.release_value());
                     remove_from_parent();
                 });
-                Core::EventLoop::wake();
+                origin_event_loop->wake();
             } else {
                 this->remove_from_parent();
             }


### PR DESCRIPTION
Two bugfixes related to multi-threaded event loops.

1. Fix event loop stacks on non-main thread. The event loop stack was previously only created on the main thread.
2. Fix event loop waking across threads, and add an option to post_event to wake the event loop.