### PR TITLE
LibC: Terminating 0 is automatically appended in vswprintf

### DIFF
--- a/Userland/Libraries/LibC/wstdio.cpp
+++ b/Userland/Libraries/LibC/wstdio.cpp
@@ -207,6 +207,10 @@ int vswprintf(wchar_t* __restrict wcs, size_t max_length, wchar_t const* __restr
         ++length_so_far;
     },
         wcs, fmt, args);
+    if (length_so_far < max_length)
+        wcs[length_so_far] = L'\0';
+    else
+        wcs[max_length - 1] = L'\0';
     return static_cast<int>(length_so_far);
 }
 


### PR DESCRIPTION
It should now behave the same way as _char*_ variant _vsnprintf_.

From https://en.cppreference.com/w/cpp/io/c/vfwprintf
3) Writes the results to a wide string buffer. At most size-1 wide characters are written followed by null wide character.