### PR TITLE
LibWeb: Add Geometry::DOMRectList and stub implementation of Element::get_client_rects

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator.cpp
@@ -2295,6 +2295,7 @@ void generate_implementation(IDL::Interface const& interface)
 #include <LibWeb/Bindings/CanvasRenderingContext2DWrapper.h>
 #include <LibWeb/Bindings/CommentWrapper.h>
 #include <LibWeb/Bindings/DOMImplementationWrapper.h>
+#include <LibWeb/Bindings/DOMRectListWrapper.h>
 #include <LibWeb/Bindings/DOMRectWrapper.h>
 #include <LibWeb/Bindings/DocumentFragmentWrapper.h>
 #include <LibWeb/Bindings/DocumentTypeWrapper.h>
@@ -3462,6 +3463,7 @@ void generate_prototype_implementation(IDL::Interface const& interface)
 #include <LibWeb/Bindings/CanvasRenderingContext2DWrapper.h>
 #include <LibWeb/Bindings/CommentWrapper.h>
 #include <LibWeb/Bindings/DOMImplementationWrapper.h>
+#include <LibWeb/Bindings/DOMRectListWrapper.h>
 #include <LibWeb/Bindings/DOMRectWrapper.h>
 #include <LibWeb/Bindings/DOMStringMapWrapper.h>
 #include <LibWeb/Bindings/DOMTokenListWrapper.h>

--- a/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
@@ -43,6 +43,8 @@
 #include <LibWeb/Bindings/DOMParserConstructor.h>
 #include <LibWeb/Bindings/DOMParserPrototype.h>
 #include <LibWeb/Bindings/DOMRectConstructor.h>
+#include <LibWeb/Bindings/DOMRectListConstructor.h>
+#include <LibWeb/Bindings/DOMRectListPrototype.h>
 #include <LibWeb/Bindings/DOMRectPrototype.h>
 #include <LibWeb/Bindings/DOMRectReadOnlyConstructor.h>
 #include <LibWeb/Bindings/DOMRectReadOnlyPrototype.h>
@@ -338,6 +340,7 @@
     ADD_WINDOW_OBJECT_INTERFACE(DOMImplementation)         \
     ADD_WINDOW_OBJECT_INTERFACE(DOMParser)                 \
     ADD_WINDOW_OBJECT_INTERFACE(DOMRect)                   \
+    ADD_WINDOW_OBJECT_INTERFACE(DOMRectList)               \
     ADD_WINDOW_OBJECT_INTERFACE(DOMRectReadOnly)           \
     ADD_WINDOW_OBJECT_INTERFACE(DOMStringMap)              \
     ADD_WINDOW_OBJECT_INTERFACE(Element)                   \

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -94,6 +94,7 @@ set(SOURCES
     Dump.cpp
     Encoding/TextEncoder.cpp
     FontCache.cpp
+    Geometry/DOMRectList.cpp
     HTML/AttributeNames.cpp
     HTML/BrowsingContext.cpp
     HTML/BrowsingContextContainer.cpp
@@ -418,6 +419,7 @@ libweb_js_wrapper(DOM/ShadowRoot)
 libweb_js_wrapper(DOM/Text)
 libweb_js_wrapper(Encoding/TextEncoder)
 libweb_js_wrapper(Geometry/DOMRect)
+libweb_js_wrapper(Geometry/DOMRectList)
 libweb_js_wrapper(Geometry/DOMRectReadOnly)
 libweb_js_wrapper(HTML/CanvasGradient)
 libweb_js_wrapper(HTML/CanvasRenderingContext2D)

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -20,6 +20,7 @@
 #include <LibWeb/DOM/Text.h>
 #include <LibWeb/DOMParsing/InnerHTML.h>
 #include <LibWeb/Geometry/DOMRect.h>
+#include <LibWeb/Geometry/DOMRectList.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
 #include <LibWeb/HTML/Parser/HTMLParser.h>
@@ -445,6 +446,30 @@ NonnullRefPtr<Geometry::DOMRect> Element::get_bounding_client_rect() const
 
     auto& box = static_cast<Layout::Box const&>(*layout_node());
     return Geometry::DOMRect::create(box.absolute_rect().translated(-viewport_offset.x(), -viewport_offset.y()));
+}
+
+// https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
+NonnullRefPtr<Geometry::DOMRectList> Element::get_client_rects() const
+{
+    NonnullRefPtrVector<Geometry::DOMRect> rects;
+
+    // 1. If the element on which it was invoked does not have an associated layout box return an empty DOMRectList object and stop this algorithm.
+    if (!layout_node() || !layout_node()->is_box())
+        return Geometry::DOMRectList::create(move(rects));
+
+    // FIXME: 2. If the element has an associated SVG layout box return a DOMRectList object containing a single DOMRect object that describes
+    // the bounding box of the element as defined by the SVG specification, applying the transforms that apply to the element and its ancestors.
+
+    // FIXME: 3. Return a DOMRectList object containing DOMRect objects in content order, one for each box fragment,
+    // describing its border area (including those with a height or width of zero) with the following constraints:
+    // - Apply the transforms that apply to the element and its ancestors.
+    // - If the element on which the method was invoked has a computed value for the display property of table
+    // or inline-table include both the table box and the caption box, if any, but not the anonymous container box.
+    // - Replace each anonymous block box with its child box(es) and repeat this until no anonymous block boxes are left in the final list.
+
+    auto bounding_rect = get_bounding_client_rect();
+    rects.append(bounding_rect);
+    return Geometry::DOMRectList::create(move(rects));
 }
 
 int Element::client_top() const

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -125,6 +125,7 @@ public:
     bool serializes_as_void() const;
 
     NonnullRefPtr<Geometry::DOMRect> get_bounding_client_rect() const;
