### PR TITLE
TaskBar: Make "Themes" a shortcut to DisplaySettings

### DIFF
--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2019-2020, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -11,7 +12,9 @@
 #include "FontSettingsWidget.h"
 #include "MonitorSettingsWidget.h"
 #include "ThemesSettingsWidget.h"
+#include <AK/Array.h>
 #include <LibConfig/Client.h>
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -25,18 +28,40 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("WindowManager");
 
+    String tab_to_open;
+    Core::ArgsParser args_parser;
+    args_parser.add_option(tab_to_open, "Settings tab to open", "settings-tab", 't', "settings-tab");
+    args_parser.parse(arguments);
+
     auto app_icon = GUI::Icon::default_icon("app-display-settings");
 
-    bool background_settings_changed = false;
+    struct SettingsTab {
+        StringView name;
+        GUI::Widget* widget;
+    };
 
     auto window = TRY(GUI::SettingsWindow::create("Display Settings"));
-    (void)TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background", background_settings_changed));
-    (void)TRY(window->add_tab<DisplaySettings::ThemesSettingsWidget>("Themes", background_settings_changed));
-    (void)TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts"));
-    (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor"));
-    (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces"));
-
     window->set_icon(app_icon.bitmap_for_size(16));
+
+    auto add_tab = [&]<class T, class... Args>(StringView name, Args&&... args) {
+        return SettingsTab { name, MUST(window->add_tab<T>(name, forward<Args>(args)...)) };
+    };
+
+    bool background_settings_changed = false;
+    Array settings_tabs {
+        add_tab.template operator()<DisplaySettings::BackgroundSettingsWidget>("Background", background_settings_changed),
+        add_tab.template operator()<DisplaySettings::ThemesSettingsWidget>("Themes", background_settings_changed),
+        add_tab.template operator()<DisplaySettings::FontSettingsWidget>("Fonts"),
+        add_tab.template operator()<DisplaySettings::MonitorSettingsWidget>("Monitor"),
+        add_tab.template operator()<DisplaySettings::DesktopSettingsWidget>("Workspaces")
+    };
+
+    if (!tab_to_open.is_empty()) {
+        for (auto& tab : settings_tabs) {
+            if (tab_to_open.equals_ignoring_case(tab.name))
+                window->set_active_widget(tab.widget);
+        }
+    }
 
     window->show();
     return app->exec();

--- a/Userland/Libraries/LibGUI/SettingsWindow.h
+++ b/Userland/Libraries/LibGUI/SettingsWindow.h
@@ -41,6 +41,11 @@ public:
         return tab;
     }
 
+    inline void set_active_widget(Widget* tab)
+    {
+        m_tab_widget->set_active_widget(tab);
+    }
+
 private:
     SettingsWindow() = default;
 


### PR DESCRIPTION
This PR removes the classic theme submenu and instead makes "Themes" on the taskbar open the themes tab in the display settings (#13386).

Open to feedback on this change as it adds an extra click to change the theme, but it also avoids having two separate places to change the theme and allows previewing the theme first.