### PR TITLE
LibJS: Bytecode stuff stuff stuff stuff stuff stuff stuff

### DIFF
--- a/Tests/LibJS/test-bytecode-js.cpp
+++ b/Tests/LibJS/test-bytecode-js.cpp
@@ -22,9 +22,9 @@
     auto const& program = script->parse_node();                                 \
     JS::Bytecode::Interpreter bytecode_interpreter(ast_interpreter->global_object(), ast_interpreter->realm());
 
-#define EXPECT_NO_EXCEPTION(executable)                           \
-    auto executable = JS::Bytecode::Generator::generate(program); \
-    auto result = bytecode_interpreter.run(*executable);          \
+#define EXPECT_NO_EXCEPTION(executable)                                 \
+    auto executable = MUST(JS::Bytecode::Generator::generate(program)); \
+    auto result = bytecode_interpreter.run(*executable);                \
     EXPECT(!result.is_error());
 
 #define EXPECT_NO_EXCEPTION_WITH_OPTIMIZATIONS(executable)                  \
@@ -54,7 +54,7 @@ TEST_CASE(if_statement_fail)
 {
     SETUP_AND_PARSE("if (true) throw new Exception('failed');");
 
-    auto executable = JS::Bytecode::Generator::generate(program);
+    auto executable = MUST(JS::Bytecode::Generator::generate(program));
     auto result = bytecode_interpreter.run(*executable);
     EXPECT(result.is_error());
 }
@@ -112,7 +112,7 @@ TEST_CASE(loading_multiple_files)
         auto test_file_script = test_file_script_or_error.release_value();
         auto const& test_file_program = test_file_script->parse_node();
 
-        auto executable = JS::Bytecode::Generator::generate(test_file_program);
+        auto executable = MUST(JS::Bytecode::Generator::generate(test_file_program));
         auto result = bytecode_interpreter.run(*executable);
         EXPECT(!result.is_error());
     }

--- a/Tests/LibJS/test-bytecode-js.cpp
+++ b/Tests/LibJS/test-bytecode-js.cpp
@@ -25,7 +25,9 @@
 #define EXPECT_NO_EXCEPTION(executable)                                 \
     auto executable = MUST(JS::Bytecode::Generator::generate(program)); \
     auto result = bytecode_interpreter.run(*executable);                \
-    EXPECT(!result.is_error());
+    EXPECT(!result.is_error());                                         \
+    if (result.is_error())                                              \
+        dbgln("Error: {}", MUST(result.throw_completion().value()->to_string(bytecode_interpreter.global_object())));
 
 #define EXPECT_NO_EXCEPTION_WITH_OPTIMIZATIONS(executable)                  \
     auto& passes = JS::Bytecode::Interpreter::optimization_pipeline();      \
@@ -33,11 +35,13 @@
                                                                             \
     auto result_with_optimizations = bytecode_interpreter.run(*executable); \
                                                                             \
-    EXPECT(!result_with_optimizations.is_error());
+    EXPECT(!result_with_optimizations.is_error());                          \
+    if (result_with_optimizations.is_error())                               \
+        dbgln("Error: {}", MUST(result_with_optimizations.throw_completion().value()->to_string(bytecode_interpreter.global_object())));
 
-#define EXPECT_NO_EXCEPTION_ALL(source) \
-    SETUP_AND_PARSE(source)             \
-    EXPECT_NO_EXCEPTION(executable)     \
+#define EXPECT_NO_EXCEPTION_ALL(source)           \
+    SETUP_AND_PARSE("(() => {\n" source "\n})()") \
+    EXPECT_NO_EXCEPTION(executable)               \
     EXPECT_NO_EXCEPTION_WITH_OPTIMIZATIONS(executable)
 
 TEST_CASE(empty_program)

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -16,6 +16,7 @@
 #include <AK/String.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibJS/Bytecode/CodeGenerationError.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Handle.h>
 #include <LibJS/Runtime/Completion.h>