+    NonnullRefPtr<Geometry::DOMRectList> get_client_rects() const;
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>);
 

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -49,6 +49,7 @@ interface Element : Node {
     [SameObject] readonly attribute HTMLCollection children;
 
     DOMRect getBoundingClientRect();
+    DOMRectList getClientRects();
 
     readonly attribute long clientTop;
     readonly attribute long clientLeft;

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -118,6 +118,7 @@ class TextEncoder;
 
 namespace Web::Geometry {
 class DOMRect;
+class DOMRectList;
 class DOMRectReadOnly;
 }
 
@@ -341,6 +342,7 @@ class DocumentWrapper;
 class DOMExceptionWrapper;
 class DOMImplementationWrapper;
 class DOMParserWrapper;
+class DOMRectListWrapper;
 class DOMRectReadOnlyWrapper;
 class DOMRectWrapper;
 class DOMStringMapWrapper;

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.cpp
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, DerpyCrabs <derpycrabs@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/Geometry/DOMRect.h>
+#include <LibWeb/Geometry/DOMRectList.h>
+
+namespace Web::Geometry {
+
+DOMRectList::DOMRectList(NonnullRefPtrVector<DOMRect>&& rects)
+    : m_rects(move(rects))
+{
+}
+
+// https://drafts.fxtf.org/geometry-1/#dom-domrectlist-length
+u32 DOMRectList::length() const
+{
+    return m_rects.size();
+}
+
+// https://drafts.fxtf.org/geometry-1/#dom-domrectlist-item
+DOMRect const* DOMRectList::item(u32 index) const
+{
+    // The item(index) method, when invoked, must return null when
+    // index is greater than or equal to the number of DOMRect objects associated with the DOMRectList.
+    // Otherwise, the DOMRect object at index must be returned. Indices are zero-based.
+    if (index >= m_rects.size())
+        return nullptr;
+    return &m_rects[index];
+}
+
+bool DOMRectList::is_supported_property_index(u32 index) const
+{
+    return index < m_rects.size();
+}
+
+}

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.h
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, DerpyCrabs <derpycrabs@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Noncopyable.h>
+#include <AK/NonnullRefPtrVector.h>
+#include <AK/RefCounted.h>
+#include <AK/Vector.h>
+#include <LibWeb/Bindings/Wrappable.h>
+#include <LibWeb/Forward.h>
+#include <LibWeb/Geometry/DOMRect.h>
+
+namespace Web::Geometry {
+
+// https://drafts.fxtf.org/geometry-1/#DOMRectList
+class DOMRectList final
+    : public RefCounted<DOMRectList>
+    , public Bindings::Wrappable {
+    AK_MAKE_NONCOPYABLE(DOMRectList);
+    AK_MAKE_NONMOVABLE(DOMRectList);
+
+public:
+    using WrapperType = Bindings::DOMRectListWrapper;
+
+    static NonnullRefPtr<DOMRectList> create(NonnullRefPtrVector<DOMRect>&& rects)
+    {
+        return adopt_ref(*new DOMRectList(move(rects)));
+    }
+
+    ~DOMRectList() = default;
+
+    u32 length() const;
+    DOMRect const* item(u32 index) const;
+
+    bool is_supported_property_index(u32) const;
+
+private:
+    DOMRectList(NonnullRefPtrVector<DOMRect>&& rects);
+
+    NonnullRefPtrVector<DOMRect> m_rects;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Geometry/DOMRectList.idl
+++ b/Userland/Libraries/LibWeb/Geometry/DOMRectList.idl
@@ -1,0 +1,6 @@
+[Exposed=Window]
+interface DOMRectList {
+    getter DOMRect? item(unsigned long index);
+    readonly attribute unsigned long length;
+    iterable<DOMRect>;
+};


### PR DESCRIPTION
This pull request implements Element::get_client_rects in terms of get_bounding_client_rect that is enough for most cases but I left FIXME comments with a correct algorithm from [specification](https://drafts.csswg.org/cssom-view/#dom-element-getclientrects). This change also implements DOMRectList that is a legacy class but is needed for a compatibility with legacy sites according to note [here](https://drafts.fxtf.org/geometry-1/#DOMRectList).