### PR TITLE
Documentation: Improve VS Code settings

### DIFF
--- a/Documentation/VSCodeConfiguration.md
+++ b/Documentation/VSCodeConfiguration.md
@@ -125,7 +125,13 @@ These belong in the `.vscode/settings.json` of Serenity.
     "C_Cpp.clang_format_style": "file",
     // Tab settings
     "editor.tabSize": 4,
-    "editor.useTabStops": false
+    "editor.useTabStops": false,
+    // format trailing new lines
+    "files.trimFinalNewlines": true,
+    "files.insertFinalNewline": true,
+    // git commit message length
+    "git.inputValidationLength": 72,
+    "git.inputValidationSubjectLength": 72
 }
 ```
 


### PR DESCRIPTION
  - Set commit message length to 72 according to CONTRIBUTING.md
  - Format trailing new lines according to check-newlines-at-eof.py