### PR TITLE
HackStudio: Fix crash when requesting parameter list

### DIFF
--- a/Userland/DevTools/HackStudio/Editor.cpp
+++ b/Userland/DevTools/HackStudio/Editor.cpp
@@ -689,7 +689,8 @@ void Editor::keydown_event(GUI::KeyEvent& event)
 
 void Editor::handle_function_parameters_hint_request()
 {
-    VERIFY(m_language_client);
+    if (!m_language_client)
+        return;
 
     m_language_client->on_function_parameters_hint_result = [this](Vector<String> const& params, size_t argument_index) {
         dbgln("on_function_parameters_hint_result");


### PR DESCRIPTION
When requesting a parameter hint message with `Ctrl + p` in a file that
doesn't have a language server, we would crash.

Now, rather than verifying that we have a language server, we return
early if we don't have one.