### PR TITLE
LibC: Make wchar size definitions available from stdint.h

### DIFF
--- a/Userland/Libraries/LibC/bits/stdint.h
+++ b/Userland/Libraries/LibC/bits/stdint.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <bits/wchar_size.h>
 #include <sys/cdefs.h>
 
 __BEGIN_DECLS

--- a/Userland/Libraries/LibC/bits/wchar_size.h
+++ b/Userland/Libraries/LibC/bits/wchar_size.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022, Tim Schumacher <timschumi@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define WCHAR_MAX __WCHAR_MAX__
+#ifdef __WCHAR_MIN__
+#    define WCHAR_MIN __WCHAR_MIN__
+#else
+// Note: This assumes that wchar_t is a signed type.
+#    define WCHAR_MIN (-WCHAR_MAX - 1)
+#endif

--- a/Userland/Libraries/LibC/wchar.h
+++ b/Userland/Libraries/LibC/wchar.h
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <bits/FILE.h>
+#include <bits/wchar_size.h>
 #include <stdarg.h>
 #include <stddef.h>
 #include <sys/cdefs.h>
@@ -15,16 +16,6 @@ __BEGIN_DECLS
 
 #ifndef WEOF
 #    define WEOF (0xffffffffu)
-#endif
-
-#undef WCHAR_MAX
-#undef WCHAR_MIN
-#define WCHAR_MAX __WCHAR_MAX__
-#ifdef __WCHAR_MIN__
-#    define WCHAR_MIN __WCHAR_MIN__
-#else
-// Note: This assumes that wchar_t is a signed type.
-#    define WCHAR_MIN (-WCHAR_MAX - 1)
 #endif
 
 typedef __WINT_TYPE__ wint_t;


### PR DESCRIPTION
POSIX describes `WCHAR_MIN` and `WCHAR_MAX` in `stdint.h(0P)`, while `wchar.h(0P`) only says "as described in `stdint.h`".

As there isn't a trivial path of "may make visible", just move it to a shared header and include it from both files.

I additionally removed the `#undef`s as we probably want to know if we are unintentionally redefining those.