### PR TITLE
CI: Disable compiletime header check

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -162,7 +162,6 @@ jobs:
         # We build and run the Lagom tests in a separate job, and sanitizer builds take a good while longer than non-sanitized.
         run:  |
           cmake -S Meta/CMake/Superbuild -B Build/superbuild -GNinja \
-            -DENABLE_COMPILETIME_HEADER_CHECK=ON \
             -DSERENITY_ARCH=${{ matrix.arch }} \
             -DSERENITY_TOOLCHAIN=GNU \
             -DCMAKE_C_COMPILER=gcc-11 \


### PR DESCRIPTION
This check does not seem to provide a lot of value, and it is pretty annoying, so let's just disable it for now.