### PR TITLE
Browser: Add Ctrl-<number> actions to changes tabs

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -114,6 +114,15 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
         m_tab_widget->activate_previous_tab();
     };
 
+    for (int i = 0; i <= 7; ++i) {
+        m_window_actions.on_tabs.append([this, i] {
+            m_tab_widget->set_tab_index(i);
+        });
+    }
+    m_window_actions.on_tabs.append([this] {
+        m_tab_widget->activate_last_tab();
+    });
+
     m_window_actions.on_about = [this] {
         auto app_icon = GUI::Icon::default_icon("app-browser");
         GUI::AboutDialog::show("Browser", app_icon.bitmap_for_size(32), this);

--- a/Userland/Applications/Browser/WindowActions.cpp
+++ b/Userland/Applications/Browser/WindowActions.cpp
@@ -48,6 +48,23 @@ WindowActions::WindowActions(GUI::Window& window)
         &window);
     m_previous_tab_action->set_status_tip("Switch to the previous tab");
 
+    for (auto i = 0; i <= 7; ++i) {
+        m_tab_actions.append(GUI::Action::create(
+            String::formatted("Tab {}", i + 1), { Mod_Ctrl, static_cast<KeyCode>(Key_1 + i) }, [this, i](auto&) {
+                if (on_tabs[i])
+                    on_tabs[i]();
+            },
+            &window));
+        m_tab_actions.last().set_status_tip(String::formatted("Switch to tab {}", i + 1));
+    }
+    m_tab_actions.append(GUI::Action::create(
+        "Last tab", { Mod_Ctrl, Key_9 }, [this](auto&) {
+            if (on_tabs[8])
+                on_tabs[8]();
+        },
+        &window));
+    m_tab_actions.last().set_status_tip("Switch to last tab");
+
     m_about_action = GUI::Action::create(
         "&About Browser", GUI::Icon::default_icon("app-browser").bitmap_for_size(16), [this](const GUI::Action&) {
             if (on_about)

--- a/Userland/Applications/Browser/WindowActions.h
+++ b/Userland/Applications/Browser/WindowActions.h
@@ -19,6 +19,7 @@ public:
     Function<void()> on_create_new_tab;
     Function<void()> on_next_tab;
     Function<void()> on_previous_tab;
+    Vector<Function<void()>> on_tabs;
     Function<void()> on_about;
     Function<void(GUI::Action&)> on_show_bookmarks_bar;
 
@@ -32,6 +33,7 @@ private:
     RefPtr<GUI::Action> m_create_new_tab_action;
     RefPtr<GUI::Action> m_next_tab_action;
     RefPtr<GUI::Action> m_previous_tab_action;
+    NonnullRefPtrVector<GUI::Action> m_tab_actions;
     RefPtr<GUI::Action> m_about_action;
     RefPtr<GUI::Action> m_show_bookmarks_bar_action;
 };

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -592,6 +592,14 @@ void TabWidget::activate_previous_tab()
     set_active_widget(m_tabs.at(previous_index).widget);
 }
 
+void TabWidget::activate_last_tab()
+{
+    size_t number_of_tabs = m_tabs.size();
+    if (number_of_tabs == 0)
+        return;
+    set_active_widget(m_tabs.at(number_of_tabs - 1).widget);
+}
+
 void TabWidget::keydown_event(KeyEvent& event)
 {
     if (event.ctrl() && event.key() == Key_Tab) {

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -66,6 +66,7 @@ public:
 
     void activate_next_tab();
     void activate_previous_tab();
+    void activate_last_tab();
 
     void set_text_alignment(Gfx::TextAlignment alignment) { m_text_alignment = alignment; }
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }


### PR DESCRIPTION
It is now possible to quickly switch to specific tabs directly without
having to 'search linearly'.

Pressing Ctrl plus a number from 1 to 8 switches to the tab of that
index. Pressing Ctrl-9 swithes to the last tab.

This feature already exists in Firefox and Chrome.