### PR TITLE
LibJS: Resizable array buffer

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -48,6 +48,16 @@ ArrayBuffer::~ArrayBuffer()
 {
 }
 
+// 1.1.5 IsResizableArrayBuffer ( arrayBuffer ), https://tc39.es/proposal-resizablearraybuffer/#sec-isresizablearraybuffer
+bool ArrayBuffer::is_resizable_array_buffer() const
+{
+    // 1. Assert: Type(arrayBuffer) is Object and arrayBuffer has an [[ArrayBufferData]] internal slot.
+
+    // 2. If buffer has an [[ArrayBufferMaxByteLength]] internal slot, return true.
+    // 3. Return false.
+    return m_max_byte_length.has_value();
+}
+
 void ArrayBuffer::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -54,8 +55,10 @@ void ArrayBuffer::visit_edges(Cell::Visitor& visitor)
 }
 
 // 25.1.2.1 AllocateArrayBuffer ( constructor, byteLength ), https://tc39.es/ecma262/#sec-allocatearraybuffer
-ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject& global_object, FunctionObject& constructor, size_t byte_length)
+// 1.1.2 AllocateArrayBuffer ( constructor, byteLength [, maxByteLength ] ), https://tc39.es/proposal-resizablearraybuffer/#sec-allocatearraybuffer
+ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject& global_object, FunctionObject& constructor, size_t byte_length, Optional<size_t> max_byte_length)
 {
+    (void)max_byte_length;
     // 1. Let obj be ? OrdinaryCreateFromConstructor(constructor, "%ArrayBuffer.prototype%", « [[ArrayBufferData]], [[ArrayBufferByteLength]], [[ArrayBufferDetachKey]] »).
     auto* obj = TRY(ordinary_create_from_constructor<ArrayBuffer>(global_object, constructor, &GlobalObject::array_buffer_prototype, nullptr));
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -75,7 +75,7 @@ private:
     Value m_detach_key;
 };
 
-ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject&, FunctionObject& constructor, size_t byte_length);
+ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject&, FunctionObject& constructor, size_t byte_length, Optional<size_t> max_byte_length = {});
 ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(GlobalObject&, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length, FunctionObject& clone_constructor);
 
 // 25.1.2.9 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/ecma262/#sec-rawbytestonumeric

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -34,6 +34,7 @@ public:
     virtual ~ArrayBuffer() override;
 
     size_t byte_length() const { return buffer_impl().size(); }
+    size_t max_byte_length() const { return m_max_byte_length.value(); } // Will VERIFY() that it has value
     ByteBuffer& buffer() { return buffer_impl(); }
     const ByteBuffer& buffer() const { return buffer_impl(); }
 
@@ -46,6 +47,8 @@ public:
 
     void detach_buffer() { m_buffer = Empty {}; }
     bool is_detached() const { return m_buffer.has<Empty>(); }
+
+    bool is_resizable_array_buffer() const;
 
     enum Order {
         SeqCst,

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -39,6 +39,7 @@ public:
 
     // Used by allocate_array_buffer() to attach the data block after construction
     void set_buffer(ByteBuffer buffer) { m_buffer = move(buffer); }
+    void set_max_byte_length(size_t max_byte_length) { m_max_byte_length = max_byte_length; }
 
     Value detach_key() const { return m_detach_key; }
     void set_detach_key(Value detach_key) { m_detach_key = detach_key; }
@@ -73,6 +74,7 @@ private:
     // The various detach related members of ArrayBuffer are not used by any ECMA262 functionality,
     // but are required to be available for the use of various harnesses like the Test262 test runner.
     Value m_detach_key;
+    Optional<size_t> m_max_byte_length;
 };
 
 ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject&, FunctionObject& constructor, size_t byte_length, Optional<size_t> max_byte_length = {});

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -46,20 +47,63 @@ ThrowCompletionOr<Value> ArrayBufferConstructor::call()
     return vm.throw_completion<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, vm.names.ArrayBuffer);
 }
 
