### PR TITLE
Kernel: VGA text console fixes

### DIFF
--- a/Base/usr/share/man/man7/boot_parameters.md
+++ b/Base/usr/share/man/man7/boot_parameters.md
@@ -35,6 +35,12 @@ List of options:
 
 * **`disable_virtio`** - If present on the command line, virtio devices will not be detected, and initialized on boot.
 
+* **`early_boot_console`** - This parameter expects **`on`** or **`off`** and is by default set to **`on`**.
+  When set to **`off`**, the kernel will not initialize any early console to show kernel dmesg output.
+  When set to **`on`**, the kernel will try to initialize either a text mode console (if VGA text mode was detected)
+  or framebuffer console, based on what the Multiboot bootloader specified on the physical address, width, height
+  and bit color depth.
+
 * **`enable_ioapic`** - This parameter expects **`on`** or **`off`** and is by default set to **`on`**.
   When set to **`off`**, the kernel will initialize the two i8259 PICs.
   When set to **`on`**, the kernel will try to initialize the IOAPIC (or IOAPICs if there's more than one),

--- a/Kernel/CommandLine.cpp
+++ b/Kernel/CommandLine.cpp
@@ -135,6 +135,16 @@ UNMAP_AFTER_INIT bool CommandLine::is_ioapic_enabled() const
     PANIC("Unknown enable_ioapic setting: {}", value);
 }
 
+UNMAP_AFTER_INIT bool CommandLine::is_early_boot_console_disabled() const
+{
+    auto value = lookup("early_boot_console"sv).value_or("on"sv);
+    if (value == "on"sv)
+        return false;
+    if (value == "off"sv)
+        return true;
+    PANIC("Unknown early_boot_console setting: {}", value);
+}
+
 UNMAP_AFTER_INIT bool CommandLine::is_vmmouse_enabled() const
 {
     return lookup("vmmouse"sv).value_or("on"sv) == "on"sv;

--- a/Kernel/CommandLine.h
+++ b/Kernel/CommandLine.h
@@ -85,6 +85,7 @@ public:
     [[nodiscard]] bool disable_uhci_controller() const;
     [[nodiscard]] bool disable_usb() const;
     [[nodiscard]] bool disable_virtio() const;
+    [[nodiscard]] bool is_early_boot_console_disabled() const;
     [[nodiscard]] AHCIResetMode ahci_reset_mode() const;
     [[nodiscard]] StringView userspace_init() const;
     [[nodiscard]] NonnullOwnPtrVector<KString> userspace_init_args() const;

--- a/Kernel/Graphics/Console/TextModeConsole.h
+++ b/Kernel/Graphics/Console/TextModeConsole.h
@@ -39,6 +39,8 @@ private:
     TextModeConsole();
 
     mutable Spinlock m_vga_lock;
+    size_t m_cursor_x { 0 };
+    size_t m_cursor_y { 0 };
 
     VirtualAddress m_current_vga_window;
 };

--- a/Kernel/Graphics/GraphicsManagement.h
+++ b/Kernel/Graphics/GraphicsManagement.h
@@ -33,7 +33,10 @@ public:
     bool framebuffer_devices_use_bootloader_framebuffer() const;
     bool framebuffer_devices_exist() const;
 
-    Spinlock& main_vga_lock() { return m_main_vga_lock; }
+    void set_vga_text_mode_cursor(size_t console_width, size_t x, size_t y) const;
+    void disable_vga_text_mode_console_cursor() const;
+    void disable_vga_emulation_access_permanently();
+
     RefPtr<Graphics::Console> console() const { return m_console; }
     void set_console(Graphics::Console&);
 
@@ -41,6 +44,8 @@ public:
     void activate_graphical_mode();
 
 private:
+    void enable_vga_text_mode_console_cursor() const;
+
     bool determine_and_initialize_graphics_device(PCI::DeviceIdentifier const&);
     bool determine_and_initialize_isa_graphics_device();
     NonnullRefPtrVector<GenericGraphicsAdapter> m_graphics_devices;
@@ -50,7 +55,8 @@ private:
     RefPtr<VGACompatibleAdapter> m_vga_adapter;
     unsigned m_current_minor_number { 0 };
 
-    Spinlock m_main_vga_lock;
+    mutable RecursiveSpinlock m_main_vga_lock;
+    bool m_vga_access_is_disabled { false };
 };
 
 }

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -196,7 +196,7 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     // If the bootloader didn't provide a framebuffer, then set up an initial text console.
     // We do so we can see the output on the screen as soon as possible.
     if (!kernel_command_line().is_early_boot_console_disabled()) {
-        if (!multiboot_framebuffer_addr.is_null()) {
+        if (!multiboot_framebuffer_addr.is_null() && multiboot_framebuffer_type == MULTIBOOT_FRAMEBUFFER_TYPE_RGB) {
             g_boot_console = &try_make_ref_counted<Graphics::BootFramebufferConsole>(multiboot_framebuffer_addr, multiboot_framebuffer_width, multiboot_framebuffer_height, multiboot_framebuffer_pitch).value().leak_ref();
         } else {
             g_boot_console = &Graphics::TextModeConsole::initialize().leak_ref();

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -195,10 +195,12 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     // NOTE: If the bootloader provided a framebuffer, then set up an initial console.
     // If the bootloader didn't provide a framebuffer, then set up an initial text console.
     // We do so we can see the output on the screen as soon as possible.
-    if (!multiboot_framebuffer_addr.is_null()) {
-        g_boot_console = &try_make_ref_counted<Graphics::BootFramebufferConsole>(multiboot_framebuffer_addr, multiboot_framebuffer_width, multiboot_framebuffer_height, multiboot_framebuffer_pitch).value().leak_ref();
-    } else {
-        g_boot_console = &Graphics::TextModeConsole::initialize().leak_ref();
+    if (!kernel_command_line().is_early_boot_console_disabled()) {
+        if (!multiboot_framebuffer_addr.is_null()) {
+            g_boot_console = &try_make_ref_counted<Graphics::BootFramebufferConsole>(multiboot_framebuffer_addr, multiboot_framebuffer_width, multiboot_framebuffer_height, multiboot_framebuffer_pitch).value().leak_ref();
+        } else {
+            g_boot_console = &Graphics::TextModeConsole::initialize().leak_ref();
+        }
     }
     dmesgln("Starting SerenityOS...");
 


### PR DESCRIPTION
This PR is about making the code of the VGA text mode console more correct. It's somewhat related to #12181, but this can be merged now even before we try to merge the `DisplayConnector` feature.