### PR TITLE
Base+PixelPaint: Implement Merge Active Layer Up + Use related icons

### DIFF
--- a/Userland/Applications/PixelPaint/IconBag.cpp
+++ b/Userland/Applications/PixelPaint/IconBag.cpp
@@ -36,6 +36,8 @@ ErrorOr<IconBag> IconBag::try_create()
     icon_bag.active_layer_down = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/active-layer-down.png"));
     icon_bag.delete_layer = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/delete.png"));
     icon_bag.merge_visible = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/merge-visible.png"));
+    icon_bag.merge_active_layer_up = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/merge-active-layer-up.png"));
+    icon_bag.merge_active_layer_down = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/merge-active-layer-down.png"));
     icon_bag.filter = TRY(Gfx::Bitmap::try_load_from_file("/res/icons/pixelpaint/filter.png"));
 
     return icon_bag;

--- a/Userland/Applications/PixelPaint/IconBag.h
+++ b/Userland/Applications/PixelPaint/IconBag.h
@@ -37,6 +37,8 @@ struct IconBag final {
     RefPtr<Gfx::Bitmap> active_layer_down { nullptr };
     RefPtr<Gfx::Bitmap> delete_layer { nullptr };
     RefPtr<Gfx::Bitmap> merge_visible { nullptr };
+    RefPtr<Gfx::Bitmap> merge_active_layer_up { nullptr };
+    RefPtr<Gfx::Bitmap> merge_active_layer_down { nullptr };
     RefPtr<Gfx::Bitmap> filter { nullptr };
 };
 }

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -369,6 +369,23 @@ void Image::merge_visible_layers()
     }
 }
 
+void Image::merge_active_layer_up(Layer& layer)
+{
+    if (m_layers.size() < 2)
+        return;
+    size_t layer_index = this->index_of(layer);
+    if ((layer_index + 1) == m_layers.size()) {
+        dbgln("Cannot merge layer up: layer is already at the top");
+        return; // FIXME: Notify user of error properly.
+    }
+
+    auto& layer_above = m_layers.at(layer_index + 1);
+    GUI::Painter painter(layer_above.bitmap());
+    painter.draw_scaled_bitmap(rect(), layer.bitmap(), layer.rect(), (float)layer.opacity_percent() / 100.0f);
+    remove_layer(layer);
+    select_layer(&layer_above);
+}
+
 void Image::merge_active_layer_down(Layer& layer)
 {
     if (m_layers.size() < 2)

--- a/Userland/Applications/PixelPaint/Image.h
+++ b/Userland/Applications/PixelPaint/Image.h
@@ -81,6 +81,7 @@ public:
     void select_layer(Layer*);
     void flatten_all_layers();
     void merge_visible_layers();
+    void merge_active_layer_up(Layer& layer);
     void merge_active_layer_down(Layer& layer);
 
     void add_client(ImageClient&);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -592,7 +592,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
 
     m_layer_menu->add_action(GUI::Action::create(
-        "Merge &Active Layer Up", [&](auto&) {
+        "Merge &Active Layer Up", g_icon_bag.merge_active_layer_up, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
             auto active_layer = editor->active_layer();
@@ -603,7 +603,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
 
     m_layer_menu->add_action(GUI::Action::create(
-        "M&erge Active Layer Down", { Mod_Ctrl, Key_E }, [&](auto&) {
+        "M&erge Active Layer Down", { Mod_Ctrl, Key_E }, g_icon_bag.merge_active_layer_down, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);
             auto active_layer = editor->active_layer();

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -592,6 +592,17 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         }));
 
     m_layer_menu->add_action(GUI::Action::create(
+        "Merge &Active Layer Up", [&](auto&) {
+            auto* editor = current_image_editor();
+            VERIFY(editor);
+            auto active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+            editor->image().merge_active_layer_up(*active_layer);
+            editor->did_complete_action();
+        }));
+
+    m_layer_menu->add_action(GUI::Action::create(
         "M&erge Active Layer Down", { Mod_Ctrl, Key_E }, [&](auto&) {
             auto* editor = current_image_editor();
             VERIFY(editor);


### PR DESCRIPTION
This implements 'Merge Active Layer Up' based on 'Merge Active Layer Down', as well as using the icons for each action that were added in a previous commit but never used.

<img width="342" alt="Screen Shot 2022-02-14 at 21 37 04" src="https://user-images.githubusercontent.com/4368524/153981959-8191e615-e5bb-4f1a-9cf1-3cb85ffb7188.png">