### PR TITLE
Kernel: Use the whole kernel PD range when randomizing the KASLR offset

### DIFF
--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -326,6 +326,22 @@ Date:   Tue Aug 31 16:08:11 2021 +0200
 Build: Pass "-z separate-code" to linker
 ```
 
+### KASLR (Kernel Address Space Layout Randomization)
+
+The location of the kernel code is randomized at boot time, this ensures that attackers
+can not use a hardcoded kernel addresses when attempting ROP, instead they must first find
+an additional information leak to expose the KASLR offset.
+
+It was first enabled in the following [commit](https://github.com/SerenityOS/serenity/commit/ece5a9a1088012ca9fadfb7e0bc3edd8029d36ad):
+
+```
+commit ece5a9a1088012ca9fadfb7e0bc3edd8029d36ad
+Author Idan Horowitz <idan.horowitz@gmail.com>
+Date:  Mon Mar 21 22:59:48 2022 +0200
+
+Kernel: Add an extremely primitive version of KASLR
+```
+
 ## See also
 
 * [`unveil`(2)](help://man/2/unveil)

--- a/Base/usr/share/man/man7/Mitigations.md
+++ b/Base/usr/share/man/man7/Mitigations.md
@@ -41,6 +41,22 @@ Date:   Sun Jan 5 18:00:15 2020 +0100
 Kernel: Start implementing x86 SMAP support
 ```
 
