### PR TITLE
LibCore+Kernel: Make pledge() better by using bitfields instead of strings

### DIFF
--- a/Base/res/devel/templates/serenity-application/main.cpp
+++ b/Base/res/devel/templates/serenity-application/main.cpp
@@ -9,11 +9,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, wpath, cpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Form1");

--- a/Kernel/API/Pledge.h
+++ b/Kernel/API/Pledge.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+#define ENUMERATE_PLEDGE_PROMISES         \
+    __ENUMERATE_PLEDGE_PROMISE(stdio)     \
+    __ENUMERATE_PLEDGE_PROMISE(rpath)     \
+    __ENUMERATE_PLEDGE_PROMISE(wpath)     \
+    __ENUMERATE_PLEDGE_PROMISE(cpath)     \
+    __ENUMERATE_PLEDGE_PROMISE(dpath)     \
+    __ENUMERATE_PLEDGE_PROMISE(inet)      \
+    __ENUMERATE_PLEDGE_PROMISE(id)        \
+    __ENUMERATE_PLEDGE_PROMISE(proc)      \
+    __ENUMERATE_PLEDGE_PROMISE(ptrace)    \
+    __ENUMERATE_PLEDGE_PROMISE(exec)      \
+    __ENUMERATE_PLEDGE_PROMISE(unix)      \
+    __ENUMERATE_PLEDGE_PROMISE(recvfd)    \
+    __ENUMERATE_PLEDGE_PROMISE(sendfd)    \
+    __ENUMERATE_PLEDGE_PROMISE(fattr)     \
+    __ENUMERATE_PLEDGE_PROMISE(tty)       \
+    __ENUMERATE_PLEDGE_PROMISE(chown)     \
+    __ENUMERATE_PLEDGE_PROMISE(thread)    \
+    __ENUMERATE_PLEDGE_PROMISE(video)     \
+    __ENUMERATE_PLEDGE_PROMISE(accept)    \
+    __ENUMERATE_PLEDGE_PROMISE(settime)   \
+    __ENUMERATE_PLEDGE_PROMISE(sigaction) \
+    __ENUMERATE_PLEDGE_PROMISE(setkeymap) \
+    __ENUMERATE_PLEDGE_PROMISE(prot_exec) \
+    __ENUMERATE_PLEDGE_PROMISE(map_fixed) \
+    __ENUMERATE_PLEDGE_PROMISE(getkeymap)
+
+namespace Kernel {
+
+// This is evil, but avoids manual counting
+constexpr size_t pledge_promise_count =
+#define __ENUMERATE_PLEDGE_PROMISE(x) 1 +
+    ENUMERATE_PLEDGE_PROMISES
+#undef __ENUMERATE_PLEDGE_PROMISE
+    0;
+
+#ifdef __cplusplus
+enum class PledgeMode : u8 {
+    None = 0,
+    Promises = 1,
+    ExecPromises = 2,
+    Both = Promises | ExecPromises,
+};
+#else
+enum PledgeMode {
+    PLEDGE_MODE_PROMISES = 1,
+    PLEDGE_MODE_EXEC_PROMISES = 2,
+    PLEDGE_MODE_BOTH = PLEDGE_MODE_EXEC_PROMISES | PLEDGE_MODE_PROMISES,
+};
+#endif
+
+#ifdef __cplusplus
+enum class
+#else
+enum
+#endif
+    Pledge : u32 {
+#define __ENUMERATE_PLEDGE_PROMISE(x) x,
+        ENUMERATE_PLEDGE_PROMISES
+#undef __ENUMERATE_PLEDGE_PROMISE
+    };
+
+namespace PledgeBits {
+#define __ENUMERATE_PLEDGE_PROMISE(promise) constexpr u32 const promise = 1 << static_cast<u64>(Kernel::Pledge::promise);
+ENUMERATE_PLEDGE_PROMISES
+#undef __ENUMERATE_PLEDGE_PROMISE
+};
+
+}

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -425,8 +425,9 @@ struct SC_mount_params {
 };
 
 struct SC_pledge_params {
-    StringArgument promises;
-    StringArgument execpromises;
+    u8 mode;
+    u32 promises;
+    u32 execpromises;
 };
 
 struct SC_unveil_params {

--- a/Kernel/KString.h
+++ b/Kernel/KString.h
@@ -73,7 +73,7 @@ struct Formatter<OwnPtr<Kernel::KString>> : Formatter<StringView> {
     {
         if (value)
             return Formatter<StringView>::format(builder, value->view());
-        return Formatter<StringView>::format(builder, "[out of memory]"sv);
+        return Formatter<StringView>::format(builder, "[nullptr]"sv);
     }
 };
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -17,6 +17,7 @@
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 #include <Kernel/API/POSIX/sys/resource.h>
+#include <Kernel/API/Pledge.h>
 #include <Kernel/API/Syscall.h>
 #include <Kernel/Assertions.h>
 #include <Kernel/AtomicEdgeAction.h>
@@ -41,39 +42,6 @@ namespace Kernel {
 
 MutexProtected<OwnPtr<KString>>& hostname();
 Time kgettimeofday();
-
-#define ENUMERATE_PLEDGE_PROMISES         \
-    __ENUMERATE_PLEDGE_PROMISE(stdio)     \
-    __ENUMERATE_PLEDGE_PROMISE(rpath)     \
-    __ENUMERATE_PLEDGE_PROMISE(wpath)     \
-    __ENUMERATE_PLEDGE_PROMISE(cpath)     \
-    __ENUMERATE_PLEDGE_PROMISE(dpath)     \
-    __ENUMERATE_PLEDGE_PROMISE(inet)      \
-    __ENUMERATE_PLEDGE_PROMISE(id)        \
-    __ENUMERATE_PLEDGE_PROMISE(proc)      \
-    __ENUMERATE_PLEDGE_PROMISE(ptrace)    \
-    __ENUMERATE_PLEDGE_PROMISE(exec)      \
-    __ENUMERATE_PLEDGE_PROMISE(unix)      \
-    __ENUMERATE_PLEDGE_PROMISE(recvfd)    \
-    __ENUMERATE_PLEDGE_PROMISE(sendfd)    \
-    __ENUMERATE_PLEDGE_PROMISE(fattr)     \
-    __ENUMERATE_PLEDGE_PROMISE(tty)       \
-    __ENUMERATE_PLEDGE_PROMISE(chown)     \
-    __ENUMERATE_PLEDGE_PROMISE(thread)    \
-    __ENUMERATE_PLEDGE_PROMISE(video)     \
-    __ENUMERATE_PLEDGE_PROMISE(accept)    \
-    __ENUMERATE_PLEDGE_PROMISE(settime)   \
-    __ENUMERATE_PLEDGE_PROMISE(sigaction) \
-    __ENUMERATE_PLEDGE_PROMISE(setkeymap) \
-    __ENUMERATE_PLEDGE_PROMISE(prot_exec) \
-    __ENUMERATE_PLEDGE_PROMISE(map_fixed) \
-    __ENUMERATE_PLEDGE_PROMISE(getkeymap)
-
-enum class Pledge : u32 {
-#define __ENUMERATE_PLEDGE_PROMISE(x) x,
-    ENUMERATE_PLEDGE_PROMISES
-#undef __ENUMERATE_PLEDGE_PROMISE
-};
 
 enum class VeilState {
     None,

--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/StringView.h>
+#include <Kernel/API/Pledge.h>
 #include <Kernel/Process.h>
 
 namespace Kernel {
@@ -14,46 +15,21 @@ ErrorOr<FlatPtr> Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*>
     VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
     auto params = TRY(copy_typed_from_user(user_params));
 
-    if (params.promises.length > 1024 || params.execpromises.length > 1024)
-        return E2BIG;
-
-    OwnPtr<KString> promises;
-    if (params.promises.characters) {
-        promises = TRY(try_copy_kstring_from_user(params.promises));
-    }
-
-    OwnPtr<KString> execpromises;
-    if (params.execpromises.characters) {
-        execpromises = TRY(try_copy_kstring_from_user(params.execpromises));
-    }
-
-    auto parse_pledge = [&](auto pledge_spec, u32& mask) {
-        auto found_invalid_pledge = true;
-        pledge_spec.for_each_split_view(' ', false, [&mask, &found_invalid_pledge](auto const& part) {
-#define __ENUMERATE_PLEDGE_PROMISE(x)   \
-    if (part == StringView { #x }) {    \
-        mask |= (1u << (u32)Pledge::x); \
-        return;                         \
-    }
-            ENUMERATE_PLEDGE_PROMISES
-#undef __ENUMERATE_PLEDGE_PROMISE
-            found_invalid_pledge = false;
-        });
-        return found_invalid_pledge;
-    };
-
     u32 new_promises = 0;
-    if (promises) {
-        if (!parse_pledge(promises->view(), new_promises))
+    if (params.mode & static_cast<u8>(PledgeMode::Promises)) {
+        // The user has set invalid upper bits.
+        if (params.promises & ~((1 << pledge_promise_count) - 1))
             return EINVAL;
+        new_promises = params.promises & ((1 << pledge_promise_count) - 1);
         if (m_protected_values.has_promises && (new_promises & ~m_protected_values.promises))
             return EPERM;
     }
 
     u32 new_execpromises = 0;
-    if (execpromises) {
-        if (!parse_pledge(execpromises->view(), new_execpromises))
+    if (params.mode & static_cast<u8>(PledgeMode::ExecPromises)) {
+        if (params.execpromises & ~((1 << pledge_promise_count) - 1))
             return EINVAL;
+        new_execpromises = params.execpromises & ((1 << pledge_promise_count) - 1);
         if (m_protected_values.has_execpromises && (new_execpromises & ~m_protected_values.execpromises))
             return EPERM;
     }
@@ -65,12 +41,12 @@ ErrorOr<FlatPtr> Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*>
 
     ProtectedDataMutationScope scope { *this };
 
-    if (promises) {
+    if (params.mode & static_cast<u8>(PledgeMode::Promises)) {
         m_protected_values.has_promises = true;
         m_protected_values.promises = new_promises;
     }
 
-    if (execpromises) {
+    if (params.mode & static_cast<u8>(PledgeMode::ExecPromises)) {
         m_protected_values.has_execpromises = true;
         m_protected_values.execpromises = new_execpromises;
     }

--- a/Tests/Kernel/crash.cpp
+++ b/Tests/Kernel/crash.cpp
@@ -8,6 +8,7 @@
 #include <AK/Assertions.h>
 #include <AK/Function.h>
 #include <AK/String.h>
+#include <Kernel/API/Pledge.h>
 #include <Kernel/Arch/x86/IO.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/Object.h>
@@ -277,7 +278,7 @@ int main(int argc, char** argv)
 
     if (do_pledge_violation || do_all_crash_types) {
         any_failures |= !Crash("Violate pledge()'d promises", [] {
-            if (pledge("", nullptr) < 0) {
+            if (pledge((u8)Kernel::PledgeMode::Promises, 0, 0) < 0) {
                 perror("pledge");
                 return Crash::Failure::DidNotCrash;
             }

--- a/Tests/LibC/TestMkDir.cpp
+++ b/Tests/LibC/TestMkDir.cpp
@@ -6,6 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
+#include <Kernel/API/Pledge.h>
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/stat.h>
@@ -63,7 +64,8 @@ TEST_CASE(parent_is_file)
 
 TEST_CASE(pledge)
 {
-    int res = pledge("stdio cpath", nullptr);
+    using namespace Kernel::PledgeBits;
+    auto res = pledge((u8)Kernel::PledgeMode::Promises, stdio | cpath, 0);
     EXPECT(res == 0);
 
     auto dirname = random_dirname();

--- a/Userland/Applets/Audio/main.cpp
+++ b/Userland/Applets/Audio/main.cpp
@@ -237,7 +237,8 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, wpath, cpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("AudioApplet");
@@ -256,7 +257,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     // This positioning code depends on the window actually existing.
     static_cast<AudioWidget*>(window->main_widget())->set_audio_widget_size(Config::read_bool("AudioApplet", "Applet", "ShowPercent", false));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     return app->exec();
 }

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -17,13 +17,14 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
     auto app = GUI::Application::construct(arguments);
 
     Config::pledge_domain("ClipboardHistory");
     Config::monitor_domain("ClipboardHistory");
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("edit-copy"));

--- a/Userland/Applets/Keymap/main.cpp
+++ b/Userland/Applets/Keymap/main.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix getkeymap proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix, getkeymap, proc, exec>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -24,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
     window->make_window_manager(WindowServer::WMEventMask::KeymapChanged);
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath getkeymap proc exec"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, getkeymap, proc, exec>::pledge()));
 
     return app->exec();
 }

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -169,7 +169,8 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix, proc, exec>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -191,11 +191,12 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec, rpath, unix>::pledge()));
 
     auto app = GUI::Application::construct(arguments);
 
-    TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec, rpath>::pledge()));
 
     const char* cpu = nullptr;
     const char* memory = nullptr;

--- a/Userland/Applets/WorkspacePicker/main.cpp
+++ b/Userland/Applets/WorkspacePicker/main.cpp
@@ -14,14 +14,15 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
     // We need to obtain the WM connection here as well before the pledge shortening.
     GUI::ConnectionToWindowMangerServer::the();
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     auto window = TRY(DesktopStatusWindow::try_create());
     window->set_title("WorkspacePicker");

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -328,7 +328,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = GUI::Application::construct(arguments);
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/home/anon/Documents/3D Models/teapot.obj", "r"));

--- a/Userland/Applications/About/main.cpp
+++ b/Userland/Applications/About/main.cpp
@@ -13,10 +13,11 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/AnalogClock/main.cpp
+++ b/Userland/Applications/AnalogClock/main.cpp
@@ -19,7 +19,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -193,7 +193,8 @@ static constexpr size_t MAX_SEARCH_RESULTS = 6;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath unix proc exec thread", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, cpath, unix, proc, exec, thread>::pledge()));
 
     Core::LockFile lockfile("/tmp/lock/assistant.lock");
 

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -57,7 +57,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TRY(Core::System::pledge("stdio recvfd sendfd unix cpath rpath wpath proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix, cpath, rpath, wpath, proc, exec>::pledge()));
 
     const char* specified_url = nullptr;
 

--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -15,7 +15,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("Browser");
 

--- a/Userland/Applications/Calculator/main.cpp
+++ b/Userland/Applications/Calculator/main.cpp
@@ -20,10 +20,11 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Calendar/main.cpp
+++ b/Userland/Applications/Calendar/main.cpp
@@ -22,11 +22,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath", nullptr));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/CharacterMap/main.cpp
+++ b/Userland/Applications/CharacterMap/main.cpp
@@ -40,7 +40,8 @@ static void search_and_print_results(String const& query)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("CharacterMap");
@@ -48,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/CharacterMap.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/ClockSettings/main.cpp
+++ b/Userland/Applications/ClockSettings/main.cpp
@@ -13,11 +13,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix, proc, exec>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd proc exec"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/timezone", "x"));
     TRY(Core::System::unveil("/etc/timezone", "r"));

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -132,7 +132,8 @@ static void unlink_coredump(StringView const& coredump_path)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd cpath rpath unix proc exec thread"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, cpath, rpath, unix, proc, exec, thread>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 

--- a/Userland/Applications/Debugger/main.cpp
+++ b/Userland/Applications/Debugger/main.cpp
@@ -212,7 +212,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     editor = Line::Editor::construct();
 
-    TRY(Core::System::pledge("stdio proc ptrace exec rpath tty sigaction cpath unix", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, proc, Kernel::Pledge::ptrace, exec, rpath, tty, Kernel::Pledge::sigaction, cpath, unix>::pledge()));
 
     const char* command = nullptr;
     Core::ArgsParser args_parser;

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -19,7 +19,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, cpath, wpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("WindowManager");

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -67,7 +67,8 @@ static bool add_launch_handler_actions_to_menu(RefPtr<GUI::Menu>& menu, Director
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread recvfd sendfd unix cpath rpath wpath fattr proc exec sigaction"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix, cpath, rpath, wpath, fattr, proc, exec, Kernel::Pledge::sigaction>::pledge()));
 
     struct sigaction act = {};
     act.sa_flags = SA_NOCLDWAIT;
@@ -87,7 +88,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath fattr proc exec unix"));
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, cpath, rpath, wpath, fattr, proc, exec, unix>::pledge()));
 
     Config::pledge_domains({ "FileManager", "WindowManager" });
     Config::monitor_domain("FileManager");

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -21,7 +21,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath unix cpath wpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, thread, rpath, unix, cpath, wpath>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -29,7 +30,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::seal_allowlist());
 
     Config::pledge_domain("FontEditor");
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, thread, rpath, cpath, wpath>::pledge()));
 
     char const* path = nullptr;
     Core::ArgsParser args_parser;

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -18,7 +18,8 @@ using namespace Help;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Applications/HexEditor/main.cpp
+++ b/Userland/Applications/HexEditor/main.cpp
@@ -19,7 +19,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath thread"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix, cpath, wpath, thread>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -35,7 +35,8 @@ using namespace ImageViewer;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix thread"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, wpath, cpath, unix, thread>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -23,11 +23,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(path, "Keyboard character mapping file.", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, getkeymap, thread, rpath, cpath, wpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = GUI::Application::construct(arguments.argc, arguments.argv);
 
-    TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, getkeymap, thread, rpath, cpath, wpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     auto app_icon = GUI::Icon::default_icon("app-keyboard-mapper");
 
@@ -43,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     else
         TRY(keyboard_mapper_widget->load_map_from_file(path));
 
-    TRY(Core::System::pledge("stdio thread rpath cpath wpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, thread, rpath, cpath, wpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     auto open_action = GUI::CommonActions::make_open_action(
         [&](auto&) {

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -16,11 +16,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix, proc, exec>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("KeyboardSettings");
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd proc exec"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/keymap", "x"));
     TRY(Core::System::unveil("/proc/keymap", "r"));

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -17,10 +17,11 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd unix", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, cpath, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
     auto app = GUI::Application::construct(arguments);
 
-    TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd", nullptr));
+    TRY((Core::System::Promise<stdio, cpath, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -18,7 +18,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix inet"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix, inet>::pledge()));
 
     auto app = GUI::Application::construct(arguments);
 

--- a/Userland/Applications/MailSettings/main.cpp
+++ b/Userland/Applications/MailSettings/main.cpp
@@ -15,13 +15,14 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("Mail");
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/MouseSettings/main.cpp
+++ b/Userland/Applications/MouseSettings/main.cpp
@@ -17,11 +17,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, cpath, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, cpath, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     auto app_icon = GUI::Icon::default_icon("app-mouse");
 

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -24,7 +24,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_title("PDF Viewer");
     window->resize(640, 400);
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -27,7 +27,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread rpath cpath wpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, rpath, cpath, wpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = GUI::Application::construct(arguments);
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -21,7 +21,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix, wpath, cpath>::pledge()));
 
     auto app = GUI::Application::construct(arguments);
     Config::pledge_domain("PixelPaint");

--- a/Userland/Applications/Run/main.cpp
+++ b/Userland/Applications/Run/main.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd thread cpath rpath wpath unix proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, thread, cpath, rpath, wpath, unix, proc, exec>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto window = TRY(RunWindow::try_create());

--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -70,11 +70,12 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath unix proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, cpath, wpath, unix, proc, exec>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath proc exec"));
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, cpath, wpath, proc, exec>::pledge()));
 
     auto app_icon = GUI::Icon::default_icon("app-settings");
 

--- a/Userland/Applications/SoundPlayer/main.cpp
+++ b/Userland/Applications/SoundPlayer/main.cpp
@@ -25,12 +25,13 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath thread unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, thread, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto audio_client = TRY(Audio::ConnectionFromClient::try_create());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath thread"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, thread>::pledge()));
 
     auto app_icon = GUI::Icon::default_icon("app-sound-player");
 

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -26,7 +26,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, fattr, unix, cpath, wpath, thread>::pledge()));
 
     auto app = GUI::Application::construct(arguments);
 

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -104,7 +104,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         sched_setparam(0, &param);
     }
 
