### PR TITLE
Userland/Applets: Use default constructors/destructors

### DIFF
--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>
  * Copyright (c) 2021, David Isaksson <davidisaksson93@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -134,7 +135,7 @@ private:
     };
 
 public:
-    virtual ~AudioWidget() override { }
+    virtual ~AudioWidget() override = default;
 
     void set_audio_widget_size(bool show_percent)
     {

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,10 +18,6 @@ NonnullRefPtr<ClipboardHistoryModel> ClipboardHistoryModel::create()
 
 ClipboardHistoryModel::ClipboardHistoryModel()
     : m_history_limit(Config::read_i32("ClipboardHistory", "ClipboardHistory", "NumHistoryItems", 20))
-{
-}
-
-ClipboardHistoryModel::~ClipboardHistoryModel()
 {
 }
 

--- a/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
+++ b/Userland/Applets/ClipboardHistory/ClipboardHistoryModel.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@cs.toronto.edu>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,7 +26,7 @@ public:
         __Count
     };
 
-    virtual ~ClipboardHistoryModel() override;
+    virtual ~ClipboardHistoryModel() override = default;
 
     const GUI::Clipboard::DataAndType& item_at(int index) const { return m_history_items[index]; }
     void remove_item(int index);

--- a/Userland/Applets/Keymap/KeymapStatusWindow.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWindow.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Timur Sultanov <SultanovTS@yandex.ru>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,10 +29,6 @@ KeymapStatusWindow::KeymapStatusWindow()
     auto current_keymap_name = current_keymap.character_map_name();
     m_status_widget->set_tooltip(current_keymap_name);
     m_status_widget->set_text(current_keymap_name.substring(0, 2));
-}
-
-KeymapStatusWindow::~KeymapStatusWindow()
-{
 }
 
 void KeymapStatusWindow::wm_event(GUI::WMEvent& event)

--- a/Userland/Applets/Keymap/KeymapStatusWindow.h
+++ b/Userland/Applets/Keymap/KeymapStatusWindow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Timur Sultanov <SultanovTS@yandex.ru>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -17,7 +18,7 @@ class KeymapStatusWidget : public GUI::Label {
 class KeymapStatusWindow final : public GUI::Window {
     C_OBJECT(KeymapStatusWindow)
 public:
-    virtual ~KeymapStatusWindow() override;
+    virtual ~KeymapStatusWindow() override = default;
 
 private:
     virtual void wm_event(GUI::WMEvent&) override;

--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,9 +16,7 @@ class DesktopStatusWidget : public GUI::Widget {
     C_OBJECT(DesktopStatusWidget);
 
 public:
-    virtual ~DesktopStatusWidget() override
-    {
-    }
+    virtual ~DesktopStatusWidget() override = default;
 
     Gfx::IntRect rect_for_desktop(unsigned row, unsigned col) const
     {
@@ -94,14 +93,12 @@ public:
     unsigned gap() const { return m_gap; }
 
 private:
-    DesktopStatusWidget()
-    {
-    }
+    DesktopStatusWidget() = default;
 
     unsigned m_gap { 1 };
 
-    unsigned m_current_row;
-    unsigned m_current_col;
+    unsigned m_current_row { 0 };
+    unsigned m_current_col { 0 };
 };
 
 DesktopStatusWindow::DesktopStatusWindow()
@@ -112,10 +109,6 @@ DesktopStatusWindow::DesktopStatusWindow()
     set_window_type(GUI::WindowType::Applet);
     set_has_alpha_channel(true);
     m_widget = &set_main_widget<DesktopStatusWidget>();
-}
-
-DesktopStatusWindow::~DesktopStatusWindow()
-{
 }
 
 void DesktopStatusWindow::wm_event(GUI::WMEvent& event)

--- a/Userland/Applets/WorkspacePicker/DesktopStatusWindow.h
+++ b/Userland/Applets/WorkspacePicker/DesktopStatusWindow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Peter Elliott <pelliott@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,7 +15,7 @@ class DesktopStatusWindow : public GUI::Window {
     C_OBJECT(DesktopStatusWindow);
 
 public:
-    virtual ~DesktopStatusWindow() override;
+    virtual ~DesktopStatusWindow() override = default;
 
     virtual void wm_event(GUI::WMEvent&) override;
 


### PR DESCRIPTION
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cother-other-default-operation-rules

"The compiler is more likely to get the default semantics right and
you cannot implement these functions better than the compiler."