### PR TITLE
Kernel: Allow setting AC'97 sample rate during playback

### DIFF
--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -145,6 +145,10 @@ ErrorOr<void> AC97::set_pcm_output_sample_rate(u32 sample_rate)
 
     dbgln("AC97 @ {}: PCM front DAC rate set to {} Hz", pci_address(), m_sample_rate);
 
+    // Setting the sample rate stops a running DMA engine, so restart it
+    if (m_pcm_out_channel.dma_running())
+        m_pcm_out_channel.start_dma();
+
     return {};
 }
 

--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -61,11 +61,10 @@ bool AC97::handle_irq(RegisterState const&)
     pcm_out_status_register.out(pcm_out_status);
 
     // Stop the DMA engine if we're through with the buffer and no one is waiting
-    if (is_dma_halted && m_irq_queue.is_empty()) {
+    if (is_dma_halted && m_irq_queue.is_empty())
         reset_pcm_out();
-    } else {
+    else
         m_irq_queue.wake_all();
-    }
     return true;
 }
 
@@ -187,9 +186,9 @@ ErrorOr<size_t> AC97::write(size_t channel_index, UserOrKernelBuffer const& data
     if (channel_index != 0)
         return Error::from_errno(ENODEV);
 
-    if (!m_output_buffer) {
+    if (!m_output_buffer)
         m_output_buffer = TRY(MM.allocate_dma_buffer_pages(m_output_buffer_page_count * PAGE_SIZE, "AC97 Output buffer"sv, Memory::Region::Access::Write));
-    }
+
     if (!m_buffer_descriptor_list) {
         size_t buffer_descriptor_list_size = buffer_descriptor_list_max_entries * sizeof(BufferDescriptorListEntry);
         buffer_descriptor_list_size = TRY(Memory::page_round_up(buffer_descriptor_list_size));
@@ -236,9 +235,8 @@ ErrorOr<void> AC97::write_single_buffer(UserOrKernelBuffer const& data, size_t o
     // Copy data from userspace into one of our buffers
     TRY(data.read(m_output_buffer->vaddr_from_page_index(m_output_buffer_page_index).as_ptr(), offset, length));
 
-    if (!m_pcm_out_channel.dma_running()) {
+    if (!m_pcm_out_channel.dma_running())
         reset_pcm_out();
-    }
 
     // Write the next entry to the buffer descriptor list
     u16 number_of_samples = length / sizeof(u16);
@@ -250,9 +248,8 @@ ErrorOr<void> AC97::write_single_buffer(UserOrKernelBuffer const& data, size_t o
     auto buffer_address = static_cast<u32>(m_buffer_descriptor_list->physical_page(0)->paddr().get());
     m_pcm_out_channel.set_last_valid_index(buffer_address, m_buffer_descriptor_list_index);
 
-    if (!m_pcm_out_channel.dma_running()) {
+    if (!m_pcm_out_channel.dma_running())
         m_pcm_out_channel.start_dma();
-    }
 
     m_output_buffer_page_index = (m_output_buffer_page_index + 1) % m_output_buffer_page_count;
     m_buffer_descriptor_list_index = (m_buffer_descriptor_list_index + 1) % buffer_descriptor_list_max_entries;

--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -135,7 +135,7 @@ private:
     private:
         IOAddress m_channel_base;
         AC97& m_device;
-        bool m_dma_running = false;
+        bool m_dma_running { false };
         StringView m_name;
     };
 
@@ -160,17 +160,17 @@ private:
     virtual ErrorOr<u32> get_pcm_output_sample_rate(size_t channel_index) override;
 
     OwnPtr<Memory::Region> m_buffer_descriptor_list;
-    u8 m_buffer_descriptor_list_index = 0;
-    bool m_double_rate_pcm_enabled = false;
+    u8 m_buffer_descriptor_list_index { 0 };
+    bool m_double_rate_pcm_enabled { false };
     IOAddress m_io_mixer_base;
     IOAddress m_io_bus_base;
     WaitQueue m_irq_queue;
     OwnPtr<Memory::Region> m_output_buffer;
-    u8 m_output_buffer_page_count = 4;
-    u8 m_output_buffer_page_index = 0;
+    u8 m_output_buffer_page_count { 4 };
+    u8 m_output_buffer_page_index { 0 };
     AC97Channel m_pcm_out_channel;
-    u32 m_sample_rate = 0;
-    bool m_variable_rate_pcm_supported = false;
+    u32 m_sample_rate { 0 };
+    bool m_variable_rate_pcm_supported { false };
     RefPtr<AudioChannel> m_audio_channel;
 };
 


### PR DESCRIPTION
The Qemu AC'97 device stops its PCM channel's DMA engine when it is running and the sample rate is changed. We now make sure the DMA engine is restarted after changing the sample rate, allowing you to e.g. run `asctl set r 22050` during `aplay` playback.

Also, a small cleanup commit is included for free.