### PR TITLE
tar: Automatically recognize gzip archives

### DIFF
--- a/Base/usr/share/man/man1/tar.md
+++ b/Base/usr/share/man/man1/tar.md
@@ -5,7 +5,7 @@ tar - file archiving utility
 ## Synopsis
 
 ```**sh
-$ tar [--create] [--extract] [--list] [--verbose] [--gzip] [--file FILE] [PATHS...]
+$ tar [--create] [--extract] [--list] [--verbose] [--gzip] [--directory DIRECTORY] [--file FILE] [PATHS...]
 ```
 
 ## Description
@@ -21,8 +21,9 @@ Files may also be compressed and decompressed using GNU Zip (GZIP) compression.
 * `-x`, `--extract`: Extract archive
 * `-t`, `--list`: List contents
 * `-v`, `--verbose`: Print paths
-* `-z`, `--gzip`: compress or uncompress file using gzip
-* `-f`, `--file`: Archive file
+* `-z`, `--gzip`: Compress or decompress file using gzip
+* `-C DIRECTORY`, `--directory DIRECTORY`: Directory to extract to/create from
+* `-f FILE`, `--file FILE`: Archive file
 
 ## Examples
 

--- a/Base/usr/share/man/man1/tar.md
+++ b/Base/usr/share/man/man1/tar.md
@@ -5,7 +5,7 @@ tar - file archiving utility
 ## Synopsis
 
 ```**sh
-$ tar [--create] [--extract] [--list] [--verbose] [--gzip] [--directory DIRECTORY] [--file FILE] [PATHS...]
+$ tar [--create] [--extract] [--list] [--verbose] [--gzip] [--no-auto-compress] [--directory DIRECTORY] [--file FILE] [PATHS...]
 ```
 
 ## Description
@@ -22,6 +22,7 @@ Files may also be compressed and decompressed using GNU Zip (GZIP) compression.
 * `-t`, `--list`: List contents
 * `-v`, `--verbose`: Print paths
 * `-z`, `--gzip`: Compress or decompress file using gzip
+* `--no-auto-compress`: Do not use the archive suffix to select the compression algorithm
 * `-C DIRECTORY`, `--directory DIRECTORY`: Directory to extract to/create from
 * `-f FILE`, `--file FILE`: Archive file
 


### PR DESCRIPTION
"Normal" `tar` automatically uses gzip compression/decompression when the filename ends in `.gz`, so ours should too for compatibility reasons.

While we're at it, add the other forgotten flags to the manpage as well.