### PR TITLE
LibC+LibCore: Actually apply DST rules to the system time / tzname

### DIFF
--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -146,7 +146,7 @@ static time_t tm_to_time(struct tm* tm, long timezone_adjust_seconds)
 time_t mktime(struct tm* tm)
 {
     tzset();
-    return tm_to_time(tm, timezone);
+    return tm_to_time(tm, daylight ? altzone : timezone);
 }
 
 struct tm* localtime(const time_t* t)
@@ -162,7 +162,7 @@ struct tm* localtime_r(const time_t* t, struct tm* tm)
     if (!t)
         return nullptr;
 
-    time_to_tm(tm, *t - timezone);
+    time_to_tm(tm, *t - (daylight ? altzone : timezone));
     return tm;
 }
 

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -106,7 +106,9 @@ String DateTime::to_string(StringView format) const
     const int format_len = format.length();
 
     auto format_time_zone_offset = [&](bool with_separator) {
-#ifndef __FreeBSD__
+#if defined(__serenity__)
+        auto offset_seconds = daylight ? -altzone : -timezone;
+#elif !defined(__FreeBSD__)
         auto offset_seconds = -timezone;
 #else
         auto offset_seconds = 0;
@@ -251,7 +253,7 @@ String DateTime::to_string(StringView format) const
                 format_time_zone_offset(true);
                 break;
             case 'Z':
-                builder.append(tzname[0]);
+                builder.append(tzname[daylight]);
                 break;
             case '%':
                 builder.append('%');


### PR DESCRIPTION
Let's just pretend this always worked :)

Before:
![before](https://user-images.githubusercontent.com/5600524/158061978-da1c5a93-beb8-482c-96d6-ea1232558722.png)

After:
![after](https://user-images.githubusercontent.com/5600524/158061983-0ab7fbbe-5c0e-4a21-931d-4b3a6551e9b5.png)

