### PR TITLE
LibWeb: Don't serialize hex-colors as identifiers

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.cpp
@@ -23,8 +23,15 @@ String Token::to_string() const
         return String::formatted("{}(", serialize_an_identifier(function()));
     case Type::AtKeyword:
         return String::formatted("@{}", serialize_an_identifier(at_keyword()));
-    case Type::Hash:
-        return String::formatted("#{}", serialize_an_identifier(hash_value()));
+    case Type::Hash: {
+        switch (m_hash_type) {
+        case HashType::Id:
+            return String::formatted("#{}", serialize_an_identifier(hash_value()));
+        case HashType::Unrestricted:
+            return String::formatted("#{}", hash_value());
+        }
+        VERIFY_NOT_REACHED();
+    }
     case Type::String:
         return serialize_a_string(string());
     case Type::BadString:


### PR DESCRIPTION
ID selectors need to be serialized as identifiers in the spec, but other
hash-values do not. This was causing hex colors that start with a
number, like `#54a3ff`, to serialize as `#\35 4a3ff`, which is silly
and unnecessary.

Selector serialization is done elsewhere, so this case in Token is
probably also unnecessary, but there might be situations I haven't
thought of where serializing an ID does need to happen while it's still
a Token.