+### UMIP (User Mode Instruction Prevention)
+
+User Mode Instruction Prevention is an x86 CPU security feature which prevents execution of specific privileged
+instructions in user mode (SGDT, SIDT, SLDT, SMSW, STR).
+These instructions let user mode code query the addresses of various kernel structures (the GDT, LDT, IDT, etc),
+meaning that they leak kernel addresses that can be exploited to defeat ASLR.
+
+It was enabled in the following [commit](https://github.com/SerenityOS/serenity/commit/9c0836ce97ae36165abd8eb5241bb5239af3a756):
+```
+commit 9c0836ce97ae36165abd8eb5241bb5239af3a756
+Author: Andreas Kling <awesomekling@gmail.com>
+Date:   Wed Jan 1 13:02:32 2020 +0100
+
+Kernel: Enable x86 UMIP (User Mode Instruction Prevention) if supported
+```
+
 ### Pledge
 
 [pledge](https://marc.info/?l=openbsd-tech&m=143725996614627&w=2) is a mitigation which originated from OpenBSD.

--- a/Kernel/BootInfo.h
+++ b/Kernel/BootInfo.h
@@ -18,7 +18,6 @@ extern "C" PhysicalAddress start_of_prekernel_image;
 extern "C" PhysicalAddress end_of_prekernel_image;
 extern "C" size_t physical_to_virtual_offset;
 extern "C" FlatPtr kernel_mapping_base;
-extern "C" FlatPtr default_kernel_load_base;
 extern "C" FlatPtr kernel_load_base;
 #if ARCH(X86_64)
 extern "C" u32 gdt64ptr;

--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -36,7 +36,8 @@ UNMAP_AFTER_INIT NonnullRefPtr<PageDirectory> PageDirectory::must_create_kernel_
 {
     auto directory = adopt_ref_if_nonnull(new (nothrow) PageDirectory).release_nonnull();
 
-    MUST(directory->m_range_allocator.initialize_with_range(VirtualAddress(default_kernel_load_base), KERNEL_PD_END - default_kernel_load_base));
+    auto kernel_range_start = kernel_mapping_base + 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
+    MUST(directory->m_range_allocator.initialize_with_range(VirtualAddress(kernel_range_start), KERNEL_PD_END - kernel_range_start));
     // Carve out the whole page directory covering the kernel image to make MemoryManager::initialize_physical_pages() happy
     FlatPtr start_of_range = ((FlatPtr)start_of_kernel_image & ~(FlatPtr)0x1fffff);
     FlatPtr end_of_range = ((FlatPtr)end_of_kernel_image & ~(FlatPtr)0x1fffff) + 0x200000;

--- a/Kernel/Prekernel/Prekernel.h
+++ b/Kernel/Prekernel/Prekernel.h
@@ -13,6 +13,7 @@
 #endif
 
 #define MAX_KERNEL_SIZE 0x4000000
+#define KERNEL_PD_SIZE 0x31000000
 
 #ifdef __cplusplus
 namespace Kernel {
@@ -22,7 +23,6 @@ struct [[gnu::packed]] BootInfo {
     u32 end_of_prekernel_image;
     u64 physical_to_virtual_offset;
     u64 kernel_mapping_base;
-    u64 default_kernel_load_base;
     u64 kernel_load_base;
 #    if ARCH(X86_64)
     u32 gdt64ptr;

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -97,7 +97,7 @@ extern "C" [[noreturn]] void init()
 #endif
 
     // KASLR
-    static constexpr auto maximum_offset = 256 * MiB;
+    FlatPtr maximum_offset = (FlatPtr)KERNEL_PD_SIZE - MAX_KERNEL_SIZE - 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
     FlatPtr kernel_load_base = default_kernel_load_base + (generate_secure_seed() % maximum_offset);
     kernel_load_base &= ~(2 * MiB - 1);
 
@@ -184,7 +184,6 @@ extern "C" [[noreturn]] void init()
     info.end_of_prekernel_image = (PhysicalPtr)end_of_prekernel_image;
     info.physical_to_virtual_offset = kernel_load_base - kernel_physical_base;
     info.kernel_mapping_base = kernel_mapping_base;
-    info.default_kernel_load_base = default_kernel_load_base;
     info.kernel_load_base = kernel_load_base;
 #if ARCH(X86_64)
     info.gdt64ptr = (PhysicalPtr)gdt64ptr;

--- a/Kernel/Sections.h
+++ b/Kernel/Sections.h
@@ -15,7 +15,7 @@
 #define READONLY_AFTER_INIT __attribute__((section(".ro_after_init")))
 #define UNMAP_AFTER_INIT NEVER_INLINE __attribute__((section(".unmap_after_init")))
 
-#define KERNEL_PD_END (kernel_mapping_base + 0x31000000)
+#define KERNEL_PD_END (kernel_mapping_base + KERNEL_PD_SIZE)
 #define KERNEL_PT1024_BASE (kernel_mapping_base + 0x3FE00000)
 #define KERNEL_QUICKMAP_PT (KERNEL_PT1024_BASE + 0x6000)
 #define KERNEL_QUICKMAP_PD (KERNEL_PT1024_BASE + 0x7000)

--- a/Kernel/init.cpp
+++ b/Kernel/init.cpp
@@ -116,7 +116,6 @@ READONLY_AFTER_INIT PhysicalAddress start_of_prekernel_image;
 READONLY_AFTER_INIT PhysicalAddress end_of_prekernel_image;
 READONLY_AFTER_INIT size_t physical_to_virtual_offset;
 READONLY_AFTER_INIT FlatPtr kernel_mapping_base;
-READONLY_AFTER_INIT FlatPtr default_kernel_load_base;
 READONLY_AFTER_INIT FlatPtr kernel_load_base;
 #if ARCH(X86_64)
 READONLY_AFTER_INIT PhysicalAddress boot_pml4t;
@@ -149,7 +148,6 @@ extern "C" [[noreturn]] UNMAP_AFTER_INIT void init(BootInfo const& boot_info)
     end_of_prekernel_image = PhysicalAddress { boot_info.end_of_prekernel_image };
     physical_to_virtual_offset = boot_info.physical_to_virtual_offset;
     kernel_mapping_base = boot_info.kernel_mapping_base;
-    default_kernel_load_base = boot_info.default_kernel_load_base;
     kernel_load_base = boot_info.kernel_load_base;
 #if ARCH(X86_64)
     gdt64ptr = boot_info.gdt64ptr;


### PR DESCRIPTION
Now that we reclaim the memory range that is created by KASLR before the start of the kernel image, there's no need to be conservative with the KASLR offset.