### PR TITLE
LibTest: Provide detailed per-file JSON output with --detailed-json / Meta: Run Wasm spec tests on master push

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
-          sudo apt-get install -y ninja-build unzip gcc-11 g++-11
+          sudo apt-get install -y ninja-build unzip gcc-11 g++-11 jq
 
       - name: Setup Python
         uses: actions/setup-python@v2
@@ -94,14 +94,15 @@ jobs:
         working-directory: libjs-test262
         run: |
           cd Build
-          cmake -GNinja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DSERENITY_SOURCE_DIR=${{ env.SERENITY_SOURCE_DIR }} ..
-          ninja libjs-test262-runner test-js
+          cmake -GNinja -DCMAKE_C_COMPILER=gcc-11 -DCMAKE_CXX_COMPILER=g++-11 -DINCLUDE_WASM_SPEC_TESTS=ON -DSERENITY_SOURCE_DIR=${{ env.SERENITY_SOURCE_DIR }} ..
+          ninja libjs-test262-runner test-js test-wasm
 
       - name: Get previous results
         working-directory: libjs-test262
         run: |
           cp -f ../libjs-website/test262/data/per-file-master.json .
           cp -f ../libjs-website/test262/data/per-file-bytecode-master.json .
+          cp -f ../libjs-website/wasm/data/per-file-master.json wasm-per-file-master.json
 
       - name: Run test262 and test262-parser-tests
         working-directory: libjs-test262
@@ -113,6 +114,32 @@ jobs:
             --results-json ../libjs-website/test262/data/results.json \
             --per-file-output ../libjs-website/test262/data/per-file-master.json \
             --per-file-bytecode-output ../libjs-website/test262/data/per-file-bytecode-master.json
+
+      - name: Run test-wasm
+        working-directory: libjs-test262/Build
+        run: |
+          _deps/lagom-build/test-wasm --per-file > ../../libjs-website/wasm/data/per-file-master.json
+          jq -nc -f <<-EOF --slurpfile previous ../../libjs-website/wasm/data/results.json --slurpfile details ../../libjs-website/wasm/data/per-file-master.json
+            \$details[0] as \$details | \$previous[0] + [{
+              "commit_timestamp": $(git -C ../.. log -1 --format=%ct),
+              "run_timestamp": $(date +%s),
+              "versions": {
+                "serenity": "$(git -C ../.. rev-parse HEAD)"
+              },
+              "tests": {
+                "spectest": {
+                  "duration": (\$details.duration),
+                  "results": {
+                    "total": (\$details.results | keys | length),
+                    "passed": ([\$details.results | values[] | select(. == "PASSED")] | length),
+                    "failed": ([\$details.results | values[] | select(. == "FAILED")] | length),
+                    "skipped": ([\$details.results | values[] | select(. == "SKIPPED")] | length),
+                    "process_error": ([\$details.results | values[] | select(. == "PROCESS_ERROR")] | length)
+                  }
+                }
+              }
+            }]
+          EOF
 
       - name: Deploy to GitHub pages
         uses: JamesIves/github-pages-deploy-action@4.1.1
@@ -133,6 +160,11 @@ jobs:
         continue-on-error: true
         working-directory: libjs-test262
         run: ./per_file_result_diff.py -o per-file-bytecode-master.json -n ../libjs-website/test262/data/per-file-bytecode-master.json
+
+      - name: Compare wasm
+        continue-on-error: true
+        working-directory: libjs-test262
+        run: ./per_file_result_diff.py -o wasm-per-file-master.json -n ../libjs-website/wasm/data/per-file-master.json
 
       - name: Build and package js
         working-directory: libjs-test262/Build

--- a/Meta/generate-libwasm-spec-test.py
+++ b/Meta/generate-libwasm-spec-test.py
@@ -274,6 +274,10 @@ def genarg(spec):
                 return str(struct.unpack('>q', struct.pack('>Q', int(x, 16)))[0]) + 'n'
             if spec['type'] == 'i64':
                 # Make a bigint instead, since `double' cannot fit all i64 values.
+                if x.startswith('0'):
+                    x = x.lstrip('0')
+                if x == '':
+                    x = '0'
                 return x + 'n'
             return x
 
@@ -434,7 +438,7 @@ def compile_wasm_source(mod, outpath):
         with NamedTemporaryFile("w+") as temp:
             temp.write(mod[1])
             temp.flush()
-            rc = call(["wat2wasm", temp.name, "-o", outpath])
+            rc = call(["wat2wasm", "--enable-all", "--no-check", temp.name, "-o", outpath])
             return rc == 0
     return False
 

