### PR TITLE
Browser: Storage inspector improvements

### DIFF
--- a/Userland/Applications/Browser/CookiesModel.cpp
+++ b/Userland/Applications/Browser/CookiesModel.cpp
@@ -29,14 +29,14 @@ void CookiesModel::clear_items()
 String CookiesModel::column_name(int column) const
 {
     switch (column) {
-    case Column::Name:
-        return "Name";
-    case Column::Value:
-        return "Value";
     case Column::Domain:
         return "Domain";
     case Column::Path:
         return "Path";
+    case Column::Name:
+        return "Name";
+    case Column::Value:
+        return "Value";
     case Column::ExpiryTime:
         return "Expiry time";
     case Column::__Count:
@@ -61,14 +61,14 @@ GUI::Variant CookiesModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
     const auto& cookie = m_cookies[index.row()];
 
     switch (index.column()) {
-    case Column::Name:
-        return cookie.name;
-    case Column::Value:
-        return cookie.value;
     case Column::Domain:
         return cookie.domain;
     case Column::Path:
         return cookie.path;
+    case Column::Name:
+        return cookie.name;
+    case Column::Value:
+        return cookie.value;
     case Column::ExpiryTime:
         return cookie.expiry_time.to_string();
     }

--- a/Userland/Applications/Browser/CookiesModel.h
+++ b/Userland/Applications/Browser/CookiesModel.h
@@ -17,10 +17,10 @@ namespace Browser {
 class CookiesModel final : public GUI::Model {
 public:
     enum Column {
-        Name,
-        Value,
         Domain,
         Path,
+        Name,
+        Value,
         ExpiryTime,
         __Count,
     };

--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -26,7 +26,10 @@ StorageWidget::StorageWidget()
     m_cookies_table_view = cookies_tab->find_descendant_of_type_named<GUI::TableView>("cookies_tableview");
     m_cookies_model = adopt_ref(*new CookiesModel());
 
-    m_cookies_table_view->set_model(*m_cookies_model);
+    m_sorting_model = MUST(GUI::SortingProxyModel::create(*m_cookies_model));
+    m_sorting_model->set_sort_role(GUI::ModelRole::Display);
+
+    m_cookies_table_view->set_model(m_sorting_model);
     m_cookies_table_view->set_column_headers_visible(true);
     m_cookies_table_view->set_alternating_row_colors(true);
 }

--- a/Userland/Applications/Browser/StorageWidget.h
+++ b/Userland/Applications/Browser/StorageWidget.h
@@ -8,6 +8,7 @@
 
 #include "CookiesModel.h"
 #include "Tab.h"
+#include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/Widget.h>
 #include <LibWeb/Cookie/Cookie.h>
 
@@ -26,6 +27,7 @@ private:
 
     RefPtr<GUI::TableView> m_cookies_table_view;
     RefPtr<CookiesModel> m_cookies_model;
+    RefPtr<GUI::SortingProxyModel> m_sorting_model;
 };
 
 }


### PR DESCRIPTION
* Show cookie `domain` and `path` values first by moving the columns all the way to the left
* Make the table sortable

![Screenshot_20220330_000140](https://user-images.githubusercontent.com/3210731/160714931-4f7ec168-1283-41a9-b2d5-9c2354a22a7e.png)