### PR TITLE
WindowServer: Allow WindowServer to run with virtual screens

### DIFF
--- a/Base/etc/WindowServer.ini
+++ b/Base/etc/WindowServer.ini
@@ -2,6 +2,7 @@
 MainScreen=0
 
 [Screen0]
+Mode=Device
 Device=/dev/fb0
 Left=0
 Top=0

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -76,9 +76,7 @@ static ErrorOr<void> determine_system_mode()
     // FIXME: Support more than one framebuffer detection
     struct stat file_state;
     int rc = lstat("/dev/fb0", &file_state);
-    if (rc < 0 && g_system_mode == "graphical") {
-        g_system_mode = "text";
-    } else if (rc == 0 && g_system_mode == "text") {
+    if (rc == 0 && g_system_mode == "text") {
         dbgln("WARNING: Text mode with framebuffers won't work as expected! Consider using 'fbdev=off'.");
     }
     dbgln("System in {} mode", g_system_mode);

--- a/Userland/Services/WindowServer/CMakeLists.txt
+++ b/Userland/Services/WindowServer/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
     MultiScaleBitmaps.cpp
     Overlays.cpp
     Screen.cpp
+    HardwareScreenBackend.cpp
     ScreenLayout.cpp
     Window.cpp
     WindowFrame.cpp

--- a/Userland/Services/WindowServer/CMakeLists.txt
+++ b/Userland/Services/WindowServer/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     Overlays.cpp
     Screen.cpp
     HardwareScreenBackend.cpp
+    VirtualScreenBackend.cpp
     ScreenLayout.cpp
     Window.cpp
     WindowFrame.cpp

--- a/Userland/Services/WindowServer/HardwareScreenBackend.cpp
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.cpp
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2018-2020, the SerenityOS developers.
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "HardwareScreenBackend.h"
+#include "ScreenBackend.h"
+#include <AK/Try.h>
+#include <Kernel/API/FB.h>
+#include <LibCore/System.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+namespace WindowServer {
+
+HardwareScreenBackend::HardwareScreenBackend(String device)
+    : m_device(move(device))
+{
+}
+
+ErrorOr<void> HardwareScreenBackend::open()
+{
+    m_framebuffer_fd = TRY(Core::System::open(m_device.characters(), O_RDWR | O_CLOEXEC));
+
+    FBProperties properties;
+    if (fb_get_properties(m_framebuffer_fd, &properties) < 0)
+        return Error::from_syscall(String::formatted("failed to ioctl {}", m_device), errno);
+
+    m_can_device_flush_buffers = (properties.partial_flushing_support != 0);
+    m_can_set_head_buffer = (properties.doublebuffer_support != 0);
+    return {};
+}
+
+HardwareScreenBackend::~HardwareScreenBackend()
+{
+    if (m_framebuffer_fd >= 0) {
+        close(m_framebuffer_fd);
+        m_framebuffer_fd = -1;
+    }
+    if (m_framebuffer) {
+        MUST(Core::System::munmap(m_framebuffer, m_size_in_bytes));
+
+        m_framebuffer = nullptr;
+        m_size_in_bytes = 0;
+    }
+}
+
+ErrorOr<void> HardwareScreenBackend::set_head_resolution(FBHeadResolution resolution)
+{
+    auto rc = fb_set_resolution(m_framebuffer_fd, &resolution);
+    if (rc != 0)
+        return Error::from_syscall("fb_set_resolution", rc);
+    return {};
+}
+
+ErrorOr<void> HardwareScreenBackend::unmap_framebuffer()
+{
+    if (m_framebuffer) {
+        size_t previous_size_in_bytes = m_size_in_bytes;
+        return Core::System::munmap(m_framebuffer, previous_size_in_bytes);
+    }
+    return {};
+}
+
+ErrorOr<void> HardwareScreenBackend::map_framebuffer()
+{
+    FBHeadProperties properties;
+    properties.head_index = 0;
+    int rc = fb_get_head_properties(m_framebuffer_fd, &properties);
+    if (rc != 0)
+        return Error::from_syscall("fb_get_head_properties", rc);
+    m_size_in_bytes = properties.buffer_length;
+
+    m_framebuffer = (Gfx::ARGB32*)TRY(Core::System::mmap(nullptr, m_size_in_bytes, PROT_READ | PROT_WRITE, MAP_SHARED, m_framebuffer_fd, 0));
+
+    if (m_can_set_head_buffer) {
+        // Note: fall back to assuming the second buffer starts right after the last line of the first
+        // Note: for now, this calculation works quite well, so need to defer it to another function
+        // that does ioctl to figure out the correct offset. If a Framebuffer device ever happens to
+        // to set the second buffer at different location than this, we might need to consider bringing
+        // back a function with ioctl to check this.
+        m_back_buffer_offset = static_cast<size_t>(properties.pitch) * properties.height;
+    } else {
+        m_back_buffer_offset = 0;
+    }
+
+    return {};
+}
+
+ErrorOr<FBHeadProperties> HardwareScreenBackend::get_head_properties()
+{
+    FBHeadProperties properties;
+    properties.head_index = 0;
+    int rc = fb_get_head_properties(m_framebuffer_fd, &properties);
+    if (rc != 0)
+        return Error::from_syscall("fb_get_head_properties", rc);
+    m_pitch = static_cast<int>(properties.pitch);
+    return properties;
+}
+
+void HardwareScreenBackend::set_head_buffer(int head_index)
+{
+    VERIFY(m_can_set_head_buffer);
+    VERIFY(head_index <= 1 && head_index >= 0);
+    FBHeadVerticalOffset offset { 0, 0 };
+    if (head_index == 1)
+        offset.offsetted = 1;
+    int rc = fb_set_head_vertical_offset_buffer(m_framebuffer_fd, &offset);
+    VERIFY(rc == 0);
+}
+
+ErrorOr<void> HardwareScreenBackend::flush_framebuffer_rects(int buffer_index, Span<FBRect const> flush_rects)
+{
+    int rc = fb_flush_buffers(m_framebuffer_fd, buffer_index, flush_rects.data(), (unsigned)flush_rects.size());
+    if (rc == -ENOTSUP)
+        m_can_device_flush_buffers = false;
+    else
+        return Error::from_syscall("fb_flush_buffers", rc);
+    return {};
+}
+
+}

