### PR TITLE
WindowServer: Mark window frame as invalidated when updating title

### DIFF
--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -650,23 +650,23 @@ void Window::invalidate(bool invalidate_frame, bool re_render_frame)
     Compositor::the().invalidate_window();
 }
 
-void Window::invalidate(Gfx::IntRect const& rect)
+void Window::invalidate(Gfx::IntRect const& rect, bool invalidate_frame)
 {
     if (type() == WindowType::Applet) {
         AppletManager::the().invalidate_applet(*this, rect);
         return;
     }
 
-    if (invalidate_no_notify(rect))
+    if (invalidate_no_notify(rect, invalidate_frame))
         Compositor::the().invalidate_window();
 }
 
-bool Window::invalidate_no_notify(const Gfx::IntRect& rect, bool with_frame)
+bool Window::invalidate_no_notify(const Gfx::IntRect& rect, bool invalidate_frame)
 {
     if (rect.is_empty())
         return false;
     if (m_invalidated_all) {
-        if (with_frame)
+        if (invalidate_frame)
             m_invalidated_frame |= true;
         return false;
     }
@@ -680,7 +680,7 @@ bool Window::invalidate_no_notify(const Gfx::IntRect& rect, bool with_frame)
         return false;
 
     m_invalidated = true;
-    if (with_frame)
+    if (invalidate_frame)
         m_invalidated_frame |= true;
     m_dirty_rects.add(inner_rect.translated(-outer_rect.location()));
     return true;

--- a/Userland/Services/WindowServer/Window.h
+++ b/Userland/Services/WindowServer/Window.h
@@ -211,9 +211,9 @@ public:
     Gfx::IntSize size() const { return m_rect.size(); }
 
     void invalidate(bool with_frame = true, bool re_render_frame = false);
-    void invalidate(Gfx::IntRect const&);
+    void invalidate(Gfx::IntRect const&, bool invalidate_frame = false);
     void invalidate_menubar();
-    bool invalidate_no_notify(const Gfx::IntRect& rect, bool with_frame = false);
+    bool invalidate_no_notify(const Gfx::IntRect& rect, bool invalidate_frame = false);
     void invalidate_last_rendered_screen_rects();
     void invalidate_last_rendered_screen_rects_now();
     [[nodiscard]] bool should_invalidate_last_rendered_screen_rects() { return exchange(m_invalidate_last_render_rects, false); }

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -624,7 +624,7 @@ void WindowFrame::invalidate(Gfx::IntRect relative_rect)
     auto window_rect = m_window.rect();
     relative_rect.translate_by(frame_rect.x() - window_rect.x(), frame_rect.y() - window_rect.y());
     set_dirty();
-    m_window.invalidate(relative_rect);
+    m_window.invalidate(relative_rect, true);
 }
 
 void WindowFrame::window_rect_changed(const Gfx::IntRect& old_rect, const Gfx::IntRect& new_rect)


### PR DESCRIPTION
We need to set Window::m_invalidated_frame to true when invalidating
the title, otherwise we may miss re-rendering the frame if nothing
else triggers it.

This fixes a rendering issue noticed by @GMTA 

![Screenshot from 2022-02-21 19-29-45](https://user-images.githubusercontent.com/10320822/155052290-6d1f7b13-86d1-4171-9696-77a014076141.png)