### PR TITLE
LibWeb: Begin supporting non-image HTMLObjectElement data representation

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
+++ b/Userland/Libraries/LibWeb/DOM/EventTarget.cpp
@@ -336,9 +336,11 @@ Bindings::CallbackType* EventTarget::get_current_value_of_event_handler(FlyStrin
         // 5. If element is not null and element has a form owner, let form owner be that form owner. Otherwise, let form owner be null.
         RefPtr<HTML::HTMLFormElement> form_owner;
         if (is<HTML::FormAssociatedElement>(element.ptr())) {
-            auto& form_associated_element = verify_cast<HTML::FormAssociatedElement>(*element);
-            if (form_associated_element.form())
-                form_owner = form_associated_element.form();
+            auto* form_associated_element = dynamic_cast<HTML::FormAssociatedElement*>(element.ptr());
+            VERIFY(form_associated_element);
+
+            if (form_associated_element->form())
+                form_owner = form_associated_element->form();
         }
 
         // 6. Let settings object be the relevant settings object of document.

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.cpp
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.cpp
@@ -21,25 +21,38 @@ BrowsingContextContainer::BrowsingContextContainer(DOM::Document& document, DOM:
 
 BrowsingContextContainer::~BrowsingContextContainer() = default;
 
-void BrowsingContextContainer::inserted()
+// https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-nested-browsing-context
+void BrowsingContextContainer::create_new_nested_browsing_context()
 {
-    HTMLElement::inserted();
-    if (!is_connected())
+    // 1. Let group be element's node document's browsing context's top-level browsing context's group.
+    // FIXME: We do not have a concept of "browsing context groups" yet.
+    auto* group = document().browsing_context();
+    if (!group)
         return;
-    if (auto* browsing_context = document().browsing_context()) {
-        VERIFY(browsing_context->page());
-        m_nested_browsing_context = BrowsingContext::create_nested(*browsing_context->page(), *this);
-        browsing_context->append_child(*m_nested_browsing_context);
-        m_nested_browsing_context->set_frame_nesting_levels(browsing_context->frame_nesting_levels());
-        m_nested_browsing_context->register_frame_nesting(document().url());
-    }
+
+    VERIFY(group->page());
+
+    // 2. Let browsingContext be the result of creating a new browsing context with element's node document, element, and group.
+    // 3. Set element's nested browsing context to browsingContext.
+    m_nested_browsing_context = BrowsingContext::create_nested(*group->page(), *this);
+    group->append_child(*m_nested_browsing_context);
+    m_nested_browsing_context->set_frame_nesting_levels(group->frame_nesting_levels());
+    m_nested_browsing_context->register_frame_nesting(document().url());
+
+    // 4. If element has a name attribute, then set browsingContext's name to the value of this attribute.
+    if (auto name = attribute(HTML::AttributeNames::name); !name.is_empty())
+        m_nested_browsing_context->set_name(name);
 }
 
-void BrowsingContextContainer::removed_from(Node* old_parent)
+// https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded
+void BrowsingContextContainer::discard_nested_browsing_context()
 {
-    HTMLElement::removed_from(old_parent);
+    // 1. Discard all Document objects for all the entries in browsingContext's session history.
     if (m_nested_browsing_context && m_nested_browsing_context->parent())
         m_nested_browsing_context->parent()->remove_child(*m_nested_browsing_context);
+
+    // 2. If browsingContext is a top-level browsing context, then remove browsingContext.
+    // NOTE: We skip this here because this is by definition a nested browsing context, not top-level.
 }
 
 // https://html.spec.whatwg.org/multipage/browsers.html#concept-bcc-content-document
@@ -55,7 +68,7 @@ const DOM::Document* BrowsingContextContainer::content_document() const
     // 3. Let document be context's active document.
     auto const* document = context.active_document();
 
-    //FIXME: This should not be here, as we're expected to have a document at this point.
+    // FIXME: This should not be here, as we're expected to have a document at this point.
     if (!document)
         return nullptr;
 

--- a/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.h
+++ b/Userland/Libraries/LibWeb/HTML/BrowsingContextContainer.h
@@ -21,10 +21,10 @@ public:
     const DOM::Document* content_document() const;
     DOM::Document const* content_document_without_origin_check() const;
 
-    virtual void inserted() override;
-    virtual void removed_from(Node*) override;
-
 protected:
+    void create_new_nested_browsing_context();
+    void discard_nested_browsing_context();
+
     RefPtr<BrowsingContext> m_nested_browsing_context;
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.cpp
@@ -12,44 +12,49 @@
 #include <LibWeb/HTML/HTMLLegendElement.h>
 #include <LibWeb/HTML/HTMLSelectElement.h>
 #include <LibWeb/HTML/HTMLTextAreaElement.h>
+#include <LibWeb/HTML/Parser/HTMLParser.h>
 
 namespace Web::HTML {
 
 void FormAssociatedElement::set_form(HTMLFormElement* form)
 {
     if (m_form)
-        m_form->remove_associated_element({}, *this);
+        m_form->remove_associated_element({}, form_associated_element_to_html_element());
     m_form = form;
     if (m_form)
-        m_form->add_associated_element({}, *this);
+        m_form->add_associated_element({}, form_associated_element_to_html_element());
 }
 
 bool FormAssociatedElement::enabled() const
 {
     // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#concept-fe-disabled
+    auto const& html_element = const_cast<FormAssociatedElement&>(*this).form_associated_element_to_html_element();
 
     // A form control is disabled if any of the following conditions are met:
     // 1. The element is a button, input, select, textarea, or form-associated custom element, and the disabled attribute is specified on this element (regardless of its value).
     // FIXME: This doesn't check for form-associated custom elements.
-    if ((is<HTMLButtonElement>(this) || is<HTMLInputElement>(this) || is<HTMLSelectElement>(this) || is<HTMLTextAreaElement>(this)) && has_attribute(HTML::AttributeNames::disabled))
+    if ((is<HTMLButtonElement>(html_element) || is<HTMLInputElement>(html_element) || is<HTMLSelectElement>(html_element) || is<HTMLTextAreaElement>(html_element)) && html_element.has_attribute(HTML::AttributeNames::disabled))
         return false;
 
     // 2. The element is a descendant of a fieldset element whose disabled attribute is specified, and is not a descendant of that fieldset element's first legend element child, if any.
-    auto* fieldset_ancestor = first_ancestor_of_type<HTMLFieldSetElement>();
+    auto* fieldset_ancestor = html_element.first_ancestor_of_type<HTMLFieldSetElement>();
     if (fieldset_ancestor && fieldset_ancestor->has_attribute(HTML::AttributeNames::disabled)) {
         auto* first_legend_element_child = fieldset_ancestor->first_child_of_type<HTMLLegendElement>();
-        if (!first_legend_element_child || !is_descendant_of(*first_legend_element_child))
+        if (!first_legend_element_child || !html_element.is_descendant_of(*first_legend_element_child))
             return false;
     }
 
     return true;
 }
 
-// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:nodes-are-inserted
-void FormAssociatedElement::inserted()
+void FormAssociatedElement::set_parser_inserted(Badge<HTMLParser>)
 {
-    HTMLElement::inserted();
+    m_parser_inserted = true;
+}
 
+// https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:nodes-are-inserted
+void FormAssociatedElement::form_node_was_inserted()
+{
     // 1. If the form-associated element's parser inserted flag is set, then return.
     if (m_parser_inserted)
         return;
@@ -59,18 +64,18 @@ void FormAssociatedElement::inserted()
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#association-of-controls-and-forms:nodes-are-removed
-void FormAssociatedElement::removed_from(DOM::Node* node)
+void FormAssociatedElement::form_node_was_removed()
 {
-    HTMLElement::removed_from(node);
-
     // 1. If the form-associated element has a form owner and the form-associated element and its form owner are no longer in the same tree, then reset the form owner of the form-associated element.
-    if (m_form && &root() != &m_form->root())
+    if (m_form && &form_associated_element_to_html_element().root() != &m_form->root())
         reset_form_owner();
 }
 
 // https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#reset-the-form-owner
 void FormAssociatedElement::reset_form_owner()
 {
+    auto& html_element = form_associated_element_to_html_element();
+
     // Although these aren't in the "reset form owner" algorithm, these here as they are triggers for this algorithm:
     // FIXME: When a listed form-associated element's form attribute is set, changed, or removed, then the user agent must reset the form owner of that element.
     // FIXME: When a listed form-associated element has a form attribute and the ID of any of the elements in the tree changes, then the user agent must reset the form owner of that form-associated element.
@@ -85,8 +90,8 @@ void FormAssociatedElement::reset_form_owner()
     //    - element's form owner is its nearest form element ancestor after the change to the ancestor chain
     //    then do nothing, and return.
     if (m_form
-        && (!is_listed() || !has_attribute(HTML::AttributeNames::form))
-        && first_ancestor_of_type<HTMLFormElement>() == m_form.ptr()) {
+        && (!is_listed() || !html_element.has_attribute(HTML::AttributeNames::form))
+        && html_element.first_ancestor_of_type<HTMLFormElement>() == m_form.ptr()) {
         return;
     }
 
@@ -94,10 +99,10 @@ void FormAssociatedElement::reset_form_owner()
     set_form(nullptr);
 
     // 4. If element is listed, has a form content attribute, and is connected, then:
-    if (is_listed() && has_attribute(HTML::AttributeNames::form) && is_connected()) {
+    if (is_listed() && html_element.has_attribute(HTML::AttributeNames::form) && html_element.is_connected()) {
         // 1. If the first element in element's tree, in tree order, to have an ID that is identical to element's form content attribute's value, is a form element, then associate the element with that form element.
-        auto form_value = attribute(HTML::AttributeNames::form);
-        root().for_each_in_inclusive_subtree_of_type<HTMLFormElement>([this, &form_value](HTMLFormElement& form_element) mutable {
+        auto form_value = html_element.attribute(HTML::AttributeNames::form);
+        html_element.root().for_each_in_inclusive_subtree_of_type<HTMLFormElement>([this, &form_value](HTMLFormElement& form_element) mutable {
             if (form_element.attribute(HTML::AttributeNames::id) == form_value) {
                 set_form(&form_element);
                 return IterationDecision::Break;
@@ -109,7 +114,7 @@ void FormAssociatedElement::reset_form_owner()
 
     // 5. Otherwise, if element has an ancestor form element, then associate element with the nearest such ancestor form element.
     else {
-        auto* form_ancestor = first_ancestor_of_type<HTMLFormElement>();
+        auto* form_ancestor = html_element.first_ancestor_of_type<HTMLFormElement>();
         if (form_ancestor)
             set_form(form_ancestor);
     }

--- a/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
+++ b/Userland/Libraries/LibWeb/HTML/FormAssociatedElement.h
@@ -8,11 +8,39 @@
 
 #include <AK/WeakPtr.h>
 #include <LibWeb/Forward.h>
-#include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
 
-class FormAssociatedElement : public HTMLElement {
+// Form-associated elements should invoke this macro to inject overidden FormAssociatedElement and HTMLElement
+// methods as needed. If your class wished to override an HTMLElement method that is overidden here, use the
+// following methods instead:
+//
+//    HTMLElement::inserted() -> Use form_associated_element_was_inserted()
+//    HTMLElement::removed_from() -> Use form_associated_element_was_removed()
+//
+#define FORM_ASSOCIATED_ELEMENT(ElementBaseClass, ElementClass)             \
+private:                                                                    \
+    virtual HTMLElement& form_associated_element_to_html_element() override \
+    {                                                                       \
+        static_assert(IsBaseOf<HTMLElement, ElementClass>);                 \
+        return *this;                                                       \
+    }                                                                       \
+                                                                            \
+    virtual void inserted() override                                        \
+    {                                                                       \
+        ElementBaseClass::inserted();                                       \
+        form_node_was_inserted();                                           \
+        form_associated_element_was_inserted();                             \
+    }                                                                       \
+                                                                            \
+    virtual void removed_from(DOM::Node* node) override                     \
+    {                                                                       \
+        ElementBaseClass::removed_from(node);                               \
+        form_node_was_removed();                                            \
+        form_associated_element_was_removed(node);                          \
+    }
+
+class FormAssociatedElement {
 public:
     HTMLFormElement* form() { return m_form; }
     HTMLFormElement const* form() const { return m_form; }
@@ -21,7 +49,7 @@ public:
 
     bool enabled() const;
 
-    void set_parser_inserted(Badge<HTMLParser>) { m_parser_inserted = true; }
+    void set_parser_inserted(Badge<HTMLParser>);
 
     // https://html.spec.whatwg.org/multipage/forms.html#category-listed
     virtual bool is_listed() const { return false; }
@@ -35,13 +63,17 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
     virtual bool is_auto_capitalize_inheriting() const { return false; }
 
-protected:
-    FormAssociatedElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-        : HTMLElement(document, move(qualified_name))
-    {
-    }
+    virtual HTMLElement& form_associated_element_to_html_element() = 0;
 
+protected:
+    FormAssociatedElement() = default;
     virtual ~FormAssociatedElement() = default;
+
+    virtual void form_associated_element_was_inserted() { }
+    virtual void form_associated_element_was_removed(DOM::Node*) { }
+
+    void form_node_was_inserted();
+    void form_node_was_removed();
 
 private:
     WeakPtr<HTMLFormElement> m_form;
@@ -50,10 +82,6 @@ private:
     bool m_parser_inserted { false };
 
     void reset_form_owner();
-
-    // ^DOM::Node
-    virtual void inserted() override;
-    virtual void removed_from(DOM::Node*) override;
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.cpp
@@ -11,7 +11,7 @@
 namespace Web::HTML {
 
 HTMLButtonElement::HTMLButtonElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : FormAssociatedElement(document, move(qualified_name))
+    : HTMLElement(document, move(qualified_name))
 {
     // https://html.spec.whatwg.org/multipage/form-elements.html#the-button-element:activation-behaviour
     activation_behavior = [this](auto&) {

--- a/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLButtonElement.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
 
@@ -15,7 +16,11 @@ namespace Web::HTML {
     __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(reset, Reset)   \
     __ENUMERATE_HTML_BUTTON_TYPE_ATTRIBUTE(button, Button)
 
-class HTMLButtonElement final : public FormAssociatedElement {
+class HTMLButtonElement final
+    : public HTMLElement
+    , public FormAssociatedElement {
+    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLButtonElement)
+
 public:
     using WrapperType = Bindings::HTMLButtonElementWrapper;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.cpp
@@ -9,7 +9,7 @@
 namespace Web::HTML {
 
 HTMLFieldSetElement::HTMLFieldSetElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : FormAssociatedElement(document, move(qualified_name))
+    : HTMLElement(document, move(qualified_name))
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLFieldSetElement.h
@@ -7,10 +7,15 @@
 #pragma once
 
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
 
-class HTMLFieldSetElement final : public FormAssociatedElement {
+class HTMLFieldSetElement final
+    : public HTMLElement
+    , public FormAssociatedElement {
+    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLFieldSetElement)
+
 public:
     using WrapperType = Bindings::HTMLFieldSetElementWrapper;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.cpp
@@ -32,11 +32,28 @@ void HTMLIFrameElement::parse_attribute(const FlyString& name, const String& val
         load_src(value);
 }
 
+// https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:the-iframe-element-6
 void HTMLIFrameElement::inserted()
 {
-    BrowsingContextContainer::inserted();
-    if (is_connected())
-        load_src(attribute(HTML::AttributeNames::src));
+    HTMLElement::inserted();
+
+    if (!is_connected())
+        return;
+
+    // 1. Create a new nested browsing context for element.
+    create_new_nested_browsing_context();
+
+    // 2. FIXME: If element has a sandbox attribute, then parse the sandboxing directive given the attribute's value and element's iframe sandboxing flag set.
+
+    // 3. Process the iframe attributes for element, with initialInsertion set to true.
+    load_src(attribute(HTML::AttributeNames::src));
+}
+
+// https://html.spec.whatwg.org/multipage/iframe-embed-object.html#the-iframe-element:the-iframe-element-7
+void HTMLIFrameElement::removed_from(DOM::Node* node)
+{
+    HTMLElement::removed_from(node);
+    discard_nested_browsing_context();
 }
 
 void HTMLIFrameElement::load_src(const String& value)

--- a/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLIFrameElement.h
@@ -21,6 +21,7 @@ public:
 
 private:
     virtual void inserted() override;
+    virtual void removed_from(Node*) override;
     virtual void parse_attribute(const FlyString& name, const String& value) override;
 
     void load_src(const String&);

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -18,7 +18,7 @@
 namespace Web::HTML {
 
 HTMLImageElement::HTMLImageElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : FormAssociatedElement(document, move(qualified_name))
+    : HTMLElement(document, move(qualified_name))
     , m_image_loader(*this)
 {
     m_image_loader.on_load = [this] {

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -10,11 +10,16 @@
 #include <AK/OwnPtr.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/Loader/ImageLoader.h>
 
 namespace Web::HTML {
 
-class HTMLImageElement final : public FormAssociatedElement {
+class HTMLImageElement final
+    : public HTMLElement
+    , public FormAssociatedElement {
+    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLImageElement)
+
 public:
     using WrapperType = Bindings::HTMLImageElementWrapper;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.cpp
@@ -21,7 +21,7 @@
 namespace Web::HTML {
 
 HTMLInputElement::HTMLInputElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : FormAssociatedElement(document, move(qualified_name))
+    : HTMLElement(document, move(qualified_name))
     , m_value(String::empty())
 {
     activation_behavior = [this](auto&) {
@@ -215,7 +215,7 @@ bool HTMLInputElement::is_focusable() const
 
 void HTMLInputElement::parse_attribute(FlyString const& name, String const& value)
 {
-    FormAssociatedElement::parse_attribute(name, value);
+    HTMLElement::parse_attribute(name, value);
     if (name == HTML::AttributeNames::checked) {
         // When the checked content attribute is added, if the control does not have dirty checkedness,
         // the user agent must set the checkedness of the element to true
@@ -245,7 +245,7 @@ HTMLInputElement::TypeAttributeState HTMLInputElement::parse_type_attribute(Stri
 
 void HTMLInputElement::did_remove_attribute(FlyString const& name)
 {
-    FormAssociatedElement::did_remove_attribute(name);
+    HTMLElement::did_remove_attribute(name);
     if (name == HTML::AttributeNames::checked) {
         // When the checked content attribute is removed, if the control does not have dirty checkedness,
         // the user agent must set the checkedness of the element to false.
@@ -310,7 +310,7 @@ String HTMLInputElement::value_sanitization_algorithm(String value) const
     return value;
 }
 
-void HTMLInputElement::inserted()
+void HTMLInputElement::form_associated_element_was_inserted()
 {
     create_shadow_tree_if_needed();
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLInputElement.h
@@ -37,7 +37,11 @@ namespace Web::HTML {
     __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(reset, ResetButton)                 \
     __ENUMERATE_HTML_INPUT_TYPE_ATTRIBUTE(button, Button)
 
-class HTMLInputElement final : public FormAssociatedElement {
+class HTMLInputElement final
+    : public HTMLElement
+    , public FormAssociatedElement {
+    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLInputElement)
+
 public:
     using WrapperType = Bindings::HTMLInputElementWrapper;
 
@@ -92,11 +96,11 @@ public:
     // https://html.spec.whatwg.org/multipage/forms.html#category-autocapitalize
     virtual bool is_auto_capitalize_inheriting() const override { return true; }
 
+    virtual void form_associated_element_was_inserted() override;
+
     // ^HTMLElement
     // https://html.spec.whatwg.org/multipage/forms.html#category-label
     virtual bool is_labelable() const override { return type_state() != TypeAttributeState::Hidden; }
-
-    virtual void inserted() override;
 
 private:
     // ^DOM::EventTarget

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.cpp
@@ -15,7 +15,7 @@
 namespace Web::HTML {
 
 HTMLObjectElement::HTMLObjectElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : FormAssociatedElement(document, move(qualified_name))
+    : HTMLElement(document, move(qualified_name))
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -9,13 +9,17 @@
 #include <LibCore/Forward.h>
 #include <LibGfx/Forward.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/Loader/ImageLoader.h>
 
 namespace Web::HTML {
 
 class HTMLObjectElement final
-    : public FormAssociatedElement
+    : public HTMLElement
+    , public FormAssociatedElement
     , public ResourceClient {
+    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLObjectElement)
+
 public:
     using WrapperType = Bindings::HTMLObjectElementWrapper;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLObjectElement.h
@@ -8,6 +8,7 @@
 
 #include <LibCore/Forward.h>
 #include <LibGfx/Forward.h>
+#include <LibWeb/HTML/BrowsingContextContainer.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
 #include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/Loader/ImageLoader.h>
@@ -15,10 +16,17 @@
 namespace Web::HTML {
 
 class HTMLObjectElement final
-    : public HTMLElement
+    : public BrowsingContextContainer
     , public FormAssociatedElement
     , public ResourceClient {
-    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLObjectElement)
+    FORM_ASSOCIATED_ELEMENT(BrowsingContextContainer, HTMLObjectElement)
+
+    enum class Representation {
+        Unknown,
+        Image,
+        NestedBrowsingContext,
+        Children,
+    };
 
 public:
     using WrapperType = Bindings::HTMLObjectElementWrapper;
@@ -52,8 +60,8 @@ private:
     virtual void resource_did_load() override;
     virtual void resource_did_fail() override;
 
+    Representation m_representation { Representation::Unknown };
     Optional<ImageLoader> m_image_loader;
-    bool m_should_show_fallback_content { false };
 };
 
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.cpp
@@ -9,7 +9,7 @@
 namespace Web::HTML {
 
 HTMLOutputElement::HTMLOutputElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : FormAssociatedElement(document, move(qualified_name))
+    : HTMLElement(document, move(qualified_name))
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOutputElement.h
@@ -8,10 +8,15 @@
 #pragma once
 
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
 
-class HTMLOutputElement final : public FormAssociatedElement {
+class HTMLOutputElement final
+    : public HTMLElement
+    , public FormAssociatedElement {
+    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLOutputElement)
+
 public:
     using WrapperType = Bindings::HTMLOutputElementWrapper;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.cpp
@@ -13,7 +13,7 @@
 namespace Web::HTML {
 
 HTMLSelectElement::HTMLSelectElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : FormAssociatedElement(document, move(qualified_name))
+    : HTMLElement(document, move(qualified_name))
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLSelectElement.h
@@ -14,7 +14,11 @@
 
 namespace Web::HTML {
 
-class HTMLSelectElement final : public FormAssociatedElement {
+class HTMLSelectElement final
+    : public HTMLElement
+    , public FormAssociatedElement {
+    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLSelectElement)
+
 public:
     using WrapperType = Bindings::HTMLSelectElementWrapper;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.cpp
@@ -9,7 +9,7 @@
 namespace Web::HTML {
 
 HTMLTextAreaElement::HTMLTextAreaElement(DOM::Document& document, DOM::QualifiedName qualified_name)
-    : FormAssociatedElement(document, move(qualified_name))
+    : HTMLElement(document, move(qualified_name))
 {
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLTextAreaElement.h
@@ -8,10 +8,15 @@
 #pragma once
 
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLElement.h>
 
 namespace Web::HTML {
 
-class HTMLTextAreaElement final : public FormAssociatedElement {
+class HTMLTextAreaElement final
+    : public HTMLElement
+    , public FormAssociatedElement {
+    FORM_ASSOCIATED_ELEMENT(HTMLElement, HTMLTextAreaElement)
+
 public:
     using WrapperType = Bindings::HTMLTextAreaElementWrapper;
 

--- a/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
+++ b/Userland/Libraries/LibWeb/HTML/Parser/HTMLParser.cpp
@@ -632,14 +632,17 @@ NonnullRefPtr<DOM::Element> HTMLParser::create_element_for(HTMLToken const& toke
     //     then associate element with the form element pointed to by the form element pointer and set element's parser inserted flag.
     // FIXME: Check if the element is not a form-associated custom element.
     if (is<FormAssociatedElement>(*element)) {
-        auto& form_associated_element = static_cast<FormAssociatedElement&>(*element);
+        auto* form_associated_element = dynamic_cast<FormAssociatedElement*>(element.ptr());
+        VERIFY(form_associated_element);
+
+        auto& html_element = form_associated_element->form_associated_element_to_html_element();
 
         if (m_form_element
             && !m_stack_of_open_elements.contains(HTML::TagNames::template_)
-            && (!form_associated_element.is_listed() || !form_associated_element.has_attribute(HTML::AttributeNames::form))
+            && (!form_associated_element->is_listed() || !html_element.has_attribute(HTML::AttributeNames::form))
             && &intended_parent.root() == &m_form_element->root()) {
-            form_associated_element.set_form(m_form_element);
-            form_associated_element.set_parser_inserted({});
+            form_associated_element->set_form(m_form_element);
+            form_associated_element->set_parser_inserted({});
         }
     }
 

--- a/Userland/Libraries/LibWeb/Layout/FormAssociatedLabelableNode.h
+++ b/Userland/Libraries/LibWeb/Layout/FormAssociatedLabelableNode.h
@@ -8,18 +8,19 @@
 
 #include <LibWeb/Forward.h>
 #include <LibWeb/HTML/FormAssociatedElement.h>
+#include <LibWeb/HTML/HTMLElement.h>
 #include <LibWeb/Layout/LabelableNode.h>
 
 namespace Web::Layout {
 
 class FormAssociatedLabelableNode : public LabelableNode {
 public:
-    const HTML::FormAssociatedElement& dom_node() const { return static_cast<const HTML::FormAssociatedElement&>(LabelableNode::dom_node()); }
-    HTML::FormAssociatedElement& dom_node() { return static_cast<HTML::FormAssociatedElement&>(LabelableNode::dom_node()); }
+    const HTML::FormAssociatedElement& dom_node() const { return dynamic_cast<const HTML::FormAssociatedElement&>(LabelableNode::dom_node()); }
+    HTML::FormAssociatedElement& dom_node() { return dynamic_cast<HTML::FormAssociatedElement&>(LabelableNode::dom_node()); }
 
 protected:
     FormAssociatedLabelableNode(DOM::Document& document, HTML::FormAssociatedElement& element, NonnullRefPtr<CSS::StyleProperties> style)
-        : LabelableNode(document, element, move(style))
+        : LabelableNode(document, element.form_associated_element_to_html_element(), move(style))
     {
     }
 


### PR DESCRIPTION
This is enough to make the FAIL text on Acid 3 go away :)

Plenty more to do here, but want to avoid making the PR chonkier

![fail](https://user-images.githubusercontent.com/5600524/159817690-aa01b37c-03ef-4a6e-8068-0bf446412832.png)
