### PR TITLE
LibGfx+WindowServer: Support window shadows with a border-radius 

### DIFF
--- a/Base/res/themes/Cupertino.ini
+++ b/Base/res/themes/Cupertino.ini
@@ -83,8 +83,8 @@ TitleButtonHeight=16
 
 [Paths]
 TitleButtonIcons=/res/icons/themes/Cupertino/16x16/
-ActiveWindowShadow=
-InactiveWindowShadow=
+ActiveWindowShadow=/res/icons/themes/Default/frame-shadow-dark.png
+InactiveWindowShadow=/res/icons/themes/Default/frame-shadow-light.png
 MenuShadow=/res/icons/themes/Default/frame-shadow-light.png
 TaskBarShadow=/res/icons/themes/Default/frame-shadow-light.png
 TooltipShadow=/res/icons/themes/Default/frame-shadow-light.png

--- a/Userland/Libraries/LibGfx/ClassicStylePainter.h
+++ b/Userland/Libraries/LibGfx/ClassicStylePainter.h
@@ -23,7 +23,7 @@ public:
     virtual void paint_radio_button(Painter&, IntRect const&, Palette const&, bool is_checked, bool is_being_pressed) override;
     virtual void paint_check_box(Painter&, IntRect const&, Palette const&, bool is_enabled, bool is_checked, bool is_being_pressed) override;
     virtual void paint_transparency_grid(Painter&, IntRect const&, Palette const&) override;
-    virtual void paint_simple_rect_shadow(Painter&, IntRect const&, Bitmap const& shadow_bitmap, bool shadow_includes_frame, bool fill_content) override;
+    virtual void paint_simple_rect_shadow(Painter&, IntRect const&, Bitmap const& shadow_bitmap, bool shadow_includes_frame, bool fill_content, int border_radius) override;
 };
 
 }

--- a/Userland/Libraries/LibGfx/StylePainter.cpp
+++ b/Userland/Libraries/LibGfx/StylePainter.cpp
@@ -58,9 +58,9 @@ void StylePainter::paint_transparency_grid(Painter& painter, const IntRect& rect
     current().paint_transparency_grid(painter, rect, palette);
 }
 
-void StylePainter::paint_simple_rect_shadow(Painter& painter, IntRect const& rect, Bitmap const& shadow_bitmap, bool shadow_includes_frame, bool fill_content)
+void StylePainter::paint_simple_rect_shadow(Painter& painter, IntRect const& rect, Bitmap const& shadow_bitmap, bool shadow_includes_frame, bool fill_content, int border_radius)
 {
-    current().paint_simple_rect_shadow(painter, rect, shadow_bitmap, shadow_includes_frame, fill_content);
+    current().paint_simple_rect_shadow(painter, rect, shadow_bitmap, shadow_includes_frame, fill_content, border_radius);
 }
 
 }

--- a/Userland/Libraries/LibGfx/StylePainter.h
+++ b/Userland/Libraries/LibGfx/StylePainter.h
@@ -44,7 +44,7 @@ public:
     virtual void paint_radio_button(Painter&, IntRect const&, Palette const&, bool is_checked, bool is_being_pressed) = 0;
     virtual void paint_check_box(Painter&, IntRect const&, Palette const&, bool is_enabled, bool is_checked, bool is_being_pressed) = 0;
     virtual void paint_transparency_grid(Painter&, IntRect const&, Palette const&) = 0;
-    virtual void paint_simple_rect_shadow(Painter&, IntRect const&, Bitmap const& shadow_bitmap, bool shadow_includes_frame = false, bool fill_content = false) = 0;
+    virtual void paint_simple_rect_shadow(Painter&, IntRect const&, Bitmap const& shadow_bitmap, bool shadow_includes_frame = false, bool fill_content = false, int border_radius = 0) = 0;
 
 protected:
     BaseStylePainter() { }
@@ -63,7 +63,7 @@ public:
     static void paint_radio_button(Painter&, IntRect const&, Palette const&, bool is_checked, bool is_being_pressed);
     static void paint_check_box(Painter&, IntRect const&, Palette const&, bool is_enabled, bool is_checked, bool is_being_pressed);
     static void paint_transparency_grid(Painter&, IntRect const&, Palette const&);
-    static void paint_simple_rect_shadow(Painter&, IntRect const&, Bitmap const& shadow_bitmap, bool shadow_includes_frame = false, bool fill_content = false);
+    static void paint_simple_rect_shadow(Painter&, IntRect const&, Bitmap const& shadow_bitmap, bool shadow_includes_frame = false, bool fill_content = false, int border_radius = 0);
 };
 
 }

--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -190,9 +190,6 @@ MultiScaleBitmaps const* WindowFrame::shadow_bitmap() const
     case WindowType::WindowSwitcher:
         return nullptr;
     default:
-        // FIXME: Support shadow for themes with border radius
-        if (WindowManager::the().palette().window_border_radius() > 0)
-            return nullptr;
         if (auto* highlight_window = WindowManager::the().highlight_window())
             return highlight_window == &m_window ? s_active_window_shadow : s_inactive_window_shadow;
         return m_window.is_active() ? s_active_window_shadow : s_inactive_window_shadow;
@@ -477,7 +474,7 @@ void WindowFrame::PerScaleRenderedCache::render(WindowFrame& frame, Screen& scre
         painter.clear_rect({ rect.location() - frame_rect_to_update.location(), rect.size() }, { 255, 255, 255, 0 });
 
     if (m_shadow_dirty && shadow_bitmap)
-        Gfx::StylePainter::paint_simple_rect_shadow(painter, { { 0, 0 }, frame_rect_including_shadow.size() }, shadow_bitmap->bitmap(screen.scale_factor()));
+        Gfx::StylePainter::paint_simple_rect_shadow(painter, { { 0, 0 }, frame_rect_including_shadow.size() }, shadow_bitmap->bitmap(screen.scale_factor()), false, false, WindowManager::the().palette().window_border_radius());
 
     {
         Gfx::PainterStateSaver save(painter);


### PR DESCRIPTION
Following on from my previous PR [#12661](https://github.com/SerenityOS/serenity/pull/12661), this fixes my `FIXME` to support window shadows for themes with a border-radius.

This still uses the same shadow bitmap, but pushes it in and rearranges it a bit at the corners when there is a border radius.

**Before**            |  **After**
:-------------------------:|:-------------------------:
![Screenshot from 2022-03-03 23-13-23](https://user-images.githubusercontent.com/11597044/156669144-87acc27a-80da-41b0-98fb-ed2f2ea44bca.png) |![Screenshot from 2022-03-03 23-09-53](https://user-images.githubusercontent.com/11597044/156669154-80612477-1cbb-48fa-92c7-ff818b738ad9.png)
Incorrect corners | Correct corners
