### PR TITLE
LibLine+Shell+js: Random fun features & fixes because I felt like playing with LibLine again

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -974,6 +974,12 @@ void Editor::handle_read_event()
                     }
                     if (is_in_paste && param1 == 201) {
                         m_state = InputState::Free;
+                        if (on_paste) {
+                            on_paste(Utf32View { m_paste_buffer.data(), m_paste_buffer.size() }, *this);
+                            m_paste_buffer.clear_with_capacity();
+                        }
+                        if (!m_paste_buffer.is_empty())
+                            insert(Utf32View { m_paste_buffer.data(), m_paste_buffer.size() });
                         continue;
                     }
                 }
@@ -998,7 +1004,10 @@ void Editor::handle_read_event()
                 m_state = InputState::GotEscape;
                 continue;
             }
-            insert(code_point);
+            if (on_paste)
+                m_paste_buffer.append(code_point);
+            else
+                insert(code_point);
             continue;
         case InputState::Free:
             m_previous_free_state = InputState::Free;

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -489,7 +489,7 @@ void Editor::stylize(Span const& span, Style const& style)
     ending_map.set(start, style);
 }
 
-void Editor::suggest(size_t invariant_offset, size_t static_offset, Span::Mode offset_mode) const
+void Editor::transform_suggestion_offsets(size_t& invariant_offset, size_t& static_offset, Span::Mode offset_mode) const
 {
     auto internal_static_offset = static_offset;
     auto internal_invariant_offset = invariant_offset;
@@ -501,7 +501,8 @@ void Editor::suggest(size_t invariant_offset, size_t static_offset, Span::Mode o
         internal_static_offset = offsets.start;
         internal_invariant_offset = offsets.end - offsets.start;
     }
-    m_suggestion_manager.set_suggestion_variants(internal_static_offset, internal_invariant_offset, 0);
+    invariant_offset = internal_invariant_offset;
+    static_offset = internal_static_offset;
 }
 
 void Editor::initialize()
@@ -1141,7 +1142,6 @@ void Editor::handle_read_event()
                 // We have none, or just one suggestion,
                 // we should just commit that and continue
                 // after it, as if it were auto-completed.
-                suggest(0, 0, Span::CodepointOriented);
                 m_times_tab_pressed = 0;
                 m_suggestion_manager.reset();
                 m_suggestion_display->finish();
@@ -1180,7 +1180,6 @@ void Editor::cleanup_suggestions()
             m_refresh_needed = true;
         }
         m_suggestion_manager.reset();
-        suggest(0, 0, Span::CodepointOriented);
         m_suggestion_display->finish();
     }
     m_times_tab_pressed = 0; // Safe to say if we get here, the user didn't press TAB

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -218,22 +218,17 @@ void Editor::ensure_free_lines_from_origin(size_t count)
 void Editor::get_terminal_size()
 {
     struct winsize ws;
-
-    if (ioctl(STDERR_FILENO, TIOCGWINSZ, &ws) < 0) {
-        m_num_columns = 80;
-        m_num_lines = 25;
-    } else {
-        if (ws.ws_col == 0 || ws.ws_row == 0) {
-            // LLDB uses ttys which "work" and then gives us a zero sized
-            // terminal which is far from useful
-            if (int fd = open("/dev/tty", O_RDONLY); fd != -1) {
-                ioctl(fd, TIOCGWINSZ, &ws);
-                close(fd);
-            }
+    ioctl(STDERR_FILENO, TIOCGWINSZ, &ws);
+    if (ws.ws_col == 0 || ws.ws_row == 0) {
+        // LLDB uses ttys which "work" and then gives us a zero sized
+        // terminal which is far from useful
+        if (int fd = open("/dev/tty", O_RDONLY); fd != -1) {
+            ioctl(fd, TIOCGWINSZ, &ws);
+            close(fd);
         }
-        m_num_columns = ws.ws_col;
-        m_num_lines = ws.ws_row;
     }
+    m_num_columns = ws.ws_col;
+    m_num_lines = ws.ws_row;
 }
 
 void Editor::add_to_history(String const& line)

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -163,6 +163,7 @@ public:
     static StringMetrics actual_rendered_string_metrics(Utf32View const&);
 
     Function<Vector<CompletionSuggestion>(Editor const&)> on_tab_complete;
+    Function<void(Utf32View, Editor&)> on_paste;
     Function<void()> on_interrupt_handled;
     Function<void(Editor&)> on_display_refresh;
 
@@ -316,6 +317,7 @@ private:
         m_chars_touched_in_the_middle = 0;
         m_drawn_end_of_line_offset = 0;
         m_drawn_spans = {};
+        m_paste_buffer.clear_with_capacity();
     }
 
     void refresh_display();
@@ -490,6 +492,8 @@ private:
     } m_drawn_spans, m_current_spans;
 
     RefPtr<Core::Notifier> m_notifier;
