### PR TITLE
HackStudio: Allow customizing what the "Build" and "Run" buttons do

### DIFF
--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -44,6 +44,7 @@ set(SOURCES
     Locator.cpp
     Project.cpp
     ProjectBuilder.cpp
+    ProjectConfig.cpp
     ProjectDeclarations.cpp
     ProjectFile.cpp
     ProjectTemplate.cpp

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -185,6 +185,7 @@ HackStudioWidget::HackStudioWidget(String path_to_project)
     }
 
     m_project_builder = make<ProjectBuilder>(*m_terminal_wrapper, *m_project);
+    project().model().set_should_show_dotfiles(Config::read_bool("HackStudio", "Global", "ShowDotfiles", false));
 }
 
 void HackStudioWidget::update_actions()
@@ -1394,7 +1395,9 @@ void HackStudioWidget::create_view_menu(GUI::Window& window)
     });
     auto show_dotfiles_action = GUI::Action::create_checkable("S&how Dotfiles", { Mod_Ctrl, Key_H }, [&](auto& checked) {
         project().model().set_should_show_dotfiles(checked.is_checked());
+        Config::write_bool("HackStudio", "Global", "ShowDotfiles", checked.is_checked());
     });
+    show_dotfiles_action->set_checked(Config::read_bool("HackStudio", "Global", "ShowDotfiles", false));
 
     auto& view_menu = window.add_menu("&View");
     view_menu.add_action(hide_action_tabs_action);

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -137,6 +137,8 @@ HackStudioWidget::HackStudioWidget(String path_to_project)
         m_stop_action->set_enabled(false);
     };
 
+    m_open_project_configuration_action = create_open_project_configuration_action();
+
     m_build_action = create_build_action();
     m_run_action = create_run_action();
     m_stop_action = create_stop_action();
@@ -1366,6 +1368,9 @@ void HackStudioWidget::create_edit_menu(GUI::Window& window)
     });
     vim_emulation_setting_action->set_checked(false);
     edit_menu.add_action(vim_emulation_setting_action);
+
+    edit_menu.add_separator();
+    edit_menu.add_action(*m_open_project_configuration_action);
 }
 
 void HackStudioWidget::create_build_menu(GUI::Window& window)
@@ -1641,6 +1646,33 @@ void HackStudioWidget::create_location_history_actions()
         update_history_actions();
     });
     m_locations_history_forward_action->set_enabled(false);
+}
+
+NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_project_configuration_action()
+{
+    return GUI::Action::create("Project Configuration", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png").release_value(), [&](auto&) {
+        auto parent_directory = LexicalPath::dirname(Project::config_file_path);
+        auto absolute_config_file_path = LexicalPath::absolute_path(m_project->root_path(), Project::config_file_path);
+
+        if (!Core::File::exists(absolute_config_file_path)) {
+            if (Core::File::exists(parent_directory) && !Core::File::is_directory(parent_directory)) {
+                GUI::MessageBox::show_error(window(), String::formatted("Cannot create the '{}' directory because there is already a file with that name", parent_directory));
+                return;
+            }
+
+            mkdir(LexicalPath::absolute_path(m_project->root_path(), parent_directory).characters(), 0755);
+
+            auto file = Core::File::open(absolute_config_file_path, Core::OpenMode::WriteOnly);
+            file.value()->write(
+                "{\n"
+                "    \"build_command\": \"your build command here\",\n"
+                "    \"run_command\": \"your run command here\"\n"
+                "}\n");
+            file.value()->close();
+        }
+
+        open_file(Project::config_file_path);
+    });
 }
 
 HackStudioWidget::ProjectLocation HackStudioWidget::current_project_location() const

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -120,6 +120,7 @@ private:
     NonnullRefPtr<GUI::Action> create_run_action();
     NonnullRefPtr<GUI::Action> create_stop_action();
     NonnullRefPtr<GUI::Action> create_toggle_syntax_highlighting_mode_action();
+    NonnullRefPtr<GUI::Action> create_open_project_configuration_action();
     void create_location_history_actions();
 
     void add_new_editor_tab_widget(GUI::Widget& parent);
@@ -238,6 +239,7 @@ private:
     RefPtr<GUI::Action> m_locations_history_back_action;
     RefPtr<GUI::Action> m_locations_history_forward_action;
     RefPtr<GUI::Action> m_toggle_semantic_highlighting_action;
+    RefPtr<GUI::Action> m_open_project_configuration_action;
 
     RefPtr<Gfx::Font> read_editor_font_from_config();
     void change_editor_font(RefPtr<Gfx::Font>);

--- a/Userland/DevTools/HackStudio/Project.cpp
+++ b/Userland/DevTools/HackStudio/Project.cpp
@@ -10,7 +10,7 @@
 
 namespace HackStudio {
 
-Project::Project(const String& root_path)
+Project::Project(String const& root_path)
     : m_root_path(root_path)
 {
     m_model = GUI::FileSystemModel::create(root_path, GUI::FileSystemModel::Mode::FilesAndDirectories);
@@ -64,6 +64,15 @@ bool Project::project_is_serenity() const
     // FIXME: Improve this heuristic
     // Running "Meta/serenity.sh copy-src" installs the serenity repository at this path in the home directory
     return m_root_path.ends_with("Source/serenity");
+}
+
+NonnullOwnPtr<ProjectConfig> Project::config() const
+{
+    auto config_or_error = ProjectConfig::try_load_project_config(LexicalPath::absolute_path(m_root_path, config_file_path));
+    if (config_or_error.is_error())
+        return ProjectConfig::create_empty();
+
+    return config_or_error.release_value();
 }
 
 }

