### PR TITLE
[WIP] LibWeb: Add ::before and ::after pseudo-elements

### DIFF
--- a/Base/res/html/misc/pseudo-elements.html
+++ b/Base/res/html/misc/pseudo-elements.html
@@ -1,0 +1,70 @@
+<!--
+  ~ Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+  ~
+  ~ SPDX-License-Identifier: BSD-2-Clause
+  -->
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Pseudo-elements</title>
+    <style>
+        p {
+            border: 1px solid black;
+            padding: 0.5em;
+        }
+
+        .quote::before {
+            content: open-quote;
+            font-size: 2em;
+        }
+        .quote::after {
+            content: close-quote;
+            font-size: 2em;
+        }
+
+        a.heart::before {
+            content: url("custom-list-item.png");
+        }
+        a.page::before {
+            content: url("custom-list-item-2.png");
+        }
+        a.face::before {
+            content: url("background-repeat.png") / ":^)";
+        }
+
+        .inline:hover::before {
+            background: yellow;
+        }
+        .inline::before {
+            content: "This sentence is first, and will turn yellow if you hover the paragraph.";
+            color: blue;
+        }
+        .inline::after {
+            content: "This sentence is last, still in the same paragraph.";
+            color: red;
+        }
+
+        .block::before {
+            display: block;
+            content: "This should appear as a block, first.";
+            color: blue;
+        }
+        .block::after {
+            display: block;
+            content: "This should appear as a block, last.";
+            color: red;
+        }
+    </style>
+</head>
+<body>
+    <h1>::before and ::after</h1>
+    <p class="quote">This should have chonky quotation marks.</p>
+    <p>
+        This is some text. Each <a href="#" class="heart">link</a> should have a little <a href="#" class="page">icon</a> before it, <a href="#" class="face">and this one has a tooltip too.</a>
+    </p>
+    <p class="inline">There should be a sentence before this, and one after, forming a single paragraph.</p>
+    <p class="block">There should be a sentence before this, and one after, each as its own block.</p>
+</body>
+</html>

--- a/Base/res/html/misc/pseudo-elements.html
+++ b/Base/res/html/misc/pseudo-elements.html
@@ -56,6 +56,10 @@
             content: "This should appear as a block, last.";
             color: red;
         }
+
+        .fancy-list li::marker {
+            color: green;
+        }
     </style>
 </head>
 <body>
@@ -66,5 +70,15 @@
     </p>
     <p class="inline">There should be a sentence before this, and one after, forming a single paragraph.</p>
     <p class="block">There should be a sentence before this, and one after, each as its own block.</p>
+
+    <ul class="fancy-list">
+        <li>This</li>
+        <li>Is</li>
+        <li>A</li>
+        <li>List</li>
+        <li>With</li>
+        <li>Green</li>
+        <li>Markers</li>
+    </ul>
 </body>
 </html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -133,6 +133,7 @@
             <li><a href="position-absolute-top-left.html">position: absolute; for top and left</a></li>
             <li><a href="cascade-keywords.html">Cascade keywords (initial, inherit, unset)</a></li>
             <li><a href="inline-node.html">Styling "inline" elements</a></li>
+            <li><a href="pseudo-elements.html">Pseudo-elements (::before, ::after, etc)</a></li>
         </ul>
 
         <h2>JavaScript/Wasm</h2>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -87,11 +87,24 @@ struct BoxShadowData {
     CSS::BoxShadowPlacement placement { CSS::BoxShadowPlacement::Outer };
 };
 
+struct ContentData {
+    enum class Type {
+        Normal,
+        None,
+        String,
+    } type { Type::Normal };
+
+    // FIXME: Data is a list of identifiers, strings and image values.
+    String data {};
+    String alt_text {};
+};
+
 class ComputedValues {
 public:
     CSS::Float float_() const { return m_noninherited.float_; }
     CSS::Clear clear() const { return m_noninherited.clear; }
     CSS::Cursor cursor() const { return m_inherited.cursor; }
+    CSS::ContentData content() const { return m_noninherited.content; }
     CSS::PointerEvents pointer_events() const { return m_inherited.pointer_events; }
     CSS::Display display() const { return m_noninherited.display; }
     Optional<int> const& z_index() const { return m_noninherited.z_index; }
@@ -216,6 +229,7 @@ protected:
         Vector<BoxShadowData> box_shadow {};
         Vector<CSS::Transformation> transformations {};
         CSS::BoxSizing box_sizing { InitialValues::box_sizing() };
+        CSS::ContentData content;
     } m_noninherited;
 };
 
@@ -227,6 +241,7 @@ public:
     void set_font_size(float font_size) { m_inherited.font_size = font_size; }
     void set_font_weight(int font_weight) { m_inherited.font_weight = font_weight; }
     void set_color(const Color& color) { m_inherited.color = color; }
