### PR TITLE
UserspaceEmulator: Fix syntax of generated profiles

### DIFF
--- a/Userland/DevTools/UserspaceEmulator/main.cpp
+++ b/Userland/DevTools/UserspaceEmulator/main.cpp
@@ -116,7 +116,7 @@ int main(int argc, char** argv, char** env)
     rc = emulator.exec();
 
     if (dump_profile) {
-        emulator.profile_stream().write_or_error(", \"strings\": ["sv.bytes());
+        emulator.profile_stream().write_or_error("], \"strings\": ["sv.bytes());
         if (emulator.profiler_strings().size()) {
             for (size_t i = 0; i < emulator.profiler_strings().size() - 1; ++i)
                 emulator.profile_stream().write_or_error(String::formatted("\"{}\", ", emulator.profiler_strings().at(i)).bytes());


### PR DESCRIPTION
While trying out `ue --profile` today, I received an invalid json
profile. After poking around at the file it looks like we never close
the `events: [..` array that we generate, and thus end up with an
invalid document.

The fix is straight forward, always emit the closing brace.