### PR TITLE
Gfx/PixelPaint: Make Box blur filter directional

### DIFF
--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.cpp
@@ -26,6 +26,13 @@ void FastBoxBlur::apply(Gfx::Bitmap& target_bitmap, Gfx::Bitmap const& source_bi
     Gfx::FastBoxBlurFilter filter(target_bitmap);
 
     if (m_use_asymmetric_radii) {
+        if (m_use_vector) {
+            auto radius_x = m_radius * fabs(cos((double)m_angle * M_DEG2RAD));
+            auto radius_y = m_radius * fabs(sin((double)m_angle * M_DEG2RAD));
+            filter.apply_single_pass(radius_x, radius_y);
+            return;
+        }
+
         filter.apply_single_pass(m_radius_x, m_radius_y);
         return;
     }
@@ -53,6 +60,7 @@ RefPtr<GUI::Widget> FastBoxBlur::get_settings_widget()
         asymmetric_checkbox.on_checked = [&](bool checked) {
             m_use_asymmetric_radii = checked;
             if (m_use_asymmetric_radii) {
+                m_vector_checkbox->set_visible(true);
                 m_radius_x_slider->set_value(m_radius);
                 m_radius_y_slider->set_value(m_radius);
                 m_asymmetric_radius_container->set_visible(true);
@@ -62,6 +70,23 @@ RefPtr<GUI::Widget> FastBoxBlur::get_settings_widget()
                 m_asymmetric_radius_container->set_visible(false);
                 m_radius_container->set_visible(true);
                 m_gaussian_checkbox->set_visible(true);
+                m_vector_checkbox->set_visible(false);
+            }
+            update_preview();
+        };
+
+        m_vector_checkbox = m_settings_widget->add<GUI::CheckBox>("Use Direction and magnitude");
+        m_vector_checkbox->set_checked(false);
+        m_vector_checkbox->set_visible(false);
+        m_vector_checkbox->set_fixed_height(15);
+        m_vector_checkbox->on_checked = [&](bool checked) {
+            m_use_vector = checked;
+            if (m_use_vector) {
+                m_asymmetric_radius_container->set_visible(false);
+                m_vector_container->set_visible(true);
+            } else {
+                m_asymmetric_radius_container->set_visible(true);
+                m_vector_container->set_visible(false);
             }
             update_preview();
         };
@@ -118,6 +143,44 @@ RefPtr<GUI::Widget> FastBoxBlur::get_settings_widget()
         m_radius_y_slider->set_value(m_radius_y);
         m_radius_y_slider->on_change = [&](int value) {
             m_radius_y = value;
+            update_preview();
+        };
+
+        m_vector_container = m_settings_widget->add<GUI::Widget>();
+        m_vector_container->set_visible(false);
+        m_vector_container->set_fixed_height(50);
+        m_vector_container->set_layout<GUI::VerticalBoxLayout>();
+        m_vector_container->layout()->set_margins({ 4, 0, 4, 0 });
+
+        auto& angle_container = m_vector_container->add<GUI::Widget>();
+        angle_container.set_fixed_height(20);
+        angle_container.set_layout<GUI::HorizontalBoxLayout>();
+
+        auto& angle_label = angle_container.add<GUI::Label>("Angle:");
+        angle_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        angle_label.set_fixed_size(60, 20);
+
+        m_angle_slider = angle_container.add<GUI::ValueSlider>(Orientation::Horizontal, "°");
+        m_angle_slider->set_range(0, 360);
+        m_angle_slider->set_value(m_angle);
+        m_angle_slider->on_change = [&](int value) {
+            m_angle = value;
+            update_preview();
+        };
+
+        auto& magnitude_container = m_vector_container->add<GUI::Widget>();
+        magnitude_container.set_fixed_height(20);
+        magnitude_container.set_layout<GUI::HorizontalBoxLayout>();
+
+        auto& magnitude_label = magnitude_container.add<GUI::Label>("Magnitude:");
+        magnitude_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
+        magnitude_label.set_fixed_size(60, 20);
+
+        m_magnitude_slider = magnitude_container.add<GUI::ValueSlider>(Orientation::Horizontal, "px");
+        m_magnitude_slider->set_range(0, 50);
+        m_magnitude_slider->set_value(m_radius);
+        m_magnitude_slider->on_change = [&](int value) {
+            m_radius = value;
             update_preview();
         };
 

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
@@ -28,12 +28,15 @@ private:
     bool m_use_vector { false };
     size_t m_radius_x { 0 };
     size_t m_radius_y { 0 };
+    size_t m_angle { 0 };
 
     bool m_approximate_gauss { false };
 
     RefPtr<GUI::Widget> m_radius_container { nullptr };
     RefPtr<GUI::Widget> m_asymmetric_radius_container { nullptr };
+    RefPtr<GUI::Widget> m_vector_container { nullptr };
     RefPtr<GUI::CheckBox> m_gaussian_checkbox { nullptr };
+    RefPtr<GUI::CheckBox> m_vector_checkbox { nullptr };
     RefPtr<GUI::ValueSlider> m_radius_x_slider { nullptr };
     RefPtr<GUI::ValueSlider> m_radius_y_slider { nullptr };
     RefPtr<GUI::ValueSlider> m_angle_slider { nullptr };

--- a/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
+++ b/Userland/Applications/PixelPaint/Filters/FastBoxBlur.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Filter.h"
+#include <LibGUI/ValueSlider.h>
 
 namespace PixelPaint::Filters {
 
@@ -22,7 +23,21 @@ public:
 
 private:
     size_t m_radius { 5 };
+
+    bool m_use_asymmetric_radii { false };
+    bool m_use_vector { false };
+    size_t m_radius_x { 0 };
+    size_t m_radius_y { 0 };
+
     bool m_approximate_gauss { false };
+
+    RefPtr<GUI::Widget> m_radius_container { nullptr };
+    RefPtr<GUI::Widget> m_asymmetric_radius_container { nullptr };
+    RefPtr<GUI::CheckBox> m_gaussian_checkbox { nullptr };
+    RefPtr<GUI::ValueSlider> m_radius_x_slider { nullptr };
+    RefPtr<GUI::ValueSlider> m_radius_y_slider { nullptr };
+    RefPtr<GUI::ValueSlider> m_angle_slider { nullptr };
+    RefPtr<GUI::ValueSlider> m_magnitude_slider { nullptr };
 };
 
 }

