### PR TITLE
Shell: Use an opaque color for SyntaxError

### DIFF
--- a/Userland/Shell/SyntaxHighlighter.cpp
+++ b/Userland/Shell/SyntaxHighlighter.cpp
@@ -481,6 +481,7 @@ private:
         auto& span = span_for_node(node);
         span.attributes.underline = true;
         span.attributes.background_color = Color(Color::NamedColor::MidRed).lightened(1.3f).with_alpha(128);
+        span.attributes.color = m_palette.base_text();
     }
     virtual void visit(const AST::Tilde* node) override
     {


### PR DESCRIPTION
Use an opaque color for SyntaxError in Syntax Highlighter to avoid transparent errors.

**Before**:
![Syntax_error_transparent](https://user-images.githubusercontent.com/6242549/155414757-877b6980-5950-41f9-8209-b99590077413.png)

**After**:
![SyntaxError_Opaque](https://user-images.githubusercontent.com/6242549/155414736-06a4b48c-d8f9-4c62-8498-3ef7948ec5d5.png)