### PR TITLE
LibWeb: Add some default style for <textarea> elements and add a small test for it

### DIFF
--- a/Base/res/html/misc/textarea.html
+++ b/Base/res/html/misc/textarea.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<textarea>
+This is some text
+inside a &lt;textarea&gt;
+</textarea>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -72,6 +72,7 @@
             <li><a href="blink.html">blink</a></li>
             <li><a href="br.html">br</a></li>
             <li><a href="progressbar.html">progressbar</a></li>
+            <li><a href="textarea.html">textarea</a></li>
         </ul>
 
         <h2>CSS</h2>

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -222,13 +222,19 @@ ol {
 }
 
 /* FIXME: This is a temporary hack until we can render a native-looking frame for these. */
-input {
+input, textarea {
     border: 1px solid black;
     min-width: 80px;
     min-height: 16px;
     width: 120px;
     cursor: text;
     overflow: hidden;
+}
+
+textarea {
+    padding: 2px;
+    display: inline-block;
+    overflow: scroll;
 }
 
 input[type=submit], input[type=button], input[type=reset], input[type=checkbox], input[type=radio] {


### PR DESCRIPTION
A <textarea> element should probably defaults to have [contenteditable](https://html.spec.whatwg.org/multipage/interaction.html#attr-contenteditable) set but this is some start.