+
+    Vector<u32> m_paste_buffer;
 
     bool m_initialized { false };
     bool m_refresh_needed { false };

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -221,7 +221,7 @@ public:
     //       +-|- static offset: the suggestions start here
     //         +- invariant offset: the suggestions do not change up to here
     //
-    void suggest(size_t invariant_offset = 0, size_t static_offset = 0, Span::Mode offset_mode = Span::ByteOriented) const;
+    void transform_suggestion_offsets(size_t& invariant_offset, size_t& static_offset, Span::Mode offset_mode = Span::ByteOriented) const;
 
     const struct termios& termios() const { return m_termios; }
     const struct termios& default_termios() const { return m_default_termios; }

--- a/Userland/Libraries/LibLine/SuggestionManager.h
+++ b/Userland/Libraries/LibLine/SuggestionManager.h
@@ -53,6 +53,8 @@ public:
     Style style;
     size_t start_index { 0 };
     size_t input_offset { 0 };
+    size_t static_offset { 0 };
+    size_t invariant_offset { 0 };
 
     Utf32View text_view;
     Utf32View trivia_view;
@@ -102,12 +104,6 @@ public:
 
     void next();
     void previous();
-    void set_suggestion_variants(size_t static_offset, size_t invariant_offset, size_t suggestion_index) const
-    {
-        m_next_suggestion_index = suggestion_index;
-        m_next_suggestion_static_offset = static_offset;
-        m_next_suggestion_invariant_offset = invariant_offset;
-    }
 
     CompletionSuggestion const& suggest();
     CompletionSuggestion const& current_suggestion() const { return m_last_shown_suggestion; }
@@ -131,8 +127,6 @@ private:
     size_t m_last_shown_suggestion_display_length { 0 };
     bool m_last_shown_suggestion_was_complete { false };
     mutable size_t m_next_suggestion_index { 0 };
-    mutable size_t m_next_suggestion_invariant_offset { 0 };
-    mutable size_t m_next_suggestion_static_offset { 0 };
     size_t m_largest_common_suggestion_prefix_length { 0 };
     mutable size_t m_last_displayed_suggestion_index { 0 };
     size_t m_selected_suggestion_index { 0 };

--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -2736,6 +2736,15 @@ HitTestResult Sequence::hit_test_position(size_t offset) const
     return {};
 }
 
+RefPtr<Node> Sequence::leftmost_trivial_literal() const
+{
+    for (auto& entry : m_entries) {
+        if (auto node = entry.leftmost_trivial_literal())
+            return node;
+    }
+    return nullptr;
+}
+
 Sequence::Sequence(Position position, NonnullRefPtrVector<Node> entries, Vector<Position> separator_positions)
     : Node(move(position))
     , m_entries(move(entries))

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -1183,6 +1183,7 @@ private:
     virtual HitTestResult hit_test_position(size_t) const override;
     virtual bool is_list() const override { return true; }
     virtual bool should_override_execution_in_current_process() const override { return true; }
+    virtual RefPtr<Node> leftmost_trivial_literal() const override;
 
     NonnullRefPtrVector<Node> m_entries;
     Vector<Position> m_separator_positions;

