### PR TITLE
HackStudio+TextEditor: Add highlighted search

### DIFF
--- a/Userland/Applications/SoundPlayer/Common.h
+++ b/Userland/Applications/SoundPlayer/Common.h
@@ -13,11 +13,11 @@ class AutoSlider final : public GUI::Slider {
 public:
     ~AutoSlider() override = default;
     Function<void(int)> on_knob_released;
-    virtual void set_value(int value, GUI::AllowCallback allow_callback = GUI::AllowCallback::Yes) override
+    virtual void set_value(int value, GUI::AllowCallback allow_callback = GUI::AllowCallback::Yes, DoClamp do_clamp = DoClamp::Yes) override
     {
         m_in_drag_value = value;
         if (!knob_dragging() && !mouse_is_down())
-            GUI::Slider::set_value(value, allow_callback);
+            GUI::Slider::set_value(value, allow_callback, do_clamp);
     }
 
     bool mouse_is_down() const { return m_mouse_is_down; }

--- a/Userland/Applications/TextEditor/MainWidget.h
+++ b/Userland/Applications/TextEditor/MainWidget.h
@@ -56,6 +56,12 @@ private:
 
     virtual void drop_event(GUI::DropEvent&) override;
 
+    enum class ShowMessageIfNoResutls {
+        Yes = 1,
+        No = 0
+    };
+    void find_text(GUI::TextEditor::SearchDirection, ShowMessageIfNoResutls);
+
     RefPtr<GUI::TextEditor> m_editor;
     String m_path;
     String m_name;

--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -10,6 +10,7 @@ add_subdirectory(LanguageClients)
 
 compile_gml(Dialogs/NewProjectDialog.gml Dialogs/NewProjectDialogGML.h new_project_dialog_gml)
 compile_gml(Dialogs/Git/GitCommitDialog.gml Dialogs/Git/GitCommitDialogGML.h git_commit_dialog_gml)
+compile_gml(FindWidget.gml FindWidgetGML.h find_widget_gml)
 
 set(SOURCES
     CodeDocument.cpp
@@ -32,6 +33,8 @@ set(SOURCES
     Editor.cpp
     EditorWrapper.cpp
     FindInFilesWidget.cpp
+    FindWidget.cpp
+    FindWidgetGML.h
     Git/DiffViewer.cpp
     Git/GitFilesModel.cpp
     Git/GitFilesView.cpp

--- a/Userland/DevTools/HackStudio/EditorWrapper.cpp
+++ b/Userland/DevTools/HackStudio/EditorWrapper.cpp
@@ -20,11 +20,13 @@ namespace HackStudio {
 EditorWrapper::EditorWrapper()
 {
     set_layout<GUI::VerticalBoxLayout>();
-
     m_filename_title = untitled_label;
 
     // FIXME: Propagate errors instead of giving up
-    m_editor = MUST(try_add<Editor>());
+    m_editor = MUST(Editor::try_create());
+    m_find_widget = add<FindWidget>(*m_editor);
+
+    add_child(*m_editor);
     m_editor->set_ruler_visible(true);
     m_editor->set_automatic_indentation_enabled(true);
 
@@ -113,6 +115,14 @@ void EditorWrapper::update_title()
 void EditorWrapper::set_debug_mode(bool enabled)
 {
     m_editor->set_debug_mode(enabled);
+}
+
+void EditorWrapper::search_action()
+{
+    if (m_find_widget->visible())
+        m_find_widget->hide();
+    else
+        m_find_widget->show();
 }
 
 }

--- a/Userland/DevTools/HackStudio/EditorWrapper.h
+++ b/Userland/DevTools/HackStudio/EditorWrapper.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include "Debugger/BreakpointCallback.h"
+#include "FindWidget.h"
 #include "Git/GitRepo.h"
 #include "LanguageClient.h"
 #include <AK/Function.h>
@@ -52,6 +53,9 @@ public:
     Function<void()> on_change;
     Function<void(EditorWrapper&)> on_tab_close_request;
 
+    void search_action();
+    FindWidget const& find_widget() const { return *m_find_widget; }
+
 private:
     static constexpr auto untitled_label = "(Untitled)";
 
@@ -62,6 +66,7 @@ private:
     String m_filename;
     String m_filename_title;
     RefPtr<Editor> m_editor;
+    RefPtr<FindWidget> m_find_widget;
 
     Optional<String> m_project_root;
     RefPtr<GitRepo> m_git_repo;

--- a/Userland/DevTools/HackStudio/FindWidget.cpp
+++ b/Userland/DevTools/HackStudio/FindWidget.cpp
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2022, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "FindWidget.h"
+#include "Editor.h"
+#include <AK/QuickSort.h>
+#include <DevTools/HackStudio/FindWidgetGML.h>
+#include <LibGUI/BoxLayout.h>
+#include <LibGfx/Palette.h>
+
+namespace HackStudio {
+
+FindWidget::FindWidget(NonnullRefPtr<Editor> editor)
+    : m_editor(move(editor))
+{
+    load_from_gml(find_widget_gml);
+    set_fixed_height(widget_height);
+    m_input_field = find_descendant_of_type_named<GUI::TextBox>("input_field");
+    m_index_label = find_descendant_of_type_named<GUI::Label>("index_label");
+    m_next = find_descendant_of_type_named<GUI::Button>("next");
+    m_previous = find_descendant_of_type_named<GUI::Button>("previous");
+
+    VERIFY(m_input_field);
+    VERIFY(m_next);
+    VERIFY(m_previous);
+
+    m_next->on_click = [this](auto) {
+        find_next(GUI::TextEditor::SearchDirection::Forward);
+    };
+    m_previous->on_click = [this](auto) {
+        find_next(GUI::TextEditor::SearchDirection::Backward);
+    };
+
+    m_input_field->on_change = [this]() {
+        m_editor->reset_search_results();
+        find_next(GUI::TextEditor::SearchDirection::Forward);
+    };
+
+    m_input_field->on_return_pressed = [this]() {
+        find_next(GUI::TextEditor::SearchDirection::Forward);
+    };
+}
+
+void FindWidget::show()
+{
+    set_visible(true);
+    set_focus(true);
+    m_input_field->set_focus(true);
+    // Adjust scroll value to smooth the appearance of the FindWidget.
+    m_editor->vertical_scrollbar().set_value(m_editor->vertical_scrollbar().value() + widget_height, GUI::AllowCallback::Yes, GUI::Scrollbar::DoClamp::No);
+    m_visible = !m_visible;
+}
+
+void FindWidget::hide()
+{
+    set_visible(false);
+    set_focus(false);
+    m_visible = !m_visible;
+    m_editor->vertical_scrollbar().set_value(m_editor->vertical_scrollbar().value() - widget_height, GUI::AllowCallback::Yes, GUI::Scrollbar::DoClamp::No);
+    m_editor->set_focus(true);
+    m_editor->reset_search_results();
+}
+
+void FindWidget::find_next(GUI::TextEditor::SearchDirection direction)
+{
+    auto needle = m_input_field->text();
+    if (needle.is_empty()) {
+        m_editor->reset_search_results();
+        m_index_label->set_text(String::empty());
+        return;
+    }
+    auto result = m_editor->find_text(needle, direction, GUI::TextDocument::SearchShouldWrap::Yes, false, false);
+
+    if (result.is_valid())
+        m_index_label->set_text(String::formatted("{}/{}", m_editor->search_result_index().value_or(0) + 1, m_editor->search_results().size()));
+    else
+        m_index_label->set_text(String::empty());
+}
+
+}

--- a/Userland/DevTools/HackStudio/FindWidget.gml
+++ b/Userland/DevTools/HackStudio/FindWidget.gml
@@ -1,0 +1,32 @@
+@GUI::Widget {
+    name: "find_widget"
+    fill_with_background_color: true
+    shrink_to_fit: true
+    visible: false
+    layout: @GUI::HorizontalBoxLayout {
+        margins: [0, 0]
+    }
+
+    @GUI::TextBox {
+        name: "input_field"
+        max_width: 250
+    }
+
+    @GUI::Label {
+        name: "index_label"
+        max_width: 30
+        text: ""
+    }
+
+    @GUI::Button {
+        name: "next"
+        icon: "/res/icons/16x16/go-down.png"
+        max_width: 15
+    }
+
+    @GUI::Button {
+        name: "previous"
+        icon: "/res/icons/16x16/go-up.png"
+        max_width: 15
+    }
+}

--- a/Userland/DevTools/HackStudio/FindWidget.h
+++ b/Userland/DevTools/HackStudio/FindWidget.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Itamar S. <itamar8910@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "Editor.h"
+#include <LibGUI/Button.h>
+#include <LibGUI/TextBox.h>
+#include <LibGUI/Widget.h>
+#include <LibGUI/Window.h>
+
+namespace HackStudio {
+
+class Editor;
+class EditorWrapper;
+
+class FindWidget final : public GUI::Widget {
+    C_OBJECT(FindWidget)
+public:
+    ~FindWidget() = default;
+
+    void show();
+    void hide();
+    bool visible() const { return m_visible; }
+
+private:
+    FindWidget(NonnullRefPtr<Editor>);
+
+    void find_next(GUI::TextEditor::SearchDirection);
+
+    static constexpr auto widget_height = 25;
+
+    NonnullRefPtr<Editor> m_editor;
+    RefPtr<GUI::TextBox> m_input_field;
+    RefPtr<GUI::Label> m_index_label;
+    RefPtr<GUI::Button> m_next;
+    RefPtr<GUI::Button> m_previous;
+    bool m_visible { false };
+};
+
+}

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2020-2022, Itamar S. <itamar8910@gmail.com>
  * Copyright (c) 2020-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -1445,6 +1445,11 @@ void HackStudioWidget::create_view_menu(GUI::Window& window)
     create_location_history_actions();
     view_menu.add_action(*m_locations_history_back_action);
     view_menu.add_action(*m_locations_history_forward_action);
+
+    auto search_action = GUI::Action::create("&Search", { Mod_Ctrl, Key_F }, [this](auto&) {
+        current_editor_wrapper().search_action();
+    });
+    view_menu.add_action(search_action);
 }
 
 void HackStudioWidget::create_help_menu(GUI::Window& window)

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2020, Itamar S. <itamar8910@gmail.com>
+ * Copyright (c) 2020-2022, Itamar S. <itamar8910@gmail.com>
  * Copyright (c) 2020-2021, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause

--- a/Userland/Libraries/LibGUI/AbstractSlider.cpp
+++ b/Userland/Libraries/LibGUI/AbstractSlider.cpp
@@ -50,9 +50,10 @@ void AbstractSlider::set_range(int min, int max)
     update();
 }
 
-void AbstractSlider::set_value(int value, AllowCallback allow_callback)
+void AbstractSlider::set_value(int value, AllowCallback allow_callback, DoClamp do_clamp)
 {
-    value = clamp(value, m_min, m_max);
+    if (do_clamp == DoClamp::Yes)
+        value = clamp(value, m_min, m_max);
     if (m_value == value)
         return;
     m_value = value;

--- a/Userland/Libraries/LibGUI/AbstractSlider.h
+++ b/Userland/Libraries/LibGUI/AbstractSlider.h
@@ -30,7 +30,12 @@ public:
     bool is_max() const { return m_value == m_max; }
 
     void set_range(int min, int max);
-    virtual void set_value(int, AllowCallback = AllowCallback::Yes);
+
+    enum class DoClamp {
+        Yes = 1,
+        No = 0
+    };
+    virtual void set_value(int, AllowCallback = AllowCallback::Yes, DoClamp = DoClamp::Yes);
 
     void set_min(int min) { set_range(min, max()); }
     void set_max(int max) { set_range(min(), max); }

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -119,13 +119,13 @@ void Scrollbar::set_scroll_animation(Animation scroll_animation)
     m_scroll_animation = scroll_animation;
 }
 
-void Scrollbar::set_value(int value, AllowCallback allow_callback)
+void Scrollbar::set_value(int value, AllowCallback allow_callback, DoClamp do_clamp)
 {
     m_target_value = value;
     if (!(m_animated_scrolling_timer.is_null()))
         m_animated_scrolling_timer->stop();
 
-    AbstractSlider::set_value(value, allow_callback);
+    AbstractSlider::set_value(value, allow_callback, do_clamp);
 }
 
 void Scrollbar::set_target_value(int new_target_value)

--- a/Userland/Libraries/LibGUI/Scrollbar.h
+++ b/Userland/Libraries/LibGUI/Scrollbar.h
@@ -30,7 +30,7 @@ public:
 
     void set_scroll_animation(Animation scroll_animation);
 
-    virtual void set_value(int, AllowCallback = AllowCallback::Yes) override;
+    virtual void set_value(int, AllowCallback = AllowCallback::Yes, DoClamp = DoClamp::Yes) override;
     void set_target_value(int);
 
     virtual void increase_slider_by(int delta) override { set_target_value(m_target_value + delta); }

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -580,13 +580,13 @@ TextRange TextDocument::find_previous(StringView needle, const TextPosition& sta
     return {};
 }
 
-Vector<TextRange> TextDocument::find_all(StringView needle, bool regmatch)
+Vector<TextRange> TextDocument::find_all(StringView needle, bool regmatch, bool match_case)
 {
     Vector<TextRange> ranges;
 
     TextPosition position;
     for (;;) {
-        auto range = find_next(needle, position, SearchShouldWrap::No, regmatch);
+        auto range = find_next(needle, position, SearchShouldWrap::No, regmatch, match_case);
         if (!range.is_valid())
             break;
         ranges.append(range);

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -89,7 +89,7 @@ public:
     String text() const;
     String text_in_range(const TextRange&) const;
 
-    Vector<TextRange> find_all(StringView needle, bool regmatch = false);
+    Vector<TextRange> find_all(StringView needle, bool regmatch = false, bool match_case = true);
 
     void update_regex_matches(StringView);
     TextRange find_next(StringView, const TextPosition& start = {}, SearchShouldWrap = SearchShouldWrap::Yes, bool regmatch = false, bool match_case = true);

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -62,7 +62,7 @@ public:
     const TextDocumentLine& line(size_t line_index) const { return m_lines[line_index]; }
     TextDocumentLine& line(size_t line_index) { return m_lines[line_index]; }
 
-    void set_spans(Vector<TextDocumentSpan> spans) { m_spans = move(spans); }
+    void set_spans(u32 span_collection_index, Vector<TextDocumentSpan> spans);
 
     bool set_text(StringView, AllowCallback = AllowCallback::Yes);
 
@@ -136,7 +136,10 @@ protected:
     explicit TextDocument(Client* client);
 
 private:
+    void merge_span_collections();
+
     NonnullOwnPtrVector<TextDocumentLine> m_lines;
+    HashMap<u32, Vector<TextDocumentSpan>> m_span_collections;
     Vector<TextDocumentSpan> m_spans;
 
     HashTable<Client*> m_clients;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1951,7 +1951,7 @@ void TextEditor::set_syntax_highlighter(OwnPtr<Syntax::Highlighter> highlighter)
         m_highlighter->attach(*this);
         m_needs_rehighlight = true;
     } else
-        document().set_spans({});
+        document().set_spans(Syntax::HighlighterClient::span_collection_index, {});
     if (on_highlighter_change)
         on_highlighter_change();
 }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -242,6 +242,8 @@ protected:
     int ruler_width() const;
     int gutter_width() const;
 
+    virtual void highlighter_did_set_spans(Vector<TextDocumentSpan> spans) final { document().set_spans(Syntax::HighlighterClient::span_collection_index, move(spans)); }
+
 private:
     friend class TextDocumentLine;
 

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -213,6 +214,15 @@ public:
     void set_text_is_secret(bool text_is_secret);
     void force_rehighlight();
 
+    enum class SearchDirection {
+        Forward,
+        Backward,
+    };
+    TextRange find_text(StringView needle, SearchDirection, GUI::TextDocument::SearchShouldWrap, bool use_regex, bool match_case);
+    void reset_search_results();
+    Optional<size_t> search_result_index() const { return m_search_result_index; }
+    Vector<TextRange> const& search_results() const { return m_search_results; }
+
 protected:
     explicit TextEditor(Type = Type::MultiLine);
 
@@ -260,7 +270,6 @@ private:
     // ^Syntax::HighlighterClient
     virtual Vector<TextDocumentSpan>& spans() final { return document().spans(); }
     virtual Vector<TextDocumentSpan> const& spans() const final { return document().spans(); }
-    virtual void highlighter_did_set_spans(Vector<TextDocumentSpan> spans) final { document().set_spans(move(spans)); }
     virtual void set_span_at_index(size_t index, TextDocumentSpan span) final { document().set_span_at_index(index, move(span)); }
     virtual void highlighter_did_request_update() final { update(); }
     virtual String highlighter_did_request_text() const final { return text(); }
@@ -337,6 +346,9 @@ private:
     }
 
     virtual void will_execute(TextDocumentUndoCommand const&) { }
+    void on_search_results(GUI::TextRange current, Vector<GUI::TextRange> all_results);
+
+    static constexpr auto search_results_span_collection_index = 1;
 
     Type m_type { MultiLine };
     Mode m_mode { Editable };
@@ -408,6 +420,9 @@ private:
     RefPtr<Gfx::Bitmap> m_icon;
 
     bool m_text_is_secret { false };
+
+    Optional<size_t> m_search_result_index;
+    Vector<GUI::TextRange> m_search_results;
 };
 
 }

