### PR TITLE
Lagom: Allow compiling fuzzers as standalone programs

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -46,6 +46,7 @@ There are some optional features that can be enabled during compilation that are
 - `ENABLE_MEMORY_SANITIZER`: enables runtime checks for uninitialized memory accesses in Lagom test cases.
 - `ENABLE_UNDEFINED_SANITIZER`: builds in runtime checks for [undefined behavior](https://en.wikipedia.org/wiki/Undefined_behavior) (like null pointer dereferences and signed integer overflows) in Lagom test cases.
 - `ENABLE_COMPILER_EXPLORER_BUILD`: Skip building non-library entities in Lagom (this only applies to Lagom).
+- `ENABLE_FUZZERS`: builds [fuzzers](https://en.wikipedia.org/wiki/Fuzzing) for various parts of the system.
 - `ENABLE_FUZZERS_LIBFUZZER`: builds Clang libFuzzer-based [fuzzers](https://en.wikipedia.org/wiki/Fuzzing) for various parts of the system.
 - `ENABLE_FUZZERS_OSSFUZZ`: builds OSS-Fuzz compatible [fuzzers](https://en.wikipedia.org/wiki/Fuzzing) for various parts of the system.
 - `ENABLE_EXTRA_KERNEL_DEBUG_SYMBOLS`: sets -Og and -ggdb3 compile options for building the Kernel. Allows for easier debugging of Kernel code. By default, the Kernel is built with -O2 instead.

--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -46,7 +46,8 @@ There are some optional features that can be enabled during compilation that are
 - `ENABLE_MEMORY_SANITIZER`: enables runtime checks for uninitialized memory accesses in Lagom test cases.
 - `ENABLE_UNDEFINED_SANITIZER`: builds in runtime checks for [undefined behavior](https://en.wikipedia.org/wiki/Undefined_behavior) (like null pointer dereferences and signed integer overflows) in Lagom test cases.
 - `ENABLE_COMPILER_EXPLORER_BUILD`: Skip building non-library entities in Lagom (this only applies to Lagom).
-- `ENABLE_FUZZER_SANITIZER`: builds [fuzzers](https://en.wikipedia.org/wiki/Fuzzing) for various parts of the system.
+- `ENABLE_FUZZERS_LIBFUZZER`: builds Clang libFuzzer-based [fuzzers](https://en.wikipedia.org/wiki/Fuzzing) for various parts of the system.
+- `ENABLE_FUZZERS_OSSFUZZ`: builds OSS-Fuzz compatible [fuzzers](https://en.wikipedia.org/wiki/Fuzzing) for various parts of the system.
 - `ENABLE_EXTRA_KERNEL_DEBUG_SYMBOLS`: sets -Og and -ggdb3 compile options for building the Kernel. Allows for easier debugging of Kernel code. By default, the Kernel is built with -O2 instead.
 - `ENABLE_ALL_THE_DEBUG_MACROS`: used for checking whether debug code compiles on CI. This should not be set normally, as it clutters the console output and makes the system run very slowly. Instead, enable only the needed debug macros, as described below.
 - `ENABLE_ALL_DEBUG_FACILITIES`: used for checking whether debug code compiles on CI. Enables both `ENABLE_ALL_THE_DEBUG_MACROS` and `ENABLE_EXTRA_KERNEL_DEBUG_SYMBOLS`.

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -53,7 +53,7 @@ jobs:
           cmake -GNinja -B Build \
             -DBUILD_LAGOM=ON \
             -DENABLE_LAGOM_CCACHE=ON \
-            -DENABLE_FUZZER_SANITIZER=ON \
+            -DENABLE_FUZZERS_LIBFUZZER=ON \
             -DENABLE_ADDRESS_SANITIZER=ON \
             -DCMAKE_C_COMPILER=clang \
             -DCMAKE_CXX_COMPILER=clang++ \

--- a/Meta/CMake/lagom_options.cmake
+++ b/Meta/CMake/lagom_options.cmake
@@ -6,6 +6,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/common_options.cmake)
 
 serenity_option(ENABLE_ADDRESS_SANITIZER OFF CACHE BOOL "Enable address sanitizer testing in gcc/clang")
 serenity_option(ENABLE_MEMORY_SANITIZER OFF CACHE BOOL "Enable memory sanitizer testing in gcc/clang")
-serenity_option(ENABLE_FUZZER_SANITIZER OFF CACHE BOOL "Enable fuzzer sanitizer testing in clang")
+serenity_option(ENABLE_FUZZERS_LIBFUZZER OFF CACHE BOOL "Build fuzzers using Clang's libFuzzer")
+serenity_option(ENABLE_FUZZERS_OSSFUZZ OFF CACHE BOOL "Build OSS-Fuzz compatible fuzzers")
 serenity_option(BUILD_LAGOM OFF CACHE BOOL "Build parts of the system targeting the host OS for fuzzing/testing")
 serenity_option(ENABLE_LAGOM_CCACHE ON CACHE BOOL "Enable ccache for Lagom builds")

--- a/Meta/CMake/lagom_options.cmake
+++ b/Meta/CMake/lagom_options.cmake
@@ -6,6 +6,7 @@ include(${CMAKE_CURRENT_LIST_DIR}/common_options.cmake)
 
 serenity_option(ENABLE_ADDRESS_SANITIZER OFF CACHE BOOL "Enable address sanitizer testing in gcc/clang")
 serenity_option(ENABLE_MEMORY_SANITIZER OFF CACHE BOOL "Enable memory sanitizer testing in gcc/clang")
+serenity_option(ENABLE_FUZZERS OFF CACHE BOOL "Build fuzzing targets")
 serenity_option(ENABLE_FUZZERS_LIBFUZZER OFF CACHE BOOL "Build fuzzers using Clang's libFuzzer")
 serenity_option(ENABLE_FUZZERS_OSSFUZZ OFF CACHE BOOL "Build OSS-Fuzz compatible fuzzers")
 serenity_option(BUILD_LAGOM OFF CACHE BOOL "Build parts of the system targeting the host OS for fuzzing/testing")

--- a/Meta/Lagom/BuildFuzzers.sh
+++ b/Meta/Lagom/BuildFuzzers.sh
@@ -61,7 +61,7 @@ if [ "$#" -gt "0" ] && [ "--oss-fuzz" = "$1" ] ; then
     cmake -GNinja -B Build/fuzzers \
         -DBUILD_LAGOM=ON \
         -DBUILD_SHARED_LIBS=OFF \
-        -DENABLE_OSS_FUZZ=ON \
+        -DENABLE_FUZZERS_OSSFUZZ=ON \
         -DCMAKE_C_COMPILER="$CC" \
         -DCMAKE_CXX_COMPILER="$CXX" \
         -DCMAKE_CXX_FLAGS="$CXXFLAGS -DOSS_FUZZ=ON" \
@@ -74,7 +74,7 @@ else
     pick_clang
     cmake -GNinja -B Build/lagom-fuzzers \
         -DBUILD_LAGOM=ON \
-        -DENABLE_FUZZER_SANITIZER=ON \
+        -DENABLE_FUZZERS_LIBFUZZER=ON \
         -DENABLE_ADDRESS_SANITIZER=ON \
         -DENABLE_UNDEFINED_SANITIZER=ON \
         -DCMAKE_PREFIX_PATH=Build/tool-install \

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -55,6 +55,10 @@ if (ENABLE_LAGOM_CCACHE)
     endif()
 endif()
 
+if (ENABLE_FUZZERS_LIBFUZZER OR ENABLE_FUZZERS_OSSFUZZ)
+	set(ENABLE_FUZZERS ON)
+endif()
+
 include(wasm_spec_tests)
 
 add_compile_options(-fsigned-char)
@@ -64,7 +68,7 @@ add_compile_options(-Wall -Wextra -Werror)
 add_compile_options(-fPIC -g)
 add_compile_options(-Wno-maybe-uninitialized)
 add_compile_options(-fno-exceptions)
-if (NOT ENABLE_FUZZERS_LIBFUZZER)
+if (NOT ENABLE_FUZZERS)
     add_compile_options(-fno-semantic-interposition)
 endif()
 
@@ -105,12 +109,16 @@ if (ENABLE_UNDEFINED_SANITIZER)
     set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=undefined -fno-sanitize=vptr")
 endif()
 
+if (ENABLE_FUZZERS)
+    add_compile_options(-fno-omit-frame-pointer)
+endif()
+
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
     add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216)
 
     if (ENABLE_FUZZERS_LIBFUZZER)
-        add_compile_options(-fsanitize=fuzzer -fno-omit-frame-pointer)
+        add_compile_options(-fsanitize=fuzzer)
         set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=fuzzer")
     endif()
 
@@ -119,7 +127,8 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if (ENABLE_FUZZERS_LIBFUZZER)
         message(FATAL_ERROR
             "Fuzzer Sanitizer (-fsanitize=fuzzer) is only supported for Fuzzer targets with LLVM. "
-            "Reconfigure CMake with -DCMAKE_C_COMPILER and -DCMAKE_CXX_COMPILER pointing to a clang-based toolchain"
+            "Reconfigure CMake with -DCMAKE_C_COMPILER and -DCMAKE_CXX_COMPILER pointing to a clang-based toolchain "
+	    "or build binaries without built-in fuzzing support by setting -DENABLE_FUZZERS instead."
         )
     endif()
 endif()
@@ -173,7 +182,7 @@ function(lagom_lib library fs_name)
 
     # Don't make alias when we're going to import a previous build for Tools
     # FIXME: Is there a better way to write this?
-    if (NOT ENABLE_FUZZERS_OSSFUZZ AND NOT ENABLE_FUZZERS_LIBFUZZER)
+    if (NOT ENABLE_FUZZERS)
         # alias for parity with exports
         add_library(Lagom::${library} ALIAS ${target_name})
     endif()
@@ -272,7 +281,7 @@ install(
 # Code Generators and other host tools
 # We need to make sure not to build code generators for Fuzzer builds, as they already have their own main.cpp
 # Instead, we import them from a previous install of Lagom. This mandates a two-stage build for fuzzers.
-if (ENABLE_FUZZERS_OSSFUZZ OR ENABLE_FUZZERS_LIBFUZZER)
+if (ENABLE_FUZZERS)
     find_package(Lagom REQUIRED)
 else()
     add_subdirectory(Tools)
@@ -482,7 +491,7 @@ if (BUILD_LAGOM)
     lagom_lib(XML xml
         SOURCES ${LIBXML_SOURCES})
 
-    if (NOT ENABLE_FUZZERS_OSSFUZZ AND NOT ENABLE_FUZZERS_LIBFUZZER AND NOT ENABLE_COMPILER_EXPLORER_BUILD)
+    if (NOT ENABLE_FUZZERS AND NOT ENABLE_COMPILER_EXPLORER_BUILD)
         # Lagom Examples
         add_executable(TestApp TestApp.cpp)
         target_link_libraries(TestApp LagomCore)
@@ -710,6 +719,6 @@ if (BUILD_LAGOM)
     endif()
 endif()
 
-if (ENABLE_FUZZERS_LIBFUZZER OR ENABLE_FUZZERS_OSSFUZZ)
+if (ENABLE_FUZZERS)
     add_subdirectory(Fuzzers)
 endif()

--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -64,7 +64,7 @@ add_compile_options(-Wall -Wextra -Werror)
 add_compile_options(-fPIC -g)
 add_compile_options(-Wno-maybe-uninitialized)
 add_compile_options(-fno-exceptions)
-if (NOT ENABLE_FUZZER_SANITIZER)
+if (NOT ENABLE_FUZZERS_LIBFUZZER)
     add_compile_options(-fno-semantic-interposition)
 endif()
 
@@ -109,14 +109,14 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
     # Clang's default constexpr-steps limit is 1048576(2^20), GCC doesn't have one
     add_compile_options(-Wno-overloaded-virtual -Wno-user-defined-literals -fconstexpr-steps=16777216)
 
-    if (ENABLE_FUZZER_SANITIZER)
+    if (ENABLE_FUZZERS_LIBFUZZER)
         add_compile_options(-fsanitize=fuzzer -fno-omit-frame-pointer)
         set(LINKER_FLAGS "${LINKER_FLAGS} -fsanitize=fuzzer")
     endif()
 
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     add_compile_options(-Wno-expansion-to-defined)
-    if (ENABLE_FUZZER_SANITIZER)
+    if (ENABLE_FUZZERS_LIBFUZZER)
         message(FATAL_ERROR
             "Fuzzer Sanitizer (-fsanitize=fuzzer) is only supported for Fuzzer targets with LLVM. "
             "Reconfigure CMake with -DCMAKE_C_COMPILER and -DCMAKE_CXX_COMPILER pointing to a clang-based toolchain"
@@ -173,7 +173,7 @@ function(lagom_lib library fs_name)
 
     # Don't make alias when we're going to import a previous build for Tools
     # FIXME: Is there a better way to write this?
-    if (NOT ENABLE_OSS_FUZZ AND NOT ENABLE_FUZZER_SANITIZER)
+    if (NOT ENABLE_FUZZERS_OSSFUZZ AND NOT ENABLE_FUZZERS_LIBFUZZER)
         # alias for parity with exports
         add_library(Lagom::${library} ALIAS ${target_name})
     endif()
@@ -272,7 +272,7 @@ install(
 # Code Generators and other host tools
 # We need to make sure not to build code generators for Fuzzer builds, as they already have their own main.cpp
 # Instead, we import them from a previous install of Lagom. This mandates a two-stage build for fuzzers.
-if (ENABLE_OSS_FUZZ OR ENABLE_FUZZER_SANITIZER)
+if (ENABLE_FUZZERS_OSSFUZZ OR ENABLE_FUZZERS_LIBFUZZER)
     find_package(Lagom REQUIRED)
 else()
     add_subdirectory(Tools)
@@ -482,7 +482,7 @@ if (BUILD_LAGOM)
     lagom_lib(XML xml
         SOURCES ${LIBXML_SOURCES})
 
-    if (NOT ENABLE_OSS_FUZZ AND NOT ENABLE_FUZZER_SANITIZER AND NOT ENABLE_COMPILER_EXPLORER_BUILD)
+    if (NOT ENABLE_FUZZERS_OSSFUZZ AND NOT ENABLE_FUZZERS_LIBFUZZER AND NOT ENABLE_COMPILER_EXPLORER_BUILD)
         # Lagom Examples
         add_executable(TestApp TestApp.cpp)
         target_link_libraries(TestApp LagomCore)
@@ -710,6 +710,6 @@ if (BUILD_LAGOM)
     endif()
 endif()
 
-if (ENABLE_FUZZER_SANITIZER OR ENABLE_OSS_FUZZ)
+if (ENABLE_FUZZERS_LIBFUZZER OR ENABLE_FUZZERS_OSSFUZZ)
     add_subdirectory(Fuzzers)
 endif()

--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -12,6 +12,9 @@ function(add_simple_fuzzer name)
       PUBLIC ${ARGN} LagomCore
       PRIVATE $<$<CXX_COMPILER_ID:Clang>:-fsanitize=fuzzer>
       )
+  else()
+    target_sources(${name} PRIVATE "EntryShim.cpp")
+    target_link_libraries(${name} PUBLIC ${ARGN} LagomCore)
   endif()
 endfunction()
 

--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -4,7 +4,7 @@ function(add_simple_fuzzer name)
   if (ENABLE_FUZZERS_OSSFUZZ)
       target_link_libraries(${name}
           PUBLIC ${ARGN} LagomCore)
-  else()
+  elseif (ENABLE_FUZZERS_LIBFUZZER)
     target_compile_options(${name}
       PRIVATE $<$<CXX_COMPILER_ID:Clang>:-g -O1 -fsanitize=fuzzer>
       )
@@ -63,7 +63,7 @@ add_simple_fuzzer(FuzzWasmParser LagomWasm)
 add_simple_fuzzer(FuzzZip LagomArchive)
 add_simple_fuzzer(FuzzZlibDecompression LagomCompress)
 
-if (NOT ENABLE_FUZZERS_OSSFUZZ)
+if (ENABLE_FUZZERS_LIBFUZZER)
 set(CMAKE_EXE_LINKER_FLAGS "${ORIGINAL_CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
 set(CMAKE_SHARED_LINKER_FLAGS "${ORIGINAL_CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
 set(CMAKE_MODULE_LINKER_FLAGS "${ORIGINAL_CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")

--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -1,7 +1,7 @@
 function(add_simple_fuzzer name)
   add_executable(${name} "${name}.cpp")
 
-  if (ENABLE_OSS_FUZZ)
+  if (ENABLE_FUZZERS_OSSFUZZ)
       target_link_libraries(${name}
           PUBLIC ${ARGN} LagomCore)
   else()
@@ -63,7 +63,7 @@ add_simple_fuzzer(FuzzWasmParser LagomWasm)
 add_simple_fuzzer(FuzzZip LagomArchive)
 add_simple_fuzzer(FuzzZlibDecompression LagomCompress)
 
-if (NOT ENABLE_OSS_FUZZ)
+if (NOT ENABLE_FUZZERS_OSSFUZZ)
 set(CMAKE_EXE_LINKER_FLAGS "${ORIGINAL_CMAKE_EXE_LINKER_FLAGS} -fsanitize=address")
 set(CMAKE_SHARED_LINKER_FLAGS "${ORIGINAL_CMAKE_SHARED_LINKER_FLAGS} -fsanitize=address")
 set(CMAKE_MODULE_LINKER_FLAGS "${ORIGINAL_CMAKE_MODULE_LINKER_FLAGS} -fsanitize=address")

--- a/Meta/Lagom/Fuzzers/EntryShim.cpp
+++ b/Meta/Lagom/Fuzzers/EntryShim.cpp
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <fcntl.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t size);
+
+int fuzz_from_file(const char* filename)
+{
+    struct stat file_stats;
+
+    if (stat(filename, &file_stats) < 0) {
+        perror("EntryShim: Failed to stat the input file");
+        return 1;
+    }
+
+    size_t file_size = file_stats.st_size;
+
+    uint8_t* file_buffer = (uint8_t*)malloc(file_size);
+
+    if (!file_buffer) {
+        fprintf(stderr, "EntryShim: Failed to allocate file buffer\n");
+        return 1;
+    }
+
+    int fd = open(filename, O_RDONLY);
+
+    if (fd < 0) {
+        perror("EntryShim: Failed to open the input file");
+        return 1;
+    }
+
+    ssize_t bytes_read = read(fd, file_buffer, file_size);
+    if (bytes_read < 0) {
+        fprintf(stderr, "EntryShim: Failed to read the input file\n");
+        return 1;
+    }
+
+    LLVMFuzzerTestOneInput(file_buffer, bytes_read);
+    return 0;
+}
+
+int fuzz_from_stdin()
+{
+    size_t chunk_size = 4096;
+
+    uint8_t* file_buffer = nullptr;
+    size_t file_size = 0;
+
+    while (true) {
+        file_buffer = (uint8_t*)realloc(file_buffer, file_size + chunk_size);
+
+        if (!file_buffer) {
+            fprintf(stderr, "EntryShim: Failed to reallocate buffer to a size of %lu bytes\n", file_size + chunk_size);
+            return 1;
+        }
+
+        ssize_t bytes_read = read(STDIN_FILENO, file_buffer + file_size, chunk_size);
+
+        if (bytes_read < 0) {
+            perror("EntryShim: Failed to read from stdin");
+            return 1;
+        }
+
+        if (bytes_read == 0)
+            break;
+
+        file_size += bytes_read;
+    }
+
+    LLVMFuzzerTestOneInput(file_buffer, file_size);
+    return 0;
+}
+
+extern "C" int main(int argc, char** argv)
+{
+    if (argc > 1)
+        return fuzz_from_file(argv[1]);
+
+    return fuzz_from_stdin();
+}

--- a/Meta/Lagom/Fuzzers/FuzzilliJs.dockerfile
+++ b/Meta/Lagom/Fuzzers/FuzzilliJs.dockerfile
@@ -39,7 +39,7 @@ RUN sed -i 's/-Wmissing-declarations //' ../CMakeLists.txt
 RUN CXXFLAGS="-Wno-defaulted-function-deleted" \
     cmake -GNinja \
           -DBUILD_LAGOM=ON \
-          -DENABLE_FUZZER_SANITIZER=ON \
+          -DENABLE_FUZZERS_LIBFUZZER=ON \
           -DCMAKE_C_COMPILER=clang \
           -DCMAKE_CXX_COMPILER=clang++ \
           ..

--- a/Meta/Lagom/ReadMe.md
+++ b/Meta/Lagom/ReadMe.md
@@ -27,7 +27,7 @@ the ``BuildFuzzers.sh`` script with no arguments. The script does the equivalent
     # Stage 2: Build fuzzers, making sure the build can find the tools we just built
     cmake -GNinja -B Build/lagom-fuzzers \
       -DBUILD_LAGOM=ON \
-      -DENABLE_FUZZER_SANITIZER=ON \
+      -DENABLE_FUZZERS_LIBFUZZER=ON \
       -DENABLE_ADDRESS_SANITIZER=ON \
       -DENABLE_UNDEFINED_SANITIZER=ON \
       -DCMAKE_PREFIX_PATH=Build/tool-install \
@@ -72,7 +72,7 @@ Feel free to upload lots and lots files there, or use them for great good!
 
 ### Fuzzing on OSS-Fuzz
 
-https://oss-fuzz.com/ automatically runs all fuzzers in the Fuzzers/ subdirectory whose name starts with "Fuzz" and which are added to the build in `Fuzzers/CMakeLists.txt` if `ENABLE_OSS_FUZZ` is set. Looking for "serenity" on oss-fuzz.com finds interesting links, in particular:
+https://oss-fuzz.com/ automatically runs all fuzzers in the Fuzzers/ subdirectory whose name starts with "Fuzz" and which are added to the build in `Fuzzers/CMakeLists.txt` if `ENABLE_FUZZERS_OSSFUZZ` is set. Looking for "serenity" on oss-fuzz.com finds interesting links, in particular:
 
 * [known open bugs found by fuzzers](https://oss-fuzz.com/testcases?project=serenity&open=yes)
   * [oss-fuzz bug tracker for these](https://bugs.chromium.org/p/oss-fuzz/issues/list?sort=-opened&can=1&q=proj:serenity)


### PR DESCRIPTION
This adds a small shim into each fuzzer that reads data from `stdin` or from a file and passes it to the existing `LLVMFuzzerTestOneInput` function. Binaries for OSS-Fuzz or binaries that include `-fsanitize=fuzzer` remain unchanged.

Reading from `stdin` makes the binaries compatible with most existing fuzzers. Reading from a file is a nice bonus, but is mainly intended for allowing to read the input data in one go, as repeated reallocations and memory movements may confuse certain fuzzers more than necessary.

The shim is intentionally written in rather basic C, as it represents the underlying syscalls quite closely.