### PR TITLE
LibWeb+LibTextCodec: Respect the reported charset in XHR text and add support for the x-user-defined charset

### DIFF
--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -70,4 +70,7 @@ public:
 Decoder* decoder_for(String const& encoding);
 Optional<String> get_standardized_encoding(const String& encoding);
 
+// This returns the appropriate Unicode decoder for the sniffed BOM or nullptr if there is no appropriate decoder.
+Decoder* bom_sniff_to_decoder(StringView);
+
 }

--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -73,4 +73,8 @@ Optional<String> get_standardized_encoding(const String& encoding);
 // This returns the appropriate Unicode decoder for the sniffed BOM or nullptr if there is no appropriate decoder.
 Decoder* bom_sniff_to_decoder(StringView);
 
+// NOTE: This has an obnoxious name to discourage usage. Only use this if you absolutely must! For example, XHR in LibWeb uses this.
+// This will use the given decoder unless there is a byte order mark in the input, in which we will instead use the appropriate Unicode decoder.
+String convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(Decoder&, StringView);
+
 }

--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -67,6 +67,11 @@ public:
     virtual void process(StringView, Function<void(u32)> on_code_point) override;
 };
 
+class XUserDefinedDecoder final : public Decoder {
+public:
+    virtual void process(StringView, Function<void(u32)> on_code_point) override;
+};
+
 Decoder* decoder_for(String const& encoding);
 Optional<String> get_standardized_encoding(const String& encoding);
 

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -93,6 +93,7 @@ set(SOURCES
     DOMTreeModel.cpp
     Dump.cpp
     Encoding/TextEncoder.cpp
+    Fetch/AbstractOperations.cpp
     FontCache.cpp
     HTML/AttributeNames.cpp
     HTML/BrowsingContext.cpp
@@ -252,6 +253,7 @@ set(SOURCES
     Loader/LoadRequest.cpp
     Loader/Resource.cpp
     Loader/ResourceLoader.cpp
+    MimeSniff/MimeType.cpp
     Namespace.cpp
     NavigationTiming/PerformanceTiming.cpp
     OutOfProcessWebView.cpp

--- a/Userland/Libraries/LibWeb/Fetch/AbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Fetch/AbstractOperations.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/GenericLexer.h>
+#include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <LibWeb/Fetch/AbstractOperations.h>
+
+namespace Web::Fetch {
+
+// https://fetch.spec.whatwg.org/#collect-an-http-quoted-string
+String collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStringExtractValue extract_value)
+{
+    // To collect an HTTP quoted string from a string input, given a position variable position and optionally an extract-value flag, run these steps:
+    // 1. Let positionStart be position.
+    auto position_start = lexer.tell();
+
+    // 2. Let value be the empty string.
+    StringBuilder value;
+
+    // 3. Assert: the code point at position within input is U+0022 (").
+    VERIFY(lexer.peek() == '"');
+
+    // 4. Advance position by 1.
+    lexer.ignore(1);
+
+    // 5. While true:
+    while (true) {
+        // 1. Append the result of collecting a sequence of code points that are not U+0022 (") or U+005C (\) from input, given position, to value.
+        auto value_part = lexer.consume_until([](char ch) {
+            return ch == '"' || ch == '\\';
+        });
+
+        value.append(value_part);
+
+        // 2. If position is past the end of input, then break.
+        if (lexer.is_eof())
+            break;
+
+        // 3. Let quoteOrBackslash be the code point at position within input.
+        // 4. Advance position by 1.
+        char quote_or_backslash = lexer.consume();
+
+        // 5. If quoteOrBackslash is U+005C (\), then:
+        if (quote_or_backslash == '\\') {
+            // 1. If position is past the end of input, then append U+005C (\) to value and break.
+            if (lexer.is_eof()) {
+                value.append('\\');
+                break;
+            }
+
+            // 2. Append the code point at position within input to value.
+            // 3. Advance position by 1.
+            value.append(lexer.consume());
+        }
+
+        // 6. Otherwise:
+        else {
+            // 1. Assert: quoteOrBackslash is U+0022 (").
+            VERIFY(quote_or_backslash == '"');
+
+            // 2. Break.
+            break;
+        }
+    }
+
+    // 6. If the extract-value flag is set, then return value.
+    if (extract_value == HttpQuotedStringExtractValue::Yes)
+        return value.to_string();
+
+    // 7. Return the code points from positionStart to position, inclusive, within input.
+    auto position = lexer.tell();
+    auto number_of_characters_to_consume = position - position_start + 1;
+    lexer.retreat(number_of_characters_to_consume);
+    return lexer.consume(number_of_characters_to_consume);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Fetch/AbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Fetch/AbstractOperations.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+
+namespace Web::Fetch {
+
+enum class HttpQuotedStringExtractValue {
+    No,
+    Yes,
+};
+
+String collect_an_http_quoted_string(GenericLexer& lexer, HttpQuotedStringExtractValue extract_value);
+
+}

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -231,6 +231,10 @@ namespace Web::IntersectionObserver {
 class IntersectionObserver;
 }
 
+namespace Web::MimeSniff {
+class MimeType;
+}
+
 namespace Web::NavigationTiming {
 class PerformanceTiming;
 }

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -1,0 +1,191 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/CharacterTypes.h>
+#include <AK/GenericLexer.h>
+#include <AK/StringBuilder.h>
+#include <LibWeb/Fetch/AbstractOperations.h>
+#include <LibWeb/MimeSniff/MimeType.h>
+
+namespace Web::MimeSniff {
+
+static bool contains_only_http_quoted_string_token_code_points(StringView string)
+{
+    // https://mimesniff.spec.whatwg.org/#http-quoted-string-token-code-point
+    // An HTTP quoted-string token code point is U+0009 TAB, a code point in the range U+0020 SPACE to U+007E (~), inclusive,
+    // or a code point in the range U+0080 through U+00FF (ÿ), inclusive.
+    for (char ch : string) {
+        // NOTE: This doesn't check for ch <= 0xFF, as ch is 8-bits and so that condition will always be true.
+        if (!(ch == '\t' || (ch >= 0x20 && ch <= 0x7E) || (u8)ch >= 0x80))
+            return false;
+    }
+    return true;
+}
+
+MimeType::MimeType(String type, String subtype)
+    : m_type(type)
+    , m_subtype(subtype)
+{
+    // https://mimesniff.spec.whatwg.org/#parameters
+    // A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings limited to HTTP quoted-string token code points.
+    VERIFY(contains_only_http_quoted_string_token_code_points(type));
+    VERIFY(contains_only_http_quoted_string_token_code_points(subtype));
+}
+
+MimeType::~MimeType()
+{
+}
+
+static bool contains_only_http_token_code_points(StringView string)
+{
+    // https://mimesniff.spec.whatwg.org/#http-token-code-point
+    // An HTTP token code point is U+0021 (!), U+0023 (#), U+0024 ($), U+0025 (%), U+0026 (&), U+0027 ('), U+002A (*),
+    // U+002B (+), U+002D (-), U+002E (.), U+005E (^), U+005F (_), U+0060 (`), U+007C (|), U+007E (~), or an ASCII alphanumeric.
+    constexpr auto is_certain_non_ascii_alphanumeric = is_any_of("!#$%&'*+-.^_`|~");
+    for (char ch : string) {
+        if (!is_certain_non_ascii_alphanumeric(ch) && !is_ascii_alphanumeric(ch))
+            return false;
+    }
+    return true;
+}
+
+// https://mimesniff.spec.whatwg.org/#parse-a-mime-type
+Optional<MimeType> MimeType::from_string(StringView string)
+{
+    // https://fetch.spec.whatwg.org/#http-whitespace
+    // HTTP whitespace is U+000A LF, U+000D CR, or an HTTP tab or space.
+    // An HTTP tab or space is U+0009 TAB or U+0020 SPACE.
+    constexpr const char* http_whitespace = "\n\r\t ";
+
+    // 1. Remove any leading and trailing HTTP whitespace from input.
+    auto trimmed_string = string.trim(http_whitespace, TrimMode::Both);
+
+    // 2. Let position be a position variable for input, initially pointing at the start of input.
+    GenericLexer lexer(trimmed_string);
+
+    // 3. Let type be the result of collecting a sequence of code points that are not U+002F (/) from input, given position.
+    auto type = lexer.consume_until('/');
+
+    // 4. If type is the empty string or does not solely contain HTTP token code points, then return failure.
+    if (type.is_empty() || !contains_only_http_token_code_points(type))
+        return {};
+
+    // 5. If position is past the end of input, then return failure.
+    if (lexer.is_eof())
+        return {};
+
+    // 6. Advance position by 1. (This skips past U+002F (/).)
+    lexer.ignore(1);
+
+    // 7. Let subtype be the result of collecting a sequence of code points that are not U+003B (;) from input, given position.
+    auto subtype = lexer.consume_until(';');
+
+    // 8. Remove any trailing HTTP whitespace from subtype.
+    subtype = subtype.trim(http_whitespace, TrimMode::Right);
+
+    // 9. If subtype is the empty string or does not solely contain HTTP token code points, then return failure.
+    if (subtype.is_empty() || !contains_only_http_token_code_points(subtype))
+        return {};
+
+    // 10. Let mimeType be a new MIME type record whose type is type, in ASCII lowercase, and subtype is subtype, in ASCII lowercase.
+    auto mime_type = MimeType(type.to_lowercase_string(), subtype.to_lowercase_string());
+
+    // 11. While position is not past the end of input:
+    while (!lexer.is_eof()) {
+        // 1. Advance position by 1. (This skips past U+003B (;).)
+        lexer.ignore(1);
+
+        // 2. Collect a sequence of code points that are HTTP whitespace from input given position.
+        lexer.ignore_while(is_any_of(http_whitespace));
+
+        // 3. Let parameterName be the result of collecting a sequence of code points that are not U+003B (;) or U+003D (=) from input, given position.
+        auto parameter_name = lexer.consume_until([](char ch) {
+            return ch == ';' || ch == '=';
+        });
+
+        // 4. Set parameterName to parameterName, in ASCII lowercase.
+        // NOTE: Reassigning to parameter_name here causes a UAF when trying to use parameter_name down the road.
+        auto lowercase_parameter_name = parameter_name.to_lowercase_string();
+
+        // 5. If position is not past the end of input, then:
+        if (!lexer.is_eof()) {
+            // 1. If the code point at position within input is U+003B (;), then continue.
+            if (lexer.peek() == ';')
+                continue;
+
+            // 2. Advance position by 1. (This skips past U+003D (=).)
+            lexer.ignore(1);
+        }
+
+        // 6. If position is past the end of input, then break.
+        // NOTE: This is not an `else` because the ignore on step 11.5.2 could put us past the end of the input.
+        if (lexer.is_eof())
+            break;
+
+        // 7. Let parameterValue be null.
+        String parameter_value;
+
+        // 8. If the code point at position within input is U+0022 ("), then:
+        if (lexer.tell() == '"') {
+            // 1. Set parameterValue to the result of collecting an HTTP quoted string from input, given position and the extract-value flag.
+            parameter_value = collect_an_http_quoted_string(lexer, Fetch::HttpQuotedStringExtractValue::Yes);
+
+            // 2. Collect a sequence of code points that are not U+003B (;) from input, given position.
+            // NOTE: This uses the predicate version as the ignore_until(char) version will also ignore the ';'.
+            lexer.ignore_until([](char ch) {
+                return ch == ';';
+            });
+        }
+
+        // 9. Otherwise:
+        else {
+            // 1. Set parameterValue to the result of collecting a sequence of code points that are not U+003B (;) from input, given position.
+            parameter_value = lexer.consume_until(';');
+
+            // 2. Remove any trailing HTTP whitespace from parameterValue.
+            parameter_value = parameter_value.trim(http_whitespace, TrimMode::Right);
+
+            // 3. If parameterValue is the empty string, then continue.
+            if (parameter_value.is_empty())
+                continue;
+        }
+
+        // 10. If all of the following are true
+        //       - parameterName is not the empty string
+        //       - parameterName solely contains HTTP token code points
+        //       - parameterValue solely contains HTTP quoted-string token code points
+        //       - mimeType’s parameters[parameterName] does not exist
+        //     then set mimeType’s parameters[parameterName] to parameterValue.
+        if (!parameter_name.is_empty()
+            && contains_only_http_token_code_points(lowercase_parameter_name)
+            && contains_only_http_quoted_string_token_code_points(parameter_value)
+            && !mime_type.m_parameters.contains(lowercase_parameter_name)) {
+            mime_type.m_parameters.set(lowercase_parameter_name, parameter_value);
+        }
+    }
+
+    // 12. Return mimeType.
+    return Optional<MimeType> { move(mime_type) };
+}
+
+// https://mimesniff.spec.whatwg.org/#mime-type-essence
+String MimeType::essence() const
+{
+    // The essence of a MIME type mimeType is mimeType’s type, followed by U+002F (/), followed by mimeType’s subtype.
+    // FIXME: I believe this can easily be cached as I don't think anything directly changes the type and subtype.
+    return String::formatted("{}/{}", m_type, m_subtype);
+}
+
+void MimeType::set_parameter(String const& name, String const& value)
+{
+    // https://mimesniff.spec.whatwg.org/#parameters
+    // A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings limited to HTTP quoted-string token code points.
+    VERIFY(contains_only_http_quoted_string_token_code_points(name));
+    VERIFY(contains_only_http_quoted_string_token_code_points(value));
+    m_parameters.set(name, value);
+}
+
+}

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/String.h>
+
+namespace Web::MimeSniff {
+
+// https://mimesniff.spec.whatwg.org/#mime-type
+class MimeType {
+public:
+    static Optional<MimeType> from_string(StringView);
+
+    MimeType(String type, String subtype);
+    ~MimeType();
+
+    String const& type() const { return m_type; }
+    String const& subtype() const { return m_subtype; }
+    OrderedHashMap<String, String> const& parameters() const { return m_parameters; }
+
+    void set_parameter(String const& name, String const& value);
+
+    String essence() const;
+
+private:
+    // https://mimesniff.spec.whatwg.org/#type
+    // A MIME type’s type is a non-empty ASCII string.
+    String m_type;
+
+    // https://mimesniff.spec.whatwg.org/#subtype
+    // A MIME type’s subtype is a non-empty ASCII string.
+    String m_subtype;
+
+    // https://mimesniff.spec.whatwg.org/#parameters
+    // A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings limited to HTTP quoted-string token code points. It is initially empty.
+    OrderedHashMap<String, String> m_parameters;
+};
+
+}

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -291,4 +291,21 @@ String XMLHttpRequest::get_all_response_headers() const
     return builder.to_string();
 }
 
+// https://xhr.spec.whatwg.org/#dom-xmlhttprequest-overridemimetype
+DOM::ExceptionOr<void> XMLHttpRequest::override_mime_type(String const& mime)
+{
+    // 1. If this’s state is loading or done, then throw an "InvalidStateError" DOMException.
+    if (m_ready_state == ReadyState::Loading || m_ready_state == ReadyState::Done)
+        return DOM::InvalidStateError::create("Cannot override MIME type when state is Loading or Done.");
+
+    // 2. Set this’s override MIME type to the result of parsing mime.
+    m_override_mime_type = MimeSniff::MimeType::from_string(mime);
+
+    // 3. If this’s override MIME type is failure, then set this’s override MIME type to application/octet-stream.
+    if (!m_override_mime_type.has_value())
+        m_override_mime_type = MimeSniff::MimeType("application"sv, "octet-stream"sv);
+
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -1,12 +1,15 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/GenericLexer.h>
 #include <AK/QuickSort.h>
 #include <LibJS/Runtime/FunctionObject.h>
+#include <LibTextCodec/Decoder.h>
 #include <LibWeb/Bindings/EventWrapper.h>
 #include <LibWeb/Bindings/XMLHttpRequestWrapper.h>
 #include <LibWeb/DOM/DOMException.h>
@@ -16,6 +19,7 @@
 #include <LibWeb/DOM/EventListener.h>
 #include <LibWeb/DOM/ExceptionOr.h>
 #include <LibWeb/DOM/Window.h>
+#include <LibWeb/Fetch/AbstractOperations.h>
 #include <LibWeb/HTML/EventHandler.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/Loader/ResourceLoader.h>
@@ -52,11 +56,218 @@ void XMLHttpRequest::fire_progress_event(const String& event_name, u64 transmitt
     dispatch_event(ProgressEvent::create(event_name, event_init));
 }
 
+// https://xhr.spec.whatwg.org/#dom-xmlhttprequest-responsetext
 String XMLHttpRequest::response_text() const
 {
-    if (m_response_object.is_empty())
+    // FIXME: 1. If this’s response type is not the empty string or "text", then throw an "InvalidStateError" DOMException.
+
+    // 2. If this’s state is not loading or done, then return the empty string.
+    if (m_ready_state != ReadyState::Loading && m_ready_state != ReadyState::Done)
+        return String::empty();
+
+    return get_text_response();
+}
+
+// https://xhr.spec.whatwg.org/#text-response
+String XMLHttpRequest::get_text_response() const
+{
+    // FIXME: 1. If xhr’s response’s body is null, then return the empty string.
+
+    // 2. Let charset be the result of get a final encoding for xhr.
+    auto charset = get_final_encoding();
+
+    // FIXME: 3. If xhr’s response type is the empty string, charset is null, and the result of get a final MIME type for xhr is an XML MIME type,
+    //           then use the rules set forth in the XML specifications to determine the encoding. Let charset be the determined encoding. [XML] [XML-NAMES]
+
+    // 4. If charset is null, then set charset to UTF-8.
+    if (!charset.has_value())
+        charset = "UTF-8";
+
+    // 5. Return the result of running decode on xhr’s received bytes using fallback encoding charset.
+    auto* decoder = TextCodec::decoder_for(charset.value());
+
+    // If we don't support the decoder yet, let's crash instead of attempting to return something, as the result would be incorrect and create obscure bugs.
+    VERIFY(decoder);
+
+    return TextCodec::convert_input_to_utf8_using_given_decoder_unless_there_is_a_byte_order_mark(*decoder, m_response_object);
+}
+
+// https://xhr.spec.whatwg.org/#response-mime-type
+MimeSniff::MimeType XMLHttpRequest::get_response_mime_type() const
+{
+    // 1. Let mimeType be the result of extracting a MIME type from xhr’s response’s header list.
+    auto mime_type = extract_mime_type(m_response_headers);
+
+    // 2. If mimeType is failure, then set mimeType to text/xml.
+    if (!mime_type.has_value())
+        return MimeSniff::MimeType("text"sv, "xml"sv);
+
+    // 3. Return mimeType.
+    return mime_type.release_value();
+}
+
+// https://xhr.spec.whatwg.org/#final-charset
+Optional<String> XMLHttpRequest::get_final_encoding() const
+{
+    // 1. Let label be null.
+    Optional<String> label;
+
+    // 2. Let responseMIME be the result of get a response MIME type for xhr.
+    auto response_mime = get_response_mime_type();
+
+    // 3. If responseMIME’s parameters["charset"] exists, then set label to it.
+    auto response_mime_charset_it = response_mime.parameters().find("charset"sv);
+    if (response_mime_charset_it != response_mime.parameters().end())
+        label = response_mime_charset_it->value;
+
+    // 4. If xhr’s override MIME type’s parameters["charset"] exists, then set label to it.
+    if (m_override_mime_type.has_value()) {
+        auto override_mime_charset_it = m_override_mime_type->parameters().find("charset"sv);
+        if (override_mime_charset_it != m_override_mime_type->parameters().end())
+            label = override_mime_charset_it->value;
+    }
+
+    // 5. If label is null, then return null.
+    if (!label.has_value())
         return {};
-    return String::copy(m_response_object);
+
+    // 6. Let encoding be the result of getting an encoding from label.
+    auto encoding = TextCodec::get_standardized_encoding(label.value());
+
+    // 7. If encoding is failure, then return null.
+    // 8. Return encoding.
+    return encoding;
+}
+
+// https://fetch.spec.whatwg.org/#concept-header-list-get-decode-split
+// FIXME: This is not only used by XHR, it is also used for multiple things in Fetch.
+Optional<Vector<String>> XMLHttpRequest::get_decode_and_split(String const& header_name, HashMap<String, String, CaseInsensitiveStringTraits> const& header_list) const
+{
+    // 1. Let initialValue be the result of getting name from list.
+    auto initial_value_iterator = header_list.find(header_name);
+
+    // 2. If initialValue is null, then return null.
+    if (initial_value_iterator == header_list.end())
+        return {};
+
+    auto& initial_value = initial_value_iterator->value;
+
+    // FIXME: 3. Let input be the result of isomorphic decoding initialValue.
+    // NOTE: We don't store raw byte sequences in the header list as per the spec, so we can't do this step.
+    //       The spec no longer uses initialValue after this step. For our purposes, treat any reference to `input` in the spec comments to initial_value.
+
+    // 4. Let position be a position variable for input, initially pointing at the start of input.
+    GenericLexer lexer(initial_value);
+
+    // 5. Let values be a list of strings, initially empty.
+    Vector<String> values;
+
+    // 6. Let value be the empty string.
+    StringBuilder value;
+
+    // 7. While position is not past the end of input:
+    while (!lexer.is_eof()) {
+        // 1. Append the result of collecting a sequence of code points that are not U+0022 (") or U+002C (,) from input, given position, to value.
+        auto value_part = lexer.consume_until([](char ch) {
+            return ch == '"' || ch == ',';
+        });
+        value.append(value_part);
+
+        // 2. If position is not past the end of input, then:
+        if (!lexer.is_eof()) {
+            // 1. If the code point at position within input is U+0022 ("), then:
+            if (lexer.peek() == '"') {
+                // 1. Append the result of collecting an HTTP quoted string from input, given position, to value.
+                auto quoted_value_part = Fetch::collect_an_http_quoted_string(lexer, Fetch::HttpQuotedStringExtractValue::No);
+                value.append(quoted_value_part);
+
+                // 2. If position is not past the end of input, then continue.
+                if (!lexer.is_eof())
+                    continue;
+            }
+
+            // 2. Otherwise:
+            else {
+                // 1. Assert: the code point at position within input is U+002C (,).
+                VERIFY(lexer.peek() == ',');
+
+                // 2. Advance position by 1.
+                lexer.ignore(1);
+            }
+        }
+
+        // 3. Remove all HTTP tab or space from the start and end of value.
+        // https://fetch.spec.whatwg.org/#http-tab-or-space
+        // An HTTP tab or space is U+0009 TAB or U+0020 SPACE.
+        auto trimmed_value = value.to_string().trim("\t ", TrimMode::Both);
+
+        // 4. Append value to values.
+        values.append(move(trimmed_value));
+
+        // 5. Set value to the empty string.
+        value.clear();
+    }
+
+    // 8. Return values.
+    return values;
+}
+
+// https://fetch.spec.whatwg.org/#concept-header-extract-mime-type
+// FIXME: This is not only used by XHR, it is also used for multiple things in Fetch.
+Optional<MimeSniff::MimeType> XMLHttpRequest::extract_mime_type(HashMap<String, String, CaseInsensitiveStringTraits> const& header_list) const
+{
+    // 1. Let charset be null.
+    Optional<String> charset;
+
+    // 2. Let essence be null.
+    Optional<String> essence;
+
+    // 3. Let mimeType be null.
+    Optional<MimeSniff::MimeType> mime_type;
+
+    // 4. Let values be the result of getting, decoding, and splitting `Content-Type` from headers.
+    auto potentially_values = get_decode_and_split("Content-Type"sv, header_list);
+
+    // 5. If values is null, then return failure.
+    if (!potentially_values.has_value())
+        return {};
+
+    auto values = potentially_values.release_value();
+
+    // 6. For each value of values:
+    for (auto& value : values) {
+        // 1. Let temporaryMimeType be the result of parsing value.
+        auto temporary_mime_type = MimeSniff::MimeType::from_string(value);
+
+        // 2. If temporaryMimeType is failure or its essence is "*/*", then continue.
+        if (!temporary_mime_type.has_value() || temporary_mime_type->essence() == "*/*"sv)
+            continue;
+
+        // 3. Set mimeType to temporaryMimeType.
+        mime_type = temporary_mime_type;
+
+        // 4. If mimeType’s essence is not essence, then:
+        if (mime_type->essence() != essence) {
+            // 1. Set charset to null.
+            charset = {};
+
+            // 2. If mimeType’s parameters["charset"] exists, then set charset to mimeType’s parameters["charset"].
+            auto charset_it = mime_type->parameters().find("charset"sv);
+            if (charset_it != mime_type->parameters().end())
+                charset = charset_it->value;
+
+            // 3. Set essence to mimeType’s essence.
+            essence = mime_type->essence();
+        } else {
+            // 5. Otherwise, if mimeType’s parameters["charset"] does not exist, and charset is non-null, set mimeType’s parameters["charset"] to charset.
+            if (!mime_type->parameters().contains("charset"sv) && charset.has_value())
+                mime_type->set_parameter("charset"sv, charset.value());
+        }
+    }
+
+    // 7. If mimeType is null, then return failure.
+    // 8. Return mimeType.
+    return mime_type;
 }
 
 // https://fetch.spec.whatwg.org/#forbidden-header-name

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -74,6 +74,14 @@ private:
     void set_status(unsigned status) { m_status = status; }
     void fire_progress_event(const String&, u64, u64);
 
+    MimeSniff::MimeType get_response_mime_type() const;
+    Optional<String> get_final_encoding() const;
+
+    String get_text_response() const;
+
+    Optional<Vector<String>> get_decode_and_split(String const& header_name, HashMap<String, String, CaseInsensitiveStringTraits> const& header_list) const;
+    Optional<MimeSniff::MimeType> extract_mime_type(HashMap<String, String, CaseInsensitiveStringTraits> const& header_list) const;
+
     explicit XMLHttpRequest(DOM::Window&);
 
     NonnullRefPtr<DOM::Window> m_window;

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -14,6 +14,7 @@
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/DOM/EventTarget.h>
 #include <LibWeb/DOM/ExceptionOr.h>
+#include <LibWeb/MimeSniff/MimeType.h>
 #include <LibWeb/XHR/XMLHttpRequestEventTarget.h>
 
 namespace Web::XHR {
@@ -62,6 +63,8 @@ public:
     Bindings::CallbackType* onreadystatechange();
     void set_onreadystatechange(Optional<Bindings::CallbackType>);
 
+    DOM::ExceptionOr<void> override_mime_type(String const& mime);
+
 private:
     virtual void ref_event_target() override { ref(); }
     virtual void unref_event_target() override { unref(); }
@@ -91,6 +94,9 @@ private:
     bool m_timed_out { false };
 
     ByteBuffer m_response_object;
+
+    // https://xhr.spec.whatwg.org/#override-mime-type
+    Optional<MimeSniff::MimeType> m_override_mime_type;
 };
 
 }

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
@@ -18,6 +18,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
 
     ByteString? getResponseHeader(ByteString name);
     ByteString getAllResponseHeaders();
+    undefined overrideMimeType(DOMString mime);
 
     attribute EventHandler onreadystatechange;
 


### PR DESCRIPTION
This is required for Google Maps, which downloads text blobs via XHR that are encoded in the x-user-defined charset. Previously it would try to decode it with UTF-8 and print out a bunch of "bytes don't make sense" messages, then crash when passing the malformed string to JavaScript.

This now allows XHR text to decode from any of our supported text decoders instead of just UTF-8. If it tries to use a decoder we don't currently support, it will just crash instead of trying to salvage something that will only cause issues down the road.

The x-user-defined charset is pretty simple. It is an 8-bit charset where 0x00-0x7F is standard ASCII and 0x80-0xFF is mapped to the Unicode Private Use Area at 0xF780-0xF7FF. The vast majority of this PR is properly extracting the Content-Type header and parsing it as a MIME type all according to the specification.

This allows us to view Google Maps without crashing :). It currently breaks on needing CanvasRenderingContext2D.setTransform to progress further. This is how it looks in this state:
![Screenshot from 2022-02-11 17-37-13](https://user-images.githubusercontent.com/25595356/153682477-6183a5db-d078-48d3-95b5-8aabc3c88a9a.png)

And as a hint of things to come, with setTransform stubbed, we get to views like these:
![Screenshot from 2022-02-11 18-41-19](https://user-images.githubusercontent.com/25595356/153682615-559a1d2e-4bdc-4fd7-a272-8232a2f6df99.png)
![Screenshot from 2022-02-11 18-43-10](https://user-images.githubusercontent.com/25595356/153682656-5b67f054-90ef-45c7-8776-df671b3d1571.png)
![Screenshot from 2022-02-11 19-12-51](https://user-images.githubusercontent.com/25595356/153682662-d3ab8629-2ff1-4012-890d-05dba11d27ce.png)

