### PR TITLE
LibWeb: Fire resize event at the Window instead of Document

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -1286,7 +1286,7 @@ void Document::run_the_resize_steps()
         return;
     m_last_viewport_size = viewport_size;
 
-    dispatch_event(DOM::Event::create(UIEvents::EventNames::resize));
+    window().dispatch_event(DOM::Event::create(UIEvents::EventNames::resize));
 
     update_layout();
 }


### PR DESCRIPTION
The spec says "fire an event named resize at the Window object
associated with doc."

However, we were accidentally firing it at `doc` instead of the Window.