### PR TITLE
LibJS: Add a spec link for Iterator Records

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Iterator.h
+++ b/Userland/Libraries/LibJS/Runtime/Iterator.h
@@ -11,7 +11,7 @@
 
 namespace JS {
 
-// Iterator Record
+// 7.4.1 Iterator Records, https://tc39.es/ecma262/#sec-iterator-records
 struct Iterator {
     Object* iterator { nullptr }; // [[Iterator]]
     Value next_method;            // [[NextMethod]]

--- a/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorOperations.cpp
@@ -14,7 +14,7 @@
 
 namespace JS {
 
-// 7.4.1 GetIterator ( obj [ , hint [ , method ] ] ), https://tc39.es/ecma262/#sec-getiterator
+// 7.4.2 GetIterator ( obj [ , hint [ , method ] ] ), https://tc39.es/ecma262/#sec-getiterator
 ThrowCompletionOr<Iterator> get_iterator(GlobalObject& global_object, Value value, IteratorHint hint, Optional<Value> method)
 {
     auto& vm = global_object.vm();
@@ -69,7 +69,7 @@ ThrowCompletionOr<Iterator> get_iterator(GlobalObject& global_object, Value valu
     return iterator_record;
 }
 
-// 7.4.2 IteratorNext ( iteratorRecord [ , value ] ), https://tc39.es/ecma262/#sec-iteratornext
+// 7.4.3 IteratorNext ( iteratorRecord [ , value ] ), https://tc39.es/ecma262/#sec-iteratornext
 ThrowCompletionOr<Object*> iterator_next(GlobalObject& global_object, Iterator const& iterator_record, Optional<Value> value)
 {
     auto& vm = global_object.vm();
@@ -93,7 +93,7 @@ ThrowCompletionOr<Object*> iterator_next(GlobalObject& global_object, Iterator c
     return &result.as_object();
 }
 
-// 7.4.3 IteratorComplete ( iterResult ), https://tc39.es/ecma262/#sec-iteratorcomplete
+// 7.4.4 IteratorComplete ( iterResult ), https://tc39.es/ecma262/#sec-iteratorcomplete
 ThrowCompletionOr<bool> iterator_complete(GlobalObject& global_object, Object& iterator_result)
 {
     auto& vm = global_object.vm();
@@ -102,7 +102,7 @@ ThrowCompletionOr<bool> iterator_complete(GlobalObject& global_object, Object& i
     return TRY(iterator_result.get(vm.names.done)).to_boolean();
 }
 
-// 7.4.4 IteratorValue ( iterResult ), https://tc39.es/ecma262/#sec-iteratorvalue
+// 7.4.5 IteratorValue ( iterResult ), https://tc39.es/ecma262/#sec-iteratorvalue
 ThrowCompletionOr<Value> iterator_value(GlobalObject& global_object, Object& iterator_result)
 {
     auto& vm = global_object.vm();
@@ -111,7 +111,7 @@ ThrowCompletionOr<Value> iterator_value(GlobalObject& global_object, Object& ite
     return TRY(iterator_result.get(vm.names.value));
 }
 
-// 7.4.5 IteratorStep ( iteratorRecord ), https://tc39.es/ecma262/#sec-iteratorstep
+// 7.4.6 IteratorStep ( iteratorRecord ), https://tc39.es/ecma262/#sec-iteratorstep
 ThrowCompletionOr<Object*> iterator_step(GlobalObject& global_object, Iterator const& iterator_record)
 {
     // 1. Let result be ? IteratorNext(iteratorRecord).
@@ -128,8 +128,8 @@ ThrowCompletionOr<Object*> iterator_step(GlobalObject& global_object, Iterator c
     return result;
 }
 
-// 7.4.6 IteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-iteratorclose
-// 7.4.8 AsyncIteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-asynciteratorclose
+// 7.4.7 IteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-iteratorclose
+// 7.4.9 AsyncIteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-asynciteratorclose
 // NOTE: These only differ in that async awaits the inner value after the call.
 static Completion iterator_close_impl(GlobalObject& global_object, Iterator const& iterator_record, Completion completion, IteratorHint iterator_hint)
 {
@@ -181,19 +181,19 @@ static Completion iterator_close_impl(GlobalObject& global_object, Iterator cons
     return completion;
 }
 
-// 7.4.6 IteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-iteratorclose
+// 7.4.7 IteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-iteratorclose
 Completion iterator_close(GlobalObject& global_object, Iterator const& iterator_record, Completion completion)
 {
     return iterator_close_impl(global_object, iterator_record, move(completion), IteratorHint::Sync);
 }
 
-// 7.4.8 AsyncIteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-asynciteratorclose
+// 7.4.9 AsyncIteratorClose ( iteratorRecord, completion ), https://tc39.es/ecma262/#sec-asynciteratorclose
 Completion async_iterator_close(GlobalObject& global_object, Iterator const& iterator_record, Completion completion)
 {
     return iterator_close_impl(global_object, iterator_record, move(completion), IteratorHint::Async);
 }
 
-// 7.4.9 CreateIterResultObject ( value, done ), https://tc39.es/ecma262/#sec-createiterresultobject
+// 7.4.10 CreateIterResultObject ( value, done ), https://tc39.es/ecma262/#sec-createiterresultobject
 Object* create_iterator_result_object(GlobalObject& global_object, Value value, bool done)
 {
     auto& vm = global_object.vm();
@@ -211,7 +211,7 @@ Object* create_iterator_result_object(GlobalObject& global_object, Value value, 
     return object;
 }
 
-// 7.4.11 IterableToList ( items [ , method ] ), https://tc39.es/ecma262/#sec-iterabletolist
+// 7.4.12 IterableToList ( items [ , method ] ), https://tc39.es/ecma262/#sec-iterabletolist
 ThrowCompletionOr<MarkedVector<Value>> iterable_to_list(GlobalObject& global_object, Value iterable, Optional<Value> method)
 {
     auto& vm = global_object.vm();


### PR DESCRIPTION
This is an editorial change to the spec to strongly define this record:
https://github.com/tc39/ecma262/commit/85d910c