### PR TITLE
Taskbar: Add tooltip hint for Super+Digit shortcuts

### DIFF
--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -20,42 +20,6 @@
 
 namespace GUI {
 
-class Application::TooltipWindow final : public Window {
-    C_OBJECT(TooltipWindow);
-
-public:
-    void set_tooltip(const String& tooltip)
-    {
-        m_label->set_text(Gfx::parse_ampersand_string(tooltip));
-        int tooltip_width = m_label->min_width() + 10;
-        int line_count = m_label->text().count("\n");
-        int glyph_height = m_label->font().glyph_height();
-        int tooltip_height = glyph_height * (1 + line_count) + ((glyph_height + 1) / 2) * line_count + 8;
-
-        Gfx::IntRect desktop_rect = Desktop::the().rect();
-        if (tooltip_width > desktop_rect.width())
-            tooltip_width = desktop_rect.width();
-
-        set_rect(rect().x(), rect().y(), tooltip_width, tooltip_height);
-    }
-
-private:
-    TooltipWindow()
-    {
-        set_window_type(WindowType::Tooltip);
-        m_label = set_main_widget<Label>();
-        m_label->set_background_role(Gfx::ColorRole::Tooltip);
-        m_label->set_foreground_role(Gfx::ColorRole::TooltipText);
-        m_label->set_fill_with_background_color(true);
-        m_label->set_frame_thickness(1);
-        m_label->set_frame_shape(Gfx::FrameShape::Container);
-        m_label->set_frame_shadow(Gfx::FrameShadow::Plain);
-        m_label->set_autosize(true);
-    }
-
-    RefPtr<Label> m_label;
-};
-
 static NeverDestroyed<WeakPtr<Application>> s_the;
 
 Application* Application::the()
@@ -149,7 +113,6 @@ void Application::show_tooltip(String tooltip, const Widget* tooltip_source_widg
     m_tooltip_source_widget = tooltip_source_widget;
     if (!m_tooltip_window) {
         m_tooltip_window = TooltipWindow::construct();
-        m_tooltip_window->set_double_buffering_enabled(false);
     }
     m_tooltip_window->set_tooltip(move(tooltip));
 
@@ -168,7 +131,6 @@ void Application::show_tooltip_immediately(String tooltip, const Widget* tooltip
     m_tooltip_source_widget = tooltip_source_widget;
     if (!m_tooltip_window) {
         m_tooltip_window = TooltipWindow::construct();
-        m_tooltip_window->set_double_buffering_enabled(false);
     }
     m_tooltip_window->set_tooltip(move(tooltip));
 

--- a/Userland/Libraries/LibGUI/Application.h
+++ b/Userland/Libraries/LibGUI/Application.h
@@ -14,6 +14,7 @@
 #include <LibCore/Object.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Shortcut.h>
+#include <LibGUI/TooltipWindow.h>
 #include <LibGUI/Widget.h>
 #include <LibGfx/Point.h>
 #include <LibMain/Main.h>
@@ -105,7 +106,6 @@ private:
     RefPtr<Gfx::PaletteImpl> m_palette;
     RefPtr<Gfx::PaletteImpl> m_system_palette;
     HashMap<Shortcut, Action*> m_global_shortcut_actions;
-    class TooltipWindow;
     RefPtr<Core::Timer> m_tooltip_show_timer;
     RefPtr<Core::Timer> m_tooltip_hide_timer;
     RefPtr<TooltipWindow> m_tooltip_window;

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -104,6 +104,7 @@ set(SOURCES
     TextEditor.cpp
     Toolbar.cpp
     ToolbarContainer.cpp
+    TooltipWindow.cpp
     Tray.cpp
     TreeView.cpp
     UndoStack.cpp

--- a/Userland/Libraries/LibGUI/ConnectionToWindowMangerServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowMangerServer.cpp
@@ -52,10 +52,22 @@ void ConnectionToWindowMangerServer::window_removed(i32 wm_id, i32 client_id, i3
         Core::EventLoop::current().post_event(*window, make<WMWindowRemovedEvent>(client_id, window_id));
 }
 
+void ConnectionToWindowMangerServer::super_key_down(i32 wm_id)
+{
+    if (auto* window = Window::from_window_id(wm_id))
+        Core::EventLoop::current().post_event(*window, make<WMSuperKeyDownEvent>(wm_id));
+}
+
 void ConnectionToWindowMangerServer::super_key_pressed(i32 wm_id)
 {
     if (auto* window = Window::from_window_id(wm_id))
         Core::EventLoop::current().post_event(*window, make<WMSuperKeyPressedEvent>(wm_id));
+}
+
+void ConnectionToWindowMangerServer::super_key_up(i32 wm_id)
+{
+    if (auto* window = Window::from_window_id(wm_id))
+        Core::EventLoop::current().post_event(*window, make<WMSuperKeyUpEvent>(wm_id));
 }
 
 void ConnectionToWindowMangerServer::super_space_key_pressed(i32 wm_id)

--- a/Userland/Libraries/LibGUI/ConnectionToWindowMangerServer.h
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowMangerServer.h
@@ -32,7 +32,9 @@ private:
     virtual void window_icon_bitmap_changed(i32, i32, i32, Gfx::ShareableBitmap const&) override;
     virtual void window_rect_changed(i32, i32, i32, Gfx::IntRect const&) override;
     virtual void applet_area_size_changed(i32, Gfx::IntSize const&) override;
+    virtual void super_key_down(i32) override;
     virtual void super_key_pressed(i32) override;
+    virtual void super_key_up(i32) override;
     virtual void super_space_key_pressed(i32) override;
     virtual void super_digit_key_pressed(i32, u8) override;
     virtual void workspace_changed(i32, u32, u32) override;

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -64,7 +64,9 @@ public:
         WM_WindowRectChanged,
         WM_WindowIconBitmapChanged,
         WM_AppletAreaSizeChanged,
+        WM_SuperKeyDown,
         WM_SuperKeyPressed,
+        WM_SuperKeyUp,
         WM_SuperSpaceKeyPressed,
         WM_SuperDigitKeyPressed,
         WM_WorkspaceChanged,
@@ -100,10 +102,26 @@ private:
     int m_window_id { -1 };
 };
 
+class WMSuperKeyDownEvent : public WMEvent {
+public:
+    explicit WMSuperKeyDownEvent(int client_id)
+        : WMEvent(Event::Type::WM_SuperKeyDown, client_id, 0)
+    {
+    }
+};
+
 class WMSuperKeyPressedEvent : public WMEvent {
 public:
     explicit WMSuperKeyPressedEvent(int client_id)
         : WMEvent(Event::Type::WM_SuperKeyPressed, client_id, 0)
+    {
+    }
+};
+
+class WMSuperKeyUpEvent : public WMEvent {
+public:
+    explicit WMSuperKeyUpEvent(int client_id)
+        : WMEvent(Event::Type::WM_SuperKeyUp, client_id, 0)
     {
     }
 };

--- a/Userland/Libraries/LibGUI/TooltipWindow.cpp
+++ b/Userland/Libraries/LibGUI/TooltipWindow.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibGUI/Application.h>
+#include <LibGUI/Desktop.h>
+#include <LibGUI/Label.h>
+#include <LibGUI/Window.h>
+#include <LibGfx/Painter.h>
+#include <LibGfx/SystemTheme.h>
+#include <LibGfx/TextAlignment.h>
+
+namespace GUI {
+
+void TooltipWindow::set_tooltip(const String& tooltip)
+{
+    m_label->set_text(Gfx::parse_ampersand_string(tooltip));
+    int tooltip_width = m_label->min_width() + 10;
+    int line_count = m_label->text().count("\n");
+    int glyph_height = m_label->font().glyph_height();
+    int tooltip_height = glyph_height * (1 + line_count) + ((glyph_height + 1) / 2) * line_count + 8;
+
+    Gfx::IntRect desktop_rect = Desktop::the().rect();
+    if (tooltip_width > desktop_rect.width())
+        tooltip_width = desktop_rect.width();
+
+    set_rect(rect().x(), rect().y(), tooltip_width, tooltip_height);
+}
+
+TooltipWindow::TooltipWindow()
+{
+    set_window_type(WindowType::Tooltip);
+    set_double_buffering_enabled(false);
+
+    m_label = set_main_widget<Label>();
+    m_label->set_background_role(Gfx::ColorRole::Tooltip);
+    m_label->set_foreground_role(Gfx::ColorRole::TooltipText);
+    m_label->set_fill_with_background_color(true);
+    m_label->set_frame_thickness(1);
+    m_label->set_frame_shape(Gfx::FrameShape::Container);
+    m_label->set_frame_shadow(Gfx::FrameShadow::Plain);
+    m_label->set_autosize(true);
+}
+
+}

--- a/Userland/Libraries/LibGUI/TooltipWindow.h
+++ b/Userland/Libraries/LibGUI/TooltipWindow.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Window.h>
+
+namespace GUI {
+
+class TooltipWindow final : public Window {
+    C_OBJECT(TooltipWindow);
+
+public:
+    void set_tooltip(const String& tooltip);
+
+private:
+    TooltipWindow();
+
+    RefPtr<Label> m_label;
+};
+
+}

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -10,6 +10,7 @@
 #include "QuickLaunchWidget.h"
 #include "TaskbarButton.h"
 #include <AK/Debug.h>
+#include <AK/IterationDecision.h>
 #include <LibCore/StandardPaths.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -335,21 +336,20 @@ void TaskbarWindow::wm_event(GUI::WMEvent& event)
         break;
     }
     case GUI::Event::WM_SuperDigitKeyPressed: {
+        m_start_menu->dismiss();
+
         auto& digit_event = static_cast<GUI::WMSuperDigitKeyPressedEvent&>(event);
         auto index = digit_event.digit() != 0 ? digit_event.digit() - 1 : 9;
 
-        for (auto& widget : m_task_button_container->child_widgets()) {
-            // NOTE: The button might be invisible depending on the current workspace
-            if (!widget.is_visible())
-                continue;
-
+        for_each_visible_taskbar_button([&](auto& button) {
             if (index == 0) {
-                static_cast<TaskbarButton&>(widget).click();
-                break;
+                static_cast<TaskbarButton&>(button).click();
+                return IterationDecision::Break;
             }
 
             --index;
-        }
+            return IterationDecision::Continue;
+        });
         break;
     }
     case GUI::Event::WM_WorkspaceChanged: {

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -335,6 +335,14 @@ void TaskbarWindow::wm_event(GUI::WMEvent& event)
             warnln("failed to spawn 'Assistant' when requested via Super+Space");
         break;
     }
+    case GUI::Event::WM_SuperKeyDown: {
+        show_task_button_tooltips();
+        break;
+    }
+    case GUI::Event::WM_SuperKeyUp: {
+        hide_task_button_tooltips();
+        break;
+    }
     case GUI::Event::WM_SuperDigitKeyPressed: {
         m_start_menu->dismiss();
 
@@ -387,4 +395,37 @@ void TaskbarWindow::set_start_button_font(Gfx::Font const& font)
 {
     m_start_button->set_font(font);
     m_start_button->set_fixed_size(font.width(m_start_button->text()) + 30, 21);
+}
+
+void TaskbarWindow::show_task_button_tooltips()
+{
+    size_t index = 0;
+
+    for_each_visible_taskbar_button([&](auto& button) {
+        if (index >= 10)
+            return IterationDecision::Break;
+
+        if (index >= m_task_button_tooltips.size())
+            m_task_button_tooltips.append(GUI::TooltipWindow::construct());
+
+        VERIFY(index < m_task_button_tooltips.size());
+        auto& window = m_task_button_tooltips[index++];
+
+        auto key = index != 10 ? index : 0;
+        window.set_tooltip(String::number(key));
+
+        auto rect = button.screen_relative_rect();
+        Gfx::IntPoint position(rect.center().x() - window.width() / 2, rect.y() - window.height());
+        window.move_to(position);
+
+        window.show();
+
+        return IterationDecision::Continue;
+    });
+}
+
+void TaskbarWindow::hide_task_button_tooltips()
+{
+    for (auto& window : m_task_button_tooltips)
+        window.hide();
 }

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -8,8 +8,10 @@
 
 #include "TaskbarButton.h"
 #include "WindowList.h"
+#include <AK/NonnullRefPtrVector.h>
 #include <LibConfig/Listener.h>
 #include <LibDesktop/AppFile.h>
+#include <LibGUI/TooltipWindow.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/ShareableBitmap.h>
@@ -47,6 +49,9 @@ private:
         });
     }
 
