### PR TITLE
LibWeb: Fix incorrect check in BrowsingContext::is_top_level

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -57,6 +57,13 @@ void BrowsingContext::reset_cursor_blink_cycle()
     m_cursor_position.node()->layout_node()->set_needs_display();
 }
 
+// https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context
+bool BrowsingContext::is_top_level() const
+{
+    // A browsing context that has no parent browsing context is the top-level browsing context for itself and all of the browsing contexts for which it is an ancestor browsing context.
+    return !parent();
+}
+
 bool BrowsingContext::is_focused_context() const
 {
     return m_page && &m_page->focused_context() == this;

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -36,7 +36,7 @@ public:
     void register_viewport_client(ViewportClient&);
     void unregister_viewport_client(ViewportClient&);
 
-    bool is_top_level() const { return !container(); }
+    bool is_top_level() const;
     bool is_focused_context() const;
 
     DOM::Document const* active_document() const { return m_active_document; }


### PR DESCRIPTION
A top level browsing context is a browsing context with no parent
browsing context.

However, we considered a top level browsing context to be a browsing
context with no associated browsing context container.