### PR TITLE
AK: Suppress clang-tidy warning on TODO()

### DIFF
--- a/AK/Assertions.h
+++ b/AK/Assertions.h
@@ -13,5 +13,5 @@
 #    define VERIFY assert
 #    define VERIFY_NOT_REACHED() assert(false) /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 static constexpr bool TODO = false;
-#    define TODO() VERIFY(TODO)
+#    define TODO() VERIFY(TODO)                /* NOLINT(cert-dcl03-c,misc-static-assert) No, this can't be static_assert, it's a runtime check */
 #endif


### PR DESCRIPTION
This adds a `NOLINT` directive to the definition of the `TODO()` macro. `clang-tidy` wants the `assert` replaced with a `static_assert`, since the macro simply resolves to `assert(false)`. This is obviously nonsensical, since we want the code to still compile even with `TODO()`.

The same fix has already been implemented for `VERIFY_NOT_REACHED()`.