### PR TITLE
 LibGUI: JsonArrayModel update without invalidating indices

### DIFF
--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -114,7 +114,7 @@ NetworkStatisticsWidget::NetworkStatisticsWidget()
 
 void NetworkStatisticsWidget::update_models()
 {
-    m_adapter_model->invalidate();
-    m_tcp_socket_model->invalidate();
-    m_udp_socket_model->invalidate();
+    m_adapter_model->update();
+    m_tcp_socket_model->update();
+    m_udp_socket_model->update();
 }

--- a/Userland/Libraries/LibGUI/JsonArrayModel.cpp
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.cpp
@@ -28,6 +28,24 @@ void JsonArrayModel::invalidate()
     did_update();
 }
 
+void JsonArrayModel::update()
+{
+    auto file = Core::File::construct(m_json_path);
+    if (!file->open(Core::OpenMode::ReadOnly)) {
+        dbgln("Unable to open {}", file->filename());
+        m_array.clear();
+        did_update();
+        return;
+    }
+
+    auto json = JsonValue::from_string(file->read_all()).release_value_but_fixme_should_propagate_errors();
+
+    VERIFY(json.is_array());
+    m_array = json.as_array();
+
+    did_update(GUI::Model::UpdateFlag::DontInvalidateIndices);
+}
+
 bool JsonArrayModel::store()
 {
     auto file = Core::File::construct(m_json_path);

--- a/Userland/Libraries/LibGUI/JsonArrayModel.h
+++ b/Userland/Libraries/LibGUI/JsonArrayModel.h
@@ -51,6 +51,7 @@ public:
     virtual String column_name(int column) const override { return m_fields[column].column_name; }
     virtual Variant data(const ModelIndex&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
+    virtual void update();
 
     const String& json_path() const { return m_json_path; }
     void set_json_path(const String& json_path);


### PR DESCRIPTION
Add function to update a JsonArrayModel without invalidating it. Now, for example in the SystemMonitor in the Network tab, a selected line will not be deselected whenever the data is updated.