### PR TITLE
LibCore+Utilities: Add various options to `install`

### DIFF
--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -38,6 +38,7 @@ public:
     static bool exists(String const& filename);
     static ErrorOr<size_t> size(String const& filename);
     static bool ensure_parent_directories(String const& path);
+    static bool ensure_directories(String const& path);
     static String current_working_directory();
     static String absolute_path(String const& path);
 

--- a/Userland/Utilities/install.cpp
+++ b/Userland/Utilities/install.cpp
@@ -19,6 +19,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     StringView destination;
 
     Core::ArgsParser args_parser;
+    args_parser.add_ignored(nullptr, 'c'); // "copy files" is the default, no contradicting options exist.
     args_parser.add_option(create_leading_dest_components, "Create leading components of the destination path", nullptr, 'D');
     args_parser.add_positional_argument(source, "Source path", "source");
     args_parser.add_positional_argument(destination, "Destination path", "destination");

--- a/Userland/Utilities/install.cpp
+++ b/Userland/Utilities/install.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/LexicalPath.h>
+#include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
@@ -15,24 +16,35 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath wpath cpath fattr"));
 
     bool create_leading_dest_components = false;
-    StringView source;
+    Vector<StringView> sources;
     StringView destination;
 
     Core::ArgsParser args_parser;
     args_parser.add_ignored(nullptr, 'c'); // "copy files" is the default, no contradicting options exist.
     args_parser.add_option(create_leading_dest_components, "Create leading components of the destination path", nullptr, 'D');
-    args_parser.add_positional_argument(source, "Source path", "source");
+    args_parser.add_positional_argument(sources, "Source path", "source");
     args_parser.add_positional_argument(destination, "Destination path", "destination");
     args_parser.parse(arguments);
 
+    String destination_dir = (sources.size() > 1 ? String { destination } : LexicalPath::dirname(destination));
+
     if (create_leading_dest_components) {
-        String destination_absolute = Core::File::absolute_path(destination);
-        Core::File::ensure_parent_directories(destination_absolute);
+        String destination_dir_absolute = Core::File::absolute_path(destination_dir);
+        Core::File::ensure_directories(destination_dir_absolute);
     }
 
-    TRY(Core::File::copy_file_or_directory(destination, source, Core::File::RecursionMode::Allowed,
-        Core::File::LinkMode::Disallowed, Core::File::AddDuplicateFileMarker::No,
-        Core::File::PreserveMode::Nothing));
+    for (auto const& source : sources) {
+        String final_destination;
+        if (sources.size() > 1) {
+            final_destination = LexicalPath(destination).append(LexicalPath::basename(source)).string();
+        } else {
+            final_destination = destination;
+        }
+
+        TRY(Core::File::copy_file_or_directory(final_destination, source, Core::File::RecursionMode::Allowed,
+            Core::File::LinkMode::Disallowed, Core::File::AddDuplicateFileMarker::No,
+            Core::File::PreserveMode::Nothing));
+    }
 
     return 0;
 }

--- a/Userland/Utilities/install.cpp
+++ b/Userland/Utilities/install.cpp
@@ -8,6 +8,7 @@
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/File.h>
+#include <LibCore/FilePermissionsMask.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 
@@ -16,15 +17,19 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::pledge("stdio rpath wpath cpath fattr"));
 
     bool create_leading_dest_components = false;
+    StringView mode = "0755"sv;
     Vector<StringView> sources;
     StringView destination;
 
     Core::ArgsParser args_parser;
     args_parser.add_ignored(nullptr, 'c'); // "copy files" is the default, no contradicting options exist.
     args_parser.add_option(create_leading_dest_components, "Create leading components of the destination path", nullptr, 'D');
+    args_parser.add_option(mode, "Permissions to set (instead of 0755)", "mode", 'm', "mode");
     args_parser.add_positional_argument(sources, "Source path", "source");
     args_parser.add_positional_argument(destination, "Destination path", "destination");
     args_parser.parse(arguments);
+
+    auto permission_mask = TRY(Core::FilePermissionsMask::parse(mode));
 
     String destination_dir = (sources.size() > 1 ? String { destination } : LexicalPath::dirname(destination));
 
@@ -44,6 +49,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         TRY(Core::File::copy_file_or_directory(final_destination, source, Core::File::RecursionMode::Allowed,
             Core::File::LinkMode::Disallowed, Core::File::AddDuplicateFileMarker::No,
             Core::File::PreserveMode::Nothing));
+
+        auto current_access = TRY(Core::System::stat(final_destination));
+        TRY(Core::System::chmod(final_destination, permission_mask.apply(current_access.st_mode)));
     }
 
     return 0;


### PR DESCRIPTION
The `-c` option itself is quite useless, as it implies default behavior and it has no contradicting options. However, autoconf uses it anyways to check if the provided `install` utility is "BSD-compatible".

Additionally included is the `-m` option for setting file permissions and support for multiple source files.

This allows the `binutils` configure script to get a bit further before failing.