-    TRY(Core::System::pledge("stdio thread proc recvfd sendfd rpath exec unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, proc, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, exec, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -232,7 +232,8 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio tty rpath cpath wpath recvfd sendfd proc exec unix sigaction"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, tty, rpath, cpath, wpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec, unix, Kernel::Pledge::sigaction>::pledge()));
 
     struct sigaction act;
     memset(&act, 0, sizeof(act));
@@ -243,7 +244,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio tty rpath cpath wpath recvfd sendfd proc exec unix"));
+    TRY((Core::System::Promise<stdio, tty, rpath, cpath, wpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec, unix>::pledge()));
 
     Config::pledge_domain("Terminal");
 

--- a/Userland/Applications/TerminalSettings/main.cpp
+++ b/Userland/Applications/TerminalSettings/main.cpp
@@ -16,11 +16,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("Terminal");
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -18,7 +18,8 @@ using namespace TextEditor;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, thread, rpath, cpath, wpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -159,7 +159,8 @@ public:
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, thread, rpath, cpath, wpath, unix>::pledge()));
 
     auto app = GUI::Application::construct(arguments);
 
@@ -182,7 +183,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath unix", nullptr));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, thread, rpath, unix>::pledge()));
     TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Applications/Welcome/main.cpp
+++ b/Userland/Applications/Welcome/main.cpp
@@ -15,7 +15,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix, proc, exec>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("SystemServer");

--- a/Userland/Demos/CatDog/main.cpp
+++ b/Userland/Demos/CatDog/main.cpp
@@ -19,12 +19,13 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, wpath, cpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-catdog"));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/proc/all", "r"));
     // FIXME: For some reason, this is needed in the /proc/all shenanigans.

