### PR TITLE
FileManager+FileOperation: Port to Core::Stream

### DIFF
--- a/Userland/Applications/FileManager/DirectoryView.cpp
+++ b/Userland/Applications/FileManager/DirectoryView.cpp
@@ -650,7 +650,7 @@ void DirectoryView::handle_drop(GUI::ModelIndex const& index, GUI::DropEvent con
     }
 
     if (!paths_to_copy.is_empty())
-        run_file_operation(FileOperation::Copy, paths_to_copy, target_node.full_path(), window());
+        MUST(run_file_operation(FileOperation::Copy, paths_to_copy, target_node.full_path(), window()));
 
     if (had_accepted_drop && on_accepted_drop)
         on_accepted_drop();

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.h
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.h
@@ -8,6 +8,7 @@
 
 #include "FileUtils.h"
 #include <LibCore/ElapsedTimer.h>
+#include <LibCore/Stream.h>
 #include <LibGUI/Widget.h>
 
 namespace FileManager {
@@ -19,7 +20,8 @@ public:
     virtual ~FileOperationProgressWidget() override;
 
 private:
-    FileOperationProgressWidget(FileOperation, NonnullRefPtr<Core::File> helper_pipe);
+    // FIXME: The helper_pipe_fd parameter is only needed because we can't get the fd from a Core::Stream.
+    FileOperationProgressWidget(FileOperation, NonnullOwnPtr<Core::Stream::BufferedFile> helper_pipe, int helper_pipe_fd);
 
     void did_finish();
     void did_error(StringView message);
@@ -32,6 +34,6 @@ private:
 
     FileOperation m_operation;
     RefPtr<Core::Notifier> m_notifier;
-    RefPtr<Core::File> m_helper_pipe;
+    OwnPtr<Core::Stream::BufferedFile> m_helper_pipe;
 };
 }

--- a/Userland/Applications/FileManager/FileUtils.h
+++ b/Userland/Applications/FileManager/FileUtils.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -21,5 +21,5 @@ enum class FileOperation {
 
 void delete_paths(Vector<String> const&, bool should_confirm, GUI::Window*);
 
-void run_file_operation(FileOperation, Vector<String> const& sources, String const& destination, GUI::Window*);
+ErrorOr<void> run_file_operation(FileOperation, Vector<String> const& sources, String const& destination, GUI::Window*);
 }

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -176,8 +176,10 @@ void do_paste(String const& target_directory, GUI::Window* window)
         source_paths.append(url.path());
     }
 
-    if (!source_paths.is_empty())
-        run_file_operation(file_operation, source_paths, target_directory, window);
+    if (!source_paths.is_empty()) {
+        if (auto result = run_file_operation(file_operation, source_paths, target_directory, window); result.is_error())
+            dbgln("Failed to paste files: {}", result.error());
+    }
 }
 
 void do_create_link(Vector<String> const& selected_file_paths, GUI::Window* window)


### PR DESCRIPTION
A couple of things that came up during this:

- We don't have Core::System wrappers for `execvp()` and friends. Seems like we could just have a single `Core::System::exec()` that takes an Optional for the environment, and a flag for whether to look in `PATH`. (But I have no experience using these so don't really know what I'm talking about.)
- You can't get the file descriptor out of a Core::Stream::File, so using a Notifier is awkward. I had to pass it separately to the `FileOperationProgressWidget` constructor. Maybe something like a `Core::Stream::File::create_notifier()` method would be good here? Or just a way to get the fd directly.