### PR TITLE
LibGfx/LibGfxScaleDemo: Fix scaling for AntiAliasingPainter::draw_circle()

### DIFF
--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -44,15 +44,15 @@ private:
 
 Canvas::Canvas()
 {
-    m_bitmap_1x = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { WIDTH, HEIGHT }, 1).release_value_but_fixme_should_propagate_errors();
-    m_bitmap_2x = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { WIDTH, HEIGHT }, 2).release_value_but_fixme_should_propagate_errors();
+    m_bitmap_1x = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, { WIDTH, HEIGHT }, 1).release_value_but_fixme_should_propagate_errors();
+    m_bitmap_2x = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, { WIDTH, HEIGHT }, 2).release_value_but_fixme_should_propagate_errors();
 
     // m_bitmap_1x and m_bitmap_2x have the same logical size, so LibGfx will try to draw them at the same physical size:
     // When drawing on a 2x backing store it'd scale m_bitmap_1x up 2x and paint m_bitmap_2x at its physical size.
     // When drawing on a 1x backing store it'd draw m_bitmap_1x at its physical size, and it would have to scale down m_bitmap_2x to 0.5x its size.
     // But the system can't current scale down, and we want to draw the 2x bitmap at twice the size of the 1x bitmap in this particular application,
     // so make a 1x alias of the 2x bitmap to make LibGfx paint it without any scaling at paint time, mapping once pixel to one pixel.
-    m_bitmap_2x_as_1x = Gfx::Bitmap::try_create_wrapper(Gfx::BitmapFormat::BGRx8888, m_bitmap_2x->physical_size(), 1, m_bitmap_2x->pitch(), m_bitmap_2x->scanline(0)).release_value_but_fixme_should_propagate_errors();
+    m_bitmap_2x_as_1x = Gfx::Bitmap::try_create_wrapper(Gfx::BitmapFormat::BGRA8888, m_bitmap_2x->physical_size(), 1, m_bitmap_2x->pitch(), m_bitmap_2x->scanline(0)).release_value_but_fixme_should_propagate_errors();
 
     Gfx::Painter painter_1x(*m_bitmap_1x);
     draw(painter_1x);
@@ -75,8 +75,10 @@ void Canvas::paint_event(GUI::PaintEvent& event)
 void Canvas::draw(Gfx::Painter& painter)
 {
     auto active_window_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window.png").release_value_but_fixme_should_propagate_errors();
+
     Gfx::WindowTheme::current().paint_normal_frame(painter, Gfx::WindowTheme::WindowState::Active, { 4, 18, WIDTH - 8, HEIGHT - 29 }, "Well hello friends 🐞", *active_window_icon, palette(), { WIDTH - 20, 6, 16, 16 }, 0, false);
 
+    painter.fill_rect({ 4, 25, WIDTH - 8, HEIGHT - 30 }, palette().color(Gfx::ColorRole::Background));
     painter.draw_rect({ 20, 34, WIDTH - 40, HEIGHT - 45 }, palette().color(Gfx::ColorRole::Selection), true);
     painter.draw_rect({ 24, 38, WIDTH - 48, HEIGHT - 53 }, palette().color(Gfx::ColorRole::Selection));
 

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -178,6 +178,9 @@ void Gfx::AntiAliasingPainter::draw_circle(IntPoint center, int radius, Color co
     Inline comments are from the paper.
     */
 
+    center *= m_underlying_painter.scale();
+    radius *= m_underlying_painter.scale();
+
     // TODO: Generalize to ellipses (see paper)
 
     // These happen to be the same here, but are treated separately in the paper:
@@ -337,11 +340,11 @@ void Gfx::AntiAliasingPainter::fill_rect_with_rounded_corners(IntRect const& a_r
         a_rect.x() + a_rect.width() - top_right_radius,
         a_rect.y() + top_right_radius,
     };
-    IntPoint bottom_right_corner {
+    IntPoint bottom_left_corner {
         a_rect.x() + bottom_left_radius,
         a_rect.y() + a_rect.height() - bottom_right_radius
     };
-    IntPoint bottom_left_corner {
+    IntPoint bottom_right_corner {
         a_rect.x() + a_rect.width() - bottom_left_radius,
         a_rect.y() + a_rect.height() - bottom_left_radius
     };

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1685,11 +1685,11 @@ void Painter::draw_text(Function<void(IntRect const&, Utf8CodePointIterator&)> d
 
 void Painter::set_pixel(IntPoint const& p, Color color, bool blend)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
     auto point = p;
     point.translate_by(state().translation);
-    if (!clip_rect().contains(point))
+    // Use the scale only to avoid clipping pixels set in drawing functions that handle
+    // scaling and call set_pixel() -- do not scale the pixel.
+    if (!clip_rect().contains(point / scale()))
         return;
     auto& dst = m_target->scanline(point.y())[point.x()];
     if (!blend) {

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -145,11 +145,12 @@ public:
 
     IntRect clip_rect() const { return state().clip_rect; }
 
+    int scale() const { return state().scale; }
+
 protected:
     IntPoint translation() const { return state().translation; }
     IntRect to_physical(IntRect const& r) const { return r.translated(translation()) * scale(); }
     IntPoint to_physical(IntPoint const& p) const { return p.translated(translation()) * scale(); }
-    int scale() const { return state().scale; }
     void set_physical_pixel_with_draw_op(u32& pixel, Color const&);
     void fill_physical_scanline_with_draw_op(int y, int x, int width, Color const& color);
     void fill_rect_with_draw_op(IntRect const&, Color);


### PR DESCRIPTION
Fixes/adds scaling in `AntiAliasingPainter::draw_circle()` (currently it crashes when scaling is enabled).

Also switches `LibGfxScaleDemo` to use a `BGRA8888` bitmap rather than `BGRx8888` so the blending used in the anti-aliased
window frames works.