### PR TITLE
LibJS/Bytecode: Implement the delete unary expression and a couple of other improvements

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -427,6 +427,9 @@ Bytecode::CodeGenerationErrorOr<void> LogicalExpression::generate_bytecode(Bytec
 
 Bytecode::CodeGenerationErrorOr<void> UnaryExpression::generate_bytecode(Bytecode::Generator& generator) const
 {
+    if (m_op == UnaryOp::Delete)
+        return generator.emit_delete_reference(m_lhs);
+
     TRY(m_lhs->generate_bytecode(generator));
 
     switch (m_op) {
@@ -448,11 +451,9 @@ Bytecode::CodeGenerationErrorOr<void> UnaryExpression::generate_bytecode(Bytecod
     case UnaryOp::Void:
         generator.emit<Bytecode::Op::LoadImmediate>(js_undefined());
         break;
+    case UnaryOp::Delete: // Delete is implemented above.
     default:
-        return Bytecode::CodeGenerationError {
-            this,
-            "Unimplemented operation"sv,
-        };
+        VERIFY_NOT_REACHED();
     }
 
     return {};

--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -1999,7 +1999,11 @@ static Bytecode::CodeGenerationErrorOr<void> for_in_of_body_evaluation(Bytecode:
     //         3. If iteratorKind is async, return ? AsyncIteratorClose(iteratorRecord, status).
     //         4. Return ? IteratorClose(iteratorRecord, status).
     // o. If result.[[Value]] is not empty, set V to result.[[Value]].
-    generator.emit<Bytecode::Op::Jump>().set_targets(Bytecode::Label { loop_update }, {});
+
+    // The body can contain an unconditional block terminator (e.g. return, throw), so we have to check for that before generating the Jump.
+    if (!generator.is_current_block_terminated())
+        generator.emit<Bytecode::Op::Jump>().set_targets(Bytecode::Label { loop_update }, {});
+
     generator.switch_to_basic_block(loop_end);
     return {};
 }

--- a/Userland/Libraries/LibJS/Bytecode/Generator.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.cpp
@@ -137,10 +137,10 @@ CodeGenerationErrorOr<void> Generator::emit_load_from_reference(JS::ASTNode cons
         auto& expression = static_cast<MemberExpression const&>(node);
         TRY(expression.object().generate_bytecode(*this));
 
-        auto object_reg = allocate_register();
-        emit<Bytecode::Op::Store>(object_reg);
-
         if (expression.is_computed()) {
+            auto object_reg = allocate_register();
+            emit<Bytecode::Op::Store>(object_reg);
+
             TRY(expression.property().generate_bytecode(*this));
             emit<Bytecode::Op::GetByValue>(object_reg);
         } else if (expression.property().is_identifier()) {

--- a/Userland/Libraries/LibJS/Bytecode/Generator.h
+++ b/Userland/Libraries/LibJS/Bytecode/Generator.h
@@ -79,6 +79,7 @@ public:
 
     CodeGenerationErrorOr<void> emit_load_from_reference(JS::ASTNode const&);
     CodeGenerationErrorOr<void> emit_store_to_reference(JS::ASTNode const&);
+    CodeGenerationErrorOr<void> emit_delete_reference(JS::ASTNode const&);
 
     void begin_continuable_scope(Label continue_target);
     void end_continuable_scope();

--- a/Userland/Libraries/LibJS/Bytecode/Instruction.h
+++ b/Userland/Libraries/LibJS/Bytecode/Instruction.h
@@ -23,6 +23,9 @@
     O(CreateEnvironment)             \
     O(CreateVariable)                \
     O(Decrement)                     \
+    O(DeleteById)                    \
+    O(DeleteByValue)                 \
+    O(DeleteVariable)                \
     O(Div)                           \
     O(EnterUnwindContext)            \
     O(EnterObjectEnvironment)        \

--- a/Userland/Libraries/LibJS/Bytecode/Op.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/Op.cpp
@@ -725,13 +725,7 @@ String NewArray::to_string_impl(Bytecode::Executable const&) const
     StringBuilder builder;
     builder.append("NewArray");
     if (m_element_count != 0) {
-        builder.append(" [");
-        for (size_t i = 0; i < m_element_count; ++i) {
-            builder.appendff("{}", m_elements[i]);
-            if (i != m_element_count - 1)
-                builder.append(',');
-        }
-        builder.append(']');
+        builder.appendff(" [{}-{}]", m_elements[0], m_elements[1]);
     }
     return builder.to_string();
 }

--- a/Userland/Libraries/LibJS/Bytecode/Op.h
+++ b/Userland/Libraries/LibJS/Bytecode/Op.h
@@ -378,6 +378,22 @@ private:
     Optional<EnvironmentCoordinate> mutable m_cached_environment_coordinate;
 };
 
+class DeleteVariable final : public Instruction {
+public:
+    explicit DeleteVariable(IdentifierTableIndex identifier)
+        : Instruction(Type::DeleteVariable)
+        , m_identifier(identifier)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    String to_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+
+private:
+    IdentifierTableIndex m_identifier;
+};
+
 class GetById final : public Instruction {
 public:
     explicit GetById(IdentifierTableIndex property)
@@ -409,6 +425,22 @@ public:
 
 private:
     Register m_base;
+    IdentifierTableIndex m_property;
+};
+
+class DeleteById final : public Instruction {
+public:
+    explicit DeleteById(IdentifierTableIndex property)
+        : Instruction(Type::DeleteById)
+        , m_property(property)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    String to_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+
+private:
     IdentifierTableIndex m_property;
 };
 
@@ -444,6 +476,22 @@ public:
 private:
     Register m_base;
     Register m_property;
+};
+
+class DeleteByValue final : public Instruction {
+public:
+    DeleteByValue(Register base)
+        : Instruction(Type::DeleteByValue)
+        , m_base(base)
+    {
+    }
+
+    ThrowCompletionOr<void> execute_impl(Bytecode::Interpreter&) const;
+    String to_string_impl(Bytecode::Executable const&) const;
+    void replace_references_impl(BasicBlock const&, BasicBlock const&) { }
+
+private:
+    Register m_base;
 };
 
 class Jump : public Instruction {


### PR DESCRIPTION
```
Summary:
    Diff Tests:
        +3068 ✅   +862 ❌   +1 💀   +120 💥️    -4051 📝
```

(This is lower than what I originally showed on Discord as the results I posted on Discord had a `super` implementation, which is not included in this PR)