### PR TITLE
LibWeb: Include cookies in form submission

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFormElement.cpp
@@ -116,8 +116,7 @@ void HTMLFormElement::submit_form(RefPtr<HTMLElement> submitter, bool from_submi
         url.set_query(url_encode(parameters, AK::URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded));
     }
 
-    LoadRequest request;
-    request.set_url(url);
+    LoadRequest request = LoadRequest::create_for_url_on_page(url, document().page());
 
     if (effective_method == "post") {
         auto body = url_encode(parameters, AK::URL::PercentEncodeSet::ApplicationXWWWFormUrlencoded).to_byte_buffer();


### PR DESCRIPTION
Services expect cookies to be submitted with forms, especially login
screens.

Allows us to sign in to GitHub (including two factor authentication)
and start using it!
![Screenshot from 2022-03-03 12-40-43](https://user-images.githubusercontent.com/25595356/156574039-60c16012-0f26-4aa3-b413-0fd4ec30c754.png)
![Screenshot from 2022-03-03 13-03-20](https://user-images.githubusercontent.com/25595356/156574063-66fb41e5-d9f5-4dc1-8ea7-8ac6687ace12.png)

https://user-images.githubusercontent.com/25595356/156574192-a6434394-c0b7-42e3-b2ef-d11543ab44f3.mp4


