### PR TITLE
Inspector: Adjust close behavior while inspecting self

### DIFF
--- a/Userland/DevTools/Inspector/main.cpp
+++ b/Userland/DevTools/Inspector/main.cpp
@@ -66,7 +66,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (pid == getpid()) {
         GUI::MessageBox::show(window, "Cannot inspect Inspector itself!", "Error", GUI::MessageBox::Type::Error);
-        return 1;
+        if (gui_mode) {
+            goto choose_pid;
+        } else {
+            return 1;
+        }
     }
 
     RemoteProcess remote_process(pid);


### PR DESCRIPTION
When inspecting an "uninspectable process", the inspector simply shows and error message and returns to the list of processes. However, when inspecting itself, the inspector shows an error message and then terminates. This PR makes that behavior of more predictable/inline with what the other errors do.

This old behavior seems something to do with before `gui_mode` was a thing (before my time maybe)

Fixes #13206