### PR TITLE
HackStudio: Organize Menus

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -497,7 +497,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_file_action(String const
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_directory_action()
 {
-    return GUI::Action::create("&New Directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
+    return GUI::Action::create("&Directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
         String directory_name;
         if (GUI::InputBox::show(window(), directory_name, "Enter name of new directory:", "Add new folder to project") != GUI::InputBox::ExecOK)
             return;
@@ -608,7 +608,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_project_action()
 {
-    return GUI::Action::create("&New Project...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/hackstudio-project.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
+    return GUI::Action::create("&Project...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/hackstudio-project.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
         auto dialog = NewProjectDialog::construct(window());
         dialog->set_icon(window()->icon());
         auto result = dialog->exec();
@@ -1200,7 +1200,19 @@ void HackStudioWidget::update_recent_projects_submenu()
 void HackStudioWidget::create_file_menu(GUI::Window& window)
 {
     auto& file_menu = window.add_menu("&File");
-    file_menu.add_action(*m_new_project_action);
+
+    auto& new_submenu = file_menu.add_submenu("New...");
+    new_submenu.add_action(*m_new_project_action);
+    new_submenu.add_separator();
+
+    for (auto& new_file_action : m_new_file_actions)
+        new_submenu.add_action(new_file_action);
+
+    new_submenu.add_action(*m_new_plain_file_action);
+    new_submenu.add_separator();
+    new_submenu.add_action(*m_new_directory_action);
+    new_submenu.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png").release_value_but_fixme_should_propagate_errors());
+
     file_menu.add_action(*m_open_action);
     m_recent_projects_submenu = &file_menu.add_submenu("Open Recent");
     update_recent_projects_submenu();
@@ -1210,22 +1222,6 @@ void HackStudioWidget::create_file_menu(GUI::Window& window)
     file_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();
     }));
-}
-
-void HackStudioWidget::create_project_menu(GUI::Window& window)
-{
-    auto& project_menu = window.add_menu("&Project");
-    auto& new_submenu = project_menu.add_submenu("New");
-    for (auto& new_file_action : m_new_file_actions) {
-        new_submenu.add_action(new_file_action);
-    }
-    new_submenu.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png").release_value_but_fixme_should_propagate_errors());
-    new_submenu.add_action(*m_new_plain_file_action);
-    new_submenu.add_separator();
-    new_submenu.add_action(*m_new_directory_action);
-
-    m_toggle_semantic_highlighting_action = create_toggle_syntax_highlighting_mode_action();
-    project_menu.add_action(*m_toggle_semantic_highlighting_action);
 }
 
 void HackStudioWidget::create_edit_menu(GUI::Window& window)
@@ -1278,6 +1274,8 @@ void HackStudioWidget::create_view_menu(GUI::Window& window)
     view_menu.add_action(hide_action_tabs_action);
     view_menu.add_action(open_locator_action);
     view_menu.add_action(show_dotfiles_action);
+    m_toggle_semantic_highlighting_action = create_toggle_syntax_highlighting_mode_action();
+    view_menu.add_action(*m_toggle_semantic_highlighting_action);
     view_menu.add_separator();
 
     m_wrapping_mode_actions.set_exclusive(true);
@@ -1351,7 +1349,6 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_stop_action()
 void HackStudioWidget::initialize_menubar(GUI::Window& window)
 {
     create_file_menu(window);
-    create_project_menu(window);
     create_edit_menu(window);
     create_build_menu(window);
     create_view_menu(window);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -417,14 +417,14 @@ void HackStudioWidget::set_edit_mode(EditMode mode)
 
 NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu()
 {
-    m_new_file_actions.append(create_new_file_action("C++ Source File", "/res/icons/16x16/filetype-cplusplus.png", "cpp"));
-    m_new_file_actions.append(create_new_file_action("C++ Header File", "/res/icons/16x16/filetype-header.png", "h"));
-    m_new_file_actions.append(create_new_file_action("GML File", "/res/icons/16x16/filetype-gml.png", "gml"));
-    m_new_file_actions.append(create_new_file_action("JavaScript Source File", "/res/icons/16x16/filetype-javascript.png", "js"));
-    m_new_file_actions.append(create_new_file_action("HTML File", "/res/icons/16x16/filetype-html.png", "html"));
-    m_new_file_actions.append(create_new_file_action("CSS File", "/res/icons/16x16/filetype-css.png", "css"));
+    m_new_file_actions.append(create_new_file_action("&C++ Source File", "/res/icons/16x16/filetype-cplusplus.png", "cpp"));
+    m_new_file_actions.append(create_new_file_action("C++ &Header File", "/res/icons/16x16/filetype-header.png", "h"));
+    m_new_file_actions.append(create_new_file_action("&GML File", "/res/icons/16x16/filetype-gml.png", "gml"));
+    m_new_file_actions.append(create_new_file_action("&JavaScript Source File", "/res/icons/16x16/filetype-javascript.png", "js"));
+    m_new_file_actions.append(create_new_file_action("HT&ML File", "/res/icons/16x16/filetype-html.png", "html"));
+    m_new_file_actions.append(create_new_file_action("C&SS File", "/res/icons/16x16/filetype-css.png", "css"));
 
-    m_new_plain_file_action = create_new_file_action("Plain File", "/res/icons/16x16/new.png", "");
+    m_new_plain_file_action = create_new_file_action("Plain &File", "/res/icons/16x16/new.png", "");
 
     m_open_selected_action = create_open_selected_action();
     m_show_in_file_manager_action = create_show_in_file_manager_action();
@@ -436,7 +436,7 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     });
     auto project_tree_view_context_menu = GUI::Menu::construct("Project Files");
 
-    auto& new_file_submenu = project_tree_view_context_menu->add_submenu("New");
+    auto& new_file_submenu = project_tree_view_context_menu->add_submenu("&New...");
     for (auto& new_file_action : m_new_file_actions) {
         new_file_submenu.add_action(new_file_action);
     }
@@ -528,7 +528,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_directory_action()
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_action()
 {
-    auto open_selected_action = GUI::Action::create("Open", [this](const GUI::Action&) {
+    auto open_selected_action = GUI::Action::create("&Open", [this](const GUI::Action&) {
         auto files = selected_file_paths();
         for (auto& file : files)
             open_file(file);
@@ -540,7 +540,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_action()
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_show_in_file_manager_action()
 {
-    auto show_in_file_manager_action = GUI::Action::create("Show in File Manager", [this](const GUI::Action&) {
+    auto show_in_file_manager_action = GUI::Action::create("Show in File &Manager", [this](const GUI::Action&) {
         auto files = selected_file_paths();
         for (auto& file : files)
             Desktop::Launcher::open(URL::create_with_file_protocol(m_project->root_path(), file));
@@ -608,7 +608,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_project_action()
 {
-    return GUI::Action::create("&Project...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/hackstudio-project.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
+    return GUI::Action::create("&Project...", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/hackstudio-project.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
         auto dialog = NewProjectDialog::construct(window());
         dialog->set_icon(window()->icon());
         auto result = dialog->exec();
@@ -1201,7 +1201,7 @@ void HackStudioWidget::create_file_menu(GUI::Window& window)
 {
     auto& file_menu = window.add_menu("&File");
 
-    auto& new_submenu = file_menu.add_submenu("New...");
+    auto& new_submenu = file_menu.add_submenu("&New...");
     new_submenu.add_action(*m_new_project_action);
     new_submenu.add_separator();
 
@@ -1214,7 +1214,8 @@ void HackStudioWidget::create_file_menu(GUI::Window& window)
     new_submenu.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png").release_value_but_fixme_should_propagate_errors());
 
     file_menu.add_action(*m_open_action);
-    m_recent_projects_submenu = &file_menu.add_submenu("Open Recent");
+    m_recent_projects_submenu = &file_menu.add_submenu("Open &Recent");
+    m_recent_projects_submenu->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open-recent.png").release_value_but_fixme_should_propagate_errors());
     update_recent_projects_submenu();
     file_menu.add_action(*m_save_action);
     file_menu.add_action(*m_save_as_action);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -133,7 +133,6 @@ private:
     void create_action_tab(GUI::Widget& parent);
     void create_file_menu(GUI::Window&);
     void update_recent_projects_submenu();
-    void create_project_menu(GUI::Window&);
     void create_edit_menu(GUI::Window&);
     void create_build_menu(GUI::Window&);
     void create_view_menu(GUI::Window&);

--- a/Userland/Libraries/LibCpp/AST.cpp
+++ b/Userland/Libraries/LibCpp/AST.cpp
@@ -124,8 +124,9 @@ String FunctionType::to_string() const
             first = false;
         else
             builder.append(", ");
-        builder.append(parameter.type()->to_string());
-        if (!parameter.name().is_empty()) {
+        if (parameter.type())
+            builder.append(parameter.type()->to_string());
+        if (parameter.name() && !parameter.full_name().is_empty()) {
             builder.append(" ");
             builder.append(parameter.name());
         }


### PR DESCRIPTION
Move 'New...' to 'File' menu. Move 'New Project...' to 'New...' submenu.

![Screen Shot 2022-02-21 at 23 10 31](https://user-images.githubusercontent.com/4368524/155061699-26adcfb6-4320-498c-87e3-d8692c81f257.png)

Move 'Semantic Highlighting' to 'View' menu, remove 'Project' menu.

![Screen Shot 2022-02-21 at 22 27 02](https://user-images.githubusercontent.com/4368524/155061060-3b00331d-f9ed-423c-9d43-552c5b52c615.png)

Add missing key triggers to 'New' menu, but also to 'Open in File Manager'

<img width="550" alt="Screen Shot 2022-02-23 at 18 45 57" src="https://user-images.githubusercontent.com/4368524/155429786-cf541b61-fa46-4138-a8c2-1513fb5a6853.png">