### PR TITLE
LibJS: Reorganize spec steps for Intl objects

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Collator.h
@@ -38,7 +38,7 @@ public:
 
     static constexpr auto relevant_extension_keys()
     {
-        // 10.2.3 Internal Slots, https://tc39.es/ecma402/#sec-intl-collator-internal-slots
+        // 10.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl-collator-internal-slots
         // The value of the [[RelevantExtensionKeys]] internal slot is a List that must include the element "co", may include any or all of the elements "kf" and "kn", and must not include any other elements.
         return AK::Array { "co"sv, "kf"sv, "kn"sv };
     }

--- a/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/CollatorConstructor.cpp
@@ -14,7 +14,7 @@
 
 namespace JS::Intl {
 
-// 10.1.1 InitializeCollator ( collator, locales, options ), https://tc39.es/ecma402/#sec-initializecollator
+// 10.1.2 InitializeCollator ( collator, locales, options ), https://tc39.es/ecma402/#sec-initializecollator
 static ThrowCompletionOr<Collator*> initialize_collator(GlobalObject& global_object, Collator& collator, Value locales_value, Value options_value)
 {
     auto& vm = global_object.vm();
@@ -151,14 +151,14 @@ void CollatorConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.supportedLocalesOf, supported_locales_of, 1, attr);
 }
 
-// 10.1.2 Intl.Collator ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.collator
+// 10.1.1 Intl.Collator ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.collator
 ThrowCompletionOr<Value> CollatorConstructor::call()
 {
     // 1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget
     return TRY(construct(*this));
 }
 
-// 10.1.2 Intl.Collator ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.collator
+// 10.1.1 Intl.Collator ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.collator
 ThrowCompletionOr<Object*> CollatorConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -37,7 +37,7 @@ public:
 
     static constexpr auto relevant_extension_keys()
     {
-        // 11.3.3 Internal slots, https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots
+        // 11.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.datetimeformat-internal-slots
         // The value of the [[RelevantExtensionKeys]] internal slot is « "ca", "hc", "nu" ».
         return AK::Array { "ca"sv, "hc"sv, "nu"sv };
     }
@@ -160,7 +160,7 @@ enum class OptionDefaults {
     Time,
 };
 
-// Table 5: Record returned by ToLocalTime, https://tc39.es/ecma402/#table-datetimeformat-tolocaltime-record
+// Table 7: Record returned by ToLocalTime, https://tc39.es/ecma402/#table-datetimeformat-tolocaltime-record
 // Note: [[InDST]] is not included here - it is handled by LibUnicode / LibTimeZone.
 struct LocalTime {
     AK::Time time_since_epoch() const
@@ -200,7 +200,6 @@ struct PatternPartitionWithSource : public PatternPartition {
     StringView source;
 };
 
-ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& global_object, DateTimeFormat& date_time_format, Value locales_value, Value options_value);
 ThrowCompletionOr<Object*> to_date_time_options(GlobalObject& global_object, Value options_value, OptionRequired, OptionDefaults);
 Optional<Unicode::CalendarPattern> date_time_style_format(StringView data_locale, DateTimeFormat& date_time_format);
 Optional<Unicode::CalendarPattern> basic_format_matcher(Unicode::CalendarPattern const& options, Vector<Unicode::CalendarPattern> formats);
