### PR TITLE
LibWeb: Put some CSS types on a diet

### DIFF
--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -75,57 +75,57 @@ public:
         return Color(r, g, b);
     }
 
-    static constexpr Color from_hsl(double h_degrees, double s, double l) { return from_hsla(h_degrees, s, l, 1.0); }
-    static constexpr Color from_hsla(double h_degrees, double s, double l, double a)
+    static constexpr Color from_hsl(float h_degrees, float s, float l) { return from_hsla(h_degrees, s, l, 1.0); }
+    static constexpr Color from_hsla(float h_degrees, float s, float l, float a)
     {
         // Algorithm from https://www.w3.org/TR/css-color-3/#hsl-color
-        double h = clamp(h_degrees / 360.0, 0.0, 1.0);
-        s = clamp(s, 0.0, 1.0);
-        l = clamp(l, 0.0, 1.0);
-        a = clamp(a, 0.0, 1.0);
+        float h = clamp(h_degrees / 360.0f, 0.0f, 1.0f);
+        s = clamp(s, 0.0f, 1.0f);
+        l = clamp(l, 0.0f, 1.0f);
+        a = clamp(a, 0.0f, 1.0f);
 
         // HOW TO RETURN hue.to.rgb(m1, m2, h):
-        auto hue_to_rgb = [](double m1, double m2, double h) -> double {
+        auto hue_to_rgb = [](float m1, float m2, float h) -> float {
             // IF h<0: PUT h+1 IN h
-            if (h < 0.0)
-                h = h + 1.0;
+            if (h < 0.0f)
+                h = h + 1.0f;
             // IF h>1: PUT h-1 IN h
-            if (h > 1.0)
-                h = h - 1.0;
+            if (h > 1.0f)
+                h = h - 1.0f;
             // IF h*6<1: RETURN m1+(m2-m1)*h*6
-            if (h * 6.0 < 1.0)
-                return m1 + (m2 - m1) * h * 6.0;
+            if (h * 6.0f < 1.0f)
+                return m1 + (m2 - m1) * h * 6.0f;
             // IF h*2<1: RETURN m2
-            if (h * 2.0 < 1.0)
+            if (h * 2.0f < 1.0f)
                 return m2;
             // IF h*3<2: RETURN m1+(m2-m1)*(2/3-h)*6
-            if (h * 3.0 < 2.0)
-                return m1 + (m2 - m1) * (2.0 / 3.0 - h) * 6.0;
+            if (h * 3.0f < 2.0f)
+                return m1 + (m2 - m1) * (2.0f / 3.0f - h) * 6.0f;
             // RETURN m1
             return m1;
         };
 
         // SELECT:
         // l<=0.5: PUT l*(s+1) IN m2
-        double m2;
-        if (l <= 0.5)
-            m2 = l * (s + 1.0);
+        float m2;
+        if (l <= 0.5f)
+            m2 = l * (s + 1.0f);
         // ELSE: PUT l+s-l*s IN m2
         else
             m2 = l + s - l * s;
         // PUT l*2-m2 IN m1
-        double m1 = l * 2.0 - m2;
+        float m1 = l * 2.0f - m2;
         // PUT hue.to.rgb(m1, m2, h+1/3) IN r
-        double r = hue_to_rgb(m1, m2, h + 1.0 / 3.0);
+        float r = hue_to_rgb(m1, m2, h + 1.0f / 3.0f);
         // PUT hue.to.rgb(m1, m2, h    ) IN g
-        double g = hue_to_rgb(m1, m2, h);
+        float g = hue_to_rgb(m1, m2, h);
         // PUT hue.to.rgb(m1, m2, h-1/3) IN b
-        double b = hue_to_rgb(m1, m2, h - 1.0 / 3.0);
+        float b = hue_to_rgb(m1, m2, h - 1.0f / 3.0f);
         // RETURN (r, g, b)
-        u8 r_u8 = clamp(lroundf(r * 255.0), 0, 255);
-        u8 g_u8 = clamp(lroundf(g * 255.0), 0, 255);
-        u8 b_u8 = clamp(lroundf(b * 255.0), 0, 255);
-        u8 a_u8 = clamp(lroundf(a * 255.0), 0, 255);
+        u8 r_u8 = clamp(lroundf(r * 255.0f), 0, 255);
+        u8 g_u8 = clamp(lroundf(g * 255.0f), 0, 255);
+        u8 b_u8 = clamp(lroundf(b * 255.0f), 0, 255);
+        u8 a_u8 = clamp(lroundf(a * 255.0f), 0, 255);
         return Color(r_u8, g_u8, b_u8, a_u8);
     }
 

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -27,7 +27,7 @@ String MediaFeatureValue::to_string() const
         [](Length const& length) { return length.to_string(); },
         [](Ratio const& ratio) { return ratio.to_string(); },
         [](Resolution const& resolution) { return resolution.to_string(); },
-        [](double number) { return String::number(number); });
+        [](float number) { return String::number(number); });
 }
 
 bool MediaFeatureValue::is_same_type(MediaFeatureValue const& other) const
@@ -37,7 +37,7 @@ bool MediaFeatureValue::is_same_type(MediaFeatureValue const& other) const
         [&](Length const&) { return other.is_length(); },
         [&](Ratio const&) { return other.is_ratio(); },
         [&](Resolution const&) { return other.is_resolution(); },
-        [&](double) { return other.is_number(); });
+        [&](float) { return other.is_number(); });
 }
 
 String MediaFeature::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.h
@@ -42,7 +42,7 @@ public:
     {
     }
 
-    explicit MediaFeatureValue(double number)
+    explicit MediaFeatureValue(float number)
         : m_value(number)
     {
     }
@@ -51,7 +51,7 @@ public:
 
     bool is_ident() const { return m_value.has<ValueID>(); }
     bool is_length() const { return m_value.has<Length>(); }
-    bool is_number() const { return m_value.has<double>(); }
+    bool is_number() const { return m_value.has<float>(); }
     bool is_ratio() const { return m_value.has<Ratio>(); }
     bool is_resolution() const { return m_value.has<Resolution>(); }
     bool is_same_type(MediaFeatureValue const& other) const;
@@ -80,14 +80,14 @@ public:
         return m_value.get<Resolution>();
     }
 
-    double number() const
+    float number() const
     {
         VERIFY(is_number());
-        return m_value.get<double>();
+        return m_value.get<float>();
     }
 
 private:
-    Variant<ValueID, Length, Ratio, Resolution, double> m_value;
+    Variant<ValueID, Length, Ratio, Resolution, float> m_value;
 };
 
 // https://www.w3.org/TR/mediaqueries-4/#mq-features

