### PR TITLE
WindowServer+LibGUI: Expose raw scroll wheel values to applications

### DIFF
--- a/Userland/Applications/PixelPaint/ImageEditor.cpp
+++ b/Userland/Applications/PixelPaint/ImageEditor.cpp
@@ -267,6 +267,8 @@ GUI::MouseEvent ImageEditor::event_with_pan_and_scale_applied(GUI::MouseEvent co
         event.modifiers(),
         event.wheel_delta_x(),
         event.wheel_delta_y(),
+        event.wheel_raw_delta_x(),
+        event.wheel_raw_delta_y(),
     };
 }
 
@@ -282,6 +284,8 @@ GUI::MouseEvent ImageEditor::event_adjusted_for_layer(GUI::MouseEvent const& eve
         event.modifiers(),
         event.wheel_delta_x(),
         event.wheel_delta_y(),
+        event.wheel_raw_delta_x(),
+        event.wheel_raw_delta_y(),
     };
 }
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -202,7 +202,7 @@ void InfinitelyScrollableTableView::mousedown_event(GUI::MouseEvent& event)
         else if (m_is_hovering_extend_zone)
             m_is_dragging_for_extend = true;
         auto rect = content_rect_minus_scrollbars(m_target_cell);
-        GUI::MouseEvent adjusted_event = { (GUI::Event::Type)event.type(), rect.center(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y() };
+        GUI::MouseEvent adjusted_event = { (GUI::Event::Type)event.type(), rect.center(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y() };
         AbstractTableView::mousedown_event(adjusted_event);
     } else {
         AbstractTableView::mousedown_event(event);
@@ -239,7 +239,7 @@ void InfinitelyScrollableTableView::mouseup_event(GUI::MouseEvent& event)
     m_has_committed_to_extending = false;
     if (m_is_hovering_cut_zone || m_is_hovering_extend_zone) {
         auto rect = content_rect_minus_scrollbars(m_target_cell);
-        GUI::MouseEvent adjusted_event = { (GUI::Event::Type)event.type(), rect.center(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y() };
+        GUI::MouseEvent adjusted_event = { (GUI::Event::Type)event.type(), rect.center(), event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y() };
         TableView::mouseup_event(adjusted_event);
     } else {
         TableView::mouseup_event(event);

--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.cpp
@@ -246,38 +246,38 @@ static MouseButton to_mouse_button(u32 button)
     }
 }
 
-void ConnectionToWindowServer::mouse_down(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
+void ConnectionToWindowServer::mouse_down(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y)
 {
     if (auto* window = Window::from_window_id(window_id))
-        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDown, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDown, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y, wheel_raw_delta_x, wheel_raw_delta_y));
 }
 
-void ConnectionToWindowServer::mouse_up(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
+void ConnectionToWindowServer::mouse_up(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y)
 {
     if (auto* window = Window::from_window_id(window_id))
-        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseUp, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseUp, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y, wheel_raw_delta_x, wheel_raw_delta_y));
 }
 
-void ConnectionToWindowServer::mouse_move(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, bool is_drag, Vector<String> const& mime_types)
+void ConnectionToWindowServer::mouse_move(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y, bool is_drag, Vector<String> const& mime_types)
 {
     if (auto* window = Window::from_window_id(window_id)) {
         if (is_drag)
             Core::EventLoop::current().post_event(*window, make<DragEvent>(Event::DragMove, mouse_position, mime_types));
         else
-            Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseMove, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
+            Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseMove, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y, wheel_raw_delta_x, wheel_raw_delta_y));
     }
 }
 
-void ConnectionToWindowServer::mouse_double_click(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
+void ConnectionToWindowServer::mouse_double_click(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y)
 {
     if (auto* window = Window::from_window_id(window_id))
-        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDoubleClick, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseDoubleClick, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y, wheel_raw_delta_x, wheel_raw_delta_y));
 }
 
