### PR TITLE
Toolchain: Update Dockerfile to use gcc 11 and add texinfo package

### DIFF
--- a/Toolchain/Dockerfile
+++ b/Toolchain/Dockerfile
@@ -8,8 +8,8 @@ RUN apt-get update -y \
         ccache \
         cmake \
         curl \
-        g++-10 \
-        gcc-10 \
+        g++-11 \
+        gcc-11 \
         e2fsprogs \
         genext2fs \
         git \
@@ -25,7 +25,8 @@ RUN apt-get update -y \
         qemu-utils \
         rsync \
         sudo \
+        texinfo \
         tzdata \
         unzip \
     && rm -rf /var/lib/apt/lists/ \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-10 900 --slave /usr/bin/g++ g++ /usr/bin/g++-10
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 900 --slave /usr/bin/g++ g++ /usr/bin/g++-11


### PR DESCRIPTION
Missed this in the gcc 11 version update, but if anyone is using this then they'll
need gcc 11 to build Lagom.