### PR TITLE
Base: Add Spreadsheet alias to shellrc

### DIFF
--- a/Base/etc/shellrc
+++ b/Base/etc/shellrc
@@ -26,6 +26,7 @@ alias ws=WebServer
 alias sl=Solitaire
 alias ue=UserspaceEmulator
 alias fe=FontEditor
+alias ss=Spreadsheet
 
 alias rgrep="grep -r"
 alias egrep="grep -E"


### PR DESCRIPTION
Adds `ss` as a Spreadsheet alias for the shell :^)