### PR TITLE
Kernel: Fixed behavior of repeated calls to register_string

### DIFF
--- a/Kernel/PerformanceEventBuffer.h
+++ b/Kernel/PerformanceEventBuffer.h
@@ -145,7 +145,7 @@ private:
     size_t m_count { 0 };
     NonnullOwnPtr<KBuffer> m_buffer;
 
-    HashTable<NonnullOwnPtr<KString>> m_strings;
+    HashMap<NonnullOwnPtr<KString>, size_t> m_strings;
 };
 
 extern bool g_profiling_all_threads;


### PR DESCRIPTION
Previously register_string would return incorrect values when
called multiple times with the same input. This patch makes this
function return the same index, identical strings. This change was required,
as this functionality is now being used with read syscall profiling,
#12465, which uses 'register_string' to registers file path on every
read syscall.
