### PR TITLE
WindowServer+LibGfx+Base: Improve handling of themes with a border radius

### DIFF
--- a/Base/res/themes/Cupertino.ini
+++ b/Base/res/themes/Cupertino.ini
@@ -77,14 +77,14 @@ IsDark=true
 
 [Metrics]
 BorderRadius=8
-BorderThickness=1
+BorderThickness=4
 TitleButtonWidth=20
 TitleButtonHeight=16
 
 [Paths]
 TitleButtonIcons=/res/icons/themes/Cupertino/16x16/
-ActiveWindowShadow=/res/icons/themes/Default/frame-shadow-dark.png
-InactiveWindowShadow=/res/icons/themes/Default/frame-shadow-light.png
+ActiveWindowShadow=
+InactiveWindowShadow=
 MenuShadow=/res/icons/themes/Default/frame-shadow-light.png
 TaskBarShadow=/res/icons/themes/Default/frame-shadow-light.png
 TooltipShadow=/res/icons/themes/Default/frame-shadow-light.png

--- a/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
+++ b/Userland/Libraries/LibGfx/ClassicStylePainter.cpp
@@ -294,11 +294,7 @@ void ClassicStylePainter::paint_window_frame(Painter& painter, IntRect const& re
         // FIXME: This will draw "useless" pixels that'll get drawn over by the window contents.
         // preferrably we should just remove the corner pixels from the completely drawn window
         // but I don't know how to do that yet. :^)
-        painter.fill_rect_with_rounded_corners({ rect.x() - border_radius / 2,
-                                                   rect.y() - border_radius / 2,
-                                                   rect.width() + border_radius,
-                                                   rect.height() + border_radius },
-            base_color, border_radius);
+        painter.fill_rect_with_rounded_corners(rect, base_color, border_radius);
         return;
     }
 

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -571,7 +571,8 @@ Gfx::IntRect WindowFrame::unconstrained_render_rect() const
 
 Gfx::DisjointRectSet WindowFrame::opaque_render_rects() const
 {
-    if (has_alpha_channel()) {
+    auto border_radius = WindowManager::the().palette().window_border_radius();
+    if (has_alpha_channel() || border_radius > 0) {
         if (m_window.is_opaque())
             return constrained_render_rect_to_screen(m_window.rect());
         return {};
@@ -585,7 +586,8 @@ Gfx::DisjointRectSet WindowFrame::opaque_render_rects() const
 
 Gfx::DisjointRectSet WindowFrame::transparent_render_rects() const
 {
-    if (has_alpha_channel()) {
+    auto border_radius = WindowManager::the().palette().window_border_radius();
+    if (has_alpha_channel() || border_radius > 0) {
         if (m_window.is_opaque()) {
             Gfx::DisjointRectSet transparent_rects;
             transparent_rects.add_many(render_rect().shatter(m_window.rect()));

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -190,6 +190,9 @@ MultiScaleBitmaps const* WindowFrame::shadow_bitmap() const
     case WindowType::WindowSwitcher:
         return nullptr;
     default:
+        // FIXME: Support shadow for themes with border radius
+        if (WindowManager::the().palette().window_border_radius() > 0)
+            return nullptr;
         if (auto* highlight_window = WindowManager::the().highlight_window())
             return highlight_window == &m_window ? s_active_window_shadow : s_inactive_window_shadow;
         return m_window.is_active() ? s_active_window_shadow : s_inactive_window_shadow;


### PR DESCRIPTION
Currently windows frames a border radiuses/radii are painted by expanding (only within the painter) the window frame rectangle 
to paint over the window shadow (presumably to avoid repainting issues in the corners).

The issue with this is alongside pointlessly drawing the shadow, it creates a "ghost" window frame that does not respond to clicks/resize attempts.

This PR fixes these issues, by keeping the window frame its proper size, and instead treats window frames 
as if they have an alpha channel if the current theme has a window border-radius property.