### PR TITLE
Kernel/VFS: Make the mkdir syscall respect process veils

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -828,7 +828,11 @@ ErrorOr<void> VirtualFileSystem::validate_path_against_process_veil(StringView p
 ErrorOr<NonnullRefPtr<Custody>> VirtualFileSystem::resolve_path(StringView path, Custody& base, RefPtr<Custody>* out_parent, int options, int symlink_recursion_level)
 {
     auto custody = TRY(resolve_path_without_veil(path, base, out_parent, options, symlink_recursion_level));
-    TRY(validate_path_against_process_veil(*custody, options));
+    if (auto result = validate_path_against_process_veil(*custody, options); result.is_error()) {
+        if (out_parent)
+            out_parent->clear();
+        return result.release_error();
+    }
     return custody;
 }
 

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -363,7 +363,7 @@ ErrorOr<void> VirtualFileSystem::mkdir(StringView path, mode_t mode, Custody& ba
     }
 
     RefPtr<Custody> parent_custody;
-    auto result = resolve_path(path, base, &parent_custody);
+    auto result = resolve_path_without_veil(path, base, &parent_custody);
     if (!result.is_error())
         return EEXIST;
     else if (!parent_custody)
@@ -371,6 +371,7 @@ ErrorOr<void> VirtualFileSystem::mkdir(StringView path, mode_t mode, Custody& ba
     // NOTE: If resolve_path fails with a non-null parent custody, the error should be ENOENT.
     VERIFY(result.error().code() == ENOENT);
 
+    TRY(validate_path_against_process_veil(*parent_custody, O_CREAT));
     auto& parent_inode = parent_custody->inode();
     auto& current_process = Process::current();
     if (!parent_inode.metadata().may_write(current_process))

--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -11,6 +11,7 @@ set(TEST_SOURCES
     TestLibCTime.cpp
     TestMalloc.cpp
     TestMemmem.cpp
+    TestMkDir.cpp
     TestQsort.cpp
     TestRaise.cpp
     TestRealpath.cpp

--- a/Tests/LibC/TestMkDir.cpp
+++ b/Tests/LibC/TestMkDir.cpp
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2021, Max Wipfli <max.wipfli@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <errno.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+static String random_dirname()
+{
+    return String::formatted("/tmp/test_mkdir_{:04x}", (u16)rand());
+}
+
+TEST_SETUP
+{
+    srand(time(NULL));
+}
+
+TEST_CASE(basic)
+{
+    auto dirname = random_dirname();
+    int res = mkdir(dirname.characters(), 0755);
+    EXPECT(res == 0);
+
+    res = mkdir(dirname.characters(), 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, EEXIST);
+}
+
+TEST_CASE(insufficient_permissions)
+{
+    VERIFY(getuid() != 0);
+    int res = mkdir("/root/foo", 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, EACCES);
+}
+
+TEST_CASE(nonexistent_parent)
+{
+    auto parent = random_dirname();
+    auto child = String::formatted("{}/foo", parent);
+    int res = mkdir(child.characters(), 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, ENOENT);
+}
+
+TEST_CASE(parent_is_file)
+{
+    int res = mkdir("/etc/passwd/foo", 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, ENOTDIR);
+}
+
+TEST_CASE(pledge)
+{
+    int res = pledge("stdio cpath", nullptr);
+    EXPECT(res == 0);
+
+    auto dirname = random_dirname();
+    res = mkdir(dirname.characters(), 0755);
+    EXPECT(res == 0);
+    // FIXME: Somehow also check that mkdir() stops working when removing the cpath promise. This is currently
+    //        not possible because this would prevent the unveil test case from properly working.
+}
+
+TEST_CASE(unveil)
+{
+    int res = unveil("/tmp", "rwc");
+    EXPECT(res == 0);
+
+    auto dirname = random_dirname();
+    res = mkdir(dirname.characters(), 0755);
+    EXPECT(res == 0);
+
+    res = unveil("/tmp", "rw");
+    EXPECT(res == 0);
+
+    dirname = random_dirname();
+    res = mkdir(dirname.characters(), 0755);
+    int cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, EACCES);
+
+    res = unveil("/tmp", "");
+    EXPECT(res == 0);
+
+    dirname = random_dirname();
+    res = mkdir(dirname.characters(), 0755);
+    cached_errno = errno;
+    EXPECT(res < 0);
+    EXPECT_EQ(cached_errno, ENOENT);
+
+    res = unveil(nullptr, nullptr);
+    EXPECT(res == 0);
+}


### PR DESCRIPTION
This fixes a bug where the `mkdir` syscall would not respect the process veil at all.

It also changes `resolve_path` to return a null `out_parent` if it fails because a path wasn't unveiled. This seems sensible because relying on `out_parent` for veiled paths is dangerous, as the parent and child could be unveiled/veiled differently, and it thus makes more sense to use `resolve_path_without_veil` and check the veil manually.

I have already made this PR (#8643) once before I got distracted from working on Serenity, so please also refer to the discussion there.

Note that I haven't worked on Serenity for almost seven months, so if I am not following some "new" code style rules are anything like that, I'm sorry. :^)