### PR TITLE
Meta: Make the timer-period QEMU parameter configurable

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -160,7 +160,8 @@ elif [ "$NATIVE_WINDOWS_QEMU" -eq "1" ]; then
 elif "$SERENITY_QEMU_BIN" -audio-help 2>&1 | grep -- "-audiodev id=sdl" >/dev/null; then
     SERENITY_AUDIO_BACKEND="-audiodev sdl,id=snd0"
 else
-    SERENITY_AUDIO_BACKEND="-audiodev pa,timer-period=2000,id=snd0"
+    [ -z "$SERENITY_AUDIO_TIMER_PERIOD" ] && SERENITY_AUDIO_TIMER_PERIOD=2000
+    SERENITY_AUDIO_BACKEND="-audiodev pa,timer-period=$SERENITY_AUDIO_TIMER_PERIOD,id=snd0"
 fi
 
 if [ "$installed_major_version" -eq 5 ] && [ "$installed_minor_version" -eq 0 ]; then

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -157,7 +157,7 @@ if [ "$(uname)" = "Darwin" ]; then
     SERENITY_AUDIO_BACKEND="-audiodev coreaudio,id=snd0"
 elif [ "$NATIVE_WINDOWS_QEMU" -eq "1" ]; then
     SERENITY_AUDIO_BACKEND="-audiodev dsound,id=snd0"
-elif "$SERENITY_QEMU_BIN" -audio-help 2>&1 | grep -- "-audiodev id=sdl" >/dev/null; then
+elif "$SERENITY_QEMU_BIN" -help 2>&1 | grep -- "-audiodev sdl" >/dev/null; then
     SERENITY_AUDIO_BACKEND="-audiodev sdl,id=snd0"
 else
     [ -z "$SERENITY_AUDIO_TIMER_PERIOD" ] && SERENITY_AUDIO_TIMER_PERIOD=2000


### PR DESCRIPTION
The previous value (20ms) causes noticeable crackling on my host. This adds an environment variable (SERENITY_AUDIO_TIMER_PERIOD) which makes the timer configurable.