--- a/Userland/Libraries/LibWeb/CSS/Number.h
+++ b/Userland/Libraries/LibWeb/CSS/Number.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+#include <math.h>
+
+namespace Web::CSS {
+
+class Tokenizer;
+
+class Number {
+    friend class Tokenizer;
+
+public:
+    enum class Type {
+        Number,
+        IntegerWithExplicitSign, // This only exists for the nightmarish An+B parsing algorithm
+        Integer
+    };
+
+    Number()
+        : m_value(0)
+        , m_type(Type::Number)
+    {
+    }
+    Number(Type type, float value)
+        : m_value(value)
+        , m_type(type)
+    {
+    }
+
+    float value() const { return m_value; }
+    i64 integer_value() const
+    {
+        // https://www.w3.org/TR/css-values-4/#numeric-types
+        // When a value cannot be explicitly supported due to range/precision limitations, it must be converted
+        // to the closest value supported by the implementation, but how the implementation defines "closest"
+        // is explicitly undefined as well.
+        return llroundf(m_value);
+    }
+    bool is_integer() const { return m_type == Type::Integer || m_type == Type::IntegerWithExplicitSign; }
+    bool is_integer_with_explicit_sign() const { return m_type == Type::IntegerWithExplicitSign; }
+
+    Number operator+(Number const& other) const
+    {
+        if (is_integer() && other.is_integer())
+            return { Type::Integer, m_value + other.m_value };
+        return { Type::Number, m_value + other.m_value };
+    }
+
+    Number operator-(Number const& other) const
+    {
+        if (is_integer() && other.is_integer())
+            return { Type::Integer, m_value - other.m_value };
+        return { Type::Number, m_value - other.m_value };
+    }
+
+    Number operator*(Number const& other) const
+    {
+        if (is_integer() && other.is_integer())
+            return { Type::Integer, m_value * other.m_value };
+        return { Type::Number, m_value * other.m_value };
+    }
+
+    Number operator/(Number const& other) const
+    {
+        return { Type::Number, m_value / other.m_value };
+    }
+
+    auto operator<=>(Number const& other) const
+    {
+        return m_value - other.m_value;
+    }
+
+private:
+    float m_value { 0 };
+    Type m_type;
+};
+}

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2476,9 +2476,9 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
                 && g_val.is(Token::Type::Percentage)
                 && b_val.is(Token::Type::Percentage)) {
 
-                u8 r = clamp(lroundf(r_val.percentage() * 2.55), 0, 255);
-                u8 g = clamp(lroundf(g_val.percentage() * 2.55), 0, 255);
-                u8 b = clamp(lroundf(b_val.percentage() * 2.55), 0, 255);
+                u8 r = clamp(lroundf(r_val.percentage() * 2.55f), 0, 255);
+                u8 g = clamp(lroundf(g_val.percentage() * 2.55f), 0, 255);
+                u8 b = clamp(lroundf(b_val.percentage() * 2.55f), 0, 255);
                 return Color(r, g, b);
             }
         } else if (function.name().equals_ignoring_case("rgba")) {
@@ -2498,7 +2498,7 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
                 auto r = r_val.to_integer();
                 auto g = g_val.to_integer();
                 auto b = b_val.to_integer();
-                auto a = clamp(lroundf(a_val.number_value() * 255.0), 0, 255);
+                auto a = clamp(lroundf(a_val.number_value() * 255.0f), 0, 255);
                 if (AK::is_within_range<u8>(r) && AK::is_within_range<u8>(g) && AK::is_within_range<u8>(b))
                     return Color(r, g, b, a);
 
@@ -2512,10 +2512,10 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
                 auto b = b_val.percentage();
                 auto a = a_val.number_value();
 
-                u8 r_255 = clamp(lroundf(r * 2.55), 0, 255);
-                u8 g_255 = clamp(lroundf(g * 2.55), 0, 255);
-                u8 b_255 = clamp(lroundf(b * 2.55), 0, 255);
-                u8 a_255 = clamp(lroundf(a * 255.0), 0, 255);
+                u8 r_255 = clamp(lroundf(r * 2.55f), 0, 255);
+                u8 g_255 = clamp(lroundf(g * 2.55f), 0, 255);
+                u8 b_255 = clamp(lroundf(b * 2.55f), 0, 255);
+                u8 a_255 = clamp(lroundf(a * 255.0f), 0, 255);
                 return Color(r_255, g_255, b_255, a_255);
             }
         } else if (function.name().equals_ignoring_case("hsl")) {
@@ -2530,9 +2530,9 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
                 && s_val.is(Token::Type::Percentage)
                 && l_val.is(Token::Type::Percentage)) {
 
-                auto h = static_cast<float>(h_val.number_value());
-                auto s = static_cast<float>(s_val.percentage() / 100.0f);
-                auto l = static_cast<float>(l_val.percentage() / 100.0f);
+                auto h = h_val.number_value();
+                auto s = s_val.percentage() / 100.0f;
+                auto l = l_val.percentage() / 100.0f;
                 return Color::from_hsl(h, s, l);
             }
         } else if (function.name().equals_ignoring_case("hsla")) {
@@ -2549,10 +2549,10 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
                 && l_val.is(Token::Type::Percentage)
                 && a_val.is(Token::Type::Number)) {
 
-                auto h = static_cast<float>(h_val.number_value());
-                auto s = static_cast<float>(s_val.percentage() / 100.0f);
-                auto l = static_cast<float>(l_val.percentage() / 100.0f);
-                auto a = static_cast<float>(a_val.number_value());
+                auto h = h_val.number_value();
+                auto s = s_val.percentage() / 100.0f;
+                auto l = l_val.percentage() / 100.0f;
+                auto a = a_val.number_value();
                 return Color::from_hsla(h, s, l, a);
             }
         }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4647,11 +4647,7 @@ Optional<CalculatedStyleValue::CalcValue> Parser::parse_calc_value(TokenStream<S
     }
 
     if (current_token.is(Token::Type::Number))
-        return CalculatedStyleValue::CalcValue {
-            CalculatedStyleValue::Number {
-                .is_integer = current_token.token().number_type() == Token::NumberType::Integer,
-                .value = static_cast<float>(current_token.token().number_value()) }
-        };
+        return CalculatedStyleValue::CalcValue { current_token.token().number() };
 
     if (current_token.is(Token::Type::Dimension) || current_token.is(Token::Type::Percentage)) {
         auto maybe_dimension = parse_dimension(current_token);
@@ -4684,7 +4680,7 @@ OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> Parser::parse_calc_pro
     // Note: The default value is not used or passed around.
     auto product_with_operator = make<CalculatedStyleValue::CalcProductPartWithOperator>(
         CalculatedStyleValue::ProductOperation::Multiply,
-        CalculatedStyleValue::CalcNumberValue { CalculatedStyleValue::Number { false, 0 } });
+        CalculatedStyleValue::CalcNumberValue { Number {} });
 
     tokens.skip_whitespace();
 
@@ -4723,7 +4719,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> Parser::parse_ca
     // Note: The default value is not used or passed around.
     auto number_product_with_operator = make<CalculatedStyleValue::CalcNumberProductPartWithOperator>(
         CalculatedStyleValue::ProductOperation::Multiply,
-        CalculatedStyleValue::CalcNumberValue { CalculatedStyleValue::Number { false, 0 } });
+        CalculatedStyleValue::CalcNumberValue { Number {} });
 
     tokens.skip_whitespace();
 
