### PR TITLE
Ports: Fix installdepends when portname is specified as port="$name"

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -491,7 +491,7 @@ package_install_state() {
 installdepends() {
     for depend in "${depends[@]}"; do
         if [ -z "$(package_install_state $depend)" ]; then
-            (cd "$(dirname $(grep -E port=${depend} ../*/package.sh))" && ./package.sh --auto)
+            (cd "$(dirname $(grep -E ^port=\"\?${depend}\"\?\$ ../*/package.sh))" && ./package.sh --auto)
         fi
     done
 }


### PR DESCRIPTION
This fixes the case when the port name is in quotation marks.

I pushed this to https://github.com/SerenityOS/serenity/pull/13398 just 2 minutes to late to get merged in that PR, sorry!