### PR TITLE
LibWeb: Flex fix minimum main size in min/max violations calculation

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FlexFormattingContext.cpp
@@ -773,7 +773,7 @@ void FlexFormattingContext::resolve_flexible_lengths()
             for_each_unfrozen_item([&](FlexItem* item) {
                 auto min_main = has_main_min_size(item->box)
                     ? specified_main_min_size(item->box)
-                    : 0;
+                    : determine_min_main_size_of_child(item->box);
                 auto max_main = has_main_max_size(item->box)
                     ? specified_main_max_size(item->box)
                     : NumericLimits<float>::max();


### PR DESCRIPTION
While calculating the minimum size for main min/max size violations
we were flooring the min size to 0 if the item doesn't have a min
main size. Instead of that determine the intrinsic min main size
of that element.

This fixes the flex: 80% 0 4/1/0 test case in the flex.html
test page.

This case was missed in a previous commit that added the
determine_min_main_size_of_child function