### PR TITLE
LibCrypto: Simplify and move static CRC32 table to cpp file

### DIFF
--- a/Userland/Libraries/LibCrypto/Checksum/CRC32.cpp
+++ b/Userland/Libraries/LibCrypto/Checksum/CRC32.cpp
@@ -1,14 +1,36 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/Span.h>
 #include <AK/Types.h>
 #include <LibCrypto/Checksum/CRC32.h>
 
 namespace Crypto::Checksum {
+
+static constexpr auto generate_table()
+{
+    Array<u32, 256> data {};
+    for (auto i = 0u; i < data.size(); i++) {
+        u32 value = i;
+
+        for (auto j = 0; j < 8; j++) {
+            if (value & 1) {
+                value = 0xEDB88320 ^ (value >> 1);
+            } else {
+                value = value >> 1;
+            }
+        }
+
+        data[i] = value;
+    }
+    return data;
+}
+
+static constexpr auto table = generate_table();
 
 void CRC32::update(ReadonlyBytes data)
 {

--- a/Userland/Libraries/LibCrypto/Checksum/CRC32.h
+++ b/Userland/Libraries/LibCrypto/Checksum/CRC32.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,35 +11,6 @@
 #include <LibCrypto/Checksum/ChecksumFunction.h>
 
 namespace Crypto::Checksum {
-
-struct Table {
-    u32 data[256];
-
-    constexpr Table()
-        : data()
-    {
-        for (auto i = 0; i < 256; i++) {
-            u32 value = i;
-
-            for (auto j = 0; j < 8; j++) {
-                if (value & 1) {
-                    value = 0xEDB88320 ^ (value >> 1);
-                } else {
-                    value = value >> 1;
-                }
-            }
-
-            data[i] = value;
-        }
-    }
-
-    constexpr u32 operator[](int index) const
-    {
-        return data[index];
-    }
-};
-
-constexpr static auto table = Table();
 
 class CRC32 : public ChecksumFunction<u32> {
 public:


### PR DESCRIPTION
CRC32 table is generated at compile-time and put into a static
variable in the header file. This can be moved to be a function
instead of a class, be moved to the `.cpp` file`, and generated as a
`constexpr` variable instead of a `static`.