### PR TITLE
Revert "Kernel: Don't override FramebufferDevice's memory regions"

### DIFF
--- a/Kernel/Graphics/FramebufferDevice.h
+++ b/Kernel/Graphics/FramebufferDevice.h
@@ -67,7 +67,6 @@ private:
 
     bool m_graphical_writes_enabled { true };
     bool m_write_combine { true };
-    bool m_initialized { false };
 
     RefPtr<Memory::AnonymousVMObject> m_userspace_real_framebuffer_vmobject;
     Memory::Region* m_userspace_framebuffer_region { nullptr };


### PR DESCRIPTION
This reverts commit 85ba70d. 
Reverts SerenityOS/serenity#12587

It broke changing resolutions, undoing this change until we get a fix. 
Fixes: #12970

