### PR TITLE
PDFViewer: Multipage view, misc QOL changes

### DIFF
--- a/Userland/Applications/PDFViewer/CMakeLists.txt
+++ b/Userland/Applications/PDFViewer/CMakeLists.txt
@@ -13,4 +13,4 @@ set(SOURCES
     )
 
 serenity_app(PDFViewer ICON app-pdf-viewer)
-target_link_libraries(PDFViewer LibGUI LibPDF LibFileSystemAccessClient LibMain)
+target_link_libraries(PDFViewer LibGUI LibPDF LibFileSystemAccessClient LibConfig LibMain)

--- a/Userland/Applications/PDFViewer/NumericInput.cpp
+++ b/Userland/Applications/PDFViewer/NumericInput.cpp
@@ -14,7 +14,7 @@ NumericInput::NumericInput()
     on_change = [&] {
         auto number_opt = text().to_int();
         if (number_opt.has_value()) {
-            set_current_number(number_opt.value(), false);
+            set_current_number(number_opt.value(), GUI::AllowCallback::No);
             return;
         }
 
@@ -36,7 +36,7 @@ NumericInput::NumericInput()
         }
 
         set_text(builder.to_string());
-        set_current_number(new_number_opt.value(), false);
+        set_current_number(new_number_opt.value(), GUI::AllowCallback::No);
     };
 
     on_up_pressed = [&] {
@@ -78,13 +78,13 @@ void NumericInput::on_focus_lost()
         on_number_changed(m_current_number);
 }
 
-void NumericInput::set_current_number(i32 number, bool call_change_handler)
+void NumericInput::set_current_number(i32 number, GUI::AllowCallback allow_callback)
 {
     if (number == m_current_number)
         return;
 
     m_current_number = clamp(number, m_min_number, m_max_number);
     set_text(String::number(m_current_number));
-    if (on_number_changed && call_change_handler)
+    if (on_number_changed && allow_callback == GUI::AllowCallback::Yes)
         on_number_changed(m_current_number);
 }

--- a/Userland/Applications/PDFViewer/NumericInput.h
+++ b/Userland/Applications/PDFViewer/NumericInput.h
@@ -18,7 +18,7 @@ public:
 
     void set_min_number(i32 number);
     void set_max_number(i32 number);
-    void set_current_number(i32 number, bool call_change_handler = true);
+    void set_current_number(i32 number, GUI::AllowCallback allow_callback = GUI::AllowCallback::Yes);
 
 private:
     NumericInput();

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -155,6 +155,13 @@ void PDFViewer::paint_event(GUI::PaintEvent& event)
     }
 }
 
