### PR TITLE
LibWeb: Implement reverse lookup to labels from their labelable nodes

### DIFF
--- a/Base/res/html/misc/checkbox.html
+++ b/Base/res/html/misc/checkbox.html
@@ -1,12 +1,29 @@
 <html>
     <input id=foo type=checkbox>
-    <label for=foo>This is a checkbox</label>
-    <pre id=bar></pre>
+    <label for=foo>Checkbox 1 (with a "for" attribute)</label>
+    <pre id=foo-status></pre>
+
+    <label>
+        <input id=bar type=checkbox>
+        Checkbox 2 (inside a label element)
+    </label>
+    <pre id=bar-status></pre>
+
     <script>
         var foo = document.getElementById("foo");
+        var fooStatus = document.getElementById("foo-status");
+        fooStatus.innerHTML = `Checkbox 1: ${foo.checked}\n`;
+
         var bar = document.getElementById("bar");
+        var barStatus = document.getElementById("bar-status");
+        barStatus.innerHTML = `Checkbox 2: ${bar.checked}\n`;
+
         foo.addEventListener("change", function() {
-            bar.innerHTML += foo.checked + "\n";
+            fooStatus.innerHTML = `Checkbox 1: ${foo.checked}\n`;
+        });
+
+        bar.addEventListener("change", function() {
+            barStatus.innerHTML = `Checkbox 2: ${bar.checked}\n`;
         });
     </script>
 </html>


### PR DESCRIPTION
This enables, for example, clicking on the check box, dragging the mouse
over to the label, releasing the mouse to act as a click on the check
box.

This was implemented for labels / labelable nodes with the "for"
attribute already. This implements the same for labelable nodes that are
inside the label.

https://user-images.githubusercontent.com/5600524/154295638-0fe9f2c2-a531-439d-ac48-599154078cdc.mp4