### PR TITLE
LibWeb: Implement `:is()`, `:where()` and `:nth-child(3n of fancy[pants], #selector.list)`

### DIFF
--- a/Base/res/html/misc/is-selector.html
+++ b/Base/res/html/misc/is-selector.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>:is() test</title>
+    <style>
+        div {
+            border: 1px solid black;
+            margin-bottom: 1em;
+            padding: 0 0.5em;
+        }
+        .special :is(h2, p) {
+            background-color: lime;
+        }
+        .forgiving :is(&&&fakhsdaskjhd, h2, p) {
+            background-color: lime;
+        }
+    </style>
+</head>
+<body>
+    <h1>:is() test</h1>
+    <div>
+        <h2>Nothing</h2>
+        <p>These should have no background.</p>
+    </div>
+    <br/>
+    <div class="special">
+        <h2>.special :is(h2, p)</h2>
+        <p>These should have a green background.</p>
+    </div>
+    <br/>
+    <div class="forgiving">
+        <h2>.forgiving :is(&&&fakhsdaskjhd, h2, p)</h2>
+        <p>These should have a green background. :is() takes a "permissive selector list",
+            so even though part of it is invalid, this does not make the whole selector-list invalid.</p>
+    </div>
+</body>
+</html>

--- a/Base/res/html/misc/lists.html
+++ b/Base/res/html/misc/lists.html
@@ -14,6 +14,42 @@
         <li>Another entry</li>
     </ul>
 
+    <p>Multiple levels</p>
+    <ul>
+        <li>First</li>
+        <li>Second
+            <ul>
+                <li>Sub-1</li>
+                <li>Sub-2
+                    <ul>
+                        <li>Sub-sub-1</li>
+                        <li>Sub-sub-2</li>
+                        <li>Sub-sub-3</li>
+                    </ul>
+                </li>
+                <li>Sub-3</li>
+            </ul>
+        </li>
+    </ul>
+
+    <p>Multiple levels of numbers</p>
+    <ol>
+        <li>First</li>
+        <li>Second
+            <ol>
+                <li>Sub-1</li>
+                <li>Sub-2
+                    <ol>
+                        <li>Sub-sub-1</li>
+                        <li>Sub-sub-2</li>
+                        <li>Sub-sub-3</li>
+                    </ol>
+                </li>
+                <li>Sub-3</li>
+            </ol>
+        </li>
+    </ol>
+
     <p>list-style: disc</p>
     <ul style="list-style: disc;">
         <li>Entry one</li>

--- a/Base/res/html/misc/not-selector.html
+++ b/Base/res/html/misc/not-selector.html
@@ -1,6 +1,7 @@
-<html>
+<!doctype html>
+<html lang="en">
 <head>
