### PR TITLE
LibRegex: Allow quantifiers after quantifiable assertions / Make parse_disjunction() consume all disjunctions in one frame 

### DIFF
--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -498,6 +498,8 @@ TEST_CASE(posix_extended_nested_capture_group)
     EXPECT_EQ(result.capture_group_matches[0][2].view, "llo"sv);
 }
 
+auto parse_test_case_long_disjunction_chain = String::repeated("a|"sv, 10000);
+
 TEST_CASE(ECMA262_parse)
 {
     struct _test {
@@ -506,7 +508,7 @@ TEST_CASE(ECMA262_parse)
         regex::ECMAScriptFlags flags {};
     };
 
-    constexpr _test tests[] {
+    _test const tests[] {
         { "^hello.$"sv },
         { "^(hello.)$"sv },
         { "^h{0,1}ello.$"sv },
@@ -599,7 +601,8 @@ TEST_CASE(ECMA262_parse)
         { "(?<$$_$$>a)"sv },
         { "(?<ÿ>a)"sv },
         { "(?<𝓑𝓻𝓸𝔀𝓷>a)"sv },
-        { "((?=lg)?[vl]k\\-?\\d{3}) bui| 3\\.[-\\w; ]{10}lg?-([06cv9]{3,4})"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended } // #12373, quantifiable assertions.
+        { "((?=lg)?[vl]k\\-?\\d{3}) bui| 3\\.[-\\w; ]{10}lg?-([06cv9]{3,4})"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended }, // #12373, quantifiable assertions.
+        { parse_test_case_long_disjunction_chain.view() },                                                                                 // A whole lot of disjunctions, should not overflow the stack.
     };
 
     for (auto& test : tests) {

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -498,7 +498,7 @@ TEST_CASE(posix_extended_nested_capture_group)
     EXPECT_EQ(result.capture_group_matches[0][2].view, "llo"sv);
 }
 
-auto parse_test_case_long_disjunction_chain = String::repeated("a|"sv, 10000);
+auto parse_test_case_long_disjunction_chain = String::repeated("a|"sv, 100000);
 
 TEST_CASE(ECMA262_parse)
 {

--- a/Tests/LibRegex/Regex.cpp
+++ b/Tests/LibRegex/Regex.cpp
@@ -599,6 +599,7 @@ TEST_CASE(ECMA262_parse)
         { "(?<$$_$$>a)"sv },
         { "(?<ÿ>a)"sv },
         { "(?<𝓑𝓻𝓸𝔀𝓷>a)"sv },
+        { "((?=lg)?[vl]k\\-?\\d{3}) bui| 3\\.[-\\w; ]{10}lg?-([06cv9]{3,4})"sv, regex::Error::NoError, ECMAScriptFlags::BrowserExtended } // #12373, quantifiable assertions.
     };
 
     for (auto& test : tests) {

--- a/Userland/Libraries/LibRegex/RegexBytecodeStreamOptimizer.h
+++ b/Userland/Libraries/LibRegex/RegexBytecodeStreamOptimizer.h
@@ -14,6 +14,7 @@ namespace regex {
 class Optimizer {
 public:
     static void append_alternation(ByteCode& target, ByteCode&& left, ByteCode&& right);
+    static void append_alternation(ByteCode& target, Span<ByteCode> alternatives);
     static void append_character_class(ByteCode& target, Vector<CompareTypeAndValuePair>&& pairs);
 };
 

--- a/Userland/Libraries/LibRegex/RegexDebug.h
+++ b/Userland/Libraries/LibRegex/RegexDebug.h
@@ -35,9 +35,12 @@ public:
     template<typename T>
     void print_bytecode(Regex<T> const& regex) const
     {
-        MatchState state;
-        auto& bytecode = regex.parser_result.bytecode;
+        print_bytecode(regex.parser_result.bytecode);
+    }
 
+    void print_bytecode(ByteCode const& bytecode) const
+    {
+        MatchState state;
         for (;;) {
             auto& opcode = bytecode.get_opcode(state);
             print_opcode("PrintBytecode", opcode, state);

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -958,7 +958,7 @@ bool ECMA262Parser::parse_disjunction(ByteCode& stack, size_t& match_length_mini
 {
     size_t total_match_length_minimum = NumericLimits<size_t>::max();
     Vector<ByteCode> alternatives;
-    do {
+    while (true) {
         ByteCode alternative_stack;
         size_t alternative_minimum_length = 0;
         auto alt_ok = parse_alternative(alternative_stack, alternative_minimum_length, unicode, named);
@@ -971,20 +971,9 @@ bool ECMA262Parser::parse_disjunction(ByteCode& stack, size_t& match_length_mini
         if (!match(TokenType::Pipe))
             break;
         consume();
-    } while (true);
-
-    Optional<ByteCode> alternative_stack {};
-    for (auto& alternative : alternatives) {
-        if (alternative_stack.has_value()) {
-            ByteCode target_stack;
-            target_stack.insert_bytecode_alternation(alternative_stack.release_value(), move(alternative));
-            alternative_stack = move(target_stack);
-        } else {
-            alternative_stack = move(alternative);
-        }
     }
 
-    stack.extend(alternative_stack.release_value());
+    Optimizer::append_alternation(stack, alternatives.span());
     match_length_minimum = total_match_length_minimum;
     return true;
 }

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -1083,6 +1083,9 @@ bool ECMA262Parser::parse_assertion(ByteCode& stack, [[maybe_unused]] size_t& ma
         if (m_should_use_browser_extended_grammar) {
             if (!unicode) {
                 if (parse_quantifiable_assertion(assertion_stack, match_length_minimum, named)) {
+                    if (!parse_quantifier(assertion_stack, match_length_minimum, unicode, named))
+                        return false;
+
                     stack.extend(move(assertion_stack));
                     return true;
                 }


### PR DESCRIPTION
Fixes #12373.
Fixes #12615.

~~There are obvious performance issues (that were already present) with parsing so many alternations, but I'll try fix that later.~~

Perf problems resolved.
<details>
<summary>Silly demo</summary>


```
❯ hyperfine 'node test.js' './js test.js' 'js78 test.js'
Benchmark 1: node test.js
  Time (mean ± σ):      7.499 s ±  0.371 s    [User: 7.132 s, System: 0.348 s]
  Range (min … max):    7.000 s …  7.959 s    10 runs
 
Benchmark 2: ./js test.js
  Time (mean ± σ):      2.221 s ±  0.082 s    [User: 1.889 s, System: 0.326 s]
  Range (min … max):    2.159 s …  2.437 s    10 runs
 
Benchmark 3: js78 test.js
  Time (mean ± σ):      2.994 s ±  0.091 s    [User: 2.565 s, System: 0.418 s]
  Range (min … max):    2.865 s …  3.149 s    10 runs
 
Summary
  './js test.js' ran
    1.35 ± 0.06 times faster than 'js78 test.js'
    3.38 ± 0.21 times faster than 'node test.js'
```

[test.txt](https://github.com/SerenityOS/serenity/files/8103221/test.txt)

</details>