-void ConnectionToWindowServer::mouse_wheel(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y)
+void ConnectionToWindowServer::mouse_wheel(i32 window_id, Gfx::IntPoint const& mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y)
 {
     if (auto* window = Window::from_window_id(window_id))
-        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseWheel, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y));
+        Core::EventLoop::current().post_event(*window, make<MouseEvent>(Event::MouseWheel, mouse_position, buttons, to_mouse_button(button), modifiers, wheel_delta_x, wheel_delta_y, wheel_raw_delta_x, wheel_raw_delta_y));
 }
 
 void ConnectionToWindowServer::menu_visibility_did_change(i32 menu_id, bool visible)

--- a/Userland/Libraries/LibGUI/ConnectionToWindowServer.h
+++ b/Userland/Libraries/LibGUI/ConnectionToWindowServer.h
@@ -26,11 +26,11 @@ private:
 
     virtual void fast_greet(Vector<Gfx::IntRect> const&, u32, u32, u32, Core::AnonymousBuffer const&, String const&, String const&, i32) override;
     virtual void paint(i32, Gfx::IntSize const&, Vector<Gfx::IntRect> const&) override;
-    virtual void mouse_move(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32, bool, Vector<String> const&) override;
-    virtual void mouse_down(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32) override;
-    virtual void mouse_double_click(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32) override;
-    virtual void mouse_up(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32) override;
-    virtual void mouse_wheel(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32) override;
+    virtual void mouse_move(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32, i32, i32, bool, Vector<String> const&) override;
+    virtual void mouse_down(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32, i32, i32) override;
+    virtual void mouse_double_click(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32, i32, i32) override;
+    virtual void mouse_up(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32, i32, i32) override;
+    virtual void mouse_wheel(i32, Gfx::IntPoint const&, u32, u32, u32, i32, i32, i32, i32) override;
     virtual void window_entered(i32) override;
     virtual void window_left(i32) override;
     virtual void key_down(i32, u32, u32, u32, u32) override;

