### PR TITLE
LibWeb: Allow percentages in word/letter-spacing properties

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -829,7 +829,8 @@
     "inherited": true,
     "initial": "normal",
     "valid-types": [
-      "length"
+      "length",
+      "percentage"
     ],
     "valid-identifiers": [
       "normal"
@@ -1459,7 +1460,8 @@
     "inherited": true,
     "initial": "normal",
     "valid-types": [
-      "length"
+      "length",
+      "percentage"
     ],
     "valid-identifiers": [
       "normal"


### PR DESCRIPTION
This is a change to CSS-TEXT-4, listed here:
https://www.w3.org/TR/2022/WD-css-text-4-20220318/#changes

We don't actually support these properties yet, but it doesn't hurt to
keep them up to date for when they get implemented in the future. :^)