@@ -224,7 +223,7 @@ ThrowCompletionOr<void> for_each_calendar_field(GlobalObject& global_object, Uni
     constexpr auto two_digit_numeric_narrow_short_long = AK::Array { "2-digit"sv, "numeric"sv, "narrow"sv, "short"sv, "long"sv };
     constexpr auto time_zone = AK::Array { "short"sv, "long"sv, "shortOffset"sv, "longOffset"sv, "shortGeneric"sv, "longGeneric"sv };
 
-    // Table 4: Components of date and time formats, https://tc39.es/ecma402/#table-datetimeformat-components
+    // Table 6: Components of date and time formats, https://tc39.es/ecma402/#table-datetimeformat-components
     TRY(callback(pattern.weekday, vm.names.weekday, narrow_short_long));
     TRY(callback(pattern.era, vm.names.era, narrow_short_long));
     TRY(callback(pattern.year, vm.names.year, two_digit_numeric));

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,10 +10,13 @@
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibJS/Runtime/Intl/DateTimeFormat.h>
 #include <LibJS/Runtime/Intl/DateTimeFormatConstructor.h>
+#include <LibJS/Runtime/Temporal/TimeZone.h>
+#include <LibUnicode/DateTimeFormat.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
-// 11.2 The Intl.DateTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor
+// 11.1 The Intl.DateTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-datetimeformat-constructor
 DateTimeFormatConstructor::DateTimeFormatConstructor(GlobalObject& global_object)
     : NativeFunction(vm().names.DateTimeFormat.as_string(), *global_object.function_prototype())
 {
@@ -25,7 +28,7 @@ void DateTimeFormatConstructor::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 11.3.1 Intl.DateTimeFormat.prototype, https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype
+    // 11.2.1 Intl.DateTimeFormat.prototype, https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype
     define_direct_property(vm.names.prototype, global_object.intl_date_time_format_prototype(), 0);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
@@ -34,14 +37,14 @@ void DateTimeFormatConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-// 11.2.1 Intl.DateTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.datetimeformat
+// 11.1.1 Intl.DateTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.datetimeformat
 ThrowCompletionOr<Value> DateTimeFormatConstructor::call()
 {
     // 1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
     return TRY(construct(*this));
 }
 
-// 11.2.1 Intl.DateTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.datetimeformat
+// 11.1.1 Intl.DateTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.datetimeformat
 ThrowCompletionOr<Object*> DateTimeFormatConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -64,7 +67,7 @@ ThrowCompletionOr<Object*> DateTimeFormatConstructor::construct(FunctionObject& 
     return date_time_format;
 }
 
-// 11.3.2 Intl.DateTimeFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-intl.datetimeformat.supportedlocalesof
+// 11.2.2 Intl.DateTimeFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-intl.datetimeformat.supportedlocalesof
 JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatConstructor::supported_locales_of)
 {
     auto locales = vm.argument(0);
@@ -77,6 +80,312 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatConstructor::supported_locales_of)
 
     // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
     return TRY(supported_locales(global_object, requested_locales, options));
+}
+
+// 11.1.2 InitializeDateTimeFormat ( dateTimeFormat, locales, options ), https://tc39.es/ecma402/#sec-initializedatetimeformat
+ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& global_object, DateTimeFormat& date_time_format, Value locales_value, Value options_value)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = TRY(canonicalize_locale_list(global_object, locales_value));
+
+    // 2. Let options be ? ToDateTimeOptions(options, "any", "date").
+    auto* options = TRY(to_date_time_options(global_object, options_value, OptionRequired::Any, OptionDefaults::Date));
+
+    // 3. Let opt be a new Record.
+    LocaleOptions opt {};
+
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    auto matcher = TRY(get_option(global_object, *options, vm.names.localeMatcher, Value::Type::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
+
+    // 5. Set opt.[[localeMatcher]] to matcher.
+    opt.locale_matcher = matcher;
+
+    // 6. Let calendar be ? GetOption(options, "calendar", "string", undefined, undefined).
+    auto calendar = TRY(get_option(global_object, *options, vm.names.calendar, Value::Type::String, {}, Empty {}));
+
+    // 7. If calendar is not undefined, then
+    if (!calendar.is_undefined()) {
+        // a. If calendar does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
+        if (!Unicode::is_type_identifier(calendar.as_string().string()))
+            return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, calendar, "calendar"sv);
+
+        // 8. Set opt.[[ca]] to calendar.
+        opt.ca = calendar.as_string().string();
+    }
+
+    // 9. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    auto numbering_system = TRY(get_option(global_object, *options, vm.names.numberingSystem, Value::Type::String, {}, Empty {}));
+
+    // 10. If numberingSystem is not undefined, then
+    if (!numbering_system.is_undefined()) {
+        // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
+        if (!Unicode::is_type_identifier(numbering_system.as_string().string()))
+            return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
+
+        // 11. Set opt.[[nu]] to numberingSystem.
+        opt.nu = numbering_system.as_string().string();
+    }
+
+    // 12. Let hour12 be ? GetOption(options, "hour12", "boolean", undefined, undefined).
+    auto hour12 = TRY(get_option(global_object, *options, vm.names.hour12, Value::Type::Boolean, {}, Empty {}));
+
+    // 13. Let hourCycle be ? GetOption(options, "hourCycle", "string", « "h11", "h12", "h23", "h24" », undefined).
+    auto hour_cycle = TRY(get_option(global_object, *options, vm.names.hourCycle, Value::Type::String, AK::Array { "h11"sv, "h12"sv, "h23"sv, "h24"sv }, Empty {}));
+
+    // 14. If hour12 is not undefined, then
+    if (!hour12.is_undefined()) {
+        // a. Let hourCycle be null.
+        hour_cycle = js_null();
+    }
+
+    // 15. Set opt.[[hc]] to hourCycle.
+    if (!hour_cycle.is_nullish())
+        opt.hc = hour_cycle.as_string().string();
+
+    // 16. Let localeData be %DateTimeFormat%.[[LocaleData]].
+    // 17. Let r be ResolveLocale(%DateTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %DateTimeFormat%.[[RelevantExtensionKeys]], localeData).
+    auto result = resolve_locale(requested_locales, opt, DateTimeFormat::relevant_extension_keys());
+
+    // 18. Set dateTimeFormat.[[Locale]] to r.[[locale]].
+    date_time_format.set_locale(move(result.locale));
+
+    // 19. Let calendar be r.[[ca]].
+    // 20. Set dateTimeFormat.[[Calendar]] to calendar.
+    if (result.ca.has_value())
+        date_time_format.set_calendar(result.ca.release_value());
+
+    // 21. Set dateTimeFormat.[[HourCycle]] to r.[[hc]].
+    if (result.hc.has_value())
+        date_time_format.set_hour_cycle(result.hc.release_value());
+
+    // 22. Set dateTimeFormat.[[NumberingSystem]] to r.[[nu]].
+    if (result.nu.has_value())
+        date_time_format.set_numbering_system(result.nu.release_value());
+
+    // 23. Let dataLocale be r.[[dataLocale]].
+    auto data_locale = move(result.data_locale);
+
+    // Non-standard, the data locale is needed for LibUnicode lookups while formatting.
+    date_time_format.set_data_locale(data_locale);
+
+    // 24. Let timeZone be ? Get(options, "timeZone").
+    auto time_zone_value = TRY(options->get(vm.names.timeZone));
+    String time_zone;
+
+    // 25. If timeZone is undefined, then
+    if (time_zone_value.is_undefined()) {
+        // a. Let timeZone be DefaultTimeZone().
+        time_zone = Temporal::default_time_zone();
+    }
+    // 26. Else,
+    else {
+        // a. Let timeZone be ? ToString(timeZone).
+        time_zone = TRY(time_zone_value.to_string(global_object));
+
+        // b. If the result of IsValidTimeZoneName(timeZone) is false, then
+        if (!Temporal::is_valid_time_zone_name(time_zone)) {
+            // i. Throw a RangeError exception.
+            return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, time_zone, vm.names.timeZone);
+        }
+
+        // c. Let timeZone be CanonicalizeTimeZoneName(timeZone).
+        time_zone = Temporal::canonicalize_time_zone_name(time_zone);
+    }
+
+    // 27. Set dateTimeFormat.[[TimeZone]] to timeZone.
+    date_time_format.set_time_zone(move(time_zone));
+
+    // 28. Let formatOptions be a new Record.
+    Unicode::CalendarPattern format_options {};
+
+    // 29. For each row of Table 6, except the header row, in table order, do
+    TRY(for_each_calendar_field(global_object, format_options, [&](auto& option, auto const& property, auto const& defaults) -> ThrowCompletionOr<void> {
+        using ValueType = typename RemoveReference<decltype(option)>::ValueType;
+
+        // a. Let prop be the name given in the Property column of the row.
+
+        // b. If prop is "fractionalSecondDigits", then
+        if constexpr (IsIntegral<ValueType>) {
+            // i. Let value be ? GetNumberOption(options, "fractionalSecondDigits", 1, 3, undefined).
+            auto value = TRY(get_number_option(global_object, *options, property, 1, 3, {}));
+
+            // d. Set formatOptions.[[<prop>]] to value.
+            if (value.has_value())
+                option = static_cast<ValueType>(value.value());
+        }
+        // c. Else,
+        else {
+            // i. Let value be ? GetOption(options, prop, "string", « the strings given in the Values column of the row », undefined).
+            auto value = TRY(get_option(global_object, *options, property, Value::Type::String, defaults, Empty {}));
+
+            // d. Set formatOptions.[[<prop>]] to value.
+            if (!value.is_undefined())
+                option = Unicode::calendar_pattern_style_from_string(value.as_string().string());
+        }
+
+        return {};
+    }));
+
+    // 30. Let dataLocaleData be localeData.[[<dataLocale>]].
+
+    // 31. Let hcDefault be dataLocaleData.[[hourCycle]].
+    auto default_hour_cycle = Unicode::get_default_regional_hour_cycle(data_locale);
+
+    // Non-standard, default_hour_cycle will be empty if Unicode data generation is disabled.
+    if (!default_hour_cycle.has_value())
+        return &date_time_format;
+
+    // 32. Let hc be dateTimeFormat.[[HourCycle]].
+    // 33. If hc is null, then
+    //     a. Set hc to hcDefault.
+    auto hour_cycle_value = date_time_format.has_hour_cycle() ? date_time_format.hour_cycle() : *default_hour_cycle;
+
+    // 34. If hour12 is true, then
+    if (hour12.is_boolean() && hour12.as_bool()) {
+        // a. If hcDefault is "h11" or "h23", then
+        if ((default_hour_cycle == Unicode::HourCycle::H11) || (default_hour_cycle == Unicode::HourCycle::H23)) {
+            // i. Set hc to "h11".
+            hour_cycle_value = Unicode::HourCycle::H11;
+        }
+        // b. Else,
+        else {
+            // i. Set hc to "h12".
+            hour_cycle_value = Unicode::HourCycle::H12;
+        }
+    }
+    // 35. Else if hour12 is false, then
+    else if (hour12.is_boolean() && !hour12.as_bool()) {
+        // a. If hcDefault is "h11" or "h23", then
+        if ((default_hour_cycle == Unicode::HourCycle::H11) || (default_hour_cycle == Unicode::HourCycle::H23)) {
+            // i. Set hc to "h23".
+            hour_cycle_value = Unicode::HourCycle::H23;
+        }
+        // b. Else,
+        else {
+            // i. Set hc to "h24".
+            hour_cycle_value = Unicode::HourCycle::H24;
+        }
+    }
+    // 36. Else,
+    else {
+        // a. Assert: hour12 is undefined.
+        VERIFY(hour12.is_undefined());
+    }
+
+    // 37. Set dateTimeFormat.[[HourCycle]] to hc.
+    date_time_format.set_hour_cycle(hour_cycle_value);
+
+    // 38. Set formatOptions.[[hourCycle]] to hc.
+    format_options.hour_cycle = hour_cycle_value;
+
+    // 39. Let matcher be ? GetOption(options, "formatMatcher", "string", « "basic", "best fit" », "best fit").
+    matcher = TRY(get_option(global_object, *options, vm.names.formatMatcher, Value::Type::String, AK::Array { "basic"sv, "best fit"sv }, "best fit"sv));
+
+    // 40. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
+    auto date_style = TRY(get_option(global_object, *options, vm.names.dateStyle, Value::Type::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
+
+    // 41. Set dateTimeFormat.[[DateStyle]] to dateStyle.
+    if (!date_style.is_undefined())
+        date_time_format.set_date_style(date_style.as_string().string());
+
+    // 42. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
+    auto time_style = TRY(get_option(global_object, *options, vm.names.timeStyle, Value::Type::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
+
+    // 43. Set dateTimeFormat.[[TimeStyle]] to timeStyle.
+    if (!time_style.is_undefined())
+        date_time_format.set_time_style(time_style.as_string().string());
+
+    Optional<Unicode::CalendarPattern> best_format {};
+
+    // 44. If dateStyle is not undefined or timeStyle is not undefined, then
+    if (date_time_format.has_date_style() || date_time_format.has_time_style()) {
+        // a. For each row in Table 6, except the header row, do
+        TRY(for_each_calendar_field(global_object, format_options, [&](auto const& option, auto const& property, auto const&) -> ThrowCompletionOr<void> {
+            // i. Let prop be the name given in the Property column of the row.
+            // ii. Let p be formatOptions.[[<prop>]].
+            // iii. If p is not undefined, then
+            if (option.has_value()) {
+                // 1. Throw a TypeError exception.
+                return vm.throw_completion<TypeError>(global_object, ErrorType::IntlInvalidDateTimeFormatOption, property, "dateStyle or timeStyle"sv);
+            }
+
+            return {};
+        }));
+
+        // b. Let styles be dataLocaleData.[[styles]].[[<calendar>]].
+        // c. Let bestFormat be DateTimeStyleFormat(dateStyle, timeStyle, styles).
+        best_format = date_time_style_format(data_locale, date_time_format);
+    }
+    // 45. Else,
+    else {
+        // a. Let formats be dataLocaleData.[[formats]].[[<calendar>]].
+        auto formats = Unicode::get_calendar_available_formats(data_locale, date_time_format.calendar());
+
+        // b. If matcher is "basic", then
+        if (matcher.as_string().string() == "basic"sv) {
+            // i. Let bestFormat be BasicFormatMatcher(formatOptions, formats).
+            best_format = basic_format_matcher(format_options, move(formats));
+        }
+        // c. Else,
+        else {
+            // i. Let bestFormat be BestFitFormatMatcher(formatOptions, formats).
+            best_format = best_fit_format_matcher(format_options, move(formats));
+        }
+    }
+
+    // 46. For each row in Table 6, except the header row, in table order, do
+    date_time_format.for_each_calendar_field_zipped_with(*best_format, [&](auto& date_time_format_field, auto const& best_format_field, auto) {
+        // a. Let prop be the name given in the Property column of the row.
+        // b. If bestFormat has a field [[<prop>]], then
+        if (best_format_field.has_value()) {
+            // i. Let p be bestFormat.[[<prop>]].
+            // ii. Set dateTimeFormat's internal slot whose name is the Internal Slot column of the row to p.
+            date_time_format_field = best_format_field;
+        }
+    });
+
+    String pattern;
+    Vector<Unicode::CalendarRangePattern> range_patterns;
+
+    // 47. If dateTimeFormat.[[Hour]] is undefined, then
+    if (!date_time_format.has_hour()) {
+        // a. Set dateTimeFormat.[[HourCycle]] to undefined.
+        date_time_format.clear_hour_cycle();
+    }
+
+    // 48. If dateTimeformat.[[HourCycle]] is "h11" or "h12", then
+    if ((hour_cycle_value == Unicode::HourCycle::H11) || (hour_cycle_value == Unicode::HourCycle::H12)) {
+        // a. Let pattern be bestFormat.[[pattern12]].
+        if (best_format->pattern12.has_value()) {
+            pattern = best_format->pattern12.release_value();
+        } else {
+            // Non-standard, LibUnicode only provides [[pattern12]] when [[pattern]] has a day
+            // period. Other implementations provide [[pattern12]] as a copy of [[pattern]].
+            pattern = move(best_format->pattern);
+        }
+
+        // b. Let rangePatterns be bestFormat.[[rangePatterns12]].
+        range_patterns = Unicode::get_calendar_range12_formats(data_locale, date_time_format.calendar(), best_format->skeleton);
+    }
+    // 49. Else,
+    else {
+        // a. Let pattern be bestFormat.[[pattern]].
+        pattern = move(best_format->pattern);
+
+        // b. Let rangePatterns be bestFormat.[[rangePatterns]].
+        range_patterns = Unicode::get_calendar_range_formats(data_locale, date_time_format.calendar(), best_format->skeleton);
+    }
+
+    // 50. Set dateTimeFormat.[[Pattern]] to pattern.
+    date_time_format.set_pattern(move(pattern));
+
+    // 51. Set dateTimeFormat.[[RangePatterns]] to rangePatterns.
+    date_time_format.set_range_patterns(move(range_patterns));
+
+    // 52. Return dateTimeFormat.
+    return &date_time_format;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -26,5 +26,7 @@ private:
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);
 };
+
+ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& global_object, DateTimeFormat& date_time_format, Value locales_value, Value options_value);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,7 +13,7 @@
 
 namespace JS::Intl {
 
-// 11.1.6 DateTime Format Functions, https://tc39.es/ecma402/#sec-datetime-format-functions
+// 11.5.5 DateTime Format Functions, https://tc39.es/ecma402/#sec-datetime-format-functions
 DateTimeFormatFunction* DateTimeFormatFunction::create(GlobalObject& global_object, DateTimeFormat& date_time_format)
 {
     return global_object.heap().allocate<DateTimeFormatFunction>(global_object, date_time_format, *global_object.function_prototype());

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,7 +13,7 @@
 
 namespace JS::Intl {
 
-// 11.4 Properties of the Intl.DateTimeFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-datetimeformat-prototype-object
+// 11.3 Properties of the Intl.DateTimeFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-datetimeformat-prototype-object
 DateTimeFormatPrototype::DateTimeFormatPrototype(GlobalObject& global_object)
     : PrototypeObject(*global_object.object_prototype())
 {
@@ -25,7 +25,7 @@ void DateTimeFormatPrototype::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 11.4.2 Intl.DateTimeFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype-@@tostringtag
+    // 11.3.2 Intl.DateTimeFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype-@@tostringtag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.DateTimeFormat"), Attribute::Configurable);
 
     define_native_accessor(vm.names.format, format, nullptr, Attribute::Configurable);
@@ -37,7 +37,7 @@ void DateTimeFormatPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
-// 11.4.3 get Intl.DateTimeFormat.prototype.format, https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.format
+// 11.3.3 get Intl.DateTimeFormat.prototype.format, https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.format
 JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format)
 {
     // 1. Let dtf be the this value.
@@ -60,7 +60,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format)
     return date_time_format->bound_format();
 }
 
-// 11.4.4 Intl.DateTimeFormat.prototype.formatToParts ( date ), https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts
+// 11.3.4 Intl.DateTimeFormat.prototype.formatToParts ( date ), https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.formatToParts
 JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_to_parts)
 {
     auto date = vm.argument(0);
@@ -84,7 +84,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_to_parts)
     return TRY(format_date_time_to_parts(global_object, *date_time_format, date));
 }
 
-// 11.4.5 Intl.DateTimeFormat.prototype.formatRange ( startDate, endDate ), https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatRange
+// 11.3.5 Intl.DateTimeFormat.prototype.formatRange ( startDate, endDate ), https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.formatRange
 JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_range)
 {
     auto start_date = vm.argument(0);
@@ -111,7 +111,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_range)
     return js_string(vm, move(formatted));
 }
 
