### PR TITLE
WindowServer: Fix animation crash

### DIFF
--- a/Userland/Services/WindowServer/Animation.h
+++ b/Userland/Services/WindowServer/Animation.h
@@ -28,11 +28,12 @@ public:
 
     void start();
     void stop();
+    void was_removed(Badge<Compositor>);
 
     void set_duration(int duration_in_ms);
     int duration() const { return m_duration; }
 
-    void update(Badge<Compositor>, Gfx::Painter&, Screen&, Gfx::DisjointRectSet& flush_rects);
+    bool update(Badge<Compositor>, Gfx::Painter&, Screen&, Gfx::DisjointRectSet& flush_rects);
 
     Function<void(float progress, Gfx::Painter&, Screen&, Gfx::DisjointRectSet& flush_rects)> on_update;
     Function<void()> on_stop;
@@ -43,6 +44,7 @@ private:
     Core::ElapsedTimer m_timer;
     int m_duration { 0 };
     bool m_running { false };
+    bool m_was_removed { false };
 };
 
 }


### PR DESCRIPTION
If an Animation's on_stop handler cleared itself inside the on_stop
event handler, it would remove itself from the animation map that was
still being iterated, leading to a crash.

To solve this, we'll iterate over the animations using the
remove_all_matching function, which enables us to delete it by simply
returning true when the animation finished. In the event that the
Animation is kept alive elsewhere and the on_stop event clears its own
reference, we need to temporarily bump the reference count. Another
advantage is that we only need to bump the reference count when an
animation is finished, whereas before this we bumped it
unconditionally.

This fixes this crash I ran into the other day:
```
30.381 CrashReporter(40:52): 0x3dca1672: [/bin/WindowServer] WindowServer::Compositor::update_animations(WindowServer::Screen&, Gfx::DisjointRectSet&) +0x82 (RefCounted.h:31 => NonnullRefPtr.h:31 => RefPtr.h:45 => Compositor.cpp:1463)
30.381 CrashReporter(40:52): 0x3dca9b1c: [/bin/WindowServer] WindowServer::Compositor::compose() [clone .localalias] +0x1bbc (Compositor.cpp:588 => Screen.h:127 => Compositor.cpp:586)
30.381 CrashReporter(40:52): 0x99e14978: [libcore.so.serenity] Core::Timer::timer_event(Core::TimerEvent&) [clone .localalias] +0x68 (Function.h:91)
30.386 CrashReporter(40:52): 0x99e00120: [libcore.so.serenity] Core::Object::dispatch_event(Core::Event&, Core::Object*) +0xb0 (Object.cpp:220)
30.386 CrashReporter(40:52): 0x99de9171: [libcore.so.serenity] Core::EventLoop::pump(Core::EventLoop::WaitMode) [clone .localalias] +0x161 (EventLoop.cpp:481)
30.386 CrashReporter(40:52): 0x99de9aea: [libcore.so.serenity] Core::EventLoop::exec() +0x11a (EventLoop.cpp:438)
30.386 CrashReporter(40:52): 0x3dcafb07: [/bin/WindowServer] serenity_main(Main::Arguments) +0x1217 (EventLoop.h:25 => main.cpp:130)
30.386 CrashReporter(40:52): 0x1d5bb1e7: [libmain.so.serenity] main +0x77 (Main.cpp:23)
30.386 CrashReporter(40:52): 0x3dc65295: [/bin/WindowServer] _entry +0x65 (crt0.cpp:49)
31.145 CrashReporter(42:51): Generating backtrace took 2077 ms
31.145 CrashReporter(42:51): --- Backtrace for thread #0 (TID 30) ---
31.145 CrashReporter(42:51): 0x5443902e: [libsystem.so] syscall2 +0xe (syscall.cpp:25 => syscall.cpp:24)
31.145 CrashReporter(42:51): 0x0ba95374: [libc.so] raise +0x24 (syscall.h:35 => signal.cpp:22 => signal.cpp:37)
31.145 CrashReporter(42:51): 0x0ba79b89: [libc.so] abort +0x29 (stdlib.cpp:220)
31.145 CrashReporter(42:51): 0x0ba818ac: [libc.so] __assertion_failed +0x6c (assert.cpp:33)
31.145 CrashReporter(42:51): 0x330bc4ae: [libgui.so.serenity] GUI::Window::rect() const [clone .localalias] +0x11e (Connection.h:95 => WindowServerEndpoint.h:7078 => Window.cpp:255 => Window.cpp:251)
31.145 CrashReporter(42:51): 0x330c0e0b: [libgui.so.serenity] GUI::Window::update() [clone .localalias] +0x2b (Window.cpp:679)
31.145 CrashReporter(42:51): 0x4f882675: [/bin/WorkspacePicker.Applet] DesktopStatusWindow::wm_event(GUI::WMEvent&) +0x55 (DesktopStatusWindow.cpp:120 => DesktopStatusWindow.cpp:114)
31.145 CrashReporter(42:51): 0x330c75fb: [libgui.so.serenity] GUI::Window::event(Core::Event&) [clone .localalias] +0x14b (Window.cpp:652)
31.150 CrashReporter(42:51): 0x6fd85120: [libcore.so.serenity] Core::Object::dispatch_event(Core::Event&, Core::Object*) +0xb0 (Object.cpp:220)
31.150 CrashReporter(42:51): 0x6fd6e171: [libcore.so.serenity] Core::EventLoop::pump(Core::EventLoop::WaitMode) [clone .localalias] +0x161 (EventLoop.cpp:481)
31.150 CrashReporter(42:51): 0x6fd6eaea: [libcore.so.serenity] Core::EventLoop::exec() +0x11a (EventLoop.cpp:438)
31.150 CrashReporter(42:51): 0x32f8ffe7: [libgui.so.serenity] GUI::Application::exec() +0x27 (Application.cpp:119)
31.150 CrashReporter(42:51): 0x4f88372d: [/bin/WorkspacePicker.Applet] serenity_main(Main::Arguments) +0x15d (main.cpp:32)
31.150 CrashReporter(42:51): 0x1bda41e7: [libmain.so.serenity] main +0x77 (Main.cpp:23)
31.150 CrashReporter(42:51): 0x4f8823b5: [/bin/WorkspacePicker.Applet] _entry +0x65 (crt0.cpp:49)
```