### PR TITLE
Ports: Add OpenJDK port

### DIFF
--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -20,7 +20,7 @@ extern "C" size_t strlen(const char*);
 namespace PrintfImplementation {
 
 template<typename PutChFunc, typename T, typename CharType>
-ALWAYS_INLINE int print_hex(PutChFunc putch, CharType*& bufptr, T number, bool upper_case, bool alternate_form, bool left_pad, bool zero_pad, u8 field_width)
+ALWAYS_INLINE int print_hex(PutChFunc putch, CharType*& bufptr, T number, bool upper_case, bool alternate_form, bool left_pad, bool zero_pad, u8 field_width, u8 fraction_length)
 {
     int ret = 0;
 
@@ -49,7 +49,7 @@ ALWAYS_INLINE int print_hex(PutChFunc putch, CharType*& bufptr, T number, bool u
     }
 
     if (zero_pad) {
-        while (ret < field_width - digits) {
+        while (ret < fraction_length - digits) {
             putch(bufptr, '0');
             ++ret;
         }
@@ -324,7 +324,7 @@ struct PrintfImpl {
     }
     ALWAYS_INLINE int format_q(const ModifierState& state, ArgumentListRefT ap) const
     {
-        return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, false, state.left_pad, state.zero_pad, 16);
+        return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, false, state.left_pad, state.zero_pad, 16, 1);
     }
     ALWAYS_INLINE int format_g(const ModifierState& state, ArgumentListRefT ap) const
     {
@@ -344,14 +344,14 @@ struct PrintfImpl {
     ALWAYS_INLINE int format_x(const ModifierState& state, ArgumentListRefT ap) const
     {
         if (state.long_qualifiers >= 2)
-            return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width);
-        return print_hex(m_putch, m_bufptr, NextArgument<u32>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width);
+            return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.fraction_length);
+        return print_hex(m_putch, m_bufptr, NextArgument<u32>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.fraction_length);
     }
     ALWAYS_INLINE int format_X(const ModifierState& state, ArgumentListRefT ap) const
     {
         if (state.long_qualifiers >= 2)
-            return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), true, state.alternate_form, state.left_pad, state.zero_pad, state.field_width);
-        return print_hex(m_putch, m_bufptr, NextArgument<u32>()(ap), true, state.alternate_form, state.left_pad, state.zero_pad, state.field_width);
+            return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), true, state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.fraction_length);
+        return print_hex(m_putch, m_bufptr, NextArgument<u32>()(ap), true, state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.fraction_length);
     }
     ALWAYS_INLINE int format_n(const ModifierState&, ArgumentListRefT ap) const
     {
@@ -360,11 +360,11 @@ struct PrintfImpl {
     }
     ALWAYS_INLINE int format_p(const ModifierState&, ArgumentListRefT ap) const
     {
-        return print_hex(m_putch, m_bufptr, NextArgument<FlatPtr>()(ap), false, true, false, true, 8);
+        return print_hex(m_putch, m_bufptr, NextArgument<FlatPtr>()(ap), false, true, false, true, 8, 1);
     }
     ALWAYS_INLINE int format_P(const ModifierState&, ArgumentListRefT ap) const
     {
-        return print_hex(m_putch, m_bufptr, NextArgument<FlatPtr>()(ap), true, true, false, true, 8);
+        return print_hex(m_putch, m_bufptr, NextArgument<FlatPtr>()(ap), true, true, false, true, 8, 1);
     }
     ALWAYS_INLINE int format_percent(const ModifierState&, ArgumentListRefT) const
     {

--- a/Kernel/API/POSIX/netinet/in.h
+++ b/Kernel/API/POSIX/netinet/in.h
@@ -87,7 +87,13 @@ struct ip_mreq_source {
 #define IPV6_LEAVE_GROUP 6
 
 struct in6_addr {
-    uint8_t s6_addr[16];
+    union{
+        uint8_t s6_addr[16];
+        uint32_t s6_addr32[4];
+    } in6_union;
+
+#define s6_addr in6_union.s6_addr
+#define s6_addr32 in6_union.s6_addr32    
 };
 
 #define IN6ADDR_ANY_INIT                               \

--- a/Ports/.hosted_defs.sh
+++ b/Ports/.hosted_defs.sh
@@ -22,9 +22,9 @@ fi
 
 export PKG_CONFIG_DIR=""
 export PKG_CONFIG_SYSROOT_DIR="${SERENITY_BUILD_DIR}/Root"
-export PKG_CONFIG_LIBDIR="${PKG_CONFIG_SYSROOT_DIR}/usr/lib/pkgconfig/:${PKG_CONFIG_SYSROOT_DIR}/usr/local/lib/pkgconfig"
+export PKG_CONFIG_LIBDIR="${PKG_CONFIG_SYSROOT_DIR}/usr/lib/pkgconfig/:${PKG_CONFIG_SYSROOT_DIR}/usr/local/lib/pkgconfig:${PKG_CONFIG_SYSROOT_DIR}/usr/local/share/pkgconfig"
 
-enable_ccache
+#enable_ccache
 
 DESTDIR="${SERENITY_BUILD_DIR}/Root"
 export SERENITY_INSTALL_ROOT="$DESTDIR"

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -25,16 +25,16 @@ maybe_source() {
     fi
 }
 
-enable_ccache() {
-    if command -v ccache &>/dev/null; then
-        ccache_tooldir="${SERENITY_BUILD_DIR}/ccache"
-        mkdir -p "$ccache_tooldir"
-        for tool in gcc g++ c++; do
-            ln -sf "$(command -v ccache)" "${ccache_tooldir}/${SERENITY_ARCH}-pc-serenity-${tool}"
-        done
-        export PATH="${ccache_tooldir}:$PATH"
-    fi
-}
+# enable_ccache() {
+#     if command -v ccache &>/dev/null; then
+#         ccache_tooldir="${SERENITY_BUILD_DIR}/ccache"
+#         mkdir -p "$ccache_tooldir"
+#         for tool in gcc g++ c++; do
+#             ln -sf "$(command -v ccache)" "${ccache_tooldir}/${SERENITY_ARCH}-pc-serenity-${tool}"
+#         done
+#         export PATH="${ccache_tooldir}:$PATH"
+#     fi
+# }
 
 target_env() {
     maybe_source "${SCRIPT}/.hosted_defs.sh"
@@ -52,7 +52,7 @@ host_env() {
     export PKG_CONFIG_DIR="${HOST_PKG_CONFIG_DIR}"
     export PKG_CONFIG_SYSROOT_DIR="${HOST_PKG_CONFIG_SYSROOT_DIR}"
     export PKG_CONFIG_LIBDIR="${HOST_PKG_CONFIG_LIBDIR}"
-    enable_ccache
+    #enable_ccache
 }
 
 packagesdb="${DESTDIR}/usr/Ports/packages.db"

--- a/Ports/OpenJDK/package.sh
+++ b/Ports/OpenJDK/package.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+
+port="OpenJDK"
+version="17"
+workdir=jdk-jdk-17-ga
+useconfigure="true"
+files="https://github.com/openjdk/jdk/archive/refs/tags/jdk-17-ga.tar.gz jdk-17-ga.tar.gz"
+depends=("cups" "fontconfig" "libffi")
+
+configure() {
+    run bash configure --host=${SERENITY_ARCH}-pc-serenity --target=${SERENITY_ARCH}-pc-serenity --build=x86_64-unknown-linux-gnu --with-jvm-variants=zero --enable-headless-only --with-debug-level=slowdebug --with-native-debug-symbols=internal
+}
+
+build() {
+    run make java.base
+}
+
+install() {
+    run pwd
+    run sh -c "cp ./build/serenity-*/jdk/ ${SERENITY_INSTALL_ROOT}/home/anon/ -rf"
+}

--- a/Ports/OpenJDK/patches/0001-Update-make-system-to-support-Serenity.patch
+++ b/Ports/OpenJDK/patches/0001-Update-make-system-to-support-Serenity.patch
@@ -1,0 +1,142 @@
+From c792eecc5a95268fe2ece6ccbe7ed75fb919cb4a Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Wed, 16 Feb 2022 21:04:18 +0300
+Subject: [PATCH 1/9] Update make system to support Serenity
+
+---
+ make/autoconf/build-aux/autoconf-config.sub |  5 ++++-
+ make/autoconf/flags-cflags.m4               |  3 +++
+ make/autoconf/flags-ldflags.m4              |  7 +++++++
+ make/autoconf/platform.m4                   |  4 ++++
+ make/autoconf/toolchain.m4                  |  1 +
+ make/common/modules/LauncherCommon.gmk      |  3 +++
+ make/hotspot/lib/JvmMapfile.gmk             | 12 ++++++++++++
+ 7 files changed, 34 insertions(+), 1 deletion(-)
+
+diff --git a/make/autoconf/build-aux/autoconf-config.sub b/make/autoconf/build-aux/autoconf-config.sub
+index 1aab2b303..15c624905 100644
+--- a/make/autoconf/build-aux/autoconf-config.sub
++++ b/make/autoconf/build-aux/autoconf-config.sub
+@@ -148,7 +148,7 @@ maybe_os=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\2/'`
+ case $maybe_os in
+   nto-qnx* | linux-gnu* | linux-dietlibc | linux-newlib* | linux-uclibc* | \
+   uclinux-uclibc* | uclinux-gnu* | kfreebsd*-gnu* | knetbsd*-gnu* | netbsd*-gnu* | \
+-  storm-chaos* | os2-emx* | rtmk-nova*)
++  storm-chaos* | os2-emx* | rtmk-nova* )
+     os=-$maybe_os
+     basic_machine=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`
+     ;;
+@@ -1414,6 +1414,9 @@ case $os in
+ 	-zvmoe)
+ 		os=-zvmoe
+ 		;;
++	-serenity)
++		os=-serenity
++		;;
+ 	-none)
+ 		;;
+ 	*)
+diff --git a/make/autoconf/flags-cflags.m4 b/make/autoconf/flags-cflags.m4
+index 5eed1138f..6f74cf191 100644
+--- a/make/autoconf/flags-cflags.m4
++++ b/make/autoconf/flags-cflags.m4
+@@ -382,6 +382,9 @@ AC_DEFUN([FLAGS_SETUP_CFLAGS_HELPER],
+     CFLAGS_OS_DEF_JVM="-DAIX"
+   elif test "x$OPENJDK_TARGET_OS" = xbsd; then
+     CFLAGS_OS_DEF_JDK="-D_ALLBSD_SOURCE"
++  elif test "x$OPENJDK_TARGET_OS" = xserenity; then
++    CFLAGS_OS_DEF_JDK="-DSERENITY -fno-stack-protector"
++    CFLAGS_OS_DEF_JVM="-DSERENITY -fno-stack-protector"
+   elif test "x$OPENJDK_TARGET_OS" = xwindows; then
+     CFLAGS_OS_DEF_JVM="-D_WINDOWS -DWIN32 -D_JNI_IMPLEMENTATION_"
+   fi
+diff --git a/make/autoconf/flags-ldflags.m4 b/make/autoconf/flags-ldflags.m4
+index 23bb33e87..fc3d5ccf4 100644
+--- a/make/autoconf/flags-ldflags.m4
++++ b/make/autoconf/flags-ldflags.m4
+@@ -110,6 +110,13 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
+     fi
+   fi
+ 
++  if test "x$TOOLCHAIN_TYPE" = xclang || test "x$TOOLCHAIN_TYPE" = xgcc; then
++    if test "x$OPENJDK_TARGET_OS" = xserenity; then
++      OS_LDFLAGS_JVM_ONLY="$OS_LDFLAGS_JVM_ONLY -ldl -lpthread"
++      OS_LDFLAGS="$OS_LDFLAGS -ldl -lpthread"
++    fi
++  fi
++
+   # Setup debug level-dependent LDFLAGS
+   if test "x$TOOLCHAIN_TYPE" = xgcc; then
+     if test "x$OPENJDK_TARGET_OS" = xlinux; then
+diff --git a/make/autoconf/platform.m4 b/make/autoconf/platform.m4
+index 2dd13d0d5..6f69e037b 100644
+--- a/make/autoconf/platform.m4
++++ b/make/autoconf/platform.m4
+@@ -214,6 +214,10 @@ AC_DEFUN([PLATFORM_EXTRACT_VARS_FROM_OS],
+       VAR_OS=aix
+       VAR_OS_TYPE=unix
+       ;;
++    *serenity*)
++      VAR_OS=serenity
++      VAR_OS_TYPE=unix
++      ;;
+     *)
+       AC_MSG_ERROR([unsupported operating system $1])
+       ;;
+diff --git a/make/autoconf/toolchain.m4 b/make/autoconf/toolchain.m4
+index 788958880..e34b45b31 100644
+--- a/make/autoconf/toolchain.m4
++++ b/make/autoconf/toolchain.m4
+@@ -42,6 +42,7 @@ VALID_TOOLCHAINS_linux="gcc clang"
+ VALID_TOOLCHAINS_macosx="gcc clang"
+ VALID_TOOLCHAINS_aix="xlc"
+ VALID_TOOLCHAINS_windows="microsoft"
++VALID_TOOLCHAINS_serenity="gcc"
+ 
+ # Toolchain descriptions
+ TOOLCHAIN_DESCRIPTION_clang="clang/LLVM"
+diff --git a/make/common/modules/LauncherCommon.gmk b/make/common/modules/LauncherCommon.gmk
+index 7ad0375e2..873887b72 100644
+--- a/make/common/modules/LauncherCommon.gmk
++++ b/make/common/modules/LauncherCommon.gmk
+@@ -157,11 +157,14 @@ define SetupBuildLauncherBody
+           $$($1_LDFLAGS), \
+       LDFLAGS_linux := $$(call SET_EXECUTABLE_ORIGIN,/../lib) \
+           -L$(call FindLibDirForModule, java.base), \
++      LDFLAGS_serenity := $$(call SET_EXECUTABLE_ORIGIN,/../lib) \
++          -L$(call FindLibDirForModule, java.base), \
+       LDFLAGS_macosx := $$(call SET_EXECUTABLE_ORIGIN,/../lib) \
+           -L$(call FindLibDirForModule, java.base), \
+       LDFLAGS_aix := -L$(SUPPORT_OUTPUTDIR)/native/java.base, \
+       LIBS := $(JDKEXE_LIBS) $$($1_LIBS), \
+       LIBS_linux := -ljli -lpthread $(LIBDL), \
++      LIBS_serenity := -ljli -lpthread -lgcc_s $(LIBDL), \
+       LIBS_macosx := -ljli -framework Cocoa -framework Security \
+           -framework ApplicationServices, \
+       LIBS_aix := -ljli_static, \
+diff --git a/make/hotspot/lib/JvmMapfile.gmk b/make/hotspot/lib/JvmMapfile.gmk
+index 5cba93178..752727d0d 100644
+--- a/make/hotspot/lib/JvmMapfile.gmk
++++ b/make/hotspot/lib/JvmMapfile.gmk
+@@ -64,6 +64,18 @@ ifeq ($(call isTargetOs, linux), true)
+         if ($$3 ~ /$(FILTER_SYMBOLS_PATTERN)/) print $$3; \
+       }'
+ 
++else ifeq ($(call isTargetOs, serenity), true)
++  DUMP_SYMBOLS_CMD := $(NM) --defined-only *.o
++  ifneq ($(FILTER_SYMBOLS_PATTERN), )
++    FILTER_SYMBOLS_PATTERN := $(FILTER_SYMBOLS_PATTERN)|
++  endif
++  FILTER_SYMBOLS_PATTERN := $(FILTER_SYMBOLS_PATTERN)^_ZTV|^gHotSpotVM|^UseSharedSpaces$$
++  FILTER_SYMBOLS_PATTERN := $(FILTER_SYMBOLS_PATTERN)|^_ZN9Arguments17SharedArchivePathE$$
++  FILTER_SYMBOLS_AWK_SCRIPT := \
++      '{ \
++        if ($$3 ~ /$(FILTER_SYMBOLS_PATTERN)/) print $$3; \
++      }'
++
+ else ifeq ($(call isTargetOs, macosx), true)
+   # nm on macosx prints out "warning: nm: no name list" to stderr for
+   # files without symbols. Hide this, even at the expense of hiding real errors.
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/0002-Add-Serenity-specific-native-modules.patch
+++ b/Ports/OpenJDK/patches/0002-Add-Serenity-specific-native-modules.patch
@@ -1,0 +1,11538 @@
+From 765b45ff4e30e9ebb5f5f1bae7deac7499a67685 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Wed, 16 Feb 2022 21:05:15 +0300
+Subject: [PATCH 2/9] Add Serenity-specific native modules
+
+---
+ .../os/serenity/attachListener_serenity.cpp   |  567 ++++
+ .../os/serenity/c1_globals_serenity.hpp       |   36 +
+ .../os/serenity/c2_globals_serenity.hpp       |   36 +
+ src/hotspot/os/serenity/decoder_serenity.cpp  |   46 +
+ .../os/serenity/gc/z/zLargePages_serenity.cpp |   34 +
+ .../os/serenity/gc/z/zNUMA_serenity.cpp       |   42 +
+ .../gc/z/zPhysicalMemoryBacking_serenity.cpp  |  181 ++
+ .../gc/z/zPhysicalMemoryBacking_serenity.hpp  |   48 +
+ src/hotspot/os/serenity/globals_serenity.hpp  |   54 +
+ src/hotspot/os/serenity/osThread_serenity.cpp |   55 +
+ src/hotspot/os/serenity/osThread_serenity.hpp |  150 ++
+ src/hotspot/os/serenity/os_perf_serenity.cpp  |  440 ++++
+ src/hotspot/os/serenity/os_serenity.cpp       | 2344 +++++++++++++++++
+ src/hotspot/os/serenity/os_serenity.hpp       |  115 +
+ .../os/serenity/os_serenity.inline.hpp        |   54 +
+ src/hotspot/os/serenity/os_share_serenity.hpp |   36 +
+ .../os/serenity/semaphore_serenity.cpp        |   30 +
+ .../os/serenity/semaphore_serenity.hpp        |   32 +
+ .../os/serenity/threadCritical_serenity.cpp   |   61 +
+ .../os/serenity/vmStructs_serenity.hpp        |   45 +
+ .../serenity_x86/assembler_serenity_x86.cpp   |   32 +
+ .../serenity_x86/atomic_serenity_x86.hpp      |  225 ++
+ .../serenity_x86/bytes_serenity_x86.hpp       |  101 +
+ .../os_cpu/serenity_x86/copy_serenity_x86.hpp |  309 +++
+ .../serenity_x86/globals_serenity_x86.hpp     |   52 +
+ .../serenity_x86/orderAccess_serenity_x86.hpp |   67 +
+ .../os_cpu/serenity_x86/os_serenity_x86.cpp   |  922 +++++++
+ .../os_cpu/serenity_x86/os_serenity_x86.hpp   |   44 +
+ .../serenity_x86/os_serenity_x86.inline.hpp   |   46 +
+ .../serenity_x86/prefetch_bsd_x86.inline.hpp  |   47 +
+ .../os_cpu/serenity_x86/serenity_x86_32.S     |  667 +++++
+ .../os_cpu/serenity_x86/serenity_x86_64.S     |  388 +++
+ .../serenity_x86/thread_serenity_x86.cpp      |   92 +
+ .../serenity_x86/thread_serenity_x86.hpp      |   49 +
+ .../serenity_x86/vmStructs_serenity_x86.hpp   |   53 +
+ .../serenity_x86/vm_version_serenity_x86.cpp  |   48 +
+ .../serenity_zero/assembler_serenity_zero.cpp |   26 +
+ .../serenity_zero/atomic_serenity_zero.hpp    |  305 +++
+ .../serenity_zero/bytes_serenity_zero.hpp     |   69 +
+ .../serenity_zero/globals_serenity_zero.hpp   |   47 +
+ .../orderAccess_serenity_zero.hpp             |   82 +
+ .../os_cpu/serenity_zero/os_serenity_zero.cpp |  303 +++
+ .../os_cpu/serenity_zero/os_serenity_zero.hpp |   54 +
+ .../prefetch_serenity_zero.inline.hpp         |   37 +
+ .../serenity_zero/thread_serenity_zero.cpp    |   37 +
+ .../serenity_zero/thread_serenity_zero.hpp    |  104 +
+ .../serenity_zero/vmStructs_serenity_zero.hpp |   42 +
+ .../vm_version_serenity_zero.cpp              |   30 +
+ .../DefaultAsynchronousChannelProvider.java   |   47 +
+ .../sun/nio/ch/DefaultSelectorProvider.java   |   54 +
+ .../SerenityAsynchronousChannelProvider.java  |   91 +
+ .../classes/sun/nio/ch/SerenityPollPort.java  |  538 ++++
+ .../sun/nio/fs/DefaultFileSystemProvider.java |   53 +
+ .../classes/sun/nio/fs/SerenityFileStore.java |  105 +
+ .../sun/nio/fs/SerenityFileSystem.java        |   94 +
+ .../nio/fs/SerenityFileSystemProvider.java    |   52 +
+ .../sun/nio/fs/SerenityNativeDispatcher.java  |   49 +
+ .../libjava/ProcessHandleImpl_serenity.c      |   68 +
+ .../serenity/native/libnet/serenity_close.c   |  458 ++++
+ .../sun/tools/attach/AttachProviderImpl.java  |   82 +
+ .../sun/tools/attach/VirtualMachineImpl.java  |  326 +++
+ .../native/libattach/VirtualMachineImpl.c     |  328 +++
+ 62 files changed, 11029 insertions(+)
+ create mode 100644 src/hotspot/os/serenity/attachListener_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/c1_globals_serenity.hpp
+ create mode 100644 src/hotspot/os/serenity/c2_globals_serenity.hpp
+ create mode 100644 src/hotspot/os/serenity/decoder_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/gc/z/zLargePages_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/gc/z/zNUMA_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/gc/z/zPhysicalMemoryBacking_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/gc/z/zPhysicalMemoryBacking_serenity.hpp
+ create mode 100644 src/hotspot/os/serenity/globals_serenity.hpp
+ create mode 100644 src/hotspot/os/serenity/osThread_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/osThread_serenity.hpp
+ create mode 100644 src/hotspot/os/serenity/os_perf_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/os_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/os_serenity.hpp
+ create mode 100644 src/hotspot/os/serenity/os_serenity.inline.hpp
+ create mode 100644 src/hotspot/os/serenity/os_share_serenity.hpp
+ create mode 100644 src/hotspot/os/serenity/semaphore_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/semaphore_serenity.hpp
+ create mode 100644 src/hotspot/os/serenity/threadCritical_serenity.cpp
+ create mode 100644 src/hotspot/os/serenity/vmStructs_serenity.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/assembler_serenity_x86.cpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/atomic_serenity_x86.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/bytes_serenity_x86.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/copy_serenity_x86.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/globals_serenity_x86.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/orderAccess_serenity_x86.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/os_serenity_x86.cpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/os_serenity_x86.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/os_serenity_x86.inline.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/prefetch_bsd_x86.inline.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/serenity_x86_32.S
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/serenity_x86_64.S
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/thread_serenity_x86.cpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/thread_serenity_x86.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/vmStructs_serenity_x86.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_x86/vm_version_serenity_x86.cpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/assembler_serenity_zero.cpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/atomic_serenity_zero.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/bytes_serenity_zero.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/globals_serenity_zero.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/orderAccess_serenity_zero.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/os_serenity_zero.cpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/os_serenity_zero.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/prefetch_serenity_zero.inline.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/thread_serenity_zero.cpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/thread_serenity_zero.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/vmStructs_serenity_zero.hpp
+ create mode 100644 src/hotspot/os_cpu/serenity_zero/vm_version_serenity_zero.cpp
+ create mode 100644 src/java.base/serenity/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java
+ create mode 100644 src/java.base/serenity/classes/sun/nio/ch/DefaultSelectorProvider.java
+ create mode 100644 src/java.base/serenity/classes/sun/nio/ch/SerenityAsynchronousChannelProvider.java
+ create mode 100644 src/java.base/serenity/classes/sun/nio/ch/SerenityPollPort.java
+ create mode 100644 src/java.base/serenity/classes/sun/nio/fs/DefaultFileSystemProvider.java
+ create mode 100644 src/java.base/serenity/classes/sun/nio/fs/SerenityFileStore.java
+ create mode 100644 src/java.base/serenity/classes/sun/nio/fs/SerenityFileSystem.java
+ create mode 100644 src/java.base/serenity/classes/sun/nio/fs/SerenityFileSystemProvider.java
+ create mode 100644 src/java.base/serenity/classes/sun/nio/fs/SerenityNativeDispatcher.java
+ create mode 100644 src/java.base/serenity/native/libjava/ProcessHandleImpl_serenity.c
+ create mode 100644 src/java.base/serenity/native/libnet/serenity_close.c
+ create mode 100644 src/jdk.attach/serenity/classes/sun/tools/attach/AttachProviderImpl.java
+ create mode 100644 src/jdk.attach/serenity/classes/sun/tools/attach/VirtualMachineImpl.java
+ create mode 100644 src/jdk.attach/serenity/native/libattach/VirtualMachineImpl.c
+
+diff --git a/src/hotspot/os/serenity/attachListener_serenity.cpp b/src/hotspot/os/serenity/attachListener_serenity.cpp
+new file mode 100644
+index 000000000..56482426e
+--- /dev/null
++++ b/src/hotspot/os/serenity/attachListener_serenity.cpp
+@@ -0,0 +1,567 @@
++/*
++ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "logging/log.hpp"
++#include "runtime/interfaceSupport.inline.hpp"
++#include "runtime/os.inline.hpp"
++#include "services/attachListener.hpp"
++#include "services/dtraceAttacher.hpp"
++
++#include <unistd.h>
++#include <signal.h>
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <sys/un.h>
++#include <sys/stat.h>
++
++#ifndef UNIX_PATH_MAX
++#define UNIX_PATH_MAX   sizeof(((struct sockaddr_un *)0)->sun_path)
++#endif
++
++// The attach mechanism on Bsd uses a UNIX domain socket. An attach listener
++// thread is created at startup or is created on-demand via a signal from
++// the client tool. The attach listener creates a socket and binds it to a file
++// in the filesystem. The attach listener then acts as a simple (single-
++// threaded) server - it waits for a client to connect, reads the request,
++// executes it, and returns the response to the client via the socket
++// connection.
++//
++// As the socket is a UNIX domain socket it means that only clients on the
++// local machine can connect. In addition there are two other aspects to
++// the security:
++// 1. The well known file that the socket is bound to has permission 400
++// 2. When a client connect, the SO_PEERCRED socket option is used to
++//    obtain the credentials of client. We check that the effective uid
++//    of the client matches this process.
++
++// forward reference
++class BsdAttachOperation;
++
++class BsdAttachListener: AllStatic {
++ private:
++  // the path to which we bind the UNIX domain socket
++  static char _path[UNIX_PATH_MAX];
++  static bool _has_path;
++
++  // the file descriptor for the listening socket
++  static volatile int _listener;
++
++  static bool _atexit_registered;
++
++  // reads a request from the given connected socket
++  static BsdAttachOperation* read_request(int s);
++
++ public:
++  enum {
++    ATTACH_PROTOCOL_VER = 1                     // protocol version
++  };
++  enum {
++    ATTACH_ERROR_BADVERSION     = 101           // error codes
++  };
++
++  static void set_path(char* path) {
++    if (path == NULL) {
++      _path[0] = '\0';
++      _has_path = false;
++    } else {
++      strncpy(_path, path, UNIX_PATH_MAX);
++      _path[UNIX_PATH_MAX-1] = '\0';
++      _has_path = true;
++    }
++  }
++
++  static void set_listener(int s)               { _listener = s; }
++
++  // initialize the listener, returns 0 if okay
++  static int init();
++
++  static char* path()                   { return _path; }
++  static bool has_path()                { return _has_path; }
++  static int listener()                 { return _listener; }
++
++  // write the given buffer to a socket
++  static int write_fully(int s, char* buf, int len);
++
++  static BsdAttachOperation* dequeue();
++};
++
++class BsdAttachOperation: public AttachOperation {
++ private:
++  // the connection to the client
++  int _socket;
++
++ public:
++  void complete(jint res, bufferedStream* st);
++
++  void set_socket(int s)                                { _socket = s; }
++  int socket() const                                    { return _socket; }
++
++  BsdAttachOperation(char* name) : AttachOperation(name) {
++    set_socket(-1);
++  }
++};
++
++// statics
++char BsdAttachListener::_path[UNIX_PATH_MAX];
++bool BsdAttachListener::_has_path;
++volatile int BsdAttachListener::_listener = -1;
++bool BsdAttachListener::_atexit_registered = false;
++
++// Supporting class to help split a buffer into individual components
++class ArgumentIterator : public StackObj {
++ private:
++  char* _pos;
++  char* _end;
++ public:
++  ArgumentIterator(char* arg_buffer, size_t arg_size) {
++    _pos = arg_buffer;
++    _end = _pos + arg_size - 1;
++  }
++  char* next() {
++    if (*_pos == '\0') {
++      // advance the iterator if possible (null arguments)
++      if (_pos < _end) {
++        _pos += 1;
++      }
++      return NULL;
++    }
++    char* res = _pos;
++    char* next_pos = strchr(_pos, '\0');
++    if (next_pos < _end)  {
++      next_pos++;
++    }
++    _pos = next_pos;
++    return res;
++  }
++};
++
++
++// atexit hook to stop listener and unlink the file that it is
++// bound too.
++extern "C" {
++  static void listener_cleanup() {
++    int s = BsdAttachListener::listener();
++    if (s != -1) {
++      BsdAttachListener::set_listener(-1);
++      ::shutdown(s, SHUT_RDWR);
++      ::close(s);
++    }
++    if (BsdAttachListener::has_path()) {
++      ::unlink(BsdAttachListener::path());
++      BsdAttachListener::set_path(NULL);
++    }
++  }
++}
++
++// Initialization - create a listener socket and bind it to a file
++
++int BsdAttachListener::init() {
++  char path[UNIX_PATH_MAX];          // socket file
++  char initial_path[UNIX_PATH_MAX];  // socket file during setup
++  int listener;                      // listener socket (file descriptor)
++
++  // register function to cleanup
++  if (!_atexit_registered) {
++    _atexit_registered = true;
++    ::atexit(listener_cleanup);
++  }
++
++  int n = snprintf(path, UNIX_PATH_MAX, "%s/.java_pid%d",
++                   os::get_temp_directory(), os::current_process_id());
++  if (n < (int)UNIX_PATH_MAX) {
++    n = snprintf(initial_path, UNIX_PATH_MAX, "%s.tmp", path);
++  }
++  if (n >= (int)UNIX_PATH_MAX) {
++    return -1;
++  }
++
++  // create the listener socket
++  listener = ::socket(PF_UNIX, SOCK_STREAM, 0);
++  if (listener == -1) {
++    return -1;
++  }
++
++  // bind socket
++  struct sockaddr_un addr;
++  memset((void *)&addr, 0, sizeof(addr));
++  addr.sun_family = AF_UNIX;
++  strcpy(addr.sun_path, initial_path);
++  ::unlink(initial_path);
++  int res = ::bind(listener, (struct sockaddr*)&addr, sizeof(addr));
++  if (res == -1) {
++    ::close(listener);
++    return -1;
++  }
++
++  // put in listen mode, set permissions, and rename into place
++  res = ::listen(listener, 5);
++  if (res == 0) {
++    RESTARTABLE(::chmod(initial_path, S_IREAD|S_IWRITE), res);
++    if (res == 0) {
++      // make sure the file is owned by the effective user and effective group
++      // e.g. default behavior on mac is that new files inherit the group of
++      // the directory that they are created in
++      RESTARTABLE(::chown(initial_path, geteuid(), getegid()), res);
++      if (res == 0) {
++        res = ::rename(initial_path, path);
++      }
++    }
++  }
++  if (res == -1) {
++    ::close(listener);
++    ::unlink(initial_path);
++    return -1;
++  }
++  set_path(path);
++  set_listener(listener);
++
++  return 0;
++}
++
++// Given a socket that is connected to a peer we read the request and
++// create an AttachOperation. As the socket is blocking there is potential
++// for a denial-of-service if the peer does not response. However this happens
++// after the peer credentials have been checked and in the worst case it just
++// means that the attach listener thread is blocked.
++//
++BsdAttachOperation* BsdAttachListener::read_request(int s) {
++  char ver_str[8];
++  sprintf(ver_str, "%d", ATTACH_PROTOCOL_VER);
++
++  // The request is a sequence of strings so we first figure out the
++  // expected count and the maximum possible length of the request.
++  // The request is:
++  //   <ver>0<cmd>0<arg>0<arg>0<arg>0
++  // where <ver> is the protocol version (1), <cmd> is the command
++  // name ("load", "datadump", ...), and <arg> is an argument
++  int expected_str_count = 2 + AttachOperation::arg_count_max;
++  const int max_len = (sizeof(ver_str) + 1) + (AttachOperation::name_length_max + 1) +
++    AttachOperation::arg_count_max*(AttachOperation::arg_length_max + 1);
++
++  char buf[max_len];
++  int str_count = 0;
++
++  // Read until all (expected) strings have been read, the buffer is
++  // full, or EOF.
++
++  int off = 0;
++  int left = max_len;
++
++  do {
++    int n;
++    RESTARTABLE(read(s, buf+off, left), n);
++    assert(n <= left, "buffer was too small, impossible!");
++    buf[max_len - 1] = '\0';
++    if (n == -1) {
++      return NULL;      // reset by peer or other error
++    }
++    if (n == 0) {
++      break;
++    }
++    for (int i=0; i<n; i++) {
++      if (buf[off+i] == 0) {
++        // EOS found
++        str_count++;
++
++        // The first string is <ver> so check it now to
++        // check for protocol mis-match
++        if (str_count == 1) {
++          if ((strlen(buf) != strlen(ver_str)) ||
++              (atoi(buf) != ATTACH_PROTOCOL_VER)) {
++            char msg[32];
++            sprintf(msg, "%d\n", ATTACH_ERROR_BADVERSION);
++            write_fully(s, msg, strlen(msg));
++            return NULL;
++          }
++        }
++      }
++    }
++    off += n;
++    left -= n;
++  } while (left > 0 && str_count < expected_str_count);
++
++  if (str_count != expected_str_count) {
++    return NULL;        // incomplete request
++  }
++
++  // parse request
++
++  ArgumentIterator args(buf, (max_len)-left);
++
++  // version already checked
++  char* v = args.next();
++
++  char* name = args.next();
++  if (name == NULL || strlen(name) > AttachOperation::name_length_max) {
++    return NULL;
++  }
++
++  BsdAttachOperation* op = new BsdAttachOperation(name);
++
++  for (int i=0; i<AttachOperation::arg_count_max; i++) {
++    char* arg = args.next();
++    if (arg == NULL) {
++      op->set_arg(i, NULL);
++    } else {
++      if (strlen(arg) > AttachOperation::arg_length_max) {
++        delete op;
++        return NULL;
++      }
++      op->set_arg(i, arg);
++    }
++  }
++
++  op->set_socket(s);
++  return op;
++}
++
++
++// Dequeue an operation
++//
++// In the Bsd implementation there is only a single operation and clients
++// cannot queue commands (except at the socket level).
++//
++BsdAttachOperation* BsdAttachListener::dequeue() {
++  for (;;) {
++    int s;
++
++    // wait for client to connect
++    struct sockaddr addr;
++    socklen_t len = sizeof(addr);
++    RESTARTABLE(::accept(listener(), &addr, &len), s);
++    if (s == -1) {
++      return NULL;      // log a warning?
++    }
++
++    // get the credentials of the peer and check the effective uid/guid
++    // FIXME: use getsockopt, see Stream.cpp:528
++
++    struct ucred creds = {};
++    socklen_t creds_size = sizeof(creds);
++
++    if(::getsockopt(s, SOL_SOCKET, SO_PEERCRED, &creds, &creds_size) != 0) {
++      log_debug(attach)("Failed to get peer id");
++      ::close(s);
++      continue;
++    }
++
++    // uid_t puid;
++    // gid_t pgid;
++    // if (::getpeereid(s, &puid, &pgid) != 0) {
++    //   log_debug(attach)("Failed to get peer id");
++    //   ::close(s);
++    //   continue;
++    // }
++
++    if (!os::Posix::matches_effective_uid_and_gid_or_root(creds.uid, creds.gid)) {
++      log_debug(attach)("euid/egid check failed (%d/%d vs %d/%d)", creds.uid, creds.gid,
++              geteuid(), getegid());
++      ::close(s);
++      continue;
++    }
++
++    // peer credential look okay so we read the request
++    BsdAttachOperation* op = read_request(s);
++    if (op == NULL) {
++      ::close(s);
++      continue;
++    } else {
++      return op;
++    }
++  }
++}
++
++// write the given buffer to the socket
++int BsdAttachListener::write_fully(int s, char* buf, int len) {
++  do {
++    int n = ::write(s, buf, len);
++    if (n == -1) {
++      if (errno != EINTR) return -1;
++    } else {
++      buf += n;
++      len -= n;
++    }
++  }
++  while (len > 0);
++  return 0;
++}
++
++// Complete an operation by sending the operation result and any result
++// output to the client. At this time the socket is in blocking mode so
++// potentially we can block if there is a lot of data and the client is
++// non-responsive. For most operations this is a non-issue because the
++// default send buffer is sufficient to buffer everything. In the future
++// if there are operations that involves a very big reply then it the
++// socket could be made non-blocking and a timeout could be used.
++
++void BsdAttachOperation::complete(jint result, bufferedStream* st) {
++  JavaThread* thread = JavaThread::current();
++  ThreadBlockInVM tbivm(thread);
++
++  // write operation result
++  char msg[32];
++  sprintf(msg, "%d\n", result);
++  int rc = BsdAttachListener::write_fully(this->socket(), msg, strlen(msg));
++
++  // write any result data
++  if (rc == 0) {
++    BsdAttachListener::write_fully(this->socket(), (char*) st->base(), st->size());
++    ::shutdown(this->socket(), 2);
++  }
++
++  // done
++  ::close(this->socket());
++
++  delete this;
++}
++
++
++// AttachListener functions
++
++AttachOperation* AttachListener::dequeue() {
++  JavaThread* thread = JavaThread::current();
++  ThreadBlockInVM tbivm(thread);
++
++  AttachOperation* op = BsdAttachListener::dequeue();
++
++  return op;
++}
++
++// Performs initialization at vm startup
++// For BSD we remove any stale .java_pid file which could cause
++// an attaching process to think we are ready to receive on the
++// domain socket before we are properly initialized
++
++void AttachListener::vm_start() {
++  char fn[UNIX_PATH_MAX];
++  struct stat st;
++  int ret;
++
++  int n = snprintf(fn, UNIX_PATH_MAX, "%s/.java_pid%d",
++           os::get_temp_directory(), os::current_process_id());
++  assert(n < (int)UNIX_PATH_MAX, "java_pid file name buffer overflow");
++
++  RESTARTABLE(::stat(fn, &st), ret);
++  if (ret == 0) {
++    ret = ::unlink(fn);
++    if (ret == -1) {
++      log_debug(attach)("Failed to remove stale attach pid file at %s", fn);
++    }
++  }
++}
++
++int AttachListener::pd_init() {
++  JavaThread* thread = JavaThread::current();
++  ThreadBlockInVM tbivm(thread);
++
++  int ret_code = BsdAttachListener::init();
++
++  return ret_code;
++}
++
++bool AttachListener::check_socket_file() {
++  int ret;
++  struct stat st;
++  ret = stat(BsdAttachListener::path(), &st);
++  if (ret == -1) { // need to restart attach listener.
++    log_debug(attach)("Socket file %s does not exist - Restart Attach Listener",
++                      BsdAttachListener::path());
++
++    listener_cleanup();
++
++    // wait to terminate current attach listener instance...
++    {
++      // avoid deadlock if AttachListener thread is blocked at safepoint
++      ThreadBlockInVM tbivm(JavaThread::current());
++      while (AttachListener::transit_state(AL_INITIALIZING,
++                                           AL_NOT_INITIALIZED) != AL_NOT_INITIALIZED) {
++        os::naked_yield();
++      }
++    }
++    return is_init_trigger();
++  }
++  return false;
++}
++
++// Attach Listener is started lazily except in the case when
++// +ReduseSignalUsage is used
++bool AttachListener::init_at_startup() {
++  if (ReduceSignalUsage) {
++    return true;
++  } else {
++    return false;
++  }
++}
++
++// If the file .attach_pid<pid> exists in the working directory
++// or /tmp then this is the trigger to start the attach mechanism
++bool AttachListener::is_init_trigger() {
++  if (init_at_startup() || is_initialized()) {
++    return false;               // initialized at startup or already initialized
++  }
++  char fn[PATH_MAX + 1];
++  int ret;
++  struct stat st;
++  snprintf(fn, PATH_MAX + 1, "%s/.attach_pid%d",
++           os::get_temp_directory(), os::current_process_id());
++  RESTARTABLE(::stat(fn, &st), ret);
++  if (ret == -1) {
++    log_debug(attach)("Failed to find attach file: %s", fn);
++  }
++  if (ret == 0) {
++    // simple check to avoid starting the attach mechanism when
++    // a bogus non-root user creates the file
++    if (os::Posix::matches_effective_uid_or_root(st.st_uid)) {
++      init();
++      log_trace(attach)("Attach triggered by %s", fn);
++      return true;
++    } else {
++      log_debug(attach)("File %s has wrong user id %d (vs %d). Attach is not triggered", fn, st.st_uid, geteuid());
++    }
++  }
++  return false;
++}
++
++// if VM aborts then remove listener
++void AttachListener::abort() {
++  listener_cleanup();
++}
++
++void AttachListener::pd_data_dump() {
++  os::signal_notify(SIGQUIT);
++}
++
++AttachOperationFunctionInfo* AttachListener::pd_find_operation(const char* n) {
++  return NULL;
++}
++
++jint AttachListener::pd_set_flag(AttachOperation* op, outputStream* out) {
++  out->print_cr("flag '%s' cannot be changed", op->arg(0));
++  return JNI_ERR;
++}
++
++void AttachListener::pd_detachall() {
++  // do nothing for now
++}
+diff --git a/src/hotspot/os/serenity/c1_globals_serenity.hpp b/src/hotspot/os/serenity/c1_globals_serenity.hpp
+new file mode 100644
+index 000000000..ff831f74b
+--- /dev/null
++++ b/src/hotspot/os/serenity/c1_globals_serenity.hpp
+@@ -0,0 +1,36 @@
++/*
++ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_C1_GLOBALS_SERENITY_HPP
++#define OS_SERENITY_C1_GLOBALS_SERENITY_HPP
++
++#include "utilities/globalDefinitions.hpp"
++#include "utilities/macros.hpp"
++
++//
++// Sets the default values for operating system dependent flags used by the
++// client compiler. (see c1_globals.hpp)
++//
++
++#endif // OS_SERENITY_C1_GLOBALS_SERENITY_HPP
+diff --git a/src/hotspot/os/serenity/c2_globals_serenity.hpp b/src/hotspot/os/serenity/c2_globals_serenity.hpp
+new file mode 100644
+index 000000000..d9e708703
+--- /dev/null
++++ b/src/hotspot/os/serenity/c2_globals_serenity.hpp
+@@ -0,0 +1,36 @@
++/*
++ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_C2_GLOBALS_SERENITY_HPP
++#define OS_SERENITY_C2_GLOBALS_SERENITY_HPP
++
++#include "utilities/globalDefinitions.hpp"
++#include "utilities/macros.hpp"
++
++//
++// Sets the default values for operating system dependent flags used by the
++// server compiler. (see c2_globals.hpp)
++//
++
++#endif // OS_SERENITY_C2_GLOBALS_SERENITY_HPP
+diff --git a/src/hotspot/os/serenity/decoder_serenity.cpp b/src/hotspot/os/serenity/decoder_serenity.cpp
+new file mode 100644
+index 000000000..bea936923
+--- /dev/null
++++ b/src/hotspot/os/serenity/decoder_serenity.cpp
+@@ -0,0 +1,46 @@
++/*
++ * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "jvm.h"
++#include "utilities/decoder_elf.hpp"
++#include "utilities/elfFile.hpp"
++
++#include <cxxabi.h>
++
++bool ElfDecoder::demangle(const char* symbol, char *buf, int buflen) {
++  int   status;
++  char* result;
++  size_t size = (size_t)buflen;
++
++  // Don't pass buf to __cxa_demangle. In case of the 'buf' is too small,
++  // __cxa_demangle will call system "realloc" for additional memory, which
++  // may use different malloc/realloc mechanism that allocates 'buf'.
++  if ((result = abi::__cxa_demangle(symbol, NULL, NULL, &status)) != NULL) {
++    jio_snprintf(buf, buflen, "%s", result);
++      // call c library's free
++      ::free(result);
++      return true;
++  }
++  return false;
++}
+\ No newline at end of file
+diff --git a/src/hotspot/os/serenity/gc/z/zLargePages_serenity.cpp b/src/hotspot/os/serenity/gc/z/zLargePages_serenity.cpp
+new file mode 100644
+index 000000000..6e26741a5
+--- /dev/null
++++ b/src/hotspot/os/serenity/gc/z/zLargePages_serenity.cpp
+@@ -0,0 +1,34 @@
++/*
++ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++#include "precompiled.hpp"
++#include "gc/z/zLargePages.hpp"
++#include "runtime/globals.hpp"
++
++void ZLargePages::pd_initialize() {
++  if (UseLargePages) {
++    _state = Explicit;
++  } else {
++    _state = Disabled;
++  }
++}
+diff --git a/src/hotspot/os/serenity/gc/z/zNUMA_serenity.cpp b/src/hotspot/os/serenity/gc/z/zNUMA_serenity.cpp
+new file mode 100644
+index 000000000..a0fe34c65
+--- /dev/null
++++ b/src/hotspot/os/serenity/gc/z/zNUMA_serenity.cpp
+@@ -0,0 +1,42 @@
++/*
++ * Copyright (c) 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++#include "precompiled.hpp"
++#include "gc/z/zNUMA.hpp"
++
++void ZNUMA::pd_initialize() {
++  _enabled = false;
++}
++
++uint32_t ZNUMA::count() {
++  return 1;
++}
++
++uint32_t ZNUMA::id() {
++  return 0;
++}
++
++uint32_t ZNUMA::memory_id(uintptr_t addr) {
++  // NUMA support not enabled, assume everything belongs to node zero
++  return 0;
++}
+diff --git a/src/hotspot/os/serenity/gc/z/zPhysicalMemoryBacking_serenity.cpp b/src/hotspot/os/serenity/gc/z/zPhysicalMemoryBacking_serenity.cpp
+new file mode 100644
+index 000000000..ea9a54bcb
+--- /dev/null
++++ b/src/hotspot/os/serenity/gc/z/zPhysicalMemoryBacking_serenity.cpp
+@@ -0,0 +1,181 @@
++/*
++ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++#include "precompiled.hpp"
++#include "gc/shared/gcLogPrecious.hpp"
++#include "gc/z/zErrno.hpp"
++#include "gc/z/zGlobals.hpp"
++#include "gc/z/zLargePages.inline.hpp"
++#include "gc/z/zPhysicalMemory.inline.hpp"
++#include "gc/z/zPhysicalMemoryBacking_bsd.hpp"
++#include "logging/log.hpp"
++#include "runtime/globals.hpp"
++#include "runtime/os.hpp"
++#include "utilities/align.hpp"
++#include "utilities/debug.hpp"
++
++#include <mach/mach.h>
++#include <mach/mach_vm.h>
++#include <sys/mman.h>
++#include <sys/types.h>
++
++// The backing is represented by a reserved virtual address space, in which
++// we commit and uncommit physical memory. Multi-mapping the different heap
++// views is done by simply remapping the backing memory using mach_vm_remap().
++
++static int vm_flags_superpage() {
++  if (!ZLargePages::is_explicit()) {
++    return 0;
++  }
++
++  const int page_size_in_megabytes = ZGranuleSize >> 20;
++  return page_size_in_megabytes << VM_FLAGS_SUPERPAGE_SHIFT;
++}
++
++static ZErrno mremap(uintptr_t from_addr, uintptr_t to_addr, size_t size) {
++  mach_vm_address_t remap_addr = to_addr;
++  vm_prot_t remap_cur_prot;
++  vm_prot_t remap_max_prot;
++
++  // Remap memory to an additional location
++  const kern_return_t res = mach_vm_remap(mach_task_self(),
++                                          &remap_addr,
++                                          size,
++                                          0 /* mask */,
++                                          VM_FLAGS_FIXED | VM_FLAGS_OVERWRITE | vm_flags_superpage(),
++                                          mach_task_self(),
++                                          from_addr,
++                                          FALSE /* copy */,
++                                          &remap_cur_prot,
++                                          &remap_max_prot,
++                                          VM_INHERIT_COPY);
++
++  return (res == KERN_SUCCESS) ? ZErrno(0) : ZErrno(EINVAL);
++}
++
++ZPhysicalMemoryBacking::ZPhysicalMemoryBacking(size_t max_capacity) :
++    _base(0),
++    _initialized(false) {
++
++  // Reserve address space for backing memory
++  _base = (uintptr_t)os::reserve_memory(max_capacity);
++  if (_base == 0) {
++    // Failed
++    log_error_pd(gc)("Failed to reserve address space for backing memory");
++    return;
++  }
++
++  // Successfully initialized
++  _initialized = true;
++}
++
++bool ZPhysicalMemoryBacking::is_initialized() const {
++  return _initialized;
++}
++
++void ZPhysicalMemoryBacking::warn_commit_limits(size_t max_capacity) const {
++  // Does nothing
++}
++
++bool ZPhysicalMemoryBacking::commit_inner(size_t offset, size_t length) const {
++  assert(is_aligned(offset, os::vm_page_size()), "Invalid offset");
++  assert(is_aligned(length, os::vm_page_size()), "Invalid length");
++
++  log_trace(gc, heap)("Committing memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
++                      offset / M, (offset + length) / M, length / M);
++
++  const uintptr_t addr = _base + offset;
++  const void* const res = mmap((void*)addr, length, PROT_READ | PROT_WRITE, MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
++  if (res == MAP_FAILED) {
++    ZErrno err;
++    log_error(gc)("Failed to commit memory (%s)", err.to_string());
++    return false;
++  }
++
++  // Success
++  return true;
++}
++
++size_t ZPhysicalMemoryBacking::commit(size_t offset, size_t length) const {
++  // Try to commit the whole region
++  if (commit_inner(offset, length)) {
++    // Success
++    return length;
++  }
++
++  // Failed, try to commit as much as possible
++  size_t start = offset;
++  size_t end = offset + length;
++
++  for (;;) {
++    length = align_down((end - start) / 2, ZGranuleSize);
++    if (length == 0) {
++      // Done, don't commit more
++      return start - offset;
++    }
++
++    if (commit_inner(start, length)) {
++      // Success, try commit more
++      start += length;
++    } else {
++      // Failed, try commit less
++      end -= length;
++    }
++  }
++}
++
++size_t ZPhysicalMemoryBacking::uncommit(size_t offset, size_t length) const {
++  assert(is_aligned(offset, os::vm_page_size()), "Invalid offset");
++  assert(is_aligned(length, os::vm_page_size()), "Invalid length");
++
++  log_trace(gc, heap)("Uncommitting memory: " SIZE_FORMAT "M-" SIZE_FORMAT "M (" SIZE_FORMAT "M)",
++                      offset / M, (offset + length) / M, length / M);
++
++  const uintptr_t start = _base + offset;
++  const void* const res = mmap((void*)start, length, PROT_NONE, MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
++  if (res == MAP_FAILED) {
++    ZErrno err;
++    log_error(gc)("Failed to uncommit memory (%s)", err.to_string());
++    return 0;
++  }
++
++  return length;
++}
++
++void ZPhysicalMemoryBacking::map(uintptr_t addr, size_t size, uintptr_t offset) const {
++  const ZErrno err = mremap(_base + offset, addr, size);
++  if (err) {
++    fatal("Failed to remap memory (%s)", err.to_string());
++  }
++}
++
++void ZPhysicalMemoryBacking::unmap(uintptr_t addr, size_t size) const {
++  // Note that we must keep the address space reservation intact and just detach
++  // the backing memory. For this reason we map a new anonymous, non-accessible
++  // and non-reserved page over the mapping instead of actually unmapping.
++  const void* const res = mmap((void*)addr, size, PROT_NONE, MAP_FIXED | MAP_ANONYMOUS | MAP_PRIVATE | MAP_NORESERVE, -1, 0);
++  if (res == MAP_FAILED) {
++    ZErrno err;
++    fatal("Failed to map memory (%s)", err.to_string());
++  }
++}
+diff --git a/src/hotspot/os/serenity/gc/z/zPhysicalMemoryBacking_serenity.hpp b/src/hotspot/os/serenity/gc/z/zPhysicalMemoryBacking_serenity.hpp
+new file mode 100644
+index 000000000..20da01675
+--- /dev/null
++++ b/src/hotspot/os/serenity/gc/z/zPhysicalMemoryBacking_serenity.hpp
+@@ -0,0 +1,48 @@
++/*
++ * Copyright (c) 2019, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++#ifndef OS_SERENITY_GC_Z_ZPHYSICALMEMORYBACKING_SERENITY_HPP
++#define OS_SERENITY_GC_Z_ZPHYSICALMEMORYBACKING_SERENITY_HPP
++
++class ZPhysicalMemoryBacking {
++private:
++  uintptr_t _base;
++  bool      _initialized;
++
++  bool commit_inner(size_t offset, size_t length) const;
++
++public:
++  ZPhysicalMemoryBacking(size_t max_capacity);
++
++  bool is_initialized() const;
++
++  void warn_commit_limits(size_t max_capacity) const;
++
++  size_t commit(size_t offset, size_t length) const;
++  size_t uncommit(size_t offset, size_t length) const;
++
++  void map(uintptr_t addr, size_t size, uintptr_t offset) const;
++  void unmap(uintptr_t addr, size_t size) const;
++};
++
++#endif // OS_SERENITY_GC_Z_ZPHYSICALMEMORYBACKING_SERENITY_HPP
+diff --git a/src/hotspot/os/serenity/globals_serenity.hpp b/src/hotspot/os/serenity/globals_serenity.hpp
+new file mode 100644
+index 000000000..4affe8f26
+--- /dev/null
++++ b/src/hotspot/os/serenity/globals_serenity.hpp
+@@ -0,0 +1,54 @@
++/*
++ * Copyright (c) 2005, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_GLOBALS_SERENITY_HPP
++#define OS_SERENITY_GLOBALS_SERENITY_HPP
++
++//
++// Declare Bsd specific flags. They are not available on other platforms.
++//
++#define RUNTIME_OS_FLAGS(develop,                                       \
++                         develop_pd,                                    \
++                         product,                                       \
++                         product_pd,                                    \
++                         notproduct,                                    \
++                         range,                                         \
++                         constraint)                                    \
++                                                                        \
++  AARCH64_ONLY(develop(bool, AssertWXAtThreadSync, false,                \
++          "Conservatively check W^X thread state at possible safepoint" \
++          "or handshake"))
++
++// end of RUNTIME_OS_FLAGS
++
++//
++// Defines Bsd-specific default values. The flags are available on all
++// platforms, but they may have different default values on other platforms.
++//
++define_pd_global(size_t, PreTouchParallelChunkSize, 1 * G);
++define_pd_global(bool, UseLargePages, false);
++define_pd_global(bool, UseLargePagesIndividualAllocation, false);
++define_pd_global(bool, UseThreadPriorities, true) ;
++
++#endif // OS_SERENITY_GLOBALS_SERENITY_HPP
+diff --git a/src/hotspot/os/serenity/osThread_serenity.cpp b/src/hotspot/os/serenity/osThread_serenity.cpp
+new file mode 100644
+index 000000000..b80a33df7
+--- /dev/null
++++ b/src/hotspot/os/serenity/osThread_serenity.cpp
+@@ -0,0 +1,55 @@
++/*
++ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++// no precompiled headers
++#include "memory/allocation.inline.hpp"
++#include "runtime/mutexLocker.hpp"
++#include "runtime/osThread.hpp"
++
++#include <signal.h>
++
++void OSThread::pd_initialize() {
++  assert(this != NULL, "check");
++  _thread_id        = 0;
++  _unique_thread_id = 0;
++  _pthread_id       = 0;
++  _siginfo          = NULL;
++  // _ucontext         = NULL;
++  _expanding_stack  = 0;
++  _alt_sig_stack    = NULL;
++
++  sigemptyset(&_caller_sigmask);
++
++  _startThread_lock = new Monitor(Mutex::event, "startThread_lock", true,
++                                  Monitor::_safepoint_check_never);
++  assert(_startThread_lock !=NULL, "check");
++}
++
++// Additional thread_id used to correlate threads in SA
++void OSThread::set_unique_thread_id() {
++}
++
++void OSThread::pd_destroy() {
++  delete _startThread_lock;
++}
+diff --git a/src/hotspot/os/serenity/osThread_serenity.hpp b/src/hotspot/os/serenity/osThread_serenity.hpp
+new file mode 100644
+index 000000000..23d7031f0
+--- /dev/null
++++ b/src/hotspot/os/serenity/osThread_serenity.hpp
+@@ -0,0 +1,150 @@
++/*
++ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_OSTHREAD_SERENITY_HPP
++#define OS_SERENITY_OSTHREAD_SERENITY_HPP
++
++ private:
++  int _thread_type;
++
++ public:
++
++  int thread_type() const {
++    return _thread_type;
++  }
++  void set_thread_type(int type) {
++    _thread_type = type;
++  }
++
++ private:
++
++#ifdef __APPLE__
++  typedef thread_t thread_id_t;
++#else
++  typedef pid_t thread_id_t;
++#endif
++
++  // _pthread_id is the pthread id, which is used by library calls
++  // (e.g. pthread_kill).
++  pthread_t _pthread_id;
++
++  // This is the "thread_id" from struct thread_identifier_info. According to a
++  // comment in thread_info.h, this is a "system-wide unique 64-bit thread id".
++  // The value is used by SA to correlate threads.
++  uint64_t _unique_thread_id;
++
++  sigset_t _caller_sigmask; // Caller's signal mask
++
++ public:
++
++  // Methods to save/restore caller's signal mask
++  sigset_t  caller_sigmask() const       { return _caller_sigmask; }
++  void    set_caller_sigmask(sigset_t sigmask)  { _caller_sigmask = sigmask; }
++
++#ifndef PRODUCT
++  // Used for debugging, return a unique integer for each thread.
++  intptr_t thread_identifier() const   { return (intptr_t)_pthread_id; }
++#endif
++
++#ifdef ASSERT
++  // We expect no reposition failures so kill vm if we get one.
++  //
++  bool valid_reposition_failure() {
++    return false;
++  }
++#endif // ASSERT
++
++  pthread_t pthread_id() const {
++    return _pthread_id;
++  }
++  void set_pthread_id(pthread_t tid) {
++    _pthread_id = tid;
++  }
++
++  void set_unique_thread_id();
++
++  // ***************************************************************
++  // suspension support.
++  // ***************************************************************
++
++public:
++  // flags that support signal based suspend/resume on Bsd are in a
++  // separate class to avoid confusion with many flags in OSThread that
++  // are used by VM level suspend/resume.
++  os::SuspendResume sr;
++
++  // _ucontext and _siginfo are used by SR_handler() to save thread context,
++  // and they will later be used to walk the stack or reposition thread PC.
++  // If the thread is not suspended in SR_handler() (e.g. self suspend),
++  // the value in _ucontext is meaningless, so we must use the last Java
++  // frame information as the frame. This will mean that for threads
++  // that are parked on a mutex the profiler (and safepoint mechanism)
++  // will see the thread as if it were still in the Java frame. This
++  // not a problem for the profiler since the Java frame is a close
++  // enough result. For the safepoint mechanism when the give it the
++  // Java frame we are not at a point where the safepoint needs the
++  // frame to that accurate (like for a compiled safepoint) since we
++  // should be in a place where we are native and will block ourselves
++  // if we transition.
++private:
++  void* _siginfo;
++  ucontext_t* _ucontext;
++  int _expanding_stack;                 /* non zero if manually expanding stack */
++  address _alt_sig_stack;               /* address of base of alternate signal stack */
++
++public:
++  void* siginfo() const                   { return _siginfo;  }
++  void set_siginfo(void* ptr)             { _siginfo = ptr;   }
++  ucontext_t* ucontext() const            { return _ucontext; }
++  void set_ucontext(ucontext_t* ptr)      { _ucontext = ptr;  }
++  void set_expanding_stack(void)          { _expanding_stack = 1;  }
++  void clear_expanding_stack(void)        { _expanding_stack = 0;  }
++  int  expanding_stack(void)              { return _expanding_stack;  }
++
++  void set_alt_sig_stack(address val)     { _alt_sig_stack = val; }
++  address alt_sig_stack(void)             { return _alt_sig_stack; }
++
++private:
++  Monitor* _startThread_lock;     // sync parent and child in thread creation
++
++public:
++
++  Monitor* startThread_lock() const {
++    return _startThread_lock;
++  }
++
++  // ***************************************************************
++  // Platform dependent initialization and cleanup
++  // ***************************************************************
++
++private:
++
++  void pd_initialize();
++  void pd_destroy();
++
++// Reconciliation History
++// osThread_solaris.hpp 1.24 99/08/27 13:11:54
++// End
++
++#endif // OS_SERENITY_OSTHREAD_SERENITY_HPP
+diff --git a/src/hotspot/os/serenity/os_perf_serenity.cpp b/src/hotspot/os/serenity/os_perf_serenity.cpp
+new file mode 100644
+index 000000000..67de3f2c4
+--- /dev/null
++++ b/src/hotspot/os/serenity/os_perf_serenity.cpp
+@@ -0,0 +1,440 @@
++/*
++ * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++#include "precompiled.hpp"
++#include "memory/allocation.inline.hpp"
++#include "memory/resourceArea.hpp"
++#include "runtime/os.hpp"
++#include "runtime/os_perf.hpp"
++#include "utilities/globalDefinitions.hpp"
++#include CPU_HEADER(vm_version_ext)
++
++#include <ifaddrs.h>
++
++static const double NANOS_PER_SEC = 1000000000.0;
++
++class CPUPerformanceInterface::CPUPerformance : public CHeapObj<mtInternal> {
++   friend class CPUPerformanceInterface;
++ private:
++  long _total_cpu_nanos;
++  long _total_csr_nanos;
++  long _jvm_user_nanos;
++  long _jvm_system_nanos;
++  long _jvm_context_switches;
++  long _used_ticks;
++  long _total_ticks;
++  int  _active_processor_count;
++
++  bool now_in_nanos(long* resultp) {
++    struct timespec tp;
++    int status = clock_gettime(CLOCK_REALTIME, &tp);
++    assert(status == 0, "clock_gettime error: %s", os::strerror(errno));
++    if (status != 0) {
++      return false;
++    }
++    *resultp = tp.tv_sec * NANOS_PER_SEC + tp.tv_nsec;
++    return true;
++  }
++
++  double normalize(double value) {
++    return MIN2<double>(MAX2<double>(value, 0.0), 1.0);
++  }
++  int cpu_load(int which_logical_cpu, double* cpu_load);
++  int context_switch_rate(double* rate);
++  int cpu_load_total_process(double* cpu_load);
++  int cpu_loads_process(double* pjvmUserLoad, double* pjvmKernelLoad, double* psystemTotalLoad);
++
++  NONCOPYABLE(CPUPerformance);
++
++ public:
++  CPUPerformance();
++  bool initialize();
++  ~CPUPerformance();
++};
++
++CPUPerformanceInterface::CPUPerformance::CPUPerformance() {
++  _total_cpu_nanos= 0;
++  _total_csr_nanos= 0;
++  _jvm_context_switches = 0;
++  _jvm_user_nanos = 0;
++  _jvm_system_nanos = 0;
++  _used_ticks = 0;
++  _total_ticks = 0;
++  _active_processor_count = 0;
++}
++
++bool CPUPerformanceInterface::CPUPerformance::initialize() {
++  return true;
++}
++
++CPUPerformanceInterface::CPUPerformance::~CPUPerformance() {
++}
++
++int CPUPerformanceInterface::CPUPerformance::cpu_load(int which_logical_cpu, double* cpu_load) {
++  return FUNCTIONALITY_NOT_IMPLEMENTED;
++}
++
++int CPUPerformanceInterface::CPUPerformance::cpu_load_total_process(double* cpu_load) {
++#ifdef __APPLE__
++  host_name_port_t host = mach_host_self();
++  host_flavor_t flavor = HOST_CPU_LOAD_INFO;
++  mach_msg_type_number_t host_info_count = HOST_CPU_LOAD_INFO_COUNT;
++  host_cpu_load_info_data_t cpu_load_info;
++
++  kern_return_t kr = host_statistics(host, flavor, (host_info_t)&cpu_load_info, &host_info_count);
++  if (kr != KERN_SUCCESS) {
++    return OS_ERR;
++  }
++
++  long used_ticks  = cpu_load_info.cpu_ticks[CPU_STATE_USER] + cpu_load_info.cpu_ticks[CPU_STATE_NICE] + cpu_load_info.cpu_ticks[CPU_STATE_SYSTEM];
++  long total_ticks = used_ticks + cpu_load_info.cpu_ticks[CPU_STATE_IDLE];
++
++  if (_used_ticks == 0 || _total_ticks == 0) {
++    // First call, just set the values
++    _used_ticks  = used_ticks;
++    _total_ticks = total_ticks;
++    return OS_ERR;
++  }
++
++  long used_delta  = used_ticks - _used_ticks;
++  long total_delta = total_ticks - _total_ticks;
++
++  _used_ticks  = used_ticks;
++  _total_ticks = total_ticks;
++
++  if (total_delta == 0) {
++    // Avoid division by zero
++    return OS_ERR;
++  }
++
++  *cpu_load = (double)used_delta / total_delta;
++
++  return OS_OK;
++#else
++  return FUNCTIONALITY_NOT_IMPLEMENTED;
++#endif
++}
++
++int CPUPerformanceInterface::CPUPerformance::cpu_loads_process(double* pjvmUserLoad, double* pjvmKernelLoad, double* psystemTotalLoad) {
++#ifdef __APPLE__
++  int result = cpu_load_total_process(psystemTotalLoad);
++  mach_port_t task = mach_task_self();
++  mach_msg_type_number_t task_info_count = TASK_INFO_MAX;
++  task_info_data_t task_info_data;
++  kern_return_t kr = task_info(task, TASK_ABSOLUTETIME_INFO, (task_info_t)task_info_data, &task_info_count);
++  if (kr != KERN_SUCCESS) {
++    return OS_ERR;
++  }
++  task_absolutetime_info_t absolutetime_info = (task_absolutetime_info_t)task_info_data;
++
++  int active_processor_count = os::active_processor_count();
++  long jvm_user_nanos = absolutetime_info->total_user;
++  long jvm_system_nanos = absolutetime_info->total_system;
++
++  long total_cpu_nanos;
++  if(!now_in_nanos(&total_cpu_nanos)) {
++    return OS_ERR;
++  }
++
++  if (_total_cpu_nanos == 0 || active_processor_count != _active_processor_count) {
++    // First call or change in active processor count
++    result = OS_ERR;
++  }
++
++  long delta_nanos = active_processor_count * (total_cpu_nanos - _total_cpu_nanos);
++  if (delta_nanos == 0) {
++    // Avoid division by zero
++    return OS_ERR;
++  }
++
++  *pjvmUserLoad = normalize((double)(jvm_user_nanos - _jvm_user_nanos)/delta_nanos);
++  *pjvmKernelLoad = normalize((double)(jvm_system_nanos - _jvm_system_nanos)/delta_nanos);
++
++  _active_processor_count = active_processor_count;
++  _total_cpu_nanos = total_cpu_nanos;
++  _jvm_user_nanos = jvm_user_nanos;
++  _jvm_system_nanos = jvm_system_nanos;
++
++  return result;
++#else
++  return FUNCTIONALITY_NOT_IMPLEMENTED;
++#endif
++}
++
++int CPUPerformanceInterface::CPUPerformance::context_switch_rate(double* rate) {
++#ifdef __APPLE__
++  mach_port_t task = mach_task_self();
++  mach_msg_type_number_t task_info_count = TASK_INFO_MAX;
++  task_info_data_t task_info_data;
++  kern_return_t kr = task_info(task, TASK_EVENTS_INFO, (task_info_t)task_info_data, &task_info_count);
++  if (kr != KERN_SUCCESS) {
++    return OS_ERR;
++  }
++
++  int result = OS_OK;
++  if (_total_csr_nanos == 0 || _jvm_context_switches == 0) {
++    // First call just set initial values.
++    result = OS_ERR;
++  }
++
++  long jvm_context_switches = ((task_events_info_t)task_info_data)->csw;
++
++  long total_csr_nanos;
++  if(!now_in_nanos(&total_csr_nanos)) {
++    return OS_ERR;
++  }
++  double delta_in_sec = (double)(total_csr_nanos - _total_csr_nanos) / NANOS_PER_SEC;
++  if (delta_in_sec == 0.0) {
++    // Avoid division by zero
++    return OS_ERR;
++  }
++
++  *rate = (jvm_context_switches - _jvm_context_switches) / delta_in_sec;
++
++  _jvm_context_switches = jvm_context_switches;
++  _total_csr_nanos = total_csr_nanos;
++
++  return result;
++#else
++  return FUNCTIONALITY_NOT_IMPLEMENTED;
++#endif
++}
++
++CPUPerformanceInterface::CPUPerformanceInterface() {
++  _impl = NULL;
++}
++
++bool CPUPerformanceInterface::initialize() {
++  _impl = new CPUPerformanceInterface::CPUPerformance();
++  return _impl->initialize();
++}
++
++CPUPerformanceInterface::~CPUPerformanceInterface() {
++  if (_impl != NULL) {
++    delete _impl;
++  }
++}
++
++int CPUPerformanceInterface::cpu_load(int which_logical_cpu, double* cpu_load) const {
++  return _impl->cpu_load(which_logical_cpu, cpu_load);
++}
++
++int CPUPerformanceInterface::cpu_load_total_process(double* cpu_load) const {
++  return _impl->cpu_load_total_process(cpu_load);
++}
++
++int CPUPerformanceInterface::cpu_loads_process(double* pjvmUserLoad, double* pjvmKernelLoad, double* psystemTotalLoad) const {
++  return _impl->cpu_loads_process(pjvmUserLoad, pjvmKernelLoad, psystemTotalLoad);
++}
++
++int CPUPerformanceInterface::context_switch_rate(double* rate) const {
++  return _impl->context_switch_rate(rate);
++}
++
++class SystemProcessInterface::SystemProcesses : public CHeapObj<mtInternal> {
++  friend class SystemProcessInterface;
++ private:
++  SystemProcesses();
++  bool initialize();
++  NONCOPYABLE(SystemProcesses);
++  ~SystemProcesses();
++
++  //information about system processes
++  int system_processes(SystemProcess** system_processes, int* no_of_sys_processes) const;
++};
++
++SystemProcessInterface::SystemProcesses::SystemProcesses() {
++}
++
++bool SystemProcessInterface::SystemProcesses::initialize() {
++  return true;
++}
++
++SystemProcessInterface::SystemProcesses::~SystemProcesses() {
++}
++int SystemProcessInterface::SystemProcesses::system_processes(SystemProcess** system_processes, int* no_of_sys_processes) const {
++  assert(system_processes != NULL, "system_processes pointer is NULL!");
++  assert(no_of_sys_processes != NULL, "system_processes counter pointer is NULL!");
++#ifdef __APPLE__
++  pid_t* pids = NULL;
++  int pid_count = 0;
++  ResourceMark rm;
++
++  int try_count = 0;
++  while (pids == NULL) {
++    // Find out buffer size
++    size_t pids_bytes = proc_listpids(PROC_ALL_PIDS, 0, NULL, 0);
++    if (pids_bytes <= 0) {
++      return OS_ERR;
++    }
++    pid_count = pids_bytes / sizeof(pid_t);
++    pids = NEW_RESOURCE_ARRAY(pid_t, pid_count);
++    memset(pids, 0, pids_bytes);
++
++    pids_bytes = proc_listpids(PROC_ALL_PIDS, 0, pids, pids_bytes);
++    if (pids_bytes <= 0) {
++       // couldn't fit buffer, retry.
++      FREE_RESOURCE_ARRAY(pid_t, pids, pid_count);
++      pids = NULL;
++      try_count++;
++      if (try_count > 3) {
++      return OS_ERR;
++      }
++    } else {
++      pid_count = pids_bytes / sizeof(pid_t);
++    }
++  }
++
++  int process_count = 0;
++  SystemProcess* next = NULL;
++  for (int i = 0; i < pid_count; i++) {
++    pid_t pid = pids[i];
++    if (pid != 0) {
++      char buffer[PROC_PIDPATHINFO_MAXSIZE];
++      memset(buffer, 0 , sizeof(buffer));
++      if (proc_pidpath(pid, buffer, sizeof(buffer)) != -1) {
++        int length = strlen(buffer);
++        if (length > 0) {
++          SystemProcess* current = new SystemProcess();
++          char * path = NEW_C_HEAP_ARRAY(char, length + 1, mtInternal);
++          strcpy(path, buffer);
++          current->set_path(path);
++          current->set_pid((int)pid);
++          current->set_next(next);
++          next = current;
++          process_count++;
++        }
++      }
++    }
++  }
++
++  *no_of_sys_processes = process_count;
++  *system_processes = next;
++
++  return OS_OK;
++#endif
++  return FUNCTIONALITY_NOT_IMPLEMENTED;
++}
++
++int SystemProcessInterface::system_processes(SystemProcess** system_procs, int* no_of_sys_processes) const {
++  return _impl->system_processes(system_procs, no_of_sys_processes);
++}
++
++SystemProcessInterface::SystemProcessInterface() {
++  _impl = NULL;
++}
++
++bool SystemProcessInterface::initialize() {
++  _impl = new SystemProcessInterface::SystemProcesses();
++  return _impl->initialize();
++}
++
++SystemProcessInterface::~SystemProcessInterface() {
++  if (_impl != NULL) {
++    delete _impl;
++ }
++}
++
++CPUInformationInterface::CPUInformationInterface() {
++  _cpu_info = NULL;
++}
++
++bool CPUInformationInterface::initialize() {
++  _cpu_info = new CPUInformation();
++  _cpu_info->set_number_of_hardware_threads(VM_Version_Ext::number_of_threads());
++  _cpu_info->set_number_of_cores(VM_Version_Ext::number_of_cores());
++  _cpu_info->set_number_of_sockets(VM_Version_Ext::number_of_sockets());
++  _cpu_info->set_cpu_name(VM_Version_Ext::cpu_name());
++  _cpu_info->set_cpu_description(VM_Version_Ext::cpu_description());
++  return true;
++}
++
++CPUInformationInterface::~CPUInformationInterface() {
++  if (_cpu_info != NULL) {
++    if (_cpu_info->cpu_name() != NULL) {
++      const char* cpu_name = _cpu_info->cpu_name();
++      FREE_C_HEAP_ARRAY(char, cpu_name);
++      _cpu_info->set_cpu_name(NULL);
++    }
++    if (_cpu_info->cpu_description() != NULL) {
++      const char* cpu_desc = _cpu_info->cpu_description();
++      FREE_C_HEAP_ARRAY(char, cpu_desc);
++      _cpu_info->set_cpu_description(NULL);
++    }
++    delete _cpu_info;
++  }
++}
++
++int CPUInformationInterface::cpu_information(CPUInformation& cpu_info) {
++  if (NULL == _cpu_info) {
++    return OS_ERR;
++  }
++
++  cpu_info = *_cpu_info; // shallow copy assignment
++  return OS_OK;
++}
++
++class NetworkPerformanceInterface::NetworkPerformance : public CHeapObj<mtInternal> {
++  friend class NetworkPerformanceInterface;
++ private:
++  NetworkPerformance();
++  NONCOPYABLE(NetworkPerformance);
++  bool initialize();
++  ~NetworkPerformance();
++  int network_utilization(NetworkInterface** network_interfaces) const;
++};
++
++NetworkPerformanceInterface::NetworkPerformance::NetworkPerformance() {
++}
++
++bool NetworkPerformanceInterface::NetworkPerformance::initialize() {
++  return true;
++}
++
++NetworkPerformanceInterface::NetworkPerformance::~NetworkPerformance() {
++}
++
++int NetworkPerformanceInterface::NetworkPerformance::network_utilization(NetworkInterface** network_interfaces) const {
++  // FIXME
++  
++  return OS_ERR;
++}
++
++NetworkPerformanceInterface::NetworkPerformanceInterface() {
++  _impl = NULL;
++}
++
++NetworkPerformanceInterface::~NetworkPerformanceInterface() {
++  if (_impl != NULL) {
++    delete _impl;
++  }
++}
++
++bool NetworkPerformanceInterface::initialize() {
++  _impl = new NetworkPerformanceInterface::NetworkPerformance();
++  return _impl->initialize();
++}
++
++int NetworkPerformanceInterface::network_utilization(NetworkInterface** network_interfaces) const {
++  return _impl->network_utilization(network_interfaces);
++}
+diff --git a/src/hotspot/os/serenity/os_serenity.cpp b/src/hotspot/os/serenity/os_serenity.cpp
+new file mode 100644
+index 000000000..c1a71aa53
+--- /dev/null
++++ b/src/hotspot/os/serenity/os_serenity.cpp
+@@ -0,0 +1,2344 @@
++/*
++ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++// no precompiled headers
++#include "jvm.h"
++#include "classfile/vmSymbols.hpp"
++#include "code/icBuffer.hpp"
++#include "code/vtableStubs.hpp"
++#include "compiler/compileBroker.hpp"
++#include "compiler/disassembler.hpp"
++#include "interpreter/interpreter.hpp"
++#include "jvmtifiles/jvmti.h"
++#include "logging/log.hpp"
++#include "logging/logStream.hpp"
++#include "memory/allocation.inline.hpp"
++#include "oops/oop.inline.hpp"
++#include "os_serenity.inline.hpp"
++#include "os_posix.inline.hpp"
++#include "os_share_serenity.hpp"
++#include "prims/jniFastGetField.hpp"
++#include "prims/jvm_misc.hpp"
++#include "runtime/arguments.hpp"
++#include "runtime/atomic.hpp"
++#include "runtime/globals.hpp"
++#include "runtime/globals_extension.hpp"
++#include "runtime/interfaceSupport.inline.hpp"
++#include "runtime/java.hpp"
++#include "runtime/javaCalls.hpp"
++#include "runtime/mutexLocker.hpp"
++#include "runtime/objectMonitor.hpp"
++#include "runtime/osThread.hpp"
++#include "runtime/perfMemory.hpp"
++#include "runtime/semaphore.hpp"
++#include "runtime/sharedRuntime.hpp"
++#include "runtime/statSampler.hpp"
++#include "runtime/stubRoutines.hpp"
++#include "runtime/thread.inline.hpp"
++#include "runtime/threadCritical.hpp"
++#include "runtime/timer.hpp"
++#include "services/attachListener.hpp"
++#include "services/memTracker.hpp"
++#include "services/runtimeService.hpp"
++#include "signals_posix.hpp"
++#include "utilities/align.hpp"
++#include "utilities/decoder.hpp"
++#include "utilities/defaultStream.hpp"
++#include "utilities/events.hpp"
++#include "utilities/growableArray.hpp"
++#include "utilities/vmError.hpp"
++
++// put OS-includes here
++# include <dlfcn.h>
++# include <errno.h>
++# include <fcntl.h>
++# include <inttypes.h>
++# include <poll.h>
++# include <pthread.h>
++# include <pwd.h>
++# include <signal.h>
++# include <stdint.h>
++# include <stdio.h>
++# include <string.h>
++# include <sys/ioctl.h>
++# include <sys/mman.h>
++# include <sys/param.h>
++# include <sys/resource.h>
++# include <sys/socket.h>
++# include <sys/stat.h>
++// # include <sys/syscall.h>
++// # include <sys/sysctl.h>
++# include <sys/time.h>
++# include <sys/times.h>
++# include <sys/types.h>
++# include <time.h>
++# include <unistd.h>
++
++#include <elf.h>
++
++#ifndef MAP_ANONYMOUS
++  #define MAP_ANONYMOUS MAP_ANON
++#endif
++
++#define MAX_PATH    (2 * K)
++
++// for timer info max values which include all bits
++#define ALL_64_BITS CONST64(0xFFFFFFFFFFFFFFFF)
++
++////////////////////////////////////////////////////////////////////////////////
++// global variables
++julong os::Serenity::_physical_memory = 0;
++
++#ifdef __APPLE__
++mach_timebase_info_data_t os::Serenity::_timebase_info = {0, 0};
++volatile uint64_t         os::Serenity::_max_abstime   = 0;
++#endif
++pthread_t os::Serenity::_main_thread;
++int os::Serenity::_page_size = -1;
++
++static jlong initial_time_count=0;
++
++static int clock_tics_per_sec = 100;
++
++#if defined(__APPLE__) && defined(__x86_64__)
++static const int processor_id_unassigned = -1;
++static const int processor_id_assigning = -2;
++static const int processor_id_map_size = 256;
++static volatile int processor_id_map[processor_id_map_size];
++static volatile int processor_id_next = 0;
++#endif
++
++////////////////////////////////////////////////////////////////////////////////
++// utility functions
++
++julong os::available_memory() {
++  return Serenity::available_memory();
++}
++
++// available here means free
++julong os::Serenity::available_memory() {
++  uint64_t available = physical_memory() >> 2;
++#ifdef __APPLE__
++  mach_msg_type_number_t count = HOST_VM_INFO64_COUNT;
++  vm_statistics64_data_t vmstat;
++  kern_return_t kerr = host_statistics64(mach_host_self(), HOST_VM_INFO64,
++                                         (host_info64_t)&vmstat, &count);
++  assert(kerr == KERN_SUCCESS,
++         "host_statistics64 failed - check mach_host_self() and count");
++  if (kerr == KERN_SUCCESS) {
++    available = vmstat.free_count * os::vm_page_size();
++  }
++#endif
++  return available;
++}
++
++// for more info see :
++// https://man.openbsd.org/sysctl.2
++void os::Serenity::print_uptime_info(outputStream* st) {
++  //FIXME
++  st->print("OS uptime: unknown");
++}
++
++julong os::physical_memory() {
++  return Serenity::physical_memory();
++}
++
++// Return true if user is running as root.
++
++bool os::have_special_privileges() {
++  static bool init = false;
++  static bool privileges = false;
++  if (!init) {
++    privileges = (getuid() != geteuid()) || (getgid() != getegid());
++    init = true;
++  }
++  return privileges;
++}
++
++
++
++// Cpu architecture string
++#if   defined(ZERO)
++static char cpu_arch[] = ZERO_LIBARCH;
++#elif defined(IA64)
++static char cpu_arch[] = "ia64";
++#elif defined(IA32)
++static char cpu_arch[] = "i386";
++#elif defined(AMD64)
++static char cpu_arch[] = "amd64";
++#elif defined(ARM)
++static char cpu_arch[] = "arm";
++#elif defined(AARCH64)
++static char cpu_arch[] = "aarch64";
++#elif defined(PPC32)
++static char cpu_arch[] = "ppc";
++#else
++  #error Add appropriate cpu_arch setting
++#endif
++
++// Compiler variant
++#ifdef COMPILER2
++  #define COMPILER_VARIANT "server"
++#else
++  #define COMPILER_VARIANT "client"
++#endif
++
++
++void os::Serenity::initialize_system_info() {
++  set_processor_count(1);   // fallback
++
++  _physical_memory = 256 * 1024 * 1024;       // fallback (XXXBSD?)
++}
++
++#ifdef __APPLE__
++static const char *get_home() {
++  const char *home_dir = ::getenv("HOME");
++  if ((home_dir == NULL) || (*home_dir == '\0')) {
++    struct passwd *passwd_info = getpwuid(geteuid());
++    if (passwd_info != NULL) {
++      home_dir = passwd_info->pw_dir;
++    }
++  }
++
++  return home_dir;
++}
++#endif
++
++void os::init_system_properties_values() {
++  // The next steps are taken in the product version:
++  //
++  // Obtain the JAVA_HOME value from the location of libjvm.so.
++  // This library should be located at:
++  // <JAVA_HOME>/lib/{client|server}/libjvm.so.
++  //
++  // If "/jre/lib/" appears at the right place in the path, then we
++  // assume libjvm.so is installed in a JDK and we use this path.
++  //
++  // Otherwise exit with message: "Could not create the Java virtual machine."
++  //
++  // The following extra steps are taken in the debugging version:
++  //
++  // If "/jre/lib/" does NOT appear at the right place in the path
++  // instead of exit check for $JAVA_HOME environment variable.
++  //
++  // If it is defined and we are able to locate $JAVA_HOME/jre/lib/<arch>,
++  // then we append a fake suffix "hotspot/libjvm.so" to this path so
++  // it looks like libjvm.so is installed there
++  // <JAVA_HOME>/jre/lib/<arch>/hotspot/libjvm.so.
++  //
++  // Otherwise exit.
++  //
++  // Important note: if the location of libjvm.so changes this
++  // code needs to be changed accordingly.
++
++  // See ld(1):
++  //      The linker uses the following search paths to locate required
++  //      shared libraries:
++  //        1: ...
++  //        ...
++  //        7: The default directories, normally /lib and /usr/lib.
++#ifndef OVERRIDE_LIBPATH
++  #if defined(_LP64)
++    #define DEFAULT_LIBPATH "/usr/lib64:/lib64:/lib:/usr/lib"
++  #else
++    #define DEFAULT_LIBPATH "/lib:/usr/lib"
++  #endif
++#else
++  #define DEFAULT_LIBPATH OVERRIDE_LIBPATH
++#endif
++
++// Base path of extensions installed on the system.
++#define SYS_EXT_DIR     "/usr/java/packages"
++#define EXTENSIONS_DIR  "/lib/ext"
++
++  // Buffer that fits several sprintfs.
++  // Note that the space for the colon and the trailing null are provided
++  // by the nulls included by the sizeof operator.
++  const size_t bufsize =
++    MAX2((size_t)MAXPATHLEN,  // For dll_dir & friends.
++         (size_t)MAXPATHLEN + sizeof(EXTENSIONS_DIR) + sizeof(SYS_EXT_DIR) + sizeof(EXTENSIONS_DIR)); // extensions dir
++  char *buf = NEW_C_HEAP_ARRAY(char, bufsize, mtInternal);
++
++  // sysclasspath, java_home, dll_dir
++  {
++    char *pslash;
++    os::jvm_path(buf, bufsize);
++
++    // Found the full path to libjvm.so.
++    // Now cut the path to <java_home>/jre if we can.
++    pslash = strrchr(buf, '/');
++    if (pslash != NULL) {
++      *pslash = '\0';            // Get rid of /libjvm.so.
++    }
++    pslash = strrchr(buf, '/');
++    if (pslash != NULL) {
++      *pslash = '\0';            // Get rid of /{client|server|hotspot}.
++    }
++    Arguments::set_dll_dir(buf);
++
++    if (pslash != NULL) {
++      pslash = strrchr(buf, '/');
++      if (pslash != NULL) {
++        *pslash = '\0';        // Get rid of /lib.
++      }
++    }
++    Arguments::set_java_home(buf);
++    if (!set_boot_path('/', ':')) {
++      vm_exit_during_initialization("Failed setting boot class path.", NULL);
++    }
++  }
++
++  // Where to look for native libraries.
++  //
++  // Note: Due to a legacy implementation, most of the library path
++  // is set in the launcher. This was to accomodate linking restrictions
++  // on legacy Linux implementations (which are no longer supported).
++  // Eventually, all the library path setting will be done here.
++  //
++  // However, to prevent the proliferation of improperly built native
++  // libraries, the new path component /usr/java/packages is added here.
++  // Eventually, all the library path setting will be done here.
++  {
++    // Get the user setting of LD_LIBRARY_PATH, and prepended it. It
++    // should always exist (until the legacy problem cited above is
++    // addressed).
++    const char *v = ::getenv("LD_LIBRARY_PATH");
++    const char *v_colon = ":";
++    if (v == NULL) { v = ""; v_colon = ""; }
++    // That's +1 for the colon and +1 for the trailing '\0'.
++    char *ld_library_path = NEW_C_HEAP_ARRAY(char,
++                                             strlen(v) + 1 +
++                                             sizeof(SYS_EXT_DIR) + sizeof("/lib/") + sizeof(DEFAULT_LIBPATH) + 1,
++                                             mtInternal);
++    sprintf(ld_library_path, "%s%s" SYS_EXT_DIR "/lib:" DEFAULT_LIBPATH, v, v_colon);
++    Arguments::set_library_path(ld_library_path);
++    FREE_C_HEAP_ARRAY(char, ld_library_path);
++  }
++
++  // Extensions directories.
++  sprintf(buf, "%s" EXTENSIONS_DIR ":" SYS_EXT_DIR EXTENSIONS_DIR, Arguments::get_java_home());
++  Arguments::set_ext_dirs(buf);
++
++  FREE_C_HEAP_ARRAY(char, buf);
++
++#undef DEFAULT_LIBPATH
++#undef SYS_EXT_DIR
++#undef EXTENSIONS_DIR
++}
++
++////////////////////////////////////////////////////////////////////////////////
++// breakpoint support
++
++void os::breakpoint() {
++  BREAKPOINT;
++}
++
++extern "C" void breakpoint() {
++  // use debugger to set breakpoint here
++}
++
++//////////////////////////////////////////////////////////////////////////////
++// create new thread
++
++
++// Thread start routine for all newly created threads
++static void *thread_native_entry(Thread *thread) {
++
++  thread->record_stack_base_and_size();
++  thread->initialize_thread_current();
++
++  OSThread* osthread = thread->osthread();
++  Monitor* sync = osthread->startThread_lock();
++
++  osthread->set_thread_id(os::Serenity::gettid());
++
++#ifdef __APPLE__
++  // Store unique OS X thread id used by SA
++  osthread->set_unique_thread_id();
++#endif
++
++  // initialize signal mask for this thread
++  PosixSignals::hotspot_sigmask(thread);
++
++  // initialize floating point control register
++  os::Serenity::init_thread_fpu_state();
++
++#ifdef __APPLE__
++  // register thread with objc gc
++  if (objc_registerThreadWithCollectorFunction != NULL) {
++    objc_registerThreadWithCollectorFunction();
++  }
++#endif
++
++  // handshaking with parent thread
++  {
++    MutexLocker ml(sync, Mutex::_no_safepoint_check_flag);
++
++    // notify parent thread
++    osthread->set_state(INITIALIZED);
++    sync->notify_all();
++
++    // wait until os::start_thread()
++    while (osthread->get_state() == INITIALIZED) {
++      sync->wait_without_safepoint_check();
++    }
++  }
++
++  log_info(os, thread)("Thread is alive (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT ").",
++    os::current_thread_id(), (uintx) pthread_self());
++
++  // call one more level start routine
++  thread->call_run();
++
++  // Note: at this point the thread object may already have deleted itself.
++  // Prevent dereferencing it from here on out.
++  thread = NULL;
++
++  log_info(os, thread)("Thread finished (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT ").",
++    os::current_thread_id(), (uintx) pthread_self());
++
++  return 0;
++}
++
++bool os::create_thread(Thread* thread, ThreadType thr_type,
++                       size_t req_stack_size) {
++  assert(thread->osthread() == NULL, "caller responsible");
++
++  // Allocate the OSThread object
++  OSThread* osthread = new OSThread(NULL, NULL);
++  if (osthread == NULL) {
++    return false;
++  }
++
++  // set the correct thread state
++  osthread->set_thread_type(thr_type);
++
++  // Initial state is ALLOCATED but not INITIALIZED
++  osthread->set_state(ALLOCATED);
++
++  thread->set_osthread(osthread);
++
++  // init thread attributes
++  pthread_attr_t attr;
++  pthread_attr_init(&attr);
++  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
++
++  // calculate stack size if it's not specified by caller
++  size_t stack_size = os::Posix::get_initial_stack_size(thr_type, req_stack_size);
++  int status = pthread_attr_setstacksize(&attr, stack_size);
++  assert_status(status == 0, status, "pthread_attr_setstacksize");
++
++  ThreadState state;
++
++  {
++    pthread_t tid;
++    int ret = pthread_create(&tid, &attr, (void* (*)(void*)) thread_native_entry, thread);
++
++    char buf[64];
++    if (ret == 0) {
++      log_info(os, thread)("Thread started (pthread id: " UINTX_FORMAT ", attributes: %s). ",
++        (uintx) tid, os::Posix::describe_pthread_attr(buf, sizeof(buf), &attr));
++    } else {
++      log_warning(os, thread)("Failed to start thread - pthread_create failed (%s) for attributes: %s.",
++        os::errno_name(ret), os::Posix::describe_pthread_attr(buf, sizeof(buf), &attr));
++      // Log some OS information which might explain why creating the thread failed.
++      log_info(os, thread)("Number of threads approx. running in the VM: %d", Threads::number_of_threads());
++      LogStream st(Log(os, thread)::info());
++      os::Posix::print_rlimit_info(&st);
++      os::print_memory_info(&st);
++    }
++
++    pthread_attr_destroy(&attr);
++
++    if (ret != 0) {
++      // Need to clean up stuff we've allocated so far
++      thread->set_osthread(NULL);
++      delete osthread;
++      return false;
++    }
++
++    // Store pthread info into the OSThread
++    osthread->set_pthread_id(tid);
++
++    // Wait until child thread is either initialized or aborted
++    {
++      Monitor* sync_with_child = osthread->startThread_lock();
++      MutexLocker ml(sync_with_child, Mutex::_no_safepoint_check_flag);
++      while ((state = osthread->get_state()) == ALLOCATED) {
++        sync_with_child->wait_without_safepoint_check();
++      }
++    }
++
++  }
++
++  // The thread is returned suspended (in state INITIALIZED),
++  // and is started higher up in the call chain
++  assert(state == INITIALIZED, "race condition");
++  return true;
++}
++
++/////////////////////////////////////////////////////////////////////////////
++// attach existing thread
++
++// bootstrap the main thread
++bool os::create_main_thread(JavaThread* thread) {
++  assert(os::Serenity::_main_thread == pthread_self(), "should be called inside main thread");
++  return create_attached_thread(thread);
++}
++
++bool os::create_attached_thread(JavaThread* thread) {
++#ifdef ASSERT
++  thread->verify_not_published();
++#endif
++
++  // Allocate the OSThread object
++  OSThread* osthread = new OSThread(NULL, NULL);
++
++  if (osthread == NULL) {
++    return false;
++  }
++
++  osthread->set_thread_id(os::Serenity::gettid());
++
++#ifdef __APPLE__
++  // Store unique OS X thread id used by SA
++  osthread->set_unique_thread_id();
++#endif
++
++  // Store pthread info into the OSThread
++  osthread->set_pthread_id(::pthread_self());
++
++  // initialize floating point control register
++  os::Serenity::init_thread_fpu_state();
++
++  // Initial thread state is RUNNABLE
++  osthread->set_state(RUNNABLE);
++
++  thread->set_osthread(osthread);
++
++  // initialize signal mask for this thread
++  // and save the caller's signal mask
++  PosixSignals::hotspot_sigmask(thread);
++
++  log_info(os, thread)("Thread attached (tid: " UINTX_FORMAT ", pthread id: " UINTX_FORMAT ").",
++    os::current_thread_id(), (uintx) pthread_self());
++
++  return true;
++}
++
++void os::pd_start_thread(Thread* thread) {
++  OSThread * osthread = thread->osthread();
++  assert(osthread->get_state() != INITIALIZED, "just checking");
++  Monitor* sync_with_child = osthread->startThread_lock();
++  MutexLocker ml(sync_with_child, Mutex::_no_safepoint_check_flag);
++  sync_with_child->notify();
++}
++
++// Free Bsd resources related to the OSThread
++void os::free_thread(OSThread* osthread) {
++  assert(osthread != NULL, "osthread not set");
++
++  // We are told to free resources of the argument thread,
++  // but we can only really operate on the current thread.
++  assert(Thread::current()->osthread() == osthread,
++         "os::free_thread but not current thread");
++
++  // Restore caller's signal mask
++  sigset_t sigmask = osthread->caller_sigmask();
++  pthread_sigmask(SIG_SETMASK, &sigmask, NULL);
++
++  delete osthread;
++}
++
++////////////////////////////////////////////////////////////////////////////////
++// time support
++
++// Time since start-up in seconds to a fine granularity.
++double os::elapsedTime() {
++  return ((double)os::elapsed_counter()) / os::elapsed_frequency();
++}
++
++jlong os::elapsed_counter() {
++  return javaTimeNanos() - initial_time_count;
++}
++
++jlong os::elapsed_frequency() {
++  return NANOSECS_PER_SEC; // nanosecond resolution
++}
++
++bool os::supports_vtime() { return true; }
++
++double os::elapsedVTime() {
++  // better than nothing, but not much
++  return elapsedTime();
++}
++
++#ifdef __APPLE__
++void os::Serenity::clock_init() {
++  mach_timebase_info(&_timebase_info);
++}
++#else
++void os::Serenity::clock_init() {
++  // Nothing to do
++}
++#endif
++
++
++
++#ifdef __APPLE__
++
++jlong os::javaTimeNanos() {
++  const uint64_t tm = mach_absolute_time();
++  const uint64_t now = (tm * Serenity::_timebase_info.numer) / Serenity::_timebase_info.denom;
++  const uint64_t prev = Serenity::_max_abstime;
++  if (now <= prev) {
++    return prev;   // same or retrograde time;
++  }
++  const uint64_t obsv = Atomic::cmpxchg(&Serenity::_max_abstime, prev, now);
++  assert(obsv >= prev, "invariant");   // Monotonicity
++  // If the CAS succeeded then we're done and return "now".
++  // If the CAS failed and the observed value "obsv" is >= now then
++  // we should return "obsv".  If the CAS failed and now > obsv > prv then
++  // some other thread raced this thread and installed a new value, in which case
++  // we could either (a) retry the entire operation, (b) retry trying to install now
++  // or (c) just return obsv.  We use (c).   No loop is required although in some cases
++  // we might discard a higher "now" value in deference to a slightly lower but freshly
++  // installed obsv value.   That's entirely benign -- it admits no new orderings compared
++  // to (a) or (b) -- and greatly reduces coherence traffic.
++  // We might also condition (c) on the magnitude of the delta between obsv and now.
++  // Avoiding excessive CAS operations to hot RW locations is critical.
++  // See https://blogs.oracle.com/dave/entry/cas_and_cache_trivia_invalidate
++  return (prev == obsv) ? now : obsv;
++}
++
++void os::javaTimeNanos_info(jvmtiTimerInfo *info_ptr) {
++  info_ptr->max_value = ALL_64_BITS;
++  info_ptr->may_skip_backward = false;      // not subject to resetting or drifting
++  info_ptr->may_skip_forward = false;       // not subject to resetting or drifting
++  info_ptr->kind = JVMTI_TIMER_ELAPSED;     // elapsed not CPU time
++}
++
++#endif // __APPLE__
++
++// Return the real, user, and system times in seconds from an
++// arbitrary fixed point in the past.
++bool os::getTimesSecs(double* process_real_time,
++                      double* process_user_time,
++                      double* process_system_time) {
++  struct tms ticks;
++  clock_t real_ticks = times(&ticks);
++
++  if (real_ticks == (clock_t) (-1)) {
++    return false;
++  } else {
++    double ticks_per_second = (double) clock_tics_per_sec;
++    *process_user_time = ((double) ticks.tms_utime) / ticks_per_second;
++    *process_system_time = ((double) ticks.tms_stime) / ticks_per_second;
++    *process_real_time = ((double) real_ticks) / ticks_per_second;
++
++    return true;
++  }
++}
++
++
++char * os::local_time_string(char *buf, size_t buflen) {
++  struct tm t;
++  time_t long_time;
++  time(&long_time);
++  localtime_r(&long_time, &t);
++  jio_snprintf(buf, buflen, "%d-%02d-%02d %02d:%02d:%02d",
++               t.tm_year + 1900, t.tm_mon + 1, t.tm_mday,
++               t.tm_hour, t.tm_min, t.tm_sec);
++  return buf;
++}
++
++struct tm* os::localtime_pd(const time_t* clock, struct tm*  res) {
++  return localtime_r(clock, res);
++}
++
++// Information of current thread in variety of formats
++pid_t os::Serenity::gettid() {
++  int retval = -1;
++
++#ifdef __APPLE__ // XNU kernel
++  mach_port_t port = mach_thread_self();
++  guarantee(MACH_PORT_VALID(port), "just checking");
++  mach_port_deallocate(mach_task_self(), port);
++  return (pid_t)port;
++
++#else
++  #ifdef __FreeBSD__
++  retval = syscall(SYS_thr_self);
++  #else
++    #ifdef __OpenBSD__
++  retval = syscall(SYS_getthrid);
++    #else
++      #ifdef __NetBSD__
++  retval = (pid_t) syscall(SYS__lwp_self);
++      #endif
++    #endif
++  #endif
++#endif
++
++  if (retval == -1) {
++    return getpid();
++  }
++}
++
++intx os::current_thread_id() {
++#ifdef __APPLE__
++  return (intx)os::Serenity::gettid();
++#else
++  return (intx)::pthread_self();
++#endif
++}
++
++int os::current_process_id() {
++  return (int)(getpid());
++}
++
++// DLL functions
++
++const char* os::dll_file_extension() { return JNI_LIB_SUFFIX; }
++
++// This must be hard coded because it's the system's temporary
++// directory not the java application's temp directory, ala java.io.tmpdir.
++#ifdef __APPLE__
++// macosx has a secure per-user temporary directory
++char temp_path_storage[PATH_MAX];
++const char* os::get_temp_directory() {
++  static char *temp_path = NULL;
++  if (temp_path == NULL) {
++    int pathSize = confstr(_CS_DARWIN_USER_TEMP_DIR, temp_path_storage, PATH_MAX);
++    if (pathSize == 0 || pathSize > PATH_MAX) {
++      strlcpy(temp_path_storage, "/tmp/", sizeof(temp_path_storage));
++    }
++    temp_path = temp_path_storage;
++  }
++  return temp_path;
++}
++#else // __APPLE__
++const char* os::get_temp_directory() { return "/tmp"; }
++#endif // __APPLE__
++
++// check if addr is inside libjvm.so
++bool os::address_is_in_vm(address addr) {
++  static address libjvm_base_addr;
++  Dl_info dlinfo;
++
++  if (libjvm_base_addr == NULL) {
++    if (dladdr(CAST_FROM_FN_PTR(void *, os::address_is_in_vm), &dlinfo) != 0) {
++      libjvm_base_addr = (address)dlinfo.dli_fbase;
++    }
++    assert(libjvm_base_addr !=NULL, "Cannot obtain base address for libjvm");
++  }
++
++  if (dladdr((void *)addr, &dlinfo) != 0) {
++    if (libjvm_base_addr == (address)dlinfo.dli_fbase) return true;
++  }
++
++  return false;
++}
++
++
++#define MACH_MAXSYMLEN 256
++
++bool os::dll_address_to_function_name(address addr, char *buf,
++                                      int buflen, int *offset,
++                                      bool demangle) {
++  // buf is not optional, but offset is optional
++  assert(buf != NULL, "sanity check");
++
++  Dl_info dlinfo;
++  char localbuf[MACH_MAXSYMLEN];
++
++  if (dladdr((void*)addr, &dlinfo) != 0) {
++    // see if we have a matching symbol
++    if (dlinfo.dli_saddr != NULL && dlinfo.dli_sname != NULL) {
++      if (!(demangle && Decoder::demangle(dlinfo.dli_sname, buf, buflen))) {
++        jio_snprintf(buf, buflen, "%s", dlinfo.dli_sname);
++      }
++      if (offset != NULL) *offset = addr - (address)dlinfo.dli_saddr;
++      return true;
++    }
++    // no matching symbol so try for just file info
++    if (dlinfo.dli_fname != NULL && dlinfo.dli_fbase != NULL) {
++      if (Decoder::decode((address)(addr - (address)dlinfo.dli_fbase),
++                          buf, buflen, offset, dlinfo.dli_fname, demangle)) {
++        return true;
++      }
++    }
++
++    // Handle non-dynamic manually:
++    if (dlinfo.dli_fbase != NULL &&
++        Decoder::decode(addr, localbuf, MACH_MAXSYMLEN, offset,
++                        dlinfo.dli_fbase)) {
++      if (!(demangle && Decoder::demangle(localbuf, buf, buflen))) {
++        jio_snprintf(buf, buflen, "%s", localbuf);
++      }
++      return true;
++    }
++  }
++  buf[0] = '\0';
++  if (offset != NULL) *offset = -1;
++  return false;
++}
++
++// ported from solaris version
++bool os::dll_address_to_library_name(address addr, char* buf,
++                                     int buflen, int* offset) {
++  // buf is not optional, but offset is optional
++  assert(buf != NULL, "sanity check");
++
++  Dl_info dlinfo;
++
++  if (dladdr((void*)addr, &dlinfo) != 0) {
++    if (dlinfo.dli_fname != NULL) {
++      jio_snprintf(buf, buflen, "%s", dlinfo.dli_fname);
++    }
++    if (dlinfo.dli_fbase != NULL && offset != NULL) {
++      *offset = addr - (address)dlinfo.dli_fbase;
++    }
++    return true;
++  }
++
++  buf[0] = '\0';
++  if (offset) *offset = -1;
++  return false;
++}
++
++// Loads .dll/.so and
++// in case of error it checks if .dll/.so was built for the
++// same architecture as Hotspot is running on
++
++#ifdef __APPLE__
++void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
++#ifdef STATIC_BUILD
++  return os::get_default_process_handle();
++#else
++  log_info(os)("attempting shared library load of %s", filename);
++
++  void * result= ::dlopen(filename, RTLD_LAZY);
++  if (result != NULL) {
++    Events::log(NULL, "Loaded shared library %s", filename);
++    // Successful loading
++    log_info(os)("shared library load of %s was successful", filename);
++    return result;
++  }
++
++  const char* error_report = ::dlerror();
++  if (error_report == NULL) {
++    error_report = "dlerror returned no error description";
++  }
++  if (ebuf != NULL && ebuflen > 0) {
++    // Read system error message into ebuf
++    ::strncpy(ebuf, error_report, ebuflen-1);
++    ebuf[ebuflen-1]='\0';
++  }
++  Events::log(NULL, "Loading shared library %s failed, %s", filename, error_report);
++  log_info(os)("shared library load of %s failed, %s", filename, error_report);
++
++  return NULL;
++#endif // STATIC_BUILD
++}
++#else
++void * os::dll_load(const char *filename, char *ebuf, int ebuflen) {
++#ifdef STATIC_BUILD
++  return os::get_default_process_handle();
++#else
++  log_info(os)("attempting shared library load of %s", filename);
++  void * result= ::dlopen(filename, RTLD_LAZY);
++  if (result != NULL) {
++    Events::log(NULL, "Loaded shared library %s", filename);
++    // Successful loading
++    log_info(os)("shared library load of %s was successful", filename);
++    return result;
++  }
++
++  Elf32_Ehdr elf_head;
++
++  const char* const error_report = ::dlerror();
++  // if (error_report == NULL) {
++  //   error_report = "dlerror returned no error description";
++  // }
++  if (ebuf != NULL && ebuflen > 0) {
++    // Read system error message into ebuf
++    ::strncpy(ebuf, error_report, ebuflen-1);
++    ebuf[ebuflen-1]='\0';
++  }
++  Events::log(NULL, "Loading shared library %s failed, %s", filename, error_report);
++  log_info(os)("shared library load of %s failed, %s", filename, error_report);
++
++  int diag_msg_max_length=ebuflen-strlen(ebuf);
++  char* diag_msg_buf=ebuf+strlen(ebuf);
++
++  if (diag_msg_max_length==0) {
++    // No more space in ebuf for additional diagnostics message
++    return NULL;
++  }
++
++
++  int file_descriptor= ::open(filename, O_RDONLY | O_NONBLOCK);
++
++  if (file_descriptor < 0) {
++    // Can't open library, report dlerror() message
++    return NULL;
++  }
++
++  bool failed_to_read_elf_head=
++    (sizeof(elf_head)!=
++     (::read(file_descriptor, &elf_head,sizeof(elf_head))));
++
++  ::close(file_descriptor);
++  if (failed_to_read_elf_head) {
++    // file i/o error - report dlerror() msg
++    return NULL;
++  }
++
++  typedef struct {
++    Elf32_Half  code;         // Actual value as defined in elf.h
++    Elf32_Half  compat_class; // Compatibility of archs at VM's sense
++    char        elf_class;    // 32 or 64 bit
++    char        endianess;    // MSB or LSB
++    char*       name;         // String representation
++  } arch_t;
++
++  #ifndef EM_486
++    #define EM_486          6               /* Intel 80486 */
++  #endif
++
++  #ifndef EM_MIPS_RS3_LE
++    #define EM_MIPS_RS3_LE  10              /* MIPS */
++  #endif
++
++  #ifndef EM_PPC64
++    #define EM_PPC64        21              /* PowerPC64 */
++  #endif
++
++  #ifndef EM_S390
++    #define EM_S390         22              /* IBM System/390 */
++  #endif
++
++  #ifndef EM_IA_64
++    #define EM_IA_64        50              /* HP/Intel IA-64 */
++  #endif
++
++  #ifndef EM_X86_64
++    #define EM_X86_64       62              /* AMD x86-64 */
++  #endif
++
++  static const arch_t arch_array[]={
++    {EM_386,         EM_386,     ELFCLASS32, ELFDATA2LSB, (char*)"IA 32"},
++    {EM_486,         EM_386,     ELFCLASS32, ELFDATA2LSB, (char*)"IA 32"},
++    {EM_IA_64,       EM_IA_64,   ELFCLASS64, ELFDATA2LSB, (char*)"IA 64"},
++    {EM_X86_64,      EM_X86_64,  ELFCLASS64, ELFDATA2LSB, (char*)"AMD 64"},
++    {EM_PPC,         EM_PPC,     ELFCLASS32, ELFDATA2MSB, (char*)"Power PC 32"},
++    {EM_PPC64,       EM_PPC64,   ELFCLASS64, ELFDATA2MSB, (char*)"Power PC 64"},
++    {EM_ARM,         EM_ARM,     ELFCLASS32,   ELFDATA2LSB, (char*)"ARM"},
++    {EM_S390,        EM_S390,    ELFCLASSNONE, ELFDATA2MSB, (char*)"IBM System/390"},
++    {EM_ALPHA,       EM_ALPHA,   ELFCLASS64, ELFDATA2LSB, (char*)"Alpha"},
++    {EM_MIPS_RS3_LE, EM_MIPS_RS3_LE, ELFCLASS32, ELFDATA2LSB, (char*)"MIPSel"},
++    {EM_MIPS,        EM_MIPS,    ELFCLASS32, ELFDATA2MSB, (char*)"MIPS"},
++    {EM_PARISC,      EM_PARISC,  ELFCLASS32, ELFDATA2MSB, (char*)"PARISC"},
++    {EM_68K,         EM_68K,     ELFCLASS32, ELFDATA2MSB, (char*)"M68k"}
++  };
++
++  #if  (defined IA32)
++  static  Elf32_Half running_arch_code=EM_386;
++  #elif   (defined AMD64)
++  static  Elf32_Half running_arch_code=EM_X86_64;
++  #elif  (defined IA64)
++  static  Elf32_Half running_arch_code=EM_IA_64;
++  #elif  (defined __powerpc64__)
++  static  Elf32_Half running_arch_code=EM_PPC64;
++  #elif  (defined __powerpc__)
++  static  Elf32_Half running_arch_code=EM_PPC;
++  #elif  (defined ARM)
++  static  Elf32_Half running_arch_code=EM_ARM;
++  #elif  (defined S390)
++  static  Elf32_Half running_arch_code=EM_S390;
++  #elif  (defined ALPHA)
++  static  Elf32_Half running_arch_code=EM_ALPHA;
++  #elif  (defined MIPSEL)
++  static  Elf32_Half running_arch_code=EM_MIPS_RS3_LE;
++  #elif  (defined PARISC)
++  static  Elf32_Half running_arch_code=EM_PARISC;
++  #elif  (defined MIPS)
++  static  Elf32_Half running_arch_code=EM_MIPS;
++  #elif  (defined M68K)
++  static  Elf32_Half running_arch_code=EM_68K;
++  #else
++    #error Method os::dll_load requires that one of following is defined:\
++         IA32, AMD64, IA64, __powerpc__, ARM, S390, ALPHA, MIPS, MIPSEL, PARISC, M68K
++  #endif
++
++  // Identify compatability class for VM's architecture and library's architecture
++  // Obtain string descriptions for architectures
++
++  arch_t lib_arch={elf_head.e_machine,0,(char)elf_head.e_ident[EI_CLASS], (char)elf_head.e_ident[EI_DATA], NULL};
++  int running_arch_index=-1;
++
++  for (unsigned int i=0; i < ARRAY_SIZE(arch_array); i++) {
++    if (running_arch_code == arch_array[i].code) {
++      running_arch_index    = i;
++    }
++    if (lib_arch.code == arch_array[i].code) {
++      lib_arch.compat_class = arch_array[i].compat_class;
++      lib_arch.name         = arch_array[i].name;
++    }
++  }
++
++  assert(running_arch_index != -1,
++         "Didn't find running architecture code (running_arch_code) in arch_array");
++  if (running_arch_index == -1) {
++    // Even though running architecture detection failed
++    // we may still continue with reporting dlerror() message
++    return NULL;
++  }
++
++  if (lib_arch.endianess != arch_array[running_arch_index].endianess) {
++    ::snprintf(diag_msg_buf, diag_msg_max_length-1," (Possible cause: endianness mismatch)");
++    return NULL;
++  }
++
++#ifndef S390
++  if (lib_arch.elf_class != arch_array[running_arch_index].elf_class) {
++    ::snprintf(diag_msg_buf, diag_msg_max_length-1," (Possible cause: architecture word width mismatch)");
++    return NULL;
++  }
++#endif // !S390
++
++  if (lib_arch.compat_class != arch_array[running_arch_index].compat_class) {
++    if (lib_arch.name!=NULL) {
++      ::snprintf(diag_msg_buf, diag_msg_max_length-1,
++                 " (Possible cause: can't load %s-bit .so on a %s-bit platform)",
++                 lib_arch.name, arch_array[running_arch_index].name);
++    } else {
++      ::snprintf(diag_msg_buf, diag_msg_max_length-1,
++                 " (Possible cause: can't load this .so (machine code=0x%x) on a %s-bit platform)",
++                 lib_arch.code,
++                 arch_array[running_arch_index].name);
++    }
++  }
++
++  return NULL;
++#endif // STATIC_BUILD
++}
++#endif // !__APPLE__
++
++void* os::get_default_process_handle() {
++#ifdef __APPLE__
++  // MacOS X needs to use RTLD_FIRST instead of RTLD_LAZY
++  // to avoid finding unexpected symbols on second (or later)
++  // loads of a library.
++  return (void*)::dlopen(NULL, RTLD_FIRST);
++#else
++  return (void*)::dlopen(NULL, RTLD_LAZY);
++#endif
++}
++
++// XXX: Do we need a lock around this as per Linux?
++void* os::dll_lookup(void* handle, const char* name) {
++  return dlsym(handle, name);
++}
++
++int _print_dll_info_cb(const char * name, address base_address, address top_address, void * param) {
++  outputStream * out = (outputStream *) param;
++  out->print_cr(INTPTR_FORMAT " \t%s", (intptr_t)base_address, name);
++  return 0;
++}
++
++void os::print_dll_info(outputStream *st) {
++  st->print_cr("Dynamic libraries:");
++  if (get_loaded_modules_info(_print_dll_info_cb, (void *)st)) {
++    st->print_cr("Error: Cannot print dynamic libraries.");
++  }
++}
++
++int os::get_loaded_modules_info(os::LoadedModulesCallbackFunc callback, void *param) {
++#ifdef RTLD_DI_LINKMAP
++  Dl_info dli;
++  void *handle;
++  Link_map *map;
++  Link_map *p;
++
++  if (dladdr(CAST_FROM_FN_PTR(void *, os::print_dll_info), &dli) == 0 ||
++      dli.dli_fname == NULL) {
++    return 1;
++  }
++  handle = dlopen(dli.dli_fname, RTLD_LAZY);
++  if (handle == NULL) {
++    return 1;
++  }
++  dlinfo(handle, RTLD_DI_LINKMAP, &map);
++  if (map == NULL) {
++    dlclose(handle);
++    return 1;
++  }
++
++  while (map->l_prev != NULL)
++    map = map->l_prev;
++
++  while (map != NULL) {
++    // Value for top_address is returned as 0 since we don't have any information about module size
++    if (callback(map->l_name, (address)map->l_addr, (address)0, param)) {
++      dlclose(handle);
++      return 1;
++    }
++    map = map->l_next;
++  }
++
++  dlclose(handle);
++#elif defined(__APPLE__)
++  for (uint32_t i = 1; i < _dyld_image_count(); i++) {
++    // Value for top_address is returned as 0 since we don't have any information about module size
++    if (callback(_dyld_get_image_name(i), (address)_dyld_get_image_header(i), (address)0, param)) {
++      return 1;
++    }
++  }
++  return 0;
++#else
++  return 1;
++#endif
++}
++
++void os::get_summary_os_info(char* buf, size_t buflen) {
++  snprintf(buf, buflen, "Serenity");
++}
++
++void os::print_os_info_brief(outputStream* st) {
++  os::Posix::print_uname_info(st);
++}
++
++void os::print_os_info(outputStream* st) {
++  st->print_cr("OS:");
++
++  os::Posix::print_uname_info(st);
++
++  os::Serenity::print_uptime_info(st);
++
++  os::Posix::print_rlimit_info(st);
++
++  os::Posix::print_load_average(st);
++
++  VM_Version::print_platform_virtualization_info(st);
++}
++
++void os::pd_print_cpu_info(outputStream* st, char* buf, size_t buflen) {
++  // Nothing to do for now.
++}
++
++void os::get_summary_cpu_info(char* buf, size_t buflen) {
++  snprintf(buf, buflen, "Unknown");
++}
++
++void os::print_memory_info(outputStream* st) {
++  st->print("Memory: unknown");
++}
++
++static char saved_jvm_path[MAXPATHLEN] = {0};
++
++// Find the full path to the current module, libjvm
++void os::jvm_path(char *buf, jint buflen) {
++  // Error checking.
++  if (buflen < MAXPATHLEN) {
++    assert(false, "must use a large-enough buffer");
++    buf[0] = '\0';
++    return;
++  }
++  // Lazy resolve the path to current module.
++  if (saved_jvm_path[0] != 0) {
++    strcpy(buf, saved_jvm_path);
++    return;
++  }
++
++  char dli_fname[MAXPATHLEN];
++  dli_fname[0] = '\0';
++  bool ret = dll_address_to_library_name(
++                                         CAST_FROM_FN_PTR(address, os::jvm_path),
++                                         dli_fname, sizeof(dli_fname), NULL);
++  assert(ret, "cannot locate libjvm");
++  char *rp = NULL;
++  if (ret && dli_fname[0] != '\0') {
++    rp = os::Posix::realpath(dli_fname, buf, buflen);
++  }
++  if (rp == NULL) {
++    return;
++  }
++
++  if (Arguments::sun_java_launcher_is_altjvm()) {
++    // Support for the java launcher's '-XXaltjvm=<path>' option. Typical
++    // value for buf is "<JAVA_HOME>/jre/lib/<arch>/<vmtype>/libjvm.so"
++    // or "<JAVA_HOME>/jre/lib/<vmtype>/libjvm.dylib". If "/jre/lib/"
++    // appears at the right place in the string, then assume we are
++    // installed in a JDK and we're done. Otherwise, check for a
++    // JAVA_HOME environment variable and construct a path to the JVM
++    // being overridden.
++
++    const char *p = buf + strlen(buf) - 1;
++    for (int count = 0; p > buf && count < 5; ++count) {
++      for (--p; p > buf && *p != '/'; --p)
++        /* empty */ ;
++    }
++
++    if (strncmp(p, "/jre/lib/", 9) != 0) {
++      // Look for JAVA_HOME in the environment.
++      char* java_home_var = ::getenv("JAVA_HOME");
++      if (java_home_var != NULL && java_home_var[0] != 0) {
++        char* jrelib_p;
++        int len;
++
++        // Check the current module name "libjvm"
++        p = strrchr(buf, '/');
++        assert(strstr(p, "/libjvm") == p, "invalid library name");
++
++        rp = os::Posix::realpath(java_home_var, buf, buflen);
++        if (rp == NULL) {
++          return;
++        }
++
++        // determine if this is a legacy image or modules image
++        // modules image doesn't have "jre" subdirectory
++        len = strlen(buf);
++        assert(len < buflen, "Ran out of buffer space");
++        jrelib_p = buf + len;
++
++        // Add the appropriate library subdir
++        snprintf(jrelib_p, buflen-len, "/jre/lib");
++        if (0 != access(buf, F_OK)) {
++          snprintf(jrelib_p, buflen-len, "/lib");
++        }
++
++        // Add the appropriate client or server subdir
++        len = strlen(buf);
++        jrelib_p = buf + len;
++        snprintf(jrelib_p, buflen-len, "/%s", COMPILER_VARIANT);
++        if (0 != access(buf, F_OK)) {
++          snprintf(jrelib_p, buflen-len, "%s", "");
++        }
++
++        // If the path exists within JAVA_HOME, add the JVM library name
++        // to complete the path to JVM being overridden.  Otherwise fallback
++        // to the path to the current library.
++        if (0 == access(buf, F_OK)) {
++          // Use current module name "libjvm"
++          len = strlen(buf);
++          snprintf(buf + len, buflen-len, "/libjvm%s", JNI_LIB_SUFFIX);
++        } else {
++          // Fall back to path of current library
++          rp = os::Posix::realpath(dli_fname, buf, buflen);
++          if (rp == NULL) {
++            return;
++          }
++        }
++      }
++    }
++  }
++
++  strncpy(saved_jvm_path, buf, MAXPATHLEN);
++  saved_jvm_path[MAXPATHLEN - 1] = '\0';
++}
++
++void os::print_jni_name_prefix_on(outputStream* st, int args_size) {
++  // no prefix required, not even "_"
++}
++
++void os::print_jni_name_suffix_on(outputStream* st, int args_size) {
++  // no suffix required
++}
++
++////////////////////////////////////////////////////////////////////////////////
++// Virtual Memory
++
++int os::vm_page_size() {
++  // Seems redundant as all get out
++  assert(os::Serenity::page_size() != -1, "must call os::init");
++  return os::Serenity::page_size();
++}
++
++// Solaris allocates memory by pages.
++int os::vm_allocation_granularity() {
++  assert(os::Serenity::page_size() != -1, "must call os::init");
++  return os::Serenity::page_size();
++}
++
++static void warn_fail_commit_memory(char* addr, size_t size, bool exec,
++                                    int err) {
++  warning("INFO: os::commit_memory(" INTPTR_FORMAT ", " SIZE_FORMAT
++          ", %d) failed; error='%s' (errno=%d)", (intptr_t)addr, size, exec,
++           os::errno_name(err), err);
++}
++
++bool os::pd_commit_memory(char* addr, size_t size, bool exec) {
++  int prot = exec ? PROT_READ|PROT_WRITE/*|PROT_EXEC*/ : PROT_READ|PROT_WRITE;
++  
++  // warning("mmap(%lx, %lx, %x, MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0), exec=%d", (size_t)addr, size, prot, exec);
++  uintptr_t res = (uintptr_t) ::mmap(addr, size, prot,
++                                     MAP_PRIVATE|MAP_FIXED|MAP_ANONYMOUS, -1, 0);
++  // warning("INFO: mmap errno = %d, res = %u", errno, res);
++  if (res != (uintptr_t) MAP_FAILED) {
++    // if(exec)
++    // {
++    //   if (::mprotect(addr, size, PROT_READ|PROT_WRITE|PROT_EXEC) == 0) {
++    //     return true;
++    //   }
++    //   else
++    //   {
++    //     warning("INFO: mprotect failed");
++    //   }
++    // }
++    // else
++    return true;
++  }
++
++  NOT_PRODUCT(warn_fail_commit_memory(addr, size, exec, errno);)
++
++  return false;
++}
++
++bool os::pd_commit_memory(char* addr, size_t size, size_t alignment_hint,
++                          bool exec) {
++  // alignment_hint is ignored on this OS
++  return pd_commit_memory(addr, size, exec);
++}
++
++void os::pd_commit_memory_or_exit(char* addr, size_t size, bool exec,
++                                  const char* mesg) {
++  assert(mesg != NULL, "mesg must be specified");
++  if (!pd_commit_memory(addr, size, exec)) {
++    // add extra info in product mode for vm_exit_out_of_memory():
++    PRODUCT_ONLY(warn_fail_commit_memory(addr, size, exec, errno);)
++    vm_exit_out_of_memory(size, OOM_MMAP_ERROR, "%s", mesg);
++  }
++}
++
++void os::pd_commit_memory_or_exit(char* addr, size_t size,
++                                  size_t alignment_hint, bool exec,
++                                  const char* mesg) {
++  // alignment_hint is ignored on this OS
++  pd_commit_memory_or_exit(addr, size, exec, mesg);
++}
++
++void os::pd_realign_memory(char *addr, size_t bytes, size_t alignment_hint) {
++}
++
++void os::pd_free_memory(char *addr, size_t bytes, size_t alignment_hint) {
++  ::madvise(addr, bytes, MADV_DONTNEED);
++}
++
++void os::numa_make_global(char *addr, size_t bytes) {
++}
++
++void os::numa_make_local(char *addr, size_t bytes, int lgrp_hint) {
++}
++
++bool os::numa_topology_changed()   { return false; }
++
++size_t os::numa_get_groups_num() {
++  return 1;
++}
++
++int os::numa_get_group_id() {
++  return 0;
++}
++
++size_t os::numa_get_leaf_groups(int *ids, size_t size) {
++  if (size > 0) {
++    ids[0] = 0;
++    return 1;
++  }
++  return 0;
++}
++
++int os::numa_get_group_id_for_address(const void* address) {
++  return 0;
++}
++
++bool os::get_page_info(char *start, page_info* info) {
++  return false;
++}
++
++char *os::scan_pages(char *start, char* end, page_info* page_expected, page_info* page_found) {
++  return end;
++}
++
++
++bool os::pd_uncommit_memory(char* addr, size_t size, bool exec) {
++#if defined(__OpenBSD__)
++  // XXX: Work-around mmap/MAP_FIXED bug temporarily on OpenBSD
++  Events::log(NULL, "Protecting memory [" INTPTR_FORMAT "," INTPTR_FORMAT "] with PROT_NONE", p2i(addr), p2i(addr+size));
++  return ::mprotect(addr, size, PROT_NONE) == 0;
++#elif defined(__APPLE__)
++  if (exec) {
++    if (::madvise(addr, size, MADV_FREE) != 0) {
++      return false;
++    }
++    return ::mprotect(addr, size, PROT_NONE) == 0;
++  } else {
++    uintptr_t res = (uintptr_t) ::mmap(addr, size, PROT_NONE,
++        MAP_PRIVATE|MAP_FIXED|MAP_NORESERVE|MAP_ANONYMOUS, -1, 0);
++    return res  != (uintptr_t) MAP_FAILED;
++  }
++#else
++  uintptr_t res = (uintptr_t) ::mmap(addr, size, PROT_NONE,
++                                     MAP_PRIVATE|MAP_FIXED|MAP_NORESERVE|MAP_ANONYMOUS, -1, 0);
++  return res  != (uintptr_t) MAP_FAILED;
++#endif
++}
++
++bool os::pd_create_stack_guard_pages(char* addr, size_t size) {
++  return os::commit_memory(addr, size, !ExecMem);
++}
++
++// If this is a growable mapping, remove the guard pages entirely by
++// munmap()ping them.  If not, just call uncommit_memory().
++bool os::remove_stack_guard_pages(char* addr, size_t size) {
++  return os::uncommit_memory(addr, size);
++}
++
++// 'requested_addr' is only treated as a hint, the return value may or
++// may not start from the requested address. Unlike Bsd mmap(), this
++// function returns NULL to indicate failure.
++static char* anon_mmap(char* requested_addr, size_t bytes, bool exec) {
++  // MAP_FIXED is intentionally left out, to leave existing mappings intact.
++  const int flags = MAP_PRIVATE | MAP_NORESERVE | MAP_ANONYMOUS
++      MACOS_ONLY(| (exec ? MAP_JIT : 0));
++
++  // Map reserved/uncommitted pages PROT_NONE so we fail early if we
++  // touch an uncommitted page. Otherwise, the read/write might
++  // succeed if we have enough swap space to back the physical page.
++  char* addr = (char*)::mmap(requested_addr, bytes, PROT_NONE, flags, -1, 0);
++
++  return addr == MAP_FAILED ? NULL : addr;
++}
++
++static int anon_munmap(char * addr, size_t size) {
++  return ::munmap(addr, size) == 0;
++}
++
++char* os::pd_reserve_memory(size_t bytes, bool exec) {
++  return anon_mmap(NULL /* addr */, bytes, exec);
++}
++
++bool os::pd_release_memory(char* addr, size_t size) {
++  return anon_munmap(addr, size);
++}
++
++static bool bsd_mprotect(char* addr, size_t size, int prot) {
++  // Bsd wants the mprotect address argument to be page aligned.
++  char* bottom = (char*)align_down((intptr_t)addr, os::Serenity::page_size());
++
++  // According to SUSv3, mprotect() should only be used with mappings
++  // established by mmap(), and mmap() always maps whole pages. Unaligned
++  // 'addr' likely indicates problem in the VM (e.g. trying to change
++  // protection of malloc'ed or statically allocated memory). Check the
++  // caller if you hit this assert.
++  assert(addr == bottom, "sanity check");
++
++  size = align_up(pointer_delta(addr, bottom, 1) + size, os::Serenity::page_size());
++  Events::log(NULL, "Protecting memory [" INTPTR_FORMAT "," INTPTR_FORMAT "] with protection modes %x", p2i(bottom), p2i(bottom+size), prot);
++  return ::mprotect(bottom, size, prot) == 0;
++}
++
++// Set protections specified
++bool os::protect_memory(char* addr, size_t bytes, ProtType prot,
++                        bool is_committed) {
++  unsigned int p = 0;
++  switch (prot) {
++  case MEM_PROT_NONE: p = PROT_NONE; break;
++  case MEM_PROT_READ: p = PROT_READ; break;
++  case MEM_PROT_RW:   p = PROT_READ|PROT_WRITE; break;
++  case MEM_PROT_RWX:  p = PROT_READ|PROT_WRITE|PROT_EXEC; break;
++  default:
++    ShouldNotReachHere();
++  }
++  // is_committed is unused.
++  return bsd_mprotect(addr, bytes, p);
++}
++
++bool os::guard_memory(char* addr, size_t size) {
++  return bsd_mprotect(addr, size, PROT_NONE);
++}
++
++bool os::unguard_memory(char* addr, size_t size) {
++  return bsd_mprotect(addr, size, PROT_READ|PROT_WRITE);
++}
++
++bool os::Serenity::hugetlbfs_sanity_check(bool warn, size_t page_size) {
++  return false;
++}
++
++// Large page support
++
++static size_t _large_page_size = 0;
++
++void os::large_page_init() {
++}
++
++
++char* os::pd_reserve_memory_special(size_t bytes, size_t alignment, size_t page_size, char* req_addr, bool exec) {
++  fatal("os::reserve_memory_special should not be called on BSD.");
++  return NULL;
++}
++
++bool os::pd_release_memory_special(char* base, size_t bytes) {
++  fatal("os::release_memory_special should not be called on BSD.");
++  return false;
++}
++
++size_t os::large_page_size() {
++  return _large_page_size;
++}
++
++bool os::can_commit_large_page_memory() {
++  // Does not matter, we do not support huge pages.
++  return false;
++}
++
++bool os::can_execute_large_page_memory() {
++  // Does not matter, we do not support huge pages.
++  return false;
++}
++
++char* os::pd_attempt_map_memory_to_file_at(char* requested_addr, size_t bytes, int file_desc) {
++  assert(file_desc >= 0, "file_desc is not valid");
++  char* result = pd_attempt_reserve_memory_at(requested_addr, bytes, !ExecMem);
++  if (result != NULL) {
++    if (replace_existing_mapping_with_file_mapping(result, bytes, file_desc) == NULL) {
++      vm_exit_during_initialization(err_msg("Error in mapping Java heap at the given filesystem directory"));
++    }
++  }
++  return result;
++}
++
++// Reserve memory at an arbitrary address, only if that area is
++// available (and not reserved for something else).
++
++char* os::pd_attempt_reserve_memory_at(char* requested_addr, size_t bytes, bool exec) {
++  // Assert only that the size is a multiple of the page size, since
++  // that's all that mmap requires, and since that's all we really know
++  // about at this low abstraction level.  If we need higher alignment,
++  // we can either pass an alignment to this method or verify alignment
++  // in one of the methods further up the call chain.  See bug 5044738.
++  assert(bytes % os::vm_page_size() == 0, "reserving unexpected size block");
++
++  // Repeatedly allocate blocks until the block is allocated at the
++  // right spot.
++
++  // Bsd mmap allows caller to pass an address as hint; give it a try first,
++  // if kernel honors the hint then we can return immediately.
++  char * addr = anon_mmap(requested_addr, bytes, exec);
++  if (addr == requested_addr) {
++    return requested_addr;
++  }
++
++  if (addr != NULL) {
++    // mmap() is successful but it fails to reserve at the requested address
++    anon_munmap(addr, bytes);
++  }
++
++  return NULL;
++}
++
++// Sleep forever; naked call to OS-specific sleep; use with CAUTION
++void os::infinite_sleep() {
++  while (true) {    // sleep forever ...
++    ::sleep(100);   // ... 100 seconds at a time
++  }
++}
++
++// Used to convert frequent JVM_Yield() to nops
++bool os::dont_yield() {
++  return DontYieldALot;
++}
++
++void os::naked_yield() {
++  sched_yield();
++}
++
++////////////////////////////////////////////////////////////////////////////////
++// thread priority support
++
++// Note: Normal Bsd applications are run with SCHED_OTHER policy. SCHED_OTHER
++// only supports dynamic priority, static priority must be zero. For real-time
++// applications, Bsd supports SCHED_RR which allows static priority (1-99).
++// However, for large multi-threaded applications, SCHED_RR is not only slower
++// than SCHED_OTHER, but also very unstable (my volano tests hang hard 4 out
++// of 5 runs - Sep 2005).
++//
++// The following code actually changes the niceness of kernel-thread/LWP. It
++// has an assumption that setpriority() only modifies one kernel-thread/LWP,
++// not the entire user process, and user level threads are 1:1 mapped to kernel
++// threads. It has always been the case, but could change in the future. For
++// this reason, the code should not be used as default (ThreadPriorityPolicy=0).
++// It is only used when ThreadPriorityPolicy=1 and may require system level permission
++// (e.g., root privilege or CAP_SYS_NICE capability).
++
++#if !defined(__APPLE__)
++int os::java_to_os_priority[CriticalPriority + 1] = {
++  19,              // 0 Entry should never be used
++
++   0,              // 1 MinPriority
++   3,              // 2
++   6,              // 3
++
++  10,              // 4
++  15,              // 5 NormPriority
++  18,              // 6
++
++  21,              // 7
++  25,              // 8
++  28,              // 9 NearMaxPriority
++
++  31,              // 10 MaxPriority
++
++  31               // 11 CriticalPriority
++};
++#else
++// Using Mach high-level priority assignments
++int os::java_to_os_priority[CriticalPriority + 1] = {
++   0,              // 0 Entry should never be used (MINPRI_USER)
++
++  27,              // 1 MinPriority
++  28,              // 2
++  29,              // 3
++
++  30,              // 4
++  31,              // 5 NormPriority (BASEPRI_DEFAULT)
++  32,              // 6
++
++  33,              // 7
++  34,              // 8
++  35,              // 9 NearMaxPriority
++
++  36,              // 10 MaxPriority
++
++  36               // 11 CriticalPriority
++};
++#endif
++
++static int prio_init() {
++  if (ThreadPriorityPolicy == 1) {
++    if (geteuid() != 0) {
++      if (!FLAG_IS_DEFAULT(ThreadPriorityPolicy) && !FLAG_IS_JIMAGE_RESOURCE(ThreadPriorityPolicy)) {
++        warning("-XX:ThreadPriorityPolicy=1 may require system level permission, " \
++                "e.g., being the root user. If the necessary permission is not " \
++                "possessed, changes to priority will be silently ignored.");
++      }
++    }
++  }
++  if (UseCriticalJavaThreadPriority) {
++    os::java_to_os_priority[MaxPriority] = os::java_to_os_priority[CriticalPriority];
++  }
++  return 0;
++}
++
++OSReturn os::set_native_priority(Thread* thread, int newpri) {
++  if (!UseThreadPriorities || ThreadPriorityPolicy == 0) return OS_OK;
++
++#ifdef __OpenBSD__
++  // OpenBSD pthread_setprio starves low priority threads
++  return OS_OK;
++#elif defined(__FreeBSD__)
++  int ret = pthread_setprio(thread->osthread()->pthread_id(), newpri);
++  return (ret == 0) ? OS_OK : OS_ERR;
++#elif defined(__APPLE__) || defined(__NetBSD__)
++  struct sched_param sp;
++  int policy;
++
++  if (pthread_getschedparam(thread->osthread()->pthread_id(), &policy, &sp) != 0) {
++    return OS_ERR;
++  }
++
++  sp.sched_priority = newpri;
++  if (pthread_setschedparam(thread->osthread()->pthread_id(), policy, &sp) != 0) {
++    return OS_ERR;
++  }
++
++  return OS_OK;
++#else
++  int ret = setpriority(PRIO_PROCESS, thread->osthread()->thread_id(), newpri);
++  return (ret == 0) ? OS_OK : OS_ERR;
++#endif
++}
++
++OSReturn os::get_native_priority(const Thread* const thread, int *priority_ptr) {
++  if (!UseThreadPriorities || ThreadPriorityPolicy == 0) {
++    *priority_ptr = java_to_os_priority[NormPriority];
++    return OS_OK;
++  }
++
++  errno = 0;
++#if defined(__OpenBSD__) || defined(__FreeBSD__)
++  *priority_ptr = pthread_getprio(thread->osthread()->pthread_id());
++#elif defined(__APPLE__) || defined(__NetBSD__)
++  int policy;
++  struct sched_param sp;
++
++  int res = pthread_getschedparam(thread->osthread()->pthread_id(), &policy, &sp);
++  if (res != 0) {
++    *priority_ptr = -1;
++    return OS_ERR;
++  } else {
++    *priority_ptr = sp.sched_priority;
++    return OS_OK;
++  }
++#else
++  *priority_ptr = getpriority(PRIO_PROCESS, thread->osthread()->thread_id());
++#endif
++  return (*priority_ptr != -1 || errno == 0 ? OS_OK : OS_ERR);
++}
++
++extern void report_error(char* file_name, int line_no, char* title,
++                         char* format, ...);
++
++// this is called _before_ the most of global arguments have been parsed
++void os::init(void) {
++  char dummy;   // used to get a guess on initial stack address
++
++  clock_tics_per_sec = sysconf(_SC_CLK_TCK);
++
++  Serenity::set_page_size(sysconf(_SC_PAGESIZE));
++  if (Serenity::page_size() == -1) {
++    fatal("os_serenity.cpp: os::init: sysconf failed (%s)",
++          os::strerror(errno));
++  }
++  _page_sizes.add(Serenity::page_size());
++
++  Serenity::initialize_system_info();
++
++  // _main_thread points to the thread that created/loaded the JVM.
++  Serenity::_main_thread = pthread_self();
++
++  os::Posix::init();
++
++  initial_time_count = javaTimeNanos();
++}
++
++// To install functions for atexit system call
++extern "C" {
++  static void perfMemory_exit_helper() {
++    perfMemory_exit();
++  }
++}
++
++// this is called _after_ the global arguments have been parsed
++jint os::init_2(void) {
++
++  // This could be set after os::Posix::init() but all platforms
++  // have to set it the same so we have to mirror Solaris.
++  DEBUG_ONLY(os::set_mutex_init_done();)
++
++  os::Posix::init_2();
++
++  if (PosixSignals::init() == JNI_ERR) {
++    return JNI_ERR;
++  }
++
++  // Check and sets minimum stack sizes against command line options
++  if (Posix::set_minimum_stack_sizes() == JNI_ERR) {
++    return JNI_ERR;
++  }
++
++  // Not supported.
++  FLAG_SET_ERGO(UseNUMA, false);
++  FLAG_SET_ERGO(UseNUMAInterleaving, false);
++
++  if (MaxFDLimit) {
++    // set the number of file descriptors to max. print out error
++    // if getrlimit/setrlimit fails but continue regardless.
++    struct rlimit nbr_files;
++    int status = getrlimit(RLIMIT_NOFILE, &nbr_files);
++    if (status != 0) {
++      log_info(os)("os::init_2 getrlimit failed: %s", os::strerror(errno));
++    } else {
++      nbr_files.rlim_cur = nbr_files.rlim_max;
++
++#ifdef __APPLE__
++      // Darwin returns RLIM_INFINITY for rlim_max, but fails with EINVAL if
++      // you attempt to use RLIM_INFINITY. As per setrlimit(2), OPEN_MAX must
++      // be used instead
++      nbr_files.rlim_cur = MIN(OPEN_MAX, nbr_files.rlim_cur);
++#endif
++
++      status = setrlimit(RLIMIT_NOFILE, &nbr_files);
++      if (status != 0) {
++        log_info(os)("os::init_2 setrlimit failed: %s", os::strerror(errno));
++      }
++    }
++  }
++
++  // at-exit methods are called in the reverse order of their registration.
++  // atexit functions are called on return from main or as a result of a
++  // call to exit(3C). There can be only 32 of these functions registered
++  // and atexit() does not set errno.
++
++  if (PerfAllowAtExitRegistration) {
++    // only register atexit functions if PerfAllowAtExitRegistration is set.
++    // atexit functions can be delayed until process exit time, which
++    // can be problematic for embedded VM situations. Embedded VMs should
++    // call DestroyJavaVM() to assure that VM resources are released.
++
++    // note: perfMemory_exit_helper atexit function may be removed in
++    // the future if the appropriate cleanup code can be added to the
++    // VM_Exit VMOperation's doit method.
++    if (atexit(perfMemory_exit_helper) != 0) {
++      warning("os::init_2 atexit(perfMemory_exit_helper) failed");
++    }
++  }
++
++  // initialize thread priority policy
++  prio_init();
++
++#ifdef __APPLE__
++  // dynamically link to objective c gc registration
++  void *handleLibObjc = dlopen(OBJC_LIB, RTLD_LAZY);
++  if (handleLibObjc != NULL) {
++    objc_registerThreadWithCollectorFunction = (objc_registerThreadWithCollector_t) dlsym(handleLibObjc, OBJC_GCREGISTER);
++  }
++#endif
++
++  return JNI_OK;
++}
++
++int os::active_processor_count() {
++  // User has overridden the number of active processors
++  if (ActiveProcessorCount > 0) {
++    log_trace(os)("active_processor_count: "
++                  "active processor count set by user : %d",
++                  ActiveProcessorCount);
++    return ActiveProcessorCount;
++  }
++
++  return _processor_count;
++}
++
++uint os::processor_id() {
++#if defined(__APPLE__) && defined(__x86_64__)
++  // Get the initial APIC id and return the associated processor id. The initial APIC
++  // id is limited to 8-bits, which means we can have at most 256 unique APIC ids. If
++  // the system has more processors (or the initial APIC ids are discontiguous) the
++  // APIC id will be truncated and more than one processor will potentially share the
++  // same processor id. This is not optimal, but unlikely to happen in practice. Should
++  // this become a real problem we could switch to using x2APIC ids, which are 32-bit
++  // wide. However, note that x2APIC is Intel-specific, and the wider number space
++  // would require a more complicated mapping approach.
++  uint eax = 0x1;
++  uint ebx;
++  uint ecx = 0;
++  uint edx;
++
++  __asm__ ("cpuid\n\t" : "+a" (eax), "+b" (ebx), "+c" (ecx), "+d" (edx) : );
++
++  uint apic_id = (ebx >> 24) & (processor_id_map_size - 1);
++  int processor_id = Atomic::load(&processor_id_map[apic_id]);
++
++  while (processor_id < 0) {
++    // Assign processor id to APIC id
++    processor_id = Atomic::cmpxchg(&processor_id_map[apic_id], processor_id_unassigned, processor_id_assigning);
++    if (processor_id == processor_id_unassigned) {
++      processor_id = Atomic::fetch_and_add(&processor_id_next, 1) % os::processor_count();
++      Atomic::store(&processor_id_map[apic_id], processor_id);
++    }
++  }
++
++  assert(processor_id >= 0 && processor_id < os::processor_count(), "invalid processor id");
++
++  return (uint)processor_id;
++#else // defined(__APPLE__) && defined(__x86_64__)
++  // Return 0 until we find a good way to get the current processor id on
++  // the platform. Returning 0 is safe, since there is always at least one
++  // processor, but might not be optimal for performance in some cases.
++  return 0;
++#endif
++}
++
++void os::set_native_thread_name(const char *name) {
++#if defined(__APPLE__) && MAC_OS_X_VERSION_MIN_REQUIRED > MAC_OS_X_VERSION_10_5
++  // This is only supported in Snow Leopard and beyond
++  if (name != NULL) {
++    // Add a "Java: " prefix to the name
++    char buf[MAXTHREADNAMESIZE];
++    snprintf(buf, sizeof(buf), "Java: %s", name);
++    pthread_setname_np(buf);
++  }
++#endif
++}
++
++bool os::bind_to_processor(uint processor_id) {
++  // Not yet implemented.
++  return false;
++}
++
++////////////////////////////////////////////////////////////////////////////////
++// debug support
++
++bool os::find(address addr, outputStream* st) {
++  Dl_info dlinfo;
++  memset(&dlinfo, 0, sizeof(dlinfo));
++  if (dladdr(addr, &dlinfo) != 0) {
++    st->print(INTPTR_FORMAT ": ", (intptr_t)addr);
++    if (dlinfo.dli_sname != NULL && dlinfo.dli_saddr != NULL) {
++      st->print("%s+%#x", dlinfo.dli_sname,
++                (uint)((uintptr_t)addr - (uintptr_t)dlinfo.dli_saddr));
++    } else if (dlinfo.dli_fbase != NULL) {
++      st->print("<offset %#x>", (uint)((uintptr_t)addr - (uintptr_t)dlinfo.dli_fbase));
++    } else {
++      st->print("<absolute address>");
++    }
++    if (dlinfo.dli_fname != NULL) {
++      st->print(" in %s", dlinfo.dli_fname);
++    }
++    if (dlinfo.dli_fbase != NULL) {
++      st->print(" at " INTPTR_FORMAT, (intptr_t)dlinfo.dli_fbase);
++    }
++    st->cr();
++
++    if (Verbose) {
++      // decode some bytes around the PC
++      address begin = clamp_address_in_page(addr-40, addr, os::vm_page_size());
++      address end   = clamp_address_in_page(addr+40, addr, os::vm_page_size());
++      address       lowest = (address) dlinfo.dli_sname;
++      if (!lowest)  lowest = (address) dlinfo.dli_fbase;
++      if (begin < lowest)  begin = lowest;
++      Dl_info dlinfo2;
++      if (dladdr(end, &dlinfo2) != 0 && dlinfo2.dli_saddr != dlinfo.dli_saddr
++          && end > dlinfo2.dli_saddr && dlinfo2.dli_saddr > begin) {
++        end = (address) dlinfo2.dli_saddr;
++      }
++      Disassembler::decode(begin, end, st);
++    }
++    return true;
++  }
++  return false;
++}
++
++////////////////////////////////////////////////////////////////////////////////
++// misc
++
++// This does not do anything on Bsd. This is basically a hook for being
++// able to use structured exception handling (thread-local exception filters)
++// on, e.g., Win32.
++void os::os_exception_wrapper(java_call_t f, JavaValue* value,
++                              const methodHandle& method, JavaCallArguments* args,
++                              JavaThread* thread) {
++  f(value, method, args, thread);
++}
++
++void os::print_statistics() {
++}
++
++bool os::message_box(const char* title, const char* message) {
++  int i;
++  fdStream err(defaultStream::error_fd());
++  for (i = 0; i < 78; i++) err.print_raw("=");
++  err.cr();
++  err.print_raw_cr(title);
++  for (i = 0; i < 78; i++) err.print_raw("-");
++  err.cr();
++  err.print_raw_cr(message);
++  for (i = 0; i < 78; i++) err.print_raw("=");
++  err.cr();
++
++  char buf[16];
++  // Prevent process from exiting upon "read error" without consuming all CPU
++  while (::read(0, buf, sizeof(buf)) <= 0) { ::sleep(100); }
++
++  return buf[0] == 'y' || buf[0] == 'Y';
++}
++
++static inline struct timespec get_mtime(const char* filename) {
++  struct stat st;
++  int ret = os::stat(filename, &st);
++  assert(ret == 0, "failed to stat() file '%s': %s", filename, os::strerror(errno));
++#ifdef __APPLE__
++  return st.st_mtimespec;
++#else
++  return st.st_mtim;
++#endif
++}
++
++int os::compare_file_modified_times(const char* file1, const char* file2) {
++  struct timespec filetime1 = get_mtime(file1);
++  struct timespec filetime2 = get_mtime(file2);
++  int diff = filetime1.tv_sec - filetime2.tv_sec;
++  if (diff == 0) {
++    return filetime1.tv_nsec - filetime2.tv_nsec;
++  }
++  return diff;
++}
++
++// Is a (classpath) directory empty?
++bool os::dir_is_empty(const char* path) {
++  DIR *dir = NULL;
++  struct dirent *ptr;
++
++  dir = opendir(path);
++  if (dir == NULL) return true;
++
++  // Scan the directory
++  bool result = true;
++  while (result && (ptr = readdir(dir)) != NULL) {
++    if (strcmp(ptr->d_name, ".") != 0 && strcmp(ptr->d_name, "..") != 0) {
++      result = false;
++    }
++  }
++  closedir(dir);
++  return result;
++}
++
++// This code originates from JDK's sysOpen and open64_w
++// from src/solaris/hpi/src/system_md.c
++
++int os::open(const char *path, int oflag, int mode) {
++  if (strlen(path) > MAX_PATH - 1) {
++    errno = ENAMETOOLONG;
++    return -1;
++  }
++  int fd;
++
++  fd = ::open(path, oflag, mode);
++  if (fd == -1) return -1;
++
++  // If the open succeeded, the file might still be a directory
++  {
++    struct stat buf;
++    int ret = ::fstat(fd, &buf);
++    int st_mode = buf.st_mode;
++
++    if (ret != -1) {
++      if ((st_mode & S_IFMT) == S_IFDIR) {
++        errno = EISDIR;
++        ::close(fd);
++        return -1;
++      }
++    } else {
++      ::close(fd);
++      return -1;
++    }
++  }
++
++  // All file descriptors that are opened in the JVM and not
++  // specifically destined for a subprocess should have the
++  // close-on-exec flag set.  If we don't set it, then careless 3rd
++  // party native code might fork and exec without closing all
++  // appropriate file descriptors (e.g. as we do in closeDescriptors in
++  // UNIXProcess.c), and this in turn might:
++  //
++  // - cause end-of-file to fail to be detected on some file
++  //   descriptors, resulting in mysterious hangs, or
++  //
++  // - might cause an fopen in the subprocess to fail on a system
++  //   suffering from bug 1085341.
++  //
++  // (Yes, the default setting of the close-on-exec flag is a Unix
++  // design flaw)
++  //
++  // See:
++  // 1085341: 32-bit stdio routines should support file descriptors >255
++  // 4843136: (process) pipe file descriptor from Runtime.exec not being closed
++  // 6339493: (process) Runtime.exec does not close all file descriptors on Solaris 9
++  //
++#ifdef FD_CLOEXEC
++  {
++    int flags = ::fcntl(fd, F_GETFD);
++    if (flags != -1) {
++      ::fcntl(fd, F_SETFD, flags | FD_CLOEXEC);
++    }
++  }
++#endif
++
++  return fd;
++}
++
++
++// create binary file, rewriting existing file if required
++int os::create_binary_file(const char* path, bool rewrite_existing) {
++  int oflags = O_WRONLY | O_CREAT;
++  if (!rewrite_existing) {
++    oflags |= O_EXCL;
++  }
++  return ::open(path, oflags, S_IREAD | S_IWRITE);
++}
++
++// return current position of file pointer
++jlong os::current_file_offset(int fd) {
++  return (jlong)::lseek(fd, (off_t)0, SEEK_CUR);
++}
++
++// move file pointer to the specified offset
++jlong os::seek_to_file_offset(int fd, jlong offset) {
++  return (jlong)::lseek(fd, (off_t)offset, SEEK_SET);
++}
++
++// This code originates from JDK's sysAvailable
++// from src/solaris/hpi/src/native_threads/src/sys_api_td.c
++
++int os::available(int fd, jlong *bytes) {
++  jlong cur, end;
++  int mode;
++  struct stat buf;
++
++  if (::fstat(fd, &buf) >= 0) {
++    mode = buf.st_mode;
++    if (S_ISCHR(mode) || S_ISFIFO(mode) || S_ISSOCK(mode)) {
++      int n;
++      if (::ioctl(fd, FIONREAD, &n) >= 0) {
++        *bytes = n;
++        return 1;
++      }
++    }
++  }
++  if ((cur = ::lseek(fd, 0L, SEEK_CUR)) == -1) {
++    return 0;
++  } else if ((end = ::lseek(fd, 0L, SEEK_END)) == -1) {
++    return 0;
++  } else if (::lseek(fd, cur, SEEK_SET) == -1) {
++    return 0;
++  }
++  *bytes = end - cur;
++  return 1;
++}
++
++// Map a block of memory.
++char* os::pd_map_memory(int fd, const char* file_name, size_t file_offset,
++                        char *addr, size_t bytes, bool read_only,
++                        bool allow_exec) {
++  int prot;
++  int flags;
++
++  if (read_only) {
++    prot = PROT_READ;
++    flags = MAP_SHARED;
++  } else {
++    prot = PROT_READ | PROT_WRITE;
++    flags = MAP_PRIVATE;
++  }
++
++  if (allow_exec) {
++    prot |= PROT_EXEC;
++  }
++
++  if (addr != NULL) {
++    flags |= MAP_FIXED;
++  }
++
++  char* mapped_address = (char*)mmap(addr, (size_t)bytes, prot, flags,
++                                     fd, file_offset);
++  if (mapped_address == MAP_FAILED) {
++    return NULL;
++  }
++  return mapped_address;
++}
++
++
++// Remap a block of memory.
++char* os::pd_remap_memory(int fd, const char* file_name, size_t file_offset,
++                          char *addr, size_t bytes, bool read_only,
++                          bool allow_exec) {
++  // same as map_memory() on this OS
++  return os::map_memory(fd, file_name, file_offset, addr, bytes, read_only,
++                        allow_exec);
++}
++
++
++// Unmap a block of memory.
++bool os::pd_unmap_memory(char* addr, size_t bytes) {
++  return munmap(addr, bytes) == 0;
++}
++
++// current_thread_cpu_time(bool) and thread_cpu_time(Thread*, bool)
++// are used by JVM M&M and JVMTI to get user+sys or user CPU time
++// of a thread.
++//
++// current_thread_cpu_time() and thread_cpu_time(Thread*) returns
++// the fast estimate available on the platform.
++
++jlong os::current_thread_cpu_time() {
++#ifdef __APPLE__
++  return os::thread_cpu_time(Thread::current(), true /* user + sys */);
++#else
++  Unimplemented();
++  return 0;
++#endif
++}
++
++jlong os::thread_cpu_time(Thread* thread) {
++#ifdef __APPLE__
++  return os::thread_cpu_time(thread, true /* user + sys */);
++#else
++  Unimplemented();
++  return 0;
++#endif
++}
++
++jlong os::current_thread_cpu_time(bool user_sys_cpu_time) {
++#ifdef __APPLE__
++  return os::thread_cpu_time(Thread::current(), user_sys_cpu_time);
++#else
++  Unimplemented();
++  return 0;
++#endif
++}
++
++jlong os::thread_cpu_time(Thread *thread, bool user_sys_cpu_time) {
++#ifdef __APPLE__
++  struct thread_basic_info tinfo;
++  mach_msg_type_number_t tcount = THREAD_INFO_MAX;
++  kern_return_t kr;
++  thread_t mach_thread;
++
++  mach_thread = thread->osthread()->thread_id();
++  kr = thread_info(mach_thread, THREAD_BASIC_INFO, (thread_info_t)&tinfo, &tcount);
++  if (kr != KERN_SUCCESS) {
++    return -1;
++  }
++
++  if (user_sys_cpu_time) {
++    jlong nanos;
++    nanos = ((jlong) tinfo.system_time.seconds + tinfo.user_time.seconds) * (jlong)1000000000;
++    nanos += ((jlong) tinfo.system_time.microseconds + (jlong) tinfo.user_time.microseconds) * (jlong)1000;
++    return nanos;
++  } else {
++    return ((jlong)tinfo.user_time.seconds * 1000000000) + ((jlong)tinfo.user_time.microseconds * (jlong)1000);
++  }
++#else
++  Unimplemented();
++  return 0;
++#endif
++}
++
++
++void os::current_thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
++  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
++  info_ptr->may_skip_backward = false;     // elapsed time not wall time
++  info_ptr->may_skip_forward = false;      // elapsed time not wall time
++  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
++}
++
++void os::thread_cpu_time_info(jvmtiTimerInfo *info_ptr) {
++  info_ptr->max_value = ALL_64_BITS;       // will not wrap in less than 64 bits
++  info_ptr->may_skip_backward = false;     // elapsed time not wall time
++  info_ptr->may_skip_forward = false;      // elapsed time not wall time
++  info_ptr->kind = JVMTI_TIMER_TOTAL_CPU;  // user+system time is returned
++}
++
++bool os::is_thread_cpu_time_supported() {
++#ifdef __APPLE__
++  return true;
++#else
++  return false;
++#endif
++}
++
++// System loadavg support.  Returns -1 if load average cannot be obtained.
++// Bsd doesn't yet have a (official) notion of processor sets,
++// so just return the system wide load average.
++int os::loadavg(double loadavg[], int nelem) {
++  //return ::getloadavg(loadavg, nelem);
++  return 0; //FIXME
++}
++
++void os::pause() {
++  char filename[MAX_PATH];
++  if (PauseAtStartupFile && PauseAtStartupFile[0]) {
++    jio_snprintf(filename, MAX_PATH, "%s", PauseAtStartupFile);
++  } else {
++    jio_snprintf(filename, MAX_PATH, "./vm.paused.%d", current_process_id());
++  }
++
++  int fd = ::open(filename, O_WRONLY | O_CREAT | O_TRUNC, 0666);
++  if (fd != -1) {
++    struct stat buf;
++    ::close(fd);
++    while (::stat(filename, &buf) == 0) {
++      (void)::poll(NULL, 0, 100);
++    }
++  } else {
++    jio_fprintf(stderr,
++                "Could not open pause file '%s', continuing immediately.\n", filename);
++  }
++}
++
++// Get the kern.corefile setting, or otherwise the default path to the core file
++// Returns the length of the string
++int os::get_core_path(char* buffer, size_t bufferSize) {
++  int n = 0;
++#ifdef __APPLE__
++  char coreinfo[MAX_PATH];
++  size_t sz = sizeof(coreinfo);
++  int ret = sysctlbyname("kern.corefile", coreinfo, &sz, NULL, 0);
++  if (ret == 0) {
++    char *pid_pos = strstr(coreinfo, "%P");
++    // skip over the "%P" to preserve any optional custom user pattern
++    const char* tail = (pid_pos != NULL) ? (pid_pos + 2) : "";
++
++    if (pid_pos != NULL) {
++      *pid_pos = '\0';
++      n = jio_snprintf(buffer, bufferSize, "%s%d%s", coreinfo, os::current_process_id(), tail);
++    } else {
++      n = jio_snprintf(buffer, bufferSize, "%s", coreinfo);
++    }
++  } else
++#endif
++  {
++    n = jio_snprintf(buffer, bufferSize, "/cores/core.%d", os::current_process_id());
++  }
++  // Truncate if theoretical string was longer than bufferSize
++  n = MIN2(n, (int)bufferSize);
++
++  return n;
++}
++
++bool os::supports_map_sync() {
++  return false;
++}
++
++bool os::start_debugging(char *buf, int buflen) {
++  int len = (int)strlen(buf);
++  char *p = &buf[len];
++
++  jio_snprintf(p, buflen-len,
++             "\n\n"
++             "Do you want to debug the problem?\n\n"
++             "To debug, run 'gdb /proc/%d/exe %d'; then switch to thread " INTX_FORMAT " (" INTPTR_FORMAT ")\n"
++             "Enter 'yes' to launch gdb automatically (PATH must include gdb)\n"
++             "Otherwise, press RETURN to abort...",
++             os::current_process_id(), os::current_process_id(),
++             os::current_thread_id(), os::current_thread_id());
++
++  bool yes = os::message_box("Unexpected Error", buf);
++
++  if (yes) {
++    // yes, user asked VM to launch debugger
++    jio_snprintf(buf, sizeof(buf), "gdb /proc/%d/exe %d",
++                     os::current_process_id(), os::current_process_id());
++
++    os::fork_and_exec(buf);
++    yes = false;
++  }
++  return yes;
++}
++
++void os::print_memory_mappings(char* addr, size_t bytes, outputStream* st) {}
+diff --git a/src/hotspot/os/serenity/os_serenity.hpp b/src/hotspot/os/serenity/os_serenity.hpp
+new file mode 100644
+index 000000000..d4e85068f
+--- /dev/null
++++ b/src/hotspot/os/serenity/os_serenity.hpp
+@@ -0,0 +1,115 @@
++/*
++ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_OS_SERENITY_HPP
++#define OS_SERENITY_OS_SERENITY_HPP
++
++// Serenity_OS defines the interface to Serenity operating systems
++
++// Information about the protection of the page at address '0' on this os.
++static bool zero_page_read_protected() { return true; }
++
++class Serenity {
++  friend class os;
++
++  static GrowableArray<int>* _cpu_to_node;
++
++ protected:
++
++  static julong _physical_memory;
++  static pthread_t _main_thread;
++  static int _page_size;
++
++  static julong available_memory();
++  static julong physical_memory() { return _physical_memory; }
++  static void initialize_system_info();
++
++  static void rebuild_cpu_to_node_map();
++  static GrowableArray<int>* cpu_to_node()    { return _cpu_to_node; }
++
++  static bool hugetlbfs_sanity_check(bool warn, size_t page_size);
++
++ public:
++
++  static void init_thread_fpu_state();
++  static pthread_t main_thread(void)                                { return _main_thread; }
++
++  static pid_t gettid();
++
++  static int page_size(void)                                        { return _page_size; }
++  static void set_page_size(int val)                                { _page_size = val; }
++
++  // static bool get_frame_at_stack_banging_point(JavaThread* thread, ucontext_t* uc, frame* fr);
++
++  // Real-time clock functions
++  static void clock_init(void);
++
++  // Stack repair handling
++
++  // none present
++
++ private:
++  typedef int (*sched_getcpu_func_t)(void);
++  typedef int (*numa_node_to_cpus_func_t)(int node, unsigned long *buffer, int bufferlen);
++  typedef int (*numa_max_node_func_t)(void);
++  typedef int (*numa_available_func_t)(void);
++  typedef int (*numa_tonode_memory_func_t)(void *start, size_t size, int node);
++  typedef void (*numa_interleave_memory_func_t)(void *start, size_t size, unsigned long *nodemask);
++
++  static sched_getcpu_func_t _sched_getcpu;
++  static numa_node_to_cpus_func_t _numa_node_to_cpus;
++  static numa_max_node_func_t _numa_max_node;
++  static numa_available_func_t _numa_available;
++  static numa_tonode_memory_func_t _numa_tonode_memory;
++  static numa_interleave_memory_func_t _numa_interleave_memory;
++  static unsigned long* _numa_all_nodes;
++
++  static void set_sched_getcpu(sched_getcpu_func_t func) { _sched_getcpu = func; }
++  static void set_numa_node_to_cpus(numa_node_to_cpus_func_t func) { _numa_node_to_cpus = func; }
++  static void set_numa_max_node(numa_max_node_func_t func) { _numa_max_node = func; }
++  static void set_numa_available(numa_available_func_t func) { _numa_available = func; }
++  static void set_numa_tonode_memory(numa_tonode_memory_func_t func) { _numa_tonode_memory = func; }
++  static void set_numa_interleave_memory(numa_interleave_memory_func_t func) { _numa_interleave_memory = func; }
++  static void set_numa_all_nodes(unsigned long* ptr) { _numa_all_nodes = ptr; }
++ public:
++  static int sched_getcpu()  { return _sched_getcpu != NULL ? _sched_getcpu() : -1; }
++  static int numa_node_to_cpus(int node, unsigned long *buffer, int bufferlen) {
++    return _numa_node_to_cpus != NULL ? _numa_node_to_cpus(node, buffer, bufferlen) : -1;
++  }
++  static int numa_max_node() { return _numa_max_node != NULL ? _numa_max_node() : -1; }
++  static int numa_available() { return _numa_available != NULL ? _numa_available() : -1; }
++  static int numa_tonode_memory(void *start, size_t size, int node) {
++    return _numa_tonode_memory != NULL ? _numa_tonode_memory(start, size, node) : -1;
++  }
++  static void numa_interleave_memory(void *start, size_t size) {
++    if (_numa_interleave_memory != NULL && _numa_all_nodes != NULL) {
++      _numa_interleave_memory(start, size, _numa_all_nodes);
++    }
++  }
++  static int get_node_by_cpu(int cpu_id);
++
++  static void print_uptime_info(outputStream* st);
++};
++
++#endif // OS_SERENITY_OS_SERENITY_HPP
+diff --git a/src/hotspot/os/serenity/os_serenity.inline.hpp b/src/hotspot/os/serenity/os_serenity.inline.hpp
+new file mode 100644
+index 000000000..26ae2f6d4
+--- /dev/null
++++ b/src/hotspot/os/serenity/os_serenity.inline.hpp
+@@ -0,0 +1,54 @@
++/*
++ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_OS_SERENITY_INLINE_HPP
++#define OS_SERENITY_OS_SERENITY_INLINE_HPP
++
++// os_bsd.hpp included by os.hpp
++
++#include "runtime/os.hpp"
++#include "os_posix.inline.hpp"
++
++inline bool os::uses_stack_guard_pages() {
++  return true;
++}
++
++inline bool os::must_commit_stack_guard_pages() {
++  assert(uses_stack_guard_pages(), "sanity check");
++#if !defined(__FreeBSD__) || __FreeBSD__ < 5
++  // Since FreeBSD 4 uses malloc() for allocating the thread stack
++  // there is no need to do anything extra to allocate the guard pages
++  return false;
++#else
++  // FreeBSD 5+ uses mmap MAP_STACK for allocating the thread stacks.
++  // Must 'allocate' them or guard pages are ignored.
++  return true;
++#endif
++}
++
++// Bang the shadow pages if they need to be touched to be mapped.
++inline void os::map_stack_shadow_pages(address sp) {
++}
++
++#endif // OS_SERENITY_OS_SERENITY_INLINE_HPP
+diff --git a/src/hotspot/os/serenity/os_share_serenity.hpp b/src/hotspot/os/serenity/os_share_serenity.hpp
+new file mode 100644
+index 000000000..bc752ccf2
+--- /dev/null
++++ b/src/hotspot/os/serenity/os_share_serenity.hpp
+@@ -0,0 +1,36 @@
++/*
++ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_OS_SHARE_SERENITY_HPP
++#define OS_SERENITY_OS_SHARE_SERENITY_HPP
++
++// misc
++void handle_unexpected_exception(Thread* thread, int sig, siginfo_t* info, address pc, address adjusted_pc);
++#ifndef PRODUCT
++void continue_with_dump(void);
++#endif
++
++#define PROCFILE_LENGTH 128
++
++#endif // OS_SERENITY_OS_SHARE_SERENITY_HPP
+diff --git a/src/hotspot/os/serenity/semaphore_serenity.cpp b/src/hotspot/os/serenity/semaphore_serenity.cpp
+new file mode 100644
+index 000000000..584b1115c
+--- /dev/null
++++ b/src/hotspot/os/serenity/semaphore_serenity.cpp
+@@ -0,0 +1,30 @@
++/*
++ * Copyright (c) 2018, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "semaphore_serenity.hpp"
++#include "runtime/os.hpp"
++#include "utilities/debug.hpp"
++
++#include <semaphore.h>
+diff --git a/src/hotspot/os/serenity/semaphore_serenity.hpp b/src/hotspot/os/serenity/semaphore_serenity.hpp
+new file mode 100644
+index 000000000..4764d2105
+--- /dev/null
++++ b/src/hotspot/os/serenity/semaphore_serenity.hpp
+@@ -0,0 +1,32 @@
++/*
++ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_SEMAPHORE_SERENITY_HPP
++#define OS_SERENITY_SEMAPHORE_SERENITY_HPP
++
++#include "utilities/globalDefinitions.hpp"
++
++# include "semaphore_posix.hpp"
++
++#endif // OS_SERENITY_SEMAPHORE_SERENITY_HPP
+diff --git a/src/hotspot/os/serenity/threadCritical_serenity.cpp b/src/hotspot/os/serenity/threadCritical_serenity.cpp
+new file mode 100644
+index 000000000..71c51df59
+--- /dev/null
++++ b/src/hotspot/os/serenity/threadCritical_serenity.cpp
+@@ -0,0 +1,61 @@
++/*
++ * Copyright (c) 2001, 2010, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "runtime/thread.inline.hpp"
++#include "runtime/threadCritical.hpp"
++
++// put OS-includes here
++# include <pthread.h>
++
++//
++// See threadCritical.hpp for details of this class.
++//
++
++static pthread_t             tc_owner = 0;
++static pthread_mutex_t       tc_mutex = PTHREAD_MUTEX_INITIALIZER;
++static int                   tc_count = 0;
++
++ThreadCritical::ThreadCritical() {
++  pthread_t self = pthread_self();
++  if (self != tc_owner) {
++    int ret = pthread_mutex_lock(&tc_mutex);
++    guarantee(ret == 0, "fatal error with pthread_mutex_lock()");
++    assert(tc_count == 0, "Lock acquired with illegal reentry count.");
++    tc_owner = self;
++  }
++  tc_count++;
++}
++
++ThreadCritical::~ThreadCritical() {
++  assert(tc_owner == pthread_self(), "must have correct owner");
++  assert(tc_count > 0, "must have correct count");
++
++  tc_count--;
++  if (tc_count == 0) {
++    tc_owner = 0;
++    int ret = pthread_mutex_unlock(&tc_mutex);
++    guarantee(ret == 0, "fatal error with pthread_mutex_unlock()");
++  }
++}
+diff --git a/src/hotspot/os/serenity/vmStructs_serenity.hpp b/src/hotspot/os/serenity/vmStructs_serenity.hpp
+new file mode 100644
+index 000000000..73d6adbdb
+--- /dev/null
++++ b/src/hotspot/os/serenity/vmStructs_serenity.hpp
+@@ -0,0 +1,45 @@
++/*
++ * Copyright (c) 2015, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_SERENITY_VMSTRUCTS_SERENITY_HPP
++#define OS_SERENITY_VMSTRUCTS_SERENITY_HPP
++
++#include <dlfcn.h>
++
++// These are the OS-specific fields, types and integer
++// constants required by the Serviceability Agent. This file is
++// referenced by vmStructs.cpp.
++
++#define VM_STRUCTS_OS(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field)
++
++#define VM_TYPES_OS(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type, declare_c1_toplevel_type, declare_c2_type, declare_c2_toplevel_type)
++
++#define VM_INT_CONSTANTS_OS(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
++
++#define VM_LONG_CONSTANTS_OS(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
++
++#define VM_ADDRESSES_OS(declare_address, declare_preprocessor_address, declare_function) \
++  declare_preprocessor_address("RTLD_DEFAULT", RTLD_DEFAULT)
++
++#endif // OS_SERENITY_VMSTRUCTS_SERENITY_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/assembler_serenity_x86.cpp b/src/hotspot/os_cpu/serenity_x86/assembler_serenity_x86.cpp
+new file mode 100644
+index 000000000..dd20ea833
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/assembler_serenity_x86.cpp
+@@ -0,0 +1,32 @@
++/*
++ * Copyright (c) 1999, 2015, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "asm/macroAssembler.hpp"
++#include "asm/macroAssembler.inline.hpp"
++#include "runtime/os.hpp"
++
++void MacroAssembler::int3() {
++  call(RuntimeAddress(CAST_FROM_FN_PTR(address, os::breakpoint)));
++}
+diff --git a/src/hotspot/os_cpu/serenity_x86/atomic_serenity_x86.hpp b/src/hotspot/os_cpu/serenity_x86/atomic_serenity_x86.hpp
+new file mode 100644
+index 000000000..0e2f153b3
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/atomic_serenity_x86.hpp
+@@ -0,0 +1,225 @@
++/*
++ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_ATOMIC_SERENITY_X86_HPP
++#define OS_CPU_SERENITY_X86_ATOMIC_SERENITY_X86_HPP
++
++// Implementation of class atomic
++
++template<size_t byte_size>
++struct Atomic::PlatformAdd {
++  template<typename D, typename I>
++  D fetch_and_add(D volatile* dest, I add_value, atomic_memory_order /* order */) const;
++
++  template<typename D, typename I>
++  D add_and_fetch(D volatile* dest, I add_value, atomic_memory_order order) const {
++    return fetch_and_add(dest, add_value, order) + add_value;
++  }
++};
++
++template<>
++template<typename D, typename I>
++inline D Atomic::PlatformAdd<4>::fetch_and_add(D volatile* dest, I add_value,
++                                               atomic_memory_order /* order */) const {
++  STATIC_ASSERT(4 == sizeof(I));
++  STATIC_ASSERT(4 == sizeof(D));
++  D old_value;
++  __asm__ volatile (  "lock xaddl %0,(%2)"
++                    : "=r" (old_value)
++                    : "0" (add_value), "r" (dest)
++                    : "cc", "memory");
++  return old_value;
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
++                                             T exchange_value,
++                                             atomic_memory_order /* order */) const {
++  STATIC_ASSERT(4 == sizeof(T));
++  __asm__ volatile (  "xchgl (%2),%0"
++                    : "=r" (exchange_value)
++                    : "0" (exchange_value), "r" (dest)
++                    : "memory");
++  return exchange_value;
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformCmpxchg<1>::operator()(T volatile* dest,
++                                                T compare_value,
++                                                T exchange_value,
++                                                atomic_memory_order /* order */) const {
++  STATIC_ASSERT(1 == sizeof(T));
++  __asm__ volatile (  "lock cmpxchgb %1,(%3)"
++                    : "=a" (exchange_value)
++                    : "q" (exchange_value), "a" (compare_value), "r" (dest)
++                    : "cc", "memory");
++  return exchange_value;
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
++                                                T compare_value,
++                                                T exchange_value,
++                                                atomic_memory_order /* order */) const {
++  STATIC_ASSERT(4 == sizeof(T));
++  __asm__ volatile (  "lock cmpxchgl %1,(%3)"
++                    : "=a" (exchange_value)
++                    : "r" (exchange_value), "a" (compare_value), "r" (dest)
++                    : "cc", "memory");
++  return exchange_value;
++}
++
++#ifdef AMD64
++template<>
++template<typename D, typename I>
++inline D Atomic::PlatformAdd<8>::fetch_and_add(D volatile* dest, I add_value,
++                                               atomic_memory_order /* order */) const {
++  STATIC_ASSERT(8 == sizeof(I));
++  STATIC_ASSERT(8 == sizeof(D));
++  D old_value;
++  __asm__ __volatile__ (  "lock xaddq %0,(%2)"
++                        : "=r" (old_value)
++                        : "0" (add_value), "r" (dest)
++                        : "cc", "memory");
++  return old_value;
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformXchg<8>::operator()(T volatile* dest,
++                                             T exchange_value,
++                                             atomic_memory_order /* order */) const {
++  STATIC_ASSERT(8 == sizeof(T));
++  __asm__ __volatile__ ("xchgq (%2),%0"
++                        : "=r" (exchange_value)
++                        : "0" (exchange_value), "r" (dest)
++                        : "memory");
++  return exchange_value;
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
++                                                T compare_value,
++                                                T exchange_value,
++                                                atomic_memory_order /* order */) const {
++  STATIC_ASSERT(8 == sizeof(T));
++  __asm__ __volatile__ (  "lock cmpxchgq %1,(%3)"
++                        : "=a" (exchange_value)
++                        : "r" (exchange_value), "a" (compare_value), "r" (dest)
++                        : "cc", "memory");
++  return exchange_value;
++}
++
++#else // !AMD64
++
++extern "C" {
++  // defined in bsd_x86.s
++  int64_t _Atomic_cmpxchg_long(int64_t, volatile int64_t*, int64_t);
++  void _Atomic_move_long(const volatile int64_t* src, volatile int64_t* dst);
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
++                                                T compare_value,
++                                                T exchange_value,
++                                                atomic_memory_order /* order */) const {
++  STATIC_ASSERT(8 == sizeof(T));
++  return cmpxchg_using_helper<int64_t>(_Atomic_cmpxchg_long, dest, compare_value, exchange_value);
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {
++  STATIC_ASSERT(8 == sizeof(T));
++  volatile int64_t dest;
++  _Atomic_move_long(reinterpret_cast<const volatile int64_t*>(src), reinterpret_cast<volatile int64_t*>(&dest));
++  return PrimitiveConversions::cast<T>(dest);
++}
++
++template<>
++template<typename T>
++inline void Atomic::PlatformStore<8>::operator()(T volatile* dest,
++                                                 T store_value) const {
++  STATIC_ASSERT(8 == sizeof(T));
++  _Atomic_move_long(reinterpret_cast<const volatile int64_t*>(&store_value), reinterpret_cast<volatile int64_t*>(dest));
++}
++
++#endif // AMD64
++
++template<>
++struct Atomic::PlatformOrderedStore<1, RELEASE_X_FENCE>
++{
++  template <typename T>
++  void operator()(volatile T* p, T v) const {
++    __asm__ volatile (  "xchgb (%2),%0"
++                      : "=q" (v)
++                      : "0" (v), "r" (p)
++                      : "memory");
++  }
++};
++
++template<>
++struct Atomic::PlatformOrderedStore<2, RELEASE_X_FENCE>
++{
++  template <typename T>
++  void operator()(volatile T* p, T v) const {
++    __asm__ volatile (  "xchgw (%2),%0"
++                      : "=r" (v)
++                      : "0" (v), "r" (p)
++                      : "memory");
++  }
++};
++
++template<>
++struct Atomic::PlatformOrderedStore<4, RELEASE_X_FENCE>
++{
++  template <typename T>
++  void operator()(volatile T* p, T v) const {
++    __asm__ volatile (  "xchgl (%2),%0"
++                      : "=r" (v)
++                      : "0" (v), "r" (p)
++                      : "memory");
++  }
++};
++
++#ifdef AMD64
++template<>
++struct Atomic::PlatformOrderedStore<8, RELEASE_X_FENCE>
++{
++  template <typename T>
++  void operator()(volatile T* p, T v) const {
++    __asm__ volatile (  "xchgq (%2), %0"
++                      : "=r" (v)
++                      : "0" (v), "r" (p)
++                      : "memory");
++  }
++};
++#endif // AMD64
++
++#endif // OS_CPU_SERENITY_X86_ATOMIC_SERENITY_X86_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/bytes_serenity_x86.hpp b/src/hotspot/os_cpu/serenity_x86/bytes_serenity_x86.hpp
+new file mode 100644
+index 000000000..13d3bca9d
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/bytes_serenity_x86.hpp
+@@ -0,0 +1,101 @@
++/*
++ * Copyright (c) 1999, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_BYTES_SERENITY_X86_HPP
++#define OS_CPU_SERENITY_X86_BYTES_SERENITY_X86_HPP
++
++#ifdef __APPLE__
++#include <libkern/OSByteOrder.h>
++#endif
++
++#if defined(AMD64)
++#  if defined(__APPLE__)
++#    define bswap_16(x) OSSwapInt16(x)
++#    define bswap_32(x) OSSwapInt32(x)
++#    define bswap_64(x) OSSwapInt64(x)
++#  elif defined(__OpenBSD__)
++#    define bswap_16(x) swap16(x)
++#    define bswap_32(x) swap32(x)
++#    define bswap_64(x) swap64(x)
++#  elif defined(__NetBSD__)
++#    define bswap_16(x) bswap16(x)
++#    define bswap_32(x) bswap32(x)
++#    define bswap_64(x) bswap64(x)
++#  else
++#    define bswap_16(x) __bswap16(x)
++#    define bswap_32(x) __bswap32(x)
++#    define bswap_64(x) __bswap64(x)
++#  endif
++#endif
++
++// Efficient swapping of data bytes from Java byte
++// ordering to native byte ordering and vice versa.
++inline u2   Bytes::swap_u2(u2 x) {
++#ifdef AMD64
++  return bswap_16(x);
++#else
++  u2 ret;
++  __asm__ __volatile__ (
++    "movw %0, %%ax;"
++    "xchg %%al, %%ah;"
++    "movw %%ax, %0"
++    :"=r" (ret)      // output : register 0 => ret
++    :"0"  (x)        // input  : x => register 0
++    :"ax", "0"       // clobbered registers
++  );
++  return ret;
++#endif // AMD64
++}
++
++inline u4   Bytes::swap_u4(u4 x) {
++#ifdef AMD64
++  return bswap_32(x);
++#else
++  u4 ret;
++  __asm__ __volatile__ (
++    "bswap %0"
++    :"=r" (ret)      // output : register 0 => ret
++    :"0"  (x)        // input  : x => register 0
++    :"0"             // clobbered register
++  );
++  return ret;
++#endif // AMD64
++}
++
++#ifdef AMD64
++inline u8 Bytes::swap_u8(u8 x) {
++  return bswap_64(x);
++}
++#else
++// Helper function for swap_u8
++inline u8   Bytes::swap_u8_base(u4 x, u4 y) {
++  return (((u8)swap_u4(x))<<32) | swap_u4(y);
++}
++
++inline u8 Bytes::swap_u8(u8 x) {
++  return swap_u8_base(*(u4*)&x, *(((u4*)&x)+1));
++}
++#endif // !AMD64
++
++#endif // OS_CPU_SERENITY_X86_BYTES_SERENITY_X86_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/copy_serenity_x86.hpp b/src/hotspot/os_cpu/serenity_x86/copy_serenity_x86.hpp
+new file mode 100644
+index 000000000..2437be87f
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/copy_serenity_x86.hpp
+@@ -0,0 +1,309 @@
++/*
++ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_COPY_SERENITY_X86_HPP
++#define OS_CPU_SERENITY_X86_COPY_SERENITY_X86_HPP
++
++static void pd_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
++#ifdef AMD64
++  (void)memmove(to, from, count * HeapWordSize);
++#else
++  // Includes a zero-count check.
++  intx temp;
++  __asm__ volatile("        testl   %6,%6         ;"
++                   "        jz      7f            ;"
++                   "        cmpl    %4,%5         ;"
++                   "        leal    -4(%4,%6,4),%3;"
++                   "        jbe     1f            ;"
++                   "        cmpl    %7,%5         ;"
++                   "        jbe     4f            ;"
++                   "1:      cmpl    $32,%6        ;"
++                   "        ja      3f            ;"
++                   "        subl    %4,%1         ;"
++                   "2:      movl    (%4),%3       ;"
++                   "        movl    %7,(%5,%4,1)  ;"
++                   "        addl    $4,%0         ;"
++                   "        subl    $1,%2          ;"
++                   "        jnz     2b            ;"
++                   "        jmp     7f            ;"
++                   "3:      rep;    smovl         ;"
++                   "        jmp     7f            ;"
++                   "4:      cmpl    $32,%2        ;"
++                   "        movl    %7,%0         ;"
++                   "        leal    -4(%5,%6,4),%1;"
++                   "        ja      6f            ;"
++                   "        subl    %4,%1         ;"
++                   "5:      movl    (%4),%3       ;"
++                   "        movl    %7,(%5,%4,1)  ;"
++                   "        subl    $4,%0         ;"
++                   "        subl    $1,%2          ;"
++                   "        jnz     5b            ;"
++                   "        jmp     7f            ;"
++                   "6:      std                   ;"
++                   "        rep;    smovl         ;"
++                   "        cld                   ;"
++                   "7:      nop                    "
++                   : "=S" (from), "=D" (to), "=c" (count), "=r" (temp)
++                   : "0"  (from), "1"  (to), "2"  (count), "3"  (temp)
++                   : "memory", "flags");
++#endif // AMD64
++}
++
++static void pd_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
++#ifdef AMD64
++  switch (count) {
++  case 8:  to[7] = from[7];
++  case 7:  to[6] = from[6];
++  case 6:  to[5] = from[5];
++  case 5:  to[4] = from[4];
++  case 4:  to[3] = from[3];
++  case 3:  to[2] = from[2];
++  case 2:  to[1] = from[1];
++  case 1:  to[0] = from[0];
++  case 0:  break;
++  default:
++    (void)memcpy(to, from, count * HeapWordSize);
++    break;
++  }
++#else
++  // Includes a zero-count check.
++  intx temp;
++  __asm__ volatile("        testl   %6,%6       ;"
++                   "        jz      3f          ;"
++                   "        cmpl    $32,%6      ;"
++                   "        ja      2f          ;"
++                   "        subl    %4,%1       ;"
++                   "1:      movl    (%4),%3     ;"
++                   "        movl    %7,(%5,%4,1);"
++                   "        addl    $4,%0       ;"
++                   "        subl    $1,%2        ;"
++                   "        jnz     1b          ;"
++                   "        jmp     3f          ;"
++                   "2:      rep;    smovl       ;"
++                   "3:      nop                  "
++                   : "=S" (from), "=D" (to), "=c" (count), "=r" (temp)
++                   : "0"  (from), "1"  (to), "2"  (count), "3"  (temp)
++                   : "memory", "cc");
++#endif // AMD64
++}
++
++static void pd_disjoint_words_atomic(const HeapWord* from, HeapWord* to, size_t count) {
++#ifdef AMD64
++  switch (count) {
++  case 8:  to[7] = from[7];
++  case 7:  to[6] = from[6];
++  case 6:  to[5] = from[5];
++  case 5:  to[4] = from[4];
++  case 4:  to[3] = from[3];
++  case 3:  to[2] = from[2];
++  case 2:  to[1] = from[1];
++  case 1:  to[0] = from[0];
++  case 0:  break;
++  default:
++    while (count-- > 0) {
++      *to++ = *from++;
++    }
++    break;
++  }
++#else
++  // pd_disjoint_words is word-atomic in this implementation.
++  pd_disjoint_words(from, to, count);
++#endif // AMD64
++}
++
++static void pd_aligned_conjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
++  pd_conjoint_words(from, to, count);
++}
++
++static void pd_aligned_disjoint_words(const HeapWord* from, HeapWord* to, size_t count) {
++  pd_disjoint_words(from, to, count);
++}
++
++static void pd_conjoint_bytes(const void* from, void* to, size_t count) {
++#ifdef AMD64
++  (void)memmove(to, from, count);
++#else
++  // Includes a zero-count check.
++  intx temp;
++  __asm__ volatile("        testl   %6,%6          ;"
++                   "        jz      13f            ;"
++                   "        cmpl    %4,%5          ;"
++                   "        leal    -1(%4,%6),%3   ;"
++                   "        jbe     1f             ;"
++                   "        cmpl    %7,%5          ;"
++                   "        jbe     8f             ;"
++                   "1:      cmpl    $3,%6          ;"
++                   "        jbe     6f             ;"
++                   "        movl    %6,%3          ;"
++                   "        movl    $4,%2          ;"
++                   "        subl    %4,%2          ;"
++                   "        andl    $3,%2          ;"
++                   "        jz      2f             ;"
++                   "        subl    %6,%3          ;"
++                   "        rep;    smovb          ;"
++                   "2:      movl    %7,%2          ;"
++                   "        shrl    $2,%2          ;"
++                   "        jz      5f             ;"
++                   "        cmpl    $32,%2         ;"
++                   "        ja      4f             ;"
++                   "        subl    %4,%1          ;"
++                   "3:      movl    (%4),%%edx     ;"
++                   "        movl    %%edx,(%5,%4,1);"
++                   "        addl    $4,%0          ;"
++                   "        subl    $1,%2           ;"
++                   "        jnz     3b             ;"
++                   "        addl    %4,%1          ;"
++                   "        jmp     5f             ;"
++                   "4:      rep;    smovl          ;"
++                   "5:      movl    %7,%2          ;"
++                   "        andl    $3,%2          ;"
++                   "        jz      13f            ;"
++                   "6:      xorl    %7,%3          ;"
++                   "7:      movb    (%4,%7,1),%%dl ;"
++                   "        movb    %%dl,(%5,%7,1) ;"
++                   "        addl    $1,%3          ;"
++                   "        subl    $1,%2           ;"
++                   "        jnz     7b             ;"
++                   "        jmp     13f            ;"
++                   "8:      std                    ;"
++                   "        cmpl    $12,%2         ;"
++                   "        ja      9f             ;"
++                   "        movl    %7,%0          ;"
++                   "        leal    -1(%6,%5),%1   ;"
++                   "        jmp     11f            ;"
++                   "9:      xchgl   %3,%2          ;"
++                   "        movl    %6,%0          ;"
++                   "        addl    $1,%2          ;"
++                   "        leal    -1(%7,%5),%1   ;"
++                   "        andl    $3,%2          ;"
++                   "        jz      10f            ;"
++                   "        subl    %6,%3          ;"
++                   "        rep;    smovb          ;"
++                   "10:     movl    %7,%2          ;"
++                   "        subl    $3,%0          ;"
++                   "        shrl    $2,%2          ;"
++                   "        subl    $3,%1          ;"
++                   "        rep;    smovl          ;"
++                   "        andl    $3,%3          ;"
++                   "        jz      12f            ;"
++                   "        movl    %7,%2          ;"
++                   "        addl    $3,%0          ;"
++                   "        addl    $3,%1          ;"
++                   "11:     rep;    smovb          ;"
++                   "12:     cld                    ;"
++                   "13:     nop                    ;"
++                   : "=S" (from), "=D" (to), "=c" (count), "=r" (temp)
++                   : "0"  (from), "1"  (to), "2"  (count), "3"  (temp)
++                   : "memory", "flags", "%edx");
++#endif // AMD64
++}
++
++static void pd_conjoint_bytes_atomic(const void* from, void* to, size_t count) {
++  pd_conjoint_bytes(from, to, count);
++}
++
++static void pd_conjoint_jshorts_atomic(const jshort* from, jshort* to, size_t count) {
++  _Copy_conjoint_jshorts_atomic(from, to, count);
++}
++
++static void pd_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
++#ifdef AMD64
++  _Copy_conjoint_jints_atomic(from, to, count);
++#else
++  assert(HeapWordSize == BytesPerInt, "heapwords and jints must be the same size");
++  // pd_conjoint_words is word-atomic in this implementation.
++  pd_conjoint_words((const HeapWord*)from, (HeapWord*)to, count);
++#endif // AMD64
++}
++
++static void pd_conjoint_jlongs_atomic(const jlong* from, jlong* to, size_t count) {
++#ifdef AMD64
++  _Copy_conjoint_jlongs_atomic(from, to, count);
++#else
++  // Guarantee use of fild/fistp or xmm regs via some asm code, because compilers won't.
++  if (from > to) {
++    while (count-- > 0) {
++      __asm__ volatile("fildll (%0); fistpll (%1)"
++                       :
++                       : "r" (from), "r" (to)
++                       : "memory" );
++      ++from;
++      ++to;
++    }
++  } else {
++    while (count-- > 0) {
++      __asm__ volatile("fildll (%0,%2,8); fistpll (%1,%2,8)"
++                       :
++                       : "r" (from), "r" (to), "r" (count)
++                       : "memory" );
++    }
++  }
++#endif // AMD64
++}
++
++static void pd_conjoint_oops_atomic(const oop* from, oop* to, size_t count) {
++#ifdef AMD64
++  assert(BytesPerLong == BytesPerOop, "jlongs and oops must be the same size");
++  _Copy_conjoint_jlongs_atomic((const jlong*)from, (jlong*)to, count);
++#else
++  assert(HeapWordSize == BytesPerOop, "heapwords and oops must be the same size");
++  // pd_conjoint_words is word-atomic in this implementation.
++  pd_conjoint_words((const HeapWord*)from, (HeapWord*)to, count);
++#endif // AMD64
++}
++
++static void pd_arrayof_conjoint_bytes(const HeapWord* from, HeapWord* to, size_t count) {
++  _Copy_arrayof_conjoint_bytes(from, to, count);
++}
++
++static void pd_arrayof_conjoint_jshorts(const HeapWord* from, HeapWord* to, size_t count) {
++  _Copy_arrayof_conjoint_jshorts(from, to, count);
++}
++
++static void pd_arrayof_conjoint_jints(const HeapWord* from, HeapWord* to, size_t count) {
++#ifdef AMD64
++   _Copy_arrayof_conjoint_jints(from, to, count);
++#else
++  pd_conjoint_jints_atomic((const jint*)from, (jint*)to, count);
++#endif // AMD64
++}
++
++static void pd_arrayof_conjoint_jlongs(const HeapWord* from, HeapWord* to, size_t count) {
++#ifdef AMD64
++  _Copy_arrayof_conjoint_jlongs(from, to, count);
++#else
++  pd_conjoint_jlongs_atomic((const jlong*)from, (jlong*)to, count);
++#endif // AMD64
++}
++
++static void pd_arrayof_conjoint_oops(const HeapWord* from, HeapWord* to, size_t count) {
++#ifdef AMD64
++  assert(BytesPerLong == BytesPerOop, "jlongs and oops must be the same size");
++  _Copy_arrayof_conjoint_jlongs(from, to, count);
++#else
++  pd_conjoint_oops_atomic((const oop*)from, (oop*)to, count);
++#endif // AMD64
++}
++
++#endif // OS_CPU_SERENITY_X86_COPY_SERENITY_X86_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/globals_serenity_x86.hpp b/src/hotspot/os_cpu/serenity_x86/globals_serenity_x86.hpp
+new file mode 100644
+index 000000000..38cbf1a98
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/globals_serenity_x86.hpp
+@@ -0,0 +1,52 @@
++/*
++ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_GLOBALS_SERENITY_X86_HPP
++#define OS_CPU_SERENITY_X86_GLOBALS_SERENITY_X86_HPP
++
++//
++// Sets the default values for platform dependent flags used by the runtime system.
++// (see globals.hpp)
++//
++define_pd_global(bool, DontYieldALot,            false);
++#ifdef AMD64
++define_pd_global(intx, CompilerThreadStackSize,  1024);
++define_pd_global(intx, ThreadStackSize,          1024); // 0 => use system default
++define_pd_global(intx, VMThreadStackSize,        1024);
++#else
++define_pd_global(intx, CompilerThreadStackSize,  512);
++// ThreadStackSize 320 allows a couple of test cases to run while
++// keeping the number of threads that can be created high.  System
++// default ThreadStackSize appears to be 512 which is too big.
++define_pd_global(intx, ThreadStackSize,          320);
++define_pd_global(intx, VMThreadStackSize,        512);
++#endif // AMD64
++
++
++define_pd_global(size_t, JVMInvokeMethodSlack,   8192);
++
++// Used on 64 bit platforms for UseCompressedOops base address
++define_pd_global(size_t, HeapBaseMinAddress,     2*G);
++
++#endif // OS_CPU_SERENITY_X86_GLOBALS_SERENITY_X86_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/orderAccess_serenity_x86.hpp b/src/hotspot/os_cpu/serenity_x86/orderAccess_serenity_x86.hpp
+new file mode 100644
+index 000000000..1da0b0e6e
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/orderAccess_serenity_x86.hpp
+@@ -0,0 +1,67 @@
++/*
++ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_ORDERACCESS_SERENITY_X86_HPP
++#define OS_CPU_SERENITY_X86_ORDERACCESS_SERENITY_X86_HPP
++
++// Included in orderAccess.hpp header file.
++
++// Compiler version last used for testing: clang 5.1
++// Please update this information when this file changes
++
++// A compiler barrier, forcing the C++ compiler to invalidate all memory assumptions
++static inline void compiler_barrier() {
++  __asm__ volatile ("" : : : "memory");
++}
++
++// x86 is TSO and hence only needs a fence for storeload
++// However, a compiler barrier is still needed to prevent reordering
++// between volatile and non-volatile memory accesses.
++
++// Implementation of class OrderAccess.
++
++inline void OrderAccess::loadload()   { compiler_barrier(); }
++inline void OrderAccess::storestore() { compiler_barrier(); }
++inline void OrderAccess::loadstore()  { compiler_barrier(); }
++inline void OrderAccess::storeload()  { fence();            }
++
++inline void OrderAccess::acquire()    { compiler_barrier(); }
++inline void OrderAccess::release()    { compiler_barrier(); }
++
++inline void OrderAccess::fence() {
++  // always use locked addl since mfence is sometimes expensive
++#ifdef AMD64
++  __asm__ volatile ("lock; addl $0,0(%%rsp)" : : : "cc", "memory");
++#else
++  __asm__ volatile ("lock; addl $0,0(%%esp)" : : : "cc", "memory");
++#endif
++  compiler_barrier();
++}
++
++inline void OrderAccess::cross_modify_fence_impl() {
++  int idx = 0;
++  __asm__ volatile ("cpuid " : "+a" (idx) : : "ebx", "ecx", "edx", "memory");
++}
++
++#endif // OS_CPU_SERENITY_X86_ORDERACCESS_SERENITY_X86_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.cpp b/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.cpp
+new file mode 100644
+index 000000000..ad48c6e47
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.cpp
+@@ -0,0 +1,922 @@
++/*
++ * Copyright (c) 1999, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++// no precompiled headers
++#include "jvm.h"
++#include "asm/macroAssembler.hpp"
++#include "classfile/vmSymbols.hpp"
++#include "code/codeCache.hpp"
++#include "code/icBuffer.hpp"
++#include "code/vtableStubs.hpp"
++#include "interpreter/interpreter.hpp"
++#include "logging/log.hpp"
++#include "memory/allocation.inline.hpp"
++#include "os_share_bsd.hpp"
++#include "prims/jniFastGetField.hpp"
++#include "prims/jvm_misc.hpp"
++#include "runtime/arguments.hpp"
++#include "runtime/frame.inline.hpp"
++#include "runtime/interfaceSupport.inline.hpp"
++#include "runtime/java.hpp"
++#include "runtime/javaCalls.hpp"
++#include "runtime/mutexLocker.hpp"
++#include "runtime/osThread.hpp"
++#include "runtime/safepointMechanism.hpp"
++#include "runtime/sharedRuntime.hpp"
++#include "runtime/stubRoutines.hpp"
++#include "runtime/thread.inline.hpp"
++#include "runtime/timer.hpp"
++#include "signals_posix.hpp"
++#include "utilities/align.hpp"
++#include "utilities/events.hpp"
++#include "utilities/vmError.hpp"
++
++// put OS-includes here
++# include <sys/types.h>
++# include <sys/mman.h>
++# include <pthread.h>
++# include <signal.h>
++# include <errno.h>
++# include <dlfcn.h>
++# include <stdlib.h>
++# include <stdio.h>
++# include <unistd.h>
++# include <sys/resource.h>
++# include <sys/stat.h>
++# include <sys/time.h>
++# include <sys/utsname.h>
++# include <sys/socket.h>
++# include <sys/wait.h>
++# include <pwd.h>
++# include <poll.h>
++#ifndef __OpenBSD__
++# include <ucontext.h>
++#endif
++
++#if !defined(__APPLE__) && !defined(__NetBSD__)
++# include <pthread_np.h>
++#endif
++
++// needed by current_stack_region() workaround for Mavericks
++#if defined(__APPLE__)
++# include <errno.h>
++# include <sys/types.h>
++# include <sys/sysctl.h>
++# define DEFAULT_MAIN_THREAD_STACK_PAGES 2048
++# define OS_X_10_9_0_KERNEL_MAJOR_VERSION 13
++#endif
++
++#ifdef AMD64
++#define SPELL_REG_SP "rsp"
++#define SPELL_REG_FP "rbp"
++#else
++#define SPELL_REG_SP "esp"
++#define SPELL_REG_FP "ebp"
++#endif // AMD64
++
++#ifdef __FreeBSD__
++# define context_trapno uc_mcontext.mc_trapno
++# ifdef AMD64
++#  define context_pc uc_mcontext.mc_rip
++#  define context_sp uc_mcontext.mc_rsp
++#  define context_fp uc_mcontext.mc_rbp
++#  define context_rip uc_mcontext.mc_rip
++#  define context_rsp uc_mcontext.mc_rsp
++#  define context_rbp uc_mcontext.mc_rbp
++#  define context_rax uc_mcontext.mc_rax
++#  define context_rbx uc_mcontext.mc_rbx
++#  define context_rcx uc_mcontext.mc_rcx
++#  define context_rdx uc_mcontext.mc_rdx
++#  define context_rsi uc_mcontext.mc_rsi
++#  define context_rdi uc_mcontext.mc_rdi
++#  define context_r8  uc_mcontext.mc_r8
++#  define context_r9  uc_mcontext.mc_r9
++#  define context_r10 uc_mcontext.mc_r10
++#  define context_r11 uc_mcontext.mc_r11
++#  define context_r12 uc_mcontext.mc_r12
++#  define context_r13 uc_mcontext.mc_r13
++#  define context_r14 uc_mcontext.mc_r14
++#  define context_r15 uc_mcontext.mc_r15
++#  define context_flags uc_mcontext.mc_flags
++#  define context_err uc_mcontext.mc_err
++# else
++#  define context_pc uc_mcontext.mc_eip
++#  define context_sp uc_mcontext.mc_esp
++#  define context_fp uc_mcontext.mc_ebp
++#  define context_eip uc_mcontext.mc_eip
++#  define context_esp uc_mcontext.mc_esp
++#  define context_eax uc_mcontext.mc_eax
++#  define context_ebx uc_mcontext.mc_ebx
++#  define context_ecx uc_mcontext.mc_ecx
++#  define context_edx uc_mcontext.mc_edx
++#  define context_ebp uc_mcontext.mc_ebp
++#  define context_esi uc_mcontext.mc_esi
++#  define context_edi uc_mcontext.mc_edi
++#  define context_eflags uc_mcontext.mc_eflags
++#  define context_trapno uc_mcontext.mc_trapno
++# endif
++#endif
++
++#ifdef __APPLE__
++# if __DARWIN_UNIX03 && (MAC_OS_X_VERSION_MAX_ALLOWED >= MAC_OS_X_VERSION_10_5)
++  // 10.5 UNIX03 member name prefixes
++  #define DU3_PREFIX(s, m) __ ## s.__ ## m
++# else
++  #define DU3_PREFIX(s, m) s ## . ## m
++# endif
++
++# ifdef AMD64
++#  define context_pc context_rip
++#  define context_sp context_rsp
++#  define context_fp context_rbp
++#  define context_rip uc_mcontext->DU3_PREFIX(ss,rip)
++#  define context_rsp uc_mcontext->DU3_PREFIX(ss,rsp)
++#  define context_rax uc_mcontext->DU3_PREFIX(ss,rax)
++#  define context_rbx uc_mcontext->DU3_PREFIX(ss,rbx)
++#  define context_rcx uc_mcontext->DU3_PREFIX(ss,rcx)
++#  define context_rdx uc_mcontext->DU3_PREFIX(ss,rdx)
++#  define context_rbp uc_mcontext->DU3_PREFIX(ss,rbp)
++#  define context_rsi uc_mcontext->DU3_PREFIX(ss,rsi)
++#  define context_rdi uc_mcontext->DU3_PREFIX(ss,rdi)
++#  define context_r8  uc_mcontext->DU3_PREFIX(ss,r8)
++#  define context_r9  uc_mcontext->DU3_PREFIX(ss,r9)
++#  define context_r10 uc_mcontext->DU3_PREFIX(ss,r10)
++#  define context_r11 uc_mcontext->DU3_PREFIX(ss,r11)
++#  define context_r12 uc_mcontext->DU3_PREFIX(ss,r12)
++#  define context_r13 uc_mcontext->DU3_PREFIX(ss,r13)
++#  define context_r14 uc_mcontext->DU3_PREFIX(ss,r14)
++#  define context_r15 uc_mcontext->DU3_PREFIX(ss,r15)
++#  define context_flags uc_mcontext->DU3_PREFIX(ss,rflags)
++#  define context_trapno uc_mcontext->DU3_PREFIX(es,trapno)
++#  define context_err uc_mcontext->DU3_PREFIX(es,err)
++# else
++#  define context_pc context_eip
++#  define context_sp context_esp
++#  define context_fp context_ebp
++#  define context_eip uc_mcontext->DU3_PREFIX(ss,eip)
++#  define context_esp uc_mcontext->DU3_PREFIX(ss,esp)
++#  define context_eax uc_mcontext->DU3_PREFIX(ss,eax)
++#  define context_ebx uc_mcontext->DU3_PREFIX(ss,ebx)
++#  define context_ecx uc_mcontext->DU3_PREFIX(ss,ecx)
++#  define context_edx uc_mcontext->DU3_PREFIX(ss,edx)
++#  define context_ebp uc_mcontext->DU3_PREFIX(ss,ebp)
++#  define context_esi uc_mcontext->DU3_PREFIX(ss,esi)
++#  define context_edi uc_mcontext->DU3_PREFIX(ss,edi)
++#  define context_eflags uc_mcontext->DU3_PREFIX(ss,eflags)
++#  define context_trapno uc_mcontext->DU3_PREFIX(es,trapno)
++# endif
++#endif
++
++#ifdef __OpenBSD__
++# define context_trapno sc_trapno
++# ifdef AMD64
++#  define context_pc sc_rip
++#  define context_sp sc_rsp
++#  define context_fp sc_rbp
++#  define context_rip sc_rip
++#  define context_rsp sc_rsp
++#  define context_rbp sc_rbp
++#  define context_rax sc_rax
++#  define context_rbx sc_rbx
++#  define context_rcx sc_rcx
++#  define context_rdx sc_rdx
++#  define context_rsi sc_rsi
++#  define context_rdi sc_rdi
++#  define context_r8  sc_r8
++#  define context_r9  sc_r9
++#  define context_r10 sc_r10
++#  define context_r11 sc_r11
++#  define context_r12 sc_r12
++#  define context_r13 sc_r13
++#  define context_r14 sc_r14
++#  define context_r15 sc_r15
++#  define context_flags sc_rflags
++#  define context_err sc_err
++# else
++#  define context_pc sc_eip
++#  define context_sp sc_esp
++#  define context_fp sc_ebp
++#  define context_eip sc_eip
++#  define context_esp sc_esp
++#  define context_eax sc_eax
++#  define context_ebx sc_ebx
++#  define context_ecx sc_ecx
++#  define context_edx sc_edx
++#  define context_ebp sc_ebp
++#  define context_esi sc_esi
++#  define context_edi sc_edi
++#  define context_eflags sc_eflags
++#  define context_trapno sc_trapno
++# endif
++#endif
++
++#ifdef __NetBSD__
++# define context_trapno uc_mcontext.__gregs[_REG_TRAPNO]
++# ifdef AMD64
++#  define __register_t __greg_t
++#  define context_pc uc_mcontext.__gregs[_REG_RIP]
++#  define context_sp uc_mcontext.__gregs[_REG_URSP]
++#  define context_fp uc_mcontext.__gregs[_REG_RBP]
++#  define context_rip uc_mcontext.__gregs[_REG_RIP]
++#  define context_rsp uc_mcontext.__gregs[_REG_URSP]
++#  define context_rax uc_mcontext.__gregs[_REG_RAX]
++#  define context_rbx uc_mcontext.__gregs[_REG_RBX]
++#  define context_rcx uc_mcontext.__gregs[_REG_RCX]
++#  define context_rdx uc_mcontext.__gregs[_REG_RDX]
++#  define context_rbp uc_mcontext.__gregs[_REG_RBP]
++#  define context_rsi uc_mcontext.__gregs[_REG_RSI]
++#  define context_rdi uc_mcontext.__gregs[_REG_RDI]
++#  define context_r8  uc_mcontext.__gregs[_REG_R8]
++#  define context_r9  uc_mcontext.__gregs[_REG_R9]
++#  define context_r10 uc_mcontext.__gregs[_REG_R10]
++#  define context_r11 uc_mcontext.__gregs[_REG_R11]
++#  define context_r12 uc_mcontext.__gregs[_REG_R12]
++#  define context_r13 uc_mcontext.__gregs[_REG_R13]
++#  define context_r14 uc_mcontext.__gregs[_REG_R14]
++#  define context_r15 uc_mcontext.__gregs[_REG_R15]
++#  define context_flags uc_mcontext.__gregs[_REG_RFL]
++#  define context_err uc_mcontext.__gregs[_REG_ERR]
++# else
++#  define context_pc uc_mcontext.__gregs[_REG_EIP]
++#  define context_sp uc_mcontext.__gregs[_REG_UESP]
++#  define context_fp uc_mcontext.__gregs[_REG_EBP]
++#  define context_eip uc_mcontext.__gregs[_REG_EIP]
++#  define context_esp uc_mcontext.__gregs[_REG_UESP]
++#  define context_eax uc_mcontext.__gregs[_REG_EAX]
++#  define context_ebx uc_mcontext.__gregs[_REG_EBX]
++#  define context_ecx uc_mcontext.__gregs[_REG_ECX]
++#  define context_edx uc_mcontext.__gregs[_REG_EDX]
++#  define context_ebp uc_mcontext.__gregs[_REG_EBP]
++#  define context_esi uc_mcontext.__gregs[_REG_ESI]
++#  define context_edi uc_mcontext.__gregs[_REG_EDI]
++#  define context_eflags uc_mcontext.__gregs[_REG_EFL]
++#  define context_trapno uc_mcontext.__gregs[_REG_TRAPNO]
++# endif
++#endif
++
++address os::current_stack_pointer() {
++#if defined(__clang__) || defined(__llvm__)
++  void *esp;
++  __asm__("mov %%" SPELL_REG_SP ", %0":"=r"(esp));
++  return (address) esp;
++#else
++  register void *esp __asm__ (SPELL_REG_SP);
++  return (address) esp;
++#endif
++}
++
++char* os::non_memory_address_word() {
++  // Must never look like an address returned by reserve_memory,
++  // even in its subfields (as defined by the CPU immediate fields,
++  // if the CPU splits constants across multiple instructions).
++
++  return (char*) -1;
++}
++
++address os::Posix::ucontext_get_pc(const ucontext_t * uc) {
++  return (address)uc->context_pc;
++}
++
++void os::Posix::ucontext_set_pc(ucontext_t * uc, address pc) {
++  uc->context_pc = (intptr_t)pc ;
++}
++
++intptr_t* os::Bsd::ucontext_get_sp(const ucontext_t * uc) {
++  return (intptr_t*)uc->context_sp;
++}
++
++intptr_t* os::Bsd::ucontext_get_fp(const ucontext_t * uc) {
++  return (intptr_t*)uc->context_fp;
++}
++
++address os::fetch_frame_from_context(const void* ucVoid,
++                    intptr_t** ret_sp, intptr_t** ret_fp) {
++
++  address  epc;
++  const ucontext_t* uc = (const ucontext_t*)ucVoid;
++
++  if (uc != NULL) {
++    epc = os::Posix::ucontext_get_pc(uc);
++    if (ret_sp) *ret_sp = os::Bsd::ucontext_get_sp(uc);
++    if (ret_fp) *ret_fp = os::Bsd::ucontext_get_fp(uc);
++  } else {
++    epc = NULL;
++    if (ret_sp) *ret_sp = (intptr_t *)NULL;
++    if (ret_fp) *ret_fp = (intptr_t *)NULL;
++  }
++
++  return epc;
++}
++
++frame os::fetch_frame_from_context(const void* ucVoid) {
++  intptr_t* sp;
++  intptr_t* fp;
++  address epc = fetch_frame_from_context(ucVoid, &sp, &fp);
++  return frame(sp, fp, epc);
++}
++
++frame os::fetch_compiled_frame_from_context(const void* ucVoid) {
++  const ucontext_t* uc = (const ucontext_t*)ucVoid;
++  frame fr = os::fetch_frame_from_context(uc);
++  // in compiled code, the stack banging is performed just after the return pc
++  // has been pushed on the stack
++  return frame(fr.sp() + 1, fr.fp(), (address)*(fr.sp()));
++}
++
++// By default, gcc always save frame pointer (%ebp/%rbp) on stack. It may get
++// turned off by -fomit-frame-pointer,
++frame os::get_sender_for_C_frame(frame* fr) {
++  return frame(fr->sender_sp(), fr->link(), fr->sender_pc());
++}
++
++intptr_t* _get_previous_fp() {
++#if defined(__clang__) || defined(__llvm__)
++  intptr_t **ebp;
++  __asm__("mov %%" SPELL_REG_FP ", %0":"=r"(ebp));
++#else
++  register intptr_t **ebp __asm__ (SPELL_REG_FP);
++#endif
++  // ebp is for this frame (_get_previous_fp). We want the ebp for the
++  // caller of os::current_frame*(), so go up two frames. However, for
++  // optimized builds, _get_previous_fp() will be inlined, so only go
++  // up 1 frame in that case.
++#ifdef _NMT_NOINLINE_
++  return **(intptr_t***)ebp;
++#else
++  return *ebp;
++#endif
++}
++
++
++frame os::current_frame() {
++  intptr_t* fp = _get_previous_fp();
++  frame myframe((intptr_t*)os::current_stack_pointer(),
++                (intptr_t*)fp,
++                CAST_FROM_FN_PTR(address, os::current_frame));
++  if (os::is_first_C_frame(&myframe)) {
++    // stack is not walkable
++    return frame();
++  } else {
++    return os::get_sender_for_C_frame(&myframe);
++  }
++}
++
++// From IA32 System Programming Guide
++enum {
++  trap_page_fault = 0xE
++};
++
++bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info,
++                                             ucontext_t* uc, JavaThread* thread) {
++  // decide if this trap can be handled by a stub
++  address stub = NULL;
++
++  address pc          = NULL;
++
++  //%note os_trap_1
++  if (info != NULL && uc != NULL && thread != NULL) {
++    pc = (address) os::Posix::ucontext_get_pc(uc);
++
++    // Handle ALL stack overflow variations here
++    if (sig == SIGSEGV || sig == SIGBUS) {
++      address addr = (address) info->si_addr;
++
++      // check if fault address is within thread stack
++      if (thread->is_in_full_stack(addr)) {
++        // stack overflow
++        if (os::Posix::handle_stack_overflow(thread, addr, pc, uc, &stub)) {
++          return true; // continue
++        }
++      }
++    }
++
++    if ((sig == SIGSEGV || sig == SIGBUS) && VM_Version::is_cpuinfo_segv_addr(pc)) {
++      // Verify that OS save/restore AVX registers.
++      stub = VM_Version::cpuinfo_cont_addr();
++    }
++
++    // We test if stub is already set (by the stack overflow code
++    // above) so it is not overwritten by the code that follows. This
++    // check is not required on other platforms, because on other
++    // platforms we check for SIGSEGV only or SIGBUS only, where here
++    // we have to check for both SIGSEGV and SIGBUS.
++    if (thread->thread_state() == _thread_in_Java && stub == NULL) {
++      // Java thread running in Java code => find exception handler if any
++      // a fault inside compiled code, the interpreter, or a stub
++
++      if ((sig == SIGSEGV || sig == SIGBUS) && SafepointMechanism::is_poll_address((address)info->si_addr)) {
++        stub = SharedRuntime::get_poll_stub(pc);
++#if defined(__APPLE__)
++      // 32-bit Darwin reports a SIGBUS for nearly all memory access exceptions.
++      // 64-bit Darwin may also use a SIGBUS (seen with compressed oops).
++      // Catching SIGBUS here prevents the implicit SIGBUS NULL check below from
++      // being called, so only do so if the implicit NULL check is not necessary.
++      } else if (sig == SIGBUS && !MacroAssembler::uses_implicit_null_check(info->si_addr)) {
++#else
++      } else if (sig == SIGBUS /* && info->si_code == BUS_OBJERR */) {
++#endif
++        // BugId 4454115: A read from a MappedByteBuffer can fault
++        // here if the underlying file has been truncated.
++        // Do not crash the VM in such a case.
++        CodeBlob* cb = CodeCache::find_blob_unsafe(pc);
++        CompiledMethod* nm = (cb != NULL) ? cb->as_compiled_method_or_null() : NULL;
++        bool is_unsafe_arraycopy = thread->doing_unsafe_access() && UnsafeCopyMemory::contains_pc(pc);
++        if ((nm != NULL && nm->has_unsafe_access()) || is_unsafe_arraycopy) {
++          address next_pc = Assembler::locate_next_instruction(pc);
++          if (is_unsafe_arraycopy) {
++            next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
++          }
++          stub = SharedRuntime::handle_unsafe_access(thread, next_pc);
++        }
++      }
++      else
++
++#ifdef AMD64
++      if (sig == SIGFPE  &&
++          (info->si_code == FPE_INTDIV || info->si_code == FPE_FLTDIV
++           // Workaround for macOS ARM incorrectly reporting FPE_FLTINV for "div by 0"
++           // instead of the expected FPE_FLTDIV when running x86_64 binary under Rosetta emulation
++           MACOS_ONLY(|| (VM_Version::is_cpu_emulated() && info->si_code == FPE_FLTINV)))) {
++        stub =
++          SharedRuntime::
++          continuation_for_implicit_exception(thread,
++                                              pc,
++                                              SharedRuntime::
++                                              IMPLICIT_DIVIDE_BY_ZERO);
++#ifdef __APPLE__
++      } else if (sig == SIGFPE && info->si_code == FPE_NOOP) {
++        int op = pc[0];
++
++        // Skip REX
++        if ((pc[0] & 0xf0) == 0x40) {
++          op = pc[1];
++        } else {
++          op = pc[0];
++        }
++
++        // Check for IDIV
++        if (op == 0xF7) {
++          stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime:: IMPLICIT_DIVIDE_BY_ZERO);
++        } else {
++          // TODO: handle more cases if we are using other x86 instructions
++          //   that can generate SIGFPE signal.
++          tty->print_cr("unknown opcode 0x%X with SIGFPE.", op);
++          fatal("please update this code.");
++        }
++#endif /* __APPLE__ */
++
++#else
++      if (sig == SIGFPE /* && info->si_code == FPE_INTDIV */) {
++        // HACK: si_code does not work on bsd 2.2.12-20!!!
++        int op = pc[0];
++        if (op == 0xDB) {
++          // FIST
++          // TODO: The encoding of D2I in x86_32.ad can cause an exception
++          // prior to the fist instruction if there was an invalid operation
++          // pending. We want to dismiss that exception. From the win_32
++          // side it also seems that if it really was the fist causing
++          // the exception that we do the d2i by hand with different
++          // rounding. Seems kind of weird.
++          // NOTE: that we take the exception at the NEXT floating point instruction.
++          assert(pc[0] == 0xDB, "not a FIST opcode");
++          assert(pc[1] == 0x14, "not a FIST opcode");
++          assert(pc[2] == 0x24, "not a FIST opcode");
++          return true;
++        } else if (op == 0xF7) {
++          // IDIV
++          stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_DIVIDE_BY_ZERO);
++        } else {
++          // TODO: handle more cases if we are using other x86 instructions
++          //   that can generate SIGFPE signal on bsd.
++          tty->print_cr("unknown opcode 0x%X with SIGFPE.", op);
++          fatal("please update this code.");
++        }
++#endif // AMD64
++      } else if ((sig == SIGSEGV || sig == SIGBUS) &&
++                 MacroAssembler::uses_implicit_null_check(info->si_addr)) {
++          // Determination of interpreter/vtable stub/compiled code null exception
++          stub = SharedRuntime::continuation_for_implicit_exception(thread, pc, SharedRuntime::IMPLICIT_NULL);
++      }
++    } else if ((thread->thread_state() == _thread_in_vm ||
++                thread->thread_state() == _thread_in_native) &&
++               sig == SIGBUS && /* info->si_code == BUS_OBJERR && */
++               thread->doing_unsafe_access()) {
++        address next_pc = Assembler::locate_next_instruction(pc);
++        if (UnsafeCopyMemory::contains_pc(pc)) {
++          next_pc = UnsafeCopyMemory::page_error_continue_pc(pc);
++        }
++        stub = SharedRuntime::handle_unsafe_access(thread, next_pc);
++    }
++
++    // jni_fast_Get<Primitive>Field can trap at certain pc's if a GC kicks in
++    // and the heap gets shrunk before the field access.
++    if ((sig == SIGSEGV) || (sig == SIGBUS)) {
++      address addr = JNI_FastGetField::find_slowcase_pc(pc);
++      if (addr != (address)-1) {
++        stub = addr;
++      }
++    }
++  }
++
++#ifndef AMD64
++  // Execution protection violation
++  //
++  // This should be kept as the last step in the triage.  We don't
++  // have a dedicated trap number for a no-execute fault, so be
++  // conservative and allow other handlers the first shot.
++  //
++  // Note: We don't test that info->si_code == SEGV_ACCERR here.
++  // this si_code is so generic that it is almost meaningless; and
++  // the si_code for this condition may change in the future.
++  // Furthermore, a false-positive should be harmless.
++  if (UnguardOnExecutionViolation > 0 &&
++      stub == NULL &&
++      (sig == SIGSEGV || sig == SIGBUS) &&
++      uc->context_trapno == trap_page_fault) {
++    int page_size = os::vm_page_size();
++    address addr = (address) info->si_addr;
++    address pc = os::Posix::ucontext_get_pc(uc);
++    // Make sure the pc and the faulting address are sane.
++    //
++    // If an instruction spans a page boundary, and the page containing
++    // the beginning of the instruction is executable but the following
++    // page is not, the pc and the faulting address might be slightly
++    // different - we still want to unguard the 2nd page in this case.
++    //
++    // 15 bytes seems to be a (very) safe value for max instruction size.
++    bool pc_is_near_addr =
++      (pointer_delta((void*) addr, (void*) pc, sizeof(char)) < 15);
++    bool instr_spans_page_boundary =
++      (align_down((intptr_t) pc ^ (intptr_t) addr,
++                       (intptr_t) page_size) > 0);
++
++    if (pc == addr || (pc_is_near_addr && instr_spans_page_boundary)) {
++      static volatile address last_addr =
++        (address) os::non_memory_address_word();
++
++      // In conservative mode, don't unguard unless the address is in the VM
++      if (addr != last_addr &&
++          (UnguardOnExecutionViolation > 1 || os::address_is_in_vm(addr))) {
++
++        // Set memory to RWX and retry
++        address page_start = align_down(addr, page_size);
++        bool res = os::protect_memory((char*) page_start, page_size,
++                                      os::MEM_PROT_RWX);
++
++        log_debug(os)("Execution protection violation "
++                      "at " INTPTR_FORMAT
++                      ", unguarding " INTPTR_FORMAT ": %s, errno=%d", p2i(addr),
++                      p2i(page_start), (res ? "success" : "failed"), errno);
++        stub = pc;
++
++        // Set last_addr so if we fault again at the same address, we don't end
++        // up in an endless loop.
++        //
++        // There are two potential complications here.  Two threads trapping at
++        // the same address at the same time could cause one of the threads to
++        // think it already unguarded, and abort the VM.  Likely very rare.
++        //
++        // The other race involves two threads alternately trapping at
++        // different addresses and failing to unguard the page, resulting in
++        // an endless loop.  This condition is probably even more unlikely than
++        // the first.
++        //
++        // Although both cases could be avoided by using locks or thread local
++        // last_addr, these solutions are unnecessary complication: this
++        // handler is a best-effort safety net, not a complete solution.  It is
++        // disabled by default and should only be used as a workaround in case
++        // we missed any no-execute-unsafe VM code.
++
++        last_addr = addr;
++      }
++    }
++  }
++#endif // !AMD64
++
++  if (stub != NULL) {
++    // save all thread context in case we need to restore it
++    if (thread != NULL) thread->set_saved_exception_pc(pc);
++
++    os::Posix::ucontext_set_pc(uc, stub);
++    return true;
++  }
++
++  return false;
++}
++
++// From solaris_i486.s ported to bsd_i486.s
++extern "C" void fixcw();
++
++void os::Bsd::init_thread_fpu_state(void) {
++#ifndef AMD64
++  // Set fpu to 53 bit precision. This happens too early to use a stub.
++  fixcw();
++#endif // !AMD64
++}
++
++
++// Check that the bsd kernel version is 2.4 or higher since earlier
++// versions do not support SSE without patches.
++bool os::supports_sse() {
++  return true;
++}
++
++juint os::cpu_microcode_revision() {
++  juint result = 0;
++  char data[8];
++  size_t sz = sizeof(data);
++  int ret = sysctlbyname("machdep.cpu.microcode_version", data, &sz, NULL, 0);
++  if (ret == 0) {
++    if (sz == 4) result = *((juint*)data);
++    if (sz == 8) result = *((juint*)data + 1); // upper 32-bits
++  }
++  return result;
++}
++
++////////////////////////////////////////////////////////////////////////////////
++// thread stack
++
++// Minimum usable stack sizes required to get to user code. Space for
++// HotSpot guard pages is added later.
++size_t os::Posix::_compiler_thread_min_stack_allowed = 48 * K;
++size_t os::Posix::_java_thread_min_stack_allowed = 48 * K;
++#ifdef _LP64
++size_t os::Posix::_vm_internal_thread_min_stack_allowed = 64 * K;
++#else
++size_t os::Posix::_vm_internal_thread_min_stack_allowed = (48 DEBUG_ONLY(+ 4)) * K;
++#endif // _LP64
++
++#ifndef AMD64
++#ifdef __GNUC__
++#define GET_GS() ({int gs; __asm__ volatile("movw %%gs, %w0":"=q"(gs)); gs&0xffff;})
++#endif
++#endif // AMD64
++
++// return default stack size for thr_type
++size_t os::Posix::default_stack_size(os::ThreadType thr_type) {
++  // default stack size (compiler thread needs larger stack)
++#ifdef AMD64
++  size_t s = (thr_type == os::compiler_thread ? 4 * M : 1 * M);
++#else
++  size_t s = (thr_type == os::compiler_thread ? 2 * M : 512 * K);
++#endif // AMD64
++  return s;
++}
++
++
++// Java thread:
++//
++//   Low memory addresses
++//    +------------------------+
++//    |                        |\  Java thread created by VM does not have glibc
++//    |    glibc guard page    | - guard, attached Java thread usually has
++//    |                        |/  1 glibc guard page.
++// P1 +------------------------+ Thread::stack_base() - Thread::stack_size()
++//    |                        |\
++//    |  HotSpot Guard Pages   | - red, yellow and reserved pages
++//    |                        |/
++//    +------------------------+ StackOverflow::stack_reserved_zone_base()
++//    |                        |\
++//    |      Normal Stack      | -
++//    |                        |/
++// P2 +------------------------+ Thread::stack_base()
++//
++// Non-Java thread:
++//
++//   Low memory addresses
++//    +------------------------+
++//    |                        |\
++//    |  glibc guard page      | - usually 1 page
++//    |                        |/
++// P1 +------------------------+ Thread::stack_base() - Thread::stack_size()
++//    |                        |\
++//    |      Normal Stack      | -
++//    |                        |/
++// P2 +------------------------+ Thread::stack_base()
++//
++// ** P1 (aka bottom) and size ( P2 = P1 - size) are the address and stack size returned from
++//    pthread_attr_getstack()
++
++static void current_stack_region(address * bottom, size_t * size) {
++#ifdef __APPLE__
++  pthread_t self = pthread_self();
++  void *stacktop = pthread_get_stackaddr_np(self);
++  *size = pthread_get_stacksize_np(self);
++  // workaround for OS X 10.9.0 (Mavericks)
++  // pthread_get_stacksize_np returns 128 pages even though the actual size is 2048 pages
++  if (pthread_main_np() == 1) {
++    // At least on Mac OS 10.12 we have observed stack sizes not aligned
++    // to pages boundaries. This can be provoked by e.g. setrlimit() (ulimit -s xxxx in the
++    // shell). Apparently Mac OS actually rounds upwards to next multiple of page size,
++    // however, we round downwards here to be on the safe side.
++    *size = align_down(*size, getpagesize());
++
++    if ((*size) < (DEFAULT_MAIN_THREAD_STACK_PAGES * (size_t)getpagesize())) {
++      char kern_osrelease[256];
++      size_t kern_osrelease_size = sizeof(kern_osrelease);
++      int ret = sysctlbyname("kern.osrelease", kern_osrelease, &kern_osrelease_size, NULL, 0);
++      if (ret == 0) {
++        // get the major number, atoi will ignore the minor amd micro portions of the version string
++        if (atoi(kern_osrelease) >= OS_X_10_9_0_KERNEL_MAJOR_VERSION) {
++          *size = (DEFAULT_MAIN_THREAD_STACK_PAGES*getpagesize());
++        }
++      }
++    }
++  }
++  *bottom = (address) stacktop - *size;
++#elif defined(__OpenBSD__)
++  stack_t ss;
++  int rslt = pthread_stackseg_np(pthread_self(), &ss);
++
++  if (rslt != 0)
++    fatal("pthread_stackseg_np failed with error = %d", rslt);
++
++  *bottom = (address)((char *)ss.ss_sp - ss.ss_size);
++  *size   = ss.ss_size;
++#else
++  pthread_attr_t attr;
++
++  int rslt = pthread_attr_init(&attr);
++
++  // JVM needs to know exact stack location, abort if it fails
++  if (rslt != 0)
++    fatal("pthread_attr_init failed with error = %d", rslt);
++
++  rslt = pthread_attr_get_np(pthread_self(), &attr);
++
++  if (rslt != 0)
++    fatal("pthread_attr_get_np failed with error = %d", rslt);
++
++  if (pthread_attr_getstackaddr(&attr, (void **)bottom) != 0 ||
++    pthread_attr_getstacksize(&attr, size) != 0) {
++    fatal("Can not locate current stack attributes!");
++  }
++
++  pthread_attr_destroy(&attr);
++#endif
++  assert(os::current_stack_pointer() >= *bottom &&
++         os::current_stack_pointer() < *bottom + *size, "just checking");
++}
++
++address os::current_stack_base() {
++  address bottom;
++  size_t size;
++  current_stack_region(&bottom, &size);
++  return (bottom + size);
++}
++
++size_t os::current_stack_size() {
++  // stack size includes normal stack and HotSpot guard pages
++  address bottom;
++  size_t size;
++  current_stack_region(&bottom, &size);
++  return size;
++}
++
++/////////////////////////////////////////////////////////////////////////////
++// helper functions for fatal error handler
++
++void os::print_context(outputStream *st, const void *context) {
++  if (context == NULL) return;
++
++  const ucontext_t *uc = (const ucontext_t*)context;
++  st->print_cr("Registers:");
++#ifdef AMD64
++  st->print(  "RAX=" INTPTR_FORMAT, (intptr_t)uc->context_rax);
++  st->print(", RBX=" INTPTR_FORMAT, (intptr_t)uc->context_rbx);
++  st->print(", RCX=" INTPTR_FORMAT, (intptr_t)uc->context_rcx);
++  st->print(", RDX=" INTPTR_FORMAT, (intptr_t)uc->context_rdx);
++  st->cr();
++  st->print(  "RSP=" INTPTR_FORMAT, (intptr_t)uc->context_rsp);
++  st->print(", RBP=" INTPTR_FORMAT, (intptr_t)uc->context_rbp);
++  st->print(", RSI=" INTPTR_FORMAT, (intptr_t)uc->context_rsi);
++  st->print(", RDI=" INTPTR_FORMAT, (intptr_t)uc->context_rdi);
++  st->cr();
++  st->print(  "R8 =" INTPTR_FORMAT, (intptr_t)uc->context_r8);
++  st->print(", R9 =" INTPTR_FORMAT, (intptr_t)uc->context_r9);
++  st->print(", R10=" INTPTR_FORMAT, (intptr_t)uc->context_r10);
++  st->print(", R11=" INTPTR_FORMAT, (intptr_t)uc->context_r11);
++  st->cr();
++  st->print(  "R12=" INTPTR_FORMAT, (intptr_t)uc->context_r12);
++  st->print(", R13=" INTPTR_FORMAT, (intptr_t)uc->context_r13);
++  st->print(", R14=" INTPTR_FORMAT, (intptr_t)uc->context_r14);
++  st->print(", R15=" INTPTR_FORMAT, (intptr_t)uc->context_r15);
++  st->cr();
++  st->print(  "RIP=" INTPTR_FORMAT, (intptr_t)uc->context_rip);
++  st->print(", EFLAGS=" INTPTR_FORMAT, (intptr_t)uc->context_flags);
++  st->print(", ERR=" INTPTR_FORMAT, (intptr_t)uc->context_err);
++  st->cr();
++  st->print("  TRAPNO=" INTPTR_FORMAT, (intptr_t)uc->context_trapno);
++#else
++  st->print(  "EAX=" INTPTR_FORMAT, (intptr_t)uc->context_eax);
++  st->print(", EBX=" INTPTR_FORMAT, (intptr_t)uc->context_ebx);
++  st->print(", ECX=" INTPTR_FORMAT, (intptr_t)uc->context_ecx);
++  st->print(", EDX=" INTPTR_FORMAT, (intptr_t)uc->context_edx);
++  st->cr();
++  st->print(  "ESP=" INTPTR_FORMAT, (intptr_t)uc->context_esp);
++  st->print(", EBP=" INTPTR_FORMAT, (intptr_t)uc->context_ebp);
++  st->print(", ESI=" INTPTR_FORMAT, (intptr_t)uc->context_esi);
++  st->print(", EDI=" INTPTR_FORMAT, (intptr_t)uc->context_edi);
++  st->cr();
++  st->print(  "EIP=" INTPTR_FORMAT, (intptr_t)uc->context_eip);
++  st->print(", EFLAGS=" INTPTR_FORMAT, (intptr_t)uc->context_eflags);
++#endif // AMD64
++  st->cr();
++  st->cr();
++
++  intptr_t *sp = (intptr_t *)os::Bsd::ucontext_get_sp(uc);
++  st->print_cr("Top of Stack: (sp=" INTPTR_FORMAT ")", (intptr_t)sp);
++  print_hex_dump(st, (address)sp, (address)(sp + 8*sizeof(intptr_t)), sizeof(intptr_t));
++  st->cr();
++
++  // Note: it may be unsafe to inspect memory near pc. For example, pc may
++  // point to garbage if entry point in an nmethod is corrupted. Leave
++  // this at the end, and hope for the best.
++  address pc = os::Posix::ucontext_get_pc(uc);
++  print_instructions(st, pc, sizeof(char));
++  st->cr();
++}
++
++void os::print_register_info(outputStream *st, const void *context) {
++  if (context == NULL) return;
++
++  const ucontext_t *uc = (const ucontext_t*)context;
++
++  st->print_cr("Register to memory mapping:");
++  st->cr();
++
++  // this is horrendously verbose but the layout of the registers in the
++  // context does not match how we defined our abstract Register set, so
++  // we can't just iterate through the gregs area
++
++  // this is only for the "general purpose" registers
++
++#ifdef AMD64
++  st->print("RAX="); print_location(st, uc->context_rax);
++  st->print("RBX="); print_location(st, uc->context_rbx);
++  st->print("RCX="); print_location(st, uc->context_rcx);
++  st->print("RDX="); print_location(st, uc->context_rdx);
++  st->print("RSP="); print_location(st, uc->context_rsp);
++  st->print("RBP="); print_location(st, uc->context_rbp);
++  st->print("RSI="); print_location(st, uc->context_rsi);
++  st->print("RDI="); print_location(st, uc->context_rdi);
++  st->print("R8 ="); print_location(st, uc->context_r8);
++  st->print("R9 ="); print_location(st, uc->context_r9);
++  st->print("R10="); print_location(st, uc->context_r10);
++  st->print("R11="); print_location(st, uc->context_r11);
++  st->print("R12="); print_location(st, uc->context_r12);
++  st->print("R13="); print_location(st, uc->context_r13);
++  st->print("R14="); print_location(st, uc->context_r14);
++  st->print("R15="); print_location(st, uc->context_r15);
++#else
++  st->print("EAX="); print_location(st, uc->context_eax);
++  st->print("EBX="); print_location(st, uc->context_ebx);
++  st->print("ECX="); print_location(st, uc->context_ecx);
++  st->print("EDX="); print_location(st, uc->context_edx);
++  st->print("ESP="); print_location(st, uc->context_esp);
++  st->print("EBP="); print_location(st, uc->context_ebp);
++  st->print("ESI="); print_location(st, uc->context_esi);
++  st->print("EDI="); print_location(st, uc->context_edi);
++#endif // AMD64
++
++  st->cr();
++}
++
++void os::setup_fpu() {
++#ifndef AMD64
++  address fpu_cntrl = StubRoutines::addr_fpu_cntrl_wrd_std();
++  __asm__ volatile (  "fldcw (%0)" :
++                      : "r" (fpu_cntrl) : "memory");
++#endif // !AMD64
++}
++
++#ifndef PRODUCT
++void os::verify_stack_alignment() {
++}
++#endif
++
++int os::extra_bang_size_in_bytes() {
++  // JDK-8050147 requires the full cache line bang for x86.
++  return VM_Version::L1_line_size();
++}
+diff --git a/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.hpp b/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.hpp
+new file mode 100644
+index 000000000..f5af84e14
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.hpp
+@@ -0,0 +1,44 @@
++/*
++ * Copyright (c) 1999, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_OS_SERENITY_X86_HPP
++#define OS_CPU_SERENITY_X86_OS_SERENITY_X86_HPP
++
++// Core region alignment is 16K to be able to run binaries built on MacOS x64
++// on MacOS aarch64.
++#if defined(__APPLE__) && defined(COMPATIBLE_CDS_ALIGNMENT)
++#define CDS_CORE_REGION_ALIGNMENT (16*K)
++#endif
++
++  static void setup_fpu();
++  static bool supports_sse();
++  static juint cpu_microcode_revision();
++
++  static jlong rdtsc();
++
++  // Used to register dynamic code cache area with the OS
++  // Note: Currently only used in 64 bit Windows implementations
++  static bool register_code_area(char *low, char *high) { return true; }
++
++#endif // OS_CPU_SERENITY_X86_OS_SERENITY_X86_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.inline.hpp b/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.inline.hpp
+new file mode 100644
+index 000000000..b4a7aa621
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/os_serenity_x86.inline.hpp
+@@ -0,0 +1,46 @@
++/*
++ * Copyright (c) 2011, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_OS_SERENITY_X86_INLINE_HPP
++#define OS_CPU_SERENITY_X86_OS_SERENITY_X86_INLINE_HPP
++
++#include "runtime/os.hpp"
++
++// See http://www.technovelty.org/code/c/reading-rdtsc.htl for details
++inline jlong os::rdtsc() {
++#ifndef AMD64
++  // 64 bit result in edx:eax
++  uint64_t res;
++  __asm__ __volatile__ ("rdtsc" : "=A" (res));
++  return (jlong)res;
++#else
++  uint64_t res;
++  uint32_t ts1, ts2;
++  __asm__ __volatile__ ("rdtsc" : "=a" (ts1), "=d" (ts2));
++  res = ((uint64_t)ts1 | (uint64_t)ts2 << 32);
++  return (jlong)res;
++#endif // AMD64
++}
++
++#endif // OS_CPU_SERENITY_X86_OS_SERENITY_X86_INLINE_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/prefetch_bsd_x86.inline.hpp b/src/hotspot/os_cpu/serenity_x86/prefetch_bsd_x86.inline.hpp
+new file mode 100644
+index 000000000..01f7c46f7
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/prefetch_bsd_x86.inline.hpp
+@@ -0,0 +1,47 @@
++/*
++ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_PREFETCH_SERENITY_X86_INLINE_HPP
++#define OS_CPU_SERENITY_X86_PREFETCH_SERENITY_X86_INLINE_HPP
++
++#include "runtime/prefetch.hpp"
++
++
++inline void Prefetch::read (void *loc, intx interval) {
++#ifdef AMD64
++  __asm__ ("prefetcht0 (%0,%1,1)" : : "r" (loc), "r" (interval));
++#endif // AMD64
++}
++
++inline void Prefetch::write(void *loc, intx interval) {
++#ifdef AMD64
++
++  // Do not use the 3dnow prefetchw instruction.  It isn't supported on em64t.
++  //  __asm__ ("prefetchw (%0,%1,1)" : : "r" (loc), "r" (interval));
++  __asm__ ("prefetcht0 (%0,%1,1)" : : "r" (loc), "r" (interval));
++
++#endif // AMD64
++}
++
++#endif // OS_CPU_SERENITY_X86_PREFETCH_SERENITY_X86_INLINE_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/serenity_x86_32.S b/src/hotspot/os_cpu/serenity_x86/serenity_x86_32.S
+new file mode 100644
+index 000000000..0d22a6a67
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/serenity_x86_32.S
+@@ -0,0 +1,667 @@
++#
++# Copyright (c) 2004, 2017, Oracle and/or its affiliates. All rights reserved.
++# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++#
++# This code is free software; you can redistribute it and/or modify it
++# under the terms of the GNU General Public License version 2 only, as
++# published by the Free Software Foundation.
++#
++# This code is distributed in the hope that it will be useful, but WITHOUT
++# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++# version 2 for more details (a copy is included in the LICENSE file that
++# accompanied this code).
++#
++# You should have received a copy of the GNU General Public License version
++# 2 along with this work; if not, write to the Free Software Foundation,
++# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++#
++# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++# or visit www.oracle.com if you need additional information or have any
++# questions.
++#
++
++
++#ifdef __APPLE__
++# Darwin uses _ prefixed global symbols
++#define SYMBOL(s) _ ## s
++#define ELF_TYPE(name, description)
++#else
++#define SYMBOL(s) s
++#define ELF_TYPE(name, description) .type name,description
++#endif
++
++        .globl SYMBOL(fixcw)
++
++        # NOTE WELL!  The _Copy functions are called directly
++        # from server-compiler-generated code via CallLeafNoFP,
++        # which means that they *must* either not use floating
++        # point or use it in the same manner as does the server
++        # compiler.
++
++        .globl SYMBOL(_Copy_conjoint_bytes)
++        .globl SYMBOL(_Copy_arrayof_conjoint_bytes)
++        .globl SYMBOL(_Copy_conjoint_jshorts_atomic)
++        .globl SYMBOL(_Copy_arrayof_conjoint_jshorts)
++        .globl SYMBOL(_Copy_conjoint_jints_atomic)
++        .globl SYMBOL(_Copy_arrayof_conjoint_jints)
++        .globl SYMBOL(_Copy_conjoint_jlongs_atomic)
++        .globl SYMBOL(_mmx_Copy_arrayof_conjoint_jshorts)
++
++        .globl SYMBOL(_Atomic_cmpxchg_long)
++        .globl SYMBOL(_Atomic_move_long)
++
++        .text
++
++# Support for void os::Solaris::init_thread_fpu_state() in os_solaris_i486.cpp
++# Set fpu to 53 bit precision.  This happens too early to use a stub.
++# ported from solaris_x86_32.s
++        .p2align 4,,15
++SYMBOL(fixcw):
++        pushl    $0x27f
++        fldcw    0(%esp)
++        popl     %eax
++        ret
++
++        .globl  SYMBOL(SpinPause)
++        ELF_TYPE(SpinPause,@function)
++        .p2align 4,,15
++SYMBOL(SpinPause):
++        rep
++        nop
++        movl    $1, %eax
++        ret
++
++        # Support for void Copy::conjoint_bytes(void* from,
++        #                                       void* to,
++        #                                       size_t count)
++        .p2align 4,,15
++        ELF_TYPE(_Copy_conjoint_bytes,@function)
++SYMBOL(_Copy_conjoint_bytes):
++        pushl    %esi
++        movl     4+12(%esp),%ecx      # count
++        pushl    %edi
++        movl     8+ 4(%esp),%esi      # from
++        movl     8+ 8(%esp),%edi      # to
++        cmpl     %esi,%edi
++        leal     -1(%esi,%ecx),%eax   # from + count - 1
++        jbe      cb_CopyRight
++        cmpl     %eax,%edi
++        jbe      cb_CopyLeft
++        # copy from low to high
++cb_CopyRight:
++        cmpl     $3,%ecx
++        jbe      5f                   # <= 3 bytes
++        # align source address at dword address boundary
++        movl     %ecx,%eax            # original count
++        movl     $4,%ecx
++        subl     %esi,%ecx
++        andl     $3,%ecx              # prefix byte count
++        jz       1f                   # no prefix
++        subl     %ecx,%eax            # byte count less prefix
++        # copy prefix
++        subl     %esi,%edi
++0:      movb     (%esi),%dl
++        movb     %dl,(%edi,%esi,1)
++        addl     $1,%esi
++        subl     $1,%ecx
++        jnz      0b
++        addl     %esi,%edi
++1:      movl     %eax,%ecx            # byte count less prefix
++        shrl     $2,%ecx              # dword count
++        jz       4f                   # no dwords to move
++        cmpl     $32,%ecx
++        jbe      2f                   # <= 32 dwords
++        # copy aligned dwords
++        rep;     smovl
++        jmp      4f
++        # copy aligned dwords
++2:      subl     %esi,%edi
++        .p2align 4,,15
++3:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        addl     $4,%esi
++        subl     $1,%ecx
++        jnz      3b
++        addl     %esi,%edi
++4:      movl     %eax,%ecx            # byte count less prefix
++5:      andl     $3,%ecx              # suffix byte count
++        jz       7f                   # no suffix
++        # copy suffix
++        xorl     %eax,%eax
++6:      movb     (%esi,%eax,1),%dl
++        movb     %dl,(%edi,%eax,1)
++        addl     $1,%eax
++        subl     $1,%ecx
++        jnz      6b
++7:      popl     %edi
++        popl     %esi
++        ret
++        # copy from high to low
++cb_CopyLeft:
++        std
++        leal     -4(%edi,%ecx),%edi   # to + count - 4
++        movl     %eax,%esi            # from + count - 1
++        movl     %ecx,%eax
++        subl     $3,%esi              # from + count - 4
++        cmpl     $3,%ecx
++        jbe      5f                   # <= 3 bytes
++1:      shrl     $2,%ecx              # dword count
++        jz       4f                   # no dwords to move
++        cmpl     $32,%ecx
++        ja       3f                   # > 32 dwords
++        # copy dwords, aligned or not
++        subl     %esi,%edi
++        .p2align 4,,15
++2:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        subl     $4,%esi
++        subl     $1,%ecx
++        jnz      2b
++        addl     %esi,%edi
++        jmp      4f
++        # copy dwords, aligned or not
++3:      rep;     smovl
++4:      movl     %eax,%ecx            # byte count
++5:      andl     $3,%ecx              # suffix byte count
++        jz       7f                   # no suffix
++        # copy suffix
++        subl     %esi,%edi
++        addl     $3,%esi
++6:      movb     (%esi),%dl
++        movb     %dl,(%edi,%esi,1)
++        subl     $1,%esi
++        subl     $1,%ecx
++        jnz      6b
++7:      cld
++        popl     %edi
++        popl     %esi
++        ret
++
++        # Support for void Copy::arrayof_conjoint_bytes(void* from,
++        #                                               void* to,
++        #                                               size_t count)
++        #
++        # Same as _Copy_conjoint_bytes, except no source alignment check.
++        .p2align 4,,15
++        ELF_TYPE(_Copy_arrayof_conjoint_bytes,@function)
++SYMBOL(_Copy_arrayof_conjoint_bytes):
++        pushl    %esi
++        movl     4+12(%esp),%ecx      # count
++        pushl    %edi
++        movl     8+ 4(%esp),%esi      # from
++        movl     8+ 8(%esp),%edi      # to
++        cmpl     %esi,%edi
++        leal     -1(%esi,%ecx),%eax   # from + count - 1
++        jbe      acb_CopyRight
++        cmpl     %eax,%edi
++        jbe      acb_CopyLeft
++        # copy from low to high
++acb_CopyRight:
++        cmpl     $3,%ecx
++        jbe      5f
++1:      movl     %ecx,%eax
++        shrl     $2,%ecx
++        jz       4f
++        cmpl     $32,%ecx
++        ja       3f
++        # copy aligned dwords
++        subl     %esi,%edi
++        .p2align 4,,15
++2:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        addl     $4,%esi
++        subl     $1,%ecx
++        jnz      2b
++        addl     %esi,%edi
++        jmp      4f
++        # copy aligned dwords
++3:      rep;     smovl
++4:      movl     %eax,%ecx
++5:      andl     $3,%ecx
++        jz       7f
++        # copy suffix
++        xorl     %eax,%eax
++6:      movb     (%esi,%eax,1),%dl
++        movb     %dl,(%edi,%eax,1)
++        addl     $1,%eax
++        subl     $1,%ecx
++        jnz      6b
++7:      popl     %edi
++        popl     %esi
++        ret
++acb_CopyLeft:
++        std
++        leal     -4(%edi,%ecx),%edi   # to + count - 4
++        movl     %eax,%esi            # from + count - 1
++        movl     %ecx,%eax
++        subl     $3,%esi              # from + count - 4
++        cmpl     $3,%ecx
++        jbe      5f
++1:      shrl     $2,%ecx
++        jz       4f
++        cmpl     $32,%ecx
++        jbe      2f                   # <= 32 dwords
++        rep;     smovl
++        jmp      4f
++        .space 8
++2:      subl     %esi,%edi
++        .p2align 4,,15
++3:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        subl     $4,%esi
++        subl     $1,%ecx
++        jnz      3b
++        addl     %esi,%edi
++4:      movl     %eax,%ecx
++5:      andl     $3,%ecx
++        jz       7f
++        subl     %esi,%edi
++        addl     $3,%esi
++6:      movb     (%esi),%dl
++        movb     %dl,(%edi,%esi,1)
++        subl     $1,%esi
++        subl     $1,%ecx
++        jnz      6b
++7:      cld
++        popl     %edi
++        popl     %esi
++        ret
++
++        # Support for void Copy::conjoint_jshorts_atomic(void* from,
++        #                                                void* to,
++        #                                                size_t count)
++        .p2align 4,,15
++        ELF_TYPE(_Copy_conjoint_jshorts_atomic,@function)
++SYMBOL(_Copy_conjoint_jshorts_atomic):
++        pushl    %esi
++        movl     4+12(%esp),%ecx      # count
++        pushl    %edi
++        movl     8+ 4(%esp),%esi      # from
++        movl     8+ 8(%esp),%edi      # to
++        cmpl     %esi,%edi
++        leal     -2(%esi,%ecx,2),%eax # from + count*2 - 2
++        jbe      cs_CopyRight
++        cmpl     %eax,%edi
++        jbe      cs_CopyLeft
++        # copy from low to high
++cs_CopyRight:
++        # align source address at dword address boundary
++        movl     %esi,%eax            # original from
++        andl     $3,%eax              # either 0 or 2
++        jz       1f                   # no prefix
++        # copy prefix
++        subl     $1,%ecx
++        jl       5f                   # zero count
++        movw     (%esi),%dx
++        movw     %dx,(%edi)
++        addl     %eax,%esi            # %eax == 2
++        addl     %eax,%edi
++1:      movl     %ecx,%eax            # word count less prefix
++        sarl     %ecx                 # dword count
++        jz       4f                   # no dwords to move
++        cmpl     $32,%ecx
++        jbe      2f                   # <= 32 dwords
++        # copy aligned dwords
++        rep;     smovl
++        jmp      4f
++        # copy aligned dwords
++2:      subl     %esi,%edi
++        .p2align 4,,15
++3:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        addl     $4,%esi
++        subl     $1,%ecx
++        jnz      3b
++        addl     %esi,%edi
++4:      andl     $1,%eax              # suffix count
++        jz       5f                   # no suffix
++        # copy suffix
++        movw     (%esi),%dx
++        movw     %dx,(%edi)
++5:      popl     %edi
++        popl     %esi
++        ret
++        # copy from high to low
++cs_CopyLeft:
++        std
++        leal     -4(%edi,%ecx,2),%edi # to + count*2 - 4
++        movl     %eax,%esi            # from + count*2 - 2
++        movl     %ecx,%eax
++        subl     $2,%esi              # from + count*2 - 4
++1:      sarl     %ecx                 # dword count
++        jz       4f                   # no dwords to move
++        cmpl     $32,%ecx
++        ja       3f                   # > 32 dwords
++        subl     %esi,%edi
++        .p2align 4,,15
++2:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        subl     $4,%esi
++        subl     $1,%ecx
++        jnz      2b
++        addl     %esi,%edi
++        jmp      4f
++3:      rep;     smovl
++4:      andl     $1,%eax              # suffix count
++        jz       5f                   # no suffix
++        # copy suffix
++        addl     $2,%esi
++        addl     $2,%edi
++        movw     (%esi),%dx
++        movw     %dx,(%edi)
++5:      cld
++        popl     %edi
++        popl     %esi
++        ret
++
++        # Support for void Copy::arrayof_conjoint_jshorts(void* from,
++        #                                                 void* to,
++        #                                                 size_t count)
++        .p2align 4,,15
++        ELF_TYPE(_Copy_arrayof_conjoint_jshorts,@function)
++SYMBOL(_Copy_arrayof_conjoint_jshorts):
++        pushl    %esi
++        movl     4+12(%esp),%ecx      # count
++        pushl    %edi
++        movl     8+ 4(%esp),%esi      # from
++        movl     8+ 8(%esp),%edi      # to
++        cmpl     %esi,%edi
++        leal     -2(%esi,%ecx,2),%eax # from + count*2 - 2
++        jbe      acs_CopyRight
++        cmpl     %eax,%edi
++        jbe      acs_CopyLeft
++acs_CopyRight:
++        movl     %ecx,%eax            # word count
++        sarl     %ecx                 # dword count
++        jz       4f                   # no dwords to move
++        cmpl     $32,%ecx
++        jbe      2f                   # <= 32 dwords
++        # copy aligned dwords
++        rep;     smovl
++        jmp      4f
++        # copy aligned dwords
++        .space 5
++2:      subl     %esi,%edi
++        .p2align 4,,15
++3:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        addl     $4,%esi
++        subl     $1,%ecx
++        jnz      3b
++        addl     %esi,%edi
++4:      andl     $1,%eax              # suffix count
++        jz       5f                   # no suffix
++        # copy suffix
++        movw     (%esi),%dx
++        movw     %dx,(%edi)
++5:      popl     %edi
++        popl     %esi
++        ret
++acs_CopyLeft:
++        std
++        leal     -4(%edi,%ecx,2),%edi # to + count*2 - 4
++        movl     %eax,%esi            # from + count*2 - 2
++        movl     %ecx,%eax
++        subl     $2,%esi              # from + count*2 - 4
++        sarl     %ecx                 # dword count
++        jz       4f                   # no dwords to move
++        cmpl     $32,%ecx
++        ja       3f                   # > 32 dwords
++        subl     %esi,%edi
++        .p2align 4,,15
++2:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        subl     $4,%esi
++        subl     $1,%ecx
++        jnz      2b
++        addl     %esi,%edi
++        jmp      4f
++3:      rep;     smovl
++4:      andl     $1,%eax              # suffix count
++        jz       5f                   # no suffix
++        # copy suffix
++        addl     $2,%esi
++        addl     $2,%edi
++        movw     (%esi),%dx
++        movw     %dx,(%edi)
++5:      cld
++        popl     %edi
++        popl     %esi
++        ret
++
++        # Support for void Copy::conjoint_jints_atomic(void* from,
++        #                                              void* to,
++        #                                              size_t count)
++        # Equivalent to
++        #   arrayof_conjoint_jints
++        .p2align 4,,15
++        ELF_TYPE(_Copy_conjoint_jints_atomic,@function)
++        ELF_TYPE(_Copy_arrayof_conjoint_jints,@function)
++SYMBOL(_Copy_conjoint_jints_atomic):
++SYMBOL(_Copy_arrayof_conjoint_jints):
++        pushl    %esi
++        movl     4+12(%esp),%ecx      # count
++        pushl    %edi
++        movl     8+ 4(%esp),%esi      # from
++        movl     8+ 8(%esp),%edi      # to
++        cmpl     %esi,%edi
++        leal     -4(%esi,%ecx,4),%eax # from + count*4 - 4
++        jbe      ci_CopyRight
++        cmpl     %eax,%edi
++        jbe      ci_CopyLeft
++ci_CopyRight:
++        cmpl     $32,%ecx
++        jbe      2f                   # <= 32 dwords
++        rep;     smovl
++        popl     %edi
++        popl     %esi
++        ret
++        .space 10
++2:      subl     %esi,%edi
++        jmp      4f
++        .p2align 4,,15
++3:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        addl     $4,%esi
++4:      subl     $1,%ecx
++        jge      3b
++        popl     %edi
++        popl     %esi
++        ret
++ci_CopyLeft:
++        std
++        leal     -4(%edi,%ecx,4),%edi # to + count*4 - 4
++        cmpl     $32,%ecx
++        ja       4f                   # > 32 dwords
++        subl     %eax,%edi            # eax == from + count*4 - 4
++        jmp      3f
++        .p2align 4,,15
++2:      movl     (%eax),%edx
++        movl     %edx,(%edi,%eax,1)
++        subl     $4,%eax
++3:      subl     $1,%ecx
++        jge      2b
++        cld
++        popl     %edi
++        popl     %esi
++        ret
++4:      movl     %eax,%esi            # from + count*4 - 4
++        rep;     smovl
++        cld
++        popl     %edi
++        popl     %esi
++        ret
++
++        # Support for void Copy::conjoint_jlongs_atomic(jlong* from,
++        #                                               jlong* to,
++        #                                               size_t count)
++        #
++        # 32-bit
++        #
++        # count treated as signed
++        #
++        # // if (from > to) {
++        #   while (--count >= 0) {
++        #     *to++ = *from++;
++        #   }
++        # } else {
++        #   while (--count >= 0) {
++        #     to[count] = from[count];
++        #   }
++        # }
++        .p2align 4,,15
++        ELF_TYPE(_Copy_conjoint_jlongs_atomic,@function)
++SYMBOL(_Copy_conjoint_jlongs_atomic):
++        movl     4+8(%esp),%ecx       # count
++        movl     4+0(%esp),%eax       # from
++        movl     4+4(%esp),%edx       # to
++        cmpl     %eax,%edx
++        jae      cla_CopyLeft
++cla_CopyRight:
++        subl     %eax,%edx
++        jmp      2f
++        .p2align 4,,15
++1:      fildll   (%eax)
++        fistpll  (%edx,%eax,1)
++        addl     $8,%eax
++2:      subl     $1,%ecx
++        jge      1b
++        ret
++        .p2align 4,,15
++3:      fildll   (%eax,%ecx,8)
++        fistpll  (%edx,%ecx,8)
++cla_CopyLeft:
++        subl     $1,%ecx
++        jge      3b
++        ret
++
++        # Support for void Copy::arrayof_conjoint_jshorts(void* from,
++        #                                                 void* to,
++        #                                                 size_t count)
++        .p2align 4,,15
++        ELF_TYPE(_mmx_Copy_arrayof_conjoint_jshorts,@function)
++SYMBOL(_mmx_Copy_arrayof_conjoint_jshorts):
++        pushl    %esi
++        movl     4+12(%esp),%ecx
++        pushl    %edi
++        movl     8+ 4(%esp),%esi
++        movl     8+ 8(%esp),%edi
++        cmpl     %esi,%edi
++        leal     -2(%esi,%ecx,2),%eax
++        jbe      mmx_acs_CopyRight
++        cmpl     %eax,%edi
++        jbe      mmx_acs_CopyLeft
++mmx_acs_CopyRight:
++        movl     %ecx,%eax
++        sarl     %ecx
++        je       5f
++        cmpl     $33,%ecx
++        jae      3f
++1:      subl     %esi,%edi
++        .p2align 4,,15
++2:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        addl     $4,%esi
++        subl     $1,%ecx
++        jnz      2b
++        addl     %esi,%edi
++        jmp      5f
++3:      smovl # align to 8 bytes, we know we are 4 byte aligned to start
++        subl     $1,%ecx
++4:      .p2align 4,,15
++        movq     0(%esi),%mm0
++        addl     $64,%edi
++        movq     8(%esi),%mm1
++        subl     $16,%ecx
++        movq     16(%esi),%mm2
++        movq     %mm0,-64(%edi)
++        movq     24(%esi),%mm0
++        movq     %mm1,-56(%edi)
++        movq     32(%esi),%mm1
++        movq     %mm2,-48(%edi)
++        movq     40(%esi),%mm2
++        movq     %mm0,-40(%edi)
++        movq     48(%esi),%mm0
++        movq     %mm1,-32(%edi)
++        movq     56(%esi),%mm1
++        movq     %mm2,-24(%edi)
++        movq     %mm0,-16(%edi)
++        addl     $64,%esi
++        movq     %mm1,-8(%edi)
++        cmpl     $16,%ecx
++        jge      4b
++        emms
++        testl    %ecx,%ecx
++        ja       1b
++5:      andl     $1,%eax
++        je       7f
++6:      movw     (%esi),%dx
++        movw     %dx,(%edi)
++7:      popl     %edi
++        popl     %esi
++        ret
++mmx_acs_CopyLeft:
++        std
++        leal     -4(%edi,%ecx,2),%edi
++        movl     %eax,%esi
++        movl     %ecx,%eax
++        subl     $2,%esi
++        sarl     %ecx
++        je       4f
++        cmpl     $32,%ecx
++        ja       3f
++        subl     %esi,%edi
++        .p2align 4,,15
++2:      movl     (%esi),%edx
++        movl     %edx,(%edi,%esi,1)
++        subl     $4,%esi
++        subl     $1,%ecx
++        jnz      2b
++        addl     %esi,%edi
++        jmp      4f
++3:      rep;     smovl
++4:      andl     $1,%eax
++        je       6f
++        addl     $2,%esi
++        addl     $2,%edi
++5:      movw     (%esi),%dx
++        movw     %dx,(%edi)
++6:      cld
++        popl     %edi
++        popl     %esi
++        ret
++
++
++        # Support for int64_t Atomic::cmpxchg(int64_t compare_value,
++        #                                     volatile int64_t* dest,
++        #                                     int64_t exchange_value)
++        #
++        .p2align 4,,15
++        ELF_TYPE(_Atomic_cmpxchg_long,@function)
++SYMBOL(_Atomic_cmpxchg_long):
++                                   #  8(%esp) : return PC
++        pushl    %ebx              #  4(%esp) : old %ebx
++        pushl    %edi              #  0(%esp) : old %edi
++        movl     12(%esp), %ebx    # 12(%esp) : exchange_value (low)
++        movl     16(%esp), %ecx    # 16(%esp) : exchange_value (high)
++        movl     24(%esp), %eax    # 24(%esp) : compare_value (low)
++        movl     28(%esp), %edx    # 28(%esp) : compare_value (high)
++        movl     20(%esp), %edi    # 20(%esp) : dest
++        lock
++        cmpxchg8b (%edi)
++        popl     %edi
++        popl     %ebx
++        ret
++
++
++        # Support for int64_t Atomic::load and Atomic::store.
++        # void _Atomic_move_long(const volatile int64_t* src, volatile int64_t* dst)
++        .p2align 4,,15
++        ELF_TYPE(_Atomic_move_long,@function)
++SYMBOL(_Atomic_move_long):
++        movl     4(%esp), %eax   # src
++        fildll    (%eax)
++        movl     8(%esp), %eax   # dest
++        fistpll   (%eax)
++        ret
+diff --git a/src/hotspot/os_cpu/serenity_x86/serenity_x86_64.S b/src/hotspot/os_cpu/serenity_x86/serenity_x86_64.S
+new file mode 100644
+index 000000000..95cea3bf2
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/serenity_x86_64.S
+@@ -0,0 +1,388 @@
++# 
++# Copyright (c) 2004, 2013, Oracle and/or its affiliates. All rights reserved.
++# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++#
++# This code is free software; you can redistribute it and/or modify it
++# under the terms of the GNU General Public License version 2 only, as
++# published by the Free Software Foundation.
++#
++# This code is distributed in the hope that it will be useful, but WITHOUT
++# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++# version 2 for more details (a copy is included in the LICENSE file that
++# accompanied this code).
++#
++# You should have received a copy of the GNU General Public License version
++# 2 along with this work; if not, write to the Free Software Foundation,
++# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++#
++# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++# or visit www.oracle.com if you need additional information or have any
++# questions.
++#
++
++#ifdef __APPLE__
++# Darwin uses _ prefixed global symbols
++#define SYMBOL(s) _ ## s
++#define ELF_TYPE(name, description)
++#else
++#define SYMBOL(s) s
++#define ELF_TYPE(name, description) .type name,description
++#endif
++
++        # NOTE WELL!  The _Copy functions are called directly
++	# from server-compiler-generated code via CallLeafNoFP,
++	# which means that they *must* either not use floating
++	# point or use it in the same manner as does the server
++	# compiler.
++	
++        .globl SYMBOL(_Copy_arrayof_conjoint_bytes)
++	.globl SYMBOL(_Copy_arrayof_conjoint_jshorts)
++        .globl SYMBOL(_Copy_conjoint_jshorts_atomic)
++        .globl SYMBOL(_Copy_arrayof_conjoint_jints)
++        .globl SYMBOL(_Copy_conjoint_jints_atomic)
++        .globl SYMBOL(_Copy_arrayof_conjoint_jlongs)
++        .globl SYMBOL(_Copy_conjoint_jlongs_atomic)
++
++	.text
++
++        .globl SYMBOL(SpinPause)
++        .p2align 4,,15
++        ELF_TYPE(SpinPause,@function)
++SYMBOL(SpinPause):
++        rep
++        nop
++        movq   $1, %rax
++        ret
++
++        # Support for void Copy::arrayof_conjoint_bytes(void* from,
++        #                                               void* to,
++        #                                               size_t count)
++        # rdi - from
++        # rsi - to
++        # rdx - count, treated as ssize_t
++        #
++        .p2align 4,,15
++	ELF_TYPE(_Copy_arrayof_conjoint_bytes,@function)
++SYMBOL(_Copy_arrayof_conjoint_bytes):
++        movq     %rdx,%r8             # byte count
++        shrq     $3,%rdx              # qword count
++        cmpq     %rdi,%rsi
++        leaq     -1(%rdi,%r8,1),%rax  # from + bcount*1 - 1
++        jbe      acb_CopyRight
++        cmpq     %rax,%rsi
++        jbe      acb_CopyLeft 
++acb_CopyRight:
++        leaq     -8(%rdi,%rdx,8),%rax # from + qcount*8 - 8
++        leaq     -8(%rsi,%rdx,8),%rcx # to + qcount*8 - 8
++        negq     %rdx
++        jmp      7f
++        .p2align 4,,15
++1:      movq     8(%rax,%rdx,8),%rsi
++        movq     %rsi,8(%rcx,%rdx,8)
++        addq     $1,%rdx
++        jnz      1b
++2:      testq    $4,%r8               # check for trailing dword
++        jz       3f
++        movl     8(%rax),%esi         # copy trailing dword
++        movl     %esi,8(%rcx)
++        addq     $4,%rax
++        addq     $4,%rcx              # original %rsi is trashed, so we
++                                      #  can't use it as a base register
++3:      testq    $2,%r8               # check for trailing word
++        jz       4f
++        movw     8(%rax),%si          # copy trailing word
++        movw     %si,8(%rcx)
++        addq     $2,%rcx
++4:      testq    $1,%r8               # check for trailing byte
++        jz       5f
++        movb     -1(%rdi,%r8,1),%al   # copy trailing byte
++        movb     %al,8(%rcx)
++5:      ret
++        .p2align 4,,15
++6:      movq     -24(%rax,%rdx,8),%rsi
++        movq     %rsi,-24(%rcx,%rdx,8)
++        movq     -16(%rax,%rdx,8),%rsi
++        movq     %rsi,-16(%rcx,%rdx,8)
++        movq     -8(%rax,%rdx,8),%rsi
++        movq     %rsi,-8(%rcx,%rdx,8)
++        movq     (%rax,%rdx,8),%rsi
++        movq     %rsi,(%rcx,%rdx,8)
++7:      addq     $4,%rdx
++        jle      6b
++        subq     $4,%rdx
++        jl       1b
++        jmp      2b
++acb_CopyLeft:
++        testq    $1,%r8               # check for trailing byte
++        jz       1f
++        movb     -1(%rdi,%r8,1),%cl   # copy trailing byte
++        movb     %cl,-1(%rsi,%r8,1)
++        subq     $1,%r8               # adjust for possible trailing word
++1:      testq    $2,%r8               # check for trailing word
++        jz       2f
++        movw     -2(%rdi,%r8,1),%cx   # copy trailing word
++        movw     %cx,-2(%rsi,%r8,1)
++2:      testq    $4,%r8               # check for trailing dword
++        jz       5f
++        movl     (%rdi,%rdx,8),%ecx   # copy trailing dword
++        movl     %ecx,(%rsi,%rdx,8)
++        jmp      5f
++        .p2align 4,,15
++3:      movq     -8(%rdi,%rdx,8),%rcx
++        movq     %rcx,-8(%rsi,%rdx,8)
++        subq     $1,%rdx
++        jnz      3b
++        ret
++        .p2align 4,,15
++4:      movq     24(%rdi,%rdx,8),%rcx
++        movq     %rcx,24(%rsi,%rdx,8)
++        movq     16(%rdi,%rdx,8),%rcx
++        movq     %rcx,16(%rsi,%rdx,8)
++        movq     8(%rdi,%rdx,8),%rcx
++        movq     %rcx,8(%rsi,%rdx,8)
++        movq     (%rdi,%rdx,8),%rcx
++        movq     %rcx,(%rsi,%rdx,8)
++5:      subq     $4,%rdx
++        jge      4b
++        addq     $4,%rdx
++        jg       3b
++        ret
++
++        # Support for void Copy::arrayof_conjoint_jshorts(void* from,
++        #                                                 void* to,
++        #                                                 size_t count)
++        # Equivalent to
++        #   conjoint_jshorts_atomic
++        #
++        # If 'from' and/or 'to' are aligned on 4- or 2-byte boundaries, we
++        # let the hardware handle it.  The tow or four words within dwords
++        # or qwords that span cache line boundaries will still be loaded
++        # and stored atomically.
++        #
++        # rdi - from
++        # rsi - to
++        # rdx - count, treated as ssize_t
++        #
++        .p2align 4,,15
++	ELF_TYPE(_Copy_arrayof_conjoint_jshorts,@function)
++	ELF_TYPE(_Copy_conjoint_jshorts_atomic,@function)
++SYMBOL(_Copy_arrayof_conjoint_jshorts):
++SYMBOL(_Copy_conjoint_jshorts_atomic):
++        movq     %rdx,%r8             # word count
++        shrq     $2,%rdx              # qword count
++        cmpq     %rdi,%rsi
++        leaq     -2(%rdi,%r8,2),%rax  # from + wcount*2 - 2
++        jbe      acs_CopyRight
++        cmpq     %rax,%rsi
++        jbe      acs_CopyLeft 
++acs_CopyRight:
++        leaq     -8(%rdi,%rdx,8),%rax # from + qcount*8 - 8
++        leaq     -8(%rsi,%rdx,8),%rcx # to + qcount*8 - 8
++        negq     %rdx
++        jmp      6f
++1:      movq     8(%rax,%rdx,8),%rsi
++        movq     %rsi,8(%rcx,%rdx,8)
++        addq     $1,%rdx
++        jnz      1b
++2:      testq    $2,%r8               # check for trailing dword
++        jz       3f
++        movl     8(%rax),%esi         # copy trailing dword
++        movl     %esi,8(%rcx)
++        addq     $4,%rcx              # original %rsi is trashed, so we
++                                      #  can't use it as a base register
++3:      testq    $1,%r8               # check for trailing word
++        jz       4f
++        movw     -2(%rdi,%r8,2),%si   # copy trailing word
++        movw     %si,8(%rcx)
++4:      ret
++        .p2align 4,,15
++5:      movq     -24(%rax,%rdx,8),%rsi
++        movq     %rsi,-24(%rcx,%rdx,8)
++        movq     -16(%rax,%rdx,8),%rsi
++        movq     %rsi,-16(%rcx,%rdx,8)
++        movq     -8(%rax,%rdx,8),%rsi
++        movq     %rsi,-8(%rcx,%rdx,8)
++        movq     (%rax,%rdx,8),%rsi
++        movq     %rsi,(%rcx,%rdx,8)
++6:      addq     $4,%rdx
++        jle      5b
++        subq     $4,%rdx
++        jl       1b
++        jmp      2b
++acs_CopyLeft:
++        testq    $1,%r8               # check for trailing word
++        jz       1f
++        movw     -2(%rdi,%r8,2),%cx   # copy trailing word
++        movw     %cx,-2(%rsi,%r8,2)
++1:      testq    $2,%r8               # check for trailing dword
++        jz       4f
++        movl     (%rdi,%rdx,8),%ecx   # copy trailing dword
++        movl     %ecx,(%rsi,%rdx,8)
++        jmp      4f
++2:      movq     -8(%rdi,%rdx,8),%rcx
++        movq     %rcx,-8(%rsi,%rdx,8)
++        subq     $1,%rdx
++        jnz      2b
++        ret
++        .p2align 4,,15
++3:      movq     24(%rdi,%rdx,8),%rcx
++        movq     %rcx,24(%rsi,%rdx,8)
++        movq     16(%rdi,%rdx,8),%rcx
++        movq     %rcx,16(%rsi,%rdx,8)
++        movq     8(%rdi,%rdx,8),%rcx
++        movq     %rcx,8(%rsi,%rdx,8)
++        movq     (%rdi,%rdx,8),%rcx
++        movq     %rcx,(%rsi,%rdx,8)
++4:      subq     $4,%rdx
++        jge      3b
++        addq     $4,%rdx
++        jg       2b
++        ret
++
++        # Support for void Copy::arrayof_conjoint_jints(jint* from,
++        #                                               jint* to,
++        #                                               size_t count)
++        # Equivalent to
++        #   conjoint_jints_atomic
++        #
++        # If 'from' and/or 'to' are aligned on 4-byte boundaries, we let
++        # the hardware handle it.  The two dwords within qwords that span
++        # cache line boundaries will still be loaded and stored atomically.
++        #
++        # rdi - from
++        # rsi - to
++        # rdx - count, treated as ssize_t
++        #
++        .p2align 4,,15
++	ELF_TYPE(_Copy_arrayof_conjoint_jints,@function)
++	ELF_TYPE(_Copy_conjoint_jints_atomic,@function)
++SYMBOL(_Copy_arrayof_conjoint_jints):
++SYMBOL(_Copy_conjoint_jints_atomic):
++        movq     %rdx,%r8             # dword count
++        shrq     %rdx                 # qword count
++        cmpq     %rdi,%rsi
++        leaq     -4(%rdi,%r8,4),%rax  # from + dcount*4 - 4
++        jbe      aci_CopyRight
++        cmpq     %rax,%rsi
++        jbe      aci_CopyLeft 
++aci_CopyRight:
++        leaq     -8(%rdi,%rdx,8),%rax # from + qcount*8 - 8
++        leaq     -8(%rsi,%rdx,8),%rcx # to + qcount*8 - 8
++        negq     %rdx
++        jmp      5f
++        .p2align 4,,15
++1:      movq     8(%rax,%rdx,8),%rsi
++        movq     %rsi,8(%rcx,%rdx,8)
++        addq     $1,%rdx
++        jnz       1b
++2:      testq    $1,%r8               # check for trailing dword
++        jz       3f
++        movl     8(%rax),%esi         # copy trailing dword
++        movl     %esi,8(%rcx)
++3:      ret
++        .p2align 4,,15
++4:      movq     -24(%rax,%rdx,8),%rsi
++        movq     %rsi,-24(%rcx,%rdx,8)
++        movq     -16(%rax,%rdx,8),%rsi
++        movq     %rsi,-16(%rcx,%rdx,8)
++        movq     -8(%rax,%rdx,8),%rsi
++        movq     %rsi,-8(%rcx,%rdx,8)
++        movq     (%rax,%rdx,8),%rsi
++        movq     %rsi,(%rcx,%rdx,8)
++5:      addq     $4,%rdx
++        jle      4b
++        subq     $4,%rdx
++        jl       1b
++        jmp      2b
++aci_CopyLeft:
++        testq    $1,%r8               # check for trailing dword
++        jz       3f
++        movl     -4(%rdi,%r8,4),%ecx  # copy trailing dword
++        movl     %ecx,-4(%rsi,%r8,4)
++        jmp      3f
++1:      movq     -8(%rdi,%rdx,8),%rcx
++        movq     %rcx,-8(%rsi,%rdx,8)
++        subq     $1,%rdx
++        jnz      1b
++        ret
++        .p2align 4,,15
++2:      movq     24(%rdi,%rdx,8),%rcx
++        movq     %rcx,24(%rsi,%rdx,8)
++        movq     16(%rdi,%rdx,8),%rcx
++        movq     %rcx,16(%rsi,%rdx,8)
++        movq     8(%rdi,%rdx,8),%rcx
++        movq     %rcx,8(%rsi,%rdx,8)
++        movq     (%rdi,%rdx,8),%rcx
++        movq     %rcx,(%rsi,%rdx,8)
++3:      subq     $4,%rdx
++        jge      2b
++        addq     $4,%rdx
++        jg       1b
++        ret
++
++        # Support for void Copy::arrayof_conjoint_jlongs(jlong* from,
++        #                                                jlong* to,
++        #                                                size_t count)
++        # Equivalent to
++        #   conjoint_jlongs_atomic
++        #   arrayof_conjoint_oops
++        #   conjoint_oops_atomic
++        #
++        # rdi - from
++        # rsi - to
++        # rdx - count, treated as ssize_t
++        #
++        .p2align 4,,15
++	ELF_TYPE(_Copy_arrayof_conjoint_jlongs,@function)
++	ELF_TYPE(_Copy_conjoint_jlongs_atomic,@function)
++SYMBOL(_Copy_arrayof_conjoint_jlongs):
++SYMBOL(_Copy_conjoint_jlongs_atomic):
++        cmpq     %rdi,%rsi
++        leaq     -8(%rdi,%rdx,8),%rax # from + count*8 - 8
++        jbe      acl_CopyRight
++        cmpq     %rax,%rsi
++        jbe      acl_CopyLeft 
++acl_CopyRight:
++        leaq     -8(%rsi,%rdx,8),%rcx # to + count*8 - 8
++        negq     %rdx
++        jmp      3f
++1:      movq     8(%rax,%rdx,8),%rsi
++        movq     %rsi,8(%rcx,%rdx,8)
++        addq     $1,%rdx
++        jnz      1b
++        ret
++        .p2align 4,,15
++2:      movq     -24(%rax,%rdx,8),%rsi
++        movq     %rsi,-24(%rcx,%rdx,8)
++        movq     -16(%rax,%rdx,8),%rsi
++        movq     %rsi,-16(%rcx,%rdx,8)
++        movq     -8(%rax,%rdx,8),%rsi
++        movq     %rsi,-8(%rcx,%rdx,8)
++        movq     (%rax,%rdx,8),%rsi
++        movq     %rsi,(%rcx,%rdx,8)
++3:      addq     $4,%rdx
++        jle      2b
++        subq     $4,%rdx
++        jl       1b
++        ret
++4:      movq     -8(%rdi,%rdx,8),%rcx
++        movq     %rcx,-8(%rsi,%rdx,8)
++        subq     $1,%rdx
++        jnz      4b
++        ret
++        .p2align 4,,15
++5:      movq     24(%rdi,%rdx,8),%rcx
++        movq     %rcx,24(%rsi,%rdx,8)
++        movq     16(%rdi,%rdx,8),%rcx
++        movq     %rcx,16(%rsi,%rdx,8)
++        movq     8(%rdi,%rdx,8),%rcx
++        movq     %rcx,8(%rsi,%rdx,8)
++        movq     (%rdi,%rdx,8),%rcx
++        movq     %rcx,(%rsi,%rdx,8)
++acl_CopyLeft:
++        subq     $4,%rdx
++        jge      5b
++        addq     $4,%rdx
++        jg       4b
++        ret
+diff --git a/src/hotspot/os_cpu/serenity_x86/thread_serenity_x86.cpp b/src/hotspot/os_cpu/serenity_x86/thread_serenity_x86.cpp
+new file mode 100644
+index 000000000..8d580c79b
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/thread_serenity_x86.cpp
+@@ -0,0 +1,92 @@
++/*
++ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "runtime/frame.inline.hpp"
++#include "runtime/thread.inline.hpp"
++
++frame JavaThread::pd_last_frame() {
++  assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
++  vmassert(_anchor.last_Java_pc() != NULL, "not walkable");
++  return frame(_anchor.last_Java_sp(), _anchor.last_Java_fp(), _anchor.last_Java_pc());
++}
++
++// For Forte Analyzer AsyncGetCallTrace profiling support - thread is
++// currently interrupted by SIGPROF
++bool JavaThread::pd_get_top_frame_for_signal_handler(frame* fr_addr,
++  void* ucontext, bool isInJava) {
++  assert(Thread::current() == this, "caller must be current thread");
++  return pd_get_top_frame(fr_addr, ucontext, isInJava);
++}
++
++bool JavaThread::pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext, bool isInJava) {
++  return pd_get_top_frame(fr_addr, ucontext, isInJava);
++}
++
++bool JavaThread::pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava) {
++  // If we have a last_Java_frame, then we should use it even if
++  // isInJava == true.  It should be more reliable than ucontext info.
++  if (has_last_Java_frame() && frame_anchor()->walkable()) {
++    *fr_addr = pd_last_frame();
++    return true;
++  }
++
++  // At this point, we don't have a last_Java_frame, so
++  // we try to glean some information out of the ucontext
++  // if we were running Java code when SIGPROF came in.
++  if (isInJava) {
++    ucontext_t* uc = (ucontext_t*) ucontext;
++
++    intptr_t* ret_fp;
++    intptr_t* ret_sp;
++    address addr = os::fetch_frame_from_context(uc, &ret_sp, &ret_fp);
++    if (addr == NULL || ret_sp == NULL ) {
++      // ucontext wasn't useful
++      return false;
++    }
++
++    frame ret_frame(ret_sp, ret_fp, addr);
++    if (!ret_frame.safe_for_sender(this)) {
++#if COMPILER2_OR_JVMCI
++      // C2 and JVMCI use ebp as a general register see if NULL fp helps
++      frame ret_frame2(ret_sp, NULL, addr);
++      if (!ret_frame2.safe_for_sender(this)) {
++        // nothing else to try if the frame isn't good
++        return false;
++      }
++      ret_frame = ret_frame2;
++#else
++      // nothing else to try if the frame isn't good
++      return false;
++#endif // COMPILER2_OR_JVMCI
++    }
++    *fr_addr = ret_frame;
++    return true;
++  }
++
++  // nothing else to try
++  return false;
++}
++
++void JavaThread::cache_global_variables() { }
+diff --git a/src/hotspot/os_cpu/serenity_x86/thread_serenity_x86.hpp b/src/hotspot/os_cpu/serenity_x86/thread_serenity_x86.hpp
+new file mode 100644
+index 000000000..df2994ea1
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/thread_serenity_x86.hpp
+@@ -0,0 +1,49 @@
++/*
++ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_THREAD_SERENITY_X86_HPP
++#define OS_CPU_SERENITY_X86_THREAD_SERENITY_X86_HPP
++
++ private:
++  void pd_initialize() {
++    _anchor.clear();
++  }
++
++  frame pd_last_frame();
++
++ public:
++  static ByteSize last_Java_fp_offset()          {
++    return byte_offset_of(JavaThread, _anchor) + JavaFrameAnchor::last_Java_fp_offset();
++  }
++
++  bool pd_get_top_frame_for_signal_handler(frame* fr_addr, void* ucontext,
++    bool isInJava);
++
++  bool pd_get_top_frame_for_profiling(frame* fr_addr, void* ucontext,
++    bool isInJava);
++
++private:
++  bool pd_get_top_frame(frame* fr_addr, void* ucontext, bool isInJava);
++
++#endif // OS_CPU_SERENITY_X86_THREAD_SERENITY_X86_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/vmStructs_serenity_x86.hpp b/src/hotspot/os_cpu/serenity_x86/vmStructs_serenity_x86.hpp
+new file mode 100644
+index 000000000..422b4f55d
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/vmStructs_serenity_x86.hpp
+@@ -0,0 +1,53 @@
++/*
++ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_X86_VMSTRUCTS_SERENITY_X86_HPP
++#define OS_CPU_SERENITY_X86_VMSTRUCTS_SERENITY_X86_HPP
++
++// These are the OS and CPU-specific fields, types and integer
++// constants required by the Serviceability Agent. This file is
++// referenced by vmStructs.cpp.
++
++#define VM_STRUCTS_OS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field) \
++                                                                                                                                     \
++  /******************************/                                                                                                   \
++  /* Threads (NOTE: incomplete) */                                                                                                   \
++  /******************************/                                                                                                   \
++  nonstatic_field(OSThread,                      _thread_id,                                      OSThread::thread_id_t)             \
++  nonstatic_field(OSThread,                      _unique_thread_id,                               uint64_t)
++
++
++#define VM_TYPES_OS_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type, declare_c1_toplevel_type, declare_c2_type, declare_c2_toplevel_type) \
++                                                                          \
++  /**********************/                                                \
++  /* Thread IDs         */                                                \
++  /**********************/                                                \
++                                                                          \
++  declare_unsigned_integer_type(OSThread::thread_id_t)
++
++#define VM_INT_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
++
++#define VM_LONG_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
++
++#endif // OS_CPU_SERENITY_X86_VMSTRUCTS_SERENITY_X86_HPP
+diff --git a/src/hotspot/os_cpu/serenity_x86/vm_version_serenity_x86.cpp b/src/hotspot/os_cpu/serenity_x86/vm_version_serenity_x86.cpp
+new file mode 100644
+index 000000000..05cb7ef99
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_x86/vm_version_serenity_x86.cpp
+@@ -0,0 +1,48 @@
++/*
++ * Copyright (c) 2006, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "runtime/os.hpp"
++#include "runtime/vm_version.hpp"
++
++#ifdef __APPLE__
++
++#include <sys/types.h>
++#include <sys/sysctl.h>
++
++bool VM_Version::is_cpu_emulated() {
++  int ret = 0;
++  size_t size = sizeof(ret);
++  // Is this process being ran in Rosetta (i.e. emulation) mode on macOS?
++  if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) {
++    // errno == ENOENT is a valid response, but anything else is a real error
++    if (errno != ENOENT) {
++      warning("unable to lookup sysctl.proc_translated");
++    }
++  }
++  return (ret==1);
++}
++
++#endif
++
+diff --git a/src/hotspot/os_cpu/serenity_zero/assembler_serenity_zero.cpp b/src/hotspot/os_cpu/serenity_zero/assembler_serenity_zero.cpp
+new file mode 100644
+index 000000000..cb6fbce15
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/assembler_serenity_zero.cpp
+@@ -0,0 +1,26 @@
++/*
++ * Copyright (c) 1997, 2015, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2009 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++// This file is intentionally empty
+diff --git a/src/hotspot/os_cpu/serenity_zero/atomic_serenity_zero.hpp b/src/hotspot/os_cpu/serenity_zero/atomic_serenity_zero.hpp
+new file mode 100644
+index 000000000..55c4926c7
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/atomic_serenity_zero.hpp
+@@ -0,0 +1,305 @@
++/*
++ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2007, 2008, 2011, 2015, Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_ZERO_ATOMIC_SERENITY_ZERO_HPP
++#define OS_CPU_SERENITY_ZERO_ATOMIC_SERENITY_ZERO_HPP
++
++#include "orderAccess_serenity_zero.hpp"
++#include "runtime/os.hpp"
++
++// Implementation of class atomic
++
++#ifdef M68K
++
++/*
++ * __m68k_cmpxchg
++ *
++ * Atomically store newval in *ptr if *ptr is equal to oldval for user space.
++ * Returns newval on success and oldval if no exchange happened.
++ * This implementation is processor specific and works on
++ * 68020 68030 68040 and 68060.
++ *
++ * It will not work on ColdFire, 68000 and 68010 since they lack the CAS
++ * instruction.
++ * Using a kernelhelper would be better for arch complete implementation.
++ *
++ */
++
++static inline int __m68k_cmpxchg(int oldval, int newval, volatile int *ptr) {
++  int ret;
++  __asm __volatile ("cas%.l %0,%2,%1"
++                   : "=d" (ret), "+m" (*(ptr))
++                   : "d" (newval), "0" (oldval));
++  return ret;
++}
++
++/* Perform an atomic compare and swap: if the current value of `*PTR'
++   is OLDVAL, then write NEWVAL into `*PTR'.  Return the contents of
++   `*PTR' before the operation.*/
++static inline int m68k_compare_and_swap(int newval,
++                                        volatile int *ptr,
++                                        int oldval) {
++  for (;;) {
++      int prev = *ptr;
++      if (prev != oldval)
++        return prev;
++
++      if (__m68k_cmpxchg (prev, newval, ptr) == newval)
++        // Success.
++        return prev;
++
++      // We failed even though prev == oldval.  Try again.
++    }
++}
++
++/* Atomically add an int to memory.  */
++static inline int m68k_add_and_fetch(int add_value, volatile int *ptr) {
++  for (;;) {
++      // Loop until success.
++
++      int prev = *ptr;
++
++      if (__m68k_cmpxchg (prev, prev + add_value, ptr) == prev + add_value)
++        return prev + add_value;
++    }
++}
++
++/* Atomically write VALUE into `*PTR' and returns the previous
++   contents of `*PTR'.  */
++static inline int m68k_lock_test_and_set(int newval, volatile int *ptr) {
++  for (;;) {
++      // Loop until success.
++      int prev = *ptr;
++
++      if (__m68k_cmpxchg (prev, newval, ptr) == prev)
++        return prev;
++    }
++}
++#endif // M68K
++
++#ifdef ARM
++
++/*
++ * __kernel_cmpxchg
++ *
++ * Atomically store newval in *ptr if *ptr is equal to oldval for user space.
++ * Return zero if *ptr was changed or non-zero if no exchange happened.
++ * The C flag is also set if *ptr was changed to allow for assembly
++ * optimization in the calling code.
++ *
++ */
++
++typedef int (__kernel_cmpxchg_t)(int oldval, int newval, volatile int *ptr);
++#define __kernel_cmpxchg (*(__kernel_cmpxchg_t *) 0xffff0fc0)
++
++
++
++/* Perform an atomic compare and swap: if the current value of `*PTR'
++   is OLDVAL, then write NEWVAL into `*PTR'.  Return the contents of
++   `*PTR' before the operation.*/
++static inline int arm_compare_and_swap(int newval,
++                                       volatile int *ptr,
++                                       int oldval) {
++  for (;;) {
++      int prev = *ptr;
++      if (prev != oldval)
++        return prev;
++
++      if (__kernel_cmpxchg (prev, newval, ptr) == 0)
++        // Success.
++        return prev;
++
++      // We failed even though prev == oldval.  Try again.
++    }
++}
++
++/* Atomically add an int to memory.  */
++static inline int arm_add_and_fetch(int add_value, volatile int *ptr) {
++  for (;;) {
++      // Loop until a __kernel_cmpxchg succeeds.
++
++      int prev = *ptr;
++
++      if (__kernel_cmpxchg (prev, prev + add_value, ptr) == 0)
++        return prev + add_value;
++    }
++}
++
++/* Atomically write VALUE into `*PTR' and returns the previous
++   contents of `*PTR'.  */
++static inline int arm_lock_test_and_set(int newval, volatile int *ptr) {
++  for (;;) {
++      // Loop until a __kernel_cmpxchg succeeds.
++      int prev = *ptr;
++
++      if (__kernel_cmpxchg (prev, newval, ptr) == 0)
++        return prev;
++    }
++}
++#endif // ARM
++
++template<size_t byte_size>
++struct Atomic::PlatformAdd {
++  template<typename D, typename I>
++  D add_and_fetch(D volatile* dest, I add_value, atomic_memory_order order) const;
++
++  template<typename D, typename I>
++  D fetch_and_add(D volatile* dest, I add_value, atomic_memory_order order) const {
++    return add_and_fetch(dest, add_value, order) - add_value;
++  }
++};
++
++template<>
++template<typename D, typename I>
++inline D Atomic::PlatformAdd<4>::add_and_fetch(D volatile* dest, I add_value,
++                                               atomic_memory_order order) const {
++  STATIC_ASSERT(4 == sizeof(I));
++  STATIC_ASSERT(4 == sizeof(D));
++
++#ifdef ARM
++  return add_using_helper<int>(arm_add_and_fetch, dest, add_value);
++#else
++#ifdef M68K
++  return add_using_helper<int>(m68k_add_and_fetch, dest, add_value);
++#else
++  D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
++  FULL_MEM_BARRIER;
++  return res;
++#endif // M68K
++#endif // ARM
++}
++
++template<>
++template<typename D, typename I>
++inline D Atomic::PlatformAdd<8>::add_and_fetch(D volatile* dest, I add_value,
++                                               atomic_memory_order order) const {
++  STATIC_ASSERT(8 == sizeof(I));
++  STATIC_ASSERT(8 == sizeof(D));
++
++  D res = __atomic_add_fetch(dest, add_value, __ATOMIC_RELEASE);
++  FULL_MEM_BARRIER;
++  return res;
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformXchg<4>::operator()(T volatile* dest,
++                                             T exchange_value,
++                                             atomic_memory_order order) const {
++  STATIC_ASSERT(4 == sizeof(T));
++#ifdef ARM
++  return xchg_using_helper<int>(arm_lock_test_and_set, dest, exchange_value);
++#else
++#ifdef M68K
++  return xchg_using_helper<int>(m68k_lock_test_and_set, dest, exchange_value);
++#else
++  // __sync_lock_test_and_set is a bizarrely named atomic exchange
++  // operation.  Note that some platforms only support this with the
++  // limitation that the only valid value to store is the immediate
++  // constant 1.  There is a test for this in JNI_CreateJavaVM().
++  T result = __sync_lock_test_and_set (dest, exchange_value);
++  // All atomic operations are expected to be full memory barriers
++  // (see atomic.hpp). However, __sync_lock_test_and_set is not
++  // a full memory barrier, but an acquire barrier. Hence, this added
++  // barrier. Some platforms (notably ARM) have peculiarities with
++  // their barrier implementations, delegate it to OrderAccess.
++  OrderAccess::fence();
++  return result;
++#endif // M68K
++#endif // ARM
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformXchg<8>::operator()(T volatile* dest,
++                                             T exchange_value,
++                                             atomic_memory_order order) const {
++  STATIC_ASSERT(8 == sizeof(T));
++  T result = __sync_lock_test_and_set (dest, exchange_value);
++  OrderAccess::fence();
++  return result;
++}
++
++// No direct support for cmpxchg of bytes; emulate using int.
++template<>
++struct Atomic::PlatformCmpxchg<1> : Atomic::CmpxchgByteUsingInt {};
++
++template<>
++template<typename T>
++inline T Atomic::PlatformCmpxchg<4>::operator()(T volatile* dest,
++                                                T compare_value,
++                                                T exchange_value,
++                                                atomic_memory_order order) const {
++  STATIC_ASSERT(4 == sizeof(T));
++#ifdef ARM
++  return cmpxchg_using_helper<int>(arm_compare_and_swap, dest, compare_value, exchange_value);
++#else
++#ifdef M68K
++  return cmpxchg_using_helper<int>(m68k_compare_and_swap, dest, compare_value, exchange_value);
++#else
++  T value = compare_value;
++  FULL_MEM_BARRIER;
++  __atomic_compare_exchange(dest, &value, &exchange_value, /*weak*/false,
++                            __ATOMIC_RELAXED, __ATOMIC_RELAXED);
++  FULL_MEM_BARRIER;
++  return value;
++#endif // M68K
++#endif // ARM
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformCmpxchg<8>::operator()(T volatile* dest,
++                                                T compare_value,
++                                                T exchange_value,
++                                                atomic_memory_order order) const {
++  STATIC_ASSERT(8 == sizeof(T));
++
++  T value = compare_value;
++  FULL_MEM_BARRIER;
++  __atomic_compare_exchange(dest, &value, &exchange_value, /*weak*/false,
++                            __ATOMIC_RELAXED, __ATOMIC_RELAXED);
++  FULL_MEM_BARRIER;
++  return value;
++}
++
++template<>
++template<typename T>
++inline T Atomic::PlatformLoad<8>::operator()(T const volatile* src) const {
++  STATIC_ASSERT(8 == sizeof(T));
++  volatile int64_t dest;
++  os::atomic_copy64(reinterpret_cast<const volatile int64_t*>(src), reinterpret_cast<volatile int64_t*>(&dest));
++  return PrimitiveConversions::cast<T>(dest);
++}
++
++template<>
++template<typename T>
++inline void Atomic::PlatformStore<8>::operator()(T volatile* dest,
++                                                 T store_value) const {
++  STATIC_ASSERT(8 == sizeof(T));
++  os::atomic_copy64(reinterpret_cast<const volatile int64_t*>(&store_value), reinterpret_cast<volatile int64_t*>(dest));
++}
++
++#endif // OS_CPU_SERENITY_ZERO_ATOMIC_SERENITY_ZERO_HPP
+diff --git a/src/hotspot/os_cpu/serenity_zero/bytes_serenity_zero.hpp b/src/hotspot/os_cpu/serenity_zero/bytes_serenity_zero.hpp
+new file mode 100644
+index 000000000..6ec34d6f7
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/bytes_serenity_zero.hpp
+@@ -0,0 +1,69 @@
++/*
++ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_ZERO_BYTES_SERENITY_ZERO_HPP
++#define OS_CPU_SERENITY_ZERO_BYTES_SERENITY_ZERO_HPP
++
++// Efficient swapping of data bytes from Java byte
++// ordering to native byte ordering and vice versa.
++
++#ifdef __APPLE__
++#  include <libkern/OSByteOrder.h>
++#elif defined(SERENITY)
++#  include <endian.h>
++#else
++#  include <sys/endian.h>
++#endif
++
++#if defined(__APPLE__)
++#  define bswap_16(x)   OSSwapInt16(x)
++#  define bswap_32(x)   OSSwapInt32(x)
++#  define bswap_64(x)   OSSwapInt64(x)
++#elif defined(__OpenBSD__)
++#  define bswap_16(x)   swap16(x)
++#  define bswap_32(x)   swap32(x)
++#  define bswap_64(x)   swap64(x)
++#elif defined(__NetBSD__)
++#  define bswap_16(x)   bswap16(x)
++#  define bswap_32(x)   bswap32(x)
++#  define bswap_64(x)   bswap64(x)
++#else
++#  define bswap_16(x) __bswap16(x)
++#  define bswap_32(x) __bswap32(x)
++#  define bswap_64(x) __bswap64(x)
++#endif
++
++inline u2 Bytes::swap_u2(u2 x) {
++  return bswap_16(x);
++}
++
++inline u4 Bytes::swap_u4(u4 x) {
++  return bswap_32(x);
++}
++
++inline u8 Bytes::swap_u8(u8 x) {
++  return bswap_64(x);
++}
++
++#endif // OS_CPU_SERENITY_ZERO_BYTES_SERENITY_ZERO_HPP
+diff --git a/src/hotspot/os_cpu/serenity_zero/globals_serenity_zero.hpp b/src/hotspot/os_cpu/serenity_zero/globals_serenity_zero.hpp
+new file mode 100644
+index 000000000..ed67f9585
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/globals_serenity_zero.hpp
+@@ -0,0 +1,47 @@
++/*
++ * Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2007, 2008, 2010 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_ZERO_GLOBALS_SERENITY_ZERO_HPP
++#define OS_CPU_SERENITY_ZERO_GLOBALS_SERENITY_ZERO_HPP
++
++//
++// Set the default values for platform dependent flags used by the
++// runtime system.  See globals.hpp for details of what they do.
++//
++
++define_pd_global(bool,  DontYieldALot,           false);
++define_pd_global(intx,  ThreadStackSize,         1536);
++#ifdef _LP64
++define_pd_global(intx,  VMThreadStackSize,       1024);
++#else
++define_pd_global(intx,  VMThreadStackSize,       512);
++#endif // _LP64
++define_pd_global(intx,  CompilerThreadStackSize, 0);
++define_pd_global(size_t, JVMInvokeMethodSlack,   8192);
++
++// Used on 64 bit platforms for UseCompressedOops base address
++define_pd_global(size_t, HeapBaseMinAddress,     2*G);
++
++#endif // OS_CPU_SERENITY_ZERO_GLOBALS_SERENITY_ZERO_HPP
+diff --git a/src/hotspot/os_cpu/serenity_zero/orderAccess_serenity_zero.hpp b/src/hotspot/os_cpu/serenity_zero/orderAccess_serenity_zero.hpp
+new file mode 100644
+index 000000000..6d12b2dfc
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/orderAccess_serenity_zero.hpp
+@@ -0,0 +1,82 @@
++/*
++ * Copyright (c) 2003, 2020, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2007, 2008, 2009 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_ZERO_ORDERACCESS_SERENITY_ZERO_HPP
++#define OS_CPU_SERENITY_ZERO_ORDERACCESS_SERENITY_ZERO_HPP
++
++// Included in orderAccess.hpp header file.
++
++#if defined(ARM)   // ----------------------------------------------------
++
++/*
++ * ARM Kernel helper for memory barrier.
++ * Using __asm __volatile ("":::"memory") does not work reliable on ARM
++ * and gcc __sync_synchronize(); implementation does not use the kernel
++ * helper for all gcc versions so it is unreliable to use as well.
++ */
++typedef void (__kernel_dmb_t) (void);
++#define __kernel_dmb (*(__kernel_dmb_t *) 0xffff0fa0)
++
++#define LIGHT_MEM_BARRIER __kernel_dmb()
++#define FULL_MEM_BARRIER  __kernel_dmb()
++
++#elif defined(PPC) // ----------------------------------------------------
++
++#ifdef __NO_LWSYNC__
++#define LIGHT_MEM_BARRIER __asm __volatile ("sync":::"memory")
++#else
++#define LIGHT_MEM_BARRIER __asm __volatile ("lwsync":::"memory")
++#endif
++
++#define FULL_MEM_BARRIER  __sync_synchronize()
++
++#elif defined(X86) // ----------------------------------------------------
++
++#define LIGHT_MEM_BARRIER __asm __volatile ("":::"memory")
++#define FULL_MEM_BARRIER  __sync_synchronize()
++
++#else              // ----------------------------------------------------
++
++// Default to strongest barriers for correctness.
++
++#define LIGHT_MEM_BARRIER __sync_synchronize()
++#define FULL_MEM_BARRIER  __sync_synchronize()
++
++#endif             // ----------------------------------------------------
++
++// Note: What is meant by LIGHT_MEM_BARRIER is a barrier which is sufficient
++// to provide TSO semantics, i.e. StoreStore | LoadLoad | LoadStore.
++
++inline void OrderAccess::loadload()   { LIGHT_MEM_BARRIER; }
++inline void OrderAccess::storestore() { LIGHT_MEM_BARRIER; }
++inline void OrderAccess::loadstore()  { LIGHT_MEM_BARRIER; }
++inline void OrderAccess::storeload()  { FULL_MEM_BARRIER;  }
++
++inline void OrderAccess::acquire()    { LIGHT_MEM_BARRIER; }
++inline void OrderAccess::release()    { LIGHT_MEM_BARRIER; }
++inline void OrderAccess::fence()      { FULL_MEM_BARRIER;  }
++inline void OrderAccess::cross_modify_fence_impl()             { }
++
++#endif // OS_CPU_SERENITY_ZERO_ORDERACCESS_SERENITY_ZERO_HPP
+diff --git a/src/hotspot/os_cpu/serenity_zero/os_serenity_zero.cpp b/src/hotspot/os_cpu/serenity_zero/os_serenity_zero.cpp
+new file mode 100644
+index 000000000..08baff54f
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/os_serenity_zero.cpp
+@@ -0,0 +1,303 @@
++/*
++ * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include <pthread.h>
++//# include <pthread_np.h> /* For pthread_attr_get_np */
++
++// no precompiled headers
++#include "jvm.h"
++#include "asm/assembler.inline.hpp"
++#include "classfile/vmSymbols.hpp"
++#include "code/icBuffer.hpp"
++#include "code/vtableStubs.hpp"
++#include "interpreter/interpreter.hpp"
++#include "memory/allocation.inline.hpp"
++#include "nativeInst_zero.hpp"
++#include "os_share_serenity.hpp"
++#include "prims/jniFastGetField.hpp"
++#include "prims/jvm_misc.hpp"
++#include "runtime/arguments.hpp"
++#include "runtime/frame.inline.hpp"
++#include "runtime/interfaceSupport.inline.hpp"
++#include "runtime/java.hpp"
++#include "runtime/javaCalls.hpp"
++#include "runtime/mutexLocker.hpp"
++#include "runtime/osThread.hpp"
++#include "runtime/sharedRuntime.hpp"
++#include "runtime/stubRoutines.hpp"
++#include "runtime/thread.inline.hpp"
++#include "runtime/timer.hpp"
++#include "signals_posix.hpp"
++#include "utilities/events.hpp"
++#include "utilities/vmError.hpp"
++
++#include <serenity.h>
++
++address os::current_stack_pointer() {
++  return (address)__builtin_frame_address(0);
++}
++
++frame os::get_sender_for_C_frame(frame* fr) {
++  ShouldNotCallThis();
++  return frame();
++}
++
++frame os::current_frame() {
++  // The only thing that calls this is the stack printing code in
++  // VMError::report:
++  //   - Step 110 (printing stack bounds) uses the sp in the frame
++  //     to determine the amount of free space on the stack.  We
++  //     set the sp to a close approximation of the real value in
++  //     order to allow this step to complete.
++  //   - Step 120 (printing native stack) tries to walk the stack.
++  //     The frame we create has a NULL pc, which is ignored as an
++  //     invalid frame.
++  frame dummy = frame();
++  dummy.set_sp((intptr_t *) current_stack_pointer());
++  return dummy;
++}
++
++char* os::non_memory_address_word() {
++  // Must never look like an address returned by reserve_memory,
++  // even in its subfields (as defined by the CPU immediate fields,
++  // if the CPU splits constants across multiple instructions).
++  // This is the value for x86; works pretty well for PPC too.
++  return (char *) -1;
++}
++
++address os::Posix::ucontext_get_pc(const ucontext_t* uc) {
++  ShouldNotCallThis();
++  return NULL;
++}
++
++void os::Posix::ucontext_set_pc(ucontext_t * uc, address pc) {
++  ShouldNotCallThis();
++}
++
++address os::fetch_frame_from_context(const void* ucVoid,
++                                     intptr_t** ret_sp,
++                                     intptr_t** ret_fp) {
++  ShouldNotCallThis();
++  return NULL;
++}
++
++frame os::fetch_frame_from_context(const void* ucVoid) {
++  ShouldNotCallThis();
++  return frame();
++}
++
++bool PosixSignals::pd_hotspot_signal_handler(int sig, siginfo_t* info, ucontext_t* uc, JavaThread* thread) {
++
++  if (info != NULL && thread != NULL) {
++    // Handle ALL stack overflow variations here
++    if (sig == SIGSEGV || sig == SIGBUS) {
++      address addr = (address) info->si_addr;
++
++      // check if fault address is within thread stack
++      if (thread->is_in_full_stack(addr)) {
++        StackOverflow* overflow_state = thread->stack_overflow_state();
++        // stack overflow
++        if (overflow_state->in_stack_yellow_reserved_zone(addr)) {
++          overflow_state->disable_stack_yellow_reserved_zone();
++          ShouldNotCallThis();
++        }
++        else if (overflow_state->in_stack_red_zone(addr)) {
++          overflow_state->disable_stack_red_zone();
++          ShouldNotCallThis();
++        }
++      }
++    }
++
++    /*if (thread->thread_state() == _thread_in_Java) {
++      ShouldNotCallThis();
++    }
++    else*/ if ((thread->thread_state() == _thread_in_vm ||
++               thread->thread_state() == _thread_in_native) &&
++               sig == SIGBUS && thread->doing_unsafe_access()) {
++      ShouldNotCallThis();
++    }
++
++    // jni_fast_Get<Primitive>Field can trap at certain pc's if a GC
++    // kicks in and the heap gets shrunk before the field access.
++    /*if (sig == SIGSEGV || sig == SIGBUS) {
++      address addr = JNI_FastGetField::find_slowcase_pc(pc);
++      if (addr != (address)-1) {
++        stub = addr;
++      }
++    }*/
++  }
++
++  return false;
++}
++
++void os::Serenity::init_thread_fpu_state(void) {
++  // FIXME
++}
++
++///////////////////////////////////////////////////////////////////////////////
++// thread stack
++
++size_t os::Posix::_compiler_thread_min_stack_allowed = 64 * K;
++size_t os::Posix::_java_thread_min_stack_allowed = 64 * K;
++size_t os::Posix::_vm_internal_thread_min_stack_allowed = 64 * K;
++
++size_t os::Posix::default_stack_size(os::ThreadType thr_type) {
++#ifdef _LP64
++  size_t s = (thr_type == os::compiler_thread ? 4 * M : 1 * M);
++#else
++  size_t s = (thr_type == os::compiler_thread ? 2 * M : 512 * K);
++#endif // _LP64
++  return s;
++}
++
++static void current_stack_region(address *bottom, size_t *size) {
++  get_stack_bounds((uintptr_t*)bottom, size);
++}
++
++address os::current_stack_base() {
++  address bottom;
++  size_t size;
++  current_stack_region(&bottom, &size);
++  return bottom + size;
++}
++
++size_t os::current_stack_size() {
++  // stack size includes normal stack and HotSpot guard pages
++  address bottom;
++  size_t size;
++  current_stack_region(&bottom, &size);
++  return size;
++}
++
++/////////////////////////////////////////////////////////////////////////////
++// helper functions for fatal error handler
++
++void os::print_context(outputStream* st, const void* context) {
++  ShouldNotCallThis();
++}
++
++void os::print_register_info(outputStream *st, const void *context) {
++  ShouldNotCallThis();
++}
++
++/////////////////////////////////////////////////////////////////////////////
++// Stubs for things that would be in bsd_zero.s if it existed.
++// You probably want to disassemble these monkeys to check they're ok.
++
++extern "C" {
++  int SpinPause() {
++    return 1;
++  }
++
++  void _Copy_conjoint_jshorts_atomic(const jshort* from, jshort* to, size_t count) {
++    if (from > to) {
++      const jshort *end = from + count;
++      while (from < end)
++        *(to++) = *(from++);
++    }
++    else if (from < to) {
++      const jshort *end = from;
++      from += count - 1;
++      to   += count - 1;
++      while (from >= end)
++        *(to--) = *(from--);
++    }
++  }
++  void _Copy_conjoint_jints_atomic(const jint* from, jint* to, size_t count) {
++    if (from > to) {
++      const jint *end = from + count;
++      while (from < end)
++        *(to++) = *(from++);
++    }
++    else if (from < to) {
++      const jint *end = from;
++      from += count - 1;
++      to   += count - 1;
++      while (from >= end)
++        *(to--) = *(from--);
++    }
++  }
++  void _Copy_conjoint_jlongs_atomic(const jlong* from, jlong* to, size_t count) {
++    if (from > to) {
++      const jlong *end = from + count;
++      while (from < end)
++        os::atomic_copy64(from++, to++);
++    }
++    else if (from < to) {
++      const jlong *end = from;
++      from += count - 1;
++      to   += count - 1;
++      while (from >= end)
++        os::atomic_copy64(from--, to--);
++    }
++  }
++
++  void _Copy_arrayof_conjoint_bytes(const HeapWord* from,
++                                    HeapWord* to,
++                                    size_t    count) {
++    memmove(to, from, count);
++  }
++  void _Copy_arrayof_conjoint_jshorts(const HeapWord* from,
++                                      HeapWord* to,
++                                      size_t    count) {
++    memmove(to, from, count * 2);
++  }
++  void _Copy_arrayof_conjoint_jints(const HeapWord* from,
++                                    HeapWord* to,
++                                    size_t    count) {
++    memmove(to, from, count * 4);
++  }
++  void _Copy_arrayof_conjoint_jlongs(const HeapWord* from,
++                                     HeapWord* to,
++                                     size_t    count) {
++    memmove(to, from, count * 8);
++  }
++};
++
++/////////////////////////////////////////////////////////////////////////////
++// Implementations of atomic operations not supported by processors.
++//  -- http://gcc.gnu.org/onlinedocs/gcc-4.2.1/gcc/Atomic-Builtins.html
++
++#ifndef _LP64
++extern "C" {
++  long long unsigned int __sync_val_compare_and_swap_8(
++    volatile void *ptr,
++    long long unsigned int oldval,
++    long long unsigned int newval) {
++    ShouldNotCallThis();
++    return 0; // silence compiler warnings
++  }
++};
++#endif // !_LP64
++
++#ifndef PRODUCT
++void os::verify_stack_alignment() {
++}
++#endif
++
++int os::extra_bang_size_in_bytes() {
++  // Zero does not require an additional stack bang.
++  return 0;
++}
+diff --git a/src/hotspot/os_cpu/serenity_zero/os_serenity_zero.hpp b/src/hotspot/os_cpu/serenity_zero/os_serenity_zero.hpp
+new file mode 100644
+index 000000000..e7aead0a7
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/os_serenity_zero.hpp
+@@ -0,0 +1,54 @@
++/*
++ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2007, 2008, 2010 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_ZERO_OS_SERENITY_ZERO_HPP
++#define OS_CPU_SERENITY_ZERO_OS_SERENITY_ZERO_HPP
++
++  static void setup_fpu() {}
++
++  // Used to register dynamic code cache area with the OS
++  // Note: Currently only used in 64 bit Windows implementations
++  static bool register_code_area(char *low, char *high) { return true; }
++
++  // Atomically copy 64 bits of data
++  static void atomic_copy64(const volatile void *src, volatile void *dst) {
++#if defined(PPC32)
++    double tmp;
++    asm volatile ("lfd  %0, 0(%1)\n"
++                  "stfd %0, 0(%2)\n"
++                  : "=f"(tmp)
++                  : "b"(src), "b"(dst));
++#elif defined(S390) && !defined(_LP64)
++    double tmp;
++    asm volatile ("ld  %0, 0(%1)\n"
++                  "std %0, 0(%2)\n"
++                  : "=r"(tmp)
++                  : "a"(src), "a"(dst));
++#else
++    *(jlong *) dst = *(const jlong *) src;
++#endif
++  }
++
++#endif // OS_CPU_SERENITY_ZERO_OS_SERENITY_ZERO_HPP
+diff --git a/src/hotspot/os_cpu/serenity_zero/prefetch_serenity_zero.inline.hpp b/src/hotspot/os_cpu/serenity_zero/prefetch_serenity_zero.inline.hpp
+new file mode 100644
+index 000000000..3c09458f5
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/prefetch_serenity_zero.inline.hpp
+@@ -0,0 +1,37 @@
++/*
++ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2007, 2008 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_ZERO_PREFETCH_SERENITY_ZERO_INLINE_HPP
++#define OS_CPU_SERENITY_ZERO_PREFETCH_SERENITY_ZERO_INLINE_HPP
++
++#include "runtime/prefetch.hpp"
++
++inline void Prefetch::read(void* loc, intx interval) {
++}
++
++inline void Prefetch::write(void* loc, intx interval) {
++}
++
++#endif // OS_CPU_SERENITY_ZERO_PREFETCH_SERENITY_ZERO_INLINE_HPP
+diff --git a/src/hotspot/os_cpu/serenity_zero/thread_serenity_zero.cpp b/src/hotspot/os_cpu/serenity_zero/thread_serenity_zero.cpp
+new file mode 100644
+index 000000000..816ca4114
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/thread_serenity_zero.cpp
+@@ -0,0 +1,37 @@
++/*
++ * Copyright (c) 1997, 2018, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2009, 2010 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "runtime/frame.inline.hpp"
++#include "runtime/thread.inline.hpp"
++
++frame JavaThread::pd_last_frame() {
++  assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
++  return frame(last_Java_fp(), last_Java_sp());
++}
++
++void JavaThread::cache_global_variables() {
++  // nothing to do
++}
+diff --git a/src/hotspot/os_cpu/serenity_zero/thread_serenity_zero.hpp b/src/hotspot/os_cpu/serenity_zero/thread_serenity_zero.hpp
+new file mode 100644
+index 000000000..bcaf1224a
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/thread_serenity_zero.hpp
+@@ -0,0 +1,104 @@
++/*
++ * Copyright (c) 2000, 2020, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2007, 2008, 2009, 2010 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_ZERO_THREAD_SERENITY_ZERO_HPP
++#define OS_CPU_SERENITY_ZERO_THREAD_SERENITY_ZERO_HPP
++
++ private:
++  ZeroStack  _zero_stack;
++  ZeroFrame* _top_zero_frame;
++
++  void pd_initialize() {
++    _top_zero_frame = NULL;
++  }
++
++ public:
++  ZeroStack *zero_stack() {
++    return &_zero_stack;
++  }
++
++ public:
++  ZeroFrame *top_zero_frame() {
++    return _top_zero_frame;
++  }
++  void push_zero_frame(ZeroFrame *frame) {
++    *(ZeroFrame **) frame = _top_zero_frame;
++    _top_zero_frame = frame;
++  }
++  void pop_zero_frame() {
++    zero_stack()->set_sp((intptr_t *) _top_zero_frame + 1);
++    _top_zero_frame = *(ZeroFrame **) _top_zero_frame;
++  }
++
++ public:
++  static ByteSize zero_stack_offset() {
++    return byte_offset_of(JavaThread, _zero_stack);
++  }
++  static ByteSize top_zero_frame_offset() {
++    return byte_offset_of(JavaThread, _top_zero_frame);
++  }
++
++ public:
++  void set_last_Java_frame() {
++    set_last_Java_frame(top_zero_frame(), zero_stack()->sp());
++  }
++  void reset_last_Java_frame() {
++    frame_anchor()->zap();
++  }
++  void set_last_Java_frame(ZeroFrame* fp, intptr_t* sp) {
++    frame_anchor()->set(sp, NULL, fp);
++  }
++
++ public:
++  ZeroFrame* last_Java_fp() {
++    return frame_anchor()->last_Java_fp();
++  }
++
++ private:
++  frame pd_last_frame();
++
++ public:
++  static ByteSize last_Java_fp_offset() {
++    return byte_offset_of(JavaThread, _anchor) +
++      JavaFrameAnchor::last_Java_fp_offset();
++  }
++
++ public:
++  // Check for pending suspend requests and pending asynchronous
++  // exceptions.  There are separate accessors for these, but
++  // _suspend_flags is volatile so using them would be unsafe.
++  bool has_special_condition_for_native_trans() {
++    return _suspend_flags != 0;
++  }
++
++ public:
++  bool pd_get_top_frame_for_signal_handler(frame* fr_addr,
++                                           void* ucontext,
++                                           bool isInJava) {
++    ShouldNotCallThis();
++    return false;
++  }
++
++#endif // OS_CPU_SERENITY_ZERO_THREAD_SERENITY_ZERO_HPP
+diff --git a/src/hotspot/os_cpu/serenity_zero/vmStructs_serenity_zero.hpp b/src/hotspot/os_cpu/serenity_zero/vmStructs_serenity_zero.hpp
+new file mode 100644
+index 000000000..9ed7c1a3b
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/vmStructs_serenity_zero.hpp
+@@ -0,0 +1,42 @@
++/*
++ * Copyright (c) 2003, 2019, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2007 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#ifndef OS_CPU_SERENITY_ZERO_VMSTRUCTS_SERENITY_ZERO_HPP
++#define OS_CPU_SERENITY_ZERO_VMSTRUCTS_SERENITY_ZERO_HPP
++
++// These are the OS and CPU-specific fields, types and integer
++// constants required by the Serviceability Agent. This file is
++// referenced by vmStructs.cpp.
++
++#define VM_STRUCTS_OS_CPU(nonstatic_field, static_field, unchecked_nonstatic_field, volatile_nonstatic_field, nonproduct_nonstatic_field, c2_nonstatic_field, unchecked_c1_static_field, unchecked_c2_static_field)
++
++
++#define VM_TYPES_OS_CPU(declare_type, declare_toplevel_type, declare_oop_type, declare_integer_type, declare_unsigned_integer_type, declare_c1_toplevel_type, declare_c2_type, declare_c2_toplevel_type)
++
++#define VM_INT_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
++
++#define VM_LONG_CONSTANTS_OS_CPU(declare_constant, declare_preprocessor_constant, declare_c1_constant, declare_c2_constant, declare_c2_preprocessor_constant)
++
++#endif // OS_CPU_SERENITY_ZERO_VMSTRUCTS_SERENITY_ZERO_HPP
+diff --git a/src/hotspot/os_cpu/serenity_zero/vm_version_serenity_zero.cpp b/src/hotspot/os_cpu/serenity_zero/vm_version_serenity_zero.cpp
+new file mode 100644
+index 000000000..eaf1b85e4
+--- /dev/null
++++ b/src/hotspot/os_cpu/serenity_zero/vm_version_serenity_zero.cpp
+@@ -0,0 +1,30 @@
++/*
++ * Copyright (c) 1997, 2019, Oracle and/or its affiliates. All rights reserved.
++ * Copyright 2009 Red Hat, Inc.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ *
++ */
++
++#include "precompiled.hpp"
++#include "runtime/os.hpp"
++#include "runtime/vm_version.hpp"
++
++// This file is intentionally empty
+diff --git a/src/java.base/serenity/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java b/src/java.base/serenity/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java
+new file mode 100644
+index 000000000..7a7bfe089
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/ch/DefaultAsynchronousChannelProvider.java
+@@ -0,0 +1,47 @@
++/*
++ * Copyright (c) 2017, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.ch;
++
++import java.nio.channels.spi.AsynchronousChannelProvider;
++
++/**
++ * Creates this platform's default AsynchronousChannelProvider
++ */
++
++public class DefaultAsynchronousChannelProvider {
++
++    /**
++     * Prevent instantiation.
++     */
++    private DefaultAsynchronousChannelProvider() { }
++
++    /**
++     * Returns the default AsynchronousChannelProvider.
++     */
++    public static AsynchronousChannelProvider create() {
++        return new SerenityAsynchronousChannelProvider();
++    }
++}
+diff --git a/src/java.base/serenity/classes/sun/nio/ch/DefaultSelectorProvider.java b/src/java.base/serenity/classes/sun/nio/ch/DefaultSelectorProvider.java
+new file mode 100644
+index 000000000..86d3ade19
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/ch/DefaultSelectorProvider.java
+@@ -0,0 +1,54 @@
++/*
++ * Copyright (c) 2015, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.ch;
++
++import java.security.AccessController;
++import java.security.PrivilegedAction;
++
++/**
++ * Creates this platform's default SelectorProvider
++ */
++
++@SuppressWarnings("removal")
++public class DefaultSelectorProvider {
++    private static final SelectorProviderImpl INSTANCE;
++    static {
++        PrivilegedAction<SelectorProviderImpl> pa = PollSelectorProvider::new;
++        INSTANCE = AccessController.doPrivileged(pa);
++    }
++
++    /**
++     * Prevent instantiation.
++     */
++    private DefaultSelectorProvider() { }
++
++    /**
++     * Returns the default SelectorProvider implementation.
++     */
++    public static SelectorProviderImpl get() {
++        return INSTANCE;
++    }
++}
+\ No newline at end of file
+diff --git a/src/java.base/serenity/classes/sun/nio/ch/SerenityAsynchronousChannelProvider.java b/src/java.base/serenity/classes/sun/nio/ch/SerenityAsynchronousChannelProvider.java
+new file mode 100644
+index 000000000..2daa2cca4
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/ch/SerenityAsynchronousChannelProvider.java
+@@ -0,0 +1,91 @@
++/*
++ * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2012 SAP SE. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.ch;
++
++import java.nio.channels.*;
++import java.nio.channels.spi.AsynchronousChannelProvider;
++import java.util.concurrent.ExecutorService;
++import java.util.concurrent.ThreadFactory;
++import java.io.IOException;
++
++public class SerenityAsynchronousChannelProvider
++    extends AsynchronousChannelProvider
++{
++    private static volatile SerenityPollPort defaultPort;
++
++    private SerenityPollPort defaultEventPort() throws IOException {
++        if (defaultPort == null) {
++            synchronized (SerenityAsynchronousChannelProvider.class) {
++                if (defaultPort == null) {
++                    defaultPort = new SerenityPollPort(this, ThreadPool.getDefault()).start();
++                }
++            }
++        }
++        return defaultPort;
++    }
++
++    public SerenityAsynchronousChannelProvider() {
++    }
++
++    @Override
++    public AsynchronousChannelGroup openAsynchronousChannelGroup(int nThreads, ThreadFactory factory)
++        throws IOException
++    {
++        return new SerenityPollPort(this, ThreadPool.create(nThreads, factory)).start();
++    }
++
++    @Override
++    public AsynchronousChannelGroup openAsynchronousChannelGroup(ExecutorService executor, int initialSize)
++        throws IOException
++    {
++        return new SerenityPollPort(this, ThreadPool.wrap(executor, initialSize)).start();
++    }
++
++    private Port toPort(AsynchronousChannelGroup group) throws IOException {
++        if (group == null) {
++            return defaultEventPort();
++        } else {
++            if (!(group instanceof SerenityPollPort))
++                throw new IllegalChannelGroupException();
++            return (Port)group;
++        }
++    }
++
++    @Override
++    public AsynchronousServerSocketChannel openAsynchronousServerSocketChannel(AsynchronousChannelGroup group)
++        throws IOException
++    {
++        return new UnixAsynchronousServerSocketChannelImpl(toPort(group));
++    }
++
++    @Override
++    public AsynchronousSocketChannel openAsynchronousSocketChannel(AsynchronousChannelGroup group)
++        throws IOException
++    {
++        return new UnixAsynchronousSocketChannelImpl(toPort(group));
++    }
++}
+diff --git a/src/java.base/serenity/classes/sun/nio/ch/SerenityPollPort.java b/src/java.base/serenity/classes/sun/nio/ch/SerenityPollPort.java
+new file mode 100644
+index 000000000..0894d1814
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/ch/SerenityPollPort.java
+@@ -0,0 +1,538 @@
++/*
++ * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2012 SAP SE. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.ch;
++
++import java.nio.channels.spi.AsynchronousChannelProvider;
++import java.io.IOException;
++import java.util.HashSet;
++import java.util.Iterator;
++import java.util.concurrent.ArrayBlockingQueue;
++import java.util.concurrent.RejectedExecutionException;
++import java.util.concurrent.atomic.AtomicInteger;
++import java.util.concurrent.locks.ReentrantLock;
++import jdk.internal.misc.Unsafe;
++
++/**
++ * AsynchronousChannelGroup implementation based on the AIX pollset framework.
++ */
++final class SerenityPollPort
++    extends Port
++{
++    private static final Unsafe unsafe = Unsafe.getUnsafe();
++
++    static {
++        IOUtil.load();
++        init();
++    }
++
++    /**
++     * struct pollfd {
++     *     int fd;
++     *     short events;
++     *     short revents;
++     * }
++     */
++    private static final int SIZEOF_POLLFD    = eventSize();
++    private static final int OFFSETOF_EVENTS  = eventsOffset();
++    private static final int OFFSETOF_REVENTS = reventsOffset();
++    private static final int OFFSETOF_FD      = fdOffset();
++
++    // opcodes
++    private static final int PS_ADD     = 0x0;
++    private static final int PS_MOD     = 0x1;
++    private static final int PS_DELETE  = 0x2;
++
++    // maximum number of events to poll at a time
++    private static final int MAX_POLL_EVENTS = 512;
++
++    // pollset ID
++    private final int pollset;
++
++    // true if port is closed
++    private boolean closed;
++
++    // socket pair used for wakeup
++    private final int sp[];
++
++    // socket pair used to indicate pending pollsetCtl calls
++    // Background info: pollsetCtl blocks when another thread is in a pollsetPoll call.
++    private final int ctlSp[];
++
++    // number of wakeups pending
++    private final AtomicInteger wakeupCount = new AtomicInteger();
++
++    // address of the poll array passed to pollset_poll
++    private final long address;
++
++    // encapsulates an event for a channel
++    static class Event {
++        final PollableChannel channel;
++        final int events;
++
++        Event(PollableChannel channel, int events) {
++            this.channel = channel;
++            this.events = events;
++        }
++
++        PollableChannel channel()   { return channel; }
++        int events()                { return events; }
++    }
++
++    // queue of events for cases that a polling thread dequeues more than one
++    // event
++    private final ArrayBlockingQueue<Event> queue;
++    private final Event NEED_TO_POLL = new Event(null, 0);
++    private final Event EXECUTE_TASK_OR_SHUTDOWN = new Event(null, 0);
++    private final Event CONTINUE_AFTER_CTL_EVENT = new Event(null, 0);
++
++    // encapsulates a pollset control event for a file descriptor
++    static class ControlEvent {
++        final int fd;
++        final int events;
++        final boolean removeOnly;
++        int error = 0;
++
++        ControlEvent(int fd, int events, boolean removeOnly) {
++            this.fd = fd;
++            this.events = events;
++            this.removeOnly = removeOnly;
++        }
++
++        int fd()                 { return fd; }
++        int events()             { return events; }
++        boolean removeOnly()     { return removeOnly; }
++        int error()              { return error; }
++        void setError(int error) { this.error = error; }
++    }
++
++    // queue of control events that need to be processed
++    // (this object is also used for synchronization)
++    private final HashSet<ControlEvent> controlQueue = new HashSet<ControlEvent>();
++
++    // lock used to check whether a poll operation is ongoing
++    private final ReentrantLock controlLock = new ReentrantLock();
++
++    SerenityPollPort(AsynchronousChannelProvider provider, ThreadPool pool)
++        throws IOException
++    {
++        super(provider, pool);
++
++        // open pollset
++        this.pollset = pollsetCreate();
++
++        // create socket pair for wakeup mechanism
++        int[] sv = new int[2];
++        try {
++            socketpair(sv);
++            // register one end with pollset
++            pollsetCtl(pollset, PS_ADD, sv[0], Net.POLLIN);
++        } catch (IOException x) {
++            pollsetDestroy(pollset);
++            throw x;
++        }
++        this.sp = sv;
++
++        // create socket pair for pollset control mechanism
++        sv = new int[2];
++        try {
++            socketpair(sv);
++            // register one end with pollset
++            pollsetCtl(pollset, PS_ADD, sv[0], Net.POLLIN);
++        } catch (IOException x) {
++            pollsetDestroy(pollset);
++            throw x;
++        }
++        this.ctlSp = sv;
++
++        // allocate the poll array
++        this.address = allocatePollArray(MAX_POLL_EVENTS);
++
++        // create the queue and offer the special event to ensure that the first
++        // threads polls
++        this.queue = new ArrayBlockingQueue<Event>(MAX_POLL_EVENTS);
++        this.queue.offer(NEED_TO_POLL);
++    }
++
++    SerenityPollPort start() {
++        startThreads(new EventHandlerTask());
++        return this;
++    }
++
++    /**
++     * Release all resources
++     */
++    private void implClose() {
++        synchronized (this) {
++            if (closed)
++                return;
++            closed = true;
++        }
++        freePollArray(address);
++        close0(sp[0]);
++        close0(sp[1]);
++        close0(ctlSp[0]);
++        close0(ctlSp[1]);
++        pollsetDestroy(pollset);
++    }
++
++    private void wakeup() {
++        if (wakeupCount.incrementAndGet() == 1) {
++            // write byte to socketpair to force wakeup
++            try {
++                interrupt(sp[1]);
++            } catch (IOException x) {
++                throw new AssertionError(x);
++            }
++        }
++    }
++
++    @Override
++    void executeOnHandlerTask(Runnable task) {
++        synchronized (this) {
++            if (closed)
++                throw new RejectedExecutionException();
++            offerTask(task);
++            wakeup();
++        }
++    }
++
++    @Override
++    void shutdownHandlerTasks() {
++        /*
++         * If no tasks are running then just release resources; otherwise
++         * write to the one end of the socketpair to wakeup any polling threads.
++         */
++        int nThreads = threadCount();
++        if (nThreads == 0) {
++            implClose();
++        } else {
++            // send interrupt to each thread
++            while (nThreads-- > 0) {
++                wakeup();
++            }
++        }
++    }
++
++    // invoke by clients to register a file descriptor
++    @Override
++    void startPoll(int fd, int events) {
++        queueControlEvent(new ControlEvent(fd, events, false));
++    }
++
++    // Callback method for implementations that need special handling when fd is removed
++    @Override
++    protected void preUnregister(int fd) {
++        queueControlEvent(new ControlEvent(fd, 0, true));
++    }
++
++    // Add control event into queue and wait for completion.
++    // In case the control lock is free, this method also tries to apply the control change directly.
++    private void queueControlEvent(ControlEvent ev) {
++        // pollsetCtl blocks when a poll call is ongoing. This is very probable.
++        // Therefore we let the polling thread do the pollsetCtl call.
++        synchronized (controlQueue) {
++            controlQueue.add(ev);
++            // write byte to socketpair to force wakeup
++            try {
++                interrupt(ctlSp[1]);
++            } catch (IOException x) {
++                throw new AssertionError(x);
++            }
++            do {
++                // Directly empty queue if no poll call is ongoing.
++                if (controlLock.tryLock()) {
++                    try {
++                        processControlQueue();
++                    } finally {
++                        controlLock.unlock();
++                    }
++                } else {
++                    try {
++                        // Do not starve in case the polling thread returned before
++                        // we could write to ctlSp[1] but the polling thread did not
++                        // release the control lock until we checked. Therefore, use
++                        // a timed wait for the time being.
++                        controlQueue.wait(100);
++                    } catch (InterruptedException e) {
++                        // ignore exception and try again
++                    }
++                }
++            } while (controlQueue.contains(ev));
++        }
++        if (ev.error() != 0) {
++            throw new AssertionError();
++        }
++    }
++
++    // Process all events currently stored in the control queue.
++    private void processControlQueue() {
++        synchronized (controlQueue) {
++            // TODO: this is ripped straight out of AIX implementation, who knows if it will work for Serenity
++            Iterator<ControlEvent> iter = controlQueue.iterator();
++            while (iter.hasNext()) {
++                ControlEvent ev = iter.next();
++                pollsetCtl(pollset, PS_DELETE, ev.fd(), 0);
++                if (!ev.removeOnly()) {
++                    ev.setError(pollsetCtl(pollset, PS_MOD, ev.fd(), ev.events()));
++                }
++                iter.remove();
++            }
++            controlQueue.notifyAll();
++        }
++    }
++
++    /*
++     * Task to process events from pollset and dispatch to the channel's
++     * onEvent handler.
++     *
++     * Events are retreived from pollset in batch and offered to a BlockingQueue
++     * where they are consumed by handler threads. A special "NEED_TO_POLL"
++     * event is used to signal one consumer to re-poll when all events have
++     * been consumed.
++     */
++    private class EventHandlerTask implements Runnable {
++        private Event poll() throws IOException {
++            try {
++                for (;;) {
++                    int n;
++                    controlLock.lock();
++                    try {
++                        n = pollsetPoll(pollset, address, MAX_POLL_EVENTS);
++                    } finally {
++                        controlLock.unlock();
++                    }
++                    /*
++                     * 'n' events have been read. Here we map them to their
++                     * corresponding channel in batch and queue n-1 so that
++                     * they can be handled by other handler threads. The last
++                     * event is handled by this thread (and so is not queued).
++                     */
++                    fdToChannelLock.readLock().lock();
++                    try {
++                        while (n-- > 0) {
++                            long eventAddress = getEvent(address, n);
++                            int fd = getDescriptor(eventAddress);
++
++                            // To emulate one shot semantic we need to remove
++                            // the file descriptor here.
++                            if (fd != sp[0] && fd != ctlSp[0]) {
++                                synchronized (controlQueue) {
++                                    pollsetCtl(pollset, PS_DELETE, fd, 0);
++                                }
++                            }
++
++                            // wakeup
++                            if (fd == sp[0]) {
++                                if (wakeupCount.decrementAndGet() == 0) {
++                                    // no more wakeups so drain pipe
++                                    drain1(sp[0]);
++                                }
++
++                                // queue special event if there are more events
++                                // to handle.
++                                if (n > 0) {
++                                    queue.offer(EXECUTE_TASK_OR_SHUTDOWN);
++                                    continue;
++                                }
++                                return EXECUTE_TASK_OR_SHUTDOWN;
++                            }
++
++                            // wakeup to process control event
++                            if (fd == ctlSp[0]) {
++                                synchronized (controlQueue) {
++                                    drain1(ctlSp[0]);
++                                    processControlQueue();
++                                }
++                                if (n > 0) {
++                                    continue;
++                                }
++                                return CONTINUE_AFTER_CTL_EVENT;
++                            }
++
++                            PollableChannel channel = fdToChannel.get(fd);
++                            if (channel != null) {
++                                int events = getRevents(eventAddress);
++                                Event ev = new Event(channel, events);
++
++                                // n-1 events are queued; This thread handles
++                                // the last one except for the wakeup
++                                if (n > 0) {
++                                    queue.offer(ev);
++                                } else {
++                                    return ev;
++                                }
++                            }
++                        }
++                    } finally {
++                        fdToChannelLock.readLock().unlock();
++                    }
++                }
++            } finally {
++                // to ensure that some thread will poll when all events have
++                // been consumed
++                queue.offer(NEED_TO_POLL);
++            }
++        }
++
++        public void run() {
++            Invoker.GroupAndInvokeCount myGroupAndInvokeCount =
++                Invoker.getGroupAndInvokeCount();
++            final boolean isPooledThread = (myGroupAndInvokeCount != null);
++            boolean replaceMe = false;
++            Event ev;
++            try {
++                for (;;) {
++                    // reset invoke count
++                    if (isPooledThread)
++                        myGroupAndInvokeCount.resetInvokeCount();
++
++                    try {
++                        replaceMe = false;
++                        ev = queue.take();
++
++                        // no events and this thread has been "selected" to
++                        // poll for more.
++                        if (ev == NEED_TO_POLL) {
++                            try {
++                                ev = poll();
++                            } catch (IOException x) {
++                                x.printStackTrace();
++                                return;
++                            }
++                        }
++                    } catch (InterruptedException x) {
++                        continue;
++                    }
++
++                    // contine after we processed a control event
++                    if (ev == CONTINUE_AFTER_CTL_EVENT) {
++                        continue;
++                    }
++
++                    // handle wakeup to execute task or shutdown
++                    if (ev == EXECUTE_TASK_OR_SHUTDOWN) {
++                        Runnable task = pollTask();
++                        if (task == null) {
++                            // shutdown request
++                            return;
++                        }
++                        // run task (may throw error/exception)
++                        replaceMe = true;
++                        task.run();
++                        continue;
++                    }
++
++                    // process event
++                    try {
++                        ev.channel().onEvent(ev.events(), isPooledThread);
++                    } catch (Error x) {
++                        replaceMe = true; throw x;
++                    } catch (RuntimeException x) {
++                        replaceMe = true; throw x;
++                    }
++                }
++            } finally {
++                // last handler to exit when shutdown releases resources
++                int remaining = threadExit(this, replaceMe);
++                if (remaining == 0 && isShutdown()) {
++                    implClose();
++                }
++            }
++        }
++    }
++
++    /**
++     * Allocates a poll array to handle up to {@code count} events.
++     */
++    private static long allocatePollArray(int count) {
++        return unsafe.allocateMemory(count * SIZEOF_POLLFD);
++    }
++
++    /**
++     * Free a poll array
++     */
++    private static void freePollArray(long address) {
++        unsafe.freeMemory(address);
++    }
++
++    /**
++     * Returns event[i];
++     */
++    private static long getEvent(long address, int i) {
++        return address + (SIZEOF_POLLFD*i);
++    }
++
++    /**
++     * Returns event->fd
++     */
++    private static int getDescriptor(long eventAddress) {
++        return unsafe.getInt(eventAddress + OFFSETOF_FD);
++    }
++
++    /**
++     * Returns event->events
++     */
++    private static int getEvents(long eventAddress) {
++        return unsafe.getChar(eventAddress + OFFSETOF_EVENTS);
++    }
++
++    /**
++     * Returns event->revents
++     */
++    private static int getRevents(long eventAddress) {
++        return unsafe.getChar(eventAddress + OFFSETOF_REVENTS);
++    }
++
++    // -- Native methods --
++
++    private static native void init();
++
++    private static native int eventSize();
++
++    private static native int eventsOffset();
++
++    private static native int reventsOffset();
++
++    private static native int fdOffset();
++
++    private static native int pollsetCreate() throws IOException;
++
++    private static native int pollsetCtl(int pollset, int opcode, int fd, int events);
++
++    private static native int pollsetPoll(int pollset, long pollAddress, int numfds)
++        throws IOException;
++
++    private static native void pollsetDestroy(int pollset);
++
++    private static native void socketpair(int[] sv) throws IOException;
++
++    private static native void interrupt(int fd) throws IOException;
++
++    private static native void drain1(int fd) throws IOException;
++
++    private static native void close0(int fd);
++}
+diff --git a/src/java.base/serenity/classes/sun/nio/fs/DefaultFileSystemProvider.java b/src/java.base/serenity/classes/sun/nio/fs/DefaultFileSystemProvider.java
+new file mode 100644
+index 000000000..b24f3de01
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/fs/DefaultFileSystemProvider.java
+@@ -0,0 +1,53 @@
++/*
++ * Copyright (c) 2017, 2018, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.fs;
++
++import java.nio.file.FileSystem;
++
++/**
++ * Creates this platform's default FileSystemProvider.
++ */
++
++public class DefaultFileSystemProvider {
++    private static final SerenityFileSystemProvider INSTANCE
++        = new SerenityFileSystemProvider();
++
++    private DefaultFileSystemProvider() { }
++
++    /**
++     * Returns the platform's default file system provider.
++     */
++    public static SerenityFileSystemProvider instance() {
++        return INSTANCE;
++    }
++
++    /**
++     * Returns the platform's default file system.
++     */
++    public static FileSystem theFileSystem() {
++        return INSTANCE.theFileSystem();
++    }
++}
+diff --git a/src/java.base/serenity/classes/sun/nio/fs/SerenityFileStore.java b/src/java.base/serenity/classes/sun/nio/fs/SerenityFileStore.java
+new file mode 100644
+index 000000000..3f408ec9b
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/fs/SerenityFileStore.java
+@@ -0,0 +1,105 @@
++/*
++ * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2013 SAP SE. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.fs;
++
++import java.nio.file.attribute.*;
++import java.util.*;
++import java.io.IOException;
++
++/**
++ * AIX implementation of FileStore
++ */
++
++class SerenityFileStore
++    extends UnixFileStore
++{
++
++    SerenityFileStore(UnixPath file) throws IOException {
++        super(file);
++    }
++
++    SerenityFileStore(UnixFileSystem fs, UnixMountEntry entry) throws IOException {
++        super(fs, entry);
++    }
++
++    /**
++     * Finds, and returns, the mount entry for the file system where the file
++     * resides.
++     */
++    @Override
++    UnixMountEntry findMountEntry() throws IOException {
++        SerenityFileSystem fs = (SerenityFileSystem)file().getFileSystem();
++
++        // step 1: get realpath
++        UnixPath path = null;
++        try {
++            byte[] rp = UnixNativeDispatcher.realpath(file());
++            path = new UnixPath(fs, rp);
++        } catch (UnixException x) {
++            x.rethrowAsIOException(file());
++        }
++
++        // step 2: find mount point
++        UnixPath parent = path.getParent();
++        while (parent != null) {
++            UnixFileAttributes attrs = null;
++            try {
++                attrs = UnixFileAttributes.get(parent, true);
++            } catch (UnixException x) {
++                x.rethrowAsIOException(parent);
++            }
++            if (attrs.dev() != dev())
++                break;
++            path = parent;
++            parent = parent.getParent();
++        }
++
++        // step 3: lookup mounted file systems
++        byte[] dir = path.asByteArray();
++        for (UnixMountEntry entry: fs.getMountEntries()) {
++            if (Arrays.equals(dir, entry.dir()))
++                return entry;
++        }
++
++        throw new IOException("Mount point not found");
++    }
++
++    @Override
++    protected boolean isExtendedAttributesEnabled(UnixPath path) {
++        return false;
++    }
++
++    @Override
++    public boolean supportsFileAttributeView(Class<? extends FileAttributeView> type) {
++        return super.supportsFileAttributeView(type);
++    }
++
++    @Override
++    public boolean supportsFileAttributeView(String name) {
++        return super.supportsFileAttributeView(name);
++    }
++}
+diff --git a/src/java.base/serenity/classes/sun/nio/fs/SerenityFileSystem.java b/src/java.base/serenity/classes/sun/nio/fs/SerenityFileSystem.java
+new file mode 100644
+index 000000000..bee588a7e
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/fs/SerenityFileSystem.java
+@@ -0,0 +1,94 @@
++/*
++ * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2013 SAP SE. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.fs;
++
++import java.nio.file.*;
++import java.nio.file.attribute.*;
++import java.io.IOException;
++import java.util.*;
++import static sun.nio.fs.SerenityNativeDispatcher.*;
++
++/**
++ * AIX implementation of FileSystem
++ */
++
++class SerenityFileSystem extends UnixFileSystem {
++
++    SerenityFileSystem(UnixFileSystemProvider provider, String dir) {
++        super(provider, dir);
++    }
++
++    @Override
++    public WatchService newWatchService()
++        throws IOException
++    {
++        return new PollingWatchService();
++    }
++
++    // lazy initialization of the list of supported attribute views
++    private static class SupportedFileFileAttributeViewsHolder {
++        static final Set<String> supportedFileAttributeViews =
++            supportedFileAttributeViews();
++        private static Set<String> supportedFileAttributeViews() {
++            Set<String> result = new HashSet<String>();
++            result.addAll(UnixFileSystem.standardFileAttributeViews());
++            return Collections.unmodifiableSet(result);
++        }
++    }
++
++    @Override
++    public Set<String> supportedFileAttributeViews() {
++        return SupportedFileFileAttributeViewsHolder.supportedFileAttributeViews;
++    }
++
++    @Override
++    void copyNonPosixAttributes(int ofd, int nfd) {
++        // TODO: Implement if needed.
++    }
++
++    /**
++     * Returns object to iterate over the mount entries returned by mntctl
++     */
++    @Override
++    Iterable<UnixMountEntry> getMountEntries() {
++        UnixMountEntry[] entries = null;
++        try {
++            entries = getmntctl();
++        } catch (UnixException x) {
++            // nothing we can do
++        }
++        if (entries == null) {
++            return Collections.emptyList();
++        }
++        return Arrays.asList(entries);
++    }
++
++    @Override
++    FileStore getFileStore(UnixMountEntry entry) throws IOException {
++        return new SerenityFileStore(this, entry);
++    }
++}
+diff --git a/src/java.base/serenity/classes/sun/nio/fs/SerenityFileSystemProvider.java b/src/java.base/serenity/classes/sun/nio/fs/SerenityFileSystemProvider.java
+new file mode 100644
+index 000000000..8582190af
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/fs/SerenityFileSystemProvider.java
+@@ -0,0 +1,52 @@
++/*
++ * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2013 SAP SE. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.fs;
++
++import java.io.IOException;
++
++/**
++ * Serenity implementation of FileSystemProvider
++ */
++
++class SerenityFileSystemProvider extends UnixFileSystemProvider {
++    public SerenityFileSystemProvider() {
++        super();
++    }
++
++    @Override
++    SerenityFileSystem newFileSystem(String dir) {
++        return new SerenityFileSystem(this, dir);
++    }
++
++    /**
++     * @see sun.nio.fs.UnixFileSystemProvider#getFileStore(sun.nio.fs.UnixPath)
++     */
++    @Override
++    SerenityFileStore getFileStore(UnixPath path) throws IOException {
++        return new SerenityFileStore(path);
++    }
++}
+diff --git a/src/java.base/serenity/classes/sun/nio/fs/SerenityNativeDispatcher.java b/src/java.base/serenity/classes/sun/nio/fs/SerenityNativeDispatcher.java
+new file mode 100644
+index 000000000..7c50b719c
+--- /dev/null
++++ b/src/java.base/serenity/classes/sun/nio/fs/SerenityNativeDispatcher.java
+@@ -0,0 +1,49 @@
++/*
++ * Copyright (c) 2008, 2019, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2013 SAP SE. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++package sun.nio.fs;
++
++/**
++ * Serenity specific system calls.
++ */
++
++class SerenityNativeDispatcher extends UnixNativeDispatcher {
++    private SerenityNativeDispatcher() { }
++
++    /**
++     * Special implementation of 'getextmntent' (see SolarisNativeDispatcher)
++     * that returns all entries at once.
++     */
++    static native UnixMountEntry[] getmntctl() throws UnixException;
++
++    // initialize
++    private static native void init();
++
++    static {
++        jdk.internal.loader.BootLoader.loadLibrary("nio");
++        init();
++    }
++}
+diff --git a/src/java.base/serenity/native/libjava/ProcessHandleImpl_serenity.c b/src/java.base/serenity/native/libjava/ProcessHandleImpl_serenity.c
+new file mode 100644
+index 000000000..afa159d9c
+--- /dev/null
++++ b/src/java.base/serenity/native/libjava/ProcessHandleImpl_serenity.c
+@@ -0,0 +1,68 @@
++/*
++ * Copyright (c) 2015, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++#include "jni.h"
++#include "jni_util.h"
++
++#include "ProcessHandleImpl_unix.h"
++
++// #include <sys/procfs.h>
++
++/*
++ * Implementation of native ProcessHandleImpl functions for SERENITY.
++ * See ProcessHandleImpl_unix.c for more details.
++ */
++
++void os_initNative(JNIEnv *env, jclass clazz) {}
++
++jint os_getChildren(JNIEnv *env, jlong jpid, jlongArray jarray,
++                    jlongArray jparentArray, jlongArray jstimesArray) {
++    return unix_getChildren(env, jpid, jarray, jparentArray, jstimesArray);
++}
++
++pid_t os_getParentPidAndTimings(JNIEnv *env, pid_t pid, jlong *total, jlong *start) {
++    // FIXME: parse /proc/all
++    return -1;
++}
++
++void os_getCmdlineAndUserInfo(JNIEnv *env, jobject jinfo, pid_t pid) {
++    //FIXME
++    // int fd;
++    // int cmdlen = 0;
++    // char *cmdline = NULL, *cmdEnd = NULL; // used for command line args and exe
++    // char *args = NULL;
++    // jstring cmdexe = NULL;
++    // char fn[32];
++    // struct stat stat_buf;
++    
++    // /*
++    //  * Stat /proc/<pid> to get the user id
++    //  */
++    // snprintf(fn, sizeof fn, "/proc/%d", pid);
++    // if (stat64(fn, &stat_buf) == 0) {
++    //     unix_getUserInfo(env, jinfo, stat_buf.st_uid);
++    //     JNU_CHECK_EXCEPTION(env);
++    // }
++}
+diff --git a/src/java.base/serenity/native/libnet/serenity_close.c b/src/java.base/serenity/native/libnet/serenity_close.c
+new file mode 100644
+index 000000000..6a177bbb9
+--- /dev/null
++++ b/src/java.base/serenity/native/libnet/serenity_close.c
+@@ -0,0 +1,458 @@
++/*
++ * Copyright (c) 2001, 2020, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++#include <assert.h>
++#include <limits.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <sys/param.h>
++#include <signal.h>
++#include <pthread.h>
++#include <sys/types.h>
++#include <sys/socket.h>
++#include <sys/select.h>
++#include <sys/time.h>
++#include <sys/resource.h>
++#include <sys/uio.h>
++#include <unistd.h>
++#include <errno.h>
++#include <poll.h>
++#include "jvm.h"
++#include "net_util.h"
++
++/*
++ * Stack allocated by thread when doing blocking operation
++ */
++typedef struct threadEntry {
++    pthread_t thr;                      /* this thread */
++    struct threadEntry *next;           /* next thread */
++    int intr;                           /* interrupted */
++} threadEntry_t;
++
++/*
++ * Heap allocated during initialized - one entry per fd
++ */
++typedef struct {
++    pthread_mutex_t lock;               /* fd lock */
++    threadEntry_t *threads;             /* threads blocked on fd */
++} fdEntry_t;
++
++/*
++ * Signal to unblock thread
++ */
++static int sigWakeup = SIGIO;
++
++/*
++ * fdTable holds one entry per file descriptor, up to a certain
++ * maximum.
++ * Theoretically, the number of possible file descriptors can get
++ * large, though usually it does not. Entries for small value file
++ * descriptors are kept in a simple table, which covers most scenarios.
++ * Entries for large value file descriptors are kept in an overflow
++ * table, which is organized as a sparse two dimensional array whose
++ * slabs are allocated on demand. This covers all corner cases while
++ * keeping memory consumption reasonable.
++ */
++
++/* Base table for low value file descriptors */
++static fdEntry_t* fdTable = NULL;
++/* Maximum size of base table (in number of entries). */
++static const int fdTableMaxSize = 0x1000; /* 4K */
++/* Actual size of base table (in number of entries) */
++static int fdTableLen = 0;
++/* Max. theoretical number of file descriptors on system. */
++static int fdLimit = 0;
++
++/* Overflow table, should base table not be large enough. Organized as
++ *   an array of n slabs, each holding 64k entries.
++ */
++static fdEntry_t** fdOverflowTable = NULL;
++/* Number of slabs in the overflow table */
++static int fdOverflowTableLen = 0;
++/* Number of entries in one slab */
++static const int fdOverflowTableSlabSize = 0x10000; /* 64k */
++pthread_mutex_t fdOverflowTableLock = PTHREAD_MUTEX_INITIALIZER;
++
++/*
++ * Null signal handler
++ */
++static void sig_wakeup(int sig) {
++}
++
++/*
++ * Initialization routine (executed when library is loaded)
++ * Allocate fd tables and sets up signal handler.
++ */
++static void __attribute((constructor)) init() {
++    struct rlimit nbr_files;
++    sigset_t sigset;
++    struct sigaction sa;
++    int i = 0;
++
++    /* Determine the maximum number of possible file descriptors. */
++    if (-1 == getrlimit(RLIMIT_NOFILE, &nbr_files)) {
++        fprintf(stderr, "library initialization failed - "
++                "unable to get max # of allocated fds\n");
++        abort();
++    }
++    if (nbr_files.rlim_max != RLIM_INFINITY) {
++        fdLimit = nbr_files.rlim_max;
++    } else {
++        /* We just do not know. */
++        fdLimit = INT_MAX;
++    }
++
++    /* Allocate table for low value file descriptors. */
++    fdTableLen = fdLimit < fdTableMaxSize ? fdLimit : fdTableMaxSize;
++    fdTable = (fdEntry_t*) calloc(fdTableLen, sizeof(fdEntry_t));
++    if (fdTable == NULL) {
++        fprintf(stderr, "library initialization failed - "
++                "unable to allocate file descriptor table - out of memory");
++        abort();
++    } else {
++        for (i = 0; i < fdTableLen; i ++) {
++            pthread_mutex_init(&fdTable[i].lock, NULL);
++        }
++    }
++
++    /* Allocate overflow table, if needed */
++    if (fdLimit > fdTableMaxSize) {
++        fdOverflowTableLen = ((fdLimit - fdTableMaxSize) / fdOverflowTableSlabSize) + 1;
++        fdOverflowTable = (fdEntry_t**) calloc(fdOverflowTableLen, sizeof(fdEntry_t*));
++        if (fdOverflowTable == NULL) {
++            fprintf(stderr, "library initialization failed - "
++                    "unable to allocate file descriptor overflow table - out of memory");
++            abort();
++        }
++    }
++
++    /*
++     * Setup the signal handler
++     */
++    sa.sa_handler = sig_wakeup;
++    sa.sa_flags   = 0;
++    sigemptyset(&sa.sa_mask);
++    sigaction(sigWakeup, &sa, NULL);
++
++    sigemptyset(&sigset);
++    sigaddset(&sigset, sigWakeup);
++    sigprocmask(SIG_UNBLOCK, &sigset, NULL);
++}
++
++/*
++ * Return the fd table for this fd.
++ */
++static inline fdEntry_t *getFdEntry(int fd)
++{
++    fdEntry_t* result = NULL;
++
++    if (fd < 0) {
++        return NULL;
++    }
++
++    /* This should not happen. If it does, our assumption about
++     * max. fd value was wrong. */
++    assert(fd < fdLimit);
++
++    if (fd < fdTableMaxSize) {
++        /* fd is in base table. */
++        assert(fd < fdTableLen);
++        result = &fdTable[fd];
++    } else {
++        /* fd is in overflow table. */
++        const int indexInOverflowTable = fd - fdTableMaxSize;
++        const int rootindex = indexInOverflowTable / fdOverflowTableSlabSize;
++        const int slabindex = indexInOverflowTable % fdOverflowTableSlabSize;
++        fdEntry_t* slab = NULL;
++        assert(rootindex < fdOverflowTableLen);
++        assert(slabindex < fdOverflowTableSlabSize);
++        pthread_mutex_lock(&fdOverflowTableLock);
++        /* Allocate new slab in overflow table if needed */
++        if (fdOverflowTable[rootindex] == NULL) {
++            fdEntry_t* const newSlab =
++                (fdEntry_t*)calloc(fdOverflowTableSlabSize, sizeof(fdEntry_t));
++            if (newSlab == NULL) {
++                fprintf(stderr, "Unable to allocate file descriptor overflow"
++                        " table slab - out of memory");
++                pthread_mutex_unlock(&fdOverflowTableLock);
++                abort();
++            } else {
++                int i;
++                for (i = 0; i < fdOverflowTableSlabSize; i ++) {
++                    pthread_mutex_init(&newSlab[i].lock, NULL);
++                }
++                fdOverflowTable[rootindex] = newSlab;
++            }
++        }
++        pthread_mutex_unlock(&fdOverflowTableLock);
++        slab = fdOverflowTable[rootindex];
++        result = &slab[slabindex];
++    }
++
++    return result;
++
++}
++
++
++/*
++ * Start a blocking operation :-
++ *    Insert thread onto thread list for the fd.
++ */
++static inline void startOp(fdEntry_t *fdEntry, threadEntry_t *self)
++{
++    self->thr = pthread_self();
++    self->intr = 0;
++
++    pthread_mutex_lock(&(fdEntry->lock));
++    {
++        self->next = fdEntry->threads;
++        fdEntry->threads = self;
++    }
++    pthread_mutex_unlock(&(fdEntry->lock));
++}
++
++/*
++ * End a blocking operation :-
++ *     Remove thread from thread list for the fd
++ *     If fd has been interrupted then set errno to EBADF
++ */
++static inline void endOp
++    (fdEntry_t *fdEntry, threadEntry_t *self)
++{
++    int orig_errno = errno;
++    pthread_mutex_lock(&(fdEntry->lock));
++    {
++        threadEntry_t *curr, *prev=NULL;
++        curr = fdEntry->threads;
++        while (curr != NULL) {
++            if (curr == self) {
++                if (curr->intr) {
++                    orig_errno = EBADF;
++                }
++                if (prev == NULL) {
++                    fdEntry->threads = curr->next;
++                } else {
++                    prev->next = curr->next;
++                }
++                break;
++            }
++            prev = curr;
++            curr = curr->next;
++        }
++    }
++    pthread_mutex_unlock(&(fdEntry->lock));
++    errno = orig_errno;
++}
++
++/*
++ * Close or dup2 a file descriptor ensuring that all threads blocked on
++ * the file descriptor are notified via a wakeup signal.
++ *
++ *      fd1 < 0    => close(fd2)
++ *      fd1 >= 0   => dup2(fd1, fd2)
++ *
++ * Returns -1 with errno set if operation fails.
++ */
++static int closefd(int fd1, int fd2) {
++    int rv, orig_errno;
++    fdEntry_t *fdEntry = getFdEntry(fd2);
++    if (fdEntry == NULL) {
++        errno = EBADF;
++        return -1;
++    }
++
++    /*
++     * Lock the fd to hold-off additional I/O on this fd.
++     */
++    pthread_mutex_lock(&(fdEntry->lock));
++
++    {
++        /*
++         * Send a wakeup signal to all threads blocked on this
++         * file descriptor.
++         */
++        threadEntry_t *curr = fdEntry->threads;
++        while (curr != NULL) {
++            curr->intr = 1;
++            pthread_kill( curr->thr, sigWakeup );
++            curr = curr->next;
++        }
++
++        /*
++         * And close/dup the file descriptor
++         * (restart if interrupted by signal)
++         */
++        do {
++            if (fd1 < 0) {
++                rv = close(fd2);
++            } else {
++                rv = dup2(fd1, fd2);
++            }
++        } while (rv == -1 && errno == EINTR);
++
++    }
++
++    /*
++     * Unlock without destroying errno
++     */
++    orig_errno = errno;
++    pthread_mutex_unlock(&(fdEntry->lock));
++    errno = orig_errno;
++
++    return rv;
++}
++
++/*
++ * Wrapper for dup2 - same semantics as dup2 system call except
++ * that any threads blocked in an I/O system call on fd2 will be
++ * preempted and return -1/EBADF;
++ */
++int NET_Dup2(int fd, int fd2) {
++    if (fd < 0) {
++        errno = EBADF;
++        return -1;
++    }
++    return closefd(fd, fd2);
++}
++
++/*
++ * Wrapper for close - same semantics as close system call
++ * except that any threads blocked in an I/O on fd will be
++ * preempted and the I/O system call will return -1/EBADF.
++ */
++int NET_SocketClose(int fd) {
++    return closefd(-1, fd);
++}
++
++/************** Basic I/O operations here ***************/
++
++/*
++ * Macro to perform a blocking IO operation. Restarts
++ * automatically if interrupted by signal (other than
++ * our wakeup signal)
++ */
++#define BLOCKING_IO_RETURN_INT(FD, FUNC) {      \
++    int ret;                                    \
++    threadEntry_t self;                         \
++    fdEntry_t *fdEntry = getFdEntry(FD);        \
++    if (fdEntry == NULL) {                      \
++        errno = EBADF;                          \
++        return -1;                              \
++    }                                           \
++    do {                                        \
++        startOp(fdEntry, &self);                \
++        ret = FUNC;                             \
++        endOp(fdEntry, &self);                  \
++    } while (ret == -1 && errno == EINTR);      \
++    return ret;                                 \
++}
++
++int NET_Read(int s, void* buf, size_t len) {
++    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, 0) );
++}
++
++int NET_NonBlockingRead(int s, void* buf, size_t len) {
++    BLOCKING_IO_RETURN_INT( s, recv(s, buf, len, MSG_DONTWAIT));
++}
++
++int NET_RecvFrom(int s, void *buf, int len, unsigned int flags,
++       struct sockaddr *from, socklen_t *fromlen) {
++    BLOCKING_IO_RETURN_INT( s, recvfrom(s, buf, len, flags, from, fromlen) );
++}
++
++int NET_Send(int s, void *msg, int len, unsigned int flags) {
++    BLOCKING_IO_RETURN_INT( s, send(s, msg, len, flags) );
++}
++
++int NET_SendTo(int s, const void *msg, int len,  unsigned  int
++       flags, const struct sockaddr *to, int tolen) {
++    BLOCKING_IO_RETURN_INT( s, sendto(s, msg, len, flags, to, tolen) );
++}
++
++int NET_Accept(int s, struct sockaddr *addr, socklen_t *addrlen) {
++    BLOCKING_IO_RETURN_INT( s, accept(s, addr, addrlen) );
++}
++
++int NET_Connect(int s, struct sockaddr *addr, int addrlen) {
++    BLOCKING_IO_RETURN_INT( s, connect(s, addr, addrlen) );
++}
++
++int NET_Poll(struct pollfd *ufds, unsigned int nfds, int timeout) {
++    BLOCKING_IO_RETURN_INT( ufds[0].fd, poll(ufds, nfds, timeout) );
++}
++
++/*
++ * Wrapper for poll(s, timeout).
++ * Auto restarts with adjusted timeout if interrupted by
++ * signal other than our wakeup signal.
++ */
++int NET_Timeout(JNIEnv *env, int s, long timeout, jlong nanoTimeStamp) {
++    jlong prevNanoTime = nanoTimeStamp;
++    jlong nanoTimeout = (jlong)timeout * NET_NSEC_PER_MSEC;
++    fdEntry_t *fdEntry = getFdEntry(s);
++
++    /*
++     * Check that fd hasn't been closed.
++     */
++    if (fdEntry == NULL) {
++        errno = EBADF;
++        return -1;
++    }
++
++    for(;;) {
++        struct pollfd pfd;
++        int rv;
++        threadEntry_t self;
++
++        /*
++         * Poll the fd. If interrupted by our wakeup signal
++         * errno will be set to EBADF.
++         */
++        pfd.fd = s;
++        pfd.events = POLLIN | POLLERR;
++
++        startOp(fdEntry, &self);
++        rv = poll(&pfd, 1, nanoTimeout / NET_NSEC_PER_MSEC);
++        endOp(fdEntry, &self);
++        /*
++         * If interrupted then adjust timeout. If timeout
++         * has expired return 0 (indicating timeout expired).
++         */
++        if (rv < 0 && errno == EINTR) {
++            if (timeout > 0) {
++                jlong newNanoTime = JVM_NanoTime(env, 0);
++                nanoTimeout -= newNanoTime - prevNanoTime;
++                if (nanoTimeout < NET_NSEC_PER_MSEC) {
++                    return 0;
++                }
++                prevNanoTime = newNanoTime;
++            } else {
++                continue; // timeout is -1, so  loop again.
++            }
++        } else {
++            return rv;
++        }
++    }
++}
+diff --git a/src/jdk.attach/serenity/classes/sun/tools/attach/AttachProviderImpl.java b/src/jdk.attach/serenity/classes/sun/tools/attach/AttachProviderImpl.java
+new file mode 100644
+index 000000000..2f6fc4d4d
+--- /dev/null
++++ b/src/jdk.attach/serenity/classes/sun/tools/attach/AttachProviderImpl.java
+@@ -0,0 +1,82 @@
++/*
++ * Copyright (c) 2008, 2013, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2013 SAP SE. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++package sun.tools.attach;
++
++import com.sun.tools.attach.VirtualMachine;
++import com.sun.tools.attach.VirtualMachineDescriptor;
++import com.sun.tools.attach.AttachNotSupportedException;
++import java.io.IOException;
++
++// Based on linux/classes/sun/tools/attach/AttachProviderImpl.java.
++
++/*
++ * An AttachProvider implementation for Aix that uses a UNIX domain
++ * socket.
++ */
++public class AttachProviderImpl extends HotSpotAttachProvider {
++
++    public AttachProviderImpl() {
++    }
++
++    public String name() {
++        return "sun";
++    }
++
++    public String type() {
++        return "socket";
++    }
++
++    public VirtualMachine attachVirtualMachine(String vmid)
++        throws AttachNotSupportedException, IOException
++    {
++        checkAttachPermission();
++
++        // AttachNotSupportedException will be thrown if the target VM can be determined
++        // to be not attachable.
++        testAttachable(vmid);
++
++        return new VirtualMachineImpl(this, vmid);
++    }
++
++    public VirtualMachine attachVirtualMachine(VirtualMachineDescriptor vmd)
++        throws AttachNotSupportedException, IOException
++    {
++        if (vmd.provider() != this) {
++            throw new AttachNotSupportedException("provider mismatch");
++        }
++        // To avoid re-checking if the VM if attachable, we check if the descriptor
++        // is for a hotspot VM - these descriptors are created by the listVirtualMachines
++        // implementation which only returns a list of attachable VMs.
++        if (vmd instanceof HotSpotVirtualMachineDescriptor) {
++            assert ((HotSpotVirtualMachineDescriptor)vmd).isAttachable();
++            checkAttachPermission();
++            return new VirtualMachineImpl(this, vmd.id());
++        } else {
++            return attachVirtualMachine(vmd.id());
++        }
++    }
++
++}
+diff --git a/src/jdk.attach/serenity/classes/sun/tools/attach/VirtualMachineImpl.java b/src/jdk.attach/serenity/classes/sun/tools/attach/VirtualMachineImpl.java
+new file mode 100644
+index 000000000..0c432edee
+--- /dev/null
++++ b/src/jdk.attach/serenity/classes/sun/tools/attach/VirtualMachineImpl.java
+@@ -0,0 +1,326 @@
++/*
++ * Copyright (c) 2008, 2021, Oracle and/or its affiliates. All rights reserved.
++ * Copyright (c) 2015, 2019 SAP SE. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++package sun.tools.attach;
++
++import com.sun.tools.attach.AttachOperationFailedException;
++import com.sun.tools.attach.AgentLoadException;
++import com.sun.tools.attach.AttachNotSupportedException;
++import com.sun.tools.attach.spi.AttachProvider;
++
++import java.io.InputStream;
++import java.io.IOException;
++import java.io.File;
++
++/*
++ * Aix implementation of HotSpotVirtualMachine
++ */
++public class VirtualMachineImpl extends HotSpotVirtualMachine {
++    // "/tmp" is used as a global well-known location for the files
++    // .java_pid<pid>. and .attach_pid<pid>. It is important that this
++    // location is the same for all processes, otherwise the tools
++    // will not be able to find all Hotspot processes.
++    // Any changes to this needs to be synchronized with HotSpot.
++    private static final String tmpdir = "/tmp";
++    String socket_path;
++
++    /**
++     * Attaches to the target VM
++     */
++    VirtualMachineImpl(AttachProvider provider, String vmid)
++        throws AttachNotSupportedException, IOException
++    {
++        super(provider, vmid);
++
++        // This provider only understands pids
++        int pid;
++        try {
++            pid = Integer.parseInt(vmid);
++            if (pid < 1) {
++                throw new NumberFormatException();
++            }
++        } catch (NumberFormatException x) {
++            throw new AttachNotSupportedException("Invalid process identifier: " + vmid);
++        }
++
++        // Find the socket file. If not found then we attempt to start the
++        // attach mechanism in the target VM by sending it a QUIT signal.
++        // Then we attempt to find the socket file again.
++        File socket_file = new File(tmpdir, ".java_pid" + pid);
++        socket_path = socket_file.getPath();
++        if (!socket_file.exists()) {
++            // Keep canonical version of File, to delete, in case target process ends and /proc link has gone:
++            File f = createAttachFile(pid).getCanonicalFile();
++            try {
++                sendQuitTo(pid);
++
++                // give the target VM time to start the attach mechanism
++                final int delay_step = 100;
++                final long timeout = attachTimeout();
++                long time_spend = 0;
++                long delay = 0;
++                do {
++                    // Increase timeout on each attempt to reduce polling
++                    delay += delay_step;
++                    try {
++                        Thread.sleep(delay);
++                    } catch (InterruptedException x) { }
++
++                    time_spend += delay;
++                    if (time_spend > timeout/2 && !socket_file.exists()) {
++                        // Send QUIT again to give target VM the last chance to react
++                        sendQuitTo(pid);
++                    }
++                } while (time_spend <= timeout && !socket_file.exists());
++                if (!socket_file.exists()) {
++                    throw new AttachNotSupportedException(
++                        String.format("Unable to open socket file %s: " +
++                          "target process %d doesn't respond within %dms " +
++                           "or HotSpot VM not loaded", socket_path, pid,
++                                      time_spend));
++                }
++            } finally {
++                f.delete();
++            }
++        }
++
++        // Check that the file owner/permission to avoid attaching to
++        // bogus process
++        checkPermissions(socket_path);
++
++        // Check that we can connect to the process
++        // - this ensures we throw the permission denied error now rather than
++        // later when we attempt to enqueue a command.
++        int s = socket();
++        try {
++            connect(s, socket_path);
++        } finally {
++            close(s);
++        }
++    }
++
++    /**
++     * Detach from the target VM
++     */
++    public void detach() throws IOException {
++        synchronized (this) {
++            if (socket_path != null) {
++                socket_path = null;
++            }
++        }
++    }
++
++    // protocol version
++    private final static String PROTOCOL_VERSION = "1";
++
++    // known errors
++    private final static int ATTACH_ERROR_BADVERSION = 101;
++
++    /**
++     * Execute the given command in the target VM.
++     */
++    InputStream execute(String cmd, Object ... args) throws AgentLoadException, IOException {
++        assert args.length <= 3;                // includes null
++
++        // did we detach?
++        synchronized (this) {
++            if (socket_path == null) {
++                throw new IOException("Detached from target VM");
++            }
++        }
++
++        // create UNIX socket
++        int s = socket();
++
++        // connect to target VM
++        try {
++            connect(s, socket_path);
++        } catch (IOException x) {
++            close(s);
++            throw x;
++        }
++
++        IOException ioe = null;
++
++        // connected - write request
++        // <ver> <cmd> <args...>
++        try {
++            writeString(s, PROTOCOL_VERSION);
++            writeString(s, cmd);
++
++            for (int i = 0; i < 3; i++) {
++                if (i < args.length && args[i] != null) {
++                    writeString(s, (String)args[i]);
++                } else {
++                    writeString(s, "");
++                }
++            }
++        } catch (IOException x) {
++            ioe = x;
++        }
++
++
++        // Create an input stream to read reply
++        SocketInputStream sis = new SocketInputStream(s);
++
++        // Read the command completion status
++        int completionStatus;
++        try {
++            completionStatus = readInt(sis);
++        } catch (IOException x) {
++            sis.close();
++            if (ioe != null) {
++                throw ioe;
++            } else {
++                throw x;
++            }
++        }
++
++        if (completionStatus != 0) {
++            // read from the stream and use that as the error message
++            String message = readErrorMessage(sis);
++            sis.close();
++
++            // In the event of a protocol mismatch then the target VM
++            // returns a known error so that we can throw a reasonable
++            // error.
++            if (completionStatus == ATTACH_ERROR_BADVERSION) {
++                throw new IOException("Protocol mismatch with target VM");
++            }
++
++            // Special-case the "load" command so that the right exception is
++            // thrown.
++            if (cmd.equals("load")) {
++                String msg = "Failed to load agent library";
++                if (!message.isEmpty())
++                    msg += ": " + message;
++                throw new AgentLoadException(msg);
++            } else {
++                if (message.isEmpty())
++                    message = "Command failed in target VM";
++                throw new AttachOperationFailedException(message);
++            }
++        }
++
++        // Return the input stream so that the command output can be read
++        return sis;
++    }
++
++    /*
++     * InputStream for the socket connection to get target VM
++     */
++    private class SocketInputStream extends InputStream {
++        int s;
++
++        public SocketInputStream(int s) {
++            this.s = s;
++        }
++
++        public synchronized int read() throws IOException {
++            byte b[] = new byte[1];
++            int n = this.read(b, 0, 1);
++            if (n == 1) {
++                return b[0] & 0xff;
++            } else {
++                return -1;
++            }
++        }
++
++        public synchronized int read(byte[] bs, int off, int len) throws IOException {
++            if ((off < 0) || (off > bs.length) || (len < 0) ||
++                ((off + len) > bs.length) || ((off + len) < 0)) {
++                throw new IndexOutOfBoundsException();
++            } else if (len == 0)
++                return 0;
++
++            return VirtualMachineImpl.read(s, bs, off, len);
++        }
++
++        public synchronized void close() throws IOException {
++            if (s != -1) {
++                int toClose = s;
++                s = -1;
++                VirtualMachineImpl.close(toClose);
++            }
++        }
++    }
++
++    // On Aix a simple handshake is used to start the attach mechanism
++    // if not already started. The client creates a .attach_pid<pid> file in the
++    // target VM's working directory (or temp directory), and the SIGQUIT handler
++    // checks for the file.
++    private File createAttachFile(int pid) throws IOException {
++        String fn = ".attach_pid" + pid;
++        String path = "/proc/" + pid + "/cwd/" + fn;
++        File f = new File(path);
++        try {
++            f.createNewFile();
++        } catch (IOException x) {
++            f = new File(tmpdir, fn);
++            f.createNewFile();
++        }
++        return f;
++    }
++
++    /*
++     * Write/sends the given to the target VM. String is transmitted in
++     * UTF-8 encoding.
++     */
++    private void writeString(int fd, String s) throws IOException {
++        if (s.length() > 0) {
++            byte b[];
++            try {
++                b = s.getBytes("UTF-8");
++            } catch (java.io.UnsupportedEncodingException x) {
++                throw new InternalError(x);
++            }
++            VirtualMachineImpl.write(fd, b, 0, b.length);
++        }
++        byte b[] = new byte[1];
++        b[0] = 0;
++        write(fd, b, 0, 1);
++    }
++
++
++    //-- native methods
++
++    static native void sendQuitTo(int pid) throws IOException;
++
++    static native void checkPermissions(String path) throws IOException;
++
++    static native int socket() throws IOException;
++
++    static native void connect(int fd, String path) throws IOException;
++
++    static native void close(int fd) throws IOException;
++
++    static native int read(int fd, byte buf[], int off, int bufLen) throws IOException;
++
++    static native void write(int fd, byte buf[], int off, int bufLen) throws IOException;
++
++    static {
++        System.loadLibrary("attach");
++    }
++}
+diff --git a/src/jdk.attach/serenity/native/libattach/VirtualMachineImpl.c b/src/jdk.attach/serenity/native/libattach/VirtualMachineImpl.c
+new file mode 100644
+index 000000000..d20a6f012
+--- /dev/null
++++ b/src/jdk.attach/serenity/native/libattach/VirtualMachineImpl.c
+@@ -0,0 +1,328 @@
++/*
++ * Copyright (c) 2005, 2021, Oracle and/or its affiliates. All rights reserved.
++ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
++ *
++ * This code is free software; you can redistribute it and/or modify it
++ * under the terms of the GNU General Public License version 2 only, as
++ * published by the Free Software Foundation.  Oracle designates this
++ * particular file as subject to the "Classpath" exception as provided
++ * by Oracle in the LICENSE file that accompanied this code.
++ *
++ * This code is distributed in the hope that it will be useful, but WITHOUT
++ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
++ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
++ * version 2 for more details (a copy is included in the LICENSE file that
++ * accompanied this code).
++ *
++ * You should have received a copy of the GNU General Public License version
++ * 2 along with this work; if not, write to the Free Software Foundation,
++ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
++ *
++ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
++ * or visit www.oracle.com if you need additional information or have any
++ * questions.
++ */
++
++#include "jni_util.h"
++
++#include <sys/socket.h>
++#include <sys/stat.h>
++#include <sys/syslimits.h>
++#include <sys/types.h>
++#include <sys/un.h>
++#include <errno.h>
++#include <fcntl.h>
++#include <signal.h>
++#include <stdio.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++
++#include "sun_tools_attach_VirtualMachineImpl.h"
++
++#define RESTARTABLE(_cmd, _result) do { \
++  do { \
++    _result = _cmd; \
++  } while((_result == -1) && (errno == EINTR)); \
++} while(0)
++
++#define ROOT_UID 0
++
++/*
++ * Declare library specific JNI_Onload entry if static build
++ */
++DEF_STATIC_JNI_OnLoad
++
++/*
++ * Class:     sun_tools_attach_VirtualMachineImpl
++ * Method:    socket
++ * Signature: ()I
++ */
++JNIEXPORT jint JNICALL Java_sun_tools_attach_VirtualMachineImpl_socket
++  (JNIEnv *env, jclass cls)
++{
++    int fd = socket(PF_UNIX, SOCK_STREAM, 0);
++    if (fd == -1) {
++        JNU_ThrowIOExceptionWithLastError(env, "socket");
++    }
++    return (jint)fd;
++}
++
++/*
++ * Class:     sun_tools_attach_VirtualMachineImpl
++ * Method:    connect
++ * Signature: (ILjava/lang/String;)I
++ */
++JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_connect
++  (JNIEnv *env, jclass cls, jint fd, jstring path)
++{
++    jboolean isCopy;
++    const char* p = GetStringPlatformChars(env, path, &isCopy);
++    if (p != NULL) {
++        struct sockaddr_un addr;
++        int err = 0;
++
++        memset(&addr, 0, sizeof(addr));
++        addr.sun_family = AF_UNIX;
++        /* strncpy is safe because addr.sun_path was zero-initialized before. */
++        strncpy(addr.sun_path, p, sizeof(addr.sun_path) - 1);
++
++        if (connect(fd, (struct sockaddr*)&addr, sizeof(addr)) == -1) {
++            err = errno;
++        }
++
++        if (isCopy) {
++            JNU_ReleaseStringPlatformChars(env, path, p);
++        }
++
++        /*
++         * If the connect failed then we throw the appropriate exception
++         * here (can't throw it before releasing the string as can't call
++         * JNI with pending exception)
++         */
++        if (err != 0) {
++            if (err == ENOENT) {
++                JNU_ThrowByName(env, "java/io/FileNotFoundException", NULL);
++            } else {
++                char* msg = strdup(strerror(err));
++                JNU_ThrowIOException(env, msg);
++                if (msg != NULL) {
++                    free(msg);
++                }
++            }
++        }
++    }
++}
++
++/*
++ * Class:     sun_tools_attach_VirtualMachineImpl
++ * Method:    sendQuitTo
++ * Signature: (I)V
++ */
++JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_sendQuitTo
++  (JNIEnv *env, jclass cls, jint pid)
++{
++    if (kill((pid_t)pid, SIGQUIT)) {
++        JNU_ThrowIOExceptionWithLastError(env, "kill");
++    }
++}
++
++/*
++ * Class:     sun_tools_attach_VirtualMachineImpl
++ * Method:    checkPermissions
++ * Signature: (Ljava/lang/String;)V
++ */
++JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_checkPermissions
++  (JNIEnv *env, jclass cls, jstring path)
++{
++    jboolean isCopy;
++    const char* p = GetStringPlatformChars(env, path, &isCopy);
++    if (p != NULL) {
++        struct stat sb;
++        uid_t uid, gid;
++        int res;
++
++        memset(&sb, 0, sizeof(struct stat));
++
++        /*
++         * Check that the path is owned by the effective uid/gid of this
++         * process. Also check that group/other access is not allowed.
++         */
++        uid = geteuid();
++        gid = getegid();
++
++        res = stat(p, &sb);
++        if (res != 0) {
++            /* save errno */
++            res = errno;
++        }
++
++        if (res == 0) {
++            char msg[100];
++            jboolean isError = JNI_FALSE;
++            if (sb.st_uid != uid && uid != ROOT_UID) {
++                snprintf(msg, sizeof(msg),
++                    "file should be owned by the current user (which is %d) but is owned by %d", uid, sb.st_uid);
++                isError = JNI_TRUE;
++            } else if (sb.st_gid != gid && uid != ROOT_UID) {
++                snprintf(msg, sizeof(msg),
++                    "file's group should be the current group (which is %d) but the group is %d", gid, sb.st_gid);
++                isError = JNI_TRUE;
++            } else if ((sb.st_mode & (S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH)) != 0) {
++                snprintf(msg, sizeof(msg),
++                    "file should only be readable and writable by the owner but has 0%03o access", sb.st_mode & 0777);
++                isError = JNI_TRUE;
++            }
++            if (isError) {
++                char buf[256];
++                snprintf(buf, sizeof(buf), "well-known file %s is not secure: %s", p, msg);
++                JNU_ThrowIOException(env, buf);
++            }
++        } else {
++            char* msg = strdup(strerror(res));
++            JNU_ThrowIOException(env, msg);
++            if (msg != NULL) {
++                free(msg);
++            }
++        }
++
++        if (isCopy) {
++            JNU_ReleaseStringPlatformChars(env, path, p);
++        }
++    }
++}
++
++/*
++ * Class:     sun_tools_attach_VirtualMachineImpl
++ * Method:    close
++ * Signature: (I)V
++ */
++JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_close
++  (JNIEnv *env, jclass cls, jint fd)
++{
++    int res;
++    shutdown(fd, SHUT_RDWR);
++    RESTARTABLE(close(fd), res);
++}
++
++/*
++ * Class:     sun_tools_attach_VirtualMachineImpl
++ * Method:    read
++ * Signature: (I[BI)I
++ */
++JNIEXPORT jint JNICALL Java_sun_tools_attach_VirtualMachineImpl_read
++  (JNIEnv *env, jclass cls, jint fd, jbyteArray ba, jint off, jint baLen)
++{
++    unsigned char buf[128];
++    size_t len = sizeof(buf);
++    ssize_t n;
++
++    size_t remaining = (size_t)(baLen - off);
++    if (len > remaining) {
++        len = remaining;
++    }
++
++    RESTARTABLE(read(fd, buf, len), n);
++    if (n == -1) {
++        JNU_ThrowIOExceptionWithLastError(env, "read");
++    } else {
++        if (n == 0) {
++            n = -1;     // EOF
++        } else {
++            (*env)->SetByteArrayRegion(env, ba, off, (jint)n, (jbyte *)(buf));
++        }
++    }
++    return n;
++}
++
++/*
++ * Class:     sun_tools_attach_VirtualMachineImpl
++ * Method:    write
++ * Signature: (I[B)V
++ */
++JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_write
++  (JNIEnv *env, jclass cls, jint fd, jbyteArray ba, jint off, jint bufLen)
++{
++    size_t remaining = bufLen;
++    do {
++        unsigned char buf[128];
++        size_t len = sizeof(buf);
++        int n;
++
++        if (len > remaining) {
++            len = remaining;
++        }
++        (*env)->GetByteArrayRegion(env, ba, off, len, (jbyte *)buf);
++
++        RESTARTABLE(write(fd, buf, len), n);
++        if (n > 0) {
++            off += n;
++            remaining -= n;
++        } else {
++            JNU_ThrowIOExceptionWithLastError(env, "write");
++            return;
++        }
++
++    } while (remaining > 0);
++}
++
++/*
++ * Class:     sun_tools_attach_BSDVirtualMachine
++ * Method:    createAttachFile
++ * Signature: (Ljava.lang.String;)V
++ */
++JNIEXPORT void JNICALL Java_sun_tools_attach_VirtualMachineImpl_createAttachFile0(JNIEnv *env, jclass cls, jstring path)
++{
++    const char* _path;
++    jboolean isCopy;
++    int fd, rc;
++
++    _path = GetStringPlatformChars(env, path, &isCopy);
++    if (_path == NULL) {
++        JNU_ThrowIOException(env, "Must specify a path");
++        return;
++    }
++
++    RESTARTABLE(open(_path, O_CREAT | O_EXCL, S_IWUSR | S_IRUSR), fd);
++    if (fd == -1) {
++        /* release p here before we throw an I/O exception */
++        if (isCopy) {
++            JNU_ReleaseStringPlatformChars(env, path, _path);
++        }
++        JNU_ThrowIOExceptionWithLastError(env, "open");
++        return;
++    }
++
++    RESTARTABLE(chown(_path, geteuid(), getegid()), rc);
++
++    RESTARTABLE(close(fd), rc);
++
++    /* release p here */
++    if (isCopy) {
++        JNU_ReleaseStringPlatformChars(env, path, _path);
++    }
++}
++
++/*
++ * Class:     sun_tools_attach_BSDVirtualMachine
++ * Method:    getTempDir
++ * Signature: (V)Ljava.lang.String;
++ */
++JNIEXPORT jstring JNICALL Java_sun_tools_attach_VirtualMachineImpl_getTempDir(JNIEnv *env, jclass cls)
++{
++    // This must be hard coded because it's the system's temporary
++    // directory not the java application's temp directory, ala java.io.tmpdir.
++
++#ifdef __APPLE__
++    // macosx has a secure per-user temporary directory.
++    // Don't cache the result as this is only called once.
++    char path[PATH_MAX];
++    int pathSize = confstr(_CS_DARWIN_USER_TEMP_DIR, path, PATH_MAX);
++    if (pathSize == 0 || pathSize > PATH_MAX) {
++        strlcpy(path, "/tmp", sizeof(path));
++    }
++    return JNU_NewStringPlatform(env, path);
++#else /* __APPLE__ */
++    return (*env)->NewStringUTF(env, "/tmp");
++#endif /* __APPLE__ */
++}
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/0003-Update-hotspot-native-modules-to-support-Serenity.patch
+++ b/Ports/OpenJDK/patches/0003-Update-hotspot-native-modules-to-support-Serenity.patch
@@ -1,0 +1,704 @@
+From 3caa443bfde1562b4f09c5a3636f3277d687cbfc Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Wed, 16 Feb 2022 21:05:55 +0300
+Subject: [PATCH 3/9] Update hotspot native modules to support Serenity
+
+---
+ src/hotspot/os/posix/os_posix.cpp             | 23 +++++++++++-
+ src/hotspot/os/posix/signals_posix.cpp        | 18 +++++++++
+ src/hotspot/share/code/codeHeapState.cpp      |  4 +-
+ src/hotspot/share/compiler/disassembler.cpp   |  2 +-
+ src/hotspot/share/gc/g1/g1FromCardCache.cpp   |  2 +-
+ .../share/gc/shared/blockOffsetTable.cpp      |  2 +-
+ .../share/gc/shared/jvmFlagConstraintsGC.cpp  |  2 +-
+ src/hotspot/share/memory/heap.cpp             |  4 +-
+ .../memory/metaspace/metaspaceCommon.cpp      |  4 +-
+ src/hotspot/share/memory/virtualspace.cpp     |  6 ++-
+ src/hotspot/share/prims/jvmtiExport.cpp       | 14 +++----
+ .../flags/jvmFlagConstraintsRuntime.cpp       |  4 +-
+ src/hotspot/share/runtime/frame.cpp           |  2 +-
+ src/hotspot/share/runtime/os.cpp              | 12 +++++-
+ src/hotspot/share/runtime/os.hpp              |  2 +-
+ src/hotspot/share/runtime/perfMemory.cpp      |  2 +-
+ src/hotspot/share/runtime/semaphore.hpp       |  4 +-
+ .../share/utilities/globalDefinitions.hpp     | 27 ++++++++++++++
+ .../share/utilities/globalDefinitions_gcc.hpp | 10 ++---
+ src/hotspot/share/utilities/ostream.cpp       |  4 +-
+ .../share/utilities/tableStatistics.cpp       | 37 ++++++++++---------
+ 21 files changed, 131 insertions(+), 54 deletions(-)
+
+diff --git a/src/hotspot/os/posix/os_posix.cpp b/src/hotspot/os/posix/os_posix.cpp
+index ae058dd34..200bfc091 100644
+--- a/src/hotspot/os/posix/os_posix.cpp
++++ b/src/hotspot/os/posix/os_posix.cpp
+@@ -65,7 +65,9 @@
+ #include <sys/wait.h>
+ #include <time.h>
+ #include <unistd.h>
++#ifndef SERENITY
+ #include <utmpx.h>
++#endif
+ 
+ #ifdef __APPLE__
+   #include <crt_externs.h>
+@@ -272,7 +274,12 @@ static int util_posix_fallocate(int fd, off_t offset, off_t len) {
+   }
+   return -1;
+ #else
++#ifndef SERENITY
+   return posix_fallocate(fd, offset, len);
++#else
++  // YOLO
++  return 0;
++#endif
+ #endif
+ }
+ 
+@@ -418,6 +425,7 @@ void os::Posix::print_load_average(outputStream* st) {
+ // unfortunately it does not work on macOS and Linux because the utx chain has no entry
+ // for reboot at least on my test machines
+ void os::Posix::print_uptime_info(outputStream* st) {
++#ifndef SERENITY
+   int bootsec = -1;
+   int currsec = time(NULL);
+   struct utmpx* ent;
+@@ -432,6 +440,9 @@ void os::Posix::print_uptime_info(outputStream* st) {
+   if (bootsec != -1) {
+     os::print_dhm(st, "OS uptime:", (long) (currsec-bootsec));
+   }
++#else
++    st->print("OS uptime: not implemented");
++#endif
+ }
+ 
+ static void print_rlimit(outputStream* st, const char* msg,
+@@ -470,7 +481,9 @@ void os::Posix::print_rlimit_info(outputStream* st) {
+ 
+   print_rlimit(st, ", THREADS", RLIMIT_THREADS);
+ #else
++#ifndef SERENITY
+   print_rlimit(st, ", NPROC", RLIMIT_NPROC);
++#endif
+ #endif
+ 
+   print_rlimit(st, ", NOFILE", RLIMIT_NOFILE);
+@@ -638,7 +651,11 @@ void os::dll_unload(void *lib) {
+ }
+ 
+ jlong os::lseek(int fd, jlong offset, int whence) {
++#ifdef SERENITY
++  return (jlong) ::lseek(fd, offset, whence);
++#else
+   return (jlong) BSD_ONLY(::lseek) NOT_BSD(::lseek64)(fd, offset, whence);
++#endif
+ }
+ 
+ int os::fsync(int fd) {
+@@ -646,7 +663,11 @@ int os::fsync(int fd) {
+ }
+ 
+ int os::ftruncate(int fd, jlong length) {
+-   return BSD_ONLY(::ftruncate) NOT_BSD(::ftruncate64)(fd, length);
++#ifdef SERENITY
++  return ftruncate(fd, length);
++#else
++  return BSD_ONLY(::ftruncate) NOT_BSD(::ftruncate64)(fd, length);
++#endif
+ }
+ 
+ const char* os::get_current_directory(char *buf, size_t buflen) {
+diff --git a/src/hotspot/os/posix/signals_posix.cpp b/src/hotspot/os/posix/signals_posix.cpp
+index c2e5d50bb..c728eb522 100644
+--- a/src/hotspot/os/posix/signals_posix.cpp
++++ b/src/hotspot/os/posix/signals_posix.cpp
+@@ -552,6 +552,8 @@ public:
+ #define JVM_HANDLE_XXX_SIGNAL JVM_handle_aix_signal
+ #elif defined(LINUX)
+ #define JVM_HANDLE_XXX_SIGNAL JVM_handle_linux_signal
++#elif defined(SERENITY)
++#define JVM_HANDLE_XXX_SIGNAL JVM_handle_serenity_signal
+ #else
+ #error who are you?
+ #endif
+@@ -913,6 +915,7 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
+   const struct {
+     int sig; int code; const char* s_code; const char* s_desc;
+   } t1 [] = {
++#ifndef SERENITY
+     { SIGILL,  ILL_ILLOPC,   "ILL_ILLOPC",   "Illegal opcode." },
+     { SIGILL,  ILL_ILLOPN,   "ILL_ILLOPN",   "Illegal operand." },
+     { SIGILL,  ILL_ILLADR,   "ILL_ILLADR",   "Illegal addressing mode." },
+@@ -921,6 +924,7 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
+     { SIGILL,  ILL_PRVREG,   "ILL_PRVREG",   "Privileged register." },
+     { SIGILL,  ILL_COPROC,   "ILL_COPROC",   "Coprocessor error." },
+     { SIGILL,  ILL_BADSTK,   "ILL_BADSTK",   "Internal stack error." },
++#endif
+ #if defined(IA64) && defined(LINUX)
+     { SIGILL,  ILL_BADIADDR, "ILL_BADIADDR", "Unimplemented instruction address" },
+     { SIGILL,  ILL_BREAK,    "ILL_BREAK",    "Application Break instruction" },
+@@ -933,8 +937,10 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
+     { SIGFPE,  FPE_FLTRES,   "FPE_FLTRES",   "Floating-point inexact result." },
+     { SIGFPE,  FPE_FLTINV,   "FPE_FLTINV",   "Invalid floating-point operation." },
+     { SIGFPE,  FPE_FLTSUB,   "FPE_FLTSUB",   "Subscript out of range." },
++#ifndef SERENITY
+     { SIGSEGV, SEGV_MAPERR,  "SEGV_MAPERR",  "Address not mapped to object." },
+     { SIGSEGV, SEGV_ACCERR,  "SEGV_ACCERR",  "Invalid permissions for mapped object." },
++#endif
+ #if defined(AIX)
+     // no explanation found what keyerr would be
+     { SIGSEGV, SEGV_KEYERR,  "SEGV_KEYERR",  "key error" },
+@@ -942,11 +948,13 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
+ #if defined(IA64) && !defined(AIX)
+     { SIGSEGV, SEGV_PSTKOVF, "SEGV_PSTKOVF", "Paragraph stack overflow" },
+ #endif
++#ifndef SERENITY
+     { SIGBUS,  BUS_ADRALN,   "BUS_ADRALN",   "Invalid address alignment." },
+     { SIGBUS,  BUS_ADRERR,   "BUS_ADRERR",   "Nonexistent physical address." },
+     { SIGBUS,  BUS_OBJERR,   "BUS_OBJERR",   "Object-specific hardware error." },
+     { SIGTRAP, TRAP_BRKPT,   "TRAP_BRKPT",   "Process breakpoint." },
+     { SIGTRAP, TRAP_TRACE,   "TRAP_TRACE",   "Process trace trap." },
++#endif
+     { SIGCHLD, CLD_EXITED,   "CLD_EXITED",   "Child has exited." },
+     { SIGCHLD, CLD_KILLED,   "CLD_KILLED",   "Child has terminated abnormally and did not create a core file." },
+     { SIGCHLD, CLD_DUMPED,   "CLD_DUMPED",   "Child has terminated abnormally and created a core file." },
+@@ -967,11 +975,17 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
+   const struct {
+     int code; const char* s_code; const char* s_desc;
+   } t2 [] = {
++    { SIGTRAP,      "SIGTRAP",   "SIGTRAP FIXME" },
++    { SIGBUS,       "SIGBUS",   "SIGBUS FIXME" },
++    { SIGILL,       "SIGILL",   "Illegal opcode FIXME." },
++    { SIGSEGV,      "SIGSEGV",  "SIGSEGV FIXME" },
++#ifndef SERENITY
+     { SI_USER,      "SI_USER",     "Signal sent by kill()." },
+     { SI_QUEUE,     "SI_QUEUE",    "Signal sent by the sigqueue()." },
+     { SI_TIMER,     "SI_TIMER",    "Signal generated by expiration of a timer set by timer_settime()." },
+     { SI_ASYNCIO,   "SI_ASYNCIO",  "Signal generated by completion of an asynchronous I/O request." },
+     { SI_MESGQ,     "SI_MESGQ",    "Signal generated by arrival of a message on an empty message queue." },
++#endif
+     // Linux specific
+ #ifdef SI_TKILL
+     { SI_TKILL,     "SI_TKILL",    "Signal sent by tkill (pthread_kill)" },
+@@ -1028,9 +1042,13 @@ static bool get_signal_code_description(const siginfo_t* si, enum_sigcode_desc_t
+ 
+ bool os::signal_sent_by_kill(const void* siginfo) {
+   const siginfo_t* const si = (const siginfo_t*)siginfo;
++#ifdef SERENITY
++  return false;
++#else
+   return si->si_code == SI_USER || si->si_code == SI_QUEUE
+ #ifdef SI_TKILL
+          || si->si_code == SI_TKILL
++#endif
+ #endif
+   ;
+ }
+diff --git a/src/hotspot/share/code/codeHeapState.cpp b/src/hotspot/share/code/codeHeapState.cpp
+index 30948e4f7..4586859f7 100644
+--- a/src/hotspot/share/code/codeHeapState.cpp
++++ b/src/hotspot/share/code/codeHeapState.cpp
+@@ -1142,8 +1142,8 @@ void CodeHeapState::aggregate(outputStream* out, CodeHeap* heap, size_t granular
+       ast->print_cr("ZombieBlocks     = %8d. These are HeapBlocks which could not be identified as CodeBlobs.", nBlocks_zomb);
+       ast->cr();
+       ast->print_cr("Segment start          = " INTPTR_FORMAT ", used space      = " SIZE_FORMAT_W(8)"k", p2i(low_bound), size/K);
+-      ast->print_cr("Segment end (used)     = " INTPTR_FORMAT ", remaining space = " SIZE_FORMAT_W(8)"k", p2i(low_bound) + size, (res_size - size)/K);
+-      ast->print_cr("Segment end (reserved) = " INTPTR_FORMAT ", reserved space  = " SIZE_FORMAT_W(8)"k", p2i(low_bound) + res_size, res_size/K);
++      ast->print_cr("Segment end (used)     = " SIZE_FORMAT ", remaining space = " SIZE_FORMAT_W(8)"k", p2i(low_bound) + size, (res_size - size)/K);
++      ast->print_cr("Segment end (reserved) = " SIZE_FORMAT ", reserved space  = " SIZE_FORMAT_W(8)"k", p2i(low_bound) + res_size, res_size/K);
+       ast->cr();
+       ast->print_cr("latest allocated compilation id = %d", latest_compilation_id);
+       ast->print_cr("highest observed compilation id = %d", highest_compilation_id);
+diff --git a/src/hotspot/share/compiler/disassembler.cpp b/src/hotspot/share/compiler/disassembler.cpp
+index bd9272a8e..b95bc09e0 100644
+--- a/src/hotspot/share/compiler/disassembler.cpp
++++ b/src/hotspot/share/compiler/disassembler.cpp
+@@ -596,7 +596,7 @@ void decode_env::print_address(address adr) {
+       if (desc != NULL) {
+         st->print("Stub::%s", desc->name());
+         if (desc->begin() != adr) {
+-          st->print(INTX_FORMAT_W(+) " " PTR_FORMAT, adr - desc->begin(), p2i(adr));
++          st->print(SIZE_FORMAT " " PTR_FORMAT, adr - desc->begin(), p2i(adr));
+         } else if (WizardMode) {
+           st->print(" " PTR_FORMAT, p2i(adr));
+         }
+diff --git a/src/hotspot/share/gc/g1/g1FromCardCache.cpp b/src/hotspot/share/gc/g1/g1FromCardCache.cpp
+index 0a566af9d..bc2515ae9 100644
+--- a/src/hotspot/share/gc/g1/g1FromCardCache.cpp
++++ b/src/hotspot/share/gc/g1/g1FromCardCache.cpp
+@@ -73,7 +73,7 @@ void G1FromCardCache::invalidate(uint start_idx, size_t new_num_regions) {
+ void G1FromCardCache::print(outputStream* out) {
+   for (uint i = 0; i < num_par_rem_sets(); i++) {
+     for (uint j = 0; j < _max_reserved_regions; j++) {
+-      out->print_cr("_from_card_cache[%u][%u] = " SIZE_FORMAT ".",
++      out->print_cr("_from_card_cache[%u][%u] = " UINTX_FORMAT ".",
+                     i, j, at(i, j));
+     }
+   }
+diff --git a/src/hotspot/share/gc/shared/blockOffsetTable.cpp b/src/hotspot/share/gc/shared/blockOffsetTable.cpp
+index bea66b65d..6cf736e9f 100644
+--- a/src/hotspot/share/gc/shared/blockOffsetTable.cpp
++++ b/src/hotspot/share/gc/shared/blockOffsetTable.cpp
+@@ -55,7 +55,7 @@ BlockOffsetSharedArray::BlockOffsetSharedArray(MemRegion reserved,
+   _offset_array = (u_char*)_vs.low_boundary();
+   resize(init_word_size);
+   log_trace(gc, bot)("BlockOffsetSharedArray::BlockOffsetSharedArray: ");
+-  log_trace(gc, bot)("   rs.base(): " INTPTR_FORMAT " rs.size(): " INTPTR_FORMAT " rs end(): " INTPTR_FORMAT,
++  log_trace(gc, bot)("   rs.base(): " INTPTR_FORMAT " rs.size(): " SIZE_FORMAT " rs end(): " INTPTR_FORMAT,
+                      p2i(rs.base()), rs.size(), p2i(rs.base() + rs.size()));
+   log_trace(gc, bot)("   _vs.low_boundary(): " INTPTR_FORMAT "  _vs.high_boundary(): " INTPTR_FORMAT,
+                      p2i(_vs.low_boundary()), p2i(_vs.high_boundary()));
+diff --git a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
+index 83f0f8e43..ee53a5049 100644
+--- a/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
++++ b/src/hotspot/share/gc/shared/jvmFlagConstraintsGC.cpp
+@@ -324,7 +324,7 @@ JVMFlag::Error HeapBaseMinAddressConstraintFunc(size_t value, bool verbose) {
+   if (UseCompressedOops && FLAG_IS_ERGO(MaxHeapSize) && (value > (max_uintx - MaxHeapSize))) {
+     JVMFlag::printError(verbose,
+                         "HeapBaseMinAddress (" SIZE_FORMAT ") or MaxHeapSize (" SIZE_FORMAT ") is too large. "
+-                        "Sum of them must be less than or equal to maximum of size_t (" SIZE_FORMAT ")\n",
++                        "Sum of them must be less than or equal to maximum of size_t (" UINTX_FORMAT ")\n",
+                         value, MaxHeapSize, max_uintx);
+     return JVMFlag::VIOLATES_CONSTRAINT;
+   }
+diff --git a/src/hotspot/share/memory/heap.cpp b/src/hotspot/share/memory/heap.cpp
+index 60e2ad451..729e2fe3d 100644
+--- a/src/hotspot/share/memory/heap.cpp
++++ b/src/hotspot/share/memory/heap.cpp
+@@ -215,6 +215,7 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
+   os::trace_page_sizes(_name, c_size, rs.size(), page_size,
+                        rs.base(), rs.size());
+   if (!_memory.initialize(rs, c_size)) {
++    printf("Failed _memory.initialize\n");
+     return false;
+   }
+ 
+@@ -229,6 +230,7 @@ bool CodeHeap::reserve(ReservedSpace rs, size_t committed_size, size_t segment_s
+   // reserve space for _segmap
+   ReservedSpace seg_rs(reserved_segments_size);
+   if (!_segmap.initialize(seg_rs, committed_segments_size)) {
++    printf("Failed _segmap.initialize\n");
+     return false;
+   }
+ 
+@@ -813,7 +815,7 @@ void CodeHeap::verify() {
+     //---<  all free block memory must have been invalidated  >---
+     for(FreeBlock* b = _freelist; b != NULL; b = b->link()) {
+       for (char* c = (char*)b + sizeof(FreeBlock); c < (char*)b + segments_to_size(b->length()); c++) {
+-        assert(*c == (char)badCodeHeapNewVal, "FreeBlock@" PTR_FORMAT "(" PTR_FORMAT ") not invalidated @byte %d", p2i(b), b->length(), (int)(c - (char*)b));
++        assert(*c == (char)badCodeHeapNewVal, "FreeBlock@" PTR_FORMAT "(" SIZE_FORMAT ") not invalidated @byte %d", p2i(b), b->length(), (int)(c - (char*)b));
+       }
+     }
+ 
+diff --git a/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp b/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
+index 96673621b..a32a30764 100644
+--- a/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
++++ b/src/hotspot/share/memory/metaspace/metaspaceCommon.cpp
+@@ -114,9 +114,9 @@ void print_human_readable_size(outputStream* st, size_t byte_size, size_t scale,
+     }
+   } else {
+     if (scale == 1) {
+-      st->print("%*" PRIuPTR " bytes", width, byte_size);
++      st->print("%*lx bytes", width, byte_size);
+     } else if (scale == BytesPerWord) {
+-      st->print("%*" PRIuPTR " words", width, byte_size / BytesPerWord);
++      st->print("%*lx words", width, byte_size / BytesPerWord);
+     } else {
+       const char* display_unit = display_unit_for_scale(scale);
+       float display_value = (float) byte_size / scale;
+diff --git a/src/hotspot/share/memory/virtualspace.cpp b/src/hotspot/share/memory/virtualspace.cpp
+index f1b1f2d72..dd45286de 100644
+--- a/src/hotspot/share/memory/virtualspace.cpp
++++ b/src/hotspot/share/memory/virtualspace.cpp
+@@ -354,7 +354,7 @@ void ReservedHeapSpace::establish_noaccess_prefix() {
+         fatal("cannot protect protection page");
+       }
+       log_debug(gc, heap, coops)("Protected page at the reserved heap base: "
+-                                 PTR_FORMAT " / " INTX_FORMAT " bytes",
++                                 PTR_FORMAT " / " SIZE_FORMAT " bytes",
+                                  p2i(_base),
+                                  _noaccess_prefix);
+       assert(CompressedOops::use_implicit_null_checks() == true, "not initialized?");
+@@ -672,7 +672,7 @@ bool VirtualSpace::initialize(ReservedSpace rs, size_t committed_size) {
+ }
+ 
+ bool VirtualSpace::initialize_with_granularity(ReservedSpace rs, size_t committed_size, size_t max_commit_granularity) {
+-  if(!rs.is_reserved()) return false;  // allocation failed.
++  if(!rs.is_reserved()) { printf("allocation failed\n"); return false; }  // allocation failed.
+   assert(_low_boundary == NULL, "VirtualSpace already initialized");
+   assert(max_commit_granularity > 0, "Granularity must be non-zero.");
+ 
+@@ -712,6 +712,7 @@ bool VirtualSpace::initialize_with_granularity(ReservedSpace rs, size_t committe
+   // commit to initial size
+   if (committed_size > 0) {
+     if (!expand_by(committed_size)) {
++      printf("expand_by failed\n");
+       return false;
+     }
+   }
+@@ -837,6 +838,7 @@ static bool commit_expanded(char* start, size_t size, size_t alignment, bool pre
+ */
+ bool VirtualSpace::expand_by(size_t bytes, bool pre_touch) {
+   if (uncommitted_size() < bytes) {
++    printf("uncommitted_size < bytes (%lu)\n", bytes);
+     return false;
+   }
+ 
+diff --git a/src/hotspot/share/prims/jvmtiExport.cpp b/src/hotspot/share/prims/jvmtiExport.cpp
+index dd0f1885c..c261bef42 100644
+--- a/src/hotspot/share/prims/jvmtiExport.cpp
++++ b/src/hotspot/share/prims/jvmtiExport.cpp
+@@ -1195,7 +1195,7 @@ void JvmtiExport::post_raw_breakpoint(JavaThread *thread, Method* method, addres
+     if (!ets->breakpoint_posted() && ets->is_enabled(JVMTI_EVENT_BREAKPOINT)) {
+       ThreadState old_os_state = thread->osthread()->get_state();
+       thread->osthread()->set_state(BREAKPOINTED);
+-      EVT_TRACE(JVMTI_EVENT_BREAKPOINT, ("[%s] Evt Breakpoint sent %s.%s @ " INTX_FORMAT,
++      EVT_TRACE(JVMTI_EVENT_BREAKPOINT, ("[%s] Evt Breakpoint sent %s.%s @ " SSIZE_FORMAT,
+                      JvmtiTrace::safe_get_thread_name(thread),
+                      (mh() == NULL) ? "NULL" : mh()->klass_name()->as_C_string(),
+                      (mh() == NULL) ? "NULL" : mh()->name()->as_C_string(),
+@@ -1703,7 +1703,7 @@ void JvmtiExport::post_single_step(JavaThread *thread, Method* method, address l
+   for (JvmtiEnvThreadState* ets = it.first(); ets != NULL; ets = it.next(ets)) {
+     ets->compare_and_set_current_location(mh(), location, JVMTI_EVENT_SINGLE_STEP);
+     if (!ets->single_stepping_posted() && ets->is_enabled(JVMTI_EVENT_SINGLE_STEP)) {
+-      EVT_TRACE(JVMTI_EVENT_SINGLE_STEP, ("[%s] Evt Single Step sent %s.%s @ " INTX_FORMAT,
++      EVT_TRACE(JVMTI_EVENT_SINGLE_STEP, ("[%s] Evt Single Step sent %s.%s @ " SSIZE_FORMAT,
+                     JvmtiTrace::safe_get_thread_name(thread),
+                     (mh() == NULL) ? "NULL" : mh()->klass_name()->as_C_string(),
+                     (mh() == NULL) ? "NULL" : mh()->name()->as_C_string(),
+@@ -1742,7 +1742,7 @@ void JvmtiExport::post_exception_throw(JavaThread *thread, Method* method, addre
+       if (ets->is_enabled(JVMTI_EVENT_EXCEPTION) && (exception != NULL)) {
+ 
+         EVT_TRACE(JVMTI_EVENT_EXCEPTION,
+-                     ("[%s] Evt Exception thrown sent %s.%s @ " INTX_FORMAT,
++                     ("[%s] Evt Exception thrown sent %s.%s @ " SSIZE_FORMAT,
+                       JvmtiTrace::safe_get_thread_name(thread),
+                       (mh() == NULL) ? "NULL" : mh()->klass_name()->as_C_string(),
+                       (mh() == NULL) ? "NULL" : mh()->name()->as_C_string(),
+@@ -1818,7 +1818,7 @@ void JvmtiExport::notice_unwind_due_to_exception(JavaThread *thread, Method* met
+     return;
+   }
+   EVT_TRIG_TRACE(JVMTI_EVENT_EXCEPTION_CATCH,
+-                    ("[%s] Trg unwind_due_to_exception triggered %s.%s @ %s" INTX_FORMAT " - %s",
++                    ("[%s] Trg unwind_due_to_exception triggered %s.%s @ %s" SSIZE_FORMAT " - %s",
+                      JvmtiTrace::safe_get_thread_name(thread),
+                      (mh() == NULL) ? "NULL" : mh()->klass_name()->as_C_string(),
+                      (mh() == NULL) ? "NULL" : mh()->name()->as_C_string(),
+@@ -1855,7 +1855,7 @@ void JvmtiExport::notice_unwind_due_to_exception(JavaThread *thread, Method* met
+       for (JvmtiEnvThreadState* ets = it.first(); ets != NULL; ets = it.next(ets)) {
+         if (ets->is_enabled(JVMTI_EVENT_EXCEPTION_CATCH) && (exception_handle() != NULL)) {
+           EVT_TRACE(JVMTI_EVENT_EXCEPTION_CATCH,
+-                     ("[%s] Evt ExceptionCatch sent %s.%s @ " INTX_FORMAT,
++                     ("[%s] Evt ExceptionCatch sent %s.%s @ " SSIZE_FORMAT,
+                       JvmtiTrace::safe_get_thread_name(thread),
+                       (mh() == NULL) ? "NULL" : mh()->klass_name()->as_C_string(),
+                       (mh() == NULL) ? "NULL" : mh()->name()->as_C_string(),
+@@ -1931,7 +1931,7 @@ void JvmtiExport::post_field_access(JavaThread *thread, Method* method,
+   JvmtiEnvThreadStateIterator it(state);
+   for (JvmtiEnvThreadState* ets = it.first(); ets != NULL; ets = it.next(ets)) {
+     if (ets->is_enabled(JVMTI_EVENT_FIELD_ACCESS)) {
+-      EVT_TRACE(JVMTI_EVENT_FIELD_ACCESS, ("[%s] Evt Field Access event sent %s.%s @ " INTX_FORMAT,
++      EVT_TRACE(JVMTI_EVENT_FIELD_ACCESS, ("[%s] Evt Field Access event sent %s.%s @ " SSIZE_FORMAT,
+                      JvmtiTrace::safe_get_thread_name(thread),
+                      (mh() == NULL) ? "NULL" : mh()->klass_name()->as_C_string(),
+                      (mh() == NULL) ? "NULL" : mh()->name()->as_C_string(),
+@@ -2078,7 +2078,7 @@ void JvmtiExport::post_field_modification(JavaThread *thread, Method* method,
+   for (JvmtiEnvThreadState* ets = it.first(); ets != NULL; ets = it.next(ets)) {
+     if (ets->is_enabled(JVMTI_EVENT_FIELD_MODIFICATION)) {
+       EVT_TRACE(JVMTI_EVENT_FIELD_MODIFICATION,
+-                   ("[%s] Evt Field Modification event sent %s.%s @ " INTX_FORMAT,
++                   ("[%s] Evt Field Modification event sent %s.%s @ " SSIZE_FORMAT,
+                     JvmtiTrace::safe_get_thread_name(thread),
+                     (mh() == NULL) ? "NULL" : mh()->klass_name()->as_C_string(),
+                     (mh() == NULL) ? "NULL" : mh()->name()->as_C_string(),
+diff --git a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+index 5b09758e0..079961377 100644
+--- a/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
++++ b/src/hotspot/share/runtime/flags/jvmFlagConstraintsRuntime.cpp
+@@ -154,8 +154,8 @@ JVMFlag::Error NUMAInterleaveGranularityConstraintFunc(size_t value, bool verbos
+ 
+   if (value < min || value > max) {
+     JVMFlag::printError(verbose,
+-                        "size_t NUMAInterleaveGranularity=" UINTX_FORMAT " is outside the allowed range [ " UINTX_FORMAT
+-                        " ... " UINTX_FORMAT " ]\n", value, min, max);
++                        "size_t NUMAInterleaveGranularity=" SIZE_FORMAT " is outside the allowed range [ " SIZE_FORMAT
++                        " ... " SIZE_FORMAT " ]\n", value, min, max);
+     return JVMFlag::VIOLATES_CONSTRAINT;
+   }
+ 
+diff --git a/src/hotspot/share/runtime/frame.cpp b/src/hotspot/share/runtime/frame.cpp
+index 528fb904c..0e15bed35 100644
+--- a/src/hotspot/share/runtime/frame.cpp
++++ b/src/hotspot/share/runtime/frame.cpp
+@@ -625,7 +625,7 @@ void frame::print_on_error(outputStream* st, char* buf, int buflen, bool verbose
+             st->print("@%s", buf);
+           }
+         }
+-        st->print(" (%d bytes) @ " PTR_FORMAT " [" PTR_FORMAT "+" INTPTR_FORMAT "]",
++        st->print(" (%d bytes) @ " PTR_FORMAT " [" PTR_FORMAT "+" SIZE_FORMAT "]",
+                   m->code_size(), p2i(_pc), p2i(_cb->code_begin()), _pc - _cb->code_begin());
+ #if INCLUDE_JVMCI
+         if (cm->is_nmethod()) {
+diff --git a/src/hotspot/share/runtime/os.cpp b/src/hotspot/share/runtime/os.cpp
+index 9b8e667f9..0fb28ed6b 100644
+--- a/src/hotspot/share/runtime/os.cpp
++++ b/src/hotspot/share/runtime/os.cpp
+@@ -155,7 +155,7 @@ char* os::iso8601_time(jlong milliseconds_since_19700101, char* buffer, size_t b
+   // No offset when dealing with UTC
+   time_t UTC_to_local = 0;
+   if (!utc) {
+-#if defined(_ALLBSD_SOURCE) || defined(_GNU_SOURCE)
++#if (defined(_ALLBSD_SOURCE) || defined(_GNU_SOURCE)) && !defined(SERENITY)
+     UTC_to_local = -(time_struct.tm_gmtoff);
+ #elif defined(_WINDOWS)
+     long zone;
+@@ -896,7 +896,12 @@ bool os::print_function_and_library_name(outputStream* st,
+   //  is worse than (raw) C-heap allocation in that case).
+   char* p = buf;
+   if (p == NULL) {
++// #ifndef SERENITY
+     p = (char*)::alloca(O_BUFLEN);
++// #else
++//     char buffer_vla[O_BUFLEN];
++//     p = buffer_vla;
++// #endif
+     buflen = O_BUFLEN;
+   }
+   int offset = 0;
+@@ -1375,7 +1380,6 @@ ssize_t os::read(int fd, void *buf, unsigned int nBytes) {
+ bool os::set_boot_path(char fileSep, char pathSep) {
+   const char* home = Arguments::get_java_home();
+   int home_len = (int)strlen(home);
+-
+   struct stat st;
+ 
+   // modular image if "modules" jimage exists
+@@ -1502,6 +1506,7 @@ size_t os::page_size_for_region_unaligned(size_t region_size, size_t min_pages)
+ }
+ 
+ static const char* errno_to_string (int e, bool short_text) {
++#ifndef SERENITY
+   #define ALL_SHARED_ENUMS(X) \
+     X(E2BIG, "Argument list too long") \
+     X(EACCES, "Permission denied") \
+@@ -1579,6 +1584,9 @@ static const char* errno_to_string (int e, bool short_text) {
+     X(ETXTBSY, "Text file busy") \
+     X(EWOULDBLOCK, "Operation would block") \
+     X(EXDEV, "Cross-device link")
++#else
++  #define ALL_SHARED_ENUMS(X) ENUMERATE_ERRNO_CODES(X)
++#endif
+ 
+   #define DEFINE_ENTRY(e, text) { e, #e, text },
+ 
+diff --git a/src/hotspot/share/runtime/os.hpp b/src/hotspot/share/runtime/os.hpp
+index 7eaaa9db9..50591f707 100644
+--- a/src/hotspot/share/runtime/os.hpp
++++ b/src/hotspot/share/runtime/os.hpp
+@@ -468,7 +468,7 @@ class os: AllStatic {
+   // need special-case handling of the primordial thread if it attaches
+   // to the VM.
+   static bool is_primordial_thread(void)
+-#if defined(_WINDOWS) || defined(BSD)
++#if defined(_WINDOWS) || defined(BSD) || defined(SERENITY)
+     // No way to identify the primordial thread.
+     { return false; }
+ #else
+diff --git a/src/hotspot/share/runtime/perfMemory.cpp b/src/hotspot/share/runtime/perfMemory.cpp
+index 5f4804adc..33c771368 100644
+--- a/src/hotspot/share/runtime/perfMemory.cpp
++++ b/src/hotspot/share/runtime/perfMemory.cpp
+@@ -96,7 +96,7 @@ void PerfMemory::initialize() {
+   size_t capacity = align_up(PerfDataMemorySize,
+                              os::vm_allocation_granularity());
+ 
+-  log_debug(perf, memops)("PerfDataMemorySize = " SIZE_FORMAT ","
++  log_debug(perf, memops)("PerfDataMemorySize = " INTX_FORMAT ","
+                           " os::vm_allocation_granularity = %d,"
+                           " adjusted size = " SIZE_FORMAT,
+                           PerfDataMemorySize,
+diff --git a/src/hotspot/share/runtime/semaphore.hpp b/src/hotspot/share/runtime/semaphore.hpp
+index 0e19c101d..873f8f084 100644
+--- a/src/hotspot/share/runtime/semaphore.hpp
++++ b/src/hotspot/share/runtime/semaphore.hpp
+@@ -28,12 +28,14 @@
+ #include "memory/allocation.hpp"
+ #include "utilities/globalDefinitions.hpp"
+ 
+-#if defined(LINUX) || defined(AIX)
++#if defined(LINUX) || defined(AIX) || defined(SERENITY)
+ # include "semaphore_posix.hpp"
+ #elif defined(BSD)
+ # include "semaphore_bsd.hpp"
+ #elif defined(_WINDOWS)
+ # include "semaphore_windows.hpp"
++//#elif defined(SERENITY)
++//# include "semaphore_serenity.hpp"
+ #else
+ # error "No semaphore implementation provided for this OS"
+ #endif
+diff --git a/src/hotspot/share/utilities/globalDefinitions.hpp b/src/hotspot/share/utilities/globalDefinitions.hpp
+index 082a3272c..f115e4e21 100644
+--- a/src/hotspot/share/utilities/globalDefinitions.hpp
++++ b/src/hotspot/share/utilities/globalDefinitions.hpp
+@@ -130,8 +130,14 @@ class oopDesc;
+ #define INTPTR_FORMAT "0x%016" PRIxPTR
+ #define PTR_FORMAT    "0x%016" PRIxPTR
+ #else   // !_LP64
++
++#ifndef SERENITY
+ #define INTPTR_FORMAT "0x%08"  PRIxPTR
+ #define PTR_FORMAT    "0x%08"  PRIxPTR
++#else
++#define INTPTR_FORMAT "0x%08x"
++#define PTR_FORMAT    "0x%08x"
++#endif
+ #endif  // _LP64
+ 
+ // Format pointers without leading zeros
+@@ -139,12 +145,23 @@ class oopDesc;
+ 
+ #define INTPTR_FORMAT_W(width)   "%" #width PRIxPTR
+ 
++
++#ifndef SERENITY
+ #define SSIZE_FORMAT             "%"   PRIdPTR
+ #define SIZE_FORMAT              "%"   PRIuPTR
+ #define SIZE_FORMAT_HEX          "0x%" PRIxPTR
+ #define SSIZE_FORMAT_W(width)    "%"   #width PRIdPTR
+ #define SIZE_FORMAT_W(width)     "%"   #width PRIuPTR
+ #define SIZE_FORMAT_HEX_W(width) "0x%" #width PRIxPTR
++#else // FIXME: figure out why sizeof(size_t) != sizeof(unsigned int)
++#define SSIZE_FORMAT             "%ld"
++#define SIZE_FORMAT              "%lx"
++#define SIZE_FORMAT_HEX          "0x%lx"
++#define SSIZE_FORMAT_W(width)    "%"   #width "ld"
++#define SIZE_FORMAT_W(width)     "%"   #width "lx"
++#define SIZE_FORMAT_HEX_W(width) "0x%" #width "lx"
++#endif
++
+ 
+ #define INTX_FORMAT           "%" PRIdPTR
+ #define UINTX_FORMAT          "%" PRIuPTR
+@@ -1209,5 +1226,15 @@ template<typename K> bool primitive_equals(const K& k0, const K& k1) {
+   return k0 == k1;
+ }
+ 
++#ifdef SERENITY
++#define MAX(a,b)          ((a)>(b)?(a):(b))
++#define MAX2(a,b)          ((a)>(b)?(a):(b))
++#endif
++
++#ifdef SERENITY
++typedef void ucontext_t;
++
++# define alloca(size)	__builtin_alloca (size)
++#endif
+ 
+ #endif // SHARE_UTILITIES_GLOBALDEFINITIONS_HPP
+diff --git a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+index 30cca9ee7..90abf34c4 100644
+--- a/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
++++ b/src/hotspot/share/utilities/globalDefinitions_gcc.hpp
+@@ -48,12 +48,14 @@
+ #include <limits.h>
+ #include <errno.h>
+ 
+-#if defined(LINUX) || defined(_ALLBSD_SOURCE)
++#if defined(LINUX) || defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ #include <inttypes.h>
+ #include <signal.h>
+ #ifndef __OpenBSD__
++#ifndef SERENITY
+ #include <ucontext.h>
+ #endif
++#endif
+ #ifdef __APPLE__
+   #include <AvailabilityMacros.h>
+   #include <mach/mach.h>
+@@ -109,14 +111,8 @@ typedef uint32_t juint;
+ typedef uint64_t julong;
+ 
+ // checking for nanness
+-#if defined(__APPLE__)
+-inline int g_isnan(double f) { return isnan(f); }
+-#elif defined(LINUX) || defined(_ALLBSD_SOURCE)
+ inline int g_isnan(float  f) { return isnan(f); }
+ inline int g_isnan(double f) { return isnan(f); }
+-#else
+-#error "missing platform-specific definition here"
+-#endif
+ 
+ #define CAN_USE_NAN_DEFINE 1
+ 
+diff --git a/src/hotspot/share/utilities/ostream.cpp b/src/hotspot/share/utilities/ostream.cpp
+index 04995064f..b4c55066b 100644
+--- a/src/hotspot/share/utilities/ostream.cpp
++++ b/src/hotspot/share/utilities/ostream.cpp
+@@ -285,7 +285,7 @@ void outputStream::print_data(void* data, size_t len, bool with_ascii) {
+   size_t limit = (len + 16) / 16 * 16;
+   for (size_t i = 0; i < limit; ++i) {
+     if (i % 16 == 0) {
+-      indent().print(INTPTR_FORMAT_W(07) ":", i);
++      indent().print(SIZE_FORMAT_W(07) ":", i);
+     }
+     if (i % 2 == 0) {
+       print(" ");
+@@ -1065,7 +1065,7 @@ bufferedStream::~bufferedStream() {
+ 
+ #ifndef PRODUCT
+ 
+-#if defined(LINUX) || defined(AIX) || defined(_ALLBSD_SOURCE)
++#if defined(LINUX) || defined(AIX) || defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ #include <sys/types.h>
+ #include <sys/socket.h>
+ #include <netinet/in.h>
+diff --git a/src/hotspot/share/utilities/tableStatistics.cpp b/src/hotspot/share/utilities/tableStatistics.cpp
+index 0e05802ff..8351b4332 100644
+--- a/src/hotspot/share/utilities/tableStatistics.cpp
++++ b/src/hotspot/share/utilities/tableStatistics.cpp
+@@ -127,23 +127,24 @@ TableStatistics::TableStatistics(TableRateStatistics& rate_stats, NumberSeq summ
+ TableStatistics::~TableStatistics() { }
+ 
+ void TableStatistics::print(outputStream* st, const char *table_name) {
+-  st->print_cr("%s statistics:", table_name);
+-  st->print_cr("Number of buckets       : %9" PRIuPTR " = %9" PRIuPTR
+-               " bytes, each " SIZE_FORMAT,
+-              _number_of_buckets, _bucket_bytes, _bucket_size);
+-  st->print_cr("Number of entries       : %9" PRIuPTR " = %9" PRIuPTR
+-               " bytes, each " SIZE_FORMAT,
+-               _number_of_entries, _entry_bytes, _entry_size);
+-  if (_literal_bytes != 0) {
+-    float literal_avg = (_number_of_entries <= 0) ? 0 : (_literal_bytes / _number_of_entries);
+-    st->print_cr("Number of literals      : %9" PRIuPTR " = %9" PRIuPTR
+-                 " bytes, avg %7.3f",
+-                 _number_of_entries, _literal_bytes, literal_avg);
+-  }
+-  st->print_cr("Total footprint         : %9s = %9" PRIuPTR " bytes", "", _total_footprint);
+-  st->print_cr("Average bucket size     : %9.3f", _average_bucket_size);
+-  st->print_cr("Variance of bucket size : %9.3f", _variance_of_bucket_size);
+-  st->print_cr("Std. dev. of bucket size: %9.3f", _stddev_of_bucket_size);
+-  st->print_cr("Maximum bucket size     : %9" PRIuPTR, _maximum_bucket_size);
++  // FIXME
++  // st->print_cr("%s statistics:", table_name);
++  // st->print_cr("Number of buckets       : %9" PRIuPTR " = %9" PRIuPTR
++  //              " bytes, each " SIZE_FORMAT,
++  //             _number_of_buckets, _bucket_bytes, _bucket_size);
++  // st->print_cr("Number of entries       : %9" PRIuPTR " = %9" PRIuPTR
++  //              " bytes, each " SIZE_FORMAT,
++  //              _number_of_entries, _entry_bytes, _entry_size);
++  // if (_literal_bytes != 0) {
++  //   float literal_avg = (_number_of_entries <= 0) ? 0 : (_literal_bytes / _number_of_entries);
++  //   st->print_cr("Number of literals      : %9" PRIuPTR " = %9" PRIuPTR
++  //                " bytes, avg %7.3f",
++  //                _number_of_entries, _literal_bytes, literal_avg);
++  // }
++  // st->print_cr("Total footprint         : %9s = %9" PRIuPTR " bytes", "", _total_footprint);
++  // st->print_cr("Average bucket size     : %9.3f", _average_bucket_size);
++  // st->print_cr("Variance of bucket size : %9.3f", _variance_of_bucket_size);
++  // st->print_cr("Std. dev. of bucket size: %9.3f", _stddev_of_bucket_size);
++  // st->print_cr("Maximum bucket size     : %9" PRIuPTR, _maximum_bucket_size);
+ }
+ 
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/0004-Update-java.base-native-modules-to-support-Serenity.patch
+++ b/Ports/OpenJDK/patches/0004-Update-java.base-native-modules-to-support-Serenity.patch
@@ -1,0 +1,718 @@
+From 73bc0b17b859ac4225b558e6c7a58be0d6338d9b Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Wed, 16 Feb 2022 21:06:23 +0300
+Subject: [PATCH 4/9] Update java.base native modules to support Serenity
+
+---
+ .../nio/ch/SocketOptionRegistry.java.template |  23 ++++
+ src/java.base/share/native/libjava/jni_util.c |  14 +-
+ src/java.base/share/native/libjli/jli_util.h  |   3 +
+ .../share/native/libverify/check_code.c       |   2 +-
+ src/java.base/share/native/libzip/zip_util.c  |   2 +-
+ .../sun/nio/fs/UnixConstants.java.template    | 128 ++++++++++++++++++
+ .../native/libjava/ProcessHandleImpl_unix.c   |   2 +-
+ .../unix/native/libjava/TimeZone_md.c         |   4 +-
+ .../unix/native/libjava/io_util_md.c          |   2 +-
+ .../unix/native/libjava/io_util_md.h          |   6 +-
+ src/java.base/unix/native/libjsig/jsig.c      |   4 +
+ .../unix/native/libnet/Inet4AddressImpl.c     |   3 +
+ .../unix/native/libnet/Inet6AddressImpl.c     |   4 +
+ .../unix/native/libnet/NetworkInterface.c     |  11 +-
+ .../unix/native/libnet/net_util_md.h          |   4 +
+ .../unix/native/libnio/MappedMemoryUtils.c    |   7 +
+ .../native/libnio/ch/DatagramDispatcher.c     |   4 +
+ .../unix/native/libnio/ch/FileChannelImpl.c   |   3 +
+ .../native/libnio/ch/FileDispatcherImpl.c     |   7 +-
+ src/java.base/unix/native/libnio/ch/FileKey.c |   2 +-
+ src/java.base/unix/native/libnio/ch/IOUtil.c  |   5 +
+ .../unix/native/libnio/ch/NativeThread.c      |   2 +-
+ src/java.base/unix/native/libnio/ch/Net.c     |   2 +-
+ .../native/libnio/fs/UnixNativeDispatcher.c   |  20 ++-
+ 24 files changed, 242 insertions(+), 22 deletions(-)
+
+diff --git a/src/java.base/share/classes/sun/nio/ch/SocketOptionRegistry.java.template b/src/java.base/share/classes/sun/nio/ch/SocketOptionRegistry.java.template
+index 0672ced15..eeec84047 100644
+--- a/src/java.base/share/classes/sun/nio/ch/SocketOptionRegistry.java.template
++++ b/src/java.base/share/classes/sun/nio/ch/SocketOptionRegistry.java.template
+@@ -50,6 +50,26 @@
+ #endif
+ #endif
+ 
++#ifdef SERENITY
++#define SO_RCVTIMEO 0
++#define SO_SNDTIMEO 1
++#define SO_TYPE 2
++#define SO_ERROR 3
++#define SO_PEERCRED 4
++#define SO_DEBUG 5
++#define SO_REUSEADDR 6
++#define SO_BINDTODEVICE 7
++#define SO_KEEPALIVE 8
++#define SO_TIMESTAMP 9
++#define SO_BROADCAST 10
++#define SO_SNDBUF 11
++#define SO_RCVBUF 12
++#define SO_LINGER 13
++#define SO_ACCEPTCONN 14
++#define SO_DONTROUTE 15
++#define SO_OOBINLINE 16
++#endif
++
+ /* To be able to name the Java constants the same as the C constants without
+    having the preprocessor rewrite those identifiers, add PREFIX_ to all
+    identifiers matching a C constant. The PREFIX_ is filtered out in the
+@@ -125,6 +145,9 @@ class SocketOptionRegistry {
+ 
+ #ifdef AF_INET6
+             // IPPROTO_IPV6 is 41
++#ifdef SERENITY
++#define IPV6_TCLASS 1
++#endif
+             map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_TOS,
+                 StandardProtocolFamily.INET6), new OptionKey(41, IPV6_TCLASS));
+             map.put(new RegistryKey(StandardSocketOptions.PREFIX_IP_MULTICAST_IF,
+diff --git a/src/java.base/share/native/libjava/jni_util.c b/src/java.base/share/native/libjava/jni_util.c
+index 6ee8a4228..8bffd30b8 100644
+--- a/src/java.base/share/native/libjava/jni_util.c
++++ b/src/java.base/share/native/libjava/jni_util.c
+@@ -462,19 +462,19 @@ static jstring
+ newString646_US(JNIEnv *env, const char *str)
+ {
+     int len = (int)strlen(str);
+-    jchar buf[512] = {0};
+-    jchar *str1;
++    // jchar buf[512] = {0};
++    // jchar *str1 = buf;
+     jstring result;
+     int i;
+ 
+-    if (len > 512) {
+-        str1 = (jchar *)malloc(len * sizeof(jchar));
++    // if (len > 512) {
++        jchar *str1 = (jchar *)malloc(len * sizeof(jchar));
+         if (str1 == 0) {
+             JNU_ThrowOutOfMemoryError(env, 0);
+             return 0;
+         }
+-    } else
+-        str1 = buf;
++    // } else
++        // str1 = buf;
+ 
+     for (i=0; i<len; i++) {
+         unsigned char c = (unsigned char)str[i];
+@@ -485,7 +485,7 @@ newString646_US(JNIEnv *env, const char *str)
+     }
+ 
+     result = (*env)->NewString(env, str1, len);
+-    if (str1 != buf)
++    // if (str1 != buf)
+         free(str1);
+     return result;
+ }
+diff --git a/src/java.base/share/native/libjli/jli_util.h b/src/java.base/share/native/libjli/jli_util.h
+index 3512b1e96..e60f7581f 100644
+--- a/src/java.base/share/native/libjli/jli_util.h
++++ b/src/java.base/share/native/libjli/jli_util.h
+@@ -108,6 +108,9 @@ JLI_CmdToArgs(char *cmdline);
+ #define _LARGFILE64_SOURCE
+ #define JLI_Lseek                       lseek64
+ #endif
++#ifdef SERENITY
++#define JLI_Lseek                       lseek
++#endif
+ #ifdef MACOSX
+ #define JLI_Lseek                       lseek
+ #endif
+diff --git a/src/java.base/share/native/libverify/check_code.c b/src/java.base/share/native/libverify/check_code.c
+index fca549cfc..e193c3fc3 100644
+--- a/src/java.base/share/native/libverify/check_code.c
++++ b/src/java.base/share/native/libverify/check_code.c
+@@ -934,7 +934,7 @@ static void
+ read_all_code(context_type* context, jclass cb, int num_methods,
+               int** lengths_addr, unsigned char*** code_addr)
+ {
+-    int* lengths;
++    int* lengths = NULL;
+     unsigned char** code;
+     int i;
+ 
+diff --git a/src/java.base/share/native/libzip/zip_util.c b/src/java.base/share/native/libzip/zip_util.c
+index fbbd9d850..eef30b9e4 100644
+--- a/src/java.base/share/native/libzip/zip_util.c
++++ b/src/java.base/share/native/libzip/zip_util.c
+@@ -46,7 +46,7 @@
+ #include "zip_util.h"
+ #include <zlib.h>
+ 
+-#ifdef _ALLBSD_SOURCE
++#if defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ #define off64_t off_t
+ #define mmap64 mmap
+ #endif
+diff --git a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+index d60283d24..970d2c73f 100644
+--- a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
++++ b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+@@ -26,11 +26,130 @@
+ @@END_COPYRIGHT@@
+ 
+ #include <stdio.h>
++
++#ifndef SERENITY
+ #include <errno.h>
++#endif
++
+ #include <unistd.h>
+ #include <fcntl.h>
+ #include <sys/stat.h>
+ 
++#ifdef SERENITY
++
++#define EPERM 0
++#define ENOENT 1
++#define ESRCH 2
++#define EINTR 3
++#define EIO 4
++#define ENXIO 5
++#define E2BIG 6
++#define ENOEXEC 7
++#define EBADF 8
++#define ECHILD 9
++#define EAGAIN 10
++#define ENOMEM 11
++#define EACCES 12
++#define EFAULT 13
++#define ENOTBLK 14
++#define EBUSY 15
++#define EEXIST 16
++#define EXDEV 17
++#define ENODEV 18
++#define ENOTDIR 19
++#define EISDIR 20
++#define EINVAL 21
++#define ENFILE 22
++#define EMFILE 23
++#define ENOTTY 24
++#define ETXTBSY 25
++#define EFBIG 26
++#define ENOSPC 27
++#define ESPIPE 28
++#define EROFS 29
++#define EMLINK 30
++#define EPIPE 31
++#define ERANGE 32
++#define ENAMETOOLONG 33
++#define ELOOP 34
++#define EOVERFLOW 35
++#define EOPNOTSUPP 36
++#define ENOSYS 37
++#define ENOTIMPL 38
++#define EAFNOSUPPORT 39
++#define ENOTSOCK 40
++#define EADDRINUSE 41
++#define ENOTEMPTY 42
++#define EDOM 43
++#define ECONNREFUSED 44
++#define EHOSTDOWN 45
++#define EADDRNOTAVAIL 46
++#define EISCONN 47
++#define ECONNABORTED 48
++#define EALREADY 49
++#define ECONNRESET 50
++#define EDESTADDRREQ 51
++#define EHOSTUNREACH 52
++#define EILSEQ 53
++#define EMSGSIZE 54
++#define ENETDOWN 55
++#define ENETUNREACH 56
++#define ENETRESET 57
++#define ENOBUFS 58
++#define ENOLCK 59
++#define ENOMSG 60
++#define ENOPROTOOPT 61
++#define ENOTCONN 62
++#define ESHUTDOWN 63
++#define ETOOMANYREFS 64
++#define EPROTONOSUPPORT 65
++#define ESOCKTNOSUPPORT 66
++#define EDEADLK 67
++#define ETIMEDOUT 68
++#define EPROTOTYPE 69
++#define EINPROGRESS 70
++#define ENOTHREAD 71
++#define EPROTO 72
++#define ENOTSUP 73
++#define EPFNOSUPPORT 74
++#define EDQUOT 75
++#define EDIRINTOSELF 76
++#define ENOTRECOVERABLE 77
++#define ECANCELED 78
++#define EMAXERRNO 79
++
++
++#define EWOULDBLOCK EMAXERRNO //Serenity doesn't define it
++#define ENODATA EMAXERRNO
++
++#define S_IFMT 0170000
++#define S_IFDIR 0040000
++#define S_IFCHR 0020000
++#define S_IFBLK 0060000
++#define S_IFREG 0100000
++#define S_IFIFO 0010000
++#define S_IFLNK 0120000
++#define S_IFSOCK 0140000
++
++#define S_ISUID 04000
++#define S_ISGID 02000
++#define S_ISVTX 01000
++#define S_IRUSR 0400
++#define S_IWUSR 0200
++#define S_IXUSR 0100
++#define S_IREAD S_IRUSR
++#define S_IWRITE S_IWUSR
++#define S_IEXEC S_IXUSR
++#define S_IRGRP 0040
++#define S_IWGRP 0020
++#define S_IXGRP 0010
++#define S_IROTH 0004
++#define S_IWOTH 0002
++#define S_IXOTH 0001
++
++#define S_IRWXU (S_IRUSR | S_IWUSR | S_IXUSR)
++#endif
++
+ /* To be able to name the Java constants the same as the C constants without
+    having the preprocessor rewrite those identifiers, add PREFIX_ to all
+    identifiers matching a C constant. The PREFIX_ is filtered out in the
+@@ -48,11 +167,20 @@ class UnixConstants {
+     static final int PREFIX_O_CREAT = O_CREAT;
+     static final int PREFIX_O_EXCL = O_EXCL;
+     static final int PREFIX_O_TRUNC = O_TRUNC;
++#ifdef SERENITY  // Serenity doesn't have O_SYNC, so we fake it here
++    static final int PREFIX_O_SYNC = 0;
++#else
+     static final int PREFIX_O_SYNC = O_SYNC;
++#endif
++
+ 
+ #ifndef O_DSYNC
+     // At least FreeBSD doesn't define O_DSYNC
++#ifdef SERENITY
++    static final int PREFIX_O_DSYNC = 0;
++#else
+     static final int PREFIX_O_DSYNC = O_SYNC;
++#endif
+ #else
+     static final int PREFIX_O_DSYNC = O_DSYNC;
+ #endif
+diff --git a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+index d53e88764..eddb5f169 100644
+--- a/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
++++ b/src/java.base/unix/native/libjava/ProcessHandleImpl_unix.c
+@@ -488,7 +488,7 @@ void unix_getUserInfo(JNIEnv* env, jobject jinfo, uid_t uid) {
+  * The following functions are common on Solaris, Linux and AIX.
+  */
+ 
+-#if defined (__linux__) || defined(_AIX)
++#if defined (__linux__) || defined(_AIX) || defined(SERENITY)
+ 
+ /*
+  * Returns the children of the requested pid and optionally each parent and
+diff --git a/src/java.base/unix/native/libjava/TimeZone_md.c b/src/java.base/unix/native/libjava/TimeZone_md.c
+index 94dfc207f..2a6c3851a 100644
+--- a/src/java.base/unix/native/libjava/TimeZone_md.c
++++ b/src/java.base/unix/native/libjava/TimeZone_md.c
+@@ -53,7 +53,7 @@ static char *isFileIdentical(char* buf, size_t size, char *pathname);
+ #define filegets        fgets
+ #define fileclose       fclose
+ 
+-#if defined(_ALLBSD_SOURCE)
++#if defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ #define stat64 stat
+ #define lstat64 lstat
+ #define fstat64 fstat
+@@ -75,7 +75,7 @@ static const char popularZones[][4] = {"UTC", "GMT"};
+ static const char *ETC_ENVIRONMENT_FILE = "/etc/environment";
+ #endif
+ 
+-#if defined(__linux__) || defined(MACOSX)
++#if defined(__linux__) || defined(MACOSX) || defined(SERENITY)
+ 
+ /*
+  * Returns a pointer to the zone ID portion of the given zoneinfo file
+diff --git a/src/java.base/unix/native/libjava/io_util_md.c b/src/java.base/unix/native/libjava/io_util_md.c
+index e207c57d4..8afabc544 100644
+--- a/src/java.base/unix/native/libjava/io_util_md.c
++++ b/src/java.base/unix/native/libjava/io_util_md.c
+@@ -30,7 +30,7 @@
+ #include <string.h>
+ #include <unistd.h>
+ 
+-#if defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX)
++#if defined(__linux__) || defined(_ALLBSD_SOURCE) || defined(_AIX) || defined(SERENITY)
+ #include <sys/ioctl.h>
+ #endif
+ 
+diff --git a/src/java.base/unix/native/libjava/io_util_md.h b/src/java.base/unix/native/libjava/io_util_md.h
+index 3dccf64f4..3e9e7d3b0 100644
+--- a/src/java.base/unix/native/libjava/io_util_md.h
++++ b/src/java.base/unix/native/libjava/io_util_md.h
+@@ -66,7 +66,7 @@ FD getFD(JNIEnv *env, jobject cur, jfieldID fid);
+ #define IO_SetLength handleSetLength
+ #define IO_GetLength handleGetLength
+ 
+-#ifdef _ALLBSD_SOURCE
++#if defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ #define open64 open
+ #define fstat64 fstat
+ #define stat64 stat
+@@ -77,6 +77,10 @@ FD getFD(JNIEnv *env, jobject cur, jfieldID fid);
+ #define IO_Lseek lseek64
+ #endif
+ 
++#ifdef SERENITY
++#define statvfs64 statvfs
++#endif
++
+ /*
+  * On Solaris, the handle field is unused
+  */
+diff --git a/src/java.base/unix/native/libjsig/jsig.c b/src/java.base/unix/native/libjsig/jsig.c
+index 1108b2f9c..d891aab93 100644
+--- a/src/java.base/unix/native/libjsig/jsig.c
++++ b/src/java.base/unix/native/libjsig/jsig.c
+@@ -100,6 +100,10 @@ static sa_handler_t call_os_signal(int sig, sa_handler_t disp,
+                                    bool is_sigset) {
+   sa_handler_t res;
+ 
++#ifdef SERENITY
++#define RTLD_NEXT 0 //stub out RTLD_NEXT
++#endif
++
+   if (os_signal == NULL) {
+     // Deprecation warning first time through
+     printf(HOTSPOT_VM_DISTRO " VM warning: the use of signal() and sigset() "
+diff --git a/src/java.base/unix/native/libnet/Inet4AddressImpl.c b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+index b165be7ce..be14e35de 100644
+--- a/src/java.base/unix/native/libnet/Inet4AddressImpl.c
++++ b/src/java.base/unix/native/libnet/Inet4AddressImpl.c
+@@ -335,6 +335,7 @@ static jboolean
+ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
+       jint timeout, jint ttl)
+ {
++#ifndef SERENITY
+     jint n, size = 60 * 1024, hlen, tmout2, seq = 1;
+     socklen_t len;
+     unsigned char sendbuf[1500], recvbuf[1500];
+@@ -438,6 +439,8 @@ ping4(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
+         timeout -= 1000;
+     } while (timeout > 0);
+     close(fd);
++#endif
++    //FIXME
+     return JNI_FALSE;
+ }
+ 
+diff --git a/src/java.base/unix/native/libnet/Inet6AddressImpl.c b/src/java.base/unix/native/libnet/Inet6AddressImpl.c
+index 058f3d3a7..61460fda8 100644
+--- a/src/java.base/unix/native/libnet/Inet6AddressImpl.c
++++ b/src/java.base/unix/native/libnet/Inet6AddressImpl.c
+@@ -29,7 +29,9 @@
+ #include <sys/time.h>
+ #include <sys/types.h>
+ #include <netinet/in.h>
++#ifndef SERENITY
+ #include <netinet/icmp6.h>
++#endif
+ 
+ #if defined(_ALLBSD_SOURCE)
+ #include <ifaddrs.h>
+@@ -539,6 +541,7 @@ static jboolean
+ ping6(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
+       jint timeout, jint ttl)
+ {
++#ifndef SERENITY
+     jint n, size = 60 * 1024, tmout2, seq = 1;
+     socklen_t len;
+     unsigned char sendbuf[1500], recvbuf[1500];
+@@ -643,6 +646,7 @@ ping6(JNIEnv *env, jint fd, SOCKETADDRESS *sa, SOCKETADDRESS *netif,
+         timeout -= 1000;
+     } while (timeout > 0);
+     close(fd);
++#endif
+     return JNI_FALSE;
+ }
+ 
+diff --git a/src/java.base/unix/native/libnet/NetworkInterface.c b/src/java.base/unix/native/libnet/NetworkInterface.c
+index 990bc1bcc..514d1af37 100644
+--- a/src/java.base/unix/native/libnet/NetworkInterface.c
++++ b/src/java.base/unix/native/libnet/NetworkInterface.c
+@@ -43,6 +43,10 @@
+ #include <ifaddrs.h>
+ #endif
+ 
++#if defined(SERENITY)
++#include <ifaddrs.h>
++#endif
++
+ #include "net_util.h"
+ 
+ #include "java_net_InetAddress.h"
+@@ -1664,7 +1668,7 @@ static int getFlags(int sock, const char *ifname, int *flags) {
+ #endif /* _AIX */
+ 
+ /** BSD **/
+-#if defined(_ALLBSD_SOURCE)
++#if defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ 
+ /*
+  * Opens a socket for further ioctl calls. Tries AF_INET socket first and
+@@ -1803,6 +1807,7 @@ static int getMacAddress
+   (JNIEnv *env, const char *ifname, const struct in_addr *addr,
+    unsigned char *buf)
+ {
++#ifndef SERENITY //FIXME
+     struct ifaddrs *ifa0, *ifa;
+     struct sockaddr *saddr;
+     int i;
+@@ -1827,7 +1832,7 @@ static int getMacAddress
+         }
+         freeifaddrs(ifa0);
+     }
+-
++#endif
+     return -1;
+ }
+ 
+@@ -1848,7 +1853,7 @@ static int getMTU(JNIEnv *env, int sock, const char *ifname) {
+ static int getFlags(int sock, const char *ifname, int *flags) {
+     struct ifreq if2;
+     memset((char *)&if2, 0, sizeof(if2));
+-    strncpy(if2.ifr_name, ifname, sizeof(if2.ifr_name) - 1);
++    memcpy(if2.ifr_name, ifname, sizeof(if2.ifr_name) - 1);
+ 
+     if (ioctl(sock, SIOCGIFFLAGS, (char *)&if2) < 0) {
+         return -1;
+diff --git a/src/java.base/unix/native/libnet/net_util_md.h b/src/java.base/unix/native/libnet/net_util_md.h
+index 68835987b..f99b11207 100644
+--- a/src/java.base/unix/native/libnet/net_util_md.h
++++ b/src/java.base/unix/native/libnet/net_util_md.h
+@@ -30,6 +30,10 @@
+ #include <poll.h>
+ #include <sys/socket.h>
+ 
++#ifdef SERENITY
++#include <netinet/in.h>
++#endif
++
+ /************************************************************************
+  * Macros and constants
+  */
+diff --git a/src/java.base/unix/native/libnio/MappedMemoryUtils.c b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+index e90acd286..850518095 100644
+--- a/src/java.base/unix/native/libnio/MappedMemoryUtils.c
++++ b/src/java.base/unix/native/libnio/MappedMemoryUtils.c
+@@ -58,6 +58,7 @@ JNIEXPORT jboolean JNICALL
+ Java_java_nio_MappedMemoryUtils_isLoaded0(JNIEnv *env, jobject obj, jlong address,
+                                          jlong len, jlong numPages)
+ {
++#ifndef SERENITY
+     jboolean loaded = JNI_TRUE;
+     int result = 0;
+     long i = 0;
+@@ -100,6 +101,9 @@ Java_java_nio_MappedMemoryUtils_isLoaded0(JNIEnv *env, jobject obj, jlong addres
+     }
+     free(vec);
+     return loaded;
++#else
++    return JNI_FALSE; //FIXME
++#endif
+ }
+ 
+ 
+@@ -108,6 +112,9 @@ Java_java_nio_MappedMemoryUtils_load0(JNIEnv *env, jobject obj, jlong address,
+                                      jlong len)
+ {
+     char *a = (char *)jlong_to_ptr(address);
++#ifdef SERENITY
++#define MADV_WILLNEED MADV_NORMAL
++#endif
+     int result = madvise((caddr_t)a, (size_t)len, MADV_WILLNEED);
+     if (result == -1) {
+         JNU_ThrowIOExceptionWithLastError(env, "madvise failed");
+diff --git a/src/java.base/unix/native/libnio/ch/DatagramDispatcher.c b/src/java.base/unix/native/libnio/ch/DatagramDispatcher.c
+index 3979b3417..bf22951d6 100644
+--- a/src/java.base/unix/native/libnio/ch/DatagramDispatcher.c
++++ b/src/java.base/unix/native/libnio/ch/DatagramDispatcher.c
+@@ -37,6 +37,10 @@
+ #include "nio_util.h"
+ #include "sun_nio_ch_DatagramDispatcher.h"
+ 
++#ifndef IOV_MAX
++#define IOV_MAX 1024
++#endif
++
+ JNIEXPORT jint JNICALL
+ Java_sun_nio_ch_DatagramDispatcher_read0(JNIEnv *env, jclass clazz,
+                                          jobject fdo, jlong address, jint len)
+diff --git a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+index e0debb09f..aafba703f 100644
+--- a/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
++++ b/src/java.base/unix/native/libnio/ch/FileChannelImpl.c
+@@ -39,6 +39,9 @@
+ #include <sys/uio.h>
+ #define lseek64 lseek
+ #define mmap64 mmap
++#elif defined(SERENITY)
++#define lseek64 lseek
++#define mmap64 mmap
+ #endif
+ 
+ #include "jni.h"
+diff --git a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+index 882146127..ba4c155d8 100644
+--- a/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
++++ b/src/java.base/unix/native/libnio/ch/FileDispatcherImpl.c
+@@ -40,7 +40,7 @@
+ #include <sys/ioctl.h>
+ #endif
+ 
+-#if defined(_ALLBSD_SOURCE)
++#if defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ #define lseek64 lseek
+ #define stat64 stat
+ #define flock64 flock
+@@ -54,6 +54,11 @@
+ #define fdatasync fsync
+ #endif
+ 
++#ifdef SERENITY
++#define statvfs64 statvfs
++#define fstatvfs64 fstatvfs
++#endif
++
+ #include "jni.h"
+ #include "jni_util.h"
+ #include "jvm.h"
+diff --git a/src/java.base/unix/native/libnio/ch/FileKey.c b/src/java.base/unix/native/libnio/ch/FileKey.c
+index bdb42a632..a433cdf01 100644
+--- a/src/java.base/unix/native/libnio/ch/FileKey.c
++++ b/src/java.base/unix/native/libnio/ch/FileKey.c
+@@ -30,7 +30,7 @@
+ #include "nio_util.h"
+ #include "sun_nio_ch_FileKey.h"
+ 
+-#ifdef _ALLBSD_SOURCE
++#if defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ #define stat64 stat
+ 
+ #define fstat64 fstat
+diff --git a/src/java.base/unix/native/libnio/ch/IOUtil.c b/src/java.base/unix/native/libnio/ch/IOUtil.c
+index 930137ce0..029cf50da 100644
+--- a/src/java.base/unix/native/libnio/ch/IOUtil.c
++++ b/src/java.base/unix/native/libnio/ch/IOUtil.c
+@@ -167,10 +167,15 @@ Java_sun_nio_ch_IOUtil_fdLimit(JNIEnv *env, jclass this)
+ JNIEXPORT jint JNICALL
+ Java_sun_nio_ch_IOUtil_iovMax(JNIEnv *env, jclass this)
+ {
++    #ifndef SERENITY
+     jlong iov_max = sysconf(_SC_IOV_MAX);
+     if (iov_max == -1)
+         iov_max = 16;
++    
+     return (jint)iov_max;
++    #else
++    return (jint)1024;
++    #endif
+ }
+ 
+ /* Declared in nio_util.h for use elsewhere in NIO */
+diff --git a/src/java.base/unix/native/libnio/ch/NativeThread.c b/src/java.base/unix/native/libnio/ch/NativeThread.c
+index 92dcb9e56..4bf09d03b 100644
+--- a/src/java.base/unix/native/libnio/ch/NativeThread.c
++++ b/src/java.base/unix/native/libnio/ch/NativeThread.c
+@@ -40,7 +40,7 @@
+ #elif defined(_AIX)
+   /* Also defined in net/aix_close.c */
+   #define INTERRUPT_SIGNAL (SIGRTMAX - 1)
+-#elif defined(_ALLBSD_SOURCE)
++#elif defined(_ALLBSD_SOURCE) || defined(SERENITY)
+   /* Also defined in net/bsd_close.c */
+   #define INTERRUPT_SIGNAL SIGIO
+ #else
+diff --git a/src/java.base/unix/native/libnio/ch/Net.c b/src/java.base/unix/native/libnio/ch/Net.c
+index 42a07359d..ca1401861 100644
+--- a/src/java.base/unix/native/libnio/ch/Net.c
++++ b/src/java.base/unix/native/libnio/ch/Net.c
+@@ -701,7 +701,7 @@ JNIEXPORT jint JNICALL
+ Java_sun_nio_ch_Net_blockOrUnblock6(JNIEnv *env, jobject this, jboolean block, jobject fdo,
+                                     jbyteArray group, jint index, jbyteArray source)
+ {
+-#ifdef __APPLE__
++#if defined(__APPLE__) || defined(SERENITY)
+     /* no IPv6 exclude-mode filtering for now */
+     return IOS_UNAVAILABLE;
+ #else
+diff --git a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+index 9df8be1e6..866762450 100644
+--- a/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
++++ b/src/java.base/unix/native/libnio/fs/UnixNativeDispatcher.c
+@@ -57,7 +57,7 @@
+ #include <string.h>
+ #endif
+ 
+-#ifdef _ALLBSD_SOURCE
++#if defined(_ALLBSD_SOURCE) || defined(SERENITY)
+ #include <string.h>
+ 
+ #define stat64 stat
+@@ -1114,6 +1114,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_getgrgid(JNIEnv* env, jclass this, jint gid
+     int retry;
+ 
+     /* initial size of buffer for group record */
++#ifndef SERENITY
+     buflen = (int)sysconf(_SC_GETGR_R_SIZE_MAX);
+     if (buflen == -1)
+         buflen = ENT_BUF_SIZE;
+@@ -1156,6 +1157,16 @@ Java_sun_nio_fs_UnixNativeDispatcher_getgrgid(JNIEnv* env, jclass this, jint gid
+ 
+     } while (retry);
+ 
++#else
++    // FIXME: this leaks memory
++    struct group * g = getgrgid(gid);
++    jsize len = strlen(g->gr_name);
++    result = (*env)->NewByteArray(env, len);
++    if (result != NULL) {
++        (*env)->SetByteArrayRegion(env, result, 0, len, (jbyte*)(g->gr_name));
++    }
++#endif
++
+     return result;
+ }
+ 
+@@ -1204,6 +1215,7 @@ Java_sun_nio_fs_UnixNativeDispatcher_getgrnam0(JNIEnv* env, jclass this,
+     jlong nameAddress)
+ {
+     jint gid = -1;
++#ifndef SERENITY
+     int buflen, retry;
+ 
+     /* initial size of buffer for group record */
+@@ -1248,6 +1260,12 @@ Java_sun_nio_fs_UnixNativeDispatcher_getgrnam0(JNIEnv* env, jclass this,
+         free(grbuf);
+ 
+     } while (retry);
++#else
++    // FIXME: this leaks memory
++    const char* name = (const char*)jlong_to_ptr(nameAddress);
++    struct group * g = getgrnam(name);
++    gid = g->gr_gid;
++#endif
+ 
+     return gid;
+ }
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/0005-Fix-errno-defines.patch
+++ b/Ports/OpenJDK/patches/0005-Fix-errno-defines.patch
@@ -1,0 +1,184 @@
+From 604931ace6629e553a0b577b70095c2bb3efa179 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <sultanovts@yandex.ru>
+Date: Tue, 15 Feb 2022 11:05:34 +0300
+Subject: [PATCH 5/9] Fix errno defines
+
+---
+ .../sun/nio/fs/UnixConstants.java.template    | 161 +++++++++---------
+ 1 file changed, 81 insertions(+), 80 deletions(-)
+
+diff --git a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+index 970d2c73f..6ec3fd3a2 100644
+--- a/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
++++ b/src/java.base/unix/classes/sun/nio/fs/UnixConstants.java.template
+@@ -37,86 +37,87 @@
+ 
+ #ifdef SERENITY
+ 
+-#define EPERM 0
+-#define ENOENT 1
+-#define ESRCH 2
+-#define EINTR 3
+-#define EIO 4
+-#define ENXIO 5
+-#define E2BIG 6
+-#define ENOEXEC 7
+-#define EBADF 8
+-#define ECHILD 9
+-#define EAGAIN 10
+-#define ENOMEM 11
+-#define EACCES 12
+-#define EFAULT 13
+-#define ENOTBLK 14
+-#define EBUSY 15
+-#define EEXIST 16
+-#define EXDEV 17
+-#define ENODEV 18
+-#define ENOTDIR 19
+-#define EISDIR 20
+-#define EINVAL 21
+-#define ENFILE 22
+-#define EMFILE 23
+-#define ENOTTY 24
+-#define ETXTBSY 25
+-#define EFBIG 26
+-#define ENOSPC 27
+-#define ESPIPE 28
+-#define EROFS 29
+-#define EMLINK 30
+-#define EPIPE 31
+-#define ERANGE 32
+-#define ENAMETOOLONG 33
+-#define ELOOP 34
+-#define EOVERFLOW 35
+-#define EOPNOTSUPP 36
+-#define ENOSYS 37
+-#define ENOTIMPL 38
+-#define EAFNOSUPPORT 39
+-#define ENOTSOCK 40
+-#define EADDRINUSE 41
+-#define ENOTEMPTY 42
+-#define EDOM 43
+-#define ECONNREFUSED 44
+-#define EHOSTDOWN 45
+-#define EADDRNOTAVAIL 46
+-#define EISCONN 47
+-#define ECONNABORTED 48
+-#define EALREADY 49
+-#define ECONNRESET 50
+-#define EDESTADDRREQ 51
+-#define EHOSTUNREACH 52
+-#define EILSEQ 53
+-#define EMSGSIZE 54
+-#define ENETDOWN 55
+-#define ENETUNREACH 56
+-#define ENETRESET 57
+-#define ENOBUFS 58
+-#define ENOLCK 59
+-#define ENOMSG 60
+-#define ENOPROTOOPT 61
+-#define ENOTCONN 62
+-#define ESHUTDOWN 63
+-#define ETOOMANYREFS 64
+-#define EPROTONOSUPPORT 65
+-#define ESOCKTNOSUPPORT 66
+-#define EDEADLK 67
+-#define ETIMEDOUT 68
+-#define EPROTOTYPE 69
+-#define EINPROGRESS 70
+-#define ENOTHREAD 71
+-#define EPROTO 72
+-#define ENOTSUP 73
+-#define EPFNOSUPPORT 74
+-#define EDQUOT 75
+-#define EDIRINTOSELF 76
+-#define ENOTRECOVERABLE 77
+-#define ECANCELED 78
+-#define EMAXERRNO 79
++#define ESUCCESS 0
++#define EPERM 1
++#define ENOENT 2
++#define ESRCH 3
++#define EINTR 4
++#define EIO 5
++#define ENXIO 6
++#define E2BIG 7
++#define ENOEXEC 8
++#define EBADF 9
++#define ECHILD 10
++#define EAGAIN 12
++#define ENOMEM 12
++#define EACCES 13
++#define EFAULT 14
++#define ENOTBLK 15
++#define EBUSY 16
++#define EEXIST 17
++#define EXDEV 18
++#define ENODEV 19
++#define ENOTDIR 20
++#define EISDIR 21
++#define EINVAL 22
++#define ENFILE 23
++#define EMFILE 24
++#define ENOTTY 25
++#define ETXTBSY 26
++#define EFBIG 27
++#define ENOSPC 28
++#define ESPIPE 29
++#define EROFS 30
++#define EMLINK 31
++#define EPIPE 32
++#define ERANGE 33
++#define ENAMETOOLONG 34
++#define ELOOP 35
++#define EOVERFLOW 36
++#define EOPNOTSUPP 37
++#define ENOSYS 38
++#define ENOTIMPL 39
++#define EAFNOSUPPORT 40
++#define ENOTSOCK 41
++#define EADDRINUSE 42
++#define ENOTEMPTY 43
++#define EDOM 44
++#define ECONNREFUSED 45
++#define EHOSTDOWN 46
++#define EADDRNOTAVAIL 47
++#define EISCONN 48
++#define ECONNABORTED 49
++#define EALREADY 50
++#define ECONNRESET 51
++#define EDESTADDRREQ 52
++#define EHOSTUNREACH 53
++#define EILSEQ 54
++#define EMSGSIZE 55
++#define ENETDOWN 56
++#define ENETUNREACH 57
++#define ENETRESET 58
++#define ENOBUFS 59
++#define ENOLCK 60
++#define ENOMSG 61
++#define ENOPROTOOPT 62
++#define ENOTCONN 63
++#define ESHUTDOWN 64
++#define ETOOMANYREFS 65
++#define EPROTONOSUPPORT 66
++#define ESOCKTNOSUPPORT 67
++#define EDEADLK 68
++#define ETIMEDOUT 69
++#define EPROTOTYPE 70
++#define EINPROGRESS 71
++#define ENOTHREAD 72
++#define EPROTO 73
++#define ENOTSUP 74
++#define EPFNOSUPPORT 75
++#define EDQUOT 76
++#define EDIRINTOSELF 77
++#define ENOTRECOVERABLE 78
++#define ECANCELED 79
++#define EMAXERRNO 80
+ 
+ 
+ #define EWOULDBLOCK EMAXERRNO //Serenity doesn't define it
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/0006-Use-O_RDONLY-instead-of-0-in-open-call.patch
+++ b/Ports/OpenJDK/patches/0006-Use-O_RDONLY-instead-of-0-in-open-call.patch
@@ -1,0 +1,25 @@
+From 5bfafd31780256770a0e44767dbe001559d5e230 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <sultanovts@yandex.ru>
+Date: Tue, 15 Feb 2022 11:06:09 +0300
+Subject: [PATCH 6/9] Use O_RDONLY instead of 0 in open() call
+
+---
+ src/hotspot/share/classfile/classLoader.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/hotspot/share/classfile/classLoader.cpp b/src/hotspot/share/classfile/classLoader.cpp
+index 724ecfcd5..814050c1a 100644
+--- a/src/hotspot/share/classfile/classLoader.cpp
++++ b/src/hotspot/share/classfile/classLoader.cpp
+@@ -249,7 +249,7 @@ ClassFileStream* ClassPathDirEntry::open_stream(JavaThread* current, const char*
+   struct stat st;
+   if (os::stat(path, &st) == 0) {
+     // found file, open it
+-    int file_handle = os::open(path, 0, 0);
++    int file_handle = os::open(path, O_RDONLY, 0);
+     if (file_handle != -1) {
+       // read contents into resource array
+       u1* buffer = NEW_RESOURCE_ARRAY(u1, st.st_size);
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/0007-Ignore-maybe-uninitialized-warning.patch
+++ b/Ports/OpenJDK/patches/0007-Ignore-maybe-uninitialized-warning.patch
@@ -1,0 +1,25 @@
+From 1594c8333d04a1b20514061e01dc27c5c3fa0b3f Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <sultanovts@yandex.ru>
+Date: Tue, 15 Feb 2022 11:09:41 +0300
+Subject: [PATCH 7/9] Ignore maybe-uninitialized warning
+
+---
+ make/autoconf/flags-cflags.m4 | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/make/autoconf/flags-cflags.m4 b/make/autoconf/flags-cflags.m4
+index 6f74cf191..1bba2e822 100644
+--- a/make/autoconf/flags-cflags.m4
++++ b/make/autoconf/flags-cflags.m4
+@@ -154,7 +154,7 @@ AC_DEFUN([FLAGS_SETUP_WARNINGS],
+       WARNINGS_ENABLE_ALL_CFLAGS="-Wall -Wextra -Wformat=2 $WARNINGS_ENABLE_ADDITIONAL"
+       WARNINGS_ENABLE_ALL_CXXFLAGS="$WARNINGS_ENABLE_ALL_CFLAGS $WARNINGS_ENABLE_ADDITIONAL_CXX"
+ 
+-      DISABLED_WARNINGS="unused-parameter unused"
++      DISABLED_WARNINGS="unused-parameter unused maybe-uninitialized"
+       ;;
+ 
+     clang)
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/0008-Disable-stack-protector.patch
+++ b/Ports/OpenJDK/patches/0008-Disable-stack-protector.patch
@@ -1,0 +1,27 @@
+From 2072ab8c050e643398435b7d8d61d6548f12a965 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <sultanovts@yandex.ru>
+Date: Tue, 15 Feb 2022 11:10:16 +0300
+Subject: [PATCH 8/9] Disable stack protector
+
+---
+ make/autoconf/flags-cflags.m4 | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/make/autoconf/flags-cflags.m4 b/make/autoconf/flags-cflags.m4
+index 1bba2e822..2f38c5f07 100644
+--- a/make/autoconf/flags-cflags.m4
++++ b/make/autoconf/flags-cflags.m4
+@@ -204,8 +204,8 @@ AC_DEFUN([FLAGS_SETUP_QUALITY_CHECKS],
+       # This is most likely not really correct.
+ 
+       # Add runtime stack smashing and undefined behavior checks.
+-      CFLAGS_DEBUG_OPTIONS="-fstack-protector-all --param ssp-buffer-size=1"
+-      CXXFLAGS_DEBUG_OPTIONS="-fstack-protector-all --param ssp-buffer-size=1"
++      # CFLAGS_DEBUG_OPTIONS="-fstack-protector-all --param ssp-buffer-size=1"
++      # CXXFLAGS_DEBUG_OPTIONS="-fstack-protector-all --param ssp-buffer-size=1"
+ 
+       JVM_CFLAGS_SYMBOLS="$JVM_CFLAGS_SYMBOLS -fstack-protector-all --param ssp-buffer-size=1"
+       ;;
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/0009-Disable-set_signal_handler.patch
+++ b/Ports/OpenJDK/patches/0009-Disable-set_signal_handler.patch
@@ -1,0 +1,25 @@
+From 3cdcbd4674c6056c00fc27da787c6c69de9a0451 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <sultanovts@yandex.ru>
+Date: Tue, 15 Feb 2022 19:41:22 +0300
+Subject: [PATCH 9/9] Disable set_signal_handler
+
+---
+ src/hotspot/os/posix/signals_posix.cpp | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/hotspot/os/posix/signals_posix.cpp b/src/hotspot/os/posix/signals_posix.cpp
+index c728eb522..4572796f9 100644
+--- a/src/hotspot/os/posix/signals_posix.cpp
++++ b/src/hotspot/os/posix/signals_posix.cpp
+@@ -1212,6 +1212,8 @@ int os::get_signal_number(const char* signal_name) {
+ }
+ 
+ void set_signal_handler(int sig) {
++  return;
++
+   // Check for overwrite.
+   struct sigaction oldAct;
+   sigaction(sig, (struct sigaction*)NULL, &oldAct);
+-- 
+2.25.1
+

--- a/Ports/OpenJDK/patches/ReadMe.md
+++ b/Ports/OpenJDK/patches/ReadMe.md
@@ -1,0 +1,47 @@
+# Patches for OpenJDK on SerenityOS
+
+## `0001-Update-make-system-to-support-Serenity.patch`
+
+Update make system to support Serenity
+
+
+## `0002-Add-Serenity-specific-native-modules.patch`
+
+Add Serenity-specific native modules
+
+
+## `0003-Update-hotspot-native-modules-to-support-Serenity.patch`
+
+Update hotspot native modules to support Serenity
+
+
+## `0004-Update-java.base-native-modules-to-support-Serenity.patch`
+
+Update java.base native modules to support Serenity
+
+
+## `0005-Fix-errno-defines.patch`
+
+Fix errno defines
+
+
+## `0006-Use-O_RDONLY-instead-of-0-in-open-call.patch`
+
+Use O_RDONLY instead of 0 in open() call
+
+
+## `0007-Ignore-maybe-uninitialized-warning.patch`
+
+Ignore maybe-uninitialized warning
+
+
+## `0008-Disable-stack-protector.patch`
+
+Disable stack protector
+
+
+## `0009-Disable-set_signal_handler.patch`
+
+Disable set_signal_handler
+
+

--- a/Ports/cups/package.sh
+++ b/Ports/cups/package.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env -S bash ../.port_include.sh
+
+port="cups"
+version="2.3.3"
+workdir=cups-2.3.3
+useconfigure="true"
+files="https://github.com/apple/cups/releases/download/v2.3.3/cups-2.3.3-source.tar.gz cups-2.3.3-source.tar.gz"
+depends=()
+configopts=("--prefix=/usr/local")
+
+pre_configure() {
+    #NOCONFIGURE=1 run ./autogen.sh
+    run sed -i 's@irix\* \\@irix* | *serenity* \\@' config.sub
+}

--- a/Ports/cups/patches/0001-Remove-lockf-calls-as-Serenity-doesn-t-implement-the.patch
+++ b/Ports/cups/patches/0001-Remove-lockf-calls-as-Serenity-doesn-t-implement-the.patch
@@ -1,0 +1,34 @@
+From d70bae664aaabd4f09083d0799d8f2cc23e6b128 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 19:33:57 +0300
+Subject: [PATCH 01/24] Remove lockf() calls as Serenity doesn't implement them
+
+---
+ cups/file.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cups/file.c b/cups/file.c
+index e6e1f5b..1fa864e 100644
+--- a/cups/file.c
++++ b/cups/file.c
+@@ -1030,7 +1030,7 @@ cupsFileLock(cups_file_t *fp,		/* I - CUPS file */
+ #ifdef _WIN32
+   return (_locking(fp->fd, block ? _LK_LOCK : _LK_NBLCK, 0));
+ #else
+-  return (lockf(fp->fd, block ? F_LOCK : F_TLOCK, 0));
++  return 0; // Who cares about actually locking a file? (lockf(fp->fd, block ? F_LOCK : F_TLOCK, 0));
+ #endif /* _WIN32 */
+ }
+ 
+@@ -2075,7 +2075,7 @@ cupsFileUnlock(cups_file_t *fp)		/* I - CUPS file */
+ #ifdef _WIN32
+   return (_locking(fp->fd, _LK_UNLCK, 0));
+ #else
+-  return (lockf(fp->fd, F_ULOCK, 0));
++  return 0; // Who cares about actually locking a file? (lockf(fp->fd, F_ULOCK, 0));
+ #endif /* _WIN32 */
+ }
+ 
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0002-Silence-string-truncation-error.patch
+++ b/Ports/cups/patches/0002-Silence-string-truncation-error.patch
@@ -1,0 +1,53 @@
+From dfd4c1806be60758cef10fa1173b74fe6c5c6ded Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 19:48:31 +0300
+Subject: [PATCH 02/24] Silence string truncation error
+
+---
+ cups/dest.c | 6 +++---
+ cups/dir.c  | 2 +-
+ 2 files changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/cups/dest.c b/cups/dest.c
+index cde987a..7c499a5 100644
+--- a/cups/dest.c
++++ b/cups/dest.c
+@@ -1272,19 +1272,19 @@ cupsGetDestWithURI(const char *name,	/* I - Desired printer name or @code NULL@
+     }
+     else if (!strncmp(resource, "/classes/", 9))
+     {
+-      snprintf(temp, sizeof(temp), "%s @ %s", resource + 9, hostname);
++      snprintf(temp, sizeof(temp), "%s @ %s", resource + 9, hostname) < 0 ? abort() : (void)0;
+       name = resource + 9;
+       info = temp;
+     }
+     else if (!strncmp(resource, "/printers/", 10))
+     {
+-      snprintf(temp, sizeof(temp), "%s @ %s", resource + 10, hostname);
++      snprintf(temp, sizeof(temp), "%s @ %s", resource + 10, hostname) < 0 ? abort() : (void)0;
+       name = resource + 10;
+       info = temp;
+     }
+     else if (!strncmp(resource, "/ipp/print/", 11))
+     {
+-      snprintf(temp, sizeof(temp), "%s @ %s", resource + 11, hostname);
++      snprintf(temp, sizeof(temp), "%s @ %s", resource + 11, hostname) < 0 ? abort() : (void)0;
+       name = resource + 11;
+       info = temp;
+     }
+diff --git a/cups/dir.c b/cups/dir.c
+index 184aa7c..fe0d702 100644
+--- a/cups/dir.c
++++ b/cups/dir.c
+@@ -376,7 +376,7 @@ cupsDirRead(cups_dir_t *dp)		/* I - Directory pointer */
+ 
+     strlcpy(dp->entry.filename, entry->d_name, sizeof(dp->entry.filename));
+ 
+-    snprintf(filename, sizeof(filename), "%s/%s", dp->directory, entry->d_name);
++    snprintf(filename, sizeof(filename), "%s/%s", dp->directory, entry->d_name) < 0 ? abort() : (void)0;
+ 
+     if (stat(filename, &(dp->entry.fileinfo)))
+     {
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0003-Silence-size_t-to-int-casting-error.patch
+++ b/Ports/cups/patches/0003-Silence-size_t-to-int-casting-error.patch
@@ -1,0 +1,25 @@
+From 34f4c83feb2f94cd4be6299739b6e25c94d0be14 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 19:49:30 +0300
+Subject: [PATCH 03/24] Silence size_t to int casting error
+
+---
+ cups/hash.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cups/hash.c b/cups/hash.c
+index 4fbb443..a84e87d 100644
+--- a/cups/hash.c
++++ b/cups/hash.c
+@@ -263,7 +263,7 @@ cupsHashData(const char    *algorithm,	/* I - Algorithm name */
+       goto too_small;
+ 
+     _cupsMD5Init(&state);
+-    _cupsMD5Append(&state, data, datalen);
++    _cupsMD5Append(&state, data, (int)datalen);
+     _cupsMD5Finish(&state, hash);
+ 
+     return (16);
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0004-Silence-one-more-string-truncation-error.patch
+++ b/Ports/cups/patches/0004-Silence-one-more-string-truncation-error.patch
@@ -1,0 +1,25 @@
+From a4fbef0226e1c8c04d0f5f3e7643594ea69c2f1f Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 19:50:31 +0300
+Subject: [PATCH 04/24] Silence one more string truncation error
+
+---
+ cups/http.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/cups/http.c b/cups/http.c
+index 8d69ce3..2d4b18d 100644
+--- a/cups/http.c
++++ b/cups/http.c
+@@ -3637,7 +3637,7 @@ http_add_field(http_t       *http,	/* I - HTTP connection */
+       char	combined[HTTP_MAX_VALUE];
+ 					/* Combined value string */
+ 
+-      snprintf(combined, sizeof(combined), "%s, %s", http->_fields[field], value);
++      snprintf(combined, sizeof(combined), "%s, %s", http->_fields[field], value) < 0 ? abort() : (void)0;
+       value = combined;
+     }
+ 
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0005-comment-out-IN6_IS_ADDR_UNSPECIFIED-call.patch
+++ b/Ports/cups/patches/0005-comment-out-IN6_IS_ADDR_UNSPECIFIED-call.patch
@@ -1,0 +1,28 @@
+From 47e5b89438414a07f77db29f3d222f93e90d8d72 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 19:52:28 +0300
+Subject: [PATCH 05/24] comment out IN6_IS_ADDR_UNSPECIFIED call
+
+---
+ cups/http-addr.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cups/http-addr.c b/cups/http-addr.c
+index 86749c8..248283a 100644
+--- a/cups/http-addr.c
++++ b/cups/http-addr.c
+@@ -39,9 +39,9 @@ httpAddrAny(const http_addr_t *addr)	/* I - Address to check */
+     return (0);
+ 
+ #ifdef AF_INET6
+-  if (addr->addr.sa_family == AF_INET6 &&
++  /*if (addr->addr.sa_family == AF_INET6 &&
+       IN6_IS_ADDR_UNSPECIFIED(&(addr->ipv6.sin6_addr)))
+-    return (1);
++    return (1);*/ // We don't implement the IN6_IS_ADDR_UNSPECIFIED macro
+ #endif /* AF_INET6 */
+ 
+   if (addr->addr.sa_family == AF_INET &&
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0006-Silence-more-string-truncations.patch
+++ b/Ports/cups/patches/0006-Silence-more-string-truncations.patch
@@ -1,0 +1,28 @@
+From 7cdc19db3561f660f9160b381dad880b6faf42bf Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 19:53:43 +0300
+Subject: [PATCH 06/24] Silence more string truncations
+
+---
+ cups/http-support.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/cups/http-support.c b/cups/http-support.c
+index 6317514..7da93b6 100644
+--- a/cups/http-support.c
++++ b/cups/http-support.c
+@@ -1411,9 +1411,9 @@ _httpSetDigestAuthString(
+     */
+ 
+     if (http->opaque[0])
+-      snprintf(digest, sizeof(digest), "username=\"%s\", realm=\"%s\", nonce=\"%s\", algorithm=%s, qop=auth, opaque=\"%s\", cnonce=\"%s\", nc=%08x, uri=\"%s\", response=\"%s\"", cupsUser(), http->realm, http->nonce, http->algorithm, http->opaque, cnonce, http->nonce_count, resource, kd);
++      snprintf(digest, sizeof(digest), "username=\"%s\", realm=\"%s\", nonce=\"%s\", algorithm=%s, qop=auth, opaque=\"%s\", cnonce=\"%s\", nc=%08x, uri=\"%s\", response=\"%s\"", cupsUser(), http->realm, http->nonce, http->algorithm, http->opaque, cnonce, http->nonce_count, resource, kd) < 0 ? abort() : (void)0;
+     else
+-      snprintf(digest, sizeof(digest), "username=\"%s\", realm=\"%s\", nonce=\"%s\", algorithm=%s, qop=auth, cnonce=\"%s\", nc=%08x, uri=\"%s\", response=\"%s\"", username, http->realm, http->nonce, http->algorithm, cnonce, http->nonce_count, resource, kd);
++      snprintf(digest, sizeof(digest), "username=\"%s\", realm=\"%s\", nonce=\"%s\", algorithm=%s, qop=auth, cnonce=\"%s\", nc=%08x, uri=\"%s\", response=\"%s\"", username, http->realm, http->nonce, http->algorithm, cnonce, http->nonce_count, resource, kd) < 0 ? abort() : (void)0;
+   }
+   else
+   {
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0007-Add-missing-select.h-include.patch
+++ b/Ports/cups/patches/0007-Add-missing-select.h-include.patch
@@ -1,0 +1,24 @@
+From d6c26e706fd1983caab50a03b944e078ffdef00e Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 19:56:28 +0300
+Subject: [PATCH 07/24] Add missing select.h include
+
+---
+ cups/backchannel.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/cups/backchannel.c b/cups/backchannel.c
+index 916c314..d8fa301 100644
+--- a/cups/backchannel.c
++++ b/cups/backchannel.c
+@@ -19,6 +19,7 @@
+ #  include <fcntl.h>
+ #else
+ #  include <sys/time.h>
++#  include <sys/select.h>
+ #endif /* _WIN32 */
+ 
+ 
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0008-More-truncation-silencing.patch
+++ b/Ports/cups/patches/0008-More-truncation-silencing.patch
@@ -1,0 +1,162 @@
+From d79f2f414729ee88a5deb965188f77b41ef20d8a Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 19:59:49 +0300
+Subject: [PATCH 08/24] More truncation silencing
+
+---
+ cups/ppd-emit.c     |  2 +-
+ cups/ppd-localize.c |  2 +-
+ cups/ppd-page.c     | 12 ++++++------
+ cups/ppd.c          | 14 +++++++-------
+ 4 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/cups/ppd-emit.c b/cups/ppd-emit.c
+index 8bffb2b..ca8150a 100644
+--- a/cups/ppd-emit.c
++++ b/cups/ppd-emit.c
+@@ -496,7 +496,7 @@ ppdEmitJCL(ppd_file_t *ppd,		/* I - PPD file record */
+     if (!user)
+       user = "anonymous";
+ 
+-    snprintf(displaymsg, sizeof(displaymsg), "%d %s %s", job_id, user, temp);
++    snprintf(displaymsg, sizeof(displaymsg), "%d %s %s", job_id, user, temp) < 0 ? abort() : (void)0;
+ 
+    /*
+     * Send PJL JOB and PJL RDYMSG commands before we enter PostScript mode...
+diff --git a/cups/ppd-localize.c b/cups/ppd-localize.c
+index ea84915..ec2875f 100644
+--- a/cups/ppd-localize.c
++++ b/cups/ppd-localize.c
+@@ -115,7 +115,7 @@ ppdLocalize(ppd_file_t *ppd)		/* I - PPD file */
+ 	 cparam;
+ 	 cparam = (ppd_cparam_t *)cupsArrayNext(coption->params))
+     {
+-      snprintf(ckeyword, sizeof(ckeyword), "ParamCustom%s", coption->keyword);
++      snprintf(ckeyword, sizeof(ckeyword), "ParamCustom%s", coption->keyword) < 0 ? abort() : (void)0;
+ 
+       if ((locattr = _ppdLocalizedAttr(ppd, ckeyword, cparam->name,
+                                        ll_CC)) != NULL)
+diff --git a/cups/ppd-page.c b/cups/ppd-page.c
+index 1f5860a..564eb3c 100644
+--- a/cups/ppd-page.c
++++ b/cups/ppd-page.c
+@@ -249,7 +249,7 @@ ppdPageSizeLimits(ppd_file_t *ppd,	/* I - PPD file record */
+     if (qualifier3)
+     {
+       snprintf(spec, sizeof(spec), ".%s.%s", qualifier2->choice,
+-	       qualifier3->choice);
++	       qualifier3->choice) < 0 ? abort() : (void)0;
+       attr = ppdFindAttr(ppd, "cupsMinSize", spec);
+     }
+     else
+@@ -257,13 +257,13 @@ ppdPageSizeLimits(ppd_file_t *ppd,	/* I - PPD file record */
+ 
+     if (!attr)
+     {
+-      snprintf(spec, sizeof(spec), ".%s.", qualifier2->choice);
++      snprintf(spec, sizeof(spec), ".%s.", qualifier2->choice) < 0 ? abort() : (void)0;
+       attr = ppdFindAttr(ppd, "cupsMinSize", spec);
+     }
+ 
+     if (!attr && qualifier3)
+     {
+-      snprintf(spec, sizeof(spec), "..%s", qualifier3->choice);
++      snprintf(spec, sizeof(spec), "..%s", qualifier3->choice) < 0 ? abort() : (void)0;
+       attr = ppdFindAttr(ppd, "cupsMinSize", spec);
+     }
+ 
+@@ -298,7 +298,7 @@ ppdPageSizeLimits(ppd_file_t *ppd,	/* I - PPD file record */
+     if (qualifier3)
+     {
+       snprintf(spec, sizeof(spec), ".%s.%s", qualifier2->choice,
+-	       qualifier3->choice);
++	       qualifier3->choice) < 0 ? abort() : (void)0;
+       attr = ppdFindAttr(ppd, "cupsMaxSize", spec);
+     }
+     else
+@@ -306,13 +306,13 @@ ppdPageSizeLimits(ppd_file_t *ppd,	/* I - PPD file record */
+ 
+     if (!attr)
+     {
+-      snprintf(spec, sizeof(spec), ".%s.", qualifier2->choice);
++      snprintf(spec, sizeof(spec), ".%s.", qualifier2->choice) < 0 ? abort() : (void)0;
+       attr = ppdFindAttr(ppd, "cupsMaxSize", spec);
+     }
+ 
+     if (!attr && qualifier3)
+     {
+-      snprintf(spec, sizeof(spec), "..%s", qualifier3->choice);
++      snprintf(spec, sizeof(spec), "..%s", qualifier3->choice) < 0 ? abort() : (void)0;
+       attr = ppdFindAttr(ppd, "cupsMaxSize", spec);
+     }
+ 
+diff --git a/cups/ppd.c b/cups/ppd.c
+index 199cf03..7013c76 100644
+--- a/cups/ppd.c
++++ b/cups/ppd.c
+@@ -545,7 +545,7 @@ _ppdOpen(
+     if ((lang = cupsLangDefault()) == NULL)
+       return (NULL);
+ 
+-    snprintf(ll_CC, sizeof(ll_CC), "%s.", lang->language);
++    snprintf(ll_CC, sizeof(ll_CC), "%s.", lang->language) < 0 ? abort() : (void)0;
+ 
+    /*
+     * <rdar://problem/22130168>
+@@ -1364,7 +1364,7 @@ _ppdOpen(
+       if (!_cups_strcasecmp(name, "PageRegion"))
+         strlcpy(custom_name, "CustomPageSize", sizeof(custom_name));
+       else
+-        snprintf(custom_name, sizeof(custom_name), "Custom%s", name);
++        snprintf(custom_name, sizeof(custom_name), "Custom%s", name) < 0 ? abort() : (void)0;
+ 
+       if ((custom_attr = ppdFindAttr(ppd, custom_name, "True")) != NULL)
+       {
+@@ -1468,7 +1468,7 @@ _ppdOpen(
+       * attribute...
+       */
+ 
+-      snprintf(custom_name, sizeof(custom_name), "Custom%s", name);
++      snprintf(custom_name, sizeof(custom_name), "Custom%s", name) < 0 ? abort() : (void)0;
+ 
+       if ((custom_attr = ppdFindAttr(ppd, custom_name, "True")) != NULL)
+       {
+@@ -1874,7 +1874,7 @@ _ppdOpen(
+       if (!_cups_strcasecmp(name, "custom") || !_cups_strncasecmp(name, "custom.", 7))
+       {
+         char cname[PPD_MAX_NAME];	/* Rewrite with a leading underscore */
+-        snprintf(cname, sizeof(cname), "_%s", name);
++        snprintf(cname, sizeof(cname), "_%s", name) < 0 ? abort() : (void)0;
+         strlcpy(name, cname, sizeof(name));
+       }
+ 
+@@ -1903,7 +1903,7 @@ _ppdOpen(
+       if (!_cups_strcasecmp(name, "custom") || !_cups_strncasecmp(name, "custom.", 7))
+       {
+         char cname[PPD_MAX_NAME];	/* Rewrite with a leading underscore */
+-        snprintf(cname, sizeof(cname), "_%s", name);
++        snprintf(cname, sizeof(cname), "_%s", name) < 0 ? abort() : (void)0;
+         strlcpy(name, cname, sizeof(name));
+       }
+ 
+@@ -1939,7 +1939,7 @@ _ppdOpen(
+       if (!_cups_strcasecmp(name, "custom") || !_cups_strncasecmp(name, "custom.", 7))
+       {
+         char cname[PPD_MAX_NAME];	/* Rewrite with a leading underscore */
+-        snprintf(cname, sizeof(cname), "_%s", name);
++        snprintf(cname, sizeof(cname), "_%s", name) < 0 ? abort() : (void)0;
+         strlcpy(name, cname, sizeof(name));
+       }
+ 
+@@ -3433,7 +3433,7 @@ ppd_update_filters(ppd_file_t     *ppd,	/* I - PPD file */
+     */
+ 
+     snprintf(buffer, sizeof(buffer), "%s/%s %d %s", srcsuper, srctype, cost,
+-             program);
++             program) < 0 ? abort() : (void)0;
+     DEBUG_printf(("5ppd_update_filters: Adding \"%s\".", buffer));
+ 
+    /*
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0009-silencing-int-casting.patch
+++ b/Ports/cups/patches/0009-silencing-int-casting.patch
@@ -1,0 +1,25 @@
+From fdf906791e37a1c6c739e8bf4aaadbb0c815697a Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:03:10 +0300
+Subject: [PATCH 09/24] silencing int casting
+
+---
+ tools/ippeveps.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/ippeveps.c b/tools/ippeveps.c
+index 52e14ee..47403cb 100644
+--- a/tools/ippeveps.c
++++ b/tools/ippeveps.c
+@@ -628,7 +628,7 @@ jpeg_to_ps(const char    *filename,	/* I - Filename */
+ 	bufend += bytes;
+       }
+ 
+-      length = (size_t)((bufptr[1] << 8) | bufptr[2]);
++      length = (ssize_t)((bufptr[1] << 8) | bufptr[2]);
+ 
+       if ((*bufptr >= 0xc0 && *bufptr <= 0xc3) || (*bufptr >= 0xc5 && *bufptr <= 0xc7) || (*bufptr >= 0xc9 && *bufptr <= 0xcb) || (*bufptr >= 0xcd && *bufptr <= 0xcf))
+       {
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0010-Commenting-out-missing-header.patch
+++ b/Ports/cups/patches/0010-Commenting-out-missing-header.patch
@@ -1,0 +1,25 @@
+From d50581e6b9ff18ef21afd87b543d35159f8954ae Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:04:20 +0300
+Subject: [PATCH 10/24] Commenting out missing header
+
+---
+ tools/ippeveprinter.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/tools/ippeveprinter.c b/tools/ippeveprinter.c
+index 41954a5..68a9235 100644
+--- a/tools/ippeveprinter.c
++++ b/tools/ippeveprinter.c
+@@ -38,7 +38,7 @@ typedef ULONG nfds_t;
+ #else
+ extern char **environ;
+ 
+-#  include <sys/fcntl.h>
++//#  include <sys/fcntl.h>
+ #  include <sys/wait.h>
+ #  include <poll.h>
+ #endif /* _WIN32 */
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0011-Silencing-int-conversion-warning.patch
+++ b/Ports/cups/patches/0011-Silencing-int-conversion-warning.patch
@@ -1,0 +1,34 @@
+From 56aeba261bf70ff3728e029cf231ac068b84122d Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:05:40 +0300
+Subject: [PATCH 11/24] Silencing int conversion warning
+
+---
+ tools/ipptool.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/ipptool.c b/tools/ipptool.c
+index a3a694d..67aafff 100644
+--- a/tools/ipptool.c
++++ b/tools/ipptool.c
+@@ -2148,7 +2148,7 @@ init_data(_cups_testdata_t *data)	/* I - Data */
+   data->errors       = cupsArrayNew3(NULL, NULL, NULL, 0, (cups_acopy_func_t)strdup, (cups_afree_func_t)free);
+   data->pass         = 1;
+   data->prev_pass    = 1;
+-  data->request_id   = (CUPS_RAND() % 1000) * 137 + 1;
++  data->request_id   = (int)((CUPS_RAND() % 1000) * 137 + 1);
+   data->show_header  = 1;
+ }
+ 
+@@ -3155,7 +3155,7 @@ token_cb(_ipp_file_t      *f,		/* I - IPP file data */
+ 	}
+ 	else if (!_cups_strcasecmp(temp, "random"))
+ 	{
+-	  data->request_id = (CUPS_RAND() % 1000) * 137 + 1;
++	  data->request_id = (int)((CUPS_RAND() % 1000) * 137 + 1);
+ 	}
+ 	else
+ 	{
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0012-Silencing-more-truncation-errors.patch
+++ b/Ports/cups/patches/0012-Silencing-more-truncation-errors.patch
@@ -1,0 +1,25 @@
+From 67a6bf15246546e493b508d449236cd3c6e94f9c Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:07:04 +0300
+Subject: [PATCH 12/24] Silencing more truncation errors
+
+---
+ backend/snmp-supplies.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/backend/snmp-supplies.c b/backend/snmp-supplies.c
+index 687e7ae..b78a18b 100644
+--- a/backend/snmp-supplies.c
++++ b/backend/snmp-supplies.c
+@@ -559,7 +559,7 @@ backend_init_supplies(
+     cachedir = CUPS_CACHEDIR;
+ 
+   snprintf(cachefilename, sizeof(cachefilename), "%s/%s.snmp", cachedir,
+-           addrstr);
++           addrstr) < 0 ? abort() : (void)0;
+ 
+   if ((cachefile = cupsFileOpen(cachefilename, "r")) != NULL)
+   {
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0013-Fixing-missing-select.h-header.patch
+++ b/Ports/cups/patches/0013-Fixing-missing-select.h-header.patch
@@ -1,0 +1,37 @@
+From d60f40f495e2132853435eb821df544b64f19969 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:08:13 +0300
+Subject: [PATCH 13/24] Fixing missing select.h header
+
+---
+ backend/ipp.c  | 1 +
+ backend/snmp.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/backend/ipp.c b/backend/ipp.c
+index 3f3e186..8592d22 100644
+--- a/backend/ipp.c
++++ b/backend/ipp.c
+@@ -18,6 +18,7 @@
+ #include <sys/types.h>
+ #include <sys/stat.h>
+ #include <sys/wait.h>
++#include <sys/select.h>
+ #if defined(HAVE_GSSAPI) && defined(HAVE_XPC)
+ #  include <xpc/xpc.h>
+ #  define kPMPrintUIToolAgent	"com.apple.printuitool.agent"
+diff --git a/backend/snmp.c b/backend/snmp.c
+index 66ac884..dbe3bba 100644
+--- a/backend/snmp.c
++++ b/backend/snmp.c
+@@ -17,6 +17,7 @@
+ #include <cups/file.h>
+ #include <cups/http-private.h>
+ #include <regex.h>
++#include <sys/select.h>
+ 
+ 
+ /*
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0014-Truncations.patch
+++ b/Ports/cups/patches/0014-Truncations.patch
@@ -1,0 +1,31 @@
+From 8dc63ea6bbf21b131752e2ff3d46331837350fbd Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:08:52 +0300
+Subject: [PATCH 14/24] Truncations
+
+---
+ backend/snmp.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/backend/snmp.c b/backend/snmp.c
+index dbe3bba..9f70716 100644
+--- a/backend/snmp.c
++++ b/backend/snmp.c
+@@ -503,11 +503,11 @@ fix_make_model(
+     strlcpy(make_model + 3, mmptr, (size_t)make_model_size - 3);
+   }
+   else if (!_cups_strncasecmp(old_make_model, "deskjet", 7))
+-    snprintf(make_model, (size_t)make_model_size, "HP DeskJet%s", old_make_model + 7);
++    snprintf(make_model, (size_t)make_model_size, "HP DeskJet%s", old_make_model + 7) < 0 ? abort() : (void)0;
+   else if (!_cups_strncasecmp(old_make_model, "officejet", 9))
+-    snprintf(make_model, (size_t)make_model_size, "HP OfficeJet%s", old_make_model + 9);
++    snprintf(make_model, (size_t)make_model_size, "HP OfficeJet%s", old_make_model + 9) < 0 ? abort() : (void)0;
+   else if (!_cups_strncasecmp(old_make_model, "stylus_pro_", 11))
+-    snprintf(make_model, (size_t)make_model_size, "EPSON Stylus Pro %s", old_make_model + 11);
++    snprintf(make_model, (size_t)make_model_size, "EPSON Stylus Pro %s", old_make_model + 11) < 0 ? abort() : (void)0;
+   else
+     strlcpy(make_model, old_make_model, (size_t)make_model_size);
+ 
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0015-select.patch
+++ b/Ports/cups/patches/0015-select.patch
@@ -1,0 +1,24 @@
+From e80dccf9539f19b5fa6774b8399a54fcb71c86bf Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:09:31 +0300
+Subject: [PATCH 15/24] select
+
+---
+ backend/socket.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/backend/socket.c b/backend/socket.c
+index 68379e9..32d54c3 100644
+--- a/backend/socket.c
++++ b/backend/socket.c
+@@ -27,6 +27,7 @@
+ #  include <netinet/in.h>
+ #  include <arpa/inet.h>
+ #  include <netdb.h>
++#  include <sys/select.h>
+ #endif /* _WIN32 */
+ 
+ 
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0016-truncation.patch
+++ b/Ports/cups/patches/0016-truncation.patch
@@ -1,0 +1,319 @@
+From b6f72057992c785fd418dfe5e013b569b9b9f7d3 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:16:21 +0300
+Subject: [PATCH 16/24] truncation
+
+---
+ cgi-bin/admin.c      | 12 ++++++------
+ cgi-bin/classes.c    |  4 ++--
+ cgi-bin/ipp-var.c    |  8 ++++----
+ cgi-bin/printers.c   |  4 ++--
+ notifier/mailto.c    |  2 +-
+ notifier/rss.c       |  4 ++--
+ ppdc/ppdc-source.cxx |  6 +++---
+ ppdc/ppdc.cxx        |  4 ++--
+ scheduler/client.c   | 22 +++++++++++-----------
+ scheduler/type.c     |  2 +-
+ 10 files changed, 34 insertions(+), 34 deletions(-)
+
+diff --git a/cgi-bin/admin.c b/cgi-bin/admin.c
+index f087809..8ca6df8 100644
+--- a/cgi-bin/admin.c
++++ b/cgi-bin/admin.c
+@@ -589,7 +589,7 @@ do_am_class(http_t *http,		/* I - HTTP connection */
+ 
+     cgiFormEncode(uri, name, sizeof(uri));
+     snprintf(refresh, sizeof(refresh), "5;URL=/admin/?OP=redirect&URL=/classes/%s",
+-             uri);
++             uri) < 0 ? abort() : (void)0;
+     cgiSetVariable("refresh_page", refresh);
+ 
+     cgiStartHTML(title);
+@@ -1204,7 +1204,7 @@ do_am_printer(http_t *http,		/* I - HTTP connection */
+       cgiFormEncode(uri, name, sizeof(uri));
+ 
+       snprintf(refresh, sizeof(refresh),
+-	       "5;/admin/?OP=redirect&URL=/printers/%s", uri);
++	       "5;/admin/?OP=redirect&URL=/printers/%s", uri) < 0 ? abort() : (void)0;
+ 
+       cgiSetVariable("refresh_page", refresh);
+ 
+@@ -2506,7 +2506,7 @@ do_set_allowed_users(http_t *http)	/* I - HTTP connection */
+       cgiRewriteURL(uri, url, sizeof(url), NULL);
+       cgiFormEncode(uri, url, sizeof(uri));
+       snprintf(refresh, sizeof(refresh), "5;URL=/admin/?OP=redirect&URL=%s",
+-               uri);
++               uri) < 0 ? abort() : (void)0;
+       cgiSetVariable("refresh_page", refresh);
+ 
+       cgiStartHTML(cgiText(_("Set Allowed Users")));
+@@ -2592,7 +2592,7 @@ do_set_default(http_t *http)		/* I - HTTP connection */
+ 
+     cgiRewriteURL(uri, url, sizeof(url), NULL);
+     cgiFormEncode(uri, url, sizeof(uri));
+-    snprintf(refresh, sizeof(refresh), "5;URL=/admin/?OP=redirect&URL=%s", uri);
++    snprintf(refresh, sizeof(refresh), "5;URL=/admin/?OP=redirect&URL=%s", uri) < 0 ? abort() : (void)0;
+     cgiSetVariable("refresh_page", refresh);
+ 
+     cgiStartHTML(title);
+@@ -3324,7 +3324,7 @@ do_set_options(http_t *http,		/* I - HTTP connection */
+ 
+       cgiFormEncode(uri, printer, sizeof(uri));
+       snprintf(refresh, sizeof(refresh), "5;URL=/admin/?OP=redirect&URL=/%s/%s",
+-	       is_class ? "classes" : "printers", uri);
++	       is_class ? "classes" : "printers", uri) < 0 ? abort() : (void)0;
+       cgiSetVariable("refresh_page", refresh);
+ 
+       cgiStartHTML(title);
+@@ -3424,7 +3424,7 @@ do_set_sharing(http_t *http)		/* I - HTTP connection */
+ 
+     cgiRewriteURL(uri, url, sizeof(url), NULL);
+     cgiFormEncode(uri, url, sizeof(uri));
+-    snprintf(refresh, sizeof(refresh), "5;URL=/admin/?OP=redirect&URL=%s", uri);
++    snprintf(refresh, sizeof(refresh), "5;URL=/admin/?OP=redirect&URL=%s", uri) < 0 ? abort() : (void)0;
+     cgiSetVariable("refresh_page", refresh);
+ 
+     cgiStartHTML(cgiText(_("Set Publishing")));
+diff --git a/cgi-bin/classes.c b/cgi-bin/classes.c
+index 78ef08e..bef6534 100644
+--- a/cgi-bin/classes.c
++++ b/cgi-bin/classes.c
+@@ -257,7 +257,7 @@ do_class_op(http_t      *http,		/* I - HTTP connection */
+ 
+     cgiRewriteURL(uri, url, sizeof(url), NULL);
+     cgiFormEncode(uri, url, sizeof(uri));
+-    snprintf(refresh, sizeof(refresh), "5;URL=%s", uri);
++    snprintf(refresh, sizeof(refresh), "5;URL=%s", uri) < 0 ? abort() : (void)0;
+     cgiSetVariable("refresh_page", refresh);
+ 
+     cgiStartHTML(title);
+@@ -486,7 +486,7 @@ show_class(http_t     *http,		/* I - Connection to server */
+       */
+ 
+       cgiFormEncode(uri, pclass, sizeof(uri));
+-      snprintf(refresh, sizeof(refresh), "10;URL=/classes/%s", uri);
++      snprintf(refresh, sizeof(refresh), "10;URL=/classes/%s", uri) < 0 ? abort() : (void)0;
+       cgiSetVariable("refresh_page", refresh);
+     }
+ 
+diff --git a/cgi-bin/ipp-var.c b/cgi-bin/ipp-var.c
+index 8c5a561..0aeef84 100644
+--- a/cgi-bin/ipp-var.c
++++ b/cgi-bin/ipp-var.c
+@@ -487,7 +487,7 @@ cgiMoveJobs(http_t     *http,		/* I - Connection to server */
+       if (path)
+       {
+         cgiFormEncode(uri, path, sizeof(uri));
+-        snprintf(refresh, sizeof(refresh), "2;URL=%s", uri);
++        snprintf(refresh, sizeof(refresh), "2;URL=%s", uri) < 0 ? abort() : (void)0;
+ 	cgiSetVariable("refresh_page", refresh);
+       }
+     }
+@@ -665,7 +665,7 @@ cgiPrintCommand(http_t     *http,	/* I - Connection to server */
+   snprintf(resource, sizeof(resource), "/printers/%s", dest);
+ 
+   cgiFormEncode(uri, resource, sizeof(uri));
+-  snprintf(refresh, sizeof(refresh), "5;URL=%s", uri);
++  snprintf(refresh, sizeof(refresh), "5;URL=%s", uri) < 0 ? abort() : (void)0;
+   cgiSetVariable("refresh_page", refresh);
+ 
+   cgiStartHTML(title);
+@@ -762,7 +762,7 @@ cgiPrintTestPage(http_t     *http,	/* I - Connection to server */
+     */
+ 
+     cgiFormEncode(uri, resource, sizeof(uri));
+-    snprintf(refresh, sizeof(refresh), "2;URL=%s", uri);
++    snprintf(refresh, sizeof(refresh), "2;URL=%s", uri) < 0 ? abort() : (void)0;
+     cgiSetVariable("refresh_page", refresh);
+   }
+   else if (cupsLastError() == IPP_NOT_AUTHORIZED)
+@@ -1112,7 +1112,7 @@ cgiSetIPPObjectVars(
+ 	  * Link to local feed...
+ 	  */
+ 
+-	  snprintf(uri, sizeof(uri), "/rss%s", resource);
++	  snprintf(uri, sizeof(uri), "/rss%s", resource) < 0 ? abort() : (void)0;
+           strlcpy(name, resource + 1, sizeof(name));
+ 	}
+       }
+diff --git a/cgi-bin/printers.c b/cgi-bin/printers.c
+index bbc153e..1721699 100644
+--- a/cgi-bin/printers.c
++++ b/cgi-bin/printers.c
+@@ -266,7 +266,7 @@ do_printer_op(http_t      *http,	/* I - HTTP connection */
+ 
+     cgiRewriteURL(uri, url, sizeof(url), NULL);
+     cgiFormEncode(uri, url, sizeof(uri));
+-    snprintf(refresh, sizeof(refresh), "5;URL=%s", uri);
++    snprintf(refresh, sizeof(refresh), "5;URL=%s", uri) < 0 ? abort() : (void)0;
+     cgiSetVariable("refresh_page", refresh);
+ 
+     cgiStartHTML(title);
+@@ -506,7 +506,7 @@ show_printer(http_t     *http,		/* I - Connection to server */
+       */
+ 
+       cgiFormEncode(uri, printer, sizeof(uri));
+-      snprintf(refresh, sizeof(refresh), "10;URL=/printers/%s", uri);
++      snprintf(refresh, sizeof(refresh), "10;URL=/printers/%s", uri) < 0 ? abort() : (void)0;
+       cgiSetVariable("refresh_page", refresh);
+     }
+ 
+diff --git a/notifier/mailto.c b/notifier/mailto.c
+index 9325855..6e74886 100644
+--- a/notifier/mailto.c
++++ b/notifier/mailto.c
+@@ -237,7 +237,7 @@ email_message(const char *to,		/* I - Recipient of message */
+       char	spec[1024];		/* Host:service spec */
+ 
+ 
+-      snprintf(spec, sizeof(spec), "%s:smtp", mailtoSMTPServer);
++      snprintf(spec, sizeof(spec), "%s:smtp", mailtoSMTPServer) < 0 ? abort() : (void)0;
+       fp = cupsFileOpen(spec, "s");
+     }
+ 
+diff --git a/notifier/rss.c b/notifier/rss.c
+index 44d368c..cdd2dd4 100644
+--- a/notifier/rss.c
++++ b/notifier/rss.c
+@@ -205,8 +205,8 @@ main(int  argc,				/* I - Number of command-line arguments */
+     if ((server_port = getenv("SERVER_PORT")) == NULL)
+       server_port = "631";
+ 
+-    snprintf(filename, sizeof(filename), "%s/rss%s", cachedir, resource);
+-    snprintf(newname, sizeof(newname), "%s.N", filename);
++    snprintf(filename, sizeof(filename), "%s/rss%s", cachedir, resource) < 0 ? abort() : (void)0;
++    snprintf(newname, sizeof(newname), "%s.N", filename) < 0 ? abort() : (void)0;
+ 
+     httpAssembleURIf(HTTP_URI_CODING_ALL, baseurl, sizeof(baseurl), "http",
+                      NULL, server_name, atoi(server_port), "/rss%s", resource);
+diff --git a/ppdc/ppdc-source.cxx b/ppdc/ppdc-source.cxx
+index b28c472..57bbe70 100644
+--- a/ppdc/ppdc-source.cxx
++++ b/ppdc/ppdc-source.cxx
+@@ -1120,16 +1120,16 @@ ppdcSource::get_generic(ppdcFile   *fp,	// I - File to read
+     if (tattr)
+       snprintf(command, sizeof(command),
+                "<</%s(%s)/%s %d>>setpagedevice",
+-               tattr, name, nattr, val);
++               tattr, name, nattr, val) < 0 ? abort() : (void)0;
+     else
+       snprintf(command, sizeof(command),
+                "<</%s %d>>setpagedevice",
+-               nattr, val);
++               nattr, val) < 0 ? abort() : (void)0;
+   }
+   else
+     snprintf(command, sizeof(command),
+              "<</%s(%s)>>setpagedevice",
+-             tattr, name);
++             tattr, name) < 0 ? abort() : (void)0;
+ 
+   return (new ppdcChoice(name, text, command));
+ }
+diff --git a/ppdc/ppdc.cxx b/ppdc/ppdc.cxx
+index 5411b5e..8b14936 100644
+--- a/ppdc/ppdc.cxx
++++ b/ppdc/ppdc.cxx
+@@ -345,9 +345,9 @@ main(int  argc,				// I - Number of command-line arguments
+ 
+ 	// Open the PPD file for writing...
+ 	if (comp)
+-	  snprintf(filename, sizeof(filename), "%s/%s.gz", outdir, pcfilename);
++	  snprintf(filename, sizeof(filename), "%s/%s.gz", outdir, pcfilename) < 0 ? abort() : (void)0;
+ 	else
+-	  snprintf(filename, sizeof(filename), "%s/%s", outdir, pcfilename);
++	  snprintf(filename, sizeof(filename), "%s/%s", outdir, pcfilename) < 0 ? abort() : (void)0;
+ 
+         if (cupsArrayFind(filenames, filename))
+ 	  _cupsLangPrintf(stderr,
+diff --git a/scheduler/client.c b/scheduler/client.c
+index c2ee8f1..f331160 100644
+--- a/scheduler/client.c
++++ b/scheduler/client.c
+@@ -1994,9 +1994,9 @@ cupsdSendError(cupsd_client_t *con,	/* I - Connection */
+     {
+       text = urltext;
+ 
+-      snprintf(urltext, sizeof(urltext), _cupsLangString(con->language, _("You must access this page using the URL https://%s:%d%s.")), con->servername, con->serverport, con->uri);
++      snprintf(urltext, sizeof(urltext), _cupsLangString(con->language, _("You must access this page using the URL https://%s:%d%s.")), con->servername, con->serverport, con->uri) < 0 ? abort() : (void)0;
+ 
+-      snprintf(redirect, sizeof(redirect), "<META HTTP-EQUIV=\"Refresh\" CONTENT=\"3;URL=https://%s:%d%s\">\n", con->servername, con->serverport, con->uri);
++      snprintf(redirect, sizeof(redirect), "<META HTTP-EQUIV=\"Refresh\" CONTENT=\"3;URL=https://%s:%d%s\">\n", con->servername, con->serverport, con->uri) < 0 ? abort() : (void)0;
+     }
+     else if (code == HTTP_STATUS_CUPS_WEBIF_DISABLED)
+       text = _cupsLangString(con->language,
+@@ -2843,8 +2843,8 @@ get_file(cupsd_client_t *con,		/* I  - Client connection */
+   }
+   else if (con->language)
+   {
+-    snprintf(language, sizeof(language), "/%s", con->language->language);
+-    snprintf(filename, len, "%s%s%s", DocumentRoot, language, con->uri);
++    snprintf(language, sizeof(language), "/%s", con->language->language) < 0 ? abort() : (void)0;
++    snprintf(filename, len, "%s%s%s", DocumentRoot, language, con->uri) < 0 ? abort() : (void)0;
+   }
+   else
+     snprintf(filename, len, "%s%s", DocumentRoot, con->uri);
+@@ -2870,7 +2870,7 @@ get_file(cupsd_client_t *con,		/* I  - Client connection */
+     */
+ 
+     language[3] = '\0';
+-    snprintf(filename, len, "%s%s%s", DocumentRoot, language, con->uri);
++    snprintf(filename, len, "%s%s%s", DocumentRoot, language, con->uri) < 0 ? abort() : (void)0;
+ 
+     if ((ptr = strchr(filename, '?')) != NULL)
+       *ptr = '\0';
+@@ -2947,7 +2947,7 @@ get_file(cupsd_client_t *con,		/* I  - Client connection */
+       * Look for the index file...
+       */
+ 
+-      snprintf(filename, len, "%s%s%s", DocumentRoot, language, con->uri);
++      snprintf(filename, len, "%s%s%s", DocumentRoot, language, con->uri) < 0 ? abort() : (void)0;
+ 
+       if ((ptr = strchr(filename, '?')) != NULL)
+ 	*ptr = '\0';
+@@ -3267,7 +3267,7 @@ pipe_command(cupsd_client_t *con,	/* I - Client connection */
+ 
+     commch   = *commptr;
+     *commptr = '\0';
+-    snprintf(path_info, sizeof(path_info), "PATH_INFO=%s", argbuf);
++    snprintf(path_info, sizeof(path_info), "PATH_INFO=%s", argbuf) < 0 ? abort() : (void)0;
+     *commptr = commch;
+   }
+   else
+@@ -3377,16 +3377,16 @@ pipe_command(cupsd_client_t *con,	/* I - Client connection */
+                  sizeof(remote_addr) - 12);
+ 
+   snprintf(remote_host, sizeof(remote_host), "REMOTE_HOST=%s",
+-           httpGetHostname(con->http, NULL, 0));
++           httpGetHostname(con->http, NULL, 0)) < 0 ? abort() : (void)0;
+ 
+-  snprintf(script_name, sizeof(script_name), "SCRIPT_NAME=%s", con->uri);
++  snprintf(script_name, sizeof(script_name), "SCRIPT_NAME=%s", con->uri) < 0 ? abort() : (void)0;
+   if ((uriptr = strchr(script_name, '?')) != NULL)
+     *uriptr = '\0';
+ 
+   snprintf(script_filename, sizeof(script_filename), "SCRIPT_FILENAME=%s%s",
+-           DocumentRoot, script_name + 12);
++           DocumentRoot, script_name + 12) < 0 ? abort() : (void)0;
+ 
+-  snprintf(server_port, sizeof(server_port), "SERVER_PORT=%d", con->serverport);
++  snprintf(server_port, sizeof(server_port), "SERVER_PORT=%d", con->serverport) < 0 ? abort() : (void)0;
+ 
+   if (httpGetField(con->http, HTTP_FIELD_HOST)[0])
+   {
+diff --git a/scheduler/type.c b/scheduler/type.c
+index f547b83..1bd38ef 100644
+--- a/scheduler/type.c
++++ b/scheduler/type.c
+@@ -448,7 +448,7 @@ mimeAddTypeRule(mime_type_t *mt,	/* I - Type to add to */
+         * This is just a filename match on the extension...
+ 	*/
+ 
+-	snprintf(value[0], sizeof(value[0]), "*.%s", name);
++	snprintf(value[0], sizeof(value[0]), "*.%s", name) < 0 ? abort() : (void)0;
+ 	length[0]  = (int)strlen(value[0]);
+ 	op         = MIME_MAGIC_MATCH;
+ 	num_values = 1;
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0017-int.patch
+++ b/Ports/cups/patches/0017-int.patch
@@ -1,0 +1,25 @@
+From 93a98930e1911d6de7393546f37436ec8d88bb5a Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:17:32 +0300
+Subject: [PATCH 17/24] int
+
+---
+ scheduler/main.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/scheduler/main.c b/scheduler/main.c
+index d5fdf97..d01bf01 100644
+--- a/scheduler/main.c
++++ b/scheduler/main.c
+@@ -535,7 +535,7 @@ main(int  argc,				/* I - Number of command-line args */
+     MaxFDs = 16384;
+   else
+ #endif /* RLIM_INFINITY */
+-    MaxFDs = limit.rlim_max;
++    MaxFDs = (int)limit.rlim_max;
+ 
+   limit.rlim_cur = (rlim_t)MaxFDs;
+ 
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0018-select.patch
+++ b/Ports/cups/patches/0018-select.patch
@@ -1,0 +1,25 @@
+From 61dda6338c2b334aef385b7d132701f15bcae6e3 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:18:10 +0300
+Subject: [PATCH 18/24] select
+
+---
+ scheduler/ipp.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/scheduler/ipp.c b/scheduler/ipp.c
+index 2fe3bf2..da1f782 100644
+--- a/scheduler/ipp.c
++++ b/scheduler/ipp.c
+@@ -18,6 +18,8 @@
+ #include "cupsd.h"
+ #include <cups/ppd-private.h>
+ 
++#include <sys/select.h>
++
+ #ifdef __APPLE__
+ #  ifdef HAVE_MEMBERSHIP_H
+ #    include <membership.h>
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0019-truncations.patch
+++ b/Ports/cups/patches/0019-truncations.patch
@@ -1,0 +1,75 @@
+From bffcf1b5e9ee67f96cfa874ac0f93a4c93b8be6a Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:19:53 +0300
+Subject: [PATCH 19/24] truncations
+
+---
+ scheduler/ipp.c      | 8 ++++----
+ scheduler/printers.c | 4 ++--
+ 2 files changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/scheduler/ipp.c b/scheduler/ipp.c
+index da1f782..dc5f2f3 100644
+--- a/scheduler/ipp.c
++++ b/scheduler/ipp.c
+@@ -2019,7 +2019,7 @@ add_job_subscriptions(
+ 	  return;
+ 	}
+ 
+-        snprintf(notifier, sizeof(notifier), "%s/notifier/%s", ServerBin, scheme);
++        snprintf(notifier, sizeof(notifier), "%s/notifier/%s", ServerBin, scheme) < 0 ? abort() : (void)0;
+         if (access(notifier, X_OK) || stat(notifier, &info) || !S_ISREG(info.st_mode))
+ 	{
+           send_ipp_status(con, IPP_NOT_POSSIBLE,
+@@ -2401,7 +2401,7 @@ add_printer(cupsd_client_t  *con,	/* I - Client connection */
+       * See if the backend exists and is executable...
+       */
+ 
+-      snprintf(srcfile, sizeof(srcfile), "%s/backend/%s", ServerBin, scheme);
++      snprintf(srcfile, sizeof(srcfile), "%s/backend/%s", ServerBin, scheme) < 0 ? abort() : (void)0;
+       if (access(srcfile, X_OK))
+       {
+        /*
+@@ -5743,7 +5743,7 @@ create_subscriptions(
+ 	}
+ 
+         snprintf(notifier, sizeof(notifier), "%s/notifier/%s", ServerBin,
+-	         scheme);
++	         scheme) < 0 ? abort() : (void)0;
+         if (access(notifier, X_OK) || !strcmp(scheme, ".") || !strcmp(scheme, ".."))
+ 	{
+           send_ipp_status(con, IPP_NOT_POSSIBLE,
+@@ -7054,7 +7054,7 @@ get_ppd(cupsd_client_t  *con,		/* I - Client connection */
+ 
+     snprintf(command, sizeof(command), "%s/daemon/cups-driverd", ServerBin);
+     url_encode_string(ppd_name, oppd_name, sizeof(oppd_name));
+-    snprintf(options, sizeof(options), "get+%d+%s", ippGetRequestId(con->request), oppd_name);
++    snprintf(options, sizeof(options), "get+%d+%s", ippGetRequestId(con->request), oppd_name) < 0 ? abort() : (void)0;
+ 
+     if (cupsdSendCommand(con, command, options, 0))
+     {
+diff --git a/scheduler/printers.c b/scheduler/printers.c
+index e341bdb..dff5444 100644
+--- a/scheduler/printers.c
++++ b/scheduler/printers.c
+@@ -1033,7 +1033,7 @@ cupsdLoadAllPrinters(void)
+ 	    */
+ 
+ 	    p->state = IPP_PRINTER_STOPPED;
+-	    snprintf(p->state_message, sizeof(p->state_message), "Backend %s does not exist!", line);
++	    snprintf(p->state_message, sizeof(p->state_message), "Backend %s does not exist!", line) < 0 ? abort() : (void)0;
+ 	  }
+         }
+ 
+@@ -3542,7 +3542,7 @@ add_printer_filter(
+     if (program[0] == '/')
+       strlcpy(filename, program, sizeof(filename));
+     else
+-      snprintf(filename, sizeof(filename), "%s/filter/%s", ServerBin, program);
++      snprintf(filename, sizeof(filename), "%s/filter/%s", ServerBin, program) < 0 ? abort() : (void)0;
+ 
+     _cupsFileCheck(filename, _CUPS_FILE_CHECK_PROGRAM, !RunUser,
+                    cupsdLogFCMessage, p);
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0020-Replace-O_NDELAY-with-O_NONBLOCK.patch
+++ b/Ports/cups/patches/0020-Replace-O_NDELAY-with-O_NONBLOCK.patch
@@ -1,0 +1,33 @@
+From 4dd492acd9d544a14046a9fc8f5a99eea39fed1f Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:22:42 +0300
+Subject: [PATCH 20/24] Replace O_NDELAY with O_NONBLOCK
+
+---
+ scheduler/cupsfilter.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/scheduler/cupsfilter.c b/scheduler/cupsfilter.c
+index fa914d2..9d65860 100644
+--- a/scheduler/cupsfilter.c
++++ b/scheduler/cupsfilter.c
+@@ -879,14 +879,14 @@ exec_filter(const char *filter,		/* I - Filter to execute */
+       dup2(fd, 3);
+       close(fd);
+     }
+-    fcntl(3, F_SETFL, O_NDELAY);
++    fcntl(3, F_SETFL, O_NONBLOCK);
+ 
+     if ((fd = open("/dev/null", O_RDWR)) > 4)
+     {
+       dup2(fd, 4);
+       close(fd);
+     }
+-    fcntl(4, F_SETFL, O_NDELAY);
++    fcntl(4, F_SETFL, O_NONBLOCK);
+ 
+    /*
+     * Execute command...
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0021-int.patch
+++ b/Ports/cups/patches/0021-int.patch
@@ -1,0 +1,87 @@
+From 599aa89e970cd5cca2dfe3bb7198205df4aaf382 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:25:13 +0300
+Subject: [PATCH 21/24] int
+
+---
+ scheduler/cups-driverd.cxx | 12 ++++++------
+ scheduler/cupsfilter.c     |  4 ++--
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/scheduler/cups-driverd.cxx b/scheduler/cups-driverd.cxx
+index 85516eb..e72d90a 100644
+--- a/scheduler/cups-driverd.cxx
++++ b/scheduler/cups-driverd.cxx
+@@ -702,9 +702,9 @@ compare_inodes(struct stat *a,		/* I - First inode */
+                struct stat *b)		/* I - Second inode */
+ {
+   if (a->st_dev != b->st_dev)
+-    return (a->st_dev - b->st_dev);
++    return (int)(a->st_dev - b->st_dev);
+   else
+-    return (a->st_ino - b->st_ino);
++    return (int)(a->st_ino - b->st_ino);
+ }
+ 
+ 
+@@ -1132,7 +1132,7 @@ list_ppds(int        request_id,	/* I - Request ID */
+   {
+     char	newname[1024];		/* New filename */
+ 
+-    snprintf(newname, sizeof(newname), "%s.%d", filename, (int)getpid());
++    snprintf(newname, sizeof(newname), "%s.%d", filename, (int)getpid()) < 0 ? abort() : (void)0;
+ 
+     if ((fp = cupsFileOpen(newname, "w")) != NULL)
+     {
+@@ -1832,7 +1832,7 @@ load_drivers(cups_array_t *include,	/* I - Drivers to include */
+     * Run the driver with no arguments and collect the output...
+     */
+ 
+-    snprintf(filename, sizeof(filename), "%s/%s", drivers, dent->filename);
++    snprintf(filename, sizeof(filename), "%s/%s", drivers, dent->filename) < 0 ? abort() : (void)0;
+ 
+     if (_cupsFileCheck(filename, _CUPS_FILE_CHECK_PROGRAM, !geteuid(),
+                        _cupsFileCheckFilter, NULL))
+@@ -2439,7 +2439,7 @@ load_ppds(const char *d,		/* I - Actual directory */
+     snprintf(filename, sizeof(filename), "%s/%s", d, dent->filename);
+ 
+     if (p[0])
+-      snprintf(name, sizeof(name), "%s/%s", p, dent->filename);
++      snprintf(name, sizeof(name), "%s/%s", p, dent->filename) < 0 ? abort() : (void)0;
+     else
+       strlcpy(name, dent->filename, sizeof(name));
+ 
+@@ -2611,7 +2611,7 @@ load_ppds_dat(char   *filename,		/* I - Filename buffer */
+         ppdsync == PPD_SYNC &&
+         !stat(filename, &fileinfo) &&
+ 	(((size_t)fileinfo.st_size - sizeof(ppdsync)) % sizeof(ppd_rec_t)) == 0 &&
+-	(num_ppds = ((size_t)fileinfo.st_size - sizeof(ppdsync)) / sizeof(ppd_rec_t)) > 0)
++	(num_ppds = (int)(((size_t)fileinfo.st_size - sizeof(ppdsync)) / sizeof(ppd_rec_t))) > 0)
+     {
+      /*
+       * We have a ppds.dat file, so read it!
+diff --git a/scheduler/cupsfilter.c b/scheduler/cupsfilter.c
+index 9d65860..1e511fe 100644
+--- a/scheduler/cupsfilter.c
++++ b/scheduler/cupsfilter.c
+@@ -556,7 +556,7 @@ add_printer_filter(
+   if (sscanf(filter, "%15[^/]/%255s%*[ \t]%15[^/]/%255s%d%*[ \t]%1023[^\n]",
+              super, type, dsuper, dtype, &cost, program) == 6)
+   {
+-    snprintf(dest, sizeof(dest), "%s/%s/%s", filtertype->type, dsuper, dtype);
++    snprintf(dest, sizeof(dest), "%s/%s/%s", filtertype->type, dsuper, dtype) < 0 ? abort() : (void)0;
+ 
+     if ((desttype = mimeType(mime, "printer", dest)) == NULL)
+       desttype = mimeAddType(mime, "printer", dest);
+@@ -607,7 +607,7 @@ add_printer_filter(
+     if (program[0] == '/')
+       strlcpy(filename, program, sizeof(filename));
+     else
+-      snprintf(filename, sizeof(filename), "%s/filter/%s", ServerBin, program);
++      snprintf(filename, sizeof(filename), "%s/filter/%s", ServerBin, program) < 0 ? abort() : (void)0;
+ 
+     if (_cupsFileCheck(filename, _CUPS_FILE_CHECK_PROGRAM, !geteuid(), check_cb,
+                        (void *)command))
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0022-O_NDLEAY.patch
+++ b/Ports/cups/patches/0022-O_NDLEAY.patch
@@ -1,0 +1,27 @@
+From 0898d1043be2b41dce96706707dedacb5f17198d Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:25:47 +0300
+Subject: [PATCH 22/24] O_NDLEAY
+
+---
+ scheduler/cups-exec.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/scheduler/cups-exec.c b/scheduler/cups-exec.c
+index 674de0a..bd50fba 100644
+--- a/scheduler/cups-exec.c
++++ b/scheduler/cups-exec.c
+@@ -114,8 +114,8 @@ main(int  argc,				/* I - Number of command-line args */
+   * Make sure side and back channel FDs are non-blocking...
+   */
+ 
+-  fcntl(3, F_SETFL, O_NDELAY);
+-  fcntl(4, F_SETFL, O_NDELAY);
++  fcntl(3, F_SETFL, O_NONBLOCK);
++  fcntl(4, F_SETFL, O_NONBLOCK);
+ 
+  /*
+   * Change UID, GID, and nice value...
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0023-Removing-nice-call.patch
+++ b/Ports/cups/patches/0023-Removing-nice-call.patch
@@ -1,0 +1,45 @@
+From b0d92cdedec9ee769489c128cfc773eb5b0c5780 Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:27:49 +0300
+Subject: [PATCH 23/24] Removing nice() call
+
+---
+ scheduler/cups-exec.c | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/scheduler/cups-exec.c b/scheduler/cups-exec.c
+index bd50fba..96d375a 100644
+--- a/scheduler/cups-exec.c
++++ b/scheduler/cups-exec.c
+@@ -48,7 +48,7 @@ main(int  argc,				/* I - Number of command-line args */
+   const char	*opt;			/* Current option character */
+   uid_t		uid = getuid();		/* UID */
+   gid_t		gid = getgid();		/* GID */
+-  int		niceval = 0;		/* Nice value */
++  //int		niceval = 0;		/* Nice value */
+ #ifdef HAVE_SANDBOX_H
+   char		*sandbox_error = NULL;	/* Sandbox error, if any */
+ #endif /* HAVE_SANDBOX_H */
+@@ -79,7 +79,7 @@ main(int  argc,				/* I - Number of command-line args */
+               if (i >= argc)
+                 usage();
+ 
+-              niceval = atoi(argv[i]);
++              //niceval = atoi(argv[i]);
+               break;
+ 
+           case 'u' : /* -g gid */
+@@ -121,8 +121,8 @@ main(int  argc,				/* I - Number of command-line args */
+   * Change UID, GID, and nice value...
+   */
+ 
+-  if (uid)
+-    nice(niceval);
++  // if (uid)
++  //   nice(niceval);
+ 
+   if (!getuid())
+   {
+-- 
+2.25.1
+

--- a/Ports/cups/patches/0024-truncations.patch
+++ b/Ports/cups/patches/0024-truncations.patch
@@ -1,0 +1,97 @@
+From 8bc1440c948fc7ff3e673a3f4367007fe91cfd0b Mon Sep 17 00:00:00 2001
+From: Timur Sultanov <SultanovTS@yandex.ru>
+Date: Sun, 6 Feb 2022 20:29:36 +0300
+Subject: [PATCH 24/24] truncations
+
+---
+ systemv/cupstestppd.c | 24 ++++++++++++------------
+ 1 file changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/systemv/cupstestppd.c b/systemv/cupstestppd.c
+index b94cae9..d47be96 100644
+--- a/systemv/cupstestppd.c
++++ b/systemv/cupstestppd.c
+@@ -2404,7 +2404,7 @@ check_filters(ppd_file_t *ppd,		/* I - PPD file */
+     if (strcmp(program, "-"))
+     {
+       if (program[0] == '/')
+-	snprintf(pathprog, sizeof(pathprog), "%s%s", root, program);
++	snprintf(pathprog, sizeof(pathprog), "%s%s", root, program) < 0 ? abort() : (void)0;
+       else
+       {
+ 	if ((ptr = getenv("CUPS_SERVERBIN")) == NULL)
+@@ -2412,10 +2412,10 @@ check_filters(ppd_file_t *ppd,		/* I - PPD file */
+ 
+ 	if (*ptr == '/' || !*root)
+ 	  snprintf(pathprog, sizeof(pathprog), "%s%s/filter/%s", root, ptr,
+-		   program);
++		   program) < 0 ? abort() : (void)0;
+ 	else
+ 	  snprintf(pathprog, sizeof(pathprog), "%s/%s/filter/%s", root, ptr,
+-		   program);
++		   program) < 0 ? abort() : (void)0;
+       }
+ 
+       if (stat(pathprog, &fileinfo))
+@@ -2540,10 +2540,10 @@ check_filters(ppd_file_t *ppd,		/* I - PPD file */
+ 
+ 	if (*ptr == '/' || !*root)
+ 	  snprintf(pathprog, sizeof(pathprog), "%s%s/filter/%s", root, ptr,
+-		   program);
++		   program) < 0 ? abort() : (void)0;
+ 	else
+ 	  snprintf(pathprog, sizeof(pathprog), "%s/%s/filter/%s", root, ptr,
+-		   program);
++		   program) < 0 ? abort() : (void)0;
+       }
+ 
+       if (stat(pathprog, &fileinfo))
+@@ -2626,10 +2626,10 @@ check_filters(ppd_file_t *ppd,		/* I - PPD file */
+ 
+ 	if (*ptr == '/' || !*root)
+ 	  snprintf(pathprog, sizeof(pathprog), "%s%s/filter/%s", root, ptr,
+-		   program);
++		   program) < 0 ? abort() : (void)0;
+ 	else
+ 	  snprintf(pathprog, sizeof(pathprog), "%s/%s/filter/%s", root, ptr,
+-		   program);
++		   program) < 0 ? abort() : (void)0;
+       }
+ 
+       if (stat(pathprog, &fileinfo))
+@@ -3508,9 +3508,9 @@ check_translations(ppd_file_t *ppd,	/* I - PPD file */
+ 	}
+ 
+ 	snprintf(keyword, sizeof(keyword), "%s.%s", language,
+-		 option->keyword);
++		 option->keyword) < 0 ? abort() : (void)0;
+ 	snprintf(llkeyword, sizeof(llkeyword), "%s.%s", ll,
+-		 option->keyword);
++		 option->keyword) < 0 ? abort() : (void)0;
+ 
+ 	for (j = 0; j < option->num_choices; j ++)
+ 	{
+@@ -3535,7 +3535,7 @@ check_translations(ppd_file_t *ppd,	/* I - PPD file */
+ 					     option->keyword)) != NULL)
+ 	  {
+ 	    snprintf(ckeyword, sizeof(ckeyword), "%s.Custom%s",
+-		     language, option->keyword);
++		     language, option->keyword) < 0 ? abort() : (void)0;
+ 
+ 	    if ((attr = ppdFindAttr(ppd, ckeyword, "True")) != NULL &&
+ 		!valid_utf8(attr->text))
+@@ -3563,9 +3563,9 @@ check_translations(ppd_file_t *ppd,	/* I - PPD file */
+ 		   cparam = (ppd_cparam_t *)cupsArrayNext(coption->params))
+ 	      {
+ 		snprintf(ckeyword, sizeof(ckeyword), "%s.ParamCustom%s",
+-			 language, option->keyword);
++			 language, option->keyword) < 0 ? abort() : (void)0;
+ 		snprintf(cllkeyword, sizeof(cllkeyword), "%s.ParamCustom%s",
+-			 ll, option->keyword);
++			 ll, option->keyword) < 0 ? abort() : (void)0;
+ 
+ 		if ((attr = ppdFindAttr(ppd, ckeyword,
+ 					cparam->name)) == NULL &&
+-- 
+2.25.1
+

--- a/Ports/cups/patches/ReadMe.md
+++ b/Ports/cups/patches/ReadMe.md
@@ -1,0 +1,122 @@
+# Patches for cups on SerenityOS
+
+## `0001-Remove-lockf-calls-as-Serenity-doesn-t-implement-the.patch`
+
+Remove lockf() calls as Serenity doesn't implement them
+
+
+## `0002-Silence-string-truncation-error.patch`
+
+Silence string truncation error
+
+
+## `0003-Silence-size_t-to-int-casting-error.patch`
+
+Silence size_t to int casting error
+
+
+## `0004-Silence-one-more-string-truncation-error.patch`
+
+Silence one more string truncation error
+
+
+## `0005-comment-out-IN6_IS_ADDR_UNSPECIFIED-call.patch`
+
+comment out IN6_IS_ADDR_UNSPECIFIED call
+
+
+## `0006-Silence-more-string-truncations.patch`
+
+Silence more string truncations
+
+
+## `0007-Add-missing-select.h-include.patch`
+
+Add missing select.h include
+
+
+## `0008-More-truncation-silencing.patch`
+
+More truncation silencing
+
+
+## `0009-silencing-int-casting.patch`
+
+silencing int casting
+
+
+## `0010-Commenting-out-missing-header.patch`
+
+Commenting out missing header
+
+
+## `0011-Silencing-int-conversion-warning.patch`
+
+Silencing int conversion warning
+
+
+## `0012-Silencing-more-truncation-errors.patch`
+
+Silencing more truncation errors
+
+
+## `0013-Fixing-missing-select.h-header.patch`
+
+Fixing missing select.h header
+
+
+## `0014-Truncations.patch`
+
+Truncations
+
+
+## `0015-select.patch`
+
+select
+
+
+## `0016-truncation.patch`
+
+truncation
+
+
+## `0017-int.patch`
+
+int
+
+
+## `0018-select.patch`
+
+select
+
+
+## `0019-truncations.patch`
+
+truncations
+
+
+## `0020-Replace-O_NDELAY-with-O_NONBLOCK.patch`
+
+Replace O_NDELAY with O_NONBLOCK
+
+
+## `0021-int.patch`
+
+int
+
+
+## `0022-O_NDLEAY.patch`
+
+O_NDLEAY
+
+
+## `0023-Removing-nice-call.patch`
+
+Removing nice() call
+
+
+## `0024-truncations.patch`
+
+truncations
+
+

--- a/Userland/Libraries/LibC/scanf.cpp
+++ b/Userland/Libraries/LibC/scanf.cpp
@@ -301,6 +301,7 @@ struct ReadElement<char*, ReadKind::Normal> {
 
     bool operator()(LengthModifier length_modifier, GenericLexer& input_lexer, va_list* ap)
     {
+
         // FIXME: Implement wide strings and such.
         if (length_modifier != LengthModifier::Default)
             return false;
@@ -313,6 +314,8 @@ struct ReadElement<char*, ReadKind::Normal> {
         if (str.is_empty())
             return false;
 
+        if(ap == nullptr)
+            return true;
         memcpy(ptr, str.characters_without_null_termination(), str.length());
         ptr[str.length()] = 0;
 
@@ -597,7 +600,7 @@ extern "C" int vsscanf(const char* input, const char* format, va_list ap)
         case ConversionSpecifier::UseScanList:
             if (!ReadElement<char*, ReadKind::Normal> { scanlist, invert_scanlist }(length_modifier, input_lexer, ap_or_null))
                 format_lexer.consume_all();
-            else
+            else if (!suppress_assignment)
                 ++elements_matched;
             break;
         case ConversionSpecifier::Character:

--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -450,17 +450,27 @@ static Result<void*, DlErrorMessage> __dlsym(void* handle, const char* symbol_na
     __pthread_mutex_lock(&s_loader_lock);
     ScopeGuard unlock_guard = [] { __pthread_mutex_unlock(&s_loader_lock); };
 
-    auto object = static_cast<DynamicObject*>(handle);
-    if (!handle) {
-        auto library_name = get_library_name(s_main_program_name);
-        auto global_object = s_global_objects.get(library_name);
-        object = *global_object;
+    if(handle)
+    {
+        auto object = static_cast<DynamicObject*>(handle);
+        auto symbol = object->lookup_symbol(symbol_name);
+        if (symbol.has_value()) {
+            return symbol.value().address.as_ptr();
+        }
     }
-    auto symbol = object->lookup_symbol(symbol_name);
-    if (!symbol.has_value()) {
-        return DlErrorMessage { String::formatted("Symbol {} not found", symbol_name) };
+    else
+    {
+        for (auto& object_name : s_global_objects.keys())
+        {
+            auto object = s_global_objects.get(object_name);
+            auto symbol = (*object)->lookup_symbol(symbol_name);
+            if (symbol.has_value())
+            {
+                return symbol.value().address.as_ptr();
+            }
+        }
     }
-    return symbol.value().address.as_ptr();
+    return DlErrorMessage { String::formatted("Symbol {} not found", symbol_name) };
 }
 
 static Result<void, DlErrorMessage> __dladdr(void* addr, Dl_info* info)


### PR DESCRIPTION
An initial OpenJDK port.

Notes:
- Only `zero` variant of JVM is supported -- no JIT support
- Only `java.base` module build is tested
- No signals support
- PR contains a non-working CUPS port which is required for OpenJDK `configure` to proceed. Plan is to make this dependency optional.