### PR TITLE
AK: Mark the StringView user-defined literal as consteval

### DIFF
--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -301,7 +301,15 @@ struct CaseInsensitiveStringViewTraits : public Traits<StringView> {
 
 }
 
-[[nodiscard]] ALWAYS_INLINE constexpr AK::StringView operator"" sv(const char* cstring, size_t length)
+// FIXME: Remove this when clang fully supports consteval (specifically in the context of default parameter initialization).
+// See: https://stackoverflow.com/questions/68789984/immediate-function-as-default-function-argument-initializer-in-clang
+#if defined(__clang__)
+#    define AK_STRING_VIEW_LITERAL_CONSTEVAL constexpr
+#else
+#    define AK_STRING_VIEW_LITERAL_CONSTEVAL consteval
+#endif
+
+[[nodiscard]] ALWAYS_INLINE AK_STRING_VIEW_LITERAL_CONSTEVAL AK::StringView operator"" sv(const char* cstring, size_t length)
 {
     return AK::StringView(cstring, length);
 }


### PR DESCRIPTION
Even though the StringView(char*, size_t) constructor only runs its
overflow check when evaluated in a runtime context, the code generated
here could prevent the compiler from optimizing invocations from the
StringView user-defined literal (verified on Compiler Explorer).

This changes the user-defined literal declaration to be consteval to
ensure it is evaluated at compile time.