### PR TITLE
LibSoftGPU+LibGfx: Improve triangle rendering quality

### DIFF
--- a/Userland/Libraries/LibGfx/VectorN.h
+++ b/Userland/Libraries/LibGfx/VectorN.h
@@ -201,7 +201,12 @@ public:
             return AK::sqrt(m_data[0] * m_data[0] + m_data[1] * m_data[1] + m_data[2] * m_data[2] + m_data[3] * m_data[3]);
     }
 
-    [[nodiscard]] constexpr VectorN<3, T> xyz() const requires(N == 4)
+    [[nodiscard]] constexpr VectorN<2, T> xy() const requires(N >= 3)
+    {
+        return VectorN<2, T>(x(), y());
+    }
+
+    [[nodiscard]] constexpr VectorN<3, T> xyz() const requires(N >= 4)
     {
         return VectorN<3, T>(x(), y(), z());
     }

--- a/Userland/Libraries/LibGfx/VectorN.h
+++ b/Userland/Libraries/LibGfx/VectorN.h
@@ -193,12 +193,11 @@ public:
 
     [[nodiscard]] constexpr T length() const
     {
-        if constexpr (N == 2)
-            return AK::hypot(m_data[0] * m_data[0] + m_data[1] * m_data[1]);
-        else if constexpr (N == 3)
-            return AK::sqrt(m_data[0] * m_data[0] + m_data[1] * m_data[1] + m_data[2] * m_data[2]);
-        else
-            return AK::sqrt(m_data[0] * m_data[0] + m_data[1] * m_data[1] + m_data[2] * m_data[2] + m_data[3] * m_data[3]);
+        T squared_sum {};
+        UNROLL_LOOP
+        for (auto i = 0u; i < N; ++i)
+            squared_sum += m_data[i] * m_data[i];
+        return AK::sqrt(squared_sum);
     }
 
     [[nodiscard]] constexpr VectorN<2, T> xy() const requires(N >= 3)

