### PR TITLE
AK: Allow printing wide characters using %ls modifier

### DIFF
--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -47,6 +47,7 @@ set(AK_TEST_SOURCES
     TestNonnullRefPtr.cpp
     TestNumberFormat.cpp
     TestOptional.cpp
+    TestPrint.cpp
     TestQueue.cpp
     TestQuickSort.cpp
     TestRedBlackTree.cpp

--- a/Tests/AK/TestPrint.cpp
+++ b/Tests/AK/TestPrint.cpp
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+#include <wchar.h>
+
+TEST_CASE(swprint_no_format)
+{
+    wchar_t buffer[256];
+    size_t len = swprintf(buffer, 64, L"Well, hello friends!");
+
+    VERIFY(wcscmp(buffer, L"Well, hello friends!") == 0);
+    VERIFY(wcscmp(buffer, L"Well, hello friends") != 0);
+    VERIFY(wcslen(buffer) == len);
+}
+
+TEST_CASE(swprint_single_wchar_argument)
+{
+    wchar_t buffer[256];
+    size_t len = swprintf(buffer, 64, L"Well, %ls friends!", L"hello");
+
+    VERIFY(wcscmp(buffer, L"Well, hello friends!") == 0);
+    VERIFY(wcscmp(buffer, L"Well, hello friends") != 0);
+    VERIFY(wcslen(buffer) == len);
+}
+
+TEST_CASE(swprint_single_char_argument)
+{
+    wchar_t buffer[256];
+    size_t len = swprintf(buffer, 64, L"Well, %s friends!", "hello");
+
+    VERIFY(wcscmp(buffer, L"Well, hello friends!") == 0);
+    VERIFY(wcscmp(buffer, L"Well, hello friends") != 0);
+    VERIFY(wcslen(buffer) == len);
+}
+
+TEST_CASE(swprint_single_narrow_char_argument)
+{
+    wchar_t buffer[256];
+    size_t len = swprintf(buffer, 64, L"Well, %hs friends!", "hello");
+
+    VERIFY(wcscmp(buffer, L"Well, hello friends!") == 0);
+    VERIFY(wcscmp(buffer, L"Well, hello friends") != 0);
+    VERIFY(wcslen(buffer) == len);
+}
+
+TEST_CASE(swprint_mixed_arguments)
+{
+    wchar_t buffer[256];
+    size_t len = swprintf(buffer, 64, L"Well, %ls friends! %hs is less then %s.", L"hello", "10", "20");
+
+    VERIFY(wcscmp(buffer, L"Well, hello friends! 10 is less then 20.") == 0);
+    VERIFY(wcscmp(buffer, L"Well, hello friends! 10 is less then 2.") != 0);
+    VERIFY(wcslen(buffer) == len);
+}

--- a/Userland/Utilities/printf.cpp
+++ b/Userland/Utilities/printf.cpp
@@ -118,6 +118,17 @@ struct ArgvNextArgument<const char*, V> {
 };
 
 template<typename V>
+struct ArgvNextArgument<const wchar_t*, V> {
+    ALWAYS_INLINE const wchar_t* operator()(V arg) const
+    {
+        if (arg.argc == 0)
+            return L"";
+
+        return L"";
+    }
+};
+
+template<typename V>
 struct ArgvNextArgument<int, V> {
     ALWAYS_INLINE int operator()(V arg) const
     {


### PR DESCRIPTION
The commit relates to [this](https://discord.com/channels/830522505605283862/860165510263996427/953963329636954172) Discord discussion.

Basically it fixes printing wide characters using %ls printf-style modifier, for example

```
wchar_t text[] = L"SerenityOS";
wprintf(L"Hello %ls!", text);
```

Before the change, the _text_ was handled as _char*_ array in the wprintf function, causing invalid outputs.