### PR TITLE
Browser+LibGUI: Make CTRL+Enter append .com to the URL

### DIFF
--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -94,6 +94,13 @@ private:
     void view_source(const URL& url, const String& source);
     void update_status(Optional<String> text_override = {}, i32 count_waiting = 0);
 
+    enum class MayAppendTLD {
+        No,
+        Yes
+    };
+
+    Optional<URL> url_from_location_bar(MayAppendTLD = MayAppendTLD::No);
+
     History m_history;
 
     RefPtr<Web::OutOfProcessWebView> m_web_content_view;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -781,6 +781,12 @@ void TextEditor::keydown_event(KeyEvent& event)
             return;
         }
 
+        if (event.modifiers() == KeyModifier::Mod_Ctrl && event.key() == KeyCode::Key_Return) {
+            if (on_ctrl_return_pressed)
+                on_ctrl_return_pressed();
+            return;
+        }
+
         if (event.key() == KeyCode::Key_Return) {
             if (on_return_pressed)
                 on_return_pressed();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -155,6 +155,7 @@ public:
     Function<void()> on_mousedown;
     Function<void()> on_return_pressed;
     Function<void()> on_shift_return_pressed;
+    Function<void()> on_ctrl_return_pressed;
     Function<void()> on_escape_pressed;
     Function<void()> on_up_pressed;
     Function<void()> on_down_pressed;


### PR DESCRIPTION
This patch adds the behavior seen in other browsers where, by pressing CTRL+Enter in the URL bar, `.com` is automatically appended (if no domain extension is yet present).

The list of all possible domain extension is to be done in the future. :)