### PR TITLE
LibWeb: Fix comparing current position to quote in Mime Type quote parse

### DIFF
--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -129,7 +129,7 @@ Optional<MimeType> MimeType::from_string(StringView string)
         String parameter_value;
 
         // 8. If the code point at position within input is U+0022 ("), then:
-        if (lexer.tell() == '"') {
+        if (lexer.peek() == '"') {
             // 1. Set parameterValue to the result of collecting an HTTP quoted string from input, given position and the extract-value flag.
             parameter_value = collect_an_http_quoted_string(lexer, Fetch::HttpQuotedStringExtractValue::Yes);
 


### PR DESCRIPTION
Had a look over this with a fresh head and noticed I was comparing the
current lexer position to the quote character, oops!