+void PDFViewer::set_current_page(u32 current_page)
+{
+    m_current_page_index = current_page;
+    vertical_scrollbar().set_value(m_page_dimension_cache.render_info[current_page].total_height_before_this_page);
+    update();
+}
+
 void PDFViewer::resize_event(GUI::ResizeEvent&)
 {
     for (auto& map : m_rendered_page_list)

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -7,13 +7,14 @@
 
 #include "PDFViewer.h"
 #include <AK/Array.h>
+#include <AK/BinarySearch.h>
 #include <LibConfig/Client.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
 #include <LibPDF/Renderer.h>
 
-static constexpr int PAGE_PADDING = 25;
+static constexpr int PAGE_PADDING = 10;
 
 static constexpr Array zoom_levels = {
     17,
@@ -46,7 +47,7 @@ PDFViewer::PDFViewer()
     m_page_view_mode = static_cast<PageViewMode>(Config::read_i32("PDFViewer", "Display", "PageMode", 0));
 }
 
-void PDFViewer::set_document(RefPtr<PDF::Document> document)
+PDF::PDFErrorOr<void> PDFViewer::set_document(RefPtr<PDF::Document> document)
 {
     m_document = document;
     m_current_page_index = document->get_first_page_index();
@@ -57,7 +58,10 @@ void PDFViewer::set_document(RefPtr<PDF::Document> document)
     for (u32 i = 0; i < document->get_page_count(); i++)
         m_rendered_page_list.unchecked_append(HashMap<u32, RenderedPage>());
 
+    TRY(cache_page_dimensions(true));
     update();
+
+    return {};
 }
 
 PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> PDFViewer::get_rendered_page(u32 index)
@@ -67,8 +71,7 @@ PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> PDFViewer::get_rendered_page(u32 ind
     if (existing_rendered_page.has_value() && existing_rendered_page.value().rotation == m_rotations)
         return existing_rendered_page.value().bitmap;
 
-    auto page = TRY(m_document->get_page(index));
-    auto rendered_page = TRY(render_page(page));
+    auto rendered_page = TRY(render_page(index));
     rendered_page_map.set(m_zoom_level, { rendered_page, m_rotations });
     return rendered_page;
 }
@@ -85,29 +88,79 @@ void PDFViewer::paint_event(GUI::PaintEvent& event)
     if (!m_document)
         return;
 
-    auto maybe_page = get_rendered_page(m_current_page_index);
-    if (maybe_page.is_error()) {
-        auto error = maybe_page.release_error();
-        GUI::MessageBox::show_error(nullptr, String::formatted("Error rendering page:\n{}", error.message()));
+    auto handle_error = [&]<typename T>(PDF::PDFErrorOr<T> maybe_error) {
+        if (maybe_error.is_error()) {
+            auto error = maybe_error.release_error();
+            GUI::MessageBox::show_error(nullptr, String::formatted("Error rendering page:\n{}", error.message()));
+            return true;
+        }
+        return false;
+    };
+
+    if (m_page_view_mode == PageViewMode::Single) {
+        auto maybe_page = get_rendered_page(m_current_page_index);
+        if (handle_error(maybe_page))
+            return;
+
+        auto page = maybe_page.release_value();
+        set_content_size(page->size());
+
+        painter.translate(frame_thickness(), frame_thickness());
+        painter.translate(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
+
+        int x = max(0, (width() - page->width()) / 2);
+        int y = max(0, (height() - page->height()) / 2);
+
+        painter.blit({ x, y }, *page, page->rect());
         return;
     }
 
-    auto page = maybe_page.release_value();
-    set_content_size(page->size());
+    set_content_size({ m_page_dimension_cache.max_width, m_page_dimension_cache.total_height });
+
+    size_t first_page_index = 0;
+    size_t last_page_index = 0;
+
+    binary_search(m_page_dimension_cache.render_info, vertical_scrollbar().value(), &first_page_index, [](int height, PageDimensionCache::RenderInfo const& render_info) {
+        return height - render_info.total_height_before_this_page;
+    });
+
+    binary_search(m_page_dimension_cache.render_info, vertical_scrollbar().value() + height(), &last_page_index, [](int height, PageDimensionCache::RenderInfo const& render_info) {
+        return height - render_info.total_height_before_this_page;
+    });
+
+    auto initial_offset = m_page_dimension_cache.render_info[first_page_index].total_height_before_this_page - vertical_scrollbar().value();
 
     painter.translate(frame_thickness(), frame_thickness());
-    painter.translate(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
+    painter.translate(-horizontal_scrollbar().value(), initial_offset);
+    auto middle = height() / 2;
+    auto y_offset = initial_offset;
 
-    int x = max(0, (width() - page->width()) / 2);
-    int y = max(0, (height() - page->height()) / 2);
+    for (size_t page_index = first_page_index; page_index <= last_page_index; page_index++) {
+        auto maybe_page = get_rendered_page(page_index);
+        if (handle_error(maybe_page))
+            return;
 
-    painter.blit({ x, y }, *page, page->rect());
+        auto page = maybe_page.release_value();
+
+        auto x = max(0, (width() - page->width()) / 2);
+
+        painter.blit({ x, PAGE_PADDING }, *page, page->rect());
+        auto diff_y = page->height() + PAGE_PADDING * 2;
+        painter.translate(0, diff_y);
+
+        if (y_offset < middle && y_offset + diff_y >= middle)
+            change_page(page_index);
+
+        y_offset += diff_y;
+    }
 }
 
 void PDFViewer::resize_event(GUI::ResizeEvent&)
 {
     for (auto& map : m_rendered_page_list)
         map.clear();
+    if (m_document)
+        MUST(cache_page_dimensions());
     update();
 }
 
@@ -124,15 +177,24 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
         } else {
             zoom_in();
         }
-    } else {
-        auto& scrollbar = event.shift() ? horizontal_scrollbar() : vertical_scrollbar();
+        return;
+    }
 
+    auto& scrollbar = event.shift() ? horizontal_scrollbar() : vertical_scrollbar();
+
+    if (m_page_view_mode == PageViewMode::Multiple) {
+        if (scrolled_down) {
+            if (scrollbar.value() != scrollbar.max())
+                scrollbar.increase_slider_by(20);
+        } else {
+            if (scrollbar.value() > 0)
+                scrollbar.decrease_slider_by(20);
+        }
+    } else {
         if (scrolled_down) {
             if (scrollbar.value() == scrollbar.max()) {
-                if (m_current_page_index < m_document->get_page_count() - 1 && !event.shift()) {
-                    m_current_page_index++;
-                    if (on_page_change)
-                        on_page_change(m_current_page_index);
+                if (m_current_page_index < m_document->get_page_count() - 1) {
+                    change_page(m_current_page_index + 1);
                     scrollbar.set_value(0);
                 }
             } else {
@@ -140,18 +202,17 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
             }
         } else {
             if (scrollbar.value() == 0) {
-                if (m_current_page_index > 0 && !event.shift()) {
-                    m_current_page_index--;
-                    if (on_page_change)
-                        on_page_change(m_current_page_index);
+                if (m_current_page_index > 0) {
+                    change_page(m_current_page_index - 1);
                     scrollbar.set_value(scrollbar.max());
                 }
             } else {
                 scrollbar.decrease_slider_by(20);
             }
         }
-        update();
     }
+
+    update();
 }
 
 void PDFViewer::mousedown_event(GUI::MouseEvent& event)
@@ -190,6 +251,7 @@ void PDFViewer::zoom_in()
 {
     if (m_zoom_level < zoom_levels.size() - 1) {
         m_zoom_level++;
+        MUST(cache_page_dimensions());
         update();
     }
 }
@@ -198,6 +260,7 @@ void PDFViewer::zoom_out()
 {
     if (m_zoom_level > 0) {
         m_zoom_level--;
+        MUST(cache_page_dimensions());
         update();
     }
 }
@@ -205,12 +268,14 @@ void PDFViewer::zoom_out()
 void PDFViewer::reset_zoom()
 {
     m_zoom_level = initial_zoom_level;
+    MUST(cache_page_dimensions());
     update();
 }
 
 void PDFViewer::rotate(int degrees)
 {
     m_rotations = (m_rotations + degrees + 360) % 360;
+    MUST(cache_page_dimensions());
     update();
 }
 
@@ -221,17 +286,11 @@ void PDFViewer::set_page_view_mode(PageViewMode mode)
     update();
 }
 
-PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> PDFViewer::render_page(const PDF::Page& page)
+PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> PDFViewer::render_page(u32 page_index)
 {
-    auto zoom_scale_factor = static_cast<float>(zoom_levels[m_zoom_level]) / 100.0f;
-
-    auto page_width = page.media_box.upper_right_x - page.media_box.lower_left_x;
-    auto page_height = page.media_box.upper_right_y - page.media_box.lower_left_y;
-    auto page_scale_factor = page_height / page_width;
-
-    auto height = static_cast<float>(this->height() - 2 * frame_thickness() - PAGE_PADDING * 2) * zoom_scale_factor;
-    auto width = height / page_scale_factor;
-    auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, { width, height }).release_value_but_fixme_should_propagate_errors();
+    auto page = TRY(m_document->get_page(page_index));
+    auto& page_size = m_page_dimension_cache.render_info[page_index].size;
+    auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, page_size.to_type<int>()).release_value_but_fixme_should_propagate_errors();
 
     TRY(PDF::Renderer::render(*m_document, page, bitmap));
 
