### PR TITLE
Kernel: Use TRY() when validating clock_id in TimeManagement

### DIFF
--- a/Kernel/Syscalls/clock.cpp
+++ b/Kernel/Syscalls/clock.cpp
@@ -27,8 +27,7 @@ ErrorOr<FlatPtr> Process::sys$clock_gettime(clockid_t clock_id, Userspace<timesp
     VERIFY_NO_PROCESS_BIG_LOCK(this);
     TRY(require_promise(Pledge::stdio));
 
-    if (!TimeManagement::is_valid_clock_id(clock_id))
-        return EINVAL;
+    TRY(TimeManagement::validate_clock_id(clock_id));
 
     auto ts = TimeManagement::the().current_time(clock_id).to_timespec();
     TRY(copy_to_user(user_ts, &ts));
@@ -75,8 +74,7 @@ ErrorOr<FlatPtr> Process::sys$clock_nanosleep(Userspace<const Syscall::SC_clock_
         return EINVAL;
     }
 
-    if (!TimeManagement::is_valid_clock_id(params.clock_id))
-        return EINVAL;
+    TRY(TimeManagement::validate_clock_id(params.clock_id));
 
     bool was_interrupted;
     if (is_absolute) {

--- a/Kernel/Time/TimeManagement.cpp
+++ b/Kernel/Time/TimeManagement.cpp
@@ -37,7 +37,7 @@ TimeManagement& TimeManagement::the()
     return *s_the;
 }
 
-bool TimeManagement::is_valid_clock_id(clockid_t clock_id)
+ErrorOr<void> TimeManagement::validate_clock_id(clockid_t clock_id)
 {
     switch (clock_id) {
     case CLOCK_MONOTONIC:
@@ -45,9 +45,9 @@ bool TimeManagement::is_valid_clock_id(clockid_t clock_id)
     case CLOCK_MONOTONIC_RAW:
     case CLOCK_REALTIME:
     case CLOCK_REALTIME_COARSE:
-        return true;
+        return {};
     default:
-        return false;
+        return EINVAL;
     };
 }
 

--- a/Kernel/Time/TimeManagement.h
+++ b/Kernel/Time/TimeManagement.h
@@ -36,7 +36,7 @@ public:
     static bool is_initialized();
     static TimeManagement& the();
 
-    static bool is_valid_clock_id(clockid_t);
+    static ErrorOr<void> validate_clock_id(clockid_t);
     Time current_time(clockid_t) const;
     Time monotonic_time(TimePrecision = TimePrecision::Coarse) const;
     Time monotonic_time_raw() const


### PR DESCRIPTION
Gets rid of a bit of code duplication, and makes the API more consistent
with the style we are moving towards.