### PR TITLE
LibWeb: transform-origin and translate(...) by percentage

### DIFF
--- a/Base/res/html/misc/transform.html
+++ b/Base/res/html/misc/transform.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <style>
+        body {
+            padding: 0;
+            margin: 0;
+        }
+
+        .container {
+            display: inline-flex;
+            flex-direction: column;
+            width: 60em;
+        }
+
+        .example {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            position: relative;
+            margin: 4em 5em;
+            background-color: #ccc;
+        }
+
+        .example > style {
+            display: block;
+            font-family: monospace;
+            margin: 0 3em 0 10em;
+        }
+
+        .box {
+            display: block;
+            width: 3em;
+            height: 3em;
+            border: solid 1px;
+            background-color: palegreen;
+        }
+
+        .original {
+            position: absolute;
+            left: 0;
+            top: 0;
+            opacity: 20%;
+        }
+    </style>
+</head>
+<body>
+<p>This is based on the examples for <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/transform-origin">transform-origin</a>
+    on MDN</p>
+<div class="container">
+    <div class="example">
+        <div>
+            <div id="box1" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box1 {
+            transform: none;
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box2" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box2 {
+            transform: scale(1.7);
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box3" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box3 {
+            transform: scale(1.7);
+            transform-origin: 0 0;
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box4" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box4 {
+            transform: scale(1.7);
+            transform-origin: 100% -30%;
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box5" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box5 {
+            transform: translate(20px, 20px);
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box6" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box6 {
+            transform: translate(50%, 10%);
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box7" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box7 {
+            transform: rotate(30deg);
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box8" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box8 {
+            transform: rotate(30deg);
+            transform-origin: 0 0;
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box9" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box9 {
+            transform: rotate(30deg);
+            transform-origin: 100% 100%;
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box10" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box10 {
+            transform: rotate(30deg);
+            transform-origin: -1em -3em;
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box11" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box11 {
+            transform: skewX(50deg);
+            transform-origin: 100% -30%;
+        }</style>
+    </div>
+    <div class="example">
+        <div>
+            <div id="box12" class="box">&nbsp;</div>
+            <div class="box original">&nbsp;</div>
+        </div>
+        <style>#box12 {
+            transform: skewY(50deg);
+            transform-origin: 100% -30%;
+        }</style>
+    </div>
+</div>
+</body>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -124,6 +124,7 @@
             <li><a href="clear-1.html">Float clearing</a></li>
             <li><a href="overflow.html">Overflow</a></li>
             <li><a href="image-rendering.html">image-rendering property</a></li>
+            <li><a href="transform.html">Transforms</a></li>
             <li><h3>Features</h3></li>
             <li><a href="css.html">Basic functionality</a></li>
             <li><a href="colors.html">css colors</a></li>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -75,6 +75,11 @@ struct Transformation {
     Vector<Variant<CSS::Length, float>> values;
 };
 
