### PR TITLE
Shell: Add a shell option for autocompleting via the program itself

### DIFF
--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1668,6 +1668,8 @@ ErrorOr<Vector<Line::CompletionSuggestion>> Shell::complete_via_program_itself(s
     auto completion_utility_name = String::formatted("_complete_{}", completion_command.argv[0]);
     if (binary_search(cached_path, completion_utility_name))
         completion_command.argv[0] = completion_utility_name;
+    else if (!options.invoke_program_for_autocomplete)
+        return Error::from_string_literal("Refusing to use the program itself as completion source");
 
     completion_command.argv.extend({ "--complete", "--" });
 

--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -56,7 +56,8 @@
 
 #define ENUMERATE_SHELL_OPTIONS()                                                                                    \
     __ENUMERATE_SHELL_OPTION(inline_exec_keep_empty_segments, false, "Keep empty segments in inline execute $(...)") \
-    __ENUMERATE_SHELL_OPTION(verbose, false, "Announce every command that is about to be executed")
+    __ENUMERATE_SHELL_OPTION(verbose, false, "Announce every command that is about to be executed")                  \
+    __ENUMERATE_SHELL_OPTION(invoke_program_for_autocomplete, false, "Attempt to use the program being completed itself for autocompletion via --complete")
 
 #define ENUMERATE_SHELL_IMMEDIATE_FUNCTIONS()           \
     __ENUMERATE_SHELL_IMMEDIATE_FUNCTION(concat_lists)  \


### PR DESCRIPTION
This feature needs a bit more work, so let's disable it by default.
Note that the shell will still use _complete_foo if it is defined
regardless of this setting.