### PR TITLE
LibGL: Prevent divide by zero in rotation matrix

### DIFF
--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -594,15 +594,16 @@ void GLContext::gl_mult_matrix(FloatMatrix4x4 const& matrix)
         VERIFY_NOT_REACHED();
 }
 
-void GLContext::gl_rotate(GLdouble angle, GLdouble x, GLdouble y, GLdouble z)
+void GLContext::gl_rotate(GLfloat angle, GLfloat x, GLfloat y, GLfloat z)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_rotate, angle, x, y, z);
 
     RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
 
-    FloatVector3 axis = { (float)x, (float)y, (float)z };
-    axis.normalize();
-    auto rotation_mat = Gfx::rotation_matrix(axis, static_cast<float>(angle * M_PI * 2 / 360));
+    FloatVector3 axis = { x, y, z };
+    if (axis.length() > 0.f)
+        axis.normalize();
+    auto rotation_mat = Gfx::rotation_matrix(axis, angle * static_cast<float>(M_PI * 2 / 360));
 
     if (m_current_matrix_mode == GL_MODELVIEW)
         m_model_view_matrix = m_model_view_matrix * rotation_mat;

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -196,15 +196,17 @@ private:
     [[nodiscard]] bool should_execute_after_appending_to_listing() const { return m_current_listing_index.has_value() && m_current_listing_index->mode == GL_COMPILE_AND_EXECUTE; }
 
     GLenum m_current_draw_mode;
-    GLenum m_current_matrix_mode;
-    FloatMatrix4x4 m_projection_matrix = FloatMatrix4x4::identity();
-    FloatMatrix4x4 m_model_view_matrix = FloatMatrix4x4::identity();
-    FloatMatrix4x4 m_texture_matrix = FloatMatrix4x4::identity();
+    GLenum m_current_matrix_mode { GL_MODELVIEW };
+    FloatMatrix4x4 m_projection_matrix { FloatMatrix4x4::identity() };
+    FloatMatrix4x4 m_model_view_matrix { FloatMatrix4x4::identity() };
+    FloatMatrix4x4 m_texture_matrix { FloatMatrix4x4::identity() };
+    FloatMatrix4x4* m_current_matrix { &m_model_view_matrix };
 
     Vector<FloatMatrix4x4> m_projection_matrix_stack;
     Vector<FloatMatrix4x4> m_model_view_matrix_stack;
     // FIXME: implement multi-texturing: the texture matrix stack should live inside a texture unit
     Vector<FloatMatrix4x4> m_texture_matrix_stack;
+    Vector<FloatMatrix4x4>* m_current_matrix_stack { &m_model_view_matrix_stack };
 
     Gfx::IntRect m_viewport;
 

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -70,7 +70,7 @@ public:
     void gl_push_matrix();
     void gl_pop_matrix();
     void gl_mult_matrix(FloatMatrix4x4 const& matrix);
-    void gl_rotate(GLdouble angle, GLdouble x, GLdouble y, GLdouble z);
+    void gl_rotate(GLfloat angle, GLfloat x, GLfloat y, GLfloat z);
     void gl_scale(GLdouble x, GLdouble y, GLdouble z);
     void gl_translate(GLdouble x, GLdouble y, GLdouble z);
     void gl_vertex(GLdouble x, GLdouble y, GLdouble z, GLdouble w);


### PR DESCRIPTION
Another case of normalization resulting in a divide by zero; this fixes the skybox rendering of Quake2!

Also some matrix and matrix stack handling cleanup :^)

Before:
![Screenshot_20220310_104154](https://user-images.githubusercontent.com/3210731/157634731-c305d689-cb40-4a3c-91b8-e5f54c36c08e.png)

After:
![Screenshot_20220310_103659](https://user-images.githubusercontent.com/3210731/157634484-43031742-c2e0-4e29-9fe6-eb57b968d633.png)