### PR TITLE
KeyboardMapper: Set button text and stored keymap to a first code point on button click

### DIFF
--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -8,6 +8,7 @@
 
 #include "KeyboardMapperWidget.h"
 #include "KeyPositions.h"
+#include <AK/Utf8View.h>
 #include <LibCore/Stream.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/InputBox.h>
@@ -71,7 +72,7 @@ void KeyboardMapperWidget::create_frame()
                 if (value.length() == 0)
                     map[index] = '\0'; // Empty string
                 else
-                    map[index] = value[0];
+                    map[index] = *Utf8View(value).begin();
 
                 window()->set_modified(true);
             }

--- a/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
+++ b/Userland/Applications/KeyboardMapper/KeyboardMapperWidget.cpp
@@ -66,13 +66,17 @@ void KeyboardMapperWidget::create_frame()
                 auto index = keys[i].map_index;
                 VERIFY(index > 0);
 
-                tmp_button.set_text(value);
                 u32* map = map_from_name(m_current_map_name);
 
                 if (value.length() == 0)
                     map[index] = '\0'; // Empty string
                 else
                     map[index] = *Utf8View(value).begin();
+
+                StringBuilder sb;
+                sb.append_code_point(map[index]);
+
+                tmp_button.set_text(sb.to_string());
 
                 window()->set_modified(true);
             }


### PR DESCRIPTION
- **KeyboardMapper: Set key to a first code point on button click**

  Previously, we were only using the first byte of the string, which meant that we couldn’t put correct characters outside of the Basic Latin (U+0000..U+007F) and Latin-1 Supplement (U+0080..U+00FF) blocks.

- **KeyboardMapper: Reduce key button text to the first code point on click**

  The keyboard map only supports one code point per key, so not trimming the text was a bit misleading.