--- a/Userland/DevTools/HackStudio/Project.h
+++ b/Userland/DevTools/HackStudio/Project.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "ProjectConfig.h"
 #include "ProjectFile.h"
 #include <AK/LexicalPath.h>
 #include <AK/Noncopyable.h>
@@ -32,8 +33,11 @@ public:
     String to_absolute_path(String const&) const;
     bool project_is_serenity() const;
 
+    static constexpr StringView config_file_path = ".hackstudio/config.json";
+    NonnullOwnPtr<ProjectConfig> config() const;
+
 private:
-    explicit Project(const String& root_path);
+    explicit Project(String const& root_path);
 
     RefPtr<GUI::FileSystemModel> m_model;
 

--- a/Userland/DevTools/HackStudio/ProjectBuilder.cpp
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.cpp
@@ -16,6 +16,7 @@ namespace HackStudio {
 
 ProjectBuilder::ProjectBuilder(NonnullRefPtr<TerminalWrapper> terminal, Project const& project)
     : m_project_root(project.root_path())
+    , m_project(project)
     , m_terminal(move(terminal))
     , m_is_serenity(project.project_is_serenity() ? IsSerenityRepo::Yes : IsSerenityRepo::No)
 {
@@ -24,6 +25,12 @@ ProjectBuilder::ProjectBuilder(NonnullRefPtr<TerminalWrapper> terminal, Project 
 ErrorOr<void> ProjectBuilder::build(StringView active_file)
 {
     m_terminal->clear_including_history();
+
+    if (auto command = m_project.config()->build_command(); command.has_value()) {
+        TRY(m_terminal->run_command(command.value()));
+        return {};
+    }
+
     if (active_file.is_null())
         return Error::from_string_literal("no active file"sv);
 
@@ -44,6 +51,11 @@ ErrorOr<void> ProjectBuilder::build(StringView active_file)
 
 ErrorOr<void> ProjectBuilder::run(StringView active_file)
 {
+    if (auto command = m_project.config()->run_command(); command.has_value()) {
+        TRY(m_terminal->run_command(command.value()));
+        return {};
+    }
+
     if (active_file.is_null())
         return Error::from_string_literal("no active file"sv);
 

--- a/Userland/DevTools/HackStudio/ProjectBuilder.h
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.h
@@ -49,6 +49,7 @@ private:
     static ErrorOr<void> verify_cmake_is_installed();
 
     String m_project_root;
+    Project const& m_project;
     NonnullRefPtr<TerminalWrapper> m_terminal;
     IsSerenityRepo m_is_serenity { IsSerenityRepo::No };
     String m_serenity_component_cmake_file;

--- a/Userland/DevTools/HackStudio/ProjectConfig.cpp
+++ b/Userland/DevTools/HackStudio/ProjectConfig.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ProjectConfig.h"
+#include <AK/NonnullOwnPtr.h>
+#include <LibCore/File.h>
+
+namespace HackStudio {
+
+ProjectConfig::ProjectConfig(JsonObject config)
+    : m_config(move(config))
+{
+}
+
+ErrorOr<NonnullOwnPtr<ProjectConfig>> ProjectConfig::try_load_project_config(String path)
+{
+    auto file = TRY(Core::File::open(path, Core::OpenMode::ReadOnly));
+    auto file_contents = file->read_all();
+    file->close();
+
+    auto json = TRY(JsonValue::from_string(StringView { file_contents }));
+    if (!json.is_object())
+        return Error::from_string_literal("The topmost JSON element is not an object");
+
+    return adopt_own(*new ProjectConfig(json.as_object()));
+}
+
+NonnullOwnPtr<ProjectConfig> ProjectConfig::create_empty()
+{
+    JsonObject empty {};
+    return adopt_own(*new ProjectConfig(empty));
+}
+
+Optional<String> ProjectConfig::read_key(String key_name) const
+{
+    auto const& value = m_config.get(key_name);
+    if (!value.is_string())
+        return {};
+
+    return { value.as_string() };
+}
+
+}

--- a/Userland/DevTools/HackStudio/ProjectConfig.h
+++ b/Userland/DevTools/HackStudio/ProjectConfig.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/JsonObject.h>
+#include <AK/Optional.h>
+#include <AK/OwnPtr.h>
+#include <LibCore/Object.h>
+
+namespace HackStudio {
+
+class ProjectConfig {
+public:
+    static ErrorOr<NonnullOwnPtr<ProjectConfig>> try_load_project_config(String path);
+    static NonnullOwnPtr<ProjectConfig> create_empty();
+
+    ProjectConfig(JsonObject);
+
+    Optional<String> build_command() const { return read_key("build_command"); }
+    Optional<String> run_command() const { return read_key("run_command"); }
+
+private:
+    Optional<String> read_key(String key_name) const;
+
+    JsonObject m_config;
+};
+
+}


### PR DESCRIPTION
Right now we have a few hard coded commands we run when pressing the "Build" or "Run" buttons.

This PR introduces a way to store project-specific settings using a simple JSON file in the `.hackstudio/config.json` path in the project's root. Right now the user is expected to edit this file by hand.

There are only 2 settings that can be configured through this file for now: `"build_command"` and `"run_command"` which are the point of this PR.

The last commit is unrelated, it's just something that was bugging me while testing