@@ -47,7 +48,7 @@ class ASTNode : public RefCounted<ASTNode> {
 public:
     virtual ~ASTNode() { }
     virtual Completion execute(Interpreter&, GlobalObject&) const = 0;
-    virtual void generate_bytecode(Bytecode::Generator&) const;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const;
     virtual void dump(int indent) const;
 
     SourceRange const& source_range() const { return m_source_range; }
@@ -135,7 +136,7 @@ public:
     {
     }
     Completion execute(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 };
 
 class ErrorStatement final : public Statement {
@@ -157,7 +158,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     Expression const& expression() const { return m_expression; };
 
@@ -211,7 +212,7 @@ public:
 
     NonnullRefPtrVector<Statement> const& children() const { return m_children; }
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     Completion evaluate_statements(Interpreter& interpreter, GlobalObject& global_object) const;
 
@@ -649,7 +650,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<FlyString const&>&& callback) const override;
 
@@ -676,7 +677,7 @@ public:
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
 
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     bool has_name() const { return !name().is_empty(); }
 
@@ -710,7 +711,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     RefPtr<Expression> m_argument;
@@ -727,7 +728,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<Expression> m_argument;
@@ -745,7 +746,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     RefPtr<Expression> m_argument;
@@ -767,7 +768,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<Expression> m_predicate;
@@ -790,7 +791,7 @@ public:
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual Completion loop_evaluation(Interpreter&, GlobalObject&, Vector<FlyString> const&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<Expression> m_test;
@@ -812,7 +813,7 @@ public:
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual Completion loop_evaluation(Interpreter&, GlobalObject&, Vector<FlyString> const&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<Expression> m_test;
@@ -858,7 +859,7 @@ public:
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual Completion loop_evaluation(Interpreter&, GlobalObject&, Vector<FlyString> const&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     RefPtr<ASTNode> m_init;
@@ -972,7 +973,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     BinaryOp m_op;
@@ -998,7 +999,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     LogicalOp m_op;
@@ -1027,7 +1028,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     UnaryOp m_op;
@@ -1045,7 +1046,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtrVector<Expression> m_expressions;
@@ -1069,7 +1070,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     bool m_value { false };
@@ -1085,7 +1086,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     Value m_value;
@@ -1101,7 +1102,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     String m_value;
@@ -1118,7 +1119,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     StringView value() const { return m_value; }
     bool is_use_strict_directive() const { return m_is_use_strict_directive; };
@@ -1137,7 +1138,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 };
 
 class RegExpLiteral final : public Literal {
@@ -1154,7 +1155,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     regex::Parser::Result const& parsed_regex() const { return m_parsed_regex; }
     String const& parsed_pattern() const { return m_parsed_pattern; }
@@ -1184,7 +1185,7 @@ public:
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual ThrowCompletionOr<Reference> to_reference(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     virtual bool is_identifier() const override { return true; }
@@ -1378,7 +1379,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     virtual ThrowCompletionOr<void> for_each_bound_name(ThrowCompletionOrVoidCallback<FlyString const&>&& callback) const override;
 
@@ -1415,7 +1416,7 @@ public:
     }
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 };
 
 class CallExpression : public Expression {
@@ -1434,7 +1435,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     Expression const& callee() const { return m_callee; }
 
@@ -1518,7 +1519,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     AssignmentOp m_op;
@@ -1543,7 +1544,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     UpdateOp m_op;
@@ -1603,7 +1604,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     NonnullRefPtrVector<VariableDeclarator> const& declarations() const { return m_declarations; }
 
@@ -1667,7 +1668,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     Optional<SourceRange> const& invalid_property_range() const { return m_first_invalid_property_range; }
 
@@ -1688,7 +1689,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     Vector<RefPtr<Expression>> m_elements;
@@ -1711,7 +1712,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     NonnullRefPtrVector<Expression> const& expressions() const { return m_expressions; }
     NonnullRefPtrVector<Expression> const& raw_strings() const { return m_raw_strings; }
@@ -1732,7 +1733,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<Expression> const m_tag;
@@ -1752,7 +1753,7 @@ public:
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
     virtual ThrowCompletionOr<Reference> to_reference(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     bool is_computed() const { return m_computed; }
     Expression const& object() const { return *m_object; }
@@ -1867,7 +1868,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<Expression> m_test;
@@ -1918,7 +1919,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<BlockStatement> m_block;
@@ -1938,7 +1939,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     NonnullRefPtr<Expression> m_argument;
@@ -1971,7 +1972,7 @@ public:
 
     virtual void dump(int indent) const override;
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     Completion execute_impl(Interpreter&, GlobalObject&) const;
     void add_case(NonnullRefPtr<SwitchCase> switch_case) { m_cases.append(move(switch_case)); }
@@ -1992,7 +1993,7 @@ public:
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
 
     FlyString const& target_label() const { return m_target_label; }
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
 private:
     FlyString m_target_label;
@@ -2007,7 +2008,7 @@ public:
     }
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     FlyString const& target_label() const { return m_target_label; }
 
@@ -2023,7 +2024,7 @@ public:
     }
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
-    virtual void generate_bytecode(Bytecode::Generator&) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 };
 
 class SyntheticReferenceExpression final : public Expression {

--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -1354,6 +1354,7 @@ public:
 
     virtual Completion execute(Interpreter&, GlobalObject&) const override;
     virtual void dump(int indent) const override;
+    virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const override;
 
     bool has_name() const { return !m_name.is_empty(); }
 

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1152,8 +1152,6 @@ void TryStatement::generate_bytecode(Bytecode::Generator& generator) const
     if (m_handler) {
         auto& handler_block = generator.make_block();
         generator.switch_to_basic_block(handler_block);
-        if (!m_finalizer)
-            generator.emit<Bytecode::Op::LeaveUnwindContext>();
         m_handler->parameter().visit(
             [&](FlyString const& parameter) {
                 if (!parameter.is_empty()) {

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1337,10 +1337,17 @@ Bytecode::CodeGenerationErrorOr<void> SwitchStatement::generate_bytecode(Bytecod
     return {};
 }
 
-void ClassDeclaration::generate_bytecode(Bytecode::Generator& generator) const
+Bytecode::CodeGenerationErrorOr<void> ClassDeclaration::generate_bytecode(Bytecode::Generator& generator) const
 {
-    generator.emit<Bytecode::Op::NewClass>(m_class_expression);
-    generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(m_class_expression.ptr()->name()));
+    TRY(m_class_expression->generate_bytecode(generator));
+    generator.emit<Bytecode::Op::SetVariable>(generator.intern_identifier(m_class_expression.ptr()->name()), Bytecode::Op::SetVariable::InitializationMode::Initialize);
+    return {};
+}
+
+Bytecode::CodeGenerationErrorOr<void> ClassExpression::generate_bytecode(Bytecode::Generator& generator) const
+{
+    generator.emit<Bytecode::Op::NewClass>(*this);
+    return {};
 }
 
 Bytecode::CodeGenerationErrorOr<void> ThisExpression::generate_bytecode(Bytecode::Generator& generator) const

--- a/Userland/Libraries/LibJS/Bytecode/CodeGenerationError.h
+++ b/Userland/Libraries/LibJS/Bytecode/CodeGenerationError.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/StringView.h>
+#include <LibJS/Forward.h>
+
+namespace JS::Bytecode {
+
+struct CodeGenerationError {
+    ASTNode const* failing_node { nullptr };
+    StringView reason_literal;
+
+    String to_string();
+};
+
+template<typename T>
+using CodeGenerationErrorOr = ErrorOr<T, CodeGenerationError>;
+
+}

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -10,6 +10,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/SinglyLinkedList.h>
 #include <LibJS/Bytecode/BasicBlock.h>
+#include <LibJS/Bytecode/CodeGenerationError.h>
 #include <LibJS/Bytecode/Executable.h>
 #include <LibJS/Bytecode/IdentifierTable.h>
 #include <LibJS/Bytecode/Label.h>
@@ -23,7 +24,7 @@ namespace JS::Bytecode {
 
 class Generator {
 public:
-    static NonnullOwnPtr<Executable> generate(ASTNode const&, FunctionKind = FunctionKind::Normal);
+    static CodeGenerationErrorOr<NonnullOwnPtr<Executable>> generate(ASTNode const&, FunctionKind = FunctionKind::Normal);
 
     Register allocate_register();
 
@@ -71,8 +72,8 @@ public:
         return *static_cast<OpType*>(slot);
     }
 
-    void emit_load_from_reference(JS::ASTNode const&);
-    void emit_store_to_reference(JS::ASTNode const&);
+    CodeGenerationErrorOr<void> emit_load_from_reference(JS::ASTNode const&);
+    CodeGenerationErrorOr<void> emit_store_to_reference(JS::ASTNode const&);
 
     void begin_continuable_scope(Label continue_target);
     void end_continuable_scope();

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -24,6 +24,11 @@ namespace JS::Bytecode {
 
 class Generator {
 public:
+    enum class SurroundingScopeKind {
+        Global,
+        Function,
+        Block,
+    };
     static CodeGenerationErrorOr<NonnullOwnPtr<Executable>> generate(ASTNode const&, FunctionKind = FunctionKind::Normal);
 
     Register allocate_register();
@@ -117,6 +122,55 @@ public:
     bool is_in_generator_function() const { return m_enclosing_function_kind == FunctionKind::Generator; }
     bool is_in_async_function() const { return m_enclosing_function_kind == FunctionKind::Async; }
 
+    enum class BindingMode {
+        Lexical,
+        Var,
+        Global,
+    };
+    struct LexicalScope {
+        SurroundingScopeKind kind;
+        BindingMode mode;
+        HashTable<IdentifierTableIndex> known_bindings;
+    };
+
+    void register_binding(IdentifierTableIndex identifier, BindingMode mode = BindingMode::Lexical)
+    {
+        m_variable_scopes.last_matching([&](auto& x) { return x.mode == BindingMode::Global || x.mode == mode; })->known_bindings.set(identifier);
+    }
+    bool has_binding(IdentifierTableIndex identifier, Optional<BindingMode> const& specific_binding_mode = {})
+    {
+        for (auto index = m_variable_scopes.size(); index > 0; --index) {
+            auto& scope = m_variable_scopes[index - 1];
+
+            if (scope.mode != BindingMode::Global && specific_binding_mode.value_or(scope.mode) != scope.mode)
+                continue;
+
+            if (scope.known_bindings.contains(identifier))
+                return true;
+        }
+        return false;
+    }
+    void begin_variable_scope(BindingMode mode = BindingMode::Lexical, SurroundingScopeKind kind = SurroundingScopeKind::Block)
+    {
+        m_variable_scopes.append({ kind, mode, {} });
+        if (mode != BindingMode::Global) {
+            emit<Bytecode::Op::CreateEnvironment>(
+                mode == BindingMode::Lexical
+                    ? Bytecode::Op::EnvironmentMode::Lexical
+                    : Bytecode::Op::EnvironmentMode::Var);
+        }
+    }
+    void end_variable_scope()
+    {
+        auto mode = m_variable_scopes.take_last().mode;
+        if (mode != BindingMode::Global && !m_current_basic_block->is_terminated()) {
+            emit<Bytecode::Op::LeaveEnvironment>(
+                mode == BindingMode::Lexical
+                    ? Bytecode::Op::EnvironmentMode::Lexical
+                    : Bytecode::Op::EnvironmentMode::Var);
+        }
+    }
+
 private:
     Generator();
     ~Generator();
@@ -134,6 +188,7 @@ private:
     FunctionKind m_enclosing_function_kind { FunctionKind::Normal };
     Vector<Label> m_continuable_scopes;
     Vector<Label> m_breakable_scopes;
+    Vector<LexicalScope> m_variable_scopes;
 };
 
 }

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -20,6 +20,8 @@
     O(ConcatString)                  \
     O(ContinuePendingUnwind)         \
     O(CopyObjectExcludingProperties) \
+    O(CreateEnvironment)             \
+    O(CreateVariable)                \
     O(Decrement)                     \
     O(Div)                           \
     O(EnterUnwindContext)            \
@@ -42,6 +44,7 @@
     O(JumpConditional)               \
     O(JumpNullish)                   \
     O(JumpUndefined)                 \
+    O(LeaveEnvironment)              \
     O(LeaveUnwindContext)            \
     O(LeftShift)                     \
     O(LessThan)                      \

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -10,6 +10,7 @@
 #include <LibJS/Bytecode/Instruction.h>
 #include <LibJS/Bytecode/Interpreter.h>
 #include <LibJS/Bytecode/Op.h>
+#include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/GlobalEnvironment.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Realm.h>
@@ -191,6 +192,14 @@ ThrowCompletionOr<void> Interpreter::continue_pending_unwind(Label const& resume
 
     jump(resume_label);
     return {};
+}
+
+VM::InterpreterExecutionScope Interpreter::ast_interpreter_scope()
+{
+    if (!m_ast_interpreter)
+        m_ast_interpreter = JS::Interpreter::create_with_existing_realm(m_realm);
+
+    return { *m_ast_interpreter };
 }
 
 AK::Array<OwnPtr<PassManager>, static_cast<UnderlyingType<Interpreter::OptimizationLevel>>(Interpreter::OptimizationLevel::__Count)> Interpreter::s_optimization_pipelines {};

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.cpp
@@ -67,7 +67,7 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable const& e
     if (!m_manually_entered_frames.is_empty() && m_manually_entered_frames.last()) {
         m_register_windows.append(make<RegisterWindow>(m_register_windows.last()));
     } else {
-        m_register_windows.append(make<RegisterWindow>());
+        m_register_windows.append(make<RegisterWindow>(MarkedVector<Value>(vm().heap()), MarkedVector<Environment*>(vm().heap()), MarkedVector<Environment*>(vm().heap())));
     }
 
     registers().resize(executable.number_of_registers);
@@ -150,7 +150,7 @@ Interpreter::ValueAndFrame Interpreter::run_and_return_frame(Executable const& e
 
     // NOTE: The return value from a called function is put into $0 in the caller context.
     if (!m_register_windows.is_empty())
-        m_register_windows.last()[0] = return_value;
+        m_register_windows.last().registers[0] = return_value;
 
     // At this point we may have already run any queued promise jobs via on_call_stack_emptied,
     // in which case this is a no-op.

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -18,7 +18,11 @@
 
 namespace JS::Bytecode {
 
-using RegisterWindow = Vector<Value>;
+struct RegisterWindow {
+    MarkedVector<Value> registers;
+    MarkedVector<Environment*> saved_lexical_environments;
+    MarkedVector<Environment*> saved_variable_environments;
+};
 
 class Interpreter {
 public:
@@ -47,6 +51,9 @@ public:
     ALWAYS_INLINE Value& accumulator() { return reg(Register::accumulator()); }
     Value& reg(Register const& r) { return registers()[r.index()]; }
     [[nodiscard]] RegisterWindow snapshot_frame() const { return m_register_windows.last(); }
+
+    auto& saved_lexical_environment_stack() { return m_register_windows.last().saved_lexical_environments; }
+    auto& saved_variable_environment_stack() { return m_register_windows.last().saved_variable_environments; }
 
     void enter_frame(RegisterWindow const& frame)
     {
@@ -82,7 +89,7 @@ public:
     VM::InterpreterExecutionScope ast_interpreter_scope();
 
 private:
-    RegisterWindow& registers() { return m_register_windows.last(); }
+    MarkedVector<Value>& registers() { return m_register_windows.last().registers; }
 
     static AK::Array<OwnPtr<PassManager>, static_cast<UnderlyingType<Interpreter::OptimizationLevel>>(Interpreter::OptimizationLevel::__Count)> s_optimization_pipelines;
 

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -13,6 +13,7 @@
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/Handle.h>
+#include <LibJS/Runtime/VM.h>
 #include <LibJS/Runtime/Value.h>
 
 namespace JS::Bytecode {
@@ -34,7 +35,7 @@ public:
     ThrowCompletionOr<Value> run(Bytecode::Executable const& executable, Bytecode::BasicBlock const* entry_point = nullptr)
     {
         auto value_and_frame = run_and_return_frame(executable, entry_point);
-        return value_and_frame.value;
+        return move(value_and_frame.value);
     }
 
     struct ValueAndFrame {
@@ -78,6 +79,8 @@ public:
     };
     static Bytecode::PassManager& optimization_pipeline(OptimizationLevel = OptimizationLevel::Default);
 
+    VM::InterpreterExecutionScope ast_interpreter_scope();
+
 private:
     RegisterWindow& registers() { return m_register_windows.last(); }
 
@@ -93,6 +96,7 @@ private:
     Executable const* m_current_executable { nullptr };
     Vector<UnwindInfo> m_unwind_contexts;
     Handle<Value> m_saved_exception;
+    OwnPtr<JS::Interpreter> m_ast_interpreter;
 };
 
 extern bool g_dump_bytecode;

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -260,12 +260,63 @@ ThrowCompletionOr<void> GetVariable::execute_impl(Bytecode::Interpreter& interpr
     return {};
 }
 
+ThrowCompletionOr<void> CreateEnvironment::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto make_and_swap_envs = [&](auto*& old_environment) {
+        Environment* environment = new_declarative_environment(*old_environment);
+        swap(old_environment, environment);
+        return environment;
+    };
+    if (m_mode == EnvironmentMode::Lexical)
+        interpreter.saved_lexical_environment_stack().append(make_and_swap_envs(interpreter.vm().running_execution_context().lexical_environment));
+    else if (m_mode == EnvironmentMode::Var)
+        interpreter.saved_variable_environment_stack().append(make_and_swap_envs(interpreter.vm().running_execution_context().variable_environment));
+    return {};
+}
+
+ThrowCompletionOr<void> CreateVariable::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    auto& vm = interpreter.vm();
+    auto const& name = interpreter.current_executable().get_identifier(m_identifier);
+
+    if (m_mode == EnvironmentMode::Lexical) {
+        // Note: This is papering over an issue where "FunctionDeclarationInstantiation" creates these bindings for us.
+        //       Instead of crashing in there, we'll just raise an exception here.
+        if (TRY(vm.lexical_environment()->has_binding(name)))
+            return vm.throw_completion<InternalError>(interpreter.global_object(), String::formatted("Lexical environment already has binding '{}'", name));
+
+        if (m_is_immutable)
+            vm.lexical_environment()->create_immutable_binding(interpreter.global_object(), name, vm.in_strict_mode());
+        else
+            vm.lexical_environment()->create_mutable_binding(interpreter.global_object(), name, vm.in_strict_mode());
+    } else {
+        if (m_is_immutable)
+            vm.variable_environment()->create_immutable_binding(interpreter.global_object(), name, vm.in_strict_mode());
+        else
+            vm.variable_environment()->create_mutable_binding(interpreter.global_object(), name, vm.in_strict_mode());
+    }
+    return {};
+}
+
 ThrowCompletionOr<void> SetVariable::execute_impl(Bytecode::Interpreter& interpreter) const
 {
     auto& vm = interpreter.vm();
-    auto reference = TRY(vm.resolve_binding(interpreter.current_executable().get_identifier(m_identifier)));
-
-    TRY(reference.put_value(interpreter.global_object(), interpreter.accumulator()));
+    auto const& name = interpreter.current_executable().get_identifier(m_identifier);
+    auto environment = m_mode == EnvironmentMode::Lexical ? vm.running_execution_context().lexical_environment : vm.running_execution_context().variable_environment;
+    auto reference = TRY(vm.resolve_binding(name, environment));
+    switch (m_initialization_mode) {
+    case InitializationMode::Initialize:
+        TRY(reference.initialize_referenced_binding(interpreter.global_object(), interpreter.accumulator()));
+        break;
+    case InitializationMode::Set:
+        TRY(reference.put_value(interpreter.global_object(), interpreter.accumulator()));
+        break;
+    case InitializationMode::InitializeOrSet:
+        VERIFY(reference.is_environment_reference());
+        VERIFY(reference.base_environment().is_declarative_environment());
+        TRY(static_cast<DeclarativeEnvironment&>(reference.base_environment()).initialize_or_set_mutable_binding(interpreter.global_object(), name, interpreter.accumulator()));
+        break;
+    }
     return {};
 }
 
@@ -438,6 +489,15 @@ void FinishUnwind::replace_references_impl(BasicBlock const& from, BasicBlock co
 {
     if (&m_next_target.block() == &from)
         m_next_target = Label { to };
+}
+
+ThrowCompletionOr<void> LeaveEnvironment::execute_impl(Bytecode::Interpreter& interpreter) const
+{
+    if (m_mode == EnvironmentMode::Lexical)
+        interpreter.vm().running_execution_context().lexical_environment = interpreter.saved_lexical_environment_stack().take_last();
+    if (m_mode == EnvironmentMode::Var)
+        interpreter.vm().running_execution_context().variable_environment = interpreter.saved_variable_environment_stack().take_last();
+    return {};
 }
 
 ThrowCompletionOr<void> LeaveUnwindContext::execute_impl(Bytecode::Interpreter& interpreter) const
@@ -628,9 +688,27 @@ String GetVariable::to_string_impl(Bytecode::Executable const& executable) const
     return String::formatted("GetVariable {} ({})", m_identifier, executable.identifier_table->get(m_identifier));
 }
 
+String CreateEnvironment::to_string_impl(Bytecode::Executable const&) const
+{
+    auto mode_string = m_mode == EnvironmentMode::Lexical
+        ? "Lexical"
+        : "Variable";
+    return String::formatted("CreateEnvironment mode:{}", mode_string);
+}
+
+String CreateVariable::to_string_impl(Bytecode::Executable const& executable) const
+{
+    auto mode_string = m_mode == EnvironmentMode::Lexical ? "Lexical" : "Variable";
+    return String::formatted("CreateVariable env:{} immutable:{} {} ({})", mode_string, m_is_immutable, m_identifier, executable.identifier_table->get(m_identifier));
+}
+
 String SetVariable::to_string_impl(Bytecode::Executable const& executable) const
 {
-    return String::formatted("SetVariable {} ({})", m_identifier, executable.identifier_table->get(m_identifier));
+    auto initialization_mode_name = m_initialization_mode == InitializationMode ::Initialize ? "Initialize"
+        : m_initialization_mode == InitializationMode::Set                                   ? "Set"
+                                                                                             : "InitializeOrSet";
+    auto mode_string = m_mode == EnvironmentMode::Lexical ? "Lexical" : "Variable";
+    return String::formatted("SetVariable env:{} init:{} {} ({})", mode_string, initialization_mode_name, m_identifier, executable.identifier_table->get(m_identifier));
 }
 
 String PutById::to_string_impl(Bytecode::Executable const& executable) const
@@ -727,6 +805,14 @@ String EnterUnwindContext::to_string_impl(Bytecode::Executable const&) const
 String FinishUnwind::to_string_impl(const Bytecode::Executable&) const
 {
     return String::formatted("FinishUnwind next:{}", m_next_target);
+}
+
+String LeaveEnvironment::to_string_impl(Bytecode::Executable const&) const
+{
+    auto mode_string = m_mode == EnvironmentMode::Lexical
+        ? "Lexical"
+        : "Variable";
+    return String::formatted("LeaveEnvironment env:{}", mode_string);
 }
 
 String LeaveUnwindContext::to_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -536,10 +536,14 @@ ThrowCompletionOr<void> IteratorResultValue::execute_impl(Bytecode::Interpreter&
     return {};
 }
 
-ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter&) const
+ThrowCompletionOr<void> NewClass::execute_impl(Bytecode::Interpreter& interpreter) const
 {
-    (void)m_class_expression;
-    TODO();
+    auto name = m_class_expression.name();
+    auto scope = interpreter.ast_interpreter_scope();
+    auto& ast_interpreter = scope.interpreter();
+    auto class_object = TRY(m_class_expression.class_definition_evaluation(ast_interpreter, interpreter.global_object(), name, name.is_null() ? "" : name));
+    interpreter.accumulator() = class_object;
+    return {};
 }
 
 String Load::to_string_impl(Bytecode::Executable const&) const

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -281,11 +281,34 @@ private:
     Register m_lhs;
 };
 
-class SetVariable final : public Instruction {
+enum class EnvironmentMode {
+    Lexical,
+    Var,
+};
+
+class CreateEnvironment final : public Instruction {
 public:
-    explicit SetVariable(IdentifierTableIndex identifier)
-        : Instruction(Type::SetVariable)
+    explicit CreateEnvironment(EnvironmentMode mode)
+        : Instruction(Type::CreateEnvironment)
+        , m_mode(mode)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    String to_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+
+private:
+    EnvironmentMode m_mode { EnvironmentMode::Lexical };
+};
+
+class CreateVariable final : public Instruction {
+public:
+    explicit CreateVariable(IdentifierTableIndex identifier, EnvironmentMode mode, bool is_immutable)
+        : Instruction(Type::CreateVariable)
         , m_identifier(identifier)
+        , m_mode(mode)
+        , m_is_immutable(is_immutable)
     {
     }
 
@@ -295,6 +318,33 @@ public:
 
 private:
     IdentifierTableIndex m_identifier;
+    EnvironmentMode m_mode;
+    bool m_is_immutable { false };
+};
+
+class SetVariable final : public Instruction {
+public:
+    enum class InitializationMode {
+        Initialize,
+        Set,
+        InitializeOrSet,
+    };
+    explicit SetVariable(IdentifierTableIndex identifier, InitializationMode initialization_mode = InitializationMode::Set, EnvironmentMode mode = EnvironmentMode::Lexical)
+        : Instruction(Type::SetVariable)
+        , m_identifier(identifier)
+        , m_mode(mode)
+        , m_initialization_mode(initialization_mode)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    String to_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+
+private:
+    IdentifierTableIndex m_identifier;
+    EnvironmentMode m_mode;
+    InitializationMode m_initialization_mode { InitializationMode::Set };
 };
 
 class GetVariable final : public Instruction {
@@ -596,6 +646,22 @@ private:
     Label m_entry_point;
     Optional<Label> m_handler_target;
     Optional<Label> m_finalizer_target;
+};
+
+class LeaveEnvironment final : public Instruction {
+public:
+    LeaveEnvironment(EnvironmentMode mode)
+        : Instruction(Type::LeaveEnvironment)
+        , m_mode(mode)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    String to_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+
+private:
+    EnvironmentMode m_mode { EnvironmentMode::Lexical };
 };
 
 class LeaveUnwindContext final : public Instruction {

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -579,7 +579,11 @@ ThrowCompletionOr<Value> perform_eval(Value x, GlobalObject& caller_realm, Calle
     Optional<Value> eval_result;
 
     if (auto* bytecode_interpreter = Bytecode::Interpreter::current()) {
-        auto executable = JS::Bytecode::Generator::generate(program);
+        auto executable_result = JS::Bytecode::Generator::generate(program);
+        if (executable_result.is_error())
+            return vm.throw_completion<InternalError>(bytecode_interpreter->global_object(), ErrorType::NotImplemented, executable_result.error().to_string());
+
+        auto executable = executable_result.release_value();
         executable->name = "eval"sv;
         if (JS::Bytecode::g_dump_bytecode)
             executable->dump();

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -196,15 +196,21 @@ ThrowCompletionOr<bool> DeclarativeEnvironment::delete_binding(GlobalObject&, Fl
     return true;
 }
 
-void DeclarativeEnvironment::initialize_or_set_mutable_binding(Badge<ScopeNode>, GlobalObject& global_object, FlyString const& name, Value value)
+ThrowCompletionOr<void> DeclarativeEnvironment::initialize_or_set_mutable_binding(GlobalObject& global_object, FlyString const& name, Value value)
 {
     auto it = m_names.find(name);
     VERIFY(it != m_names.end());
     auto& binding = m_bindings[it->value];
     if (!binding.initialized)
-        MUST(initialize_binding(global_object, name, value));
+        TRY(initialize_binding(global_object, name, value));
     else
-        MUST(set_mutable_binding(global_object, name, value, false));
+        TRY(set_mutable_binding(global_object, name, value, false));
+    return {};
+}
+
+void DeclarativeEnvironment::initialize_or_set_mutable_binding(Badge<ScopeNode>, GlobalObject& global_object, FlyString const& name, Value value)
+{
+    MUST(initialize_or_set_mutable_binding(global_object, name, value));
 }
 
 Vector<String> DeclarativeEnvironment::bindings() const

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -31,6 +31,7 @@ public:
     virtual ThrowCompletionOr<bool> delete_binding(GlobalObject&, FlyString const& name) override;
 
     void initialize_or_set_mutable_binding(Badge<ScopeNode>, GlobalObject& global_object, FlyString const& name, Value value);
+    ThrowCompletionOr<void> initialize_or_set_mutable_binding(GlobalObject& global_object, FlyString const& name, Value value);
 
     // This is not a method defined in the spec! Do not use this in any LibJS (or other spec related) code.
     [[nodiscard]] Vector<String> bindings() const;

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -767,7 +767,11 @@ Completion ECMAScriptFunctionObject::ordinary_call_evaluate_body()
         // FIXME: pass something to evaluate default arguments with
         TRY(function_declaration_instantiation(nullptr));
         if (!m_bytecode_executable) {
-            m_bytecode_executable = Bytecode::Generator::generate(m_ecmascript_code, m_kind);
+            auto executable_result = JS::Bytecode::Generator::generate(m_ecmascript_code, m_kind);
+            if (executable_result.is_error())
+                return vm.throw_completion<InternalError>(bytecode_interpreter->global_object(), ErrorType::NotImplemented, executable_result.error().to_string());
+
+            m_bytecode_executable = executable_result.release_value();
             m_bytecode_executable->name = m_name;
             auto& passes = JS::Bytecode::Interpreter::optimization_pipeline();
             passes.perform(*m_bytecode_executable);

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -542,14 +542,16 @@ ThrowCompletionOr<void> ECMAScriptFunctionObject::function_declaration_instantia
     if (!scope_body)
         return {};
 
-    scope_body->for_each_lexically_scoped_declaration([&](Declaration const& declaration) {
-        declaration.for_each_bound_name([&](auto const& name) {
-            if (declaration.is_constant_declaration())
-                MUST(lex_environment->create_immutable_binding(global_object(), name, true));
-            else
-                MUST(lex_environment->create_mutable_binding(global_object(), name, false));
+    if (!Bytecode::Interpreter::current()) {
+        scope_body->for_each_lexically_scoped_declaration([&](Declaration const& declaration) {
+            declaration.for_each_bound_name([&](auto const& name) {
+                if (declaration.is_constant_declaration())
+                    MUST(lex_environment->create_immutable_binding(global_object(), name, true));
+                else
+                    MUST(lex_environment->create_mutable_binding(global_object(), name, false));
+            });
         });
-    });
+    }
 
     auto* private_environment = callee_context.private_environment;
     for (auto& declaration : functions_to_initialize) {

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -97,7 +97,7 @@ ThrowCompletionOr<Value> GeneratorObject::next_impl(VM& vm, GlobalObject& global
     VERIFY(!m_generating_function->bytecode_executable()->basic_blocks.find_if([next_block](auto& block) { return block == next_block; }).is_end());
 
     // Restore the snapshot registers
-    bytecode_interpreter->enter_frame(m_frame);
+    bytecode_interpreter->enter_frame(*m_frame);
 
     // Temporarily switch to the captured execution context
     TRY(vm.push_execution_context(m_execution_context, global_object));

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -29,7 +29,7 @@ private:
     ExecutionContext m_execution_context;
     ECMAScriptFunctionObject* m_generating_function { nullptr };
     Value m_previous_value;
-    Bytecode::RegisterWindow m_frame;
+    Optional<Bytecode::RegisterWindow> m_frame;
     bool m_done { false };
 };
 

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -55,6 +55,8 @@ public:
         InterpreterExecutionScope(Interpreter&);
         ~InterpreterExecutionScope();
 
+        Interpreter& interpreter() { return m_interpreter; }
+
     private:
         Interpreter& m_interpreter;
     };

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -346,7 +346,7 @@ inline JSFileResult TestRunner::run_file_test(const String& test_path)
     auto test_script = result.release_value();
 
     if (g_run_bytecode) {
-        auto executable = JS::Bytecode::Generator::generate(test_script->parse_node());
+        auto executable = MUST(JS::Bytecode::Generator::generate(test_script->parse_node()));
         executable->name = test_path;
         if (JS::Bytecode::g_dump_bytecode)
             executable->dump();
@@ -362,12 +362,15 @@ inline JSFileResult TestRunner::run_file_test(const String& test_path)
     if (file_script.is_error())
         return { test_path, file_script.error() };
     if (g_run_bytecode) {
-        auto executable = JS::Bytecode::Generator::generate(file_script.value()->parse_node());
-        executable->name = test_path;
-        if (JS::Bytecode::g_dump_bytecode)
-            executable->dump();
-        JS::Bytecode::Interpreter bytecode_interpreter(interpreter->global_object(), interpreter->realm());
-        (void)bytecode_interpreter.run(*executable);
+        auto executable_result = JS::Bytecode::Generator::generate(file_script.value()->parse_node());
+        if (!executable_result.is_error()) {
+            auto executable = executable_result.release_value();
+            executable->name = test_path;
+            if (JS::Bytecode::g_dump_bytecode)
+                executable->dump();
+            JS::Bytecode::Interpreter bytecode_interpreter(interpreter->global_object(), interpreter->realm());
+            (void)bytecode_interpreter.run(*executable);
+        }
     } else {
         g_vm->push_execution_context(global_execution_context, interpreter->global_object());
         (void)interpreter->run(file_script.value());


### PR DESCRIPTION
Implements some stuff, fixes some more, makes running a bit faster, and breaks about 150 currently passing test262 tests.

- Scoping: Much closer to the specification
- Classes: Kinda work
- Hoisting: hoisted
- Exceptions: kinda working a bit
- test-js: we can run the test common file now
- Gets rid of TODO() calls in the code generator, that's yucky.

Note: will come with an accompanying libjs-test262 patch that is required for that guy to compile with these changes.

TLDR: test262 -> 40%

Nitpick away, friends.