### PR TITLE
SoundPlayer: Show album cover in the Album Cover visualization

### DIFF
--- a/Userland/Applications/SoundPlayer/AlbumCoverVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/AlbumCoverVisualizationWidget.cpp
@@ -6,12 +6,12 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "NoVisualizationWidget.h"
+#include "AlbumCoverVisualizationWidget.h"
 #include <AK/LexicalPath.h>
 #include <LibCore/File.h>
 #include <LibGUI/Painter.h>
 
-void NoVisualizationWidget::paint_event(GUI::PaintEvent& event)
+void AlbumCoverVisualizationWidget::paint_event(GUI::PaintEvent& event)
 {
     Frame::paint_event(event);
     GUI::Painter painter(*this);
@@ -25,7 +25,7 @@ void NoVisualizationWidget::paint_event(GUI::PaintEvent& event)
     }
 }
 
-ErrorOr<NonnullRefPtr<Gfx::Bitmap>> NoVisualizationWidget::get_album_cover(StringView const filename)
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> AlbumCoverVisualizationWidget::get_album_cover(StringView const filename)
 {
     auto directory = LexicalPath::dirname(filename);
 
@@ -39,7 +39,7 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> NoVisualizationWidget::get_album_cover(Strin
     return Error::from_string_literal("No cover file found");
 }
 
-void NoVisualizationWidget::start_new_file(StringView filename)
+void AlbumCoverVisualizationWidget::start_new_file(StringView filename)
 {
     auto album_cover_or_error = get_album_cover(filename);
     if (album_cover_or_error.is_error())
@@ -48,6 +48,6 @@ void NoVisualizationWidget::start_new_file(StringView filename)
         m_album_cover = album_cover_or_error.value();
 }
 
-void NoVisualizationWidget::set_buffer(RefPtr<Audio::Buffer>)
+void AlbumCoverVisualizationWidget::set_buffer(RefPtr<Audio::Buffer>)
 {
 }

--- a/Userland/Applications/SoundPlayer/AlbumCoverVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/AlbumCoverVisualizationWidget.cpp
@@ -10,6 +10,7 @@
 #include <AK/LexicalPath.h>
 #include <LibCore/File.h>
 #include <LibGUI/Painter.h>
+#include <LibGfx/Rect.h>
 
 void AlbumCoverVisualizationWidget::paint_event(GUI::PaintEvent& event)
 {
@@ -17,7 +18,16 @@ void AlbumCoverVisualizationWidget::paint_event(GUI::PaintEvent& event)
     GUI::Painter painter(*this);
 
     if (m_album_cover) {
-        painter.draw_scaled_bitmap(frame_inner_rect(), *m_album_cover, m_album_cover->rect(), 1.0f);
+        auto album_cover_rect = m_album_cover->rect();
+
+        auto height_ratio = frame_inner_rect().height() / (float)album_cover_rect.height();
+        auto width_ratio = frame_inner_rect().width() / (float)album_cover_rect.width();
+        auto scale = min(height_ratio, width_ratio);
+
+        Gfx::IntRect fitted_rect = { 0, 0, (int)(album_cover_rect.width() * scale), (int)(album_cover_rect.height() * scale) };
+        fitted_rect.center_within(frame_inner_rect());
+
+        painter.draw_scaled_bitmap(fitted_rect, *m_album_cover, m_album_cover->rect(), 1.0f);
     } else {
         if (!m_serenity_bg)
             m_serenity_bg = Gfx::Bitmap::try_load_from_file("/res/wallpapers/sunset-retro.png").release_value_but_fixme_should_propagate_errors();

--- a/Userland/Applications/SoundPlayer/AlbumCoverVisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/AlbumCoverVisualizationWidget.h
@@ -11,17 +11,17 @@
 #include <LibAudio/Buffer.h>
 #include <LibGUI/Frame.h>
 
-class NoVisualizationWidget final : public VisualizationWidget {
-    C_OBJECT(NoVisualizationWidget)
+class AlbumCoverVisualizationWidget final : public VisualizationWidget {
+    C_OBJECT(AlbumCoverVisualizationWidget)
 
 public:
-    ~NoVisualizationWidget() override = default;
+    ~AlbumCoverVisualizationWidget() override = default;
     void set_buffer(RefPtr<Audio::Buffer>) override;
     void start_new_file(StringView) override;
 
 private:
     void paint_event(GUI::PaintEvent&) override;
-    NoVisualizationWidget() = default;
+    AlbumCoverVisualizationWidget() = default;
     ErrorOr<NonnullRefPtr<Gfx::Bitmap>> get_album_cover(StringView const filename);
 
     RefPtr<Gfx::Bitmap> m_serenity_bg;

--- a/Userland/Applications/SoundPlayer/CMakeLists.txt
+++ b/Userland/Applications/SoundPlayer/CMakeLists.txt
@@ -6,16 +6,16 @@ serenity_component(
 )
 
 set(SOURCES
-    main.cpp
+    AlbumCoverVisualizationWidget.cpp
+    BarsVisualizationWidget.cpp
+    M3UParser.cpp
+    PlaybackManager.cpp
     Player.cpp
     Playlist.cpp
-    PlaybackManager.cpp
+    PlaylistWidget.cpp
     SampleWidget.cpp
     SoundPlayerWidgetAdvancedView.cpp
-    BarsVisualizationWidget.cpp
-    AlbumCoverVisualizationWidget.cpp
-    M3UParser.cpp
-    PlaylistWidget.cpp
+    main.cpp
 )
 
 serenity_app(SoundPlayer ICON app-sound-player)

--- a/Userland/Applications/SoundPlayer/CMakeLists.txt
+++ b/Userland/Applications/SoundPlayer/CMakeLists.txt
@@ -13,7 +13,7 @@ set(SOURCES
     SampleWidget.cpp
     SoundPlayerWidgetAdvancedView.cpp
     BarsVisualizationWidget.cpp
-    NoVisualizationWidget.cpp
+    AlbumCoverVisualizationWidget.cpp
     M3UParser.cpp
     PlaylistWidget.cpp
 )

--- a/Userland/Applications/SoundPlayer/NoVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/NoVisualizationWidget.cpp
@@ -1,11 +1,14 @@
 /*
  * Copyright (c) 2021, Cesar Torres <shortanemoia@protonmail.com>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Nícolas F. R. A. Prado <n@nfraprado.net>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "NoVisualizationWidget.h"
+#include <AK/LexicalPath.h>
+#include <LibCore/File.h>
 #include <LibGUI/Painter.h>
 
 void NoVisualizationWidget::paint_event(GUI::PaintEvent& event)
@@ -13,9 +16,36 @@ void NoVisualizationWidget::paint_event(GUI::PaintEvent& event)
     Frame::paint_event(event);
     GUI::Painter painter(*this);
 
-    if (!m_serenity_bg)
-        m_serenity_bg = Gfx::Bitmap::try_load_from_file("/res/wallpapers/sunset-retro.png").release_value_but_fixme_should_propagate_errors();
-    painter.draw_scaled_bitmap(frame_inner_rect(), *m_serenity_bg, m_serenity_bg->rect(), 1.0f);
+    if (m_album_cover) {
+        painter.draw_scaled_bitmap(frame_inner_rect(), *m_album_cover, m_album_cover->rect(), 1.0f);
+    } else {
+        if (!m_serenity_bg)
+            m_serenity_bg = Gfx::Bitmap::try_load_from_file("/res/wallpapers/sunset-retro.png").release_value_but_fixme_should_propagate_errors();
+        painter.draw_scaled_bitmap(frame_inner_rect(), *m_serenity_bg, m_serenity_bg->rect(), 1.0f);
+    }
+}
+
+ErrorOr<NonnullRefPtr<Gfx::Bitmap>> NoVisualizationWidget::get_album_cover(StringView const filename)
+{
+    auto directory = LexicalPath::dirname(filename);
+
+    static constexpr auto possible_cover_filenames = Array { "cover.png"sv, "cover.jpg"sv };
+    for (auto& it : possible_cover_filenames) {
+        LexicalPath cover_path = LexicalPath::join(directory, it);
+        if (Core::File::exists(cover_path.string()))
+            return Gfx::Bitmap::try_load_from_file(cover_path.string());
+    }
+
+    return Error::from_string_literal("No cover file found");
+}
+
+void NoVisualizationWidget::start_new_file(StringView filename)
+{
+    auto album_cover_or_error = get_album_cover(filename);
+    if (album_cover_or_error.is_error())
+        m_album_cover = nullptr;
+    else
+        m_album_cover = album_cover_or_error.value();
 }
 
 void NoVisualizationWidget::set_buffer(RefPtr<Audio::Buffer>)

--- a/Userland/Applications/SoundPlayer/NoVisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/NoVisualizationWidget.h
@@ -17,10 +17,13 @@ class NoVisualizationWidget final : public VisualizationWidget {
 public:
     ~NoVisualizationWidget() override = default;
     void set_buffer(RefPtr<Audio::Buffer>) override;
+    void start_new_file(StringView) override;
 
 private:
     void paint_event(GUI::PaintEvent&) override;
     NoVisualizationWidget() = default;
+    ErrorOr<NonnullRefPtr<Gfx::Bitmap>> get_album_cover(StringView const filename);
 
     RefPtr<Gfx::Bitmap> m_serenity_bg;
+    RefPtr<Gfx::Bitmap> m_album_cover;
 };

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.cpp
@@ -206,6 +206,7 @@ void SoundPlayerWidgetAdvancedView::time_elapsed(int seconds)
 
 void SoundPlayerWidgetAdvancedView::file_name_changed(StringView name)
 {
+    m_visualization->start_new_file(name);
     m_window.set_title(String::formatted("{} - Sound Player", name));
 }
 

--- a/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
+++ b/Userland/Applications/SoundPlayer/SoundPlayerWidgetAdvancedView.h
@@ -32,6 +32,8 @@ public:
         auto new_visualization = T::construct();
         m_player_view->insert_child_before(new_visualization, *static_cast<Core::Object*>(m_playback_progress_slider.ptr()));
         m_visualization = new_visualization;
+        if (!loaded_filename().is_empty())
+            m_visualization->start_new_file(loaded_filename());
     }
 
     virtual void play_state_changed(PlayState) override;

--- a/Userland/Applications/SoundPlayer/VisualizationWidget.h
+++ b/Userland/Applications/SoundPlayer/VisualizationWidget.h
@@ -15,6 +15,7 @@ class VisualizationWidget : public GUI::Frame {
 public:
     virtual void set_buffer(RefPtr<Audio::Buffer> buffer) = 0;
     virtual void set_samplerate(int) { }
+    virtual void start_new_file(StringView) { }
 
 protected:
     VisualizationWidget() = default;

--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "AlbumCoverVisualizationWidget.h"
 #include "BarsVisualizationWidget.h"
-#include "NoVisualizationWidget.h"
 #include "Player.h"
 #include "SampleWidget.h"
 #include "SoundPlayerWidgetAdvancedView.h"
@@ -124,11 +124,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(visualization_menu->try_add_action(samples));
     visualization_actions.add_action(samples);
 
-    auto none = GUI::Action::create_checkable("&None", [&](auto&) {
-        static_cast<SoundPlayerWidgetAdvancedView*>(player)->set_visualization<NoVisualizationWidget>();
+    auto album_cover_visualization = GUI::Action::create_checkable("&Album Cover", [&](auto&) {
+        static_cast<SoundPlayerWidgetAdvancedView*>(player)->set_visualization<AlbumCoverVisualizationWidget>();
     });
-    TRY(visualization_menu->try_add_action(none));
-    visualization_actions.add_action(none);
+    TRY(visualization_menu->try_add_action(album_cover_visualization));
+    visualization_actions.add_action(album_cover_visualization);
 
     auto help_menu = TRY(window->try_add_menu("&Help"));
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Sound Player", app_icon, window)));


### PR DESCRIPTION
This PR renames the "None" visualization to "Album Cover" and shows the album cover for the current loaded sound file there.

This is just the first small step, and simply looks for a file named "cover.png" or "cover.jpg" in the same directory as the sound file, since this is common practice. In the future we'd want to also try loading the image embedded in the sound file and only use the "cover.png" file as a fallback.