### PR TITLE
LibWeb: Cross origin stuff & preparation for WindowProxy

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.cpp
@@ -71,4 +71,11 @@ JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS:
     return vm.throw_completion<DOMExceptionWrapper>(global_object, DOM::SecurityError::create(String::formatted("Can't access property '{}' on cross-origin object", property_key)));
 }
 
+// 7.2.3.3 IsPlatformObjectSameOrigin ( O ), https://html.spec.whatwg.org/multipage/browsers.html#isplatformobjectsameorigin-(-o-)
+bool is_platform_object_same_origin(JS::Object const& object)
+{
+    // 1. Return true if the current settings object's origin is same origin-domain with O's relevant settings object's origin, and false otherwise.
+    return HTML::current_settings_object().origin().is_same_origin_domain(HTML::relevant_settings_object(object).origin());
+}
+
 }

--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.cpp
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Variant.h>
+#include <AK/Vector.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibWeb/Bindings/CrossOriginAbstractOperations.h>
+#include <LibWeb/Bindings/LocationObject.h>
+#include <LibWeb/Bindings/WindowObject.h>
+
+namespace Web::Bindings {
+
+// 7.2.3.1 CrossOriginProperties ( O ), https://html.spec.whatwg.org/multipage/browsers.html#crossoriginproperties-(-o-)
+Vector<CrossOriginProperty> cross_origin_properties(Variant<LocationObject const*, WindowObject const*> const& object)
+{
+    // 1. Assert: O is a Location or Window object.
+
+    return object.visit(
+        // 2. If O is a Location object, then return « { [[Property]]: "href", [[NeedsGet]]: false, [[NeedsSet]]: true }, { [[Property]]: "replace" } ».
+        [](LocationObject const*) -> Vector<CrossOriginProperty> {
+            return {
+                { .property = "href"sv, .needs_get = false, .needs_set = true },
+                { .property = "replace"sv },
+            };
+        },
+        // 3. Return « { [[Property]]: "window", [[NeedsGet]]: true, [[NeedsSet]]: false }, { [[Property]]: "self", [[NeedsGet]]: true, [[NeedsSet]]: false }, { [[Property]]: "location", [[NeedsGet]]: true, [[NeedsSet]]: true }, { [[Property]]: "close" }, { [[Property]]: "closed", [[NeedsGet]]: true, [[NeedsSet]]: false }, { [[Property]]: "focus" }, { [[Property]]: "blur" }, { [[Property]]: "frames", [[NeedsGet]]: true, [[NeedsSet]]: false }, { [[Property]]: "length", [[NeedsGet]]: true, [[NeedsSet]]: false }, { [[Property]]: "top", [[NeedsGet]]: true, [[NeedsSet]]: false }, { [[Property]]: "opener", [[NeedsGet]]: true, [[NeedsSet]]: false }, { [[Property]]: "parent", [[NeedsGet]]: true, [[NeedsSet]]: false }, { [[Property]]: "postMessage" } ».
+        [](WindowObject const*) -> Vector<CrossOriginProperty> {
+            return {
+                { .property = "window"sv, .needs_get = true, .needs_set = false },
+                { .property = "self"sv, .needs_get = true, .needs_set = false },
+                { .property = "location"sv, .needs_get = true, .needs_set = true },
+                { .property = "close"sv },
+                { .property = "closed"sv, .needs_get = true, .needs_set = false },
+                { .property = "focus"sv },
+                { .property = "blur"sv },
+                { .property = "frames"sv, .needs_get = true, .needs_set = false },
+                { .property = "length"sv, .needs_get = true, .needs_set = false },
+                { .property = "top"sv, .needs_get = true, .needs_set = false },
+                { .property = "opener"sv, .needs_get = true, .needs_set = false },
+                { .property = "parent"sv, .needs_get = true, .needs_set = false },
+                { .property = "postMessage"sv },
+            };
+        });
+}
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
@@ -28,6 +28,7 @@ struct CrossOriginKey {
 using CrossOriginPropertyDescriptorMap = HashMap<CrossOriginKey, JS::PropertyDescriptor>;
 
 Vector<CrossOriginProperty> cross_origin_properties(Variant<LocationObject const*, WindowObject const*> const&);
+JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS::GlobalObject&, JS::PropertyKey const&);
 
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
@@ -9,8 +9,15 @@
 #include <AK/Forward.h>
 #include <AK/Traits.h>
 #include <LibJS/Forward.h>
+#include <LibWeb/Forward.h>
 
 namespace Web::Bindings {
+
+struct CrossOriginProperty {
+    String property;
+    Optional<bool> needs_get {};
+    Optional<bool> needs_set {};
+};
 
 struct CrossOriginKey {
     FlatPtr current_settings_object;
@@ -19,6 +26,8 @@ struct CrossOriginKey {
 };
 
 using CrossOriginPropertyDescriptorMap = HashMap<CrossOriginKey, JS::PropertyDescriptor>;
+
+Vector<CrossOriginProperty> cross_origin_properties(Variant<LocationObject const*, WindowObject const*> const&);
 
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
@@ -33,6 +33,7 @@ bool is_platform_object_same_origin(JS::Object const&);
 Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<LocationObject*, WindowObject*> const&, JS::PropertyKey const&);
 JS::ThrowCompletionOr<JS::Value> cross_origin_get(JS::GlobalObject&, JS::Object const&, JS::PropertyKey const&, JS::Value receiver);
 JS::ThrowCompletionOr<bool> cross_origin_set(JS::GlobalObject&, JS::Object&, JS::PropertyKey const&, JS::Value, JS::Value receiver);
+JS::MarkedVector<JS::Value> cross_origin_own_property_keys(Variant<LocationObject const*, WindowObject const*> const&);
 
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
@@ -29,6 +29,7 @@ using CrossOriginPropertyDescriptorMap = HashMap<CrossOriginKey, JS::PropertyDes
 
 Vector<CrossOriginProperty> cross_origin_properties(Variant<LocationObject const*, WindowObject const*> const&);
 JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS::GlobalObject&, JS::PropertyKey const&);
+bool is_platform_object_same_origin(JS::Object const&);
 
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
@@ -30,6 +30,7 @@ using CrossOriginPropertyDescriptorMap = HashMap<CrossOriginKey, JS::PropertyDes
 Vector<CrossOriginProperty> cross_origin_properties(Variant<LocationObject const*, WindowObject const*> const&);
 JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS::GlobalObject&, JS::PropertyKey const&);
 bool is_platform_object_same_origin(JS::Object const&);
+Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<LocationObject*, WindowObject*> const&, JS::PropertyKey const&);
 
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Forward.h>
+#include <AK/Traits.h>
+#include <LibJS/Forward.h>
+
+namespace Web::Bindings {
+
+struct CrossOriginKey {
+    FlatPtr current_settings_object;
+    FlatPtr relevant_settings_object;
+    JS::PropertyKey property_key;
+};
+
+using CrossOriginPropertyDescriptorMap = HashMap<CrossOriginKey, JS::PropertyDescriptor>;
+
+}
+
+namespace AK {
+
+template<>
+struct Traits<Web::Bindings::CrossOriginKey> : public GenericTraits<Web::Bindings::CrossOriginKey> {
+    static unsigned hash(Web::Bindings::CrossOriginKey const& key)
+    {
+        return pair_int_hash(
+            Traits<JS::PropertyKey>::hash(key.property_key),
+            pair_int_hash(ptr_hash(key.current_settings_object), ptr_hash(key.relevant_settings_object)));
+    }
+
+    static bool equals(Web::Bindings::CrossOriginKey const& a, Web::Bindings::CrossOriginKey const& b)
+    {
+        return a.current_settings_object == b.current_settings_object
+            && a.relevant_settings_object == b.relevant_settings_object
+            && Traits<JS::PropertyKey>::equals(a.property_key, b.property_key);
+    }
+};
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
+++ b/Userland/Libraries/LibWeb/Bindings/CrossOriginAbstractOperations.h
@@ -31,6 +31,8 @@ Vector<CrossOriginProperty> cross_origin_properties(Variant<LocationObject const
 JS::ThrowCompletionOr<JS::PropertyDescriptor> cross_origin_property_fallback(JS::GlobalObject&, JS::PropertyKey const&);
 bool is_platform_object_same_origin(JS::Object const&);
 Optional<JS::PropertyDescriptor> cross_origin_get_own_property_helper(Variant<LocationObject*, WindowObject*> const&, JS::PropertyKey const&);
+JS::ThrowCompletionOr<JS::Value> cross_origin_get(JS::GlobalObject&, JS::Object const&, JS::PropertyKey const&, JS::Value receiver);
+JS::ThrowCompletionOr<bool> cross_origin_set(JS::GlobalObject&, JS::Object&, JS::PropertyKey const&, JS::Value, JS::Value receiver);
 
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/URL.h>
+#include <LibJS/Forward.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Object.h>
 #include <LibWeb/Bindings/CrossOriginAbstractOperations.h>
@@ -24,12 +25,16 @@ public:
     virtual void initialize(JS::GlobalObject&) override;
     virtual ~LocationObject() override;
 
+    virtual JS::ThrowCompletionOr<JS::Object*> internal_get_prototype_of() const override;
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(Object* prototype) override;
     virtual JS::ThrowCompletionOr<bool> internal_is_extensible() const override;
     virtual JS::ThrowCompletionOr<bool> internal_prevent_extensions() override;
-
-    // FIXME: There should also be a custom [[GetPrototypeOf]], [[GetOwnProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]] and [[OwnPropertyKeys]],
-    //        but we don't have the infrastructure in place to implement them yet.
+    virtual JS::ThrowCompletionOr<Optional<JS::PropertyDescriptor>> internal_get_own_property(JS::PropertyKey const&) const override;
+    virtual JS::ThrowCompletionOr<bool> internal_define_own_property(JS::PropertyKey const&, JS::PropertyDescriptor const&) override;
+    virtual JS::ThrowCompletionOr<JS::Value> internal_get(JS::PropertyKey const&, JS::Value receiver) const override;
+    virtual JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
+    virtual JS::ThrowCompletionOr<bool> internal_delete(JS::PropertyKey const&) override;
+    virtual JS::ThrowCompletionOr<JS::MarkedVector<JS::Value>> internal_own_property_keys() const override;
 
     CrossOriginPropertyDescriptorMap const& cross_origin_property_descriptor_map() const { return m_cross_origin_property_descriptor_map; }
     CrossOriginPropertyDescriptorMap& cross_origin_property_descriptor_map() { return m_cross_origin_property_descriptor_map; }
@@ -54,6 +59,9 @@ private:
 
     // [[CrossOriginPropertyDescriptorMap]], https://html.spec.whatwg.org/multipage/browsers.html#crossoriginpropertydescriptormap
     CrossOriginPropertyDescriptorMap m_cross_origin_property_descriptor_map;
+
+    // [[DefaultProperties]], https://html.spec.whatwg.org/multipage/history.html#defaultproperties
+    JS::MarkedVector<JS::Value> m_default_properties;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.h
@@ -10,6 +10,7 @@
 #include <AK/URL.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Object.h>
+#include <LibWeb/Bindings/CrossOriginAbstractOperations.h>
 #include <LibWeb/Forward.h>
 
 namespace Web {
@@ -30,6 +31,9 @@ public:
     // FIXME: There should also be a custom [[GetPrototypeOf]], [[GetOwnProperty]], [[DefineOwnProperty]], [[Get]], [[Set]], [[Delete]] and [[OwnPropertyKeys]],
     //        but we don't have the infrastructure in place to implement them yet.
 
+    CrossOriginPropertyDescriptorMap const& cross_origin_property_descriptor_map() const { return m_cross_origin_property_descriptor_map; }
+    CrossOriginPropertyDescriptorMap& cross_origin_property_descriptor_map() { return m_cross_origin_property_descriptor_map; }
+
 private:
     DOM::Document const* relevant_document() const;
     AK::URL url() const;
@@ -47,6 +51,9 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(search_getter);
     JS_DECLARE_NATIVE_FUNCTION(protocol_getter);
     JS_DECLARE_NATIVE_FUNCTION(port_getter);
+
+    // [[CrossOriginPropertyDescriptorMap]], https://html.spec.whatwg.org/multipage/browsers.html#crossoriginpropertydescriptormap
+    CrossOriginPropertyDescriptorMap m_cross_origin_property_descriptor_map;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2022, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,6 +14,7 @@
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibWeb/Bindings/CallbackType.h>
+#include <LibWeb/Bindings/CrossOriginAbstractOperations.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
 
@@ -67,6 +69,9 @@ public:
     }
 
     virtual JS::ThrowCompletionOr<bool> internal_set_prototype_of(JS::Object* prototype) override;
+
+    CrossOriginPropertyDescriptorMap const& cross_origin_property_descriptor_map() const { return m_cross_origin_property_descriptor_map; }
+    CrossOriginPropertyDescriptorMap& cross_origin_property_descriptor_map() { return m_cross_origin_property_descriptor_map; }
 
 private:
     virtual void visit_edges(Visitor&) override;
@@ -136,6 +141,9 @@ private:
 
     HashMap<String, JS::Object*> m_prototypes;
     HashMap<String, JS::NativeFunction*> m_constructors;
+
+    // [[CrossOriginPropertyDescriptorMap]], https://html.spec.whatwg.org/multipage/browsers.html#crossoriginpropertydescriptormap
+    CrossOriginPropertyDescriptorMap m_cross_origin_property_descriptor_map;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES
     Bindings/AudioConstructor.cpp
+    Bindings/CrossOriginAbstractOperations.cpp
     Bindings/CSSNamespace.cpp
     Bindings/CSSRuleWrapperFactory.cpp
     Bindings/CSSStyleDeclarationWrapperCustom.cpp

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -291,4 +291,25 @@ JS::GlobalObject& current_global_object()
     return vm.current_realm()->global_object();
 }
 
+// https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-realm
+JS::Realm& relevant_realm(JS::Object const& object)
+{
+    // The relevant Realm for a platform object is the value of its [[Realm]] field.
+    return *object.global_object().associated_realm();
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object
+EnvironmentSettingsObject& relevant_settings_object(JS::Object const& object)
+{
+    // Then, the relevant settings object for a platform object o is the environment settings object of the relevant Realm for o.
+    return verify_cast<EnvironmentSettingsObject>(*relevant_realm(object).host_defined());
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#concept-relevant-global
+JS::GlobalObject& relevant_global_object(JS::Object const& object)
+{
+    // Similarly, the relevant global object for a platform object o is the global object of the relevant Realm for o.
+    return relevant_realm(object).global_object();
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -268,6 +269,26 @@ JS::GlobalObject& incumbent_global_object()
 {
     // Similarly, the incumbent global object is the global object of the incumbent settings object.
     return incumbent_settings_object().global_object();
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object
+EnvironmentSettingsObject& current_settings_object()
+{
+    auto& event_loop = HTML::main_thread_event_loop();
+    auto& vm = event_loop.vm();
+
+    // Then, the current settings object is the environment settings object of the current Realm Record.
+    return verify_cast<EnvironmentSettingsObject>(*vm.current_realm()->host_defined());
+}
+
+// https://html.spec.whatwg.org/multipage/webappapis.html#current-global-object
+JS::GlobalObject& current_global_object()
+{
+    auto& event_loop = HTML::main_thread_event_loop();
+    auto& vm = event_loop.vm();
+
+    // Similarly, the current global object is the global object of the current Realm Record.
+    return vm.current_realm()->global_object();
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Luke Wilde <lukew@serenityos.org>
+ * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -117,5 +118,7 @@ private:
 EnvironmentSettingsObject& incumbent_settings_object();
 JS::Realm& incumbent_realm();
 JS::GlobalObject& incumbent_global_object();
+EnvironmentSettingsObject& current_settings_object();
+JS::GlobalObject& current_global_object();
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/Environments.h
@@ -10,6 +10,7 @@
 #include <AK/URL.h>
 #include <LibJS/Runtime/ExecutionContext.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
 #include <LibJS/Runtime/Realm.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/EventLoop/EventLoop.h>
@@ -120,5 +121,8 @@ JS::Realm& incumbent_realm();
 JS::GlobalObject& incumbent_global_object();
 EnvironmentSettingsObject& current_settings_object();
 JS::GlobalObject& current_global_object();
+JS::Realm& relevant_realm(JS::Object const&);
+EnvironmentSettingsObject& relevant_settings_object(JS::Object const&);
+JS::GlobalObject& relevant_global_object(JS::Object const&);
 
 }


### PR DESCRIPTION
There's a whole bunch of infrastructure needed for `WindowProxy`, so let's start with that. Turns out, `LocationObject` also was missing these functions for some of its internal methods.

Hard to test as `window.top` / `window.parent` are broken (#12917), but with a couple of local tweaks [1], I could confirm this is working.

<details>

<summary>[1] Ugly diff</summary>

```diff
diff --git a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
index 1d0ca9d25f..5f5269c5d0 100644
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -196,6 +196,13 @@ void BrowsingContext::scroll_to_anchor(String const& fragment)
         m_page->client().page_did_request_scroll_into_view(enclosing_int_rect(float_rect));
 }
 
+BrowsingContext* BrowsingContext::parent()
+{
+    if (m_container)
+        return m_container->document().browsing_context();
+    return nullptr;
+}
+
 Gfx::IntRect BrowsingContext::to_top_level_rect(Gfx::IntRect const& a_rect)
 {
     auto rect = a_rect;
diff --git a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
index 067303e2be..b7ab690139 100644
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -8,8 +8,10 @@
 
 #include <AK/Function.h>
 #include <AK/Noncopyable.h>
+#include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
 #include <AK/WeakPtr.h>
+#include <AK/Weakable.h>
 #include <LibCore/Timer.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Rect.h>
@@ -18,11 +20,12 @@
 #include <LibWeb/HTML/BrowsingContextContainer.h>
 #include <LibWeb/Loader/FrameLoader.h>
 #include <LibWeb/Page/EventHandler.h>
-#include <LibWeb/TreeNode.h>
 
 namespace Web::HTML {
 
-class BrowsingContext : public TreeNode<BrowsingContext> {
+class BrowsingContext
+    : public RefCounted<BrowsingContext>
+    , public Weakable<BrowsingContext> {
 public:
     static NonnullRefPtr<BrowsingContext> create_nested(Page& page, HTML::BrowsingContextContainer& container) { return adopt_ref(*new BrowsingContext(page, &container)); }
     static NonnullRefPtr<BrowsingContext> create(Page& page) { return adopt_ref(*new BrowsingContext(page, nullptr)); }
@@ -66,11 +69,14 @@ public:
 
     void scroll_to_anchor(String const&);
 
+    BrowsingContext* parent();
+    BrowsingContext const* parent() const { return const_cast<BrowsingContext*>(this)->parent(); }
+
     BrowsingContext& top_level_browsing_context()
     {
         BrowsingContext* context = this;
-        while (context->parent())
-            context = context->parent();
+        while (auto* parent = context->parent())
+            context = parent;
         return *context;
     }
 
diff --git a/Userland/Libraries/LibWeb/Origin.h b/Userland/Libraries/LibWeb/Origin.h
index f22c888669..8735816a76 100644
--- a/Userland/Libraries/LibWeb/Origin.h
+++ b/Userland/Libraries/LibWeb/Origin.h
@@ -45,6 +45,7 @@ public:
     // https://html.spec.whatwg.org/multipage/origin.html#same-origin-domain
     bool is_same_origin_domain(Origin const& other) const
     {
+        return false;
         // 1. If A and B are the same opaque origin, then return true.
         if (is_opaque() && other.is_opaque())
             return true;
diff --git a/Userland/Services/WebContent/ConnectionFromClient.cpp b/Userland/Services/WebContent/ConnectionFromClient.cpp
index d9a52631b1..ffd886191b 100644
--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -247,14 +247,14 @@ void ConnectionFromClient::inspect_dom_tree()
 
 Messages::WebContentServer::InspectDomNodeResponse ConnectionFromClient::inspect_dom_node(i32 node_id)
 {
-    auto& top_context = page().top_level_browsing_context();
-
-    top_context.for_each_in_inclusive_subtree([&](auto& ctx) {
-        if (ctx.active_document() != nullptr) {
-            ctx.active_document()->set_inspected_node(nullptr);
-        }
-        return IterationDecision::Continue;
-    });
+//    auto& top_context = page().top_level_browsing_context();
+//
+//    top_context.for_each_in_inclusive_subtree([&](auto& ctx) {
+//        if (ctx.active_document() != nullptr) {
+//            ctx.active_document()->set_inspected_node(nullptr);
+//        }
+//        return IterationDecision::Continue;
+//    });
 
     Web::DOM::Node* node = Web::DOM::Node::from_id(node_id);
     if (!node) {
```

</details>