### PR TITLE
LibGfx: Optimize Painter::blit when source format is RGBA8888

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1046,10 +1046,10 @@ void Painter::blit(IntPoint const& position, Gfx::Bitmap const& source, IntRect 
         size_t const src_skip = source.pitch() / sizeof(u32);
         for (int row = first_row; row <= last_row; ++row) {
             for (int i = 0; i < clipped_rect.width(); ++i) {
-                u32 rgba = src[i];
-                u32 bgra = (rgba & 0xff00ff00)
-                    | ((rgba & 0x000000ff) << 16)
-                    | ((rgba & 0x00ff0000) >> 16);
+                u32 bgra = src[i];
+                u8 const r = reinterpret_cast<u8*>(&bgra)[1];
+                reinterpret_cast<u8*>(&bgra)[1] = reinterpret_cast<u8*>(&bgra)[3]; // r = b
+                reinterpret_cast<u8*>(&bgra)[3] = r;                               // b = r
                 dst[i] = bgra;
             }
             dst += dst_skip;


### PR DESCRIPTION
By reimplementing the format conversion as a byte swap instead of using
explicit bitwise operations, the compiler is able to further optimize the
inner pixel transformation loop, saving three instructions on the final
binary which amounts to 10 bytes worth of code. For reference, here is the
disassembly of the original code as well as the new optimized version:

Original (17 insns)
```
        00034bf0 8b 0c b3        MOV        ECX,dword ptr [EBX + ESI*0x4]
        00034bf3 89 cf           MOV        EDI,ECX
        00034bf5 89 c8           MOV        EAX,ECX
        00034bf7 81 e1 00        AND        ECX,0xff00ff00
                 ff 00 ff
        00034bfd c1 ef 10        SHR        EDI,0x10
        00034c00 c1 e0 10        SHL        EAX,0x10
        00034c03 89 fa           MOV        EDX,EDI
        00034c05 25 00 00        AND        EAX,0xff0000
                 ff 00
        00034c0a 0f b6 fa        MOVZX      EDI,DL
        00034c0d 8b 55 a4        MOV        EDX,dword ptr [EBP + local_60]
        00034c10 09 f8           OR         EAX,EDI
        00034c12 09 c8           OR         EAX,ECX
        00034c14 89 04 b2        MOV        dword ptr [EDX + ESI*0x4],EAX
        00034c17 8b 45 cc        MOV        EAX,dword ptr [EBP + local_38]
        00034c1a 83 c6 01        ADD        ESI,0x1
        00034c1d 39 c6           CMP        ESI,EAX
        00034c1f 7c cf           JL         LAB_00034bf0
```

New (14 insns)
```
        00034c00 8b 04 b3        MOV        EAX,dword ptr [EBX + ESI*0x4]
        00034c03 89 c1           MOV        ECX,EAX
        00034c05 89 c2           MOV        EDX,EAX
        00034c07 0f b6 c4        MOVZX      EAX,AH
        00034c0a c1 e9 18        SHR        ECX,0x18
        00034c0d c1 e0 18        SHL        EAX,0x18
        00034c10 88 ce           MOV        DH,CL
        00034c12 81 e2 ff        AND        EDX,0xffffff
                 ff ff 00
        00034c18 09 c2           OR         EDX,EAX
        00034c1a 89 14 b7        MOV        dword ptr [EDI + ESI*0x4],EDX
        00034c1d 8b 45 cc        MOV        EAX,dword ptr [EBP + local_38]
        00034c20 83 c6 01        ADD        ESI,0x1
        00034c23 39 c6           CMP        ESI,EAX
        00034c25 7c d9           JL         LAB_00034c00
```