### PR TITLE
LibVT: Fix tooltip condition, properly reset when tooltip not available

### DIFF
--- a/Userland/Libraries/LibVT/TerminalWidget.cpp
+++ b/Userland/Libraries/LibVT/TerminalWidget.cpp
@@ -823,7 +823,7 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
     auto attribute = m_terminal.attribute_at(position);
 
     if (attribute.href_id != m_hovered_href_id) {
-        if (m_active_href_id.is_null() || m_active_href_id == attribute.href_id) {
+        if (!attribute.href_id.is_null()) {
             m_hovered_href_id = attribute.href_id;
             m_hovered_href = attribute.href;
 
@@ -839,6 +839,7 @@ void TerminalWidget::mousemove_event(GUI::MouseEvent& event)
         } else {
             m_hovered_href_id = {};
             m_hovered_href = {};
+            set_tooltip({});
         }
         show_or_hide_tooltip();
         if (!m_hovered_href.is_empty())


### PR DESCRIPTION
Steps to reproduce:
- Run something like `less /etc/Keyboard.ini` in the Terminal (because I'm debugging an issue with that), and press `q` to leave it again.
- Hover your mouse over the link, but only for half a second.
- Move it away before the tooltip can appear.

Expected behavior: No tooltip ever appears

(Acceptable behavior, but not compatible with Serenity: Tooltip immediately appears when hovering)

Actual behavior, before this PR: Tooltip appears after the timeout, regardless of whether the mouse is still hovering the original source, leading to silly things like this:
![Bildschirmfoto_2022-03-25_01-03-26](https://user-images.githubusercontent.com/2690845/160031262-78658453-22cf-4b98-ad8e-40233583a43d.png)