### PR TITLE
Kernel: Defer signal handling without a register capture earlier 

### DIFF
--- a/Kernel/Arch/x86/x86_64/Processor.cpp
+++ b/Kernel/Arch/x86/x86_64/Processor.cpp
@@ -160,6 +160,7 @@ FlatPtr Processor::init_context(Thread& thread, bool leave_crit)
     regs.rip = FlatPtr(&thread_context_first_enter);
     regs.rsp0 = kernel_stack_top;
     regs.rsp = stack_top;
+    regs.cs = GDT_SELECTOR_CODE0;
     return stack_top;
 }
 

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -608,8 +608,8 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
     new_main_thread->reset_fpu_state();
 
     auto& regs = new_main_thread->m_regs;
-#if ARCH(I386)
     regs.cs = GDT_SELECTOR_CODE3 | 3;
+#if ARCH(I386)
     regs.ds = GDT_SELECTOR_DATA3 | 3;
     regs.es = GDT_SELECTOR_DATA3 | 3;
     regs.ss = GDT_SELECTOR_DATA3 | 3;


### PR DESCRIPTION
We were deferring the signal handling after already marking the signal as handling, which led to some failures in the Shell tests.

This does not seem to fix the segmentation faults that I'm able to reproduce by running Shell tests locally without KVM, but that seems to be a separate issue.