### PR TITLE
VimEditingEngine: Alias `|` to `Home` (beginning of line)

### DIFF
--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -168,7 +168,8 @@ void VimMotion::add_key_code(KeyCode key, [[maybe_unused]] bool ctrl, bool shift
 
 #undef DIGIT
 
-    // Home means to the beginning of the line.
+    // | and Home means to the beginning of the line.
+    case KeyCode::Key_Pipe:
     case KeyCode::Key_Home:
         m_unit = Unit::Character;
         m_amount = START_OF_LINE;


### PR DESCRIPTION
This patch implements two simple vim motions.

`$` and `|`.

NOTE: on most US English keyboards these are accessible only via the shift key, but that may not be the case on other keyboard configurations; so these motion cases exist under both the "shift"  and  "no modifiers" section.