### PR TITLE
Shell: Use an opaque default color for BarewordLiteral

### DIFF
--- a/Userland/Shell/SyntaxHighlighter.cpp
+++ b/Userland/Shell/SyntaxHighlighter.cpp
@@ -130,6 +130,8 @@ private:
             m_is_first_in_command = false;
         } else if (node->text().starts_with("-")) {
             span.attributes.color = m_palette.syntax_preprocessor_statement();
+        } else {
+            span.attributes.color = m_palette.base_text();
         }
     }
     virtual void visit(const AST::CastToCommand* node) override


### PR DESCRIPTION
Use an opaque default color for BarewordLiteral in Syntax Highlighter to avoid transparent barewords. 
It should fix #12545.