### PR TITLE
Utilities: Add the 'files' argument to the unzip utility

### DIFF
--- a/Base/usr/share/man/man1/unzip.md
+++ b/Base/usr/share/man/man1/unzip.md
@@ -5,7 +5,7 @@ unzip - extract files from a ZIP archive
 ## Synopsis
 
 ```**sh
-$ unzip file.zip
+$ unzip file.zip [files...]
 ```
 
 ## Description
@@ -13,6 +13,8 @@ $ unzip file.zip
 unzip will extract files from a zip archive to the current directory.
 
 The program is compatible with the PKZIP file format specification.
+
+The optional [files] argument can be used to only extract specific files within the archive (using wildcards) during the unzip process. A `_` can be used as a single-character wildcard, and  `*` can be used as a variable-length wildcard.
 
 ## Examples
 
@@ -22,4 +24,11 @@ $ unzip archive.zip
 Archive: archive.zip
  extracting: file1.txt
  extracting: file2.png
+```
+
+```sh
+# Unzip select files from archive.zip, according to a filter
+$ unzip archive.zip "*.tx_"
+Archive: archive.unzip
+ extracting: file1.txt
 ```


### PR DESCRIPTION
Adds support for unix-compatible `files` argument to the unzip built-in utility.

Works with * (multiple) and _ (single) wildcards, just like most common unix unzip utilities, so command formats should be compatible with other systems :^)
Also added example usage on the manpage.

Example use:
![image](https://user-images.githubusercontent.com/793454/153826695-ada4d152-1ec4-467a-bc5f-2cb029b53f9d.png)