+// 1.1.6 GetArrayBufferMaxByteLengthOption ( options ), https://tc39.es/proposal-resizablearraybuffer/#sec-getarraybuffermaxbytelengthoption
+static ThrowCompletionOr<Optional<size_t>> get_array_buffer_max_byte_length_option(VM& vm, GlobalObject& global_object, Value options)
+{
+    // 1. If Type(options) is not Object, return empty.
+    if (!options.is_object())
+        return Optional<size_t>();
+
+    // 2. Let maxByteLength be ? Get(options, "maxByteLength").
+    auto max_byte_length = TRY(options.get(global_object, vm.names.maxByteLength));
+
+    // 3. If maxByteLength is undefined, return empty.
+    if (max_byte_length.is_undefined())
+        return Optional<size_t>();
+
+    // 4. Return ? ToIndex(maxByteLength).
+    return TRY(max_byte_length.to_index(global_object));
+}
+
 // 25.1.3.1 ArrayBuffer ( length ), https://tc39.es/ecma262/#sec-arraybuffer-length
+// 1.2.1 ArrayBuffer ( length [, options ] ), https://tc39.es/proposal-resizablearraybuffer/#sec-arraybuffer-constructor
 ThrowCompletionOr<Object*> ArrayBufferConstructor::construct(FunctionObject& new_target)
 {
+    auto& global_object = new_target.realm()->global_object();
     auto& vm = this->vm();
-    auto byte_length_or_error = vm.argument(0).to_index(global_object());
+
+    // 1. If NewTarget is undefined, throw a TypeError exception.
+    // NOTE: See `ArrayBufferConstructor::call()`
+
+    // 2. Let byteLength be ? ToIndex(length).
+    auto byte_length_or_error = vm.argument(0).to_index(global_object);
     if (byte_length_or_error.is_error()) {
         auto error = byte_length_or_error.release_error();
         if (error.value()->is_object() && is<RangeError>(error.value()->as_object())) {
             // Re-throw more specific RangeError
-            return vm.throw_completion<RangeError>(global_object(), ErrorType::InvalidLength, "array buffer");
+            return vm.throw_completion<RangeError>(global_object, ErrorType::InvalidLength, "array buffer");
         }
         return error;
     }
-    return TRY(allocate_array_buffer(global_object(), new_target, byte_length_or_error.release_value()));
+    auto byte_length = byte_length_or_error.release_value();
+
+    // 3. Let requestedMaxByteLength be ? GetArrayBufferMaxByteLengthOption(options).
+    auto options = vm.argument(1);
+    auto requested_max_byte_length_value = TRY(get_array_buffer_max_byte_length_option(vm, global_object, options));
+
+    // 4. If requestedMaxByteLength is empty, then
+    if (!requested_max_byte_length_value.has_value()) {
+        // a. Return ? AllocateArrayBuffer(NewTarget, byteLength).
+        return TRY(allocate_array_buffer(global_object, new_target, byte_length));
+    }
+    auto requested_max_byte_length = requested_max_byte_length_value.release_value();
+
+    // 5. If byteLength > requestedMaxByteLength, throw a RangeError exception.
+    if (byte_length > requested_max_byte_length)
+        return vm.throw_completion<RangeError>(global_object, ErrorType::ByteLengthBeyondRequestedMax);
+
+    // 6. Return ? AllocateArrayBuffer(NewTarget, byteLength, requestedMaxByteLength).
+    return TRY(allocate_array_buffer(global_object, new_target, byte_length, requested_max_byte_length));
 }
 
 // 25.1.4.1 ArrayBuffer.isView ( arg ), https://tc39.es/ecma262/#sec-arraybuffer.isview

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -21,6 +21,7 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(slice);
+    JS_DECLARE_NATIVE_FUNCTION(resize);
     JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
     JS_DECLARE_NATIVE_FUNCTION(max_byte_length_getter);
     JS_DECLARE_NATIVE_FUNCTION(resizable_getter);

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -22,6 +22,8 @@ public:
 private:
     JS_DECLARE_NATIVE_FUNCTION(slice);
     JS_DECLARE_NATIVE_FUNCTION(byte_length_getter);