--- a/Userland/Services/WindowServer/HardwareScreenBackend.h
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ScreenBackend.h"
+#include "ScreenLayout.h"
+#include <AK/Error.h>
+#include <AK/Span.h>
+#include <AK/String.h>
+#include <sys/ioctl_numbers.h>
+
+namespace WindowServer {
+class HardwareScreenBackend : public ScreenBackend {
+public:
+    virtual ~HardwareScreenBackend();
+
+    HardwareScreenBackend(String device);
+
+    virtual ErrorOr<void> open() override;
+
+    virtual void set_head_buffer(int index) override;
+
+    virtual ErrorOr<void> flush_framebuffer_rects(int buffer_index, Span<FBRect const> rects) override;
+
+    virtual ErrorOr<void> unmap_framebuffer() override;
+    virtual ErrorOr<void> map_framebuffer() override;
+
+    virtual ErrorOr<void> set_head_resolution(FBHeadResolution) override;
+    virtual ErrorOr<FBHeadProperties> get_head_properties() override;
+
+    String m_device {};
+    int m_framebuffer_fd { -1 };
+};
+
+}

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -1,11 +1,14 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include "HardwareScreenBackend.h"
+#include "ScreenBackend.h"
 #include "ScreenLayout.h"
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/OwnPtr.h>
@@ -145,13 +148,13 @@ public:
     void make_main_screen() { s_main_screen = this; }
     bool is_main_screen() const { return s_main_screen == this; }
 
-    bool can_set_buffer() { return m_can_set_buffer; }
+    bool can_set_buffer() { return m_backend->m_can_set_head_buffer; }
     void set_buffer(int index);
     size_t buffer_offset(int index) const;
 
     int physical_width() const { return width() * scale_factor(); }
     int physical_height() const { return height() * scale_factor(); }
-    size_t pitch() const { return m_pitch; }
+    size_t pitch() const { return m_backend->m_pitch; }
 
     int width() const { return m_virtual_rect.width(); }
     int height() const { return m_virtual_rect.height(); }
@@ -164,7 +167,7 @@ public:
     Gfx::IntSize size() const { return { m_virtual_rect.width(), m_virtual_rect.height() }; }
     Gfx::IntRect rect() const { return m_virtual_rect; }
 
-    bool can_device_flush_buffers() const { return m_can_device_flush_buffers; }
+    bool can_device_flush_buffers() const { return m_backend->m_can_device_flush_buffers; }
     void queue_flush_display_rect(Gfx::IntRect const& rect);
     void flush_display(int buffer_index);
     void flush_display_front_buffer(int front_buffer_index, Gfx::IntRect&);
@@ -187,7 +190,7 @@ private:
     static void update_bounding_rect();
     static void update_scale_factors_in_use();
 
-    bool is_opened() const { return m_framebuffer_fd >= 0; }
+    bool is_opened() const { return m_backend != nullptr; }
 
     void set_index(size_t index) { m_index = index; }
     void update_virtual_rect();
@@ -201,23 +204,16 @@ private:
     static Vector<int, default_scale_factors_in_use_count> s_scale_factors_in_use;
     size_t m_index { 0 };
 
-    size_t m_size_in_bytes { 0 };
-    size_t m_back_buffer_offset { 0 };
+    OwnPtr<ScreenBackend> m_backend;
 
