### PR TITLE
Userland: Change class_name to use StringView instead of char const*

### DIFF
--- a/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.h
+++ b/Userland/DevTools/HackStudio/Debugger/DebuggerVariableJSObject.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "DebuggerGlobalJSObject.h"
+#include <AK/StringView.h>
 #include <LibDebug/DebugInfo.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Object.h>
@@ -24,7 +25,7 @@ public:
     DebuggerVariableJSObject(const Debug::DebugInfo::VariableInfo& variable_info, JS::Object& prototype);
     virtual ~DebuggerVariableJSObject() override = default;
 
-    virtual const char* class_name() const override { return m_variable_info.type_name.characters(); }
+    virtual StringView class_name() const override { return m_variable_info.type_name; }
 
     JS::ThrowCompletionOr<bool> internal_set(JS::PropertyKey const&, JS::Value value, JS::Value receiver) override;
 

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -14,6 +14,7 @@
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/OwnPtr.h>
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <AK/TypeCasts.h>
 #include <AK/Weakable.h>
 #include <LibCore/Forward.h>
@@ -43,7 +44,7 @@ public:
     ObjectClassRegistration(StringView class_name, Function<RefPtr<Object>()> factory, ObjectClassRegistration* parent_class = nullptr);
     ~ObjectClassRegistration() = default;
 
-    String class_name() const { return m_class_name; }
+    StringView class_name() const { return m_class_name; }
     const ObjectClassRegistration* parent_class() const { return m_parent_class; }
     RefPtr<Object> construct() const { return m_factory(); }
     bool is_derived_from(const ObjectClassRegistration& base_class) const;
