### PR TITLE
Revert "Ports: Fix dependency install when port name is not port folder name"

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -491,7 +491,7 @@ package_install_state() {
 installdepends() {
     for depend in "${depends[@]}"; do
         if [ -z "$(package_install_state $depend)" ]; then
-            (cd "$(dirname $(grep -E port=${depend} ../*/package.sh))" && ./package.sh --auto)
+            (cd "../$depend" && ./package.sh --auto)
         fi
     done
 }


### PR DESCRIPTION
This breaks ports whose name may come up in more than one port name (e.g. `SDL2`).

This reverts commit cc08f82ddb104829112c7c5fe028f2e7dd9aaee1.