### PR TITLE
LibVT: Fix triple click behavior

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -776,6 +776,10 @@ void TerminalWidget::mouseup_event(GUI::MouseEvent& event)
             m_active_href_id = {};
             update();
         }
+
+        if (m_triple_click_timer.is_valid())
+            m_triple_click_timer.reset();
+
         set_auto_scroll_direction(AutoScrollDirection::None);
     }
 }
@@ -809,7 +813,6 @@ void TerminalWidget::mousedown_event(GUI::MouseEvent& event)
         else if (m_rectangle_selection)
             m_rectangle_selection = false;
 
-        m_triple_click_timer.reset();
         update_copy_action();
         update();
     }


### PR DESCRIPTION
When triple clicking a line in the terminal the selection will span the
whole line. However, after dragging down to lines above/below the
selection will stop at the cursor.

Instead, the expected functionality of triple clicking and dragging is
to select the whole line and any whole lines dragged to after the triple
click.

Previously, the triple line counter would get reset as soon as the whole
line was selected. This patch resets the m_triple_click_timer in the
mouse up event, so that the triple click selecting functionality is
maintained during the entire click event and terminated when the event
is over.