--- a/Userland/Shell/AST.h
+++ b/Userland/Shell/AST.h
@@ -1344,11 +1344,18 @@ private:
 
 class StringLiteral final : public Node {
 public:
-    StringLiteral(Position, String);
+    enum class EnclosureType {
+        None,
+        SingleQuotes,
+        DoubleQuotes,
+    };
+
+    StringLiteral(Position, String, EnclosureType);
     virtual ~StringLiteral();
     virtual void visit(NodeVisitor& visitor) override { visitor.visit(this); }
 
     const String& text() const { return m_text; }
+    EnclosureType enclosure_type() const { return m_enclosure_type; }
 
 private:
     NODE(StringLiteral);
@@ -1358,6 +1365,7 @@ private:
     virtual RefPtr<Node> leftmost_trivial_literal() const override { return this; };
 
     String m_text;
+    EnclosureType m_enclosure_type;
 };
 
 class StringPartCompose final : public Node {

--- a/Userland/Shell/ImmediateFunctions.cpp
+++ b/Userland/Shell/ImmediateFunctions.cpp
@@ -228,7 +228,7 @@ RefPtr<AST::Node> Shell::immediate_regex_replace(AST::ImmediateExpression& invok
     Regex<PosixExtendedParser> re { pattern->resolve_as_list(this).first() };
     auto result = re.replace(value->resolve_as_list(this)[0], replacement->resolve_as_list(this)[0], PosixFlags::Global | PosixFlags::Multiline | PosixFlags::Unicode);
 
-    return AST::make_ref_counted<AST::StringLiteral>(invoking_node.position(), move(result));
+    return AST::make_ref_counted<AST::StringLiteral>(invoking_node.position(), move(result), AST::StringLiteral::EnclosureType::None);
 }
 
 RefPtr<AST::Node> Shell::immediate_remove_suffix(AST::ImmediateExpression& invoking_node, const NonnullRefPtrVector<AST::Node>& arguments)
@@ -256,7 +256,7 @@ RefPtr<AST::Node> Shell::immediate_remove_suffix(AST::ImmediateExpression& invok
 
         if (value_str.ends_with(suffix_str))
             removed = removed.substring_view(0, value_str.length() - suffix_str.length());
-        nodes.append(AST::make_ref_counted<AST::StringLiteral>(invoking_node.position(), removed));
+        nodes.append(AST::make_ref_counted<AST::StringLiteral>(invoking_node.position(), removed, AST::StringLiteral::EnclosureType::None));
     }
 
     return AST::make_ref_counted<AST::ListConcatenate>(invoking_node.position(), move(nodes));
@@ -287,7 +287,7 @@ RefPtr<AST::Node> Shell::immediate_remove_prefix(AST::ImmediateExpression& invok
 
         if (value_str.starts_with(prefix_str))
             removed = removed.substring_view(prefix_str.length());
-        nodes.append(AST::make_ref_counted<AST::StringLiteral>(invoking_node.position(), removed));
+        nodes.append(AST::make_ref_counted<AST::StringLiteral>(invoking_node.position(), removed, AST::StringLiteral::EnclosureType::None));
     }
 
     return AST::make_ref_counted<AST::ListConcatenate>(invoking_node.position(), move(nodes));
@@ -375,7 +375,7 @@ RefPtr<AST::Node> Shell::immediate_concat_lists(AST::ImmediateExpression& invoki
             } else {
                 auto values = list_of_values->resolve_as_list(this);
                 for (auto& entry : values)
-                    result.append(AST::make_ref_counted<AST::StringLiteral>(argument.position(), entry));
+                    result.append(AST::make_ref_counted<AST::StringLiteral>(argument.position(), entry, AST::StringLiteral::EnclosureType::None));
             }
         }
     }

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -164,6 +164,7 @@ public:
     static String escape_token_for_double_quotes(StringView token);
     static String escape_token_for_single_quotes(StringView token);
     static String escape_token(StringView token, EscapeMode = EscapeMode::Bareword);
+    static String escape_token(Utf32View token, EscapeMode = EscapeMode::Bareword);
     static String unescape_token(StringView token);
     enum class SpecialCharacterEscapeMode {
         Untouched,

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1580,6 +1580,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                         Line::CompletionSuggestion completion { key, Line::CompletionSuggestion::ForSearch };
                         if (!results.contains_slow(completion)) { // hide duplicates
                             results.append(String(key));
+                            results.last().invariant_offset = property_pattern.length();
                         }
                     }
                 }
@@ -1605,8 +1606,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 auto const* object = MUST(variable.to_object(interpreter->global_object()));
                 auto const& shape = object->shape();
                 list_all_properties(shape, property_name);
-                if (results.size())
-                    editor.suggest(property_name.length());
                 break;
             }
             case CompleteVariable: {
@@ -1614,12 +1613,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                 list_all_properties(variable.shape(), variable_name);
 
                 for (String& name : global_environment.declarative_record().bindings()) {
-                    if (name.starts_with(variable_name))
+                    if (name.starts_with(variable_name)) {
                         results.empend(name);
+                        results.last().invariant_offset = variable_name.length();
+                    }
                 }
 
-                if (results.size())
-                    editor.suggest(variable_name.length());
                 break;
             }
             default:

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1451,7 +1451,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             bool indenters_starting_line = true;
             for (JS::Token token = lexer.next(); token.type() != JS::TokenType::Eof; token = lexer.next()) {
                 auto length = Utf8View { token.value() }.length();
-                auto start = token.line_column() - 1;
+                auto start = token.offset();
                 auto end = start + length;
                 if (indenters_starting_line) {
                     if (token.type() != JS::TokenType::ParenClose && token.type() != JS::TokenType::BracketClose && token.type() != JS::TokenType::CurlyClose) {


### PR DESCRIPTION
- js: Use token offset for highlighting instead of column offset
	Can you believe no one notices that multiline highlighting was broken in `js(1)`?
- LibLine: Never assume a 25x80 terminal
    This made the cursor jump to row 25 when the program did something silly with termios; just don't assume anything and read from `/dev/tty` instead, and if that fails...good luck.
- LibLine+Userland: Make suggestion offsets per-suggestion
    Begone `Editor::suggest()`. I hated this API from the day after I added it (now suggestions can replace different parts of the input)
- Shell: Allow completing StringLiterals as paths
    `ls './<tab>`
- The rest:

https://user-images.githubusercontent.com/14001776/156917962-80a6d0be-bfcf-4f8a-b1db-44eb8e68e0b3.mp4

