### PR TITLE
LibJS: Fix toFixed() implementation for real this time :^)

### DIFF
--- a/AK/FloatExtractor.h
+++ b/AK/FloatExtractor.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, Andreas Kling <kling@serenityos.org>.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+template<typename T>
+union FloatExtractor;
+
+#if ARCH(I386) || ARCH(X86_64)
+// This assumes long double is 80 bits, which is true with GCC on Intel platforms
+template<>
+union FloatExtractor<long double> {
+    static const int mantissa_bits = 64;
+    static const unsigned long long mantissa_max = ~0u;
+    static const int exponent_bias = 16383;
+    static const int exponent_bits = 15;
+    static const unsigned exponent_max = 32767;
+    struct {
+        unsigned long long mantissa;
+        unsigned exponent : 15;
+        unsigned sign : 1;
+    };
+    long double d;
+};
+#endif
+
+template<>
+union FloatExtractor<double> {
+    static const int mantissa_bits = 52;
+    static const unsigned long long mantissa_max = (1ull << 52) - 1;
+    static const int exponent_bias = 1023;
+    static const int exponent_bits = 11;
+    static const unsigned exponent_max = 2047;
+    struct {
+        unsigned long long mantissa : 52;
+        unsigned exponent : 11;
+        unsigned sign : 1;
+    };
+    double d;
+};
+
+template<>
+union FloatExtractor<float> {
+    static const int mantissa_bits = 23;
+    static const unsigned mantissa_max = (1 << 23) - 1;
+    static const int exponent_bias = 127;
+    static const int exponent_bits = 8;
+    static const unsigned exponent_max = 255;
+    struct {
+        unsigned long long mantissa : 23;
+        unsigned exponent : 8;
+        unsigned sign : 1;
+    };
+    float d;
+};

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/Multiplication.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/Multiplication.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
  * Copyright (c) 2020-2021, Dex♪ <dexes.ttp@gmail.com>
+ * Copyright (c) 2022, Ben Abraham <ben.d.abraham@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -25,7 +26,19 @@ FLATTEN void UnsignedBigIntegerAlgorithms::multiply_without_allocation(
     UnsignedBigInteger& temp_shift,
     UnsignedBigInteger& output)
 {
+    if (left == 1) {
+        output.set_to(right);
+        return;
+    }
+    if (right == 1) {
+        output.set_to(left);
+        return;
+    }
+
     output.set_to_0();
+
+    if (left == 0 || right == 0)
+        return;
 
     // iterate all bits
     for (size_t word_index = 0; word_index < left.length(); ++word_index) {

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2022, Ben Abraham <ben.d.abraham@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -60,6 +61,11 @@ public:
         }
         return SignedBigInteger { UnsignedBigInteger::create_from(unsigned_value), sign };
     }
+    static SignedBigInteger create_from_double(double value)
+    {
+        return create_from_double_with_multiplier(value, 1);
+    }
+    static SignedBigInteger create_from_double_with_multiplier(double value, UnsignedBigInteger multiplier);
 
     size_t export_data(Bytes, bool remove_leading_zeros = false) const;
 

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -352,12 +352,12 @@ void UnsignedBigInteger::clear_bit_inplace(size_t bit_index)
     size_t const word_index = bit_index / UnsignedBigInteger::BITS_IN_WORD;
     size_t const inner_word_index = bit_index % UnsignedBigInteger::BITS_IN_WORD;
 
-    m_words.ensure_capacity(word_index + 1);
-
-    for (size_t i = length(); i <= word_index; ++i)
-        m_words.unchecked_append(0);
+    if (word_index >= length())
+        return;
 
     m_words[word_index] &= ~(1 << inner_word_index);
