### PR TITLE
Ports: Solve various build issues and pitfalls

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -119,6 +119,10 @@ run_replace_in_file() {
 
 get_new_config_sub() {
     config_sub="${1:-config.sub}"
+    if [ ! -f "$workdir/$config_sub" ]; then
+        >&2 echo "Error: Downloaded $config_sub does not replace an existing file!"
+        exit 1
+    fi
     if ! run grep -q serenity "$config_sub"; then
         run do_download_file "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub" "${1:-config.sub}" false
     fi
@@ -126,6 +130,10 @@ get_new_config_sub() {
 
 get_new_config_guess() {
     config_guess="${1:-config.guess}"
+    if [ ! -f "$workdir/$config_guess" ]; then
+        >&2 echo "Error: Downloaded $config_guess does not replace an existing file!"
+        exit 1
+    fi
     if ! run grep -q SerenityOS "$config_guess"; then
         run do_download_file "https://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess" "${1:-config_guess}" false
     fi

--- a/Ports/citron/package.sh
+++ b/Ports/citron/package.sh
@@ -2,7 +2,7 @@
 port=citron
 version=0.0.9.3
 useconfigure=false
-depends=(sparsehash libffi)
+depends=(sparsehash libffi pcre)
 commit_hash=d28b7d62bd61397e46152aa6e4ee59b115c0e2d7
 archive_hash=0e31ab638c4fd1438f68fdf069336e2541eb4cfc5db2f55888f6175e0171a2ef
 files="https://github.com/alimpfard/citron/archive/$commit_hash.tar.gz citron.tar.gz $archive_hash"

--- a/Ports/imgcat/package.sh
+++ b/Ports/imgcat/package.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
 port=imgcat
 version=2.5.0
-depends=("ncurses")
+depends=("ncurses" "libpng" "libjpeg")
 files="https://github.com/eddieantonio/imgcat/releases/download/v${version}/imgcat-${version}.tar.gz imgcat-v${version}.tar.gz 8f18e10464ed1426b29a5b11aee766a43db92be17ba0a17fd127dd9cf9fb544b"
 auth_type=sha256
 

--- a/Ports/libmpeg2/package.sh
+++ b/Ports/libmpeg2/package.sh
@@ -4,5 +4,6 @@ version=0.5.1
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_path=.auto/config.sub
+configopts=("--disable-sdl")
 files="https://libmpeg2.sourceforge.io/files/libmpeg2-${version}.tar.gz libmpeg2-${version}.tar.gz dee22e893cb5fc2b2b6ebd60b88478ab8556cb3b93f9a0d7ce8f3b61851871d4"
 auth_type=sha256

--- a/Ports/ntbtls/package.sh
+++ b/Ports/ntbtls/package.sh
@@ -4,7 +4,7 @@ version=0.2.0
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_path=build-aux/config.sub
-depends=("libgpg-error" "libksba" "libgcrypt")
+depends=("libgpg-error" "libksba" "libgcrypt" "zlib")
 files="https://gnupg.org/ftp/gcrypt/ntbtls/ntbtls-${version}.tar.bz2 ntbtls-${version}.tar.bz2 649fe74a311d13e43b16b26ebaa91665ddb632925b73902592eac3ed30519e17"
 auth_type=sha256
 

--- a/Ports/p7zip/package.sh
+++ b/Ports/p7zip/package.sh
@@ -7,6 +7,7 @@ auth_type=sha256
 files="https://github.com/jinfeihan57/p7zip/archive/refs/tags/v${version}.tar.gz p7zip-${version}.tar.gz ea029a2e21d2d6ad0a156f6679bd66836204aa78148a4c5e498fe682e77127ef"
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
 workdir=$port-$version/CPP
+depends=("libiconv")
 
 post_fetch() {
     run_replace_in_file "s/\r//" 7zip/CMAKE/7za/CMakeLists.txt

--- a/Ports/tig/package.sh
+++ b/Ports/tig/package.sh
@@ -4,4 +4,4 @@ version=2.5.5
 useconfigure="true"
 files="https://github.com/jonas/tig/releases/download/tig-${version}/tig-${version}.tar.gz tig-${version}.tar.gz 24ba2c8beae889e6002ea7ced0e29851dee57c27fde8480fb9c64d5eb8765313"
 auth_type=sha256
-depends=("ncurses" "pcre" "readline")
+depends=("ncurses" "pcre" "readline" "libiconv")


### PR DESCRIPTION
This mainly adds forgotten dependencies to packages. Those were previously missed because `zlib` and `libiconv` are commonly used, and the chance that some other package has already built them is very high.

Also included is a patch to disable SDL support for `libmpeg2` (as it was previously dependent on whether the host has an installation of SDL), and a patch to make the `config.sub` and `config.guess` downloaders fail if they don't replace an existing file.