### PR TITLE
LibWeb+Base: Fix `An+B of foo` parsing

### DIFF
--- a/Base/res/html/misc/nth-child.html
+++ b/Base/res/html/misc/nth-child.html
@@ -52,6 +52,9 @@
         .acid3 > div:nth-child(-5n+3) {
             background-color: lightblue;
         }
+        .test-of-type > div:nth-child(2n of div) {
+            background-color: lightblue;
+        }
         .test-of > div:nth-child(3n+1 of .special) {
             background-color: lightblue;
         }
@@ -189,6 +192,22 @@
     <div>13</div>
     <div>14</div>
     <div>15</div>
+</div>
+
+<h4>:nth-child(2n of div)</h4>
+<div class="test-of-type">
+    <div>1</div>
+    <p>Paragraph</p>
+    <div>2 +</div>
+    <p>Paragraph</p>
+    <div>3</div>
+    <p>Paragraph</p>
+    <div>4 +</div>
+    <p>Paragraph</p>
+    <div>5</div>
+    <p>Paragraph</p>
+    <div>6 +</div>
+    <p>Paragraph</p>
 </div>
 
 <h4>:nth-child(3n+1 of .special)</h4>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4486,12 +4486,14 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     if (is_n_dimension(first_value)) {
         a = first_value.token().dimension_value_int();
 
-        values.skip_whitespace();
-        auto& second_value = values.next_token();
-        if (second_value.is(Token::Type::EndOfFile)) {
+        if (!values.has_next_token() || values.peek_token().is(Token::Type::Whitespace)) {
             // <n-dimension>
             return make_return_value();
-        } else if (is_signed_integer(second_value)) {
+        }
+
+        values.skip_whitespace();
+        auto& second_value = values.next_token();
+        if (is_signed_integer(second_value)) {
             // <n-dimension> <signed-integer>
             b = second_value.token().to_integer();
             return make_return_value();
@@ -4547,12 +4549,14 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // -n ['+' | '-'] <signless-integer>
     if (is_dashn(first_value)) {
         a = -1;
-        values.skip_whitespace();
-        auto& second_value = values.next_token();
-        if (second_value.is(Token::Type::EndOfFile)) {
+        if (!values.has_next_token() || values.peek_token().is(Token::Type::Whitespace)) {
             // -n
             return make_return_value();
-        } else if (is_signed_integer(second_value)) {
+        }
+
+        values.skip_whitespace();
+        auto& second_value = values.next_token();
+        if (is_signed_integer(second_value)) {
             // -n <signed-integer>
             b = second_value.token().to_integer();
             return make_return_value();
@@ -4600,12 +4604,14 @@ Optional<Selector::SimpleSelector::ANPlusBPattern> Parser::parse_a_n_plus_b_patt
     // '+'?† n ['+' | '-'] <signless-integer>
     if (is_n(first_after_plus)) {
         a = 1;
-        values.skip_whitespace();
-        auto& second_value = values.next_token();
-        if (second_value.is(Token::Type::EndOfFile)) {
+        if (!values.has_next_token() || values.peek_token().is(Token::Type::Whitespace)) {
             // '+'?† n
             return make_return_value();
-        } else if (is_signed_integer(second_value)) {
+        }
+
+        values.skip_whitespace();
+        auto& second_value = values.next_token();
+        if (is_signed_integer(second_value)) {
             // '+'?† n <signed-integer>
             b = second_value.token().to_integer();
             return make_return_value();


### PR DESCRIPTION
When I wrote the An+B parser, it was guaranteed to have no
non-whitespace tokens after it. This is no longer true with the `of
foo` syntax, so this patch corrects the logic when there is no `+B`
segment.

This makes this case shown on Twitter work correctly. :^)
https://twitter.com/simevidas/status/1506657566012678151