### PR TITLE
Ports: Ensure port's directory name matches `port` property

### DIFF
--- a/Meta/lint-ports.py
+++ b/Meta/lint-ports.py
@@ -193,7 +193,6 @@ def get_port_properties(port):
         dict: keys are values from PORT_PROPERTIES, values are from the package.sh file
     """
 
-    props = {}
     package_sh_command = f"./package.sh showproperty {' '.join(PORT_PROPERTIES)}"
     res = subprocess.run(f"cd {port}; exec {package_sh_command}", shell=True, capture_output=True)
     if res.returncode == 0:
@@ -224,6 +223,11 @@ def check_package_files(ports):
         if not os.path.exists(package_file):
             continue
         props = ports[port]
+
+        if props['port'] != port:
+            print(f"Ports/{port} should use '{port}' for 'port' but is using '{props['port']}' instead")
+            all_good = False
+
         if not props['auth_type'] in ('sha256', 'sig', ''):
             print(f"Ports/{port} uses invalid signature algorithm '{props['auth_type']}' for 'auth_type'")
             all_good = False

--- a/Ports/SDLPoP/package.sh
+++ b/Ports/SDLPoP/package.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=PrinceOfPersia
+port=SDLPoP
 useconfigure=true
 version=git
 depends=("SDL2" "SDL2_image")
-workdir=SDLPoP-86988c668eeaa10f218e1d4938fc5b4e42314d68
+commitid="86988c668eeaa10f218e1d4938fc5b4e42314d68"
+workdir="${port}-${commitid}"
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
-files="https://github.com/NagyD/SDLPoP/archive/86988c668eeaa10f218e1d4938fc5b4e42314d68.zip PoP.zip d18cae8541fb8cbcc374fd998316993d561429a83f92061bc0754337ada774c5"
+files="https://github.com/NagyD/SDLPoP/archive/${commitid}.zip PoP.zip d18cae8541fb8cbcc374fd998316993d561429a83f92061bc0754337ada774c5"
 auth_type=sha256
 launcher_name="Prince of Persia"
 launcher_category=Games

--- a/Ports/dungeonrush/package.sh
+++ b/Ports/dungeonrush/package.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=DungeonRush
+port=dungeonrush
 version=1.1-beta
 useconfigure=true
+workdir="DungeonRush-${version}"
 files="https://github.com/Rapiz1/DungeonRush/archive/refs/tags/v${version}.tar.gz v${version}.tar.gz 295b83cb023bf5d21318992daee125399892bdf16a87c835dfc90b841c929eda"
 auth_type=sha256
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")

--- a/Ports/freedink/package.sh
+++ b/Ports/freedink/package.sh
@@ -1,11 +1,10 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=FreeDink
+port=freedink
 version=109.6
 useconfigure="true"
 use_fresh_config_sub="true"
 config_sub_path=autotools/config.sub
 depends=("SDL2" "SDL2_image" "SDL2_mixer" "SDL2_ttf" "SDL2_gfx" "gettext" "fontconfig" "glm")
-workdir="freedink-${version}"
 freedink_data="freedink-data-1.08.20190120"
 files="https://ftpmirror.gnu.org/gnu/freedink/freedink-${version}.tar.gz freedink-${version}.tar.gz
 https://ftpmirror.gnu.org/gnu/freedink/freedink-${version}.tar.gz.sig freedink-${version}.tar.gz.sig

--- a/Ports/imagemagick/package.sh
+++ b/Ports/imagemagick/package.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=ImageMagick
+port=imagemagick
 version=7.1.0-23
-workdir="${port}-${version}"
+workdir="ImageMagick-${version}"
 useconfigure="true"
-files="https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${version}.tar.gz imagemagick-v${version}.tar.gz 62c24362891d0af2be9a81d01117195ba0ec8e6982c7568195a33019bfc82188"
+files="https://github.com/ImageMagick/ImageMagick/archive/refs/tags/${version}.tar.gz ${port}-v${version}.tar.gz 62c24362891d0af2be9a81d01117195ba0ec8e6982c7568195a33019bfc82188"
 auth_type=sha256
 configopts=("--host=${SERENITY_ARCH}")
 depends=("libpng" "libtiff" "libjpeg")

--- a/Ports/luajit/package.sh
+++ b/Ports/luajit/package.sh
@@ -5,7 +5,10 @@ files="https://luajit.org/download/LuaJIT-${version}.tar.gz LuaJIT-${version}.ta
 auth_type=sha256
 workdir="LuaJIT-${version}"
 
-printf "\x1b[31m\x1b[5mATTENTION: \x1b[0m\x1b[31m\x1b[1mIf this fails, install either libc6-dev-i386 or libc6-dev-amd64\x1b[0m\n"
+preconfigure() {
+    printf "\x1b[31m\x1b[5mATTENTION: \x1b[0m\x1b[31m\x1b[1mIf this fails, install either libc6-dev-i386 or libc6-dev-amd64\x1b[0m\n"
+}
+
 if [ ${SERENITY_ARCH} = "i686" ]; then
     M_FLAG=-m32
 elif [ ${SERENITY_ARCH} = "x86_64" ]; then

--- a/Ports/sam/package.sh
+++ b/Ports/sam/package.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=SAM
+port=sam
 version=c86ea395743b8ea4ad071c2167fd1f7f96648f7b
+workdir="SAM-${version}"
 files="https://github.com/vidarh/SAM/archive/${version}.tar.gz ${version}.tar.gz 1f534245e2c7a096de5f886fd96ea1ad966c4e674c1ed91e0c6a59662e8d6c11"
 auth_type=sha256
 depends=("SDL2")

--- a/Ports/stpuzzles/package.sh
+++ b/Ports/stpuzzles/package.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=SimonTathamsPuzzles
+port=stpuzzles
 useconfigure=true
 version=git
-workdir=stpuzzles-main
+workdir="${port}-main"
 configopts=("-DCMAKE_TOOLCHAIN_FILE=${SERENITY_BUILD_DIR}/CMakeToolchain.txt")
-files="https://github.com/SerenityPorts/stpuzzles/archive/refs/heads/main.zip stpuzzles.zip"
+files="https://github.com/SerenityPorts/stpuzzles/archive/refs/heads/main.zip ${port}.zip"
 
 configure() {
     run cmake "${configopts[@]}" -DCMAKE_CXX_FLAGS="-std=c++2a -O2"

--- a/Ports/vlang/package.sh
+++ b/Ports/vlang/package.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env -S bash ../.port_include.sh
-port=v
+port=vlang
 auth_type=sha256
 version=weekly.2021.31
-files="https://codeload.github.com/vlang/v/tar.gz/refs/tags/$version v-$version.tar.gz b0daf0a2e2cb6d463710952f4d2e8705c17d02a9270355b20861ff3fd5f72563"
+workdir="v-${version}"
+files="https://codeload.github.com/vlang/v/tar.gz/refs/tags/${version} v-${version}.tar.gz b0daf0a2e2cb6d463710952f4d2e8705c17d02a9270355b20861ff3fd5f72563"
 
 build() {
     (


### PR DESCRIPTION
We currently have no valid use case for having a `port` property different from the directory name the port's residing in. We do have issues when this is the case when referencing dependencies, so let's make sure all ports have a sensible `port` property to begin with.