### PR TITLE
LibWeb: Use inline script tag source line as javascript line offset

### DIFF
--- a/Userland/Libraries/LibJS/Script.cpp
+++ b/Userland/Libraries/LibJS/Script.cpp
@@ -13,10 +13,10 @@
 namespace JS {
 
 // 16.1.5 ParseScript ( sourceText, realm, hostDefined ), https://tc39.es/ecma262/#sec-parse-script
-Result<NonnullRefPtr<Script>, Vector<Parser::Error>> Script::parse(StringView source_text, Realm& realm, StringView filename, HostDefined* host_defined)
+Result<NonnullRefPtr<Script>, Vector<Parser::Error>> Script::parse(StringView source_text, Realm& realm, StringView filename, HostDefined* host_defined, size_t line_number_offset)
 {
     // 1. Let body be ParseText(sourceText, Script).
-    auto parser = Parser(Lexer(source_text, filename));
+    auto parser = Parser(Lexer(source_text, filename, line_number_offset));
     auto body = parser.parse_program();
 
     // 2. If body is a List of errors, return body.

--- a/Userland/Libraries/LibJS/Script.h
+++ b/Userland/Libraries/LibJS/Script.h
@@ -25,7 +25,7 @@ public:
     };
 
     ~Script();
-    static Result<NonnullRefPtr<Script>, Vector<Parser::Error>> parse(StringView source_text, Realm&, StringView filename = {}, HostDefined* = nullptr);
+    static Result<NonnullRefPtr<Script>, Vector<Parser::Error>> parse(StringView source_text, Realm&, StringView filename = {}, HostDefined* = nullptr, size_t line_number_offset = 1);
 
     Realm& realm() { return *m_realm.cell(); }
     Program const& parse_node() const { return *m_parse_node; }

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.cpp
@@ -329,7 +329,7 @@ void HTMLScriptElement::prepare_script()
             // 1. Let script be the result of creating a classic script using source text, settings object, base URL, and options.
 
             // FIXME: Pass settings, base URL and options.
-            auto script = ClassicScript::create(m_document->url().to_string(), source_text, document().relevant_settings_object(), AK::URL());
+            auto script = ClassicScript::create(m_document->url().to_string(), source_text, document().relevant_settings_object(), AK::URL(), m_source_line_number);
 
             // 2. Set the script's script to script.
             m_script = script;

--- a/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLScriptElement.h
@@ -40,6 +40,8 @@ public:
         return type.is_one_of("classic", "module");
     }
 
+    void set_source_line_number(Badge<HTMLParser>, size_t source_line_number) { m_source_line_number = source_line_number; }
+
 private:
     void prepare_script();
     void script_became_ready();
@@ -66,6 +68,8 @@ private:
     RefPtr<Script> m_script;
 
     Optional<DOM::DocumentLoadEventDelayer> m_document_load_event_delayer;
+
+    size_t m_source_line_number { 1 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -790,6 +790,7 @@ void HTMLParser::handle_in_head(HTMLToken& token)
         auto& script_element = verify_cast<HTMLScriptElement>(*element);
         script_element.set_parser_document({}, document());
         script_element.set_non_blocking({}, false);
+        script_element.set_source_line_number({}, token.start_position().line + 1); // FIXME: This +1 is incorrect for script tags whose script does not start on a new line
 
         if (m_parsing_fragment) {
             script_element.set_already_started({}, true);

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.cpp
@@ -16,7 +16,7 @@
 namespace Web::HTML {
 
 // https://html.spec.whatwg.org/multipage/webappapis.html#creating-a-classic-script
-NonnullRefPtr<ClassicScript> ClassicScript::create(String filename, StringView source, EnvironmentSettingsObject& environment_settings_object, AK::URL base_url, MutedErrors muted_errors)
+NonnullRefPtr<ClassicScript> ClassicScript::create(String filename, StringView source, EnvironmentSettingsObject& environment_settings_object, AK::URL base_url, size_t source_line_number, MutedErrors muted_errors)
 {
     // 1. If muted errors was not provided, let it be false. (NOTE: This is taken care of by the default argument.)
 
@@ -43,7 +43,7 @@ NonnullRefPtr<ClassicScript> ClassicScript::create(String filename, StringView s
 
     // 10. Let result be ParseScript(source, settings's Realm, script).
     auto parse_timer = Core::ElapsedTimer::start_new();
-    auto result = JS::Script::parse(source, environment_settings_object.realm(), script->filename(), script.ptr());
+    auto result = JS::Script::parse(source, environment_settings_object.realm(), script->filename(), script.ptr(), source_line_number);
     dbgln_if(HTML_SCRIPT_DEBUG, "ClassicScript: Parsed {} in {}ms", script->filename(), parse_timer.elapsed());
 
     // 11. If result is a list of errors, then:

--- a/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
+++ b/Userland/Libraries/LibWeb/HTML/Scripting/ClassicScript.h
@@ -23,7 +23,7 @@ public:
         No,
         Yes,
     };
-    static NonnullRefPtr<ClassicScript> create(String filename, StringView source, EnvironmentSettingsObject&, AK::URL base_url, MutedErrors = MutedErrors::No);
+    static NonnullRefPtr<ClassicScript> create(String filename, StringView source, EnvironmentSettingsObject&, AK::URL base_url, size_t source_line_number = 1, MutedErrors = MutedErrors::No);
 
     JS::Script* script_record() { return m_script_record; }
     JS::Script const* script_record() const { return m_script_record; }


### PR DESCRIPTION
This makes JS exception line numbers meaningful for inline script tags.