### PR TITLE
LibC: Remove semicolon in definition of FD_ZERO

### DIFF
--- a/Userland/Libraries/LibC/fd_set.h
+++ b/Userland/Libraries/LibC/fd_set.h
@@ -7,7 +7,10 @@
 #pragma once
 
 #define FD_SETSIZE 1024
-#define FD_ZERO(set) memset((set), 0, sizeof(fd_set));
+#define FD_ZERO(set)                      \
+    do {                                  \
+        memset((set), 0, sizeof(fd_set)); \
+    } while (0)
 #define FD_CLR(fd, set) ((set)->fds_bits[(fd / 8)] &= ~(1 << (fd) % 8))
 #define FD_SET(fd, set) ((set)->fds_bits[(fd / 8)] |= (1 << (fd) % 8))
 #define FD_ISSET(fd, set) ((set)->fds_bits[(fd / 8)] & (1 << (fd) % 8))


### PR DESCRIPTION
This causes problems in code of the form

```c
if (/* condition */)
  FD_ZERO(&thing);
else
  do_other_thing();
```

Wrapping the call to memset() in a do/while block fixes the issue.