### PR TITLE
LibWeb: Implement the :focus-within selector

### DIFF
--- a/Base/res/html/misc/focus.html
+++ b/Base/res/html/misc/focus.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>:focus and :focus-within test</title>
+    <style>
+        :focus {
+            background-color: magenta;
+        }
+        p.focus-within-test:focus-within {
+            background-color: lime;
+        }
+    </style>
+</head>
+<body>
+    <h1>:focus and :focus-within test</h1>
+    <p>
+        Anything with :focus will have a magenta background.
+        <button>I'm a button</button>
+        <input type="text" value="Hello friends!"/>
+    </p>
+    <p class="focus-within-test">
+        This paragraph will turn green if anything inside it is focused.
+        <button>I'm a button</button>
+        <input type="text" value="Hello friends!"/>
+    </p>
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -101,6 +101,7 @@
             <li><a href="not-selector.html">:not()</a></li>
             <li><a href="where-selector.html">:where()</a></li>
             <li><a href="hover.html">:hover</a></li>
+            <li><a href="focus.html">:focus</a></li>
             <li><h3>Properties</h3></li>
             <li><a href="backgrounds.html">Backgrounds</a></li>
             <li><a href="background-repeat-test.html">Background-repeat</a></li>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -506,6 +506,8 @@ Result<Selector::SimpleSelector, Parser::ParsingResult> Parser::parse_simple_sel
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::FirstOfType;
             } else if (pseudo_name.equals_ignoring_case("focus")) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Focus;
+            } else if (pseudo_name.equals_ignoring_case("focus-within")) {
+                simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::FocusWithin;
             } else if (pseudo_name.equals_ignoring_case("hover")) {
                 simple_selector.pseudo_class.type = Selector::SimpleSelector::PseudoClass::Type::Hover;
             } else if (pseudo_name.equals_ignoring_case("last-child")) {

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -60,6 +60,7 @@ public:
                 Visited,
                 Hover,
                 Focus,
+                FocusWithin,
                 FirstChild,
                 LastChild,
                 OnlyChild,
@@ -185,6 +186,8 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "hover"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Focus:
         return "focus"sv;
+    case Selector::SimpleSelector::PseudoClass::Type::FocusWithin:
+        return "focus-within"sv;
     case Selector::SimpleSelector::PseudoClass::Type::FirstChild:
         return "first-child"sv;
     case Selector::SimpleSelector::PseudoClass::Type::LastChild:

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -137,6 +137,10 @@ static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoCla
         return matches_hover_pseudo_class(element);
     case CSS::Selector::SimpleSelector::PseudoClass::Type::Focus:
         return element.is_focused();
+    case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusWithin: {
+        auto* focused_element = element.document().focused_element();
+        return focused_element && element.is_inclusive_ancestor_of(*focused_element);
+    }
     case CSS::Selector::SimpleSelector::PseudoClass::Type::FirstChild:
         return !element.previous_element_sibling();
     case CSS::Selector::SimpleSelector::PseudoClass::Type::LastChild:

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -405,6 +405,9 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Focus:
                     pseudo_class_description = "Focus";
                     break;
+                case CSS::Selector::SimpleSelector::PseudoClass::Type::FocusWithin:
+                    pseudo_class_description = "FocusWithin";
+                    break;
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Empty:
                     pseudo_class_description = "Empty";
                     break;


### PR DESCRIPTION
This matches if it has focus, or any nodes inside it do.

![image](https://user-images.githubusercontent.com/222642/159164699-d1b64889-8878-4cd8-b837-80c9921f591d.png)

(IIRC Discord makes use of this in their CSS, but it's probably not that noticeable.)