### PR TITLE
Hackstudio: Organize Menus + Add file types

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -435,9 +435,19 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     m_new_file_actions.append(create_new_file_action("&C++ Source File", "/res/icons/16x16/filetype-cplusplus.png", "cpp"));
     m_new_file_actions.append(create_new_file_action("C++ &Header File", "/res/icons/16x16/filetype-header.png", "h"));
     m_new_file_actions.append(create_new_file_action("&GML File", "/res/icons/16x16/filetype-gml.png", "gml"));
-    m_new_file_actions.append(create_new_file_action("Java&Script Source File", "/res/icons/16x16/filetype-javascript.png", "js"));
+    m_new_file_actions.append(create_new_file_action("P&ython Source File", "/res/icons/16x16/filetype-python.png", "py"));
+    m_new_file_actions.append(create_new_file_action("Ja&va Source File", "/res/icons/16x16/filetype-java.png", "java"));
+    m_new_file_actions.append(create_new_file_action("C Source File", "/res/icons/16x16/filetype-c.png", "c"));
+
+    m_new_file_actions.append(create_new_file_action("&JavaScript Source File", "/res/icons/16x16/filetype-javascript.png", "js"));
     m_new_file_actions.append(create_new_file_action("HT&ML File", "/res/icons/16x16/filetype-html.png", "html"));
     m_new_file_actions.append(create_new_file_action("C&SS File", "/res/icons/16x16/filetype-css.png", "css"));
+    m_new_file_actions.append(create_new_file_action("&PHP File", "/res/icons/16x16/filetype-php.png", "php"));
+    m_new_file_actions.append(create_new_file_action("&Wasm File", "/res/icons/16x16/filetype-wasm.png", "wasm"));
+
+    m_new_file_actions.append(create_new_file_action("&INI File", "/res/icons/16x16/filetype-ini.png", "ini"));
+    m_new_file_actions.append(create_new_file_action("JS&ON File", "/res/icons/16x16/filetype-json.png", "json"));
+    m_new_file_actions.append(create_new_file_action("Mark&down File", "/res/icons/16x16/filetype-markdown.png", "md"));
 
     m_new_plain_file_action = create_new_file_action("Plain &File", "/res/icons/16x16/new.png", "");
 

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -432,14 +432,14 @@ void HackStudioWidget::set_edit_mode(EditMode mode)
 
 NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu()
 {
-    m_new_file_actions.append(create_new_file_action("C++ Source File", "/res/icons/16x16/filetype-cplusplus.png", "cpp"));
-    m_new_file_actions.append(create_new_file_action("C++ Header File", "/res/icons/16x16/filetype-header.png", "h"));
-    m_new_file_actions.append(create_new_file_action("GML File", "/res/icons/16x16/filetype-gml.png", "gml"));
-    m_new_file_actions.append(create_new_file_action("JavaScript Source File", "/res/icons/16x16/filetype-javascript.png", "js"));
-    m_new_file_actions.append(create_new_file_action("HTML File", "/res/icons/16x16/filetype-html.png", "html"));
-    m_new_file_actions.append(create_new_file_action("CSS File", "/res/icons/16x16/filetype-css.png", "css"));
+    m_new_file_actions.append(create_new_file_action("&C++ Source File", "/res/icons/16x16/filetype-cplusplus.png", "cpp"));
+    m_new_file_actions.append(create_new_file_action("C++ &Header File", "/res/icons/16x16/filetype-header.png", "h"));
+    m_new_file_actions.append(create_new_file_action("&GML File", "/res/icons/16x16/filetype-gml.png", "gml"));
+    m_new_file_actions.append(create_new_file_action("Java&Script Source File", "/res/icons/16x16/filetype-javascript.png", "js"));
+    m_new_file_actions.append(create_new_file_action("HT&ML File", "/res/icons/16x16/filetype-html.png", "html"));
+    m_new_file_actions.append(create_new_file_action("C&SS File", "/res/icons/16x16/filetype-css.png", "css"));
 
-    m_new_plain_file_action = create_new_file_action("Plain File", "/res/icons/16x16/new.png", "");
+    m_new_plain_file_action = create_new_file_action("Plain &File", "/res/icons/16x16/new.png", "");
 
     m_open_selected_action = create_open_selected_action();
     m_show_in_file_manager_action = create_show_in_file_manager_action();
@@ -451,7 +451,7 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     });
     auto project_tree_view_context_menu = GUI::Menu::construct("Project Files");
 
