### PR TITLE
3DFileViewer: Allow escape key to exit fullscreen mode

### DIFF
--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -96,6 +96,7 @@ private:
     virtual void timer_event(Core::TimerEvent&) override;
     virtual void mousemove_event(GUI::MouseEvent&) override;
     virtual void mousewheel_event(GUI::MouseEvent&) override;
+    virtual void keydown_event(GUI::KeyEvent&) override;
 
 private:
     RefPtr<Mesh> m_mesh;
@@ -159,6 +160,14 @@ void GLContextWidget::mousewheel_event(GUI::MouseEvent& event)
         m_zoom /= 1.1f;
     else
         m_zoom *= 1.1f;
+}
+
+void GLContextWidget::keydown_event(GUI::KeyEvent& event)
+{
+    if (event.key() == Key_Escape && window()->is_fullscreen()) {
+        window()->set_fullscreen(false);
+        return;
+    }
 }
 
 void GLContextWidget::timer_event(Core::TimerEvent&)


### PR DESCRIPTION
I went into fullscreen mode, via the View menu, before looking at the associated key (F11). I had to kill Qemu to be able to escape.

Escape is an intuitive way to exit most fullscreen modes.

### Notes

This is my first patch so there are a few things I may have incorrect. 

- I'm unsure if setting the window on the widget (`m_window`) is idiomatic
- I used `RefPtr<GUI::Window>` for `m_window` as I could see that being used throughout the Serenity codebase

Thanks!

