### PR TITLE
LibCore: Make EventLoop connect to InspectorServer if requested

### DIFF
--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -333,7 +333,7 @@ EventLoop::EventLoop([[maybe_unused]] MakeInspectable make_inspectable)
             if (getuid() != 0
                 && make_inspectable == MakeInspectable::Yes
                 // FIXME: Deadlock potential; though the main loop and inspector server connection are rarely used in conjunction
-                && s_inspector_server_connection.with_locked([](auto inspector_server_connection) { return inspector_server_connection; })) {
+                && !s_inspector_server_connection.with_locked([](auto inspector_server_connection) { return inspector_server_connection; })) {
                 if (!connect_to_inspector_server())
                     dbgln("Core::EventLoop: Failed to connect to InspectorServer");
             }


### PR DESCRIPTION
I regressed this at some point by inverting the condition here.