### PR TITLE
Kernel+Userland: Implement 'wxallowed' mount option

### DIFF
--- a/Base/usr/share/man/man2/mount.md
+++ b/Base/usr/share/man/man2/mount.md
@@ -37,6 +37,7 @@ The following `flags` are supported:
 * `MS_BIND`: Perform a bind-mount (see below).
 * `MS_RDONLY`: Mount the filesystem read-only.
 * `MS_REMOUNT`: Remount an already mounted filesystem (see below).
+* `MS_WXALLOWED`: Allow W^X protection circumvention for executables on this file system.
 
 These flags can be used as a security measure to limit the possible abuses of the newly
 mounted file system.

--- a/Kernel/API/POSIX/unistd.h
+++ b/Kernel/API/POSIX/unistd.h
@@ -27,6 +27,7 @@ extern "C" {
 #define MS_BIND (1 << 3)
 #define MS_RDONLY (1 << 4)
 #define MS_REMOUNT (1 << 5)
+#define MS_WXALLOWED (1 << 6)
 
 enum {
     _SC_MONOTONIC_CLOCK,

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -513,8 +513,8 @@ public:
     ErrorOr<void> require_promise(Pledge);
     ErrorOr<void> require_no_promises() const;
 
-    bool validate_mmap_prot(int prot, bool map_stack, bool map_anonymous, Memory::Region const* region = nullptr) const;
-    bool validate_inode_mmap_prot(int prot, const Inode& inode, bool map_shared) const;
+    ErrorOr<void> validate_mmap_prot(int prot, bool map_stack, bool map_anonymous, Memory::Region const* region = nullptr) const;
+    ErrorOr<void> validate_inode_mmap_prot(int prot, const Inode& inode, bool map_shared) const;
 
 private:
     friend class MemoryManager;

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -513,6 +513,9 @@ public:
     ErrorOr<void> require_promise(Pledge);
     ErrorOr<void> require_no_promises() const;
 
+    bool validate_mmap_prot(int prot, bool map_stack, bool map_anonymous, Memory::Region const* region = nullptr) const;
+    bool validate_inode_mmap_prot(int prot, const Inode& inode, bool map_shared) const;
+
 private:
     friend class MemoryManager;
     friend class Scheduler;

--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -69,7 +69,7 @@ static bool should_make_executable_exception_for_dynamic_loader(bool make_readab
     return true;
 }
 
-static bool validate_mmap_prot(int prot, bool map_stack, bool map_anonymous, Memory::Region const* region = nullptr)
+static bool validate_mmap_prot(const Process& process, int prot, bool map_stack, bool map_anonymous, Memory::Region const* region = nullptr)
 {
     bool make_readable = prot & PROT_READ;
     bool make_writable = prot & PROT_WRITE;
@@ -78,10 +78,13 @@ static bool validate_mmap_prot(int prot, bool map_stack, bool map_anonymous, Mem
     if (map_anonymous && make_executable)
         return false;
 
-    if (make_writable && make_executable)
+    if (map_stack && make_executable)
         return false;
 
-    if (map_stack && make_executable)
+    if (executable()->mount_flags() & MS_WXALLOWED)
+        return true;
+
+    if (make_writable && make_executable)
         return false;
 
     if (region) {
@@ -177,7 +180,7 @@ ErrorOr<FlatPtr> Process::sys$mmap(Userspace<const Syscall::SC_mmap_params*> use
     if ((map_fixed || map_fixed_noreplace) && map_randomized)
         return EINVAL;
 
-    if (!validate_mmap_prot(prot, map_stack, map_anonymous))
+    if (!validate_mmap_prot(*this, prot, map_stack, map_anonymous))
         return EINVAL;
 
     if (map_stack && (!map_private || !map_anonymous))
@@ -270,7 +273,7 @@ ErrorOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int p
     if (auto* whole_region = address_space().find_region_from_range(range_to_mprotect)) {
         if (!whole_region->is_mmap())
             return EPERM;
-        if (!validate_mmap_prot(prot, whole_region->is_stack(), whole_region->vmobject().is_anonymous(), whole_region))
+        if (!validate_mmap_prot(*this, prot, whole_region->is_stack(), whole_region->vmobject().is_anonymous(), whole_region))
             return EINVAL;
         if (whole_region->access() == Memory::prot_to_region_access_flags(prot))
             return 0;
@@ -290,7 +293,7 @@ ErrorOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int p
     if (auto* old_region = address_space().find_region_containing(range_to_mprotect)) {
         if (!old_region->is_mmap())
             return EPERM;
-        if (!validate_mmap_prot(prot, old_region->is_stack(), old_region->vmobject().is_anonymous(), old_region))
+        if (!validate_mmap_prot(*this, prot, old_region->is_stack(), old_region->vmobject().is_anonymous(), old_region))
             return EINVAL;
         if (old_region->access() == Memory::prot_to_region_access_flags(prot))
             return 0;
@@ -330,7 +333,7 @@ ErrorOr<FlatPtr> Process::sys$mprotect(Userspace<void*> addr, size_t size, int p
         for (const auto* region : regions) {
             if (!region->is_mmap())
                 return EPERM;
-            if (!validate_mmap_prot(prot, region->is_stack(), region->vmobject().is_anonymous(), region))
+            if (!validate_mmap_prot(*this, prot, region->is_stack(), region->vmobject().is_anonymous(), region))
                 return EINVAL;
             if (region->vmobject().is_inode()
                 && !validate_inode_mmap_prot(*this, prot, static_cast<Memory::InodeVMObject const&>(region->vmobject()).inode(), region->is_shared())) {

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -550,6 +550,7 @@ NonnullRefPtr<GUI::Widget> build_storage_widget()
             check(MS_NOSUID, "nosuid");
             check(MS_BIND, "bind");
             check(MS_RDONLY, "ro");
+            check(MS_WXALLOWED, "wxallowed");
             if (builder.string_view().is_empty())
                 return String("defaults");
             return builder.to_string();

--- a/Userland/Utilities/mount.cpp
+++ b/Userland/Utilities/mount.cpp
@@ -35,6 +35,8 @@ static int parse_options(StringView options)
             flags |= MS_RDONLY;
         else if (part == "remount")
             flags |= MS_REMOUNT;
+        else if (part == "wxallowed")
+            flags |= MS_WXALLOWED;
         else
             warnln("Ignoring invalid option: {}", part);
     }
@@ -144,6 +146,8 @@ static ErrorOr<void> print_mounts()
             out(",nosuid");
         if (mount_flags & MS_BIND)
             out(",bind");
+        if (mount_flags & MS_WXALLOWED)
+            out(",wxallowed");
 
         outln(")");
     });


### PR DESCRIPTION
This PR implements a 'wxallowed' mount option similar to OpenBSD's. The 'wxallowed' mount option allows any program located in a file system mounted with this option to violate w^x memory protection.

This will allow the user to run ports which violate the w^x protection (eg. for JIT code) without compromising any base system programs.