### PR TITLE
LibWebSocket: Don't try to send empty payload inside of frame

### DIFF
--- a/Userland/Libraries/LibWebSocket/WebSocket.cpp
+++ b/Userland/Libraries/LibWebSocket/WebSocket.cpp
@@ -541,6 +541,9 @@ void WebSocket::send_frame(WebSocket::OpCode op_code, ReadonlyBytes payload, boo
         u8 masking_key[4];
         fill_with_random(masking_key, 4);
         m_impl->send(ReadonlyBytes(masking_key, 4));
+        // don't try to send empty payload
+        if (payload.size() == 0)
+            return;
         // Mask the payload
         auto buffer_result = ByteBuffer::create_uninitialized(payload.size());
         if (!buffer_result.is_error()) {
@@ -550,7 +553,7 @@ void WebSocket::send_frame(WebSocket::OpCode op_code, ReadonlyBytes payload, boo
             }
             m_impl->send(masked_payload);
         }
-    } else {
+    } else if (payload.size() > 0) {
         m_impl->send(payload);
     }
 }


### PR DESCRIPTION
According to [RFC 6455 sections 5.5.2-5.5.3](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.2) Ping and Pong frames
can have empty "Application data" that means payload can be of size 0.
This change fixes failed "buffer.size()" assertion inside
of Core::Stream::write_or_error by not trying to send empty payload
in WebSocket::send_frame.

This error is reproducible in browser on [this linux.org.ru page](https://www.linux.org.ru/news/opensource/16780786) (it will crash a page after a few seconds).