### PR TITLE
PixelPaint: Add Timer for displaying previews of filters

### DIFF
--- a/Userland/Applications/PixelPaint/Filters/Filter.cpp
+++ b/Userland/Applications/PixelPaint/Filters/Filter.cpp
@@ -11,6 +11,16 @@
 
 namespace PixelPaint {
 
+Filter::Filter(ImageEditor* editor)
+    : m_editor(editor)
+    , m_update_timer(Core::Timer::create_single_shot(100, [&] {
+        if (on_settings_change)
+            on_settings_change();
+    }))
+{
+    m_update_timer->set_active(false);
+}
+
 RefPtr<GUI::Widget> Filter::get_settings_widget()
 {
     if (!m_settings_widget) {
@@ -39,8 +49,6 @@ void Filter::apply() const
 
 void Filter::update_preview()
 {
-    if (on_settings_change)
-        on_settings_change();
+    m_update_timer->restart();
 }
-
 }

--- a/Userland/Applications/PixelPaint/Filters/Filter.h
+++ b/Userland/Applications/PixelPaint/Filters/Filter.h
@@ -24,8 +24,7 @@ public:
 
     virtual ~Filter() {};
 
-    Filter(ImageEditor* editor)
-        : m_editor(editor) {};
+    Filter(ImageEditor* editor);
 
     Function<void(void)> on_settings_change;
 
@@ -33,6 +32,9 @@ protected:
     ImageEditor* m_editor { nullptr };
     RefPtr<GUI::Widget> m_settings_widget { nullptr };
     void update_preview();
+
+private:
+    NonnullRefPtr<Core::Timer> m_update_timer;
 };
 
 }


### PR DESCRIPTION
This way the preview image is not generated on _every_ update_preview()
call but rather only if the last update_preview() was longer than 100ms
ago.
When rapidly moving the Slider for large blur values in the
FastBoxBlurFilter with the Gaussian approximation the usage became
noticeably sliggish because we queued a lot of preview generation just
to throw it away immediately. This patch fixes that.