### PR TITLE
Spreadsheet: Change paste action’s enabled state on clipboard change

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -242,6 +242,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
 
     m_cut_action->set_enabled(false);
     m_copy_action->set_enabled(false);
+    m_paste_action->set_enabled(false);
 
     m_tab_widget->on_context_menu_request = [&](auto& widget, auto& event) {
         m_tab_context_menu_sheet_view = static_cast<SpreadsheetView&>(widget);
@@ -271,6 +272,12 @@ void SpreadsheetWidget::resize_event(GUI::ResizeEvent& event)
         m_inline_documentation_window->set_rect(m_cell_value_editor->screen_relative_rect().translated(0, m_cell_value_editor->height() + 7).inflated(6, 6));
 }
 
+void SpreadsheetWidget::clipboard_content_did_change(String const& mime_type)
+{
+    if (auto* sheet = current_worksheet_if_available())
+        m_paste_action->set_enabled(!sheet->selected_cells().is_empty() && mime_type.starts_with("text/"));
+}
+
 void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
 {
     for (auto& sheet : new_sheets) {
@@ -288,6 +295,7 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
             VERIFY(!selection.is_empty());
             m_cut_action->set_enabled(true);
             m_copy_action->set_enabled(true);
+            m_paste_action->set_enabled(GUI::Clipboard::the().fetch_mime_type().starts_with("text/"));
             m_current_cell_label->set_enabled(true);
             m_cell_value_editor->set_enabled(true);
 
@@ -355,6 +363,7 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
 
             m_cut_action->set_enabled(false);
             m_copy_action->set_enabled(false);
+            m_paste_action->set_enabled(false);
 
             static_cast<CellSyntaxHighlighter*>(const_cast<Syntax::Highlighter*>(m_cell_value_editor->syntax_highlighter()))->set_cell(nullptr);
         };

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -9,12 +9,15 @@
 #include "SpreadsheetView.h"
 #include "Workbook.h"
 #include <AK/NonnullRefPtrVector.h>
+#include <LibGUI/Clipboard.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/Widget.h>
 
 namespace Spreadsheet {
 
-class SpreadsheetWidget final : public GUI::Widget {
+class SpreadsheetWidget final
+    : public GUI::Widget
+    , public GUI::Clipboard::ClipboardClient {
     C_OBJECT(SpreadsheetWidget);
 
 public:
@@ -49,7 +52,11 @@ public:
     auto& undo_stack() { return m_undo_stack; }
 
 private:
+    // ^GUI::Widget
     virtual void resize_event(GUI::ResizeEvent&) override;
+
+    // ^GUI::Clipboard::ClipboardClient
+    virtual void clipboard_content_did_change(String const& mime_type) override;
 
     explicit SpreadsheetWidget(GUI::Window& window, NonnullRefPtrVector<Sheet>&& sheets = {}, bool should_add_sheet_if_empty = true);
 


### PR DESCRIPTION
Previously, the paste action was always enabled and always assumed that anything was selected, which led to a crash by clicking the paste action right after the application startup.

https://user-images.githubusercontent.com/16520278/159097679-aae745ef-e2ea-481a-b71a-7342476dd109.mp4

This patch will automatically enable/disable the paste action depending on whether a selection exists (it usually does, except on the app launch and after adding a new tab) and if the clipboard mime type is a text/ group.

So no, you can’t paste an image into the app anymore, even though this mostly froze the app before…