### PR TITLE
KeyboardSettings: Fix adding empty keymaps

### DIFF
--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -163,7 +163,8 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
 
     m_add_keymap_button->on_click = [&](auto) {
         auto keymap = KeymapSelectionDialog::select_keymap(window(), keymaps_list_model.keymaps());
-        keymaps_list_model.add_keymap(keymap);
+        if (!keymap.is_empty())
+            keymaps_list_model.add_keymap(keymap);
     };
 
     m_remove_keymap_button = find_descendant_of_type_named<GUI::Button>("remove_keymap_button");


### PR DESCRIPTION
In the Keymap Settings dialog, a check was missing
when the Keymap selection dialog was cancelled.

Not checking the return value causes an empty string
to be added to the keymap list.