### PR TITLE
LibWeb: More `@font-face`

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/FontFace.cpp
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.cpp
@@ -8,9 +8,10 @@
 
 namespace Web::CSS {
 
-FontFace::FontFace(FlyString font_family, Vector<Source> sources)
+FontFace::FontFace(FlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges)
     : m_font_family(move(font_family))
     , m_sources(move(sources))
+    , m_unicode_ranges(move(unicode_ranges))
 {
 }
 

--- a/Userland/Libraries/LibWeb/CSS/FontFace.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.h
@@ -8,6 +8,7 @@
 
 #include <AK/FlyString.h>
 #include <AK/URL.h>
+#include <LibWeb/CSS/UnicodeRange.h>
 
 namespace Web::CSS {
 
@@ -17,16 +18,18 @@ public:
         AK::URL url;
     };
 
-    FontFace(FlyString font_family, Vector<Source> sources);
+    FontFace(FlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges);
     ~FontFace() = default;
 
     FlyString font_family() const { return m_font_family; }
     Vector<Source> const& sources() const { return m_sources; }
-    // FIXME: font-style, font-weight, font-stretch, unicode-range, font-feature-settings
+    Vector<UnicodeRange> const& unicode_ranges() const { return m_unicode_ranges; }
+    // FIXME: font-style, font-weight, font-stretch, font-feature-settings
 
 private:
     FlyString m_font_family;
     Vector<Source> m_sources;
+    Vector<UnicodeRange> m_unicode_ranges;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/FontFace.h
+++ b/Userland/Libraries/LibWeb/CSS/FontFace.h
@@ -16,6 +16,8 @@ class FontFace {
 public:
     struct Source {
         AK::URL url;
+        // FIXME: Do we need to keep this around, or is it only needed to discard unwanted formats during parsing?
+        Optional<FlyString> format;
     };
 
     FontFace(FlyString font_family, Vector<Source> sources, Vector<UnicodeRange> unicode_ranges);

--- a/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/ComponentValue.h
@@ -16,14 +16,13 @@ namespace Web::CSS {
 class StyleBlockRule;
 class StyleFunctionRule;
 
-class StyleComponentValueRule {
-    friend class Parser;
-
+// https://www.w3.org/TR/css-syntax-3/#component-value
+class ComponentValue {
 public:
-    StyleComponentValueRule(Token);
-    explicit StyleComponentValueRule(NonnullRefPtr<StyleFunctionRule>);
-    explicit StyleComponentValueRule(NonnullRefPtr<StyleBlockRule>);
-    ~StyleComponentValueRule();
+    ComponentValue(Token);
+    explicit ComponentValue(NonnullRefPtr<StyleFunctionRule>);
+    explicit ComponentValue(NonnullRefPtr<StyleBlockRule>);
+    ~ComponentValue();
 
     bool is_block() const { return m_value.has<NonnullRefPtr<StyleBlockRule>>(); }
     StyleBlockRule const& block() const { return m_value.get<NonnullRefPtr<StyleBlockRule>>(); }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Declaration.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Declaration.h
@@ -20,6 +20,10 @@ public:
     Declaration();
     ~Declaration();
 
+    String const& name() const { return m_name; }
+    Vector<ComponentValue> const& values() const { return m_values; }
+    Important importance() const { return m_important; }
+
     String to_string() const;
 
 private:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Declaration.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Declaration.h
@@ -13,12 +13,12 @@
 
 namespace Web::CSS {
 
-class StyleDeclarationRule {
+class Declaration {
     friend class Parser;
 
 public:
-    StyleDeclarationRule();
-    ~StyleDeclarationRule();
+    Declaration();
+    ~Declaration();
 
     String to_string() const;
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/DeclarationOrAtRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/DeclarationOrAtRule.h
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/CSS/Parser/StyleDeclarationRule.h>
+#include <LibWeb/CSS/Parser/Declaration.h>
 #include <LibWeb/CSS/Parser/StyleRule.h>
 
 namespace Web::CSS {
@@ -16,7 +16,7 @@ class DeclarationOrAtRule {
 
 public:
     explicit DeclarationOrAtRule(RefPtr<StyleRule> at);
-    explicit DeclarationOrAtRule(StyleDeclarationRule declaration);
+    explicit DeclarationOrAtRule(Declaration declaration);
     ~DeclarationOrAtRule();
 
     enum class DeclarationType {
@@ -33,7 +33,7 @@ public:
         return *m_at;
     }
 
-    StyleDeclarationRule const& declaration() const
+    Declaration const& declaration() const
     {
         VERIFY(is_declaration());
         return m_declaration;
@@ -44,7 +44,7 @@ public:
 private:
     DeclarationType m_type;
     RefPtr<StyleRule> m_at;
-    StyleDeclarationRule m_declaration;
+    Declaration m_declaration;
 };
 
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4412,6 +4412,11 @@ RefPtr<CSSRule> Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens
                     continue;
                 }
                 if (part.is(Token::Type::Ident)) {
+                    if (is_builtin(part.token().ident())) {
+                        dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @font-face font-family format invalid; discarding.");
+                        had_syntax_error = true;
+                        break;
+                    }
                     auto value_id = value_id_from_string(part.token().ident());
                     if (is_generic_font_family(value_id)) {
                         dbgln_if(CSS_PARSER_DEBUG, "CSSParser: @font-face font-family format invalid; discarding.");

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -2515,7 +2515,7 @@ RefPtr<PropertyOwningCSSStyleDeclaration> Parser::convert_to_style_declaration(V
 
 Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& declaration)
 {
-    auto& property_name = declaration.m_name;
+    auto& property_name = declaration.name();
     auto property_id = property_id_from_string(property_name);
 
     if (property_id == PropertyID::Invalid) {
@@ -2529,7 +2529,7 @@ Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& dec
         }
     }
 
-    auto value_token_stream = TokenStream(declaration.m_values);
+    auto value_token_stream = TokenStream(declaration.values());
     auto value = parse_css_value(property_id, value_token_stream);
     if (value.is_error()) {
         if (value.error() != ParsingResult::IncludesIgnoredVendorPrefix) {
@@ -2542,9 +2542,9 @@ Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& dec
     }
 
     if (property_id == PropertyID::Custom) {
-        return StyleProperty { declaration.m_important, property_id, value.release_value(), declaration.m_name };
+        return StyleProperty { declaration.importance(), property_id, value.release_value(), declaration.name() };
     } else {
-        return StyleProperty { declaration.m_important, property_id, value.release_value(), {} };
+        return StyleProperty { declaration.importance(), property_id, value.release_value(), {} };
     }
 }
 
@@ -4131,13 +4131,13 @@ RefPtr<CSSRule> Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens
         }
 
         auto& declaration = declaration_or_at_rule.declaration();
-        if (declaration.m_name.equals_ignoring_case("font-family"sv)) {
+        if (declaration.name().equals_ignoring_case("font-family"sv)) {
             // FIXME: This is very similar to, but different from, the logic in parse_font_family_value().
             //        Ideally they could share code.
             Vector<String> font_family_parts;
             bool had_syntax_error = false;
-            for (size_t i = 0; i < declaration.m_values.size(); ++i) {
-                auto& part = declaration.m_values[i];
+            for (size_t i = 0; i < declaration.values().size(); ++i) {
+                auto& part = declaration.values()[i];
                 if (part.is(Token::Type::Whitespace))
                     continue;
                 if (part.is(Token::Type::String)) {
@@ -4170,11 +4170,11 @@ RefPtr<CSSRule> Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens
             font_family = String::join(' ', font_family_parts);
             continue;
         }
-        if (declaration.m_name.equals_ignoring_case("src"sv)) {
+        if (declaration.name().equals_ignoring_case("src"sv)) {
             Vector<FontFace::Source> supported_sources;
             // FIXME: Implement `local()`.
             // FIXME: Implement `format()`.
-            TokenStream token_stream { declaration.m_values };
+            TokenStream token_stream { declaration.values() };
             auto list_of_source_token_lists = parse_a_comma_separated_list_of_component_values(token_stream);
             for (auto const& source_token_list : list_of_source_token_lists) {
                 Optional<AK::URL> url;
@@ -4201,7 +4201,7 @@ RefPtr<CSSRule> Parser::parse_font_face_rule(TokenStream<ComponentValue>& tokens
             src = move(supported_sources);
         }
 
-        dbgln_if(CSS_PARSER_DEBUG, "CSSParser: Unrecognized descriptor '{}' in @font-family; discarding.", declaration.m_name);
+        dbgln_if(CSS_PARSER_DEBUG, "CSSParser: Unrecognized descriptor '{}' in @font-family; discarding.", declaration.name());
     }
 
     if (!font_family.has_value()) {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1909,7 +1909,7 @@ NonnullRefPtr<StyleFunctionRule> Parser::consume_a_function(TokenStream<T>& toke
 // 5.4.6. Consume a declaration
 // https://www.w3.org/TR/css-syntax-3/#consume-declaration
 template<typename T>
-Optional<StyleDeclarationRule> Parser::consume_a_declaration(TokenStream<T>& tokens)
+Optional<Declaration> Parser::consume_a_declaration(TokenStream<T>& tokens)
 {
     // Note: This algorithm assumes that the next input token has already been checked to
     // be an <ident-token>.
@@ -1930,7 +1930,7 @@ Optional<StyleDeclarationRule> Parser::consume_a_declaration(TokenStream<T>& tok
 
     // Create a new declaration with its name set to the value of the current input token
     // and its value initially set to the empty list.
-    StyleDeclarationRule declaration;
+    Declaration declaration;
     declaration.m_name = ((Token)token).ident();
 
     // 1. While the next input token is a <whitespace-token>, consume the next input token.
@@ -2170,7 +2170,7 @@ Optional<StyleProperty> Parser::parse_as_supports_condition()
 // 5.3.6. Parse a declaration
 // https://www.w3.org/TR/css-syntax-3/#parse-a-declaration
 template<typename T>
-Optional<StyleDeclarationRule> Parser::parse_a_declaration(TokenStream<T>& tokens)
+Optional<Declaration> Parser::parse_a_declaration(TokenStream<T>& tokens)
 {
     // To parse a declaration from input:
 
@@ -2513,7 +2513,7 @@ RefPtr<PropertyOwningCSSStyleDeclaration> Parser::convert_to_style_declaration(V
     return PropertyOwningCSSStyleDeclaration::create(move(properties), move(custom_properties));
 }
 
-Optional<StyleProperty> Parser::convert_to_style_property(StyleDeclarationRule const& declaration)
+Optional<StyleProperty> Parser::convert_to_style_property(Declaration const& declaration)
 {
     auto& property_name = declaration.m_name;
     auto property_id = property_id_from_string(property_name);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -16,9 +16,9 @@
 #include <LibWeb/CSS/GeneralEnclosed.h>
 #include <LibWeb/CSS/MediaQuery.h>
 #include <LibWeb/CSS/Parser/ComponentValue.h>
+#include <LibWeb/CSS/Parser/Declaration.h>
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
 #include <LibWeb/CSS/Parser/StyleBlockRule.h>
-#include <LibWeb/CSS/Parser/StyleDeclarationRule.h>
 #include <LibWeb/CSS/Parser/StyleFunctionRule.h>
 #include <LibWeb/CSS/Parser/StyleRule.h>
 #include <LibWeb/CSS/Parser/Tokenizer.h>
@@ -139,7 +139,7 @@ private:
 
     // "Parse a declaration" is used in @supports conditions. [CSS3-CONDITIONAL]
     template<typename T>
-    Optional<StyleDeclarationRule> parse_a_declaration(TokenStream<T>&);
+    Optional<Declaration> parse_a_declaration(TokenStream<T>&);
 
     template<typename T>
     Vector<DeclarationOrAtRule> parse_a_style_blocks_contents(TokenStream<T>&);
@@ -192,7 +192,7 @@ private:
     template<typename T>
     [[nodiscard]] Vector<DeclarationOrAtRule> consume_a_list_of_declarations(TokenStream<T>&);
     template<typename T>
-    Optional<StyleDeclarationRule> consume_a_declaration(TokenStream<T>&);
+    Optional<Declaration> consume_a_declaration(TokenStream<T>&);
     template<typename T>
     [[nodiscard]] ComponentValue consume_a_component_value(TokenStream<T>&);
     template<typename T>
@@ -206,7 +206,7 @@ private:
 
     RefPtr<CSSRule> convert_to_rule(NonnullRefPtr<StyleRule>);
     RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_style_declaration(Vector<DeclarationOrAtRule> declarations);
-    Optional<StyleProperty> convert_to_style_property(StyleDeclarationRule const&);
+    Optional<StyleProperty> convert_to_style_property(Declaration const&);
 
     class Dimension {
     public:

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -15,9 +15,9 @@
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
 #include <LibWeb/CSS/GeneralEnclosed.h>
 #include <LibWeb/CSS/MediaQuery.h>
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
 #include <LibWeb/CSS/Parser/StyleBlockRule.h>
-#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
 #include <LibWeb/CSS/Parser/StyleDeclarationRule.h>
 #include <LibWeb/CSS/Parser/StyleFunctionRule.h>
 #include <LibWeb/CSS/Parser/StyleRule.h>
@@ -112,7 +112,7 @@ public:
 
     RefPtr<StyleValue> parse_as_css_value(PropertyID);
 
-    static RefPtr<StyleValue> parse_css_value(Badge<StyleComputer>, ParsingContext const&, PropertyID, Vector<StyleComponentValueRule> const&);
+    static RefPtr<StyleValue> parse_css_value(Badge<StyleComputer>, ParsingContext const&, PropertyID, Vector<ComponentValue> const&);
 
 private:
     enum class ParsingResult {
@@ -150,14 +150,14 @@ private:
 
     // "Parse a component value" is for things that need to consume a single value, like the parsing rules for attr().
     template<typename T>
-    Optional<StyleComponentValueRule> parse_a_component_value(TokenStream<T>&);
+    Optional<ComponentValue> parse_a_component_value(TokenStream<T>&);
 
     // "Parse a list of component values" is for the contents of presentational attributes, which parse text into a single declaration’s value, or for parsing a stand-alone selector [SELECT] or list of Media Queries [MEDIAQ], as in Selectors API or the media HTML attribute.
     template<typename T>
-    Vector<StyleComponentValueRule> parse_a_list_of_component_values(TokenStream<T>&);
+    Vector<ComponentValue> parse_a_list_of_component_values(TokenStream<T>&);
 
     template<typename T>
-    Vector<Vector<StyleComponentValueRule>> parse_a_comma_separated_list_of_component_values(TokenStream<T>&);
+    Vector<Vector<ComponentValue>> parse_a_comma_separated_list_of_component_values(TokenStream<T>&);
 
     enum class SelectorType {
         Standalone,
@@ -175,7 +175,7 @@ private:
         No,
         Yes
     };
-    Optional<Selector::SimpleSelector::ANPlusBPattern> parse_a_n_plus_b_pattern(TokenStream<StyleComponentValueRule>&, AllowTrailingTokens = AllowTrailingTokens::No);
+    Optional<Selector::SimpleSelector::ANPlusBPattern> parse_a_n_plus_b_pattern(TokenStream<ComponentValue>&, AllowTrailingTokens = AllowTrailingTokens::No);
 
     enum class TopLevel {
         No,
@@ -194,15 +194,15 @@ private:
     template<typename T>
     Optional<StyleDeclarationRule> consume_a_declaration(TokenStream<T>&);
     template<typename T>
-    [[nodiscard]] StyleComponentValueRule consume_a_component_value(TokenStream<T>&);
+    [[nodiscard]] ComponentValue consume_a_component_value(TokenStream<T>&);
     template<typename T>
     NonnullRefPtr<StyleBlockRule> consume_a_simple_block(TokenStream<T>&);
     template<typename T>
     NonnullRefPtr<StyleFunctionRule> consume_a_function(TokenStream<T>&);
 
-    Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<StyleComponentValueRule>&);
+    Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<ComponentValue>&);
 
-    RefPtr<CSSRule> parse_font_face_rule(TokenStream<StyleComponentValueRule>&);
+    RefPtr<CSSRule> parse_font_face_rule(TokenStream<ComponentValue>&);
 
     RefPtr<CSSRule> convert_to_rule(NonnullRefPtr<StyleRule>);
     RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_style_declaration(Vector<DeclarationOrAtRule> declarations);
@@ -272,87 +272,87 @@ private:
     private:
         Variant<Angle, Frequency, Length, Percentage, Resolution, Time> m_value;
     };
-    Optional<Dimension> parse_dimension(StyleComponentValueRule const&);
-    Optional<Color> parse_color(StyleComponentValueRule const&);
-    Optional<Length> parse_length(StyleComponentValueRule const&);
-    Optional<Ratio> parse_ratio(TokenStream<StyleComponentValueRule>&);
+    Optional<Dimension> parse_dimension(ComponentValue const&);
+    Optional<Color> parse_color(ComponentValue const&);
+    Optional<Length> parse_length(ComponentValue const&);
+    Optional<Ratio> parse_ratio(TokenStream<ComponentValue>&);
 
     enum class AllowedDataUrlType {
         None,
         Image,
     };
-    Optional<AK::URL> parse_url_function(StyleComponentValueRule const&, AllowedDataUrlType = AllowedDataUrlType::None);
+    Optional<AK::URL> parse_url_function(ComponentValue const&, AllowedDataUrlType = AllowedDataUrlType::None);
 
-    Result<NonnullRefPtr<StyleValue>, ParsingResult> parse_css_value(PropertyID, TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_css_value(StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_builtin_value(StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_dynamic_value(StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_calculated_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_dimension_value(StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_numeric_value(StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_identifier_value(StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_color_value(StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_string_value(StyleComponentValueRule const&);
-    RefPtr<StyleValue> parse_image_value(StyleComponentValueRule const&);
+    Result<NonnullRefPtr<StyleValue>, ParsingResult> parse_css_value(PropertyID, TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_css_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_builtin_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_dynamic_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_calculated_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_dimension_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_numeric_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_identifier_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_color_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_string_value(ComponentValue const&);
+    RefPtr<StyleValue> parse_image_value(ComponentValue const&);
     template<typename ParseFunction>
-    RefPtr<StyleValue> parse_comma_separated_value_list(Vector<StyleComponentValueRule> const&, ParseFunction);
-    RefPtr<StyleValue> parse_simple_comma_separated_value_list(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_comma_separated_value_list(Vector<ComponentValue> const&, ParseFunction);
+    RefPtr<StyleValue> parse_simple_comma_separated_value_list(Vector<ComponentValue> const&);
 
-    RefPtr<StyleValue> parse_background_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_single_background_position_value(TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_single_background_size_value(TokenStream<StyleComponentValueRule>&);
-    RefPtr<StyleValue> parse_border_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_border_radius_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_border_radius_shorthand_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_content_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_flex_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_flex_flow_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_font_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_font_family_value(Vector<StyleComponentValueRule> const&, size_t start_index = 0);
-    RefPtr<StyleValue> parse_list_style_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_overflow_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_background_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_single_background_position_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_single_background_repeat_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_single_background_size_value(TokenStream<ComponentValue>&);
+    RefPtr<StyleValue> parse_border_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_border_radius_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_border_radius_shorthand_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_content_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_flex_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_flex_flow_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_font_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_font_family_value(Vector<ComponentValue> const&, size_t start_index = 0);
+    RefPtr<StyleValue> parse_list_style_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_overflow_value(Vector<ComponentValue> const&);
     enum class AllowInsetKeyword {
         No,
         Yes,
     };
-    RefPtr<StyleValue> parse_shadow_value(Vector<StyleComponentValueRule> const&, AllowInsetKeyword);
-    RefPtr<StyleValue> parse_single_shadow_value(TokenStream<StyleComponentValueRule>&, AllowInsetKeyword);
-    RefPtr<StyleValue> parse_text_decoration_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_transform_value(Vector<StyleComponentValueRule> const&);
-    RefPtr<StyleValue> parse_transform_origin_value(Vector<StyleComponentValueRule> const&);
+    RefPtr<StyleValue> parse_shadow_value(Vector<ComponentValue> const&, AllowInsetKeyword);
+    RefPtr<StyleValue> parse_single_shadow_value(TokenStream<ComponentValue>&, AllowInsetKeyword);
+    RefPtr<StyleValue> parse_text_decoration_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_transform_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_transform_origin_value(Vector<ComponentValue> const&);
 
     // calc() parsing, according to https://www.w3.org/TR/css-values-3/#calc-syntax
-    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcProduct> parse_calc_product(TokenStream<StyleComponentValueRule>&);
-    Optional<CalculatedStyleValue::CalcValue> parse_calc_value(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(TokenStream<StyleComponentValueRule>&);
-    Optional<CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(TokenStream<StyleComponentValueRule>& tokens);
-    OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(Vector<StyleComponentValueRule> const&);
+    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_sum(TokenStream<ComponentValue>&);
+    OwnPtr<CalculatedStyleValue::CalcProduct> parse_calc_product(TokenStream<ComponentValue>&);
+    Optional<CalculatedStyleValue::CalcValue> parse_calc_value(TokenStream<ComponentValue>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberSum> parse_calc_number_sum(TokenStream<ComponentValue>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberProduct> parse_calc_number_product(TokenStream<ComponentValue>&);
+    Optional<CalculatedStyleValue::CalcNumberValue> parse_calc_number_value(TokenStream<ComponentValue>&);
+    OwnPtr<CalculatedStyleValue::CalcProductPartWithOperator> parse_calc_product_part_with_operator(TokenStream<ComponentValue>&);
+    OwnPtr<CalculatedStyleValue::CalcSumPartWithOperator> parse_calc_sum_part_with_operator(TokenStream<ComponentValue>&);
+    OwnPtr<CalculatedStyleValue::CalcNumberProductPartWithOperator> parse_calc_number_product_part_with_operator(TokenStream<ComponentValue>& tokens);
+    OwnPtr<CalculatedStyleValue::CalcNumberSumPartWithOperator> parse_calc_number_sum_part_with_operator(TokenStream<ComponentValue>&);
+    OwnPtr<CalculatedStyleValue::CalcSum> parse_calc_expression(Vector<ComponentValue> const&);
 
-    Result<NonnullRefPtr<Selector>, ParsingResult> parse_complex_selector(TokenStream<StyleComponentValueRule>&, SelectorType);
-    Result<Selector::CompoundSelector, ParsingResult> parse_compound_selector(TokenStream<StyleComponentValueRule>&);
-    Optional<Selector::Combinator> parse_selector_combinator(TokenStream<StyleComponentValueRule>&);
+    Result<NonnullRefPtr<Selector>, ParsingResult> parse_complex_selector(TokenStream<ComponentValue>&, SelectorType);
+    Result<Selector::CompoundSelector, ParsingResult> parse_compound_selector(TokenStream<ComponentValue>&);
+    Optional<Selector::Combinator> parse_selector_combinator(TokenStream<ComponentValue>&);
 
-    Result<Selector::SimpleSelector, ParsingResult> parse_attribute_simple_selector(StyleComponentValueRule const&);
-    Result<Selector::SimpleSelector, ParsingResult> parse_pseudo_simple_selector(TokenStream<StyleComponentValueRule>&);
-    Result<Selector::SimpleSelector, ParsingResult> parse_simple_selector(TokenStream<StyleComponentValueRule>&);
+    Result<Selector::SimpleSelector, ParsingResult> parse_attribute_simple_selector(ComponentValue const&);
+    Result<Selector::SimpleSelector, ParsingResult> parse_pseudo_simple_selector(TokenStream<ComponentValue>&);
+    Result<Selector::SimpleSelector, ParsingResult> parse_simple_selector(TokenStream<ComponentValue>&);
 
-    NonnullRefPtr<MediaQuery> parse_media_query(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<MediaCondition> parse_media_condition(TokenStream<StyleComponentValueRule>&, MediaCondition::AllowOr allow_or);
-    Optional<MediaFeature> parse_media_feature(TokenStream<StyleComponentValueRule>&);
-    Optional<MediaQuery::MediaType> parse_media_type(TokenStream<StyleComponentValueRule>&);
-    OwnPtr<MediaCondition> parse_media_in_parens(TokenStream<StyleComponentValueRule>&);
-    Optional<MediaFeatureValue> parse_media_feature_value(MediaFeatureID, TokenStream<StyleComponentValueRule>&);
+    NonnullRefPtr<MediaQuery> parse_media_query(TokenStream<ComponentValue>&);
+    OwnPtr<MediaCondition> parse_media_condition(TokenStream<ComponentValue>&, MediaCondition::AllowOr allow_or);
+    Optional<MediaFeature> parse_media_feature(TokenStream<ComponentValue>&);
+    Optional<MediaQuery::MediaType> parse_media_type(TokenStream<ComponentValue>&);
+    OwnPtr<MediaCondition> parse_media_in_parens(TokenStream<ComponentValue>&);
+    Optional<MediaFeatureValue> parse_media_feature_value(MediaFeatureID, TokenStream<ComponentValue>&);
 
-    OwnPtr<Supports::Condition> parse_supports_condition(TokenStream<StyleComponentValueRule>&);
-    Optional<Supports::InParens> parse_supports_in_parens(TokenStream<StyleComponentValueRule>&);
-    Optional<Supports::Feature> parse_supports_feature(TokenStream<StyleComponentValueRule>&);
+    OwnPtr<Supports::Condition> parse_supports_condition(TokenStream<ComponentValue>&);
+    Optional<Supports::InParens> parse_supports_in_parens(TokenStream<ComponentValue>&);
+    Optional<Supports::Feature> parse_supports_feature(TokenStream<ComponentValue>&);
 
     static bool has_ignored_vendor_prefix(StringView);
     static bool is_builtin(StringView);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020-2021, the SerenityOS developers.
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -26,6 +26,7 @@
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/CSS/Supports.h>
+#include <LibWeb/CSS/UnicodeRange.h>
 
 namespace Web::CSS {
 
@@ -276,6 +277,8 @@ private:
     Optional<Color> parse_color(ComponentValue const&);
     Optional<Length> parse_length(ComponentValue const&);
     Optional<Ratio> parse_ratio(TokenStream<ComponentValue>&);
+    Optional<UnicodeRange> parse_unicode_range(TokenStream<ComponentValue>&);
+    Optional<UnicodeRange> create_unicode_range_from_tokens(TokenStream<ComponentValue>&, int start_position, int end_position);
 
     enum class AllowedDataUrlType {
         None,

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -13,6 +13,7 @@
 #include <AK/Result.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
+#include <LibWeb/CSS/FontFace.h>
 #include <LibWeb/CSS/GeneralEnclosed.h>
 #include <LibWeb/CSS/MediaQuery.h>
 #include <LibWeb/CSS/Parser/ComponentValue.h>
@@ -204,6 +205,7 @@ private:
     Optional<GeneralEnclosed> parse_general_enclosed(TokenStream<ComponentValue>&);
 
     RefPtr<CSSRule> parse_font_face_rule(TokenStream<ComponentValue>&);
+    Vector<FontFace::Source> parse_font_face_src(TokenStream<ComponentValue>&);
 
     RefPtr<CSSRule> convert_to_rule(NonnullRefPtr<StyleRule>);
     RefPtr<PropertyOwningCSSStyleDeclaration> convert_to_style_declaration(Vector<DeclarationOrAtRule> declarations);

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleBlockRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleBlockRule.h
@@ -9,7 +9,7 @@
 
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
-#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Parser/Token.h>
 
 namespace Web::CSS {
@@ -19,7 +19,7 @@ class StyleBlockRule : public RefCounted<StyleBlockRule> {
 
 public:
     StyleBlockRule();
-    explicit StyleBlockRule(Token token, Vector<StyleComponentValueRule>&& values)
+    explicit StyleBlockRule(Token token, Vector<ComponentValue>&& values)
         : m_token(move(token))
         , m_values(move(values))
     {
@@ -32,12 +32,12 @@ public:
 
     Token const& token() const { return m_token; }
 
-    Vector<StyleComponentValueRule> const& values() const { return m_values; }
+    Vector<ComponentValue> const& values() const { return m_values; }
 
     String to_string() const;
 
 private:
     Token m_token;
-    Vector<StyleComponentValueRule> m_values;
+    Vector<ComponentValue> m_values;
 };
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleDeclarationRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleDeclarationRule.h
@@ -9,7 +9,7 @@
 #include <AK/String.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
-#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 
 namespace Web::CSS {
 
@@ -24,7 +24,7 @@ public:
 
 private:
     String m_name;
-    Vector<StyleComponentValueRule> m_values;
+    Vector<ComponentValue> m_values;
     Important m_important { Important::No };
 };
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleFunctionRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleFunctionRule.h
@@ -10,27 +10,27 @@
 #include <AK/RefCounted.h>
 #include <AK/String.h>
 #include <AK/Vector.h>
-#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 
 namespace Web::CSS {
 
-class StyleComponentValueRule;
+class ComponentValue;
 
 class StyleFunctionRule : public RefCounted<StyleFunctionRule> {
     friend class Parser;
 
 public:
     explicit StyleFunctionRule(String name);
-    StyleFunctionRule(String name, Vector<StyleComponentValueRule>&& values);
+    StyleFunctionRule(String name, Vector<ComponentValue>&& values);
     ~StyleFunctionRule();
 
     String const& name() const { return m_name; }
-    Vector<StyleComponentValueRule> const& values() const { return m_values; }
+    Vector<ComponentValue> const& values() const { return m_values; }
 
     String to_string() const;
 
 private:
     String m_name;
-    Vector<StyleComponentValueRule> m_values;
+    Vector<ComponentValue> m_values;
 };
 }

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRule.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRule.h
@@ -9,8 +9,8 @@
 
 #include <AK/RefCounted.h>
 #include <AK/Vector.h>
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Parser/StyleBlockRule.h>
-#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
 
 namespace Web::CSS {
 
@@ -29,7 +29,7 @@ public:
     bool is_qualified_rule() const { return m_type == Type::Qualified; }
     bool is_at_rule() const { return m_type == Type::At; }
 
-    Vector<StyleComponentValueRule> const& prelude() const { return m_prelude; }
+    Vector<ComponentValue> const& prelude() const { return m_prelude; }
     RefPtr<StyleBlockRule const> block() const { return m_block; }
     String const& at_rule_name() const { return m_at_rule_name; }
 
@@ -38,7 +38,7 @@ public:
 private:
     Type const m_type;
     String m_at_rule_name;
-    Vector<StyleComponentValueRule> m_prelude;
+    Vector<ComponentValue> m_prelude;
     RefPtr<StyleBlockRule> m_block;
 };
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
@@ -6,9 +6,9 @@
  */
 
 #include <LibWeb/CSS/Parser/ComponentValue.h>
+#include <LibWeb/CSS/Parser/Declaration.h>
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
 #include <LibWeb/CSS/Parser/StyleBlockRule.h>
-#include <LibWeb/CSS/Parser/StyleDeclarationRule.h>
 #include <LibWeb/CSS/Parser/StyleFunctionRule.h>
 #include <LibWeb/CSS/Parser/StyleRule.h>
 #include <LibWeb/CSS/Serialize.h>
@@ -20,7 +20,7 @@ DeclarationOrAtRule::DeclarationOrAtRule(RefPtr<StyleRule> at)
     , m_at(move(at))
 {
 }
-DeclarationOrAtRule::DeclarationOrAtRule(StyleDeclarationRule declaration)
+DeclarationOrAtRule::DeclarationOrAtRule(Declaration declaration)
     : m_type(DeclarationType::Declaration)
     , m_declaration(move(declaration))
 {
@@ -50,8 +50,8 @@ ComponentValue::ComponentValue(NonnullRefPtr<StyleBlockRule> block)
 }
 ComponentValue::~ComponentValue() = default;
 
-StyleDeclarationRule::StyleDeclarationRule() = default;
-StyleDeclarationRule::~StyleDeclarationRule() = default;
+Declaration::Declaration() = default;
+Declaration::~Declaration() = default;
 
 StyleFunctionRule::StyleFunctionRule(String name)
     : m_name(move(name))
@@ -146,7 +146,7 @@ String ComponentValue::to_debug_string() const
         });
 }
 
-String StyleDeclarationRule::to_string() const
+String Declaration::to_string() const
 {
     StringBuilder builder;
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/StyleRules.cpp
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Parser/DeclarationOrAtRule.h>
 #include <LibWeb/CSS/Parser/StyleBlockRule.h>
-#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
 #include <LibWeb/CSS/Parser/StyleDeclarationRule.h>
 #include <LibWeb/CSS/Parser/StyleFunctionRule.h>
 #include <LibWeb/CSS/Parser/StyleRule.h>
@@ -36,19 +36,19 @@ StyleRule::~StyleRule() = default;
 StyleBlockRule::StyleBlockRule() = default;
 StyleBlockRule::~StyleBlockRule() = default;
 
-StyleComponentValueRule::StyleComponentValueRule(Token token)
+ComponentValue::ComponentValue(Token token)
     : m_value(token)
 {
 }
-StyleComponentValueRule::StyleComponentValueRule(NonnullRefPtr<StyleFunctionRule> function)
+ComponentValue::ComponentValue(NonnullRefPtr<StyleFunctionRule> function)
     : m_value(function)
 {
 }
-StyleComponentValueRule::StyleComponentValueRule(NonnullRefPtr<StyleBlockRule> block)
+ComponentValue::ComponentValue(NonnullRefPtr<StyleBlockRule> block)
     : m_value(block)
 {
 }
-StyleComponentValueRule::~StyleComponentValueRule() = default;
+ComponentValue::~ComponentValue() = default;
 
 StyleDeclarationRule::StyleDeclarationRule() = default;
 StyleDeclarationRule::~StyleDeclarationRule() = default;
@@ -58,7 +58,7 @@ StyleFunctionRule::StyleFunctionRule(String name)
 {
 }
 
-StyleFunctionRule::StyleFunctionRule(String name, Vector<StyleComponentValueRule>&& values)
+StyleFunctionRule::StyleFunctionRule(String name, Vector<ComponentValue>&& values)
     : m_name(move(name))
     , m_values(move(values))
 {
@@ -124,7 +124,7 @@ String StyleBlockRule::to_string() const
     return builder.to_string();
 }
 
-String StyleComponentValueRule::to_string() const
+String ComponentValue::to_string() const
 {
     return m_value.visit(
         [](Token const& token) { return token.to_string(); },
@@ -132,7 +132,7 @@ String StyleComponentValueRule::to_string() const
         [](NonnullRefPtr<StyleFunctionRule> const& function) { return function->to_string(); });
 }
 
-String StyleComponentValueRule::to_debug_string() const
+String ComponentValue::to_debug_string() const
 {
     return m_value.visit(
         [](Token const& token) {

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -492,7 +492,7 @@ static RefPtr<StyleValue> get_custom_property(DOM::Element const& element, FlySt
     return nullptr;
 }
 
-bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Vector<StyleComponentValueRule> const& source, Vector<StyleComponentValueRule>& dest, size_t source_start_index) const
+bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Vector<ComponentValue> const& source, Vector<ComponentValue>& dest, size_t source_start_index) const
 {
     // FIXME: Do this better!
     // We build a copy of the tree of StyleComponentValueRules, with all var()s and attr()s replaced with their contents.
@@ -585,7 +585,7 @@ bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView p
             }
 
             auto const& source_function = value.function();
-            Vector<StyleComponentValueRule> function_values;
+            Vector<ComponentValue> function_values;
             if (!expand_unresolved_values(element, property_name, dependencies, source_function.values(), function_values, 0))
                 return false;
             NonnullRefPtr<StyleFunctionRule> function = adopt_ref(*new StyleFunctionRule(source_function.name(), move(function_values)));
@@ -594,7 +594,7 @@ bool StyleComputer::expand_unresolved_values(DOM::Element& element, StringView p
         }
         if (value.is_block()) {
             auto const& source_block = value.block();
-            Vector<StyleComponentValueRule> block_values;
+            Vector<ComponentValue> block_values;
             if (!expand_unresolved_values(element, property_name, dependencies, source_block.values(), block_values, 0))
                 return false;
             NonnullRefPtr<StyleBlockRule> block = adopt_ref(*new StyleBlockRule(source_block.token(), move(block_values)));
@@ -613,7 +613,7 @@ RefPtr<StyleValue> StyleComputer::resolve_unresolved_style_value(DOM::Element& e
     // to produce a different StyleValue from it.
     VERIFY(unresolved.contains_var_or_attr());
 
-    Vector<StyleComponentValueRule> expanded_values;
+    Vector<ComponentValue> expanded_values;
     HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>> dependencies;
     if (!expand_unresolved_values(element, string_from_property_id(property_id), dependencies, unresolved.values(), expanded_values, 0))
         return {};

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.h
@@ -13,7 +13,7 @@
 #include <AK/OwnPtr.h>
 #include <LibWeb/CSS/CSSFontFaceRule.h>
 #include <LibWeb/CSS/CSSStyleDeclaration.h>
-#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Selector.h>
 #include <LibWeb/CSS/StyleProperties.h>
 #include <LibWeb/Forward.h>
@@ -84,7 +84,7 @@ private:
     void compute_defaulted_property_value(StyleProperties&, DOM::Element const*, CSS::PropertyID, Optional<CSS::Selector::PseudoElement>) const;
 
     RefPtr<StyleValue> resolve_unresolved_style_value(DOM::Element&, PropertyID, UnresolvedStyleValue const&) const;
-    bool expand_unresolved_values(DOM::Element&, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Vector<StyleComponentValueRule> const& source, Vector<StyleComponentValueRule>& dest, size_t source_start_index) const;
+    bool expand_unresolved_values(DOM::Element&, StringView property_name, HashMap<FlyString, NonnullRefPtr<PropertyDependencyNode>>& dependencies, Vector<ComponentValue> const& source, Vector<ComponentValue>& dest, size_t source_start_index) const;
 
     template<typename Callback>
     void for_each_stylesheet(CascadeOrigin, Callback) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -28,7 +28,7 @@
 #include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Number.h>
-#include <LibWeb/CSS/Parser/StyleComponentValueRule.h>
+#include <LibWeb/CSS/Parser/ComponentValue.h>
 #include <LibWeb/CSS/Percentage.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/Resolution.h>
@@ -1625,7 +1625,7 @@ private:
 
 class UnresolvedStyleValue final : public StyleValue {
 public:
-    static NonnullRefPtr<UnresolvedStyleValue> create(Vector<StyleComponentValueRule>&& values, bool contains_var_or_attr)
+    static NonnullRefPtr<UnresolvedStyleValue> create(Vector<ComponentValue>&& values, bool contains_var_or_attr)
     {
         return adopt_ref(*new UnresolvedStyleValue(move(values), contains_var_or_attr));
     }
@@ -1633,18 +1633,18 @@ public:
 
     virtual String to_string() const override;
 
-    Vector<StyleComponentValueRule> const& values() const { return m_values; }
+    Vector<ComponentValue> const& values() const { return m_values; }
     bool contains_var_or_attr() const { return m_contains_var_or_attr; }
 
 private:
-    UnresolvedStyleValue(Vector<StyleComponentValueRule>&& values, bool contains_var_or_attr)
+    UnresolvedStyleValue(Vector<ComponentValue>&& values, bool contains_var_or_attr)
         : StyleValue(Type::Unresolved)
         , m_values(move(values))
         , m_contains_var_or_attr(contains_var_or_attr)
     {
     }
 
-    Vector<StyleComponentValueRule> m_values;
+    Vector<ComponentValue> m_values;
     bool m_contains_var_or_attr { false };
 };
 

--- a/Userland/Libraries/LibWeb/CSS/Supports.h
+++ b/Userland/Libraries/LibWeb/CSS/Supports.h
@@ -12,7 +12,7 @@
 #include <AK/Variant.h>
 #include <AK/Vector.h>
 #include <LibWeb/CSS/GeneralEnclosed.h>
-#include <LibWeb/CSS/Parser/StyleDeclarationRule.h>
+#include <LibWeb/CSS/Parser/Declaration.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/CSS/UnicodeRange.h
+++ b/Userland/Libraries/LibWeb/CSS/UnicodeRange.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Assertions.h>
+
+namespace Web::CSS {
+
+// https://www.w3.org/TR/css-syntax-3/#urange-syntax
+class UnicodeRange {
+public:
+    UnicodeRange(u32 min_code_point, u32 max_code_point)
+        : m_min_code_point(min_code_point)
+        , m_max_code_point(max_code_point)
+    {
+        VERIFY(min_code_point <= max_code_point);
+    }
+
+    u32 min_code_point() const { return m_min_code_point; }
+    u32 max_code_point() const { return m_max_code_point; }
+
+    bool contains(u32 code_point) const
+    {
+        return m_min_code_point <= code_point && code_point <= m_max_code_point;
+    }
+
+    String to_string() const
+    {
+        if (m_min_code_point == m_max_code_point)
+            return String::formatted("U+{:x}", m_min_code_point);
+        return String::formatted("U+{:x}-{:x}", m_min_code_point, m_max_code_point);
+    }
+
+private:
+    u32 m_min_code_point;
+    u32 m_max_code_point;
+};
+
+}

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -578,7 +578,7 @@ void dump_font_face_rule(StringBuilder& builder, CSS::CSSFontFaceRule const& rul
     builder.append("sources:\n");
     for (auto const& source : font_face.sources()) {
         indent(builder, indent_levels + 2);
-        builder.appendff("{}\n", source.url);
+        builder.appendff("url={}, format={}\n", source.url, source.format.value_or("???"));
     }
 
     indent(builder, indent_levels + 1);

--- a/Userland/Libraries/LibWeb/Dump.cpp
+++ b/Userland/Libraries/LibWeb/Dump.cpp
@@ -580,6 +580,13 @@ void dump_font_face_rule(StringBuilder& builder, CSS::CSSFontFaceRule const& rul
         indent(builder, indent_levels + 2);
         builder.appendff("{}\n", source.url);
     }
+
+    indent(builder, indent_levels + 1);
+    builder.append("unicode-ranges:\n");
+    for (auto const& unicode_range : font_face.unicode_ranges()) {
+        indent(builder, indent_levels + 2);
+        builder.appendff("{}\n", unicode_range.to_string());
+    }
 }
 
 void dump_import_rule(StringBuilder& builder, CSS::CSSImportRule const& rule, int indent_levels)

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -89,6 +89,7 @@ class Time;
 class TimePercentage;
 class TimeStyleValue;
 class TransformationStyleValue;
+class UnicodeRange;
 class UnresolvedStyleValue;
 class UnsetStyleValue;
 }


### PR DESCRIPTION
This is about 50% cleaning up CSS parser things, and 50% `@font-face` improvements.

I originally was going to make this more complete before submitting, but the `<urange>` parsing burned me out a bit! :sweat_smile: So, still a lot to do.

The actual noticeable change is that we now understand the `format("foo")` part of the `src` of a `@font-face`. This lets us ignore font URLs for formats we don't support. (Which right now is most of them!)