### PR TITLE
LibGfx: Implement TTF kern tables

### DIFF
--- a/Userland/Libraries/LibGfx/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/BitmapFont.h
@@ -54,6 +54,7 @@ public:
             return m_glyph_width;
         return glyph_or_emoji_width_for_variable_width_font(code_point);
     }
+    i32 glyphs_horizontal_kerning(u32, u32) const override { return 0; }
     u8 glyph_height() const override { return m_glyph_height; }
     int x_height() const override { return m_x_height; }
     int preferred_line_height() const override { return glyph_height() + m_line_gap; }

--- a/Userland/Libraries/LibGfx/Font.h
+++ b/Userland/Libraries/LibGfx/Font.h
@@ -114,6 +114,7 @@ public:
 
     virtual u8 glyph_width(u32 code_point) const = 0;
     virtual int glyph_or_emoji_width(u32 code_point) const = 0;
+    virtual i32 glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const = 0;
     virtual u8 glyph_height() const = 0;
     virtual int x_height() const = 0;
     virtual int preferred_line_height() const = 0;

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1378,12 +1378,19 @@ void draw_text_line(IntRect const& a_rect, Utf8View const& text, Font const& fon
         space_width = -space_width;          // Draw spaces backwards
     }
 
+    u32 last_code_point { 0 };
     for (auto it = text.begin(); it != text.end(); ++it) {
         auto code_point = *it;
         if (code_point == ' ') {
             point.translate_by(space_width, 0);
+            last_code_point = code_point;
             continue;
         }
+
+        int kerning = font.glyphs_horizontal_kerning(last_code_point, code_point);
+        if (kerning != 0)
+            point.translate_by(direction == TextDirection::LTR ? kerning : -kerning, 0);
+
         IntSize glyph_size(font.glyph_or_emoji_width(code_point) + font.glyph_spacing(), font.glyph_height());
         if (direction == TextDirection::RTL)
             point.translate_by(-glyph_size.width(), 0); // If we are drawing right to left, we have to move backwards before drawing the glyph
@@ -1393,6 +1400,7 @@ void draw_text_line(IntRect const& a_rect, Utf8View const& text, Font const& fon
         // The callback function might have exhausted the iterator.
         if (it == text.end())
             break;
+        last_code_point = code_point;
     }
 }
 

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Cmap.cpp
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Cmap.cpp
@@ -121,13 +121,13 @@ u32 Cmap::Subtable::glyph_id_for_code_point_table_12(u32 code_point) const
     VERIFY(m_slice.size() >= (u32)Table12Sizes::Header + (u32)Table12Sizes::Record * num_groups);
     for (u32 offset = 0; offset < num_groups * (u32)Table12Sizes::Record; offset += (u32)Table12Sizes::Record) {
         u32 start_code_point = be_u32(m_slice.offset_pointer((u32)Table12Offsets::Record_StartCode + offset));
-        if (code_point < start_code_point) {
+        if (code_point < start_code_point)
             break;
-        }
+
         u32 end_code_point = be_u32(m_slice.offset_pointer((u32)Table12Offsets::Record_EndCode + offset));
-        if (code_point > end_code_point) {
+        if (code_point > end_code_point)
             continue;
-        }
+
         u32 glyph_offset = be_u32(m_slice.offset_pointer((u32)Table12Offsets::Record_StartGlyph + offset));
         return code_point - start_code_point + glyph_offset;
     }
@@ -137,18 +137,17 @@ u32 Cmap::Subtable::glyph_id_for_code_point_table_12(u32 code_point) const
 u32 Cmap::glyph_id_for_code_point(u32 code_point) const
 {
     auto opt_subtable = subtable(m_active_index);
-    if (!opt_subtable.has_value()) {
+    if (!opt_subtable.has_value())
         return 0;
-    }
+
     auto subtable = opt_subtable.value();
     return subtable.glyph_id_for_code_point(code_point);
 }
 
 Optional<Cmap> Cmap::from_slice(ReadonlyBytes slice)
 {
-    if (slice.size() < (size_t)Sizes::TableHeader) {
+    if (slice.size() < (size_t)Sizes::TableHeader)
         return {};
-    }
     return Cmap(slice);
 }
 

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
@@ -10,7 +10,6 @@
 #include <AK/Try.h>
 #include <AK/Utf32View.h>
 #include <AK/Utf8View.h>
-#include <LibCore/File.h>
 #include <LibCore/MappedFile.h>
 #include <LibGfx/TrueTypeFont/Cmap.h>
 #include <LibGfx/TrueTypeFont/Font.h>
