### PR TITLE
LibJS: Big batch of editorial / normative changes to `Intl`

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeNumberFormat.cpp
@@ -26,6 +26,7 @@
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibCore/Stream.h>
+#include <LibJS/Runtime/Intl/AbstractOperations.h>
 #include <LibUnicode/Locale.h>
 #include <LibUnicode/NumberFormat.h>
 #include <math.h>
@@ -631,11 +632,9 @@ static ErrorOr<void> parse_units(String locale_units_path, UnicodeLocaleData& lo
     };
 
     auto is_sanctioned_unit = [](StringView unit_name) {
-        // This is a copy of the units sanctioned for use within ECMA-402. LibUnicode generally tries to
-        // avoid being directly dependent on ECMA-402, but this rather significantly reduces the amount
+        // LibUnicode generally tries to avoid being directly dependent on ECMA-402, but this rather significantly reduces the amount
         // of data generated here, and ECMA-402 is currently the only consumer of this data.
-        // https://tc39.es/ecma402/#table-sanctioned-simple-unit-identifiers
-        constexpr auto sanctioned_units = AK::Array { "acre"sv, "bit"sv, "byte"sv, "celsius"sv, "centimeter"sv, "day"sv, "degree"sv, "fahrenheit"sv, "fluid-ounce"sv, "foot"sv, "gallon"sv, "gigabit"sv, "gigabyte"sv, "gram"sv, "hectare"sv, "hour"sv, "inch"sv, "kilobit"sv, "kilobyte"sv, "kilogram"sv, "kilometer"sv, "liter"sv, "megabit"sv, "megabyte"sv, "meter"sv, "mile"sv, "mile-scandinavian"sv, "milliliter"sv, "millimeter"sv, "millisecond"sv, "minute"sv, "month"sv, "ounce"sv, "percent"sv, "petabyte"sv, "pound"sv, "second"sv, "stone"sv, "terabit"sv, "terabyte"sv, "week"sv, "yard"sv, "year"sv };
+        constexpr auto sanctioned_units = JS::Intl::sanctioned_single_unit_identifiers();
         return find(sanctioned_units.begin(), sanctioned_units.end(), unit_name) != sanctioned_units.end();
     };
 

--- a/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayPrototype.cpp
@@ -407,7 +407,7 @@ JS_DEFINE_NATIVE_FUNCTION(ArrayPrototype::to_locale_string)
     // 2. Let len be ? ToLength(? Get(array, "length")).
     auto length = TRY(length_of_array_like(global_object, *this_object));
 
-    // 3. Let separator be the String value for the list-separator String appropriate for the host environment's current locale (this is derived in an implementation-defined way).
+    // 3. Let separator be the implementation-defined list-separator String value appropriate for the host environment's current locale (such as ", ").
     constexpr auto separator = ","sv;
 
     // 4. Let R be the empty String.

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -121,15 +121,15 @@ String canonicalize_unicode_locale_id(Unicode::LocaleID& locale)
     return locale_id.release_value();
 }
 
-// 6.3.1 IsWellFormedCurrencyCode ( currency ), https://tc39.es/ecma402/#sec-canonicalcodefordisplaynames
+// 6.3.1 IsWellFormedCurrencyCode ( currency ), https://tc39.es/ecma402/#sec-iswellformedcurrencycode
 bool is_well_formed_currency_code(StringView currency)
 {
-    // 1. Let normalized be the result of mapping currency to upper case as described in 6.1.
-    // 2. If the number of elements in normalized is not 3, return false.
+    // 1. If the length of currency is not 3, return false.
     if (currency.length() != 3)
         return false;
 
-    // 3. If normalized contains any character that is not in the range "A" to "Z" (U+0041 to U+005A), return false.
+    // 2. Let normalized be the ASCII-uppercase of currency.
+    // 3. If normalized contains any code unit outside of 0x0041 through 0x005A (corresponding to Unicode characters LATIN CAPITAL LETTER A through LATIN CAPITAL LETTER Z), return false.
     if (!all_of(currency, is_ascii_alpha))
         return false;
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -201,7 +201,7 @@ ThrowCompletionOr<Vector<String>> canonicalize_locale_list(GlobalObject& global_
     Object* object = nullptr;
     // 3. If Type(locales) is String or Type(locales) is Object and locales has an [[InitializedLocale]] internal slot, then
     if (locales.is_string() || (locales.is_object() && is<Locale>(locales.as_object()))) {
-        // a. Let O be CreateArrayFromList(« locales »).
+        // a. Let O be ! CreateArrayFromList(« locales »).
         object = Array::create_from(global_object, { locales });
     }
     // 4. Else,
@@ -245,12 +245,12 @@ ThrowCompletionOr<Vector<String>> canonicalize_locale_list(GlobalObject& global_
                 tag = TRY(key_value.to_string(global_object));
             }
 
-            // v. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+            // v. If ! IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
             auto locale_id = is_structurally_valid_language_tag(tag);
             if (!locale_id.has_value())
                 return vm.throw_completion<RangeError>(global_object, ErrorType::IntlInvalidLanguageTag, tag);
 
-            // vi. Let canonicalizedTag be CanonicalizeUnicodeLocaleId(tag).
+            // vi. Let canonicalizedTag be ! CanonicalizeUnicodeLocaleId(tag).
             auto canonicalized_tag = JS::Intl::canonicalize_unicode_locale_id(*locale_id);
 
             // vii. If canonicalizedTag is not an element of seen, append canonicalizedTag as the last element of seen.
@@ -310,7 +310,7 @@ static MatcherResult lookup_matcher(Vector<String> const& requested_locales)
         auto extensions = locale_id->remove_extension_type<Unicode::LocaleExtension>();
         auto no_extensions_locale = locale_id->to_string();
 
-        // b. Let availableLocale be BestAvailableLocale(availableLocales, noExtensionsLocale).
+        // b. Let availableLocale be ! BestAvailableLocale(availableLocales, noExtensionsLocale).
         auto available_locale = best_available_locale(no_extensions_locale);
 
         // c. If availableLocale is not undefined, then
@@ -330,7 +330,7 @@ static MatcherResult lookup_matcher(Vector<String> const& requested_locales)
         }
     }
 
