### PR TITLE
Kernel: Propagate errors of HIDDevices

### DIFF
--- a/Kernel/Devices/HID/HIDManagement.cpp
+++ b/Kernel/Devices/HID/HIDManagement.cpp
@@ -131,12 +131,11 @@ UNMAP_AFTER_INIT ErrorOr<void> HIDManagement::enumerate()
     return {};
 }
 
-UNMAP_AFTER_INIT void HIDManagement::initialize()
+UNMAP_AFTER_INIT ErrorOr<void> HIDManagement::initialize()
 {
     VERIFY(!s_the.is_initialized());
     s_the.ensure_instance();
-    // FIXME: Propagate errors back to init to deal with them.
-    MUST(s_the->enumerate());
+    return s_the->enumerate();
 }
 
 HIDManagement& HIDManagement::the()

--- a/Kernel/Devices/HID/HIDManagement.h
+++ b/Kernel/Devices/HID/HIDManagement.h
@@ -34,7 +34,7 @@ class HIDManagement {
 
 public:
     HIDManagement();
-    static void initialize();
+    static ErrorOr<void> initialize();
     static HIDManagement& the();
 
     ErrorOr<void> enumerate();

--- a/Kernel/Devices/HID/I8042Controller.h
+++ b/Kernel/Devices/HID/I8042Controller.h
@@ -91,47 +91,39 @@ public:
 
     ErrorOr<void> detect_devices();
 
-    bool reset_device(HIDDevice::Type device)
+    ErrorOr<void> reset_device(HIDDevice::Type device)
     {
         SpinlockLocker lock(m_lock);
-        // FIXME: Propagate errors properly
-        if (auto result = do_reset_device(device); result.is_error())
-            return false;
-        return true;
+        return do_reset_device(device);
     }
 
-    u8 send_command(HIDDevice::Type device, u8 command)
+    ErrorOr<u8> send_command(HIDDevice::Type device, u8 command)
     {
         SpinlockLocker lock(m_lock);
-        // FIXME: Propagate errors properly
-        return MUST(do_send_command(device, command));
+        return do_send_command(device, command);
     }
-    u8 send_command(HIDDevice::Type device, u8 command, u8 data)
+    ErrorOr<u8> send_command(HIDDevice::Type device, u8 command, u8 data)
     {
         SpinlockLocker lock(m_lock);
-        // FIXME: Propagate errors properly
-        return MUST(do_send_command(device, command, data));
+        return do_send_command(device, command, data);
     }
 
-    u8 read_from_device(HIDDevice::Type device)
+    ErrorOr<u8> read_from_device(HIDDevice::Type device)
     {
         SpinlockLocker lock(m_lock);
-        // FIXME: Propagate errors properly
-        return MUST(do_read_from_device(device));
+        return do_read_from_device(device);
     }
 
-    void wait_then_write(u8 port, u8 data)
+    ErrorOr<void> wait_then_write(u8 port, u8 data)
     {
         SpinlockLocker lock(m_lock);
-        // FIXME: Propagate errors properly
-        MUST(do_wait_then_write(port, data));
+        return do_wait_then_write(port, data);
     }
 
-    u8 wait_then_read(u8 port)
+    ErrorOr<u8> wait_then_read(u8 port)
     {
         SpinlockLocker lock(m_lock);
-        // FIXME: Propagate errors properly
-        return MUST(do_wait_then_read(port));
+        return do_wait_then_read(port);
     }
 
     ErrorOr<void> prepare_for_output();

--- a/Kernel/Devices/HID/PS2KeyboardDevice.h
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.h
@@ -23,9 +23,9 @@ class PS2KeyboardDevice final : public IRQHandler
     friend class DeviceManagement;
 
 public:
-    static RefPtr<PS2KeyboardDevice> try_to_initialize(const I8042Controller&);
+    static ErrorOr<NonnullRefPtr<PS2KeyboardDevice>> try_to_initialize(const I8042Controller&);
     virtual ~PS2KeyboardDevice() override;
-    bool initialize();
+    ErrorOr<void> initialize();
 
     virtual StringView purpose() const override { return class_name(); }
 

--- a/Kernel/Devices/HID/PS2MouseDevice.cpp
+++ b/Kernel/Devices/HID/PS2MouseDevice.cpp
@@ -139,70 +139,69 @@ MousePacket PS2MouseDevice::parse_data_packet(const RawPacket& raw_packet)
     return packet;
 }
 
