### PR TITLE
Spreadsheet: Set tab functions for every tab on setup and other cleanups

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -9,6 +9,7 @@
 #include "SpreadsheetView.h"
 #include "Workbook.h"
 #include <AK/NonnullRefPtrVector.h>
+#include <LibGUI/TabWidget.h>
 #include <LibGUI/Widget.h>
 
 namespace Spreadsheet {
@@ -26,18 +27,19 @@ public:
     void add_sheet(NonnullRefPtr<Sheet>&&);
 
     const String& current_filename() const { return m_workbook->current_filename(); }
-    Sheet* current_worksheet_if_available() { return m_selected_view ? m_selected_view->sheet_if_available() : nullptr; }
+    SpreadsheetView* current_view() { return static_cast<SpreadsheetView*>(m_tab_widget->active_widget()); }
+    Sheet* current_worksheet_if_available() { return current_view() ? current_view()->sheet_if_available() : nullptr; }
     void update_window_title();
 
     Workbook& workbook() { return *m_workbook; }
     const Workbook& workbook() const { return *m_workbook; }
 
-    const GUI::ModelIndex* current_selection_cursor() const
+    const GUI::ModelIndex* current_selection_cursor()
     {
-        if (!m_selected_view)
+        if (!current_view())
             return nullptr;
 
-        return m_selected_view->cursor();
+        return current_view()->cursor();
     }
 
     void initialize_menubar(GUI::Window&);
@@ -55,7 +57,6 @@ private:
 
     void try_generate_tip_for_input_expression(StringView source, size_t offset);
 
-    SpreadsheetView* m_selected_view { nullptr };
     RefPtr<GUI::Label> m_current_cell_label;
     RefPtr<GUI::TextEditor> m_cell_value_editor;
     RefPtr<GUI::Window> m_inline_documentation_window;


### PR DESCRIPTION
- **Spreadsheet: Set tab functions for every tab on setup**

  Previously, we were setting tab actions only for the active tab on a tab change, and the same actions for the previous tab were removed.

  Unfortunately, this also happened when making a new tab, which meant that you could trick the cell editor to jump to the new sheet and start writing there:

  https://user-images.githubusercontent.com/16520278/158072461-4b4d4409-cdf4-4628-8e9f-d2be2cc22bb3.mp4

  To fix this, every view will always have `on_selection_changed` and `on_selection_dropped` assigned. I haven’t seen much difference in the memory usage, so I guess it’ll be fine :)

- **Spreadsheet: Get the active sheet via TabWidget::active_widget()**

  We don’t have to track the active widget ourselves anymore — less possible boogs!

- **Spreadsheet: Move tab widget actions to the main widget constructor**

  There’s no need to reassign these functions when we add a new tab. Nothing changes inside them and they don’t depend on anything in the function.