@@ -4756,7 +4752,7 @@ OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> Parser::parse_ca
 OwnPtr<CalculatedStyleValue::CalcNumberProduct> Parser::parse_calc_number_product(TokenStream<StyleComponentValueRule>& tokens)
 {
     auto calc_number_product = make<CalculatedStyleValue::CalcNumberProduct>(
-        CalculatedStyleValue::CalcNumberValue { CalculatedStyleValue::Number { false, 0 } },
+        CalculatedStyleValue::CalcNumberValue { Number {} },
         NonnullOwnPtrVector<CalculatedStyleValue::CalcNumberProductPartWithOperator> {});
 
     auto first_calc_number_value_or_error = parse_calc_number_value(tokens);
@@ -4834,17 +4830,13 @@ Optional<CalculatedStyleValue::CalcNumberValue> Parser::parse_calc_number_value(
         return {};
     tokens.next_token();
 
-    return CalculatedStyleValue::CalcNumberValue {
-        CalculatedStyleValue::Number {
-            .is_integer = first.token().number_type() == Token::NumberType::Integer,
-            .value = static_cast<float>(first.token().number_value()) }
-    };
+    return CalculatedStyleValue::CalcNumberValue { first.token().number() };
 }
 
 OwnPtr<CalculatedStyleValue::CalcProduct> Parser::parse_calc_product(TokenStream<StyleComponentValueRule>& tokens)
 {
     auto calc_product = make<CalculatedStyleValue::CalcProduct>(
-        CalculatedStyleValue::CalcValue { CalculatedStyleValue::Number { false, 0 } },
+        CalculatedStyleValue::CalcValue { Number {} },
         NonnullOwnPtrVector<CalculatedStyleValue::CalcProductPartWithOperator> {});
 
     auto first_calc_value_or_error = parse_calc_value(tokens);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1233,14 +1233,14 @@ Optional<MediaFeatureValue> Parser::parse_media_feature_value(MediaFeatureID med
 
     // Boolean (<mq-boolean> in the spec: a 1 or 0)
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Boolean)) {
-        if (first.is(Token::Type::Number) && first.token().number_type() == Token::NumberType::Integer
+        if (first.is(Token::Type::Number) && first.token().number().is_integer()
             && (first.token().number_value() == 0 || first.token().number_value() == 1))
             return MediaFeatureValue(first.token().number_value());
     }
 
     // Integer
     if (media_feature_accepts_type(media_feature, MediaFeatureValueType::Integer)) {
-        if (first.is(Token::Type::Number) && first.token().number_type() == Token::NumberType::Integer)
+        if (first.is(Token::Type::Number) && first.token().number().is_integer())
             return MediaFeatureValue(first.token().number_value());
     }
 
@@ -2392,7 +2392,7 @@ RefPtr<StyleValue> Parser::parse_numeric_value(StyleComponentValueRule const& co
 {
     if (component_value.is(Token::Type::Number)) {
         auto number = component_value.token();
-        if (number.number_type() == Token::NumberType::Integer) {
+        if (number.number().is_integer()) {
             return NumericStyleValue::create_integer(number.to_integer());
         } else {
             return NumericStyleValue::create_float(number.number_value());
@@ -2462,9 +2462,9 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
             auto g_val = params[1];
             auto b_val = params[2];
 
-            if (r_val.is(Token::NumberType::Integer)
-                && g_val.is(Token::NumberType::Integer)
-                && b_val.is(Token::NumberType::Integer)) {
+            if (r_val.is(Token::Type::Number) && r_val.number().is_integer()
+                && g_val.is(Token::Type::Number) && g_val.number().is_integer()
+                && b_val.is(Token::Type::Number) && b_val.number().is_integer()) {
 
                 auto r = r_val.to_integer();
                 auto g = g_val.to_integer();
@@ -2490,9 +2490,9 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
             auto b_val = params[2];
             auto a_val = params[3];
 
-            if (r_val.is(Token::NumberType::Integer)
-                && g_val.is(Token::NumberType::Integer)
-                && b_val.is(Token::NumberType::Integer)
+            if (r_val.is(Token::Type::Number) && r_val.number().is_integer()
+                && g_val.is(Token::Type::Number) && g_val.number().is_integer()
+                && b_val.is(Token::Type::Number) && b_val.number().is_integer()
                 && a_val.is(Token::Type::Number)) {
 
                 auto r = r_val.to_integer();
@@ -2571,7 +2571,7 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
         if (cv.is(Token::Type::Number) || cv.is(Token::Type::Dimension)) {
             // 1. If cv’s type flag is not "integer", return an error.
             //    This means that values that happen to use scientific notation, e.g., 5e5e5e, will fail to parse.
-            if (cv.token().number_type() != Token::NumberType::Integer)
+            if (!cv.token().number().is_integer())
                 return {};
 
             // 2. If cv’s value is less than zero, return an error.
@@ -4372,7 +4372,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     auto is_n_dimension = [](StyleComponentValueRule const& value) -> bool {
         if (!value.is(Token::Type::Dimension))
             return false;
-        if (value.token().number_type() != Token::NumberType::Integer)
+        if (!value.token().number().is_integer())
             return false;
         if (!value.token().dimension_unit().equals_ignoring_case("n"sv))
             return false;
@@ -4381,7 +4381,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     auto is_ndash_dimension = [](StyleComponentValueRule const& value) -> bool {
         if (!value.is(Token::Type::Dimension))
             return false;
-        if (value.token().number_type() != Token::NumberType::Integer)
+        if (!value.token().number().is_integer())
             return false;
         if (!value.token().dimension_unit().equals_ignoring_case("n-"sv))
             return false;
@@ -4390,7 +4390,7 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     auto is_ndashdigit_dimension = [](StyleComponentValueRule const& value) -> bool {
         if (!value.is(Token::Type::Dimension))
             return false;
-        if (value.token().number_type() != Token::NumberType::Integer)
+        if (!value.token().number().is_integer())
             return false;
         auto dimension_unit = value.token().dimension_unit();
         if (!dimension_unit.starts_with("n-"sv, CaseSensitivity::CaseInsensitive))
@@ -4426,13 +4426,13 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
         return true;
     };
     auto is_integer = [](StyleComponentValueRule const& value) -> bool {
-        return value.is(Token::Type::Number) && value.token().is(Token::NumberType::Integer);
+        return value.is(Token::Type::Number) && value.token().number().is_integer();
     };
-    auto is_signed_integer = [is_integer](StyleComponentValueRule const& value) -> bool {
-        return is_integer(value) && value.token().is_integer_value_signed();
+    auto is_signed_integer = [](StyleComponentValueRule const& value) -> bool {
+        return value.is(Token::Type::Number) && value.token().number().is_integer_with_explicit_sign();
     };
-    auto is_signless_integer = [is_integer](StyleComponentValueRule const& value) -> bool {
-        return is_integer(value) && !value.token().is_integer_value_signed();
+    auto is_signless_integer = [](StyleComponentValueRule const& value) -> bool {
+        return value.is(Token::Type::Number) && !value.token().number().is_integer_with_explicit_sign();
     };
 
     // https://www.w3.org/TR/css-syntax-3/#the-anb-type

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2530,9 +2530,9 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
                 && s_val.is(Token::Type::Percentage)
                 && l_val.is(Token::Type::Percentage)) {
 
-                auto h = h_val.number_value();
-                auto s = s_val.percentage() / 100.0;
-                auto l = l_val.percentage() / 100.0;
+                auto h = static_cast<float>(h_val.number_value());
+                auto s = static_cast<float>(s_val.percentage() / 100.0f);
+                auto l = static_cast<float>(l_val.percentage() / 100.0f);
                 return Color::from_hsl(h, s, l);
             }
         } else if (function.name().equals_ignoring_case("hsla")) {
@@ -2549,10 +2549,10 @@ Optional<Color> Parser::parse_color(StyleComponentValueRule const& component_val
                 && l_val.is(Token::Type::Percentage)
                 && a_val.is(Token::Type::Number)) {
 
-                auto h = h_val.number_value();
-                auto s = s_val.percentage() / 100.0;
-                auto l = l_val.percentage() / 100.0;
-                auto a = a_val.number_value();
+                auto h = static_cast<float>(h_val.number_value());
+                auto s = static_cast<float>(s_val.percentage() / 100.0f);
+                auto l = static_cast<float>(l_val.percentage() / 100.0f);
+                auto a = static_cast<float>(a_val.number_value());
                 return Color::from_hsla(h, s, l, a);
             }
         }

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleComponentValueRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleComponentValueRule.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -20,46 +20,26 @@ class StyleComponentValueRule {
     friend class Parser;
 
 public:
-    enum class ComponentType {
-        Token,
-        Function,
-        Block
-    };
-
     StyleComponentValueRule(Token);
     explicit StyleComponentValueRule(NonnullRefPtr<StyleFunctionRule>);
     explicit StyleComponentValueRule(NonnullRefPtr<StyleBlockRule>);
     ~StyleComponentValueRule();
 
-    bool is_block() const { return m_type == ComponentType::Block; }
-    StyleBlockRule const& block() const
-    {
-        VERIFY(is_block());
-        return *m_block;
-    }
+    bool is_block() const { return m_value.has<NonnullRefPtr<StyleBlockRule>>(); }
+    StyleBlockRule const& block() const { return m_value.get<NonnullRefPtr<StyleBlockRule>>(); }
 
-    bool is_function() const { return m_type == ComponentType::Function; }
-    StyleFunctionRule const& function() const
-    {
-        VERIFY(is_function());
-        return *m_function;
-    }
+    bool is_function() const { return m_value.has<NonnullRefPtr<StyleFunctionRule>>(); }
+    StyleFunctionRule const& function() const { return m_value.get<NonnullRefPtr<StyleFunctionRule>>(); }
 
-    bool is_token() const { return m_type == ComponentType::Token; }
-    bool is(Token::Type type) const
-    {
-        return m_type == ComponentType::Token && m_token.is(type);
-    }
-    Token const& token() const { return m_token; }
-    operator Token() const { return m_token; }
+    bool is_token() const { return m_value.has<Token>(); }
+    bool is(Token::Type type) const { return is_token() && token().is(type); }
+    Token const& token() const { return m_value.get<Token>(); }
+    operator Token() const { return m_value.get<Token>(); }
 
     String to_string() const;
     String to_debug_string() const;
 
 private:
-    ComponentType m_type;
-    Token m_token;
-    RefPtr<StyleFunctionRule> m_function;
-    RefPtr<StyleBlockRule> m_block;
+    Variant<Token, NonnullRefPtr<StyleFunctionRule>, NonnullRefPtr<StyleBlockRule>> m_value;
 };
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
@@ -37,18 +37,15 @@ StyleBlockRule::StyleBlockRule() = default;
 StyleBlockRule::~StyleBlockRule() = default;
 
 StyleComponentValueRule::StyleComponentValueRule(Token token)
-    : m_type(StyleComponentValueRule::ComponentType::Token)
-    , m_token(token)
+    : m_value(token)
 {
 }
 StyleComponentValueRule::StyleComponentValueRule(NonnullRefPtr<StyleFunctionRule> function)
-    : m_type(StyleComponentValueRule::ComponentType::Function)
-    , m_function(function)
+    : m_value(function)
 {
 }
 StyleComponentValueRule::StyleComponentValueRule(NonnullRefPtr<StyleBlockRule> block)
-    : m_type(StyleComponentValueRule::ComponentType::Block)
-    , m_block(block)
+    : m_value(block)
 {
 }
 StyleComponentValueRule::~StyleComponentValueRule() = default;
@@ -129,38 +126,24 @@ String StyleBlockRule::to_string() const
 
 String StyleComponentValueRule::to_string() const
 {
-    switch (m_type) {
-    case StyleComponentValueRule::ComponentType::Token:
-        return m_token.to_string();
-    case StyleComponentValueRule::ComponentType::Function:
-        return m_function->to_string();
-    case StyleComponentValueRule::ComponentType::Block:
-        return m_block->to_string();
-    default:
-        VERIFY_NOT_REACHED();
-    }
+    return m_value.visit(
+        [](Token const& token) { return token.to_string(); },
+        [](NonnullRefPtr<StyleBlockRule> const& block) { return block->to_string(); },
+        [](NonnullRefPtr<StyleFunctionRule> const& function) { return function->to_string(); });
 }
 
 String StyleComponentValueRule::to_debug_string() const
 {
-    StringBuilder builder;
-
-    switch (m_type) {
-    case ComponentType::Token:
-        builder.append("Token: ");
-        builder.append(m_token.to_debug_string());
-        break;
-    case ComponentType::Function:
-        builder.append("Function: ");
-        builder.append(m_function->to_string());
-        break;
-    case ComponentType::Block:
-        builder.append("Block: ");
-        builder.append(m_block->to_string());
-        break;
-    }
-
-    return builder.to_string();
+    return m_value.visit(
+        [](Token const& token) {
+            return String::formatted("Token: {}", token.to_debug_string());
+        },
+        [](NonnullRefPtr<StyleBlockRule> const& block) {
+            return String::formatted("Function: {}", block->to_string());
+        },
+        [](NonnullRefPtr<StyleFunctionRule> const& function) {
+            return String::formatted("Block: {}", function->to_string());
+        });
 }
 
 String StyleDeclarationRule::to_string() const

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.cpp
@@ -43,11 +43,11 @@ String Token::to_string() const
     case Type::Delim:
         return m_value;
     case Type::Number:
-        return String::number(m_number_value);
+        return String::number(m_number_value.value());
     case Type::Percentage:
-        return String::formatted("{}%", m_number_value);
+        return String::formatted("{}%", m_number_value.value());
     case Type::Dimension:
-        return String::formatted("{}{}", m_number_value, m_unit);
+        return String::formatted("{}{}", m_number_value.value(), dimension_unit());
     case Type::Whitespace:
         return " ";
     case Type::CDO:
@@ -122,8 +122,8 @@ String Token::to_debug_string() const
         return builder.to_string();
     case Type::Number:
         builder.append("Number: ");
-        builder.append(m_value);
-        builder.append(m_number_type == NumberType::Integer ? " (int)" : " (float)");
+        builder.append(m_number_value.value());
+        builder.append(m_number_value.is_integer() ? " (int)" : " (float)");
         return builder.to_string();
     case Type::Percentage:
         builder.append("Percentage: ");
@@ -132,8 +132,8 @@ String Token::to_debug_string() const
         return builder.to_string();
     case Type::Dimension:
         builder.append("Dimension: ");
-        builder.append(m_value);
-        builder.append(m_unit);
+        builder.append(dimension_value());
+        builder.append(dimension_unit());
         return builder.to_string();
     case Type::Whitespace:
         builder.append("Whitespace");
@@ -193,7 +193,7 @@ String Token::to_debug_string() const
 
     if (m_type == Token::Type::Number) {
         builder.append("', number_type: '");
-        if (m_number_type == Token::NumberType::Integer) {
+        if (m_number_value.is_integer()) {
             builder.append("Integer");
         } else {
             builder.append("Number");
@@ -202,14 +202,14 @@ String Token::to_debug_string() const
 
     if (m_type == Token::Type::Dimension) {
         builder.append("', number_type: '");
-        if (m_number_type == Token::NumberType::Integer) {
+        if (m_number_value.is_integer()) {
             builder.append("Integer");
         } else {
             builder.append("Number");
         }
 
         builder.append("', unit: '");
-        builder.append(m_unit);
+        builder.append(dimension_unit());
     }
 
     builder.append("' }");

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -80,140 +81,62 @@ String Token::to_string() const
 
 String Token::to_debug_string() const
 {
-    StringBuilder builder;
-
     switch (m_type) {
     case Type::Invalid:
         VERIFY_NOT_REACHED();
 
     case Type::EndOfFile:
-        builder.append("__EOF__");
-        break;
+        return "__EOF__";
     case Type::Ident:
-        builder.append("Identifier: ");
-        builder.append(m_value);
-        return builder.to_string();
+        return String::formatted("Ident: {}", ident());
     case Type::Function:
-        builder.append("Function");
-        break;
+        return String::formatted("Function: {}", function());
     case Type::AtKeyword:
-        builder.append("@");
-        break;
+        return String::formatted("AtKeyword: {}", at_keyword());
     case Type::Hash:
-        builder.append("Hash: ");
-        builder.append(m_value);
-        return builder.to_string();
+        return String::formatted("Hash: {} (hash_type: {})", hash_value(), m_hash_type == HashType::Unrestricted ? "Unrestricted" : "Id");
     case Type::String:
-        builder.append("String: ");
-        builder.append(m_value);
-        return builder.to_string();
+        return String::formatted("String: {}", string());
     case Type::BadString:
-        builder.append("Invalid String");
-        break;
+        return "BadString";
     case Type::Url:
-        builder.append("Url");
-        break;
+        return String::formatted("Url: {}", url());
     case Type::BadUrl:
-        builder.append("Invalid Url");
-        break;
+        return "BadUrl";
     case Type::Delim:
-        builder.append("Delimiter: ");
-        builder.append(m_value);
-        return builder.to_string();
+        return String::formatted("Delim: {}", m_value);
     case Type::Number:
-        builder.append("Number: ");
-        builder.append(m_number_value.value());
-        builder.append(m_number_value.is_integer() ? " (int)" : " (float)");
-        return builder.to_string();
+        return String::formatted("Number: {} (number_type: {})", m_number_value.value(), m_number_value.is_integer() ? "Integer" : "Number");
     case Type::Percentage:
-        builder.append("Percentage: ");
-        builder.append(m_value);
-        builder.append('%');
-        return builder.to_string();
+        return String::formatted("Percentage: {}% (number_type: {})", percentage(), m_number_value.is_integer() ? "Integer" : "Number");
     case Type::Dimension:
-        builder.append("Dimension: ");
-        builder.append(dimension_value());
-        builder.append(dimension_unit());
-        return builder.to_string();
+        return String::formatted("Dimension: {}{} (number_type: {})", dimension_value(), dimension_unit(), m_number_value.is_integer() ? "Integer" : "Number");
     case Type::Whitespace:
-        builder.append("Whitespace");
-        break;
+        return "Whitespace";
     case Type::CDO:
-        builder.append("CDO");
-        break;
+        return "CDO";
     case Type::CDC:
-        builder.append("CDC");
-        break;
+        return "CDC";
     case Type::Colon:
-        builder.append(":");
-        break;
+        return "Colon";
     case Type::Semicolon:
-        builder.append(";");
-        break;
+        return "Semicolon";
     case Type::Comma:
-        builder.append(",");
-        break;
+        return "Comma";
     case Type::OpenSquare:
-        builder.append("[");
-        break;
+        return "OpenSquare";
     case Type::CloseSquare:
-        builder.append("]");
-        break;
+        return "CloseSquare";
     case Type::OpenParen:
-        builder.append("(");
-        break;
+        return "OpenParen";
     case Type::CloseParen:
-        builder.append(")");
-        break;
+        return "CloseParen";
     case Type::OpenCurly:
-        builder.append("{");
-        break;
+        return "OpenCurly";
     case Type::CloseCurly:
-        builder.append("}");
-        break;
+        return "CloseCurly";
     }
-
-    if (m_value.is_empty()) {
-        return builder.to_string();
-    }
-
-    builder.append(" ");
-
-    builder.append(" { value: '");
-    builder.append(m_value);
-
-    if (m_type == Token::Type::Hash) {
-        builder.append("', hash_type: '");
-        if (m_hash_type == Token::HashType::Unrestricted) {
-            builder.append("Unrestricted");
-        } else {
-            builder.append("Id");
-        }
-    }
-
-    if (m_type == Token::Type::Number) {
-        builder.append("', number_type: '");
-        if (m_number_value.is_integer()) {
-            builder.append("Integer");
-        } else {
-            builder.append("Number");
-        }
-    }
-
-    if (m_type == Token::Type::Dimension) {
-        builder.append("', number_type: '");
-        if (m_number_value.is_integer()) {
-            builder.append("Integer");
-        } else {
-            builder.append("Number");
-        }
-
-        builder.append("', unit: '");
-        builder.append(dimension_unit());
-    }
-
-    builder.append("' }");
-    return builder.to_string();
+    VERIFY_NOT_REACHED();
 }
 
 Token::Type Token::mirror_variant() const

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -126,7 +126,7 @@ public:
     StringView dimension_unit() const
     {
         VERIFY(m_type == Type::Dimension);
-        return m_unit.view();
+        return m_value.view();
     }
     float dimension_value() const
     {
@@ -155,7 +155,6 @@ private:
     Type m_type { Type::Invalid };
 
     FlyString m_value;
-    FlyString m_unit;
     Number m_number_value;
     HashType m_hash_type { HashType::Unrestricted };
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -118,7 +118,7 @@ public:
         VERIFY(m_type == Type::Number);
         return m_value.view();
     }
-    double number_value() const
+    float number_value() const
     {
         VERIFY(m_type == Type::Number);
         return m_number_value;
@@ -135,14 +135,14 @@ public:
         VERIFY(m_type == Type::Dimension);
         return m_unit.view();
     }
-    double dimension_value() const
+    float dimension_value() const
     {
         VERIFY(m_type == Type::Dimension);
         return m_number_value;
     }
     i64 dimension_value_int() const { return to_closest_integer(dimension_value()); }
 
-    double percentage() const
+    float percentage() const
     {
         VERIFY(m_type == Type::Percentage);
         return m_number_value;
@@ -165,22 +165,22 @@ public:
     Position const& end_position() const { return m_end_position; }
 
 private:
-    static i64 to_closest_integer(double value)
+    static i64 to_closest_integer(float value)
     {
         // https://www.w3.org/TR/css-values-4/#numeric-types
         // When a value cannot be explicitly supported due to range/precision limitations, it must be converted
         // to the closest value supported by the implementation, but how the implementation defines "closest"
         // is explicitly undefined as well.
-        return llround(value);
+        return llroundf(value);
     }
 
     Type m_type { Type::Invalid };
 
     FlyString m_value;
     FlyString m_unit;
-    HashType m_hash_type { HashType::Unrestricted };
+    float m_number_value { 0 };
     NumberType m_number_type { NumberType::Integer };
-    double m_number_value { 0 };
+    HashType m_hash_type { HashType::Unrestricted };
 
     Position m_start_position;
     Position m_end_position;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -845,7 +845,8 @@ Token Tokenizer::consume_a_numeric_token()
         // 2. Consume a name. Set the <dimension-token>’s unit to the returned value.
         auto unit = consume_a_name();
         VERIFY(!unit.is_empty());
-        token.m_unit = move(unit);
+        // NOTE: We intentionally store this in the `value`, to save space.
+        token.m_value = move(unit);
 
         // 3. Return the <dimension-token>.
         return token;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -582,7 +582,7 @@ double Tokenizer::convert_a_string_to_a_number(StringView string)
     // 2. An integer part: zero or more digits.
     //    If there is at least one digit, let i [integer_part] be the number formed by interpreting the digits
     //    as a base-10 integer; otherwise, let i be the number 0.
-    double integer_part = 0;
+    i64 integer_part = 0;
     while (is_ascii_digit(code_point_at(position))) {
         integer_part = (integer_part * 10) + (code_point_at(position) - '0');
         position++;
@@ -595,7 +595,7 @@ double Tokenizer::convert_a_string_to_a_number(StringView string)
     // 4. A fractional part: zero or more digits.
     //    If there is at least one digit, let f [fractional_part] be the number formed by interpreting the digits
     //    as a base-10 integer and d [fractional_digits] be the number of digits; otherwise, let f and d be the number 0.
-    double fractional_part = 0;
+    i64 fractional_part = 0;
     int fractional_digits = 0;
     while (is_ascii_digit(code_point_at(position))) {
         fractional_part = (fractional_part * 10) + (code_point_at(position) - '0');
@@ -619,7 +619,7 @@ double Tokenizer::convert_a_string_to_a_number(StringView string)
     // 7. An exponent: zero or more digits.
     //    If there is at least one digit, let e [exponent] be the number formed by interpreting the digits as a
     //    base-10 integer; otherwise, let e be the number 0.
-    double exponent = 0;
+    i64 exponent = 0;
     while (is_ascii_digit(code_point_at(position))) {
         exponent = (exponent * 10) + (code_point_at(position) - '0');
         position++;

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -557,7 +557,7 @@ CSSNumber Tokenizer::consume_a_number()
 }
 
 // https://www.w3.org/TR/css-syntax-3/#convert-string-to-number
-double Tokenizer::convert_a_string_to_a_number(StringView string)
+float Tokenizer::convert_a_string_to_a_number(StringView string)
 {
     auto code_point_at = [&](size_t index) -> u32 {
         if (index < string.length())
@@ -630,7 +630,7 @@ double Tokenizer::convert_a_string_to_a_number(StringView string)
     VERIFY(position == string.length());
 
     // Return the number s·(i + f·10^-d)·10^te.
-    return sign * (integer_part + fractional_part * pow(10, -fractional_digits)) * pow(10, exponent_sign * exponent);
+    return sign * (integer_part + fractional_part * powf(10, -fractional_digits)) * powf(10, exponent_sign * exponent);
 }
 
 // https://www.w3.org/TR/css-syntax-3/#consume-name

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -57,13 +57,6 @@ public:
     u32 third {};
 };
 
-class CSSNumber {
-public:
-    String string;
-    float value { 0 };
-    Token::NumberType type {};
-};
-
 class Tokenizer {
 
 public:
@@ -89,7 +82,7 @@ private:
     [[nodiscard]] Token consume_string_token(u32 ending_code_point);
     [[nodiscard]] Token consume_a_numeric_token();
     [[nodiscard]] Token consume_an_ident_like_token();
-    [[nodiscard]] CSSNumber consume_a_number();
+    [[nodiscard]] Number consume_a_number();
     [[nodiscard]] float convert_a_string_to_a_number(StringView);
     [[nodiscard]] String consume_a_name();
     [[nodiscard]] u32 consume_escaped_code_point();

--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.h
@@ -60,7 +60,7 @@ public:
 class CSSNumber {
 public:
     String string;
-    double value { 0 };
+    float value { 0 };
     Token::NumberType type {};
 };
 
@@ -90,7 +90,7 @@ private:
     [[nodiscard]] Token consume_a_numeric_token();
     [[nodiscard]] Token consume_an_ident_like_token();
     [[nodiscard]] CSSNumber consume_a_number();
-    [[nodiscard]] double convert_a_string_to_a_number(StringView);
+    [[nodiscard]] float convert_a_string_to_a_number(StringView);
     [[nodiscard]] String consume_a_name();
     [[nodiscard]] u32 consume_escaped_code_point();
     [[nodiscard]] Token consume_a_url_token();

--- a/Userland/Libraries/LibWeb/CSS/Selector.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Selector.cpp
@@ -105,8 +105,6 @@ u32 Selector::specificity() const
             case SimpleSelector::Type::Universal:
                 // ignore the universal selector
                 break;
-            case SimpleSelector::Type::Invalid:
-                break;
             }
         }
     }

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -85,12 +85,12 @@ public:
 
             // FIXME: We don't need this field on every single SimpleSelector, but it's also annoying to malloc it somewhere.
             // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
-            ANPlusBPattern nth_child_pattern;
+            ANPlusBPattern nth_child_pattern {};
 
             SelectorList argument_selector_list {};
 
             // Used for :lang(en-gb,dk)
-            Vector<FlyString> languages;
+            Vector<FlyString> languages {};
         };
 
         struct Attribute {

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -41,7 +41,6 @@ public:
             PseudoClass,
             PseudoElement,
         };
-        Type type { Type::Invalid };
 
         struct ANPlusBPattern {
             int step_size { 0 }; // "A"
@@ -93,10 +92,6 @@ public:
             // Used for :lang(en-gb,dk)
             Vector<FlyString> languages;
         };
-        PseudoClass pseudo_class {};
-        PseudoElement pseudo_element { PseudoElement::None };
-
-        FlyString value {};
 
         struct Attribute {
             enum class MatchType {
@@ -113,7 +108,18 @@ public:
             FlyString name {};
             String value {};
         };
-        Attribute attribute {};
+
+        Type type { Type::Invalid };
+        Variant<Empty, Attribute, PseudoClass, PseudoElement, FlyString> value {};
+
+        Attribute const& attribute() const { return value.get<Attribute>(); }
+        Attribute& attribute() { return value.get<Attribute>(); }
+        PseudoClass const& pseudo_class() const { return value.get<PseudoClass>(); }
+        PseudoClass& pseudo_class() { return value.get<PseudoClass>(); }
+        PseudoElement const& pseudo_element() const { return value.get<PseudoElement>(); }
+        PseudoElement& pseudo_element() { return value.get<PseudoElement>(); }
+        FlyString const& name() const { return value.get<FlyString>(); }
+        FlyString& name() { return value.get<FlyString>(); }
 
         String serialize() const;
     };

--- a/Userland/Libraries/LibWeb/CSS/Selector.h
+++ b/Userland/Libraries/LibWeb/CSS/Selector.h
@@ -21,7 +21,6 @@ using SelectorList = NonnullRefPtrVector<class Selector>;
 class Selector : public RefCounted<Selector> {
 public:
     enum class PseudoElement {
-        None,
         Before,
         After,
         FirstLine,
@@ -32,7 +31,6 @@ public:
 
     struct SimpleSelector {
         enum class Type {
-            Invalid,
             Universal,
             TagName,
             Id,
@@ -54,7 +52,6 @@ public:
 
         struct PseudoClass {
             enum class Type {
-                None,
                 Link,
                 Visited,
                 Hover,
@@ -81,7 +78,7 @@ public:
                 Active,
                 Lang,
             };
-            Type type { Type::None };
+            Type type;
 
             // FIXME: We don't need this field on every single SimpleSelector, but it's also annoying to malloc it somewhere.
             // Only used when "pseudo_class" is "NthChild" or "NthLastChild".
@@ -95,7 +92,6 @@ public:
 
         struct Attribute {
             enum class MatchType {
-                None,
                 HasAttribute,
                 ExactValueMatch,
                 ContainsWord,      // [att~=val]
@@ -104,12 +100,12 @@ public:
                 StartsWithString,  // [att^=val]
                 EndsWithString,    // [att$=val]
             };
-            MatchType match_type { MatchType::None };
+            MatchType match_type;
             FlyString name {};
             String value {};
         };
 
-        Type type { Type::Invalid };
+        Type type;
         Variant<Empty, Attribute, PseudoClass, PseudoElement, FlyString> value {};
 
         Attribute const& attribute() const { return value.get<Attribute>(); }
@@ -173,8 +169,6 @@ constexpr StringView pseudo_element_name(Selector::PseudoElement pseudo_element)
         return "first-letter"sv;
     case Selector::PseudoElement::Marker:
         return "marker"sv;
-    case Selector::PseudoElement::None:
-        break;
     }
     VERIFY_NOT_REACHED();
 }
@@ -234,8 +228,6 @@ constexpr StringView pseudo_class_name(Selector::SimpleSelector::PseudoClass::Ty
         return "where"sv;
     case Selector::SimpleSelector::PseudoClass::Type::Lang:
         return "lang"sv;
-    case Selector::SimpleSelector::PseudoClass::Type::None:
-        break;
     }
     VERIFY_NOT_REACHED();
 }

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -95,9 +95,6 @@ static inline bool matches_attribute(CSS::Selector::SimpleSelector::Attribute co
         return element.attribute(attribute.name).starts_with(attribute.value);
     case CSS::Selector::SimpleSelector::Attribute::MatchType::EndsWithString:
         return element.attribute(attribute.name).ends_with(attribute.value);
-    case CSS::Selector::SimpleSelector::Attribute::MatchType::None:
-        VERIFY_NOT_REACHED();
-        break;
     }
 
     return false;
@@ -124,8 +121,6 @@ static inline DOM::Element const* next_sibling_with_same_tag_name(DOM::Element c
 static inline bool matches_pseudo_class(CSS::Selector::SimpleSelector::PseudoClass const& pseudo_class, DOM::Element const& element)
 {
     switch (pseudo_class.type) {
-    case CSS::Selector::SimpleSelector::PseudoClass::Type::None:
-        break;
     case CSS::Selector::SimpleSelector::PseudoClass::Type::Link:
         return element.is_link();
     case CSS::Selector::SimpleSelector::PseudoClass::Type::Visited:

--- a/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
+++ b/Userland/Libraries/LibWeb/CSS/SelectorEngine.cpp
@@ -301,15 +301,15 @@ static inline bool matches(CSS::Selector::SimpleSelector const& component, DOM::
     case CSS::Selector::SimpleSelector::Type::Universal:
         return true;
     case CSS::Selector::SimpleSelector::Type::Id:
-        return component.value == element.attribute(HTML::AttributeNames::id);
+        return component.name() == element.attribute(HTML::AttributeNames::id);
     case CSS::Selector::SimpleSelector::Type::Class:
-        return element.has_class(component.value);
+        return element.has_class(component.name());
     case CSS::Selector::SimpleSelector::Type::TagName:
-        return component.value == element.local_name();
+        return component.name() == element.local_name();
     case CSS::Selector::SimpleSelector::Type::Attribute:
-        return matches_attribute(component.attribute, element);
+        return matches_attribute(component.attribute(), element);
     case CSS::Selector::SimpleSelector::Type::PseudoClass:
-        return matches_pseudo_class(component.pseudo_class, element);
+        return matches_pseudo_class(component.pseudo_class(), element);
     case CSS::Selector::SimpleSelector::Type::PseudoElement:
         // Pseudo-element matching/not-matching is handled in the top level matches().
         return true;

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -1109,7 +1109,7 @@ void StyleComputer::build_rule_cache()
                 bool added_to_bucket = false;
                 for (auto const& simple_selector : selector.compound_selectors().last().simple_selectors) {
                     if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoElement) {
-                        m_rule_cache->rules_by_pseudo_element.ensure(simple_selector.pseudo_element).append(move(matching_rule));
+                        m_rule_cache->rules_by_pseudo_element.ensure(simple_selector.pseudo_element()).append(move(matching_rule));
                         ++num_pseudo_element_rules;
                         added_to_bucket = true;
                         break;
@@ -1118,19 +1118,19 @@ void StyleComputer::build_rule_cache()
                 if (!added_to_bucket) {
                     for (auto const& simple_selector : selector.compound_selectors().last().simple_selectors) {
                         if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Id) {
-                            m_rule_cache->rules_by_id.ensure(simple_selector.value).append(move(matching_rule));
+                            m_rule_cache->rules_by_id.ensure(simple_selector.name()).append(move(matching_rule));
                             ++num_id_rules;
                             added_to_bucket = true;
                             break;
                         }
                         if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Class) {
-                            m_rule_cache->rules_by_class.ensure(simple_selector.value).append(move(matching_rule));
+                            m_rule_cache->rules_by_class.ensure(simple_selector.name()).append(move(matching_rule));
                             ++num_class_rules;
                             added_to_bucket = true;
                             break;
                         }
                         if (simple_selector.type == CSS::Selector::SimpleSelector::Type::TagName) {
-                            m_rule_cache->rules_by_tag_name.ensure(simple_selector.value).append(move(matching_rule));
+                            m_rule_cache->rules_by_tag_name.ensure(simple_selector.name()).append(move(matching_rule));
                             ++num_tag_name_rules;
                             added_to_bucket = true;
                             break;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -27,6 +27,7 @@
 #include <LibWeb/CSS/Display.h>
 #include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Length.h>
+#include <LibWeb/CSS/Number.h>
 #include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/PropertyID.h>
@@ -806,11 +807,6 @@ public:
     enum class ProductOperation {
         Multiply,
         Divide,
-    };
-
-    struct Number {
-        bool is_integer;
-        float value;
     };
 
     using PercentageBasis = Variant<Empty, Angle, Frequency, Length, Time>;

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -333,9 +333,6 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             auto& simple_selector = relative_selector.simple_selectors[i];
             char const* type_description = "Unknown";
             switch (simple_selector.type) {
-            case CSS::Selector::SimpleSelector::Type::Invalid:
-                type_description = "Invalid";
-                break;
             case CSS::Selector::SimpleSelector::Type::Universal:
                 type_description = "Universal";
                 break;
@@ -377,9 +374,6 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                     break;
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Active:
                     pseudo_class_description = "Active";
-                    break;
-                case CSS::Selector::SimpleSelector::PseudoClass::Type::None:
-                    pseudo_class_description = "None";
                     break;
                 case CSS::Selector::SimpleSelector::PseudoClass::Type::Root:
                     pseudo_class_description = "Root";
@@ -479,9 +473,6 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoElement) {
                 char const* pseudo_element_description = "";
                 switch (simple_selector.pseudo_element()) {
-                case CSS::Selector::PseudoElement::None:
-                    pseudo_element_description = "NONE";
-                    break;
                 case CSS::Selector::PseudoElement::Before:
                     pseudo_element_description = "before";
                     break;
@@ -507,9 +498,6 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 char const* attribute_match_type_description = "";
 
                 switch (attribute.match_type) {
-                case CSS::Selector::SimpleSelector::Attribute::MatchType::None:
-                    attribute_match_type_description = "NONE";
-                    break;
                 case CSS::Selector::SimpleSelector::Attribute::MatchType::HasAttribute:
                     attribute_match_type_description = "HasAttribute";
                     break;

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -359,10 +359,13 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                 break;
             }
 
-            builder.appendff("{}:{}", type_description, simple_selector.value);
+            builder.appendff("{}:", type_description);
+            // FIXME: This is goofy
+            if (simple_selector.value.has<FlyString>())
+                builder.append(simple_selector.name());
 
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoClass) {
-                auto const& pseudo_class = simple_selector.pseudo_class;
+                auto const& pseudo_class = simple_selector.pseudo_class();
 
                 char const* pseudo_class_description = "";
                 switch (pseudo_class.type) {
@@ -475,7 +478,7 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
 
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::PseudoElement) {
                 char const* pseudo_element_description = "";
-                switch (simple_selector.pseudo_element) {
+                switch (simple_selector.pseudo_element()) {
                 case CSS::Selector::PseudoElement::None:
                     pseudo_element_description = "NONE";
                     break;
@@ -500,9 +503,10 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
             }
 
             if (simple_selector.type == CSS::Selector::SimpleSelector::Type::Attribute) {
+                auto const& attribute = simple_selector.attribute();
                 char const* attribute_match_type_description = "";
 
-                switch (simple_selector.attribute.match_type) {
+                switch (attribute.match_type) {
                 case CSS::Selector::SimpleSelector::Attribute::MatchType::None:
                     attribute_match_type_description = "NONE";
                     break;
@@ -529,7 +533,7 @@ void dump_selector(StringBuilder& builder, CSS::Selector const& selector)
                     break;
                 }
 
-                builder.appendff(" [{}, name='{}', value='{}']", attribute_match_type_description, simple_selector.attribute.name, simple_selector.attribute.value);
+                builder.appendff(" [{}, name='{}', value='{}']", attribute_match_type_description, attribute.name, attribute.value);
             }
 
             if (i != relative_selector.simple_selectors.size() - 1)

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -59,6 +59,7 @@ class MediaList;
 class MediaQuery;
 class MediaQueryList;
 class MediaQueryListEvent;
+class Number;
 class NumericStyleValue;
 class OverflowStyleValue;
 class Percentage;


### PR DESCRIPTION
First off, the results:
<table>
<tr>
	<th>
	<th>Before
	<th>After
	<th>Difference
<tr>
	<th>`Token`
	<td>72 bytes
	<td>64 bytes
	<td>11% smaller
<tr>
	<th>`StyleComponentValueRule`
	<td>96 bytes
	<td>72 bytes
	<td>25% smaller
<tr>
	<th>`Selector::SimpleSelector`
	<td>112 bytes
	<td>80 bytes
	<td>28% smaller
</table>

The main change is using `Variant`s instead of having all the fields all the time and only using one. This had the nice bonus of being able to remove the 'none' state from 4 enums. :^)

Also, this replaces uses of `double` in CSS tokens with `float`. At some point while working on this before, I decided we needed ***maximum precision all the time*** when that's really not true. The only time numbers are likely to get larger than a million is when someone wants a generically-large z-index (side-note: they're adding an `infinity` value for this in a recent spec) and fractional numbers rarely go smaller than 0.01, so `float` is fine.

I also introduced a `CSS::Number` type, which wraps the "is this number an integer" flags that were used in several places, in the hope of making `Token` even smaller, to no avail, but I think it's still a positive change. I haven't used it in `NumericStyleValue` yet, because that explicitly stores integers as integers, and I'm not sure how best to handle that. `Number` can *almost* be a `Variant<float,i32>` except for needing to also track whether the integer value had a sign character, since that's needed for An+B parsing, which is a pain.