### PR TITLE
LibWeb: Put SVG elements in their place

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/SVGBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGBox.cpp
@@ -12,7 +12,6 @@ namespace Web::Layout {
 SVGBox::SVGBox(DOM::Document& document, SVG::SVGElement& element, NonnullRefPtr<CSS::StyleProperties> style)
     : BlockContainer(document, &element, move(style))
 {
-    set_inline(true);
 }
 
 void SVGBox::before_children_paint(PaintContext& context, PaintPhase phase)

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,7 +8,6 @@
 #include <AK/Format.h>
 #include <LibWeb/Layout/SVGFormattingContext.h>
 #include <LibWeb/Layout/SVGGeometryBox.h>
-#include <LibWeb/Layout/SVGSVGBox.h>
 
 namespace Web::Layout {
 
@@ -22,12 +22,6 @@ SVGFormattingContext::~SVGFormattingContext()
 
 void SVGFormattingContext::run(Box& box, LayoutMode)
 {
-    // FIXME: This formatting context is basically a total hack.
-    //        It works by computing the united bounding box of all <path>'s
-    //        within an <svg>, and using that as the size of this box.
-
-    Gfx::FloatRect total_bounding_box;
-
     box.for_each_in_subtree_of_type<SVGBox>([&](auto& descendant) {
         if (is<SVGGeometryBox>(descendant)) {
             auto& geometry_box = static_cast<SVGGeometryBox&>(descendant);
@@ -40,14 +34,10 @@ void SVGFormattingContext::run(Box& box, LayoutMode)
 
             geometry_box.set_offset(bounding_box.top_left());
             geometry_box.set_content_size(bounding_box.size());
-
-            total_bounding_box = total_bounding_box.united(path.bounding_box());
         }
 
         return IterationDecision::Continue;
     });
-
-    box.set_content_size(total_bounding_box.size());
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGFormattingContext.cpp
@@ -32,7 +32,14 @@ void SVGFormattingContext::run(Box& box, LayoutMode)
         if (is<SVGGeometryBox>(descendant)) {
             auto& geometry_box = static_cast<SVGGeometryBox&>(descendant);
             auto& path = geometry_box.dom_node().get_path();
-            geometry_box.set_content_size(path.bounding_box().size());
+            auto bounding_box = path.bounding_box();
+
+            // Stroke increases the path's size by stroke_width/2 per side.
+            auto stroke_width = geometry_box.dom_node().stroke_width().value_or(0);
+            bounding_box.inflate(stroke_width, stroke_width);
+
+            geometry_box.set_offset(bounding_box.top_left());
+            geometry_box.set_content_size(bounding_box.size());
 
             total_bounding_box = total_bounding_box.united(path.bounding_box());
         }

--- a/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGGeometryBox.cpp
@@ -32,7 +32,7 @@ void SVGGeometryBox::paint(PaintContext& context, PaintPhase phase)
     Gfx::AntiAliasingPainter painter { context.painter() };
     auto& svg_context = context.svg_context();
 
-    auto offset = absolute_position();
+    auto offset = svg_context.svg_element_position();
     painter.translate(offset);
 
     if (auto fill_color = geometry_element.fill_color().value_or(svg_context.fill_color()); fill_color.alpha() > 0) {

--- a/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/SVGSVGBox.cpp
@@ -19,7 +19,7 @@ void SVGSVGBox::before_children_paint(PaintContext& context, PaintPhase phase)
         return;
 
     if (!context.has_svg_context())
-        context.set_svg_context(SVGContext());
+        context.set_svg_context(SVGContext(absolute_rect()));
 
     SVGGraphicsBox::before_children_paint(context, phase);
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGContext.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGContext.h
@@ -8,12 +8,14 @@
 
 #include <AK/Vector.h>
 #include <LibGfx/Color.h>
+#include <LibGfx/Rect.h>
 
 namespace Web {
 
 class SVGContext {
 public:
-    SVGContext()
+    SVGContext(Gfx::FloatRect svg_element_bounds)
+        : m_svg_element_bounds(svg_element_bounds)
     {
         m_states.append(State());
     }
@@ -25,6 +27,8 @@ public:
     void set_fill_color(Gfx::Color color) { state().fill_color = color; }
     void set_stroke_color(Gfx::Color color) { state().stroke_color = color; }
     void set_stroke_width(float width) { state().stroke_width = width; }
+
+    Gfx::FloatPoint svg_element_position() const { return m_svg_element_bounds.top_left(); }
 
     void save() { m_states.append(m_states.last()); }
     void restore() { m_states.take_last(); }
@@ -39,6 +43,7 @@ private:
     const State& state() const { return m_states.last(); }
     State& state() { return m_states.last(); }
 
+    Gfx::FloatRect m_svg_element_bounds;
     Vector<State> m_states;
 };
 

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibGfx/Painter.h>
+#include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
@@ -24,14 +25,21 @@ RefPtr<Layout::Node> SVGSVGElement::create_layout_node(NonnullRefPtr<CSS::StyleP
     return adopt_ref(*new Layout::SVGSVGBox(document(), *this, move(style)));
 }
 
-unsigned SVGSVGElement::width() const
+void SVGSVGElement::apply_presentational_hints(CSS::StyleProperties& style) const
 {
-    return attribute(HTML::AttributeNames::width).to_uint().value_or(300);
-}
+    // Width defaults to 100%
+    if (auto width_value = parse_html_length(document(), attribute("width"))) {
+        style.set_property(CSS::PropertyID::Width, width_value.release_nonnull());
+    } else {
+        style.set_property(CSS::PropertyID::Width, CSS::PercentageStyleValue::create(CSS::Percentage { 100 }));
+    }
 
-unsigned SVGSVGElement::height() const
-{
-    return attribute(HTML::AttributeNames::height).to_uint().value_or(150);
+    // Height defaults to 100%
+    if (auto height_value = parse_html_length(document(), attribute("height"))) {
+        style.set_property(CSS::PropertyID::Height, height_value.release_nonnull());
+    } else {
+        style.set_property(CSS::PropertyID::Height, CSS::PercentageStyleValue::create(CSS::Percentage { 100 }));
+    }
 }
 
 void SVGSVGElement::parse_attribute(FlyString const& name, String const& value)

--- a/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGSVGElement.h
@@ -20,8 +20,7 @@ public:
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
-    unsigned width() const;
-    unsigned height() const;
+    virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 
     virtual bool requires_svg_container() const override { return false; }
     virtual bool is_svg_container() const override { return true; }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/154310332-398c6ed3-3f0c-49da-864e-3dcdb21f215d.png)

With these changes:
- `<svg>` elements have a size again, based on their `width` and `height` attributes, but defaulting to `100%` as the spec dictates.
- Graphical SVG elements (like `<path>`, `<line>`, `<rect>` etc) now have a correct bounding box instead of it appearing in the top-left corner.
- Those elements also hit-test now!
- The hack to produce the SVGFormattingContext's content_size is no longer needed, so it's gone!