### PR TITLE
Browser: Don't crash when selecting nothing in the Inspector DOM tree

### DIFF
--- a/Userland/Applications/Browser/InspectorWidget.cpp
+++ b/Userland/Applications/Browser/InspectorWidget.cpp
@@ -43,6 +43,9 @@ void InspectorWidget::set_selection(Selection selection)
 
 void InspectorWidget::set_selection(GUI::ModelIndex const index)
 {
+    if (!index.is_valid())
+        return;
+
     auto* json = static_cast<JsonObject const*>(index.internal_data());
     VERIFY(json);
 


### PR DESCRIPTION
This fixes the crash when clicking the background of the DOM tree in the inspector. The root cause of this is that AbstractView calls `did_update_selection()` and `on_selection_change()` when you do this, and claims no selection, when it's still kind of selected? Feels like it should just keep the selection in this case but I don't know the knock-on consequences of that.