### PR TITLE
LibGL: Improve GLTron rendering

### DIFF
--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -2467,18 +2467,16 @@ void SoftwareGLContext::read_from_vertex_attribute_pointer(VertexAttribPointer c
         if (stride == 0)
             stride = sizeof(GLfloat) * attrib.size;
 
-        for (int i = 0; i < attrib.size; i++) {
+        for (int i = 0; i < attrib.size; i++)
             elements[i] = *(reinterpret_cast<const GLfloat*>(byte_ptr + stride * index) + i);
-        }
         break;
     }
     case GL_DOUBLE: {
         if (stride == 0)
             stride = sizeof(GLdouble) * attrib.size;
 
-        for (int i = 0; i < attrib.size; i++) {
+        for (int i = 0; i < attrib.size; i++)
             elements[i] = static_cast<float>(*(reinterpret_cast<const GLdouble*>(byte_ptr + stride * index) + i));
-        }
         break;
     }
     }

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -2128,6 +2128,7 @@ void SoftwareGLContext::gl_tex_env(GLenum target, GLenum pname, GLfloat param)
     case GL_REPLACE:
     case GL_DECAL:
         m_active_texture_unit->set_env_mode(param_enum);
+        m_sampler_config_is_dirty = true;
         break;
     default:
         // FIXME: We currently only support a subset of possible param values. Implement the rest!

--- a/Userland/Libraries/LibGL/SoftwareGLContext.cpp
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.cpp
@@ -2787,8 +2787,9 @@ void SoftwareGLContext::gl_light_model(GLenum pname, GLfloat x, GLfloat y, GLflo
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_light_model, pname, x, y, z, w);
 
-    RETURN_WITH_ERROR_IF(!(pname == GL_LIGHT_MODEL_AMBIENT
-                             || pname == GL_LIGHT_MODEL_TWO_SIDE),
+    RETURN_WITH_ERROR_IF(pname != GL_LIGHT_MODEL_LOCAL_VIEWER
+            && pname != GL_LIGHT_MODEL_TWO_SIDE
+            && pname != GL_LIGHT_MODEL_AMBIENT,
         GL_INVALID_ENUM);
 
     auto lighting_params = m_rasterizer.light_model();

--- a/Userland/Libraries/LibGL/SoftwareGLContext.h
+++ b/Userland/Libraries/LibGL/SoftwareGLContext.h
@@ -211,9 +211,9 @@ private:
     float m_clear_depth { 1.f };
     u8 m_clear_stencil { 0 };
 
-    FloatVector4 m_current_vertex_color = { 1.0f, 1.0f, 1.0f, 1.0f };
+    FloatVector4 m_current_vertex_color { 1.0f, 1.0f, 1.0f, 1.0f };
     Vector<FloatVector4> m_current_vertex_tex_coord;
-    FloatVector3 m_current_vertex_normal = { 0.0f, 0.0f, 1.0f };
+    FloatVector3 m_current_vertex_normal { 0.0f, 0.0f, 1.0f };
 
     Vector<SoftGPU::Vertex> m_vertex_list;
 
@@ -261,10 +261,11 @@ private:
     GLenum m_current_draw_buffer = GL_BACK;
 
     // Client side arrays
-    bool m_client_side_vertex_array_enabled = false;
-    bool m_client_side_color_array_enabled = false;
+    bool m_client_side_vertex_array_enabled { false };
+    bool m_client_side_color_array_enabled { false };
     Vector<bool> m_client_side_texture_coord_array_enabled;
     size_t m_client_active_texture = 0;
+    bool m_client_side_normal_array_enabled { false };
 
     NonnullRefPtr<Gfx::Bitmap> m_frontbuffer;
 
@@ -413,6 +414,7 @@ private:
     VertexAttribPointer m_client_vertex_pointer;
     VertexAttribPointer m_client_color_pointer;
     Vector<VertexAttribPointer> m_client_tex_coord_pointer;
+    VertexAttribPointer m_client_normal_pointer;
 
     u8 m_pack_alignment { 4 };
     GLsizei m_unpack_row_length { 0 };


### PR DESCRIPTION
Apart from vertex, color and texture coord pointers, we now also support normal pointers in LibGL. Our port GLTron uses this for lighting information on the cycles, for example.

Before:
![image](https://user-images.githubusercontent.com/3210731/156904653-478ee873-9b1f-400e-b2d7-8dbfb002466a.png)

After: 
![image](https://user-images.githubusercontent.com/3210731/156904655-0a20a371-2082-4688-8e0e-63fcb40f3aff.png)
