### PR TITLE
Kernel: AC'97 improvements

### DIFF
--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -50,7 +50,6 @@ bool AC97::handle_irq(RegisterState const&)
     bool current_equals_last_valid = (pcm_out_status & AudioStatusRegisterFlag::CurrentEqualsLastValid) > 0;
     bool is_completion_interrupt = (pcm_out_status & AudioStatusRegisterFlag::BufferCompletionInterruptStatus) > 0;
     bool is_fifo_error = (pcm_out_status & AudioStatusRegisterFlag::FIFOError) > 0;
-
     VERIFY(!is_fifo_error);
 
     // If there is no buffer completion, we're not going to do anything
@@ -171,6 +170,7 @@ RefPtr<AudioChannel> AC97::audio_channel(u32 index) const
         return m_audio_channel;
     return {};
 }
+
 void AC97::detect_hardware_audio_channels(Badge<AudioManagement>)
 {
     m_audio_channel = AudioChannel::must_create(*this, 0);
@@ -179,10 +179,11 @@ void AC97::detect_hardware_audio_channels(Badge<AudioManagement>)
 ErrorOr<void> AC97::set_pcm_output_sample_rate(size_t channel_index, u32 samples_per_second_rate)
 {
     if (channel_index != 0)
-        return Error::from_errno(ENODEV);
+        return ENODEV;
     TRY(set_pcm_output_sample_rate(samples_per_second_rate));
     return {};
 }
+
 ErrorOr<u32> AC97::get_pcm_output_sample_rate(size_t channel_index)
 {
     if (channel_index != 0)

--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -57,6 +57,7 @@ private:
         Revision21OrEarlier = 0b00,
         Revision22 = 0b01,
         Revision23 = 0b10,
+        Reserved = 0b11,
     };
 
     enum NativeAudioBusChannel : u8 {
@@ -162,6 +163,7 @@ private:
 
     OwnPtr<Memory::Region> m_buffer_descriptor_list;
     u8 m_buffer_descriptor_list_index { 0 };
+    AC97Revision m_codec_revision;
     bool m_double_rate_pcm_enabled { false };
     IOAddress m_io_mixer_base;
     IOAddress m_io_bus_base;

--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2021, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2021-2022, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Error.h>
 #include <Kernel/Arch/x86/IO.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Device.h>
@@ -145,7 +146,7 @@ private:
     virtual bool handle_irq(const RegisterState&) override;
 
     AC97Channel channel(StringView name, NativeAudioBusChannel channel) { return AC97Channel(*this, name, m_io_bus_base.offset(channel)); }
-    void initialize();
+    ErrorOr<void> initialize();
     void reset_pcm_out();
     void set_master_output_volume(u8, u8, Muted);
     ErrorOr<void> set_pcm_output_sample_rate(u32);

--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -128,6 +128,7 @@ private:
         }
 
         bool dma_running() const { return m_dma_running; }
+        void handle_dma_stopped();
         StringView name() const { return m_name; }
         IOAddress reg(Register reg) const { return m_channel_base.offset(reg); }
         void reset();
@@ -148,7 +149,6 @@ private:
 
     AC97Channel channel(StringView name, NativeAudioBusChannel channel) { return AC97Channel(*this, name, m_io_bus_base.offset(channel)); }
     ErrorOr<void> initialize();
-    void reset_pcm_out();
     void set_master_output_volume(u8, u8, Muted);
     ErrorOr<void> set_pcm_output_sample_rate(u32);
     void set_pcm_output_volume(u8, u8, Muted);

--- a/Kernel/Devices/Audio/Management.cpp
+++ b/Kernel/Devices/Audio/Management.cpp
@@ -45,8 +45,13 @@ UNMAP_AFTER_INIT void AudioManagement::enumerate_hardware_controllers()
             return;
 
         dbgln("AC97: found audio controller at {}", device_identifier.address());
-        // FIXME: Propagate errors properly
-        m_controllers_list.append(AC97::try_create(device_identifier).release_value());
+        auto ac97_device = AC97::try_create(device_identifier);
+        if (ac97_device.is_error()) {
+            // FIXME: Propagate errors properly
+            dbgln("AudioManagement: failed to initialize AC97 device: {}", ac97_device.error());
+            return;
+        }
+        m_controllers_list.append(ac97_device.release_value());
     });
 }
 


### PR DESCRIPTION
* Make `AC97` initialization fallible
* Read out codec revision version instead of `VERIFY`ing (CC @tomuta)
* Prevent excessive channel resetting by dealing with the actual buffer position instead