### PR TITLE
LibVT: Fix crash from integer overflow in text wrapping

### DIFF
--- a/Userland/Libraries/LibVT/Line.cpp
+++ b/Userland/Libraries/LibVT/Line.cpp
@@ -28,7 +28,7 @@ void Line::rewrap(size_t new_length, Line* next_line, CursorPosition* cursor, bo
         m_cells.remove(m_terminated_at.value(), m_cells.size() - m_terminated_at.value());
 
     if (!next_line)
-        return m_cells.resize(new_length);
+        return set_length(new_length);
 
     if (old_length < new_length)
         take_cells_from_next_line(new_length, next_line, cursor_is_on_next_line, cursor);
@@ -39,6 +39,8 @@ void Line::rewrap(size_t new_length, Line* next_line, CursorPosition* cursor, bo
 void Line::set_length(size_t new_length)
 {
     m_cells.resize(new_length);
+    if (m_terminated_at.has_value())
+        m_terminated_at = min(*m_terminated_at, new_length);
 }
 
 void Line::push_cells_into_next_line(size_t new_length, Line* next_line, bool cursor_is_on_next_line, CursorPosition* cursor)
@@ -92,7 +94,7 @@ void Line::take_cells_from_next_line(size_t new_length, Line* next_line, bool cu
     auto cells_to_grab_from_next_line = min(new_length - length(), next_line->length());
     auto clear_next_line = false;
     if (next_line->m_terminated_at.has_value()) {
-        if (cells_to_grab_from_next_line == *next_line->m_terminated_at) {
+        if (cells_to_grab_from_next_line >= *next_line->m_terminated_at) {
             m_terminated_at = length() + *next_line->m_terminated_at;
             next_line->m_terminated_at.clear();
             clear_next_line = true;


### PR DESCRIPTION
Fixes the crash from #12786,  which would happen if the `m_terminated_at` was left longer than the line length after a resize,
leading to `cells_to_push_into_next_line` to overflow.

Another overflow was also possible if `cells_to_grab_from_next_line` was greater `m_terminated_at`