### PR TITLE
LibWeb: Add default padding around contents of text <input> elements + other improvements to text <input> elements

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -172,7 +172,7 @@ void HTMLInputElement::create_shadow_tree_if_needed()
     if (initial_value.is_null())
         initial_value = String::empty();
     auto element = document().create_element(HTML::TagNames::div);
-    element->set_attribute(HTML::AttributeNames::style, "white-space: pre");
+    element->set_attribute(HTML::AttributeNames::style, "white-space: pre; padding-top: 1px; padding-bottom: 1px; padding-left: 2px; padding-right: 2px");
     m_text_node = adopt_ref(*new DOM::Text(document(), initial_value));
     m_text_node->set_always_editable(true);
     m_text_node->set_owner_input_element({}, *this);

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -510,6 +510,11 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
             }
             return true;
         }
+        if (key == KeyCode::Key_Home) {
+            auto& node = *static_cast<DOM::Text*>(const_cast<DOM::Node*>(m_browsing_context.cursor_position().node()));
+            m_browsing_context.set_cursor_position(DOM::Position { node, 0 });
+            return true;
+        }
         if (!should_ignore_keydown_event(code_point)) {
             m_edit_event_handler->handle_insert(m_browsing_context.cursor_position(), code_point);
             m_browsing_context.increment_cursor_position_offset();

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -439,7 +439,7 @@ bool EventHandler::focus_previous_element()
 constexpr bool should_ignore_keydown_event(u32 code_point)
 {
     // FIXME: There are probably also keys with non-zero code points that should be filtered out.
-    return code_point == 0;
+    return code_point == 0 || code_point == 27;
 }
 
 bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_point)

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -515,6 +515,11 @@ bool EventHandler::handle_keydown(KeyCode key, unsigned modifiers, u32 code_poin
             m_browsing_context.set_cursor_position(DOM::Position { node, 0 });
             return true;
         }
+        if (key == KeyCode::Key_End) {
+            auto& node = *static_cast<DOM::Text*>(const_cast<DOM::Node*>(m_browsing_context.cursor_position().node()));
+            m_browsing_context.set_cursor_position(DOM::Position { node, (unsigned)node.data().length() });
+            return true;
+        }
         if (!should_ignore_keydown_event(code_point)) {
             m_edit_event_handler->handle_insert(m_browsing_context.cursor_position(), code_point);
             m_browsing_context.increment_cursor_position_offset();


### PR DESCRIPTION
- LibWeb: Add support for navigating text `<input>` with Home key

- LibWeb: Add support for navigating text `<input>` with End key

- LibWeb: Add key code 'Esc' to ignored Keydown Events in EventHandler
This filters out the key code 'Esc' so it won't be printed to editable
text nodes, e.g. text `<input>` elements.

- LibWeb: Add default padding around contents of text `<input>` elements
This patch adds a default padding around the contents of text `<input>`
elements. It adds these defaults to the existing style attribute in
'HTMLInputElement::create_shadow_tree_if_needed()'.
Use a default padding for text <input> elements:
'- padding-top and padding-bottom: 1px
'- padding-left and padding-right: 2px
These values seems to align with what other browsers do.