### PR TITLE
AK: take deleted_count in account for should_shrink in HashTable

### DIFF
--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -547,9 +547,10 @@ private:
 
     void shrink_if_needed()
     {
-        // Shrink if less than 20% of buckets are used, but never going below 16.
+        // Shrink if more than 12.5% of buckets are deleted and less than 20% of buckets are
+        // used, but never going below 16.
         // These limits are totally arbitrary and can probably be improved.
-        bool should_shrink = m_size * 5 < m_capacity && m_capacity > 16;
+        bool should_shrink = m_deleted_count * 8 > m_capacity && m_size * 5 < m_capacity && m_capacity > 16;
         if (!should_shrink)
             return;
 


### PR DESCRIPTION
Just got done watching Andreas' stream where he fixed the HashTable capacity leak.  It seemed to me that the `should_shrink` formula should take the `deleted_count` into account.  In the worse case, if `delete_count` is `0` then shrinking would just be a waste.  So I've added another arbitrary limit which can be tweaked in the future.  In this case I chose to only shrink if the delete count is above `12.5%`, partially because that's easy to check (a multiply by 8 turns into a bit shift).
