### PR TITLE
LibPDF: Improve text rendering; PDFViewer: Use ArgsParser

### DIFF
--- a/Meta/Lagom/CMakeLists.txt
+++ b/Meta/Lagom/CMakeLists.txt
@@ -396,8 +396,9 @@ if (BUILD_LAGOM)
 
     # PDF
     file(GLOB LIBPDF_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibPDF/*.cpp")
+    file(GLOB LIBPDF_SUBDIR_SOURCES CONFIGURE_DEPENDS "../../Userland/Libraries/LibPDF/*/*.cpp")
     lagom_lib(PDF pdf
-       SOURCES ${LIBPDF_SOURCES}
+       SOURCES ${LIBPDF_SOURCES} ${LIBPDF_SUBDIR_SOURCES}
        LIBS LagomGfx LagomIPC LagomTextCodec
     )
 

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -160,7 +160,7 @@ void PDFViewerWidget::open_file(Core::File& file)
 
     auto document = maybe_document.release_value();
 
-    if (auto sh = document->security_handler(); !sh->has_user_password()) {
+    if (auto sh = document->security_handler(); sh && !sh->has_user_password()) {
         // FIXME: Prompt the user for a password
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -6,18 +6,23 @@
  */
 
 #include "PDFViewerWidget.h"
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibFileSystemAccessClient/Client.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
 #include <LibGUI/Menubar.h>
-#include <LibGUI/MessageBox.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(arguments);
+    const char* file_path = nullptr;
+    Core::ArgsParser args_parser;
+    args_parser.add_positional_argument(file_path, "PDF file to open", "path", Core::ArgsParser::Required::No);
+    args_parser.parse(arguments);
+
+    auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = GUI::Icon::default_icon("app-pdf-viewer");
 
     auto window = GUI::Window::construct();
@@ -37,8 +42,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
 
-    if (arguments.argc >= 2) {
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, arguments.argv[1]);
+    if (file_path) {
+        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, file_path);
         if (response.is_error())
             return 1;
         pdf_viewer_widget->open_file(*response.value());

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -6,6 +6,8 @@ set(SOURCES
     Encryption.cpp
     Filter.cpp
     Fonts/PDFFont.cpp
+    Fonts/TrueTypeFont.cpp
+    Fonts/Type0Font.cpp
     Fonts/Type1Font.cpp
     ObjectDerivatives.cpp
     Parser.cpp

--- a/Userland/Libraries/LibPDF/CMakeLists.txt
+++ b/Userland/Libraries/LibPDF/CMakeLists.txt
@@ -5,7 +5,8 @@ set(SOURCES
     Encoding.cpp
     Encryption.cpp
     Filter.cpp
-    Fonts.cpp
+    Fonts/PDFFont.cpp
+    Fonts/Type1Font.cpp
     ObjectDerivatives.cpp
     Parser.cpp
     Renderer.cpp

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -89,4 +89,16 @@ private:
     Array<float, 9> m_matrix { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
 };
 
+class ICCBasedColorSpace final : public ColorSpace {
+public:
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, Page const&, Vector<Value>&& parameters);
+
+    ~ICCBasedColorSpace() override = default;
+
+    Color color(Vector<Value> const& arguments) const override;
+
+private:
+    ICCBasedColorSpace() = delete;
+};
+
 }

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -25,8 +25,12 @@
 
 namespace PDF {
 
+class Page;
+
 class ColorSpace : public RefCounted<ColorSpace> {
 public:
+    static PDFErrorOr<NonnullRefPtr<ColorSpace>> create(Document*, FlyString const& name, Page const& page);
+
     virtual ~ColorSpace() = default;
 
     virtual Color color(Vector<Value> const& arguments) const = 0;
@@ -36,9 +40,9 @@ class DeviceGrayColorSpace final : public ColorSpace {
 public:
     static NonnullRefPtr<DeviceGrayColorSpace> the();
 
-    virtual ~DeviceGrayColorSpace() override = default;
+    ~DeviceGrayColorSpace() override = default;
 
-    virtual Color color(Vector<Value> const& arguments) const override;
+    Color color(Vector<Value> const& arguments) const override;
 
 private:
     DeviceGrayColorSpace() = default;
@@ -48,9 +52,9 @@ class DeviceRGBColorSpace final : public ColorSpace {
 public:
     static NonnullRefPtr<DeviceRGBColorSpace> the();
 
-    virtual ~DeviceRGBColorSpace() override = default;
+    ~DeviceRGBColorSpace() override = default;
 
-    virtual Color color(Vector<Value> const& arguments) const override;
+    Color color(Vector<Value> const& arguments) const override;
 
 private:
     DeviceRGBColorSpace() = default;
@@ -60,9 +64,9 @@ class DeviceCMYKColorSpace final : public ColorSpace {
 public:
     static NonnullRefPtr<DeviceCMYKColorSpace> the();
 
-    virtual ~DeviceCMYKColorSpace() override = default;
+    ~DeviceCMYKColorSpace() override = default;
 
-    virtual Color color(Vector<Value> const& arguments) const override;
+    Color color(Vector<Value> const& arguments) const override;
 
 private:
     DeviceCMYKColorSpace() = default;
@@ -70,10 +74,11 @@ private:
 
 class CalRGBColorSpace final : public ColorSpace {
 public:
-    static PDFErrorOr<NonnullRefPtr<CalRGBColorSpace>> create(RefPtr<Document>, Vector<Value>&& parameters);
-    virtual ~CalRGBColorSpace() override = default;
+    static PDFErrorOr<NonnullRefPtr<CalRGBColorSpace>> create(Document*, Vector<Value>&& parameters);
 
-    virtual Color color(Vector<Value> const& arguments) const override;
+    ~CalRGBColorSpace() override = default;
+
+    Color color(Vector<Value> const& arguments) const override;
 
 private:
     CalRGBColorSpace() = default;

--- a/Userland/Libraries/LibPDF/ColorSpace.h
+++ b/Userland/Libraries/LibPDF/ColorSpace.h
@@ -25,7 +25,7 @@
 
 namespace PDF {
 
-class Page;
+struct Page;
 
 class ColorSpace : public RefCounted<ColorSpace> {
 public:

--- a/Userland/Libraries/LibPDF/CommonNames.cpp
+++ b/Userland/Libraries/LibPDF/CommonNames.cpp
@@ -12,4 +12,6 @@ namespace PDF {
 ENUMERATE_COMMON_NAMES(ENUMERATE)
 #undef ENUMERATE
 
+FlyString CommonNames::IdentityH = "Identity-H";
+
 }

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -81,6 +81,7 @@
     A(ML)                         \
     A(Matrix)                     \
     A(MediaBox)                   \
+    A(MissingWidth)               \
     A(N)                          \
     A(Next)                       \
     A(O)                          \

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -23,13 +23,17 @@
     A(CA)                         \
     A(CCITTFaxDecode)             \
     A(CalRGB)                     \
+    A(CIDSystemInfo)              \
+    A(CIDToGIDMap)                \
     A(ColorSpace)                 \
     A(Contents)                   \
     A(Count)                      \
     A(CropBox)                    \
     A(Crypt)                      \
     A(D)                          \
+    A(DW)                         \
     A(DCTDecode)                  \
+    A(DescendantFonts)            \
     A(Dest)                       \
     A(Dests)                      \
     A(DeviceCMYK)                 \
@@ -87,6 +91,7 @@
     A(O)                          \
     A(OP)                         \
     A(OPM)                        \
+    A(Ordering)                   \
     A(Outlines)                   \
     A(P)                          \
     A(Pages)                      \
@@ -95,6 +100,7 @@
     A(Prev)                       \
     A(R)                          \
     A(RI)                         \
+    A(Registry)                   \
     A(Resources)                  \
     A(Root)                       \
     A(Rotate)                     \
@@ -103,6 +109,7 @@
     A(SM)                         \
     A(SMask)                      \
     A(Subtype)                    \
+    A(Supplement)                 \
     A(T)                          \
     A(TK)                         \
     A(TR)                         \
@@ -114,6 +121,7 @@
     A(UCR)                        \
     A(UseBlackPTComp)             \
     A(UserUnit)                   \
+    A(W)                          \
     A(WhitePoint)                 \
     A(Widths)                     \
     A(XYZ)                        \
@@ -127,6 +135,8 @@ public:
 #define ENUMERATE(name) static FlyString name;
     ENUMERATE_COMMON_NAMES(ENUMERATE)
 #undef ENUMERATE
+
+    static FlyString IdentityH;
 };
 
 }

--- a/Userland/Libraries/LibPDF/CommonNames.h
+++ b/Userland/Libraries/LibPDF/CommonNames.h
@@ -10,6 +10,7 @@
 
 #define ENUMERATE_COMMON_NAMES(A) \
     A(AIS)                        \
+    A(Alternate)                  \
     A(ASCII85Decode)              \
     A(ASCIIHexDecode)             \
     A(BG)                         \
@@ -63,6 +64,7 @@
     A(H)                          \
     A(HT)                         \
     A(HTO)                        \
+    A(ICCBased)                   \
     A(ID)                         \
     A(JBIG2Decode)                \
     A(JPXDecode)                  \

--- a/Userland/Libraries/LibPDF/Error.h
+++ b/Userland/Libraries/LibPDF/Error.h
@@ -18,6 +18,12 @@ public:
         MalformedPDF,
     };
 
+    Error(AK::Error error)
+        : m_type(Type::Internal)
+        , m_message(String::formatted("Internal error while processing PDF file: {}", error.string_literal()))
+    {
+    }
+
     Error(Type type, String const& message)
         : m_type(type)
     {

--- a/Userland/Libraries/LibPDF/Fonts.h
+++ b/Userland/Libraries/LibPDF/Fonts.h
@@ -18,20 +18,24 @@ public:
     virtual ~PDFFont() = default;
 
     virtual u32 char_code_to_code_point(u16 char_code) const = 0;
+    virtual float get_char_width(u16 char_code) const = 0;
 };
 
 class Type1Font : public PDFFont {
 public:
     static PDFErrorOr<NonnullRefPtr<Type1Font>> create(Document*, NonnullRefPtr<DictObject>);
 
-    Type1Font(RefPtr<StreamObject> to_unicode, NonnullRefPtr<Encoding>);
+    Type1Font(RefPtr<StreamObject> to_unicode, NonnullRefPtr<Encoding>, HashMap<u16, u16> const& m_widths, u16 missing_width);
     ~Type1Font() override = default;
 
     u32 char_code_to_code_point(u16 char_code) const override;
+    float get_char_width(u16 char_code) const override;
 
 private:
     RefPtr<StreamObject> m_to_unicode;
     NonnullRefPtr<Encoding> m_encoding;
+    HashMap<u16, u16> m_widths;
+    u16 m_missing_width;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPDF/CommonNames.h>
+#include <LibPDF/Fonts/PDFFont.h>
+#include <LibPDF/Fonts/Type1Font.h>
+
+namespace PDF {
+
+PDFErrorOr<NonnullRefPtr<PDFFont>> PDFFont::create(Document* document, NonnullRefPtr<DictObject> dict)
+{
+    auto subtype = TRY(dict->get_name(document, CommonNames::Subtype))->name();
+
+    if (subtype == "Type1")
+        return TRY(Type1Font::create(document, dict));
+
+    dbgln("Unknown font subtype: {}", subtype);
+    TODO();
+}
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.cpp
@@ -6,6 +6,8 @@
 
 #include <LibPDF/CommonNames.h>
 #include <LibPDF/Fonts/PDFFont.h>
+#include <LibPDF/Fonts/TrueTypeFont.h>
+#include <LibPDF/Fonts/Type0Font.h>
 #include <LibPDF/Fonts/Type1Font.h>
 
 namespace PDF {
@@ -14,8 +16,12 @@ PDFErrorOr<NonnullRefPtr<PDFFont>> PDFFont::create(Document* document, NonnullRe
 {
     auto subtype = TRY(dict->get_name(document, CommonNames::Subtype))->name();
 
+    if (subtype == "Type0")
+        return TRY(Type0Font::create(document, dict));
     if (subtype == "Type1")
         return TRY(Type1Font::create(document, dict));
+    if (subtype == "TrueType")
+        return TRY(TrueTypeFont::create(document, dict));
 
     dbgln("Unknown font subtype: {}", subtype);
     TODO();

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -17,7 +17,7 @@ public:
     virtual ~PDFFont() = default;
 
     virtual u32 char_code_to_code_point(u16 char_code) const = 0;
-    virtual float get_char_width(u16 char_code) const = 0;
+    virtual float get_char_width(u16 char_code, float font_size) const = 0;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Fonts/PDFFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/PDFFont.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibPDF/Document.h>
+
+namespace PDF {
+
+class PDFFont : public RefCounted<PDFFont> {
+public:
+    static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject>);
+
+    virtual ~PDFFont() = default;
+
+    virtual u32 char_code_to_code_point(u16 char_code) const = 0;
+    virtual float get_char_width(u16 char_code) const = 0;
+};
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2022, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPDF/CommonNames.h>
+#include <LibPDF/Fonts/TrueTypeFont.h>
+#include <LibPDF/Fonts/Type1Font.h>
+
+namespace PDF {
+
+PDFErrorOr<NonnullRefPtr<PDFFont>> TrueTypeFont::create(Document* document, NonnullRefPtr<DictObject> dict)
+{
+    auto font_descriptor = TRY(dict->get_dict(document, CommonNames::FontDescriptor));
+
+    if (!dict->contains(CommonNames::FontFile2)) {
+        // FIXME: The TTF is one of the standard 14 fonts. These should be built into
+        //        the system, and their attributes hardcoded. Until we have them, just
+        //        treat this as a Type1 font (which are very similar to TTF fonts)
+        return TRY(Type1Font::create(document, dict));
+    }
+
+    auto font_file = TRY(dict->get_stream(document, CommonNames::FontFile2));
+    auto ttf_font = TRY(TTF::Font::try_load_from_externally_owned_memory(font_file->bytes()));
+    auto data = TRY(Type1Font::parse_data(document, dict));
+
+    return adopt_ref(*new TrueTypeFont(ttf_font, move(data)));
+}
+
+TrueTypeFont::TrueTypeFont(NonnullRefPtr<TTF::Font> ttf_font, Type1Font::Data data)
+    : m_ttf_font(ttf_font)
+    , m_data(data)
+{
+}
+
+u32 TrueTypeFont::char_code_to_code_point(u16 char_code) const
+{
+    if (m_data.to_unicode)
+        TODO();
+
+    auto descriptor = m_data.encoding->get_char_code_descriptor(char_code);
+    return descriptor.code_point;
+}
+
+float TrueTypeFont::get_char_width(u16 char_code, float font_size) const
+{
+    u16 width;
+    if (auto char_code_width = m_data.widths.get(char_code); char_code_width.has_value()) {
+        width = char_code_width.value();
+    } else {
+        // FIXME: Should we do something with m_data.missing_width here?
+        float units_per_em = m_ttf_font->units_per_em();
+        auto scale = (font_size * DEFAULT_DPI) / (POINTS_PER_INCH * units_per_em);
+
+        auto code_point = char_code_to_code_point(char_code);
+        auto id = m_ttf_font->glyph_id_for_code_point(code_point);
+        auto metrics = m_ttf_font->glyph_metrics(id, scale, scale);
+        width = metrics.advance_width;
+    }
+
+    return static_cast<float>(width) / 1000.0f;
+}
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
+++ b/Userland/Libraries/LibPDF/Fonts/TrueTypeFont.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGfx/TrueTypeFont/Font.h>
+#include <LibPDF/Fonts/Type1Font.h>
+
+namespace PDF {
+
+class TrueTypeFont : public PDFFont {
+public:
+    static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject>);
+
+    TrueTypeFont(NonnullRefPtr<TTF::Font> ttf_font, Type1Font::Data);
+    ~TrueTypeFont() override = default;
+
+    u32 char_code_to_code_point(u16 char_code) const override;
+    float get_char_width(u16 char_code, float font_size) const override;
+
+private:
+    NonnullRefPtr<TTF::Font> m_ttf_font;
+    Type1Font::Data m_data;
+};
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.cpp
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2022, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibPDF/CommonNames.h>
+#include <LibPDF/Fonts/Type0Font.h>
+
+namespace PDF {
+
+PDFErrorOr<NonnullRefPtr<Type0Font>> Type0Font::create(Document* document, NonnullRefPtr<DictObject> dict)
+{
+    // FIXME: Support arbitrary CMaps
+    auto cmap_value = TRY(dict->get_object(document, CommonNames::Encoding));
+    if (!cmap_value->is<NameObject>() || cmap_value->cast<NameObject>()->name() != CommonNames::IdentityH)
+        TODO();
+
+    auto descendant_font_value = TRY(dict->get_array(document, CommonNames::DescendantFonts));
+    auto descendant_font = TRY(descendant_font_value->get_dict_at(document, 0));
+
+    auto system_info_dict = TRY(descendant_font->get_dict(document, CommonNames::CIDSystemInfo));
+    auto registry = TRY(system_info_dict->get_string(document, CommonNames::Registry))->string();
+    auto ordering = TRY(system_info_dict->get_string(document, CommonNames::Ordering))->string();
+    u8 supplement = system_info_dict->get_value(CommonNames::Supplement).get<int>();
+    CIDSystemInfo system_info { registry, ordering, supplement };
+
+    auto font_descriptor = TRY(descendant_font->get_dict(document, CommonNames::FontDescriptor));
+
+    u16 default_width = 1000;
+    if (descendant_font->contains(CommonNames::DW))
+        default_width = descendant_font->get_value(CommonNames::DW).get<int>();
+
+    HashMap<u16, u16> widths;
+
+    if (descendant_font->contains(CommonNames::W)) {
+        auto widths_array = MUST(descendant_font->get_array(document, CommonNames::W));
+        Optional<u16> pending_code;
+
+        for (size_t i = 0; i < widths_array->size(); i++) {
+            auto& value = widths_array->at(i);
+            if (!pending_code.has_value()) {
+                pending_code = value.get<int>();
+            } else if (value.has<NonnullRefPtr<Object>>()) {
+                auto array = value.get<NonnullRefPtr<Object>>()->cast<ArrayObject>();
+                auto code = pending_code.release_value();
+                for (auto& width : *array)
+                    widths.set(code++, width.get<int>());
+            } else {
+                auto first_code = pending_code.release_value();
+                auto last_code = value.get<int>();
+                auto width = widths_array->at(i + 1).get<int>();
+                for (u16 code = first_code; code <= last_code; code++)
+                    widths.set(code, width);
+
+                i++;
+            }
+        }
+    }
+
+    if (dict->contains(CommonNames::CIDToGIDMap)) {
+        auto value = TRY(dict->get_object(document, CommonNames::CIDToGIDMap));
+        if (value->is<StreamObject>()) {
+            TODO();
+        } else if (value->cast<NameObject>()->name() != "Identity") {
+            TODO();
+        }
+    }
+
+    return adopt_ref(*new Type0Font(system_info, widths, default_width));
+}
+
+Type0Font::Type0Font(CIDSystemInfo const& system_info, HashMap<u16, u16> const& widths, u16 missing_width)
+    : m_system_info(system_info)
+    , m_widths(widths)
+    , m_missing_width(missing_width)
+{
+}
+
+u32 Type0Font::char_code_to_code_point(u16 char_code) const
+{
+    return char_code;
+}
+
+float Type0Font::get_char_width(u16 char_code, float) const
+{
+    u16 width;
+    if (auto char_code_width = m_widths.get(char_code); char_code_width.has_value()) {
+        width = char_code_width.value();
+    } else {
+        width = m_missing_width;
+    }
+
+    return static_cast<float>(width) / 1000.0f;
+}
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/Type0Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type0Font.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Matthew Olsson <mattco@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibPDF/Fonts/PDFFont.h>
+
+namespace PDF {
+
+struct CIDSystemInfo {
+    String registry;
+    String ordering;
+    u8 supplement;
+};
+
+class Type0Font : public PDFFont {
+public:
+    static PDFErrorOr<NonnullRefPtr<Type0Font>> create(Document*, NonnullRefPtr<DictObject>);
+
+    Type0Font(CIDSystemInfo const&, HashMap<u16, u16> const& widths, u16 missing_width);
+    ~Type0Font() override = default;
+
+    u32 char_code_to_code_point(u16 char_code) const override;
+    float get_char_width(u16 char_code, float font_size) const override;
+
+private:
+    CIDSystemInfo m_system_info;
+    HashMap<u16, u16> m_widths;
+    u16 m_missing_width;
+};
+
+}

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -5,7 +5,7 @@
  */
 
 #include <LibPDF/CommonNames.h>
-#include <LibPDF/Fonts.h>
+#include <LibPDF/Fonts/Type1Font.h>
 
 namespace PDF {
 
@@ -24,16 +24,6 @@ static bool is_standard_latin_font(FlyString const& font)
         "Times-BoldItalic",
         "Helvetica-BoldOblique",
         "Courier-BoldOblique");
-}
-
-PDFErrorOr<NonnullRefPtr<PDFFont>> PDFFont::create(Document* document, NonnullRefPtr<DictObject> dict)
-{
-    auto subtype = TRY(dict->get_name(document, CommonNames::Subtype))->name();
-
-    if (subtype == "Type1")
-        return TRY(Type1Font::create(document, dict));
-
-    TODO();
 }
 
 PDFErrorOr<NonnullRefPtr<Type1Font>> Type1Font::create(Document* document, NonnullRefPtr<DictObject> dict)

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.cpp
@@ -88,7 +88,7 @@ u32 Type1Font::char_code_to_code_point(u16 char_code) const
     return descriptor.code_point;
 }
 
-float Type1Font::get_char_width(u16 char_code) const
+float Type1Font::get_char_width(u16 char_code, float) const
 {
     u16 width;
     if (auto char_code_width = m_widths.get(char_code); char_code_width.has_value()) {

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -7,19 +7,9 @@
 #pragma once
 
 #include <LibPDF/Encoding.h>
-#include <LibPDF/ObjectDerivatives.h>
+#include <LibPDF/Fonts/PDFFont.h>
 
 namespace PDF {
-
-class PDFFont : public RefCounted<PDFFont> {
-public:
-    static PDFErrorOr<NonnullRefPtr<PDFFont>> create(Document*, NonnullRefPtr<DictObject>);
-
-    virtual ~PDFFont() = default;
-
-    virtual u32 char_code_to_code_point(u16 char_code) const = 0;
-    virtual float get_char_width(u16 char_code) const = 0;
-};
 
 class Type1Font : public PDFFont {
 public:

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -19,7 +19,7 @@ public:
     ~Type1Font() override = default;
 
     u32 char_code_to_code_point(u16 char_code) const override;
-    float get_char_width(u16 char_code) const override;
+    float get_char_width(u16 char_code, float font_size) const override;
 
 private:
     RefPtr<StreamObject> m_to_unicode;

--- a/Userland/Libraries/LibPDF/Fonts/Type1Font.h
+++ b/Userland/Libraries/LibPDF/Fonts/Type1Font.h
@@ -13,19 +13,26 @@ namespace PDF {
 
 class Type1Font : public PDFFont {
 public:
+    // Also used by TrueTypeFont, which is very similar to Type1
+    struct Data {
+        RefPtr<StreamObject> to_unicode;
+        NonnullRefPtr<Encoding> encoding;
+        HashMap<u16, u16> widths;
+        u16 missing_width;
+    };
+
+    static PDFErrorOr<Data> parse_data(Document*, NonnullRefPtr<DictObject> font_dict);
+
     static PDFErrorOr<NonnullRefPtr<Type1Font>> create(Document*, NonnullRefPtr<DictObject>);
 
-    Type1Font(RefPtr<StreamObject> to_unicode, NonnullRefPtr<Encoding>, HashMap<u16, u16> const& m_widths, u16 missing_width);
+    Type1Font(Data);
     ~Type1Font() override = default;
 
     u32 char_code_to_code_point(u16 char_code) const override;
     float get_char_width(u16 char_code, float font_size) const override;
 
 private:
-    RefPtr<StreamObject> m_to_unicode;
-    NonnullRefPtr<Encoding> m_encoding;
-    HashMap<u16, u16> m_widths;
-    u16 m_missing_width;
+    Data m_data;
 };
 
 }

--- a/Userland/Libraries/LibPDF/Parser.h
+++ b/Userland/Libraries/LibPDF/Parser.h
@@ -9,8 +9,8 @@
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/SourceLocation.h>
 #include <AK/WeakPtr.h>
-#include <LibPDF/Command.h>
 #include <LibPDF/Object.h>
+#include <LibPDF/Operator.h>
 #include <LibPDF/Reader.h>
 #include <LibPDF/XRefTable.h>
 
@@ -25,7 +25,7 @@ public:
         Linearized,
     };
 
-    static PDFErrorOr<Vector<Command>> parse_graphics_commands(Document*, ReadonlyBytes);
+    static PDFErrorOr<Vector<Operator>> parse_operators(Document*, ReadonlyBytes);
 
     Parser(Document*, ReadonlyBytes);
 
@@ -115,7 +115,7 @@ private:
     PDFErrorOr<NonnullRefPtr<DictObject>> parse_dict();
     PDFErrorOr<NonnullRefPtr<StreamObject>> parse_stream(NonnullRefPtr<DictObject> dict);
 
-    PDFErrorOr<Vector<Command>> parse_graphics_commands();
+    PDFErrorOr<Vector<Operator>> parse_operators();
 
     void push_reference(Reference const& ref) { m_current_reference_stack.append(ref); }
     void pop_reference() { m_current_reference_stack.take_last(); }

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -480,7 +480,16 @@ RENDERER_HANDLER(set_stroking_color)
     return {};
 }
 
-RENDERER_TODO(set_stroking_color_extended)
+RENDERER_HANDLER(set_stroking_color_extended)
+{
+    // FIXME: Handle Pattern color spaces
+    auto last_arg = args.last();
+    if (last_arg.has<NonnullRefPtr<Object>>() && last_arg.get<NonnullRefPtr<Object>>()->is<NameObject>())
+        TODO();
+
+    state().stroke_color = state().stroke_color_space->color(args);
+    return {};
+}
 
 RENDERER_HANDLER(set_painting_color)
 {
@@ -488,7 +497,16 @@ RENDERER_HANDLER(set_painting_color)
     return {};
 }
 
-RENDERER_TODO(set_painting_color_extended)
+RENDERER_HANDLER(set_painting_color_extended)
+{
+    // FIXME: Handle Pattern color spaces
+    auto last_arg = args.last();
+    if (last_arg.has<NonnullRefPtr<Object>>() && last_arg.get<NonnullRefPtr<Object>>()->is<NameObject>())
+        TODO();
+
+    state().paint_color = state().paint_color_space->color(args);
+    return {};
+}
 
 RENDERER_HANDLER(set_stroking_color_and_space_to_gray)
 {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -654,7 +654,7 @@ void Renderer::show_text(String const& string, float shift)
 
     for (auto char_code : string.bytes()) {
         auto code_point = text_state().font->char_code_to_code_point(char_code);
-        auto char_width = text_state().font->get_char_width(char_code);
+        auto char_width = text_state().font->get_char_width(char_code, font_size);
 
         if (code_point != 0x20)
             m_painter.draw_glyph(glyph_position.to_type<int>(), code_point, *font, state().paint_color);

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -387,10 +387,8 @@ RENDERER_HANDLER(text_set_rise)
 RENDERER_HANDLER(text_next_line_offset)
 {
     Gfx::AffineTransform transform(1.0f, 0.0f, 0.0f, 1.0f, args[0].to_float(), args[1].to_float());
-    transform.multiply(m_text_line_matrix);
-    m_text_matrix = transform;
-    m_text_line_matrix = transform;
-    m_text_rendering_matrix_is_dirty = true;
+    m_text_line_matrix.multiply(transform);
+    m_text_matrix = m_text_line_matrix;
     return {};
 }
 
@@ -668,7 +666,7 @@ void Renderer::show_text(String const& string, float shift)
     // Update text matrix
     auto delta_x = glyph_position.x() - original_position.x();
     m_text_rendering_matrix_is_dirty = true;
-    m_text_matrix = Gfx::AffineTransform(1, 0, 0, 1, delta_x, 0).multiply(m_text_matrix);
+    m_text_matrix.translate(delta_x / text_rendering_matrix.x_scale(), 0.0f);
 }
 
 PDFErrorOr<NonnullRefPtr<ColorSpace>> Renderer::get_color_space(Value const& value)

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -78,28 +78,28 @@ PDFErrorOr<void> Renderer::render()
         byte_buffer.append(bytes.data(), bytes.size());
     }
 
-    auto commands = TRY(Parser::parse_graphics_commands(m_document, byte_buffer));
+    auto operators = TRY(Parser::parse_operators(m_document, byte_buffer));
 
-    for (auto& command : commands)
-        TRY(handle_command(command));
+    for (auto& op : operators)
+        TRY(handle_operator(op));
 
     return {};
 }
 
-PDFErrorOr<void> Renderer::handle_command(Command const& command)
+PDFErrorOr<void> Renderer::handle_operator(Operator const& op)
 {
-    switch (command.command_type()) {
-#define V(name, snake_name, symbol)                    \
-    case CommandType::name:                            \
-        TRY(handle_##snake_name(command.arguments())); \
+    switch (op.type()) {
+#define V(name, snake_name, symbol)               \
+    case OperatorType::name:                      \
+        TRY(handle_##snake_name(op.arguments())); \
         break;
-        ENUMERATE_COMMANDS(V)
+        ENUMERATE_OPERATORS(V)
 #undef V
-    case CommandType::TextNextLineShowString:
-        TRY(handle_text_next_line_show_string(command.arguments()));
+    case OperatorType::TextNextLineShowString:
+        TRY(handle_text_next_line_show_string(op.arguments()));
         break;
-    case CommandType::TextNextLineShowStringSetSpacing:
-        TRY(handle_text_next_line_show_string_set_spacing(command.arguments()));
+    case OperatorType::TextNextLineShowStringSetSpacing:
+        TRY(handle_text_next_line_show_string_set_spacing(op.arguments()));
         break;
     }
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -641,8 +641,9 @@ void Renderer::show_text(String const& string, float shift)
 {
     auto& text_rendering_matrix = calculate_text_rendering_matrix();
 
-    auto font_size = static_cast<int>(text_rendering_matrix.x_scale() * text_state().font_size);
-    auto font = Gfx::FontDatabase::the().get(text_state().font_family, text_state().font_variant, font_size);
+    auto font_size = text_rendering_matrix.x_scale() * text_state().font_size;
+    auto font_size_int = static_cast<int>(text_rendering_matrix.x_scale() * text_state().font_size);
+    auto font = Gfx::FontDatabase::the().get(text_state().font_family, text_state().font_variant, font_size_int);
     VERIFY(font);
 
     auto glyph_position = text_rendering_matrix.map(Gfx::FloatPoint { 0.0f, 0.0f });
@@ -653,11 +654,12 @@ void Renderer::show_text(String const& string, float shift)
 
     for (auto char_code : string.bytes()) {
         auto code_point = text_state().font->char_code_to_code_point(char_code);
+        auto char_width = text_state().font->get_char_width(char_code);
 
         if (code_point != 0x20)
             m_painter.draw_glyph(glyph_position.to_type<int>(), code_point, *font, state().paint_color);
 
-        auto glyph_width = static_cast<float>(font->glyph_width(code_point));
+        auto glyph_width = char_width * font_size;
         auto tx = (glyph_width - shift / 1000.0f);
         tx += text_state().character_spacing;
 

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -6,7 +6,7 @@
 
 #include <AK/Utf8View.h>
 #include <LibPDF/CommonNames.h>
-#include <LibPDF/Fonts.h>
+#include <LibPDF/Fonts/PDFFont.h>
 #include <LibPDF/Renderer.h>
 
 #define RENDERER_HANDLER(name) \

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -89,16 +89,16 @@ private:
 
     PDFErrorOr<void> render();
 
-    PDFErrorOr<void> handle_command(Command const&);
+    PDFErrorOr<void> handle_operator(Operator const&);
 #define V(name, snake_name, symbol) \
     PDFErrorOr<void> handle_##snake_name(Vector<Value> const& args);
-    ENUMERATE_COMMANDS(V)
+    ENUMERATE_OPERATORS(V)
 #undef V
     PDFErrorOr<void> handle_text_next_line_show_string(Vector<Value> const& args);
     PDFErrorOr<void> handle_text_next_line_show_string_set_spacing(Vector<Value> const& args);
 
     PDFErrorOr<void> set_graphics_state_from_dict(NonnullRefPtr<DictObject>);
-    // shift is the manual advance given in the TJ command array
+    // shift is the manual advance given in the TJ operator array
     void show_text(String const&, float shift = 0.0f);
     PDFErrorOr<NonnullRefPtr<ColorSpace>> get_color_space(Value const&);
 

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -19,7 +19,7 @@
 #include <LibGfx/Size.h>
 #include <LibPDF/ColorSpace.h>
 #include <LibPDF/Document.h>
-#include <LibPDF/Fonts.h>
+#include <LibPDF/Fonts/PDFFont.h>
 #include <LibPDF/Object.h>
 
 namespace PDF {

--- a/Userland/Libraries/LibPDF/Renderer.h
+++ b/Userland/Libraries/LibPDF/Renderer.h
@@ -8,6 +8,7 @@
 
 #include <AK/Format.h>
 #include <LibGfx/AffineTransform.h>
+#include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Font.h>
 #include <LibGfx/FontDatabase.h>
@@ -121,6 +122,7 @@ private:
     RefPtr<Gfx::Bitmap> m_bitmap;
     Page const& m_page;
     Gfx::Painter m_painter;
+    Gfx::AntiAliasingPainter m_anti_aliasing_painter;
 
     Gfx::Path m_current_path;
     Vector<GraphicsState> m_graphics_state_stack;


### PR DESCRIPTION
LibPDF:

Lots of text-related changes here, mostly focused around fonts. Enjoy the following screenshots from the PDF 1.7 spec (compared to Firefox) which demonstrate how big of a difference this makes!

<details>
<summary>Page 1: </summary>
<br />
<img src="https://i.imgur.com/kWFyRjT.png" alt="https://i.imgur.com/kWFyRjT.png" width="400">
<img src="https://i.imgur.com/ffBGfAE.png" alt="https://i.imgur.com/ffBGfAE.png" width="400">
</details>

<details>
<summary>Page 2: </summary>
<br />
<img src="https://i.imgur.com/SpZIhge.png" alt="https://i.imgur.com/SpZIhge.png" width="400">
<img src="https://i.imgur.com/5Wgc3Bu.png" alt="https://i.imgur.com/5Wgc3Bu.png" width="400">
</details>

PDFViewer: 

Use ArgsParser to avoid Shell completion shenanigans. 