### PR TITLE
Everywhere: Switch from EnableIf to requires

### DIFF
--- a/AK/Buffered.h
+++ b/AK/Buffered.h
@@ -17,11 +17,11 @@ namespace AK {
 
 // FIXME: Implement Buffered<T> for DuplexStream.
 
-template<typename StreamType, size_t Size = 4096, typename = void>
+template<typename StreamType, size_t Size = 4096>
 class Buffered;
 
 template<typename StreamType, size_t Size>
-class Buffered<StreamType, Size, typename EnableIf<IsBaseOf<InputStream, StreamType>>::Type> final : public InputStream {
+requires(IsBaseOf<InputStream, StreamType>) class Buffered<StreamType, Size> final : public InputStream {
     AK_MAKE_NONCOPYABLE(Buffered);
 
 public:
@@ -119,7 +119,7 @@ private:
 };
 
 template<typename StreamType, size_t Size>
-class Buffered<StreamType, Size, typename EnableIf<IsBaseOf<OutputStream, StreamType>>::Type> final : public OutputStream {
+requires(IsBaseOf<OutputStream, StreamType>) class Buffered<StreamType, Size> : public OutputStream {
     AK_MAKE_NONCOPYABLE(Buffered);
 
 public:
@@ -192,7 +192,6 @@ private:
     u8 m_buffer[Size];
     size_t m_buffered { 0 };
 };
-
 }
 
 using AK::Buffered;

--- a/AK/Format.cpp
+++ b/AK/Format.cpp
@@ -692,8 +692,8 @@ ErrorOr<void> Formatter<FormatString>::vformat(FormatBuilder& builder, StringVie
     return {};
 }
 
-template<typename T>
-ErrorOr<void> Formatter<T, typename EnableIf<IsIntegral<T>>::Type>::format(FormatBuilder& builder, T value)
+template<Integral T>
+ErrorOr<void> Formatter<T>::format(FormatBuilder& builder, T value)
 {
     if (m_mode == Mode::Character) {
         // FIXME: We just support ASCII for now, in the future maybe unicode?

--- a/AK/Format.h
+++ b/AK/Format.h
@@ -307,8 +307,8 @@ struct StandardFormatter {
     void parse(TypeErasedFormatParams&, FormatParser&);
 };
 
-template<typename T>
-struct Formatter<T, typename EnableIf<IsIntegral<T>>::Type> : StandardFormatter {
+template<Integral T>
+struct Formatter<T> : StandardFormatter {
     Formatter() = default;
     explicit Formatter(StandardFormatter formatter)
         : StandardFormatter(move(formatter))

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -10,15 +10,6 @@
 
 namespace AK::Detail {
 
-template<bool B, class T = void>
-struct EnableIf {
-};
-
-template<class T>
-struct EnableIf<true, T> {
-    using Type = T;
-};
-
 template<class T, T v>
 struct IntegralConstant {
     static constexpr T value = v;
@@ -591,7 +582,6 @@ using AK::Detail::Conditional;
 using AK::Detail::CopyConst;
 using AK::Detail::declval;
 using AK::Detail::DependentFalse;
-using AK::Detail::EnableIf;
 using AK::Detail::FalseType;
 using AK::Detail::IdentityType;
 using AK::Detail::IndexSequence;

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -22,27 +22,27 @@ class [[nodiscard]] WeakPtr {
 public:
     WeakPtr() = default;
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(const WeakPtr<U>& other)
+    template<typename U>
+    WeakPtr(const WeakPtr<U>& other) requires(IsBaseOf<T, U>)
         : m_link(other.m_link)
     {
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(WeakPtr<U>&& other)
+    template<typename U>
+    WeakPtr(WeakPtr<U>&& other) requires(IsBaseOf<T, U>)
         : m_link(other.take_link())
     {
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(WeakPtr<U>&& other)
+    template<typename U>
+    WeakPtr& operator=(WeakPtr<U>&& other) requires(IsBaseOf<T, U>)
     {
         m_link = other.take_link();
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const WeakPtr<U>& other)
+    template<typename U>
+    WeakPtr& operator=(const WeakPtr<U>& other) requires(IsBaseOf<T, U>)
     {
         if ((const void*)this != (const void*)&other)
             m_link = other.m_link;
@@ -55,41 +55,41 @@ public:
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(const U& object)
+    template<typename U>
+    WeakPtr(const U& object) requires(IsBaseOf<T, U>)
         : m_link(object.template make_weak_ptr<U>().take_link())
     {
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(const U* object)
+    template<typename U>
+    WeakPtr(const U* object) requires(IsBaseOf<T, U>)
     {
         if (object)
             m_link = object->template make_weak_ptr<U>().take_link();
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(RefPtr<U> const& object)
+    template<typename U>
+    WeakPtr(RefPtr<U> const& object) requires(IsBaseOf<T, U>)
     {
         if (object)
             m_link = object->template make_weak_ptr<U>().take_link();
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(NonnullRefPtr<U> const& object)
+    template<typename U>
+    WeakPtr(NonnullRefPtr<U> const& object) requires(IsBaseOf<T, U>)
     {
         m_link = object->template make_weak_ptr<U>().take_link();
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const U& object)
+    template<typename U>
+    WeakPtr& operator=(const U& object) requires(IsBaseOf<T, U>)
     {
         m_link = object.template make_weak_ptr<U>().take_link();
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const U* object)
+    template<typename U>
+    WeakPtr& operator=(const U* object) requires(IsBaseOf<T, U>)
     {
         if (object)
             m_link = object->template make_weak_ptr<U>().take_link();
@@ -98,8 +98,8 @@ public:
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const RefPtr<U>& object)
+    template<typename U>
+    WeakPtr& operator=(const RefPtr<U>& object) requires(IsBaseOf<T, U>)
     {
         if (object)
             m_link = object->template make_weak_ptr<U>().take_link();
@@ -108,8 +108,8 @@ public:
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const NonnullRefPtr<U>& object)
+    template<typename U>
+    WeakPtr& operator=(const NonnullRefPtr<U>& object) requires(IsBaseOf<T, U>)
     {
         m_link = object->template make_weak_ptr<U>().take_link();
         return *this;

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -32,8 +32,9 @@ class WeakLink : public RefCounted<WeakLink> {
     friend class WeakPtr;
 
 public:
-    template<typename T, typename PtrTraits = RefPtrTraits<T>, typename EnableIf<IsBaseOf<RefCountedBase, T>>::Type* = nullptr>
+    template<typename T, typename PtrTraits = RefPtrTraits<T>>
     RefPtr<T, PtrTraits> strong_ref() const
+        requires(IsBaseOf<RefCountedBase, T>)
     {
         RefPtr<T, PtrTraits> ref;
 

--- a/Kernel/Library/ThreadSafeRefPtr.h
+++ b/Kernel/Library/ThreadSafeRefPtr.h
@@ -361,16 +361,17 @@ public:
 
     ALWAYS_INLINE bool is_null() const { return PtrTraits::is_null(m_bits.load(AK::MemoryOrder::memory_order_relaxed)); }
 
-    template<typename U = T, typename EnableIf<IsSame<U, T> && !IsNullPointer<typename PtrTraits::NullType>>::Type* = nullptr>
+    template<typename U = T>
     typename PtrTraits::NullType null_value() const
+        requires(IsSame<U, T> && !IsNullPointer<typename PtrTraits::NullType>)
     {
         // make sure we are holding a null value
         FlatPtr bits = m_bits.load(AK::MemoryOrder::memory_order_relaxed);
         VERIFY(PtrTraits::is_null(bits));
         return PtrTraits::to_null_value(bits);
     }
-    template<typename U = T, typename EnableIf<IsSame<U, T> && !IsNullPointer<typename PtrTraits::NullType>>::Type* = nullptr>
-    void set_null_value(typename PtrTraits::NullType value)
+    template<typename U = T>
+    void set_null_value(typename PtrTraits::NullType value) requires(IsSame<U, T> && !IsNullPointer<typename PtrTraits::NullType>)
     {
         // make sure that new null value would be interpreted as a null value
         FlatPtr bits = PtrTraits::from_null_value(value);

--- a/Kernel/Library/ThreadSafeWeakPtr.h
+++ b/Kernel/Library/ThreadSafeWeakPtr.h
@@ -18,27 +18,27 @@ class [[nodiscard]] WeakPtr {
 public:
     WeakPtr() = default;
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(const WeakPtr<U>& other)
+    template<typename U>
+    WeakPtr(const WeakPtr<U>& other) requires(IsBaseOf<T, U>)
         : m_link(other.m_link)
     {
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(WeakPtr<U>&& other)
+    template<typename U>
+    WeakPtr(WeakPtr<U>&& other) requires(IsBaseOf<T, U>)
         : m_link(other.take_link())
     {
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(WeakPtr<U>&& other)
+    template<typename U>
+    WeakPtr& operator=(WeakPtr<U>&& other) requires(IsBaseOf<T, U>)
     {
         m_link = other.take_link();
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const WeakPtr<U>& other)
+    template<typename U>
+    WeakPtr& operator=(const WeakPtr<U>& other) requires(IsBaseOf<T, U>)
     {
         if ((const void*)this != (const void*)&other)
             m_link = other.m_link;
@@ -51,21 +51,21 @@ public:
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(const U& object)
+    template<typename U>
+    WeakPtr(const U& object) requires(IsBaseOf<T, U>)
         : m_link(object.template try_make_weak_ptr<U>().release_value_but_fixme_should_propagate_errors().take_link())
     {
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(const U* object)
+    template<typename U>
+    WeakPtr(const U* object) requires(IsBaseOf<T, U>)
     {
         if (object)
             m_link = object->template try_make_weak_ptr<U>().release_value_but_fixme_should_propagate_errors().take_link();
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(const RefPtr<U>& object)
+    template<typename U>
+    WeakPtr(const RefPtr<U>& object) requires(IsBaseOf<T, U>)
     {
         object.do_while_locked([&](U* obj) {
             if (obj)
@@ -73,8 +73,8 @@ public:
         });
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr(const NonnullRefPtr<U>& object)
+    template<typename U>
+    WeakPtr(const NonnullRefPtr<U>& object) requires(IsBaseOf<T, U>)
     {
         object.do_while_locked([&](U* obj) {
             if (obj)
@@ -82,15 +82,15 @@ public:
         });
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const U& object)
+    template<typename U>
+    WeakPtr& operator=(const U& object) requires(IsBaseOf<T, U>)
     {
         m_link = object.template try_make_weak_ptr<U>().release_value_but_fixme_should_propagate_errors().take_link();
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const U* object)
+    template<typename U>
+    WeakPtr& operator=(const U* object) requires(IsBaseOf<T, U>)
     {
         if (object)
             m_link = object->template try_make_weak_ptr<U>().release_value_but_fixme_should_propagate_errors().take_link();
@@ -99,8 +99,8 @@ public:
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const RefPtr<U>& object)
+    template<typename U>
+    WeakPtr& operator=(const RefPtr<U>& object) requires(IsBaseOf<T, U>)
     {
         object.do_while_locked([&](U* obj) {
             if (obj)
@@ -111,8 +111,8 @@ public:
         return *this;
     }
 
-    template<typename U, typename EnableIf<IsBaseOf<T, U>>::Type* = nullptr>
-    WeakPtr& operator=(const NonnullRefPtr<U>& object)
+    template<typename U>
+    WeakPtr& operator=(const NonnullRefPtr<U>& object) requires(IsBaseOf<T, U>)
     {
         object.do_while_locked([&](U* obj) {
             if (obj)

--- a/Userland/Libraries/LibGfx/Filters/SpatialGaussianBlurFilter.h
+++ b/Userland/Libraries/LibGfx/Filters/SpatialGaussianBlurFilter.h
@@ -11,13 +11,12 @@
 
 namespace Gfx {
 
-template<size_t N, typename = typename EnableIf<N % 2 == 1>::Type>
-class SpatialGaussianBlurFilter : public GenericConvolutionFilter<N> {
+template<size_t N>
+requires(N % 2 == 1) class SpatialGaussianBlurFilter : public GenericConvolutionFilter<N> {
 public:
     SpatialGaussianBlurFilter() = default;
     virtual ~SpatialGaussianBlurFilter() = default;
 
     virtual const char* class_name() const override { return "SpatialGaussianBlurFilter"; }
 };
-
 }


### PR DESCRIPTION
C++20 provides the `requires` clause which simplifies the ability to
limit overload resolution. Prefer it over `EnableIf`

With all uses of `EnableIf` being removed, also remove the
implementation so future devs are not tempted.