### PR TITLE
LibCards+Games: Change name of card type to card suit

### DIFF
--- a/Userland/Games/Hearts/Helpers.h
+++ b/Userland/Games/Hearts/Helpers.h
@@ -39,9 +39,9 @@ inline CardValue hearts_card_value(Card const& card)
 
 inline uint8_t hearts_card_points(Card const& card)
 {
-    if (card.type() == Card::Type::Hearts)
+    if (card.suit() == Card::Suit::Hearts)
         return 1;
-    else if (card.type() == Card::Type::Spades && hearts_card_value(card) == CardValue::Queen)
+    else if (card.suit() == Card::Suit::Spades && hearts_card_value(card) == CardValue::Queen)
         return 13;
     else
         return 0;
@@ -49,8 +49,8 @@ inline uint8_t hearts_card_points(Card const& card)
 
 inline bool hearts_card_less(RefPtr<Card>& card1, RefPtr<Card>& card2)
 {
-    if (card1->type() != card2->type())
-        return card1->type() < card2->type();
+    if (card1->suit() != card2->suit())
+        return card1->suit() < card2->suit();
     else
         return hearts_card_value(*card1) < hearts_card_value(*card2);
 }

--- a/Userland/Games/Hearts/Player.cpp
+++ b/Userland/Games/Hearts/Player.cpp
@@ -71,13 +71,13 @@ size_t Player::pick_lead_card(Function<bool(Card&)> valid_play, Function<bool(Ca
     return last_index;
 }
 
-Optional<size_t> Player::pick_low_points_high_value_card(Optional<Card::Type> type)
+Optional<size_t> Player::pick_low_points_high_value_card(Optional<Card::Suit> suit)
 {
     auto sorted_hand = hand_sorted_by_fn(compare_card_value);
     int min_points = -1;
     Optional<size_t> card_index;
     for (auto& cwi : sorted_hand) {
-        if (type.has_value() && cwi.card->type() != type.value())
+        if (suit.has_value() && cwi.card->suit() != suit.value())
             continue;
         auto points = hearts_card_points(*cwi.card);
         if (min_points == -1 || points < min_points) {
@@ -85,7 +85,7 @@ Optional<size_t> Player::pick_low_points_high_value_card(Optional<Card::Type> ty
             card_index = cwi.index;
         }
     }
-    VERIFY(card_index.has_value() || type.has_value());
+    VERIFY(card_index.has_value() || suit.has_value());
     return card_index;
 }
 
@@ -95,7 +95,7 @@ Optional<size_t> Player::pick_lower_value_card(Card& other_card)
         auto& card = hand[i];
         if (card.is_null())
             continue;
-        if (card->type() == other_card.type() && hearts_card_value(*card) < hearts_card_value(other_card))
+        if (card->suit() == other_card.suit() && hearts_card_value(*card) < hearts_card_value(other_card))
             return i;
     }
     return {};
@@ -107,7 +107,7 @@ Optional<size_t> Player::pick_slightly_higher_value_card(Card& other_card)
         auto& card = hand[i];
         if (card.is_null())
             continue;
-        if (card->type() == other_card.type() && hearts_card_value(*card) > hearts_card_value(other_card))
+        if (card->suit() == other_card.suit() && hearts_card_value(*card) > hearts_card_value(other_card))
             return i;
     }
     return {};
@@ -115,10 +115,10 @@ Optional<size_t> Player::pick_slightly_higher_value_card(Card& other_card)
 
 size_t Player::pick_max_points_card(Function<bool(Card&)> ignore_card)
 {
-    auto queen_of_spades_maybe = pick_specific_card(Card::Type::Spades, CardValue::Queen);
+    auto queen_of_spades_maybe = pick_specific_card(Card::Suit::Spades, CardValue::Queen);
     if (queen_of_spades_maybe.has_value())
         return queen_of_spades_maybe.value();
-    if (has_card_of_type(Card::Type::Hearts)) {
+    if (has_card_of_suit(Card::Suit::Hearts)) {
         auto highest_hearts_card_index = pick_last_card();
         auto& card = hand[highest_hearts_card_index];
         if (!ignore_card(*card))
@@ -127,13 +127,13 @@ size_t Player::pick_max_points_card(Function<bool(Card&)> ignore_card)
     return pick_low_points_high_value_card().value();
 }
 
-Optional<size_t> Player::pick_specific_card(Card::Type type, CardValue value)
+Optional<size_t> Player::pick_specific_card(Card::Suit suit, CardValue value)
 {
     for (size_t i = 0; i < hand.size(); i++) {
         auto& card = hand[i];
         if (card.is_null())
             continue;
-        if (card->type() == type && hearts_card_value(*card) == value)
+        if (card->suit() == suit && hearts_card_value(*card) == value)
             return i;
     }
     return {};
@@ -150,10 +150,10 @@ size_t Player::pick_last_card()
     VERIFY_NOT_REACHED();
 }
 
-bool Player::has_card_of_type(Card::Type type)
+bool Player::has_card_of_suit(Card::Suit suit)
 {
     auto matching_card = hand.first_matching([&](auto const& other_card) {
-        return !other_card.is_null() && other_card->type() == type;
+        return !other_card.is_null() && other_card->suit() == suit;
     });
     return matching_card.has_value();
 }

--- a/Userland/Games/Hearts/Player.h
+++ b/Userland/Games/Hearts/Player.h
@@ -35,13 +35,13 @@ public:
 
     NonnullRefPtrVector<Card> pick_cards_to_pass(PassingDirection);
     size_t pick_lead_card(Function<bool(Card&)>, Function<bool(Card&)>);
-    Optional<size_t> pick_low_points_high_value_card(Optional<Card::Type> type = {});
+    Optional<size_t> pick_low_points_high_value_card(Optional<Card::Suit> suit = {});
     Optional<size_t> pick_lower_value_card(Card& other_card);
     Optional<size_t> pick_slightly_higher_value_card(Card& other_card);
     size_t pick_max_points_card(Function<bool(Card&)>);
-    Optional<size_t> pick_specific_card(Card::Type type, CardValue value);
+    Optional<size_t> pick_specific_card(Card::Suit suit, CardValue value);
     size_t pick_last_card();
-    bool has_card_of_type(Card::Type type);
+    bool has_card_of_suit(Card::Suit suit);
     Vector<CardWithIndex> hand_sorted_by_fn(bool (*)(CardWithIndex&, CardWithIndex&)) const;
 
     void sort_hand() { quick_sort(hand, hearts_card_less); }

--- a/Userland/Games/Solitaire/Game.cpp
+++ b/Userland/Games/Solitaire/Game.cpp
@@ -90,7 +90,7 @@ void Game::timer_event(Core::TimerEvent&)
 
 void Game::create_new_animation_card()
 {
-    auto card = Card::construct(static_cast<Card::Type>(get_random_uniform(to_underlying(Card::Type::__Count))), get_random_uniform(Card::card_count));
+    auto card = Card::construct(static_cast<Card::Suit>(get_random_uniform(to_underlying(Card::Suit::__Count))), get_random_uniform(Card::card_count));
     card->set_position({ get_random_uniform(Game::width - Card::width), get_random_uniform(Game::height / 8) });
 
     int x_sgn = card->position().x() > (Game::width / 2) ? -1 : 1;
@@ -163,10 +163,10 @@ void Game::setup(Mode mode)
         on_undo_availability_change(false);
 
     for (int i = 0; i < Card::card_count; ++i) {
-        m_new_deck.append(Card::construct(Card::Type::Clubs, i));
-        m_new_deck.append(Card::construct(Card::Type::Spades, i));
-        m_new_deck.append(Card::construct(Card::Type::Hearts, i));
-        m_new_deck.append(Card::construct(Card::Type::Diamonds, i));
+        m_new_deck.append(Card::construct(Card::Suit::Clubs, i));
+        m_new_deck.append(Card::construct(Card::Suit::Spades, i));
+        m_new_deck.append(Card::construct(Card::Suit::Hearts, i));
+        m_new_deck.append(Card::construct(Card::Suit::Diamonds, i));
     }
 
     for (uint8_t i = 0; i < 200; ++i)

--- a/Userland/Games/Spider/Game.cpp
+++ b/Userland/Games/Spider/Game.cpp
@@ -55,13 +55,13 @@ void Game::setup(Mode mode)
         switch (m_mode) {
         case Mode::SingleSuit:
             for (int j = 0; j < 8; j++) {
-                deck.append(Card::construct(Card::Type::Spades, i));
+                deck.append(Card::construct(Card::Suit::Spades, i));
             }
             break;
         case Mode::TwoSuit:
             for (int j = 0; j < 4; j++) {
-                deck.append(Card::construct(Card::Type::Spades, i));
-                deck.append(Card::construct(Card::Type::Hearts, i));
+                deck.append(Card::construct(Card::Suit::Spades, i));
+                deck.append(Card::construct(Card::Suit::Hearts, i));
             }
             break;
         default:

--- a/Userland/Libraries/LibCards/Card.cpp
+++ b/Userland/Libraries/LibCards/Card.cpp
@@ -67,10 +67,10 @@ static constexpr Gfx::CharacterBitmap s_club {
 static RefPtr<Gfx::Bitmap> s_background;
 static RefPtr<Gfx::Bitmap> s_background_inverted;
 
-Card::Card(Type type, uint8_t value)
+Card::Card(Suit suit, uint8_t value)
     : m_rect(Gfx::IntRect({}, { width, height }))
     , m_front(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, { width, height }).release_value_but_fixme_should_propagate_errors())
-    , m_type(type)
+    , m_suit(suit)
     , m_value(value)
 {
     VERIFY(value < card_count);
@@ -111,15 +111,15 @@ Card::Card(Type type, uint8_t value)
     painter.draw_text(text_rect, label, font, Gfx::TextAlignment::Center, color());
 
     auto const& symbol = [&]() -> Gfx::CharacterBitmap const& {
-        switch (m_type) {
-        case Type::Diamonds:
+        switch (m_suit) {
+        case Suit::Diamonds:
             return s_diamond;
-        case Type::Clubs:
+        case Suit::Clubs:
             return s_club;
             break;
-        case Type::Spades:
+        case Suit::Spades:
             return s_spade;
-        case Type::Hearts:
+        case Suit::Hearts:
             return s_heart;
         default:
             VERIFY_NOT_REACHED();

--- a/Userland/Libraries/LibCards/Card.h
+++ b/Userland/Libraries/LibCards/Card.h
@@ -29,7 +29,7 @@ public:
         "A", "2", "3", "4", "5", "6", "7", "8", "9", "10", "J", "Q", "K"
     };
 
-    enum class Type {
+    enum class Suit {
         Clubs,
         Diamonds,
         Spades,
@@ -43,13 +43,13 @@ public:
     Gfx::IntPoint position() const { return m_rect.location(); }
     const Gfx::IntPoint& old_position() const { return m_old_position; }
     uint8_t value() const { return m_value; };
-    Type type() const { return m_type; }
+    Suit suit() const { return m_suit; }
 
     bool is_old_position_valid() const { return m_old_position_valid; }
     bool is_moving() const { return m_moving; }
     bool is_upside_down() const { return m_upside_down; }
     bool is_inverted() const { return m_inverted; }
-    Gfx::Color color() const { return (m_type == Type::Diamonds || m_type == Type::Hearts) ? Color::Red : Color::Black; }
+    Gfx::Color color() const { return (m_suit == Suit::Diamonds || m_suit == Suit::Hearts) ? Color::Red : Color::Black; }
 
     void set_position(const Gfx::IntPoint p) { m_rect.set_location(p); }
     void set_moving(bool moving) { m_moving = moving; }
@@ -63,7 +63,7 @@ public:
     void clear_and_draw(GUI::Painter&, const Color& background_color);
 
 private:
-    Card(Type type, uint8_t value);
+    Card(Suit suit, uint8_t value);
 
     static NonnullRefPtr<Gfx::Bitmap> invert_bitmap(Gfx::Bitmap&);
 
@@ -71,7 +71,7 @@ private:
     NonnullRefPtr<Gfx::Bitmap> m_front;
     RefPtr<Gfx::Bitmap> m_front_inverted;
     Gfx::IntPoint m_old_position;
-    Type m_type;
+    Suit m_suit;
     uint8_t m_value;
     bool m_old_position_valid { false };
     bool m_moving { false };
@@ -85,25 +85,25 @@ template<>
 struct AK::Formatter<Cards::Card> : Formatter<FormatString> {
     ErrorOr<void> format(FormatBuilder& builder, Cards::Card const& card)
     {
-        StringView type;
+        StringView suit;
 
-        switch (card.type()) {
-        case Cards::Card::Type::Clubs:
-            type = "C"sv;
+        switch (card.suit()) {
+        case Cards::Card::Suit::Clubs:
+            suit = "C"sv;
             break;
-        case Cards::Card::Type::Diamonds:
-            type = "D"sv;
+        case Cards::Card::Suit::Diamonds:
+            suit = "D"sv;
             break;
-        case Cards::Card::Type::Hearts:
-            type = "H"sv;
+        case Cards::Card::Suit::Hearts:
+            suit = "H"sv;
             break;
-        case Cards::Card::Type::Spades:
-            type = "S"sv;
+        case Cards::Card::Suit::Spades:
+            suit = "S"sv;
             break;
         default:
             VERIFY_NOT_REACHED();
         }
 
-        return Formatter<FormatString>::format(builder, "{:>2}{}", Cards::Card::labels[card.value()], type);
+        return Formatter<FormatString>::format(builder, "{:>2}{}", Cards::Card::labels[card.value()], suit);
     }
 };

--- a/Userland/Libraries/LibCards/CardStack.cpp
+++ b/Userland/Libraries/LibCards/CardStack.cpp
@@ -212,7 +212,7 @@ bool CardStack::is_allowed_to_push(const Card& card, size_t stack_size, Movement
             // Prevent player from dragging an entire stack of cards to the foundation stack
             if (stack_size > 1)
                 return false;
-            return top_card.type() == card.type() && m_stack.size() == card.value();
+            return top_card.suit() == card.suit() && m_stack.size() == card.value();
         } else if (m_type == Type::Normal) {
             bool color_match;
             switch (movement_rule) {


### PR DESCRIPTION
Playing cards have a `suit` such as `hearts`/`diamonds`, not a
`type`. Make the internal naming consistent with the way playing cards
are typically named.