### PR TITLE
Spreadsheet: Make Range Function support all examples & Add Range(s).toArray()

### DIFF
--- a/Base/res/js/Spreadsheet/runtime.js
+++ b/Base/res/js/Spreadsheet/runtime.js
@@ -171,6 +171,12 @@ class Ranges {
         }
     }
 
+    toArray() {
+        const cells = [];
+        this.forEach(val => cells.push(val));
+        return cells;
+    }
+
     toString() {
         return `Ranges.from(${this.ranges.map(r => r.toString()).join(", ")})`;
     }
@@ -263,6 +269,12 @@ class Range {
         }
     }
 
+    toArray() {
+        const cells = [];
+        this.forEach(val => cells.push(val));
+        return cells;
+    }
+
     toString() {
         const endingRow = this.endingRow ?? "";
         return `R\`${this.startingColumnName}${this.startingRow}:${this.endingColumnName}${endingRow}:${this.columnStep}:${this.rowStep}\``;
@@ -340,12 +352,8 @@ function numericResolve(cells) {
 }
 
 function resolve(cells) {
-    let values = [];
-    if (cells instanceof Range || cells instanceof Ranges)
-        cells.forEach(cell => values.push(cell.value()));
-    else values = cells;
-
-    return values;
+    const isRange = cells instanceof Range || cells instanceof Ranges;
+    return isRange ? cells.toArray().map(cell => cell.value()) : cells;
 }
 
 // Statistics

--- a/Base/res/js/Spreadsheet/runtime.js
+++ b/Base/res/js/Spreadsheet/runtime.js
@@ -187,6 +187,10 @@ class Range {
         // using == to account for '0' since js will parse `+'0'` to 0
         if (columnStep == 0 || rowStep == 0)
             throw new Error("rowStep or columnStep is 0, this will cause an infinite loop");
+        if (typeof startingRow === "string" || typeof endingRow === "string")
+            throw new Error(
+                "startingRow or endingRow is a string, this will cause an infinite loop"
+            );
         this.startingColumnName = startingColumnName;
         this.endingColumnName = endingColumnName;
         this.startingRow = startingRow;

--- a/Userland/Applications/Spreadsheet/Tests/basic.js
+++ b/Userland/Applications/Spreadsheet/Tests/basic.js
@@ -114,11 +114,34 @@ describe("Range", () => {
         const sheet = createSheet(workbook, "Sheet 1");
         sheet.makeCurrent();
         let i = 0;
-        for (const col of ["A", "B"])
-            for (const row of [0, 1, 2]) sheet.setCell(col, row, Math.pow(i++, 2));
+        for (const col of ["A", "B"]) {
+            for (const row of [0, 1, 2]) {
+                sheet.setCell(col, row, Math.pow(i++, 2));
+            }
+        }
 
         sheet.focusCell("A", 0);
         expect(R`A0:A2`.at(2).name).toEqual("A2");
         expect(Ranges.from(R`A0:A2`, R`B0:B2`).at(5).name).toEqual("B2");
+    });
+
+    test("Range(s)#toArray", () => {
+        const workbook = createWorkbook();
+        const sheet = createSheet(workbook, "Sheet 1");
+        sheet.makeCurrent();
+        let i = 0;
+        for (const col of ["A", "B"]) {
+            for (const row of [0, 1, 2]) {
+                sheet.setCell(col, row, Math.pow(i++, 2));
+            }
+        }
+
+        sheet.focusCell("A", 0);
+        expect(R`A0:A2`.toArray().toString()).toEqual("<Cell at A0>,<Cell at A1>,<Cell at A2>");
+        expect(
+            Ranges.from(R`A0:A2`, R`B0:B2`)
+                .toArray()
+                .toString()
+        ).toEqual("<Cell at A0>,<Cell at A1>,<Cell at A2>,<Cell at B0>,<Cell at B1>,<Cell at B2>");
     });
 });

--- a/Userland/Applications/Spreadsheet/Tests/basic.js
+++ b/Userland/Applications/Spreadsheet/Tests/basic.js
@@ -145,3 +145,62 @@ describe("Range", () => {
         ).toEqual("<Cell at A0>,<Cell at A1>,<Cell at A2>,<Cell at B0>,<Cell at B1>,<Cell at B2>");
     });
 });
+
+describe("R function", () => {
+    const workbook = createWorkbook();
+    const sheet = createSheet(workbook, "Sheet 1");
+    sheet.makeCurrent();
+    /*
+      A B
+      +++
+    0+1 1
+    1+2 4
+    2+3 9
+    */
+    for (const row of ["A", "B"]) {
+        for (let col of [0, 1, 2]) {
+            sheet.setCell(row, col++, row === "A" ? col : Math.pow(col, 2));
+        }
+    }
+    sheet.focusCell("A", 0);
+
+    test("Check for correctness: R`A0:A`", () => {
+        const range = R`A0:A`;
+        expect(range.toString()).toEqual("R`A0:A`");
+        expect(count(range)).toEqual(3);
+        expect(sum(range)).toEqual(6);
+    });
+    test("Check for correctness: R`A`", () => {
+        const range = R`A`;
+        expect(range.toString()).toEqual("R`A0:A`");
+        expect(count(range)).toEqual(3);
+        expect(sum(range)).toEqual(6);
+    });
+    test("Check for correctness: R`A0:B`", () => {
+        const range = R`A0:B`;
+        expect(range.toString()).toEqual("R`A0:B`");
+        expect(count(range)).toEqual(6);
+        expect(sum(range)).toEqual(20);
+    });
+    test("Check for correctness: R`A0:B0`", () => {
+        const range = R`A0:B0`;
+        expect(range.toString()).toEqual("R`A0:B0`");
+        expect(count(range)).toEqual(2);
+        expect(sum(range)).toEqual(2);
+    });
+    test("Check for correctness: R`A0:B:2:1`", () => {
+        const range = R`A0:B2:1:2`;
+        expect(range.toString()).toEqual("R`A0:B2:1:2`");
+        expect(range.toArray().toString()).toEqual(
+            "<Cell at A0>,<Cell at A2>,<Cell at B0>,<Cell at B2>"
+        );
+        expect(count(range)).toEqual(4);
+        expect(sum(range)).toEqual(14);
+    });
+    test("R`B`", () => {
+        const range = R`B`;
+        expect(range.toString()).toEqual("R`B0:B`");
+        expect(count(range)).toEqual(3);
+        expect(sum(range)).toEqual(14);
+    });
+});

--- a/Userland/Applications/Spreadsheet/Tests/mock.test-common.js
+++ b/Userland/Applications/Spreadsheet/Tests/mock.test-common.js
@@ -136,7 +136,7 @@ class Sheet {
             if (column !== name) continue;
             bound = Math.max(bound, row);
         }
-        return row;
+        return bound;
     }
 
     evaluate(currentColumn, currentRow, expression) {


### PR DESCRIPTION
We will now support R\`A` syntax