### PR TITLE
ping: Fix broken count argument error

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -484,6 +484,22 @@ void ArgsParser::add_option(Optional<double>& value, const char* help_string, co
     add_option(move(option));
 }
 
+void ArgsParser::add_option(Optional<size_t>& value, const char* help_string, const char* long_name, char short_name, const char* value_name)
+{
+    Option option {
+        true,
+        help_string,
+        long_name,
+        short_name,
+        value_name,
+        [&value](const char* s) {
+            value = AK::StringUtils::convert_to_uint<size_t>(s);
+            return value.has_value();
+        }
+    };
+    add_option(move(option));
+}
+
 void ArgsParser::add_positional_argument(Arg&& arg)
 {
     m_positional_args.append(move(arg));

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -78,6 +78,7 @@ public:
     void add_option(unsigned& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
     void add_option(double& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
     void add_option(Optional<double>& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
+    void add_option(Optional<size_t>& value, const char* help_string, const char* long_name, char short_name, const char* value_name);
 
     void add_positional_argument(Arg&&);
     void add_positional_argument(const char*& value, const char* help_string, const char* name, Required required = Required::Yes);

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -26,7 +26,7 @@
 
 static uint32_t total_pings;
 static int successful_pings;
-static uint32_t count;
+static Optional<size_t> count;
 static uint32_t total_ms;
 static int min_ms;
 static int max_ms;
@@ -67,8 +67,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(payload_size, "Amount of bytes to send as payload in the ECHO_REQUEST packets.", "size", 's', "size");
     args_parser.parse(arguments);
 
-    if (count < 1 || count > UINT32_MAX) {
-        warnln("invalid count argument: '{}': out of range: 1 <= value <= {}", count, UINT32_MAX);
+    if (count.has_value() && (count.value() < 1 || count.value() > UINT32_MAX)) {
+        warnln("invalid count argument: '{}': out of range: 1 <= value <= {}", count.value(), UINT32_MAX);
         return 1;
     }
 
@@ -157,7 +157,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         struct timeval tv_send;
         gettimeofday(&tv_send, nullptr);
 
-        if (count && total_pings == count)
+        if (count.has_value() && total_pings == count.value())
             closing_statistics();
         else
             total_pings++;


### PR DESCRIPTION
Apologies for the silly bug :flushed: 

**ArgsParser: Add support for Optional<size_t>**

**ping: Fix broken count argument error**
By storing count as an Optional<size_t>, we can leverage count's empty
state to proceed with pinging indefinitely, and ensure a proper value is
passed when count does have a value.

This returns pings expected behavior to send infinite packets when a
count is not specified, stop after sending a specified count, and
disallow any count < 1.

Closes #12524