### PR TITLE
SystemMonitor: Move to GML

### DIFF
--- a/Userland/Applications/Help/HelpWindow.gml
+++ b/Userland/Applications/Help/HelpWindow.gml
@@ -22,10 +22,12 @@
 
             @GUI::TreeView {
                 name: "browse_view"
+                title: "Browse"
             }
 
             @GUI::Widget {
                 name: "search_container"
+                title: "Search"
                 layout: @GUI::VerticalBoxLayout {}
 
                 @GUI::TextBox {

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -255,9 +255,6 @@ ErrorOr<void> MainWidget::initialize_fallibles(GUI::Window& window)
     TRY(m_context_menu->try_add_action(*m_copy_action));
     TRY(m_context_menu->try_add_action(*m_select_all_action));
 
-    TRY(m_tab_widget->try_add_widget("Browse", *m_browse_view));
-    TRY(m_tab_widget->try_add_widget("Search", *m_search_container));
-
     m_manual_model = TRY(ManualModel::create());
     m_browse_view->set_model(*m_manual_model);
     m_filter_model = TRY(GUI::FilteringProxyModel::create(*m_manual_model));

--- a/Userland/Applications/SystemMonitor/CMakeLists.txt
+++ b/Userland/Applications/SystemMonitor/CMakeLists.txt
@@ -4,6 +4,8 @@ serenity_component(
     TARGETS SystemMonitor Profiler Inspector
 )
 
+compile_gml(SystemMonitor.gml SystemMonitorGML.h system_monitor_gml)
+
 set(SOURCES
     GraphWidget.cpp
     main.cpp
@@ -15,6 +17,7 @@ set(SOURCES
     ProcessUnveiledPathsWidget.cpp
     ProcessStateWidget.cpp
     ThreadStackWidget.cpp
+    SystemMonitorGML.h
 )
 
 serenity_app(SystemMonitor ICON app-system-monitor)

--- a/Userland/Applications/SystemMonitor/CMakeLists.txt
+++ b/Userland/Applications/SystemMonitor/CMakeLists.txt
@@ -5,6 +5,7 @@ serenity_component(
 )
 
 compile_gml(SystemMonitor.gml SystemMonitorGML.h system_monitor_gml)
+compile_gml(ProcessWindow.gml ProcessWindowGML.h process_window_gml)
 
 set(SOURCES
     GraphWidget.cpp
@@ -18,6 +19,7 @@ set(SOURCES
     ProcessStateWidget.cpp
     ThreadStackWidget.cpp
     SystemMonitorGML.h
+    ProcessWindowGML.h
 )
 
 serenity_app(SystemMonitor ICON app-system-monitor)

--- a/Userland/Applications/SystemMonitor/GraphWidget.cpp
+++ b/Userland/Applications/SystemMonitor/GraphWidget.cpp
@@ -13,6 +13,10 @@
 #include <LibGfx/Path.h>
 #include <LibGfx/SystemTheme.h>
 
+REGISTER_WIDGET(SystemMonitor, GraphWidget)
+
+namespace SystemMonitor {
+
 void GraphWidget::add_value(Vector<u64, 1>&& value)
 {
     m_values.enqueue(move(value));
@@ -142,4 +146,6 @@ void GraphWidget::paint_event(GUI::PaintEvent& event)
             y += text_rect.height() + 4;
         }
     }
+}
+
 }

--- a/Userland/Applications/SystemMonitor/GraphWidget.cpp
+++ b/Userland/Applications/SystemMonitor/GraphWidget.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "GraphWidget.h"
+#include <LibCore/Object.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Painter.h>
 #include <LibGfx/Font.h>
@@ -16,6 +17,17 @@
 REGISTER_WIDGET(SystemMonitor, GraphWidget)
 
 namespace SystemMonitor {
+
+GraphWidget::GraphWidget()
+{
+    REGISTER_BOOL_PROPERTY("stack_values", stack_values, set_stack_values);
+}
+
+void GraphWidget::set_stack_values(bool stack_values)
+{
+    m_stack_values = stack_values;
+    update();
+}
 
 void GraphWidget::add_value(Vector<u64, 1>&& value)
 {

--- a/Userland/Applications/SystemMonitor/GraphWidget.h
+++ b/Userland/Applications/SystemMonitor/GraphWidget.h
@@ -34,10 +34,11 @@ public:
             m_value_format.resize(index + 1);
         m_value_format[index] = move(format);
     }
-    void set_stack_values(bool stack_values) { m_stack_values = stack_values; }
+    void set_stack_values(bool stack_values);
+    bool stack_values() const { return m_stack_values; }
 
 private:
-    explicit GraphWidget() = default;
+    explicit GraphWidget();
 
     virtual void paint_event(GUI::PaintEvent&) override;
 

--- a/Userland/Applications/SystemMonitor/GraphWidget.h
+++ b/Userland/Applications/SystemMonitor/GraphWidget.h
@@ -11,6 +11,8 @@
 #include <LibGUI/Frame.h>
 #include <LibGfx/SystemTheme.h>
 
+namespace SystemMonitor {
+
 class GraphWidget final : public GUI::Frame {
     C_OBJECT(GraphWidget)
 public:
@@ -46,3 +48,5 @@ private:
 
     Vector<Gfx::IntPoint, 1> m_calculated_points;
 };
+
+}

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -17,6 +17,10 @@
 #include <LibGfx/StylePainter.h>
 #include <stdlib.h>
 
+REGISTER_WIDGET(SystemMonitor, MemoryStatsWidget)
+
+namespace SystemMonitor {
+
 static MemoryStatsWidget* s_the;
 
 MemoryStatsWidget* MemoryStatsWidget::the()
@@ -24,7 +28,12 @@ MemoryStatsWidget* MemoryStatsWidget::the()
     return s_the;
 }
 
-MemoryStatsWidget::MemoryStatsWidget(SystemMonitor::GraphWidget& graph)
+MemoryStatsWidget::MemoryStatsWidget()
+    : MemoryStatsWidget(nullptr)
+{
+}
+
+MemoryStatsWidget::MemoryStatsWidget(GraphWidget* graph)
     : m_graph(graph)
 {
     VERIFY(!s_the);
@@ -57,6 +66,11 @@ MemoryStatsWidget::MemoryStatsWidget(SystemMonitor::GraphWidget& graph)
     m_kmalloc_difference_label = build_widgets_for_label("Difference:");
 
     refresh();
+}
+
+void MemoryStatsWidget::set_graph_widget(GraphWidget& graph)
+{
+    m_graph = &graph;
 }
 
 static inline u64 page_count_to_bytes(size_t count)
@@ -101,6 +115,10 @@ void MemoryStatsWidget::refresh()
     m_kfree_count_label->set_text(String::formatted("{}", kfree_call_count));
     m_kmalloc_difference_label->set_text(String::formatted("{:+}", kmalloc_call_count - kfree_call_count));
 
-    m_graph.set_max(page_count_to_bytes(total_userphysical_and_swappable_pages) + kmalloc_bytes_total);
-    m_graph.add_value({ page_count_to_bytes(user_physical_committed), page_count_to_bytes(user_physical_allocated), kmalloc_bytes_total });
+    if (m_graph) {
+        m_graph->set_max(page_count_to_bytes(total_userphysical_and_swappable_pages) + kmalloc_bytes_total);
+        m_graph->add_value({ page_count_to_bytes(user_physical_committed), page_count_to_bytes(user_physical_allocated), kmalloc_bytes_total });
+    }
+}
+
 }

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.cpp
@@ -24,7 +24,7 @@ MemoryStatsWidget* MemoryStatsWidget::the()
     return s_the;
 }
 
