### PR TITLE
Fix calculating the intrinsic height of an item, and fix sizing of flex children with flex-basis 0

### DIFF
--- a/Base/res/html/misc/flex.html
+++ b/Base/res/html/misc/flex.html
@@ -186,6 +186,12 @@
         <div class="box" style="flex: 0 0 0;">2</div>
         <div class="box" style="flex: 0 0 0;">3</div>
     </div>
+    <p>flex: 0 0 0; flex-direction: column;</p>
+    <div class="my-container column" style="width: 500px;">
+        <div class="box" style="flex: 0 0 0;">1</div>
+        <div class="box" style="flex: 0 0 0;">2</div>
+        <div class="box" style="flex: 0 0 0;">3</div>
+    </div>
     <p>flex: 1 2 0;</p>
     <div class="my-container" style="width: 500px;">
         <div class="box" style="flex: 1 2 0;">1</div>

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -565,9 +565,14 @@ void FlexFormattingContext::determine_flex_base_size_and_hypothetical_main_size(
     }();
 
     // The hypothetical main size is the item’s flex base size clamped according to its used min and max main sizes (and flooring the content box size at zero).
-    auto clamp_min = has_main_min_size(child_box) ? specified_main_min_size(child_box) : 0;
+    auto clamp_min = has_main_min_size(child_box) ? specified_main_min_size(child_box) : determine_min_main_size_of_child(child_box);
     auto clamp_max = has_main_max_size(child_box) ? specified_main_max_size(child_box) : NumericLimits<float>::max();
     flex_item.hypothetical_main_size = clamp(flex_item.flex_base_size, clamp_min, clamp_max);
+}
+
+float FlexFormattingContext::determine_min_main_size_of_child(Box const& box)
+{
+    return is_row_layout() ? calculate_min_and_max_content_width(box).min_content_size : calculate_min_and_max_content_height(box).min_content_size;
 }
 
 // https://www.w3.org/TR/css-flexbox-1/#algo-main-container

--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.h
@@ -79,6 +79,7 @@ private:
     bool has_main_max_size(Box const&) const;
     bool has_cross_max_size(Box const&) const;
     float sum_of_margin_padding_border_in_main_axis(Box const&) const;
+    float determine_min_main_size_of_child(Box const& box);
 
     void set_main_size(Box const&, float size);
     void set_cross_size(Box const&, float size);

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -817,7 +817,7 @@ FormattingState::IntrinsicSizes FormattingContext::calculate_intrinsic_sizes(Lay
 
         independent_formatting_context->run(box, LayoutMode::MaxContent);
         cached_box_sizes.max_content_size.set_width(independent_formatting_context->greatest_child_width(box));
-        cached_box_sizes.max_content_size.set_height(BlockFormattingContext::compute_theoretical_height(throwaway_state, box));
+        cached_box_sizes.max_content_size.set_height(compute_intrinsic_height(throwaway_state, box));
     }
 
     {
@@ -829,7 +829,7 @@ FormattingState::IntrinsicSizes FormattingContext::calculate_intrinsic_sizes(Lay
         VERIFY(independent_formatting_context);
         independent_formatting_context->run(box, LayoutMode::MinContent);
         cached_box_sizes.min_content_size.set_width(independent_formatting_context->greatest_child_width(box));
-        cached_box_sizes.min_content_size.set_height(BlockFormattingContext::compute_theoretical_height(throwaway_state, box));
+        cached_box_sizes.min_content_size.set_height(compute_intrinsic_height(throwaway_state, box));
     }
 
     if (cached_box_sizes.min_content_size.width() > cached_box_sizes.max_content_size.width()) {
@@ -887,5 +887,14 @@ float FormattingContext::calculate_fit_content_height(Layout::Box const& box, Op
 {
     auto [min_content_size, max_content_size] = calculate_min_and_max_content_height(box);
     return calculate_fit_content_size(min_content_size, max_content_size, available_space);
+}
+
+float FormattingContext::compute_intrinsic_height(FormattingState const& state, Box const& box)
+{
+    if (is<ReplacedBox>(box)) {
+        return compute_height_for_replaced_element(state, verify_cast<ReplacedBox>(box));
+    }
+
+    return compute_auto_height_for_block_level_element(state, box);
 }
 }

--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.h
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.h
@@ -81,6 +81,7 @@ protected:
     static float tentative_height_for_replaced_element(FormattingState const&, ReplacedBox const&, CSS::Length const& height);
     static float compute_auto_height_for_block_formatting_context_root(FormattingState const&, BlockContainer const&);
     static float compute_auto_height_for_block_level_element(FormattingState const&, Box const&);
+    static float compute_intrinsic_height(FormattingState const& state, Box const& box);
 
     ShrinkToFitResult calculate_shrink_to_fit_widths(Box const&);
 


### PR DESCRIPTION
The main goal of this was fixing the flex: 0 0 0 test case in the flex.html test page. 
While fixing that I also found that FormattingContext::calculate_intrinsic_sizes wasn't entirely right when calculating height. 
This fixes both of those things.