--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -132,12 +132,13 @@ TESTJS_RUN_FILE_FUNCTION(String const& test_file, JS::Interpreter& interpreter, 
     }
 
     auto test_result = test_passed ? Test::Result::Pass : Test::Result::Fail;
-
+    auto test_path = LexicalPath::relative_path(test_file, Test::JS::g_test_root);
+    auto duration_ms = Test::get_time_in_ms() - start_time;
     return Test::JS::JSFileResult {
-        LexicalPath::relative_path(test_file, Test::JS::g_test_root),
+        test_path,
         {},
-        Test::get_time_in_ms() - start_time,
+        duration_ms,
         test_result,
-        { Test::Suite { "Parse file", test_result, { { expectation_string, test_result, message } } } }
+        { Test::Suite { test_path, "Parse file", test_result, { { expectation_string, test_result, message, static_cast<u64>(duration_ms) * 1000u } } } }
     };
 }

--- a/Userland/Libraries/LibJS/Tests/test-common.js
+++ b/Userland/Libraries/LibJS/Tests/test-common.js
@@ -536,6 +536,7 @@ class ExpectationError extends Error {
             __TestResults__[suiteMessage][defaultSuiteMessage] = {
                 result: "fail",
                 details: String(e),
+                duration: 0,
             };
         }
         suiteMessage = defaultSuiteMessage;
@@ -549,19 +550,25 @@ class ExpectationError extends Error {
             suite[message] = {
                 result: "fail",
                 details: "Another test with the same message did already run",
+                duration: 0,
             };
             return;
         }
 
+        const now = () => Temporal.Now.instant().epochNanoseconds;
+        const start = now();
+        const time_us = () => Number(BigInt.asIntN(53, (now() - start) / 1000n));
         try {
             callback();
             suite[message] = {
                 result: "pass",
+                duration: time_us(),
             };
         } catch (e) {
             suite[message] = {
                 result: "fail",
                 details: String(e),
+                duration: time_us(),
             };
         }
     };
@@ -577,12 +584,14 @@ class ExpectationError extends Error {
             suite[message] = {
                 result: "fail",
                 details: "Another test with the same message did already run",
+                duration: 0,
             };
             return;
         }
 
         suite[message] = {
             result: "skip",
+            duration: 0,
         };
     };
 })();

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -87,6 +87,7 @@ int main(int argc, char** argv)
         false;
 #endif
     bool print_json = false;
+    bool per_file = false;
     const char* specified_test_root = nullptr;
     String common_path;
     String test_glob;
@@ -109,6 +110,7 @@ int main(int argc, char** argv)
         },
     });
     args_parser.add_option(print_json, "Show results as JSON", "json", 'j');
+    args_parser.add_option(per_file, "Show detailed per-file results as JSON (implies -j)", "per-file", 0);
     args_parser.add_option(g_collect_on_every_allocation, "Collect garbage after every allocation", "collect-often", 'g');
     args_parser.add_option(g_run_bytecode, "Use the bytecode interpreter", "run-bytecode", 'b');
     args_parser.add_option(JS::Bytecode::g_dump_bytecode, "Dump the bytecode", "dump-bytecode", 'd');
@@ -118,6 +120,9 @@ int main(int argc, char** argv)
     args_parser.add_positional_argument(specified_test_root, "Tests root directory", "path", Core::ArgsParser::Required::No);
     args_parser.add_positional_argument(common_path, "Path to tests-common.js", "common-path", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
+
+    if (per_file)
+        print_json = true;
 
     test_glob = String::formatted("*{}*", test_glob);
 
@@ -182,7 +187,7 @@ int main(int argc, char** argv)
         g_vm->enable_default_host_import_module_dynamically_hook();
     }
 
-    Test::JS::TestRunner test_runner(test_root, common_path, print_times, print_progress, print_json);
+    Test::JS::TestRunner test_runner(test_root, common_path, print_times, print_progress, print_json, per_file);
     test_runner.run(test_glob);
 
     g_vm = nullptr;

--- a/Userland/Libraries/LibTest/Results.h
+++ b/Userland/Libraries/LibTest/Results.h
@@ -24,9 +24,11 @@ struct Case {
     String name;
     Result result;
     String details;
+    u64 duration_us;
 };
 
 struct Suite {
+    String path;
     String name;
     // A failed test takes precedence over a skipped test, which both have
     // precedence over a passed test

--- a/Userland/Libraries/LibTest/TestRunner.h
+++ b/Userland/Libraries/LibTest/TestRunner.h
@@ -29,11 +29,12 @@ public:
         return s_the;
     }
 
