### PR TITLE
Hex editor value inspector

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -229,6 +229,14 @@ void HexEditor::set_content_length(size_t length)
     set_content_size({ static_cast<int>(newWidth), static_cast<int>(newHeight) });
 }
 
+Optional<u8> HexEditor::get_byte(size_t position)
+{
+    if (position < m_document->size())
+        return m_document->get(position).value;
+
+    return {};
+}
+
 void HexEditor::mousedown_event(GUI::MouseEvent& event)
 {
     if (event.button() != GUI::MouseButton::Primary) {

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -111,7 +112,19 @@ void HexEditor::set_position(size_t position)
     scroll_position_into_view(position);
     update_status();
 }
+void HexEditor::set_selection(size_t position, size_t length)
+{
+    if (position > m_document->size() || position + length > m_document->size())
+        return;
 
+    m_position = position;
+    m_cursor_at_low_nibble = false;
+    m_selection_start = position;
+    m_selection_end = position + length;
+    reset_cursor_blink_state();
+    scroll_position_into_view(position);
+    update_status();
+}
 bool HexEditor::save_as(NonnullRefPtr<Core::File> new_file)
 {
     if (m_document->type() == HexDocument::Type::File) {

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -53,6 +54,7 @@ public:
     void set_bytes_per_row(size_t);
 
     void set_position(size_t position);
+    void set_selection(size_t position, size_t length);
     void highlight(size_t start, size_t end);
     Optional<size_t> find(ByteBuffer& needle, size_t start = 0);
     Optional<size_t> find_and_highlight(ByteBuffer& needle, size_t start = 0);

--- a/Userland/Applications/HexEditor/HexEditor.h
+++ b/Userland/Applications/HexEditor/HexEditor.h
@@ -39,6 +39,7 @@ public:
     bool open_new_file(size_t size);
     void open_file(NonnullRefPtr<Core::File> file);
     void fill_selection(u8 fill_byte);
+    Optional<u8> get_byte(size_t position);
     bool save_as(NonnullRefPtr<Core::File>);
     bool save();
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -2,6 +2,7 @@
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +10,7 @@
 #pragma once
 
 #include "HexEditor.h"
+#include "ValueInspectorModel.h"
 #include <AK/Function.h>
 #include <AK/LexicalPath.h>
 #include <LibGUI/ActionGroup.h>
@@ -32,7 +34,8 @@ private:
     void set_path(StringView);
     void update_title();
     void set_search_results_visible(bool visible);
-
+    void set_value_inspector_visible(bool visible);
+    void update_inspector_values(size_t position);
     virtual void drop_event(GUI::DropEvent&) override;
 
     RefPtr<HexEditor> m_editor;
@@ -54,6 +57,7 @@ private:
     RefPtr<GUI::Action> m_goto_offset_action;
     RefPtr<GUI::Action> m_layout_toolbar_action;
     RefPtr<GUI::Action> m_layout_search_results_action;
+    RefPtr<GUI::Action> m_layout_value_inspector_action;
 
     RefPtr<GUI::Action> m_copy_hex_action;
     RefPtr<GUI::Action> m_copy_text_action;
@@ -61,10 +65,17 @@ private:
     RefPtr<GUI::Action> m_fill_selection_action;
 
     GUI::ActionGroup m_bytes_per_row_actions;
+    GUI::ActionGroup m_value_inspector_mode_actions;
 
     RefPtr<GUI::Statusbar> m_statusbar;
     RefPtr<GUI::Toolbar> m_toolbar;
     RefPtr<GUI::ToolbarContainer> m_toolbar_container;
     RefPtr<GUI::TableView> m_search_results;
     RefPtr<GUI::Widget> m_search_results_container;
+    RefPtr<GUI::Widget> m_side_panel_container;
+    RefPtr<GUI::Widget> m_value_inspector_container;
+    RefPtr<GUI::TableView> m_value_inspector;
+
+    bool m_value_inspector_little_endian { true };
+    bool m_selecting_from_inspector { false };
 };

--- a/Userland/Applications/HexEditor/HexEditorWindow.gml
+++ b/Userland/Applications/HexEditor/HexEditorWindow.gml
@@ -18,13 +18,29 @@
             name: "editor"
         }
 
-        @GUI::Widget {
-            name: "search_results_container"
+        @GUI::VerticalSplitter {
+            name: "side_panel_container"
             visible: false
-            layout: @GUI::VerticalBoxLayout {}
 
-            @GUI::TableView {
-                name: "search_results"
+            @GUI::Widget {
+                name: "search_results_container"
+                visible: false
+                layout: @GUI::VerticalBoxLayout {}
+
+                @GUI::TableView {
+                    name: "search_results"
+                }
+            }
+
+            @GUI::Widget {
+                name: "value_inspector_container"
+                visible: false
+                layout: @GUI::VerticalBoxLayout {}
+
+                @GUI::TableView {
+                    name: "value_inspector"
+                    activates_on_selection: true
+                }
             }
         }
     }

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022, Timothy Slater <tslater2006@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Hex.h>
+#include <AK/NonnullRefPtr.h>
+#include <AK/String.h>
+#include <AK/Utf8View.h>
+#include <AK/Vector.h>
+#include <LibGUI/Model.h>
+
+class ValueInspectorModel final : public GUI::Model {
+public:
+    enum ValueType {
+        SignedByte,
+        UnsignedByte,
+        SignedShort,
+        UnsignedShort,
+        SignedInt,
+        UnsignedInt,
+        SignedLong,
+        UnsignedLong,
+        Float,
+        Double,
+        __Count
+    };
+
+    enum Column {
+        Type,
+        Value
+    };
+
+    explicit ValueInspectorModel()
+    {
+        for (int i = 0; i < ValueType::__Count; i++)
+            set_parsed_value(static_cast<ValueType>(i), "");
+    }
+
+    void set_parsed_value(ValueType type, String value)
+    {
+        m_values[type] = value;
+    }
+
+    virtual int row_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override
+    {
+        return m_values.size();
+    }
+
+    virtual int column_count(GUI::ModelIndex const&) const override
+    {
+        return 2;
+    }
+
+    String column_name(int column) const override
+    {
+        switch (column) {
+        case Column::Type:
+            return "Type";
+        case Column::Value:
+            return "Value";
+        }
+        VERIFY_NOT_REACHED();
+    }
+
+    String inspector_value_type_to_string(ValueType type) const
+    {
+        switch (type) {
+        case SignedByte:
+            return "Signed Byte";
+        case UnsignedByte:
+            return "Unsigned Byte";
+        case SignedShort:
+            return "Signed Short";
+        case UnsignedShort:
+            return "Unsigned Short";
+        case SignedInt:
+            return "Signed Int";
+        case UnsignedInt:
+            return "Unsigned Int";
+        case SignedLong:
+            return "Signed Long";
+        case UnsignedLong:
+            return "Unsigned Long";
+        case Float:
+            return "Float";
+        case Double:
+            return "Double";
+        default:
+            return "";
+        }
+    }
+
+    virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role) const override
+    {
+        if (role == GUI::ModelRole::TextAlignment)
+            return Gfx::TextAlignment::CenterLeft;
+        if (role == GUI::ModelRole::Display) {
+            switch (index.column()) {
+            case Column::Type:
+                return inspector_value_type_to_string(static_cast<ValueType>(index.row()));
+            case Column::Value:
+                return m_values.at(index.row());
+            }
+        }
+        if (role == GUI::ModelRole::Custom) {
+            ValueType selected_type = static_cast<ValueType>(index.row());
+            switch (selected_type) {
+            case SignedByte:
+            case UnsignedByte:
+                return 1;
+            case SignedShort:
+            case UnsignedShort:
+                return 2;
+            case SignedInt:
+            case UnsignedInt:
+            case Float:
+                return 4;
+            case SignedLong:
+            case UnsignedLong:
+            case Double:
+                return 8;
+            default:
+                return 0;
+            }
+        }
+        return {};
+    }
+
+private:
+    Array<String, ValueType::__Count> m_values = {};
+};


### PR DESCRIPTION
This change implements a value inspector for the hex editor. This inspector operates on the current cursor position (or the start of selection range if one is selected) and interprets bytes moving forward as various data types. The inspector can toggle between big and little endian modes. When a value is selected in the inspector, the associated bytes that make up that value also get highlighted in the editor.

This change also includes some API changes for HexEditor, specifically the ability to programmatically set a selection range as well as exposing a mechanism to retrieve a byte from a specific position in the underlying HexDocument.

All described features are visible in this screenshot:
![image](https://user-images.githubusercontent.com/1731714/156585300-9a7d8057-1eac-4e85-8f71-6cfb9579043c.png)
