### PR TITLE
Kernel: Use IO init method for Bochs emulated VGA adapter

### DIFF
--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -109,8 +109,14 @@ UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::DeviceIdentifie
     m_framebuffer_console = Graphics::ContiguousFramebufferConsole::initialize(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), 1024, 768, 1024 * sizeof(u32));
     GraphicsManagement::the().set_console(*m_framebuffer_console);
 
-    // Note: If we use VirtualBox graphics adapter (which is based on Bochs one), we need to use IO ports
-    if (pci_device_identifier.hardware_id().vendor_id == 0x80ee && pci_device_identifier.hardware_id().device_id == 0xbeef)
+    auto vendor_id = pci_device_identifier.hardware_id().vendor_id;
+    auto device_id = pci_device_identifier.hardware_id().device_id;
+    auto revision_id = pci_device_identifier.revision_id();
+
+    auto is_bochs = vendor_id == PCI::VendorID::QEMUOld && device_id == 0x1111 && revision_id == 0;
+    auto is_virtualbox = vendor_id == PCI::VendorID::VirtualBox && device_id == 0xbeef;
+
+    if (is_bochs || is_virtualbox)
         m_io_required = true;
 
     if (pci_device_identifier.class_code().value() == 0x3 && pci_device_identifier.subclass_code().value() == 0x0)


### PR DESCRIPTION
In short: QEMU supports both Memory-Mapped-IO and classic IO methods
for controlling the emulated VGA device. Bochs and VirtualBox only
support the classic IO method. An excellent write up on the history of
these interfaces can be found here:
https://www.kraxel.org/blog/2018/10/qemu-vga-emulation-and-bochs-display

The IO method was how things were done originally in SerenityOS. Commit
6a728e2d761601a9d21f2269e2febbfde55b3646 introduced the MMIO method for
all devices, breaking Bochs and VirtualBox compatibility. Later in
commit 6a9dc5562db9e6b0c519f9e7439e6964b326c419 the classic IO method
was restored for VirtualBox graphics adapters.

QEMU and Bochs use the same PCI VID/DID (0x1234/0x1111) for the emulated
VGA adapter. To distinguish betwen QEMU and Bochs we use the PCI
revision ID field (0=Bochs, 2=QEMU).