### PR TITLE
Meta: Don't use heredocs as file paths

### DIFF
--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -119,7 +119,7 @@ jobs:
         working-directory: libjs-test262/Build
         run: |
           _deps/lagom-build/test-wasm --per-file > ../../libjs-website/wasm/data/per-file-master.json
-          jq -nc -f <<-EOF --slurpfile previous ../../libjs-website/wasm/data/results.json --slurpfile details ../../libjs-website/wasm/data/per-file-master.json
+          jq -nc -f /dev/stdin <<-EOF --slurpfile previous ../../libjs-website/wasm/data/results.json --slurpfile details ../../libjs-website/wasm/data/per-file-master.json
             \$details[0] as \$details | \$previous[0] + [{
               "commit_timestamp": $(git -C ../.. log -1 --format=%ct),
               "run_timestamp": $(date +%s),


### PR DESCRIPTION
Heredocs are passed to stdin, so make `jq` read it from stdin instead of
treating it as a file path argument.