### PR TITLE
LibGfx: Implement font kerning for `Painter::draw_text_run`

### DIFF
--- a/Userland/Libraries/LibGfx/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/BitmapFont.h
@@ -59,7 +59,7 @@ public:
             return m_glyph_width;
         return glyph_or_emoji_width_for_variable_width_font(code_point);
     }
-    i32 glyphs_horizontal_kerning(u32, u32) const override { return 0; }
+    float glyphs_horizontal_kerning(u32, u32) const override { return 0.f; }
     u8 glyph_height() const override { return m_glyph_height; }
     int x_height() const override { return m_x_height; }
     int preferred_line_height() const override { return glyph_height() + m_line_gap; }

--- a/Userland/Libraries/LibGfx/Font.h
+++ b/Userland/Libraries/LibGfx/Font.h
@@ -127,7 +127,7 @@ public:
 
     virtual u8 glyph_width(u32 code_point) const = 0;
     virtual int glyph_or_emoji_width(u32 code_point) const = 0;
-    virtual i32 glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const = 0;
+    virtual float glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const = 0;
     virtual u8 glyph_height() const = 0;
     virtual int x_height() const = 0;
     virtual int preferred_line_height() const = 0;

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1387,8 +1387,8 @@ void draw_text_line(IntRect const& a_rect, Utf8View const& text, Font const& fon
             continue;
         }
 
-        int kerning = font.glyphs_horizontal_kerning(last_code_point, code_point);
-        if (kerning != 0)
+        int kerning = static_cast<int>(lroundf(font.glyphs_horizontal_kerning(last_code_point, code_point)));
+        if (kerning != 0.f)
             point.translate_by(direction == TextDirection::LTR ? kerning : -kerning, 0);
 
         IntSize glyph_size(font.glyph_or_emoji_width(code_point) + font.glyph_spacing(), font.pixel_size());

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2322,14 +2322,17 @@ void Painter::draw_text_run(FloatPoint const& baseline_start, Utf8View const& st
     int y = baseline_start.y() - pixel_metrics.ascent;
     float space_width = font.glyph_or_emoji_width(' ');
 
+    u32 last_code_point = 0;
     for (auto code_point : string) {
         if (code_point == ' ') {
             x += space_width;
+            last_code_point = code_point;
             continue;
         }
-        float advance = font.glyph_or_emoji_width(code_point) + font.glyph_spacing();
-        draw_glyph_or_emoji({ (int)roundf(x), y }, code_point, font, color);
-        x += advance;
+        x += font.glyphs_horizontal_kerning(last_code_point, code_point);
+        draw_glyph_or_emoji({ static_cast<int>(lroundf(x)), y }, code_point, font, color);
+        x += font.glyph_or_emoji_width(code_point) + font.glyph_spacing();
+        last_code_point = code_point;
     }
 }
 

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Font.cpp
@@ -558,10 +558,10 @@ ScaledGlyphMetrics Font::glyph_metrics(u32 glyph_id, float x_scale, float y_scal
     };
 }
 
-i32 Font::glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, float x_scale) const
+float Font::glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, float x_scale) const
 {
     if (!m_kern.has_value())
-        return 0;
+        return 0.f;
     return m_kern->get_glyph_kerning(left_glyph_id, right_glyph_id) * x_scale;
 }
 
@@ -705,15 +705,15 @@ int ScaledFont::glyph_or_emoji_width(u32 code_point) const
     return metrics.advance_width;
 }
 
-i32 ScaledFont::glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const
+float ScaledFont::glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const
 {
     if (left_code_point == 0 || right_code_point == 0)
-        return 0;
+        return 0.f;
 
     auto left_glyph_id = glyph_id_for_code_point(left_code_point);
     auto right_glyph_id = glyph_id_for_code_point(right_code_point);
     if (left_glyph_id == 0 || right_glyph_id == 0)
-        return 0;
+        return 0.f;
 
     return m_font->glyphs_horizontal_kerning(left_glyph_id, right_glyph_id, m_x_scale);
 }

--- a/Userland/Libraries/LibGfx/TrueTypeFont/Font.h
+++ b/Userland/Libraries/LibGfx/TrueTypeFont/Font.h
@@ -49,7 +49,7 @@ public:
 
     ScaledFontMetrics metrics(float x_scale, float y_scale) const;
     ScaledGlyphMetrics glyph_metrics(u32 glyph_id, float x_scale, float y_scale) const;
-    i32 glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, float x_scale) const;
+    float glyphs_horizontal_kerning(u32 left_glyph_id, u32 right_glyph_id, float x_scale) const;
     RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id, float x_scale, float y_scale) const;
     u32 glyph_count() const;
     u16 units_per_em() const;
@@ -122,7 +122,7 @@ public:
     ScaledGlyphMetrics glyph_metrics(u32 glyph_id) const { return m_font->glyph_metrics(glyph_id, m_x_scale, m_y_scale); }
     RefPtr<Gfx::Bitmap> rasterize_glyph(u32 glyph_id) const;
 
-    // Gfx::Font implementation
+    // ^Gfx::Font
     virtual NonnullRefPtr<Font> clone() const override { return *this; } // FIXME: clone() should not need to be implemented
     virtual u8 presentation_size() const override { return m_point_height; }
     virtual int pixel_size() const override { return m_point_height * 1.33333333f; }
@@ -134,7 +134,7 @@ public:
     virtual bool contains_glyph(u32 code_point) const override { return m_font->glyph_id_for_code_point(code_point) > 0; }
     virtual u8 glyph_width(u32 code_point) const override;
     virtual int glyph_or_emoji_width(u32 code_point) const override;
-    virtual i32 glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const override;
+    virtual float glyphs_horizontal_kerning(u32 left_code_point, u32 right_code_point) const override;
     virtual int preferred_line_height() const override { return metrics().height() + metrics().line_gap; }
     virtual u8 glyph_height() const override { return m_point_height; }
     virtual int x_height() const override { return m_point_height; }      // FIXME: Read from font


### PR DESCRIPTION
In Andreas' latest work on text rendering, `Painter::draw_text_run` was introduced which did not take kerning into account. This PR adds the implementation for that.