### PR TITLE
Libraries: Use default constructors/destructors in LibJS

### DIFF
--- a/Userland/Libraries/LibJS/AST.h
+++ b/Userland/Libraries/LibJS/AST.h
@@ -46,7 +46,7 @@ create_ast_node(SourceRange range, Args&&... args)
 
 class ASTNode : public RefCounted<ASTNode> {
 public:
-    virtual ~ASTNode() { }
+    virtual ~ASTNode() = default;
     virtual Completion execute(Interpreter&, GlobalObject&) const = 0;
     virtual Bytecode::CodeGenerationErrorOr<void> generate_bytecode(Bytecode::Generator&) const;
     virtual void dump(int indent) const;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -19,10 +19,6 @@ Generator::Generator()
 {
 }
 
-Generator::~Generator()
-{
-}
-
 CodeGenerationErrorOr<NonnullOwnPtr<Executable>> Generator::generate(ASTNode const& node, FunctionKind enclosing_function_kind)
 {
     Generator generator;

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -203,7 +203,7 @@ public:
 
 private:
     Generator();
-    ~Generator();
+    ~Generator() = default;
 
     void grow(size_t);
     void* next_slot();

--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.cpp
@@ -17,10 +17,6 @@
 
 namespace JS {
 
-BlockAllocator::BlockAllocator()
-{
-}
-
 BlockAllocator::~BlockAllocator()
 {
     for (auto* block : m_blocks) {

--- a/Userland/Libraries/LibJS/Heap/BlockAllocator.h
+++ b/Userland/Libraries/LibJS/Heap/BlockAllocator.h
@@ -13,7 +13,7 @@ namespace JS {
 
 class BlockAllocator {
 public:
-    BlockAllocator();
+    BlockAllocator() = default;
     ~BlockAllocator();
 
     void* allocate_block(char const* name);

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -19,7 +19,7 @@ class Cell {
 
 public:
     virtual void initialize(GlobalObject&) { }
-    virtual ~Cell() { }
+    virtual ~Cell() = default;
 
     bool is_marked() const { return m_mark; }
     void set_marked(bool b) { m_mark = b; }
@@ -55,7 +55,7 @@ public:
     VM& vm() const;
 
 protected:
-    Cell() { }
+    Cell() = default;
 
 private:
     bool m_mark : 1 { false };

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -173,7 +173,7 @@ __attribute__((no_sanitize("address"))) void Heap::gather_conservative_roots(Has
 
 class MarkingVisitor final : public Cell::Visitor {
 public:
-    MarkingVisitor() { }
+    MarkingVisitor() = default;
 
     virtual void visit_impl(Cell& cell) override
     {

--- a/Userland/Libraries/LibJS/Interpreter.cpp
+++ b/Userland/Libraries/LibJS/Interpreter.cpp
@@ -36,10 +36,6 @@ Interpreter::Interpreter(VM& vm)
 {
 }
 
-Interpreter::~Interpreter()
-{
-}
-
 // 16.1.6 ScriptEvaluation ( scriptRecord ), https://tc39.es/ecma262/#sec-runtime-semantics-scriptevaluation
 ThrowCompletionOr<Value> Interpreter::run(Script& script_record)
 {

--- a/Userland/Libraries/LibJS/Interpreter.h
+++ b/Userland/Libraries/LibJS/Interpreter.h
@@ -101,7 +101,7 @@ public:
 
     static NonnullOwnPtr<Interpreter> create_with_existing_realm(Realm&);
 
-    ~Interpreter();
+    ~Interpreter() = default;
 
     ThrowCompletionOr<Value> run(Script&);
     ThrowCompletionOr<Value> run(SourceTextModule&);

--- a/Userland/Libraries/LibJS/Module.cpp
+++ b/Userland/Libraries/LibJS/Module.cpp
@@ -17,10 +17,6 @@ Module::Module(Realm& realm, String filename)
 {
 }
 
-Module::~Module()
-{
-}
-
 // 16.2.1.5.1.1 InnerModuleLinking ( module, stack, index ), https://tc39.es/ecma262/#sec-InnerModuleLinking
 ThrowCompletionOr<u32> Module::inner_module_linking(VM& vm, Vector<Module*>&, u32 index)
 {

--- a/Userland/Libraries/LibJS/Module.h
+++ b/Userland/Libraries/LibJS/Module.h
@@ -59,7 +59,7 @@ class Module
     : public RefCounted<Module>
     , public Weakable<Module> {
 public:
-    virtual ~Module();
+    virtual ~Module() = default;
 
     Realm& realm() { return *m_realm.cell(); }
     Realm const& realm() const { return *m_realm.cell(); }

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.cpp
@@ -23,10 +23,6 @@ void ArgumentsObject::initialize(GlobalObject& global_object)
     m_parameter_map = Object::create(global_object, nullptr);
 }
 
-ArgumentsObject::~ArgumentsObject()
-{
-}
-
 void ArgumentsObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ArgumentsObject.h
@@ -19,7 +19,7 @@ public:
     ArgumentsObject(GlobalObject&, Environment&);
 
     virtual void initialize(GlobalObject&) override;
-    virtual ~ArgumentsObject() override;
+    virtual ~ArgumentsObject() override = default;
 
     Environment& environment() { return m_environment; }
 

--- a/Userland/Libraries/LibJS/Runtime/Array.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Array.cpp
@@ -52,10 +52,6 @@ Array::Array(Object& prototype)
 {
 }
 
-Array::~Array()
-{
-}
-
 // 10.4.2.4 ArraySetLength ( A, Desc ), https://tc39.es/ecma262/#sec-arraysetlength
 ThrowCompletionOr<bool> Array::set_length(PropertyDescriptor const& property_descriptor)
 {

--- a/Userland/Libraries/LibJS/Runtime/Array.h
+++ b/Userland/Libraries/LibJS/Runtime/Array.h
@@ -35,7 +35,7 @@ public:
     }
 
     explicit Array(Object& prototype);
-    virtual ~Array() override;
+    virtual ~Array() override = default;
 
     virtual ThrowCompletionOr<Optional<PropertyDescriptor>> internal_get_own_property(PropertyKey const&) const override;
     virtual ThrowCompletionOr<bool> internal_define_own_property(PropertyKey const&, PropertyDescriptor const&) override;

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -44,10 +44,6 @@ ArrayBuffer::ArrayBuffer(ByteBuffer* buffer, Object& prototype)
 {
 }
 
-ArrayBuffer::~ArrayBuffer()
-{
-}
-
 // 1.1.5 IsResizableArrayBuffer ( arrayBuffer ), https://tc39.es/proposal-resizablearraybuffer/#sec-isresizablearraybuffer
 bool ArrayBuffer::is_resizable_array_buffer() const
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -31,7 +31,7 @@ public:
 
     ArrayBuffer(ByteBuffer buffer, Object& prototype);
     ArrayBuffer(ByteBuffer* buffer, Object& prototype);
-    virtual ~ArrayBuffer() override;
+    virtual ~ArrayBuffer() override = default;
 
     size_t byte_length() const { return buffer_impl().size(); }
     size_t max_byte_length() const { return m_max_byte_length.value(); } // Will VERIFY() that it has value

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.cpp
@@ -36,10 +36,6 @@ void ArrayBufferConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-ArrayBufferConstructor::~ArrayBufferConstructor()
-{
-}
-
 // 25.1.3.1 ArrayBuffer ( length ), https://tc39.es/ecma262/#sec-arraybuffer-length
 ThrowCompletionOr<Value> ArrayBufferConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferConstructor.h
@@ -16,7 +16,7 @@ class ArrayBufferConstructor final : public NativeFunction {
 public:
     explicit ArrayBufferConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ArrayBufferConstructor() override;
+    virtual ~ArrayBufferConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.cpp
@@ -35,10 +35,6 @@ void ArrayBufferPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, vm.names.ArrayBuffer.as_string()), Attribute::Configurable);
 }
 
-ArrayBufferPrototype::~ArrayBufferPrototype()
-{
-}
-
 // 25.1.5.3 ArrayBuffer.prototype.slice ( start, end ), https://tc39.es/ecma262/#sec-arraybuffer.prototype.slice
 JS_DEFINE_NATIVE_FUNCTION(ArrayBufferPrototype::slice)
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBufferPrototype.h
@@ -17,7 +17,7 @@ class ArrayBufferPrototype final : public PrototypeObject<ArrayBufferPrototype, 
 public:
     explicit ArrayBufferPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ArrayBufferPrototype() override;
+    virtual ~ArrayBufferPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(slice);

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.cpp
@@ -21,10 +21,6 @@ ArrayConstructor::ArrayConstructor(GlobalObject& global_object)
 {
 }
 
-ArrayConstructor::~ArrayConstructor()
-{
-}
-
 void ArrayConstructor::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();

--- a/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayConstructor.h
@@ -16,7 +16,7 @@ class ArrayConstructor final : public NativeFunction {
 public:
     explicit ArrayConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ArrayConstructor() override;
+    virtual ~ArrayConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/ArrayIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIterator.cpp
@@ -21,10 +21,6 @@ ArrayIterator::ArrayIterator(Value array, Object::PropertyKind iteration_kind, O
 {
 }
 
-ArrayIterator::~ArrayIterator()
-{
-}
-
 void ArrayIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/ArrayIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIterator.h
@@ -17,7 +17,7 @@ public:
     static ArrayIterator* create(GlobalObject&, Value array, Object::PropertyKind iteration_kind);
 
     explicit ArrayIterator(Value array, Object::PropertyKind iteration_kind, Object& prototype);
-    virtual ~ArrayIterator() override;
+    virtual ~ArrayIterator() override = default;
 
     Value array() const { return m_array; }
     Object::PropertyKind iteration_kind() const { return m_iteration_kind; }

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.cpp
@@ -30,10 +30,6 @@ void ArrayIteratorPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Array Iterator"), Attribute::Configurable);
 }
 
-ArrayIteratorPrototype::~ArrayIteratorPrototype()
-{
-}
-
 // 23.1.5.2.1 %ArrayIteratorPrototype%.next ( ), https://tc39.es/ecma262/#sec-%arrayiteratorprototype%.next
 // FIXME: This seems to be CreateArrayIterator (https://tc39.es/ecma262/#sec-createarrayiterator) instead of %ArrayIteratorPrototype%.next.
 JS_DEFINE_NATIVE_FUNCTION(ArrayIteratorPrototype::next)

--- a/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayIteratorPrototype.h
@@ -17,7 +17,7 @@ class ArrayIteratorPrototype final : public PrototypeObject<ArrayIteratorPrototy
 public:
     ArrayIteratorPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ArrayIteratorPrototype() override;
+    virtual ~ArrayIteratorPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(next);

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -105,10 +105,6 @@ void ArrayPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_unscopables(), unscopable_list, Attribute::Configurable);
 }
 
-ArrayPrototype::~ArrayPrototype()
-{
-}
-
 // 10.4.2.3 ArraySpeciesCreate ( originalArray, length ), https://tc39.es/ecma262/#sec-arrayspeciescreate
 static ThrowCompletionOr<Object*> array_species_create(GlobalObject& global_object, Object& original_array, size_t length)
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.h
@@ -17,7 +17,7 @@ class ArrayPrototype final : public Array {
 public:
     ArrayPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ArrayPrototype() override;
+    virtual ~ArrayPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(filter);

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.cpp
@@ -60,10 +60,6 @@ ThrowCompletionOr<Value> AsyncFunctionDriverWrapper::react_to_async_task_complet
     return promise->perform_then(m_on_fulfillment, m_on_rejection, PromiseCapability { promise, m_on_fulfillment, m_on_rejection });
 }
 
-AsyncFunctionDriverWrapper::~AsyncFunctionDriverWrapper()
-{
-}
-
 void AsyncFunctionDriverWrapper::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
+++ b/Userland/Libraries/LibJS/Runtime/AsyncFunctionDriverWrapper.h
@@ -21,7 +21,7 @@ public:
     static ThrowCompletionOr<Value> create(GlobalObject&, GeneratorObject*);
     explicit AsyncFunctionDriverWrapper(GlobalObject&, GeneratorObject*);
 
-    virtual ~AsyncFunctionDriverWrapper() override;
+    virtual ~AsyncFunctionDriverWrapper() override = default;
     void visit_edges(Cell::Visitor&) override;
 
     ThrowCompletionOr<Value> react_to_async_task_completion(VM&, GlobalObject&, Value, bool is_successful);

--- a/Userland/Libraries/LibJS/Runtime/BigInt.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigInt.cpp
@@ -17,10 +17,6 @@ BigInt::BigInt(Crypto::SignedBigInteger big_integer)
     VERIFY(!m_big_integer.is_invalid());
 }
 
-BigInt::~BigInt()
-{
-}
-
 BigInt* js_bigint(Heap& heap, Crypto::SignedBigInteger big_integer)
 {
     return heap.allocate_without_global_object<BigInt>(move(big_integer));

--- a/Userland/Libraries/LibJS/Runtime/BigInt.h
+++ b/Userland/Libraries/LibJS/Runtime/BigInt.h
@@ -14,7 +14,7 @@ namespace JS {
 class BigInt final : public Cell {
 public:
     explicit BigInt(Crypto::SignedBigInteger);
-    virtual ~BigInt();
+    virtual ~BigInt() override = default;
 
     const Crypto::SignedBigInteger& big_integer() const { return m_big_integer; }
     const String to_string() const { return String::formatted("{}n", m_big_integer.to_base(10)); }

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.cpp
@@ -37,10 +37,6 @@ void BigIntConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-BigIntConstructor::~BigIntConstructor()
-{
-}
-
 // 21.2.1.1 BigInt ( value ), https://tc39.es/ecma262/#sec-bigint-constructor-number-value
 ThrowCompletionOr<Value> BigIntConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/BigIntConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntConstructor.h
@@ -16,7 +16,7 @@ class BigIntConstructor final : public NativeFunction {
 public:
     explicit BigIntConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~BigIntConstructor() override;
+    virtual ~BigIntConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/BigIntObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntObject.cpp
@@ -20,10 +20,6 @@ BigIntObject::BigIntObject(BigInt& bigint, Object& prototype)
 {
 }
 
-BigIntObject::~BigIntObject()
-{
-}
-
 void BigIntObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/BigIntObject.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntObject.h
@@ -18,7 +18,7 @@ public:
     static BigIntObject* create(GlobalObject&, BigInt&);
 
     BigIntObject(BigInt&, Object& prototype);
-    virtual ~BigIntObject();
+    virtual ~BigIntObject() override = default;
 
     BigInt const& bigint() const { return m_bigint; }
     BigInt& bigint() { return m_bigint; }

--- a/Userland/Libraries/LibJS/Runtime/BigIntPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BigIntPrototype.cpp
@@ -35,10 +35,6 @@ void BigIntPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.BigInt.as_string()), Attribute::Configurable);
 }
 
-BigIntPrototype::~BigIntPrototype()
-{
-}
-
 // thisBigIntValue ( value ), https://tc39.es/ecma262/#thisbigintvalue
 static ThrowCompletionOr<BigInt*> this_bigint_value(GlobalObject& global_object, Value value)
 {

--- a/Userland/Libraries/LibJS/Runtime/BigIntPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/BigIntPrototype.h
@@ -16,7 +16,7 @@ class BigIntPrototype final : public Object {
 public:
     explicit BigIntPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~BigIntPrototype() override;
+    virtual ~BigIntPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(to_string);

--- a/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanConstructor.cpp
@@ -27,10 +27,6 @@ void BooleanConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-BooleanConstructor::~BooleanConstructor()
-{
-}
-
 // 20.3.1.1 Boolean ( value ), https://tc39.es/ecma262/#sec-boolean-constructor-boolean-value
 ThrowCompletionOr<Value> BooleanConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/BooleanConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanConstructor.h
@@ -16,7 +16,7 @@ class BooleanConstructor final : public NativeFunction {
 public:
     explicit BooleanConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~BooleanConstructor() override;
+    virtual ~BooleanConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/BooleanObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanObject.cpp
@@ -19,9 +19,4 @@ BooleanObject::BooleanObject(bool value, Object& prototype)
     , m_value(value)
 {
 }
-
-BooleanObject::~BooleanObject()
-{
-}
-
 }

--- a/Userland/Libraries/LibJS/Runtime/BooleanObject.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanObject.h
@@ -16,7 +16,7 @@ public:
     static BooleanObject* create(GlobalObject&, bool);
 
     BooleanObject(bool, Object& prototype);
-    virtual ~BooleanObject() override;
+    virtual ~BooleanObject() override = default;
 
     bool boolean() const { return m_value; }
 

--- a/Userland/Libraries/LibJS/Runtime/BooleanPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BooleanPrototype.cpp
@@ -26,10 +26,6 @@ void BooleanPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.valueOf, value_of, 0, attr);
 }
 
-BooleanPrototype::~BooleanPrototype()
-{
-}
-
 // 20.3.3.2 Boolean.prototype.toString ( ), https://tc39.es/ecma262/#sec-boolean.prototype.tostring
 JS_DEFINE_NATIVE_FUNCTION(BooleanPrototype::to_string)
 {

--- a/Userland/Libraries/LibJS/Runtime/BooleanPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/BooleanPrototype.h
@@ -16,7 +16,7 @@ class BooleanPrototype final : public BooleanObject {
 public:
     explicit BooleanPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~BooleanPrototype() override;
+    virtual ~BooleanPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(to_string);

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.cpp
@@ -42,10 +42,6 @@ BoundFunction::BoundFunction(GlobalObject& global_object, FunctionObject& bound_
 {
 }
 
-BoundFunction::~BoundFunction()
-{
-}
-
 // 10.4.1.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-bound-function-exotic-objects-call-thisargument-argumentslist
 ThrowCompletionOr<Value> BoundFunction::internal_call([[maybe_unused]] Value this_argument, MarkedVector<Value> arguments_list)
 {

--- a/Userland/Libraries/LibJS/Runtime/BoundFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/BoundFunction.h
@@ -18,7 +18,7 @@ public:
     static ThrowCompletionOr<BoundFunction*> create(GlobalObject&, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments);
 
     BoundFunction(GlobalObject&, FunctionObject& target_function, Value bound_this, Vector<Value> bound_arguments, Object* prototype);
-    virtual ~BoundFunction();
+    virtual ~BoundFunction() override = default;
 
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
     virtual ThrowCompletionOr<Object*> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.cpp
@@ -40,10 +40,6 @@ void ConsoleObject::initialize(GlobalObject& global_object)
     define_native_function(vm.names.timeEnd, time_end, 0, attr);
 }
 
-ConsoleObject::~ConsoleObject()
-{
-}
-
 // 1.1.6. log(...data), https://console.spec.whatwg.org/#log
 JS_DEFINE_NATIVE_FUNCTION(ConsoleObject::log)
 {

--- a/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ConsoleObject.h
@@ -16,7 +16,7 @@ class ConsoleObject final : public Object {
 public:
     explicit ConsoleObject(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ConsoleObject() override;
+    virtual ~ConsoleObject() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(log);

--- a/Userland/Libraries/LibJS/Runtime/DataView.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataView.cpp
@@ -21,10 +21,6 @@ DataView::DataView(ArrayBuffer* viewed_buffer, size_t byte_length, size_t byte_o
 {
 }
 
-DataView::~DataView()
-{
-}
-
 void DataView::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/DataView.h
+++ b/Userland/Libraries/LibJS/Runtime/DataView.h
@@ -19,7 +19,7 @@ public:
     static DataView* create(GlobalObject&, ArrayBuffer*, size_t byte_length, size_t byte_offset);
 
     explicit DataView(ArrayBuffer*, size_t byte_length, size_t byte_offset, Object& prototype);
-    virtual ~DataView() override;
+    virtual ~DataView() override = default;
 
     ArrayBuffer* viewed_array_buffer() const { return m_viewed_array_buffer; }
     size_t byte_length() const { return m_byte_length; }

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.cpp
@@ -28,10 +28,6 @@ void DataViewConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-DataViewConstructor::~DataViewConstructor()
-{
-}
-
 // 25.3.2.1 DataView ( buffer [ , byteOffset [ , byteLength ] ] ), https://tc39.es/ecma262/#sec-dataview-buffer-byteoffset-bytelength
 ThrowCompletionOr<Value> DataViewConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/DataViewConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/DataViewConstructor.h
@@ -16,7 +16,7 @@ class DataViewConstructor final : public NativeFunction {
 public:
     explicit DataViewConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~DataViewConstructor() override;
+    virtual ~DataViewConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.cpp
@@ -50,10 +50,6 @@ void DataViewPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.DataView.as_string()), Attribute::Configurable);
 }
 
-DataViewPrototype::~DataViewPrototype()
-{
-}
-
 // 25.3.1.1 GetViewValue ( view, requestIndex, isLittleEndian, type ), https://tc39.es/ecma262/#sec-getviewvalue
 template<typename T>
 static ThrowCompletionOr<Value> get_view_value(GlobalObject& global_object, Value request_index, Value is_little_endian)

--- a/Userland/Libraries/LibJS/Runtime/DataViewPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DataViewPrototype.h
@@ -17,7 +17,7 @@ class DataViewPrototype final : public PrototypeObject<DataViewPrototype, DataVi
 public:
     DataViewPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~DataViewPrototype() override;
+    virtual ~DataViewPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(get_big_int_64);

--- a/Userland/Libraries/LibJS/Runtime/Date.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Date.cpp
@@ -28,10 +28,6 @@ Date::Date(double date_value, Object& prototype)
 {
 }
 
-Date::~Date()
-{
-}
-
 String Date::iso_date_string() const
 {
     int year = year_from_time(m_date_value);

--- a/Userland/Libraries/LibJS/Runtime/Date.h
+++ b/Userland/Libraries/LibJS/Runtime/Date.h
@@ -19,7 +19,7 @@ public:
     static Date* now(GlobalObject&);
 
     Date(double date_value, Object& prototype);
-    virtual ~Date() override;
+    virtual ~Date() override = default;
 
     double date_value() const { return m_date_value; }
     void set_date_value(double value) { m_date_value = value; }

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -180,10 +180,6 @@ void DateConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(7), Attribute::Configurable);
 }
 
-DateConstructor::~DateConstructor()
-{
-}
-
 // 21.4.2.1 Date ( ...values ), https://tc39.es/ecma262/#sec-date
 ThrowCompletionOr<Value> DateConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.h
@@ -16,7 +16,7 @@ class DateConstructor final : public NativeFunction {
 public:
     explicit DateConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~DateConstructor() override;
+    virtual ~DateConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -104,10 +104,6 @@ void DatePrototype::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.toGMTString, get_without_side_effects(vm.names.toUTCString), attr);
 }
 
-DatePrototype::~DatePrototype()
-{
-}
-
 // thisTimeValue ( value ), https://tc39.es/ecma262/#thistimevalue
 ThrowCompletionOr<Value> this_time_value(GlobalObject& global_object, Value value)
 {

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.h
@@ -17,7 +17,7 @@ class DatePrototype final : public PrototypeObject<DatePrototype, Date> {
 public:
     explicit DatePrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~DatePrototype() override;
+    virtual ~DatePrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(get_date);

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.cpp
@@ -37,10 +37,6 @@ DeclarativeEnvironment::DeclarativeEnvironment(Environment* parent_scope, Span<B
 {
 }
 
-DeclarativeEnvironment::~DeclarativeEnvironment()
-{
-}
-
 void DeclarativeEnvironment::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/DeclarativeEnvironment.h
@@ -32,7 +32,7 @@ public:
     DeclarativeEnvironment();
     explicit DeclarativeEnvironment(Environment* parent_scope);
     explicit DeclarativeEnvironment(Environment* parent_scope, Span<Binding const> bindings);
-    virtual ~DeclarativeEnvironment() override;
+    virtual ~DeclarativeEnvironment() override = default;
 
     virtual ThrowCompletionOr<bool> has_binding(FlyString const& name, Optional<size_t>* = nullptr) const override;
     virtual ThrowCompletionOr<void> create_mutable_binding(GlobalObject&, FlyString const& name, bool can_be_deleted) override;

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -134,10 +134,6 @@ void ECMAScriptFunctionObject::initialize(GlobalObject& global_object)
     }
 }
 
-ECMAScriptFunctionObject::~ECMAScriptFunctionObject()
-{
-}
-
 // 10.2.1 [[Call]] ( thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-ecmascript-function-objects-call-thisargument-argumentslist
 ThrowCompletionOr<Value> ECMAScriptFunctionObject::internal_call(Value this_argument, MarkedVector<Value> arguments_list)
 {

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -37,7 +37,7 @@ public:
 
     ECMAScriptFunctionObject(FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ECMAScriptFunctionObject();
+    virtual ~ECMAScriptFunctionObject() override = default;
 
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
     virtual ThrowCompletionOr<Object*> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.cpp
@@ -17,10 +17,6 @@ FinalizationRegistry::FinalizationRegistry(Realm& realm, JS::JobCallback cleanup
 {
 }
 
-FinalizationRegistry::~FinalizationRegistry()
-{
-}
-
 void FinalizationRegistry::add_finalization_record(Cell& target, Value held_value, Object* unregister_token)
 {
     VERIFY(!held_value.is_empty());

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistry.h
@@ -23,7 +23,7 @@ class FinalizationRegistry final
 
 public:
     explicit FinalizationRegistry(Realm&, JS::JobCallback, Object& prototype);
-    virtual ~FinalizationRegistry() override;
+    virtual ~FinalizationRegistry() override = default;
 
     void add_finalization_record(Cell& target, Value held_value, Object* unregister_token);
     bool remove_by_token(Object& unregister_token);

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.cpp
@@ -29,10 +29,6 @@ void FinalizationRegistryConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-FinalizationRegistryConstructor::~FinalizationRegistryConstructor()
-{
-}
-
 // 26.2.1.1 FinalizationRegistry ( cleanupCallback ), https://tc39.es/ecma262/#sec-finalization-registry-cleanup-callback
 ThrowCompletionOr<Value> FinalizationRegistryConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryConstructor.h
@@ -16,7 +16,7 @@ class FinalizationRegistryConstructor final : public NativeFunction {
 public:
     explicit FinalizationRegistryConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~FinalizationRegistryConstructor() override;
+    virtual ~FinalizationRegistryConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.cpp
@@ -28,10 +28,6 @@ void FinalizationRegistryPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.FinalizationRegistry.as_string()), Attribute::Configurable);
 }
 
-FinalizationRegistryPrototype::~FinalizationRegistryPrototype()
-{
-}
-
 // @STAGE 2@ FinalizationRegistry.prototype.cleanupSome ( [ callback ] ), https://github.com/tc39/proposal-cleanup-some/blob/master/spec/finalization-registry.html
 JS_DEFINE_NATIVE_FUNCTION(FinalizationRegistryPrototype::cleanup_some)
 {

--- a/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FinalizationRegistryPrototype.h
@@ -17,7 +17,7 @@ class FinalizationRegistryPrototype final : public PrototypeObject<FinalizationR
 public:
     FinalizationRegistryPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~FinalizationRegistryPrototype() override;
+    virtual ~FinalizationRegistryPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(cleanup_some);

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -35,10 +35,6 @@ void FunctionConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-FunctionConstructor::~FunctionConstructor()
-{
-}
-
 // 20.2.1.1.1 CreateDynamicFunction ( constructor, newTarget, kind, args ), https://tc39.es/ecma262/#sec-createdynamicfunction
 ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic_function(GlobalObject& global_object, FunctionObject& constructor, FunctionObject* new_target, FunctionKind kind, MarkedVector<Value> const& args)
 {

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.h
@@ -19,7 +19,7 @@ public:
 
     explicit FunctionConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~FunctionConstructor() override;
+    virtual ~FunctionConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.cpp
@@ -16,10 +16,6 @@ FunctionEnvironment::FunctionEnvironment(Environment* parent_scope)
 {
 }
 
-FunctionEnvironment::~FunctionEnvironment()
-{
-}
-
 void FunctionEnvironment::visit_edges(Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionEnvironment.h
@@ -23,7 +23,7 @@ public:
     };
 
     explicit FunctionEnvironment(Environment* parent_scope);
-    virtual ~FunctionEnvironment() override;
+    virtual ~FunctionEnvironment() override = default;
 
     ThisBindingStatus this_binding_status() const { return m_this_binding_status; }
     void set_this_binding_status(ThisBindingStatus status) { m_this_binding_status = status; }

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.cpp
@@ -21,10 +21,6 @@ FunctionObject::FunctionObject(Object& prototype)
 {
 }
 
-FunctionObject::~FunctionObject()
-{
-}
-
 // 10.2.9 SetFunctionName ( F, name [ , prefix ] ), https://tc39.es/ecma262/#sec-setfunctionname
 void FunctionObject::set_function_name(Variant<PropertyKey, PrivateName> const& name_arg, Optional<StringView> const& prefix)
 {

--- a/Userland/Libraries/LibJS/Runtime/FunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionObject.h
@@ -19,7 +19,7 @@ class FunctionObject : public Object {
     JS_OBJECT(Function, Object);
 
 public:
-    virtual ~FunctionObject();
+    virtual ~FunctionObject() = default;
     virtual void initialize(GlobalObject&) override { }
 
     // Table 7: Additional Essential Internal Methods of Function Objects, https://tc39.es/ecma262/#table-additional-essential-internal-methods-of-function-objects

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.cpp
@@ -39,10 +39,6 @@ void FunctionPrototype::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.name, js_string(heap(), ""), Attribute::Configurable);
 }
 
-FunctionPrototype::~FunctionPrototype()
-{
-}
-
 // 20.2.3.1 Function.prototype.apply ( thisArg, argArray ), https://tc39.es/ecma262/#sec-function.prototype.apply
 JS_DEFINE_NATIVE_FUNCTION(FunctionPrototype::apply)
 {

--- a/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/FunctionPrototype.h
@@ -16,7 +16,7 @@ class FunctionPrototype final : public Object {
 public:
     explicit FunctionPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~FunctionPrototype() override;
+    virtual ~FunctionPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(apply);

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.cpp
@@ -27,10 +27,6 @@ void GeneratorFunctionConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.prototype, global_object.generator_function_prototype(), 0);
 }
 
-GeneratorFunctionConstructor::~GeneratorFunctionConstructor()
-{
-}
-
 // 27.3.1.1 GeneratorFunction ( p1, p2, … , pn, body ), https://tc39.es/ecma262/#sec-generatorfunction
 ThrowCompletionOr<Value> GeneratorFunctionConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionConstructor.h
@@ -17,7 +17,7 @@ class GeneratorFunctionConstructor final : public NativeFunction {
 public:
     explicit GeneratorFunctionConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~GeneratorFunctionConstructor() override;
+    virtual ~GeneratorFunctionConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.cpp
@@ -25,9 +25,4 @@ void GeneratorFunctionPrototype::initialize(GlobalObject& global_object)
     // 27.3.3.3 GeneratorFunction.prototype [ @@toStringTag ], https://tc39.es/ecma262/#sec-generatorfunction.prototype-@@tostringtag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "GeneratorFunction"), Attribute::Configurable);
 }
-
-GeneratorFunctionPrototype::~GeneratorFunctionPrototype()
-{
-}
-
 }

--- a/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorFunctionPrototype.h
@@ -18,7 +18,7 @@ class GeneratorFunctionPrototype final : public Object {
 public:
     explicit GeneratorFunctionPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~GeneratorFunctionPrototype() override;
+    virtual ~GeneratorFunctionPrototype() override = default;
 };
 
 }

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.cpp
@@ -43,10 +43,6 @@ void GeneratorObject::initialize(GlobalObject&)
 {
 }
 
-GeneratorObject::~GeneratorObject()
-{
-}
-
 void GeneratorObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorObject.h
@@ -19,7 +19,7 @@ public:
     static ThrowCompletionOr<GeneratorObject*> create(GlobalObject&, Value, ECMAScriptFunctionObject*, ExecutionContext, Bytecode::RegisterWindow);
     GeneratorObject(GlobalObject&, Object& prototype, ExecutionContext);
     virtual void initialize(GlobalObject&) override;
-    virtual ~GeneratorObject() override;
+    virtual ~GeneratorObject() override = default;
     void visit_edges(Cell::Visitor&) override;
 
     ThrowCompletionOr<Value> next_impl(VM&, GlobalObject&, Optional<Value> next_argument, Optional<Value> value_to_throw);

--- a/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.cpp
@@ -27,10 +27,6 @@ void GeneratorPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Generator"), Attribute::Configurable);
 }
 
-GeneratorPrototype::~GeneratorPrototype()
-{
-}
-
 // 27.5.1.2 Generator.prototype.next ( value ), https://tc39.es/ecma262/#sec-generator.prototype.next
 JS_DEFINE_NATIVE_FUNCTION(GeneratorPrototype::next)
 {

--- a/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/GeneratorPrototype.h
@@ -18,7 +18,7 @@ class GeneratorPrototype final : public PrototypeObject<GeneratorPrototype, Gene
 public:
     explicit GeneratorPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~GeneratorPrototype() override;
+    virtual ~GeneratorPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(next);

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -304,9 +304,7 @@ void GlobalObject::initialize_global_object()
     m_json_parse_function = &get_without_side_effects(vm.names.JSON).as_object().get_without_side_effects(vm.names.parse).as_function();
 }
 
-GlobalObject::~GlobalObject()
-{
-}
+GlobalObject::~GlobalObject() = default;
 
 void GlobalObject::visit_edges(Visitor& visitor)
 {

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.cpp
@@ -82,10 +82,6 @@ bool SimpleIndexedPropertyStorage::set_array_like_size(size_t new_size)
     return true;
 }
 
-GenericIndexedPropertyStorage::GenericIndexedPropertyStorage()
-{
-}
-
 GenericIndexedPropertyStorage::GenericIndexedPropertyStorage(SimpleIndexedPropertyStorage&& storage)
 {
     m_array_size = storage.array_like_size();

--- a/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
+++ b/Userland/Libraries/LibJS/Runtime/IndexedProperties.h
@@ -23,7 +23,7 @@ class GenericIndexedPropertyStorage;
 
 class IndexedPropertyStorage {
 public:
-    virtual ~IndexedPropertyStorage() {};
+    virtual ~IndexedPropertyStorage() = default;
 
     virtual bool has_index(u32 index) const = 0;
     virtual Optional<ValueAndAttributes> get(u32 index) const = 0;
@@ -72,7 +72,7 @@ private:
 class GenericIndexedPropertyStorage final : public IndexedPropertyStorage {
 public:
     explicit GenericIndexedPropertyStorage(SimpleIndexedPropertyStorage&&);
-    explicit GenericIndexedPropertyStorage();
+    explicit GenericIndexedPropertyStorage() = default;
 
     virtual bool has_index(u32 index) const override;
     virtual Optional<ValueAndAttributes> get(u32 index) const override;

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.cpp
@@ -24,10 +24,6 @@ void IteratorPrototype::initialize(GlobalObject& global_object)
     define_native_function(*vm.well_known_symbol_iterator(), symbol_iterator, 0, attr);
 }
 
-IteratorPrototype::~IteratorPrototype()
-{
-}
-
 // 27.1.2.1 %IteratorPrototype% [ @@iterator ] ( ), https://tc39.es/ecma262/#sec-%iteratorprototype%-@@iterator
 JS_DEFINE_NATIVE_FUNCTION(IteratorPrototype::symbol_iterator)
 {

--- a/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/IteratorPrototype.h
@@ -16,7 +16,7 @@ class IteratorPrototype : public Object {
 public:
     IteratorPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~IteratorPrototype() override;
+    virtual ~IteratorPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(symbol_iterator);

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.cpp
@@ -42,10 +42,6 @@ void JSONObject::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "JSON"), Attribute::Configurable);
 }
 
-JSONObject::~JSONObject()
-{
-}
-
 // 25.5.2 JSON.stringify ( value [ , replacer [ , space ] ] ), https://tc39.es/ecma262/#sec-json.stringify
 ThrowCompletionOr<String> JSONObject::stringify_impl(GlobalObject& global_object, Value value, Value replacer, Value space)
 {

--- a/Userland/Libraries/LibJS/Runtime/JSONObject.h
+++ b/Userland/Libraries/LibJS/Runtime/JSONObject.h
@@ -16,7 +16,7 @@ class JSONObject final : public Object {
 public:
     explicit JSONObject(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~JSONObject() override;
+    virtual ~JSONObject() override = default;
 
     // The base implementation of stringify is exposed because it is used by
     // test-js to communicate between the JS tests and the C++ test runner.

--- a/Userland/Libraries/LibJS/Runtime/Map.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Map.cpp
@@ -18,10 +18,6 @@ Map::Map(Object& prototype)
 {
 }
 
-Map::~Map()
-{
-}
-
 // 24.1.3.1 Map.prototype.clear ( ), https://tc39.es/ecma262/#sec-map.prototype.clear
 void Map::map_clear()
 {

--- a/Userland/Libraries/LibJS/Runtime/Map.h
+++ b/Userland/Libraries/LibJS/Runtime/Map.h
@@ -23,7 +23,7 @@ public:
     static Map* create(GlobalObject&);
 
     explicit Map(Object& prototype);
-    virtual ~Map() override;
+    virtual ~Map() override = default;
 
     void map_clear();
     bool map_remove(Value const&);

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.cpp
@@ -31,10 +31,6 @@ void MapConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-MapConstructor::~MapConstructor()
-{
-}
-
 // 24.1.1.1 Map ( [ iterable ] ), https://tc39.es/ecma262/#sec-map-iterable
 ThrowCompletionOr<Value> MapConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/MapConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/MapConstructor.h
@@ -16,7 +16,7 @@ class MapConstructor final : public NativeFunction {
 public:
     explicit MapConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~MapConstructor() override;
+    virtual ~MapConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.cpp
@@ -22,10 +22,6 @@ MapIterator::MapIterator(Map& map, Object::PropertyKind iteration_kind, Object& 
 {
 }
 
-MapIterator::~MapIterator()
-{
-}
-
 void MapIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/MapIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIterator.h
@@ -19,7 +19,7 @@ public:
     static MapIterator* create(GlobalObject&, Map& map, Object::PropertyKind iteration_kind);
 
     explicit MapIterator(Map& map, Object::PropertyKind iteration_kind, Object& prototype);
-    virtual ~MapIterator() override;
+    virtual ~MapIterator() override = default;
 
     Map& map() const { return m_map; }
     bool done() const { return m_done; }

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.cpp
@@ -27,10 +27,6 @@ void MapIteratorPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Map Iterator"), Attribute::Configurable);
 }
 
-MapIteratorPrototype::~MapIteratorPrototype()
-{
-}
-
 // 24.1.5.2.1 %MapIteratorPrototype%.next ( ), https://tc39.es/ecma262/#sec-%mapiteratorprototype%.next
 JS_DEFINE_NATIVE_FUNCTION(MapIteratorPrototype::next)
 {

--- a/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapIteratorPrototype.h
@@ -17,7 +17,7 @@ class MapIteratorPrototype final : public PrototypeObject<MapIteratorPrototype, 
 public:
     MapIteratorPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~MapIteratorPrototype() override;
+    virtual ~MapIteratorPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(next);

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.cpp
@@ -39,10 +39,6 @@ void MapPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.Map.as_string()), Attribute::Configurable);
 }
 
-MapPrototype::~MapPrototype()
-{
-}
-
 // 24.1.3.1 Map.prototype.clear ( ), https://tc39.es/ecma262/#sec-map.prototype.clear
 JS_DEFINE_NATIVE_FUNCTION(MapPrototype::clear)
 {

--- a/Userland/Libraries/LibJS/Runtime/MapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/MapPrototype.h
@@ -17,7 +17,7 @@ class MapPrototype final : public PrototypeObject<MapPrototype, Map> {
 public:
     MapPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~MapPrototype() override;
+    virtual ~MapPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(clear);

--- a/Userland/Libraries/LibJS/Runtime/MathObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.cpp
@@ -75,10 +75,6 @@ void MathObject::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, vm.names.Math.as_string()), Attribute::Configurable);
 }
 
-MathObject::~MathObject()
-{
-}
-
 // 21.3.2.1 Math.abs ( x ), https://tc39.es/ecma262/#sec-math.abs
 JS_DEFINE_NATIVE_FUNCTION(MathObject::abs)
 {

--- a/Userland/Libraries/LibJS/Runtime/MathObject.h
+++ b/Userland/Libraries/LibJS/Runtime/MathObject.h
@@ -16,7 +16,7 @@ class MathObject final : public Object {
 public:
     explicit MathObject(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~MathObject() override;
+    virtual ~MathObject() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(abs);

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.cpp
@@ -88,10 +88,6 @@ NativeFunction::NativeFunction(FlyString name, Object& prototype)
 {
 }
 
-NativeFunction::~NativeFunction()
-{
-}
-
 // NOTE: Do not attempt to DRY these, it's not worth it. The difference in return types (Value vs Object*),
 // called functions (call() vs construct(FunctionObject&)), and this value (passed vs uninitialized) make
 // these good candidates for a bit of code duplication :^)

--- a/Userland/Libraries/LibJS/Runtime/NativeFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/NativeFunction.h
@@ -26,7 +26,7 @@ public:
     NativeFunction(GlobalObject&, Function<ThrowCompletionOr<Value>(VM&, GlobalObject&)>, Object* prototype, Realm& realm);
     NativeFunction(FlyString name, Function<ThrowCompletionOr<Value>(VM&, GlobalObject&)>, Object& prototype);
     virtual void initialize(GlobalObject&) override { }
-    virtual ~NativeFunction() override;
+    virtual ~NativeFunction() override = default;
 
     virtual ThrowCompletionOr<Value> internal_call(Value this_argument, MarkedVector<Value> arguments_list) override;
     virtual ThrowCompletionOr<Object*> internal_construct(MarkedVector<Value> arguments_list, FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.cpp
@@ -55,10 +55,6 @@ void NumberConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-NumberConstructor::~NumberConstructor()
-{
-}
-
 // Most of 21.1.1.1 Number ( value ) factored into a separate function for sharing between call() and construct().
 static ThrowCompletionOr<Value> get_value_from_constructor_argument(GlobalObject& global_object)
 {

--- a/Userland/Libraries/LibJS/Runtime/NumberConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberConstructor.h
@@ -16,7 +16,7 @@ class NumberConstructor final : public NativeFunction {
 public:
     explicit NumberConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~NumberConstructor() override;
+    virtual ~NumberConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/NumberObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberObject.cpp
@@ -19,9 +19,4 @@ NumberObject::NumberObject(double value, Object& prototype)
     , m_value(value)
 {
 }
-
-NumberObject::~NumberObject()
-{
-}
-
 }

--- a/Userland/Libraries/LibJS/Runtime/NumberObject.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberObject.h
@@ -17,7 +17,7 @@ public:
     static NumberObject* create(GlobalObject&, double);
 
     NumberObject(double, Object& prototype);
-    virtual ~NumberObject() override;
+    virtual ~NumberObject() override = default;
 
     double number() const { return m_value; }
 

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -95,10 +95,6 @@ void NumberPrototype::initialize(GlobalObject& object)
     define_native_function(vm.names.valueOf, value_of, 0, attr);
 }
 
-NumberPrototype::~NumberPrototype()
-{
-}
-
 // thisNumberValue ( value ), https://tc39.es/ecma262/#thisnumbervalue
 static ThrowCompletionOr<Value> this_number_value(GlobalObject& global_object, Value value)
 {

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.h
@@ -16,7 +16,7 @@ class NumberPrototype final : public NumberObject {
 public:
     explicit NumberPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~NumberPrototype() override;
+    virtual ~NumberPrototype() override = default;
 
     JS_DECLARE_NATIVE_FUNCTION(to_exponential);
     JS_DECLARE_NATIVE_FUNCTION(to_fixed);

--- a/Userland/Libraries/LibJS/Runtime/Object.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Object.cpp
@@ -67,10 +67,6 @@ void Object::initialize(GlobalObject&)
 {
 }
 
-Object::~Object()
-{
-}
-
 // 7.2 Testing and Comparison Operations, https://tc39.es/ecma262/#sec-testing-and-comparison-operations
 
 // 7.2.5 IsExtensible ( O ), https://tc39.es/ecma262/#sec-isextensible-o

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -49,7 +49,7 @@ public:
     explicit Object(Object& prototype);
     explicit Object(Shape&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~Object();
+    virtual ~Object() = default;
 
     enum class PropertyKind {
         Key,

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.cpp
@@ -57,10 +57,6 @@ void ObjectConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-ObjectConstructor::~ObjectConstructor()
-{
-}
-
 // 20.1.1.1 Object ( [ value ] ), https://tc39.es/ecma262/#sec-object-value
 ThrowCompletionOr<Value> ObjectConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectConstructor.h
@@ -17,7 +17,7 @@ class ObjectConstructor final : public NativeFunction {
 public:
     explicit ObjectConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ObjectConstructor() override;
+    virtual ~ObjectConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.cpp
@@ -48,10 +48,6 @@ void ObjectPrototype::initialize(GlobalObject& global_object)
     define_native_accessor(vm.names.__proto__, proto_getter, proto_setter, Attribute::Configurable);
 }
 
-ObjectPrototype::~ObjectPrototype()
-{
-}
-
 // 10.4.7.1 [[SetPrototypeOf]] ( V ), https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects-setprototypeof-v
 ThrowCompletionOr<bool> ObjectPrototype::internal_set_prototype_of(Object* prototype)
 {

--- a/Userland/Libraries/LibJS/Runtime/ObjectPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/ObjectPrototype.h
@@ -17,7 +17,7 @@ class ObjectPrototype final : public Object {
 public:
     explicit ObjectPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ObjectPrototype() override;
+    virtual ~ObjectPrototype() override = default;
 
     // 10.4.7 Immutable Prototype Exotic Objects, https://tc39.es/ecma262/#sec-immutable-prototype-exotic-objects
 

--- a/Userland/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyKey.h
@@ -37,7 +37,7 @@ public:
         return TRY(value.to_string(global_object));
     }
 
-    PropertyKey() { }
+    PropertyKey() = default;
 
     template<Integral T>
     PropertyKey(T index)

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.cpp
@@ -39,10 +39,6 @@ void ProxyConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 }
 
-ProxyConstructor::~ProxyConstructor()
-{
-}
-
 // 28.2.1.1 Proxy ( target, handler ), https://tc39.es/ecma262/#sec-proxy-target-handler
 ThrowCompletionOr<Value> ProxyConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/ProxyConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyConstructor.h
@@ -17,7 +17,7 @@ class ProxyConstructor final : public NativeFunction {
 public:
     explicit ProxyConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ProxyConstructor() override;
+    virtual ~ProxyConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.cpp
@@ -27,10 +27,6 @@ ProxyObject::ProxyObject(Object& target, Object& handler, Object& prototype)
 {
 }
 
-ProxyObject::~ProxyObject()
-{
-}
-
 static Value property_key_to_value(VM& vm, PropertyKey const& property_key)
 {
     VERIFY(property_key.is_valid());

--- a/Userland/Libraries/LibJS/Runtime/ProxyObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ProxyObject.h
@@ -19,7 +19,7 @@ public:
     static ProxyObject* create(GlobalObject&, Object& target, Object& handler);
 
     ProxyObject(Object& target, Object& handler, Object& prototype);
-    virtual ~ProxyObject() override;
+    virtual ~ProxyObject() override = default;
 
     virtual const FlyString& name() const override;
     virtual bool has_constructor() const override;

--- a/Userland/Libraries/LibJS/Runtime/Reference.h
+++ b/Userland/Libraries/LibJS/Runtime/Reference.h
@@ -24,7 +24,7 @@ public:
         Environment,
     };
 
-    Reference() { }
+    Reference() = default;
     Reference(BaseType type, PropertyKey name, bool strict)
         : m_base_type(type)
         , m_name(move(name))

--- a/Userland/Libraries/LibJS/Runtime/ReflectObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ReflectObject.cpp
@@ -43,10 +43,6 @@ void ReflectObject::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, vm.names.Reflect.as_string()), Attribute::Configurable);
 }
 
-ReflectObject::~ReflectObject()
-{
-}
-
 // 28.1.1 Reflect.apply ( target, thisArgument, argumentsList ), https://tc39.es/ecma262/#sec-reflect.apply
 JS_DEFINE_NATIVE_FUNCTION(ReflectObject::apply)
 {

--- a/Userland/Libraries/LibJS/Runtime/ReflectObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ReflectObject.h
@@ -16,7 +16,7 @@ class ReflectObject final : public Object {
 public:
     explicit ReflectObject(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~ReflectObject() override;
+    virtual ~ReflectObject() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(apply);

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -29,10 +29,6 @@ void RegExpConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 }
 
-RegExpConstructor::~RegExpConstructor()
-{
-}
-
 // 22.2.3.1 RegExp ( pattern, flags ), https://tc39.es/ecma262/#sec-regexp-pattern-flags
 ThrowCompletionOr<Value> RegExpConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.h
@@ -16,7 +16,7 @@ class RegExpConstructor final : public NativeFunction {
 public:
     explicit RegExpConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~RegExpConstructor() override;
+    virtual ~RegExpConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.cpp
@@ -128,10 +128,6 @@ RegExpObject::RegExpObject(Regex<ECMA262> regex, String pattern, String flags, O
     VERIFY(m_regex->parser_result.error == regex::Error::NoError);
 }
 
-RegExpObject::~RegExpObject()
-{
-}
-
 void RegExpObject::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();

--- a/Userland/Libraries/LibJS/Runtime/RegExpObject.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpObject.h
@@ -42,7 +42,7 @@ public:
     String escape_regexp_pattern() const;
 
     virtual void initialize(GlobalObject&) override;
-    virtual ~RegExpObject() override;
+    virtual ~RegExpObject() override = default;
 
     const String& pattern() const { return m_pattern; }
     const String& flags() const { return m_flags; }

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -51,10 +51,6 @@ void RegExpPrototype::initialize(GlobalObject& global_object)
 #undef __JS_ENUMERATE
 }
 
-RegExpPrototype::~RegExpPrototype()
-{
-}
-
 // Non-standard abstraction around steps used by multiple prototypes.
 static ThrowCompletionOr<void> increment_last_index(GlobalObject& global_object, Object& regexp_object, Utf16View const& string, bool unicode)
 {

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.h
@@ -21,7 +21,7 @@ class RegExpPrototype final : public PrototypeObject<RegExpPrototype, RegExpObje
 public:
     explicit RegExpPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~RegExpPrototype() override;
+    virtual ~RegExpPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(exec);

--- a/Userland/Libraries/LibJS/Runtime/Set.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Set.cpp
@@ -19,10 +19,6 @@ Set::Set(Object& prototype)
 {
 }
 
-Set::~Set()
-{
-}
-
 void Set::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/Set.h
+++ b/Userland/Libraries/LibJS/Runtime/Set.h
@@ -20,7 +20,7 @@ public:
     static Set* create(GlobalObject&);
 
     explicit Set(Object& prototype);
-    virtual ~Set() override;
+    virtual ~Set() override = default;
 
     // NOTE: Unlike what the spec says, we implement Sets using an underlying map,
     //       so all the functions below do not directly implement the operations as

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.cpp
@@ -31,10 +31,6 @@ void SetConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-SetConstructor::~SetConstructor()
-{
-}
-
 // 24.2.1.1 Set ( [ iterable ] ), https://tc39.es/ecma262/#sec-set-iterable
 ThrowCompletionOr<Value> SetConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/SetConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/SetConstructor.h
@@ -16,7 +16,7 @@ class SetConstructor final : public NativeFunction {
 public:
     explicit SetConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~SetConstructor() override;
+    virtual ~SetConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.cpp
@@ -22,10 +22,6 @@ SetIterator::SetIterator(Set& set, Object::PropertyKind iteration_kind, Object& 
 {
 }
 
-SetIterator::~SetIterator()
-{
-}
-
 void SetIterator::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/SetIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIterator.h
@@ -19,7 +19,7 @@ public:
     static SetIterator* create(GlobalObject&, Set& set, Object::PropertyKind iteration_kind);
 
     explicit SetIterator(Set& set, Object::PropertyKind iteration_kind, Object& prototype);
-    virtual ~SetIterator() override;
+    virtual ~SetIterator() override = default;
 
     Set& set() const { return m_set; }
     bool done() const { return m_done; }

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.cpp
@@ -29,10 +29,6 @@ void SetIteratorPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Set Iterator"), Attribute::Configurable);
 }
 
-SetIteratorPrototype::~SetIteratorPrototype()
-{
-}
-
 // 24.2.5.2.1 %SetIteratorPrototype%.next ( ), https://tc39.es/ecma262/#sec-%setiteratorprototype%.next
 JS_DEFINE_NATIVE_FUNCTION(SetIteratorPrototype::next)
 {

--- a/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetIteratorPrototype.h
@@ -17,7 +17,7 @@ class SetIteratorPrototype final : public PrototypeObject<SetIteratorPrototype, 
 public:
     SetIteratorPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~SetIteratorPrototype() override;
+    virtual ~SetIteratorPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(next);

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.cpp
@@ -41,10 +41,6 @@ void SetPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, vm.names.Set.as_string()), Attribute::Configurable);
 }
 
-SetPrototype::~SetPrototype()
-{
-}
-
 // 24.2.3.1 Set.prototype.add ( value ), https://tc39.es/ecma262/#sec-set.prototype.add
 JS_DEFINE_NATIVE_FUNCTION(SetPrototype::add)
 {

--- a/Userland/Libraries/LibJS/Runtime/SetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SetPrototype.h
@@ -17,7 +17,7 @@ class SetPrototype final : public PrototypeObject<SetPrototype, Set> {
 public:
     SetPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~SetPrototype() override;
+    virtual ~SetPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(add);

--- a/Userland/Libraries/LibJS/Runtime/Shape.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Shape.cpp
@@ -88,10 +88,6 @@ Shape* Shape::create_prototype_transition(Object* new_prototype)
     return new_shape;
 }
 
-Shape::Shape(ShapeWithoutGlobalObjectTag)
-{
-}
-
 Shape::Shape(Object& global_object)
     : m_global_object(&global_object)
 {
@@ -114,10 +110,6 @@ Shape::Shape(Shape& previous_shape, Object* new_prototype)
     , m_prototype(new_prototype)
     , m_property_count(previous_shape.m_property_count)
     , m_transition_type(TransitionType::Prototype)
-{
-}
-
-Shape::~Shape()
 {
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -37,7 +37,7 @@ class Shape final
     : public Cell
     , public Weakable<Shape> {
 public:
-    virtual ~Shape() override;
+    virtual ~Shape() override = default;
 
     enum class TransitionType {
         Invalid,
@@ -48,7 +48,7 @@ public:
 
     enum class ShapeWithoutGlobalObjectTag { Tag };
 
-    explicit Shape(ShapeWithoutGlobalObjectTag);
+    explicit Shape(ShapeWithoutGlobalObjectTag) {};
     explicit Shape(Object& global_object);
     Shape(Shape& previous_shape, const StringOrSymbol& property_key, PropertyAttributes attributes, TransitionType);
     Shape(Shape& previous_shape, Object* new_prototype);

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.cpp
@@ -38,10 +38,6 @@ void StringConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-StringConstructor::~StringConstructor()
-{
-}
-
 // 22.1.1.1 String ( value ), https://tc39.es/ecma262/#sec-string-constructor-string-value
 ThrowCompletionOr<Value> StringConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/StringConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/StringConstructor.h
@@ -16,7 +16,7 @@ class StringConstructor final : public NativeFunction {
 public:
     explicit StringConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~StringConstructor() override;
+    virtual ~StringConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/StringIterator.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIterator.cpp
@@ -21,9 +21,4 @@ StringIterator::StringIterator(String string, Object& prototype)
     , m_iterator(Utf8View(m_string).begin())
 {
 }
-
-StringIterator::~StringIterator()
-{
-}
-
 }

--- a/Userland/Libraries/LibJS/Runtime/StringIterator.h
+++ b/Userland/Libraries/LibJS/Runtime/StringIterator.h
@@ -18,7 +18,7 @@ public:
     static StringIterator* create(GlobalObject&, String string);
 
     explicit StringIterator(String string, Object& prototype);
-    virtual ~StringIterator() override;
+    virtual ~StringIterator() override = default;
 
     Utf8CodePointIterator& iterator() { return m_iterator; }
     bool done() const { return m_done; }

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.cpp
@@ -28,10 +28,6 @@ void StringIteratorPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "String Iterator"), Attribute::Configurable);
 }
 
-StringIteratorPrototype::~StringIteratorPrototype()
-{
-}
-
 // 22.1.5.1.1 %StringIteratorPrototype%.next ( ), https://tc39.es/ecma262/#sec-%stringiteratorprototype%.next
 JS_DEFINE_NATIVE_FUNCTION(StringIteratorPrototype::next)
 {

--- a/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringIteratorPrototype.h
@@ -18,7 +18,7 @@ class StringIteratorPrototype final : public PrototypeObject<StringIteratorProto
 public:
     StringIteratorPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~StringIteratorPrototype() override;
+    virtual ~StringIteratorPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(next);

--- a/Userland/Libraries/LibJS/Runtime/StringObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.cpp
@@ -26,10 +26,6 @@ StringObject::StringObject(PrimitiveString& string, Object& prototype)
 {
 }
 
-StringObject::~StringObject()
-{
-}
-
 void StringObject::initialize(GlobalObject& global_object)
 {
     auto& vm = this->vm();

--- a/Userland/Libraries/LibJS/Runtime/StringObject.h
+++ b/Userland/Libraries/LibJS/Runtime/StringObject.h
@@ -18,7 +18,7 @@ public:
 
     StringObject(PrimitiveString&, Object& prototype);
     virtual void initialize(GlobalObject&) override;
-    virtual ~StringObject() override;
+    virtual ~StringObject() override = default;
 
     PrimitiveString const& primitive_string() const { return m_string; }
     PrimitiveString& primitive_string() { return m_string; }

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -163,10 +163,6 @@ void StringPrototype::initialize(GlobalObject& global_object)
     define_native_function(*vm.well_known_symbol_iterator(), symbol_iterator, 0, attr);
 }
 
-StringPrototype::~StringPrototype()
-{
-}
-
 // thisStringValue ( value ), https://tc39.es/ecma262/#thisstringvalue
 static ThrowCompletionOr<PrimitiveString*> this_string_value(GlobalObject& global_object, Value value)
 {

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.h
@@ -26,7 +26,7 @@ class StringPrototype final : public StringObject {
 public:
     explicit StringPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~StringPrototype() override;
+    virtual ~StringPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(char_at);

--- a/Userland/Libraries/LibJS/Runtime/Symbol.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.cpp
@@ -16,10 +16,6 @@ Symbol::Symbol(Optional<String> description, bool is_global)
 {
 }
 
-Symbol::~Symbol()
-{
-}
-
 Symbol* js_symbol(Heap& heap, Optional<String> description, bool is_global)
 {
     return heap.allocate_without_global_object<Symbol>(move(description), is_global);

--- a/Userland/Libraries/LibJS/Runtime/Symbol.h
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.h
@@ -17,7 +17,7 @@ class Symbol final : public Cell {
 
 public:
     Symbol(Optional<String>, bool);
-    virtual ~Symbol();
+    virtual ~Symbol() = default;
 
     String description() const { return m_description.value_or(""); }
     const Optional<String>& raw_description() const { return m_description; }

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.cpp
@@ -35,10 +35,6 @@ void SymbolConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-SymbolConstructor::~SymbolConstructor()
-{
-}
-
 // 20.4.1.1 Symbol ( [ description ] ), https://tc39.es/ecma262/#sec-symbol-description
 ThrowCompletionOr<Value> SymbolConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/SymbolConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolConstructor.h
@@ -16,7 +16,7 @@ class SymbolConstructor final : public NativeFunction {
 public:
     explicit SymbolConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~SymbolConstructor() override;
+    virtual ~SymbolConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.cpp
@@ -21,10 +21,6 @@ SymbolObject::SymbolObject(Symbol& symbol, Object& prototype)
 {
 }
 
-SymbolObject::~SymbolObject()
-{
-}
-
 void SymbolObject::visit_edges(Cell::Visitor& visitor)
 {
     Base::visit_edges(visitor);

--- a/Userland/Libraries/LibJS/Runtime/SymbolObject.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolObject.h
@@ -18,7 +18,7 @@ public:
     static SymbolObject* create(GlobalObject&, Symbol&);
 
     SymbolObject(Symbol&, Object& prototype);
-    virtual ~SymbolObject() override;
+    virtual ~SymbolObject() override = default;
 
     Symbol& primitive_symbol() { return m_symbol; }
     const Symbol& primitive_symbol() const { return m_symbol; }

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.cpp
@@ -37,10 +37,6 @@ void SymbolPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), "Symbol"), Attribute::Configurable);
 }
 
-SymbolPrototype::~SymbolPrototype()
-{
-}
-
 // thisSymbolValue ( value ), https://tc39.es/ecma262/#thissymbolvalue
 static ThrowCompletionOr<Symbol*> this_symbol_value(GlobalObject& global_object, Value value)
 {

--- a/Userland/Libraries/LibJS/Runtime/SymbolPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/SymbolPrototype.h
@@ -16,7 +16,7 @@ class SymbolPrototype final : public Object {
 public:
     explicit SymbolPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~SymbolPrototype() override;
+    virtual ~SymbolPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(description_getter);

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.cpp
@@ -38,10 +38,6 @@ void TypedArrayConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-TypedArrayConstructor::~TypedArrayConstructor()
-{
-}
-
 // 23.2.1.1 %TypedArray% ( ), https://tc39.es/ecma262/#sec-%typedarray%
 ThrowCompletionOr<Value> TypedArrayConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayConstructor.h
@@ -17,7 +17,7 @@ public:
     TypedArrayConstructor(const FlyString& name, Object& prototype);
     explicit TypedArrayConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~TypedArrayConstructor() override;
+    virtual ~TypedArrayConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject& new_target) override;

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -67,10 +67,6 @@ void TypedArrayPrototype::initialize(GlobalObject& object)
     define_direct_property(*vm.well_known_symbol_iterator(), get_without_side_effects(vm.names.values), attr);
 }
 
-TypedArrayPrototype::~TypedArrayPrototype()
-{
-}
-
 static ThrowCompletionOr<TypedArrayBase*> typed_array_from_this(GlobalObject& global_object)
 {
     auto this_value = global_object.vm().this_value(global_object);

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.h
@@ -17,7 +17,7 @@ class TypedArrayPrototype final : public Object {
 public:
     explicit TypedArrayPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~TypedArrayPrototype() override;
+    virtual ~TypedArrayPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(length_getter);

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -137,10 +137,6 @@ VM::VM(OwnPtr<CustomData> custom_data)
 #undef __JS_ENUMERATE
 }
 
-VM::~VM()
-{
-}
-
 void VM::enable_default_host_import_module_dynamically_hook()
 {
     host_import_module_dynamically = [&](ScriptOrModule referencing_script_or_module, ModuleRequest const& specifier, PromiseCapability promise_capability) {
@@ -703,10 +699,6 @@ void VM::dump_backtrace() const
             dbgln("-> {}", frame->function_name);
         }
     }
-}
-
-VM::CustomData::~CustomData()
-{
 }
 
 void VM::save_execution_context_stack()

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -33,11 +33,11 @@ struct BindingPattern;
 class VM : public RefCounted<VM> {
 public:
     struct CustomData {
-        virtual ~CustomData();
+        virtual ~CustomData() = default;
     };
 
     static NonnullRefPtr<VM> create(OwnPtr<CustomData> = {});
-    ~VM();
+    ~VM() = default;
 
     enum class HostResizeArrayBufferResult {
         Unhandled,

--- a/Userland/Libraries/LibJS/Runtime/WeakMap.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMap.cpp
@@ -19,10 +19,6 @@ WeakMap::WeakMap(Object& prototype)
 {
 }
 
-WeakMap::~WeakMap()
-{
-}
-
 void WeakMap::remove_dead_cells(Badge<Heap>)
 {
     m_values.remove_all_matching([](Cell* key, Value) {

--- a/Userland/Libraries/LibJS/Runtime/WeakMap.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMap.h
@@ -22,7 +22,7 @@ public:
     static WeakMap* create(GlobalObject&);
 
     explicit WeakMap(Object& prototype);
-    virtual ~WeakMap() override;
+    virtual ~WeakMap() override = default;
 
     HashMap<Cell*, Value> const& values() const { return m_values; };
     HashMap<Cell*, Value>& values() { return m_values; };

--- a/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.cpp
@@ -29,10 +29,6 @@ void WeakMapConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-WeakMapConstructor::~WeakMapConstructor()
-{
-}
-
 // 24.3.1.1 WeakMap ( [ iterable ] ), https://tc39.es/ecma262/#sec-weakmap-iterable
 ThrowCompletionOr<Value> WeakMapConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapConstructor.h
@@ -16,7 +16,7 @@ class WeakMapConstructor final : public NativeFunction {
 public:
     explicit WeakMapConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~WeakMapConstructor() override;
+    virtual ~WeakMapConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.cpp
@@ -30,10 +30,6 @@ void WeakMapPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, vm.names.WeakMap.as_string()), Attribute::Configurable);
 }
 
-WeakMapPrototype::~WeakMapPrototype()
-{
-}
-
 // 24.3.3.2 WeakMap.prototype.delete ( key ), https://tc39.es/ecma262/#sec-weakmap.prototype.delete
 JS_DEFINE_NATIVE_FUNCTION(WeakMapPrototype::delete_)
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakMapPrototype.h
@@ -17,7 +17,7 @@ class WeakMapPrototype final : public PrototypeObject<WeakMapPrototype, WeakMap>
 public:
     WeakMapPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~WeakMapPrototype() override;
+    virtual ~WeakMapPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(delete_);

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.cpp
@@ -21,10 +21,6 @@ WeakRef::WeakRef(Object* object, Object& prototype)
 {
 }
 
-WeakRef::~WeakRef()
-{
-}
-
 void WeakRef::remove_dead_cells(Badge<Heap>)
 {
     VERIFY(m_value);

--- a/Userland/Libraries/LibJS/Runtime/WeakRef.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRef.h
@@ -21,7 +21,7 @@ public:
     static WeakRef* create(GlobalObject&, Object*);
 
     explicit WeakRef(Object*, Object& prototype);
-    virtual ~WeakRef() override;
+    virtual ~WeakRef() override = default;
 
     Object* value() const { return m_value; };
 

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.cpp
@@ -28,10 +28,6 @@ void WeakRefConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-WeakRefConstructor::~WeakRefConstructor()
-{
-}
-
 // 26.1.1.1 WeakRef ( target ), https://tc39.es/ecma262/#sec-weak-ref-target
 ThrowCompletionOr<Value> WeakRefConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefConstructor.h
@@ -16,7 +16,7 @@ class WeakRefConstructor final : public NativeFunction {
 public:
     explicit WeakRefConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~WeakRefConstructor() override;
+    virtual ~WeakRefConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.cpp
@@ -24,10 +24,6 @@ void WeakRefPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, vm.names.WeakRef.as_string()), Attribute::Configurable);
 }
 
-WeakRefPrototype::~WeakRefPrototype()
-{
-}
-
 // 26.1.3.2 WeakRef.prototype.deref ( ), https://tc39.es/ecma262/#sec-weak-ref.prototype.deref
 JS_DEFINE_NATIVE_FUNCTION(WeakRefPrototype::deref)
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakRefPrototype.h
@@ -17,7 +17,7 @@ class WeakRefPrototype final : public PrototypeObject<WeakRefPrototype, WeakRef>
 public:
     WeakRefPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~WeakRefPrototype() override;
+    virtual ~WeakRefPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(deref);

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.cpp
@@ -19,10 +19,6 @@ WeakSet::WeakSet(Object& prototype)
 {
 }
 
-WeakSet::~WeakSet()
-{
-}
-
 void WeakSet::remove_dead_cells(Badge<Heap>)
 {
     m_values.remove_all_matching([](Cell* cell) {

--- a/Userland/Libraries/LibJS/Runtime/WeakSet.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSet.h
@@ -22,7 +22,7 @@ public:
     static WeakSet* create(GlobalObject&);
 
     explicit WeakSet(Object& prototype);
-    virtual ~WeakSet() override;
+    virtual ~WeakSet() override = default;
 
     HashTable<Cell*> const& values() const { return m_values; };
     HashTable<Cell*>& values() { return m_values; };

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.cpp
@@ -29,10 +29,6 @@ void WeakSetConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-WeakSetConstructor::~WeakSetConstructor()
-{
-}
-
 // 24.4.1.1 WeakSet ( [ iterable ] ), https://tc39.es/ecma262/#sec-weakset-iterable
 ThrowCompletionOr<Value> WeakSetConstructor::call()
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetConstructor.h
@@ -16,7 +16,7 @@ class WeakSetConstructor final : public NativeFunction {
 public:
     explicit WeakSetConstructor(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~WeakSetConstructor() override;
+    virtual ~WeakSetConstructor() override = default;
 
     virtual ThrowCompletionOr<Value> call() override;
     virtual ThrowCompletionOr<Object*> construct(FunctionObject&) override;

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.cpp
@@ -29,10 +29,6 @@ void WeakSetPrototype::initialize(GlobalObject& global_object)
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(global_object.heap(), vm.names.WeakSet.as_string()), Attribute::Configurable);
 }
 
-WeakSetPrototype::~WeakSetPrototype()
-{
-}
-
 // 24.4.3.1 WeakSet.prototype.add ( value ), https://tc39.es/ecma262/#sec-weakset.prototype.add
 JS_DEFINE_NATIVE_FUNCTION(WeakSetPrototype::add)
 {

--- a/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
+++ b/Userland/Libraries/LibJS/Runtime/WeakSetPrototype.h
@@ -17,7 +17,7 @@ class WeakSetPrototype final : public PrototypeObject<WeakSetPrototype, WeakSet>
 public:
     WeakSetPrototype(GlobalObject&);
     virtual void initialize(GlobalObject&) override;
-    virtual ~WeakSetPrototype() override;
+    virtual ~WeakSetPrototype() override = default;
 
 private:
     JS_DECLARE_NATIVE_FUNCTION(add);

--- a/Userland/Libraries/LibJS/Script.cpp
+++ b/Userland/Libraries/LibJS/Script.cpp
@@ -35,9 +35,4 @@ Script::Script(Realm& realm, StringView filename, NonnullRefPtr<Program> parse_n
     , m_host_defined(host_defined)
 {
 }
-
-Script::~Script()
-{
-}
-
 }

--- a/Userland/Libraries/LibJS/Script.h
+++ b/Userland/Libraries/LibJS/Script.h
@@ -24,7 +24,7 @@ public:
         virtual ~HostDefined() = default;
     };
 
-    ~Script();
+    ~Script() = default;
     static Result<NonnullRefPtr<Script>, Vector<Parser::Error>> parse(StringView source_text, Realm&, StringView filename = {}, HostDefined* = nullptr, size_t line_number_offset = 1);
 
     Realm& realm() { return *m_realm.cell(); }

--- a/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.cpp
@@ -124,9 +124,4 @@ bool SyntaxHighlighter::token_types_equal(u64 token1, u64 token2) const
 {
     return static_cast<JS::TokenType>(token1) == static_cast<JS::TokenType>(token2);
 }
-
-SyntaxHighlighter::~SyntaxHighlighter()
-{
-}
-
 }

--- a/Userland/Libraries/LibJS/SyntaxHighlighter.h
+++ b/Userland/Libraries/LibJS/SyntaxHighlighter.h
@@ -12,8 +12,8 @@ namespace JS {
 
 class SyntaxHighlighter : public Syntax::Highlighter {
 public:
-    SyntaxHighlighter() { }
-    virtual ~SyntaxHighlighter() override;
+    SyntaxHighlighter() = default;
+    virtual ~SyntaxHighlighter() override = default;
 
     virtual bool is_identifier(u64) const override;
     virtual bool is_navigatable(u64) const override;


### PR DESCRIPTION
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cother-other-default-operation-rules

"The compiler is more likely to get the default semantics right and
you cannot implement these functions better than the compiler."