### PR TITLE
PixelPaint: Add alpha masks to Layers!

### DIFF
--- a/Userland/Applications/PixelPaint/FilterGallery.cpp
+++ b/Userland/Applications/PixelPaint/FilterGallery.cpp
@@ -65,7 +65,7 @@ FilterGallery::FilterGallery(GUI::Window* parent_window, ImageEditor* editor)
         m_config_widget->add_child(*m_selected_filter_config_widget);
     };
 
-    m_preview_widget->set_bitmap(editor->active_layer()->bitmap().clone().release_value());
+    m_preview_widget->set_bitmap(editor->active_layer()->content_bitmap().clone().release_value());
 
     apply_button->on_click = [this](auto) {
         if (!m_selected_filter) {

--- a/Userland/Applications/PixelPaint/Filters/Filter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Filter.cpp
@@ -31,7 +31,7 @@ void Filter::apply() const
     if (!m_editor)
         return;
     if (auto* layer = m_editor->active_layer()) {
-        apply(layer->bitmap(), layer->bitmap());
+        apply(layer->content_bitmap(), layer->content_bitmap());
         layer->did_modify_bitmap(layer->rect());
         m_editor->did_complete_action();
     }

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -153,10 +153,16 @@ void Layer::update_cached_bitmap()
     if (!is_masked()) {
         if (m_content_bitmap.ptr() == m_cached_display_bitmap.ptr())
             return;
-
         m_cached_display_bitmap = m_content_bitmap;
         return;
     }
+}
+
+void Layer::create_mask()
+{
+    m_mask_bitmap = MUST(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, size()));
+    m_mask_bitmap->fill(Gfx::Color::White);
+    update_cached_bitmap();
 }
 
 }

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -156,6 +156,20 @@ void Layer::update_cached_bitmap()
         m_cached_display_bitmap = m_content_bitmap;
         return;
     }
+
+    if (m_content_bitmap.ptr() == m_cached_display_bitmap.ptr())
+        m_cached_display_bitmap = MUST(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, size()));
+
+    // FIXME: This can probably be done nicer
+    m_cached_display_bitmap->fill(Color::Transparent);
+    for (int y = 0; y < size().height(); ++y) {
+        for (int x = 0; x < size().width(); ++x) {
+            auto opacity_multiplier = (float)m_mask_bitmap->get_pixel(x, y).to_grayscale().red() / 255;
+            auto content_color = m_content_bitmap->get_pixel(x, y);
+            content_color.set_alpha(content_color.alpha() * opacity_multiplier);
+            m_cached_display_bitmap->set_pixel(x, y, content_color);
+        }
+    }
 }
 
 void Layer::create_mask()

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -179,4 +179,25 @@ void Layer::create_mask()
     update_cached_bitmap();
 }
 
+Gfx::Bitmap& Layer::currently_edited_bitmap()
+{
+    switch (edit_mode()) {
+    case EditMode::Mask:
+        if (is_masked())
+            return *mask_bitmap();
+        [[fallthrough]];
+    case EditMode::Content:
+        return content_bitmap();
+    }
+    VERIFY_NOT_REACHED();
+}
+
+void Layer::set_edit_mode(Layer::EditMode mode)
+{
+    if (m_edit_mode == mode)
+        return;
+
+    m_edit_mode = mode;
+}
+
 }

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -40,6 +40,11 @@ public:
     Gfx::Bitmap const& content_bitmap() const { return m_content_bitmap; }
     Gfx::Bitmap& content_bitmap() { return m_content_bitmap; }
 
+    Gfx::Bitmap const* mask_bitmap() const { return m_mask_bitmap; }
+    Gfx::Bitmap* mask_bitmap() { return m_mask_bitmap; }
+
+    void create_mask();
+
     Gfx::IntSize size() const { return content_bitmap().size(); }
 
     Gfx::IntRect relative_rect() const { return { location(), size() }; }
@@ -67,6 +72,8 @@ public:
 
     void erase_selection(Selection const&);
 
+    bool is_masked() { return !m_mask_bitmap.is_null(); }
+
 private:
     Layer(Image&, NonnullRefPtr<Gfx::Bitmap>, String name);
 