--- a/Userland/Demos/Cube/Cube.cpp
+++ b/Userland/Demos/Cube/Cube.cpp
@@ -201,7 +201,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -31,11 +31,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(grid_columns, "Number of columns in grid (incompatible with --number)", "grid-cols", 'c', "number");
     args_parser.parse(arguments);
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath thread"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix, cpath, wpath, thread>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath wpath thread"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, cpath, wpath, thread>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Demos/Fire/Fire.cpp
+++ b/Userland/Demos/Fire/Fire.cpp
@@ -198,7 +198,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Demos/LibGfxDemo/main.cpp
+++ b/Userland/Demos/LibGfxDemo/main.cpp
@@ -185,7 +185,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -105,7 +105,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -377,7 +377,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, wpath, cpath>::pledge()));
 
 #if 0
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Demos/ModelGallery/main.cpp
+++ b/Userland/Demos/ModelGallery/main.cpp
@@ -16,11 +16,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath wpath cpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, wpath, cpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-model-gallery"));
 

--- a/Userland/Demos/Mouse/main.cpp
+++ b/Userland/Demos/Mouse/main.cpp
@@ -162,7 +162,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-mouse"));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Demos/Screensaver/Screensaver.cpp
+++ b/Userland/Demos/Screensaver/Screensaver.cpp
@@ -110,11 +110,12 @@ void Screensaver::draw()
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Demos/Starfield/Starfield.cpp
+++ b/Userland/Demos/Starfield/Starfield.cpp
@@ -147,7 +147,8 @@ void Starfield::draw()
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     unsigned star_count = 1000;
     unsigned refresh_rate = 16;
@@ -162,7 +163,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     auto app_icon = GUI::Icon::default_icon("app-starfield");
     auto window = TRY(GUI::Window::try_create());

--- a/Userland/Demos/WidgetGallery/main.cpp
+++ b/Userland/Demos/WidgetGallery/main.cpp
@@ -14,10 +14,11 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix thread"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix, thread>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath thread"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, thread>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/home/anon", "r"));
     TRY(Core::System::unveil("/etc/FileIconProvider.ini", "r"));

--- a/Userland/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Cpp/main.cpp
@@ -32,11 +32,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 ErrorOr<int> mode_server()
 {
     Core::EventLoop event_loop;
-    TRY(Core::System::pledge("stdio unix recvfd rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, unix, Kernel::Pledge::recvfd, rpath>::pledge()));
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<LanguageServers::Cpp::ConnectionFromClient>());
 
-    TRY(Core::System::pledge("stdio recvfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, rpath>::pledge()));
     TRY(Core::System::unveil("/usr/include", "r"));
 
     // unveil will be sealed later, when we know the project's root path.

--- a/Userland/DevTools/HackStudio/LanguageServers/Shell/main.cpp
+++ b/Userland/DevTools/HackStudio/LanguageServers/Shell/main.cpp
@@ -14,11 +14,12 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
-    TRY(Core::System::pledge("stdio unix rpath recvfd"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, unix, rpath, Kernel::Pledge::recvfd>::pledge()));
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<LanguageServers::Shell::ConnectionFromClient>());
 
-    TRY(Core::System::pledge("stdio rpath recvfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd>::pledge()));
     TRY(Core::System::unveil("/etc/passwd", "r"));
 
     return event_loop.exec();

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -36,7 +36,8 @@ static Optional<String> last_opened_project_path();
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd tty rpath cpath wpath proc exec unix fattr thread ptrace"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, tty, rpath, cpath, wpath, proc, exec, unix, fattr, thread, Kernel::Pledge::ptrace>::pledge()));
 
     auto app = GUI::Application::construct(arguments.argc, arguments.argv);
     Config::pledge_domains({ "HackStudio", "Terminal" });

--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -36,7 +36,8 @@ using namespace Inspector;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin", "r"));
     TRY(Core::System::unveil("/tmp", "rwc"));
@@ -146,6 +147,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
     remote_process.update();
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
     return app->exec();
 }

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -64,13 +64,14 @@ void UnregisteredWidget::paint_event(GUI::PaintEvent& event)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, cpath, rpath, wpath, unix>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/Playground.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath"));
+    TRY((Core::System::Promise<stdio, thread, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, cpath, wpath>::pledge()));
 
     const char* path = nullptr;
     Core::ArgsParser args_parser;

--- a/Userland/Games/2048/main.cpp
+++ b/Userland/Games/2048/main.cpp
@@ -28,7 +28,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     srand(time(nullptr));
 
@@ -42,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/2048.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/Games/Breakout/main.cpp
+++ b/Userland/Games/Breakout/main.cpp
@@ -18,14 +18,15 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Breakout.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/Games/Chess/main.cpp
+++ b/Userland/Games/Chess/main.cpp
@@ -22,7 +22,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath recvfd sendfd thread proc exec unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, thread, proc, exec, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -31,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Chess.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath wpath cpath recvfd sendfd thread proc exec"));
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, thread, proc, exec>::pledge()));
 
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-chess"));
 

--- a/Userland/Games/FlappyBug/main.cpp
+++ b/Userland/Games/FlappyBug/main.cpp
@@ -19,7 +19,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -28,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/FlappyBug.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/Games/GameOfLife/main.cpp
+++ b/Userland/Games/GameOfLife/main.cpp
@@ -27,14 +27,15 @@ const char* click_tip = "Tip: click the board to toggle individual cells, or cli
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/GameOfLife.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -33,12 +33,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("Hearts");
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Hearts.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -26,7 +26,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -35,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Minesweeper.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/Games/Pong/main.cpp
+++ b/Userland/Games/Pong/main.cpp
@@ -18,14 +18,15 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Pong.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/Games/Snake/main.cpp
+++ b/Userland/Games/Snake/main.cpp
@@ -22,7 +22,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
 
@@ -31,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man6/Snake.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -24,14 +24,15 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-solitaire"));
 
     Config::pledge_domain("Solitaire");
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -39,14 +39,15 @@ static String format_seconds(uint64_t seconds_elapsed)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-spider"));
 
     Config::pledge_domain("Spider");
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath>::pledge()));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -862,11 +862,12 @@ int set_process_name(const char* name, size_t name_length)
     __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 
-int pledge(const char* promises, const char* execpromises)
+int pledge(unsigned char mode, unsigned int promises, unsigned int execpromises)
 {
     Syscall::SC_pledge_params params {
-        { promises, promises ? strlen(promises) : 0 },
-        { execpromises, execpromises ? strlen(execpromises) : 0 }
+        mode,
+        promises,
+        execpromises,
     };
     int rc = syscall(SC_pledge, &params);
     __RETURN_WITH_ERRNO(rc, rc, -1);

--- a/Userland/Libraries/LibC/unistd.h
+++ b/Userland/Libraries/LibC/unistd.h
@@ -113,7 +113,7 @@ int ftruncate(int fd, off_t length);
 int truncate(const char* path, off_t length);
 int mount(int source_fd, const char* target, const char* fs_type, int flags);
 int umount(const char* mountpoint);
-int pledge(const char* promises, const char* execpromises);
+int pledge(unsigned char mode, unsigned int promises, unsigned int execpromises);
 int unveil(const char* path, const char* permissions);
 char* getpass(const char* prompt);
 int pause(void);

--- a/Userland/Libraries/LibCore/SyscallMacros.h
+++ b/Userland/Libraries/LibCore/SyscallMacros.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+
+#define HANDLE_SYSCALL_RETURN_VALUE(syscall_name, rc, success_value) \
+    if ((rc) < 0) {                                                  \
+        return Error::from_syscall(syscall_name, rc);                \
+    }                                                                \
+    return success_value;

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -10,6 +10,7 @@
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <LibCore/SyscallMacros.h>
 #include <LibCore/System.h>
 #include <LibSystem/syscall.h>
 #include <limits.h>
@@ -39,12 +40,6 @@ static int memfd_create(const char* name, unsigned int flags)
 #if defined(__APPLE__)
 #    include <sys/mman.h>
 #endif
-
-#define HANDLE_SYSCALL_RETURN_VALUE(syscall_name, rc, success_value) \
-    if ((rc) < 0) {                                                  \
-        return Error::from_syscall(syscall_name, rc);                \
-    }                                                                \
-    return success_value;
 
 namespace Core::System {
 

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -10,6 +10,7 @@
 #include <AK/StdLibExtras.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
+#include <Kernel/API/Pledge.h>
 #include <LibCore/SyscallMacros.h>
 #include <LibCore/System.h>
 #include <LibSystem/syscall.h>
@@ -59,16 +60,6 @@ ErrorOr<void> beep()
     if (rc < 0)
         return Error::from_syscall("beep"sv, -errno);
     return {};
-}
-
-ErrorOr<void> pledge(StringView promises, StringView execpromises)
-{
-    Syscall::SC_pledge_params params {
-        { promises.characters_without_null_termination(), promises.length() },
-        { execpromises.characters_without_null_termination(), execpromises.length() },
-    };
-    int rc = syscall(SC_pledge, &params);
-    HANDLE_SYSCALL_RETURN_VALUE("pledge"sv, rc, {});
 }
 
 ErrorOr<void> unveil(StringView path, StringView permissions)

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -9,7 +9,10 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/Optional.h>
 #include <AK/StringView.h>
+#include <Kernel/API/Pledge.h>
+#include <LibCore/System/Promise.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <pwd.h>
@@ -33,7 +36,8 @@ namespace Core::System {
 
 #ifdef __serenity__
 ErrorOr<void> beep();
-ErrorOr<void> pledge(StringView promises, StringView execpromises = {});
+
+// pledge() is provided by Core::System::Promise, which this header includes for user convenience.
 ErrorOr<void> unveil(StringView path, StringView permissions);
 ErrorOr<void> sendfd(int sockfd, int fd);
 ErrorOr<int> recvfd(int sockfd, int options);

--- a/Userland/Libraries/LibCore/System/Promise.h
+++ b/Userland/Libraries/LibCore/System/Promise.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/StdLibExtras.h>
+#include <Kernel/API/Pledge.h>
+#include <Kernel/API/Syscall.h>
+#include <LibCore/SyscallMacros.h>
+#include <LibSystem/syscall.h>
+
+namespace Core::System {
+
+using Kernel::Pledge;
+using Kernel::PledgeMode;
+
+template<Pledge... Promises>
+class Promise {
+public:
+    static ErrorOr<void> pledge()
+    {
+        [[maybe_unused]] Promise<Promises...> promises {};
+#ifdef __serenity__
+        u8 mode = static_cast<u8>(PledgeMode::Promises);
+        Syscall::SC_pledge_params params {
+            mode,
+            static_cast<u32>(promises),
+            0,
+        };
+        int rc = syscall(SC_pledge, &params);
+        HANDLE_SYSCALL_RETURN_VALUE("pledge"sv, rc, {});
+#else
+        return {};
+#endif
+    }
+
+    // Supply some aditional execpromises.
+    template<Pledge... ExecPromises>
+    static ErrorOr<void> pledge_with_exec([[maybe_unused]] Promise<ExecPromises...> exec_promises = {})
+    {
+        [[maybe_unused]] Promise<Promises...> promises {};
+#ifdef __serenity__
+        u8 mode = static_cast<u8>(PledgeMode::Both);
+        Syscall::SC_pledge_params params {
+            mode,
+            static_cast<u32>(promises),
+            static_cast<u32>(exec_promises),
+        };
+        int rc = syscall(SC_pledge, &params);
+        HANDLE_SYSCALL_RETURN_VALUE("pledge"sv, rc, {});
+#else
+        return {};
+#endif
+    }
+
+    // Use this promise as the execpromises.
+    static ErrorOr<void> pledge_as_exec()
+    {
+        [[maybe_unused]] Promise<Promises...> exec_promises {};
+#ifdef __serenity__
+        u8 mode = static_cast<u8>(PledgeMode::ExecPromises);
+        Syscall::SC_pledge_params params {
+            mode,
+            0,
+            static_cast<u32>(exec_promises),
+        };
+        int rc = syscall(SC_pledge, &params);
+        HANDLE_SYSCALL_RETURN_VALUE("pledge"sv, rc, {});
+#else
+        return {};
+#endif
+    }
+
+private:
+    template<Pledge...>
+    friend class Promise;
+
+    consteval Promise() = default;
+
+    consteval operator u32()
+    {
+        return 0 | ((1 << static_cast<u32>(Promises)) | ...);
+    }
+};
+
+}

--- a/Userland/Services/AudioServer/main.cpp
+++ b/Userland/Services/AudioServer/main.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd thread accept cpath rpath wpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, thread, Kernel::Pledge::accept, cpath, rpath, wpath, unix>::pledge()));
 
     auto config = TRY(Core::ConfigFile::open_for_app("Audio", Core::ConfigFile::AllowWriting::Yes));
     TRY(Core::System::unveil(config->filename(), "rwc"));
