### PR TITLE
LibGUI+WindowServer+Taskbar: Minimize/activate windows via Super+Digit shortcut

### DIFF
--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -66,6 +66,7 @@ public:
         WM_AppletAreaSizeChanged,
         WM_SuperKeyPressed,
         WM_SuperSpaceKeyPressed,
+        WM_SuperDigitKeyPressed,
         WM_WorkspaceChanged,
         WM_KeymapChanged,
         __End_WM_Events,
@@ -113,6 +114,20 @@ public:
         : WMEvent(Event::Type::WM_SuperSpaceKeyPressed, client_id, 0)
     {
     }
+};
+
+class WMSuperDigitKeyPressedEvent : public WMEvent {
+public:
+    WMSuperDigitKeyPressedEvent(int client_id, u8 digit)
+        : WMEvent(Event::Type::WM_SuperDigitKeyPressed, client_id, 0)
+        , m_digit(digit)
+    {
+    }
+
+    u8 digit() const { return m_digit; }
+
+private:
+    u8 m_digit { 0 };
 };
 
 class WMAppletAreaSizeChangedEvent : public WMEvent {

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.cpp
@@ -64,6 +64,12 @@ void WindowManagerServerConnection::super_space_key_pressed(i32 wm_id)
         Core::EventLoop::current().post_event(*window, make<WMSuperSpaceKeyPressedEvent>(wm_id));
 }
 
+void WindowManagerServerConnection::super_digit_key_pressed(i32 wm_id, u8 digit)
+{
+    if (auto* window = Window::from_window_id(wm_id))
+        Core::EventLoop::current().post_event(*window, make<WMSuperDigitKeyPressedEvent>(wm_id, digit));
+}
+
 void WindowManagerServerConnection::workspace_changed(i32 wm_id, u32 row, u32 column)
 {
     if (auto* window = Window::from_window_id(wm_id))

--- a/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
+++ b/Userland/Libraries/LibGUI/WindowManagerServerConnection.h
@@ -34,6 +34,7 @@ private:
     virtual void applet_area_size_changed(i32, Gfx::IntSize const&) override;
     virtual void super_key_pressed(i32) override;
     virtual void super_space_key_pressed(i32) override;
+    virtual void super_digit_key_pressed(i32, u8) override;
     virtual void workspace_changed(i32, u32, u32) override;
     virtual void keymap_changed(i32, String const&) override;
 };

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -334,6 +334,24 @@ void TaskbarWindow::wm_event(GUI::WMEvent& event)
             warnln("failed to spawn 'Assistant' when requested via Super+Space");
         break;
     }
+    case GUI::Event::WM_SuperDigitKeyPressed: {
+        auto& digit_event = static_cast<GUI::WMSuperDigitKeyPressedEvent&>(event);
+        auto index = digit_event.digit() != 0 ? digit_event.digit() - 1 : 9;
+
+        for (auto& widget : m_task_button_container->child_widgets()) {
+            // NOTE: The button might be invisible depending on the current workspace
+            if (!widget.is_visible())
+                continue;
+
+            if (index == 0) {
+                static_cast<TaskbarButton&>(widget).click();
+                break;
+            }
+
+            --index;
+        }
+        break;
+    }
     case GUI::Event::WM_WorkspaceChanged: {
         auto& changed_event = static_cast<GUI::WMWorkspaceChangedEvent&>(event);
         workspace_change_event(changed_event.current_row(), changed_event.current_column());

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -546,6 +546,17 @@ void WindowManager::tell_wms_super_space_key_pressed()
     });
 }
 
+void WindowManager::tell_wms_super_digit_key_pressed(u8 digit)
+{
+    for_each_window_manager([digit](WMClientConnection& conn) {
+        if (conn.window_id() < 0)
+            return IterationDecision::Continue;
+
+        conn.async_super_digit_key_pressed(conn.window_id(), digit);
+        return IterationDecision::Continue;
+    });
+}
+
 void WindowManager::tell_wms_current_window_stack_changed()
 {
     for_each_window_manager([&](WMClientConnection& conn) {
@@ -1601,6 +1612,12 @@ void WindowManager::process_key_event(KeyEvent& event)
 
         if (event.type() == Event::KeyDown && event.key() == Key_Space) {
             tell_wms_super_space_key_pressed();
+            return;
+        }
+
+        if (event.type() == Event::KeyDown && event.key() >= Key_0 && event.key() <= Key_9) {
+            auto digit = event.key() - Key_0;
+            tell_wms_super_digit_key_pressed(digit);
             return;
         }
     }

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -187,6 +187,7 @@ public:
     void tell_wms_applet_area_size_changed(Gfx::IntSize const&);
     void tell_wms_super_key_pressed();
     void tell_wms_super_space_key_pressed();
+    void tell_wms_super_digit_key_pressed(u8);
     void tell_wms_current_window_stack_changed();
 
     bool is_active_window_or_accessory(Window&) const;

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -9,6 +9,7 @@ endpoint WindowManagerClient
     applet_area_size_changed(i32 wm_id, Gfx::IntSize size) =|
     super_key_pressed(i32 wm_id) =|
     super_space_key_pressed(i32 wm_id) =|
+    super_digit_key_pressed(i32 wm_id, u8 digit) =|
     workspace_changed(i32 wm_id, u32 row, u32 column) =|
     keymap_changed(i32 wm_id, [UTF8] String keymap) =|
 }


### PR DESCRIPTION
Minimize/activate currently open windows in the taskbar via the shortcuts <kbd>Super</kbd>+<kbd>0</kbd> to <kbd>Super</kbd>+<kbd>9</kbd>.