### PR TITLE
LibWeb+LibTextCodec: Avoid some allocations during text decoding

### DIFF
--- a/AK/String.h
+++ b/AK/String.h
@@ -302,6 +302,18 @@ public:
         return (... || this->operator==(forward<Ts>(strings)));
     }
 
+    template<typename... Ts>
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of_ignoring_case(Ts&&... strings) const
+    {
+        return (... ||
+                [this, &strings]() -> bool {
+            if constexpr (requires(Ts a) { a.view()->StringView; })
+                return this->equals_ignoring_case(forward<Ts>(strings.view()));
+            else
+                return this->equals_ignoring_case(forward<Ts>(strings));
+        }());
+    }
+
 private:
     RefPtr<StringImpl> m_impl;
 };

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -279,6 +279,18 @@ public:
         return (... || this->operator==(forward<Ts>(strings)));
     }
 
+    template<typename... Ts>
+    [[nodiscard]] ALWAYS_INLINE constexpr bool is_one_of_ignoring_case(Ts&&... strings) const
+    {
+        return (... ||
+                [this, &strings]() -> bool {
+            if constexpr (requires(Ts a) { a.view()->StringView; })
+                return this->equals_ignoring_case(forward<Ts>(strings.view()));
+            else
+                return this->equals_ignoring_case(forward<Ts>(strings));
+        }());
+    }
+
 private:
     friend class String;
     const char* m_characters { nullptr };

--- a/Userland/Libraries/LibTextCodec/Decoder.cpp
+++ b/Userland/Libraries/LibTextCodec/Decoder.cpp
@@ -57,91 +57,91 @@ Decoder* decoder_for(const String& a_encoding)
 }
 
 // https://encoding.spec.whatwg.org/#concept-encoding-get
