### PR TITLE
LibWeb: Weakly store a reference to the Window object in timer tasks

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -10,6 +10,7 @@
 #include <AK/IDAllocator.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>
+#include <AK/Weakable.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/Bindings/Wrappable.h>
 #include <LibWeb/CSS/MediaQueryList.h>
@@ -26,6 +27,7 @@ class RequestAnimationFrameCallback;
 
 class Window final
     : public RefCounted<Window>
+    , public Weakable<Window>
     , public DOM::EventTarget
     , public HTML::GlobalEventHandlers {
 public:


### PR DESCRIPTION
This prevents a crash when refreshing or navigating away from the Acid3
test page while it is actively running.