### PR TITLE
LibWeb: Ignore malformed at-rules in CSS parser

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1934,8 +1934,10 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
 
             auto media_query_tokens = TokenStream { rule->prelude() };
             auto media_query_list = parse_a_media_query_list(media_query_tokens);
+            if (media_query_list.is_empty() || !rule->block())
+                return {};
 
-            auto child_tokens = TokenStream { rule->block().values() };
+            auto child_tokens = TokenStream { rule->block()->values() };
             auto parser_rules = consume_a_list_of_rules(child_tokens, false);
             NonnullRefPtrVector<CSSRule> child_rules;
             for (auto& raw_rule : parser_rules) {
@@ -1980,7 +1982,9 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
                 return {};
             }
 
-            auto child_tokens = TokenStream { rule->block().values() };
+            if (!rule->block())
+                return {};
+            auto child_tokens = TokenStream { rule->block()->values() };
             auto parser_rules = consume_a_list_of_rules(child_tokens, false);
             NonnullRefPtrVector<CSSRule> child_rules;
             for (auto& raw_rule : parser_rules) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRule.h
@@ -27,7 +27,7 @@ public:
     ~StyleRule();
 
     Vector<StyleComponentValueRule> const& prelude() const { return m_prelude; }
-    StyleBlockRule const& block() const { return *m_block; }
+    RefPtr<StyleBlockRule> const block() const { return m_block; }
 
     String to_string() const;
 


### PR DESCRIPTION
Fixes #12405.