### PR TITLE
LibWeb: Add basic support for the attr() CSS function

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Token.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Token.h
@@ -151,6 +151,14 @@ public:
     Position const& start_position() const { return m_start_position; }
     Position const& end_position() const { return m_end_position; }
 
+    static Token of_string(FlyString str)
+    {
+        Token token;
+        token.m_type = Type::String;
+        token.m_value = move(str);
+        return token;
+    }
+
 private:
     Type m_type { Type::Invalid };
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -1625,27 +1625,27 @@ private:
 
 class UnresolvedStyleValue final : public StyleValue {
 public:
-    static NonnullRefPtr<UnresolvedStyleValue> create(Vector<StyleComponentValueRule>&& values, bool contains_var)
+    static NonnullRefPtr<UnresolvedStyleValue> create(Vector<StyleComponentValueRule>&& values, bool contains_var_or_attr)
     {
-        return adopt_ref(*new UnresolvedStyleValue(move(values), contains_var));
+        return adopt_ref(*new UnresolvedStyleValue(move(values), contains_var_or_attr));
     }
     virtual ~UnresolvedStyleValue() override = default;
 
     virtual String to_string() const override;
 
     Vector<StyleComponentValueRule> const& values() const { return m_values; }
-    bool contains_var() const { return m_contains_var; }
+    bool contains_var_or_attr() const { return m_contains_var_or_attr; }
 
 private:
-    UnresolvedStyleValue(Vector<StyleComponentValueRule>&& values, bool contains_var)
+    UnresolvedStyleValue(Vector<StyleComponentValueRule>&& values, bool contains_var_or_attr)
         : StyleValue(Type::Unresolved)
         , m_values(move(values))
-        , m_contains_var(contains_var)
+        , m_contains_var_or_attr(contains_var_or_attr)
     {
     }
 
     Vector<StyleComponentValueRule> m_values;
-    bool m_contains_var { false };
+    bool m_contains_var_or_attr { false };
 };
 
 class UnsetStyleValue final : public StyleValue {


### PR DESCRIPTION
This makes the line numbers and +/- on GitHub diffs show up:

![Screenshot](https://user-images.githubusercontent.com/4679350/160730316-5f84e239-7842-4a83-b56b-ab7e46fb87a9.png)

