### PR TITLE
DisplaySettings: Stop theme tab from overriding background color

### DIFF
--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.h
@@ -27,12 +27,14 @@ public:
     virtual void apply_settings() override;
 
 private:
-    BackgroundSettingsWidget();
+    BackgroundSettingsWidget(bool& background_settings_changed);
 
     void create_frame();
     void load_current_settings();
 
     Vector<String> m_modes;
+
+    bool& m_background_settings_changed;
 
     RefPtr<DisplaySettings::MonitorWidget> m_monitor_widget;
     RefPtr<GUI::IconView> m_wallpaper_view;

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -19,7 +19,8 @@ static inline String current_system_theme()
     return GUI::ConnectionToWindowServer::the().get_system_theme();
 }
 
-ThemesSettingsWidget::ThemesSettingsWidget()
+ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
+    : m_background_settings_changed { background_settings_changed }
 {
     load_from_gml(themes_settings_gml);
     m_themes = Gfx::list_installed_system_themes();
@@ -50,7 +51,8 @@ ThemesSettingsWidget::ThemesSettingsWidget()
 void ThemesSettingsWidget::apply_settings()
 {
     if (m_selected_theme && m_selected_theme->name != current_system_theme())
-        VERIFY(GUI::ConnectionToWindowServer::the().set_system_theme(m_selected_theme->path, m_selected_theme->name));
+        VERIFY(GUI::ConnectionToWindowServer::the().set_system_theme(m_selected_theme->path, m_selected_theme->name, m_background_settings_changed));
+    m_background_settings_changed = false;
 }
 
 }

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -14,14 +14,18 @@
 
 namespace DisplaySettings {
 
+static inline String current_system_theme()
+{
+    return GUI::ConnectionToWindowServer::the().get_system_theme();
+}
+
 ThemesSettingsWidget::ThemesSettingsWidget()
 {
     load_from_gml(themes_settings_gml);
     m_themes = Gfx::list_installed_system_themes();
 
-    auto current_theme_name = GUI::ConnectionToWindowServer::the().get_system_theme();
-
     size_t current_theme_index;
+    auto current_theme_name = current_system_theme();
     m_theme_names.ensure_capacity(m_themes.size());
     for (auto& theme_meta : m_themes) {
         m_theme_names.append(theme_meta.name);
@@ -45,7 +49,7 @@ ThemesSettingsWidget::ThemesSettingsWidget()
 
 void ThemesSettingsWidget::apply_settings()
 {
-    if (m_selected_theme)
+    if (m_selected_theme && m_selected_theme->name != current_system_theme())
         VERIFY(GUI::ConnectionToWindowServer::the().set_system_theme(m_selected_theme->path, m_selected_theme->name));
 }
 

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
@@ -31,7 +31,9 @@ private:
 
     Gfx::SystemThemeMetaData const* m_selected_theme { nullptr };
 
-    ThemesSettingsWidget();
+    bool& m_background_settings_changed;
+
+    ThemesSettingsWidget(bool& background_settings_changed);
 };
 
 }

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -27,9 +27,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto app_icon = GUI::Icon::default_icon("app-display-settings");
 
+    bool background_settings_changed = false;
+
     auto window = TRY(GUI::SettingsWindow::create("Display Settings"));
-    (void)TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background"));
-    (void)TRY(window->add_tab<DisplaySettings::ThemesSettingsWidget>("Themes"));
+    (void)TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background", background_settings_changed));
+    (void)TRY(window->add_tab<DisplaySettings::ThemesSettingsWidget>("Themes", background_settings_changed));
     (void)TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts"));
     (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor"));
     (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces"));

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -217,7 +217,7 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu()
             auto action = GUI::Action::create_checkable(theme.name, [theme_identifier](auto&) {
                 auto& theme = g_themes[theme_identifier];
                 dbgln("Theme switched to {} at path {}", theme.name, theme.path);
-                auto success = GUI::ConnectionToWindowServer::the().set_system_theme(theme.path, theme.name);
+                auto success = GUI::ConnectionToWindowServer::the().set_system_theme(theme.path, theme.name, false);
                 VERIFY(success);
             });
             if (theme.name == current_theme_name)

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -790,9 +790,9 @@ Messages::WindowServer::StartDragResponse ConnectionFromClient::start_drag(Strin
     return true;
 }
 
-Messages::WindowServer::SetSystemThemeResponse ConnectionFromClient::set_system_theme(String const& theme_path, String const& theme_name)
+Messages::WindowServer::SetSystemThemeResponse ConnectionFromClient::set_system_theme(String const& theme_path, String const& theme_name, bool keep_desktop_background)
 {
-    bool success = WindowManager::the().update_theme(theme_path, theme_name);
+    bool success = WindowManager::the().update_theme(theme_path, theme_name, keep_desktop_background);
     return success;
 }
 

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -140,7 +140,7 @@ private:
     virtual void dismiss_menu(i32) override;
     virtual void set_window_icon_bitmap(i32, Gfx::ShareableBitmap const&) override;
     virtual Messages::WindowServer::StartDragResponse start_drag(String const&, HashMap<String, ByteBuffer> const&, Gfx::ShareableBitmap const&) override;
-    virtual Messages::WindowServer::SetSystemThemeResponse set_system_theme(String const&, String const&) override;
+    virtual Messages::WindowServer::SetSystemThemeResponse set_system_theme(String const&, String const&, bool keep_desktop_background) override;
     virtual Messages::WindowServer::GetSystemThemeResponse get_system_theme() override;
     virtual void apply_cursor_theme(String const&) override;
     virtual Messages::WindowServer::GetCursorThemeResponse get_cursor_theme() override;

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -2089,7 +2089,7 @@ void WindowManager::invalidate_after_theme_or_font_change()
     Compositor::the().invalidate_after_theme_or_font_change();
 }
 
-bool WindowManager::update_theme(String theme_path, String theme_name)
+bool WindowManager::update_theme(String theme_path, String theme_name, bool keep_desktop_background)
 {
     auto new_theme = Gfx::load_system_theme(theme_path);
     if (!new_theme.is_valid())
@@ -2097,7 +2097,8 @@ bool WindowManager::update_theme(String theme_path, String theme_name)
     Gfx::set_system_theme(new_theme);
     m_palette = Gfx::PaletteImpl::create_with_anonymous_buffer(new_theme);
     m_config->write_entry("Theme", "Name", theme_name);
-    m_config->remove_entry("Background", "Color");
+    if (!keep_desktop_background)
+        m_config->remove_entry("Background", "Color");
     if (auto result = m_config->sync(); result.is_error()) {
         dbgln("Failed to save config file: {}", result.error());
         return false;

--- a/Userland/Services/WindowServer/WindowManager.h
+++ b/Userland/Services/WindowServer/WindowManager.h
@@ -213,7 +213,7 @@ public:
         return nullptr;
     }
 
-    bool update_theme(String theme_path, String theme_name);
+    bool update_theme(String theme_path, String theme_name, bool keep_desktop_background);
     void invalidate_after_theme_or_font_change();
 
     bool set_hovered_window(Window*);

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -113,7 +113,7 @@ endpoint WindowServer
 
     start_drag([UTF8] String text, HashMap<String,ByteBuffer> mime_data, Gfx::ShareableBitmap drag_bitmap) => (bool started)
 
-    set_system_theme(String theme_path, [UTF8] String theme_name) => (bool success)
+    set_system_theme(String theme_path, [UTF8] String theme_name, bool keep_desktop_background) => (bool success)
     get_system_theme() => ([UTF8] String theme_name)
     refresh_system_theme() =|
 


### PR DESCRIPTION
Fixes #13448

Allows setting the background color again :sweat_smile: 

(Good spot by @djwisdom)