-MemoryStatsWidget::MemoryStatsWidget(GraphWidget& graph)
+MemoryStatsWidget::MemoryStatsWidget(SystemMonitor::GraphWidget& graph)
     : m_graph(graph)
 {
     VERIFY(!s_the);

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.h
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.h
@@ -22,6 +22,9 @@ public:
 
     void set_graph_widget(GraphWidget& graph);
 
+    void set_graph_widget_via_name(String name);
+    String graph_widget_name();
+
     void refresh();
 
 private:
@@ -29,6 +32,8 @@ private:
     MemoryStatsWidget();
 
     GraphWidget* m_graph;
+    // Is null if we have a valid graph
+    String m_graph_widget_name {};
     RefPtr<GUI::Label> m_user_physical_pages_label;
     RefPtr<GUI::Label> m_user_physical_pages_committed_label;
     RefPtr<GUI::Label> m_supervisor_physical_pages_label;

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.h
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.h
@@ -10,8 +10,8 @@
 #include <LibGUI/Widget.h>
 
 namespace SystemMonitor {
+
 class GraphWidget;
-}
 
 class MemoryStatsWidget final : public GUI::Widget {
     C_OBJECT(MemoryStatsWidget)
@@ -20,12 +20,15 @@ public:
 
     virtual ~MemoryStatsWidget() override = default;
 
+    void set_graph_widget(GraphWidget& graph);
+
     void refresh();
 
 private:
-    MemoryStatsWidget(SystemMonitor::GraphWidget& graph);
+    MemoryStatsWidget(GraphWidget* graph);
+    MemoryStatsWidget();
 
-    SystemMonitor::GraphWidget& m_graph;
+    GraphWidget* m_graph;
     RefPtr<GUI::Label> m_user_physical_pages_label;
     RefPtr<GUI::Label> m_user_physical_pages_committed_label;
     RefPtr<GUI::Label> m_supervisor_physical_pages_label;
@@ -34,3 +37,5 @@ private:
     RefPtr<GUI::Label> m_kfree_count_label;
     RefPtr<GUI::Label> m_kmalloc_difference_label;
 };
+
+}

