### PR TITLE
LibWeb: Don’t put a backslash after escape sequences in text–like tokens

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -761,6 +761,7 @@ Token Tokenizer::consume_a_url_token()
             if (is_valid_escape_sequence(start_of_input_stream_twin())) {
                 // consume an escaped code point and append the returned code point to the <url-token>’s value.
                 builder.append_code_point(consume_escaped_code_point());
+                continue;
             } else {
                 // Otherwise, this is a parse error.
                 log_parse_error();
@@ -1037,6 +1038,7 @@ Token Tokenizer::consume_string_token(u32 ending_code_point)
             // point and append the returned code point to the <string-token>’s value.
             auto escaped = consume_escaped_code_point();
             builder.append_code_point(escaped);
+            continue;
         }
 
         // anything else


### PR DESCRIPTION
Previously, a string token like '\41' would be tokenized to 'A\'. This could be seen on Wikipedia headlines.

current master | this pr
---|---
![](https://user-images.githubusercontent.com/16520278/159136266-5cfa92a3-6718-406b-99e9-6302ca6ca9a3.png) | ![](https://user-images.githubusercontent.com/16520278/159136265-b776489b-08c0-4785-b0bb-1a15d00993d7.png) 
