### PR TITLE
FilePicker: Opened File/Folder history

### DIFF
--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -162,7 +162,7 @@ bool RunWindow::run_via_launch(String const& run_input)
 
 String RunWindow::history_file_path()
 {
-    return LexicalPath::canonicalized_path(String::formatted("{}/{}", Core::StandardPaths::config_directory(), "RunHistory.txt"));
+    return LexicalPath::canonicalized_path(String::formatted("{}/{}", Core::StandardPaths::history_directory(), "Run.txt"));
 }
 
 void RunWindow::load_history()

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -175,7 +175,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& path_picker_button = *main_widget->find_descendant_of_type_named<GUI::Button>("path_picker_button");
 
     color_combo_box.set_model(TRY(RoleModel<Gfx::ColorRole>::try_create(color_roles)));
-    color_combo_box.on_change = [&](auto&, auto& index) {
+    color_combo_box.on_activation = [&](auto&, auto& index) {
         auto role = index.model()->data(index, GUI::ModelRole::Custom).to_color_role();
         color_input.set_color(preview_widget.preview_palette().color(role));
     };
@@ -190,7 +190,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     color_input.set_color(startup_preview_palette.color(Gfx::ColorRole::Window));
 
     alignment_combo_box.set_model(TRY(RoleModel<Gfx::AlignmentRole>::try_create(alignment_roles)));
-    alignment_combo_box.on_change = [&](auto&, auto& index) {
+    alignment_combo_box.on_activation = [&](auto&, auto& index) {
         auto role = index.model()->data(index, GUI::ModelRole::Custom).to_alignment_role();
         alignment_input.set_selected_index((size_t)preview_widget.preview_palette().alignment(role), GUI::AllowCallback::No);
     };
@@ -199,7 +199,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     alignment_input.set_only_allow_values_from_model(true);
     alignment_input.set_model(adopt_ref(*new AlignmentModel()));
     alignment_input.set_selected_index((size_t)startup_preview_palette.alignment(Gfx::AlignmentRole::TitleAlignment));
-    alignment_input.on_change = [&](auto&, auto& index) {
+    alignment_input.on_activation = [&](auto&, auto& index) {
         auto role = alignment_combo_box.model()->index(alignment_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_alignment_role();
         auto preview_palette = preview_widget.preview_palette();
 
@@ -208,7 +208,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     flag_combo_box.set_model(TRY(RoleModel<Gfx::FlagRole>::try_create(flag_roles)));
-    flag_combo_box.on_change = [&](auto&, auto& index) {
+    flag_combo_box.on_activation = [&](auto&, auto& index) {
         auto role = index.model()->data(index, GUI::ModelRole::Custom).to_flag_role();
         flag_input.set_checked(preview_widget.preview_palette().flag(role), GUI::AllowCallback::No);
     };
@@ -223,7 +223,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     flag_input.set_checked(startup_preview_palette.flag(Gfx::FlagRole::IsDark), GUI::AllowCallback::No);
 
     metric_combo_box.set_model(TRY(RoleModel<Gfx::MetricRole>::try_create(metric_roles)));
-    metric_combo_box.on_change = [&](auto&, auto& index) {
+    metric_combo_box.on_activation = [&](auto&, auto& index) {
         auto role = index.model()->data(index, GUI::ModelRole::Custom).to_metric_role();
         metric_input.set_value(preview_widget.preview_palette().metric(role), GUI::AllowCallback::No);
     };
@@ -238,7 +238,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     metric_input.set_value(startup_preview_palette.metric(Gfx::MetricRole::TitleButtonHeight), GUI::AllowCallback::No);
 
     path_combo_box.set_model(TRY(RoleModel<Gfx::PathRole>::try_create(path_roles)));
-    path_combo_box.on_change = [&](auto&, auto& index) {
+    path_combo_box.on_activation = [&](auto&, auto& index) {
         auto role = index.model()->data(index, GUI::ModelRole::Custom).to_path_role();
         path_input.set_text(preview_widget.preview_palette().path(role));
     };

--- a/Userland/Libraries/LibCore/StandardPaths.cpp
+++ b/Userland/Libraries/LibCore/StandardPaths.cpp
@@ -49,6 +49,14 @@ String StandardPaths::config_directory()
     return LexicalPath::canonicalized_path(builder.to_string());
 }
 
+String StandardPaths::history_directory()
+{
+    StringBuilder builder;
+    builder.append(home_directory());
+    builder.append("/.history");
+    return LexicalPath::canonicalized_path(builder.to_string());
+}
+
 String StandardPaths::tempfile_directory()
 {
     return "/tmp";

--- a/Userland/Libraries/LibCore/StandardPaths.h
+++ b/Userland/Libraries/LibCore/StandardPaths.h
@@ -17,6 +17,7 @@ public:
     static String downloads_directory();
     static String tempfile_directory();
     static String config_directory();
+    static String history_directory();
 };
 
 }

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -115,6 +115,7 @@ ComboBox::ComboBox()
     m_list_view->set_alternating_row_colors(false);
     m_list_view->set_hover_highlighting(true);
     m_list_view->set_frame_thickness(1);
+    m_list_view->set_focus_policy(GUI::FocusPolicy::NoFocus);
     m_list_view->set_frame_shadow(Gfx::FrameShadow::Plain);
     m_list_view->on_selection_change = [this] {
         VERIFY(model());

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -279,6 +279,16 @@ void ComboBox::set_text(String const& text)
     m_editor->set_text(text);
 }
 
+Gfx::Bitmap const* ComboBox::icon() const
+{
+    return m_editor->icon();
+}
+
+void ComboBox::set_icon(Gfx::Bitmap const* icon)
+{
+    m_editor->set_icon(icon);
+}
+
 void ComboBox::set_only_allow_values_from_model(bool b)
 {
     if (m_only_allow_values_from_model == b)

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -55,6 +55,7 @@ ComboBox::ComboBox()
 {
     REGISTER_STRING_PROPERTY("placeholder", editor_placeholder, set_editor_placeholder);
     REGISTER_BOOL_PROPERTY("model_only", only_allow_values_from_model, set_only_allow_values_from_model);
+    REGISTER_INT_PROPERTY("max_rows", max_rows, set_max_rows);
 
     set_min_width(32);
     set_fixed_height(22);
@@ -211,6 +212,11 @@ void ComboBox::set_selected_index(size_t index, AllowCallback allow_callback)
         on_change(m_editor->text(), m_list_view->cursor_index());
 }
 
+void ComboBox::set_max_rows(size_t rows)
+{
+    m_max_rows = rows;
+}
+
 size_t ComboBox::selected_index() const
 {
     return m_selected_index.has_value() ? m_selected_index.value().row() : 0;
@@ -236,7 +242,7 @@ void ComboBox::open()
     }
     Gfx::IntSize size {
         max(width(), longest_item_width + m_list_view->width_occupied_by_vertical_scrollbar() + m_list_view->frame_thickness() * 2 + m_list_view->horizontal_padding()),
-        model()->row_count() * m_list_view->item_height() + m_list_view->frame_thickness() * 2
+        min(model()->row_count(), static_cast<int>(max_rows())) * m_list_view->item_height() + m_list_view->frame_thickness() * 2
     };
 
     auto taskbar_height = GUI::Desktop::the().taskbar_height();

--- a/Userland/Libraries/LibGUI/ComboBox.h
+++ b/Userland/Libraries/LibGUI/ComboBox.h
@@ -43,6 +43,9 @@ public:
     int model_column() const;
     void set_model_column(int);
 
+    void set_max_rows(size_t rows);
+    size_t max_rows() const { return m_max_rows; };
+
     void set_editor_placeholder(StringView placeholder);
     String const& editor_placeholder() const;
 
@@ -65,6 +68,7 @@ private:
     Optional<ModelIndex> m_selected_index;
     bool m_only_allow_values_from_model { false };
     bool m_updating_model { false };
+    size_t m_max_rows { 10 };
 };
 
 }

--- a/Userland/Libraries/LibGUI/ComboBox.h
+++ b/Userland/Libraries/LibGUI/ComboBox.h
@@ -23,6 +23,9 @@ public:
     String text() const;
     void set_text(String const&);
 
+    void set_icon(Gfx::Bitmap const*);
+    Gfx::Bitmap const* icon() const;
+
     void open();
     void close();
     void select_all();

--- a/Userland/Libraries/LibGUI/FilePicker.h
+++ b/Userland/Libraries/LibGUI/FilePicker.h
@@ -40,6 +40,10 @@ private:
 
     void set_path(String const&);
 
+    String history_file_path() const;
+    ErrorOr<void> load_history();
+    ErrorOr<void> save_history();
+
     // ^GUI::ModelClient
     virtual void model_did_update(unsigned) override;
 
@@ -64,13 +68,14 @@ private:
         size_t tray_item_index { 0 };
     };
 
+    Vector<String> m_history;
     RefPtr<MultiView> m_view;
     NonnullRefPtr<FileSystemModel> m_model;
     String m_selected_file;
 
     RefPtr<GUI::Label> m_error_label;
 
-    RefPtr<TextBox> m_filename_textbox;
+    RefPtr<ComboBox> m_filename_combobox;
     RefPtr<TextBox> m_location_textbox;
     Vector<CommonLocationButton> m_common_location_buttons;
     RefPtr<Menu> m_context_menu;

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -23,6 +23,7 @@
         }
 
         @GUI::Label {
+            name: "target_label"
             text: "Filename:"
             text_alignment: "CenterRight"
             fixed_height: 24
@@ -61,8 +62,9 @@
                 fixed_height: 22
                 layout: @GUI::HorizontalBoxLayout {}
 
-                @GUI::TextBox {
-                    name: "filename_textbox"
+                @GUI::ComboBox {
+                    name: "filename_combobox"
+                    max_rows: 5
                 }
 
                 @GUI::Widget {

--- a/Userland/Shell/Shell.cpp
+++ b/Userland/Shell/Shell.cpp
@@ -1131,7 +1131,7 @@ String Shell::get_history_path()
 {
     if (auto histfile = getenv("HISTFILE"))
         return { histfile };
-    return String::formatted("{}/.history", home);
+    return String::formatted("{}/.history/Shell.txt", home);
 }
 
 String Shell::escape_token_for_single_quotes(StringView token)


### PR DESCRIPTION

![Peek 2022-04-12 23-56](https://user-images.githubusercontent.com/63465728/163038636-b94b9393-3fb5-40be-9a4f-45b024ca547a.gif)

Location history support for file picker.
saves history into `.config/FilePickerHistory.txt` (max `25` rows), but it's convinced to move it all into `.history/` (`.history/Shell.txt`, `.history/Run.txt`, `.history/FilePicker.txt`, etc)