### PR TITLE
Base: Remove usermod and wc from the generated manpage list

### DIFF
--- a/Base/root/generate_manpages.sh
+++ b/Base/root/generate_manpages.sh
@@ -33,9 +33,7 @@ for i in ( \
             (traceroute 1) \
             (tree 1) \
             (truncate 1) \
-            (usermod 8) \
             (utmpupdate 1) \
-            (wc 1) \
         ) {
     filename="generated_manpages/man$i[1]/$i[0].md"
     mkdir -p "generated_manpages/man$i[1]"


### PR DESCRIPTION
These now have customizations that CI doesn't like.