### PR TITLE
LibWeb: Fix resolving relative URLs in style sheets

### DIFF
--- a/Base/res/html/misc/css-import-relative/css-import-4a.css
+++ b/Base/res/html/misc/css-import-relative/css-import-4a.css
@@ -1,0 +1,1 @@
+@import "css-import-4b.css";

--- a/Base/res/html/misc/css-import-relative/css-import-4b.css
+++ b/Base/res/html/misc/css-import-relative/css-import-4b.css
@@ -1,0 +1,1 @@
+p.fourth { background-color: lime; }

--- a/Base/res/html/misc/css-import.html
+++ b/Base/res/html/misc/css-import.html
@@ -5,6 +5,7 @@
 @import "css-import-1.css";
 @import url("css-import-2.css");
 @import url(css-import-3.css);
+@import "css-import-relative/css-import-4a.css";
 </style>
 </head>
 <body>
@@ -12,6 +13,7 @@
     <p class="first">If this is green, <code>@import "string";</code> works!</p>
     <p class="second">If this is green, <code>@import url("string");</code> works!</p>
     <p class="third">If this is green, <code>@import url(unquoted-string);</code> works!</p>
+    <p class="fourth">If this is green, relative <code>@import</code> resolves correctly!</p>
 </div>
 </body>
 </html>

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -77,7 +77,7 @@ void CSSImportRule::resource_did_load()
         dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Resource did load, has encoded data. URL: {}", resource()->url());
     }
 
-    auto sheet = parse_css(CSS::ParsingContext(*m_document), resource()->encoded_data());
+    auto sheet = parse_css(CSS::ParsingContext(*m_document, resource()->url()), resource()->encoded_data());
     if (!sheet) {
         dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Failed to parse stylesheet: {}", resource()->url());
         return;

--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -84,6 +84,9 @@ void CSSImportRule::resource_did_load()
     }
 
     m_style_sheet = move(sheet);
+
+    m_document->style_sheets().bump_generation();
+    m_document->invalidate_style();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -34,13 +34,21 @@ static void log_parse_error(const SourceLocation& location = SourceLocation::cur
 
 namespace Web::CSS {
 
+ParsingContext::ParsingContext(DOM::Document const& document, Optional<AK::URL> const url)
+    : m_document(&document)
+    , m_url(move(url))
+{
+}
+
 ParsingContext::ParsingContext(DOM::Document const& document)
     : m_document(&document)
+    , m_url(document.url())
 {
 }
 
 ParsingContext::ParsingContext(DOM::ParentNode& parent_node)
     : m_document(&parent_node.document())
+    , m_url(parent_node.document().url())
 {
 }
 
@@ -49,9 +57,10 @@ bool ParsingContext::in_quirks_mode() const
     return m_document ? m_document->in_quirks_mode() : false;
 }
 
+// https://www.w3.org/TR/css-values-4/#relative-urls
 AK::URL ParsingContext::complete_url(String const& addr) const
 {
-    return m_document ? m_document->url().complete_url(addr) : AK::URL::create_with_url_or_path(addr);
+    return m_url.has_value() ? m_url->complete_url(addr) : AK::URL::create_with_url_or_path(addr);
 }
 
 template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -39,6 +39,7 @@ class ParsingContext {
 public:
     ParsingContext() = default;
     explicit ParsingContext(DOM::Document const&);
+    explicit ParsingContext(DOM::Document const&, Optional<AK::URL> const);
     explicit ParsingContext(DOM::ParentNode&);
 
     bool in_quirks_mode() const;
@@ -51,6 +52,7 @@ public:
 private:
     DOM::Document const* m_document { nullptr };
     PropertyID m_current_property_id { PropertyID::Invalid };
+    Optional<AK::URL> m_url;
 };
 
 template<typename T>

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -90,7 +90,7 @@ void HTMLLinkElement::resource_did_load()
         dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Resource did load, has encoded data. URL: {}", resource()->url());
     }
 
-    auto sheet = parse_css(CSS::ParsingContext(document()), resource()->encoded_data());
+    auto sheet = parse_css(CSS::ParsingContext(document(), resource()->url()), resource()->encoded_data());
     if (!sheet) {
         dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Failed to parse stylesheet: {}", resource()->url());
         return;


### PR DESCRIPTION
While browsing https://quiltmc.org/ I realized that the reason it wasn't loading the CSS was because the two main style sheets (style-light.css and style-dark.css) were `@import`ed by style.css which itself is in a sub-directory.

[CSS Values 4 §4.5.1](https://www.w3.org/TR/css-values-4/#relative-urls) specifies that URLs should be relative to the style sheet, not the document.

While adding a test case for this scenario I also ran into the issue that the document style is not invalidated once `@import` results load.