### PR TITLE
LibWeb: Reflect only known values for <input> element's type attribute

### DIFF
--- a/Base/res/html/misc/input.html
+++ b/Base/res/html/misc/input.html
@@ -1,0 +1,71 @@
+<p>
+    <input type="hidden" id="hidden" value="hidden" /><br />
+    <input type="text" id="text" value="text" /><br />
+    <input type="search" id="search" value="search" /><br />
+    <input type="tel" id="tel" value="tel" /><br />
+    <input type="url" id="url" value="url" /><br />
+    <input type="email" id="email" value="email" /><br />
+    <input type="password" id="password" value="password" /><br />
+    <input type="date" id="date" value="date" /><br />
+    <input type="month" id="month" value="month" /><br />
+    <input type="week" id="week" value="week" /><br />
+    <input type="time" id="time" value="time" /><br />
+    <input type="datetime-local" id="datetime-local" value="datetime-local" /><br />
+    <input type="number" id="number" value="number" /><br />
+    <input type="range" id="range" value="range" /><br />
+    <input type="color" id="color" value="color" /><br />
+    <input type="checkbox" id="checkbox" value="checkbox" /><br />
+    <input type="radio" id="radio" value="radio" /><br />
+    <input type="file" id="file" value="file" /><br />
+    <input type="submit" id="submit" value="submit" /><br />
+    <input type="image" id="image" value="image" /><br />
+    <input type="reset" id="reset" value="reset" /><br />
+    <input type="button" id="button" value="button" /><br />
+
+    <input type="invalid" id="invalid" value="invalid" /><br />
+</p>
+
+<script>
+    var ids = [
+        "hidden",
+        "text",
+        "search",
+        "tel",
+        "url",
+        "email",
+        "password",
+        "date",
+        "month",
+        "week",
+        "time",
+        "datetime-local",
+        "number",
+        "range",
+        "color",
+        "checkbox",
+        "radio",
+        "file",
+        "submit",
+        "image",
+        "reset",
+        "button",
+        "invalid",
+    ];
+    document.addEventListener("DOMContentLoaded", function() {
+        for (var i = 0; i < ids.length; i++) {
+            var id = ids[i];
+            var e = document.getElementById(id);
+            console.log("id=", id, "type=", e.type);
+        }
+
+        var e = document.getElementById("invalid");
+        e.type = "invalid2"
+        console.log("after change type=", e.type);
+
+        e.type = "number"
+        console.log("after change 2 type=", e.type);
+        e.value = "123abc456"
+        console.log("after value change value=", e.value);
+
+    });
+</script>

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -211,10 +211,21 @@ ol ol ul {
 }
 
 /* FIXME: This is a temporary hack until we can render a native-looking frame for these. */
