### PR TITLE
LibWeb: Send Origin on WebSocket connection

### DIFF
--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.cpp
@@ -47,9 +47,9 @@ WebSocketClientManager::WebSocketClientManager(NonnullRefPtr<Protocol::WebSocket
 {
 }
 
-RefPtr<Protocol::WebSocket> WebSocketClientManager::connect(const AK::URL& url)
+RefPtr<Protocol::WebSocket> WebSocketClientManager::connect(const AK::URL& url, String const& origin)
 {
-    return m_websocket_client->connect(url);
+    return m_websocket_client->connect(url, origin);
 }
 
 // https://websockets.spec.whatwg.org/#dom-websocket-websocket
@@ -72,7 +72,8 @@ WebSocket::WebSocket(DOM::Window& window, AK::URL& url)
     , m_window(window)
 {
     // FIXME: Integrate properly with FETCH as per https://fetch.spec.whatwg.org/#websocket-opening-handshake
-    m_websocket = WebSocketClientManager::the().connect(url);
+    auto origin_string = m_window->associated_document().origin().serialize();
+    m_websocket = WebSocketClientManager::the().connect(url, origin_string);
     m_websocket->on_open = [weak_this = make_weak_ptr()] {
         if (!weak_this)
             return;

--- a/Userland/Libraries/LibWeb/WebSockets/WebSocket.h
+++ b/Userland/Libraries/LibWeb/WebSockets/WebSocket.h
@@ -35,7 +35,7 @@ class WebSocketClientManager : public Core::Object {
 public:
     static WebSocketClientManager& the();
 
-    RefPtr<Protocol::WebSocket> connect(const AK::URL&);
+    RefPtr<Protocol::WebSocket> connect(const AK::URL&, String const& origin);
 
 private:
     static ErrorOr<NonnullRefPtr<WebSocketClientManager>> try_create();


### PR DESCRIPTION
Some services using WebSockets require that the request contains the Origin header, otherwise these services will return a 403 Forbidden response. WebSocketServer already supports sending the Origin header, however LibWeb did not send the origin with the IPC request.

This pull request depends on the `Origin::serialize` method of #12594.