### PR TITLE
LibWeb: Spec all the things! (In the CSS Parser)

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSImportRule.cpp
@@ -73,7 +73,7 @@ void CSSImportRule::resource_did_load()
         dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Resource did load, has encoded data. URL: {}", resource()->url());
     }
 
-    auto sheet = parse_css(CSS::ParsingContext(*m_document, resource()->url()), resource()->encoded_data());
+    auto sheet = parse_css_stylesheet(CSS::ParsingContext(*m_document, resource()->url()), resource()->encoded_data());
     if (!sheet) {
         dbgln_if(CSS_LOADER_DEBUG, "CSSImportRule: Failed to parse stylesheet: {}", resource()->url());
         return;

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.cpp
@@ -12,9 +12,11 @@
 
 namespace Web::CSS {
 
-CSSStyleSheet::CSSStyleSheet(NonnullRefPtrVector<CSSRule> rules)
+CSSStyleSheet::CSSStyleSheet(NonnullRefPtrVector<CSSRule> rules, Optional<AK::URL> location)
     : m_rules(CSSRuleList::create(move(rules)))
 {
+    if (location.has_value())
+        set_location(location->to_string());
 }
 
 // https://www.w3.org/TR/cssom/#dom-cssstylesheet-insertrule

--- a/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
+++ b/Userland/Libraries/LibWeb/CSS/CSSStyleSheet.h
@@ -24,9 +24,9 @@ class CSSStyleSheet final
 public:
     using WrapperType = Bindings::CSSStyleSheetWrapper;
 
-    static NonnullRefPtr<CSSStyleSheet> create(NonnullRefPtrVector<CSSRule> rules)
+    static NonnullRefPtr<CSSStyleSheet> create(NonnullRefPtrVector<CSSRule> rules, Optional<AK::URL> location)
     {
-        return adopt_ref(*new CSSStyleSheet(move(rules)));
+        return adopt_ref(*new CSSStyleSheet(move(rules), move(location)));
     }
 
     virtual ~CSSStyleSheet() override = default;
@@ -53,7 +53,7 @@ public:
     void set_style_sheet_list(Badge<StyleSheetList>, StyleSheetList*);
 
 private:
-    explicit CSSStyleSheet(NonnullRefPtrVector<CSSRule>);
+    explicit CSSStyleSheet(NonnullRefPtrVector<CSSRule>, Optional<AK::URL> location);
 
     NonnullRefPtr<CSSRuleList> m_rules;
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2134,7 +2134,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
                 return {};
 
             auto child_tokens = TokenStream { rule->block()->values() };
-            auto parser_rules = consume_a_list_of_rules(child_tokens, TopLevel::No);
+            auto parser_rules = parse_a_list_of_rules(child_tokens);
             NonnullRefPtrVector<CSSRule> child_rules;
             for (auto& raw_rule : parser_rules) {
                 if (auto child_rule = convert_to_rule(raw_rule))
@@ -2158,7 +2158,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
             if (!rule->block())
                 return {};
             auto child_tokens = TokenStream { rule->block()->values() };
-            auto parser_rules = consume_a_list_of_rules(child_tokens, TopLevel::No);
+            auto parser_rules = parse_a_list_of_rules(child_tokens);
             NonnullRefPtrVector<CSSRule> child_rules;
             for (auto& raw_rule : parser_rules) {
                 if (auto child_rule = convert_to_rule(raw_rule))

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1776,6 +1776,7 @@ NonnullRefPtr<StyleFunctionRule> Parser::consume_a_function(TokenStream<T>& toke
     return function;
 }
 
+// 5.4.6. Consume a declaration
 // https://www.w3.org/TR/css-syntax-3/#consume-declaration
 template<typename T>
 Optional<StyleDeclarationRule> Parser::consume_a_declaration(TokenStream<T>& tokens)
@@ -1790,6 +1791,8 @@ Optional<StyleDeclarationRule> Parser::consume_a_declaration(TokenStream<T>& tok
     auto start_position = tokens.position();
     auto& token = tokens.next_token();
 
+    // Note: Not to spec, handle the case where the input token *isn't* an <ident-token>.
+    // FIXME: Perform this check before calling consume_a_declaration().
     if (!token.is(Token::Type::Ident)) {
         tokens.rewind_to_position(start_position);
         return {};

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1903,24 +1903,21 @@ RefPtr<CSSRule> Parser::parse_a_rule(TokenStream<T>& tokens)
     return {};
 }
 
-NonnullRefPtrVector<CSSRule> Parser::parse_as_list_of_rules()
-{
-    return parse_a_list_of_rules(m_token_stream);
-}
-
+// 5.3.4. Parse a list of rules
+// https://www.w3.org/TR/css-syntax-3/#parse-list-of-rules
 template<typename T>
-NonnullRefPtrVector<CSSRule> Parser::parse_a_list_of_rules(TokenStream<T>& tokens)
+NonnullRefPtrVector<StyleRule> Parser::parse_a_list_of_rules(TokenStream<T>& tokens)
 {
-    auto parsed_rules = consume_a_list_of_rules(tokens, TopLevel::No);
-    NonnullRefPtrVector<CSSRule> rules;
+    // To parse a list of rules from input:
 
-    for (auto& rule : parsed_rules) {
-        auto converted_rule = convert_to_rule(rule);
-        if (converted_rule)
-            rules.append(*converted_rule);
-    }
+    // 1. Normalize input, and set input to the result.
+    // Note: This is done when initializing the Parser.
 
-    return rules;
+    // 2. Consume a list of rules from the input, with the top-level flag unset.
+    auto list_of_rules = consume_a_list_of_rules(tokens, TopLevel::No);
+
+    // 3. Return the returned list.
+    return list_of_rules;
 }
 
 Optional<StyleProperty> Parser::parse_as_declaration()

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1697,20 +1697,30 @@ RefPtr<StyleRule> Parser::consume_a_qualified_rule(TokenStream<T>& tokens)
 template<>
 StyleComponentValueRule Parser::consume_a_component_value(TokenStream<StyleComponentValueRule>& tokens)
 {
+    // Note: This overload is called once tokens have already been converted into component values,
+    //       so we do not need to do the work in the more general overload.
     return tokens.next_token();
 }
 
+// 5.4.7. Consume a component value
+// https://www.w3.org/TR/css-syntax-3/#consume-component-value
 template<typename T>
 StyleComponentValueRule Parser::consume_a_component_value(TokenStream<T>& tokens)
 {
+    // To consume a component value:
+
+    // Consume the next input token.
     auto& token = tokens.next_token();
 
+    // If the current input token is a <{-token>, <[-token>, or <(-token>, consume a simple block and return it.
     if (token.is(Token::Type::OpenCurly) || token.is(Token::Type::OpenSquare) || token.is(Token::Type::OpenParen))
         return StyleComponentValueRule(consume_a_simple_block(tokens));
 
+    // Otherwise, if the current input token is a <function-token>, consume a function and return it.
     if (token.is(Token::Type::Function))
         return StyleComponentValueRule(consume_a_function(tokens));
 
+    // Otherwise, return the current input token.
     return StyleComponentValueRule(token);
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1932,26 +1932,36 @@ NonnullRefPtrVector<StyleRule> Parser::parse_a_list_of_rules(TokenStream<T>& tok
     return list_of_rules;
 }
 
-Optional<StyleProperty> Parser::parse_as_declaration()
+Optional<StyleProperty> Parser::parse_as_supports_condition()
 {
-    return parse_a_declaration(m_token_stream);
+    auto maybe_declaration = parse_a_declaration(m_token_stream);
+    if (maybe_declaration.has_value())
+        return convert_to_style_property(maybe_declaration.release_value());
+    return {};
 }
 
+// 5.3.6. Parse a declaration
+// https://www.w3.org/TR/css-syntax-3/#parse-a-declaration
 template<typename T>
-Optional<StyleProperty> Parser::parse_a_declaration(TokenStream<T>& tokens)
+Optional<StyleDeclarationRule> Parser::parse_a_declaration(TokenStream<T>& tokens)
 {
+    // To parse a declaration from input:
+
+    // 1. Normalize input, and set input to the result.
+    // Note: This is done when initializing the Parser.
+
+    // 2. While the next input token from input is a <whitespace-token>, consume the next input token.
     tokens.skip_whitespace();
 
+    // 3. If the next input token from input is not an <ident-token>, return a syntax error.
     auto& token = tokens.peek_token();
-
     if (!token.is(Token::Type::Ident)) {
         return {};
     }
 
-    auto declaration = consume_a_declaration(tokens);
-    if (declaration.has_value())
-        return convert_to_style_property(declaration.value());
-
+    // 4. Consume a declaration from input. If anything was returned, return it. Otherwise, return a syntax error.
+    if (auto declaration = consume_a_declaration(tokens); declaration.has_value())
+        return declaration.release_value();
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -180,7 +180,7 @@ NonnullRefPtr<CSSStyleSheet> Parser::parse_a_stylesheet(TokenStream<T>& tokens, 
     // NOTE: We create the stylesheet at the end.
 
     // 4. Consume a list of rules from input, with the top-level flag set, and set the stylesheet’s value to the result.
-    auto parser_rules = consume_a_list_of_rules(tokens, true);
+    auto parser_rules = consume_a_list_of_rules(tokens, TopLevel::Yes);
     NonnullRefPtrVector<CSSRule> rules;
 
     for (auto& raw_rule : parser_rules) {
@@ -1510,7 +1510,7 @@ Optional<GeneralEnclosed> Parser::parse_general_enclosed(TokenStream<StyleCompon
 }
 
 template<typename T>
-NonnullRefPtrVector<StyleRule> Parser::consume_a_list_of_rules(TokenStream<T>& tokens, bool top_level)
+NonnullRefPtrVector<StyleRule> Parser::consume_a_list_of_rules(TokenStream<T>& tokens, TopLevel top_level)
 {
     NonnullRefPtrVector<StyleRule> rules;
 
@@ -1526,7 +1526,7 @@ NonnullRefPtrVector<StyleRule> Parser::consume_a_list_of_rules(TokenStream<T>& t
         }
 
         if (token.is(Token::Type::CDO) || token.is(Token::Type::CDC)) {
-            if (top_level) {
+            if (top_level == TopLevel::Yes) {
                 continue;
             }
 
@@ -1904,7 +1904,7 @@ NonnullRefPtrVector<CSSRule> Parser::parse_as_list_of_rules()
 template<typename T>
 NonnullRefPtrVector<CSSRule> Parser::parse_a_list_of_rules(TokenStream<T>& tokens)
 {
-    auto parsed_rules = consume_a_list_of_rules(tokens, false);
+    auto parsed_rules = consume_a_list_of_rules(tokens, TopLevel::No);
     NonnullRefPtrVector<CSSRule> rules;
 
     for (auto& rule : parsed_rules) {
@@ -2130,7 +2130,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
                 return {};
 
             auto child_tokens = TokenStream { rule->block()->values() };
-            auto parser_rules = consume_a_list_of_rules(child_tokens, false);
+            auto parser_rules = consume_a_list_of_rules(child_tokens, TopLevel::No);
             NonnullRefPtrVector<CSSRule> child_rules;
             for (auto& raw_rule : parser_rules) {
                 if (auto child_rule = convert_to_rule(raw_rule))
@@ -2154,7 +2154,7 @@ RefPtr<CSSRule> Parser::convert_to_rule(NonnullRefPtr<StyleRule> rule)
             if (!rule->block())
                 return {};
             auto child_tokens = TokenStream { rule->block()->values() };
-            auto parser_rules = consume_a_list_of_rules(child_tokens, false);
+            auto parser_rules = consume_a_list_of_rules(child_tokens, TopLevel::No);
             NonnullRefPtrVector<CSSRule> child_rules;
             for (auto& raw_rule : parser_rules) {
                 if (auto child_rule = convert_to_rule(raw_rule))

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -160,14 +160,26 @@ Parser::Parser(ParsingContext const& context, StringView input, String const& en
 {
 }
 
-NonnullRefPtr<CSSStyleSheet> Parser::parse_as_stylesheet()
+NonnullRefPtr<CSSStyleSheet> Parser::parse_as_stylesheet(Optional<AK::URL> location)
 {
-    return parse_a_stylesheet(m_token_stream);
+    return parse_a_stylesheet(m_token_stream, location);
 }
 
+// 5.3.3. Parse a stylesheet
+// https://www.w3.org/TR/css-syntax-3/#parse-stylesheet
 template<typename T>
-NonnullRefPtr<CSSStyleSheet> Parser::parse_a_stylesheet(TokenStream<T>& tokens)
+NonnullRefPtr<CSSStyleSheet> Parser::parse_a_stylesheet(TokenStream<T>& tokens, Optional<AK::URL> location)
 {
+    // To parse a stylesheet from an input given an optional url location:
+
+    // 1. If input is a byte stream for stylesheet, decode bytes from input, and set input to the result.
+    // 2. Normalize input, and set input to the result.
+    // NOTE: These are done automatically when creating the Parser.
+
+    // 3. Create a new stylesheet, with its location set to location (or null, if location was not passed).
+    // NOTE: We create the stylesheet at the end.
+
+    // 4. Consume a list of rules from input, with the top-level flag set, and set the stylesheet’s value to the result.
     auto parser_rules = consume_a_list_of_rules(tokens, true);
     NonnullRefPtrVector<CSSRule> rules;
 
@@ -177,7 +189,8 @@ NonnullRefPtr<CSSStyleSheet> Parser::parse_a_stylesheet(TokenStream<T>& tokens)
             rules.append(*rule);
     }
 
-    return CSSStyleSheet::create(rules);
+    // 5. Return the stylesheet.
+    return CSSStyleSheet::create(move(rules), move(location));
 }
 
 Optional<SelectorList> Parser::parse_as_selector(SelectorParsingMode parsing_mode)
@@ -5224,12 +5237,12 @@ TimePercentage Parser::Dimension::time_percentage() const
 
 namespace Web {
 
-RefPtr<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::ParsingContext const& context, StringView css)
+RefPtr<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::ParsingContext const& context, StringView css, Optional<AK::URL> location)
 {
     if (css.is_empty())
-        return CSS::CSSStyleSheet::create({});
+        return CSS::CSSStyleSheet::create({}, location);
     CSS::Parser parser(context, css);
-    return parser.parse_as_stylesheet();
+    return parser.parse_as_stylesheet(location);
 }
 
 RefPtr<CSS::ElementInlineCSSStyleDeclaration> parse_css_style_attribute(CSS::ParsingContext const& context, StringView css, DOM::Element& element)

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1965,18 +1965,16 @@ Optional<StyleDeclarationRule> Parser::parse_a_declaration(TokenStream<T>& token
     return {};
 }
 
-Vector<DeclarationOrAtRule> Parser::parse_as_list_of_declarations()
-{
-    return parse_a_list_of_declarations(m_token_stream);
-}
-
 // 5.3.8. Parse a list of declarations
 // https://www.w3.org/TR/css-syntax-3/#parse-list-of-declarations
 template<typename T>
 Vector<DeclarationOrAtRule> Parser::parse_a_list_of_declarations(TokenStream<T>& tokens)
 {
     // To parse a list of declarations from input:
+
     // 1. Normalize input, and set input to the result.
+    // Note: This is done when initializing the Parser.
+
     // 2. Consume a list of declarations from input, and return the result.
     return consume_a_list_of_declarations(tokens);
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2008,25 +2008,28 @@ Optional<StyleComponentValueRule> Parser::parse_a_component_value(TokenStream<T>
     return {};
 }
 
-Vector<StyleComponentValueRule> Parser::parse_as_list_of_component_values()
-{
-    return parse_a_list_of_component_values(m_token_stream);
-}
-
+// 5.3.10. Parse a list of component values
+// https://www.w3.org/TR/css-syntax-3/#parse-list-of-component-values
 template<typename T>
 Vector<StyleComponentValueRule> Parser::parse_a_list_of_component_values(TokenStream<T>& tokens)
 {
-    Vector<StyleComponentValueRule> rules;
+    // To parse a list of component values from input:
+
+    // 1. Normalize input, and set input to the result.
+    // Note: This is done when initializing the Parser.
+
+    // 2. Repeatedly consume a component value from input until an <EOF-token> is returned, appending the returned values (except the final <EOF-token>) into a list. Return the list.
+    Vector<StyleComponentValueRule> component_values;
 
     for (;;) {
         if (tokens.peek_token().is(Token::Type::EndOfFile)) {
             break;
         }
 
-        rules.append(consume_a_component_value(tokens));
+        component_values.append(consume_a_component_value(tokens));
     }
 
-    return rules;
+    return component_values;
 }
 
 Vector<Vector<StyleComponentValueRule>> Parser::parse_as_comma_separated_list_of_component_values()
@@ -4322,7 +4325,7 @@ RefPtr<StyleValue> Parser::parse_transform_origin_value(Vector<StyleComponentVal
 
 RefPtr<StyleValue> Parser::parse_as_css_value(PropertyID property_id)
 {
-    auto component_values = parse_as_list_of_component_values();
+    auto component_values = parse_a_list_of_component_values(m_token_stream);
     auto tokens = TokenStream(component_values);
     auto parsed_value = parse_css_value(property_id, tokens);
     if (parsed_value.is_error())

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5224,7 +5224,7 @@ TimePercentage Parser::Dimension::time_percentage() const
 
 namespace Web {
 
-RefPtr<CSS::CSSStyleSheet> parse_css(CSS::ParsingContext const& context, StringView css)
+RefPtr<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::ParsingContext const& context, StringView css)
 {
     if (css.is_empty())
         return CSS::CSSStyleSheet::create({});

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1979,31 +1979,32 @@ Vector<DeclarationOrAtRule> Parser::parse_a_list_of_declarations(TokenStream<T>&
     return consume_a_list_of_declarations(tokens);
 }
 
-Optional<StyleComponentValueRule> Parser::parse_as_component_value()
-{
-    return parse_a_component_value(m_token_stream);
-}
-
+// 5.3.9. Parse a component value
+// https://www.w3.org/TR/css-syntax-3/#parse-component-value
 template<typename T>
 Optional<StyleComponentValueRule> Parser::parse_a_component_value(TokenStream<T>& tokens)
 {
+    // To parse a component value from input:
+
+    // 1. Normalize input, and set input to the result.
+    // Note: This is done when initializing the Parser.
+
+    // 2. While the next input token from input is a <whitespace-token>, consume the next input token from input.
     tokens.skip_whitespace();
 
-    auto& token = tokens.peek_token();
-
-    if (token.is(Token::Type::EndOfFile)) {
+    // 3. If the next input token from input is an <EOF-token>, return a syntax error.
+    if (tokens.peek_token().is(Token::Type::EndOfFile))
         return {};
-    }
 
+    // 4. Consume a component value from input and let value be the return value.
     auto value = consume_a_component_value(tokens);
 
+    // 5. While the next input token from input is a <whitespace-token>, consume the next input token.
     tokens.skip_whitespace();
 
-    auto& maybe_eof = tokens.peek_token();
-    if (maybe_eof.is(Token::Type::EndOfFile)) {
+    // 6. If the next input token from input is an <EOF-token>, return value. Otherwise, return a syntax error.
+    if (tokens.peek_token().is(Token::Type::EndOfFile))
         return value;
-    }
-
     return {};
 }
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,8 +89,6 @@ public:
     Parser(ParsingContext const&, StringView input, String const& encoding = "utf-8");
     ~Parser() = default;
 
-    // For use by the CSSStyleSheet#insertRule method, and similar functions which might exist, which parse text into a single rule.
-    RefPtr<CSSRule> parse_as_rule();
     // Used in @supports conditions. [CSS3-CONDITIONAL]
     Optional<StyleProperty> parse_as_declaration();
     // For the contents of a style attribute, which parses text into the contents of a single style rule.
@@ -103,6 +101,7 @@ public:
 
     NonnullRefPtr<CSSStyleSheet> parse_as_css_stylesheet(Optional<AK::URL> location);
     RefPtr<ElementInlineCSSStyleDeclaration> parse_as_style_attribute(DOM::Element&);
+    RefPtr<CSSRule> parse_as_css_rule();
 
     enum class SelectorParsingMode {
         Standard,
@@ -142,8 +141,11 @@ private:
     // "Parse a list of rules" is intended for the content of at-rules such as @media. It differs from "Parse a stylesheet" in the handling of <CDO-token> and <CDC-token>.
     template<typename T>
     NonnullRefPtrVector<StyleRule> parse_a_list_of_rules(TokenStream<T>&);
+
+    // "Parse a rule" is intended for use by the CSSStyleSheet#insertRule method, and similar functions which might exist, which parse text into a single rule.
     template<typename T>
-    RefPtr<CSSRule> parse_a_rule(TokenStream<T>&);
+    RefPtr<StyleRule> parse_a_rule(TokenStream<T>&);
+
     template<typename T>
     Optional<StyleProperty> parse_a_declaration(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -141,6 +141,9 @@ private:
     template<typename T>
     Optional<StyleDeclarationRule> parse_a_declaration(TokenStream<T>&);
 
+    template<typename T>
+    Vector<DeclarationOrAtRule> parse_a_style_blocks_contents(TokenStream<T>&);
+
     // "Parse a list of declarations" is for the contents of a style attribute, which parses text into the contents of a single style rule.
     template<typename T>
     Vector<DeclarationOrAtRule> parse_a_list_of_declarations(TokenStream<T>&);
@@ -184,6 +187,8 @@ private:
     [[nodiscard]] NonnullRefPtr<StyleRule> consume_an_at_rule(TokenStream<T>&);
     template<typename T>
     [[nodiscard]] RefPtr<StyleRule> consume_a_qualified_rule(TokenStream<T>&);
+    template<typename T>
+    [[nodiscard]] Vector<DeclarationOrAtRule> consume_a_style_blocks_contents(TokenStream<T>&);
     template<typename T>
     [[nodiscard]] Vector<DeclarationOrAtRule> consume_a_list_of_declarations(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,8 +89,6 @@ public:
     Parser(ParsingContext const&, StringView input, String const& encoding = "utf-8");
     ~Parser() = default;
 
-    // For the contents of presentational attributes, which parse text into a single declaration’s value, or for parsing a stand-alone selector [SELECT] or list of Media Queries [MEDIAQ], as in Selectors API or the media HTML attribute.
-    Vector<StyleComponentValueRule> parse_as_list_of_component_values();
     Vector<Vector<StyleComponentValueRule>> parse_as_comma_separated_list_of_component_values();
 
     NonnullRefPtr<CSSStyleSheet> parse_as_css_stylesheet(Optional<AK::URL> location);
@@ -152,8 +150,11 @@ private:
     // "Parse a component value" is for things that need to consume a single value, like the parsing rules for attr().
     template<typename T>
     Optional<StyleComponentValueRule> parse_a_component_value(TokenStream<T>&);
+
+    // "Parse a list of component values" is for the contents of presentational attributes, which parse text into a single declaration’s value, or for parsing a stand-alone selector [SELECT] or list of Media Queries [MEDIAQ], as in Selectors API or the media HTML attribute.
     template<typename T>
     Vector<StyleComponentValueRule> parse_a_list_of_component_values(TokenStream<T>&);
+
     template<typename T>
     Vector<Vector<StyleComponentValueRule>> parse_a_comma_separated_list_of_component_values(TokenStream<T>&);
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -90,7 +90,7 @@ public:
     ~Parser() = default;
 
     // The normal parser entry point, for parsing stylesheets.
-    NonnullRefPtr<CSSStyleSheet> parse_as_stylesheet();
+    NonnullRefPtr<CSSStyleSheet> parse_as_stylesheet(Optional<AK::URL> location);
     // For the content of at-rules such as @media. It differs from "Parse a stylesheet" in the handling of <CDO-token> and <CDC-token>.
     NonnullRefPtrVector<CSSRule> parse_as_list_of_rules();
     // For use by the CSSStyleSheet#insertRule method, and similar functions which might exist, which parse text into a single rule.
@@ -135,7 +135,7 @@ private:
     };
 
     template<typename T>
-    NonnullRefPtr<CSSStyleSheet> parse_a_stylesheet(TokenStream<T>&);
+    NonnullRefPtr<CSSStyleSheet> parse_a_stylesheet(TokenStream<T>&, Optional<AK::URL> location);
     template<typename T>
     NonnullRefPtrVector<CSSRule> parse_a_list_of_rules(TokenStream<T>&);
     template<typename T>
@@ -361,7 +361,7 @@ private:
 
 namespace Web {
 
-RefPtr<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::ParsingContext const&, StringView);
+RefPtr<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::ParsingContext const&, StringView, Optional<AK::URL> location = {});
 RefPtr<CSS::ElementInlineCSSStyleDeclaration> parse_css_style_attribute(CSS::ParsingContext const&, StringView, DOM::Element&);
 RefPtr<CSS::StyleValue> parse_css_value(CSS::ParsingContext const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);
 Optional<CSS::SelectorList> parse_selector(CSS::ParsingContext const&, StringView);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,8 +89,6 @@ public:
     Parser(ParsingContext const&, StringView input, String const& encoding = "utf-8");
     ~Parser() = default;
 
-    // For the content of at-rules such as @media. It differs from "Parse a stylesheet" in the handling of <CDO-token> and <CDC-token>.
-    NonnullRefPtrVector<CSSRule> parse_as_list_of_rules();
     // For use by the CSSStyleSheet#insertRule method, and similar functions which might exist, which parse text into a single rule.
     RefPtr<CSSRule> parse_as_rule();
     // Used in @supports conditions. [CSS3-CONDITIONAL]
@@ -141,8 +139,9 @@ private:
     template<typename T>
     ParsedStyleSheet parse_a_stylesheet(TokenStream<T>&, Optional<AK::URL> location);
 
+    // For the content of at-rules such as @media. It differs from "Parse a stylesheet" in the handling of <CDO-token> and <CDC-token>.
     template<typename T>
-    NonnullRefPtrVector<CSSRule> parse_a_list_of_rules(TokenStream<T>&);
+    NonnullRefPtrVector<StyleRule> parse_a_list_of_rules(TokenStream<T>&);
     template<typename T>
     RefPtr<CSSRule> parse_a_rule(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -139,7 +139,7 @@ private:
     template<typename T>
     ParsedStyleSheet parse_a_stylesheet(TokenStream<T>&, Optional<AK::URL> location);
 
-    // For the content of at-rules such as @media. It differs from "Parse a stylesheet" in the handling of <CDO-token> and <CDC-token>.
+    // "Parse a list of rules" is intended for the content of at-rules such as @media. It differs from "Parse a stylesheet" in the handling of <CDO-token> and <CDC-token>.
     template<typename T>
     NonnullRefPtrVector<StyleRule> parse_a_list_of_rules(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,8 +89,6 @@ public:
     Parser(ParsingContext const&, StringView input, String const& encoding = "utf-8");
     ~Parser() = default;
 
-    // Used in @supports conditions. [CSS3-CONDITIONAL]
-    Optional<StyleProperty> parse_as_declaration();
     // For the contents of a style attribute, which parses text into the contents of a single style rule.
     Vector<DeclarationOrAtRule> parse_as_list_of_declarations();
     // For things that need to consume a single value, like the parsing rules for attr().
@@ -102,6 +100,7 @@ public:
     NonnullRefPtr<CSSStyleSheet> parse_as_css_stylesheet(Optional<AK::URL> location);
     RefPtr<ElementInlineCSSStyleDeclaration> parse_as_style_attribute(DOM::Element&);
     RefPtr<CSSRule> parse_as_css_rule();
+    Optional<StyleProperty> parse_as_supports_condition();
 
     enum class SelectorParsingMode {
         Standard,
@@ -146,8 +145,9 @@ private:
     template<typename T>
     RefPtr<StyleRule> parse_a_rule(TokenStream<T>&);
 
+    // "Parse a declaration" is used in @supports conditions. [CSS3-CONDITIONAL]
     template<typename T>
-    Optional<StyleProperty> parse_a_declaration(TokenStream<T>&);
+    Optional<StyleDeclarationRule> parse_a_declaration(TokenStream<T>&);
     template<typename T>
     Vector<DeclarationOrAtRule> parse_a_list_of_declarations(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,8 +89,6 @@ public:
     Parser(ParsingContext const&, StringView input, String const& encoding = "utf-8");
     ~Parser() = default;
 
-    // For the contents of a style attribute, which parses text into the contents of a single style rule.
-    Vector<DeclarationOrAtRule> parse_as_list_of_declarations();
     // For things that need to consume a single value, like the parsing rules for attr().
     Optional<StyleComponentValueRule> parse_as_component_value();
     // For the contents of presentational attributes, which parse text into a single declaration’s value, or for parsing a stand-alone selector [SELECT] or list of Media Queries [MEDIAQ], as in Selectors API or the media HTML attribute.
@@ -148,6 +146,8 @@ private:
     // "Parse a declaration" is used in @supports conditions. [CSS3-CONDITIONAL]
     template<typename T>
     Optional<StyleDeclarationRule> parse_a_declaration(TokenStream<T>&);
+
+    // "Parse a list of declarations" is for the contents of a style attribute, which parses text into the contents of a single style rule.
     template<typename T>
     Vector<DeclarationOrAtRule> parse_a_list_of_declarations(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -186,27 +186,27 @@ private:
     template<typename T>
     [[nodiscard]] NonnullRefPtr<StyleRule> consume_an_at_rule(TokenStream<T>&);
     template<typename T>
-    [[nodiscard]] RefPtr<StyleRule> consume_a_qualified_rule(TokenStream<T>&);
+    RefPtr<StyleRule> consume_a_qualified_rule(TokenStream<T>&);
     template<typename T>
     [[nodiscard]] Vector<DeclarationOrAtRule> consume_a_style_blocks_contents(TokenStream<T>&);
     template<typename T>
     [[nodiscard]] Vector<DeclarationOrAtRule> consume_a_list_of_declarations(TokenStream<T>&);
     template<typename T>
-    [[nodiscard]] Optional<StyleDeclarationRule> consume_a_declaration(TokenStream<T>&);
+    Optional<StyleDeclarationRule> consume_a_declaration(TokenStream<T>&);
     template<typename T>
     [[nodiscard]] StyleComponentValueRule consume_a_component_value(TokenStream<T>&);
     template<typename T>
-    [[nodiscard]] NonnullRefPtr<StyleBlockRule> consume_a_simple_block(TokenStream<T>&);
+    NonnullRefPtr<StyleBlockRule> consume_a_simple_block(TokenStream<T>&);
     template<typename T>
-    [[nodiscard]] NonnullRefPtr<StyleFunctionRule> consume_a_function(TokenStream<T>&);
+    NonnullRefPtr<StyleFunctionRule> consume_a_function(TokenStream<T>&);
 
-    [[nodiscard]] Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<StyleComponentValueRule>&);
+    Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<StyleComponentValueRule>&);
 
     RefPtr<CSSRule> parse_font_face_rule(TokenStream<StyleComponentValueRule>&);
 
-    [[nodiscard]] RefPtr<CSSRule> convert_to_rule(NonnullRefPtr<StyleRule>);
-    [[nodiscard]] RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_style_declaration(Vector<DeclarationOrAtRule> declarations);
-    [[nodiscard]] Optional<StyleProperty> convert_to_style_property(StyleDeclarationRule const&);
+    RefPtr<CSSRule> convert_to_rule(NonnullRefPtr<StyleRule>);
+    RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_style_declaration(Vector<DeclarationOrAtRule> declarations);
+    Optional<StyleProperty> convert_to_style_property(StyleDeclarationRule const&);
 
     class Dimension {
     public:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -361,7 +361,7 @@ private:
 
 namespace Web {
 
-RefPtr<CSS::CSSStyleSheet> parse_css(CSS::ParsingContext const&, StringView);
+RefPtr<CSS::CSSStyleSheet> parse_css_stylesheet(CSS::ParsingContext const&, StringView);
 RefPtr<CSS::ElementInlineCSSStyleDeclaration> parse_css_style_attribute(CSS::ParsingContext const&, StringView, DOM::Element&);
 RefPtr<CSS::StyleValue> parse_css_value(CSS::ParsingContext const&, StringView, CSS::PropertyID property_id = CSS::PropertyID::Invalid);
 Optional<CSS::SelectorList> parse_selector(CSS::ParsingContext const&, StringView);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,8 +89,6 @@ public:
     Parser(ParsingContext const&, StringView input, String const& encoding = "utf-8");
     ~Parser() = default;
 
-    // The normal parser entry point, for parsing stylesheets.
-    NonnullRefPtr<CSSStyleSheet> parse_as_stylesheet(Optional<AK::URL> location);
     // For the content of at-rules such as @media. It differs from "Parse a stylesheet" in the handling of <CDO-token> and <CDC-token>.
     NonnullRefPtrVector<CSSRule> parse_as_list_of_rules();
     // For use by the CSSStyleSheet#insertRule method, and similar functions which might exist, which parse text into a single rule.
@@ -105,6 +103,7 @@ public:
     Vector<StyleComponentValueRule> parse_as_list_of_component_values();
     Vector<Vector<StyleComponentValueRule>> parse_as_comma_separated_list_of_component_values();
 
+    NonnullRefPtr<CSSStyleSheet> parse_as_css_stylesheet(Optional<AK::URL> location);
     RefPtr<ElementInlineCSSStyleDeclaration> parse_as_style_attribute(DOM::Element&);
 
     enum class SelectorParsingMode {
@@ -134,8 +133,14 @@ private:
         SyntaxError,
     };
 
+    // "Parse a stylesheet" is intended to be the normal parser entry point, for parsing stylesheets.
+    struct ParsedStyleSheet {
+        Optional<AK::URL> location;
+        NonnullRefPtrVector<StyleRule> rules;
+    };
     template<typename T>
-    NonnullRefPtr<CSSStyleSheet> parse_a_stylesheet(TokenStream<T>&, Optional<AK::URL> location);
+    ParsedStyleSheet parse_a_stylesheet(TokenStream<T>&, Optional<AK::URL> location);
+
     template<typename T>
     NonnullRefPtrVector<CSSRule> parse_a_list_of_rules(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -169,8 +169,12 @@ private:
     };
     Optional<Selector::SimpleSelector::ANPlusBPattern> parse_a_n_plus_b_pattern(TokenStream<StyleComponentValueRule>&, AllowTrailingTokens = AllowTrailingTokens::No);
 
+    enum class TopLevel {
+        No,
+        Yes
+    };
     template<typename T>
-    [[nodiscard]] NonnullRefPtrVector<StyleRule> consume_a_list_of_rules(TokenStream<T>&, bool top_level);
+    [[nodiscard]] NonnullRefPtrVector<StyleRule> consume_a_list_of_rules(TokenStream<T>&, TopLevel);
     template<typename T>
     [[nodiscard]] NonnullRefPtr<StyleRule> consume_an_at_rule(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,8 +89,6 @@ public:
     Parser(ParsingContext const&, StringView input, String const& encoding = "utf-8");
     ~Parser() = default;
 
-    // For things that need to consume a single value, like the parsing rules for attr().
-    Optional<StyleComponentValueRule> parse_as_component_value();
     // For the contents of presentational attributes, which parse text into a single declaration’s value, or for parsing a stand-alone selector [SELECT] or list of Media Queries [MEDIAQ], as in Selectors API or the media HTML attribute.
     Vector<StyleComponentValueRule> parse_as_list_of_component_values();
     Vector<Vector<StyleComponentValueRule>> parse_as_comma_separated_list_of_component_values();
@@ -150,6 +148,8 @@ private:
     // "Parse a list of declarations" is for the contents of a style attribute, which parses text into the contents of a single style rule.
     template<typename T>
     Vector<DeclarationOrAtRule> parse_a_list_of_declarations(TokenStream<T>&);
+
+    // "Parse a component value" is for things that need to consume a single value, like the parsing rules for attr().
     template<typename T>
     Optional<StyleComponentValueRule> parse_a_component_value(TokenStream<T>&);
     template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -89,8 +89,6 @@ public:
     Parser(ParsingContext const&, StringView input, String const& encoding = "utf-8");
     ~Parser() = default;
 
-    Vector<Vector<StyleComponentValueRule>> parse_as_comma_separated_list_of_component_values();
-
     NonnullRefPtr<CSSStyleSheet> parse_as_css_stylesheet(Optional<AK::URL> location);
     RefPtr<ElementInlineCSSStyleDeclaration> parse_as_style_attribute(DOM::Element&);
     RefPtr<CSSRule> parse_as_css_rule();

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRule.h
@@ -26,14 +26,18 @@ public:
     StyleRule(Type);
     ~StyleRule();
 
+    bool is_qualified_rule() const { return m_type == Type::Qualified; }
+    bool is_at_rule() const { return m_type == Type::At; }
+
     Vector<StyleComponentValueRule> const& prelude() const { return m_prelude; }
     RefPtr<StyleBlockRule const> block() const { return m_block; }
+    String const& at_rule_name() const { return m_at_rule_name; }
 
     String to_string() const;
 
 private:
     Type const m_type;
-    String m_name; // At-rules only
+    String m_at_rule_name;
     Vector<StyleComponentValueRule> m_prelude;
     RefPtr<StyleBlockRule> m_block;
 };

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
@@ -98,9 +98,9 @@ String StyleRule::to_string() const
 {
     StringBuilder builder;
 
-    if (m_type == Type::At) {
+    if (is_at_rule()) {
         builder.append("@");
-        serialize_an_identifier(builder, m_name);
+        serialize_an_identifier(builder, m_at_rule_name);
     }
 
     append_with_to_string(builder, " ", m_prelude);

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -80,7 +80,7 @@ static StyleSheet& default_stylesheet()
     if (!sheet) {
         extern char const default_stylesheet_source[];
         String css = default_stylesheet_source;
-        sheet = parse_css(CSS::ParsingContext(), css).leak_ref();
+        sheet = parse_css_stylesheet(CSS::ParsingContext(), css).leak_ref();
     }
     return *sheet;
 }
@@ -91,7 +91,7 @@ static StyleSheet& quirks_mode_stylesheet()
     if (!sheet) {
         extern char const quirks_mode_stylesheet_source[];
         String css = quirks_mode_stylesheet_source;
-        sheet = parse_css(CSS::ParsingContext(), css).leak_ref();
+        sheet = parse_css_stylesheet(CSS::ParsingContext(), css).leak_ref();
     }
     return *sheet;
 }

--- a/Userland/Libraries/LibWeb/CSS/Supports.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Supports.cpp
@@ -52,7 +52,7 @@ bool Supports::InParens::evaluate() const
 
 bool Supports::Declaration::evaluate() const
 {
-    auto style_property = Parser({}, declaration).parse_as_declaration();
+    auto style_property = Parser({}, declaration).parse_as_supports_condition();
     return style_property.has_value();
 }
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -97,7 +97,7 @@ void HTMLLinkElement::resource_did_load()
         }
     }
 
-    auto sheet = parse_css(CSS::ParsingContext(document(), resource()->url()), resource()->encoded_data());
+    auto sheet = parse_css_stylesheet(CSS::ParsingContext(document(), resource()->url()), resource()->encoded_data());
     if (!sheet) {
         dbgln_if(CSS_LOADER_DEBUG, "HTMLLinkElement: Failed to parse stylesheet: {}", resource()->url());
         return;

--- a/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLStyleElement.cpp
@@ -126,7 +126,7 @@ void HTMLStyleElement::update_a_style_block()
 
     // FIXME: This is a bit awkward, as the spec doesn't actually tell us when to parse the CSS text,
     //        so we just do it here and pass the parsed sheet to create_a_css_style_sheet().
-    auto sheet = parse_css(CSS::ParsingContext(document()), text_content());
+    auto sheet = parse_css_stylesheet(CSS::ParsingContext(document()), text_content());
     if (!sheet)
         return;
 


### PR DESCRIPTION
Caught and corrected a few places where we went off spec. Also, we now have (and use) `parse_a_style_blocks_contents()` which was added in December. And I cleaned up a couple of things too. :^)