-    Gfx::ARGB32* m_framebuffer { nullptr };
-    bool m_can_set_buffer { false };
-    bool m_can_device_flush_buffers { true }; // If the device can't do it we revert to false
-
-    int m_pitch { 0 };
     Gfx::IntRect m_virtual_rect;
-    int m_framebuffer_fd { -1 };
     NonnullOwnPtr<FlushRectData> m_flush_rects;
     NonnullOwnPtr<CompositorScreenData> m_compositor_screen_data;
 };
 
 inline Gfx::ARGB32* Screen::scanline(int buffer_index, int y)
 {
-    return reinterpret_cast<Gfx::ARGB32*>(((u8*)m_framebuffer) + buffer_offset(buffer_index) + (y * m_pitch));
+    return reinterpret_cast<Gfx::ARGB32*>(((u8*)m_backend->m_framebuffer) + buffer_offset(buffer_index) + (y * m_backend->m_pitch));
 }
 
 }

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -59,7 +59,7 @@ private:
 };
 
 struct CompositorScreenData;
-struct ScreenFBData;
+struct FlushRectData;
 
 class Screen : public RefCounted<Screen> {
 public:
@@ -211,7 +211,7 @@ private:
     int m_pitch { 0 };
     Gfx::IntRect m_virtual_rect;
     int m_framebuffer_fd { -1 };
-    NonnullOwnPtr<ScreenFBData> m_framebuffer_data;
+    NonnullOwnPtr<FlushRectData> m_flush_rects;
     NonnullOwnPtr<CompositorScreenData> m_compositor_screen_data;
 };
 

--- a/Userland/Services/WindowServer/ScreenBackend.h
+++ b/Userland/Services/WindowServer/ScreenBackend.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ScreenLayout.h"
+#include <AK/Error.h>
+#include <AK/Span.h>
+#include <sys/ioctl_numbers.h>
+
+namespace WindowServer {
+
+// Handles low-level device interfacing for the screen.
+// ScreenBackend is a thin transparent wrapper around framebuffer-related data which is responsible for setting up this data,
+// tearing it down, changing its properties like size, and performing flushes.
+// The screen is intended to directly access the members to perform its function, but it only ever reads from anything
+// except the data in the framebuffer memory.
+class ScreenBackend {
+public:
+    virtual ~ScreenBackend() = default;
+
+    virtual ErrorOr<void> open() = 0;
+
+    virtual void set_head_buffer(int index) = 0;
+
+    virtual ErrorOr<void> flush_framebuffer_rects(int buffer_index, Span<FBRect const> rects) = 0;
+
+    virtual ErrorOr<void> unmap_framebuffer() = 0;
+    virtual ErrorOr<void> map_framebuffer() = 0;
+
+    virtual ErrorOr<void> set_head_resolution(FBHeadResolution) = 0;
+    virtual ErrorOr<FBHeadProperties> get_head_properties() = 0;
+
+    bool m_can_device_flush_buffers { true };
+    bool m_can_set_head_buffer { false };
+
+    Gfx::ARGB32* m_framebuffer { nullptr };
+    size_t m_size_in_bytes { 0 };
+    size_t m_back_buffer_offset { 0 };
+
+    int m_pitch { 0 };
+};
+
+}

