### PR TITLE
LibWeb: Table layout improvements

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/BlockFormattingContext.cpp
@@ -96,7 +96,19 @@ void BlockFormattingContext::compute_width(Box const& box, LayoutMode layout_mod
     }
 
     auto const& computed_values = box.computed_values();
-    float width_of_containing_block = m_state.get(*box.containing_block()).content_width;
+    float width_of_containing_block;
+    switch (layout_mode) {
+    case LayoutMode::Normal:
+        width_of_containing_block = m_state.get(*box.containing_block()).content_width;
+        break;
+    case LayoutMode::MinContent:
+        width_of_containing_block = 0;
+        break;
+    case LayoutMode::MaxContent:
+        width_of_containing_block = INFINITY;
+        break;
+    }
+
     auto width_of_containing_block_as_length = CSS::Length::make_px(width_of_containing_block);
 
     auto zero_value = CSS::Length::make_px(0);

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -118,14 +118,19 @@ void TableFormattingContext::layout_row(Box const& row, Vector<float>& column_wi
         tallest_cell_height = max(tallest_cell_height, cell_state.border_box_height());
     });
 
+    row_state.content_height = tallest_cell_height;
+
+    row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
+        auto& cell_state = m_state.get_mutable(cell);
+        cell_state.content_height = tallest_cell_height - cell_state.border_box_top() - cell_state.border_box_bottom();
+    });
+
     if (use_auto_layout) {
         row_state.content_width = content_width;
     } else {
         auto& table_state = m_state.get_mutable(*table);
         row_state.content_width = table_state.content_width;
     }
-
-    row_state.content_height = tallest_cell_height;
 }
 
 }

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -125,6 +125,11 @@ void TableFormattingContext::layout_row(Box const& row, Vector<float>& column_wi
     row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
         auto& cell_state = m_state.get_mutable(cell);
 
+        float span_width = 0;
+        for (size_t i = 0; i < cell.colspan(); ++i)
+            span_width += column_widths[column_index++];
+        cell_state.content_width = span_width - cell_state.border_box_left() - cell_state.border_box_right();
+
         BlockFormattingContext::compute_height(cell, m_state);
         cell_state.offset = row_state.offset.translated(cell_state.border_box_left() + content_width, cell_state.border_box_top());
 
@@ -135,9 +140,7 @@ void TableFormattingContext::layout_row(Box const& row, Vector<float>& column_wi
             (void)layout_inside(cell, LayoutMode::Normal);
         }
 
-        size_t cell_colspan = cell.colspan();
-        for (size_t i = 0; i < cell_colspan; ++i)
-            content_width += column_widths[column_index++];
+        content_width += span_width;
         tallest_cell_height = max(tallest_cell_height, cell_state.border_box_height());
     });
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -91,8 +91,25 @@ void TableFormattingContext::calculate_column_widths(Box const& row, Vector<floa
         } else {
             (void)layout_inside(cell, LayoutMode::Normal);
         }
-        column_widths[column_index] = max(column_widths[column_index], cell_state.border_box_width());
+        if (cell.colspan() == 1)
+            column_widths[column_index] = max(column_widths[column_index], cell_state.border_box_width());
         column_index += cell.colspan();
+    });
+    column_index = 0;
+    row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
+        auto& cell_state = m_state.get_mutable(cell);
+        size_t colspan = cell.colspan();
+        if (colspan != 1) {
+            float missing = cell_state.border_box_width();
+            for (size_t i = 0; i < colspan; ++i)
+                missing -= column_widths[column_index + i];
+            if (missing > 0) {
+                float extra = missing / (float)colspan;
+                for (size_t i = 0; i < colspan; ++i)
+                    column_widths[column_index + i] += extra;
+            }
+        }
+        column_index += colspan;
     });
 }
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -44,6 +44,12 @@ void TableFormattingContext::run(Box const& box, LayoutMode)
             calculate_column_widths(row, column_widths);
         });
 
+        float missing_width = box_state.content_width;
+        for (auto column_width : column_widths)
+            missing_width -= column_width;
+        if (missing_width > 0)
+            column_widths[column_widths.size() - 1] += missing_width;
+
         float content_width = 0;
         float content_height = 0;
 

--- a/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/TableFormattingContext.cpp
@@ -85,7 +85,7 @@ void TableFormattingContext::calculate_column_widths(Box const& row, Vector<floa
     bool use_auto_layout = !table || (!table->computed_values().width().has_value() || (table->computed_values().width()->is_length() && table->computed_values().width()->length().is_auto()));
     row.for_each_child_of_type<TableCellBox>([&](auto& cell) {
         auto& cell_state = m_state.get_mutable(cell);
-        compute_width(cell);
+        compute_width(cell, LayoutMode::MinContent);
         if (use_auto_layout) {
             (void)layout_inside(cell, LayoutMode::MaxContent);
         } else {


### PR DESCRIPTION
Here are some changes to how table cell sizes are handled, which allows us to render GitHub diffs (almost) correctly:

![Diff of "LibWeb: Expand the last cell in a row to the right edge" in Browser](https://user-images.githubusercontent.com/4679350/160404482-ad363184-4642-4e19-9046-a272bd4781fa.png)
