### PR TITLE
grep: Recognize mode based on the program name

### DIFF
--- a/Base/etc/shellrc
+++ b/Base/etc/shellrc
@@ -28,8 +28,6 @@ alias ue=UserspaceEmulator
 alias fe=FontEditor
 alias ss=Spreadsheet
 
-alias rgrep="grep -r"
-alias egrep="grep -E"
 alias ll='ls -l'
 
 if [ "$(id -u)" = "0" ] {

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -51,6 +51,9 @@ foreach(CMD_SRC ${CMD_SOURCES})
     endif()
 endforeach()
 
+install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/egrep SYMBOLIC)")
+install(CODE "file(CREATE_LINK grep ${CMAKE_INSTALL_PREFIX}/bin/rgrep SYMBOLIC)")
+
 target_link_libraries(abench LibAudio LibMain LibCore)
 target_link_libraries(adjtime LibMain)
 target_link_libraries(allocate LibMain)

--- a/Userland/Utilities/grep.cpp
+++ b/Userland/Utilities/grep.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/Assertions.h>
+#include <AK/LexicalPath.h>
 #include <AK/ScopeGuard.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
@@ -36,10 +37,12 @@ ErrorOr<int> serenity_main(Main::Arguments args)
 {
     TRY(Core::System::pledge("stdio rpath", nullptr));
 
+    String program_name = AK::LexicalPath::basename(args.strings[0]);
+
     Vector<const char*> files;
 
-    bool recursive { false };
-    bool use_ere { false };
+    bool recursive = (program_name == "rgrep"sv);
+    bool use_ere = (program_name == "egrep"sv);
     Vector<const char*> patterns;
     BinaryFileMode binary_mode { BinaryFileMode::Binary };
     bool case_insensitive = false;


### PR DESCRIPTION
This now works in all shells and scripts, not just in ours.

Once again, this is needed for the `binutils` configure script (and probably many others).