### PR TITLE
Kernel: Put scopeguards around some mmaps

### DIFF
--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -40,11 +40,10 @@ ErrorOr<Memory::Region*> FramebufferDevice::mmap(Process& process, OpenFileDescr
     if (range.size() != framebuffer_length)
         return EOVERFLOW;
 
-    m_userspace_real_framebuffer_vmobject = TRY(Memory::AnonymousVMObject::try_create_for_physical_range(m_framebuffer_address, framebuffer_length));
-    m_real_framebuffer_vmobject = TRY(Memory::AnonymousVMObject::try_create_for_physical_range(m_framebuffer_address, framebuffer_length));
-    m_swapped_framebuffer_vmobject = TRY(Memory::AnonymousVMObject::try_create_with_size(framebuffer_length, AllocationStrategy::AllocateNow));
-    m_real_framebuffer_region = TRY(MM.allocate_kernel_region_with_vmobject(*m_real_framebuffer_vmobject, framebuffer_length, "Framebuffer", Memory::Region::Access::ReadWrite));
-    m_swapped_framebuffer_region = TRY(MM.allocate_kernel_region_with_vmobject(*m_swapped_framebuffer_vmobject, framebuffer_length, "Framebuffer Swap (Blank)", Memory::Region::Access::ReadWrite));
+    TRY(try_to_initialize());
+
+    if (m_userspace_framebuffer_region)
+        return m_userspace_framebuffer_region;
 
     RefPtr<Memory::VMObject> chosen_vmobject;
     if (m_graphical_writes_enabled) {
@@ -99,16 +98,26 @@ void FramebufferDevice::activate_writes()
     m_graphical_writes_enabled = true;
 }
 
-UNMAP_AFTER_INIT ErrorOr<void> FramebufferDevice::try_to_initialize()
+ErrorOr<void> FramebufferDevice::try_to_initialize()
 {
-    // FIXME: Would be nice to be able to unify this with mmap above, but this
-    //        function is UNMAP_AFTER_INIT for the time being.
+    if (m_initialized)
+        return {};
+
     auto framebuffer_length = TRY(buffer_length(0));
     framebuffer_length = TRY(Memory::page_round_up(framebuffer_length));
-    m_real_framebuffer_vmobject = TRY(Memory::AnonymousVMObject::try_create_for_physical_range(m_framebuffer_address, framebuffer_length));
-    m_swapped_framebuffer_vmobject = TRY(Memory::AnonymousVMObject::try_create_with_size(framebuffer_length, AllocationStrategy::AllocateNow));
-    m_real_framebuffer_region = TRY(MM.allocate_kernel_region_with_vmobject(*m_real_framebuffer_vmobject, framebuffer_length, "Framebuffer", Memory::Region::Access::ReadWrite));
-    m_swapped_framebuffer_region = TRY(MM.allocate_kernel_region_with_vmobject(*m_swapped_framebuffer_vmobject, framebuffer_length, "Framebuffer Swap (Blank)", Memory::Region::Access::ReadWrite));
+
+    auto real_framebuffer_vmobject = TRY(Memory::AnonymousVMObject::try_create_for_physical_range(m_framebuffer_address, framebuffer_length));
+    auto swapped_framebuffer_vmobject = TRY(Memory::AnonymousVMObject::try_create_with_size(framebuffer_length, AllocationStrategy::AllocateNow));
+    auto real_framebuffer_region = TRY(MM.allocate_kernel_region_with_vmobject(*real_framebuffer_vmobject, framebuffer_length, "Framebuffer", Memory::Region::Access::ReadWrite));
+    auto swapped_framebuffer_region = TRY(MM.allocate_kernel_region_with_vmobject(*swapped_framebuffer_vmobject, framebuffer_length, "Framebuffer Swap (Blank)", Memory::Region::Access::ReadWrite));
+
+    m_real_framebuffer_vmobject = move(real_framebuffer_vmobject);
+    m_swapped_framebuffer_vmobject = move(swapped_framebuffer_vmobject);
+    m_real_framebuffer_region = move(real_framebuffer_region);
+    m_swapped_framebuffer_region = move(swapped_framebuffer_region);
+
+    m_initialized = true;
+
     return {};
 }
 

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -67,6 +67,7 @@ private:
 
     bool m_graphical_writes_enabled { true };
     bool m_write_combine { true };
+    bool m_initialized { false };
 
     RefPtr<Memory::AnonymousVMObject> m_userspace_real_framebuffer_vmobject;
     Memory::Region* m_userspace_framebuffer_region { nullptr };

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/kmalloc.h>
 #include <Kernel/Arch/SmapDisabler.h>
 #include <Kernel/Arch/x86/MSR.h>
 #include <Kernel/Arch/x86/SafeMem.h>
@@ -184,8 +185,16 @@ ErrorOr<FlatPtr> Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> use
         return EINVAL;
 
     Memory::Region* region = nullptr;
+    Memory::VirtualRange range { {}, 0 };
 
-    auto range = TRY([&]() -> ErrorOr<Memory::VirtualRange> {
+    ArmedScopeGuard scope_guard = [&] {
+        if (region)
+            address_space().deallocate_region(*region);
+        else if (range.is_valid())
+            address_space().page_directory().range_allocator().deallocate(range);
+    };
+
+    range = TRY([&]() -> ErrorOr<Memory::VirtualRange> {
         if (map_randomized)
             return address_space().page_directory().range_allocator().try_allocate_randomized(rounded_size, alignment);
 
@@ -247,6 +256,8 @@ ErrorOr<FlatPtr> Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> use
     region->set_name(move(name));
 
     PerformanceManager::add_mmap_perf_event(*this, *region);
+
+    scope_guard.disarm();
 
     return region->vaddr().get();
 }


### PR DESCRIPTION
This ticks of one box in #6369

----
I need a another persons look on the destruction logic.
This assumes that a region de-allocates its own range.
This also assumes that pretty much all types are self cleaning, when captured by a (partially) owning construct, like OwnPtr or RefPtr, this might need a second opinion.