-// 11.4.6 Intl.DateTimeFormat.prototype.formatRangeToParts ( startDate, endDate ), https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.formatRangeToParts
+// 11.3.6 Intl.DateTimeFormat.prototype.formatRangeToParts ( startDate, endDate ), https://tc39.es/ecma402/#sec-Intl.DateTimeFormat.prototype.formatRangeToParts
 JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_range_to_parts)
 {
     auto start_date = vm.argument(0);
@@ -137,7 +137,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_range_to_parts)
     return TRY(format_date_time_range_to_parts(global_object, *date_time_format, start_date, end_date));
 }
 
-// 11.4.7 Intl.DateTimeFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions
+// 11.3.7 Intl.DateTimeFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.datetimeformat.prototype.resolvedoptions
 JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::resolved_options)
 {
     // 1. Let dtf be the this value.
@@ -149,7 +149,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::resolved_options)
     // 4. Let options be ! OrdinaryObjectCreate(%Object.prototype%).
     auto* options = Object::create(global_object, global_object.object_prototype());
 
-    // 5. For each row of Table 7, except the header row, in table order, do
+    // 5. For each row of Table 5, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. If p is "hour12", then
     //         i. Let hc be dtf.[[HourCycle]].
@@ -158,7 +158,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::resolved_options)
     //         iv. Else, let v be undefined.
     //     c. Else,
     //         i. Let v be the value of dtf's internal slot whose name is the Internal Slot value of the current row.
-    //     d. If the Internal Slot value of the current row is an Internal Slot value in Table 4, then
+    //     d. If the Internal Slot value of the current row is an Internal Slot value in Table 6, then
     //         i. If dtf.[[DateStyle]] is not undefined or dtf.[[TimeStyle]] is not undefined, then
     //             1. Let v be undefined.
     //     e. If v is not undefined, then

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -100,7 +100,7 @@ StringView DisplayNames::language_display_string() const
     }
 }
 
-// 12.1.1 CanonicalCodeForDisplayNames ( type, code ), https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames
+// 12.5.1 CanonicalCodeForDisplayNames ( type, code ), https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames
 ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_object, DisplayNames::Type type, StringView code)
 {
     auto& vm = global_object.vm();
@@ -177,10 +177,10 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_o
     return js_string(vm, code.to_uppercase_string());
 }
 
