### PR TITLE
Toolchain: Make some types more consistent between GCC and Clang (and enable IFUNC)

### DIFF
--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -68,10 +68,10 @@ index 357b0bed0..8e96b74e5 100644
  
  case ${target} in
 +i[34567]86-*-serenity*)
-+    tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h glibc-stdint.h i386/i386elf.h serenity.h"
++    tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h glibc-stdint.h i386/i386elf.h serenity.h i386/serenity.h"
 +    ;;
 +x86_64-*-serenity*)
-+    tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h glibc-stdint.h i386/i386elf.h i386/x86-64.h serenity.h"
++    tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h glibc-stdint.h i386/i386elf.h i386/x86-64.h serenity.h i386/serenity.h"
 +    ;;
 +arm-*-serenity*)
 +    tm_file="dbxelf.h elfos.h arm/elf.h arm/aout.h glibc-stdint.h arm/serenity-elf.h ${tm_file} serenity.h"
@@ -154,6 +154,19 @@ index 000000000..24b29c3da
 +
 +#undef PTRDIFF_TYPE
 +#define PTRDIFF_TYPE "long int"
+diff --git a/gcc/config/i386/serenity.h b/gcc/config/i386/serenity.h
+new file mode 100644
+index 000000000..dc2f5361e
+--- /dev/null
++++ b/gcc/config/i386/serenity.h
+@@ -0,0 +1,7 @@
++/* Ensure that we are using the SIZE_TYPE indicated by SysV */
++#undef SIZE_TYPE
++#define SIZE_TYPE    (TARGET_64BIT ? "long unsigned int" : "unsigned int")
++
++/* Ensure that ptrdiff_t matches the actual pointer size */
++#undef PTRDIFF_TYPE
++#define PTRDIFF_TYPE    (TARGET_64BIT ? "long int" : "int")
 diff --git a/gcc/config/host-darwin.c b/gcc/config/host-darwin.c
 index 14a01fe71..3f8e44288 100644
 --- a/gcc/config/host-darwin.c

--- a/Toolchain/Patches/gcc.patch
+++ b/Toolchain/Patches/gcc.patch
@@ -63,20 +63,24 @@ index 357b0bed0..8e96b74e5 100644
  *-*-darwin*)
    tmake_file="t-darwin "
    tm_file="${tm_file} darwin.h"
-@@ -1084,6 +1091,19 @@ case ${target} in
+@@ -1084,6 +1091,23 @@ case ${target} in
  esac
  
  case ${target} in
 +i[34567]86-*-serenity*)
++    default_gnu_indirect_function=yes
 +    tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h glibc-stdint.h i386/i386elf.h serenity.h i386/serenity.h"
 +    ;;
 +x86_64-*-serenity*)
++    default_gnu_indirect_function=yes
 +    tm_file="${tm_file} i386/unix.h i386/att.h dbxelf.h elfos.h glibc-stdint.h i386/i386elf.h i386/x86-64.h serenity.h i386/serenity.h"
 +    ;;
 +arm-*-serenity*)
++    default_gnu_indirect_function=yes
 +    tm_file="dbxelf.h elfos.h arm/elf.h arm/aout.h glibc-stdint.h arm/serenity-elf.h ${tm_file} serenity.h"
 +    ;;
 +aarch64-*-serenity*)
++    default_gnu_indirect_function=yes
 +    tm_file="${tm_file} dbxelf.h elfos.h aarch64/aarch64-elf.h glibc-stdint.h serenity.h"
 +    tmake_file="${tmake_file} aarch64/t-aarch64"
 +    ;;

--- a/Toolchain/Patches/llvm.patch
+++ b/Toolchain/Patches/llvm.patch
@@ -33,7 +33,7 @@ diff --git a/clang/lib/Basic/Targets/OSTargets.h b/clang/lib/Basic/Targets/OSTar
 index 3fe39ed64..51e7a6cca 100644
 --- a/clang/lib/Basic/Targets/OSTargets.h
 +++ b/clang/lib/Basic/Targets/OSTargets.h
-@@ -966,6 +966,22 @@ public:
+@@ -966,6 +966,24 @@ public:
    }
  };
  
@@ -50,7 +50,9 @@ index 3fe39ed64..51e7a6cca 100644
 +
 +public:
 +  SerenityTargetInfo(const llvm::Triple &Triple, const TargetOptions &Opts)
-+      : OSTargetInfo<Target>(Triple, Opts) {}
++      : OSTargetInfo<Target>(Triple, Opts) {
++    this->WIntType = TargetInfo::UnsignedInt;
++  }
 +};
 +
  } // namespace targets

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -13,13 +13,8 @@
 
 __BEGIN_DECLS
 
-// Note: wint_t is unsigned on gcc, and signed on clang.
 #ifndef WEOF
-#    ifdef __clang__
-#        define WEOF (-1)
-#    else
-#        define WEOF (0xffffffffu)
-#    endif
+#    define WEOF (0xffffffffu)
 #endif
 
 #undef WCHAR_MAX


### PR DESCRIPTION
This fixes some inconsistencies between the type definitions that were chosen by GCC and Clang respectively, occasionally resulting in weird linking issues or compiler messages.

Previous type definitions:

```
               | __SIZE_TYPE__     | __WCHAR_TYPE__ | __WINT_TYPE__ | __PTRDIFF_TYPE__ |
---------------|-------------------|----------------|---------------|------------------|
GCC (i686)     | long unsigned int | int            | unsigned int  | long int         |
GCC (x86_64)   | long unsigned int | int            | unsigned int  | long int         |
Clang (i686)   | unsigned int      | int            | int           | int              |
Clang (x86_64) | long unsigned int | int            | int           | long int         |
```

Current type definitions (including this PR):

```
               | __SIZE_TYPE__     | __WCHAR_TYPE__ | __WINT_TYPE__ | __PTRDIFF_TYPE__ |
---------------|-------------------|----------------|---------------|------------------|
GCC (i686)     | unsigned int      | int            | unsigned int  | int              |
GCC (x86_64)   | long unsigned int | int            | unsigned int  | long int         |
Clang (i686)   | unsigned int      | int            | unsigned int  | int              |
Clang (x86_64) | long unsigned int | int            | unsigned int  | long int         |
```

Additionally included (although not technically related) is a patch to enable IFUNC-support in GCC, on request of @BertalanD (as we did not want to force a rebuild of the toolchain twice in short succession).