@@ -31,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
         (void)IPC::new_client_connection<AudioServer::ConnectionFromClient>(move(client_socket), client_id, *mixer);
     };
 
-    TRY(Core::System::pledge("stdio recvfd thread accept cpath rpath wpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, thread, Kernel::Pledge::accept, cpath, rpath, wpath>::pledge()));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     return event_loop.exec();

--- a/Userland/Services/ChessEngine/main.cpp
+++ b/Userland/Services/ChessEngine/main.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
     Core::EventLoop loop;
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/Clipboard/main.cpp
+++ b/Userland/Services/Clipboard/main.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd accept"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, Kernel::Pledge::accept>::pledge()));
     Core::EventLoop event_loop;
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/ConfigServer/main.cpp
+++ b/Userland/Services/ConfigServer/main.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio accept rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::accept, rpath, wpath, cpath>::pledge()));
     TRY(Core::System::unveil(Core::StandardPaths::config_directory(), "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/CrashDaemon/main.cpp
+++ b/Userland/Services/CrashDaemon/main.cpp
@@ -53,7 +53,8 @@ static void launch_crash_reporter(const String& coredump_path, bool unlink_on_ex
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, proc, exec>::pledge()));
 
     Core::BlockingFileWatcher watcher;
     TRY(watcher.add_watch("/tmp/coredump", Core::FileWatcherEvent::Type::ChildCreated));

--- a/Userland/Services/DHCPClient/main.cpp
+++ b/Userland/Services/DHCPClient/main.cpp
@@ -11,7 +11,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio unix inet cpath rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, unix, inet, cpath, rpath>::pledge()));
     Core::EventLoop event_loop;
 
     TRY(Core::System::unveil("/proc/net/", "r"));
@@ -19,6 +20,6 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     auto client = TRY(DHCPv4Client::try_create());
 
-    TRY(Core::System::pledge("stdio inet cpath rpath"));
+    TRY((Core::System::Promise<stdio, inet, cpath, rpath>::pledge()));
     return event_loop.exec();
 }

--- a/Userland/Services/EchoServer/main.cpp
+++ b/Userland/Services/EchoServer/main.cpp
@@ -15,7 +15,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio unix inet id accept", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, unix, inet, id, Kernel::Pledge::accept>::pledge()));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     int port = 7;

--- a/Userland/Services/FileSystemAccessServer/main.cpp
+++ b/Userland/Services/FileSystemAccessServer/main.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath wpath unix thread"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, cpath, wpath, unix, thread>::pledge()));
 
     auto app = GUI::Application::construct(0, nullptr);
     app->set_quit_when_last_window_deleted(false);

--- a/Userland/Services/ImageDecoder/main.cpp
+++ b/Userland/Services/ImageDecoder/main.cpp
@@ -13,11 +13,12 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
-    TRY(Core::System::pledge("stdio recvfd sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, unix>::pledge()));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<ImageDecoder::ConnectionFromClient>());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd>::pledge()));
     return event_loop.exec();
 }

--- a/Userland/Services/InspectorServer/main.cpp
+++ b/Userland/Services/InspectorServer/main.cpp
@@ -17,7 +17,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
 
-    TRY(Core::System::pledge("stdio unix accept"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, unix, Kernel::Pledge::accept>::pledge()));
 
     auto server = TRY(IPC::MultiServer<InspectorServer::ConnectionFromClient>::try_create("/tmp/portal/inspector"));
 

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -16,7 +16,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio proc exec rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, proc, exec, rpath>::pledge()));
     auto keyboard_settings_config = TRY(Core::ConfigFile::open_for_app("KeyboardSettings"));
 
     TRY(Core::System::unveil("/bin/keymap", "x"));

--- a/Userland/Services/LaunchServer/main.cpp
+++ b/Userland/Services/LaunchServer/main.cpp
@@ -21,7 +21,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
     launcher.load_handlers();
     launcher.load_config(TRY(Core::ConfigFile::open_for_app("LaunchServer")));
 