+
+    clamp_to_trimmed_length();
 
     m_cached_trimmed_length = {};
     m_cached_hash = 0;

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2022, Ben Abraham <ben.d.abraham@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -274,6 +275,9 @@ FLATTEN UnsignedBigInteger UnsignedBigInteger::multiplied_by(const UnsignedBigIn
 
 FLATTEN UnsignedDivisionResult UnsignedBigInteger::divided_by(const UnsignedBigInteger& divisor) const
 {
+    if (divisor == 1)
+        return UnsignedDivisionResult { *this, 0 };
+
     UnsignedBigInteger quotient;
     UnsignedBigInteger remainder;
 

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2022, Ben Abraham <ben.d.abraham@gmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -98,6 +99,7 @@ public:
     u32 hash() const;
 
     void set_bit_inplace(size_t bit_index);
+    void clear_bit_inplace(size_t bit_index);
 
     bool operator==(const UnsignedBigInteger& other) const;
     bool operator!=(const UnsignedBigInteger& other) const;

--- a/Userland/Libraries/LibM/math.cpp
+++ b/Userland/Libraries/LibM/math.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/BuiltinWrappers.h>
 #include <AK/ExtraMathConstants.h>
+#include <AK/FloatExtractor.h>
 #include <AK/Math.h>
 #include <AK/Platform.h>
 #include <AK/StdLibExtras.h>
@@ -54,57 +55,6 @@ enum class RoundingMode {
     Up = FE_UPWARD,
     Down = FE_DOWNWARD,
     ToEven = FE_TONEAREST
-};
-
-template<typename T>
-union FloatExtractor;
-
-#if ARCH(I386) || ARCH(X86_64)
-// This assumes long double is 80 bits, which is true with GCC on Intel platforms
-template<>
-union FloatExtractor<long double> {
-    static const int mantissa_bits = 64;
-    static const unsigned long long mantissa_max = ~0u;
-    static const int exponent_bias = 16383;
-    static const int exponent_bits = 15;
-    static const unsigned exponent_max = 32767;
-    struct {
-        unsigned long long mantissa;
-        unsigned exponent : 15;
-        unsigned sign : 1;
-    };
-    long double d;
-};
-#endif
-
-template<>
-union FloatExtractor<double> {
-    static const int mantissa_bits = 52;
-    static const unsigned long long mantissa_max = (1ull << 52) - 1;
-    static const int exponent_bias = 1023;
-    static const int exponent_bits = 11;
-    static const unsigned exponent_max = 2047;
-    struct {
-        unsigned long long mantissa : 52;
-        unsigned exponent : 11;
-        unsigned sign : 1;
-    };
-    double d;
-};
-
-template<>
-union FloatExtractor<float> {
-    static const int mantissa_bits = 23;
-    static const unsigned mantissa_max = (1 << 23) - 1;
-    static const int exponent_bias = 127;
-    static const int exponent_bits = 8;
-    static const unsigned exponent_max = 255;
-    struct {
-        unsigned long long mantissa : 23;
-        unsigned exponent : 8;
-        unsigned sign : 1;
-    };
-    float d;
 };
 
 // This is much branchier than it really needs to be


### PR DESCRIPTION
This resolves the test262 test that was broken in my last PR. Also brings execution basically perfectly in line with modern browsers.
There is still one failing `toFixed()` test, but it's actually on the toString() impl here being TOO accurate (*sigh*)

```js
assert.sameValue((1000000000000000128).toString(), "1000000000000000100");
assert.sameValue((1000000000000000128).toFixed(0), "1000000000000000128");
```

Acid3 test behavior still working:
![image](https://user-images.githubusercontent.com/793454/156870083-385dced7-e14c-4c13-b480-f59444320bdc.png)

Previously broken test-262 case:
![image](https://user-images.githubusercontent.com/793454/156870111-3795d35b-10c9-4edb-8886-a3127ebe6177.png)

Comparison of worst-case-scenario to FF - exact match:
![image](https://user-images.githubusercontent.com/793454/156867368-0b883a2c-1b41-43bb-b6fe-bfaf3eb73e95.png)
