### PR TITLE
Magnifier: Add missing icons

### DIFF
--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -78,13 +78,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto timeline_menu = TRY(window->try_add_menu("&Timeline"));
     auto previous_frame_action = GUI::Action::create(
-        "&Previous frame", { Key_Left }, [&](auto&) {
+        "&Previous frame", { Key_Left }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-back.png")), [&](auto&) {
             pause_action->set_checked(true);
             magnifier->pause_capture(true);
             magnifier->display_previous_frame();
         });
     auto next_frame_action = GUI::Action::create(
-        "&Next frame", { Key_Right }, [&](auto&) {
+        "&Next frame", { Key_Right }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-forward.png")), [&](auto&) {
             pause_action->set_checked(true);
             magnifier->pause_capture(true);
             magnifier->display_next_frame();


### PR DESCRIPTION
Add icons for 'Next Frame' and 'Previous Frame'.

<img width="224" alt="Screen Shot 2022-02-13 at 13 21 03" src="https://user-images.githubusercontent.com/4368524/153768992-a1d522a7-36ab-49ab-bc90-2e6b1d025ec9.png">