### PR TITLE
nc: Make the IP Address argument optional when listening on a port

### DIFF
--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -92,6 +92,11 @@ public:
     void add_positional_argument(Vector<char const*>& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(Vector<StringView>& value, char const* help_string, char const* name, Required required = Required::Yes);
 
+    bool get_show_help()
+    {
+        return m_show_help;
+    }
+
 private:
     void autocomplete(FILE*, StringView program_name, Span<char const* const> remaining_arguments);
 

--- a/Userland/Utilities/nc.cpp
+++ b/Userland/Utilities/nc.cpp
@@ -61,7 +61,13 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(udp_mode, "UDP mode", "udp", 'u');
     args_parser.add_option(should_close, "Close connection after reading stdin to the end", nullptr, 'N');
     args_parser.add_option(maximum_tcp_receive_buffer_size_input, "Set maximum tcp receive buffer size", "length", 'I', nullptr);
-    args_parser.add_positional_argument(target, "Address to listen on, or the address or hostname to connect to", "target");
+    args_parser.parse(arguments, Core::ArgsParser::FailureBehavior::Ignore);
+    if (args_parser.get_show_help())
+        return 0;
+    if (should_listen)
+        target = "0.0.0.0";
+    args_parser.add_positional_argument(target, "Address to listen on, or the address or hostname to connect to", "target",
+        should_listen ? Core::ArgsParser::Required::No : Core::ArgsParser::Required::Yes);
     args_parser.add_positional_argument(port, "Port to connect to or listen on", "port");
     args_parser.parse(arguments);
 


### PR DESCRIPTION
It doesn’t make sense to specify an IP address when listening because you can’t listen with any address other than your own.  This change is in agreement with the MacOS and Linux netcat versions.

Old syntax: nc -l 127.0.0.1 8000
New syntax: nc -l 8000 

