### PR TITLE
LibWeb: Fix off-by-one in HTMLTokenizer::restore_to()

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -2726,15 +2726,13 @@ bool HTMLTokenizer::consumed_as_part_of_an_attribute() const
 
 void HTMLTokenizer::restore_to(Utf8CodePointIterator const& new_iterator)
 {
-    if (new_iterator != m_prev_utf8_iterator) {
-        auto diff = m_prev_utf8_iterator - new_iterator;
-        if (diff > 0) {
-            for (ssize_t i = 0; i < diff; ++i)
-                m_source_positions.take_last();
-        } else {
-            // Going forwards...?
-            TODO();
-        }
+    auto diff = m_utf8_iterator - new_iterator;
+    if (diff > 0) {
+        for (ssize_t i = 0; i < diff; ++i)
+            m_source_positions.take_last();
+    } else {
+        // Going forwards...?
+        TODO();
     }
     m_utf8_iterator = new_iterator;
 }


### PR DESCRIPTION
I noticed an off-by-one in the syntax highlighting for pages that use minified HTML.
Tracked it down to `HTMLTokenizer::restore_to()` when called for `DOCTYPE`, popping one less source position than needed as the number to pop was based on `m_prev_utf8_iterator` rather than the current iterator.

**Before**:
![before](https://user-images.githubusercontent.com/11597044/153757698-6208a624-ef5c-4fbe-a282-976877a1dadd.png)

**After**:
![after](https://user-images.githubusercontent.com/11597044/153757702-2aca6cd7-a665-4e5d-a410-a5abdf791883.png)

