### PR TITLE
LibVT: Properly populate context menu with open actions

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -827,23 +827,21 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
     if (attribute.href_id != m_hovered_href_id) {
         if (m_active_href_id.is_null() || m_active_href_id == attribute.href_id) {
             m_hovered_href_id = attribute.href_id;
+            m_hovered_href = attribute.href;
+
             auto handlers = Desktop::Launcher::get_handlers_for_url(attribute.href);
             if (!handlers.is_empty()) {
                 auto path = URL(attribute.href).path();
                 auto name = LexicalPath::basename(path);
-                if (path == handlers[0]) {
-                    m_hovered_href = String::formatted("Execute {}", name);
-                } else {
-                    m_hovered_href = String::formatted("Open {} with {}", name, LexicalPath::basename(handlers[0]));
-                }
-            } else {
-                m_hovered_href = attribute.href;
+                if (path == handlers[0])
+                    set_tooltip(String::formatted("Execute {}", name));
+                else
+                    set_tooltip(String::formatted("Open {} with {}", name, LexicalPath::basename(handlers[0])));
             }
         } else {
             m_hovered_href_id = {};
             m_hovered_href = {};
         }
-        set_tooltip(m_hovered_href);
         show_or_hide_tooltip();
         if (!m_hovered_href.is_empty())
             set_override_cursor(Gfx::StandardCursor::Arrow);


### PR DESCRIPTION
We would previously overwrite m_hovered_href with tooltip texts instead of leaving it as an url as was expected by the context menu event handler.

This makes context menus work just fine again :^)

![image](https://user-images.githubusercontent.com/42888162/154457851-3dfe512c-34de-43a7-ac61-501fe13e80b9.png)