+    void show_task_button_tooltips();
+    void hide_task_button_tooltips();
+
     virtual void event(Core::Event&) override;
     virtual void wm_event(GUI::WMEvent&) override;
     virtual void screen_rects_change_event(GUI::ScreenRectsChangeEvent&) override;
@@ -60,6 +65,7 @@ private:
 
     NonnullRefPtr<GUI::Menu> m_start_menu;
     RefPtr<GUI::Widget> m_task_button_container;
+    NonnullRefPtrVector<GUI::TooltipWindow> m_task_button_tooltips;
     RefPtr<Gfx::Bitmap> m_default_icon;
 
     Gfx::IntSize m_applet_area_size;

--- a/Userland/Services/Taskbar/TaskbarWindow.h
+++ b/Userland/Services/Taskbar/TaskbarWindow.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "TaskbarButton.h"
 #include "WindowList.h"
 #include <LibConfig/Listener.h>
 #include <LibDesktop/AppFile.h>
@@ -33,6 +34,18 @@ private:
     void remove_window_button(::Window&, bool);
     void update_window_button(::Window&, bool);
     ::Window* find_window_owner(::Window&) const;
+
+    template<typename Callback>
+    void for_each_visible_taskbar_button(Callback callback)
+    {
+        m_task_button_container->for_each_child_widget([&](auto& widget) {
+            // The button might be invisible depending on the current workspace
+            if (!widget.is_visible())
+                return IterationDecision::Continue;
+
+            return callback(static_cast<TaskbarButton&>(widget));
+        });
+    }
 
     virtual void event(Core::Event&) override;
     virtual void wm_event(GUI::WMEvent&) override;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -524,6 +524,17 @@ void WindowManager::tell_wms_applet_area_size_changed(Gfx::IntSize const& size)
     });
 }
 
