### PR TITLE
Kernel: Don't enable write-combine for the Bochs framebuffer device

### DIFF
--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -127,6 +127,8 @@ UNMAP_AFTER_INIT void BochsGraphicsAdapter::initialize_framebuffer_devices()
 {
     // FIXME: Find a better way to determine default resolution...
     m_framebuffer_device = FramebufferDevice::create(*this, PhysicalAddress(PCI::get_BAR0(pci_address()) & 0xfffffff0), 1024, 768, 1024 * sizeof(u32));
+    // While write-combine helps greatly on actual hardware, it greatly reduces performance in QEMU
+    m_framebuffer_device->enable_write_combine(false);
     // FIXME: Would be nice to be able to return a ErrorOr<void> here.
     VERIFY(!m_framebuffer_device->try_to_initialize().is_error());
 }

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -59,8 +59,10 @@ ErrorOr<Memory::Region*> FramebufferDevice::mmap(Process& process, OpenFileDescr
         "Framebuffer",
         prot,
         shared));
-    if (auto result = m_userspace_framebuffer_region->set_write_combine(true); result.is_error())
-        dbgln("FramebufferDevice: Failed to enable Write-Combine on Framebuffer: {}", result.error());
+    if (m_write_combine) {
+        if (auto result = m_userspace_framebuffer_region->set_write_combine(true); result.is_error())
+            dbgln("FramebufferDevice: Failed to enable Write-Combine on Framebuffer: {}", result.error());
+    }
     return m_userspace_framebuffer_region;
 }
 

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -42,6 +42,8 @@ public:
 
     virtual ErrorOr<ByteBuffer> get_edid(size_t head) const override;
 
+    void enable_write_combine(bool write_combine) { m_write_combine = write_combine; }
+
 private:
     virtual ErrorOr<void> set_head_resolution(size_t head, size_t width, size_t height, size_t pitch) override;
     virtual ErrorOr<void> set_head_buffer(size_t head, bool second_buffer) override;
@@ -64,6 +66,7 @@ private:
     OwnPtr<Memory::Region> m_swapped_framebuffer_region;
 
     bool m_graphical_writes_enabled { true };
+    bool m_write_combine { true };
 
     RefPtr<Memory::AnonymousVMObject> m_userspace_real_framebuffer_vmobject;
     Memory::Region* m_userspace_framebuffer_region { nullptr };


### PR DESCRIPTION
While write-combine greatly improves performance on bare metal, QEMU
appears to perform significantly worse when enabling it.

_I noticed that lately moving a window around seemed to consume a lot of CPU in QEMU. Turns out QEMU doesn't like write-combine enabled..._