### PR TITLE
Kernel: Expose maximum argument limit in sysconf

### DIFF
--- a/Kernel/API/POSIX/unistd.h
+++ b/Kernel/API/POSIX/unistd.h
@@ -40,6 +40,7 @@ enum {
     _SC_CLK_TCK,
     _SC_SYMLOOP_MAX,
     _SC_MAPPED_FILES,
+    _SC_ARG_MAX,
 };
 
 #define _SC_MONOTONIC_CLOCK _SC_MONOTONIC_CLOCK
@@ -53,6 +54,7 @@ enum {
 #define _SC_CLK_TCK _SC_CLK_TCK
 #define _SC_SYMLOOP_MAX _SC_SYMLOOP_MAX
 #define _SC_MAPPED_FILES _SC_MAPPED_FILES
+#define _SC_ARG_MAX _SC_ARG_MAX
 
 #ifdef __cplusplus
 }

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -434,6 +434,8 @@ public:
     Custody* executable() { return m_executable.ptr(); }
     const Custody* executable() const { return m_executable.ptr(); }
 
+    static constexpr size_t max_arguments_size = Thread::default_userspace_stack_size / 8;
+    static constexpr size_t max_environment_size = Thread::default_userspace_stack_size / 8;
     NonnullOwnPtrVector<KString> const& arguments() const { return m_arguments; };
     NonnullOwnPtrVector<KString> const& environment() const { return m_environment; };
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -58,13 +58,10 @@ static bool validate_stack_size(NonnullOwnPtrVector<KString> const& arguments, N
     total_arguments_size += sizeof(char*) * (arguments.size() + 1);
     total_environment_size += sizeof(char*) * (environment.size() + 1);
 
-    constexpr size_t max_arguments_size = Thread::default_userspace_stack_size / 8;
-    constexpr size_t max_environment_size = Thread::default_userspace_stack_size / 8;
-
-    if (total_arguments_size > max_arguments_size)
+    if (total_arguments_size > Process::max_arguments_size)
         return false;
 
-    if (total_environment_size > max_environment_size)
+    if (total_environment_size > Process::max_environment_size)
         return false;
 
     // FIXME: This doesn't account for the size of the auxiliary vector

--- a/Kernel/Syscalls/sysconf.cpp
+++ b/Kernel/Syscalls/sysconf.cpp
@@ -33,6 +33,8 @@ ErrorOr<FlatPtr> Process::sys$sysconf(int name)
         return TimeManagement::the().ticks_per_second();
     case _SC_SYMLOOP_MAX:
         return Kernel::VirtualFileSystem::symlink_recursion_limit;
+    case _SC_ARG_MAX:
+        return Process::max_arguments_size;
     default:
         return EINVAL;
     }


### PR DESCRIPTION
Move the definitions for maximum argument and environment size to
Process.h from execve.cpp. This allows sysconf(_SC_ARG_MAX) to return
the actual argument maximum of 128 KiB to userspace.