### PR TITLE
Kernel: Add an extremely primitive version of KASLR

### DIFF
--- a/Kernel/Arch/x86/ASM_wrapper.h
+++ b/Kernel/Arch/x86/ASM_wrapper.h
@@ -160,6 +160,28 @@ ALWAYS_INLINE u64 read_tsc()
     return ((u64)msw << 32) | lsw;
 }
 
+ALWAYS_INLINE u32 rdrand()
+{
+    u32 value;
+    asm volatile(
+        "1:\n"
+        "rdrand %0\n"
+        "jnc 1b\n"
+        : "=r"(value)::"cc");
+    return value;
+}
+
+ALWAYS_INLINE u32 rdseed()
+{
+    u32 value;
+    asm volatile(
+        "1:\n"
+        "rdseed %0\n"
+        "jnc 1b\n"
+        : "=r"(value)::"cc");
+    return value;
+}
+
 void stac();
 void clac();
 


### PR DESCRIPTION
This initial (and very basic) implementation of KASLR simply randomizes the kernel base VA in the 256 MiB range following the default load base.