-    auto& new_file_submenu = project_tree_view_context_menu->add_submenu("New");
+    auto& new_file_submenu = project_tree_view_context_menu->add_submenu("N&ew...");
     for (auto& new_file_action : m_new_file_actions) {
         new_file_submenu.add_action(new_file_action);
     }
@@ -543,7 +543,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_directory_action()
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_action()
 {
-    auto open_selected_action = GUI::Action::create("Open", [this](const GUI::Action&) {
+    auto open_selected_action = GUI::Action::create("&Open", [this](const GUI::Action&) {
         auto files = selected_file_paths();
         for (auto& file : files)
             open_file(file);
@@ -555,7 +555,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_action()
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_show_in_file_manager_action()
 {
-    auto show_in_file_manager_action = GUI::Action::create("Show in File Manager", [this](const GUI::Action&) {
+    auto show_in_file_manager_action = GUI::Action::create("Show in File &Manager", [this](const GUI::Action&) {
         auto files = selected_file_paths();
         for (auto& file : files)
             Desktop::Launcher::open(URL::create_with_file_protocol(m_project->root_path(), file));
@@ -1204,7 +1204,7 @@ void HackStudioWidget::create_file_menu(GUI::Window& window)
 {
     auto& file_menu = window.add_menu("&File");
 
-    auto& new_submenu = file_menu.add_submenu("New...");
+    auto& new_submenu = file_menu.add_submenu("&New...");
     new_submenu.add_action(*m_new_project_action);
     new_submenu.add_separator();
     for (auto& new_file_action : m_new_file_actions) {
@@ -1216,7 +1216,7 @@ void HackStudioWidget::create_file_menu(GUI::Window& window)
     new_submenu.add_action(*m_new_directory_action);
 
     file_menu.add_action(*m_open_action);
-    m_recent_projects_submenu = &file_menu.add_submenu("Open Recent");
+    m_recent_projects_submenu = &file_menu.add_submenu("Open &Recent");
     m_recent_projects_submenu->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open-recent.png").release_value_but_fixme_should_propagate_errors());
     update_recent_projects_submenu();
     file_menu.add_action(*m_save_action);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -512,7 +512,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_file_action(String const
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_directory_action()
 {
-    return GUI::Action::create("&New Directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
+    return GUI::Action::create("&Directory...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/mkdir.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
         String directory_name;
         if (GUI::InputBox::show(window(), directory_name, "Enter name of new directory:", "Add new folder to project") != GUI::InputBox::ExecOK)
             return;
@@ -623,7 +623,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_delete_action()
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_new_project_action()
 {
-    return GUI::Action::create("&New Project...", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/hackstudio-project.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
+    return GUI::Action::create("&Project...", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/hackstudio-project.png").release_value_but_fixme_should_propagate_errors(), [this](const GUI::Action&) {
         auto dialog = NewProjectDialog::construct(window());
         dialog->set_icon(window()->icon());
         auto result = dialog->exec();
@@ -1203,7 +1203,18 @@ void HackStudioWidget::update_recent_projects_submenu()
 void HackStudioWidget::create_file_menu(GUI::Window& window)
 {
     auto& file_menu = window.add_menu("&File");
-    file_menu.add_action(*m_new_project_action);
+
+    auto& new_submenu = file_menu.add_submenu("New...");
+    new_submenu.add_action(*m_new_project_action);
+    new_submenu.add_separator();
+    for (auto& new_file_action : m_new_file_actions) {
+        new_submenu.add_action(new_file_action);
+    }
+    new_submenu.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png").release_value_but_fixme_should_propagate_errors());
+    new_submenu.add_action(*m_new_plain_file_action);
+    new_submenu.add_separator();
+    new_submenu.add_action(*m_new_directory_action);
+
     file_menu.add_action(*m_open_action);
     m_recent_projects_submenu = &file_menu.add_submenu("Open Recent");
     m_recent_projects_submenu->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open-recent.png").release_value_but_fixme_should_propagate_errors());
@@ -1214,22 +1225,6 @@ void HackStudioWidget::create_file_menu(GUI::Window& window)
     file_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
         GUI::Application::the()->quit();
     }));
-}
-
-void HackStudioWidget::create_project_menu(GUI::Window& window)
-{
-    auto& project_menu = window.add_menu("&Project");
-    auto& new_submenu = project_menu.add_submenu("New");
-    for (auto& new_file_action : m_new_file_actions) {
-        new_submenu.add_action(new_file_action);
-    }
-    new_submenu.set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/new.png").release_value_but_fixme_should_propagate_errors());
-    new_submenu.add_action(*m_new_plain_file_action);
-    new_submenu.add_separator();
-    new_submenu.add_action(*m_new_directory_action);
-
-    m_toggle_semantic_highlighting_action = create_toggle_syntax_highlighting_mode_action();
-    project_menu.add_action(*m_toggle_semantic_highlighting_action);
 }
 
 void HackStudioWidget::create_edit_menu(GUI::Window& window)
@@ -1282,6 +1277,8 @@ void HackStudioWidget::create_view_menu(GUI::Window& window)
     view_menu.add_action(hide_action_tabs_action);
     view_menu.add_action(open_locator_action);
     view_menu.add_action(show_dotfiles_action);
+    m_toggle_semantic_highlighting_action = create_toggle_syntax_highlighting_mode_action();
+    view_menu.add_action(*m_toggle_semantic_highlighting_action);
     view_menu.add_separator();
 
     m_wrapping_mode_actions.set_exclusive(true);
@@ -1356,7 +1353,6 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_stop_action()
 void HackStudioWidget::initialize_menubar(GUI::Window& window)
 {
     create_file_menu(window);
-    create_project_menu(window);
     create_edit_menu(window);
     create_build_menu(window);
     create_view_menu(window);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -133,7 +133,6 @@ private:
     void create_action_tab(GUI::Widget& parent);
     void create_file_menu(GUI::Window&);
     void update_recent_projects_submenu();
-    void create_project_menu(GUI::Window&);
     void create_edit_menu(GUI::Window&);
     void create_build_menu(GUI::Window&);
     void create_view_menu(GUI::Window&);


### PR DESCRIPTION
Move 'New...' to 'File' menu. Move 'New Project...' to 'New...' submenu. Add missing key triggers.

Add Python, Java, C, PHP, Wasm, INI, JSON, and Markdown files to new file menu.

<img width="545" alt="Screen Shot 2022-03-06 at 23 05 22" src="https://user-images.githubusercontent.com/4368524/156966119-7c8833bc-721a-4320-ba7e-1bdac497ba90.png">

Move 'Semantic Highlighting' to 'View' menu, remove 'Project' menu.

![Screen Shot 2022-02-21 at 22 27 02](https://user-images.githubusercontent.com/4368524/155061060-3b00331d-f9ed-423c-9d43-552c5b52c615.png)

Add missing key triggers to TreeView context menu.
<img width="610" alt="Screen Shot 2022-03-06 at 23 05 35" src="https://user-images.githubusercontent.com/4368524/156966098-36433968-c741-446d-9dd1-e13854e3e545.png">