### PR TITLE
SoundPlayer: Fix potential never-updated bars visualization

### DIFF
--- a/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
+++ b/Userland/Applications/SoundPlayer/BarsVisualizationWidget.cpp
@@ -95,8 +95,10 @@ void BarsVisualizationWidget::set_buffer(RefPtr<Audio::Buffer> buffer, int sampl
     m_is_using_last = true;
     // FIXME: We should dynamically adapt to the sample count and e.g. perform the fft over multiple buffers.
     // For now, the visualizer doesn't work with extremely low global sample rates.
-    if (buffer->sample_count() < 256)
+    if (buffer->sample_count() < 256) {
+        m_is_using_last = false;
         return;
+    }
     m_sample_count = round_previous_power_of_2(samples_to_use);
     m_sample_buffer.resize(m_sample_count);
     for (int i = 0; i < m_sample_count; i++) {


### PR DESCRIPTION
When the bars visualization receives a new buffer, it checks if it needs a new buffer, which is only the case after it has repainted. However, after then setting m_is_using_last, which is the flag for this, it checks the buffer size of the passed buffer and returns if that is too small. This means that if the visualizer receives a buffer that is too small, and because of external circumstances the update doesn't run after the buffer modification routine, the m_is_using_last variable is stuck at true, which means that the visualization incorrectly believes that the passed buffer is old and we need not update. This simply fixes that by resetting m_is_using_last if the buffer we're passed is too small, because in that case, we're clearly not using the last buffer anymore.

Note: This bug is not exposed by the current SoundPlayer behavior. It will become an issue with future changes (#12102), so we should fix it regardless.