-Optional<String> get_standardized_encoding(const String& encoding)
+Optional<StringView> get_standardized_encoding(StringView encoding)
 {
-    String trimmed_lowercase_encoding = encoding.trim_whitespace().to_lowercase();
+    encoding = encoding.trim_whitespace();
 
-    if (trimmed_lowercase_encoding.is_one_of("unicode-1-1-utf-8", "unicode11utf8", "unicode20utf8", "utf-8", "utf8", "x-unicode20utf8"))
+    if (encoding.is_one_of_ignoring_case("unicode-1-1-utf-8", "unicode11utf8", "unicode20utf8", "utf-8", "utf8", "x-unicode20utf8"))
         return "UTF-8";
-    if (trimmed_lowercase_encoding.is_one_of("866", "cp866", "csibm866", "ibm866"))
+    if (encoding.is_one_of_ignoring_case("866", "cp866", "csibm866", "ibm866"))
         return "IBM866";
-    if (trimmed_lowercase_encoding.is_one_of("csisolatin2", "iso-8859-2", "iso-ir-101", "iso8859-2", "iso88592", "iso_8859-2", "iso_8859-2:1987", "l2", "latin2"))
+    if (encoding.is_one_of_ignoring_case("csisolatin2", "iso-8859-2", "iso-ir-101", "iso8859-2", "iso88592", "iso_8859-2", "iso_8859-2:1987", "l2", "latin2"))
         return "ISO-8859-2";
-    if (trimmed_lowercase_encoding.is_one_of("csisolatin3", "iso-8859-3", "iso-ir-109", "iso8859-3", "iso88593", "iso_8859-3", "iso_8859-3:1988", "l3", "latin3"))
+    if (encoding.is_one_of_ignoring_case("csisolatin3", "iso-8859-3", "iso-ir-109", "iso8859-3", "iso88593", "iso_8859-3", "iso_8859-3:1988", "l3", "latin3"))
         return "ISO-8859-3";
-    if (trimmed_lowercase_encoding.is_one_of("csisolatin4", "iso-8859-4", "iso-ir-110", "iso8859-4", "iso88594", "iso_8859-4", "iso_8859-4:1989", "l4", "latin4"))
+    if (encoding.is_one_of_ignoring_case("csisolatin4", "iso-8859-4", "iso-ir-110", "iso8859-4", "iso88594", "iso_8859-4", "iso_8859-4:1989", "l4", "latin4"))
         return "ISO-8859-4";
-    if (trimmed_lowercase_encoding.is_one_of("csisolatincyrillic", "cyrillic", "iso-8859-5", "iso-ir-144", "iso8859-5", "iso88595", "iso_8859-5", "iso_8859-5:1988"))
+    if (encoding.is_one_of_ignoring_case("csisolatincyrillic", "cyrillic", "iso-8859-5", "iso-ir-144", "iso8859-5", "iso88595", "iso_8859-5", "iso_8859-5:1988"))
         return "ISO-8859-5";
-    if (trimmed_lowercase_encoding.is_one_of("arabic", "asmo-708", "csiso88596e", "csiso88596i", "csisolatinarabic", "ecma-114", "iso-8859-6", "iso-8859-6-e", "iso-8859-6-i", "iso-ir-127", "iso8859-6", "iso88596", "iso_8859-6", "iso_8859-6:1987"))
+    if (encoding.is_one_of_ignoring_case("arabic", "asmo-708", "csiso88596e", "csiso88596i", "csisolatinarabic", "ecma-114", "iso-8859-6", "iso-8859-6-e", "iso-8859-6-i", "iso-ir-127", "iso8859-6", "iso88596", "iso_8859-6", "iso_8859-6:1987"))
         return "ISO-8859-6";
-    if (trimmed_lowercase_encoding.is_one_of("csisolatingreek", "ecma-118", "elot_928", "greek", "greek8", "iso-8859-7", "iso-ir-126", "iso8859-7", "iso88597", "iso_8859-7", "iso_8859-7:1987", "sun_eu_greek"))
+    if (encoding.is_one_of_ignoring_case("csisolatingreek", "ecma-118", "elot_928", "greek", "greek8", "iso-8859-7", "iso-ir-126", "iso8859-7", "iso88597", "iso_8859-7", "iso_8859-7:1987", "sun_eu_greek"))
         return "ISO-8859-7";
-    if (trimmed_lowercase_encoding.is_one_of("csiso88598e", "csisolatinhebrew", "hebrew", "iso-8859-8", "iso-8859-8-e", "iso-ir-138", "iso8859-8", "iso88598", "iso_8859-8", "iso_8859-8:1988", "visual"))
+    if (encoding.is_one_of_ignoring_case("csiso88598e", "csisolatinhebrew", "hebrew", "iso-8859-8", "iso-8859-8-e", "iso-ir-138", "iso8859-8", "iso88598", "iso_8859-8", "iso_8859-8:1988", "visual"))
         return "ISO-8859-8";
-    if (trimmed_lowercase_encoding.is_one_of("csiso88598i", "iso-8859-8-i", "logical"))
+    if (encoding.is_one_of_ignoring_case("csiso88598i", "iso-8859-8-i", "logical"))
         return "ISO-8859-8-I";
-    if (trimmed_lowercase_encoding.is_one_of("csisolatin6", "iso8859-10", "iso-ir-157", "iso8859-10", "iso885910", "l6", "latin6"))
+    if (encoding.is_one_of_ignoring_case("csisolatin6", "iso8859-10", "iso-ir-157", "iso8859-10", "iso885910", "l6", "latin6"))
         return "ISO-8859-10";
-    if (trimmed_lowercase_encoding.is_one_of("iso-8859-13", "iso8859-13", "iso885913"))
+    if (encoding.is_one_of_ignoring_case("iso-8859-13", "iso8859-13", "iso885913"))
         return "ISO-8859-13";
-    if (trimmed_lowercase_encoding.is_one_of("iso-8859-14", "iso8859-14", "iso885914"))
+    if (encoding.is_one_of_ignoring_case("iso-8859-14", "iso8859-14", "iso885914"))
         return "ISO-8859-14";
-    if (trimmed_lowercase_encoding.is_one_of("csisolatin9", "iso-8859-15", "iso8859-15", "iso885915", "iso_8859-15", "l9"))
+    if (encoding.is_one_of_ignoring_case("csisolatin9", "iso-8859-15", "iso8859-15", "iso885915", "iso_8859-15", "l9"))
         return "ISO-8859-15";
-    if (trimmed_lowercase_encoding == "iso-8859-16")
+    if (encoding.is_one_of_ignoring_case("iso-8859-16"))
         return "ISO-8859-16";
-    if (trimmed_lowercase_encoding.is_one_of("cskoi8r", "koi", "koi8", "koi8-r", "koi8_r"))
+    if (encoding.is_one_of_ignoring_case("cskoi8r", "koi", "koi8", "koi8-r", "koi8_r"))
         return "KOI8-R";
-    if (trimmed_lowercase_encoding.is_one_of("koi8-ru", "koi8-u"))
+    if (encoding.is_one_of_ignoring_case("koi8-ru", "koi8-u"))
         return "KOI8-U";
-    if (trimmed_lowercase_encoding.is_one_of("csmacintosh", "mac", "macintosh", "x-mac-roman"))
+    if (encoding.is_one_of_ignoring_case("csmacintosh", "mac", "macintosh", "x-mac-roman"))
         return "macintosh";
-    if (trimmed_lowercase_encoding.is_one_of("dos-874", "iso-8859-11", "iso8859-11", "iso885911", "tis-620", "windows-874"))
+    if (encoding.is_one_of_ignoring_case("dos-874", "iso-8859-11", "iso8859-11", "iso885911", "tis-620", "windows-874"))
         return "windows-874";
-    if (trimmed_lowercase_encoding.is_one_of("cp1250", "windows-1250", "x-cp1250"))
+    if (encoding.is_one_of_ignoring_case("cp1250", "windows-1250", "x-cp1250"))
         return "windows-1250";
-    if (trimmed_lowercase_encoding.is_one_of("cp1251", "windows-1251", "x-cp1251"))
+    if (encoding.is_one_of_ignoring_case("cp1251", "windows-1251", "x-cp1251"))
         return "windows-1251";
-    if (trimmed_lowercase_encoding.is_one_of("ansi_x3.4-1968", "ascii", "cp1252", "cp819", "csisolatin1", "ibm819", "iso-8859-1", "iso-ir-100", "iso8859-1", "iso88591", "iso_8859-1", "iso_8859-1:1987", "l1", "latin1", "us-ascii", "windows-1252", "x-cp1252"))
+    if (encoding.is_one_of_ignoring_case("ansi_x3.4-1968", "ascii", "cp1252", "cp819", "csisolatin1", "ibm819", "iso-8859-1", "iso-ir-100", "iso8859-1", "iso88591", "iso_8859-1", "iso_8859-1:1987", "l1", "latin1", "us-ascii", "windows-1252", "x-cp1252"))
         return "windows-1252";
-    if (trimmed_lowercase_encoding.is_one_of("cp1253", "windows-1253", "x-cp1253"))
+    if (encoding.is_one_of_ignoring_case("cp1253", "windows-1253", "x-cp1253"))
         return "windows-1253";
-    if (trimmed_lowercase_encoding.is_one_of("cp1254", "csisolatin5", "iso-8859-9", "iso-ir-148", "iso-8859-9", "iso-88599", "iso_8859-9", "iso_8859-9:1989", "l5", "latin5", "windows-1254", "x-cp1254"))
+    if (encoding.is_one_of_ignoring_case("cp1254", "csisolatin5", "iso-8859-9", "iso-ir-148", "iso-8859-9", "iso-88599", "iso_8859-9", "iso_8859-9:1989", "l5", "latin5", "windows-1254", "x-cp1254"))
         return "windows-1254";
-    if (trimmed_lowercase_encoding.is_one_of("cp1255", "windows-1255", "x-cp1255"))
+    if (encoding.is_one_of_ignoring_case("cp1255", "windows-1255", "x-cp1255"))
         return "windows-1255";
-    if (trimmed_lowercase_encoding.is_one_of("cp1256", "windows-1256", "x-cp1256"))
+    if (encoding.is_one_of_ignoring_case("cp1256", "windows-1256", "x-cp1256"))
         return "windows-1256";
-    if (trimmed_lowercase_encoding.is_one_of("cp1257", "windows-1257", "x-cp1257"))
+    if (encoding.is_one_of_ignoring_case("cp1257", "windows-1257", "x-cp1257"))
         return "windows-1257";
-    if (trimmed_lowercase_encoding.is_one_of("cp1258", "windows-1258", "x-cp1258"))
+    if (encoding.is_one_of_ignoring_case("cp1258", "windows-1258", "x-cp1258"))
         return "windows-1258";
-    if (trimmed_lowercase_encoding.is_one_of("x-mac-cyrillic", "x-mac-ukrainian"))
+    if (encoding.is_one_of_ignoring_case("x-mac-cyrillic", "x-mac-ukrainian"))
         return "x-mac-cyrillic";
-    if (trimmed_lowercase_encoding.is_one_of("koi8-r", "koi8r"))
+    if (encoding.is_one_of_ignoring_case("koi8-r", "koi8r"))
         return "koi8-r";
-    if (trimmed_lowercase_encoding.is_one_of("chinese", "csgb2312", "csiso58gb231280", "gb2312", "gb_2312", "gb_2312-80", "gbk", "iso-ir-58", "x-gbk"))
+    if (encoding.is_one_of_ignoring_case("chinese", "csgb2312", "csiso58gb231280", "gb2312", "gb_2312", "gb_2312-80", "gbk", "iso-ir-58", "x-gbk"))
         return "GBK";
-    if (trimmed_lowercase_encoding == "gb18030")
+    if (encoding.is_one_of_ignoring_case("gb18030"))
         return "gb18030";
-    if (trimmed_lowercase_encoding.is_one_of("big5", "big5-hkscs", "cn-big5", "csbig5", "x-x-big5"))
+    if (encoding.is_one_of_ignoring_case("big5", "big5-hkscs", "cn-big5", "csbig5", "x-x-big5"))
         return "Big5";
-    if (trimmed_lowercase_encoding.is_one_of("cseucpkdfmtjapanese", "euc-jp", "x-euc-jp"))
+    if (encoding.is_one_of_ignoring_case("cseucpkdfmtjapanese", "euc-jp", "x-euc-jp"))
         return "EUC-JP";
-    if (trimmed_lowercase_encoding.is_one_of("csiso2022jp", "iso-2022-jp"))
+    if (encoding.is_one_of_ignoring_case("csiso2022jp", "iso-2022-jp"))
         return "ISO-2022-JP";
-    if (trimmed_lowercase_encoding.is_one_of("csshiftjis", "ms932", "ms_kanji", "shift-jis", "shift_jis", "sjis", "windows-31j", "x-sjis"))
+    if (encoding.is_one_of_ignoring_case("csshiftjis", "ms932", "ms_kanji", "shift-jis", "shift_jis", "sjis", "windows-31j", "x-sjis"))
         return "Shift_JIS";
-    if (trimmed_lowercase_encoding.is_one_of("cseuckr", "csksc56011987", "euc-kr", "iso-ir-149", "korean", "ks_c_5601-1987", "ks_c_5601-1989", "ksc5601", "ksc_5601", "windows-949"))
+    if (encoding.is_one_of_ignoring_case("cseuckr", "csksc56011987", "euc-kr", "iso-ir-149", "korean", "ks_c_5601-1987", "ks_c_5601-1989", "ksc5601", "ksc_5601", "windows-949"))
         return "EUC-KR";
-    if (trimmed_lowercase_encoding.is_one_of("csiso2022kr", "hz-gb-2312", "iso-2022-cn", "iso-2022-cn-ext", "iso-2022-kr", "replacement"))
+    if (encoding.is_one_of_ignoring_case("csiso2022kr", "hz-gb-2312", "iso-2022-cn", "iso-2022-cn-ext", "iso-2022-kr", "replacement"))
         return "replacement";
-    if (trimmed_lowercase_encoding.is_one_of("unicodefffe", "utf-16be"))
+    if (encoding.is_one_of_ignoring_case("unicodefffe", "utf-16be"))
         return "UTF-16BE";
-    if (trimmed_lowercase_encoding.is_one_of("csunicode", "iso-10646-ucs-2", "ucs-2", "unicode", "unicodefeff", "utf-16", "utf-16le"))
+    if (encoding.is_one_of_ignoring_case("csunicode", "iso-10646-ucs-2", "ucs-2", "unicode", "unicodefeff", "utf-16", "utf-16le"))
         return "UTF-16LE";
-    if (trimmed_lowercase_encoding == "x-user-defined")
+    if (encoding.is_one_of_ignoring_case("x-user-defined"))
         return "x-user-defined";
 
     dbgln("TextCodec: Unrecognized encoding: {}", encoding);

--- a/Userland/Libraries/LibTextCodec/Decoder.h
+++ b/Userland/Libraries/LibTextCodec/Decoder.h
@@ -80,7 +80,7 @@ public:
 };
 
 Decoder* decoder_for(String const& encoding);
