### PR TITLE
LibJS: Add a QueueingConsoleClient to capture early console commands

### DIFF
--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -1,6 +1,11 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script>
+        let tempObj = [1, 2, 3];
+        console.log('This is a console.log from within <head> before anything else! What follows is a temporary array:', tempObj);
+        tempObj = null;
+    </script>
     <meta charset="UTF-8" />
     <title>Welcome!</title>
     <!-- this is a comment -->
@@ -194,6 +199,7 @@
         </ul>
     </nav>
     <script>
+        console.log('This is a console.log at the end of the <body> but not within queueMicrotask');
         queueMicrotask(function() {
             document.getElementById("loadtime").innerHTML = performance.now();
         });

--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -54,8 +54,9 @@ public:
     };
 
     explicit Console(GlobalObject&);
+    ~Console();
 
-    void set_client(ConsoleClient& client) { m_client = &client; }
+    void set_client(ConsoleClient& client);
 
     GlobalObject& global_object() { return m_global_object; }
     const GlobalObject& global_object() const { return m_global_object; }


### PR DESCRIPTION
Now you can `console.log` in HTML to your hearts content