### PR TITLE
LibGL+LibSoftGPU: Decoupling of device info

### DIFF
--- a/Userland/Libraries/LibGL/DeviceInfo.h
+++ b/Userland/Libraries/LibGL/DeviceInfo.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/StringView.h>
+#include <AK/Types.h>
+
+namespace GL {
+
+struct DeviceInfo final {
+    StringView vendor_name;
+    StringView device_name;
+    unsigned num_texture_units;
+    unsigned num_lights;
+    u8 stencil_bits;
+    bool supports_npot_textures;
+};
+
+}

--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -14,11 +14,13 @@
 #include <AK/TemporaryChange.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibGL/DeviceInfo.h>
 #include <LibGL/GLContext.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Painter.h>
 #include <LibGfx/Vector4.h>
 #include <LibSoftGPU/Device.h>
+#include <LibSoftGPU/DeviceInfo.h>
 #include <LibSoftGPU/Enums.h>
 #include <LibSoftGPU/ImageFormat.h>
 
@@ -65,7 +67,7 @@ GLContext::GLContext(Gfx::Bitmap& frontbuffer)
     : m_viewport(frontbuffer.rect())
     , m_frontbuffer(frontbuffer)
     , m_rasterizer(frontbuffer.size())
-    , m_device_info(m_rasterizer.info())
+    , m_device_info(SoftGPU::device_info)
 {
     m_texture_units.resize(m_device_info.num_texture_units);
     m_active_texture_unit = &m_texture_units[0];
@@ -446,9 +448,9 @@ GLubyte* GLContext::gl_get_string(GLenum name)
 
     switch (name) {
     case GL_VENDOR:
-        return reinterpret_cast<GLubyte*>(const_cast<char*>(m_device_info.vendor_name.characters()));
+        return reinterpret_cast<GLubyte*>(const_cast<char*>(m_device_info.vendor_name.characters_without_null_termination()));
     case GL_RENDERER:
-        return reinterpret_cast<GLubyte*>(const_cast<char*>(m_device_info.device_name.characters()));
+        return reinterpret_cast<GLubyte*>(const_cast<char*>(m_device_info.device_name.characters_without_null_termination()));
     case GL_VERSION:
         return reinterpret_cast<GLubyte*>(const_cast<char*>("1.5"));
     case GL_EXTENSIONS:

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -14,6 +14,7 @@
 #include <AK/Tuple.h>
 #include <AK/Variant.h>
 #include <AK/Vector.h>
+#include <LibGL/DeviceInfo.h>
 #include <LibGL/Tex/NameAllocator.h>
 #include <LibGL/Tex/Texture.h>
 #include <LibGL/Tex/TextureUnit.h>
@@ -304,7 +305,7 @@ private:
     }
 
     SoftGPU::Device m_rasterizer;
-    SoftGPU::DeviceInfo const m_device_info;
+    GL::DeviceInfo m_device_info;
     bool m_sampler_config_is_dirty { true };
     bool m_light_state_is_dirty { true };
 

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -16,6 +16,7 @@
 #include <LibGfx/Vector3.h>
 #include <LibSoftGPU/Config.h>
 #include <LibSoftGPU/Device.h>
+#include <LibSoftGPU/DeviceInfo.h>
 #include <LibSoftGPU/PixelQuad.h>
 #include <LibSoftGPU/SIMD.h>
 #include <math.h>
@@ -512,7 +513,7 @@ void Device::rasterize_triangle(const Triangle& triangle)
             else
                 quad.vertex_color = expand4(vertex0.color);
 
-            for (size_t i = 0; i < NUM_SAMPLERS; ++i)
+            for (size_t i = 0; i < device_info.num_texture_units; ++i)
                 quad.texture_coordinates[i] = interpolate(expand4(vertex0.tex_coords[i]), expand4(vertex1.tex_coords[i]), expand4(vertex2.tex_coords[i]), quad.barycentrics);
 
             if (m_options.fog_enabled)
@@ -577,18 +578,6 @@ Device::Device(Gfx::IntSize const& size)
 {
     m_options.scissor_box = m_frame_buffer->rect();
     m_options.viewport = m_frame_buffer->rect();
-}
-
-DeviceInfo Device::info() const
-{
-    return {
-        .vendor_name = "SerenityOS",
-        .device_name = "SoftGPU",
-        .num_texture_units = NUM_SAMPLERS,
-        .num_lights = NUM_LIGHTS,
-        .stencil_bits = sizeof(StencilType) * 8,
-        .supports_npot_textures = true,
-    };
 }
 
 static void generate_texture_coordinates(Vertex& vertex, RasterizerOptions const& options)
@@ -956,7 +945,7 @@ void Device::draw_primitives(PrimitiveType primitive_type, FloatMatrix4x4 const&
         }
 
         // Apply texture transformation
-        for (size_t i = 0; i < NUM_SAMPLERS; ++i) {
+        for (size_t i = 0; i < device_info.num_texture_units; ++i) {
             triangle.vertices[0].tex_coords[i] = texture_transform * triangle.vertices[0].tex_coords[i];
             triangle.vertices[1].tex_coords[i] = texture_transform * triangle.vertices[1].tex_coords[i];
             triangle.vertices[2].tex_coords[i] = texture_transform * triangle.vertices[2].tex_coords[i];

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -92,87 +92,89 @@ static Vector4<f32x4> to_vec4(u32x4 bgra)
     };
 }
 
-void Device::setup_blend_factors()
+static AlphaBlendFactors setup_blend_factors(BlendFactor blend_source_factor, BlendFactor blend_destination_factor)
 {
-    m_alpha_blend_factors = {};
+    AlphaBlendFactors alpha_blend_factors {};
 
-    switch (m_options.blend_source_factor) {
+    switch (blend_source_factor) {
     case BlendFactor::Zero:
         break;
     case BlendFactor::One:
-        m_alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
         break;
     case BlendFactor::SrcColor:
-        m_alpha_blend_factors.src_factor_src_color = 1;
+        alpha_blend_factors.src_factor_src_color = 1;
         break;
     case BlendFactor::OneMinusSrcColor:
-        m_alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
-        m_alpha_blend_factors.src_factor_src_color = -1;
+        alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.src_factor_src_color = -1;
         break;
     case BlendFactor::SrcAlpha:
-        m_alpha_blend_factors.src_factor_src_alpha = 1;
+        alpha_blend_factors.src_factor_src_alpha = 1;
         break;
     case BlendFactor::OneMinusSrcAlpha:
-        m_alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
-        m_alpha_blend_factors.src_factor_src_alpha = -1;
+        alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.src_factor_src_alpha = -1;
         break;
     case BlendFactor::DstAlpha:
-        m_alpha_blend_factors.src_factor_dst_alpha = 1;
+        alpha_blend_factors.src_factor_dst_alpha = 1;
         break;
     case BlendFactor::OneMinusDstAlpha:
-        m_alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
-        m_alpha_blend_factors.src_factor_dst_alpha = -1;
+        alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.src_factor_dst_alpha = -1;
         break;
     case BlendFactor::DstColor:
-        m_alpha_blend_factors.src_factor_dst_color = 1;
+        alpha_blend_factors.src_factor_dst_color = 1;
         break;
     case BlendFactor::OneMinusDstColor:
-        m_alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
-        m_alpha_blend_factors.src_factor_dst_color = -1;
+        alpha_blend_factors.src_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.src_factor_dst_color = -1;
         break;
     case BlendFactor::SrcAlphaSaturate:
     default:
         VERIFY_NOT_REACHED();
     }
 
-    switch (m_options.blend_destination_factor) {
+    switch (blend_destination_factor) {
     case BlendFactor::Zero:
         break;
     case BlendFactor::One:
-        m_alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
         break;
     case BlendFactor::SrcColor:
-        m_alpha_blend_factors.dst_factor_src_color = 1;
+        alpha_blend_factors.dst_factor_src_color = 1;
         break;
     case BlendFactor::OneMinusSrcColor:
-        m_alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
-        m_alpha_blend_factors.dst_factor_src_color = -1;
+        alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.dst_factor_src_color = -1;
         break;
     case BlendFactor::SrcAlpha:
-        m_alpha_blend_factors.dst_factor_src_alpha = 1;
+        alpha_blend_factors.dst_factor_src_alpha = 1;
         break;
     case BlendFactor::OneMinusSrcAlpha:
-        m_alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
-        m_alpha_blend_factors.dst_factor_src_alpha = -1;
+        alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.dst_factor_src_alpha = -1;
         break;
     case BlendFactor::DstAlpha:
-        m_alpha_blend_factors.dst_factor_dst_alpha = 1;
+        alpha_blend_factors.dst_factor_dst_alpha = 1;
         break;
     case BlendFactor::OneMinusDstAlpha:
-        m_alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
-        m_alpha_blend_factors.dst_factor_dst_alpha = -1;
+        alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.dst_factor_dst_alpha = -1;
         break;
     case BlendFactor::DstColor:
-        m_alpha_blend_factors.dst_factor_dst_color = 1;
+        alpha_blend_factors.dst_factor_dst_color = 1;
         break;
     case BlendFactor::OneMinusDstColor:
-        m_alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
-        m_alpha_blend_factors.dst_factor_dst_color = -1;
+        alpha_blend_factors.dst_constant = { 1.0f, 1.0f, 1.0f, 1.0f };
+        alpha_blend_factors.dst_factor_dst_color = -1;
         break;
     case BlendFactor::SrcAlphaSaturate:
     default:
         VERIFY_NOT_REACHED();
     }
+
+    return alpha_blend_factors;
 }
 
 void Device::rasterize_triangle(const Triangle& triangle)
@@ -1195,7 +1197,7 @@ void Device::set_options(const RasterizerOptions& options)
     m_options = options;
 
     if (m_options.enable_blending)
-        setup_blend_factors();
+        m_alpha_blend_factors = setup_blend_factors(options.blend_source_factor, options.blend_destination_factor);
 }
 
 void Device::set_light_model_params(const LightModelParameters& lighting_model)

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -146,7 +146,6 @@ private:
     Gfx::IntRect get_rasterization_rect_of_size(Gfx::IntSize size);
 
     void rasterize_triangle(const Triangle& triangle);
-    void setup_blend_factors();
     void shade_fragments(PixelQuad&);
     bool test_alpha(PixelQuad&);
 

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -21,7 +21,6 @@
 #include <LibSoftGPU/Buffer/Typed2DBuffer.h>
 #include <LibSoftGPU/Clipper.h>
 #include <LibSoftGPU/Config.h>
-#include <LibSoftGPU/DeviceInfo.h>
 #include <LibSoftGPU/Enums.h>
 #include <LibSoftGPU/Image.h>
 #include <LibSoftGPU/ImageFormat.h>
@@ -112,8 +111,6 @@ struct StencilConfiguration {
 class Device final {
 public:
     Device(const Gfx::IntSize& min_size);
-
-    DeviceInfo info() const;
 
     void draw_primitives(PrimitiveType, FloatMatrix4x4 const& model_view_transform, FloatMatrix4x4 const& projection_transform, FloatMatrix4x4 const& texture_transform, Vector<Vertex> const& vertices, Vector<size_t> const& enabled_texture_units);
     void resize(Gfx::IntSize const& min_size);

--- a/Userland/Libraries/LibSoftGPU/DeviceInfo.h
+++ b/Userland/Libraries/LibSoftGPU/DeviceInfo.h
@@ -1,22 +1,26 @@
 /*
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include <AK/String.h>
+#include <AK/StringView.h>
+#include <LibGL/DeviceInfo.h>
+#include <LibSoftGPU/Config.h>
+#include <LibSoftGPU/Enums.h>
 
 namespace SoftGPU {
 
-struct DeviceInfo final {
-    String vendor_name;
-    String device_name;
-    unsigned num_texture_units;
-    unsigned num_lights;
-    u8 stencil_bits;
-    bool supports_npot_textures;
+static constexpr GL::DeviceInfo device_info {
+    .vendor_name = "SerenityOS"sv,
+    .device_name = "SoftGPU"sv,
+    .num_texture_units = NUM_SAMPLERS,
+    .num_lights = NUM_LIGHTS,
+    .stencil_bits = sizeof(StencilType) * 8,
+    .supports_npot_textures = true,
 };
 
 }


### PR DESCRIPTION
Problem:
- `Device::setup_blend_factors` is a private member function, but it can
  be free.
- DeviceInfo is only implemented in LibSoftGPU, but it is used in
  LibGL. LibGL should not have a dependency on LibSoftGPU if it is
  ever going to be a generic GL engine. This tight coupling makes it
  difficult to do some metaprogramming/constexpr-programming to remove
  some run-time computations.

Solution:
- There are several things within the Device and DeviceInfo which are
  configured statically, but cannot be used statically by LibGL. This is
  the first step towards making a more constexpr-friendly Device config.
- Decouple `DeviceInfo` from `Device` and move into LibGL and make an
  instance of it in LibSoftGPU which can be referenced.
- The specific instance of DeviceInfo is coupled to the
  `SoftGPU::Device` through namespace rather than included as a member
  variable of the instance. Since it doesn't change there is no need
  to be part of the instance.

Note: This is a step towards making it generic, but this does not
really remove the dependency yet.