### PR TITLE
Ports: Fix dependency install when port name is not port folder name

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -491,7 +491,7 @@ package_install_state() {
 installdepends() {
     for depend in "${depends[@]}"; do
         if [ -z "$(package_install_state $depend)" ]; then
-            (cd "../$depend" && ./package.sh --auto)
+            (cd "$(dirname $(grep -E port=${depend} ../*/package.sh))" && ./package.sh --auto)
         fi
     done
 }

--- a/Ports/libtiff/package.sh
+++ b/Ports/libtiff/package.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=tiff
+port=libtiff
 version=4.3.0
 useconfigure=true
+workdir="tiff-$version"
 files="http://download.osgeo.org/libtiff/tiff-${version}.tar.gz tiff-${version}.tar.gz 0e46e5acb087ce7d1ac53cf4f56a09b221537fc86dfc5daaad1c2e89e1b37ac8"
 auth_type="sha256"
 depends=("libjpeg" "zstd" "xz")


### PR DESCRIPTION
There was a bug in the way the .port_include.sh script handled installing dependencies. According to the [documentation](https://github.com/SerenityOS/serenity/tree/master/Ports#depends) the depends array should have port names in it. The port system allows the for the name of the port to be different from the folder where build scripts live. Previously the installdepends function would change directory to the name of the port, hence this was used in the depends list of several ports. These have also been fixed.