### PR TITLE
LibWeb: Add favicon handling on link tags

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -339,6 +339,8 @@ public:
 
     bool in_removed_last_ref() const { return m_in_removed_last_ref; }
 
+    void check_favicon_after_loading_link_resource();
+
 private:
     explicit Document(const AK::URL&);
 
@@ -374,6 +376,7 @@ private:
     RefPtr<CSS::StyleSheetList> m_style_sheets;
     RefPtr<Node> m_hovered_node;
     RefPtr<Node> m_inspected_node;
+    RefPtr<Node> m_active_favicon;
     WeakPtr<HTML::BrowsingContext> m_browsing_context;
     AK::URL m_url;
 

--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -339,6 +339,7 @@ public:
 
     bool in_removed_last_ref() const { return m_in_removed_last_ref; }
 
+    bool has_active_favicon() const { return m_active_favicon; }
     void check_favicon_after_loading_link_resource();
 
 private:

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.cpp
@@ -55,9 +55,15 @@ void HTMLLinkElement::inserted()
 
 void HTMLLinkElement::parse_attribute(FlyString const& name, String const& value)
 {
+    // 4.6.7 Link types - https://html.spec.whatwg.org/multipage/links.html#linkTypes
     if (name == HTML::AttributeNames::rel) {
         m_relationship = 0;
-        auto parts = value.split_view(' ');
+        // Keywords are always ASCII case-insensitive, and must be compared as such.
+        auto lowercased_value = value.to_lowercase();
+        // To determine which link types apply to a link, a, area, or form element,
+        // the element's rel attribute must be split on ASCII whitespace.
+        // The resulting tokens are the keywords for the link types that apply to that element.
+        auto parts = lowercased_value.split_view(' ');
         for (auto& part : parts) {
             if (part == "stylesheet"sv)
                 m_relationship |= Relationship::Stylesheet;
@@ -69,6 +75,8 @@ void HTMLLinkElement::parse_attribute(FlyString const& name, String const& value
                 m_relationship |= Relationship::DNSPrefetch;
             else if (part == "preconnect"sv)
                 m_relationship |= Relationship::Preconnect;
+            else if (part == "icon"sv)
+                m_relationship |= Relationship::Icon;
         }
     }
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -42,6 +42,7 @@ private:
             Preload = 1 << 2,
             DNSPrefetch = 1 << 3,
             Preconnect = 1 << 4,
+            Icon = 1 << 5,
         };
     };
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLLinkElement.h
@@ -28,12 +28,18 @@ public:
     String type() const { return attribute(HTML::AttributeNames::type); }
     String href() const { return attribute(HTML::AttributeNames::href); }
 
+    bool has_loaded_icon() const;
+    bool load_favicon_and_use_if_window_is_active();
+
 private:
     void parse_attribute(FlyString const&, String const&) override;
 
     // ^ResourceClient
     virtual void resource_did_fail() override;
     virtual void resource_did_load() override;
+
+    void resource_did_load_stylesheet();
+    void resource_did_load_favicon();
 
     struct Relationship {
         enum {

--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -187,6 +187,10 @@ bool FrameLoader::load(LoadRequest& request, Type type)
     if (type == Type::IFrame)
         return true;
 
+    auto* document = browsing_context().active_document();
+    if (document && document->has_active_favicon())
+        return true;
+
     if (url.protocol() == "http" || url.protocol() == "https") {
         AK::URL favicon_url;
         favicon_url.set_protocol(url.protocol());
@@ -197,6 +201,10 @@ bool FrameLoader::load(LoadRequest& request, Type type)
         ResourceLoader::the().load(
             favicon_url,
             [this, favicon_url](auto data, auto&, auto) {
+                // Always fetch the current document
+                auto* document = this->browsing_context().active_document();
+                if (document && document->has_active_favicon())
+                    return;
                 dbgln_if(SPAM_DEBUG, "Favicon downloaded, {} bytes from {}", data.size(), favicon_url);
                 if (data.is_empty())
                     return;
@@ -211,6 +219,11 @@ bool FrameLoader::load(LoadRequest& request, Type type)
                 load_favicon(favicon_bitmap);
             },
             [this](auto&, auto) {
+                // Always fetch the current document
+                auto* document = this->browsing_context().active_document();
+                if (document && document->has_active_favicon())
+                    return;
+
                 load_favicon();
             });
     } else {


### PR DESCRIPTION
What is in:
- Favicon handling when an icon link tag is added to the head element
- Overrides the default favicon of the website when an icon is loaded by the link tag
- The latest favicon is preferred when multiple link tags are found
- There is some fallback behavior when a favicon doesn't load when multiple are available (added on 4/4/2022)

What is not in:
- There is no best icon selector when multiple favicons are found in the head tag
- There is no favicon update when the tag has been altered, the favicon does update when a new link tag is added though
    -  Example: https://mashpoe.github.io/favicon-dino-game/
    - The cause of that issue is the lack of a trigger with this line of code: https://github.com/Mashpoe/favicon-dino-game/blob/b33191329faafdad31ed04a1944fcb2db5fd2129/index.html#L56
- The icon won't be updated when its link tag is removed, other browsers seem to have similar behavior though

Example websites that use favicons through link tags:
- [discord website.](https://www.discord.com/)
- http://peachananr.github.io/notify-better/demo/index.html (favicon update works, though the image needs to be scaled)

Notes:
- I like to see https://favicon.cc working but currently there are some other issues