-<title>:only-child test</title>
+<title>:not() test</title>
 <style>
 div {
     background: yellow;

--- a/Base/res/html/misc/nth-child.html
+++ b/Base/res/html/misc/nth-child.html
@@ -4,21 +4,55 @@
     <title>:nth-child test</title>
     <style>
         /** We have weird spacing inside parentheses to test parser. */
-        .odd > div:nth-child(odd ),
-        ._2n-plus-1 > div:nth-child(2n+1),
-        .even > div:nth-child( even),
-        ._2n > div:nth-child( 2n ),
-        ._3n > div:nth-child(3n),
-        ._2 > div:nth-child(2 ),
-        ._3n-plus-1 > div:nth-child( 3n + 1 ),
-        ._3n-minus-1 > div:nth-child( 3n -1),
-        ._minus-n-plus-3 > div:nth-child(-n+ 3),
-        .n > div:nth-child(n), /** "n" is special case inside parser. */
-        .plus-n > div:nth-child(+n), /** "+n" is special case inside parser. */
-        .minus-n > div:nth-child(-n), /** "-n" is special case inside parser. */
-        ._0n-plus-1 > div:nth-child(-0n+1),
-        .n-plus-2__minus-n-plus-4 > div:nth-child(+n + 2 ):nth-child( -n+4),
+        .odd > div:nth-child(odd ) {
+            background-color: lightblue;
+        }
+        ._2n-plus-1 > div:nth-child(2n+1) {
+            background-color: lightblue;
+        }
+        .even > div:nth-child( even) {
+            background-color: lightblue;
+        }
+        ._2n > div:nth-child( 2n ) {
+            background-color: lightblue;
+        }
+        ._3n > div:nth-child(3n) {
+            background-color: lightblue;
+        }
+        ._2 > div:nth-child(2 ) {
+            background-color: lightblue;
+        }
+        ._3n-plus-1 > div:nth-child( 3n + 1 ) {
+            background-color: lightblue;
+        }
+        ._3n-minus-1 > div:nth-child( 3n -1) {
+            background-color: lightblue;
+        }
+        ._minus-n-plus-3 > div:nth-child(-n+ 3) {
+            background-color: lightblue;
+        }
+        /** "n" is special case inside parser. */
+        .n > div:nth-child(n) {
+            background-color: lightblue;
+        }
+        /** "+n" is special case inside parser. */
+        .plus-n > div:nth-child(+n) {
+            background-color: lightblue;
+        }
+        /** "-n" is special case inside parser. */
+        .minus-n > div:nth-child(-n) {
+            background-color: lightblue;
+        }
+        ._0n-plus-1 > div:nth-child(-0n+1) {
+            background-color: lightblue;
+        }
+        .n-plus-2__minus-n-plus-4 > div:nth-child(+n + 2 ):nth-child( -n+4) {
+            background-color: lightblue;
+        }
         .acid3 > div:nth-child(-5n+3) {
+            background-color: lightblue;
+        }
+        .test-of > div:nth-child(3n+1 of .special) {
             background-color: lightblue;
         }
     </style>
@@ -142,7 +176,7 @@
 <div class="acid3">
     <div>1</div>
     <div>2</div>
-    <div>3+</div>
+    <div>3 +</div>
     <div>4</div>
     <div>5</div>
     <div>6</div>
@@ -155,6 +189,16 @@
     <div>13</div>
     <div>14</div>
     <div>15</div>
+</div>
+
+<h4>:nth-child(3n+1 of .special)</h4>
+<div class="test-of">
+    <div class="special">1 +</div>
+    <div class="special">2</div>
+    <div>(Ignored)</div>
+    <div class="special">3</div>
+    <div>(Ignored)</div>
+    <div class="special">4 +</div>
 </div>
 </body>
 </html>

--- a/Base/res/html/misc/nth-last-child.html
+++ b/Base/res/html/misc/nth-last-child.html
@@ -4,21 +4,56 @@
     <title>:nth-last-child test</title>
     <style>
         /** We have weird spacing inside parentheses to test parser. */
-        .odd > div:nth-last-child(odd ),
-        ._2n-plus-1 > div:nth-last-child(2n+1),
-        .even > div:nth-last-child( even),
-        ._2n > div:nth-last-child( 2n ),
-        ._3n > div:nth-last-child(3n),
-        ._2 > div:nth-last-child(2 ),
-        ._3n-plus-1 > div:nth-last-child( 3n + 1 ),
-        ._3n-minus-1 > div:nth-last-child( 3n -1),
-        ._minus-n-plus-3 > div:nth-last-child(-n+ 3),
-        .n > div:nth-last-child(n), /** "n" is special case inside parser. */
-        .plus-n > div:nth-last-child(+n), /** "+n" is special case inside parser. */
-        .minus-n > div:nth-last-child(-n), /** "-n" is special case inside parser. */
-        ._0n-plus-1 > div:nth-last-child(-0n+1),
-        .n-plus-2__minus-n-plus-3 > div:nth-last-child(+n + 2 ):nth-last-child( -n+3),
+        .odd > div:nth-last-child(odd ) {
+            background-color: lightblue;
+        }
+        ._2n-plus-1 > div:nth-last-child(2n+1) {
+            background-color: lightblue;
+        }
+        .even > div:nth-last-child( even) {
+            background-color: lightblue;
+        }
+        ._2n > div:nth-last-child( 2n ) {
+            background-color: lightblue;
+        }
+        ._3n > div:nth-last-child(3n) {
+            background-color: lightblue;
+        }
+        ._2 > div:nth-last-child(2 ) {
+            background-color: lightblue;
+        }
+        ._3n-plus-1 > div:nth-last-child( 3n + 1 ) {
+            background-color: lightblue;
+        }
+        ._3n-minus-1 > div:nth-last-child( 3n -1) {
+            background-color: lightblue;
+        }
+        ._minus-n-plus-3 > div:nth-last-child(-n+ 3) {
+            background-color: lightblue;
+        }
+        /** "n" is special case inside parser. */
+        .n > div:nth-last-child(n) {
+            background-color: lightblue;
+        }
+        /** "+n" is special case inside parser. */
+        .plus-n > div:nth-last-child(+n) {
+            background-color: lightblue;
+        }
+        /** "-n" is special case inside parser. */
+        .minus-n > div:nth-last-child(-n) {
+            background-color: lightblue;
+        }
+        ._0n-plus-1 > div:nth-last-child(-0n+1) {
+            background-color: lightblue;
+        }
+        .n-plus-2__minus-n-plus-3 > div:nth-last-child(+n + 2 ):nth-last-child( -n+3) {
+            background-color: lightblue;
+        }
         .acid3 > div:nth-last-child(-5n+3) {
+            background-color: lightblue;
+        }
+        /* Separate because only Safari supports this syntax right now */
+        .test-of > div:nth-last-child(3n+1 of .special) {
             background-color: lightblue;
         }
     </style>
@@ -152,9 +187,23 @@
     <div>10</div>
     <div>11</div>
     <div>12</div>
-    <div>13+</div>
+    <div>13 +</div>
     <div>14</div>
     <div>15</div>
+</div>
+
+<h4>:nth-last-child(3n+1 of .special)</h4>
+<div class="test-of">
+    <div class="special">1</div>
+    <div class="special">2</div>
+    <div>(Ignored)</div>
+    <div class="special">3 +</div>
+    <div>(Ignored)</div>
+    <div class="special">4</div>
+    <div>(Ignored)</div>
+    <div>(Ignored)</div>
+    <div class="special">5</div>
+    <div class="special">6 +</div>
 </div>
 </body>
 </html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -96,8 +96,9 @@
             <li><a href="nth-last-of-type.html">:nth-last-of-type</a></li>
             <li><a href="empty.html">:empty</a></li>
             <li><a href="root.html">:root</a></li>
-            <li><a href="is-selector.html">:is</a></li>
-            <li><a href="not-selector.html">:not</a></li>
+            <li><a href="is-selector.html">:is()</a></li>
+            <li><a href="not-selector.html">:not()</a></li>
+            <li><a href="where-selector.html">:where()</a></li>
             <li><a href="hover.html">:hover</a></li>
             <li><h3>Properties</h3></li>
             <li><a href="backgrounds.html">Backgrounds</a></li>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -96,6 +96,7 @@
             <li><a href="nth-last-of-type.html">:nth-last-of-type</a></li>
             <li><a href="empty.html">:empty</a></li>
             <li><a href="root.html">:root</a></li>
+            <li><a href="is-selector.html">:is</a></li>
             <li><a href="not-selector.html">:not</a></li>
             <li><a href="hover.html">:hover</a></li>
             <li><h3>Properties</h3></li>

--- a/Base/res/html/misc/where-selector.html
+++ b/Base/res/html/misc/where-selector.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>:where() test</title>
+    <style>
+        div {
+            border: 1px solid black;
+            margin-bottom: 1em;
+            padding: 0 0.5em;
+        }
+        .special :where(h2, p) {
+            background-color: lime;
+        }
+        .forgiving :where(&&&fakhsdaskjhd, h2, p) {
+            background-color: lime;
+        }
+    </style>
+</head>
+<body>
+    <h1>:where() test</h1>
+    <div>
+        <h2>Nothing</h2>
+        <p>These should have no background.</p>
+    </div>
+    <br/>
+    <div class="special">
+        <h2>.special :where(h2, p)</h2>
+        <p>These should have a green background.</p>
+    </div>
+    <br/>
+    <div class="forgiving">
+        <h2>.forgiving :where(&&&fakhsdaskjhd, h2, p)</h2>
+        <p>These should have a green background. :where() takes a "permissive selector list",
+            so even though part of it is invalid, this does not make the whole selector-list invalid.</p>
+    </div>
+</body>
+</html>

--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -213,18 +213,11 @@ ol {
     list-style-type: decimal;
 }
 
-/* FIXME: Implement these using :is() :^) */
-/* :is(ul, ol) ul */
-ul ul,
-ol ul {
+:is(ul, ol) ul {
     list-style-type: circle;
 }
 
-/* :is(ul, ol) :is(ul, ol) ul */
-ul ul ul,
-ol ul ul,
-ul ol ul,
-ol ol ul {
+:is(ul, ol) :is(ul, ol) ul {
     list-style-type: square;
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -593,7 +593,14 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
             };
 
             auto& pseudo_function = pseudo_class_token.function();
-            if (pseudo_function.name().equals_ignoring_case("not")) {
+            if (pseudo_function.name().equals_ignoring_case("is"sv)) {
+                simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Is;
+                auto function_token_stream = TokenStream(pseudo_function.values());
+                auto is_selector = parse_a_selector_list(function_token_stream, SelectorParsingMode::Forgiving);
+                // NOTE: Because it's forgiving, even complete garbage will parse OK as an empty selector-list.
+                VERIFY(!is_selector.is_error());
+                simple_selector.pseudo_class.argument_selector_list = is_selector.release_value();
+            } else if (pseudo_function.name().equals_ignoring_case("not"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Not;
                 auto function_token_stream = TokenStream(pseudo_function.values());
                 auto not_selector = parse_a_selector_list(function_token_stream);
@@ -601,20 +608,20 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                     dbgln_if(CSS_PARSER_DEBUG, "Invalid selector in :not() clause");
                     return ParsingResult::SyntaxError;
                 }
-                simple_selector.pseudo_class.not_selector = not_selector.release_value();
-            } else if (pseudo_function.name().equals_ignoring_case("nth-child")) {
+                simple_selector.pseudo_class.argument_selector_list = not_selector.release_value();
+            } else if (pseudo_function.name().equals_ignoring_case("nth-child"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::NthChild;
                 if (!parse_nth_child_pattern(simple_selector, pseudo_function))
                     return ParsingResult::SyntaxError;
-            } else if (pseudo_function.name().equals_ignoring_case("nth-last-child")) {
+            } else if (pseudo_function.name().equals_ignoring_case("nth-last-child"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::NthLastChild;
                 if (!parse_nth_child_pattern(simple_selector, pseudo_function))
                     return ParsingResult::SyntaxError;
-            } else if (pseudo_function.name().equals_ignoring_case("nth-of-type")) {
+            } else if (pseudo_function.name().equals_ignoring_case("nth-of-type"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::NthOfType;
                 if (!parse_nth_child_pattern(simple_selector, pseudo_function))
                     return ParsingResult::SyntaxError;
-            } else if (pseudo_function.name().equals_ignoring_case("nth-last-of-type")) {
+            } else if (pseudo_function.name().equals_ignoring_case("nth-last-of-type"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::NthLastOfType;
                 if (!parse_nth_child_pattern(simple_selector, pseudo_function))
                     return ParsingResult::SyntaxError;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -190,7 +190,7 @@ NonnullRefPtr<CSSStyleSheet> Parser::parse_a_stylesheet(TokenStream<T>& tokens)
 
 Optional<SelectorList> Parser::parse_as_selector(SelectorParsingMode parsing_mode)
 {
-    auto selector_list = parse_a_selector_list(m_token_stream, parsing_mode);
+    auto selector_list = parse_a_selector_list(m_token_stream, SelectorType::Standalone, parsing_mode);
     if (!selector_list.is_error())
         return selector_list.release_value();
 
@@ -199,7 +199,7 @@ Optional<SelectorList> Parser::parse_as_selector(SelectorParsingMode parsing_mod
 
 Optional<SelectorList> Parser::parse_as_relative_selector(SelectorParsingMode parsing_mode)
 {
-    auto selector_list = parse_a_relative_selector_list(m_token_stream, parsing_mode);
+    auto selector_list = parse_a_selector_list(m_token_stream, SelectorType::Relative, parsing_mode);
     if (!selector_list.is_error())
         return selector_list.release_value();
 
@@ -207,14 +207,14 @@ Optional<SelectorList> Parser::parse_as_relative_selector(SelectorParsingMode pa
 }
 
 template<typename T>
-Result<SelectorList, Parser::ParsingResult> Parser::parse_a_selector_list(TokenStream<T>& tokens, SelectorParsingMode parsing_mode)
+Result<SelectorList, Parser::ParsingResult> Parser::parse_a_selector_list(TokenStream<T>& tokens, SelectorType mode, SelectorParsingMode parsing_mode)
 {
     auto comma_separated_lists = parse_a_comma_separated_list_of_component_values(tokens);
 
     NonnullRefPtrVector<Selector> selectors;
     for (auto& selector_parts : comma_separated_lists) {
         auto stream = TokenStream(selector_parts);
-        auto selector = parse_complex_selector(stream, false);
+        auto selector = parse_complex_selector(stream, mode);
         if (selector.is_error()) {
             if (parsing_mode == SelectorParsingMode::Forgiving)
                 continue;
@@ -229,37 +229,14 @@ Result<SelectorList, Parser::ParsingResult> Parser::parse_a_selector_list(TokenS
     return selectors;
 }
 
-template<typename T>
-Result<SelectorList, Parser::ParsingResult> Parser::parse_a_relative_selector_list(TokenStream<T>& tokens, SelectorParsingMode parsing_mode)
-{
-    auto comma_separated_lists = parse_a_comma_separated_list_of_component_values(tokens);
-
-    NonnullRefPtrVector<Selector> selectors;
-    for (auto& selector_parts : comma_separated_lists) {
-        auto stream = TokenStream(selector_parts);
-        auto selector = parse_complex_selector(stream, true);
-        if (selector.is_error()) {
-            if (parsing_mode == SelectorParsingMode::Forgiving)
-                continue;
-            return selector.error();
-        }
-        selectors.append(selector.release_value());
-    }
-
-    if (selectors.is_empty() && parsing_mode != SelectorParsingMode::Forgiving)
-        return ParsingResult::SyntaxError;
-
-    return selectors;
-}
-
-Result<NonnullRefPtr<Selector>, Parser::ParsingResult> Parser::parse_complex_selector(TokenStream<StyleComponentValueRule>& tokens, bool allow_starting_combinator)
+Result<NonnullRefPtr<Selector>, Parser::ParsingResult> Parser::parse_complex_selector(TokenStream<StyleComponentValueRule>& tokens, SelectorType mode)
 {
     Vector<Selector::CompoundSelector> compound_selectors;
 
     auto first_selector = parse_compound_selector(tokens);
     if (first_selector.is_error())
         return first_selector.error();
-    if (!allow_starting_combinator) {
+    if (mode == SelectorType::Standalone) {
         if (first_selector.value().combinator != Selector::Combinator::Descendant)
             return ParsingResult::SyntaxError;
         first_selector.value().combinator = Selector::Combinator::None;
@@ -602,7 +579,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                     return false;
 
                 function_values.skip_whitespace();
-                auto selector_list = parse_a_selector_list(function_values);
+                auto selector_list = parse_a_selector_list(function_values, SelectorType::Standalone);
                 if (selector_list.is_error())
                     return false;
 
@@ -622,14 +599,14 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                     ? Selector::SimpleSelector::PseudoClass::Type::Is
                     : Selector::SimpleSelector::PseudoClass::Type::Where;
                 auto function_token_stream = TokenStream(pseudo_function.values());
-                auto argument_selector_list = parse_a_selector_list(function_token_stream, SelectorParsingMode::Forgiving);
+                auto argument_selector_list = parse_a_selector_list(function_token_stream, SelectorType::Standalone, SelectorParsingMode::Forgiving);
                 // NOTE: Because it's forgiving, even complete garbage will parse OK as an empty selector-list.
                 VERIFY(!argument_selector_list.is_error());
                 simple_selector.pseudo_class.argument_selector_list = argument_selector_list.release_value();
             } else if (pseudo_function.name().equals_ignoring_case("not"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Not;
                 auto function_token_stream = TokenStream(pseudo_function.values());
-                auto not_selector = parse_a_selector_list(function_token_stream);
+                auto not_selector = parse_a_selector_list(function_token_stream, SelectorType::Standalone);
                 if (not_selector.is_error()) {
                     dbgln_if(CSS_PARSER_DEBUG, "Invalid selector in :not() clause");
                     return ParsingResult::SyntaxError;
@@ -2123,7 +2100,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
 
     } else {
         auto prelude_stream = TokenStream(rule->m_prelude);
-        auto selectors = parse_a_selector_list(prelude_stream);
+        auto selectors = parse_a_selector_list(prelude_stream, SelectorType::Standalone);
 
         if (selectors.is_error()) {
             if (selectors.error() != ParsingResult::IncludesIgnoredVendorPrefix) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -580,15 +580,37 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
 
         } else if (pseudo_class_token.is_function()) {
 
-            auto parse_nth_child_pattern = [this](auto& simple_selector, auto& pseudo_function) -> bool {
+            auto parse_nth_child_pattern = [this](Selector::SimpleSelector& simple_selector, StyleFunctionRule const& pseudo_function, bool allow_of = false) -> bool {
                 auto function_values = TokenStream<StyleComponentValueRule>(pseudo_function.values());
-                auto nth_child_pattern = parse_a_n_plus_b_pattern(function_values);
+                auto nth_child_pattern = parse_a_n_plus_b_pattern(function_values, allow_of ? AllowTrailingTokens::Yes : AllowTrailingTokens::No);
                 if (nth_child_pattern.has_value()) {
                     simple_selector.pseudo_class.nth_child_pattern = nth_child_pattern.value();
                 } else {
                     dbgln_if(CSS_PARSER_DEBUG, "!!! Invalid format for {}", pseudo_function.name());
                     return false;
                 }
+                if (!allow_of)
+                    return true;
+
+                function_values.skip_whitespace();
+                if (!function_values.has_next_token())
+                    return true;
+
+                // Parse the `of <selector-list>` syntax
+                auto& maybe_of = function_values.next_token();
+                if (!(maybe_of.is(Token::Type::Ident) && maybe_of.token().ident().equals_ignoring_case("of"sv)))
+                    return false;
+
+                function_values.skip_whitespace();
+                auto selector_list = parse_a_selector_list(function_values);
+                if (selector_list.is_error())
+                    return false;
+
+                function_values.skip_whitespace();
+                if (function_values.has_next_token())
+                    return false;
+
+                simple_selector.pseudo_class.argument_selector_list = selector_list.value();
                 return true;
             };
 
@@ -615,11 +637,11 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                 simple_selector.pseudo_class.argument_selector_list = not_selector.release_value();
             } else if (pseudo_function.name().equals_ignoring_case("nth-child"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::NthChild;
-                if (!parse_nth_child_pattern(simple_selector, pseudo_function))
+                if (!parse_nth_child_pattern(simple_selector, pseudo_function, true))
                     return ParsingResult::SyntaxError;
             } else if (pseudo_function.name().equals_ignoring_case("nth-last-child"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::NthLastChild;
-                if (!parse_nth_child_pattern(simple_selector, pseudo_function))
+                if (!parse_nth_child_pattern(simple_selector, pseudo_function, true))
                     return ParsingResult::SyntaxError;
             } else if (pseudo_function.name().equals_ignoring_case("nth-of-type"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::NthOfType;
@@ -4138,7 +4160,7 @@ RefPtr<StyleValue> Parser::parse_css_value(StyleComponentValueRule const& compon
     return {};
 }
 
-Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_pattern(TokenStream<StyleComponentValueRule>& values)
+Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_pattern(TokenStream<StyleComponentValueRule>& values, AllowTrailingTokens allow_trailing_tokens)
 {
     int a = 0;
     int b = 0;
@@ -4154,7 +4176,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     auto make_return_value = [&]() -> Optional<Selector::SimpleSelector::ANPlusBPattern> {
         // When we think we are done, but there are more non-whitespace tokens, then it's a parse error.
         values.skip_whitespace();
-        if (values.has_next_token()) {
+        if (values.has_next_token() && allow_trailing_tokens == AllowTrailingTokens::No) {
             if constexpr (CSS_PARSER_DEBUG) {
                 dbgln_if(CSS_PARSER_DEBUG, "Extra tokens at end of An+B value:");
                 values.dump_all_tokens();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -593,13 +593,17 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
             };
 
             auto& pseudo_function = pseudo_class_token.function();
-            if (pseudo_function.name().equals_ignoring_case("is"sv)) {
-                simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Is;
+            if (pseudo_function.name().equals_ignoring_case("is"sv)
+                || pseudo_function.name().equals_ignoring_case("where"sv)) {
+
+                simple_selector.pseudo_class.type = pseudo_function.name().equals_ignoring_case("is"sv)
+                    ? Selector::SimpleSelector::PseudoClass::Type::Is
+                    : Selector::SimpleSelector::PseudoClass::Type::Where;
                 auto function_token_stream = TokenStream(pseudo_function.values());
-                auto is_selector = parse_a_selector_list(function_token_stream, SelectorParsingMode::Forgiving);
+                auto argument_selector_list = parse_a_selector_list(function_token_stream, SelectorParsingMode::Forgiving);
                 // NOTE: Because it's forgiving, even complete garbage will parse OK as an empty selector-list.
-                VERIFY(!is_selector.is_error());
-                simple_selector.pseudo_class.argument_selector_list = is_selector.release_value();
+                VERIFY(!argument_selector_list.is_error());
+                simple_selector.pseudo_class.argument_selector_list = argument_selector_list.release_value();
             } else if (pseudo_function.name().equals_ignoring_case("not"sv)) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Not;
                 auto function_token_stream = TokenStream(pseudo_function.values());

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -188,9 +188,18 @@ NonnullRefPtr<CSSStyleSheet> Parser::parse_a_stylesheet(TokenStream<T>& tokens)
     return CSSStyleSheet::create(rules);
 }
 
-Optional<SelectorList> Parser::parse_as_selector()
+Optional<SelectorList> Parser::parse_as_selector(SelectorParsingMode parsing_mode)
 {
-    auto selector_list = parse_a_selector(m_token_stream);
+    auto selector_list = parse_a_selector_list(m_token_stream, parsing_mode);
+    if (!selector_list.is_error())
+        return selector_list.release_value();
+
+    return {};
+}
+
+Optional<SelectorList> Parser::parse_as_relative_selector(SelectorParsingMode parsing_mode)
+{
+    auto selector_list = parse_a_relative_selector_list(m_token_stream, parsing_mode);
     if (!selector_list.is_error())
         return selector_list.release_value();
 
@@ -198,28 +207,7 @@ Optional<SelectorList> Parser::parse_as_selector()
 }
 
 template<typename T>
-Result<SelectorList, Parser::ParsingResult> Parser::parse_a_selector(TokenStream<T>& tokens)
-{
-    return parse_a_selector_list(tokens);
-}
-
-Optional<SelectorList> Parser::parse_as_relative_selector()
-{
-    auto selector_list = parse_a_relative_selector(m_token_stream);
-    if (!selector_list.is_error())
-        return selector_list.release_value();
-
-    return {};
-}
-
-template<typename T>
-Result<SelectorList, Parser::ParsingResult> Parser::parse_a_relative_selector(TokenStream<T>& tokens)
-{
-    return parse_a_relative_selector_list(tokens);
-}
-
-template<typename T>
-Result<SelectorList, Parser::ParsingResult> Parser::parse_a_selector_list(TokenStream<T>& tokens)
+Result<SelectorList, Parser::ParsingResult> Parser::parse_a_selector_list(TokenStream<T>& tokens, SelectorParsingMode parsing_mode)
 {
     auto comma_separated_lists = parse_a_comma_separated_list_of_component_values(tokens);
 
@@ -227,19 +215,22 @@ Result<SelectorList, Parser::ParsingResult> Parser::parse_a_selector_list(TokenS
     for (auto& selector_parts : comma_separated_lists) {
         auto stream = TokenStream(selector_parts);
         auto selector = parse_complex_selector(stream, false);
-        if (selector.is_error())
+        if (selector.is_error()) {
+            if (parsing_mode == SelectorParsingMode::Forgiving)
+                continue;
             return selector.error();
+        }
         selectors.append(selector.release_value());
     }
 
-    if (selectors.is_empty())
+    if (selectors.is_empty() && parsing_mode != SelectorParsingMode::Forgiving)
         return ParsingResult::SyntaxError;
 
     return selectors;
 }
 
 template<typename T>
-Result<SelectorList, Parser::ParsingResult> Parser::parse_a_relative_selector_list(TokenStream<T>& tokens)
+Result<SelectorList, Parser::ParsingResult> Parser::parse_a_relative_selector_list(TokenStream<T>& tokens, SelectorParsingMode parsing_mode)
 {
     auto comma_separated_lists = parse_a_comma_separated_list_of_component_values(tokens);
 
@@ -247,12 +238,15 @@ Result<SelectorList, Parser::ParsingResult> Parser::parse_a_relative_selector_li
     for (auto& selector_parts : comma_separated_lists) {
         auto stream = TokenStream(selector_parts);
         auto selector = parse_complex_selector(stream, true);
-        if (selector.is_error())
+        if (selector.is_error()) {
+            if (parsing_mode == SelectorParsingMode::Forgiving)
+                continue;
             return selector.error();
+        }
         selectors.append(selector.release_value());
     }
 
-    if (selectors.is_empty())
+    if (selectors.is_empty() && parsing_mode != SelectorParsingMode::Forgiving)
         return ParsingResult::SyntaxError;
 
     return selectors;
@@ -602,7 +596,7 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
             if (pseudo_function.name().equals_ignoring_case("not")) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Not;
                 auto function_token_stream = TokenStream(pseudo_function.values());
-                auto not_selector = parse_a_selector(function_token_stream);
+                auto not_selector = parse_a_selector_list(function_token_stream);
                 if (not_selector.is_error()) {
                     dbgln_if(CSS_PARSER_DEBUG, "Invalid selector in :not() clause");
                     return ParsingResult::SyntaxError;
@@ -2096,7 +2090,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
 
     } else {
         auto prelude_stream = TokenStream(rule->m_prelude);
-        auto selectors = parse_a_selector(prelude_stream);
+        auto selectors = parse_a_selector_list(prelude_stream);
 
         if (selectors.is_error()) {
             if (selectors.error() != ParsingResult::IncludesIgnoredVendorPrefix) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -105,9 +105,16 @@ public:
     Vector<StyleComponentValueRule> parse_as_list_of_component_values();
     Vector<Vector<StyleComponentValueRule>> parse_as_comma_separated_list_of_component_values();
 
+    enum class SelectorParsingMode {
+        Standard,
+        // `<forgiving-selector-list>` and `<forgiving-relative-selector-list>`
+        // are handled with this parameter, not as separate functions.
+        // https://drafts.csswg.org/selectors/#forgiving-selector
+        Forgiving
+    };
     // Contrary to the name, these parse a comma-separated list of selectors, according to the spec.
-    Optional<SelectorList> parse_as_selector();
-    Optional<SelectorList> parse_as_relative_selector();
+    Optional<SelectorList> parse_as_selector(SelectorParsingMode = SelectorParsingMode::Standard);
+    Optional<SelectorList> parse_as_relative_selector(SelectorParsingMode = SelectorParsingMode::Standard);
 
     NonnullRefPtrVector<MediaQuery> parse_as_media_query_list();
     RefPtr<MediaQuery> parse_as_media_query();
@@ -142,13 +149,9 @@ private:
     template<typename T>
     Vector<Vector<StyleComponentValueRule>> parse_a_comma_separated_list_of_component_values(TokenStream<T>&);
     template<typename T>
-    Result<SelectorList, ParsingResult> parse_a_selector(TokenStream<T>&);
+    Result<SelectorList, ParsingResult> parse_a_selector_list(TokenStream<T>&, SelectorParsingMode = SelectorParsingMode::Standard);
     template<typename T>
-    Result<SelectorList, ParsingResult> parse_a_relative_selector(TokenStream<T>&);
-    template<typename T>
-    Result<SelectorList, ParsingResult> parse_a_selector_list(TokenStream<T>&);
-    template<typename T>
-    Result<SelectorList, ParsingResult> parse_a_relative_selector_list(TokenStream<T>&);
+    Result<SelectorList, ParsingResult> parse_a_relative_selector_list(TokenStream<T>&, SelectorParsingMode = SelectorParsingMode::Standard);
     template<typename T>
     NonnullRefPtrVector<MediaQuery> parse_a_media_query_list(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -157,7 +157,11 @@ private:
     template<typename T>
     RefPtr<Supports> parse_a_supports(TokenStream<T>&);
 
-    Optional<Selector::SimpleSelector::ANPlusBPattern> parse_a_n_plus_b_pattern(TokenStream<StyleComponentValueRule>&);
+    enum class AllowTrailingTokens {
+        No,
+        Yes
+    };
+    Optional<Selector::SimpleSelector::ANPlusBPattern> parse_a_n_plus_b_pattern(TokenStream<StyleComponentValueRule>&, AllowTrailingTokens = AllowTrailingTokens::No);
 
     template<typename T>
     [[nodiscard]] NonnullRefPtrVector<StyleRule> consume_a_list_of_rules(TokenStream<T>&, bool top_level);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -148,10 +148,14 @@ private:
     Vector<StyleComponentValueRule> parse_a_list_of_component_values(TokenStream<T>&);
     template<typename T>
     Vector<Vector<StyleComponentValueRule>> parse_a_comma_separated_list_of_component_values(TokenStream<T>&);
+
+    enum class SelectorType {
+        Standalone,
+        Relative
+    };
     template<typename T>
-    Result<SelectorList, ParsingResult> parse_a_selector_list(TokenStream<T>&, SelectorParsingMode = SelectorParsingMode::Standard);
-    template<typename T>
-    Result<SelectorList, ParsingResult> parse_a_relative_selector_list(TokenStream<T>&, SelectorParsingMode = SelectorParsingMode::Standard);
+    Result<SelectorList, ParsingResult> parse_a_selector_list(TokenStream<T>&, SelectorType, SelectorParsingMode = SelectorParsingMode::Standard);
+
     template<typename T>
     NonnullRefPtrVector<MediaQuery> parse_a_media_query_list(TokenStream<T>&);
     template<typename T>
@@ -308,7 +312,7 @@ private:
     OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(TokenStream<StyleComponentValueRule>&);
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(Vector<StyleComponentValueRule> const&);
 
-    Result<NonnullRefPtr<Selector>, ParsingResult> parse_complex_selector(TokenStream<StyleComponentValueRule>&, bool allow_starting_combinator);
+    Result<NonnullRefPtr<Selector>, ParsingResult> parse_complex_selector(TokenStream<StyleComponentValueRule>&, SelectorType);
     Result<Selector::CompoundSelector, ParsingResult> parse_compound_selector(TokenStream<StyleComponentValueRule>&);
     Optional<Selector::Combinator> parse_selector_combinator(TokenStream<StyleComponentValueRule>&);
     Result<Selector::SimpleSelector, ParsingResult> parse_simple_selector(TokenStream<StyleComponentValueRule>&);

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -163,6 +163,7 @@ String Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
         case Selector::SimpleSelector::PseudoClass::Type::Not:
         case Selector::SimpleSelector::PseudoClass::Type::Is:
+        case Selector::SimpleSelector::PseudoClass::Type::Where:
             // Otherwise, append ":" (U+003A), followed by the name of the pseudo-class, followed by "(" (U+0028),
             // followed by the value of the pseudo-class argument(s) determined as per below, followed by ")" (U+0029), to s.
             s.append(':');
@@ -173,9 +174,10 @@ String Selector::SimpleSelector::serialize() const
                 // The result of serializing the value using the rules to serialize an <an+b> value.
                 s.append(pseudo_class.nth_child_pattern.serialize());
             } else if (pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Not
-                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Is) {
+                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Is
+                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Where) {
                 // The result of serializing the value using the rules for serializing a group of selectors.
-                // NOTE: `:is()` isn't in the spec for this yet, but it should be!
+                // NOTE: `:is()` and `:where()` aren't in the spec for this yet, but it should be!
                 s.append(serialize_a_group_of_selectors(pseudo_class.argument_selector_list));
             }
             s.append(')');

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -46,6 +46,21 @@ u32 Selector::specificity() const
     u32 classes = 0;
     u32 tag_names = 0;
 
+    auto count_specificity_of_most_complex_selector = [&](auto& selector_list) {
+        u32 max_selector_list_argument_specificity = 0;
+        for (auto const& complex_selector : selector_list) {
+            max_selector_list_argument_specificity = max(max_selector_list_argument_specificity, complex_selector.specificity());
+        }
+
+        u32 child_ids = (max_selector_list_argument_specificity & ids_mask) >> ids_shift;
+        u32 child_classes = (max_selector_list_argument_specificity & classes_mask) >> classes_shift;
+        u32 child_tag_names = (max_selector_list_argument_specificity & tag_names_mask) >> tag_names_shift;
+
+        ids += child_ids;
+        classes += child_classes;
+        tag_names += child_tag_names;
+    };
+
     for (auto& list : m_compound_selectors) {
         for (auto& simple_selector : list.simple_selectors) {
             switch (simple_selector.type) {
@@ -64,18 +79,16 @@ u32 Selector::specificity() const
                 case SimpleSelector::PseudoClass::Type::Not: {
                     // The specificity of an :is(), :not(), or :has() pseudo-class is replaced by the
                     // specificity of the most specific complex selector in its selector list argument.
-                    u32 max_selector_list_argument_specificity = 0;
-                    for (auto const& complex_selector : simple_selector.pseudo_class.argument_selector_list) {
-                        max_selector_list_argument_specificity = max(max_selector_list_argument_specificity, complex_selector.specificity());
-                    }
-
-                    u32 child_ids = (max_selector_list_argument_specificity & ids_mask) >> ids_shift;
-                    u32 child_classes = (max_selector_list_argument_specificity & classes_mask) >> classes_shift;
-                    u32 child_tag_names = (max_selector_list_argument_specificity & tag_names_mask) >> tag_names_shift;
-
-                    ids += child_ids;
-                    classes += child_classes;
-                    tag_names += child_tag_names;
+                    count_specificity_of_most_complex_selector(simple_selector.pseudo_class.argument_selector_list);
+                    break;
+                }
+                case SimpleSelector::PseudoClass::Type::NthChild:
+                case SimpleSelector::PseudoClass::Type::NthLastChild: {
+                    // Analogously, the specificity of an :nth-child() or :nth-last-child() selector
+                    // is the specificity of the pseudo class itself (counting as one pseudo-class selector)
+                    // plus the specificity of the most specific complex selector in its selector list argument (if any).
+                    ++classes;
+                    count_specificity_of_most_complex_selector(simple_selector.pseudo_class.argument_selector_list);
                     break;
                 }
                 case SimpleSelector::PseudoClass::Type::Where:

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -162,6 +162,7 @@ String Selector::SimpleSelector::serialize() const
         case Selector::SimpleSelector::PseudoClass::Type::NthChild:
         case Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
         case Selector::SimpleSelector::PseudoClass::Type::Not:
+        case Selector::SimpleSelector::PseudoClass::Type::Is:
             // Otherwise, append ":" (U+003A), followed by the name of the pseudo-class, followed by "(" (U+0028),
             // followed by the value of the pseudo-class argument(s) determined as per below, followed by ")" (U+0029), to s.
             s.append(':');
@@ -171,9 +172,11 @@ String Selector::SimpleSelector::serialize() const
                 || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::NthLastChild) {
                 // The result of serializing the value using the rules to serialize an <an+b> value.
                 s.append(pseudo_class.nth_child_pattern.serialize());
-            } else if (pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Not) {
+            } else if (pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Not
+                || pseudo_class.type == Selector::SimpleSelector::PseudoClass::Type::Is) {
                 // The result of serializing the value using the rules for serializing a group of selectors.
-                s.append(serialize_a_group_of_selectors(pseudo_class.not_selector));
+                // NOTE: `:is()` isn't in the spec for this yet, but it should be!
+                s.append(serialize_a_group_of_selectors(pseudo_class.argument_selector_list));
             }
             s.append(')');
             break;

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -35,32 +35,76 @@ u32 Selector::specificity() const
     if (m_specificity.has_value())
         return *m_specificity;
 
-    unsigned ids = 0;
-    unsigned tag_names = 0;
-    unsigned classes = 0;
+    constexpr u32 ids_shift = 16;
+    constexpr u32 classes_shift = 8;
+    constexpr u32 tag_names_shift = 0;
+    constexpr u32 ids_mask = 0xff << ids_shift;
+    constexpr u32 classes_mask = 0xff << classes_shift;
+    constexpr u32 tag_names_mask = 0xff << tag_names_shift;
+
+    u32 ids = 0;
+    u32 classes = 0;
+    u32 tag_names = 0;
 
     for (auto& list : m_compound_selectors) {
         for (auto& simple_selector : list.simple_selectors) {
             switch (simple_selector.type) {
             case SimpleSelector::Type::Id:
+                // count the number of ID selectors in the selector (= A)
                 ++ids;
                 break;
             case SimpleSelector::Type::Class:
             case SimpleSelector::Type::Attribute:
-            case SimpleSelector::Type::PseudoClass:
+                // count the number of class selectors, attributes selectors, and pseudo-classes in the selector (= B)
                 ++classes;
+                break;
+            case SimpleSelector::Type::PseudoClass:
+                switch (simple_selector.pseudo_class.type) {
+                case SimpleSelector::PseudoClass::Type::Is:
+                case SimpleSelector::PseudoClass::Type::Not: {
+                    // The specificity of an :is(), :not(), or :has() pseudo-class is replaced by the
+                    // specificity of the most specific complex selector in its selector list argument.
+                    u32 max_selector_list_argument_specificity = 0;
+                    for (auto const& complex_selector : simple_selector.pseudo_class.argument_selector_list) {
+                        max_selector_list_argument_specificity = max(max_selector_list_argument_specificity, complex_selector.specificity());
+                    }
+
+                    u32 child_ids = (max_selector_list_argument_specificity & ids_mask) >> ids_shift;
+                    u32 child_classes = (max_selector_list_argument_specificity & classes_mask) >> classes_shift;
+                    u32 child_tag_names = (max_selector_list_argument_specificity & tag_names_mask) >> tag_names_shift;
+
+                    ids += child_ids;
+                    classes += child_classes;
+                    tag_names += child_tag_names;
+                    break;
+                }
+                case SimpleSelector::PseudoClass::Type::Where:
+                    // The specificity of a :where() pseudo-class is replaced by zero.
+                    break;
+                default:
+                    ++classes;
+                    break;
+                }
                 break;
             case SimpleSelector::Type::TagName:
             case SimpleSelector::Type::PseudoElement:
+                // count the number of type selectors and pseudo-elements in the selector (= C)
                 ++tag_names;
                 break;
-            default:
+            case SimpleSelector::Type::Universal:
+                // ignore the universal selector
+                break;
+            case SimpleSelector::Type::Invalid:
                 break;
             }
         }
     }
 
-    m_specificity = ids * 0x10000 + classes * 0x100 + tag_names;
+    // Due to storage limitations, implementations may have limitations on the size of A, B, or C.
+    // If so, values higher than the limit must be clamped to that limit, and not overflow.
+    m_specificity = (min(ids, 0xff) << ids_shift)
+        + (min(classes, 0xff) << classes_shift)
+        + (min(tag_names, 0xff) << tag_names_shift);
 
     return *m_specificity;
 }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -77,6 +77,7 @@ public:
                 Checked,
                 Is,
                 Not,
+                Where,
                 Active,
             };
             Type type { Type::None };
@@ -216,6 +217,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "is"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Not:
         return "not"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Where:
+        return "where"sv;
     case Selector::SimpleSelector::PseudoClass::Type::None:
         break;
     }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -75,6 +75,7 @@ public:
                 Disabled,
                 Enabled,
                 Checked,
+                Is,
                 Not,
                 Active,
             };
@@ -84,7 +85,7 @@ public:
             // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
             ANPlusBPattern nth_child_pattern;
 
-            SelectorList not_selector {};
+            SelectorList argument_selector_list {};
         };
         PseudoClass pseudo_class {};
         PseudoElement pseudo_element { PseudoElement::None };
@@ -211,6 +212,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "nth-child"sv;
     case Selector::SimpleSelector::PseudoClass::Type::NthLastChild:
         return "nth-last-child"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::Is:
+        return "is"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Not:
         return "not"sv;
     case Selector::SimpleSelector::PseudoClass::Type::None:

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -155,6 +155,7 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
     case CSS::Selector::SimpleSelector::PseudoClass::Type::Checked:
         return matches_checked_pseudo_class(element);
     case CSS::Selector::SimpleSelector::PseudoClass::Type::Is:
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Where:
         for (auto& selector : pseudo_class.argument_selector_list) {
             if (matches(selector, element))
                 return true;

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -180,16 +180,35 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         if (!parent)
             return false;
 
+        auto matches_selector_list = [](CSS::SelectorList const& list, DOM::Element const& element) {
+            if (list.is_empty())
+                return true;
+            for (auto const& child_selector : list) {
+                if (matches(child_selector, element)) {
+                    return true;
+                }
+            }
+            return false;
+        };
+
         int index = 1;
         switch (pseudo_class.type) {
         case CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild: {
-            for (auto* child = parent->first_child_of_type<DOM::Element>(); child && child != &element; child = child->next_element_sibling())
-                ++index;
+            if (!matches_selector_list(pseudo_class.argument_selector_list, element))
+                return false;
+            for (auto* child = parent->first_child_of_type<DOM::Element>(); child && child != &element; child = child->next_element_sibling()) {
+                if (matches_selector_list(pseudo_class.argument_selector_list, *child))
+                    ++index;
+            }
             break;
         }
         case CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild: {
-            for (auto* child = parent->last_child_of_type<DOM::Element>(); child && child != &element; child = child->previous_element_sibling())
-                ++index;
+            if (!matches_selector_list(pseudo_class.argument_selector_list, element))
+                return false;
+            for (auto* child = parent->last_child_of_type<DOM::Element>(); child && child != &element; child = child->previous_element_sibling()) {
+                if (matches_selector_list(pseudo_class.argument_selector_list, *child))
+                    ++index;
+            }
             break;
         }
         case CSS::Selector::SimpleSelector::PseudoClass::Type::NthOfType: {

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -154,8 +154,14 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         return true;
     case CSS::Selector::SimpleSelector::PseudoClass::Type::Checked:
         return matches_checked_pseudo_class(element);
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::Is:
+        for (auto& selector : pseudo_class.argument_selector_list) {
+            if (matches(selector, element))
+                return true;
+        }
+        return false;
     case CSS::Selector::SimpleSelector::PseudoClass::Type::Not:
-        for (auto& selector : pseudo_class.not_selector) {
+        for (auto& selector : pseudo_class.argument_selector_list) {
             if (matches(selector, element))
                 return false;
         }

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -430,12 +430,16 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Not:
                     pseudo_class_description = "Not";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Is:
+                    pseudo_class_description = "Is";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);
-                if (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Not) {
+                if (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Not
+                    || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Is) {
                     builder.append("([");
-                    for (auto& selector : pseudo_class.not_selector)
+                    for (auto& selector : pseudo_class.argument_selector_list)
                         dump_selector(builder, selector);
                     builder.append("])");
                 } else if ((pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild)

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -433,11 +433,15 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Is:
                     pseudo_class_description = "Is";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::Where:
+                    pseudo_class_description = "Where";
+                    break;
                 }
 
                 builder.appendff(" pseudo_class={}", pseudo_class_description);
                 if (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Not
-                    || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Is) {
+                    || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Is
+                    || pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::Where) {
                     builder.append("([");
                     for (auto& selector : pseudo_class.argument_selector_list)
                         dump_selector(builder, selector);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -447,8 +447,17 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                         dump_selector(builder, selector);
                     builder.append("])");
                 } else if ((pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthChild)
-                    || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild)) {
-                    builder.appendff("(step={}, offset={})", pseudo_class.nth_child_pattern.step_size, pseudo_class.nth_child_pattern.offset);
+                    || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastChild)
+                    || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthOfType)
+                    || (pseudo_class.type == CSS::Selector::SimpleSelector::PseudoClass::Type::NthLastOfType)) {
+                    builder.appendff("(step={}, offset={}", pseudo_class.nth_child_pattern.step_size, pseudo_class.nth_child_pattern.offset);
+                    if (!pseudo_class.argument_selector_list.is_empty()) {
+                        builder.append(", selectors=[");
+                        for (auto const& child_selector : pseudo_class.argument_selector_list)
+                            dump_selector(builder, child_selector);
+                        builder.append("]");
+                    }
+                    builder.append(")");
                 }
             }
 


### PR DESCRIPTION
## `:is()`
Matches if any of the contained selectors match. This lets you shrink things like
```css
ul ul ul,
ol ul ul,
ul ol ul,
ol ol ul { }
```
into
```css
:is(ul, ol) :is(ul, ol) ul { }
```

## `:where()`
This behaves almost identically to `:is()`, except neither it nor its contents increase the specificity of the selector.

## `:nth-child(foo of bar)` (and same for `:nth-last-child()`)
Ever thought that `:nth-of-type()` is nice, but you'd like to give it arbitrary selectors to match instead of just the type name? This syntax is for you! After the An+B, put "or" followed by a selector-list and that acts as a filter for the elements that are counted.

## Fix specificity
We were calculating the specificity of `:not()` incorrectly. Now, that and the selectors listed above all calculate it correctly.