### PR TITLE
LibWeb: Add hack to dispatch load event for <object>s

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -21,11 +21,15 @@ HTMLObjectElement::HTMLObjectElement(DOM::Document& document, DOM::QualifiedName
     m_image_loader.on_load = [this] {
         m_should_show_fallback_content = false;
         set_needs_style_update(true);
+        // FIXME: This should be done by the HTML^Wdocument parser.
+        dispatch_event(DOM::Event::create(HTML::EventNames::load));
     };
 
     m_image_loader.on_fail = [this] {
         m_should_show_fallback_content = true;
         set_needs_style_update(true);
+        // FIXME: This should be done by the HTML^Wdocument parser.
+        dispatch_event(DOM::Event::create(HTML::EventNames::load));
     };
 }
 


### PR DESCRIPTION
This increases our Acid3 score to 81/100 on the live website, and fixes
the 5 second spin locally.