### PR TITLE
LibGUI: Don't try to get link target value if read_link failed

### DIFF
--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -64,10 +64,11 @@ bool FileSystemModel::Node::fetch_data(String const& full_path, bool is_root)
         auto sym_link_target_or_error = Core::File::read_link(full_path);
         if (sym_link_target_or_error.is_error())
             perror("readlink");
-
-        symlink_target = sym_link_target_or_error.release_value();
-        if (symlink_target.is_null())
-            perror("readlink");
+        else {
+            symlink_target = sym_link_target_or_error.release_value();
+            if (symlink_target.is_null())
+                perror("readlink");
+        }
     }
 
     if (S_ISDIR(mode)) {


### PR DESCRIPTION
Found this trying to view /proc in the file explorer, which caused it to crash.

Should symlink_target be reset to null if this fails? If fetch_data is called twice on the same Node with different paths and the second call fails, then the old value would stick around. Not sure if that's something that needs handling.