### PR TITLE
Kernel/Audio+Userland: Introduce a new design architecture for the subsystem

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -46,6 +46,8 @@ set(KERNEL_SOURCES
     Coredump.cpp
     Devices/AsyncDeviceRequest.cpp
     Devices/Audio/AC97.cpp
+    Devices/Audio/Channel.cpp
+    Devices/Audio/Management.cpp
     Devices/Audio/SB16.cpp
     Devices/BlockDevice.cpp
     Devices/CharacterDevice.cpp

--- a/Kernel/Devices/Audio/Channel.cpp
+++ b/Kernel/Devices/Audio/Channel.cpp
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Devices/Audio/Management.h>
+#include <Kernel/Devices/DeviceManagement.h>
+#include <Kernel/Devices/RandomDevice.h>
+#include <Kernel/Random.h>
+#include <Kernel/Sections.h>
+#include <LibC/sys/ioctl_numbers.h>
+
+namespace Kernel {
+
+UNMAP_AFTER_INIT NonnullRefPtr<AudioChannel> AudioChannel::must_create(AudioController const& controller, size_t channel_index)
+{
+    auto audio_device_or_error = DeviceManagement::try_create_device<AudioChannel>(controller, channel_index);
+    // FIXME: Find a way to propagate errors
+    VERIFY(!audio_device_or_error.is_error());
+    return audio_device_or_error.release_value();
+}
+
+AudioChannel::AudioChannel(AudioController const& controller, size_t channel_index)
+    : CharacterDevice(AudioManagement::the().audio_type_major_number(), AudioManagement::the().generate_storage_minor_number())
+    , m_controller(controller)
+    , m_channel_index(channel_index)
+{
+}
+
+ErrorOr<void> AudioChannel::ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg)
+{
+    auto controller = m_controller.strong_ref();
+    if (!controller)
+        return Error::from_errno(EIO);
+    switch (request) {
+    case SOUNDCARD_IOCTL_GET_SAMPLE_RATE: {
+        auto output = static_ptr_cast<u32*>(arg);
+        u32 sample_rate = 0;
+        sample_rate = TRY(controller->get_pcm_output_sample_rate(m_channel_index));
+        return copy_to_user(output, &sample_rate);
+    }
+    case SOUNDCARD_IOCTL_SET_SAMPLE_RATE: {
+        auto sample_rate = static_cast<u32>(arg.ptr());
+        TRY(controller->set_pcm_output_sample_rate(m_channel_index, sample_rate));
+        return {};
+    }
+    default:
+        return EINVAL;
+    }
+}
+
+bool AudioChannel::can_read(const OpenFileDescription&, u64) const
+{
+    // FIXME: Implement input from device
+    return false;
+}
+
+ErrorOr<size_t> AudioChannel::read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t)
+{
+    // FIXME: Implement input from device
+    return Error::from_errno(ENOTIMPL);
+}
+
+ErrorOr<size_t> AudioChannel::write(OpenFileDescription&, u64, UserOrKernelBuffer const& buffer, size_t size)
+{
+    auto controller = m_controller.strong_ref();
+    if (!controller)
+        return Error::from_errno(EIO);
+    return controller->write(m_channel_index, buffer, size);
+}
+
+}

--- a/Kernel/Devices/Audio/Channel.h
+++ b/Kernel/Devices/Audio/Channel.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Devices/CharacterDevice.h>
+#include <Kernel/Interrupts/IRQHandler.h>
+#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/PhysicalAddress.h>
+#include <Kernel/WaitQueue.h>
+
+namespace Kernel {
+
+class AudioController;
+class AudioChannel final
+    : public CharacterDevice {
+    friend class DeviceManagement;
+
+public:
+    static NonnullRefPtr<AudioChannel> must_create(AudioController const&, size_t channel_index);
+    virtual ~AudioChannel() override { }
+
+    // ^CharacterDevice
+    virtual bool can_read(const OpenFileDescription&, u64) const override;
+    virtual ErrorOr<size_t> read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t) override;
+    virtual ErrorOr<size_t> write(OpenFileDescription&, u64, const UserOrKernelBuffer&, size_t) override;
+    virtual bool can_write(const OpenFileDescription&, u64) const override { return true; }
+
+    virtual ErrorOr<void> ioctl(OpenFileDescription&, unsigned, Userspace<void*>) override;
+
+private:
+    AudioChannel(AudioController const&, size_t channel_index);
+
+    // ^CharacterDevice
+    virtual StringView class_name() const override { return "AudioChannel"sv; }
+
+    WeakPtr<AudioController> m_controller;
+    const size_t m_channel_index;
+};
+}