-    TRY(Core::System::pledge("stdio accept rpath proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::accept, rpath, proc, exec>::pledge()));
 
     return event_loop.exec();
 }

--- a/Userland/Services/LoginServer/main.cpp
+++ b/Userland/Services/LoginServer/main.cpp
@@ -56,7 +56,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     auto app = GUI::Application::construct(arguments);
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath exec proc id"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, rpath, exec, proc, id>::pledge()));
     TRY(Core::System::unveil("/home", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/shadow", "r"));

--- a/Userland/Services/LookupServer/main.cpp
+++ b/Userland/Services/LookupServer/main.cpp
@@ -12,11 +12,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio accept unix inet rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::accept, unix, inet, rpath>::pledge()));
     Core::EventLoop event_loop;
     auto server = TRY(LookupServer::LookupServer::try_create());
 
-    TRY(Core::System::pledge("stdio accept inet rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::accept, inet, rpath>::pledge()));
     TRY(Core::System::unveil("/proc/net/adapters", "r"));
     TRY(Core::System::unveil("/etc/hosts", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Services/NotificationServer/main.cpp
+++ b/Userland/Services/NotificationServer/main.cpp
@@ -12,14 +12,15 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd accept rpath unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, Kernel::Pledge::accept, rpath, unix>::pledge()));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     auto server = TRY(IPC::MultiServer<NotificationServer::ConnectionFromClient>::try_create());
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    TRY(Core::System::pledge("stdio recvfd sendfd accept rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, Kernel::Pledge::accept, rpath>::pledge()));
 
     return app->exec();
 }

--- a/Userland/Services/RequestServer/main.cpp
+++ b/Userland/Services/RequestServer/main.cpp
@@ -19,17 +19,18 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
+    using enum Kernel::Pledge;
     if constexpr (TLS_SSL_KEYLOG_DEBUG)
-        TRY(Core::System::pledge("stdio inet accept unix cpath wpath rpath sendfd recvfd sigaction"));
+        TRY((Core::System::Promise<stdio, inet, Kernel::Pledge::accept, unix, cpath, wpath, rpath, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd, Kernel::Pledge::sigaction>::pledge()));
     else
-        TRY(Core::System::pledge("stdio inet accept unix rpath sendfd recvfd sigaction"));
+        TRY((Core::System::Promise<stdio, inet, Kernel::Pledge::accept, unix, rpath, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd, Kernel::Pledge::sigaction>::pledge()));
 
     signal(SIGINFO, [](int) { RequestServer::ConnectionCache::dump_jobs(); });
 
     if constexpr (TLS_SSL_KEYLOG_DEBUG)
-        TRY(Core::System::pledge("stdio inet accept unix cpath wpath rpath sendfd recvfd"));
+        TRY((Core::System::Promise<stdio, inet, Kernel::Pledge::accept, unix, cpath, wpath, rpath, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd>::pledge()));
     else
-        TRY(Core::System::pledge("stdio inet accept unix rpath sendfd recvfd"));
+        TRY((Core::System::Promise<stdio, inet, Kernel::Pledge::accept, unix, rpath, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd>::pledge()));
 
     // Ensure the certificates are read out here.
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();

--- a/Userland/Services/SQLServer/main.cpp
+++ b/Userland/Services/SQLServer/main.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio accept unix rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::accept, unix, rpath, wpath, cpath>::pledge()));
 
     if (mkdir("/home/anon/sql", 0700) < 0 && errno != EEXIST) {
         perror("mkdir");

--- a/Userland/Services/SpiceAgent/main.cpp
+++ b/Userland/Services/SpiceAgent/main.cpp
@@ -16,7 +16,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop loop;
 
-    TRY(Core::System::pledge("unix rpath wpath stdio sendfd recvfd", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<unix, rpath, wpath, stdio, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd>::pledge()));
     TRY(Core::System::unveil(SPICE_DEVICE, "rw"));
     TRY(Core::System::unveil("/tmp/portal/clipboard", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -478,7 +478,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         TRY(prepare_synthetic_filesystems());
     }
 
-    TRY(Core::System::pledge("stdio proc exec tty accept unix rpath wpath cpath chown fattr id sigaction"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, proc, exec, tty, Kernel::Pledge::accept, unix, rpath, wpath, cpath, Kernel::Pledge::chown, fattr, id, Kernel::Pledge::sigaction>::pledge()));
 
     if (!user) {
         TRY(create_tmp_coredump_directory());

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -37,7 +37,8 @@ static ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu();
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath unix sigaction"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec, rpath, unix, Kernel::Pledge::sigaction>::pledge()));
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("Taskbar");
     Config::monitor_domain("Taskbar");
@@ -47,12 +48,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             ;
     });
 
-    TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath unix"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec, rpath, unix>::pledge()));
 
     GUI::ConnectionToWindowMangerServer::the();
     Desktop::Launcher::ensure_connection();
 
-    TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, proc, exec, rpath>::pledge()));
 
     auto menu = TRY(build_system_menu());
     menu->realize_menu_if_needed();

--- a/Userland/Services/WebContent/main.cpp
+++ b/Userland/Services/WebContent/main.cpp
@@ -14,7 +14,8 @@
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     Core::EventLoop event_loop;
-    TRY(Core::System::pledge("stdio recvfd sendfd accept unix rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, Kernel::Pledge::sendfd, Kernel::Pledge::accept, unix, rpath>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil("/tmp/portal/request", "rw"));

--- a/Userland/Services/WebServer/main.cpp
+++ b/Userland/Services/WebServer/main.cpp
@@ -60,7 +60,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TRY(Core::System::pledge("stdio accept rpath inet unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::accept, rpath, inet, unix>::pledge()));
 
     WebServer::Configuration configuration(real_root_path);
 
@@ -99,6 +100,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil(real_root_path.characters(), "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
-    TRY(Core::System::pledge("stdio accept rpath"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::accept, rpath>::pledge()));
     return loop.exec();
 }

--- a/Userland/Services/WebSocket/main.cpp
+++ b/Userland/Services/WebSocket/main.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio inet unix rpath sendfd recvfd"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, inet, unix, rpath, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd>::pledge()));
 
     // Ensure the certificates are read out here.
     [[maybe_unused]] auto& certs = DefaultRootCACertificates::the();

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -21,7 +21,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio video thread sendfd recvfd accept rpath wpath cpath unix proc sigaction exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, video, thread, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd, Kernel::Pledge::accept, rpath, wpath, cpath, unix, proc, Kernel::Pledge::sigaction, exec>::pledge()));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp", "cw"));
     TRY(Core::System::unveil("/etc/WindowServer.ini", "rwc"));
@@ -34,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     act.sa_flags = SA_NOCLDWAIT;
     act.sa_handler = SIG_IGN;
     TRY(Core::System::sigaction(SIGCHLD, &act, nullptr));
-    TRY(Core::System::pledge("stdio video thread sendfd recvfd accept rpath wpath cpath unix proc exec"));
+    TRY((Core::System::Promise<stdio, video, thread, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd, Kernel::Pledge::accept, rpath, wpath, cpath, unix, proc, exec>::pledge()));
 
     auto wm_config = TRY(Core::ConfigFile::open("/etc/WindowServer.ini"));
     auto theme_name = wm_config->read_entry("Theme", "Name", "Default");
@@ -52,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
     WindowServer::EventLoop loop;
 
-    TRY(Core::System::pledge("stdio video thread sendfd recvfd accept rpath wpath cpath proc exec"));
+    TRY((Core::System::Promise<stdio, video, thread, Kernel::Pledge::sendfd, Kernel::Pledge::recvfd, Kernel::Pledge::accept, rpath, wpath, cpath, proc, exec>::pledge()));
 
     // First check which screens are explicitly configured
     {

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -42,7 +42,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     });
 
 #ifdef __serenity__
-    TRY(Core::System::pledge("stdio rpath wpath cpath proc exec tty sigaction unix fattr", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, proc, exec, tty, Kernel::Pledge::sigaction, unix, fattr>::pledge()));
 #endif
 
     RefPtr<::Shell::Shell> shell;

--- a/Userland/Utilities/abench.cpp
+++ b/Userland/Utilities/abench.cpp
@@ -30,7 +30,8 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     TRY(Core::System::unveil(Core::File::absolute_path(path), "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    TRY(Core::System::pledge("stdio recvfd rpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::recvfd, rpath>::pledge()));
 
     auto maybe_loader = Audio::Loader::create(path);
     if (maybe_loader.is_error()) {

--- a/Userland/Utilities/adjtime.cpp
+++ b/Userland/Utilities/adjtime.cpp
@@ -14,7 +14,8 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
 #ifdef __serenity__
-    TRY(Core::System::pledge("stdio settime"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, settime>::pledge()));
 #endif
 
     Core::ArgsParser args_parser;
@@ -35,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
 #ifdef __serenity__
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 #endif
 
     timeval remaining_delta_timeval;

--- a/Userland/Utilities/aplay.cpp
+++ b/Userland/Utilities/aplay.cpp
@@ -21,7 +21,8 @@ constexpr size_t LOAD_CHUNK_SIZE = 128 * KiB;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath sendfd unix"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::sendfd, unix>::pledge()));
 
     const char* path = nullptr;
     bool should_loop = false;
@@ -47,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
     auto loader = maybe_loader.release_value();
 
-    TRY(Core::System::pledge("stdio sendfd"));
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::sendfd>::pledge()));
 
     outln("\033[34;1m Playing\033[0m: {}", path);
     outln("\033[34;1m  Format\033[0m: {} {} Hz, {}-bit, {}",

--- a/Userland/Utilities/arp.cpp
+++ b/Userland/Utilities/arp.cpp
@@ -25,7 +25,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, tty>::pledge()));
     TRY(Core::System::unveil("/proc/net/arp", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/asctl.cpp
+++ b/Userland/Utilities/asctl.cpp
@@ -43,7 +43,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     TRY(Core::System::unveil(nullptr, nullptr));
-    TRY(Core::System::pledge("stdio rpath wpath recvfd", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, Kernel::Pledge::recvfd>::pledge()));
 
     if (command.equals_ignoring_case("get") || command == "g") {
         // Get variables

--- a/Userland/Utilities/base64.cpp
+++ b/Userland/Utilities/base64.cpp
@@ -17,7 +17,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     bool decode = false;
     const char* filepath = nullptr;
@@ -43,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         buffer = file->read_all();
     }
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     if (decode) {
         auto decoded = TRY(decode_base64(StringView(buffer)));

--- a/Userland/Utilities/basename.cpp
+++ b/Userland/Utilities/basename.cpp
@@ -11,7 +11,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     StringView path;
     StringView suffix;

--- a/Userland/Utilities/blockdev.cpp
+++ b/Userland/Utilities/blockdev.cpp
@@ -25,7 +25,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::unveil("/dev", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     const char* device = nullptr;
 

--- a/Userland/Utilities/bt.cpp
+++ b/Userland/Utilities/bt.cpp
@@ -17,7 +17,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     auto hostname = TRY(Core::System::gethostname());
 
     Core::ArgsParser args_parser;

--- a/Userland/Utilities/cal.cpp
+++ b/Userland/Utilities/cal.cpp
@@ -90,7 +90,8 @@ static void clean_buffers()
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/etc/timezone", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/cat.cpp
+++ b/Userland/Utilities/cat.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Vector<StringView> paths;
 
@@ -43,7 +44,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     Array<u8, 32768> buffer;
     for (auto& fd : fds) {

--- a/Userland/Utilities/checksum.cpp
+++ b/Userland/Utilities/checksum.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     auto program_name = LexicalPath::basename(arguments.strings[0]);
     auto hash_kind = Crypto::Hash::HashKind::None;

--- a/Userland/Utilities/chgrp.cpp
+++ b/Userland/Utilities/chgrp.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath chown", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::chown>::pledge()));
 
     const char* gid_arg = nullptr;
     const char* path = nullptr;

--- a/Userland/Utilities/chmod.cpp
+++ b/Userland/Utilities/chmod.cpp
@@ -20,7 +20,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath fattr"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, fattr>::pledge()));
 
     if (arguments.strings.size() < 3) {
         warnln("usage: chmod <octal-mode> <path...>");

--- a/Userland/Utilities/chown.cpp
+++ b/Userland/Utilities/chown.cpp
@@ -18,7 +18,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath chown", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, Kernel::Pledge::chown>::pledge()));
 
     String spec;
     String path;

--- a/Userland/Utilities/clear.cpp
+++ b/Userland/Utilities/clear.cpp
@@ -10,7 +10,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio>::pledge()));
     printf("\033[3J\033[H\033[2J");
     fflush(stdout);
     return 0;

--- a/Userland/Utilities/comm.cpp
+++ b/Userland/Utilities/comm.cpp
@@ -18,7 +18,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     String file1_path, file2_path;
     bool suppress_col1 { false };

--- a/Userland/Utilities/cp.cpp
+++ b/Userland/Utilities/cp.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath fattr chown"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, fattr, Kernel::Pledge::chown>::pledge()));
 
     bool link = false;
     bool preserve = false;
@@ -36,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (preserve) {
         umask(0);
     } else {
-        TRY(Core::System::pledge("stdio rpath wpath cpath fattr"));
+        TRY((Core::System::Promise<stdio, rpath, wpath, cpath, fattr>::pledge()));
     }
 
     bool destination_is_existing_dir = Core::File::is_directory(destination);

--- a/Userland/Utilities/date.cpp
+++ b/Userland/Utilities/date.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio settime rpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, settime, rpath>::pledge()));
 
     bool print_unix_date = false;
     bool print_iso_8601 = false;

--- a/Userland/Utilities/ddate.cpp
+++ b/Userland/Utilities/ddate.cpp
@@ -102,7 +102,8 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     auto date = Core::DateTime::now();
     outln("Today is {}", DiscordianDate(date).to_string());

--- a/Userland/Utilities/diff.cpp
+++ b/Userland/Utilities/diff.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Core::ArgsParser parser;
     String filename1;

--- a/Userland/Utilities/dmesg.cpp
+++ b/Userland/Utilities/dmesg.cpp
@@ -10,7 +10,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/proc/dmesg", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/echo.cpp
+++ b/Userland/Utilities/echo.cpp
@@ -99,7 +99,8 @@ static String interpret_backslash_escapes(StringView string, bool& no_trailing_n
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     Vector<const char*> text;
     bool no_trailing_newline = false;

--- a/Userland/Utilities/env.cpp
+++ b/Userland/Utilities/env.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, exec>::pledge()));
 
     bool ignore_env = false;
     const char* split_string = nullptr;

--- a/Userland/Utilities/expr.cpp
+++ b/Userland/Utilities/expr.cpp
@@ -575,7 +575,7 @@ NonnullOwnPtr<Expression> Expression::parse(Queue<StringView>& args, Precedence 
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio"sv));
+    TRY((Core::System::Promise<Kernel::Pledge::stdio>::pledge()));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     if ((arguments.strings.size() == 2 && "--help"sv == arguments.strings[1]) || arguments.strings.size() == 1)

--- a/Userland/Utilities/fdtdump.cpp
+++ b/Userland/Utilities/fdtdump.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     String filename;
 

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -139,7 +139,8 @@ static Optional<String> get_description_from_mime_type(const String& mime, const
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Vector<const char*> paths;
     bool flag_mime_only = false;

--- a/Userland/Utilities/fortune.cpp
+++ b/Userland/Utilities/fortune.cpp
@@ -73,7 +73,8 @@ static Vector<Quote> parse_all(const JsonArray& array)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     const char* path = "/res/fortunes.json";
 

--- a/Userland/Utilities/functrace.cpp
+++ b/Userland/Utilities/functrace.cpp
@@ -98,7 +98,8 @@ static NonnullOwnPtr<HashMap<FlatPtr, X86::Instruction>> instrument_code()
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio proc exec rpath sigaction ptrace"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, proc, exec, rpath, Kernel::Pledge::sigaction, Kernel::Pledge::ptrace>::pledge()));
 
     if (isatty(STDOUT_FILENO))
         g_should_output_color = true;

--- a/Userland/Utilities/gml-format.cpp
+++ b/Userland/Utilities/gml-format.cpp
@@ -49,7 +49,8 @@ ErrorOr<bool> format_file(StringView path, bool inplace)
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
 #ifdef __serenity__
-    TRY(Core::System::pledge("stdio rpath wpath cpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath>::pledge()));
 #endif
 
     bool inplace = false;
@@ -63,7 +64,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
 #ifdef __serenity__
     if (!inplace)
-        TRY(Core::System::pledge("stdio rpath", nullptr));
+        TRY((Core::System::Promise<stdio, rpath>::pledge()));
 #endif
 
     if (files.is_empty())

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -34,7 +34,8 @@ void fail(StringView format, Ts... args)
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
-    TRY(Core::System::pledge("stdio rpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Vector<const char*> files;
 

--- a/Userland/Utilities/gron.cpp
+++ b/Userland/Utilities/gron.cpp
@@ -27,12 +27,13 @@ static StringView color_off = ""sv;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, tty>::pledge()));
 
     if (isatty(STDOUT_FILENO))
         use_color = true;
 
-    TRY(Core::System::pledge("stdio rpath"));
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Print each value in a JSON file with its fully expanded key.");
@@ -48,7 +49,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     else
         file = TRY(Core::File::open(path, Core::OpenMode::ReadOnly));
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     auto file_contents = file->read_all();
     auto json = TRY(JsonValue::from_string(file_contents));

--- a/Userland/Utilities/groupadd.cpp
+++ b/Userland/Utilities/groupadd.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio wpath rpath cpath chown"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, wpath, rpath, cpath, Kernel::Pledge::chown>::pledge()));
 
     gid_t gid = 0;
     StringView group_name;

--- a/Userland/Utilities/groupdel.cpp
+++ b/Userland/Utilities/groupdel.cpp
@@ -17,7 +17,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio wpath rpath cpath fattr proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, wpath, rpath, cpath, fattr, proc, exec>::pledge()));
     TRY(Core::System::unveil("/etc/", "rwc"));
     TRY(Core::System::unveil("/bin/rm", "x"));
 

--- a/Userland/Utilities/groups.cpp
+++ b/Userland/Utilities/groups.cpp
@@ -33,7 +33,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/group", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    TRY(Core::System::pledge("stdio rpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Vector<const char*> usernames;
 

--- a/Userland/Utilities/head.cpp
+++ b/Userland/Utilities/head.cpp
@@ -18,7 +18,8 @@ int head(const String& filename, bool print_filename, ssize_t line_count, ssize_
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
-    TRY(Core::System::pledge("stdio rpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     int line_count = -1;
     int byte_count = -1;

--- a/Userland/Utilities/host.cpp
+++ b/Userland/Utilities/host.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
-    TRY(Core::System::pledge("stdio unix", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, unix>::pledge()));
 
     const char* name_or_ip = nullptr;
     Core::ArgsParser args_parser;

--- a/Userland/Utilities/id.cpp
+++ b/Userland/Utilities/id.cpp
@@ -28,7 +28,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/group", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Core::ArgsParser args_parser;
     args_parser.add_option(flag_print_uid, "Print UID", nullptr, 'u');

--- a/Userland/Utilities/ini.cpp
+++ b/Userland/Utilities/ini.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath>::pledge()));
 
     const char* path = nullptr;
     const char* group = nullptr;

--- a/Userland/Utilities/install.cpp
+++ b/Userland/Utilities/install.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath fattr"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, fattr>::pledge()));
 
     bool create_leading_dest_components = false;
     StringView source;

--- a/Userland/Utilities/jp.cpp
+++ b/Userland/Utilities/jp.cpp
@@ -24,7 +24,8 @@ static void print_indent(int indent, int spaces_per_indent)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     StringView path;
     int spaces_in_indent = 4;
@@ -42,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     else
         file = TRY(Core::File::open(path, Core::OpenMode::ReadOnly));
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     auto file_contents = file->read_all();
     auto json = TRY(JsonValue::from_string(file_contents));

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1368,7 +1368,8 @@ private:
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
 #ifdef __serenity__
-    TRY(Core::System::pledge("stdio rpath wpath cpath tty sigaction"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, tty, Kernel::Pledge::sigaction>::pledge()));
 #endif
 
     bool gc_on_every_allocation = false;

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -34,7 +34,8 @@ int set_keymap(String const& keymap)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio setkeymap getkeymap rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, setkeymap, getkeymap, rpath, wpath, cpath>::pledge()));
     TRY(Core::System::unveil("/res/keymaps", "r"));
     TRY(Core::System::unveil("/etc/Keyboard.ini", "rwc"));
 

--- a/Userland/Utilities/kill.cpp
+++ b/Userland/Utilities/kill.cpp
@@ -22,8 +22,8 @@ static void print_usage_and_exit()
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-
-    TRY(Core::System::pledge("stdio proc"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, proc>::pledge()));
 
     int argc = arguments.argc;
     auto strings = arguments.strings;

--- a/Userland/Utilities/less.cpp
+++ b/Userland/Utilities/less.cpp
@@ -524,7 +524,8 @@ static void cat_file(FILE* file)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty sigaction", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, tty, Kernel::Pledge::sigaction>::pledge()));
 
     char const* filename = "-";
     char const* prompt = "?f%f :.(line %l)?e (END):.";
@@ -557,7 +558,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         g_resized = true;
     });
 
