### PR TITLE
LibGUI+LibVT: Use coarse scrolling animation in TerminalWidget 

### DIFF
--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -202,24 +202,24 @@ void Scrollbar::paint_event(PaintEvent& event)
         hovered_component_for_painting = Component::None;
 
     painter.fill_rect_with_dither_pattern(rect(), palette().button().lightened(1.3f), palette().button());
-    if (gutter_click_state != GutterClickState::NotPressed && has_scrubber() && hovered_component_for_painting == Component::Gutter) {
+    if (m_gutter_click_state != GutterClickState::NotPressed && has_scrubber() && hovered_component_for_painting == Component::Gutter) {
         VERIFY(!scrubber_rect().is_null());
         Gfx::IntRect rect_to_fill = rect();
         if (orientation() == Orientation::Vertical) {
-            if (gutter_click_state == GutterClickState::BeforeScrubber) {
+            if (m_gutter_click_state == GutterClickState::BeforeScrubber) {
                 rect_to_fill.set_top(decrement_button_rect().bottom());
                 rect_to_fill.set_bottom(scrubber_rect().top());
             } else {
-                VERIFY(gutter_click_state == GutterClickState::AfterScrubber);
+                VERIFY(m_gutter_click_state == GutterClickState::AfterScrubber);
                 rect_to_fill.set_top(scrubber_rect().bottom());
                 rect_to_fill.set_bottom(increment_button_rect().top());
             }
         } else {
-            if (gutter_click_state == GutterClickState::BeforeScrubber) {
+            if (m_gutter_click_state == GutterClickState::BeforeScrubber) {
                 rect_to_fill.set_left(decrement_button_rect().right());
                 rect_to_fill.set_right(scrubber_rect().left());
             } else {
-                VERIFY(gutter_click_state == GutterClickState::AfterScrubber);
+                VERIFY(m_gutter_click_state == GutterClickState::AfterScrubber);
                 rect_to_fill.set_left(scrubber_rect().right());
                 rect_to_fill.set_right(increment_button_rect().left());
             }
@@ -268,12 +268,12 @@ void Scrollbar::on_automatic_scrolling_timer_fired()
         if (m_hovered_component != component_at_position(m_last_mouse_position)) {
             m_hovered_component = component_at_position(m_last_mouse_position);
             if (m_hovered_component != Component::Gutter)
-                gutter_click_state = GutterClickState::NotPressed;
+                m_gutter_click_state = GutterClickState::NotPressed;
             update();
         }
         return;
     }
-    gutter_click_state = GutterClickState::NotPressed;
+    m_gutter_click_state = GutterClickState::NotPressed;
 }
 
 void Scrollbar::mousedown_event(MouseEvent& event)
@@ -344,7 +344,7 @@ void Scrollbar::set_automatic_scrolling_active(bool active, Component pressed_co
         m_automatic_scrolling_timer->start();
     } else {
         m_automatic_scrolling_timer->stop();
-        gutter_click_state = GutterClickState::NotPressed;
+        m_gutter_click_state = GutterClickState::NotPressed;
     }
 }
 
@@ -356,10 +356,10 @@ void Scrollbar::scroll_by_page(const Gfx::IntPoint& click_position)
     float page_increment = range_size * rel_scrubber_size;
 
     if (click_position.primary_offset_for_orientation(orientation()) < scrubber_rect().primary_offset_for_orientation(orientation())) {
-        gutter_click_state = GutterClickState::BeforeScrubber;
+        m_gutter_click_state = GutterClickState::BeforeScrubber;
         decrease_slider_by(page_increment);
     } else {
-        gutter_click_state = GutterClickState::AfterScrubber;
+        m_gutter_click_state = GutterClickState::AfterScrubber;
         increase_slider_by(page_increment);
     }
 }

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -118,6 +118,11 @@ bool Scrollbar::has_scrubber() const
     return max() != min();
 }
 
+void Scrollbar::set_scroll_animation(Animation scroll_animation)
+{
+    m_scroll_animation = scroll_animation;
+}
+
 void Scrollbar::set_value(int value, AllowCallback allow_callback)
 {
     m_target_value = value;
@@ -129,6 +134,9 @@ void Scrollbar::set_value(int value, AllowCallback allow_callback)
 
 void Scrollbar::set_target_value(int new_target_value)
 {
+    if (m_scroll_animation == Animation::CoarseScroll)
+        return set_value(new_target_value);
+
     new_target_value = clamp(new_target_value, min(), max());
 
     // If we are already at or scrolling to the new target then don't touch anything

--- a/Userland/Libraries/LibGUI/Scrollbar.h
+++ b/Userland/Libraries/LibGUI/Scrollbar.h
@@ -21,6 +21,13 @@ public:
 
     bool has_scrubber() const;
 
+    enum class Animation {
+        SmoothScroll,
+        CoarseScroll
+    };
+
+    void set_scroll_animation(Animation scroll_animation);
+
     virtual void set_value(int, AllowCallback = AllowCallback::Yes) override;
     void set_target_value(int);
 
@@ -76,6 +83,8 @@ private:
     Component component_at_position(const Gfx::IntPoint&);
 
     void update_animated_scroll();
+
+    Animation m_scroll_animation { Animation::SmoothScroll };
 
     int m_target_value { 0 };
     int m_start_value { 0 };

--- a/Userland/Libraries/LibGUI/Scrollbar.h
+++ b/Userland/Libraries/LibGUI/Scrollbar.h
@@ -55,8 +55,7 @@ private:
         NotPressed,
         BeforeScrubber,
         AfterScrubber,
-    } gutter_click_state
-        = GutterClickState::NotPressed;
+    } m_gutter_click_state { GutterClickState::NotPressed };
 
     int default_button_size() const { return 16; }
     int button_size() const { return length(orientation()) <= (default_button_size() * 2) ? length(orientation()) / 2 : default_button_size(); }

--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -90,6 +90,7 @@ TerminalWidget::TerminalWidget(int ptm_fd, bool automatic_size_policy)
     m_auto_scroll_timer = add<Core::Timer>();
 
     m_scrollbar = add<GUI::Scrollbar>(Orientation::Vertical);
+    m_scrollbar->set_scroll_animation(GUI::Scrollbar::Animation::CoarseScroll);
     m_scrollbar->set_relative_rect(0, 0, 16, 0);
     m_scrollbar->on_change = [this](int) {
         update();


### PR DESCRIPTION
The scroll animation @ForLoveOfCats added looks really nice, but it looks slightly strange when applied to the terminal.

The terminal scrolls instantly line by line, but with the animation enabled the scrollbar itself will animate, and the animation lasts longer than the actual (instant) line scroll. 

This PR switches the terminal back to coarse scrolling, and also now allows setting the scrollbar animation between `Smooth` or `Coarse`.
The coarse scrolling for the terminal is also consistent with what other terminal emulators seem to do.

P.s.

I also renamed `gutter_click_state` to `m_gutter_click_state` in ScrollBar to follow the naming conventions. 