### PR TITLE
LibTLS+LibCrypto: Implement signature checking for DHE and ECDHE

### DIFF
--- a/Userland/Libraries/LibCrypto/Hash/HashManager.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashManager.h
@@ -200,6 +200,11 @@ public:
     }
 #endif
 
+    inline HashKind kind() const
+    {
+        return m_kind;
+    }
+
     inline bool is(HashKind kind) const
     {
         return m_kind == kind;

--- a/Userland/Libraries/LibCrypto/PK/Code/EMSA_PKCS1_V1_5.h
+++ b/Userland/Libraries/LibCrypto/PK/Code/EMSA_PKCS1_V1_5.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2022, Michiel Visser <opensource@webmichiel.nl>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/Format.h>
+#include <AK/Random.h>
+#include <AK/Vector.h>
+#include <LibCrypto/Hash/MD5.h>
+#include <LibCrypto/Hash/SHA1.h>
+#include <LibCrypto/Hash/SHA2.h>
+#include <LibCrypto/PK/Code/Code.h>
+
+namespace Crypto {
+namespace PK {
+
+template<typename HashFunction>
+class EMSA_PKCS1_V1_5 : public Code<HashFunction> {
+public:
+    template<typename... Args>
+    EMSA_PKCS1_V1_5(Args... args)
+        : Code<HashFunction>(args...)
+    {
+    }
+
+    virtual void encode(ReadonlyBytes in, ByteBuffer& out, size_t em_bits) override
+    {
+        auto& hash_fn = this->hasher();
+        hash_fn.update(in);
+        auto message_digest = hash_fn.digest();
+        auto message_digest_size = message_digest.bytes().size();
+
+        auto digest_info = hash_function_digest_info();
+        auto encoded_message_length = digest_info.size() + message_digest_size;
+
+        auto em_bytes = (em_bits + 7) / 8;
+        // RFC8017 section 9.2: 3. If emLen < tLen + 11, output "intended encoded message length too short" and stop.
+        if (em_bytes < encoded_message_length + 11) {
+            dbgln("EMSA-PKCS1-V1_5-ENCODE: intended encoded message length too short");
+            return;
+        }
+
+        auto offset = 0;
+        // Build the padding 0x0001ffff..ff00
+        out[offset++] = 0x00;
+        out[offset++] = 0x01;
+        for (size_t i = 0; i < em_bytes - encoded_message_length - 3; i++)
+            out[offset++] = 0xff;
+        out[offset++] = 0x00;
+        // Add the digest info and message digest
+        out.overwrite(offset, digest_info.data(), digest_info.size());
+        offset += digest_info.size();
+        out.overwrite(offset, message_digest.immutable_data(), message_digest.data_length());
+    }
+
+    virtual VerificationConsistency verify(ReadonlyBytes msg, ReadonlyBytes emsg, size_t em_bits) override
+    {
+        auto em_bytes = (em_bits + 7) / 8;
+        auto buffer_result = ByteBuffer::create_uninitialized(em_bytes);
+        if (buffer_result.is_error()) {
+            dbgln("EMSA-PKCS1-V1_5-VERIFY: out of memory");
+            return VerificationConsistency::Inconsistent;
+        }
+        auto buffer = buffer_result.release_value();
+
+        // Encode the supplied message into the buffer
+        encode(msg, buffer, em_bits);
+
+        // Check that the expected message matches the encoded original message
+        if (emsg != buffer) {
+            return VerificationConsistency::Inconsistent;
+        }
+        return VerificationConsistency::Consistent;
+    }
+
+private:
+    inline ReadonlyBytes hash_function_digest_info();
+};
+
+template<>
+inline ReadonlyBytes EMSA_PKCS1_V1_5<Crypto::Hash::MD5>::hash_function_digest_info()
+{
+    // RFC8017 section 9.2 notes 1
+    return { "\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10", 18 };
+}
+
+template<>
+inline ReadonlyBytes EMSA_PKCS1_V1_5<Crypto::Hash::SHA1>::hash_function_digest_info()
+{
+    // RFC8017 section 9.2 notes 1
+    return { "\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14", 15 };
+}
+
+template<>
+inline ReadonlyBytes EMSA_PKCS1_V1_5<Crypto::Hash::SHA256>::hash_function_digest_info()
+{
+    // RFC8017 section 9.2 notes 1
+    return { "\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20", 19 };
+}
+
+template<>
+inline ReadonlyBytes EMSA_PKCS1_V1_5<Crypto::Hash::SHA384>::hash_function_digest_info()
+{
+    // RFC8017 section 9.2 notes 1
+    return { "\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30", 19 };
+}
+
+template<>
+inline ReadonlyBytes EMSA_PKCS1_V1_5<Crypto::Hash::SHA512>::hash_function_digest_info()
+{
+    // RFC8017 section 9.2 notes 1
+    return { "\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40", 19 };
+}
+
+}
+}

--- a/Userland/Libraries/LibCrypto/PK/Code/EMSA_PKCS1_V1_5.h
+++ b/Userland/Libraries/LibCrypto/PK/Code/EMSA_PKCS1_V1_5.h
@@ -6,10 +6,7 @@
 
 #pragma once
 
-#include <AK/Array.h>
-#include <AK/Format.h>
-#include <AK/Random.h>
-#include <AK/Vector.h>
+#include <LibCrypto/Hash/HashManager.h>
 #include <LibCrypto/Hash/MD5.h>
 #include <LibCrypto/Hash/SHA1.h>
 #include <LibCrypto/Hash/SHA2.h>
@@ -114,6 +111,27 @@ inline ReadonlyBytes EMSA_PKCS1_V1_5<Crypto::Hash::SHA512>::hash_function_digest
 {
     // RFC8017 section 9.2 notes 1
     return { "\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40", 19 };
+}
+
+template<>
+inline ReadonlyBytes EMSA_PKCS1_V1_5<Crypto::Hash::Manager>::hash_function_digest_info()
+{
+    // RFC8017 section 9.2 notes 1
+    switch (hasher().kind()) {
+    case Hash::HashKind::MD5:
+        return { "\x30\x20\x30\x0c\x06\x08\x2a\x86\x48\x86\xf7\x0d\x02\x05\x05\x00\x04\x10", 18 };
+    case Hash::HashKind::SHA1:
+        return { "\x30\x21\x30\x09\x06\x05\x2b\x0e\x03\x02\x1a\x05\x00\x04\x14", 15 };
+    case Hash::HashKind::SHA256:
+        return { "\x30\x31\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x01\x05\x00\x04\x20", 19 };
+    case Hash::HashKind::SHA384:
+        return { "\x30\x41\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x02\x05\x00\x04\x30", 19 };
+    case Hash::HashKind::SHA512:
+        return { "\x30\x51\x30\x0d\x06\x09\x60\x86\x48\x01\x65\x03\x04\x02\x03\x05\x00\x04\x40", 19 };
+    case Hash::HashKind::None:
+    default:
+        VERIFY_NOT_REACHED();
+    }
 }
 
 }

