### PR TITLE
Tests+LibTest: Port to Core::Stream

### DIFF
--- a/Tests/LibCpp/test-cpp-parser.cpp
+++ b/Tests/LibCpp/test-cpp-parser.cpp
@@ -6,22 +6,21 @@
 
 #include <AK/LexicalPath.h>
 #include <LibCore/DirIterator.h>
-#include <LibCore/File.h>
+#include <LibCore/Stream.h>
 #include <LibCpp/Parser.h>
 #include <LibTest/TestCase.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <string.h>
 #include <unistd.h>
 
 constexpr char TESTS_ROOT_DIR[] = "/home/anon/cpp-tests/parser";
 
-static String read_all(const String& path)
+static String read_all(String const& path)
 {
-    auto result = Core::File::open(path, Core::OpenMode::ReadOnly);
-    VERIFY(!result.is_error());
-    auto content = result.value()->read_all();
-    return { reinterpret_cast<const char*>(content.data()), content.size() };
+    auto file = MUST(Core::Stream::File::open(path, Core::Stream::OpenMode::Read));
+    auto file_size = MUST(file->size());
+    auto content = MUST(ByteBuffer::create_uninitialized(file_size));
+    if (!file->read_or_error(content.bytes()))
+        VERIFY_NOT_REACHED();
+    return String { content.bytes() };
 }
 
 TEST_CASE(test_regression)

--- a/Tests/LibCpp/test-cpp-preprocessor.cpp
+++ b/Tests/LibCpp/test-cpp-preprocessor.cpp
@@ -6,22 +6,20 @@
 
 #include <AK/LexicalPath.h>
 #include <LibCore/DirIterator.h>
-#include <LibCore/File.h>
+#include <LibCore/Stream.h>
 #include <LibCpp/Parser.h>
 #include <LibTest/TestCase.h>
-#include <fcntl.h>
-#include <stdio.h>
-#include <string.h>
-#include <unistd.h>
 
 constexpr char TESTS_ROOT_DIR[] = "/home/anon/cpp-tests/preprocessor";
 
-static String read_all(const String& path)
+static String read_all(String const& path)
 {
-    auto result = Core::File::open(path, Core::OpenMode::ReadOnly);
-    VERIFY(!result.is_error());
-    auto content = result.value()->read_all();
-    return { reinterpret_cast<const char*>(content.data()), content.size() };
+    auto file = MUST(Core::Stream::File::open(path, Core::Stream::OpenMode::Read));
+    auto file_size = MUST(file->size());
+    auto content = MUST(ByteBuffer::create_uninitialized(file_size));
+    if (!file->read_or_error(content.bytes()))
+        VERIFY_NOT_REACHED();
+    return String { content.bytes() };
 }
 
 TEST_CASE(test_regression)

--- a/Tests/LibWeb/TestHTMLTokenizer.cpp
+++ b/Tests/LibWeb/TestHTMLTokenizer.cpp
@@ -6,7 +6,7 @@
 
 #include <LibTest/TestCase.h>
 
-#include <LibCore/File.h>
+#include <LibCore/Stream.h>
 #include <LibWeb/HTML/Parser/HTMLTokenizer.h>
 
 using Tokenizer = Web::HTML::HTMLTokenizer;
@@ -201,9 +201,11 @@ TEST_CASE(doctype)
 //       If that changes, or something is added to the test HTML, the hash needs to be adjusted.
 TEST_CASE(regression)
 {
-    auto file = Core::File::open("/usr/Tests/LibWeb/tokenizer-test.html", Core::OpenMode::ReadOnly);
-    VERIFY(!file.is_error());
-    auto file_contents = file.value()->read_all();
+    auto file = MUST(Core::Stream::File::open("/usr/Tests/LibWeb/tokenizer-test.html", Core::Stream::OpenMode::Read));
+    auto file_size = MUST(file->size());
+    auto content = MUST(ByteBuffer::create_uninitialized(file_size));
+    MUST(file->read(content.bytes()));
+    String file_contents { content.bytes() };
     auto tokens = run_tokenizer(file_contents);
     u32 hash = hash_tokens(tokens);
     EXPECT_EQ(hash, 710375345u);


### PR DESCRIPTION
As far as I can tell, this is all the tests ported from using Core::File to Core::Stream::File. (Except the IODevice tests of course!)

The test-wasm code is a bit awkward because using TRY on the stream functions returns an ErrorOr that's incompatible with the JS ones. Might be a better way to do that.