### PR TITLE
LibWeb: Improve focus outline

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Default.css
+++ b/Userland/Libraries/LibWeb/CSS/Default.css
@@ -223,7 +223,7 @@ ol {
 
 /* FIXME: This is a temporary hack until we can render a native-looking frame for these. */
 input, textarea {
-    border: 1px solid black;
+    border: 1px solid -libweb-palette-threed-shadow1;
     min-width: 80px;
     min-height: 16px;
     width: 120px;

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -154,7 +154,9 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
     }
 
     if (phase == PaintPhase::FocusOutline && layout_box().dom_node() && layout_box().dom_node()->is_element() && verify_cast<DOM::Element>(*layout_box().dom_node()).is_focused()) {
-        context.painter().draw_rect(enclosing_int_rect(absolute_rect()), context.palette().focus_outline());
+        // FIXME: Implement this as `outline` using :focus-visible in the default UA stylesheet to make it possible to override/disable.
+        auto focus_outline_rect = enclosing_int_rect(absolute_border_box_rect()).inflated(4, 4);
+        context.painter().draw_rect(focus_outline_rect, context.palette().focus_outline());
     }
 }
 
@@ -463,8 +465,11 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
                 auto* parent = node->parent_element();
                 if (!parent)
                     continue;
-                if (parent->is_focused())
-                    context.painter().draw_rect(enclosing_int_rect(fragment.absolute_rect()), context.palette().focus_outline());
+                if (parent->is_focused()) {
+                    // FIXME: Implement this as `outline` using :focus-visible in the default UA stylesheet to make it possible to override/disable.
+                    auto focus_outline_rect = enclosing_int_rect(fragment.absolute_rect()).inflated(4, 4);
+                    context.painter().draw_rect(focus_outline_rect, context.palette().focus_outline());
+                }
             }
         }
     }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -156,7 +156,7 @@ void PaintableBox::paint(PaintContext& context, PaintPhase phase) const
     if (phase == PaintPhase::FocusOutline && layout_box().dom_node() && layout_box().dom_node()->is_element() && verify_cast<DOM::Element>(*layout_box().dom_node()).is_focused()) {
         // FIXME: Implement this as `outline` using :focus-visible in the default UA stylesheet to make it possible to override/disable.
         auto focus_outline_rect = enclosing_int_rect(absolute_border_box_rect()).inflated(4, 4);
-        context.painter().draw_rect(focus_outline_rect, context.palette().focus_outline());
+        context.painter().draw_focus_rect(focus_outline_rect, context.palette().focus_outline());
     }
 }
 
@@ -468,7 +468,7 @@ void PaintableWithLines::paint(PaintContext& context, PaintPhase phase) const
                 if (parent->is_focused()) {
                     // FIXME: Implement this as `outline` using :focus-visible in the default UA stylesheet to make it possible to override/disable.
                     auto focus_outline_rect = enclosing_int_rect(fragment.absolute_rect()).inflated(4, 4);
-                    context.painter().draw_rect(focus_outline_rect, context.palette().focus_outline());
+                    context.painter().draw_focus_rect(focus_outline_rect, context.palette().focus_outline());
                 }
             }
         }


### PR DESCRIPTION
| | Before | After |
|-|-|-|
| GitHub Login | ![image](https://user-images.githubusercontent.com/19366641/160218449-534e01f0-0f1d-4ec5-9b44-977b6ee35922.png) | ![image](https://user-images.githubusercontent.com/19366641/160218413-74a8b9ce-6110-4b86-a18d-dce72ef9244e.png) |
| Focused input default style | ![image](https://user-images.githubusercontent.com/19366641/160218509-3be9aba1-925e-4083-bcb7-74680379f946.png) | ![image](https://user-images.githubusercontent.com/19366641/160218544-cb64c844-14fc-46a2-9a44-6053a2963d18.png) |

(note that just *clicking* the input doesn't *focus* it, so this outline doesn't appear without tabbing)