--- a/Userland/Libraries/LibTLS/Handshake.cpp
+++ b/Userland/Libraries/LibTLS/Handshake.cpp
@@ -489,6 +489,11 @@ ssize_t TLSv12::handle_handshake_payload(ReadonlyBytes vbuffer)
                 write_packet(packet);
                 break;
             }
+            case Error::NotSafe: {
+                auto packet = build_alert(true, (u8)AlertDescription::DecryptError);
+                write_packet(packet);
+                break;
+            }
             case Error::NeedMoreData:
                 // Ignore this, as it's not an "error"
                 dbgln_if(TLS_DEBUG, "More data needed");

--- a/Userland/Libraries/LibTLS/Handshake.cpp
+++ b/Userland/Libraries/LibTLS/Handshake.cpp
@@ -473,7 +473,8 @@ ssize_t TLSv12::handle_handshake_payload(ReadonlyBytes vbuffer)
                 write_packet(packet);
                 break;
             }
-            case Error::NotUnderstood: {
+            case Error::NotUnderstood:
+            case Error::OutOfMemory: {
                 auto packet = build_alert(true, (u8)AlertDescription::InternalError);
                 write_packet(packet);
                 break;

--- a/Userland/Libraries/LibTLS/HandshakeServer.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeServer.cpp
@@ -225,8 +225,7 @@ ssize_t TLSv12::handle_server_key_exchange(ReadonlyBytes buffer)
         TODO();
         break;
     case KeyExchangeAlgorithm::DHE_RSA:
-        handle_dhe_rsa_server_key_exchange(buffer);
-        break;
+        return handle_dhe_rsa_server_key_exchange(buffer);
     case KeyExchangeAlgorithm::DH_anon:
         dbgln("Server key exchange for DH_anon is not implemented");
         TODO();
@@ -255,7 +254,7 @@ ssize_t TLSv12::handle_dhe_rsa_server_key_exchange(ReadonlyBytes buffer)
     auto p_result = ByteBuffer::copy(dh_p);
     if (p_result.is_error()) {
         dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
-        return 0;
+        return (i8)Error::OutOfMemory;
     }
     m_context.server_diffie_hellman_params.p = p_result.release_value();
 
@@ -264,7 +263,7 @@ ssize_t TLSv12::handle_dhe_rsa_server_key_exchange(ReadonlyBytes buffer)
     auto g_result = ByteBuffer::copy(dh_g);
     if (g_result.is_error()) {
         dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
-        return 0;
+        return (i8)Error::OutOfMemory;
     }
     m_context.server_diffie_hellman_params.g = g_result.release_value();
 
@@ -273,7 +272,7 @@ ssize_t TLSv12::handle_dhe_rsa_server_key_exchange(ReadonlyBytes buffer)
     auto Ys_result = ByteBuffer::copy(dh_Ys);
     if (Ys_result.is_error()) {
         dbgln("dhe_rsa_server_key_exchange failed: Not enough memory");
-        return 0;
+        return (i8)Error::OutOfMemory;
     }
     m_context.server_diffie_hellman_params.Ys = Ys_result.release_value();
 
@@ -310,7 +309,7 @@ ssize_t TLSv12::handle_ecdhe_rsa_server_key_exchange(ReadonlyBytes buffer)
     auto server_public_key_copy_result = ByteBuffer::copy(server_public_key);
     if (server_public_key_copy_result.is_error()) {
         dbgln("ecdhe_rsa_server_key_exchange failed: Not enough memory");
-        return 0;
+        return (i8)Error::OutOfMemory;
     }
     m_context.server_diffie_hellman_params.p = server_public_key_copy_result.release_value();
 

--- a/Userland/Libraries/LibTLS/HandshakeServer.cpp
+++ b/Userland/Libraries/LibTLS/HandshakeServer.cpp
@@ -295,15 +295,15 @@ ssize_t TLSv12::handle_ecdhe_rsa_server_key_exchange(ReadonlyBytes buffer)
 
     auto curve_type = buffer[3];
     if (curve_type != (u8)ECCurveType::NamedCurve)
-        return (i8)Error::FeatureNotSupported;
+        return (i8)Error::NotUnderstood;
 
     auto curve = AK::convert_between_host_and_network_endian(ByteReader::load16(buffer.offset_pointer(4)));
     if (curve != (u16)NamedCurve::x25519)
-        return (i8)Error::FeatureNotSupported;
+        return (i8)Error::NotUnderstood;
 
     auto server_public_key_length = buffer[6];
     if (server_public_key_length != x25519_key_size_bytes)
-        return (i8)Error::FeatureNotSupported;
+        return (i8)Error::NotUnderstood;
 
     auto server_public_key = buffer.slice(7, server_public_key_length);
     auto server_public_key_copy_result = ByteBuffer::copy(server_public_key);

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -109,6 +109,7 @@ enum class Error : i8 {
     DecryptionFailed = -20,
     NeedMoreData = -21,
     TimedOut = -22,
+    OutOfMemory = -23,
 };
 
 enum class AlertLevel : u8 {

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -482,6 +482,8 @@ private:
 
     void pseudorandom_function(Bytes output, ReadonlyBytes secret, const u8* label, size_t label_length, ReadonlyBytes seed, ReadonlyBytes seed_b);
 
+    ssize_t verify_rsa_server_key_exchange(ReadonlyBytes server_key_info_buffer, ReadonlyBytes signature_buffer);
+
     size_t key_length() const
     {
         switch (m_context.cipher) {


### PR DESCRIPTION
This pull request implements the signature checking for the DHE and ECDHE key exchanges. Implementing this requires the EMSA-PKCS1-V1_5 encoding, which is also implemented in this pull request.

It also contains some error cleanup in LibTLS, which was originally introduced in #12625.

> This pull request makes sure that an OOM condition will actually result in an error in the DHE and ECDHE key exchange instead of simply returning no error and hoping it will break elsewhere.
> 
> It also changes some of the FeatureNotSupported errors in ECDHE to NotUnderstood, as a compliant server should never send values that will result in the errors. Furthermore, NotUnderstood will actually generate an InternalError TLS alert, instead of crashing the RequestServer.
