### PR TITLE
Everywhere: Rename CommandResult stdout & stderr members to output & error

### DIFF
--- a/Userland/DevTools/HackStudio/Git/GitRepo.cpp
+++ b/Userland/DevTools/HackStudio/Git/GitRepo.cpp
@@ -83,7 +83,7 @@ String GitRepo::command_wrapper(Vector<String> const& command_parts, String cons
     auto result = Core::command("git", command_parts, LexicalPath(chdir));
     if (result.is_error() || result.value().exit_code != 0)
         return {};
-    return result.value().stdout;
+    return result.value().output;
 }
 
 bool GitRepo::git_is_installed()

--- a/Userland/DevTools/HackStudio/ProjectBuilder.cpp
+++ b/Userland/DevTools/HackStudio/ProjectBuilder.cpp
@@ -193,7 +193,7 @@ void ProjectBuilder::for_each_library_definition(Function<void(String, String)> 
     }
 
     static const Regex<ECMA262> parse_library_definition(R"~~~(.+:serenity_lib[c]?\((\w+) (\w+)\).*)~~~");
-    for (auto& line : res.value().stdout.split('\n')) {
+    for (auto& line : res.value().output.split('\n')) {
         RegexResult result;
         if (!parse_library_definition.search(line, result))
             continue;
@@ -220,7 +220,7 @@ void ProjectBuilder::for_each_library_dependencies(Function<void(String, Vector<
     }
 
     static const Regex<ECMA262> parse_library_definition(R"~~~(.+:target_link_libraries\((\w+) ([\w\s]+)\).*)~~~");
-    for (auto& line : res.value().stdout.split('\n')) {
+    for (auto& line : res.value().output.split('\n')) {
 
         RegexResult result;
         if (!parse_library_definition.search(line, result))

--- a/Userland/Libraries/LibCore/Command.cpp
+++ b/Userland/Libraries/LibCore/Command.cpp
@@ -80,8 +80,8 @@ ErrorOr<CommandResult> command(String const& program, Vector<String> const& argu
         }
         return String::copy(result_file->read_all());
     };
-    auto stdout = read_all_from_pipe(stdout_pipe);
-    auto stderr = read_all_from_pipe(stderr_pipe);
+    auto output = read_all_from_pipe(stdout_pipe);
+    auto error = read_all_from_pipe(stderr_pipe);
 
     int wstatus { 0 };
     waitpid(pid, &wstatus, 0);
@@ -94,7 +94,7 @@ ErrorOr<CommandResult> command(String const& program, Vector<String> const& argu
 #    endif
     }
 
-    return CommandResult { WEXITSTATUS(wstatus), stdout, stderr };
+    return CommandResult { WEXITSTATUS(wstatus), output, error };
 }
 
 #endif

--- a/Userland/Libraries/LibCore/Command.h
+++ b/Userland/Libraries/LibCore/Command.h
@@ -17,8 +17,8 @@ namespace Core {
 
 struct CommandResult {
     int exit_code { 0 };
-    String stdout;
-    String stderr;
+    String output;
+    String error;
 };
 
 ErrorOr<CommandResult> command(String const& program, Vector<String> const& arguments, Optional<LexicalPath> chdir);


### PR DESCRIPTION
The names `stdout` / `stderr` are bound to conflict with existing
declarations when compiling against other LibC's. The build on OpenBSD
is broken for this reason at the moment.

Lets rename the members to more generic names to resolve the situation.