@@ -66,7 +67,7 @@ enum class TimerShouldFireWhenNotVisible {
 
 #define C_OBJECT(klass)                                                                  \
 public:                                                                                  \
-    virtual const char* class_name() const override { return #klass; }                   \
+    virtual StringView class_name() const override { return #klass; }                    \
     template<typename Klass = klass, class... Args>                                      \
     static NonnullRefPtr<klass> construct(Args&&... args)                                \
     {                                                                                    \
@@ -80,7 +81,7 @@ public:                                                                         
 
 #define C_OBJECT_ABSTRACT(klass) \
 public:                          \
-    virtual const char* class_name() const override { return #klass; }
+    virtual StringView class_name() const override { return #klass; }
 
 class Object
     : public RefCounted<Object>
@@ -95,7 +96,7 @@ class Object
 public:
     virtual ~Object();
 
-    virtual const char* class_name() const = 0;
+    virtual StringView class_name() const = 0;
 
     const String& name() const { return m_name; }
     void set_name(String name) { m_name = move(name); }

--- a/Userland/Libraries/LibCpp/AST.h
+++ b/Userland/Libraries/LibCpp/AST.h
@@ -11,6 +11,7 @@
 #include <AK/Optional.h>
 #include <AK/RefCounted.h>
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <AK/TypeCasts.h>
 #include <AK/Vector.h>
 #include <LibCpp/Lexer.h>
@@ -29,7 +30,7 @@ class Name;
 class ASTNode : public RefCounted<ASTNode> {
 public:
     virtual ~ASTNode() = default;
-    virtual const char* class_name() const = 0;
+    virtual StringView class_name() const = 0;
     virtual void dump(FILE* = stdout, size_t indent = 0) const;
 
     template<typename T>
@@ -84,7 +85,7 @@ class TranslationUnit : public ASTNode {
 
 public:
     virtual ~TranslationUnit() override = default;
-    virtual const char* class_name() const override { return "TranslationUnit"; }
+    virtual StringView class_name() const override { return "TranslationUnit"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual NonnullRefPtrVector<Declaration> declarations() const override { return m_declarations; }
 
@@ -102,7 +103,7 @@ private:
 class Statement : public ASTNode {
 public:
     virtual ~Statement() override = default;
-    virtual const char* class_name() const override { return "Statement"; }
+    virtual StringView class_name() const override { return "Statement"sv; }
 
     virtual NonnullRefPtrVector<Declaration> declarations() const override;
 
@@ -144,7 +145,7 @@ class InvalidDeclaration : public Declaration {
 
 public:
     virtual ~InvalidDeclaration() override = default;
-    virtual const char* class_name() const override { return "InvalidDeclaration"; }
+    virtual StringView class_name() const override { return "InvalidDeclaration"sv; }
     InvalidDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
         : Declaration(parent, start, end, filename)
     {
@@ -154,7 +155,7 @@ public:
 class FunctionDeclaration : public Declaration {
 public:
     virtual ~FunctionDeclaration() override = default;
-    virtual const char* class_name() const override { return "FunctionDeclaration"; }
+    virtual StringView class_name() const override { return "FunctionDeclaration"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_function() const override { return true; }
     virtual bool is_constructor() const { return false; }
@@ -203,7 +204,7 @@ protected:
 class Parameter : public VariableOrParameterDeclaration {
 public:
     virtual ~Parameter() override = default;
-    virtual const char* class_name() const override { return "Parameter"; }
+    virtual StringView class_name() const override { return "Parameter"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_parameter() const override { return true; }
 
@@ -223,7 +224,7 @@ private:
 class Type : public ASTNode {
 public:
     virtual ~Type() override = default;
-    virtual const char* class_name() const override { return "Type"; }
+    virtual StringView class_name() const override { return "Type"sv; }
     virtual bool is_type() const override { return true; }
     virtual bool is_templatized() const { return false; }
     virtual bool is_named_type() const { return false; }
@@ -249,7 +250,7 @@ private:
 class NamedType : public Type {
 public:
     virtual ~NamedType() override = default;
-    virtual const char* class_name() const override { return "NamedType"; }
+    virtual StringView class_name() const override { return "NamedType"sv; }
     virtual String to_string() const override;
     virtual bool is_named_type() const override { return true; }
 
@@ -268,7 +269,7 @@ private:
 class Pointer : public Type {
 public:
     virtual ~Pointer() override = default;
-    virtual const char* class_name() const override { return "Pointer"; }
+    virtual StringView class_name() const override { return "Pointer"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual String to_string() const override;
 
@@ -287,7 +288,7 @@ private:
 class Reference : public Type {
 public:
     virtual ~Reference() override = default;
-    virtual const char* class_name() const override { return "Reference"; }
+    virtual StringView class_name() const override { return "Reference"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual String to_string() const override;
 
@@ -314,7 +315,7 @@ private:
 class FunctionType : public Type {
 public:
     virtual ~FunctionType() override = default;
-    virtual const char* class_name() const override { return "FunctionType"; }
+    virtual StringView class_name() const override { return "FunctionType"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual String to_string() const override;
 
@@ -334,7 +335,7 @@ private:
 class FunctionDefinition : public ASTNode {
 public:
     virtual ~FunctionDefinition() override = default;
-    virtual const char* class_name() const override { return "FunctionDefinition"; }
+    virtual StringView class_name() const override { return "FunctionDefinition"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     FunctionDefinition(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
@@ -353,7 +354,7 @@ private:
 class InvalidStatement : public Statement {
 public:
     virtual ~InvalidStatement() override = default;
-    virtual const char* class_name() const override { return "InvalidStatement"; }
+    virtual StringView class_name() const override { return "InvalidStatement"sv; }
     InvalidStatement(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
         : Statement(parent, start, end, filename)
     {
@@ -363,7 +364,7 @@ public:
 class Expression : public Statement {
 public:
     virtual ~Expression() override = default;
-    virtual const char* class_name() const override { return "Expression"; }
+    virtual StringView class_name() const override { return "Expression"sv; }
 
 protected:
     Expression(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
@@ -375,7 +376,7 @@ protected:
 class InvalidExpression : public Expression {
 public:
     virtual ~InvalidExpression() override = default;
-    virtual const char* class_name() const override { return "InvalidExpression"; }
+    virtual StringView class_name() const override { return "InvalidExpression"sv; }
     InvalidExpression(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
         : Expression(parent, start, end, filename)
     {
@@ -385,7 +386,7 @@ public:
 class VariableDeclaration : public VariableOrParameterDeclaration {
 public:
     virtual ~VariableDeclaration() override = default;
-    virtual const char* class_name() const override { return "VariableDeclaration"; }
+    virtual StringView class_name() const override { return "VariableDeclaration"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     VariableDeclaration(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
@@ -405,7 +406,7 @@ private:
 class Identifier : public Expression {
 public:
     virtual ~Identifier() override = default;
-    virtual const char* class_name() const override { return "Identifier"; }
+    virtual StringView class_name() const override { return "Identifier"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     Identifier(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename, StringView name)
@@ -430,7 +431,7 @@ private:
 class Name : public Expression {
 public:
     virtual ~Name() override = default;
-    virtual const char* class_name() const override { return "Name"; }
+    virtual StringView class_name() const override { return "Name"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_name() const override { return true; }
     virtual bool is_templatized() const { return false; }
@@ -456,7 +457,7 @@ private:
 class TemplatizedName : public Name {
 public:
     virtual ~TemplatizedName() override = default;
-    virtual const char* class_name() const override { return "TemplatizedName"; }
+    virtual StringView class_name() const override { return "TemplatizedName"sv; }
     virtual bool is_templatized() const override { return true; }
     virtual StringView full_name() const override;
 
@@ -475,7 +476,7 @@ private:
 class NumericLiteral : public Expression {
 public:
     virtual ~NumericLiteral() override = default;
-    virtual const char* class_name() const override { return "NumericLiteral"; }
+    virtual StringView class_name() const override { return "NumericLiteral"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     NumericLiteral(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename, StringView value)
@@ -491,7 +492,7 @@ private:
 class NullPointerLiteral : public Expression {
 public:
     virtual ~NullPointerLiteral() override = default;
-    virtual const char* class_name() const override { return "NullPointerLiteral"; }
+    virtual StringView class_name() const override { return "NullPointerLiteral"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     NullPointerLiteral(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
@@ -503,7 +504,7 @@ public:
 class BooleanLiteral : public Expression {
 public:
     virtual ~BooleanLiteral() override = default;
-    virtual const char* class_name() const override { return "BooleanLiteral"; }
+    virtual StringView class_name() const override { return "BooleanLiteral"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     BooleanLiteral(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename, bool value)
@@ -546,7 +547,7 @@ public:
     }
 
     virtual ~BinaryExpression() override = default;
-    virtual const char* class_name() const override { return "BinaryExpression"; }
+    virtual StringView class_name() const override { return "BinaryExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     BinaryOp op() const { return m_op; }
@@ -576,7 +577,7 @@ public:
     }
 
     virtual ~AssignmentExpression() override = default;
-    virtual const char* class_name() const override { return "AssignmentExpression"; }
+    virtual StringView class_name() const override { return "AssignmentExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     AssignmentOp op() const { return m_op; }
@@ -600,7 +601,7 @@ public:
     }
 
     virtual ~FunctionCall() override = default;
-    virtual const char* class_name() const override { return "FunctionCall"; }
+    virtual StringView class_name() const override { return "FunctionCall"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_function_call() const override { return true; }
 
@@ -623,7 +624,7 @@ public:
     }
 
     ~StringLiteral() override = default;
-    virtual const char* class_name() const override { return "StringLiteral"; }
+    virtual StringView class_name() const override { return "StringLiteral"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     String const& value() const { return m_value; }
@@ -636,7 +637,7 @@ private:
 class ReturnStatement : public Statement {
 public:
     virtual ~ReturnStatement() override = default;
-    virtual const char* class_name() const override { return "ReturnStatement"; }
+    virtual StringView class_name() const override { return "ReturnStatement"sv; }
 
     ReturnStatement(ASTNode* parent, Optional<Position> start, Optional<Position> end, const String& filename)
         : Statement(parent, start, end, filename)
@@ -654,7 +655,7 @@ private:
 class EnumDeclaration : public Declaration {
 public:
     virtual ~EnumDeclaration() override = default;
-    virtual const char* class_name() const override { return "EnumDeclaration"; }
+    virtual StringView class_name() const override { return "EnumDeclaration"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_enum() const override { return true; }
 
@@ -683,7 +684,7 @@ private:
 class StructOrClassDeclaration : public Declaration {
 public:
     virtual ~StructOrClassDeclaration() override = default;
-    virtual const char* class_name() const override { return "StructOrClassDeclaration"; }
+    virtual StringView class_name() const override { return "StructOrClassDeclaration"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_struct_or_class() const override { return true; }
     virtual bool is_struct() const override { return m_type == Type::Struct; }
@@ -727,7 +728,7 @@ public:
     }
 
     virtual ~UnaryExpression() override = default;
-    virtual const char* class_name() const override { return "UnaryExpression"; }
+    virtual StringView class_name() const override { return "UnaryExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     void set_op(UnaryOp op) { m_op = op; }
@@ -746,7 +747,7 @@ public:
     }
 
     virtual ~MemberExpression() override = default;
-    virtual const char* class_name() const override { return "MemberExpression"; }
+    virtual StringView class_name() const override { return "MemberExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_member_expression() const override { return true; }
 
@@ -768,7 +769,7 @@ public:
     }
 
     virtual ~ForStatement() override = default;
-    virtual const char* class_name() const override { return "ForStatement"; }
+    virtual StringView class_name() const override { return "ForStatement"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     virtual NonnullRefPtrVector<Declaration> declarations() const override;
@@ -794,7 +795,7 @@ public:
     }
 
     virtual ~BlockStatement() override = default;
-    virtual const char* class_name() const override { return "BlockStatement"; }
+    virtual StringView class_name() const override { return "BlockStatement"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     virtual NonnullRefPtrVector<Declaration> declarations() const override;
@@ -813,7 +814,7 @@ public:
     }
 
     virtual ~Comment() override = default;
-    virtual const char* class_name() const override { return "Comment"; }
+    virtual StringView class_name() const override { return "Comment"sv; }
 };
 
 class IfStatement : public Statement {
@@ -824,7 +825,7 @@ public:
     }
 
     virtual ~IfStatement() override = default;
-    virtual const char* class_name() const override { return "IfStatement"; }
+    virtual StringView class_name() const override { return "IfStatement"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual NonnullRefPtrVector<Declaration> declarations() const override;
 
@@ -844,7 +845,7 @@ private:
 class NamespaceDeclaration : public Declaration {
 public:
     virtual ~NamespaceDeclaration() override = default;
-    virtual const char* class_name() const override { return "NamespaceDeclaration"; }
+    virtual StringView class_name() const override { return "NamespaceDeclaration"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_namespace() const override { return true; }
 
@@ -868,7 +869,7 @@ public:
     }
 
     virtual ~CppCastExpression() override = default;
-    virtual const char* class_name() const override { return "CppCastExpression"; }
+    virtual StringView class_name() const override { return "CppCastExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     void set_cast_type(StringView cast_type) { m_cast_type = move(cast_type); }
@@ -889,7 +890,7 @@ public:
     }
 
     virtual ~CStyleCastExpression() override = default;
-    virtual const char* class_name() const override { return "CStyleCastExpression"; }
+    virtual StringView class_name() const override { return "CStyleCastExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     void set_type(NonnullRefPtr<Type>&& type) { m_type = move(type); }
@@ -908,7 +909,7 @@ public:
     }
 
     virtual ~SizeofExpression() override = default;
-    virtual const char* class_name() const override { return "SizeofExpression"; }
+    virtual StringView class_name() const override { return "SizeofExpression"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     void set_type(RefPtr<Type>&& type) { m_type = move(type); }
@@ -925,7 +926,7 @@ public:
     }
 
     virtual ~BracedInitList() override = default;
-    virtual const char* class_name() const override { return "BracedInitList"; }
+    virtual StringView class_name() const override { return "BracedInitList"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
 
     void add_expression(NonnullRefPtr<Expression>&& exp) { m_expressions.append(move(exp)); }
@@ -941,14 +942,14 @@ public:
     {
     }
     virtual bool is_dummy_node() const override { return true; }
-    virtual const char* class_name() const override { return "DummyAstNode"; }
+    virtual StringView class_name() const override { return "DummyAstNode"sv; }
     virtual void dump(FILE* = stdout, size_t = 0) const override { }
 };
 
 class Constructor : public FunctionDeclaration {
 public:
     virtual ~Constructor() override = default;
-    virtual const char* class_name() const override { return "Constructor"; }
+    virtual StringView class_name() const override { return "Constructor"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_constructor() const override { return true; }
 
@@ -961,7 +962,7 @@ public:
 class Destructor : public FunctionDeclaration {
 public:
     virtual ~Destructor() override = default;
-    virtual const char* class_name() const override { return "Destructor"; }
+    virtual StringView class_name() const override { return "Destructor"sv; }
     virtual void dump(FILE* = stdout, size_t indent = 0) const override;
     virtual bool is_destructor() const override { return true; }
 

--- a/Userland/Libraries/LibGfx/Filters/BoxBlurFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/BoxBlurFilter.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "GenericConvolutionFilter.h"
+#include <AK/StringView.h>
 
 namespace Gfx {
 
@@ -16,7 +17,7 @@ public:
     BoxBlurFilter() = default;
     virtual ~BoxBlurFilter() = default;
 
-    virtual const char* class_name() const override { return "BoxBlurFilter"; }
+    virtual StringView class_name() const override { return "BoxBlurFilter"sv; }
 };
 
 }

--- a/Userland/Libraries/LibGfx/Filters/ColorBlindnessFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/ColorBlindnessFilter.h
@@ -8,6 +8,7 @@
 
 #include "ColorFilter.h"
 #include <AK/NonnullOwnPtr.h>
+#include <AK/StringView.h>
 
 namespace Gfx {
 class ColorBlindnessFilter : public ColorFilter {
@@ -35,7 +36,7 @@ public:
     }
 
     virtual ~ColorBlindnessFilter() = default;
-    virtual char const* class_name() const override { return "ColorBlindnessFilter"; }
+    virtual StringView class_name() const override { return "ColorBlindnessFilter"sv; }
 
     static NonnullOwnPtr<ColorBlindnessFilter> create_protanopia();
     static NonnullOwnPtr<ColorBlindnessFilter> create_protanomaly();

--- a/Userland/Libraries/LibGfx/Filters/Filter.h
+++ b/Userland/Libraries/LibGfx/Filters/Filter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Rect.h>
 
@@ -21,7 +22,7 @@ public:
     };
     virtual ~Filter() = default;
 
-    virtual const char* class_name() const = 0;
+    virtual StringView class_name() const = 0;
 
     virtual void apply(Bitmap&, IntRect const&, Bitmap const&, IntRect const&, Parameters const&) {};
     virtual void apply(Bitmap&, IntRect const&, Bitmap const&, IntRect const&) {};

--- a/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GenericConvolutionFilter.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "Filter.h"
+#include <AK/StringView.h>
 #include <LibGfx/Matrix.h>
 #include <LibGfx/Matrix4x4.h>
 
@@ -61,7 +62,7 @@ public:
     GenericConvolutionFilter() = default;
     virtual ~GenericConvolutionFilter() = default;
 
-    virtual const char* class_name() const override { return "GenericConvolutionFilter"; }
+    virtual StringView class_name() const override { return "GenericConvolutionFilter"sv; }
 
     virtual void apply(Bitmap& target_bitmap, const IntRect& target_rect, const Bitmap& source_bitmap, const IntRect& source_rect, const Filter::Parameters& parameters) override
     {

--- a/Userland/Libraries/LibGfx/Filters/GrayscaleFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/GrayscaleFilter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibGfx/Filters/ColorFilter.h>
 
 namespace Gfx {
@@ -15,7 +16,7 @@ public:
     GrayscaleFilter() = default;
     virtual ~GrayscaleFilter() = default;
 
-    virtual char const* class_name() const override { return "GrayscaleFilter"; }
+    virtual StringView class_name() const override { return "GrayscaleFilter"sv; }
 
 protected:
     Color convert_color(Color original) override { return original.to_grayscale(); };

--- a/Userland/Libraries/LibGfx/Filters/InvertFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/InvertFilter.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibGfx/Filters/ColorFilter.h>
 
 namespace Gfx {
@@ -15,7 +16,7 @@ public:
     InvertFilter() = default;
     virtual ~InvertFilter() = default;
 
-    virtual char const* class_name() const override { return "InvertFilter"; }
+    virtual StringView class_name() const override { return "InvertFilter"sv; }
 
 protected:
     Color convert_color(Color original) override { return original.inverted(); };

--- a/Userland/Libraries/LibGfx/Filters/LaplacianFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/LaplacianFilter.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "GenericConvolutionFilter.h"
+#include <AK/StringView.h>
 
 namespace Gfx {
 
@@ -15,7 +16,7 @@ public:
     LaplacianFilter() = default;
     virtual ~LaplacianFilter() = default;
 
-    virtual const char* class_name() const override { return "LaplacianFilter"; }
+    virtual StringView class_name() const override { return "LaplacianFilter"sv; }
 };
 
 }

--- a/Userland/Libraries/LibGfx/Filters/SepiaFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/SepiaFilter.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/StdLibExtras.h>
+#include <AK/StringView.h>
 #include <LibGfx/Filters/ColorFilter.h>
 #include <math.h>
 
@@ -20,7 +21,7 @@ public:
     }
     virtual ~SepiaFilter() = default;
 
-    virtual char const* class_name() const override { return "SepiaFilter"; }
+    virtual StringView class_name() const override { return "SepiaFilter"sv; }
 
 protected:
     Color convert_color(Color original) override { return original.sepia(m_amount); };

--- a/Userland/Libraries/LibGfx/Filters/SharpenFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/SharpenFilter.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "GenericConvolutionFilter.h"
+#include <AK/StringView.h>
 
 namespace Gfx {
 
@@ -15,7 +16,7 @@ public:
     SharpenFilter() = default;
     virtual ~SharpenFilter() = default;
 
-    virtual const char* class_name() const override { return "SharpenFilter"; }
+    virtual StringView class_name() const override { return "SharpenFilter"sv; }
 };
 
 }

--- a/Userland/Libraries/LibGfx/Filters/SpatialGaussianBlurFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/SpatialGaussianBlurFilter.h
@@ -8,6 +8,7 @@
 
 #include "GenericConvolutionFilter.h"
 #include <AK/StdLibExtras.h>
+#include <AK/StringView.h>
 
 namespace Gfx {
 
@@ -17,6 +18,6 @@ public:
     SpatialGaussianBlurFilter() = default;
     virtual ~SpatialGaussianBlurFilter() = default;
 
-    virtual const char* class_name() const override { return "SpatialGaussianBlurFilter"; }
+    virtual StringView class_name() const override { return "SpatialGaussianBlurFilter"sv; }
 };
 }

--- a/Userland/Libraries/LibJS/Heap/Cell.h
+++ b/Userland/Libraries/LibJS/Heap/Cell.h
@@ -9,6 +9,7 @@
 #include <AK/Format.h>
 #include <AK/Forward.h>
 #include <AK/Noncopyable.h>
+#include <AK/StringView.h>
 #include <LibJS/Forward.h>
 
 namespace JS {
@@ -32,7 +33,7 @@ public:
     State state() const { return m_state; }
     void set_state(State state) { m_state = state; }
 
-    virtual const char* class_name() const = 0;
+    virtual StringView class_name() const = 0;
 
     class Visitor {
     public:

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -8,6 +8,7 @@
 
 #include <AK/IntrusiveList.h>
 #include <AK/Platform.h>
+#include <AK/StringView.h>
 #include <AK/Types.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
@@ -98,7 +99,7 @@ private:
     struct FreelistEntry final : public Cell {
         FreelistEntry* next { nullptr };
 
-        virtual const char* class_name() const override { return "FreelistEntry"; }
+        virtual StringView class_name() const override { return "FreelistEntry"sv; }
     };
 
     Cell* cell(size_t index)

--- a/Userland/Libraries/LibJS/Runtime/Accessor.h
+++ b/Userland/Libraries/LibJS/Runtime/Accessor.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibJS/Runtime/FunctionObject.h>
 #include <LibJS/Runtime/VM.h>
 
@@ -38,7 +39,7 @@ public:
     }
 
 private:
-    const char* class_name() const override { return "Accessor"; };
+    StringView class_name() const override { return "Accessor"sv; };
 
     FunctionObject* m_getter { nullptr };
     FunctionObject* m_setter { nullptr };

--- a/Userland/Libraries/LibJS/Runtime/BigInt.h
+++ b/Userland/Libraries/LibJS/Runtime/BigInt.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibCrypto/BigInt/SignedBigInteger.h>
 #include <LibJS/Heap/Cell.h>
 
@@ -20,7 +21,7 @@ public:
     const String to_string() const { return String::formatted("{}n", m_big_integer.to_base(10)); }
 
 private:
-    virtual const char* class_name() const override { return "BigInt"; }
+    virtual StringView class_name() const override { return "BigInt"sv; }
 
     Crypto::SignedBigInteger m_big_integer;
 };

--- a/Userland/Libraries/LibJS/Runtime/Environment.h
+++ b/Userland/Libraries/LibJS/Runtime/Environment.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibJS/Runtime/Object.h>
 
@@ -19,7 +20,7 @@ struct Variable {
 #define JS_ENVIRONMENT(class_, base_class) \
 public:                                    \
     using Base = base_class;               \
-    virtual char const* class_name() const override { return #class_; }
+    virtual StringView class_name() const override { return #class_; }
 
 class Environment : public Cell {
 public:
@@ -47,7 +48,7 @@ public:
     template<typename T>
     bool fast_is() const = delete;
 
-    virtual char const* class_name() const override { return "Environment"; }
+    virtual StringView class_name() const override { return "Environment"sv; }
 
     // This flag is set on the entire variable environment chain when direct eval() is performed.
     // It is used to disable non-local variable access caching.

--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -10,6 +10,7 @@
 #include <AK/Badge.h>
 #include <AK/HashMap.h>
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Heap/MarkedVector.h>
@@ -27,7 +28,7 @@ namespace JS {
 #define JS_OBJECT(class_, base_class) \
 public:                               \
     using Base = base_class;          \
-    virtual const char* class_name() const override { return #class_; }
+    virtual StringView class_name() const override { return #class_; }
 
 struct PrivateElement {
     enum class Kind {
@@ -166,7 +167,7 @@ public:
     bool has_parameter_map() const { return m_has_parameter_map; }
     void set_has_parameter_map() { m_has_parameter_map = true; }
 
-    virtual const char* class_name() const override { return "Object"; }
+    virtual StringView class_name() const override { return "Object"sv; }
     virtual void visit_edges(Cell::Visitor&) override;
 
     Value get_direct(size_t index) const { return m_storage[index]; }

--- a/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
+++ b/Userland/Libraries/LibJS/Runtime/PrimitiveString.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <LibJS/Forward.h>
 #include <LibJS/Heap/Cell.h>
 #include <LibJS/Runtime/Utf16String.h>
@@ -33,7 +34,7 @@ public:
     Optional<Value> get(GlobalObject&, PropertyKey const&) const;
 
 private:
-    virtual const char* class_name() const override { return "PrimitiveString"; }
+    virtual StringView class_name() const override { return "PrimitiveString"sv; }
 
     mutable String m_utf8_string;
     mutable bool m_has_utf8_string { false };

--- a/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
+++ b/Userland/Libraries/LibJS/Runtime/PrivateEnvironment.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/FlyString.h>
+#include <AK/StringView.h>
 #include <AK/Vector.h>
 #include <LibJS/Heap/Cell.h>
 
@@ -35,7 +36,7 @@ public:
     void add_private_name(Badge<ClassExpression>, FlyString description);
 
 private:
-    virtual char const* class_name() const override { return "PrivateEnvironment"; }
+    virtual StringView class_name() const override { return "PrivateEnvironment"sv; }
     virtual void visit_edges(Visitor&) override;
 
     auto find_private_name(FlyString const& description) const

--- a/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseReaction.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/JobCallback.h>
 #include <LibJS/Runtime/VM.h>
@@ -79,7 +80,7 @@ public:
     const Optional<JobCallback>& handler() const { return m_handler; }
 
 private:
-    virtual const char* class_name() const override { return "PromiseReaction"; }
+    virtual StringView class_name() const override { return "PromiseReaction"sv; }
     virtual void visit_edges(Visitor&) override;
 
     Type m_type;

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingElementFunctions.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibJS/Runtime/NativeFunction.h>
 #include <LibJS/Runtime/PromiseReaction.h>
 
@@ -19,7 +20,7 @@ struct RemainingElements final : public Cell {
     {
     }
 
-    virtual const char* class_name() const override { return "RemainingElements"; }
+    virtual StringView class_name() const override { return "RemainingElements"sv; }
 
     u64 value { 0 };
 };
@@ -34,7 +35,7 @@ public:
     Vector<Value> const& values() const { return m_values; }
 
 private:
-    virtual const char* class_name() const override { return "PromiseValueList"; }
+    virtual StringView class_name() const override { return "PromiseValueList"sv; }
     virtual void visit_edges(Visitor&) override;
 
     Vector<Value> m_values;

--- a/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
+++ b/Userland/Libraries/LibJS/Runtime/PromiseResolvingFunction.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibJS/Runtime/NativeFunction.h>
 
 namespace JS {
@@ -13,7 +14,7 @@ namespace JS {
 struct AlreadyResolved final : public Cell {
     bool value { false };
 
-    virtual const char* class_name() const override { return "AlreadyResolved"; }
+    virtual StringView class_name() const override { return "AlreadyResolved"sv; }
 
 protected:
     // Allocated cells must be >= sizeof(FreelistEntry), which is 24 bytes -

--- a/Userland/Libraries/LibJS/Runtime/Realm.h
+++ b/Userland/Libraries/LibJS/Runtime/Realm.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <AK/OwnPtr.h>
+#include <AK/StringView.h>
 #include <AK/Weakable.h>
 #include <LibJS/Heap/Cell.h>
 
@@ -35,7 +36,7 @@ public:
     void set_host_defined(OwnPtr<HostDefined> host_defined) { m_host_defined = move(host_defined); }
 
 private:
-    virtual char const* class_name() const override { return "Realm"; }
+    virtual StringView class_name() const override { return "Realm"sv; }
     virtual void visit_edges(Visitor&) override;
 
     GlobalObject* m_global_object { nullptr };           // [[GlobalObject]]

--- a/Userland/Libraries/LibJS/Runtime/Shape.h
+++ b/Userland/Libraries/LibJS/Runtime/Shape.h
@@ -8,6 +8,7 @@
 
 #include <AK/HashMap.h>
 #include <AK/OwnPtr.h>
+#include <AK/StringView.h>
 #include <AK/WeakPtr.h>
 #include <AK/Weakable.h>
 #include <LibJS/Forward.h>
@@ -86,7 +87,7 @@ public:
     void reconfigure_property_in_unique_shape(const StringOrSymbol& property_key, PropertyAttributes attributes);
 
 private:
-    virtual const char* class_name() const override { return "Shape"; }
+    virtual StringView class_name() const override { return "Shape"sv; }
     virtual void visit_edges(Visitor&) override;
 
     Shape* get_or_prune_cached_forward_transition(TransitionKey const&);

--- a/Userland/Libraries/LibJS/Runtime/Symbol.h
+++ b/Userland/Libraries/LibJS/Runtime/Symbol.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/String.h>
+#include <AK/StringView.h>
 #include <LibJS/Heap/Cell.h>
 
 namespace JS {
@@ -25,7 +26,7 @@ public:
     String to_string() const { return String::formatted("Symbol({})", description()); }
 
 private:
-    virtual const char* class_name() const override { return "Symbol"; }
+    virtual StringView class_name() const override { return "Symbol"sv; }
 
     Optional<String> m_description;
     bool m_is_global;

--- a/Userland/Libraries/LibWeb/Bindings/AudioConstructor.h
+++ b/Userland/Libraries/LibWeb/Bindings/AudioConstructor.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibJS/Runtime/NativeFunction.h>
 
 namespace Web::Bindings {
@@ -21,7 +22,7 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
-    virtual const char* class_name() const override { return "AudioConstructor"; }
+    virtual StringView class_name() const override { return "AudioConstructor"sv; }
 };
 
 }

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.h
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/StringView.h>
 #include <LibJS/Runtime/NativeFunction.h>
 
 namespace Web::Bindings {
@@ -21,7 +22,7 @@ public:
 
 private:
     virtual bool has_constructor() const override { return true; }
-    virtual const char* class_name() const override { return "ImageConstructor"; }
+    virtual StringView class_name() const override { return "ImageConstructor"sv; }
 };
 
 }


### PR DESCRIPTION
This helps make the overall codebase consistent. `class_name()` in 
`Kernel` is always `StringView`, but not elsewhere.                
                                                                   
Additionally, this results in the `strlen` (which needs to be done 
when printing or other operations) always being computed at        
compile-time.                                                      