--- a/Userland/Services/WindowServer/ScreenLayout.h
+++ b/Userland/Services/WindowServer/ScreenLayout.h
@@ -18,7 +18,12 @@ namespace WindowServer {
 class ScreenLayout {
 public:
     struct Screen {
-        String device;
+        enum class Mode {
+            Invalid,
+            Device,
+            Virtual,
+        } mode;
+        Optional<String> device;
         Gfx::IntPoint location;
         Gfx::IntSize resolution;
         int scale_factor;
@@ -26,6 +31,22 @@ public:
         Gfx::IntRect virtual_rect() const
         {
             return { location, { resolution.width() / scale_factor, resolution.height() / scale_factor } };
+        }
+
+        static StringView mode_to_string(Mode mode)
+        {
+#define __ENUMERATE_MODE_ENUM(val) \
+    case Mode::val:                \
+        return #val;
+
+            switch (mode) {
+                __ENUMERATE_MODE_ENUM(Invalid)
+                __ENUMERATE_MODE_ENUM(Device)
+                __ENUMERATE_MODE_ENUM(Virtual)
+            }
+            VERIFY_NOT_REACHED();
+
+#undef __ENUMERATE_MODE_ENUM
         }
 
         bool operator==(Screen const&) const = default;

--- a/Userland/Services/WindowServer/VirtualScreenBackend.cpp
+++ b/Userland/Services/WindowServer/VirtualScreenBackend.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2018-2020, the SerenityOS developers.
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "VirtualScreenBackend.h"
+#include "ScreenBackend.h"
+#include <AK/Try.h>
+#include <AK/kmalloc.h>
+#include <LibGfx/Color.h>
+
+namespace WindowServer {
+
+VirtualScreenBackend::~VirtualScreenBackend()
+{
+    MUST(unmap_framebuffer());
+}
+
+ErrorOr<void> VirtualScreenBackend::open()
+{
+    m_can_device_flush_buffers = true;
+    m_can_set_head_buffer = true;
+    return {};
+}
+
+void VirtualScreenBackend::set_head_buffer(int index)
+{
+    VERIFY(index <= 1 && index >= 0);
+    m_first_buffer_active = index == 0;
+}
+
+ErrorOr<void> VirtualScreenBackend::set_head_resolution(FBHeadResolution resolution)
+{
+    if (resolution.head_index != 0)
+        return Error::from_string_literal("Only head index 0 is supported."sv);
+    m_height = resolution.height;
+
+    if (resolution.pitch == 0)
+        resolution.pitch = static_cast<int>(resolution.width * sizeof(Gfx::ARGB32));
+    m_pitch = resolution.pitch;
+    if (static_cast<int>(resolution.width * sizeof(Gfx::ARGB32)) != resolution.pitch)
+        return Error::from_string_literal("Unsupported pitch"sv);
+
+    m_width = resolution.width;
+    return {};
+}
+
+ErrorOr<FBHeadProperties> VirtualScreenBackend::get_head_properties()
+{
+    return FBHeadProperties {
+        .head_index = 0,
+        .pitch = static_cast<unsigned>(m_pitch),
+        .width = static_cast<unsigned>(m_width),
+        .height = static_cast<unsigned>(m_height),
+        .offset = static_cast<unsigned>(m_first_buffer_active ? 0 : m_back_buffer_offset),
+        .buffer_length = static_cast<unsigned>(m_size_in_bytes),
+    };
+}
+
+ErrorOr<void> VirtualScreenBackend::map_framebuffer()
+{
+    m_size_in_bytes = static_cast<unsigned long>(m_pitch) * m_height * 2;
+    m_framebuffer = new Gfx::ARGB32[static_cast<unsigned long>(m_width) * m_height * 2];
+    if (m_framebuffer == nullptr)
+        return Error::from_errno(ENOMEM);
+
+    m_back_buffer_offset = m_size_in_bytes / 2;
+    m_first_buffer_active = true;
+
+    return {};
+}
+
+ErrorOr<void> VirtualScreenBackend::unmap_framebuffer()
+{
+    delete[] m_framebuffer;
+    return {};
+}
+
+}

--- a/Userland/Services/WindowServer/VirtualScreenBackend.h
+++ b/Userland/Services/WindowServer/VirtualScreenBackend.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "ScreenBackend.h"
+#include "ScreenLayout.h"
+#include <AK/Error.h>
+#include <AK/Span.h>
+#include <AK/String.h>
+#include <sys/ioctl_numbers.h>
+
+namespace WindowServer {
+
+class VirtualScreenBackend : public ScreenBackend {
+public:
+    virtual ~VirtualScreenBackend();
+
+    VirtualScreenBackend() = default;
+
+private:
+    friend class Screen;
+
+    virtual ErrorOr<void> open() override;
+
+    virtual void set_head_buffer(int index) override;
+
+    virtual ErrorOr<void> flush_framebuffer_rects(int, Span<FBRect const>) override { return {}; }
+
+    virtual ErrorOr<void> unmap_framebuffer() override;
+    virtual ErrorOr<void> map_framebuffer() override;
+
+    virtual ErrorOr<void> set_head_resolution(FBHeadResolution) override;
+    virtual ErrorOr<FBHeadProperties> get_head_properties() override;
+
+    int m_height { 0 };
+    int m_width { 0 };
+    bool m_first_buffer_active { true };
+};
+
+}

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -92,7 +92,8 @@ ErrorOr<int> serenity_main(Main::Arguments)
 
         if (screen_layout.load_config(*wm_config, &error_msg)) {
             for (auto& screen_info : screen_layout.screens)
-                fb_devices_configured.set(screen_info.device);
+                if (screen_info.mode == WindowServer::ScreenLayout::Screen::Mode::Device)
+                    fb_devices_configured.set(screen_info.device.value());
 
             add_unconfigured_devices();
 


### PR DESCRIPTION
First step on the road to #13379, this PR allows WindowServer to run with virtual screens that don't have video hardware behind them. Therefore, it's possible to start up WindowServer without video hardware with the right config and still get a frame buffer & stuff.

Screenshotting the second window with Browser on it:
![](https://cdn.discordapp.com/attachments/830739873119207426/959563218278305832/unknown.png)

Proof that there's no Kernel involved:
![](https://cdn.discordapp.com/attachments/830739873119207426/959564667074777158/unknown.png)