### PR TITLE
LibWeb: Improve HTML Tokeniser

### DIFF
--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -206,5 +206,5 @@ TEST_CASE(regression)
     auto file_contents = file.value()->read_all();
     auto tokens = run_tokenizer(file_contents);
     u32 hash = hash_tokens(tokens);
-    EXPECT_EQ(hash, 3215459107u);
+    EXPECT_EQ(hash, 710375345u);
 }

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -145,6 +145,32 @@ void Node::set_text_content(String const& content)
     set_needs_style_update(true);
 }
 
+// https://dom.spec.whatwg.org/#dom-node-nodevalue
+String Node::node_value() const
+{
+    if (is<Attribute>(this)) {
+        return verify_cast<Attribute>(this)->value();
+    }
+    if (is<CharacterData>(this)) {
+        return verify_cast<CharacterData>(this)->data();
+    }
+
+    return {};
+}
+
+// https://dom.spec.whatwg.org/#ref-for-dom-node-nodevalue%E2%91%A0
+void Node::set_node_value(const String& value)
+{
+
+    if (is<Attribute>(this)) {
+        verify_cast<Attribute>(this)->set_value(value);
+    } else if (is<CharacterData>(this)) {
+        verify_cast<CharacterData>(this)->set_data(value);
+    }
+
+    // Otherwise: Do nothing.
+}
+
 void Node::invalidate_style()
 {
     for_each_in_inclusive_subtree_of_type<Element>([&](auto& element) {

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -111,6 +111,9 @@ public:
     String text_content() const;
     void set_text_content(String const&);
 
+    String node_value() const;
+    void set_node_value(String const&);
+
     Document& document() { return *m_document; }
     const Document& document() const { return *m_document; }
 

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -19,6 +19,7 @@ interface Node : EventTarget {
     readonly attribute Document? ownerDocument;
     Node getRootNode(optional GetRootNodeOptions options = {});
 
+    [CEReactions] attribute DOMString? nodeValue;
     // FIXME: [LegacyNullToEmptyString] is not allowed on nullable types as per the Web IDL spec.
     //        However, we only apply it to setters, so this works as a stop gap.
     //        Replace this with something like a special cased [LegacyNullToEmptyString].

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1617,7 +1617,7 @@ _StartOfFunction:
             {
                 size_t byte_offset = m_utf8_view.byte_offset_of(m_prev_utf8_iterator);
 
-                auto match = HTML::code_points_from_entity(m_decoded_input.substring_view(byte_offset, m_decoded_input.length() - byte_offset - 1));
+                auto match = HTML::code_points_from_entity(m_decoded_input.substring_view(byte_offset, m_decoded_input.length() - byte_offset));
 
                 if (match.has_value()) {
                     skip(match->entity.length() - 1);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLTokenizer.cpp
@@ -1483,7 +1483,7 @@ _StartOfFunction:
                 }
                 ANYTHING_ELSE
                 {
-                    m_current_builder.append('-');
+                    m_current_builder.append("--");
                     RECONSUME_IN(Comment);
                 }
             }


### PR DESCRIPTION
Fix a few bugs in the HTML Tokenizer.
With these changes Browser now passes the "HTML5 tokenizer" test on html5test.com
(Though as Browser doesn't yet load html5test.com you can't see the result)

* Implement `Node.nodeValue` DOM attribute
* Fix off by one error in HTML Tokenizer, in `NamedCharacterReference`
* Implement tokenization newline preprocessing
* Fix 'Comment end state' in HTML Tokenizer