### PR TITLE
Kernel: fixed argument passing for profiling_enable syscall

### DIFF
--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -390,7 +390,7 @@ public:
     ErrorOr<FlatPtr> sys$getrandom(Userspace<void*>, size_t, unsigned int);
     ErrorOr<FlatPtr> sys$getkeymap(Userspace<const Syscall::SC_getkeymap_params*>);
     ErrorOr<FlatPtr> sys$setkeymap(Userspace<const Syscall::SC_setkeymap_params*>);
-    ErrorOr<FlatPtr> sys$profiling_enable(pid_t, u64);
+    ErrorOr<FlatPtr> sys$profiling_enable(pid_t, Userspace<u64 const*>);
     ErrorOr<FlatPtr> sys$profiling_disable(pid_t);
     ErrorOr<FlatPtr> sys$profiling_free_buffer(pid_t);
     ErrorOr<FlatPtr> sys$futex(Userspace<const Syscall::SC_futex_params*>);

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -373,7 +373,8 @@ void init_stage2(void*)
     if (boot_profiling) {
         dbgln("Starting full system boot profiling");
         MutexLocker mutex_locker(Process::current().big_lock());
-        auto result = Process::current().sys$profiling_enable(-1, ~0ull);
+        const auto enable_all = ~(u64)0;
+        auto result = Process::current().sys$profiling_enable(-1, reinterpret_cast<FlatPtr>(&enable_all));
         VERIFY(!result.is_error());
     }
 

--- a/Userland/Libraries/LibC/serenity.cpp
+++ b/Userland/Libraries/LibC/serenity.cpp
@@ -22,7 +22,7 @@ int disown(pid_t pid)
 
 int profiling_enable(pid_t pid, uint64_t event_mask)
 {
-    int rc = syscall(SC_profiling_enable, pid, event_mask);
+    int rc = syscall(SC_profiling_enable, pid, &event_mask);
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 


### PR DESCRIPTION
Arguments larger than 32bit need to be passed as a pointer on a 32bit
architectures. sys$profiling_enable has u64 event_mask argument,
which means that it needs to be passed as an pointer. Previously upper
32bits were filled by garbage.