--- a/Kernel/Devices/Audio/Controller.h
+++ b/Kernel/Devices/Audio/Controller.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/IntrusiveList.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Weakable.h>
+#include <Kernel/Bus/PCI/Access.h>
+#include <Kernel/Bus/PCI/Device.h>
+#include <Kernel/Devices/Audio/Channel.h>
+#include <Kernel/Devices/Device.h>
+#include <Kernel/Locking/Mutex.h>
+#include <Kernel/Memory/PhysicalPage.h>
+#include <Kernel/PhysicalAddress.h>
+#include <Kernel/Random.h>
+
+namespace Kernel {
+
+class AudioManagement;
+class AudioController
+    : public RefCounted<AudioController>
+    , public Weakable<AudioController> {
+    friend class AudioManagement;
+
+public:
+    virtual ~AudioController() = default;
+
+    virtual RefPtr<AudioChannel> audio_channel(u32 index) const = 0;
+    virtual ErrorOr<size_t> write(size_t channel_index, UserOrKernelBuffer const& data, size_t length) = 0;
+
+    virtual void detect_hardware_audio_channels(Badge<AudioManagement>) = 0;
+
+    virtual ErrorOr<void> set_pcm_output_sample_rate(size_t channel_index, u32 samples_per_second_rate) = 0;
+    // Note: The return value is rate of samples per second
+    virtual ErrorOr<u32> get_pcm_output_sample_rate(size_t channel_index) = 0;
+
+private:
+    IntrusiveListNode<AudioController, RefPtr<AudioController>> m_node;
+};
+}

--- a/Kernel/Devices/Audio/Management.cpp
+++ b/Kernel/Devices/Audio/Management.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Singleton.h>
+#include <Kernel/Bus/PCI/API.h>
+#include <Kernel/Bus/PCI/IDs.h>
+#include <Kernel/Devices/Audio/AC97.h>
+#include <Kernel/Devices/Audio/Management.h>
+#include <Kernel/Devices/Audio/SB16.h>
+#include <Kernel/Sections.h>
+
+namespace Kernel {
+
+static Singleton<AudioManagement> s_the;
+static Atomic<u32> s_device_minor_number;
+
+MajorNumber AudioManagement::audio_type_major_number()
+{
+    return 116;
+}
+MinorNumber AudioManagement::generate_storage_minor_number()
+{
+    auto minor_number = s_device_minor_number.load();
+    s_device_minor_number++;
+    return minor_number;
+}
+
+AudioManagement& AudioManagement::the()
+{
+    return *s_the;
+}
+
+UNMAP_AFTER_INIT AudioManagement::AudioManagement()
+{
+}
+
+UNMAP_AFTER_INIT void AudioManagement::enumerate_hardware_controllers()
+{
+    if (auto controller = SB16::try_detect_and_create(); !controller.is_error())
+        m_controllers_list.append(controller.release_value());
+
+    PCI::enumerate([&](PCI::DeviceIdentifier const& device_identifier) {
+        // Note: Only consider PCI audio controllers
+        if (device_identifier.class_code().value() != to_underlying(PCI::ClassID::Multimedia)
+            || device_identifier.subclass_code().value() != to_underlying(PCI::Multimedia::SubclassID::AudioController))
+            return;
+
+        dbgln("AC97: found audio controller at {}", device_identifier.address());
+        // FIXME: Propagate errors properly
+        m_controllers_list.append(AC97::try_create(device_identifier).release_value());
+    });
+}
+
+UNMAP_AFTER_INIT void AudioManagement::enumerate_hardware_audio_channels()
+{
+    for (auto& controller : m_controllers_list)
+        controller.detect_hardware_audio_channels({});
+}
+
+UNMAP_AFTER_INIT bool AudioManagement::initialize()
+{
+
+    /* Explanation on the flow:
+     * 1. Enumerate all audio controllers connected to the system:
+     *  a. Try to find the SB16 ISA-based controller.
+     *  b. Enumerate the PCI bus and try to find audio controllers there too
+     * 2. Ask each controller to detect the audio channels and instantiate AudioChannel objects.
+     */
+    enumerate_hardware_controllers();
+    enumerate_hardware_audio_channels();
+
+    if (m_controllers_list.is_empty()) {
+        dbgln("No audio controller was initialized.");
+        return false;
+    }
+    return true;
+}
+
+}

