### PR TITLE
LibWeb: Expose SVGLineElement, SVGCircleElement and SVGEllipseElement attributes to JS

### DIFF
--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.cpp
@@ -70,4 +70,34 @@ Gfx::Path& SVGCircleElement::get_path()
     return m_path.value();
 }
 
+// https://www.w3.org/TR/SVG11/shapes.html#CircleElementCXAttribute
+NonnullRefPtr<SVGAnimatedLength> SVGCircleElement::cx() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_center_x.value_or(0));
+    auto anim_length = SVGLength::create(0, m_center_x.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
+// https://www.w3.org/TR/SVG11/shapes.html#CircleElementCYAttribute
+NonnullRefPtr<SVGAnimatedLength> SVGCircleElement::cy() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_center_y.value_or(0));
+    auto anim_length = SVGLength::create(0, m_center_y.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
+// https://www.w3.org/TR/SVG11/shapes.html#CircleElementRAttribute
+NonnullRefPtr<SVGAnimatedLength> SVGCircleElement::r() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_radius.value_or(0));
+    auto anim_length = SVGLength::create(0, m_radius.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/SVG/SVGAnimatedLength.h>
 #include <LibWeb/SVG/SVGGeometryElement.h>
 
 namespace Web::SVG {
@@ -20,6 +21,10 @@ public:
     virtual void parse_attribute(FlyString const& name, String const& value) override;
 
     virtual Gfx::Path& get_path() override;
+
+    NonnullRefPtr<SVGAnimatedLength> cx() const;
+    NonnullRefPtr<SVGAnimatedLength> cy() const;
+    NonnullRefPtr<SVGAnimatedLength> r() const;
 
 private:
     Optional<Gfx::Path> m_path;

--- a/Userland/Libraries/LibWeb/SVG/SVGCircleElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGCircleElement.idl
@@ -1,8 +1,9 @@
+#import <SVG/SVGAnimatedLength.idl>
 #import <SVG/SVGGeometryElement.idl>
 
 [Exposed=Window]
 interface SVGCircleElement : SVGGeometryElement {
-    // [SameObject] readonly attribute SVGAnimatedLength cx;
-    // [SameObject] readonly attribute SVGAnimatedLength cy;
-    // [SameObject] readonly attribute SVGAnimatedLength r;
+    [SameObject] readonly attribute SVGAnimatedLength cx;
+    [SameObject] readonly attribute SVGAnimatedLength cy;
+    [SameObject] readonly attribute SVGAnimatedLength r;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.cpp
@@ -75,4 +75,44 @@ Gfx::Path& SVGEllipseElement::get_path()
     return m_path.value();
 }
 
+// https://www.w3.org/TR/SVG11/shapes.html#EllipseElementCXAttribute
+NonnullRefPtr<SVGAnimatedLength> SVGEllipseElement::cx() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_center_x.value_or(0));
+    auto anim_length = SVGLength::create(0, m_center_x.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
+// https://www.w3.org/TR/SVG11/shapes.html#EllipseElementCYAttribute
+NonnullRefPtr<SVGAnimatedLength> SVGEllipseElement::cy() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_center_y.value_or(0));
+    auto anim_length = SVGLength::create(0, m_center_y.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
+// https://www.w3.org/TR/SVG11/shapes.html#EllipseElementRXAttribute
+NonnullRefPtr<SVGAnimatedLength> SVGEllipseElement::rx() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_radius_x.value_or(0));
+    auto anim_length = SVGLength::create(0, m_radius_x.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
+// https://www.w3.org/TR/SVG11/shapes.html#EllipseElementRYAttribute
+NonnullRefPtr<SVGAnimatedLength> SVGEllipseElement::ry() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_radius_y.value_or(0));
+    auto anim_length = SVGLength::create(0, m_radius_y.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/SVG/SVGAnimatedLength.h>
 #include <LibWeb/SVG/SVGGeometryElement.h>
 
 namespace Web::SVG {
@@ -20,6 +21,11 @@ public:
     virtual void parse_attribute(FlyString const& name, String const& value) override;
 
     virtual Gfx::Path& get_path() override;
+
+    NonnullRefPtr<SVGAnimatedLength> cx() const;
+    NonnullRefPtr<SVGAnimatedLength> cy() const;
+    NonnullRefPtr<SVGAnimatedLength> rx() const;
+    NonnullRefPtr<SVGAnimatedLength> ry() const;
 
 private:
     Optional<Gfx::Path> m_path;

--- a/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGEllipseElement.idl
@@ -1,9 +1,10 @@
+#import <SVG/SVGAnimatedLength.idl>
 #import <SVG/SVGGeometryElement.idl>
 
 [Exposed=Window]
 interface SVGEllipseElement : SVGGeometryElement {
-    // [SameObject] readonly attribute SVGAnimatedLength cx;
-    // [SameObject] readonly attribute SVGAnimatedLength cy;
-    // [SameObject] readonly attribute SVGAnimatedLength rx;
-    // [SameObject] readonly attribute SVGAnimatedLength ry;
+    [SameObject] readonly attribute SVGAnimatedLength cx;
+    [SameObject] readonly attribute SVGAnimatedLength cy;
+    [SameObject] readonly attribute SVGAnimatedLength rx;
+    [SameObject] readonly attribute SVGAnimatedLength ry;
 };

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.cpp
@@ -55,4 +55,44 @@ Gfx::Path& SVGLineElement::get_path()
     return m_path.value();
 }
 
+// https://www.w3.org/TR/SVG11/shapes.html#LineElementX1Attribute
+NonnullRefPtr<SVGAnimatedLength> SVGLineElement::x1() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_x1.value_or(0));
+    auto anim_length = SVGLength::create(0, m_x1.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
+// https://www.w3.org/TR/SVG11/shapes.html#LineElementY1Attribute
+NonnullRefPtr<SVGAnimatedLength> SVGLineElement::y1() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_y1.value_or(0));
+    auto anim_length = SVGLength::create(0, m_y1.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
+// https://www.w3.org/TR/SVG11/shapes.html#LineElementX2Attribute
+NonnullRefPtr<SVGAnimatedLength> SVGLineElement::x2() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_x2.value_or(0));
+    auto anim_length = SVGLength::create(0, m_x2.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
+// https://www.w3.org/TR/SVG11/shapes.html#LineElementY2Attribute
+NonnullRefPtr<SVGAnimatedLength> SVGLineElement::y2() const
+{
+    // FIXME: Populate the unit type when it is parsed (0 here is "unknown").
+    // FIXME: Create a proper animated value when animations are supported.
+    auto base_length = SVGLength::create(0, m_y2.value_or(0));
+    auto anim_length = SVGLength::create(0, m_y2.value_or(0));
+    return SVGAnimatedLength::create(move(base_length), move(anim_length));
+}
+
 }

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibWeb/SVG/SVGAnimatedLength.h>
 #include <LibWeb/SVG/SVGGeometryElement.h>
 
 namespace Web::SVG {
@@ -20,6 +21,11 @@ public:
     virtual void parse_attribute(FlyString const& name, String const& value) override;
 
     virtual Gfx::Path& get_path() override;
+
+    NonnullRefPtr<SVGAnimatedLength> x1() const;
+    NonnullRefPtr<SVGAnimatedLength> y1() const;
+    NonnullRefPtr<SVGAnimatedLength> x2() const;
+    NonnullRefPtr<SVGAnimatedLength> y2() const;
 
 private:
     Optional<Gfx::Path> m_path;

--- a/Userland/Libraries/LibWeb/SVG/SVGLineElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGLineElement.idl
@@ -1,9 +1,10 @@
+#import <SVG/SVGAnimatedLength.idl>
 #import <SVG/SVGGeometryElement.idl>
 
 [Exposed=Window]
 interface SVGLineElement : SVGGeometryElement {
-    // [SameObject] readonly attribute SVGAnimatedLength x1;
-    // [SameObject] readonly attribute SVGAnimatedLength y1;
-    // [SameObject] readonly attribute SVGAnimatedLength x2;
-    // [SameObject] readonly attribute SVGAnimatedLength y2;
+    [SameObject] readonly attribute SVGAnimatedLength x1;
+    [SameObject] readonly attribute SVGAnimatedLength y1;
+    [SameObject] readonly attribute SVGAnimatedLength x2;
+    [SameObject] readonly attribute SVGAnimatedLength y2;
 };


### PR DESCRIPTION
Following on from Tim's work on SVGRectElement, here are the other simple cases.