### PR TITLE
LibWeb: Make DOM::ExceptionOr compatible with the TRY macro

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/ExceptionOr.h
+++ b/Userland/Libraries/LibWeb/DOM/ExceptionOr.h
@@ -34,7 +34,10 @@ struct SimpleException {
 template<typename ValueType>
 class ExceptionOr {
 public:
-    ExceptionOr() requires(IsSame<ValueType, Empty>) = default;
+    ExceptionOr() requires(IsSame<ValueType, Empty>)
+        : m_result(Empty {})
+    {
+    }
 
     ExceptionOr(const ValueType& result)
         : m_result(result)
@@ -70,7 +73,7 @@ public:
         return m_result.value();
     }
 
-    ValueType release_value() requires(!IsSame<ValueType, Empty>)
+    ValueType release_value()
     {
         return m_result.release_value();
     }
@@ -84,6 +87,10 @@ public:
     {
         return !m_exception.template has<Empty>();
     }
+
+    // These are for compatibility with the TRY() macro in AK.
+    [[nodiscard]] bool is_error() const { return is_exception(); }
+    Variant<SimpleException, NonnullRefPtr<DOMException>> release_error() { return exception(); }
 
 private:
     Optional<ValueType> m_result;

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionsCollection.cpp
@@ -50,8 +50,7 @@ DOM::ExceptionOr<void> HTMLOptionsCollection::add(HTMLOptionOrOptGroupElement el
     DOM::Node* parent = reference ? reference->parent() : root().ptr();
 
     // 6. Pre-insert element into parent node before reference.
-    if (auto result = parent->pre_insert(resolved_element, reference); result.is_exception())
-        return result.exception();
+    TRY(parent->pre_insert(resolved_element, reference));
 
     return {};
 }


### PR DESCRIPTION
Found myself writing `is_exception()` / `exception()` / `release_value()` a few too many times yesterday :)

I think eventually, it might be possible to replace `ExceptionOr` with an `AK::ErrorOr` alias, but that'll be much easier once all callers are using `TRY`.