-// 12.2 IsValidDateTimeFieldCode ( field ), https://tc39.es/ecma402/#sec-isvaliddatetimefieldcode
+// 12.5.2 IsValidDateTimeFieldCode ( field ), https://tc39.es/ecma402/#sec-isvaliddatetimefieldcode
 bool is_valid_date_time_field_code(StringView field)
 {
-    // 1. If field is listed in the Code column of Table 8, return true.
+    // 1. If field is listed in the Code column of Table 9, return true.
     // 2. Return false.
     return field.is_one_of("era"sv, "year"sv, "quarter"sv, "month"sv, "weekOfYear"sv, "weekday"sv, "day"sv, "dayPeriod"sv, "hour"sv, "minute"sv, "second"sv, "timeZoneName"sv);
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesConstructor.cpp
@@ -15,7 +15,7 @@
 
 namespace JS::Intl {
 
-// 12.2 The Intl.DisplayNames Constructor, https://tc39.es/ecma402/#sec-intl-displaynames-constructor
+// 12.1 The Intl.DisplayNames Constructor, https://tc39.es/ecma402/#sec-intl-displaynames-constructor
 DisplayNamesConstructor::DisplayNamesConstructor(GlobalObject& global_object)
     : NativeFunction(vm().names.DisplayNames.as_string(), *global_object.function_prototype())
 {
@@ -27,7 +27,7 @@ void DisplayNamesConstructor::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 12.3.1 Intl.DisplayNames.prototype, https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype
+    // 12.2.1 Intl.DisplayNames.prototype, https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype
     define_direct_property(vm.names.prototype, global_object.intl_display_names_prototype(), 0);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
@@ -36,14 +36,14 @@ void DisplayNamesConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
 }
 
-// 12.2.1 Intl.DisplayNames ( locales, options ), https://tc39.es/ecma402/#sec-Intl.DisplayNames
+// 12.1.1 Intl.DisplayNames ( locales, options ), https://tc39.es/ecma402/#sec-Intl.DisplayNames
 ThrowCompletionOr<Value> DisplayNamesConstructor::call()
 {
     // 1. If NewTarget is undefined, throw a TypeError exception.
     return vm().throw_completion<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Intl.DisplayNames");
 }
 
-// 12.2.1 Intl.DisplayNames ( locales, options ), https://tc39.es/ecma402/#sec-Intl.DisplayNames
+// 12.1.1 Intl.DisplayNames ( locales, options ), https://tc39.es/ecma402/#sec-Intl.DisplayNames
 ThrowCompletionOr<Object*> DisplayNamesConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -134,7 +134,7 @@ ThrowCompletionOr<Object*> DisplayNamesConstructor::construct(FunctionObject& ne
     return display_names;
 }
 
-// 12.3.2 Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-Intl.DisplayNames.supportedLocalesOf
+// 12.2.2 Intl.DisplayNames.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-Intl.DisplayNames.supportedLocalesOf
 JS_DEFINE_NATIVE_FUNCTION(DisplayNamesConstructor::supported_locales_of)
 {
     auto locales = vm.argument(0);

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNamesPrototype.cpp
@@ -13,7 +13,7 @@
 
 namespace JS::Intl {
 
-// 12.4 Properties of the Intl.DisplayNames Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-displaynames-prototype-object
+// 12.3 Properties of the Intl.DisplayNames Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-displaynames-prototype-object
 DisplayNamesPrototype::DisplayNamesPrototype(GlobalObject& global_object)
     : PrototypeObject(*global_object.object_prototype())
 {
@@ -25,7 +25,7 @@ void DisplayNamesPrototype::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 12.4.2 Intl.DisplayNames.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype-@@tostringtag
+    // 12.3.2 Intl.DisplayNames.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype-@@tostringtag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.DisplayNames"), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
@@ -33,7 +33,7 @@ void DisplayNamesPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
-// 12.4.3 Intl.DisplayNames.prototype.of ( code ), https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.of
+// 12.3.3 Intl.DisplayNames.prototype.of ( code ), https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.of
 JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
 {
     auto code = vm.argument(0);
@@ -121,7 +121,7 @@ JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::of)
     return js_undefined();
 }
 
-// 12.4.4 Intl.DisplayNames.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.resolvedOptions
+// 12.3.4 Intl.DisplayNames.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-Intl.DisplayNames.prototype.resolvedOptions
 JS_DEFINE_NATIVE_FUNCTION(DisplayNamesPrototype::resolved_options)
 {
     // 1. Let displayNames be this value.

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -45,7 +45,7 @@ StringView ListFormat::type_string() const
     }
 }
 
-// 13.1.1 DeconstructPattern ( pattern, placeables ), https://tc39.es/ecma402/#sec-deconstructpattern
+// 13.5.1 DeconstructPattern ( pattern, placeables ), https://tc39.es/ecma402/#sec-deconstructpattern
 Vector<PatternPartition> deconstruct_pattern(StringView pattern, Placeables placeables)
 {
     // 1. Let patternParts be PartitionPattern(pattern).
@@ -92,7 +92,7 @@ Vector<PatternPartition> deconstruct_pattern(StringView pattern, Placeables plac
     return result;
 }
 
-// 13.1.2 CreatePartsFromList ( listFormat, list ), https://tc39.es/ecma402/#sec-createpartsfromlist
+// 13.5.2 CreatePartsFromList ( listFormat, list ), https://tc39.es/ecma402/#sec-createpartsfromlist
 Vector<PatternPartition> create_parts_from_list(ListFormat const& list_format, Vector<String> const& list)
 {
     auto list_patterns = Unicode::get_locale_list_patterns(list_format.locale(), list_format.type_string(), list_format.style());
@@ -181,7 +181,7 @@ Vector<PatternPartition> create_parts_from_list(ListFormat const& list_format, V
     return parts;
 }
 
-// 13.1.3 FormatList ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlist
+// 13.5.3 FormatList ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlist
 String format_list(ListFormat const& list_format, Vector<String> const& list)
 {
     // 1. Let parts be CreatePartsFromList(listFormat, list).
@@ -200,7 +200,7 @@ String format_list(ListFormat const& list_format, Vector<String> const& list)
     return result.build();
 }
 
-// 13.1.4 FormatListToParts ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlisttoparts
+// 13.5.4 FormatListToParts ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlisttoparts
 Array* format_list_to_parts(GlobalObject& global_object, ListFormat const& list_format, Vector<String> const& list)
 {
     auto& vm = global_object.vm();
@@ -236,7 +236,7 @@ Array* format_list_to_parts(GlobalObject& global_object, ListFormat const& list_
     return result;
 }
 
-// 13.1.5 StringListFromIterable ( iterable ), https://tc39.es/ecma402/#sec-createstringlistfromiterable
+// 13.5.5 StringListFromIterable ( iterable ), https://tc39.es/ecma402/#sec-createstringlistfromiterable
 ThrowCompletionOr<Vector<String>> string_list_from_iterable(GlobalObject& global_object, Value iterable)
 {
     auto& vm = global_object.vm();

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -14,7 +14,7 @@
 
 namespace JS::Intl {
 
-// 13.2 The Intl.ListFormat Constructor, https://tc39.es/ecma402/#sec-intl-listformat-constructor
+// 13.1 The Intl.ListFormat Constructor, https://tc39.es/ecma402/#sec-intl-listformat-constructor
 ListFormatConstructor::ListFormatConstructor(GlobalObject& global_object)
     : NativeFunction(vm().names.ListFormat.as_string(), *global_object.function_prototype())
 {
@@ -26,7 +26,7 @@ void ListFormatConstructor::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 13.3.1 Intl.ListFormat.prototype, https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype
+    // 13.2.1 Intl.ListFormat.prototype, https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype
     define_direct_property(vm.names.prototype, global_object.intl_list_format_prototype(), 0);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
@@ -35,14 +35,14 @@ void ListFormatConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-// 13.2.1 Intl.ListFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat
+// 13.1.1 Intl.ListFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat
 ThrowCompletionOr<Value> ListFormatConstructor::call()
 {
     // 1. If NewTarget is undefined, throw a TypeError exception.
     return vm().throw_completion<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Intl.ListFormat");
 }
 
-// 13.2.1 Intl.ListFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat
+// 13.1.1 Intl.ListFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat
 ThrowCompletionOr<Object*> ListFormatConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -95,7 +95,7 @@ ThrowCompletionOr<Object*> ListFormatConstructor::construct(FunctionObject& new_
     return list_format;
 }
 
-// 13.3.2 Intl.ListFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat.supportedLocalesOf
+// 13.2.2 Intl.ListFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-Intl.ListFormat.supportedLocalesOf
 JS_DEFINE_NATIVE_FUNCTION(ListFormatConstructor::supported_locales_of)
 {
     auto locales = vm.argument(0);

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,7 +12,7 @@
 
 namespace JS::Intl {
 
-// 13.4 Properties of the Intl.ListFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-listformat-prototype-object
+// 13.3 Properties of the Intl.ListFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-listformat-prototype-object
 ListFormatPrototype::ListFormatPrototype(GlobalObject& global_object)
     : PrototypeObject(*global_object.object_prototype())
 {
@@ -24,7 +24,7 @@ void ListFormatPrototype::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 13.4.2 Intl.ListFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype-toStringTag
+    // 13.3.2 Intl.ListFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype-toStringTag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.ListFormat"), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
@@ -33,7 +33,7 @@ void ListFormatPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
-// 13.4.3 Intl.ListFormat.prototype.format ( list ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.format
+// 13.3.3 Intl.ListFormat.prototype.format ( list ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.format
 JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format)
 {
     auto list = vm.argument(0);
@@ -50,7 +50,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format)
     return js_string(vm, move(formatted));
 }
 
-// 13.4.4 Intl.ListFormat.prototype.formatToParts ( list ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.formatToParts
+// 13.3.4 Intl.ListFormat.prototype.formatToParts ( list ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.formatToParts
 JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format_to_parts)
 {
     auto list = vm.argument(0);
@@ -66,7 +66,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format_to_parts)
     return format_list_to_parts(global_object, *list_format, string_list);
 }
 
-// 13.4.5 Intl.ListFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.resolvedoptions
+// 13.3.5 Intl.ListFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-Intl.ListFormat.prototype.resolvedoptions
 JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::resolved_options)
 {
     // 1. Let lf be the this value.
@@ -76,7 +76,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::resolved_options)
     // 3. Let options be ! OrdinaryObjectCreate(%Object.prototype%).
     auto* options = Object::create(global_object, global_object.object_prototype());
 
-    // 4. For each row of Table 9, except the header row, in table order, do
+    // 4. For each row of Table 10, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of lf's internal slot whose name is the Internal Slot value of the current row.
     //     c. Assert: v is not undefined.

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -40,7 +40,7 @@ static ThrowCompletionOr<Optional<String>> get_string_option(GlobalObject& globa
     return option.as_string().string();
 }
 
-// 14.1.1 ApplyOptionsToTag ( tag, options ), https://tc39.es/ecma402/#sec-apply-options-to-tag
+// 14.1.2 ApplyOptionsToTag ( tag, options ), https://tc39.es/ecma402/#sec-apply-options-to-tag
 static ThrowCompletionOr<String> apply_options_to_tag(GlobalObject& global_object, StringView tag, Object const& options)
 {
     auto& vm = global_object.vm();
@@ -107,7 +107,7 @@ static ThrowCompletionOr<String> apply_options_to_tag(GlobalObject& global_objec
     return JS::Intl::canonicalize_unicode_locale_id(*locale_id);
 }
 
-// 14.1.2 ApplyUnicodeExtensionToTag ( tag, options, relevantExtensionKeys ), https://tc39.es/ecma402/#sec-apply-unicode-extension-to-tag
+// 14.1.3 ApplyUnicodeExtensionToTag ( tag, options, relevantExtensionKeys ), https://tc39.es/ecma402/#sec-apply-unicode-extension-to-tag
 static LocaleAndKeys apply_unicode_extension_to_tag(StringView tag, LocaleAndKeys options, Span<StringView const> relevant_extension_keys)
 {
     // 1. Assert: Type(tag) is String.
@@ -236,14 +236,14 @@ void LocaleConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(1), Attribute::Configurable);
 }
 
-// 14.1.3 Intl.Locale ( tag [ , options ] ), https://tc39.es/ecma402/#sec-Intl.Locale
+// 14.1.1 Intl.Locale ( tag [ , options ] ), https://tc39.es/ecma402/#sec-Intl.Locale
 ThrowCompletionOr<Value> LocaleConstructor::call()
 {
     // 1. If NewTarget is undefined, throw a TypeError exception.
     return vm().throw_completion<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Intl.Locale");
 }
 
-// 14.1.3 Intl.Locale ( tag [ , options ] ), https://tc39.es/ecma402/#sec-Intl.Locale
+// 14.1.1 Intl.Locale ( tag [ , options ] ), https://tc39.es/ecma402/#sec-Intl.Locale
 ThrowCompletionOr<Object*> LocaleConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -124,7 +124,7 @@ public:
 
     static constexpr auto relevant_extension_keys()
     {
-        // 15.3.3 Internal slots, https://tc39.es/ecma402/#sec-intl.numberformat-internal-slots
+        // 15.2.3 Internal slots, https://tc39.es/ecma402/#sec-intl.numberformat-internal-slots
         // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
         return AK::Array { "nu"sv };
     }
@@ -220,8 +220,6 @@ struct RawFormatResult : public FormatResult {
     int digits { 0 }; // [[IntegerDigitsCount]]
 };
 
-ThrowCompletionOr<void> set_number_format_digit_options(GlobalObject& global_object, NumberFormatBase& intl_object, Object const& options, int default_min_fraction_digits, int default_max_fraction_digits, NumberFormat::Notation notation);
-ThrowCompletionOr<NumberFormat*> initialize_number_format(GlobalObject& global_object, NumberFormat& number_format, Value locales_value, Value options_value);
 int currency_digits(StringView currency);
 FormatResult format_numeric_to_string(GlobalObject& global_object, NumberFormatBase& intl_object, Value number);
 Vector<PatternPartition> partition_number_pattern(GlobalObject& global_object, NumberFormat& number_format, Value number);
@@ -230,7 +228,6 @@ String format_numeric(GlobalObject& global_object, NumberFormat& number_format, 
 Array* format_numeric_to_parts(GlobalObject& global_object, NumberFormat& number_format, Value number);
 RawFormatResult to_raw_precision(GlobalObject& global_object, Value number, int min_precision, int max_precision);
 RawFormatResult to_raw_fixed(GlobalObject& global_object, Value number, int min_fraction, int max_fraction);
-ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_object, NumberFormat& intl_object, Object const& options);
 Optional<Variant<StringView, String>> get_number_format_pattern(NumberFormat& number_format, Value number, Unicode::NumberFormat& found_pattern);
 Optional<StringView> get_notation_sub_pattern(NumberFormat& number_format, int exponent);
 int compute_exponent(GlobalObject& global_object, NumberFormat& number_format, Value number);

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,12 +8,12 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
-#include <LibJS/Runtime/Intl/NumberFormat.h>
 #include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
-// 15.2 The Intl.NumberFormat Constructor, https://tc39.es/ecma402/#sec-intl-numberformat-constructor
+// 15.1 The Intl.NumberFormat Constructor, https://tc39.es/ecma402/#sec-intl-numberformat-constructor
 NumberFormatConstructor::NumberFormatConstructor(GlobalObject& global_object)
     : NativeFunction(vm().names.NumberFormat.as_string(), *global_object.function_prototype())
 {
@@ -25,7 +25,7 @@ void NumberFormatConstructor::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 15.3.1 Intl.NumberFormat.prototype, https://tc39.es/ecma402/#sec-intl.numberformat.prototype
+    // 15.2.1 Intl.NumberFormat.prototype, https://tc39.es/ecma402/#sec-intl.numberformat.prototype
     define_direct_property(vm.names.prototype, global_object.intl_number_format_prototype(), 0);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
@@ -34,14 +34,14 @@ void NumberFormatConstructor::initialize(GlobalObject& global_object)
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 }
 
-// 15.2.1 Intl.NumberFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.numberformat
+// 15.1.1 Intl.NumberFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.numberformat
 ThrowCompletionOr<Value> NumberFormatConstructor::call()
 {
     // 1. If NewTarget is undefined, let newTarget be the active function object, else let newTarget be NewTarget.
     return TRY(construct(*this));
 }
 
-// 15.2.1 Intl.NumberFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.numberformat
+// 15.1.1 Intl.NumberFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.numberformat
 ThrowCompletionOr<Object*> NumberFormatConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -64,7 +64,7 @@ ThrowCompletionOr<Object*> NumberFormatConstructor::construct(FunctionObject& ne
     return number_format;
 }
 
-// 15.3.2 Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-intl.numberformat.supportedlocalesof
+// 15.2.2 Intl.NumberFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-intl.numberformat.supportedlocalesof
 JS_DEFINE_NATIVE_FUNCTION(NumberFormatConstructor::supported_locales_of)
 {
     auto locales = vm.argument(0);
@@ -77,6 +77,315 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatConstructor::supported_locales_of)
 
     // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
     return TRY(supported_locales(global_object, requested_locales, options));
+}
+
+// 15.1.2 InitializeNumberFormat ( numberFormat, locales, options ), https://tc39.es/ecma402/#sec-initializenumberformat
+ThrowCompletionOr<NumberFormat*> initialize_number_format(GlobalObject& global_object, NumberFormat& number_format, Value locales_value, Value options_value)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = TRY(canonicalize_locale_list(global_object, locales_value));
+
+    // 2. Set options to ? CoerceOptionsToObject(options).
+    auto* options = TRY(coerce_options_to_object(global_object, options_value));
+
+    // 3. Let opt be a new Record.
+    LocaleOptions opt {};
+
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    auto matcher = TRY(get_option(global_object, *options, vm.names.localeMatcher, Value::Type::String, { "lookup"sv, "best fit"sv }, "best fit"sv));
+
+    // 5. Set opt.[[localeMatcher]] to matcher.
+    opt.locale_matcher = matcher;
+
+    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    auto numbering_system = TRY(get_option(global_object, *options, vm.names.numberingSystem, Value::Type::String, {}, Empty {}));
+
+    // 7. If numberingSystem is not undefined, then
+    if (!numbering_system.is_undefined()) {
+        // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
+        if (!Unicode::is_type_identifier(numbering_system.as_string().string()))
+            return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
+
+        // 8. Set opt.[[nu]] to numberingSystem.
+        opt.nu = numbering_system.as_string().string();
+    }
+
+    // 9. Let localeData be %NumberFormat%.[[LocaleData]].
+    // 10. Let r be ResolveLocale(%NumberFormat%.[[AvailableLocales]], requestedLocales, opt, %NumberFormat%.[[RelevantExtensionKeys]], localeData).
+    auto result = resolve_locale(requested_locales, opt, NumberFormat::relevant_extension_keys());
+
+    // 11. Set numberFormat.[[Locale]] to r.[[locale]].
+    number_format.set_locale(move(result.locale));
+
+    // 12. Set numberFormat.[[DataLocale]] to r.[[dataLocale]].
+    number_format.set_data_locale(move(result.data_locale));
+
+    // 13. Set numberFormat.[[NumberingSystem]] to r.[[nu]].
+    if (result.nu.has_value())
+        number_format.set_numbering_system(result.nu.release_value());
+
+    // 14. Perform ? SetNumberFormatUnitOptions(numberFormat, options).
+    TRY(set_number_format_unit_options(global_object, number_format, *options));
+
+    // 15. Let style be numberFormat.[[Style]].
+    auto style = number_format.style();
+
+    int default_min_fraction_digits = 0;
+    int default_max_fraction_digits = 0;
+
+    // 16. If style is "currency", then
+    if (style == NumberFormat::Style::Currency) {
+        // a. Let currency be numberFormat.[[Currency]].
+        auto const& currency = number_format.currency();
+
+        // b. Let cDigits be CurrencyDigits(currency).
+        int digits = currency_digits(currency);
+
+        // c. Let mnfdDefault be cDigits.
+        default_min_fraction_digits = digits;
+
+        // d. Let mxfdDefault be cDigits.
+        default_max_fraction_digits = digits;
+    }
+    // 17. Else,
+    else {
+        // a. Let mnfdDefault be 0.
+        default_min_fraction_digits = 0;
+
+        // b. If style is "percent", then
+        //     i. Let mxfdDefault be 0.
+        // c. Else,
+        //     i. Let mxfdDefault be 3.
+        default_max_fraction_digits = style == NumberFormat::Style::Percent ? 0 : 3;
+    }
+
+    // 18. Let notation be ? GetOption(options, "notation", "string", « "standard", "scientific", "engineering", "compact" », "standard").
+    auto notation = TRY(get_option(global_object, *options, vm.names.notation, Value::Type::String, { "standard"sv, "scientific"sv, "engineering"sv, "compact"sv }, "standard"sv));
+
+    // 19. Set numberFormat.[[Notation]] to notation.
+    number_format.set_notation(notation.as_string().string());
+
+    // 20. Perform ? SetNumberFormatDigitOptions(numberFormat, options, mnfdDefault, mxfdDefault, notation).
+    TRY(set_number_format_digit_options(global_object, number_format, *options, default_min_fraction_digits, default_max_fraction_digits, number_format.notation()));
+
+    // 21. Let compactDisplay be ? GetOption(options, "compactDisplay", "string", « "short", "long" », "short").
+    auto compact_display = TRY(get_option(global_object, *options, vm.names.compactDisplay, Value::Type::String, { "short"sv, "long"sv }, "short"sv));
+
+    // 22. If notation is "compact", then
+    if (number_format.notation() == NumberFormat::Notation::Compact) {
+        // a. Set numberFormat.[[CompactDisplay]] to compactDisplay.
+        number_format.set_compact_display(compact_display.as_string().string());
+    }
+
+    // 23. Let useGrouping be ? GetOption(options, "useGrouping", "boolean", undefined, true).
+    auto use_grouping = TRY(get_option(global_object, *options, vm.names.useGrouping, Value::Type::Boolean, {}, true));
+
+    // 24. Set numberFormat.[[UseGrouping]] to useGrouping.
+    number_format.set_use_grouping(use_grouping.as_bool());
+
+    // 25. Let signDisplay be ? GetOption(options, "signDisplay", "string", « "auto", "never", "always", "exceptZero" », "auto").
+    auto sign_display = TRY(get_option(global_object, *options, vm.names.signDisplay, Value::Type::String, { "auto"sv, "never"sv, "always"sv, "exceptZero"sv }, "auto"sv));
+
+    // 26. Set numberFormat.[[SignDisplay]] to signDisplay.
+    number_format.set_sign_display(sign_display.as_string().string());
+
+    // 27. Return numberFormat.
+    return &number_format;
+}
+
+// 15.1.3 SetNumberFormatDigitOptions ( intlObj, options, mnfdDefault, mxfdDefault, notation ), https://tc39.es/ecma402/#sec-setnfdigitoptions
+ThrowCompletionOr<void> set_number_format_digit_options(GlobalObject& global_object, NumberFormatBase& intl_object, Object const& options, int default_min_fraction_digits, int default_max_fraction_digits, NumberFormat::Notation notation)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Let mnid be ? GetNumberOption(options, "minimumIntegerDigits,", 1, 21, 1).
+    auto min_integer_digits = TRY(get_number_option(global_object, options, vm.names.minimumIntegerDigits, 1, 21, 1));
+
+    // 2. Let mnfd be ? Get(options, "minimumFractionDigits").
+    auto min_fraction_digits = TRY(options.get(vm.names.minimumFractionDigits));
+
+    // 3. Let mxfd be ? Get(options, "maximumFractionDigits").
+    auto max_fraction_digits = TRY(options.get(vm.names.maximumFractionDigits));
+
+    // 4. Let mnsd be ? Get(options, "minimumSignificantDigits").
+    auto min_significant_digits = TRY(options.get(vm.names.minimumSignificantDigits));
+
+    // 5. Let mxsd be ? Get(options, "maximumSignificantDigits").
+    auto max_significant_digits = TRY(options.get(vm.names.maximumSignificantDigits));
+
+    // 6. Set intlObj.[[MinimumIntegerDigits]] to mnid.
+    intl_object.set_min_integer_digits(*min_integer_digits);
+
+    // 7. If mnsd is not undefined or mxsd is not undefined, then
+    //     a. Let hasSd be true.
+    // 8. Else,
+    //     a. Let hasSd be false.
+    bool has_significant_digits = !min_significant_digits.is_undefined() || !max_significant_digits.is_undefined();
+
+    // 9. If mnfd is not undefined or mxfd is not undefined, then
+    //     a. Let hasFd be true.
+    // 10. Else,
+    //     a. Let hasFd be false.
+    bool has_fraction_digits = !min_fraction_digits.is_undefined() || !max_fraction_digits.is_undefined();
+
+    // 11. Let needSd be hasSd.
+    bool need_significant_digits = has_significant_digits;
+
+    // 12. If hasSd is true, or hasFd is false and notation is "compact", then
+    //     a. Let needFd be false.
+    // 13. Else,
+    //     a. Let needFd be true.
+    bool need_fraction_digits = !has_significant_digits && (has_fraction_digits || (notation != NumberFormat::Notation::Compact));
+
+    // 14. If needSd is true, then
+    if (need_significant_digits) {
+        // a. Assert: hasSd is true.
+        VERIFY(has_significant_digits);
+
+        // b. Set mnsd to ? DefaultNumberOption(mnsd, 1, 21, 1).
+        auto min_digits = TRY(default_number_option(global_object, min_significant_digits, 1, 21, 1));
+
+        // c. Set mxsd to ? DefaultNumberOption(mxsd, mnsd, 21, 21).
+        auto max_digits = TRY(default_number_option(global_object, max_significant_digits, *min_digits, 21, 21));
+
+        // d. Set intlObj.[[MinimumSignificantDigits]] to mnsd.
+        intl_object.set_min_significant_digits(*min_digits);
+
+        // e. Set intlObj.[[MaximumSignificantDigits]] to mxsd.
+        intl_object.set_max_significant_digits(*max_digits);
+    }
+
+    // 15. If needFd is true, then
+    if (need_fraction_digits) {
+        // a. If hasFd is true, then
+        if (has_fraction_digits) {
+            // i. Set mnfd to ? DefaultNumberOption(mnfd, 0, 20, undefined).
+            auto min_digits = TRY(default_number_option(global_object, min_fraction_digits, 0, 20, {}));
+
+            // ii. Set mxfd to ? DefaultNumberOption(mxfd, 0, 20, undefined).
+            auto max_digits = TRY(default_number_option(global_object, max_fraction_digits, 0, 20, {}));
+
+            // iii. If mnfd is undefined, set mnfd to min(mnfdDefault, mxfd).
+            if (!min_digits.has_value())
+                min_digits = min(default_min_fraction_digits, *max_digits);
+            // iv. Else if mxfd is undefined, set mxfd to max(mxfdDefault, mnfd).
+            else if (!max_digits.has_value())
+                max_digits = max(default_max_fraction_digits, *min_digits);
+            // v. Else if mnfd is greater than mxfd, throw a RangeError exception.
+            else if (*min_digits > *max_digits)
+                return vm.throw_completion<RangeError>(global_object, ErrorType::IntlMinimumExceedsMaximum, *min_digits, *max_digits);
+
+            // vi. Set intlObj.[[MinimumFractionDigits]] to mnfd.
+            intl_object.set_min_fraction_digits(*min_digits);
+
+            // vii. Set intlObj.[[MaximumFractionDigits]] to mxfd.
+            intl_object.set_max_fraction_digits(*max_digits);
+        }
+        // b. Else,
+        else {
+            // i. Set intlObj.[[MinimumFractionDigits]] to mnfdDefault.
+            intl_object.set_min_fraction_digits(default_min_fraction_digits);
+
+            // ii. Set intlObj.[[MaximumFractionDigits]] to mxfdDefault.
+            intl_object.set_max_fraction_digits(default_max_fraction_digits);
+        }
+    }
+
+    // 16. If needSd is false and needFd is false, then
+    if (!need_significant_digits && !need_fraction_digits) {
+        // a. Set intlObj.[[RoundingType]] to compactRounding.
+        intl_object.set_rounding_type(NumberFormatBase::RoundingType::CompactRounding);
+    }
+    // 17. Else if hasSd is true, then
+    else if (has_significant_digits) {
+        // a. Set intlObj.[[RoundingType]] to significantDigits.
+        intl_object.set_rounding_type(NumberFormatBase::RoundingType::SignificantDigits);
+    }
+    // 18. Else,
+    else {
+        // a. Set intlObj.[[RoundingType]] to fractionDigits.
+        intl_object.set_rounding_type(NumberFormatBase::RoundingType::FractionDigits);
+    }
+
+    return {};
+}
+
+// 15.1.4 SetNumberFormatUnitOptions ( intlObj, options ), https://tc39.es/ecma402/#sec-setnumberformatunitoptions
+ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_object, NumberFormat& intl_object, Object const& options)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Assert: Type(intlObj) is Object.
+    // 2. Assert: Type(options) is Object.
+
+    // 3. Let style be ? GetOption(options, "style", "string", « "decimal", "percent", "currency", "unit" », "decimal").
+    auto style = TRY(get_option(global_object, options, vm.names.style, Value::Type::String, { "decimal"sv, "percent"sv, "currency"sv, "unit"sv }, "decimal"sv));
+
+    // 4. Set intlObj.[[Style]] to style.
+    intl_object.set_style(style.as_string().string());
+
+    // 5. Let currency be ? GetOption(options, "currency", "string", undefined, undefined).
+    auto currency = TRY(get_option(global_object, options, vm.names.currency, Value::Type::String, {}, Empty {}));
+
+    // 6. If currency is undefined, then
+    if (currency.is_undefined()) {
+        // a. If style is "currency", throw a TypeError exception.
+        if (intl_object.style() == NumberFormat::Style::Currency)
+            return vm.throw_completion<TypeError>(global_object, ErrorType::IntlOptionUndefined, "currency"sv, "style"sv, style);
+    }
+    // 7. Else,
+    //     a. If the result of IsWellFormedCurrencyCode(currency) is false, throw a RangeError exception.
+    else if (!is_well_formed_currency_code(currency.as_string().string()))
+        return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, currency, "currency"sv);
+
+    // 8. Let currencyDisplay be ? GetOption(options, "currencyDisplay", "string", « "code", "symbol", "narrowSymbol", "name" », "symbol").
+    auto currency_display = TRY(get_option(global_object, options, vm.names.currencyDisplay, Value::Type::String, { "code"sv, "symbol"sv, "narrowSymbol"sv, "name"sv }, "symbol"sv));
+
+    // 9. Let currencySign be ? GetOption(options, "currencySign", "string", « "standard", "accounting" », "standard").
+    auto currency_sign = TRY(get_option(global_object, options, vm.names.currencySign, Value::Type::String, { "standard"sv, "accounting"sv }, "standard"sv));
+
+    // 10. Let unit be ? GetOption(options, "unit", "string", undefined, undefined).
+    auto unit = TRY(get_option(global_object, options, vm.names.unit, Value::Type::String, {}, Empty {}));
+
+    // 11. If unit is undefined, then
+    if (unit.is_undefined()) {
+        // a. If style is "unit", throw a TypeError exception.
+        if (intl_object.style() == NumberFormat::Style::Unit)
+            return vm.throw_completion<TypeError>(global_object, ErrorType::IntlOptionUndefined, "unit"sv, "style"sv, style);
+    }
+    // 12. Else,
+    //     a. If the result of IsWellFormedUnitIdentifier(unit) is false, throw a RangeError exception.
+    else if (!is_well_formed_unit_identifier(unit.as_string().string()))
+        return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, unit, "unit"sv);
+
+    // 13. Let unitDisplay be ? GetOption(options, "unitDisplay", "string", « "short", "narrow", "long" », "short").
+    auto unit_display = TRY(get_option(global_object, options, vm.names.unitDisplay, Value::Type::String, { "short"sv, "narrow"sv, "long"sv }, "short"sv));
+
+    // 14. If style is "currency", then
+    if (intl_object.style() == NumberFormat::Style::Currency) {
+        // a. Let currency be the result of converting currency to upper case as specified in 6.1.
+        // b. Set intlObj.[[Currency]] to currency.
+        intl_object.set_currency(currency.as_string().string().to_uppercase());
+
+        // c. Set intlObj.[[CurrencyDisplay]] to currencyDisplay.
+        intl_object.set_currency_display(currency_display.as_string().string());
+
+        // d. Set intlObj.[[CurrencySign]] to currencySign.
+        intl_object.set_currency_sign(currency_sign.as_string().string());
+    }
+
+    // 15. If style is "unit", then
+    if (intl_object.style() == NumberFormat::Style::Unit) {
+        // a. Set intlObj.[[Unit]] to unit.
+        intl_object.set_unit(unit.as_string().string());
+
+        // b. Set intlObj.[[UnitDisplay]] to unitDisplay.
+        intl_object.set_unit_display(unit_display.as_string().string());
+    }
+
+    return {};
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <LibJS/Runtime/Intl/NumberFormat.h>
 #include <LibJS/Runtime/NativeFunction.h>
 
 namespace JS::Intl {
@@ -26,5 +27,9 @@ private:
 
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);
 };
