### PR TITLE
Kernel: Add support for SA_SIGINFO

### DIFF
--- a/Kernel/API/POSIX/ucontext.h
+++ b/Kernel/API/POSIX/ucontext.h
@@ -54,6 +54,7 @@ typedef struct __ucontext {
 #define SI_TIMER 0x40000002
 #define SI_ASYNCIO 0x40000003
 #define SI_MESGQ 0x40000004
+#define SI_NOINFO 0x40000042
 
 #ifdef __cplusplus
 }

--- a/Kernel/API/POSIX/ucontext.h
+++ b/Kernel/API/POSIX/ucontext.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/API/POSIX/sys/types.h>
+#include <Kernel/Arch/mcontext.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct __mcontext mcontext_t;
+
+typedef struct __ucontext {
+    struct __ucontext* uc_link;
+    sigset_t uc_sigmask;
+    stack_t uc_stack;
+    mcontext_t uc_mcontext;
+} ucontext_t;
+
+#define ILL_ILLOPC 0
+#define ILL_ILLOPN 1
+#define ILL_ILLADR 2
+#define ILL_ILLTRP 3
+#define ILL_PRVOPC 4
+#define ILL_PRVREG 5
+#define ILL_COPROC 6
+#define ILL_BADSTK 7
+
+#define FPE_INTDIV 0
+#define FPE_INTOVF 1
+#define FPE_FLTDIV 2
+#define FPE_FLTOVF 3
+#define FPE_FLTUND 4
+#define FPE_FLTRES 5
+#define FPE_FLTINV 6
+
+#define SEGV_MAPERR 0
+#define SEGV_ACCERR 1
+
+#define BUS_ADRALN 0
+#define BUS_ADRERR 1
+#define BUS_OBJERR 2
+
+#define TRAP_BRKPT 0
+#define TRAP_TRACE 1
+
+#define SI_USER 0x40000000
+#define SI_QUEUE 0x40000001
+#define SI_TIMER 0x40000002
+#define SI_ASYNCIO 0x40000003
+#define SI_MESGQ 0x40000004
+
+#ifdef __cplusplus
+}
+#endif

--- a/Kernel/Arch/mcontext.h
+++ b/Kernel/Arch/mcontext.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#if ARCH(X86_64) || ARCH(I386)
+#    include <Kernel/Arch/x86/mcontext.h>
+#elif ARCH(AARCH64)
+#    error "Unknown architecture"
+#endif

