### PR TITLE
LibJS: Add a bare-bones implementation of Intl.Collator.protoype.compare

### DIFF
--- a/Userland/Libraries/LibJS/CMakeLists.txt
+++ b/Userland/Libraries/LibJS/CMakeLists.txt
@@ -88,6 +88,7 @@ set(SOURCES
     Runtime/IndexedProperties.cpp
     Runtime/Intl/AbstractOperations.cpp
     Runtime/Intl/Collator.cpp
+    Runtime/Intl/CollatorCompareFunction.cpp
     Runtime/Intl/CollatorConstructor.cpp
     Runtime/Intl/CollatorPrototype.cpp
     Runtime/Intl/DateTimeFormat.cpp

--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.cpp
@@ -91,5 +91,10 @@ StringView Collator::case_first_string() const
         VERIFY_NOT_REACHED();
     }
 }
+void Collator::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(m_bound_compare);
+}
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
@@ -9,6 +9,7 @@
 #include <AK/Array.h>
 #include <AK/String.h>
 #include <AK/StringView.h>
+#include <LibJS/Runtime/Intl/CollatorCompareFunction.h>
 #include <LibJS/Runtime/Object.h>
 
 namespace JS::Intl {
@@ -69,14 +70,20 @@ public:
     bool numeric() const { return m_numeric; }
     void set_numeric(bool numeric) { m_numeric = numeric; }
 
+    CollatorCompareFunction* bound_compare() const { return m_bound_compare; }
+    void set_bound_compare(CollatorCompareFunction* bound_compare) { m_bound_compare = bound_compare; }
+
 private:
-    String m_locale;                                    // [[Locale]]
-    Usage m_usage { Usage::Sort };                      // [[Usage]]
-    Sensitivity m_sensitivity { Sensitivity::Variant }; // [[Sensitivity]]
-    CaseFirst m_case_first { CaseFirst::False };        // [[CaseFirst]]
-    String m_collation;                                 // [[Collation]]
-    bool m_ignore_punctuation { false };                // [[IgnorePunctuation]]
-    bool m_numeric { false };                           // [[Numeric]]
+    virtual void visit_edges(Visitor&) override;
+
+    String m_locale;                                      // [[Locale]]
+    Usage m_usage { Usage::Sort };                        // [[Usage]]
+    Sensitivity m_sensitivity { Sensitivity::Variant };   // [[Sensitivity]]
+    CaseFirst m_case_first { CaseFirst::False };          // [[CaseFirst]]
+    String m_collation;                                   // [[Collation]]
+    bool m_ignore_punctuation { false };                  // [[IgnorePunctuation]]
+    bool m_numeric { false };                             // [[Numeric]]
+    CollatorCompareFunction* m_bound_compare { nullptr }; // [[BoundCompare]]
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Utf8View.h>
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/Collator.h>
+#include <LibJS/Runtime/Intl/CollatorCompareFunction.h>
+
+namespace JS::Intl {
+
+CollatorCompareFunction* CollatorCompareFunction::create(GlobalObject& global_object, Collator& collator)
+{
+    return global_object.heap().allocate<CollatorCompareFunction>(global_object, global_object, collator);
+}
+
+CollatorCompareFunction::CollatorCompareFunction(GlobalObject& global_object, Collator& collator)
+    : NativeFunction(*global_object.function_prototype())
+    , m_collator(collator)
+{
+}
+
+void CollatorCompareFunction::initialize(GlobalObject& global_object)
+{
+    auto& vm = global_object.vm();
+    define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
+}
+
+// 10.3.3.2 CompareStrings ( collator, x, y ), https://tc39.es/ecma402/#sec-collator-comparestrings
+double compare_strings(Collator& collator, Utf8View const& x, Utf8View const& y)
+{
+    // FIXME: Implement https://unicode.org/reports/tr10
+    (void)collator;
+    auto x_iterator = x.begin();
+    auto y_iterator = y.begin();
+    for (; x_iterator != x.end() && y_iterator != y.end(); ++x_iterator, ++y_iterator) {
+        if (*x_iterator != *y_iterator)
+            return static_cast<double>(*x_iterator) - static_cast<double>(*y_iterator);
+    }
+    if (x_iterator != x.end())
+        return 1.0;
+    if (y_iterator != y.end())
+        return -1.0;
+    return 0.0;
+}
+
+// 10.3.3.1 Collator Compare Functions, https://tc39.es/ecma402/#sec-collator-compare-functions
+ThrowCompletionOr<Value> CollatorCompareFunction::call()
+{
+    auto& vm = this->vm();
+    auto& global_object = this->global_object();
+
+    // 1. Let collator be F.[[Collator]].
+    // 2. Assert: Type(collator) is Object and collator has an [[InitializedCollator]] internal slot.
+    // 3. If x is not provided, let x be undefined.
+    // 4. If y is not provided, let y be undefined.
+
+    // 5. Let X be ? ToString(x).
+    auto x = TRY(vm.argument(0).to_string(global_object));
+    // 6. Let Y be ? ToString(y).
+    auto y = TRY(vm.argument(1).to_string(global_object));
+
+    // 7. Return CompareStrings(collator, X, Y).
+    return compare_strings(m_collator, Utf8View(x), Utf8View(y));
+}
+
+void CollatorCompareFunction::visit_edges(Visitor& visitor)
+{
+    Base::visit_edges(visitor);
+    visitor.visit(&m_collator);
+}
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace JS::Intl {
+
+class CollatorCompareFunction : public NativeFunction {
+    JS_OBJECT(CollatorCompareFunction, NativeFunction);
+
+public:
+    static CollatorCompareFunction* create(GlobalObject&, Collator&);
+
+    explicit CollatorCompareFunction(GlobalObject&, Collator&);
+    virtual void initialize(GlobalObject&) override;
+    virtual ~CollatorCompareFunction() override = default;
+
+    virtual ThrowCompletionOr<Value> call() override;
+
+private:
+    virtual void visit_edges(Visitor&) override;
+
+    Collator& m_collator; // [[Collator]]
+};
+
+double compare_strings(Collator&, Utf8View const& x, Utf8View const& y);
+
+}

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorPrototype.h
@@ -20,6 +20,7 @@ public:
     virtual ~CollatorPrototype() override = default;
 
 private:
+    JS_DECLARE_NATIVE_FUNCTION(compare_getter);
     JS_DECLARE_NATIVE_FUNCTION(resolved_options);
 };
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.compare.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.compare.js
@@ -1,0 +1,41 @@
+describe("correct behavior", () => {
+    test("length is 2", () => {
+        expect(new Intl.Collator().compare).toHaveLength(2);
+    });
+
+    test("basic functionality", () => {
+        const collator = new Intl.Collator();
+        expect(collator.compare("", "")).toBe(0);
+        expect(collator.compare("a", "a")).toBe(0);
+        expect(collator.compare("6", "6")).toBe(0);
+
+        function compareBoth(a, b) {
+            const aTob = collator.compare(a, b);
+            const bToa = collator.compare(b, a);
+
+            expect(aTob > 0).toBeTrue();
+            expect(aTob).toBe(-bToa);
+        }
+
+        compareBoth("a", "");
+        compareBoth("1", "");
+        compareBoth("a", "A");
+        compareBoth("7", "3");
+        compareBoth("0000", "0");
+
+        expect(collator.compare("undefined")).toBe(0);
+        expect(collator.compare("undefined", undefined)).toBe(0);
+
+        expect(collator.compare("null", null)).toBe(0);
+        expect(collator.compare("null", undefined)).not.toBe(0);
+        expect(collator.compare("null") < 0).toBeTrue();
+    });
+
+    test("UTF-16", () => {
+        const collator = new Intl.Collator();
+        const string = "😀😀";
+        expect(collator.compare(string, "😀😀")).toBe(0);
+        expect(collator.compare(string, "\ud83d") > 0);
+        expect(collator.compare(string, "😀😀s") < 0);
+    });
+});

--- a/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.localeCompare.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/String/String.prototype.localeCompare.js
@@ -9,7 +9,7 @@ test("basic functionality", () => {
         const aTob = a.localeCompare(b);
         const bToa = b.localeCompare(a);
 
-        expect(aTob).toBe(1);
+        expect(aTob > 0).toBeTrue();
         expect(aTob).toBe(-bToa);
     }
 
@@ -24,7 +24,7 @@ test("basic functionality", () => {
 
     expect("null".localeCompare(null)).toBe(0);
     expect("null".localeCompare(undefined)).not.toBe(0);
-    expect("null".localeCompare()).toBe(-1);
+    expect("null".localeCompare() < 0).toBeTrue();
 
     expect(() => {
         String.prototype.localeCompare.call(undefined, undefined);
@@ -34,6 +34,6 @@ test("basic functionality", () => {
 test("UTF-16", () => {
     var s = "😀😀";
     expect(s.localeCompare("😀😀")).toBe(0);
-    expect(s.localeCompare("\ud83d")).toBe(1);
-    expect(s.localeCompare("😀😀s")).toBe(-1);
+    expect(s.localeCompare("\ud83d") > 0);
+    expect(s.localeCompare("😀😀s") < 0);
 });


### PR DESCRIPTION
    test/intl402/Collator/prototype/compare/bound-to-collator-instance.js             ❌ -> ✅
    test/intl402/Collator/prototype/compare/builtin.js                                ❌ -> ✅
    test/intl402/Collator/prototype/compare/compare-function-builtin.js               ❌ -> ✅
    test/intl402/Collator/prototype/compare/length.js                                 ❌ -> ✅
    test/intl402/Collator/prototype/compare/name.js                                   ❌ -> ✅
    test/intl402/Collator/prototype/compare/prop-desc.js                              ❌ -> ✅
    test/intl402/Collator/prototype/this-value-not-collator.js                        ❌ -> ✅
    test/intl402/String/prototype/localeCompare/throws-same-exceptions-as-Collator.js ❌ -> ✅