### PR TITLE
CMake: Install generated IPC headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ serenity_component(
 )
 
 if (HACKSTUDIO_BUILD)
+    include_directories(/usr/include/Userland/Services)
     include(${HACKSTUDIO_BUILD_CMAKE_FILE})
     return()
 endif()

--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -32,6 +32,10 @@ function(compile_ipc source output)
     get_filename_component(output_name ${output} NAME)
     add_custom_target(generate_${output_name} DEPENDS ${output})
     add_dependencies(all_generated generate_${output_name})
+
+    string(LENGTH ${SerenityOS_SOURCE_DIR} root_source_dir_length)
+    string(SUBSTRING ${CMAKE_CURRENT_SOURCE_DIR} ${root_source_dir_length} -1 current_source_dir_relative)
+    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${output} DESTINATION usr/include${current_source_dir_relative} OPTIONAL)
 endfunction()
 
 function(generate_state_machine source header)

--- a/Meta/CMake/code_generators.cmake
+++ b/Meta/CMake/code_generators.cmake
@@ -33,6 +33,8 @@ function(compile_ipc source output)
     add_custom_target(generate_${output_name} DEPENDS ${output})
     add_dependencies(all_generated generate_${output_name})
 
+    # TODO: Use cmake_path() when we upgrade the minimum CMake version to 3.20
+    #       https://cmake.org/cmake/help/v3.23/command/cmake_path.html#relative-path
     string(LENGTH ${SerenityOS_SOURCE_DIR} root_source_dir_length)
     string(SUBSTRING ${CMAKE_CURRENT_SOURCE_DIR} ${root_source_dir_length} -1 current_source_dir_relative)
     install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${output} DESTINATION usr/include${current_source_dir_relative} OPTIONAL)

--- a/Meta/CMake/utils.cmake
+++ b/Meta/CMake/utils.cmake
@@ -11,6 +11,8 @@ function(serenity_install_headers target_name)
 endfunction()
 
 function(serenity_install_sources)
+    # TODO: Use cmake_path() when we upgrade the minimum CMake version to 3.20
+    #       https://cmake.org/cmake/help/v3.23/command/cmake_path.html#relative-path
     string(LENGTH ${SerenityOS_SOURCE_DIR} root_source_dir_length)
     string(SUBSTRING ${CMAKE_CURRENT_SOURCE_DIR} ${root_source_dir_length} -1 current_source_dir_relative)
     file(GLOB_RECURSE sources RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} "*.h" "*.cpp")

--- a/Userland/DevTools/HackStudio/ProjectBuilder.cpp
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.cpp
@@ -185,7 +185,7 @@ HashMap<String, NonnullOwnPtr<ProjectBuilder::LibraryInfo>> ProjectBuilder::get_
 
 void ProjectBuilder::for_each_library_definition(Function<void(String, String)> func)
 {
-    Vector<String> arguments = { "-c", "find Userland/Libraries -name CMakeLists.txt | xargs grep serenity_lib" };
+    Vector<String> arguments = { "-c", "find Userland -name CMakeLists.txt | xargs grep serenity_lib" };
     auto res = Core::command("/bin/sh", arguments, {});
     if (res.is_error()) {
         warnln("{}", res.error());


### PR DESCRIPTION
This installs the generated IPC headers in the filesystem image, which means they can be used when building serenity components in-system from Hack Studio.
After this change, we can now build most components from Hack Studio.

However other types of generated headers are not yet supported, which means that components that use `gml` or LibWeb  do not currently work.