### PR TITLE
Piano+AK: Logarithmic sliders

### DIFF
--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -179,6 +179,16 @@ public:
     {
         return create_raw(m_value / other);
     }
+    template<Integral I>
+    constexpr This operator>>(I other) const
+    {
+        return create_raw(m_value >> other);
+    }
+    template<Integral I>
+    constexpr This operator<<(I other) const
+    {
+        return create_raw(m_value << other);
+    }
 
     This& operator+=(This const& other)
     {
@@ -237,6 +247,18 @@ public:
     This& operator/=(I other)
     {
         m_value /= other;
+        return *this;
+    }
+    template<Integral I>
+    This& operator>>=(I other)
+    {
+        m_value >>= other;
+        return *this;
+    }
+    template<Integral I>
+    This& operator<<=(I other)
+    {
+        m_value <<= other;
         return *this;
     }
 

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -261,42 +261,22 @@ public:
     template<Integral I>
     bool operator>(I other) const
     {
-        if (m_value > 0)
-            return (m_value >> precision) > other || (m_value >> precision == other && (m_value & radix_mask));
-        if (other > 0)
-            return false;
-
-        return (m_value >> precision) > other || !(m_value >> precision == other && (m_value & radix_mask));
+        return !(*this <= other);
     }
     template<Integral I>
     bool operator>=(I other) const
     {
-        if (m_value > 0)
-            return (m_value >> precision) >= other || (m_value >> precision == other && (m_value & radix_mask));
-        if (other > 0)
-            return false;
-
-        return (m_value >> precision) >= other || !(m_value >> precision == other && (m_value & radix_mask));
+        return !(*this < other);
     }
     template<Integral I>
     bool operator<(I other) const
     {
-        if (m_value > 0)
-            return (m_value >> precision) < other || !(m_value >> precision == other && (m_value & radix_mask));
-        if (other > 0)
-            return true;
-
-        return (m_value >> precision) < other || (m_value >> precision == other && (m_value & radix_mask));
+        return (m_value >> precision) < other || m_value < (other << precision);
     }
     template<Integral I>
     bool operator<=(I other) const
     {
-        if (m_value > 0)
-            return (m_value >> precision) <= other || !(m_value >> precision == other && (m_value & radix_mask));
-        if (other > 0)
-            return true;
-
-        return (m_value >> precision) <= other || (m_value >> precision == other && (m_value & radix_mask));
+        return *this < other || *this == other;
     }
 
     // Casting from a float should be faster than casting to a float

--- a/Tests/AK/TestFixedPoint.cpp
+++ b/Tests/AK/TestFixedPoint.cpp
@@ -73,6 +73,31 @@ TEST_CASE(rounding)
     EXPECT_EQ(Type(-1.5).ltrunk(), -1);
 }
 
+TEST_CASE(comparison)
+{
+    EXPECT(Type(0) < 1);
+    EXPECT(Type(0) <= 1);
+    EXPECT(Type(0) <= 0);
+    EXPECT(Type(-10) <= -10);
+
+    EXPECT(Type(4.25) > 4);
+    EXPECT(Type(4.25) >= 4);
+    EXPECT(Type(4.25) <= 5);
+    EXPECT(Type(4.25) < 5);
+    EXPECT(Type(1.5) > 1);
+
+    EXPECT(!(FixedPoint<4, u8>(2) > 128));
+    EXPECT(!(FixedPoint<4, u8>(2) >= 128));
+
+    EXPECT(Type(-6.25) < -6);
+    EXPECT(Type(-6.25) <= -6);
+    EXPECT(Type(-6.75) > -7);
+    EXPECT(Type(-6.75) >= -7);
+
+    EXPECT(Type(17) == 17);
+    EXPECT(Type(-8) != -9);
+}
+
 TEST_CASE(cast)
 {
     FixedPoint<16, u32> downcast_value1(FixedPoint<32, u64>(123.4567));

--- a/Tests/AK/TestFixedPoint.cpp
+++ b/Tests/AK/TestFixedPoint.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <AK/FixedPoint.h>
+#include <AK/NumericLimits.h>
 
 using Type = FixedPoint<4>;
 
@@ -71,6 +72,18 @@ TEST_CASE(rounding)
     EXPECT_EQ(Type(-1.5).lfloor(), -2);
     EXPECT_EQ(Type(-1.5).lceil(), -1);
     EXPECT_EQ(Type(-1.5).ltrunk(), -1);
+}
+
+TEST_CASE(logarithm)
+{
+    EXPECT_EQ(Type(0).log2().raw(), NumericLimits<int>::min());
+    EXPECT_EQ(Type(1).log2(), Type(0));
+    EXPECT_EQ(Type(2).log2(), Type(1));
+    EXPECT_EQ(Type(8).log2(), Type(3));
+    EXPECT_EQ(Type(0.5).log2(), Type(-1));
+
+    EXPECT_EQ(Type(22.627416997969520780827019587355).log2(), Type(4.4375));
+    EXPECT_EQ(Type(3088).log2(), Type(11.592457037268080419637304576833));
 }
 
 TEST_CASE(comparison)

--- a/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
+++ b/Userland/Applications/Piano/ProcessorParameterWidget/Slider.h
@@ -12,6 +12,8 @@
 #include <LibGUI/Slider.h>
 #include <LibGfx/Orientation.h>
 
