### PR TITLE
Browser: Search highlighting browser inspector

### DIFF
--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -162,12 +162,15 @@ void InspectorWidget::load_style_json(String specified_values_json, String compu
 {
     m_selection_specified_values_json = specified_values_json;
     m_style_table_view->set_model(Web::StylePropertiesModel::create(m_selection_specified_values_json.value().view()));
+    m_style_table_view->set_searchable(true);
 
     m_selection_computed_values_json = computed_values_json;
     m_computed_style_table_view->set_model(Web::StylePropertiesModel::create(m_selection_computed_values_json.value().view()));
+    m_computed_style_table_view->set_searchable(true);
 
     m_selection_custom_properties_json = custom_properties_json;
     m_custom_properties_table_view->set_model(Web::StylePropertiesModel::create(m_selection_custom_properties_json.value().view()));
+    m_custom_properties_table_view->set_searchable(true);
 }
 
 void InspectorWidget::update_node_box_model(Optional<String> node_box_sizing_json)

--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -613,6 +613,7 @@ void AbstractView::keydown_event(KeyEvent& event)
                 m_highlighted_search = sb.to_string();
                 highlight_search(index);
                 start_highlighted_search_timer();
+                set_cursor(index, SelectionUpdate::None, true);
             }
 
             event.accept();

--- a/Userland/Libraries/LibWeb/StylePropertiesModel.cpp
+++ b/Userland/Libraries/LibWeb/StylePropertiesModel.cpp
@@ -56,4 +56,21 @@ GUI::Variant StylePropertiesModel::data(GUI::ModelIndex const& index, GUI::Model
     return {};
 }
 
+Vector<GUI::ModelIndex> StylePropertiesModel::matches(StringView searching, unsigned flags, GUI::ModelIndex const& parent)
+{
+    if (m_values.is_empty())
+        return {};
+    Vector<GUI::ModelIndex> found_indices;
+    for (auto it = m_values.begin(); !it.is_end(); ++it) {
+        GUI::ModelIndex index = this->index(it.index(), Column::PropertyName, parent);
+        if (!string_matches(data(index, GUI::ModelRole::Display).as_string(), searching, flags))
+            continue;
+
+        found_indices.append(index);
+        if (flags & FirstMatchOnly)
+            break;
+    }
+    return found_indices;
+}
+
 }

--- a/Userland/Libraries/LibWeb/StylePropertiesModel.h
+++ b/Userland/Libraries/LibWeb/StylePropertiesModel.h
@@ -33,6 +33,8 @@ public:
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int) const override;
     virtual GUI::Variant data(GUI::ModelIndex const&, GUI::ModelRole) const override;
+    virtual bool is_searchable() const override { return true; }
+    virtual Vector<GUI::ModelIndex> matches(StringView, unsigned flags, GUI::ModelIndex const&) override;
 
 private:
     explicit StylePropertiesModel(JsonObject);


### PR DESCRIPTION
Hi there, second commit here :) 

This PR allows users to more easily navigate through the inspector window in the browser by allowing searching for style properties that they know the name of. 
This works in all the 3 tabs, styles, computed, variables on the first column. 

Also modified AbstractView to always set the cursor to the found result of the search_highlighter. This feels more natural and is especially noticeable in the File Manager. 
Here it allows a user to select a top level folder and then start typing 'var' which selects the var folder. It now allows you to press enter and actually open that folder. Also, using the arrow keys will now be relative to the found folder instead of the previously selected one. 