### PR TITLE
Userland: Dynamically update the MonitorSettingsWidget dialog revert countdown timer

### DIFF
--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -55,6 +55,12 @@ int MessageBox::ask_about_unsaved_changes(Window* parent_window, StringView path
     return box->exec();
 }
 
+void MessageBox::set_text(String text)
+{
+    m_text = move(text);
+    build();
+}
+
 MessageBox::MessageBox(Window* parent_window, StringView text, StringView title, Type type, InputType input_type)
     : Dialog(parent_window)
     , m_text(text)

--- a/Userland/Libraries/LibGUI/MessageBox.h
+++ b/Userland/Libraries/LibGUI/MessageBox.h
@@ -35,6 +35,8 @@ public:
     static int show_error(Window* parent_window, StringView text);
     static int ask_about_unsaved_changes(Window* parent_window, StringView path, Optional<Time> last_unmodified_timestamp = {});
 
+    void set_text(String text);
+
 private:
     explicit MessageBox(Window* parent_window, StringView text, StringView title, Type type = Type::None, InputType input_type = InputType::OK);
 


### PR DESCRIPTION
This causes the number of seconds in "Do you want to keep the new settings? They will be reverted after 10 seconds." to be dynamically updated.
![image](https://user-images.githubusercontent.com/12155595/154588449-9172a870-7b14-4df4-a43e-d10c196004ec.png)
