### PR TITLE
AK::Hashtable::remove_all_matching Remove unnecessary `if`-condition

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -417,10 +417,10 @@ public:
                 ++removed_count;
             }
         }
-        if (removed_count) {
-            m_deleted_count += removed_count;
-            m_size -= removed_count;
-        }
+
+        m_deleted_count += removed_count;
+        m_size -= removed_count;
+
         shrink_if_needed();
         return removed_count;
     }


### PR DESCRIPTION
Adding/Subtracting a value is equivalent of adding/subtracting a value only if it is non-zero :-)

To be honest, the compiler probably optimizes this away anyways, but it was really annoying me in the last Episode :-)