### PR TITLE
AK: Inform Atomic users that it's not compatible with complex types

### DIFF
--- a/AK/Atomic.h
+++ b/AK/Atomic.h
@@ -138,6 +138,10 @@ static inline bool atomic_is_lock_free(volatile T* ptr = nullptr) noexcept
 
 template<typename T, MemoryOrder DefaultMemoryOrder = AK::MemoryOrder::memory_order_seq_cst>
 class Atomic {
+    // FIXME: This should work through concepts/requires clauses, but according to the compiler,
+    //        "IsIntegral is not more specialized than IsFundamental".
+    //        Additionally, Enums are not fundamental types except that they behave like them in every observable way.
+    static_assert(IsFundamental<T> | IsEnum<T>, "Atomic doesn't support non-primitive types, because it relies on compiler intrinsics. If you put non-primitives into it, you'll get linker errors like \"undefined reference to __atomic_store\".");
     T m_value { 0 };
 
 public:

--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -19,6 +19,9 @@ template<typename T>
 concept FloatingPoint = IsFloatingPoint<T>;
 
 template<typename T>
+concept Fundamental = IsFundamental<T>;
+
+template<typename T>
 concept Arithmetic = IsArithmetic<T>;
 
 template<typename T>
@@ -109,6 +112,7 @@ using AK::Concepts::Arithmetic;
 using AK::Concepts::ArrayLike;
 using AK::Concepts::Enum;
 using AK::Concepts::FloatingPoint;
+using AK::Concepts::Fundamental;
 using AK::Concepts::Integral;
 using AK::Concepts::IterableContainer;
 using AK::Concepts::IteratorFunction;


### PR DESCRIPTION
This would throw some really weird linker errors, so let's warn everyone instead.