--- a/Userland/Libraries/LibGUI/TextPosition.h
+++ b/Userland/Libraries/LibGUI/TextPosition.h
@@ -30,6 +30,8 @@ public:
     bool operator==(const TextPosition& other) const { return m_line == other.m_line && m_column == other.m_column; }
     bool operator!=(const TextPosition& other) const { return m_line != other.m_line || m_column != other.m_column; }
     bool operator<(const TextPosition& other) const { return m_line < other.m_line || (m_line == other.m_line && m_column < other.m_column); }
+    bool operator>(const TextPosition& other) const { return *this != other && !(*this < other); }
+    bool operator>=(const TextPosition& other) const { return *this > other || (*this == other); }
 
 private:
     size_t m_line { 0xffffffff };

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -142,9 +142,9 @@ int ValueSlider::value_at(const Gfx::IntPoint& position) const
     return (int)(relative_offset * (float)max());
 }
 
-void ValueSlider::set_value(int value, AllowCallback allow_callback)
+void ValueSlider::set_value(int value, AllowCallback allow_callback, DoClamp do_clamp)
 {
-    AbstractSlider::set_value(value, allow_callback);
+    AbstractSlider::set_value(value, allow_callback, do_clamp);
     m_textbox->set_text(formatted_value());
 }
 

