### PR TITLE
LIbVT: Fix copy paste regression I introduced in #13102

### DIFF
--- a/Userland/Libraries/LibVT/Attribute.h
+++ b/Userland/Libraries/LibVT/Attribute.h
@@ -55,7 +55,7 @@ struct Attribute {
     constexpr Color effective_background_color() const { return has_flag(flags, Flags::Negative) ? foreground_color : background_color; }
     constexpr Color effective_foreground_color() const { return has_flag(flags, Flags::Negative) ? background_color : foreground_color; }
 
-    constexpr bool is_untouched() const { return has_flag(flags, Flags::Touched); }
+    constexpr bool is_untouched() const { return !has_flag(flags, Flags::Touched); }
 
     Flags flags { Flags::NoAttributes };
 


### PR DESCRIPTION
I accidentally inverted this behavior in commit 2042d909972

Previously it read:
```cpp
constexpr bool is_untouched() const { return !(flags & Touched); }
```