### PR TITLE
LibJS: Implement the Error.prototype.stack setter

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ErrorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorPrototype.h
@@ -22,7 +22,8 @@ public:
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(to_string);
-    JS_DECLARE_NATIVE_FUNCTION(stack);
+    JS_DECLARE_NATIVE_FUNCTION(stack_getter);
+    JS_DECLARE_NATIVE_FUNCTION(stack_setter);
 };
 
 #define DECLARE_NATIVE_ERROR_PROTOTYPE(ClassName, snake_name, PrototypeName, ConstructorName) \

--- a/Userland/Libraries/LibJS/Tests/builtins/Error/Error.prototype.stack-setter.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Error/Error.prototype.stack-setter.js
@@ -1,0 +1,73 @@
+const stackDescriptor = Object.getOwnPropertyDescriptor(Error.prototype, "stack");
+const stackSetter = stackDescriptor.set;
+
+describe("normal behavior", () => {
+    test("basic functionality", () => {
+        "use strict";
+        const error = new Error();
+        expect(Object.hasOwn(error, "stack")).toBeFalse();
+        expect(() => {
+            error.stack = "hello world";
+        }).not.toThrowWithMessage(TypeError, "Cannot set property 'stack' of [object Error]");
+        expect(Object.hasOwn(error, "stack")).toBeTrue();
+        expect(error.stack).toBe("hello world");
+    });
+
+    test("the name of the set function is 'set stack'", () => {
+        expect(stackSetter.name).toBe("set stack");
+    });
+
+    test("works on any object", () => {
+        const nonError = {};
+        expect(Object.hasOwn(nonError, "stack")).toBeFalse();
+        stackSetter.call(nonError, "hello world");
+        expect(Object.hasOwn(nonError, "stack")).toBeTrue();
+        expect(nonError.stack).toBe("hello world");
+    });
+
+    test("accepts any value", () => {
+        const nonError = { stack: 1 };
+        stackSetter.call(nonError, undefined);
+        expect(nonError.stack).toBeUndefined();
+        stackSetter.call(nonError, null);
+        expect(nonError.stack).toBeNull();
+        stackSetter.call(nonError, NaN);
+        expect(nonError.stack).toBeNaN();
+        stackSetter.call(nonError, 1n);
+        expect(nonError.stack).toBe(1n);
+    });
+});
+
+describe("errors", () => {
+    test("this is not an object", () => {
+        expect(() => {
+            stackSetter.call(undefined);
+        }).toThrowWithMessage(TypeError, "undefined is not an object");
+
+        expect(() => {
+            stackSetter.call(null);
+        }).toThrowWithMessage(TypeError, "null is not an object");
+
+        expect(() => {
+            stackSetter.call(1);
+        }).toThrowWithMessage(TypeError, "1 is not an object");
+
+        expect(() => {
+            stackSetter.call("foo");
+        }).toThrowWithMessage(TypeError, "foo is not an object");
+    });
+
+    test("requires one argument", () => {
+        expect(() => {
+            stackSetter.call({});
+        }).toThrowWithMessage(TypeError, "set stack() needs one argument");
+    });
+
+    test("create_data_property_or_throw can throw", () => {
+        const revocable = Proxy.revocable([], {});
+        revocable.revoke();
+        expect(() => {
+            stackSetter.call(revocable.proxy, "foo");
+        }).toThrowWithMessage(TypeError, "An operation was performed on a revoked Proxy object");
+    });
+});


### PR DESCRIPTION
This implements the setter based on the Error Stacks proposal.
https://tc39.es/proposal-error-stacks/#sec-set-error.prototype-stack

Required by Twitch. Along with #12862, we can start displaying the home page:
![Screenshot from 2022-03-06 14-46-15](https://user-images.githubusercontent.com/25595356/156929906-771d08c7-3e54-4d04-9cc1-19beef83ece6.png)

