### PR TITLE
Browser: Open bookmark in a new tab on middle mouse click

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -210,6 +210,11 @@ void BookmarksBarWidget::model_did_update(unsigned)
                 on_bookmark_click(url, modifiers);
         };
 
+        button.on_middle_click = [url, this]() {
+            if (on_bookmark_click)
+                on_bookmark_click(url, Mod_Ctrl);
+        };
+
         button.on_context_menu_request = [this, url](auto& context_menu_event) {
             m_context_menu_url = url;
             m_context_menu->popup(context_menu_event.screen_position(), m_context_menu_default_action);

--- a/Userland/Libraries/LibGUI/AbstractButton.cpp
+++ b/Userland/Libraries/LibGUI/AbstractButton.cpp
@@ -120,13 +120,17 @@ void AbstractButton::mousedown_event(MouseEvent& event)
             m_auto_repeat_timer->start(m_auto_repeat_interval);
         }
         event.accept();
+    } else if (event.button() == MouseButton::Middle) {
+        repaint();
+        middle_click();
+        event.accept();
     }
     Widget::mousedown_event(event);
 }
 
 void AbstractButton::mouseup_event(MouseEvent& event)
 {
-    if (event.button() == MouseButton::Primary && m_being_pressed) {
+    if ((event.button() == MouseButton::Primary || event.button() == MouseButton::Middle) && m_being_pressed) {
         bool was_auto_repeating = m_auto_repeat_timer->is_active();
         m_auto_repeat_timer->stop();
         bool was_being_pressed = m_being_pressed;

--- a/Userland/Libraries/LibGUI/AbstractButton.h
+++ b/Userland/Libraries/LibGUI/AbstractButton.h
@@ -36,6 +36,7 @@ public:
     bool is_being_pressed() const { return m_being_pressed; }
 
     virtual void click(unsigned modifiers = 0) = 0;
+    virtual void middle_click() {};
     virtual bool is_uncheckable() const { return true; }
 
     int auto_repeat_interval() const { return m_auto_repeat_interval; }

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -127,6 +127,14 @@ void Button::click(unsigned modifiers)
         m_action->activate(this);
 }
 
+void Button::middle_click()
+{
+    if (!is_enabled())
+        return;
+    if (on_middle_click)
+        on_middle_click();
+}
+
 void Button::context_menu_event(ContextMenuEvent& context_menu_event)
 {
     if (!is_enabled())

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -30,12 +30,14 @@ public:
     Gfx::TextAlignment text_alignment() const { return m_text_alignment; }
 
     Function<void(unsigned modifiers)> on_click;
+    Function<void()> on_middle_click;
     Function<void(ContextMenuEvent&)> on_context_menu_request;
 
     void set_button_style(Gfx::ButtonStyle style) { m_button_style = style; }
     Gfx::ButtonStyle button_style() const { return m_button_style; }
 
     virtual void click(unsigned modifiers = 0) override;
+    virtual void middle_click() override;
     virtual void context_menu_event(ContextMenuEvent&) override;
 
     Action* action() { return m_action; }


### PR DESCRIPTION
With this change, you can now open a bookmark from the bookmark bar in a new tab with the middle mouse click, similar to other browsers.