### PR TITLE
LibWeb: Reduce division cost by mulitply the reciprocal when painting

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -24,10 +24,12 @@ BorderRadiusData normalized_border_radius_data(Layout::Node const& node, Gfx::Fl
 
     // Scale overlapping curves according to https://www.w3.org/TR/css-backgrounds-3/#corner-overlap
     auto f = 1.0f;
-    f = min(f, rect.width() / (float)(top_left_radius_px + top_right_radius_px));
-    f = min(f, rect.height() / (float)(top_right_radius_px + bottom_right_radius_px));
-    f = min(f, rect.width() / (float)(bottom_left_radius_px + bottom_right_radius_px));
-    f = min(f, rect.height() / (float)(top_left_radius_px + bottom_left_radius_px));
+    auto width_reciprocal = 1.0f / rect.width();
+    auto height_reciprocal = 1.0f / rect.height();
+    f = min(f, width_reciprocal * (top_left_radius_px + top_right_radius_px));
+    f = min(f, height_reciprocal * (top_right_radius_px + bottom_right_radius_px));
+    f = min(f, width_reciprocal * (bottom_left_radius_px + bottom_right_radius_px));
+    f = min(f, height_reciprocal * (top_left_radius_px + bottom_left_radius_px));
 
     top_left_radius_px = (int)(top_left_radius_px * f);
     top_right_radius_px = (int)(top_right_radius_px * f);


### PR DESCRIPTION
Rather than dividing two awkward numbers; we calculate the reciprocal of one, and multiply other by the result. This should be faster as multiplication is faster than division, and the division that does take place is simpler. I saw performance improvements when mousing around on the html spec website. The profile showed that inline painting went from ~15% to ~3%, but I'd appreciate if someone could verify this as it's my first time using the profiler.