+void WindowManager::tell_wms_super_key_down()
+{
+    for_each_window_manager([](WMConnectionFromClient& conn) {
+        if (conn.window_id() < 0)
+            return IterationDecision::Continue;
+
+        conn.async_super_key_down(conn.window_id());
+        return IterationDecision::Continue;
+    });
+}
+
 void WindowManager::tell_wms_super_key_pressed()
 {
     for_each_window_manager([](WMConnectionFromClient& conn) {
@@ -531,6 +542,17 @@ void WindowManager::tell_wms_super_key_pressed()
             return IterationDecision::Continue;
 
         conn.async_super_key_pressed(conn.window_id());
+        return IterationDecision::Continue;
+    });
+}
+
+void WindowManager::tell_wms_super_key_up()
+{
+    for_each_window_manager([](WMConnectionFromClient& conn) {
+        if (conn.window_id() < 0)
+            return IterationDecision::Continue;
+
+        conn.async_super_key_up(conn.window_id());
         return IterationDecision::Continue;
     });
 }
@@ -1601,8 +1623,12 @@ void WindowManager::process_key_event(KeyEvent& event)
         return;
     }
 
+    if (event.type() == Event::KeyUp && event.key() == Key_Super)
+        tell_wms_super_key_up();
+
     if (event.type() == Event::KeyDown && event.key() == Key_Super) {
         m_previous_event_was_super_keydown = true;
+        tell_wms_super_key_down();
     } else if (m_previous_event_was_super_keydown) {
         m_previous_event_was_super_keydown = false;
         if (!m_dnd_client && !current_window_stack().active_input_tracking_window() && event.type() == Event::KeyUp && event.key() == Key_Super) {

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -1614,12 +1614,12 @@ void WindowManager::process_key_event(KeyEvent& event)
             tell_wms_super_space_key_pressed();
             return;
         }
+    }
 
