### PR TITLE
PixelPaint: Call set_modified on window

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -50,7 +50,14 @@ ImageEditor::~ImageEditor()
 
 void ImageEditor::did_complete_action()
 {
+    if (on_modified_change)
+        on_modified_change(true);
     m_undo_stack.push(make<ImageUndoCommand>(*m_image));
+}
+
+bool ImageEditor::is_modified()
+{
+    return undo_stack().is_current_modified();
 }
 
 bool ImageEditor::undo()
@@ -580,6 +587,8 @@ void ImageEditor::save_project()
         return;
     }
     undo_stack().set_current_unmodified();
+    if (on_modified_change)
+        on_modified_change(false);
 }
 
 void ImageEditor::save_project_as()
@@ -596,6 +605,8 @@ void ImageEditor::save_project_as()
     set_path(file->filename());
     set_loaded_from_image(false);
     undo_stack().set_current_unmodified();
+    if (on_modified_change)
+        on_modified_change(false);
 }
 
 Result<void, String> ImageEditor::save_project_to_file(Core::File& file) const

--- a/Userland/Applications/PixelPaint/ImageEditor.h
+++ b/Userland/Applications/PixelPaint/ImageEditor.h
@@ -87,6 +87,7 @@ public:
     Function<void(Gfx::IntPoint const&)> on_image_mouse_position_change;
 
     Function<void(void)> on_leave;
+    Function<void(bool modified)> on_modified_change;
 
     bool request_close();
 
@@ -109,6 +110,8 @@ public:
     void set_show_active_layer_boundary(bool);
 
     void set_loaded_from_image(bool);
+
+    bool is_modified();
 
 private:
     explicit ImageEditor(NonnullRefPtr<Image>);

--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -88,6 +88,10 @@ MainWidget::MainWidget()
         m_palette_widget->set_image_editor(&image_editor);
         m_layer_list_widget->set_image(&image_editor.image());
         m_layer_properties_widget->set_layer(image_editor.active_layer());
+        window()->set_modified(image_editor.is_modified());
+        image_editor.on_modified_change = [this](bool modified) {
+            window()->set_modified(modified);
+        };
         if (auto* active_tool = m_toolbox->active_tool())
             image_editor.set_active_tool(active_tool);
         m_show_guides_action->set_checked(image_editor.guide_visibility());


### PR DESCRIPTION
Calls `set_modified` on PixelPaint's window to indicate unsaved changes in the currently active tab.