+
+ThrowCompletionOr<NumberFormat*> initialize_number_format(GlobalObject& global_object, NumberFormat& number_format, Value locales_value, Value options_value);
+ThrowCompletionOr<void> set_number_format_digit_options(GlobalObject& global_object, NumberFormatBase& intl_object, Object const& options, int default_min_fraction_digits, int default_max_fraction_digits, NumberFormat::Notation notation);
+ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_object, NumberFormat& intl_object, Object const& options);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatFunction.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -10,7 +10,7 @@
 
 namespace JS::Intl {
 
-// 15.1.4 Number Format Functions, https://tc39.es/ecma402/#sec-number-format-functions
+// 15.5.2 Number Format Functions, https://tc39.es/ecma402/#sec-number-format-functions
 NumberFormatFunction* NumberFormatFunction::create(GlobalObject& global_object, NumberFormat& number_format)
 {
     return global_object.heap().allocate<NumberFormatFunction>(global_object, number_format, *global_object.function_prototype());

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatPrototype.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Tim Flynn <trflynn89@serenityos.org>
+ * Copyright (c) 2021-2022, Tim Flynn <trflynn89@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -13,7 +13,7 @@
 
 namespace JS::Intl {
 
-// 15.4 Properties of the Intl.NumberFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-numberformat-prototype-object
+// 15.3 Properties of the Intl.NumberFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-numberformat-prototype-object
 NumberFormatPrototype::NumberFormatPrototype(GlobalObject& global_object)
     : PrototypeObject(*global_object.object_prototype())
 {
@@ -25,7 +25,7 @@ void NumberFormatPrototype::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 15.4.2 Intl.NumberFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.numberformat.prototype-@@tostringtag
+    // 15.3.2 Intl.NumberFormat.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.numberformat.prototype-@@tostringtag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.NumberFormat"), Attribute::Configurable);
 
     define_native_accessor(vm.names.format, format, nullptr, Attribute::Configurable);
@@ -35,7 +35,7 @@ void NumberFormatPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
-// 15.4.3 get Intl.NumberFormat.prototype.format, https://tc39.es/ecma402/#sec-intl.numberformat.prototype.format
+// 15.3.3 get Intl.NumberFormat.prototype.format, https://tc39.es/ecma402/#sec-intl.numberformat.prototype.format
 JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format)
 {
     // 1. Let nf be the this value.
@@ -58,7 +58,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format)
     return number_format->bound_format();
 }
 
-// 15.4.4 Intl.NumberFormat.prototype.formatToParts ( value ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts
+// 15.3.4 Intl.NumberFormat.prototype.formatToParts ( value ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.formattoparts
 JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_to_parts)
 {
     auto value = vm.argument(0);
@@ -75,7 +75,7 @@ JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::format_to_parts)
     return format_numeric_to_parts(global_object, *number_format, value);
 }
 
