### PR TITLE
Utilities: Add a basic `install` utility

### DIFF
--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND REQUIRED_TARGETS
     touch tr true umount uname uniq uptime w wc which whoami xargs yes less
 )
 list(APPEND RECOMMENDED_TARGETS
-    adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip init keymap lsirq lsof lspci man mknod mktemp
+    adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip init install keymap lsirq lsof lspci man mknod mktemp
     nc netstat notify ntpquery open pape passwd pls printf pro shot tar tt unzip zip
 )
 
@@ -114,6 +114,7 @@ target_link_libraries(hostname LibMain)
 target_link_libraries(id LibMain)
 target_link_libraries(ifconfig LibMain)
 target_link_libraries(ini LibMain)
+target_link_libraries(install-bin LibMain)
 target_link_libraries(jp LibMain)
 target_link_libraries(js LibJS LibLine LibMain)
 link_with_unicode_data(js)

--- a/Userland/Utilities/install.cpp
+++ b/Userland/Utilities/install.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, Tim Schumacher <timschumi@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/LexicalPath.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibMain/Main.h>
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    TRY(Core::System::pledge("stdio rpath wpath cpath fattr"));
+
+    bool create_leading_dest_components = false;
+    StringView source;
+    StringView destination;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(create_leading_dest_components, "Create leading components of the destination path", nullptr, 'D');
+    args_parser.add_positional_argument(source, "Source path", "source");
+    args_parser.add_positional_argument(destination, "Destination path", "destination");
+    args_parser.parse(arguments);
+
+    if (create_leading_dest_components) {
+        String destination_absolute = Core::File::absolute_path(destination);
+        Core::File::ensure_parent_directories(destination_absolute);
+    }
+
+    TRY(Core::File::copy_file_or_directory(destination, source, Core::File::RecursionMode::Allowed,
+        Core::File::LinkMode::Disallowed, Core::File::AddDuplicateFileMarker::No,
+        Core::File::PreserveMode::Nothing));
+
+    return 0;
+}


### PR DESCRIPTION
This is currently just a glorified single-file `cp` with a `-D` flag, which is just enough to make installing headers with our Clang toolchain work.