### PR TITLE
Base/man: Update audio documentation

### DIFF
--- a/Base/usr/share/man/man4/audio.md
+++ b/Base/usr/share/man/man4/audio.md
@@ -1,10 +1,10 @@
 ## Name
 
-audio - system audio device
+audio - system audio devices
 
 ## Description
 
-The `/dev/audio` character device file exposes the audio output device of the system. As of now, this is an output-only device and reading it has no effect. To get the audio device to play audio, PCM samples need to be written to `/dev/audio` as a series of "frames" (in MPEG terminology) or multi-channel samples with the following format:
+`/dev/audio` is the directory for the system audio devices. Currently, there are only output devices, so every device file in the directory is an output channel. These channels are numbered, with `/dev/audio/0` being the first channel of the first device. To get the audio device to play audio, PCM samples need to be written to it as a series of "frames" (in MPEG terminology) or multi-channel samples with the following format:
 
 | Byte | 0-1 | 2-3 |
 |--|:--:|:--:|
@@ -19,3 +19,7 @@ Note that for convenience, the audio device may not block the call to `write` an
 
 * `SOUNDCARD_IOCTL_GET_SAMPLE_RATE`: Passes the current device sample rate (in samples per second) into a provided `u16*` (16-bit unsigned integer pointer).
 * `SOUNDCARD_IOCTL_SET_SAMPLE_RATE`: Sets the sample rate of the underlying hardware from a provided 16-bit unsigned integer. Note that not all sound cards support all sample rate and the actually achieved sample rate should be checked with the GET_SAMPLE_RATE ioctl.
+
+## See also
+
+* [Audio-subsystem](help://man/7/Audio-subsystem)

--- a/Base/usr/share/man/man7/Audio-subsystem.md
+++ b/Base/usr/share/man/man7/Audio-subsystem.md
@@ -10,7 +10,7 @@ SerenityOS structures audio into three groups of responsibilities: Audio drivers
 
 ### AudioServer
 
-AudioServer is responsible for handling userland audio clients and talking to the hardware. For this reason, no userland application should ever need to write to `/dev/audio` directly, except for special cases in which AudioServer is not present.
+AudioServer is responsible for handling userland audio clients and talking to the hardware. For this reason, no userland application should ever need to write to a device in `/dev/audio` directly, except for special cases in which AudioServer is not present.
 
 As with all system servers, AudioServer provides an IPC interface on `/tmp/portal/audio`. For specifics on how to talk to AudioServer, the IPC interface specifications are the best source of information. Audio clients send audio buffers with the standard audio format (see [audio](help://man/4/audio)) to the server. They can then query the state of these buffers, pause buffer playback or clear the playing buffers. For controlling mixer functionality, clients have the ability to obtain and change their own volume, or the main volume and mute state.
 

--- a/Base/usr/share/man/man7/Audio-subsystem.md
+++ b/Base/usr/share/man/man7/Audio-subsystem.md
@@ -35,7 +35,7 @@ LibDSP was started to support development efforts in Piano, but it is intended a
 This is a non-exhaustive list of applications that use audio. Most of these follow the good practices laid out in this manual page and may serve as a template for new audio applications.
 
 * **Piano** is a sequencer/tracker and synthesizer.
-* **aplay** is a command line audio file playback utility.
+* [**aplay**](help://man/1/aplay) is a command line audio file playback utility.
 * **SoundPlayer** is a UI audio file player with extra features such as playlist support and audio visualizations.
 * [**asctl**](help://man/1/asctl) is a command line audio server control utility.
 * **Applets/Audio** (AudioApplet) is a taskbar applet for setting audio parameters through a UI.


### PR DESCRIPTION
After #12445, the audio device documentation isn't up-to-date anymore, so let's fix that.

Additionally, this fixes a missing link to aplay in Audio-subsystem.