### PR TITLE
LibWeb: Bring handling of anchor elements closer to spec 

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.cpp
@@ -428,4 +428,118 @@ RefPtr<DOM::Node> BrowsingContext::currently_focused_area()
     return candidate;
 }
 
+BrowsingContext* BrowsingContext::choose_a_browsing_context(StringView name, bool)
+{
+    // The rules for choosing a browsing context, given a browsing context name
+    // name, a browsing context current, and a boolean noopener are as follows:
+
+    // 1. Let chosen be null.
+    BrowsingContext* chosen = nullptr;
+
+    // FIXME: 2. Let windowType be "existing or none".
+
+    // FIXME: 3. Let sandboxingFlagSet be current's active document's active
+    // sandboxing flag set.
+
+    // 4. If name is the empty string or an ASCII case-insensitive match for "_self", then set chosen to current.
+    if (name.is_empty() || name.equals_ignoring_case("_self"sv))
+        chosen = this;
+
+    // 5. Otherwise, if name is an ASCII case-insensitive match for "_parent",
+    // set chosen to current's parent browsing context, if any, and current
+    // otherwise.
+    if (name.equals_ignoring_case("_parent"sv)) {
+        if (auto* parent = this->parent())
+            chosen = parent;
+        else
+            chosen = this;
+    }
+
+    // 6. Otherwise, if name is an ASCII case-insensitive match for "_top", set
+    // chosen to current's top-level browsing context, if any, and current
+    // otherwise.
+    if (name.equals_ignoring_case("_top"sv)) {
+        chosen = &top_level_browsing_context();
+    }
+
+    // FIXME: 7. Otherwise, if name is not an ASCII case-insensitive match for
+    // "_blank", there exists a browsing context whose name is the same as name,
+    // current is familiar with that browsing context, and the user agent
+    // determines that the two browsing contexts are related enough that it is
+    // ok if they reach each other, set chosen to that browsing context. If
+    // there are multiple matching browsing contexts, the user agent should set
+    // chosen to one in some arbitrary consistent manner, such as the most
+    // recently opened, most recently focused, or more closely related.
+    if (!name.equals_ignoring_case("_blank"sv)) {
+        chosen = this;
+    } else {
+        // 8. Otherwise, a new browsing context is being requested, and what
+        // happens depends on the user agent's configuration and abilities — it
+        // is determined by the rules given for the first applicable option from
+        // the following list:
+        dbgln("FIXME: Create a new browsing context!");
+
+        // --> If current's active window does not have transient activation and
+        //     the user agent has been configured to not show popups (i.e., the
+        //     user agent has a "popup blocker" enabled)
+        //
+        //     The user agent may inform the user that a popup has been blocked.
+
+        // --> If sandboxingFlagSet has the sandboxed auxiliary navigation
+        //     browsing context flag set
+        //
+        //     The user agent may report to a developer console that a popup has
+        //     been blocked.
+
+        // --> If the user agent has been configured such that in this instance
+        //     it will create a new browsing context
+        //
+        //     1. Set windowType to "new and unrestricted".
+
+        //     2. If current's top-level browsing context's active document's
+        //     cross-origin opener policy's value is "same-origin" or
+        //     "same-origin-plus-COEP", then:
+
+        //         2.1. Let currentDocument be current's active document.
+
+        //         2.2. If currentDocument's origin is not same origin with
+        //         currentDocument's relevant settings object's top-level
+        //         origin, then set noopener to true, name to "_blank", and
+        //         windowType to "new with no opener".
+
+        //     3. If noopener is true, then set chosen to the result of creating
+        //     a new top-level browsing context.
+
+        //     4. Otherwise:
+
+        //         4.1. Set chosen to the result of creating a new auxiliary
+        //         browsing context with current.
+
+        //         4.2. If sandboxingFlagSet's sandboxed navigation browsing
+        //         context flag is set, then current must be set as chosen's one
+        //         permitted sandboxed navigator.
+
+        //     5. If sandboxingFlagSet's sandbox propagates to auxiliary
+        //     browsing contexts flag is set, then all the flags that are set in
+        //     sandboxingFlagSet must be set in chosen's popup sandboxing flag
+        //     set.
+
+        //     6. If name is not an ASCII case-insensitive match for "_blank",
+        //     then set chosen's name to name.
+
+        // --> If the user agent has been configured such that in this instance
+        //     it will reuse current
+        //
+        //     Set chosen to current.
+
+        // --> If the user agent has been configured such that in this instance
+        //     it will not find a browsing context
+        //
+        //     Do nothing.
+    }
+
+    // 9. Return chosen and windowType.
+    return chosen;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContext.h
@@ -76,6 +76,8 @@ public:
 
     BrowsingContext const& top_level_browsing_context() const { return const_cast<BrowsingContext*>(this)->top_level_browsing_context(); }
 
+    BrowsingContext* choose_a_browsing_context(StringView name, bool noopener);
+
     HTML::BrowsingContextContainer* container() { return m_container; }
     HTML::BrowsingContextContainer const* container() const { return m_container; }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.cpp
@@ -11,6 +11,9 @@ namespace Web::HTML {
 HTMLAnchorElement::HTMLAnchorElement(DOM::Document& document, DOM::QualifiedName qualified_name)
     : HTMLElement(document, move(qualified_name))
 {
+    activation_behavior = [this](auto const& event) {
+        run_activation_behavior(event);
+    };
 }
 
 HTMLAnchorElement::~HTMLAnchorElement() = default;
@@ -31,6 +34,44 @@ String HTMLAnchorElement::hyperlink_element_utils_href() const
 void HTMLAnchorElement::set_hyperlink_element_utils_href(String href)
 {
     set_attribute(HTML::AttributeNames::href, move(href));
+}
+
+void HTMLAnchorElement::run_activation_behavior(Web::DOM::Event const&)
+{
+    // The activation behavior of an a element element given an event event is:
+
+    // 1. If element has no href attribute, then return.
+    if (href().is_empty())
+        return;
+
+    // 2. Let hyperlinkSuffix be null.
+    Optional<String> hyperlink_suffix {};
+
+    // FIXME: 3. If event's target is an img with an ismap attribute
+    //        specified, then:
+    //   3.1. Let x and y be 0.
+    //
+    //   3.2. If event's isTrusted attribute is initialized to true, then
+    //   set x to the distance in CSS pixels from the left edge of the image
+    //   to the location of the click, and set y to the distance in CSS
+    //   pixels from the top edge of the image to the location of the click.
+    //
+    //   3.3. If x is negative, set x to 0.
+    //
+    //   3.4. If y is negative, set y to 0.
+    //
+    //   3.5. Set hyperlinkSuffix to the concatenation of U+003F (?), the
+    //   value of x expressed as a base-ten integer using ASCII digits,
+    //   U+002C (,), and the value of y expressed as a base-ten integer
+    //   using ASCII digits.
+
+    // FIXME: 4. If element has a download attribute, or if the user has
+    // expressed a preference to download the hyperlink, then download the
+    // hyperlink created by element given hyperlinkSuffix.
+
+    // 5. Otherwise, follow the hyperlink created by element given
+    // hyperlinkSuffix.
+    follow_the_hyperlink(hyperlink_suffix);
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAnchorElement.h
@@ -21,19 +21,29 @@ public:
     virtual ~HTMLAnchorElement() override;
 
     String target() const { return attribute(HTML::AttributeNames::target); }
+    String download() const { return attribute(HTML::AttributeNames::download); }
 
     virtual bool is_focusable() const override { return has_attribute(HTML::AttributeNames::href); }
 
     virtual bool is_html_anchor_element() const override { return true; }
 
 private:
+    void run_activation_behavior(Web::DOM::Event const&);
+
     // ^DOM::Element
     virtual void parse_attribute(FlyString const& name, String const& value) override;
 
     // ^HTML::HTMLHyperlinkElementUtils
-    virtual DOM::Document const& hyperlink_element_utils_document() const override { return document(); }
+    virtual DOM::Document& hyperlink_element_utils_document() override { return document(); }
     virtual String hyperlink_element_utils_href() const override;
     virtual void set_hyperlink_element_utils_href(String) override;
+    virtual bool hyperlink_element_utils_is_html_anchor_element() const final { return true; }
+    virtual bool hyperlink_element_utils_is_connected() const final { return is_connected(); }
+    virtual String hyperlink_element_utils_target() const final { return target(); }
+    virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) override
+    {
+        queue_an_element_task(source, move(steps));
+    }
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLAreaElement.h
@@ -26,9 +26,16 @@ private:
     virtual void parse_attribute(FlyString const& name, String const& value) override;
 
     // ^HTML::HTMLHyperlinkElementUtils
-    virtual DOM::Document const& hyperlink_element_utils_document() const override { return document(); }
+    virtual DOM::Document& hyperlink_element_utils_document() override { return document(); }
     virtual String hyperlink_element_utils_href() const override;
     virtual void set_hyperlink_element_utils_href(String) override;
+    virtual bool hyperlink_element_utils_is_html_anchor_element() const override { return false; }
+    virtual bool hyperlink_element_utils_is_connected() const override { return is_connected(); }
+    virtual String hyperlink_element_utils_target() const override { return ""; }
+    virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) override
+    {
+        queue_an_element_task(source, move(steps));
+    }
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLHyperlinkElementUtils.h
@@ -8,6 +8,7 @@
 
 #include <AK/URL.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/HTML/EventLoop/Task.h>
 
 namespace Web::HTML {
 
@@ -48,15 +49,23 @@ public:
     void set_hash(String);
 
 protected:
-    virtual DOM::Document const& hyperlink_element_utils_document() const = 0;
+    virtual DOM::Document& hyperlink_element_utils_document() = 0;
     virtual String hyperlink_element_utils_href() const = 0;
     virtual void set_hyperlink_element_utils_href(String) = 0;
+    virtual bool hyperlink_element_utils_is_html_anchor_element() const = 0;
+    virtual bool hyperlink_element_utils_is_connected() const = 0;
+    virtual String hyperlink_element_utils_target() const = 0;
+    virtual void hyperlink_element_utils_queue_an_element_task(HTML::Task::Source source, Function<void()> steps) = 0;
 
     void set_the_url();
+    void follow_the_hyperlink(Optional<String> hyperlink_suffix);
 
 private:
     void reinitialize_url() const;
     void update_href();
+    bool cannot_navigate() const;
+    String get_an_elements_target() const;
+    bool get_an_elements_noopener(StringView target) const;
 
     Optional<AK::URL> m_url;
 };


### PR DESCRIPTION
This commit moves the regular handling of links to the anchor elements'
activation behavior, and implements a few auxiliary algorithms as
defined by the HTML specification.

Note that certain things such as javascript links, fragments and opening
a new tab are still handled directly in EventHandler, but they have been
moved to handle_mouseup so that it behaves closer to how it would if it
was entirely up-to-spec.

Depends on #13052.