### PR TITLE
KeyboardSettings: Allow changing and applying active keymap

### DIFF
--- a/Userland/Applications/KeyboardSettings/Keyboard.gml
+++ b/Userland/Applications/KeyboardSettings/Keyboard.gml
@@ -40,6 +40,12 @@
                 }
 
                 @GUI::Button {
+                    name: "activate_keymap_button"
+                    text: "Activate keymap"
+                    enabled: false
+                }
+
+                @GUI::Button {
                     name: "add_keymap_button"
                     text: "Add keymap"
                 }

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -153,8 +153,8 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     auto json = JsonValue::from_string(proc_keymap->read_all()).release_value_but_fixme_should_propagate_errors();
     auto const& keymap_object = json.as_object();
     VERIFY(keymap_object.has("keymap"));
-    m_current_applied_keymap = keymap_object.get("keymap").to_string();
-    dbgln("KeyboardSettings thinks the current keymap is: {}", m_current_applied_keymap);
+    m_initial_active_keymap = keymap_object.get("keymap").to_string();
+    dbgln("KeyboardSettings thinks the current keymap is: {}", m_initial_active_keymap);
 
     auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini").release_value_but_fixme_should_propagate_errors());
     auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
@@ -171,7 +171,7 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
         keymaps_list_model.add_keymap(keymap);
     }
 
-    keymaps_list_model.set_active_keymap(m_current_applied_keymap);
+    keymaps_list_model.set_active_keymap(m_initial_active_keymap);
 
     m_add_keymap_button = find_descendant_of_type_named<GUI::Button>("add_keymap_button");
 

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.h
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.h
@@ -30,7 +30,7 @@ private:
 
     Vector<String> m_initial_keymap_list;
 
-    String m_current_applied_keymap;
+    String m_initial_active_keymap;
 
     RefPtr<GUI::ListView> m_selected_keymaps_listview;
     RefPtr<GUI::CheckBox> m_num_lock_checkbox;

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.h
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.h
@@ -26,14 +26,16 @@ public:
 private:
     KeyboardSettingsWidget();
 
-    void set_keymaps(Vector<String> const& keymaps);
+    void set_keymaps(Vector<String> const& keymaps, String const& active_keymap);
 
     Vector<String> m_initial_keymap_list;
 
     String m_initial_active_keymap;
 
     RefPtr<GUI::ListView> m_selected_keymaps_listview;
+    RefPtr<GUI::Label> m_active_keymap_label;
     RefPtr<GUI::CheckBox> m_num_lock_checkbox;
+    RefPtr<GUI::Button> m_activate_keymap_button;
     RefPtr<GUI::Button> m_add_keymap_button;
     RefPtr<GUI::Button> m_remove_keymap_button;
     RefPtr<GUI::TextEditor> m_test_typing_area;


### PR DESCRIPTION
The KeyboardSettings application previously only allowed to change the allowed keymaps on the system but not the active one. This changes the GUI and logic so that the active layout can also be viewed and set.

There's also one commit fixing a little bug and another doing a member variable rename.