### PR TITLE
Lagom: Add an initial LibGUI port

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -398,8 +398,8 @@ if (BUILD_LAGOM)
     # PDF
     file(GLOB LIBPDF_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibPDF/*.cpp")
     lagom_lib(PDF pdf
-       SOURCES ${LIBPDF_SOURCES}
-       LIBS LagomGfx LagomIPC LagomTextCodec
+        SOURCES ${LIBPDF_SOURCES}
+        LIBS LagomGfx LagomIPC LagomTextCodec
     )
 
     # Regex

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -139,6 +139,7 @@ include_directories(./Libraries/)
 include_directories(../../)
 include_directories(../../Userland/)
 include_directories(../../Userland/Libraries/)
+include_directories(${CMAKE_BINARY_DIR}/Userland/Libraries/)
 include_directories(${CMAKE_BINARY_DIR})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
@@ -177,6 +178,33 @@ function(lagom_lib library fs_name)
     if (NOT ENABLE_OSS_FUZZ AND NOT ENABLE_FUZZER_SANITIZER)
         # alias for parity with exports
         add_library(Lagom::${library} ALIAS ${target_name})
+    endif()
+
+    # FIXME: do this properly and not here.
+    # Currently LibGUI is the only one that uses GML and we have no proper
+    # way to handle adding custom target dependenices to libraries.
+    if ("${library}" STREQUAL "GUI")
+        # Custom compile_gml function based on code_generators.cmake
+        function(compile_gml source output string_name)
+            set(output ${CMAKE_BINARY_DIR}/Userland/Libraries/LibGUI/${output})
+            add_custom_command(
+                OUTPUT ${output}
+                COMMAND ${SERENITY_PROJECT_ROOT}/Meta/text-to-cpp-string.sh ${string_name} ${source} > ${output}.tmp
+                COMMAND "${CMAKE_COMMAND}" -E copy_if_different ${output}.tmp ${output}
+                COMMAND "${CMAKE_COMMAND}" -E remove ${output}.tmp
+                VERBATIM
+                DEPENDS ${SERENITY_PROJECT_ROOT}/Meta/text-to-cpp-string.sh
+                MAIN_DEPENDENCY ${source}
+            )
+            get_filename_component(output_name ${output} NAME)
+            add_custom_target(generate_${output_name} DEPENDS ${output})
+            add_dependencies(${target_name} generate_${output_name})
+        endfunction()
+
+        # TODO: Customizable array?
+        compile_gml("../../Userland/Libraries/LibGUI/FontPickerDialog.gml" FontPickerDialogGML.h font_picker_dialog_gml)
+        compile_gml("../../Userland/Libraries/LibGUI/FilePickerDialog.gml" FilePickerDialogGML.h file_picker_dialog_gml)
+        compile_gml("../../Userland/Libraries/LibGUI/PasswordInputDialog.gml" PasswordInputDialogGML.h password_input_dialog_gml)
     endif()
 
     set_target_properties(
@@ -483,15 +511,14 @@ if (BUILD_LAGOM)
 
         # FIXME: Let's exclude a bunch of things to get something building :^)
         list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/ColorInput.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/ColorPicker.*")
         list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/DisplayLink.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/FilePicker.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/FileSystemModel.*")
         list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/Notification.*")
         list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/MouseTracker.*")
-        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/FileSystemModel.*")
-        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/PasswordInputDialog.*")
-        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/ScreenLayout.*")
-        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/SettingsWindow.*")
         list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/ProcessChooser.*")
-        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/(.*)Picker(.*).*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/ScreenLayout.*")
 
         lagom_lib(GUI gui
             SOURCES ${SDL2_INCLUDE_DIRS} ${LIBGUI_LAGOM_SOURCES} ${LIBGUI_SOURCES}

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -135,6 +135,7 @@ set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} ${LINKER_FLAGS}")
 
 configure_file(../../AK/Debug.h.in AK/Debug.h @ONLY)
 
+include_directories(./Libraries/)
 include_directories(../../)
 include_directories(../../Userland/)
 include_directories(../../Userland/Libraries/)
@@ -467,6 +468,36 @@ if (BUILD_LAGOM)
     lagom_lib(Wasm wasm
         SOURCES ${LIBWASM_SOURCES}
     )
+
+    # LibGUI
+    find_package(SDL2)
+    if(${SDL2_FOUND})
+        file(GLOB LIBGUI_LAGOM_SOURCES CONFIGURE_DEPENDS "./Libraries/LibGUI/*.cpp")
+        file(GLOB LIBGUI_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibGUI/*.cpp")
+
+        # Re-impl in `Libraries/LibGUI`
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/Clipboard.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/Desktop.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/WindowManagerServerConnection.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/WindowServerConnection.*")
+
+        # FIXME: Let's exclude a bunch of things to get something building :^)
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/ColorInput.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/DisplayLink.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/Notification.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/MouseTracker.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/FileSystemModel.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/PasswordInputDialog.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/ScreenLayout.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/SettingsWindow.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/ProcessChooser.*")
+        list(FILTER LIBGUI_SOURCES EXCLUDE REGEX "../../Userland/Libraries/LibGUI/(.*)Picker(.*).*")
+
+        lagom_lib(GUI gui
+            SOURCES ${SDL2_INCLUDE_DIRS} ${LIBGUI_LAGOM_SOURCES} ${LIBGUI_SOURCES}
+            LIBS SDL2::SDL2 LagomELF LagomGfx LagomGML LagomRegex
+        )
+    endif()
 
     # x86
     # FIXME: Excluding arm64 is a temporary hack to circumvent a build problem

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -518,6 +518,11 @@ if (BUILD_LAGOM)
         add_executable(TestApp TestApp.cpp)
         target_link_libraries(TestApp LagomCore)
 
+        if(${SDL2_FOUND})
+            add_executable(DemoGUI Demos/DemoGUI.cpp)
+            target_link_libraries(DemoGUI LagomCore LagomMain LagomGUI)
+        endif()
+
         add_executable(TestJson TestJson.cpp)
         target_link_libraries(TestJson LagomCore)
 

--- a/Meta/Lagom/Demos/DemoGUI.cpp
+++ b/Meta/Lagom/Demos/DemoGUI.cpp
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/System.h>
+#include <LibGUI/AboutDialog.h>
+#include <LibGUI/Application.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGUI/Button.h>
+#include <LibGUI/Frame.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/MessageBox.h>
+#include <LibGUI/TableView.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/FontDatabase.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/SystemTheme.h>
+#include <LibMain/Main.h>
+#include <stdlib.h>
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    char const* serenity_source_dir = getenv("SERENITY_SOURCE_DIR");
+    if (serenity_source_dir == nullptr) {
+        // Assume running from Build/lagom.
+        serenity_source_dir = "../..";
+    }
+
+    // Set default font path.
+    Gfx::FontDatabase::set_default_fonts_lookup_path(String::formatted("{}/Base/res/fonts", serenity_source_dir));
+    // Set the default font, this is required here since we're not running in a Serenity env
+    Gfx::FontDatabase::set_default_font_query("Katica 10 400 0"sv);
+    Gfx::FontDatabase::set_fixed_width_font_query("Katica 10 400 0"sv);
+    // Ditto but for the theme and palette
+    Gfx::set_system_theme(Gfx::load_system_theme(String::formatted("{}/Base/res/themes/Default.ini", serenity_source_dir)));
+
+    auto app = TRY(GUI::Application::try_create(arguments));
+    app->set_system_palette(Gfx::current_system_theme_buffer());
+
+    auto window = TRY(GUI::Window::try_create());
+    window->set_title("Hello LibGUI World");
+    window->resize(600, 400);
+    window->set_minimum_size(300, 245);
+
+    auto widget = TRY(window->try_set_main_widget<GUI::Widget>());
+    widget->set_fill_with_background_color(true);
+
+    auto layout = TRY(widget->try_set_layout<GUI::VerticalBoxLayout>());
+    layout->set_margins(16);
+    layout->set_spacing(5);
+
+    auto label = TRY(widget->try_add<GUI::Label>("Hello World :^)"));
+    label->set_tooltip("Well howdy friend!");
+    label->set_fixed_height(25);
+
+    auto frame = TRY(widget->try_add<GUI::Frame>());
+    auto frame_layout = TRY(frame->try_set_layout<GUI::VerticalBoxLayout>());
+    frame_layout->set_margins(16);
+    frame_layout->set_spacing(5);
+
+    auto center_button = TRY(frame->try_add<GUI::Button>("Center"));
+    center_button->on_click = [&](auto) {
+        window->center_on_screen();
+    };
+
+    auto opacity_button = TRY(frame->try_add<GUI::Button>("Toggle opacity"));
+    opacity_button->on_click = [&](auto) {
+        window->set_opacity(window->opacity() < 1 ? 1 : 0.45);
+    };
+
+    auto disabled_button = TRY(frame->try_add<GUI::Button>("This button is disabled :^("));
+    disabled_button->set_enabled(false);
+    disabled_button->set_shrink_to_fit(true);
+
+    auto buttons = TRY(widget->try_add<GUI::Widget>());
+    buttons->set_fixed_height(25);
+    auto buttons_layout = TRY(buttons->try_set_layout<GUI::HorizontalBoxLayout>());
+    buttons_layout->set_spacing(5);
+
+    auto popup_button = TRY(buttons->try_add<GUI::Button>("A very cool button"));
+    popup_button->on_click = [&](auto) {
+        GUI::MessageBox::show(window, "Hello friends!", ":^)");
+    };
+
+    auto about_button = TRY(buttons->try_add<GUI::Button>("About"));
+    about_button->on_click = [&](auto) {
+        GUI::AboutDialog::show("SerenityOS", nullptr, nullptr, nullptr, Core::Version::read_long_version_string());
+    };
+
+    auto exit_button = TRY(buttons->try_add<GUI::Button>("Exit"));
+    exit_button->on_click = [&](auto) {
+        app->quit(0);
+    };
+
+    window->show();
+    return app->exec();
+}

--- a/Meta/Lagom/Libraries/LibGUI/Clipboard.cpp
+++ b/Meta/Lagom/Libraries/LibGUI/Clipboard.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGUI/Clipboard.h>
+
+namespace GUI {
+
+Clipboard& Clipboard::the()
+{
+    static Clipboard s_the;
+    return s_the;
+}
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/Clipboard.h
+++ b/Meta/Lagom/Libraries/LibGUI/Clipboard.h
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/ByteBuffer.h>
+#include <AK/Function.h>
+#include <AK/HashMap.h>
+#include <AK/String.h>
+#include <LibGUI/Forward.h>
+#include <LibGfx/Forward.h>
+
+namespace GUI {
+
+class ClipboardServerConnection;
+
+class Clipboard {
+public:
+    class ClipboardClient {
+    public:
+        ClipboardClient() = default;
+        virtual ~ClipboardClient() = default;
+
+        virtual void clipboard_content_did_change(String const& mime_type) = 0;
+    };
+
+    struct DataAndType {
+        ByteBuffer data;
+        String mime_type;
+        HashMap<String, String> metadata;
+
+        RefPtr<Gfx::Bitmap> as_bitmap() const;
+    };
+
+    static void initialize(Badge<Application>) { }
+    static Clipboard& the();
+
+    DataAndType fetch_data_and_type() const { return {}; }
+    String fetch_mime_type() const { return ""; }
+
+    void set_data(ReadonlyBytes, String const&, HashMap<String, String> const&) { }
+    void set_plain_text(String const&) { }
+    void set_bitmap(Gfx::Bitmap const&) { }
+    void clear() { }
+
+private:
+    Clipboard() = default;
+};
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/ConnectionToWindowMangerServer.cpp
+++ b/Meta/Lagom/Libraries/LibGUI/ConnectionToWindowMangerServer.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Singleton.h>
+#include <LibGUI/ConnectionToWindowMangerServer.h>
+
+namespace GUI {
+
+static Singleton<ConnectionToWindowMangerServer> s_the;
+ConnectionToWindowMangerServer& ConnectionToWindowMangerServer::the()
+{
+    return *s_the;
+}
+
+void ConnectionToWindowMangerServer::async_set_event_mask(i32)
+{
+    // NOP
+}
+
+void ConnectionToWindowMangerServer::async_set_manager_window(i32)
+{
+    // NOP
+}
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/ConnectionToWindowMangerServer.h
+++ b/Meta/Lagom/Libraries/LibGUI/ConnectionToWindowMangerServer.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+
+namespace GUI {
+
+class ConnectionToWindowMangerServer {
+public:
+    static ConnectionToWindowMangerServer& the();
+    ConnectionToWindowMangerServer() = default;
+
+    void async_set_event_mask(i32);
+    void async_set_manager_window(i32);
+};
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/ConnectionToWindowServer.cpp
+++ b/Meta/Lagom/Libraries/LibGUI/ConnectionToWindowServer.cpp
@@ -1,0 +1,269 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Singleton.h>
+#include <LibCore/EventLoop.h>
+#include <LibGUI/ConnectionToWindowServer.h>
+#include <LibGUI/Event.h>
+#include <LibGUI/SDLServer.h>
+#include <LibGUI/Window.h>
+#include <SDL.h>
+
+namespace GUI {
+
+static Singleton<ConnectionToWindowServer> s_the;
+ConnectionToWindowServer& ConnectionToWindowServer::the()
+{
+    return *s_the;
+}
+
+void ConnectionToWindowServer::paint(i32 window_id, Gfx::IntSize const& window_size, Vector<Gfx::IntRect> const& rects)
+{
+    if (auto* window = Window::from_window_id(window_id))
+        Core::EventLoop::current().post_event(*window, make<MultiPaintEvent>(rects, window_size));
+}
+
+void ConnectionToWindowServer::window_resized(i32 window_id, Gfx::IntRect const& new_rect)
+{
+    if (auto* window = Window::from_window_id(window_id)) {
+        Core::EventLoop::current().post_event(*window, make<ResizeEvent>(new_rect.size()));
+    }
+}
+
+static MouseButton to_mouse_button(u32 button)
+{
+    switch (button) {
+    case 0:
+        return MouseButton::None;
+    case 1:
+        return MouseButton::Primary;
+    case 2:
+        return MouseButton::Secondary;
+    case 4:
+        return MouseButton::Middle;
+    case 8:
+        return MouseButton::Backward;
+    case 16:
+        return MouseButton::Forward;
+    default:
+        VERIFY_NOT_REACHED();
+        break;
+    }
+}
+
+void ConnectionToWindowServer::mouse_move(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, bool is_drag, Vector<String> const& mime_types)
+{
+    if (auto* window = Window::from_window_id(window_id)) {
+        if (is_drag)
+            Core::EventLoop::current().post_event(*window, make<DragEvent>(Event::DragMove, mouse_position, mime_types));
+        else
+            Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseMove, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
+    }
+}
+
+void ConnectionToWindowServer::mouse_down(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
+{
+    if (auto* window = Window::from_window_id(window_id))
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDown, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
+}
+
+void ConnectionToWindowServer::mouse_up(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
+{
+    if (auto* window = Window::from_window_id(window_id))
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseUp, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
+}
+
+void ConnectionToWindowServer::async_create_window(i32 window_id, Gfx::IntRect const& rect,
+    bool auto_position, bool, bool modal, bool, bool, bool resizable,
+    bool fullscreen, bool frameless, bool, bool, float opacity,
+    float, Gfx::IntSize const&, Gfx::IntSize const&,
+    Gfx::IntSize const& minimum_size, Optional<Gfx::IntSize> const&, i32 type,
+    String const& title, i32 parent_window_id, Gfx::IntRect const&)
+{
+    // FIXME: track child windows
+    u32 flags = SDL_WINDOW_SHOWN;
+
+    switch ((GUI::WindowType)type) {
+    case GUI::WindowType::Tooltip:
+        flags |= SDL_WINDOW_BORDERLESS;
+        flags |= SDL_WINDOW_ALWAYS_ON_TOP;
+        flags |= SDL_WINDOW_SKIP_TASKBAR;
+        flags |= SDL_WINDOW_TOOLTIP;
+        break;
+    default:
+        break;
+    }
+
+    if (fullscreen)
+        flags |= SDL_WINDOW_FULLSCREEN;
+
+    SDL_Window* window = SDL_CreateWindow(
+        title.characters(),
+        auto_position ? SDL_WINDOWPOS_CENTERED : rect.x(),
+        auto_position ? SDL_WINDOWPOS_CENTERED : rect.y(),
+        rect.width(),
+        rect.height(),
+        flags);
+
+    if (frameless)
+        SDL_SetWindowBordered(window, SDL_bool(!frameless));
+    if (modal && parent_window_id != 0)
+        SDL_SetWindowModalFor(window, SDLServer::the().window(parent_window_id));
+
+    SDL_SetWindowMinimumSize(window, minimum_size.width(), minimum_size.height());
+    SDL_SetWindowResizable(window, SDL_bool(resizable));
+    SDL_SetWindowOpacity(window, opacity);
+    SDL_SetSurfaceRLE(SDL_GetWindowSurface(window), 1);
+
+    SDL_DisplayMode mode {
+        SDL_PIXELFORMAT_RGBA32,
+        rect.width(),
+        rect.height(),
+        0,
+        nullptr
+    };
+    SDL_SetWindowDisplayMode(window, &mode);
+
+    SDLServer::the().register_window(window_id, window);
+}
+
+Vector<i32>& ConnectionToWindowServer::destroy_window(i32 window_id)
+{
+    // FIXME: destroy child windows
+    SDLServer::the().deregister_window(window_id);
+
+    auto destroyed_window_ids = new Vector<i32>();
+    destroyed_window_ids->append(window_id);
+    return *destroyed_window_ids;
+}
+
+void ConnectionToWindowServer::async_set_window_title(i32 window_id, String const& title)
+{
+    SDLServer::the().set_window_title(window_id, title);
+}
+
+String ConnectionToWindowServer::get_window_title(i32 window_id)
+{
+    return SDLServer::the().get_window_title(window_id);
+}
+
+void ConnectionToWindowServer::async_did_finish_painting(i32 window_id, Vector<Gfx::IntRect> const&)
+{
+    // TODO: only update the rects that were actually painted
+    // as per provided by the second argument
+
+    auto sdl_window = SDLServer::the().window(window_id);
+    auto window = Window::from_window_id(window_id);
+
+    auto screen_surface = SDL_GetWindowSurface(sdl_window);
+
+    auto bitmap = window->back_bitmap();
+    if (!bitmap)
+        return;
+
+    int sdl_width, sdl_height;
+    SDL_GetWindowSize(sdl_window, &sdl_width, &sdl_height);
+
+    // If we resize the window fast enough there will be a size mismatch; let's handle that.
+    if (bitmap->width() != sdl_width || bitmap->height() != sdl_height) {
+        return;
+    }
+
+    SDL_LockSurface(screen_surface);
+    SDL_memcpy(screen_surface->pixels, bitmap->data(), bitmap->size_in_bytes());
+    SDL_UnlockSurface(screen_surface);
+    SDL_UpdateWindowSurface(sdl_window);
+}
+
+void ConnectionToWindowServer::async_invalidate_rect(i32 window_id, Vector<Gfx::IntRect> const& rects, bool)
+{
+    auto window = Window::from_window_id(window_id);
+    if (!window->is_visible())
+        return;
+
+    ConnectionToWindowServer::the().paint(window->window_id(), window->size(), rects);
+}
+
+void ConnectionToWindowServer::async_set_forced_shadow(i32, bool)
+{
+    // NOP
+}
+
+void ConnectionToWindowServer::async_refresh_system_theme()
+{
+    // NOP
+}
+
+void ConnectionToWindowServer::async_set_fullscreen(i32 window_id, bool fullscreen)
+{
+    SDL_SetWindowFullscreen(SDLServer::the().window(window_id), fullscreen ? SDL_WINDOW_FULLSCREEN_DESKTOP : 0);
+}
+
+void ConnectionToWindowServer::async_set_frameless(i32 window_id, bool frameless)
+{
+    SDL_SetWindowBordered(SDLServer::the().window(window_id), SDL_bool(!frameless));
+}
+
+void ConnectionToWindowServer::async_set_maximized(i32 window_id, bool maximized)
+{
+    if (maximized)
+        SDL_MaximizeWindow(SDLServer::the().window(window_id));
+    else
+        SDL_RestoreWindow(SDLServer::the().window(window_id));
+}
+
+void ConnectionToWindowServer::async_set_window_opacity(i32 window_id, float opacity)
+{
+    SDL_SetWindowOpacity(SDLServer::the().window(window_id), opacity);
+}
+
+Gfx::IntPoint ConnectionToWindowServer::get_global_cursor_position()
+{
+    int x = 0, y = 0;
+    SDL_GetGlobalMouseState(&x, &y);
+    return Gfx::IntPoint(x, y);
+}
+
+Gfx::IntRect const& ConnectionToWindowServer::set_window_rect(i32 window_id, Gfx::IntRect const& rect)
+{
+    SDLServer::the().set_window_rect(window_id, rect);
+
+    return rect;
+}
+
+Gfx::IntRect ConnectionToWindowServer::get_window_rect(i32 window_id)
+{
+    return SDLServer::the().get_window_rect(window_id);
+}
+
+void ConnectionToWindowServer::async_move_window_to_front(i32 window_id)
+{
+    SDL_RaiseWindow(SDLServer::the().window(window_id));
+}
+
+Gfx::IntRect ConnectionToWindowServer::get_applet_rect_on_screen(i32)
+{
+    return Gfx::IntRect(0, 0, 0, 0);
+}
+
+Gfx::IntSize ConnectionToWindowServer::get_window_minimum_size(i32 window_id)
+{
+    int width = 0, height = 0;
+    SDL_GetWindowMinimumSize(SDLServer::the().window(window_id), &width, &height);
+    return Gfx::IntSize(width, height);
+}
+
+void ConnectionToWindowServer::async_set_window_minimum_size(i32 window_id, Gfx::IntSize size)
+{
+    SDL_SetWindowMinimumSize(SDLServer::the().window(window_id), size.width(), size.height());
+}
+
+void ConnectionToWindowServer::async_set_window_resize_aspect_ratio(i32 window_id, Optional<Gfx::IntSize> const& resize_aspect_ratio)
+{
+    SDLServer::the().set_window_resize_aspect_ratio(window_id, resize_aspect_ratio);
+}
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/ConnectionToWindowServer.h
+++ b/Meta/Lagom/Libraries/LibGUI/ConnectionToWindowServer.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/ShareableBitmap.h>
+#include <LibGfx/Size.h>
+
+namespace GUI {
+
+class ConnectionToWindowServer {
+public:
+    static ConnectionToWindowServer& the();
+    ConnectionToWindowServer() = default;
+
+    void window_resized(i32, Gfx::IntRect const&);
+    void paint(i32, Gfx::IntSize const&, Vector<Gfx::IntRect> const&);
+    void mouse_move(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32, bool, Vector<String> const&);
+    void mouse_down(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32);
+    void mouse_up(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32);
+
+    void async_create_window(i32, Gfx::IntRect const&,
+        bool, bool, bool, bool, bool, bool,
+        bool, bool, bool, bool, float,
+        float, Gfx::IntSize const&, Gfx::IntSize const&,
+        Gfx::IntSize const&, Optional<Gfx::IntSize> const&, i32,
+        String const&, i32, Gfx::IntRect const&);
+    Vector<i32>& destroy_window(i32);
+
+    void async_set_window_title(i32 window_id, String const& title);
+    String get_window_title(i32 window_id);
+    bool is_window_modified(i32) { return false; }
+    void async_set_window_modified(i32, bool) { }
+
+    void async_did_finish_painting(i32, Vector<Gfx::IntRect> const&);
+    void async_invalidate_rect(i32, Vector<Gfx::IntRect> const&, bool);
+    void async_set_forced_shadow(i32, bool);
+    void async_refresh_system_theme();
+
+    void async_set_fullscreen(i32, bool);
+    void async_set_frameless(i32, bool);
+    void async_set_maximized(i32, bool);
+    void async_set_window_opacity(i32, float);
+    void async_set_window_alpha_hit_threshold(i32, float) { }
+    void async_set_window_has_alpha_channel(i32, bool) { }
+    void set_window_backing_store(i32, i32, i32, int, i32, bool, Gfx::IntSize const&, bool) { }
+    void async_set_window_base_size_and_size_increment(i32, Gfx::IntSize const&, Gfx::IntSize const&) { }
+    void async_set_window_progress(i32, Optional<i32> const&) { }
+
+    void async_add_menu(i32, i32) { }
+    int async_create_menu(i32, String const&) { return -1; }
+    void async_popup_menu(i32, Gfx::IntPoint const&) { }
+    void async_destroy_menu(i32) { }
+    void async_dismiss_menu(i32) { }
+    void async_add_menu_separator(i32) { }
+    void async_add_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&, Gfx::ShareableBitmap const&, bool) { }
+    void async_update_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&) { }
+    void async_remove_menu_item(i32, i32) { }
+    void async_flash_menubar_menu(i32, i32) { }
+
+    void async_set_window_cursor(i32, i32) { }
+    void async_set_window_custom_cursor(i32, Gfx::ShareableBitmap const&) { }
+
+    bool start_drag(String const&, HashMap<String, ByteBuffer> const&, Gfx::ShareableBitmap const&) { return false; }
+
+    Gfx::IntPoint get_global_cursor_position();
+
+    Gfx::IntRect const& set_window_rect(i32 window_id, Gfx::IntRect const& rect);
+    Gfx::IntRect get_window_rect(i32 window_id);
+
+    void async_move_window_to_front(i32 window_id);
+
+    Gfx::IntRect get_applet_rect_on_screen(i32 window_id);
+
+    Gfx::IntSize get_window_minimum_size(i32 window_id);
+    void async_set_window_minimum_size(i32 window_id, Gfx::IntSize size);
+
+    void async_set_window_resize_aspect_ratio(i32 window_id, Optional<Gfx::IntSize> const& resize_aspect_ratio);
+
+    void async_set_window_icon_bitmap(i32, Gfx::ShareableBitmap const&) { }
+
+    void async_start_window_resize(i32) { }
+
+    bool is_maximized(i32) { return false; }
+};
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/Desktop.cpp
+++ b/Meta/Lagom/Libraries/LibGUI/Desktop.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Badge.h>
+#include <LibGUI/Desktop.h>
+#include <string.h>
+
+namespace GUI {
+
+Desktop& Desktop::the()
+{
+    static Desktop s_the;
+    return s_the;
+}
+
+void Desktop::did_receive_screen_rects(Badge<WindowServerConnection>, const Vector<Gfx::IntRect, 4>& rects, size_t main_screen_index, unsigned, unsigned)
+{
+    m_main_screen_index = main_screen_index;
+    m_rects = rects;
+    if (!m_rects.is_empty()) {
+        m_bounding_rect = m_rects[0];
+        for (size_t i = 1; i < m_rects.size(); i++)
+            m_bounding_rect = m_bounding_rect.united(m_rects[i]);
+    } else {
+        m_bounding_rect = {};
+    }
+
+    for (auto& callback : m_receive_rects_callbacks)
+        callback(*this);
+}
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/Desktop.h
+++ b/Meta/Lagom/Libraries/LibGUI/Desktop.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibGUI/ConnectionToWindowServer.h>
+#include <LibGfx/Rect.h>
+#include <SDL.h>
+
+namespace GUI {
+
+class Desktop {
+public:
+    static constexpr size_t default_screen_rect_count = 4;
+
+    static Desktop& the();
+    Desktop() = default;
+
+    void set_background_color(StringView) { }
+
+    void set_wallpaper_mode(StringView) { }
+
+    String wallpaper() const { return ""; }
+    bool set_wallpaper(StringView, bool) { return false; }
+
+    Gfx::IntRect rect() const
+    {
+        SDL_Rect rect;
+        SDL_GetDisplayBounds(0, &rect);
+        return Gfx::IntRect(rect.x, rect.y, rect.w, rect.h);
+    }
+    const Vector<Gfx::IntRect, 4>& rects() const { return m_rects; }
+    size_t main_screen_index() const { return 0; }
+
+    unsigned workspace_rows() const { return 0; }
+    unsigned workspace_columns() const { return 0; }
+
+    int taskbar_height() const { return 0; }
+
+    void did_receive_screen_rects(Badge<ConnectionToWindowServer>, const Vector<Gfx::IntRect, 4>&, size_t, unsigned, unsigned);
+
+    template<typename F>
+    void on_receive_screen_rects(F&& callback)
+    {
+        m_receive_rects_callbacks.append(forward<F>(callback));
+    }
+
+private:
+    Vector<Gfx::IntRect, default_screen_rect_count> m_rects;
+    size_t m_main_screen_index { 0 };
+    Gfx::IntRect m_bounding_rect;
+    unsigned m_workspace_rows { 1 };
+    unsigned m_workspace_columns { 1 };
+    Vector<Function<void(Desktop&)>> m_receive_rects_callbacks;
+};
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/SDLServer.cpp
+++ b/Meta/Lagom/Libraries/LibGUI/SDLServer.cpp
@@ -38,21 +38,20 @@ SDLServer::SDLServer()
             if (event.window.windowID == 0)
                 continue;
 
+            u32 buttons = 0;
+            if (event.button.button == SDL_BUTTON_LEFT)
+                buttons = GUI::MouseButton::Primary;
+            if (event.button.button == SDL_BUTTON_RIGHT)
+                buttons = GUI::MouseButton::Secondary;
+
             switch (event.type) {
             case SDL_MOUSEMOTION: {
                 auto window = Window::from_window_id(get_window_from_sdl_id(event.window.windowID));
-                WindowServerConnection::the().mouse_move(window->window_id(), Gfx::IntPoint(event.motion.x, event.motion.y), 0, 0, 0, 0, 0, false, Vector<String>());
+                WindowServerConnection::the().mouse_move(window->window_id(), Gfx::IntPoint(event.motion.x, event.motion.y), 0, buttons, 0, 0, 0, false, Vector<String>());
                 break;
             }
             case SDL_MOUSEBUTTONDOWN: {
                 auto window = Window::from_window_id(get_window_from_sdl_id(event.window.windowID));
-
-                u32 buttons = 0;
-                if (event.button.button == SDL_BUTTON_LEFT)
-                    buttons = GUI::MouseButton::Primary;
-                if (event.button.button == SDL_BUTTON_RIGHT)
-                    buttons = GUI::MouseButton::Secondary;
-
                 if (buttons > 0)
                     WindowServerConnection::the().mouse_down(window->window_id(), Gfx::IntPoint(event.motion.x, event.motion.y), buttons, buttons, 0, 0, 0);
                 break;

--- a/Meta/Lagom/Libraries/LibGUI/SDLServer.cpp
+++ b/Meta/Lagom/Libraries/LibGUI/SDLServer.cpp
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Singleton.h>
+#include <LibCore/EventLoop.h>
+#include <LibCore/Timer.h>
+#include <LibGUI/Event.h>
+#include <LibGUI/SDLServer.h>
+#include <LibGUI/Window.h>
+#include <LibGUI/WindowServerConnection.h>
+#include <LibGfx/Bitmap.h>
+
+namespace GUI {
+
+static Singleton<SDLServer> s_the;
+SDLServer& SDLServer::the()
+{
+    return *s_the;
+}
+
+SDLServer::SDLServer()
+{
+    SDL_Init(SDL_INIT_VIDEO);
+    dbgln("SDL: Brought up SDL");
+
+    m_process_loop = Core::Timer::create_repeating(16, [this] {
+        SDL_Event event;
+        while (SDL_PollEvent(&event)) {
+            if (event.type == SDL_QUIT) {
+                this->quit();
+                return;
+            }
+
+            // "0" is the window ID for the desktop. Let's ignore all of those events.
+            if (event.window.windowID == 0)
+                continue;
+
+            switch (event.type) {
+            case SDL_MOUSEMOTION: {
+                auto window = Window::from_window_id(get_window_from_sdl_id(event.window.windowID));
+                WindowServerConnection::the().mouse_move(window->window_id(), Gfx::IntPoint(event.motion.x, event.motion.y), 0, 0, 0, 0, 0, false, Vector<String>());
+                break;
+            }
+            case SDL_MOUSEBUTTONDOWN: {
+                auto window = Window::from_window_id(get_window_from_sdl_id(event.window.windowID));
+
+                u32 buttons = 0;
+                if (event.button.button == SDL_BUTTON_LEFT)
+                    buttons = GUI::MouseButton::Primary;
+                if (event.button.button == SDL_BUTTON_RIGHT)
+                    buttons = GUI::MouseButton::Secondary;
+
+                if (buttons > 0)
+                    WindowServerConnection::the().mouse_down(window->window_id(), Gfx::IntPoint(event.motion.x, event.motion.y), buttons, buttons, 0, 0, 0);
+                break;
+            }
+            case SDL_MOUSEBUTTONUP: {
+                auto window = Window::from_window_id(get_window_from_sdl_id(event.window.windowID));
+
+                u32 buttons = 0;
+                if (event.button.button == SDL_BUTTON_LEFT)
+                    buttons = GUI::MouseButton::Primary;
+                if (event.button.button == SDL_BUTTON_RIGHT)
+                    buttons = GUI::MouseButton::Secondary;
+
+                if (buttons > 0)
+                    WindowServerConnection::the().mouse_up(window->window_id(), Gfx::IntPoint(event.motion.x, event.motion.y), buttons, buttons, 0, 0, 0);
+                break;
+            }
+            case SDL_WINDOWEVENT: {
+                auto window = Window::from_window_id(get_window_from_sdl_id(event.window.windowID));
+                switch (event.window.event) {
+                case SDL_WINDOWEVENT_RESIZED: {
+                    WindowServerConnection::the().window_resized(window->window_id(), Gfx::IntRect(0, 0, event.window.data1, event.window.data2));
+                    break;
+                }
+                case SDL_WINDOWEVENT_CLOSE: {
+                    window->close();
+                    break;
+                }
+                }
+                break;
+            }
+            }
+        }
+    });
+    m_process_loop->start();
+}
+
+i32 SDLServer::get_window_from_sdl_id(u32 sdl_id)
+{
+    for (auto& entry : m_windows) {
+        auto sdl_window_id = SDL_GetWindowID(entry.value);
+
+        if (sdl_window_id == sdl_id)
+            return entry.key;
+    }
+
+    return -1;
+}
+
+void SDLServer::quit()
+{
+    dbgln("SDL: Quitting");
+    m_process_loop->stop();
+
+    SDL_Quit();
+    auto& loop = Core::EventLoop::current();
+    loop.quit(0);
+}
+
+void SDLServer::register_window(i32 window_id, SDL_Window* window)
+{
+    dbgln("SDL: Register window with id {}", window_id);
+    m_windows.set(window_id, window);
+}
+
+void SDLServer::deregister_window(i32 window_id)
+{
+    dbgln("SDL: De-register window with id {}", window_id);
+    auto window = m_windows.get(window_id).value();
+    SDL_DestroyWindow(window);
+    m_windows.remove(window_id);
+}
+
+void SDLServer::set_window_title(i32 window_id, String title)
+{
+    SDL_SetWindowTitle(m_windows.get(window_id).value(), title.characters());
+}
+
+String SDLServer::get_window_title(i32 window_id)
+{
+    return String(SDL_GetWindowTitle(m_windows.get(window_id).value()));
+}
+
+void SDLServer::set_window_rect(i32 window_id, Gfx::IntRect const& rect)
+{
+    auto window = m_windows.get(window_id).value();
+    SDL_SetWindowPosition(window, rect.x(), rect.y());
+    SDL_SetWindowSize(window, rect.width(), rect.height());
+}
+
+Gfx::IntRect SDLServer::get_window_rect(i32 window_id)
+{
+    auto window = m_windows.get(window_id).value();
+    auto size = SDL_GetWindowSurface(window);
+
+    int x = 0, y = 0;
+    SDL_GetWindowPosition(window, &x, &y);
+
+    return Gfx::IntRect(x, y, size->w, size->h);
+}
+
+void SDLServer::set_window_resize_aspect_ratio(i32, Optional<Gfx::IntSize> const&)
+{
+    // NOP
+}
+
+}

--- a/Meta/Lagom/Libraries/LibGUI/SDLServer.h
+++ b/Meta/Lagom/Libraries/LibGUI/SDLServer.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Rect.h>
+#include <SDL.h>
+
+namespace GUI {
+
+class SDLServer : public Core::Object {
+    C_OBJECT(SDLServer)
+public:
+    static SDLServer& the();
+    SDLServer();
+
+    SDL_Window* window(u32 window_id) const { return m_windows.get(window_id).value(); }
+    i32 get_window_from_sdl_id(u32);
+
+    void quit();
+
+    void register_window(i32, SDL_Window*);
+    void deregister_window(i32);
+
+    void set_window_title(i32, String);
+    String get_window_title(i32);
+
+    void set_window_rect(i32 window_id, Gfx::IntRect const& rect);
+    Gfx::IntRect get_window_rect(i32 window_id);
+
+    void set_window_resize_aspect_ratio(i32 window_id, Optional<Gfx::IntSize> const& resize_aspect_ratio);
+
+private:
+    RefPtr<Core::Timer> m_process_loop;
+    HashMap<i32, SDL_Window*> m_windows;
+};
+
+}

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -12,6 +12,7 @@
 #include <AK/WeakPtr.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Object.h>
+#include <LibCore/Timer.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Shortcut.h>
 #include <LibGUI/Widget.h>

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -14,6 +14,7 @@
 #include <LibCore/MimeData.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/Application.h>
+#include <LibGUI/Button.h>
 #include <LibGUI/ConnectionToWindowMangerServer.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/Desktop.h>

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -123,6 +123,7 @@ public:
 
     ~Bitmap();
 
+    [[nodiscard]] u8 const* data() const { return reinterpret_cast<u8 const*>(m_data); }
     [[nodiscard]] u8* scanline_u8(int physical_y);
     [[nodiscard]] u8 const* scanline_u8(int physical_y) const;
     [[nodiscard]] ARGB32* scanline(int physical_y);


### PR DESCRIPTION
This PR adds an initial LibGUI port that uses SDL2 for easy multi-platform support. The lagom build step automatically detects the presence of SDL2 and skips building LibGUI if it ain't present.

I have chosen not to add SDL2 to the CI machines (yet) since it would both slow down the build time for no real gain and prevent people from expanding on WindowServer without also stubbing that out in the fake Lagom WindowServer.

https://user-images.githubusercontent.com/1370209/153757142-588bf022-8174-4408-989a-649e11070a9d.mov
https://user-images.githubusercontent.com/1370209/153757155-cd4f947c-1a4e-4391-855a-cf3016e7f88c.mov