### PR TITLE
Browser: Show currently loading host and remaining resource count

### DIFF
--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -80,6 +80,29 @@ void Tab::view_source(const URL& url, const String& source)
     window->show();
 }
 
+void Tab::update_status(Optional<String> text_override, i32 count_waiting)
+{
+    if (text_override.has_value()) {
+        m_statusbar->set_text(*text_override);
+        return;
+    }
+
+    if (m_loaded) {
+        m_statusbar->set_text("");
+        return;
+    }
+
+    VERIFY(m_navigating_url.has_value());
+
+    if (count_waiting == 0) {
+        // ex: "Loading google.com"
+        m_statusbar->set_text(String::formatted("Loading {}", m_navigating_url->host()));
+    } else {
+        // ex: "google.com is waiting on 5 resources"
+        m_statusbar->set_text(String::formatted("{} is waiting on {} resource{}", m_navigating_url->host(), count_waiting, count_waiting == 1 ? ""sv : "s"sv));
+    }
+}
+
 Tab::Tab(BrowserWindow& window)
 {
     load_from_gml(tab_gml);
@@ -165,6 +188,11 @@ Tab::Tab(BrowserWindow& window)
         this);
 
     hooks().on_load_start = [this](auto& url) {
+        m_navigating_url = url;
+        m_loaded = false;
+
+        update_status();
+
         m_location_box->set_icon(nullptr);
         m_location_box->set_text(url.to_string());
 
@@ -184,6 +212,11 @@ Tab::Tab(BrowserWindow& window)
     };
 
     hooks().on_load_finish = [this](auto&) {
+        m_navigating_url = {};
+        m_loaded = true;
+
+        update_status();
+
         if (m_dom_inspector_widget)
             m_web_content_view->inspect_dom_tree();
     };
@@ -194,6 +227,10 @@ Tab::Tab(BrowserWindow& window)
         } else {
             load(url);
         }
+    };
+
+    hooks().on_resource_status_change = [this](auto count_waiting) {
+        update_status({}, count_waiting);
     };
 
     m_link_context_menu = GUI::Menu::construct();
@@ -317,9 +354,9 @@ Tab::Tab(BrowserWindow& window)
 
     hooks().on_link_hover = [this](auto& url) {
         if (url.is_valid())
-            m_statusbar->set_text(url.to_string());
+            update_status(url.to_string());
         else
-            m_statusbar->set_text("");
+            update_status();
     };
 
     hooks().on_url_drop = [this](auto& url) {

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "History.h"
+#include <AK/Optional.h>
 #include <AK/URL.h>
 #include <LibGUI/ActionGroup.h>
 #include <LibGUI/Widget.h>
@@ -91,6 +92,7 @@ private:
     void update_bookmark_button(const String& url);
     void start_download(const URL& url);
     void view_source(const URL& url, const String& source);
+    void update_status(Optional<String> text_override = {}, i32 count_waiting = 0);
 
     History m_history;
 
@@ -119,6 +121,9 @@ private:
     String m_title;
     RefPtr<const Gfx::Bitmap> m_icon;
 
+    Optional<URL> m_navigating_url;
+
+    bool m_loaded { false };
     bool m_is_history_navigation { false };
 };
 

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1496,4 +1496,21 @@ void Document::unregister_node_iterator(Badge<NodeIterator>, NodeIterator& node_
     VERIFY(was_removed);
 }
 
+void Document::increment_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>)
+{
+    ++m_number_of_things_delaying_the_load_event;
+
+    if (auto* page = this->page())
+        page->client().page_did_update_resource_count(m_number_of_things_delaying_the_load_event);
+}
+
+void Document::decrement_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>)
+{
+    VERIFY(m_number_of_things_delaying_the_load_event);
+    --m_number_of_things_delaying_the_load_event;
+
+    if (auto* page = this->page())
+        page->client().page_did_update_resource_count(m_number_of_things_delaying_the_load_event);
+}
+
 }

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -294,12 +294,8 @@ public:
     Bindings::LocationObject* location();
 
     size_t number_of_things_delaying_the_load_event() { return m_number_of_things_delaying_the_load_event; }
-    void increment_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>) { ++m_number_of_things_delaying_the_load_event; }
-    void decrement_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>)
-    {
-        VERIFY(m_number_of_things_delaying_the_load_event);
-        --m_number_of_things_delaying_the_load_event;
-    }
+    void increment_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>);
+    void decrement_number_of_things_delaying_the_load_event(Badge<DocumentLoadEventDelayer>);
 
     bool page_showing() const { return m_page_showing; }
     void set_page_showing(bool value) { m_page_showing = value; }

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -391,6 +391,12 @@ void OutOfProcessWebView::notify_server_did_set_cookie(Badge<WebContentClient>, 
         on_set_cookie(url, cookie, source);
 }
 