--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -17,7 +17,6 @@ namespace SoftGPU {
 static constexpr bool ENABLE_STATISTICS_OVERLAY = false;
 static constexpr int NUM_SAMPLERS = 2;
 static constexpr int MILLISECONDS_PER_STATISTICS_PERIOD = 500;
-static constexpr int SUBPIXEL_BITS = 5;
 static constexpr int NUM_LIGHTS = 8;
 
 // See: https://www.khronos.org/opengl/wiki/Common_Mistakes#Texture_edge_color_problem

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1316,8 +1316,8 @@ Gfx::IntRect Device::get_rasterization_rect_of_size(Gfx::IntSize size)
     // "Any fragments whose centers lie inside of this rectangle (or on its bottom or left
     // boundaries) are produced in correspondence with this particular group of elements."
     return {
-        static_cast<int>(roundf(m_raster_position.window_coordinates.x())),
-        static_cast<int>(roundf(m_raster_position.window_coordinates.y())),
+        static_cast<int>(lroundf(m_raster_position.window_coordinates.x())),
+        static_cast<int>(lroundf(m_raster_position.window_coordinates.y())),
         size.width(),
         size.height(),
     };

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -192,9 +192,9 @@ void Device::rasterize_triangle(const Triangle& triangle)
     Vertex const vertex2 = triangle.vertices[2];
 
     // Calculate area of the triangle for later tests
-    FloatVector2 const v0 { vertex0.window_coordinates.x(), vertex0.window_coordinates.y() };
-    FloatVector2 const v1 { vertex1.window_coordinates.x(), vertex1.window_coordinates.y() };
-    FloatVector2 const v2 { vertex2.window_coordinates.x(), vertex2.window_coordinates.y() };
+    FloatVector2 const v0 = vertex0.window_coordinates.xy();
+    FloatVector2 const v1 = vertex1.window_coordinates.xy();
+    FloatVector2 const v2 = vertex2.window_coordinates.xy();
 
     auto const area = edge_function(v0, v1, v2);
     auto const one_over_area = 1.0f / area;
@@ -608,7 +608,7 @@ static void generate_texture_coordinates(Vertex& vertex, RasterizerOptions const
         }
         case TexCoordGenerationMode::SphereMap: {
             auto const eye_unit = vertex.eye_coordinates.normalized();
-            FloatVector3 const eye_unit_xyz = { eye_unit.x(), eye_unit.y(), eye_unit.z() };
+            FloatVector3 const eye_unit_xyz = eye_unit.xyz();
             auto const normal = vertex.normal;
             auto reflection = eye_unit_xyz - normal * 2 * normal.dot(eye_unit_xyz);
             reflection.set_z(reflection.z() + 1);
@@ -617,7 +617,7 @@ static void generate_texture_coordinates(Vertex& vertex, RasterizerOptions const
         }
         case TexCoordGenerationMode::ReflectionMap: {
             auto const eye_unit = vertex.eye_coordinates.normalized();
-            FloatVector3 const eye_unit_xyz = { eye_unit.x(), eye_unit.y(), eye_unit.z() };
+            FloatVector3 const eye_unit_xyz = eye_unit.xyz();
             auto const normal = vertex.normal;
             auto reflection = eye_unit_xyz - normal * 2 * normal.dot(eye_unit_xyz);
             switch (config_index) {
@@ -995,7 +995,7 @@ ALWAYS_INLINE void Device::shade_fragments(PixelQuad& quad)
         // FIXME: implement GL_TEXTURE_1D, GL_TEXTURE_3D and GL_TEXTURE_CUBE_MAP
         auto const& sampler = m_samplers[i];
 
-        auto texel = sampler.sample_2d({ quad.texture_coordinates[i].x(), quad.texture_coordinates[i].y() });
+        auto texel = sampler.sample_2d(quad.texture_coordinates[i].xy());
         INCREASE_STATISTICS_COUNTER(g_num_sampler_calls, 1);
 
         // FIXME: Implement more blend modes

--- a/Userland/Libraries/LibSoftGPU/PixelQuad.h
+++ b/Userland/Libraries/LibSoftGPU/PixelQuad.h
@@ -15,7 +15,7 @@
 namespace SoftGPU {
 
 struct PixelQuad final {
-    Vector2<AK::SIMD::i32x4> screen_coordinates;
+    Vector2<AK::SIMD::f32x4> screen_coordinates;
     Vector3<AK::SIMD::f32x4> barycentrics;
     AK::SIMD::f32x4 depth;
     Vector4<AK::SIMD::f32x4> vertex_color;


### PR DESCRIPTION
We used to convert every triangle's window coordinates to `int` screen coordinates, losing a bit too much precision in the process. Two triangles could partially share an edge, but because the vertex positions were casted to `int`s some gaps could occur in between what would otherwise be perfectly colinear edges. This PR converts the logic to use `float` precision instead. This fixes the triangle edge artifacts that were visible in GLQuake and improves the ice reflections in Tux Racer.

Also: some `Gfx::Vector` improvements :^)

Some super subjective benchmarks on my machine, eyeballing the FPS counter:

**GLQuake benchmark**
Start a new game, turn around to face the wall.

| Build | `master` | PR |
| ----- | -------- | -- |
| i686 | 2 FPS | 3 FPS |
| i686 + SSE1+2 | 29 FPS | 30 FPS |
| x86_64 | 37 FPS | 39 FPS |

**Tux Racer benchmark**
Start a practice run on the default level, measure during intro waddle.

| Build | `master` | PR |
| ----- | -------- | -- |
| i686 | 2 FPS | 2 FPS |
| i686 + SSE1+2 | 17 FPS | 17 FPS |
| x86_64 | 21 FPS | 21 FPS |

**3DFileViewer benchmark**
Open application and measure immediately.

| Build | `master` | PR |
| ----- | -------- | -- |
| i686 | 16 FPS | 16 FPS |
| i686 + SSE1+2 | 41 FPS | 44 FPS |
| x86_64 | 48 FPS | 47 FPS |

GLquake before: (white pixels to the left of the gun)
![image](https://user-images.githubusercontent.com/3210731/156937959-ea6430b8-0965-4bd8-ba3a-c204bc826a25.png)

After: (no white pixels to be seen)
![image](https://user-images.githubusercontent.com/3210731/156937967-a843df87-824d-4c75-ac10-80b733505b47.png)