### PR TITLE
Userland: Change static const variables to static constexpr

### DIFF
--- a/Userland/Demos/Fire/Fire.cpp
+++ b/Userland/Demos/Fire/Fire.cpp
@@ -23,6 +23,7 @@
  *  [ ] handle fire bitmap edges better
  */
 
+#include <AK/Array.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/System.h>
 #include <LibGUI/Action.h>
@@ -45,7 +46,7 @@
 #define FIRE_HEIGHT 200
 #define FIRE_MAX 29
 
-static const Color s_palette[] = {
+static constexpr Array<Color, 30> s_palette = {
     Color(0x07, 0x07, 0x07), Color(0x1F, 0x07, 0x07), Color(0x2F, 0x0F, 0x07),
     Color(0x47, 0x0F, 0x07), Color(0x57, 0x17, 0x07), Color(0x67, 0x1F, 0x07),
     Color(0x77, 0x1F, 0x07), Color(0x9F, 0x2F, 0x07), Color(0xAF, 0x3F, 0x07),

--- a/Userland/Demos/VirGLDemo/CommandBufferBuilder.cpp
+++ b/Userland/Demos/VirGLDemo/CommandBufferBuilder.cpp
@@ -1,9 +1,11 @@
 /*
  * Copyright (c) 2022, Sahan Fernando <sahan.h.fernando@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/StringView.h>
 #include <Kernel/API/VirGL.h>
 #include <sys/ioctl_numbers.h>
 
@@ -235,9 +237,9 @@ void CommandBufferBuilder::append_set_constant_buffer(Vector<float> const& const
     }
 }
 
-void CommandBufferBuilder::append_create_shader(ObjectHandle handle, Gallium::ShaderType shader_type, const char* shader_data)
+void CommandBufferBuilder::append_create_shader(ObjectHandle handle, Gallium::ShaderType shader_type, StringView shader_data)
 {
-    size_t shader_len = strlen(shader_data) + 1; // Need to remember to copy null terminator as well if needed
+    size_t shader_len = shader_data.length() + 1; // Need to remember to copy null terminator as well if needed
     CommandBuilder builder(m_buffer, Protocol::VirGLCommand::CREATE_OBJECT, to_underlying(Protocol::ObjectType::SHADER));
     builder.appendu32(handle.value()); // VIRGL_OBJ_CREATE_HANDLE
     builder.appendu32(to_underlying(shader_type));

--- a/Userland/Demos/VirGLDemo/CommandBufferBuilder.h
+++ b/Userland/Demos/VirGLDemo/CommandBufferBuilder.h
@@ -1,11 +1,13 @@
 /*
  * Copyright (c) 2022, Sahan Fernando <sahan.h.fernando@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <sys/ioctl_numbers.h>
 
@@ -28,7 +30,7 @@ public:
     void append_gl_viewport();
     void append_set_framebuffer_state_no_attach();
     void append_set_constant_buffer(Vector<float> const& constant_buffer);
-    void append_create_shader(ObjectHandle handle, Gallium::ShaderType shader_type, const char* shader_data);
+    void append_create_shader(ObjectHandle handle, Gallium::ShaderType shader_type, StringView shader_data);
     void append_bind_shader(ObjectHandle handle, Gallium::ShaderType shader_type);
     void append_create_rasterizer(ObjectHandle handle);
     void append_bind_rasterizer(ObjectHandle handle);

--- a/Userland/Demos/VirGLDemo/VirGLDemo.cpp
+++ b/Userland/Demos/VirGLDemo/VirGLDemo.cpp
@@ -1,10 +1,13 @@
 /*
  * Copyright (c) 2022, Sahan Fernando <sahan.h.fernando@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <Kernel/API/VirGL.h>
 #include <LibGUI/Application.h>
@@ -23,26 +26,26 @@
 #include "VirGLProtocol.h"
 #include "Widget.h"
 
-static const char* frag_shader = "FRAG\n"
-                                 "PROPERTY FS_COLOR0_WRITES_ALL_CBUFS 1\n"
-                                 "DCL IN[0], COLOR, COLOR\n"
-                                 "DCL OUT[0], COLOR\n"
-                                 "  0: MOV OUT[0], IN[0]\n"
-                                 "  1: END\n";
+static constexpr StringView frag_shader = "FRAG\n"
+                                          "PROPERTY FS_COLOR0_WRITES_ALL_CBUFS 1\n"
+                                          "DCL IN[0], COLOR, COLOR\n"
+                                          "DCL OUT[0], COLOR\n"
+                                          "  0: MOV OUT[0], IN[0]\n"
+                                          "  1: END\n";
 
-static const char* vert_shader = "VERT\n"
-                                 "DCL IN[0]\n"
-                                 "DCL IN[1]\n"
-                                 "DCL OUT[0], POSITION\n"
-                                 "DCL OUT[1], COLOR\n"
-                                 "DCL CONST[0..3]\n"
-                                 "DCL TEMP[0..1]\n"
-                                 "  0: MUL TEMP[0], IN[0].xxxx, CONST[0]\n"
-                                 "  1: MAD TEMP[1], IN[0].yyyy, CONST[1], TEMP[0]\n"
-                                 "  2: MAD TEMP[0], IN[0].zzzz, CONST[2], TEMP[1]\n"
-                                 "  3: MAD OUT[0], IN[0].wwww, CONST[3], TEMP[0]\n"
-                                 "  4: MOV_SAT OUT[1], IN[1]\n"
-                                 "  5: END\n";
+static constexpr StringView vert_shader = "VERT\n"
+                                          "DCL IN[0]\n"
+                                          "DCL IN[1]\n"
+                                          "DCL OUT[0], POSITION\n"
+                                          "DCL OUT[1], COLOR\n"
+                                          "DCL CONST[0..3]\n"
+                                          "DCL TEMP[0..1]\n"
+                                          "  0: MUL TEMP[0], IN[0].xxxx, CONST[0]\n"
+                                          "  1: MAD TEMP[1], IN[0].yyyy, CONST[1], TEMP[0]\n"
+                                          "  2: MAD TEMP[0], IN[0].zzzz, CONST[2], TEMP[1]\n"
+                                          "  3: MAD OUT[0], IN[0].wwww, CONST[3], TEMP[0]\n"
+                                          "  4: MOV_SAT OUT[1], IN[1]\n"
+                                          "  5: END\n";
 
 struct VertexData {
     float r;
@@ -92,7 +95,7 @@ static ResourceID create_virgl_resource(VirGL3DResourceSpec& spec)
 static Vector<VertexData> gen_vertex_data()
 {
     Vector<VertexData> data;
-    static const VertexData vertices[8] = {
+    static constexpr Array<VertexData, 8> vertices = {
         VertexData { .r = 0, .g = 0, .b = 0, .x = -0.5, .y = -0.5, .z = -0.5 },
         VertexData { .r = 0, .g = 0, .b = 0, .x = 0.5, .y = -0.5, .z = -0.5 },
         VertexData { .r = 0, .g = 0, .b = 0, .x = -0.5, .y = 0.5, .z = -0.5 },
@@ -102,7 +105,7 @@ static Vector<VertexData> gen_vertex_data()
         VertexData { .r = 0, .g = 0, .b = 0, .x = -0.5, .y = 0.5, .z = 0.5 },
         VertexData { .r = 0, .g = 0, .b = 0, .x = 0.5, .y = 0.5, .z = 0.5 },
     };
-    size_t tris[36] = {
+    static constexpr Array<size_t, 36> tris = {
         0, 1, 2, 1, 3, 2, // Top
         4, 0, 6, 0, 2, 6, // Left
         4, 5, 0, 5, 1, 0, // Up

--- a/Userland/Games/Breakout/Game.h
+++ b/Userland/Games/Breakout/Game.h
@@ -16,8 +16,8 @@ class Game final : public GUI::Widget {
     C_OBJECT(Game);
 
 public:
-    static const int game_width = 480;
-    static const int game_height = 500;
+    static constexpr int game_width = 480;
+    static constexpr int game_height = 500;
 
     virtual ~Game() override = default;
 

--- a/Userland/Games/FlappyBug/Game.h
+++ b/Userland/Games/FlappyBug/Game.h
@@ -22,8 +22,8 @@ class Game final : public GUI::Frame {
     C_OBJECT(Game);
 
 public:
-    static const int game_width = 560;
-    static const int game_height = 480;
+    static constexpr int game_width = 560;
+    static constexpr int game_height = 480;
 
     Function<u32(u32)> on_game_end;
 

--- a/Userland/Games/Pong/Game.h
+++ b/Userland/Games/Pong/Game.h
@@ -23,8 +23,8 @@ class Game final : public GUI::Widget
     C_OBJECT(Game);
 
 public:
-    static const int game_width = 560;
-    static const int game_height = 480;
+    static constexpr int game_width = 560;
+    static constexpr int game_height = 480;
 
     virtual ~Game() override = default;
 

--- a/Userland/Libraries/LibAudio/Loader.h
+++ b/Userland/Libraries/LibAudio/Loader.h
@@ -20,8 +20,7 @@
 
 namespace Audio {
 
-static const String empty_string = "";
-static String no_plugin_error = "No loader plugin available";
+static constexpr StringView no_plugin_error = "No loader plugin available";
 
 using LoaderSamples = Result<NonnullRefPtr<Buffer>, LoaderError>;
 using MaybeLoaderError = Result<void, LoaderError>;

--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <LibCore/DateTime.h>
 #include <LibGUI/Calendar.h>
 #include <LibGUI/Painter.h>
@@ -16,21 +17,21 @@ REGISTER_WIDGET(GUI, Calendar);
 
 namespace GUI {
 
-static const char* long_day_names[] = {
+static constexpr Array<StringView, 7> long_day_names = {
     "Sunday", "Monday", "Tuesday", "Wednesday",
     "Thursday", "Friday", "Saturday"
 };
 
-static const char* short_day_names[] = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
-static const char* mini_day_names[] = { "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa" };
-static const char* micro_day_names[] = { "S", "M", "T", "W", "T", "F", "S" };
+static constexpr Array<StringView, 7> short_day_names = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
+static constexpr Array<StringView, 7> mini_day_names = { "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa" };
+static constexpr Array<StringView, 7> micro_day_names = { "S", "M", "T", "W", "T", "F", "S" };
 
-static const char* long_month_names[] = {
+static constexpr Array<StringView, 12> long_month_names = {
     "January", "February", "March", "April", "May", "June",
     "July", "August", "September", "October", "November", "December"
 };
 
-static const char* short_month_names[] = {
+static constexpr Array<StringView, 12> short_month_names = {
     "Jan", "Feb", "Mar", "Apr", "May", "Jun",
     "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
 };

--- a/Userland/Libraries/LibGUI/CheckBox.cpp
+++ b/Userland/Libraries/LibGUI/CheckBox.cpp
@@ -16,9 +16,9 @@ REGISTER_WIDGET(GUI, CheckBox)
 
 namespace GUI {
 
-static const int s_box_width = 13;
-static const int s_box_height = 13;
-static const int s_horizontal_padding = 6;
+static constexpr int s_box_width = 13;
+static constexpr int s_box_height = 13;
+static constexpr int s_horizontal_padding = 6;
 
 CheckBox::CheckBox(String text)
     : AbstractButton(move(text))

--- a/Userland/Libraries/LibGUI/FileIconProvider.cpp
+++ b/Userland/Libraries/LibGUI/FileIconProvider.cpp
@@ -1,9 +1,11 @@
 /*
  * Copyright (c) 2020-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/LexicalPath.h>
 #include <AK/String.h>
 #include <LibCore/ConfigFile.h>
@@ -178,7 +180,10 @@ Icon FileIconProvider::icon_for_executable(const String& path)
         int image_size;
     };
 
-    static const IconSection icon_sections[] = { { .section_name = "serenity_icon_s", .image_size = 16 }, { .section_name = "serenity_icon_m", .image_size = 32 } };
+    static constexpr Array<IconSection, 2> icon_sections = {
+        IconSection { .section_name = "serenity_icon_s", .image_size = 16 },
+        IconSection { .section_name = "serenity_icon_m", .image_size = 32 }
+    };
 
     bool had_error = false;
     for (const auto& icon_section : icon_sections) {

--- a/Userland/Libraries/LibGUI/LinkLabel.cpp
+++ b/Userland/Libraries/LibGUI/LinkLabel.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Alex McGrath <amk@amk.ie>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -48,7 +49,7 @@ void LinkLabel::set_hovered(bool hover)
 
 void LinkLabel::mousemove_event(MouseEvent& event)
 {
-    static const int extra_target_width = 3;
+    constexpr int extra_target_width = 3;
     set_hovered(event.position().x() <= font().width(text()) + extra_target_width);
 }
 

--- a/Userland/Libraries/LibGfx/GIFLoader.cpp
+++ b/Userland/Libraries/LibGfx/GIFLoader.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -16,8 +17,8 @@
 namespace Gfx {
 
 // Row strides and offsets for each interlace pass.
-static const int INTERLACE_ROW_STRIDES[] = { 8, 8, 4, 2 };
-static const int INTERLACE_ROW_OFFSETS[] = { 0, 4, 2, 1 };
+static constexpr Array<int, 4> INTERLACE_ROW_STRIDES = { 8, 8, 4, 2 };
+static constexpr Array<int, 4> INTERLACE_ROW_OFFSETS = { 0, 4, 2, 1 };
 
 struct GIFImageDescriptor {
     u16 x { 0 };

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -1,9 +1,11 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/Debug.h>
 #include <AK/Endian.h>
 #include <AK/Vector.h>
@@ -17,7 +19,7 @@
 
 namespace Gfx {
 
-static const u8 png_header[8] = { 0x89, 'P', 'N', 'G', 13, 10, 26, 10 };
+static constexpr Array<u8, 8> png_header = { 0x89, 'P', 'N', 'G', 13, 10, 26, 10 };
 
 struct PNG_IHDR {
     NetworkOrdered<u32> width;
@@ -516,7 +518,7 @@ static bool decode_png_header(PNGLoadingContext& context)
         return false;
     }
 
-    if (memcmp(context.data, png_header, sizeof(png_header)) != 0) {
+    if (memcmp(context.data, png_header.span().data(), sizeof(png_header)) != 0) {
         dbgln_if(PNG_DEBUG, "Invalid PNG header");
         context.state = PNGLoadingContext::State::Error;
         return false;

--- a/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/NumberPrototype.cpp
@@ -1,10 +1,12 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/Function.h>
 #include <AK/TypeCasts.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -19,7 +21,7 @@
 
 namespace JS {
 
-static const u8 max_precision_for_radix[37] = {
+static constexpr AK::Array<u8, 37> max_precision_for_radix = {
     // clang-format off
     0,  0,  52, 32, 26, 22, 20, 18, 17, 16,
     15, 15, 14, 14, 13, 13, 13, 12, 12, 12,
@@ -28,7 +30,11 @@ static const u8 max_precision_for_radix[37] = {
     // clang-format on
 };
 
-static char digits[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+static constexpr AK::Array<char, 36> digits = {
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9',
+    'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
+    'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z'
+};
 
 static String decimal_digits_to_string(double number)
 {

--- a/Userland/Libraries/LibM/math.cpp
+++ b/Userland/Libraries/LibM/math.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Mițca Dumitru <dumitru0mitca@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -63,11 +64,11 @@ union FloatExtractor;
 // This assumes long double is 80 bits, which is true with GCC on Intel platforms
 template<>
 union FloatExtractor<long double> {
-    static const int mantissa_bits = 64;
-    static const unsigned long long mantissa_max = ~0u;
-    static const int exponent_bias = 16383;
-    static const int exponent_bits = 15;
-    static const unsigned exponent_max = 32767;
+    static constexpr int mantissa_bits = 64;
+    static constexpr unsigned long long mantissa_max = ~0u;
+    static constexpr int exponent_bias = 16383;
+    static constexpr int exponent_bits = 15;
+    static constexpr unsigned exponent_max = 32767;
     struct {
         unsigned long long mantissa;
         unsigned exponent : 15;
@@ -79,11 +80,11 @@ union FloatExtractor<long double> {
 
 template<>
 union FloatExtractor<double> {
-    static const int mantissa_bits = 52;
-    static const unsigned long long mantissa_max = (1ull << 52) - 1;
-    static const int exponent_bias = 1023;
-    static const int exponent_bits = 11;
-    static const unsigned exponent_max = 2047;
+    static constexpr int mantissa_bits = 52;
+    static constexpr unsigned long long mantissa_max = (1ull << 52) - 1;
+    static constexpr int exponent_bias = 1023;
+    static constexpr int exponent_bits = 11;
+    static constexpr unsigned exponent_max = 2047;
     struct {
         unsigned long long mantissa : 52;
         unsigned exponent : 11;
@@ -94,11 +95,11 @@ union FloatExtractor<double> {
 
 template<>
 union FloatExtractor<float> {
-    static const int mantissa_bits = 23;
-    static const unsigned mantissa_max = (1 << 23) - 1;
-    static const int exponent_bias = 127;
-    static const int exponent_bits = 8;
-    static const unsigned exponent_max = 255;
+    static constexpr int mantissa_bits = 23;
+    static constexpr unsigned mantissa_max = (1 << 23) - 1;
+    static constexpr int exponent_bias = 127;
+    static constexpr int exponent_bits = 8;
+    static constexpr unsigned exponent_max = 255;
     struct {
         unsigned long long mantissa : 23;
         unsigned exponent : 8;

--- a/Userland/Libraries/LibPthread/forward.cpp
+++ b/Userland/Libraries/LibPthread/forward.cpp
@@ -1,12 +1,13 @@
 /*
  * Copyright (c) 2021, Gunnar Beutner <gunnar@beutner.name>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <LibC/bits/pthread_forward.h>
 
-static const PthreadFunctions s_functions = {
+static constexpr PthreadFunctions s_functions = {
     .pthread_mutex_trylock = pthread_mutex_trylock,
     .pthread_mutex_destroy = pthread_mutex_destroy,
 

--- a/Userland/Libraries/LibSQL/AST/Expression.cpp
+++ b/Userland/Libraries/LibSQL/AST/Expression.cpp
@@ -1,16 +1,18 @@
 /*
  * Copyright (c) 2021, Jan de Visser <jan@de-visser.net>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/StringView.h>
 #include <LibRegex/Regex.h>
 #include <LibSQL/AST/AST.h>
 #include <LibSQL/Database.h>
 
 namespace SQL::AST {
 
-static const String s_posix_basic_metacharacters = ".^$*[]+\\";
+static constexpr StringView s_posix_basic_metacharacters = ".^$*[]+\\";
 
 ResultOr<Value> NumericLiteral::evaluate(ExecutionContext&) const
 {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020-2021, the SerenityOS developers.
+ * Copyright (c) 2020-2022, the SerenityOS developers.
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -15,7 +15,7 @@
 
 // U+FFFD REPLACEMENT CHARACTER (�)
 #define REPLACEMENT_CHARACTER 0xFFFD
-static const u32 TOKENIZER_EOF = 0xFFFFFFFF;
+static constexpr u32 TOKENIZER_EOF = 0xFFFFFFFF;
 
 static inline void log_parse_error(const SourceLocation& location = SourceLocation::current())
 {

--- a/Userland/Libraries/LibX86/Instruction.h
+++ b/Userland/Libraries/LibX86/Instruction.h
@@ -29,9 +29,9 @@ protected:
 
 template<typename T>
 struct TypeTrivia {
-    static const size_t bits = sizeof(T) * 8;
-    static const T sign_bit = 1 << (bits - 1);
-    static const T mask = MakeUnsigned<T>(-1);
+    static constexpr size_t bits = sizeof(T) * 8;
+    static constexpr T sign_bit = 1 << (bits - 1);
+    static constexpr T mask = MakeUnsigned<T>(-1);
 };
 
 template<typename T, typename U>
@@ -189,7 +189,7 @@ enum InstructionFormat {
     OP_NEAR_imm,
 };
 
-static const unsigned CurrentAddressSize = 0xB33FBABE;
+static constexpr unsigned CurrentAddressSize = 0xB33FBABE;
 
 struct InstructionDescriptor {
     InstructionHandler handler { nullptr };

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -19,7 +19,7 @@
 
 namespace WindowServer {
 
-const static Gfx::IntSize s_default_normal_minimum_size = { 50, 50 };
+static constexpr Gfx::IntSize s_default_normal_minimum_size = { 50, 50 };
 
 static String default_window_icon_path()
 {

--- a/Userland/Utilities/ddate.cpp
+++ b/Userland/Utilities/ddate.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2021-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -43,9 +43,9 @@ public:
     }
 
 private:
-    static const int m_days_in_week = 5;
-    static const int m_days_in_season = 73;
-    static const int m_st_tibs_day_of_yold = 60;
+    static constexpr int m_days_in_week = 5;
+    static constexpr int m_days_in_season = 73;
+    static constexpr int m_st_tibs_day_of_yold = 60;
     Core::DateTime m_gregorian_date;
     String m_day_of_week;
     String m_season;

--- a/Userland/Utilities/lspci.cpp
+++ b/Userland/Utilities/lspci.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,6 +10,7 @@
 #include <AK/JsonObject.h>
 #include <AK/String.h>
 #include <AK/StringUtils.h>
+#include <AK/StringView.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
@@ -19,9 +21,9 @@
 static bool flag_show_numerical = false;
 static bool flag_verbose = false;
 
-static const char* format_numerical = "{:04x}:{:02x}:{:02x}.{} {}: {}:{} (rev {:02x})";
-static const char* format_textual = "{:04x}:{:02x}:{:02x}.{} {}: {} {} (rev {:02x})";
-static const char* format_region = "\tBAR {}: {} region @ {:#x}";
+static constexpr StringView format_numerical = "{:04x}:{:02x}:{:02x}.{} {}: {}:{} (rev {:02x})";
+static constexpr StringView format_textual = "{:04x}:{:02x}:{:02x}.{} {}: {} {} (rev {:02x})";
+static constexpr StringView format_region = "\tBAR {}: {} region @ {:#x}";
 
 static u32 read_hex_string_from_bytebuffer(ByteBuffer const& buf)
 {
@@ -50,7 +52,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_verbose, "Show verbose info on devices", "verbose", 'v');
     args_parser.parse(arguments);
 
-    const char* format = flag_show_numerical ? format_numerical : format_textual;
+    auto const format = flag_show_numerical ? format_numerical : format_textual;
 
     RefPtr<PCIDB::Database> db;
     if (!flag_show_numerical) {


### PR DESCRIPTION
`static const` variables can be computed and initialized at run-time
during initialization or the first time a function is called. Change
them to `static constexpr` to ensure they are computed at
compile-time.

This allows some removal of `strlen` because the length of the 
`StringView` can be used which is pre-computed at compile-time.