### PR TITLE
LibWeb+Base: Set custom properties and resolve values from the element inline style

### DIFF
--- a/Base/res/html/misc/custom-properties.html
+++ b/Base/res/html/misc/custom-properties.html
@@ -152,6 +152,14 @@
         This should be cyan
     </div>
 
+    <h2>Inline properties</h2>
+    <pre>
+        &lt;div style="--color: turquoise; background-color: var(--color)"&gt;
+    </pre>
+    <div class="box" style="--color: turquoise; background-color: var(--color)">
+        This should be turquoise
+    </div>
+
     <h2>Nested var()</h2>
     <pre>
         :root {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -571,7 +571,12 @@ void StyleComputer::cascade_declarations(StyleProperties& style, DOM::Element& e
             for (auto const& property : inline_style->properties()) {
                 if (important != property.important)
                     continue;
-                set_property_expanding_shorthands(style, property.property_id, property.value, m_document);
+                auto property_value = property.value;
+                if (property.value->is_unresolved()) {
+                    if (auto resolved = resolve_unresolved_style_value(element, property.property_id, property.value->as_unresolved()))
+                        property_value = resolved.release_nonnull();
+                }
+                set_property_expanding_shorthands(style, property.property_id, property_value, m_document);
             }
         }
     }

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -582,12 +582,19 @@ static void cascade_custom_properties(DOM::Element& element, Vector<MatchingRule
     size_t needed_capacity = 0;
     for (auto const& matching_rule : matching_rules)
         needed_capacity += verify_cast<PropertyOwningCSSStyleDeclaration>(matching_rule.rule->declaration()).custom_properties().size();
+    if (auto const* inline_style = verify_cast<PropertyOwningCSSStyleDeclaration>(element.inline_style()))
+        needed_capacity += inline_style->custom_properties().size();
 
     HashMap<FlyString, StyleProperty> custom_properties;
     custom_properties.ensure_capacity(needed_capacity);
 
     for (auto const& matching_rule : matching_rules) {
         for (auto const& it : verify_cast<PropertyOwningCSSStyleDeclaration>(matching_rule.rule->declaration()).custom_properties())
+            custom_properties.set(it.key, it.value);
+    }
+
+    if (auto const* inline_style = verify_cast<PropertyOwningCSSStyleDeclaration>(element.inline_style())) {
+        for (auto const& it : inline_style->custom_properties())
             custom_properties.set(it.key, it.value);
     }
 


### PR DESCRIPTION
![test page preview](https://user-images.githubusercontent.com/16520278/160246648-6ba464a5-452e-4055-aaa6-0bcbb8f1a193.png)

> This will set the background color in the project header on GitHub! :^)

Before | After
---|---
![scrot](https://user-images.githubusercontent.com/16520278/160246903-50a12a86-e8a1-472f-a9a7-e7cfee99e06a.png) | ![](https://user-images.githubusercontent.com/16520278/160246725-dd4b28fd-abcd-4bdf-89cd-9f3384eca307.png)
