### PR TITLE
LibWeb: Calculate line colors, thickness and implement missing styles in `text-decoration`

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -23,6 +23,7 @@ public:
     static CSS::TextAlign text_align() { return CSS::TextAlign::Left; }
     static CSS::Position position() { return CSS::Position::Static; }
     static CSS::TextDecorationLine text_decoration_line() { return CSS::TextDecorationLine::None; }
+    static CSS::Length text_decoration_thickness() { return Length::make_px(1); }
     static CSS::TextDecorationStyle text_decoration_style() { return CSS::TextDecorationStyle::Solid; }
     static CSS::TextTransform text_transform() { return CSS::TextTransform::None; }
     static CSS::Display display() { return CSS::Display { CSS::Display::Outside::Inline, CSS::Display::Inside::Flow }; }
@@ -111,6 +112,7 @@ public:
     Optional<int> const& z_index() const { return m_noninherited.z_index; }
     CSS::TextAlign text_align() const { return m_inherited.text_align; }
     CSS::TextDecorationLine text_decoration_line() const { return m_noninherited.text_decoration_line; }
+    CSS::LengthPercentage text_decoration_thickness() const { return m_noninherited.text_decoration_thickness; }
     CSS::TextDecorationStyle text_decoration_style() const { return m_noninherited.text_decoration_style; }
     Color text_decoration_color() const { return m_noninherited.text_decoration_color; }
     CSS::TextTransform text_transform() const { return m_inherited.text_transform; }
@@ -198,6 +200,7 @@ protected:
         CSS::Display display { InitialValues::display() };
         Optional<int> z_index;
         CSS::TextDecorationLine text_decoration_line { InitialValues::text_decoration_line() };
+        CSS::LengthPercentage text_decoration_thickness { InitialValues::text_decoration_thickness() };
         CSS::TextDecorationStyle text_decoration_style { InitialValues::text_decoration_style() };
         Color text_decoration_color { InitialValues::color() };
         CSS::Position position { InitialValues::position() };
@@ -257,6 +260,7 @@ public:
     void set_z_index(Optional<int> value) { m_noninherited.z_index = value; }
     void set_text_align(CSS::TextAlign text_align) { m_inherited.text_align = text_align; }
     void set_text_decoration_line(CSS::TextDecorationLine value) { m_noninherited.text_decoration_line = value; }
