### PR TITLE
Shell: Keep the stdio and rpath pledges for execute_process() / LibLine: Handle read events serially

### DIFF
--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -791,6 +791,13 @@ void Editor::handle_interrupt_event()
 
 void Editor::handle_read_event()
 {
+    if (m_prohibit_input_processing) {
+        m_have_unprocessed_read_event = true;
+        return;
+    }
+
+    auto prohibit_scope = prohibit_input();
+
     char keybuf[16];
     ssize_t nread = 0;
 

--- a/Userland/Libraries/LibLine/Editor.cpp
+++ b/Userland/Libraries/LibLine/Editor.cpp
@@ -827,9 +827,9 @@ void Editor::handle_read_event()
     }
 
     m_incomplete_data.append(keybuf, nread);
-    nread = m_incomplete_data.size();
+    auto available_bytes = m_incomplete_data.size();
 
-    if (nread == 0) {
+    if (available_bytes == 0) {
         m_input_error = Error::Empty;
         finish();
         return;
@@ -839,12 +839,12 @@ void Editor::handle_read_event()
 
     // Discard starting bytes until they make sense as utf-8.
     size_t valid_bytes = 0;
-    while (nread) {
-        Utf8View { StringView { m_incomplete_data.data(), (size_t)nread } }.validate(valid_bytes);
-        if (valid_bytes)
+    while (available_bytes > 0) {
+        Utf8View { StringView { m_incomplete_data.data(), available_bytes } }.validate(valid_bytes);
+        if (valid_bytes != 0)
             break;
         m_incomplete_data.take_first();
-        --nread;
+        --available_bytes;
     }
 
     Utf8View input_view { StringView { m_incomplete_data.data(), valid_bytes } };

--- a/Userland/Libraries/LibLine/Editor.h
+++ b/Userland/Libraries/LibLine/Editor.h
@@ -241,6 +241,20 @@ public:
 
     const Utf32View buffer_view() const { return { m_buffer.data(), m_buffer.size() }; }
 
+    auto prohibit_input()
+    {
+        auto previous_value = m_prohibit_input_processing;
+        m_prohibit_input_processing = true;
+        m_have_unprocessed_read_event = false;
+        return ScopeGuard {
+            [this, previous_value] {
+                m_prohibit_input_processing = previous_value;
+                if (!m_prohibit_input_processing && m_have_unprocessed_read_event)
+                    handle_read_event();
+            }
+        };
+    }
+
 private:
     explicit Editor(Configuration configuration = Configuration::from_config());
 
@@ -500,6 +514,8 @@ private:
     Vector<int, 2> m_signal_handlers;
 
     bool m_is_editing { false };
+    bool m_prohibit_input_processing { false };
+    bool m_have_unprocessed_read_event { false };
 
     Configuration m_configuration;
 };

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -846,7 +846,7 @@ void Shell::execute_process(Vector<const char*>&& argv)
 {
 #ifdef __serenity__
     for (auto& promise : m_active_promises) {
-        pledge("exec", promise.data.exec_promises.characters());
+        pledge("stdio rpath exec", promise.data.exec_promises.characters());
         for (auto& item : promise.data.unveils)
             unveil(item.path.characters(), item.access.characters());
     }


### PR DESCRIPTION
Fixes #13281.
Fixes #13280.
