### PR TITLE
Meta: Use correct variable for checking if the mold linker is used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,7 +280,7 @@ if(NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
         add_link_options(-fuse-ld=mold)
     endif()
 
-    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$" OR USE_MOLD_LINKER)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$" OR ENABLE_MOLD_LINKER)
         add_link_options(LINKER:--pack-dyn-relocs=relr)
     else()
         add_link_options(LINKER:-z,pack-relative-relocs)


### PR DESCRIPTION
This variable was originally called USE_MOLD_LINKER, but it was changed
to ENABLE_MOLD_LINKER during review to be consistent with other
configuration options. I branched off the commits that added RELR
support before this change, and I failed to update the variable name
there.