### PR TITLE
Kernel: Remove an unused fd_set.h import

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -10,10 +10,6 @@
 #include <AK/Types.h>
 #include <AK/Userspace.h>
 
-#ifdef __serenity__
-#    include <LibC/fd_set.h>
-#endif
-
 constexpr int syscall_vector = 0x82;
 
 extern "C" {


### PR DESCRIPTION
The project appears to build just fine without it, and the explicit use of `LibC` causes it to conflict with the system-wide `fd_set.h` when building inside of Serenity.