### PR TITLE
Spreadsheet: Fix overridden max length related crash

### DIFF
--- a/Userland/Applications/Spreadsheet/CellType/Numeric.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Numeric.cpp
@@ -28,7 +28,7 @@ JS::ThrowCompletionOr<String> NumericCell::display(Cell& cell, const CellTypeMet
             string = format_double(metadata.format.characters(), TRY(value.to_double(cell.sheet().global_object())));
 
         if (metadata.length >= 0)
-            return string.substring(0, metadata.length);
+            return string.substring(0, min(string.length(), metadata.length));
 
         return string;
     });


### PR DESCRIPTION
`NumericCell::display()` attempted to take a substring of cell contents according to the "Override max length" parameter, but it did not account for the actual string length. Fixes #12901.