--- a/Kernel/Devices/Audio/Management.h
+++ b/Kernel/Devices/Audio/Management.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Badge.h>
+#include <AK/Error.h>
+#include <AK/IntrusiveList.h>
+#include <AK/OwnPtr.h>
+#include <AK/RefPtr.h>
+#include <AK/Time.h>
+#include <AK/Types.h>
+#include <Kernel/Devices/Audio/Controller.h>
+
+namespace Kernel {
+
+class AudioManagement {
+
+public:
+    AudioManagement();
+    static AudioManagement& the();
+
+    static MajorNumber audio_type_major_number();
+    static MinorNumber generate_storage_minor_number();
+
+    bool initialize();
+
+private:
+    void enumerate_hardware_controllers();
+    void enumerate_hardware_audio_channels();
+
+    IntrusiveList<&AudioController::m_node> m_controllers_list;
+};
+
+}

--- a/Kernel/Devices/Audio/SB16.cpp
+++ b/Kernel/Devices/Audio/SB16.cpp
@@ -62,8 +62,6 @@ void SB16::set_sample_rate(uint16_t hz)
 
 UNMAP_AFTER_INIT SB16::SB16()
     : IRQHandler(SB16_DEFAULT_IRQ)
-    // FIXME: We can't change version numbers later, i.e. after the sound card is initialized.
-    , CharacterDevice(42, 42)
 {
     initialize();
 }
@@ -72,7 +70,7 @@ UNMAP_AFTER_INIT SB16::~SB16()
 {
 }
 
-UNMAP_AFTER_INIT RefPtr<SB16> SB16::try_detect_and_create()
+UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<SB16>> SB16::try_detect_and_create()
 {
     IO::out8(0x226, 1);
     IO::delay(32);
@@ -80,13 +78,8 @@ UNMAP_AFTER_INIT RefPtr<SB16> SB16::try_detect_and_create()
 
     auto data = dsp_read();
     if (data != 0xaa)
-        return {};
-    auto device_or_error = DeviceManagement::try_create_device<SB16>();
-    if (device_or_error.is_error())
-        return {};
-    auto device = device_or_error.release_value();
-    DeviceManagement::the().attach_audio_device(device);
-    return device;
+        return Error::from_errno(ENODEV);
+    return adopt_nonnull_ref_or_enomem(new (nothrow) SB16());
 }
 
 UNMAP_AFTER_INIT void SB16::initialize()
@@ -113,27 +106,6 @@ UNMAP_AFTER_INIT void SB16::initialize()
     dmesgln("SB16: IRQ {}", get_irq_line());
 
     set_sample_rate(m_sample_rate);
-}
-
-ErrorOr<void> SB16::ioctl(OpenFileDescription&, unsigned request, Userspace<void*> arg)
-{
-    switch (request) {
-    case SOUNDCARD_IOCTL_GET_SAMPLE_RATE: {
-        auto output = static_ptr_cast<u16*>(arg);
-        return copy_to_user(output, &m_sample_rate);
-    }
-    case SOUNDCARD_IOCTL_SET_SAMPLE_RATE: {
-        auto sample_rate_input = static_cast<u32>(arg.ptr());
-        if (sample_rate_input == 0 || sample_rate_input > 44100)
-            return ENOTSUP;
-        auto sample_rate_value = static_cast<u16>(sample_rate_input);
-        if (m_sample_rate != sample_rate_value)
-            set_sample_rate(sample_rate_value);
-        return {};
-    }
-    default:
-        return EINVAL;
-    }
 }
 
 void SB16::set_irq_register(u8 irq_number)
@@ -182,16 +154,6 @@ void SB16::set_irq_line(u8 irq_number)
         return;
     set_irq_register(irq_number);
     change_irq_number(irq_number);
-}
-
-bool SB16::can_read(OpenFileDescription const&, u64) const
-{
-    return false;
-}
-
-ErrorOr<size_t> SB16::read(OpenFileDescription&, u64, UserOrKernelBuffer&, size_t)
-{
-    return 0;
 }
 
 void SB16::dma_start(uint32_t length)
@@ -249,8 +211,41 @@ void SB16::wait_for_irq()
     disable_irq();
 }
 
