### PR TITLE
Kernel: Report AC'97 vendor and device ID

### DIFF
--- a/Kernel/Devices/Audio/AC97.h
+++ b/Kernel/Devices/Audio/AC97.h
@@ -40,6 +40,8 @@ private:
         ExtendedAudioID = 0x28,
         ExtendedAudioStatusControl = 0x2a,
         PCMFrontDACRate = 0x2c,
+        VendorID1 = 0x7c,
+        VendorID2 = 0x7e,
     };
 
     enum ExtendedAudioMask : u16 {


### PR DESCRIPTION
Every AC'97 device has a specific vendor and device ID that we can report during boot which could help us identify specific hardware versions on bare metal.

Fun fact: Sigmatel AC'97 devices (emulated by Qemu) report a vendor ID of `0x838476`, but the spec instead states that the vendor ID should be three ASCII characters. Someone at Sigmatel apparently chose "STL" as their vendor string, and then proceeded to use the decimal ASCII values (83, 84 and 76) with `0x` in front...