### PR TITLE
Spreadsheet: Simplify enabling/disabling actions on selection 

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -275,10 +275,13 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
             auto& sheet = *sheet_ptr;
 
             VERIFY(!selection.is_empty());
+            m_cut_action->set_enabled(true);
+            m_copy_action->set_enabled(true);
+            m_current_cell_label->set_enabled(true);
+            m_cell_value_editor->set_enabled(true);
 
             if (selection.size() == 1) {
                 auto& position = selection.first();
-                m_current_cell_label->set_enabled(true);
                 m_current_cell_label->set_text(position.to_cell_identifier(sheet));
 
                 auto& cell = sheet.ensure(position);
@@ -293,9 +296,6 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
                     sheet.update();
                     update();
                 };
-                m_cell_value_editor->set_enabled(true);
-                m_cut_action->set_enabled(true);
-                m_copy_action->set_enabled(true);
                 static_cast<CellSyntaxHighlighter*>(const_cast<Syntax::Highlighter*>(m_cell_value_editor->syntax_highlighter()))->set_cell(&cell);
                 return;
             }
@@ -303,7 +303,6 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
             // There are many cells selected, change all of them.
             StringBuilder builder;
             builder.appendff("<{}>", selection.size());
-            m_current_cell_label->set_enabled(true);
             m_current_cell_label->set_text(builder.string_view());
 
             Vector<Cell&> cells;
@@ -332,7 +331,6 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
                     update();
                 }
             };
-            m_cell_value_editor->set_enabled(true);
             static_cast<CellSyntaxHighlighter*>(const_cast<Syntax::Highlighter*>(m_cell_value_editor->syntax_highlighter()))->set_cell(&first_cell);
         };
         m_selected_view->on_selection_dropped = [&]() {

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -273,18 +273,8 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
             // How did this even happen?
             VERIFY(sheet_ptr);
             auto& sheet = *sheet_ptr;
-            if (selection.is_empty()) {
-                m_current_cell_label->set_enabled(false);
-                m_current_cell_label->set_text({});
-                m_cell_value_editor->on_change = nullptr;
-                m_cell_value_editor->on_focusin = nullptr;
-                m_cell_value_editor->on_focusout = nullptr;
-                m_cell_value_editor->set_text("");
-                m_cell_value_editor->set_enabled(false);
-                m_cut_action->set_enabled(false);
-                m_copy_action->set_enabled(false);
-                return;
-            }
+
+            VERIFY(!selection.is_empty());
 
             if (selection.size() == 1) {
                 auto& position = selection.first();
@@ -346,11 +336,18 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
             static_cast<CellSyntaxHighlighter*>(const_cast<Syntax::Highlighter*>(m_cell_value_editor->syntax_highlighter()))->set_cell(&first_cell);
         };
         m_selected_view->on_selection_dropped = [&]() {
-            m_cell_value_editor->set_enabled(false);
-            static_cast<CellSyntaxHighlighter*>(const_cast<Syntax::Highlighter*>(m_cell_value_editor->syntax_highlighter()))->set_cell(nullptr);
-            m_cell_value_editor->set_text("");
             m_current_cell_label->set_enabled(false);
-            m_current_cell_label->set_text("");
+            m_current_cell_label->set_text({});
+            m_cell_value_editor->on_change = nullptr;
+            m_cell_value_editor->on_focusin = nullptr;
+            m_cell_value_editor->on_focusout = nullptr;
+            m_cell_value_editor->set_text({});
+            m_cell_value_editor->set_enabled(false);
+
+            m_cut_action->set_enabled(false);
+            m_copy_action->set_enabled(false);
+
+            static_cast<CellSyntaxHighlighter*>(const_cast<Syntax::Highlighter*>(m_cell_value_editor->syntax_highlighter()))->set_cell(nullptr);
         };
     };
 


### PR DESCRIPTION
- **Spreadsheet: Move deselection instructions to on_selection_dropped**

  The previous code never executed, as SpreadsheetView splits selection events into `on_selection_changed` and `on_selection_dropped` depending on whether there is any selection.[^1]

- **Spreadsheet: Simplify enabling actions on selection**

  Since the function will *always* be called with some selection, we can straight up enable actions.

[^1]: https://github.com/SerenityOS/serenity/blob/e0de892f8f5535769e4aaf75e51f8f1a4f2d4cca/Userland/Applications/Spreadsheet/SpreadsheetView.cpp#L209-L220