### PR TITLE
LibWeb: Implement <button>'s activation behaviour and the required infrastructure

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/AttributeNames.h
+++ b/Userland/Libraries/LibWeb/HTML/AttributeNames.h
@@ -61,6 +61,7 @@ namespace AttributeNames {
     __ENUMERATE_HTML_ATTRIBUTE(event)                      \
     __ENUMERATE_HTML_ATTRIBUTE(face)                       \
     __ENUMERATE_HTML_ATTRIBUTE(for_)                       \
+    __ENUMERATE_HTML_ATTRIBUTE(form)                       \
     __ENUMERATE_HTML_ATTRIBUTE(formnovalidate)             \
     __ENUMERATE_HTML_ATTRIBUTE(formtarget)                 \
     __ENUMERATE_HTML_ATTRIBUTE(frame)                      \

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -5,7 +5,13 @@
  */
 
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLButtonElement.h>
+#include <LibWeb/HTML/HTMLFieldSetElement.h>
 #include <LibWeb/HTML/HTMLFormElement.h>
+#include <LibWeb/HTML/HTMLInputElement.h>
+#include <LibWeb/HTML/HTMLLegendElement.h>
+#include <LibWeb/HTML/HTMLSelectElement.h>
+#include <LibWeb/HTML/HTMLTextAreaElement.h>
 
 namespace Web::HTML {
 
@@ -16,6 +22,27 @@ void FormAssociatedElement::set_form(HTMLFormElement* form)
     m_form = form;
     if (m_form)
         m_form->add_associated_element({}, *this);
+}
+
+bool FormAssociatedElement::enabled() const
+{
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled
+
+    // A form control is disabled if any of the following conditions are met:
+    // 1. The element is a button, input, select, textarea, or form-associated custom element, and the disabled attribute is specified on this element (regardless of its value).
+    // FIXME: This doesn't check for form-associated custom elements.
+    if ((is<HTMLButtonElement>(this) || is<HTMLInputElement>(this) || is<HTMLSelectElement>(this) || is<HTMLTextAreaElement>(this)) && has_attribute(HTML::AttributeNames::disabled))
+        return false;
+
+    // 2. The element is a descendant of a fieldset element whose disabled attribute is specified, and is not a descendant of that fieldset element's first legend element child, if any.
+    auto* fieldset_ancestor = first_ancestor_of_type<HTMLFieldSetElement>();
+    if (fieldset_ancestor && fieldset_ancestor->has_attribute(HTML::AttributeNames::disabled)) {
+        auto* first_legend_element_child = fieldset_ancestor->first_child_of_type<HTMLLegendElement>();
+        if (!first_legend_element_child || !is_descendant_of(*first_legend_element_child))
+            return false;
+    }
+
+    return true;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -21,6 +21,18 @@ public:
 
     bool enabled() const;
 
+    // https://html.spec.whatwg.org/multipage/forms.html#category-listed
+    virtual bool is_listed() const { return false; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-submit
+    virtual bool is_submittable() const { return false; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-reset
+    virtual bool is_resettable() const { return false; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
+    virtual bool is_auto_capitalize_inheriting() const { return false; }
+
 protected:
     FormAssociatedElement(DOM::Document& document, DOM::QualifiedName qualified_name)
         : HTMLElement(document, move(qualified_name))

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -21,6 +21,8 @@ public:
 
     bool enabled() const;
 
+    void set_parser_inserted(Badge<HTMLParser>) { m_parser_inserted = true; }
+
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed
     virtual bool is_listed() const { return false; }
 
@@ -43,6 +45,15 @@ protected:
 
 private:
     WeakPtr<HTMLFormElement> m_form;
+
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#parser-inserted-flag
+    bool m_parser_inserted { false };
+
+    void reset_form_owner();
+
+    // ^DOM::Node
+    virtual void inserted() override;
+    virtual void removed_from(DOM::Node*) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -19,6 +19,8 @@ public:
 
     void set_form(HTMLFormElement*);
 
+    bool enabled() const;
+
 protected:
     FormAssociatedElement(DOM::Document& document, DOM::QualifiedName qualified_name)
         : HTMLElement(document, move(qualified_name))

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -17,4 +17,37 @@ HTMLButtonElement::~HTMLButtonElement()
 {
 }
 
+String HTMLButtonElement::type() const
+{
+    auto value = attribute(HTML::AttributeNames::type);
+
+#define __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(keyword, _) \
+    if (value.equals_ignoring_case(#keyword))              \
+        return #keyword;
+    ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTES
+#undef __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE
+
+    // The missing value default and invalid value default are the Submit Button state.
+    return "submit";
+}
+
+HTMLButtonElement::TypeAttributeState HTMLButtonElement::type_state() const
+{
+    auto value = attribute(HTML::AttributeNames::type);
+
+#define __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(keyword, state) \
+    if (value.equals_ignoring_case(#keyword))                  \
+        return HTMLButtonElement::TypeAttributeState::state;
+    ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTES
+#undef __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE
+
+    // The missing value default and invalid value default are the Submit Button state.
+    return HTMLButtonElement::TypeAttributeState::Submit;
+}
+
+void HTMLButtonElement::set_type(String const& type)
+{
+    set_attribute(HTML::AttributeNames::type, type);
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -4,13 +4,49 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLButtonElement.h>
+#include <LibWeb/HTML/HTMLFormElement.h>
 
 namespace Web::HTML {
 
 HTMLButtonElement::HTMLButtonElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : FormAssociatedElement(document, move(qualified_name))
 {
+    // https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element:activation-behaviour
+    activation_behavior = [this](auto&) {
+        // 1. If element is disabled, then return.
+        if (!enabled())
+            return;
+
+        // 2. If element does not have a form owner, then return.
+        if (!form())
+            return;
+
+        // 3. If element's node document is not fully active, then return.
+        if (!this->document().is_fully_active())
+            return;
+
+        // 4. Switch on element's type attribute's state:
+        switch (type_state()) {
+        case TypeAttributeState::Submit:
+            // Submit Button
+            // Submit element's form owner from element.
+            form()->submit_form(this);
+            break;
+        case TypeAttributeState::Reset:
+            // Reset Button
+            // FIXME: Reset element's form owner.
+            TODO();
+            break;
+        case TypeAttributeState::Button:
+            // Button
+            // Do nothing.
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    };
 }
 
 HTMLButtonElement::~HTMLButtonElement()

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -16,6 +16,20 @@ public:
 
     HTMLButtonElement(DOM::Document&, DOM::QualifiedName);
     virtual ~HTMLButtonElement() override;
+
+    // ^FormAssociatedElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-listed
+    virtual bool is_listed() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-submit
+    virtual bool is_submittable() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
+    virtual bool is_auto_capitalize_inheriting() const override { return true; }
+
+    // ^HTMLElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-label
+    virtual bool is_labelable() const override { return true; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -10,12 +10,27 @@
 
 namespace Web::HTML {
 
+#define ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTES              \
+    __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(submit, Submit) \
+    __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(reset, Reset)   \
+    __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(button, Button)
+
 class HTMLButtonElement final : public FormAssociatedElement {
 public:
     using WrapperType = Bindings::HTMLButtonElementWrapper;
 
     HTMLButtonElement(DOM::Document&, DOM::QualifiedName);
     virtual ~HTMLButtonElement() override;
+
+    enum class TypeAttributeState {
+#define __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(_, state) state,
+        ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTES
+#undef __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE
+    };
+
+    String type() const;
+    TypeAttributeState type_state() const;
+    void set_type(String const&);
 
     // ^FormAssociatedElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.idl
@@ -6,5 +6,6 @@ interface HTMLButtonElement : HTMLElement {
     [Reflect=formtarget] attribute DOMString formTarget;
     [Reflect] attribute DOMString name;
     [Reflect] attribute DOMString value;
+    [CEReactions] attribute DOMString type;
 
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.h
@@ -46,6 +46,9 @@ public:
 
     bool fire_a_synthetic_pointer_event(FlyString const& type, DOM::Element& target, bool not_trusted);
 
+    // https://html.spec.whatwg.org/multipage/forms.html#category-label
+    virtual bool is_labelable() const { return false; }
+
 protected:
     virtual void parse_attribute(const FlyString& name, const String& value) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -22,6 +22,13 @@ public:
         static String fieldset = "fieldset";
         return fieldset;
     }
+
+    // ^FormAssociatedElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-listed
+    virtual bool is_listed() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
+    virtual bool is_auto_capitalize_inheriting() const override { return true; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -191,18 +191,6 @@ bool HTMLInputElement::is_focusable() const
     return m_text_node;
 }
 
-void HTMLInputElement::inserted()
-{
-    HTMLElement::inserted();
-    set_form(first_ancestor_of_type<HTMLFormElement>());
-}
-
-void HTMLInputElement::removed_from(DOM::Node* old_parent)
-{
-    HTMLElement::removed_from(old_parent);
-    set_form(nullptr);
-}
-
 void HTMLInputElement::parse_attribute(FlyString const& name, String const& value)
 {
     FormAssociatedElement::parse_attribute(name, value);

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -138,11 +138,6 @@ void HTMLInputElement::did_edit_text_node(Badge<BrowsingContext>)
     });
 }
 
-bool HTMLInputElement::enabled() const
-{
-    return !has_attribute(HTML::AttributeNames::disabled);
-}
-
 String HTMLInputElement::value() const
 {
     if (m_text_node)

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -83,6 +83,23 @@ public:
     virtual void parse_attribute(FlyString const&, String const&) override;
     virtual void did_remove_attribute(FlyString const&) override;
 
+    // ^FormAssociatedElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-listed
+    virtual bool is_listed() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-submit
+    virtual bool is_submittable() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-reset
+    virtual bool is_resettable() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
+    virtual bool is_auto_capitalize_inheriting() const override { return true; }
+
+    // ^HTMLElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-label
+    virtual bool is_labelable() const override { return type_state() != TypeAttributeState::Hidden; }
+
 private:
     // ^DOM::Node
     virtual void inserted() override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -101,10 +101,6 @@ public:
     virtual bool is_labelable() const override { return type_state() != TypeAttributeState::Hidden; }
 
 private:
-    // ^DOM::Node
-    virtual void inserted() override;
-    virtual void removed_from(Node*) override;
-
     // ^DOM::EventTarget
     virtual void did_receive_focus() override;
     virtual void run_activation_behavior() override;

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -73,8 +73,6 @@ public:
     };
     void set_checked(bool, ChangeSource = ChangeSource::Programmatic, ShouldRunActivationBehavior = ShouldRunActivationBehavior::Yes);
 
-    bool enabled() const;
-
     void did_click_button(Badge<Layout::ButtonBox>);
     void did_click_checkbox(Badge<Layout::CheckBox>);
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLMeterElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,6 +17,10 @@ public:
 
     HTMLMeterElement(DOM::Document&, DOM::QualifiedName);
     virtual ~HTMLMeterElement() override;
+
+    // ^HTMLElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-label
+    virtual bool is_labelable() const override { return true; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -25,6 +25,10 @@ public:
     String data() const { return attribute(HTML::AttributeNames::data); }
     String type() const { return attribute(HTML::AttributeNames::type); }
 
+    // ^FormAssociatedElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-listed
+    virtual bool is_listed() const override { return true; }
+
 private:
     virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,6 +23,20 @@ public:
         static String output = "output";
         return output;
     }
+
+    // ^FormAssociatedElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-listed
+    virtual bool is_listed() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
+    virtual bool is_resettable() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
+    virtual bool is_auto_capitalize_inheriting() const override { return true; }
+
+    // ^HTMLElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-label
+    virtual bool is_labelable() const override { return true; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLProgressElement.h
@@ -27,6 +27,10 @@ public:
 
     double position() const;
 
+    // ^HTMLElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-label
+    virtual bool is_labelable() const override { return true; }
+
 private:
     bool is_determinate() const { return has_attribute(HTML::AttributeNames::value); }
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -19,16 +19,4 @@ HTMLSelectElement::~HTMLSelectElement()
 {
 }
 
-void HTMLSelectElement::inserted()
-{
-    HTMLElement::inserted();
-    set_form(first_ancestor_of_type<HTMLFormElement>());
-}
-
-void HTMLSelectElement::removed_from(DOM::Node* old_parent)
-{
-    HTMLElement::removed_from(old_parent);
-    set_form(nullptr);
-}
-
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -18,6 +19,23 @@ public:
 
     HTMLSelectElement(DOM::Document&, DOM::QualifiedName);
     virtual ~HTMLSelectElement() override;
+
+    // ^FormAssociatedElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-listed
+    virtual bool is_listed() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-submit
+    virtual bool is_submittable() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-reset
+    virtual bool is_resettable() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
+    virtual bool is_auto_capitalize_inheriting() const override { return true; }
+
+    // ^HTMLElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-label
+    virtual bool is_labelable() const override { return true; }
 
 private:
     // ^DOM::Node

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -36,11 +36,6 @@ public:
     // ^HTMLElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return true; }
-
-private:
-    // ^DOM::Node
-    virtual void inserted() override;
-    virtual void removed_from(DOM::Node*) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -22,6 +23,23 @@ public:
         static String textarea = "textarea";
         return textarea;
     }
+
+    // ^FormAssociatedElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-listed
+    virtual bool is_listed() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-submit
+    virtual bool is_submittable() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-reset
+    virtual bool is_resettable() const override { return true; }
+
+    // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
+    virtual bool is_auto_capitalize_inheriting() const override { return true; }
+
+    // ^HTMLElement
+    // https://html.spec.whatwg.org/multipage/forms.html#category-label
+    virtual bool is_labelable() const override { return true; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.h
@@ -113,7 +113,7 @@ private:
 
     void generate_implied_end_tags(const FlyString& exception = {});
     void generate_all_implied_end_tags_thoroughly();
-    NonnullRefPtr<DOM::Element> create_element_for(const HTMLToken&, const FlyString& namespace_);
+    NonnullRefPtr<DOM::Element> create_element_for(HTMLToken const&, FlyString const& namespace_, DOM::Node const& intended_parent);
 
     struct AdjustedInsertionLocation {
         RefPtr<DOM::Node> parent;


### PR DESCRIPTION
This allows us to submit forms from `<button>` elements and not just
`<input type="submit">`

This allows Discord to progress past the username registration :^)

https://user-images.githubusercontent.com/25595356/156249932-e3806553-9973-4b49-b433-eb5068867c64.mp4