### PR TITLE
PixelPaint: Correctly apply flip/rotate/crop to layers' alpha mask

### DIFF
--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -96,7 +96,7 @@ ErrorOr<NonnullRefPtr<Image>> Image::try_create_from_pixel_paint_json(JsonObject
             auto mask_base64_encoded = mask_object.as_string();
             auto mask_data = TRY(decode_base64(mask_base64_encoded));
             auto mask = TRY(try_decode_bitmap(mask_data));
-            layer->set_mask_bitmap(move(mask));
+            TRY(layer->try_set_bitmaps(layer->content_bitmap(), mask));
         }
 
         auto width = layer_object.get("width").to_i32();
@@ -485,10 +485,7 @@ void ImageUndoCommand::redo()
 void Image::flip(Gfx::Orientation orientation)
 {
     for (auto& layer : m_layers) {
-        auto flipped = layer.content_bitmap().flipped(orientation).release_value_but_fixme_should_propagate_errors();
-        layer.set_content_bitmap(*flipped);
-        layer.did_modify_bitmap(rect());
-        // FIXME: Respect mask
+        layer.flip(orientation);
     }
 
     did_change();
@@ -497,10 +494,7 @@ void Image::flip(Gfx::Orientation orientation)
 void Image::rotate(Gfx::RotationDirection direction)
 {
     for (auto& layer : m_layers) {
-        auto rotated = layer.content_bitmap().rotated(direction).release_value_but_fixme_should_propagate_errors();
-        layer.set_content_bitmap(*rotated);
-        layer.did_modify_bitmap(rect());
-        // FIXME: Respect mask
+        layer.rotate(direction);
     }
 
     m_size = { m_size.height(), m_size.width() };
@@ -510,10 +504,7 @@ void Image::rotate(Gfx::RotationDirection direction)
 void Image::crop(Gfx::IntRect const& cropped_rect)
 {
     for (auto& layer : m_layers) {
-        auto cropped = layer.content_bitmap().cropped(cropped_rect).release_value_but_fixme_should_propagate_errors();
-        layer.set_content_bitmap(*cropped);
-        layer.did_modify_bitmap(rect());
-        // FIXME: Respect mask
+        layer.crop(cropped_rect);
     }
 
     m_size = { cropped_rect.width(), cropped_rect.height() };

--- a/Userland/Applications/PixelPaint/Layer.h
+++ b/Userland/Applications/PixelPaint/Layer.h
@@ -53,8 +53,11 @@ public:
     String const& name() const { return m_name; }
     void set_name(String);
 
-    void set_content_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap);
-    void set_mask_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap);
+    void flip(Gfx::Orientation orientation);
+    void rotate(Gfx::RotationDirection direction);
+    void crop(Gfx::IntRect const& rect);
+
+    ErrorOr<void> try_set_bitmaps(NonnullRefPtr<Gfx::Bitmap> content, RefPtr<Gfx::Bitmap> mask);
 
     void did_modify_bitmap(Gfx::IntRect const& = {});
 


### PR DESCRIPTION
A couple fixes in order to prepare for work I'm doing on #11862

- Layer now has methods for flip/rotate/crop, which are responsible for handling the alpha mask.
- Fixed crash when the cached display image size is out of sync with the content image size.
- Changed API for setting content and mask image in Layer. Now, both must be set at the same time, and it can result in an error if you provide mismatched dimensions.

Screenshots below. Notice the alpha mask stays correct!

**Original**
![start](https://user-images.githubusercontent.com/5752601/158033528-7c2c523e-28ec-479d-a98c-5809c1f8ca33.png)

**Flipped horizontally**
![flip_h](https://user-images.githubusercontent.com/5752601/158033530-c1816d04-4612-4946-85e8-bdfe41e1e36f.png)

**Rotated ccw**
![rotate_ccw](https://user-images.githubusercontent.com/5752601/158033531-b0d7f0fc-80ca-4975-b309-4a8b7417286e.png)

**Cropped**
![crop](https://user-images.githubusercontent.com/5752601/158033533-4279b8d1-b882-44df-a20f-2d12bf0e2c80.png)

