### PR TITLE
LibWeb: Mark more CSS properties as not affecting layout

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -11,6 +11,7 @@
     ]
   },
   "background": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "transparent",
     "longhands": [
@@ -25,6 +26,7 @@
     ]
   },
   "background-attachment": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "scroll",
     "valid-identifiers": [
@@ -34,6 +36,7 @@
     ]
   },
   "background-clip": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "border-box",
     "valid-identifiers": [
@@ -54,6 +57,7 @@
     ]
   },
   "background-image": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "none",
     "valid-types": [
@@ -64,6 +68,7 @@
     ]
   },
   "background-origin": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "padding-box",
     "valid-identifiers": [
@@ -73,6 +78,7 @@
     ]
   },
   "background-position": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "0% 0%",
     "max-values": 4,
@@ -92,6 +98,7 @@
     ]
   },
   "background-repeat": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "repeat",
     "max-values": 2,
@@ -105,6 +112,7 @@
     ]
   },
   "background-size": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "auto",
     "max-values": 2,
@@ -474,6 +482,7 @@
     ]
   },
   "box-shadow": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "none",
     "valid-identifiers": [
@@ -540,6 +549,7 @@
     ]
   },
   "cursor": {
+    "affects-layout": false,
     "inherited": true,
     "initial": "auto",
     "valid-types": [
@@ -616,6 +626,7 @@
     ]
   },
   "fill": {
+    "affects-layout": false,
     "inherited": true,
     "initial": "black",
     "valid-types": [
@@ -778,6 +789,7 @@
     ]
   },
   "image-rendering": {
+    "affects-layout": false,
     "inherited": true,
     "initial": "auto",
     "valid-identifiers": [
@@ -1030,6 +1042,7 @@
     ]
   },
   "outline": {
+    "affects-layout": false,
     "inherited": false,
     "__comment": "FIXME: Initial value is really `medium invert none` but we don't yet parse the outline shorthand.",
     "initial": "none",
@@ -1040,6 +1053,7 @@
     ]
   },
   "outline-color": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "invert",
     "valid-types": [
@@ -1050,6 +1064,7 @@
     ]
   },
   "outline-style": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "none",
     "valid-identifiers": [
@@ -1179,6 +1194,7 @@
     ]
   },
   "pointer-events": {
+    "affects-layout": false,
     "inherited": true,
     "initial": "auto",
     "valid-identifiers": [
@@ -1213,6 +1229,7 @@
     ]
   },
   "stroke": {
+    "affects-layout": false,
     "inherited": true,
     "initial": "none",
     "valid-types": [
@@ -1223,6 +1240,7 @@
     ]
   },
   "stroke-width": {
+    "affects-layout": false,
     "inherited": true,
     "initial": "1px",
     "valid-types": [
@@ -1352,6 +1370,7 @@
     "initial": "none"
   },
   "user-select": {
+    "affects-layout": false,
     "inherited": false,
     "initial": "auto",
     "valid-identifiers": [


### PR DESCRIPTION
- background properties
- box-shadow
- cursor
- SVG fill/stroke properties
- image-rendering
- outline properties
- pointer-events
- user-select

This should be basically all of them. I skipped `opacity` and
`transform` since establishing a stacking context feels like a
layout-affecting thing, but I could be very wrong on that!