### PR TITLE
DisplaySettings: Add theme selection and preview

### DIFF
--- a/AK/Span.h
+++ b/AK/Span.h
@@ -212,6 +212,16 @@ public:
         return this->m_values[index];
     }
 
+    [[nodiscard]] ALWAYS_INLINE constexpr T const& last() const
+    {
+        return this->at(this->size() - 1);
+    }
+
+    [[nodiscard]] ALWAYS_INLINE constexpr T& last()
+    {
+        return this->at(this->size() - 1);
+    }
+
     [[nodiscard]] ALWAYS_INLINE constexpr T const& operator[](size_t index) const
     {
         return at(index);

--- a/Userland/Applications/DisplaySettings/CMakeLists.txt
+++ b/Userland/Applications/DisplaySettings/CMakeLists.txt
@@ -8,6 +8,7 @@ compile_gml(MonitorSettings.gml MonitorSettingsGML.h monitor_settings_window_gml
 compile_gml(BackgroundSettings.gml BackgroundSettingsGML.h background_settings_gml)
 compile_gml(DesktopSettings.gml DesktopSettingsGML.h desktop_settings_gml)
 compile_gml(FontSettings.gml FontSettingsGML.h font_settings_gml)
+compile_gml(ThemesSettings.gml ThemesSettingsGML.h themes_settings_gml)
 
 set(SOURCES
     BackgroundSettingsGML.h
@@ -19,6 +20,11 @@ set(SOURCES
     MonitorSettingsWidget.cpp
     MonitorSettingsGML.h
     MonitorWidget.cpp
+    ThemePreviewWidget.h
+    ThemePreviewWidget.cpp
+    ThemesSettingsWidget.h
+    ThemesSettingsWidget.cpp
+    ThemesSettingsGML.h
     main.cpp
 )
 

--- a/Userland/Applications/DisplaySettings/ThemePreviewWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemePreviewWidget.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ThemePreviewWidget.h"
+#include <AK/Array.h>
+#include <LibCore/File.h>
+#include <LibGUI/Painter.h>
+#include <LibGfx/Painter.h>
+#include <LibGfx/StylePainter.h>
+
+namespace DisplaySettings {
+
+ThemePreviewWidget::ThemePreviewWidget(Gfx::Palette const& palette)
+    : GUI::AbstractThemePreview(palette)
+{
+    set_fixed_size(304, 201);
+}
+
+void ThemePreviewWidget::set_theme(String path)
+{
+    set_theme_from_file(*Core::File::open(path, Core::OpenMode::ReadOnly).release_value_but_fixme_should_propagate_errors());
+}
+
+void ThemePreviewWidget::paint_preview(GUI::PaintEvent&)
+{
+    GUI::Painter painter(*this);
+
+    auto active_window_rect = rect().shrunken(48, 100).translated(4, 26);
+    auto inactive_window_rect = active_window_rect.translated(-8, -32);
+    auto message_box = active_window_rect.shrunken(100, 60);
+
+    paint_window("Inactive Window", inactive_window_rect, Gfx::WindowTheme::WindowState::Inactive, inactive_window_icon());
+    paint_window("Active Window", active_window_rect, Gfx::WindowTheme::WindowState::Active, active_window_icon());
+    paint_window("Alert", message_box, Gfx::WindowTheme::WindowState::Highlighted, active_window_icon(), 1);
+
+    auto draw_centered_button = [&](auto window_rect, auto text, int button_width, int button_height) {
+        auto box_center = window_rect.center();
+        Gfx::IntRect button_rect { box_center.x() - button_width / 2, box_center.y() - button_height / 2, button_width, button_height };
+        Gfx::StylePainter::paint_button(
+            painter, button_rect, preview_palette(), Gfx::ButtonStyle::Normal, false, false, false, true, false, false);
+        painter.draw_text(button_rect, text, Gfx::TextAlignment::Center, preview_palette().color(foreground_role()), Gfx::TextElision::Right, Gfx::TextWrapping::DontWrap);
+    };
+
+    draw_centered_button(message_box, "Ok", 32, 16);
+}
+
+}

--- a/Userland/Applications/DisplaySettings/ThemePreviewWidget.h
+++ b/Userland/Applications/DisplaySettings/ThemePreviewWidget.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/AbstractThemePreview.h>
+#include <LibGUI/Widget.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/WindowTheme.h>
+
+namespace DisplaySettings {
+
+class ThemePreviewWidget final : public GUI::AbstractThemePreview {
+    C_OBJECT(ThemePreviewWidget);
+
+public:
+    void set_theme(String path);
+
+private:
+    explicit ThemePreviewWidget(Gfx::Palette const& palette);
+
+    void paint_preview(GUI::PaintEvent& event) override;
+};
+
+}

--- a/Userland/Applications/DisplaySettings/ThemesSettings.gml
+++ b/Userland/Applications/DisplaySettings/ThemesSettings.gml
@@ -1,0 +1,32 @@
+@GUI::Widget {
+    fill_with_background_color: true
+    layout: @GUI::VerticalBoxLayout {
+        margins: [8]
+    }
+
+    @GUI::Frame {
+        layout: @GUI::HorizontalBoxLayout {}
+        name: "preview_frame"
+        fixed_width: 304
+        fixed_height: 201
+    }
+
+    @GUI::Widget {
+        fixed_height: 20
+    }
+
+    @GUI::Widget {
+        shrink_to_fit: true
+        layout: @GUI::HorizontalBoxLayout {}
+
+        @GUI::Label {
+            text: "Theme:"
+            text_alignment: "CenterLeft"
+            fixed_width: 95
+        }
+
+        @GUI::ComboBox {
+            name: "themes_combo"
+        }
+    }
+}

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ThemesSettingsWidget.h"
+#include <AK/LexicalPath.h>
+#include <AK/QuickSort.h>
+#include <Applications/DisplaySettings/ThemesSettingsGML.h>
+#include <LibCore/DirIterator.h>
+#include <LibGUI/ConnectionToWindowServer.h>
+#include <LibGUI/ItemListModel.h>
+
+namespace DisplaySettings {
+
+ThemesSettingsWidget::ThemesSettingsWidget()
+{
+    load_from_gml(themes_settings_gml);
+    m_themes = Gfx::list_installed_system_themes();
+
+    auto current_theme_name = GUI::ConnectionToWindowServer::the().get_system_theme();
+
+    size_t current_theme_index;
+    m_theme_names.ensure_capacity(m_themes.size());
+    for (auto& theme_meta : m_themes) {
+        m_theme_names.append(theme_meta.name);
+        if (current_theme_name == theme_meta.name) {
+            m_selected_theme = &theme_meta;
+            current_theme_index = m_theme_names.size() - 1;
+        }
+    }
+    VERIFY(m_selected_theme);
+
+    m_theme_preview = find_descendant_of_type_named<GUI::Frame>("preview_frame")->add<ThemePreviewWidget>(palette());
+    m_themes_combo = *find_descendant_of_type_named<GUI::ComboBox>("themes_combo");
+    m_themes_combo->set_only_allow_values_from_model(true);
+    m_themes_combo->set_model(*GUI::ItemListModel<String>::create(m_theme_names));
+    m_themes_combo->on_change = [this](auto&, const GUI::ModelIndex& index) {
+        m_selected_theme = &m_themes.at(index.row());
+        m_theme_preview->set_theme(m_selected_theme->path);
+    };
+    m_themes_combo->set_selected_index(current_theme_index);
+}
+
+void ThemesSettingsWidget::apply_settings()
+{
+    if (m_selected_theme)
+        VERIFY(GUI::ConnectionToWindowServer::the().set_system_theme(m_selected_theme->path, m_selected_theme->name));
+}
+
+}

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/String.h>
+#include <AK/Vector.h>
+#include <LibGUI/ComboBox.h>
+#include <LibGUI/SettingsWindow.h>
+#include <LibGfx/SystemTheme.h>
+
+#include "ThemePreviewWidget.h"
+
+namespace DisplaySettings {
+
+class ThemesSettingsWidget final : public GUI::SettingsWindow::Tab {
+    C_OBJECT(ThemesSettingsWidget);
+
+public:
+    virtual void apply_settings() override;
+
+private:
+    Vector<Gfx::SystemThemeMetaData> m_themes;
+    Vector<String> m_theme_names;
+
+    RefPtr<GUI::ComboBox> m_themes_combo;
+    RefPtr<ThemePreviewWidget> m_theme_preview;
+
+    Gfx::SystemThemeMetaData const* m_selected_theme { nullptr };
+
+    ThemesSettingsWidget();
+};
+
+}

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -10,6 +10,7 @@
 #include "DesktopSettingsWidget.h"
 #include "FontSettingsWidget.h"
 #include "MonitorSettingsWidget.h"
+#include "ThemesSettingsWidget.h"
 #include <LibConfig/Client.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
@@ -28,6 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Display Settings"));
     (void)TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background"));
+    (void)TRY(window->add_tab<DisplaySettings::ThemesSettingsWidget>("Themes"));
     (void)TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts"));
     (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor"));
     (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces"));

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <LibGUI/AbstractThemePreview.h>
 #include <LibGUI/Frame.h>
 #include <LibGfx/Bitmap.h>
 #include <LibGfx/Filters/ColorBlindnessFilter.h>
@@ -18,59 +19,24 @@ namespace ThemeEditor {
 
 class MiniWidgetGallery;
 
-class PreviewWidget final : public GUI::Frame {
+class PreviewWidget final : public GUI::AbstractThemePreview {
     C_OBJECT(PreviewWidget);
 
 public:
     virtual ~PreviewWidget() override = default;
 
-    Gfx::Palette const& preview_palette() const { return m_preview_palette; }
-    void set_preview_palette(Gfx::Palette const&);
-    void set_theme_from_file(Core::File&);
-
     void set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter>);
-
-    Function<void(String const&)> on_theme_load_from_file;
 
 private:
     explicit PreviewWidget(Gfx::Palette const&);
 
-    void load_theme_bitmaps();
-
-    virtual void paint_event(GUI::PaintEvent&) override;
+    virtual void paint_preview(GUI::PaintEvent&) override;
     virtual void second_paint_event(GUI::PaintEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
-    Gfx::Palette m_preview_palette;
-
     OwnPtr<Gfx::ColorBlindnessFilter> m_color_filter = nullptr;
-
-    RefPtr<Gfx::Bitmap> m_active_window_icon;
-    RefPtr<Gfx::Bitmap> m_inactive_window_icon;
-
     RefPtr<MiniWidgetGallery> m_gallery;
-
-    RefPtr<Gfx::Bitmap> m_default_close_bitmap;
-    RefPtr<Gfx::Bitmap> m_default_maximize_bitmap;
-    RefPtr<Gfx::Bitmap> m_default_minimize_bitmap;
-    RefPtr<Gfx::Bitmap> m_close_bitmap;
-    RefPtr<Gfx::Bitmap> m_maximize_bitmap;
-    RefPtr<Gfx::Bitmap> m_minimize_bitmap;
-    String m_last_close_path;
-    String m_last_maximize_path;
-    String m_last_minimize_path;
-
-    RefPtr<Gfx::Bitmap> m_active_window_shadow;
-    RefPtr<Gfx::Bitmap> m_inactive_window_shadow;
-    RefPtr<Gfx::Bitmap> m_menu_shadow;
-    RefPtr<Gfx::Bitmap> m_taskbar_shadow;
-    RefPtr<Gfx::Bitmap> m_tooltip_shadow;
-    String m_last_active_window_shadow_path;
-    String m_last_inactive_window_shadow_path;
-    String m_last_menu_shadow_path;
-    String m_last_taskbar_shadow_path;
-    String m_last_tooltip_shadow_path;
 };
 
 }

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Array.h>
+#include <AK/LexicalPath.h>
+#include <AK/StringView.h>
+#include <LibCore/ConfigFile.h>
+#include <LibCore/File.h>
+#include <LibGUI/AbstractThemePreview.h>
+#include <LibGUI/Painter.h>
+#include <LibGfx/Bitmap.h>
+
+namespace GUI {
+
+AbstractThemePreview::AbstractThemePreview(Gfx::Palette const& preview_palette)
+    : m_preview_palette(preview_palette)
+{
+    m_active_window_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window.png").release_value_but_fixme_should_propagate_errors();
+    m_inactive_window_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window.png").release_value_but_fixme_should_propagate_errors();
+
+    m_default_close_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window-close.png").release_value_but_fixme_should_propagate_errors();
+    m_default_maximize_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/upward-triangle.png").release_value_but_fixme_should_propagate_errors();
+    m_default_minimize_bitmap = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/downward-triangle.png").release_value_but_fixme_should_propagate_errors();
+
+    VERIFY(m_active_window_icon);
+    VERIFY(m_inactive_window_icon);
+    VERIFY(m_default_close_bitmap);
+    VERIFY(m_default_maximize_bitmap);
+    VERIFY(m_default_minimize_bitmap);
+
+    load_theme_bitmaps();
+}
+
+void AbstractThemePreview::load_theme_bitmaps()
+{
+    auto load_bitmap = [](String const& path, String& last_path, RefPtr<Gfx::Bitmap>& bitmap) {
+        if (path.is_empty()) {
+            last_path = String::empty();
+            bitmap = nullptr;
+        } else if (last_path != path) {
+            auto bitmap_or_error = Gfx::Bitmap::try_load_from_file(path);
+            if (bitmap_or_error.is_error()) {
+                last_path = String::empty();
+                bitmap = nullptr;
+            } else {
+                last_path = path;
+                bitmap = bitmap_or_error.release_value();
+            }
+        }
+    };
+
+    auto buttons_path = m_preview_palette.title_button_icons_path();
+
+    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-close.png"), m_last_close_path, m_close_bitmap);
+    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-maximize.png"), m_last_maximize_path, m_maximize_bitmap);
+    load_bitmap(LexicalPath::absolute_path(buttons_path, "window-minimize.png"), m_last_minimize_path, m_minimize_bitmap);
+
+    load_bitmap(m_preview_palette.active_window_shadow_path(), m_last_active_window_shadow_path, m_active_window_shadow);
+    load_bitmap(m_preview_palette.inactive_window_shadow_path(), m_last_inactive_window_shadow_path, m_inactive_window_shadow);
+    load_bitmap(m_preview_palette.menu_shadow_path(), m_last_menu_shadow_path, m_menu_shadow);
+    load_bitmap(m_preview_palette.taskbar_shadow_path(), m_last_taskbar_shadow_path, m_taskbar_shadow);
+    load_bitmap(m_preview_palette.tooltip_shadow_path(), m_last_tooltip_shadow_path, m_tooltip_shadow);
+}
+
+void AbstractThemePreview::set_preview_palette(Gfx::Palette const& palette)
+{
+    m_preview_palette = palette;
+    if (on_palette_change) {
+        on_palette_change();
+    }
+    load_theme_bitmaps();
+    update();
+}
+
+void AbstractThemePreview::set_theme_from_file(Core::File& file)
+{
+    auto config_file = Core::ConfigFile::open(file.filename(), file.leak_fd()).release_value_but_fixme_should_propagate_errors();
+    auto theme = Gfx::load_system_theme(config_file);
+    VERIFY(theme.is_valid());
+
+    m_preview_palette = Gfx::Palette(Gfx::PaletteImpl::create_with_anonymous_buffer(theme));
+    set_preview_palette(m_preview_palette);
+    if (on_theme_load_from_file)
+        on_theme_load_from_file(file.filename());
+}
+
+void AbstractThemePreview::paint_window(StringView title, Gfx::IntRect const& rect, Gfx::WindowTheme::WindowState state, Gfx::Bitmap const& icon, int button_count)
+{
+    GUI::Painter painter(*this);
+
+    struct Button {
+        Gfx::IntRect rect;
+        RefPtr<Gfx::Bitmap> bitmap;
+    };
+
+    int window_button_width = m_preview_palette.window_title_button_width();
+    int window_button_height = m_preview_palette.window_title_button_height();
+    auto titlebar_text_rect = Gfx::WindowTheme::current().titlebar_text_rect(Gfx::WindowTheme::WindowType::Normal, rect, m_preview_palette);
+    int pos = titlebar_text_rect.right() + 1;
+
+    Array possible_buttons {
+        Button { {}, m_close_bitmap.is_null() ? m_default_close_bitmap : m_close_bitmap },
+        Button { {}, m_maximize_bitmap.is_null() ? m_default_maximize_bitmap : m_maximize_bitmap },
+        Button { {}, m_minimize_bitmap.is_null() ? m_default_minimize_bitmap : m_minimize_bitmap }
+    };
+
+    auto buttons = possible_buttons.span().trim(button_count);
+
+    for (auto& button : buttons) {
+        pos -= window_button_width;
+        Gfx::IntRect button_rect { pos, 0, window_button_width, window_button_height };
+        button_rect.center_vertically_within(titlebar_text_rect);
+        button.rect = button_rect;
+    }
+
+    auto frame_rect = Gfx::WindowTheme::current().frame_rect_for_window(Gfx::WindowTheme::WindowType::Normal, rect, m_preview_palette, 0);
+
+    auto paint_shadow = [](Gfx::Painter& painter, Gfx::IntRect& frame_rect, Gfx::Bitmap const& shadow_bitmap) {
+        auto total_shadow_size = shadow_bitmap.height();
+        auto shadow_rect = frame_rect.inflated(total_shadow_size, total_shadow_size);
+        Gfx::StylePainter::paint_simple_rect_shadow(painter, shadow_rect, shadow_bitmap);
+    };
+
+    if ((state == Gfx::WindowTheme::WindowState::Active || state == Gfx::WindowTheme::WindowState::Highlighted) && m_active_window_shadow) {
+        paint_shadow(painter, frame_rect, *m_active_window_shadow);
+    } else if (state == Gfx::WindowTheme::WindowState::Inactive && m_inactive_window_shadow) {
+        paint_shadow(painter, frame_rect, *m_inactive_window_shadow);
+    }
+
+    Gfx::PainterStateSaver saver(painter);
+    painter.translate(frame_rect.location());
+    Gfx::WindowTheme::current().paint_normal_frame(painter, state, rect, title, icon, m_preview_palette, buttons.last().rect, 0, false);
+    painter.fill_rect(rect.translated(-frame_rect.location()), m_preview_palette.color(Gfx::ColorRole::Background));
+
+    for (auto& button : buttons) {
+        Gfx::StylePainter::paint_button(painter, button.rect, m_preview_palette, Gfx::ButtonStyle::Normal, false);
+        auto bitmap_rect = button.bitmap->rect().centered_within(button.rect);
+        painter.blit(bitmap_rect.location(), *button.bitmap, button.bitmap->rect());
+    }
+}
+
+void AbstractThemePreview::paint_event(GUI::PaintEvent& event)
+{
+    GUI::Frame::paint_event(event);
+    GUI::Painter painter(*this);
+
+    painter.add_clip_rect(event.rect());
+    painter.add_clip_rect(frame_inner_rect());
+
+    painter.fill_rect(frame_inner_rect(), m_preview_palette.desktop_background());
+    paint_preview(event);
+}
+
+}

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.h
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.h
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibGUI/Frame.h>
+#include <LibGfx/Bitmap.h>
+#include <LibGfx/Palette.h>
+#include <LibGfx/WindowTheme.h>
+
+namespace GUI {
+
+class AbstractThemePreview : public GUI::Frame {
+    C_OBJECT_ABSTRACT(AbstractThemePreview);
+
+public:
+    virtual ~AbstractThemePreview() override = default;
+
+    Gfx::Palette const& preview_palette() const { return m_preview_palette; }
+    void set_preview_palette(Gfx::Palette const&);
+    void set_theme_from_file(Core::File&);
+
+    void paint_window(StringView title, Gfx::IntRect const& rect, Gfx::WindowTheme::WindowState, Gfx::Bitmap const& icon, int button_count = 3);
+
+    Function<void(String const&)> on_theme_load_from_file;
+    Function<void()> on_palette_change;
+
+protected:
+    explicit AbstractThemePreview(Gfx::Palette const&);
+
+    inline Gfx::Bitmap const& active_window_icon() const
+    {
+        VERIFY(m_active_window_icon);
+        return *m_active_window_icon;
+    }
+    inline Gfx::Bitmap const& inactive_window_icon() const
+    {
+        VERIFY(m_inactive_window_icon);
+        return *m_inactive_window_icon;
+    }
+
+private:
+    virtual void paint_preview(GUI::PaintEvent&) = 0;
+
+    void load_theme_bitmaps();
+
+    virtual void paint_event(GUI::PaintEvent&) override;
+
+    Gfx::Palette m_preview_palette;
+
+    RefPtr<Gfx::Bitmap> m_active_window_icon;
+    RefPtr<Gfx::Bitmap> m_inactive_window_icon;
+
+    RefPtr<Gfx::Bitmap> m_default_close_bitmap;
+    RefPtr<Gfx::Bitmap> m_default_maximize_bitmap;
+    RefPtr<Gfx::Bitmap> m_default_minimize_bitmap;
+    RefPtr<Gfx::Bitmap> m_close_bitmap;
+    RefPtr<Gfx::Bitmap> m_maximize_bitmap;
+    RefPtr<Gfx::Bitmap> m_minimize_bitmap;
+    String m_last_close_path;
+    String m_last_maximize_path;
+    String m_last_minimize_path;
+
+    RefPtr<Gfx::Bitmap> m_active_window_shadow;
+    RefPtr<Gfx::Bitmap> m_inactive_window_shadow;
+    RefPtr<Gfx::Bitmap> m_menu_shadow;
+    RefPtr<Gfx::Bitmap> m_taskbar_shadow;
+    RefPtr<Gfx::Bitmap> m_tooltip_shadow;
+    String m_last_active_window_shadow_path;
+    String m_last_inactive_window_shadow_path;
+    String m_last_menu_shadow_path;
+    String m_last_taskbar_shadow_path;
+    String m_last_tooltip_shadow_path;
+};
+
+}

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SOURCES
     AbstractTableView.cpp
     AbstractView.cpp
     AbstractZoomPanWidget.cpp
+    AbstractThemePreview.cpp
     Action.cpp
     ActionGroup.cpp
     Application.cpp
@@ -111,8 +112,8 @@ set(SOURCES
     VimEditingEngine.cpp
     Widget.cpp
     Window.cpp
-        ConnectionToWindowServer.cpp
-        ConnectionToWindowMangerServer.cpp
+    ConnectionToWindowServer.cpp
+    ConnectionToWindowMangerServer.cpp
     Wizards/WizardDialog.cpp
     Wizards/AbstractWizardPage.cpp
     Wizards/CoverWizardPage.cpp

--- a/Userland/Libraries/LibGfx/SystemTheme.cpp
+++ b/Userland/Libraries/LibGfx/SystemTheme.cpp
@@ -6,7 +6,10 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/LexicalPath.h>
+#include <AK/QuickSort.h>
 #include <LibCore/ConfigFile.h>
+#include <LibCore/DirIterator.h>
 #include <LibGfx/SystemTheme.h>
 #include <string.h>
 
@@ -148,6 +151,19 @@ Core::AnonymousBuffer load_system_theme(Core::ConfigFile const& file)
 Core::AnonymousBuffer load_system_theme(String const& path)
 {
     return load_system_theme(Core::ConfigFile::open(path).release_value_but_fixme_should_propagate_errors());
+}
+
+Vector<SystemThemeMetaData> list_installed_system_themes()
+{
+    Vector<SystemThemeMetaData> system_themes;
+    Core::DirIterator dt("/res/themes", Core::DirIterator::SkipDots);
+    while (dt.has_next()) {
+        auto theme_name = dt.next_path();
+        auto theme_path = String::formatted("/res/themes/{}", theme_name);
+        system_themes.append({ LexicalPath::title(theme_name), theme_path });
+    }
+    quick_sort(system_themes, [](auto& a, auto& b) { return a.name < b.name; });
+    return system_themes;
 }
 
 }

--- a/Userland/Libraries/LibGfx/SystemTheme.h
+++ b/Userland/Libraries/LibGfx/SystemTheme.h
@@ -11,6 +11,7 @@
 #include <AK/Forward.h>
 #include <AK/String.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/ConfigFile.h>
 #include <LibGfx/Color.h>
@@ -271,6 +272,13 @@ Core::AnonymousBuffer& current_system_theme_buffer();
 void set_system_theme(Core::AnonymousBuffer);
 Core::AnonymousBuffer load_system_theme(Core::ConfigFile const&);
 Core::AnonymousBuffer load_system_theme(String const& path);
+
+struct SystemThemeMetaData {
+    String name;
+    String path;
+};
+
+Vector<SystemThemeMetaData> list_installed_system_themes();
 
 }
 

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -7,11 +7,9 @@
 #include "ShutdownDialog.h"
 #include "TaskbarWindow.h"
 #include <AK/Debug.h>
-#include <AK/LexicalPath.h>
 #include <AK/QuickSort.h>
 #include <LibConfig/Client.h>
 #include <LibCore/ConfigFile.h>
-#include <LibCore/DirIterator.h>
 #include <LibCore/EventLoop.h>
 #include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
@@ -23,6 +21,7 @@
 #include <LibGUI/ConnectionToWindowMangerServer.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/Menu.h>
+#include <LibGfx/SystemTheme.h>
 #include <LibMain/Main.h>
 #include <WindowServer/Window.h>
 #include <serenity.h>
@@ -78,14 +77,9 @@ struct AppMetadata {
 };
 Vector<AppMetadata> g_apps;
 
-struct ThemeMetadata {
-    String name;
-    String path;
-};
-
 Color g_menu_selection_color;
 
-Vector<ThemeMetadata> g_themes;
+Vector<Gfx::SystemThemeMetaData> g_themes;
 RefPtr<GUI::Menu> g_themes_menu;
 GUI::ActionGroup g_themes_group;
 
@@ -214,16 +208,7 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu()
     g_themes_menu = &system_menu->add_submenu("&Themes");
     g_themes_menu->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/themes.png").release_value_but_fixme_should_propagate_errors());
 
-    {
-        Core::DirIterator dt("/res/themes", Core::DirIterator::SkipDots);
-        while (dt.has_next()) {
-            auto theme_name = dt.next_path();
-            auto theme_path = String::formatted("/res/themes/{}", theme_name);
-            g_themes.append({ LexicalPath::title(theme_name), theme_path });
-        }
-        quick_sort(g_themes, [](auto& a, auto& b) { return a.name < b.name; });
-    }
-
+    g_themes = Gfx::list_installed_system_themes();
     auto current_theme_name = GUI::ConnectionToWindowServer::the().get_system_theme();
 
     {


### PR DESCRIPTION

![Screenshot from 2022-04-02 03-03-19](https://user-images.githubusercontent.com/11597044/161361442-32b672e9-1903-495f-bd52-40a6ae75843a.png)

This PR adds a Windows XP-ish inspired theme selector + preview to the display settings.
I thought this may possibly replace the theme selection on the 'Serenity Menu', though I've not included that change in this PR.