### PR TITLE
Kernel+Utilities: Implement a global routing table

### DIFF
--- a/Kernel/API/POSIX/net/route.h
+++ b/Kernel/API/POSIX/net/route.h
@@ -14,6 +14,7 @@ extern "C" {
 #endif
 
 struct rtentry {
+    struct sockaddr rt_dst;     /* the target address */
     struct sockaddr rt_gateway; /* the gateway address */
     struct sockaddr rt_genmask; /* the target network mask */
     unsigned short int rt_flags;

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -47,16 +47,16 @@ private:
             auto obj = TRY(array.add_object());
             TRY(obj.add("name", adapter.name()));
             TRY(obj.add("class_name", adapter.class_name()));
-            auto mac_address = adapter.mac_address().to_string().release_value_but_fixme_should_propagate_errors();
+            auto mac_address = TRY(adapter.mac_address().to_string());
             TRY(obj.add("mac_address", mac_address->view()));
             if (!adapter.ipv4_address().is_zero()) {
-                auto ipv4_address = adapter.ipv4_address().to_string().release_value_but_fixme_should_propagate_errors();
+                auto ipv4_address = TRY(adapter.ipv4_address().to_string());
                 TRY(obj.add("ipv4_address", ipv4_address->view()));
-                auto ipv4_netmask = adapter.ipv4_netmask().to_string().release_value_but_fixme_should_propagate_errors();
+                auto ipv4_netmask = TRY(adapter.ipv4_netmask().to_string());
                 TRY(obj.add("ipv4_netmask", ipv4_netmask->view()));
             }
             if (!adapter.ipv4_gateway().is_zero()) {
-                auto ipv4_gateway = adapter.ipv4_gateway().to_string().release_value_but_fixme_should_propagate_errors();
+                auto ipv4_gateway = TRY(adapter.ipv4_gateway().to_string());
                 TRY(obj.add("ipv4_gateway", ipv4_gateway->view()));
             }
             TRY(obj.add("packets_in", adapter.packets_in()));
@@ -87,9 +87,9 @@ private:
         TRY(arp_table().with([&](auto const& table) -> ErrorOr<void> {
             for (auto& it : table) {
                 auto obj = TRY(array.add_object());
-                auto mac_address = it.value.to_string().release_value_but_fixme_should_propagate_errors();
+                auto mac_address = TRY(it.value.to_string());
                 TRY(obj.add("mac_address", mac_address->view()));
-                auto ip_address = it.key.to_string().release_value_but_fixme_should_propagate_errors();
+                auto ip_address = TRY(it.key.to_string());
                 TRY(obj.add("ip_address", ip_address->view()));
                 TRY(obj.finish());
             }
@@ -111,10 +111,10 @@ private:
         auto array = TRY(JsonArraySerializer<>::try_create(builder));
         TRY(TCPSocket::try_for_each([&array](auto& socket) -> ErrorOr<void> {
             auto obj = TRY(array.add_object());
-            auto local_address = socket.local_address().to_string().release_value_but_fixme_should_propagate_errors();
+            auto local_address = TRY(socket.local_address().to_string());
             TRY(obj.add("local_address", local_address->view()));
             TRY(obj.add("local_port", socket.local_port()));
-            auto peer_address = socket.peer_address().to_string().release_value_but_fixme_should_propagate_errors();
+            auto peer_address = TRY(socket.peer_address().to_string());
             TRY(obj.add("peer_address", peer_address->view()));
             TRY(obj.add("peer_port", socket.peer_port()));
             TRY(obj.add("state", TCPSocket::to_string(socket.state())));
@@ -174,10 +174,10 @@ private:
         auto array = TRY(JsonArraySerializer<>::try_create(builder));
         TRY(UDPSocket::try_for_each([&array](auto& socket) -> ErrorOr<void> {
             auto obj = TRY(array.add_object());
-            auto local_address = socket.local_address().to_string().release_value_but_fixme_should_propagate_errors();
+            auto local_address = TRY(socket.local_address().to_string());
             TRY(obj.add("local_address", local_address->view()));
             TRY(obj.add("local_port", socket.local_port()));
-            auto peer_address = socket.peer_address().to_string().release_value_but_fixme_should_propagate_errors();
+            auto peer_address = TRY(socket.peer_address().to_string());
             TRY(obj.add("peer_address", peer_address->view()));
             TRY(obj.add("peer_port", socket.peer_port()));
             if (Process::current().is_superuser() || Process::current().uid() == socket.origin_uid()) {

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -653,7 +653,7 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
                 return EPERM;
             if (arp_req.arp_pa.sa_family != AF_INET)
                 return EAFNOSUPPORT;
-            update_arp_table(IPv4Address(((sockaddr_in&)arp_req.arp_pa).sin_addr.s_addr), *(MACAddress*)&arp_req.arp_ha.sa_data[0], UpdateArp::Set);
+            update_arp_table(IPv4Address(((sockaddr_in&)arp_req.arp_pa).sin_addr.s_addr), *(MACAddress*)&arp_req.arp_ha.sa_data[0], UpdateTable::Set);
             return {};
 
         case SIOCDARP:
@@ -661,7 +661,7 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
                 return EPERM;
             if (arp_req.arp_pa.sa_family != AF_INET)
                 return EAFNOSUPPORT;
-            update_arp_table(IPv4Address(((sockaddr_in&)arp_req.arp_pa).sin_addr.s_addr), *(MACAddress*)&arp_req.arp_ha.sa_data[0], UpdateArp::Delete);
+            update_arp_table(IPv4Address(((sockaddr_in&)arp_req.arp_pa).sin_addr.s_addr), *(MACAddress*)&arp_req.arp_ha.sa_data[0], UpdateTable::Delete);
             return {};
         }
 

--- a/Kernel/Net/IPv4Socket.cpp
+++ b/Kernel/Net/IPv4Socket.cpp
@@ -624,16 +624,20 @@ ErrorOr<void> IPv4Socket::ioctl(OpenFileDescription&, unsigned request, Userspac
             return ENODEV;
 
         switch (request) {
-        case SIOCADDRT:
+        case SIOCADDRT: {
             if (!Process::current().is_superuser())
                 return EPERM;
             if (route.rt_gateway.sa_family != AF_INET)
                 return EAFNOSUPPORT;
             if ((route.rt_flags & (RTF_UP | RTF_GATEWAY)) != (RTF_UP | RTF_GATEWAY))
                 return EINVAL; // FIXME: Find the correct value to return
-            adapter->set_ipv4_gateway(IPv4Address(((sockaddr_in&)route.rt_gateway).sin_addr.s_addr));
-            return {};
 
+            auto destination = IPv4Address(((sockaddr_in&)route.rt_dst).sin_addr.s_addr);
+            auto gateway = IPv4Address(((sockaddr_in&)route.rt_gateway).sin_addr.s_addr);
+            auto genmask = IPv4Address(((sockaddr_in&)route.rt_genmask).sin_addr.s_addr);
+
+            return update_routing_table(destination, gateway, genmask, adapter, UpdateTable::Set);
+        }
         case SIOCDELRT:
             // FIXME: Support gateway deletion
             return {};

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -158,7 +158,7 @@ void handle_arp(EthernetFrameHeader const& eth, size_t frame_size)
     if (!packet.sender_hardware_address().is_zero() && !packet.sender_protocol_address().is_zero()) {
         // Someone has this IPv4 address. I guess we can try to remember that.
         // FIXME: Protect against ARP spamming.
-        update_arp_table(packet.sender_protocol_address(), packet.sender_hardware_address(), UpdateArp::Set);
+        update_arp_table(packet.sender_protocol_address(), packet.sender_hardware_address(), UpdateTable::Set);
     }
 
     if (packet.operation() == ARPOperation::Request) {
@@ -206,7 +206,7 @@ void handle_ipv4(EthernetFrameHeader const& eth, size_t frame_size, Time const& 
             auto my_net = adapter.ipv4_address().to_u32() & adapter.ipv4_netmask().to_u32();
             auto their_net = packet.source().to_u32() & adapter.ipv4_netmask().to_u32();
             if (my_net == their_net)
-                update_arp_table(packet.source(), eth.source(), UpdateArp::Set);
+                update_arp_table(packet.source(), eth.source(), UpdateTable::Set);
         }
     });
 

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -110,12 +110,12 @@ SpinlockProtected<HashMap<IPv4Address, MACAddress>>& arp_table()
     return *s_arp_table;
 }
 
-void update_arp_table(IPv4Address const& ip_addr, MACAddress const& addr, UpdateArp update)
+void update_arp_table(IPv4Address const& ip_addr, MACAddress const& addr, UpdateTable update)
 {
     arp_table().with([&](auto& table) {
-        if (update == UpdateArp::Set)
+        if (update == UpdateTable::Set)
             table.set(ip_addr, addr);
-        if (update == UpdateArp::Delete)
+        if (update == UpdateTable::Delete)
             table.remove(ip_addr);
     });
     s_arp_table_blocker_set->unblock_blockers_waiting_for_ipv4_address(ip_addr, addr);

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -17,6 +17,7 @@
 namespace Kernel {
 
 static Singleton<SpinlockProtected<HashMap<IPv4Address, MACAddress>>> s_arp_table;
+static Singleton<SpinlockProtected<Route::RouteList>> s_routing_table;
 
 class ARPTableBlocker final : public Thread::Blocker {
 public:
@@ -129,6 +130,32 @@ void update_arp_table(IPv4Address const& ip_addr, MACAddress const& addr, Update
     }
 }
 
+SpinlockProtected<Route::RouteList>& routing_table()
+{
+    return *s_routing_table;
+}
+
+ErrorOr<void> update_routing_table(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, RefPtr<NetworkAdapter> adapter, UpdateTable update)
+{
+    auto route_entry = adopt_ref_if_nonnull(new (nothrow) Route { destination, gateway, netmask, adapter.release_nonnull() });
+    if (!route_entry)
+        return ENOMEM;
+
+    TRY(routing_table().with([&](auto& table) -> ErrorOr<void> {
+        // TODO: Add support for deleting routing entries
+        if (update == UpdateTable::Set) {
+            for (auto const& route : table) {
+                if (route == *route_entry)
+                    return EEXIST;
+            }
+            table.append(*route_entry);
+        }
+        return {};
+    }));
+
+    return {};
+}
+
 bool RoutingDecision::is_zero() const
 {
     return adapter.is_null() || next_hop.is_zero();
@@ -162,9 +189,9 @@ RoutingDecision route_to(IPv4Address const& target, IPv4Address const& source, R
     auto source_addr = source.to_u32();
 
     RefPtr<NetworkAdapter> local_adapter = nullptr;
-    RefPtr<NetworkAdapter> gateway_adapter = nullptr;
+    RefPtr<Route> chosen_route = nullptr;
 
-    NetworkingManagement::the().for_each([source_addr, &target_addr, &local_adapter, &gateway_adapter, &matches, &through](NetworkAdapter& adapter) {
+    NetworkingManagement::the().for_each([source_addr, &target_addr, &local_adapter, &matches, &through](NetworkAdapter& adapter) {
         auto adapter_addr = adapter.ipv4_address().to_u32();
         auto adapter_mask = adapter.ipv4_netmask().to_u32();
 
@@ -181,15 +208,45 @@ RoutingDecision route_to(IPv4Address const& target, IPv4Address const& source, R
 
         if ((target_addr & adapter_mask) == (adapter_addr & adapter_mask) && matches(adapter))
             local_adapter = adapter;
+    });
 
-        if (adapter.ipv4_gateway().to_u32() != 0 && matches(adapter))
-            gateway_adapter = adapter;
+    u32 longest_prefix_match = 0;
+    routing_table().for_each([&target_addr, &matches, &longest_prefix_match, &chosen_route](auto& route) {
+        auto route_addr = route.destination.to_u32();
+        auto route_mask = route.netmask.to_u32();
+
+        if (route_addr == 0 && matches(*route.adapter)) {
+            dbgln_if(ROUTING_DEBUG, "Resorting to default route found for adapter: {}", route.adapter->name());
+            chosen_route = route;
+        }
+
+        // We have a direct match and we can exit the routing table earlier.
+        if (target_addr == route_addr) {
+            dbgln_if(ROUTING_DEBUG, "Target address has a direct match in the routing table");
+            chosen_route = route;
+            return;
+        }
+
+        if ((target_addr & route_mask) == (route_addr & route_mask) && (route_addr != 0)) {
+            auto prefix = (target_addr & (route_addr & route_mask));
+
+            if (chosen_route && prefix == longest_prefix_match) {
+                chosen_route = (route.netmask.to_u32() > chosen_route->netmask.to_u32()) ? route : chosen_route;
+                dbgln_if(ROUTING_DEBUG, "Found a matching prefix match. Using longer netmask: {}", chosen_route->netmask);
+            }
+
+            if (prefix > longest_prefix_match) {
+                dbgln_if(ROUTING_DEBUG, "Found a longer prefix match - route: {}, netmask: {}", route.destination.to_string(), route.netmask);
+                longest_prefix_match = prefix;
+                chosen_route = route;
+            }
+        }
     });
 
     if (local_adapter && target == local_adapter->ipv4_address())
         return { local_adapter, local_adapter->mac_address() };
 
-    if (!local_adapter && !gateway_adapter) {
+    if (!local_adapter && !chosen_route) {
         dbgln_if(ROUTING_DEBUG, "Routing: Couldn't find a suitable adapter for route to {}", target);
         return { nullptr, {} };
     }
@@ -206,15 +263,15 @@ RoutingDecision route_to(IPv4Address const& target, IPv4Address const& source, R
 
         adapter = local_adapter;
         next_hop_ip = target;
-    } else if (gateway_adapter && allow_using_gateway == AllowUsingGateway::Yes) {
+    } else if (chosen_route && allow_using_gateway == AllowUsingGateway::Yes) {
         dbgln_if(ROUTING_DEBUG, "Routing: Got adapter for route (using gateway {}): {} ({}/{}) for {}",
-            gateway_adapter->ipv4_gateway(),
-            gateway_adapter->name(),
-            gateway_adapter->ipv4_address(),
-            gateway_adapter->ipv4_netmask(),
+            chosen_route->gateway,
+            chosen_route->adapter->name(),
+            chosen_route->adapter->ipv4_address(),
+            chosen_route->adapter->ipv4_netmask(),
             target);
-        adapter = gateway_adapter;
-        next_hop_ip = gateway_adapter->ipv4_gateway();
+        adapter = chosen_route->adapter;
+        next_hop_ip = chosen_route->gateway;
     } else {
         return { nullptr, {} };
     }

--- a/Kernel/Net/Routing.h
+++ b/Kernel/Net/Routing.h
@@ -6,11 +6,36 @@
 
 #pragma once
 
+#include <AK/IPv4Address.h>
+#include <AK/NonnullRefPtr.h>
 #include <Kernel/Locking/MutexProtected.h>
 #include <Kernel/Net/NetworkAdapter.h>
 #include <Kernel/Thread.h>
 
 namespace Kernel {
+
+struct Route : public RefCounted<Route> {
+    Route(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, NonnullRefPtr<NetworkAdapter> adapter)
+        : destination(destination)
+        , gateway(gateway)
+        , netmask(netmask)
+        , adapter(adapter)
+    {
+    }
+
+    bool operator==(Route const& other)
+    {
+        return destination == other.destination && gateway == other.gateway && netmask == other.netmask && adapter.ptr() == other.adapter.ptr();
+    }
+
+    const IPv4Address destination;
+    const IPv4Address gateway;
+    const IPv4Address netmask;
+    NonnullRefPtr<NetworkAdapter> adapter;
+
+    IntrusiveListNode<Route, RefPtr<Route>> route_list_node {};
+    using RouteList = IntrusiveList<&Route::route_list_node>;
+};
 
 struct RoutingDecision {
     RefPtr<NetworkAdapter> adapter;
@@ -25,6 +50,7 @@ enum class UpdateTable {
 };
 
 void update_arp_table(IPv4Address const&, MACAddress const&, UpdateTable update);
+ErrorOr<void> update_routing_table(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, RefPtr<NetworkAdapter> const adapter, UpdateTable update);
 
 enum class AllowUsingGateway {
     Yes,
@@ -34,5 +60,6 @@ enum class AllowUsingGateway {
 RoutingDecision route_to(IPv4Address const& target, IPv4Address const& source, RefPtr<NetworkAdapter> const through = nullptr, AllowUsingGateway = AllowUsingGateway::Yes);
 
 SpinlockProtected<HashMap<IPv4Address, MACAddress>>& arp_table();
+SpinlockProtected<Route::RouteList>& routing_table();
 
 }

--- a/Kernel/Net/Routing.h
+++ b/Kernel/Net/Routing.h
@@ -19,12 +19,12 @@ struct RoutingDecision {
     bool is_zero() const;
 };
 
-enum class UpdateArp {
+enum class UpdateTable {
     Set,
     Delete,
 };
 
-void update_arp_table(IPv4Address const&, MACAddress const&, UpdateArp update);
+void update_arp_table(IPv4Address const&, MACAddress const&, UpdateTable update);
 
 enum class AllowUsingGateway {
     Yes,

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -3,7 +3,7 @@ list(APPEND SPECIAL_TARGETS test install)
 list(APPEND REQUIRED_TARGETS
     arp base64 basename cat chmod chown clear comm cp cut date dd df diff dirname dmesg du echo env expr false fgrep
     file find grep groups head host hostname id ifconfig kill killall ln logout ls mkdir mount mv nproc
-    pgrep pidof ping pmap ps readlink realpath reboot rm rmdir seq shutdown sleep sort stat stty su tail test
+    pgrep pidof ping pmap ps readlink realpath reboot rm rmdir route seq shutdown sleep sort stat stty su tail test
     touch tr true umount uname uniq uptime w wc which whoami xargs yes less
 )
 list(APPEND RECOMMENDED_TARGETS
@@ -177,6 +177,7 @@ target_link_libraries(reboot LibMain)
 target_link_libraries(rev LibMain)
 target_link_libraries(rm LibMain)
 target_link_libraries(rmdir LibMain)
+target_link_libraries(route LibMain)
 target_link_libraries(run-tests LibRegex LibCoredump LibMain)
 target_link_libraries(seq LibMain)
 target_link_libraries(shot LibGUI LibMain)

--- a/Userland/Utilities/route.cpp
+++ b/Userland/Utilities/route.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2022, Brandon Pruitt <brapru@pm.me>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/IPv4Address.h>
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/QuickSort.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibCore/ProcessStatisticsReader.h>
+#include <LibCore/System.h>
+#include <LibMain/Main.h>
+#include <net/if.h>
+#include <net/route.h>
+#include <netinet/in.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    TRY(Core::System::pledge("stdio rpath inet"));
+    TRY(Core::System::unveil("/proc/net", "r"));
+    TRY(Core::System::unveil(nullptr, nullptr));
+
+    StringView modify_action;
+    StringView value_host_address;
+    StringView value_network_address;
+    StringView value_gateway_address;
+    StringView value_netmask_address;
+    StringView value_interface;
+
+    Core::ArgsParser args_parser;
+    args_parser.set_general_help("Display kernel routing table");
+    args_parser.add_positional_argument(modify_action, "Modify the global routing table { add | del }", "action", Core::ArgsParser::Required::No);
+    args_parser.add_option(value_host_address, "Target destination is an IPv4 address", "host", 'h', "host");
+    args_parser.add_option(value_network_address, "Target destination is a network address", "net", 'n', "net");
+    args_parser.add_option(value_gateway_address, "Route packets via a gateway", "gw", 'g', "gw");
+    args_parser.add_option(value_netmask_address, "The netmask to be used when adding a network route", "netmask", 'm', "netmask");
+    args_parser.add_option(value_interface, "Force the route to be associated with the specified device interface", "interface", 'i', "interface");
+    args_parser.parse(arguments);
+
+    enum class Alignment {
+        Left,
+        Right
+    };
+
+    struct Column {
+        String title;
+        Alignment alignment { Alignment::Left };
+        int width { 0 };
+        String buffer;
+    };
+
+    Vector<Column> columns;
+
+    int destination_column = -1;
+    int gateway_column = -1;
+    int genmask_column = -1;
+    int interface_column = -1;
+
+    auto add_column = [&](auto title, auto alignment, auto width) {
+        columns.append({ title, alignment, width, {} });
+        return columns.size() - 1;
+    };
+
+    destination_column = add_column("Destination", Alignment::Left, 15);
+    gateway_column = add_column("Gateway", Alignment::Left, 15);
+    genmask_column = add_column("Genmask", Alignment::Left, 15);
+    interface_column = add_column("Interface", Alignment::Left, 9);
+
+    auto print_column = [](auto& column, auto& string) {
+        if (!column.width) {
+            out("{}", string);
+            return;
+        }
+        if (column.alignment == Alignment::Right) {
+            out("{:>{1}}  "sv, string, column.width);
+        } else {
+            out("{:<{1}}  "sv, string, column.width);
+        }
+    };
+
+    if (modify_action.is_empty()) {
+        auto file = TRY(Core::File::open("/proc/net/route", Core::OpenMode::ReadOnly));
+        auto file_contents = file->read_all();
+        auto json = TRY(JsonValue::from_string(file_contents));
+
+        outln("Kernel IP routing table");
+
+        for (auto& column : columns)
+            print_column(column, column.title);
+        outln();
+
+        Vector<JsonValue> sorted_regions = json.as_array().values();
+        quick_sort(sorted_regions, [](auto& a, auto& b) {
+            return a.as_object().get("destination").to_string() < b.as_object().get("destination").to_string();
+        });
+
+        for (auto& value : sorted_regions) {
+            auto& if_object = value.as_object();
+
+            auto destination = if_object.get("destination").to_string();
+            auto gateway = if_object.get("gateway").to_string();
+            auto genmask = if_object.get("genmask").to_string();
+            auto interface = if_object.get("interface").to_string();
+
+            if (destination_column != -1)
+                columns[destination_column].buffer = destination;
+            if (gateway_column != -1)
+                columns[gateway_column].buffer = gateway;
+            if (genmask_column != -1)
+                columns[genmask_column].buffer = genmask;
+            if (interface_column != -1)
+                columns[interface_column].buffer = interface;
+
+            for (auto& column : columns)
+                print_column(column, column.buffer);
+            outln();
+        };
+    }
+
+    if (!modify_action.is_empty()) {
+        bool const action_add = (modify_action == "add");
+        bool const action_del = (modify_action == "del");
+
+        if (!action_add && !action_del) {
+            warnln("Invalid modify action: {}", modify_action);
+            return 1;
+        }
+
+        if (value_host_address.is_empty() && value_network_address.is_empty()) {
+            warnln("No target host or network specified");
+            return 1;
+        }
+
+        Optional<IPv4Address> destination;
+
+        if (!value_host_address.is_empty())
+            destination = AK::IPv4Address::from_string(value_host_address);
+
+        if (!value_network_address.is_empty())
+            destination = AK::IPv4Address::from_string(value_network_address);
+
+        if (!destination.has_value()) {
+            warnln("Invalid destination IPv4 address");
+            return 1;
+        }
+
+        auto gateway = AK::IPv4Address::from_string(value_gateway_address);
+        if (!gateway.has_value()) {
+            warnln("Invalid gateway IPv4 address: '{}'", value_gateway_address);
+            return 1;
+        }
+
+        auto genmask = AK::IPv4Address::from_string(value_netmask_address);
+        if (!genmask.has_value()) {
+            warnln("Invalid genmask IPv4 address: '{}'", value_netmask_address);
+            return 1;
+        }
+
+        int fd = TRY(Core::System::socket(AF_INET, SOCK_DGRAM, IPPROTO_IP));
+
+        rtentry rt {};
+        memset(&rt, 0, sizeof(rt));
+
+        rt.rt_dev = const_cast<char*>(value_interface.characters_without_null_termination());
+        rt.rt_gateway.sa_family = AF_INET;
+        ((sockaddr_in&)rt.rt_dst).sin_addr.s_addr = destination.value().to_in_addr_t();
+        ((sockaddr_in&)rt.rt_gateway).sin_addr.s_addr = gateway.value().to_in_addr_t();
+        ((sockaddr_in&)rt.rt_genmask).sin_addr.s_addr = genmask.value().to_in_addr_t();
+        rt.rt_flags = RTF_UP | RTF_GATEWAY;
+
+        if (action_add)
+            TRY(Core::System::ioctl(fd, SIOCADDRT, &rt));
+
+        // FIXME: Add support for route deletion.
+        if (action_del) {
+            warnln("Route deletion currently not implemented.");
+            return 1;
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
This isn't an entirely sophisticated implementation, but it's a decent start. I gave up trying to implement it with a Trie as it was growing too complicated (I guess you could say I tried... :man_shrugging:  ). While I think eventually we can move towards a prefix tree routing implementation for better lookup performance, considering that realistically few routes are in the table on day-to-day use (this isn't a router handling thousands of routing options), I think the linear time complexity of a linked-list is an acceptable trade off. 

![route_serenity](https://user-images.githubusercontent.com/54456386/160289748-e4912118-dd91-4cb5-92a7-fd6e0a647ec3.png)

**Kernel: Generalize the UpdateArp table to UpdateTable**
We can use the same enum cases to apply to updates on different
networking tables within the Kernel (i.e. a routing table)

**Kernel: Add a global routing table**
Previously the system had no concept of assigning different routes for
different destination addresses as the default gateway IP address was
directly assigned to a network adapter. This default gateway was
statically assigned and any update  would remove the previously existing
route.

This patch is a beginning step towards implementing https://github.com/SerenityOS/serenity/issues/180. It implements
a simple global routing table that is referenced during the routing
process. With this implementation it is now possible for a user or
service (i.e. DHCP) to dynamically add routes to the table.

The routing table will select the most specific route when possible. It
will select any direct match between the destination and routing entry
addresses. If the destination address overlaps between multiple entries,
the Kernel will use the longest prefix match, or the longest number of
matching bits between the destination address and the routing address.
In the event that there is no entries found for a specific destination
address, this implementation supports entries for a default route to be
set for any specified interface.

This is a small first step towards enhancing the system's routing
capabilities. Future enhancements would include referencing a
configuration file at boot to load pre-defined static routes.

**Kernel+Utilities: Add the route utility**
This exposes the global routing table in the /proc directory and adds
the userspace utility to query dynamically add from the table.