### PR TITLE
LibWeb: Handle input element value setting & getting closer to the spec

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -119,11 +119,15 @@ private:
     // https://html.spec.whatwg.org/multipage/input.html#concept-input-checked-dirty-flag
     bool m_dirty_checkedness { false };
 
+    // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-dirty
+    bool m_dirty_value { false };
+
     // https://html.spec.whatwg.org/multipage/input.html#the-input-element:legacy-pre-activation-behavior
     bool m_before_legacy_pre_activation_behavior_checked { false };
     RefPtr<HTMLInputElement> m_legacy_pre_activation_behavior_checked_element_in_group;
 
     TypeAttributeState m_type { TypeAttributeState::Text };
+    String m_value;
 };
 
 }


### PR DESCRIPTION
Fixes test 53 on Acid 3. It verifies the value of an input element, but also verifies that "value" is not an attribute when it was only set programmatically.

I double checked that our form.html test page and submitting search queries on Google still work with this change.

![94](https://user-images.githubusercontent.com/5600524/159511778-9a13a305-5d67-4792-ad90-5ec9e518e27c.png)
