### PR TITLE
LibSoftGPU+LibGfx: Allow indexed reads into `Gfx::Vector`

### DIFF
--- a/Userland/Libraries/LibGfx/VectorN.h
+++ b/Userland/Libraries/LibGfx/VectorN.h
@@ -56,6 +56,12 @@ public:
     constexpr void set_z(T value) requires(N >= 3) { m_data[2] = value; }
     constexpr void set_w(T value) requires(N >= 4) { m_data[3] = value; }
 
+    [[nodiscard]] constexpr T operator[](size_t index) const
+    {
+        VERIFY(index < N);
+        return m_data[index];
+    }
+
     constexpr VectorN& operator+=(const VectorN& other)
     {
         UNROLL_LOOP

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -609,7 +609,7 @@ static void generate_texture_coordinates(Vertex& vertex, RasterizerOptions const
             auto const normal = vertex.normal;
             auto reflection = eye_unit_xyz - normal * 2 * normal.dot(eye_unit_xyz);
             reflection.set_z(reflection.z() + 1);
-            auto const reflection_value = (config_index == 0) ? reflection.x() : reflection.y();
+            auto const reflection_value = reflection[config_index];
             return reflection_value / (2 * reflection.length()) + 0.5f;
         }
         case TexCoordGenerationMode::ReflectionMap: {
@@ -617,29 +617,10 @@ static void generate_texture_coordinates(Vertex& vertex, RasterizerOptions const
             FloatVector3 const eye_unit_xyz = eye_unit.xyz();
             auto const normal = vertex.normal;
             auto reflection = eye_unit_xyz - normal * 2 * normal.dot(eye_unit_xyz);
-            switch (config_index) {
-            case 0:
-                return reflection.x();
-            case 1:
-                return reflection.y();
-            case 2:
-                return reflection.z();
-            default:
-                VERIFY_NOT_REACHED();
-            }
+            return reflection[config_index];
         }
         case TexCoordGenerationMode::NormalMap: {
-            auto const normal = vertex.normal;
-            switch (config_index) {
-            case 0:
-                return normal.x();
-            case 1:
-                return normal.y();
-            case 2:
-                return normal.z();
-            default:
-                VERIFY_NOT_REACHED();
-            }
+            return vertex.normal[config_index];
         }
         default:
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -30,9 +30,6 @@ static long long g_num_sampler_calls;
 static long long g_num_stencil_writes;
 static long long g_num_quads;
 
-using IntVector2 = Gfx::Vector2<int>;
-using IntVector3 = Gfx::Vector3<int>;
-
 using AK::SIMD::any;
 using AK::SIMD::exp;
 using AK::SIMD::expand4;


### PR DESCRIPTION
This simplifies our texture coordinate generation code somewhat :^)