### PR TITLE
LibGfx: Abort draw_circle_arc_intersecting with 0 radius

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -428,7 +428,7 @@ void Painter::fill_rounded_corner(IntRect const& a_rect, int radius, Color color
 
 void Painter::draw_circle_arc_intersecting(IntRect const& a_rect, IntPoint const& center, int radius, Color color, int thickness)
 {
-    if (thickness <= 0)
+    if (thickness <= 0 || radius <= 0)
         return;
 
     // Care about clipping


### PR DESCRIPTION
In testing a particular website (https://www.icpms.com), WebContent
was crashing with infinite recursion in draw_circle_arc_intersecting.
Presumably, radius must be > 0 to paint something, so this trivial
patch simply returns if radius <= 0. The website in question no longer
crashes WebContent.