### PR TITLE
Spreadsheet: Show the opened filename in the window title

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -140,6 +140,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
                 return;
 
             save(save_path.value());
+            update_window_title();
         } else {
             save(current_filename());
         }
@@ -152,9 +153,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
             return;
 
         save(save_path.value());
-
-        if (!current_filename().is_empty())
-            set_filename(current_filename());
+        update_window_title();
     });
 
     m_quit_action = GUI::CommonActions::make_quit_action([&](auto&) {
@@ -457,6 +456,7 @@ void SpreadsheetWidget::load_file(Core::File& file)
     }
 
     setup_tabs(m_workbook->sheets());
+    update_window_title();
 }
 
 bool SpreadsheetWidget::request_close()
@@ -473,6 +473,7 @@ bool SpreadsheetWidget::request_close()
                 return false;
 
             save(save_path.value());
+            update_window_title();
         } else {
             save(current_filename());
         }
@@ -506,16 +507,16 @@ void SpreadsheetWidget::add_sheet(NonnullRefPtr<Sheet>&& sheet)
     setup_tabs(new_sheets);
 }
 
-void SpreadsheetWidget::set_filename(const String& filename)
+void SpreadsheetWidget::update_window_title()
 {
-    if (m_workbook->set_filename(filename)) {
-        StringBuilder builder;
-        builder.append("Spreadsheet - ");
+    StringBuilder builder;
+    if (current_filename().is_empty())
+        builder.append("Untitled");
+    else
         builder.append(current_filename());
+    builder.append("[*] - Spreadsheet");
 
-        window()->set_title(builder.string_view());
-        window()->update();
-    }
+    window()->set_title(builder.to_string());
 }
 
 void SpreadsheetWidget::clipboard_action(bool is_cut)

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -27,7 +27,7 @@ public:
 
     const String& current_filename() const { return m_workbook->current_filename(); }
     Sheet* current_worksheet_if_available() { return m_selected_view ? m_selected_view->sheet_if_available() : nullptr; }
-    void set_filename(const String& filename);
+    void update_window_title();
 
     Workbook& workbook() { return *m_workbook; }
     const Workbook& workbook() const { return *m_workbook; }

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -54,13 +54,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-spreadsheet");
     auto window = GUI::Window::construct();
-    window->set_title("Spreadsheet");
     window->resize(640, 480);
     window->set_icon(app_icon.bitmap_for_size(16));
 
     auto& spreadsheet_widget = window->set_main_widget<Spreadsheet::SpreadsheetWidget>(*window, NonnullRefPtrVector<Spreadsheet::Sheet> {}, filename == nullptr);
 
     spreadsheet_widget.initialize_menubar(*window);
+    spreadsheet_widget.update_window_title();
 
     window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
         if (spreadsheet_widget.request_close())


### PR DESCRIPTION
Prior to this commit, there was a set_filename() function that could set the window title, but actually it never did that.  It was called only in one place — by the ‘Save as…’ action, but it always failed change anything, because there was a check that tried to reassign the same filename. :/

This patch:
1. removes that check, and therefore
2. renames the function to simply `update_window_title()`,
3. starts calling the function from more places (at startup and after loading a file),
4. changes the window title order (`{app_name} - {filename}` → `{filename} - {app_name}`) to match the other applications style on the system. :^)

![preview](https://user-images.githubusercontent.com/16520278/155882612-497744cd-d5df-4a15-b414-0bd6e44fce8a.png)
