### PR TITLE
LibWeb: Add border style for iframe to default UA stylesheet

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -286,3 +286,8 @@ input[type=hidden i] { display: none !important; }
 @media (scripting) {
   noscript { display: none !important; }
 }
+
+/* 15.4.1 Embedded content
+ * https://html.spec.whatwg.org/multipage/rendering.html#embedded-content-rendering-rules
+ */
+iframe { border: 2px inset; }


### PR DESCRIPTION
That being said, the current rendering looks a bit strange:

![image](https://user-images.githubusercontent.com/19366641/156942691-b6dae72a-c054-4600-a481-c4351303c98d.png)
