### PR TITLE
LibWeb: Align text shadows the same way we align text

### DIFF
--- a/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
+++ b/Userland/Libraries/LibWeb/Painting/ShadowPainting.cpp
@@ -159,7 +159,7 @@ void paint_text_shadow(PaintContext& context, Layout::LineBoxFragment const& fra
         Gfx::Painter shadow_painter { *shadow_bitmap };
         shadow_painter.set_font(context.painter().font());
         // FIXME: "Spread" the shadow somehow.
-        shadow_painter.draw_text(text_rect, fragment.text(), Gfx::TextAlignment::TopLeft, layer.color);
+        shadow_painter.draw_text(text_rect, fragment.text(), Gfx::TextAlignment::CenterLeft, layer.color);
 
         // Blur
         Gfx::FastBoxBlurFilter filter(*shadow_bitmap);


### PR DESCRIPTION
This makes the shadow line-up correctly on Acid3. :^)
![image](https://user-images.githubusercontent.com/222642/159993542-006a695f-e678-41e2-935d-a7207ae2b7aa.png)
