### PR TITLE
LibJS: Add a fast path for creating per-iteration DeclarativeEnvironment

### DIFF
--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -91,6 +91,13 @@ public:
         m_size = other.size();
     }
 
+    explicit Vector(Span<T const> other) requires(!IsLvalueReference<T>)
+    {
+        ensure_capacity(other.size());
+        TypedTransfer<StorageType>::copy(data(), other.data(), other.size());
+        m_size = other.size();
+    }
+
     template<size_t other_inline_capacity>
     Vector(Vector<T, other_inline_capacity> const& other)
     {

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -115,6 +115,7 @@ ThrowCompletionOr<MarkedVector<Value>> create_list_from_array_like(GlobalObject&
 
     // 4. Let list be a new empty List.
     auto list = MarkedVector<Value> { heap };
+    list.ensure_capacity(length);
 
     // 5. Let index be 0.
     // 6. Repeat, while index < len,
@@ -130,7 +131,7 @@ ThrowCompletionOr<MarkedVector<Value>> create_list_from_array_like(GlobalObject&
             TRY(check_value(next));
 
         // d. Append next as the last element of list.
-        list.append(next);
+        list.unchecked_append(next);
     }
 
     // 7. Return list.

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -13,6 +13,14 @@
 
 namespace JS {
 
+DeclarativeEnvironment* DeclarativeEnvironment::create_for_per_iteration_bindings(Badge<ForStatement>, DeclarativeEnvironment& other, size_t bindings_size)
+{
+    auto bindings = other.m_bindings.span().slice(0, bindings_size);
+    auto* parent_scope = other.outer_environment();
+
+    return parent_scope->heap().allocate_without_global_object<DeclarativeEnvironment>(parent_scope, bindings);
+}
+
 DeclarativeEnvironment::DeclarativeEnvironment()
     : Environment(nullptr)
 {
@@ -20,6 +28,12 @@ DeclarativeEnvironment::DeclarativeEnvironment()
 
 DeclarativeEnvironment::DeclarativeEnvironment(Environment* parent_scope)
     : Environment(parent_scope)
+{
+}
+
+DeclarativeEnvironment::DeclarativeEnvironment(Environment* parent_scope, Span<Binding const> bindings)
+    : Environment(parent_scope)
+    , m_bindings(bindings)
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -17,9 +17,21 @@ namespace JS {
 class DeclarativeEnvironment : public Environment {
     JS_ENVIRONMENT(DeclarativeEnvironment, Environment);
 
+    struct Binding {
+        FlyString name;
+        Value value;
+        bool strict { false };
+        bool mutable_ { false };
+        bool can_be_deleted { false };
+        bool initialized { false };
+    };
+
 public:
+    static DeclarativeEnvironment* create_for_per_iteration_bindings(Badge<ForStatement>, DeclarativeEnvironment& other, size_t bindings_size);
+
     DeclarativeEnvironment();
     explicit DeclarativeEnvironment(Environment* parent_scope);
+    explicit DeclarativeEnvironment(Environment* parent_scope, Span<Binding const> bindings);
     virtual ~DeclarativeEnvironment() override;
 
     virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override;
@@ -49,11 +61,6 @@ public:
     ThrowCompletionOr<Value> get_binding_value_direct(GlobalObject&, size_t index, bool strict);
     ThrowCompletionOr<void> set_mutable_binding_direct(GlobalObject&, size_t index, Value, bool strict);
 
-    void ensure_capacity(size_t capacity)
-    {
-        m_bindings.ensure_capacity(capacity);
-    }
-
 protected:
     virtual void visit_edges(Visitor&) override;
 
@@ -70,15 +77,6 @@ private:
             return {};
         return it.index();
     }
-
-    struct Binding {
-        FlyString name;
-        Value value;
-        bool strict { false };
-        bool mutable_ { false };
-        bool can_be_deleted { false };
-        bool initialized { false };
-    };
 
     Vector<Binding> m_bindings;
 };


### PR DESCRIPTION
This squeezes out a bit more performance when creating per-iteration lexical environments. On my machine, this brings the runtime of the `test/built-ins/RegExp/property-escapes/generated` tests down from about 7 minutes 47 seconds to 7 minutes 27 seconds, so 20 seconds saved.

For reference, if we change the [`buildString`](https://github.com/tc39/test262/blob/489a9f8d52b5559cf5d27d867492fccfc974f873/harness/regExpUtils.js#L9) helper to use `var` instead of `let`, then these tests take about 7 minutes 10 seconds, so we're approaching the limit of reducing the overhead of `CreatePerIterationEnvironment` (we started at 8 minutes 11 seconds).