-Optional<String> get_standardized_encoding(const String& encoding);
+Optional<StringView> get_standardized_encoding(StringView encoding);
 
 // This returns the appropriate Unicode decoder for the sniffed BOM or nullptr if there is no appropriate decoder.
 Decoder* bom_sniff_to_decoder(StringView);

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.cpp
@@ -34,7 +34,7 @@ bool prescan_skip_whitespace_and_slashes(const ByteBuffer& input, size_t& positi
 }
 
 // https://html.spec.whatwg.org/multipage/urls-and-fetching.html#algorithm-for-extracting-a-character-encoding-from-a-meta-element
-Optional<String> extract_character_encoding_from_meta_element(String const& string)
+Optional<StringView> extract_character_encoding_from_meta_element(String const& string)
 {
     // Checking for "charset" is case insensitive, as is getting an encoding.
     // Therefore, stick to lowercase from the start for simplicity.

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLEncodingDetection.h
@@ -15,7 +15,7 @@ namespace Web::HTML {
 bool prescan_should_abort(const ByteBuffer& input, const size_t& position);
 bool prescan_is_whitespace_or_slash(const u8& byte);
 bool prescan_skip_whitespace_and_slashes(const ByteBuffer& input, size_t& position);
-Optional<String> extract_character_encoding_from_meta_element(String const&);
+Optional<StringView> extract_character_encoding_from_meta_element(String const&);
 RefPtr<DOM::Attribute> prescan_get_attribute(DOM::Document&, const ByteBuffer& input, size_t& position);
 Optional<String> run_prescan_byte_stream_algorithm(DOM::Document&, const ByteBuffer& input);
 String run_encoding_sniffing_algorithm(DOM::Document&, const ByteBuffer& input);

--- a/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
+++ b/Userland/Libraries/LibWeb/MimeSniff/MimeType.cpp
@@ -26,8 +26,8 @@ static bool contains_only_http_quoted_string_token_code_points(StringView string
 }
 
 MimeType::MimeType(String type, String subtype)
-    : m_type(type)
-    , m_subtype(subtype)
+    : m_type(move(type))
+    , m_subtype(move(subtype))
 {
     // https://mimesniff.spec.whatwg.org/#parameters
     // A MIME type’s parameters is an ordered map whose keys are ASCII strings and values are strings limited to HTTP quoted-string token code points.

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.cpp
@@ -207,7 +207,7 @@ MimeSniff::MimeType XMLHttpRequest::get_response_mime_type() const
 }
 
 // https://xhr.spec.whatwg.org/#final-charset
-Optional<String> XMLHttpRequest::get_final_encoding() const
+Optional<StringView> XMLHttpRequest::get_final_encoding() const
 {
     // 1. Let label be null.
     Optional<String> label;

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -78,7 +78,7 @@ private:
     void fire_progress_event(const String&, u64, u64);
 
     MimeSniff::MimeType get_response_mime_type() const;
-    Optional<String> get_final_encoding() const;
+    Optional<StringView> get_final_encoding() const;
     MimeSniff::MimeType get_final_mime_type() const;
 
     String get_text_response() const;


### PR DESCRIPTION
Found these while looking at #13164

No functional changes per-se, just some `String`->`StringView` and one `move`.