-    TRY(Core::System::pledge("stdio tty", nullptr));
+    TRY((Core::System::Promise<stdio, tty>::pledge()));
 
     if (emulate_more) {
         // Configure options that match more's behavior

--- a/Userland/Utilities/ln.cpp
+++ b/Userland/Utilities/ln.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments argmuments)
 {
-    TRY(Core::System::pledge("stdio cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, cpath>::pledge()));
 
     bool force = false;
     bool symbolic = false;

--- a/Userland/Utilities/logout.cpp
+++ b/Userland/Utilities/logout.cpp
@@ -20,7 +20,8 @@ static Core::ProcessStatistics const& get_proc(Core::AllProcessesStatistics cons
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio proc rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, proc, rpath>::pledge()));
     TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Utilities/ls.cpp
+++ b/Userland/Utilities/ls.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "Kernel/API/Pledge.h"
+#include "LibCore/System/Promise.h"
 #include <AK/Assertions.h>
 #include <AK/HashMap.h>
 #include <AK/NumberFormat.h>
@@ -77,7 +79,8 @@ static bool is_a_tty = false;
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, tty>::pledge()));
 
     struct winsize ws;
     int rc = ioctl(STDOUT_FILENO, TIOCGWINSZ, &ws);
@@ -94,10 +97,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         flag_colorize = true;
     }
 
-    if (pledge("stdio rpath", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Vector<StringView> paths;
 

--- a/Userland/Utilities/lsirq.cpp
+++ b/Userland/Utilities/lsirq.cpp
@@ -12,13 +12,14 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/proc/interrupts", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto proc_interrupts = TRY(Core::File::open("/proc/interrupts", Core::OpenMode::ReadOnly));
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     outln("      CPU0");
     auto file_contents = proc_interrupts->read_all();

--- a/Userland/Utilities/lsof.cpp
+++ b/Userland/Utilities/lsof.cpp
@@ -101,7 +101,8 @@ static void display_entry(const OpenFile& file, const Core::ProcessStatistics& s
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath proc"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, proc>::pledge()));
 
     TRY(Core::System::unveil("/proc", "r"));
     // needed by ProcessStatisticsReader::get_all()

--- a/Userland/Utilities/lspci.cpp
+++ b/Userland/Utilities/lspci.cpp
@@ -39,7 +39,8 @@ static u32 convert_sysfs_value_to_uint(String const& value)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/res/pci.ids", "r"));
     TRY(Core::System::unveil("/sys/bus/pci", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
@@ -67,7 +68,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TRY(Core::System::pledge("stdio rpath"));
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     while (di.has_next()) {
         auto dir = di.next_path();

--- a/Userland/Utilities/lsusb.cpp
+++ b/Userland/Utilities/lsusb.cpp
@@ -20,7 +20,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/sys/bus/usb", "r"));
     TRY(Core::System::unveil("/res/usb.ids", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Utilities/man.cpp
+++ b/Userland/Utilities/man.cpp
@@ -54,7 +54,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (view_width == 0)
         view_width = 80;
 
-    TRY(Core::System::pledge("stdio rpath exec proc"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, exec, proc>::pledge()));
     TRY(Core::System::unveil("/usr/share/man", "r"));
     TRY(Core::System::unveil("/bin", "x"));
     TRY(Core::System::unveil(nullptr, nullptr));
@@ -110,7 +111,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto file = TRY(Core::File::open(filename, Core::OpenMode::ReadOnly));
 
-    TRY(Core::System::pledge("stdio proc"));
+    TRY((Core::System::Promise<stdio, proc>::pledge()));
 
     dbgln("Loading man page from {}", file->filename());
     auto buffer = file->read_all();

--- a/Userland/Utilities/md.cpp
+++ b/Userland/Utilities/md.cpp
@@ -15,7 +15,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, tty>::pledge()));
 
     const char* filename = nullptr;
     bool html = false;
@@ -53,7 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     auto buffer = file->read_all();
     dbgln("Read size {}", buffer.size());

--- a/Userland/Utilities/mkdir.cpp
+++ b/Userland/Utilities/mkdir.cpp
@@ -18,7 +18,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio cpath rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, cpath, rpath>::pledge()));
 
     bool create_parents = false;
     String mode_string;

--- a/Userland/Utilities/mkfifo.cpp
+++ b/Userland/Utilities/mkfifo.cpp
@@ -11,7 +11,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio dpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, dpath>::pledge()));
 
     mode_t mode = 0666;
     Vector<StringView> paths;

--- a/Userland/Utilities/mknod.cpp
+++ b/Userland/Utilities/mknod.cpp
@@ -19,7 +19,8 @@ static int usage()
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio dpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, dpath>::pledge()));
 
     // FIXME: Add some kind of option for specifying the file permissions.
     if (arguments.strings.size() < 3)

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -54,7 +54,8 @@ static ErrorOr<String> make_temp(String const& pattern, bool directory, bool dry
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath>::pledge()));
 
     StringView file_template;
     bool create_directory = false;

--- a/Userland/Utilities/mv.cpp
+++ b/Userland/Utilities/mv.cpp
@@ -17,7 +17,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath fattr"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath, fattr>::pledge()));
 
     // NOTE: The "force" option is a dummy for now, it's just here to silence scripts that use "mv -f"
     //       In the future, it might be used to cancel out an "-i" interactive option.

--- a/Userland/Utilities/netstat.cpp
+++ b/Userland/Utilities/netstat.cpp
@@ -18,7 +18,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/proc/net", "r"));
     TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));