+    void set_content(ContentData const& content) { m_noninherited.content = content; }
     void set_cursor(CSS::Cursor cursor) { m_inherited.cursor = cursor; }
     void set_image_rendering(CSS::ImageRendering value) { m_inherited.image_rendering = value; }
     void set_pointer_events(CSS::PointerEvents value) { m_inherited.pointer_events = value; }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -504,6 +504,8 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                 simple_selector.pseudo_element = Selector::PseudoElement::FirstLetter;
             } else if (pseudo_name.equals_ignoring_case("first-line")) {
                 simple_selector.pseudo_element = Selector::PseudoElement::FirstLine;
+            } else if (pseudo_name.equals_ignoring_case("marker")) {
+                simple_selector.pseudo_element = Selector::PseudoElement::Marker;
             } else {
                 dbgln_if(CSS_PARSER_DEBUG, "Unrecognized pseudo-element: '::{}'", pseudo_name);
                 return ParsingResult::SyntaxError;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -497,13 +497,13 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                 return ParsingResult::IncludesIgnoredVendorPrefix;
 
             if (pseudo_name.equals_ignoring_case("after")) {
-                simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::After;
+                simple_selector.pseudo_element = Selector::PseudoElement::After;
             } else if (pseudo_name.equals_ignoring_case("before")) {
-                simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::Before;
+                simple_selector.pseudo_element = Selector::PseudoElement::Before;
             } else if (pseudo_name.equals_ignoring_case("first-letter")) {
-                simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLetter;
+                simple_selector.pseudo_element = Selector::PseudoElement::FirstLetter;
             } else if (pseudo_name.equals_ignoring_case("first-line")) {
-                simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLine;
+                simple_selector.pseudo_element = Selector::PseudoElement::FirstLine;
             } else {
                 dbgln_if(CSS_PARSER_DEBUG, "Unrecognized pseudo-element: '::{}'", pseudo_name);
                 return ParsingResult::SyntaxError;
@@ -561,19 +561,19 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
             } else if (pseudo_name.equals_ignoring_case("after")) {
                 // Single-colon syntax allowed for compatibility. https://www.w3.org/TR/selectors/#pseudo-element-syntax
                 simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
-                simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::After;
+                simple_selector.pseudo_element = Selector::PseudoElement::After;
             } else if (pseudo_name.equals_ignoring_case("before")) {
                 // See :after
                 simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
-                simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::Before;
+                simple_selector.pseudo_element = Selector::PseudoElement::Before;
             } else if (pseudo_name.equals_ignoring_case("first-letter")) {
                 // See :after
                 simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
-                simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLetter;
+                simple_selector.pseudo_element = Selector::PseudoElement::FirstLetter;
             } else if (pseudo_name.equals_ignoring_case("first-line")) {
                 // See :after
                 simple_selector.type = Selector::SimpleSelector::Type::PseudoElement;
-                simple_selector.pseudo_element = Selector::SimpleSelector::PseudoElement::FirstLine;
+                simple_selector.pseudo_element = Selector::PseudoElement::FirstLine;
             } else {
                 dbgln_if(CSS_PARSER_DEBUG, "Unrecognized pseudo-class: ':{}'", pseudo_name);
                 return ParsingResult::SyntaxError;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3292,6 +3292,66 @@ RefPtr<StyleValue> Parser::parse_single_box_shadow_value(TokenStream<StyleCompon
     return BoxShadowStyleValue::create(color.release_value(), offset_x.release_value(), offset_y.release_value(), blur_radius.release_value(), spread_distance.release_value(), placement.release_value());
 }
 
+RefPtr<StyleValue> Parser::parse_content_value(Vector<StyleComponentValueRule> const& component_values)
+{
+    // FIXME: `content` accepts several kinds of function() type, which we don't handle in property_accepts_value() yet.
+
+    auto is_single_value_identifier = [](ValueID identifier) -> bool {
+        switch (identifier) {
+        case ValueID::None:
+        case ValueID::Normal:
+            return true;
+        default:
+            return false;
+        }
+    };
+
+    if (component_values.size() == 1) {
+        if (auto identifier = parse_identifier_value(component_values.first())) {
+            if (is_single_value_identifier(identifier->to_identifier()))
+                return identifier;
+        }
+    }
+
+    NonnullRefPtrVector<StyleValue> content_values;
+    NonnullRefPtrVector<StyleValue> alt_text_values;
+    bool in_alt_text = false;
+
+    for (auto const& value : component_values) {
+        if (value.is(Token::Type::Delim) && value.token().delim() == "/"sv) {
+            if (in_alt_text || content_values.is_empty())
+                return {};
+            in_alt_text = true;
+            continue;
+        }
+        auto style_value = parse_css_value(value);
+        if (style_value && property_accepts_value(PropertyID::Content, *style_value)) {
+            if (is_single_value_identifier(style_value->to_identifier()))
+                return {};
+
+            if (in_alt_text) {
+                alt_text_values.append(style_value.release_nonnull());
+            } else {
+                content_values.append(style_value.release_nonnull());
+            }
+            continue;
+        }
+
+        return {};
+    }
+
+    if (content_values.is_empty())
+        return {};
+    if (in_alt_text && alt_text_values.is_empty())
+        return {};
+
+    RefPtr<StyleValueList> alt_text;
+    if (!alt_text_values.is_empty())
+        alt_text = StyleValueList::create(move(alt_text_values), StyleValueList::Separator::Space);
+
+    return ContentStyleValue::create(StyleValueList::create(move(content_values), StyleValueList::Separator::Space), move(alt_text));
+}
+
 RefPtr<StyleValue> Parser::parse_flex_value(Vector<StyleComponentValueRule> const& component_values)
 {
     if (component_values.size() == 1) {
@@ -3874,6 +3934,10 @@ Result<NonnullRefPtr<StyleValue>, Parser::ParsingResult> Parser::parse_css_value
         return ParsingResult::SyntaxError;
     case PropertyID::BoxShadow:
         if (auto parsed_value = parse_box_shadow_value(component_values))
+            return parsed_value.release_nonnull();
+        return ParsingResult::SyntaxError;
+    case PropertyID::Content:
+        if (auto parsed_value = parse_content_value(component_values))
             return parsed_value.release_nonnull();
         return ParsingResult::SyntaxError;
     case PropertyID::Flex:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -233,6 +233,7 @@ private:
     RefPtr<StyleValue> parse_border_radius_shorthand_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_box_shadow_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_single_box_shadow_value(TokenStream<StyleComponentValueRule>&);
+    RefPtr<StyleValue> parse_content_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_flex_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_flex_flow_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_font_value(Vector<StyleComponentValueRule> const&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -510,6 +510,18 @@
       "hashless-hex-color"
     ]
   },
+  "content": {
+    "inherited": false,
+    "initial": "normal",
+    "__comment": "FIXME: This accepts a whole lot of other types and identifiers!",
+    "valid-types": [
+      "string"
+    ],
+    "valid-identifiers": [
+      "normal",
+      "none"
+    ]
+  },
   "cursor": {
     "inherited": true,
     "initial": "auto",

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,6 +17,19 @@ Selector::Selector(Vector<CompoundSelector>&& compound_selectors)
 
 Selector::~Selector()
 {
+}
+
+Optional<Selector::PseudoElement> Selector::pseudo_element() const
+{
+    // Note: This assumes that only one pseudo-element is allowed in a selector, and that it appears at the end.
+    //       This is true currently, and there are no current proposals to change this, but you never know!
+    if (compound_selectors().is_empty())
+        return {};
+    for (auto const& simple_selector : compound_selectors().last().simple_selectors) {
+        if (simple_selector.type == SimpleSelector::Type::PseudoElement)
+            return simple_selector.pseudo_element;
+    }
+    return {};
 }
 
 u32 Selector::specificity() const

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -32,6 +32,7 @@ Optional<Selector::PseudoElement> Selector::pseudo_element() const
     return {};
 }
 
+// https://www.w3.org/TR/selectors-4/#specificity-rules
 u32 Selector::specificity() const
 {
     if (m_specificity.has_value())
@@ -48,9 +49,12 @@ u32 Selector::specificity() const
                 ++ids;
                 break;
             case SimpleSelector::Type::Class:
+            case SimpleSelector::Type::Attribute:
+            case SimpleSelector::Type::PseudoClass:
                 ++classes;
                 break;
             case SimpleSelector::Type::TagName:
+            case SimpleSelector::Type::PseudoElement:
                 ++tag_names;
                 break;
             default:
@@ -179,6 +183,9 @@ String Selector::SimpleSelector::serialize() const
         default:
             VERIFY_NOT_REACHED();
         }
+        break;
+    case Selector::SimpleSelector::Type::PseudoElement:
+        // Note: Pseudo-elements are dealt with in Selector::serialize()
         break;
     default:
         dbgln("FIXME: Unsupported simple selector serialization for type {}", to_underlying(type));

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -240,18 +240,18 @@ String serialize_a_group_of_selectors(NonnullRefPtrVector<Selector> const& selec
     return builder.to_string();
 }
 
-constexpr StringView pseudo_element_name(Selector::SimpleSelector::PseudoElement pseudo_element)
+constexpr StringView pseudo_element_name(Selector::PseudoElement pseudo_element)
 {
     switch (pseudo_element) {
-    case Selector::SimpleSelector::PseudoElement::Before:
+    case Selector::PseudoElement::Before:
         return "before"sv;
-    case Selector::SimpleSelector::PseudoElement::After:
+    case Selector::PseudoElement::After:
         return "after"sv;
-    case Selector::SimpleSelector::PseudoElement::FirstLine:
+    case Selector::PseudoElement::FirstLine:
         return "first-line"sv;
-    case Selector::SimpleSelector::PseudoElement::FirstLetter:
+    case Selector::PseudoElement::FirstLetter:
         return "first-letter"sv;
-    case Selector::SimpleSelector::PseudoElement::None:
+    case Selector::PseudoElement::None:
         break;
     }
     VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -272,6 +272,8 @@ constexpr StringView pseudo_element_name(Selector::PseudoElement pseudo_element)
         return "first-line"sv;
     case Selector::PseudoElement::FirstLetter:
         return "first-letter"sv;
+    case Selector::PseudoElement::Marker:
+        return "marker"sv;
     case Selector::PseudoElement::None:
         break;
     }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -26,6 +26,7 @@ public:
         After,
         FirstLine,
         FirstLetter,
+        Marker,
     };
 
     struct SimpleSelector {

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -131,7 +131,7 @@ public:
     ~Selector();
 
     Vector<CompoundSelector> const& compound_selectors() const { return m_compound_selectors; }
-
+    Optional<PseudoElement> pseudo_element() const;
     u32 specificity() const;
     String serialize() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -20,6 +20,14 @@ using SelectorList = NonnullRefPtrVector<class Selector>;
 // This is a <complex-selector> in the spec. https://www.w3.org/TR/selectors-4/#complex
 class Selector : public RefCounted<Selector> {
 public:
+    enum class PseudoElement {
+        None,
+        Before,
+        After,
+        FirstLine,
+        FirstLetter,
+    };
+
     struct SimpleSelector {
         enum class Type {
             Invalid,
@@ -75,14 +83,6 @@ public:
             SelectorList not_selector {};
         };
         PseudoClass pseudo_class {};
-
-        enum class PseudoElement {
-            None,
-            Before,
-            After,
-            FirstLine,
-            FirstLetter,
-        };
         PseudoElement pseudo_element { PseudoElement::None };
 
         FlyString value {};
@@ -142,7 +142,7 @@ private:
     mutable Optional<u32> m_specificity;
 };
 
-constexpr StringView pseudo_element_name(Selector::SimpleSelector::PseudoElement);
+constexpr StringView pseudo_element_name(Selector::PseudoElement);
 constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Type);
 
 String serialize_a_group_of_selectors(NonnullRefPtrVector<Selector> const& selectors);

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -192,8 +192,8 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, DOM::
     case CSS::Selector::SimpleSelector::Type::PseudoClass:
         return matches_pseudo_class(component.pseudo_class, element);
     case CSS::Selector::SimpleSelector::Type::PseudoElement:
-        // FIXME: Implement pseudo-elements.
-        return false;
+        // Pseudo-element matching/not-matching is handled in the top level matches().
+        return true;
     default:
         VERIFY_NOT_REACHED();
     }
@@ -241,9 +241,13 @@ static inline bool matches(CSS::Selector const& selector, int component_list_ind
     VERIFY_NOT_REACHED();
 }
 
-bool matches(CSS::Selector const& selector, DOM::Element const& element)
+bool matches(CSS::Selector const& selector, DOM::Element const& element, Optional<CSS::Selector::PseudoElement> pseudo_element)
 {
     VERIFY(!selector.compound_selectors().is_empty());
+    if (pseudo_element.has_value() && selector.pseudo_element() != pseudo_element)
+        return false;
+    if (!pseudo_element.has_value() && selector.pseudo_element().has_value())
+        return false;
     return matches(selector, selector.compound_selectors().size() - 1, element);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.h
@@ -11,6 +11,6 @@
 
 namespace Web::SelectorEngine {
 
-bool matches(CSS::Selector const&, DOM::Element const&);
+bool matches(CSS::Selector const&, DOM::Element const&, Optional<CSS::Selector::PseudoElement> = {});
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, the SerenityOS developers.
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -70,9 +70,10 @@ void StyleComputer::for_each_stylesheet(CascadeOrigin cascade_origin, Callback c
     }
 }
 
-Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& element, CascadeOrigin cascade_origin) const
+Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& element, CascadeOrigin cascade_origin, Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     if (cascade_origin == CascadeOrigin::Author) {
+        // FIXME: Cache pseudo-element rules and look at only those if pseudo_element is set.
         Vector<MatchingRule> rules_to_run;
         for (auto const& class_name : element.class_names()) {
             if (auto it = m_rule_cache->rules_by_class.find(class_name); it != m_rule_cache->rules_by_class.end())
@@ -89,7 +90,7 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
         Vector<MatchingRule> matching_rules;
         for (auto const& rule_to_run : rules_to_run) {
             auto const& selector = rule_to_run.rule->selectors()[rule_to_run.selector_index];
-            if (SelectorEngine::matches(selector, element))
+            if (SelectorEngine::matches(selector, element, pseudo_element))
                 matching_rules.append(rule_to_run);
         }
         return matching_rules;
@@ -102,7 +103,7 @@ Vector<MatchingRule> StyleComputer::collect_matching_rules(DOM::Element const& e
         static_cast<CSSStyleSheet const&>(sheet).for_each_effective_style_rule([&](auto const& rule) {
             size_t selector_index = 0;
             for (auto& selector : rule.selectors()) {
-                if (SelectorEngine::matches(selector, element)) {
+                if (SelectorEngine::matches(selector, element, pseudo_element)) {
                     matching_rules.append({ rule, style_sheet_index, rule_index, selector_index, selector.specificity() });
                     break;
                 }
@@ -593,13 +594,13 @@ static HashMap<String, StyleProperty const*> cascade_custom_properties(DOM::Elem
 }
 
 // https://www.w3.org/TR/css-cascade/#cascading
-void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element& element) const
+void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element& element, Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     // First, we collect all the CSS rules whose selectors match `element`:
     MatchingRuleSet matching_rule_set;
-    matching_rule_set.user_agent_rules = collect_matching_rules(element, CascadeOrigin::UserAgent);
+    matching_rule_set.user_agent_rules = collect_matching_rules(element, CascadeOrigin::UserAgent, pseudo_element);
     sort_matching_rules(matching_rule_set.user_agent_rules);
-    matching_rule_set.author_rules = collect_matching_rules(element, CascadeOrigin::Author);
+    matching_rule_set.author_rules = collect_matching_rules(element, CascadeOrigin::Author, pseudo_element);
     sort_matching_rules(matching_rule_set.author_rules);
 
     // Then we resolve all the CSS custom properties ("variables") for this element:
@@ -631,21 +632,35 @@ void StyleComputer::compute_cascaded_values(StyleProperties& style, DOM::Element
     // FIXME: Transition declarations [css-transitions-1]
 }
 
-static NonnullRefPtr<StyleValue> get_inherit_value(CSS::PropertyID property_id, DOM::Element const* element)
+static DOM::Element const* get_parent_element(DOM::Element const* element, Optional<CSS::Selector::PseudoElement> pseudo_element)
 {
-    if (!element || !element->parent_element() || !element->parent_element()->specified_css_values())
+    // Pseudo-elements treat their originating element as their parent.
+    DOM::Element const* parent_element = nullptr;
+    if (pseudo_element.has_value()) {
+        parent_element = element;
+    } else if (element) {
+        parent_element = element->parent_element();
+    }
+    return parent_element;
+}
+
+static NonnullRefPtr<StyleValue> get_inherit_value(CSS::PropertyID property_id, DOM::Element const* element, Optional<CSS::Selector::PseudoElement> pseudo_element)
+{
+    auto* parent_element = get_parent_element(element, pseudo_element);
+
+    if (!parent_element || !parent_element->specified_css_values())
         return property_initial_value(property_id);
-    return element->parent_element()->specified_css_values()->property(property_id).release_value();
+    return parent_element->specified_css_values()->property(property_id).release_value();
 };
 
-void StyleComputer::compute_defaulted_property_value(StyleProperties& style, DOM::Element const* element, CSS::PropertyID property_id) const
+void StyleComputer::compute_defaulted_property_value(StyleProperties& style, DOM::Element const* element, CSS::PropertyID property_id, Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     // FIXME: If we don't know the correct initial value for a property, we fall back to InitialStyleValue.
 
     auto& value_slot = style.m_property_values[to_underlying(property_id)];
     if (!value_slot) {
         if (is_inherited_property(property_id))
-            style.m_property_values[to_underlying(property_id)] = get_inherit_value(property_id, element);
+            style.m_property_values[to_underlying(property_id)] = get_inherit_value(property_id, element, pseudo_element);
         else
             style.m_property_values[to_underlying(property_id)] = property_initial_value(property_id);
         return;
@@ -657,31 +672,33 @@ void StyleComputer::compute_defaulted_property_value(StyleProperties& style, DOM
     }
 
     if (value_slot->is_inherit()) {
-        value_slot = get_inherit_value(property_id, element);
+        value_slot = get_inherit_value(property_id, element, pseudo_element);
         return;
     }
 }
 
 // https://www.w3.org/TR/css-cascade/#defaulting
-void StyleComputer::compute_defaulted_values(StyleProperties& style, DOM::Element const* element) const
+void StyleComputer::compute_defaulted_values(StyleProperties& style, DOM::Element const* element, Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     // Walk the list of all known CSS properties and:
     // - Add them to `style` if they are missing.
     // - Resolve `inherit` and `initial` as needed.
     for (auto i = to_underlying(CSS::first_longhand_property_id); i <= to_underlying(CSS::last_longhand_property_id); ++i) {
         auto property_id = (CSS::PropertyID)i;
-        compute_defaulted_property_value(style, element, property_id);
+        compute_defaulted_property_value(style, element, property_id, pseudo_element);
     }
 }
 
-void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* element) const
+void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* element, Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     // To compute the font, first ensure that we've defaulted the relevant CSS font properties.
     // FIXME: This should be more sophisticated.
-    compute_defaulted_property_value(style, element, CSS::PropertyID::FontFamily);
-    compute_defaulted_property_value(style, element, CSS::PropertyID::FontSize);
-    compute_defaulted_property_value(style, element, CSS::PropertyID::FontStyle);
-    compute_defaulted_property_value(style, element, CSS::PropertyID::FontWeight);
+    compute_defaulted_property_value(style, element, CSS::PropertyID::FontFamily, pseudo_element);
+    compute_defaulted_property_value(style, element, CSS::PropertyID::FontSize, pseudo_element);
+    compute_defaulted_property_value(style, element, CSS::PropertyID::FontStyle, pseudo_element);
+    compute_defaulted_property_value(style, element, CSS::PropertyID::FontWeight, pseudo_element);
+
+    auto* parent_element = get_parent_element(element, pseudo_element);
 
     auto viewport_rect = document().browsing_context()->viewport_rect();
 
@@ -755,8 +772,8 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
         float root_font_size = 10;
 
         Gfx::FontMetrics font_metrics;
-        if (element && element->parent_element() && element->parent_element()->specified_css_values())
-            font_metrics = element->parent_element()->specified_css_values()->computed_font().metrics('M');
+        if (parent_element && parent_element->specified_css_values())
+            font_metrics = parent_element->specified_css_values()->computed_font().metrics('M');
         else
             font_metrics = Gfx::FontDatabase::default_font().metrics('M');
 
@@ -765,8 +782,8 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
             // Percentages refer to parent element's font size
             auto percentage = font_size->as_percentage().percentage();
             auto parent_font_size = size;
-            if (element && element->parent_element() && element->parent_element()->layout_node() && element->parent_element()->specified_css_values()) {
-                auto value = element->parent_element()->specified_css_values()->property(CSS::PropertyID::FontSize).value();
+            if (parent_element && parent_element->layout_node() && parent_element->specified_css_values()) {
+                auto value = parent_element->specified_css_values()->property(CSS::PropertyID::FontSize).value();
                 if (value->is_length()) {
                     auto length = static_cast<LengthStyleValue const&>(*value).to_length();
                     if (length.is_absolute() || length.is_relative())
@@ -880,7 +897,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
     style.set_computed_font(found_font.release_nonnull());
 }
 
-void StyleComputer::absolutize_values(StyleProperties& style, DOM::Element const*) const
+void StyleComputer::absolutize_values(StyleProperties& style, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const
 {
     auto viewport_rect = document().browsing_context()->viewport_rect();
     auto font_metrics = style.computed_font().metrics('M');
@@ -903,7 +920,7 @@ void StyleComputer::absolutize_values(StyleProperties& style, DOM::Element const
 }
 
 // https://drafts.csswg.org/css-display/#transformations
-void StyleComputer::transform_box_type_if_needed(StyleProperties& style, DOM::Element const&) const
+void StyleComputer::transform_box_type_if_needed(StyleProperties& style, DOM::Element const&, Optional<CSS::Selector::PseudoElement>) const
 {
     // 2.7. Automatic Box Type Transformations
 
@@ -940,9 +957,9 @@ void StyleComputer::transform_box_type_if_needed(StyleProperties& style, DOM::El
 NonnullRefPtr<StyleProperties> StyleComputer::create_document_style() const
 {
     auto style = StyleProperties::create();
-    compute_font(style, nullptr);
-    compute_defaulted_values(style, nullptr);
-    absolutize_values(style, nullptr);
+    compute_font(style, nullptr, {});
+    compute_defaulted_values(style, nullptr, {});
+    absolutize_values(style, nullptr, {});
     if (auto* browsing_context = m_document.browsing_context()) {
         auto viewport_rect = browsing_context->viewport_rect();
         style->set_property(CSS::PropertyID::Width, CSS::LengthStyleValue::create(CSS::Length::make_px(viewport_rect.width())));
@@ -951,25 +968,25 @@ NonnullRefPtr<StyleProperties> StyleComputer::create_document_style() const
     return style;
 }
 
-NonnullRefPtr<StyleProperties> StyleComputer::compute_style(DOM::Element& element) const
+NonnullRefPtr<StyleProperties> StyleComputer::compute_style(DOM::Element& element, Optional<CSS::Selector::PseudoElement> pseudo_element) const
 {
     build_rule_cache_if_needed();
 
     auto style = StyleProperties::create();
     // 1. Perform the cascade. This produces the "specified style"
-    compute_cascaded_values(style, element);
+    compute_cascaded_values(style, element, pseudo_element);
 
     // 2. Compute the font, since that may be needed for font-relative CSS units
-    compute_font(style, &element);
+    compute_font(style, &element, pseudo_element);
 
     // 3. Absolutize values, turning font/viewport relative lengths into absolute lengths
-    absolutize_values(style, &element);
+    absolutize_values(style, &element, pseudo_element);
 
     // 4. Default the values, applying inheritance and 'initial' as needed
-    compute_defaulted_values(style, &element);
+    compute_defaulted_values(style, &element, pseudo_element);
 
     // 5. Run automatic box type transformations
-    transform_box_type_if_needed(style, element);
+    transform_box_type_if_needed(style, element, pseudo_element);
 
     return style;
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -9,9 +9,11 @@
 
 #include <AK/HashMap.h>
 #include <AK/NonnullRefPtrVector.h>
+#include <AK/Optional.h>
 #include <AK/OwnPtr.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
+#include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/Forward.h>
 
@@ -52,7 +54,7 @@ public:
     DOM::Document const& document() const { return m_document; }
 
     NonnullRefPtr<StyleProperties> create_document_style() const;
-    NonnullRefPtr<StyleProperties> compute_style(DOM::Element&) const;
+    NonnullRefPtr<StyleProperties> compute_style(DOM::Element&, Optional<CSS::Selector::PseudoElement> = {}) const;
 
     // https://www.w3.org/TR/css-cascade/#origin
     enum class CascadeOrigin {
@@ -63,18 +65,18 @@ public:
         Transition,
     };
 
-    Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin) const;
+    Vector<MatchingRule> collect_matching_rules(DOM::Element const&, CascadeOrigin, Optional<CSS::Selector::PseudoElement>) const;
 
     void invalidate_rule_cache();
 
 private:
-    void compute_cascaded_values(StyleProperties&, DOM::Element&) const;
-    void compute_font(StyleProperties&, DOM::Element const*) const;
-    void compute_defaulted_values(StyleProperties&, DOM::Element const*) const;
-    void absolutize_values(StyleProperties&, DOM::Element const*) const;
-    void transform_box_type_if_needed(StyleProperties&, DOM::Element const&) const;
+    void compute_cascaded_values(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement>) const;
+    void compute_font(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
+    void compute_defaulted_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
+    void absolutize_values(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;
+    void transform_box_type_if_needed(StyleProperties&, DOM::Element const&, Optional<CSS::Selector::PseudoElement>) const;
 
-    void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID) const;
+    void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID, Optional<CSS::Selector::PseudoElement>) const;
 
     RefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, PropertyID, UnresolvedStyleValue const&, HashMap<String, StyleProperty const*> const&) const;
     bool expand_unresolved_values(DOM::Element&, StringView property_name, HashMap<String, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Vector<StyleComponentValueRule> const& source, Vector<StyleComponentValueRule>& dest, size_t source_start_index, HashMap<String, StyleProperty const*> const& custom_properties) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -100,6 +100,7 @@ private:
         HashMap<FlyString, Vector<MatchingRule>> rules_by_id;
         HashMap<FlyString, Vector<MatchingRule>> rules_by_class;
         HashMap<FlyString, Vector<MatchingRule>> rules_by_tag_name;
+        HashMap<Selector::PseudoElement, Vector<MatchingRule>> rules_by_pseudo_element;
         Vector<MatchingRule> other_rules;
         int generation { 0 };
     };

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -538,6 +538,59 @@ Optional<CSS::Clear> StyleProperties::clear() const
     }
 }
 
+CSS::ContentData StyleProperties::content() const
+{
+    auto maybe_value = property(CSS::PropertyID::Content);
+    if (!maybe_value.has_value())
+        return CSS::ContentData {};
+
+    auto& value = maybe_value.value();
+    if (value->is_content()) {
+        auto& content_style_value = value->as_content();
+
+        CSS::ContentData content_data;
+
+        // FIXME: The content is a list of things: strings, identifiers or functions that return strings, and images.
+        //        So it can't always be represented as a single String, but may have to be multiple boxes.
+        //        For now, we'll just assume strings since that is easiest.
+        StringBuilder builder;
+        for (auto const& item : content_style_value.content().values()) {
+            if (item.is_string()) {
+                builder.append(item.to_string());
+            } else {
+                // TODO: Implement quotes, counters, images, and other things.
+            }
+        }
+        content_data.type = ContentData::Type::String;
+        content_data.data = builder.to_string();
+
+        if (content_style_value.has_alt_text()) {
+            StringBuilder alt_text_builder;
+            for (auto const& item : content_style_value.alt_text()->values()) {
+                if (item.is_string()) {
+                    alt_text_builder.append(item.to_string());
+                } else {
+                    // TODO: Implement counters
+                }
+            }
+            content_data.alt_text = alt_text_builder.to_string();
+        }
+
+        return content_data;
+    }
+
+    switch (value->to_identifier()) {
+    case ValueID::None:
+        return { ContentData::Type::None };
+    case ValueID::Normal:
+        return { ContentData::Type::Normal };
+    default:
+        break;
+    }
+
+    return CSS::ContentData {};
+}
+
 Optional<CSS::Cursor> StyleProperties::cursor() const
 {
     auto value = property(CSS::PropertyID::Cursor);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -50,6 +50,7 @@ public:
     CSS::Display display() const;
     Optional<CSS::Float> float_() const;
     Optional<CSS::Clear> clear() const;
+    CSS::ContentData content() const;
     Optional<CSS::Cursor> cursor() const;
     Optional<CSS::WhiteSpace> white_space() const;
     Optional<CSS::LineStyle> line_style(CSS::PropertyID) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -75,6 +75,12 @@ ColorStyleValue const& StyleValue::as_color() const
     return static_cast<ColorStyleValue const&>(*this);
 }
 
+ContentStyleValue const& StyleValue::as_content() const
+{
+    VERIFY(is_content());
+    return static_cast<ContentStyleValue const&>(*this);
+}
+
 FlexStyleValue const& StyleValue::as_flex() const
 {
     VERIFY(is_flex());
@@ -853,6 +859,13 @@ String ColorStyleValue::to_string() const
 String CombinedBorderRadiusStyleValue::to_string() const
 {
     return String::formatted("{} {} {} {} / {} {} {} {}", m_top_left->horizontal_radius().to_string(), m_top_right->horizontal_radius().to_string(), m_bottom_right->horizontal_radius().to_string(), m_bottom_left->horizontal_radius().to_string(), m_top_left->vertical_radius().to_string(), m_top_right->vertical_radius().to_string(), m_bottom_right->vertical_radius().to_string(), m_bottom_left->vertical_radius().to_string());
+}
+
+String ContentStyleValue::to_string() const
+{
+    if (has_alt_text())
+        return String::formatted("{} / {}", m_content->to_string(), m_alt_text->to_string());
+    return m_content->to_string();
 }
 
 String FlexStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -292,6 +292,7 @@ public:
         Calculated,
         Color,
         CombinedBorderRadius,
+        Content,
         Flex,
         FlexFlow,
         Font,
@@ -324,6 +325,7 @@ public:
     bool is_box_shadow() const { return type() == Type::BoxShadow; }
     bool is_calculated() const { return type() == Type::Calculated; }
     bool is_color() const { return type() == Type::Color; }
+    bool is_content() const { return type() == Type::Content; }
     bool is_flex() const { return type() == Type::Flex; }
     bool is_flex_flow() const { return type() == Type::FlexFlow; }
     bool is_font() const { return type() == Type::Font; }
@@ -354,6 +356,7 @@ public:
     BoxShadowStyleValue const& as_box_shadow() const;
     CalculatedStyleValue const& as_calculated() const;
     ColorStyleValue const& as_color() const;
+    ContentStyleValue const& as_content() const;
     FlexFlowStyleValue const& as_flex_flow() const;
     FlexStyleValue const& as_flex() const;
     FontStyleValue const& as_font() const;
@@ -382,6 +385,7 @@ public:
     BoxShadowStyleValue& as_box_shadow() { return const_cast<BoxShadowStyleValue&>(const_cast<StyleValue const&>(*this).as_box_shadow()); }
     CalculatedStyleValue& as_calculated() { return const_cast<CalculatedStyleValue&>(const_cast<StyleValue const&>(*this).as_calculated()); }
     ColorStyleValue& as_color() { return const_cast<ColorStyleValue&>(const_cast<StyleValue const&>(*this).as_color()); }
+    ContentStyleValue& as_content() { return const_cast<ContentStyleValue&>(const_cast<StyleValue const&>(*this).as_content()); }
     FlexFlowStyleValue& as_flex_flow() { return const_cast<FlexFlowStyleValue&>(const_cast<StyleValue const&>(*this).as_flex_flow()); }
     FlexStyleValue& as_flex() { return const_cast<FlexStyleValue&>(const_cast<StyleValue const&>(*this).as_flex()); }
     FontStyleValue& as_font() { return const_cast<FontStyleValue&>(const_cast<StyleValue const&>(*this).as_font()); }
@@ -910,6 +914,31 @@ private:
     NonnullRefPtr<BorderRadiusStyleValue> m_top_right;
     NonnullRefPtr<BorderRadiusStyleValue> m_bottom_right;
     NonnullRefPtr<BorderRadiusStyleValue> m_bottom_left;
+};
+
+class ContentStyleValue final : public StyleValue {
+public:
+    static NonnullRefPtr<ContentStyleValue> create(NonnullRefPtr<StyleValueList> content, RefPtr<StyleValueList> alt_text)
+    {
+        return adopt_ref(*new ContentStyleValue(move(content), move(alt_text)));
+    }
+
+    StyleValueList const& content() const { return *m_content; }
+    bool has_alt_text() const { return !m_alt_text.is_null(); }
+    StyleValueList const* alt_text() const { return m_alt_text; }
+
+    virtual String to_string() const override;
+
+private:
+    ContentStyleValue(NonnullRefPtr<StyleValueList> content, RefPtr<StyleValueList> alt_text)
+        : StyleValue(Type::Content)
+        , m_content(move(content))
+        , m_alt_text(move(alt_text))
+    {
+    }
+
+    NonnullRefPtr<StyleValueList> m_content;
+    RefPtr<StyleValueList> m_alt_text;
 };
 
 class FlexStyleValue final : public StyleValue {

--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -205,7 +205,7 @@ RefPtr<Layout::Node> Element::create_layout_node(NonnullRefPtr<CSS::StylePropert
         return adopt_ref(*new Layout::TableBox(document(), this, move(style)));
 
     if (display.is_list_item())
-        return adopt_ref(*new Layout::ListItemBox(document(), *this, move(style)));
+        return adopt_ref(*new Layout::ListItemBox(document(), this, move(style)));
 
     if (display.is_table_row())
         return adopt_ref(*new Layout::TableRowBox(document(), this, move(style)));
@@ -214,7 +214,7 @@ RefPtr<Layout::Node> Element::create_layout_node(NonnullRefPtr<CSS::StylePropert
         return adopt_ref(*new Layout::TableCellBox(document(), this, move(style)));
 
     if (display.is_table_row_group() || display.is_table_header_group() || display.is_table_footer_group())
-        return adopt_ref(*new Layout::TableRowGroupBox(document(), *this, move(style)));
+        return adopt_ref(*new Layout::TableRowGroupBox(document(), this, move(style)));
 
     if (display.is_table_column() || display.is_table_column_group() || display.is_table_caption()) {
         // FIXME: This is just an incorrect placeholder until we improve table layout support.
@@ -228,10 +228,10 @@ RefPtr<Layout::Node> Element::create_layout_node(NonnullRefPtr<CSS::StylePropert
             return block;
         }
         if (display.is_flow_inside())
-            return adopt_ref(*new Layout::InlineNode(document(), *this, move(style)));
+            return adopt_ref(*new Layout::InlineNode(document(), this, move(style)));
 
         dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Support display: {}", display.to_string());
-        return adopt_ref(*new Layout::InlineNode(document(), *this, move(style)));
+        return adopt_ref(*new Layout::InlineNode(document(), this, move(style)));
     }
 
     if (display.is_flow_inside() || display.is_flow_root_inside() || display.is_flex_inside())

--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -134,6 +134,8 @@ public:
     virtual void did_receive_focus() { }
     virtual void did_lose_focus() { }
 
+    static RefPtr<Layout::Node> create_layout_node_for_display_type(DOM::Document&, CSS::Display const&, NonnullRefPtr<CSS::StyleProperties>, Element*);
+
 protected:
     virtual void children_changed() override;
 

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -438,19 +438,19 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoElement) {
                 char const* pseudo_element_description = "";
                 switch (simple_selector.pseudo_element) {
-                case CSS::Selector::SimpleSelector::PseudoElement::None:
+                case CSS::Selector::PseudoElement::None:
                     pseudo_element_description = "NONE";
                     break;
-                case CSS::Selector::SimpleSelector::PseudoElement::Before:
+                case CSS::Selector::PseudoElement::Before:
                     pseudo_element_description = "before";
                     break;
-                case CSS::Selector::SimpleSelector::PseudoElement::After:
+                case CSS::Selector::PseudoElement::After:
                     pseudo_element_description = "after";
                     break;
-                case CSS::Selector::SimpleSelector::PseudoElement::FirstLine:
+                case CSS::Selector::PseudoElement::FirstLine:
                     pseudo_element_description = "first-line";
                     break;
-                case CSS::Selector::SimpleSelector::PseudoElement::FirstLetter:
+                case CSS::Selector::PseudoElement::FirstLetter:
                     pseudo_element_description = "first-letter";
                     break;
                 }

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -453,6 +453,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::PseudoElement::FirstLetter:
                     pseudo_element_description = "first-letter";
                     break;
+                case CSS::Selector::PseudoElement::Marker:
+                    pseudo_element_description = "marker";
+                    break;
                 }
 
                 builder.appendff(" pseudo_element={}", pseudo_element_description);

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -27,6 +27,7 @@ class BorderStyleValue;
 class BoxShadowStyleValue;
 class CalculatedStyleValue;
 class ColorStyleValue;
+class ContentStyleValue;
 class CSSImportRule;
 class CSSMediaRule;
 class CSSRule;

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -112,7 +112,9 @@ void InlineNode::paint(PaintContext& context, PaintPhase phase)
         });
     }
 
-    if (phase == PaintPhase::Foreground && document().inspected_node() == dom_node()) {
+    // FIXME: We check for a non-null dom_node(), since pseudo-elements have a null one and were getting
+    //        highlighted incorrectly. A better solution will be needed if we want to inspect them too.
+    if (phase == PaintPhase::Overlay && dom_node() && document().inspected_node() == dom_node()) {
         // FIXME: This paints a double-thick border between adjacent fragments, where ideally there
         //        would be none. Once we implement non-rectangular outlines for the `outline` CSS
         //        property, we can use that here instead.

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.cpp
@@ -17,8 +17,8 @@
 
 namespace Web::Layout {
 
-InlineNode::InlineNode(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
-    : Layout::NodeWithStyleAndBoxModelMetrics(document, &element, move(style))
+InlineNode::InlineNode(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
+    : Layout::NodeWithStyleAndBoxModelMetrics(document, element, move(style))
 {
     set_inline(true);
 }

--- a/Userland/Libraries/LibWeb/Layout/InlineNode.h
+++ b/Userland/Libraries/LibWeb/Layout/InlineNode.h
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 class InlineNode : public NodeWithStyleAndBoxModelMetrics {
 public:
-    InlineNode(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
+    InlineNode(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~InlineNode() override;
 
     virtual void paint(PaintContext&, PaintPhase) override;

--- a/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemBox.cpp
@@ -10,8 +10,8 @@
 
 namespace Web::Layout {
 
-ListItemBox::ListItemBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
-    : Layout::BlockContainer(document, &element, move(style))
+ListItemBox::ListItemBox(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
+    : Layout::BlockContainer(document, element, move(style))
 {
 }
 

--- a/Userland/Libraries/LibWeb/Layout/ListItemBox.h
+++ b/Userland/Libraries/LibWeb/Layout/ListItemBox.h
@@ -13,7 +13,7 @@ namespace Web::Layout {
 
 class ListItemBox final : public BlockContainer {
 public:
-    ListItemBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
+    ListItemBox(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~ListItemBox() override;
 
     DOM::Element& dom_node() { return static_cast<DOM::Element&>(*BlockContainer::dom_node()); }

--- a/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ListItemMarkerBox.cpp
@@ -66,8 +66,7 @@ void ListItemMarkerBox::paint(PaintContext& context, PaintPhase phase)
         return;
     }
 
-    // FIXME: It would be nicer to not have to go via the parent here to get our inherited style.
-    auto color = parent()->computed_values().color();
+    auto color = computed_values().color();
 
     int marker_width = (int)enclosing.height() / 2;
     Gfx::IntRect marker_rect { 0, 0, marker_width, marker_width };

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -478,6 +478,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     do_border_style(computed_values.border_right(), CSS::PropertyID::BorderRightWidth, CSS::PropertyID::BorderRightColor, CSS::PropertyID::BorderRightStyle);
     do_border_style(computed_values.border_bottom(), CSS::PropertyID::BorderBottomWidth, CSS::PropertyID::BorderBottomColor, CSS::PropertyID::BorderBottomStyle);
 
+    computed_values.set_content(specified_style.content());
+
     if (auto fill = specified_style.property(CSS::PropertyID::Fill); fill.has_value())
         computed_values.set_fill(fill.value()->to_color(*this));
     if (auto stroke = specified_style.property(CSS::PropertyID::Stroke); stroke.has_value())

--- a/Userland/Libraries/LibWeb/Layout/TableRowGroupBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableRowGroupBox.cpp
@@ -11,8 +11,8 @@
 
 namespace Web::Layout {
 
-TableRowGroupBox::TableRowGroupBox(DOM::Document& document, DOM::Element& element, NonnullRefPtr<CSS::StyleProperties> style)
-    : Layout::BlockContainer(document, &element, move(style))
+TableRowGroupBox::TableRowGroupBox(DOM::Document& document, DOM::Element* element, NonnullRefPtr<CSS::StyleProperties> style)
+    : Layout::BlockContainer(document, element, move(style))
 {
 }
 

--- a/Userland/Libraries/LibWeb/Layout/TableRowGroupBox.h
+++ b/Userland/Libraries/LibWeb/Layout/TableRowGroupBox.h
@@ -12,7 +12,7 @@ namespace Web::Layout {
 
 class TableRowGroupBox final : public BlockContainer {
 public:
-    TableRowGroupBox(DOM::Document&, DOM::Element&, NonnullRefPtr<CSS::StyleProperties>);
+    TableRowGroupBox(DOM::Document&, DOM::Element*, NonnullRefPtr<CSS::StyleProperties>);
     virtual ~TableRowGroupBox() override;
 
     size_t column_count() const;

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2022, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -115,13 +116,14 @@ void TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
     if (!layout_node)
         return;
 
-    if (!dom_node.parent_or_shadow_host()) {
-        m_layout_root = layout_node;
-    } else {
-        if (layout_node->is_inline() && !(layout_node->is_inline_block() && m_parent_stack.last()->computed_values().display().is_flex_inside())) {
+    auto insert_node_into_inline_or_block_ancestor = [this](auto& node, bool prepend = false) {
+        if (node->is_inline() && !(node->is_inline_block() && m_parent_stack.last()->computed_values().display().is_flex_inside())) {
             // Inlines can be inserted into the nearest ancestor.
             auto& insertion_point = insertion_parent_for_inline_node(*m_parent_stack.last());
-            insertion_point.append_child(*layout_node);
+            if (prepend)
+                insertion_point.prepend_child(*node);
+            else
+                insertion_point.append_child(*node);
             insertion_point.set_children_are_inline(true);
         } else {
             // Non-inlines can't be inserted into an inline parent, so find the nearest non-inline ancestor.
@@ -132,10 +134,19 @@ void TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
                 }
                 VERIFY_NOT_REACHED();
             }();
-            auto& insertion_point = insertion_parent_for_block_node(nearest_non_inline_ancestor, *layout_node);
-            insertion_point.append_child(*layout_node);
+            auto& insertion_point = insertion_parent_for_block_node(nearest_non_inline_ancestor, *node);
+            if (prepend)
+                insertion_point.prepend_child(*node);
+            else
+                insertion_point.append_child(*node);
             insertion_point.set_children_are_inline(false);
         }
+    };
+
+    if (!dom_node.parent_or_shadow_host()) {
+        m_layout_root = layout_node;
+    } else {
+        insert_node_into_inline_or_block_ancestor(layout_node);
     }
 
     auto* shadow_root = is<DOM::Element>(dom_node) ? verify_cast<DOM::Element>(dom_node).shadow_root() : nullptr;
@@ -147,6 +158,45 @@ void TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
         verify_cast<DOM::ParentNode>(dom_node).for_each_child([&](auto& dom_child) {
             create_layout_tree(dom_child, context);
         });
+        pop_parent();
+    }
+
+    // Add nodes for the ::before and ::after pseudo-elements.
+    if (is<DOM::Element>(dom_node)) {
+        auto& element = static_cast<DOM::Element&>(dom_node);
+        auto create_pseudo_element_if_needed = [&](CSS::Selector::PseudoElement pseudo_element) -> RefPtr<Node> {
+            auto pseudo_element_style = style_computer.compute_style(element, pseudo_element);
+            auto pseudo_element_content = pseudo_element_style->content();
+            auto pseudo_element_display = pseudo_element_style->display();
+            // ::before and ::after only exist if they have content. `content: normal` computes to `none` for them.
+            // We also don't create them if they are `display: none`.
+            if (pseudo_element_display.is_none()
+                || pseudo_element_content.type == CSS::ContentData::Type::Normal
+                || pseudo_element_content.type == CSS::ContentData::Type::None)
+                return nullptr;
+
+            if (auto pseudo_element_node = DOM::Element::create_layout_node_for_display_type(document, pseudo_element_display, move(pseudo_element_style), nullptr)) {
+                // FIXME: Handle images, and multiple values
+                if (pseudo_element_content.type == CSS::ContentData::Type::String) {
+                    auto text = adopt_ref(*new DOM::Text(document, pseudo_element_content.data));
+                    auto text_node = adopt_ref(*new TextNode(document, text));
+                    push_parent(verify_cast<NodeWithStyle>(*pseudo_element_node));
+                    insert_node_into_inline_or_block_ancestor(text_node);
+                    pop_parent();
+                } else {
+                    TODO();
+                }
+                return pseudo_element_node;
+            }
+
+            return nullptr;
+        };
+
+        push_parent(verify_cast<NodeWithStyle>(*layout_node));
+        if (auto before_node = create_pseudo_element_if_needed(CSS::Selector::PseudoElement::Before))
+            insert_node_into_inline_or_block_ancestor(before_node, true);
+        if (auto after_node = create_pseudo_element_if_needed(CSS::Selector::PseudoElement::After))
+            insert_node_into_inline_or_block_ancestor(after_node);
         pop_parent();
     }
 

--- a/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TreeBuilder.cpp
@@ -202,7 +202,7 @@ void TreeBuilder::create_layout_tree(DOM::Node& dom_node, TreeBuilder::Context& 
 
     if (is<ListItemBox>(*layout_node)) {
         int child_index = layout_node->parent()->index_of_child<ListItemBox>(*layout_node).value();
-        auto marker_style = static_cast<DOM::Element const&>(dom_node).specified_css_values();
+        auto marker_style = style_computer.compute_style(static_cast<DOM::Element&>(dom_node), CSS::Selector::PseudoElement::Marker);
         auto list_item_marker = adopt_ref(*new ListItemMarkerBox(document, layout_node->computed_values().list_style_type(), child_index + 1, *marker_style));
         if (layout_node->first_child())
             list_item_marker->set_inline(layout_node->first_child()->is_inline());


### PR DESCRIPTION
Acid2 man has his proper nose.
![image](https://user-images.githubusercontent.com/222642/155763193-31132ccb-04f0-4a0d-a11a-f768b51d5f36.png)

And here are some other examples. (Some of these are aspirational still, as you can see. But several new shiny things work now! :^)
![image](https://user-images.githubusercontent.com/222642/155763316-991acc3d-9498-4c0e-b117-2b23ae0abc86.png)