### PR TITLE
LibGUI: Allow activation of CommandPalette without a focused widget

### DIFF
--- a/Userland/Libraries/LibGUI/WindowServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowServerConnection.cpp
@@ -195,9 +195,12 @@ void WindowServerConnection::key_down(i32 window_id, u32 code_point, u32 key, u3
         key_event->m_code_point = emoji_code_point;
     }
 
+    bool accepts_command_palette = true;
+    if (window->focused_widget())
+        accepts_command_palette = window->focused_widget()->accepts_command_palette();
+
     // FIXME: This shortcut should be configurable.
-    bool focused_widget_accepts_command_palette = window->focused_widget() && window->focused_widget()->accepts_command_palette();
-    if (focused_widget_accepts_command_palette && !m_in_command_palette && modifiers == (Mod_Ctrl | Mod_Shift) && key == Key_A) {
+    if (accepts_command_palette && !m_in_command_palette && modifiers == (Mod_Ctrl | Mod_Shift) && key == Key_A) {
         auto command_palette = CommandPalette::construct(*window);
         TemporaryChange change { m_in_command_palette, true };
         if (command_palette->exec() != GUI::Dialog::ExecOK)


### PR DESCRIPTION
Previously we required there to be a focused widget so it would have been able to opt out. In case the isn't a focused widget there is no way for it to opt out anyways, so let's allow CommandPalette to work in this case :^)

This makes various applications like ImageViewer work with CommandPalette again
