### PR TITLE
LibLine: Update inline search cursor after kill_line (^U) command

### DIFF
--- a/Userland/Libraries/LibLine/InternalFunctions.cpp
+++ b/Userland/Libraries/LibLine/InternalFunctions.cpp
@@ -170,6 +170,7 @@ void Editor::kill_line()
     for (size_t i = 0; i < m_cursor; ++i)
         remove_at_index(0);
     m_cursor = 0;
+    m_inline_search_cursor = m_cursor;
     m_refresh_needed = true;
 }
 


### PR DESCRIPTION
After the kill_line (^U) command was used, searching backwards in the
history would still filter based on the text previous to the deletion.

Update the inline search cursor like already done in other internal
functions, so the text used for search is the current one.