### PR TITLE
LibWeb: Compute some heights of BlockFormattingContexts earlier

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -403,6 +403,10 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer& block_c
         if (is<ReplacedBox>(child_box) || is<BlockContainer>(child_box))
             place_block_level_element_in_normal_flow_vertically(child_box, block_container);
 
+        if (child_box.has_definite_height()) {
+            compute_height(child_box);
+        }
+
         OwnPtr<FormattingContext> independent_formatting_context;
         if (child_box.can_have_children()) {
             independent_formatting_context = create_independent_formatting_context_if_needed(child_box);


### PR DESCRIPTION
Fyi: first contribution :) 

In some cases the height of the parent is needed in computations of the height for the child.
This patch attempts to fix these cases by performing the height computation earlier. 

Note: we now sometimes perform the height computation twice, but it's not expensive. 

Example: 
```html
<html>
<head>
    <style>
        .container {
            height: 200px;
            width: 100%;
        }
        .child {
            height: 100%;
            margin: 20px;
            background-color: red;
        }
    </style>
</head>
<body>
<div class="container">
    <div class="child">
        <p>test</p>
    </div>
</div>
</body>
</html>
```
Previously the child container would not get the correct height (200px), instead the height would be computed based on the size of the `<p`> tag.