-// 15.4.5 Intl.NumberFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions
+// 15.3.5 Intl.NumberFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.numberformat.prototype.resolvedoptions
 JS_DEFINE_NATIVE_FUNCTION(NumberFormatPrototype::resolved_options)
 {
     // 1. Let nf be the this value.

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
 #include <LibJS/Runtime/Intl/PluralRules.h>
 
 namespace JS::Intl {

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.cpp
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
-#include <LibJS/Runtime/GlobalObject.h>
-#include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
 #include <LibJS/Runtime/Intl/PluralRules.h>
 
 namespace JS::Intl {
@@ -38,49 +35,6 @@ StringView PluralRules::type_string() const
     default:
         VERIFY_NOT_REACHED();
     }
-}
-
-// 16.1.1 InitializePluralRules ( pluralRules, locales, options ), https://tc39.es/ecma402/#sec-initializepluralrules
-ThrowCompletionOr<PluralRules*> initialize_plural_rules(GlobalObject& global_object, PluralRules& plural_rules, Value locales_value, Value options_value)
-{
-    auto& vm = global_object.vm();
-
-    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
-    auto requested_locales = TRY(canonicalize_locale_list(global_object, locales_value));
-
-    // 2. Set options to ? CoerceOptionsToObject(options).
-    auto* options = TRY(coerce_options_to_object(global_object, options_value));
-
-    // 3. Let opt be a new Record.
-    LocaleOptions opt {};
-
-    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
-    auto matcher = TRY(get_option(global_object, *options, vm.names.localeMatcher, Value::Type::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
-
-    // 5. Set opt.[[localeMatcher]] to matcher.
-    opt.locale_matcher = matcher;
-
-    // 6. Let t be ? GetOption(options, "type", "string", « "cardinal", "ordinal" », "cardinal").
-    auto type = TRY(get_option(global_object, *options, vm.names.type, Value::Type::String, AK::Array { "cardinal"sv, "ordinal"sv }, "cardinal"sv));
-
-    // 7. Set pluralRules.[[Type]] to t.
-    plural_rules.set_type(type.as_string().string());
-
-    // 8. Perform ? SetNumberFormatDigitOptions(pluralRules, options, +0𝔽, 3𝔽, "standard").
-    TRY(set_number_format_digit_options(global_object, plural_rules, *options, 0, 3, NumberFormat::Notation::Standard));
-
-    // 9. Let localeData be %PluralRules%.[[LocaleData]].
-    // 10. Let r be ResolveLocale(%PluralRules%.[[AvailableLocales]], requestedLocales, opt, %PluralRules%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, {});
-
-    // 11. Set pluralRules.[[Locale]] to r.[[locale]].
-    plural_rules.set_locale(move(result.locale));
-
-    // Non-standard, the data locale is used by our NumberFormat implementation.
-    plural_rules.set_data_locale(move(result.data_locale));
-
-    // 12. Return pluralRules.
-    return &plural_rules;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRules.h
@@ -8,7 +8,6 @@
 
 #include <AK/String.h>
 #include <AK/StringView.h>
-#include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Intl/NumberFormat.h>
 #include <LibJS/Runtime/Object.h>
 
@@ -33,7 +32,5 @@ public:
 private:
     Type m_type { Type::Cardinal }; // [[Type]]
 };
-
-ThrowCompletionOr<PluralRules*> initialize_plural_rules(GlobalObject& global_object, PluralRules& plural_rules, Value locales_value, Value options_value);
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.cpp
@@ -4,16 +4,18 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
+#include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
 #include <LibJS/Runtime/Intl/PluralRules.h>
 #include <LibJS/Runtime/Intl/PluralRulesConstructor.h>
 
 namespace JS::Intl {
 
-// 16.2 The Intl.PluralRules Constructor, https://tc39.es/ecma402/#sec-intl-pluralrules-constructor
+// 16.1 The Intl.PluralRules Constructor, https://tc39.es/ecma402/#sec-intl-pluralrules-constructor
 PluralRulesConstructor::PluralRulesConstructor(GlobalObject& global_object)
     : NativeFunction(vm().names.PluralRules.as_string(), *global_object.function_prototype())
 {
@@ -25,7 +27,7 @@ void PluralRulesConstructor::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 16.3.1 Intl.PluralRules.prototype, https://tc39.es/ecma402/#sec-intl.pluralrules.prototype
+    // 16.2.1 Intl.PluralRules.prototype, https://tc39.es/ecma402/#sec-intl.pluralrules.prototype
     define_direct_property(vm.names.prototype, global_object.intl_plural_rules_prototype(), 0);
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 
@@ -33,14 +35,14 @@ void PluralRulesConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.supportedLocalesOf, supported_locales_of, 1, attr);
 }
 
-// 16.2.1 Intl.PluralRules ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.pluralrules
+// 16.1.1 Intl.PluralRules ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.pluralrules
 ThrowCompletionOr<Value> PluralRulesConstructor::call()
 {
     // 1. If NewTarget is undefined, throw a TypeError exception.
     return vm().throw_completion<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Intl.PluralRules");
 }
 
-// 16.2.1 Intl.PluralRules ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.pluralrules
+// 16.1.1 Intl.PluralRules ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-intl.pluralrules
 ThrowCompletionOr<Object*> PluralRulesConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -56,7 +58,7 @@ ThrowCompletionOr<Object*> PluralRulesConstructor::construct(FunctionObject& new
     return TRY(initialize_plural_rules(global_object, *plural_rules, locales, options));
 }
 
-// 16.3.2 Intl.PluralRules.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-intl.pluralrules.supportedlocalesof
+// 16.2.2 Intl.PluralRules.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-intl.pluralrules.supportedlocalesof
 JS_DEFINE_NATIVE_FUNCTION(PluralRulesConstructor::supported_locales_of)
 {
     auto locales = vm.argument(0);
@@ -69,6 +71,49 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesConstructor::supported_locales_of)
 
     // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
     return TRY(supported_locales(global_object, requested_locales, options));
+}
+
+// 16.1.2 InitializePluralRules ( pluralRules, locales, options ), https://tc39.es/ecma402/#sec-initializepluralrules
+ThrowCompletionOr<PluralRules*> initialize_plural_rules(GlobalObject& global_object, PluralRules& plural_rules, Value locales_value, Value options_value)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = TRY(canonicalize_locale_list(global_object, locales_value));
+
+    // 2. Set options to ? CoerceOptionsToObject(options).
+    auto* options = TRY(coerce_options_to_object(global_object, options_value));
+
+    // 3. Let opt be a new Record.
+    LocaleOptions opt {};
+
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    auto matcher = TRY(get_option(global_object, *options, vm.names.localeMatcher, Value::Type::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
+
+    // 5. Set opt.[[localeMatcher]] to matcher.
+    opt.locale_matcher = matcher;
+
+    // 6. Let t be ? GetOption(options, "type", "string", « "cardinal", "ordinal" », "cardinal").
+    auto type = TRY(get_option(global_object, *options, vm.names.type, Value::Type::String, AK::Array { "cardinal"sv, "ordinal"sv }, "cardinal"sv));
+
+    // 7. Set pluralRules.[[Type]] to t.
+    plural_rules.set_type(type.as_string().string());
+
+    // 8. Perform ? SetNumberFormatDigitOptions(pluralRules, options, +0𝔽, 3𝔽, "standard").
+    TRY(set_number_format_digit_options(global_object, plural_rules, *options, 0, 3, NumberFormat::Notation::Standard));
+
+    // 9. Let localeData be %PluralRules%.[[LocaleData]].
+    // 10. Let r be ResolveLocale(%PluralRules%.[[AvailableLocales]], requestedLocales, opt, %PluralRules%.[[RelevantExtensionKeys]], localeData).
+    auto result = resolve_locale(requested_locales, opt, {});
+
+    // 11. Set pluralRules.[[Locale]] to r.[[locale]].
+    plural_rules.set_locale(move(result.locale));
+
+    // Non-standard, the data locale is used by our NumberFormat implementation.
+    plural_rules.set_data_locale(move(result.data_locale));
+
+    // 12. Return pluralRules.
+    return &plural_rules;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesConstructor.h
@@ -27,4 +27,6 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);
 };
 
+ThrowCompletionOr<PluralRules*> initialize_plural_rules(GlobalObject& global_object, PluralRules& plural_rules, Value locales_value, Value options_value);
+
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
@@ -11,7 +11,7 @@
 
 namespace JS::Intl {
 
-// 16.4 Properties of the Intl.PluralRules Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-pluralrules-prototype-object
+// 16.3 Properties of the Intl.PluralRules Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-pluralrules-prototype-object
 PluralRulesPrototype::PluralRulesPrototype(GlobalObject& global_object)
     : PrototypeObject(*global_object.object_prototype())
 {
@@ -23,14 +23,14 @@ void PluralRulesPrototype::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 16.4.2 Intl.PluralRules.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.pluralrules.prototype-tostringtag
+    // 16.3.2 Intl.PluralRules.prototype [ @@toStringTag ], https://tc39.es/ecma402/#sec-intl.pluralrules.prototype-tostringtag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.PluralRules"sv), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
-// 16.4.4 Intl.PluralRules.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
+// 16.3.4 Intl.PluralRules.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.pluralrules.prototype.resolvedoptions
 JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
 {
     // 1. Let pr be the this value.
@@ -40,7 +40,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
     // 3. Let options be ! OrdinaryObjectCreate(%Object.prototype%).
     auto* options = Object::create(global_object, global_object.object_prototype());
 
-    // 4. For each row of Table 14, except the header row, in table order, do
+    // 4. For each row of Table 13, except the header row, in table order, do
     //     a. Let p be the Property value of the current row.
     //     b. Let v be the value of pr's internal slot whose name is the Internal Slot value of the current row.
     //     c. If v is not undefined, then

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -51,80 +51,7 @@ StringView RelativeTimeFormat::numeric_string() const
     }
 }
 
-// 17.1.1 InitializeRelativeTimeFormat ( relativeTimeFormat, locales, options ), https://tc39.es/ecma402/#sec-InitializeRelativeTimeFormat
-ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, Value locales_value, Value options_value)
-{
-    auto& vm = global_object.vm();
-
-    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
-    auto requested_locales = TRY(canonicalize_locale_list(global_object, locales_value));
-
-    // 2. Set options to ? CoerceOptionsToObject(options).
-    auto* options = TRY(coerce_options_to_object(global_object, options_value));
-
-    // 3. Let opt be a new Record.
-    LocaleOptions opt {};
-
-    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
-    auto matcher = TRY(get_option(global_object, *options, vm.names.localeMatcher, Value::Type::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
-
-    // 5. Set opt.[[LocaleMatcher]] to matcher.
-    opt.locale_matcher = matcher;
-
-    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
-    auto numbering_system = TRY(get_option(global_object, *options, vm.names.numberingSystem, Value::Type::String, {}, Empty {}));
-
-    // 7. If numberingSystem is not undefined, then
-    if (!numbering_system.is_undefined()) {
-        // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
-        if (!Unicode::is_type_identifier(numbering_system.as_string().string()))
-            return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
-
-        // 8. Set opt.[[nu]] to numberingSystem.
-        opt.nu = numbering_system.as_string().string();
-    }
-
-    // 9. Let localeData be %RelativeTimeFormat%.[[LocaleData]].
-    // 10. Let r be ResolveLocale(%RelativeTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %RelativeTimeFormat%.[[RelevantExtensionKeys]], localeData).
-    auto result = resolve_locale(requested_locales, opt, RelativeTimeFormat::relevant_extension_keys());
-
-    // 11. Let locale be r.[[locale]].
-    auto locale = move(result.locale);
-
-    // 12. Set relativeTimeFormat.[[Locale]] to locale.
-    relative_time_format.set_locale(locale);
-
-    // 13. Set relativeTimeFormat.[[DataLocale]] to r.[[dataLocale]].
-    relative_time_format.set_data_locale(move(result.data_locale));
-
-    // 14. Set relativeTimeFormat.[[NumberingSystem]] to r.[[nu]].
-    if (result.nu.has_value())
-        relative_time_format.set_numbering_system(result.nu.release_value());
-
-    // 15. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow" », "long").
-    auto style = TRY(get_option(global_object, *options, vm.names.style, Value::Type::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));
-
-    // 16. Set relativeTimeFormat.[[Style]] to style.
-    relative_time_format.set_style(style.as_string().string());
-
-    // 17. Let numeric be ? GetOption(options, "numeric", "string", « "always", "auto" », "always").
-    auto numeric = TRY(get_option(global_object, *options, vm.names.numeric, Value::Type::String, { "always"sv, "auto"sv }, "always"sv));
-
-    // 18. Set relativeTimeFormat.[[Numeric]] to numeric.
-    relative_time_format.set_numeric(numeric.as_string().string());
-
-    // 19. Let relativeTimeFormat.[[NumberFormat]] be ! Construct(%NumberFormat%, « locale »).
-    auto* number_format = MUST(construct(global_object, *global_object.intl_number_format_constructor(), js_string(vm, locale)));
-    relative_time_format.set_number_format(static_cast<NumberFormat*>(number_format));
-
-    // 20. Let relativeTimeFormat.[[PluralRules]] be ! Construct(%PluralRules%, « locale »).
-    // FIXME: We do not yet support Intl.PluralRules.
-
-    // 21. Return relativeTimeFormat.
-    return &relative_time_format;
-}
-
-// 17.1.2 SingularRelativeTimeUnit ( unit ), https://tc39.es/ecma402/#sec-singularrelativetimeunit
+// 17.5.1 SingularRelativeTimeUnit ( unit ), https://tc39.es/ecma402/#sec-singularrelativetimeunit
 ThrowCompletionOr<Unicode::TimeUnit> singular_relative_time_unit(GlobalObject& global_object, StringView unit)
 {
     auto& vm = global_object.vm();
@@ -163,7 +90,7 @@ ThrowCompletionOr<Unicode::TimeUnit> singular_relative_time_unit(GlobalObject& g
     return vm.throw_completion<RangeError>(global_object, ErrorType::IntlInvalidUnit, unit);
 }
 
-// 17.1.3 PartitionRelativeTimePattern ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-PartitionRelativeTimePattern
+// 17.5.2 PartitionRelativeTimePattern ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-PartitionRelativeTimePattern
 ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_pattern(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, double value, StringView unit)
 {
     auto& vm = global_object.vm();
@@ -262,7 +189,7 @@ ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_patt
     return make_parts_list(pattern->pattern, Unicode::time_unit_to_string(time_unit), move(value_partitions));
 }
 
-// 17.1.4 MakePartsList ( pattern, unit, parts ), https://tc39.es/ecma402/#sec-makepartslist
+// 17.5.3 MakePartsList ( pattern, unit, parts ), https://tc39.es/ecma402/#sec-makepartslist
 Vector<PatternPartitionWithUnit> make_parts_list(StringView pattern, StringView unit, Vector<PatternPartition> parts)
 {
     // 1. Let patternParts be PartitionPattern(pattern).
@@ -295,7 +222,7 @@ Vector<PatternPartitionWithUnit> make_parts_list(StringView pattern, StringView 
     return result;
 }
 
-// 17.1.5 FormatRelativeTime ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-FormatRelativeTime
+// 17.5.4 FormatRelativeTime ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-FormatRelativeTime
 ThrowCompletionOr<String> format_relative_time(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, double value, StringView unit)
 {
     // 1. Let parts be ? PartitionRelativeTimePattern(relativeTimeFormat, value, unit).
@@ -314,7 +241,7 @@ ThrowCompletionOr<String> format_relative_time(GlobalObject& global_object, Rela
     return result.build();
 }
 
-// 17.1.6 FormatRelativeTimeToParts ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-FormatRelativeTimeToParts
+// 17.5.5 FormatRelativeTimeToParts ( relativeTimeFormat, value, unit ), https://tc39.es/ecma402/#sec-FormatRelativeTimeToParts
 ThrowCompletionOr<Array*> format_relative_time_to_parts(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, double value, StringView unit)
 {
     auto& vm = global_object.vm();

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.h
@@ -28,7 +28,7 @@ public:
 
     static constexpr auto relevant_extension_keys()
     {
-        // 17.3.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat-internal-slots
+        // 17.2.3 Internal slots, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat-internal-slots
         // The value of the [[RelevantExtensionKeys]] internal slot is « "nu" ».
         return AK::Array { "nu"sv };
     }
@@ -77,7 +77,6 @@ struct PatternPartitionWithUnit : public PatternPartition {
     StringView unit;
 };
 
-ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, Value locales_value, Value options_value);
 ThrowCompletionOr<Unicode::TimeUnit> singular_relative_time_unit(GlobalObject& global_object, StringView unit);
 ThrowCompletionOr<Vector<PatternPartitionWithUnit>> partition_relative_time_pattern(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, double value, StringView unit);
 Vector<PatternPartitionWithUnit> make_parts_list(StringView pattern, StringView unit, Vector<PatternPartition> parts);

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.cpp
@@ -8,12 +8,15 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/Intl/AbstractOperations.h>
+#include <LibJS/Runtime/Intl/NumberFormat.h>
+#include <LibJS/Runtime/Intl/NumberFormatConstructor.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormat.h>
 #include <LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h>
+#include <LibUnicode/Locale.h>
 
 namespace JS::Intl {
 
-// 17.2 The Intl.RelativeTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor
+// 17.1 The Intl.RelativeTimeFormat Constructor, https://tc39.es/ecma402/#sec-intl-relativetimeformat-constructor
 RelativeTimeFormatConstructor::RelativeTimeFormatConstructor(GlobalObject& global_object)
     : NativeFunction(vm().names.RelativeTimeFormat.as_string(), *global_object.function_prototype())
 {
@@ -25,7 +28,7 @@ void RelativeTimeFormatConstructor::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 17.3.1 Intl.RelativeTimeFormat.prototype, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype
+    // 17.2.1 Intl.RelativeTimeFormat.prototype, https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype
     define_direct_property(vm.names.prototype, global_object.intl_relative_time_format_prototype(), 0);
     define_direct_property(vm.names.length, Value(0), Attribute::Configurable);
 
@@ -33,14 +36,14 @@ void RelativeTimeFormatConstructor::initialize(GlobalObject& global_object)
     define_native_function(vm.names.supportedLocalesOf, supported_locales_of, 1, attr);
 }
 
-// 17.2.1 Intl.RelativeTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
+// 17.1.1 Intl.RelativeTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
 ThrowCompletionOr<Value> RelativeTimeFormatConstructor::call()
 {
     // 1. If NewTarget is undefined, throw a TypeError exception.
     return vm().throw_completion<TypeError>(global_object(), ErrorType::ConstructorWithoutNew, "Intl.RelativeTimeFormat");
 }
 
-// 17.2.1 Intl.RelativeTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
+// 17.1.1 Intl.RelativeTimeFormat ( [ locales [ , options ] ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat
 ThrowCompletionOr<Object*> RelativeTimeFormatConstructor::construct(FunctionObject& new_target)
 {
     auto& vm = this->vm();
@@ -56,7 +59,7 @@ ThrowCompletionOr<Object*> RelativeTimeFormatConstructor::construct(FunctionObje
     return TRY(initialize_relative_time_format(global_object, *relative_time_format, locales, options));
 }
 
-// 17.3.2 Intl.RelativeTimeFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.supportedLocalesOf
+// 17.2.2 Intl.RelativeTimeFormat.supportedLocalesOf ( locales [ , options ] ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.supportedLocalesOf
 JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatConstructor::supported_locales_of)
 {
     auto locales = vm.argument(0);
@@ -69,6 +72,79 @@ JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatConstructor::supported_locales_of)
 
     // 3. Return ? SupportedLocales(availableLocales, requestedLocales, options).
     return TRY(supported_locales(global_object, requested_locales, options));
+}
+
+// 17.1.2 InitializeRelativeTimeFormat ( relativeTimeFormat, locales, options ), https://tc39.es/ecma402/#sec-InitializeRelativeTimeFormat
+ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, Value locales_value, Value options_value)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
+    auto requested_locales = TRY(canonicalize_locale_list(global_object, locales_value));
+
+    // 2. Set options to ? CoerceOptionsToObject(options).
+    auto* options = TRY(coerce_options_to_object(global_object, options_value));
+
+    // 3. Let opt be a new Record.
+    LocaleOptions opt {};
+
+    // 4. Let matcher be ? GetOption(options, "localeMatcher", "string", « "lookup", "best fit" », "best fit").
+    auto matcher = TRY(get_option(global_object, *options, vm.names.localeMatcher, Value::Type::String, AK::Array { "lookup"sv, "best fit"sv }, "best fit"sv));
+
+    // 5. Set opt.[[LocaleMatcher]] to matcher.
+    opt.locale_matcher = matcher;
+
+    // 6. Let numberingSystem be ? GetOption(options, "numberingSystem", "string", undefined, undefined).
+    auto numbering_system = TRY(get_option(global_object, *options, vm.names.numberingSystem, Value::Type::String, {}, Empty {}));
+
+    // 7. If numberingSystem is not undefined, then
+    if (!numbering_system.is_undefined()) {
+        // a. If numberingSystem does not match the Unicode Locale Identifier type nonterminal, throw a RangeError exception.
+        if (!Unicode::is_type_identifier(numbering_system.as_string().string()))
+            return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, numbering_system, "numberingSystem"sv);
+
+        // 8. Set opt.[[nu]] to numberingSystem.
+        opt.nu = numbering_system.as_string().string();
+    }
+
+    // 9. Let localeData be %RelativeTimeFormat%.[[LocaleData]].
+    // 10. Let r be ResolveLocale(%RelativeTimeFormat%.[[AvailableLocales]], requestedLocales, opt, %RelativeTimeFormat%.[[RelevantExtensionKeys]], localeData).
+    auto result = resolve_locale(requested_locales, opt, RelativeTimeFormat::relevant_extension_keys());
+
+    // 11. Let locale be r.[[locale]].
+    auto locale = move(result.locale);
+
+    // 12. Set relativeTimeFormat.[[Locale]] to locale.
+    relative_time_format.set_locale(locale);
+
+    // 13. Set relativeTimeFormat.[[DataLocale]] to r.[[dataLocale]].
+    relative_time_format.set_data_locale(move(result.data_locale));
+
+    // 14. Set relativeTimeFormat.[[NumberingSystem]] to r.[[nu]].
+    if (result.nu.has_value())
+        relative_time_format.set_numbering_system(result.nu.release_value());
+
+    // 15. Let style be ? GetOption(options, "style", "string", « "long", "short", "narrow" », "long").
+    auto style = TRY(get_option(global_object, *options, vm.names.style, Value::Type::String, { "long"sv, "short"sv, "narrow"sv }, "long"sv));
+
+    // 16. Set relativeTimeFormat.[[Style]] to style.
+    relative_time_format.set_style(style.as_string().string());
+
+    // 17. Let numeric be ? GetOption(options, "numeric", "string", « "always", "auto" », "always").
+    auto numeric = TRY(get_option(global_object, *options, vm.names.numeric, Value::Type::String, { "always"sv, "auto"sv }, "always"sv));
+
+    // 18. Set relativeTimeFormat.[[Numeric]] to numeric.
+    relative_time_format.set_numeric(numeric.as_string().string());
+
+    // 19. Let relativeTimeFormat.[[NumberFormat]] be ! Construct(%NumberFormat%, « locale »).
+    auto* number_format = MUST(construct(global_object, *global_object.intl_number_format_constructor(), js_string(vm, locale)));
+    relative_time_format.set_number_format(static_cast<NumberFormat*>(number_format));
+
+    // 20. Let relativeTimeFormat.[[PluralRules]] be ! Construct(%PluralRules%, « locale »).
+    // FIXME: We do not yet support Intl.PluralRules.
+
+    // 21. Return relativeTimeFormat.
+    return &relative_time_format;
 }
 
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatConstructor.h
@@ -27,4 +27,6 @@ private:
     JS_DECLARE_NATIVE_FUNCTION(supported_locales_of);
 };
 
+ThrowCompletionOr<RelativeTimeFormat*> initialize_relative_time_format(GlobalObject& global_object, RelativeTimeFormat& relative_time_format, Value locales_value, Value options_value);
+
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormatPrototype.cpp
@@ -10,7 +10,7 @@
 
 namespace JS::Intl {
 
-// 17.4 Properties of the Intl.RelativeTimeFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-relativetimeformat-prototype-object
+// 17.3 Properties of the Intl.RelativeTimeFormat Prototype Object, https://tc39.es/ecma402/#sec-properties-of-intl-relativetimeformat-prototype-object
 RelativeTimeFormatPrototype::RelativeTimeFormatPrototype(GlobalObject& global_object)
     : PrototypeObject(*global_object.object_prototype())
 {
@@ -22,7 +22,7 @@ void RelativeTimeFormatPrototype::initialize(GlobalObject& global_object)
 
     auto& vm = this->vm();
 
-    // 17.4.2 Intl.RelativeTimeFormat.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype-toStringTag
+    // 17.3.2 Intl.RelativeTimeFormat.prototype[ @@toStringTag ], https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype-toStringTag
     define_direct_property(*vm.well_known_symbol_to_string_tag(), js_string(vm, "Intl.RelativeTimeFormat"sv), Attribute::Configurable);
 
     u8 attr = Attribute::Writable | Attribute::Configurable;
@@ -31,7 +31,7 @@ void RelativeTimeFormatPrototype::initialize(GlobalObject& global_object)
     define_native_function(vm.names.resolvedOptions, resolved_options, 0, attr);
 }
 
-// 17.4.3 Intl.RelativeTimeFormat.prototype.format ( value, unit ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.format
+// 17.3.3 Intl.RelativeTimeFormat.prototype.format ( value, unit ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.format
 JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::format)
 {
     // 1. Let relativeTimeFormat be the this value.
@@ -49,7 +49,7 @@ JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::format)
     return js_string(vm, move(formatted));
 }
 
-// 17.4.4 Intl.RelativeTimeFormat.prototype.formatToParts ( value, unit ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.formatToParts
+// 17.3.4 Intl.RelativeTimeFormat.prototype.formatToParts ( value, unit ), https://tc39.es/ecma402/#sec-Intl.RelativeTimeFormat.prototype.formatToParts
 JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::format_to_parts)
 {
     // 1. Let relativeTimeFormat be the this value.
@@ -66,7 +66,7 @@ JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::format_to_parts)
     return TRY(format_relative_time_to_parts(global_object, *relative_time_format, value.as_double(), unit));
 }
 
-// 17.4.5 Intl.RelativeTimeFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.resolvedoptions
+// 17.3.5 Intl.RelativeTimeFormat.prototype.resolvedOptions ( ), https://tc39.es/ecma402/#sec-intl.relativetimeformat.prototype.resolvedoptions
 JS_DEFINE_NATIVE_FUNCTION(RelativeTimeFormatPrototype::resolved_options)
 {
     // 1. Let relativeTimeFormat be the this value.


### PR DESCRIPTION
That actually wasn't too bad :)

Main things are:
1. The order of each section is now: constructor, constructor properties, prototype, instance properties (internal slots), abstract operations.
2. Any initialization AOs, e.g. `InitializeNumberFormat`, are now in their constructor section.