### PR TITLE
Mail: Misc fixes

### DIFF
--- a/Userland/Applications/Mail/MailWidget.cpp
+++ b/Userland/Applications/Mail/MailWidget.cpp
@@ -131,8 +131,8 @@ bool MailWidget::connect_and_login()
     m_imap_client = maybe_imap_client.release_value();
 
     auto connection_promise = m_imap_client->connection_promise();
-    VERIFY(!connection_promise.is_null());
-    connection_promise->await();
+    if (!connection_promise.is_null())
+        connection_promise->await();
 
     auto response = m_imap_client->login(username, password)->await().release_value();
 

--- a/Userland/Libraries/LibIMAP/Client.cpp
+++ b/Userland/Libraries/LibIMAP/Client.cpp
@@ -37,6 +37,11 @@ void Client::setup_callbacks()
             close();
         }
     };
+
+    // for the case the socket is already ready to read, call our callback right
+    // now, this prevents the application hanging forever in case the connection
+    // was established too fast
+    m_socket->on_ready_to_read();
 }
 
 ErrorOr<NonnullOwnPtr<Client>> Client::connect_tls(StringView host, u16 port)

--- a/Userland/Libraries/LibIMAP/Client.cpp
+++ b/Userland/Libraries/LibIMAP/Client.cpp
@@ -61,7 +61,8 @@ ErrorOr<void> Client::on_ready_to_receive()
 
     auto pending_bytes = TRY(m_socket->pending_bytes());
     auto receive_buffer = TRY(m_buffer.get_bytes_for_writing(pending_bytes));
-    TRY(m_socket->read(receive_buffer));
+    size_t read = TRY(m_socket->read(receive_buffer));
+    m_buffer.resize(m_buffer.size() + read);
 
     // Once we get server hello we can start sending.
     if (m_connect_pending) {


### PR DESCRIPTION
- Fixed the read buffer in LibIMAP never actually getting extended with the newly read bytes, which caused an out of range index into m_buffer below
- Before, when the connection to the mail server is established before Client::setup_callbacks gets called, the read callback was never called because it was set after the socket would have called it, causing Mail to forever wait
- Make the parser more lenient when reading mails with missing From header, or some weirdly formatted headers (previously expected: `Subject: [text]`, I also found `Subject:[text]` and `Subject:\r\n [text]` in my mailbox)