### PR TITLE
LibGUI: Indent selected text on tab press in TextEditor

### DIFF
--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -959,6 +959,35 @@ void IndentSelection::undo()
     m_document.set_all_cursors(m_range.start());
 }
 
+UnindentSelection::UnindentSelection(TextDocument& document, size_t tab_width, TextRange const& range)
+    : TextDocumentUndoCommand(document)
+    , m_tab_width(tab_width)
+    , m_range(range)
+{
+}
+
+void UnindentSelection::redo()
+{
+    for (size_t i = m_range.start().line(); i <= m_range.end().line(); i++) {
+        if (m_document.line(i).leading_spaces() >= m_tab_width)
+            m_document.remove({ { i, 0 }, { i, m_tab_width } });
+        else
+            m_document.remove({ { i, 0 }, { i, m_document.line(i).leading_spaces() } });
+    }
+
+    m_document.set_all_cursors(m_range.start());
+}
+
+void UnindentSelection::undo()
+{
+    auto const tab = String::repeated(' ', m_tab_width);
+
+    for (size_t i = m_range.start().line(); i <= m_range.end().line(); i++)
+        m_document.insert_at({ i, 0 }, tab, m_client);
+
+    m_document.set_all_cursors(m_range.start());
+}
+
 TextPosition TextDocument::insert_at(TextPosition const& position, StringView text, Client const* client)
 {
     TextPosition cursor = position;

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -932,6 +932,33 @@ String ReplaceAllTextCommand::action_text() const
     return m_action_text;
 }
 
+IndentSelection::IndentSelection(TextDocument& document, size_t tab_width, TextRange const& range)
+    : TextDocumentUndoCommand(document)
+    , m_tab_width(tab_width)
+    , m_range(range)
+{
+}
+
+void IndentSelection::redo()
+{
+    auto const tab = String::repeated(' ', m_tab_width);
+
+    for (size_t i = m_range.start().line(); i <= m_range.end().line(); i++) {
+        m_document.insert_at({ i, 0 }, tab, m_client);
+    }
+
+    m_document.set_all_cursors(m_range.start());
+}
+
+void IndentSelection::undo()
+{
+    for (size_t i = m_range.start().line(); i <= m_range.end().line(); i++) {
+        m_document.remove({ { i, 0 }, { i, m_tab_width } });
+    }
+
+    m_document.set_all_cursors(m_range.start());
+}
+
 TextPosition TextDocument::insert_at(TextPosition const& position, StringView text, Client const* client)
 {
     TextPosition cursor = position;

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -271,4 +271,16 @@ private:
     TextRange m_range;
 };
 
+class UnindentSelection : public TextDocumentUndoCommand {
+public:
+    UnindentSelection(TextDocument&, size_t tab_width, TextRange const&);
+    virtual void undo() override;
+    virtual void redo() override;
+    TextRange const& range() const { return m_range; }
+
+private:
+    size_t m_tab_width { 0 };
+    TextRange m_range;
+};
+
 }

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -259,4 +259,16 @@ private:
     String m_action_text;
 };
 
+class IndentSelection : public TextDocumentUndoCommand {
+public:
+    IndentSelection(TextDocument&, size_t tab_width, TextRange const&);
+    virtual void undo() override;
+    virtual void redo() override;
+    TextRange const& range() const { return m_range; }
+
+private:
+    size_t m_tab_width { 0 };
+    TextRange m_range;
+};
+
 }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -153,6 +153,7 @@ public:
     virtual void redo();
     bool is_indenting_selection();
     void indent_selection();
+    void unindent_selection();
 
     Function<void()> on_change;
     Function<void(bool modified)> on_modified_change;

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -151,6 +151,8 @@ public:
     void select_current_line();
     virtual void undo();
     virtual void redo();
+    bool is_indenting_selection();
+    void indent_selection();
 
     Function<void()> on_change;
     Function<void(bool modified)> on_modified_change;


### PR DESCRIPTION
If selected text is less than a whole line, usual delete/replace takes
place. Otherwise, if the selected text is a whole line or spans
multiple lines, an indentation will be added to the start of the line.
This behavior matches the behavior of the text editor in Ubuntu.

This also applies to HackStudio and GML Playground.