### PR TITLE
Meta: Read MAKEJOBS to limit jobs for ninja in serenity.sh

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -220,7 +220,7 @@ build_target() {
     fi
 
     # Get either the environement MAKEJOBS or all processors via CMake
-    [ -z "$MAKEJOBS" ] && MAKEJOBS=$(cmake -P "$SERENITY_SOURCE_DIR/Meta/CMake/processor-count.cmake")
+    [ -z "$MAKEJOBS" ] && MAKEJOBS=$(cmake -P "$SERENITY_SOURCE_DIR/Meta/CMake/processor-count.cmake" 2>&1)
 
     # With zero args, we are doing a standard "build"
     # With multiple args, we are doing an install/image/run


### PR DESCRIPTION
Whoops although this worked because of ninja's use all the processors this printed the processor count and would not actually use the value.