### PR TITLE
Applications: Do not crash if decoded bitmap is null

### DIFF
--- a/Userland/Applications/ImageViewer/ViewWidget.cpp
+++ b/Userland/Applications/ImageViewer/ViewWidget.cpp
@@ -176,6 +176,11 @@ void ViewWidget::load_from_file(const String& path)
 
     m_decoded_image = decoded_image_or_error.release_value();
     m_bitmap = m_decoded_image->frames[0].bitmap;
+    if (m_bitmap.is_null()) {
+        show_error();
+        return;
+    }
+
     set_original_rect(m_bitmap->rect());
     if (on_image_change)
         on_image_change(m_bitmap);

--- a/Userland/Applications/PixelPaint/Image.cpp
+++ b/Userland/Applications/PixelPaint/Image.cpp
@@ -67,7 +67,11 @@ ErrorOr<NonnullRefPtr<Gfx::Bitmap>> Image::try_decode_bitmap(ReadonlyBytes bitma
     auto decoded_image = maybe_decoded_image.release_value();
     if (decoded_image.frames.is_empty())
         return Error::from_string_literal("Image decode failed (no frames)"sv);
-    return decoded_image.frames[0].bitmap.release_nonnull();
+
+    auto decoded_bitmap = decoded_image.frames.first().bitmap;
+    if (decoded_bitmap.is_null())
+        return Error::from_string_literal("Image decode failed (no bitmap for frame)"sv);
+    return decoded_bitmap.release_nonnull();
 }
 
 ErrorOr<NonnullRefPtr<Image>> Image::try_create_from_bitmap(NonnullRefPtr<Gfx::Bitmap> bitmap)


### PR DESCRIPTION
ImageViewer and PixelPaint would crash when the ImageDecoderClient returns a frame without a bitmap. This can happen with `.ico` files with an unsupported BPP, for example.