### PR TITLE
AK+LibHTTP: Ensure plus signs are percent encoded in query string

### DIFF
--- a/AK/URL.cpp
+++ b/AK/URL.cpp
@@ -395,19 +395,19 @@ constexpr bool code_point_is_in_percent_encode_set(u32 code_point, URL::PercentE
     }
 }
 
-void URL::append_percent_encoded_if_necessary(StringBuilder& builder, u32 code_point, URL::PercentEncodeSet set)
+void URL::append_percent_encoded_if_necessary(StringBuilder& builder, u32 code_point, URL::PercentEncodeSet set, StringView reserved_chars)
 {
-    if (code_point_is_in_percent_encode_set(code_point, set))
+    if (code_point_is_in_percent_encode_set(code_point, set) || (!reserved_chars.is_null() && reserved_chars.contains(code_point)))
         append_percent_encoded(builder, code_point);
     else
         builder.append_code_point(code_point);
 }
 
-String URL::percent_encode(StringView input, URL::PercentEncodeSet set)
+String URL::percent_encode(StringView input, URL::PercentEncodeSet set, StringView reserved_chars)
 {
     StringBuilder builder;
     for (auto code_point : Utf8View(input)) {
-        append_percent_encoded_if_necessary(builder, code_point, set);
+        append_percent_encoded_if_necessary(builder, code_point, set, reserved_chars);
     }
     return builder.to_string();
 }

--- a/AK/URL.h
+++ b/AK/URL.h
@@ -104,7 +104,7 @@ public:
     static u16 default_port_for_scheme(StringView);
     static bool is_special_scheme(StringView);
 
-    static String percent_encode(StringView input, PercentEncodeSet set = PercentEncodeSet::Userinfo);
+    static String percent_encode(StringView input, PercentEncodeSet set = PercentEncodeSet::Userinfo, StringView reserved_chars = {});
     static String percent_decode(StringView input);
 
     bool operator==(URL const& other) const { return equals(other, ExcludeFragment::No); }
@@ -122,7 +122,7 @@ private:
     bool compute_validity() const;
     String serialize_data_url() const;
 
-    static void append_percent_encoded_if_necessary(StringBuilder&, u32 code_point, PercentEncodeSet set = PercentEncodeSet::Userinfo);
+    static void append_percent_encoded_if_necessary(StringBuilder&, u32 code_point, PercentEncodeSet set = PercentEncodeSet::Userinfo, StringView reserved_chars = {});
     static void append_percent_encoded(StringBuilder&, u32 code_point);
 
     bool m_valid { false };

--- a/Userland/Libraries/LibHTTP/HttpRequest.cpp
+++ b/Userland/Libraries/LibHTTP/HttpRequest.cpp
@@ -37,7 +37,7 @@ ByteBuffer HttpRequest::to_raw_request() const
     builder.append(URL::percent_encode(m_url.path(), URL::PercentEncodeSet::EncodeURI));
     if (!m_url.query().is_empty()) {
         builder.append('?');
-        builder.append(URL::percent_encode(m_url.query(), URL::PercentEncodeSet::EncodeURI));
+        builder.append(URL::percent_encode(m_url.query(), URL::PercentEncodeSet::EncodeURI, "+"sv));
     }
     builder.append(" HTTP/1.1\r\nHost: ");
     builder.append(m_url.host());


### PR DESCRIPTION
This PR fixes an issue where plus signs were not getting percent encoded in the query string.

Open to suggestions if there is a cleaner way of implementing this fix! (I dare say there probably is)