### PR TITLE
Toolchain: Move nix script from Documentation into Toolchain

### DIFF
--- a/Documentation/BuildInstructionsOther.md
+++ b/Documentation/BuildInstructionsOther.md
@@ -26,46 +26,11 @@ apt-get install curl cmake libmpc-devel gmp-devel e2fsprogs libmpfr-devel ninja-
 
 ## NixOS
 
-You can use a `nix-shell` script like the following to set up the correct environment:
+You can use the `nix-shell` script [`Toolchain/serenity.nix`](../Toolchain/serenity.nix) to set up the environment:
 
-myshell.nix:
-
+```console
+nix-shell Toolchain/serenity.nix
 ```
-with import <nixpkgs> {};
-
-stdenv.mkDerivation {
-  name = "cpp-env";
-  nativeBuildInputs = [
-    gcc11
-    curl
-    cmake
-    mpfr
-    ninja
-    gmp
-    libmpc
-    e2fsprogs
-    patch
-    ccache
-    rsync
-    unzip
-
-    # Example Build-time Additional Dependencies
-    pkgconfig
-  ];
-  buildInputs = [
-    # Example Run-time Additional Dependencies
-    openssl
-    x11
-    qemu
-    # glibc
-  ];
-  hardeningDisable = [ "format" "fortify" ];
-}
-```
-
-Then use this script: `nix-shell myshell.nix`.
-
-Once you're in nix-shell, you should be able to follow the build directions.
 
 ## Alpine Linux
 

--- a/Toolchain/serenity.nix
+++ b/Toolchain/serenity.nix
@@ -1,0 +1,31 @@
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+
+stdenv.mkDerivation {
+  name = "cpp-env";
+  nativeBuildInputs = [
+    gcc11
+    curl
+    cmake
+    mpfr
+    ninja
+    gmp
+    libmpc
+    e2fsprogs
+    patch
+    ccache
+    rsync
+    unzip
+
+    # Example Build-time Additional Dependencies
+    pkgconfig
+  ];
+  buildInputs = [
+    # Example Run-time Additional Dependencies
+    openssl
+    x11
+    qemu
+    # glibc
+  ];
+  hardeningDisable = [ "format" "fortify" ];
+}


### PR DESCRIPTION
Moves the nix script to setup the build environment from Documentation
into the Toolchain as a callable script.  I also modified the script
to accept a "pkgs" argument to make it easy to override the nixpkgs
version from the command-line when calling the script.