### PR TITLE
Shell: Stop parsing options after the script name

### DIFF
--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -174,6 +174,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     parser.add_positional_argument(file_to_read_from, "File to read commands from", "file", Core::ArgsParser::Required::No);
     parser.add_positional_argument(script_args, "Extra arguments to pass to the script (via $* and co)", "argument", Core::ArgsParser::Required::No);
 
+    parser.set_stop_on_first_non_option(true);
     parser.parse(arguments);
 
     if (format) {


### PR DESCRIPTION
Otherwise, Shell will try to parse and consume options that are really meant for the shell script that we are running.
This fixes invocations like `Shell script.sh --dry-run`, where the Shell would previously assume that `--dry-run` was an option for the Shell.

Fixes #12964