### PR TITLE
FontEditor: Add code previews for fixed-width fonts

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -51,7 +51,9 @@ static constexpr Array pangrams = {
     "waxy and quivering jocks fumble the pizza",
     "~#:[@_1%]*{$2.3}/4^(5'6\")-&|7+8!=<9,0\\>?;",
     "byxfjärmat föl gick på duvshowen",
-    "         "
+    "         ",
+    "float Fox.quick(h){ is_brown && it_jumps_over(doges.lazy) }",
+    "<fox color=\"brown\" speed=\"quick\" jumps=\"over\">lazy dog</fox>"
 };
 
 static RefPtr<GUI::Window> create_font_preview_window(FontEditorWidget& editor)


### PR DESCRIPTION
Add pseudo code to font preview for fixed-width programming fonts.

<img width="455" alt="Screen Shot 2022-02-26 at 09 30 05" src="https://user-images.githubusercontent.com/4368524/155846992-34b79e1d-f0cb-4f60-a8eb-64fd55cf26b7.png">
<img width="477" alt="Screen Shot 2022-02-26 at 14 07 14" src="https://user-images.githubusercontent.com/4368524/155855979-a8ac56ca-e75d-4906-b662-713bd16143d1.png">

One of them is seen here in a preview of the Iosevka font, the other I wrote.
![iosevka-slender-monospace-sans-serif](https://user-images.githubusercontent.com/4368524/155847001-81517e2f-4841-4625-8759-822b17d48af9.png)