### PR TITLE
LibSoftGPU: Use destination alpha for texture decal function

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1016,10 +1016,10 @@ ALWAYS_INLINE void Device::shade_fragments(PixelQuad& quad)
             quad.out_color = texel;
             break;
         case TextureEnvMode::Decal: {
-            auto src_alpha = quad.out_color.w();
-            quad.out_color.set_x(mix(quad.out_color.x(), texel.x(), src_alpha));
-            quad.out_color.set_y(mix(quad.out_color.y(), texel.y(), src_alpha));
-            quad.out_color.set_z(mix(quad.out_color.z(), texel.z(), src_alpha));
+            auto dst_alpha = texel.w();
+            quad.out_color.set_x(mix(quad.out_color.x(), texel.x(), dst_alpha));
+            quad.out_color.set_y(mix(quad.out_color.y(), texel.y(), dst_alpha));
+            quad.out_color.set_z(mix(quad.out_color.z(), texel.z(), dst_alpha));
             break;
         }
         default:


### PR DESCRIPTION
According to the OpenGL spec, the decal function uses the destination (or texture) alpha instead of the source alpha. This fixes the sky in GLQuake.

Before:
![image](https://user-images.githubusercontent.com/3210731/156902981-078ae0d4-cdc0-42fa-b112-39b7d326053f.png)

After:
![image](https://user-images.githubusercontent.com/3210731/156902986-03c17e6d-ae49-4e0a-ae76-deff5ff79beb.png)
