### PR TITLE
sql: Do not indent next line when current one is blank

### DIFF
--- a/Userland/Utilities/sql.cpp
+++ b/Userland/Utilities/sql.cpp
@@ -227,8 +227,10 @@ private:
             bool is_first_token = true;
             bool is_command = false;
             bool last_token_ended_statement = false;
+            bool tokens_found = false;
 
             for (SQL::AST::Token token = lexer.next(); token.type() != SQL::AST::TokenType::Eof; token = lexer.next()) {
+                tokens_found = true;
                 switch (token.type()) {
                 case SQL::AST::TokenType::ParenOpen:
                     ++m_repl_line_level;
@@ -251,7 +253,8 @@ private:
                 is_first_token = false;
             }
 
-            m_repl_line_level = last_token_ended_statement ? 0 : (m_repl_line_level > 0 ? m_repl_line_level : 1);
+            if (tokens_found)
+                m_repl_line_level = last_token_ended_statement ? 0 : (m_repl_line_level > 0 ? m_repl_line_level : 1);
         } while ((m_repl_line_level > 0) || piece.is_empty());
 
         return piece.to_string();


### PR DESCRIPTION
Previously, if a user pressed Enter without typing a command at
the SQL REPL, the next line would be automatically indented. This
change makes it so we check if there were any tokens in the command
before applying the indentation logic.

Before:
<img width="593" alt="before" src="https://user-images.githubusercontent.com/6569270/159619633-73b28be2-d171-482e-bf28-7d14fb8864b2.png">

After:
<img width="592" alt="after" src="https://user-images.githubusercontent.com/6569270/159619644-8e42b9de-db93-4141-8339-f70b92ac1985.png">