-    // 3. Let defLocale be DefaultLocale().
+    // 3. Let defLocale be ! DefaultLocale().
     // 4. Set result.[[locale]] to defLocale.
     result.locale = Unicode::default_locale();
 
@@ -386,12 +386,12 @@ LocaleResult resolve_locale(Vector<String> const& requested_locales, LocaleOptio
 
     // 2. If matcher is "lookup", then
     if (matcher.is_string() && (matcher.as_string().string() == "lookup"sv)) {
-        // a. Let r be LookupMatcher(availableLocales, requestedLocales).
+        // a. Let r be ! LookupMatcher(availableLocales, requestedLocales).
         matcher_result = lookup_matcher(requested_locales);
     }
     // 3. Else,
     else {
-        // a. Let r be BestFitMatcher(availableLocales, requestedLocales).
+        // a. Let r be ! BestFitMatcher(availableLocales, requestedLocales).
         matcher_result = best_fit_matcher(requested_locales);
     }
 
@@ -540,7 +540,7 @@ Vector<String> lookup_supported_locales(Vector<String> const& requested_locales)
         locale_id->remove_extension_type<Unicode::LocaleExtension>();
         auto no_extensions_locale = locale_id->to_string();
 
-        // b. Let availableLocale be BestAvailableLocale(availableLocales, noExtensionsLocale).
+        // b. Let availableLocale be ! BestAvailableLocale(availableLocales, noExtensionsLocale).
         auto available_locale = best_available_locale(no_extensions_locale);
 
         // c. If availableLocale is not undefined, append locale to the end of subset.
@@ -588,7 +588,7 @@ ThrowCompletionOr<Array*> supported_locales(GlobalObject& global_object, Vector<
         supported_locales = lookup_supported_locales(requested_locales);
     }
 
-    // 5. Return CreateArrayFromList(supportedLocales).
+    // 5. Return ! CreateArrayFromList(supportedLocales).
     return Array::create_from<String>(global_object, supported_locales, [&vm](auto& locale) { return js_string(vm, locale); });
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.cpp
@@ -140,48 +140,46 @@ bool is_well_formed_currency_code(StringView currency)
 // 6.5.1 IsWellFormedUnitIdentifier ( unitIdentifier ), https://tc39.es/ecma402/#sec-iswellformedunitidentifier
 bool is_well_formed_unit_identifier(StringView unit_identifier)
 {
-    // 6.5.2 IsSanctionedSimpleUnitIdentifier ( unitIdentifier ), https://tc39.es/ecma402/#sec-iswellformedunitidentifier
-    constexpr auto is_sanctioned_simple_unit_identifier = [](StringView unit_identifier) {
+    // 6.5.2 IsSanctionedSingleUnitIdentifier ( unitIdentifier ), https://tc39.es/ecma402/#sec-issanctionedsingleunitidentifier
+    constexpr auto is_sanctioned_single_unit_identifier = [](StringView unit_identifier) {
         // 1. If unitIdentifier is listed in Table 2 below, return true.
         // 2. Else, return false.
-        static constexpr auto sanctioned_units = sanctioned_simple_unit_identifiers();
+        static constexpr auto sanctioned_units = sanctioned_single_unit_identifiers();
         return find(sanctioned_units.begin(), sanctioned_units.end(), unit_identifier) != sanctioned_units.end();
     };
 
-    // 1. If the result of IsSanctionedSimpleUnitIdentifier(unitIdentifier) is true, then
-    if (is_sanctioned_simple_unit_identifier(unit_identifier)) {
+    // 1. If ! IsSanctionedSingleUnitIdentifier(unitIdentifier) is true, then
+    if (is_sanctioned_single_unit_identifier(unit_identifier)) {
         // a. Return true.
         return true;
     }
 
+    // 2. Let i be ! StringIndexOf(unitIdentifier, "-per-", 0).
     auto indices = unit_identifier.find_all("-per-"sv);
 
-    // 2. If the substring "-per-" does not occur exactly once in unitIdentifier, then
+    // 3. If i is -1 or ! StringIndexOf(unitIdentifier, "-per-", i + 1) is not -1, then
     if (indices.size() != 1) {
         // a. Return false.
         return false;
     }
 
-    // 3. Let numerator be the substring of unitIdentifier from the beginning to just before "-per-".
+    // 4. Assert: The five-character substring "-per-" occurs exactly once in unitIdentifier, at index i.
+    // NOTE: We skip this because the indices vector being of size 1 already verifies this invariant.
+
+    // 5. Let numerator be the substring of unitIdentifier from 0 to i.
     auto numerator = unit_identifier.substring_view(0, indices[0]);
 
-    // 4. If the result of IsSanctionedSimpleUnitIdentifier(numerator) is false, then
-    if (!is_sanctioned_simple_unit_identifier(numerator)) {
-        // a. Return false.
-        return false;
-    }
-
-    // 5. Let denominator be the substring of unitIdentifier from just after "-per-" to the end.
+    // 6. Let denominator be the substring of unitIdentifier from i + 5.
     auto denominator = unit_identifier.substring_view(indices[0] + 5);
 
-    // 6. If the result of IsSanctionedSimpleUnitIdentifier(denominator) is false, then
-    if (!is_sanctioned_simple_unit_identifier(denominator)) {
-        // a. Return false.
-        return false;
+    // 7. If ! IsSanctionedSingleUnitIdentifier(numerator) and ! IsSanctionedSingleUnitIdentifier(denominator) are both true, then
+    if (is_sanctioned_single_unit_identifier(numerator) && is_sanctioned_single_unit_identifier(denominator)) {
+        // a. Return true.
+        return true;
     }
 
-    // 7. Return true.
-    return true;
+    // 8. Return false.
+    return false;
 }
 
 // 9.2.1 CanonicalizeLocaleList ( locales ), https://tc39.es/ecma402/#sec-canonicalizelocalelist

--- a/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/AbstractOperations.h
@@ -54,7 +54,8 @@ struct PatternPartition {
     String value;
 };
 
-constexpr auto sanctioned_simple_unit_identifiers()
+// Table 2: Single units sanctioned for use in ECMAScript, https://tc39.es/ecma402/#table-sanctioned-single-unit-identifiers
+constexpr auto sanctioned_single_unit_identifiers()
 {
     return AK::Array { "acre"sv, "bit"sv, "byte"sv, "celsius"sv, "centimeter"sv, "day"sv, "degree"sv, "fahrenheit"sv, "fluid-ounce"sv, "foot"sv, "gallon"sv, "gigabit"sv, "gigabyte"sv, "gram"sv, "hectare"sv, "hour"sv, "inch"sv, "kilobit"sv, "kilobyte"sv, "kilogram"sv, "kilometer"sv, "liter"sv, "megabit"sv, "megabyte"sv, "meter"sv, "mile"sv, "mile-scandinavian"sv, "milliliter"sv, "millimeter"sv, "millisecond"sv, "minute"sv, "month"sv, "ounce"sv, "percent"sv, "petabyte"sv, "pound"sv, "second"sv, "stone"sv, "terabit"sv, "terabyte"sv, "week"sv, "yard"sv, "year"sv };
 }

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.cpp
@@ -72,7 +72,7 @@ ThrowCompletionOr<Object*> to_date_time_options(GlobalObject& global_object, Val
     if (!options_value.is_undefined())
         options = TRY(options_value.to_object(global_object));
 
-    // 2. Let options be OrdinaryObjectCreate(options).
+    // 2. Let options be ! OrdinaryObjectCreate(options).
     options = Object::create(global_object, options);
 
     // 3. Let needDefaults be true.
@@ -524,7 +524,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObjec
         return static_cast<NumberFormat*>(number_format);
     };
 
-    // 4. Let nfOptions be OrdinaryObjectCreate(null).
+    // 4. Let nfOptions be ! OrdinaryObjectCreate(null).
     auto* number_format_options = Object::create(global_object, nullptr);
 
     // 5. Perform ! CreateDataPropertyOrThrow(nfOptions, "useGrouping", false).
@@ -533,7 +533,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObjec
     // 6. Let nf be ? Construct(%NumberFormat%, « locale, nfOptions »).
     auto* number_format = TRY(construct_number_format(number_format_options));
 
-    // 7. Let nf2Options be OrdinaryObjectCreate(null).
+    // 7. Let nf2Options be ! OrdinaryObjectCreate(null).
     auto* number_format_options2 = Object::create(global_object, nullptr);
 
     // 8. Perform ! CreateDataPropertyOrThrow(nf2Options, "minimumIntegerDigits", 2).
@@ -553,7 +553,7 @@ ThrowCompletionOr<Vector<PatternPartition>> format_date_time_pattern(GlobalObjec
     if (date_time_format.has_fractional_second_digits()) {
         fractional_second_digits = date_time_format.fractional_second_digits();
 
-        // a. Let nf3Options be OrdinaryObjectCreate(null).
+        // a. Let nf3Options be ! OrdinaryObjectCreate(null).
         auto* number_format_options3 = Object::create(global_object, nullptr);
 
         // b. Perform ! CreateDataPropertyOrThrow(nf3Options, "minimumIntegerDigits", fractionalSecondDigits).
@@ -827,7 +827,7 @@ ThrowCompletionOr<Array*> format_date_time_to_parts(GlobalObject& global_object,
     // 1. Let parts be ? PartitionDateTimePattern(dateTimeFormat, x).
     auto parts = TRY(partition_date_time_pattern(global_object, date_time_format, time));
 
-    // 2. Let result be ArrayCreate(0).
+    // 2. Let result be ! ArrayCreate(0).
     auto* result = MUST(Array::create(global_object, 0));
 
     // 3. Let n be 0.
@@ -835,7 +835,7 @@ ThrowCompletionOr<Array*> format_date_time_to_parts(GlobalObject& global_object,
 
     // 4. For each Record { [[Type]], [[Value]] } part in parts, do
     for (auto& part : parts) {
-        // a. Let O be OrdinaryObjectCreate(%Object.prototype%).
+        // a. Let O be ! OrdinaryObjectCreate(%Object.prototype%).
         auto* object = Object::create(global_object, global_object.object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).
@@ -1147,7 +1147,7 @@ ThrowCompletionOr<Array*> format_date_time_range_to_parts(GlobalObject& global_o
     // 1. Let parts be ? PartitionDateTimeRangePattern(dateTimeFormat, x, y).
     auto parts = TRY(partition_date_time_range_pattern(global_object, date_time_format, start, end));
 
-    // 2. Let result be ArrayCreate(0).
+    // 2. Let result be ! ArrayCreate(0).
     auto* result = MUST(Array::create(global_object, 0));
 
     // 3. Let n be 0.
@@ -1155,7 +1155,7 @@ ThrowCompletionOr<Array*> format_date_time_range_to_parts(GlobalObject& global_o
 
     // 4. For each Record { [[Type]], [[Value]], [[Source]] } part in parts, do
     for (auto& part : parts) {
-        // a. Let O be OrdinaryObjectCreate(%ObjectPrototype%).
+        // a. Let O be ! OrdinaryObjectCreate(%ObjectPrototype%).
         auto* object = Object::create(global_object, global_object.object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormat.h
@@ -60,7 +60,6 @@ public:
     bool has_hour_cycle() const { return m_hour_cycle.has_value(); }
     Unicode::HourCycle hour_cycle() const { return *m_hour_cycle; }
     StringView hour_cycle_string() const { return Unicode::hour_cycle_to_string(*m_hour_cycle); }
-    void set_hour_cycle(StringView hour_cycle) { m_hour_cycle = Unicode::hour_cycle_from_string(hour_cycle); }
     void set_hour_cycle(Unicode::HourCycle hour_cycle) { m_hour_cycle = hour_cycle; }
     void clear_hour_cycle() { m_hour_cycle.clear(); }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -90,7 +90,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
     // 1. Let requestedLocales be ? CanonicalizeLocaleList(locales).
     auto requested_locales = TRY(canonicalize_locale_list(global_object, locales_value));
 
-    // 2. Let options be ? ToDateTimeOptions(options, "any", "date").
+    // 2. Set options to ? ToDateTimeOptions(options, "any", "date").
     auto* options = TRY(to_date_time_options(global_object, options_value, OptionRequired::Any, OptionDefaults::Date));
 
     // 3. Let opt be a new Record.
@@ -136,7 +136,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
 
     // 14. If hour12 is not undefined, then
     if (!hour12.is_undefined()) {
-        // a. Let hourCycle be null.
+        // a. Set hourCycle to null.
         hour_cycle = js_null();
     }
 
@@ -151,7 +151,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
     // 18. Set dateTimeFormat.[[Locale]] to r.[[locale]].
     date_time_format.set_locale(move(result.locale));
 
-    // 19. Let calendar be r.[[ca]].
+    // 19. Set calendar to r.[[ca]].
     // 20. Set dateTimeFormat.[[Calendar]] to calendar.
     if (result.ca.has_value())
         date_time_format.set_calendar(result.ca.release_value());
@@ -234,7 +234,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
 
     // 33. If timeZone is undefined, then
     if (time_zone_value.is_undefined()) {
-        // a. Set timeZone to DefaultTimeZone().
+        // a. Set timeZone to ! DefaultTimeZone().
         time_zone = Temporal::default_time_zone();
     }
     // 34. Else,
@@ -242,21 +242,25 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         // a. Set timeZone to ? ToString(timeZone).
         time_zone = TRY(time_zone_value.to_string(global_object));
 
-        // b. If the result of IsValidTimeZoneName(timeZone) is false, then
+        // b. If the result of ! IsValidTimeZoneName(timeZone) is false, then
         if (!Temporal::is_valid_time_zone_name(time_zone)) {
             // i. Throw a RangeError exception.
             return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, time_zone, vm.names.timeZone);
         }
 
-        // c. Set timeZone to CanonicalizeTimeZoneName(timeZone).
+        // c. Set timeZone to ! CanonicalizeTimeZoneName(timeZone).
         time_zone = Temporal::canonicalize_time_zone_name(time_zone);
     }
 
     // 35. Set dateTimeFormat.[[TimeZone]] to timeZone.
     date_time_format.set_time_zone(move(time_zone));
 
-    // 36. For each row of Table 6, except the header row, in table order, do
-    TRY(for_each_calendar_field(global_object, format_options, [&](auto& option, auto const& property, auto const& defaults) -> ThrowCompletionOr<void> {
+    // 36. Let hasExplicitFormatComponents be false.
+    // NOTE: Instead of using a boolean, we track any explicitly provided component name for nicer exception messages.
+    PropertyKey const* explicit_format_component = nullptr;
+
+    // 37. For each row of Table 6, except the header row, in table order, do
+    TRY(for_each_calendar_field(global_object, format_options, [&](auto& option, auto const& property, auto const& values) -> ThrowCompletionOr<void> {
         using ValueType = typename RemoveReference<decltype(option)>::ValueType;
 
         // a. Let prop be the name given in the Property column of the row.
@@ -267,61 +271,65 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
             auto value = TRY(get_number_option(global_object, *options, property, 1, 3, {}));
 
             // d. Set formatOptions.[[<prop>]] to value.
-            if (value.has_value())
+            if (value.has_value()) {
                 option = static_cast<ValueType>(value.value());
+
+                // e. If value is not undefined, then
+                //     i. Set hasExplicitFormatComponents to true.
+                explicit_format_component = &property;
+            }
         }
         // c. Else,
         else {
-            // i. Let value be ? GetOption(options, prop, "string", « the strings given in the Values column of the row », undefined).
-            auto value = TRY(get_option(global_object, *options, property, Value::Type::String, defaults, Empty {}));
+            // i. Let values be a List whose elements are the strings given in the Values column of the row.
+            // ii. Let value be ? GetOption(options, prop, "string", values, undefined).
+            auto value = TRY(get_option(global_object, *options, property, Value::Type::String, values, Empty {}));
 
             // d. Set formatOptions.[[<prop>]] to value.
-            if (!value.is_undefined())
+            if (!value.is_undefined()) {
                 option = Unicode::calendar_pattern_style_from_string(value.as_string().string());
+
+                // e. If value is not undefined, then
+                //     i. Set hasExplicitFormatComponents to true.
+                explicit_format_component = &property;
+            }
         }
 
         return {};
     }));
 
-    // 37. Let matcher be ? GetOption(options, "formatMatcher", "string", « "basic", "best fit" », "best fit").
+    // 38. Let matcher be ? GetOption(options, "formatMatcher", "string", « "basic", "best fit" », "best fit").
     matcher = TRY(get_option(global_object, *options, vm.names.formatMatcher, Value::Type::String, AK::Array { "basic"sv, "best fit"sv }, "best fit"sv));
 
-    // 38. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
+    // 39. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
     auto date_style = TRY(get_option(global_object, *options, vm.names.dateStyle, Value::Type::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
 
-    // 39. Set dateTimeFormat.[[DateStyle]] to dateStyle.
+    // 40. Set dateTimeFormat.[[DateStyle]] to dateStyle.
     if (!date_style.is_undefined())
         date_time_format.set_date_style(date_style.as_string().string());
 
-    // 40. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
+    // 41. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
     auto time_style = TRY(get_option(global_object, *options, vm.names.timeStyle, Value::Type::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
 
-    // 41. Set dateTimeFormat.[[TimeStyle]] to timeStyle.
+    // 42. Set dateTimeFormat.[[TimeStyle]] to timeStyle.
     if (!time_style.is_undefined())
         date_time_format.set_time_style(time_style.as_string().string());
 
     Optional<Unicode::CalendarPattern> best_format {};
 
-    // 42. If dateStyle is not undefined or timeStyle is not undefined, then
+    // 43. If dateStyle is not undefined or timeStyle is not undefined, then
     if (date_time_format.has_date_style() || date_time_format.has_time_style()) {
-        // a. For each row in Table 6, except the header row, do
-        TRY(for_each_calendar_field(global_object, format_options, [&](auto const& option, auto const& property, auto const&) -> ThrowCompletionOr<void> {
-            // i. Let prop be the name given in the Property column of the row.
-            // ii. Let p be formatOptions.[[<prop>]].
-            // iii. If p is not undefined, then
-            if (option.has_value()) {
-                // 1. Throw a TypeError exception.
-                return vm.throw_completion<TypeError>(global_object, ErrorType::IntlInvalidDateTimeFormatOption, property, "dateStyle or timeStyle"sv);
-            }
-
-            return {};
-        }));
+        // a. If hasExplicitFormatComponents is true, then
+        if (explicit_format_component != nullptr) {
+            // i. Throw a TypeError exception.
+            return vm.throw_completion<TypeError>(global_object, ErrorType::IntlInvalidDateTimeFormatOption, *explicit_format_component, "dateStyle or timeStyle"sv);
+        }
 
         // b. Let styles be dataLocaleData.[[styles]].[[<calendar>]].
         // c. Let bestFormat be DateTimeStyleFormat(dateStyle, timeStyle, styles).
         best_format = date_time_style_format(data_locale, date_time_format);
     }
-    // 43. Else,
+    // 44. Else,
     else {
         // a. Let formats be dataLocaleData.[[formats]].[[<calendar>]].
         auto formats = Unicode::get_calendar_available_formats(data_locale, date_time_format.calendar());
@@ -338,7 +346,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         }
     }
 
-    // 44. For each row in Table 6, except the header row, in table order, do
+    // 45. For each row in Table 6, except the header row, in table order, do
     date_time_format.for_each_calendar_field_zipped_with(*best_format, [&](auto& date_time_format_field, auto const& best_format_field, auto) {
         // a. Let prop be the name given in the Property column of the row.
         // b. If bestFormat has a field [[<prop>]], then
@@ -352,13 +360,13 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
     String pattern;
     Vector<Unicode::CalendarRangePattern> range_patterns;
 
-    // 45. If dateTimeFormat.[[Hour]] is undefined, then
+    // 46. If dateTimeFormat.[[Hour]] is undefined, then
     if (!date_time_format.has_hour()) {
         // a. Set dateTimeFormat.[[HourCycle]] to undefined.
         date_time_format.clear_hour_cycle();
     }
 
-    // 46. If dateTimeformat.[[HourCycle]] is "h11" or "h12", then
+    // 47. If dateTimeformat.[[HourCycle]] is "h11" or "h12", then
     if ((hour_cycle_value == Unicode::HourCycle::H11) || (hour_cycle_value == Unicode::HourCycle::H12)) {
         // a. Let pattern be bestFormat.[[pattern12]].
         if (best_format->pattern12.has_value()) {
@@ -372,7 +380,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         // b. Let rangePatterns be bestFormat.[[rangePatterns12]].
         range_patterns = Unicode::get_calendar_range12_formats(data_locale, date_time_format.calendar(), best_format->skeleton);
     }
-    // 47. Else,
+    // 48. Else,
     else {
         // a. Let pattern be bestFormat.[[pattern]].
         pattern = move(best_format->pattern);
@@ -381,13 +389,13 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         range_patterns = Unicode::get_calendar_range_formats(data_locale, date_time_format.calendar(), best_format->skeleton);
     }
 
-    // 48. Set dateTimeFormat.[[Pattern]] to pattern.
+    // 49. Set dateTimeFormat.[[Pattern]] to pattern.
     date_time_format.set_pattern(move(pattern));
 
-    // 49. Set dateTimeFormat.[[RangePatterns]] to rangePatterns.
+    // 50. Set dateTimeFormat.[[RangePatterns]] to rangePatterns.
     date_time_format.set_range_patterns(move(range_patterns));
 
-    // 50. Return dateTimeFormat.
+    // 51. Return dateTimeFormat.
     return &date_time_format;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatFunction.cpp
@@ -46,7 +46,7 @@ ThrowCompletionOr<Value> DateTimeFormatFunction::call()
 
     // 3. If date is not provided or is undefined, then
     if (date.is_undefined()) {
-        // a. Let x be Call(%Date.now%, undefined).
+        // a. Let x be ! Call(%Date.now%, undefined).
         date = MUST(JS::call(global_object, global_object.date_constructor_now_function(), js_undefined()));
     }
     // 4. Else,

--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatPrototype.cpp
@@ -71,7 +71,7 @@ JS_DEFINE_NATIVE_FUNCTION(DateTimeFormatPrototype::format_to_parts)
 
     // 3. If date is undefined, then
     if (date.is_undefined()) {
-        // a. Let x be Call(%Date.now%, undefined).
+        // a. Let x be ! Call(%Date.now%, undefined).
         date = MUST(call(global_object, global_object.date_constructor_now_function(), js_undefined()));
     }
     // 4. Else,

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -116,8 +116,7 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_o
         if (!locale_id.has_value())
             return vm.throw_completion<RangeError>(global_object, ErrorType::IntlInvalidLanguageTag, code);
 
-        // c. Set code to CanonicalizeUnicodeLocaleId(code).
-        // d. Return code.
+        // c. Return ! CanonicalizeUnicodeLocaleId(code).
         auto canonicalized_tag = JS::Intl::canonicalize_unicode_locale_id(*locale_id);
         return js_string(vm, move(canonicalized_tag));
     }
@@ -128,8 +127,7 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_o
         if (!Unicode::is_unicode_region_subtag(code))
             return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "region"sv);
 
-        // b. Let code be the result of mapping code to upper case as described in 6.1.
-        // c. Return code.
+        // b. Return the ASCII-uppercase of code.
         return js_string(vm, code.to_uppercase_string());
     }
 
@@ -139,8 +137,13 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_o
         if (!Unicode::is_unicode_script_subtag(code))
             return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "script"sv);
 
-        // b. Let code be the result of mapping the first character in code to upper case, and mapping the second, third, and fourth character in code to lower case, as described in 6.1.
-        // c. Return code.
+        // Assert: The length of code is 4, and every code unit of code represents an ASCII letter (0x0041 through 0x005A and 0x0061 through 0x007A, both inclusive).
+        VERIFY(code.length() == 4);
+        VERIFY(all_of(code, is_ascii_alpha));
+
+        // c. Let first be the ASCII-uppercase of the substring of code from 0 to 1.
+        // d. Let rest be the ASCII-lowercase of the substring of code from 1.
+        // e. Return the string-concatenation of first and rest.
         return js_string(vm, code.to_titlecase_string());
     }
 
@@ -154,8 +157,7 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_o
         if (code.contains('_'))
             return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "calendar"sv);
 
-        // c. Let code be the result of mapping code to lower case as described in 6.1.
-        // d. Return code.
+        // c. Return the ASCII-lowercase of code.
         return js_string(vm, code.to_lowercase_string());
     }
 
@@ -176,8 +178,7 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_o
     if (!is_well_formed_currency_code(code))
         return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "currency"sv);
 
-    // 8. Let code be the result of mapping code to upper case as described in 6.1.
-    // 9. Return code.
+    // 8. Return the ASCII-uppercase of code.
     return js_string(vm, code.to_uppercase_string());
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DisplayNames.cpp
@@ -150,8 +150,12 @@ ThrowCompletionOr<Value> canonical_code_for_display_names(GlobalObject& global_o
         if (!Unicode::is_type_identifier(code))
             return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "calendar"sv);
 
-        // b. Let code be the result of mapping code to lower case as described in 6.1.
-        // c. Return code.
+        // b. If code uses any of the backwards compatibility syntax described in Unicode Technical Standard #35 LDML § 3.3 BCP 47 Conformance, throw a RangeError exception.
+        if (code.contains('_'))
+            return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, code, "calendar"sv);
+
+        // c. Let code be the result of mapping code to lower case as described in 6.1.
+        // d. Return code.
         return js_string(vm, code.to_lowercase_string());
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -69,7 +69,7 @@ JS_DEFINE_NATIVE_FUNCTION(Intl::get_canonical_locales)
     for (auto& locale : locale_list)
         marked_locale_list.append(js_string(vm, move(locale)));
 
-    // 2. Return CreateArrayFromList(ll).
+    // 2. Return ! CreateArrayFromList(ll).
     return Array::create_from(global_object, marked_locale_list);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/Intl.cpp
@@ -141,7 +141,7 @@ JS_DEFINE_NATIVE_FUNCTION(Intl::supported_values_of)
     // 7. Else if key is "unit", then
     else if (key == "unit"sv) {
         // a. Let list be ! AvailableUnits( ).
-        static auto units = sanctioned_simple_unit_identifiers();
+        static auto units = sanctioned_single_unit_identifiers();
         list = units.span();
     }
     // 8. Else,

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormat.cpp
@@ -48,7 +48,7 @@ StringView ListFormat::type_string() const
 // 13.5.1 DeconstructPattern ( pattern, placeables ), https://tc39.es/ecma402/#sec-deconstructpattern
 Vector<PatternPartition> deconstruct_pattern(StringView pattern, Placeables placeables)
 {
-    // 1. Let patternParts be PartitionPattern(pattern).
+    // 1. Let patternParts be ! PartitionPattern(pattern).
     auto pattern_parts = partition_pattern(pattern);
 
     // 2. Let result be a new empty List.
@@ -125,7 +125,7 @@ Vector<PatternPartition> create_parts_from_list(ListFormat const& list_format, V
         placeables.set("0"sv, move(first));
         placeables.set("1"sv, move(second));
 
-        // f. Return DeconstructPattern(pattern, placeables).
+        // f. Return ! DeconstructPattern(pattern, placeables).
         return deconstruct_pattern(pattern, move(placeables));
     }
 
@@ -171,7 +171,7 @@ Vector<PatternPartition> create_parts_from_list(ListFormat const& list_format, V
         placeables.set("0"sv, move(head));
         placeables.set("1"sv, move(parts));
 
-        // g. Set parts to DeconstructPattern(pattern, placeables).
+        // g. Set parts to ! DeconstructPattern(pattern, placeables).
         parts = deconstruct_pattern(pattern, move(placeables));
 
         // h. Decrement i by 1.
@@ -184,7 +184,7 @@ Vector<PatternPartition> create_parts_from_list(ListFormat const& list_format, V
 // 13.5.3 FormatList ( listFormat, list ), https://tc39.es/ecma402/#sec-formatlist
 String format_list(ListFormat const& list_format, Vector<String> const& list)
 {
-    // 1. Let parts be CreatePartsFromList(listFormat, list).
+    // 1. Let parts be ! CreatePartsFromList(listFormat, list).
     auto parts = create_parts_from_list(list_format, list);
 
     // 2. Let result be an empty String.
@@ -205,10 +205,10 @@ Array* format_list_to_parts(GlobalObject& global_object, ListFormat const& list_
 {
     auto& vm = global_object.vm();
 
-    // 1. Let parts be CreatePartsFromList(listFormat, list).
+    // 1. Let parts be ! CreatePartsFromList(listFormat, list).
     auto parts = create_parts_from_list(list_format, list);
 
-    // 2. Let result be ArrayCreate(0).
+    // 2. Let result be ! ArrayCreate(0).
     auto* result = MUST(Array::create(global_object, 0));
 
     // 3. Let n be 0.
@@ -216,7 +216,7 @@ Array* format_list_to_parts(GlobalObject& global_object, ListFormat const& list_
 
     // 4. For each Record { [[Type]], [[Value]] } part in parts, do
     for (auto& part : parts) {
-        // a. Let O be OrdinaryObjectCreate(%Object.prototype%).
+        // a. Let O be ! OrdinaryObjectCreate(%Object.prototype%).
         auto* object = Object::create(global_object, global_object.object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).

--- a/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/ListFormatPrototype.cpp
@@ -45,7 +45,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format)
     // 3. Let stringList be ? StringListFromIterable(list).
     auto string_list = TRY(string_list_from_iterable(global_object, list));
 
-    // 4. Return FormatList(lf, stringList).
+    // 4. Return ! FormatList(lf, stringList).
     auto formatted = format_list(*list_format, string_list);
     return js_string(vm, move(formatted));
 }
@@ -62,7 +62,7 @@ JS_DEFINE_NATIVE_FUNCTION(ListFormatPrototype::format_to_parts)
     // 3. Let stringList be ? StringListFromIterable(list).
     auto string_list = TRY(string_list_from_iterable(global_object, list));
 
-    // 4. Return FormatListToParts(lf, stringList).
+    // 4. Return ! FormatListToParts(lf, stringList).
     return format_list_to_parts(global_object, *list_format, string_list);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/LocaleConstructor.cpp
@@ -48,7 +48,7 @@ static ThrowCompletionOr<String> apply_options_to_tag(GlobalObject& global_objec
     // 1. Assert: Type(tag) is String.
     // 2. Assert: Type(options) is Object.
 
-    // 3. If IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
+    // 3. If ! IsStructurallyValidLanguageTag(tag) is false, throw a RangeError exception.
     auto locale_id = is_structurally_valid_language_tag(tag);
     if (!locale_id.has_value())
         return vm.throw_completion<RangeError>(global_object, ErrorType::IntlInvalidLanguageTag, tag);
@@ -68,7 +68,7 @@ static ThrowCompletionOr<String> apply_options_to_tag(GlobalObject& global_objec
     //     a. If region does not match the unicode_region_subtag production, throw a RangeError exception.
     auto region = TRY(get_string_option(global_object, options, vm.names.region, Unicode::is_unicode_region_subtag));
 
-    // 10. Set tag to CanonicalizeUnicodeLocaleId(tag).
+    // 10. Set tag to ! CanonicalizeUnicodeLocaleId(tag).
     auto canonicalized_tag = JS::Intl::canonicalize_unicode_locale_id(*locale_id);
 
     // 11. Assert: tag matches the unicode_locale_id production.
@@ -103,7 +103,7 @@ static ThrowCompletionOr<String> apply_options_to_tag(GlobalObject& global_objec
     }
 
     // 16. Set tag to tag with the substring corresponding to the unicode_language_id production replaced by the string languageId.
-    // 17. Return CanonicalizeUnicodeLocaleId(tag).
+    // 17. Return ! CanonicalizeUnicodeLocaleId(tag).
     return JS::Intl::canonicalize_unicode_locale_id(*locale_id);
 }
 

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -941,7 +941,7 @@ RawFormatResult to_raw_precision(GlobalObject& global_object, Value number, int 
     // 7. Else,
     else {
         // a. Assert: e < 0.
-        // b. Let m be the string-concatenation of the String value "0.", –(e+1) occurrences of the character "0", and m.
+        // b. Let m be the string-concatenation of "0.", –(e+1) occurrences of the character "0", and m.
         result.formatted_string = String::formatted(
             "0.{}{}",
             String::repeated('0', -1 * (exponent + 1)),
@@ -981,7 +981,7 @@ RawFormatResult to_raw_fixed(GlobalObject& global_object, Value number, int min_
     // 4. Let xFinal be n / 10^f.
     result.rounded_number = divide_by_power(global_object, n, fraction);
 
-    // 5. If n = 0, let m be the String "0". Otherwise, let m be the String consisting of the digits of the decimal representation of n (in order, with no leading zeroes).
+    // 5. If n = 0, let m be "0". Otherwise, let m be the String consisting of the digits of the decimal representation of n (in order, with no leading zeroes).
     result.formatted_string = is_zero(n) ? String("0"sv) : number_to_string(n);
 
     // 6. If f ≠ 0, then

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -809,7 +809,7 @@ Array* format_numeric_to_parts(GlobalObject& global_object, NumberFormat& number
     // Note: Our implementation of PartitionNumberPattern does not throw.
     auto parts = partition_number_pattern(global_object, number_format, number);
 
-    // 2. Let result be ArrayCreate(0).
+    // 2. Let result be ! ArrayCreate(0).
     auto* result = MUST(Array::create(global_object, 0));
 
     // 3. Let n be 0.
@@ -817,7 +817,7 @@ Array* format_numeric_to_parts(GlobalObject& global_object, NumberFormat& number
 
     // 4. For each Record { [[Type]], [[Value]] } part in parts, do
     for (auto& part : parts) {
-        // a. Let O be OrdinaryObjectCreate(%Object.prototype%).
+        // a. Let O be ! OrdinaryObjectCreate(%Object.prototype%).
         auto* object = Object::create(global_object, global_object.object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormat.cpp
@@ -346,7 +346,7 @@ int currency_digits(StringView currency)
 // 15.5.3 FormatNumericToString ( intlObject, x ), https://tc39.es/ecma402/#sec-formatnumberstring
 FormatResult format_numeric_to_string(GlobalObject& global_object, NumberFormatBase& intl_object, Value number)
 {
-    // 1. If x < 0 or x is -0𝔽, let isNegative be true; else let isNegative be false.
+    // 1. If ℝ(x) < 0 or x is -0𝔽, let isNegative be true; else let isNegative be false.
     bool is_negative = is_less_than(number, 0) || number.is_negative_zero();
 
     // 2. If isNegative, then
@@ -1160,12 +1160,12 @@ Optional<Variant<StringView, String>> get_number_format_pattern(NumberFormat& nu
     // 15. Else,
     case NumberFormat::SignDisplay::ExceptZero:
         // a. Assert: signDisplay is "exceptZero".
-        // b. If x is 0 or x is -0 or x is NaN, then
+        // b. If x is NaN, or if x is finite and ℝ(x) is 0, then
         if (is_positive_zero || is_negative_zero || is_nan) {
             // i. Let pattern be patterns.[[zeroPattern]].
             pattern = patterns->zero_format;
         }
-        // c. Else if x > 0, then
+        // c. Else if ℝ(x) > 0, then
         else if (is_greater_than(number, 0)) {
             // i. Let pattern be patterns.[[positivePattern]].
             pattern = patterns->positive_format;

--- a/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/NumberFormatConstructor.cpp
@@ -336,7 +336,7 @@ ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_obje
             return vm.throw_completion<TypeError>(global_object, ErrorType::IntlOptionUndefined, "currency"sv, "style"sv, style);
     }
     // 7. Else,
-    //     a. If the result of IsWellFormedCurrencyCode(currency) is false, throw a RangeError exception.
+    //     a. If ! IsWellFormedCurrencyCode(currency) is false, throw a RangeError exception.
     else if (!is_well_formed_currency_code(currency.as_string().string()))
         return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, currency, "currency"sv);
 
@@ -356,7 +356,7 @@ ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_obje
             return vm.throw_completion<TypeError>(global_object, ErrorType::IntlOptionUndefined, "unit"sv, "style"sv, style);
     }
     // 12. Else,
-    //     a. If the result of IsWellFormedUnitIdentifier(unit) is false, throw a RangeError exception.
+    //     a. If ! IsWellFormedUnitIdentifier(unit) is false, throw a RangeError exception.
     else if (!is_well_formed_unit_identifier(unit.as_string().string()))
         return vm.throw_completion<RangeError>(global_object, ErrorType::OptionIsNotValidValue, unit, "unit"sv);
 
@@ -365,8 +365,7 @@ ThrowCompletionOr<void> set_number_format_unit_options(GlobalObject& global_obje
 
     // 14. If style is "currency", then
     if (intl_object.style() == NumberFormat::Style::Currency) {
-        // a. Let currency be the result of converting currency to upper case as specified in 6.1.
-        // b. Set intlObj.[[Currency]] to currency.
+        // a. Set intlObj.[[Currency]] to the ASCII-uppercase of currency.
         intl_object.set_currency(currency.as_string().string().to_uppercase());
 
         // c. Set intlObj.[[CurrencyDisplay]] to currencyDisplay.

--- a/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/PluralRulesPrototype.cpp
@@ -61,7 +61,7 @@ JS_DEFINE_NATIVE_FUNCTION(PluralRulesPrototype::resolved_options)
     // FIXME: Implement this when the data is available in LibUnicode.
     MarkedVector<Value> plural_categories { vm.heap() };
 
-    // 6. Perform ! CreateDataProperty(options, "pluralCategories", CreateArrayFromList(pluralCategories)).
+    // 6. Perform ! CreateDataProperty(options, "pluralCategories", ! CreateArrayFromList(pluralCategories)).
     MUST(options->create_data_property_or_throw(vm.names.pluralCategories, Array::create_from(global_object, plural_categories)));
 
     // 7. Return options.

--- a/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/RelativeTimeFormat.cpp
@@ -249,7 +249,7 @@ ThrowCompletionOr<Array*> format_relative_time_to_parts(GlobalObject& global_obj
     // 1. Let parts be ? PartitionRelativeTimePattern(relativeTimeFormat, value, unit).
     auto parts = TRY(partition_relative_time_pattern(global_object, relative_time_format, value, unit));
 
-    // 2. Let result be ArrayCreate(0).
+    // 2. Let result be ! ArrayCreate(0).
     auto* result = MUST(Array::create(global_object, 0));
 
     // 3. Let n be 0.
@@ -257,7 +257,7 @@ ThrowCompletionOr<Array*> format_relative_time_to_parts(GlobalObject& global_obj
 
     // 4. For each Record { [[Type]], [[Value]], [[Unit]] } part in parts, do
     for (auto& part : parts) {
-        // a. Let O be OrdinaryObjectCreate(%Object.prototype%).
+        // a. Let O be ! OrdinaryObjectCreate(%Object.prototype%).
         auto* object = Object::create(global_object, global_object.object_prototype());
 
         // b. Perform ! CreateDataPropertyOrThrow(O, "type", part.[[Type]]).

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -1038,7 +1038,7 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::sup)
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::locale_compare)
 {
     // FIXME: This can throw (spec issue)
-    // 1. Let O be RequireObjectCoercible(this value).
+    // 1. Let O be ? RequireObjectCoercible(this value).
     auto object = TRY(require_object_coercible(global_object, vm.this_value(global_object)));
 
     // 2. Let S be ? ToString(O).

--- a/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.of.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Intl/DisplayNames/DisplayNames.prototype.of.js
@@ -27,6 +27,10 @@ describe("errors", () => {
         expect(() => {
             new Intl.DisplayNames("en", { type: "calendar" }).of("hello!");
         }).toThrowWithMessage(RangeError, "hello! is not a valid value for option calendar");
+
+        expect(() => {
+            new Intl.DisplayNames("en", { type: "calendar" }).of("abc_def");
+        }).toThrowWithMessage(RangeError, "abc_def is not a valid value for option calendar");
     });
 
     test("invalid dateTimeField", () => {


### PR DESCRIPTION
ECMA-402 had a merge frenzy last night!

Most of these are editorial, there is one normative change (`LibJS: Disallow calendar display names which contain an underscore`) which nets us a +1 on test262.