### PR TITLE
LibGUI+WindowServer: Make ListView and menu item heights depend on the font height

### DIFF
--- a/Userland/Libraries/LibGUI/ListView.h
+++ b/Userland/Libraries/LibGUI/ListView.h
@@ -15,7 +15,7 @@ class ListView : public AbstractView {
 public:
     virtual ~ListView() override;
 
-    int item_height() const { return 16; }
+    int item_height() const { return font().preferred_line_height() + vertical_padding(); }
 
     bool alternating_row_colors() const { return m_alternating_row_colors; }
     void set_alternating_row_colors(bool b) { m_alternating_row_colors = b; }
@@ -24,6 +24,7 @@ public:
     void set_hover_highlighting(bool b) { m_hover_highlighting = b; }
 
     int horizontal_padding() const { return m_horizontal_padding; }
+    int vertical_padding() const { return m_vertical_padding; }
 
     virtual void scroll_into_view(const ModelIndex& index, bool scroll_horizontally, bool scroll_vertically) override;
 
@@ -58,6 +59,7 @@ private:
     void update_content_size();
 
     int m_horizontal_padding { 2 };
+    int m_vertical_padding { 2 };
     int m_model_column { 0 };
     bool m_alternating_row_colors { true };
     bool m_hover_highlighting { false };

--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -95,6 +95,11 @@ int Menu::content_width() const
     return max(widest_item, rect_in_window_menubar().width()) + horizontal_padding() + frame_thickness() * 2;
 }
 
+int Menu::item_height() const
+{
+    return max(font().preferred_line_height(), s_item_icon_width + 2) + 4;
+}
+
 void Menu::redraw()
 {
     if (!menu_window())

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -86,7 +86,7 @@ public:
 
     int content_width() const;
 
-    static constexpr int item_height() { return 22; }
+    int item_height() const;
     static constexpr int frame_thickness() { return 2; }
     static constexpr int horizontal_padding() { return left_padding() + right_padding(); }
     static constexpr int left_padding() { return 14; }

--- a/Userland/Services/WindowServer/Menubar.h
+++ b/Userland/Services/WindowServer/Menubar.h
@@ -56,6 +56,13 @@ public:
         }
     }
 
+    void font_changed(Gfx::IntRect window_rect)
+    {
+        m_next_menu_location = { 0, 0 };
+        for (auto& menu : m_menus)
+            layout_menu(menu, window_rect);
+    }
+
 private:
     void layout_menu(Menu&, Gfx::IntRect window_rect);
 

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -2080,6 +2080,7 @@ void WindowManager::invalidate_after_theme_or_font_change()
     for_each_window_stack([&](auto& window_stack) {
         window_stack.for_each_window([&](Window& window) {
             window.frame().theme_changed();
+            window.menubar().font_changed(window.rect());
             return IterationDecision::Continue;
         });
         return IterationDecision::Continue;


### PR DESCRIPTION
…aaand update menu buttons’ rects on font change

aka *patches for your SerenityOS SmartTV*

Font | Current master | this pr
---|:-:|:-:
**Large** | ![large-master] Issues: cramped menu buttons in Terminal (restarting an app fixed it though), ListView items doesn’t show any text, and text in Start items are truncated… a bit | ![large-this]
**Small** | ![small-master] menu buttons in Terminal are too far from each other | ![small-this] ListView items are now smaller (which I like, tbh)

[large-master]: https://user-images.githubusercontent.com/16520278/158238677-cadd0f78-9538-4b4b-b441-e52d8090fb71.png
[large-this]: https://user-images.githubusercontent.com/16520278/158238670-e0341a16-674c-4177-8835-76dd2288b257.png
[small-master]: https://user-images.githubusercontent.com/16520278/158238680-010f3b3c-d805-415a-b667-ef73b09a710f.png
[small-this]: https://user-images.githubusercontent.com/16520278/158238675-08ec0ebd-9092-48a3-acc5-7707e0567750.png