--- a/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.cpp
+++ b/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.cpp
@@ -29,10 +29,8 @@ FastBoxBlurFilter::FastBoxBlurFilter(Bitmap& bitmap)
 }
 
 // Based on the super fast blur algorithm by Quasimondo, explored here: https://stackoverflow.com/questions/21418892/understanding-super-fast-blur-algorithm
-void FastBoxBlurFilter::apply_single_pass(int radius)
+void FastBoxBlurFilter::apply_single_pass(size_t radius)
 {
-    VERIFY(radius >= 0);
-
     auto format = m_bitmap.format();
     VERIFY(format == BitmapFormat::BGRA8888 || format == BitmapFormat::BGRx8888);
 
@@ -74,7 +72,7 @@ void FastBoxBlurFilter::apply_single_pass(int radius)
         size_t sum_alpha = 0;
 
         // Setup sliding window
-        for (int i = -radius; i <= radius; ++i) {
+        for (int i = -(int)radius; i <= (int)radius; ++i) {
             auto color_at_px = get_pixel_function(clamp(i, 0, width - 1), y);
             sum_red += red_value(color_at_px);
             sum_green += green_value(color_at_px);
@@ -88,8 +86,8 @@ void FastBoxBlurFilter::apply_single_pass(int radius)
             intermediate_blue[y * width + x] = (sum_blue / div);
             intermediate_alpha[y * width + x] = (sum_alpha / div);
 
-            auto leftmost_x_coord = max(x - radius, 0);
-            auto rightmost_x_coord = min(x + radius + 1, width - 1);
+            auto leftmost_x_coord = max(x - (int)radius, 0);
+            auto rightmost_x_coord = min(x + (int)radius + 1, width - 1);
 
             auto leftmost_x_color = get_pixel_function(leftmost_x_coord, y);
             auto rightmost_x_color = get_pixel_function(rightmost_x_coord, y);
@@ -113,7 +111,7 @@ void FastBoxBlurFilter::apply_single_pass(int radius)
         size_t sum_alpha = 0;
 
         // Setup sliding window
-        for (int i = -radius; i <= radius; ++i) {
+        for (int i = -(int)radius; i <= (int)radius; ++i) {
             int offset = clamp(i, 0, height - 1) * width + x;
             sum_red += intermediate_red[offset];
             sum_green += intermediate_green[offset];
@@ -130,8 +128,8 @@ void FastBoxBlurFilter::apply_single_pass(int radius)
 
             set_pixel_function(x, y, color);
 
-            auto topmost_y_coord = max(y - radius, 0);
-            auto bottommost_y_coord = min(y + radius + 1, height - 1);
+            auto topmost_y_coord = max(y - (int)radius, 0);
+            auto bottommost_y_coord = min(y + (int)radius + 1, height - 1);
 
             sum_red += intermediate_red[x + bottommost_y_coord * width];
             sum_red -= intermediate_red[x + topmost_y_coord * width];

--- a/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.h
@@ -14,7 +14,7 @@ class FastBoxBlurFilter {
 public:
     FastBoxBlurFilter(Bitmap&);
 
-    void apply_single_pass(int radius);
+    void apply_single_pass(size_t radius);
     void apply_three_passes(size_t radius);
 
 private:

--- a/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.h
@@ -15,6 +15,8 @@ public:
     FastBoxBlurFilter(Bitmap&);
 
     void apply_single_pass(size_t radius);
+    void apply_single_pass(size_t radius_x, size_t radius_y);
+
     void apply_three_passes(size_t radius);
 
 private:


### PR DESCRIPTION
This patch allows you to separately specify x and y blur radii when applying the FastBoxBlurFilter (without gaussian approximation).

The settings gained a "Use asymmetric radii" checkbox
![image](https://user-images.githubusercontent.com/6002167/158609701-f3060d72-47e6-4046-adec-7042a0e2aaca.png)
When checked, you can enter x and y radii
![image](https://user-images.githubusercontent.com/6002167/158609969-f5d3c986-4b61-4f98-b3c1-aa09560913cc.png)
Alternatively you can select "Use direction and magnitude" input method
![image](https://user-images.githubusercontent.com/6002167/158610252-e3c988aa-2c19-421b-be2c-323f5850ef3c.png)

