### PR TITLE
LibWeb: Add CSS Ratio type and use it for `aspect-ratio` media queries

### DIFF
--- a/Base/res/html/misc/media-queries.html
+++ b/Base/res/html/misc/media-queries.html
@@ -4,9 +4,13 @@
     <meta charset="UTF-8">
     <title>Media queries</title>
     <style>
+        p {
+            border: 1px solid black;
+            background-color: red;
+        }
+
         .negative {
             background-color: lime;
-            border: 1px solid black;
         }
 
         @media not all {
@@ -30,132 +34,147 @@
         @media screen {
             .screen {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media only all and (min-width: 400px) {
             .size-min {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media only all and (width > 399px) {
             .size-min-range {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (max-width: 1000px) {
             .size-max {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (1001px > width) {
             .size-max-range {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (min-width: 400px) and (max-width: 1000px) {
             .size-range {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (400px <= width <= 1000px) {
             .size-range-syntax {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (color) {
             .color {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (not (not (color))) {
             .color-2 {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (color) or ((color) and ((color) or (color) or (not (color)))) {
             .deeply-nested {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (width >= 80em) {
             .em {
                 background-color: lime;
-                border: 1px solid black;
             }
         }
 
         @media (width < 100vh) {
             .viewport {
                 background-color: lime;
-                border: 1px solid black;
+            }
+        }
+
+        @media (aspect-ratio < 4 / 3) {
+            .aspect-ratio {
+                background-color: lime;
+            }
+        }
+        @media (aspect-ratio >= 2) {
+            .aspect-ratio-integer {
+                background-color: lime;
+            }
+        }
+        @media (aspect-ratio < 0.5) {
+            .aspect-ratio-decimal {
+                background-color: lime;
             }
         }
     </style>
 </head>
 <body>
-    <p id="interactive">
+    <div id="interactive">
         I don't know how wide the page is. <code>window.matchMedia("(min-width: 800px)")</code> is not working. :^(
-    </p>
+    </div>
     <p class="negative">
-        This should be green, with a black border and black text, if we are correctly ignoring <code>@media</code> rules that do not apply.
+        This should be green if we are correctly ignoring <code>@media</code> rules that do not apply.
     </p>
     <p class="screen">
-        This should be green, with a black border and black text, if we are correctly applying <code>@media screen</code>.
+        This should be green if we are correctly applying <code>@media screen</code>.
     </p>
     <p class="size-min">
-        This should be green, with a black border and black text, if the window is at least 400px wide.
+        This should be green if the window is at least 400px wide.
     </p>
     <p class="size-min-range">
-        This should be green, with a black border and black text, if the window is at least 400px wide, and we understand range syntax.
+        This should be green if the window is at least 400px wide, and we understand range syntax.
     </p>
     <p class="size-max">
-        This should be green, with a black border and black text, if the window is at most 1000px wide.
+        This should be green if the window is at most 1000px wide.
     </p>
     <p class="size-max-range">
-        This should be green, with a black border and black text, if the window is at most 1000px wide, and we understand range syntax.
+        This should be green if the window is at most 1000px wide, and we understand range syntax.
     </p>
     <p class="size-range">
-        This should be green, with a black border and black text, if the window is between 400px and 1000px wide.
+        This should be green if the window is between 400px and 1000px wide.
     </p>
     <p class="size-range-syntax">
-        This should be green, with a black border and black text, if the window is between 400px and 1000px wide, and we understand range syntax.
+        This should be green if the window is between 400px and 1000px wide, and we understand range syntax.
     </p>
     <p class="color">
-        This should be green, with a black border and black text, if we detected the <code>color</code> feature.
+        This should be green if we detected the <code>color</code> feature.
     </p>
     <p class="color-2">
-        This should be green, with a black border and black text, if we detected the <code>color</code> feature and we understand <code>not</code>.
+        This should be green if we detected the <code>color</code> feature and we understand <code>not</code>.
     </p>
     <p class="color-2">
-        This should be green, with a black border and black text, if we detected the <code>color</code> feature and a deeply nested query: <code>(color) or ((color) and ((color) or (color) or (not (color))))</code>.
+        This should be green if we detected the <code>color</code> feature and a deeply nested query: <code>(color) or ((color) and ((color) or (color) or (not (color))))</code>.
     </p>
 
     <h2>Relative lengths</h2>
     <p class="em">
-        This should be green, with a black border and black text, if the window is wider than 80em.
+        This should be green if the window is wider than 80em.
     </p>
     <p class="viewport">
-        This should be green, with a black border and black text, if the window is taller than it is wide.
+        This should be green if the window is taller than it is wide.
+    </p>
+
+    <h2>Ratio</h2>
+    <p class="aspect-ratio">
+        This should be green if the viewport aspect-ratio is less than 4/3. (So, less wide than a 4:3 ratio.)
+    </p>
+    <p class="aspect-ratio-integer">
+        This should be green if the viewport aspect-ratio is at least 2. (So, at least twice as wide as it is tall.)
+    </p>
+    <p class="aspect-ratio-decimal">
+        This should be green if the viewport aspect-ratio is less than 0.5. (So, at least twice as tall as it is wide.)
     </p>
 
     <script>

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -43,6 +43,7 @@ set(SOURCES
     CSS/PropertyID.cpp
     CSS/PropertyID.h
     CSS/QuirksModeStyleSheetSource.cpp
+    CSS/Ratio.cpp
     CSS/Resolution.cpp
     CSS/ResolvedCSSStyleDeclaration.cpp
     CSS/Screen.cpp

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.h
@@ -13,6 +13,7 @@
 #include <AK/OwnPtr.h>
 #include <AK/RefCounted.h>
 #include <LibWeb/CSS/GeneralEnclosed.h>
+#include <LibWeb/CSS/Ratio.h>
 #include <LibWeb/CSS/StyleValue.h>
 
 namespace Web::CSS {
@@ -27,6 +28,11 @@ public:
 
     explicit MediaFeatureValue(Length length)
         : m_value(move(length))
+    {
+    }
+
+    explicit MediaFeatureValue(Ratio ratio)
+        : m_value(move(ratio))
     {
     }
 
@@ -45,6 +51,7 @@ public:
     bool is_ident() const { return m_value.has<String>(); }
     bool is_length() const { return m_value.has<Length>(); }
     bool is_number() const { return m_value.has<double>(); }
+    bool is_ratio() const { return m_value.has<Ratio>(); }
     bool is_resolution() const { return m_value.has<Resolution>(); }
     bool is_same_type(MediaFeatureValue const& other) const;
 
@@ -60,6 +67,12 @@ public:
         return m_value.get<Length>();
     }
 
+    Ratio const& ratio() const
+    {
+        VERIFY(is_ratio());
+        return m_value.get<Ratio>();
+    }
+
     Resolution const& resolution() const
     {
         VERIFY(is_resolution());
@@ -73,8 +86,7 @@ public:
     }
 
 private:
-    // TODO: Support <ratio> once we have that.
-    Variant<String, Length, Resolution, double> m_value;
+    Variant<String, Length, Ratio, Resolution, double> m_value;
 };
 
 // https://www.w3.org/TR/mediaqueries-4/#mq-features

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -22,6 +22,7 @@
 #include <LibWeb/CSS/Parser/StyleFunctionRule.h>
 #include <LibWeb/CSS/Parser/StyleRule.h>
 #include <LibWeb/CSS/Parser/Tokenizer.h>
+#include <LibWeb/CSS/Ratio.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/CSS/Supports.h>
@@ -243,6 +244,7 @@ private:
     Optional<Dimension> parse_dimension(StyleComponentValueRule const&);
     Optional<Color> parse_color(StyleComponentValueRule const&);
     Optional<Length> parse_length(StyleComponentValueRule const&);
+    Optional<Ratio> parse_ratio(TokenStream<StyleComponentValueRule>&);
 
     enum class AllowedDataUrlType {
         None,

--- a/Userland/Libraries/LibWeb/CSS/Ratio.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Ratio.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Ratio.h"
+#include <math.h>
+
+namespace Web::CSS {
+
+Ratio::Ratio(float first, float second)
+    : m_first_value(first)
+    , m_second_value(second)
+{
+}
+
+// https://www.w3.org/TR/css-values-4/#degenerate-ratio
+bool Ratio::is_degenerate() const
+{
+    return !isfinite(m_first_value) || m_first_value == 0
+        || !isfinite(m_second_value) || m_second_value == 0;
+}
+
+String Ratio::to_string() const
+{
+    return String::formatted("{} / {}", m_first_value, m_second_value);
+}
+
+auto Ratio::operator<=>(const Ratio& other) const
+{
+    return value() - other.value();
+}
+
+}

--- a/Userland/Libraries/LibWeb/CSS/Ratio.h
+++ b/Userland/Libraries/LibWeb/CSS/Ratio.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+
+namespace Web::CSS {
+
+// https://www.w3.org/TR/css-values-4/#ratios
+class Ratio {
+public:
+    Ratio(float first, float second = 1);
+    float value() const { return m_first_value / m_second_value; }
+    bool is_degenerate() const;
+
+    String to_string() const;
+    auto operator<=>(Ratio const& other) const;
+
+private:
+    float m_first_value { 0 };
+    float m_second_value { 1 };
+};
+
+}

--- a/Userland/Libraries/LibWeb/DOM/Window.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Window.cpp
@@ -383,7 +383,7 @@ Optional<CSS::MediaFeatureValue> Window::query_media_feature(FlyString const& na
         return CSS::MediaFeatureValue("fine");
     // FIXME: aspect-ratio
     if (name.equals_ignoring_case("color"sv))
-        return CSS::MediaFeatureValue(32);
+        return CSS::MediaFeatureValue(8);
     if (name.equals_ignoring_case("color-gamut"sv))
         return CSS::MediaFeatureValue("srgb");
     if (name.equals_ignoring_case("color-index"sv))

--- a/Userland/Libraries/LibWeb/DOM/Window.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Window.cpp
@@ -381,7 +381,8 @@ Optional<CSS::MediaFeatureValue> Window::query_media_feature(FlyString const& na
         return CSS::MediaFeatureValue("hover");
     if (name.equals_ignoring_case("any-pointer"sv))
         return CSS::MediaFeatureValue("fine");
-    // FIXME: aspect-ratio
+    if (name.equals_ignoring_case("aspect-ratio"sv))
+        return CSS::MediaFeatureValue(CSS::Ratio(inner_width(), inner_height()));
     if (name.equals_ignoring_case("color"sv))
         return CSS::MediaFeatureValue(8);
     if (name.equals_ignoring_case("color-gamut"sv))


### PR DESCRIPTION
(And fix the `color` media query while I'm at it.)

As noted in several commit messages and the code, the parser needs to be smarter to make these work properly. That's what I'm working on next, but this seemed self-contained enough to make a separate PR for. :^)