### PR TITLE
LibWeb: Stub getting the initial font instead of the root one

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -159,15 +159,12 @@ bool MediaFeature::compare(HTML::Window const& window, MediaFeatureValue left, C
         } else {
             Gfx::IntRect viewport_rect { 0, 0, window.inner_width(), window.inner_height() };
 
-            // FIXME: This isn't right - we want to query the initial-value font, which is the one used
-            //        if no author styles are defined.
-            auto& root_layout_node = *window.associated_document().root().layout_node();
-            auto const& font = root_layout_node.font();
-            Gfx::FontMetrics const& font_metrics = font.metrics('M');
-            float root_font_size = root_layout_node.computed_values().font_size();
+            auto const& initial_font = window.associated_document().style_computer().initial_font();
+            Gfx::FontMetrics const& initial_font_metrics = initial_font.metrics('M');
+            float initial_font_size = initial_font.presentation_size();
 
-            left_px = left.length().to_px(viewport_rect, font_metrics, root_font_size, root_font_size);
-            right_px = right.length().to_px(viewport_rect, font_metrics, root_font_size, root_font_size);
+            left_px = left.length().to_px(viewport_rect, initial_font_metrics, initial_font_size, initial_font_size);
+            right_px = right.length().to_px(viewport_rect, initial_font_metrics, initial_font_size, initial_font_size);
         }
 
         switch (comparison) {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -908,6 +908,12 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
     style.set_computed_font(found_font.release_nonnull());
 }
 
+Gfx::Font const& StyleComputer::initial_font() const
+{
+    // FIXME: This is not correct.
+    return StyleProperties::font_fallback(false, false);
+}
+
 void StyleComputer::absolutize_values(StyleProperties& style, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const
 {
     auto viewport_rect = document().browsing_context()->viewport_rect();

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -69,6 +69,8 @@ public:
 
     void invalidate_rule_cache();
 
+    Gfx::Font const& initial_font() const;
+
 private:
     void compute_cascaded_values(StyleProperties&, DOM::Element&, Optional<CSS::Selector::PseudoElement>) const;
     void compute_font(StyleProperties&, DOM::Element const*, Optional<CSS::Selector::PseudoElement>) const;


### PR DESCRIPTION
Previously this queried the root layout-node's font, which was both
wrong and could crash if the layout wasn't ready yet. Now, it's just
wrong. But at least all the font-related wrongness is grouped together
in StyleComputer. :^)