### PR TITLE
LibWeb: Implement CSS Transforms on stacking contexts

### DIFF
--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -125,6 +125,21 @@ AffineTransform& AffineTransform::rotate_radians(float radians)
     return *this;
 }
 
+Optional<AffineTransform> AffineTransform::inverse() const
+{
+    auto determinant = a() * d() - b() * c();
+    if (determinant == 0)
+        return {};
+    return AffineTransform {
+        d() / determinant,
+        -b() / determinant,
+        -c() / determinant,
+        a() / determinant,
+        (c() * f() - d() * e()) / determinant,
+        (b() * e() - a() * f()) / determinant,
+    };
+}
+
 void AffineTransform::map(float unmapped_x, float unmapped_y, float& mapped_x, float& mapped_y) const
 {
     mapped_x = a() * unmapped_x + b() * unmapped_y + m_values[4];

--- a/Userland/Libraries/LibGfx/AffineTransform.h
+++ b/Userland/Libraries/LibGfx/AffineTransform.h
@@ -62,6 +62,8 @@ public:
     AffineTransform& rotate_radians(float);
     AffineTransform& multiply(const AffineTransform&);
 
+    Optional<AffineTransform> inverse() const;
+
 private:
     float m_values[6] { 0 };
 };

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -335,6 +335,8 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
                 values.append({ transformation_value.to_length() });
             } else if (transformation_value.is_numeric()) {
                 values.append({ transformation_value.to_number() });
+            } else if (transformation_value.is_angle()) {
+                values.append({ transformation_value.as_angle().angle().to_degrees() });
             } else {
                 dbgln("FIXME: Unsupported value in transform!");
             }

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1323,8 +1323,38 @@ String TransformationStyleValue::to_string() const
     StringBuilder builder;
 
     switch (m_transform_function) {
+    case TransformFunction::Matrix:
+        builder.append("matrix");
+        break;
+    case TransformFunction::Translate:
+        builder.append("translate");
+        break;
+    case TransformFunction::TranslateX:
+        builder.append("translateX");
+        break;
     case TransformFunction::TranslateY:
         builder.append("translateY");
+        break;
+    case TransformFunction::Scale:
+        builder.append("scale");
+        break;
+    case TransformFunction::ScaleX:
+        builder.append("scaleX");
+        break;
+    case TransformFunction::ScaleY:
+        builder.append("scaleY");
+        break;
+    case TransformFunction::Rotate:
+        builder.append("rotate");
+        break;
+    case TransformFunction::Skew:
+        builder.append("skew");
+        break;
+    case TransformFunction::SkewX:
+        builder.append("skewX");
+        break;
+    case TransformFunction::SkewY:
+        builder.append("skewY");
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -291,7 +291,17 @@ enum class TextTransform {
 };
 
 enum class TransformFunction {
+    Matrix,
+    Translate,
+    TranslateX,
     TranslateY,
+    Scale,
+    ScaleX,
+    ScaleY,
+    Rotate,
+    Skew,
+    SkewX,
+    SkewY,
 };
 
 enum class VerticalAlign {

--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.h
@@ -60,8 +60,6 @@ private:
 
     void layout_floating_box(Box const& child, BlockContainer const& containing_block, LayoutMode);
 
-    void apply_transformations_to_children(Box const&);
-
     void layout_list_item_marker(ListItemBox const&);
 
     enum class FloatSide {

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -69,6 +69,8 @@ bool Node::establishes_stacking_context() const
     auto position = computed_values().position();
     if (position == CSS::Position::Absolute || position == CSS::Position::Relative || position == CSS::Position::Fixed || position == CSS::Position::Sticky)
         return true;
+    if (!computed_values().transformations().is_empty())
+        return true;
     return computed_values().opacity() < 1.0f;
 }
 

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -138,7 +138,7 @@ bool EventHandler::handle_mousewheel(const Gfx::IntPoint& position, unsigned int
 
     // FIXME: Support wheel events in nested browsing contexts.
 
-    auto result = paint_root()->hit_test(position, Painting::HitTestType::Exact);
+    auto result = paint_root()->hit_test(position.to_type<float>(), Painting::HitTestType::Exact);
     if (result.paintable && result.paintable->handle_mousewheel({}, position, buttons, modifiers, wheel_delta_x, wheel_delta_y))
         return true;
 
@@ -164,7 +164,7 @@ bool EventHandler::handle_mouseup(const Gfx::IntPoint& position, unsigned button
     if (m_mouse_event_tracking_layout_node) {
         paintable = m_mouse_event_tracking_layout_node->paintable();
     } else {
-        auto result = paint_root()->hit_test(position, Painting::HitTestType::Exact);
+        auto result = paint_root()->hit_test(position.to_type<float>(), Painting::HitTestType::Exact);
         paintable = result.paintable;
     }
 
@@ -175,7 +175,7 @@ bool EventHandler::handle_mouseup(const Gfx::IntPoint& position, unsigned button
         // Things may have changed as a consequence of Layout::Node::handle_mouseup(). Hit test again.
         if (!paint_root())
             return true;
-        auto result = paint_root()->hit_test(position, Painting::HitTestType::Exact);
+        auto result = paint_root()->hit_test(position.to_type<float>(), Painting::HitTestType::Exact);
         paintable = result.paintable;
     }
 
@@ -222,7 +222,7 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
         if (m_mouse_event_tracking_layout_node) {
             paintable = m_mouse_event_tracking_layout_node->paintable();
         } else {
-            auto result = paint_root()->hit_test(position, Painting::HitTestType::Exact);
+            auto result = paint_root()->hit_test(position.to_type<float>(), Painting::HitTestType::Exact);
             if (!result.paintable)
                 return false;
             paintable = result.paintable;
@@ -300,7 +300,7 @@ bool EventHandler::handle_mousedown(const Gfx::IntPoint& position, unsigned butt
         }
     } else {
         if (button == GUI::MouseButton::Primary) {
-            auto result = paint_root()->hit_test(position, Painting::HitTestType::TextCursor);
+            auto result = paint_root()->hit_test(position.to_type<float>(), Painting::HitTestType::TextCursor);
             if (result.paintable && result.paintable->layout_node().dom_node()) {
 
                 // See if we want to focus something.
@@ -348,7 +348,7 @@ bool EventHandler::handle_mousemove(const Gfx::IntPoint& position, unsigned butt
     if (m_mouse_event_tracking_layout_node) {
         paintable = m_mouse_event_tracking_layout_node->paintable();
     } else {
-        auto result = paint_root()->hit_test(position, Painting::HitTestType::Exact);
+        auto result = paint_root()->hit_test(position.to_type<float>(), Painting::HitTestType::Exact);
         paintable = result.paintable;
         start_index = result.index_in_node;
     }
@@ -408,7 +408,7 @@ bool EventHandler::handle_mousemove(const Gfx::IntPoint& position, unsigned butt
                 return true;
         }
         if (m_in_mouse_selection) {
-            auto hit = paint_root()->hit_test(position, Painting::HitTestType::TextCursor);
+            auto hit = paint_root()->hit_test(position.to_type<float>(), Painting::HitTestType::TextCursor);
             if (start_index.has_value() && hit.paintable && hit.paintable->layout_node().dom_node()) {
                 m_browsing_context.set_cursor_position(DOM::Position(*hit.paintable->layout_node().dom_node(), *start_index));
                 layout_root()->set_selection_end({ hit.paintable->layout_node(), hit.index_in_node });

--- a/Userland/Libraries/LibWeb/Painting/Paintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.cpp
@@ -41,7 +41,7 @@ bool Paintable::handle_mousewheel(Badge<EventHandler>, Gfx::IntPoint const&, uns
     return false;
 }
 
-HitTestResult Paintable::hit_test(Gfx::IntPoint const&, HitTestType) const
+HitTestResult Paintable::hit_test(Gfx::FloatPoint const&, HitTestType) const
 {
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/Painting/Paintable.h
+++ b/Userland/Libraries/LibWeb/Painting/Paintable.h
@@ -50,7 +50,7 @@ public:
     virtual void before_children_paint(PaintContext&, PaintPhase) const { }
     virtual void after_children_paint(PaintContext&, PaintPhase) const { }
 
-    virtual HitTestResult hit_test(Gfx::IntPoint const&, HitTestType) const;
+    virtual HitTestResult hit_test(Gfx::FloatPoint const&, HitTestType) const;
 
     virtual bool wants_mouse_events() const { return false; }
 

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -526,7 +526,7 @@ void PaintableBox::for_each_child_in_paint_order(Callback callback) const
     });
 }
 
-HitTestResult PaintableBox::hit_test(Gfx::IntPoint const& position, HitTestType type) const
+HitTestResult PaintableBox::hit_test(Gfx::FloatPoint const& position, HitTestType type) const
 {
     if (layout_box().is_initial_containing_block_box())
         return stacking_context()->hit_test(position, type);
@@ -542,7 +542,7 @@ HitTestResult PaintableBox::hit_test(Gfx::IntPoint const& position, HitTestType 
     return result;
 }
 
-HitTestResult PaintableWithLines::hit_test(const Gfx::IntPoint& position, HitTestType type) const
+HitTestResult PaintableWithLines::hit_test(const Gfx::FloatPoint& position, HitTestType type) const
 {
     if (!layout_box().children_are_inline())
         return PaintableBox::hit_test(position, type);
@@ -552,7 +552,7 @@ HitTestResult PaintableWithLines::hit_test(const Gfx::IntPoint& position, HitTes
         for (auto& fragment : line_box.fragments()) {
             if (is<Layout::Box>(fragment.layout_node()) && static_cast<Layout::Box const&>(fragment.layout_node()).paint_box()->stacking_context())
                 continue;
-            if (enclosing_int_rect(fragment.absolute_rect()).contains(position)) {
+            if (fragment.absolute_rect().contains(position)) {
                 if (is<Layout::BlockContainer>(fragment.layout_node()) && fragment.layout_node().paintable())
                     return fragment.layout_node().paintable()->hit_test(position, type);
                 return { fragment.layout_node().paintable(), fragment.text_index_at(position.x()) };

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.h
@@ -115,7 +115,7 @@ public:
     virtual void before_children_paint(PaintContext&, PaintPhase) const override;
     virtual void after_children_paint(PaintContext&, PaintPhase) const override;
 
-    virtual HitTestResult hit_test(Gfx::IntPoint const&, HitTestType) const override;
+    virtual HitTestResult hit_test(Gfx::FloatPoint const&, HitTestType) const override;
 
 protected:
     explicit PaintableBox(Layout::Box const&);
@@ -164,7 +164,7 @@ public:
     virtual bool wants_mouse_events() const override { return false; }
     virtual bool handle_mousewheel(Badge<EventHandler>, const Gfx::IntPoint&, unsigned buttons, unsigned modifiers, int wheel_delta_x, int wheel_delta_y) override;
 
-    virtual HitTestResult hit_test(Gfx::IntPoint const&, HitTestType) const override;
+    virtual HitTestResult hit_test(Gfx::FloatPoint const&, HitTestType) const override;
 
 protected:
     PaintableWithLines(Layout::BlockContainer const&);

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Debug.h>
 #include <AK/QuickSort.h>
 #include <AK/StringBuilder.h>
+#include <LibGfx/AffineTransform.h>
+#include <LibGfx/Matrix4x4.h>
 #include <LibGfx/Painter.h>
+#include <LibGfx/Rect.h>
 #include <LibWeb/Layout/Box.h>
 #include <LibWeb/Layout/InitialContainingBlock.h>
 #include <LibWeb/Layout/ReplacedBox.h>
@@ -137,6 +141,104 @@ void StackingContext::paint_internal(PaintContext& context) const
     paint_descendants(context, m_box, StackingContextPaintPhase::FocusAndOverlay);
 }
 
+Gfx::FloatMatrix4x4 StackingContext::get_transformation_matrix(CSS::Transformation const& transformation) const
+{
+    Vector<float> float_values;
+    for (auto const& value : transformation.values) {
+        value.visit(
+            [&](CSS::Length const& value) {
+                float_values.append(value.to_px(m_box));
+            },
+            [&](float value) {
+                float_values.append(value);
+            });
+    }
+
+    switch (transformation.function) {
+    case CSS::TransformFunction::Matrix:
+        if (float_values.size() == 6)
+            return Gfx::FloatMatrix4x4(float_values[0], float_values[2], 0, float_values[4],
+                float_values[1], float_values[3], 0, float_values[5],
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        break;
+    case CSS::TransformFunction::Translate:
+        if (float_values.size() == 1)
+            return Gfx::FloatMatrix4x4(1, 0, 0, float_values[0],
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        if (float_values.size() == 2)
+            return Gfx::FloatMatrix4x4(1, 0, 0, float_values[0],
+                0, 1, 0, float_values[1],
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        break;
+    case CSS::TransformFunction::TranslateX:
+        if (float_values.size() == 1)
+            return Gfx::FloatMatrix4x4(1, 0, 0, float_values[0],
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        break;
+    case CSS::TransformFunction::TranslateY:
+        if (float_values.size() == 1)
+            return Gfx::FloatMatrix4x4(1, 0, 0, 0,
+                0, 1, 0, float_values[0],
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        break;
+    case CSS::TransformFunction::Scale:
+        if (float_values.size() == 1)
+            return Gfx::FloatMatrix4x4(float_values[0], 0, 0, 0,
+                0, float_values[0], 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        if (float_values.size() == 2)
+            return Gfx::FloatMatrix4x4(float_values[0], 0, 0, 0,
+                0, float_values[1], 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        break;
+    case CSS::TransformFunction::ScaleX:
+        if (float_values.size() == 1)
+            return Gfx::FloatMatrix4x4(float_values[0], 0, 0, 0,
+                0, 1, 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        break;
+    case CSS::TransformFunction::ScaleY:
+        if (float_values.size() == 1)
+            return Gfx::FloatMatrix4x4(1, 0, 0, 0,
+                0, float_values[0], 0, 0,
+                0, 0, 1, 0,
+                0, 0, 0, 1);
+        break;
+    default:
+        dbgln_if(LIBWEB_CSS_DEBUG, "FIXME: Unhandled transformation function {}", CSS::TransformationStyleValue::create(transformation.function, {})->to_string());
+    }
+    return Gfx::FloatMatrix4x4::identity();
+}
+
+Gfx::FloatMatrix4x4 StackingContext::combine_transformations(Vector<CSS::Transformation> const& transformations) const
+{
+    auto matrix = Gfx::FloatMatrix4x4::identity();
+
+    for (auto const& transform : transformations)
+        matrix = matrix * get_transformation_matrix(transform);
+
+    return matrix;
+}
+
+// FIXME: This extracts the affine 2D part of the full transformation matrix.
+//  Use the whole matrix when we get better transformation support in LibGfx or use LibGL for drawing the bitmap
+Gfx::AffineTransform StackingContext::combine_transformations_2d(Vector<CSS::Transformation> const& transformations) const
+{
+    auto matrix = combine_transformations(transformations);
+    auto* m = matrix.elements();
+    return Gfx::AffineTransform(m[0][0], m[1][0], m[0][1], m[1][1], m[0][3], m[1][3]);
+}
+
 void StackingContext::paint(PaintContext& context) const
 {
     Gfx::PainterStateSaver saver(context.painter());
@@ -148,7 +250,9 @@ void StackingContext::paint(PaintContext& context) const
     if (opacity == 0.0f)
         return;
 
-    if (opacity < 1.0f) {
+    auto affine_transform = combine_transformations_2d(m_box.computed_values().transformations());
+
+    if (opacity < 1.0f || !affine_transform.is_identity()) {
         auto bitmap_or_error = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, context.painter().target()->size());
         if (bitmap_or_error.is_error())
             return;
@@ -156,7 +260,13 @@ void StackingContext::paint(PaintContext& context) const
         Gfx::Painter painter(bitmap);
         PaintContext paint_context(painter, context.palette(), context.scroll_offset());
         paint_internal(paint_context);
-        context.painter().blit(Gfx::IntPoint(m_box.paint_box()->absolute_position()), bitmap, Gfx::IntRect(m_box.paint_box()->absolute_rect()), opacity);
+
+        // FIXME: Use the transform origin specified in CSS or SVG
+        auto transform_origin = m_box.paint_box()->absolute_position();
+        auto source_rect = m_box.paint_box()->absolute_rect().translated(-transform_origin);
+        auto transformed_destination_rect = affine_transform.map(source_rect).translated(transform_origin);
+        source_rect.translate_by(transform_origin);
+        context.painter().draw_scaled_bitmap(Gfx::rounded_int_rect(transformed_destination_rect), *bitmap, source_rect, opacity, Gfx::Painter::ScalingMode::BilinearBlend);
     } else {
         paint_internal(context);
     }
@@ -252,6 +362,11 @@ void StackingContext::dump(int indent) const
     else
         builder.append("auto");
     builder.append(')');
+
+    auto affine_transform = combine_transformations_2d(m_box.computed_values().transformations());
+    if (!affine_transform.is_identity()) {
+        builder.appendff(", transform: {}", affine_transform);
+    }
     dbgln("{}", builder.string_view());
     for (auto& child : m_children)
         child->dump(indent + 1);

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/Vector.h>
+#include <LibGfx/Matrix4x4.h>
 #include <LibWeb/Layout/Node.h>
 #include <LibWeb/Painting/Paintable.h>
 
@@ -41,6 +42,9 @@ private:
     Vector<StackingContext*> m_children;
 
     void paint_internal(PaintContext&) const;
+    Gfx::FloatMatrix4x4 get_transformation_matrix(CSS::Transformation const& transformation) const;
+    Gfx::FloatMatrix4x4 combine_transformations(Vector<CSS::Transformation> const& transformations) const;
+    Gfx::AffineTransform combine_transformations_2d(Vector<CSS::Transformation> const& transformations) const;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -30,7 +30,7 @@ public:
 
     void paint_descendants(PaintContext&, Layout::Node&, StackingContextPaintPhase) const;
     void paint(PaintContext&) const;
-    HitTestResult hit_test(Gfx::IntPoint const&, HitTestType) const;
+    HitTestResult hit_test(Gfx::FloatPoint const&, HitTestType) const;
 
     void dump(int indent = 0) const;
 

--- a/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGGraphicsElement.cpp
@@ -30,6 +30,9 @@ void SVGGraphicsElement::apply_presentational_hints(CSS::StyleProperties& style)
         } else if (name.equals_ignoring_case("stroke-width")) {
             if (auto stroke_width_value = parse_css_value(parsing_context, value, CSS::PropertyID::StrokeWidth))
                 style.set_property(CSS::PropertyID::StrokeWidth, stroke_width_value.release_nonnull());
+        } else if (name.equals_ignoring_case("transform")) {
+            if (auto transform = parse_css_value(parsing_context, value, CSS::PropertyID::Transform))
+                style.set_property(CSS::PropertyID::Transform, transform.release_nonnull());
         }
     });
 }


### PR DESCRIPTION
This also adds `translate()` and `translateX()` support in addition to the previously implemented `translateY()`