### PR TITLE
LibWeb: Remove outdated FIXME comment in Namespaces validate_and_extract

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Element.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Element.cpp
@@ -120,7 +120,6 @@ ExceptionOr<QualifiedName> validate_and_extract(FlyString namespace_, FlyString 
     // 5. If qualifiedName contains a U+003A (:), then strictly split the string on it and set prefix to the part before and localName to the part after.
     if (qualified_name.view().contains(':')) {
         auto parts = qualified_name.view().split_view(':');
-        // FIXME: Handle parts > 2
         prefix = parts[0];
         local_name = parts[1];
     }


### PR DESCRIPTION
As step "2. Validate qualifiedName" got implemented in bfa7aad0f6443249ae1a8f577b3150ac32add7a3, parts is known to have a length of 2.
