### PR TITLE
LibWeb: Add stubs for document.write and document.writeln

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -147,6 +147,18 @@ void Document::removed_last_ref()
     delete this;
 }
 
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-write
+void Document::write(Vector<String> const& strings)
+{
+    dbgln("TODO: document.write({})", strings);
+}
+
+// https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-document-writeln
+void Document::writeln(Vector<String> const& strings)
+{
+    dbgln("TODO: document.writeln({})", strings);
+}
+
 Origin Document::origin() const
 {
     if (!m_url.is_valid())

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -13,6 +13,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
 #include <AK/URL.h>
+#include <AK/Vector.h>
 #include <AK/WeakPtr.h>
 #include <LibCore/Forward.h>
 #include <LibJS/Forward.h>
@@ -242,6 +243,9 @@ public:
     void removed_last_ref();
 
     Window& window() { return *m_window; }
+
+    void write(Vector<String> const& strings);
+    void writeln(Vector<String> const& strings);
 
     Window* default_view() { return m_window; }
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -16,6 +16,9 @@ interface Document : Node {
 
     readonly attribute Window? defaultView;
 
+    undefined write(DOMString... text);
+    undefined writeln(DOMString... text);
+
     attribute DOMString cookie;
 
     readonly attribute USVString referrer;


### PR DESCRIPTION
ACID3 throws exception about document.write but seems to not test it
(score didn't changed). I added document.writeln too because it is
similar.