### PR TITLE
LibGUI: Show TableView headers even without data

### DIFF
--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -83,7 +83,7 @@ HeaderView::VisibleSectionRange HeaderView::visible_section_range() const
 {
     auto section_count = this->section_count();
     auto is_horizontal = m_orientation == Orientation::Horizontal;
-    auto rect = m_table_view.visible_content_rect();
+    auto rect = m_table_view.frame_inner_rect();
     auto start = is_horizontal ? rect.top_left().x() : rect.top_left().y();
     auto end = is_horizontal ? rect.top_right().x() : rect.bottom_left().y();
     auto offset = 0;


### PR DESCRIPTION
This patch makes the TableView header visible even when the table does
not have any data.

This was a question asked in Office Hours, why the storage inspector does not show table headers when there are no cookies. The reason was that `visible_content_rect()` always returned 0,0 when it had no data. I think `frame_inner_rect()` is the correct rect for the header.

Note: The DOM Inspector still does not show headers when no DOM node is selected, because the Model is null.