### PR TITLE
Everywhere: Deduplicate day/month name constants

### DIFF
--- a/AK/DateConstants.h
+++ b/AK/DateConstants.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Array.h>
+#include <AK/StringView.h>
+
+namespace AK {
+
+static constexpr Array<StringView, 7> long_day_names = {
+    "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
+};
+
+static constexpr Array<StringView, 7> short_day_names = {
+    "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
+};
+
+static constexpr Array<StringView, 7> mini_day_names = {
+    "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"
+};
+
+static constexpr Array<StringView, 7> micro_day_names = {
+    "S", "M", "T", "W", "T", "F", "S"
+};
+
+static constexpr Array<StringView, 12> long_month_names = {
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December"
+};
+
+static constexpr Array<StringView, 12> short_month_names = {
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+};
+
+}
+
+using AK::long_day_names;
+using AK::long_month_names;
+using AK::micro_day_names;
+using AK::mini_day_names;
+using AK::short_day_names;
+using AK::short_month_names;

--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "../LibUnicode/GeneratorUtil.h" // FIXME: Move this somewhere common.
+#include <AK/DateConstants.h>
 #include <AK/Format.h>
 #include <AK/HashMap.h>
 #include <AK/SourceGenerator.h>
@@ -143,9 +144,6 @@ struct AK::Formatter<TimeZone::Location> : Formatter<FormatString> {
 
 static Optional<DateTime> parse_date_time(Span<StringView const> segments)
 {
-    constexpr auto months = Array { "Jan"sv, "Feb"sv, "Mar"sv, "Apr"sv, "May"sv, "Jun"sv, "Jul"sv, "Aug"sv, "Sep"sv, "Oct"sv, "Nov"sv, "Dec"sv };
-    constexpr auto weekdays = Array { "Sun"sv, "Mon"sv, "Tue"sv, "Wed"sv, "Thu"sv, "Fri"sv, "Sat"sv };
-
     auto comment_index = find_index(segments.begin(), segments.end(), "#"sv);
     if (comment_index != segments.size())
         segments = segments.slice(0, comment_index);
@@ -156,21 +154,21 @@ static Optional<DateTime> parse_date_time(Span<StringView const> segments)
     date_time.year = segments[0].to_uint().value();
 
     if (segments.size() > 1)
-        date_time.month = find_index(months.begin(), months.end(), segments[1]) + 1;
+        date_time.month = find_index(short_month_names.begin(), short_month_names.end(), segments[1]) + 1;
 
     if (segments.size() > 2) {
         if (segments[2].starts_with("last"sv)) {
             auto weekday = segments[2].substring_view("last"sv.length());
-            date_time.last_weekday = find_index(weekdays.begin(), weekdays.end(), weekday);
+            date_time.last_weekday = find_index(short_day_names.begin(), short_day_names.end(), weekday);
         } else if (auto index = segments[2].find(">="sv); index.has_value()) {
             auto weekday = segments[2].substring_view(0, *index);
-            date_time.after_weekday = find_index(weekdays.begin(), weekdays.end(), weekday);
+            date_time.after_weekday = find_index(short_day_names.begin(), short_day_names.end(), weekday);
 
             auto day = segments[2].substring_view(*index + ">="sv.length());
             date_time.day = day.to_uint().value();
         } else if (auto index = segments[2].find("<="sv); index.has_value()) {
             auto weekday = segments[2].substring_view(0, *index);
-            date_time.before_weekday = find_index(weekdays.begin(), weekdays.end(), weekday);
+            date_time.before_weekday = find_index(short_day_names.begin(), short_day_names.end(), weekday);
 
             auto day = segments[2].substring_view(*index + "<="sv.length());
             date_time.day = day.to_uint().value();

--- a/Userland/Libraries/LibC/langinfo.cpp
+++ b/Userland/Libraries/LibC/langinfo.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/DateConstants.h>
 #include <langinfo.h>
 
 // Values taken from glibc's en_US locale files.
@@ -25,81 +26,47 @@ static const char* __nl_langinfo(nl_item item)
     case PM_STR:
         return "PM";
     case DAY_1:
-        return "Sunday";
     case DAY_2:
-        return "Monday";
     case DAY_3:
-        return "Tuesday";
     case DAY_4:
-        return "Wednesday";
     case DAY_5:
-        return "Thursday";
     case DAY_6:
-        return "Friday";
     case DAY_7:
-        return "Saturday";
+        return long_day_names[item - DAY_1].characters_without_null_termination();
     case ABDAY_1:
-        return "Sun";
     case ABDAY_2:
-        return "Mon";
     case ABDAY_3:
-        return "Tue";
     case ABDAY_4:
-        return "Wed";
     case ABDAY_5:
-        return "Thu";
     case ABDAY_6:
-        return "Fri";
     case ABDAY_7:
-        return "Sat";
+        return short_day_names[item - ABDAY_1].characters_without_null_termination();
     case MON_1:
-        return "January";
     case MON_2:
-        return "February";
     case MON_3:
-        return "March";
     case MON_4:
-        return "April";
     case MON_5:
-        return "May";
     case MON_6:
-        return "June";
     case MON_7:
-        return "July";
     case MON_8:
-        return "August";
     case MON_9:
-        return "September";
     case MON_10:
-        return "October";
     case MON_11:
-        return "November";
     case MON_12:
-        return "December";
+        return long_month_names[item - MON_1].characters_without_null_termination();
     case ABMON_1:
-        return "Jan";
     case ABMON_2:
-        return "Feb";
     case ABMON_3:
-        return "Mar";
     case ABMON_4:
-        return "Apr";
     case ABMON_5:
-        return "May";
     case ABMON_6:
-        return "Jun";
     case ABMON_7:
-        return "Jul";
     case ABMON_8:
-        return "Aug";
     case ABMON_9:
-        return "Sep";
     case ABMON_10:
-        return "Oct";
     case ABMON_11:
-        return "Nov";
     case ABMON_12:
-        return "Dec";
+        return short_month_names[item - ABMON_1].characters_without_null_termination();
     case RADIXCHAR:
         return ".";
     case THOUSEP:

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/DateConstants.h>
 #include <AK/String.h>
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>
@@ -208,21 +209,6 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
 {
     tzset();
 
-    const char wday_short_names[7][4] = {
-        "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-    };
-    const char wday_long_names[7][10] = {
-        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
-    };
-    const char mon_short_names[12][4] = {
-        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-    };
-    const char mon_long_names[12][10] = {
-        "January", "February", "March", "April", "May", "June",
-        "July", "August", "September", "October", "November", "December"
-    };
-
     StringBuilder builder { max_size };
 
     const int format_len = strlen(format);
@@ -235,16 +221,16 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
 
             switch (format[i]) {
             case 'a':
-                builder.append(wday_short_names[tm->tm_wday]);
+                builder.append(short_day_names[tm->tm_wday]);
                 break;
             case 'A':
-                builder.append(wday_long_names[tm->tm_wday]);
+                builder.append(long_day_names[tm->tm_wday]);
                 break;
             case 'b':
-                builder.append(mon_short_names[tm->tm_mon]);
+                builder.append(short_month_names[tm->tm_mon]);
                 break;
             case 'B':
-                builder.append(mon_long_names[tm->tm_mon]);
+                builder.append(long_month_names[tm->tm_mon]);
                 break;
             case 'C':
                 builder.appendff("{:02}", (tm->tm_year + 1900) / 100);
@@ -259,7 +245,7 @@ size_t strftime(char* destination, size_t max_size, const char* format, const st
                 builder.appendff("{:2}", tm->tm_mday);
                 break;
             case 'h':
-                builder.append(mon_short_names[tm->tm_mon]);
+                builder.append(short_month_names[tm->tm_mon]);
                 break;
             case 'H':
                 builder.appendff("{:02}", tm->tm_hour);

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/CharacterTypes.h>
+#include <AK/DateConstants.h>
 #include <AK/StringBuilder.h>
 #include <AK/Time.h>
 #include <LibCore/DateTime.h>
@@ -85,21 +86,6 @@ void DateTime::set_time(int year, int month, int day, int hour, int minute, int 
 
 String DateTime::to_string(StringView format) const
 {
-    const char wday_short_names[7][4] = {
-        "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-    };
-    const char wday_long_names[7][10] = {
-        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
-    };
-    const char mon_short_names[12][4] = {
-        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-    };
-    const char mon_long_names[12][10] = {
-        "January", "February", "March", "April", "May", "June",
-        "July", "August", "September", "October", "November", "December"
-    };
-
     struct tm tm;
     localtime_r(&m_timestamp, &tm);
     StringBuilder builder;
@@ -138,16 +124,16 @@ String DateTime::to_string(StringView format) const
 
             switch (format[i]) {
             case 'a':
-                builder.append(wday_short_names[tm.tm_wday]);
+                builder.append(short_day_names[tm.tm_wday]);
                 break;
             case 'A':
-                builder.append(wday_long_names[tm.tm_wday]);
+                builder.append(long_day_names[tm.tm_wday]);
                 break;
             case 'b':
-                builder.append(mon_short_names[tm.tm_mon]);
+                builder.append(short_month_names[tm.tm_mon]);
                 break;
             case 'B':
-                builder.append(mon_long_names[tm.tm_mon]);
+                builder.append(long_month_names[tm.tm_mon]);
                 break;
             case 'C':
                 builder.appendff("{:02}", (tm.tm_year + 1900) / 100);
@@ -162,7 +148,7 @@ String DateTime::to_string(StringView format) const
                 builder.appendff("{:2}", tm.tm_mday);
                 break;
             case 'h':
-                builder.append(mon_short_names[tm.tm_mon]);
+                builder.append(short_month_names[tm.tm_mon]);
                 break;
             case 'H':
                 builder.appendff("{:02}", tm.tm_hour);
@@ -273,21 +259,6 @@ Optional<DateTime> DateTime::parse(StringView format, const String& string)
     unsigned string_pos = 0;
     struct tm tm = {};
 
-    const StringView wday_short_names[7] = {
-        "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"
-    };
-    const StringView wday_long_names[7] = {
-        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"
-    };
-    const StringView mon_short_names[12] = {
-        "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-        "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-    };
-    const StringView mon_long_names[12] = {
-        "January", "February", "March", "April", "May", "June",
-        "July", "August", "September", "October", "November", "December"
-    };
-
     auto parsing_failed = false;
 
     auto parse_number = [&] {
@@ -336,7 +307,7 @@ Optional<DateTime> DateTime::parse(StringView format, const String& string)
         switch (format[format_pos]) {
         case 'a': {
             auto wday = 0;
-            for (auto name : wday_short_names) {
+            for (auto name : short_day_names) {
                 if (string.substring_view(string_pos).starts_with(name, AK::CaseSensitivity::CaseInsensitive)) {
                     string_pos += name.length();
                     tm.tm_wday = wday;
@@ -350,7 +321,7 @@ Optional<DateTime> DateTime::parse(StringView format, const String& string)
         }
         case 'A': {
             auto wday = 0;
-            for (auto name : wday_long_names) {
+            for (auto name : long_day_names) {
                 if (string.substring_view(string_pos).starts_with(name, AK::CaseSensitivity::CaseInsensitive)) {
                     string_pos += name.length();
                     tm.tm_wday = wday;
@@ -365,7 +336,7 @@ Optional<DateTime> DateTime::parse(StringView format, const String& string)
         case 'h':
         case 'b': {
             auto mon = 0;
-            for (auto name : mon_short_names) {
+            for (auto name : short_month_names) {
                 if (string.substring_view(string_pos).starts_with(name, AK::CaseSensitivity::CaseInsensitive)) {
                     string_pos += name.length();
                     tm.tm_mon = mon;
@@ -379,7 +350,7 @@ Optional<DateTime> DateTime::parse(StringView format, const String& string)
         }
         case 'B': {
             auto mon = 0;
-            for (auto name : mon_long_names) {
+            for (auto name : long_month_names) {
                 if (string.substring_view(string_pos).starts_with(name, AK::CaseSensitivity::CaseInsensitive)) {
                     string_pos += name.length();
                     tm.tm_mon = mon;

--- a/Userland/Libraries/LibGUI/Calendar.cpp
+++ b/Userland/Libraries/LibGUI/Calendar.cpp
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/Array.h>
+#include <AK/DateConstants.h>
 #include <LibCore/DateTime.h>
 #include <LibGUI/Calendar.h>
 #include <LibGUI/Painter.h>
@@ -16,25 +16,6 @@
 REGISTER_WIDGET(GUI, Calendar);
 
 namespace GUI {
-
-static constexpr Array<StringView, 7> long_day_names = {
-    "Sunday", "Monday", "Tuesday", "Wednesday",
-    "Thursday", "Friday", "Saturday"
-};
-
-static constexpr Array<StringView, 7> short_day_names = { "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat" };
-static constexpr Array<StringView, 7> mini_day_names = { "Su", "Mo", "Tu", "We", "Th", "Fr", "Sa" };
-static constexpr Array<StringView, 7> micro_day_names = { "S", "M", "T", "W", "T", "F", "S" };
-
-static constexpr Array<StringView, 12> long_month_names = {
-    "January", "February", "March", "April", "May", "June",
-    "July", "August", "September", "October", "November", "December"
-};
-
-static constexpr Array<StringView, 12> short_month_names = {
-    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
-};
 
 static const auto extra_large_font = Gfx::BitmapFont::load_from_file("/res/fonts/MarietaRegular36.font");
 static const auto large_font = Gfx::BitmapFont::load_from_file("/res/fonts/MarietaRegular24.font");

--- a/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DatePrototype.cpp
@@ -8,6 +8,7 @@
  */
 
 #include <AK/Array.h>
+#include <AK/DateConstants.h>
 #include <AK/Function.h>
 #include <AK/String.h>
 #include <AK/TypeCasts.h>
@@ -28,12 +29,6 @@
 #include <LibUnicode/Locale.h>
 
 namespace JS {
-
-// Table 62: Names of days of the week, https://tc39.es/ecma262/#sec-todatestring-day-names
-static constexpr auto day_names = AK::Array { "Sun"sv, "Mon"sv, "Tue"sv, "Wed"sv, "Thu"sv, "Fri"sv, "Sat"sv };
-
-// Table 63: Names of months of the year, https://tc39.es/ecma262/#sec-todatestring-day-names
-static constexpr auto month_names = AK::Array { "Jan"sv, "Feb"sv, "Mar"sv, "Apr"sv, "May"sv, "Jun"sv, "Jul"sv, "Aug"sv, "Sep"sv, "Oct"sv, "Nov"sv, "Dec"sv };
 
 DatePrototype::DatePrototype(GlobalObject& global_object)
     : PrototypeObject(*global_object.object_prototype())
@@ -1106,10 +1101,10 @@ String time_string(double time)
 String date_string(double time)
 {
     // 1. Let weekday be the Name of the entry in Table 62 with the Number WeekDay(tv).
-    auto weekday = day_names[week_day(time)];
+    auto weekday = short_day_names[week_day(time)];
 
     // 2. Let month be the Name of the entry in Table 63 with the Number MonthFromTime(tv).
-    auto month = month_names[month_from_time(time)];
+    auto month = short_month_names[month_from_time(time)];
 
     // 3. Let day be the String representation of DateFromTime(tv), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
     auto day = date_from_time(time);
@@ -1226,10 +1221,10 @@ JS_DEFINE_NATIVE_FUNCTION(DatePrototype::to_utc_string)
         return js_string(vm, "Invalid Date"sv);
 
     // 4. Let weekday be the Name of the entry in Table 62 with the Number WeekDay(tv).
-    auto weekday = day_names[week_day(time.as_double())];
+    auto weekday = short_day_names[week_day(time.as_double())];
 
     // 5. Let month be the Name of the entry in Table 63 with the Number MonthFromTime(tv).
-    auto month = month_names[month_from_time(time.as_double())];
+    auto month = short_month_names[month_from_time(time.as_double())];
 
     // 6. Let day be the String representation of DateFromTime(tv), formatted as a two-digit decimal number, padded to the left with the code unit 0x0030 (DIGIT ZERO) if necessary.
     auto day = date_from_time(time.as_double());


### PR DESCRIPTION
Day and month name constants are defined in numerous places. This
pulls them together into a single place and eliminates the
duplication. It also ensures they are `constexpr`.