### PR TITLE
LibWeb: When painting, reduce computation cost by using the reciprocal

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/BorderPainting.cpp
@@ -24,10 +24,14 @@ BorderRadiusData normalized_border_radius_data(Layout::Node const& node, Gfx::Fl
 
     // Scale overlapping curves according to https://www.w3.org/TR/css-backgrounds-3/#corner-overlap
     auto f = 1.0f;
-    f = min(f, rect.width() / (float)(top_left_radius_px + top_right_radius_px));
-    f = min(f, rect.height() / (float)(top_right_radius_px + bottom_right_radius_px));
-    f = min(f, rect.width() / (float)(bottom_left_radius_px + bottom_right_radius_px));
-    f = min(f, rect.height() / (float)(top_left_radius_px + bottom_left_radius_px));
+    auto width_reciprocal = 1.0f / rect.width();
+    auto height_reciprocal = 1.0f / rect.height();
+    f = max(f, width_reciprocal * (top_left_radius_px + top_right_radius_px));
+    f = max(f, height_reciprocal * (top_right_radius_px + bottom_right_radius_px));
+    f = max(f, width_reciprocal * (bottom_left_radius_px + bottom_right_radius_px));
+    f = max(f, height_reciprocal * (top_left_radius_px + bottom_left_radius_px));
+
+    f = 1.0f / f;
 
     top_left_radius_px = (int)(top_left_radius_px * f);
     top_right_radius_px = (int)(top_right_radius_px * f);


### PR DESCRIPTION
This should reduce the cost of division by calculating the reciprocal of the rect dimensions and multiplying that with the border radii. Calculating the reciprocal is a less costly division operation as it reduces the number of potentially difficult variables in the division operation from two to one.

With this change I saw performance improvements when mousing around on the html spec website. The profiler showed that inline painting went from ~15% to ~3%, I'd appropriate if someone could verify this as it's my first time using the profiler.
Master ->
![Master Branch](https://user-images.githubusercontent.com/60783181/159806233-ad512d3f-566a-4fb5-8006-50760856ff95.png)
PR ->
![My branch](https://user-images.githubusercontent.com/60783181/159806239-e468bda4-84a3-4d39-b833-011a773a1def.png)
 