### PR TITLE
LibWeb: Append only one line feed character in Document.writeln

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -324,6 +324,8 @@ private:
 
     void tear_down_layout_tree();
 
+    ExceptionOr<void> run_the_document_write_steps(String);
+
     void increment_referencing_node_count()
     {
         VERIFY(!m_deletion_has_begun);


### PR DESCRIPTION
There were a couple issues here:

1. The line feed should only be appended once, rather than one per
   string.
2. The new_strings lists of strings was unused (we were creating the new
   list, then passing the old list to Document.write).