+struct TransformOrigin {
+    CSS::LengthPercentage x { Percentage(50) };
+    CSS::LengthPercentage y { Percentage(50) };
+};
+
 struct FlexBasisData {
     CSS::FlexBasis type { CSS::FlexBasis::Auto };
     Optional<CSS::LengthPercentage> length_percentage;
@@ -169,6 +174,7 @@ public:
     Optional<LengthPercentage> const& stroke_width() const { return m_inherited.stroke_width; }
 
     Vector<CSS::Transformation> transformations() const { return m_noninherited.transformations; }
+    CSS::TransformOrigin transform_origin() const { return m_noninherited.transform_origin; }
 
     float font_size() const { return m_inherited.font_size; }
     int font_weight() const { return m_inherited.font_weight; }
@@ -241,6 +247,7 @@ protected:
         float opacity { InitialValues::opacity() };
         Vector<BoxShadowData> box_shadow {};
         Vector<CSS::Transformation> transformations {};
+        CSS::TransformOrigin transform_origin {};
         CSS::BoxSizing box_sizing { InitialValues::box_sizing() };
         CSS::ContentData content;
         Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align { InitialValues::vertical_align() };
@@ -304,6 +311,7 @@ public:
     void set_justify_content(CSS::JustifyContent value) { m_noninherited.justify_content = value; }
     void set_box_shadow(Vector<BoxShadowData>&& value) { m_noninherited.box_shadow = move(value); }
     void set_transformations(Vector<CSS::Transformation> value) { m_noninherited.transformations = move(value); }
+    void set_transform_origin(CSS::TransformOrigin value) { m_noninherited.transform_origin = value; }
     void set_box_sizing(CSS::BoxSizing value) { m_noninherited.box_sizing = value; }
     void set_vertical_align(Variant<CSS::VerticalAlign, CSS::LengthPercentage> value) { m_noninherited.vertical_align = value; }
     void set_visibility(CSS::Visibility value) { m_inherited.visibility = value; }

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -72,7 +72,7 @@ public:
 
 struct Transformation {
     CSS::TransformFunction function;
-    Vector<Variant<CSS::Length, float>> values;
+    Vector<Variant<CSS::LengthPercentage, float>> values;
 };
 
 struct TransformOrigin {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -3976,6 +3976,11 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<StyleComponentValueRule>
             } else if (value.is(Token::Type::Number)) {
                 auto number = parse_numeric_value(value);
                 values.append(number.release_nonnull());
+            } else if (value.is(Token::Type::Percentage)) {
+                auto percentage = parse_dimension_value(value);
+                if (!percentage || !percentage->is_percentage())
+                    return nullptr;
+                values.append(percentage.release_nonnull());
             } else {
                 dbgln_if(CSS_PARSER_DEBUG, "FIXME: Unsupported value type for transformation!");
                 return nullptr;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -298,6 +298,7 @@ private:
     RefPtr<StyleValue> parse_overflow_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_text_decoration_value(Vector<StyleComponentValueRule> const&);
     RefPtr<StyleValue> parse_transform_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_transform_origin_value(Vector<StyleComponentValueRule> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
     OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<StyleComponentValueRule>&);

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -1371,6 +1371,23 @@
     "inherited": false,
     "initial": "none"
   },
+  "transform-origin": {
+    "affects-layout": false,
+    "inherited": false,
+    "initial": "50% 50%",
+    "max-values": 3,
+    "valid-types": [
+      "length",
+      "percentage"
+    ],
+    "valid-identifiers": [
+      "bottom",
+      "center",
+      "left",
+      "right",
+      "top"
+    ]
+  },
   "user-select": {
     "affects-layout": false,
     "inherited": false,

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -347,6 +347,29 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
     return transformations;
 }
 
+static Optional<LengthPercentage> length_percentage_for_style_value(StyleValue const& value)
+{
+    if (value.is_length())
+        return value.to_length();
+    if (value.is_percentage())
+        return value.as_percentage().percentage();
+    return {};
+}
+
+CSS::TransformOrigin StyleProperties::transform_origin() const
+{
+    auto value = property(CSS::PropertyID::TransformOrigin);
+    if (!value.has_value() || !value.value()->is_value_list() || value.value()->as_value_list().size() != 2)
+        return {};
+    auto const& list = value.value()->as_value_list();
+    auto x_value = length_percentage_for_style_value(list.values()[0]);
+    auto y_value = length_percentage_for_style_value(list.values()[1]);
+    if (!x_value.has_value() || !y_value.has_value()) {
+        return {};
+    }
+    return { x_value.value(), y_value.value() };
+}
+
 Optional<CSS::AlignItems> StyleProperties::align_items() const
 {
     auto value = property(CSS::PropertyID::AlignItems);

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -329,10 +329,12 @@ Vector<CSS::Transformation> StyleProperties::transformations() const
         auto& transformation_style_value = it.as_transformation();
         CSS::Transformation transformation;
         transformation.function = transformation_style_value.transform_function();
-        Vector<Variant<CSS::Length, float>> values;
+        Vector<Variant<CSS::LengthPercentage, float>> values;
         for (auto& transformation_value : transformation_style_value.values()) {
             if (transformation_value.is_length()) {
                 values.append({ transformation_value.to_length() });
+            } else if (transformation_value.is_percentage()) {
+                values.append({ transformation_value.as_percentage().percentage() });
             } else if (transformation_value.is_numeric()) {
                 values.append({ transformation_value.to_number() });
             } else if (transformation_value.is_angle()) {

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -77,6 +77,7 @@ public:
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align() const;
 
     Vector<CSS::Transformation> transformations() const;
+    CSS::TransformOrigin transform_origin() const;
 
     Gfx::Font const& computed_font() const
     {

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -493,6 +493,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& specified_style)
     computed_values.set_box_shadow(specified_style.box_shadow());
 
     computed_values.set_transformations(specified_style.transformations());
+    computed_values.set_transform_origin(specified_style.transform_origin());
 
     auto do_border_style = [&](CSS::BorderData& border, CSS::PropertyID width_property, CSS::PropertyID color_property, CSS::PropertyID style_property) {
         // FIXME: The default border color value is `currentcolor`, but since we can't resolve that easily,

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.h
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.h
@@ -45,6 +45,7 @@ private:
     Gfx::FloatMatrix4x4 get_transformation_matrix(CSS::Transformation const& transformation) const;
     Gfx::FloatMatrix4x4 combine_transformations(Vector<CSS::Transformation> const& transformations) const;
     Gfx::AffineTransform combine_transformations_2d(Vector<CSS::Transformation> const& transformations) const;
+    Gfx::FloatPoint transform_origin() const;
 };
 
 }


### PR DESCRIPTION
Also fixes an issue that was commonly occurring with transforms, where draw_scaled_bitmap would access source pixels out of bounds.