### PR TITLE
HackStudio: Propagate error from TerminalWrapper

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1340,7 +1340,8 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_stop_action()
 {
     auto action = GUI::Action::create("&Stop", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/program-stop.png").release_value_but_fixme_should_propagate_errors(), [this](auto&) {
         if (!Debugger::the().session()) {
-            m_terminal_wrapper->kill_running_command();
+            if (auto result = m_terminal_wrapper->kill_running_command(); result.is_error())
+                warnln("{}", result.error());
             return;
         }
 

--- a/Userland/DevTools/HackStudio/TerminalWrapper.h
+++ b/Userland/DevTools/HackStudio/TerminalWrapper.h
@@ -21,8 +21,8 @@ public:
         No,
         Yes
     };
-    void run_command(const String&, Optional<String> working_directory = {}, WaitForExit = WaitForExit::No);
-    void kill_running_command();
+    ErrorOr<void> run_command(const String&, Optional<String> working_directory = {}, WaitForExit = WaitForExit::No, Optional<StringView> failure_message = {});
+    ErrorOr<void> kill_running_command();
     void clear_including_history();
 
     bool user_spawned() const { return m_user_spawned; }

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -306,11 +306,16 @@ int clearenv()
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/setenv.html
 int setenv(const char* name, const char* value, int overwrite)
 {
+    return serenity_setenv(name, strlen(name), value, strlen(value), overwrite);
+}
+
+int serenity_setenv(const char* name, ssize_t name_length, const char* value, ssize_t value_length, int overwrite)
+{
     if (!overwrite && getenv(name))
         return 0;
-    auto length = strlen(name) + strlen(value) + 2;
-    auto* var = (char*)malloc(length);
-    snprintf(var, length, "%s=%s", name, value);
+    auto const total_length = name_length + value_length + 2;
+    auto* var = (char*)malloc(total_length);
+    snprintf(var, total_length, "%s=%s", name, value);
     s_malloced_environment_variables.set((FlatPtr)var);
     return putenv(var);
 }

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -33,6 +33,7 @@ int putenv(char*);
 int unsetenv(const char*);
 int clearenv(void);
 int setenv(const char* name, const char* value, int overwrite);
+int serenity_setenv(const char* name, ssize_t name_length, const char* value, ssize_t value_length, int overwrite);
 const char* getprogname(void);
 void setprogname(const char*);
 int atoi(const char*);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -507,6 +507,14 @@ ErrorOr<void> tcsetattr(int fd, int optional_actions, struct termios const& ios)
     return {};
 }
 
+ErrorOr<int> tcsetpgrp(int fd, pid_t pgrp)
+{
+    int rc = ::tcsetpgrp(fd, pgrp);
+    if (rc < 0)
+        return Error::from_syscall("tcsetpgrp"sv, -errno);
+    return { rc };
+}
+
 ErrorOr<void> chmod(StringView pathname, mode_t mode)
 {
     if (!pathname.characters_without_null_termination())

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -14,6 +14,7 @@
 #include <LibSystem/syscall.h>
 #include <limits.h>
 #include <stdarg.h>
+#include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 #include <sys/ptrace.h>
@@ -1067,6 +1068,20 @@ ErrorOr<void> mknod(StringView pathname, mode_t mode, dev_t dev)
 ErrorOr<void> mkfifo(StringView pathname, mode_t mode)
 {
     return mknod(pathname, mode | S_IFIFO, 0);
+}
+
+ErrorOr<void> setenv(StringView name, StringView value, bool overwrite)
+{
+#ifdef __serenity__
+    auto const rc = ::serenity_setenv(name.characters_without_null_termination(), name.length(), value.characters_without_null_termination(), value.length(), overwrite);
+#else
+    String name_string = name;
+    String value_string = value;
+    auto const rc = ::setenv(name_string.characters(), value_string.characters(), overwrite);
+#endif
+    if (rc < 0)
+        return Error::from_syscall("setenv", -errno);
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -422,6 +422,13 @@ ErrorOr<void> kill(pid_t pid, int signal)
     return {};
 }
 
+ErrorOr<void> killpg(int pgrp, int signal)
+{
+    if (::killpg(pgrp, signal) < 0)
+        return Error::from_syscall("killpg"sv, -errno);
+    return {};
+}
+
 ErrorOr<int> dup(int source_fd)
 {
     int fd = ::dup(source_fd);

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1084,4 +1084,28 @@ ErrorOr<void> setenv(StringView name, StringView value, bool overwrite)
     return {};
 }
 
+ErrorOr<int> posix_openpt(int flags)
+{
+    int const rc = ::posix_openpt(flags);
+    if (rc < 0)
+        return Error::from_syscall("posix_openpt", -errno);
+    return rc;
+}
+
+ErrorOr<void> grantpt(int fildes)
+{
+    auto const rc = ::grantpt(fildes);
+    if (rc < 0)
+        return Error::from_syscall("grantpt", -errno);
+    return {};
+}
+
+ErrorOr<void> unlockpt(int fildes)
+{
+    auto const rc = ::unlockpt(fildes);
+    if (rc < 0)
+        return Error::from_syscall("unlockpt", -errno);
+    return {};
+}
+
 }

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -145,4 +145,6 @@ ErrorOr<void> socketpair(int domain, int type, int protocol, int sv[2]);
 ErrorOr<Vector<gid_t>> getgroups();
 ErrorOr<void> mknod(StringView pathname, mode_t mode, dev_t dev);
 ErrorOr<void> mkfifo(StringView pathname, mode_t mode);
+ErrorOr<void> setenv(StringView, StringView, bool);
+
 }

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -86,6 +86,7 @@ ErrorOr<String> getcwd();
 ErrorOr<void> ioctl(int fd, unsigned request, ...);
 ErrorOr<struct termios> tcgetattr(int fd);
 ErrorOr<void> tcsetattr(int fd, int optional_actions, struct termios const&);
+ErrorOr<int> tcsetpgrp(int fd, pid_t pgrp);
 ErrorOr<void> chmod(StringView pathname, mode_t mode);
 ErrorOr<void> lchown(StringView pathname, uid_t uid, gid_t gid);
 ErrorOr<void> chown(StringView pathname, uid_t uid, gid_t gid);

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -146,5 +146,8 @@ ErrorOr<Vector<gid_t>> getgroups();
 ErrorOr<void> mknod(StringView pathname, mode_t mode, dev_t dev);
 ErrorOr<void> mkfifo(StringView pathname, mode_t mode);
 ErrorOr<void> setenv(StringView, StringView, bool);
+ErrorOr<int> posix_openpt(int flags);
+ErrorOr<void> grantpt(int fildes);
+ErrorOr<void> unlockpt(int fildes);
 
 }

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -76,6 +76,7 @@ ErrorOr<struct stat> lstat(StringView path);
 ErrorOr<ssize_t> read(int fd, Bytes buffer);
 ErrorOr<ssize_t> write(int fd, ReadonlyBytes buffer);
 ErrorOr<void> kill(pid_t, int signal);
+ErrorOr<void> killpg(int pgrp, int signal);
 ErrorOr<int> dup(int source_fd);
 ErrorOr<int> dup2(int source_fd, int destination_fd);
 ErrorOr<String> ptsname(int fd);


### PR DESCRIPTION
Use the ErrorOr pattern with the Core::System wrappers to propagate more errors from TerminalWrapper.

This patch also contains some new wrappers for `Core::System`.