### PR TITLE
AK: simplify HashTable::remove_all_matching()

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -417,10 +417,8 @@ public:
                 ++removed_count;
             }
         }
-        if (removed_count) {
-            m_deleted_count += removed_count;
-            m_size -= removed_count;
-        }
+        m_deleted_count += removed_count;
+        m_size -= removed_count;
         shrink_if_needed();
         return removed_count;
     }


### PR DESCRIPTION
This minor tweak jumped out at me while watching Andreas's most recent video. Branchless programming ftw :^)