-        if (event.type() == Event::KeyDown && event.key() >= Key_0 && event.key() <= Key_9) {
-            auto digit = event.key() - Key_0;
-            tell_wms_super_digit_key_pressed(digit);
-            return;
-        }
+    if (event.type() == Event::KeyDown && event.key() >= Key_0 && event.key() <= Key_9) {
+        auto digit = event.key() - Key_0;
+        tell_wms_super_digit_key_pressed(digit);
+        return;
     }
 
     if (MenuManager::the().current_menu() && event.key() != Key_Super) {

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -185,7 +185,9 @@ public:
     void tell_wms_window_rect_changed(Window&);
     void tell_wms_screen_rects_changed();
     void tell_wms_applet_area_size_changed(Gfx::IntSize const&);
+    void tell_wms_super_key_down();
     void tell_wms_super_key_pressed();
+    void tell_wms_super_key_up();
     void tell_wms_super_space_key_pressed();
     void tell_wms_super_digit_key_pressed(u8);
     void tell_wms_current_window_stack_changed();

--- a/Userland/Services/WindowServer/WindowManagerClient.ipc
+++ b/Userland/Services/WindowServer/WindowManagerClient.ipc
@@ -7,7 +7,9 @@ endpoint WindowManagerClient
     window_icon_bitmap_changed(i32 wm_id, i32 client_id, i32 window_id, Gfx::ShareableBitmap bitmap) =|
     window_rect_changed(i32 wm_id, i32 client_id, i32 window_id, Gfx::IntRect rect) =|
     applet_area_size_changed(i32 wm_id, Gfx::IntSize size) =|
+    super_key_down(i32 wm_id) =|
     super_key_pressed(i32 wm_id) =|
+    super_key_up(i32 wm_id) =|
     super_space_key_pressed(i32 wm_id) =|
     super_digit_key_pressed(i32 wm_id, u8 digit) =|
     workspace_changed(i32 wm_id, u32 row, u32 column) =|


### PR DESCRIPTION
This pull request
- adds tooltips for Super+Digit when holding <kbd>Super</kbd>
- accepts the following keyboard sequence:
   - Super key down
   - Digit key down
   - Digit key up
   - Digit key down
 - makes sure that the start menu is closed when pressing Super+Digit.

![image](https://user-images.githubusercontent.com/8530833/156936849-5ff24504-cf5a-4895-b0f4-4a81ace50330.png)

This improves upon #12744.
