### PR TITLE
LibArchive+tar: Implement support for extended headers :^)

### DIFF
--- a/Userland/Libraries/LibArchive/Tar.cpp
+++ b/Userland/Libraries/LibArchive/Tar.cpp
@@ -30,4 +30,9 @@ void TarFileHeader::calculate_checksum()
     VERIFY(String::formatted("{:06o}", expected_checksum()).copy_characters_to_buffer(m_checksum, sizeof(m_checksum)));
 }
 
+bool TarFileHeader::content_is_like_extended_header() const
+{
+    return type_flag() == TarFileType::ExtendedHeader || type_flag() == TarFileType::GlobalExtendedHeader;
+}
+
 }

--- a/Userland/Libraries/LibArchive/Tar.h
+++ b/Userland/Libraries/LibArchive/Tar.h
@@ -116,6 +116,8 @@ public:
     unsigned expected_checksum() const;
     void calculate_checksum();
 
+    bool content_is_like_extended_header() const;
+
 private:
     char m_filename[100] { 0 };
     char m_mode[8] { 0 };

--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -40,6 +40,9 @@ public:
     const TarFileHeader& header() const { return m_header; }
     TarFileStream file_contents();
 
+    template<VoidFunction<StringView, StringView> F>
+    ErrorOr<void> for_each_extended_header(F func);
+
 private:
     TarFileHeader m_header;
     InputStream& m_stream;
@@ -63,5 +66,52 @@ private:
 
     friend class TarFileStream;
 };
+
+template<VoidFunction<StringView, StringView> F>
+inline ErrorOr<void> TarInputStream::for_each_extended_header(F func)
+{
+    VERIFY(header().content_is_like_extended_header());
+
+    Archive::TarFileStream file_stream = file_contents();
+
+    ByteBuffer file_contents_buffer = TRY(ByteBuffer::create_zeroed(header().size()));
+    VERIFY(file_stream.read(file_contents_buffer) == header().size());
+
+    StringView file_contents { file_contents_buffer };
+
+    while (!file_contents.is_empty()) {
+        // Split off the length (until the first space).
+        Optional<size_t> length_end_index = file_contents.find(' ');
+        if (!length_end_index.has_value())
+            return Error::from_string_literal("Malformed extended header: No length found.");
+        Optional<unsigned int> length = file_contents.substring_view(0, length_end_index.value()).to_uint();
+        if (!length.has_value())
+            return Error::from_string_literal("Malformed extended header: Could not parse length.");
+        unsigned int remaining_length = length.value();
+
+        remaining_length -= length_end_index.value() + 1;
+        file_contents = file_contents.substring_view(length_end_index.value() + 1);
+
+        // Extract the header.
+        StringView header = file_contents.substring_view(0, remaining_length - 1);
+        file_contents = file_contents.substring_view(remaining_length - 1);
+
+        // Ensure that the header ends at the expected location.
+        if (file_contents.length() < 1 || !file_contents.starts_with('\n'))
+            return Error::from_string_literal("Malformed extended header: Header does not end at expected location.");
+        file_contents = file_contents.substring_view(1);
+
+        // Find the delimiting '='.
+        Optional<size_t> header_delimiter_index = header.find('=');
+        if (!header_delimiter_index.has_value())
+            return Error::from_string_literal("Malformed extended header: Header does not have a delimiter.");
+        StringView key = header.substring_view(0, header_delimiter_index.value());
+        StringView value = header.substring_view(header_delimiter_index.value() + 1);
+
+        func(key, value);
+    }
+
+    return {};
+}
 
 }

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -78,19 +78,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             return 1;
         }
         for (; !tar_stream.finished(); tar_stream.advance()) {
+            const Archive::TarFileHeader& header = tar_stream.header();
+
+            LexicalPath path = LexicalPath(header.filename());
+            if (!header.prefix().is_empty())
+                path = path.prepend(header.prefix());
+            String filename = path.string();
+
             if (list || verbose)
-                outln("{}", tar_stream.header().filename());
+                outln("{}", filename);
 
             if (extract) {
                 Archive::TarFileStream file_stream = tar_stream.file_contents();
 
-                const Archive::TarFileHeader& header = tar_stream.header();
-
-                LexicalPath path = LexicalPath(header.filename());
-                if (!header.prefix().is_empty())
-                    path = path.prepend(header.prefix());
-
-                String absolute_path = Core::File::absolute_path(path.string());
+                String absolute_path = Core::File::absolute_path(filename);
 
                 switch (header.type_flag()) {
                 case Archive::TarFileType::NormalFile:

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -77,13 +77,57 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             warnln("the provided file is not a well-formatted ustar file");
             return 1;
         }
+
+        HashMap<String, String> global_overrides;
+        HashMap<String, String> local_overrides;
+
+        auto get_override = [&](StringView key) -> Optional<String> {
+            Optional<String> maybe_local = local_overrides.get(key);
+
+            if (maybe_local.has_value())
+                return maybe_local;
+
+            Optional<String> maybe_global = global_overrides.get(key);
+
+            if (maybe_global.has_value())
+                return maybe_global;
+
+            return {};
+        };
+
         for (; !tar_stream.finished(); tar_stream.advance()) {
             const Archive::TarFileHeader& header = tar_stream.header();
+
+            // Handle meta-entries earlier to avoid consuming the file content stream.
+            if (header.content_is_like_extended_header()) {
+                switch (header.type_flag()) {
+                case Archive::TarFileType::GlobalExtendedHeader: {
+                    TRY(tar_stream.for_each_extended_header([&](StringView key, StringView value) {
+                        if (value.length() == 0)
+                            global_overrides.remove(key);
+                        else
+                            global_overrides.set(key, value);
+                    }));
+                    break;
+                }
+                case Archive::TarFileType::ExtendedHeader: {
+                    TRY(tar_stream.for_each_extended_header([&](StringView key, StringView value) {
+                        local_overrides.set(key, value);
+                    }));
+                    break;
+                }
+                default:
+                    warnln("Unknown extended header type '{}' of {}", (char)header.type_flag(), header.filename());
+                    VERIFY_NOT_REACHED();
+                }
+
+                continue;
+            }
 
             LexicalPath path = LexicalPath(header.filename());
             if (!header.prefix().is_empty())
                 path = path.prepend(header.prefix());
-            String filename = path.string();
+            String filename = get_override("path"sv).value_or(path.string());
 
             if (list || verbose)
                 outln("{}", filename);
@@ -121,20 +165,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                         return result_or_error.error();
                     break;
                 }
-                case Archive::TarFileType::GlobalExtendedHeader: {
-                    dbgln("ignoring global extended header: {}", header.filename());
-                    break;
-                }
-                case Archive::TarFileType::ExtendedHeader: {
-                    dbgln("ignoring extended header: {}", header.filename());
-                    break;
-                }
                 default:
                     // FIXME: Implement other file types
                     warnln("file type '{}' of {} is not yet supported", (char)header.type_flag(), header.filename());
                     VERIFY_NOT_REACHED();
                 }
             }
+
+            // Non-global headers should be cleared after every file.
+            local_overrides.clear();
         }
         file_stream.close();
 


### PR DESCRIPTION
The parsing code looks ugly, and I'm not even sure if putting it in that header and declaring it inline is the correct thing to do. However, putting it into `tar` directly doesn't feel entirely correct either, as other applications might be able to benefit from that.

But at least we can untar official GCC tarballs now. :^)