### PR TITLE
LibGfx: Generalise AntiAliasingPainter::draw_circle() to ellipses, and use for Eyes demo

### DIFF
--- a/Userland/Demos/Eyes/EyesWidget.cpp
+++ b/Userland/Demos/Eyes/EyesWidget.cpp
@@ -20,18 +20,19 @@ void EyesWidget::track_mouse_move(Gfx::IntPoint const& point)
 void EyesWidget::paint_event(GUI::PaintEvent& event)
 {
     GUI::Painter painter(*this);
+    Gfx::AntiAliasingPainter aa_painter { painter };
 
     painter.clear_rect(event.rect(), Gfx::Color());
 
     for (int i = 0; i < m_full_rows; i++) {
         for (int j = 0; j < m_eyes_in_row; j++)
-            render_eyeball(i, j, painter);
+            render_eyeball(i, j, aa_painter);
     }
     for (int i = 0; i < m_extra_columns; ++i)
-        render_eyeball(m_full_rows, i, painter);
+        render_eyeball(m_full_rows, i, aa_painter);
 }
 
-void EyesWidget::render_eyeball(int row, int column, GUI::Painter& painter) const
+void EyesWidget::render_eyeball(int row, int column, Gfx::AntiAliasingPainter& painter) const
 {
     auto eye_width = width() / m_eyes_in_row;
     auto eye_height = height() / m_num_rows;
@@ -40,9 +41,9 @@ void EyesWidget::render_eyeball(int row, int column, GUI::Painter& painter) cons
     auto height_thickness = max(int(eye_height / 5.5), 1);
 
     bounds.shrink(int(eye_width / 12.5), 0);
-    painter.fill_ellipse(bounds, palette().base_text());
+    painter.draw_ellipse(bounds, palette().base_text());
     bounds.shrink(width_thickness, height_thickness);
-    painter.fill_ellipse(bounds, palette().base());
+    painter.draw_ellipse(bounds, palette().base());
 
     Gfx::IntPoint pupil_center = this->pupil_center(bounds);
     Gfx::IntSize pupil_size {
@@ -56,7 +57,7 @@ void EyesWidget::render_eyeball(int row, int column, GUI::Painter& painter) cons
         pupil_size.height()
     };
 
-    painter.fill_ellipse(pupil, palette().base_text());
+    painter.draw_ellipse(pupil, palette().base_text());
 }
 
 Gfx::IntPoint EyesWidget::pupil_center(Gfx::IntRect& eyeball_bounds) const

--- a/Userland/Demos/Eyes/EyesWidget.h
+++ b/Userland/Demos/Eyes/EyesWidget.h
@@ -9,6 +9,7 @@
 
 #include <LibGUI/MouseTracker.h>
 #include <LibGUI/Widget.h>
+#include <LibGfx/AntiAliasingPainter.h>
 
 class EyesWidget final : public GUI::Widget
     , GUI::MouseTracker {
@@ -29,7 +30,7 @@ private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void track_mouse_move(Gfx::IntPoint const&) override;
 
-    void render_eyeball(int row, int column, GUI::Painter&) const;
+    void render_eyeball(int row, int column, Gfx::AntiAliasingPainter& aa_painter) const;
     Gfx::IntPoint pupil_center(Gfx::IntRect& eyeball_bounds) const;
 
     Gfx::IntPoint m_mouse_position;

--- a/Userland/Demos/LibGfxScaleDemo/main.cpp
+++ b/Userland/Demos/LibGfxScaleDemo/main.cpp
@@ -44,15 +44,15 @@ private:
 
 Canvas::Canvas()
 {
-    m_bitmap_1x = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { WIDTH, HEIGHT }, 1).release_value_but_fixme_should_propagate_errors();
-    m_bitmap_2x = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRx8888, { WIDTH, HEIGHT }, 2).release_value_but_fixme_should_propagate_errors();
+    m_bitmap_1x = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, { WIDTH, HEIGHT }, 1).release_value_but_fixme_should_propagate_errors();
+    m_bitmap_2x = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, { WIDTH, HEIGHT }, 2).release_value_but_fixme_should_propagate_errors();
 
     // m_bitmap_1x and m_bitmap_2x have the same logical size, so LibGfx will try to draw them at the same physical size:
     // When drawing on a 2x backing store it'd scale m_bitmap_1x up 2x and paint m_bitmap_2x at its physical size.
     // When drawing on a 1x backing store it'd draw m_bitmap_1x at its physical size, and it would have to scale down m_bitmap_2x to 0.5x its size.
     // But the system can't current scale down, and we want to draw the 2x bitmap at twice the size of the 1x bitmap in this particular application,
     // so make a 1x alias of the 2x bitmap to make LibGfx paint it without any scaling at paint time, mapping once pixel to one pixel.
-    m_bitmap_2x_as_1x = Gfx::Bitmap::try_create_wrapper(Gfx::BitmapFormat::BGRx8888, m_bitmap_2x->physical_size(), 1, m_bitmap_2x->pitch(), m_bitmap_2x->scanline(0)).release_value_but_fixme_should_propagate_errors();
+    m_bitmap_2x_as_1x = Gfx::Bitmap::try_create_wrapper(Gfx::BitmapFormat::BGRA8888, m_bitmap_2x->physical_size(), 1, m_bitmap_2x->pitch(), m_bitmap_2x->scanline(0)).release_value_but_fixme_should_propagate_errors();
 
     Gfx::Painter painter_1x(*m_bitmap_1x);
     draw(painter_1x);
