### PR TITLE
LibArchive: Refactor zip

### DIFF
--- a/Userland/Libraries/LibArchive/Zip.cpp
+++ b/Userland/Libraries/LibArchive/Zip.cpp
@@ -68,17 +68,17 @@ Optional<Zip> Zip::try_create(ReadonlyBytes buffer)
         member_offset += central_directory_record.size();
     }
 
-    Zip zip;
-    zip.m_input_data = buffer;
-    zip.member_count = end_of_central_directory.total_records_count;
-    zip.members_start_offset = end_of_central_directory.central_directory_offset;
-    return zip;
+    return Zip {
+        end_of_central_directory.total_records_count,
+        end_of_central_directory.central_directory_offset,
+        buffer,
+    };
 }
 
 bool Zip::for_each_member(Function<IterationDecision(const ZipMember&)> callback)
 {
-    size_t member_offset = members_start_offset;
-    for (size_t i = 0; i < member_count; i++) {
+    size_t member_offset = m_members_start_offset;
+    for (size_t i = 0; i < m_member_count; i++) {
         CentralDirectoryRecord central_directory_record {};
         VERIFY(central_directory_record.read(m_input_data.slice(member_offset)));
         LocalFileHeader local_file_header {};
@@ -108,6 +108,12 @@ ZipOutputStream::ZipOutputStream(OutputStream& stream)
 {
 }
 
+static u16 minimum_version_needed(ZipCompressionMethod method)
+{
+    // Deflate was added in PKZip 2.0
+    return method == ZipCompressionMethod::Deflate ? 20 : 10;
+}
+
 void ZipOutputStream::add_member(const ZipMember& member)
 {
     VERIFY(!m_finished);
@@ -115,20 +121,21 @@ void ZipOutputStream::add_member(const ZipMember& member)
     VERIFY(member.compressed_data.size() <= UINT32_MAX);
     m_members.append(member);
 
-    LocalFileHeader local_file_header {};
-    local_file_header.minimum_version = member.compression_method == ZipCompressionMethod::Deflate ? 20 : 10; // Deflate was added in PKZip 2.0
-    local_file_header.general_purpose_flags = 0;
-    local_file_header.compression_method = static_cast<u16>(member.compression_method);
-    local_file_header.modification_time = 0; // TODO: support modification time
-    local_file_header.modification_date = 0;
-    local_file_header.crc32 = member.crc32;
-    local_file_header.compressed_size = member.compressed_data.size();
-    local_file_header.uncompressed_size = member.uncompressed_size;
-    local_file_header.name_length = member.name.length();
-    local_file_header.extra_data_length = 0;
-    local_file_header.name = (const u8*)(member.name.characters());
-    local_file_header.extra_data = nullptr;
-    local_file_header.compressed_data = member.compressed_data.data();
+    LocalFileHeader local_file_header {
+        .minimum_version = minimum_version_needed(member.compression_method),
+        .general_purpose_flags = 0,
+        .compression_method = static_cast<u16>(member.compression_method),
+        .modification_time = 0, // TODO: support modification time
+        .modification_date = 0,
+        .crc32 = member.crc32,
+        .compressed_size = static_cast<u32>(member.compressed_data.size()),
+        .uncompressed_size = member.uncompressed_size,
+        .name_length = static_cast<u16>(member.name.length()),
+        .extra_data_length = 0,
+        .name = reinterpret_cast<u8 const*>(member.name.characters()),
+        .extra_data = nullptr,
+        .compressed_data = member.compressed_data.data(),
+    };
     local_file_header.write(m_stream);
 }
 
@@ -137,44 +144,46 @@ void ZipOutputStream::finish()
     VERIFY(!m_finished);
     m_finished = true;
 
-    auto file_header_offset = 0;
-    auto central_directory_size = 0;
+    auto file_header_offset = 0u;
+    auto central_directory_size = 0u;
     for (const ZipMember& member : m_members) {
-        CentralDirectoryRecord central_directory_record {};
-        auto zip_version = member.compression_method == ZipCompressionMethod::Deflate ? 20 : 10; // Deflate was added in PKZip 2.0
-        central_directory_record.made_by_version = zip_version;
-        central_directory_record.minimum_version = zip_version;
-        central_directory_record.general_purpose_flags = 0;
-        central_directory_record.compression_method = static_cast<u16>(member.compression_method);
-        central_directory_record.modification_time = 0; // TODO: support modification time
-        central_directory_record.modification_date = 0;
-        central_directory_record.crc32 = member.crc32;
-        central_directory_record.compressed_size = member.compressed_data.size();
-        central_directory_record.uncompressed_size = member.uncompressed_size;
-        central_directory_record.name_length = member.name.length();
-        central_directory_record.extra_data_length = 0;
-        central_directory_record.comment_length = 0;
-        central_directory_record.start_disk = 0;
-        central_directory_record.internal_attributes = 0;
-        central_directory_record.external_attributes = member.is_directory ? zip_directory_external_attribute : 0;
-        central_directory_record.local_file_header_offset = file_header_offset; // FIXME: we assume the wrapped output stream was never written to before us
+        auto zip_version = minimum_version_needed(member.compression_method);
+        CentralDirectoryRecord central_directory_record {
+            .made_by_version = zip_version,
+            .minimum_version = zip_version,
+            .general_purpose_flags = 0,
+            .compression_method = member.compression_method,
+            .modification_time = 0, // TODO: support modification time
+            .modification_date = 0,
+            .crc32 = member.crc32,
+            .compressed_size = static_cast<u32>(member.compressed_data.size()),
+            .uncompressed_size = member.uncompressed_size,
+            .name_length = static_cast<u16>(member.name.length()),
+            .extra_data_length = 0,
+            .comment_length = 0,
+            .start_disk = 0,
+            .internal_attributes = 0,
+            .external_attributes = member.is_directory ? zip_directory_external_attribute : 0,
+            .local_file_header_offset = file_header_offset, // FIXME: we assume the wrapped output stream was never written to before us
+            .name = reinterpret_cast<u8 const*>(member.name.characters()),
+            .extra_data = nullptr,
+            .comment = nullptr,
+        };
         file_header_offset += sizeof(LocalFileHeader::signature) + (sizeof(LocalFileHeader) - (sizeof(u8*) * 3)) + member.name.length() + member.compressed_data.size();
-        central_directory_record.name = (const u8*)(member.name.characters());
-        central_directory_record.extra_data = nullptr;
-        central_directory_record.comment = nullptr;
         central_directory_record.write(m_stream);
         central_directory_size += central_directory_record.size();
     }
 
-    EndOfCentralDirectory end_of_central_directory {};
-    end_of_central_directory.disk_number = 0;
-    end_of_central_directory.central_directory_start_disk = 0;
-    end_of_central_directory.disk_records_count = m_members.size();
-    end_of_central_directory.total_records_count = m_members.size();
-    end_of_central_directory.central_directory_size = central_directory_size;
-    end_of_central_directory.central_directory_offset = file_header_offset;
-    end_of_central_directory.comment_length = 0;
-    end_of_central_directory.comment = nullptr;
+    EndOfCentralDirectory end_of_central_directory {
+        .disk_number = 0,
+        .central_directory_start_disk = 0,
+        .disk_records_count = static_cast<u16>(m_members.size()),
+        .total_records_count = static_cast<u16>(m_members.size()),
+        .central_directory_size = central_directory_size,
+        .central_directory_offset = file_header_offset,
+        .comment_length = 0,
+        .comment = nullptr,
+    };
     end_of_central_directory.write(m_stream);
 }
 

--- a/Userland/Libraries/LibArchive/Zip.h
+++ b/Userland/Libraries/LibArchive/Zip.h
@@ -1,14 +1,15 @@
 /*
  * Copyright (c) 2021, Idan Horowitz <idan.horowitz@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Array.h>
 #include <AK/Function.h>
 #include <AK/IterationDecision.h>
-#include <AK/Span.h>
 #include <AK/Stream.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
@@ -16,10 +17,24 @@
 
 namespace Archive {
 
+template<size_t fields_size, class T>
+static bool read_helper(ReadonlyBytes buffer, T* self)
+{
+    if (buffer.size() < T::signature.size() + fields_size)
+        return false;
+    if (buffer.slice(0, T::signature.size()) != T::signature)
+        return false;
+    memcpy(self, buffer.data() + T::signature.size(), fields_size);
+    return true;
+}
+
 // NOTE: Due to the format of zip files compression is streamed and decompression is random access.
 
-static constexpr u8 end_of_central_directory_signature[] = { 0x50, 0x4b, 0x05, 0x06 }; // 'PK\x05\x06'
+static constexpr auto signature_length = 4;
+
 struct [[gnu::packed]] EndOfCentralDirectory {
+    static constexpr Array<u8, signature_length> signature = { 0x50, 0x4b, 0x05, 0x06 }; // 'PK\x05\x06'
+
     u16 disk_number;
     u16 central_directory_start_disk;
     u16 disk_records_count;
@@ -31,21 +46,18 @@ struct [[gnu::packed]] EndOfCentralDirectory {
 
     bool read(ReadonlyBytes buffer)
     {
-        auto fields_size = sizeof(EndOfCentralDirectory) - sizeof(u8*);
-        if (buffer.size() < sizeof(end_of_central_directory_signature) + fields_size)
+        constexpr auto fields_size = sizeof(EndOfCentralDirectory) - (sizeof(u8*) * 1);
+        if (!read_helper<fields_size>(buffer, this))
             return false;
-        if (memcmp(buffer.data(), end_of_central_directory_signature, sizeof(end_of_central_directory_signature)) != 0)
+        if (buffer.size() < signature.size() + fields_size + comment_length)
             return false;
-        memcpy(reinterpret_cast<void*>(&disk_number), buffer.data() + sizeof(end_of_central_directory_signature), fields_size);
-        if (buffer.size() < sizeof(end_of_central_directory_signature) + fields_size + comment_length)
-            return false;
-        comment = buffer.data() + sizeof(end_of_central_directory_signature) + fields_size;
+        comment = buffer.data() + signature.size() + fields_size;
         return true;
     }
 
     void write(OutputStream& stream) const
     {
-        stream.write_or_error({ end_of_central_directory_signature, sizeof(end_of_central_directory_signature) });
+        stream.write_or_error(signature);
         stream << disk_number;
         stream << central_directory_start_disk;
         stream << disk_records_count;
@@ -58,8 +70,9 @@ struct [[gnu::packed]] EndOfCentralDirectory {
     }
 };
 
-static constexpr u8 central_directory_record_signature[] = { 0x50, 0x4b, 0x01, 0x02 }; // 'PK\x01\x02'
 struct [[gnu::packed]] CentralDirectoryRecord {
+    static constexpr Array<u8, signature_length> signature = { 0x50, 0x4b, 0x01, 0x02 }; // 'PK\x01\x02'
+
     u16 made_by_version;
     u16 minimum_version;
     u16 general_purpose_flags;
@@ -82,15 +95,12 @@ struct [[gnu::packed]] CentralDirectoryRecord {
 
     bool read(ReadonlyBytes buffer)
     {
-        auto fields_size = sizeof(CentralDirectoryRecord) - (sizeof(u8*) * 3);
-        if (buffer.size() < sizeof(central_directory_record_signature) + fields_size)
+        constexpr auto fields_size = sizeof(CentralDirectoryRecord) - (sizeof(u8*) * 3);
+        if (!read_helper<fields_size>(buffer, this))
             return false;
-        if (memcmp(buffer.data(), central_directory_record_signature, sizeof(central_directory_record_signature)) != 0)
+        if (buffer.size() < size())
             return false;
-        memcpy(reinterpret_cast<void*>(&made_by_version), buffer.data() + sizeof(central_directory_record_signature), fields_size);
-        if (buffer.size() < sizeof(end_of_central_directory_signature) + fields_size + comment_length + name_length + extra_data_length)
-            return false;
-        name = buffer.data() + sizeof(central_directory_record_signature) + fields_size;
+        name = buffer.data() + signature.size() + fields_size;
         extra_data = name + name_length;
         comment = extra_data + extra_data_length;
         return true;
@@ -98,7 +108,7 @@ struct [[gnu::packed]] CentralDirectoryRecord {
 
     void write(OutputStream& stream) const
     {
-        stream.write_or_error({ central_directory_record_signature, sizeof(central_directory_record_signature) });
+        stream.write_or_error(signature);
         stream << made_by_version;
         stream << minimum_version;
         stream << general_purpose_flags;
@@ -125,13 +135,14 @@ struct [[gnu::packed]] CentralDirectoryRecord {
 
     [[nodiscard]] size_t size() const
     {
-        return sizeof(central_directory_record_signature) + (sizeof(CentralDirectoryRecord) - (sizeof(u8*) * 3)) + name_length + extra_data_length + comment_length;
+        return signature.size() + (sizeof(CentralDirectoryRecord) - (sizeof(u8*) * 3)) + name_length + extra_data_length + comment_length;
     }
 };
 static constexpr u32 zip_directory_external_attribute = 1 << 4;
 
-static constexpr u8 local_file_header_signature[] = { 0x50, 0x4b, 0x03, 0x04 }; // 'PK\x03\x04'
 struct [[gnu::packed]] LocalFileHeader {
+    static constexpr Array<u8, signature_length> signature = { 0x50, 0x4b, 0x03, 0x04 }; // 'PK\x03\x04'
+
     u16 minimum_version;
     u16 general_purpose_flags;
     u16 compression_method;
@@ -148,15 +159,12 @@ struct [[gnu::packed]] LocalFileHeader {
 
     bool read(ReadonlyBytes buffer)
     {
-        auto fields_size = sizeof(LocalFileHeader) - (sizeof(u8*) * 3);
-        if (buffer.size() < sizeof(local_file_header_signature) + fields_size)
+        constexpr auto fields_size = sizeof(LocalFileHeader) - (sizeof(u8*) * 3);
+        if (!read_helper<fields_size>(buffer, this))
             return false;
-        if (memcmp(buffer.data(), local_file_header_signature, sizeof(local_file_header_signature)) != 0)
+        if (buffer.size() < signature.size() + fields_size + name_length + extra_data_length + compressed_size)
             return false;
-        memcpy(reinterpret_cast<void*>(&minimum_version), buffer.data() + sizeof(local_file_header_signature), fields_size);
-        if (buffer.size() < sizeof(end_of_central_directory_signature) + fields_size + name_length + extra_data_length + compressed_size)
-            return false;
-        name = buffer.data() + sizeof(local_file_header_signature) + fields_size;
+        name = buffer.data() + signature.size() + fields_size;
         extra_data = name + name_length;
         compressed_data = extra_data + extra_data_length;
         return true;
@@ -164,7 +172,7 @@ struct [[gnu::packed]] LocalFileHeader {
 
     void write(OutputStream& stream) const
     {
-        stream.write_or_error({ local_file_header_signature, sizeof(local_file_header_signature) });
+        stream.write_or_error(signature);
         stream << minimum_version;
         stream << general_purpose_flags;
         stream << compression_method;

--- a/Userland/Libraries/LibArchive/Zip.h
+++ b/Userland/Libraries/LibArchive/Zip.h
@@ -221,8 +221,14 @@ public:
 private:
     static bool find_end_of_central_directory_offset(ReadonlyBytes, size_t& offset);
 
-    u16 member_count { 0 };
-    size_t members_start_offset { 0 };
+    Zip(u16 member_count, size_t members_start_offset, ReadonlyBytes input_data)
+        : m_member_count { member_count }
+        , m_members_start_offset { members_start_offset }
+        , m_input_data { input_data }
+    {
+    }
+    u16 m_member_count { 0 };
+    size_t m_members_start_offset { 0 };
     ReadonlyBytes m_input_data;
 };
 


### PR DESCRIPTION
Commonize directory headers have some common code for
reading files and use designated initializers.

Benefits:                                                             
- Braced-initialization prevents unknown narrowing conversions.       
- Using designated initializers will result in a compiler error when a
  member is skipped or forgotten.                                     
