### PR TITLE
LibConfig: Rename pledge_domains(String) => pledge_domain(String)

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -235,7 +235,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domains("AudioApplet");
+    Config::pledge_domain("AudioApplet");
     TRY(Core::System::unveil("/tmp/portal/audio", "rw"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -20,7 +20,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
     auto app = GUI::Application::construct(arguments);
 
-    Config::pledge_domains("ClipboardHistory");
+    Config::pledge_domain("ClipboardHistory");
     Config::monitor_domain("ClipboardHistory");
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -64,7 +64,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = GUI::Application::construct(arguments);
 
-    Config::pledge_domains("Browser");
+    Config::pledge_domain("Browser");
 
     // Connect to LaunchServer immediately and let it know that we won't ask for anything other than opening
     // the user's downloads directory.

--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -16,7 +16,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domains("Browser");
+    Config::pledge_domain("Browser");
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/home", "r"));

--- a/Userland/Applications/CharacterMap/main.cpp
+++ b/Userland/Applications/CharacterMap/main.cpp
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domains("CharacterMap");
+    Config::pledge_domain("CharacterMap");
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/CharacterMap.md") }));
     TRY(Desktop::Launcher::seal_allowlist());

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath unix"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domains("WindowManager");
+    Config::pledge_domain("WindowManager");
 
     auto app_icon = GUI::Icon::default_icon("app-display-settings");
 

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/FontEditor.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    Config::pledge_domains("FontEditor");
+    Config::pledge_domain("FontEditor");
     Config::monitor_domain("FontEditor");
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath"));
 

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("HexEditor");
+    Config::pledge_domain("HexEditor");
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-hex-editor"));
 

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -18,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath recvfd sendfd unix proc exec"));
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domains("KeyboardSettings");
+    Config::pledge_domain("KeyboardSettings");
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd proc exec"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = GUI::Application::construct(arguments);
 
-    Config::pledge_domains("Mail");
+    Config::pledge_domain("Mail");
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc", "r"));

--- a/Userland/Applications/MailSettings/main.cpp
+++ b/Userland/Applications/MailSettings/main.cpp
@@ -19,7 +19,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("Mail");
+    Config::pledge_domain("Mail");
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix wpath cpath"));
 
     auto app = GUI::Application::construct(arguments);
-    Config::pledge_domains("PixelPaint");
+    Config::pledge_domain("PixelPaint");
 
     const char* image_file = nullptr;
     Core::ArgsParser args_parser;

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -107,7 +107,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("SystemMonitor");
+    Config::pledge_domain("SystemMonitor");
 
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -245,7 +245,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio tty rpath cpath wpath recvfd sendfd proc exec unix"));
 
-    Config::pledge_domains("Terminal");
+    Config::pledge_domain("Terminal");
 
     const char* command_to_execute = nullptr;
     bool keep_open = false;

--- a/Userland/Applications/TerminalSettings/main.cpp
+++ b/Userland/Applications/TerminalSettings/main.cpp
@@ -18,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domains("Terminal");
+    Config::pledge_domain("Terminal");
 
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("TextEditor");
+    Config::pledge_domain("TextEditor");
 
     char const* preview_mode = "auto";
     char const* file_to_edit = nullptr;

--- a/Userland/Applications/Welcome/main.cpp
+++ b/Userland/Applications/Welcome/main.cpp
@@ -18,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc exec"));
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("SystemServer");
+    Config::pledge_domain("SystemServer");
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/home", "r"));

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -37,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::Window::try_create());
 
-    Config::pledge_domains("2048");
+    Config::pledge_domain("2048");
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/2048.md") }));
     TRY(Desktop::Launcher::seal_allowlist());

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("Chess");
+    Config::pledge_domain("Chess");
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Chess.md") }));
     TRY(Desktop::Launcher::seal_allowlist());

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("FlappyBug");
+    Config::pledge_domain("FlappyBug");
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/FlappyBug.md") }));
     TRY(Desktop::Launcher::seal_allowlist());

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-hearts"));
 
-    Config::pledge_domains("Hearts");
+    Config::pledge_domain("Hearts");
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
 

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -30,7 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("Minesweeper");
+    Config::pledge_domain("Minesweeper");
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Minesweeper.md") }));
     TRY(Desktop::Launcher::seal_allowlist());

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    Config::pledge_domains("Snake");
+    Config::pledge_domain("Snake");
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Snake.md") }));
     TRY(Desktop::Launcher::seal_allowlist());

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-solitaire"));
 
-    Config::pledge_domains("Solitaire");
+    Config::pledge_domain("Solitaire");
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
 

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -44,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-spider"));
 
-    Config::pledge_domains("Spider");
+    Config::pledge_domain("Spider");
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
 

--- a/Userland/Libraries/LibConfig/Client.h
+++ b/Userland/Libraries/LibConfig/Client.h
@@ -100,9 +100,9 @@ inline void pledge_domains(Vector<String> const& domains)
     Client::the().pledge_domains(domains);
 }
 
-inline void pledge_domains(String const& domains)
+inline void pledge_domain(String const& domain)
 {
-    Client::the().pledge_domains({ domains });
+    Client::the().pledge_domains({ domain });
 }
 
 inline void monitor_domain(String const& domain)

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -39,7 +39,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath unix sigaction"));
     auto app = TRY(GUI::Application::try_create(arguments));
-    Config::pledge_domains("Taskbar");
+    Config::pledge_domain("Taskbar");
     Config::monitor_domain("Taskbar");
     app->event_loop().register_signal(SIGCHLD, [](int) {
         // Wait all available children


### PR DESCRIPTION
pledge_domains() that takes only one String argument was specifically
added as a shortcut for pledging a single domain. So, it makes sense to
use singular here.