### PR TITLE
LibWeb: Update TestHTMLTokenizer's expected token hash

### DIFF
--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -206,5 +206,5 @@ TEST_CASE(regression)
     auto file_contents = file.value()->read_all();
     auto tokens = run_tokenizer(file_contents);
     u32 hash = hash_tokens(tokens);
-    EXPECT_EQ(hash, 2203864459u);
+    EXPECT_EQ(hash, 1280197787u);
 }


### PR DESCRIPTION
The output of the tokenizer changed in commit:
b193351a998dab06228bf6cb8c2b0828704839c1.