### PR TITLE
Kernel: Fix deadlock when setting VirtIOGPU resolution

### DIFF
--- a/Kernel/Graphics/VirtIOGPU/FramebufferDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/FramebufferDevice.cpp
@@ -84,8 +84,6 @@ ErrorOr<void> FramebufferDevice::set_head_resolution(size_t head, size_t width, 
 
     auto& info = display_info();
 
-    SpinlockLocker locker(adapter()->operation_lock());
-
     info.rect = {
         .x = 0,
         .y = 0,
@@ -167,6 +165,7 @@ FramebufferDevice::~FramebufferDevice()
 
 ErrorOr<void> FramebufferDevice::create_framebuffer()
 {
+    SpinlockLocker locker(adapter()->operation_lock());
     // First delete any existing framebuffers to free the memory first
     m_framebuffer = nullptr;
     m_framebuffer_sink_vmobject = nullptr;
@@ -185,7 +184,6 @@ ErrorOr<void> FramebufferDevice::create_framebuffer()
     }
     m_framebuffer_sink_vmobject = TRY(Memory::AnonymousVMObject::try_create_with_physical_pages(pages.span()));
 
-    SpinlockLocker locker(adapter()->operation_lock());
     m_current_buffer = &buffer_from_index(m_last_set_buffer_index.load());
     create_buffer(m_main_buffer, 0, m_buffer_size);
     create_buffer(m_back_buffer, m_buffer_size, m_buffer_size);


### PR DESCRIPTION
This fixes a small regression introduced by 200589ba279d20db81a8de5f2ed0f8587e42c2d6 that causes the WindowServer to hang on boot. The code was originally written to utilize the re-entrant nature of `Mutex`es, switching them to spinlocks caused hangs in these code paths. We fix it by removing the lock in `set_head_resolution()` and moving up the lock in `create_framebuffer()`, which is something we should do anyway since we really should not be allowing the framebuffer memory regions to be modified while virtiogpu operations are ongoing elsewhere.