### PR TITLE
LibVT: Wrap dropped file in quotes if path includes spaces

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -1126,9 +1126,10 @@ void TerminalWidget::drop_event(GUI::DropEvent& event)
             if (!first)
                 send_non_user_input(" "sv.bytes());
 
-            if (url.protocol() == "file")
-                send_non_user_input(url.path().bytes());
-            else
+            if (url.protocol() == "file") {
+                auto text = String::formatted(url.path().contains(' ') ? "\"{}\"" : "{}", url.path());
+                send_non_user_input(text.bytes());
+            } else
                 send_non_user_input(url.to_string().bytes());
 
             first = false;


### PR DESCRIPTION
Small QoL improvement where drag and dropping a file in the Shell results in a quoted path if the path contained a space.