-u8 PS2MouseDevice::get_device_id()
+ErrorOr<u8> PS2MouseDevice::get_device_id()
 {
-    if (send_command(I8042Command::GetDeviceID) != I8042Response::Acknowledge)
-        return 0;
+    TRY(send_command(I8042Command::GetDeviceID));
     return read_from_device();
 }
 
-u8 PS2MouseDevice::read_from_device()
+ErrorOr<u8> PS2MouseDevice::read_from_device()
 {
     return m_i8042_controller->read_from_device(instrument_type());
 }
 
-u8 PS2MouseDevice::send_command(u8 command)
+ErrorOr<u8> PS2MouseDevice::send_command(u8 command)
 {
-    u8 response = m_i8042_controller->send_command(instrument_type(), command);
-    if (response != I8042Response::Acknowledge)
+    u8 response = TRY(m_i8042_controller->send_command(instrument_type(), command));
+
+    if (response != I8042Response::Acknowledge) {
         dbgln("PS2MouseDevice: Command {} got {} but expected ack: {}", command, response, static_cast<u8>(I8042Response::Acknowledge));
-    return response;
-}
-
-u8 PS2MouseDevice::send_command(u8 command, u8 data)
-{
-    u8 response = m_i8042_controller->send_command(instrument_type(), command, data);
-    if (response != I8042Response::Acknowledge)
-        dbgln("PS2MouseDevice: Command {} got {} but expected ack: {}", command, response, static_cast<u8>(I8042Response::Acknowledge));
-    return response;
-}
-
-void PS2MouseDevice::set_sample_rate(u8 rate)
-{
-    send_command(I8042Command::SetSampleRate, rate);
-}
-
-UNMAP_AFTER_INIT RefPtr<PS2MouseDevice> PS2MouseDevice::try_to_initialize(const I8042Controller& ps2_controller)
-{
-    auto mouse_device_or_error = DeviceManagement::try_create_device<PS2MouseDevice>(ps2_controller);
-    // FIXME: Find a way to propagate errors
-    VERIFY(!mouse_device_or_error.is_error());
-    if (mouse_device_or_error.value()->initialize())
-        return mouse_device_or_error.release_value();
-    return nullptr;
-}
-
-UNMAP_AFTER_INIT bool PS2MouseDevice::initialize()
-{
-    if (!m_i8042_controller->reset_device(instrument_type())) {
-        dbgln("PS2MouseDevice: I8042 controller failed to reset device");
-        return false;
+        // FIXME: Is this the correct errno value for this?
+        return Error::from_errno(EIO);
     }
+    return response;
+}
 
-    u8 device_id = read_from_device();
+ErrorOr<u8> PS2MouseDevice::send_command(u8 command, u8 data)
+{
+    u8 response = TRY(m_i8042_controller->send_command(instrument_type(), command, data));
+    if (response != I8042Response::Acknowledge) {
+        dbgln("PS2MouseDevice: Command {} got {} but expected ack: {}", command, response, static_cast<u8>(I8042Response::Acknowledge));
+        // FIXME: Is this the correct errno value for this?
+        return Error::from_errno(EIO);
+    }
+    return response;
+}
 
-    if (send_command(I8042Command::SetDefaults) != I8042Response::Acknowledge)
-        return false;
+ErrorOr<void> PS2MouseDevice::set_sample_rate(u8 rate)
+{
+    TRY(send_command(I8042Command::SetSampleRate, rate));
+    return {};
+}
 
-    if (send_command(I8042Command::EnablePacketStreaming) != I8042Response::Acknowledge)
-        return false;
+UNMAP_AFTER_INIT ErrorOr<NonnullRefPtr<PS2MouseDevice>> PS2MouseDevice::try_to_initialize(const I8042Controller& ps2_controller)
+{
+    auto mouse_device = TRY(DeviceManagement::try_create_device<PS2MouseDevice>(ps2_controller));
+    TRY(mouse_device->initialize());
+    return mouse_device;
+}
+
+UNMAP_AFTER_INIT ErrorOr<void> PS2MouseDevice::initialize()
+{
+    TRY(m_i8042_controller->reset_device(instrument_type()));
+
+    u8 device_id = TRY(read_from_device());
+
+    TRY(send_command(I8042Command::SetDefaults));
+
+    TRY(send_command(I8042Command::EnablePacketStreaming));
 
     if (device_id != PS2MOUSE_INTELLIMOUSE_ID) {
         // Send magical wheel initiation sequence.
-        set_sample_rate(200);
-        set_sample_rate(100);
-        set_sample_rate(80);
-        device_id = get_device_id();
+        TRY(set_sample_rate(200));
+        TRY(set_sample_rate(100));
+        TRY(set_sample_rate(80));
+        device_id = TRY(get_device_id());
     }
     if (device_id == PS2MOUSE_INTELLIMOUSE_ID) {
         m_has_wheel = true;
@@ -213,17 +212,17 @@ UNMAP_AFTER_INIT bool PS2MouseDevice::initialize()
 
     if (device_id == PS2MOUSE_INTELLIMOUSE_ID) {
         // Try to enable 5 buttons as well!
-        set_sample_rate(200);
-        set_sample_rate(200);
-        set_sample_rate(80);
-        device_id = get_device_id();
+        TRY(set_sample_rate(200));
+        TRY(set_sample_rate(200));
+        TRY(set_sample_rate(80));
+        device_id = TRY(get_device_id());
     }
 
     if (device_id == PS2MOUSE_INTELLIMOUSE_EXPLORER_ID) {
         m_has_five_buttons = true;
         dmesgln("PS2MouseDevice: 5 buttons enabled!");
     }
-    return true;
+    return {};
 }
 
 }

--- a/Kernel/Devices/HID/PS2MouseDevice.cpp
+++ b/Kernel/Devices/HID/PS2MouseDevice.cpp
@@ -156,7 +156,6 @@ ErrorOr<u8> PS2MouseDevice::send_command(u8 command)
 
     if (response != I8042Response::Acknowledge) {
         dbgln("PS2MouseDevice: Command {} got {} but expected ack: {}", command, response, static_cast<u8>(I8042Response::Acknowledge));
-        // FIXME: Is this the correct errno value for this?
         return Error::from_errno(EIO);
     }
     return response;
@@ -167,7 +166,6 @@ ErrorOr<u8> PS2MouseDevice::send_command(u8 command, u8 data)
     u8 response = TRY(m_i8042_controller->send_command(instrument_type(), command, data));
     if (response != I8042Response::Acknowledge) {
         dbgln("PS2MouseDevice: Command {} got {} but expected ack: {}", command, response, static_cast<u8>(I8042Response::Acknowledge));
-        // FIXME: Is this the correct errno value for this?
         return Error::from_errno(EIO);
     }
     return response;

--- a/Kernel/Devices/HID/PS2MouseDevice.h
+++ b/Kernel/Devices/HID/PS2MouseDevice.h
@@ -20,8 +20,8 @@ class PS2MouseDevice : public IRQHandler
     friend class DeviceManagement;
 
 public:
-    static RefPtr<PS2MouseDevice> try_to_initialize(const I8042Controller&);
-    bool initialize();
+    static ErrorOr<NonnullRefPtr<PS2MouseDevice>> try_to_initialize(const I8042Controller&);
+    ErrorOr<void> initialize();
 
     virtual ~PS2MouseDevice() override;
 
@@ -47,12 +47,12 @@ protected:
         };
     };
 
