### PR TITLE
Kernel/Graphics: Propagate errors in initialization of Graphics

### DIFF
--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
@@ -43,7 +44,7 @@ private:
     virtual bool try_to_set_resolution(size_t output_port_index, size_t width, size_t height) override;
     virtual bool set_y_offset(size_t output_port_index, size_t y) override;
 
-    virtual void initialize_framebuffer_devices() override;
+    virtual ErrorOr<void> initialize_framebuffer_devices() override;
 
     virtual void enable_consoles() override;
     virtual void disable_consoles() override;

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Checked.h>
+#include <AK/Error.h>
 #include <AK/Try.h>
 #include <Kernel/API/POSIX/errno.h>
 #include <Kernel/Debug.h>
@@ -19,12 +20,9 @@
 
 namespace Kernel {
 
-NonnullRefPtr<FramebufferDevice> FramebufferDevice::create(const GenericGraphicsAdapter& adapter, PhysicalAddress paddr, size_t width, size_t height, size_t pitch)
+ErrorOr<NonnullRefPtr<FramebufferDevice>> FramebufferDevice::create(const GenericGraphicsAdapter& adapter, PhysicalAddress paddr, size_t width, size_t height, size_t pitch)
 {
-    auto framebuffer_device_or_error = DeviceManagement::try_create_device<FramebufferDevice>(adapter, paddr, width, height, pitch);
-    // FIXME: Find a way to propagate errors
-    VERIFY(!framebuffer_device_or_error.is_error());
-    return framebuffer_device_or_error.release_value();
+    return TRY(DeviceManagement::try_create_device<FramebufferDevice>(adapter, paddr, width, height, pitch));
 }
 
 ErrorOr<Memory::Region*> FramebufferDevice::mmap(Process& process, OpenFileDescription&, Memory::VirtualRange const& range, u64 offset, int prot, bool shared)

--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/Types.h>
 #include <Kernel/Graphics/GenericFramebufferDevice.h>
@@ -20,7 +21,7 @@ class FramebufferDevice final : public GenericFramebufferDevice {
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<FramebufferDevice> create(const GenericGraphicsAdapter&, PhysicalAddress, size_t, size_t, size_t);
+    static ErrorOr<NonnullRefPtr<FramebufferDevice>> create(const GenericGraphicsAdapter&, PhysicalAddress, size_t, size_t, size_t);
 
     virtual ErrorOr<Memory::Region*> mmap(Process&, OpenFileDescription&, Memory::VirtualRange const&, u64 offset, int prot, bool shared) override;
 

--- a/Kernel/Graphics/GenericGraphicsAdapter.h
+++ b/Kernel/Graphics/GenericGraphicsAdapter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Types.h>
 #include <AK/Weakable.h>
 #include <Kernel/Bus/PCI/Definitions.h>
@@ -18,7 +19,7 @@ class GenericGraphicsAdapter
     , public Weakable<GenericGraphicsAdapter> {
 public:
     virtual ~GenericGraphicsAdapter() = default;
-    virtual void initialize_framebuffer_devices() = 0;
+    virtual ErrorOr<void> initialize_framebuffer_devices() = 0;
     virtual void enable_consoles() = 0;
     virtual void disable_consoles() = 0;
     bool consoles_enabled() const { return m_consoles_enabled; }

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/NonnullRefPtr.h>
 #include <AK/NonnullRefPtrVector.h>
@@ -24,7 +25,7 @@ class GraphicsManagement {
 public:
     static GraphicsManagement& the();
     static bool is_initialized();
-    bool initialize();
+    ErrorOr<void> initialize();
 
     unsigned allocate_minor_device_number() { return m_current_minor_number++; };
     GraphicsManagement();
@@ -41,8 +42,8 @@ public:
     void activate_graphical_mode();
 
 private:
-    bool determine_and_initialize_graphics_device(PCI::DeviceIdentifier const&);
-    bool determine_and_initialize_isa_graphics_device();
+    ErrorOr<void> determine_and_initialize_graphics_device(PCI::DeviceIdentifier const&);
+    ErrorOr<void> determine_and_initialize_isa_graphics_device();
     NonnullRefPtrVector<GenericGraphicsAdapter> m_graphics_devices;
     RefPtr<Graphics::Console> m_console;
 

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Definitions.h>
@@ -113,7 +114,7 @@ private:
     u32 read_from_register(IntelGraphics::RegisterIndex) const;
 
     // ^GenericGraphicsAdapter
-    virtual void initialize_framebuffer_devices() override;
+    virtual ErrorOr<void> initialize_framebuffer_devices() override;
     virtual ErrorOr<ByteBuffer> get_edid(size_t output_port_index) const override;
 
     bool pipe_a_enabled() const;

--- a/Kernel/Graphics/VGA/ISAAdapter.cpp
+++ b/Kernel/Graphics/VGA/ISAAdapter.cpp
@@ -34,8 +34,9 @@ void ISAVGAAdapter::disable_consoles()
     m_framebuffer_console->disable();
 }
 
-void ISAVGAAdapter::initialize_framebuffer_devices()
+ErrorOr<void> ISAVGAAdapter::initialize_framebuffer_devices()
 {
+    return {};
 }
 
 bool ISAVGAAdapter::try_to_set_resolution(size_t, size_t, size_t)

--- a/Kernel/Graphics/VGA/ISAAdapter.h
+++ b/Kernel/Graphics/VGA/ISAAdapter.h
@@ -31,7 +31,7 @@ private:
     ISAVGAAdapter();
 
     // ^GenericGraphicsAdapter
-    virtual void initialize_framebuffer_devices() override;
+    virtual ErrorOr<void> initialize_framebuffer_devices() override;
 
     virtual void enable_consoles() override;
     virtual void disable_consoles() override;

--- a/Kernel/Graphics/VGA/PCIAdapter.h
+++ b/Kernel/Graphics/VGA/PCIAdapter.h
@@ -30,7 +30,7 @@ private:
     PCIVGACompatibleAdapter(PCI::Address, PhysicalAddress, size_t framebuffer_width, size_t framebuffer_height, size_t framebuffer_pitch);
 
     // ^GenericGraphicsAdapter
-    virtual void initialize_framebuffer_devices() override;
+    virtual ErrorOr<void> initialize_framebuffer_devices() override;
 
     virtual void enable_consoles() override;
     virtual void disable_consoles() override;

--- a/Kernel/Graphics/VGACompatibleAdapter.h
+++ b/Kernel/Graphics/VGACompatibleAdapter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
 #include <Kernel/Graphics/Console/Console.h>

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/BinaryBufferWriter.h>
+#include <AK/Error.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/IDs.h>
 #include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
@@ -36,7 +37,7 @@ GraphicsAdapter::GraphicsAdapter(PCI::DeviceIdentifier const& device_identifier)
     m_scratch_space = region_or_error.release_value();
 }
 
-void GraphicsAdapter::initialize_framebuffer_devices()
+ErrorOr<void> GraphicsAdapter::initialize_framebuffer_devices()
 {
     dbgln_if(VIRTIO_DEBUG, "VirtIO::GraphicsAdapter: Initializing framebuffer devices");
     VERIFY(!m_created_framebuffer_devices);
@@ -44,6 +45,7 @@ void GraphicsAdapter::initialize_framebuffer_devices()
     m_created_framebuffer_devices = true;
 
     GraphicsManagement::the().set_console(*default_console());
+    return {};
 }
 
 void GraphicsAdapter::enable_consoles()

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -8,6 +8,7 @@
 
 #include <AK/BinaryBufferWriter.h>
 #include <AK/DistinctNumeric.h>
+#include <AK/Error.h>
 #include <Kernel/Bus/VirtIO/Device.h>
 #include <Kernel/Bus/VirtIO/Queue.h>
 #include <Kernel/Devices/BlockDevice.h>
@@ -87,7 +88,7 @@ private:
 
     void create_framebuffer_devices();
 
-    virtual void initialize_framebuffer_devices() override;
+    virtual ErrorOr<void> initialize_framebuffer_devices() override;
     virtual void enable_consoles() override;
     virtual void disable_consoles() override;
 

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Try.h>
 #include <AK/Types.h>
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/BootInfo.h>
@@ -315,7 +316,7 @@ void init_stage2(void*)
     VMWareBackdoor::the(); // don't wait until first mouse packet
     HIDManagement::initialize();
 
-    GraphicsManagement::the().initialize();
+    MUST(GraphicsManagement::the().initialize());
     ConsoleManagement::the().initialize();
 
     SyncTask::spawn();


### PR DESCRIPTION
Adds error propagatzion for the intialization of the graphics card.
Mostly only adds ErrorOr, TRY and MUST and removes errorporagation by
bool.