### PR TITLE
LibGfx: Fix JPG decoding bug on rare grayscale images

### DIFF
--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -742,6 +742,12 @@ static bool read_start_of_frame(InputMemoryStream& stream, JPGLoadingContext& co
         component.vsample_factor = subsample_factors & 0x0F;
 
         if (i == 0) {
+            // If there is only a single component, i.e. grayscale, the macroblocks will not be interleaved, even if
+            // the horizontal or vertical sample factor is larger than 1.
+            if (context.component_count == 1) {
+                component.hsample_factor = 1;
+                component.vsample_factor = 1;
+            }
             // By convention, downsampling is applied only on chroma components. So we should
             //  hope to see the maximum sampling factor in the luma component.
             if (!validate_luma_and_modify_context(component, context)) {


### PR DESCRIPTION
Some JPG grayscale images might have the horizontal and vertical sample factor on the luma channel set to 2.
However, the image data is not interleaved as one might expect.
This results in decode errors:
![2022-02-19-210353](https://user-images.githubusercontent.com/2598727/154817333-2541b0e9-7a7c-4eb6-aa29-1df3bd519f5f.png)
With this patch, the image now decodes correctly:
![2022-02-19-210446](https://user-images.githubusercontent.com/2598727/154817348-cdf1d50c-b20c-4824-9a3d-be4e611afeed.png)

