### PR TITLE
LibWeb: Keep SVG elliptical arc shape when applying viewbox

### DIFF
--- a/Userland/Libraries/LibGfx/Path.cpp
+++ b/Userland/Libraries/LibGfx/Path.cpp
@@ -110,7 +110,9 @@ void Path::elliptical_arc_to(const FloatPoint& point, const FloatPoint& radii, d
         { rx, ry },
         x_axis_rotation,
         theta_1,
-        theta_delta);
+        theta_delta,
+        large_arc,
+        sweep);
 }
 
 void Path::close()

--- a/Userland/Libraries/LibGfx/Path.h
+++ b/Userland/Libraries/LibGfx/Path.h
@@ -107,13 +107,15 @@ private:
 
 class EllipticalArcSegment final : public Segment {
 public:
-    EllipticalArcSegment(const FloatPoint& point, const FloatPoint& center, const FloatPoint radii, float x_axis_rotation, float theta_1, float theta_delta)
+    EllipticalArcSegment(const FloatPoint& point, const FloatPoint& center, const FloatPoint radii, float x_axis_rotation, float theta_1, float theta_delta, bool large_arc, bool sweep)
         : Segment(point)
         , m_center(center)
         , m_radii(radii)
         , m_x_axis_rotation(x_axis_rotation)
         , m_theta_1(theta_1)
         , m_theta_delta(theta_delta)
+        , m_large_arc(large_arc)
+        , m_sweep(sweep)
     {
     }
 
@@ -124,6 +126,8 @@ public:
     float x_axis_rotation() const { return m_x_axis_rotation; }
     float theta_1() const { return m_theta_1; }
     float theta_delta() const { return m_theta_delta; }
+    bool large_arc() const { return m_large_arc; }
+    bool sweep() const { return m_sweep; }
 
 private:
     virtual Type type() const override { return Segment::Type::EllipticalArcTo; }
@@ -133,6 +137,8 @@ private:
     float m_x_axis_rotation;
     float m_theta_1;
     float m_theta_delta;
+    bool m_large_arc;
+    bool m_sweep;
 };
 
 class Path {
@@ -185,7 +191,7 @@ public:
     }
 
     // Note: This does not do any sanity checks!
-    void elliptical_arc_to(const FloatPoint& endpoint, const FloatPoint& center, const FloatPoint& radii, double x_axis_rotation, double theta, double theta_delta)
+    void elliptical_arc_to(const FloatPoint& endpoint, const FloatPoint& center, const FloatPoint& radii, double x_axis_rotation, double theta, double theta_delta, bool large_arc, bool sweep)
     {
         append_segment<EllipticalArcSegment>(
             endpoint,
@@ -193,7 +199,9 @@ public:
             radii,
             x_axis_rotation,
             theta,
-            theta_delta);
+            theta_delta,
+            large_arc,
+            sweep);
 
         invalidate_split_lines();
     }

--- a/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/SVGGeometryPaintable.cpp
@@ -85,7 +85,7 @@ void SVGGeometryPaintable::paint(PaintContext& context, PaintPhase phase) const
             }
             case Gfx::Segment::Type::EllipticalArcTo: {
                 auto& elliptical_arc_segment = static_cast<Gfx::EllipticalArcSegment const&>(segment);
-                new_path.elliptical_arc_to(transform_point(elliptical_arc_segment.point()), elliptical_arc_segment.radii().scaled(scaling, scaling), elliptical_arc_segment.x_axis_rotation(), false, false);
+                new_path.elliptical_arc_to(transform_point(elliptical_arc_segment.point()), elliptical_arc_segment.radii().scaled(scaling, scaling), elliptical_arc_segment.x_axis_rotation(), elliptical_arc_segment.large_arc(), elliptical_arc_segment.sweep());
                 break;
             }
             }


### PR DESCRIPTION
When doing viewbox transforms, elliptical always had large arc and sweep flag
set to false. Preserve these flags so they can be set correctly when
applying viewbox transformations.

Before:
![image](https://user-images.githubusercontent.com/116551/157949843-e921df12-4593-457e-aa63-acde22c59001.png)


After:
![image](https://user-images.githubusercontent.com/116551/157949566-97dc2a0a-0396-485b-bc95-8a1f71981120.png)
