### PR TITLE
LibGUI: Make a copy of source_rows before resizing it in sort_mapping()

### DIFF
--- a/Userland/Libraries/LibGUI/SortingProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/SortingProxyModel.cpp
@@ -163,6 +163,8 @@ ModelIndex SortingProxyModel::parent_index(ModelIndex const& proxy_index) const
 
 void SortingProxyModel::sort_mapping(Mapping& mapping, int column, SortOrder sort_order)
 {
+    auto old_source_rows = mapping.source_rows;
+
     int row_count = source().row_count(mapping.source_parent);
     mapping.source_rows.resize(row_count);
     mapping.proxy_rows.resize(row_count);
@@ -174,8 +176,6 @@ void SortingProxyModel::sort_mapping(Mapping& mapping, int column, SortOrder sor
         }
         return;
     }
-
-    auto old_source_rows = mapping.source_rows;
 
     for (int i = 0; i < row_count; ++i)
         mapping.source_rows[i] = i;


### PR DESCRIPTION
Fixes #12566