+constexpr int slider_steps = 256;
+
 class ProcessorParameterSlider
     : public GUI::Slider
     , public WidgetWithLabel {
@@ -19,7 +21,12 @@ class ProcessorParameterSlider
 
 public:
     ProcessorParameterSlider(Orientation, LibDSP::ProcessorRangeParameter&, RefPtr<GUI::Label>);
+    constexpr bool is_logarithmic() const { return m_parameter.is_logarithmic() == LibDSP::Logarithmic::Yes; }
 
 protected:
     LibDSP::ProcessorRangeParameter& m_parameter;
+
+private:
+    // Converts based on processor parameter boundaries.
+    int linear_to_logarithmic(int linear_value);
 };

--- a/Userland/Libraries/LibDSP/Effects.cpp
+++ b/Userland/Libraries/LibDSP/Effects.cpp
@@ -11,9 +11,9 @@ namespace LibDSP::Effects {
 
 Delay::Delay(NonnullRefPtr<Transport> transport)
     : EffectProcessor(move(transport))
-    , m_delay_decay("Decay"sv, 0.01, 0.99, 0.33)
-    , m_delay_time("Delay Time"sv, 3, 2000, 900)
-    , m_dry_gain("Dry"sv, 0, 1, 0.9)
+    , m_delay_decay("Decay"sv, 0.01, 0.99, 0.33, Logarithmic::No)
+    , m_delay_time("Delay Time"sv, 3, 2000, 900, Logarithmic::Yes)
+    , m_dry_gain("Dry"sv, 0, 1, 0.9, Logarithmic::No)
 {
 
     m_parameters.append(m_delay_decay);

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -26,6 +26,11 @@ enum class ParameterType : u8 {
     Boolean,
 };
 
+enum class Logarithmic : bool {
+    No,
+    Yes
+};
+
 // Processors have modifiable parameters that should be presented to the UI in a uniform way without requiring the processor itself to implement custom interfaces.
 class ProcessorParameter {
 public:
@@ -101,22 +106,25 @@ public:
 
 class ProcessorRangeParameter final : public Detail::ProcessorParameterSingleValue<ParameterFixedPoint> {
 public:
-    ProcessorRangeParameter(String name, ParameterFixedPoint min_value, ParameterFixedPoint max_value, ParameterFixedPoint initial_value)
+    ProcessorRangeParameter(String name, ParameterFixedPoint min_value, ParameterFixedPoint max_value, ParameterFixedPoint initial_value, Logarithmic logarithmic)
         : Detail::ProcessorParameterSingleValue<ParameterFixedPoint>(move(name), ParameterType::Range, move(initial_value))
         , m_min_value(move(min_value))
         , m_max_value(move(max_value))
         , m_default_value(move(initial_value))
+        , m_logarithmic(logarithmic)
     {
         VERIFY(initial_value <= max_value && initial_value >= min_value);
     }
 
     ProcessorRangeParameter(ProcessorRangeParameter const& to_copy)
-        : ProcessorRangeParameter(to_copy.name(), to_copy.min_value(), to_copy.max_value(), to_copy.value())
+        : ProcessorRangeParameter(to_copy.name(), to_copy.min_value(), to_copy.max_value(), to_copy.value(), to_copy.is_logarithmic())
     {
     }
 
     ParameterFixedPoint min_value() const { return m_min_value; }
     ParameterFixedPoint max_value() const { return m_max_value; }
+    ParameterFixedPoint range() const { return m_max_value - m_min_value; }
+    constexpr Logarithmic is_logarithmic() const { return m_logarithmic; }
     ParameterFixedPoint default_value() const { return m_default_value; }
     void set_value(ParameterFixedPoint value)
     {
@@ -128,6 +136,7 @@ private:
     double const m_min_value;
     double const m_max_value;
     double const m_default_value;
+    Logarithmic const m_logarithmic;
 };
 
 template<typename EnumT>

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -17,10 +17,10 @@ namespace LibDSP::Synthesizers {
 Classic::Classic(NonnullRefPtr<Transport> transport)
     : LibDSP::SynthesizerProcessor(transport)
     , m_waveform("Waveform"sv, Waveform::Saw)
-    , m_attack("Attack"sv, 0, 2000, 5)
-    , m_decay("Decay"sv, 0, 20'000, 80)
-    , m_sustain("Sustain"sv, 0, 1, 0.725)
-    , m_release("Release", 0, 6'000, 120)
+    , m_attack("Attack"sv, 0.01, 2000, 5, Logarithmic::Yes)
+    , m_decay("Decay"sv, 0.01, 20'000, 80, Logarithmic::Yes)
+    , m_sustain("Sustain"sv, 0.001, 1, 0.725, Logarithmic::No)
+    , m_release("Release", 0.01, 6'000, 120, Logarithmic::Yes)
 {
     m_parameters.append(m_waveform);
     m_parameters.append(m_attack);


### PR DESCRIPTION
This makes many sliders in Piano logarithmic, allowing better controls over those values where this makes sense.

The accompanying AK changes implement the necessary logarithm in FixedPoint and introduce some fixes found while implementing that.

cc @Hendiadyoin1