### PR TITLE
LibWeb: Parse font-style CSS property & Make i, em, address, cite, dfn and var elements italic

### DIFF
--- a/Base/res/html/misc/fonts.html
+++ b/Base/res/html/misc/fonts.html
@@ -31,6 +31,7 @@
             <p style="font: normal small-caps 120%/120% monospace;">font: normal small-caps 120%/120% monospace;</p>
             <p style="font: condensed oblique 12pt 'Helvetica Neue', serif;">font: condensed oblique 12pt "Helvetica Neue", serif;</p>
             <p style="font: condensed oblique 25deg 12pt 'Helvetica Neue', serif;">font: condensed oblique 25deg 12pt "Helvetica Neue", serif;</p>
+            <p style="font-style: italic">font-style: italic</p>
         </section>
 
         <h2>Calc() values</h2>

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -46,6 +46,15 @@ b {
     font-weight: bold;
 }
 
+i,
+em,
+address,
+cite,
+dfn,
+var {
+    font-style: italic;
+}
+
 html,
 address,
 blockquote,


### PR DESCRIPTION
- **LibWeb+Base: Parse font-style CSS property**
- **LibWeb: Make i, em, address, cite, dfn and var elements italic**
  Although it is not said that some of the elements need to be italic, *most* browsers mark them as such to distinguish them from the normal text, so let's do that too!

![](https://user-images.githubusercontent.com/16520278/154835088-73bd6307-4756-431e-8a9f-a87dd43e49cc.png)
