### PR TITLE
Kernel: Implement kmalloc_good_size for the new kmalloc

### DIFF
--- a/Kernel/Heap/Heap.h
+++ b/Kernel/Heap/Heap.h
@@ -44,6 +44,8 @@ class Heap {
     }
 
 public:
+    static constexpr size_t AllocationHeaderSize = sizeof(AllocationHeader);
+
     Heap(u8* memory, size_t memory_size)
         : m_total_chunks(calculate_chunks(memory_size))
         , m_chunks(memory)


### PR DESCRIPTION
This let's kmalloc-aware data structures like Vector and HashTable use up the extra wasted space we allocate in the slab heaps & heap chunks.