--- a/Userland/Applications/SystemMonitor/MemoryStatsWidget.h
+++ b/Userland/Applications/SystemMonitor/MemoryStatsWidget.h
@@ -9,7 +9,9 @@
 
 #include <LibGUI/Widget.h>
 
+namespace SystemMonitor {
 class GraphWidget;
+}
 
 class MemoryStatsWidget final : public GUI::Widget {
     C_OBJECT(MemoryStatsWidget)
@@ -21,9 +23,9 @@ public:
     void refresh();
 
 private:
-    MemoryStatsWidget(GraphWidget& graph);
+    MemoryStatsWidget(SystemMonitor::GraphWidget& graph);
 
-    GraphWidget& m_graph;
+    SystemMonitor::GraphWidget& m_graph;
     RefPtr<GUI::Label> m_user_physical_pages_label;
     RefPtr<GUI::Label> m_user_physical_pages_committed_label;
     RefPtr<GUI::Label> m_supervisor_physical_pages_label;

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.cpp
@@ -13,6 +13,10 @@
 #include <LibGUI/TableView.h>
 #include <LibGfx/Painter.h>
 
+REGISTER_WIDGET(SystemMonitor, NetworkStatisticsWidget)
+
+namespace SystemMonitor {
+
 NetworkStatisticsWidget::NetworkStatisticsWidget()
 {
     on_first_show = [this](auto&) {
@@ -117,4 +121,6 @@ void NetworkStatisticsWidget::update_models()
     m_adapter_model->update();
     m_tcp_socket_model->update();
     m_udp_socket_model->update();
+}
+
 }

--- a/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.h
+++ b/Userland/Applications/SystemMonitor/NetworkStatisticsWidget.h
@@ -10,6 +10,8 @@
 #include <LibCore/Timer.h>
 #include <LibGUI/LazyWidget.h>
 
+namespace SystemMonitor {
+
 class NetworkStatisticsWidget final : public GUI::LazyWidget {
     C_OBJECT(NetworkStatisticsWidget)
 public:
@@ -30,3 +32,5 @@ private:
     RefPtr<Gfx::Bitmap> m_network_disconnected_bitmap;
     RefPtr<Gfx::Bitmap> m_network_link_down_bitmap;
 };
+
+}

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.cpp
@@ -11,6 +11,10 @@
 #include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/TableView.h>
 
+REGISTER_WIDGET(SystemMonitor, ProcessFileDescriptorMapWidget)
+
+namespace SystemMonitor {
+
 ProcessFileDescriptorMapWidget::ProcessFileDescriptorMapWidget()
 {
     set_layout<GUI::VerticalBoxLayout>();
@@ -48,4 +52,6 @@ void ProcessFileDescriptorMapWidget::set_pid(pid_t pid)
         return;
     m_pid = pid;
     m_model->set_json_path(String::formatted("/proc/{}/fds", m_pid));
+}
+
 }

--- a/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.h
+++ b/Userland/Applications/SystemMonitor/ProcessFileDescriptorMapWidget.h
@@ -9,6 +9,8 @@
 
 #include <LibGUI/Widget.h>
 
+namespace SystemMonitor {
+
 class ProcessFileDescriptorMapWidget final : public GUI::Widget {
     C_OBJECT(ProcessFileDescriptorMapWidget);
 
@@ -24,3 +26,5 @@ private:
     RefPtr<GUI::JsonArrayModel> m_model;
     pid_t m_pid { -1 };
 };
+
+}

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.cpp
@@ -14,6 +14,10 @@
 #include <LibGUI/TableView.h>
 #include <LibGfx/Palette.h>
 
+REGISTER_WIDGET(SystemMonitor, ProcessMemoryMapWidget)
+
+namespace SystemMonitor {
+
 class PagemapPaintingDelegate final : public GUI::TableCellPaintingDelegate {
 public:
     virtual ~PagemapPaintingDelegate() override = default;
@@ -120,4 +124,6 @@ void ProcessMemoryMapWidget::refresh()
 {
     if (m_pid != -1)
         m_json_model->invalidate();
+}
+
 }

--- a/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.h
+++ b/Userland/Applications/SystemMonitor/ProcessMemoryMapWidget.h
@@ -9,6 +9,8 @@
 
 #include <LibGUI/Widget.h>
 
+namespace SystemMonitor {
+
 class ProcessMemoryMapWidget final : public GUI::Widget {
     C_OBJECT(ProcessMemoryMapWidget);
 
@@ -25,3 +27,5 @@ private:
     pid_t m_pid { -1 };
     RefPtr<Core::Timer> m_timer;
 };
+
+}

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.cpp
@@ -12,8 +12,13 @@
 #include <LibGUI/HeaderView.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/TableView.h>
+#include <LibGUI/Widget.h>
 #include <LibGfx/FontDatabase.h>
 #include <LibGfx/Palette.h>
+
+REGISTER_WIDGET(SystemMonitor, ProcessStateWidget)
+
+namespace SystemMonitor {
 
 class ProcessStateModel final
     : public GUI::Model
@@ -75,18 +80,33 @@ public:
         did_update(GUI::Model::UpdateFlag::DontInvalidateIndices);
     }
 
+    void set_pid(pid_t pid)
+    {
+        m_pid = pid;
+        refresh();
+    }
+    pid_t pid() const { return m_pid; }
+
 private:
     ProcessModel& m_target;
     GUI::ModelIndex m_target_index;
     pid_t m_pid { -1 };
 };
 
-ProcessStateWidget::ProcessStateWidget(pid_t pid)
+ProcessStateWidget::ProcessStateWidget()
 {
     set_layout<GUI::VerticalBoxLayout>();
     layout()->set_margins(4);
     m_table_view = add<GUI::TableView>();
-    m_table_view->set_model(adopt_ref(*new ProcessStateModel(ProcessModel::the(), pid)));
+    m_table_view->set_model(adopt_ref(*new ProcessStateModel(ProcessModel::the(), 0)));
     m_table_view->column_header().set_visible(false);
     m_table_view->column_header().set_section_size(0, 90);
+}
+
+void ProcessStateWidget::set_pid(pid_t pid)
+{
+    static_cast<ProcessStateModel*>(m_table_view->model())->set_pid(pid);
+    update();
+}
+
 }

--- a/Userland/Applications/SystemMonitor/ProcessStateWidget.h
+++ b/Userland/Applications/SystemMonitor/ProcessStateWidget.h
@@ -9,13 +9,19 @@
 
 #include <LibGUI/Widget.h>
 
+namespace SystemMonitor {
+
 class ProcessStateWidget final : public GUI::Widget {
     C_OBJECT(ProcessStateWidget);
 
 public:
     virtual ~ProcessStateWidget() override = default;
 
+    void set_pid(pid_t);
+
 private:
-    explicit ProcessStateWidget(pid_t);
+    ProcessStateWidget();
     RefPtr<GUI::TableView> m_table_view;
 };
+
+}

--- a/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.cpp
@@ -10,6 +10,11 @@
 #include <LibGUI/JsonArrayModel.h>
 #include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/TableView.h>
+#include <LibGUI/Widget.h>
+
+REGISTER_WIDGET(SystemMonitor, ProcessUnveiledPathsWidget)
+
+namespace SystemMonitor {
 
 ProcessUnveiledPathsWidget::ProcessUnveiledPathsWidget()
 {
@@ -31,4 +36,6 @@ void ProcessUnveiledPathsWidget::set_pid(pid_t pid)
         return;
     m_pid = pid;
     m_model->set_json_path(String::formatted("/proc/{}/unveil", m_pid));
+}
+
 }

--- a/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.h
+++ b/Userland/Applications/SystemMonitor/ProcessUnveiledPathsWidget.h
@@ -9,6 +9,8 @@
 
 #include <LibGUI/Widget.h>
 
+namespace SystemMonitor {
+
 class ProcessUnveiledPathsWidget final : public GUI::Widget {
     C_OBJECT(ProcessUnveiledPathsWidget);
 
@@ -24,3 +26,5 @@ private:
     RefPtr<GUI::JsonArrayModel> m_model;
     pid_t m_pid { -1 };
 };
+
+}

--- a/Userland/Applications/SystemMonitor/ProcessWindow.gml
+++ b/Userland/Applications/SystemMonitor/ProcessWindow.gml
@@ -1,0 +1,65 @@
+@GUI::Widget {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {}
+
+    @GUI::Widget {
+        shrink_to_fit: true
+        layout: @GUI::HorizontalBoxLayout {
+            margins: [4]
+            spacing: 8
+        }
+
+        @GUI::Label {
+            name: "icon_label"
+            fixed_size: [32, 32]
+        }
+
+        @GUI::Label {
+            name: "process_name"
+            font_weight: "Bold"
+            text_alignment: "CenterLeft"
+            text: "This is the process name."
+        }
+    }
+
+    @GUI::HorizontalSeparator {
+        fixed_height: 2
+    }
+
+    @GUI::StackWidget {
+        name: "widget_stack"
+
+        @SystemMonitor::UnavailableProcessWidget {
+            name: "unavailable_process"
+        }
+
+        @GUI::TabWidget {
+            name: "available_process"
+
+            @SystemMonitor::ProcessStateWidget {
+                name: "process_state"
+                title: "State"
+            }
+
+            @SystemMonitor::ProcessMemoryMapWidget {
+                name: "memory_map"
+                title: "Memory map"
+            }
+
+            @SystemMonitor::ProcessFileDescriptorMapWidget {
+                name: "open_files"
+                title: "Open files"
+            }
+
+            @SystemMonitor::ProcessUnveiledPathsWidget {
+                name: "unveiled_paths"
+                title: "Unveiled paths"
+            }
+
+            @SystemMonitor::ThreadStackWidget {
+                name: "thread_stack"
+                title: "Stack"
+            }
+        }
+    }
+}

--- a/Userland/Applications/SystemMonitor/SystemMonitor.gml
+++ b/Userland/Applications/SystemMonitor/SystemMonitor.gml
@@ -80,7 +80,7 @@
                 name: "network"
             }
 