-ErrorOr<size_t> SB16::write(OpenFileDescription&, u64, UserOrKernelBuffer const& data, size_t length)
+RefPtr<AudioChannel> SB16::audio_channel(u32 index) const
 {
+    if (index == 0)
+        return m_audio_channel;
+    return {};
+}
+void SB16::detect_hardware_audio_channels(Badge<AudioManagement>)
+{
+    m_audio_channel = AudioChannel::must_create(*this, 0);
+}
+
+ErrorOr<void> SB16::set_pcm_output_sample_rate(size_t channel_index, u32 samples_per_second_rate)
+{
+    if (channel_index != 0)
+        return Error::from_errno(ENODEV);
+    if (samples_per_second_rate == 0 || samples_per_second_rate > 44100)
+        return Error::from_errno(ENOTSUP);
+    auto sample_rate_value = static_cast<u16>(samples_per_second_rate);
+    if (m_sample_rate != sample_rate_value)
+        set_sample_rate(sample_rate_value);
+    return {};
+}
+
+ErrorOr<u32> SB16::get_pcm_output_sample_rate(size_t channel_index)
+{
+    if (channel_index != 0)
+        return Error::from_errno(ENODEV);
+    return m_sample_rate;
+}
+
+ErrorOr<size_t> SB16::write(size_t channel_index, UserOrKernelBuffer const& data, size_t length)
+{
+    if (channel_index != 0)
+        return Error::from_errno(ENODEV);
+
     if (!m_dma_region) {
         m_dma_region = TRY(MM.allocate_dma_buffer_page("SB16 DMA buffer", Memory::Region::Access::Write));
     }

--- a/Kernel/Devices/Audio/SB16.cpp
+++ b/Kernel/Devices/Audio/SB16.cpp
@@ -252,9 +252,7 @@ ErrorOr<size_t> SB16::write(size_t channel_index, UserOrKernelBuffer const& data
 
     dbgln_if(SB16_DEBUG, "SB16: Writing buffer of {} bytes", length);
 
-    VERIFY(length <= PAGE_SIZE);
-    int const BLOCK_SIZE = 32 * 1024;
-    if (length > BLOCK_SIZE) {
+    if (length > PAGE_SIZE) {
         return ENOSPC;
     }
 

--- a/Kernel/Devices/DeviceManagement.cpp
+++ b/Kernel/Devices/DeviceManagement.cpp
@@ -22,11 +22,6 @@ UNMAP_AFTER_INIT void DeviceManagement::initialize()
     s_the.ensure_instance();
 }
 
-UNMAP_AFTER_INIT void DeviceManagement::attach_audio_device(CharacterDevice const& device)
-{
-    m_audio_devices.append(device);
-}
-
 UNMAP_AFTER_INIT void DeviceManagement::attach_console_device(ConsoleDevice const& device)
 {
     m_console_device = device;

--- a/Kernel/Devices/DeviceManagement.h
+++ b/Kernel/Devices/DeviceManagement.h
@@ -38,9 +38,6 @@ public:
     bool is_console_device_attached() const { return !m_console_device.is_null(); }
     void attach_console_device(ConsoleDevice const&);
 
-    // FIXME: Once we have a singleton for managing many sound cards, remove this from here
-    void attach_audio_device(CharacterDevice const&);
-
     Optional<DeviceEvent> dequeue_top_device_event(Badge<DeviceControlDevice>);
 
     void after_inserting_device(Badge<Device>, Device&);
@@ -76,7 +73,6 @@ private:
     RefPtr<ConsoleDevice> m_console_device;
     RefPtr<DeviceControlDevice> m_device_control_device;
     // FIXME: Once we have a singleton for managing many sound cards, remove this from here
-    NonnullRefPtrVector<CharacterDevice, 1> m_audio_devices;
     SpinlockProtected<HashMap<u64, Device*>> m_devices;
 
     mutable Spinlock m_event_queue_lock;

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -13,8 +13,7 @@
 #include <Kernel/Bus/VirtIO/Device.h>
 #include <Kernel/CMOS.h>
 #include <Kernel/CommandLine.h>
-#include <Kernel/Devices/Audio/AC97.h>
-#include <Kernel/Devices/Audio/SB16.h>
+#include <Kernel/Devices/Audio/Management.h>
 #include <Kernel/Devices/DeviceControlDevice.h>
 #include <Kernel/Devices/DeviceManagement.h>
 #include <Kernel/Devices/FullDevice.h>
@@ -339,8 +338,7 @@ void init_stage2(void*)
     (void)RandomDevice::must_create().leak_ref();
     PTYMultiplexer::initialize();
 
-    (void)SB16::try_detect_and_create();
-    AC97::detect();
+    AudioManagement::the().initialize();
 
     StorageManagement::the().initialize(kernel_command_line().root_device(), kernel_command_line().is_force_pio(), kernel_command_line().is_nvme_polling_enabled());
     if (VirtualFileSystem::the().mount_root(StorageManagement::the().root_filesystem()).is_error()) {

--- a/Userland/Services/AudioServer/Mixer.cpp
+++ b/Userland/Services/AudioServer/Mixer.cpp
@@ -23,7 +23,8 @@ namespace AudioServer {
 u8 Mixer::m_zero_filled_buffer[4096];
 
 Mixer::Mixer(NonnullRefPtr<Core::ConfigFile> config)
-    : m_device(Core::File::construct("/dev/audio", this))
+    // FIXME: Allow AudioServer to use other audio channels as well
+    : m_device(Core::File::construct("/dev/audio/0", this))
     , m_sound_thread(Threading::Thread::construct(
           [this] {
               mix();

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -100,6 +100,23 @@ static void chmod_wrapper(const char* path, mode_t mode)
     }
 }
 
+static void chown_all_matching_device_nodes_under_specific_directory(StringView directory, group* group)
+{
+    VERIFY(group);
+    struct stat cur_file_stat;
+
+    Core::DirIterator di(directory, Core::DirIterator::SkipParentAndBaseDir);
+    if (di.has_error())
+        VERIFY_NOT_REACHED();
+    while (di.has_next()) {
+        auto entry_name = di.next_full_path();
+        auto rc = stat(entry_name.characters(), &cur_file_stat);
+        if (rc < 0)
+            continue;
+        chown_wrapper(entry_name.characters(), 0, group->gr_gid);
+    }
+}
+
 static void chown_all_matching_device_nodes(group* group, unsigned major_number)
 {
     VERIFY(group);
@@ -186,16 +203,10 @@ static void populate_devtmpfs_devices_based_on_devctl()
         auto minor_number = event.minor_number;
         bool is_block_device = (event.is_block_device == 1);
         switch (major_number) {
-        case 42: {
+        case 116: {
             if (!is_block_device) {
-                switch (minor_number) {
-                case 42: {
-                    create_devtmpfs_char_device("/dev/audio", 0220, 42, 42);
-                    break;
-                }
-                default:
-                    warnln("Unknown character device {}:{}", major_number, minor_number);
-                }
+                create_devtmpfs_char_device(String::formatted("/dev/audio/{}", minor_number), 0220, 116, minor_number);
+                break;
             }
             break;
         }
@@ -373,6 +384,11 @@ static ErrorOr<void> prepare_synthetic_filesystems()
     TRY(Core::System::mount(-1, "/sys", "sys", 0));
     TRY(Core::System::mount(-1, "/dev", "dev", 0));
 
+    // FIXME: Find out why on creating the /dev/audio directory we must do chmod it too
+    // instead of one syscall.
+    TRY(Core::System::mkdir("/dev/audio", 0755));
+    TRY(Core::System::chmod("/dev/audio", 0755));
+
     TRY(Core::System::symlink("/proc/self/fd/0", "/dev/stdin"));
     TRY(Core::System::symlink("/proc/self/fd/1", "/dev/stdout"));
     TRY(Core::System::symlink("/proc/self/fd/2", "/dev/stderr"));
@@ -405,6 +421,7 @@ static ErrorOr<void> prepare_synthetic_filesystems()
     auto audio_group = getgrnam("audio");
     VERIFY(audio_group);
     chown_wrapper("/dev/audio", 0, audio_group->gr_gid);
+    chown_all_matching_device_nodes_under_specific_directory("/dev/audio", audio_group);
 
     // Note: We open the /dev/null device and set file descriptors 0, 1, 2 to it
     // because otherwise these file descriptors won't have a custody, making


### PR DESCRIPTION
We have 3 new components in the Kernel:
1. The `AudioManagement` singleton. This class like in other subsystems,
is responsible to find hardware audio controllers and keep a reference
to them.
2. `AudioController` class - this class is the parent class for hardware
controllers like the Sound Blaster 16 or Intel 82801AA (AC97). For now,
this class has simple interface for getting and controlling sample rate
of audio channels, as well a write interface for specific audio channel
but not reading from it. One `AudioController` object might have multiple
`AudioChannel` "child" objects to hold with reference counting.
3. `AudioChannel` class - this is based on the `CharacterDevice` class, and
represents hardware PCM audio channel. It facilitates an ioctl interface
which should be consistent across all supported hardware currently.
It has a weak reference to a parent `AudioController`, and when trying to
write to a channel, it redirects the data to the parent `AudioController`.
Each audio channel device should be added into a new directory under the
/dev filesystem called "audio".

The AudioServer `Mixer` code is adapted to use the first discovered audio channel. This will change in the (hopefully near) future :)

cc @kleinesfilmroellchen 