+void OutOfProcessWebView::notify_server_did_update_resource_count(i32 count_waiting)
+{
+    if (on_resource_status_change)
+        on_resource_status_change(count_waiting);
+}
+
 void OutOfProcessWebView::did_scroll()
 {
     client().async_set_viewport_rect(visible_content_rect());

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -88,6 +88,7 @@ public:
     void notify_server_did_change_favicon(const Gfx::Bitmap& favicon);
     String notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Cookie::Source source);
     void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, const Cookie::ParsedCookie& cookie, Cookie::Source source);
+    void notify_server_did_update_resource_count(i32 count_waiting);
 
 private:
     OutOfProcessWebView();

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -103,6 +103,7 @@ public:
     virtual String page_did_request_prompt(const String&, const String&) { return {}; }
     virtual String page_did_request_cookie(const AK::URL&, Cookie::Source) { return {}; }
     virtual void page_did_set_cookie(const AK::URL&, const Cookie::ParsedCookie&, Cookie::Source) { }
+    virtual void page_did_update_resource_count(i32) { }
 
 protected:
     virtual ~PageClient() = default;

--- a/Userland/Libraries/LibWeb/WebContentClient.cpp
+++ b/Userland/Libraries/LibWeb/WebContentClient.cpp
@@ -195,4 +195,9 @@ void WebContentClient::did_set_cookie(AK::URL const& url, Web::Cookie::ParsedCoo
     m_view.notify_server_did_set_cookie({}, url, cookie, static_cast<Cookie::Source>(source));
 }
 
+void WebContentClient::did_update_resource_count(i32 count_waiting)
+{
+    m_view.notify_server_did_update_resource_count(count_waiting);
+}
+
 }

--- a/Userland/Libraries/LibWeb/WebContentClient.h
+++ b/Userland/Libraries/LibWeb/WebContentClient.h
@@ -60,6 +60,7 @@ private:
     virtual Messages::WebContentClient::DidRequestPromptResponse did_request_prompt(String const&, String const&) override;
     virtual Messages::WebContentClient::DidRequestCookieResponse did_request_cookie(AK::URL const&, u8) override;
     virtual void did_set_cookie(AK::URL const&, Web::Cookie::ParsedCookie const&, u8) override;
+    virtual void did_update_resource_count(i32 count_waiting) override;
 
     OutOfProcessWebView& m_view;
 };

--- a/Userland/Libraries/LibWeb/WebViewHooks.h
+++ b/Userland/Libraries/LibWeb/WebViewHooks.h
@@ -34,6 +34,7 @@ public:
     Function<void(i32 start_index, Vector<String> const& message_types, Vector<String> const& messages)> on_get_js_console_messages;
     Function<String(const AK::URL& url, Cookie::Source source)> on_get_cookie;
     Function<void(const AK::URL& url, const Cookie::ParsedCookie& cookie, Cookie::Source source)> on_set_cookie;
+    Function<void(i32 count_waiting)> on_resource_status_change;
 };
 
 }

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -256,4 +256,9 @@ void PageHost::page_did_set_cookie(const URL& url, const Web::Cookie::ParsedCook
     m_client.async_did_set_cookie(url, cookie, static_cast<u8>(source));
 }
 
+void PageHost::page_did_update_resource_count(i32 count_waiting)
+{
+    m_client.async_did_update_resource_count(count_waiting);
+}
+
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -64,6 +64,7 @@ private:
     virtual void page_did_request_image_context_menu(const Gfx::IntPoint&, const URL&, const String& target, unsigned modifiers, const Gfx::Bitmap*) override;
     virtual String page_did_request_cookie(const URL&, Web::Cookie::Source) override;
     virtual void page_did_set_cookie(const URL&, const Web::Cookie::ParsedCookie&, Web::Cookie::Source) override;
+    virtual void page_did_update_resource_count(i32) override;
 
     explicit PageHost(ConnectionFromClient&);
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -33,6 +33,7 @@ endpoint WebContentClient
     did_change_favicon(Gfx::ShareableBitmap favicon) =|
     did_request_cookie(URL url, u8 source) => (String cookie)
     did_set_cookie(URL url, Web::Cookie::ParsedCookie cookie, u8 source) =|
+    did_update_resource_count(i32 count_waiting) =|
 
     did_output_js_console_message(i32 message_index) =|
     did_get_js_console_messages(i32 start_index, Vector<String> message_types, Vector<String> messages) =|


### PR DESCRIPTION
Update the status bar functionality in Browser to show the host that it is navigating to, as well as how many resources are blocking the load event. Similar to old-era internet explorer status bar.

Possible statuses:
- Loading `host.com`
- `host.com` is waiting on `count` resource(s)

Biggest `FIXME` seems to be that an unhandled javascript error during page load stops the resource counter. (ex: `https://github.com/SerenityOS/serenity` stops at 114 remaining.) I think this is expected more than anything, and we really should just switch to an error message or something when that happens.

Image Context: Currently at `duckduckgo.com`, just navigated to html spec page, but it has not even begun rendering yet.
![image](https://user-images.githubusercontent.com/793454/154867452-04c96f0c-8781-4464-ac5c-e377ff961440.png)