--- a/Userland/Libraries/LibGUI/ValueSlider.h
+++ b/Userland/Libraries/LibGUI/ValueSlider.h
@@ -25,7 +25,7 @@ public:
     void set_suffix(String suffix) { m_suffix = move(suffix); }
     void set_knob_style(KnobStyle knobstyle) { m_knob_style = knobstyle; }
 
-    virtual void set_value(int value, AllowCallback = AllowCallback::Yes) override;
+    virtual void set_value(int value, AllowCallback = AllowCallback::Yes, DoClamp = DoClamp::Yes) override;
 
 protected:
     virtual void paint_event(PaintEvent&) override;

--- a/Userland/Libraries/LibSyntax/HighlighterClient.h
+++ b/Userland/Libraries/LibSyntax/HighlighterClient.h
@@ -33,6 +33,8 @@ public:
     String get_text() const { return highlighter_did_request_text(); }
     GUI::TextDocument& get_document() { return highlighter_did_request_document(); }
     GUI::TextPosition get_cursor() const { return highlighter_did_request_cursor(); }
+
+    static constexpr auto span_collection_index = 0;
 };
 
 }


### PR DESCRIPTION
- Adds support for multiple layers of TextDocument spans (at last spans != snytax highlighter cc @alimpfard).
- Adds a search action to Hack Studio.
- The search results are highlighted in Hack Studio and TextEditor (using a span layer).

Demo in Hack Studio:
![hs-find2-cut](https://user-images.githubusercontent.com/9247514/160629796-b67818f8-6f8d-4f79-9359-00158b1cf4da.gif)

