### PR TITLE
Everywhere: Make JSON serialization fallible

### DIFF
--- a/AK/JsonArray.h
+++ b/AK/JsonArray.h
@@ -85,8 +85,9 @@ private:
 template<typename Builder>
 inline void JsonArray::serialize(Builder& builder) const
 {
-    JsonArraySerializer serializer { builder };
-    for_each([&](auto& value) { serializer.add(value); });
+    auto serializer = MUST(JsonArraySerializer<>::try_create(builder));
+    for_each([&](auto& value) { MUST(serializer.add(value)); });
+    MUST(serializer.finish());
 }
 
 template<typename Builder>

--- a/AK/JsonArraySerializer.h
+++ b/AK/JsonArraySerializer.h
@@ -1,137 +1,231 @@
 /*
  * Copyright (c) 2019-2020, Sergey Bugaev <bugaevc@serenityos.org>
+ * Copyright (c) 2022, Idan Horowitz <idan.horowitz@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/JsonValue.h>
+#include <AK/Error.h>
+#include <AK/Try.h>
+
+#ifndef KERNEL
+#    include <AK/JsonValue.h>
+#endif
 
 namespace AK {
 
 template<typename Builder>
+inline constexpr bool IsLegacyBuilder = requires(Builder builder) { builder.try_append('\0'); };
+
+template<typename Builder = void>
 class JsonObjectSerializer;
 
-template<typename Builder>
+template<typename Builder = void>
 class JsonArraySerializer {
 public:
-    explicit JsonArraySerializer(Builder& builder)
-        : m_builder(builder)
+    static ErrorOr<JsonArraySerializer> try_create(Builder& builder)
     {
-        (void)m_builder.append('[');
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(builder.try_append('['));
+        else
+            TRY(builder.append('['));
+        return JsonArraySerializer { builder };
+    }
+
+    JsonArraySerializer(JsonArraySerializer&& other)
+        : m_builder(other.m_builder)
+        , m_empty(other.m_empty)
+        , m_finished(exchange(other.m_finished, true))
+    {
     }
 
     JsonArraySerializer(const JsonArraySerializer&) = delete;
-    JsonArraySerializer(JsonArraySerializer&&) = delete;
 
     ~JsonArraySerializer()
     {
-        if (!m_finished)
-            finish();
+        VERIFY(m_finished);
     }
 
 #ifndef KERNEL
-    void add(const JsonValue& value)
+    ErrorOr<void> add(const JsonValue& value)
     {
-        begin_item();
+        TRY(begin_item());
         value.serialize(m_builder);
+        return {};
     }
 #endif
 
-    void add(StringView value)
+    ErrorOr<void> add(StringView value)
     {
-        begin_item();
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>) {
+            TRY(m_builder.try_append('"'));
+            TRY(m_builder.try_append_escaped_for_json(value));
+            TRY(m_builder.try_append('"'));
+        } else {
+            TRY(m_builder.append('"'));
+            TRY(m_builder.append_escaped_for_json(value));
+            TRY(m_builder.append('"'));
+        }
+        return {};
     }
 
-    void add(const String& value)
+#ifndef KERNEL
+    ErrorOr<void> add(const String& value)
     {
-        begin_item();
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>) {
+            TRY(m_builder.try_append('"'));
+            TRY(m_builder.try_append_escaped_for_json(value));
+            TRY(m_builder.try_append('"'));
+        } else {
+            TRY(m_builder.append('"'));
+            TRY(m_builder.append_escaped_for_json(value));
+            TRY(m_builder.append('"'));
+        }
+        return {};
+    }
+#endif
+
+    ErrorOr<void> add(const char* value)
+    {
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>) {
+            TRY(m_builder.try_append('"'));
+            TRY(m_builder.try_append_escaped_for_json(value));
+            TRY(m_builder.try_append('"'));
+        } else {
+            TRY(m_builder.append('"'));
+            TRY(m_builder.append_escaped_for_json(value));
+            TRY(m_builder.append('"'));
+        }
+        return {};
     }
 
-    void add(const char* value)
+    ErrorOr<void> add(bool value)
     {
-        begin_item();
-        (void)m_builder.append('"');
-        (void)m_builder.append_escaped_for_json(value);
-        (void)m_builder.append('"');
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(m_builder.try_append(value ? "true"sv : "false"sv));
+        else
+            TRY(m_builder.append(value ? "true"sv : "false"sv));
+        return {};
     }
 
-    void add(bool value)
+    ErrorOr<void> add(int value)
     {
-        begin_item();
-        (void)m_builder.append(value ? "true"sv : "false"sv);
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(m_builder.try_appendff("{}", value));
+        else
+            TRY(m_builder.appendff("{}", value));
+        return {};
     }
 
-    void add(int value)
+    ErrorOr<void> add(unsigned value)
     {
-        begin_item();
-        (void)m_builder.appendff("{}", value);
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(m_builder.try_appendff("{}", value));
+        else
+            TRY(m_builder.appendff("{}", value));
+        return {};
     }
 
-    void add(unsigned value)
+    ErrorOr<void> add(long value)
     {
-        begin_item();
-        (void)m_builder.appendff("{}", value);
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(m_builder.try_appendff("{}", value));
+        else
+            TRY(m_builder.appendff("{}", value));
+        return {};
     }
 
-    void add(long value)
+    ErrorOr<void> add(long unsigned value)
     {
-        begin_item();
-        (void)m_builder.appendff("{}", value);
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(m_builder.try_appendff("{}", value));
+        else
+            TRY(m_builder.appendff("{}", value));
+        return {};
     }
 
-    void add(long unsigned value)
+    ErrorOr<void> add(long long value)
     {
-        begin_item();
-        (void)m_builder.appendff("{}", value);
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(m_builder.try_appendff("{}", value));
+        else
+            TRY(m_builder.appendff("{}", value));
+        return {};
     }
 
-    void add(long long value)
+    ErrorOr<void> add(long long unsigned value)
     {
-        begin_item();
-        (void)m_builder.appendff("{}", value);
+        TRY(begin_item());
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(m_builder.try_appendff("{}", value));
+        else
+            TRY(m_builder.appendff("{}", value));
+        return {};
     }
 
-    void add(long long unsigned value)
+    ErrorOr<JsonArraySerializer<Builder>> add_array()
     {
-        begin_item();
-        (void)m_builder.appendff("{}", value);
-    }
-
-    JsonArraySerializer<Builder> add_array()
-    {
-        begin_item();
-        return JsonArraySerializer(m_builder);
+        TRY(begin_item());
+        return JsonArraySerializer::try_create(m_builder);
     }
 
     // Implemented in JsonObjectSerializer.h
-    JsonObjectSerializer<Builder> add_object();
+    ErrorOr<JsonObjectSerializer<Builder>> add_object();
 
-    void finish()
+    ErrorOr<void> finish()
     {
         VERIFY(!m_finished);
         m_finished = true;
-        (void)m_builder.append(']');
+        if constexpr (IsLegacyBuilder<Builder>)
+            TRY(m_builder.try_append(']'));
+        else
+            TRY(m_builder.append(']'));
+        return {};
     }
 
 private:
-    void begin_item()
+    explicit JsonArraySerializer(Builder& builder)
+        : m_builder(builder)
     {
-        if (!m_empty)
-            (void)m_builder.append(',');
+    }
+
+    ErrorOr<void> begin_item()
+    {
+        VERIFY(!m_finished);
+        if (!m_empty) {
+            if constexpr (IsLegacyBuilder<Builder>)
+                TRY(m_builder.try_append(','));
+            else
+                TRY(m_builder.append(','));
+        }
         m_empty = false;
+        return {};
     }
 
     Builder& m_builder;
     bool m_empty { true };
     bool m_finished { false };
+};
+
+// Template magic to allow for JsonArraySerializer<>::try_create(...) - Blame CxByte
+template<>
+struct JsonArraySerializer<void> {
+    template<typename Builder>
+    static ErrorOr<JsonArraySerializer<Builder>> try_create(Builder& builder)
+    {
+        return JsonArraySerializer<Builder>::try_create(builder);
+    }
 };
 
 }

--- a/AK/JsonObject.h
+++ b/AK/JsonObject.h
@@ -162,10 +162,11 @@ private:
 template<typename Builder>
 inline void JsonObject::serialize(Builder& builder) const
 {
-    JsonObjectSerializer serializer { builder };
+    auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
     for_each_member([&](auto& key, auto& value) {
-        serializer.add(key, value);
+        MUST(serializer.add(key, value));
     });
+    MUST(serializer.finish());
 }
 
 template<typename Builder>

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -172,30 +172,36 @@ void StringBuilder::append_as_lowercase(char ch)
 
 void StringBuilder::append_escaped_for_json(StringView string)
 {
+    MUST(try_append_escaped_for_json(string));
+}
+
+ErrorOr<void> StringBuilder::try_append_escaped_for_json(StringView string)
+{
     for (auto ch : string) {
         switch (ch) {
         case '\b':
-            append("\\b");
+            TRY(try_append("\\b"));
             break;
         case '\n':
-            append("\\n");
+            TRY(try_append("\\n"));
             break;
         case '\t':
-            append("\\t");
+            TRY(try_append("\\t"));
             break;
         case '\"':
-            append("\\\"");
+            TRY(try_append("\\\""));
             break;
         case '\\':
-            append("\\\\");
+            TRY(try_append("\\\\"));
             break;
         default:
             if (ch >= 0 && ch <= 0x1f)
-                appendff("\\u{:04x}", ch);
+                TRY(try_appendff("\\u{:04x}", ch));
             else
-                append(ch);
+                TRY(try_append(ch));
         }
     }
+    return {};
 }
 
 }

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -35,6 +35,7 @@ public:
         return vformat(*this, fmtstr.view(), variadic_format_params);
     }
     ErrorOr<void> try_append(char const*, size_t);
+    ErrorOr<void> try_append_escaped_for_json(StringView);
 
     void append(StringView);
 #ifndef KERNEL

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -208,6 +208,17 @@ public:
         return IterationDecision::Continue;
     }
 
+    static inline ErrorOr<void> try_for_each(Function<ErrorOr<void>(Processor&)> callback)
+    {
+        auto& procs = processors();
+        size_t count = procs.size();
+        for (size_t i = 0; i < count; i++) {
+            if (procs[i] != nullptr)
+                TRY(callback(*procs[i]));
+        }
+        return {};
+    }
+
     ALWAYS_INLINE u8 physical_address_bit_width() const { return m_physical_address_bit_width; }
     ALWAYS_INLINE u8 virtual_address_bit_width() const { return m_virtual_address_bit_width; }
 

--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -27,24 +27,24 @@ SysFSUSBDeviceInformation::~SysFSUSBDeviceInformation()
 ErrorOr<void> SysFSUSBDeviceInformation::try_generate(KBufferBuilder& builder)
 {
     VERIFY(m_lock.is_locked());
-    JsonArraySerializer array { builder };
+    auto array = TRY(JsonArraySerializer<>::try_create(builder));
 
-    auto obj = array.add_object();
-    obj.add("device_address", m_device->address());
-    obj.add("usb_spec_compliance_bcd", m_device->device_descriptor().usb_spec_compliance_bcd);
-    obj.add("device_class", m_device->device_descriptor().device_class);
-    obj.add("device_sub_class", m_device->device_descriptor().device_sub_class);
-    obj.add("device_protocol", m_device->device_descriptor().device_protocol);
-    obj.add("max_packet_size", m_device->device_descriptor().max_packet_size);
-    obj.add("vendor_id", m_device->device_descriptor().vendor_id);
-    obj.add("product_id", m_device->device_descriptor().product_id);
-    obj.add("device_release_bcd", m_device->device_descriptor().device_release_bcd);
-    obj.add("manufacturer_id_descriptor_index", m_device->device_descriptor().manufacturer_id_descriptor_index);
-    obj.add("product_string_descriptor_index", m_device->device_descriptor().product_string_descriptor_index);
-    obj.add("serial_number_descriptor_index", m_device->device_descriptor().serial_number_descriptor_index);
-    obj.add("num_configurations", m_device->device_descriptor().num_configurations);
-    obj.finish();
-    array.finish();
+    auto obj = TRY(array.add_object());
+    TRY(obj.add("device_address", m_device->address()));
+    TRY(obj.add("usb_spec_compliance_bcd", m_device->device_descriptor().usb_spec_compliance_bcd));
+    TRY(obj.add("device_class", m_device->device_descriptor().device_class));
+    TRY(obj.add("device_sub_class", m_device->device_descriptor().device_sub_class));
+    TRY(obj.add("device_protocol", m_device->device_descriptor().device_protocol));
+    TRY(obj.add("max_packet_size", m_device->device_descriptor().max_packet_size));
+    TRY(obj.add("vendor_id", m_device->device_descriptor().vendor_id));
+    TRY(obj.add("product_id", m_device->device_descriptor().product_id));
+    TRY(obj.add("device_release_bcd", m_device->device_descriptor().device_release_bcd));
+    TRY(obj.add("manufacturer_id_descriptor_index", m_device->device_descriptor().manufacturer_id_descriptor_index));
+    TRY(obj.add("product_string_descriptor_index", m_device->device_descriptor().product_string_descriptor_index));
+    TRY(obj.add("serial_number_descriptor_index", m_device->device_descriptor().serial_number_descriptor_index));
+    TRY(obj.add("num_configurations", m_device->device_descriptor().num_configurations));
+    TRY(obj.finish());
+    TRY(array.finish());
     return {};
 }
 

--- a/Kernel/Devices/DeviceManagement.cpp
+++ b/Kernel/Devices/DeviceManagement.cpp
@@ -109,6 +109,15 @@ void DeviceManagement::for_each(Function<void(Device&)> callback)
     });
 }
 
+ErrorOr<void> DeviceManagement::try_for_each(Function<ErrorOr<void>(Device&)> callback)
+{
+    return m_devices.with([&](auto& map) -> ErrorOr<void> {
+        for (auto& entry : map)
+            TRY(callback(*entry.value));
+        return {};
+    });
+}
+
 NullDevice& DeviceManagement::null_device()
 {
     return *m_null_device;

--- a/Kernel/Devices/DeviceManagement.h
+++ b/Kernel/Devices/DeviceManagement.h
@@ -44,6 +44,7 @@ public:
     void before_device_removal(Badge<Device>, Device&);
 
     void for_each(Function<void(Device&)>);
+    ErrorOr<void> try_for_each(Function<ErrorOr<void>(Device&)>);
     Device* get_device(MajorNumber major, MinorNumber minor);
 
     NullDevice const& null_device() const;

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -725,13 +725,12 @@ ErrorOr<void> VirtualFileSystem::rmdir(StringView path, Custody& base)
     return parent_inode.remove_child(KLexicalPath::basename(path));
 }
 
-void VirtualFileSystem::for_each_mount(Function<IterationDecision(Mount const&)> callback) const
+ErrorOr<void> VirtualFileSystem::for_each_mount(Function<ErrorOr<void>(Mount const&)> callback) const
 {
-    m_mounts.with([&](auto& mounts) {
-        for (auto& mount : mounts) {
-            if (callback(mount) == IterationDecision::Break)
-                break;
-        }
+    return m_mounts.with([&](auto& mounts) -> ErrorOr<void> {
+        for (auto& mount : mounts)
+            TRY(callback(mount));
+        return {};
     });
 }
 

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -68,7 +68,7 @@ public:
     ErrorOr<void> mknod(StringView path, mode_t, dev_t, Custody& base);
     ErrorOr<NonnullRefPtr<Custody>> open_directory(StringView path, Custody& base);
 
-    void for_each_mount(Function<IterationDecision(const Mount&)>) const;
+    ErrorOr<void> for_each_mount(Function<ErrorOr<void>(const Mount&)>) const;
 
     InodeIdentifier root_inode_id() const;
 

--- a/Kernel/Net/LocalSocket.cpp
+++ b/Kernel/Net/LocalSocket.cpp
@@ -34,6 +34,15 @@ void LocalSocket::for_each(Function<void(const LocalSocket&)> callback)
     });
 }
 
+ErrorOr<void> LocalSocket::try_for_each(Function<ErrorOr<void>(const LocalSocket&)> callback)
+{
+    return all_sockets().with_shared([&](const auto& sockets) -> ErrorOr<void> {
+        for (auto& socket : sockets)
+            TRY(callback(socket));
+        return {};
+    });
+}
+
 ErrorOr<NonnullRefPtr<LocalSocket>> LocalSocket::try_create(int type)
 {
     auto client_buffer = TRY(DoubleBuffer::try_create());

--- a/Kernel/Net/LocalSocket.h
+++ b/Kernel/Net/LocalSocket.h
@@ -30,6 +30,7 @@ public:
     ErrorOr<NonnullRefPtr<OpenFileDescription>> recvfd(const OpenFileDescription& socket_description);
 
     static void for_each(Function<void(const LocalSocket&)>);
+    static ErrorOr<void> try_for_each(Function<ErrorOr<void>(const LocalSocket&)>);
 
     StringView socket_path() const;
     ErrorOr<NonnullOwnPtr<KString>> pseudo_path(const OpenFileDescription& description) const override;

--- a/Kernel/Net/NetworkingManagement.cpp
+++ b/Kernel/Net/NetworkingManagement.cpp
@@ -50,6 +50,15 @@ void NetworkingManagement::for_each(Function<void(NetworkAdapter&)> callback)
     });
 }
 
+ErrorOr<void> NetworkingManagement::try_for_each(Function<ErrorOr<void>(NetworkAdapter&)> callback)
+{
+    return m_adapters.with([&](auto& adapters) -> ErrorOr<void> {
+        for (auto& adapter : adapters)
+            TRY(callback(adapter));
+        return {};
+    });
+}
+
 RefPtr<NetworkAdapter> NetworkingManagement::from_ipv4_address(IPv4Address const& address) const
 {
     if (address[0] == 0 && address[1] == 0 && address[2] == 0 && address[3] == 0)

--- a/Kernel/Net/NetworkingManagement.h
+++ b/Kernel/Net/NetworkingManagement.h
@@ -31,6 +31,7 @@ public:
     NetworkingManagement();
 
     void for_each(Function<void(NetworkAdapter&)>);
+    ErrorOr<void> try_for_each(Function<ErrorOr<void>(NetworkAdapter&)>);
 
     RefPtr<NetworkAdapter> from_ipv4_address(const IPv4Address&) const;
     RefPtr<NetworkAdapter> lookup_by_name(StringView) const;

--- a/Kernel/Net/TCPSocket.cpp
+++ b/Kernel/Net/TCPSocket.cpp
@@ -29,6 +29,15 @@ void TCPSocket::for_each(Function<void(const TCPSocket&)> callback)
     });
 }
 
+ErrorOr<void> TCPSocket::try_for_each(Function<ErrorOr<void>(const TCPSocket&)> callback)
+{
+    return sockets_by_tuple().with_shared([&](const auto& sockets) -> ErrorOr<void> {
+        for (auto& it : sockets)
+            TRY(callback(*it.value));
+        return {};
+    });
+}
+
 bool TCPSocket::unref() const
 {
     bool did_hit_zero = sockets_by_tuple().with_exclusive([&](auto& table) {

--- a/Kernel/Net/TCPSocket.h
+++ b/Kernel/Net/TCPSocket.h
@@ -19,6 +19,7 @@ namespace Kernel {
 class TCPSocket final : public IPv4Socket {
 public:
     static void for_each(Function<void(const TCPSocket&)>);
+    static ErrorOr<void> try_for_each(Function<ErrorOr<void>(const TCPSocket&)>);
     static ErrorOr<NonnullRefPtr<TCPSocket>> try_create(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);
     virtual ~TCPSocket() override;
 

--- a/Kernel/Net/UDPSocket.cpp
+++ b/Kernel/Net/UDPSocket.cpp
@@ -22,6 +22,15 @@ void UDPSocket::for_each(Function<void(const UDPSocket&)> callback)
     });
 }
 
+ErrorOr<void> UDPSocket::try_for_each(Function<ErrorOr<void>(const UDPSocket&)> callback)
+{
+    return sockets_by_port().with_shared([&](const auto& sockets) -> ErrorOr<void> {
+        for (auto& socket : sockets)
+            TRY(callback(*socket.value));
+        return {};
+    });
+}
+
 static Singleton<MutexProtected<HashMap<u16, UDPSocket*>>> s_map;
 
 MutexProtected<HashMap<u16, UDPSocket*>>& UDPSocket::sockets_by_port()

--- a/Kernel/Net/UDPSocket.h
+++ b/Kernel/Net/UDPSocket.h
@@ -19,6 +19,7 @@ public:
 
     static RefPtr<UDPSocket> from_port(u16);
     static void for_each(Function<void(const UDPSocket&)>);
+    static ErrorOr<void> try_for_each(Function<ErrorOr<void>(const UDPSocket&)>);
 
 private:
     explicit UDPSocket(int protocol, NonnullOwnPtr<DoubleBuffer> receive_buffer);

--- a/Kernel/PerformanceEventBuffer.cpp
+++ b/Kernel/PerformanceEventBuffer.cpp
@@ -198,14 +198,14 @@ template<typename Serializer>
 ErrorOr<void> PerformanceEventBuffer::to_json_impl(Serializer& object) const
 {
     {
-        auto strings = object.add_array("strings");
-        for (auto const& it : m_strings) {
-            strings.add(it->view());
-        }
+        auto strings = TRY(object.add_array("strings"));
+        for (auto const& it : m_strings)
+            TRY(strings.add(it->view()));
+        TRY(strings.finish());
     }
 
     bool show_kernel_addresses = Process::current().is_superuser();
-    auto array = object.add_array("events");
+    auto array = TRY(object.add_array("events"));
     bool seen_first_sample = false;
     for (size_t i = 0; i < m_count; ++i) {
         auto const& event = at(i);
@@ -215,109 +215,109 @@ ErrorOr<void> PerformanceEventBuffer::to_json_impl(Serializer& object) const
                 continue;
         }
 
-        auto event_object = array.add_object();
+        auto event_object = TRY(array.add_object());
         switch (event.type) {
         case PERF_EVENT_SAMPLE:
-            event_object.add("type", "sample");
+            TRY(event_object.add("type", "sample"));
             break;
         case PERF_EVENT_MALLOC:
-            event_object.add("type", "malloc");
-            event_object.add("ptr", static_cast<u64>(event.data.malloc.ptr));
-            event_object.add("size", static_cast<u64>(event.data.malloc.size));
+            TRY(event_object.add("type", "malloc"));
+            TRY(event_object.add("ptr", static_cast<u64>(event.data.malloc.ptr)));
+            TRY(event_object.add("size", static_cast<u64>(event.data.malloc.size)));
             break;
         case PERF_EVENT_FREE:
-            event_object.add("type", "free");
-            event_object.add("ptr", static_cast<u64>(event.data.free.ptr));
+            TRY(event_object.add("type", "free"));
+            TRY(event_object.add("ptr", static_cast<u64>(event.data.free.ptr)));
             break;
         case PERF_EVENT_MMAP:
-            event_object.add("type", "mmap");
-            event_object.add("ptr", static_cast<u64>(event.data.mmap.ptr));
-            event_object.add("size", static_cast<u64>(event.data.mmap.size));
-            event_object.add("name", event.data.mmap.name);
+            TRY(event_object.add("type", "mmap"));
+            TRY(event_object.add("ptr", static_cast<u64>(event.data.mmap.ptr)));
+            TRY(event_object.add("size", static_cast<u64>(event.data.mmap.size)));
+            TRY(event_object.add("name", event.data.mmap.name));
             break;
         case PERF_EVENT_MUNMAP:
-            event_object.add("type", "munmap");
-            event_object.add("ptr", static_cast<u64>(event.data.munmap.ptr));
-            event_object.add("size", static_cast<u64>(event.data.munmap.size));
+            TRY(event_object.add("type", "munmap"));
+            TRY(event_object.add("ptr", static_cast<u64>(event.data.munmap.ptr)));
+            TRY(event_object.add("size", static_cast<u64>(event.data.munmap.size)));
             break;
         case PERF_EVENT_PROCESS_CREATE:
-            event_object.add("type", "process_create");
-            event_object.add("parent_pid", static_cast<u64>(event.data.process_create.parent_pid));
-            event_object.add("executable", event.data.process_create.executable);
+            TRY(event_object.add("type", "process_create"));
+            TRY(event_object.add("parent_pid", static_cast<u64>(event.data.process_create.parent_pid)));
+            TRY(event_object.add("executable", event.data.process_create.executable));
             break;
         case PERF_EVENT_PROCESS_EXEC:
-            event_object.add("type", "process_exec");
-            event_object.add("executable", event.data.process_exec.executable);
+            TRY(event_object.add("type", "process_exec"));
+            TRY(event_object.add("executable", event.data.process_exec.executable));
             break;
         case PERF_EVENT_PROCESS_EXIT:
-            event_object.add("type", "process_exit");
+            TRY(event_object.add("type", "process_exit"));
             break;
         case PERF_EVENT_THREAD_CREATE:
-            event_object.add("type", "thread_create");
-            event_object.add("parent_tid", static_cast<u64>(event.data.thread_create.parent_tid));
+            TRY(event_object.add("type", "thread_create"));
+            TRY(event_object.add("parent_tid", static_cast<u64>(event.data.thread_create.parent_tid)));
             break;
         case PERF_EVENT_THREAD_EXIT:
-            event_object.add("type", "thread_exit");
+            TRY(event_object.add("type", "thread_exit"));
             break;
         case PERF_EVENT_CONTEXT_SWITCH:
-            event_object.add("type", "context_switch");
-            event_object.add("next_pid", static_cast<u64>(event.data.context_switch.next_pid));
-            event_object.add("next_tid", static_cast<u64>(event.data.context_switch.next_tid));
+            TRY(event_object.add("type", "context_switch"));
+            TRY(event_object.add("next_pid", static_cast<u64>(event.data.context_switch.next_pid)));
+            TRY(event_object.add("next_tid", static_cast<u64>(event.data.context_switch.next_tid)));
             break;
         case PERF_EVENT_KMALLOC:
-            event_object.add("type", "kmalloc");
-            event_object.add("ptr", static_cast<u64>(event.data.kmalloc.ptr));
-            event_object.add("size", static_cast<u64>(event.data.kmalloc.size));
+            TRY(event_object.add("type", "kmalloc"));
+            TRY(event_object.add("ptr", static_cast<u64>(event.data.kmalloc.ptr)));
+            TRY(event_object.add("size", static_cast<u64>(event.data.kmalloc.size)));
             break;
         case PERF_EVENT_KFREE:
-            event_object.add("type", "kfree");
-            event_object.add("ptr", static_cast<u64>(event.data.kfree.ptr));
-            event_object.add("size", static_cast<u64>(event.data.kfree.size));
+            TRY(event_object.add("type", "kfree"));
+            TRY(event_object.add("ptr", static_cast<u64>(event.data.kfree.ptr)));
+            TRY(event_object.add("size", static_cast<u64>(event.data.kfree.size)));
             break;
         case PERF_EVENT_PAGE_FAULT:
-            event_object.add("type", "page_fault");
+            TRY(event_object.add("type", "page_fault"));
             break;
         case PERF_EVENT_SYSCALL:
-            event_object.add("type", "syscall");
+            TRY(event_object.add("type", "syscall"));
             break;
         case PERF_EVENT_SIGNPOST:
-            event_object.add("type"sv, "signpost"sv);
-            event_object.add("arg1"sv, event.data.signpost.arg1);
-            event_object.add("arg2"sv, event.data.signpost.arg2);
+            TRY(event_object.add("type"sv, "signpost"sv));
+            TRY(event_object.add("arg1"sv, event.data.signpost.arg1));
+            TRY(event_object.add("arg2"sv, event.data.signpost.arg2));
             break;
         case PERF_EVENT_READ:
-            event_object.add("type", "read");
-            event_object.add("fd", event.data.read.fd);
-            event_object.add("size"sv, event.data.read.size);
-            event_object.add("filename_index"sv, event.data.read.filename_index);
-            event_object.add("start_timestamp"sv, event.data.read.start_timestamp);
-            event_object.add("success"sv, event.data.read.success);
+            TRY(event_object.add("type", "read"));
+            TRY(event_object.add("fd", event.data.read.fd));
+            TRY(event_object.add("size"sv, event.data.read.size));
+            TRY(event_object.add("filename_index"sv, event.data.read.filename_index));
+            TRY(event_object.add("start_timestamp"sv, event.data.read.start_timestamp));
+            TRY(event_object.add("success"sv, event.data.read.success));
             break;
         }
-        event_object.add("pid", event.pid);
-        event_object.add("tid", event.tid);
-        event_object.add("timestamp", event.timestamp);
-        event_object.add("lost_samples", seen_first_sample ? event.lost_samples : 0);
+        TRY(event_object.add("pid", event.pid));
+        TRY(event_object.add("tid", event.tid));
+        TRY(event_object.add("timestamp", event.timestamp));
+        TRY(event_object.add("lost_samples", seen_first_sample ? event.lost_samples : 0));
         if (event.type == PERF_EVENT_SAMPLE)
             seen_first_sample = true;
-        auto stack_array = event_object.add_array("stack");
+        auto stack_array = TRY(event_object.add_array("stack"));
         for (size_t j = 0; j < event.stack_size; ++j) {
             auto address = event.stack[j];
             if (!show_kernel_addresses && !Memory::is_user_address(VirtualAddress { address }))
                 address = 0xdeadc0de;
-            stack_array.add(address);
+            TRY(stack_array.add(address));
         }
-        stack_array.finish();
-        event_object.finish();
+        TRY(stack_array.finish());
+        TRY(event_object.finish());
     }
-    array.finish();
-    object.finish();
+    TRY(array.finish());
+    TRY(object.finish());
     return {};
 }
 
 ErrorOr<void> PerformanceEventBuffer::to_json(KBufferBuilder& builder) const
 {
-    JsonObjectSerializer object(builder);
+    auto object = TRY(JsonObjectSerializer<>::try_create(builder));
     return to_json_impl(object);
 }
 

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -446,6 +446,14 @@ void Process::OpenFileDescriptions::enumerate(Function<void(const OpenFileDescri
     }
 }
 
+ErrorOr<void> Process::OpenFileDescriptions::try_enumerate(Function<ErrorOr<void>(const OpenFileDescriptionAndFlags&)> callback) const
+{
+    for (auto const& file_description_metadata : m_fds_metadatas) {
+        TRY(callback(file_description_metadata));
+    }
+    return {};
+}
+
 void Process::OpenFileDescriptions::change_each(Function<void(OpenFileDescriptionAndFlags&)> callback)
 {
     for (auto& file_description_metadata : m_fds_metadatas) {

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -237,6 +237,7 @@ public:
     IterationDecision for_each_thread(Callback);
     template<IteratorFunction<Thread&> Callback>
     IterationDecision for_each_thread(Callback callback) const;
+    ErrorOr<void> try_for_each_thread(Function<ErrorOr<void>(Thread const&)>) const;
 
     // Non-breakable iteration functions
     template<VoidFunction<Process&> Callback>
@@ -937,6 +938,15 @@ inline IterationDecision Process::for_each_thread(Callback callback) const
             callback(thread);
     });
     return IterationDecision::Continue;
+}
+
+inline ErrorOr<void> Process::try_for_each_thread(Function<ErrorOr<void>(Thread const&)> callback) const
+{
+    return thread_list().with([&](auto& thread_list) -> ErrorOr<void> {
+        for (auto& thread : thread_list)
+            TRY(callback(thread));
+        return {};
+    });
 }
 
 template<VoidFunction<Thread&> Callback>

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -660,6 +660,7 @@ public:
         OpenFileDescriptionAndFlags* get_if_valid(size_t i);
 
         void enumerate(Function<void(const OpenFileDescriptionAndFlags&)>) const;
+        ErrorOr<void> try_enumerate(Function<ErrorOr<void>(const OpenFileDescriptionAndFlags&)>) const;
         void change_each(Function<void(OpenFileDescriptionAndFlags&)>);
 
         ErrorOr<ScopedDescriptionAllocation> allocate(int first_candidate_fd = 0);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -488,12 +488,13 @@ public:
     Thread::WaitBlockerSet& wait_blocker_set() { return m_wait_blocker_set; }
 
     template<typename Callback>
-    void for_each_coredump_property(Callback callback) const
+    ErrorOr<void> for_each_coredump_property(Callback callback) const
     {
         for (auto const& property : m_coredump_properties) {
             if (property.key && property.value)
-                callback(*property.key, *property.value);
+                TRY(callback(*property.key, *property.value));
         }
+        return {};
     }
 
     ErrorOr<void> set_coredump_property(NonnullOwnPtr<KString> key, NonnullOwnPtr<KString> value);

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -111,22 +111,22 @@ ErrorOr<NonnullRefPtr<Image>> Image::try_create_from_pixel_paint_json(JsonObject
 
 void Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const
 {
-    json.add("width", m_size.width());
-    json.add("height", m_size.height());
+    MUST(json.add("width", m_size.width()));
+    MUST(json.add("height", m_size.height()));
     {
-        auto json_layers = json.add_array("layers");
+        auto json_layers = MUST(json.add_array("layers"));
         for (const auto& layer : m_layers) {
             Gfx::BMPWriter bmp_dumber;
-            auto json_layer = json_layers.add_object();
-            json_layer.add("width", layer.size().width());
-            json_layer.add("height", layer.size().height());
-            json_layer.add("name", layer.name());
-            json_layer.add("locationx", layer.location().x());
-            json_layer.add("locationy", layer.location().y());
-            json_layer.add("opacity_percent", layer.opacity_percent());
-            json_layer.add("visible", layer.is_visible());
-            json_layer.add("selected", layer.is_selected());
-            json_layer.add("bitmap", encode_base64(bmp_dumber.dump(layer.bitmap())));
+            auto json_layer = MUST(json_layers.add_object());
+            MUST(json_layer.add("width", layer.size().width()));
+            MUST(json_layer.add("height", layer.size().height()));
+            MUST(json_layer.add("name", layer.name()));
+            MUST(json_layer.add("locationx", layer.location().x()));
+            MUST(json_layer.add("locationy", layer.location().y()));
+            MUST(json_layer.add("opacity_percent", layer.opacity_percent()));
+            MUST(json_layer.add("visible", layer.is_visible()));
+            MUST(json_layer.add("selected", layer.is_selected()));
+            MUST(json_layer.add("bitmap", encode_base64(bmp_dumber.dump(layer.bitmap()))));
         }
     }
 }
@@ -134,9 +134,9 @@ void Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const
 ErrorOr<void> Image::write_to_file(const String& file_path) const
 {
     StringBuilder builder;
-    JsonObjectSerializer json(builder);
+    auto json = MUST(JsonObjectSerializer<>::try_create(builder));
     serialize_as_json(json);
-    json.finish();
+    MUST(json.finish());
 
     auto file = TRY(Core::File::open(file_path, (Core::OpenMode)(Core::OpenMode::WriteOnly | Core::OpenMode::Truncate)));
     if (!file->write(builder.string_view()))

--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -602,20 +602,20 @@ void ImageEditor::save_project_as()
 Result<void, String> ImageEditor::save_project_to_file(Core::File& file) const
 {
     StringBuilder builder;
-    JsonObjectSerializer json(builder);
+    auto json = MUST(JsonObjectSerializer<>::try_create(builder));
     m_image->serialize_as_json(json);
-    auto json_guides = json.add_array("guides");
+    auto json_guides = MUST(json.add_array("guides"));
     for (const auto& guide : m_guides) {
-        auto json_guide = json_guides.add_object();
-        json_guide.add("offset"sv, (double)guide.offset());
+        auto json_guide = MUST(json_guides.add_object());
+        MUST(json_guide.add("offset"sv, (double)guide.offset()));
         if (guide.orientation() == Guide::Orientation::Vertical)
-            json_guide.add("orientation", "vertical");
+            MUST(json_guide.add("orientation", "vertical"));
         else if (guide.orientation() == Guide::Orientation::Horizontal)
-            json_guide.add("orientation", "horizontal");
-        json_guide.finish();
+            MUST(json_guide.add("orientation", "horizontal"));
+        MUST(json_guide.finish());
     }
-    json_guides.finish();
-    json.finish();
+    MUST(json_guides.finish());
+    MUST(json.finish());
 
     if (!file.write(builder.string_view()))
         return String { file.error_string() };

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1185,10 +1185,10 @@ void Document::set_cookie(String const& cookie_string, Cookie::Source source)
 String Document::dump_dom_tree_as_json() const
 {
     StringBuilder builder;
-    JsonObjectSerializer json(builder);
+    auto json = MUST(JsonObjectSerializer<>::try_create(builder));
     serialize_tree_as_json(json);
 
-    json.finish();
+    MUST(json.finish());
     return builder.to_string();
 }
 

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -45,23 +45,23 @@ void Handler::from_executable(Type handler_type, const String& executable)
 String Handler::to_details_str() const
 {
     StringBuilder builder;
-    JsonObjectSerializer obj { builder };
-    obj.add("executable", executable);
-    obj.add("name", name);
+    auto obj = MUST(JsonObjectSerializer<>::try_create(builder));
+    MUST(obj.add("executable", executable));
+    MUST(obj.add("name", name));
     switch (handler_type) {
     case Type::Application:
-        obj.add("type", "app");
+        MUST(obj.add("type", "app"));
         break;
     case Type::UserDefault:
-        obj.add("type", "userdefault");
+        MUST(obj.add("type", "userdefault"));
         break;
     case Type::UserPreferred:
-        obj.add("type", "userpreferred");
+        MUST(obj.add("type", "userpreferred"));
         break;
     default:
         break;
     }
-    obj.finish();
+    MUST(obj.finish());
     return builder.build();
 }
 

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -271,18 +271,18 @@ Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect
         auto serialize_json = [](Web::CSS::StyleProperties const& properties) -> String {
             StringBuilder builder;
 
-            JsonObjectSerializer serializer(builder);
+            auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
             properties.for_each_property([&](auto property_id, auto& value) {
-                serializer.add(Web::CSS::string_from_property_id(property_id), value.to_string());
+                MUST(serializer.add(Web::CSS::string_from_property_id(property_id), value.to_string()));
             });
-            serializer.finish();
+            MUST(serializer.finish());
 
             return builder.to_string();
         };
 
         auto serialize_custom_properties_json = [](Web::DOM::Element const& element) -> String {
             StringBuilder builder;
-            JsonObjectSerializer serializer(builder);
+            auto serializer = MUST(JsonObjectSerializer<>::try_create(builder));
             HashTable<String> seen_properties;
 
             auto const* element_to_check = &element;
@@ -290,14 +290,14 @@ Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect
                 for (auto const& property : element_to_check->custom_properties()) {
                     if (!seen_properties.contains(property.key)) {
                         seen_properties.set(property.key);
-                        serializer.add(property.key, property.value.value->to_string());
+                        MUST(serializer.add(property.key, property.value.value->to_string()));
                     }
                 }
 
                 element_to_check = element_to_check->parent_element();
             }
 
-            serializer.finish();
+            MUST(serializer.finish());
 
             return builder.to_string();
         };


### PR DESCRIPTION
This allows us to eliminate a major source of infallible allocation in the Kernel, as well as lay down the groundwork for OOM fallibility in userland.

(Apologies in advance for the last commit :sweat_smile:)