@@ -75,6 +82,7 @@ private:
     String m_name;
     Gfx::IntPoint m_location;
     NonnullRefPtr<Gfx::Bitmap> m_content_bitmap;
+    RefPtr<Gfx::Bitmap> m_mask_bitmap { nullptr };
     NonnullRefPtr<Gfx::Bitmap> m_cached_display_bitmap;
 
     bool m_selected { false };

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -74,6 +74,16 @@ public:
 
     bool is_masked() { return !m_mask_bitmap.is_null(); }
 
+    enum class EditMode {
+        Content,
+        Mask,
+    };
+
+    EditMode edit_mode() { return m_edit_mode; }
+    void set_edit_mode(EditMode mode);
+
+    Gfx::Bitmap& currently_edited_bitmap();
+
 private:
     Layer(Image&, NonnullRefPtr<Gfx::Bitmap>, String name);
 
@@ -89,6 +99,8 @@ private:
     bool m_visible { true };
 
     int m_opacity_percent { 100 };
+
+    EditMode m_edit_mode { EditMode::Content };
 
     void update_cached_bitmap();
 };

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2022, the SerenityOS developers.
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -35,9 +36,11 @@ public:
     Gfx::IntPoint const& location() const { return m_location; }
     void set_location(Gfx::IntPoint const& location) { m_location = location; }
 
-    Gfx::Bitmap const& bitmap() const { return *m_bitmap; }
-    Gfx::Bitmap& bitmap() { return *m_bitmap; }
-    Gfx::IntSize size() const { return bitmap().size(); }
+    Gfx::Bitmap const& display_bitmap() const { return m_cached_display_bitmap; }
+    Gfx::Bitmap const& content_bitmap() const { return m_content_bitmap; }
+    Gfx::Bitmap& content_bitmap() { return m_content_bitmap; }
+
+    Gfx::IntSize size() const { return content_bitmap().size(); }
 
     Gfx::IntRect relative_rect() const { return { location(), size() }; }
     Gfx::IntRect rect() const { return { {}, size() }; }
@@ -45,7 +48,7 @@ public:
     String const& name() const { return m_name; }
     void set_name(String);
 
-    void set_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap) { m_bitmap = move(bitmap); }
+    void set_content_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap);
 
     void did_modify_bitmap(Gfx::IntRect const& = {});
 
@@ -71,12 +74,15 @@ private:
 
     String m_name;
     Gfx::IntPoint m_location;
-    NonnullRefPtr<Gfx::Bitmap> m_bitmap;
+    NonnullRefPtr<Gfx::Bitmap> m_content_bitmap;
+    NonnullRefPtr<Gfx::Bitmap> m_cached_display_bitmap;
 
     bool m_selected { false };
     bool m_visible { true };
 
     int m_opacity_percent { 100 };
+
+    void update_cached_bitmap();
 };
 
 }

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -147,16 +147,31 @@ void LayerListWidget::paint_event(GUI::PaintEvent& event)
         if (is_masked)
             painter.draw_scaled_bitmap(inner_mask_thumbnail_rect, *layer.mask_bitmap(), layer.mask_bitmap()->rect());
 
+        Color border_color = layer.is_visible() ? palette().color(ColorRole::BaseText) : palette().color(ColorRole::DisabledText);
+
+        // FIXME: This needs cleaning up
         if (layer.is_visible()) {
             painter.draw_text(text_rect, layer.name(), Gfx::TextAlignment::CenterLeft, layer.is_selected() ? palette().selection_text() : palette().button_text());
-            painter.draw_rect(inner_thumbnail_rect, palette().color(ColorRole::BaseText));
-            if (is_masked)
-                painter.draw_rect(inner_mask_thumbnail_rect, palette().color(ColorRole::BaseText));
+            switch (layer.edit_mode()) {
+            case Layer::EditMode::Content:
+                if (is_masked) {
+                    painter.draw_rect_with_thickness(inner_thumbnail_rect.inflated(4, 4), Color::Yellow, 2);
+                    painter.draw_rect(inner_mask_thumbnail_rect, border_color);
+                } else {
+                    painter.draw_rect(inner_thumbnail_rect, border_color);
+                }
+                break;
+            case Layer::EditMode::Mask:
+                painter.draw_rect(inner_thumbnail_rect, border_color);
+                if (is_masked)
+                    painter.draw_rect_with_thickness(inner_mask_thumbnail_rect.inflated(4, 4), Color::Yellow, 2);
+                break;
+            }
         } else {
             painter.draw_text(text_rect, layer.name(), Gfx::TextAlignment::CenterLeft, palette().color(ColorRole::DisabledText));
-            painter.draw_rect(inner_thumbnail_rect, palette().color(ColorRole::DisabledText));
+            painter.draw_rect(inner_thumbnail_rect, border_color);
             if (is_masked)
-                painter.draw_rect(inner_mask_thumbnail_rect, palette().color(ColorRole::DisabledText));
+                painter.draw_rect(inner_mask_thumbnail_rect, border_color);
         }
     };
 

