### PR TITLE
LibCore: Improve `BigEndianInputBitStream` aligned and unaligned reads

### DIFF
--- a/Userland/Libraries/LibCore/InputBitStream.h
+++ b/Userland/Libraries/LibCore/InputBitStream.h
@@ -99,9 +99,9 @@ public:
                         m_current_byte.clear();
                 }
             } else {
-                auto temp_buffer = TRY(ByteBuffer::create_uninitialized(1));
-                TRY(m_stream.read(temp_buffer.bytes()));
-                m_current_byte = temp_buffer[0];
+                u8 temp_stream_value;
+                TRY(m_stream.read({ &temp_stream_value, sizeof(temp_stream_value) }));
+                m_current_byte = temp_stream_value;
                 m_bit_offset = 0;
             }
         }

--- a/Userland/Libraries/LibCore/InputBitStream.h
+++ b/Userland/Libraries/LibCore/InputBitStream.h
@@ -35,7 +35,7 @@ public:
     {
         if (m_current_byte.has_value() && is_aligned_to_byte_boundary()) {
             bytes[0] = m_current_byte.release_value();
-            return m_stream.read(bytes.slice(1));
+            return TRY(m_stream.read(bytes.slice(1))) + 1;
         }
         align_to_byte_boundary();
         return m_stream.read(bytes);


### PR DESCRIPTION
Just two small things I noticed when I took a quick look. Tested against master and #12102 with no regressions (aka, testing `aplay`)

cc @kleinesfilmroellchen to be sure I haven't done anything wild.