### PR TITLE
LibHTTP: Fix GET request stall when response body is small and does not contain a newline

### DIFF
--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -316,12 +316,6 @@ void Job::on_socket_connected()
                 if (m_code == 204)
                     return finish_up();
 
-                can_read_line = m_socket->can_read_line();
-                if (can_read_line.is_error())
-                    return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-
-                if (!can_read_line.value())
-                    return;
                 break;
             }
             auto parts = line.split_view(':');

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -380,12 +380,6 @@ void Job::on_socket_connected()
         }
         VERIFY(m_state == State::InBody);
 
-        auto can_read_without_blocking = m_socket->can_read_without_blocking();
-        if (can_read_without_blocking.is_error())
-            return deferred_invoke([this] { did_fail(Core::NetworkJob::Error::TransmissionFailed); });
-        if (!can_read_without_blocking.value())
-            return;
-
         while (true) {
             auto can_read_without_blocking = m_socket->can_read_without_blocking();
             if (can_read_without_blocking.is_error())


### PR DESCRIPTION
I tested a web application I'm building in the Serenity Browser but my pages would not load. I traced the problem down to an attempt to read a line after the blank line between the response headers and body was received. My web application was sending back a small body that did not contain any new line characters and the request would stall and never load. 

```
HTTP/1.1 200 OK
content-type: text/plain;charset=UTF-8
content-length: 11
date: Fri, 11 Feb 2022 21:52:50 GMT
                                  ◄───────── Attempt to read line here
Hello World     ◄───────────────┐
                                └─────────── Body does not end in new line
```

The backtrace of the stalled state is:

```
[/bin/RequestServer] Core::Stream::BufferedHelper<Core::Stream::TCPSocket>::populate_read_buffer() +0x1ba (Stream.h:697)
[/bin/RequestServer] Core::Stream::BufferedHelper<Core::Stream::TCPSocket>::can_read_line() +0x193 (Stream.h:650)
[/bin/RequestServer] Core::Stream::BufferedSocket<Core::Stream::TCPSocket>::can_read_line() +0x2e (Stream.h:837)
[libhttp.so.serenity] HTTP::Job::on_socket_connected()::{lambda()#2}::operator()() const +0x26d9 (Job.cpp:326)
[libhttp.so.serenity] AK::Function<void ()>::CallableWrapper<HTTP::Job::register_on_ready_to_read(AK::Function<void ()>)::{lambda()#1}>::call() +0x67 (Function.h:91)
[/bin/RequestServer] AK::Function<void ()>::CallableWrapper<Core::Stream::BufferedSocket<Core::Stream::TCPSocket>::setup_notifier()::{lambda()#1}>::call() +0x58 (Function.h:91)
[libcore.so.serenity] AK::Function<void ()>::CallableWrapper<Core::Stream::TCPSocket::setup_notifier()::{lambda()#1}>::call() +0x58 (Function.h:91)
[libcore.so.serenity] Core::Notifier::event(Core::Event&) +0x99 (Function.h:91)
[libcore.so.serenity] Core::Object::dispatch_event(Core::Event&, Core::Object*) +0xb0 (Object.cpp:219)
[libcore.so.serenity] Core::EventLoop::pump(Core::EventLoop::WaitMode) [clone .localalias] +0x192 (EventLoop.cpp:470)
[libcore.so.serenity] Core::EventLoop::exec() +0x8a (EventLoop.cpp:427)
[/bin/RequestServer] serenity_main(Main::Arguments) +0x1fb (main.cpp:51)
[libmain.so.serenity] main +0x77 (Main.cpp:23)
[/bin/RequestServer] _entry +0x65 (crt0.cpp:49)
```

The issue can be reproduced with this small web server: https://gist.github.com/wezm/d698e0c888016469dab8a100a454195a that can be run with [Deno] as follows:

```
deno run --allow-net https://gist.github.com/wezm/d698e0c888016469dab8a100a454195a/raw/b33d433c6a91f87071a51021c375a863c9cba28d/repro.ts
```

Booting Serenity, opening the browser and accessing `http://<your-host-ip>:8001` reliably stalls for me.

Examining the code and git history it's not clear to me why the call to  `can_read_line` is needed. Removing it allows the response handler to transition into the body reading loop and successfully complete.

Whilst following that code through I also noticed that after entering the body reading state there is a call to `can_read_without_blocking` that is immediately followed by exactly the same code (inside the body reading loop). I've deleted this too.

[Deno]: https://deno.land/
