### PR TITLE
LibGUI: Fix crash in GML Playground when auto-completing properties for SpinBox

### DIFF
--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -18,7 +18,10 @@ SpinBox::SpinBox()
     set_fixed_height(22);
     m_editor = add<TextBox>();
     m_editor->set_text("0");
-    m_editor->on_change = [this] {
+    m_editor->on_change = [this, weak_this = make_weak_ptr()] {
+        if (!weak_this)
+            return;
+
         auto value = m_editor->text().to_uint();
         if (value.has_value())
             set_value(value.value());


### PR DESCRIPTION
Fixes #12939. The crash occurred any time the SpinBox's TextEditor deferred a call to on_change, and the SpinBox dtor was called before the deferred invocation fired