### PR TITLE
su: Change the HOME enviroment variable on login

### DIFF
--- a/Userland/Utilities/su.cpp
+++ b/Userland/Utilities/su.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Undefine <undefine@undefine.pl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -47,6 +48,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     TRY(Core::System::pledge("stdio exec"));
+
+    TRY(Core::System::setenv("HOME"sv, account.home_directory(), true));
 
     execl(account.shell().characters(), account.shell().characters(), nullptr);
     perror("execl");


### PR DESCRIPTION
This makes sure that when you login to another account using the LibCore's utility the HOME variable is set. 

It also fixes #13436 