### PR TITLE
LibJS: Keep PrivateEnvironment through NativeFunction calls

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -139,6 +139,9 @@ ThrowCompletionOr<Value> NativeFunction::internal_call(Value this_argument, Mark
 
     callee_context.lexical_environment = caller_context.lexical_environment;
     callee_context.variable_environment = caller_context.variable_environment;
+    // Note: Keeping the private environment is probably only needed because of async methods in classes
+    //       calling async_block_start which goes through a NativeFunction here.
+    callee_context.private_environment = caller_context.private_environment;
 
     // NOTE: This is a LibJS specific hack for NativeFunction to inherit the strictness of its caller.
     callee_context.is_strict_mode = vm.in_strict_mode();


### PR DESCRIPTION
Fixes a couple of :boom:s in test262 with async and private fields and methods.