### PR TITLE
LibGUI: Multimonitor Dialog and Window positioning improvements

### DIFF
--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -311,7 +311,7 @@ void Window::set_minimum_size(const Gfx::IntSize& size)
 
 void Window::center_on_screen()
 {
-    set_rect(rect().centered_within(Desktop::the().rect()));
+    set_rect(rect().centered_within(Desktop::the().rects()[containing_screen_index()]));
 }
 
 void Window::center_within(const Window& other)

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -24,6 +24,7 @@
 #include <LibGUI/WindowManagerServerConnection.h>
 #include <LibGUI/WindowServerConnection.h>
 #include <LibGfx/Bitmap.h>
+#include <LibGfx/Rect.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -274,6 +275,21 @@ void Window::set_rect(const Gfx::IntRect& a_rect)
         m_front_store = nullptr;
     if (m_main_widget)
         m_main_widget->resize(window_rect.size());
+}
+
+size_t Window::containing_screen_index() const
+{
+    auto window_rect = rect();
+    auto screen_rects = Desktop::the().rects();
+
+    size_t screen_with_largest_intersection_index = 0;
+    for (size_t i = 1; i < screen_rects.size(); i++) {
+        if (Gfx::IntRect::intersection(screen_rects[i], window_rect).size().area()
+            > Gfx::IntRect::intersection(screen_rects[screen_with_largest_intersection_index], window_rect).size().area())
+            screen_with_largest_intersection_index = i;
+    }
+
+    return screen_with_largest_intersection_index;
 }
 
 Gfx::IntSize Window::minimum_size() const

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -92,6 +92,7 @@ public:
 
     Gfx::IntRect rect() const;
     Gfx::IntRect applet_rect_on_screen() const;
+    size_t containing_screen_index() const;
     Gfx::IntSize size() const { return rect().size(); }
     void set_rect(const Gfx::IntRect&);
     void set_rect(int x, int y, int width, int height) { set_rect({ x, y, width, height }); }

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -40,7 +40,7 @@ Vector<char const*> ShutdownDialog::show()
 }
 
 ShutdownDialog::ShutdownDialog()
-    : Dialog(nullptr)
+    : Dialog(nullptr, ScreenPosition::Center)
 {
     auto& widget = set_main_widget<GUI::Widget>();
     widget.set_fill_with_background_color(true);
@@ -109,7 +109,6 @@ ShutdownDialog::ShutdownDialog()
     };
 
     resize(413, 235);
-    center_on_screen();
     set_resizable(false);
     set_title("Exit SerenityOS");
     set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/power.png").release_value_but_fixme_should_propagate_errors());


### PR DESCRIPTION
These changes fix positioning of dialogs and windows on multiple screens.

For example with SERENITY_SCREENS=2 ShutdownDialog no longer appears between two screens.
Dialogs with parent and ScreenPosition other than CenterWithinParent now positioned inside of the screen containing most of the parent's window (same behavior as dialogs in Windows/Linux).