### PR TITLE
LibSoftGPU: Add mipmaps

### DIFF
--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -2996,12 +2996,12 @@ void SoftwareGLContext::sync_device_sampler_config()
             config.mipmap_filter = SoftGPU::MipMapFilter::Nearest;
             break;
         case GL_LINEAR_MIPMAP_NEAREST:
-            config.texture_min_filter = SoftGPU::TextureFilter::Nearest;
-            config.mipmap_filter = SoftGPU::MipMapFilter::Linear;
-            break;
-        case GL_NEAREST_MIPMAP_LINEAR:
             config.texture_min_filter = SoftGPU::TextureFilter::Linear;
             config.mipmap_filter = SoftGPU::MipMapFilter::Nearest;
+            break;
+        case GL_NEAREST_MIPMAP_LINEAR:
+            config.texture_min_filter = SoftGPU::TextureFilter::Nearest;
+            config.mipmap_filter = SoftGPU::MipMapFilter::Linear;
             break;
         case GL_LINEAR_MIPMAP_LINEAR:
             config.texture_min_filter = SoftGPU::TextureFilter::Linear;

--- a/Userland/Libraries/LibSoftGPU/SIMD.h
+++ b/Userland/Libraries/LibSoftGPU/SIMD.h
@@ -67,4 +67,40 @@ ALWAYS_INLINE static constexpr Vector4<AK::SIMD::i32x4> expand4(Vector4<int> con
     };
 }
 
+ALWAYS_INLINE static AK::SIMD::f32x4 ddx(AK::SIMD::f32x4 v)
+{
+    return AK::SIMD::f32x4 {
+        v[1] - v[0],
+        v[1] - v[0],
+        v[3] - v[2],
+        v[3] - v[2],
+    };
+}
+
+ALWAYS_INLINE static AK::SIMD::f32x4 ddy(AK::SIMD::f32x4 v)
+{
+    return AK::SIMD::f32x4 {
+        v[2] - v[0],
+        v[3] - v[1],
+        v[2] - v[0],
+        v[3] - v[1],
+    };
+}
+
+ALWAYS_INLINE static Vector2<AK::SIMD::f32x4> ddx(Vector2<AK::SIMD::f32x4> const& v)
+{
+    return {
+        ddx(v.x()),
+        ddx(v.y()),
+    };
+}
+
+ALWAYS_INLINE static Vector2<AK::SIMD::f32x4> ddy(Vector2<AK::SIMD::f32x4> const& v)
+{
+    return {
+        ddy(v.x()),
+        ddy(v.y()),
+    };
+}
+
 }

--- a/Userland/Libraries/LibSoftGPU/Sampler.h
+++ b/Userland/Libraries/LibSoftGPU/Sampler.h
@@ -59,6 +59,8 @@ public:
     SamplerConfig const& config() const { return m_config; }
 
 private:
+    Vector4<AK::SIMD::f32x4> sample_2d_lod(Vector2<AK::SIMD::f32x4> const& uv, AK::SIMD::u32x4 level, TextureFilter) const;
+
     SamplerConfig m_config;
 };
 


### PR DESCRIPTION
Does exactly what it says in the title. Everything's nice and blurry now, just like 1996!
![Bildschirmfoto zu 2022-02-19 02-59-24](https://user-images.githubusercontent.com/2094371/154781801-68e40edb-fde8-441e-8376-3e4851fb0d4e.png)

The above screenshot shows `GL_LINEAR_MIPMAP_LINEAR`, aka trilinear filtering.