### PR TITLE
Base+Piano: Insert missing icons into menubar

### DIFF
--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -55,11 +55,11 @@ MainWidget::MainWidget(TrackManager& track_manager, AudioPlayerLoop& loop)
 
 void MainWidget::add_track_actions(GUI::Menu& menu)
 {
-    menu.add_action(GUI::Action::create("&Add Track", { Mod_Ctrl, Key_T }, [&](auto&) {
+    menu.add_action(GUI::Action::create("&Add Track", { Mod_Ctrl, Key_T }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/plus.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         m_player_widget->add_track();
     }));
 
-    menu.add_action(GUI::Action::create("&Next Track", { Mod_Ctrl, Key_N }, [&](auto&) {
+    menu.add_action(GUI::Action::create("&Next Track", { Mod_Ctrl, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-last.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         turn_off_pressed_keys();
         m_player_widget->next_track();
         turn_on_pressed_keys();

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -54,7 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     main_widget_updater->start();
 
     auto& file_menu = window->add_menu("&File");
-    file_menu.add_action(GUI::Action::create("Export", { Mod_Ctrl, Key_E }, [&](const GUI::Action&) {
+    file_menu.add_action(GUI::Action::create("Export", { Mod_Ctrl, Key_E }, TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/file-export.png")), [&](const GUI::Action&) {
         save_path = GUI::FilePicker::get_save_filepath(window, "Untitled", "wav");
         if (!save_path.has_value())
             return;


### PR DESCRIPTION
Inserts icons for 'Export', 'Add Track' and 'Next Track'.

<img width="184" alt="Screen Shot 2022-02-14 at 23 38 10" src="https://user-images.githubusercontent.com/4368524/153993863-c01e2fe4-0182-4022-98f0-eb8bb930f7d9.png">
<img width="211" alt="Screen Shot 2022-02-14 at 23 38 04" src="https://user-images.githubusercontent.com/4368524/153993858-ea675a09-61bb-441d-bd20-3a94b5d9ad4e.png">