### PR TITLE
LibC: Implemented `strcasestr()`

### DIFF
--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -368,7 +368,6 @@ char* strstr(const char* haystack, const char* needle)
     return const_cast<char*>(haystack);
 }
 
-
 char* strcasestr(const char* haystack, const char* needle)
 {
     char nch;

--- a/Userland/Libraries/LibC/string.cpp
+++ b/Userland/Libraries/LibC/string.cpp
@@ -368,6 +368,24 @@ char* strstr(const char* haystack, const char* needle)
     return const_cast<char*>(haystack);
 }
 
+
+char* strcasestr(const char* haystack, const char* needle)
+{
+    char nch;
+    char hch;
+
+    if ((nch = *needle++) != 0) {
+        size_t len = strlen(needle);
+        do {
+            do {
+                if ((hch = *haystack++) == 0)
+                    return nullptr;
+            } while (hch != nch);
+        } while (strncasecmp(haystack, needle, len) != 0);
+        --haystack;
+    }
+    return const_cast<char*>(haystack);
+}
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/strpbrk.html
 char* strpbrk(const char* s, const char* accept)
 {

--- a/Userland/Libraries/LibC/string.h
+++ b/Userland/Libraries/LibC/string.h
@@ -43,6 +43,7 @@ __attribute__((warn_unused_result)) size_t strlcpy(char* dest, const char* src, 
 char* strchr(const char*, int c);
 char* strchrnul(const char*, int c);
 char* strstr(const char* haystack, const char* needle);
+char* strcasestr(const char* haystack, const char* needle);
 char* strrchr(const char*, int c);
 
 char* index(const char* str, int ch);


### PR DESCRIPTION
This function is almost the same as `strstr()` except for the fact that it ignores case in `haystack` and the `needle`.

This function is not part of POSIX, however, it is included in Linux and BSD and some programs (htop for example) does rely on it.

Fixes #13214 