### PR TITLE
Userland: Ask first for unsaved changes after clicking an “Open” action

### DIFF
--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -85,11 +85,11 @@ HexEditorWidget::HexEditorWidget()
     });
 
     m_open_action = GUI::CommonActions::make_open_action([this](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file(window(), {}, Core::StandardPaths::home_directory(), Core::OpenMode::ReadWrite);
-        if (response.is_error())
+        if (!request_close())
             return;
 
-        if (!request_close())
+        auto response = FileSystemAccessClient::Client::the().try_open_file(window(), {}, Core::StandardPaths::home_directory(), Core::OpenMode::ReadWrite);
+        if (response.is_error())
             return;
 
         open_file(response.value());

--- a/Userland/Applications/TextEditor/MainWidget.cpp
+++ b/Userland/Applications/TextEditor/MainWidget.cpp
@@ -267,10 +267,6 @@ MainWidget::MainWidget()
     });
 
     m_open_action = GUI::CommonActions::make_open_action([this](auto&) {
-        auto response = FileSystemAccessClient::Client::the().try_open_file(window());
-        if (response.is_error())
-            return;
-
         if (editor().document().is_modified()) {
             auto save_document_first_result = GUI::MessageBox::ask_about_unsaved_changes(window(), m_path, editor().document().undo_stack().last_unmodified_timestamp());
             if (save_document_first_result == GUI::Dialog::ExecResult::ExecYes)
@@ -278,6 +274,10 @@ MainWidget::MainWidget()
             if (save_document_first_result != GUI::Dialog::ExecResult::ExecNo && editor().document().is_modified())
                 return;
         }
+
+        auto response = FileSystemAccessClient::Client::the().try_open_file(window());
+        if (response.is_error())
+            return;
 
         read_file(*response.value());
     });

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -175,11 +175,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     });
 
     TRY(file_menu->try_add_action(GUI::CommonActions::make_open_action([&](auto&) {
-        Optional<String> open_path = GUI::FilePicker::get_open_filepath(window);
-
-        if (!open_path.has_value())
-            return;
-
         if (window->is_modified()) {
             auto result = GUI::MessageBox::ask_about_unsaved_changes(window, file_path, editor->document().undo_stack().last_unmodified_timestamp());
             if (result == GUI::MessageBox::ExecYes)
@@ -187,6 +182,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (result != GUI::MessageBox::ExecNo && window->is_modified())
                 return;
         }
+
+        Optional<String> open_path = GUI::FilePicker::get_open_filepath(window);
+        if (!open_path.has_value())
+            return;
 
         auto file = Core::File::construct(open_path.value());
         if (!file->open(Core::OpenMode::ReadOnly) && file->error() != ENOENT) {


### PR DESCRIPTION
Previously there was some inconsistency between the apps when clicking the “Open” action while the file wasn't saved.

Some programs (Font Editor) immediately asked you if you wanted to save the modified file, while others (Text Editor, Hex Editor and Playground) would show the save dialog only *after* you selected a file.

I think it’s better to ask a user right away if they want to save file, because a dialog after selecting a file should be generally related to that selected file, like an error opening a file, an import window etc.