### PR TITLE
Tests: Add two missing limits.h includes to the LibC tests

### DIFF
--- a/Tests/LibC/TestRealpath.cpp
+++ b/Tests/LibC/TestRealpath.cpp
@@ -9,6 +9,7 @@
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/Tests/LibC/TestWchar.cpp
+++ b/Tests/LibC/TestWchar.cpp
@@ -7,6 +7,7 @@
 #include <LibTest/TestCase.h>
 
 #include <errno.h>
+#include <limits.h>
 #include <string.h>
 #include <wchar.h>
 


### PR DESCRIPTION
While this isn't a problem inside SerenityOS itself (as we are much less strict about the "which header can see which symbol" restrictions), this will be more important if we eventually try to compile the tests as part of Lagom.