+    void set_text_decoration_thickness(CSS::LengthPercentage value) { m_noninherited.text_decoration_thickness = value; }
     void set_text_decoration_style(CSS::TextDecorationStyle value) { m_noninherited.text_decoration_style = value; }
     void set_text_decoration_color(Color value) { m_noninherited.text_decoration_color = value; }
     void set_text_transform(CSS::TextTransform value) { m_inherited.text_transform = value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -112,6 +112,7 @@ public:
     CSS::TextAlign text_align() const { return m_inherited.text_align; }
     CSS::TextDecorationLine text_decoration_line() const { return m_noninherited.text_decoration_line; }
     CSS::TextDecorationStyle text_decoration_style() const { return m_noninherited.text_decoration_style; }
+    Color text_decoration_color() const { return m_noninherited.text_decoration_color; }
     CSS::TextTransform text_transform() const { return m_inherited.text_transform; }
     CSS::Position position() const { return m_noninherited.position; }
     CSS::WhiteSpace white_space() const { return m_inherited.white_space; }
@@ -198,6 +199,7 @@ protected:
         Optional<int> z_index;
         CSS::TextDecorationLine text_decoration_line { InitialValues::text_decoration_line() };
         CSS::TextDecorationStyle text_decoration_style { InitialValues::text_decoration_style() };
+        Color text_decoration_color { InitialValues::color() };
         CSS::Position position { InitialValues::position() };
         Optional<CSS::LengthPercentage> width;
         Optional<CSS::LengthPercentage> min_width;
@@ -256,6 +258,7 @@ public:
     void set_text_align(CSS::TextAlign text_align) { m_inherited.text_align = text_align; }
     void set_text_decoration_line(CSS::TextDecorationLine value) { m_noninherited.text_decoration_line = value; }
     void set_text_decoration_style(CSS::TextDecorationStyle value) { m_noninherited.text_decoration_style = value; }
+    void set_text_decoration_color(Color value) { m_noninherited.text_decoration_color = value; }
     void set_text_transform(CSS::TextTransform value) { m_inherited.text_transform = value; }
     void set_position(CSS::Position position) { m_noninherited.position = position; }
     void set_white_space(CSS::WhiteSpace value) { m_inherited.white_space = value; }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3733,13 +3733,13 @@ RefPtr<StyleValue> Parser::parse_overflow_value(Vector<StyleComponentValueRule> 
 
 RefPtr<StyleValue> Parser::parse_text_decoration_value(Vector<StyleComponentValueRule> const& component_values)
 {
-    if (component_values.size() > 3)
+    if (component_values.size() > 4)
         return nullptr;
 
     RefPtr<StyleValue> decoration_line;
+    RefPtr<StyleValue> decoration_thickness;
     RefPtr<StyleValue> decoration_style;
     RefPtr<StyleValue> decoration_color;
-    // FIXME: Implement 'text-decoration-thickness' parameter. https://www.w3.org/TR/css-text-decor-4/#text-decoration-width-property
 
     for (auto& part : component_values) {
         auto value = parse_css_value(part);
@@ -3758,6 +3758,12 @@ RefPtr<StyleValue> Parser::parse_text_decoration_value(Vector<StyleComponentValu
             decoration_line = value.release_nonnull();
             continue;
         }
+        if (property_accepts_value(PropertyID::TextDecorationThickness, *value)) {
+            if (decoration_thickness)
+                return nullptr;
+            decoration_thickness = value.release_nonnull();
+            continue;
+        }
         if (property_accepts_value(PropertyID::TextDecorationStyle, *value)) {
             if (decoration_style)
                 return nullptr;
@@ -3770,12 +3776,14 @@ RefPtr<StyleValue> Parser::parse_text_decoration_value(Vector<StyleComponentValu
 
     if (!decoration_line)
         decoration_line = property_initial_value(PropertyID::TextDecorationLine);
+    if (!decoration_thickness)
+        decoration_thickness = property_initial_value(PropertyID::TextDecorationThickness);
     if (!decoration_style)
         decoration_style = property_initial_value(PropertyID::TextDecorationStyle);
     if (!decoration_color)
         decoration_color = property_initial_value(PropertyID::TextDecorationColor);
 
-    return TextDecorationStyleValue::create(decoration_line.release_nonnull(), decoration_style.release_nonnull(), decoration_color.release_nonnull());
+    return TextDecorationStyleValue::create(decoration_line.release_nonnull(), decoration_thickness.release_nonnull(), decoration_style.release_nonnull(), decoration_color.release_nonnull());
 }
 
 static Optional<CSS::TransformFunction> parse_transform_function_name(StringView name)

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -180,12 +180,14 @@ static void set_property_expanding_shorthands(StyleProperties& style, CSS::Prope
         if (value.is_text_decoration()) {
             auto const& text_decoration = value.as_text_decoration();
             style.set_property(CSS::PropertyID::TextDecorationLine, text_decoration.line());
+            style.set_property(CSS::PropertyID::TextDecorationThickness, text_decoration.thickness());
             style.set_property(CSS::PropertyID::TextDecorationStyle, text_decoration.style());
             style.set_property(CSS::PropertyID::TextDecorationColor, text_decoration.color());
             return;
         }
 
         style.set_property(CSS::PropertyID::TextDecorationLine, value);
+        style.set_property(CSS::PropertyID::TextDecorationThickness, value);
         style.set_property(CSS::PropertyID::TextDecorationStyle, value);
         style.set_property(CSS::PropertyID::TextDecorationColor, value);
         return;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1319,7 +1319,7 @@ String PositionStyleValue::to_string() const
 
 String TextDecorationStyleValue::to_string() const
 {
-    return String::formatted("{} {} {}", m_line->to_string(), m_style->to_string(), m_color->to_string());
+    return String::formatted("{} {} {} {}", m_line->to_string(), m_thickness->to_string(), m_style->to_string(), m_color->to_string());
 }
 
 String TransformationStyleValue::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1451,14 +1451,16 @@ class TextDecorationStyleValue final : public StyleValue {
 public:
     static NonnullRefPtr<TextDecorationStyleValue> create(
         NonnullRefPtr<StyleValue> line,
+        NonnullRefPtr<StyleValue> thickness,
         NonnullRefPtr<StyleValue> style,
         NonnullRefPtr<StyleValue> color)
     {
-        return adopt_ref(*new TextDecorationStyleValue(line, style, color));
+        return adopt_ref(*new TextDecorationStyleValue(line, thickness, style, color));
     }
     virtual ~TextDecorationStyleValue() override { }
 
     NonnullRefPtr<StyleValue> line() const { return m_line; }
+    NonnullRefPtr<StyleValue> thickness() const { return m_thickness; }
     NonnullRefPtr<StyleValue> style() const { return m_style; }
     NonnullRefPtr<StyleValue> color() const { return m_color; }
 
@@ -1467,16 +1469,19 @@ public:
 private:
     TextDecorationStyleValue(
         NonnullRefPtr<StyleValue> line,
+        NonnullRefPtr<StyleValue> thickness,
         NonnullRefPtr<StyleValue> style,
         NonnullRefPtr<StyleValue> color)
         : StyleValue(Type::TextDecoration)
         , m_line(line)
+        , m_thickness(thickness)
         , m_style(style)
         , m_color(color)
     {
     }
 
     NonnullRefPtr<StyleValue> m_line;
+    NonnullRefPtr<StyleValue> m_thickness;
     NonnullRefPtr<StyleValue> m_style;
     NonnullRefPtr<StyleValue> m_color;
 };

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -430,6 +430,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     //        we just manually grab the value from `color`. This makes it dependent on `color` being
     //        specified first, so it's far from ideal.
     computed_values.set_text_decoration_color(specified_style.color_or_fallback(CSS::PropertyID::TextDecorationColor, *this, computed_values.color()));
+    if (auto maybe_text_decoration_thickness = specified_style.length_percentage(CSS::PropertyID::TextDecorationThickness); maybe_text_decoration_thickness.has_value())
+        computed_values.set_text_decoration_thickness(maybe_text_decoration_thickness.release_value());
 
     computed_values.set_z_index(specified_style.z_index());
     computed_values.set_opacity(specified_style.opacity());

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -426,6 +426,11 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
 
     computed_values.set_color(specified_style.color_or_fallback(CSS::PropertyID::Color, *this, CSS::InitialValues::color()));
 
+    // FIXME: The default text decoration color value is `currentcolor`, but since we can't resolve that easily,
+    //        we just manually grab the value from `color`. This makes it dependent on `color` being
+    //        specified first, so it's far from ideal.
+    computed_values.set_text_decoration_color(specified_style.color_or_fallback(CSS::PropertyID::TextDecorationColor, *this, computed_values.color()));
+
     computed_values.set_z_index(specified_style.z_index());
     computed_values.set_opacity(specified_style.opacity());
     if (computed_values.opacity() == 0)

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -97,8 +97,6 @@ void TextNode::paint_fragment(PaintContext& context, const LineBoxFragment& frag
         if (document().inspected_node() == &dom_node())
             context.painter().draw_rect(enclosing_int_rect(fragment_absolute_rect), Color::Magenta);
 
-        paint_text_decoration(painter, fragment);
-
         // FIXME: text-transform should be done already in layout, since uppercase glyphs may be wider than lowercase, etc.
         auto text = m_text_for_rendering;
         auto text_transform = computed_values().text_transform();
@@ -119,6 +117,8 @@ void TextNode::paint_fragment(PaintContext& context, const LineBoxFragment& frag
             painter.add_clip_rect(enclosing_int_rect(selection_rect));
             painter.draw_text(enclosing_int_rect(fragment_absolute_rect), text.substring_view(fragment.start(), fragment.length()), Gfx::TextAlignment::CenterLeft, context.palette().selection_text());
         }
+
+        paint_text_decoration(painter, fragment);
 
         paint_cursor_if_needed(context, fragment);
     }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -70,17 +70,24 @@ void TextNode::paint_text_decoration(Gfx::Painter& painter, LineBoxFragment cons
 
     auto line_color = computed_values().text_decoration_color();
 
+    int line_thickness = [this] {
+        CSS::Length computed_thickness = computed_values().text_decoration_thickness().resolved(*this, CSS::Length(1, CSS::Length::Type::Em));
+        if (computed_thickness.is_auto())
+            return CSS::InitialValues::text_decoration_thickness().to_px(*this);
+
+        return computed_thickness.to_px(*this);
+    }();
+
     switch (computed_values().text_decoration_style()) {
         // FIXME: Implement the other styles
     case CSS::TextDecorationStyle::Solid:
     case CSS::TextDecorationStyle::Double:
     case CSS::TextDecorationStyle::Dashed:
     case CSS::TextDecorationStyle::Dotted:
-        painter.draw_line(line_start_point, line_end_point, line_color);
+        painter.draw_line(line_start_point, line_end_point, line_color, line_thickness);
         break;
     case CSS::TextDecorationStyle::Wavy:
-        // FIXME: There is a thing called text-decoration-thickness which also affects the amplitude here.
-        painter.draw_triangle_wave(line_start_point, line_end_point, line_color, 2);
+        painter.draw_triangle_wave(line_start_point, line_end_point, line_color, line_thickness + 1, line_thickness);
         break;
     }
 }

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -79,12 +79,33 @@ void TextNode::paint_text_decoration(Gfx::Painter& painter, LineBoxFragment cons
     }();
 
     switch (computed_values().text_decoration_style()) {
-        // FIXME: Implement the other styles
     case CSS::TextDecorationStyle::Solid:
+        painter.draw_line(line_start_point, line_end_point, line_color, line_thickness, Gfx::Painter::LineStyle::Solid);
+        break;
     case CSS::TextDecorationStyle::Double:
-    case CSS::TextDecorationStyle::Dashed:
-    case CSS::TextDecorationStyle::Dotted:
+        switch (computed_values().text_decoration_line()) {
+        case CSS::TextDecorationLine::Underline:
+            break;
+        case CSS::TextDecorationLine::Overline:
+            line_start_point.translate_by(0, -line_thickness - 1);
+            line_end_point.translate_by(0, -line_thickness - 1);
+            break;
+        case CSS::TextDecorationLine::LineThrough:
+            line_start_point.translate_by(0, -line_thickness / 2);
+            line_end_point.translate_by(0, -line_thickness / 2);
+            break;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+
         painter.draw_line(line_start_point, line_end_point, line_color, line_thickness);
+        painter.draw_line(line_start_point.translated(0, line_thickness + 1), line_end_point.translated(0, line_thickness + 1), line_color, line_thickness);
+        break;
+    case CSS::TextDecorationStyle::Dashed:
+        painter.draw_line(line_start_point, line_end_point, line_color, line_thickness, Gfx::Painter::LineStyle::Dashed);
+        break;
+    case CSS::TextDecorationStyle::Dotted:
+        painter.draw_line(line_start_point, line_end_point, line_color, line_thickness, Gfx::Painter::LineStyle::Dotted);
         break;
     case CSS::TextDecorationStyle::Wavy:
         painter.draw_triangle_wave(line_start_point, line_end_point, line_color, line_thickness + 1, line_thickness);

--- a/Userland/Libraries/LibWeb/Layout/TextNode.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TextNode.cpp
@@ -68,17 +68,19 @@ void TextNode::paint_text_decoration(Gfx::Painter& painter, LineBoxFragment cons
         return;
     }
 
+    auto line_color = computed_values().text_decoration_color();
+
     switch (computed_values().text_decoration_style()) {
         // FIXME: Implement the other styles
     case CSS::TextDecorationStyle::Solid:
     case CSS::TextDecorationStyle::Double:
     case CSS::TextDecorationStyle::Dashed:
     case CSS::TextDecorationStyle::Dotted:
-        painter.draw_line(line_start_point, line_end_point, computed_values().color());
+        painter.draw_line(line_start_point, line_end_point, line_color);
         break;
     case CSS::TextDecorationStyle::Wavy:
         // FIXME: There is a thing called text-decoration-thickness which also affects the amplitude here.
-        painter.draw_triangle_wave(line_start_point, line_end_point, computed_values().color(), 2);
+        painter.draw_triangle_wave(line_start_point, line_end_point, line_color, 2);
         break;
     }
 }


### PR DESCRIPTION
![preview](https://user-images.githubusercontent.com/16520278/156939980-1e026f35-acec-49d7-87e2-ee31a906adc7.png)
