### PR TITLE
HexEditor: Improve user experience and fix minor bugs

### DIFF
--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -93,9 +93,8 @@ void HexEditor::fill_selection(u8 fill_byte)
     if (!has_selection())
         return;
 
-    for (size_t i = m_selection_start; i <= m_selection_end; i++) {
+    for (size_t i = m_selection_start; i < m_selection_end; i++)
         m_document->set(i, fill_byte);
-    }
 
     update();
     did_change();

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -185,12 +185,12 @@ bool HexEditor::copy_selected_hex_to_clipboard_as_c_code()
     output_string_builder.append("    ");
     for (size_t i = m_selection_start, j = 1; i < m_selection_end; i++, j++) {
         output_string_builder.appendff("{:#02X}", m_document->get(i).value);
-        if (i != m_selection_end)
+        if (i >= m_selection_end - 1)
+            continue;
+        if ((j % 12) == 0)
+            output_string_builder.append(",\n    ");
+        else
             output_string_builder.append(", ");
-        if ((j % 12) == 0) {
-            output_string_builder.append("\n");
-            output_string_builder.append("    ");
-        }
     }
     output_string_builder.append("\n};\n");
 

--- a/Userland/Applications/HexEditor/HexEditor.cpp
+++ b/Userland/Applications/HexEditor/HexEditor.cpp
@@ -377,8 +377,17 @@ void HexEditor::keydown_event(GUI::KeyEvent& event)
 {
     dbgln_if(HEX_DEBUG, "HexEditor::keydown_event key={}", static_cast<u8>(event.key()));
 
-    auto update_cursor_on_change = [&]() {
-        m_selection_start = m_selection_end = m_position;
+    auto move_and_update_cursor_by = [&](i64 cursor_location_change) {
+        size_t new_position = m_position + cursor_location_change;
+        if (event.modifiers() & Mod_Shift) {
+            size_t selection_pivot = m_position == m_selection_end ? m_selection_start : m_selection_end;
+            m_position = new_position;
+            m_selection_start = selection_pivot;
+            m_selection_end = m_position;
+            if (m_selection_start > m_selection_end)
+                swap(m_selection_start, m_selection_end);
+        } else
+            m_selection_start = m_selection_end = m_position = new_position;
         m_cursor_at_low_nibble = false;
         reset_cursor_blink_state();
         scroll_position_into_view(m_position);
@@ -386,64 +395,47 @@ void HexEditor::keydown_event(GUI::KeyEvent& event)
         update_status();
     };
 
-    auto advance_cursor_backwards = [this, update_cursor_on_change](size_t cursor_location_change) -> void {
-        m_position -= cursor_location_change;
-        update_cursor_on_change();
-    };
-
-    auto advance_cursor_forward = [this, update_cursor_on_change](size_t cursor_location_change) -> void {
-        m_position += cursor_location_change;
-        update_cursor_on_change();
-    };
-
     if (event.key() == KeyCode::Key_Up) {
-        if (m_position >= bytes_per_row()) {
-            advance_cursor_backwards(bytes_per_row());
-        }
+        if (m_position >= bytes_per_row())
+            move_and_update_cursor_by(-bytes_per_row());
         return;
     }
 
     if (event.key() == KeyCode::Key_Down) {
-        if (m_position + bytes_per_row() < m_document->size()) {
-            advance_cursor_forward(bytes_per_row());
-        }
+        if (m_position + bytes_per_row() < m_document->size())
+            move_and_update_cursor_by(bytes_per_row());
         return;
     }
 
     if (event.key() == KeyCode::Key_Left) {
-        if (m_position >= 1) {
-            advance_cursor_backwards(1);
-        }
+        if (m_position >= 1)
+            move_and_update_cursor_by(-1);
         return;
     }
 
     if (event.key() == KeyCode::Key_Right) {
-        if (m_position + 1 < m_document->size()) {
-            advance_cursor_forward(1);
-        }
+        if (m_position + 1 < m_document->size())
+            move_and_update_cursor_by(1);
         return;
     }
 
     if (event.key() == KeyCode::Key_Backspace) {
-        if (m_position > 0) {
-            advance_cursor_backwards(1);
-        }
+        if (m_position > 0)
+            move_and_update_cursor_by(-1);
         return;
     }
 
     if (event.key() == KeyCode::Key_PageUp) {
         auto cursor_location_change = min(bytes_per_row() * visible_content_rect().height(), m_position);
-        if (cursor_location_change > 0) {
-            advance_cursor_backwards(cursor_location_change);
-        }
+        if (cursor_location_change > 0)
+            move_and_update_cursor_by(-cursor_location_change);
         return;
     }
 
     if (event.key() == KeyCode::Key_PageDown) {
         auto cursor_location_change = min(bytes_per_row() * visible_content_rect().height(), m_document->size() - m_position);
-        if (cursor_location_change > 0) {
-            advance_cursor_forward(cursor_location_change);
-        }
+        if (cursor_location_change > 0)
+            move_and_update_cursor_by(cursor_location_change);
         return;
     }
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -190,6 +190,9 @@ HexEditorWidget::HexEditorWidget()
     m_toolbar->add_action(*m_find_action);
     m_toolbar->add_action(*m_goto_offset_action);
 
+    m_statusbar->segment(0).set_clickable(true);
+    m_statusbar->segment(0).set_action(*m_goto_offset_action);
+
     m_editor->set_focus(true);
 }
 

--- a/Userland/Applications/HexEditor/HexEditorWidget.h
+++ b/Userland/Applications/HexEditor/HexEditorWidget.h
@@ -55,6 +55,11 @@ private:
     RefPtr<GUI::Action> m_layout_toolbar_action;
     RefPtr<GUI::Action> m_layout_search_results_action;
 
+    RefPtr<GUI::Action> m_copy_hex_action;
+    RefPtr<GUI::Action> m_copy_text_action;
+    RefPtr<GUI::Action> m_copy_as_c_code_action;
+    RefPtr<GUI::Action> m_fill_selection_action;
+
     GUI::ActionGroup m_bytes_per_row_actions;
 
     RefPtr<GUI::Statusbar> m_statusbar;


### PR DESCRIPTION
Fixes to minor bugs:
- HexEditor: Copy as C code doesn't add trailing spaces
- HexEditor: Fill selection sets only bytes inside selection

User experience features
- HexEditor: Offset segment in status bar opens goto offset dialog
- HexEditor: Disable selection dependent actions when no selection is made
- HexEditor: Selection follows cursor while pressing shift
