### PR TITLE
LibWeb: Make unconstrained row flex containers stretch horizontally

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -393,10 +393,7 @@ FlexFormattingContext::AvailableSpace FlexFormattingContext::determine_available
     auto containing_block_effective_main_size = [&](Box const& box) {
         auto& containing_block = *box.containing_block();
         if (is_row_layout()) {
-            if (containing_block.has_definite_width())
-                return m_state.get(containing_block).content_width;
-            main_size_is_infinite = true;
-            return NumericLimits<float>::max();
+            return m_state.get(containing_block).content_width;
         } else {
             if (containing_block.has_definite_height())
                 return m_state.get(containing_block).content_height;


### PR DESCRIPTION
This fixes a number of layout issues with unconstrained row flex containers. For example it makes our Github page a little more usable. The effects can also be seen in `/res/html/misc/flex.html` and `/res/html/misc/flex-2.html`.

This explicitly does not fix width issues with unconstrained column flex containers because a horizontal cross axis is handled differently for now.