### PR TITLE
Kernel: Declare Device major and minor data member numbers as const

### DIFF
--- a/Kernel/Devices/Device.h
+++ b/Kernel/Devices/Device.h
@@ -68,8 +68,8 @@ protected:
     void set_gid(GroupID gid) { m_gid = gid; }
 
 private:
-    MajorNumber m_major { 0 };
-    MinorNumber m_minor { 0 };
+    MajorNumber const m_major { 0 };
+    MinorNumber const m_minor { 0 };
     UserID m_uid { 0 };
     GroupID m_gid { 0 };
 


### PR DESCRIPTION
This is just another "safety guard" to ensure these numbers don't ever
change after being set for a certain Device at construction time.