### PR TITLE
LibC: Fix inttypes.h macros for x86-64 and extend them

### DIFF
--- a/Userland/Libraries/LibC/inttypes.h
+++ b/Userland/Libraries/LibC/inttypes.h
@@ -11,89 +11,90 @@
 
 __BEGIN_DECLS
 
+#ifndef __x86_64__
+#    define __PRI64_PREFIX "ll"
+#    define __PRIPTR_PREFIX
+#else
+#    define __PRI64_PREFIX "l"
+#    define __PRIPTR_PREFIX "l"
+#endif
+
 #define PRId8 "d"
 #define PRId16 "d"
 #define PRId32 "d"
-#define PRId64 "lld"
+#define PRId64 __PRI64_PREFIX "d"
+#define PRIdPTR __PRIPTR_PREFIX "d"
+#define PRIdMAX __PRI64_PREFIX "d"
+
 #define PRIi8 "d"
 #define PRIi16 "d"
 #define PRIi32 "d"
-#ifndef __x86_64__
-#    define PRIi64 "lld"
-#else
-#    define PRIi64 "ld"
-#endif
-#define PRIu8 "u"
+#define PRIi64 __PRI64_PREFIX "d"
+#define PRIiPTR __PRIPTR_PREFIX "d"
+#define PRIiMAX __PRI64_PREFIX "d"
+
 #define PRIo8 "o"
 #define PRIo16 "o"
 #define PRIo32 "o"
-#ifndef __x86_64__
-#    define PRIo64 "llo"
-#else
-#    define PRIo64 "lo"
-#endif
+#define PRIo64 __PRI64_PREFIX "o"
+#define PRIoPTR __PRIPTR_PREFIX "o"
+#define PRIoMAX __PRI64_PREFIX "o"
+
+#define PRIu8 "u"
 #define PRIu16 "u"
 #define PRIu32 "u"
-#ifndef __x86_64__
-#    define PRIu64 "llu"
-#    define PRIuPTR "x"
-#else
-#    define PRIu64 "lu"
-#    define PRIuPTR "lx"
-#endif
-#define PRIx8 "x"
-#define PRIX8 "X"
-#define PRIx16 "x"
-#define PRIX16 "X"
-#define PRIx32 "x"
-#define PRIX32 "X"
-#ifndef __x86_64__
-#    define PRIx64 "llx"
-#    define PRIX64 "llX"
-#    define PRIxMAX "llx"
-#    define PRIxPTR "x"
-#else
-#    define PRIx64 "lx"
-#    define PRIX64 "lX"
-#    define PRIxMAX "lx"
-#    define PRIxPTR "lx"
-#endif
-
-#define __PRI64_PREFIX "ll"
-#define __PRIPTR_PREFIX
-
-#define PRIdPTR __PRIPTR_PREFIX "d"
-#define PRIiPTR __PRIPTR_PREFIX "i"
-#define PRIXPTR __PRIPTR_PREFIX "X"
-
-#define PRIdMAX __PRI64_PREFIX "d"
-#define PRIoMAX __PRI64_PREFIX "o"
+#define PRIu64 __PRI64_PREFIX "u"
+#define PRIuPTR __PRIPTR_PREFIX "u"
 #define PRIuMAX __PRI64_PREFIX "u"
 
-#define SCNdMAX __PRI64_PREFIX "d"
-#define SCNoMAX __PRI64_PREFIX "o"
-#define SCNuMAX __PRI64_PREFIX "u"
+#define PRIx8 "x"
+#define PRIx16 "x"
+#define PRIx32 "x"
+#define PRIx64 __PRI64_PREFIX "x"
+#define PRIxPTR __PRIPTR_PREFIX "x"
+#define PRIxMAX __PRI64_PREFIX "x"
 
-#define SCNu64 __PRI64_PREFIX "u"
-#define SCNd64 __PRI64_PREFIX "d"
-#define SCNi64 __PRI64_PREFIX "i"
-#define SCNx64 __PRI64_PREFIX "x"
+#define PRIX8 "X"
+#define PRIX16 "X"
+#define PRIX32 "X"
+#define PRIX64 __PRI64_PREFIX "X"
+#define PRIXPTR __PRIPTR_PREFIX "X"
+#define PRIXMAX __PRI64_PREFIX "X"
 
 #define SCNd8 "hhd"
 #define SCNd16 "hd"
 #define SCNd32 "ld"
+#define SCNd64 __PRI64_PREFIX "d"
+#define SCNdPTR __PRIPTR_PREFIX "d"
+#define SCNdMAX __PRI64_PREFIX "d"
 
 #define SCNi8 "hhi"
 #define SCNi16 "hi"
 #define SCNi32 "li"
+#define SCNi64 __PRI64_PREFIX "i"
+#define SCNiPTR __PRIPTR_PREFIX "i"
+#define SCNiMAX __PRI64_PREFIX "i"
 
 #define SCNu8 "hhu"
 #define SCNu16 "hu"
 #define SCNu32 "lu"
+#define SCNu64 __PRI64_PREFIX "u"
+#define SCNuPTR __PRIPTR_PREFIX "u"
+#define SCNuMAX __PRI64_PREFIX "u"
+
+#define SCNo8 "hho"
+#define SCNo16 "ho"
+#define SCNo32 "lo"
+#define SCNo64 __PRI64_PREFIX "o"
+#define SCNoPTR __PRIPTR_PREFIX "o"
+#define SCNoMAX __PRI64_PREFIX "o"
 
 #define SCNx8 "hhx"
 #define SCNx16 "hx"
 #define SCNx32 "lx"
+#define SCNx64 __PRI64_PREFIX "x"
+#define SCNxPTR __PRIPTR_PREFIX "x"
+#define SCNxMAX __PRI64_PREFIX "x"
 
 typedef struct imaxdiv_t {
     intmax_t quot;


### PR DESCRIPTION
I found a couple suspicious formatting-related warnings when compiling LLVM 14 for Serenity. I have quite a lot of work to do before I can put up the toolchain update for PR, so I thought I'd open a separate PR as this change might benefit other ports too. 

This should hopefully bring no functional changes to Serenity code and isn't super important, but will require a complete toolchain rebuild on CI, so feel free to queue this up with some other LibC header changes :^)

---

On x86-64, `int64_t` is defined to be `long` (not `long long`) , so for
printing, the "l" format specifier has to be used instead of i686's
"ll".

A couple of these macros weren't updated when the x86-64 target was
added, so using them produced warnings like this:

> warning: format specifies type 'long long' but the argument has type
> 'int64_t' (aka 'long') [-Wformat]
>
>       "DW_CFA_GNU_negative_offset_extended(%" PRId64 ")\n", offset);
>       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~

This commit changes the macros to be correct for both architectures, and
reorders them to be consistent and adds a couple missing ones for the
sake of completeness.