### PR TITLE
DynamicLinker: Implement support for RPATH and RUNPATH

### DIFF
--- a/Userland/Libraries/LibELF/DynamicLinker.cpp
+++ b/Userland/Libraries/LibELF/DynamicLinker.cpp
@@ -127,7 +127,7 @@ static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> map_library(String c
     search_paths.append("/usr/local/lib"sv);
 
     for (auto const& search_path : search_paths) {
-        LexicalPath library_path(search_path);
+        LexicalPath library_path(search_path.replace("$ORIGIN"sv, LexicalPath::dirname(s_main_program_name)));
         int fd = open(library_path.append(name).string().characters(), O_RDONLY);
 
         if (fd < 0)

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -80,6 +80,8 @@ public:
     static Optional<DynamicObject::SymbolLookupResult> lookup_symbol(const ELF::DynamicObject::Symbol&);
     void copy_initial_tls_data_into(ByteBuffer& buffer) const;
 
+    DynamicObject const& dynamic_object() const;
+
 private:
     DynamicLoader(int fd, String filename, void* file_data, size_t file_size);
 
@@ -106,8 +108,6 @@ private:
     private:
         ElfW(Phdr) m_program_header; // Explicitly a copy of the PHDR in the image
     };
-
-    const DynamicObject& dynamic_object() const;
 
     // Stage 1
     void load_program_headers();


### PR DESCRIPTION
This is needed for running Lagom binaries inside Serenity, as they find their `liblagom-core` via the rpath field.