### PR TITLE
Shell: Start `history` counter from 1

### DIFF
--- a/Userland/Shell/Builtin.cpp
+++ b/Userland/Shell/Builtin.cpp
@@ -628,7 +628,7 @@ int Shell::builtin_disown(int argc, const char** argv)
 int Shell::builtin_history(int, const char**)
 {
     for (size_t i = 0; i < m_editor->history().size(); ++i) {
-        printf("%6zu  %s\n", i, m_editor->history()[i].entry.characters());
+        printf("%6zu  %s\n", i + 1, m_editor->history()[i].entry.characters());
     }
     return 0;
 }


### PR DESCRIPTION
Previously would show the list of history items starting from
an index of 0.

This is a bit misleading though. Running `!0` would actually cause
the parser to error out and prevent you from running the command.