### PR TITLE
LibCore: Set the correct invariant length for consecutive short options

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -753,11 +753,11 @@ void ArgsParser::autocomplete(FILE* file, StringView program_name, Span<char con
     if (!completing_option)
         return;
 
-    auto write_completion = [&](auto format, auto& option, auto... args) {
+    auto write_completion = [&](auto format, auto& option, auto has_invariant, auto... args) {
         JsonObject object;
         object.set("completion", String::formatted(format, args...));
         object.set("static_offset", 0);
-        object.set("invariant_offset", option_to_complete.length());
+        object.set("invariant_offset", has_invariant ? option_to_complete.length() : 0u);
         object.set("display_trivia", option.help_string);
         object.set("trailing_trivia", option.requires_argument ? " " : "");
         outln(file, "{}", object.to_string());
@@ -771,7 +771,7 @@ void ArgsParser::autocomplete(FILE* file, StringView program_name, Span<char con
                 continue;
             StringView option_string = option.long_name;
             if (option_string.starts_with(option_pattern)) {
-                write_completion("--{}", option, option_string);
+                write_completion("--{}", option, true, option_string);
             }
         }
     } else {
@@ -782,7 +782,8 @@ void ArgsParser::autocomplete(FILE* file, StringView program_name, Span<char con
             if (option.short_name == 0)
                 continue;
 
-            write_completion("-{}", option, option.short_name);
+            auto has_invariant = option_to_complete == "-";
+            write_completion("{}{}", option, has_invariant, has_invariant ? "-" : "", option.short_name);
         }
     }
 }


### PR DESCRIPTION
When completing `ls -l` to add another short option, the invariant
length should be zero as we are not replacing anything with our
suggestion.
Also skip the initial dash if there already is one.
Fixes #13301.