### PR TITLE
Meta: Make `serenity.sh gdb` work with the Clang toolchain

### DIFF
--- a/Meta/debug-kernel.sh
+++ b/Meta/debug-kernel.sh
@@ -18,6 +18,11 @@ if [ -z "$SERENITY_KERNEL_DEBUGGER" ]; then
     fi
 fi
 
+toolchain_suffix=
+if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then
+    toolchain_suffix="clang"
+fi
+
 # The QEMU -s option (enabled by default in ./run) sets up a debugger
 # remote on localhost:1234. So point our debugger there, and inform
 # the debugger which binary to load symbols, etc from.
@@ -45,10 +50,10 @@ fi
 
 
 exec $SERENITY_KERNEL_DEBUGGER \
-    -ex "file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}/Kernel/Prekernel/$prekernel_image" \
+    -ex "file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}$toolchain_suffix/Kernel/Prekernel/$prekernel_image" \
     -ex "set confirm off" \
-    -ex "directory $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}/" \
-    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}/Kernel/Kernel -o $kernel_base" \
+    -ex "directory $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}$toolchain_suffix/" \
+    -ex "add-symbol-file $SCRIPT_DIR/../Build/${SERENITY_ARCH:-i686}$toolchain_suffix/Kernel/Kernel -o $kernel_base" \
     -ex "set confirm on" \
     -ex "set arch $gdb_arch" \
     -ex "set print frame-arguments none" \

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -185,6 +185,7 @@ cmd_with_target() {
     BUILD_DIR="$SERENITY_SOURCE_DIR/Build/$TARGET$TARGET_TOOLCHAIN"
     if [ "$TARGET" != "lagom" ]; then
         export SERENITY_ARCH="$TARGET"
+        export SERENITY_TOOLCHAIN="$TOOLCHAIN_TYPE"
         if [ "$TOOLCHAIN_TYPE" = "Clang" ]; then
             TOOLCHAIN_DIR="$SERENITY_SOURCE_DIR/Toolchain/Local/clang"
         else
@@ -376,7 +377,7 @@ if [[ "$CMD" =~ ^(build|install|image|copy-src|run|gdb|test|rebuild|recreate|kad
                 build_target
                 build_target install
                 build_image
-                tmux new-session "$ARG0" __tmux_cmd "$TARGET" run "${CMD_ARGS[@]}" \; set-option -t 0 mouse on \; split-window "$ARG0" __tmux_cmd "$TARGET" gdb "${CMD_ARGS[@]}" \;
+                tmux new-session "$ARG0" __tmux_cmd "$TARGET" "$TOOLCHAIN_TYPE" run "${CMD_ARGS[@]}" \; set-option -t 0 mouse on \; split-window "$ARG0" __tmux_cmd "$TARGET" "$TOOLCHAIN_TYPE" gdb "${CMD_ARGS[@]}" \;
             fi
             ;;
         test)


### PR DESCRIPTION
We now pass along the toolchain type to all subcommands. This ensures
that gdb will load the correct debug information for kernels compiled
with Clang, and the following warning won't appear with the GNU
toolchain:

> WARNING: unknown toolchain 'gdb'. Defaulting to GNU.
>         Valid values are 'Clang', 'GNU' (default)