@@ -429,7 +428,7 @@ ErrorOr<NonnullRefPtr<Font>> Font::try_load_from_offset(ReadonlyBytes buffer, u3
         u32 table_length = be_u32(buffer.offset_pointer(record_offset + (u32)Offsets::TableRecord_Length));
 
         if (Checked<u32>::addition_would_overflow(table_offset, table_length))
-            return Error::from_string_literal("Invalid table offset/length in font."sv);
+            return Error::from_string_literal("Invalid table offset or length in font"sv);
 
         if (buffer.size() < table_offset + table_length)
             return Error::from_string_literal("Font file too small"sv);

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Font.h
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Font.h
@@ -50,6 +50,7 @@ public:
 
     ScaledFontMetrics metrics(float x_scale, float y_scale) const;
     ScaledGlyphMetrics glyph_metrics(u32 glyph_id, float x_scale, float y_scale) const;
+    i32 glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, float x_scale) const;
     RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale) const;
     u32 glyph_count() const;
     u16 units_per_em() const;
@@ -74,7 +75,7 @@ private:
 
     static ErrorOr<NonnullRefPtr<Font>> try_load_from_offset(ReadonlyBytes, unsigned index = 0);
 
-    Font(ReadonlyBytes bytes, Head&& head, Name&& name, Hhea&& hhea, Maxp&& maxp, Hmtx&& hmtx, Cmap&& cmap, Loca&& loca, Glyf&& glyf, OS2&& os2)
+    Font(ReadonlyBytes bytes, Head&& head, Name&& name, Hhea&& hhea, Maxp&& maxp, Hmtx&& hmtx, Cmap&& cmap, Loca&& loca, Glyf&& glyf, OS2&& os2, Optional<Kern>&& kern)
         : m_buffer(move(bytes))
         , m_head(move(head))
         , m_name(move(name))
@@ -85,6 +86,7 @@ private:
         , m_glyf(move(glyf))
         , m_cmap(move(cmap))
         , m_os2(move(os2))
+        , m_kern(move(kern))
     {
     }
 
@@ -102,6 +104,7 @@ private:
     Glyf m_glyf;
     Cmap m_cmap;
     OS2 m_os2;
+    Optional<Kern> m_kern;
 };
 
 class ScaledFont : public Gfx::Font {
@@ -129,6 +132,7 @@ public:
     virtual bool contains_glyph(u32 code_point) const override { return m_font->glyph_id_for_code_point(code_point) > 0; }
     virtual u8 glyph_width(u32 code_point) const override;
     virtual int glyph_or_emoji_width(u32 code_point) const override;
+    virtual i32 glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const override;
     virtual int preferred_line_height() const override { return metrics().height() + metrics().line_gap; }
     virtual u8 glyph_height() const override { return m_point_height; }
     virtual int x_height() const override { return m_point_height; }      // FIXME: Read from font
@@ -142,7 +146,7 @@ public:
     virtual int width(Utf32View const&) const override;
     virtual String name() const override { return String::formatted("{} {}", family(), variant()); }
     virtual bool is_fixed_width() const override { return m_font->is_fixed_width(); }
-    virtual u8 glyph_spacing() const override { return m_x_scale; } // FIXME: Read from font
+    virtual u8 glyph_spacing() const override { return 0; }
     virtual size_t glyph_count() const override { return m_font->glyph_count(); }
     virtual String family() const override { return m_font->family(); }
     virtual String variant() const override { return m_font->variant(); }

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Tables.h
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Tables.h
@@ -1,11 +1,14 @@
 /*
  * Copyright (c) 2020, Srimanta Barua <srimanta.barua1@gmail.com>
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Error.h>
+#include <AK/FixedArray.h>
 #include <AK/Span.h>
 #include <AK/String.h>
 
@@ -199,6 +202,29 @@ private:
     String string_for_id(NameId id) const;
 
     ReadonlyBytes m_slice;
+};
+
+class Kern {
+public:
+    static ErrorOr<Kern> from_slice(ReadonlyBytes);
+    i16 get_glyph_kerning(u16 left_glyph_id, u16 right_glyph_id) const;
+
+private:
+    enum Sizes : size_t {
+        SubtableHeader = 6,
+        Format0Entry = 6,
+    };
+
+    Kern(ReadonlyBytes slice, FixedArray<size_t> subtable_offsets)
+        : m_slice(slice)
+        , m_subtable_offsets(move(subtable_offsets))
+    {
+    }
+
+    static Optional<i16> read_glyph_kerning_format0(ReadonlyBytes slice, u16 left_glyph_id, u16 right_glyph_id);
+
+    ReadonlyBytes m_slice;
+    FixedArray<size_t> m_subtable_offsets;
 };
 
 }


### PR DESCRIPTION
This PR implements TTF `kern` tables and applies their kerning values to character pairs when rendering text using `Gfx::Painter`. The effect can be seen below for Arial regular.

Before:
![Screenshot_20220324_162457](https://user-images.githubusercontent.com/3210731/159951217-213b44bc-5e4c-4f93-be6c-0a664a00353e.png)

After:
![Screenshot_20220324_161632](https://user-images.githubusercontent.com/3210731/159951206-611e072b-df43-49f7-baeb-d1e14b7b850d.png)

