### PR TITLE
LibC: Make getaddrinfo() thread-safe.

### DIFF
--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -19,7 +19,7 @@
 
 extern "C" {
 
-int h_errno;
+__thread int h_errno;
 
 static hostent __gethostbyname_buffer;
 static in_addr_t __gethostbyname_address;

--- a/Userland/Libraries/LibC/netdb.h
+++ b/Userland/Libraries/LibC/netdb.h
@@ -48,7 +48,7 @@ struct protoent* getprotobynumber(int proto);
 struct protoent* getprotoent(void);
 void setprotoent(int stay_open);
 
-extern int h_errno;
+extern __thread int h_errno;
 
 #define HOST_NOT_FOUND 101
 #define NO_DATA 102


### PR DESCRIPTION
Fixes #7686 as per my comments.
```
getaddrinfo() is required per POSIX to be thread-safe. The netdb.h
header is lacking reentrant, thread-safe GNU extensions for
gethostbyname() and similar functions, but they are not required and has
been removed from POSIX since revision POSIX.1-2008 which makes creating a
mutex in this function a simplest solution to this incompatibility.
```

In addition, the first commit makes `h_errno` a thread-local variable.