### PR TITLE
HackStudio+LibGUI+WindowServer: Add a 'Recent Projects' submenu

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -73,7 +73,11 @@ public:
     void for_each_open_file(Function<void(ProjectFile const&)>);
     bool semantic_syntax_highlighting_is_enabled() const;
 
+    static Vector<String> read_recent_projects();
+
 private:
+    static constexpr size_t recent_projects_history_size = 15;
+
     static String get_full_path_of_serenity_source(const String& file);
     String get_absolute_path(String const&) const;
     Vector<String> selected_file_paths() const;
@@ -128,6 +132,7 @@ private:
     void create_toolbar(GUI::Widget& parent);
     void create_action_tab(GUI::Widget& parent);
     void create_file_menu(GUI::Window&);
+    void update_recent_projects_submenu();
     void create_project_menu(GUI::Window&);
     void create_edit_menu(GUI::Window&);
     void create_build_menu(GUI::Window&);
@@ -193,6 +198,7 @@ private:
     RefPtr<DisassemblyWidget> m_disassembly_widget;
     RefPtr<Threading::Thread> m_debugger_thread;
     RefPtr<EditorWrapper> m_current_editor_in_execution;
+    RefPtr<GUI::Menu> m_recent_projects_submenu { nullptr };
 
     NonnullRefPtrVector<GUI::Action> m_new_file_actions;
     RefPtr<GUI::Action> m_new_plain_file_action;

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -32,6 +32,7 @@ static RefPtr<HackStudioWidget> s_hack_studio_widget;
 static bool make_is_available();
 static void notify_make_not_available();
 static void update_path_environment_variable();
+static Optional<String> last_opened_project_path();
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -59,9 +60,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto argument_absolute_path = Core::File::real_path_for(path_argument);
 
-    auto project_path = argument_absolute_path;
-    if (argument_absolute_path.is_null() || mode_coredump)
-        project_path = Core::File::real_path_for(".");
+    auto project_path = Core::File::real_path_for(".");
+    if (!mode_coredump) {
+        if (!argument_absolute_path.is_null())
+            project_path = argument_absolute_path;
+        else if (auto path = last_opened_project_path(); path.has_value())
+            project_path = path.release_value();
+    }
 
     s_hack_studio_widget = TRY(window->try_set_main_widget<HackStudioWidget>(project_path));
 
@@ -120,6 +125,18 @@ static void update_path_environment_variable()
         path.append(":");
     path.append("/usr/local/bin:/usr/bin:/bin");
     setenv("PATH", path.to_string().characters(), true);
+}
+
+static Optional<String> last_opened_project_path()
+{
+    auto projects = HackStudioWidget::read_recent_projects();
+    if (projects.size() == 0)
+        return {};
+
+    if (!Core::File::exists(projects[0]))
+        return {};
+
+    return { projects[0] };
 }
 
 namespace HackStudio {

--- a/Userland/Libraries/LibGUI/Menu.cpp
+++ b/Userland/Libraries/LibGUI/Menu.cpp
@@ -64,6 +64,14 @@ void Menu::add_action(NonnullRefPtr<Action> action)
     MUST(try_add_action(move(action)));
 }
 
+void Menu::remove_all_actions()
+{
+    for (auto& item : m_items) {
+        WindowServerConnection::the().async_remove_menu_item(m_menu_id, item.identifier());
+    }
+    m_items.clear();
+}
+
 ErrorOr<NonnullRefPtr<Menu>> Menu::try_add_submenu(String name)
 {
     // NOTE: We grow the vector first, to get allocation failure handled immediately.

--- a/Userland/Libraries/LibGUI/Menu.h
+++ b/Userland/Libraries/LibGUI/Menu.h
@@ -39,6 +39,7 @@ public:
     void add_action(NonnullRefPtr<Action>);
     void add_separator();
     Menu& add_submenu(String name);
+    void remove_all_actions();
 
     void popup(const Gfx::IntPoint& screen_position, const RefPtr<Action>& default_action = nullptr);
     void dismiss();

--- a/Userland/Services/WindowServer/ClientConnection.cpp
+++ b/Userland/Services/WindowServer/ClientConnection.cpp
@@ -192,6 +192,18 @@ void ClientConnection::update_menu_item(i32 menu_id, i32 identifier, [[maybe_unu
         menu_item->set_checked(checked);
 }
 
+void ClientConnection::remove_menu_item(i32 menu_id, i32 identifier)
+{
+    auto it = m_menus.find(menu_id);
+    if (it == m_menus.end()) {
+        did_misbehave("RemoveMenuItem: Bad menu ID");
+        return;
+    }
+    auto& menu = *(*it).value;
+    if (!menu.remove_item_with_identifier(identifier))
+        did_misbehave("RemoveMenuItem: Bad menu item identifier");
+}
+
 void ClientConnection::flash_menubar_menu(i32 window_id, i32 menu_id)
 {
     auto itw = m_windows.find(window_id);

--- a/Userland/Services/WindowServer/ClientConnection.h
+++ b/Userland/Services/WindowServer/ClientConnection.h
@@ -97,6 +97,7 @@ private:
     virtual void add_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&, Gfx::ShareableBitmap const&, bool) override;
     virtual void add_menu_separator(i32) override;
     virtual void update_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&) override;
+    virtual void remove_menu_item(i32 menu_id, i32 identifier) override;
     virtual void flash_menubar_menu(i32, i32) override;
     virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool, bool, bool,
         bool, bool, bool, bool, bool, float, float, Gfx::IntSize const&, Gfx::IntSize const&, Gfx::IntSize const&,

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -562,6 +562,11 @@ MenuItem* Menu::item_with_identifier(unsigned identifier)
     return nullptr;
 }
 
+bool Menu::remove_item_with_identifier(unsigned identifier)
+{
+    return m_items.remove_first_matching([&](auto& item) { return item->identifier() == identifier; });
+}
+
 int Menu::item_index_at(const Gfx::IntPoint& position)
 {
     int i = 0;

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -97,6 +97,7 @@ public:
     const Gfx::Font& font() const;
 
     MenuItem* item_with_identifier(unsigned);
+    bool remove_item_with_identifier(unsigned);
     void redraw();
     void redraw(MenuItem const&);
 

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -24,6 +24,7 @@ endpoint WindowServer
     add_menu_separator(i32 menu_id) =|
 
     update_menu_item(i32 menu_id, i32 identifier, i32 submenu_id, [UTF8] String text, bool enabled, bool checkable, bool checked, bool is_default, [UTF8] String shortcut) =|
+    remove_menu_item(i32 menu_id, i32 identifier) =|
     flash_menubar_menu(i32 window_id, i32 menu_id) =|
 
     create_window(


### PR DESCRIPTION
**HackStudio: Open by default the last opened project if not specified**
Previously when opening HS without passing an argument then '/' would be opened. This change makes it so that by default the last project you were working on gets opened instead (unless you pass a path to another project via arguments)

---

The other commits are for adding a shortcut submenu in File to open recently opened projects: since we can open a project and then open another without closing HS I needed a way to update the submenu