### PR TITLE
LibGUI: Change foreground text color for desktop icons

### DIFF
--- a/Userland/Libraries/LibGUI/AbstractView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractView.cpp
@@ -728,7 +728,7 @@ void AbstractView::draw_item_text(Gfx::Painter& painter, ModelIndex const& index
     } else {
         if (m_draw_item_text_with_shadow) {
             painter.draw_text(text_rect.translated(1, 1), item_text, font, alignment, Color::Black, elision);
-            painter.draw_text(text_rect, item_text, font, alignment, Color::White, elision);
+            painter.draw_text(text_rect, item_text, font, alignment, palette().base_text().suggested_foreground_color() == Color::White ? Color::White : palette().base_text(), elision);
         } else {
             painter.draw_text(text_rect, item_text, font, alignment, text_color, elision);
         }


### PR DESCRIPTION
Previously desktop icons' text was always white, which is fine if the
theme's base_text color is either white or black. But if it was any
other color (e.g. Gruvbox Dark), having white text in the desktop was a
little bit off. This PR sets this color in the following manner:

  - If the base_text color is dark (usually in light themes), the
    suggested foregorund color is white and it is set accordingly.

  - If the base_text color is light (usually in dark themes), the
    suggested foregorund color would be black. In this case, we
    set the desktop text color to base_text.
Some pics:
![desktop_text_color](https://user-images.githubusercontent.com/45732251/158019062-ab1a3871-aa81-49f3-9f4a-017997be137b.png)
