### PR TITLE
LibWeb: Undefine undefined lengths

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -108,12 +108,12 @@ public:
     CSS::JustifyContent justify_content() const { return m_noninherited.justify_content; }
     Vector<BoxShadowData> const& box_shadow() const { return m_noninherited.box_shadow; }
     CSS::BoxSizing box_sizing() const { return m_noninherited.box_sizing; }
-    CSS::LengthPercentage const& width() const { return m_noninherited.width; }
-    CSS::LengthPercentage const& min_width() const { return m_noninherited.min_width; }
-    CSS::LengthPercentage const& max_width() const { return m_noninherited.max_width; }
-    CSS::LengthPercentage const& height() const { return m_noninherited.height; }
-    CSS::LengthPercentage const& min_height() const { return m_noninherited.min_height; }
-    CSS::LengthPercentage const& max_height() const { return m_noninherited.max_height; }
+    Optional<CSS::LengthPercentage> const& width() const { return m_noninherited.width; }
+    Optional<CSS::LengthPercentage> const& min_width() const { return m_noninherited.min_width; }
+    Optional<CSS::LengthPercentage> const& max_width() const { return m_noninherited.max_width; }
+    Optional<CSS::LengthPercentage> const& height() const { return m_noninherited.height; }
+    Optional<CSS::LengthPercentage> const& min_height() const { return m_noninherited.min_height; }
+    Optional<CSS::LengthPercentage> const& max_height() const { return m_noninherited.max_height; }
 
     const CSS::LengthBox& offset() const { return m_noninherited.offset; }
     const CSS::LengthBox& margin() const { return m_noninherited.margin; }
@@ -174,12 +174,12 @@ protected:
         CSS::TextDecorationLine text_decoration_line { InitialValues::text_decoration_line() };
         CSS::TextDecorationStyle text_decoration_style { InitialValues::text_decoration_style() };
         CSS::Position position { InitialValues::position() };
-        CSS::LengthPercentage width { Length::make_auto() };
-        CSS::LengthPercentage min_width { Length::make_auto() };
-        CSS::LengthPercentage max_width { Length::make_auto() };
-        CSS::LengthPercentage height { Length::make_auto() };
-        CSS::LengthPercentage min_height { Length::make_auto() };
-        CSS::LengthPercentage max_height { Length::make_auto() };
+        Optional<CSS::LengthPercentage> width;
+        Optional<CSS::LengthPercentage> min_width;
+        Optional<CSS::LengthPercentage> max_width;
+        Optional<CSS::LengthPercentage> height;
+        Optional<CSS::LengthPercentage> min_height;
+        Optional<CSS::LengthPercentage> max_height;
         CSS::LengthBox offset;
         CSS::LengthBox margin;
         CSS::LengthBox padding;

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -77,10 +77,10 @@ struct FlexBasisData {
 
 struct BoxShadowData {
     Color color {};
-    CSS::Length offset_x {};
-    CSS::Length offset_y {};
-    CSS::Length blur_radius {};
-    CSS::Length spread_distance {};
+    CSS::Length offset_x { Length::make_px(0) };
+    CSS::Length offset_y { Length::make_px(0) };
+    CSS::Length blur_radius { Length::make_px(0) };
+    CSS::Length spread_distance { Length::make_px(0) };
     CSS::BoxShadowPlacement placement { CSS::BoxShadowPlacement::Outer };
 };
 

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -57,25 +57,13 @@ Length Length::percentage_of(Percentage const& percentage) const
     return Length { percentage.as_fraction() * raw_value(), m_type };
 }
 
