### PR TITLE
Utilities/nc : Add support to -I/--length option to set maximum recei…

### DIFF
--- a/Base/usr/share/man/man1/nc.md
+++ b/Base/usr/share/man/man1/nc.md
@@ -5,7 +5,7 @@ nc
 ## Synopsis
 
 ```sh
-$ nc [--listen] [--verbose] [--udp] [-N] <target> <port>
+$ nc [--listen] [--verbose] [--udp] [-N] [--length ] <target> <port>
 ```
 
 ## Description
@@ -20,6 +20,7 @@ Network cat: Connect to network sockets as if it were a file.
 * `-v`, `--verbose`: Log everything that's happening
 * `-u`, `--udp`: UDP mode
 * `-N`: Close connection after reading stdin to the end
+* `-I`, `--length`: Set maximum tcp receive buffer size
 
 ## Arguments:
 


### PR DESCRIPTION
I wanted to enhance the `netcat` utility with the option of `-I length`. Below is the test result for an edge test case to check the lower and upper bounds. 

![image](https://user-images.githubusercontent.com/28380956/153344104-73e8b87d-6d4e-4c98-9149-215e5299992a.png)