### PR TITLE
Kernel: Disallow elevating pledge promises with no_error set

### DIFF
--- a/Kernel/Syscalls/pledge.cpp
+++ b/Kernel/Syscalls/pledge.cpp
@@ -47,9 +47,10 @@ ErrorOr<FlatPtr> Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*>
         if (!parse_pledge(promises->view(), new_promises))
             return EINVAL;
 
-        if (!(m_protected_values.promises & (1u << (u32)Pledge::no_error))) {
-            if (m_protected_values.has_promises && (new_promises & ~m_protected_values.promises))
+        if (m_protected_values.has_promises && (new_promises & ~m_protected_values.promises)) {
+            if (!(m_protected_values.promises & (1u << (u32)Pledge::no_error)))
                 return EPERM;
+            new_promises &= m_protected_values.promises;
         }
     }
 
@@ -57,9 +58,10 @@ ErrorOr<FlatPtr> Process::sys$pledge(Userspace<const Syscall::SC_pledge_params*>
     if (execpromises) {
         if (!parse_pledge(execpromises->view(), new_execpromises))
             return EINVAL;
-        if (!(m_protected_values.promises & (1u << (u32)Pledge::no_error))) {
-            if (m_protected_values.has_execpromises && (new_execpromises & ~m_protected_values.execpromises))
+        if (m_protected_values.has_execpromises && (new_execpromises & ~m_protected_values.execpromises)) {
+            if (!(m_protected_values.promises & (1u << (u32)Pledge::no_error)))
                 return EPERM;
+            new_execpromises &= m_protected_values.execpromises;
         }
     }
 


### PR DESCRIPTION
8233da33985bf834685bc215a8a9ed261e674f5f introduced a not-so-subtle bug
where an application with an existing pledge set containing `no_error`
could elevate its pledge set by pledging _anything_, this commit makes
sure that no new promise is accepted.