### PR TITLE
LibWeb: Redirect-related Fixes

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1006,7 +1006,7 @@ String Document::cookie(Cookie::Source source)
     return {};
 }
 
-void Document::set_cookie(String cookie_string, Cookie::Source source)
+void Document::set_cookie(String const& cookie_string, Cookie::Source source)
 {
     auto cookie = Cookie::parse_cookie(cookie_string);
     if (!cookie.has_value())

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -56,7 +56,7 @@ public:
     virtual ~Document() override;
 
     String cookie(Cookie::Source = Cookie::Source::NonHttp);
-    void set_cookie(String, Cookie::Source = Cookie::Source::NonHttp);
+    void set_cookie(String const&, Cookie::Source = Cookie::Source::NonHttp);
 
     String referrer() const;
 

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -11,6 +11,7 @@
 #include <LibGemini/Document.h>
 #include <LibGfx/ImageDecoder.h>
 #include <LibMarkdown/Document.h>
+#include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/ElementFactory.h>
 #include <LibWeb/DOM/Text.h>
@@ -253,9 +254,32 @@ void FrameLoader::load_favicon(RefPtr<Gfx::Bitmap> bitmap)
     }
 }
 
+void FrameLoader::store_response_cookies(AK::URL const& url, String const& cookies)
+{
+    auto* page = browsing_context().page();
+    if (!page)
+        return;
+
+    auto set_cookie_json_value = MUST(JsonValue::from_string(cookies));
+    VERIFY(set_cookie_json_value.type() == JsonValue::Type::Array);
+
+    for (const auto& set_cookie_entry : set_cookie_json_value.as_array().values()) {
+        VERIFY(set_cookie_entry.type() == JsonValue::Type::String);
+
+        auto cookie = Cookie::parse_cookie(set_cookie_entry.as_string());
+        if (!cookie.has_value())
+            continue;
+
+        page->client().page_did_set_cookie(url, cookie.value(), Cookie::Source::Http); // FIXME: Determine cookie source correctly
+    }
+}
+
 void FrameLoader::resource_did_load()
 {
     auto url = resource()->url();
+
+    if (auto set_cookie = resource()->response_headers().get("Set-Cookie"); set_cookie.has_value())
+        store_response_cookies(url, *set_cookie);
 
     // For 3xx (Redirection) responses, the Location value refers to the preferred target resource for automatically redirecting the request.
     auto status_code = resource()->status_code();
@@ -295,16 +319,6 @@ void FrameLoader::resource_did_load()
     if (!parse_document(*document, resource()->encoded_data())) {
         load_error_page(url, "Failed to parse content.");
         return;
-    }
-
-    auto set_cookie = resource()->response_headers().get("Set-Cookie");
-    if (set_cookie.has_value()) {
-        auto set_cookie_json_value = MUST(JsonValue::from_string(set_cookie.value()));
-        VERIFY(set_cookie_json_value.type() == JsonValue::Type::Array);
-        for (const auto& set_cookie_entry : set_cookie_json_value.as_array().values()) {
-            VERIFY(set_cookie_entry.type() == JsonValue::Type::String);
-            document->set_cookie(set_cookie_entry.as_string(), Cookie::Source::Http);
-        }
     }
 
     if (!url.fragment().is_empty())

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.h
@@ -43,6 +43,8 @@ private:
     void load_favicon(RefPtr<Gfx::Bitmap> bitmap = nullptr);
     bool parse_document(DOM::Document&, const ByteBuffer& data);
 
+    void store_response_cookies(AK::URL const& url, String const& cookies);
+
     HTML::BrowsingContext& m_browsing_context;
     size_t m_redirects_count { 0 };
 };

--- a/Userland/Libraries/LibWeb/Loader/Resource.h
+++ b/Userland/Libraries/LibWeb/Loader/Resource.h
@@ -49,6 +49,8 @@ public:
 
     const HashMap<String, String, CaseInsensitiveStringTraits>& response_headers() const { return m_response_headers; }
 
+    [[nodiscard]] Optional<u32> status_code() const { return m_status_code; }
+
     void register_client(Badge<ResourceClient>, ResourceClient&);
     void unregister_client(Badge<ResourceClient>, ResourceClient&);
 


### PR DESCRIPTION
This makes classic cookie clicker load correctly. (But it gets stuck after a while due to a thrown exception as a result of a missing property somewhere)