@@ -246,4 +305,62 @@ PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> PDFViewer::render_page(const PDF::Pa
     }
 
     return bitmap;
+}
+
+PDF::PDFErrorOr<void> PDFViewer::cache_page_dimensions(bool recalculate_fixed_info)
+{
+    if (recalculate_fixed_info)
+        m_page_dimension_cache.page_info.clear_with_capacity();
+
+    if (m_page_dimension_cache.page_info.is_empty()) {
+        m_page_dimension_cache.page_info.ensure_capacity(m_document->get_page_count());
+        for (size_t i = 0; i < m_document->get_page_count(); i++) {
+            auto page = TRY(m_document->get_page(i));
+            auto box = page.media_box;
+            m_page_dimension_cache.page_info.unchecked_append(PageDimensionCache::PageInfo {
+                { box.width(), box.height() },
+                page.rotate,
+            });
+        }
+    }
+
+    auto zoom_scale_factor = static_cast<float>(zoom_levels[m_zoom_level]) / 100.0f;
+
+    m_page_dimension_cache.render_info.clear_with_capacity();
+    m_page_dimension_cache.render_info.ensure_capacity(m_page_dimension_cache.page_info.size());
+
+    float max_width = 0;
+    float total_height = 0;
+
+    for (size_t i = 0; i < m_page_dimension_cache.page_info.size(); i++) {
+        auto& [size, rotation] = m_page_dimension_cache.page_info[i];
+        rotation += m_rotations;
+        auto page_scale_factor = size.height() / size.width();
+
+        auto height = static_cast<float>(this->height() - 2 * frame_thickness()) * zoom_scale_factor - PAGE_PADDING * 2;
+        auto width = height / page_scale_factor;
+        if (rotation % 2)
+            swap(width, height);
+
+        max_width = max(max_width, width);
+
+        m_page_dimension_cache.render_info.append({
+            { width, height },
+            total_height,
+        });
+
+        total_height += height;
+    }
+
+    m_page_dimension_cache.max_width = max_width;
+    m_page_dimension_cache.total_height = total_height;
+
+    return {};
+}
+
+void PDFViewer::change_page(u32 new_page)
+{
+    m_current_page_index = new_page;
+    if (on_page_change)
+        on_page_change(m_current_page_index);
 }

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -101,6 +101,13 @@ void PDFViewer::paint_event(GUI::PaintEvent& event)
     painter.blit({ x, y }, *page, page->rect());
 }
 
