### PR TITLE
LibRegex: Correct the alternative matching order when one is empty

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -958,6 +958,21 @@ TEST_CASE(optimizer_char_class_lut)
         EXPECT_EQ(re.match("1635488940000"sv).success, false);
 }
 
+TEST_CASE(optimizer_alternation)
+{
+    Array tests {
+        // Pattern, Subject, Expected length
+        Tuple { "a|"sv, "a"sv, 1u },
+    };
+
+    for (auto& test : tests) {
+        Regex<ECMA262> re(test.get<0>());
+        auto result = re.match(test.get<1>());
+        EXPECT(result.success);
+        EXPECT_EQ(result.matches.first().view.length(), test.get<2>());
+    }
+}
+
 TEST_CASE(posix_basic_dollar_is_end_anchor)
 {
     // Ensure that a dollar sign at the end only matches the end of the line.

--- a/Userland/Libraries/LibRegex/RegexOptimizer.cpp
+++ b/Userland/Libraries/LibRegex/RegexOptimizer.cpp
@@ -450,17 +450,17 @@ void Optimizer::append_alternation(ByteCode& target, ByteCode&& left, ByteCode&&
         if (left_is_empty && right_is_empty)
             return;
 
-        // ForkJump right (+ left.size() + 2 + right.size())
-        // (left)
-        // Jump end (+ right.size())
+        // ForkJump left (+ 2 + right.size())
         // (right)
+        // Jump end (+ left.size())
+        // (left)
         // LABEL end
         target.append(static_cast<ByteCodeValueType>(OpCodeId::ForkJump));
-        target.append(left.size() + 2 + right.size());
-        target.extend(move(left));
-        target.append(static_cast<ByteCodeValueType>(OpCodeId::Jump));
-        target.append(right.size());
+        target.append(2 + right.size());
         target.extend(move(right));
+        target.append(static_cast<ByteCodeValueType>(OpCodeId::Jump));
+        target.append(left.size());
+        target.extend(move(left));
         return;
     }
 

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -94,6 +94,7 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(save_to_file);
     JS_DECLARE_NATIVE_FUNCTION(load_json);
     JS_DECLARE_NATIVE_FUNCTION(last_value_getter);
+    JS_DECLARE_NATIVE_FUNCTION(print);
 };
 
 class ScriptObject final : public JS::GlobalObject {
@@ -107,6 +108,7 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(load_file);
     JS_DECLARE_NATIVE_FUNCTION(load_json);
+    JS_DECLARE_NATIVE_FUNCTION(print);
 };
 
 static bool s_dump_ast = false;
@@ -1171,6 +1173,7 @@ void ReplObject::initialize_global_object()
     define_native_function("load", load_file, 1, attr);
     define_native_function("save", save_to_file, 1, attr);
     define_native_function("loadJSON", load_json, 1, attr);
+    define_native_function("print", print, 1, attr);
 
     define_native_accessor(
         "_",
@@ -1230,6 +1233,12 @@ JS_DEFINE_NATIVE_FUNCTION(ReplObject::load_json)
     return load_json_impl(vm, global_object);
 }
 
+JS_DEFINE_NATIVE_FUNCTION(ReplObject::print)
+{
+    ::print(vm.argument(0));
+    return JS::js_undefined();
+}
+
 void ScriptObject::initialize_global_object()
 {
     Base::initialize_global_object();
@@ -1237,6 +1246,7 @@ void ScriptObject::initialize_global_object()
     u8 attr = JS::Attribute::Configurable | JS::Attribute::Writable | JS::Attribute::Enumerable;
     define_native_function("load", load_file, 1, attr);
     define_native_function("loadJSON", load_json, 1, attr);
+    define_native_function("print", print, 1, attr);
 }
 
 JS_DEFINE_NATIVE_FUNCTION(ScriptObject::load_file)
@@ -1247,6 +1257,12 @@ JS_DEFINE_NATIVE_FUNCTION(ScriptObject::load_file)
 JS_DEFINE_NATIVE_FUNCTION(ScriptObject::load_json)
 {
     return load_json_impl(vm, global_object);
+}
+
+JS_DEFINE_NATIVE_FUNCTION(ScriptObject::print)
+{
+    ::print(vm.argument(0));
+    return JS::js_undefined();
 }
 
 static void repl(JS::Interpreter& interpreter)


### PR DESCRIPTION
Also plus a tiny `print()` in the js repl, because I HATE [OBJECT OBJECT]