### PR TITLE
LibWeb: Add default styling to s, del, kbd and samp elements & Set default fonts for Serif and Fantasy

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -41,6 +41,11 @@ ins {
     text-decoration: underline;
 }
 
+s,
+del {
+    text-decoration: line-through;
+}
+
 strong,
 b {
     font-weight: bold;

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -32,7 +32,9 @@ pre {
     white-space: pre;
 }
 
-code {
+code,
+kbd,
+samp {
     font-family: monospace;
 }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -860,6 +860,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
             monospace = true;
             return find_font("Csilla");
         case ValueID::Serif:
+            return find_font("Roman");
         case ValueID::SansSerif:
         case ValueID::Cursive:
         case ValueID::Fantasy:

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -861,9 +861,10 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
             return find_font("Csilla");
         case ValueID::Serif:
             return find_font("Roman");
+        case ValueID::Fantasy:
+            return find_font("Comic Book");
         case ValueID::SansSerif:
         case ValueID::Cursive:
-        case ValueID::Fantasy:
         case ValueID::UiSerif:
         case ValueID::UiSansSerif:
         case ValueID::UiRounded:


### PR DESCRIPTION
![fonts](https://user-images.githubusercontent.com/16520278/156897471-aad30dbc-d998-4392-834b-a9e90a033e58.png)
