### PR TITLE
Kernel: Use default constructors/destructors

### DIFF
--- a/Kernel/Arch/aarch64/ScopedCritical.cpp
+++ b/Kernel/Arch/aarch64/ScopedCritical.cpp
@@ -10,13 +10,8 @@
 
 namespace Kernel {
 
-ScopedCritical::ScopedCritical()
-{
-}
-
-ScopedCritical::~ScopedCritical()
-{
-}
+ScopedCritical::ScopedCritical() = default;
+ScopedCritical::~ScopedCritical() = default;
 
 ScopedCritical::ScopedCritical(ScopedCritical&& /*from*/)
 {

--- a/Kernel/Arch/aarch64/SmapDisabler.cpp
+++ b/Kernel/Arch/aarch64/SmapDisabler.cpp
@@ -13,8 +13,6 @@ SmapDisabler::SmapDisabler()
 {
 }
 
-SmapDisabler::~SmapDisabler()
-{
-}
+SmapDisabler::~SmapDisabler() = default;
 
 }

--- a/Kernel/Bus/USB/SysFSUSB.cpp
+++ b/Kernel/Bus/USB/SysFSUSB.cpp
@@ -20,9 +20,7 @@ SysFSUSBDeviceInformation::SysFSUSBDeviceInformation(NonnullOwnPtr<KString> devi
 {
 }
 
-SysFSUSBDeviceInformation::~SysFSUSBDeviceInformation()
-{
-}
+SysFSUSBDeviceInformation::~SysFSUSBDeviceInformation() = default;
 
 ErrorOr<void> SysFSUSBDeviceInformation::try_generate(KBufferBuilder& builder)
 {

--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -89,9 +89,7 @@ UNMAP_AFTER_INIT UHCIController::UHCIController(PCI::DeviceIdentifier const& pci
 {
 }
 
-UNMAP_AFTER_INIT UHCIController::~UHCIController()
-{
-}
+UNMAP_AFTER_INIT UHCIController::~UHCIController() = default;
 
 ErrorOr<void> UHCIController::reset()
 {

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -51,9 +51,7 @@ Device::Device(Device const& device, NonnullOwnPtr<Pipe> default_pipe)
 {
 }
 
-Device::~Device()
-{
-}
+Device::~Device() = default;
 
 ErrorOr<void> Device::enumerate_device()
 {

--- a/Kernel/Bus/USB/USBTransfer.cpp
+++ b/Kernel/Bus/USB/USBTransfer.cpp
@@ -24,9 +24,7 @@ Transfer::Transfer(Pipe& pipe, u16 len, NonnullOwnPtr<Memory::Region> data_buffe
 {
 }
 
-Transfer::~Transfer()
-{
-}
+Transfer::~Transfer() = default;
 
 void Transfer::set_setup_packet(const USBRequestData& request)
 {

--- a/Kernel/Bus/VirtIO/Queue.cpp
+++ b/Kernel/Bus/VirtIO/Queue.cpp
@@ -44,9 +44,7 @@ Queue::Queue(NonnullOwnPtr<Memory::Region> queue_region, u16 queue_size, u16 not
     enable_interrupts();
 }
 
-Queue::~Queue()
-{
-}
+Queue::~Queue() = default;
 
 void Queue::enable_interrupts()
 {

--- a/Kernel/Devices/Audio/AC97.cpp
+++ b/Kernel/Devices/Audio/AC97.cpp
@@ -36,9 +36,7 @@ UNMAP_AFTER_INIT AC97::AC97(PCI::DeviceIdentifier const& pci_device_identifier)
 {
 }
 
-UNMAP_AFTER_INIT AC97::~AC97()
-{
-}
+UNMAP_AFTER_INIT AC97::~AC97() = default;
 
 bool AC97::handle_irq(RegisterState const&)
 {

--- a/Kernel/Devices/Audio/Channel.h
+++ b/Kernel/Devices/Audio/Channel.h
@@ -21,7 +21,7 @@ class AudioChannel final
 
 public:
     static NonnullRefPtr<AudioChannel> must_create(AudioController const&, size_t channel_index);
-    virtual ~AudioChannel() override { }
+    virtual ~AudioChannel() override = default;
 
     // ^CharacterDevice
     virtual bool can_read(const OpenFileDescription&, u64) const override;

--- a/Kernel/Devices/BlockDevice.cpp
+++ b/Kernel/Devices/BlockDevice.cpp
@@ -24,9 +24,7 @@ void AsyncBlockDeviceRequest::start()
     m_block_device.start_request(*this);
 }
 
-BlockDevice::~BlockDevice()
-{
-}
+BlockDevice::~BlockDevice() = default;
 
 bool BlockDevice::read_block(u64 index, UserOrKernelBuffer& buffer)
 {

--- a/Kernel/Devices/CharacterDevice.cpp
+++ b/Kernel/Devices/CharacterDevice.cpp
@@ -8,8 +8,6 @@
 
 namespace Kernel {
 
-CharacterDevice::~CharacterDevice()
-{
-}
+CharacterDevice::~CharacterDevice() = default;
 
 }

--- a/Kernel/Devices/ConsoleDevice.cpp
+++ b/Kernel/Devices/ConsoleDevice.cpp
@@ -28,9 +28,7 @@ UNMAP_AFTER_INIT ConsoleDevice::ConsoleDevice()
 {
 }
 
-UNMAP_AFTER_INIT ConsoleDevice::~ConsoleDevice()
-{
-}
+UNMAP_AFTER_INIT ConsoleDevice::~ConsoleDevice() = default;
 
 bool ConsoleDevice::can_read(const Kernel::OpenFileDescription&, u64) const
 {

--- a/Kernel/Devices/DeviceControlDevice.cpp
+++ b/Kernel/Devices/DeviceControlDevice.cpp
@@ -27,9 +27,7 @@ UNMAP_AFTER_INIT DeviceControlDevice::DeviceControlDevice()
 {
 }
 
-UNMAP_AFTER_INIT DeviceControlDevice::~DeviceControlDevice()
-{
-}
+UNMAP_AFTER_INIT DeviceControlDevice::~DeviceControlDevice() = default;
 
 ErrorOr<size_t> DeviceControlDevice::read(OpenFileDescription&, u64, UserOrKernelBuffer& buffer, size_t size)
 {

--- a/Kernel/Devices/FullDevice.cpp
+++ b/Kernel/Devices/FullDevice.cpp
@@ -25,9 +25,7 @@ UNMAP_AFTER_INIT FullDevice::FullDevice()
 {
 }
 
-UNMAP_AFTER_INIT FullDevice::~FullDevice()
-{
-}
+UNMAP_AFTER_INIT FullDevice::~FullDevice() = default;
 
 bool FullDevice::can_read(const OpenFileDescription&, u64) const
 {

--- a/Kernel/Devices/HID/KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/KeyboardDevice.cpp
@@ -276,9 +276,7 @@ UNMAP_AFTER_INIT KeyboardDevice::KeyboardDevice()
 
 // FIXME: UNMAP_AFTER_INIT is fine for now, but for hot-pluggable devices
 // like USB keyboards, we need to remove this
-UNMAP_AFTER_INIT KeyboardDevice::~KeyboardDevice()
-{
-}
+UNMAP_AFTER_INIT KeyboardDevice::~KeyboardDevice() = default;
 
 bool KeyboardDevice::can_read(const OpenFileDescription&, u64) const
 {

--- a/Kernel/Devices/HID/MouseDevice.cpp
+++ b/Kernel/Devices/HID/MouseDevice.cpp
@@ -14,9 +14,7 @@ MouseDevice::MouseDevice()
 {
 }
 
-MouseDevice::~MouseDevice()
-{
-}
+MouseDevice::~MouseDevice() = default;
 
 bool MouseDevice::can_read(const OpenFileDescription&, u64) const
 {

--- a/Kernel/Devices/HID/PS2KeyboardDevice.cpp
+++ b/Kernel/Devices/HID/PS2KeyboardDevice.cpp
@@ -116,8 +116,6 @@ UNMAP_AFTER_INIT PS2KeyboardDevice::PS2KeyboardDevice(const I8042Controller& ps2
 
 // FIXME: UNMAP_AFTER_INIT might not be correct, because in practice PS/2 devices
 // are hot pluggable.
-UNMAP_AFTER_INIT PS2KeyboardDevice::~PS2KeyboardDevice()
-{
-}
+UNMAP_AFTER_INIT PS2KeyboardDevice::~PS2KeyboardDevice() = default;
 
 }

--- a/Kernel/Devices/HID/PS2MouseDevice.cpp
+++ b/Kernel/Devices/HID/PS2MouseDevice.cpp
@@ -26,9 +26,7 @@ UNMAP_AFTER_INIT PS2MouseDevice::PS2MouseDevice(const I8042Controller& ps2_contr
 {
 }
 
-UNMAP_AFTER_INIT PS2MouseDevice::~PS2MouseDevice()
-{
-}
+UNMAP_AFTER_INIT PS2MouseDevice::~PS2MouseDevice() = default;
 
 bool PS2MouseDevice::handle_irq(const RegisterState&)
 {

--- a/Kernel/Devices/HID/VMWareMouseDevice.cpp
+++ b/Kernel/Devices/HID/VMWareMouseDevice.cpp
@@ -57,8 +57,6 @@ VMWareMouseDevice::VMWareMouseDevice(const I8042Controller& ps2_controller)
     : PS2MouseDevice(ps2_controller)
 {
 }
-VMWareMouseDevice::~VMWareMouseDevice()
-{
-}
+VMWareMouseDevice::~VMWareMouseDevice() = default;
 
 }

--- a/Kernel/Devices/MemoryDevice.cpp
+++ b/Kernel/Devices/MemoryDevice.cpp
@@ -28,9 +28,7 @@ UNMAP_AFTER_INIT MemoryDevice::MemoryDevice()
 {
 }
 
-UNMAP_AFTER_INIT MemoryDevice::~MemoryDevice()
-{
-}
+UNMAP_AFTER_INIT MemoryDevice::~MemoryDevice() = default;
 
 ErrorOr<size_t> MemoryDevice::read(OpenFileDescription&, u64 offset, UserOrKernelBuffer& buffer, size_t length)
 {

--- a/Kernel/Devices/NullDevice.cpp
+++ b/Kernel/Devices/NullDevice.cpp
@@ -24,9 +24,7 @@ UNMAP_AFTER_INIT NullDevice::NullDevice()
 {
 }
 
-UNMAP_AFTER_INIT NullDevice::~NullDevice()
-{
-}
+UNMAP_AFTER_INIT NullDevice::~NullDevice() = default;
 
 bool NullDevice::can_read(const OpenFileDescription&, u64) const
 {

--- a/Kernel/Devices/RandomDevice.cpp
+++ b/Kernel/Devices/RandomDevice.cpp
@@ -24,9 +24,7 @@ UNMAP_AFTER_INIT RandomDevice::RandomDevice()
 {
 }
 
-UNMAP_AFTER_INIT RandomDevice::~RandomDevice()
-{
-}
+UNMAP_AFTER_INIT RandomDevice::~RandomDevice() = default;
 
 bool RandomDevice::can_read(const OpenFileDescription&, u64) const
 {

--- a/Kernel/Devices/SerialDevice.cpp
+++ b/Kernel/Devices/SerialDevice.cpp
@@ -52,9 +52,7 @@ UNMAP_AFTER_INIT SerialDevice::SerialDevice(IOAddress base_addr, unsigned minor)
     initialize();
 }
 
-UNMAP_AFTER_INIT SerialDevice::~SerialDevice()
-{
-}
+UNMAP_AFTER_INIT SerialDevice::~SerialDevice() = default;
 
 bool SerialDevice::can_read(const OpenFileDescription&, u64) const
 {

--- a/Kernel/Devices/ZeroDevice.cpp
+++ b/Kernel/Devices/ZeroDevice.cpp
@@ -24,9 +24,7 @@ UNMAP_AFTER_INIT ZeroDevice::ZeroDevice()
 {
 }
 
-UNMAP_AFTER_INIT ZeroDevice::~ZeroDevice()
-{
-}
+UNMAP_AFTER_INIT ZeroDevice::~ZeroDevice() = default;
 
 bool ZeroDevice::can_read(const OpenFileDescription&, u64) const
 {

--- a/Kernel/FileSystem/AnonymousFile.cpp
+++ b/Kernel/FileSystem/AnonymousFile.cpp
@@ -15,9 +15,7 @@ AnonymousFile::AnonymousFile(NonnullRefPtr<Memory::AnonymousVMObject> vmobject)
 {
 }
 
-AnonymousFile::~AnonymousFile()
-{
-}
+AnonymousFile::~AnonymousFile() = default;
 
 ErrorOr<Memory::Region*> AnonymousFile::mmap(Process& process, OpenFileDescription&, Memory::VirtualRange const& range, u64 offset, int prot, bool shared)
 {

--- a/Kernel/FileSystem/BlockBasedFileSystem.cpp
+++ b/Kernel/FileSystem/BlockBasedFileSystem.cpp
@@ -114,9 +114,7 @@ BlockBasedFileSystem::BlockBasedFileSystem(OpenFileDescription& file_description
     VERIFY(file_description.file().is_seekable());
 }
 
-BlockBasedFileSystem::~BlockBasedFileSystem()
-{
-}
+BlockBasedFileSystem::~BlockBasedFileSystem() = default;
 
 ErrorOr<void> BlockBasedFileSystem::initialize()
 {

--- a/Kernel/FileSystem/Custody.cpp
+++ b/Kernel/FileSystem/Custody.cpp
@@ -47,9 +47,7 @@ Custody::Custody(Custody* parent, NonnullOwnPtr<KString> name, Inode& inode, int
 {
 }
 
-Custody::~Custody()
-{
-}
+Custody::~Custody() = default;
 
 ErrorOr<NonnullOwnPtr<KString>> Custody::try_serialize_absolute_path() const
 {

--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -17,13 +17,8 @@ ErrorOr<NonnullRefPtr<DevPtsFS>> DevPtsFS::try_create()
     return adopt_nonnull_ref_or_enomem(new (nothrow) DevPtsFS);
 }
 
-DevPtsFS::DevPtsFS()
-{
-}
-
-DevPtsFS::~DevPtsFS()
-{
-}
+DevPtsFS::DevPtsFS() = default;
+DevPtsFS::~DevPtsFS() = default;
 
 ErrorOr<void> DevPtsFS::initialize()
 {
@@ -81,9 +76,7 @@ DevPtsFSInode::DevPtsFSInode(DevPtsFS& fs, InodeIndex index, SlavePTY* pty)
         m_pty = *pty;
 }
 
-DevPtsFSInode::~DevPtsFSInode()
-{
-}
+DevPtsFSInode::~DevPtsFSInode() = default;
 
 ErrorOr<size_t> DevPtsFSInode::read_bytes(off_t, size_t, UserOrKernelBuffer&, OpenFileDescription*) const
 {

--- a/Kernel/FileSystem/DevTmpFS.cpp
+++ b/Kernel/FileSystem/DevTmpFS.cpp
@@ -16,9 +16,7 @@ ErrorOr<NonnullRefPtr<DevTmpFS>> DevTmpFS::try_create()
     return adopt_nonnull_ref_or_enomem(new (nothrow) DevTmpFS);
 }
 
-DevTmpFS::DevTmpFS()
-{
-}
+DevTmpFS::DevTmpFS() = default;
 
 size_t DevTmpFS::allocate_inode_index()
 {
@@ -28,9 +26,7 @@ size_t DevTmpFS::allocate_inode_index()
     return 1 + m_next_inode_index.value();
 }
 
-DevTmpFS::~DevTmpFS()
-{
-}
+DevTmpFS::~DevTmpFS() = default;
 
 ErrorOr<void> DevTmpFS::initialize()
 {
@@ -167,9 +163,7 @@ StringView DevTmpFSLinkInode::name() const
     return m_name->view();
 }
 
-DevTmpFSLinkInode::~DevTmpFSLinkInode()
-{
-}
+DevTmpFSLinkInode::~DevTmpFSLinkInode() = default;
 
 DevTmpFSLinkInode::DevTmpFSLinkInode(DevTmpFS& fs, NonnullOwnPtr<KString> name)
     : DevTmpFSInode(fs)
@@ -206,9 +200,7 @@ DevTmpFSDirectoryInode::DevTmpFSDirectoryInode(DevTmpFS& fs, NonnullOwnPtr<KStri
     , m_name(move(name))
 {
 }
-DevTmpFSDirectoryInode::~DevTmpFSDirectoryInode()
-{
-}
+DevTmpFSDirectoryInode::~DevTmpFSDirectoryInode() = default;
 
 ErrorOr<void> DevTmpFSDirectoryInode::traverse_as_directory(Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)> callback) const
 {
@@ -286,9 +278,7 @@ DevTmpFSRootDirectoryInode::DevTmpFSRootDirectoryInode(DevTmpFS& fs)
 {
     m_mode = 0555;
 }
-DevTmpFSRootDirectoryInode::~DevTmpFSRootDirectoryInode()
-{
-}
+DevTmpFSRootDirectoryInode::~DevTmpFSRootDirectoryInode() = default;
 ErrorOr<void> DevTmpFSRootDirectoryInode::chmod(mode_t)
 {
     return EPERM;
@@ -306,9 +296,7 @@ DevTmpFSDeviceInode::DevTmpFSDeviceInode(DevTmpFS& fs, MajorNumber major_number,
 {
 }
 
-DevTmpFSDeviceInode::~DevTmpFSDeviceInode()
-{
-}
+DevTmpFSDeviceInode::~DevTmpFSDeviceInode() = default;
 
 StringView DevTmpFSDeviceInode::name() const
 {

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -59,9 +59,7 @@ Ext2FS::Ext2FS(OpenFileDescription& file_description)
 {
 }
 
-Ext2FS::~Ext2FS()
-{
-}
+Ext2FS::~Ext2FS() = default;
 
 ErrorOr<void> Ext2FS::flush_super_block()
 {

--- a/Kernel/FileSystem/FIFO.cpp
+++ b/Kernel/FileSystem/FIFO.cpp
@@ -71,9 +71,7 @@ FIFO::FIFO(UserID uid, NonnullOwnPtr<DoubleBuffer> buffer)
     });
 }
 
-FIFO::~FIFO()
-{
-}
+FIFO::~FIFO() = default;
 
 void FIFO::attach(Direction direction)
 {

--- a/Kernel/FileSystem/File.cpp
+++ b/Kernel/FileSystem/File.cpp
@@ -12,13 +12,8 @@
 
 namespace Kernel {
 
-File::File()
-{
-}
-
-File::~File()
-{
-}
+File::File() = default;
+File::~File() = default;
 
 ErrorOr<NonnullRefPtr<OpenFileDescription>> File::open(int options)
 {

--- a/Kernel/FileSystem/FileBackedFileSystem.cpp
+++ b/Kernel/FileSystem/FileBackedFileSystem.cpp
@@ -13,8 +13,6 @@ FileBackedFileSystem::FileBackedFileSystem(OpenFileDescription& file_description
 {
 }
 
-FileBackedFileSystem::~FileBackedFileSystem()
-{
-}
+FileBackedFileSystem::~FileBackedFileSystem() = default;
 
 }

--- a/Kernel/FileSystem/ISO9660FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FileSystem.cpp
@@ -180,9 +180,7 @@ ISO9660FS::ISO9660FS(OpenFileDescription& description)
     m_logical_block_size = logical_sector_size;
 }
 
-ISO9660FS::~ISO9660FS()
-{
-}
+ISO9660FS::~ISO9660FS() = default;
 
 ErrorOr<void> ISO9660FS::initialize()
 {
@@ -553,9 +551,7 @@ ISO9660Inode::ISO9660Inode(ISO9660FS& fs, ISO::DirectoryRecordHeader const& reco
     create_metadata();
 }
 
-ISO9660Inode::~ISO9660Inode()
-{
-}
+ISO9660Inode::~ISO9660Inode() = default;
 
 ErrorOr<NonnullRefPtr<ISO9660Inode>> ISO9660Inode::try_create_from_directory_record(ISO9660FS& fs, ISO::DirectoryRecordHeader const& record, StringView name)
 {

--- a/Kernel/FileSystem/InodeFile.cpp
+++ b/Kernel/FileSystem/InodeFile.cpp
@@ -22,9 +22,7 @@ InodeFile::InodeFile(NonnullRefPtr<Inode>&& inode)
 {
 }
 
-InodeFile::~InodeFile()
-{
-}
+InodeFile::~InodeFile() = default;
 
 ErrorOr<size_t> InodeFile::read(OpenFileDescription& description, u64 offset, UserOrKernelBuffer& buffer, size_t count)
 {

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -399,9 +399,7 @@ Plan9FS::ReceiveCompletion::ReceiveCompletion(u16 tag)
 {
 }
 
-Plan9FS::ReceiveCompletion::~ReceiveCompletion()
-{
-}
+Plan9FS::ReceiveCompletion::~ReceiveCompletion() = default;
 
 bool Plan9FS::Blocker::unblock(u16 tag)
 {

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -42,13 +42,8 @@ ErrorOr<NonnullRefPtr<ProcFS>> ProcFS::try_create()
     return adopt_nonnull_ref_or_enomem(new (nothrow) ProcFS());
 }
 
-ProcFS::ProcFS()
-{
-}
-
-ProcFS::~ProcFS()
-{
-}
+ProcFS::ProcFS() = default;
+ProcFS::~ProcFS() = default;
 
 ErrorOr<void> ProcFS::initialize()
 {
@@ -66,9 +61,7 @@ ProcFSInode::ProcFSInode(const ProcFS& fs, InodeIndex index)
 {
 }
 
-ProcFSInode::~ProcFSInode()
-{
-}
+ProcFSInode::~ProcFSInode() = default;
 
 ErrorOr<void> ProcFSInode::flush_metadata()
 {
@@ -185,9 +178,7 @@ ProcFSDirectoryInode::ProcFSDirectoryInode(const ProcFS& fs, const ProcFSExposed
 {
 }
 
-ProcFSDirectoryInode::~ProcFSDirectoryInode()
-{
-}
+ProcFSDirectoryInode::~ProcFSDirectoryInode() = default;
 InodeMetadata ProcFSDirectoryInode::metadata() const
 {
     MutexLocker locker(m_inode_lock);

--- a/Kernel/FileSystem/SysFS.cpp
+++ b/Kernel/FileSystem/SysFS.cpp
@@ -73,13 +73,8 @@ ErrorOr<NonnullRefPtr<SysFS>> SysFS::try_create()
     return adopt_nonnull_ref_or_enomem(new (nothrow) SysFS);
 }
 
-SysFS::SysFS()
-{
-}
-
-SysFS::~SysFS()
-{
-}
+SysFS::SysFS() = default;
+SysFS::~SysFS() = default;
 
 ErrorOr<void> SysFS::initialize()
 {
@@ -202,9 +197,7 @@ SysFSDirectoryInode::SysFSDirectoryInode(SysFS const& fs, SysFSComponent const& 
 {
 }
 
-SysFSDirectoryInode::~SysFSDirectoryInode()
-{
-}
+SysFSDirectoryInode::~SysFSDirectoryInode() = default;
 
 InodeMetadata SysFSDirectoryInode::metadata() const
 {

--- a/Kernel/FileSystem/TmpFS.cpp
+++ b/Kernel/FileSystem/TmpFS.cpp
@@ -15,13 +15,8 @@ ErrorOr<NonnullRefPtr<TmpFS>> TmpFS::try_create()
     return adopt_nonnull_ref_or_enomem(new (nothrow) TmpFS);
 }
 
-TmpFS::TmpFS()
-{
-}
-
-TmpFS::~TmpFS()
-{
-}
+TmpFS::TmpFS() = default;
+TmpFS::~TmpFS() = default;
 
 ErrorOr<void> TmpFS::initialize()
 {
@@ -50,9 +45,7 @@ TmpFSInode::TmpFSInode(TmpFS& fs, const InodeMetadata& metadata, WeakPtr<TmpFSIn
     m_metadata.inode = identifier();
 }
 
-TmpFSInode::~TmpFSInode()
-{
-}
+TmpFSInode::~TmpFSInode() = default;
 
 ErrorOr<NonnullRefPtr<TmpFSInode>> TmpFSInode::try_create(TmpFS& fs, InodeMetadata const& metadata, WeakPtr<TmpFSInode> parent)
 {

--- a/Kernel/FileSystem/VirtualFileSystem.cpp
+++ b/Kernel/FileSystem/VirtualFileSystem.cpp
@@ -40,9 +40,7 @@ UNMAP_AFTER_INIT VirtualFileSystem::VirtualFileSystem()
 {
 }
 
-UNMAP_AFTER_INIT VirtualFileSystem::~VirtualFileSystem()
-{
-}
+UNMAP_AFTER_INIT VirtualFileSystem::~VirtualFileSystem() = default;
 
 InodeIdentifier VirtualFileSystem::root_inode_id() const
 {

--- a/Kernel/FutexQueue.cpp
+++ b/Kernel/FutexQueue.cpp
@@ -10,13 +10,8 @@
 
 namespace Kernel {
 
-FutexQueue::FutexQueue()
-{
-}
-
-FutexQueue::~FutexQueue()
-{
-}
+FutexQueue::FutexQueue() = default;
+FutexQueue::~FutexQueue() = default;
 
 bool FutexQueue::should_add_blocker(Thread::Blocker& b, void*)
 {

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -1032,8 +1032,6 @@ UNMAP_AFTER_INIT ProcFSRootDirectory::ProcFSRootDirectory()
 {
 }
 
-UNMAP_AFTER_INIT ProcFSRootDirectory::~ProcFSRootDirectory()
-{
-}
+UNMAP_AFTER_INIT ProcFSRootDirectory::~ProcFSRootDirectory() = default;
 
 }

--- a/Kernel/Graphics/Console/Console.h
+++ b/Kernel/Graphics/Console/Console.h
@@ -59,7 +59,7 @@ public:
     virtual void write(char ch, bool critical = false) = 0;
     virtual void flush(size_t x, size_t y, size_t width, size_t height) = 0;
 
-    virtual ~Console() { }
+    virtual ~Console() = default;
 
 protected:
     Console(size_t width, size_t height)

--- a/Kernel/Graphics/VirtIOGPU/FramebufferDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/FramebufferDevice.cpp
@@ -159,9 +159,7 @@ FramebufferDevice::FramebufferDevice(GraphicsAdapter const& adapter, ScanoutID s
     }
 }
 
-FramebufferDevice::~FramebufferDevice()
-{
-}
+FramebufferDevice::~FramebufferDevice() = default;
 
 ErrorOr<void> FramebufferDevice::create_framebuffer()
 {

--- a/Kernel/Interrupts/IRQHandler.cpp
+++ b/Kernel/Interrupts/IRQHandler.cpp
@@ -19,9 +19,7 @@ IRQHandler::IRQHandler(u8 irq)
         disable_irq();
 }
 
-IRQHandler::~IRQHandler()
-{
-}
+IRQHandler::~IRQHandler() = default;
 
 bool IRQHandler::eoi()
 {

--- a/Kernel/Interrupts/SpuriousInterruptHandler.cpp
+++ b/Kernel/Interrupts/SpuriousInterruptHandler.cpp
@@ -67,9 +67,7 @@ SpuriousInterruptHandler::SpuriousInterruptHandler(u8 irq)
 {
 }
 
-SpuriousInterruptHandler::~SpuriousInterruptHandler()
-{
-}
+SpuriousInterruptHandler::~SpuriousInterruptHandler() = default;
 
 bool SpuriousInterruptHandler::handle_interrupt(const RegisterState& state)
 {

--- a/Kernel/Interrupts/UnhandledInterruptHandler.cpp
+++ b/Kernel/Interrupts/UnhandledInterruptHandler.cpp
@@ -23,7 +23,5 @@ bool UnhandledInterruptHandler::handle_interrupt(const RegisterState&)
     PANIC("Interrupt: Unhandled vector {} was invoked for eoi().", interrupt_number());
 }
 
-UnhandledInterruptHandler::~UnhandledInterruptHandler()
-{
-}
+UnhandledInterruptHandler::~UnhandledInterruptHandler() = default;
 }

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -29,9 +29,7 @@ AddressSpace::AddressSpace(NonnullRefPtr<PageDirectory> page_directory)
 {
 }
 
-AddressSpace::~AddressSpace()
-{
-}
+AddressSpace::~AddressSpace() = default;
 
 ErrorOr<void> AddressSpace::unmap_mmap_range(VirtualAddress addr, size_t size)
 {

--- a/Kernel/Memory/AnonymousVMObject.cpp
+++ b/Kernel/Memory/AnonymousVMObject.cpp
@@ -166,9 +166,7 @@ AnonymousVMObject::AnonymousVMObject(AnonymousVMObject const& other, NonnullRefP
 {
 }
 
-AnonymousVMObject::~AnonymousVMObject()
-{
-}
+AnonymousVMObject::~AnonymousVMObject() = default;
 
 size_t AnonymousVMObject::purge()
 {
@@ -370,9 +368,7 @@ AnonymousVMObject::SharedCommittedCowPages::SharedCommittedCowPages(CommittedPhy
 {
 }
 
-AnonymousVMObject::SharedCommittedCowPages::~SharedCommittedCowPages()
-{
-}
+AnonymousVMObject::SharedCommittedCowPages::~SharedCommittedCowPages() = default;
 
 NonnullRefPtr<PhysicalPage> AnonymousVMObject::SharedCommittedCowPages::take_one()
 {

--- a/Kernel/Memory/InodeVMObject.cpp
+++ b/Kernel/Memory/InodeVMObject.cpp
@@ -25,9 +25,7 @@ InodeVMObject::InodeVMObject(InodeVMObject const& other, FixedArray<RefPtr<Physi
         m_dirty_pages.set(i, other.m_dirty_pages.get(i));
 }
 
-InodeVMObject::~InodeVMObject()
-{
-}
+InodeVMObject::~InodeVMObject() = default;
 
 size_t InodeVMObject::amount_clean() const
 {

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -94,9 +94,7 @@ UNMAP_AFTER_INIT MemoryManager::MemoryManager()
     m_lazy_committed_page = committed_pages.take_one();
 }
 
-UNMAP_AFTER_INIT MemoryManager::~MemoryManager()
-{
-}
+UNMAP_AFTER_INIT MemoryManager::~MemoryManager() = default;
 
 UNMAP_AFTER_INIT void MemoryManager::protect_kernel_image()
 {

--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -123,9 +123,7 @@ ErrorOr<NonnullRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace(Vi
     return directory;
 }
 
-PageDirectory::PageDirectory()
-{
-}
+PageDirectory::PageDirectory() = default;
 
 UNMAP_AFTER_INIT void PageDirectory::allocate_kernel_directory()
 {

--- a/Kernel/Memory/PhysicalRegion.cpp
+++ b/Kernel/Memory/PhysicalRegion.cpp
@@ -27,9 +27,7 @@ static constexpr u32 next_power_of_two(u32 value)
     return value;
 }
 
-PhysicalRegion::~PhysicalRegion()
-{
-}
+PhysicalRegion::~PhysicalRegion() = default;
 
 PhysicalRegion::PhysicalRegion(PhysicalAddress lower, PhysicalAddress upper)
     : m_lower(lower)

--- a/Kernel/Memory/PrivateInodeVMObject.cpp
+++ b/Kernel/Memory/PrivateInodeVMObject.cpp
@@ -33,8 +33,6 @@ PrivateInodeVMObject::PrivateInodeVMObject(PrivateInodeVMObject const& other, Fi
 {
 }
 
-PrivateInodeVMObject::~PrivateInodeVMObject()
-{
-}
+PrivateInodeVMObject::~PrivateInodeVMObject() = default;
 
 }

--- a/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000ENetworkAdapter.cpp
@@ -238,9 +238,7 @@ UNMAP_AFTER_INIT E1000ENetworkAdapter::E1000ENetworkAdapter(PCI::Address address
 {
 }
 
-UNMAP_AFTER_INIT E1000ENetworkAdapter::~E1000ENetworkAdapter()
-{
-}
+UNMAP_AFTER_INIT E1000ENetworkAdapter::~E1000ENetworkAdapter() = default;
 
 UNMAP_AFTER_INIT void E1000ENetworkAdapter::detect_eeprom()
 {

--- a/Kernel/Net/Intel/E1000NetworkAdapter.cpp
+++ b/Kernel/Net/Intel/E1000NetworkAdapter.cpp
@@ -236,9 +236,7 @@ UNMAP_AFTER_INIT E1000NetworkAdapter::E1000NetworkAdapter(PCI::Address address, 
 {
 }
 
-UNMAP_AFTER_INIT E1000NetworkAdapter::~E1000NetworkAdapter()
-{
-}
+UNMAP_AFTER_INIT E1000NetworkAdapter::~E1000NetworkAdapter() = default;
 
 bool E1000NetworkAdapter::handle_irq(const RegisterState&)
 {

--- a/Kernel/Net/LoopbackAdapter.cpp
+++ b/Kernel/Net/LoopbackAdapter.cpp
@@ -28,9 +28,7 @@ LoopbackAdapter::LoopbackAdapter(NonnullOwnPtr<KString> interface_name)
     set_mac_address({ 19, 85, 2, 9, 0x55, 0xaa });
 }
 
-LoopbackAdapter::~LoopbackAdapter()
-{
-}
+LoopbackAdapter::~LoopbackAdapter() = default;
 
 void LoopbackAdapter::send_raw(ReadonlyBytes payload)
 {

--- a/Kernel/Net/NE2000/NetworkAdapter.cpp
+++ b/Kernel/Net/NE2000/NetworkAdapter.cpp
@@ -185,9 +185,7 @@ UNMAP_AFTER_INIT NE2000NetworkAdapter::NE2000NetworkAdapter(PCI::Address address
     enable_irq();
 }
 
-UNMAP_AFTER_INIT NE2000NetworkAdapter::~NE2000NetworkAdapter()
-{
-}
+UNMAP_AFTER_INIT NE2000NetworkAdapter::~NE2000NetworkAdapter() = default;
 
 bool NE2000NetworkAdapter::handle_irq(const RegisterState&)
 {

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -19,9 +19,7 @@ NetworkAdapter::NetworkAdapter(NonnullOwnPtr<KString> interface_name)
 {
 }
 
-NetworkAdapter::~NetworkAdapter()
-{
-}
+NetworkAdapter::~NetworkAdapter() = default;
 
 void NetworkAdapter::send_packet(ReadonlyBytes packet)
 {

--- a/Kernel/Net/Realtek/RTL8139NetworkAdapter.cpp
+++ b/Kernel/Net/Realtek/RTL8139NetworkAdapter.cpp
@@ -162,9 +162,7 @@ UNMAP_AFTER_INIT RTL8139NetworkAdapter::RTL8139NetworkAdapter(PCI::Address addre
     enable_irq();
 }
 
-UNMAP_AFTER_INIT RTL8139NetworkAdapter::~RTL8139NetworkAdapter()
-{
-}
+UNMAP_AFTER_INIT RTL8139NetworkAdapter::~RTL8139NetworkAdapter() = default;
 
 bool RTL8139NetworkAdapter::handle_irq(const RegisterState&)
 {

--- a/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
+++ b/Kernel/Net/Realtek/RTL8168NetworkAdapter.cpp
@@ -1125,9 +1125,7 @@ UNMAP_AFTER_INIT void RTL8168NetworkAdapter::initialize_tx_descriptors()
     tx_descriptors[number_of_tx_descriptors - 1].flags = tx_descriptors[number_of_tx_descriptors - 1].flags | TXDescriptor::EndOfRing;
 }
 
-UNMAP_AFTER_INIT RTL8168NetworkAdapter::~RTL8168NetworkAdapter()
-{
-}
+UNMAP_AFTER_INIT RTL8168NetworkAdapter::~RTL8168NetworkAdapter() = default;
 
 bool RTL8168NetworkAdapter::handle_irq(const RegisterState&)
 {

--- a/Kernel/Net/Socket.cpp
+++ b/Kernel/Net/Socket.cpp
@@ -37,9 +37,7 @@ Socket::Socket(int domain, int type, int protocol)
     set_origin(Process::current());
 }
 
-Socket::~Socket()
-{
-}
+Socket::~Socket() = default;
 
 void Socket::set_setup_state(SetupState new_setup_state)
 {

--- a/Kernel/ProcessExposed.cpp
+++ b/Kernel/ProcessExposed.cpp
@@ -79,9 +79,7 @@ static size_t s_allocate_global_inode_index()
     return s_next_inode_index.value();
 }
 
-ProcFSExposedComponent::ProcFSExposedComponent()
-{
-}
+ProcFSExposedComponent::ProcFSExposedComponent() = default;
 
 ProcFSExposedComponent::ProcFSExposedComponent(StringView name)
     : m_component_index(s_allocate_global_inode_index())

--- a/Kernel/Storage/ATA/AHCIController.cpp
+++ b/Kernel/Storage/ATA/AHCIController.cpp
@@ -135,9 +135,7 @@ NonnullOwnPtr<Memory::Region> AHCIController::default_hba_region() const
     return MM.allocate_kernel_region(PhysicalAddress(PCI::get_BAR5(pci_address())).page_base(), Memory::page_round_up(sizeof(AHCI::HBA)).release_value_but_fixme_should_propagate_errors(), "AHCI HBA", Memory::Region::Access::ReadWrite).release_value();
 }
 
-AHCIController::~AHCIController()
-{
-}
+AHCIController::~AHCIController() = default;
 
 void AHCIController::initialize_hba(PCI::DeviceIdentifier const& pci_device_identifier)
 {

--- a/Kernel/Storage/ATA/AHCIPortHandler.cpp
+++ b/Kernel/Storage/ATA/AHCIPortHandler.cpp
@@ -78,9 +78,7 @@ AHCI::HBADefinedCapabilities AHCIPortHandler::hba_capabilities() const
     return m_parent_controller->hba_capabilities();
 }
 
-AHCIPortHandler::~AHCIPortHandler()
-{
-}
+AHCIPortHandler::~AHCIPortHandler() = default;
 
 bool AHCIPortHandler::handle_irq(const RegisterState&)
 {

--- a/Kernel/Storage/ATA/ATADevice.cpp
+++ b/Kernel/Storage/ATA/ATADevice.cpp
@@ -21,9 +21,7 @@ ATADevice::ATADevice(const ATAController& controller, ATADevice::Address ata_add
 {
 }
 
-ATADevice::~ATADevice()
-{
-}
+ATADevice::~ATADevice() = default;
 
 void ATADevice::start_request(AsyncBlockDeviceRequest& request)
 {

--- a/Kernel/Storage/ATA/ATADiskDevice.cpp
+++ b/Kernel/Storage/ATA/ATADiskDevice.cpp
@@ -31,9 +31,7 @@ ATADiskDevice::ATADiskDevice(const ATAController& controller, ATADevice::Address
 {
 }
 
-ATADiskDevice::~ATADiskDevice()
-{
-}
+ATADiskDevice::~ATADiskDevice() = default;
 
 StringView ATADiskDevice::class_name() const
 {

--- a/Kernel/Storage/ATA/ATAPIDiscDevice.cpp
+++ b/Kernel/Storage/ATA/ATAPIDiscDevice.cpp
@@ -31,9 +31,7 @@ ATAPIDiscDevice::ATAPIDiscDevice(const ATAController& controller, ATADevice::Add
 {
 }
 
-ATAPIDiscDevice::~ATAPIDiscDevice()
-{
-}
+ATAPIDiscDevice::~ATAPIDiscDevice() = default;
 
 StringView ATAPIDiscDevice::class_name() const
 {

--- a/Kernel/Storage/ATA/IDEChannel.cpp
+++ b/Kernel/Storage/ATA/IDEChannel.cpp
@@ -100,9 +100,7 @@ void IDEChannel::clear_pending_interrupts() const
     m_io_group.io_base().offset(ATA_REG_STATUS).in<u8>();
 }
 
-UNMAP_AFTER_INIT IDEChannel::~IDEChannel()
-{
-}
+UNMAP_AFTER_INIT IDEChannel::~IDEChannel() = default;
 
 void IDEChannel::start_request(AsyncBlockDeviceRequest& request, bool is_slave, u16 capabilities)
 {

--- a/Kernel/Storage/ATA/IDEController.cpp
+++ b/Kernel/Storage/ATA/IDEController.cpp
@@ -65,9 +65,7 @@ UNMAP_AFTER_INIT IDEController::IDEController()
 {
 }
 
-UNMAP_AFTER_INIT IDEController::~IDEController()
-{
-}
+UNMAP_AFTER_INIT IDEController::~IDEController() = default;
 
 RefPtr<StorageDevice> IDEController::device_by_channel_and_position(u32 index) const
 {

--- a/Kernel/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeQueue.cpp
@@ -172,7 +172,5 @@ void NVMeQueue::write(AsyncBlockDeviceRequest& request, u16 nsid, u64 index, u32
     submit_sqe(sub);
 }
 
-UNMAP_AFTER_INIT NVMeQueue::~NVMeQueue()
-{
-}
+UNMAP_AFTER_INIT NVMeQueue::~NVMeQueue() = default;
 }

--- a/Kernel/Storage/Partition/DiskPartition.cpp
+++ b/Kernel/Storage/Partition/DiskPartition.cpp
@@ -26,9 +26,7 @@ DiskPartition::DiskPartition(BlockDevice& device, unsigned minor_number, DiskPar
 {
 }
 
-DiskPartition::~DiskPartition()
-{
-}
+DiskPartition::~DiskPartition() = default;
 
 const DiskPartitionMetadata& DiskPartition::metadata() const
 {

--- a/Kernel/Storage/Partition/EBRPartitionTable.cpp
+++ b/Kernel/Storage/Partition/EBRPartitionTable.cpp
@@ -68,8 +68,6 @@ EBRPartitionTable::EBRPartitionTable(const StorageDevice& device)
     }
 }
 
-EBRPartitionTable::~EBRPartitionTable()
-{
-}
+EBRPartitionTable::~EBRPartitionTable() = default;
 
 }

--- a/Kernel/Storage/Partition/MBRPartitionTable.cpp
+++ b/Kernel/Storage/Partition/MBRPartitionTable.cpp
@@ -84,9 +84,7 @@ MBRPartitionTable::MBRPartitionTable(const StorageDevice& device)
     m_valid = true;
 }
 
-MBRPartitionTable::~MBRPartitionTable()
-{
-}
+MBRPartitionTable::~MBRPartitionTable() = default;
 
 const MBRPartitionTable::Header& MBRPartitionTable::header() const
 {

--- a/Kernel/Storage/RamdiskController.cpp
+++ b/Kernel/Storage/RamdiskController.cpp
@@ -55,9 +55,7 @@ RamdiskController::RamdiskController()
     }
 }
 
-RamdiskController::~RamdiskController()
-{
-}
+RamdiskController::~RamdiskController() = default;
 
 RefPtr<StorageDevice> RamdiskController::device(u32 index) const
 {

--- a/Kernel/Storage/RamdiskDevice.cpp
+++ b/Kernel/Storage/RamdiskDevice.cpp
@@ -32,9 +32,7 @@ RamdiskDevice::RamdiskDevice(const RamdiskController&, NonnullOwnPtr<Memory::Reg
     dmesgln("Ramdisk: Device #{} @ {}, Capacity={}", minor, m_region->vaddr(), max_addressable_block() * 512);
 }
 
-RamdiskDevice::~RamdiskDevice()
-{
-}
+RamdiskDevice::~RamdiskDevice() = default;
 
 StringView RamdiskDevice::class_name() const
 {

--- a/Kernel/TTY/PTYMultiplexer.cpp
+++ b/Kernel/TTY/PTYMultiplexer.cpp
@@ -31,9 +31,7 @@ UNMAP_AFTER_INIT PTYMultiplexer::PTYMultiplexer()
     });
 }
 
-UNMAP_AFTER_INIT PTYMultiplexer::~PTYMultiplexer()
-{
-}
+UNMAP_AFTER_INIT PTYMultiplexer::~PTYMultiplexer() = default;
 
 UNMAP_AFTER_INIT void PTYMultiplexer::initialize()
 {

--- a/Kernel/TTY/TTY.cpp
+++ b/Kernel/TTY/TTY.cpp
@@ -26,9 +26,7 @@ TTY::TTY(MajorNumber major, MinorNumber minor)
     set_default_termios();
 }
 
-TTY::~TTY()
-{
-}
+TTY::~TTY() = default;
 
 void TTY::set_default_termios()
 {

--- a/Kernel/ThreadBlockers.cpp
+++ b/Kernel/ThreadBlockers.cpp
@@ -37,9 +37,7 @@ bool Thread::Blocker::add_to_blocker_set(Thread::BlockerSet& blocker_set, void* 
     return false;
 }
 
-Thread::Blocker::~Blocker()
-{
-}
+Thread::Blocker::~Blocker() = default;
 
 void Thread::Blocker::finalize()
 {
@@ -132,9 +130,7 @@ bool Thread::WaitQueueBlocker::setup_blocker()
     return add_to_blocker_set(m_wait_queue);
 }
 
-Thread::WaitQueueBlocker::~WaitQueueBlocker()
-{
-}
+Thread::WaitQueueBlocker::~WaitQueueBlocker() = default;
 
 bool Thread::WaitQueueBlocker::unblock()
 {
@@ -160,9 +156,7 @@ bool Thread::FutexBlocker::setup_blocker()
     return add_to_blocker_set(m_futex_queue);
 }
 
-Thread::FutexBlocker::~FutexBlocker()
-{
-}
+Thread::FutexBlocker::~FutexBlocker() = default;
 
 void Thread::FutexBlocker::finish_requeue(FutexQueue& futex_queue)
 {
@@ -372,9 +366,7 @@ bool Thread::SelectBlocker::setup_blocker()
     return should_block;
 }
 
-Thread::SelectBlocker::~SelectBlocker()
-{
-}
+Thread::SelectBlocker::~SelectBlocker() = default;
 
 void Thread::SelectBlocker::finalize()
 {
@@ -504,9 +496,7 @@ Thread::WaitBlockerSet::ProcessBlockInfo::ProcessBlockInfo(NonnullRefPtr<Process
 {
 }
 
-Thread::WaitBlockerSet::ProcessBlockInfo::~ProcessBlockInfo()
-{
-}
+Thread::WaitBlockerSet::ProcessBlockInfo::~ProcessBlockInfo() = default;
 
 void Thread::WaitBlockerSet::try_unblock(Thread::WaitBlocker& blocker)
 {


### PR DESCRIPTION
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#cother-other-default-operation-rules

"The compiler is more likely to get the default semantics right and
you cannot implement these functions better than the compiler."