-    u8 read_from_device();
-    u8 send_command(u8 command);
-    u8 send_command(u8 command, u8 data);
+    ErrorOr<u8> read_from_device();
+    ErrorOr<u8> send_command(u8 command);
+    ErrorOr<u8> send_command(u8 command, u8 data);
     MousePacket parse_data_packet(const RawPacket&);
-    void set_sample_rate(u8);
-    u8 get_device_id();
+    ErrorOr<void> set_sample_rate(u8);
+    ErrorOr<u8> get_device_id();
 
     u8 m_data_state { 0 };
     RawPacket m_data;

--- a/Kernel/Devices/HID/VMWareMouseDevice.h
+++ b/Kernel/Devices/HID/VMWareMouseDevice.h
@@ -18,7 +18,7 @@ namespace Kernel {
 class VMWareMouseDevice final : public PS2MouseDevice {
 public:
     friend class DeviceManagement;
-    static RefPtr<VMWareMouseDevice> try_to_initialize(const I8042Controller&);
+    static ErrorOr<NonnullRefPtr<VMWareMouseDevice>> try_to_initialize(const I8042Controller&);
     virtual ~VMWareMouseDevice() override;
 
     // ^I8042Device

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -311,7 +311,7 @@ void init_stage2(void*)
     (void)SerialDevice::must_create(3).leak_ref();
 
     VMWareBackdoor::the(); // don't wait until first mouse packet
-    HIDManagement::initialize();
+    MUST(HIDManagement::initialize());
 
     GraphicsManagement::the().initialize();
     ConsoleManagement::the().initialize();


### PR DESCRIPTION
This PR ads the plumbing to get the errors encountered in HIDDevices out to be handled.

The error handling itself was not changed.

If someone knows more appropriate error codes instead of `EIO` please tell me.