### PR TITLE
SystemMonitor: Remove File Menu

### DIFF
--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -302,11 +302,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         },
         &process_table_view);
 
-    auto& file_menu = window->add_menu("&File");
-    file_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
-        GUI::Application::the()->quit();
-    }));
-
     auto process_context_menu = GUI::Menu::construct();
     process_context_menu->add_action(kill_action);
     process_context_menu->add_action(stop_action);


### PR DESCRIPTION
Remove File menu leaving only Frequency and Help. File menu only had
quit which made it act as a second quit button but with more steps.

Before

![FileMenu](https://user-images.githubusercontent.com/60057590/160755709-a1534d50-16d1-4d7e-8f5d-b5e0ac016e2b.png)
![FileMenuExtended](https://user-images.githubusercontent.com/60057590/160755723-2cb71d1f-f11a-470e-b5b7-d2299d25a120.png)

After

![NoFileMenu](https://user-images.githubusercontent.com/60057590/160755730-a1c8cb01-fb04-4d9b-8fc1-08770d196a27.png)
