### PR TITLE
LanguageServers/Cpp: Improve find declaration for various node types

### DIFF
--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -474,10 +474,20 @@ static Optional<TargetDeclaration> get_target_declaration(const ASTNode& node)
 
 static Optional<TargetDeclaration> get_target_declaration(const ASTNode& node, String name)
 {
-
     if (node.parent() && node.parent()->is_name()) {
-        if (&node != verify_cast<Name>(node.parent())->name()) {
+        auto& name_node = *verify_cast<Name>(node.parent());
+        if (&node != name_node.name()) {
+            // Node is part of scope reference chain
             return TargetDeclaration { TargetDeclaration::Type::Scope, name };
+        }
+        if (name_node.parent() && name_node.parent()->is_declaration()) {
+            auto declaration = verify_cast<Declaration>(name_node.parent());
+            if (declaration->is_struct_or_class()) {
+                return TargetDeclaration { TargetDeclaration::Type::Type, name };
+            }
+            if (declaration->is_function()) {
+                return TargetDeclaration { TargetDeclaration::Type::Function, name };
+            }
         }
     }
 

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/CppComprehensionEngine.cpp
@@ -482,7 +482,7 @@ static Optional<TargetDeclaration> get_target_declaration(const ASTNode& node, S
         }
         if (name_node.parent() && name_node.parent()->is_declaration()) {
             auto declaration = verify_cast<Declaration>(name_node.parent());
-            if (declaration->is_struct_or_class()) {
+            if (declaration->is_struct_or_class() || declaration->is_enum()) {
                 return TargetDeclaration { TargetDeclaration::Type::Type, name };
             }
             if (declaration->is_function()) {
@@ -517,7 +517,7 @@ RefPtr<Declaration> CppComprehensionEngine::find_declaration_of(const DocumentDa
     auto symbol_matches = [&](const Symbol& symbol) {
         bool match_function = target_decl.value().type == TargetDeclaration::Function && symbol.declaration->is_function();
         bool match_variable = target_decl.value().type == TargetDeclaration::Variable && symbol.declaration->is_variable_declaration();
-        bool match_type = target_decl.value().type == TargetDeclaration::Type && symbol.declaration->is_struct_or_class();
+        bool match_type = target_decl.value().type == TargetDeclaration::Type && (symbol.declaration->is_struct_or_class() || symbol.declaration->is_enum());
         bool match_property = target_decl.value().type == TargetDeclaration::Property && symbol.declaration->parent()->is_declaration() && verify_cast<Declaration>(symbol.declaration->parent())->is_struct_or_class();
         bool match_parameter = target_decl.value().type == TargetDeclaration::Variable && symbol.declaration->is_parameter();
         bool match_scope = target_decl.value().type == TargetDeclaration::Scope && (symbol.declaration->is_namespace() || symbol.declaration->is_struct_or_class());
@@ -990,7 +990,7 @@ GUI::AutocompleteProvider::TokenInfo::SemanticType CppComprehensionEngine::get_s
             return GUI::AutocompleteProvider::TokenInfo::SemanticType::Member;
         return GUI::AutocompleteProvider::TokenInfo::SemanticType::Variable;
     }
-    if (decl->is_struct_or_class())
+    if (decl->is_struct_or_class() || decl->is_enum())
         return GUI::AutocompleteProvider::TokenInfo::SemanticType::CustomType;
     if (decl->is_namespace())
         return GUI::AutocompleteProvider::TokenInfo::SemanticType::Namespace;

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -124,6 +124,7 @@ public:
     virtual bool is_class() const { return false; }
     virtual bool is_function() const { return false; }
     virtual bool is_namespace() const { return false; }
+    virtual bool is_enum() const { return false; }
     bool is_member() const { return parent() != nullptr && parent()->is_declaration() && verify_cast<Declaration>(parent())->is_struct_or_class(); }
     const Name* name() const { return m_name; }
     StringView full_name() const;
@@ -655,6 +656,7 @@ public:
     virtual ~EnumDeclaration() override = default;
     virtual const char* class_name() const override { return "EnumDeclaration"; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
+    virtual bool is_enum() const override { return true; }
 
     EnumDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
         : Declaration(parent, start, end, filename)

--- a/Userland/Libraries/LibCpp/Parser.cpp
+++ b/Userland/Libraries/LibCpp/Parser.cpp
@@ -1260,6 +1260,7 @@ NonnullRefPtr<Type> Parser::parse_type(ASTNode& parent)
     }
 
     if (peek().type() == Token::Type::LeftParen) {
+        type->set_end(previous_token_end());
         consume();
         auto fn_type = create_ast_node<FunctionType>(parent, type->start(), position());
         fn_type->set_return_type(*type);


### PR DESCRIPTION
This also improves semantic syntax highlighting as the declarations themselves of classes, functions and enums are now also highlighted.

Example:
![hs-improved-syntax-highlighting](https://user-images.githubusercontent.com/9247514/155896916-9271ffcd-1b7b-490b-9dbe-a6d3ce0dea90.png)
