### PR TITLE
Kernel: Add 'RegisterState' & 'KString::try_create' stubs for aarch64

### DIFF
--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -6,5 +6,8 @@
 
 #pragma once
 
+struct RegisterState {
+};
+
 struct DebugRegisterState {
 };

--- a/Kernel/Arch/aarch64/dummy.cpp
+++ b/Kernel/Arch/aarch64/dummy.cpp
@@ -45,6 +45,7 @@ void dump_backtrace(PrintToScreen) { }
 
 // KString.cpp
 ErrorOr<NonnullOwnPtr<KString>> KString::try_create_uninitialized(size_t, char*&) { return ENOMEM; }
+ErrorOr<NonnullOwnPtr<KString>> KString::try_create(StringView) { return ENOMEM; }
 void KString::operator delete(void*) { }
 
 // SafeMem.h


### PR DESCRIPTION
The aarch64 build was broken due to missing these two things, this commit adds two empty stubs for them