### PR TITLE
LibWeb: Add default styling to abbr, acronym, mark, strike and tt

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -34,7 +34,8 @@ pre {
 
 code,
 kbd,
-samp {
+samp,
+tt {
     font-family: monospace;
 }
 
@@ -44,6 +45,7 @@ ins {
 }
 
 s,
+strike,
 del {
     text-decoration: line-through;
 }
@@ -196,6 +198,15 @@ colgroup {
 blockquote {
     margin-left: 25px;
     margin-right: 25px;
+}
+
+mark {
+    background: yellow;
+}
+
+abbr[title],
+acronym[title] {
+    text-decoration: dotted underline;
 }
 
 ul,

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -200,15 +200,6 @@ blockquote {
     margin-right: 25px;
 }
 
-mark {
-    background: yellow;
-}
-
-abbr[title],
-acronym[title] {
-    text-decoration: dotted underline;
-}
-
 ul,
 ol {
     padding-left: 20px;
@@ -296,6 +287,19 @@ input[type=hidden i] { display: none !important; }
 
 @media (scripting) {
   noscript { display: none !important; }
+}
+
+/* 15.3.4 Phrasing content
+ * https://html.spec.whatwg.org/multipage/rendering.html#phrasing-content-3
+ */
+abbr[title],
+acronym[title] {
+    text-decoration: dotted underline;
+}
+
+mark {
+    background: yellow;
+    color: black;
 }
 
 /* 15.4.1 Embedded content


### PR DESCRIPTION

![libweb-default-css](https://user-images.githubusercontent.com/93391300/157277729-3d88da02-761f-41ef-8e61-96136e33d5f0.png)
