### PR TITLE
Add all Kernel/Memory files to the aarch64 platform

### DIFF
--- a/Kernel/Arch/CPU.h
+++ b/Kernel/Arch/CPU.h
@@ -21,4 +21,7 @@ namespace Kernel {
 
 struct RegisterState;
 
+void dump_registers(RegisterState const& regs);
+void handle_crash(RegisterState const&, char const* description, int signal, bool out_of_memory = false);
+
 }

--- a/Kernel/Arch/CPU.h
+++ b/Kernel/Arch/CPU.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2018-2022, James Mintram <me@jamesrm.com>
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Platform.h>
+
+#if ARCH(X86_64) || ARCH(I386)
+#    include <Kernel/Arch/x86/CPU.h>
+#elif ARCH(AARCH64)
+#    include <Kernel/Arch/aarch64/CPU.h>
+#else
+#    error "Unknown architecture"
+#endif
+
+namespace Kernel {
+
+struct RegisterState;
+
+}

--- a/Kernel/Arch/PageDirectory.h
+++ b/Kernel/Arch/PageDirectory.h
@@ -12,7 +12,6 @@
 #include <Kernel/PhysicalAddress.h>
 
 #include <AK/Platform.h>
-VALIDATE_IS_X86()
 
 namespace Kernel {
 
@@ -83,6 +82,7 @@ public:
     PhysicalPtr physical_page_base() const { return PhysicalAddress::physical_page_base(m_raw); }
     void set_physical_page_base(PhysicalPtr value)
     {
+        // FIXME: IS THIS PLATFORM SPECIFIC?
         m_raw &= 0x8000000000000fffULL;
         m_raw |= PhysicalAddress::physical_page_base(value);
     }

--- a/Kernel/Arch/PageFault.h
+++ b/Kernel/Arch/PageFault.h
@@ -6,11 +6,9 @@
 
 #pragma once
 
+#include <AK/Platform.h>
 #include <AK/Types.h>
 #include <Kernel/VirtualAddress.h>
-
-#include <AK/Platform.h>
-VALIDATE_IS_X86()
 
 namespace Kernel {
 

--- a/Kernel/Arch/aarch64/CPU.h
+++ b/Kernel/Arch/aarch64/CPU.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2018-2022, James Mintram <me@jamesrm.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#define PAGE_MASK (~(FlatPtr)0xfffu)

--- a/Kernel/Arch/aarch64/CrashHandler.cpp
+++ b/Kernel/Arch/aarch64/CrashHandler.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/CPU.h>
+#include <Kernel/Arch/RegisterState.h>
+
+namespace Kernel {
+
+void handle_crash(Kernel::RegisterState const&, char const*, int, bool)
+{
+}
+
+}

--- a/Kernel/Arch/aarch64/CrashHandler.cpp
+++ b/Kernel/Arch/aarch64/CrashHandler.cpp
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Forward.h>
+
 #include <Kernel/Arch/CPU.h>
 #include <Kernel/Arch/RegisterState.h>
 

--- a/Kernel/Arch/aarch64/PageDirectory.cpp
+++ b/Kernel/Arch/aarch64/PageDirectory.cpp
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2022, James Mintram <me@jamesrm.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Memory/PageDirectory.h>
+
+namespace Kernel::Memory {
+
+void PageDirectory::register_page_directory(PageDirectory*)
+{
+}
+
+void PageDirectory::deregister_page_directory(PageDirectory*)
+{
+}
+
+RefPtr<PageDirectory> PageDirectory::find_current()
+{
+    return nullptr;
+}
+
+void activate_kernel_page_directory(PageDirectory const&)
+{
+}
+
+void activate_page_directory(PageDirectory const&, Thread*)
+{
+}
+
+}

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -48,6 +48,16 @@ public:
         return 0;
     }
 
+    ALWAYS_INLINE bool has_nx() const
+    {
+        return true;
+    }
+
+    ALWAYS_INLINE bool has_pat() const
+    {
+        return false;
+    }
+
     ALWAYS_INLINE static FlatPtr current_in_irq()
     {
         return 0;

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -13,7 +13,13 @@
 
 #include <Kernel/Arch/ProcessorSpecificDataID.h>
 
+class VirtualAddress;
+
 namespace Kernel {
+
+namespace Memory {
+class PageDirectory;
+};
 
 class Thread;
 
@@ -39,6 +45,14 @@ public:
     ALWAYS_INLINE static bool is_initialized()
     {
         return false;
+    }
+
+    ALWAYS_INLINE static void flush_tlb_local(VirtualAddress&, size_t&)
+    {
+    }
+
+    ALWAYS_INLINE static void flush_tlb(Memory::PageDirectory const*, VirtualAddress const&, size_t)
+    {
     }
 
     ALWAYS_INLINE static u32 current_id()

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -33,6 +33,9 @@ public:
     ALWAYS_INLINE static void pause() { }
     ALWAYS_INLINE static void wait_check() { }
 
+    ALWAYS_INLINE u8 physical_address_bit_width() const { return 0; }
+    ALWAYS_INLINE u8 virtual_address_bit_width() const { return 0; }
+
     ALWAYS_INLINE static bool is_initialized()
     {
         return false;

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -60,6 +60,11 @@ public:
         return 0;
     }
 
+    ALWAYS_INLINE static Thread* idle_thread()
+    {
+        return nullptr;
+    }
+
     ALWAYS_INLINE static Processor& current() { VERIFY_NOT_REACHED(); }
 
     static void deferred_call_queue(Function<void()> /* callback */) { }

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -63,6 +63,8 @@ public:
         return 0;
     }
 
+    ALWAYS_INLINE static u64 read_cpu_counter() { return 0; }
+
     ALWAYS_INLINE static void enter_critical() { }
     ALWAYS_INLINE static void leave_critical() { }
     ALWAYS_INLINE static u32 in_critical()

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -9,6 +9,8 @@
 namespace Kernel {
 
 struct RegisterState {
+    FlatPtr userspace_sp() const { return 0; }
+    FlatPtr ip() const { return 0; }
 };
 
 struct DebugRegisterState {

--- a/Kernel/Arch/aarch64/RegisterState.h
+++ b/Kernel/Arch/aarch64/RegisterState.h
@@ -6,8 +6,12 @@
 
 #pragma once
 
+namespace Kernel {
+
 struct RegisterState {
 };
 
 struct DebugRegisterState {
 };
+
+}

--- a/Kernel/Arch/aarch64/dummy.cpp
+++ b/Kernel/Arch/aarch64/dummy.cpp
@@ -4,15 +4,121 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Singleton.h>
 #include <AK/Types.h>
+
+#include <Kernel/FileSystem/Inode.h>
 #include <Kernel/KString.h>
 #include <Kernel/KSyms.h>
+#include <Kernel/Locking/SpinlockProtected.h>
+#include <Kernel/Memory/SharedInodeVMObject.h>
+#include <Kernel/Panic.h>
+#include <Kernel/PhysicalAddress.h>
+#include <Kernel/Random.h>
 #include <Kernel/Sections.h>
+#include <Kernel/UserOrKernelBuffer.h>
 
 // This is a temporary file to get a non-empty Kernel binary on aarch64.
 // The prekernel currently never jumps to the kernel. This is dead code.
 void dummy();
 void dummy() { }
+
+// Scheduler
+namespace Kernel {
+
+READONLY_AFTER_INIT Thread* g_finalizer;
+
+}
+
+// Panic
+namespace Kernel {
+
+void __panic(char const*, unsigned int, char const*)
+{
+    for (;;) { }
+}
+
+}
+
+// Random
+namespace Kernel {
+
+void get_fast_random_bytes(Bytes) { }
+
+}
+
+// Inode
+namespace Kernel {
+
+static Singleton<SpinlockProtected<Inode::AllInstancesList>> s_all_instances;
+
+SpinlockProtected<Inode::AllInstancesList>& Inode::all_instances()
+{
+    return s_all_instances;
+}
+
+RefPtr<Memory::SharedInodeVMObject> Inode::shared_vmobject() const
+{
+    return RefPtr<Memory::SharedInodeVMObject>(nullptr);
+}
+
+void Inode::will_be_destroyed()
+{
+}
+
+ErrorOr<void> Inode::set_shared_vmobject(Memory::SharedInodeVMObject&)
+{
+    return {};
+}
+
+}
+
+// UserOrKernelBuffer.cpp
+namespace Kernel {
+
+ErrorOr<void> UserOrKernelBuffer::write(void const*, size_t, size_t)
+{
+    return {};
+}
+
+ErrorOr<void> UserOrKernelBuffer::read(void*, size_t, size_t) const
+{
+    return {};
+}
+
+}
+
+// x86 init
+
+multiboot_module_entry_t multiboot_copy_boot_modules_array[16];
+size_t multiboot_copy_boot_modules_count;
+
+extern "C" {
+READONLY_AFTER_INIT PhysicalAddress start_of_prekernel_image;
+READONLY_AFTER_INIT PhysicalAddress end_of_prekernel_image;
+READONLY_AFTER_INIT size_t physical_to_virtual_offset;
+// READONLY_AFTER_INIT FlatPtr kernel_mapping_base;
+READONLY_AFTER_INIT FlatPtr kernel_load_base;
+#if ARCH(X86_64)
+READONLY_AFTER_INIT PhysicalAddress boot_pml4t;
+#endif
+READONLY_AFTER_INIT PhysicalAddress boot_pdpt;
+READONLY_AFTER_INIT PhysicalAddress boot_pd0;
+READONLY_AFTER_INIT PhysicalAddress boot_pd_kernel;
+READONLY_AFTER_INIT Kernel::PageTableEntry* boot_pd_kernel_pt1023;
+READONLY_AFTER_INIT char const* kernel_cmdline;
+READONLY_AFTER_INIT u32 multiboot_flags;
+READONLY_AFTER_INIT multiboot_memory_map_t* multiboot_memory_map;
+READONLY_AFTER_INIT size_t multiboot_memory_map_count;
+READONLY_AFTER_INIT multiboot_module_entry_t* multiboot_modules;
+READONLY_AFTER_INIT size_t multiboot_modules_count;
+READONLY_AFTER_INIT PhysicalAddress multiboot_framebuffer_addr;
+READONLY_AFTER_INIT u32 multiboot_framebuffer_pitch;
+READONLY_AFTER_INIT u32 multiboot_framebuffer_width;
+READONLY_AFTER_INIT u32 multiboot_framebuffer_height;
+READONLY_AFTER_INIT u8 multiboot_framebuffer_bpp;
+READONLY_AFTER_INIT u8 multiboot_framebuffer_type;
+}
 
 // kmalloc.h
 size_t kmalloc_good_size(size_t);

--- a/Kernel/Arch/aarch64/dummy.cpp
+++ b/Kernel/Arch/aarch64/dummy.cpp
@@ -18,6 +18,8 @@ void dummy() { }
 size_t kmalloc_good_size(size_t);
 size_t kmalloc_good_size(size_t) { return 0; }
 
+void* kcalloc(unsigned long, unsigned long) { return nullptr; }
+
 void kfree_sized(void*, size_t);
 void kfree_sized(void*, size_t) { }
 
@@ -26,6 +28,21 @@ void* kmalloc(size_t) { return nullptr; }
 
 void* operator new(size_t size) { return kmalloc(size); }
 void* operator new(size_t size, std::align_val_t) { return kmalloc(size); }
+
+void* operator new(size_t, std::nothrow_t const&) noexcept { return nullptr; }
+void* operator new(size_t, std::align_val_t, std::nothrow_t const&) noexcept { return nullptr; }
+void* operator new[](size_t) { return (void*)0xdeadbeef; }
+void* operator new[](size_t, std::nothrow_t const&) noexcept { return nullptr; }
+
+void operator delete(void*) noexcept { }
+void operator delete(void*, size_t) noexcept { }
+void operator delete(void*, size_t, std::align_val_t) noexcept { }
+void operator delete[](void*) noexcept { }
+void operator delete[](void*, size_t) noexcept { }
+
+namespace std {
+const nothrow_t nothrow;
+}
 
 namespace Kernel {
 

--- a/Kernel/Arch/aarch64/dummy.cpp
+++ b/Kernel/Arch/aarch64/dummy.cpp
@@ -9,22 +9,10 @@
 #include <Kernel/KSyms.h>
 #include <Kernel/Sections.h>
 
-// init.cpp
-extern size_t __stack_chk_guard;
-READONLY_AFTER_INIT size_t __stack_chk_guard;
-
 // This is a temporary file to get a non-empty Kernel binary on aarch64.
 // The prekernel currently never jumps to the kernel. This is dead code.
 void dummy();
 void dummy() { }
-
-// Assertions.h
-[[noreturn]] void __assertion_failed(char const*, char const*, unsigned, char const*);
-
-[[noreturn]] void __assertion_failed(char const*, char const*, unsigned, char const*)
-{
-    for (;;) { }
-}
 
 // kmalloc.h
 size_t kmalloc_good_size(size_t);

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -39,6 +39,20 @@ SECTIONS
                physical memory. 8M is wasteful, so this should be properly calculated.
     */
     
+    /* FIXME: Placeholder to satisfy linker */
+    start_of_kernel_ksyms = .;
+    end_of_kernel_ksyms = .;
+    start_of_kernel_text = .;
+    end_of_kernel_text = .;
+    start_of_kernel_image = .;
+    end_of_kernel_image = .;
+    start_of_unmap_after_init = .;
+    end_of_unmap_after_init = .;
+    start_of_ro_after_init = .;
+    end_of_ro_after_init = .;
+    start_of_kernel_data = .;
+    end_of_kernel_data = .;
+
     . = ALIGN(4K);
     page_tables_phys_start = .;
     

--- a/Kernel/Arch/x86/CPU.h
+++ b/Kernel/Arch/x86/CPU.h
@@ -36,8 +36,6 @@ inline u32 get_iopl_from_eflags(u32 eflags)
 DescriptorTablePointer const& get_gdtr();
 DescriptorTablePointer const& get_idtr();
 
-void handle_crash(RegisterState const&, char const* description, int signal, bool out_of_memory = false);
-
 #define LSW(x) ((u32)(x)&0xFFFF)
 #define MSW(x) (((u32)(x) >> 16) & 0xFFFF)
 #define LSB(x) ((x)&0xFF)

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -397,6 +397,16 @@ public:
 
     static void deferred_call_queue(Function<void()> callback);
 
+    ALWAYS_INLINE bool has_nx() const
+    {
+        return has_feature(CPUFeature::NX);
+    }
+
+    ALWAYS_INLINE bool has_pat() const
+    {
+        return has_feature(CPUFeature::PAT);
+    }
+
     ALWAYS_INLINE bool has_feature(CPUFeature::Type const& feature) const
     {
         return m_features.has_flag(feature);

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -158,6 +158,11 @@ public:
         return *g_total_processors.ptr();
     }
 
+    ALWAYS_INLINE static u64 read_cpu_counter()
+    {
+        return read_tsc();
+    }
+
     ALWAYS_INLINE static void pause()
     {
         asm volatile("pause");

--- a/Kernel/Arch/x86/Processor.h
+++ b/Kernel/Arch/x86/Processor.h
@@ -12,11 +12,11 @@
 #include <AK/Types.h>
 
 #include <Kernel/Arch/DeferredCallEntry.h>
+#include <Kernel/Arch/PageDirectory.h>
 #include <Kernel/Arch/ProcessorSpecificDataID.h>
 #include <Kernel/Arch/x86/ASM_wrapper.h>
 #include <Kernel/Arch/x86/CPUID.h>
 #include <Kernel/Arch/x86/DescriptorTable.h>
-#include <Kernel/Arch/x86/PageDirectory.h>
 #include <Kernel/Arch/x86/TSS.h>
 #include <Kernel/Forward.h>
 #include <Kernel/KString.h>

--- a/Kernel/Arch/x86/common/CrashHandler.cpp
+++ b/Kernel/Arch/x86/common/CrashHandler.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/CPU.h>
+#include <Kernel/Arch/RegisterState.h>
+
+#include <Kernel/Panic.h>
+#include <Kernel/Process.h>
+#include <Kernel/Thread.h>
+
+namespace Kernel {
+
+void handle_crash(Kernel::RegisterState const& regs, char const* description, int signal, bool out_of_memory)
+{
+    auto* current_thread = Thread::current();
+    if (!current_thread)
+        PANIC("{} with !Thread::current()", description);
+
+    auto crashed_in_kernel = (regs.cs & 3) == 0;
+    if (!crashed_in_kernel && current_thread->has_signal_handler(signal) && !current_thread->should_ignore_signal(signal) && !current_thread->is_signal_masked(signal)) {
+        current_thread->send_urgent_signal_to_self(signal);
+        return;
+    }
+
+    auto& process = current_thread->process();
+
+    // If a process crashed while inspecting another process,
+    // make sure we switch back to the right page tables.
+    Memory::MemoryManager::enter_process_address_space(process);
+
+    dmesgln("CRASH: CPU #{} {} in ring {}", Processor::current_id(), description, (regs.cs & 3));
+    dump_registers(regs);
+
+    if (crashed_in_kernel) {
+        process.address_space().dump_regions();
+        PANIC("Crash in ring 0");
+    }
+
+    process.crash(signal, regs.ip(), out_of_memory);
+}
+
+}

--- a/Kernel/Arch/x86/common/Interrupts.cpp
+++ b/Kernel/Arch/x86/common/Interrupts.cpp
@@ -23,10 +23,10 @@
 
 #include <LibC/mallocdefs.h>
 
+#include <Kernel/Arch/PageFault.h>
 #include <Kernel/Arch/Processor.h>
 #include <Kernel/Arch/RegisterState.h>
 #include <Kernel/Arch/x86/ISRStubs.h>
-#include <Kernel/Arch/x86/PageFault.h>
 #include <Kernel/Arch/x86/SafeMem.h>
 #include <Kernel/Arch/x86/TrapFrame.h>
 

--- a/Kernel/Arch/x86/common/PageDirectory.cpp
+++ b/Kernel/Arch/x86/common/PageDirectory.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2018-2022, James Mintram <me@jamesrm.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Singleton.h>
+
+#include <Kernel/Memory/PageDirectory.h>
+#include <Kernel/Thread.h>
+
+namespace Kernel::Memory {
+
+static Singleton<IntrusiveRedBlackTree<&PageDirectory::m_tree_node>> s_cr3_map;
+
+static IntrusiveRedBlackTree<&PageDirectory::m_tree_node>& cr3_map()
+{
+    VERIFY_INTERRUPTS_DISABLED();
+    return *s_cr3_map;
+}
+
+void PageDirectory::register_page_directory(PageDirectory* directory)
+{
+    cr3_map().insert(directory->cr3(), *directory);
+}
+
+void PageDirectory::deregister_page_directory(PageDirectory* directory)
+{
+    cr3_map().remove(directory->cr3());
+}
+
+RefPtr<PageDirectory> PageDirectory::find_current()
+{
+    SpinlockLocker lock(s_mm_lock);
+    return cr3_map().find(read_cr3());
+}
+
+void activate_kernel_page_directory(PageDirectory const& pgd)
+{
+    write_cr3(pgd.cr3());
+}
+
+void activate_page_directory(PageDirectory const& pgd, Thread* current_thread)
+{
+    current_thread->regs().cr3 = pgd.cr3();
+    write_cr3(pgd.cr3());
+}
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -397,6 +397,8 @@ else()
         Arch/aarch64/UART.cpp
         Arch/aarch64/Utils.cpp
 
+        Arch/aarch64/Dummy.cpp
+
         # Preload specific
         Arch/aarch64/init.cpp
         Arch/aarch64/PrekernelMMU.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -421,6 +421,23 @@ else()
         Arch/aarch64/ScopedCritical.cpp
         MiniStdLib.cpp
         Prekernel/UBSanitizer.cpp
+
+        Memory/AddressSpace.cpp
+        Memory/AnonymousVMObject.cpp
+        Memory/InodeVMObject.cpp
+        Memory/PhysicalRegion.cpp
+        Memory/PhysicalPage.cpp
+        Memory/PhysicalZone.cpp
+        Memory/PageDirectory.cpp
+        Memory/MemoryManager.cpp
+        Memory/PrivateInodeVMObject.cpp
+        Memory/Region.cpp
+        Memory/RingBuffer.cpp
+        Memory/SharedInodeVMObject.cpp
+        Memory/ScatterGatherList.cpp
+        Memory/VirtualRange.cpp
+        Memory/VirtualRangeAllocator.cpp
+        Memory/VMObject.cpp
     )
 
     # Otherwise linker errors e.g undefined reference to `__aarch64_cas8_acq_rel'

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -390,6 +390,8 @@ if (NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
     )
 else()
     set(SOURCES
+        ${AK_SOURCES}
+
         Arch/aarch64/BootPPMParser.cpp
         Arch/aarch64/CrashHandler.cpp
         Arch/aarch64/GPIO.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -320,7 +320,9 @@ if ("${SERENITY_ARCH}" STREQUAL "i686" OR "${SERENITY_ARCH}" STREQUAL "x86_64")
 
     set(KERNEL_SOURCES
         ${KERNEL_SOURCES}
+        
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/ASM_wrapper.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/CrashHandler.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/CPU.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/CPUID.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/Interrupts.cpp
@@ -388,6 +390,7 @@ if (NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
 else()
     set(SOURCES
         Arch/aarch64/BootPPMParser.cpp
+        Arch/aarch64/CrashHandler.cpp
         Arch/aarch64/GPIO.cpp
         Arch/aarch64/Framebuffer.cpp
         Arch/aarch64/Mailbox.cpp

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -326,6 +326,7 @@ if ("${SERENITY_ARCH}" STREQUAL "i686" OR "${SERENITY_ARCH}" STREQUAL "x86_64")
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/CPU.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/CPUID.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/Interrupts.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/PageDirectory.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/Processor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/ProcessorInfo.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/Arch/x86/common/SafeMem.cpp
@@ -396,6 +397,7 @@ else()
         Arch/aarch64/Mailbox.cpp
         Arch/aarch64/MainIdRegister.cpp
         Arch/aarch64/MMIO.cpp
+        Arch/aarch64/PageDirectory.cpp
         Arch/aarch64/Timer.cpp
         Arch/aarch64/UART.cpp
         Arch/aarch64/Utils.cpp

--- a/Kernel/Memory/AddressSpace.cpp
+++ b/Kernel/Memory/AddressSpace.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <Kernel/Arch/CPU.h>
 #include <Kernel/Locking/Spinlock.h>
 #include <Kernel/Memory/AddressSpace.h>
 #include <Kernel/Memory/AnonymousVMObject.h>

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -7,7 +7,7 @@
 #include <AK/Assertions.h>
 #include <AK/Memory.h>
 #include <AK/StringView.h>
-#include <Kernel/Arch/x86/PageFault.h>
+#include <Kernel/Arch/PageFault.h>
 #include <Kernel/BootInfo.h>
 #include <Kernel/CMOS.h>
 #include <Kernel/FileSystem/Inode.h>

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -7,6 +7,7 @@
 #include <AK/Assertions.h>
 #include <AK/Memory.h>
 #include <AK/StringView.h>
+#include <Kernel/Arch/CPU.h>
 #include <Kernel/Arch/PageFault.h>
 #include <Kernel/BootInfo.h>
 #include <Kernel/CMOS.h>

--- a/Kernel/Memory/MemoryManager.cpp
+++ b/Kernel/Memory/MemoryManager.cpp
@@ -8,7 +8,9 @@
 #include <AK/Memory.h>
 #include <AK/StringView.h>
 #include <Kernel/Arch/CPU.h>
+#include <Kernel/Arch/PageDirectory.h>
 #include <Kernel/Arch/PageFault.h>
+#include <Kernel/Arch/RegisterState.h>
 #include <Kernel/BootInfo.h>
 #include <Kernel/CMOS.h>
 #include <Kernel/FileSystem/Inode.h>
@@ -78,7 +80,7 @@ UNMAP_AFTER_INIT MemoryManager::MemoryManager()
 
     SpinlockLocker lock(s_mm_lock);
     parse_memory_map();
-    write_cr3(kernel_page_directory().cr3());
+    activate_kernel_page_directory(kernel_page_directory());
     protect_kernel_image();
 
     // We're temporarily "committing" to two pages that we need to allocate below
@@ -105,7 +107,7 @@ UNMAP_AFTER_INIT void MemoryManager::protect_kernel_image()
         auto& pte = *ensure_pte(kernel_page_directory(), VirtualAddress(i));
         pte.set_writable(false);
     }
-    if (Processor::current().has_feature(CPUFeature::NX)) {
+    if (Processor::current().has_nx()) {
         // Disable execution of the kernel data, bss and heap segments.
         for (auto const* i = start_of_kernel_data; i < end_of_kernel_image; i += PAGE_SIZE) {
             auto& pte = *ensure_pte(kernel_page_directory(), VirtualAddress(i));
@@ -467,7 +469,7 @@ UNMAP_AFTER_INIT void MemoryManager::initialize_physical_pages()
             pte.set_physical_page_base(physical_page_array_current_page);
             pte.set_user_allowed(false);
             pte.set_writable(true);
-            if (Processor::current().has_feature(CPUFeature::NX))
+            if (Processor::current().has_nx())
                 pte.set_execute_disabled(false);
             pte.set_global(true);
             pte.set_present(true);
@@ -710,7 +712,7 @@ Region* MemoryManager::find_region_from_vaddr(VirtualAddress vaddr)
 {
     if (auto* region = kernel_region_from_vaddr(vaddr))
         return region;
-    auto page_directory = PageDirectory::find_by_cr3(read_cr3());
+    auto page_directory = PageDirectory::find_current();
     if (!page_directory)
         return nullptr;
     VERIFY(page_directory->address_space());
@@ -1024,7 +1026,7 @@ void MemoryManager::enter_address_space(AddressSpace& space)
     SpinlockLocker lock(s_mm_lock);
 
     current_thread->regs().cr3 = space.page_directory().cr3();
-    write_cr3(space.page_directory().cr3());
+    activate_page_directory(space.page_directory(), current_thread);
 }
 
 void MemoryManager::flush_tlb_local(VirtualAddress vaddr, size_t page_count)

--- a/Kernel/Memory/MemoryManager.h
+++ b/Kernel/Memory/MemoryManager.h
@@ -22,6 +22,7 @@
 
 namespace Kernel {
 class PageDirectoryEntry;
+class PageTableEntry;
 }
 
 struct KmallocGlobalData;

--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -6,6 +6,8 @@
 
 #include <AK/Memory.h>
 #include <AK/Singleton.h>
+#include <Kernel/Arch/CPU.h>
+#include <Kernel/Arch/PageDirectory.h>
 #include <Kernel/Memory/MemoryManager.h>
 #include <Kernel/Memory/PageDirectory.h>
 #include <Kernel/Prekernel/Prekernel.h>

--- a/Kernel/Memory/PageDirectory.cpp
+++ b/Kernel/Memory/PageDirectory.cpp
@@ -20,20 +20,6 @@ extern u8 end_of_kernel_image[];
 
 namespace Kernel::Memory {
 
-static Singleton<IntrusiveRedBlackTree<&PageDirectory::m_tree_node>> s_cr3_map;
-
-static IntrusiveRedBlackTree<&PageDirectory::m_tree_node>& cr3_map()
-{
-    VERIFY_INTERRUPTS_DISABLED();
-    return *s_cr3_map;
-}
-
-RefPtr<PageDirectory> PageDirectory::find_by_cr3(FlatPtr cr3)
-{
-    SpinlockLocker lock(s_mm_lock);
-    return cr3_map().find(cr3);
-}
-
 UNMAP_AFTER_INIT NonnullRefPtr<PageDirectory> PageDirectory::must_create_kernel_page_directory()
 {
     auto directory = adopt_ref_if_nonnull(new (nothrow) PageDirectory).release_nonnull();
@@ -125,7 +111,7 @@ ErrorOr<NonnullRefPtr<PageDirectory>> PageDirectory::try_create_for_userspace(Vi
         MM.unquickmap_page();
     }
 
-    cr3_map().insert(directory->cr3(), directory);
+    register_page_directory(directory);
     return directory;
 }
 
@@ -150,7 +136,7 @@ PageDirectory::~PageDirectory()
 {
     if (is_cr3_initialized()) {
         SpinlockLocker lock(s_mm_lock);
-        cr3_map().remove(cr3());
+        deregister_page_directory(this);
     }
 }
 

--- a/Kernel/Memory/PageDirectory.h
+++ b/Kernel/Memory/PageDirectory.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Badge.h>
 #include <AK/HashMap.h>
 #include <AK/IntrusiveRedBlackTree.h>
 #include <AK/RefCounted.h>

--- a/Kernel/Memory/PageDirectory.h
+++ b/Kernel/Memory/PageDirectory.h
@@ -23,7 +23,7 @@ class PageDirectory : public RefCounted<PageDirectory> {
 public:
     static ErrorOr<NonnullRefPtr<PageDirectory>> try_create_for_userspace(VirtualRangeAllocator const* parent_range_allocator = nullptr);
     static NonnullRefPtr<PageDirectory> must_create_kernel_page_directory();
-    static RefPtr<PageDirectory> find_by_cr3(FlatPtr);
+    static RefPtr<PageDirectory> find_current();
 
     ~PageDirectory();
 
@@ -62,6 +62,8 @@ public:
 
 private:
     PageDirectory();
+    static void register_page_directory(PageDirectory* directory);
+    static void deregister_page_directory(PageDirectory* directory);
 
     AddressSpace* m_space { nullptr };
     VirtualRangeAllocator m_range_allocator;
@@ -76,5 +78,8 @@ private:
 #endif
     RecursiveSpinlock m_lock;
 };
+
+void activate_kernel_page_directory(PageDirectory const& pgd);
+void activate_page_directory(PageDirectory const& pgd, Thread* current_thread);
 
 }

--- a/Kernel/Memory/Region.cpp
+++ b/Kernel/Memory/Region.cpp
@@ -6,7 +6,8 @@
 
 #include <AK/Memory.h>
 #include <AK/StringView.h>
-#include <Kernel/Arch/x86/PageFault.h>
+#include <Kernel/Arch/PageDirectory.h>
+#include <Kernel/Arch/PageFault.h>
 #include <Kernel/Debug.h>
 #include <Kernel/FileSystem/Inode.h>
 #include <Kernel/Memory/AnonymousVMObject.h>
@@ -212,9 +213,9 @@ bool Region::map_individual_page_impl(size_t page_index)
             pte->set_writable(false);
         else
             pte->set_writable(is_writable());
-        if (Processor::current().has_feature(CPUFeature::NX))
+        if (Processor::current().has_nx())
             pte->set_execute_disabled(!is_executable());
-        if (Processor::current().has_feature(CPUFeature::PAT))
+        if (Processor::current().has_pat())
             pte->set_pat(is_write_combine());
         pte->set_user_allowed(user_allowed);
     }
@@ -317,7 +318,7 @@ void Region::remap()
 
 ErrorOr<void> Region::set_write_combine(bool enable)
 {
-    if (enable && !Processor::current().has_feature(CPUFeature::PAT)) {
+    if (enable && !Processor::current().has_pat()) {
         dbgln("PAT is not supported, implement MTRR fallback if available");
         return Error::from_errno(ENOTSUP);
     }

--- a/Kernel/Random.h
+++ b/Kernel/Random.h
@@ -10,6 +10,7 @@
 #include <AK/Assertions.h>
 #include <AK/ByteBuffer.h>
 #include <AK/Types.h>
+#include <Kernel/Arch/Processor.h>
 #include <Kernel/Locking/Mutex.h>
 #include <Kernel/StdLib.h>
 #include <LibCrypto/Cipher/AES.h>
@@ -163,7 +164,7 @@ public:
         auto& kernel_rng = KernelRng::the();
         SpinlockLocker lock(kernel_rng.get_lock());
         // We don't lock this because on the off chance a pool is corrupted, entropy isn't lost.
-        Event<T> event = { read_tsc(), m_source, event_data };
+        Event<T> event = { Processor::read_cpu_counter(), m_source, event_data };
         kernel_rng.add_random_event(event, m_pool);
         m_pool++;
         kernel_rng.wake_if_ready();


### PR DESCRIPTION
This PR  adds all of the memory code to the aarch64 build. Where needed, code was refactored to make this possible.

A lot of additional symbols have been added in the dummy.cpp + aarch64 linker scripts to satisfy the linker. 