### PR TITLE
LibGfx: Commonize P[BGP]M file loaders

### DIFF
--- a/Userland/Libraries/LibGfx/PBMLoader.cpp
+++ b/Userland/Libraries/LibGfx/PBMLoader.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,42 +13,12 @@
 
 namespace Gfx {
 
-struct PBMLoadingContext {
-    enum Type {
-        Unknown,
-        ASCII,
-        RAWBITS
-    };
-
-    enum State {
-        NotDecoded = 0,
-        Error,
-        MagicNumber,
-        Width,
-        Height,
-        Bitmap,
-        Decoded
-    };
-
-    static constexpr auto ascii_magic_number = '1';
-    static constexpr auto binary_magic_number = '4';
-    static constexpr auto image_type = "PBM";
-
-    Type type { Type::Unknown };
-    State state { State::NotDecoded };
-    const u8* data { nullptr };
-    size_t data_size { 0 };
-    size_t width { 0 };
-    size_t height { 0 };
-    RefPtr<Gfx::Bitmap> bitmap;
-};
-
 static bool read_image_data(PBMLoadingContext& context, Streamer& streamer)
 {
     u8 byte;
     Vector<Gfx::Color> color_data;
 
-    if (context.type == PBMLoadingContext::ASCII) {
+    if (context.type == PBMLoadingContext::Type::ASCII) {
         while (streamer.read(byte)) {
             if (byte == '0') {
                 color_data.append(Color::White);
@@ -55,7 +26,7 @@ static bool read_image_data(PBMLoadingContext& context, Streamer& streamer)
                 color_data.append(Color::Black);
             }
         }
-    } else if (context.type == PBMLoadingContext::RAWBITS) {
+    } else if (context.type == PBMLoadingContext::Type::RAWBITS) {
         size_t color_index = 0;
 
         while (streamer.read(byte)) {

--- a/Userland/Libraries/LibGfx/PBMLoader.h
+++ b/Userland/Libraries/LibGfx/PBMLoader.h
@@ -20,26 +20,7 @@ struct PBM {
 };
 
 using PBMLoadingContext = PortableImageMapLoadingContext<PBM>;
+using PBMImageDecoderPlugin = PortableImageDecoderPlugin<PBMLoadingContext>;
 
-class PBMImageDecoderPlugin final : public ImageDecoderPlugin {
-public:
-    PBMImageDecoderPlugin(const u8*, size_t);
-    virtual ~PBMImageDecoderPlugin() override;
-
-    virtual IntSize size() override;
-
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
-
-    virtual bool sniff() override;
-
-    virtual bool is_animated() override;
-    virtual size_t loop_count() override;
-    virtual size_t frame_count() override;
-    virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
-
-private:
-    OwnPtr<PBMLoadingContext> m_context;
-};
-
+bool read_image_data(PBMLoadingContext& context, Streamer& streamer);
 }

--- a/Userland/Libraries/LibGfx/PBMLoader.h
+++ b/Userland/Libraries/LibGfx/PBMLoader.h
@@ -1,16 +1,25 @@
 /*
  * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibGfx/ImageDecoder.h>
+#include <LibGfx/PortableImageMapLoader.h>
 
 namespace Gfx {
 
-struct PBMLoadingContext;
+struct PBM {
+    static constexpr auto ascii_magic_number = '1';
+    static constexpr auto binary_magic_number = '4';
+    static constexpr StringView image_type = "PBM";
+};
+
+using PBMLoadingContext = PortableImageMapLoadingContext<PBM>;
 
 class PBMImageDecoderPlugin final : public ImageDecoderPlugin {
 public:

--- a/Userland/Libraries/LibGfx/PGMLoader.h
+++ b/Userland/Libraries/LibGfx/PGMLoader.h
@@ -21,26 +21,7 @@ struct PGM {
 };
 
 using PGMLoadingContext = PortableImageMapLoadingContext<PGM>;
+using PGMImageDecoderPlugin = PortableImageDecoderPlugin<PGMLoadingContext>;
 
-class PGMImageDecoderPlugin final : public ImageDecoderPlugin {
-public:
-    PGMImageDecoderPlugin(const u8*, size_t);
-    virtual ~PGMImageDecoderPlugin() override;
-
-    virtual IntSize size() override;
-
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
-
-    virtual bool sniff() override;
-
-    virtual bool is_animated() override;
-    virtual size_t loop_count() override;
-    virtual size_t frame_count() override;
-    virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
-
-private:
-    OwnPtr<PGMLoadingContext> m_context;
-};
-
+bool read_image_data(PGMLoadingContext& context, Streamer& streamer);
 }

--- a/Userland/Libraries/LibGfx/PGMLoader.h
+++ b/Userland/Libraries/LibGfx/PGMLoader.h
@@ -1,16 +1,26 @@
 /*
  * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibGfx/ImageDecoder.h>
+#include <LibGfx/PortableImageMapLoader.h>
 
 namespace Gfx {
 
-struct PGMLoadingContext;
+struct PGM {
+    static constexpr auto ascii_magic_number = '2';
+    static constexpr auto binary_magic_number = '5';
+    static constexpr StringView image_type = "PGM";
+    u16 max_val { 0 };
+};
+
+using PGMLoadingContext = PortableImageMapLoadingContext<PGM>;
 
 class PGMImageDecoderPlugin final : public ImageDecoderPlugin {
 public:

--- a/Userland/Libraries/LibGfx/PPMLoader.cpp
+++ b/Userland/Libraries/LibGfx/PPMLoader.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,44 +16,12 @@
 
 namespace Gfx {
 
-struct PPMLoadingContext {
-    enum Type {
-        Unknown,
-        ASCII,
-        RAWBITS
-    };
-
-    enum State {
-        NotDecoded = 0,
-        Error,
-        MagicNumber,
-        Width,
-        Height,
-        Maxval,
-        Bitmap,
-        Decoded
-    };
-
-    static constexpr auto ascii_magic_number = '3';
-    static constexpr auto binary_magic_number = '6';
-    static constexpr auto image_type = "PPM";
-
-    Type type { Type::Unknown };
-    State state { State::NotDecoded };
-    const u8* data { nullptr };
-    size_t data_size { 0 };
-    u16 width { 0 };
-    u16 height { 0 };
-    u16 max_val { 0 };
-    RefPtr<Gfx::Bitmap> bitmap;
-};
-
 static bool read_image_data(PPMLoadingContext& context, Streamer& streamer)
 {
     Vector<Gfx::Color> color_data;
     color_data.ensure_capacity(context.width * context.height);
 
-    if (context.type == PPMLoadingContext::ASCII) {
+    if (context.type == PPMLoadingContext::Type::ASCII) {
         u16 red;
         u16 green;
         u16 blue;
@@ -77,11 +46,11 @@ static bool read_image_data(PPMLoadingContext& context, Streamer& streamer)
                 break;
 
             Color color { (u8)red, (u8)green, (u8)blue };
-            if (context.max_val < 255)
-                color = adjust_color(context.max_val, color);
+            if (context.format_details.max_val < 255)
+                color = adjust_color(context.format_details.max_val, color);
             color_data.append(color);
         }
-    } else if (context.type == PPMLoadingContext::RAWBITS) {
+    } else if (context.type == PPMLoadingContext::Type::RAWBITS) {
         u8 pixel[3];
         while (streamer.read_bytes(pixel, 3)) {
             color_data.append({ pixel[0], pixel[1], pixel[2] });

--- a/Userland/Libraries/LibGfx/PPMLoader.h
+++ b/Userland/Libraries/LibGfx/PPMLoader.h
@@ -1,16 +1,26 @@
 /*
  * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibGfx/ImageDecoder.h>
+#include <LibGfx/PortableImageMapLoader.h>
 
 namespace Gfx {
 
-struct PPMLoadingContext;
+struct PPM {
+    static constexpr auto ascii_magic_number = '3';
+    static constexpr auto binary_magic_number = '6';
+    static constexpr StringView image_type = "PPM";
+    u16 max_val { 0 };
+};
+
+using PPMLoadingContext = PortableImageMapLoadingContext<PPM>;
 
 class PPMImageDecoderPlugin final : public ImageDecoderPlugin {
 public:

--- a/Userland/Libraries/LibGfx/PPMLoader.h
+++ b/Userland/Libraries/LibGfx/PPMLoader.h
@@ -21,26 +21,7 @@ struct PPM {
 };
 
 using PPMLoadingContext = PortableImageMapLoadingContext<PPM>;
+using PPMImageDecoderPlugin = PortableImageDecoderPlugin<PPMLoadingContext>;
 
-class PPMImageDecoderPlugin final : public ImageDecoderPlugin {
-public:
-    PPMImageDecoderPlugin(const u8*, size_t);
-    virtual ~PPMImageDecoderPlugin() override;
-
-    virtual IntSize size() override;
-
-    virtual void set_volatile() override;
-    [[nodiscard]] virtual bool set_nonvolatile(bool& was_purged) override;
-
-    virtual bool sniff() override;
-
-    virtual bool is_animated() override;
-    virtual size_t loop_count() override;
-    virtual size_t frame_count() override;
-    virtual ErrorOr<ImageFrameDescriptor> frame(size_t index) override;
-
-private:
-    OwnPtr<PPMLoadingContext> m_context;
-};
-
+bool read_image_data(PPMLoadingContext& context, Streamer& streamer);
 }

--- a/Userland/Libraries/LibGfx/PortableImageMapLoader.h
+++ b/Userland/Libraries/LibGfx/PortableImageMapLoader.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020, Hüseyin ASLITÜRK <asliturk@hotmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <AK/StringView.h>
+#include <AK/Types.h>
+#include <LibGfx/Bitmap.h>
+
+namespace Gfx {
+
+template<class TFormatDetails>
+struct PortableImageMapLoadingContext {
+    using FormatDetails = TFormatDetails;
+
+    enum class Type {
+        Unknown,
+        ASCII,
+        RAWBITS
+    };
+
+    enum class State {
+        NotDecoded = 0,
+        Error,
+        MagicNumber,
+        Width,
+        Height,
+        Maxval,
+        Bitmap,
+        Decoded
+    };
+
+    Type type { Type::Unknown };
+    State state { State::NotDecoded };
+    u8 const* data { nullptr };
+    size_t data_size { 0 };
+    size_t width { 0 };
+    size_t height { 0 };
+    FormatDetails format_details {};
+    RefPtr<Gfx::Bitmap> bitmap;
+};
+
+}


### PR DESCRIPTION
Much of the code in PBM, PGM, and PPM image loaders is common. The
contexts are nearly identical. Instead of writing multiple contexts,
write 1 with a template argument to pass in the details of the given
format.