### PR TITLE
Ports: Enable OpenSSL support for CMake

### DIFF
--- a/Ports/cmake/package.sh
+++ b/Ports/cmake/package.sh
@@ -4,8 +4,8 @@ version=3.22.1
 useconfigure=true
 files="https://github.com/Kitware/CMake/releases/download/v$version/cmake-$version.tar.gz cmake-$version.tar.gz 0e998229549d7b3f368703d20e248e7ee1f853910d42704aa87918c213ea82c0"
 auth_type=sha256
-depends=("bash" "make" "sed" "ncurses" "libuv")
-configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-DCMAKE_USE_SYSTEM_LIBRARY_LIBUV=1" "-GNinja")
+depends=("bash" "make" "sed" "ncurses" "libuv" "openssl")
+configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt" "-DCMAKE_USE_SYSTEM_LIBRARY_LIBUV=1" "-DCMAKE_USE_OPENSSL=ON" "-GNinja")
 
 configure() {
     run cmake "${configopts[@]}" .


### PR DESCRIPTION
We need this to download files via HTTPS.