### PR TITLE
LibC+LibAudio: Fix more minor issues found by static analysis

### DIFF
--- a/Userland/Libraries/LibAudio/Resampler.h
+++ b/Userland/Libraries/LibAudio/Resampler.h
@@ -80,8 +80,8 @@ private:
     const u32 m_source;
     const u32 m_target;
     u32 m_current_ratio { 0 };
-    SampleType m_last_sample_l;
-    SampleType m_last_sample_r;
+    SampleType m_last_sample_l {};
+    SampleType m_last_sample_r {};
 };
 
 class Buffer;

--- a/Userland/Libraries/LibC/unistd.cpp
+++ b/Userland/Libraries/LibC/unistd.cpp
@@ -438,6 +438,7 @@ static int ttyname_r_for_directory(const char* directory_name, dev_t device_mode
             struct stat st;
             if (lstat(name_path, &st) < 0) {
                 free(name_path);
+                name_path = nullptr;
                 continue;
             }
 


### PR DESCRIPTION
- Potential double free memory corruption in LibC:
- Uninitialized member variables in LibAudio.
 
Found by Static Analysis: Sonar Cloud