### PR TITLE
LibJS: Bring ForIn body evaluation closer to the specification

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Object.h
+++ b/Userland/Libraries/LibJS/Runtime/Object.h
@@ -136,6 +136,10 @@ public:
 
     ThrowCompletionOr<Object*> define_properties(Value properties);
 
+    // 14.7.5 The for-in, for-of, and for-await-of Statements
+
+    Optional<Completion> enumerate_object_properties(Function<Optional<Completion>(Value)>) const;
+
     // Implementation-specific storage abstractions
 
     Optional<ValueAndAttributes> storage_get(PropertyKey const&) const;

--- a/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
+++ b/Userland/Libraries/LibJS/Tests/loops/for-in-basic.js
@@ -99,3 +99,24 @@ describe("special left hand sides", () => {
         }).toThrowWithMessage(ReferenceError, "Invalid left-hand side in assignment");
     });
 });
+
+test("remove properties while iterating", () => {
+    const from = [1, 2, 3];
+    const to = [];
+    for (const prop in from) {
+        to.push(prop);
+        from.pop();
+    }
+    expect(to).toEqual(["0", "1"]);
+});
+
+test("duplicated properties in prototype", () => {
+    const object = { a: 1 };
+    const proto = { a: 2 };
+    Object.setPrototypeOf(object, proto);
+    const a = [];
+    for (const prop in object) {
+        a.push(prop);
+    }
+    expect(a).toEqual(["a"]);
+});


### PR DESCRIPTION
This fixes 2 bugs in our current implementation:
 * Properties deleted during iteration were still being iterated
 * Properties with the same name in both the object and it's prototype were iterated twice