### PR TITLE
LibGUI + Calculator: Extend mimic pressed across all keyboard shortcuts for buttons 

### DIFF
--- a/Userland/Applications/Calculator/CalculatorWidget.cpp
+++ b/Userland/Applications/Calculator/CalculatorWidget.cpp
@@ -142,16 +142,7 @@ void CalculatorWidget::set_entry(KeypadValue value)
 
 void CalculatorWidget::mimic_pressed_button(RefPtr<GUI::Button> button)
 {
-    constexpr int TIMER_MS = 80;
-
-    if (!m_mimic_pressed_button.is_null())
-        m_mimic_pressed_button->set_mimic_pressed(false);
-
     button->set_mimic_pressed(true);
-    m_mimic_pressed_button = button;
-
-    stop_timer();
-    start_timer(TIMER_MS, Core::TimerShouldFireWhenNotVisible::Yes);
 }
 
 void CalculatorWidget::update_display()
@@ -226,10 +217,4 @@ void CalculatorWidget::keydown_event(GUI::KeyEvent& event)
     }
 
     update_display();
-}
-
-void CalculatorWidget::timer_event(Core::TimerEvent&)
-{
-    if (!m_mimic_pressed_button.is_null())
-        m_mimic_pressed_button->set_mimic_pressed(false);
 }

--- a/Userland/Applications/Calculator/CalculatorWidget.h
+++ b/Userland/Applications/Calculator/CalculatorWidget.h
@@ -31,7 +31,6 @@ private:
     void update_display();
 
     virtual void keydown_event(GUI::KeyEvent&) override;
-    virtual void timer_event(Core::TimerEvent&) override;
 
     Calculator m_calculator;
     Keypad m_keypad;
@@ -57,6 +56,4 @@ private:
     RefPtr<GUI::Button> m_inverse_button;
     RefPtr<GUI::Button> m_percent_button;
     RefPtr<GUI::Button> m_equals_button;
-
-    RefPtr<GUI::Button> m_mimic_pressed_button {};
 };

--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -131,6 +131,12 @@ void Action::activate(Core::Object* activator)
         }
     }
 
+    if (activator == nullptr) {
+        for_each_toolbar_button([](auto& button) {
+            button.set_mimic_pressed(true);
+        });
+    }
+
     on_activation(*this);
     m_activator = nullptr;
 }

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -224,8 +224,23 @@ void Button::set_default(bool default_button)
 
 void Button::set_mimic_pressed(bool mimic_pressed)
 {
-    m_mimic_pressed = mimic_pressed;
-    update();
+    if (!is_being_pressed()) {
+        m_mimic_pressed = mimic_pressed;
+
+        stop_timer();
+        start_timer(80, Core::TimerShouldFireWhenNotVisible::Yes);
+
+        update();
+    }
+}
+
+void Button::timer_event(Core::TimerEvent&)
+{
+    if (is_mimic_pressed()) {
+        m_mimic_pressed = false;
+
+        update();
+    }
 }
 
 }

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -64,6 +64,8 @@ protected:
     virtual void paint_event(PaintEvent&) override;
 
 private:
+    virtual void timer_event(Core::TimerEvent&) override;
+
     RefPtr<Gfx::Bitmap> m_icon;
     RefPtr<GUI::Menu> m_menu;
     Gfx::ButtonStyle m_button_style { Gfx::ButtonStyle::Normal };


### PR DESCRIPTION
This builds on what @ForLoveOfCats  implemented in calculator. It extracts the timer into Button and sets mimic pressed on action activation when there is no activator.

I have also refactored the implementation in calculator to move the timer to Button.