-input[type=text] {
+input {
     border: 1px solid black;
     min-width: 80px;
     min-height: 16px;
+    width: 120px;
+    cursor: text;
+    overflow: hidden;
+}
+
+input[type=submit], input[type=button], input[type=reset], input[type=checkbox], input[type=radio] {
+    border: none;
+    min-width: unset;
+    min-height: unset;
+    width: unset;
+    cursor: unset;
 }
 
 option {

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -34,7 +34,7 @@ void HTMLInputElement::did_click_button(Badge<Layout::ButtonBox>)
     // FIXME: This should be a PointerEvent.
     dispatch_event(DOM::Event::create(EventNames::click));
 
-    if (type().equals_ignoring_case("submit")) {
+    if (type() == "submit") {
         if (auto* form = first_ancestor_of_type<HTMLFormElement>()) {
             form->submit_form(this);
         }
@@ -55,7 +55,7 @@ RefPtr<Layout::Node> HTMLInputElement::create_layout_node(NonnullRefPtr<CSS::Sty
     if (type() == "hidden")
         return nullptr;
 
-    if (type().equals_ignoring_case("submit") || type().equals_ignoring_case("button"))
+    if (type() == "submit" || type() == "button" || type() == "reset")
         return adopt_ref(*new Layout::ButtonBox(document(), *this, move(style)));
 
     if (type() == "checkbox")
@@ -101,7 +101,7 @@ void HTMLInputElement::run_activation_behavior()
 // https://html.spec.whatwg.org/multipage/input.html#input-activation-behavior
 void HTMLInputElement::run_input_activation_behavior()
 {
-    if (type().equals_ignoring_case("checkbox")) {
+    if (type() == "checkbox") {
         // 1. If the element is not connected, then return.
         if (!is_connected())
             return;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Adam Hodgen <ant1441@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -229,11 +230,18 @@ void HTMLInputElement::did_remove_attribute(FlyString const& name)
 
 String HTMLInputElement::type() const
 {
-    // FIXME: This should only reflect known values.
     auto value = attribute(HTML::AttributeNames::type);
-    if (value.is_null())
-        return "text";
-    return value;
+
+#define __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(keyword) \
+    if (value.equals_ignoring_case(#keyword))          \
+        return #keyword;
+    ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTES
+#undef __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE
+
+    // The missing value default and the invalid value default are the Text state.
+    // https://html.spec.whatwg.org/multipage/input.html#the-input-element:missing-value-default
+    // https://html.spec.whatwg.org/multipage/input.html#the-input-element:invalid-value-default
+    return "text";
 }
 
 void HTMLInputElement::set_type(String const& type)

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Adam Hodgen <ant1441@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,6 +11,31 @@
 #include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
+
+// https://html.spec.whatwg.org/multipage/input.html#attr-input-type
+#define ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTES                \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(hidden)           \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(text)             \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(search)           \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(tel)              \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(url)              \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(email)            \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(password)         \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(date)             \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(month)            \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(week)             \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(time)             \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE("datetime-local") \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(number)           \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(range)            \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(color)            \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(checkbox)         \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(radio)            \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(file)             \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(submit)           \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(image)            \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(reset)            \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(button)
 
 class HTMLInputElement final : public FormAssociatedElement {
 public:

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -13,29 +13,29 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/input.html#attr-input-type
-#define ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTES                \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(hidden)           \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(text)             \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(search)           \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(tel)              \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(url)              \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(email)            \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(password)         \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(date)             \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(month)            \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(week)             \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(time)             \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE("datetime-local") \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(number)           \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(range)            \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(color)            \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(checkbox)         \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(radio)            \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(file)             \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(submit)           \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(image)            \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(reset)            \
-    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(button)
+#define ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTES                                  \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(hidden, Hidden)                     \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(text, Text)                         \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(search, Search)                     \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(tel, Telephone)                     \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(url, URL)                           \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(email, Email)                       \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(password, Password)                 \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(date, Date)                         \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(month, Month)                       \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(week, Week)                         \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(time, Time)                         \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE("datetime-local", LocalDateAndTime) \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(number, Number)                     \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(range, Range)                       \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(color, Color)                       \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(checkbox, Checkbox)                 \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(radio, RadioButton)                 \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(file, FileUpload)                   \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(submit, SubmitButton)               \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(image, ImageButton)                 \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(reset, ResetButton)                 \
+    __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(button, Button)
 
 class HTMLInputElement final : public FormAssociatedElement {
 public:
@@ -46,7 +46,14 @@ public:
 
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 
+    enum TypeAttributeState {
+#define __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(_, state) state,
+        ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTES
+#undef __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE
+    };
+
     String type() const;
+    TypeAttributeState type_state() const;
     void set_type(String const&);
 
     String default_value() const { return attribute(HTML::AttributeNames::value); }
@@ -89,6 +96,9 @@ private:
 
     void create_shadow_tree_if_needed();
     void run_input_activation_behavior();
+
+    // https://html.spec.whatwg.org/multipage/input.html#value-sanitization-algorithm
+    String value_sanitization_algorithm(String) const;
 
     RefPtr<DOM::Text> m_text_node;
     bool m_checked { false };


### PR DESCRIPTION
As per the spec, reflect only the known values for the `<input>` element's `type` attribute.

Also improve the rendering for text control `<input>` elements other than just `type=text`
by increasing the `type`s matched in `Default.css`.

And add an implementation of the value sanitization algorithm for several input `type`s.