### PR TITLE
LibC: Clean up sys/cdefs.h a bit

### DIFF
--- a/Userland/Libraries/LibC/serenity.h
+++ b/Userland/Libraries/LibC/serenity.h
@@ -22,6 +22,11 @@ int profiling_free_buffer(pid_t);
 
 int futex(uint32_t* userspace_address, int futex_op, uint32_t value, const struct timespec* timeout, uint32_t* userspace_address2, uint32_t value3);
 
+#ifndef ALWAYS_INLINE
+#    define ALWAYS_INLINE inline __attribute__((always_inline))
+#    define ALWAYS_INLINE_SERENITY_H
+#endif
+
 static ALWAYS_INLINE int futex_wait(uint32_t* userspace_address, uint32_t value, const struct timespec* abstime, int clockid)
 {
     int op;
@@ -41,6 +46,10 @@ static ALWAYS_INLINE int futex_wake(uint32_t* userspace_address, uint32_t count)
 {
     return futex(userspace_address, FUTEX_WAKE, count, NULL, NULL, 0);
 }
+
+#ifdef ALWAYS_INLINE_SERENITY_H
+#    undef ALWAYS_INLINE
+#endif
 
 int purge(int mode);
 

--- a/Userland/Libraries/LibC/stddef.h
+++ b/Userland/Libraries/LibC/stddef.h
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#define offsetof(type, member) __builtin_offsetof(type, member)
+
 #ifndef KERNEL
 
 #    include <sys/cdefs.h>

--- a/Userland/Libraries/LibC/sys/cdefs.h
+++ b/Userland/Libraries/LibC/sys/cdefs.h
@@ -8,10 +8,6 @@
 
 #define _POSIX_VERSION 200809L
 
-#ifndef ALWAYS_INLINE
-#    define ALWAYS_INLINE inline __attribute__((always_inline))
-#endif
-
 #ifdef __cplusplus
 #    ifndef __BEGIN_DECLS
 #        define __BEGIN_DECLS extern "C" {

--- a/Userland/Libraries/LibC/sys/cdefs.h
+++ b/Userland/Libraries/LibC/sys/cdefs.h
@@ -22,5 +22,3 @@
 
 #undef __P
 #define __P(a) a
-
-#define offsetof(type, member) __builtin_offsetof(type, member)


### PR DESCRIPTION
- Don't export ALWAYS_INLINE from cdefs.h, macro pollution isn't nice.
- Define offsetof in stddef.h, where it belongs :posix: