### PR TITLE
Core: Remove non-existent classes from `Forward.h`

### DIFF
--- a/Userland/Libraries/LibCore/Forward.h
+++ b/Userland/Libraries/LibCore/Forward.h
@@ -22,7 +22,6 @@ class EventLoop;
 class File;
 class IODevice;
 class LocalServer;
-class LocalSocket;
 class MimeData;
 class NetworkJob;
 class NetworkResponse;
@@ -30,14 +29,11 @@ class Notifier;
 class Object;
 class ObjectClassRegistration;
 class ProcessStatisticsReader;
-class Socket;
 class SocketAddress;
 class TCPServer;
-class TCPSocket;
 class Timer;
 class TimerEvent;
 class UDPServer;
-class UDPSocket;
 
 enum class TimerShouldFireWhenNotVisible;
 


### PR DESCRIPTION
Found these whilst converting an old project, these don't exist anymore and can be removed :^)