### PR TITLE
Documentation: add Rosetta/Homebrew macOS note

### DIFF
--- a/Documentation/BuildInstructionsMacOS.md
+++ b/Documentation/BuildInstructionsMacOS.md
@@ -13,7 +13,7 @@ Make sure you also have all the following dependencies installed:
 
 ```console
 # core
-brew install coreutils e2fsprogs qemu bash gcc@11 imagemagick ninja cmake ccache rsync
+brew install coreutils e2fsprogs qemu bash gcc@11 imagemagick ninja cmake ccache rsync zstd
 
 # (option 1) fuse + ext2
 brew install m4 autoconf automake libtool
@@ -23,6 +23,12 @@ Toolchain/BuildFuseExt2.sh
 # (option 2) genext2fs
 brew install genext2fs
 ```
+
+If you're building on M1 Mac and have Homebrew installed in both Rosetta and native environments,
+you have to make sure that required packages are installed only in one of the environments. Otherwise,
+these installations can conflict during the build process, which is manifested in hard to diagnose issues.
+Building on M1 natively without Rosetta is recommended, as the build process should be faster without Rosetta
+overhead.
 
 Notes:
 


### PR DESCRIPTION
This should prevent a build issue caused by a potential conflicting zstd installation on M1 Mac.

This was manifested in a linker error when building the GNU toolchain:

```
Undefined symbols for architecture arm64:
[gcc/build]   "_ZSTD_compress", referenced from:
[gcc/build]       lto_end_compression(lto_compression_stream*) in libbackend.a(lto-compress.o)
```