-Length Length::resolved(Length const& fallback_for_undefined, Layout::Node const& layout_node) const
+Length Length::resolved(Layout::Node const& layout_node) const
 {
-    if (is_undefined())
-        return fallback_for_undefined;
     if (is_calculated())
         return m_calculated_style->resolve_length(layout_node).release_value();
     if (is_relative())
         return make_px(to_px(layout_node));
     return *this;
-}
-
-Length Length::resolved_or_auto(Layout::Node const& layout_node) const
-{
-    return resolved(make_auto(), layout_node);
-}
-
-Length Length::resolved_or_zero(Layout::Node const& layout_node) const
-{
-    return resolved(make_px(0), layout_node);
 }
 
 float Length::relative_length_to_px(Gfx::IntRect const& viewport_rect, Gfx::FontMetrics const& font_metrics, float root_font_size) const

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -18,7 +18,6 @@
 
 namespace Web::CSS {
 
-Length::Length() = default;
 Length::Length(int value, Type type)
     : m_type(type)
     , m_value(value)
@@ -49,8 +48,8 @@ Length Length::make_calculated(NonnullRefPtr<CalculatedStyleValue> calculated_st
 
 Length Length::percentage_of(Percentage const& percentage) const
 {
-    if (is_undefined_or_auto()) {
-        dbgln("Attempting to get percentage of an undefined or auto length, this seems wrong? But for now we just return the original length.");
+    if (is_auto()) {
+        dbgln("Attempting to get percentage of an auto length, this seems wrong? But for now we just return the original length.");
         return *this;
     }
 
@@ -132,8 +131,6 @@ const char* Length::unit_name() const
         return "rem";
     case Type::Auto:
         return "auto";
-    case Type::Undefined:
-        return "undefined";
     case Type::Vh:
         return "vh";
     case Type::Vw:

--- a/Userland/Libraries/LibWeb/CSS/Length.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Length.cpp
@@ -93,6 +93,9 @@ float Length::relative_length_to_px(Gfx::IntRect const& viewport_rect, Gfx::Font
 
 float Length::to_px(Layout::Node const& layout_node) const
 {
+    if (is_calculated())
+        return m_calculated_style->resolve_length(layout_node)->to_px(layout_node);
+
     if (!layout_node.document().browsing_context())
         return 0;
     auto viewport_rect = layout_node.document().browsing_context()->viewport_rect();

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -86,6 +86,8 @@ public:
             return 0;
         if (is_relative())
             return relative_length_to_px(viewport_rect, font_metrics, root_font_size);
+        if (is_calculated())
+            VERIFY_NOT_REACHED(); // We can't resolve a calculated length from here. :^(
         return absolute_length_to_px();
     }
 

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -46,9 +46,7 @@ public:
     static Length make_calculated(NonnullRefPtr<CalculatedStyleValue>);
     Length percentage_of(Percentage const&) const;
 
-    Length resolved(Length const& fallback_for_undefined, Layout::Node const& layout_node) const;
-    Length resolved_or_auto(Layout::Node const& layout_node) const;
-    Length resolved_or_zero(Layout::Node const& layout_node) const;
+    Length resolved(Layout::Node const& layout_node) const;
 
     bool is_undefined_or_auto() const { return m_type == Type::Undefined || m_type == Type::Auto; }
     bool is_undefined() const { return m_type == Type::Undefined; }

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -15,7 +15,6 @@ namespace Web::CSS {
 class Length {
 public:
     enum class Type {
-        Undefined,
         Calculated,
         Auto,
         Cm,
@@ -37,7 +36,6 @@ public:
 
     // We have a RefPtr<CalculatedStyleValue> member, but can't include the header StyleValue.h as it includes
     // this file already. To break the cyclic dependency, we must move all method definitions out.
-    Length();
     Length(int value, Type type);
     Length(float value, Type type);
 
@@ -48,8 +46,6 @@ public:
 
     Length resolved(Layout::Node const& layout_node) const;
 
-    bool is_undefined_or_auto() const { return m_type == Type::Undefined || m_type == Type::Auto; }
-    bool is_undefined() const { return m_type == Type::Undefined; }
     bool is_auto() const { return m_type == Type::Auto; }
     bool is_calculated() const { return m_type == Type::Calculated; }
 
@@ -137,7 +133,7 @@ public:
 private:
     const char* unit_name() const;
 
-    Type m_type { Type::Undefined };
+    Type m_type;
     float m_value { 0 };
 
     RefPtr<CalculatedStyleValue> m_calculated_style;

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -536,25 +536,25 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return StyleValueList::create(move(box_shadow), StyleValueList::Separator::Comma);
     }
     case CSS::PropertyID::Width:
-        return style_value_for_length_percentage(layout_node.computed_values().width());
+        return style_value_for_length_percentage(layout_node.computed_values().width().value_or(Length::make_auto()));
     case CSS::PropertyID::MinWidth:
-        if (layout_node.computed_values().min_width().is_length() && layout_node.computed_values().min_width().length().is_undefined_or_auto())
+        if (!layout_node.computed_values().min_width().has_value())
             return IdentifierStyleValue::create(CSS::ValueID::Auto);
-        return style_value_for_length_percentage(layout_node.computed_values().min_width());
+        return style_value_for_length_percentage(layout_node.computed_values().min_width().value());
     case CSS::PropertyID::MaxWidth:
-        if (layout_node.computed_values().max_width().is_length() && layout_node.computed_values().max_width().length().is_undefined())
+        if (!layout_node.computed_values().max_width().has_value())
             return IdentifierStyleValue::create(CSS::ValueID::None);
-        return style_value_for_length_percentage(layout_node.computed_values().max_width());
+        return style_value_for_length_percentage(layout_node.computed_values().max_width().value());
     case CSS::PropertyID::Height:
-        return style_value_for_length_percentage(layout_node.computed_values().height());
+        return style_value_for_length_percentage(layout_node.computed_values().height().value_or(Length::make_auto()));
     case CSS::PropertyID::MinHeight:
-        if (layout_node.computed_values().min_height().is_length() && layout_node.computed_values().min_height().length().is_undefined_or_auto())
+        if (!layout_node.computed_values().min_height().has_value())
             return IdentifierStyleValue::create(CSS::ValueID::Auto);
-        return style_value_for_length_percentage(layout_node.computed_values().min_height());
+        return style_value_for_length_percentage(layout_node.computed_values().min_height().value());
     case CSS::PropertyID::MaxHeight:
-        if (layout_node.computed_values().max_height().is_length() && layout_node.computed_values().max_height().length().is_undefined())
+        if (!layout_node.computed_values().max_height().has_value())
             return IdentifierStyleValue::create(CSS::ValueID::None);
-        return style_value_for_length_percentage(layout_node.computed_values().max_height());
+        return style_value_for_length_percentage(layout_node.computed_values().max_height().value());
     case CSS::PropertyID::Margin: {
         auto margin = layout_node.computed_values().margin();
         auto values = NonnullRefPtrVector<StyleValue> {};

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -65,9 +65,14 @@ Length StyleProperties::length_or_fallback(CSS::PropertyID id, Length const& fal
 
 LengthPercentage StyleProperties::length_percentage_or_fallback(CSS::PropertyID id, LengthPercentage const& fallback) const
 {
+    return length_percentage(id).value_or(fallback);
+}
+
+Optional<LengthPercentage> StyleProperties::length_percentage(CSS::PropertyID id) const
+{
     auto maybe_value = property(id);
     if (!maybe_value.has_value())
-        return fallback;
+        return {};
     auto& value = maybe_value.value();
 
     if (value->is_calculated())
@@ -79,7 +84,7 @@ LengthPercentage StyleProperties::length_percentage_or_fallback(CSS::PropertyID 
     if (value->has_length())
         return value->to_length();
 
-    return fallback;
+    return {};
 }
 
 LengthBox StyleProperties::length_box(CSS::PropertyID left_id, CSS::PropertyID top_id, CSS::PropertyID right_id, CSS::PropertyID bottom_id, const CSS::Length& default_value) const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -131,7 +131,7 @@ float StyleProperties::line_height(Layout::Node const& layout_node) const
 
         if (line_height->is_length()) {
             auto line_height_length = line_height->to_length();
-            if (!line_height_length.is_undefined_or_auto())
+            if (!line_height_length.is_auto())
                 return line_height_length.to_px(layout_node);
         }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -41,6 +41,7 @@ public:
 
     Length length_or_fallback(CSS::PropertyID, Length const& fallback) const;
     LengthPercentage length_percentage_or_fallback(CSS::PropertyID, LengthPercentage const& fallback) const;
+    Optional<LengthPercentage> length_percentage(CSS::PropertyID) const;
     LengthBox length_box(CSS::PropertyID left_id, CSS::PropertyID top_id, CSS::PropertyID right_id, CSS::PropertyID bottom_id, const CSS::Length& default_value) const;
     Color color_or_fallback(CSS::PropertyID, Layout::NodeWithStyle const&, Color fallback) const;
     Optional<CSS::TextAlign> text_align() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -278,17 +278,17 @@ String BoxShadowStyleValue::to_string() const
     return builder.to_string();
 }
 
-void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, Length const& percentage_basis)
+void CalculatedStyleValue::CalculationResult::add(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Add, other, layout_node, percentage_basis);
 }
 
-void CalculatedStyleValue::CalculationResult::subtract(CalculationResult const& other, Layout::Node const* layout_node, Length const& percentage_basis)
+void CalculatedStyleValue::CalculationResult::subtract(CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     add_or_subtract_internal(SumOperation::Subtract, other, layout_node, percentage_basis);
 }
 
-void CalculatedStyleValue::CalculationResult::add_or_subtract_internal(SumOperation op, CalculationResult const& other, Layout::Node const* layout_node, Length const& percentage_basis)
+void CalculatedStyleValue::CalculationResult::add_or_subtract_internal(SumOperation op, CalculationResult const& other, Layout::Node const* layout_node, PercentageBasis const& percentage_basis)
 {
     // We know from validation when resolving the type, that "both sides have the same type, or that one side is a <number> and the other is an <integer>".
     // Though, having the same type may mean that one side is a <dimension> and the other a <percentage>.
@@ -318,9 +318,9 @@ void CalculatedStyleValue::CalculationResult::add_or_subtract_internal(SumOperat
                 else
                     m_value = Length::make_px(this_px - other_px);
             } else {
-                VERIFY(!percentage_basis.is_undefined());
+                VERIFY(percentage_basis.has<Length>());
 
-                auto other_px = percentage_basis.percentage_of(other.m_value.get<Percentage>()).to_px(*layout_node);
+                auto other_px = percentage_basis.get<Length>().percentage_of(other.m_value.get<Percentage>()).to_px(*layout_node);
                 if (op == SumOperation::Add)
                     m_value = Length::make_px(this_px + other_px);
                 else
@@ -712,7 +712,7 @@ Optional<CalculatedStyleValue::ResolvedType> CalculatedStyleValue::CalcNumberVal
         [](NonnullOwnPtr<CalcNumberSum> const& sum) { return sum->resolved_type(); });
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberValue::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberValue::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     return value.visit(
         [&](Number const& number) -> CalculatedStyleValue::CalculationResult {
@@ -723,7 +723,7 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberValue::r
         });
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcValue::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcValue::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     return value.visit(
         [&](Number const& number) -> CalculatedStyleValue::CalculationResult {
@@ -740,7 +740,7 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcValue::resolve
         });
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcSum::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcSum::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     auto value = first_calc_product->resolve(layout_node, percentage_basis);
 
@@ -758,7 +758,7 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcSum::resolve(L
     return value;
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberSum::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberSum::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     auto value = first_calc_number_product->resolve(layout_node, percentage_basis);
 
@@ -776,7 +776,7 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberSum::res
     return value;
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcProduct::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcProduct::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     auto value = first_calc_value.resolve(layout_node, percentage_basis);
 
@@ -799,7 +799,7 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcProduct::resol
     return value;
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberProduct::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberProduct::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     auto value = first_calc_number_value.resolve(layout_node, percentage_basis);
 
@@ -817,7 +817,7 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberProduct:
     return value;
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcProductPartWithOperator::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcProductPartWithOperator::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     return value.visit(
         [&](CalcValue const& calc_value) {
@@ -828,17 +828,17 @@ CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcProductPartWit
         });
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcSumPartWithOperator::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcSumPartWithOperator::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     return value->resolve(layout_node, percentage_basis);
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberProductPartWithOperator::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberProductPartWithOperator::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     return value.resolve(layout_node, percentage_basis);
 }
 
-CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberSumPartWithOperator::resolve(Layout::Node const* layout_node, Length const& percentage_basis) const
+CalculatedStyleValue::CalculationResult CalculatedStyleValue::CalcNumberSumPartWithOperator::resolve(Layout::Node const* layout_node, PercentageBasis const& percentage_basis) const
 {
     return value->resolve(layout_node, percentage_basis);
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -500,7 +500,6 @@ Optional<Length> CalculatedStyleValue::resolve_length(Layout::Node const& layout
 
 Optional<LengthPercentage> CalculatedStyleValue::resolve_length_percentage(Layout::Node const& layout_node, Length const& percentage_basis) const
 {
-    VERIFY(!percentage_basis.is_undefined());
     auto result = m_expression->resolve(&layout_node, percentage_basis);
 
     return result.value().visit(

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -406,7 +406,7 @@ public:
 
     virtual Color to_color(Layout::NodeWithStyle const&) const { return {}; }
     virtual CSS::ValueID to_identifier() const { return ValueID::Invalid; }
-    virtual Length to_length() const { return {}; }
+    virtual Length to_length() const { VERIFY_NOT_REACHED(); }
     virtual float to_number() const { return 0; }
     virtual float to_integer() const { return 0; }
     virtual String to_string() const = 0;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -691,21 +691,23 @@ public:
         float value;
     };
 
+    using PercentageBasis = Variant<Empty, Length>;
+
     class CalculationResult {
     public:
         CalculationResult(Variant<Number, Length, Percentage> value)
             : m_value(move(value))
         {
         }
-        void add(CalculationResult const& other, Layout::Node const*, Length const& percentage_basis);
-        void subtract(CalculationResult const& other, Layout::Node const*, Length const& percentage_basis);
+        void add(CalculationResult const& other, Layout::Node const*, PercentageBasis const& percentage_basis);
+        void subtract(CalculationResult const& other, Layout::Node const*, PercentageBasis const& percentage_basis);
         void multiply_by(CalculationResult const& other, Layout::Node const*);
         void divide_by(CalculationResult const& other, Layout::Node const*);
 
         Variant<Number, Length, Percentage> const& value() const { return m_value; }
 
     private:
-        void add_or_subtract_internal(SumOperation op, CalculationResult const& other, Layout::Node const*, Length const& percentage_basis);
+        void add_or_subtract_internal(SumOperation op, CalculationResult const& other, Layout::Node const*, PercentageBasis const& percentage_basis);
         Variant<Number, Length, Percentage> m_value;
     };
 
@@ -722,14 +724,14 @@ public:
         Variant<Number, NonnullOwnPtr<CalcNumberSum>> value;
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcValue {
         Variant<Number, Length, Percentage, NonnullOwnPtr<CalcSum>> value;
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     // This represents that: https://www.w3.org/TR/css-values-3/#calc-syntax
@@ -743,7 +745,7 @@ public:
 
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcNumberSum {
@@ -756,7 +758,7 @@ public:
 
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcProduct {
@@ -765,7 +767,7 @@ public:
 
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcSumPartWithOperator {
@@ -778,7 +780,7 @@ public:
 
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcProductPartWithOperator {
@@ -787,7 +789,7 @@ public:
 
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcNumberProduct {
@@ -796,7 +798,7 @@ public:
 
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcNumberProductPartWithOperator {
@@ -805,7 +807,7 @@ public:
 
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     struct CalcNumberSumPartWithOperator {
@@ -818,7 +820,7 @@ public:
 
         String to_string() const;
         Optional<ResolvedType> resolved_type() const;
-        CalculationResult resolve(Layout::Node const*, Length const& percentage_basis) const;
+        CalculationResult resolve(Layout::Node const*, PercentageBasis const& percentage_basis) const;
     };
 
     static NonnullRefPtr<CalculatedStyleValue> create(NonnullOwnPtr<CalcSum> calc_sum, ResolvedType resolved_type)

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -295,7 +295,7 @@ float BlockFormattingContext::compute_theoretical_height(Box const& box)
         height = compute_height_for_replaced_element(verify_cast<ReplacedBox>(box));
     } else {
         if (!box.computed_values().height().has_value()
-            || (box.computed_values().height()->is_length() && box.computed_values().height()->length().is_undefined_or_auto())
+            || (box.computed_values().height()->is_length() && box.computed_values().height()->length().is_auto())
             || (computed_values.height().has_value() && computed_values.height()->is_percentage() && !is_absolute(containing_block.computed_values().height()))) {
             height = compute_auto_height_for_block_level_element(box, ConsiderFloats::No);
         } else {
@@ -441,7 +441,7 @@ void BlockFormattingContext::layout_block_level_children(BlockContainer& block_c
 
     if (layout_mode != LayoutMode::Default) {
         auto& width = block_container.computed_values().width();
-        if (!width.has_value() || (width->is_length() && width->length().is_undefined_or_auto()))
+        if (!width.has_value() || (width->is_length() && width->length().is_auto()))
             block_container.set_content_width(content_width);
     }
 }

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -67,7 +67,7 @@ void BlockFormattingContext::apply_transformations_to_children(Box& box)
                         continue;
                     transformation.values.first().visit(
                         [&](CSS::Length& value) {
-                            transform_y_offset += value.resolved(child_box).to_px(child_box);
+                            transform_y_offset += value.to_px(child_box);
                         },
                         [&](float value) {
                             transform_y_offset += value;
@@ -264,7 +264,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box& box)
         width = CSS::Length(min(max(result.preferred_minimum_width, available_width), result.preferred_width), CSS::Length::Type::Px);
     }
 
-    float final_width = width.resolved(box).to_px(box);
+    float final_width = width.to_px(box);
     box.set_content_width(final_width);
     box.box_model().margin.left = margin_left.to_px(box);
     box.box_model().margin.right = margin_right.to_px(box);
@@ -299,7 +299,7 @@ float BlockFormattingContext::compute_theoretical_height(Box const& box)
             || (computed_values.height().has_value() && computed_values.height()->is_percentage() && !is_absolute(containing_block.computed_values().height()))) {
             height = compute_auto_height_for_block_level_element(box, ConsiderFloats::No);
         } else {
-            height = computed_values.height().has_value() ? computed_values.height()->resolved(box, containing_block_height).resolved(box).to_px(box) : 0;
+            height = computed_values.height().has_value() ? computed_values.height()->resolved(box, containing_block_height).to_px(box) : 0;
         }
     }
 
@@ -323,13 +323,13 @@ void BlockFormattingContext::compute_height(Box& box)
     // First, resolve the top/bottom parts of the surrounding box model.
 
     // FIXME: While negative values are generally allowed for margins, for now just ignore those for height calculation
-    box.box_model().margin.top = max(computed_values.margin().top.resolved(box, width_of_containing_block_as_length).resolved(box).to_px(box), 0);
-    box.box_model().margin.bottom = max(computed_values.margin().bottom.resolved(box, width_of_containing_block_as_length).resolved(box).to_px(box), 0);
+    box.box_model().margin.top = max(computed_values.margin().top.resolved(box, width_of_containing_block_as_length).to_px(box), 0);
+    box.box_model().margin.bottom = max(computed_values.margin().bottom.resolved(box, width_of_containing_block_as_length).to_px(box), 0);
 
     box.box_model().border.top = computed_values.border_top().width;
     box.box_model().border.bottom = computed_values.border_bottom().width;
-    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block_as_length).resolved(box).to_px(box);
-    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block_as_length).resolved(box).to_px(box);
+    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block_as_length).to_px(box);
+    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block_as_length).to_px(box);
 
     auto height = compute_theoretical_height(box);
     box.set_content_height(height);

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -67,7 +67,7 @@ void BlockFormattingContext::apply_transformations_to_children(Box& box)
                         continue;
                     transformation.values.first().visit(
                         [&](CSS::Length& value) {
-                            transform_y_offset += value.resolved_or_zero(child_box).to_px(child_box);
+                            transform_y_offset += value.resolved(child_box).to_px(child_box);
                         },
                         [&](float value) {
                             transform_y_offset += value;
@@ -115,13 +115,13 @@ void BlockFormattingContext::compute_width(Box& box)
 
     auto margin_left = CSS::Length::make_auto();
     auto margin_right = CSS::Length::make_auto();
-    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
-    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).resolved(box);
+    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).resolved(box);
 
     auto try_compute_width = [&](const auto& a_width) {
         CSS::Length width = a_width;
-        margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
-        margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+        margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved(box);
+        margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved(box);
 
         float total_px = computed_values.border_left().width + computed_values.border_right().width;
         for (auto& value : { margin_left, padding_left, width, padding_right, margin_right }) {
@@ -195,14 +195,14 @@ void BlockFormattingContext::compute_width(Box& box)
         return width;
     };
 
-    auto specified_width = computed_values.width().has_value() ? computed_values.width()->resolved(box, width_of_containing_block_as_length).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_width = computed_values.width().has_value() ? computed_values.width()->resolved(box, width_of_containing_block_as_length).resolved(box) : CSS::Length::make_auto();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = try_compute_width(specified_width);
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    auto specified_max_width = computed_values.max_width().has_value() ? computed_values.max_width()->resolved(box, width_of_containing_block_as_length).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_max_width = computed_values.max_width().has_value() ? computed_values.max_width()->resolved(box, width_of_containing_block_as_length).resolved(box) : CSS::Length::make_auto();
     if (!specified_max_width.is_auto()) {
         if (used_width.to_px(box) > specified_max_width.to_px(box)) {
             used_width = try_compute_width(specified_max_width);
@@ -211,7 +211,7 @@ void BlockFormattingContext::compute_width(Box& box)
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    auto specified_min_width = computed_values.min_width().has_value() ? computed_values.min_width()->resolved(box, width_of_containing_block_as_length).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_min_width = computed_values.min_width().has_value() ? computed_values.min_width()->resolved(box, width_of_containing_block_as_length).resolved(box) : CSS::Length::make_auto();
     if (!specified_min_width.is_auto()) {
         if (used_width.to_px(box) < specified_min_width.to_px(box)) {
             used_width = try_compute_width(specified_min_width);
@@ -235,10 +235,10 @@ void BlockFormattingContext::compute_width_for_floating_box(Box& box)
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     auto zero_value = CSS::Length::make_px(0);
 
-    auto margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
-    auto margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
-    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
-    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+    auto margin_left = computed_values.margin().left.resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto margin_right = computed_values.margin().right.resolved(box, width_of_containing_block_as_length).resolved(box);
+    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block_as_length).resolved(box);
+    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block_as_length).resolved(box);
 
     // If 'margin-left', or 'margin-right' are computed as 'auto', their used value is '0'.
     if (margin_left.is_auto())
@@ -246,7 +246,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box& box)
     if (margin_right.is_auto())
         margin_right = zero_value;
 
-    auto width = computed_values.width().has_value() ? computed_values.width()->resolved(box, width_of_containing_block_as_length).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto width = computed_values.width().has_value() ? computed_values.width()->resolved(box, width_of_containing_block_as_length).resolved(box) : CSS::Length::make_auto();
 
     // If 'width' is computed as 'auto', the used value is the "shrink-to-fit" width.
     if (width.is_auto()) {
@@ -264,7 +264,7 @@ void BlockFormattingContext::compute_width_for_floating_box(Box& box)
         width = CSS::Length(min(max(result.preferred_minimum_width, available_width), result.preferred_width), CSS::Length::Type::Px);
     }
 
-    float final_width = width.resolved_or_zero(box).to_px(box);
+    float final_width = width.resolved(box).to_px(box);
     box.set_content_width(final_width);
     box.box_model().margin.left = margin_left.to_px(box);
     box.box_model().margin.right = margin_right.to_px(box);
@@ -299,15 +299,15 @@ float BlockFormattingContext::compute_theoretical_height(Box const& box)
             || (computed_values.height().has_value() && computed_values.height()->is_percentage() && !is_absolute(containing_block.computed_values().height()))) {
             height = compute_auto_height_for_block_level_element(box, ConsiderFloats::No);
         } else {
-            height = computed_values.height().has_value() ? computed_values.height()->resolved(box, containing_block_height).resolved_or_auto(box).to_px(box) : 0;
+            height = computed_values.height().has_value() ? computed_values.height()->resolved(box, containing_block_height).resolved(box).to_px(box) : 0;
         }
     }
 
-    auto specified_max_height = computed_values.max_height().has_value() ? computed_values.max_height()->resolved(box, containing_block_height).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_max_height = computed_values.max_height().has_value() ? computed_values.max_height()->resolved(box, containing_block_height).resolved(box) : CSS::Length::make_auto();
     if (!specified_max_height.is_auto()
         && !(computed_values.max_height().has_value() && computed_values.max_height()->is_percentage() && !is_absolute(containing_block.computed_values().height())))
         height = min(height, specified_max_height.to_px(box));
-    auto specified_min_height = computed_values.min_height().has_value() ? computed_values.min_height()->resolved(box, containing_block_height).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_min_height = computed_values.min_height().has_value() ? computed_values.min_height()->resolved(box, containing_block_height).resolved(box) : CSS::Length::make_auto();
     if (!specified_min_height.is_auto()
         && !(computed_values.min_height().has_value() && computed_values.min_height()->is_percentage() && !is_absolute(containing_block.computed_values().height())))
         height = max(height, specified_min_height.to_px(box));
@@ -323,13 +323,13 @@ void BlockFormattingContext::compute_height(Box& box)
     // First, resolve the top/bottom parts of the surrounding box model.
 
     // FIXME: While negative values are generally allowed for margins, for now just ignore those for height calculation
-    box.box_model().margin.top = max(computed_values.margin().top.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box).to_px(box), 0);
-    box.box_model().margin.bottom = max(computed_values.margin().bottom.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box).to_px(box), 0);
+    box.box_model().margin.top = max(computed_values.margin().top.resolved(box, width_of_containing_block_as_length).resolved(box).to_px(box), 0);
+    box.box_model().margin.bottom = max(computed_values.margin().bottom.resolved(box, width_of_containing_block_as_length).resolved(box).to_px(box), 0);
 
     box.box_model().border.top = computed_values.border_top().width;
     box.box_model().border.bottom = computed_values.border_bottom().width;
-    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box).to_px(box);
-    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box).to_px(box);
+    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block_as_length).resolved(box).to_px(box);
+    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block_as_length).resolved(box).to_px(box);
 
     auto height = compute_theoretical_height(box);
     box.set_content_height(height);
@@ -345,8 +345,8 @@ void BlockFormattingContext::compute_position(Box& box)
     float width_of_containing_block = box.containing_block()->content_width();
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
 
-    auto specified_left = computed_values.offset().left.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
-    auto specified_right = computed_values.offset().right.resolved(box, width_of_containing_block_as_length).resolved_or_zero(box);
+    auto specified_left = computed_values.offset().left.resolved(box, width_of_containing_block_as_length).resolved(box);
+    auto specified_right = computed_values.offset().right.resolved(box, width_of_containing_block_as_length).resolved(box);
 
     if (specified_left.is_auto() && specified_right.is_auto()) {
         // If both 'left' and 'right' are 'auto' (their initial values), the used values are '0' (i.e., the boxes stay in their original position).
@@ -452,12 +452,12 @@ void BlockFormattingContext::compute_vertical_box_model_metrics(Box& child_box, 
     auto const& computed_values = child_box.computed_values();
     auto width_of_containing_block = CSS::Length::make_px(containing_block.content_width());
 
-    box_model.margin.top = computed_values.margin().top.resolved(child_box, width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
-    box_model.margin.bottom = computed_values.margin().bottom.resolved(child_box, width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
+    box_model.margin.top = computed_values.margin().top.resolved(child_box, width_of_containing_block).resolved(containing_block).to_px(child_box);
+    box_model.margin.bottom = computed_values.margin().bottom.resolved(child_box, width_of_containing_block).resolved(containing_block).to_px(child_box);
     box_model.border.top = computed_values.border_top().width;
     box_model.border.bottom = computed_values.border_bottom().width;
-    box_model.padding.top = computed_values.padding().top.resolved(child_box, width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
-    box_model.padding.bottom = computed_values.padding().bottom.resolved(child_box, width_of_containing_block).resolved_or_zero(containing_block).to_px(child_box);
+    box_model.padding.top = computed_values.padding().top.resolved(child_box, width_of_containing_block).resolved(containing_block).to_px(child_box);
+    box_model.padding.bottom = computed_values.padding().bottom.resolved(child_box, width_of_containing_block).resolved(containing_block).to_px(child_box);
 }
 
 void BlockFormattingContext::place_block_level_element_in_normal_flow_vertically(Box& child_box, BlockContainer const& containing_block)

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -107,10 +107,10 @@ void Box::paint_box_shadow(PaintContext& context)
     for (auto const& layer : box_shadow_data) {
         resolved_box_shadow_data.empend(
             layer.color,
-            static_cast<int>(layer.offset_x.resolved_or_zero(*this).to_px(*this)),
-            static_cast<int>(layer.offset_y.resolved_or_zero(*this).to_px(*this)),
-            static_cast<int>(layer.blur_radius.resolved_or_zero(*this).to_px(*this)),
-            static_cast<int>(layer.spread_distance.resolved_or_zero(*this).to_px(*this)),
+            static_cast<int>(layer.offset_x.resolved(*this).to_px(*this)),
+            static_cast<int>(layer.offset_y.resolved(*this).to_px(*this)),
+            static_cast<int>(layer.blur_radius.resolved(*this).to_px(*this)),
+            static_cast<int>(layer.spread_distance.resolved(*this).to_px(*this)),
             layer.placement == CSS::BoxShadowPlacement::Outer ? Painting::BoxShadowPlacement::Outer : Painting::BoxShadowPlacement::Inner);
     }
     Painting::paint_box_shadow(context, enclosing_int_rect(absolute_border_box_rect()), resolved_box_shadow_data);

--- a/Userland/Libraries/LibWeb/Layout/Box.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Box.cpp
@@ -107,10 +107,10 @@ void Box::paint_box_shadow(PaintContext& context)
     for (auto const& layer : box_shadow_data) {
         resolved_box_shadow_data.empend(
             layer.color,
-            static_cast<int>(layer.offset_x.resolved(*this).to_px(*this)),
-            static_cast<int>(layer.offset_y.resolved(*this).to_px(*this)),
-            static_cast<int>(layer.blur_radius.resolved(*this).to_px(*this)),
-            static_cast<int>(layer.spread_distance.resolved(*this).to_px(*this)),
+            static_cast<int>(layer.offset_x.to_px(*this)),
+            static_cast<int>(layer.offset_y.to_px(*this)),
+            static_cast<int>(layer.blur_radius.to_px(*this)),
+            static_cast<int>(layer.spread_distance.to_px(*this)),
             layer.placement == CSS::BoxShadowPlacement::Outer ? Painting::BoxShadowPlacement::Outer : Painting::BoxShadowPlacement::Inner);
     }
     Painting::paint_box_shadow(context, enclosing_int_rect(absolute_border_box_rect()), resolved_box_shadow_data);

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -22,7 +22,7 @@ static float get_pixel_size(Box const& box, Optional<CSS::LengthPercentage> cons
     if (!length_percentage.has_value())
         return 0;
     auto inner_main_size = CSS::Length::make_px(box.containing_block()->content_width());
-    return length_percentage->resolved(box, inner_main_size).resolved(CSS::Length::make_px(0), box).to_px(box);
+    return length_percentage->resolved(box, inner_main_size).resolved(box).to_px(box);
 }
 
 static bool is_undefined_or_auto(Optional<CSS::LengthPercentage> const& length_percentage)
@@ -120,15 +120,15 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     // FIXME: This should also take reverse-ness into account
     if (flex_direction == CSS::FlexDirection::Row || flex_direction == CSS::FlexDirection::RowReverse) {
-        item.margins.main_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.main_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
+        item.margins.main_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
+        item.margins.cross_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
+        item.margins.cross_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
     } else {
-        item.margins.main_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).resolved_or_zero(item.box).to_px(item.box);
+        item.margins.main_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
+        item.margins.main_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
+        item.margins.cross_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
+        item.margins.cross_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
     }
 };
 
@@ -148,7 +148,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
 
         auto& maybe_width = flex_container().computed_values().width();
         if (maybe_width.has_value()) {
-            auto width = maybe_width->resolved(flex_container(), CSS::Length::make_px(container_width)).resolved_or_zero(flex_container()).to_px(flex_container());
+            auto width = maybe_width->resolved(flex_container(), CSS::Length::make_px(container_width)).resolved(flex_container()).to_px(flex_container());
             flex_container().set_content_width(width);
         } else {
             flex_container().set_content_width(0);
@@ -161,7 +161,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
         auto container_height = flex_container().containing_block()->content_height();
         auto& maybe_height = flex_container().computed_values().height();
         if (maybe_height.has_value()) {
-            auto height = maybe_height->resolved(flex_container(), CSS::Length::make_px(container_height)).resolved_or_zero(flex_container()).to_px(flex_container());
+            auto height = maybe_height->resolved(flex_container(), CSS::Length::make_px(container_height)).resolved(flex_container()).to_px(flex_container());
             flex_container().set_content_height(height);
         } else {
             flex_container().set_content_height(0);
@@ -256,7 +256,7 @@ float FlexFormattingContext::specified_main_size_of_child_box(Box const& child_b
     auto& value = is_row_layout() ? child_box.computed_values().width() : child_box.computed_values().height();
     if (!value.has_value())
         return 0;
-    return value->resolved(child_box, CSS::Length::make_px(main_size_of_parent)).resolved_or_zero(child_box).to_px(child_box);
+    return value->resolved(child_box, CSS::Length::make_px(main_size_of_parent)).resolved(child_box).to_px(child_box);
 }
 
 float FlexFormattingContext::specified_main_min_size(Box const& box) const

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -29,7 +29,7 @@ static bool is_undefined_or_auto(Optional<CSS::LengthPercentage> const& length_p
 {
     if (!length_percentage.has_value())
         return true;
-    return length_percentage->is_length() && length_percentage->length().is_undefined_or_auto();
+    return length_percentage->is_length() && length_percentage->length().is_auto();
 }
 
 FlexFormattingContext::FlexFormattingContext(Box& flex_container, FormattingContext* parent)
@@ -235,11 +235,12 @@ bool FlexFormattingContext::cross_size_is_absolute_or_resolved_nicely(NodeWithSt
     if (!length_percentage.has_value())
         return false;
 
+    // FIXME: Handle calc here.
     if (length_percentage->is_length()) {
         auto& length = length_percentage->length();
         if (length.is_absolute() || length.is_relative())
             return true;
-        if (length.is_undefined_or_auto())
+        if (length.is_auto())
             return false;
     }
 

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -17,17 +17,19 @@
 
 namespace Web::Layout {
 
-static float get_pixel_size(Box const& box, CSS::LengthPercentage const& length_percentage)
+static float get_pixel_size(Box const& box, Optional<CSS::LengthPercentage> const& length_percentage)
 {
+    if (!length_percentage.has_value())
+        return 0;
     auto inner_main_size = CSS::Length::make_px(box.containing_block()->content_width());
-    return length_percentage.resolved(box, inner_main_size)
-        .resolved(CSS::Length::make_px(0), box)
-        .to_px(box);
+    return length_percentage->resolved(box, inner_main_size).resolved(CSS::Length::make_px(0), box).to_px(box);
 }
 
-static bool is_undefined_or_auto(CSS::LengthPercentage const& length_percentage)
+static bool is_undefined_or_auto(Optional<CSS::LengthPercentage> const& length_percentage)
 {
-    return length_percentage.is_length() && length_percentage.length().is_undefined_or_auto();
+    if (!length_percentage.has_value())
+        return true;
+    return length_percentage->is_length() && length_percentage->length().is_undefined_or_auto();
 }
 
 FlexFormattingContext::FlexFormattingContext(Box& flex_container, FormattingContext* parent)
@@ -143,16 +145,27 @@ void FlexFormattingContext::generate_anonymous_flex_items()
         flex_container().set_content_width(flex_container().containing_block()->content_width());
     } else {
         auto container_width = flex_container().containing_block()->content_width();
-        auto width = flex_container().computed_values().width().resolved(flex_container(), CSS::Length::make_px(container_width)).resolved_or_zero(flex_container()).to_px(flex_container());
-        flex_container().set_content_width(width);
+
+        auto& maybe_width = flex_container().computed_values().width();
+        if (maybe_width.has_value()) {
+            auto width = maybe_width->resolved(flex_container(), CSS::Length::make_px(container_width)).resolved_or_zero(flex_container()).to_px(flex_container());
+            flex_container().set_content_width(width);
+        } else {
+            flex_container().set_content_width(0);
+        }
     }
 
     if (!flex_container().has_definite_height()) {
         flex_container().set_content_height(flex_container().containing_block()->content_height());
     } else {
         auto container_height = flex_container().containing_block()->content_height();
-        auto height = flex_container().computed_values().height().resolved(flex_container(), CSS::Length::make_px(container_height)).resolved_or_zero(flex_container()).to_px(flex_container());
-        flex_container().set_content_height(height);
+        auto& maybe_height = flex_container().computed_values().height();
+        if (maybe_height.has_value()) {
+            auto height = maybe_height->resolved(flex_container(), CSS::Length::make_px(container_height)).resolved_or_zero(flex_container()).to_px(flex_container());
+            flex_container().set_content_height(height);
+        } else {
+            flex_container().set_content_height(0);
+        }
     }
 
     flex_container().for_each_child_of_type<Box>([&](Box& child_box) {
@@ -219,8 +232,11 @@ bool FlexFormattingContext::cross_size_is_absolute_or_resolved_nicely(NodeWithSt
 {
     auto length_percentage = is_row_layout() ? box.computed_values().height() : box.computed_values().width();
 
-    if (length_percentage.is_length()) {
-        auto& length = length_percentage.length();
+    if (!length_percentage.has_value())
+        return false;
+
+    if (length_percentage->is_length()) {
+        auto& length = length_percentage->length();
         if (length.is_absolute() || length.is_relative())
             return true;
         if (length.is_undefined_or_auto())
@@ -229,7 +245,7 @@ bool FlexFormattingContext::cross_size_is_absolute_or_resolved_nicely(NodeWithSt
 
     if (!box.parent())
         return false;
-    if (length_percentage.is_percentage() && cross_size_is_absolute_or_resolved_nicely(*box.parent()))
+    if (length_percentage->is_percentage() && cross_size_is_absolute_or_resolved_nicely(*box.parent()))
         return true;
     return false;
 }
@@ -237,8 +253,10 @@ bool FlexFormattingContext::cross_size_is_absolute_or_resolved_nicely(NodeWithSt
 float FlexFormattingContext::specified_main_size_of_child_box(Box const& child_box) const
 {
     auto main_size_of_parent = specified_main_size(flex_container());
-    auto value = is_row_layout() ? child_box.computed_values().width() : child_box.computed_values().height();
-    return value.resolved(child_box, CSS::Length::make_px(main_size_of_parent)).resolved_or_zero(child_box).to_px(child_box);
+    auto& value = is_row_layout() ? child_box.computed_values().width() : child_box.computed_values().height();
+    if (!value.has_value())
+        return 0;
+    return value->resolved(child_box, CSS::Length::make_px(main_size_of_parent)).resolved_or_zero(child_box).to_px(child_box);
 }
 
 float FlexFormattingContext::specified_main_min_size(Box const& box) const
@@ -290,9 +308,8 @@ float FlexFormattingContext::calculated_main_size(Box const& box) const
 
 bool FlexFormattingContext::is_cross_auto(Box const& box) const
 {
-    if (is_row_layout())
-        return box.computed_values().height().is_length() && box.computed_values().height().length().is_auto();
-    return box.computed_values().width().is_length() && box.computed_values().width().length().is_auto();
+    auto& cross_length = is_row_layout() ? box.computed_values().height() : box.computed_values().width();
+    return cross_length.has_value() && cross_length->length().is_auto();
 }
 
 bool FlexFormattingContext::is_main_axis_margin_first_auto(Box const& box) const

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -22,7 +22,7 @@ static float get_pixel_size(Box const& box, Optional<CSS::LengthPercentage> cons
     if (!length_percentage.has_value())
         return 0;
     auto inner_main_size = CSS::Length::make_px(box.containing_block()->content_width());
-    return length_percentage->resolved(box, inner_main_size).resolved(box).to_px(box);
+    return length_percentage->resolved(box, inner_main_size).to_px(box);
 }
 
 static bool is_undefined_or_auto(Optional<CSS::LengthPercentage> const& length_percentage)
@@ -120,15 +120,15 @@ void FlexFormattingContext::populate_specified_margins(FlexItem& item, CSS::Flex
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
     // FIXME: This should also take reverse-ness into account
     if (flex_direction == CSS::FlexDirection::Row || flex_direction == CSS::FlexDirection::RowReverse) {
-        item.margins.main_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
+        item.margins.main_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
     } else {
-        item.margins.main_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
-        item.margins.main_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
-        item.margins.cross_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
-        item.margins.cross_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).resolved(item.box).to_px(item.box);
+        item.margins.main_before = item.box.computed_values().margin().top.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.main_after = item.box.computed_values().margin().bottom.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_before = item.box.computed_values().margin().left.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
+        item.margins.cross_after = item.box.computed_values().margin().right.resolved(item.box, width_of_containing_block_as_length).to_px(item.box);
     }
 };
 
@@ -148,7 +148,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
 
         auto& maybe_width = flex_container().computed_values().width();
         if (maybe_width.has_value()) {
-            auto width = maybe_width->resolved(flex_container(), CSS::Length::make_px(container_width)).resolved(flex_container()).to_px(flex_container());
+            auto width = maybe_width->resolved(flex_container(), CSS::Length::make_px(container_width)).to_px(flex_container());
             flex_container().set_content_width(width);
         } else {
             flex_container().set_content_width(0);
@@ -161,7 +161,7 @@ void FlexFormattingContext::generate_anonymous_flex_items()
         auto container_height = flex_container().containing_block()->content_height();
         auto& maybe_height = flex_container().computed_values().height();
         if (maybe_height.has_value()) {
-            auto height = maybe_height->resolved(flex_container(), CSS::Length::make_px(container_height)).resolved(flex_container()).to_px(flex_container());
+            auto height = maybe_height->resolved(flex_container(), CSS::Length::make_px(container_height)).to_px(flex_container());
             flex_container().set_content_height(height);
         } else {
             flex_container().set_content_height(0);
@@ -256,7 +256,7 @@ float FlexFormattingContext::specified_main_size_of_child_box(Box const& child_b
     auto& value = is_row_layout() ? child_box.computed_values().width() : child_box.computed_values().height();
     if (!value.has_value())
         return 0;
-    return value->resolved(child_box, CSS::Length::make_px(main_size_of_parent)).resolved(child_box).to_px(child_box);
+    return value->resolved(child_box, CSS::Length::make_px(main_size_of_parent)).to_px(child_box);
 }
 
 float FlexFormattingContext::specified_main_min_size(Box const& box) const

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -414,8 +414,8 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     auto margin_right = CSS::Length::make_auto();
     const auto border_left = computed_values.border_left().width;
     const auto border_right = computed_values.border_right().width;
-    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block).resolved(box);
-    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block).resolved(box);
+    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block).to_px(box);
+    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block).to_px(box);
 
     auto try_compute_width = [&](const auto& a_width) {
         margin_left = computed_values.margin().left.resolved(box, width_of_containing_block).resolved(box);
@@ -426,15 +426,15 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         auto width = a_width;
 
         auto solve_for_left = [&] {
-            return CSS::Length(containing_block.content_width() - margin_left.to_px(box) - border_left - padding_left.to_px(box) - width.to_px(box) - padding_right.to_px(box) - border_right - margin_right.to_px(box) - right.to_px(box), CSS::Length::Type::Px);
+            return CSS::Length(containing_block.content_width() - margin_left.to_px(box) - border_left - padding_left - width.to_px(box) - padding_right - border_right - margin_right.to_px(box) - right.to_px(box), CSS::Length::Type::Px);
         };
 
         auto solve_for_width = [&] {
-            return CSS::Length(containing_block.content_width() - left.to_px(box) - margin_left.to_px(box) - border_left - padding_left.to_px(box) - padding_right.to_px(box) - border_right - margin_right.to_px(box) - right.to_px(box), CSS::Length::Type::Px);
+            return CSS::Length(containing_block.content_width() - left.to_px(box) - margin_left.to_px(box) - border_left - padding_left - padding_right - border_right - margin_right.to_px(box) - right.to_px(box), CSS::Length::Type::Px);
         };
 
         auto solve_for_right = [&] {
-            return CSS::Length(containing_block.content_width() - left.to_px(box) - margin_left.to_px(box) - border_left - padding_left.to_px(box) - width.to_px(box) - padding_right.to_px(box) - border_right - margin_right.to_px(box), CSS::Length::Type::Px);
+            return CSS::Length(containing_block.content_width() - left.to_px(box) - margin_left.to_px(box) - border_left - padding_left - width.to_px(box) - padding_right - border_right - margin_right.to_px(box), CSS::Length::Type::Px);
         };
 
         // If all three of 'left', 'width', and 'right' are 'auto':
@@ -540,8 +540,8 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     box.box_model().margin.right = margin_right.to_px(box);
     box.box_model().border.left = border_left;
     box.box_model().border.right = border_right;
-    box.box_model().padding.left = padding_left.to_px(box);
-    box.box_model().padding.right = padding_right.to_px(box);
+    box.box_model().padding.left = padding_left;
+    box.box_model().padding.right = padding_right;
 }
 
 void FormattingContext::compute_width_for_absolutely_positioned_replaced_element(ReplacedBox& box)

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -157,10 +157,10 @@ static Gfx::FloatSize solve_replaced_size_constraint(float w, float h, const Rep
     auto width_of_containing_block = CSS::Length::make_px(containing_block.content_width());
     auto height_of_containing_block = CSS::Length::make_px(containing_block.content_height());
 
-    auto specified_min_width = box.computed_values().min_width().has_value() ? box.computed_values().min_width()->resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box) : 0;
-    auto specified_max_width = box.computed_values().max_width().has_value() ? box.computed_values().max_width()->resolved(box, width_of_containing_block).resolved(CSS::Length::make_px(w), box).to_px(box) : w;
-    auto specified_min_height = box.computed_values().min_height().has_value() ? box.computed_values().min_height()->resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box) : 0;
-    auto specified_max_height = box.computed_values().max_height().has_value() ? box.computed_values().max_height()->resolved(box, height_of_containing_block).resolved(CSS::Length::make_px(h), box).to_px(box) : h;
+    auto specified_min_width = box.computed_values().min_width().has_value() ? box.computed_values().min_width()->resolved(box, width_of_containing_block).resolved(box).to_px(box) : 0;
+    auto specified_max_width = box.computed_values().max_width().has_value() ? box.computed_values().max_width()->resolved(box, width_of_containing_block).resolved(box).to_px(box) : w;
+    auto specified_min_height = box.computed_values().min_height().has_value() ? box.computed_values().min_height()->resolved(box, height_of_containing_block).resolved(box).to_px(box) : 0;
+    auto specified_max_height = box.computed_values().max_height().has_value() ? box.computed_values().max_height()->resolved(box, height_of_containing_block).resolved(box).to_px(box) : h;
 
     auto min_width = min(specified_min_width, specified_max_width);
     auto max_width = max(specified_min_width, specified_max_width);
@@ -252,7 +252,7 @@ float FormattingContext::tentative_width_for_replaced_element(ReplacedBox const&
 {
     auto& containing_block = *box.containing_block();
     auto height_of_containing_block = CSS::Length::make_px(containing_block.content_height());
-    auto computed_height = box.computed_values().height().has_value() ? box.computed_values().height()->resolved(box, height_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto computed_height = box.computed_values().height().has_value() ? box.computed_values().height()->resolved(box, height_of_containing_block).resolved(box) : CSS::Length::make_auto();
 
     float used_width = computed_width.to_px(box);
 
@@ -314,8 +314,8 @@ float FormattingContext::compute_width_for_replaced_element(const ReplacedBox& b
     auto& containing_block = *box.containing_block();
     auto width_of_containing_block = CSS::Length::make_px(containing_block.content_width());
 
-    auto margin_left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved_or_zero(box);
-    auto margin_right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved_or_zero(box);
+    auto margin_left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved(box);
+    auto margin_right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved(box);
 
     // A computed value of 'auto' for 'margin-left' or 'margin-right' becomes a used value of '0'.
     if (margin_left.is_auto())
@@ -323,14 +323,14 @@ float FormattingContext::compute_width_for_replaced_element(const ReplacedBox& b
     if (margin_right.is_auto())
         margin_right = zero_value;
 
-    auto specified_width = box.computed_values().width().has_value() ? box.computed_values().width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_width = box.computed_values().width().has_value() ? box.computed_values().width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = tentative_width_for_replaced_element(box, specified_width);
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    auto specified_max_width = box.computed_values().max_width().has_value() ? box.computed_values().max_width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_max_width = box.computed_values().max_width().has_value() ? box.computed_values().max_width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
     if (!specified_max_width.is_auto()) {
         if (used_width > specified_max_width.to_px(box)) {
             used_width = tentative_width_for_replaced_element(box, specified_max_width);
@@ -339,7 +339,7 @@ float FormattingContext::compute_width_for_replaced_element(const ReplacedBox& b
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    auto specified_min_width = box.computed_values().min_width().has_value() ? box.computed_values().min_width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_min_width = box.computed_values().min_width().has_value() ? box.computed_values().min_width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
     if (!specified_min_width.is_auto()) {
         if (used_width < specified_min_width.to_px(box)) {
             used_width = tentative_width_for_replaced_element(box, specified_min_width);
@@ -355,7 +355,7 @@ float FormattingContext::tentative_height_for_replaced_element(ReplacedBox const
 {
     auto& containing_block = *box.containing_block();
     auto width_of_containing_block = CSS::Length::make_px(containing_block.content_width());
-    auto computed_width = box.computed_values().width().has_value() ? box.computed_values().width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto computed_width = box.computed_values().width().has_value() ? box.computed_values().width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
 
     // If 'height' and 'width' both have computed values of 'auto' and the element also has
     // an intrinsic height, then that intrinsic height is the used value of 'height'.
@@ -389,8 +389,8 @@ float FormattingContext::compute_height_for_replaced_element(const ReplacedBox& 
     auto& containing_block = *box.containing_block();
     auto width_of_containing_block = CSS::Length::make_px(containing_block.content_width());
     auto height_of_containing_block = CSS::Length::make_px(containing_block.content_height());
-    auto specified_width = box.computed_values().width().has_value() ? box.computed_values().width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
-    auto specified_height = box.computed_values().height().has_value() ? box.computed_values().height()->resolved(box, height_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_width = box.computed_values().width().has_value() ? box.computed_values().width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
+    auto specified_height = box.computed_values().height().has_value() ? box.computed_values().height()->resolved(box, height_of_containing_block).resolved(box) : CSS::Length::make_auto();
 
     float used_height = tentative_height_for_replaced_element(box, specified_height);
 
@@ -414,15 +414,15 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
     auto margin_right = CSS::Length::make_auto();
     const auto border_left = computed_values.border_left().width;
     const auto border_right = computed_values.border_right().width;
-    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block).resolved_or_zero(box);
-    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block).resolved_or_zero(box);
+    const auto padding_left = computed_values.padding().left.resolved(box, width_of_containing_block).resolved(box);
+    const auto padding_right = computed_values.padding().right.resolved(box, width_of_containing_block).resolved(box);
 
     auto try_compute_width = [&](const auto& a_width) {
-        margin_left = computed_values.margin().left.resolved(box, width_of_containing_block).resolved_or_zero(box);
-        margin_right = computed_values.margin().right.resolved(box, width_of_containing_block).resolved_or_zero(box);
+        margin_left = computed_values.margin().left.resolved(box, width_of_containing_block).resolved(box);
+        margin_right = computed_values.margin().right.resolved(box, width_of_containing_block).resolved(box);
 
-        auto left = computed_values.offset().left.resolved(box, width_of_containing_block).resolved_or_auto(box);
-        auto right = computed_values.offset().right.resolved(box, width_of_containing_block).resolved_or_auto(box);
+        auto left = computed_values.offset().left.resolved(box, width_of_containing_block).resolved(box);
+        auto right = computed_values.offset().right.resolved(box, width_of_containing_block).resolved(box);
         auto width = a_width;
 
         auto solve_for_left = [&] {
@@ -511,14 +511,14 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
         return width;
     };
 
-    auto specified_width = computed_values.width().has_value() ? computed_values.width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_width = computed_values.width().has_value() ? computed_values.width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
 
     // 1. The tentative used width is calculated (without 'min-width' and 'max-width')
     auto used_width = try_compute_width(specified_width);
 
     // 2. The tentative used width is greater than 'max-width', the rules above are applied again,
     //    but this time using the computed value of 'max-width' as the computed value for 'width'.
-    auto specified_max_width = computed_values.max_width().has_value() ? computed_values.max_width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_max_width = computed_values.max_width().has_value() ? computed_values.max_width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
     if (!specified_max_width.is_auto()) {
         if (used_width.to_px(box) > specified_max_width.to_px(box)) {
             used_width = try_compute_width(specified_max_width);
@@ -527,7 +527,7 @@ void FormattingContext::compute_width_for_absolutely_positioned_non_replaced_ele
 
     // 3. If the resulting width is smaller than 'min-width', the rules above are applied again,
     //    but this time using the value of 'min-width' as the computed value for 'width'.
-    auto specified_min_width = computed_values.min_width().has_value() ? computed_values.min_width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_min_width = computed_values.min_width().has_value() ? computed_values.min_width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
     if (!specified_min_width.is_auto()) {
         if (used_width.to_px(box) < specified_min_width.to_px(box)) {
             used_width = try_compute_width(specified_min_width);
@@ -559,26 +559,26 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto width_of_containing_block = CSS::Length::make_px(containing_block.content_width());
     auto height_of_containing_block = CSS::Length::make_px(containing_block.content_height());
 
-    CSS::Length specified_top = computed_values.offset().top.resolved(box, height_of_containing_block).resolved_or_auto(box);
-    CSS::Length specified_bottom = computed_values.offset().bottom.resolved(box, height_of_containing_block).resolved_or_auto(box);
+    CSS::Length specified_top = computed_values.offset().top.resolved(box, height_of_containing_block).resolved(box);
+    CSS::Length specified_bottom = computed_values.offset().bottom.resolved(box, height_of_containing_block).resolved(box);
     CSS::Length specified_height = CSS::Length::make_auto();
 
     if (computed_values.height().has_value() && computed_values.height()->is_percentage()
         && !(containing_block.computed_values().height().has_value() && containing_block.computed_values().height()->is_length() && containing_block.computed_values().height()->length().is_absolute())) {
         // specified_height is already auto
     } else {
-        specified_height = computed_values.height().has_value() ? computed_values.height()->resolved(box, height_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+        specified_height = computed_values.height().has_value() ? computed_values.height()->resolved(box, height_of_containing_block).resolved(box) : CSS::Length::make_auto();
     }
 
-    auto specified_max_height = computed_values.max_height().has_value() ? computed_values.max_height()->resolved(box, height_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
-    auto specified_min_height = computed_values.min_height().has_value() ? computed_values.min_height()->resolved(box, height_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_max_height = computed_values.max_height().has_value() ? computed_values.max_height()->resolved(box, height_of_containing_block).resolved(box) : CSS::Length::make_auto();
+    auto specified_min_height = computed_values.min_height().has_value() ? computed_values.min_height()->resolved(box, height_of_containing_block).resolved(box) : CSS::Length::make_auto();
 
-    box.box_model().margin.top = computed_values.margin().top.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
-    box.box_model().margin.bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box.box_model().margin.top = computed_values.margin().top.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box.box_model().margin.bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block).resolved(box).to_px(box);
     box.box_model().border.top = computed_values.border_top().width;
     box.box_model().border.bottom = computed_values.border_bottom().width;
-    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
-    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block).resolved(box).to_px(box);
 
     if (specified_height.is_auto() && !specified_top.is_auto() && specified_bottom.is_auto()) {
         const auto& margin = box.box_model().margin;
@@ -614,26 +614,26 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     auto height_of_containing_block = CSS::Length::make_px(containing_block.content_height());
     auto& box_model = box.box_model();
 
-    auto specified_width = box.computed_values().width().has_value() ? box.computed_values().width()->resolved(box, width_of_containing_block).resolved_or_auto(box) : CSS::Length::make_auto();
+    auto specified_width = box.computed_values().width().has_value() ? box.computed_values().width()->resolved(box, width_of_containing_block).resolved(box) : CSS::Length::make_auto();
 
     compute_width_for_absolutely_positioned_element(box);
     auto independent_formatting_context = layout_inside(box, LayoutMode::Default);
     compute_height_for_absolutely_positioned_element(box);
 
-    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.margin.top = box.computed_values().margin().top.resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.margin.bottom = box.computed_values().margin().bottom.resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box_model.margin.top = box.computed_values().margin().top.resolved(box, height_of_containing_block).resolved(box).to_px(box);
+    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box_model.margin.bottom = box.computed_values().margin().bottom.resolved(box, height_of_containing_block).resolved(box).to_px(box);
 
     box_model.border.left = box.computed_values().border_left().width;
     box_model.border.right = box.computed_values().border_right().width;
     box_model.border.top = box.computed_values().border_top().width;
     box_model.border.bottom = box.computed_values().border_bottom().width;
 
-    box_model.offset.left = box.computed_values().offset().left.resolved(box, width_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.offset.top = box.computed_values().offset().top.resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.offset.right = box.computed_values().offset().right.resolved(box, width_of_containing_block).resolved_or_auto(box).to_px(box);
-    box_model.offset.bottom = box.computed_values().offset().bottom.resolved(box, height_of_containing_block).resolved_or_auto(box).to_px(box);
+    box_model.offset.left = box.computed_values().offset().left.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box_model.offset.top = box.computed_values().offset().top.resolved(box, height_of_containing_block).resolved(box).to_px(box);
+    box_model.offset.right = box.computed_values().offset().right.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box_model.offset.bottom = box.computed_values().offset().bottom.resolved(box, height_of_containing_block).resolved(box).to_px(box);
 
     auto is_auto = [](auto const& length_percentage) {
         return length_percentage.is_length() && length_percentage.length().is_auto();

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -157,10 +157,10 @@ static Gfx::FloatSize solve_replaced_size_constraint(float w, float h, const Rep
     auto width_of_containing_block = CSS::Length::make_px(containing_block.content_width());
     auto height_of_containing_block = CSS::Length::make_px(containing_block.content_height());
 
-    auto specified_min_width = box.computed_values().min_width().has_value() ? box.computed_values().min_width()->resolved(box, width_of_containing_block).resolved(box).to_px(box) : 0;
-    auto specified_max_width = box.computed_values().max_width().has_value() ? box.computed_values().max_width()->resolved(box, width_of_containing_block).resolved(box).to_px(box) : w;
-    auto specified_min_height = box.computed_values().min_height().has_value() ? box.computed_values().min_height()->resolved(box, height_of_containing_block).resolved(box).to_px(box) : 0;
-    auto specified_max_height = box.computed_values().max_height().has_value() ? box.computed_values().max_height()->resolved(box, height_of_containing_block).resolved(box).to_px(box) : h;
+    auto specified_min_width = box.computed_values().min_width().has_value() ? box.computed_values().min_width()->resolved(box, width_of_containing_block).to_px(box) : 0;
+    auto specified_max_width = box.computed_values().max_width().has_value() ? box.computed_values().max_width()->resolved(box, width_of_containing_block).to_px(box) : w;
+    auto specified_min_height = box.computed_values().min_height().has_value() ? box.computed_values().min_height()->resolved(box, height_of_containing_block).to_px(box) : 0;
+    auto specified_max_height = box.computed_values().max_height().has_value() ? box.computed_values().max_height()->resolved(box, height_of_containing_block).to_px(box) : h;
 
     auto min_width = min(specified_min_width, specified_max_width);
     auto max_width = max(specified_min_width, specified_max_width);
@@ -573,12 +573,12 @@ void FormattingContext::compute_height_for_absolutely_positioned_non_replaced_el
     auto specified_max_height = computed_values.max_height().has_value() ? computed_values.max_height()->resolved(box, height_of_containing_block).resolved(box) : CSS::Length::make_auto();
     auto specified_min_height = computed_values.min_height().has_value() ? computed_values.min_height()->resolved(box, height_of_containing_block).resolved(box) : CSS::Length::make_auto();
 
-    box.box_model().margin.top = computed_values.margin().top.resolved(box, width_of_containing_block).resolved(box).to_px(box);
-    box.box_model().margin.bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box.box_model().margin.top = computed_values.margin().top.resolved(box, width_of_containing_block).to_px(box);
+    box.box_model().margin.bottom = computed_values.margin().bottom.resolved(box, width_of_containing_block).to_px(box);
     box.box_model().border.top = computed_values.border_top().width;
     box.box_model().border.bottom = computed_values.border_bottom().width;
-    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block).resolved(box).to_px(box);
-    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box.box_model().padding.top = computed_values.padding().top.resolved(box, width_of_containing_block).to_px(box);
+    box.box_model().padding.bottom = computed_values.padding().bottom.resolved(box, width_of_containing_block).to_px(box);
 
     if (specified_height.is_auto() && !specified_top.is_auto() && specified_bottom.is_auto()) {
         const auto& margin = box.box_model().margin;
@@ -620,20 +620,20 @@ void FormattingContext::layout_absolutely_positioned_element(Box& box)
     auto independent_formatting_context = layout_inside(box, LayoutMode::Default);
     compute_height_for_absolutely_positioned_element(box);
 
-    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved(box).to_px(box);
-    box_model.margin.top = box.computed_values().margin().top.resolved(box, height_of_containing_block).resolved(box).to_px(box);
-    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved(box).to_px(box);
-    box_model.margin.bottom = box.computed_values().margin().bottom.resolved(box, height_of_containing_block).resolved(box).to_px(box);
+    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).to_px(box);
+    box_model.margin.top = box.computed_values().margin().top.resolved(box, height_of_containing_block).to_px(box);
+    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).to_px(box);
+    box_model.margin.bottom = box.computed_values().margin().bottom.resolved(box, height_of_containing_block).to_px(box);
 
     box_model.border.left = box.computed_values().border_left().width;
     box_model.border.right = box.computed_values().border_right().width;
     box_model.border.top = box.computed_values().border_top().width;
     box_model.border.bottom = box.computed_values().border_bottom().width;
 
-    box_model.offset.left = box.computed_values().offset().left.resolved(box, width_of_containing_block).resolved(box).to_px(box);
-    box_model.offset.top = box.computed_values().offset().top.resolved(box, height_of_containing_block).resolved(box).to_px(box);
-    box_model.offset.right = box.computed_values().offset().right.resolved(box, width_of_containing_block).resolved(box).to_px(box);
-    box_model.offset.bottom = box.computed_values().offset().bottom.resolved(box, height_of_containing_block).resolved(box).to_px(box);
+    box_model.offset.left = box.computed_values().offset().left.resolved(box, width_of_containing_block).to_px(box);
+    box_model.offset.top = box.computed_values().offset().top.resolved(box, height_of_containing_block).to_px(box);
+    box_model.offset.right = box.computed_values().offset().right.resolved(box, width_of_containing_block).to_px(box);
+    box_model.offset.bottom = box.computed_values().offset().bottom.resolved(box, height_of_containing_block).to_px(box);
 
     auto is_auto = [](auto const& length_percentage) {
         return length_percentage.is_length() && length_percentage.length().is_auto();

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -125,7 +125,8 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
     if (box.is_inline_block()) {
         auto& inline_block = const_cast<BlockContainer&>(verify_cast<BlockContainer>(box));
 
-        if (inline_block.computed_values().width().is_length() && inline_block.computed_values().width().length().is_undefined_or_auto()) {
+        auto& width_value = inline_block.computed_values().width();
+        if (!width_value.has_value() || (width_value->is_length() && width_value->length().is_undefined_or_auto())) {
             auto result = calculate_shrink_to_fit_widths(inline_block);
 
             auto available_width = containing_block().content_width()
@@ -140,16 +141,17 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             inline_block.set_content_width(width);
         } else {
             auto container_width = CSS::Length::make_px(containing_block().content_width());
-            inline_block.set_content_width(inline_block.computed_values().width().resolved(box, container_width).resolved_or_zero(inline_block).to_px(inline_block));
+            inline_block.set_content_width(width_value->resolved(box, container_width).resolved_or_zero(inline_block).to_px(inline_block));
         }
         auto independent_formatting_context = layout_inside(inline_block, layout_mode);
 
-        if (inline_block.computed_values().height().is_length() && inline_block.computed_values().height().length().is_undefined_or_auto()) {
+        auto& height_value = inline_block.computed_values().height();
+        if (!height_value.has_value() || (height_value->is_length() && height_value->length().is_undefined_or_auto())) {
             // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.
             BlockFormattingContext::compute_height(inline_block);
         } else {
             auto container_height = CSS::Length::make_px(containing_block().content_height());
-            inline_block.set_content_height(inline_block.computed_values().height().resolved(box, container_height).resolved_or_zero(inline_block).to_px(inline_block));
+            inline_block.set_content_height(height_value->resolved(box, container_height).resolved_or_zero(inline_block).to_px(inline_block));
         }
 
         independent_formatting_context->parent_context_did_dimension_child_root_box();

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -108,12 +108,12 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
     auto width_of_containing_block = CSS::Length::make_px(containing_block().content_width());
     auto& box_model = box.box_model();
 
-    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).to_px(box);
     box_model.border.left = box.computed_values().border_left().width;
-    box_model.padding.left = box.computed_values().padding().left.resolved(box, width_of_containing_block).resolved(box).to_px(box);
-    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box_model.padding.left = box.computed_values().padding().left.resolved(box, width_of_containing_block).to_px(box);
+    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).to_px(box);
     box_model.border.right = box.computed_values().border_right().width;
-    box_model.padding.right = box.computed_values().padding().right.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box_model.padding.right = box.computed_values().padding().right.resolved(box, width_of_containing_block).to_px(box);
 
     if (is<ReplacedBox>(box)) {
         auto& replaced = verify_cast<ReplacedBox>(box);
@@ -141,7 +141,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             inline_block.set_content_width(width);
         } else {
             auto container_width = CSS::Length::make_px(containing_block().content_width());
-            inline_block.set_content_width(width_value->resolved(box, container_width).resolved(inline_block).to_px(inline_block));
+            inline_block.set_content_width(width_value->resolved(box, container_width).to_px(inline_block));
         }
         auto independent_formatting_context = layout_inside(inline_block, layout_mode);
 
@@ -151,7 +151,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             BlockFormattingContext::compute_height(inline_block);
         } else {
             auto container_height = CSS::Length::make_px(containing_block().content_height());
-            inline_block.set_content_height(height_value->resolved(box, container_height).resolved(inline_block).to_px(inline_block));
+            inline_block.set_content_height(height_value->resolved(box, container_height).to_px(inline_block));
         }
 
         independent_formatting_context->parent_context_did_dimension_child_root_box();

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -126,7 +126,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
         auto& inline_block = const_cast<BlockContainer&>(verify_cast<BlockContainer>(box));
 
         auto& width_value = inline_block.computed_values().width();
-        if (!width_value.has_value() || (width_value->is_length() && width_value->length().is_undefined_or_auto())) {
+        if (!width_value.has_value() || (width_value->is_length() && width_value->length().is_auto())) {
             auto result = calculate_shrink_to_fit_widths(inline_block);
 
             auto available_width = containing_block().content_width()
@@ -146,7 +146,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
         auto independent_formatting_context = layout_inside(inline_block, layout_mode);
 
         auto& height_value = inline_block.computed_values().height();
-        if (!height_value.has_value() || (height_value->is_length() && height_value->length().is_undefined_or_auto())) {
+        if (!height_value.has_value() || (height_value->is_length() && height_value->length().is_auto())) {
             // FIXME: (10.6.6) If 'height' is 'auto', the height depends on the element's descendants per 10.6.7.
             BlockFormattingContext::compute_height(inline_block);
         } else {

--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -108,12 +108,12 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
     auto width_of_containing_block = CSS::Length::make_px(containing_block().content_width());
     auto& box_model = box.box_model();
 
-    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box_model.margin.left = box.computed_values().margin().left.resolved(box, width_of_containing_block).resolved(box).to_px(box);
     box_model.border.left = box.computed_values().border_left().width;
-    box_model.padding.left = box.computed_values().padding().left.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
-    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box_model.padding.left = box.computed_values().padding().left.resolved(box, width_of_containing_block).resolved(box).to_px(box);
+    box_model.margin.right = box.computed_values().margin().right.resolved(box, width_of_containing_block).resolved(box).to_px(box);
     box_model.border.right = box.computed_values().border_right().width;
-    box_model.padding.right = box.computed_values().padding().right.resolved(box, width_of_containing_block).resolved_or_zero(box).to_px(box);
+    box_model.padding.right = box.computed_values().padding().right.resolved(box, width_of_containing_block).resolved(box).to_px(box);
 
     if (is<ReplacedBox>(box)) {
         auto& replaced = verify_cast<ReplacedBox>(box);
@@ -141,7 +141,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             inline_block.set_content_width(width);
         } else {
             auto container_width = CSS::Length::make_px(containing_block().content_width());
-            inline_block.set_content_width(width_value->resolved(box, container_width).resolved_or_zero(inline_block).to_px(inline_block));
+            inline_block.set_content_width(width_value->resolved(box, container_width).resolved(inline_block).to_px(inline_block));
         }
         auto independent_formatting_context = layout_inside(inline_block, layout_mode);
 
@@ -151,7 +151,7 @@ void InlineFormattingContext::dimension_box_on_line(Box& box, LayoutMode layout_
             BlockFormattingContext::compute_height(inline_block);
         } else {
             auto container_height = CSS::Length::make_px(containing_block().content_height());
-            inline_block.set_content_height(height_value->resolved(box, container_height).resolved_or_zero(inline_block).to_px(inline_block));
+            inline_block.set_content_height(height_value->resolved(box, container_height).resolved(inline_block).to_px(inline_block));
         }
 
         independent_formatting_context->parent_context_did_dimension_child_root_box();

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -61,10 +61,10 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
                 for (auto const& layer : computed_box_shadow) {
                     resolved_box_shadow_data.empend(
                         layer.color,
-                        static_cast<int>(layer.offset_x.resolved_or_zero(*this).to_px(*this)),
-                        static_cast<int>(layer.offset_y.resolved_or_zero(*this).to_px(*this)),
-                        static_cast<int>(layer.blur_radius.resolved_or_zero(*this).to_px(*this)),
-                        static_cast<int>(layer.spread_distance.resolved_or_zero(*this).to_px(*this)),
+                        static_cast<int>(layer.offset_x.resolved(*this).to_px(*this)),
+                        static_cast<int>(layer.offset_y.resolved(*this).to_px(*this)),
+                        static_cast<int>(layer.blur_radius.resolved(*this).to_px(*this)),
+                        static_cast<int>(layer.spread_distance.resolved(*this).to_px(*this)),
                         layer.placement == CSS::BoxShadowPlacement::Outer ? Painting::BoxShadowPlacement::Outer : Painting::BoxShadowPlacement::Inner);
                 }
                 Painting::paint_box_shadow(context, enclosing_int_rect(absolute_fragment_rect), resolved_box_shadow_data);

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -61,10 +61,10 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
                 for (auto const& layer : computed_box_shadow) {
                     resolved_box_shadow_data.empend(
                         layer.color,
-                        static_cast<int>(layer.offset_x.resolved(*this).to_px(*this)),
-                        static_cast<int>(layer.offset_y.resolved(*this).to_px(*this)),
-                        static_cast<int>(layer.blur_radius.resolved(*this).to_px(*this)),
-                        static_cast<int>(layer.spread_distance.resolved(*this).to_px(*this)),
+                        static_cast<int>(layer.offset_x.to_px(*this)),
+                        static_cast<int>(layer.offset_y.to_px(*this)),
+                        static_cast<int>(layer.blur_radius.to_px(*this)),
+                        static_cast<int>(layer.spread_distance.to_px(*this)),
                         layer.placement == CSS::BoxShadowPlacement::Outer ? Painting::BoxShadowPlacement::Outer : Painting::BoxShadowPlacement::Inner);
                 }
                 Painting::paint_box_shadow(context, enclosing_int_rect(absolute_fragment_rect), resolved_box_shadow_data);

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -463,7 +463,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
         if (border.line_style == CSS::LineStyle::None)
             border.width = 0;
         else
-            border.width = specified_style.length_or_fallback(width_property, CSS::Length::make_px(0)).resolved(*this).to_px(*this);
+            border.width = specified_style.length_or_fallback(width_property, CSS::Length::make_px(0)).to_px(*this);
     };
 
     do_border_style(computed_values.border_left(), CSS::PropertyID::BorderLeftWidth, CSS::PropertyID::BorderLeftColor, CSS::PropertyID::BorderLeftStyle);

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -463,7 +463,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
         if (border.line_style == CSS::LineStyle::None)
             border.width = 0;
         else
-            border.width = specified_style.length_or_fallback(width_property, CSS::Length::make_px(0)).resolved_or_zero(*this).to_px(*this);
+            border.width = specified_style.length_or_fallback(width_property, CSS::Length::make_px(0)).resolved(*this).to_px(*this);
     };
 
     do_border_style(computed_values.border_left(), CSS::PropertyID::BorderLeftWidth, CSS::PropertyID::BorderLeftColor, CSS::PropertyID::BorderLeftStyle);

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -430,15 +430,21 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
 
     if (auto width = specified_style.property(CSS::PropertyID::Width); width.has_value() && !width.value()->has_auto())
         m_has_definite_width = true;
-    computed_values.set_width(specified_style.length_percentage_or_fallback(CSS::PropertyID::Width, CSS::Length {}));
-    computed_values.set_min_width(specified_style.length_percentage_or_fallback(CSS::PropertyID::MinWidth, CSS::Length {}));
-    computed_values.set_max_width(specified_style.length_percentage_or_fallback(CSS::PropertyID::MaxWidth, CSS::Length {}));
+    if (auto maybe_length_percentage = specified_style.length_percentage(CSS::PropertyID::Width); maybe_length_percentage.has_value())
+        computed_values.set_width(maybe_length_percentage.release_value());
+    if (auto maybe_length_percentage = specified_style.length_percentage(CSS::PropertyID::MinWidth); maybe_length_percentage.has_value())
+        computed_values.set_min_width(maybe_length_percentage.release_value());
+    if (auto maybe_length_percentage = specified_style.length_percentage(CSS::PropertyID::MaxWidth); maybe_length_percentage.has_value())
+        computed_values.set_max_width(maybe_length_percentage.release_value());
 
     if (auto height = specified_style.property(CSS::PropertyID::Height); height.has_value() && !height.value()->has_auto())
         m_has_definite_height = true;
-    computed_values.set_height(specified_style.length_percentage_or_fallback(CSS::PropertyID::Height, CSS::Length {}));
-    computed_values.set_min_height(specified_style.length_percentage_or_fallback(CSS::PropertyID::MinHeight, CSS::Length {}));
-    computed_values.set_max_height(specified_style.length_percentage_or_fallback(CSS::PropertyID::MaxHeight, CSS::Length {}));
+    if (auto maybe_length_percentage = specified_style.length_percentage(CSS::PropertyID::Height); maybe_length_percentage.has_value())
+        computed_values.set_height(maybe_length_percentage.release_value());
+    if (auto maybe_length_percentage = specified_style.length_percentage(CSS::PropertyID::MinHeight); maybe_length_percentage.has_value())
+        computed_values.set_min_height(maybe_length_percentage.release_value());
+    if (auto maybe_length_percentage = specified_style.length_percentage(CSS::PropertyID::MaxHeight); maybe_length_percentage.has_value())
+        computed_values.set_max_height(maybe_length_percentage.release_value());
 
     computed_values.set_offset(specified_style.length_box(CSS::PropertyID::Left, CSS::PropertyID::Top, CSS::PropertyID::Right, CSS::PropertyID::Bottom, CSS::Length::make_auto()));
     computed_values.set_margin(specified_style.length_box(CSS::PropertyID::MarginLeft, CSS::PropertyID::MarginTop, CSS::PropertyID::MarginRight, CSS::PropertyID::MarginBottom, CSS::Length::make_px(0)));
@@ -457,7 +463,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
         if (border.line_style == CSS::LineStyle::None)
             border.width = 0;
         else
-            border.width = specified_style.length_or_fallback(width_property, {}).resolved_or_zero(*this).to_px(*this);
+            border.width = specified_style.length_or_fallback(width_property, CSS::Length::make_px(0)).resolved_or_zero(*this).to_px(*this);
     };
 
     do_border_style(computed_values.border_left(), CSS::PropertyID::BorderLeftWidth, CSS::PropertyID::BorderLeftColor, CSS::PropertyID::BorderLeftStyle);

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -52,7 +52,7 @@ void TableFormattingContext::run(Box& box, LayoutMode)
             content_height += row.content_height();
         });
 
-        if (row_group_box.computed_values().width().is_length() && row_group_box.computed_values().width().length().is_auto())
+        if (row_group_box.computed_values().width().has_value() && row_group_box.computed_values().width()->is_length() && row_group_box.computed_values().width()->length().is_auto())
             row_group_box.set_content_width(content_width);
         row_group_box.set_content_height(content_height);
 
@@ -61,7 +61,7 @@ void TableFormattingContext::run(Box& box, LayoutMode)
         total_content_width = max(total_content_width, row_group_box.content_width());
     });
 
-    if (box.computed_values().width().is_length() && box.computed_values().width().length().is_auto())
+    if (box.computed_values().width().has_value() && box.computed_values().width()->is_length() && box.computed_values().width()->length().is_auto())
         box.set_content_width(total_content_width);
 
     // FIXME: This is a total hack, we should respect the 'height' property.
@@ -72,7 +72,7 @@ void TableFormattingContext::calculate_column_widths(Box& row, Vector<float>& co
 {
     size_t column_index = 0;
     auto* table = row.first_ancestor_of_type<TableBox>();
-    bool use_auto_layout = !table || (table->computed_values().width().is_length() && table->computed_values().width().length().is_undefined_or_auto());
+    bool use_auto_layout = !table || (!table->computed_values().width().has_value() || (table->computed_values().width()->is_length() && table->computed_values().width()->length().is_undefined_or_auto()));
     row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
         compute_width(cell);
         if (use_auto_layout) {
@@ -91,7 +91,7 @@ void TableFormattingContext::layout_row(Box& row, Vector<float>& column_widths)
     float tallest_cell_height = 0;
     float content_width = 0;
     auto* table = row.first_ancestor_of_type<TableBox>();
-    bool use_auto_layout = !table || (table->computed_values().width().is_length() && table->computed_values().width().length().is_undefined_or_auto());
+    bool use_auto_layout = !table || (!table->computed_values().width().has_value() || (table->computed_values().width()->is_length() && table->computed_values().width()->length().is_undefined_or_auto()));
 
     row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
         cell.set_offset(row.effective_offset().translated(content_width, 0));

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -72,7 +72,7 @@ void TableFormattingContext::calculate_column_widths(Box& row, Vector<float>& co
 {
     size_t column_index = 0;
     auto* table = row.first_ancestor_of_type<TableBox>();
-    bool use_auto_layout = !table || (!table->computed_values().width().has_value() || (table->computed_values().width()->is_length() && table->computed_values().width()->length().is_undefined_or_auto()));
+    bool use_auto_layout = !table || (!table->computed_values().width().has_value() || (table->computed_values().width()->is_length() && table->computed_values().width()->length().is_auto()));
     row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
         compute_width(cell);
         if (use_auto_layout) {
@@ -91,7 +91,7 @@ void TableFormattingContext::layout_row(Box& row, Vector<float>& column_widths)
     float tallest_cell_height = 0;
     float content_width = 0;
     auto* table = row.first_ancestor_of_type<TableBox>();
-    bool use_auto_layout = !table || (!table->computed_values().width().has_value() || (table->computed_values().width()->is_length() && table->computed_values().width()->length().is_undefined_or_auto()));
+    bool use_auto_layout = !table || (!table->computed_values().width().has_value() || (table->computed_values().width()->is_length() && table->computed_values().width()->length().is_auto()));
 
     row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
         cell.set_offset(row.effective_offset().translated(content_width, 0));

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -88,22 +88,14 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
                 width = image.width();
                 height = image.height();
             } else if (x_is_auto) {
-                height = layer.size_y.resolved(layout_node, CSS::Length::make_px(background_positioning_area.height()))
-                             .resolved(layout_node)
-                             .to_px(layout_node);
+                height = layer.size_y.resolved(layout_node, CSS::Length::make_px(background_positioning_area.height())).to_px(layout_node);
                 width = roundf(image.width() * ((float)height / (float)image.height()));
             } else if (y_is_auto) {
-                width = layer.size_x.resolved(layout_node, CSS::Length::make_px(background_positioning_area.width()))
-                            .resolved(layout_node)
-                            .to_px(layout_node);
+                width = layer.size_x.resolved(layout_node, CSS::Length::make_px(background_positioning_area.width())).to_px(layout_node);
                 height = roundf(image.height() * ((float)width / (float)image.width()));
             } else {
-                width = layer.size_x.resolved(layout_node, CSS::Length::make_px(background_positioning_area.width()))
-                            .resolved(layout_node)
-                            .to_px(layout_node);
-                height = layer.size_y.resolved(layout_node, CSS::Length::make_px(background_positioning_area.height()))
-                             .resolved(layout_node)
-                             .to_px(layout_node);
+                width = layer.size_x.resolved(layout_node, CSS::Length::make_px(background_positioning_area.width())).to_px(layout_node);
+                height = layer.size_y.resolved(layout_node, CSS::Length::make_px(background_positioning_area.height())).to_px(layout_node);
             }
 
             image_rect.set_size(width, height);
@@ -143,18 +135,14 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         int space_y = background_positioning_area.height() - image_rect.height();
 
         // Position
-        int offset_x = layer.position_offset_x.resolved(layout_node, CSS::Length::make_px(space_x))
-                           .resolved(layout_node)
-                           .to_px(layout_node);
+        int offset_x = layer.position_offset_x.resolved(layout_node, CSS::Length::make_px(space_x)).to_px(layout_node);
         if (layer.position_edge_x == CSS::PositionEdge::Right) {
             image_rect.set_right_without_resize(background_positioning_area.right() - offset_x);
         } else {
             image_rect.set_left(background_positioning_area.left() + offset_x);
         }
 
-        int offset_y = layer.position_offset_y.resolved(layout_node, CSS::Length::make_px(space_y))
-                           .resolved(layout_node)
-                           .to_px(layout_node);
+        int offset_y = layer.position_offset_y.resolved(layout_node, CSS::Length::make_px(space_y)).to_px(layout_node);
         if (layer.position_edge_y == CSS::PositionEdge::Bottom) {
             image_rect.set_bottom_without_resize(background_positioning_area.bottom() - offset_y);
         } else {

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.cpp
@@ -89,20 +89,20 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
                 height = image.height();
             } else if (x_is_auto) {
                 height = layer.size_y.resolved(layout_node, CSS::Length::make_px(background_positioning_area.height()))
-                             .resolved_or_zero(layout_node)
+                             .resolved(layout_node)
                              .to_px(layout_node);
                 width = roundf(image.width() * ((float)height / (float)image.height()));
             } else if (y_is_auto) {
                 width = layer.size_x.resolved(layout_node, CSS::Length::make_px(background_positioning_area.width()))
-                            .resolved_or_zero(layout_node)
+                            .resolved(layout_node)
                             .to_px(layout_node);
                 height = roundf(image.height() * ((float)width / (float)image.width()));
             } else {
                 width = layer.size_x.resolved(layout_node, CSS::Length::make_px(background_positioning_area.width()))
-                            .resolved_or_zero(layout_node)
+                            .resolved(layout_node)
                             .to_px(layout_node);
                 height = layer.size_y.resolved(layout_node, CSS::Length::make_px(background_positioning_area.height()))
-                             .resolved_or_zero(layout_node)
+                             .resolved(layout_node)
                              .to_px(layout_node);
             }
 
@@ -144,7 +144,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
 
         // Position
         int offset_x = layer.position_offset_x.resolved(layout_node, CSS::Length::make_px(space_x))
-                           .resolved_or_zero(layout_node)
+                           .resolved(layout_node)
                            .to_px(layout_node);
         if (layer.position_edge_x == CSS::PositionEdge::Right) {
             image_rect.set_right_without_resize(background_positioning_area.right() - offset_x);
@@ -153,7 +153,7 @@ void paint_background(PaintContext& context, Layout::NodeWithStyleAndBoxModelMet
         }
 
         int offset_y = layer.position_offset_y.resolved(layout_node, CSS::Length::make_px(space_y))
-                           .resolved_or_zero(layout_node)
+                           .resolved(layout_node)
                            .to_px(layout_node);
         if (layer.position_edge_y == CSS::PositionEdge::Bottom) {
             image_rect.set_bottom_without_resize(background_positioning_area.bottom() - offset_y);

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -17,10 +17,10 @@ BorderRadiusData normalized_border_radius_data(Layout::Node const& node, Gfx::Fl
     //        Spec just says "Refer to corresponding dimension of the border box."
     //        For now, all relative values are relative to the width.
     auto width_length = CSS::Length::make_px(rect.width());
-    auto bottom_left_radius_px = bottom_left_radius.resolved(node, width_length).resolved(node).to_px(node);
-    auto bottom_right_radius_px = bottom_right_radius.resolved(node, width_length).resolved(node).to_px(node);
-    auto top_left_radius_px = top_left_radius.resolved(node, width_length).resolved(node).to_px(node);
-    auto top_right_radius_px = top_right_radius.resolved(node, width_length).resolved(node).to_px(node);
+    auto bottom_left_radius_px = bottom_left_radius.resolved(node, width_length).to_px(node);
+    auto bottom_right_radius_px = bottom_right_radius.resolved(node, width_length).to_px(node);
+    auto top_left_radius_px = top_left_radius.resolved(node, width_length).to_px(node);
+    auto top_right_radius_px = top_right_radius.resolved(node, width_length).to_px(node);
 
     // Scale overlapping curves according to https://www.w3.org/TR/css-backgrounds-3/#corner-overlap
     auto f = 1.0f;

--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -17,10 +17,10 @@ BorderRadiusData normalized_border_radius_data(Layout::Node const& node, Gfx::Fl
     //        Spec just says "Refer to corresponding dimension of the border box."
     //        For now, all relative values are relative to the width.
     auto width_length = CSS::Length::make_px(rect.width());
-    auto bottom_left_radius_px = bottom_left_radius.resolved(node, width_length).resolved_or_zero(node).to_px(node);
-    auto bottom_right_radius_px = bottom_right_radius.resolved(node, width_length).resolved_or_zero(node).to_px(node);
-    auto top_left_radius_px = top_left_radius.resolved(node, width_length).resolved_or_zero(node).to_px(node);
-    auto top_right_radius_px = top_right_radius.resolved(node, width_length).resolved_or_zero(node).to_px(node);
+    auto bottom_left_radius_px = bottom_left_radius.resolved(node, width_length).resolved(node).to_px(node);
+    auto bottom_right_radius_px = bottom_right_radius.resolved(node, width_length).resolved(node).to_px(node);
+    auto top_left_radius_px = top_left_radius.resolved(node, width_length).resolved(node).to_px(node);
+    auto top_right_radius_px = top_right_radius.resolved(node, width_length).resolved(node).to_px(node);
 
     // Scale overlapping curves according to https://www.w3.org/TR/css-backgrounds-3/#corner-overlap
     auto f = 1.0f;


### PR DESCRIPTION
The existence of "undefined" lengths has been annoying me for a while, so let's remove it! Now, Lengths always have a value. `++type_safety;` :^)

There is some awkwardness still. The `Length::to_px()` overload that takes several values can't resolve a `calc()` Length. That could be solved by passing all those parameters to the calc() resolution functions instead of just a layout node, but that gets unwieldy. Maybe some kind of `LengthResolutionParameters` struct would be better?

Also not entirely convinced about making the width/height properties Optional... `max-width/height` defaults to `none`, which means we can't just use `auto` as the default for them all.