### PR TITLE
LibJS: AsyncFunction related fixes

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionConstructor.cpp
@@ -13,7 +13,7 @@
 namespace JS {
 
 AsyncFunctionConstructor::AsyncFunctionConstructor(GlobalObject& global_object)
-    : NativeFunction(vm().names.AsyncFunction.as_string(), *global_object.function_prototype())
+    : NativeFunction(vm().names.AsyncFunction.as_string(), *global_object.function_constructor())
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -127,7 +127,10 @@ void ECMAScriptFunctionObject::initialize(GlobalObject& global_object)
             // FIXME: Add the AsyncGeneratorObject and set it as prototype.
             break;
         }
-        define_direct_property(vm.names.prototype, prototype, Attribute::Writable);
+        // 27.7.4 AsyncFunction Instances, https://tc39.es/ecma262/#sec-async-function-instances
+        // AsyncFunction instances do not have a prototype property as they are not constructible.
+        if (m_kind != FunctionKind::Async)
+            define_direct_property(vm.names.prototype, prototype, Attribute::Writable);
     }
 }
 

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -291,21 +291,12 @@ void GlobalObject::initialize_global_object()
 #undef __JS_ENUMERATE
 
     // NOTE: These constructors cannot be initialized with add_constructor as they have no global binding.
-    m_generator_function_constructor = heap().allocate<GeneratorFunctionConstructor>(*this, *this);
-    m_async_generator_function_constructor = heap().allocate<AsyncGeneratorFunctionConstructor>(*this, *this);
-    m_async_function_constructor = heap().allocate<AsyncFunctionConstructor>(*this, *this);
-
-    // 27.3.3.1 GeneratorFunction.prototype.constructor, https://tc39.es/ecma262/#sec-generatorfunction.prototype.constructor
-    m_generator_function_prototype->define_direct_property(vm.names.constructor, m_generator_function_constructor, Attribute::Configurable);
-
-    // 27.4.3.1 AsyncGeneratorFunction.prototype.constructor, https://tc39.es/ecma262/#sec-asyncgeneratorfunction-prototype-constructor
-    m_async_generator_function_prototype->define_direct_property(vm.names.constructor, m_async_generator_function_constructor, Attribute::Configurable);
+    initialize_constructor(vm.names.GeneratorFunction, m_generator_function_constructor, m_generator_function_prototype, Attribute::Configurable);
+    initialize_constructor(vm.names.AsyncGeneratorFunction, m_async_generator_function_constructor, m_async_generator_function_prototype, Attribute::Configurable);
+    initialize_constructor(vm.names.AsyncFunction, m_async_function_constructor, m_async_function_prototype, Attribute::Configurable);
 
     // 27.5.1.1 Generator.prototype.constructor, https://tc39.es/ecma262/#sec-generator.prototype.constructor
     m_generator_prototype->define_direct_property(vm.names.constructor, m_generator_function_prototype, Attribute::Configurable);
-
-    // 27.7.3.1 AsyncFunction.prototype.constructor, https://tc39.es/ecma262/#sec-async-function-prototype-properties-constructor
-    m_async_function_prototype->define_direct_property(vm.names.constructor, m_async_function_constructor, Attribute::Configurable);
 
     m_array_prototype_values_function = &m_array_prototype->get_without_side_effects(vm.names.values).as_function();
     m_date_constructor_now_function = &m_date_constructor->get_without_side_effects(vm.names.now).as_function();

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -74,7 +74,7 @@ protected:
     virtual void visit_edges(Visitor&) override;
 
     template<typename ConstructorType>
-    void initialize_constructor(PropertyKey const&, ConstructorType*&, Object* prototype);
+    void initialize_constructor(PropertyKey const&, ConstructorType*&, Object* prototype, PropertyAttributes = Attribute::Writable | Attribute::Configurable);
     template<typename ConstructorType>
     void add_constructor(PropertyKey const&, ConstructorType*&, Object* prototype);
 
@@ -143,13 +143,13 @@ private:
 };
 
 template<typename ConstructorType>
-inline void GlobalObject::initialize_constructor(PropertyKey const& property_key, ConstructorType*& constructor, Object* prototype)
+inline void GlobalObject::initialize_constructor(PropertyKey const& property_key, ConstructorType*& constructor, Object* prototype, PropertyAttributes attributes)
 {
     auto& vm = this->vm();
     constructor = heap().allocate<ConstructorType>(*this, *this);
     constructor->define_direct_property(vm.names.name, js_string(heap(), property_key.as_string()), Attribute::Configurable);
     if (prototype)
-        prototype->define_direct_property(vm.names.constructor, constructor, Attribute::Writable | Attribute::Configurable);
+        prototype->define_direct_property(vm.names.constructor, constructor, attributes);
 }
 
 template<typename ConstructorType>


### PR DESCRIPTION
```
    test/built-ins/AsyncFunction/AsyncFunction-is-subclass.js            ❌ -> ✅
    test/built-ins/AsyncFunction/AsyncFunction-name.js                   ❌ -> ✅
    test/built-ins/AsyncFunction/instance-prototype-property.js          ❌ -> ✅
    test/built-ins/AsyncGeneratorFunction/name.js                        ❌ -> ✅
    test/built-ins/GeneratorFunction/name.js                             ❌ -> ✅
    test/language/statements/class/subclass/superclass-async-function.js ❌ -> ✅
```