### PR TITLE
Toolchain: Fix serenity.nix :^)

### DIFF
--- a/Toolchain/serenity.nix
+++ b/Toolchain/serenity.nix
@@ -16,16 +16,22 @@ stdenv.mkDerivation {
     ccache
     rsync
     unzip
-
+    texinfo
     # Example Build-time Additional Dependencies
     pkgconfig
   ];
   buildInputs = [
     # Example Run-time Additional Dependencies
     openssl
-    x11
+    xlibsWrapper
     qemu
+    # e2fsprogs needs some optional parameter to activate fuse2fs with which
+    # the qemu image will be mounted without root access.
+    (e2fsprogs.overrideAttrs (oldAttrs: {
+      buildInputs = oldAttrs.buildInputs ++ [ pkgs.fuse ];
+    }))
     # glibc
   ];
+  
   hardeningDisable = [ "format" "fortify" ];
 }


### PR DESCRIPTION
* x11 package name has changed to xlibsWrapper.
* texinfo is necessary for Makeinfo.
* e2fsprogs was recenty fixed on nicpkgs to include fuse2fs to mount serenity images without root access but it needed some configuration.

To use it:
```bash
nix-shell serenity.nix
Meta/serenity.sh run
```