--- a/Kernel/Arch/x86/RegisterState.h
+++ b/Kernel/Arch/x86/RegisterState.h
@@ -131,26 +131,26 @@ static_assert(AssertSize<RegisterState, REGISTER_STATE_SIZE>());
 inline void copy_kernel_registers_into_ptrace_registers(PtraceRegisters& ptrace_regs, const RegisterState& kernel_regs)
 {
 #if ARCH(I386)
-    ptrace_regs.eax = kernel_regs.eax,
-    ptrace_regs.ecx = kernel_regs.ecx,
-    ptrace_regs.edx = kernel_regs.edx,
-    ptrace_regs.ebx = kernel_regs.ebx,
-    ptrace_regs.esp = kernel_regs.userspace_esp,
-    ptrace_regs.ebp = kernel_regs.ebp,
-    ptrace_regs.esi = kernel_regs.esi,
-    ptrace_regs.edi = kernel_regs.edi,
-    ptrace_regs.eip = kernel_regs.eip,
-    ptrace_regs.eflags = kernel_regs.eflags,
+    ptrace_regs.eax = kernel_regs.eax;
+    ptrace_regs.ecx = kernel_regs.ecx;
+    ptrace_regs.edx = kernel_regs.edx;
+    ptrace_regs.ebx = kernel_regs.ebx;
+    ptrace_regs.esp = kernel_regs.userspace_esp;
+    ptrace_regs.ebp = kernel_regs.ebp;
+    ptrace_regs.esi = kernel_regs.esi;
+    ptrace_regs.edi = kernel_regs.edi;
+    ptrace_regs.eip = kernel_regs.eip;
+    ptrace_regs.eflags = kernel_regs.eflags;
 #else
-    ptrace_regs.rax = kernel_regs.rax,
-    ptrace_regs.rcx = kernel_regs.rcx,
-    ptrace_regs.rdx = kernel_regs.rdx,
-    ptrace_regs.rbx = kernel_regs.rbx,
-    ptrace_regs.rsp = kernel_regs.userspace_rsp,
-    ptrace_regs.rbp = kernel_regs.rbp,
-    ptrace_regs.rsi = kernel_regs.rsi,
-    ptrace_regs.rdi = kernel_regs.rdi,
-    ptrace_regs.rip = kernel_regs.rip,
+    ptrace_regs.rax = kernel_regs.rax;
+    ptrace_regs.rcx = kernel_regs.rcx;
+    ptrace_regs.rdx = kernel_regs.rdx;
+    ptrace_regs.rbx = kernel_regs.rbx;
+    ptrace_regs.rsp = kernel_regs.userspace_rsp;
+    ptrace_regs.rbp = kernel_regs.rbp;
+    ptrace_regs.rsi = kernel_regs.rsi;
+    ptrace_regs.rdi = kernel_regs.rdi;
+    ptrace_regs.rip = kernel_regs.rip;
     ptrace_regs.r8 = kernel_regs.r8;
     ptrace_regs.r9 = kernel_regs.r9;
     ptrace_regs.r10 = kernel_regs.r10;

--- a/Kernel/Arch/x86/mcontext.h
+++ b/Kernel/Arch/x86/mcontext.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+#include <Kernel/API/POSIX/sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct __attribute__((packed)) __mcontext {
+#if ARCH(I386)
+    uint32_t eax;
+    uint32_t ecx;
+    uint32_t edx;
+    uint32_t ebx;
+    uint32_t esp;
+    uint32_t ebp;
+    uint32_t esi;
+    uint32_t edi;
+    uint32_t eip;
+    uint32_t eflags;
+#else
+    uint64_t rax;
+    uint64_t rcx;
+    uint64_t rdx;
+    uint64_t rbx;
+    uint64_t rsp;
+    uint64_t rbp;
+    uint64_t rsi;
+    uint64_t rdi;
+    uint64_t rip;
+    uint64_t r8;
+    uint64_t r9;
+    uint64_t r10;
+    uint64_t r11;
+    uint64_t r12;
+    uint64_t r13;
+    uint64_t r14;
+    uint64_t r15;
+    uint64_t rflags;
+#endif
+    uint32_t cs;
+    uint32_t ss;
+    uint32_t ds;
+    uint32_t es;
+    uint32_t fs;
+    uint32_t gs;
+};
+
+#ifdef __cplusplus
+}
+#endif

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -612,10 +612,9 @@ void Process::finalize()
     m_state.store(State::Dead, AK::MemoryOrder::memory_order_release);
 
     {
-        // FIXME: PID/TID BUG
-        if (auto parent_thread = Thread::from_tid(ppid().value())) {
-            if (parent_thread->process().is_user_process() && (parent_thread->m_signal_action_data[SIGCHLD].flags & SA_NOCLDWAIT) != SA_NOCLDWAIT)
-                parent_thread->send_signal(SIGCHLD, this);
+        if (auto parent_process = Process::from_pid(ppid())) {
+            if (parent_process->is_user_process() && (parent_process->m_signal_action_data[SIGCHLD].flags & SA_NOCLDWAIT) != SA_NOCLDWAIT)
+                (void)parent_process->send_signal(SIGCHLD, this);
         }
     }
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -827,6 +827,12 @@ private:
     NonnullRefPtrVector<Thread> m_threads_for_coredump;
 
     mutable RefPtr<ProcessProcFSTraits> m_procfs_traits;
+    struct SignalActionData {
+        VirtualAddress handler_or_sigaction;
+        int flags { 0 };
+        u32 mask { 0 };
+    };
+    Array<SignalActionData, NSIG> m_signal_action_data;
 
     static_assert(sizeof(ProtectedValues) < (PAGE_SIZE));
     alignas(4096) ProtectedValues m_protected_values;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -451,6 +451,7 @@ public:
     ErrorOr<void> send_signal(u8 signal, Process* sender);
 
     u8 termination_signal() const { return m_protected_values.termination_signal; }
+    u8 termination_status() const { return m_protected_values.termination_status; }
 
     u16 thread_count() const
     {

--- a/Kernel/Syscalls/sigaction.cpp
+++ b/Kernel/Syscalls/sigaction.cpp
@@ -68,6 +68,8 @@ ErrorOr<FlatPtr> Process::sys$sigaction(int signum, Userspace<const sigaction*> 
     }
     if (user_act) {
         auto act = TRY(copy_typed_from_user(user_act));
+        if (act.sa_flags & SA_SIGINFO)
+            return ENOTSUP;
         action.mask = act.sa_mask;
         action.flags = act.sa_flags;
         action.handler_or_sigaction = VirtualAddress { reinterpret_cast<void*>(act.sa_sigaction) };

--- a/Kernel/Thread.cpp
+++ b/Kernel/Thread.cpp
@@ -1190,6 +1190,11 @@ DispatchSignalResult Thread::dispatch_signal(u8 signal)
 
         VERIFY(stack % 16 == 0);
 
+#if ARCH(I386) || ARCH(X86_64)
+        // Save the FPU/SSE state
+        TRY(copy_value_on_user_stack(stack, fpu_state()));
+#endif
+
 #if ARCH(I386)
         // Leave one empty slot to align the stack for a handler call.
         TRY(push_value_on_user_stack(stack, 0));

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1220,6 +1220,7 @@ private:
     VirtualAddress m_thread_specific_data;
     Optional<Memory::VirtualRange> m_thread_specific_range;
     Array<Optional<u32>, NSIG> m_signal_action_masks;
+    Array<ProcessID, NSIG> m_signal_senders;
     Blocker* m_blocker { nullptr };
     Kernel::Mutex* m_blocking_mutex { nullptr };
     u32 m_lock_requested_count { 0 };

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -46,12 +46,6 @@ enum class DispatchSignalResult {
     Continue
 };
 
-struct SignalActionData {
-    VirtualAddress handler_or_sigaction;
-    u32 mask { 0 };
-    int flags { 0 };
-};
-
 struct ThreadSpecificData {
     ThreadSpecificData* self;
 };
@@ -1225,7 +1219,7 @@ private:
     NonnullOwnPtr<Memory::Region> m_kernel_stack_region;
     VirtualAddress m_thread_specific_data;
     Optional<Memory::VirtualRange> m_thread_specific_range;
-    Array<SignalActionData, NSIG> m_signal_action_data;
+    Array<Optional<u32>, NSIG> m_signal_action_masks;
     Blocker* m_blocker { nullptr };
     Kernel::Mutex* m_blocking_mutex { nullptr };
     u32 m_lock_requested_count { 0 };

--- a/Kernel/UnixTypes.h
+++ b/Kernel/UnixTypes.h
@@ -31,4 +31,5 @@
 #include <Kernel/API/POSIX/sys/wait.h>
 #include <Kernel/API/POSIX/termios.h>
 #include <Kernel/API/POSIX/time.h>
+#include <Kernel/API/POSIX/ucontext.h>
 #include <Kernel/API/POSIX/unistd.h>

--- a/Tests/Kernel/CMakeLists.txt
+++ b/Tests/Kernel/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TEST_SOURCES
     path-resolution-race.cpp
     pthread-cond-timedwait-example.cpp
     setpgid-across-sessions-without-leader.cpp
+    siginfo-example.cpp
     stress-truncate.cpp
     stress-writeread.cpp
     uaf-close-while-blocked-in-read.cpp

--- a/Tests/Kernel/siginfo-example.cpp
+++ b/Tests/Kernel/siginfo-example.cpp
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2020-2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <signal.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+// Supposed to use volatile everywhere here but good lord does C++ make that a pain
+volatile sig_atomic_t saved_signal;
+volatile siginfo_t saved_siginfo;
+volatile ucontext_t saved_ucontext;
+siginfo_t* sig_info_addr;
+ucontext_t* ucontext_addr;
+void* stack_ptr;
+volatile bool signal_was_delivered = false;
+
+static void signal_handler(int sig, siginfo_t* sig_info, void* u_context)
+{
+    int x;
+    stack_ptr = &x;
+    signal_was_delivered = true;
+
+    saved_signal = sig;
+    // grumble grumble, assignment operator on volatile types not a thing
+    // grumble grumble more, can't memcpy voltile either, that casts away volatile
+    // grumble grumble even more, can't std::copy to volatile.
+    // screw it, just write all the fields
+    sig_info_addr = sig_info;
+    saved_siginfo.si_status = sig_info->si_status;
+    saved_siginfo.si_signo = sig_info->si_signo;
+    saved_siginfo.si_code = sig_info->si_code;
+    saved_siginfo.si_pid = sig_info->si_pid;
+    saved_siginfo.si_uid = sig_info->si_uid;
+    saved_siginfo.si_value.sival_int = sig_info->si_value.sival_int;
+    auto user_context = (ucontext_t*)u_context;
+    ucontext_addr = user_context;
+    saved_ucontext.uc_link = user_context->uc_link;
+    saved_ucontext.uc_sigmask = user_context->uc_sigmask;
+    saved_ucontext.uc_stack.ss_sp = user_context->uc_stack.ss_sp;
+    saved_ucontext.uc_stack.ss_size = user_context->uc_stack.ss_size;
+    saved_ucontext.uc_stack.ss_flags = user_context->uc_stack.ss_flags;
+    // saved_ucontext.uc_mcontext = user_context->uc_mcontext;
+}
+
+static int print_signal_results()
+{
+    if (!signal_was_delivered) {
+        fprintf(stderr, "Where was my signal bro?\n");
+        return 2;
+    }
+
+    sig_atomic_t read_the_signal = saved_signal;
+    siginfo_t read_the_siginfo = {};
+    read_the_siginfo.si_status = saved_siginfo.si_status;
+    read_the_siginfo.si_signo = saved_siginfo.si_signo;
+    read_the_siginfo.si_code = saved_siginfo.si_code;
+    read_the_siginfo.si_pid = saved_siginfo.si_pid;
+    read_the_siginfo.si_uid = saved_siginfo.si_uid;
+    read_the_siginfo.si_value.sival_int = saved_siginfo.si_value.sival_int;
+
+    ucontext_t read_the_ucontext = {};
+    read_the_ucontext.uc_link = saved_ucontext.uc_link;
+    read_the_ucontext.uc_sigmask = saved_ucontext.uc_sigmask;
+    read_the_ucontext.uc_stack.ss_sp = saved_ucontext.uc_stack.ss_sp;
+    read_the_ucontext.uc_stack.ss_size = saved_ucontext.uc_stack.ss_size;
+    read_the_ucontext.uc_stack.ss_flags = saved_ucontext.uc_stack.ss_flags;
+    // read_the_ucontext.uc_mcontext = saved_ucontext.uc_mcontext;
+
+    printf("Handled signal: %d\n", read_the_signal);
+    printf("Stack sorta started as %p\n", stack_ptr);
+    printf("Siginfo was stored at %p:\n", sig_info_addr);
+    printf("\tsi_signo: %d\n", read_the_siginfo.si_signo);
+    printf("\tsi_code, %x\n", read_the_siginfo.si_code);
+    printf("\tsi_pid, %d\n", read_the_siginfo.si_pid);
+    printf("\tsi_uid, %d\n", read_the_siginfo.si_uid);
+    printf("\tsi_status, %x\n", read_the_siginfo.si_status);
+    printf("\tsi_value.sival_int, %x\n", read_the_siginfo.si_value.sival_int);
+    printf("ucontext was stored at %p:\n", ucontext_addr);
+    printf("\tuc_link, %p\n", read_the_ucontext.uc_link);
+    printf("\tuc_sigmask, %d\n", read_the_ucontext.uc_sigmask);
+    printf("\tuc_stack.ss_sp, %p\n", read_the_ucontext.uc_stack.ss_sp);
+    printf("\tuc_stack.ss_size, %zu\n", read_the_ucontext.uc_stack.ss_size);
+    printf("\tuc_stack.ss_flags, %d\n", read_the_ucontext.uc_stack.ss_flags);
+    // printf("\tuc_mcontext, %d\n", read_the_ucontext.uc_mcontext);
+
+    return 0;
+}
+
+int main()
+{
+    struct sigaction action = {};
+    action.sa_flags = SA_SIGINFO;
+    sigemptyset(&action.sa_mask);
+    action.sa_sigaction = signal_handler;
+
+    for (size_t i = 0; i < NSIG; ++i)
+        (void)sigaction(i, &action, nullptr);
+
+    printf("Sleeping for a long time waiting for kill -<N> %d\n", getpid());
+
+    sleep(1000);
+    return print_signal_results();
+}

--- a/Toolchain/BuildIt.sh
+++ b/Toolchain/BuildIt.sh
@@ -350,9 +350,21 @@ pushd "$DIR/Build/$ARCH"
     pushd "$BUILD"
         mkdir -p Root/usr/include/
         SRC_ROOT=$($REALPATH "$DIR"/..)
-        FILES=$(find "$SRC_ROOT"/Kernel/API "$SRC_ROOT"/Userland/Libraries/LibC "$SRC_ROOT"/Userland/Libraries/LibM "$SRC_ROOT"/Userland/Libraries/LibPthread -name '*.h' -print)
+        FILES=$(find \
+            "$SRC_ROOT"/AK \
+            "$SRC_ROOT"/Kernel/API \
+            "$SRC_ROOT"/Kernel/Arch \
+            "$SRC_ROOT"/Userland/Libraries/LibC \
+            "$SRC_ROOT"/Userland/Libraries/LibM \
+            "$SRC_ROOT"/Userland/Libraries/LibPthread \
+            -name '*.h' -print)
         for header in $FILES; do
-            target=$(echo "$header" | sed -e "s@$SRC_ROOT/Userland/Libraries/LibC@@" -e "s@$SRC_ROOT/Userland/Libraries/LibM@@" -e "s@$SRC_ROOT/Userland/Libraries/LibPthread@@" -e "s@$SRC_ROOT/Kernel/@Kernel/@")
+            target=$(echo "$header" | sed \
+                -e "s@$SRC_ROOT/AK/@AK/@" \
+                -e "s@$SRC_ROOT/Userland/Libraries/LibC@@" \
+                -e "s@$SRC_ROOT/Userland/Libraries/LibM@@" \
+                -e "s@$SRC_ROOT/Userland/Libraries/LibPthread@@" \
+                -e "s@$SRC_ROOT/Kernel/@Kernel/@")
             buildstep "system_headers" $INSTALL -D "$header" "Root/usr/include/$target"
         done
         unset SRC_ROOT

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -10,7 +10,6 @@
 #include "MallocTracer.h"
 #include "RangeAllocator.h"
 #include "Report.h"
-#include "SoftCPU.h"
 #include "SoftMMU.h"
 #include <AK/FileStream.h>
 #include <AK/Types.h>
@@ -26,6 +25,7 @@
 namespace UserspaceEmulator {
 
 class MallocTracer;
+class SoftCPU;
 
 class Emulator {
 public:
@@ -117,7 +117,7 @@ private:
     const Vector<String> m_environment;
 
     SoftMMU m_mmu;
-    SoftCPU m_cpu;
+    NonnullOwnPtr<SoftCPU> m_cpu;
 
     OwnPtr<MallocTracer> m_malloc_tracer;
 
@@ -292,17 +292,5 @@ private:
     bool m_is_in_region_of_interest { false };
     bool m_is_memory_auditing_suppressed { false };
 };
-
-ALWAYS_INLINE bool Emulator::is_in_libsystem() const
-{
-    return m_cpu.base_eip() >= m_libsystem_start && m_cpu.base_eip() < m_libsystem_end;
-}
-
-ALWAYS_INLINE bool Emulator::is_in_loader_code() const
-{
-    if (!m_loader_text_base.has_value() || !m_loader_text_size.has_value())
-        return false;
-    return (m_cpu.base_eip() >= m_loader_text_base.value() && m_cpu.base_eip() < m_loader_text_base.value() + m_loader_text_size.value());
-}
 
 }

--- a/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
+++ b/Userland/DevTools/UserspaceEmulator/Emulator_syscalls.cpp
@@ -1400,32 +1400,43 @@ int Emulator::virt$sigprocmask(int how, FlatPtr set, FlatPtr old_set)
 int Emulator::virt$sigreturn()
 {
     u32 stack_ptr = m_cpu->esp().value();
-    auto local_pop = [&]() -> ValueWithShadow<u32> {
-        auto value = m_cpu->read_memory32({ m_cpu->ss(), stack_ptr });
-        stack_ptr += sizeof(u32);
+    auto local_pop = [&]<typename T>() {
+        auto value = m_cpu->read_memory<T>({ m_cpu->ss(), stack_ptr });
+        stack_ptr += sizeof(T);
         return value;
     };
 
-    auto smuggled_eax = local_pop();
+    // State from signal trampoline (note that we're assuming i386 here):
+    // saved_ax, ucontext, signal_info, fpu_state.
 
-    stack_ptr += 4 * sizeof(u32);
+    // Drop the FPU state
+    // FIXME: Read and restore from this.
+    stack_ptr += 512;
 
-    m_signal_mask = local_pop().value();
+    // Drop the signal info
+    stack_ptr += sizeof(siginfo_t);
 
-    m_cpu->set_edi(local_pop());
-    m_cpu->set_esi(local_pop());
-    m_cpu->set_ebp(local_pop());
-    m_cpu->set_esp(local_pop());
-    m_cpu->set_ebx(local_pop());
-    m_cpu->set_edx(local_pop());
-    m_cpu->set_ecx(local_pop());
-    m_cpu->set_eax(local_pop());
+    auto ucontext = local_pop.operator()<ucontext_t>();
 
-    m_cpu->set_eip(local_pop().value());
-    m_cpu->set_eflags(local_pop());
+    auto eax = local_pop.operator()<u32>();
 
-    // FIXME: We're losing shadow bits here.
-    return smuggled_eax.value();
+    m_signal_mask = ucontext.value().uc_sigmask;
+
+    auto mcontext_slice = ucontext.slice<&ucontext_t::uc_mcontext>();
+
+    m_cpu->set_edi(mcontext_slice.slice<&__mcontext::edi>());
+    m_cpu->set_esi(mcontext_slice.slice<&__mcontext::esi>());
+    m_cpu->set_ebp(mcontext_slice.slice<&__mcontext::ebp>());
+    m_cpu->set_esp(mcontext_slice.slice<&__mcontext::esp>());
+    m_cpu->set_ebx(mcontext_slice.slice<&__mcontext::ebx>());
+    m_cpu->set_edx(mcontext_slice.slice<&__mcontext::edx>());
+    m_cpu->set_ecx(mcontext_slice.slice<&__mcontext::ecx>());
+    m_cpu->set_eax(mcontext_slice.slice<&__mcontext::eax>());
+    m_cpu->set_eip(mcontext_slice.value().eip);
+    m_cpu->set_eflags(mcontext_slice.slice<&__mcontext::eflags>());
+
+    // FIXME: We're dropping the shadow bits here.
+    return eax.value();
 }
 
 int Emulator::virt$getpgrp()

--- a/Userland/DevTools/UserspaceEmulator/MmapRegion.cpp
+++ b/Userland/DevTools/UserspaceEmulator/MmapRegion.cpp
@@ -6,6 +6,7 @@
 
 #include "MmapRegion.h"
 #include "Emulator.h"
+#include <AK/ByteReader.h>
 #include <string.h>
 #include <sys/mman.h>
 
@@ -196,7 +197,7 @@ void MmapRegion::write8(u32 offset, ValueWithShadow<u8> value)
 
     VERIFY(offset < size());
     m_data[offset] = value.value();
-    m_shadow_data[offset] = value.shadow();
+    m_shadow_data[offset] = value.shadow()[0];
 }
 
 void MmapRegion::write16(u32 offset, ValueWithShadow<u16> value)

--- a/Userland/DevTools/UserspaceEmulator/SimpleRegion.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SimpleRegion.cpp
@@ -85,7 +85,7 @@ void SimpleRegion::write8(u32 offset, ValueWithShadow<u8> value)
 {
     VERIFY(offset < size());
     m_data[offset] = value.value();
-    m_shadow_data[offset] = value.shadow();
+    m_shadow_data[offset] = value.shadow()[0];
 }
 
 void SimpleRegion::write16(u32 offset, ValueWithShadow<u16> value)

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -74,8 +74,10 @@ SoftCPU::SoftCPU(Emulator& emulator)
     : m_emulator(emulator)
     , m_fpu(emulator, *this)
 {
-    memset(m_gpr, 0, sizeof(m_gpr));
-    memset(m_gpr_shadow, 1, sizeof(m_gpr_shadow));
+    PartAddressableRegister empty_reg;
+    explicit_bzero(&empty_reg, sizeof(empty_reg));
+    for (auto& gpr : m_gpr)
+        gpr = ValueWithShadow<PartAddressableRegister>::create_initialized(empty_reg);
 
     m_segment[(int)X86::SegmentRegister::CS] = 0x1b;
     m_segment[(int)X86::SegmentRegister::DS] = 0x23;

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.h
@@ -176,21 +176,21 @@ public:
     {
         if (a32)
             return esi();
-        return { si().value(), (u32)si().shadow() & 0xffff };
+        return { si().value(), (u32)si().shadow_as_value() & 0xffff };
     }
 
     ValueWithShadow<u32> destination_index(bool a32) const
     {
         if (a32)
             return edi();
-        return { di().value(), (u32)di().shadow() & 0xffff };
+        return { di().value(), (u32)di().shadow_as_value() & 0xffff };
     }
 
     ValueWithShadow<u32> loop_index(bool a32) const
     {
         if (a32)
             return ecx();
-        return { cx().value(), (u32)cx().shadow() & 0xffff };
+        return { cx().value(), (u32)cx().shadow_as_value() & 0xffff };
     }
 
     bool decrement_loop_index(bool a32)

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.h
@@ -88,21 +88,21 @@ public:
     {
         switch (reg) {
         case X86::RegisterAL:
-            return { m_gpr[X86::RegisterEAX].low_u8, m_gpr_shadow[X86::RegisterEAX].low_u8 };
+            return m_gpr[X86::RegisterEAX].reference_to<&PartAddressableRegister::low_u8>();
         case X86::RegisterAH:
-            return { m_gpr[X86::RegisterEAX].high_u8, m_gpr_shadow[X86::RegisterEAX].high_u8 };
+            return m_gpr[X86::RegisterEAX].reference_to<&PartAddressableRegister::high_u8>();
         case X86::RegisterBL:
-            return { m_gpr[X86::RegisterEBX].low_u8, m_gpr_shadow[X86::RegisterEBX].low_u8 };
+            return m_gpr[X86::RegisterEBX].reference_to<&PartAddressableRegister::low_u8>();
         case X86::RegisterBH:
-            return { m_gpr[X86::RegisterEBX].high_u8, m_gpr_shadow[X86::RegisterEBX].high_u8 };
+            return m_gpr[X86::RegisterEBX].reference_to<&PartAddressableRegister::high_u8>();
         case X86::RegisterCL:
-            return { m_gpr[X86::RegisterECX].low_u8, m_gpr_shadow[X86::RegisterECX].low_u8 };
+            return m_gpr[X86::RegisterECX].reference_to<&PartAddressableRegister::low_u8>();
         case X86::RegisterCH:
-            return { m_gpr[X86::RegisterECX].high_u8, m_gpr_shadow[X86::RegisterECX].high_u8 };
+            return m_gpr[X86::RegisterECX].reference_to<&PartAddressableRegister::high_u8>();
         case X86::RegisterDL:
-            return { m_gpr[X86::RegisterEDX].low_u8, m_gpr_shadow[X86::RegisterEDX].low_u8 };
+            return m_gpr[X86::RegisterEDX].reference_to<&PartAddressableRegister::low_u8>();
         case X86::RegisterDH:
-            return { m_gpr[X86::RegisterEDX].high_u8, m_gpr_shadow[X86::RegisterEDX].high_u8 };
+            return m_gpr[X86::RegisterEDX].reference_to<&PartAddressableRegister::high_u8>();
         }
         VERIFY_NOT_REACHED();
     }
@@ -111,43 +111,43 @@ public:
     {
         switch (reg) {
         case X86::RegisterAL:
-            return { m_gpr[X86::RegisterEAX].low_u8, m_gpr_shadow[X86::RegisterEAX].low_u8 };
+            return m_gpr[X86::RegisterEAX].slice<&PartAddressableRegister::low_u8>();
         case X86::RegisterAH:
-            return { m_gpr[X86::RegisterEAX].high_u8, m_gpr_shadow[X86::RegisterEAX].high_u8 };
+            return m_gpr[X86::RegisterEAX].slice<&PartAddressableRegister::high_u8>();
         case X86::RegisterBL:
-            return { m_gpr[X86::RegisterEBX].low_u8, m_gpr_shadow[X86::RegisterEBX].low_u8 };
+            return m_gpr[X86::RegisterEBX].slice<&PartAddressableRegister::low_u8>();
         case X86::RegisterBH:
-            return { m_gpr[X86::RegisterEBX].high_u8, m_gpr_shadow[X86::RegisterEBX].high_u8 };
+            return m_gpr[X86::RegisterEBX].slice<&PartAddressableRegister::high_u8>();
         case X86::RegisterCL:
-            return { m_gpr[X86::RegisterECX].low_u8, m_gpr_shadow[X86::RegisterECX].low_u8 };
+            return m_gpr[X86::RegisterECX].slice<&PartAddressableRegister::low_u8>();
         case X86::RegisterCH:
-            return { m_gpr[X86::RegisterECX].high_u8, m_gpr_shadow[X86::RegisterECX].high_u8 };
+            return m_gpr[X86::RegisterECX].slice<&PartAddressableRegister::high_u8>();
         case X86::RegisterDL:
-            return { m_gpr[X86::RegisterEDX].low_u8, m_gpr_shadow[X86::RegisterEDX].low_u8 };
+            return m_gpr[X86::RegisterEDX].slice<&PartAddressableRegister::low_u8>();
         case X86::RegisterDH:
-            return { m_gpr[X86::RegisterEDX].high_u8, m_gpr_shadow[X86::RegisterEDX].high_u8 };
+            return m_gpr[X86::RegisterEDX].slice<&PartAddressableRegister::high_u8>();
         }
         VERIFY_NOT_REACHED();
     }
 
     ValueWithShadow<u16> const_gpr16(X86::RegisterIndex16 reg) const
     {
-        return { m_gpr[reg].low_u16, m_gpr_shadow[reg].low_u16 };
+        return m_gpr[reg].slice<&PartAddressableRegister::low_u16>();
     }
 
     ValueAndShadowReference<u16> gpr16(X86::RegisterIndex16 reg)
     {
-        return { m_gpr[reg].low_u16, m_gpr_shadow[reg].low_u16 };
+        return m_gpr[reg].reference_to<&PartAddressableRegister::low_u16>();
     }
 
     ValueWithShadow<u32> const_gpr32(X86::RegisterIndex32 reg) const
     {
-        return { m_gpr[reg].full_u32, m_gpr_shadow[reg].full_u32 };
+        return m_gpr[reg].slice<&PartAddressableRegister::full_u32>();
     }
 
     ValueAndShadowReference<u32> gpr32(X86::RegisterIndex32 reg)
     {
-        return { m_gpr[reg].full_u32, m_gpr_shadow[reg].full_u32 };
+        return m_gpr[reg].reference_to<&PartAddressableRegister::full_u32>();
     }
 
     template<typename T>
@@ -1252,8 +1252,7 @@ private:
     Emulator& m_emulator;
     SoftFPU m_fpu;
 
-    PartAddressableRegister m_gpr[8];
-    PartAddressableRegister m_gpr_shadow[8];
+    ValueWithShadow<PartAddressableRegister> m_gpr[8];
 
     u16 m_segment[8] { 0 };
     u32 m_eflags { 0 };

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include "AK/Debug.h"
+#include "Emulator.h"
 #include "Region.h"
 #include "SoftFPU.h"
 #include "ValueWithShadow.h"
@@ -367,18 +369,12 @@ public:
     template<typename T>
     ValueWithShadow<T> read_memory(X86::LogicalAddress address)
     {
-        if constexpr (sizeof(T) == 1)
-            return read_memory8(address);
-        if constexpr (sizeof(T) == 2)
-            return read_memory16(address);
-        if constexpr (sizeof(T) == 4)
-            return read_memory32(address);
-        if constexpr (sizeof(T) == 8)
-            return read_memory64(address);
-        if constexpr (sizeof(T) == 16)
-            return read_memory128(address);
-        if constexpr (sizeof(T) == 32)
-            return read_memory256(address);
+        auto value = m_emulator.mmu().read<T>(address);
+        if constexpr (AK::HasFormatter<T>)
+            outln_if(MEMORY_DEBUG, "\033[36;1mread_memory: @{:#04x}:{:p} -> {:#064x} ({:hex-dump})\033[0m", address.selector(), address.offset(), value.value(), value.shadow().span());
+        else
+            outln_if(MEMORY_DEBUG, "\033[36;1mread_memory: @{:#04x}:{:p} -> ??? ({:hex-dump})\033[0m", address.selector(), address.offset(), value.shadow().span());
+        return value;
     }
 
     void write_memory8(X86::LogicalAddress, ValueWithShadow<u8>);

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
@@ -300,7 +300,7 @@ void SoftFPU::FSTP_RM80(const X86::Instruction& insn)
         f80 = insn.modrm().read128(m_cpu, insn);
         *(long double*)value.bytes().data() = fpu_pop();
         memcpy(f80.value().bytes().data(), &value, 10); // copy
-        memset(f80.shadow().bytes().data(), 0x01, 10);  // mark as initialized
+        f80.set_initialized();
         insn.modrm().write128(m_cpu, insn, f80);
     }
 }
@@ -688,7 +688,7 @@ void SoftFPU::FDIVR_RM64(const X86::Instruction& insn)
 {
     if (insn.modrm().is_register()) {
         // XXX this is FDIVR, Instruction decodes this weirdly
-        //fpu_set(insn.modrm().register_index(), fpu_get(0) / fpu_get(insn.modrm().register_index()));
+        // fpu_set(insn.modrm().register_index(), fpu_get(0) / fpu_get(insn.modrm().register_index()));
         fpu_set(insn.modrm().register_index(), fpu_get(insn.modrm().register_index()) / fpu_get(0));
     } else {
         auto new_f64 = insn.modrm().read64(m_cpu, insn);
@@ -1167,13 +1167,13 @@ void SoftFPU::FNSTENV(const X86::Instruction& insn)
      * |                |       TW      | 8
      * +----------------+---------------+
      * |               FIP              | 12
-     * +----+-----------+---------------+ 
+     * +----+-----------+---------------+
      * |0000|fpuOp[10:0]|    FIP_sel    | 16
-     * +----+-----------+---------------+ 
+     * +----+-----------+---------------+
      * |               FDP              | 20
-     * +----------------+---------------+ 
+     * +----------------+---------------+
      * |                |    FDP_ds     | 24
-     * +----------------|---------------+ 
+     * +----------------|---------------+
      * */
 
     auto address = insn.modrm().resolve(m_cpu, insn);

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -347,7 +347,7 @@ bool SoftMMU::fast_fill_memory8(X86::LogicalAddress address, size_t size, ValueW
 
     size_t offset_in_region = address.offset() - region->base();
     memset(region->data() + offset_in_region, value.value(), size);
-    memset(region->shadow_data() + offset_in_region, value.shadow(), size);
+    memset(region->shadow_data() + offset_in_region, value.shadow()[0], size);
     return true;
 }
 
@@ -372,7 +372,7 @@ bool SoftMMU::fast_fill_memory32(X86::LogicalAddress address, size_t count, Valu
 
     size_t offset_in_region = address.offset() - region->base();
     fast_u32_fill((u32*)(region->data() + offset_in_region), value.value(), count);
-    fast_u32_fill((u32*)(region->shadow_data() + offset_in_region), value.shadow(), count);
+    fast_u32_fill((u32*)(region->shadow_data() + offset_in_region), value.shadow_as_value(), count);
     return true;
 }
 

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.cpp
@@ -376,4 +376,9 @@ bool SoftMMU::fast_fill_memory32(X86::LogicalAddress address, size_t count, Valu
     return true;
 }
 
+void SoftMMU::dump_backtrace()
+{
+    m_emulator.dump_backtrace();
+}
+
 }

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Region.h"
+#include "Report.h"
 #include "ValueWithShadow.h"
 #include <AK/HashMap.h>
 #include <AK/NonnullOwnPtrVector.h>
@@ -28,6 +29,39 @@ public:
     ValueWithShadow<u64> read64(X86::LogicalAddress);
     ValueWithShadow<u128> read128(X86::LogicalAddress);
     ValueWithShadow<u256> read256(X86::LogicalAddress);
+
+    void dump_backtrace();
+
+    template<typename T>
+    ValueWithShadow<T> read(X86::LogicalAddress address) requires(IsTriviallyConstructible<T>)
+    {
+        auto* region = find_region(address);
+        if (!region) {
+            reportln("SoftMMU::read256: No region for @ {:p}", address.offset());
+            dump_backtrace();
+            TODO();
+        }
+
+        if (!region->is_readable()) {
+            reportln("SoftMMU::read256: Non-readable region @ {:p}", address.offset());
+            dump_backtrace();
+            TODO();
+        }
+
+        alignas(alignof(T)) u8 data[sizeof(T)];
+        Array<u8, sizeof(T)> shadow;
+
+        for (auto i = 0u; i < sizeof(T); ++i) {
+            auto result = region->read8(address.offset() - region->base() + i);
+            data[i] = result.value();
+            shadow[i] = result.shadow()[0];
+        }
+
+        return {
+            *bit_cast<T*>(&data[0]),
+            shadow,
+        };
+    }
 
     void write8(X86::LogicalAddress, ValueWithShadow<u8>);
     void write16(X86::LogicalAddress, ValueWithShadow<u16>);

--- a/Userland/DevTools/UserspaceEmulator/ValueWithShadow.h
+++ b/Userland/DevTools/UserspaceEmulator/ValueWithShadow.h
@@ -107,12 +107,6 @@ public:
     {
     }
 
-    ValueAndShadowReference(T& value, T& shadow)
-        : m_value(value)
-        , m_shadow(*bit_cast<ShadowType*>(&shadow))
-    {
-    }
-
     bool is_uninitialized() const
     {
         for (size_t i = 0; i < sizeof(ShadowType); ++i) {

--- a/Userland/Libraries/LibC/signal.h
+++ b/Userland/Libraries/LibC/signal.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/signal.h>
+#include <Kernel/API/POSIX/ucontext.h>
 #include <bits/sighow.h>
 #include <signal_numbers.h>
 #include <sys/types.h>

--- a/Userland/Libraries/LibC/sys/arch/i386/regs.h
+++ b/Userland/Libraries/LibC/sys/arch/i386/regs.h
@@ -14,80 +14,49 @@
 #    include <sys/types.h>
 #endif
 
-struct [[gnu::packed]] PtraceRegisters {
-#if ARCH(I386)
-    uint32_t eax;
-    uint32_t ecx;
-    uint32_t edx;
-    uint32_t ebx;
-    uint32_t esp;
-    uint32_t ebp;
-    uint32_t esi;
-    uint32_t edi;
-    uint32_t eip;
-    uint32_t eflags;
-#else
-    uint64_t rax;
-    uint64_t rcx;
-    uint64_t rdx;
-    uint64_t rbx;
-    uint64_t rsp;
-    uint64_t rbp;
-    uint64_t rsi;
-    uint64_t rdi;
-    uint64_t rip;
-    uint64_t r8;
-    uint64_t r9;
-    uint64_t r10;
-    uint64_t r11;
-    uint64_t r12;
-    uint64_t r13;
-    uint64_t r14;
-    uint64_t r15;
-    uint64_t rflags;
-#endif
-    uint32_t cs;
-    uint32_t ss;
-    uint32_t ds;
-    uint32_t es;
-    uint32_t fs;
-    uint32_t gs;
+#include <Kernel/Arch/mcontext.h>
 
-#if defined(__cplusplus) && defined(__cpp_concepts)
+#ifdef __cplusplus
+struct [[gnu::packed]] PtraceRegisters : public __mcontext {
+#    if defined(__cplusplus) && defined(__cpp_concepts)
     FlatPtr ip() const
     {
-#    if ARCH(I386)
+#        if ARCH(I386)
         return eip;
-#    else
+#        else
         return rip;
-#    endif
+#        endif
     }
 
     void set_ip(FlatPtr ip)
     {
-#    if ARCH(I386)
+#        if ARCH(I386)
         eip = ip;
-#    else
+#        else
         rip = ip;
-#    endif
+#        endif
     }
 
     FlatPtr bp() const
     {
-#    if ARCH(I386)
+#        if ARCH(I386)
         return ebp;
-#    else
+#        else
         return rbp;
-#    endif
+#        endif
     }
 
     void set_bp(FlatPtr bp)
     {
-#    if ARCH(I386)
+#        if ARCH(I386)
         ebp = bp;
-#    else
+#        else
         rbp = bp;
-#    endif
+#        endif
     }
-#endif
+#    endif
 };
+
+#else
+typedef struct __mcontext PthreadRegisters;
+#endif


### PR DESCRIPTION
The first two commits are from #12748, less pain to maintain like this.

Adds support for SA_SIGINFO, like you've always wanted
This includes a semi-dumb version of `ucontext` that probably can't do shit, and nice asm comments.