### PR TITLE
Help: Fix selection bug caused by scrolling between pages too fast

### DIFF
--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -292,7 +292,6 @@ void MainWidget::open_url(URL const& url)
             auto browse_view_index = m_manual_model->index_from_path(path);
             if (browse_view_index.has_value()) {
                 m_browse_view->expand_tree(browse_view_index.value().parent());
-                m_browse_view->selection().set(browse_view_index.value());
 
                 String page_and_section = m_manual_model->page_and_section(browse_view_index.value());
                 window()->set_title(String::formatted("{} - Help", page_and_section));


### PR DESCRIPTION
[A GIF of the bug](https://imgur.com/s5zZJ4v)

When scrolling too fast between pages in the Help application (e.g. by holding down the down key) the application sometimes starts "freaking out" and starts looping between pages forever, using up a lot of CPU power. 

This bug seems to be caused by the selection update in the MainWidget::load_url() function. Removing this function call fixes the bug and doesn't break the program since the selection still gets updated in the AbstractView::keydown_event() and AbstractView::mousedown() event handlers. 

Edit: Maybe this solution is possibly "sweeping under the rug" a deeper problem with the event queue since moving the selection update out of the deferred invoke also seems to fix the problem? I'm very new to this project and don't know much about the event loop but would like to get your thoughts on this if it should be investigated further.