### PR TITLE
AK: Remove unused String[256] from JsonParser

### DIFF
--- a/AK/JsonParser.h
+++ b/AK/JsonParser.h
@@ -31,8 +31,6 @@ private:
     ErrorOr<JsonValue> parse_false();
     ErrorOr<JsonValue> parse_true();
     ErrorOr<JsonValue> parse_null();
-
-    String m_last_string_starting_with_character[256];
 };
 
 }


### PR DESCRIPTION
This shrinks the JsonParser class from 2072 bytes to 24. :^)