+void PDFViewer::resize_event(GUI::ResizeEvent&)
+{
+    for (auto& map : m_rendered_page_list)
+        map.clear();
+    update();
+}
+
 void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
 {
     if (!m_document)

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -126,7 +126,7 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
 
         if (scrolled_down) {
             if (scrollbar.value() == scrollbar.max()) {
-                if (m_current_page_index < m_document->get_page_count() - 1) {
+                if (m_current_page_index < m_document->get_page_count() - 1 && !event.shift()) {
                     m_current_page_index++;
                     if (on_page_change)
                         on_page_change(m_current_page_index);
@@ -137,7 +137,7 @@ void PDFViewer::mousewheel_event(GUI::MouseEvent& event)
             }
         } else {
             if (scrollbar.value() == 0) {
-                if (m_current_page_index > 0) {
+                if (m_current_page_index > 0 && !event.shift()) {
                     m_current_page_index--;
                     if (on_page_change)
                         on_page_change(m_current_page_index);

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -297,17 +297,17 @@ PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> PDFViewer::render_page(u32 page_inde
 {
     auto page = TRY(m_document->get_page(page_index));
     auto& page_size = m_page_dimension_cache.render_info[page_index].size;
-    auto bitmap = Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, page_size.to_type<int>()).release_value_but_fixme_should_propagate_errors();
+    auto bitmap = TRY(Gfx::Bitmap::try_create(Gfx::BitmapFormat::BGRA8888, page_size.to_type<int>()));
 
     TRY(PDF::Renderer::render(*m_document, page, bitmap));
 
     if (page.rotate + m_rotations != 0) {
         int rotation_count = ((page.rotate + m_rotations) / 90) % 4;
         if (rotation_count == 3) {
-            bitmap = bitmap->rotated(Gfx::RotationDirection::CounterClockwise).release_value_but_fixme_should_propagate_errors();
+            bitmap = TRY(bitmap->rotated(Gfx::RotationDirection::CounterClockwise));
         } else {
             for (int i = 0; i < rotation_count; i++)
-                bitmap = bitmap->rotated(Gfx::RotationDirection::Clockwise).release_value_but_fixme_should_propagate_errors();
+                bitmap = TRY(bitmap->rotated(Gfx::RotationDirection::Clockwise));
         }
     }
 

--- a/Userland/Applications/PDFViewer/PDFViewer.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewer.cpp
@@ -7,6 +7,7 @@
 
 #include "PDFViewer.h"
 #include <AK/Array.h>
+#include <LibConfig/Client.h>
 #include <LibGUI/Action.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
@@ -41,6 +42,8 @@ PDFViewer::PDFViewer()
     set_scrollbars_enabled(true);
 
     start_timer(30'000);
+
+    m_page_view_mode = static_cast<PageViewMode>(Config::read_i32("PDFViewer", "Display", "PageMode", 0));
 }
 
 void PDFViewer::set_document(RefPtr<PDF::Document> document)
@@ -208,6 +211,13 @@ void PDFViewer::reset_zoom()
 void PDFViewer::rotate(int degrees)
 {
     m_rotations = (m_rotations + degrees + 360) % 360;
+    update();
+}
+
+void PDFViewer::set_page_view_mode(PageViewMode mode)
+{
+    m_page_view_mode = mode;
+    Config::write_i32("PDFViewer", "Display", "PageMode", static_cast<i32>(mode));
     update();
 }
 

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -18,6 +18,11 @@ class PDFViewer : public GUI::AbstractScrollableWidget {
     C_OBJECT(PDFViewer)
 
 public:
+    enum class PageViewMode {
+        Single,
+        Multiple,
+    };
+
     virtual ~PDFViewer() override = default;
 
     ALWAYS_INLINE u32 current_page() const { return m_current_page_index; }
@@ -37,6 +42,7 @@ protected:
     PDFViewer();
 
     virtual void paint_event(GUI::PaintEvent&) override;
+    virtual void resize_event(GUI::ResizeEvent&) override;
     virtual void mousewheel_event(GUI::MouseEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -46,7 +46,7 @@ public:
     virtual ~PDFViewer() override = default;
 
     ALWAYS_INLINE u32 current_page() const { return m_current_page_index; }
-    ALWAYS_INLINE void set_current_page(u32 current_page) { m_current_page_index = current_page; }
+    void set_current_page(u32 current_page);
 
     ALWAYS_INLINE RefPtr<PDF::Document> const& document() const { return m_document; }
     PDF::PDFErrorOr<void> set_document(RefPtr<PDF::Document>);

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -38,6 +38,9 @@ public:
     void reset_zoom();
     void rotate(int degrees);
 
+    PageViewMode page_view_mode() const { return m_page_view_mode; }
+    void set_page_view_mode(PageViewMode);
+
 protected:
     PDFViewer();
 
@@ -63,6 +66,7 @@ private:
     Vector<HashMap<u32, RenderedPage>> m_rendered_page_list;
 
     u8 m_zoom_level { initial_zoom_level };
+    PageViewMode m_page_view_mode;
 
     Gfx::IntPoint m_pan_starting_position;
     int m_rotations { 0 };

--- a/Userland/Applications/PDFViewer/PDFViewer.h
+++ b/Userland/Applications/PDFViewer/PDFViewer.h
@@ -14,6 +14,26 @@
 
 static constexpr size_t initial_zoom_level = 8;
 
+struct PageDimensionCache {
+    // Fixed for a given document
+    struct PageInfo {
+        Gfx::FloatSize size;
+        int rotation;
+    };
+
+    // Based on PageInfo, also depends on some dynamic factors like
+    // zoom level and app size
+    struct RenderInfo {
+        Gfx::FloatSize size;
+        float total_height_before_this_page;
+    };
+
+    Vector<PageInfo> page_info;
+    Vector<RenderInfo> render_info;
+    float max_width;
+    float total_height;
+};
+
 class PDFViewer : public GUI::AbstractScrollableWidget {
     C_OBJECT(PDFViewer)
 
@@ -29,7 +49,7 @@ public:
     ALWAYS_INLINE void set_current_page(u32 current_page) { m_current_page_index = current_page; }
 
     ALWAYS_INLINE RefPtr<PDF::Document> const& document() const { return m_document; }
-    void set_document(RefPtr<PDF::Document>);
+    PDF::PDFErrorOr<void> set_document(RefPtr<PDF::Document>);
 
     Function<void(u32 new_page)> on_page_change;
 
@@ -59,13 +79,16 @@ private:
     };
 
     PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> get_rendered_page(u32 index);
-    PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> render_page(const PDF::Page&);
+    PDF::PDFErrorOr<NonnullRefPtr<Gfx::Bitmap>> render_page(u32 page_index);
+    PDF::PDFErrorOr<void> cache_page_dimensions(bool recalculate_fixed_info = false);
+    void change_page(u32 new_page);
 
     RefPtr<PDF::Document> m_document;
     u32 m_current_page_index { 0 };
     Vector<HashMap<u32, RenderedPage>> m_rendered_page_list;
 
     u8 m_zoom_level { initial_zoom_level };
+    PageDimensionCache m_page_dimension_cache;
     PageViewMode m_page_view_mode;
 
     Gfx::IntPoint m_pan_starting_position;

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -24,7 +24,8 @@ PDFViewerWidget::PDFViewerWidget()
     set_fill_with_background_color(true);
     set_layout<GUI::VerticalBoxLayout>();
 
-    create_toolbar();
+    auto& toolbar_container = add<GUI::ToolbarContainer>();
+    auto& toolbar = toolbar_container.add<GUI::Toolbar>();
 
     auto& splitter = add<GUI::HorizontalSplitter>();
 
@@ -35,6 +36,8 @@ PDFViewerWidget::PDFViewerWidget()
     m_viewer->on_page_change = [&](auto new_page) {
         m_page_text_box->set_current_number(new_page + 1);
     };
+
+    initialize_toolbar(toolbar);
 }
 
 void PDFViewerWidget::initialize_menubar(GUI::Window& window)
@@ -42,9 +45,8 @@ void PDFViewerWidget::initialize_menubar(GUI::Window& window)
     auto& file_menu = window.add_menu("&File");
     file_menu.add_action(GUI::CommonActions::make_open_action([&](auto&) {
         auto response = FileSystemAccessClient::Client::the().try_open_file(&window);
-        if (response.is_error())
-            return;
-        open_file(*response.value());
+        if (!response.is_error())
+            open_file(*response.value());
     }));
     file_menu.add_separator();
     file_menu.add_action(GUI::CommonActions::make_quit_action([](auto&) {
@@ -54,6 +56,10 @@ void PDFViewerWidget::initialize_menubar(GUI::Window& window)
     auto& view_menu = window.add_menu("&View");
     view_menu.add_action(*m_toggle_sidebar_action);
     view_menu.add_separator();
+    auto& view_mode_menu = view_menu.add_submenu("View &Mode");
+    view_mode_menu.add_action(*m_page_view_mode_single);
+    view_mode_menu.add_action(*m_page_view_mode_multiple);
+    view_menu.add_separator();
     view_menu.add_action(*m_zoom_in_action);
     view_menu.add_action(*m_zoom_out_action);
     view_menu.add_action(*m_reset_zoom_action);
@@ -62,11 +68,8 @@ void PDFViewerWidget::initialize_menubar(GUI::Window& window)
     help_menu.add_action(GUI::CommonActions::make_about_action("PDF Viewer", GUI::Icon::default_icon("app-pdf-viewer"), &window));
 }
 
-void PDFViewerWidget::create_toolbar()
+void PDFViewerWidget::initialize_toolbar(GUI::Toolbar& toolbar)
 {
-    auto& toolbar_container = add<GUI::ToolbarContainer>();
-    auto& toolbar = toolbar_container.add<GUI::Toolbar>();
-
     auto open_outline_action = GUI::Action::create(
         "Toggle &Sidebar", { Mod_Ctrl, Key_S }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/sidebar.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
             m_sidebar_open = !m_sidebar_open;
@@ -138,6 +141,24 @@ void PDFViewerWidget::create_toolbar()
     m_reset_zoom_action->set_enabled(false);
     m_rotate_counterclockwise_action->set_enabled(false);
     m_rotate_clockwise_action->set_enabled(false);
+
+    m_page_view_mode_single = GUI::Action::create_checkable("Single", [&](auto&) {
+        m_viewer->set_page_view_mode(PDFViewer::PageViewMode::Single);
+    });
+
+    m_page_view_mode_multiple = GUI::Action::create_checkable("Multiple", [&](auto&) {
+        m_viewer->set_page_view_mode(PDFViewer::PageViewMode::Multiple);
+    });
+
+    if (m_viewer->page_view_mode() == PDFViewer::PageViewMode::Single) {
+        m_page_view_mode_single->set_checked(true);
+    } else {
+        m_page_view_mode_multiple->set_checked(true);
+    }
+
+    m_page_view_action_group.add_action(*m_page_view_mode_single);
+    m_page_view_action_group.add_action(*m_page_view_mode_multiple);
+    m_page_view_action_group.set_exclusive(true);
 
     toolbar.add_action(*m_zoom_in_action);
     toolbar.add_action(*m_zoom_out_action);

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -112,7 +112,7 @@ void PDFViewerWidget::initialize_toolbar(GUI::Toolbar& toolbar)
     };
 
     m_total_page_label = toolbar.add<GUI::Label>();
-    m_total_page_label->set_fixed_width(30);
+    m_total_page_label->set_autosize(true, 5);
     toolbar.add_separator();
 
     m_zoom_in_action = GUI::CommonActions::make_zoom_in_action([&](auto&) {

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.cpp
@@ -34,7 +34,7 @@ PDFViewerWidget::PDFViewerWidget()
 
     m_viewer = splitter.add<PDFViewer>();
     m_viewer->on_page_change = [&](auto new_page) {
-        m_page_text_box->set_current_number(new_page + 1);
+        m_page_text_box->set_current_number(new_page + 1, GUI::AllowCallback::No);
     };
 
     initialize_toolbar(toolbar);
@@ -107,7 +107,6 @@ void PDFViewerWidget::initialize_toolbar(GUI::Toolbar& toolbar)
         auto new_page_number = static_cast<u32>(number);
         VERIFY(new_page_number >= 1 && new_page_number <= page_count);
         m_viewer->set_current_page(new_page_number - 1);
-        m_viewer->update();
         m_go_to_prev_page_action->set_enabled(new_page_number > 1);
         m_go_to_next_page_action->set_enabled(new_page_number < page_count);
     };
@@ -201,7 +200,7 @@ void PDFViewerWidget::open_file(Core::File& file)
     m_total_page_label->set_text(String::formatted("of {}", document->get_page_count()));
 
     m_page_text_box->set_enabled(true);
-    m_page_text_box->set_current_number(1, false);
+    m_page_text_box->set_current_number(1, GUI::AllowCallback::No);
     m_page_text_box->set_max_number(document->get_page_count());
     m_go_to_prev_page_action->set_enabled(false);
     m_go_to_next_page_action->set_enabled(document->get_page_count() > 1);

--- a/Userland/Applications/PDFViewer/PDFViewerWidget.h
+++ b/Userland/Applications/PDFViewer/PDFViewerWidget.h
@@ -10,6 +10,7 @@
 #include "PDFViewer.h"
 #include "SidebarWidget.h"
 #include <LibGUI/Action.h>
+#include <LibGUI/ActionGroup.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 
@@ -22,11 +23,12 @@ public:
     ~PDFViewerWidget() override = default;
 
     void initialize_menubar(GUI::Window&);
-    void create_toolbar();
     void open_file(Core::File&);
 
 private:
     PDFViewerWidget();
+
+    void initialize_toolbar(GUI::Toolbar&);
 
     RefPtr<PDFViewer> m_viewer;
     RefPtr<SidebarWidget> m_sidebar;
@@ -40,6 +42,9 @@ private:
     RefPtr<GUI::Action> m_reset_zoom_action;
     RefPtr<GUI::Action> m_rotate_counterclockwise_action;
     RefPtr<GUI::Action> m_rotate_clockwise_action;
+    GUI::ActionGroup m_page_view_action_group;
+    RefPtr<GUI::Action> m_page_view_mode_single;
+    RefPtr<GUI::Action> m_page_view_mode_multiple;
 
     bool m_sidebar_open { false };
     ByteBuffer m_buffer;

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "PDFViewerWidget.h"
+#include <LibConfig/Client.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibFileSystemAccessClient/Client.h>
@@ -25,7 +26,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = GUI::Icon::default_icon("app-pdf-viewer");
 
-    auto window = GUI::Window::construct();
+    Config::pledge_domain("PDFViewer");
+
+    auto window = TRY(GUI::Window::try_create());
     window->set_title("PDF Viewer");
     window->resize(640, 400);
 

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -34,11 +34,12 @@ Label::Label(String text)
     REGISTER_STRING_PROPERTY("icon", icon, set_icon_from_path);
 }
 
-void Label::set_autosize(bool autosize)
+void Label::set_autosize(bool autosize, size_t padding)
 {
-    if (m_autosize == autosize)
+    if (m_autosize == autosize && m_autosize_padding == padding)
         return;
     m_autosize = autosize;
+    m_autosize_padding = padding;
     if (m_autosize)
         size_to_fit();
 }
@@ -108,7 +109,7 @@ void Label::paint_event(PaintEvent& event)
 
 void Label::size_to_fit()
 {
-    set_fixed_width(font().width(m_text));
+    set_fixed_width(font().width(m_text) + m_autosize_padding * 2);
 }
 
 int Label::preferred_height() const

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -37,7 +37,7 @@ public:
     void set_should_stretch_icon(bool b) { m_should_stretch_icon = b; }
 
     bool is_autosize() const { return m_autosize; }
-    void set_autosize(bool);
+    void set_autosize(bool, size_t padding = 0);
 
     int preferred_height() const;
 
@@ -58,6 +58,7 @@ private:
     Gfx::TextWrapping m_text_wrapping { Gfx::TextWrapping::Wrap };
     bool m_should_stretch_icon { false };
     bool m_autosize { false };
+    size_t m_autosize_padding { 0 };
 };
 
 }

--- a/Userland/Libraries/LibPDF/Document.h
+++ b/Userland/Libraries/LibPDF/Document.h
@@ -23,6 +23,9 @@ struct Rectangle {
     float lower_left_y;
     float upper_right_x;
     float upper_right_y;
+
+    float width() const { return upper_right_x - lower_left_x; }
+    float height() const { return upper_right_y - lower_left_y; }
 };
 
 struct Page {

--- a/Userland/Libraries/LibPDF/Renderer.cpp
+++ b/Userland/Libraries/LibPDF/Renderer.cpp
@@ -38,8 +38,8 @@ Renderer::Renderer(RefPtr<Document> document, Page const& page, RefPtr<Gfx::Bitm
     Gfx::AffineTransform userspace_matrix;
     userspace_matrix.translate(media_box.lower_left_x, media_box.lower_left_y);
 
-    float width = media_box.upper_right_x - media_box.lower_left_x;
-    float height = media_box.upper_right_y - media_box.lower_left_y;
+    float width = media_box.width();
+    float height = media_box.height();
     float scale_x = static_cast<float>(bitmap->width()) / width;
     float scale_y = static_cast<float>(bitmap->height()) / height;
     userspace_matrix.scale(scale_x, scale_y);


### PR DESCRIPTION
We now support displaying multiple pages in a single columns, and smoothly scrolling through them, much like any other PDF viewer. The user can toggle between single- and multi-page mode. 

Also fixes a couple bugs, such as re-rendering the pages on app resize and auto-sizing the page label (so that large total pages don't turn into `...`). 