### PR TITLE
Aestetic and readability man improvements

### DIFF
--- a/Userland/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.cpp
@@ -49,8 +49,11 @@ String CodeBlock::render_for_terminal(size_t) const
 {
     StringBuilder builder;
 
-    builder.append(m_code);
-    builder.append("\n\n");
+    for (auto line : m_code.split('\n')) {
+        builder.append("  ");
+        builder.append(line);
+        builder.append("\n");
+    }
 
     return builder.build();
 }

--- a/Userland/Libraries/LibMarkdown/Heading.cpp
+++ b/Userland/Libraries/LibMarkdown/Heading.cpp
@@ -19,15 +19,14 @@ String Heading::render_for_terminal(size_t) const
 {
     StringBuilder builder;
 
+    builder.append("\033[0;31;1m\n");
     switch (m_level) {
     case 1:
     case 2:
-        builder.append("\n\033[1m");
         builder.append(m_text.render_for_terminal().to_uppercase());
         builder.append("\033[0m\n");
         break;
     default:
-        builder.append("\n\033[1m");
         builder.append(m_text.render_for_terminal());
         builder.append("\033[0m\n");
         break;

--- a/Userland/Libraries/LibMarkdown/List.cpp
+++ b/Userland/Libraries/LibMarkdown/List.cpp
@@ -45,12 +45,11 @@ String List::render_for_terminal(size_t) const
     for (auto& item : m_items) {
         builder.append("  ");
         if (m_is_ordered)
-            builder.appendff("{}. ", ++i);
+            builder.appendff("{}.", ++i);
         else
-            builder.append("* ");
+            builder.append("*");
         builder.append(item->render_for_terminal());
     }
-    builder.append("\n");
 
     return builder.build();
 }

--- a/Userland/Libraries/LibMarkdown/Paragraph.cpp
+++ b/Userland/Libraries/LibMarkdown/Paragraph.cpp
@@ -30,6 +30,7 @@ String Paragraph::render_to_html(bool tight) const
 String Paragraph::render_for_terminal(size_t) const
 {
     StringBuilder builder;
+    builder.append("  ");
     builder.append(m_text.render_for_terminal());
     builder.append("\n\n");
     return builder.build();

--- a/Userland/Libraries/LibMarkdown/Table.cpp
+++ b/Userland/Libraries/LibMarkdown/Table.cpp
@@ -63,6 +63,8 @@ String Table::render_for_terminal(size_t view_width) const
         builder.append("\n");
     }
 
+    builder.append("\n");
+
     return builder.to_string();
 }
 

--- a/Userland/Libraries/LibMarkdown/Text.cpp
+++ b/Userland/Libraries/LibMarkdown/Text.cpp
@@ -156,7 +156,7 @@ void Text::LinkNode::render_for_terminal(StringBuilder& builder) const
 {
     bool is_linked = href.contains("://");
     if (is_linked) {
-        builder.append("\e]8;;");
+        builder.append("\033[0;34m\e]8;;");
         builder.append(href);
         builder.append("\e\\");
     }
@@ -165,7 +165,7 @@ void Text::LinkNode::render_for_terminal(StringBuilder& builder) const
 
     if (is_linked) {
         builder.appendff(" <{}>", href);
-        builder.append("\033]8;;\033\\");
+        builder.append("\033]8;;\033\\\033[0m");
     }
 }
 

--- a/Userland/Utilities/man.cpp
+++ b/Userland/Utilities/man.cpp
@@ -116,13 +116,21 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto buffer = file->read_all();
     auto source = String::copy(buffer);
 
-    outln("{}({})\t\tSerenityOS manual", name, section);
+    const String title("SerenityOS manual");
+
+    int spaces = view_width / 2 - String(name).length() - String(section).length() - title.length() / 2 - 4;
+    if (spaces < 0)
+        spaces = 0;
+    out("{}({})", name, section);
+    while (spaces--)
+        out(" ");
+    outln(title);
 
     auto document = Markdown::Document::parse(source);
     VERIFY(document);
 
     String rendered = document->render_for_terminal(view_width);
-    out("{}", rendered);
+    outln("{}", rendered);
 
     // FIXME: Remove this wait, it shouldn't be necessary but Shell does not
     //        resume properly without it. This wait also breaks <C-z> backgrounding


### PR DESCRIPTION
I thought that the output generated by the `man` command was kind of hard to read and a bit monochrome. I decided to take this into my own hands and create this:

![preview](https://i.imgur.com/KKcat1Y.png)

Changes:
 * Centering of the title
 * Color highlighting
 * Margin on the left to make the structure visibility better