### PR TITLE
LibJS: Define the Intl.Collator's compare function name to be empty

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorCompareFunction.cpp
@@ -26,6 +26,7 @@ void CollatorCompareFunction::initialize(GlobalObject& global_object)
 {
     auto& vm = global_object.vm();
     define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
+    define_direct_property(vm.names.name, js_string(vm, String::empty()), Attribute::Configurable);
 }
 
 // 10.3.3.2 CompareStrings ( collator, x, y ), https://tc39.es/ecma402/#sec-collator-comparestrings

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.compare.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/Collator/Collator.prototype.compare.js
@@ -3,6 +3,10 @@ describe("correct behavior", () => {
         expect(new Intl.Collator().compare).toHaveLength(2);
     });
 
+    test("name is empty string", () => {
+        expect(new Intl.Collator().compare.name).toBe("");
+    });
+
     test("basic functionality", () => {
         const collator = new Intl.Collator();
         expect(collator.compare("", "")).toBe(0);


### PR DESCRIPTION
Fixes:
```
test262/test/intl402/Collator/prototype/compare/compare-function-property-order.js
test262/test/intl402/Collator/prototype/compare/compare-function-name.js
```