### PR TITLE
LibTLS: Add SHA-384 as supported certificate signing algorithm

### DIFF
--- a/Userland/Libraries/LibTLS/Certificate.cpp
+++ b/Userland/Libraries/LibTLS/Certificate.cpp
@@ -24,6 +24,7 @@ constexpr static Array<int, 7>
     rsa_md5_encryption_oid { 1, 2, 840, 113549, 1, 1, 4 },
     rsa_sha1_encryption_oid { 1, 2, 840, 113549, 1, 1, 5 },
     rsa_sha256_encryption_oid { 1, 2, 840, 113549, 1, 1, 11 },
+    rsa_sha384_encryption_oid { 1, 2, 840, 113549, 1, 1, 12 },
     rsa_sha512_encryption_oid { 1, 2, 840, 113549, 1, 1, 13 };
 
 constexpr static Array<int, 4>
@@ -151,6 +152,8 @@ Optional<Certificate> Certificate::parse_asn1(ReadonlyBytes buffer, bool)
             field = CertificateKeyAlgorithm ::RSA_SHA1;
         else if (identifier == rsa_sha256_encryption_oid)
             field = CertificateKeyAlgorithm ::RSA_SHA256;
+        else if (identifier == rsa_sha384_encryption_oid)
+            field = CertificateKeyAlgorithm ::RSA_SHA384;
         else if (identifier == rsa_sha512_encryption_oid)
             field = CertificateKeyAlgorithm ::RSA_SHA512;
         else

--- a/Userland/Libraries/LibTLS/Certificate.h
+++ b/Userland/Libraries/LibTLS/Certificate.h
@@ -23,6 +23,7 @@ enum class CertificateKeyAlgorithm {
     RSA_MD5 = 0x04,
     RSA_SHA1 = 0x05,
     RSA_SHA256 = 0x0b,
+    RSA_SHA384 = 0x0c,
     RSA_SHA512 = 0x0d,
 };
 


### PR DESCRIPTION
This changes LibTLS to be able to identify certificates signed with SHA-384 with RSA encryption.

It fixes loading some pages (such as https://paginas.fe.up.pt) that would otherwise fail with:

```
11.106 RequestServer(39:39): Consumed an error: -15
11.106 RequestServer(39:39): consume error: -15
11.106 RequestServer(39:39): Possible failure cause(s):
11.106 RequestServer(39:39): - No one knows.
11.110 RequestServer(39:39): ConnectionCache: Connection to https://paginas.fe.up.pt/ failed: UnsupportedCertificate
```