### PR TITLE
LibCore: Add a wrapper for execvpe() and friends

### DIFF
--- a/Userland/DevTools/HackStudio/TerminalWrapper.cpp
+++ b/Userland/DevTools/HackStudio/TerminalWrapper.cpp
@@ -60,18 +60,9 @@ ErrorOr<void> TerminalWrapper::run_command(String const& command, Optional<Strin
 
     TRY(setup_slave_pseudoterminal(ptm_fd));
 
-    auto parts = command.split(' ');
-    VERIFY(!parts.is_empty());
-    char const** args = (char const**)calloc(parts.size() + 1, sizeof(char const*));
-    for (size_t i = 0; i < parts.size(); i++) {
-        args[i] = parts[i].characters();
-    }
-
-    auto rc = execvp(args[0], const_cast<char**>(args));
-    if (rc < 0) {
-        perror("execve");
-        exit(1);
-    }
+    auto args = command.split_view(' ');
+    VERIFY(!args.is_empty());
+    TRY(Core::System::exec(args[0], args, Core::System::SearchInPath::Yes));
     VERIFY_NOT_REACHED();
 }
 

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -676,6 +676,21 @@ void ArgsParser::add_positional_argument(Vector<char const*>& values, char const
     add_positional_argument(move(arg));
 }
 
