### PR TITLE
Ports: Stop zlib from trying to use the host linker

### DIFF
--- a/Ports/zlib/patches/ReadMe.md
+++ b/Ports/zlib/patches/ReadMe.md
@@ -1,0 +1,7 @@
+# Patches for zlib on SerenityOS
+
+## `fix-cross-compilation.patch`
+
+Backports an upstream fix for a bug that caused the host compiler to be used
+for linking even though the cross-compiler was specified in the `CC`
+environment variable.

--- a/Ports/zlib/patches/fix-cross-compilation.patch
+++ b/Ports/zlib/patches/fix-cross-compilation.patch
@@ -1,0 +1,24 @@
+From 05796d3d8d5546cf1b4dfe2cd72ab746afae505d Mon Sep 17 00:00:00 2001
+From: Mark Adler <madler@alumni.caltech.edu>
+Date: Mon, 28 Mar 2022 18:34:10 -0700
+Subject: [PATCH] Fix configure issue that discarded provided CC definition.
+
+---
+ configure | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/configure b/configure
+index 52ff4a04e..3fa3e8618 100755
+--- a/configure
++++ b/configure
+@@ -174,7 +174,10 @@ if test -z "$CC"; then
+   else
+     cc=${CROSS_PREFIX}cc
+   fi
++else
++  cc=${CC}
+ fi
++
+ cflags=${CFLAGS-"-O3"}
+ # to force the asm version use: CFLAGS="-O3 -DASMV" ./configure
+ case "$cc" in


### PR DESCRIPTION
Backports an upstream fix for a bug that caused the host compiler to be
used for linking even though the cross-compiler was specified in the `CC`
environment variable.

This didn't cause an issue for SERENITY_ARCH=i686 on Linux hosts,
because seeing that the host linker couldn't deal with i686 objects, the
configure script fell back to generating only a static library. On
x86-64, the host toolchain was able to deal with the object files, but
tried to link those to host libraries. On macOS hosts, nothing worked.