### PR TITLE
AK: Only use x86 assembly in sincos on corr. arch and builtins otherwise 

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -211,10 +211,15 @@ constexpr void sincos(T angle, T& sin_val, T& cos_val)
         cos_val = cos(angle);
         return;
     }
+#if ARCH(I386) || ARCH(X86_64)
     asm(
         "fsincos"
         : "=t"(cos_val), "=u"(sin_val)
         : "0"(angle));
+#else
+    sin_val = __builtin_sin(angle);
+    sin_val = __builtin_cos(angle);
+#endif
 }
 
 template<FloatingPoint T>


### PR DESCRIPTION
this guards some x86 assembly in AKMath to allow compilation on non x86 systems