### PR TITLE
Ports: Use the objcopy built as part of the toolchain

### DIFF
--- a/Ports/.hosted_defs.sh
+++ b/Ports/.hosted_defs.sh
@@ -9,6 +9,7 @@ if [ "$SERENITY_TOOLCHAIN" = "Clang" ]; then
     export AR="llvm-ar"
     export RANLIB="llvm-ranlib"
     export READELF="llvm-readelf"
+    export OBJCOPY="llvm-objcopy"
     export PATH="${SERENITY_SOURCE_DIR}/Toolchain/Local/clang/bin:${HOST_PATH}"
 else
     export SERENITY_BUILD_DIR="${SERENITY_SOURCE_DIR}/Build/${SERENITY_ARCH}"
@@ -17,6 +18,7 @@ else
     export AR="${SERENITY_ARCH}-pc-serenity-ar"
     export RANLIB="${SERENITY_ARCH}-pc-serenity-ranlib"
     export READELF="${SERENITY_ARCH}-pc-serenity-readelf"
+    export OBJCOPY="${SERENITY_ARCH}-pc-serenity-objcopy"
     export PATH="${SERENITY_SOURCE_DIR}/Toolchain/Local/${SERENITY_ARCH}/bin:${HOST_PATH}"
 fi
 

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -12,6 +12,7 @@ if [ -z "${HOST_CC:=}" ]; then
     export HOST_RANLIB="${RANLIB:=ranlib}"
     export HOST_PATH="${PATH:=}"
     export HOST_READELF="${READELF:=readelf}"
+    export HOST_OBJCOPY="${OBJCOPY:=objcopy}"
     export HOST_PKG_CONFIG_DIR="${PKG_CONFIG_DIR:=}"
     export HOST_PKG_CONFIG_SYSROOT_DIR="${PKG_CONFIG_SYSROOT_DIR:=}"
     export HOST_PKG_CONFIG_LIBDIR="${PKG_CONFIG_LIBDIR:=}"
@@ -49,6 +50,7 @@ host_env() {
     export RANLIB="${HOST_RANLIB}"
     export PATH="${HOST_PATH}"
     export READELF="${HOST_READELF}"
+    export OBJCOPY="${HOST_OBJCOPY}"
     export PKG_CONFIG_DIR="${HOST_PKG_CONFIG_DIR}"
     export PKG_CONFIG_SYSROOT_DIR="${HOST_PKG_CONFIG_SYSROOT_DIR}"
     export PKG_CONFIG_LIBDIR="${HOST_PKG_CONFIG_LIBDIR}"
@@ -164,8 +166,8 @@ install_icon() {
             run convert "$icon[0]" -resize $icon_size "app-${icon_size}.png"
         fi
     done
-    run objcopy --add-section serenity_icon_s="app-16x16.png" "${DESTDIR}${launcher}"
-    run objcopy --add-section serenity_icon_m="app-32x32.png" "${DESTDIR}${launcher}"
+    run $OBJCOPY --add-section serenity_icon_s="app-16x16.png" "${DESTDIR}${launcher}"
+    run $OBJCOPY --add-section serenity_icon_m="app-32x32.png" "${DESTDIR}${launcher}"
 }
 
 install_main_launcher() {

--- a/Ports/Super-Mario/package.sh
+++ b/Ports/Super-Mario/package.sh
@@ -21,7 +21,7 @@ install() {
     if command -v convert >/dev/null; then
         run convert "app.ico[0]" app-16x16.png
         run convert "app.ico[1]" app-32x32.png
-        run objcopy --add-section serenity_icon_s="app-16x16.png" "${SERENITY_INSTALL_ROOT}/opt/Super_Mario/uMario"
-        run objcopy --add-section serenity_icon_m="app-32x32.png" "${SERENITY_INSTALL_ROOT}/opt/Super_Mario/uMario"
+        run $OBJCOPY --add-section serenity_icon_s="app-16x16.png" "${SERENITY_INSTALL_ROOT}/opt/Super_Mario/uMario"
+        run $OBJCOPY --add-section serenity_icon_m="app-32x32.png" "${SERENITY_INSTALL_ROOT}/opt/Super_Mario/uMario"
     fi
 }


### PR DESCRIPTION
Relying on host tools working correctly is not a good idea, as they may
be outdated (and therefore not support features like RELR relocations)
or may not exist at all (like objcopy on macOS).