### PR TITLE
LibWeb: Set cursor on mousemove for non-text elements

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -352,6 +352,12 @@ bool EventHandler::handle_mousemove(const Gfx::IntPoint& position, unsigned butt
                     hovered_node_cursor = Gfx::StandardCursor::IBeam;
                 else
                     hovered_node_cursor = cursor_css_to_gfx(cursor);
+            } else if (node->is_element()) {
+                auto cursor = result.layout_node->computed_values().cursor();
+                if (cursor == CSS::Cursor::Auto)
+                    hovered_node_cursor = Gfx::StandardCursor::Arrow;
+                else
+                    hovered_node_cursor = cursor_css_to_gfx(cursor);
             }
 
             auto offset = compute_mouse_event_offset(position, *result.layout_node);


### PR DESCRIPTION
Hi this is my first attempt at a PR here and it is quite tiny but maybe something helpful.  I noticed while testing the Serenity browser that images with a "cursor: pointer" CSS style did not change the cursor, while text links did.  I got curious and was able to find that the event handler only changed the cursor for text nodes and not element nodes.  With this change, any element with a customized cursor style will work (at least as far as I can tell).

Here is a sample html file for test purposes:
```
<p>should show beam</p>

<a href="https://google.com">should show pointer</a>

<div style="width:100px;height:100px;cursor: pointer;background-color: blue;">cursor</div>

<div style="width:100px;height:100px;background-color: green;">pointer</div>
```

Thanks!
Adam