--- a/Userland/Applications/PixelPaint/LayerListWidget.cpp
+++ b/Userland/Applications/PixelPaint/LayerListWidget.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mustafa Quraish <mustafa@serenityos.org>
+ * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -128,7 +129,7 @@ void LayerListWidget::paint_event(GUI::PaintEvent& event)
         }
 
         painter.draw_rect(adjusted_rect, palette().color(ColorRole::BaseText));
-        painter.draw_scaled_bitmap(inner_thumbnail_rect, layer.bitmap(), layer.bitmap().rect());
+        painter.draw_scaled_bitmap(inner_thumbnail_rect, layer.display_bitmap(), layer.display_bitmap().rect());
 
         if (layer.is_visible()) {
             painter.draw_text(text_rect, layer.name(), Gfx::TextAlignment::CenterLeft, layer.is_selected() ? palette().selection_text() : palette().button_text());

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -39,6 +39,7 @@ private:
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void context_menu_event(GUI::ContextMenuEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
+    virtual void doubleclick_event(GUI::MouseEvent&) override;
 
     virtual void image_did_add_layer(size_t) override;
     virtual void image_did_remove_layer(size_t) override;

--- a/Userland/Applications/PixelPaint/LayerListWidget.h
+++ b/Userland/Applications/PixelPaint/LayerListWidget.h
@@ -59,7 +59,7 @@ private:
         Gfx::IntPoint movement_delta;
     };
 
-    void get_gadget_rects(Gadget const&, Gfx::IntRect& outer_rect, Gfx::IntRect& outer_thumbnail_rect, Gfx::IntRect& inner_thumbnail_rect, Gfx::IntRect& text_rect);
+    void get_gadget_rects(Gadget const& gadget, bool is_masked, Gfx::IntRect& outer_rect, Gfx::IntRect& outer_thumbnail_rect, Gfx::IntRect& inner_thumbnail_rect, Gfx::IntRect& outer_mask_thumbnail_rect, Gfx::IntRect& inner_mask_thumbnail_rect, Gfx::IntRect& text_rect);
     bool is_moving_gadget() const { return m_moving_gadget_index.has_value(); }
 
     Optional<size_t> gadget_at(Gfx::IntPoint const&);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -114,7 +114,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
                 auto image = PixelPaint::Image::try_create_with_size(dialog->image_size()).release_value_but_fixme_should_propagate_errors();
                 auto bg_layer = PixelPaint::Layer::try_create_with_size(*image, image->size(), "Background").release_value_but_fixme_should_propagate_errors();
                 image->add_layer(*bg_layer);
-                bg_layer->bitmap().fill(Color::White);
+                bg_layer->content_bitmap().fill(Color::White);
 
                 auto& editor = create_new_editor(*image);
                 auto image_title = dialog->image_name().trim_whitespace();
@@ -630,7 +630,7 @@ void MainWidget::initialize_menubar(GUI::Window& window)
         if (auto* layer = editor->active_layer()) {
             Gfx::GenericConvolutionFilter<5> filter;
             if (auto parameters = PixelPaint::FilterParameters<Gfx::GenericConvolutionFilter<5>>::get(&window)) {
-                filter.apply(layer->bitmap(), layer->rect(), layer->bitmap(), layer->rect(), *parameters);
+                filter.apply(layer->content_bitmap(), layer->rect(), layer->content_bitmap(), layer->rect(), *parameters);
                 layer->did_modify_bitmap(layer->rect());
                 editor->did_complete_action();
             }
@@ -735,7 +735,7 @@ void MainWidget::create_default_image()
 
     auto bg_layer = Layer::try_create_with_size(*image, image->size(), "Background").release_value_but_fixme_should_propagate_errors();
     image->add_layer(*bg_layer);
-    bg_layer->bitmap().fill(Color::White);
+    bg_layer->content_bitmap().fill(Color::White);
 
     m_layer_list_widget->set_image(image);
 

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -493,6 +493,20 @@ void MainWidget::initialize_menubar(GUI::Window& window)
 
     m_layer_menu->add_separator();
     m_layer_menu->add_action(GUI::Action::create(
+        "Add M&ask", { Mod_Ctrl | Mod_Shift, Key_M }, nullptr, [&](auto&) {
+            auto* editor = current_image_editor();
+            VERIFY(editor);
+            auto active_layer = editor->active_layer();
+            if (!active_layer)
+                return;
+            active_layer->create_mask();
+            editor->update();
+            m_layer_list_widget->repaint();
+        }));
+
+    m_layer_menu->add_separator();
+
+    m_layer_menu->add_action(GUI::Action::create(
         "Select &Previous Layer", { 0, Key_PageUp }, g_icon_bag.previous_layer, [&](auto&) {
             m_layer_list_widget->cycle_through_selection(1);
         }));

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -29,7 +29,7 @@ void BrushTool::on_mousedown(Layer* layer, MouseEvent& event)
 
     // Shift+Click draws a line from the last position to current one.
     if (layer_event.shift() && m_has_clicked) {
-        draw_line(layer->content_bitmap(), color_for(layer_event), m_last_position, layer_event.position());
+        draw_line(layer->currently_edited_bitmap(), color_for(layer_event), m_last_position, layer_event.position());
         auto modified_rect = Gfx::IntRect::from_two_points(m_last_position, layer_event.position()).inflated(m_size * 2, m_size * 2);
         layer->did_modify_bitmap(modified_rect);
         m_last_position = layer_event.position();
@@ -39,7 +39,7 @@ void BrushTool::on_mousedown(Layer* layer, MouseEvent& event)
     const int first_draw_opacity = 10;
 
     for (int i = 0; i < first_draw_opacity; ++i)
-        draw_point(layer->content_bitmap(), color_for(layer_event), layer_event.position());
+        draw_point(layer->currently_edited_bitmap(), color_for(layer_event), layer_event.position());
 
     layer->did_modify_bitmap(Gfx::IntRect::centered_on(layer_event.position(), Gfx::IntSize { m_size * 2, m_size * 2 }));
     m_last_position = layer_event.position();
@@ -55,7 +55,7 @@ void BrushTool::on_mousemove(Layer* layer, MouseEvent& event)
     if (!(layer_event.buttons() & GUI::MouseButton::Primary || layer_event.buttons() & GUI::MouseButton::Secondary))
         return;
 
-    draw_line(layer->content_bitmap(), color_for(layer_event), m_last_position, layer_event.position());
+    draw_line(layer->currently_edited_bitmap(), color_for(layer_event), m_last_position, layer_event.position());
 
     auto modified_rect = Gfx::IntRect::from_two_points(m_last_position, layer_event.position()).inflated(m_size * 2, m_size * 2);
 

--- a/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BrushTool.cpp
@@ -29,7 +29,7 @@ void BrushTool::on_mousedown(Layer* layer, MouseEvent& event)
 
     // Shift+Click draws a line from the last position to current one.
     if (layer_event.shift() && m_has_clicked) {
-        draw_line(layer->bitmap(), color_for(layer_event), m_last_position, layer_event.position());
+        draw_line(layer->content_bitmap(), color_for(layer_event), m_last_position, layer_event.position());
         auto modified_rect = Gfx::IntRect::from_two_points(m_last_position, layer_event.position()).inflated(m_size * 2, m_size * 2);
         layer->did_modify_bitmap(modified_rect);
         m_last_position = layer_event.position();
@@ -39,7 +39,7 @@ void BrushTool::on_mousedown(Layer* layer, MouseEvent& event)
     const int first_draw_opacity = 10;
 
     for (int i = 0; i < first_draw_opacity; ++i)
-        draw_point(layer->bitmap(), color_for(layer_event), layer_event.position());
+        draw_point(layer->content_bitmap(), color_for(layer_event), layer_event.position());
 
     layer->did_modify_bitmap(Gfx::IntRect::centered_on(layer_event.position(), Gfx::IntSize { m_size * 2, m_size * 2 }));
     m_last_position = layer_event.position();
@@ -55,7 +55,7 @@ void BrushTool::on_mousemove(Layer* layer, MouseEvent& event)
     if (!(layer_event.buttons() & GUI::MouseButton::Primary || layer_event.buttons() & GUI::MouseButton::Secondary))
         return;
 
-    draw_line(layer->bitmap(), color_for(layer_event), m_last_position, layer_event.position());
+    draw_line(layer->content_bitmap(), color_for(layer_event), m_last_position, layer_event.position());
 
     auto modified_rect = Gfx::IntRect::from_two_points(m_last_position, layer_event.position()).inflated(m_size * 2, m_size * 2);
 

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -82,10 +82,10 @@ void BucketTool::on_mousedown(Layer* layer, MouseEvent& event)
     if (!layer->rect().contains(layer_event.position()))
         return;
 
-    GUI::Painter painter(layer->bitmap());
-    auto target_color = layer->bitmap().get_pixel(layer_event.x(), layer_event.y());
+    GUI::Painter painter(layer->content_bitmap());
+    auto target_color = layer->content_bitmap().get_pixel(layer_event.x(), layer_event.y());
 
-    flood_fill(layer->bitmap(), layer_event.position(), target_color, m_editor->color_for(layer_event), m_threshold);
+    flood_fill(layer->content_bitmap(), layer_event.position(), target_color, m_editor->color_for(layer_event), m_threshold);
 
     layer->did_modify_bitmap();
     m_editor->did_complete_action();

--- a/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/BucketTool.cpp
@@ -82,10 +82,10 @@ void BucketTool::on_mousedown(Layer* layer, MouseEvent& event)
     if (!layer->rect().contains(layer_event.position()))
         return;
 
-    GUI::Painter painter(layer->content_bitmap());
-    auto target_color = layer->content_bitmap().get_pixel(layer_event.x(), layer_event.y());
+    GUI::Painter painter(layer->currently_edited_bitmap());
+    auto target_color = layer->currently_edited_bitmap().get_pixel(layer_event.x(), layer_event.y());
 
-    flood_fill(layer->content_bitmap(), layer_event.position(), target_color, m_editor->color_for(layer_event), m_threshold);
+    flood_fill(layer->currently_edited_bitmap(), layer_event.position(), target_color, m_editor->color_for(layer_event), m_threshold);
 
     layer->did_modify_bitmap();
     m_editor->did_complete_action();

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -67,7 +67,7 @@ void EllipseTool::on_mouseup(Layer* layer, MouseEvent& event)
         return;
 
     if (event.layer_event().button() == m_drawing_button) {
-        GUI::Painter painter(layer->bitmap());
+        GUI::Painter painter(layer->content_bitmap());
         draw_using(painter, m_ellipse_start_position, m_ellipse_end_position, m_thickness);
         m_drawing_button = GUI::MouseButton::None;
         layer->did_modify_bitmap();

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -67,7 +67,7 @@ void EllipseTool::on_mouseup(Layer* layer, MouseEvent& event)
         return;
 
     if (event.layer_event().button() == m_drawing_button) {
-        GUI::Painter painter(layer->content_bitmap());
+        GUI::Painter painter(layer->currently_edited_bitmap());
         draw_using(painter, m_ellipse_start_position, m_ellipse_end_position, m_thickness);
         m_drawing_button = GUI::MouseButton::None;
         layer->did_modify_bitmap();

--- a/Userland/Applications/PixelPaint/Tools/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.cpp
@@ -60,7 +60,7 @@ void LineTool::on_mouseup(Layer* layer, MouseEvent& event)
 
     auto& layer_event = event.layer_event();
     if (layer_event.button() == m_drawing_button) {
-        GUI::Painter painter(layer->bitmap());
+        GUI::Painter painter(layer->content_bitmap());
         painter.draw_line(m_line_start_position, m_line_end_position, m_editor->color_for(m_drawing_button), m_thickness);
         m_drawing_button = GUI::MouseButton::None;
         layer->did_modify_bitmap();

--- a/Userland/Applications/PixelPaint/Tools/LineTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/LineTool.cpp
@@ -60,7 +60,7 @@ void LineTool::on_mouseup(Layer* layer, MouseEvent& event)
 
     auto& layer_event = event.layer_event();
     if (layer_event.button() == m_drawing_button) {
-        GUI::Painter painter(layer->content_bitmap());
+        GUI::Painter painter(layer->currently_edited_bitmap());
         painter.draw_line(m_line_start_position, m_line_end_position, m_editor->color_for(m_drawing_button), m_thickness);
         m_drawing_button = GUI::MouseButton::None;
         layer->did_modify_bitmap();

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
@@ -24,7 +24,7 @@ void PickerTool::on_mousedown(Layer* layer, MouseEvent& event)
     } else {
         if (!layer || !layer->rect().contains(position))
             return;
-        color = layer->content_bitmap().get_pixel(position);
+        color = layer->currently_edited_bitmap().get_pixel(position);
     }
 
     // We picked a transparent pixel, do nothing.

--- a/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/PickerTool.cpp
@@ -24,7 +24,7 @@ void PickerTool::on_mousedown(Layer* layer, MouseEvent& event)
     } else {
         if (!layer || !layer->rect().contains(position))
             return;
-        color = layer->bitmap().get_pixel(position);
+        color = layer->content_bitmap().get_pixel(position);
     }
 
     // We picked a transparent pixel, do nothing.

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
@@ -70,7 +70,7 @@ void RectangleTool::on_mouseup(Layer* layer, MouseEvent& event)
         return;
 
     if (event.layer_event().button() == m_drawing_button) {
-        GUI::Painter painter(layer->bitmap());
+        GUI::Painter painter(layer->content_bitmap());
         draw_using(painter, m_rectangle_start_position, m_rectangle_end_position, m_thickness);
         m_drawing_button = GUI::MouseButton::None;
         layer->did_modify_bitmap();

--- a/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/RectangleTool.cpp
@@ -70,7 +70,7 @@ void RectangleTool::on_mouseup(Layer* layer, MouseEvent& event)
         return;
 
     if (event.layer_event().button() == m_drawing_button) {
-        GUI::Painter painter(layer->content_bitmap());
+        GUI::Painter painter(layer->currently_edited_bitmap());
         draw_using(painter, m_rectangle_start_position, m_rectangle_end_position, m_thickness);
         m_drawing_button = GUI::MouseButton::None;
         layer->did_modify_bitmap();

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
@@ -40,7 +40,7 @@ void SprayTool::paint_it()
     if (!layer)
         return;
 
-    auto& bitmap = layer->bitmap();
+    auto& bitmap = layer->content_bitmap();
     GUI::Painter painter(bitmap);
     VERIFY(bitmap.bpp() == 32);
     const double minimal_radius = 2;

--- a/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/SprayTool.cpp
@@ -40,7 +40,7 @@ void SprayTool::paint_it()
     if (!layer)
         return;
 
-    auto& bitmap = layer->content_bitmap();
+    auto& bitmap = layer->currently_edited_bitmap();
     GUI::Painter painter(bitmap);
     VERIFY(bitmap.bpp() == 32);
     const double minimal_radius = 2;


### PR DESCRIPTION
This adds Alpha Masks to Layers!
In the following Demo the background is completely white, while the front Layer is completely black. The grey comes from the mask!
![image](https://user-images.githubusercontent.com/6002167/157128997-e526d140-7520-416e-aa3f-4e8e11f977c0.png)
A Mask is added via the context menu on the LayerListWidget:
![image](https://user-images.githubusercontent.com/6002167/157129101-f8c8f7f0-fbfd-406a-a7fb-715923947913.png)
To switch to editing the mask, double click on the thumbnail in the LayerList:
![image](https://user-images.githubusercontent.com/6002167/157129251-1c83b90d-ed10-4e3b-9a94-7f72076ef2b9.png)


