### PR TITLE
WebServer+LibCore: Fixes for big binary files and more

### DIFF
--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -86,7 +86,7 @@ String guess_mime_type_based_on_filename(StringView path)
         return "text/html";
     if (path.ends_with(".csv", CaseSensitivity::CaseInsensitive))
         return "text/csv";
-    return "text/plain";
+    return "application/octet-stream";
 }
 
 #define ENUMERATE_HEADER_CONTENTS                                                                                                                \

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -75,6 +75,8 @@ String guess_mime_type_based_on_filename(StringView path)
         return "text/markdown";
     if (path.ends_with(".html", CaseSensitivity::CaseInsensitive) || path.ends_with(".htm", CaseSensitivity::CaseInsensitive))
         return "text/html";
+    if (path.ends_with(".css", CaseSensitivity::CaseInsensitive))
+        return "text/css";
     if (path.ends_with(".js", CaseSensitivity::CaseInsensitive))
         return "application/javascript";
     if (path.ends_with(".json", CaseSensitivity::CaseInsensitive))

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/MimeData.h>
 
@@ -86,6 +87,20 @@ String guess_mime_type_based_on_filename(StringView path)
         return "text/html";
     if (path.ends_with(".csv", CaseSensitivity::CaseInsensitive))
         return "text/csv";
+    // FIXME: Share this, TextEditor and HackStudio language detection somehow.
+    auto basename = LexicalPath::basename(path);
+    if (path.ends_with(".cpp", CaseSensitivity::CaseInsensitive)
+        || path.ends_with(".c", CaseSensitivity::CaseInsensitive)
+        || path.ends_with(".hpp", CaseSensitivity::CaseInsensitive)
+        || path.ends_with(".h", CaseSensitivity::CaseInsensitive)
+        || path.ends_with(".gml", CaseSensitivity::CaseInsensitive)
+        || path.ends_with(".ini", CaseSensitivity::CaseInsensitive)
+        || path.ends_with(".ipc", CaseSensitivity::CaseInsensitive)
+        || path.ends_with(".txt", CaseSensitivity::CaseInsensitive)
+        || basename == "CMakeLists.txt"
+        || basename == ".history"
+        || basename == ".shellrc")
+        return "text/plain";
     return "application/octet-stream";
 }
 

--- a/Userland/Services/WebServer/Client.h
+++ b/Userland/Services/WebServer/Client.h
@@ -22,8 +22,13 @@ public:
 private:
     Client(NonnullOwnPtr<Core::Stream::BufferedTCPSocket>, Core::Object* parent);
 
+    struct ContentInfo {
+        String type;
+        size_t length {};
+    };
+
     ErrorOr<bool> handle_request(ReadonlyBytes);
-    ErrorOr<void> send_response(InputStream&, HTTP::HttpRequest const&, String const& content_type);
+    ErrorOr<void> send_response(InputStream&, HTTP::HttpRequest const&, ContentInfo);
     ErrorOr<void> send_redirect(StringView redirect, HTTP::HttpRequest const&);
     ErrorOr<void> send_error_response(unsigned code, HTTP::HttpRequest const&, Vector<String> const& headers = {});
     void die();


### PR DESCRIPTION
(GitHub doesn't let me to upload a video...)

This makes browsers like Firefox actually display download progress when someone tries to download a big file.

**[WebServer: Add Content-Length header to HTTP responses](https://github.com/SerenityOS/serenity/commit/728ca40022d4d85a4f4f9163847747bb3276d138)**

This makes the browser know how much data it should expect.

**[LibCore: Make application/octet-stream the default guessed MIME type](https://github.com/SerenityOS/serenity/commit/c6a5d5510fd54fa16289b39584283010b6a42381)**

This MIME type can be associated with every file, text/plain only with
plaintext files.

This makes browsers (e.g Firefox) properly displaying download progress
when downloading files in WebServer :^)

**[LibCore: Add some extensions that are text/plain](https://github.com/SerenityOS/serenity/commit/6dd8b3d8c4eb228e02c9cb66f90e1d3d2012e149)**

C++ source/header files, GML, IPC, CMake and various Serenity Shell
config files.