### PR TITLE
LibWeb: Implement HTMLTableRowElement's rowIndex and sectionRowIndex

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.cpp
@@ -6,7 +6,9 @@
 
 #include <LibWeb/DOM/HTMLCollection.h>
 #include <LibWeb/HTML/HTMLTableCellElement.h>
+#include <LibWeb/HTML/HTMLTableElement.h>
 #include <LibWeb/HTML/HTMLTableRowElement.h>
+#include <LibWeb/HTML/HTMLTableSectionElement.h>
 
 namespace Web::HTML {
 
@@ -28,6 +30,47 @@ NonnullRefPtr<DOM::HTMLCollection> HTMLTableRowElement::cells() const
         return element.parent() == this
             && is<HTMLTableCellElement>(element);
     });
+}
+
+void HTMLTableRowElement::inserted()
+{
+    auto row_index_in_collection = [&](auto const& collection) -> long {
+        auto elements = collection->collect_matching_elements();
+
+        for (size_t i = 0; i < elements.size(); ++i) {
+            if (elements[i] == this)
+                return i;
+        }
+
+        return -1;
+    };
+
+    // https://html.spec.whatwg.org/multipage/tables.html#dom-tr-rowindex
+    auto determine_row_index = [&]() -> long {
+        auto* table = first_ancestor_of_type<HTMLTableElement>();
+        return table ? row_index_in_collection(table->rows()) : -1;
+    };
+
+    // https://html.spec.whatwg.org/multipage/tables.html#dom-tr-sectionrowindex
+    auto determine_section_row_index = [&]() -> long {
+        for (auto* ancestor = parent(); ancestor; ancestor = ancestor->parent()) {
+            if (is<HTMLTableElement>(*ancestor))
+                return row_index_in_collection(static_cast<HTMLTableElement&>(*ancestor).rows());
+            if (is<HTMLTableSectionElement>(*ancestor))
+                return row_index_in_collection(static_cast<HTMLTableSectionElement&>(*ancestor).rows());
+        }
+
+        return -1;
+    };
+
+    m_row_index = determine_row_index();
+    m_section_row_index = determine_section_row_index();
+}
+
+void HTMLTableRowElement::removed_from(Node*)
+{
+    m_row_index = -1;
+    m_section_row_index = -1;
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.h
@@ -17,7 +17,17 @@ public:
     HTMLTableRowElement(DOM::Document&, DOM::QualifiedName);
     virtual ~HTMLTableRowElement() override;
 
+    long row_index() const { return m_row_index; }
+    long section_row_index() const { return m_section_row_index; }
+
     NonnullRefPtr<DOM::HTMLCollection> cells() const;
+
+private:
+    void inserted() override;
+    void removed_from(Node*) override;
+
+    long m_row_index { -1 };
+    long m_section_row_index { -1 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTableRowElement.idl
@@ -10,6 +10,8 @@ interface HTMLTableRowElement : HTMLElement {
 
     [LegacyNullToEmptyString, Reflect=bgcolor] attribute DOMString bgColor;
 
+    readonly attribute long rowIndex;
+    readonly attribute long sectionRowIndex;
     [SameObject] readonly attribute HTMLCollection cells;
 
 };


### PR DESCRIPTION
These return the row element's index in the entire table and in its
containing section within the table, respectively.

Fixes test 50 on Acid 3:
![test50](https://user-images.githubusercontent.com/5600524/159295902-671b4409-7387-4a71-9957-edb402b31751.png)