+    JS_DECLARE_NATIVE_FUNCTION(max_byte_length_getter);
+    JS_DECLARE_NATIVE_FUNCTION(resizable_getter);
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -380,6 +380,7 @@ namespace JS {
     P(reject)                                \
     P(relativeTo)                            \
     P(repeat)                                \
+    P(resizable)                             \
     P(resolve)                               \
     P(resolvedOptions)                       \
     P(reverse)                               \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -314,6 +314,7 @@ namespace JS {
     P(log10)                                 \
     P(map)                                   \
     P(max)                                   \
+    P(maxByteLength)                         \
     P(maximize)                              \
     P(mergeFields)                           \
     P(message)                               \

--- a/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
+++ b/Userland/Libraries/LibJS/Runtime/CommonPropertyNames.h
@@ -380,6 +380,7 @@ namespace JS {
     P(reject)                                \
     P(relativeTo)                            \
     P(repeat)                                \
+    P(resize)                                \
     P(resizable)                             \
     P(resolve)                               \
     P(resolvedOptions)                       \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -15,6 +15,7 @@
     M(BigIntFromNonIntegral, "Cannot convert non-integral number to BigInt")                                                            \
     M(BigIntInvalidValue, "Invalid value for BigInt: {}")                                                                               \
     M(BindingNotInitialized, "Binding {} is not initialized")                                                                           \
+    M(ByteLengthBeyondRequestedMax, "Byte length exceeds maxByteLength option")                                                         \
     M(CallStackSizeExceeded, "Call stack size limit exceeded")                                                                          \
     M(CannotDeclareGlobalFunction, "Cannot declare global function of name '{}'")                                                       \
     M(CannotDeclareGlobalVariable, "Cannot declare global variable of name '{}'")                                                       \

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -75,6 +75,7 @@
     M(ModuleNotFound, "Cannot find/open module: '{}'")                                                                                  \
     M(ModuleNotFoundNoReferencingScript, "Cannot resolve module {} without any active script or module")                                \
     M(NegativeExponent, "Exponent must be positive")                                                                                    \
+    M(NewByteLengthOutOfRange, "New byte length outside range supported by ArrayBuffer instance")                                       \
     M(NonExtensibleDefine, "Cannot define property {} on non-extensible object")                                                        \
     M(NotAConstructor, "{} is not a constructor")                                                                                       \
     M(NotAFunction, "{} is not a function")                                                                                             \
@@ -83,6 +84,7 @@
     M(NotAnObjectOfType, "Not an object of type {}")                                                                                    \
     M(NotAnObjectOrNull, "{} is neither an object nor null")                                                                            \
     M(NotAnObjectOrString, "{} is neither an object nor a string")                                                                      \
+    M(NotAResizableArrayBuffer, "ArrayBuffer instance not resizable")                                                                   \
     M(NotAString, "{} is not a string")                                                                                                 \
     M(NotASymbol, "{} is not a symbol")                                                                                                 \
     M(NotImplemented, "TODO({} is not implemented in LibJS)")                                                                           \

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -14,6 +14,7 @@
 #include <LibJS/Interpreter.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
+#include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibJS/Runtime/BoundFunction.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/ECMAScriptFunctionObject.h>
@@ -111,6 +112,23 @@ VM::VM(OwnPtr<CustomData> custom_data)
 
     host_get_supported_import_assertions = [&] {
         return Vector<String> { "type" };
+    };
+
+    // 1.1.7 HostResizeArrayBuffer ( buffer, newByteLength ), https://tc39.es/proposal-resizablearraybuffer/#sec-hostresizearraybuffer
+    host_resize_array_buffer = [](GlobalObject& global_object, size_t new_byte_length) {
+        // The host-defined abstract operation HostResizeArrayBuffer takes arguments buffer (an ArrayBuffer) and newByteLength (a non-negative integer).
+        // The host-defined abstract operation HostResizeArrayBuffer takes arguments buffer (an ArrayBuffer object) and newByteLength.
+        // It gives the host an opportunity to perform implementation-defined resizing of buffer. If the host chooses not to handle resizing of buffer, it may return unhandled for the default behavior.
+        // The implementation of HostResizeArrayBuffer must conform to the following requirements:
+        //   * The abstract operation must return either NormalCompletion(handled), NormalCompletion(unhandled), or an abrupt throw completion.
+        //   * The abstract operation does not detach buffer.
+        //   * If the abstract operation completes normally with handled, buffer.[[ArrayBufferByteLength]] is newByteLength.
+        // The default implementation of HostResizeArrayBuffer is to return unhandled.
+
+        (void)global_object;
+        (void)new_byte_length;
+
+        return HostResizeArrayBufferResult::Unhandled;
     };
 
 #define __JS_ENUMERATE(SymbolName, snake_name) \

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -39,6 +39,11 @@ public:
     static NonnullRefPtr<VM> create(OwnPtr<CustomData> = {});
     ~VM();
 
+    enum class HostResizeArrayBufferResult {
+        Unhandled,
+        Handled,
+    };
+
     Heap& heap() { return m_heap; }
     const Heap& heap() const { return m_heap; }
 
@@ -223,6 +228,7 @@ public:
     Function<void(FinalizationRegistry&)> host_enqueue_finalization_registry_cleanup_job;
     Function<void(Function<ThrowCompletionOr<Value>()>, Realm*)> host_enqueue_promise_job;
     Function<JobCallback(FunctionObject&)> host_make_job_callback;
+    Function<ThrowCompletionOr<HostResizeArrayBufferResult>(GlobalObject&, size_t)> host_resize_array_buffer;
 
 private:
     explicit VM(OwnPtr<CustomData>);

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.js
@@ -11,3 +11,57 @@ test("ArrayBuffer constructor must be invoked with 'new'", () => {
         ArrayBuffer();
     }).toThrowWithMessage(TypeError, "ArrayBuffer constructor must be called with 'new'");
 });
+
+describe("resizable array buffer", () => {
+    test("construct with options", () => {
+        expect(new ArrayBuffer(5, { maxByteLength: 5 })).toBeInstanceOf(ArrayBuffer);
+    });
+
+    test("resizable when provided max byte length", () => {
+        expect(new ArrayBuffer(1).resizable).toEqual(false);
+        expect(new ArrayBuffer(1, {}).resizable).toEqual(false);
+        expect(new ArrayBuffer(1, { maxByteLength: undefined }).resizable).toEqual(false);
+        expect(new ArrayBuffer(1, { maxByteLength: 1 }).resizable).toEqual(true);
+    });
+
+    test("byte length must be shorter than max byte length", () => {
+        expect(() => {
+            new ArrayBuffer(1, { maxByteLength: 0 });
+        }).toThrowWithMessage(RangeError, "Byte length exceeds maxByteLength option");
+    });
+
+    test("max byte length cannot be too large", () => {
+        expect(() => {
+            new ArrayBuffer(0, { maxByteLength: 9007199254740992 });
+        }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+    });
+
+    test("max byte length cannot be negative", () => {
+        expect(() => {
+            new ArrayBuffer(0, { maxByteLength: -1 });
+        }).toThrowWithMessage(RangeError, "Index must be a positive integer");
+    });
+
+    test("invalid max byte length object", () => {
+        expect(() => {
+            new ArrayBuffer(0, {
+                maxByteLength: {
+                    toString: function () {
+                        return {};
+                    },
+                    valueOf: function () {
+                        return {};
+                    },
+                },
+            });
+        }).toThrowWithMessage(TypeError, "Cannot convert object to number");
+
+        expect(() => {
+            new ArrayBuffer(0, {
+                get maxByteLength() {
+                    throw "Exception";
+                },
+            });
+        }).toThrow();
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/ArrayBuffer/ArrayBuffer.prototype.resize.js
@@ -1,0 +1,35 @@
+test("length is 1", () => {
+    expect(ArrayBuffer.prototype.resize).toHaveLength(1);
+});
+
+test("resize up to max", () => {
+    let a = new ArrayBuffer(0, { maxByteLength: 10 });
+    a.resize(10);
+    expect(a.byteLength).toEqual(10);
+});
+
+test("resize less than max", () => {
+    let a = new ArrayBuffer(10, { maxByteLength: 10 });
+    a.resize(5);
+    expect(a.byteLength).toEqual(5);
+});
+
+test("resize with negative length", () => {
+    let a = new ArrayBuffer(10, { maxByteLength: 10 });
+    expect(() => {
+        a.resize(-1);
+    }).toThrowWithMessage(
+        RangeError,
+        "New byte length outside range supported by ArrayBuffer instance"
+    );
+});
+
+test("resize past max length", () => {
+    let a = new ArrayBuffer(10, { maxByteLength: 10 });
+    expect(() => {
+        a.resize(11);
+    }).toThrowWithMessage(
+        RangeError,
+        "New byte length outside range supported by ArrayBuffer instance"
+    );
+});

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -423,6 +423,10 @@ static void print_array_buffer(JS::Object const& object, HashTable<JS::Object*>&
     print_type("ArrayBuffer");
     js_out("\n  byteLength: ");
     print_value(JS::Value((double)byte_length), seen_objects);
+    if (array_buffer.is_resizable_array_buffer()) {
+        js_out("\n  maxByteLength: ");
+        print_value(JS::Value((double)array_buffer.max_byte_length()), seen_objects);
+    }
     if (!byte_length)
         return;
     js_outln();


### PR DESCRIPTION
Implements most of the resizable array buffer proposal spec (https://tc39.es/proposal-resizablearraybuffer). The proposal does not seem to have landed but test262 covers it so here it is :)