### PR TITLE
Kernel: Lock socket Mutex when servicing IPv4Socket ioctls

### DIFF
--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -609,6 +609,8 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
 {
     TRY(Process::current().require_promise(Pledge::inet));
 
+    MutexLocker locker(mutex());
+
     auto ioctl_route = [request, arg]() -> ErrorOr<void> {
         auto user_route = static_ptr_cast<rtentry*>(arg);
         rtentry route;


### PR DESCRIPTION
This prevents a kernel panic found in CI when m_receive_queue's size is
queried and found to be non-zero, then a different thread clears the
queue, and finally the first thread continues into the if block and
calls the queue's first() method, which then fails an assertion that
the queue's size is non-zero.