### PR TITLE
Kernel: Require CWD to be unveiled in getcwd syscall

### DIFF
--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -78,12 +78,13 @@ public:
     ErrorOr<NonnullRefPtr<Custody>> resolve_path(StringView path, Custody& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
     ErrorOr<NonnullRefPtr<Custody>> resolve_path_without_veil(StringView path, Custody& base, RefPtr<Custody>* out_parent = nullptr, int options = 0, int symlink_recursion_level = 0);
 
+    ErrorOr<void> validate_path_against_process_veil(Custody const& path, int options);
+    ErrorOr<void> validate_path_against_process_veil(StringView path, int options);
+
 private:
     friend class OpenFileDescription;
 
     UnveilNode const& find_matching_unveiled_path(StringView path);
-    ErrorOr<void> validate_path_against_process_veil(Custody const& path, int options);
-    ErrorOr<void> validate_path_against_process_veil(StringView path, int options);
 
     bool is_vfs_root(InodeIdentifier) const;
 

--- a/Kernel/Syscalls/chdir.cpp
+++ b/Kernel/Syscalls/chdir.cpp
@@ -41,6 +41,11 @@ ErrorOr<FlatPtr> Process::sys$getcwd(Userspace<char*> buffer, size_t size)
         return EINVAL;
 
     auto path = TRY(current_directory().try_serialize_absolute_path());
+
+    // NOTE: We use the overload of validate_path_against_process_veil that takes a StringView rather than a Custody
+    //       to avoid creating the absolute path KString twice.
+    TRY(VirtualFileSystem::the().validate_path_against_process_veil(path->view(), O_RDONLY | O_DIRECTORY));
+
     size_t ideal_size = path->length() + 1;
     auto size_to_copy = min(ideal_size, size);
     TRY(copy_to_user(buffer, path->characters(), size_to_copy));


### PR DESCRIPTION
As the `getcwd` syscall requires the `rpath` promise, it should also require that the current working directory is unveiled with read or browse permissions (due to the symmetry of `{r,w,c}path` promises and unveil).

This now also requires `VFS::validate_path_against_process_veil()` to be public.