### PR TITLE
LibJS: Performance improvements around the `CreatePerIterationEnvironment` AO

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -86,11 +86,17 @@ ThrowCompletionOr<void> DeclarativeEnvironment::create_immutable_binding(GlobalO
 }
 
 // 9.1.1.1.4 InitializeBinding ( N, V ), https://tc39.es/ecma262/#sec-declarative-environment-records-initializebinding-n-v
-ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding(GlobalObject&, FlyString const& name, Value value)
+ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding(GlobalObject& global_object, FlyString const& name, Value value)
 {
     auto index = find_binding_index(name);
     VERIFY(index.has_value());
-    auto& binding = m_bindings[*index];
+
+    return initialize_binding_direct(global_object, *index, value);
+}
+
+ThrowCompletionOr<void> DeclarativeEnvironment::initialize_binding_direct(GlobalObject&, size_t index, Value value)
+{
+    auto& binding = m_bindings[index];
 
     // 1. Assert: envRec must have an uninitialized binding for N.
     VERIFY(binding.initialized == false);

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -49,6 +49,11 @@ public:
     ThrowCompletionOr<Value> get_binding_value_direct(GlobalObject&, size_t index, bool strict);
     ThrowCompletionOr<void> set_mutable_binding_direct(GlobalObject&, size_t index, Value, bool strict);
 
+    void ensure_capacity(size_t capacity)
+    {
+        m_bindings.ensure_capacity(capacity);
+    }
+
 protected:
     virtual void visit_edges(Visitor&) override;
 

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -45,6 +45,7 @@ public:
         return names;
     }
 
+    ThrowCompletionOr<void> initialize_binding_direct(GlobalObject&, size_t index, Value);
     ThrowCompletionOr<Value> get_binding_value_direct(GlobalObject&, size_t index, bool strict);
     ThrowCompletionOr<void> set_mutable_binding_direct(GlobalObject&, size_t index, Value, bool strict);
 


### PR DESCRIPTION
The slowest part of test262 are the 445 tests under `built-ins/RegExp/property-escapes/generated`. Most of these tests have the following phases:
1. Generate a string containing the code points that match a RegExp property.
2. Run a RegExp test on that string.
3. Generate a string containing the code points that do not match a RegExp property.
4. Run a RegExp test on that string.

I profiled a single test, [White_Space.js](https://github.com/tc39/test262/blob/main/test/built-ins/RegExp/property-escapes/generated/White_Space.js). In this test, phase 1 and 2 take 0 seconds (the string is very small), phase 3 takes 2.5 seconds, phase 4 takes 0.5 seconds. So most of the time is spent generating the large string, though running the regex test is certainly non-negligible too.

The large string is generated by [this helper](https://github.com/tc39/test262/blob/489a9f8d52b5559cf5d27d867492fccfc974f873/harness/regExpUtils.js#L9). It uses a set of nested for-loops to use `Reflect.apply` to call `String.fromCodePoint` on a list of code point ranges. If we reduce this function and chop out the `Reflect` invocations:

```js
function buildString(args) {
  const ranges = args.ranges;
  const CHUNK_SIZE = 10000;
  for (let i = 0; i < ranges.length; i++) {
    const range = ranges[i];
    const start = range[0];
    const end = range[1];
    const codePoints = [];
    for (let length = 0, codePoint = start; codePoint <= end; codePoint++) {
      codePoints[length++] = codePoint;
      if (length === CHUNK_SIZE) {
        codePoints.length = length = 0;
      }
    }
  }
}
```

Then "building" the string now takes 2.3 seconds - so creating the large string only accounts for 0.2 seconds in this test, most of the time is spend iterating and creating the `codePoints` array.

As a first optimization pass, this PR looks at the `let` declarations in the nested for-loops. If these are changed to `var`, the time to invoke this function reduces to 1.6 seconds, so `let` adds 0.7 seconds of runtime. The main culprit is `CreatePerIterationEnvironment`, as the spec requires we create a new lexical environment for each iteration of a for-loop whose members are initialized with `let`.

In total, these changes reduce invocation time of `buildString` from 2.5 seconds to 2.2 seconds, so about 0.3 seconds saved. On my machine, without these changes, the 445 generated tests take 8 minutes 11 seconds to run; with these changes, that reduced to 7 minutes 45 seconds.
