### PR TITLE
LibGUI: Allow breadcrumbbar segment activation using the keyboard

### DIFF
--- a/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
+++ b/Userland/Libraries/LibGUI/Breadcrumbbar.cpp
@@ -87,6 +87,10 @@ void Breadcrumbbar::append_segment(String text, Gfx::Bitmap const* icon, String 
         if (on_segment_click)
             on_segment_click(index);
     };
+    button.on_focus_change = [this, index = m_segments.size()](auto has_focus, auto) {
+        if (has_focus && on_segment_click)
+            on_segment_click(index);
+    };
     button.on_drop = [this, index = m_segments.size()](auto& drop_event) {
         if (on_segment_drop)
             on_segment_drop(index, drop_event);


### PR DESCRIPTION
We now interpret a segment gaining focus just as clicking on the segment, allowing keyboard navigation using the arrow keys.

https://user-images.githubusercontent.com/42888162/153748988-31db4e9e-d800-460b-bc1b-3cefaac1c64f.mp4