+void ArgsParser::add_positional_argument(Vector<String>& values, char const* help_string, char const* name, Required required)
+{
+    Arg arg {
+        help_string,
+        name,
+        required == Required::Yes ? 1 : 0,
+        INT_MAX,
+        [&values](char const* s) {
+            values.append(s);
+            return true;
+        }
+    };
+    add_positional_argument(move(arg));
+}
+
 void ArgsParser::add_positional_argument(Vector<StringView>& values, char const* help_string, char const* name, Required required)
 {
     Arg arg {

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -98,6 +98,7 @@ public:
     void add_positional_argument(unsigned& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(double& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(Vector<char const*>& value, char const* help_string, char const* name, Required required = Required::Yes);
+    void add_positional_argument(Vector<String>& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(Vector<StringView>& value, char const* help_string, char const* name, Required required = Required::Yes);
 
 private:

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -127,6 +127,11 @@ ErrorOr<void> utime(StringView path, Optional<struct utimbuf>);
 ErrorOr<struct utsname> uname();
 ErrorOr<Array<int, 2>> pipe2(int flags);
 ErrorOr<void> adjtime(const struct timeval* delta, struct timeval* old_delta);
+enum class SearchInPath {
+    No,
+    Yes,
+};
+ErrorOr<void> exec(StringView filename, Span<StringView> arguments, SearchInPath, Optional<Span<StringView>> environment = {});
 
 ErrorOr<int> socket(int domain, int type, int protocol);
 ErrorOr<void> bind(int sockfd, struct sockaddr const*, socklen_t);

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -159,7 +159,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     char const* command_to_run = nullptr;
     char const* file_to_read_from = nullptr;
-    Vector<char const*> script_args;
+    Vector<String> script_args;
     bool skip_rc_files = false;
     char const* format = nullptr;
     bool should_format_live = false;
@@ -228,12 +228,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         shell->cache_path();
     }
 
-    {
-        Vector<String> args;
-        for (auto* arg : script_args)
-            args.empend(arg);
-        shell->set_local_variable("ARGV", adopt_ref(*new Shell::AST::ListValue(move(args))));
-    }
+    shell->set_local_variable("ARGV", adopt_ref(*new Shell::AST::ListValue(move(script_args))));
 
     if (command_to_run) {
         dbgln("sh -c '{}'\n", command_to_run);

--- a/Userland/Utilities/cksum.cpp
+++ b/Userland/Utilities/cksum.cpp
@@ -13,7 +13,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    Vector<char const*> paths;
+    Vector<String> paths;
     char const* opt_algorithm = nullptr;
 
     Core::ArgsParser args_parser;
@@ -43,7 +43,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     bool fail = false;
     for (auto& path : paths) {
-        auto filepath = (StringView(path) == "-") ? "/dev/stdin" : path;
+        auto filepath = (path == "-") ? "/dev/stdin" : path;
         auto file = Core::File::construct(filepath);
         if (!file->open(Core::OpenMode::ReadOnly)) {
             warnln("{}: {}: {}", arguments.strings[0], path, file->error_string());

--- a/Userland/Utilities/copy.cpp
+++ b/Userland/Utilities/copy.cpp
@@ -25,7 +25,7 @@ struct Options {
 static Options parse_options(Main::Arguments arguments)
 {
     char const* type = "text/plain";
-    Vector<char const*> text;
+    Vector<String> text;
     bool clear = false;
 
     Core::ArgsParser args_parser;

--- a/Userland/Utilities/echo.cpp
+++ b/Userland/Utilities/echo.cpp
@@ -101,7 +101,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio"));
 
-    Vector<char const*> text;
+    Vector<String> text;
     bool no_trailing_newline = false;
     bool should_interpret_backslash_escapes = false;
 

--- a/Userland/Utilities/file.cpp
+++ b/Userland/Utilities/file.cpp
@@ -141,7 +141,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
 
-    Vector<char const*> paths;
+    Vector<String> paths;
     bool flag_mime_only = false;
 
     Core::ArgsParser args_parser;
@@ -155,7 +155,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     for (auto path : paths) {
         auto file_or_error = Core::File::open(path, Core::OpenMode::ReadOnly);
         if (file_or_error.is_error()) {
-            perror(path);
+            perror(path.characters());
             all_ok = false;
             continue;
         }

--- a/Userland/Utilities/gml-format.cpp
+++ b/Userland/Utilities/gml-format.cpp
@@ -53,7 +53,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 #endif
 
     bool inplace = false;
-    Vector<char const*> files;
+    Vector<String> files;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Format GML files.");

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -39,11 +39,11 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 
     String program_name = AK::LexicalPath::basename(args.strings[0]);
 
-    Vector<char const*> files;
+    Vector<String> files;
 
     bool recursive = (program_name == "rgrep"sv);
     bool use_ere = (program_name == "egrep"sv);
-    Vector<char const*> patterns;
+    Vector<String> patterns;
     BinaryFileMode binary_mode { BinaryFileMode::Binary };
     bool case_insensitive = false;
     bool line_numbers = false;

--- a/Userland/Utilities/groups.cpp
+++ b/Userland/Utilities/groups.cpp
@@ -35,7 +35,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil(nullptr, nullptr));
     TRY(Core::System::pledge("stdio rpath"));
 
-    Vector<char const*> usernames;
+    Vector<String> usernames;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Print group memberships for each username or, if no username is specified, for the current process.");
@@ -48,7 +48,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     for (auto username : usernames) {
-        auto result = Core::Account::from_name(username, Core::Account::Read::PasswdOnly);
+        auto result = Core::Account::from_name(username.characters(), Core::Account::Read::PasswdOnly);
         if (result.is_error()) {
             warnln("{} '{}'", result.error(), username);
             continue;

--- a/Userland/Utilities/head.cpp
+++ b/Userland/Utilities/head.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments args)
     int byte_count = -1;
     bool never_print_filenames = false;
     bool always_print_filenames = false;
-    Vector<char const*> files;
+    Vector<String> files;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Print the beginning ('head') of a file.");

--- a/Userland/Utilities/mkdir.cpp
+++ b/Userland/Utilities/mkdir.cpp
@@ -22,7 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     bool create_parents = false;
     String mode_string;
-    Vector<char const*> directories;
+    Vector<String> directories;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(create_parents, "Create parent directories if they don't exist", "parents", 'p');

--- a/Userland/Utilities/mv.cpp
+++ b/Userland/Utilities/mv.cpp
@@ -24,7 +24,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool force = false;
     bool verbose = false;
 
-    Vector<char const*> paths;
+    Vector<String> paths;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(force, "Force", "force", 'f');
@@ -41,7 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     struct stat st;
 
-    int rc = lstat(original_new_path, &st);
+    int rc = lstat(original_new_path.characters(), &st);
     if (rc != 0 && errno != ENOENT) {
         perror("lstat");
         return 1;
@@ -57,14 +57,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     for (auto& old_path : paths) {
         String combined_new_path;
-        char const* new_path = original_new_path;
+        auto new_path = original_new_path;
         if (S_ISDIR(st.st_mode)) {
             auto old_basename = LexicalPath::basename(old_path);
             combined_new_path = String::formatted("{}/{}", original_new_path, old_basename);
             new_path = combined_new_path.characters();
         }
 
-        rc = rename(old_path, new_path);
+        rc = rename(old_path.characters(), new_path.characters());
         if (rc < 0) {
             if (errno == EXDEV) {
                 auto result = Core::File::copy_file_or_directory(
@@ -77,7 +77,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     warnln("mv: could not move '{}': {}", old_path, static_cast<Error const&>(result.error()));
                     return 1;
                 }
-                rc = unlink(old_path);
+                rc = unlink(old_path.characters());
                 if (rc < 0)
                     warnln("mv: unlink '{}': {}", old_path, strerror(errno));
             } else {

--- a/Userland/Utilities/nl.cpp
+++ b/Userland/Utilities/nl.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     char const* separator = "  ";
     int start_number = 1;
     int number_width = 6;
-    Vector<char const*> files;
+    Vector<String> files;
 
     Core::ArgsParser args_parser;
 
@@ -60,7 +60,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Vector<FILE*> file_pointers;
     if (!files.is_empty()) {
         for (auto& file : files) {
-            FILE* file_pointer = fopen(file, "r");
+            FILE* file_pointer = fopen(file.characters(), "r");
             if (!file_pointer) {
                 warnln("Failed to open {}: {}", file, strerror(errno));
                 continue;

--- a/Userland/Utilities/pathchk.cpp
+++ b/Userland/Utilities/pathchk.cpp
@@ -6,7 +6,6 @@
 
 #include <AK/String.h>
 #include <LibCore/ArgsParser.h>
-#include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 #include <bits/posix1_lim.h>
@@ -19,7 +18,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     static bool flag_most_posix = false;
     static bool flag_portability = false;
     static bool flag_empty_name_and_leading_dash = false;
-    Vector<char const*> paths;
+    Vector<String> paths;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(flag_most_posix, "Check for most POSIX systems", nullptr, 'p');
@@ -34,31 +33,30 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     for (auto& path : paths) {
-        auto str_path = String(path);
-        unsigned long path_max = flag_most_posix ? _POSIX_PATH_MAX : pathconf(str_path.characters(), _PC_PATH_MAX);
-        unsigned long name_max = flag_most_posix ? _POSIX_NAME_MAX : pathconf(str_path.characters(), _PC_NAME_MAX);
+        unsigned long path_max = flag_most_posix ? _POSIX_PATH_MAX : pathconf(path.characters(), _PC_PATH_MAX);
+        unsigned long name_max = flag_most_posix ? _POSIX_NAME_MAX : pathconf(path.characters(), _PC_NAME_MAX);
 
-        if (str_path.length() > path_max) {
-            warnln("Limit {} exceeded by length {} of filename '{}'", path_max, str_path.length(), str_path);
+        if (path.length() > path_max) {
+            warnln("Limit {} exceeded by length {} of filename '{}'", path_max, path.length(), path);
             fail = true;
             continue;
         }
 
         if (flag_most_posix) {
             // POSIX portable filename character set (a-z A-Z 0-9 . _ -)
-            for (long unsigned i = 0; i < str_path.length(); ++i) {
+            for (long unsigned i = 0; i < path.length(); ++i) {
                 auto c = path[i];
                 if (!(c >= 'a' && c <= 'z') && !(c >= 'A' && c <= 'Z') && !(c >= '0' && c <= '9') && c != '/' && c != '.' && c != '-' && c != '_') {
-                    warnln("Non-portable character '{}' in filename '{}'", path[i], str_path);
+                    warnln("Non-portable character '{}' in filename '{}'", path[i], path);
                     fail = true;
                     continue;
                 }
             }
         } else {
             struct stat st;
-            if (lstat(str_path.characters(), &st) < 0) {
+            if (lstat(path.characters(), &st) < 0) {
                 if (errno != ENOENT) {
-                    warnln("Directory is not searchable '{}'", str_path);
+                    warnln("Directory is not searchable '{}'", path);
                     fail = true;
                     continue;
                 }
@@ -66,17 +64,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         if (flag_empty_name_and_leading_dash) {
-            if (str_path.is_empty()) {
+            if (path.is_empty()) {
                 warnln("Empty filename");
                 fail = true;
                 continue;
             }
         }
 
-        for (auto& component : str_path.split('/')) {
+        for (auto& component : path.split('/')) {
             if (flag_empty_name_and_leading_dash) {
                 if (component.starts_with('-')) {
-                    warnln("Leading '-' in a component of filename '{}'", str_path);
+                    warnln("Leading '-' in a component of filename '{}'", path);
                     fail = true;
                     break;
                 }

--- a/Userland/Utilities/profile.cpp
+++ b/Userland/Utilities/profile.cpp
@@ -107,20 +107,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 0;
     }
 
-    auto cmd_parts = String(cmd_argument).split(' ');
-    Vector<char const*> cmd_argv;
-
-    for (auto& part : cmd_parts)
-        cmd_argv.append(part.characters());
-
-    cmd_argv.append(nullptr);
+    auto cmd_parts = String(cmd_argument).split_view(' ');
 
     dbgln("Enabling profiling for PID {}", getpid());
     TRY(Core::System::profiling_enable(getpid(), event_mask));
-    if (execvp(cmd_argv[0], const_cast<char**>(cmd_argv.data())) < 0) {
-        perror("execv");
-        return 1;
-    }
+    TRY(Core::System::exec(cmd_parts[0], cmd_parts, Core::System::SearchInPath::Yes));
 
     return 0;
 }

--- a/Userland/Utilities/rmdir.cpp
+++ b/Userland/Utilities/rmdir.cpp
@@ -15,7 +15,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio cpath"));
 
-    Vector<char const*> paths;
+    Vector<String> paths;
 
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(paths, "Directories to remove", "paths");
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     int status = 0;
     for (auto path : paths) {
-        int rc = rmdir(path);
+        int rc = rmdir(path.characters());
         if (rc < 0) {
             perror("rmdir");
             status = 1;

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -34,7 +34,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool no_auto_compress = false;
     StringView archive_file;
     char const* directory = nullptr;
-    Vector<char const*> paths;
+    Vector<String> paths;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(create, "Create archive", "create", 'c');

--- a/Userland/Utilities/touch.cpp
+++ b/Userland/Utilities/touch.cpp
@@ -12,13 +12,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <unistd.h>
-#include <utime.h>
 
-static bool file_exists(char const* path)
+static bool file_exists(String const& path)
 {
     struct stat st;
-    int rc = stat(path, &st);
+    int rc = stat(path.characters(), &st);
     if (rc < 0) {
         if (errno == ENOENT)
             return false;
@@ -34,7 +32,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath cpath fattr"));
 
-    Vector<char const*> paths;
+    Vector<String> paths;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Create a file, or update its mtime (time of last modification).");

--- a/Userland/Utilities/tree.cpp
+++ b/Userland/Utilities/tree.cpp
@@ -106,7 +106,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath tty"));
 
-    Vector<char const*> directories;
+    Vector<String> directories;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(flag_show_hidden_files, "Show hidden files", "all", 'a');
@@ -124,7 +124,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         print_directory_tree(".", 0, "");
         puts("");
     } else {
-        for (char const* directory : directories) {
+        for (auto const& directory : directories) {
             print_directory_tree(directory, 0, "");
             puts("");
         }

--- a/Userland/Utilities/wc.cpp
+++ b/Userland/Utilities/wc.cpp
@@ -90,7 +90,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath"));
 
-    Vector<char const*> file_specifiers;
+    Vector<String> file_specifiers;
 
     Core::ArgsParser args_parser;
     args_parser.add_option(g_output_line, "Output line count", "lines", 'l');

--- a/Userland/Utilities/xargs.cpp
+++ b/Userland/Utilities/xargs.cpp
@@ -28,7 +28,7 @@ bool read_items(FILE* fp, char entry_separator, Function<Decision(StringView)>);
 
 class ParsedInitialArguments {
 public:
-    ParsedInitialArguments(Vector<char const*>&, StringView placeholder);
+    ParsedInitialArguments(Vector<String>&, StringView placeholder);
 
     void for_each_joined_argument(StringView, Function<void(String const&)>) const;
 
@@ -45,7 +45,7 @@ ErrorOr<int> serenity_main(Main::Arguments main_arguments)
     char const* placeholder = nullptr;
     bool split_with_nulls = false;
     char const* specified_delimiter = "\n";
-    Vector<char const*> arguments;
+    Vector<String> arguments;
     bool verbose = false;
     char const* file_to_read = "-";
     int max_lines_for_one_command = 0;
@@ -238,18 +238,16 @@ bool run_command(Vector<char*>&& child_argv, bool verbose, bool is_stdin, int de
     return true;
 }
 
-ParsedInitialArguments::ParsedInitialArguments(Vector<char const*>& arguments, StringView placeholder)
+ParsedInitialArguments::ParsedInitialArguments(Vector<String>& arguments, StringView placeholder)
 {
     m_all_parts.ensure_capacity(arguments.size());
     bool some_argument_has_placeholder = false;
 
-    for (auto argument : arguments) {
-        StringView arg { argument };
-
+    for (auto arg : arguments) {
         if (placeholder.is_empty()) {
             m_all_parts.append({ arg });
         } else {
-            auto parts = arg.split_view(placeholder, true);
+            auto parts = arg.view().split_view(placeholder, true);
             some_argument_has_placeholder = some_argument_has_placeholder || parts.size() > 1;
             m_all_parts.append(move(parts));
         }


### PR DESCRIPTION
This was a noticeable exec-shaped hole in Core::System, so let's rectify that. :^)

Making this a draft since there are many more places that this can be used, but since I don't super know what I'm doing, I'd appreciate a look over by someone who knows exec better in case I'm doing something really dumb.