-            @GUI::LazyWidget {
+            @SystemMonitor::HardwareTabWidget {
                 title: "Hardware"
                 name: "hardware"
                 layout: @GUI::VerticalBoxLayout {

--- a/Userland/Applications/SystemMonitor/SystemMonitor.gml
+++ b/Userland/Applications/SystemMonitor/SystemMonitor.gml
@@ -63,7 +63,7 @@
                 }
             }
 
-            @GUI::LazyWidget {
+            @SystemMonitor::StorageTabWidget {
                 title: "Storage"
                 name: "storage"
                 layout: @GUI::VerticalBoxLayout {

--- a/Userland/Applications/SystemMonitor/SystemMonitor.gml
+++ b/Userland/Applications/SystemMonitor/SystemMonitor.gml
@@ -1,0 +1,120 @@
+@GUI::Widget {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {}
+
+    // Add a tasteful separating line between the menu and the main UI.
+    @GUI::HorizontalSeparator {
+        fixed_height: 2
+    }
+
+    @GUI::Widget {
+        layout: @GUI::VerticalBoxLayout {
+            margins: [0, 4, 4]
+        }
+
+        @GUI::TabWidget {
+            name: "main_tabs"
+
+            @GUI::Widget {
+                title: "Processes"
+                name: "processes"
+                layout: @GUI::VerticalBoxLayout {
+                    margins: [4]
+                    spacing: 0
+                }
+
+                @GUI::TableView {
+                    name: "process_table"
+                    column_headers_visible: true
+                }
+            }
+
+            @GUI::Widget {
+                title: "Performance"
+                name: "performance"
+                background_role: "Button"
+                fill_with_background_color: true
+                layout: @GUI::VerticalBoxLayout {
+                    margins: [4]
+                }
+
+                @GUI::GroupBox {
+                    title: "CPU usage"
+                    name: "cpu_graph"
+                    layout: @GUI::VerticalBoxLayout {}
+                }
+
+                @GUI::GroupBox {
+                    title: "Memory usage"
+                    fixed_height: 120
+                    layout: @GUI::VerticalBoxLayout {
+                        margins: [6]
+                    }
+
+                    @SystemMonitor::GraphWidget {
+                        stack_values: true
+                        name: "memory_graph"
+                    }
+                }
+
+                @SystemMonitor::MemoryStatsWidget {
+                    name: "memory_stats"
+                    memory_graph: "memory_graph"
+                }
+            }
+
+            @GUI::LazyWidget {
+                title: "Storage"
+                name: "storage"
+                layout: @GUI::VerticalBoxLayout {
+                    margins: [4]
+                }
+
+                @GUI::TableView {
+                    name: "storage_table"
+                }
+            }
+
+            @SystemMonitor::NetworkStatisticsWidget {
+                title: "Network"
+                name: "network"
+            }
+
+            @GUI::LazyWidget {
+                title: "Hardware"
+                name: "hardware"
+                layout: @GUI::VerticalBoxLayout {
+                    margins: [4]
+                }
+
+                @GUI::GroupBox {
+                    title: "CPUs"
+                    fixed_height: 128
+                    layout: @GUI::VerticalBoxLayout {
+                        margins: [6]
+                    }
+
+                    @GUI::TableView {
+                        name: "cpus_table"
+                    }
+                }
+
+                @GUI::GroupBox {
+                    title: "PCI devices"
+                    layout: @GUI::VerticalBoxLayout {
+                        margins: [6]
+                    }
+
+                    @GUI::TableView {
+                        name: "pci_dev_table"
+                    }
+                }
+            }
+        }
+    }
+
+    @GUI::Statusbar {
+        segment_count: 3
+        name: "statusbar"
+    }
+}

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.cpp
@@ -9,8 +9,13 @@
 #include <LibCore/Timer.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Model.h>
+#include <LibGUI/Widget.h>
 #include <LibSymbolication/Symbolication.h>
 #include <LibThreading/BackgroundAction.h>
+
+REGISTER_WIDGET(SystemMonitor, ThreadStackWidget)
+
+namespace SystemMonitor {
 
 class ThreadStackModel final : public GUI::Model {
 
@@ -126,4 +131,6 @@ void ThreadStackWidget::custom_event(Core::CustomEvent& event)
 {
     auto& completion_event = verify_cast<CompletionEvent>(event);
     verify_cast<ThreadStackModel>(m_stack_table->model())->set_symbols(completion_event.symbols());
+}
+
 }

--- a/Userland/Applications/SystemMonitor/ThreadStackWidget.h
+++ b/Userland/Applications/SystemMonitor/ThreadStackWidget.h
@@ -10,6 +10,8 @@
 #include <LibGUI/TableView.h>
 #include <LibGUI/Widget.h>
 
+namespace SystemMonitor {
+
 class ThreadStackWidget final : public GUI::Widget {
     C_OBJECT(ThreadStackWidget)
 public:
@@ -30,3 +32,5 @@ private:
     RefPtr<GUI::TableView> m_stack_table;
     RefPtr<Core::Timer> m_timer;
 };
+
+}

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -687,14 +687,14 @@ NonnullRefPtr<GUI::Widget> build_performance_tab()
     auto cpu_graph_rows = ceil_div(ProcessModel::the().cpus().size(), cpu_graphs_per_row);
     cpu_graph_group_box.set_fixed_height(120u * cpu_graph_rows);
 
-    Vector<GraphWidget&> cpu_graphs;
+    Vector<SystemMonitor::GraphWidget&> cpu_graphs;
     for (auto row = 0u; row < cpu_graph_rows; ++row) {
         auto& cpu_graph_row = cpu_graph_group_box.add<GUI::Widget>();
         cpu_graph_row.set_layout<GUI::HorizontalBoxLayout>();
         cpu_graph_row.layout()->set_margins(6);
         cpu_graph_row.set_fixed_height(108);
         for (auto i = 0u; i < cpu_graphs_per_row; ++i) {
-            auto& cpu_graph = cpu_graph_row.add<GraphWidget>();
+            auto& cpu_graph = cpu_graph_row.add<SystemMonitor::GraphWidget>();
             cpu_graph.set_max(100);
             cpu_graph.set_value_format(0, {
                                               .graph_color_role = ColorRole::SyntaxPreprocessorStatement,
@@ -725,7 +725,7 @@ NonnullRefPtr<GUI::Widget> build_performance_tab()
     memory_graph_group_box.set_layout<GUI::VerticalBoxLayout>();
     memory_graph_group_box.layout()->set_margins(6);
     memory_graph_group_box.set_fixed_height(120);
-    auto& memory_graph = memory_graph_group_box.add<GraphWidget>();
+    auto& memory_graph = memory_graph_group_box.add<SystemMonitor::GraphWidget>();
     memory_graph.set_stack_values(true);
     memory_graph.set_value_format(0, {
                                          .graph_color_role = ColorRole::SyntaxComment,

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -175,7 +175,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     storage_widget->set_title("Storage");
     tabwidget.add_widget(storage_widget);
 
-    auto network_stats_widget = NetworkStatisticsWidget::construct();
+    auto network_stats_widget = SystemMonitor::NetworkStatisticsWidget::construct();
     network_stats_widget->set_title("Network");
     tabwidget.add_widget(network_stats_widget);
 

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -212,7 +212,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& refresh_timer = window->add<Core::Timer>(
         frequency * 1000, [&] {
             process_model->update();
-            if (auto* memory_stats_widget = MemoryStatsWidget::the())
+            if (auto* memory_stats_widget = SystemMonitor::MemoryStatsWidget::the())
                 memory_stats_widget->refresh();
         });
 
@@ -746,6 +746,6 @@ NonnullRefPtr<GUI::Widget> build_performance_tab()
                                          },
                                      });
 
-    graphs_container->add<MemoryStatsWidget>(memory_graph);
+    graphs_container->add<SystemMonitor::MemoryStatsWidget>(&memory_graph);
     return graphs_container;
 }

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -168,16 +168,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& process_table_container = tabwidget.add_tab<GUI::Widget>("Processes");
 
     auto performance_widget = build_performance_tab();
-    tabwidget.add_widget("Performance", performance_widget);
+    performance_widget->set_title("Performance");
+    tabwidget.add_widget(performance_widget);
 
     auto storage_widget = build_storage_widget();
-    tabwidget.add_widget("Storage", storage_widget);
+    storage_widget->set_title("Storage");
+    tabwidget.add_widget(storage_widget);
 
     auto network_stats_widget = NetworkStatisticsWidget::construct();
-    tabwidget.add_widget("Network", network_stats_widget);
+    network_stats_widget->set_title("Network");
+    tabwidget.add_widget(network_stats_widget);
 
     auto hardware_widget = build_hardware_tab();
-    tabwidget.add_widget("Hardware", hardware_widget);
+    hardware_widget->set_title("Hardware");
+    tabwidget.add_widget(hardware_widget);
 
     process_table_container.set_layout<GUI::VerticalBoxLayout>();
     process_table_container.layout()->set_margins(4);

--- a/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
+++ b/Userland/DevTools/HackStudio/Debugger/DebugInfoWidget.cpp
@@ -61,8 +61,8 @@ DebugInfoWidget::DebugInfoWidget()
     m_backtrace_view = splitter.add<GUI::ListView>();
     auto& variables_tab_widget = splitter.add<GUI::TabWidget>();
     variables_tab_widget.set_tab_position(GUI::TabWidget::TabPosition::Bottom);
-    variables_tab_widget.add_widget("Variables", build_variables_tab());
-    variables_tab_widget.add_widget("Registers", build_registers_tab());
+    variables_tab_widget.add_widget(build_variables_tab());
+    variables_tab_widget.add_widget(build_registers_tab());
 
     m_backtrace_view->on_selection_change = [this] {
         const auto& index = m_backtrace_view->selection().first();
@@ -132,6 +132,7 @@ RefPtr<GUI::Menu> DebugInfoWidget::get_context_menu_for_variable(const GUI::Mode
 NonnullRefPtr<GUI::Widget> DebugInfoWidget::build_variables_tab()
 {
     auto variables_widget = GUI::Widget::construct();
+    variables_widget->set_title("Variables");
     variables_widget->set_layout<GUI::HorizontalBoxLayout>();
 
     m_variables_view = variables_widget->add<GUI::TreeView>();
@@ -148,6 +149,7 @@ NonnullRefPtr<GUI::Widget> DebugInfoWidget::build_variables_tab()
 NonnullRefPtr<GUI::Widget> DebugInfoWidget::build_registers_tab()
 {
     auto registers_widget = GUI::Widget::construct();
+    registers_widget->set_title("Registers");
     registers_widget->set_layout<GUI::HorizontalBoxLayout>();
 
     m_registers_view = registers_widget->add<GUI::TableView>();

--- a/Userland/Libraries/LibCore/Object.h
+++ b/Userland/Libraries/LibCore/Object.h
@@ -318,24 +318,24 @@ T* Object::find_descendant_of_type_named(String const& name) requires IsBaseOf<O
             return true;                                               \
         });
 
-#define REGISTER_SIZE_PROPERTY(property_name, getter, setter)          \
-    register_property(                                                 \
-        property_name,                                                 \
-        [this] {                                                       \
-            auto size = this->getter();                                \
-            JsonObject size_object;                                    \
-            size_object.set("width", size.width());                    \
-            size_object.set("height", size.height());                  \
-            return size_object;                                        \
-        },                                                             \
-        [this](auto& value) {                                          \
-            if (!value.is_object())                                    \
-                return false;                                          \
-            Gfx::IntSize size;                                         \
-            size.set_width(value.as_object().get("width").to_i32());   \
-            size.set_height(value.as_object().get("height").to_i32()); \
-            setter(size);                                              \
-            return true;                                               \
+#define REGISTER_SIZE_PROPERTY(property_name, getter, setter) \
+    register_property(                                        \
+        property_name,                                        \
+        [this] {                                              \
+            auto size = this->getter();                       \
+            JsonArray size_array;                             \
+            size_array.append(size.width());                  \
+            size_array.append(size.height());                 \
+            return size_array;                                \
+        },                                                    \
+        [this](auto& value) {                                 \
+            if (!value.is_array())                            \
+                return false;                                 \
+            Gfx::IntSize size;                                \
+            size.set_width(value.as_array()[0].to_i32());     \
+            size.set_height(value.as_array()[1].to_i32());    \
+            setter(size);                                     \
+            return true;                                      \
         });
 
 #define REGISTER_ENUM_PROPERTY(property_name, getter, setter, EnumType, ...) \

--- a/Userland/Libraries/LibGUI/LazyWidget.cpp
+++ b/Userland/Libraries/LibGUI/LazyWidget.cpp
@@ -7,6 +7,8 @@
 
 #include <LibGUI/LazyWidget.h>
 
+REGISTER_WIDGET(GUI, LazyWidget)
+
 namespace GUI {
 
 void LazyWidget::show_event(ShowEvent&)

--- a/Userland/Libraries/LibGUI/TabWidget.cpp
+++ b/Userland/Libraries/LibGUI/TabWidget.cpp
@@ -41,9 +41,9 @@ TabWidget::TabWidget()
         });
 }
 
-ErrorOr<void> TabWidget::try_add_widget(String title, Widget& widget)
+ErrorOr<void> TabWidget::try_add_widget(Widget& widget)
 {
-    m_tabs.append({ move(title), nullptr, &widget });
+    m_tabs.append({ widget.title(), nullptr, &widget });
     add_child(widget);
     update_focus_policy();
     if (on_tab_count_change)
@@ -51,9 +51,9 @@ ErrorOr<void> TabWidget::try_add_widget(String title, Widget& widget)
     return {};
 }
 
-void TabWidget::add_widget(String title, Widget& widget)
+void TabWidget::add_widget(Widget& widget)
 {
-    MUST(try_add_widget(move(title), widget));
+    MUST(try_add_widget(widget));
 }
 
 void TabWidget::remove_widget(Widget& widget)

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -37,16 +37,17 @@ public:
     GUI::Margins const& container_margins() const { return m_container_margins; }
     void set_container_margins(GUI::Margins const&);
 
-    ErrorOr<void> try_add_widget(String, Widget&);
+    ErrorOr<void> try_add_widget(Widget&);
 
-    void add_widget(String, Widget&);
+    void add_widget(Widget&);
     void remove_widget(Widget&);
 
     template<class T, class... Args>
     ErrorOr<NonnullRefPtr<T>> try_add_tab(String title, Args&&... args)
     {
         auto t = TRY(T::try_create(forward<Args>(args)...));
-        TRY(try_add_widget(move(title), *t));
+        t->set_title(move(title));
+        TRY(try_add_widget(*t));
         return *t;
     }
 
@@ -54,7 +55,8 @@ public:
     T& add_tab(String title, Args&&... args)
     {
         auto t = T::construct(forward<Args>(args)...);
-        add_widget(move(title), *t);
+        t->set_title(move(title));
+        add_widget(*t);
         return *t;
     }
 

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -70,6 +70,8 @@ Widget::Widget()
     REGISTER_INT_PROPERTY("font_size", m_font->presentation_size, set_font_size);
     REGISTER_FONT_WEIGHT_PROPERTY("font_weight", m_font->weight, set_font_weight);
 
+    REGISTER_STRING_PROPERTY("title", title, set_title);
+
     register_property(
         "font_type", [this] { return m_font->is_fixed_width() ? "FixedWidth" : "Normal"; },
         [this](auto& value) {
@@ -974,6 +976,19 @@ void Widget::set_palette(Palette const& palette)
 {
     m_palette = palette.impl();
     update();
+}
+
+void Widget::set_title(String title)
+{
+    m_title = move(title);
+    // For tab widget children, our change in title also affects the parent.
+    if (parent_widget())
+        parent_widget()->update();
+}
+
+String Widget::title() const
+{
+    return m_title;
 }
 
 void Widget::set_background_role(ColorRole role)

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -278,6 +278,9 @@ public:
     Gfx::Palette palette() const;
     void set_palette(Gfx::Palette const&);
 
+    String title() const;
+    void set_title(String);
+
     Margins const& grabbable_margins() const { return m_grabbable_margins; }
     void set_grabbable_margins(Margins const&);
 
@@ -390,6 +393,7 @@ private:
     bool m_default_font { true };
 
     NonnullRefPtr<Gfx::PaletteImpl> m_palette;
+    String m_title { String::empty() };
 
     WeakPtr<Widget> m_focus_proxy;
     FocusPolicy m_focus_policy { FocusPolicy::NoFocus };


### PR DESCRIPTION
Originally I just wanted to tackle #65, one of the oldest still-open issues, but I got sidetracked, so GML it is first.

This includes a fix for how GML and LibGUI entirely handle TabWidgets so that we can use them in GML easier.

Also, change size properties from the `{ "width": x, "height": y }` object format to the `[x, y]` array format known from `margins`.