@@ -75,8 +75,10 @@ void Canvas::paint_event(GUI::PaintEvent& event)
 void Canvas::draw(Gfx::Painter& painter)
 {
     auto active_window_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window.png").release_value_but_fixme_should_propagate_errors();
+
     Gfx::WindowTheme::current().paint_normal_frame(painter, Gfx::WindowTheme::WindowState::Active, { 4, 18, WIDTH - 8, HEIGHT - 29 }, "Well hello friends 🐞", *active_window_icon, palette(), { WIDTH - 20, 6, 16, 16 }, 0, false);
 
+    painter.fill_rect({ 4, 25, WIDTH - 8, HEIGHT - 30 }, palette().color(Gfx::ColorRole::Background));
     painter.draw_rect({ 20, 34, WIDTH - 40, HEIGHT - 45 }, palette().color(Gfx::ColorRole::Selection), true);
     painter.draw_rect({ 24, 38, WIDTH - 48, HEIGHT - 53 }, palette().color(Gfx::ColorRole::Selection));
 

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -178,6 +178,9 @@ void Gfx::AntiAliasingPainter::draw_circle(IntPoint center, int radius, Color co
     Inline comments are from the paper.
     */
 
+    center *= m_underlying_painter.scale();
+    radius *= m_underlying_painter.scale();
+
     // TODO: Generalize to ellipses (see paper)
 
     // These happen to be the same here, but are treated separately in the paper:
@@ -337,11 +340,11 @@ void Gfx::AntiAliasingPainter::fill_rect_with_rounded_corners(IntRect const& a_r
         a_rect.x() + a_rect.width() - top_right_radius,
         a_rect.y() + top_right_radius,
     };
-    IntPoint bottom_right_corner {
+    IntPoint bottom_left_corner {
         a_rect.x() + bottom_left_radius,
         a_rect.y() + a_rect.height() - bottom_right_radius
     };
-    IntPoint bottom_left_corner {
+    IntPoint bottom_right_corner {
         a_rect.x() + a_rect.width() - bottom_left_radius,
         a_rect.y() + a_rect.height() - bottom_left_radius
     };

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -29,10 +29,13 @@ public:
     void translate(FloatPoint const& delta) { m_transform.translate(delta); }
 
     void draw_circle(IntPoint center, int radius, Color);
+    void draw_ellipse(IntRect a_rect, Color);
     void fill_rect_with_rounded_corners(IntRect const&, Color, int radius);
     void fill_rect_with_rounded_corners(IntRect const&, Color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
 
 private:
+    void draw_ellipse_part(IntPoint a_rect, int radius_a, int radius_b, Color, bool fill_remaining_pixels, bool flip_x_and_y);
+
     enum class AntiAliasPolicy {
         OnlyEnds,
         Full,

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1685,11 +1685,11 @@ void Painter::draw_text(Function<void(IntRect const&, Utf8CodePointIterator&)> d
 
 void Painter::set_pixel(IntPoint const& p, Color color, bool blend)
 {
-    VERIFY(scale() == 1); // FIXME: Add scaling support.
-
     auto point = p;
     point.translate_by(state().translation);
-    if (!clip_rect().contains(point))
+    // Use the scale only to avoid clipping pixels set in drawing functions that handle
+    // scaling and call set_pixel() -- do not scale the pixel.
+    if (!clip_rect().contains(point / scale()))
         return;
     auto& dst = m_target->scanline(point.y())[point.x()];
     if (!blend) {

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -145,11 +145,12 @@ public:
 
     IntRect clip_rect() const { return state().clip_rect; }
 
+    int scale() const { return state().scale; }
+
 protected:
     IntPoint translation() const { return state().translation; }
     IntRect to_physical(IntRect const& r) const { return r.translated(translation()) * scale(); }
     IntPoint to_physical(IntPoint const& p) const { return p.translated(translation()) * scale(); }
-    int scale() const { return state().scale; }
     void set_physical_pixel_with_draw_op(u32& pixel, Color const&);
     void fill_physical_scanline_with_draw_op(int y, int x, int width, Color const& color);
     void fill_rect_with_draw_op(IntRect const&, Color);


### PR DESCRIPTION
(This PR depends on #13127)

**Before**            |  **After**
:-------------------------:|:-------------------------:
![Screenshot from 2022-03-21 01-59-25](https://user-images.githubusercontent.com/11597044/159196843-df524dc9-a977-4811-bd4c-7c66aae0b20c.png) | ![Screenshot from 2022-03-21 02-01-01](https://user-images.githubusercontent.com/11597044/159196853-02802725-32de-4e77-b90f-27276bc0c286.png)
No anti-aliasing  | Anti-aliased

This PR generalises the circle drawing function from #12979 to ellipses. Most of the code is shared between circles and 
ellipses, however, circles are still a special case as they can be rendered with 8-way symmetry.

Eyes has been updated to use this method as it looks nice and makes for an easy way to test the rendering works for different shapes/sizes.  

There's probably a bit of performance hit with this, though Eyes still seems responsive when full screen. 
