### PR TITLE
Kernel: Allow block devices to have logical block size > 512

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -212,7 +212,7 @@ else
     if [ "$SERENITY_NVME_ENABLE" -eq 1 ]; then
         SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,if=none,id=disk"
         SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -device i82801b11-bridge,id=bridge4 -device sdhci-pci,bus=bridge4"
-        SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -device nvme,serial=deadbeef,drive=disk,bus=bridge4"
+        SERENITY_BOOT_DRIVE="$SERENITY_BOOT_DRIVE -device nvme,serial=deadbeef,drive=disk,bus=bridge4,logical_block_size=4096,physical_block_size=4096"
         SERENITY_KERNEL_CMDLINE="$SERENITY_KERNEL_CMDLINE root=/dev/nvme0n1"
     else
         SERENITY_BOOT_DRIVE="-drive file=${SERENITY_DISK_IMAGE},format=raw,index=0,media=disk,id=disk"


### PR DESCRIPTION
- Final fix to allow block devices to have LBA size greater than 512. 
- Changed NVMe QEMU device to use LBA size of 4k as the file system backing the block device in the host typically have 4k logical size. (Also serves as a test to make sure the fix works in the complete block stack)

### Test:
```
SERENITY_NVME_ENABLE=1 Meta/serenity.sh run i686
```