--- a/Userland/Utilities/nproc.cpp
+++ b/Userland/Utilities/nproc.cpp
@@ -11,7 +11,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     auto file = TRY(Core::File::open("/proc/cpuinfo", Core::OpenMode::ReadOnly));
 
     auto buffer = file->read_all();

--- a/Userland/Utilities/passwd.cpp
+++ b/Userland/Utilities/passwd.cpp
@@ -23,7 +23,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::setegid(0));
 
-    TRY(Core::System::pledge("stdio wpath rpath cpath fattr tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, wpath, rpath, cpath, fattr, tty>::pledge()));
     TRY(Core::System::unveil("/etc", "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
@@ -90,7 +91,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         target_account.set_password(new_password);
     }
 
-    TRY(Core::System::pledge("stdio wpath rpath cpath fattr"));
+    TRY((Core::System::Promise<stdio, wpath, rpath, cpath, fattr>::pledge()));
 
     TRY(target_account.sync());
 

--- a/Userland/Utilities/pathchk.cpp
+++ b/Userland/Utilities/pathchk.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     bool fail = false;
     static bool flag_most_posix = false;
     static bool flag_portability = false;

--- a/Userland/Utilities/pgrep.cpp
+++ b/Userland/Utilities/pgrep.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Utilities/pidof.cpp
+++ b/Userland/Utilities/pidof.cpp
@@ -42,7 +42,8 @@ static ErrorOr<int> pid_of(const String& process_name, bool single_shot, bool om
 
 ErrorOr<int> serenity_main(Main::Arguments args)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Utilities/ping.cpp
+++ b/Userland/Utilities/ping.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "Kernel/API/Pledge.h"
+#include "LibCore/System/Promise.h"
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
 #include <LibCore/ArgsParser.h>
@@ -59,7 +61,8 @@ static void closing_statistics()
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio id inet unix sigaction"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, id, inet, unix, Kernel::Pledge::sigaction>::pledge()));
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(host, "Host to ping", "host");
@@ -88,10 +91,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    if (pledge("stdio inet unix sigaction", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    TRY((Core::System::Promise<stdio, inet, unix, sigaction>::pledge()));
 
     struct timeval timeout {
         1, 0
@@ -109,10 +109,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    if (pledge("stdio inet sigaction", nullptr) < 0) {
-        perror("pledge");
-        return 1;
-    }
+    TRY((Core::System::Promise<stdio, inet, Kernel::Pledge::sigaction>::pledge()));
 
     pid_t pid = getpid();
 

--- a/Userland/Utilities/pls.cpp
+++ b/Userland/Utilities/pls.cpp
@@ -23,7 +23,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(command, "Command to run at elevated privilege level", "command");
     args_parser.parse(arguments);
 
-    TRY(Core::System::pledge("stdio rpath exec id tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, exec, id, tty>::pledge()));
 
     TRY(Core::System::seteuid(0));
 
@@ -39,12 +40,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     }
 
-    TRY(Core::System::pledge("stdio rpath exec id"));
+    TRY((Core::System::Promise<stdio, rpath, exec, id>::pledge()));
 
     TRY(Core::System::setgid(0));
     TRY(Core::System::setuid(as_user_uid));
 
-    TRY(Core::System::pledge("stdio rpath exec"));
+    TRY((Core::System::Promise<stdio, rpath, exec>::pledge()));
 
     Vector<char const*> exec_arguments;
     for (auto const& arg : command)

--- a/Userland/Utilities/pmap.cpp
+++ b/Userland/Utilities/pmap.cpp
@@ -14,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/proc", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/pmemdump.cpp
+++ b/Userland/Utilities/pmemdump.cpp
@@ -85,7 +85,8 @@ static void try_to_dump_with_read(int fd, u64 offset, u64 length)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     StringView arg_offset;
     StringView arg_length;

--- a/Userland/Utilities/ps.cpp
+++ b/Userland/Utilities/ps.cpp
@@ -13,10 +13,11 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, tty>::pledge()));
     String this_tty = ttyname(STDIN_FILENO);
 
-    TRY(Core::System::pledge("stdio rpath"));
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Utilities/pwd.cpp
+++ b/Userland/Utilities/pwd.cpp
@@ -11,7 +11,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("rpath stdio"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<rpath, stdio>::pledge()));
     outln(TRY(Core::System::getcwd()));
     return 0;
 }

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -7,6 +7,7 @@
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/StringView.h>
+#include <Kernel/API/Pledge.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>
@@ -226,7 +227,8 @@ static const char* object_relocation_type_to_string(ElfW(Word) type)
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio rpath", nullptr) < 0) {
+    using namespace Kernel::PledgeBits;
+    if (pledge((u8)Kernel::PledgeMode::Promises, stdio | rpath, 0) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Utilities/readlink.cpp
+++ b/Userland/Utilities/readlink.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/API/Pledge.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <stdio.h>
@@ -11,7 +12,8 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio rpath", nullptr) < 0) {
+    using namespace Kernel::PledgeBits;
+    if (pledge((u8)Kernel::PledgeMode::Both, stdio | rpath, 0) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Utilities/realpath.cpp
+++ b/Userland/Utilities/realpath.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     const char* path;
 

--- a/Userland/Utilities/rev.cpp
+++ b/Userland/Utilities/rev.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/API/Pledge.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
@@ -13,7 +14,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"sv));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Vector<StringView> paths;
     Core::ArgsParser args_parser;
@@ -48,7 +50,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     };
 
-    TRY(Core::System::pledge("stdio"sv));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     for (auto* stream : streams) {
         for (;;) {

--- a/Userland/Utilities/rm.cpp
+++ b/Userland/Utilities/rm.cpp
@@ -15,7 +15,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, cpath>::pledge()));
 
     bool recursive = false;
     bool force = false;

--- a/Userland/Utilities/rmdir.cpp
+++ b/Userland/Utilities/rmdir.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, cpath>::pledge()));
 
     Vector<const char*> paths;
 

--- a/Userland/Utilities/seq.cpp
+++ b/Userland/Utilities/seq.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Format.h>
 #include <AK/StdLibExtras.h>
+#include <Kernel/API/Pledge.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -42,7 +43,7 @@ static double get_double(const char* name, const char* d_string, int* number_of_
 
 int main(int argc, const char* argv[])
 {
-    if (pledge("stdio", nullptr) < 0) {
+    if (pledge((u8)Kernel::PledgeMode::Promises, Kernel::PledgeBits::stdio, 0) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Utilities/shuf.cpp
+++ b/Userland/Utilities/shuf.cpp
@@ -16,7 +16,8 @@
 
 ErrorOr<int> serenity_main([[maybe_unused]] Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio"sv));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     Vector<String> lines;
 

--- a/Userland/Utilities/sleep.cpp
+++ b/Userland/Utilities/sleep.cpp
@@ -34,7 +34,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     sa.sa_handler = handle_sigint;
     sigaction(SIGINT, &sa, nullptr);
 
-    TRY(Core::System::pledge("stdio sigaction", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, Kernel::Pledge::sigaction>::pledge()));
 
     double whole_seconds = static_cast<time_t>(secs);
     double fraction = secs - whole_seconds;

--- a/Userland/Utilities/sort.cpp
+++ b/Userland/Utilities/sort.cpp
@@ -17,7 +17,8 @@
 
 ErrorOr<int> serenity_main([[maybe_unused]] Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio"sv));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     Vector<String> lines;
 

--- a/Userland/Utilities/stat.cpp
+++ b/Userland/Utilities/stat.cpp
@@ -88,7 +88,8 @@ static ErrorOr<int> stat(StringView file, bool should_follow_links)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     bool should_follow_links = false;
     Vector<StringView> files;

--- a/Userland/Utilities/strace.cpp
+++ b/Userland/Utilities/strace.cpp
@@ -807,7 +807,8 @@ static void format_syscall(FormattedSyscallBuilder& builder, Syscall::Function s
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio wpath cpath proc exec ptrace sigaction"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, wpath, cpath, proc, exec, Kernel::Pledge::ptrace, Kernel::Pledge::sigaction>::pledge()));
 
     Vector<const char*> child_argv;
 
@@ -842,7 +843,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     parse_syscalls(exclude_syscalls_option, exclude_syscalls);
     parse_syscalls(include_syscalls_option, include_syscalls);
 
-    TRY(Core::System::pledge("stdio proc exec ptrace sigaction"));
+    TRY((Core::System::Promise<stdio, proc, exec, Kernel::Pledge::ptrace, Kernel::Pledge::sigaction>::pledge()));
 
     int status;
     if (g_pid == -1) {

--- a/Userland/Utilities/stty.cpp
+++ b/Userland/Utilities/stty.cpp
@@ -532,7 +532,8 @@ Result<void, int> apply_modes(size_t parameter_count, char** raw_parameters, ter
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio tty rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, tty, rpath>::pledge()));
     TRY(Core::System::unveil("/dev", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/tac.cpp
+++ b/Userland/Utilities/tac.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Vector<StringView> paths;
 
@@ -53,7 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
     };
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     for (auto* stream : streams) {
         Vector<String> lines;

--- a/Userland/Utilities/tail.cpp
+++ b/Userland/Utilities/tail.cpp
@@ -74,7 +74,8 @@ static off_t find_seek_pos(Core::File& file, int wanted_lines)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     bool follow = false;
     int line_count = DEFAULT_LINE_COUNT;
@@ -88,7 +89,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     auto f = TRY(Core::File::open(file, Core::OpenMode::ReadOnly));
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     auto pos = find_seek_pos(*f, line_count);
     return tail_from_pos(*f, pos, follow);

--- a/Userland/Utilities/telws.cpp
+++ b/Userland/Utilities/telws.cpp
@@ -7,6 +7,7 @@
 #include <AK/Base64.h>
 #include <AK/Format.h>
 #include <AK/URL.h>
+#include <Kernel/API/Pledge.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
@@ -17,7 +18,8 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio unix inet accept rpath wpath cpath fattr tty sigaction", nullptr) < 0) {
+    using namespace Kernel::PledgeBits;
+    if (pledge((u8)Kernel::PledgeMode::Promises, stdio | unix | inet | Kernel::PledgeBits::accept | rpath | wpath | cpath | fattr | tty | sigaction, 0) < 0) {
         perror("pledge");
         return 1;
     }
@@ -76,7 +78,7 @@ int main(int argc, char** argv)
         Core::EventLoop::current().quit(0);
     };
 
-    if (pledge("stdio unix inet accept rpath wpath tty sigaction", nullptr) < 0) {
+    if (pledge((u8)Kernel::PledgeMode::Promises, stdio | unix | inet | Kernel::PledgeBits::accept | rpath | wpath | tty | sigaction, 0) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Utilities/test-imap.cpp
+++ b/Userland/Utilities/test-imap.cpp
@@ -4,16 +4,19 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/API/Pledge.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/File.h>
 #include <LibCore/GetPassword.h>
 #include <LibIMAP/Client.h>
 #include <LibMain/Main.h>
+#include <unistd.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    if (pledge("stdio inet tty rpath unix", nullptr) < 0) {
+    using namespace Kernel::PledgeBits;
+    if (pledge((u8)Kernel::PledgeMode::Promises, stdio | inet | tty | rpath | unix, 0) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Utilities/test.cpp
+++ b/Userland/Utilities/test.cpp
@@ -8,6 +8,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/OwnPtr.h>
+#include <Kernel/API/Pledge.h>
 #include <LibCore/File.h>
 #include <stdio.h>
 #include <sys/stat.h>
@@ -492,7 +493,8 @@ static OwnPtr<Condition> parse_complex_expression(char* argv[])
 
 int main(int argc, char* argv[])
 {
-    if (pledge("stdio rpath", nullptr) < 0) {
+    using namespace Kernel::PledgeBits;
+    if (pledge((u8)Kernel::PledgeMode::Promises, rpath | stdio, 0) < 0) {
         perror("pledge");
         return 126;
     }

--- a/Userland/Utilities/timezone.cpp
+++ b/Userland/Utilities/timezone.cpp
@@ -13,7 +13,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath>::pledge()));
     TRY(Core::System::unveil("/etc/timezone", "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/top.cpp
+++ b/Userland/Utilities/top.cpp
@@ -179,7 +179,8 @@ static void parse_args(Main::Arguments arguments, TopOption& top_option)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty sigaction"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, tty, Kernel::Pledge::sigaction>::pledge()));
     TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     unveil(nullptr, nullptr);
@@ -188,7 +189,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         g_window_size_changed = true;
     });
 
-    TRY(Core::System::pledge("stdio rpath tty"));
+    TRY((Core::System::Promise<stdio, rpath, tty>::pledge()));
     TopOption top_option;
     parse_args(arguments, top_option);
 

--- a/Userland/Utilities/touch.cpp
+++ b/Userland/Utilities/touch.cpp
@@ -32,7 +32,8 @@ static bool file_exists(const char* path)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath cpath fattr"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, cpath, fattr>::pledge()));
 
     Vector<const char*> paths;
 

--- a/Userland/Utilities/traceroute.cpp
+++ b/Userland/Utilities/traceroute.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Assertions.h>
 #include <AK/String.h>
+#include <Kernel/API/Pledge.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/ElapsedTimer.h>
 #include <arpa/inet.h>
@@ -21,7 +22,8 @@
 
 int main(int argc, char** argv)
 {
-    if (pledge("stdio id inet unix", nullptr) < 0) {
+    using namespace Kernel::PledgeBits;
+    if (pledge((u8)Kernel::PledgeMode::Promises, stdio | id | inet | unix, 0) < 0) {
         perror("pledge");
         return 1;
     }
@@ -70,7 +72,7 @@ int main(int argc, char** argv)
         return 1;
     }
 
-    if (pledge("stdio inet unix", nullptr) < 0) {
+    if (pledge((u8)Kernel::PledgeMode::Promises, stdio | inet | unix, 0) < 0) {
         perror("pledge");
         return 1;
     }

--- a/Userland/Utilities/tree.cpp
+++ b/Userland/Utilities/tree.cpp
@@ -104,7 +104,8 @@ static void print_directory_tree(const String& root_path, int depth, const Strin
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, tty>::pledge()));
 
     Vector<const char*> directories;
 

--- a/Userland/Utilities/truncate.cpp
+++ b/Userland/Utilities/truncate.cpp
@@ -20,7 +20,8 @@ enum TruncateOperation {
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath>::pledge()));
 
     const char* resize = nullptr;
     const char* reference = nullptr;

--- a/Userland/Utilities/uname.cpp
+++ b/Userland/Utilities/uname.cpp
@@ -15,7 +15,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     bool flag_system = false;
     bool flag_node = false;

--- a/Userland/Utilities/uniq.cpp
+++ b/Userland/Utilities/uniq.cpp
@@ -39,7 +39,8 @@ static FILE* get_stream(const char* filepath, const char* perms)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath>::pledge()));
 
     const char* inpath = nullptr;
     const char* outpath = nullptr;

--- a/Userland/Utilities/uptime.cpp
+++ b/Userland/Utilities/uptime.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     FILE* fp = fopen("/proc/uptime", "r");
     if (!fp) {
@@ -20,7 +21,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
         return 1;
     }
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     char buffer[BUFSIZ];
     auto* p = fgets(buffer, sizeof(buffer), fp);

--- a/Userland/Utilities/useradd.cpp
+++ b/Userland/Utilities/useradd.cpp
@@ -29,7 +29,8 @@ constexpr const char* DEFAULT_SHELL = "/bin/sh";
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio wpath rpath cpath chown"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, wpath, rpath, cpath, Kernel::Pledge::chown>::pledge()));
 
     const char* home_path = nullptr;
     int uid = 0;

--- a/Userland/Utilities/userdel.cpp
+++ b/Userland/Utilities/userdel.cpp
@@ -29,7 +29,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio wpath rpath cpath fattr proc exec"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, wpath, rpath, cpath, fattr, proc, exec>::pledge()));
     TRY(Core::System::unveil("/etc/", "rwc"));
     TRY(Core::System::unveil("/bin/rm", "x"));
 
@@ -53,7 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     if (remove_home) {
         TRY(Core::System::unveil(target_account.home_directory().characters(), "c"));
     } else {
-        TRY(Core::System::pledge("stdio wpath rpath cpath fattr"));
+        TRY((Core::System::Promise<stdio, wpath, rpath, cpath, fattr>::pledge()));
     }
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/usermod.cpp
+++ b/Userland/Utilities/usermod.cpp
@@ -23,7 +23,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::setegid(0));
 
-    TRY(Core::System::pledge("stdio wpath rpath cpath fattr tty"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, wpath, rpath, cpath, fattr, tty>::pledge()));
     TRY(Core::System::unveil("/etc", "rwc"));
 
     int uid = 0;
@@ -133,7 +134,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         target_account.set_gecos(gecos);
     }
 
-    TRY(Core::System::pledge("stdio wpath rpath cpath fattr"));
+    TRY((Core::System::Promise<stdio, wpath, rpath, cpath, fattr>::pledge()));
 
     TRY(target_account.sync());
 

--- a/Userland/Utilities/utmpupdate.cpp
+++ b/Userland/Utilities/utmpupdate.cpp
@@ -17,7 +17,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, wpath, cpath>::pledge()));
     TRY(Core::System::unveil("/var/run/utmp", "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/w.cpp
+++ b/Userland/Utilities/w.cpp
@@ -17,7 +17,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/dev", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));

--- a/Userland/Utilities/watch.cpp
+++ b/Userland/Utilities/watch.cpp
@@ -109,8 +109,9 @@ static int run_command(Vector<char const*> const& command)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    using enum Kernel::Pledge;
     TRY(Core::System::signal(SIGINT, handle_signal));
-    TRY(Core::System::pledge("stdio proc exec rpath", nullptr));
+    TRY((Core::System::Promise<stdio, proc, exec, rpath>::pledge()));
 
     Vector<String> files_to_watch;
     Vector<char const*> command;
@@ -184,7 +185,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
         }
     } else {
-        TRY(Core::System::pledge("stdio proc exec", nullptr));
+        TRY((Core::System::Promise<stdio, proc, exec>::pledge()));
 
         struct timeval interval;
         if (opt_interval <= 0) {

--- a/Userland/Utilities/wc.cpp
+++ b/Userland/Utilities/wc.cpp
@@ -88,7 +88,8 @@ static Count get_total_count(const Vector<Count>& counts)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     Vector<const char*> file_specifiers;
 
@@ -106,7 +107,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     for (const auto& file_specifier : file_specifiers)
         counts.append(get_count(file_specifier));
 
-    TRY(Core::System::pledge("stdio"));
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     if (file_specifiers.is_empty())
         counts.append(get_count("-"));

--- a/Userland/Utilities/which.cpp
+++ b/Userland/Utilities/which.cpp
@@ -12,7 +12,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
 
     const char* filename = nullptr;
 

--- a/Userland/Utilities/whoami.cpp
+++ b/Userland/Utilities/whoami.cpp
@@ -11,7 +11,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath>::pledge()));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Utilities/xargs.cpp
+++ b/Userland/Utilities/xargs.cpp
@@ -40,7 +40,8 @@ private:
 
 ErrorOr<int> serenity_main(Main::Arguments main_arguments)
 {
-    TRY(Core::System::pledge("stdio rpath proc exec", nullptr));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, proc, exec>::pledge()));
 
     const char* placeholder = nullptr;
     bool split_with_nulls = false;

--- a/Userland/Utilities/yes.cpp
+++ b/Userland/Utilities/yes.cpp
@@ -11,7 +11,8 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio>::pledge()));
 
     const char* string = "yes";
 

--- a/Userland/Utilities/zip.cpp
+++ b/Userland/Utilities/zip.cpp
@@ -28,7 +28,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(force, "Overwrite existing zip file", "force", 'f');
     args_parser.parse(arguments);
 
-    TRY(Core::System::pledge("stdio rpath wpath cpath"));
+    using enum Kernel::Pledge;
+    TRY((Core::System::Promise<stdio, rpath, wpath, cpath>::pledge()));
 
     auto cwd = TRY(Core::System::getcwd());
     TRY(Core::System::unveil(LexicalPath::absolute_path(cwd, zip_path), "wc"));


### PR DESCRIPTION
The pledge syscall has turned out to be a "great idea, mediocre execution" feature. We inherited the basic structure from OpenBSD, which has a string-based API where you specify the pledge sets space-separated:

```cpp
pledge("stdio rpath cpath dns unix", nullptr)
```

nullptr stands for "don't change these promises" (as there are two collections of promises).

This PR replaces that old design with a new one based on simple bitfields. Every pledge set, or promise, is a single bit in a number that gets passed into the syscall and there are symbolic constants for all promises in the Kernel API header (Kernel::PledgeBits).

```cpp
pledge(Kernel::PledgeMode::Promises, stdio | rpath | cpath | dns | unix, 0)
```

(This invocation would do the same as the above, though Serenity doesn't have the DNS promise.)

The third pledge argument, the now first one, specifies which promises to change, as 0 means "promise nothing", i.e. "drop all promises" (and other ideas like all 1's prevent you from pledging all promises). There, we use a bitfield as well to signal no change (0), promises (1), exec promises (2), or both (3). The pledge() manpage is updated to specify the new API.

Advantages of the new API:
* Security: We avoid having to copy strings from userland into the  Kernel, circumventing any vulnerabilities that copy_from_user might have.
* Speed: The syscall arguments are just three numbers instead of two possibly very long strings, which speeds up argument validation in the  Kernel.
* Convenience: The promise names are now proper constants and can be checked at compile-time, leading to early bug detection.

It's basically all positives :^)

In Core::System, this new template-based API is available (the constants here are in the Kernel::Pledge enum):

```cpp
Core::System::Promises<stdio, rpath, cpath, dns, unix>::pledge()
```

Fixes #11140