### PR TITLE
Lagom: Port LibSyntax

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -344,9 +344,9 @@ if (BUILD_LAGOM)
     # GUI-GML
     file(GLOB LIBGUI_GML_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibGUI/GML/*.cpp")
     list(REMOVE_ITEM LIBGUI_GML_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../../Userland/Libraries/LibGUI/GML/AutocompleteProvider.cpp")
-    list(REMOVE_ITEM LIBGUI_GML_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/../../Userland/Libraries/LibGUI/GML/SyntaxHighlighter.cpp")
     lagom_lib(GML gml
         SOURCES ${LIBGUI_GML_SOURCES}
+        LIBS LagomSyntax
     )
 
     # HTTP
@@ -421,6 +421,12 @@ if (BUILD_LAGOM)
     lagom_lib(SoftGPU softgpu
         SOURCES ${LIBSOFTGPU_SOURCES}
         LIBS m LagomGfx
+    )
+
+    # Syntax
+    file(GLOB LIBSYNTAX_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibSyntax/*.cpp")
+    lagom_lib(Syntax syntax
+        SOURCES ${LIBSYNTAX_SOURCES}
     )
 
     # SQL


### PR DESCRIPTION
LibSyntax was already building for lagom without any extra changes so let's just enable it :^)

(Separating this from my LibGUI port since it makes more sense-history wise)