### PR TITLE
PixelPaint: Save and Load masks

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -128,7 +128,10 @@ void Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const
             MUST(json_layer.add("selected", layer.is_selected()));
             // FIXME: Respect mask
             MUST(json_layer.add("bitmap", encode_base64(bmp_dumber.dump(layer.display_bitmap()))));
+            MUST(json_layer.finish());
         }
+
+        MUST(json_layers.finish());
     }
 }
 

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -116,7 +116,7 @@ void Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const
     {
         auto json_layers = MUST(json.add_array("layers"));
         for (const auto& layer : m_layers) {
-            Gfx::BMPWriter bmp_dumber;
+            Gfx::BMPWriter bmp_writer;
             auto json_layer = MUST(json_layers.add_object());
             MUST(json_layer.add("width", layer.size().width()));
             MUST(json_layer.add("height", layer.size().height()));
@@ -127,7 +127,7 @@ void Image::serialize_as_json(JsonObjectSerializer<StringBuilder>& json) const
             MUST(json_layer.add("visible", layer.is_visible()));
             MUST(json_layer.add("selected", layer.is_selected()));
             // FIXME: Respect mask
-            MUST(json_layer.add("bitmap", encode_base64(bmp_dumber.dump(layer.display_bitmap()))));
+            MUST(json_layer.add("bitmap", encode_base64(bmp_writer.dump(layer.content_bitmap()))));
             MUST(json_layer.finish());
         }
 

--- a/Userland/Applications/PixelPaint/Layer.cpp
+++ b/Userland/Applications/PixelPaint/Layer.cpp
@@ -148,6 +148,12 @@ void Layer::set_content_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap)
     update_cached_bitmap();
 }
 
+void Layer::set_mask_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap)
+{
+    m_mask_bitmap = move(bitmap);
+    update_cached_bitmap();
+}
+
 void Layer::update_cached_bitmap()
 {
     if (!is_masked()) {

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -54,6 +54,7 @@ public:
     void set_name(String);
 
     void set_content_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap);
+    void set_mask_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap);
 
     void did_modify_bitmap(Gfx::IntRect const& = {});
 
@@ -72,7 +73,7 @@ public:
 
     void erase_selection(Selection const&);
 
-    bool is_masked() { return !m_mask_bitmap.is_null(); }
+    bool is_masked() const { return !m_mask_bitmap.is_null(); }
 
     enum class EditMode {
         Content,


### PR DESCRIPTION
This fixes a general problem with saving pp projects

Also the new masks get saved and loaded to/from the project file