-    TestRunner(String test_root, bool print_times, bool print_progress, bool print_json)
+    TestRunner(String test_root, bool print_times, bool print_progress, bool print_json, bool detailed_json = false)
         : m_test_root(move(test_root))
         , m_print_times(print_times)
         , m_print_progress(print_progress)
         , m_print_json(print_json)
+        , m_detailed_json(detailed_json)
     {
         VERIFY(!s_the);
         s_the = this;
@@ -46,6 +47,16 @@ public:
     const Test::Counts& counts() const { return m_counts; }
 
     bool is_printing_progress() const { return m_print_progress; }
+
+    bool needs_detailed_suites() const { return m_detailed_json; }
+    Vector<Test::Suite> const& suites() const { return *m_suites; }
+
+    Vector<Test::Suite>& ensure_suites()
+    {
+        if (!m_suites.has_value())
+            m_suites = Vector<Suite> {};
+        return *m_suites;
+    }
 
 protected:
     static TestRunner* s_the;
@@ -61,9 +72,11 @@ protected:
     bool m_print_times;
     bool m_print_progress;
     bool m_print_json;
+    bool m_detailed_json;
 
     double m_total_elapsed_time_in_ms { 0 };
     Test::Counts m_counts;
+    Optional<Vector<Test::Suite>> m_suites;
 };
 
 inline void cleanup()
@@ -223,26 +236,63 @@ inline void TestRunner::print_test_results() const
 
 inline void TestRunner::print_test_results_as_json() const
 {
-    JsonObject suites;
-    suites.set("failed", m_counts.suites_failed);
-    suites.set("passed", m_counts.suites_passed);
-    suites.set("total", m_counts.suites_failed + m_counts.suites_passed);
-
-    JsonObject tests;
-    tests.set("failed", m_counts.tests_failed);
-    tests.set("passed", m_counts.tests_passed);
-    tests.set("skipped", m_counts.tests_skipped);
-    tests.set("total", m_counts.tests_failed + m_counts.tests_passed + m_counts.tests_skipped);
-
-    JsonObject results;
-    results.set("suites", suites);
-    results.set("tests", tests);
-
     JsonObject root;
-    root.set("results", results);
-    root.set("files_total", m_counts.files_total);
-    root.set("duration", m_total_elapsed_time_in_ms / 1000.0);
+    if (needs_detailed_suites()) {
+        auto& suites = this->suites();
+        u64 duration_us = 0;
+        JsonObject tests;
 
+        for (auto& suite : suites) {
+            for (auto& case_ : suite.tests) {
+                duration_us += case_.duration_us;
+                StringView result_name;
+                switch (case_.result) {
+                case Result::Pass:
+                    result_name = "PASSED";
+                    break;
+                case Result::Fail:
+                    result_name = "FAILED";
+                    break;
+                case Result::Skip:
+                    result_name = "SKIPPED";
+                    break;
+                case Result::Crashed:
+                    result_name = "PROCESS_ERROR";
+                    break;
+                }
+
+                auto name = suite.name;
+                if (name == "__$$TOP_LEVEL$$__"sv)
+                    name = String::empty();
+
+                auto path = LexicalPath::relative_path(suite.path, m_test_root);
+
+                tests.set(String::formatted("{}/{}::{}", path, name, case_.name), result_name);
+            }
+        }
+
+        root.set("duration", static_cast<double>(duration_us) / 1000000.);
+        root.set("results", move(tests));
+    } else {
+        JsonObject suites;
+        suites.set("failed", m_counts.suites_failed);
+        suites.set("passed", m_counts.suites_passed);
+        suites.set("total", m_counts.suites_failed + m_counts.suites_passed);
+
+        JsonObject tests;
+        tests.set("failed", m_counts.tests_failed);
+        tests.set("passed", m_counts.tests_passed);
+        tests.set("skipped", m_counts.tests_skipped);
+        tests.set("total", m_counts.tests_failed + m_counts.tests_passed + m_counts.tests_skipped);
+
+        JsonObject results;
+        results.set("suites", suites);
+        results.set("tests", tests);
+
+        root.set("results", results);
+        root.set("files_total", m_counts.files_total);
+        root.set("duration", m_total_elapsed_time_in_ms / 1000.0);
+    }
     outln("{}", root.to_string());
 }
 


### PR DESCRIPTION
Note: No merge before https://github.com/linusg/libjs-website/pull/19, or it'll be a bit of a mess.

Also what this means for all other test-js-style tests: plug&play per-file viewer, just bring your own tests.