### PR TITLE
LibWeb: Implement Element.toggleAttribute()

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Element.h
+++ b/Userland/Libraries/LibWeb/DOM/Element.h
@@ -57,6 +57,7 @@ public:
     ExceptionOr<void> set_attribute(const FlyString& name, const String& value);
     ExceptionOr<void> set_attribute_ns(FlyString const& namespace_, FlyString const& qualified_name, String const& value);
     void remove_attribute(const FlyString& name);
+    DOM::ExceptionOr<bool> toggle_attribute(FlyString const& name, Optional<bool> force);
     size_t attribute_list_size() const { return m_attributes->length(); }
     NonnullRefPtr<NamedNodeMap> const& attributes() const { return m_attributes; }
     Vector<String> get_attribute_names() const;

--- a/Userland/Libraries/LibWeb/DOM/Element.idl
+++ b/Userland/Libraries/LibWeb/DOM/Element.idl
@@ -16,6 +16,7 @@ interface Element : Node {
     undefined setAttribute(DOMString qualifiedName, DOMString value);
     [CEReactions] undefined setAttributeNS(DOMString? namespace , DOMString qualifiedName , DOMString value);
     undefined removeAttribute(DOMString qualifiedName);
+    [CEReactions] boolean toggleAttribute(DOMString qualifiedName, optional boolean force);
     boolean hasAttribute(DOMString qualifiedName);
     boolean hasAttributes();
     [SameObject] readonly attribute NamedNodeMap attributes;


### PR DESCRIPTION
This PR implements `Element.prototype.toggleAttribute()` as prompted by #13355.

Although I've been following along for a long time, I've very much a noob in the codebase so let's see if I've done everything right...