### PR TITLE
LibWeb: SVG parse signed numbers in eliptical arc

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.cpp
@@ -230,7 +230,8 @@ void AttributeParser::parse_elliptical_arc()
 
 float AttributeParser::parse_length()
 {
-    return parse_sign() * parse_number();
+    // https://www.w3.org/TR/SVG11/types.html#DataTypeLength
+    return parse_number();
 }
 
 float AttributeParser::parse_coordinate()
@@ -302,10 +303,10 @@ Vector<float> AttributeParser::parse_coordinate_pair_triplet()
 Vector<float> AttributeParser::parse_elliptical_arg_argument()
 {
     Vector<float> numbers;
-    numbers.append(parse_number());
+    numbers.append(parse_nonnegative_number());
     if (match_comma_whitespace())
         parse_comma_whitespace();
-    numbers.append(parse_number());
+    numbers.append(parse_nonnegative_number());
     if (match_comma_whitespace())
         parse_comma_whitespace();
     numbers.append(parse_number());
@@ -368,7 +369,15 @@ float AttributeParser::parse_fractional_constant()
     return builder.to_string().to_int().value();
 }
 
+// https://www.w3.org/TR/SVG11/types.html#DataTypeNumber
 float AttributeParser::parse_number()
+{
+    auto sign = parse_sign();
+    return sign * parse_nonnegative_number();
+}
+
+// https://www.w3.org/TR/SVG11/paths.html#PathDataBNF
+float AttributeParser::parse_nonnegative_number()
 {
     auto number = parse_fractional_constant();
 

--- a/Userland/Libraries/LibWeb/SVG/AttributeParser.h
+++ b/Userland/Libraries/LibWeb/SVG/AttributeParser.h
@@ -70,6 +70,7 @@ private:
     void parse_comma_whitespace();
     float parse_fractional_constant();
     float parse_number();
+    float parse_nonnegative_number();
     float parse_flag();
     // -1 if negative, +1 otherwise
     int parse_sign();


### PR DESCRIPTION
Fixes crash on cartman.svg from https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/cartman.svg
Number parsing (with or without sign) is now aligned with spec.