### PR TITLE
LibProtocol: Fix crash on EOF when using Request::stream_into

### DIFF
--- a/Userland/Libraries/LibProtocol/Request.cpp
+++ b/Userland/Libraries/LibProtocol/Request.cpp
@@ -52,12 +52,12 @@ void Request::stream_into_impl(T& stream)
             if (result.is_error())
                 continue;
             auto nread = result.value();
+            if (nread == 0)
+                break;
             if (!stream.write_or_error({ buf, nread })) {
                 // FIXME: What do we do here?
                 TODO();
             }
-            if (nread == 0)
-                break;
         } while (true);
 
         if (m_internal_stream_data->read_stream->is_eof() && m_internal_stream_data->request_done) {


### PR DESCRIPTION
Trying to download an image using the browser results in the following crash:

```
63.570 Browser(56:56): ASSERTION FAILED: buffer.size()
./Userland/Libraries/LibCore/Stream.cpp:49
63.570 [#0 Browser(56:56)]: Terminating Browser(56) due to signal 6
63.574 [#0 FinalizerTask(4:4)]: Backtrace:
0x00000000deadc0de  Kernel::Processor::switch_context(Kernel::Thread*&, Kernel::Thread*&) + 0x383
63.574 [#0 FinalizerTask(4:4)]: Generating coredump for pid: 56
63.638 CrashDaemon(9:9): New coredump file: /tmp/coredump/Browser_56_1645008106
63.693 CrashReporter(61:61): Started thread "", tid = 62
63.856 CrashReporter(61:62): Generating backtrace took 163 ms
63.856 CrashReporter(61:62): --- Backtrace for thread #0 (TID 56) ---
63.856 CrashReporter(61:62): 0x000000048166102b: [libsystem.so] syscall2 +0xb (syscall.cpp:25 => syscall.cpp:24)
63.856 CrashReporter(61:62): 0x0000000531cb8ad7: [libc.so] abort +0x27 (stdlib.cpp:220)
63.856 CrashReporter(61:62): 0x0000000531cbe7ae: [libc.so] __assertion_failed +0x7e (assert.cpp:33)
63.856 CrashReporter(61:62): 0x000000004adc998b: [libcore.so.serenity] Core::Stream::Stream::write_or_error(AK::Span<unsigned char const>) [clone .localalias] +0xbb (Stream.cpp:49)
63.861 CrashReporter(61:62): 0x000000098489585d: [libprotocol.so.serenity] Protocol::Request::stream_into_impl<Core::Stream::Stream>(Core::Stream::Stream&)::{lambda()#3}::operator()() const +0x7d (Request.cpp:55)
63.861 CrashReporter(61:62): 0x000000004adc06d8: [libcore.so.serenity] Core::Notifier::event(Core::Event&) +0x88 (Function.h:91)
63.861 CrashReporter(61:62): 0x000000004adc1729: [libcore.so.serenity] Core::Object::dispatch_event(Core::Event&, Core::Object*) +0x99 (Object.cpp:219)
63.861 CrashReporter(61:62): 0x000000004adacd57: [libcore.so.serenity] Core::EventLoop::pump(Core::EventLoop::WaitMode) [clone .localalias] +0x147 (EventLoop.cpp:471)
63.861 CrashReporter(61:62): 0x000000004adad659: [libcore.so.serenity] Core::EventLoop::exec() +0x119 (EventLoop.cpp:428)
63.861 CrashReporter(61:62): 0x00000007ede2cc04: [/bin/Browser] serenity_main(Main::Arguments) +0x1c34 (main.cpp:125)
63.864 CrashReporter(61:62): 0x0000000d82c351e5: [libmain.so.serenity] main +0x95 (Main.cpp:23)
63.864 CrashReporter(61:62): 0x00000007eddf642f: [/bin/Browser] _entry +0x6f (crt0.cpp:49)
```

This VERIFY in [Stream.cpp](https://github.com/SerenityOS/serenity/blob/083b58fd89d8c49633b38b07ac97e249b68081dd/Userland/Libraries/LibCore/Stream.cpp#L49) is triggering the crash
```C++
bool Stream::write_or_error(ReadonlyBytes buffer)
{
    VERIFY(buffer.size());
```

However this is caused by a write of zero bytes in [Request.cpp](https://github.com/SerenityOS/serenity/blob/083b58fd89d8c49633b38b07ac97e249b68081dd/Userland/Libraries/LibProtocol/Request.cpp#L54-L60)
```C++
m_internal_stream_data->read_notifier->on_ready_to_read = [this, &stream] {
    constexpr size_t buffer_size = 16 * KiB;
    static char buf[buffer_size];
    do {
        auto result = m_internal_stream_data->read_stream->read({ buf, buffer_size });
        if (result.is_error() && (!result.error().is_errno() || (result.error().is_errno() && result.error().code() != EINTR)))
            break;
        if (result.is_error())
            continue;
        auto nread = result.value();
        if (!stream.write_or_error({ buf, nread })) {
            // FIXME: What do we do here?
            TODO();
        }
        if (nread == 0)
            break;
    } while (true);

    if (m_internal_stream_data->read_stream->is_eof() && m_internal_stream_data->request_done) {
        m_internal_stream_data->read_notifier->close();
        m_internal_stream_data->on_finish();
    }
};
```
This pull request moves the check for `nread == 0` before the call to `stream.write_or_error` never writing an empty buffer.