### PR TITLE
Meta: Disable KASLR when debugging the kernel with GDB

### DIFF
--- a/Base/usr/share/man/man7/boot_parameters.md
+++ b/Base/usr/share/man/man7/boot_parameters.md
@@ -89,6 +89,8 @@ List of options:
 * **`vmmouse`** - This parameter expects a binary value of **`on`** or **`off`**. If enabled and
   running on a VMWare Hypervisor, the kernel will enable absolute mouse mode.
 
+* **`disable_kaslr`** - If present on the command line, the KASLR security mitigation will be disabled.
+
 ## See also
 
 * [`SystemServer`(7)](help://man/7/SystemServer).

--- a/Kernel/MiniStdLib.cpp
+++ b/Kernel/MiniStdLib.cpp
@@ -102,4 +102,63 @@ size_t strlen(const char* str)
         ++len;
     return len;
 }
+
+size_t strnlen(const char* str, size_t maxlen)
+{
+    size_t len = 0;
+    for (; len < maxlen && *str; str++)
+        len++;
+    return len;
+}
+
+int strcmp(const char* s1, const char* s2)
+{
+    for (; *s1 == *s2; ++s1, ++s2) {
+        if (*s1 == 0)
+            return 0;
+    }
+    return *(const u8*)s1 < *(const u8*)s2 ? -1 : 1;
+}
+
+int memcmp(const void* v1, const void* v2, size_t n)
+{
+    auto const* s1 = (const u8*)v1;
+    auto const* s2 = (const u8*)v2;
+    while (n-- > 0) {
+        if (*s1++ != *s2++)
+            return s1[-1] < s2[-1] ? -1 : 1;
+    }
+    return 0;
+}
+
+int strncmp(const char* s1, const char* s2, size_t n)
+{
+    if (!n)
+        return 0;
+    do {
+        if (*s1 != *s2++)
+            return *(const unsigned char*)s1 - *(const unsigned char*)--s2;
+        if (*s1++ == 0)
+            break;
+    } while (--n);
+    return 0;
+}
+
+char* strstr(const char* haystack, const char* needle)
+{
+    char nch;
+    char hch;
+
+    if ((nch = *needle++) != 0) {
+        size_t len = strlen(needle);
+        do {
+            do {
+                if ((hch = *haystack++) == 0)
+                    return nullptr;
+            } while (hch != nch);
+        } while (strncmp(haystack, needle, len) != 0);
+        --haystack;
+    }
+    return const_cast<char*>(haystack);
+}
 }

--- a/Kernel/Prekernel/init.cpp
+++ b/Kernel/Prekernel/init.cpp
@@ -96,10 +96,13 @@ extern "C" [[noreturn]] void init()
     FlatPtr default_kernel_load_base = 0x2000200000;
 #endif
 
-    // KASLR
-    FlatPtr maximum_offset = (FlatPtr)KERNEL_PD_SIZE - MAX_KERNEL_SIZE - 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
-    FlatPtr kernel_load_base = default_kernel_load_base + (generate_secure_seed() % maximum_offset);
-    kernel_load_base &= ~(2 * MiB - 1);
+    FlatPtr kernel_load_base = default_kernel_load_base;
+
+    if (__builtin_strstr(kernel_cmdline, "disable_kaslr") == nullptr) {
+        FlatPtr maximum_offset = (FlatPtr)KERNEL_PD_SIZE - MAX_KERNEL_SIZE - 2 * MiB; // The first 2 MiB are used for mapping the pre-kernel
+        kernel_load_base += (generate_secure_seed() % maximum_offset);
+        kernel_load_base &= ~(2 * MiB - 1);
+    }
 
     FlatPtr kernel_load_end = 0;
     for (size_t i = 0; i < kernel_elf_header.e_phnum; i++) {

--- a/Kernel/StdLib.cpp
+++ b/Kernel/StdLib.cpp
@@ -225,65 +225,6 @@ const void* memmem(const void* haystack, size_t haystack_length, const void* nee
     return AK::memmem(haystack, haystack_length, needle, needle_length);
 }
 
-size_t strnlen(const char* str, size_t maxlen)
-{
-    size_t len = 0;
-    for (; len < maxlen && *str; str++)
-        len++;
-    return len;
-}
-
-int strcmp(const char* s1, const char* s2)
-{
-    for (; *s1 == *s2; ++s1, ++s2) {
-        if (*s1 == 0)
-            return 0;
-    }
-    return *(const u8*)s1 < *(const u8*)s2 ? -1 : 1;
-}
-
-int memcmp(const void* v1, const void* v2, size_t n)
-{
-    auto const* s1 = (const u8*)v1;
-    auto const* s2 = (const u8*)v2;
-    while (n-- > 0) {
-        if (*s1++ != *s2++)
-            return s1[-1] < s2[-1] ? -1 : 1;
-    }
-    return 0;
-}
-
-int strncmp(const char* s1, const char* s2, size_t n)
-{
-    if (!n)
-        return 0;
-    do {
-        if (*s1 != *s2++)
-            return *(const unsigned char*)s1 - *(const unsigned char*)--s2;
-        if (*s1++ == 0)
-            break;
-    } while (--n);
-    return 0;
-}
-
-char* strstr(const char* haystack, const char* needle)
-{
-    char nch;
-    char hch;
-
-    if ((nch = *needle++) != 0) {
-        size_t len = strlen(needle);
-        do {
-            do {
-                if ((hch = *haystack++) == 0)
-                    return nullptr;
-            } while (hch != nch);
-        } while (strncmp(haystack, needle, len) != 0);
-        --haystack;
-    }
-    return const_cast<char*>(haystack);
-}
-
 // Functions that are automatically called by the C++ compiler.
 // Declare them first, to tell the silly compiler that they are indeed being used.
 [[noreturn]] void __stack_chk_fail() __attribute__((used));

--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -464,6 +464,8 @@ elif [ "$CMD" = "__tmux_cmd" ]; then
         fi
         # We need to make sure qemu doesn't start until we continue in gdb
         export SERENITY_EXTRA_QEMU_ARGS="${SERENITY_EXTRA_QEMU_ARGS} -d int -no-reboot -no-shutdown -S"
+        # We need to disable kaslr to let gdb map the kernel symbols correctly
+        export SERENITY_KERNEL_CMDLINE="${SERENITY_KERNEL_CMDLINE} disable_kaslr"
         set_tmux_title 'qemu'
         build_target run
     elif [ "$CMD" = "gdb" ]; then


### PR DESCRIPTION
This lets GDB resolve the kernel symbols correctly.