### PR TITLE
Kernel: Fix crash when opening GPU3DDevice without creating a context

### DIFF
--- a/Kernel/Graphics/VirtIOGPU/GPU3DDevice.cpp
+++ b/Kernel/Graphics/VirtIOGPU/GPU3DDevice.cpp
@@ -62,8 +62,7 @@ ErrorOr<void> GPU3DDevice::ioctl(OpenFileDescription& description, unsigned requ
         // TODO: Delete the context if it fails to be set in m_context_state_lookup
         auto context_id = m_graphics_adapter.create_context();
         RefPtr<PerContextState> per_context_state = TRY(PerContextState::try_create(context_id));
-        auto ref = RefPtr(description);
-        TRY(m_context_state_lookup.try_set(ref, per_context_state));
+        TRY(m_context_state_lookup.try_set(&description, per_context_state));
         return {};
     }
     case VIRGL_IOCTL_TRANSFER_DATA: {

--- a/Kernel/Graphics/VirtIOGPU/GPU3DDevice.h
+++ b/Kernel/Graphics/VirtIOGPU/GPU3DDevice.h
@@ -127,7 +127,7 @@ private:
     Kernel::Graphics::VirtIOGPU::GraphicsAdapter& m_graphics_adapter;
     // Context used for kernel operations (e.g. flushing resources to scanout)
     ContextID m_kernel_context_id;
-    HashMap<RefPtr<OpenFileDescription>, RefPtr<PerContextState>> m_context_state_lookup;
+    HashMap<OpenFileDescription*, RefPtr<PerContextState>> m_context_state_lookup;
     // Memory management for backing buffers
     OwnPtr<Memory::Region> m_transfer_buffer_region;
     constexpr static size_t NUM_TRANSFER_REGION_PAGES = 256;


### PR DESCRIPTION
Fixes #13105 