### PR TITLE
Everywhere: Rename ALWAYS_INLINE => AK_ALWAYS_INLINE

### DIFF
--- a/AK/Atomic.h
+++ b/AK/Atomic.h
@@ -178,12 +178,12 @@ public:
         return __atomic_compare_exchange(&m_value, &expected, &desired, false, order, order);
     }
 
-    ALWAYS_INLINE operator T() const volatile noexcept
+    AK_ALWAYS_INLINE operator T() const volatile noexcept
     {
         return load();
     }
 
-    ALWAYS_INLINE T load(MemoryOrder order = DefaultMemoryOrder) const volatile noexcept
+    AK_ALWAYS_INLINE T load(MemoryOrder order = DefaultMemoryOrder) const volatile noexcept
     {
         alignas(T) u8 buffer[sizeof(T)];
         T* ret = reinterpret_cast<T*>(buffer);
@@ -192,18 +192,18 @@ public:
     }
 
     // NOLINTNEXTLINE(misc-unconventional-assign-operator) We want operator= to exchange the value, so returning an object of type Atomic& here does not make sense
-    ALWAYS_INLINE T operator=(T desired) volatile noexcept
+    AK_ALWAYS_INLINE T operator=(T desired) volatile noexcept
     {
         store(desired);
         return desired;
     }
 
-    ALWAYS_INLINE void store(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    AK_ALWAYS_INLINE void store(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         __atomic_store(&m_value, &desired, order);
     }
 
-    ALWAYS_INLINE bool is_lock_free() const volatile noexcept
+    AK_ALWAYS_INLINE bool is_lock_free() const volatile noexcept
     {
         return __atomic_is_lock_free(sizeof(m_value), &m_value);
     }
@@ -242,99 +242,99 @@ public:
         return __atomic_compare_exchange_n(&m_value, &expected, desired, false, order, order);
     }
 
-    ALWAYS_INLINE T operator++() volatile noexcept
+    AK_ALWAYS_INLINE T operator++() volatile noexcept
     {
         return fetch_add(1) + 1;
     }
 
-    ALWAYS_INLINE T operator++(int) volatile noexcept
+    AK_ALWAYS_INLINE T operator++(int) volatile noexcept
     {
         return fetch_add(1);
     }
 
-    ALWAYS_INLINE T operator+=(T val) volatile noexcept
+    AK_ALWAYS_INLINE T operator+=(T val) volatile noexcept
     {
         return fetch_add(val) + val;
     }
 
-    ALWAYS_INLINE T fetch_add(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    AK_ALWAYS_INLINE T fetch_add(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         return __atomic_fetch_add(&m_value, val, order);
     }
 
-    ALWAYS_INLINE T operator--() volatile noexcept
+    AK_ALWAYS_INLINE T operator--() volatile noexcept
     {
         return fetch_sub(1) - 1;
     }
 
-    ALWAYS_INLINE T operator--(int) volatile noexcept
+    AK_ALWAYS_INLINE T operator--(int) volatile noexcept
     {
         return fetch_sub(1);
     }
 
-    ALWAYS_INLINE T operator-=(T val) volatile noexcept
+    AK_ALWAYS_INLINE T operator-=(T val) volatile noexcept
     {
         return fetch_sub(val) - val;
     }
 
-    ALWAYS_INLINE T fetch_sub(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    AK_ALWAYS_INLINE T fetch_sub(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         return __atomic_fetch_sub(&m_value, val, order);
     }
 
-    ALWAYS_INLINE T operator&=(T val) volatile noexcept
+    AK_ALWAYS_INLINE T operator&=(T val) volatile noexcept
     {
         return fetch_and(val) & val;
     }
 
-    ALWAYS_INLINE T fetch_and(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    AK_ALWAYS_INLINE T fetch_and(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         return __atomic_fetch_and(&m_value, val, order);
     }
 
-    ALWAYS_INLINE T operator|=(T val) volatile noexcept
+    AK_ALWAYS_INLINE T operator|=(T val) volatile noexcept
     {
         return fetch_or(val) | val;
     }
 
-    ALWAYS_INLINE T fetch_or(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    AK_ALWAYS_INLINE T fetch_or(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         return __atomic_fetch_or(&m_value, val, order);
     }
 
-    ALWAYS_INLINE T operator^=(T val) volatile noexcept
+    AK_ALWAYS_INLINE T operator^=(T val) volatile noexcept
     {
         return fetch_xor(val) ^ val;
     }
 
-    ALWAYS_INLINE T fetch_xor(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    AK_ALWAYS_INLINE T fetch_xor(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         return __atomic_fetch_xor(&m_value, val, order);
     }
 
-    ALWAYS_INLINE operator T() const volatile noexcept
+    AK_ALWAYS_INLINE operator T() const volatile noexcept
     {
         return load();
     }
 
-    ALWAYS_INLINE T load(MemoryOrder order = DefaultMemoryOrder) const volatile noexcept
+    AK_ALWAYS_INLINE T load(MemoryOrder order = DefaultMemoryOrder) const volatile noexcept
     {
         return __atomic_load_n(&m_value, order);
     }
 
     // NOLINTNEXTLINE(misc-unconventional-assign-operator) We want operator= to exchange the value, so returning an object of type Atomic& here does not make sense
-    ALWAYS_INLINE T operator=(T desired) volatile noexcept
+    AK_ALWAYS_INLINE T operator=(T desired) volatile noexcept
     {
         store(desired);
         return desired;
     }
 
-    ALWAYS_INLINE void store(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    AK_ALWAYS_INLINE void store(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         __atomic_store_n(&m_value, desired, order);
     }
 
-    ALWAYS_INLINE bool is_lock_free() const volatile noexcept
+    AK_ALWAYS_INLINE bool is_lock_free() const volatile noexcept
     {
         return __atomic_is_lock_free(sizeof(m_value), &m_value);
     }

--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -150,12 +150,12 @@ public:
         m_size = 0;
     }
 
-    ALWAYS_INLINE void resize(size_t new_size)
+    AK_ALWAYS_INLINE void resize(size_t new_size)
     {
         MUST(try_resize(new_size));
     }
 
-    ALWAYS_INLINE void ensure_capacity(size_t new_capacity)
+    AK_ALWAYS_INLINE void ensure_capacity(size_t new_capacity)
     {
         MUST(try_ensure_capacity(new_capacity));
     }
@@ -250,7 +250,7 @@ public:
     operator Bytes() { return bytes(); }
     operator ReadonlyBytes() const { return bytes(); }
 
-    ALWAYS_INLINE size_t capacity() const { return m_inline ? inline_capacity : m_outline_capacity; }
+    AK_ALWAYS_INLINE size_t capacity() const { return m_inline ? inline_capacity : m_outline_capacity; }
 
 private:
     void move_from(ByteBuffer&& other)

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -156,13 +156,13 @@ public:
         return m_overflow;
     }
 
-    ALWAYS_INLINE constexpr bool operator!() const
+    AK_ALWAYS_INLINE constexpr bool operator!() const
     {
         VERIFY(!m_overflow);
         return !m_value;
     }
 
-    ALWAYS_INLINE constexpr T value() const
+    AK_ALWAYS_INLINE constexpr T value() const
     {
         VERIFY(!m_overflow);
         return m_value;

--- a/AK/Endian.h
+++ b/AK/Endian.h
@@ -37,7 +37,7 @@
 namespace AK {
 
 template<typename T>
-ALWAYS_INLINE constexpr T convert_between_host_and_little_endian(T value)
+AK_ALWAYS_INLINE constexpr T convert_between_host_and_little_endian(T value)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     return value;
@@ -54,7 +54,7 @@ ALWAYS_INLINE constexpr T convert_between_host_and_little_endian(T value)
 }
 
 template<typename T>
-ALWAYS_INLINE constexpr T convert_between_host_and_big_endian(T value)
+AK_ALWAYS_INLINE constexpr T convert_between_host_and_big_endian(T value)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     if constexpr (sizeof(T) == 8)
@@ -71,7 +71,7 @@ ALWAYS_INLINE constexpr T convert_between_host_and_big_endian(T value)
 }
 
 template<typename T>
-ALWAYS_INLINE T convert_between_host_and_network_endian(T value)
+AK_ALWAYS_INLINE T convert_between_host_and_network_endian(T value)
 {
     return convert_between_host_and_big_endian(value);
 }

--- a/AK/Error.h
+++ b/AK/Error.h
@@ -62,7 +62,7 @@ public:
     using Variant<T, ErrorType>::Variant;
 
     template<typename U>
-    ALWAYS_INLINE ErrorOr(U&& value) requires(!IsSame<RemoveCVReference<U>, ErrorOr<T>>)
+    AK_ALWAYS_INLINE ErrorOr(U&& value) requires(!IsSame<RemoveCVReference<U>, ErrorOr<T>>)
         : Variant<T, ErrorType>(forward<U>(value))
     {
     }

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -46,7 +46,7 @@ public:
     }
 
     template<FloatingPoint F>
-    explicit ALWAYS_INLINE operator F() const
+    explicit AK_ALWAYS_INLINE operator F() const
     {
         return (F)m_value * pow<F>(0.5, precision);
     }

--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -68,8 +68,8 @@ public:
     const char* characters() const { return m_impl ? m_impl->characters() : nullptr; }
     size_t length() const { return m_impl ? m_impl->length() : 0; }
 
-    ALWAYS_INLINE u32 hash() const { return m_impl ? m_impl->existing_hash() : 0; }
-    ALWAYS_INLINE StringView view() const { return m_impl ? m_impl->view() : StringView {}; }
+    AK_ALWAYS_INLINE u32 hash() const { return m_impl ? m_impl->existing_hash() : 0; }
+    AK_ALWAYS_INLINE StringView view() const { return m_impl ? m_impl->view() : StringView {}; }
 
     FlyString to_lowercase() const;
 
@@ -85,7 +85,7 @@ public:
     static void did_destroy_impl(Badge<StringImpl>, StringImpl&);
 
     template<typename... Ts>
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr bool is_one_of(Ts... strings) const
     {
         return (... || this->operator==(forward<Ts>(strings)));
     }

--- a/AK/Iterator.h
+++ b/AK/Iterator.h
@@ -52,11 +52,11 @@ public:
         return SimpleIterator { m_container, m_index + 1 };
     }
 
-    ALWAYS_INLINE constexpr ValueType const& operator*() const { return m_container[m_index]; }
-    ALWAYS_INLINE constexpr ValueType& operator*() { return m_container[m_index]; }
+    AK_ALWAYS_INLINE constexpr ValueType const& operator*() const { return m_container[m_index]; }
+    AK_ALWAYS_INLINE constexpr ValueType& operator*() { return m_container[m_index]; }
 
-    ALWAYS_INLINE constexpr ValueType const* operator->() const { return &m_container[m_index]; }
-    ALWAYS_INLINE constexpr ValueType* operator->() { return &m_container[m_index]; }
+    AK_ALWAYS_INLINE constexpr ValueType const* operator->() const { return &m_container[m_index]; }
+    AK_ALWAYS_INLINE constexpr ValueType* operator->() { return &m_container[m_index]; }
 
     SimpleIterator& operator=(const SimpleIterator& other)
     {

--- a/AK/Memory.h
+++ b/AK/Memory.h
@@ -16,7 +16,7 @@
 #    include <string.h>
 #endif
 
-ALWAYS_INLINE void fast_u32_copy(u32* dest, const u32* src, size_t count)
+AK_ALWAYS_INLINE void fast_u32_copy(u32* dest, const u32* src, size_t count)
 {
 #if ARCH(I386) || ARCH(X86_64)
     asm volatile(
@@ -27,7 +27,7 @@ ALWAYS_INLINE void fast_u32_copy(u32* dest, const u32* src, size_t count)
 #endif
 }
 
-ALWAYS_INLINE void fast_u32_fill(u32* dest, u32 value, size_t count)
+AK_ALWAYS_INLINE void fast_u32_fill(u32* dest, u32 value, size_t count)
 {
 #if ARCH(I386) || ARCH(X86_64)
     asm volatile(

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -97,26 +97,26 @@ public:
         return exchange(m_ptr, nullptr);
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* ptr()
+    AK_ALWAYS_INLINE RETURNS_NONNULL T* ptr()
     {
         VERIFY(m_ptr);
         return m_ptr;
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
+    AK_ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
     {
         VERIFY(m_ptr);
         return m_ptr;
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* operator->() { return ptr(); }
-    ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const { return ptr(); }
+    AK_ALWAYS_INLINE RETURNS_NONNULL T* operator->() { return ptr(); }
+    AK_ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const { return ptr(); }
 
-    ALWAYS_INLINE T& operator*() { return *ptr(); }
-    ALWAYS_INLINE const T& operator*() const { return *ptr(); }
+    AK_ALWAYS_INLINE T& operator*() { return *ptr(); }
+    AK_ALWAYS_INLINE const T& operator*() const { return *ptr(); }
 
-    ALWAYS_INLINE RETURNS_NONNULL operator const T*() const { return ptr(); }
-    ALWAYS_INLINE RETURNS_NONNULL operator T*() { return ptr(); }
+    AK_ALWAYS_INLINE RETURNS_NONNULL operator const T*() const { return ptr(); }
+    AK_ALWAYS_INLINE RETURNS_NONNULL operator T*() { return ptr(); }
 
     operator bool() const = delete;
     bool operator!() const = delete;

--- a/AK/NonnullPtrVector.h
+++ b/AK/NonnullPtrVector.h
@@ -34,30 +34,30 @@ public:
     using ReverseIterator = SimpleReverseIterator<NonnullPtrVector, T>;
     using ReverseConstIterator = SimpleReverseIterator<NonnullPtrVector, T const>;
 
-    ALWAYS_INLINE constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }
-    ALWAYS_INLINE constexpr Iterator begin() { return Iterator::begin(*this); }
-    ALWAYS_INLINE constexpr ReverseIterator rbegin() { return ReverseIterator::rbegin(*this); }
-    ALWAYS_INLINE constexpr ReverseConstIterator rbegin() const { return ReverseConstIterator::rbegin(*this); }
+    AK_ALWAYS_INLINE constexpr ConstIterator begin() const { return ConstIterator::begin(*this); }
+    AK_ALWAYS_INLINE constexpr Iterator begin() { return Iterator::begin(*this); }
+    AK_ALWAYS_INLINE constexpr ReverseIterator rbegin() { return ReverseIterator::rbegin(*this); }
+    AK_ALWAYS_INLINE constexpr ReverseConstIterator rbegin() const { return ReverseConstIterator::rbegin(*this); }
 
-    ALWAYS_INLINE constexpr ConstIterator end() const { return ConstIterator::end(*this); }
-    ALWAYS_INLINE constexpr Iterator end() { return Iterator::end(*this); }
-    ALWAYS_INLINE constexpr ReverseIterator rend() { return ReverseIterator::rend(*this); }
-    ALWAYS_INLINE constexpr ReverseConstIterator rend() const { return ReverseConstIterator::rend(*this); }
+    AK_ALWAYS_INLINE constexpr ConstIterator end() const { return ConstIterator::end(*this); }
+    AK_ALWAYS_INLINE constexpr Iterator end() { return Iterator::end(*this); }
+    AK_ALWAYS_INLINE constexpr ReverseIterator rend() { return ReverseIterator::rend(*this); }
+    AK_ALWAYS_INLINE constexpr ReverseConstIterator rend() const { return ReverseConstIterator::rend(*this); }
 
-    ALWAYS_INLINE constexpr auto in_reverse() { return ReverseWrapper::in_reverse(*this); }
-    ALWAYS_INLINE constexpr auto in_reverse() const { return ReverseWrapper::in_reverse(*this); }
+    AK_ALWAYS_INLINE constexpr auto in_reverse() { return ReverseWrapper::in_reverse(*this); }
+    AK_ALWAYS_INLINE constexpr auto in_reverse() const { return ReverseWrapper::in_reverse(*this); }
 
-    ALWAYS_INLINE PtrType& ptr_at(size_t index) { return Base::at(index); }
-    ALWAYS_INLINE const PtrType& ptr_at(size_t index) const { return Base::at(index); }
+    AK_ALWAYS_INLINE PtrType& ptr_at(size_t index) { return Base::at(index); }
+    AK_ALWAYS_INLINE const PtrType& ptr_at(size_t index) const { return Base::at(index); }
 
-    ALWAYS_INLINE T& at(size_t index) { return *Base::at(index); }
-    ALWAYS_INLINE const T& at(size_t index) const { return *Base::at(index); }
-    ALWAYS_INLINE T& operator[](size_t index) { return at(index); }
-    ALWAYS_INLINE const T& operator[](size_t index) const { return at(index); }
-    ALWAYS_INLINE T& first() { return at(0); }
-    ALWAYS_INLINE const T& first() const { return at(0); }
-    ALWAYS_INLINE T& last() { return at(size() - 1); }
-    ALWAYS_INLINE const T& last() const { return at(size() - 1); }
+    AK_ALWAYS_INLINE T& at(size_t index) { return *Base::at(index); }
+    AK_ALWAYS_INLINE const T& at(size_t index) const { return *Base::at(index); }
+    AK_ALWAYS_INLINE T& operator[](size_t index) { return at(index); }
+    AK_ALWAYS_INLINE const T& operator[](size_t index) const { return at(index); }
+    AK_ALWAYS_INLINE T& first() { return at(0); }
+    AK_ALWAYS_INLINE const T& first() const { return at(0); }
+    AK_ALWAYS_INLINE T& last() { return at(size() - 1); }
+    AK_ALWAYS_INLINE const T& last() const { return at(size() - 1); }
 
 private:
     // NOTE: You can't use resize() on a NonnullFooPtrVector since making the vector

--- a/AK/NonnullRefPtr.h
+++ b/AK/NonnullRefPtr.h
@@ -25,14 +25,14 @@ template<typename T, typename PtrTraits>
 class RefPtr;
 
 template<typename T>
-ALWAYS_INLINE void ref_if_not_null(T* ptr)
+AK_ALWAYS_INLINE void ref_if_not_null(T* ptr)
 {
     if (ptr)
         ptr->ref();
 }
 
 template<typename T>
-ALWAYS_INLINE void unref_if_not_null(T* ptr)
+AK_ALWAYS_INLINE void unref_if_not_null(T* ptr)
 {
     if (ptr)
         ptr->unref();
@@ -52,49 +52,49 @@ public:
 
     enum AdoptTag { Adopt };
 
-    ALWAYS_INLINE NonnullRefPtr(T const& object)
+    AK_ALWAYS_INLINE NonnullRefPtr(T const& object)
         : m_ptr(const_cast<T*>(&object))
     {
         m_ptr->ref();
     }
 
     template<typename U>
-    ALWAYS_INLINE NonnullRefPtr(U const& object) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE NonnullRefPtr(U const& object) requires(IsConvertible<U*, T*>)
         : m_ptr(const_cast<T*>(static_cast<T const*>(&object)))
     {
         m_ptr->ref();
     }
 
-    ALWAYS_INLINE NonnullRefPtr(AdoptTag, T& object)
+    AK_ALWAYS_INLINE NonnullRefPtr(AdoptTag, T& object)
         : m_ptr(&object)
     {
     }
 
-    ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr&& other)
+    AK_ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr&& other)
         : m_ptr(&other.leak_ref())
     {
     }
 
     template<typename U>
-    ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
         : m_ptr(static_cast<T*>(&other.leak_ref()))
     {
     }
 
-    ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr const& other)
+    AK_ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr const& other)
         : m_ptr(const_cast<T*>(other.ptr()))
     {
         m_ptr->ref();
     }
 
     template<typename U>
-    ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr<U> const& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr<U> const& other) requires(IsConvertible<U*, T*>)
         : m_ptr(const_cast<T*>(static_cast<T const*>(other.ptr())))
     {
         m_ptr->ref();
     }
 
-    ALWAYS_INLINE ~NonnullRefPtr()
+    AK_ALWAYS_INLINE ~NonnullRefPtr()
     {
         unref_if_not_null(m_ptr);
         m_ptr = nullptr;
@@ -130,7 +130,7 @@ public:
         return *this;
     }
 
-    ALWAYS_INLINE NonnullRefPtr& operator=(NonnullRefPtr&& other)
+    AK_ALWAYS_INLINE NonnullRefPtr& operator=(NonnullRefPtr&& other)
     {
         NonnullRefPtr tmp { move(other) };
         swap(tmp);
@@ -152,54 +152,54 @@ public:
         return *this;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T& leak_ref()
+    [[nodiscard]] AK_ALWAYS_INLINE T& leak_ref()
     {
         T* ptr = exchange(m_ptr, nullptr);
         VERIFY(ptr);
         return *ptr;
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* ptr()
+    AK_ALWAYS_INLINE RETURNS_NONNULL T* ptr()
     {
         return as_nonnull_ptr();
     }
-    ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
-    {
-        return as_nonnull_ptr();
-    }
-
-    ALWAYS_INLINE RETURNS_NONNULL T* operator->()
-    {
-        return as_nonnull_ptr();
-    }
-    ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const
+    AK_ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE T& operator*()
+    AK_ALWAYS_INLINE RETURNS_NONNULL T* operator->()
+    {
+        return as_nonnull_ptr();
+    }
+    AK_ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const
+    {
+        return as_nonnull_ptr();
+    }
+
+    AK_ALWAYS_INLINE T& operator*()
     {
         return *as_nonnull_ptr();
     }
-    ALWAYS_INLINE const T& operator*() const
+    AK_ALWAYS_INLINE const T& operator*() const
     {
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL operator T*()
+    AK_ALWAYS_INLINE RETURNS_NONNULL operator T*()
     {
         return as_nonnull_ptr();
     }
-    ALWAYS_INLINE RETURNS_NONNULL operator const T*() const
+    AK_ALWAYS_INLINE RETURNS_NONNULL operator const T*() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE operator T&()
+    AK_ALWAYS_INLINE operator T&()
     {
         return *as_nonnull_ptr();
     }
-    ALWAYS_INLINE operator const T&() const
+    AK_ALWAYS_INLINE operator const T&() const
     {
         return *as_nonnull_ptr();
     }
@@ -223,7 +223,7 @@ private:
     NonnullRefPtr() = delete;
     // clang-format on
 
-    ALWAYS_INLINE RETURNS_NONNULL T* as_nonnull_ptr() const
+    AK_ALWAYS_INLINE RETURNS_NONNULL T* as_nonnull_ptr() const
     {
         VERIFY(m_ptr);
         return m_ptr;

--- a/AK/Optional.h
+++ b/AK/Optional.h
@@ -30,7 +30,7 @@ class [[nodiscard]] Optional {
 public:
     using ValueType = T;
 
-    ALWAYS_INLINE Optional() = default;
+    AK_ALWAYS_INLINE Optional() = default;
 
 #ifdef AK_HAS_CONDITIONALLY_TRIVIAL
     Optional(Optional const& other) requires(!IsCopyConstructible<T>) = delete;
@@ -47,7 +47,7 @@ public:
     ~Optional() = default;
 #endif
 
-    ALWAYS_INLINE Optional(Optional const& other)
+    AK_ALWAYS_INLINE Optional(Optional const& other)
 #ifdef AK_HAS_CONDITIONALLY_TRIVIAL
         requires(!IsTriviallyCopyConstructible<T>)
 #endif
@@ -57,7 +57,7 @@ public:
             new (&m_storage) T(other.value());
     }
 
-    ALWAYS_INLINE Optional(Optional&& other)
+    AK_ALWAYS_INLINE Optional(Optional&& other)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
@@ -65,7 +65,7 @@ public:
     }
 
     template<typename U>
-    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE explicit Optional(Optional<U> const& other)
+    requires(IsConstructible<T, U const&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) AK_ALWAYS_INLINE explicit Optional(Optional<U> const& other)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
@@ -73,7 +73,7 @@ public:
     }
 
     template<typename U>
-    requires(IsConstructible<T, U&&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) ALWAYS_INLINE explicit Optional(Optional<U>&& other)
+    requires(IsConstructible<T, U&&> && !IsSpecializationOf<T, Optional> && !IsSpecializationOf<U, Optional>) AK_ALWAYS_INLINE explicit Optional(Optional<U>&& other)
         : m_has_value(other.m_has_value)
     {
         if (other.has_value())
@@ -81,13 +81,13 @@ public:
     }
 
     template<typename U = T>
-    ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) Optional(U&& value) requires(!IsSame<RemoveCVReference<U>, Optional<T>> && IsConstructible<T, U&&>)
+    AK_ALWAYS_INLINE explicit(!IsConvertible<U&&, T>) Optional(U&& value) requires(!IsSame<RemoveCVReference<U>, Optional<T>> && IsConstructible<T, U&&>)
         : m_has_value(true)
     {
         new (&m_storage) T(forward<U>(value));
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional const& other)
+    AK_ALWAYS_INLINE Optional& operator=(Optional const& other)
 #ifdef AK_HAS_CONDITIONALLY_TRIVIAL
         requires(!IsTriviallyCopyConstructible<T> || !IsTriviallyDestructible<T>)
 #endif
@@ -102,7 +102,7 @@ public:
         return *this;
     }
 
-    ALWAYS_INLINE Optional& operator=(Optional&& other)
+    AK_ALWAYS_INLINE Optional& operator=(Optional&& other)
     {
         if (this != &other) {
             clear();
@@ -115,18 +115,18 @@ public:
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(Optional<O> const& other) const
+    AK_ALWAYS_INLINE bool operator==(Optional<O> const& other) const
     {
         return has_value() == other.has_value() && (!has_value() || value() == other.value());
     }
 
     template<typename O>
-    ALWAYS_INLINE bool operator==(O const& other) const
+    AK_ALWAYS_INLINE bool operator==(O const& other) const
     {
         return has_value() && value() == other;
     }
 
-    ALWAYS_INLINE ~Optional()
+    AK_ALWAYS_INLINE ~Optional()
 #ifdef AK_HAS_CONDITIONALLY_TRIVIAL
         requires(!IsTriviallyDestructible<T>)
 #endif
@@ -134,7 +134,7 @@ public:
         clear();
     }
 
-    ALWAYS_INLINE void clear()
+    AK_ALWAYS_INLINE void clear()
     {
         if (m_has_value) {
             value().~T();
@@ -143,33 +143,33 @@ public:
     }
 
     template<typename... Parameters>
-    ALWAYS_INLINE void emplace(Parameters&&... parameters)
+    AK_ALWAYS_INLINE void emplace(Parameters&&... parameters)
     {
         clear();
         m_has_value = true;
         new (&m_storage) T(forward<Parameters>(parameters)...);
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_value() const { return m_has_value; }
+    [[nodiscard]] AK_ALWAYS_INLINE bool has_value() const { return m_has_value; }
 
-    [[nodiscard]] ALWAYS_INLINE T& value() &
+    [[nodiscard]] AK_ALWAYS_INLINE T& value() &
     {
         VERIFY(m_has_value);
         return *__builtin_launder(reinterpret_cast<T*>(&m_storage));
     }
 
-    [[nodiscard]] ALWAYS_INLINE T const& value() const&
+    [[nodiscard]] AK_ALWAYS_INLINE T const& value() const&
     {
         VERIFY(m_has_value);
         return *__builtin_launder(reinterpret_cast<T const*>(&m_storage));
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value() &&
+    [[nodiscard]] AK_ALWAYS_INLINE T value() &&
     {
         return release_value();
     }
 
-    [[nodiscard]] ALWAYS_INLINE T release_value()
+    [[nodiscard]] AK_ALWAYS_INLINE T release_value()
     {
         VERIFY(m_has_value);
         T released_value = move(value());
@@ -178,25 +178,25 @@ public:
         return released_value;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T const& fallback) const&
+    [[nodiscard]] AK_ALWAYS_INLINE T value_or(T const& fallback) const&
     {
         if (m_has_value)
             return value();
         return fallback;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T value_or(T&& fallback) &&
+    [[nodiscard]] AK_ALWAYS_INLINE T value_or(T&& fallback) &&
     {
         if (m_has_value)
             return move(value());
         return move(fallback);
     }
 
-    ALWAYS_INLINE T const& operator*() const { return value(); }
-    ALWAYS_INLINE T& operator*() { return value(); }
+    AK_ALWAYS_INLINE T const& operator*() const { return value(); }
+    AK_ALWAYS_INLINE T& operator*() { return value(); }
 
-    ALWAYS_INLINE T const* operator->() const { return &value(); }
-    ALWAYS_INLINE T* operator->() { return &value(); }
+    AK_ALWAYS_INLINE T const* operator->() const { return &value(); }
+    AK_ALWAYS_INLINE T* operator->() { return &value(); }
 
 private:
     alignas(T) u8 m_storage[sizeof(T)];

--- a/AK/Platform.h
+++ b/AK/Platform.h
@@ -39,10 +39,10 @@
 #    define AK_HAS_CONDITIONALLY_TRIVIAL
 #endif
 
-#ifdef ALWAYS_INLINE
-#    undef ALWAYS_INLINE
+#ifdef AK_ALWAYS_INLINE
+#    undef AK_ALWAYS_INLINE
 #endif
-#define ALWAYS_INLINE __attribute__((always_inline)) inline
+#define AK_ALWAYS_INLINE __attribute__((always_inline)) inline
 
 #ifdef NEVER_INLINE
 #    undef NEVER_INLINE

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -21,7 +21,7 @@ extern "C" size_t strlen(const char*);
 namespace PrintfImplementation {
 
 template<typename PutChFunc, typename T, typename CharType>
-ALWAYS_INLINE int print_hex(PutChFunc putch, CharType*& bufptr, T number, bool upper_case, bool alternate_form, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
+AK_ALWAYS_INLINE int print_hex(PutChFunc putch, CharType*& bufptr, T number, bool upper_case, bool alternate_form, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
 {
     constexpr const char* printf_hex_digits_lower = "0123456789abcdef";
     constexpr const char* printf_hex_digits_upper = "0123456789ABCDEF";
@@ -96,7 +96,7 @@ ALWAYS_INLINE int print_hex(PutChFunc putch, CharType*& bufptr, T number, bool u
 }
 
 template<typename PutChFunc, typename CharType>
-ALWAYS_INLINE int print_decimal(PutChFunc putch, CharType*& bufptr, u64 number, bool sign, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
+AK_ALWAYS_INLINE int print_decimal(PutChFunc putch, CharType*& bufptr, u64 number, bool sign, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
 {
     u64 divisor = 10000000000000000000LLU;
     char ch;
@@ -160,7 +160,7 @@ ALWAYS_INLINE int print_decimal(PutChFunc putch, CharType*& bufptr, u64 number, 
 }
 
 template<typename PutChFunc, typename CharType>
-ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, u32 precision)
+AK_ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, u32 precision)
 {
     int length = 0;
 
@@ -210,13 +210,13 @@ ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number
 }
 
 template<typename PutChFunc, typename CharType>
-ALWAYS_INLINE int print_i64(PutChFunc putch, CharType*& bufptr, i64 number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
+AK_ALWAYS_INLINE int print_i64(PutChFunc putch, CharType*& bufptr, i64 number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
 {
     return print_decimal(putch, bufptr, (number < 0) ? 0 - number : number, number < 0, always_sign, left_pad, zero_pad, field_width, has_precision, precision);
 }
 
 template<typename PutChFunc, typename CharType>
-ALWAYS_INLINE int print_octal_number(PutChFunc putch, CharType*& bufptr, u64 number, bool alternate_form, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
+AK_ALWAYS_INLINE int print_octal_number(PutChFunc putch, CharType*& bufptr, u64 number, bool alternate_form, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
 {
     u32 divisor = 134217728;
     char ch;
@@ -278,7 +278,7 @@ ALWAYS_INLINE int print_octal_number(PutChFunc putch, CharType*& bufptr, u64 num
 }
 
 template<typename PutChFunc, typename CharType>
-ALWAYS_INLINE int print_string(PutChFunc putch, CharType*& bufptr, const char* str, size_t len, bool left_pad, size_t field_width, bool dot, size_t precision, bool has_fraction)
+AK_ALWAYS_INLINE int print_string(PutChFunc putch, CharType*& bufptr, const char* str, size_t len, bool left_pad, size_t field_width, bool dot, size_t precision, bool has_fraction)
 {
     if (has_fraction)
         len = min(len, precision);
@@ -306,7 +306,7 @@ ALWAYS_INLINE int print_string(PutChFunc putch, CharType*& bufptr, const char* s
 }
 
 template<typename PutChFunc, typename CharType>
-ALWAYS_INLINE int print_signed_number(PutChFunc putch, CharType*& bufptr, int number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
+AK_ALWAYS_INLINE int print_signed_number(PutChFunc putch, CharType*& bufptr, int number, bool always_sign, bool left_pad, bool zero_pad, u32 field_width, bool has_precision, u32 precision)
 {
     return print_decimal(putch, bufptr, (number < 0) ? 0 - number : number, number < 0, always_sign, left_pad, zero_pad, field_width, has_precision, precision);
 }
@@ -330,93 +330,93 @@ struct ModifierState {
 
 template<typename PutChFunc, typename ArgumentListRefT, template<typename T, typename U = ArgumentListRefT> typename NextArgument, typename CharType = char>
 struct PrintfImpl {
-    ALWAYS_INLINE PrintfImpl(PutChFunc& putch, CharType*& bufptr, const int& nwritten)
+    AK_ALWAYS_INLINE PrintfImpl(PutChFunc& putch, CharType*& bufptr, const int& nwritten)
         : m_bufptr(bufptr)
         , m_nwritten(nwritten)
         , m_putch(putch)
     {
     }
 
-    ALWAYS_INLINE int format_s(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_s(const ModifierState& state, ArgumentListRefT ap) const
     {
         const char* sp = NextArgument<const char*>()(ap);
         if (!sp)
             sp = "(null)";
         return print_string(m_putch, m_bufptr, sp, strlen(sp), state.left_pad, state.field_width, state.dot, state.precision, state.has_precision);
     }
-    ALWAYS_INLINE int format_d(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_d(const ModifierState& state, ArgumentListRefT ap) const
     {
         if (state.long_qualifiers >= 2)
             return print_i64(m_putch, m_bufptr, NextArgument<i64>()(ap), state.always_sign, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
 
         return print_signed_number(m_putch, m_bufptr, NextArgument<int>()(ap), state.always_sign, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
     }
-    ALWAYS_INLINE int format_i(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_i(const ModifierState& state, ArgumentListRefT ap) const
     {
         return format_d(state, ap);
     }
-    ALWAYS_INLINE int format_u(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_u(const ModifierState& state, ArgumentListRefT ap) const
     {
         if (state.long_qualifiers >= 2)
             return print_decimal(m_putch, m_bufptr, NextArgument<u64>()(ap), false, false, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
         return print_decimal(m_putch, m_bufptr, NextArgument<u32>()(ap), false, false, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
     }
-    ALWAYS_INLINE int format_Q(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_Q(const ModifierState& state, ArgumentListRefT ap) const
     {
         return print_decimal(m_putch, m_bufptr, NextArgument<u64>()(ap), false, false, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
     }
-    ALWAYS_INLINE int format_q(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_q(const ModifierState& state, ArgumentListRefT ap) const
     {
         return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, false, state.left_pad, state.zero_pad, 16, false, 1);
     }
-    ALWAYS_INLINE int format_g(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_g(const ModifierState& state, ArgumentListRefT ap) const
     {
         return format_f(state, ap);
     }
-    ALWAYS_INLINE int format_f(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_f(const ModifierState& state, ArgumentListRefT ap) const
     {
         return print_double(m_putch, m_bufptr, NextArgument<double>()(ap), state.always_sign, state.left_pad, state.zero_pad, state.field_width, state.precision);
     }
-    ALWAYS_INLINE int format_o(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_o(const ModifierState& state, ArgumentListRefT ap) const
     {
         return print_octal_number(m_putch, m_bufptr, NextArgument<u32>()(ap), state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
     }
-    ALWAYS_INLINE int format_x(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_x(const ModifierState& state, ArgumentListRefT ap) const
     {
         if (state.long_qualifiers >= 2)
             return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
         return print_hex(m_putch, m_bufptr, NextArgument<u32>()(ap), false, state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
     }
-    ALWAYS_INLINE int format_X(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_X(const ModifierState& state, ArgumentListRefT ap) const
     {
         if (state.long_qualifiers >= 2)
             return print_hex(m_putch, m_bufptr, NextArgument<u64>()(ap), true, state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
         return print_hex(m_putch, m_bufptr, NextArgument<u32>()(ap), true, state.alternate_form, state.left_pad, state.zero_pad, state.field_width, state.has_precision, state.precision);
     }
-    ALWAYS_INLINE int format_n(const ModifierState&, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_n(const ModifierState&, ArgumentListRefT ap) const
     {
         *NextArgument<int*>()(ap) = m_nwritten;
         return 0;
     }
-    ALWAYS_INLINE int format_p(const ModifierState&, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_p(const ModifierState&, ArgumentListRefT ap) const
     {
         return print_hex(m_putch, m_bufptr, NextArgument<FlatPtr>()(ap), false, true, false, true, 8, false, 1);
     }
-    ALWAYS_INLINE int format_P(const ModifierState&, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_P(const ModifierState&, ArgumentListRefT ap) const
     {
         return print_hex(m_putch, m_bufptr, NextArgument<FlatPtr>()(ap), true, true, false, true, 8, false, 1);
     }
-    ALWAYS_INLINE int format_percent(const ModifierState&, ArgumentListRefT) const
+    AK_ALWAYS_INLINE int format_percent(const ModifierState&, ArgumentListRefT) const
     {
         m_putch(m_bufptr, '%');
         return 1;
     }
-    ALWAYS_INLINE int format_c(const ModifierState& state, ArgumentListRefT ap) const
+    AK_ALWAYS_INLINE int format_c(const ModifierState& state, ArgumentListRefT ap) const
     {
         char c = NextArgument<int>()(ap);
         return print_string(m_putch, m_bufptr, &c, 1, state.left_pad, state.field_width, state.dot, state.precision, state.has_precision);
     }
-    ALWAYS_INLINE int format_unrecognized(CharType format_op, const CharType* fmt, const ModifierState&, ArgumentListRefT) const
+    AK_ALWAYS_INLINE int format_unrecognized(CharType format_op, const CharType* fmt, const ModifierState&, ArgumentListRefT) const
     {
         dbgln("printf_internal: Unimplemented format specifier {} (fmt: {})", format_op, fmt);
         return 0;
@@ -430,7 +430,7 @@ protected:
 
 template<typename T, typename V>
 struct VaArgNextArgument {
-    ALWAYS_INLINE T operator()(V ap) const
+    AK_ALWAYS_INLINE T operator()(V ap) const
     {
         return va_arg(ap, T);
     }
@@ -442,7 +442,7 @@ struct VaArgNextArgument {
         break;
 
 template<typename PutChFunc, template<typename T, typename U, template<typename X, typename Y> typename V, typename C = char> typename Impl = PrintfImpl, typename ArgumentListT = va_list, template<typename T, typename V = decltype(declval<ArgumentListT&>())> typename NextArgument = VaArgNextArgument, typename CharType = char>
-ALWAYS_INLINE int printf_internal(PutChFunc putch, IdentityType<CharType>* buffer, const CharType*& fmt, ArgumentListT ap)
+AK_ALWAYS_INLINE int printf_internal(PutChFunc putch, IdentityType<CharType>* buffer, const CharType*& fmt, ArgumentListT ap)
 {
     int ret = 0;
     CharType* bufptr = buffer;

--- a/AK/RefCounted.h
+++ b/AK/RefCounted.h
@@ -26,7 +26,7 @@ public:
     using RefCountType = unsigned int;
     using AllowOwnPtr = FalseType;
 
-    ALWAYS_INLINE void ref() const
+    AK_ALWAYS_INLINE void ref() const
     {
         VERIFY(m_ref_count > 0);
         VERIFY(!Checked<RefCountType>::addition_would_overflow(m_ref_count, 1));
@@ -47,7 +47,7 @@ protected:
     RefCountedBase() = default;
     ~RefCountedBase() { VERIFY(!m_ref_count); }
 
-    ALWAYS_INLINE RefCountType deref_base() const
+    AK_ALWAYS_INLINE RefCountType deref_base() const
     {
         VERIFY(m_ref_count);
         return --m_ref_count;

--- a/AK/RefPtr.h
+++ b/AK/RefPtr.h
@@ -61,21 +61,21 @@ public:
     {
     }
 
-    ALWAYS_INLINE RefPtr(NonnullRefPtr<T> const& other)
+    AK_ALWAYS_INLINE RefPtr(NonnullRefPtr<T> const& other)
         : m_ptr(const_cast<T*>(other.ptr()))
     {
         m_ptr->ref();
     }
 
     template<typename U>
-    ALWAYS_INLINE RefPtr(NonnullRefPtr<U> const& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr(NonnullRefPtr<U> const& other) requires(IsConvertible<U*, T*>)
         : m_ptr(const_cast<T*>(static_cast<T const*>(other.ptr())))
     {
         m_ptr->ref();
     }
 
     template<typename U>
-    ALWAYS_INLINE RefPtr(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
         : m_ptr(static_cast<T*>(&other.leak_ref()))
     {
     }
@@ -99,7 +99,7 @@ public:
         ref_if_not_null(m_ptr);
     }
 
-    ALWAYS_INLINE ~RefPtr()
+    AK_ALWAYS_INLINE ~RefPtr()
     {
         clear();
 #    ifdef SANITIZE_PTRS
@@ -123,7 +123,7 @@ public:
         AK::swap(m_ptr, other.m_ptr);
     }
 
-    ALWAYS_INLINE RefPtr& operator=(RefPtr&& other)
+    AK_ALWAYS_INLINE RefPtr& operator=(RefPtr&& other)
     {
         RefPtr tmp { move(other) };
         swap(tmp);
@@ -131,7 +131,7 @@ public:
     }
 
     template<typename U, typename P = RefPtrTraits<U>>
-    ALWAYS_INLINE RefPtr& operator=(RefPtr<U, P>&& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr& operator=(RefPtr<U, P>&& other) requires(IsConvertible<U*, T*>)
     {
         RefPtr tmp { move(other) };
         swap(tmp);
@@ -139,14 +139,14 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
     {
         RefPtr tmp { move(other) };
         swap(tmp);
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<T> const& other)
+    AK_ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<T> const& other)
     {
         RefPtr tmp { other };
         swap(tmp);
@@ -154,14 +154,14 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<U> const& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<U> const& other) requires(IsConvertible<U*, T*>)
     {
         RefPtr tmp { other };
         swap(tmp);
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(RefPtr const& other)
+    AK_ALWAYS_INLINE RefPtr& operator=(RefPtr const& other)
     {
         RefPtr tmp { other };
         swap(tmp);
@@ -169,21 +169,21 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE RefPtr& operator=(RefPtr<U> const& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr& operator=(RefPtr<U> const& other) requires(IsConvertible<U*, T*>)
     {
         RefPtr tmp { other };
         swap(tmp);
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(T const* ptr)
+    AK_ALWAYS_INLINE RefPtr& operator=(T const* ptr)
     {
         RefPtr tmp { ptr };
         swap(tmp);
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(T const& object)
+    AK_ALWAYS_INLINE RefPtr& operator=(T const& object)
     {
         RefPtr tmp { object };
         swap(tmp);
@@ -196,7 +196,7 @@ public:
         return *this;
     }
 
-    ALWAYS_INLINE bool assign_if_null(RefPtr&& other)
+    AK_ALWAYS_INLINE bool assign_if_null(RefPtr&& other)
     {
         if (this == &other)
             return is_null();
@@ -205,7 +205,7 @@ public:
     }
 
     template<typename U, typename P = RefPtrTraits<U>>
-    ALWAYS_INLINE bool assign_if_null(RefPtr<U, P>&& other)
+    AK_ALWAYS_INLINE bool assign_if_null(RefPtr<U, P>&& other)
     {
         if (this == &other)
             return is_null();
@@ -213,7 +213,7 @@ public:
         return true;
     }
 
-    ALWAYS_INLINE void clear()
+    AK_ALWAYS_INLINE void clear()
     {
         unref_if_not_null(m_ptr);
         m_ptr = nullptr;
@@ -233,33 +233,33 @@ public:
         return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *ptr);
     }
 
-    ALWAYS_INLINE T* ptr() { return as_ptr(); }
-    ALWAYS_INLINE const T* ptr() const { return as_ptr(); }
+    AK_ALWAYS_INLINE T* ptr() { return as_ptr(); }
+    AK_ALWAYS_INLINE const T* ptr() const { return as_ptr(); }
 
-    ALWAYS_INLINE T* operator->()
+    AK_ALWAYS_INLINE T* operator->()
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE const T* operator->() const
+    AK_ALWAYS_INLINE const T* operator->() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE T& operator*()
+    AK_ALWAYS_INLINE T& operator*()
     {
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE const T& operator*() const
+    AK_ALWAYS_INLINE const T& operator*() const
     {
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE operator const T*() const { return as_ptr(); }
-    ALWAYS_INLINE operator T*() { return as_ptr(); }
+    AK_ALWAYS_INLINE operator const T*() const { return as_ptr(); }
+    AK_ALWAYS_INLINE operator T*() { return as_ptr(); }
 
-    ALWAYS_INLINE operator bool() { return !is_null(); }
+    AK_ALWAYS_INLINE operator bool() { return !is_null(); }
 
     bool operator==(std::nullptr_t) const { return is_null(); }
     bool operator!=(std::nullptr_t) const { return !is_null(); }
@@ -276,15 +276,15 @@ public:
     bool operator==(T* other) { return as_ptr() == other; }
     bool operator!=(T* other) { return as_ptr() != other; }
 
-    ALWAYS_INLINE bool is_null() const { return !m_ptr; }
+    AK_ALWAYS_INLINE bool is_null() const { return !m_ptr; }
 
 private:
-    ALWAYS_INLINE T* as_ptr() const
+    AK_ALWAYS_INLINE T* as_ptr() const
     {
         return m_ptr;
     }
 
-    ALWAYS_INLINE T* as_nonnull_ptr() const
+    AK_ALWAYS_INLINE T* as_nonnull_ptr() const
     {
         VERIFY(m_ptr);
         return m_ptr;

--- a/AK/ReverseIterator.h
+++ b/AK/ReverseIterator.h
@@ -49,11 +49,11 @@ public:
         return SimpleReverseIterator { m_container, m_index - 1 };
     }
 
-    ALWAYS_INLINE constexpr ValueType const& operator*() const { return m_container[m_index]; }
-    ALWAYS_INLINE constexpr ValueType& operator*() { return m_container[m_index]; }
+    AK_ALWAYS_INLINE constexpr ValueType const& operator*() const { return m_container[m_index]; }
+    AK_ALWAYS_INLINE constexpr ValueType& operator*() { return m_container[m_index]; }
 
-    ALWAYS_INLINE constexpr ValueType const* operator->() const { return &m_container[m_index]; }
-    ALWAYS_INLINE constexpr ValueType* operator->() { return &m_container[m_index]; }
+    AK_ALWAYS_INLINE constexpr ValueType const* operator->() const { return &m_container[m_index]; }
+    AK_ALWAYS_INLINE constexpr ValueType* operator->() { return &m_container[m_index]; }
 
     SimpleReverseIterator& operator=(const SimpleReverseIterator& other)
     {

--- a/AK/SIMDExtras.h
+++ b/AK/SIMDExtras.h
@@ -19,17 +19,17 @@ namespace AK::SIMD {
 
 // SIMD Vector Expansion
 
-ALWAYS_INLINE static constexpr f32x4 expand4(float f)
+AK_ALWAYS_INLINE static constexpr f32x4 expand4(float f)
 {
     return f32x4 { f, f, f, f };
 }
 
-ALWAYS_INLINE static constexpr i32x4 expand4(i32 i)
+AK_ALWAYS_INLINE static constexpr i32x4 expand4(i32 i)
 {
     return i32x4 { i, i, i, i };
 }
 
-ALWAYS_INLINE static constexpr u32x4 expand4(u32 u)
+AK_ALWAYS_INLINE static constexpr u32x4 expand4(u32 u)
 {
     return u32x4 { u, u, u, u };
 }
@@ -37,26 +37,26 @@ ALWAYS_INLINE static constexpr u32x4 expand4(u32 u)
 // Casting
 
 template<typename TSrc>
-ALWAYS_INLINE static u32x4 to_u32x4(TSrc v)
+AK_ALWAYS_INLINE static u32x4 to_u32x4(TSrc v)
 {
     return __builtin_convertvector(v, u32x4);
 }
 
 template<typename TSrc>
-ALWAYS_INLINE static i32x4 to_i32x4(TSrc v)
+AK_ALWAYS_INLINE static i32x4 to_i32x4(TSrc v)
 {
     return __builtin_convertvector(v, i32x4);
 }
 
 template<typename TSrc>
-ALWAYS_INLINE static f32x4 to_f32x4(TSrc v)
+AK_ALWAYS_INLINE static f32x4 to_f32x4(TSrc v)
 {
     return __builtin_convertvector(v, f32x4);
 }
 
 // Masking
 
-ALWAYS_INLINE static i32 maskbits(i32x4 mask)
+AK_ALWAYS_INLINE static i32 maskbits(i32x4 mask)
 {
 #if defined(__SSE__)
     return __builtin_ia32_movmskps((f32x4)mask);
@@ -65,22 +65,22 @@ ALWAYS_INLINE static i32 maskbits(i32x4 mask)
 #endif
 }
 
-ALWAYS_INLINE static bool all(i32x4 mask)
+AK_ALWAYS_INLINE static bool all(i32x4 mask)
 {
     return maskbits(mask) == 15;
 }
 
-ALWAYS_INLINE static bool any(i32x4 mask)
+AK_ALWAYS_INLINE static bool any(i32x4 mask)
 {
     return maskbits(mask) != 0;
 }
 
-ALWAYS_INLINE static bool none(i32x4 mask)
+AK_ALWAYS_INLINE static bool none(i32x4 mask)
 {
     return maskbits(mask) == 0;
 }
 
-ALWAYS_INLINE static int maskcount(i32x4 mask)
+AK_ALWAYS_INLINE static int maskcount(i32x4 mask)
 {
     constexpr static int count_lut[16] { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 };
     return count_lut[maskbits(mask)];
@@ -88,17 +88,17 @@ ALWAYS_INLINE static int maskcount(i32x4 mask)
 
 // Load / Store
 
-ALWAYS_INLINE static f32x4 load4(float const* a, float const* b, float const* c, float const* d)
+AK_ALWAYS_INLINE static f32x4 load4(float const* a, float const* b, float const* c, float const* d)
 {
     return f32x4 { *a, *b, *c, *d };
 }
 
-ALWAYS_INLINE static u32x4 load4(u32 const* a, u32 const* b, u32 const* c, u32 const* d)
+AK_ALWAYS_INLINE static u32x4 load4(u32 const* a, u32 const* b, u32 const* c, u32 const* d)
 {
     return u32x4 { *a, *b, *c, *d };
 }
 
-ALWAYS_INLINE static f32x4 load4_masked(float const* a, float const* b, float const* c, float const* d, i32x4 mask)
+AK_ALWAYS_INLINE static f32x4 load4_masked(float const* a, float const* b, float const* c, float const* d, i32x4 mask)
 {
     int bits = maskbits(mask);
     return f32x4 {
@@ -109,7 +109,7 @@ ALWAYS_INLINE static f32x4 load4_masked(float const* a, float const* b, float co
     };
 }
 
-ALWAYS_INLINE static i32x4 load4_masked(u8 const* a, u8 const* b, u8 const* c, u8 const* d, i32x4 mask)
+AK_ALWAYS_INLINE static i32x4 load4_masked(u8 const* a, u8 const* b, u8 const* c, u8 const* d, i32x4 mask)
 {
     int bits = maskbits(mask);
     return i32x4 {
@@ -120,7 +120,7 @@ ALWAYS_INLINE static i32x4 load4_masked(u8 const* a, u8 const* b, u8 const* c, u
     };
 }
 
-ALWAYS_INLINE static u32x4 load4_masked(u32 const* a, u32 const* b, u32 const* c, u32 const* d, i32x4 mask)
+AK_ALWAYS_INLINE static u32x4 load4_masked(u32 const* a, u32 const* b, u32 const* c, u32 const* d, i32x4 mask)
 {
     int bits = maskbits(mask);
     return u32x4 {
@@ -132,7 +132,7 @@ ALWAYS_INLINE static u32x4 load4_masked(u32 const* a, u32 const* b, u32 const* c
 }
 
 template<typename VectorType, typename UnderlyingType = decltype(declval<VectorType>()[0])>
-ALWAYS_INLINE static void store4(VectorType v, UnderlyingType* a, UnderlyingType* b, UnderlyingType* c, UnderlyingType* d)
+AK_ALWAYS_INLINE static void store4(VectorType v, UnderlyingType* a, UnderlyingType* b, UnderlyingType* c, UnderlyingType* d)
 {
     *a = v[0];
     *b = v[1];
@@ -141,7 +141,7 @@ ALWAYS_INLINE static void store4(VectorType v, UnderlyingType* a, UnderlyingType
 }
 
 template<typename VectorType, typename UnderlyingType = decltype(declval<VectorType>()[0])>
-ALWAYS_INLINE static void store4_masked(VectorType v, UnderlyingType* a, UnderlyingType* b, UnderlyingType* c, UnderlyingType* d, i32x4 mask)
+AK_ALWAYS_INLINE static void store4_masked(VectorType v, UnderlyingType* a, UnderlyingType* b, UnderlyingType* c, UnderlyingType* d, i32x4 mask)
 {
     int bits = maskbits(mask);
     if (bits & 1)

--- a/AK/SIMDMath.h
+++ b/AK/SIMDMath.h
@@ -21,34 +21,34 @@ namespace AK::SIMD {
 // Functions ending in "_int_range" only accept arguments within range [INT_MIN, INT_MAX].
 // Other inputs will generate unexpected results.
 
-ALWAYS_INLINE static f32x4 truncate_int_range(f32x4 v)
+AK_ALWAYS_INLINE static f32x4 truncate_int_range(f32x4 v)
 {
     return to_f32x4(to_i32x4(v));
 }
 
-ALWAYS_INLINE static f32x4 floor_int_range(f32x4 v)
+AK_ALWAYS_INLINE static f32x4 floor_int_range(f32x4 v)
 {
     auto t = truncate_int_range(v);
     return t > v ? t - 1.0f : t;
 }
 
-ALWAYS_INLINE static f32x4 ceil_int_range(f32x4 v)
+AK_ALWAYS_INLINE static f32x4 ceil_int_range(f32x4 v)
 {
     auto t = truncate_int_range(v);
     return t < v ? t + 1.0f : t;
 }
 
-ALWAYS_INLINE static f32x4 frac_int_range(f32x4 v)
+AK_ALWAYS_INLINE static f32x4 frac_int_range(f32x4 v)
 {
     return v - floor_int_range(v);
 }
 
-ALWAYS_INLINE static f32x4 clamp(f32x4 v, f32x4 min, f32x4 max)
+AK_ALWAYS_INLINE static f32x4 clamp(f32x4 v, f32x4 min, f32x4 max)
 {
     return v < min ? min : (v > max ? max : v);
 }
 
-ALWAYS_INLINE static f32x4 exp(f32x4 v)
+AK_ALWAYS_INLINE static f32x4 exp(f32x4 v)
 {
     // FIXME: This should be replaced with a vectorized algorithm instead of calling the scalar expf 4 times
     return f32x4 {

--- a/AK/Span.h
+++ b/AK/Span.h
@@ -19,23 +19,23 @@ namespace Detail {
 template<typename T>
 class Span {
 public:
-    ALWAYS_INLINE constexpr Span() = default;
+    AK_ALWAYS_INLINE constexpr Span() = default;
 
-    ALWAYS_INLINE constexpr Span(T* values, size_t size)
+    AK_ALWAYS_INLINE constexpr Span(T* values, size_t size)
         : m_values(values)
         , m_size(size)
     {
     }
 
     template<size_t size>
-    ALWAYS_INLINE constexpr Span(T (&values)[size])
+    AK_ALWAYS_INLINE constexpr Span(T (&values)[size])
         : m_values(values)
         , m_size(size)
     {
     }
 
     template<size_t size>
-    ALWAYS_INLINE constexpr Span(Array<T, size>& array)
+    AK_ALWAYS_INLINE constexpr Span(Array<T, size>& array)
         : m_values(array.data())
         , m_size(size)
     {
@@ -43,7 +43,7 @@ public:
 
     template<size_t size>
     requires(IsConst<T>)
-        ALWAYS_INLINE constexpr Span(Array<T, size> const& array)
+        AK_ALWAYS_INLINE constexpr Span(Array<T, size> const& array)
         : m_values(array.data())
         , m_size(size)
     {
@@ -57,14 +57,14 @@ protected:
 template<>
 class Span<u8> {
 public:
-    ALWAYS_INLINE constexpr Span() = default;
+    AK_ALWAYS_INLINE constexpr Span() = default;
 
-    ALWAYS_INLINE constexpr Span(u8* values, size_t size)
+    AK_ALWAYS_INLINE constexpr Span(u8* values, size_t size)
         : m_values(values)
         , m_size(size)
     {
     }
-    ALWAYS_INLINE Span(void* values, size_t size)
+    AK_ALWAYS_INLINE Span(void* values, size_t size)
         : m_values(reinterpret_cast<u8*>(values))
         , m_size(size)
     {
@@ -78,19 +78,19 @@ protected:
 template<>
 class Span<u8 const> {
 public:
-    ALWAYS_INLINE constexpr Span() = default;
+    AK_ALWAYS_INLINE constexpr Span() = default;
 
-    ALWAYS_INLINE constexpr Span(u8 const* values, size_t size)
+    AK_ALWAYS_INLINE constexpr Span(u8 const* values, size_t size)
         : m_values(values)
         , m_size(size)
     {
     }
-    ALWAYS_INLINE Span(void const* values, size_t size)
+    AK_ALWAYS_INLINE Span(void const* values, size_t size)
         : m_values(reinterpret_cast<u8 const*>(values))
         , m_size(size)
     {
     }
-    ALWAYS_INLINE Span(char const* values, size_t size)
+    AK_ALWAYS_INLINE Span(char const* values, size_t size)
         : m_values(reinterpret_cast<u8 const*>(values))
         , m_size(size)
     {
@@ -110,11 +110,11 @@ public:
 
     constexpr Span() = default;
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T const* data() const { return this->m_values; }
-    [[nodiscard]] ALWAYS_INLINE constexpr T* data() { return this->m_values; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T const* data() const { return this->m_values; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T* data() { return this->m_values; }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T const* offset_pointer(size_t offset) const { return this->m_values + offset; }
-    [[nodiscard]] ALWAYS_INLINE constexpr T* offset_pointer(size_t offset) { return this->m_values + offset; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T const* offset_pointer(size_t offset) const { return this->m_values + offset; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T* offset_pointer(size_t offset) { return this->m_values + offset; }
 
     using ConstIterator = SimpleIterator<Span const, T const>;
     using Iterator = SimpleIterator<Span, T>;
@@ -125,57 +125,57 @@ public:
     constexpr ConstIterator end() const { return ConstIterator::end(*this); }
     constexpr Iterator end() { return Iterator::end(*this); }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr size_t size() const { return this->m_size; }
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_null() const { return this->m_values == nullptr; }
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_empty() const { return this->m_size == 0; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr size_t size() const { return this->m_size; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr bool is_null() const { return this->m_values == nullptr; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr bool is_empty() const { return this->m_size == 0; }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr Span slice(size_t start, size_t length) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr Span slice(size_t start, size_t length) const
     {
         VERIFY(start + length <= size());
         return { this->m_values + start, length };
     }
-    [[nodiscard]] ALWAYS_INLINE constexpr Span slice(size_t start) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr Span slice(size_t start) const
     {
         VERIFY(start <= size());
         return { this->m_values + start, size() - start };
     }
-    [[nodiscard]] ALWAYS_INLINE constexpr Span slice_from_end(size_t count) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr Span slice_from_end(size_t count) const
     {
         VERIFY(count <= size());
         return { this->m_values + size() - count, count };
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr Span trim(size_t length) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr Span trim(size_t length) const
     {
         return { this->m_values, min(size(), length) };
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T* offset(size_t start) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T* offset(size_t start) const
     {
         VERIFY(start < this->m_size);
         return this->m_values + start;
     }
 
-    ALWAYS_INLINE constexpr void overwrite(size_t offset, void const* data, size_t data_size)
+    AK_ALWAYS_INLINE constexpr void overwrite(size_t offset, void const* data, size_t data_size)
     {
         // make sure we're not told to write past the end
         VERIFY(offset + data_size <= size());
         __builtin_memmove(this->data() + offset, data, data_size);
     }
 
-    ALWAYS_INLINE constexpr size_t copy_to(Span<RemoveConst<T>> other) const
+    AK_ALWAYS_INLINE constexpr size_t copy_to(Span<RemoveConst<T>> other) const
     {
         VERIFY(other.size() >= size());
         return TypedTransfer<RemoveConst<T>>::copy(other.data(), data(), size());
     }
 
-    ALWAYS_INLINE constexpr size_t copy_trimmed_to(Span<RemoveConst<T>> other) const
+    AK_ALWAYS_INLINE constexpr size_t copy_trimmed_to(Span<RemoveConst<T>> other) const
     {
         auto const count = min(size(), other.size());
         return TypedTransfer<RemoveConst<T>>::copy(other.data(), data(), count);
     }
 
-    ALWAYS_INLINE constexpr size_t fill(T const& value)
+    AK_ALWAYS_INLINE constexpr size_t fill(T const& value)
     {
         for (size_t idx = 0; idx < size(); ++idx)
             data()[idx] = value;
@@ -200,24 +200,24 @@ public:
         return TypedTransfer<T>::compare(data(), other.data(), other.size());
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T const& at(size_t index) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T const& at(size_t index) const
     {
         VERIFY(index < this->m_size);
         return this->m_values[index];
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T& at(size_t index)
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T& at(size_t index)
     {
         VERIFY(index < this->m_size);
         return this->m_values[index];
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T const& operator[](size_t index) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T const& operator[](size_t index) const
     {
         return at(index);
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T& operator[](size_t index)
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T& operator[](size_t index)
     {
         return at(index);
     }
@@ -230,7 +230,7 @@ public:
         return TypedTransfer<T>::compare(data(), other.data(), size());
     }
 
-    ALWAYS_INLINE constexpr operator Span<T const>() const
+    AK_ALWAYS_INLINE constexpr operator Span<T const>() const
     {
         return { data(), size() };
     }

--- a/AK/String.h
+++ b/AK/String.h
@@ -166,14 +166,14 @@ public:
     [[nodiscard]] StringView substring_view(size_t start) const;
 
     [[nodiscard]] bool is_null() const { return !m_impl; }
-    [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return length() == 0; }
-    [[nodiscard]] ALWAYS_INLINE size_t length() const { return m_impl ? m_impl->length() : 0; }
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_empty() const { return length() == 0; }
+    [[nodiscard]] AK_ALWAYS_INLINE size_t length() const { return m_impl ? m_impl->length() : 0; }
     // Includes NUL-terminator, if non-nullptr.
-    [[nodiscard]] ALWAYS_INLINE const char* characters() const { return m_impl ? m_impl->characters() : nullptr; }
+    [[nodiscard]] AK_ALWAYS_INLINE const char* characters() const { return m_impl ? m_impl->characters() : nullptr; }
 
     [[nodiscard]] bool copy_characters_to_buffer(char* buffer, size_t buffer_size) const;
 
-    [[nodiscard]] ALWAYS_INLINE ReadonlyBytes bytes() const
+    [[nodiscard]] AK_ALWAYS_INLINE ReadonlyBytes bytes() const
     {
         if (m_impl) {
             return m_impl->bytes();
@@ -181,7 +181,7 @@ public:
         return {};
     }
 
-    [[nodiscard]] ALWAYS_INLINE const char& operator[](size_t i) const
+    [[nodiscard]] AK_ALWAYS_INLINE const char& operator[](size_t i) const
     {
         VERIFY(!is_null());
         return (*m_impl)[i];
@@ -297,7 +297,7 @@ public:
     [[nodiscard]] String reverse() const;
 
     template<typename... Ts>
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
     {
         return (... || this->operator==(forward<Ts>(strings)));
     }

--- a/AK/StringImpl.h
+++ b/AK/StringImpl.h
@@ -47,8 +47,8 @@ public:
     // Includes NUL-terminator.
     const char* characters() const { return &m_inline_buffer[0]; }
 
-    ALWAYS_INLINE ReadonlyBytes bytes() const { return { characters(), length() }; }
-    ALWAYS_INLINE StringView view() const { return { characters(), length() }; }
+    AK_ALWAYS_INLINE ReadonlyBytes bytes() const { return { characters(), length() }; }
+    AK_ALWAYS_INLINE StringView view() const { return { characters(), length() }; }
 
     const char& operator[](size_t i) const
     {

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -19,26 +19,26 @@ namespace AK {
 
 class StringView {
 public:
-    ALWAYS_INLINE constexpr StringView() = default;
-    ALWAYS_INLINE constexpr StringView(const char* characters, size_t length)
+    AK_ALWAYS_INLINE constexpr StringView() = default;
+    AK_ALWAYS_INLINE constexpr StringView(const char* characters, size_t length)
         : m_characters(characters)
         , m_length(length)
     {
         if (!is_constant_evaluated())
             VERIFY(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
     }
-    ALWAYS_INLINE StringView(const unsigned char* characters, size_t length)
+    AK_ALWAYS_INLINE StringView(const unsigned char* characters, size_t length)
         : m_characters((const char*)characters)
         , m_length(length)
     {
         VERIFY(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
     }
-    ALWAYS_INLINE constexpr StringView(const char* cstring)
+    AK_ALWAYS_INLINE constexpr StringView(const char* cstring)
         : m_characters(cstring)
         , m_length(cstring ? __builtin_strlen(cstring) : 0)
     {
     }
-    ALWAYS_INLINE StringView(ReadonlyBytes bytes)
+    AK_ALWAYS_INLINE StringView(ReadonlyBytes bytes)
         : m_characters(reinterpret_cast<const char*>(bytes.data()))
         , m_length(bytes.size())
     {
@@ -274,7 +274,7 @@ public:
     }
 
     template<typename... Ts>
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr bool is_one_of(Ts&&... strings) const
     {
         return (... || this->operator==(forward<Ts>(strings)));
     }
@@ -309,7 +309,7 @@ struct CaseInsensitiveStringViewTraits : public Traits<StringView> {
 #    define AK_STRING_VIEW_LITERAL_CONSTEVAL consteval
 #endif
 
-[[nodiscard]] ALWAYS_INLINE AK_STRING_VIEW_LITERAL_CONSTEVAL AK::StringView operator"" sv(const char* cstring, size_t length)
+[[nodiscard]] AK_ALWAYS_INLINE AK_STRING_VIEW_LITERAL_CONSTEVAL AK::StringView operator"" sv(const char* cstring, size_t length)
 {
     return AK::StringView(cstring, length);
 }

--- a/AK/Time.h
+++ b/AK/Time.h
@@ -126,7 +126,7 @@ public:
 private:
     // This must be part of the header in order to make the various 'from_*' functions constexpr.
     // However, sane_mod can only deal with a limited range of values for 'denominator', so this can't be made public.
-    ALWAYS_INLINE static constexpr i64 sane_mod(i64& numerator, i64 denominator)
+    AK_ALWAYS_INLINE static constexpr i64 sane_mod(i64& numerator, i64 denominator)
     {
         VERIFY(2 <= denominator && denominator <= 1'000'000'000);
         // '%' in C/C++ does not work in the obvious way:
@@ -142,7 +142,7 @@ private:
         }
         return dividend;
     }
-    ALWAYS_INLINE static constexpr i32 sane_mod(i32& numerator, i32 denominator)
+    AK_ALWAYS_INLINE static constexpr i32 sane_mod(i32& numerator, i32 denominator)
     {
         i64 numerator_64 = numerator;
         i64 dividend = sane_mod(numerator_64, denominator);

--- a/AK/TypeCasts.h
+++ b/AK/TypeCasts.h
@@ -13,7 +13,7 @@
 namespace AK {
 
 template<typename OutputType, typename InputType>
-ALWAYS_INLINE bool is(InputType& input)
+AK_ALWAYS_INLINE bool is(InputType& input)
 {
     if constexpr (requires { input.template fast_is<OutputType>(); }) {
         return input.template fast_is<OutputType>();
@@ -22,13 +22,13 @@ ALWAYS_INLINE bool is(InputType& input)
 }
 
 template<typename OutputType, typename InputType>
-ALWAYS_INLINE bool is(InputType* input)
+AK_ALWAYS_INLINE bool is(InputType* input)
 {
     return input && is<OutputType>(*input);
 }
 
 template<typename OutputType, typename InputType>
-ALWAYS_INLINE CopyConst<InputType, OutputType>* verify_cast(InputType* input)
+AK_ALWAYS_INLINE CopyConst<InputType, OutputType>* verify_cast(InputType* input)
 {
     static_assert(IsBaseOf<InputType, OutputType>);
     VERIFY(!input || is<OutputType>(*input));
@@ -36,7 +36,7 @@ ALWAYS_INLINE CopyConst<InputType, OutputType>* verify_cast(InputType* input)
 }
 
 template<typename OutputType, typename InputType>
-ALWAYS_INLINE CopyConst<InputType, OutputType>& verify_cast(InputType& input)
+AK_ALWAYS_INLINE CopyConst<InputType, OutputType>& verify_cast(InputType& input)
 {
     static_assert(IsBaseOf<InputType, OutputType>);
     VERIFY(is<OutputType>(input));

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -118,24 +118,24 @@ public:
     operator Span<StorageType const>() const { return span(); }
 
     bool is_empty() const { return size() == 0; }
-    ALWAYS_INLINE size_t size() const { return m_size; }
+    AK_ALWAYS_INLINE size_t size() const { return m_size; }
     size_t capacity() const { return m_capacity; }
 
-    ALWAYS_INLINE StorageType* data()
+    AK_ALWAYS_INLINE StorageType* data()
     {
         if constexpr (inline_capacity > 0)
             return m_outline_buffer ? m_outline_buffer : inline_buffer();
         return m_outline_buffer;
     }
 
-    ALWAYS_INLINE StorageType const* data() const
+    AK_ALWAYS_INLINE StorageType const* data() const
     {
         if constexpr (inline_capacity > 0)
             return m_outline_buffer ? m_outline_buffer : inline_buffer();
         return m_outline_buffer;
     }
 
-    ALWAYS_INLINE VisibleType const& at(size_t i) const
+    AK_ALWAYS_INLINE VisibleType const& at(size_t i) const
     {
         VERIFY(i < m_size);
         if constexpr (contains_reference)
@@ -144,7 +144,7 @@ public:
             return data()[i];
     }
 
-    ALWAYS_INLINE VisibleType& at(size_t i)
+    AK_ALWAYS_INLINE VisibleType& at(size_t i)
     {
         VERIFY(i < m_size);
         if constexpr (contains_reference)
@@ -153,8 +153,8 @@ public:
             return data()[i];
     }
 
-    ALWAYS_INLINE VisibleType const& operator[](size_t i) const { return at(i); }
-    ALWAYS_INLINE VisibleType& operator[](size_t i) { return at(i); }
+    AK_ALWAYS_INLINE VisibleType const& operator[](size_t i) const { return at(i); }
+    AK_ALWAYS_INLINE VisibleType& operator[](size_t i) { return at(i); }
 
     VisibleType const& first() const { return at(0); }
     VisibleType& first() { return at(0); }
@@ -238,7 +238,7 @@ public:
 
 #endif
 
-    ALWAYS_INLINE void append(T&& value)
+    AK_ALWAYS_INLINE void append(T&& value)
     {
         if constexpr (contains_reference)
             MUST(try_append(value));
@@ -246,7 +246,7 @@ public:
             MUST(try_append(move(value)));
     }
 
-    ALWAYS_INLINE void append(T const& value) requires(!contains_reference)
+    AK_ALWAYS_INLINE void append(T const& value) requires(!contains_reference)
     {
         MUST(try_append(T(value)));
     }
@@ -259,7 +259,7 @@ public:
 #endif
 
     template<typename U = T>
-    ALWAYS_INLINE void unchecked_append(U&& value) requires(CanBePlacedInsideVector<U>)
+    AK_ALWAYS_INLINE void unchecked_append(U&& value) requires(CanBePlacedInsideVector<U>)
     {
         VERIFY((size() + 1) <= capacity());
         if constexpr (contains_reference)
@@ -269,7 +269,7 @@ public:
         ++m_size;
     }
 
-    ALWAYS_INLINE void unchecked_append(StorageType const* values, size_t count)
+    AK_ALWAYS_INLINE void unchecked_append(StorageType const* values, size_t count)
     {
         if (count == 0)
             return;
@@ -429,7 +429,7 @@ public:
         return something_was_removed;
     }
 
-    ALWAYS_INLINE T take_last()
+    AK_ALWAYS_INLINE T take_last()
     {
         VERIFY(!is_empty());
         auto value = move(raw_last());
@@ -714,12 +714,12 @@ public:
     ReverseIterator rend() { return ReverseIterator::rend(*this); }
     ReverseConstIterator rend() const { return ReverseConstIterator::rend(*this); }
 
-    ALWAYS_INLINE constexpr auto in_reverse()
+    AK_ALWAYS_INLINE constexpr auto in_reverse()
     {
         return ReverseWrapper::in_reverse(*this);
     }
 
-    ALWAYS_INLINE constexpr auto in_reverse() const
+    AK_ALWAYS_INLINE constexpr auto in_reverse() const
     {
         return ReverseWrapper::in_reverse(*this);
     }

--- a/Documentation/Patterns.md
+++ b/Documentation/Patterns.md
@@ -198,7 +198,7 @@ static_assert(AssertSize<Empty, 1>());
 [C++17 to enable `std::string_view` literals](https://en.cppreference.com/w/cpp/string/basic_string_view/operator%22%22sv).
 
 ```cpp
-[[nodiscard]] ALWAYS_INLINE constexpr AK::StringView operator"" sv(const char* cstring, size_t length)
+[[nodiscard]] AK_ALWAYS_INLINE constexpr AK::StringView operator"" sv(const char* cstring, size_t length)
 {
     return AK::StringView(cstring, length);
 }

--- a/Kernel/API/Device.h
+++ b/Kernel/API/Device.h
@@ -12,17 +12,17 @@
 
 __BEGIN_DECLS
 
-static ALWAYS_INLINE dev_t serenity_dev_makedev(unsigned major, unsigned minor)
+static AK_ALWAYS_INLINE dev_t serenity_dev_makedev(unsigned major, unsigned minor)
 {
     return (minor & 0xffu) | (major << 8u) | ((minor & ~0xffu) << 12u);
 }
 
-static ALWAYS_INLINE unsigned int serenity_dev_major(dev_t dev)
+static AK_ALWAYS_INLINE unsigned int serenity_dev_major(dev_t dev)
 {
     return (dev & 0xfff00u) >> 8u;
 }
 
-static ALWAYS_INLINE unsigned int serenity_dev_minor(dev_t dev)
+static AK_ALWAYS_INLINE unsigned int serenity_dev_minor(dev_t dev)
 {
     return (dev & 0xffu) | ((dev >> 12u) & 0xfff00u);
 }

--- a/Kernel/API/FB.h
+++ b/Kernel/API/FB.h
@@ -13,17 +13,17 @@
 
 __BEGIN_DECLS
 
-ALWAYS_INLINE int fb_get_properties(int fd, FBProperties* info)
+AK_ALWAYS_INLINE int fb_get_properties(int fd, FBProperties* info)
 {
     return ioctl(fd, FB_IOCTL_GET_PROPERTIES, info);
 }
 
-ALWAYS_INLINE int fb_get_head_properties(int fd, FBHeadProperties* info)
+AK_ALWAYS_INLINE int fb_get_head_properties(int fd, FBHeadProperties* info)
 {
     return ioctl(fd, FB_IOCTL_GET_HEAD_PROPERTIES, info);
 }
 
-ALWAYS_INLINE int fb_get_resolution(int fd, FBHeadResolution* info)
+AK_ALWAYS_INLINE int fb_get_resolution(int fd, FBHeadResolution* info)
 {
     FBHeadProperties head_properties;
     head_properties.head_index = info->head_index;
@@ -36,27 +36,27 @@ ALWAYS_INLINE int fb_get_resolution(int fd, FBHeadResolution* info)
     return 0;
 }
 
-ALWAYS_INLINE int fb_set_resolution(int fd, FBHeadResolution* info)
+AK_ALWAYS_INLINE int fb_set_resolution(int fd, FBHeadResolution* info)
 {
     return ioctl(fd, FB_IOCTL_SET_HEAD_RESOLUTION, info);
 }
 
-ALWAYS_INLINE int fb_get_head_edid(int fd, FBHeadEDID* info)
+AK_ALWAYS_INLINE int fb_get_head_edid(int fd, FBHeadEDID* info)
 {
     return ioctl(fd, FB_IOCTL_GET_HEAD_EDID, info);
 }
 
-ALWAYS_INLINE int fb_get_head_vertical_offset_buffer(int fd, FBHeadVerticalOffset* vertical_offset)
+AK_ALWAYS_INLINE int fb_get_head_vertical_offset_buffer(int fd, FBHeadVerticalOffset* vertical_offset)
 {
     return ioctl(fd, FB_IOCTL_GET_HEAD_VERTICAL_OFFSET_BUFFER, vertical_offset);
 }
 
-ALWAYS_INLINE int fb_set_head_vertical_offset_buffer(int fd, FBHeadVerticalOffset* vertical_offset)
+AK_ALWAYS_INLINE int fb_set_head_vertical_offset_buffer(int fd, FBHeadVerticalOffset* vertical_offset)
 {
     return ioctl(fd, FB_IOCTL_SET_HEAD_VERTICAL_OFFSET_BUFFER, vertical_offset);
 }
 
-ALWAYS_INLINE int fb_flush_buffers(int fd, int index, FBRect const* rects, unsigned count)
+AK_ALWAYS_INLINE int fb_flush_buffers(int fd, int index, FBRect const* rects, unsigned count)
 {
     FBFlushRects fb_flush_rects;
     fb_flush_rects.buffer_index = index;

--- a/Kernel/Arch/aarch64/PrekernelMMU.cpp
+++ b/Kernel/Arch/aarch64/PrekernelMMU.cpp
@@ -48,7 +48,7 @@ constexpr u32 INNER_SHAREABLE = (3 << 8);
 constexpr u32 NORMAL_MEMORY = (0 << 2);
 constexpr u32 DEVICE_MEMORY = (1 << 2);
 
-ALWAYS_INLINE static u64* descriptor_to_pointer(FlatPtr descriptor)
+AK_ALWAYS_INLINE static u64* descriptor_to_pointer(FlatPtr descriptor)
 {
     return (u64*)(descriptor & DESCRIPTOR_MASK);
 }

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -30,37 +30,37 @@ public:
     template<typename T>
     T* get_specific() { return 0; }
 
-    ALWAYS_INLINE static void pause() { }
-    ALWAYS_INLINE static void wait_check() { }
+    AK_ALWAYS_INLINE static void pause() { }
+    AK_ALWAYS_INLINE static void wait_check() { }
 
-    ALWAYS_INLINE static bool is_initialized()
+    AK_ALWAYS_INLINE static bool is_initialized()
     {
         return false;
     }
 
-    ALWAYS_INLINE static u32 current_id()
+    AK_ALWAYS_INLINE static u32 current_id()
     {
         return 0;
     }
 
-    ALWAYS_INLINE static Thread* current_thread()
+    AK_ALWAYS_INLINE static Thread* current_thread()
     {
         return 0;
     }
 
-    ALWAYS_INLINE static FlatPtr current_in_irq()
+    AK_ALWAYS_INLINE static FlatPtr current_in_irq()
     {
         return 0;
     }
 
-    ALWAYS_INLINE static void enter_critical() { }
-    ALWAYS_INLINE static void leave_critical() { }
-    ALWAYS_INLINE static u32 in_critical()
+    AK_ALWAYS_INLINE static void enter_critical() { }
+    AK_ALWAYS_INLINE static void leave_critical() { }
+    AK_ALWAYS_INLINE static u32 in_critical()
     {
         return 0;
     }
 
-    ALWAYS_INLINE static Processor& current() { VERIFY_NOT_REACHED(); }
+    AK_ALWAYS_INLINE static Processor& current() { VERIFY_NOT_REACHED(); }
 
     static void deferred_call_queue(Function<void()> /* callback */) { }
 

--- a/Kernel/Arch/aarch64/Spinlock.h
+++ b/Kernel/Arch/aarch64/Spinlock.h
@@ -22,21 +22,21 @@ public:
         (void)rank;
     }
 
-    ALWAYS_INLINE u32 lock()
+    AK_ALWAYS_INLINE u32 lock()
     {
         return 0;
     }
 
-    ALWAYS_INLINE void unlock(u32 /*prev_flags*/)
+    AK_ALWAYS_INLINE void unlock(u32 /*prev_flags*/)
     {
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_locked() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_locked() const
     {
         return false;
     }
 
-    ALWAYS_INLINE void initialize()
+    AK_ALWAYS_INLINE void initialize()
     {
     }
 };
@@ -51,26 +51,26 @@ public:
         (void)rank;
     }
 
-    ALWAYS_INLINE u32 lock()
+    AK_ALWAYS_INLINE u32 lock()
     {
         return 0;
     }
 
-    ALWAYS_INLINE void unlock(u32 /*prev_flags*/)
+    AK_ALWAYS_INLINE void unlock(u32 /*prev_flags*/)
     {
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_locked() const
-    {
-        return false;
-    }
-
-    [[nodiscard]] ALWAYS_INLINE bool is_locked_by_current_processor() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_locked() const
     {
         return false;
     }
 
-    ALWAYS_INLINE void initialize()
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_locked_by_current_processor() const
+    {
+        return false;
+    }
+
+    AK_ALWAYS_INLINE void initialize()
     {
     }
 };

--- a/Kernel/Arch/x86/ASM_wrapper.h
+++ b/Kernel/Arch/x86/ASM_wrapper.h
@@ -13,17 +13,17 @@ VALIDATE_IS_X86()
 
 namespace Kernel {
 
-ALWAYS_INLINE void cli()
+AK_ALWAYS_INLINE void cli()
 {
     asm volatile("cli" ::
                      : "memory");
 }
-ALWAYS_INLINE void sti()
+AK_ALWAYS_INLINE void sti()
 {
     asm volatile("sti" ::
                      : "memory");
 }
-ALWAYS_INLINE FlatPtr cpu_flags()
+AK_ALWAYS_INLINE FlatPtr cpu_flags()
 {
     FlatPtr flags;
     asm volatile(
@@ -34,21 +34,21 @@ ALWAYS_INLINE FlatPtr cpu_flags()
 }
 
 #if ARCH(I386)
-ALWAYS_INLINE void set_fs(u16 segment)
+AK_ALWAYS_INLINE void set_fs(u16 segment)
 {
     asm volatile(
         "mov %%ax, %%fs" ::"a"(segment)
         : "memory");
 }
 
-ALWAYS_INLINE void set_gs(u16 segment)
+AK_ALWAYS_INLINE void set_gs(u16 segment)
 {
     asm volatile(
         "mov %%ax, %%gs" ::"a"(segment)
         : "memory");
 }
 
-ALWAYS_INLINE u16 get_fs()
+AK_ALWAYS_INLINE u16 get_fs()
 {
     u16 fs;
     asm("mov %%fs, %%eax"
@@ -56,7 +56,7 @@ ALWAYS_INLINE u16 get_fs()
     return fs;
 }
 
-ALWAYS_INLINE u16 get_gs()
+AK_ALWAYS_INLINE u16 get_gs()
 {
     u16 gs;
     asm("mov %%gs, %%eax"
@@ -66,7 +66,7 @@ ALWAYS_INLINE u16 get_gs()
 #endif
 
 template<typename T>
-ALWAYS_INLINE T read_gs_value(FlatPtr offset)
+AK_ALWAYS_INLINE T read_gs_value(FlatPtr offset)
 {
     T val;
     asm volatile(
@@ -77,14 +77,14 @@ ALWAYS_INLINE T read_gs_value(FlatPtr offset)
 }
 
 template<typename T>
-ALWAYS_INLINE void write_gs_value(FlatPtr offset, T val)
+AK_ALWAYS_INLINE void write_gs_value(FlatPtr offset, T val)
 {
     asm volatile(
         "mov %[val], %%gs:%a[off]" ::[off] "ir"(offset), [val] "r"(val)
         : "memory");
 }
 
-ALWAYS_INLINE FlatPtr read_gs_ptr(FlatPtr offset)
+AK_ALWAYS_INLINE FlatPtr read_gs_ptr(FlatPtr offset)
 {
     FlatPtr val;
     asm volatile(
@@ -94,14 +94,14 @@ ALWAYS_INLINE FlatPtr read_gs_ptr(FlatPtr offset)
     return val;
 }
 
-ALWAYS_INLINE void write_gs_ptr(u32 offset, FlatPtr val)
+AK_ALWAYS_INLINE void write_gs_ptr(u32 offset, FlatPtr val)
 {
     asm volatile(
         "mov %[val], %%gs:%a[off]" ::[off] "ir"(offset), [val] "r"(val)
         : "memory");
 }
 
-ALWAYS_INLINE bool are_interrupts_enabled()
+AK_ALWAYS_INLINE bool are_interrupts_enabled()
 {
     return (cpu_flags() & 0x200) != 0;
 }
@@ -119,7 +119,7 @@ void write_xcr0(u64);
 
 void flush_idt();
 
-ALWAYS_INLINE void load_task_register(u16 selector)
+AK_ALWAYS_INLINE void load_task_register(u16 selector)
 {
     asm("ltr %0" ::"r"(selector));
 }
@@ -137,7 +137,7 @@ void write_dr6(FlatPtr);
 FlatPtr read_dr7();
 void write_dr7(FlatPtr);
 
-ALWAYS_INLINE static bool is_kernel_mode()
+AK_ALWAYS_INLINE static bool is_kernel_mode()
 {
     u16 cs;
     asm volatile(
@@ -146,13 +146,13 @@ ALWAYS_INLINE static bool is_kernel_mode()
     return (cs & 3) == 0;
 }
 
-ALWAYS_INLINE void read_tsc(u32& lsw, u32& msw)
+AK_ALWAYS_INLINE void read_tsc(u32& lsw, u32& msw)
 {
     asm volatile("rdtsc"
                  : "=d"(msw), "=a"(lsw));
 }
 
-ALWAYS_INLINE u64 read_tsc()
+AK_ALWAYS_INLINE u64 read_tsc()
 {
     u32 lsw;
     u32 msw;
@@ -163,7 +163,7 @@ ALWAYS_INLINE u64 read_tsc()
 void stac();
 void clac();
 
-[[noreturn]] ALWAYS_INLINE void halt_this()
+[[noreturn]] AK_ALWAYS_INLINE void halt_this()
 {
     for (;;) {
         asm volatile("cli; hlt");

--- a/Kernel/Arch/x86/IO.h
+++ b/Kernel/Arch/x86/IO.h
@@ -83,7 +83,7 @@ public:
     void mask(u16 m) { m_address &= m; }
 
     template<typename T>
-    ALWAYS_INLINE T in()
+    AK_ALWAYS_INLINE T in()
     {
         static_assert(sizeof(T) <= 4);
         if constexpr (sizeof(T) == 4)
@@ -96,7 +96,7 @@ public:
     }
 
     template<typename T>
-    ALWAYS_INLINE void out(T value) const
+    AK_ALWAYS_INLINE void out(T value) const
     {
         static_assert(sizeof(T) <= 4);
         if constexpr (sizeof(T) == 4) {

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -158,12 +158,12 @@ public:
         return *g_total_processors.ptr();
     }
 
-    ALWAYS_INLINE static void pause()
+    AK_ALWAYS_INLINE static void pause()
     {
         asm volatile("pause");
     }
 
-    ALWAYS_INLINE static void wait_check()
+    AK_ALWAYS_INLINE static void wait_check()
     {
         Processor::pause();
         if (Processor::is_smp_enabled())
@@ -219,10 +219,10 @@ public:
         return {};
     }
 
-    ALWAYS_INLINE u8 physical_address_bit_width() const { return m_physical_address_bit_width; }
-    ALWAYS_INLINE u8 virtual_address_bit_width() const { return m_virtual_address_bit_width; }
+    AK_ALWAYS_INLINE u8 physical_address_bit_width() const { return m_physical_address_bit_width; }
+    AK_ALWAYS_INLINE u8 virtual_address_bit_width() const { return m_virtual_address_bit_width; }
 
-    ALWAYS_INLINE ProcessorInfo& info() { return *m_info; }
+    AK_ALWAYS_INLINE ProcessorInfo& info() { return *m_info; }
 
     u64 time_spent_idle() const;
 
@@ -239,12 +239,12 @@ public:
     }
 #endif
 
-    ALWAYS_INLINE static Processor& current()
+    AK_ALWAYS_INLINE static Processor& current()
     {
         return *(Processor*)read_gs_ptr(__builtin_offsetof(Processor, m_self));
     }
 
-    ALWAYS_INLINE static bool is_initialized()
+    AK_ALWAYS_INLINE static bool is_initialized()
     {
         return
 #if ARCH(I386)
@@ -264,12 +264,12 @@ public:
         m_processor_specific_data[static_cast<size_t>(specific_id)] = ptr;
     }
 
-    ALWAYS_INLINE void set_idle_thread(Thread& idle_thread)
+    AK_ALWAYS_INLINE void set_idle_thread(Thread& idle_thread)
     {
         m_idle_thread = &idle_thread;
     }
 
-    ALWAYS_INLINE static Thread* current_thread()
+    AK_ALWAYS_INLINE static Thread* current_thread()
     {
         // If we were to use Processor::current here, we'd have to
         // disable interrupts to prevent a race where we may get pre-empted
@@ -280,19 +280,19 @@ public:
         return (Thread*)read_gs_ptr(__builtin_offsetof(Processor, m_current_thread));
     }
 
-    ALWAYS_INLINE static void set_current_thread(Thread& current_thread)
+    AK_ALWAYS_INLINE static void set_current_thread(Thread& current_thread)
     {
         // See comment in Processor::current_thread
         write_gs_ptr(__builtin_offsetof(Processor, m_current_thread), FlatPtr(&current_thread));
     }
 
-    ALWAYS_INLINE static Thread* idle_thread()
+    AK_ALWAYS_INLINE static Thread* idle_thread()
     {
         // See comment in Processor::current_thread
         return (Thread*)read_gs_ptr(__builtin_offsetof(Processor, m_idle_thread));
     }
 
-    ALWAYS_INLINE u32 id() const
+    AK_ALWAYS_INLINE u32 id() const
     {
         // NOTE: This variant should only be used when iterating over all
         // Processor instances, or when it's guaranteed that the thread
@@ -302,44 +302,44 @@ public:
         return m_cpu;
     }
 
-    ALWAYS_INLINE static u32 current_id()
+    AK_ALWAYS_INLINE static u32 current_id()
     {
         // See comment in Processor::current_thread
         return read_gs_ptr(__builtin_offsetof(Processor, m_cpu));
     }
 
-    ALWAYS_INLINE static bool is_bootstrap_processor()
+    AK_ALWAYS_INLINE static bool is_bootstrap_processor()
     {
         return Processor::current_id() == 0;
     }
 
-    ALWAYS_INLINE static FlatPtr current_in_irq()
+    AK_ALWAYS_INLINE static FlatPtr current_in_irq()
     {
         return read_gs_ptr(__builtin_offsetof(Processor, m_in_irq));
     }
 
-    ALWAYS_INLINE static void restore_in_critical(u32 critical)
+    AK_ALWAYS_INLINE static void restore_in_critical(u32 critical)
     {
         write_gs_ptr(__builtin_offsetof(Processor, m_in_critical), critical);
     }
 
-    ALWAYS_INLINE static void enter_critical()
+    AK_ALWAYS_INLINE static void enter_critical()
     {
         write_gs_ptr(__builtin_offsetof(Processor, m_in_critical), in_critical() + 1);
     }
 
-    ALWAYS_INLINE static bool current_in_scheduler()
+    AK_ALWAYS_INLINE static bool current_in_scheduler()
     {
         return read_gs_value<decltype(m_in_scheduler)>(__builtin_offsetof(Processor, m_in_scheduler));
     }
 
-    ALWAYS_INLINE static void set_current_in_scheduler(bool value)
+    AK_ALWAYS_INLINE static void set_current_in_scheduler(bool value)
     {
         write_gs_value<decltype(m_in_scheduler)>(__builtin_offsetof(Processor, m_in_scheduler), value);
     }
 
 private:
-    ALWAYS_INLINE void do_leave_critical()
+    AK_ALWAYS_INLINE void do_leave_critical()
     {
         VERIFY(m_in_critical > 0);
         if (m_in_critical == 1) {
@@ -356,12 +356,12 @@ private:
     }
 
 public:
-    ALWAYS_INLINE static void leave_critical()
+    AK_ALWAYS_INLINE static void leave_critical()
     {
         current().do_leave_critical();
     }
 
-    ALWAYS_INLINE static u32 clear_critical()
+    AK_ALWAYS_INLINE static u32 clear_critical()
     {
         auto prev_critical = in_critical();
         write_gs_ptr(__builtin_offsetof(Processor, m_in_critical), 0);
@@ -371,7 +371,7 @@ public:
         return prev_critical;
     }
 
-    ALWAYS_INLINE static void restore_critical(u32 prev_critical)
+    AK_ALWAYS_INLINE static void restore_critical(u32 prev_critical)
     {
         // NOTE: This doesn't have to be atomic, and it's also fine if we
         // get preempted in between these steps. If we move to another
@@ -380,13 +380,13 @@ public:
         write_gs_ptr(__builtin_offsetof(Processor, m_in_critical), prev_critical);
     }
 
-    ALWAYS_INLINE static u32 in_critical()
+    AK_ALWAYS_INLINE static u32 in_critical()
     {
         // See comment in Processor::current_thread
         return read_gs_ptr(__builtin_offsetof(Processor, m_in_critical));
     }
 
-    ALWAYS_INLINE static FPUState const& clean_fpu_state() { return s_clean_fpu_state; }
+    AK_ALWAYS_INLINE static FPUState const& clean_fpu_state() { return s_clean_fpu_state; }
 
     static void smp_enable();
     bool smp_process_pending_messages();
@@ -397,7 +397,7 @@ public:
 
     static void deferred_call_queue(Function<void()> callback);
 
-    ALWAYS_INLINE bool has_feature(CPUFeature f) const
+    AK_ALWAYS_INLINE bool has_feature(CPUFeature f) const
     {
         return (static_cast<u32>(m_features) & static_cast<u32>(f)) != 0;
     }

--- a/Kernel/Arch/x86/SafeMem.h
+++ b/Kernel/Arch/x86/SafeMem.h
@@ -23,7 +23,7 @@ struct RegisterState;
 [[nodiscard]] bool safe_atomic_store_relaxed(volatile u32* var, u32 val) __attribute__((used));
 [[nodiscard]] Optional<bool> safe_atomic_compare_exchange_relaxed(volatile u32* var, u32& expected, u32 val) __attribute__((used));
 
-[[nodiscard]] ALWAYS_INLINE Optional<u32> safe_atomic_fetch_and_relaxed(volatile u32* var, u32 val)
+[[nodiscard]] AK_ALWAYS_INLINE Optional<u32> safe_atomic_fetch_and_relaxed(volatile u32* var, u32 val)
 {
     auto expected_value = safe_atomic_load_relaxed(var);
     if (!expected_value.has_value())
@@ -41,7 +41,7 @@ struct RegisterState;
     }
 }
 
-[[nodiscard]] ALWAYS_INLINE Optional<u32> safe_atomic_fetch_and_not_relaxed(volatile u32* var, u32 val)
+[[nodiscard]] AK_ALWAYS_INLINE Optional<u32> safe_atomic_fetch_and_not_relaxed(volatile u32* var, u32 val)
 {
     auto expected_value = safe_atomic_load_relaxed(var);
     if (!expected_value.has_value())
@@ -59,7 +59,7 @@ struct RegisterState;
     }
 }
 
-[[nodiscard]] ALWAYS_INLINE Optional<u32> safe_atomic_fetch_or_relaxed(volatile u32* var, u32 val)
+[[nodiscard]] AK_ALWAYS_INLINE Optional<u32> safe_atomic_fetch_or_relaxed(volatile u32* var, u32 val)
 {
     auto expected_value = safe_atomic_load_relaxed(var);
     if (!expected_value.has_value())
@@ -77,7 +77,7 @@ struct RegisterState;
     }
 }
 
-[[nodiscard]] ALWAYS_INLINE Optional<u32> safe_atomic_fetch_xor_relaxed(volatile u32* var, u32 val)
+[[nodiscard]] AK_ALWAYS_INLINE Optional<u32> safe_atomic_fetch_xor_relaxed(volatile u32* var, u32 val)
 {
     auto expected_value = safe_atomic_load_relaxed(var);
     if (!expected_value.has_value())

--- a/Kernel/Arch/x86/Spinlock.h
+++ b/Kernel/Arch/x86/Spinlock.h
@@ -27,12 +27,12 @@ public:
     u32 lock();
     void unlock(u32 prev_flags);
 
-    [[nodiscard]] ALWAYS_INLINE bool is_locked() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_locked() const
     {
         return m_lock.load(AK::memory_order_relaxed) != 0;
     }
 
-    ALWAYS_INLINE void initialize()
+    AK_ALWAYS_INLINE void initialize()
     {
         m_lock.store(0, AK::memory_order_relaxed);
     }
@@ -55,17 +55,17 @@ public:
     u32 lock();
     void unlock(u32 prev_flags);
 
-    [[nodiscard]] ALWAYS_INLINE bool is_locked() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_locked() const
     {
         return m_lock.load(AK::memory_order_relaxed) != 0;
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_locked_by_current_processor() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_locked_by_current_processor() const
     {
         return m_lock.load(AK::memory_order_relaxed) == FlatPtr(&Processor::current());
     }
 
-    ALWAYS_INLINE void initialize()
+    AK_ALWAYS_INLINE void initialize()
     {
         m_lock.store(0, AK::memory_order_relaxed);
     }

--- a/Kernel/Arch/x86/common/SafeMem.cpp
+++ b/Kernel/Arch/x86/common/SafeMem.cpp
@@ -40,7 +40,7 @@ extern "C" u8 safe_atomic_compare_exchange_relaxed_faulted[];
 
 namespace Kernel {
 
-ALWAYS_INLINE bool validate_canonical_address(size_t address)
+AK_ALWAYS_INLINE bool validate_canonical_address(size_t address)
 {
 #if ARCH(X86_64)
     auto most_significant_bits = Processor::current().virtual_address_bit_width() - 1;

--- a/Kernel/FileSystem/File.h
+++ b/Kernel/FileSystem/File.h
@@ -138,7 +138,7 @@ protected:
     }
 
 private:
-    ALWAYS_INLINE void do_evaluate_block_conditions()
+    AK_ALWAYS_INLINE void do_evaluate_block_conditions()
     {
         VERIFY(!Processor::current_in_irq());
         blocker_set().unblock_all_blockers_whose_conditions_are_met();

--- a/Kernel/Heap/Heap.h
+++ b/Kernel/Heap/Heap.h
@@ -29,11 +29,11 @@ class Heap {
 
     static_assert(CHUNK_SIZE >= sizeof(AllocationHeader));
 
-    ALWAYS_INLINE AllocationHeader* allocation_header(void* ptr)
+    AK_ALWAYS_INLINE AllocationHeader* allocation_header(void* ptr)
     {
         return (AllocationHeader*)((((u8*)ptr) - sizeof(AllocationHeader)));
     }
-    ALWAYS_INLINE const AllocationHeader* allocation_header(const void* ptr) const
+    AK_ALWAYS_INLINE const AllocationHeader* allocation_header(const void* ptr) const
     {
         return (const AllocationHeader*)((((const u8*)ptr) - sizeof(AllocationHeader)));
     }

--- a/Kernel/Interrupts/GenericInterruptHandler.h
+++ b/Kernel/Interrupts/GenericInterruptHandler.h
@@ -48,7 +48,7 @@ public:
     virtual StringView controller() const = 0;
 
     virtual bool eoi() = 0;
-    ALWAYS_INLINE void increment_invoking_counter()
+    AK_ALWAYS_INLINE void increment_invoking_counter()
     {
         m_invoking_count++;
     }

--- a/Kernel/Library/ThreadSafeNonnullRefPtr.h
+++ b/Kernel/Library/ThreadSafeNonnullRefPtr.h
@@ -26,14 +26,14 @@ template<typename T, typename PtrTraits>
 class RefPtr;
 
 template<typename T>
-ALWAYS_INLINE void ref_if_not_null(T* ptr)
+AK_ALWAYS_INLINE void ref_if_not_null(T* ptr)
 {
     if (ptr)
         ptr->ref();
 }
 
 template<typename T>
-ALWAYS_INLINE void unref_if_not_null(T* ptr)
+AK_ALWAYS_INLINE void unref_if_not_null(T* ptr)
 {
     if (ptr)
         ptr->unref();
@@ -53,47 +53,47 @@ public:
 
     enum AdoptTag { Adopt };
 
-    ALWAYS_INLINE NonnullRefPtr(const T& object)
+    AK_ALWAYS_INLINE NonnullRefPtr(const T& object)
         : m_bits((FlatPtr)&object)
     {
         VERIFY(!(m_bits & 1));
         const_cast<T&>(object).ref();
     }
     template<typename U>
-    ALWAYS_INLINE NonnullRefPtr(const U& object) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE NonnullRefPtr(const U& object) requires(IsConvertible<U*, T*>)
         : m_bits((FlatPtr) static_cast<const T*>(&object))
     {
         VERIFY(!(m_bits & 1));
         const_cast<T&>(static_cast<const T&>(object)).ref();
     }
-    ALWAYS_INLINE NonnullRefPtr(AdoptTag, T& object)
+    AK_ALWAYS_INLINE NonnullRefPtr(AdoptTag, T& object)
         : m_bits((FlatPtr)&object)
     {
         VERIFY(!(m_bits & 1));
     }
-    ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr&& other)
+    AK_ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr&& other)
         : m_bits((FlatPtr)&other.leak_ref())
     {
         VERIFY(!(m_bits & 1));
     }
     template<typename U>
-    ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE NonnullRefPtr(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
         : m_bits((FlatPtr)&other.leak_ref())
     {
         VERIFY(!(m_bits & 1));
     }
-    ALWAYS_INLINE NonnullRefPtr(const NonnullRefPtr& other)
+    AK_ALWAYS_INLINE NonnullRefPtr(const NonnullRefPtr& other)
         : m_bits((FlatPtr)other.add_ref())
     {
         VERIFY(!(m_bits & 1));
     }
     template<typename U>
-    ALWAYS_INLINE NonnullRefPtr(const NonnullRefPtr<U>& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE NonnullRefPtr(const NonnullRefPtr<U>& other) requires(IsConvertible<U*, T*>)
         : m_bits((FlatPtr)other.add_ref())
     {
         VERIFY(!(m_bits & 1));
     }
-    ALWAYS_INLINE ~NonnullRefPtr()
+    AK_ALWAYS_INLINE ~NonnullRefPtr()
     {
         assign(nullptr);
 #ifdef SANITIZE_PTRS
@@ -127,7 +127,7 @@ public:
         return *this;
     }
 
-    ALWAYS_INLINE NonnullRefPtr& operator=(NonnullRefPtr&& other)
+    AK_ALWAYS_INLINE NonnullRefPtr& operator=(NonnullRefPtr&& other)
     {
         if (this != &other)
             assign(&other.leak_ref());
@@ -148,54 +148,54 @@ public:
         return *this;
     }
 
-    [[nodiscard]] ALWAYS_INLINE T& leak_ref()
+    [[nodiscard]] AK_ALWAYS_INLINE T& leak_ref()
     {
         T* ptr = exchange(nullptr);
         VERIFY(ptr);
         return *ptr;
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* ptr()
+    AK_ALWAYS_INLINE RETURNS_NONNULL T* ptr()
     {
         return as_nonnull_ptr();
     }
-    ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
-    {
-        return as_nonnull_ptr();
-    }
-
-    ALWAYS_INLINE RETURNS_NONNULL T* operator->()
-    {
-        return as_nonnull_ptr();
-    }
-    ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const
+    AK_ALWAYS_INLINE RETURNS_NONNULL const T* ptr() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE T& operator*()
+    AK_ALWAYS_INLINE RETURNS_NONNULL T* operator->()
+    {
+        return as_nonnull_ptr();
+    }
+    AK_ALWAYS_INLINE RETURNS_NONNULL const T* operator->() const
+    {
+        return as_nonnull_ptr();
+    }
+
+    AK_ALWAYS_INLINE T& operator*()
     {
         return *as_nonnull_ptr();
     }
-    ALWAYS_INLINE const T& operator*() const
+    AK_ALWAYS_INLINE const T& operator*() const
     {
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL operator T*()
+    AK_ALWAYS_INLINE RETURNS_NONNULL operator T*()
     {
         return as_nonnull_ptr();
     }
-    ALWAYS_INLINE RETURNS_NONNULL operator const T*() const
+    AK_ALWAYS_INLINE RETURNS_NONNULL operator const T*() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE operator T&()
+    AK_ALWAYS_INLINE operator T&()
     {
         return *as_nonnull_ptr();
     }
-    ALWAYS_INLINE operator const T&() const
+    AK_ALWAYS_INLINE operator const T&() const
     {
         return *as_nonnull_ptr();
     }
@@ -228,12 +228,12 @@ private:
     NonnullRefPtr() = delete;
     // clang-format on
 
-    ALWAYS_INLINE T* as_ptr() const
+    AK_ALWAYS_INLINE T* as_ptr() const
     {
         return (T*)(m_bits.load(AK::MemoryOrder::memory_order_relaxed) & ~(FlatPtr)1);
     }
 
-    ALWAYS_INLINE RETURNS_NONNULL T* as_nonnull_ptr() const
+    AK_ALWAYS_INLINE RETURNS_NONNULL T* as_nonnull_ptr() const
     {
         T* ptr = (T*)(m_bits.load(AK::MemoryOrder::memory_order_relaxed) & ~(FlatPtr)1);
         VERIFY(ptr);
@@ -261,13 +261,13 @@ private:
         m_bits.store(bits, AK::MemoryOrder::memory_order_release);
     }
 
-    ALWAYS_INLINE void assign(T* new_ptr)
+    AK_ALWAYS_INLINE void assign(T* new_ptr)
     {
         T* prev_ptr = exchange(new_ptr);
         unref_if_not_null(prev_ptr);
     }
 
-    ALWAYS_INLINE T* exchange(T* new_ptr)
+    AK_ALWAYS_INLINE T* exchange(T* new_ptr)
     {
         VERIFY(!((FlatPtr)new_ptr & 1));
 #ifdef KERNEL

--- a/Kernel/Library/ThreadSafeRefPtr.h
+++ b/Kernel/Library/ThreadSafeRefPtr.h
@@ -28,31 +28,31 @@ class OwnPtr;
 
 template<typename T>
 struct RefPtrTraits {
-    ALWAYS_INLINE static T* as_ptr(FlatPtr bits)
+    AK_ALWAYS_INLINE static T* as_ptr(FlatPtr bits)
     {
         return (T*)(bits & ~(FlatPtr)1);
     }
 
-    ALWAYS_INLINE static FlatPtr as_bits(T* ptr)
+    AK_ALWAYS_INLINE static FlatPtr as_bits(T* ptr)
     {
         VERIFY(((FlatPtr)ptr & 1) == 0);
         return (FlatPtr)ptr;
     }
 
     template<typename U, typename PtrTraits>
-    ALWAYS_INLINE static FlatPtr convert_from(FlatPtr bits)
+    AK_ALWAYS_INLINE static FlatPtr convert_from(FlatPtr bits)
     {
         if (PtrTraits::is_null(bits))
             return default_null_value;
         return as_bits(PtrTraits::as_ptr(bits));
     }
 
-    ALWAYS_INLINE static bool is_null(FlatPtr bits)
+    AK_ALWAYS_INLINE static bool is_null(FlatPtr bits)
     {
         return (bits & ~(FlatPtr)1) == 0;
     }
 
-    ALWAYS_INLINE static FlatPtr exchange(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
+    AK_ALWAYS_INLINE static FlatPtr exchange(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
     {
         // Only exchange when lock is not held
         VERIFY((new_value & 1) == 0);
@@ -68,7 +68,7 @@ struct RefPtrTraits {
         return expected;
     }
 
-    ALWAYS_INLINE static bool exchange_if_null(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
+    AK_ALWAYS_INLINE static bool exchange_if_null(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
     {
         // Only exchange when lock is not held
         VERIFY((new_value & 1) == 0);
@@ -85,7 +85,7 @@ struct RefPtrTraits {
         return true;
     }
 
-    ALWAYS_INLINE static FlatPtr lock(Atomic<FlatPtr>& atomic_var)
+    AK_ALWAYS_INLINE static FlatPtr lock(Atomic<FlatPtr>& atomic_var)
     {
         // This sets the lock bit atomically, preventing further modifications.
         // This is important when e.g. copying a RefPtr where the source
@@ -105,7 +105,7 @@ struct RefPtrTraits {
         return bits;
     }
 
-    ALWAYS_INLINE static void unlock(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
+    AK_ALWAYS_INLINE static void unlock(Atomic<FlatPtr>& atomic_var, FlatPtr new_value)
     {
         VERIFY((new_value & 1) == 0);
         atomic_var.store(new_value, AK::MemoryOrder::memory_order_release);
@@ -151,17 +151,17 @@ public:
         : m_bits(other.leak_ref_raw())
     {
     }
-    ALWAYS_INLINE RefPtr(const NonnullRefPtr<T>& other)
+    AK_ALWAYS_INLINE RefPtr(const NonnullRefPtr<T>& other)
         : m_bits(PtrTraits::as_bits(const_cast<T*>(other.add_ref())))
     {
     }
     template<typename U>
-    ALWAYS_INLINE RefPtr(const NonnullRefPtr<U>& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr(const NonnullRefPtr<U>& other) requires(IsConvertible<U*, T*>)
         : m_bits(PtrTraits::as_bits(const_cast<U*>(other.add_ref())))
     {
     }
     template<typename U>
-    ALWAYS_INLINE RefPtr(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
         : m_bits(PtrTraits::as_bits(&other.leak_ref()))
     {
         VERIFY(!is_null());
@@ -180,7 +180,7 @@ public:
         : m_bits(other.add_ref_raw())
     {
     }
-    ALWAYS_INLINE ~RefPtr()
+    AK_ALWAYS_INLINE ~RefPtr()
     {
         clear();
 #ifdef SANITIZE_PTRS
@@ -213,7 +213,7 @@ public:
         P::exchange(other.m_bits, P::template convert_from<U, P>(bits));
     }
 
-    ALWAYS_INLINE RefPtr& operator=(RefPtr&& other)
+    AK_ALWAYS_INLINE RefPtr& operator=(RefPtr&& other)
     {
         if (this != &other)
             assign_raw(other.leak_ref_raw());
@@ -221,33 +221,33 @@ public:
     }
 
     template<typename U, typename P = RefPtrTraits<U>>
-    ALWAYS_INLINE RefPtr& operator=(RefPtr<U, P>&& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr& operator=(RefPtr<U, P>&& other) requires(IsConvertible<U*, T*>)
     {
         assign_raw(PtrTraits::template convert_from<U, P>(other.leak_ref_raw()));
         return *this;
     }
 
     template<typename U>
-    ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr& operator=(NonnullRefPtr<U>&& other) requires(IsConvertible<U*, T*>)
     {
         assign_raw(PtrTraits::as_bits(&other.leak_ref()));
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(const NonnullRefPtr<T>& other)
+    AK_ALWAYS_INLINE RefPtr& operator=(const NonnullRefPtr<T>& other)
     {
         assign_raw(PtrTraits::as_bits(other.add_ref()));
         return *this;
     }
 
     template<typename U>
-    ALWAYS_INLINE RefPtr& operator=(const NonnullRefPtr<U>& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr& operator=(const NonnullRefPtr<U>& other) requires(IsConvertible<U*, T*>)
     {
         assign_raw(PtrTraits::as_bits(other.add_ref()));
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(const RefPtr& other)
+    AK_ALWAYS_INLINE RefPtr& operator=(const RefPtr& other)
     {
         if (this != &other)
             assign_raw(other.add_ref_raw());
@@ -255,20 +255,20 @@ public:
     }
 
     template<typename U>
-    ALWAYS_INLINE RefPtr& operator=(const RefPtr<U>& other) requires(IsConvertible<U*, T*>)
+    AK_ALWAYS_INLINE RefPtr& operator=(const RefPtr<U>& other) requires(IsConvertible<U*, T*>)
     {
         assign_raw(other.add_ref_raw());
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(const T* ptr)
+    AK_ALWAYS_INLINE RefPtr& operator=(const T* ptr)
     {
         ref_if_not_null(const_cast<T*>(ptr));
         assign_raw(PtrTraits::as_bits(const_cast<T*>(ptr)));
         return *this;
     }
 
-    ALWAYS_INLINE RefPtr& operator=(const T& object)
+    AK_ALWAYS_INLINE RefPtr& operator=(const T& object)
     {
         const_cast<T&>(object).ref();
         assign_raw(PtrTraits::as_bits(const_cast<T*>(&object)));
@@ -281,7 +281,7 @@ public:
         return *this;
     }
 
-    ALWAYS_INLINE bool assign_if_null(RefPtr&& other)
+    AK_ALWAYS_INLINE bool assign_if_null(RefPtr&& other)
     {
         if (this == &other)
             return is_null();
@@ -289,14 +289,14 @@ public:
     }
 
     template<typename U, typename P = RefPtrTraits<U>>
-    ALWAYS_INLINE bool assign_if_null(RefPtr<U, P>&& other)
+    AK_ALWAYS_INLINE bool assign_if_null(RefPtr<U, P>&& other)
     {
         if (this == &other)
             return is_null();
         return PtrTraits::exchange_if_null(m_bits, PtrTraits::template convert_from<U, P>(other.leak_ref_raw()));
     }
 
-    ALWAYS_INLINE void clear()
+    AK_ALWAYS_INLINE void clear()
     {
         assign_raw(PtrTraits::default_null_value);
     }
@@ -316,33 +316,33 @@ public:
         return NonnullRefPtr<T>(NonnullRefPtr<T>::Adopt, *PtrTraits::as_ptr(bits));
     }
 
-    ALWAYS_INLINE T* ptr() { return as_ptr(); }
-    ALWAYS_INLINE const T* ptr() const { return as_ptr(); }
+    AK_ALWAYS_INLINE T* ptr() { return as_ptr(); }
+    AK_ALWAYS_INLINE const T* ptr() const { return as_ptr(); }
 
-    ALWAYS_INLINE T* operator->()
+    AK_ALWAYS_INLINE T* operator->()
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE const T* operator->() const
+    AK_ALWAYS_INLINE const T* operator->() const
     {
         return as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE T& operator*()
+    AK_ALWAYS_INLINE T& operator*()
     {
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE const T& operator*() const
+    AK_ALWAYS_INLINE const T& operator*() const
     {
         return *as_nonnull_ptr();
     }
 
-    ALWAYS_INLINE operator const T*() const { return as_ptr(); }
-    ALWAYS_INLINE operator T*() { return as_ptr(); }
+    AK_ALWAYS_INLINE operator const T*() const { return as_ptr(); }
+    AK_ALWAYS_INLINE operator T*() { return as_ptr(); }
 
-    ALWAYS_INLINE operator bool() { return !is_null(); }
+    AK_ALWAYS_INLINE operator bool() { return !is_null(); }
 
     bool operator==(std::nullptr_t) const { return is_null(); }
     bool operator!=(std::nullptr_t) const { return !is_null(); }
@@ -359,7 +359,7 @@ public:
     bool operator==(T* other) { return as_ptr() == other; }
     bool operator!=(T* other) { return as_ptr() != other; }
 
-    ALWAYS_INLINE bool is_null() const { return PtrTraits::is_null(m_bits.load(AK::MemoryOrder::memory_order_relaxed)); }
+    AK_ALWAYS_INLINE bool is_null() const { return PtrTraits::is_null(m_bits.load(AK::MemoryOrder::memory_order_relaxed)); }
 
     template<typename U = T>
     typename PtrTraits::NullType null_value() const
@@ -393,12 +393,12 @@ private:
         PtrTraits::unlock(m_bits, bits);
     }
 
-    [[nodiscard]] ALWAYS_INLINE FlatPtr leak_ref_raw()
+    [[nodiscard]] AK_ALWAYS_INLINE FlatPtr leak_ref_raw()
     {
         return PtrTraits::exchange(m_bits, PtrTraits::default_null_value);
     }
 
-    [[nodiscard]] ALWAYS_INLINE FlatPtr add_ref_raw() const
+    [[nodiscard]] AK_ALWAYS_INLINE FlatPtr add_ref_raw() const
     {
 #ifdef KERNEL
         // We don't want to be pre-empted while we have the lock bit set
@@ -419,23 +419,23 @@ private:
         return bits;
     }
 
-    ALWAYS_INLINE void assign_raw(FlatPtr bits)
+    AK_ALWAYS_INLINE void assign_raw(FlatPtr bits)
     {
         FlatPtr prev_bits = PtrTraits::exchange(m_bits, bits);
         unref_if_not_null(PtrTraits::as_ptr(prev_bits));
     }
 
-    ALWAYS_INLINE T* as_ptr() const
+    AK_ALWAYS_INLINE T* as_ptr() const
     {
         return PtrTraits::as_ptr(m_bits.load(AK::MemoryOrder::memory_order_relaxed));
     }
 
-    ALWAYS_INLINE T* as_nonnull_ptr() const
+    AK_ALWAYS_INLINE T* as_nonnull_ptr() const
     {
         return as_nonnull_ptr(m_bits.load(AK::MemoryOrder::memory_order_relaxed));
     }
 
-    ALWAYS_INLINE T* as_nonnull_ptr(FlatPtr bits) const
+    AK_ALWAYS_INLINE T* as_nonnull_ptr(FlatPtr bits) const
     {
         VERIFY(!PtrTraits::is_null(bits));
         return PtrTraits::as_ptr(bits);

--- a/Kernel/Locking/Mutex.h
+++ b/Kernel/Locking/Mutex.h
@@ -72,7 +72,7 @@ public:
 private:
     using BlockedThreadList = IntrusiveList<&Thread::m_blocked_threads_list_node>;
 
-    ALWAYS_INLINE BlockedThreadList& thread_list_for_mode(Mode mode)
+    AK_ALWAYS_INLINE BlockedThreadList& thread_list_for_mode(Mode mode)
     {
         VERIFY(mode == Mode::Exclusive || mode == Mode::Shared);
         return mode == Mode::Exclusive ? m_blocked_threads_list_exclusive : m_blocked_threads_list_shared;
@@ -110,25 +110,25 @@ class MutexLocker {
     AK_MAKE_NONCOPYABLE(MutexLocker);
 
 public:
-    ALWAYS_INLINE explicit MutexLocker()
+    AK_ALWAYS_INLINE explicit MutexLocker()
         : m_lock(nullptr)
         , m_locked(false)
     {
     }
 
-    ALWAYS_INLINE explicit MutexLocker(Mutex& l, Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
+    AK_ALWAYS_INLINE explicit MutexLocker(Mutex& l, Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
         : m_lock(&l)
     {
         m_lock->lock(mode, location);
     }
 
-    ALWAYS_INLINE ~MutexLocker()
+    AK_ALWAYS_INLINE ~MutexLocker()
     {
         if (m_locked)
             unlock();
     }
 
-    ALWAYS_INLINE void unlock()
+    AK_ALWAYS_INLINE void unlock()
     {
         VERIFY(m_lock);
         VERIFY(m_locked);
@@ -136,7 +136,7 @@ public:
         m_lock->unlock();
     }
 
-    ALWAYS_INLINE void attach_and_lock(Mutex& lock, Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
+    AK_ALWAYS_INLINE void attach_and_lock(Mutex& lock, Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
     {
         VERIFY(!m_locked);
         m_lock = &lock;
@@ -145,7 +145,7 @@ public:
         m_lock->lock(mode, location);
     }
 
-    ALWAYS_INLINE void lock(Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
+    AK_ALWAYS_INLINE void lock(Mutex::Mode mode = Mutex::Mode::Exclusive, LockLocation const& location = LockLocation::current())
     {
         VERIFY(m_lock);
         VERIFY(!m_locked);

--- a/Kernel/Locking/MutexProtected.h
+++ b/Kernel/Locking/MutexProtected.h
@@ -29,14 +29,14 @@ private:
         {
         }
 
-        ALWAYS_INLINE U const* operator->() const { return &m_value; }
-        ALWAYS_INLINE U const& operator*() const { return m_value; }
+        AK_ALWAYS_INLINE U const* operator->() const { return &m_value; }
+        AK_ALWAYS_INLINE U const& operator*() const { return m_value; }
 
-        ALWAYS_INLINE U* operator->() requires(!IsConst<U>) { return &m_value; }
-        ALWAYS_INLINE U& operator*() requires(!IsConst<U>) { return m_value; }
+        AK_ALWAYS_INLINE U* operator->() requires(!IsConst<U>) { return &m_value; }
+        AK_ALWAYS_INLINE U& operator*() requires(!IsConst<U>) { return m_value; }
 
-        ALWAYS_INLINE U const& get() const { return &m_value; }
-        ALWAYS_INLINE U& get() requires(!IsConst<U>) { return &m_value; }
+        AK_ALWAYS_INLINE U const& get() const { return &m_value; }
+        AK_ALWAYS_INLINE U& get() requires(!IsConst<U>) { return &m_value; }
 
     private:
         U& m_value;

--- a/Kernel/Locking/Spinlock.h
+++ b/Kernel/Locking/Spinlock.h
@@ -46,7 +46,7 @@ public:
         }
     }
 
-    ALWAYS_INLINE void lock()
+    AK_ALWAYS_INLINE void lock()
     {
         VERIFY(m_lock);
         VERIFY(!m_have_lock);
@@ -54,7 +54,7 @@ public:
         m_have_lock = true;
     }
 
-    ALWAYS_INLINE void unlock()
+    AK_ALWAYS_INLINE void unlock()
     {
         VERIFY(m_lock);
         VERIFY(m_have_lock);
@@ -63,7 +63,7 @@ public:
         m_have_lock = false;
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool have_lock() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool have_lock() const
     {
         return m_have_lock;
     }

--- a/Kernel/Locking/SpinlockProtected.h
+++ b/Kernel/Locking/SpinlockProtected.h
@@ -28,14 +28,14 @@ private:
         {
         }
 
-        ALWAYS_INLINE U const* operator->() const { return &m_value; }
-        ALWAYS_INLINE U const& operator*() const { return m_value; }
+        AK_ALWAYS_INLINE U const* operator->() const { return &m_value; }
+        AK_ALWAYS_INLINE U const& operator*() const { return m_value; }
 
-        ALWAYS_INLINE U* operator->() { return &m_value; }
-        ALWAYS_INLINE U& operator*() { return m_value; }
+        AK_ALWAYS_INLINE U* operator->() { return &m_value; }
+        AK_ALWAYS_INLINE U& operator*() { return m_value; }
 
-        ALWAYS_INLINE U const& get() const { return m_value; }
-        ALWAYS_INLINE U& get() { return m_value; }
+        AK_ALWAYS_INLINE U const& get() const { return m_value; }
+        AK_ALWAYS_INLINE U& get() { return m_value; }
 
     private:
         U& m_value;

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -265,7 +265,7 @@ private:
 
     RefPtr<PhysicalPage> find_free_user_physical_page(bool);
 
-    ALWAYS_INLINE u8* quickmap_page(PhysicalPage& page)
+    AK_ALWAYS_INLINE u8* quickmap_page(PhysicalPage& page)
     {
         return quickmap_page(page.paddr());
     }

--- a/Kernel/Memory/Region.h
+++ b/Kernel/Memory/Region.h
@@ -134,7 +134,7 @@ public:
         return true;
     }
 
-    [[nodiscard]] ALWAYS_INLINE size_t translate_to_vmobject_page(size_t page_index) const
+    [[nodiscard]] AK_ALWAYS_INLINE size_t translate_to_vmobject_page(size_t page_index) const
     {
         return first_page_index() + page_index;
     }

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -41,13 +41,13 @@ public:
 
     virtual StringView class_name() const = 0;
 
-    ALWAYS_INLINE void add_region(Region& region)
+    AK_ALWAYS_INLINE void add_region(Region& region)
     {
         SpinlockLocker locker(m_lock);
         m_regions.append(region);
     }
 
-    ALWAYS_INLINE void remove_region(Region& region)
+    AK_ALWAYS_INLINE void remove_region(Region& region)
     {
         SpinlockLocker locker(m_lock);
         m_regions.remove(region);

--- a/Kernel/PhysicalAddress.h
+++ b/Kernel/PhysicalAddress.h
@@ -15,8 +15,8 @@ typedef u64 PhysicalSize;
 
 class PhysicalAddress {
 public:
-    ALWAYS_INLINE static PhysicalPtr physical_page_base(PhysicalPtr page_address) { return page_address & ~(PhysicalPtr)0xfff; }
-    ALWAYS_INLINE static size_t physical_page_index(PhysicalPtr page_address)
+    AK_ALWAYS_INLINE static PhysicalPtr physical_page_base(PhysicalPtr page_address) { return page_address & ~(PhysicalPtr)0xfff; }
+    AK_ALWAYS_INLINE static size_t physical_page_index(PhysicalPtr page_address)
     {
         auto page_index = page_address >> 12;
         if constexpr (sizeof(size_t) < sizeof(PhysicalPtr))

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -652,8 +652,8 @@ public:
 
     public:
         OpenFileDescriptions() { }
-        ALWAYS_INLINE const OpenFileDescriptionAndFlags& operator[](size_t i) const { return at(i); }
-        ALWAYS_INLINE OpenFileDescriptionAndFlags& operator[](size_t i) { return at(i); }
+        AK_ALWAYS_INLINE const OpenFileDescriptionAndFlags& operator[](size_t i) const { return at(i); }
+        AK_ALWAYS_INLINE OpenFileDescriptionAndFlags& operator[](size_t i) { return at(i); }
 
         ErrorOr<void> try_clone(const Kernel::Process::OpenFileDescriptions& other)
         {

--- a/Kernel/Storage/ATA/AHCIPort.h
+++ b/Kernel/Storage/ATA/AHCIPort.h
@@ -56,7 +56,7 @@ private:
 
     UNMAP_AFTER_INIT AHCIPort(const AHCIPortHandler&, volatile AHCI::PortRegisters&, u32 port_index);
 
-    ALWAYS_INLINE void clear_sata_error_register() const;
+    AK_ALWAYS_INLINE void clear_sata_error_register() const;
 
     void eject();
 
@@ -67,8 +67,8 @@ private:
     void rebase();
     void recover_from_fatal_error();
     bool shutdown();
-    ALWAYS_INLINE void spin_up() const;
-    ALWAYS_INLINE void power_on() const;
+    AK_ALWAYS_INLINE void spin_up() const;
+    AK_ALWAYS_INLINE void power_on() const;
 
     void start_request(AsyncBlockDeviceRequest&);
     void complete_current_request(AsyncDeviceRequest::RequestResult);
@@ -76,29 +76,29 @@ private:
     size_t calculate_descriptors_count(size_t block_count) const;
     [[nodiscard]] Optional<AsyncDeviceRequest::RequestResult> prepare_and_set_scatter_list(AsyncBlockDeviceRequest& request);
 
-    ALWAYS_INLINE bool is_interrupts_enabled() const;
+    AK_ALWAYS_INLINE bool is_interrupts_enabled() const;
 
     bool spin_until_ready() const;
 
     bool identify_device();
 
-    ALWAYS_INLINE void start_command_list_processing() const;
-    ALWAYS_INLINE void mark_command_header_ready_to_process(u8 command_header_index) const;
-    ALWAYS_INLINE void stop_command_list_processing() const;
+    AK_ALWAYS_INLINE void start_command_list_processing() const;
+    AK_ALWAYS_INLINE void mark_command_header_ready_to_process(u8 command_header_index) const;
+    AK_ALWAYS_INLINE void stop_command_list_processing() const;
 
-    ALWAYS_INLINE void start_fis_receiving() const;
-    ALWAYS_INLINE void stop_fis_receiving() const;
+    AK_ALWAYS_INLINE void start_fis_receiving() const;
+    AK_ALWAYS_INLINE void stop_fis_receiving() const;
 
-    ALWAYS_INLINE void set_active_state() const;
-    ALWAYS_INLINE void set_sleep_state() const;
+    AK_ALWAYS_INLINE void set_active_state() const;
+    AK_ALWAYS_INLINE void set_sleep_state() const;
 
     void set_interface_state(AHCI::DeviceDetectionInitialization);
 
     Optional<u8> try_to_find_unused_command_header();
 
-    ALWAYS_INLINE bool is_interface_disabled() const { return (m_port_registers.ssts & 0xf) == 4; };
+    AK_ALWAYS_INLINE bool is_interface_disabled() const { return (m_port_registers.ssts & 0xf) == 4; };
 
-    ALWAYS_INLINE void wait_until_condition_met_or_timeout(size_t delay_in_microseconds, size_t retries, Function<bool(void)> condition_being_met) const;
+    AK_ALWAYS_INLINE void wait_until_condition_met_or_timeout(size_t delay_in_microseconds, size_t retries, Function<bool(void)> condition_being_met) const;
 
     // Data members
 

--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -838,7 +838,7 @@ public:
     size_t thread_specific_region_size() const;
     size_t thread_specific_region_alignment() const;
 
-    ALWAYS_INLINE void yield_if_stopped()
+    AK_ALWAYS_INLINE void yield_if_stopped()
     {
         // If some thread stopped us, we need to yield to someone else
         // We check this when entering/exiting a system call. A thread
@@ -1100,12 +1100,12 @@ public:
     void set_crashing() { m_is_crashing = true; }
     [[nodiscard]] bool is_crashing() const { return m_is_crashing; }
 
-    ALWAYS_INLINE u32 enter_profiler()
+    AK_ALWAYS_INLINE u32 enter_profiler()
     {
         return m_nested_profiler_calls.fetch_add(1, AK::MemoryOrder::memory_order_acq_rel);
     }
 
-    ALWAYS_INLINE u32 leave_profiler()
+    AK_ALWAYS_INLINE u32 leave_profiler()
     {
         return m_nested_profiler_calls.fetch_sub(1, AK::MemoryOrder::memory_order_acquire);
     }

--- a/Meta/Lagom/Tools/CodeGenerators/StateMachineGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/StateMachineGenerator/main.cpp
@@ -422,7 +422,7 @@ private:
 
     Handler m_handler;
 
-    ALWAYS_INLINE StateTransition lookup_state_transition(u8 byte)
+    AK_ALWAYS_INLINE StateTransition lookup_state_transition(u8 byte)
     {
         VERIFY((u8)m_state < @state_count@);
 )~~~");

--- a/Tests/Kernel/TestMemoryDeviceMmap.cpp
+++ b/Tests/Kernel/TestMemoryDeviceMmap.cpp
@@ -19,7 +19,7 @@
 
 static u8 read_buffer[0x100000];
 
-static ALWAYS_INLINE bool mem_chunk(int fd, u64 base, u64 length)
+static AK_ALWAYS_INLINE bool mem_chunk(int fd, u64 base, u64 length)
 {
     u64 mmoffset = base % sysconf(_SC_PAGESIZE);
     void* mmp = mmap(NULL, mmoffset + length, PROT_READ, MAP_SHARED, fd, base - mmoffset);
@@ -36,7 +36,7 @@ enum class ReadResult {
     ReadSuccess,
 };
 
-static ALWAYS_INLINE ReadResult read_chunk(int fd, u64 base, u64 length)
+static AK_ALWAYS_INLINE ReadResult read_chunk(int fd, u64 base, u64 length)
 {
     VERIFY(length <= sizeof(read_buffer));
     auto rs = lseek(fd, base, SEEK_SET);

--- a/Userland/Applications/Calculator/KeypadValue.cpp
+++ b/Userland/Applications/Calculator/KeypadValue.cpp
@@ -114,7 +114,7 @@ bool KeypadValue::operator==(KeypadValue const& rhs)
 // Unfortunately, not all operators are symmetric, so the last boolean tells the callback whether the left-hand side
 // was the KeypadValue with less decimal places (true), or the one with more decimal places (false).
 template<typename T, typename F>
-ALWAYS_INLINE T KeypadValue::operator_helper(KeypadValue const& lhs, KeypadValue const& rhs, F callback)
+AK_ALWAYS_INLINE T KeypadValue::operator_helper(KeypadValue const& lhs, KeypadValue const& rhs, F callback)
 {
     KeypadValue const& less_decimal_places = (lhs.m_decimal_places < rhs.m_decimal_places) ? lhs : rhs;
     KeypadValue const& more_decimal_places = (lhs.m_decimal_places < rhs.m_decimal_places) ? rhs : lhs;

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -20,10 +20,10 @@ class PDFViewer : public GUI::AbstractScrollableWidget {
 public:
     virtual ~PDFViewer() override = default;
 
-    ALWAYS_INLINE u32 current_page() const { return m_current_page_index; }
-    ALWAYS_INLINE void set_current_page(u32 current_page) { m_current_page_index = current_page; }
+    AK_ALWAYS_INLINE u32 current_page() const { return m_current_page_index; }
+    AK_ALWAYS_INLINE void set_current_page(u32 current_page) { m_current_page_index = current_page; }
 
-    ALWAYS_INLINE const RefPtr<PDF::Document>& document() const { return m_document; }
+    AK_ALWAYS_INLINE const RefPtr<PDF::Document>& document() const { return m_document; }
     void set_document(RefPtr<PDF::Document>);
 
     Function<void(u32 new_page)> on_page_change;

--- a/Userland/Applications/Spreadsheet/CellType/Format.cpp
+++ b/Userland/Applications/Spreadsheet/CellType/Format.cpp
@@ -13,7 +13,7 @@ namespace Spreadsheet {
 
 template<typename T, typename V>
 struct SingleEntryListNext {
-    ALWAYS_INLINE T operator()(V value) const
+    AK_ALWAYS_INLINE T operator()(V value) const
     {
         return (T)value;
     }
@@ -21,17 +21,17 @@ struct SingleEntryListNext {
 
 template<typename PutChFunc, typename ArgumentListRefT, template<typename T, typename U = ArgumentListRefT> typename NextArgument, typename CharType>
 struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument, CharType> {
-    ALWAYS_INLINE PrintfImpl(PutChFunc& putch, char*& bufptr, const int& nwritten)
+    AK_ALWAYS_INLINE PrintfImpl(PutChFunc& putch, char*& bufptr, const int& nwritten)
         : PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument>(putch, bufptr, nwritten)
     {
     }
 
     // Disallow pointer formats.
-    ALWAYS_INLINE int format_n(const PrintfImplementation::ModifierState&, ArgumentListRefT&) const
+    AK_ALWAYS_INLINE int format_n(const PrintfImplementation::ModifierState&, ArgumentListRefT&) const
     {
         return 0;
     }
-    ALWAYS_INLINE int format_s(const PrintfImplementation::ModifierState&, ArgumentListRefT&) const
+    AK_ALWAYS_INLINE int format_s(const PrintfImplementation::ModifierState&, ArgumentListRefT&) const
     {
         return 0;
     }

--- a/Userland/Applications/Spreadsheet/Position.h
+++ b/Userland/Applications/Spreadsheet/Position.h
@@ -24,7 +24,7 @@ struct Position {
     {
     }
 
-    ALWAYS_INLINE u32 hash() const
+    AK_ALWAYS_INLINE u32 hash() const
     {
         if (m_hash == 0)
             return m_hash = int_hash(column * 65537 + row);

--- a/Userland/DevTools/UserspaceEmulator/Emulator.h
+++ b/Userland/DevTools/UserspaceEmulator/Emulator.h
@@ -77,14 +77,14 @@ public:
         m_steps_til_pause = 0;
         m_run_til_return = false;
     }
-    ALWAYS_INLINE void return_callback(FlatPtr addr)
+    AK_ALWAYS_INLINE void return_callback(FlatPtr addr)
     {
         if (m_run_til_return) [[unlikely]] {
             if (addr == m_watched_addr)
                 pause();
         }
     }
-    ALWAYS_INLINE void call_callback(FlatPtr addr)
+    AK_ALWAYS_INLINE void call_callback(FlatPtr addr)
     {
         if (m_run_til_call) [[unlikely]] {
             if (addr == m_watched_addr)

--- a/Userland/DevTools/UserspaceEmulator/MallocTracer.cpp
+++ b/Userland/DevTools/UserspaceEmulator/MallocTracer.cpp
@@ -96,7 +96,7 @@ void MallocTracer::target_did_change_chunk_size(Badge<Emulator>, FlatPtr block, 
     update_metadata(mmap_region, chunk_size);
 }
 
-ALWAYS_INLINE Mallocation* MallocRegionMetadata::mallocation_for_address(FlatPtr address) const
+AK_ALWAYS_INLINE Mallocation* MallocRegionMetadata::mallocation_for_address(FlatPtr address) const
 {
     auto index = chunk_index_for_address(address);
     if (!index.has_value())
@@ -104,7 +104,7 @@ ALWAYS_INLINE Mallocation* MallocRegionMetadata::mallocation_for_address(FlatPtr
     return &const_cast<Mallocation&>(this->mallocations[index.value()]);
 }
 
-ALWAYS_INLINE Optional<size_t> MallocRegionMetadata::chunk_index_for_address(FlatPtr address) const
+AK_ALWAYS_INLINE Optional<size_t> MallocRegionMetadata::chunk_index_for_address(FlatPtr address) const
 {
     bool is_chunked_block = chunk_size <= size_classes[num_size_classes - 1];
     if (!is_chunked_block) {

--- a/Userland/DevTools/UserspaceEmulator/MallocTracer.h
+++ b/Userland/DevTools/UserspaceEmulator/MallocTracer.h
@@ -89,7 +89,7 @@ private:
     bool m_auditing_enabled { true };
 };
 
-ALWAYS_INLINE Mallocation* MallocTracer::find_mallocation(const Region& region, FlatPtr address)
+AK_ALWAYS_INLINE Mallocation* MallocTracer::find_mallocation(const Region& region, FlatPtr address)
 {
     if (!is<MmapRegion>(region))
         return nullptr;

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.cpp
@@ -46,7 +46,7 @@
 namespace UserspaceEmulator {
 
 template<typename T>
-ALWAYS_INLINE void warn_if_uninitialized(T value_with_shadow, const char* message)
+AK_ALWAYS_INLINE void warn_if_uninitialized(T value_with_shadow, const char* message)
 {
     if (value_with_shadow.is_uninitialized()) [[unlikely]] {
         reportln("\033[31;1mWarning! Use of uninitialized value: {}\033[0m\n", message);
@@ -54,7 +54,7 @@ ALWAYS_INLINE void warn_if_uninitialized(T value_with_shadow, const char* messag
     }
 }
 
-ALWAYS_INLINE void SoftCPU::warn_if_flags_tainted(const char* message) const
+AK_ALWAYS_INLINE void SoftCPU::warn_if_flags_tainted(const char* message) const
 {
     if (m_flags_tainted) [[unlikely]] {
         reportln("\n=={}==  \033[31;1mConditional depends on uninitialized data\033[0m ({})\n", getpid(), message);
@@ -265,7 +265,7 @@ void SoftCPU::do_once_or_repeat(const X86::Instruction& insn, Callback callback)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_inc(SoftCPU& cpu, T data)
+AK_ALWAYS_INLINE static T op_inc(SoftCPU& cpu, T data)
 {
     typename T::ValueType result;
     u32 new_flags = 0;
@@ -295,7 +295,7 @@ ALWAYS_INLINE static T op_inc(SoftCPU& cpu, T data)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_dec(SoftCPU& cpu, T data)
+AK_ALWAYS_INLINE static T op_dec(SoftCPU& cpu, T data)
 {
     typename T::ValueType result;
     u32 new_flags = 0;
@@ -325,7 +325,7 @@ ALWAYS_INLINE static T op_dec(SoftCPU& cpu, T data)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_xor(SoftCPU& cpu, const T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_xor(SoftCPU& cpu, const T& dest, const T& src)
 {
     typename T::ValueType result;
     u32 new_flags = 0;
@@ -357,7 +357,7 @@ ALWAYS_INLINE static T op_xor(SoftCPU& cpu, const T& dest, const T& src)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_or(SoftCPU& cpu, const T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_or(SoftCPU& cpu, const T& dest, const T& src)
 {
     typename T::ValueType result = 0;
     u32 new_flags = 0;
@@ -389,7 +389,7 @@ ALWAYS_INLINE static T op_or(SoftCPU& cpu, const T& dest, const T& src)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_sub(SoftCPU& cpu, const T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_sub(SoftCPU& cpu, const T& dest, const T& src)
 {
     typename T::ValueType result = 0;
     u32 new_flags = 0;
@@ -421,7 +421,7 @@ ALWAYS_INLINE static T op_sub(SoftCPU& cpu, const T& dest, const T& src)
 }
 
 template<typename T, bool cf>
-ALWAYS_INLINE static T op_sbb_impl(SoftCPU& cpu, const T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_sbb_impl(SoftCPU& cpu, const T& dest, const T& src)
 {
     typename T::ValueType result = 0;
     u32 new_flags = 0;
@@ -458,7 +458,7 @@ ALWAYS_INLINE static T op_sbb_impl(SoftCPU& cpu, const T& dest, const T& src)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_sbb(SoftCPU& cpu, T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_sbb(SoftCPU& cpu, T& dest, const T& src)
 {
     cpu.warn_if_flags_tainted("sbb");
     if (cpu.cf())
@@ -467,7 +467,7 @@ ALWAYS_INLINE static T op_sbb(SoftCPU& cpu, T& dest, const T& src)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_add(SoftCPU& cpu, T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_add(SoftCPU& cpu, T& dest, const T& src)
 {
     typename T::ValueType result = 0;
     u32 new_flags = 0;
@@ -499,7 +499,7 @@ ALWAYS_INLINE static T op_add(SoftCPU& cpu, T& dest, const T& src)
 }
 
 template<typename T, bool cf>
-ALWAYS_INLINE static T op_adc_impl(SoftCPU& cpu, T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_adc_impl(SoftCPU& cpu, T& dest, const T& src)
 {
     typename T::ValueType result = 0;
     u32 new_flags = 0;
@@ -536,7 +536,7 @@ ALWAYS_INLINE static T op_adc_impl(SoftCPU& cpu, T& dest, const T& src)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_adc(SoftCPU& cpu, T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_adc(SoftCPU& cpu, T& dest, const T& src)
 {
     cpu.warn_if_flags_tainted("adc");
     if (cpu.cf())
@@ -545,7 +545,7 @@ ALWAYS_INLINE static T op_adc(SoftCPU& cpu, T& dest, const T& src)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_and(SoftCPU& cpu, const T& dest, const T& src)
+AK_ALWAYS_INLINE static T op_and(SoftCPU& cpu, const T& dest, const T& src)
 {
     typename T::ValueType result = 0;
     u32 new_flags = 0;
@@ -577,7 +577,7 @@ ALWAYS_INLINE static T op_and(SoftCPU& cpu, const T& dest, const T& src)
 }
 
 template<typename T>
-ALWAYS_INLINE static void op_imul(SoftCPU& cpu, const T& dest, const T& src, T& result_high, T& result_low)
+AK_ALWAYS_INLINE static void op_imul(SoftCPU& cpu, const T& dest, const T& src, T& result_high, T& result_low)
 {
     bool did_overflow = false;
     if constexpr (sizeof(T) == 4) {
@@ -607,7 +607,7 @@ ALWAYS_INLINE static void op_imul(SoftCPU& cpu, const T& dest, const T& src, T& 
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_shr(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_shr(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 {
     if (steps.value() == 0)
         return shadow_wrap_with_taint_from(data.value(), data, steps);
@@ -640,7 +640,7 @@ ALWAYS_INLINE static T op_shr(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_shl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_shl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 {
     if (steps.value() == 0)
         return shadow_wrap_with_taint_from(data.value(), data, steps);
@@ -673,7 +673,7 @@ ALWAYS_INLINE static T op_shl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_shrd(SoftCPU& cpu, T data, T extra_bits, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_shrd(SoftCPU& cpu, T data, T extra_bits, ValueWithShadow<u8> steps)
 {
     if (steps.value() == 0)
         return shadow_wrap_with_taint_from(data.value(), data, steps);
@@ -702,7 +702,7 @@ ALWAYS_INLINE static T op_shrd(SoftCPU& cpu, T data, T extra_bits, ValueWithShad
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_shld(SoftCPU& cpu, T data, T extra_bits, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_shld(SoftCPU& cpu, T data, T extra_bits, ValueWithShadow<u8> steps)
 {
     if (steps.value() == 0)
         return shadow_wrap_with_taint_from(data.value(), data, steps);
@@ -731,7 +731,7 @@ ALWAYS_INLINE static T op_shld(SoftCPU& cpu, T data, T extra_bits, ValueWithShad
 }
 
 template<bool update_dest, bool is_or, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_AL_imm8(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_AL_imm8(Op op, const X86::Instruction& insn)
 {
     auto dest = al();
     auto src = shadow_wrap_as_initialized(insn.imm8());
@@ -743,7 +743,7 @@ ALWAYS_INLINE void SoftCPU::generic_AL_imm8(Op op, const X86::Instruction& insn)
 }
 
 template<bool update_dest, bool is_or, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_AX_imm16(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_AX_imm16(Op op, const X86::Instruction& insn)
 {
     auto dest = ax();
     auto src = shadow_wrap_as_initialized(insn.imm16());
@@ -755,7 +755,7 @@ ALWAYS_INLINE void SoftCPU::generic_AX_imm16(Op op, const X86::Instruction& insn
 }
 
 template<bool update_dest, bool is_or, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_EAX_imm32(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_EAX_imm32(Op op, const X86::Instruction& insn)
 {
     auto dest = eax();
     auto src = shadow_wrap_as_initialized(insn.imm32());
@@ -767,7 +767,7 @@ ALWAYS_INLINE void SoftCPU::generic_EAX_imm32(Op op, const X86::Instruction& ins
 }
 
 template<bool update_dest, bool is_or, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM16_imm16(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM16_imm16(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read16(*this, insn);
     auto src = shadow_wrap_as_initialized(insn.imm16());
@@ -779,7 +779,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM16_imm16(Op op, const X86::Instruction& in
 }
 
 template<bool update_dest, bool is_or, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM16_imm8(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM16_imm8(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read16(*this, insn);
     auto src = shadow_wrap_as_initialized<u16>(sign_extended_to<u16>(insn.imm8()));
@@ -791,7 +791,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM16_imm8(Op op, const X86::Instruction& ins
 }
 
 template<bool update_dest, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM16_unsigned_imm8(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM16_unsigned_imm8(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read16(*this, insn);
     auto src = shadow_wrap_as_initialized(insn.imm8());
@@ -801,7 +801,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM16_unsigned_imm8(Op op, const X86::Instruc
 }
 
 template<bool update_dest, bool dont_taint_for_same_operand, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM16_reg16(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM16_reg16(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read16(*this, insn);
     auto src = const_gpr16(insn.reg16());
@@ -815,7 +815,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM16_reg16(Op op, const X86::Instruction& in
 }
 
 template<bool update_dest, bool is_or, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM32_imm32(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM32_imm32(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read32(*this, insn);
     auto src = insn.imm32();
@@ -827,7 +827,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM32_imm32(Op op, const X86::Instruction& in
 }
 
 template<bool update_dest, bool is_or, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM32_imm8(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM32_imm8(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read32(*this, insn);
     auto src = sign_extended_to<u32>(insn.imm8());
@@ -839,7 +839,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM32_imm8(Op op, const X86::Instruction& ins
 }
 
 template<bool update_dest, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM32_unsigned_imm8(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM32_unsigned_imm8(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read32(*this, insn);
     auto src = shadow_wrap_as_initialized(insn.imm8());
@@ -849,7 +849,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM32_unsigned_imm8(Op op, const X86::Instruc
 }
 
 template<bool update_dest, bool dont_taint_for_same_operand, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM32_reg32(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM32_reg32(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read32(*this, insn);
     auto src = const_gpr32(insn.reg32());
@@ -863,7 +863,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM32_reg32(Op op, const X86::Instruction& in
 }
 
 template<bool update_dest, bool is_or, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM8_imm8(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM8_imm8(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read8(*this, insn);
     auto src = insn.imm8();
@@ -875,7 +875,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM8_imm8(Op op, const X86::Instruction& insn
 }
 
 template<bool update_dest, bool dont_taint_for_same_operand, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM8_reg8(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM8_reg8(Op op, const X86::Instruction& insn)
 {
     auto dest = insn.modrm().read8(*this, insn);
     auto src = const_gpr8(insn.reg8());
@@ -889,7 +889,7 @@ ALWAYS_INLINE void SoftCPU::generic_RM8_reg8(Op op, const X86::Instruction& insn
 }
 
 template<bool update_dest, bool dont_taint_for_same_operand, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_reg16_RM16(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_reg16_RM16(Op op, const X86::Instruction& insn)
 {
     auto dest = const_gpr16(insn.reg16());
     auto src = insn.modrm().read16(*this, insn);
@@ -903,7 +903,7 @@ ALWAYS_INLINE void SoftCPU::generic_reg16_RM16(Op op, const X86::Instruction& in
 }
 
 template<bool update_dest, bool dont_taint_for_same_operand, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_reg32_RM32(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_reg32_RM32(Op op, const X86::Instruction& insn)
 {
     auto dest = const_gpr32(insn.reg32());
     auto src = insn.modrm().read32(*this, insn);
@@ -917,7 +917,7 @@ ALWAYS_INLINE void SoftCPU::generic_reg32_RM32(Op op, const X86::Instruction& in
 }
 
 template<bool update_dest, bool dont_taint_for_same_operand, typename Op>
-ALWAYS_INLINE void SoftCPU::generic_reg8_RM8(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_reg8_RM8(Op op, const X86::Instruction& insn)
 {
     auto dest = const_gpr8(insn.reg8());
     auto src = insn.modrm().read8(*this, insn);
@@ -931,42 +931,42 @@ ALWAYS_INLINE void SoftCPU::generic_reg8_RM8(Op op, const X86::Instruction& insn
 }
 
 template<typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM8_1(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM8_1(Op op, const X86::Instruction& insn)
 {
     auto data = insn.modrm().read8(*this, insn);
     insn.modrm().write8(*this, insn, op(*this, data, shadow_wrap_as_initialized<u8>(1)));
 }
 
 template<typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM8_CL(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM8_CL(Op op, const X86::Instruction& insn)
 {
     auto data = insn.modrm().read8(*this, insn);
     insn.modrm().write8(*this, insn, op(*this, data, cl()));
 }
 
 template<typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM16_1(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM16_1(Op op, const X86::Instruction& insn)
 {
     auto data = insn.modrm().read16(*this, insn);
     insn.modrm().write16(*this, insn, op(*this, data, shadow_wrap_as_initialized<u8>(1)));
 }
 
 template<typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM16_CL(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM16_CL(Op op, const X86::Instruction& insn)
 {
     auto data = insn.modrm().read16(*this, insn);
     insn.modrm().write16(*this, insn, op(*this, data, cl()));
 }
 
 template<typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM32_1(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM32_1(Op op, const X86::Instruction& insn)
 {
     auto data = insn.modrm().read32(*this, insn);
     insn.modrm().write32(*this, insn, op(*this, data, shadow_wrap_as_initialized<u8>(1)));
 }
 
 template<typename Op>
-ALWAYS_INLINE void SoftCPU::generic_RM32_CL(Op op, const X86::Instruction& insn)
+AK_ALWAYS_INLINE void SoftCPU::generic_RM32_CL(Op op, const X86::Instruction& insn)
 {
     auto data = insn.modrm().read32(*this, insn);
     insn.modrm().write32(*this, insn, op(*this, data, cl()));
@@ -980,13 +980,13 @@ void SoftCPU::ARPL(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::BOUND(const X86::Instruction&) { TODO_INSN(); }
 
 template<typename T>
-ALWAYS_INLINE static T op_bsf(SoftCPU&, T value)
+AK_ALWAYS_INLINE static T op_bsf(SoftCPU&, T value)
 {
     return { (typename T::ValueType)bit_scan_forward(value.value()), value.shadow() };
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_bsr(SoftCPU&, T value)
+AK_ALWAYS_INLINE static T op_bsr(SoftCPU&, T value)
 {
     typename T::ValueType bit_index = 0;
     if constexpr (sizeof(typename T::ValueType) == 4) {
@@ -1047,31 +1047,31 @@ void SoftCPU::BSWAP_reg32(const X86::Instruction& insn)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_bt(T value, T)
+AK_ALWAYS_INLINE static T op_bt(T value, T)
 {
     return value;
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_bts(T value, T bit_mask)
+AK_ALWAYS_INLINE static T op_bts(T value, T bit_mask)
 {
     return value | bit_mask;
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_btr(T value, T bit_mask)
+AK_ALWAYS_INLINE static T op_btr(T value, T bit_mask)
 {
     return value & ~bit_mask;
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_btc(T value, T bit_mask)
+AK_ALWAYS_INLINE static T op_btc(T value, T bit_mask)
 {
     return value ^ bit_mask;
 }
 
 template<bool should_update, typename Op>
-ALWAYS_INLINE void BTx_RM16_reg16(SoftCPU& cpu, const X86::Instruction& insn, Op op)
+AK_ALWAYS_INLINE void BTx_RM16_reg16(SoftCPU& cpu, const X86::Instruction& insn, Op op)
 {
     if (insn.modrm().is_register()) {
         unsigned bit_index = cpu.const_gpr16(insn.reg16()).value() & (X86::TypeTrivia<u16>::bits - 1);
@@ -1099,7 +1099,7 @@ ALWAYS_INLINE void BTx_RM16_reg16(SoftCPU& cpu, const X86::Instruction& insn, Op
 }
 
 template<bool should_update, typename Op>
-ALWAYS_INLINE void BTx_RM32_reg32(SoftCPU& cpu, const X86::Instruction& insn, Op op)
+AK_ALWAYS_INLINE void BTx_RM32_reg32(SoftCPU& cpu, const X86::Instruction& insn, Op op)
 {
     if (insn.modrm().is_register()) {
         unsigned bit_index = cpu.const_gpr32(insn.reg32()).value() & (X86::TypeTrivia<u32>::bits - 1);
@@ -1127,7 +1127,7 @@ ALWAYS_INLINE void BTx_RM32_reg32(SoftCPU& cpu, const X86::Instruction& insn, Op
 }
 
 template<bool should_update, typename Op>
-ALWAYS_INLINE void BTx_RM16_imm8(SoftCPU& cpu, const X86::Instruction& insn, Op op)
+AK_ALWAYS_INLINE void BTx_RM16_imm8(SoftCPU& cpu, const X86::Instruction& insn, Op op)
 {
     unsigned bit_index = insn.imm8() & (X86::TypeTrivia<u16>::mask);
 
@@ -1144,7 +1144,7 @@ ALWAYS_INLINE void BTx_RM16_imm8(SoftCPU& cpu, const X86::Instruction& insn, Op 
 }
 
 template<bool should_update, typename Op>
-ALWAYS_INLINE void BTx_RM32_imm8(SoftCPU& cpu, const X86::Instruction& insn, Op op)
+AK_ALWAYS_INLINE void BTx_RM32_imm8(SoftCPU& cpu, const X86::Instruction& insn, Op op)
 {
     unsigned bit_index = insn.imm8() & (X86::TypeTrivia<u32>::mask);
 
@@ -1248,7 +1248,7 @@ void SoftCPU::CMOVcc_reg32_RM32(const X86::Instruction& insn)
 }
 
 template<typename T>
-ALWAYS_INLINE static void do_cmps(SoftCPU& cpu, const X86::Instruction& insn)
+AK_ALWAYS_INLINE static void do_cmps(SoftCPU& cpu, const X86::Instruction& insn)
 {
     auto src_segment = cpu.segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS));
     cpu.do_once_or_repeat<true>(insn, [&] {
@@ -1854,7 +1854,7 @@ void SoftCPU::LLDT_RM16(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::LMSW_RM16(const X86::Instruction&) { TODO_INSN(); }
 
 template<typename T>
-ALWAYS_INLINE static void do_lods(SoftCPU& cpu, const X86::Instruction& insn)
+AK_ALWAYS_INLINE static void do_lods(SoftCPU& cpu, const X86::Instruction& insn)
 {
     auto src_segment = cpu.segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS));
     cpu.do_once_or_repeat<true>(insn, [&] {
@@ -1926,7 +1926,7 @@ void SoftCPU::LSS_reg32_mem32(const X86::Instruction&) { TODO_INSN(); }
 void SoftCPU::LTR_RM16(const X86::Instruction&) { TODO_INSN(); }
 
 template<typename T>
-ALWAYS_INLINE static void do_movs(SoftCPU& cpu, const X86::Instruction& insn)
+AK_ALWAYS_INLINE static void do_movs(SoftCPU& cpu, const X86::Instruction& insn)
 {
     auto src_segment = cpu.segment(insn.segment_prefix().value_or(X86::SegmentRegister::DS));
     cpu.do_once_or_repeat<false>(insn, [&] {
@@ -2390,7 +2390,7 @@ void SoftCPU::PUSH_reg32(const X86::Instruction& insn)
 FPU_INSTRUCTION(PXOR_mm1_mm2m64);
 
 template<typename T, bool cf>
-ALWAYS_INLINE static T op_rcl_impl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_rcl_impl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 {
     if (steps.value() == 0)
         return shadow_wrap_with_taint_from(data.value(), data, steps);
@@ -2428,7 +2428,7 @@ ALWAYS_INLINE static T op_rcl_impl(SoftCPU& cpu, T data, ValueWithShadow<u8> ste
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_rcl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_rcl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 {
     cpu.warn_if_flags_tainted("rcl");
     if (cpu.cf())
@@ -2439,7 +2439,7 @@ ALWAYS_INLINE static T op_rcl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 DEFINE_GENERIC_SHIFT_ROTATE_INSN_HANDLERS(RCL, op_rcl)
 
 template<typename T, bool cf>
-ALWAYS_INLINE static T op_rcr_impl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_rcr_impl(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 {
     if (steps.value() == 0)
         return shadow_wrap_with_taint_from(data.value(), data, steps);
@@ -2476,7 +2476,7 @@ ALWAYS_INLINE static T op_rcr_impl(SoftCPU& cpu, T data, ValueWithShadow<u8> ste
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_rcr(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_rcr(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 {
     cpu.warn_if_flags_tainted("rcr");
     if (cpu.cf())
@@ -2513,7 +2513,7 @@ void SoftCPU::RET_imm16(const X86::Instruction& insn)
 }
 
 template<typename T>
-ALWAYS_INLINE static T op_rol(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_rol(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 {
     if (steps.value() == 0)
         return shadow_wrap_with_taint_from(data.value(), data, steps);
@@ -2547,7 +2547,7 @@ ALWAYS_INLINE static T op_rol(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 DEFINE_GENERIC_SHIFT_ROTATE_INSN_HANDLERS(ROL, op_rol)
 
 template<typename T>
-ALWAYS_INLINE static T op_ror(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
+AK_ALWAYS_INLINE static T op_ror(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 {
     if (steps.value() == 0)
         return shadow_wrap_with_taint_from(data.value(), data, steps);
@@ -2627,7 +2627,7 @@ static T op_sar(SoftCPU& cpu, T data, ValueWithShadow<u8> steps)
 DEFINE_GENERIC_SHIFT_ROTATE_INSN_HANDLERS(SAR, op_sar)
 
 template<typename T>
-ALWAYS_INLINE static void do_scas(SoftCPU& cpu, const X86::Instruction& insn)
+AK_ALWAYS_INLINE static void do_scas(SoftCPU& cpu, const X86::Instruction& insn)
 {
     cpu.do_once_or_repeat<true>(insn, [&] {
         auto src = cpu.const_gpr<T>(X86::RegisterAL);

--- a/Userland/DevTools/UserspaceEmulator/SoftCPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftCPU.h
@@ -205,7 +205,7 @@ public:
         return cx().value() == 0;
     }
 
-    ALWAYS_INLINE void step_source_index(bool a32, u32 step)
+    AK_ALWAYS_INLINE void step_source_index(bool a32, u32 step)
     {
         if (a32) {
             if (df())
@@ -220,7 +220,7 @@ public:
         }
     }
 
-    ALWAYS_INLINE void step_destination_index(bool a32, u32 step)
+    AK_ALWAYS_INLINE void step_destination_index(bool a32, u32 step)
     {
         if (a32) {
             if (df())
@@ -1262,7 +1262,7 @@ private:
     u8* m_cached_code_base_ptr { nullptr };
 };
 
-ALWAYS_INLINE u8 SoftCPU::read8()
+AK_ALWAYS_INLINE u8 SoftCPU::read8()
 {
     if (!m_cached_code_region || !m_cached_code_region->contains(m_eip))
         update_code_cache();
@@ -1272,7 +1272,7 @@ ALWAYS_INLINE u8 SoftCPU::read8()
     return value;
 }
 
-ALWAYS_INLINE u16 SoftCPU::read16()
+AK_ALWAYS_INLINE u16 SoftCPU::read16()
 {
     if (!m_cached_code_region || !m_cached_code_region->contains(m_eip))
         update_code_cache();
@@ -1283,7 +1283,7 @@ ALWAYS_INLINE u16 SoftCPU::read16()
     return value;
 }
 
-ALWAYS_INLINE u32 SoftCPU::read32()
+AK_ALWAYS_INLINE u32 SoftCPU::read32()
 {
     if (!m_cached_code_region || !m_cached_code_region->contains(m_eip))
         update_code_cache();
@@ -1295,7 +1295,7 @@ ALWAYS_INLINE u32 SoftCPU::read32()
     return value;
 }
 
-ALWAYS_INLINE u64 SoftCPU::read64()
+AK_ALWAYS_INLINE u64 SoftCPU::read64()
 {
     if (!m_cached_code_region || !m_cached_code_region->contains(m_eip))
         update_code_cache();

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.cpp
@@ -28,7 +28,7 @@
     } while (0)
 
 template<typename T>
-ALWAYS_INLINE void warn_if_uninitialized(T value_with_shadow, const char* message)
+AK_ALWAYS_INLINE void warn_if_uninitialized(T value_with_shadow, const char* message)
 {
     if (value_with_shadow.is_uninitialized()) [[unlikely]] {
         reportln("\033[31;1mWarning! Use of uninitialized value: {}\033[0m\n", message);
@@ -38,14 +38,14 @@ ALWAYS_INLINE void warn_if_uninitialized(T value_with_shadow, const char* messag
 
 namespace UserspaceEmulator { // NOLINT(readability-implicit-bool-conversion) 0/1 to follow spec closer
 
-ALWAYS_INLINE void SoftFPU::warn_if_mmx_absolute(u8 index) const
+AK_ALWAYS_INLINE void SoftFPU::warn_if_mmx_absolute(u8 index) const
 {
     if (m_reg_is_mmx[index]) [[unlikely]] {
         reportln("\033[31;1mWarning! Use of an MMX register as an FPU value ({} abs)\033[0m\n", index);
         m_emulator.dump_backtrace();
     }
 }
-ALWAYS_INLINE void SoftFPU::warn_if_fpu_absolute(u8 index) const
+AK_ALWAYS_INLINE void SoftFPU::warn_if_fpu_absolute(u8 index) const
 {
     if (!m_reg_is_mmx[index]) [[unlikely]] {
         reportln("\033[31;1mWarning! Use of an FPU value ({} abs)  as an MMX register\033[0m\n", index);
@@ -53,7 +53,7 @@ ALWAYS_INLINE void SoftFPU::warn_if_fpu_absolute(u8 index) const
     }
 }
 
-ALWAYS_INLINE long double SoftFPU::fpu_get(u8 index)
+AK_ALWAYS_INLINE long double SoftFPU::fpu_get(u8 index)
 {
     VERIFY(index < 8);
     if (!fpu_is_set(index))
@@ -64,25 +64,25 @@ ALWAYS_INLINE long double SoftFPU::fpu_get(u8 index)
 
     return m_storage[effective_index].fp;
 }
-ALWAYS_INLINE void SoftFPU::fpu_set_absolute(u8 index, long double value)
+AK_ALWAYS_INLINE void SoftFPU::fpu_set_absolute(u8 index, long double value)
 {
     VERIFY(index < 8);
     set_tag_from_value_absolute(index, value);
     m_storage[index].fp = value;
     m_reg_is_mmx[index] = false;
 }
-ALWAYS_INLINE void SoftFPU::fpu_set(u8 index, long double value)
+AK_ALWAYS_INLINE void SoftFPU::fpu_set(u8 index, long double value)
 {
     VERIFY(index < 8);
     fpu_set_absolute((m_fpu_stack_top + index) % 8, value);
 }
-ALWAYS_INLINE MMX SoftFPU::mmx_get(u8 index) const
+AK_ALWAYS_INLINE MMX SoftFPU::mmx_get(u8 index) const
 {
     VERIFY(index < 8);
     warn_if_fpu_absolute(index);
     return m_storage[index].mmx;
 }
-ALWAYS_INLINE void SoftFPU::mmx_set(u8 index, MMX value)
+AK_ALWAYS_INLINE void SoftFPU::mmx_set(u8 index, MMX value)
 {
     m_storage[index].mmx = value;
     // The high bytes are set to 0b11... to make the floating-point value NaN.
@@ -92,7 +92,7 @@ ALWAYS_INLINE void SoftFPU::mmx_set(u8 index, MMX value)
     m_reg_is_mmx[index] = true;
 }
 
-ALWAYS_INLINE void SoftFPU::fpu_push(long double value)
+AK_ALWAYS_INLINE void SoftFPU::fpu_push(long double value)
 {
     if (fpu_is_set(7))
         fpu_set_stack_overflow();
@@ -101,7 +101,7 @@ ALWAYS_INLINE void SoftFPU::fpu_push(long double value)
     fpu_set(0, value);
 }
 
-ALWAYS_INLINE long double SoftFPU::fpu_pop()
+AK_ALWAYS_INLINE long double SoftFPU::fpu_pop()
 {
     warn_if_mmx_absolute(m_fpu_stack_top);
 
@@ -114,7 +114,7 @@ ALWAYS_INLINE long double SoftFPU::fpu_pop()
     return ret;
 }
 
-ALWAYS_INLINE void SoftFPU::fpu_set_exception(FPU_Exception ex)
+AK_ALWAYS_INLINE void SoftFPU::fpu_set_exception(FPU_Exception ex)
 {
     switch (ex) {
     case FPU_Exception::StackFault:
@@ -168,7 +168,7 @@ ALWAYS_INLINE void SoftFPU::fpu_set_exception(FPU_Exception ex)
 }
 
 template<Arithmetic T>
-ALWAYS_INLINE T SoftFPU::fpu_round(long double value) const
+AK_ALWAYS_INLINE T SoftFPU::fpu_round(long double value) const
 {
     // FIXME: may need to set indefinite values manually
     switch (fpu_get_round_mode()) {
@@ -186,7 +186,7 @@ ALWAYS_INLINE T SoftFPU::fpu_round(long double value) const
 }
 
 template<Arithmetic T>
-ALWAYS_INLINE T SoftFPU::fpu_round_checked(long double value)
+AK_ALWAYS_INLINE T SoftFPU::fpu_round_checked(long double value)
 {
     T result = fpu_round<T>(value);
     if (result != value)
@@ -199,13 +199,13 @@ ALWAYS_INLINE T SoftFPU::fpu_round_checked(long double value)
 }
 
 template<FloatingPoint T>
-ALWAYS_INLINE T SoftFPU::fpu_convert(long double value) const
+AK_ALWAYS_INLINE T SoftFPU::fpu_convert(long double value) const
 {
     // FIXME: actually round the right way
     return static_cast<T>(value);
 }
 template<FloatingPoint T>
-ALWAYS_INLINE T SoftFPU::fpu_convert_checked(long double value)
+AK_ALWAYS_INLINE T SoftFPU::fpu_convert_checked(long double value)
 {
     T result = fpu_convert<T>(value);
     if (auto rnd = value - result) {

--- a/Userland/DevTools/UserspaceEmulator/SoftFPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftFPU.h
@@ -38,15 +38,15 @@ public:
     {
     }
 
-    ALWAYS_INLINE bool c0() const { return m_fpu_c0; }
-    ALWAYS_INLINE bool c1() const { return m_fpu_c1; }
-    ALWAYS_INLINE bool c2() const { return m_fpu_c2; }
-    ALWAYS_INLINE bool c3() const { return m_fpu_c3; }
+    AK_ALWAYS_INLINE bool c0() const { return m_fpu_c0; }
+    AK_ALWAYS_INLINE bool c1() const { return m_fpu_c1; }
+    AK_ALWAYS_INLINE bool c2() const { return m_fpu_c2; }
+    AK_ALWAYS_INLINE bool c3() const { return m_fpu_c3; }
 
-    ALWAYS_INLINE void set_c0(bool val) { m_fpu_c0 = val; }
-    ALWAYS_INLINE void set_c1(bool val) { m_fpu_c1 = val; }
-    ALWAYS_INLINE void set_c2(bool val) { m_fpu_c2 = val; }
-    ALWAYS_INLINE void set_c3(bool val) { m_fpu_c3 = val; }
+    AK_ALWAYS_INLINE void set_c0(bool val) { m_fpu_c0 = val; }
+    AK_ALWAYS_INLINE void set_c1(bool val) { m_fpu_c1 = val; }
+    AK_ALWAYS_INLINE void set_c2(bool val) { m_fpu_c2 = val; }
+    AK_ALWAYS_INLINE void set_c3(bool val) { m_fpu_c3 = val; }
 
     long double fpu_get(u8 index);
 
@@ -143,14 +143,14 @@ private:
     //        be fine this way
     void fpu_set_exception(FPU_Exception ex);
 
-    ALWAYS_INLINE void fpu_set_stack_overflow()
+    AK_ALWAYS_INLINE void fpu_set_stack_overflow()
     {
         reportln("Stack Overflow");
         set_c1(1);
         fpu_set_exception(FPU_Exception::StackFault);
     }
 
-    ALWAYS_INLINE void fpu_set_stack_underflow()
+    AK_ALWAYS_INLINE void fpu_set_stack_underflow()
     {
         reportln("Stack Underflow");
         set_c1(0);
@@ -187,7 +187,7 @@ private:
         return fpu_get_tag_absolute((m_fpu_stack_top + index) % 8);
     }
 
-    ALWAYS_INLINE void fpu_set_tag_absolute(u8 index, FPU_Tag tag)
+    AK_ALWAYS_INLINE void fpu_set_tag_absolute(u8 index, FPU_Tag tag)
     {
         switch (index) {
         case 0:
@@ -219,13 +219,13 @@ private:
         }
     }
 
-    ALWAYS_INLINE void fpu_set_tag(u8 index, FPU_Tag tag)
+    AK_ALWAYS_INLINE void fpu_set_tag(u8 index, FPU_Tag tag)
     {
         VERIFY(index < 8);
         fpu_set_tag_absolute((m_fpu_stack_top + index) % 8, tag);
     }
 
-    ALWAYS_INLINE void set_tag_from_value_absolute(u8 index, long double val)
+    AK_ALWAYS_INLINE void set_tag_from_value_absolute(u8 index, long double val)
     {
         switch (fpclassify(val)) {
         case FP_ZERO:
@@ -244,22 +244,22 @@ private:
         }
     }
 
-    ALWAYS_INLINE void set_tag_from_value(u8 index, long double val)
+    AK_ALWAYS_INLINE void set_tag_from_value(u8 index, long double val)
     {
         set_tag_from_value_absolute((m_fpu_stack_top + index) % 8, val);
     }
 
-    ALWAYS_INLINE bool fpu_isnan(u8 index)
+    AK_ALWAYS_INLINE bool fpu_isnan(u8 index)
     {
         return isnan(fpu_get(index));
     }
 
-    ALWAYS_INLINE bool fpu_is_set(u8 index) const
+    AK_ALWAYS_INLINE bool fpu_is_set(u8 index) const
     {
         return fpu_get_tag_absolute((m_fpu_stack_top + index) % 8) != FPU_Tag::Empty;
     }
 
-    ALWAYS_INLINE RoundingMode fpu_get_round_mode() const
+    AK_ALWAYS_INLINE RoundingMode fpu_get_round_mode() const
     {
         return RoundingMode(m_fpu_round_mode);
     }
@@ -274,7 +274,7 @@ private:
     template<FloatingPoint T>
     T fpu_convert_checked(long double);
 
-    ALWAYS_INLINE void fpu_set_unordered()
+    AK_ALWAYS_INLINE void fpu_set_unordered()
     {
         set_c0(1);
         set_c2(1);

--- a/Userland/DevTools/UserspaceEmulator/SoftMMU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftMMU.h
@@ -70,7 +70,7 @@ public:
     void write128(X86::LogicalAddress, ValueWithShadow<u128>);
     void write256(X86::LogicalAddress, ValueWithShadow<u256>);
 
-    ALWAYS_INLINE Region* find_region(X86::LogicalAddress address)
+    AK_ALWAYS_INLINE Region* find_region(X86::LogicalAddress address)
     {
         if (address.selector() == 0x2b)
             return m_tls_region.ptr();

--- a/Userland/DevTools/UserspaceEmulator/ValueWithShadow.h
+++ b/Userland/DevTools/UserspaceEmulator/ValueWithShadow.h
@@ -135,13 +135,13 @@ private:
 };
 
 template<typename T>
-ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_as_initialized(T value)
+AK_ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_as_initialized(T value)
 {
     return ValueWithShadow<T>::create_initialized(value);
 }
 
 template<typename T, typename U>
-ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_with_taint_from(T value, U const& taint_a)
+AK_ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_with_taint_from(T value, U const& taint_a)
 {
     if (taint_a.is_uninitialized())
         return { value, 0 };
@@ -149,7 +149,7 @@ ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_with_taint_from(T value, U const& t
 }
 
 template<typename T, typename U, typename V>
-ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_with_taint_from(T value, U const& taint_a, V const& taint_b)
+AK_ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_with_taint_from(T value, U const& taint_a, V const& taint_b)
 {
     if (taint_a.is_uninitialized() || taint_b.is_uninitialized())
         return { value, 0 };
@@ -157,7 +157,7 @@ ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_with_taint_from(T value, U const& t
 }
 
 template<typename T, typename U, typename V, typename X>
-ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_with_taint_from(T value, U const& taint_a, V const& taint_b, X const& taint_c)
+AK_ALWAYS_INLINE ValueWithShadow<T> shadow_wrap_with_taint_from(T value, U const& taint_a, V const& taint_b, X const& taint_c)
 {
     if (taint_a.is_uninitialized() || taint_b.is_uninitialized() || taint_c.is_uninitialized())
         return { value, 0 };

--- a/Userland/Games/Solitaire/Game.h
+++ b/Userland/Games/Solitaire/Game.h
@@ -143,7 +143,7 @@ private:
     static constexpr Array piles = { Pile1, Pile2, Pile3, Pile4, Pile5, Pile6, Pile7 };
     static constexpr Array foundations = { Foundation1, Foundation2, Foundation3, Foundation4 };
 
-    ALWAYS_INLINE const WasteRecycleRules& recycle_rules()
+    AK_ALWAYS_INLINE const WasteRecycleRules& recycle_rules()
     {
         static constexpr Array<WasteRecycleRules, 2> rules { {
             { 0, -100 },
@@ -178,7 +178,7 @@ private:
     void check_for_game_over();
     void dump_layout() const;
 
-    ALWAYS_INLINE CardStack& stack(StackLocation location)
+    AK_ALWAYS_INLINE CardStack& stack(StackLocation location)
     {
         return m_stacks[location];
     }

--- a/Userland/Games/Spider/Game.h
+++ b/Userland/Games/Spider/Game.h
@@ -75,7 +75,7 @@ private:
     void detect_victory();
     void move_focused_cards(CardStack& stack);
 
-    ALWAYS_INLINE CardStack& stack(StackLocation location)
+    AK_ALWAYS_INLINE CardStack& stack(StackLocation location)
     {
         return m_stacks[location];
     }

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -698,7 +698,7 @@ MaybeLoaderError FlacLoaderPlugin::decode_residual(Vector<i32>& decoded, FlacSub
 }
 
 // Decode a single Rice partition as part of the residual, every partition can have its own Rice parameter k
-ALWAYS_INLINE ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input)
+AK_ALWAYS_INLINE ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input)
 {
     // Rice parameter / Exp-Golomb order
     u8 k = LOADER_TRY(bit_input.read_bits<u8>(partition_type));
@@ -730,7 +730,7 @@ ALWAYS_INLINE ErrorOr<Vector<i32>, LoaderError> FlacLoaderPlugin::decode_rice_pa
 }
 
 // Decode a single number encoded with Rice/Exponential-Golomb encoding (the unsigned variant)
-ALWAYS_INLINE ErrorOr<i32> decode_unsigned_exp_golomb(u8 k, BigEndianInputBitStream& bit_input)
+AK_ALWAYS_INLINE ErrorOr<i32> decode_unsigned_exp_golomb(u8 k, BigEndianInputBitStream& bit_input)
 {
     u8 q = 0;
     while (TRY(bit_input.read_bit()) == 0)

--- a/Userland/Libraries/LibAudio/FlacLoader.h
+++ b/Userland/Libraries/LibAudio/FlacLoader.h
@@ -26,18 +26,18 @@ using Core::Stream::BigEndianInputBitStream;
 // There was no intensive fine-tuning done to determine this value, so improvements may definitely be possible.
 constexpr size_t FLAC_BUFFER_SIZE = 8 * KiB;
 
-ALWAYS_INLINE u8 frame_channel_type_to_channel_count(FlacFrameChannelType channel_type);
+AK_ALWAYS_INLINE u8 frame_channel_type_to_channel_count(FlacFrameChannelType channel_type);
 // Sign-extend an arbitrary-size signed number to 64 bit signed
-ALWAYS_INLINE i64 sign_extend(u32 n, u8 size);
+AK_ALWAYS_INLINE i64 sign_extend(u32 n, u8 size);
 // Decodes the sign representation method used in Rice coding.
 // Numbers alternate between positive and negative: 0, 1, -1, 2, -2, 3, -3, 4, -4, 5, -5, ...
-ALWAYS_INLINE i32 rice_to_signed(u32 x);
+AK_ALWAYS_INLINE i32 rice_to_signed(u32 x);
 
 // decoders
 // read a UTF-8 encoded number, even if it is not a valid codepoint
-ALWAYS_INLINE ErrorOr<u64> read_utf8_char(BigEndianInputBitStream& input);
+AK_ALWAYS_INLINE ErrorOr<u64> read_utf8_char(BigEndianInputBitStream& input);
 // decode a single number encoded with exponential golomb encoding of the specified order
-ALWAYS_INLINE ErrorOr<i32> decode_unsigned_exp_golomb(u8 order, BigEndianInputBitStream& bit_input);
+AK_ALWAYS_INLINE ErrorOr<i32> decode_unsigned_exp_golomb(u8 order, BigEndianInputBitStream& bit_input);
 
 class FlacLoaderPlugin : public LoaderPlugin {
 public:
@@ -82,12 +82,12 @@ private:
     ErrorOr<Vector<i32>, LoaderError> decode_custom_lpc(FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
     MaybeLoaderError decode_residual(Vector<i32>& decoded, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
     // decode a single rice partition that has its own rice parameter
-    ALWAYS_INLINE ErrorOr<Vector<i32>, LoaderError> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
+    AK_ALWAYS_INLINE ErrorOr<Vector<i32>, LoaderError> decode_rice_partition(u8 partition_type, u32 partitions, u32 partition_index, FlacSubframeHeader& subframe, BigEndianInputBitStream& bit_input);
 
     // Converters for special coding used in frame headers
-    ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_count_code(u8 sample_count_code);
-    ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_rate_code(u8 sample_rate_code);
-    ALWAYS_INLINE ErrorOr<PcmSampleFormat, LoaderError> convert_bit_depth_code(u8 bit_depth_code);
+    AK_ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_count_code(u8 sample_count_code);
+    AK_ALWAYS_INLINE ErrorOr<u32, LoaderError> convert_sample_rate_code(u8 sample_rate_code);
+    AK_ALWAYS_INLINE ErrorOr<PcmSampleFormat, LoaderError> convert_bit_depth_code(u8 bit_depth_code);
 
     RefPtr<Core::File> m_file;
     Optional<LoaderError> m_error {};

--- a/Userland/Libraries/LibAudio/Sample.h
+++ b/Userland/Libraries/LibAudio/Sample.h
@@ -64,19 +64,19 @@ struct Sample {
     // - Linear:        0.0 to 1.0
     // - Logarithmic:   0.0 to 1.0
 
-    ALWAYS_INLINE double linear_to_log(double const change) const
+    AK_ALWAYS_INLINE double linear_to_log(double const change) const
     {
         // TODO: Add linear slope around 0
         return VOLUME_A * exp(VOLUME_B * change);
     }
 
-    ALWAYS_INLINE double log_to_linear(double const val) const
+    AK_ALWAYS_INLINE double log_to_linear(double const val) const
     {
         // TODO: Add linear slope around 0
         return log(val / VOLUME_A) / VOLUME_B;
     }
 
-    ALWAYS_INLINE Sample& log_multiply(double const change)
+    AK_ALWAYS_INLINE Sample& log_multiply(double const change)
     {
         double factor = linear_to_log(change);
         left *= factor;
@@ -84,7 +84,7 @@ struct Sample {
         return *this;
     }
 
-    ALWAYS_INLINE Sample log_multiplied(double const volume_change) const
+    AK_ALWAYS_INLINE Sample log_multiplied(double const volume_change) const
     {
         Sample new_frame { left, right };
         new_frame.log_multiply(volume_change);
@@ -92,7 +92,7 @@ struct Sample {
     }
 
     // Constant power panning
-    ALWAYS_INLINE Sample& pan(double const position)
+    AK_ALWAYS_INLINE Sample& pan(double const position)
     {
         double const pi_over_2 = AK::Pi<double> * 0.5;
         double const root_over_2 = AK::sqrt(2.0) * 0.5;
@@ -104,7 +104,7 @@ struct Sample {
         return *this;
     }
 
-    ALWAYS_INLINE Sample panned(double const position) const
+    AK_ALWAYS_INLINE Sample panned(double const position) const
     {
         Sample new_sample { left, right };
         new_sample.pan(position);

--- a/Userland/Libraries/LibC/malloc.cpp
+++ b/Userland/Libraries/LibC/malloc.cpp
@@ -23,19 +23,19 @@
 
 class PthreadMutexLocker {
 public:
-    ALWAYS_INLINE explicit PthreadMutexLocker(pthread_mutex_t& mutex)
+    AK_ALWAYS_INLINE explicit PthreadMutexLocker(pthread_mutex_t& mutex)
         : m_mutex(mutex)
     {
         lock();
         __heap_is_stable = false;
     }
-    ALWAYS_INLINE ~PthreadMutexLocker()
+    AK_ALWAYS_INLINE ~PthreadMutexLocker()
     {
         __heap_is_stable = true;
         unlock();
     }
-    ALWAYS_INLINE void lock() { pthread_mutex_lock(&m_mutex); }
-    ALWAYS_INLINE void unlock() { pthread_mutex_unlock(&m_mutex); }
+    AK_ALWAYS_INLINE void lock() { pthread_mutex_lock(&m_mutex); }
+    AK_ALWAYS_INLINE void unlock() { pthread_mutex_unlock(&m_mutex); }
 
 private:
     pthread_mutex_t& m_mutex;
@@ -56,37 +56,37 @@ static bool s_scrub_free = true;
 static bool s_profiling = false;
 static bool s_in_userspace_emulator = false;
 
-ALWAYS_INLINE static void ue_notify_malloc(const void* ptr, size_t size)
+AK_ALWAYS_INLINE static void ue_notify_malloc(const void* ptr, size_t size)
 {
     if (s_in_userspace_emulator)
         syscall(SC_emuctl, 1, size, (FlatPtr)ptr);
 }
 
-ALWAYS_INLINE static void ue_notify_free(const void* ptr)
+AK_ALWAYS_INLINE static void ue_notify_free(const void* ptr)
 {
     if (s_in_userspace_emulator)
         syscall(SC_emuctl, 2, (FlatPtr)ptr, 0);
 }
 
-ALWAYS_INLINE static void ue_notify_realloc(const void* ptr, size_t size)
+AK_ALWAYS_INLINE static void ue_notify_realloc(const void* ptr, size_t size)
 {
     if (s_in_userspace_emulator)
         syscall(SC_emuctl, 3, size, (FlatPtr)ptr);
 }
 
-ALWAYS_INLINE static void ue_notify_chunk_size_changed(const void* block, size_t chunk_size)
+AK_ALWAYS_INLINE static void ue_notify_chunk_size_changed(const void* block, size_t chunk_size)
 {
     if (s_in_userspace_emulator)
         syscall(SC_emuctl, 4, chunk_size, (FlatPtr)block);
 }
 
 struct MemoryAuditingSuppressor {
-    ALWAYS_INLINE MemoryAuditingSuppressor()
+    AK_ALWAYS_INLINE MemoryAuditingSuppressor()
     {
         if (s_in_userspace_emulator)
             syscall(SC_emuctl, 7);
     }
-    ALWAYS_INLINE ~MemoryAuditingSuppressor()
+    AK_ALWAYS_INLINE ~MemoryAuditingSuppressor()
     {
         if (s_in_userspace_emulator)
             syscall(SC_emuctl, 8);

--- a/Userland/Libraries/LibC/serenity.h
+++ b/Userland/Libraries/LibC/serenity.h
@@ -22,12 +22,12 @@ int profiling_free_buffer(pid_t);
 
 int futex(uint32_t* userspace_address, int futex_op, uint32_t value, const struct timespec* timeout, uint32_t* userspace_address2, uint32_t value3);
 
-#ifndef ALWAYS_INLINE
-#    define ALWAYS_INLINE inline __attribute__((always_inline))
-#    define ALWAYS_INLINE_SERENITY_H
+#ifndef AK_ALWAYS_INLINE
+#    define AK_ALWAYS_INLINE inline __attribute__((always_inline))
+#    define AK_ALWAYS_INLINE_SERENITY_H
 #endif
 
-static ALWAYS_INLINE int futex_wait(uint32_t* userspace_address, uint32_t value, const struct timespec* abstime, int clockid)
+static AK_ALWAYS_INLINE int futex_wait(uint32_t* userspace_address, uint32_t value, const struct timespec* abstime, int clockid)
 {
     int op;
 
@@ -42,13 +42,13 @@ static ALWAYS_INLINE int futex_wait(uint32_t* userspace_address, uint32_t value,
     return futex(userspace_address, op, value, abstime, NULL, FUTEX_BITSET_MATCH_ANY);
 }
 
-static ALWAYS_INLINE int futex_wake(uint32_t* userspace_address, uint32_t count)
+static AK_ALWAYS_INLINE int futex_wake(uint32_t* userspace_address, uint32_t count)
 {
     return futex(userspace_address, FUTEX_WAKE, count, NULL, NULL, 0);
 }
 
-#ifdef ALWAYS_INLINE_SERENITY_H
-#    undef ALWAYS_INLINE
+#ifdef AK_ALWAYS_INLINE_SERENITY_H
+#    undef AK_ALWAYS_INLINE
 #endif
 
 int purge(int mode);

--- a/Userland/Libraries/LibC/stdio.cpp
+++ b/Userland/Libraries/LibC/stdio.cpp
@@ -865,7 +865,7 @@ void rewind(FILE* stream)
     clearerr(stream);
 }
 
-ALWAYS_INLINE void stdout_putch(char*&, char ch)
+AK_ALWAYS_INLINE void stdout_putch(char*&, char ch)
 {
     putchar(ch);
 }

--- a/Userland/Libraries/LibCompress/Deflate.cpp
+++ b/Userland/Libraries/LibCompress/Deflate.cpp
@@ -611,7 +611,7 @@ size_t DeflateCompressor::find_back_match(size_t start, u16 hash, size_t previou
     return previous_match_length; // we found matches, but they were at most previous_match_length long
 }
 
-ALWAYS_INLINE u8 DeflateCompressor::distance_to_base(u16 distance)
+AK_ALWAYS_INLINE u8 DeflateCompressor::distance_to_base(u16 distance)
 {
     return (distance <= 256) ? distance_to_base_lo[distance - 1] : distance_to_base_hi[(distance - 1) >> 7];
 }

--- a/Userland/Libraries/LibCompress/DeflateTables.h
+++ b/Userland/Libraries/LibCompress/DeflateTables.h
@@ -178,7 +178,7 @@ static consteval Array<u8, UINT8_MAX + 1> generate_reverse8_lookup_table()
 static constexpr auto reverse8_lookup_table = generate_reverse8_lookup_table();
 
 // Lookup-table based bit swap
-ALWAYS_INLINE static u16 fast_reverse16(u16 value, size_t bits)
+AK_ALWAYS_INLINE static u16 fast_reverse16(u16 value, size_t bits)
 {
     VERIFY(bits <= 16);
 

--- a/Userland/Libraries/LibCore/InputBitStream.h
+++ b/Userland/Libraries/LibCore/InputBitStream.h
@@ -118,7 +118,7 @@ public:
     }
 
     /// Whether we are (accidentally or intentionally) at a byte boundary right now.
-    ALWAYS_INLINE bool is_aligned_to_byte_boundary() const { return m_bit_offset == 0; }
+    AK_ALWAYS_INLINE bool is_aligned_to_byte_boundary() const { return m_bit_offset == 0; }
 
 private:
     BigEndianInputBitStream(Stream& stream)

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/BitwiseOperations.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/BitwiseOperations.cpp
@@ -234,7 +234,7 @@ void UnsignedBigIntegerAlgorithms::shift_right_by_n_words(
 /**
  * Returns the word at a requested index in the result of a shift operation
  */
-ALWAYS_INLINE UnsignedBigInteger::Word UnsignedBigIntegerAlgorithms::shift_left_get_one_word(
+AK_ALWAYS_INLINE UnsignedBigInteger::Word UnsignedBigIntegerAlgorithms::shift_left_get_one_word(
     UnsignedBigInteger const& number,
     size_t num_bits,
     size_t result_word_index)

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/ModularPower.cpp
@@ -54,7 +54,7 @@ void UnsignedBigIntegerAlgorithms::destructive_modular_power_without_allocation(
  * This needs an odd input value
  * Algorithm from: Dumas, J.G. "On Newton–Raphson Iteration for Multiplicative Inverses Modulo Prime Powers".
  */
-ALWAYS_INLINE static u32 inverse_wrapped(u32 value)
+AK_ALWAYS_INLINE static u32 inverse_wrapped(u32 value)
 {
     VERIFY(value & 1);
 
@@ -73,7 +73,7 @@ ALWAYS_INLINE static u32 inverse_wrapped(u32 value)
 /**
  * Computes z = x * y + c. z_carry contains the top bits, z contains the bottom bits.
  */
-ALWAYS_INLINE static void linear_multiplication_with_carry(u32 x, u32 y, u32 c, u32& z_carry, u32& z)
+AK_ALWAYS_INLINE static void linear_multiplication_with_carry(u32 x, u32 y, u32 c, u32& z_carry, u32& z)
 {
     u64 result = static_cast<u64>(x) * static_cast<u64>(y) + static_cast<u64>(c);
     z_carry = static_cast<u32>(result >> 32);
@@ -83,7 +83,7 @@ ALWAYS_INLINE static void linear_multiplication_with_carry(u32 x, u32 y, u32 c, 
 /**
  * Computes z = a + b. z_carry contains the top bit (1 or 0), z contains the bottom bits.
  */
-ALWAYS_INLINE static void addition_with_carry(u32 a, u32 b, u32& z_carry, u32& z)
+AK_ALWAYS_INLINE static void addition_with_carry(u32 a, u32 b, u32& z_carry, u32& z)
 {
     u64 result = static_cast<u64>(a) + static_cast<u64>(b);
     z_carry = static_cast<u32>(result >> 32);

--- a/Userland/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
+++ b/Userland/Libraries/LibCrypto/BigInt/Algorithms/UnsignedBigIntegerAlgorithms.h
@@ -34,7 +34,7 @@ private:
     static void almost_montgomery_multiplication_without_allocation(UnsignedBigInteger const& x, UnsignedBigInteger const& y, UnsignedBigInteger const& modulo, UnsignedBigInteger& z, UnsignedBigInteger::Word k, size_t num_words, UnsignedBigInteger& result);
     static void shift_left_by_n_words(UnsignedBigInteger const& number, size_t number_of_words, UnsignedBigInteger& output);
     static void shift_right_by_n_words(UnsignedBigInteger const& number, size_t number_of_words, UnsignedBigInteger& output);
-    ALWAYS_INLINE static UnsignedBigInteger::Word shift_left_get_one_word(UnsignedBigInteger const& number, size_t num_bits, size_t result_word_index);
+    AK_ALWAYS_INLINE static UnsignedBigInteger::Word shift_left_get_one_word(UnsignedBigInteger const& number, size_t num_bits, size_t result_word_index);
 };
 
 }

--- a/Userland/Libraries/LibCrypto/Hash/HashFunction.h
+++ b/Userland/Libraries/LibCrypto/Hash/HashFunction.h
@@ -19,10 +19,10 @@ struct Digest {
     constexpr static size_t Size = DigestS / 8;
     u8 data[Size];
 
-    [[nodiscard]] ALWAYS_INLINE const u8* immutable_data() const { return data; }
-    [[nodiscard]] ALWAYS_INLINE size_t data_length() const { return Size; }
+    [[nodiscard]] AK_ALWAYS_INLINE const u8* immutable_data() const { return data; }
+    [[nodiscard]] AK_ALWAYS_INLINE size_t data_length() const { return Size; }
 
-    [[nodiscard]] ALWAYS_INLINE ReadonlyBytes bytes() const { return { immutable_data(), data_length() }; }
+    [[nodiscard]] AK_ALWAYS_INLINE ReadonlyBytes bytes() const { return { immutable_data(), data_length() }; }
 };
 
 template<size_t BlockS, size_t DigestS, typename DigestT = Digest<DigestS>>

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -71,7 +71,7 @@ using RollNotes = OrderedHashMap<u8, RollNote>;
 
 struct Signal : public Variant<Sample, RollNotes> {
     using Variant::Variant;
-    ALWAYS_INLINE SignalType type() const
+    AK_ALWAYS_INLINE SignalType type() const
     {
         if (has<Sample>())
             return SignalType::Sample;

--- a/Userland/Libraries/LibEDID/DMT.h
+++ b/Userland/Libraries/LibEDID/DMT.h
@@ -47,8 +47,8 @@ public:
         u8 cvt_bytes[3] {};
         ScanType scan_type { ScanType::NonInterlaced };
 
-        ALWAYS_INLINE bool has_std() const { return std_bytes[0] != 0; }
-        ALWAYS_INLINE bool has_cvt() const { return cvt_bytes[0] != 0; }
+        AK_ALWAYS_INLINE bool has_std() const { return std_bytes[0] != 0; }
+        AK_ALWAYS_INLINE bool has_cvt() const { return cvt_bytes[0] != 0; }
 
         FixedPoint<16, u32> horizontal_frequency_khz() const;
         FixedPoint<16, u32> vertical_frequency_hz() const;

--- a/Userland/Libraries/LibEDID/EDID.h
+++ b/Userland/Libraries/LibEDID/EDID.h
@@ -251,24 +251,24 @@ public:
             Manufacturer
         };
 
-        ALWAYS_INLINE Source source() const { return m_source; }
-        ALWAYS_INLINE unsigned width() const { return m_width; };
-        ALWAYS_INLINE unsigned height() const { return m_height; }
+        AK_ALWAYS_INLINE Source source() const { return m_source; }
+        AK_ALWAYS_INLINE unsigned width() const { return m_width; };
+        AK_ALWAYS_INLINE unsigned height() const { return m_height; }
 
-        ALWAYS_INLINE unsigned refresh_rate() const
+        AK_ALWAYS_INLINE unsigned refresh_rate() const
         {
             if (m_source == Source::Manufacturer)
                 return 0;
             return m_refresh_rate_or_manufacturer_specific;
         }
 
-        ALWAYS_INLINE u8 manufacturer_specific() const
+        AK_ALWAYS_INLINE u8 manufacturer_specific() const
         {
             VERIFY(m_source == Source::Manufacturer);
             return m_refresh_rate_or_manufacturer_specific;
         }
 
-        ALWAYS_INLINE u8 dmt_id() const { return m_dmt_id; }
+        AK_ALWAYS_INLINE u8 dmt_id() const { return m_dmt_id; }
 
     private:
         constexpr EstablishedTiming(Source source, u16 width, u16 height, u8 refresh_rate_or_manufacturer_specific, u8 dmt_id = 0)
@@ -335,10 +335,10 @@ public:
         u16 vertical_addressable_lines() const;
         u16 vertical_blanking_lines() const;
         u16 horizontal_front_porch_pixels() const;
-        ALWAYS_INLINE u16 horizontal_back_porch_pixels() const { return horizontal_blanking_pixels() - horizontal_sync_pulse_width_pixels() - horizontal_front_porch_pixels(); }
+        AK_ALWAYS_INLINE u16 horizontal_back_porch_pixels() const { return horizontal_blanking_pixels() - horizontal_sync_pulse_width_pixels() - horizontal_front_porch_pixels(); }
         u16 horizontal_sync_pulse_width_pixels() const;
         u16 vertical_front_porch_lines() const;
-        ALWAYS_INLINE u16 vertical_back_porch_lines() const { return vertical_blanking_lines() - vertical_sync_pulse_width_lines() - vertical_front_porch_lines(); }
+        AK_ALWAYS_INLINE u16 vertical_back_porch_lines() const { return vertical_blanking_lines() - vertical_sync_pulse_width_lines() - vertical_front_porch_lines(); }
         u16 vertical_sync_pulse_width_lines() const;
         u16 horizontal_image_size_mm() const;
         u16 vertical_image_size_mm() const;
@@ -387,7 +387,7 @@ public:
         AspectRatio aspect_ratio() const;
         u16 preferred_refresh_rate();
 
-        ALWAYS_INLINE DMT::CVT cvt_code() const { return m_cvt; }
+        AK_ALWAYS_INLINE DMT::CVT cvt_code() const { return m_cvt; }
 
     private:
         CoordinatedVideoTiming(DMT::CVT const& cvt)

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -298,7 +298,7 @@ private:
     Vector<Array<TextureCoordinateGeneration, 4>> m_texture_coordinate_generation;
     bool m_texcoord_generation_dirty { true };
 
-    ALWAYS_INLINE TextureCoordinateGeneration& texture_coordinate_generation(size_t texture_unit, GLenum capability)
+    AK_ALWAYS_INLINE TextureCoordinateGeneration& texture_coordinate_generation(size_t texture_unit, GLenum capability)
     {
         return m_texture_coordinate_generation[texture_unit][capability - GL_TEXTURE_GEN_S];
     }

--- a/Userland/Libraries/LibGfx/AffineTransform.h
+++ b/Userland/Libraries/LibGfx/AffineTransform.h
@@ -37,12 +37,12 @@ public:
     template<typename T>
     Rect<T> map(const Rect<T>&) const;
 
-    [[nodiscard]] ALWAYS_INLINE float a() const { return m_values[0]; }
-    [[nodiscard]] ALWAYS_INLINE float b() const { return m_values[1]; }
-    [[nodiscard]] ALWAYS_INLINE float c() const { return m_values[2]; }
-    [[nodiscard]] ALWAYS_INLINE float d() const { return m_values[3]; }
-    [[nodiscard]] ALWAYS_INLINE float e() const { return m_values[4]; }
-    [[nodiscard]] ALWAYS_INLINE float f() const { return m_values[5]; }
+    [[nodiscard]] AK_ALWAYS_INLINE float a() const { return m_values[0]; }
+    [[nodiscard]] AK_ALWAYS_INLINE float b() const { return m_values[1]; }
+    [[nodiscard]] AK_ALWAYS_INLINE float c() const { return m_values[2]; }
+    [[nodiscard]] AK_ALWAYS_INLINE float d() const { return m_values[3]; }
+    [[nodiscard]] AK_ALWAYS_INLINE float e() const { return m_values[4]; }
+    [[nodiscard]] AK_ALWAYS_INLINE float f() const { return m_values[5]; }
 
     [[nodiscard]] float x_scale() const;
     [[nodiscard]] float y_scale() const;

--- a/Userland/Libraries/LibGfx/BMPLoader.cpp
+++ b/Userland/Libraries/LibGfx/BMPLoader.cpp
@@ -524,7 +524,7 @@ static bool decode_bmp_core_dib(BMPLoadingContext& context, InputStreamer& strea
     return true;
 }
 
-ALWAYS_INLINE static bool is_supported_compression_format(BMPLoadingContext& context, u32 compression)
+AK_ALWAYS_INLINE static bool is_supported_compression_format(BMPLoadingContext& context, u32 compression)
 {
     return compression == Compression::RGB || compression == Compression::BITFIELDS
         || compression == Compression::ALPHABITFIELDS || compression == Compression::RLE8

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -140,12 +140,12 @@ public:
     [[nodiscard]] int physical_height() const { return physical_size().height(); }
     [[nodiscard]] size_t pitch() const { return m_pitch; }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_indexed() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_indexed() const
     {
         return is_indexed(m_format);
     }
 
-    [[nodiscard]] ALWAYS_INLINE static bool is_indexed(BitmapFormat format)
+    [[nodiscard]] AK_ALWAYS_INLINE static bool is_indexed(BitmapFormat format)
     {
         return format == BitmapFormat::Indexed8 || format == BitmapFormat::Indexed4
             || format == BitmapFormat::Indexed2 || format == BitmapFormat::Indexed1;

--- a/Userland/Libraries/LibGfx/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/BitmapFont.cpp
@@ -319,7 +319,7 @@ int BitmapFont::width(Utf8View const& view) const { return unicode_view_width(vi
 int BitmapFont::width(Utf32View const& view) const { return unicode_view_width(view); }
 
 template<typename T>
-ALWAYS_INLINE int BitmapFont::unicode_view_width(T const& view) const
+AK_ALWAYS_INLINE int BitmapFont::unicode_view_width(T const& view) const
 {
     if (view.is_empty())
         return 0;

--- a/Userland/Libraries/LibGfx/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/BitmapFont.h
@@ -48,7 +48,7 @@ public:
     bool contains_glyph(u32 code_point) const override;
     bool contains_raw_glyph(u32 code_point) const { return m_glyph_widths[code_point] > 0; }
 
-    ALWAYS_INLINE int glyph_or_emoji_width(u32 code_point) const override
+    AK_ALWAYS_INLINE int glyph_or_emoji_width(u32 code_point) const override
     {
         if (m_fixed_width)
             return m_glyph_width;

--- a/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.cpp
+++ b/Userland/Libraries/LibGfx/Filters/FastBoxBlurFilter.cpp
@@ -10,15 +10,15 @@
 
 namespace Gfx {
 
-ALWAYS_INLINE static constexpr u8 red_value(Color color)
+AK_ALWAYS_INLINE static constexpr u8 red_value(Color color)
 {
     return (color.alpha() == 0) ? 0xFF : color.red();
 }
-ALWAYS_INLINE static constexpr u8 green_value(Color color)
+AK_ALWAYS_INLINE static constexpr u8 green_value(Color color)
 {
     return (color.alpha() == 0) ? 0xFF : color.green();
 }
-ALWAYS_INLINE static constexpr u8 blue_value(Color color)
+AK_ALWAYS_INLINE static constexpr u8 blue_value(Color color)
 {
     return (color.alpha() == 0) ? 0xFF : color.blue();
 }

--- a/Userland/Libraries/LibGfx/PNGLoader.cpp
+++ b/Userland/Libraries/LibGfx/PNGLoader.cpp
@@ -165,7 +165,7 @@ private:
 
 static bool process_chunk(Streamer&, PNGLoadingContext& context);
 
-ALWAYS_INLINE static u8 paeth_predictor(int a, int b, int c)
+AK_ALWAYS_INLINE static u8 paeth_predictor(int a, int b, int c)
 {
     int p = a + b - c;
     int pa = abs(p - a);
@@ -191,7 +191,7 @@ union [[gnu::packed]] Pixel {
 static_assert(AssertSize<Pixel, 4>());
 
 template<bool has_alpha, u8 filter_type>
-ALWAYS_INLINE static void unfilter_impl(Gfx::Bitmap& bitmap, int y, const void* dummy_scanline_data)
+AK_ALWAYS_INLINE static void unfilter_impl(Gfx::Bitmap& bitmap, int y, const void* dummy_scanline_data)
 {
     auto* dummy_scanline = (const Pixel*)dummy_scanline_data;
     if constexpr (filter_type == 0) {
@@ -273,7 +273,7 @@ ALWAYS_INLINE static void unfilter_impl(Gfx::Bitmap& bitmap, int y, const void* 
 }
 
 template<typename T>
-ALWAYS_INLINE static void unpack_grayscale_without_alpha(PNGLoadingContext& context)
+AK_ALWAYS_INLINE static void unpack_grayscale_without_alpha(PNGLoadingContext& context)
 {
     for (int y = 0; y < context.height; ++y) {
         auto* gray_values = reinterpret_cast<const T*>(context.scanlines[y].data.data());
@@ -288,7 +288,7 @@ ALWAYS_INLINE static void unpack_grayscale_without_alpha(PNGLoadingContext& cont
 }
 
 template<typename T>
-ALWAYS_INLINE static void unpack_grayscale_with_alpha(PNGLoadingContext& context)
+AK_ALWAYS_INLINE static void unpack_grayscale_with_alpha(PNGLoadingContext& context)
 {
     for (int y = 0; y < context.height; ++y) {
         auto* tuples = reinterpret_cast<const Tuple<T>*>(context.scanlines[y].data.data());
@@ -303,7 +303,7 @@ ALWAYS_INLINE static void unpack_grayscale_with_alpha(PNGLoadingContext& context
 }
 
 template<typename T>
-ALWAYS_INLINE static void unpack_triplets_without_alpha(PNGLoadingContext& context)
+AK_ALWAYS_INLINE static void unpack_triplets_without_alpha(PNGLoadingContext& context)
 {
     for (int y = 0; y < context.height; ++y) {
         auto* triplets = reinterpret_cast<const Triplet<T>*>(context.scanlines[y].data.data());
@@ -318,7 +318,7 @@ ALWAYS_INLINE static void unpack_triplets_without_alpha(PNGLoadingContext& conte
 }
 
 template<typename T>
-ALWAYS_INLINE static void unpack_triplets_with_transparency_value(PNGLoadingContext& context, Triplet<T> transparency_value)
+AK_ALWAYS_INLINE static void unpack_triplets_with_transparency_value(PNGLoadingContext& context, Triplet<T> transparency_value)
 {
     for (int y = 0; y < context.height; ++y) {
         auto* triplets = reinterpret_cast<const Triplet<T>*>(context.scanlines[y].data.data());

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -41,7 +41,7 @@
 namespace Gfx {
 
 template<BitmapFormat format = BitmapFormat::Invalid>
-ALWAYS_INLINE Color get_pixel(Gfx::Bitmap const& bitmap, int x, int y)
+AK_ALWAYS_INLINE Color get_pixel(Gfx::Bitmap const& bitmap, int x, int y)
 {
     if constexpr (format == BitmapFormat::Indexed8)
         return bitmap.palette_color(bitmap.scanline_u8(y)[x]);
@@ -1070,7 +1070,7 @@ void Painter::blit(IntPoint const& position, Gfx::Bitmap const& source, IntRect 
 }
 
 template<bool has_alpha_channel, typename GetPixel>
-ALWAYS_INLINE static void do_draw_integer_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& src_rect, Gfx::Bitmap const& source, int hfactor, int vfactor, GetPixel get_pixel, float opacity)
+AK_ALWAYS_INLINE static void do_draw_integer_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& src_rect, Gfx::Bitmap const& source, int hfactor, int vfactor, GetPixel get_pixel, float opacity)
 {
     bool has_opacity = opacity != 1.0f;
     for (int y = 0; y < src_rect.height(); ++y) {
@@ -1094,7 +1094,7 @@ ALWAYS_INLINE static void do_draw_integer_scaled_bitmap(Gfx::Bitmap& target, Int
 }
 
 template<bool has_alpha_channel, bool do_bilinear_blend, typename GetPixel>
-ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity)
+AK_ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity)
 {
     if constexpr (!do_bilinear_blend) {
         IntRect int_src_rect = enclosing_int_rect(src_rect);
@@ -1155,7 +1155,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
 }
 
 template<bool has_alpha_channel, typename GetPixel>
-ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity, Painter::ScalingMode scaling_mode)
+AK_ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity, Painter::ScalingMode scaling_mode)
 {
     switch (scaling_mode) {
     case Painter::ScalingMode::NearestNeighbor:
@@ -1699,7 +1699,7 @@ void Painter::set_pixel(IntPoint const& p, Color color, bool blend)
     }
 }
 
-ALWAYS_INLINE void Painter::set_physical_pixel_with_draw_op(u32& pixel, Color const& color)
+AK_ALWAYS_INLINE void Painter::set_physical_pixel_with_draw_op(u32& pixel, Color const& color)
 {
     // This always sets a single physical pixel, independent of scale().
     // This should only be called by routines that already handle scale.
@@ -1717,7 +1717,7 @@ ALWAYS_INLINE void Painter::set_physical_pixel_with_draw_op(u32& pixel, Color co
     }
 }
 
-ALWAYS_INLINE void Painter::fill_physical_scanline_with_draw_op(int y, int x, int width, Color const& color)
+AK_ALWAYS_INLINE void Painter::fill_physical_scanline_with_draw_op(int y, int x, int width, Color const& color)
 {
     // This always draws a single physical scanline, independent of scale().
     // This should only be called by routines that already handle scale.

--- a/Userland/Libraries/LibGfx/Point.h
+++ b/Userland/Libraries/LibGfx/Point.h
@@ -42,14 +42,14 @@ public:
     {
     }
 
-    [[nodiscard]] ALWAYS_INLINE T x() const { return m_x; }
-    [[nodiscard]] ALWAYS_INLINE T y() const { return m_y; }
+    [[nodiscard]] AK_ALWAYS_INLINE T x() const { return m_x; }
+    [[nodiscard]] AK_ALWAYS_INLINE T y() const { return m_y; }
 
-    ALWAYS_INLINE void set_x(T x) { m_x = x; }
-    ALWAYS_INLINE void set_y(T y) { m_y = y; }
+    AK_ALWAYS_INLINE void set_x(T x) { m_x = x; }
+    AK_ALWAYS_INLINE void set_y(T y) { m_y = y; }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_null() const { return !m_x && !m_y; }
-    [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return m_x <= 0 && m_y <= 0; }
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_null() const { return !m_x && !m_y; }
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_empty() const { return m_x <= 0 && m_y <= 0; }
 
     void translate_by(T dx, T dy)
     {
@@ -57,8 +57,8 @@ public:
         m_y += dy;
     }
 
-    ALWAYS_INLINE void translate_by(T dboth) { translate_by(dboth, dboth); }
-    ALWAYS_INLINE void translate_by(Point<T> const& delta) { translate_by(delta.x(), delta.y()); }
+    AK_ALWAYS_INLINE void translate_by(T dboth) { translate_by(dboth, dboth); }
+    AK_ALWAYS_INLINE void translate_by(Point<T> const& delta) { translate_by(delta.x(), delta.y()); }
 
     void scale_by(T dx, T dy)
     {
@@ -66,8 +66,8 @@ public:
         m_y *= dy;
     }
 
-    ALWAYS_INLINE void scale_by(T dboth) { scale_by(dboth, dboth); }
-    ALWAYS_INLINE void scale_by(Point<T> const& delta) { scale_by(delta.x(), delta.y()); }
+    AK_ALWAYS_INLINE void scale_by(T dboth) { scale_by(dboth, dboth); }
+    AK_ALWAYS_INLINE void scale_by(Point<T> const& delta) { scale_by(delta.x(), delta.y()); }
 
     void transform_by(AffineTransform const& transform) { *this = transform.map(*this); }
 

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -61,33 +61,33 @@ public:
     {
     }
 
-    [[nodiscard]] ALWAYS_INLINE T x() const { return location().x(); }
-    [[nodiscard]] ALWAYS_INLINE T y() const { return location().y(); }
-    [[nodiscard]] ALWAYS_INLINE T width() const { return m_size.width(); }
-    [[nodiscard]] ALWAYS_INLINE T height() const { return m_size.height(); }
+    [[nodiscard]] AK_ALWAYS_INLINE T x() const { return location().x(); }
+    [[nodiscard]] AK_ALWAYS_INLINE T y() const { return location().y(); }
+    [[nodiscard]] AK_ALWAYS_INLINE T width() const { return m_size.width(); }
+    [[nodiscard]] AK_ALWAYS_INLINE T height() const { return m_size.height(); }
 
-    ALWAYS_INLINE void set_x(T x) { m_location.set_x(x); }
-    ALWAYS_INLINE void set_y(T y) { m_location.set_y(y); }
-    ALWAYS_INLINE void set_width(T width) { m_size.set_width(width); }
-    ALWAYS_INLINE void set_height(T height) { m_size.set_height(height); }
+    AK_ALWAYS_INLINE void set_x(T x) { m_location.set_x(x); }
+    AK_ALWAYS_INLINE void set_y(T y) { m_location.set_y(y); }
+    AK_ALWAYS_INLINE void set_width(T width) { m_size.set_width(width); }
+    AK_ALWAYS_INLINE void set_height(T height) { m_size.set_height(height); }
 
-    [[nodiscard]] ALWAYS_INLINE Point<T> const& location() const { return m_location; }
-    [[nodiscard]] ALWAYS_INLINE Size<T> const& size() const { return m_size; }
+    [[nodiscard]] AK_ALWAYS_INLINE Point<T> const& location() const { return m_location; }
+    [[nodiscard]] AK_ALWAYS_INLINE Size<T> const& size() const { return m_size; }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_null() const { return width() == 0 && height() == 0; }
-    [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return width() <= 0 || height() <= 0; }
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_null() const { return width() == 0 && height() == 0; }
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_empty() const { return width() <= 0 || height() <= 0; }
 
-    ALWAYS_INLINE void translate_by(T dx, T dy) { m_location.translate_by(dx, dy); }
-    ALWAYS_INLINE void translate_by(T dboth) { m_location.translate_by(dboth); }
-    ALWAYS_INLINE void translate_by(Point<T> const& delta) { m_location.translate_by(delta); }
+    AK_ALWAYS_INLINE void translate_by(T dx, T dy) { m_location.translate_by(dx, dy); }
+    AK_ALWAYS_INLINE void translate_by(T dboth) { m_location.translate_by(dboth); }
+    AK_ALWAYS_INLINE void translate_by(Point<T> const& delta) { m_location.translate_by(delta); }
 
-    ALWAYS_INLINE void scale_by(T dx, T dy)
+    AK_ALWAYS_INLINE void scale_by(T dx, T dy)
     {
         m_location.scale_by(dx, dy);
         m_size.scale_by(dx, dy);
     }
-    ALWAYS_INLINE void scale_by(T dboth) { scale_by(dboth, dboth); }
-    ALWAYS_INLINE void scale_by(Point<T> const& delta) { scale_by(delta.x(), delta.y()); }
+    AK_ALWAYS_INLINE void scale_by(T dboth) { scale_by(dboth, dboth); }
+    AK_ALWAYS_INLINE void scale_by(Point<T> const& delta) { scale_by(delta.x(), delta.y()); }
 
     void transform_by(AffineTransform const& transform) { *this = transform.map(*this); }
 
@@ -96,12 +96,12 @@ public:
         return { x() + width() / 2, y() + height() / 2 };
     }
 
-    ALWAYS_INLINE void set_location(Point<T> const& location)
+    AK_ALWAYS_INLINE void set_location(Point<T> const& location)
     {
         m_location = location;
     }
 
-    ALWAYS_INLINE void set_size(Size<T> const& size)
+    AK_ALWAYS_INLINE void set_size(Size<T> const& size)
     {
         m_size = size;
     }
@@ -298,7 +298,7 @@ public:
         return x >= m_location.x() && x <= right() && y >= m_location.y() && y <= bottom();
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool contains(Point<T> const& point) const
+    [[nodiscard]] AK_ALWAYS_INLINE bool contains(Point<T> const& point) const
     {
         return contains(point.x(), point.y());
     }
@@ -323,15 +323,15 @@ public:
         return have_any;
     }
 
-    [[nodiscard]] ALWAYS_INLINE int primary_offset_for_orientation(Orientation orientation) const { return m_location.primary_offset_for_orientation(orientation); }
-    ALWAYS_INLINE void set_primary_offset_for_orientation(Orientation orientation, int value) { m_location.set_primary_offset_for_orientation(orientation, value); }
-    [[nodiscard]] ALWAYS_INLINE int secondary_offset_for_orientation(Orientation orientation) const { return m_location.secondary_offset_for_orientation(orientation); }
-    ALWAYS_INLINE void set_secondary_offset_for_orientation(Orientation orientation, int value) { m_location.set_secondary_offset_for_orientation(orientation, value); }
+    [[nodiscard]] AK_ALWAYS_INLINE int primary_offset_for_orientation(Orientation orientation) const { return m_location.primary_offset_for_orientation(orientation); }
+    AK_ALWAYS_INLINE void set_primary_offset_for_orientation(Orientation orientation, int value) { m_location.set_primary_offset_for_orientation(orientation, value); }
+    [[nodiscard]] AK_ALWAYS_INLINE int secondary_offset_for_orientation(Orientation orientation) const { return m_location.secondary_offset_for_orientation(orientation); }
+    AK_ALWAYS_INLINE void set_secondary_offset_for_orientation(Orientation orientation, int value) { m_location.set_secondary_offset_for_orientation(orientation, value); }
 
-    [[nodiscard]] ALWAYS_INLINE int primary_size_for_orientation(Orientation orientation) const { return m_size.primary_size_for_orientation(orientation); }
-    [[nodiscard]] ALWAYS_INLINE int secondary_size_for_orientation(Orientation orientation) const { return m_size.secondary_size_for_orientation(orientation); }
-    ALWAYS_INLINE void set_primary_size_for_orientation(Orientation orientation, int value) { m_size.set_primary_size_for_orientation(orientation, value); }
-    ALWAYS_INLINE void set_secondary_size_for_orientation(Orientation orientation, int value) { m_size.set_secondary_size_for_orientation(orientation, value); }
+    [[nodiscard]] AK_ALWAYS_INLINE int primary_size_for_orientation(Orientation orientation) const { return m_size.primary_size_for_orientation(orientation); }
+    [[nodiscard]] AK_ALWAYS_INLINE int secondary_size_for_orientation(Orientation orientation) const { return m_size.secondary_size_for_orientation(orientation); }
+    AK_ALWAYS_INLINE void set_primary_size_for_orientation(Orientation orientation, int value) { m_size.set_primary_size_for_orientation(orientation, value); }
+    AK_ALWAYS_INLINE void set_secondary_size_for_orientation(Orientation orientation, int value) { m_size.set_secondary_size_for_orientation(orientation, value); }
 
     [[nodiscard]] T first_edge_for_orientation(Orientation orientation) const
     {
@@ -347,27 +347,27 @@ public:
         return right();
     }
 
-    [[nodiscard]] ALWAYS_INLINE T left() const { return x(); }
-    [[nodiscard]] ALWAYS_INLINE T right() const { return x() + width() - 1; }
-    [[nodiscard]] ALWAYS_INLINE T top() const { return y(); }
-    [[nodiscard]] ALWAYS_INLINE T bottom() const { return y() + height() - 1; }
+    [[nodiscard]] AK_ALWAYS_INLINE T left() const { return x(); }
+    [[nodiscard]] AK_ALWAYS_INLINE T right() const { return x() + width() - 1; }
+    [[nodiscard]] AK_ALWAYS_INLINE T top() const { return y(); }
+    [[nodiscard]] AK_ALWAYS_INLINE T bottom() const { return y() + height() - 1; }
 
-    ALWAYS_INLINE void set_left(T left)
+    AK_ALWAYS_INLINE void set_left(T left)
     {
         set_x(left);
     }
 
-    ALWAYS_INLINE void set_top(T top)
+    AK_ALWAYS_INLINE void set_top(T top)
     {
         set_y(top);
     }
 
-    ALWAYS_INLINE void set_right(T right)
+    AK_ALWAYS_INLINE void set_right(T right)
     {
         set_width(right - x() + 1);
     }
 
-    ALWAYS_INLINE void set_bottom(T bottom)
+    AK_ALWAYS_INLINE void set_bottom(T bottom)
     {
         set_height(bottom - y() + 1);
     }
@@ -470,7 +470,7 @@ public:
         return r;
     }
 
-    [[nodiscard]] ALWAYS_INLINE Rect<T> intersected(Rect<T> const& other) const
+    [[nodiscard]] AK_ALWAYS_INLINE Rect<T> intersected(Rect<T> const& other) const
     {
         return intersection(*this, other);
     }
@@ -691,7 +691,7 @@ public:
     }
 
     template<typename U>
-    [[nodiscard]] ALWAYS_INLINE Rect<U> to_type() const
+    [[nodiscard]] AK_ALWAYS_INLINE Rect<U> to_type() const
     {
         return Rect<U>(*this);
     }
@@ -706,7 +706,7 @@ private:
 using IntRect = Rect<int>;
 using FloatRect = Rect<float>;
 
-[[nodiscard]] ALWAYS_INLINE IntRect enclosing_int_rect(FloatRect const& float_rect)
+[[nodiscard]] AK_ALWAYS_INLINE IntRect enclosing_int_rect(FloatRect const& float_rect)
 {
     int x1 = floorf(float_rect.x());
     int y1 = floorf(float_rect.y());
@@ -715,7 +715,7 @@ using FloatRect = Rect<float>;
     return Gfx::IntRect::from_two_points({ x1, y1 }, { x2, y2 });
 }
 
-[[nodiscard]] ALWAYS_INLINE IntRect rounded_int_rect(FloatRect const& float_rect)
+[[nodiscard]] AK_ALWAYS_INLINE IntRect rounded_int_rect(FloatRect const& float_rect)
 {
     return IntRect { floorf(float_rect.x()), floorf(float_rect.y()), roundf(float_rect.width()), roundf(float_rect.height()) };
 }

--- a/Userland/Libraries/LibGfx/Size.h
+++ b/Userland/Libraries/LibGfx/Size.h
@@ -38,15 +38,15 @@ public:
     {
     }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr T width() const { return m_width; }
-    [[nodiscard]] ALWAYS_INLINE constexpr T height() const { return m_height; }
-    [[nodiscard]] ALWAYS_INLINE constexpr T area() const { return width() * height(); }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T width() const { return m_width; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T height() const { return m_height; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr T area() const { return width() * height(); }
 
-    ALWAYS_INLINE constexpr void set_width(T w) { m_width = w; }
-    ALWAYS_INLINE constexpr void set_height(T h) { m_height = h; }
+    AK_ALWAYS_INLINE constexpr void set_width(T w) { m_width = w; }
+    AK_ALWAYS_INLINE constexpr void set_height(T h) { m_height = h; }
 
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_null() const { return !m_width && !m_height; }
-    [[nodiscard]] ALWAYS_INLINE constexpr bool is_empty() const { return m_width <= 0 || m_height <= 0; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr bool is_null() const { return !m_width && !m_height; }
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr bool is_empty() const { return m_width <= 0 || m_height <= 0; }
 
     constexpr void scale_by(T dx, T dy)
     {
@@ -56,8 +56,8 @@ public:
 
     constexpr void transform_by(AffineTransform const& transform) { *this = transform.map(*this); }
 
-    ALWAYS_INLINE constexpr void scale_by(T dboth) { scale_by(dboth, dboth); }
-    ALWAYS_INLINE constexpr void scale_by(Point<T> const& s) { scale_by(s.x(), s.y()); }
+    AK_ALWAYS_INLINE constexpr void scale_by(T dboth) { scale_by(dboth, dboth); }
+    AK_ALWAYS_INLINE constexpr void scale_by(Point<T> const& s) { scale_by(s.x(), s.y()); }
 
     [[nodiscard]] constexpr Size scaled_by(T dx, T dy) const
     {
@@ -157,7 +157,7 @@ public:
     }
 
     template<typename U>
-    [[nodiscard]] ALWAYS_INLINE constexpr Size<U> to_type() const
+    [[nodiscard]] AK_ALWAYS_INLINE constexpr Size<U> to_type() const
     {
         return Size<U>(*this);
     }

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
@@ -504,7 +504,7 @@ int ScaledFont::width(Utf8View const& view) const { return unicode_view_width(vi
 int ScaledFont::width(Utf32View const& view) const { return unicode_view_width(view); }
 
 template<typename T>
-ALWAYS_INLINE int ScaledFont::unicode_view_width(T const& view) const
+AK_ALWAYS_INLINE int ScaledFont::unicode_view_width(T const& view) const
 {
     if (view.is_empty())
         return 0;

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -130,7 +130,7 @@ public:
 
     Instruction const& operator*() const { return dereference(); }
 
-    ALWAYS_INLINE void operator++()
+    AK_ALWAYS_INLINE void operator++()
     {
         VERIFY(!at_end());
         m_offset += dereference().length();

--- a/Userland/Libraries/LibJS/Bytecode/Interpreter.h
+++ b/Userland/Libraries/LibJS/Bytecode/Interpreter.h
@@ -48,7 +48,7 @@ public:
     };
     ValueAndFrame run_and_return_frame(Bytecode::Executable const&, Bytecode::BasicBlock const* entry_point);
 
-    ALWAYS_INLINE Value& accumulator() { return reg(Register::accumulator()); }
+    AK_ALWAYS_INLINE Value& accumulator() { return reg(Register::accumulator()); }
     Value& reg(Register const& r) { return registers()[r.index()]; }
     [[nodiscard]] RegisterWindow snapshot_frame() const { return m_register_windows.last(); }
 

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -830,7 +830,7 @@ public:
 
 namespace JS::Bytecode {
 
-ALWAYS_INLINE ThrowCompletionOr<void> Instruction::execute(Bytecode::Interpreter& interpreter) const
+AK_ALWAYS_INLINE ThrowCompletionOr<void> Instruction::execute(Bytecode::Interpreter& interpreter) const
 {
 #define __BYTECODE_OP(op)       \
     case Instruction::Type::op: \
@@ -845,7 +845,7 @@ ALWAYS_INLINE ThrowCompletionOr<void> Instruction::execute(Bytecode::Interpreter
 #undef __BYTECODE_OP
 }
 
-ALWAYS_INLINE void Instruction::replace_references(BasicBlock const& from, BasicBlock const& to)
+AK_ALWAYS_INLINE void Instruction::replace_references(BasicBlock const& from, BasicBlock const& to)
 {
 #define __BYTECODE_OP(op)       \
     case Instruction::Type::op: \
@@ -860,7 +860,7 @@ ALWAYS_INLINE void Instruction::replace_references(BasicBlock const& from, Basic
 #undef __BYTECODE_OP
 }
 
-ALWAYS_INLINE size_t Instruction::length() const
+AK_ALWAYS_INLINE size_t Instruction::length() const
 {
     if (type() == Type::Call)
         return static_cast<Op::Call const&>(*this).length_impl();
@@ -881,7 +881,7 @@ ALWAYS_INLINE size_t Instruction::length() const
 #undef __BYTECODE_OP
 }
 
-ALWAYS_INLINE bool Instruction::is_terminator() const
+AK_ALWAYS_INLINE bool Instruction::is_terminator() const
 {
 #define __BYTECODE_OP(op) \
     case Type::op:        \

--- a/Userland/Libraries/LibJS/Heap/Heap.cpp
+++ b/Userland/Libraries/LibJS/Heap/Heap.cpp
@@ -57,7 +57,7 @@ Heap::~Heap()
     collect_garbage(CollectionType::CollectEverything);
 }
 
-ALWAYS_INLINE CellAllocator& Heap::allocator_for_size(size_t cell_size)
+AK_ALWAYS_INLINE CellAllocator& Heap::allocator_for_size(size_t cell_size)
 {
     for (auto& allocator : m_allocators) {
         if (allocator->cell_size() >= cell_size)

--- a/Userland/Libraries/LibJS/Heap/HeapBlock.h
+++ b/Userland/Libraries/LibJS/Heap/HeapBlock.h
@@ -31,7 +31,7 @@ public:
     size_t cell_count() const { return (block_size - sizeof(HeapBlock)) / m_cell_size; }
     bool is_full() const { return !has_lazy_freelist() && !m_freelist; }
 
-    ALWAYS_INLINE Cell* allocate()
+    AK_ALWAYS_INLINE Cell* allocate()
     {
         Cell* allocated_cell = nullptr;
         if (m_freelist) {

--- a/Userland/Libraries/LibJS/Interpreter.h
+++ b/Userland/Libraries/LibJS/Interpreter.h
@@ -112,9 +112,9 @@ public:
     Realm& realm();
     Realm const& realm() const;
 
-    ALWAYS_INLINE VM& vm() { return *m_vm; }
-    ALWAYS_INLINE const VM& vm() const { return *m_vm; }
-    ALWAYS_INLINE Heap& heap() { return vm().heap(); }
+    AK_ALWAYS_INLINE VM& vm() { return *m_vm; }
+    AK_ALWAYS_INLINE const VM& vm() const { return *m_vm; }
+    AK_ALWAYS_INLINE Heap& heap() { return vm().heap(); }
 
     Environment* lexical_environment() { return vm().lexical_environment(); }
 

--- a/Userland/Libraries/LibJS/Lexer.cpp
+++ b/Userland/Libraries/LibJS/Lexer.cpp
@@ -342,7 +342,7 @@ bool Lexer::is_eof() const
     return m_eof;
 }
 
-ALWAYS_INLINE bool Lexer::is_line_terminator() const
+AK_ALWAYS_INLINE bool Lexer::is_line_terminator() const
 {
     if (m_current_char == '\n' || m_current_char == '\r')
         return true;
@@ -353,12 +353,12 @@ ALWAYS_INLINE bool Lexer::is_line_terminator() const
     return code_point == LINE_SEPARATOR || code_point == PARAGRAPH_SEPARATOR;
 }
 
-ALWAYS_INLINE bool Lexer::is_unicode_character() const
+AK_ALWAYS_INLINE bool Lexer::is_unicode_character() const
 {
     return (m_current_char & 128) != 0;
 }
 
-ALWAYS_INLINE u32 Lexer::current_code_point() const
+AK_ALWAYS_INLINE u32 Lexer::current_code_point() const
 {
     static constexpr const u32 REPLACEMENT_CHARACTER = 0xFFFD;
     if (m_position == 0)

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -61,18 +61,18 @@ ThrowCompletionOr<Value> perform_eval(Value, GlobalObject&, CallerMode, EvalMode
 ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, GlobalObject& global_object, Program const& program, Environment* variable_environment, Environment* lexical_environment, PrivateEnvironment* private_environment, bool strict);
 
 // 7.3.14 Call ( F, V [ , argumentsList ] ), https://tc39.es/ecma262/#sec-call
-ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Value function, Value this_value, MarkedVector<Value> arguments_list)
+AK_ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Value function, Value this_value, MarkedVector<Value> arguments_list)
 {
     return call_impl(global_object, function, this_value, move(arguments_list));
 }
 
-ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Value function, Value this_value, Optional<MarkedVector<Value>> arguments_list)
+AK_ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Value function, Value this_value, Optional<MarkedVector<Value>> arguments_list)
 {
     return call_impl(global_object, function, this_value, move(arguments_list));
 }
 
 template<typename... Args>
-ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Value function, Value this_value, Args&&... args)
+AK_ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Value function, Value this_value, Args&&... args)
 {
     if constexpr (sizeof...(Args) > 0) {
         MarkedVector<Value> arguments_list { global_object.heap() };
@@ -83,18 +83,18 @@ ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Value f
     return call_impl(global_object, function, this_value);
 }
 
-ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, FunctionObject& function, Value this_value, MarkedVector<Value> arguments_list)
+AK_ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, FunctionObject& function, Value this_value, MarkedVector<Value> arguments_list)
 {
     return call_impl(global_object, function, this_value, move(arguments_list));
 }
 
-ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, FunctionObject& function, Value this_value, Optional<MarkedVector<Value>> arguments_list)
+AK_ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, FunctionObject& function, Value this_value, Optional<MarkedVector<Value>> arguments_list)
 {
     return call_impl(global_object, function, this_value, move(arguments_list));
 }
 
 template<typename... Args>
-ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, FunctionObject& function, Value this_value, Args&&... args)
+AK_ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, FunctionObject& function, Value this_value, Args&&... args)
 {
     if constexpr (sizeof...(Args) > 0) {
         MarkedVector<Value> arguments_list { global_object.heap() };
@@ -107,7 +107,7 @@ ALWAYS_INLINE ThrowCompletionOr<Value> call(GlobalObject& global_object, Functio
 
 // 7.3.15 Construct ( F [ , argumentsList [ , newTarget ] ] ), https://tc39.es/ecma262/#sec-construct
 template<typename... Args>
-ALWAYS_INLINE ThrowCompletionOr<Object*> construct(GlobalObject& global_object, FunctionObject& function, Args&&... args)
+AK_ALWAYS_INLINE ThrowCompletionOr<Object*> construct(GlobalObject& global_object, FunctionObject& function, Args&&... args)
 {
     if constexpr (sizeof...(Args) > 0) {
         MarkedVector<Value> arguments_list { global_object.heap() };
@@ -118,12 +118,12 @@ ALWAYS_INLINE ThrowCompletionOr<Object*> construct(GlobalObject& global_object, 
     return construct_impl(global_object, function);
 }
 
-ALWAYS_INLINE ThrowCompletionOr<Object*> construct(GlobalObject& global_object, FunctionObject& function, MarkedVector<Value> arguments_list, FunctionObject* new_target = nullptr)
+AK_ALWAYS_INLINE ThrowCompletionOr<Object*> construct(GlobalObject& global_object, FunctionObject& function, MarkedVector<Value> arguments_list, FunctionObject* new_target = nullptr)
 {
     return construct_impl(global_object, function, move(arguments_list), new_target);
 }
 
-ALWAYS_INLINE ThrowCompletionOr<Object*> construct(GlobalObject& global_object, FunctionObject& function, Optional<MarkedVector<Value>> arguments_list, FunctionObject* new_target = nullptr)
+AK_ALWAYS_INLINE ThrowCompletionOr<Object*> construct(GlobalObject& global_object, FunctionObject& function, Optional<MarkedVector<Value>> arguments_list, FunctionObject* new_target = nullptr)
 {
     return construct_impl(global_object, function, move(arguments_list), new_target);
 }

--- a/Userland/Libraries/LibJS/Runtime/Completion.h
+++ b/Userland/Libraries/LibJS/Runtime/Completion.h
@@ -26,7 +26,7 @@ public:
         Throw,
     };
 
-    ALWAYS_INLINE Completion(Type type, Optional<Value> value, Optional<FlyString> target)
+    AK_ALWAYS_INLINE Completion(Type type, Optional<Value> value, Optional<FlyString> target)
         : m_type(type)
         , m_value(move(value))
         , m_target(move(target))
@@ -39,12 +39,12 @@ public:
 
     // 5.2.3.1 Implicit Completion Values, https://tc39.es/ecma262/#sec-implicit-completion-values
     // Not `explicit` on purpose.
-    ALWAYS_INLINE Completion(Value value)
+    AK_ALWAYS_INLINE Completion(Value value)
         : Completion(Type::Normal, value, {})
     {
     }
 
-    ALWAYS_INLINE Completion()
+    AK_ALWAYS_INLINE Completion()
         : Completion(js_undefined())
     {
     }

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.h
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.h
@@ -170,7 +170,7 @@ template<>
 inline bool Object::fast_is<GlobalObject>() const { return is_global_object(); }
 
 template<typename... Args>
-[[nodiscard]] ALWAYS_INLINE ThrowCompletionOr<Value> Value::invoke(GlobalObject& global_object, PropertyKey const& property_key, Args... args)
+[[nodiscard]] AK_ALWAYS_INLINE ThrowCompletionOr<Value> Value::invoke(GlobalObject& global_object, PropertyKey const& property_key, Args... args)
 {
     if constexpr (sizeof...(Args) > 0) {
         MarkedVector<Value> arglist { global_object.vm().heap() };

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -249,7 +249,7 @@ StringView NumberFormat::sign_display_string() const
     }
 }
 
-static ALWAYS_INLINE int log10floor(Value number)
+static AK_ALWAYS_INLINE int log10floor(Value number)
 {
     if (number.is_number())
         return static_cast<int>(floor(log10(number.as_double())));
@@ -277,56 +277,56 @@ static Value divide(GlobalObject& global_object, Value lhs, i64 rhs)
     return js_bigint(global_object.vm(), lhs.as_bigint().big_integer().divided_by(rhs_bigint).quotient);
 }
 
-static ALWAYS_INLINE Value multiply_by_power(GlobalObject& global_object, Value number, i64 exponent)
+static AK_ALWAYS_INLINE Value multiply_by_power(GlobalObject& global_object, Value number, i64 exponent)
 {
     if (exponent < 0)
         return divide(global_object, number, pow(10, -exponent));
     return multiply(global_object, number, pow(10, exponent));
 }
 
-static ALWAYS_INLINE Value divide_by_power(GlobalObject& global_object, Value number, i64 exponent)
+static AK_ALWAYS_INLINE Value divide_by_power(GlobalObject& global_object, Value number, i64 exponent)
 {
     if (exponent < 0)
         return multiply(global_object, number, pow(10, -exponent));
     return divide(global_object, number, pow(10, exponent));
 }
 
-static ALWAYS_INLINE Value rounded(Value number)
+static AK_ALWAYS_INLINE Value rounded(Value number)
 {
     if (number.is_number())
         return Value(round(number.as_double()));
     return number;
 }
 
-static ALWAYS_INLINE bool is_zero(Value number)
+static AK_ALWAYS_INLINE bool is_zero(Value number)
 {
     if (number.is_number())
         return number.as_double() == 0.0;
     return number.as_bigint().big_integer() == Crypto::SignedBigInteger::create_from(0);
 }
 
-static ALWAYS_INLINE bool is_greater_than(Value number, i64 rhs)
+static AK_ALWAYS_INLINE bool is_greater_than(Value number, i64 rhs)
 {
     if (number.is_number())
         return number.as_double() > rhs;
     return number.as_bigint().big_integer() > Crypto::SignedBigInteger::create_from(rhs);
 }
 
-static ALWAYS_INLINE bool is_greater_than_or_equal(Value number, i64 rhs)
+static AK_ALWAYS_INLINE bool is_greater_than_or_equal(Value number, i64 rhs)
 {
     if (number.is_number())
         return number.as_double() >= rhs;
     return number.as_bigint().big_integer() >= Crypto::SignedBigInteger::create_from(rhs);
 }
 
-static ALWAYS_INLINE bool is_less_than(Value number, i64 rhs)
+static AK_ALWAYS_INLINE bool is_less_than(Value number, i64 rhs)
 {
     if (number.is_number())
         return number.as_double() < rhs;
     return number.as_bigint().big_integer() < Crypto::SignedBigInteger::create_from(rhs);
 }
 
-static ALWAYS_INLINE String number_to_string(Value number)
+static AK_ALWAYS_INLINE String number_to_string(Value number)
 {
     if (number.is_number())
         return number.to_string_without_side_effects();

--- a/Userland/Libraries/LibJS/Runtime/PropertyKey.h
+++ b/Userland/Libraries/LibJS/Runtime/PropertyKey.h
@@ -96,7 +96,7 @@ public:
         }
     }
 
-    ALWAYS_INLINE Type type() const { return m_type; }
+    AK_ALWAYS_INLINE Type type() const { return m_type; }
 
     bool is_valid() const { return m_type != Type::Invalid; }
     bool is_number() const

--- a/Userland/Libraries/LibJS/Runtime/StringOrSymbol.h
+++ b/Userland/Libraries/LibJS/Runtime/StringOrSymbol.h
@@ -58,17 +58,17 @@ public:
         m_ptr = exchange(other.m_ptr, nullptr);
     }
 
-    ALWAYS_INLINE bool is_valid() const { return m_ptr != nullptr; }
-    ALWAYS_INLINE bool is_symbol() const { return is_valid() && (bits() & 1ul); }
-    ALWAYS_INLINE bool is_string() const { return is_valid() && !(bits() & 1ul); }
+    AK_ALWAYS_INLINE bool is_valid() const { return m_ptr != nullptr; }
+    AK_ALWAYS_INLINE bool is_symbol() const { return is_valid() && (bits() & 1ul); }
+    AK_ALWAYS_INLINE bool is_string() const { return is_valid() && !(bits() & 1ul); }
 
-    ALWAYS_INLINE FlyString as_string() const
+    AK_ALWAYS_INLINE FlyString as_string() const
     {
         VERIFY(is_string());
         return FlyString::from_fly_impl(as_string_impl());
     }
 
-    ALWAYS_INLINE Symbol const* as_symbol() const
+    AK_ALWAYS_INLINE Symbol const* as_symbol() const
     {
         VERIFY(is_symbol());
         return reinterpret_cast<Symbol const*>(bits() & ~1ul);
@@ -98,7 +98,7 @@ public:
             visitor.visit(const_cast<Symbol*>(as_symbol()));
     }
 
-    ALWAYS_INLINE bool operator==(StringOrSymbol const& other) const
+    AK_ALWAYS_INLINE bool operator==(StringOrSymbol const& other) const
     {
         if (is_string())
             return other.is_string() && &as_string_impl() == &other.as_string_impl();
@@ -132,17 +132,17 @@ public:
     }
 
 private:
-    ALWAYS_INLINE u64 bits() const
+    AK_ALWAYS_INLINE u64 bits() const
     {
         return reinterpret_cast<uintptr_t>(m_ptr);
     }
 
-    ALWAYS_INLINE void set_symbol_flag()
+    AK_ALWAYS_INLINE void set_symbol_flag()
     {
         m_ptr = reinterpret_cast<void const*>(bits() | 1ul);
     }
 
-    ALWAYS_INLINE StringImpl const& as_string_impl() const
+    AK_ALWAYS_INLINE StringImpl const& as_string_impl() const
     {
         VERIFY(is_string());
         return *reinterpret_cast<StringImpl const*>(m_ptr);

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -289,12 +289,12 @@ private:
     OwnPtr<CustomData> m_custom_data;
 };
 
-ALWAYS_INLINE Heap& Cell::heap() const
+AK_ALWAYS_INLINE Heap& Cell::heap() const
 {
     return HeapBlock::from_cell(this)->heap();
 }
 
-ALWAYS_INLINE VM& Cell::vm() const
+AK_ALWAYS_INLINE VM& Cell::vm() const
 {
     return heap().vm();
 }

--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -50,12 +50,12 @@ static inline bool same_type_for_equality(const Value& lhs, const Value& rhs)
 
 static const Crypto::SignedBigInteger BIGINT_ZERO { 0 };
 
-ALWAYS_INLINE bool both_number(const Value& lhs, const Value& rhs)
+AK_ALWAYS_INLINE bool both_number(const Value& lhs, const Value& rhs)
 {
     return lhs.is_number() && rhs.is_number();
 }
 
-ALWAYS_INLINE bool both_bigint(const Value& lhs, const Value& rhs)
+AK_ALWAYS_INLINE bool both_bigint(const Value& lhs, const Value& rhs)
 {
     return lhs.is_bigint() && rhs.is_bigint();
 }

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -346,7 +346,7 @@ public:
     bool operator==(Value const&) const;
 
     template<typename... Args>
-    [[nodiscard]] ALWAYS_INLINE ThrowCompletionOr<Value> invoke(GlobalObject& global_object, PropertyKey const& property_key, Args... args);
+    [[nodiscard]] AK_ALWAYS_INLINE ThrowCompletionOr<Value> invoke(GlobalObject& global_object, PropertyKey const& property_key, Args... args);
 
 private:
     Type m_type { Type::Empty };

--- a/Userland/Libraries/LibPDF/Command.h
+++ b/Userland/Libraries/LibPDF/Command.h
@@ -152,8 +152,8 @@ public:
     {
     }
 
-    [[nodiscard]] ALWAYS_INLINE CommandType command_type() const { return m_command_type; }
-    [[nodiscard]] ALWAYS_INLINE Vector<Value> const& arguments() const { return m_arguments; }
+    [[nodiscard]] AK_ALWAYS_INLINE CommandType command_type() const { return m_command_type; }
+    [[nodiscard]] AK_ALWAYS_INLINE Vector<Value> const& arguments() const { return m_arguments; }
 
 private:
     CommandType m_command_type;

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -78,7 +78,7 @@ class Document final
 public:
     static PDFErrorOr<NonnullRefPtr<Document>> create(ReadonlyBytes bytes);
 
-    ALWAYS_INLINE RefPtr<OutlineDict> const& outline() const { return m_outline; }
+    AK_ALWAYS_INLINE RefPtr<OutlineDict> const& outline() const { return m_outline; }
 
     [[nodiscard]] PDFErrorOr<Value> get_or_load_value(u32 index);
 
@@ -88,7 +88,7 @@ public:
 
     [[nodiscard]] PDFErrorOr<Page> get_page(u32 index);
 
-    ALWAYS_INLINE Value get_value(u32 index) const
+    AK_ALWAYS_INLINE Value get_value(u32 index) const
     {
         return m_values.get(index).value_or({});
     }

--- a/Userland/Libraries/LibPDF/Object.h
+++ b/Userland/Libraries/LibPDF/Object.h
@@ -40,8 +40,8 @@ class Object : public RefCounted<Object> {
 public:
     virtual ~Object() = default;
 
-    [[nodiscard]] ALWAYS_INLINE u32 generation_index() const { return m_generation_index; }
-    ALWAYS_INLINE void set_generation_index(u32 generation_index) { m_generation_index = generation_index; }
+    [[nodiscard]] AK_ALWAYS_INLINE u32 generation_index() const { return m_generation_index; }
+    AK_ALWAYS_INLINE void set_generation_index(u32 generation_index) { m_generation_index = generation_index; }
 
     template<IsObject T>
     bool is() const requires(!IsSame<T, Object>)
@@ -57,7 +57,7 @@ public:
     }
 
     template<IsObject T>
-    [[nodiscard]] ALWAYS_INLINE NonnullRefPtr<T> cast(
+    [[nodiscard]] AK_ALWAYS_INLINE NonnullRefPtr<T> cast(
 #ifdef PDF_DEBUG
         SourceLocation loc = SourceLocation::current()
 #endif

--- a/Userland/Libraries/LibPDF/ObjectDerivatives.h
+++ b/Userland/Libraries/LibPDF/ObjectDerivatives.h
@@ -27,8 +27,8 @@ public:
 
     ~StringObject() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE String const& string() const { return m_string; }
-    [[nodiscard]] ALWAYS_INLINE bool is_binary() const { return m_is_binary; }
+    [[nodiscard]] AK_ALWAYS_INLINE String const& string() const { return m_string; }
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_binary() const { return m_is_binary; }
 
     const char* type_name() const override { return "string"; }
     String to_string(int indent) const override;
@@ -50,7 +50,7 @@ public:
 
     ~NameObject() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE FlyString const& name() const { return m_name; }
+    [[nodiscard]] AK_ALWAYS_INLINE FlyString const& name() const { return m_name; }
 
     const char* type_name() const override { return "name"; }
     String to_string(int indent) const override;
@@ -71,14 +71,14 @@ public:
 
     ~ArrayObject() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE size_t size() const { return m_elements.size(); }
-    [[nodiscard]] ALWAYS_INLINE Vector<Value> elements() const { return m_elements; }
+    [[nodiscard]] AK_ALWAYS_INLINE size_t size() const { return m_elements.size(); }
+    [[nodiscard]] AK_ALWAYS_INLINE Vector<Value> elements() const { return m_elements; }
 
-    ALWAYS_INLINE auto begin() const { return m_elements.begin(); }
-    ALWAYS_INLINE auto end() const { return m_elements.end(); }
+    AK_ALWAYS_INLINE auto begin() const { return m_elements.begin(); }
+    AK_ALWAYS_INLINE auto end() const { return m_elements.end(); }
 
-    ALWAYS_INLINE Value const& operator[](size_t index) const { return at(index); }
-    ALWAYS_INLINE Value const& at(size_t index) const { return m_elements[index]; }
+    AK_ALWAYS_INLINE Value const& operator[](size_t index) const { return at(index); }
+    AK_ALWAYS_INLINE Value const& at(size_t index) const { return m_elements[index]; }
 
 #define DEFINE_INDEXER(class_name, snake_name) \
     PDFErrorOr<NonnullRefPtr<class_name>> get_##snake_name##_at(Document*, size_t index) const;
@@ -107,12 +107,12 @@ public:
 
     ~DictObject() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE HashMap<FlyString, Value> const& map() const { return m_map; }
+    [[nodiscard]] AK_ALWAYS_INLINE HashMap<FlyString, Value> const& map() const { return m_map; }
 
     template<typename... Args>
     bool contains(Args&&... keys) const { return (m_map.contains(keys) && ...); }
 
-    ALWAYS_INLINE Optional<Value> get(FlyString const& key) const { return m_map.get(key); }
+    AK_ALWAYS_INLINE Optional<Value> get(FlyString const& key) const { return m_map.get(key); }
 
     Value get_value(FlyString const& key) const
     {
@@ -150,7 +150,7 @@ public:
 
     virtual ~StreamObject() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE NonnullRefPtr<DictObject> dict() const { return m_dict; }
+    [[nodiscard]] AK_ALWAYS_INLINE NonnullRefPtr<DictObject> dict() const { return m_dict; }
     [[nodiscard]] virtual ReadonlyBytes bytes() const = 0;
 
     const char* type_name() const override { return "stream"; }
@@ -173,7 +173,7 @@ public:
 
     virtual ~PlainTextStreamObject() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE virtual ReadonlyBytes bytes() const override { return m_bytes; }
+    [[nodiscard]] AK_ALWAYS_INLINE virtual ReadonlyBytes bytes() const override { return m_bytes; }
 
 private:
     ReadonlyBytes m_bytes;
@@ -189,7 +189,7 @@ public:
 
     virtual ~EncodedStreamObject() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE virtual ReadonlyBytes bytes() const override { return m_buffer.bytes(); }
+    [[nodiscard]] AK_ALWAYS_INLINE virtual ReadonlyBytes bytes() const override { return m_buffer.bytes(); }
 
 private:
     ByteBuffer m_buffer;
@@ -206,8 +206,8 @@ public:
 
     ~IndirectValue() override = default;
 
-    [[nodiscard]] ALWAYS_INLINE u32 index() const { return m_index; }
-    [[nodiscard]] ALWAYS_INLINE Value const& value() const { return m_value; }
+    [[nodiscard]] AK_ALWAYS_INLINE u32 index() const { return m_index; }
+    [[nodiscard]] AK_ALWAYS_INLINE Value const& value() const { return m_value; }
 
     const char* type_name() const override { return "indirect_object"; }
     String to_string(int indent) const override;

--- a/Userland/Libraries/LibPDF/Parser.h
+++ b/Userland/Libraries/LibPDF/Parser.h
@@ -29,7 +29,7 @@ public:
 
     Parser(Badge<Document>, ReadonlyBytes);
 
-    [[nodiscard]] ALWAYS_INLINE RefPtr<DictObject> const& trailer() const { return m_trailer; }
+    [[nodiscard]] AK_ALWAYS_INLINE RefPtr<DictObject> const& trailer() const { return m_trailer; }
     void set_document(WeakPtr<Document> const&);
 
     // Parses the header and initializes the xref table and trailer

--- a/Userland/Libraries/LibPDF/Reader.h
+++ b/Userland/Libraries/LibPDF/Reader.h
@@ -22,8 +22,8 @@ public:
     {
     }
 
-    ALWAYS_INLINE ReadonlyBytes bytes() const { return m_bytes; }
-    ALWAYS_INLINE size_t offset() const { return m_offset; }
+    AK_ALWAYS_INLINE ReadonlyBytes bytes() const { return m_bytes; }
+    AK_ALWAYS_INLINE size_t offset() const { return m_offset; }
 
     bool done() const
     {
@@ -115,17 +115,17 @@ public:
             move_by(1);
     }
 
-    ALWAYS_INLINE void move_while(Function<bool(char)> predicate)
+    AK_ALWAYS_INLINE void move_while(Function<bool(char)> predicate)
     {
         move_until([&predicate](char t) { return !predicate(t); });
     }
 
-    ALWAYS_INLINE void set_reading_forwards() { m_forwards = true; }
-    ALWAYS_INLINE void set_reading_backwards() { m_forwards = false; }
+    AK_ALWAYS_INLINE void set_reading_forwards() { m_forwards = true; }
+    AK_ALWAYS_INLINE void set_reading_backwards() { m_forwards = false; }
 
-    ALWAYS_INLINE void save() { m_saved_offsets.append(m_offset); }
-    ALWAYS_INLINE void load() { m_offset = m_saved_offsets.take_last(); }
-    ALWAYS_INLINE void discard() { m_saved_offsets.take_last(); }
+    AK_ALWAYS_INLINE void save() { m_saved_offsets.append(m_offset); }
+    AK_ALWAYS_INLINE void load() { m_offset = m_saved_offsets.take_last(); }
+    AK_ALWAYS_INLINE void discard() { m_saved_offsets.take_last(); }
 
 #ifdef PDF_DEBUG
     void dump_state() const

--- a/Userland/Libraries/LibPDF/Reference.h
+++ b/Userland/Libraries/LibPDF/Reference.h
@@ -28,12 +28,12 @@ public:
         m_combined = (generation_index << 14) | index;
     }
 
-    [[nodiscard]] ALWAYS_INLINE u32 as_ref_index() const
+    [[nodiscard]] AK_ALWAYS_INLINE u32 as_ref_index() const
     {
         return m_combined & 0x3ffff;
     }
 
-    [[nodiscard]] ALWAYS_INLINE u32 as_ref_generation_index() const
+    [[nodiscard]] AK_ALWAYS_INLINE u32 as_ref_generation_index() const
     {
         return m_combined >> 18;
     }

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -99,19 +99,19 @@ private:
     void show_text(String const&, float shift = 0.0f);
     PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space(Value const&);
 
-    ALWAYS_INLINE GraphicsState const& state() const { return m_graphics_state_stack.last(); }
-    ALWAYS_INLINE GraphicsState& state() { return m_graphics_state_stack.last(); }
-    ALWAYS_INLINE TextState const& text_state() const { return state().text_state; }
-    ALWAYS_INLINE TextState& text_state() { return state().text_state; }
+    AK_ALWAYS_INLINE GraphicsState const& state() const { return m_graphics_state_stack.last(); }
+    AK_ALWAYS_INLINE GraphicsState& state() { return m_graphics_state_stack.last(); }
+    AK_ALWAYS_INLINE TextState const& text_state() const { return state().text_state; }
+    AK_ALWAYS_INLINE TextState& text_state() { return state().text_state; }
 
     template<typename T>
-    ALWAYS_INLINE Gfx::Point<T> map(T x, T y) const;
+    AK_ALWAYS_INLINE Gfx::Point<T> map(T x, T y) const;
 
     template<typename T>
-    ALWAYS_INLINE Gfx::Size<T> map(Gfx::Size<T>) const;
+    AK_ALWAYS_INLINE Gfx::Size<T> map(Gfx::Size<T>) const;
 
     template<typename T>
-    ALWAYS_INLINE Gfx::Rect<T> map(Gfx::Rect<T>) const;
+    AK_ALWAYS_INLINE Gfx::Rect<T> map(Gfx::Rect<T>) const;
 
     Gfx::AffineTransform const& calculate_text_rendering_matrix();
 

--- a/Userland/Libraries/LibPDF/Value.h
+++ b/Userland/Libraries/LibPDF/Value.h
@@ -37,50 +37,50 @@ public:
 
     [[nodiscard]] String to_string(int indent = 0) const;
 
-    [[nodiscard]] ALWAYS_INLINE bool has_number() const { return has<int>() || has<float>(); }
+    [[nodiscard]] AK_ALWAYS_INLINE bool has_number() const { return has<int>() || has<float>(); }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_u32() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool has_u32() const
     {
         return has<int>() && get<int>() >= 0;
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_u16() const
+    [[nodiscard]] AK_ALWAYS_INLINE bool has_u16() const
     {
         return has<int>() && get<int>() >= 0 && get<int>() < 65536;
     }
 
-    [[nodiscard]] ALWAYS_INLINE u32 get_u32() const
+    [[nodiscard]] AK_ALWAYS_INLINE u32 get_u32() const
     {
         VERIFY(has_u32());
         return get<int>();
     }
 
-    [[nodiscard]] ALWAYS_INLINE u16 get_u16() const
+    [[nodiscard]] AK_ALWAYS_INLINE u16 get_u16() const
     {
         VERIFY(has_u16());
         return get<int>();
     }
 
-    [[nodiscard]] ALWAYS_INLINE int to_int() const
+    [[nodiscard]] AK_ALWAYS_INLINE int to_int() const
     {
         if (has<int>())
             return get<int>();
         return static_cast<int>(get<float>());
     }
 
-    [[nodiscard]] ALWAYS_INLINE float to_float() const
+    [[nodiscard]] AK_ALWAYS_INLINE float to_float() const
     {
         if (has<float>())
             return get<float>();
         return static_cast<float>(get<int>());
     }
 
-    [[nodiscard]] ALWAYS_INLINE u32 as_ref_index() const
+    [[nodiscard]] AK_ALWAYS_INLINE u32 as_ref_index() const
     {
         return get<Reference>().as_ref_index();
     }
 
-    [[nodiscard]] ALWAYS_INLINE u32 as_ref_generation_index() const
+    [[nodiscard]] AK_ALWAYS_INLINE u32 as_ref_generation_index() const
     {
         return get<Reference>().as_ref_generation_index();
     }

--- a/Userland/Libraries/LibPDF/XRefTable.h
+++ b/Userland/Libraries/LibPDF/XRefTable.h
@@ -66,24 +66,24 @@ public:
             m_entries.append(entry);
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool has_object(size_t index) const
+    [[nodiscard]] AK_ALWAYS_INLINE bool has_object(size_t index) const
     {
         return index < m_entries.size() && m_entries[index].byte_offset != -1;
     }
 
-    [[nodiscard]] ALWAYS_INLINE long byte_offset_for_object(size_t index) const
+    [[nodiscard]] AK_ALWAYS_INLINE long byte_offset_for_object(size_t index) const
     {
         VERIFY(has_object(index));
         return m_entries[index].byte_offset;
     }
 
-    [[nodiscard]] ALWAYS_INLINE u16 generation_number_for_object(size_t index) const
+    [[nodiscard]] AK_ALWAYS_INLINE u16 generation_number_for_object(size_t index) const
     {
         VERIFY(has_object(index));
         return m_entries[index].generation_number;
     }
 
-    [[nodiscard]] ALWAYS_INLINE bool is_object_in_use(size_t index) const
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_object_in_use(size_t index) const
     {
         VERIFY(has_object(index));
         return m_entries[index].in_use;

--- a/Userland/Libraries/LibRegex/RegexByteCode.cpp
+++ b/Userland/Libraries/LibRegex/RegexByteCode.cpp
@@ -176,7 +176,7 @@ void ByteCode::ensure_opcodes_initialized()
     s_opcodes_initialized = true;
 }
 
-ALWAYS_INLINE OpCode& ByteCode::get_opcode_by_id(OpCodeId id) const
+AK_ALWAYS_INLINE OpCode& ByteCode::get_opcode_by_id(OpCodeId id) const
 {
     VERIFY(id >= OpCodeId::First && id <= OpCodeId::Last);
 
@@ -198,7 +198,7 @@ OpCode& ByteCode::get_opcode(MatchState& state) const
     return opcode;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(MatchInput const& input, MatchState& state) const
 {
     if (state.string_position > input.view.length() || state.instruction_position >= m_bytecode->size())
         return ExecutionResult::Succeeded;
@@ -206,21 +206,21 @@ ALWAYS_INLINE ExecutionResult OpCode_Exit::execute(MatchInput const& input, Matc
     return ExecutionResult::Failed;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Save::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_Save::execute(MatchInput const& input, MatchState& state) const
 {
     save_string_position(input, state);
     state.forks_since_last_save = 0;
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Restore::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_Restore::execute(MatchInput const& input, MatchState& state) const
 {
     if (!restore_string_position(input, state))
         return ExecutionResult::Failed;
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(MatchInput const& input, MatchState& state) const
 {
     if (count() > state.string_position)
         return ExecutionResult::Failed_ExecuteLowPrioForks;
@@ -229,26 +229,26 @@ ALWAYS_INLINE ExecutionResult OpCode_GoBack::execute(MatchInput const& input, Ma
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_FailForks::execute(MatchInput const& input, MatchState& state) const
 {
     input.fail_counter += state.forks_since_last_save;
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Jump::execute(MatchInput const&, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_Jump::execute(MatchInput const&, MatchState& state) const
 {
     state.instruction_position += offset();
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ForkJump::execute(MatchInput const&, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_ForkJump::execute(MatchInput const&, MatchState& state) const
 {
     state.fork_at_position = state.instruction_position + size() + offset();
     state.forks_since_last_save++;
     return ExecutionResult::Fork_PrioHigh;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ForkReplaceJump::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_ForkReplaceJump::execute(MatchInput const& input, MatchState& state) const
 {
     state.fork_at_position = state.instruction_position + size() + offset();
     input.fork_to_replace = state.instruction_position;
@@ -256,14 +256,14 @@ ALWAYS_INLINE ExecutionResult OpCode_ForkReplaceJump::execute(MatchInput const& 
     return ExecutionResult::Fork_PrioHigh;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ForkStay::execute(MatchInput const&, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_ForkStay::execute(MatchInput const&, MatchState& state) const
 {
     state.fork_at_position = state.instruction_position + size() + offset();
     state.forks_since_last_save++;
     return ExecutionResult::Fork_PrioLow;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ForkReplaceStay::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_ForkReplaceStay::execute(MatchInput const& input, MatchState& state) const
 {
     state.fork_at_position = state.instruction_position + size() + offset();
     input.fork_to_replace = state.instruction_position;
@@ -271,7 +271,7 @@ ALWAYS_INLINE ExecutionResult OpCode_ForkReplaceStay::execute(MatchInput const& 
     return ExecutionResult::Fork_PrioLow;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(MatchInput const& input, MatchState& state) const
 {
     auto is_at_line_boundary = [&] {
         if (state.string_position == 0)
@@ -295,7 +295,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckBegin::execute(MatchInput const& input
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(MatchInput const& input, MatchState& state) const
 {
     auto isword = [](auto ch) { return is_ascii_alphanumeric(ch) || ch == '_'; };
     auto is_word_boundary = [&] {
@@ -324,7 +324,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckBoundary::execute(MatchInput const& in
     VERIFY_NOT_REACHED();
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(MatchInput const& input, MatchState& state) const
 {
     auto is_at_line_boundary = [&] {
         if (state.string_position == input.view.length())
@@ -347,7 +347,7 @@ ALWAYS_INLINE ExecutionResult OpCode_CheckEnd::execute(MatchInput const& input, 
     return ExecutionResult::Failed_ExecuteLowPrioForks;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     if (input.match_index < state.capture_group_matches.size()) {
         auto& group = state.capture_group_matches[input.match_index];
@@ -360,7 +360,7 @@ ALWAYS_INLINE ExecutionResult OpCode_ClearCaptureGroup::execute(MatchInput const
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     if (input.match_index >= state.capture_group_matches.size()) {
         state.capture_group_matches.ensure_capacity(input.match_index);
@@ -380,7 +380,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveLeftCaptureGroup::execute(MatchInput co
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     auto& match = state.capture_group_matches.at(input.match_index).at(id());
     auto start_position = match.left_column;
@@ -405,7 +405,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightCaptureGroup::execute(MatchInput c
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchInput const& input, MatchState& state) const
 {
     auto& match = state.capture_group_matches.at(input.match_index).at(id());
     auto start_position = match.left_column;
@@ -430,7 +430,7 @@ ALWAYS_INLINE ExecutionResult OpCode_SaveRightNamedCaptureGroup::execute(MatchIn
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, MatchState& state) const
 {
     bool inverse { false };
     bool temporary_inverse { false };
@@ -609,7 +609,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Compare::execute(MatchInput const& input, M
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_char(MatchInput const& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched)
+AK_ALWAYS_INLINE void OpCode_Compare::compare_char(MatchInput const& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched)
 {
     if (state.string_position == input.view.length())
         return;
@@ -629,7 +629,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_char(MatchInput const& input, MatchSt
     }
 }
 
-ALWAYS_INLINE bool OpCode_Compare::compare_string(MatchInput const& input, MatchState& state, RegexStringView str, bool& had_zero_length_match)
+AK_ALWAYS_INLINE bool OpCode_Compare::compare_string(MatchInput const& input, MatchState& state, RegexStringView str, bool& had_zero_length_match)
 {
     if (state.string_position + str.length() > input.view.length()) {
         if (str.is_empty()) {
@@ -657,7 +657,7 @@ ALWAYS_INLINE bool OpCode_Compare::compare_string(MatchInput const& input, Match
     return equals;
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_character_class(MatchInput const& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched)
+AK_ALWAYS_INLINE void OpCode_Compare::compare_character_class(MatchInput const& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched)
 {
     auto is_space_or_line_terminator = [](u32 code_point) {
         static auto space_separator = Unicode::general_category_from_string("Space_Separator"sv);
@@ -775,7 +775,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_character_class(MatchInput const& inp
     }
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_character_range(MatchInput const& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched)
+AK_ALWAYS_INLINE void OpCode_Compare::compare_character_range(MatchInput const& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched)
 {
     if (input.regex_options & AllFlags::Insensitive) {
         from = to_ascii_lowercase(from);
@@ -791,7 +791,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_character_range(MatchInput const& inp
     }
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_property(MatchInput const& input, MatchState& state, Unicode::Property property, bool inverse, bool& inverse_matched)
+AK_ALWAYS_INLINE void OpCode_Compare::compare_property(MatchInput const& input, MatchState& state, Unicode::Property property, bool inverse, bool& inverse_matched)
 {
     if (state.string_position == input.view.length())
         return;
@@ -807,7 +807,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_property(MatchInput const& input, Mat
     }
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_general_category(MatchInput const& input, MatchState& state, Unicode::GeneralCategory general_category, bool inverse, bool& inverse_matched)
+AK_ALWAYS_INLINE void OpCode_Compare::compare_general_category(MatchInput const& input, MatchState& state, Unicode::GeneralCategory general_category, bool inverse, bool& inverse_matched)
 {
     if (state.string_position == input.view.length())
         return;
@@ -823,7 +823,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_general_category(MatchInput const& in
     }
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_script(MatchInput const& input, MatchState& state, Unicode::Script script, bool inverse, bool& inverse_matched)
+AK_ALWAYS_INLINE void OpCode_Compare::compare_script(MatchInput const& input, MatchState& state, Unicode::Script script, bool inverse, bool& inverse_matched)
 {
     if (state.string_position == input.view.length())
         return;
@@ -839,7 +839,7 @@ ALWAYS_INLINE void OpCode_Compare::compare_script(MatchInput const& input, Match
     }
 }
 
-ALWAYS_INLINE void OpCode_Compare::compare_script_extension(MatchInput const& input, MatchState& state, Unicode::Script script, bool inverse, bool& inverse_matched)
+AK_ALWAYS_INLINE void OpCode_Compare::compare_script_extension(MatchInput const& input, MatchState& state, Unicode::Script script, bool inverse, bool& inverse_matched)
 {
     if (state.string_position == input.view.length())
         return;
@@ -989,7 +989,7 @@ Vector<String> OpCode_Compare::variable_arguments_to_string(Optional<MatchInput>
     return result;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Repeat::execute(MatchInput const&, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_Repeat::execute(MatchInput const&, MatchState& state) const
 {
     VERIFY(count() > 0);
 
@@ -1007,7 +1007,7 @@ ALWAYS_INLINE ExecutionResult OpCode_Repeat::execute(MatchInput const&, MatchSta
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_ResetRepeat::execute(MatchInput const&, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_ResetRepeat::execute(MatchInput const&, MatchState& state) const
 {
     if (id() >= state.repetition_marks.size())
         state.repetition_marks.resize(id() + 1);
@@ -1016,13 +1016,13 @@ ALWAYS_INLINE ExecutionResult OpCode_ResetRepeat::execute(MatchInput const&, Mat
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_Checkpoint::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_Checkpoint::execute(MatchInput const& input, MatchState& state) const
 {
     input.checkpoints.set(state.instruction_position, state.string_position);
     return ExecutionResult::Continue;
 }
 
-ALWAYS_INLINE ExecutionResult OpCode_JumpNonEmpty::execute(MatchInput const& input, MatchState& state) const
+AK_ALWAYS_INLINE ExecutionResult OpCode_JumpNonEmpty::execute(MatchInput const& input, MatchState& state) const
 {
     auto current_position = state.string_position;
     auto checkpoint_ip = state.instruction_position + size() + checkpoint();

--- a/Userland/Libraries/LibRegex/RegexByteCode.h
+++ b/Userland/Libraries/LibRegex/RegexByteCode.h
@@ -513,7 +513,7 @@ private:
     }
 
     void ensure_opcodes_initialized();
-    ALWAYS_INLINE OpCode& get_opcode_by_id(OpCodeId id) const;
+    AK_ALWAYS_INLINE OpCode& get_opcode_by_id(OpCodeId id) const;
     static OwnPtr<OpCode> s_opcodes[(size_t)OpCodeId::Last + 1];
     static bool s_opcodes_initialized;
 };
@@ -546,20 +546,20 @@ public:
     virtual size_t size() const = 0;
     virtual ExecutionResult execute(MatchInput const& input, MatchState& state) const = 0;
 
-    ALWAYS_INLINE ByteCodeValueType argument(size_t offset) const
+    AK_ALWAYS_INLINE ByteCodeValueType argument(size_t offset) const
     {
         VERIFY(state().instruction_position + offset <= m_bytecode->size());
         return m_bytecode->at(state().instruction_position + 1 + offset);
     }
 
-    ALWAYS_INLINE char const* name() const;
+    AK_ALWAYS_INLINE char const* name() const;
     static char const* name(OpCodeId);
 
-    ALWAYS_INLINE void set_state(MatchState& state) { m_state = &state; }
+    AK_ALWAYS_INLINE void set_state(MatchState& state) { m_state = &state; }
 
-    ALWAYS_INLINE void set_bytecode(ByteCode& bytecode) { m_bytecode = &bytecode; }
+    AK_ALWAYS_INLINE void set_bytecode(ByteCode& bytecode) { m_bytecode = &bytecode; }
 
-    ALWAYS_INLINE MatchState const& state() const
+    AK_ALWAYS_INLINE MatchState const& state() const
     {
         VERIFY(m_state);
         return *m_state;
@@ -572,7 +572,7 @@ public:
 
     virtual String arguments_string() const = 0;
 
-    ALWAYS_INLINE ByteCode const& bytecode() const { return *m_bytecode; }
+    AK_ALWAYS_INLINE ByteCode const& bytecode() const { return *m_bytecode; }
 
 protected:
     ByteCode* m_bytecode { nullptr };
@@ -582,50 +582,50 @@ protected:
 class OpCode_Exit final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Exit; }
-    ALWAYS_INLINE size_t size() const override { return 1; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Exit; }
+    AK_ALWAYS_INLINE size_t size() const override { return 1; }
     String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_FailForks final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::FailForks; }
-    ALWAYS_INLINE size_t size() const override { return 1; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::FailForks; }
+    AK_ALWAYS_INLINE size_t size() const override { return 1; }
     String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_Save final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Save; }
-    ALWAYS_INLINE size_t size() const override { return 1; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Save; }
+    AK_ALWAYS_INLINE size_t size() const override { return 1; }
     String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_Restore final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Restore; }
-    ALWAYS_INLINE size_t size() const override { return 1; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Restore; }
+    AK_ALWAYS_INLINE size_t size() const override { return 1; }
     String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_GoBack final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::GoBack; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE size_t count() const { return argument(0); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::GoBack; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE size_t count() const { return argument(0); }
     String arguments_string() const override { return String::formatted("count={}", count()); }
 };
 
 class OpCode_Jump final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Jump; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE ssize_t offset() const { return argument(0); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Jump; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE ssize_t offset() const { return argument(0); }
     String arguments_string() const override
     {
         return String::formatted("offset={} [&{}]", offset(), state().instruction_position + size() + offset());
@@ -635,9 +635,9 @@ public:
 class OpCode_ForkJump : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkJump; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE ssize_t offset() const { return argument(0); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkJump; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE ssize_t offset() const { return argument(0); }
     String arguments_string() const override
     {
         return String::formatted("offset={} [&{}], sp: {}", offset(), state().instruction_position + size() + offset(), state().string_position);
@@ -647,15 +647,15 @@ public:
 class OpCode_ForkReplaceJump final : public OpCode_ForkJump {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkReplaceJump; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkReplaceJump; }
 };
 
 class OpCode_ForkStay : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkStay; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE ssize_t offset() const { return argument(0); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkStay; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE ssize_t offset() const { return argument(0); }
     String arguments_string() const override
     {
         return String::formatted("offset={} [&{}], sp: {}", offset(), state().instruction_position + size() + offset(), state().string_position);
@@ -665,70 +665,70 @@ public:
 class OpCode_ForkReplaceStay final : public OpCode_ForkStay {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkReplaceStay; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ForkReplaceStay; }
 };
 
 class OpCode_CheckBegin final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBegin; }
-    ALWAYS_INLINE size_t size() const override { return 1; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBegin; }
+    AK_ALWAYS_INLINE size_t size() const override { return 1; }
     String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_CheckEnd final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckEnd; }
-    ALWAYS_INLINE size_t size() const override { return 1; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckEnd; }
+    AK_ALWAYS_INLINE size_t size() const override { return 1; }
     String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_CheckBoundary final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBoundary; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE size_t arguments_count() const { return 1; }
-    ALWAYS_INLINE BoundaryCheckType type() const { return static_cast<BoundaryCheckType>(argument(0)); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::CheckBoundary; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE size_t arguments_count() const { return 1; }
+    AK_ALWAYS_INLINE BoundaryCheckType type() const { return static_cast<BoundaryCheckType>(argument(0)); }
     String arguments_string() const override { return String::formatted("kind={} ({})", (long unsigned int)argument(0), boundary_check_type_name(type())); }
 };
 
 class OpCode_ClearCaptureGroup final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ClearCaptureGroup; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE size_t id() const { return argument(0); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ClearCaptureGroup; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE size_t id() const { return argument(0); }
     String arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_SaveLeftCaptureGroup final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveLeftCaptureGroup; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE size_t id() const { return argument(0); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveLeftCaptureGroup; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE size_t id() const { return argument(0); }
     String arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_SaveRightCaptureGroup final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightCaptureGroup; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE size_t id() const { return argument(0); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightCaptureGroup; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE size_t id() const { return argument(0); }
     String arguments_string() const override { return String::formatted("id={}", id()); }
 };
 
 class OpCode_SaveRightNamedCaptureGroup final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightNamedCaptureGroup; }
-    ALWAYS_INLINE size_t size() const override { return 4; }
-    ALWAYS_INLINE StringView name() const { return { reinterpret_cast<char*>(argument(0)), length() }; }
-    ALWAYS_INLINE size_t length() const { return argument(1); }
-    ALWAYS_INLINE size_t id() const { return argument(2); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::SaveRightNamedCaptureGroup; }
+    AK_ALWAYS_INLINE size_t size() const override { return 4; }
+    AK_ALWAYS_INLINE StringView name() const { return { reinterpret_cast<char*>(argument(0)), length() }; }
+    AK_ALWAYS_INLINE size_t length() const { return argument(1); }
+    AK_ALWAYS_INLINE size_t id() const { return argument(2); }
     String arguments_string() const override
     {
         return String::formatted("name={}, length={}", name(), length());
@@ -738,33 +738,33 @@ public:
 class OpCode_Compare final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Compare; }
-    ALWAYS_INLINE size_t size() const override { return arguments_size() + 3; }
-    ALWAYS_INLINE size_t arguments_count() const { return argument(0); }
-    ALWAYS_INLINE size_t arguments_size() const { return argument(1); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Compare; }
+    AK_ALWAYS_INLINE size_t size() const override { return arguments_size() + 3; }
+    AK_ALWAYS_INLINE size_t arguments_count() const { return argument(0); }
+    AK_ALWAYS_INLINE size_t arguments_size() const { return argument(1); }
     String arguments_string() const override;
     Vector<String> variable_arguments_to_string(Optional<MatchInput> input = {}) const;
     Vector<CompareTypeAndValuePair> flat_compares() const;
 
 private:
-    ALWAYS_INLINE static void compare_char(MatchInput const& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static bool compare_string(MatchInput const& input, MatchState& state, RegexStringView str, bool& had_zero_length_match);
-    ALWAYS_INLINE static void compare_character_class(MatchInput const& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static void compare_character_range(MatchInput const& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static void compare_property(MatchInput const& input, MatchState& state, Unicode::Property property, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static void compare_general_category(MatchInput const& input, MatchState& state, Unicode::GeneralCategory general_category, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static void compare_script(MatchInput const& input, MatchState& state, Unicode::Script script, bool inverse, bool& inverse_matched);
-    ALWAYS_INLINE static void compare_script_extension(MatchInput const& input, MatchState& state, Unicode::Script script, bool inverse, bool& inverse_matched);
+    AK_ALWAYS_INLINE static void compare_char(MatchInput const& input, MatchState& state, u32 ch1, bool inverse, bool& inverse_matched);
+    AK_ALWAYS_INLINE static bool compare_string(MatchInput const& input, MatchState& state, RegexStringView str, bool& had_zero_length_match);
+    AK_ALWAYS_INLINE static void compare_character_class(MatchInput const& input, MatchState& state, CharClass character_class, u32 ch, bool inverse, bool& inverse_matched);
+    AK_ALWAYS_INLINE static void compare_character_range(MatchInput const& input, MatchState& state, u32 from, u32 to, u32 ch, bool inverse, bool& inverse_matched);
+    AK_ALWAYS_INLINE static void compare_property(MatchInput const& input, MatchState& state, Unicode::Property property, bool inverse, bool& inverse_matched);
+    AK_ALWAYS_INLINE static void compare_general_category(MatchInput const& input, MatchState& state, Unicode::GeneralCategory general_category, bool inverse, bool& inverse_matched);
+    AK_ALWAYS_INLINE static void compare_script(MatchInput const& input, MatchState& state, Unicode::Script script, bool inverse, bool& inverse_matched);
+    AK_ALWAYS_INLINE static void compare_script_extension(MatchInput const& input, MatchState& state, Unicode::Script script, bool inverse, bool& inverse_matched);
 };
 
 class OpCode_Repeat : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Repeat; }
-    ALWAYS_INLINE size_t size() const override { return 4; }
-    ALWAYS_INLINE size_t offset() const { return argument(0); }
-    ALWAYS_INLINE u64 count() const { return argument(1); }
-    ALWAYS_INLINE size_t id() const { return argument(2); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Repeat; }
+    AK_ALWAYS_INLINE size_t size() const override { return 4; }
+    AK_ALWAYS_INLINE size_t offset() const { return argument(0); }
+    AK_ALWAYS_INLINE u64 count() const { return argument(1); }
+    AK_ALWAYS_INLINE size_t id() const { return argument(2); }
     String arguments_string() const override
     {
         auto reps = id() < state().repetition_marks.size() ? state().repetition_marks.at(id()) : 0;
@@ -775,9 +775,9 @@ public:
 class OpCode_ResetRepeat : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ResetRepeat; }
-    ALWAYS_INLINE size_t size() const override { return 2; }
-    ALWAYS_INLINE size_t id() const { return argument(0); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::ResetRepeat; }
+    AK_ALWAYS_INLINE size_t size() const override { return 2; }
+    AK_ALWAYS_INLINE size_t id() const { return argument(0); }
     String arguments_string() const override
     {
         auto reps = id() < state().repetition_marks.size() ? state().repetition_marks.at(id()) : 0;
@@ -788,19 +788,19 @@ public:
 class OpCode_Checkpoint final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Checkpoint; }
-    ALWAYS_INLINE size_t size() const override { return 1; }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::Checkpoint; }
+    AK_ALWAYS_INLINE size_t size() const override { return 1; }
     String arguments_string() const override { return String::empty(); }
 };
 
 class OpCode_JumpNonEmpty final : public OpCode {
 public:
     ExecutionResult execute(MatchInput const& input, MatchState& state) const override;
-    ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::JumpNonEmpty; }
-    ALWAYS_INLINE size_t size() const override { return 4; }
-    ALWAYS_INLINE ssize_t offset() const { return argument(0); }
-    ALWAYS_INLINE ssize_t checkpoint() const { return argument(1); }
-    ALWAYS_INLINE OpCodeId form() const { return (OpCodeId)argument(2); }
+    AK_ALWAYS_INLINE OpCodeId opcode_id() const override { return OpCodeId::JumpNonEmpty; }
+    AK_ALWAYS_INLINE size_t size() const override { return 4; }
+    AK_ALWAYS_INLINE ssize_t offset() const { return argument(0); }
+    AK_ALWAYS_INLINE ssize_t checkpoint() const { return argument(1); }
+    AK_ALWAYS_INLINE OpCodeId form() const { return (OpCodeId)argument(2); }
     String arguments_string() const override
     {
         return String::formatted("{} offset={} [&{}], cp={} [&{}]",
@@ -814,55 +814,55 @@ template<typename T>
 bool is(OpCode const&);
 
 template<typename T>
-ALWAYS_INLINE bool is(OpCode const&)
+AK_ALWAYS_INLINE bool is(OpCode const&)
 {
     return false;
 }
 
 template<typename T>
-ALWAYS_INLINE bool is(OpCode const* opcode)
+AK_ALWAYS_INLINE bool is(OpCode const* opcode)
 {
     return is<T>(*opcode);
 }
 
 template<>
-ALWAYS_INLINE bool is<OpCode_ForkStay>(OpCode const& opcode)
+AK_ALWAYS_INLINE bool is<OpCode_ForkStay>(OpCode const& opcode)
 {
     return opcode.opcode_id() == OpCodeId::ForkStay;
 }
 
 template<>
-ALWAYS_INLINE bool is<OpCode_Exit>(OpCode const& opcode)
+AK_ALWAYS_INLINE bool is<OpCode_Exit>(OpCode const& opcode)
 {
     return opcode.opcode_id() == OpCodeId::Exit;
 }
 
 template<>
-ALWAYS_INLINE bool is<OpCode_Compare>(OpCode const& opcode)
+AK_ALWAYS_INLINE bool is<OpCode_Compare>(OpCode const& opcode)
 {
     return opcode.opcode_id() == OpCodeId::Compare;
 }
 
 template<typename T>
-ALWAYS_INLINE T const& to(OpCode const& opcode)
+AK_ALWAYS_INLINE T const& to(OpCode const& opcode)
 {
     return verify_cast<T>(opcode);
 }
 
 template<typename T>
-ALWAYS_INLINE T* to(OpCode* opcode)
+AK_ALWAYS_INLINE T* to(OpCode* opcode)
 {
     return verify_cast<T>(opcode);
 }
 
 template<typename T>
-ALWAYS_INLINE T const* to(OpCode const* opcode)
+AK_ALWAYS_INLINE T const* to(OpCode const* opcode)
 {
     return verify_cast<T>(opcode);
 }
 
 template<typename T>
-ALWAYS_INLINE T& to(OpCode& opcode)
+AK_ALWAYS_INLINE T& to(OpCode& opcode)
 {
     return verify_cast<T>(opcode);
 }

--- a/Userland/Libraries/LibRegex/RegexMatcher.cpp
+++ b/Userland/Libraries/LibRegex/RegexMatcher.cpp
@@ -335,7 +335,7 @@ class BumpAllocatedLinkedList {
 public:
     BumpAllocatedLinkedList() = default;
 
-    ALWAYS_INLINE void append(T value)
+    AK_ALWAYS_INLINE void append(T value)
     {
         auto node_ptr = m_allocator.allocate(move(value));
         VERIFY(node_ptr);
@@ -351,7 +351,7 @@ public:
         m_last = node_ptr;
     }
 
-    ALWAYS_INLINE T take_last()
+    AK_ALWAYS_INLINE T take_last()
     {
         VERIFY(m_last);
         T value = move(m_last->value);
@@ -365,12 +365,12 @@ public:
         return value;
     }
 
-    ALWAYS_INLINE T& last()
+    AK_ALWAYS_INLINE T& last()
     {
         return m_last->value;
     }
 
-    ALWAYS_INLINE bool is_empty() const
+    AK_ALWAYS_INLINE bool is_empty() const
     {
         return m_first == nullptr;
     }

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -34,7 +34,7 @@ static constexpr StringView identity_escape_characters(bool unicode, bool browse
     return "^$\\.*+?()[]{}|"sv;
 }
 
-ALWAYS_INLINE bool Parser::set_error(Error error)
+AK_ALWAYS_INLINE bool Parser::set_error(Error error)
 {
     if (m_parser_state.error == Error::NoError) {
         m_parser_state.error = error;
@@ -43,29 +43,29 @@ ALWAYS_INLINE bool Parser::set_error(Error error)
     return false; // always return false, that eases the API usage (return set_error(...)) :^)
 }
 
-ALWAYS_INLINE bool Parser::done() const
+AK_ALWAYS_INLINE bool Parser::done() const
 {
     return match(TokenType::Eof);
 }
 
-ALWAYS_INLINE bool Parser::match(TokenType type) const
+AK_ALWAYS_INLINE bool Parser::match(TokenType type) const
 {
     return m_parser_state.current_token.type() == type;
 }
 
-ALWAYS_INLINE bool Parser::match(char ch) const
+AK_ALWAYS_INLINE bool Parser::match(char ch) const
 {
     return m_parser_state.current_token.type() == TokenType::Char && m_parser_state.current_token.value().length() == 1 && m_parser_state.current_token.value()[0] == ch;
 }
 
-ALWAYS_INLINE Token Parser::consume()
+AK_ALWAYS_INLINE Token Parser::consume()
 {
     auto old_token = m_parser_state.current_token;
     m_parser_state.current_token = m_parser_state.lexer.next();
     return old_token;
 }
 
-ALWAYS_INLINE Token Parser::consume(TokenType type, Error error)
+AK_ALWAYS_INLINE Token Parser::consume(TokenType type, Error error)
 {
     if (m_parser_state.current_token.type() != type) {
         set_error(error);
@@ -74,7 +74,7 @@ ALWAYS_INLINE Token Parser::consume(TokenType type, Error error)
     return consume();
 }
 
-ALWAYS_INLINE bool Parser::consume(String const& str)
+AK_ALWAYS_INLINE bool Parser::consume(String const& str)
 {
     size_t potentially_go_back { 1 };
     for (auto ch : str) {
@@ -95,7 +95,7 @@ ALWAYS_INLINE bool Parser::consume(String const& str)
     return true;
 }
 
-ALWAYS_INLINE Optional<u32> Parser::consume_escaped_code_point(bool unicode)
+AK_ALWAYS_INLINE Optional<u32> Parser::consume_escaped_code_point(bool unicode)
 {
     if (match(TokenType::LeftCurly) && !unicode) {
         // In non-Unicode mode, this should be parsed as a repetition symbol (repeating the 'u').
@@ -118,7 +118,7 @@ ALWAYS_INLINE Optional<u32> Parser::consume_escaped_code_point(bool unicode)
     return {};
 }
 
-ALWAYS_INLINE bool Parser::try_skip(StringView str)
+AK_ALWAYS_INLINE bool Parser::try_skip(StringView str)
 {
     if (str.starts_with(m_parser_state.current_token.value()))
         str = str.substring_view(m_parser_state.current_token.value().length(), str.length() - m_parser_state.current_token.value().length());
@@ -138,12 +138,12 @@ ALWAYS_INLINE bool Parser::try_skip(StringView str)
     return true;
 }
 
-ALWAYS_INLINE bool Parser::lookahead_any(StringView str)
+AK_ALWAYS_INLINE bool Parser::lookahead_any(StringView str)
 {
     return AK::any_of(str, [this](auto ch) { return match(ch); });
 }
 
-ALWAYS_INLINE unsigned char Parser::skip()
+AK_ALWAYS_INLINE unsigned char Parser::skip()
 {
     unsigned char ch;
     if (m_parser_state.current_token.value().length() == 1) {
@@ -157,13 +157,13 @@ ALWAYS_INLINE unsigned char Parser::skip()
     return ch;
 }
 
-ALWAYS_INLINE void Parser::back(size_t count)
+AK_ALWAYS_INLINE void Parser::back(size_t count)
 {
     m_parser_state.lexer.back(count);
     m_parser_state.current_token = m_parser_state.lexer.next();
 }
 
-ALWAYS_INLINE void Parser::reset()
+AK_ALWAYS_INLINE void Parser::reset()
 {
     m_parser_state.bytecode.clear();
     m_parser_state.lexer.reset();
@@ -199,7 +199,7 @@ Parser::Result Parser::parse(Optional<AllOptions> regex_options)
     };
 }
 
-ALWAYS_INLINE bool Parser::match_ordinary_characters()
+AK_ALWAYS_INLINE bool Parser::match_ordinary_characters()
 {
     // NOTE: This method must not be called during bracket and repetition parsing!
     // FIXME: Add assertion for that?
@@ -216,7 +216,7 @@ ALWAYS_INLINE bool Parser::match_ordinary_characters()
 // Abstract Posix Parser
 // =============================
 
-ALWAYS_INLINE bool AbstractPosixParser::parse_bracket_expression(Vector<CompareTypeAndValuePair>& values, size_t& match_length_minimum)
+AK_ALWAYS_INLINE bool AbstractPosixParser::parse_bracket_expression(Vector<CompareTypeAndValuePair>& values, size_t& match_length_minimum)
 {
     for (; !done();) {
         if (match(TokenType::HyphenMinus)) {
@@ -577,7 +577,7 @@ bool PosixExtendedParser::parse_internal(ByteCode& stack, size_t& match_length_m
     return parse_root(stack, match_length_minimum);
 }
 
-ALWAYS_INLINE bool PosixExtendedParser::match_repetition_symbol()
+AK_ALWAYS_INLINE bool PosixExtendedParser::match_repetition_symbol()
 {
     auto type = m_parser_state.current_token.type();
     return (type == TokenType::Asterisk
@@ -586,7 +586,7 @@ ALWAYS_INLINE bool PosixExtendedParser::match_repetition_symbol()
         || type == TokenType::LeftCurly);
 }
 
-ALWAYS_INLINE bool PosixExtendedParser::parse_repetition_symbol(ByteCode& bytecode_to_repeat, size_t& match_length_minimum)
+AK_ALWAYS_INLINE bool PosixExtendedParser::parse_repetition_symbol(ByteCode& bytecode_to_repeat, size_t& match_length_minimum)
 {
     if (match(TokenType::LeftCurly)) {
         consume();
@@ -678,7 +678,7 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_repetition_symbol(ByteCode& byteco
     return false;
 }
 
-ALWAYS_INLINE bool PosixExtendedParser::parse_bracket_expression(ByteCode& stack, size_t& match_length_minimum)
+AK_ALWAYS_INLINE bool PosixExtendedParser::parse_bracket_expression(ByteCode& stack, size_t& match_length_minimum)
 {
     Vector<CompareTypeAndValuePair> values;
     if (!AbstractPosixParser::parse_bracket_expression(values, match_length_minimum))
@@ -690,7 +690,7 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_bracket_expression(ByteCode& stack
     return !has_error();
 }
 
-ALWAYS_INLINE bool PosixExtendedParser::parse_sub_expression(ByteCode& stack, size_t& match_length_minimum)
+AK_ALWAYS_INLINE bool PosixExtendedParser::parse_sub_expression(ByteCode& stack, size_t& match_length_minimum)
 {
     ByteCode bytecode;
     size_t length = 0;

--- a/Userland/Libraries/LibRegex/RegexParser.h
+++ b/Userland/Libraries/LibRegex/RegexParser.h
@@ -77,20 +77,20 @@ public:
 protected:
     virtual bool parse_internal(ByteCode&, size_t& match_length_minimum) = 0;
 
-    ALWAYS_INLINE bool match(TokenType type) const;
-    ALWAYS_INLINE bool match(char ch) const;
-    ALWAYS_INLINE bool match_ordinary_characters();
-    ALWAYS_INLINE Token consume();
-    ALWAYS_INLINE Token consume(TokenType type, Error error);
-    ALWAYS_INLINE bool consume(String const&);
-    ALWAYS_INLINE Optional<u32> consume_escaped_code_point(bool unicode);
-    ALWAYS_INLINE bool try_skip(StringView);
-    ALWAYS_INLINE bool lookahead_any(StringView);
-    ALWAYS_INLINE unsigned char skip();
-    ALWAYS_INLINE void back(size_t = 1);
-    ALWAYS_INLINE void reset();
-    ALWAYS_INLINE bool done() const;
-    ALWAYS_INLINE bool set_error(Error error);
+    AK_ALWAYS_INLINE bool match(TokenType type) const;
+    AK_ALWAYS_INLINE bool match(char ch) const;
+    AK_ALWAYS_INLINE bool match_ordinary_characters();
+    AK_ALWAYS_INLINE Token consume();
+    AK_ALWAYS_INLINE Token consume(TokenType type, Error error);
+    AK_ALWAYS_INLINE bool consume(String const&);
+    AK_ALWAYS_INLINE Optional<u32> consume_escaped_code_point(bool unicode);
+    AK_ALWAYS_INLINE bool try_skip(StringView);
+    AK_ALWAYS_INLINE bool lookahead_any(StringView);
+    AK_ALWAYS_INLINE unsigned char skip();
+    AK_ALWAYS_INLINE void back(size_t = 1);
+    AK_ALWAYS_INLINE void reset();
+    AK_ALWAYS_INLINE bool done() const;
+    AK_ALWAYS_INLINE bool set_error(Error error);
 
     struct NamedCaptureGroup {
         size_t group_index { 0 };
@@ -139,7 +139,7 @@ protected:
     {
     }
 
-    ALWAYS_INLINE bool parse_bracket_expression(Vector<CompareTypeAndValuePair>&, size_t&);
+    AK_ALWAYS_INLINE bool parse_bracket_expression(Vector<CompareTypeAndValuePair>&, size_t&);
 };
 
 class PosixBasicParser final : public AbstractPosixParser {
@@ -188,14 +188,14 @@ public:
     ~PosixExtendedParser() = default;
 
 private:
-    ALWAYS_INLINE bool match_repetition_symbol();
+    AK_ALWAYS_INLINE bool match_repetition_symbol();
 
     bool parse_internal(ByteCode&, size_t&) override;
 
     bool parse_root(ByteCode&, size_t&);
-    ALWAYS_INLINE bool parse_sub_expression(ByteCode&, size_t&);
-    ALWAYS_INLINE bool parse_bracket_expression(ByteCode&, size_t&);
-    ALWAYS_INLINE bool parse_repetition_symbol(ByteCode&, size_t&);
+    AK_ALWAYS_INLINE bool parse_sub_expression(ByteCode&, size_t&);
+    AK_ALWAYS_INLINE bool parse_bracket_expression(ByteCode&, size_t&);
+    AK_ALWAYS_INLINE bool parse_repetition_symbol(ByteCode&, size_t&);
 };
 
 class ECMA262Parser final : public Parser {

--- a/Userland/Libraries/LibSQL/Result.h
+++ b/Userland/Libraries/LibSQL/Result.h
@@ -73,25 +73,25 @@ enum class SQLErrorCode {
 
 class [[nodiscard]] Result {
 public:
-    ALWAYS_INLINE Result(SQLCommand command)
+    AK_ALWAYS_INLINE Result(SQLCommand command)
         : m_command(command)
     {
     }
 
-    ALWAYS_INLINE Result(SQLCommand command, SQLErrorCode error)
+    AK_ALWAYS_INLINE Result(SQLCommand command, SQLErrorCode error)
         : m_command(command)
         , m_error(error)
     {
     }
 
-    ALWAYS_INLINE Result(SQLCommand command, SQLErrorCode error, String error_message)
+    AK_ALWAYS_INLINE Result(SQLCommand command, SQLErrorCode error, String error_message)
         : m_command(command)
         , m_error(error)
         , m_error_message(move(error_message))
     {
     }
 
-    ALWAYS_INLINE Result(Error error)
+    AK_ALWAYS_INLINE Result(Error error)
         : m_error(static_cast<SQLErrorCode>(error.code()))
         , m_error_message(error.string_literal())
     {

--- a/Userland/Libraries/LibSQL/ResultSet.h
+++ b/Userland/Libraries/LibSQL/ResultSet.h
@@ -20,7 +20,7 @@ struct ResultRow {
 
 class ResultSet : public Vector<ResultRow> {
 public:
-    ALWAYS_INLINE ResultSet(SQLCommand command)
+    AK_ALWAYS_INLINE ResultSet(SQLCommand command)
         : m_command(command)
     {
     }

--- a/Userland/Libraries/LibSoftGPU/Buffer/Typed2DBuffer.h
+++ b/Userland/Libraries/LibSoftGPU/Buffer/Typed2DBuffer.h
@@ -30,8 +30,8 @@ public:
     }
 
     void fill(T value, Gfx::IntRect const& rect) { m_buffer->fill(value, rect.left(), rect.right(), rect.top(), rect.bottom(), 0, 0); }
-    ALWAYS_INLINE T* scanline(int y) { return m_buffer->buffer_pointer(0, y, 0); }
-    ALWAYS_INLINE T const* scanline(int y) const { return m_buffer->buffer_pointer(0, y, 0); }
+    AK_ALWAYS_INLINE T* scanline(int y) { return m_buffer->buffer_pointer(0, y, 0); }
+    AK_ALWAYS_INLINE T const* scanline(int y) const { return m_buffer->buffer_pointer(0, y, 0); }
 
     void blit_from_bitmap(Gfx::Bitmap const& bitmap, Gfx::IntRect const& target) requires IsSame<T, u32>
     {

--- a/Userland/Libraries/LibSoftGPU/Buffer/Typed3DBuffer.h
+++ b/Userland/Libraries/LibSoftGPU/Buffer/Typed3DBuffer.h
@@ -29,12 +29,12 @@ public:
         return adopt_ref(*new Typed3DBuffer(width, height, depth, move(data)));
     }
 
-    ALWAYS_INLINE T* buffer_pointer(int x, int y, int z)
+    AK_ALWAYS_INLINE T* buffer_pointer(int x, int y, int z)
     {
         return &m_data[z * m_width * m_height + y * m_width + x];
     }
 
-    ALWAYS_INLINE T const* buffer_pointer(int x, int y, int z) const
+    AK_ALWAYS_INLINE T const* buffer_pointer(int x, int y, int z) const
     {
         return &m_data[z * m_width * m_height + y * m_width + x];
     }

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -70,7 +70,7 @@ static ColorType to_bgra32(FloatVector4 const& color)
     return a << 24 | r << 16 | g << 8 | b;
 }
 
-ALWAYS_INLINE static u32x4 to_bgra32(Vector4<f32x4> const& v)
+AK_ALWAYS_INLINE static u32x4 to_bgra32(Vector4<f32x4> const& v)
 {
     auto clamped = v.clamped(expand4(0.0f), expand4(1.0f));
     auto r = to_u32x4(clamped.x() * 255);
@@ -965,7 +965,7 @@ void Device::draw_primitives(PrimitiveType primitive_type, FloatMatrix4x4 const&
     }
 }
 
-ALWAYS_INLINE void Device::shade_fragments(PixelQuad& quad)
+AK_ALWAYS_INLINE void Device::shade_fragments(PixelQuad& quad)
 {
     quad.out_color = quad.vertex_color;
 
@@ -1027,7 +1027,7 @@ ALWAYS_INLINE void Device::shade_fragments(PixelQuad& quad)
     }
 }
 
-ALWAYS_INLINE bool Device::test_alpha(PixelQuad& quad)
+AK_ALWAYS_INLINE bool Device::test_alpha(PixelQuad& quad)
 {
     auto const alpha = quad.out_color.w();
     auto const ref_value = expand4(m_options.alpha_test_ref_value);

--- a/Userland/Libraries/LibSoftGPU/SIMD.h
+++ b/Userland/Libraries/LibSoftGPU/SIMD.h
@@ -13,7 +13,7 @@
 
 namespace SoftGPU {
 
-ALWAYS_INLINE static constexpr Vector2<AK::SIMD::f32x4> expand4(Vector2<float> const& v)
+AK_ALWAYS_INLINE static constexpr Vector2<AK::SIMD::f32x4> expand4(Vector2<float> const& v)
 {
     return Vector2<AK::SIMD::f32x4> {
         AK::SIMD::expand4(v.x()),
@@ -21,7 +21,7 @@ ALWAYS_INLINE static constexpr Vector2<AK::SIMD::f32x4> expand4(Vector2<float> c
     };
 }
 
-ALWAYS_INLINE static constexpr Vector3<AK::SIMD::f32x4> expand4(Vector3<float> const& v)
+AK_ALWAYS_INLINE static constexpr Vector3<AK::SIMD::f32x4> expand4(Vector3<float> const& v)
 {
     return Vector3<AK::SIMD::f32x4> {
         AK::SIMD::expand4(v.x()),
@@ -30,7 +30,7 @@ ALWAYS_INLINE static constexpr Vector3<AK::SIMD::f32x4> expand4(Vector3<float> c
     };
 }
 
-ALWAYS_INLINE static constexpr Vector4<AK::SIMD::f32x4> expand4(Vector4<float> const& v)
+AK_ALWAYS_INLINE static constexpr Vector4<AK::SIMD::f32x4> expand4(Vector4<float> const& v)
 {
     return Vector4<AK::SIMD::f32x4> {
         AK::SIMD::expand4(v.x()),
@@ -40,7 +40,7 @@ ALWAYS_INLINE static constexpr Vector4<AK::SIMD::f32x4> expand4(Vector4<float> c
     };
 }
 
-ALWAYS_INLINE static constexpr Vector2<AK::SIMD::i32x4> expand4(Vector2<int> const& v)
+AK_ALWAYS_INLINE static constexpr Vector2<AK::SIMD::i32x4> expand4(Vector2<int> const& v)
 {
     return Vector2<AK::SIMD::i32x4> {
         AK::SIMD::expand4(v.x()),
@@ -48,7 +48,7 @@ ALWAYS_INLINE static constexpr Vector2<AK::SIMD::i32x4> expand4(Vector2<int> con
     };
 }
 
-ALWAYS_INLINE static constexpr Vector3<AK::SIMD::i32x4> expand4(Vector3<int> const& v)
+AK_ALWAYS_INLINE static constexpr Vector3<AK::SIMD::i32x4> expand4(Vector3<int> const& v)
 {
     return Vector3<AK::SIMD::i32x4> {
         AK::SIMD::expand4(v.x()),
@@ -57,7 +57,7 @@ ALWAYS_INLINE static constexpr Vector3<AK::SIMD::i32x4> expand4(Vector3<int> con
     };
 }
 
-ALWAYS_INLINE static constexpr Vector4<AK::SIMD::i32x4> expand4(Vector4<int> const& v)
+AK_ALWAYS_INLINE static constexpr Vector4<AK::SIMD::i32x4> expand4(Vector4<int> const& v)
 {
     return Vector4<AK::SIMD::i32x4> {
         AK::SIMD::expand4(v.x()),
@@ -67,7 +67,7 @@ ALWAYS_INLINE static constexpr Vector4<AK::SIMD::i32x4> expand4(Vector4<int> con
     };
 }
 
-ALWAYS_INLINE static AK::SIMD::f32x4 ddx(AK::SIMD::f32x4 v)
+AK_ALWAYS_INLINE static AK::SIMD::f32x4 ddx(AK::SIMD::f32x4 v)
 {
     return AK::SIMD::f32x4 {
         v[1] - v[0],
@@ -77,7 +77,7 @@ ALWAYS_INLINE static AK::SIMD::f32x4 ddx(AK::SIMD::f32x4 v)
     };
 }
 
-ALWAYS_INLINE static AK::SIMD::f32x4 ddy(AK::SIMD::f32x4 v)
+AK_ALWAYS_INLINE static AK::SIMD::f32x4 ddy(AK::SIMD::f32x4 v)
 {
     return AK::SIMD::f32x4 {
         v[2] - v[0],
@@ -87,7 +87,7 @@ ALWAYS_INLINE static AK::SIMD::f32x4 ddy(AK::SIMD::f32x4 v)
     };
 }
 
-ALWAYS_INLINE static Vector2<AK::SIMD::f32x4> ddx(Vector2<AK::SIMD::f32x4> const& v)
+AK_ALWAYS_INLINE static Vector2<AK::SIMD::f32x4> ddx(Vector2<AK::SIMD::f32x4> const& v)
 {
     return {
         ddx(v.x()),
@@ -95,7 +95,7 @@ ALWAYS_INLINE static Vector2<AK::SIMD::f32x4> ddx(Vector2<AK::SIMD::f32x4> const
     };
 }
 
-ALWAYS_INLINE static Vector2<AK::SIMD::f32x4> ddy(Vector2<AK::SIMD::f32x4> const& v)
+AK_ALWAYS_INLINE static Vector2<AK::SIMD::f32x4> ddy(Vector2<AK::SIMD::f32x4> const& v)
 {
     return {
         ddy(v.x()),
@@ -105,7 +105,7 @@ ALWAYS_INLINE static Vector2<AK::SIMD::f32x4> ddy(Vector2<AK::SIMD::f32x4> const
 
 // Calculates a quadratic approximation of log2, exploiting the fact that IEEE754 floats are represented as mantissa * 2^exponent.
 // See https://stackoverflow.com/questions/9411823/fast-log2float-x-implementation-c
-ALWAYS_INLINE static AK::SIMD::f32x4 log2_approximate(AK::SIMD::f32x4 v)
+AK_ALWAYS_INLINE static AK::SIMD::f32x4 log2_approximate(AK::SIMD::f32x4 v)
 {
     union {
         AK::SIMD::f32x4 float_val;

--- a/Userland/Libraries/LibSoftGPU/Sampler.cpp
+++ b/Userland/Libraries/LibSoftGPU/Sampler.cpp
@@ -72,7 +72,7 @@ static f32x4 wrap(f32x4 value, TextureWrapMode mode, u32x4 num_texels)
     }
 }
 
-ALWAYS_INLINE static Vector4<f32x4> texel4(Image const& image, u32x4 layer, u32x4 level, u32x4 x, u32x4 y, u32x4 z)
+AK_ALWAYS_INLINE static Vector4<f32x4> texel4(Image const& image, u32x4 layer, u32x4 level, u32x4 x, u32x4 y, u32x4 z)
 {
     auto t0 = image.texel(layer[0], level[0], x[0], y[0], z[0]);
     auto t1 = image.texel(layer[1], level[1], x[1], y[1], z[1]);
@@ -87,7 +87,7 @@ ALWAYS_INLINE static Vector4<f32x4> texel4(Image const& image, u32x4 layer, u32x
     };
 }
 
-ALWAYS_INLINE static Vector4<f32x4> texel4border(Image const& image, u32x4 layer, u32x4 level, u32x4 x, u32x4 y, u32x4 z, FloatVector4 const& border, u32x4 w, u32x4 h)
+AK_ALWAYS_INLINE static Vector4<f32x4> texel4border(Image const& image, u32x4 layer, u32x4 level, u32x4 x, u32x4 y, u32x4 z, FloatVector4 const& border, u32x4 w, u32x4 h)
 {
     auto border_mask = maskbits(x < 0 || x >= w || y < 0 || y >= h);
 

--- a/Userland/Libraries/LibThreading/ConditionVariable.h
+++ b/Userland/Libraries/LibThreading/ConditionVariable.h
@@ -26,31 +26,31 @@ public:
         VERIFY(result == 0);
     }
 
-    ALWAYS_INLINE ~ConditionVariable()
+    AK_ALWAYS_INLINE ~ConditionVariable()
     {
         auto result = pthread_cond_destroy(&m_condition);
         VERIFY(result == 0);
     }
 
     // As with pthread APIs, the mutex must be locked or undefined behavior ensues.
-    ALWAYS_INLINE void wait()
+    AK_ALWAYS_INLINE void wait()
     {
         auto result = pthread_cond_wait(&m_condition, &m_to_wait_on.m_mutex);
         VERIFY(result == 0);
     }
-    ALWAYS_INLINE void wait_while(Function<bool()> condition)
+    AK_ALWAYS_INLINE void wait_while(Function<bool()> condition)
     {
         while (condition())
             wait();
     }
     // Release at least one of the threads waiting on this variable.
-    ALWAYS_INLINE void signal()
+    AK_ALWAYS_INLINE void signal()
     {
         auto result = pthread_cond_signal(&m_condition);
         VERIFY(result == 0);
     }
     // Release all of the threads waiting on this variable.
-    ALWAYS_INLINE void broadcast()
+    AK_ALWAYS_INLINE void broadcast()
     {
         auto result = pthread_cond_broadcast(&m_condition);
         VERIFY(result == 0);

--- a/Userland/Libraries/LibThreading/Mutex.h
+++ b/Userland/Libraries/LibThreading/Mutex.h
@@ -54,29 +54,29 @@ class MutexLocker {
     AK_MAKE_NONMOVABLE(MutexLocker);
 
 public:
-    ALWAYS_INLINE explicit MutexLocker(Mutex& mutex)
+    AK_ALWAYS_INLINE explicit MutexLocker(Mutex& mutex)
         : m_mutex(mutex)
     {
         lock();
     }
-    ALWAYS_INLINE ~MutexLocker()
+    AK_ALWAYS_INLINE ~MutexLocker()
     {
         unlock();
     }
-    ALWAYS_INLINE void unlock() { m_mutex.unlock(); }
-    ALWAYS_INLINE void lock() { m_mutex.lock(); }
+    AK_ALWAYS_INLINE void unlock() { m_mutex.unlock(); }
+    AK_ALWAYS_INLINE void lock() { m_mutex.lock(); }
 
 private:
     Mutex& m_mutex;
 };
 
-ALWAYS_INLINE void Mutex::lock()
+AK_ALWAYS_INLINE void Mutex::lock()
 {
     pthread_mutex_lock(&m_mutex);
     m_lock_count++;
 }
 
-ALWAYS_INLINE void Mutex::unlock()
+AK_ALWAYS_INLINE void Mutex::unlock()
 {
     VERIFY(m_lock_count > 0);
     // FIXME: We need to protect the lock count with the mutex itself.

--- a/Userland/Libraries/LibThreading/MutexProtected.h
+++ b/Userland/Libraries/LibThreading/MutexProtected.h
@@ -19,12 +19,12 @@ class MutexProtected {
     using ProtectedType = T;
 
 public:
-    ALWAYS_INLINE MutexProtected() = default;
-    ALWAYS_INLINE MutexProtected(T&& value)
+    AK_ALWAYS_INLINE MutexProtected() = default;
+    AK_ALWAYS_INLINE MutexProtected(T&& value)
         : m_value(move(value))
     {
     }
-    ALWAYS_INLINE explicit MutexProtected(T& value)
+    AK_ALWAYS_INLINE explicit MutexProtected(T& value)
         : m_value(value)
     {
     }
@@ -47,7 +47,7 @@ public:
     }
 
 private:
-    [[nodiscard]] ALWAYS_INLINE MutexLocker lock() { return MutexLocker(m_lock); }
+    [[nodiscard]] AK_ALWAYS_INLINE MutexLocker lock() { return MutexLocker(m_lock); }
 
     T m_value;
     Mutex m_lock {};

--- a/Userland/Libraries/LibVT/EscapeSequenceParser.h
+++ b/Userland/Libraries/LibVT/EscapeSequenceParser.h
@@ -39,7 +39,7 @@ public:
     explicit EscapeSequenceParser(EscapeSequenceExecutor&);
     ~EscapeSequenceParser() = default;
 
-    ALWAYS_INLINE void on_input(u8 byte)
+    AK_ALWAYS_INLINE void on_input(u8 byte)
     {
         dbgln_if(ESCAPE_SEQUENCE_DEBUG, "on_input {:02x}", byte);
         m_state_machine.advance(byte);

--- a/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/AbstractMachine.h
@@ -112,13 +112,13 @@ public:
         }
     }
 
-    ALWAYS_INLINE Value(Value const& value) = default;
-    ALWAYS_INLINE Value(Value&& value) = default;
-    ALWAYS_INLINE Value& operator=(Value&& value) = default;
-    ALWAYS_INLINE Value& operator=(Value const& value) = default;
+    AK_ALWAYS_INLINE Value(Value const& value) = default;
+    AK_ALWAYS_INLINE Value(Value&& value) = default;
+    AK_ALWAYS_INLINE Value& operator=(Value&& value) = default;
+    AK_ALWAYS_INLINE Value& operator=(Value const& value) = default;
 
     template<typename T>
-    ALWAYS_INLINE Optional<T> to()
+    AK_ALWAYS_INLINE Optional<T> to()
     {
         Optional<T> result;
         m_value.visit(
@@ -504,15 +504,15 @@ public:
     using EntryType = Variant<Value, Label, Frame>;
     Stack() = default;
 
-    [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return m_data.is_empty(); }
-    ALWAYS_INLINE void push(EntryType entry) { m_data.append(move(entry)); }
-    ALWAYS_INLINE auto pop() { return m_data.take_last(); }
-    ALWAYS_INLINE auto& peek() const { return m_data.last(); }
-    ALWAYS_INLINE auto& peek() { return m_data.last(); }
+    [[nodiscard]] AK_ALWAYS_INLINE bool is_empty() const { return m_data.is_empty(); }
+    AK_ALWAYS_INLINE void push(EntryType entry) { m_data.append(move(entry)); }
+    AK_ALWAYS_INLINE auto pop() { return m_data.take_last(); }
+    AK_ALWAYS_INLINE auto& peek() const { return m_data.last(); }
+    AK_ALWAYS_INLINE auto& peek() { return m_data.last(); }
 
-    ALWAYS_INLINE auto size() const { return m_data.size(); }
-    ALWAYS_INLINE auto& entries() const { return m_data; }
-    ALWAYS_INLINE auto& entries() { return m_data; }
+    AK_ALWAYS_INLINE auto size() const { return m_data.size(); }
+    AK_ALWAYS_INLINE auto& entries() const { return m_data; }
+    AK_ALWAYS_INLINE auto& entries() { return m_data; }
 
 private:
     Vector<EntryType, 1024> m_data;

--- a/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/BytecodeInterpreter.h
@@ -58,7 +58,7 @@ protected:
     T read_value(ReadonlyBytes data);
 
     Vector<Value> pop_values(Configuration& configuration, size_t count);
-    ALWAYS_INLINE bool trap_if_not(bool value, StringView reason)
+    AK_ALWAYS_INLINE bool trap_if_not(bool value, StringView reason)
     {
         if (!value)
             m_trap = Trap { reason };

--- a/Userland/Libraries/LibWasm/AbstractMachine/Configuration.h
+++ b/Userland/Libraries/LibWasm/AbstractMachine/Configuration.h
@@ -32,16 +32,16 @@ public:
         m_stack.push(move(frame));
         m_stack.push(label);
     }
-    ALWAYS_INLINE auto& frame() const { return m_stack.entries()[m_current_frame_index].get<Frame>(); }
-    ALWAYS_INLINE auto& frame() { return m_stack.entries()[m_current_frame_index].get<Frame>(); }
-    ALWAYS_INLINE auto& ip() const { return m_ip; }
-    ALWAYS_INLINE auto& ip() { return m_ip; }
-    ALWAYS_INLINE auto& depth() const { return m_depth; }
-    ALWAYS_INLINE auto& depth() { return m_depth; }
-    ALWAYS_INLINE auto& stack() const { return m_stack; }
-    ALWAYS_INLINE auto& stack() { return m_stack; }
-    ALWAYS_INLINE auto& store() const { return m_store; }
-    ALWAYS_INLINE auto& store() { return m_store; }
+    AK_ALWAYS_INLINE auto& frame() const { return m_stack.entries()[m_current_frame_index].get<Frame>(); }
+    AK_ALWAYS_INLINE auto& frame() { return m_stack.entries()[m_current_frame_index].get<Frame>(); }
+    AK_ALWAYS_INLINE auto& ip() const { return m_ip; }
+    AK_ALWAYS_INLINE auto& ip() { return m_ip; }
+    AK_ALWAYS_INLINE auto& depth() const { return m_depth; }
+    AK_ALWAYS_INLINE auto& depth() { return m_depth; }
+    AK_ALWAYS_INLINE auto& stack() const { return m_stack; }
+    AK_ALWAYS_INLINE auto& stack() { return m_stack; }
+    AK_ALWAYS_INLINE auto& store() const { return m_store; }
+    AK_ALWAYS_INLINE auto& store() { return m_store; }
 
     struct CallFrameHandle {
         explicit CallFrameHandle(Configuration& configuration)

--- a/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
+++ b/Userland/Libraries/LibWeb/Bindings/ExceptionOrUtils.h
@@ -58,7 +58,7 @@ struct ExtractExceptionOrValueType<DOM::ExceptionOr<void>> {
     using Type = JS::Value;
 };
 
-ALWAYS_INLINE JS::Completion dom_exception_to_throw_completion(auto&& global_object, auto&& exception)
+AK_ALWAYS_INLINE JS::Completion dom_exception_to_throw_completion(auto&& global_object, auto&& exception)
 {
     auto& vm = global_object.vm();
 

--- a/Userland/Libraries/LibWeb/CSS/Length.h
+++ b/Userland/Libraries/LibWeb/CSS/Length.h
@@ -79,7 +79,7 @@ public:
 
     float to_px(Layout::Node const&) const;
 
-    ALWAYS_INLINE float to_px(Gfx::IntRect const& viewport_rect, Gfx::FontMetrics const& font_metrics, float font_size, float root_font_size) const
+    AK_ALWAYS_INLINE float to_px(Gfx::IntRect const& viewport_rect, Gfx::FontMetrics const& font_metrics, float font_size, float root_font_size) const
     {
         if (is_auto())
             return 0;
@@ -90,7 +90,7 @@ public:
         return absolute_length_to_px();
     }
 
-    ALWAYS_INLINE float absolute_length_to_px() const
+    AK_ALWAYS_INLINE float absolute_length_to_px() const
     {
         constexpr float inch_pixels = 96.0f;
         constexpr float centimeter_pixels = (inch_pixels / 2.54f);

--- a/Userland/Libraries/LibWeb/DOMTreeModel.h
+++ b/Userland/Libraries/LibWeb/DOMTreeModel.h
@@ -36,14 +36,14 @@ public:
 private:
     DOMTreeModel(JsonObject, GUI::TreeView&);
 
-    ALWAYS_INLINE JsonObject const* get_parent(const JsonObject& o) const
+    AK_ALWAYS_INLINE JsonObject const* get_parent(const JsonObject& o) const
     {
         auto parent_node = m_dom_node_to_parent_map.get(&o);
         VERIFY(parent_node.has_value());
         return *parent_node;
     }
 
-    ALWAYS_INLINE static JsonArray const* get_children(const JsonObject& o)
+    AK_ALWAYS_INLINE static JsonArray const* get_children(const JsonObject& o)
     {
         if (auto const* maybe_children = o.get_ptr("children"); maybe_children)
             return &maybe_children->as_array();

--- a/Userland/Libraries/LibX86/Instruction.h
+++ b/Userland/Libraries/LibX86/Instruction.h
@@ -492,12 +492,12 @@ public:
     static Instruction from_stream(InstructionStreamType&, bool o32, bool a32);
     ~Instruction() = default;
 
-    ALWAYS_INLINE MemoryOrRegisterReference& modrm() const { return m_modrm; }
+    AK_ALWAYS_INLINE MemoryOrRegisterReference& modrm() const { return m_modrm; }
 
-    ALWAYS_INLINE InstructionHandler handler() const { return m_descriptor->handler; }
+    AK_ALWAYS_INLINE InstructionHandler handler() const { return m_descriptor->handler; }
 
     bool has_segment_prefix() const { return m_segment_prefix != 0xff; }
-    ALWAYS_INLINE Optional<SegmentRegister> segment_prefix() const
+    AK_ALWAYS_INLINE Optional<SegmentRegister> segment_prefix() const
     {
         if (has_segment_prefix())
             return static_cast<SegmentRegister>(m_segment_prefix);
@@ -580,7 +580,7 @@ private:
 };
 
 template<typename CPU>
-ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve16(const CPU& cpu, Optional<SegmentRegister> segment_prefix)
+AK_ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve16(const CPU& cpu, Optional<SegmentRegister> segment_prefix)
 {
     auto default_segment = SegmentRegister::DS;
     u16 offset = 0;
@@ -624,7 +624,7 @@ ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve16(const CPU& cpu
 }
 
 template<typename CPU>
-ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve32(const CPU& cpu, Optional<SegmentRegister> segment_prefix)
+AK_ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve32(const CPU& cpu, Optional<SegmentRegister> segment_prefix)
 {
     auto default_segment = SegmentRegister::DS;
     u32 offset = 0;
@@ -653,7 +653,7 @@ ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve32(const CPU& cpu
 }
 
 template<typename CPU>
-ALWAYS_INLINE u32 MemoryOrRegisterReference::evaluate_sib(const CPU& cpu, SegmentRegister& default_segment) const
+AK_ALWAYS_INLINE u32 MemoryOrRegisterReference::evaluate_sib(const CPU& cpu, SegmentRegister& default_segment) const
 {
     u32 scale_shift = m_sib >> 6;
     u32 index = 0;
@@ -697,7 +697,7 @@ ALWAYS_INLINE u32 MemoryOrRegisterReference::evaluate_sib(const CPU& cpu, Segmen
 }
 
 template<typename CPU, typename T>
-ALWAYS_INLINE void MemoryOrRegisterReference::write8(CPU& cpu, const Instruction& insn, T value)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::write8(CPU& cpu, const Instruction& insn, T value)
 {
     if (is_register()) {
         cpu.gpr8(reg8()) = value;
@@ -709,7 +709,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::write8(CPU& cpu, const Instruction
 }
 
 template<typename CPU, typename T>
-ALWAYS_INLINE void MemoryOrRegisterReference::write16(CPU& cpu, const Instruction& insn, T value)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::write16(CPU& cpu, const Instruction& insn, T value)
 {
     if (is_register()) {
         cpu.gpr16(reg16()) = value;
@@ -721,7 +721,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::write16(CPU& cpu, const Instructio
 }
 
 template<typename CPU, typename T>
-ALWAYS_INLINE void MemoryOrRegisterReference::write32(CPU& cpu, const Instruction& insn, T value)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::write32(CPU& cpu, const Instruction& insn, T value)
 {
     if (is_register()) {
         cpu.gpr32(reg32()) = value;
@@ -733,7 +733,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::write32(CPU& cpu, const Instructio
 }
 
 template<typename CPU, typename T>
-ALWAYS_INLINE void MemoryOrRegisterReference::write64(CPU& cpu, const Instruction& insn, T value)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::write64(CPU& cpu, const Instruction& insn, T value)
 {
     VERIFY(!is_register());
     auto address = resolve(cpu, insn);
@@ -741,7 +741,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::write64(CPU& cpu, const Instructio
 }
 
 template<typename CPU, typename T>
-ALWAYS_INLINE void MemoryOrRegisterReference::write128(CPU& cpu, const Instruction& insn, T value)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::write128(CPU& cpu, const Instruction& insn, T value)
 {
     VERIFY(!is_register());
     auto address = resolve(cpu, insn);
@@ -749,7 +749,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::write128(CPU& cpu, const Instructi
 }
 
 template<typename CPU, typename T>
-ALWAYS_INLINE void MemoryOrRegisterReference::write256(CPU& cpu, const Instruction& insn, T value)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::write256(CPU& cpu, const Instruction& insn, T value)
 {
     VERIFY(!is_register());
     auto address = resolve(cpu, insn);
@@ -757,7 +757,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::write256(CPU& cpu, const Instructi
 }
 
 template<typename CPU>
-ALWAYS_INLINE typename CPU::ValueWithShadowType8 MemoryOrRegisterReference::read8(CPU& cpu, const Instruction& insn)
+AK_ALWAYS_INLINE typename CPU::ValueWithShadowType8 MemoryOrRegisterReference::read8(CPU& cpu, const Instruction& insn)
 {
     if (is_register())
         return cpu.const_gpr8(reg8());
@@ -767,7 +767,7 @@ ALWAYS_INLINE typename CPU::ValueWithShadowType8 MemoryOrRegisterReference::read
 }
 
 template<typename CPU>
-ALWAYS_INLINE typename CPU::ValueWithShadowType16 MemoryOrRegisterReference::read16(CPU& cpu, const Instruction& insn)
+AK_ALWAYS_INLINE typename CPU::ValueWithShadowType16 MemoryOrRegisterReference::read16(CPU& cpu, const Instruction& insn)
 {
     if (is_register())
         return cpu.const_gpr16(reg16());
@@ -777,7 +777,7 @@ ALWAYS_INLINE typename CPU::ValueWithShadowType16 MemoryOrRegisterReference::rea
 }
 
 template<typename CPU>
-ALWAYS_INLINE typename CPU::ValueWithShadowType32 MemoryOrRegisterReference::read32(CPU& cpu, const Instruction& insn)
+AK_ALWAYS_INLINE typename CPU::ValueWithShadowType32 MemoryOrRegisterReference::read32(CPU& cpu, const Instruction& insn)
 {
     if (is_register())
         return cpu.const_gpr32(reg32());
@@ -787,7 +787,7 @@ ALWAYS_INLINE typename CPU::ValueWithShadowType32 MemoryOrRegisterReference::rea
 }
 
 template<typename CPU>
-ALWAYS_INLINE typename CPU::ValueWithShadowType64 MemoryOrRegisterReference::read64(CPU& cpu, const Instruction& insn)
+AK_ALWAYS_INLINE typename CPU::ValueWithShadowType64 MemoryOrRegisterReference::read64(CPU& cpu, const Instruction& insn)
 {
     VERIFY(!is_register());
     auto address = resolve(cpu, insn);
@@ -795,7 +795,7 @@ ALWAYS_INLINE typename CPU::ValueWithShadowType64 MemoryOrRegisterReference::rea
 }
 
 template<typename CPU>
-ALWAYS_INLINE typename CPU::ValueWithShadowType128 MemoryOrRegisterReference::read128(CPU& cpu, const Instruction& insn)
+AK_ALWAYS_INLINE typename CPU::ValueWithShadowType128 MemoryOrRegisterReference::read128(CPU& cpu, const Instruction& insn)
 {
     VERIFY(!is_register());
     auto address = resolve(cpu, insn);
@@ -803,7 +803,7 @@ ALWAYS_INLINE typename CPU::ValueWithShadowType128 MemoryOrRegisterReference::re
 }
 
 template<typename CPU>
-ALWAYS_INLINE typename CPU::ValueWithShadowType256 MemoryOrRegisterReference::read256(CPU& cpu, const Instruction& insn)
+AK_ALWAYS_INLINE typename CPU::ValueWithShadowType256 MemoryOrRegisterReference::read256(CPU& cpu, const Instruction& insn)
 {
     VERIFY(!is_register());
     auto address = resolve(cpu, insn);
@@ -811,12 +811,12 @@ ALWAYS_INLINE typename CPU::ValueWithShadowType256 MemoryOrRegisterReference::re
 }
 
 template<typename InstructionStreamType>
-ALWAYS_INLINE Instruction Instruction::from_stream(InstructionStreamType& stream, bool o32, bool a32)
+AK_ALWAYS_INLINE Instruction Instruction::from_stream(InstructionStreamType& stream, bool o32, bool a32)
 {
     return Instruction(stream, o32, a32);
 }
 
-ALWAYS_INLINE unsigned Instruction::length() const
+AK_ALWAYS_INLINE unsigned Instruction::length() const
 {
     unsigned len = 1;
     if (has_sub_op())
@@ -831,7 +831,7 @@ ALWAYS_INLINE unsigned Instruction::length() const
     return len;
 }
 
-ALWAYS_INLINE Optional<SegmentRegister> to_segment_prefix(u8 op)
+AK_ALWAYS_INLINE Optional<SegmentRegister> to_segment_prefix(u8 op)
 {
     switch (op) {
     case 0x26:
@@ -852,7 +852,7 @@ ALWAYS_INLINE Optional<SegmentRegister> to_segment_prefix(u8 op)
 }
 
 template<typename InstructionStreamType>
-ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, bool o32, bool a32)
+AK_ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, bool o32, bool a32)
     : m_a32(a32)
     , m_o32(o32)
 {
@@ -984,7 +984,7 @@ ALWAYS_INLINE Instruction::Instruction(InstructionStreamType& stream, bool o32, 
 }
 
 template<typename InstructionStreamType>
-ALWAYS_INLINE void MemoryOrRegisterReference::decode(InstructionStreamType& stream, bool a32)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::decode(InstructionStreamType& stream, bool a32)
 {
     m_rm_byte = stream.read8();
 
@@ -1022,7 +1022,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::decode(InstructionStreamType& stre
 }
 
 template<typename InstructionStreamType>
-ALWAYS_INLINE void MemoryOrRegisterReference::decode16(InstructionStreamType&)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::decode16(InstructionStreamType&)
 {
     switch (mod()) {
     case 0b00:
@@ -1044,7 +1044,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::decode16(InstructionStreamType&)
 }
 
 template<typename InstructionStreamType>
-ALWAYS_INLINE void MemoryOrRegisterReference::decode32(InstructionStreamType& stream)
+AK_ALWAYS_INLINE void MemoryOrRegisterReference::decode32(InstructionStreamType& stream)
 {
     switch (mod()) {
     case 0b00:
@@ -1085,7 +1085,7 @@ ALWAYS_INLINE void MemoryOrRegisterReference::decode32(InstructionStreamType& st
 }
 
 template<typename CPU>
-ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve(const CPU& cpu, const Instruction& insn)
+AK_ALWAYS_INLINE LogicalAddress MemoryOrRegisterReference::resolve(const CPU& cpu, const Instruction& insn)
 {
     if (insn.a32())
         return resolve32(cpu, insn.segment_prefix());

--- a/Userland/Shell/Formatter.h
+++ b/Userland/Shell/Formatter.h
@@ -92,9 +92,9 @@ private:
     void insert_separator(bool escaped = false);
     void insert_indent();
 
-    ALWAYS_INLINE void with_added_indent(int indent, Function<void()>);
-    ALWAYS_INLINE void in_new_block(Function<void()>);
-    ALWAYS_INLINE String in_new_builder(Function<void()>, StringBuilder new_builder = StringBuilder {});
+    AK_ALWAYS_INLINE void with_added_indent(int indent, Function<void()>);
+    AK_ALWAYS_INLINE void in_new_block(Function<void()>);
+    AK_ALWAYS_INLINE String in_new_builder(Function<void()>, StringBuilder new_builder = StringBuilder {});
 
     StringBuilder& current_builder() { return m_builders.last(); }
 

--- a/Userland/Utilities/printf.cpp
+++ b/Userland/Utilities/printf.cpp
@@ -22,12 +22,12 @@
 
 template<typename PutChFunc, typename ArgumentListRefT, template<typename T, typename U = ArgumentListRefT> typename NextArgument, typename CharType>
 requires(IsSame<CharType, char>) struct PrintfImpl : public PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument, CharType> {
-    ALWAYS_INLINE PrintfImpl(PutChFunc& putch, char*& bufptr, const int& nwritten)
+    AK_ALWAYS_INLINE PrintfImpl(PutChFunc& putch, char*& bufptr, const int& nwritten)
         : PrintfImplementation::PrintfImpl<PutChFunc, ArgumentListRefT, NextArgument>(putch, bufptr, nwritten)
     {
     }
 
-    ALWAYS_INLINE int format_q(const PrintfImplementation::ModifierState& state, ArgumentListRefT& ap) const
+    AK_ALWAYS_INLINE int format_q(const PrintfImplementation::ModifierState& state, ArgumentListRefT& ap) const
     {
         auto state_copy = state;
         auto str = NextArgument<const char*>()(ap);
@@ -84,7 +84,7 @@ requires(IsSame<CharType, char>) struct PrintfImpl : public PrintfImplementation
 
 template<typename T, typename V>
 struct ArgvNextArgument {
-    ALWAYS_INLINE T operator()(V) const
+    AK_ALWAYS_INLINE T operator()(V) const
     {
         static_assert(sizeof(V) != sizeof(V), "Base instantiated");
         return declval<T>();
@@ -93,7 +93,7 @@ struct ArgvNextArgument {
 
 template<typename V>
 struct ArgvNextArgument<char*, V> {
-    ALWAYS_INLINE char* operator()(V arg) const
+    AK_ALWAYS_INLINE char* operator()(V arg) const
     {
         if (arg.argc == 0)
             fail("Not enough arguments");
@@ -106,7 +106,7 @@ struct ArgvNextArgument<char*, V> {
 
 template<typename V>
 struct ArgvNextArgument<const char*, V> {
-    ALWAYS_INLINE const char* operator()(V arg) const
+    AK_ALWAYS_INLINE const char* operator()(V arg) const
     {
         if (arg.argc == 0)
             return "";
@@ -119,7 +119,7 @@ struct ArgvNextArgument<const char*, V> {
 
 template<typename V>
 struct ArgvNextArgument<int, V> {
-    ALWAYS_INLINE int operator()(V arg) const
+    AK_ALWAYS_INLINE int operator()(V arg) const
     {
         if (arg.argc == 0)
             return 0;
@@ -132,7 +132,7 @@ struct ArgvNextArgument<int, V> {
 
 template<typename V>
 struct ArgvNextArgument<unsigned, V> {
-    ALWAYS_INLINE unsigned operator()(V arg) const
+    AK_ALWAYS_INLINE unsigned operator()(V arg) const
     {
         if (arg.argc == 0)
             return 0;
@@ -145,7 +145,7 @@ struct ArgvNextArgument<unsigned, V> {
 
 template<typename V>
 struct ArgvNextArgument<i64, V> {
-    ALWAYS_INLINE i64 operator()(V arg) const
+    AK_ALWAYS_INLINE i64 operator()(V arg) const
     {
         if (arg.argc == 0)
             return 0;
@@ -158,7 +158,7 @@ struct ArgvNextArgument<i64, V> {
 
 template<typename V>
 struct ArgvNextArgument<u64, V> {
-    ALWAYS_INLINE u64 operator()(V arg) const
+    AK_ALWAYS_INLINE u64 operator()(V arg) const
     {
         if (arg.argc == 0)
             return 0;
@@ -171,7 +171,7 @@ struct ArgvNextArgument<u64, V> {
 
 template<typename V>
 struct ArgvNextArgument<double, V> {
-    ALWAYS_INLINE double operator()(V arg) const
+    AK_ALWAYS_INLINE double operator()(V arg) const
     {
         if (arg.argc == 0)
             return 0;
@@ -184,7 +184,7 @@ struct ArgvNextArgument<double, V> {
 
 template<typename V>
 struct ArgvNextArgument<int*, V> {
-    ALWAYS_INLINE int* operator()(V) const
+    AK_ALWAYS_INLINE int* operator()(V) const
     {
         VERIFY_NOT_REACHED();
         return nullptr;


### PR DESCRIPTION
`ALWAYS_INLINE` is used by a variety of ports, and due to how we have
factored our code, our definition leaks from AK, through LibC and into
the ports includes.

To avoid duplicate definitions lets just rename our version with the
`AK_` prefix.