### PR TITLE
LibWeb: Avoid crashes if browsing context container is missing

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -740,7 +740,7 @@ void Node::serialize_tree_as_json(JsonObjectSerializer<StringBuilder>& object) c
 
         if (element->is_browsing_context_container()) {
             auto const* container = static_cast<HTML::BrowsingContextContainer const*>(element);
-            if (auto const* content_document = container->content_document()) {
+            if (auto const* content_document = container->content_document_without_origin_check()) {
                 auto children = object.add_array("children");
                 JsonObjectSerializer<StringBuilder> content_document_object = children.add_object();
                 content_document->serialize_tree_as_json(content_document_object);


### PR DESCRIPTION
Having an iframe on the page will cause Browser to crash upon
running "Inspect Dom Element" and causes Text Editor to crash immediately
due to the failed VERIFY calls.  Returning before the VERIFY
prevents the crashes, though it does fix the root issue.

To test: Just add `<iframe></iframe>` to an html file.  If you open in Text Editor it would crash immediately and in Browser it crashes when running "Inspect DOM Element".

Honestly I'm not sure if this is the right solution, but these changes allow Browser/Text Editor to not crash, which seems better to me, but I may be missing something.