### PR TITLE
LibWeb: Implement state switch for CDATA parsing, and don't crash in AAA

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -130,6 +130,7 @@ HTMLParser::HTMLParser(DOM::Document& document, StringView input, const String& 
     : m_tokenizer(input, encoding)
     , m_document(document)
 {
+    m_tokenizer.set_parser({}, *this);
     m_document->set_should_invalidate_styles_on_attribute_changes(false);
     auto standardized_encoding = TextCodec::get_standardized_encoding(encoding);
     VERIFY(standardized_encoding.has_value());

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -1112,8 +1112,7 @@ HTMLParser::AdoptionAgencyAlgorithmOutcome HTMLParser::run_the_adoption_agency_a
     }
 
     // FIXME: Implement the rest of the AAA :^)
-
-    TODO();
+    return AdoptionAgencyAlgorithmOutcome::DoNothing;
 }
 
 bool HTMLParser::is_special_tag(const FlyString& tag_name, const FlyString& namespace_)

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -42,6 +42,8 @@ namespace Web::HTML {
 RefPtr<DOM::Document> parse_html_document(StringView, const AK::URL&, const String& encoding);
 
 class HTMLParser {
+    friend class HTMLTokenizer;
+
 public:
     HTMLParser(DOM::Document&, StringView input, const String& encoding);
     ~HTMLParser();

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -100,7 +100,6 @@ private:
 
     void generate_implied_end_tags(const FlyString& exception = {});
     void generate_all_implied_end_tags_thoroughly();
-    bool stack_of_open_elements_has_element_with_tag_name_in_scope(const FlyString& tag_name);
     NonnullRefPtr<DOM::Element> create_element_for(const HTMLToken&, const FlyString& namespace_);
 
     struct AdjustedInsertionLocation {

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -238,6 +238,7 @@ _StartOfFunction:
     for (;;) {
         auto current_input_character = next_code_point();
         switch (m_state) {
+            // 13.2.5.1 Data state, https://html.spec.whatwg.org/multipage/parsing.html#data-state
             BEGIN_STATE(Data)
             {
                 ON('&')
@@ -265,6 +266,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.6 Tag open state, https://html.spec.whatwg.org/multipage/parsing.html#tag-open-state
             BEGIN_STATE(TagOpen)
             {
                 ON('!')
@@ -301,6 +303,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.8 Tag name state, https://html.spec.whatwg.org/multipage/parsing.html#tag-name-state
             BEGIN_STATE(TagName)
             {
                 ON_WHITESPACE
@@ -349,6 +352,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.7 End tag open state, https://html.spec.whatwg.org/multipage/parsing.html#end-tag-open-state
             BEGIN_STATE(EndTagOpen)
             {
                 ON_ASCII_ALPHA
@@ -377,6 +381,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.42 Markup declaration open state, https://html.spec.whatwg.org/multipage/parsing.html#markup-declaration-open-state
             BEGIN_STATE(MarkupDeclarationOpen)
             {
                 DONT_CONSUME_NEXT_INPUT_CHARACTER;
@@ -400,6 +405,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.41 Bogus comment state, https://html.spec.whatwg.org/multipage/parsing.html#bogus-comment-state
             BEGIN_STATE(BogusComment)
             {
                 ON('>')
@@ -426,6 +432,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.53 DOCTYPE state, https://html.spec.whatwg.org/multipage/parsing.html#doctype-state
             BEGIN_STATE(DOCTYPE)
             {
                 ON_WHITESPACE
@@ -452,6 +459,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.54 Before DOCTYPE name state, https://html.spec.whatwg.org/multipage/parsing.html#before-doctype-name-state
             BEGIN_STATE(BeforeDOCTYPEName)
             {
                 ON_WHITESPACE
@@ -498,6 +506,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.55 DOCTYPE name state, https://html.spec.whatwg.org/multipage/parsing.html#doctype-name-state
             BEGIN_STATE(DOCTYPEName)
             {
                 ON_WHITESPACE
@@ -536,6 +545,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.56 After DOCTYPE name state, https://html.spec.whatwg.org/multipage/parsing.html#after-doctype-name-state
             BEGIN_STATE(AfterDOCTYPEName)
             {
                 ON_WHITESPACE
@@ -568,6 +578,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.57 After DOCTYPE public keyword state, https://html.spec.whatwg.org/multipage/parsing.html#after-doctype-public-keyword-state
             BEGIN_STATE(AfterDOCTYPEPublicKeyword)
             {
                 ON_WHITESPACE
@@ -608,6 +619,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.63 After DOCTYPE system keyword state, https://html.spec.whatwg.org/multipage/parsing.html#after-doctype-system-keyword-state
             BEGIN_STATE(AfterDOCTYPESystemKeyword)
             {
                 ON_WHITESPACE
@@ -650,6 +662,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.58 Before DOCTYPE public identifier state, https://html.spec.whatwg.org/multipage/parsing.html#before-doctype-public-identifier-state
             BEGIN_STATE(BeforeDOCTYPEPublicIdentifier)
             {
                 ON_WHITESPACE
@@ -688,6 +701,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.64 Before DOCTYPE system identifier state, https://html.spec.whatwg.org/multipage/parsing.html#before-doctype-system-identifier-state
             BEGIN_STATE(BeforeDOCTYPESystemIdentifier)
             {
                 ON_WHITESPACE
@@ -726,6 +740,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.59 DOCTYPE public identifier (double-quoted) state, https://html.spec.whatwg.org/multipage/parsing.html#doctype-public-identifier-(double-quoted)-state
             BEGIN_STATE(DOCTYPEPublicIdentifierDoubleQuoted)
             {
                 ON('"')
@@ -761,6 +776,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.60 DOCTYPE public identifier (single-quoted) state, https://html.spec.whatwg.org/multipage/parsing.html#doctype-public-identifier-(single-quoted)-state
             BEGIN_STATE(DOCTYPEPublicIdentifierSingleQuoted)
             {
                 ON('\'')
@@ -796,6 +812,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.65 DOCTYPE system identifier (double-quoted) state, https://html.spec.whatwg.org/multipage/parsing.html#doctype-system-identifier-(double-quoted)-state
             BEGIN_STATE(DOCTYPESystemIdentifierDoubleQuoted)
             {
                 ON('"')
@@ -831,6 +848,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.66 DOCTYPE system identifier (single-quoted) state, https://html.spec.whatwg.org/multipage/parsing.html#doctype-system-identifier-(single-quoted)-state
             BEGIN_STATE(DOCTYPESystemIdentifierSingleQuoted)
             {
                 ON('\'')
@@ -866,6 +884,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.61 After DOCTYPE public identifier state, https://html.spec.whatwg.org/multipage/parsing.html#after-doctype-public-identifier-state
             BEGIN_STATE(AfterDOCTYPEPublicIdentifier)
             {
                 ON_WHITESPACE
@@ -904,6 +923,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.62 Between DOCTYPE public and system identifiers state, https://html.spec.whatwg.org/multipage/parsing.html#between-doctype-public-and-system-identifiers-state
             BEGIN_STATE(BetweenDOCTYPEPublicAndSystemIdentifiers)
             {
                 ON_WHITESPACE
@@ -940,6 +960,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.67 After DOCTYPE system identifier state, https://html.spec.whatwg.org/multipage/parsing.html#after-doctype-system-identifier-state
             BEGIN_STATE(AfterDOCTYPESystemIdentifier)
             {
                 ON_WHITESPACE
@@ -965,6 +986,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.68 Bogus DOCTYPE state, https://html.spec.whatwg.org/multipage/parsing.html#bogus-doctype-state
             BEGIN_STATE(BogusDOCTYPE)
             {
                 ON('>')
@@ -988,6 +1010,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.32 Before attribute name state, https://html.spec.whatwg.org/multipage/parsing.html#before-attribute-name-state
             BEGIN_STATE(BeforeAttributeName)
             {
                 ON_WHITESPACE
@@ -1027,6 +1050,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.40 Self-closing start tag state, https://html.spec.whatwg.org/multipage/parsing.html#self-closing-start-tag-state
             BEGIN_STATE(SelfClosingStartTag)
             {
                 ON('>')
@@ -1047,6 +1071,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.33 Attribute name state, https://html.spec.whatwg.org/multipage/parsing.html#attribute-name-state
             BEGIN_STATE(AttributeName)
             {
                 ON_WHITESPACE
@@ -1110,6 +1135,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.34 After attribute name state, https://html.spec.whatwg.org/multipage/parsing.html#after-attribute-name-state
             BEGIN_STATE(AfterAttributeName)
             {
                 ON_WHITESPACE
@@ -1143,6 +1169,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.35 Before attribute value state, https://html.spec.whatwg.org/multipage/parsing.html#before-attribute-value-state
             BEGIN_STATE(BeforeAttributeValue)
             {
                 m_current_token.last_attribute().value_start_position = nth_last_position(1);
@@ -1170,6 +1197,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.36 Attribute value (double-quoted) state, https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(double-quoted)-state
             BEGIN_STATE(AttributeValueDoubleQuoted)
             {
                 ON('"')
@@ -1201,6 +1229,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.37 Attribute value (single-quoted) state, https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(single-quoted)-state
             BEGIN_STATE(AttributeValueSingleQuoted)
             {
                 ON('\'')
@@ -1232,6 +1261,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.38 Attribute value (unquoted) state, https://html.spec.whatwg.org/multipage/parsing.html#attribute-value-(single-quoted)-state
             BEGIN_STATE(AttributeValueUnquoted)
             {
                 ON_WHITESPACE
@@ -1296,6 +1326,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.39 After attribute value (quoted) state, https://html.spec.whatwg.org/multipage/parsing.html#after-attribute-value-(quoted)-state
             BEGIN_STATE(AfterAttributeValueQuoted)
             {
                 m_current_token.last_attribute().value_end_position = nth_last_position(1);
@@ -1324,6 +1355,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.43 Comment start state, https://html.spec.whatwg.org/multipage/parsing.html#comment-start-state
             BEGIN_STATE(CommentStart)
             {
                 ON('-')
@@ -1342,6 +1374,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.44 Comment start dash state, https://html.spec.whatwg.org/multipage/parsing.html#comment-start-dash-state
             BEGIN_STATE(CommentStartDash)
             {
                 ON('-')
@@ -1366,6 +1399,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.45 Comment state, https://html.spec.whatwg.org/multipage/parsing.html#comment-state
             BEGIN_STATE(Comment)
             {
                 ON('<')
@@ -1397,6 +1431,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.51 Comment end state, https://html.spec.whatwg.org/multipage/parsing.html#comment-end-state
             BEGIN_STATE(CommentEnd)
             {
                 ON('>')
@@ -1427,6 +1462,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.52 Comment end bang state, https://html.spec.whatwg.org/multipage/parsing.html#comment-end-bang-state
             BEGIN_STATE(CommentEndBang)
             {
                 ON('-')
@@ -1454,6 +1490,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.50 Comment end dash state, https://html.spec.whatwg.org/multipage/parsing.html#comment-end-dash-state
             BEGIN_STATE(CommentEndDash)
             {
                 ON('-')
@@ -1474,6 +1511,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.46 Comment less-than sign state, https://html.spec.whatwg.org/multipage/parsing.html#comment-less-than-sign-state
             BEGIN_STATE(CommentLessThanSign)
             {
                 ON('!')
@@ -1493,6 +1531,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.47 Comment less-than sign bang state, https://html.spec.whatwg.org/multipage/parsing.html#comment-less-than-sign-bang-state
             BEGIN_STATE(CommentLessThanSignBang)
             {
                 ON('-')
@@ -1506,6 +1545,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.48 Comment less-than sign bang dash state, https://html.spec.whatwg.org/multipage/parsing.html#comment-less-than-sign-bang-dash-state
             BEGIN_STATE(CommentLessThanSignBangDash)
             {
                 ON('-')
@@ -1519,6 +1559,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.49 Comment less-than sign bang dash dash state, https://html.spec.whatwg.org/multipage/parsing.html#comment-less-than-sign-bang-dash-dash-state
             BEGIN_STATE(CommentLessThanSignBangDashDash)
             {
                 ON('>')
@@ -1537,6 +1578,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.72 Character reference state, https://html.spec.whatwg.org/multipage/parsing.html#character-reference-state
             BEGIN_STATE(CharacterReference)
             {
                 m_temporary_buffer.clear();
@@ -1559,6 +1601,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.73 Named character reference state, https://html.spec.whatwg.org/multipage/parsing.html#named-character-reference-state
             BEGIN_STATE(NamedCharacterReference)
             {
                 size_t byte_offset = m_utf8_view.byte_offset_of(m_prev_utf8_iterator);
@@ -1595,6 +1638,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.74 Ambiguous ampersand state, https://html.spec.whatwg.org/multipage/parsing.html#ambiguous-ampersand-state
             BEGIN_STATE(AmbiguousAmpersand)
             {
                 ON_ASCII_ALPHANUMERIC
@@ -1618,6 +1662,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.75 Numeric character reference state, https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-state
             BEGIN_STATE(NumericCharacterReference)
             {
                 m_character_reference_code = 0;
@@ -1639,6 +1684,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.76 Hexadecimal character reference start state, https://html.spec.whatwg.org/multipage/parsing.html#hexadecimal-character-reference-start-state
             BEGIN_STATE(HexadecimalCharacterReferenceStart)
             {
                 ON_ASCII_HEX_DIGIT
@@ -1654,6 +1700,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.77 Decimal character reference start state, https://html.spec.whatwg.org/multipage/parsing.html#decimal-character-reference-start-state
             BEGIN_STATE(DecimalCharacterReferenceStart)
             {
                 ON_ASCII_DIGIT
@@ -1669,6 +1716,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.78 Hexadecimal character reference state, https://html.spec.whatwg.org/multipage/parsing.html#decimal-character-reference-start-state
             BEGIN_STATE(HexadecimalCharacterReference)
             {
                 ON_ASCII_DIGIT
@@ -1701,6 +1749,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.79 Decimal character reference state, https://html.spec.whatwg.org/multipage/parsing.html#decimal-character-reference-state
             BEGIN_STATE(DecimalCharacterReference)
             {
                 ON_ASCII_DIGIT
@@ -1721,6 +1770,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.80 Numeric character reference end state, https://html.spec.whatwg.org/multipage/parsing.html#numeric-character-reference-end-state
             BEGIN_STATE(NumericCharacterReferenceEnd)
             {
                 DONT_CONSUME_NEXT_INPUT_CHARACTER;
@@ -1789,6 +1839,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.2 RCDATA state, https://html.spec.whatwg.org/multipage/parsing.html#rcdata-state
             BEGIN_STATE(RCDATA)
             {
                 ON('&')
@@ -1816,6 +1867,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.9 RCDATA less-than sign state, https://html.spec.whatwg.org/multipage/parsing.html#rcdata-less-than-sign-state
             BEGIN_STATE(RCDATALessThanSign)
             {
                 ON('/')
@@ -1830,6 +1882,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.10 RCDATA end tag open state, https://html.spec.whatwg.org/multipage/parsing.html#rcdata-end-tag-open-state
             BEGIN_STATE(RCDATAEndTagOpen)
             {
                 ON_ASCII_ALPHA
@@ -1846,6 +1899,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.11 RCDATA end tag name state, https://html.spec.whatwg.org/multipage/parsing.html#rcdata-end-tag-name-state
             BEGIN_STATE(RCDATAEndTagName)
             {
                 ON_WHITESPACE
@@ -1909,6 +1963,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.3 RAWTEXT state, https://html.spec.whatwg.org/multipage/parsing.html#rawtext-state
             BEGIN_STATE(RAWTEXT)
             {
                 ON('<')
@@ -1931,6 +1986,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.12 RAWTEXT less-than sign state, https://html.spec.whatwg.org/multipage/parsing.html#rawtext-less-than-sign-state
             BEGIN_STATE(RAWTEXTLessThanSign)
             {
                 ON('/')
@@ -1945,6 +2001,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.13 RAWTEXT end tag open state, https://html.spec.whatwg.org/multipage/parsing.html#rawtext-end-tag-open-state
             BEGIN_STATE(RAWTEXTEndTagOpen)
             {
                 ON_ASCII_ALPHA
@@ -1961,6 +2018,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.14 RAWTEXT end tag name state, https://html.spec.whatwg.org/multipage/parsing.html#rawtext-end-tag-name-state
             BEGIN_STATE(RAWTEXTEndTagName)
             {
                 ON_WHITESPACE
@@ -2024,6 +2082,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.4 Script data state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-state
             BEGIN_STATE(ScriptData)
             {
                 ON('<')
@@ -2046,6 +2105,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.5 PLAINTEXT state, https://html.spec.whatwg.org/multipage/parsing.html#plaintext-state
             BEGIN_STATE(PLAINTEXT)
             {
                 ON(0)
@@ -2064,6 +2124,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.15 Script data less-than sign state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-less-than-sign-state
             BEGIN_STATE(ScriptDataLessThanSign)
             {
                 ON('/')
@@ -2084,6 +2145,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.18 Script data escape start state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-escape-start-state
             BEGIN_STATE(ScriptDataEscapeStart)
             {
                 ON('-')
@@ -2097,6 +2159,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.19 Script data escape start dash state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-escape-start-dash-state
             BEGIN_STATE(ScriptDataEscapeStartDash)
             {
                 ON('-')
@@ -2110,6 +2173,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.22 Script data escaped dash dash state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-dash-dash-state
             BEGIN_STATE(ScriptDataEscapedDashDash)
             {
                 ON('-')
@@ -2141,6 +2205,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.23 Script data escaped less-than sign state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-less-than-sign-state
             BEGIN_STATE(ScriptDataEscapedLessThanSign)
             {
                 ON('/')
@@ -2160,6 +2225,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.24 Script data escaped end tag open state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-end-tag-open-state
             BEGIN_STATE(ScriptDataEscapedEndTagOpen)
             {
                 ON_ASCII_ALPHA
@@ -2176,6 +2242,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.25 Script data escaped end tag name state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-end-tag-name-state
             BEGIN_STATE(ScriptDataEscapedEndTagName)
             {
                 ON_WHITESPACE
@@ -2249,6 +2316,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.26 Script data double escape start state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escape-start-state
             BEGIN_STATE(ScriptDataDoubleEscapeStart)
             {
                 auto temporary_buffer_equal_to_script = [this]() -> bool {
@@ -2296,6 +2364,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.27 Script data double escaped state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escaped-state
             BEGIN_STATE(ScriptDataDoubleEscaped)
             {
                 ON('-')
@@ -2323,6 +2392,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.28 Script data double escaped dash state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escaped-dash-state
             BEGIN_STATE(ScriptDataDoubleEscapedDash)
             {
                 ON('-')
@@ -2350,6 +2420,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.29 Script data double escaped dash dash state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escaped-dash-dash-state
             BEGIN_STATE(ScriptDataDoubleEscapedDashDash)
             {
                 ON('-')
@@ -2381,6 +2452,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.30 Script data double escaped less-than sign state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escaped-less-than-sign-state
             BEGIN_STATE(ScriptDataDoubleEscapedLessThanSign)
             {
                 ON('/')
@@ -2395,6 +2467,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.31 Script data double escape end state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-double-escape-end-state
             BEGIN_STATE(ScriptDataDoubleEscapeEnd)
             {
                 auto temporary_buffer_equal_to_script = [this]() -> bool {
@@ -2442,6 +2515,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.21 Script data escaped dash state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-dash-state
             BEGIN_STATE(ScriptDataEscapedDash)
             {
                 ON('-')
@@ -2469,6 +2543,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.20 Script data escaped state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-escaped-state
             BEGIN_STATE(ScriptDataEscaped)
             {
                 ON('-')
@@ -2496,6 +2571,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.16 Script data end tag open state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-open-state
             BEGIN_STATE(ScriptDataEndTagOpen)
             {
                 ON_ASCII_ALPHA
@@ -2512,6 +2588,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.17 Script data end tag name state, https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state
             BEGIN_STATE(ScriptDataEndTagName)
             {
                 ON_WHITESPACE
@@ -2578,6 +2655,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.69 CDATA section state, https://html.spec.whatwg.org/multipage/parsing.html#cdata-section-state
             BEGIN_STATE(CDATASection)
             {
                 ON(']')
@@ -2596,6 +2674,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.70 CDATA section bracket state, https://html.spec.whatwg.org/multipage/parsing.html#cdata-section-bracket-state
             BEGIN_STATE(CDATASectionBracket)
             {
                 ON(']')
@@ -2609,6 +2688,7 @@ _StartOfFunction:
             }
             END_STATE
 
+            // 13.2.5.71 CDATA section end state, https://html.spec.whatwg.org/multipage/parsing.html#cdata-section-end-state
             BEGIN_STATE(CDATASectionEnd)
             {
                 ON(']')

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -110,6 +111,8 @@ public:
 
     Optional<HTMLToken> next_token();
 
+    void set_parser(Badge<HTMLParser>, HTMLParser& parser) { m_parser = &parser; }
+
     void switch_to(Badge<HTMLParser>, State new_state);
     void switch_to(State new_state)
     {
@@ -150,6 +153,8 @@ private:
 
     void restore_to(Utf8CodePointIterator const& new_iterator);
     HTMLToken::Position nth_last_position(size_t n = 0);
+
+    HTMLParser* m_parser { nullptr };
 
     State m_state { State::Data };
     State m_return_state { State::Data };


### PR DESCRIPTION
This makes https://html5test.com load a little bit :^)

<img src="https://user-images.githubusercontent.com/19366641/154132260-f93acfee-3809-4f9b-954f-1d456a478b5b.png" width="400">