--- a/Userland/Libraries/LibGUI/Event.h
+++ b/Userland/Libraries/LibGUI/Event.h
@@ -401,7 +401,7 @@ private:
 
 class MouseEvent final : public Event {
 public:
-    MouseEvent(Type type, const Gfx::IntPoint& position, unsigned buttons, MouseButton button, unsigned modifiers, int wheel_delta_x, int wheel_delta_y)
+    MouseEvent(Type type, const Gfx::IntPoint& position, unsigned buttons, MouseButton button, unsigned modifiers, int wheel_delta_x, int wheel_delta_y, int wheel_raw_delta_x, int wheel_raw_delta_y)
         : Event(type)
         , m_position(position)
         , m_buttons(buttons)
@@ -409,6 +409,8 @@ public:
         , m_modifiers(modifiers)
         , m_wheel_delta_x(wheel_delta_x)
         , m_wheel_delta_y(wheel_delta_y)
+        , m_wheel_raw_delta_x(wheel_raw_delta_x)
+        , m_wheel_raw_delta_y(wheel_raw_delta_y)
     {
     }
 
@@ -424,6 +426,8 @@ public:
     unsigned modifiers() const { return m_modifiers; }
     int wheel_delta_x() const { return m_wheel_delta_x; }
     int wheel_delta_y() const { return m_wheel_delta_y; }
+    int wheel_raw_delta_x() const { return m_wheel_raw_delta_x; }
+    int wheel_raw_delta_y() const { return m_wheel_raw_delta_y; }
 
 private:
     Gfx::IntPoint m_position;
@@ -432,6 +436,8 @@ private:
     unsigned m_modifiers { 0 };
     int m_wheel_delta_x { 0 };
     int m_wheel_delta_y { 0 };
+    int m_wheel_raw_delta_x { 0 };
+    int m_wheel_raw_delta_y { 0 };
 };
 
 class DragEvent final : public Event {

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -366,7 +366,7 @@ void Window::handle_mouse_event(MouseEvent& event)
     if (m_automatic_cursor_tracking_widget) {
         auto window_relative_rect = m_automatic_cursor_tracking_widget->window_relative_rect();
         Gfx::IntPoint local_point { event.x() - window_relative_rect.x(), event.y() - window_relative_rect.y() };
-        auto local_event = MouseEvent((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
+        auto local_event = MouseEvent((Event::Type)event.type(), local_point, event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y());
         m_automatic_cursor_tracking_widget->dispatch_event(local_event, this);
         if (event.buttons() == 0)
             m_automatic_cursor_tracking_widget = nullptr;
@@ -375,7 +375,7 @@ void Window::handle_mouse_event(MouseEvent& event)
     if (!m_main_widget)
         return;
     auto result = m_main_widget->hit_test(event.position());
-    auto local_event = MouseEvent((Event::Type)event.type(), result.local_position, event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
+    auto local_event = MouseEvent((Event::Type)event.type(), result.local_position, event.buttons(), event.button(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y());
     VERIFY(result.widget);
     set_hovered_widget(result.widget);
     if (event.buttons() != 0 && !m_automatic_cursor_tracking_widget)

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -207,7 +207,7 @@ void TaskbarWindow::event(Core::Event& event)
 
         if (adjusted_point != mouse_event.position()) {
             GUI::ConnectionToWindowServer::the().async_set_global_cursor_position(position() + adjusted_point);
-            GUI::MouseEvent adjusted_event = { (GUI::Event::Type)mouse_event.type(), adjusted_point, mouse_event.buttons(), mouse_event.button(), mouse_event.modifiers(), mouse_event.wheel_delta_x(), mouse_event.wheel_delta_y() };
+            GUI::MouseEvent adjusted_event = { (GUI::Event::Type)mouse_event.type(), adjusted_point, mouse_event.buttons(), mouse_event.button(), mouse_event.modifiers(), mouse_event.wheel_delta_x(), mouse_event.wheel_delta_y(), mouse_event.wheel_raw_delta_x(), mouse_event.wheel_raw_delta_y() };
             Window::event(adjusted_event);
             return;
         }

--- a/Userland/Services/WindowServer/Event.h
+++ b/Userland/Services/WindowServer/Event.h
@@ -88,7 +88,7 @@ private:
 
 class MouseEvent final : public Event {
 public:
-    MouseEvent(Type type, const Gfx::IntPoint& position, unsigned buttons, MouseButton button, unsigned modifiers, int wheel_delta_x = 0, int wheel_delta_y = 0)
+    MouseEvent(Type type, const Gfx::IntPoint& position, unsigned buttons, MouseButton button, unsigned modifiers, int wheel_delta_x = 0, int wheel_delta_y = 0, int wheel_raw_delta_x = 0, int wheel_raw_delta_y = 0)
         : Event(type)
         , m_position(position)
         , m_buttons(buttons)
@@ -96,6 +96,8 @@ public:
         , m_modifiers(modifiers)
         , m_wheel_delta_x(wheel_delta_x)
         , m_wheel_delta_y(wheel_delta_y)
+        , m_wheel_raw_delta_x(wheel_raw_delta_x)
+        , m_wheel_raw_delta_y(wheel_raw_delta_y)
     {
     }
 
@@ -107,6 +109,8 @@ public:
     unsigned modifiers() const { return m_modifiers; }
     int wheel_delta_x() const { return m_wheel_delta_x; }
     int wheel_delta_y() const { return m_wheel_delta_y; }
+    int wheel_raw_delta_x() const { return m_wheel_raw_delta_x; }
+    int wheel_raw_delta_y() const { return m_wheel_raw_delta_y; }
     bool is_drag() const { return m_drag; }
 
     Vector<String> mime_types() const
@@ -133,6 +137,8 @@ private:
     unsigned m_modifiers { 0 };
     int m_wheel_delta_x { 0 };
     int m_wheel_delta_y { 0 };
+    int m_wheel_raw_delta_x { 0 };
+    int m_wheel_raw_delta_y { 0 };
     bool m_drag { false };
     RefPtr<const Core::MimeData> m_mime_data;
 };

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -462,7 +462,7 @@ void ScreenInput::on_receive_mouse_data(const MousePacket& packet)
     }
 
     if (packet.z || packet.w) {
-        auto message = make<MouseEvent>(Event::MouseWheel, m_cursor_location, buttons, MouseButton::None, m_modifiers, packet.w * m_scroll_step_size, packet.z * m_scroll_step_size);
+        auto message = make<MouseEvent>(Event::MouseWheel, m_cursor_location, buttons, MouseButton::None, m_modifiers, packet.w * m_scroll_step_size, packet.z * m_scroll_step_size, packet.w, packet.z);
         Core::EventLoop::current().post_event(WindowManager::the(), move(message));
     }
 

--- a/Userland/Services/WindowServer/Window.cpp
+++ b/Userland/Services/WindowServer/Window.cpp
@@ -267,19 +267,19 @@ void Window::handle_mouse_event(const MouseEvent& event)
 
     switch (event.type()) {
     case Event::MouseMove:
-        m_client->async_mouse_move(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.is_drag(), event.mime_types());
+        m_client->async_mouse_move(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y(), event.is_drag(), event.mime_types());
         break;
     case Event::MouseDown:
-        m_client->async_mouse_down(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
+        m_client->async_mouse_down(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y());
         break;
     case Event::MouseDoubleClick:
-        m_client->async_mouse_double_click(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
+        m_client->async_mouse_double_click(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y());
         break;
     case Event::MouseUp:
-        m_client->async_mouse_up(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
+        m_client->async_mouse_up(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y());
         break;
     case Event::MouseWheel:
-        m_client->async_mouse_wheel(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y());
+        m_client->async_mouse_wheel(m_window_id, event.position(), (u32)event.button(), event.buttons(), event.modifiers(), event.wheel_delta_x(), event.wheel_delta_y(), event.wheel_raw_delta_x(), event.wheel_raw_delta_y());
         break;
     default:
         VERIFY_NOT_REACHED();

--- a/Userland/Services/WindowServer/WindowClient.ipc
+++ b/Userland/Services/WindowServer/WindowClient.ipc
@@ -6,11 +6,11 @@ endpoint WindowClient
     fast_greet(Vector<Gfx::IntRect> screen_rects, u32 main_screen_index, u32 workspace_rows, u32 workspace_columns, Core::AnonymousBuffer theme_buffer, String default_font_query, String fixed_width_font_query, i32 client_id) =|
 
     paint(i32 window_id, Gfx::IntSize window_size, Vector<Gfx::IntRect> rects) =|
-    mouse_move(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, bool is_drag, Vector<String> mime_types) =|
-    mouse_down(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
-    mouse_double_click(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
-    mouse_up(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
-    mouse_wheel(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y) =|
+    mouse_move(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y, bool is_drag, Vector<String> mime_types) =|
+    mouse_down(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y) =|
+    mouse_double_click(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y) =|
+    mouse_up(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y) =|
+    mouse_wheel(i32 window_id, Gfx::IntPoint mouse_position, u32 button, u32 buttons, u32 modifiers, i32 wheel_delta_x, i32 wheel_delta_y, i32 wheel_raw_delta_x, i32 wheel_raw_delta_y) =|
     window_entered(i32 window_id) =|
     window_left(i32 window_id) =|
     window_input_entered(i32 window_id) =|


### PR DESCRIPTION
This is useful, for instance, in games in which you can switch held
items using the scroll wheel. In order to implement this, they
previously would have to either add a hard-coded division by 4, or look
up your mouse settings to adjust correctly.

This commit adds an MouseEvent.wheel_raw_delta_x() and
MouseEvent.wheel_raw_delta_y().

Once this PR is merged, I will create another one for the Serenity port of SDL, to add support for the scroll wheel, and by extension weapon switching in the Half-Life port :^)