### PR TITLE
LibWeb: Return current document URL if form action missing or empty

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -139,4 +139,17 @@ void HTMLFormElement::remove_associated_element(Badge<FormAssociatedElement>, HT
     m_associated_elements.remove_first_matching([&](auto& entry) { return entry.ptr() == &element; });
 }
 
+// https://html.spec.whatwg.org/#dom-fs-action
+String HTMLFormElement::action() const
+{
+    auto value = attribute(HTML::AttributeNames::action);
+
+    // Return the current URL if the action attribute is null or an empty string
+    if (value.is_null() || value.is_empty()) {
+        return document().url().to_string();
+    }
+
+    return value;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.h
@@ -18,7 +18,7 @@ public:
     HTMLFormElement(DOM::Document&, QualifiedName);
     virtual ~HTMLFormElement() override;
 
-    String action() const { return attribute(HTML::AttributeNames::action); }
+    String action() const;
     String method() const { return attribute(HTML::AttributeNames::method); }
 
     void submit_form(RefPtr<HTMLElement> submitter, bool from_submit_binding = false);


### PR DESCRIPTION
Where forms do not specify an action or if the action is left empty, submitting a form does not work because `action()` returns empty.  I ran into this on a website I'm testing that didn't specify the form action at all.  I knew forms should fall back to using the current URL so I found it in the HTML spec and updated the action method to return the current document URL when needed.