### PR TITLE
Kernel: Remove hardcoded block sizes from Block Device drivers

### DIFF
--- a/Kernel/Devices/BlockDevice.h
+++ b/Kernel/Devices/BlockDevice.h
@@ -12,45 +12,7 @@
 
 namespace Kernel {
 
-class BlockDevice;
-
-class AsyncBlockDeviceRequest final : public AsyncDeviceRequest {
-public:
-    enum RequestType {
-        Read,
-        Write
-    };
-    AsyncBlockDeviceRequest(Device& block_device, RequestType request_type,
-        u64 block_index, u32 block_count, const UserOrKernelBuffer& buffer, size_t buffer_size);
-
-    RequestType request_type() const { return m_request_type; }
-    u64 block_index() const { return m_block_index; }
-    u32 block_count() const { return m_block_count; }
-    UserOrKernelBuffer& buffer() { return m_buffer; }
-    const UserOrKernelBuffer& buffer() const { return m_buffer; }
-    size_t buffer_size() const { return m_buffer_size; }
-
-    virtual void start() override;
-    virtual StringView name() const override
-    {
-        switch (m_request_type) {
-        case Read:
-            return "BlockDeviceRequest (read)"sv;
-        case Write:
-            return "BlockDeviceRequest (write)"sv;
-        default:
-            VERIFY_NOT_REACHED();
-        }
-    }
-
-private:
-    BlockDevice& m_block_device;
-    const RequestType m_request_type;
-    const u64 m_block_index;
-    const u32 m_block_count;
-    UserOrKernelBuffer m_buffer;
-    const size_t m_buffer_size;
-};
+class AsyncBlockDeviceRequest;
 
 class BlockDevice : public Device {
 public:
@@ -81,6 +43,45 @@ private:
 
     size_t m_block_size { 0 };
     u8 m_block_size_log { 0 };
+};
+
+class AsyncBlockDeviceRequest final : public AsyncDeviceRequest {
+public:
+    enum RequestType {
+        Read,
+        Write
+    };
+    AsyncBlockDeviceRequest(Device& block_device, RequestType request_type,
+        u64 block_index, u32 block_count, const UserOrKernelBuffer& buffer, size_t buffer_size);
+
+    RequestType request_type() const { return m_request_type; }
+    u64 block_index() const { return m_block_index; }
+    u32 block_count() const { return m_block_count; }
+    size_t block_size() const { return m_block_device.block_size(); }
+    UserOrKernelBuffer& buffer() { return m_buffer; }
+    const UserOrKernelBuffer& buffer() const { return m_buffer; }
+    size_t buffer_size() const { return m_buffer_size; }
+
+    virtual void start() override;
+    virtual StringView name() const override
+    {
+        switch (m_request_type) {
+        case Read:
+            return "BlockDeviceRequest (read)"sv;
+        case Write:
+            return "BlockDeviceRequest (write)"sv;
+        default:
+            VERIFY_NOT_REACHED();
+        }
+    }
+
+private:
+    BlockDevice& m_block_device;
+    const RequestType m_request_type;
+    const u64 m_block_index;
+    const u32 m_block_count;
+    UserOrKernelBuffer m_buffer;
+    const size_t m_buffer_size;
 };
 
 }

--- a/Kernel/Storage/ATA/IDEChannel.h
+++ b/Kernel/Storage/ATA/IDEChannel.h
@@ -105,6 +105,7 @@ public:
 private:
     void complete_current_request(AsyncDeviceRequest::RequestResult);
     void initialize();
+    static constexpr size_t m_logical_sector_size = 512;
 
 protected:
     enum class LBAMode : u8 {

--- a/Kernel/Storage/NVMe/NVMeInterruptQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeInterruptQueue.cpp
@@ -43,7 +43,7 @@ void NVMeInterruptQueue::complete_current_request(u16 status)
             return;
         }
         if (current_request->request_type() == AsyncBlockDeviceRequest::RequestType::Read) {
-            if (auto result = current_request->write_to_buffer(current_request->buffer(), m_rw_dma_region->vaddr().as_ptr(), 512 * current_request->block_count()); result.is_error()) {
+            if (auto result = current_request->write_to_buffer(current_request->buffer(), m_rw_dma_region->vaddr().as_ptr(), current_request->buffer_size()); result.is_error()) {
                 lock.unlock();
                 current_request->complete(AsyncDeviceRequest::MemoryFault);
                 return;

--- a/Kernel/Storage/NVMe/NVMePollQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMePollQueue.cpp
@@ -33,7 +33,7 @@ void NVMePollQueue::complete_current_request(u16 status)
         return;
     }
     if (current_request->request_type() == AsyncBlockDeviceRequest::RequestType::Read) {
-        if (auto result = current_request->write_to_buffer(current_request->buffer(), m_rw_dma_region->vaddr().as_ptr(), 512 * current_request->block_count()); result.is_error()) {
+        if (auto result = current_request->write_to_buffer(current_request->buffer(), m_rw_dma_region->vaddr().as_ptr(), current_request->buffer_size()); result.is_error()) {
             current_request->complete(AsyncDeviceRequest::MemoryFault);
             return;
         }

--- a/Kernel/Storage/NVMe/NVMeQueue.cpp
+++ b/Kernel/Storage/NVMe/NVMeQueue.cpp
@@ -157,7 +157,7 @@ void NVMeQueue::write(AsyncBlockDeviceRequest& request, u16 nsid, u64 index, u32
     SpinlockLocker m_lock(m_request_lock);
     m_current_request = request;
 
-    if (auto result = m_current_request->read_from_buffer(m_current_request->buffer(), m_rw_dma_region->vaddr().as_ptr(), 512 * m_current_request->block_count()); result.is_error()) {
+    if (auto result = m_current_request->read_from_buffer(m_current_request->buffer(), m_rw_dma_region->vaddr().as_ptr(), m_current_request->buffer_size()); result.is_error()) {
         complete_current_request(AsyncDeviceRequest::MemoryFault);
         return;
     }

--- a/Kernel/Storage/Ramdisk/Device.cpp
+++ b/Kernel/Storage/Ramdisk/Device.cpp
@@ -45,8 +45,8 @@ void RamdiskDevice::start_request(AsyncBlockDeviceRequest& request)
 
     u8* base = m_region->vaddr().as_ptr();
     size_t size = m_region->size();
-    u8* offset = base + request.block_index() * 512;
-    size_t length = request.block_count() * 512;
+    u8* offset = base + request.block_index() * request.block_size();
+    size_t length = request.buffer_size();
 
     if ((offset + length > base + size) || (offset + length < base)) {
         request.complete(AsyncDeviceRequest::Failure);


### PR DESCRIPTION
512 bytes block size assumption has been used in BMIDE, NVMe, Ramdisk and IDE device drivers. This patchset removes the assumption in those drivers. 

This is a preparation for serenity to work with storage that does not have a block size of 512 bytes. There are still places in block layer and in filesystem where there are these hidden assumptions. 

cc: @supercomputer7 @IdanHo 