### PR TITLE
WindowServer: Change system menu behavior when using keyboard

### DIFF
--- a/Userland/Services/WindowServer/Menu.cpp
+++ b/Userland/Services/WindowServer/Menu.cpp
@@ -332,7 +332,10 @@ void Menu::descend_into_submenu_at_hovered_item()
     auto submenu = hovered_item()->submenu();
     VERIFY(submenu);
     MenuManager::the().open_menu(*submenu, true);
-    submenu->set_hovered_index(0);
+    if (submenu->did_change_position())
+        submenu->set_hovered_index(submenu->item_count() - 1 );
+    else
+        submenu->set_hovered_index(0);
     VERIFY(submenu->hovered_item()->type() != MenuItem::Separator);
 }
 
@@ -619,6 +622,7 @@ void Menu::do_popup(const Gfx::IntPoint& position, bool make_input, bool as_subm
     }
     if (adjusted_pos.y() + window.height() > screen.rect().bottom() - margin) {
         adjusted_pos = adjusted_pos.translated(0, -min(window.height(), adjusted_pos.y()));
+        m_did_change_position = true;
         if (as_submenu)
             adjusted_pos = adjusted_pos.translated(0, item_height());
     }

--- a/Userland/Services/WindowServer/Menu.h
+++ b/Userland/Services/WindowServer/Menu.h
@@ -35,7 +35,8 @@ public:
     int menu_id() const { return m_menu_id; }
 
     bool is_open() const;
-
+    bool did_change_position() const { return m_did_change_position; }
+    
     u32 alt_shortcut_character() const { return m_alt_shortcut_character; }
 
     bool is_empty() const { return m_items.is_empty(); }
@@ -157,7 +158,8 @@ private:
     Gfx::IntPoint m_last_position_in_hover;
     int m_theme_index_at_last_paint { -1 };
     int m_hovered_item_index { -1 };
-
+    
+    bool m_did_change_position { false };
     bool m_scrollable { false };
     int m_scroll_offset { 0 };
     int m_max_scroll_offset { 0 };


### PR DESCRIPTION
When navigating the system menu using keyboard, the default selected
item will now be the last item if the submenu is to big and changed
position, so it will always be closest to it's parent. 