### PR TITLE
SpaceAnalyzer: Fix the crash caused by using arrow keys

### DIFF
--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.cpp
@@ -306,6 +306,14 @@ void TreeMapWidget::doubleclick_event(GUI::MouseEvent& event)
     }
 }
 
+void TreeMapWidget::keydown_event(GUI::KeyEvent& event)
+{
+    if (event.key() == KeyCode::Key_Left)
+        set_viewpoint(m_viewpoint == 0 ? m_path.size() : m_viewpoint - 1);
+    else if (event.key() == KeyCode::Key_Right)
+        set_viewpoint(m_viewpoint == m_path.size() ? 0 : m_viewpoint + 1);
+}
+
 void TreeMapWidget::mousewheel_event(GUI::MouseEvent& event)
 {
     int delta = event.wheel_delta_y();

--- a/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
+++ b/Userland/Applications/SpaceAnalyzer/TreeMapWidget.h
@@ -47,6 +47,7 @@ private:
     virtual void doubleclick_event(GUI::MouseEvent&) override;
     virtual void mousewheel_event(GUI::MouseEvent&) override;
     virtual void context_menu_event(GUI::ContextMenuEvent&) override;
+    virtual void keydown_event(GUI::KeyEvent&) override;
 
     bool rect_can_contain_children(const Gfx::IntRect& rect) const;
     bool rect_can_contain_label(const Gfx::IntRect& rect) const;

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -320,6 +320,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& treemapwidget = *mainwidget.find_descendant_of_type_named<SpaceAnalyzer::TreeMapWidget>("tree_map");
     auto& statusbar = *mainwidget.find_descendant_of_type_named<GUI::Statusbar>("statusbar");
 
+    treemapwidget.set_focus(true);
+
     auto& file_menu = window->add_menu("&File");
     file_menu.add_action(GUI::Action::create("&Analyze", [&](auto&) {
         analyze(tree, treemapwidget, statusbar);


### PR DESCRIPTION
Previously, SpaceAnalyzer set focus on the selected BreadcrumbButton.
Using arrow keys triggered the keydown_event of the AbstractButton,
which later on caused a Function object to be deleted while it is still
being used.

This change sets the focus on TreeMapWidget and adds an event handler
to TreeMapWidget for keydown events.

Fixes #13254.