### PR TITLE
Applications: PixelPaint visual fixes

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -119,9 +119,8 @@ void ImageEditor::paint_event(GUI::PaintEvent& event)
     painter.draw_rect(content_rect().inflated(2, 2), Color::Black);
     m_image->paint_into(painter, content_rect());
 
-    if (m_active_layer && m_show_active_layer_boundary) {
-        painter.draw_rect(enclosing_int_rect(content_to_frame_rect(m_active_layer->relative_rect())).inflated(2, 2), Color::Black);
-    }
+    if (m_active_layer && m_show_active_layer_boundary)
+        painter.draw_rect(content_to_frame_rect(m_active_layer->relative_rect()).to_rounded<int>().inflated(2, 2), Color::Black);
 
     if (m_show_pixel_grid && scale() > m_pixel_grid_threshold) {
         auto event_image_rect = enclosing_int_rect(frame_to_content_rect(event.rect())).inflated(1, 1);

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1097,12 +1097,12 @@ ALWAYS_INLINE static void do_draw_integer_scaled_bitmap(Gfx::Bitmap& target, Int
 template<bool has_alpha_channel, bool do_bilinear_blend, typename GetPixel>
 ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity)
 {
-    auto clipped_src_rect = enclosing_int_rect(src_rect).intersected(source.rect());
+    auto int_src_rect = enclosing_int_rect(src_rect);
+    auto clipped_src_rect = int_src_rect.intersected(source.rect());
     if (clipped_src_rect.is_empty())
         return;
 
     if constexpr (!do_bilinear_blend) {
-        IntRect int_src_rect = enclosing_int_rect(src_rect);
         if (dst_rect == clipped_rect && int_src_rect == src_rect && !(dst_rect.width() % int_src_rect.width()) && !(dst_rect.height() % int_src_rect.height())) {
             int hfactor = dst_rect.width() / int_src_rect.width();
             int vfactor = dst_rect.height() / int_src_rect.height();

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -5,6 +5,7 @@
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2022, Tobias Christiansen <tobyase@serenityos.org>
  * Copyright (c) 2022, Linus Groh <linusg@serenityos.org>
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -1123,15 +1124,18 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
     i64 vscale = (src_rect.height() * shift) / dst_rect.height();
     i64 src_left = src_rect.left() * shift;
     i64 src_top = src_rect.top() * shift;
+    i64 clipped_src_bottom_shifted = (clipped_src_rect.y() + clipped_src_rect.height()) * shift;
+    i64 clipped_src_right_shifted = (clipped_src_rect.x() + clipped_src_rect.width()) * shift;
 
     for (int y = clipped_rect.top(); y <= clipped_rect.bottom(); ++y) {
         auto* scanline = (Color*)target.scanline(y);
         auto desired_y = ((y - dst_rect.y()) * vscale + src_top);
-        if (desired_y < clipped_src_rect.left() || desired_y > clipped_src_rect.bottom() * shift)
+        if (desired_y < clipped_src_rect.top() || desired_y > clipped_src_bottom_shifted)
             continue;
+
         for (int x = clipped_rect.left(); x <= clipped_rect.right(); ++x) {
             auto desired_x = ((x - dst_rect.x()) * hscale + src_left);
-            if (desired_x < clipped_src_rect.left() || desired_x > clipped_src_rect.right() * shift)
+            if (desired_x < clipped_src_rect.left() || desired_x > clipped_src_right_shifted)
                 continue;
 
             Color src_pixel;

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -696,6 +697,17 @@ public:
         return Rect<U>(*this);
     }
 
+    template<typename U>
+    [[nodiscard]] ALWAYS_INLINE Rect<U> to_rounded() const
+    {
+        return {
+            static_cast<U>(llroundd(x())),
+            static_cast<U>(llroundd(y())),
+            static_cast<U>(llroundd(width())),
+            static_cast<U>(llroundd(height())),
+        };
+    }
+
     [[nodiscard]] String to_string() const;
 
 private:
@@ -713,11 +725,6 @@ using FloatRect = Rect<float>;
     int x2 = ceilf(float_rect.x() + float_rect.width());
     int y2 = ceilf(float_rect.y() + float_rect.height());
     return Gfx::IntRect::from_two_points({ x1, y1 }, { x2, y2 });
-}
-
-[[nodiscard]] ALWAYS_INLINE IntRect rounded_int_rect(FloatRect const& float_rect)
-{
-    return IntRect { floorf(float_rect.x()), floorf(float_rect.y()), roundf(float_rect.width()), roundf(float_rect.height()) };
 }
 
 }

--- a/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
+++ b/Userland/Libraries/LibWeb/HTML/CanvasRenderingContext2D.cpp
@@ -180,7 +180,7 @@ DOM::ExceptionOr<void> CanvasRenderingContext2D::draw_image(CanvasImageSource co
     if (!painter)
         return {};
     auto transformed_destination_rect = m_drawing_state.transform.map(destination_rect);
-    painter->draw_scaled_bitmap(rounded_int_rect(transformed_destination_rect), *bitmap, source_rect, 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
+    painter->draw_scaled_bitmap(transformed_destination_rect.to_rounded<int>(), *bitmap, source_rect, 1.0f, Gfx::Painter::ScalingMode::BilinearBlend);
 
     // 7. If image is not origin-clean, then set the CanvasRenderingContext2D's origin-clean flag to false.
     if (image_is_not_origin_clean(image))

--- a/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/CanvasPaintable.cpp
@@ -36,7 +36,7 @@ void CanvasPaintable::paint(PaintContext& context, PaintPhase phase) const
             return;
 
         if (layout_box().dom_node().bitmap())
-            context.painter().draw_scaled_bitmap(rounded_int_rect(absolute_rect()), *layout_box().dom_node().bitmap(), layout_box().dom_node().bitmap()->rect(), 1.0f, to_gfx_scaling_mode(computed_values().image_rendering()));
+            context.painter().draw_scaled_bitmap(absolute_rect().to_rounded<int>(), *layout_box().dom_node().bitmap(), layout_box().dom_node().bitmap()->rect(), 1.0f, to_gfx_scaling_mode(computed_values().image_rendering()));
     }
 }
 

--- a/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ImagePaintable.cpp
@@ -47,7 +47,7 @@ void ImagePaintable::paint(PaintContext& context, PaintPhase phase) const
                 alt = image_element.src();
             context.painter().draw_text(enclosing_int_rect(absolute_rect()), alt, Gfx::TextAlignment::Center, computed_values().color(), Gfx::TextElision::Right);
         } else if (auto bitmap = layout_box().image_loader().bitmap(layout_box().image_loader().current_frame_index())) {
-            context.painter().draw_scaled_bitmap(rounded_int_rect(absolute_rect()), *bitmap, bitmap->rect(), 1.0f, to_gfx_scaling_mode(computed_values().image_rendering()));
+            context.painter().draw_scaled_bitmap(absolute_rect().to_rounded<int>(), *bitmap, bitmap->rect(), 1.0f, to_gfx_scaling_mode(computed_values().image_rendering()));
         }
     }
 }

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -270,7 +270,7 @@ void StackingContext::paint(PaintContext& context) const
 
         auto transformed_destination_rect = affine_transform.map(source_rect).translated(transform_origin);
         source_rect.translate_by(transform_origin);
-        context.painter().draw_scaled_bitmap(Gfx::rounded_int_rect(transformed_destination_rect), *bitmap, source_rect, opacity, Gfx::Painter::ScalingMode::BilinearBlend);
+        context.painter().draw_scaled_bitmap(transformed_destination_rect.to_rounded<int>(), *bitmap, source_rect, opacity, Gfx::Painter::ScalingMode::BilinearBlend);
     } else {
         paint_internal(context);
     }


### PR DESCRIPTION
This PR fixes two visual bugs in PixelPaint:

1. The right- and bottom-most pixels of a layer would not always be drawn
2. The layer outline would sometimes not overlap with the image outline if the layer was exactly at `(0, 0)` and have the same width and height

Before:
![image](https://user-images.githubusercontent.com/3210731/159663202-8a648bb0-8725-49cb-af4e-fec577fcf2b2.png)

After:
![image](https://user-images.githubusercontent.com/3210731/159663357-55de8c73-6b82-48b1-86c5-fb3383636afa.png)