### PR TITLE
Spreadsheet: Make function examples easier to read

### DIFF
--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -183,8 +183,8 @@ String HelpWindow::render(StringView key)
         VERIFY(examples.is_object());
         markdown_builder.append("# EXAMPLES\n");
         examples.as_object().for_each_member([&](auto& text, auto& description_value) {
-            dbgln("- {}\n\n```js\n{}\n```\n", description_value.to_string(), text);
-            markdown_builder.appendff("- {}\n\n```js\n{}\n```\n", description_value.to_string(), text);
+            dbgln("```js\n{}\n```\n\n- {}\n", text, description_value.to_string());
+            markdown_builder.appendff("```js\n{}\n```\n\n- {}\n", text, description_value.to_string());
         });
     }
 


### PR DESCRIPTION
Up until now, the Spreadsheet function examples appeared below their
descriptions. Let's swap them to make it clearer which JS example
goes to which description.

Addresses issue #12784.

![qemu-system-i386_0227201711849_Hd39ddD6Pf](https://user-images.githubusercontent.com/32465342/156052700-9ddd80f7-bf86-4550-b176-229784f1d0c6.png)

