### PR TITLE
Userland: Remove a few gratuitous IPC namespace qualifiers

### DIFF
--- a/Userland/DevTools/HackStudio/AutoCompleteResponse.h
+++ b/Userland/DevTools/HackStudio/AutoCompleteResponse.h
@@ -16,7 +16,7 @@
 namespace IPC {
 
 template<>
-inline bool encode(IPC::Encoder& encoder, const GUI::AutocompleteProvider::Entry& response)
+inline bool encode(Encoder& encoder, const GUI::AutocompleteProvider::Entry& response)
 {
     encoder << response.completion;
     encoder << response.partial_input_length;
@@ -27,7 +27,7 @@ inline bool encode(IPC::Encoder& encoder, const GUI::AutocompleteProvider::Entry
 }
 
 template<>
-inline ErrorOr<void> decode(IPC::Decoder& decoder, GUI::AutocompleteProvider::Entry& response)
+inline ErrorOr<void> decode(Decoder& decoder, GUI::AutocompleteProvider::Entry& response)
 {
     TRY(decoder.decode(response.completion));
     TRY(decoder.decode(response.partial_input_length));

--- a/Userland/Libraries/LibCore/DateTime.h
+++ b/Userland/Libraries/LibCore/DateTime.h
@@ -54,7 +54,7 @@ private:
 
 namespace IPC {
 
-bool encode(IPC::Encoder&, Core::DateTime const&);
-ErrorOr<void> decode(IPC::Decoder&, Core::DateTime&);
+bool encode(Encoder&, Core::DateTime const&);
+ErrorOr<void> decode(Decoder&, Core::DateTime&);
 
 }

--- a/Userland/Libraries/LibGfx/Color.cpp
+++ b/Userland/Libraries/LibGfx/Color.cpp
@@ -336,13 +336,13 @@ Vector<Color> Color::tints(u32 steps, float max) const
 
 }
 
-bool IPC::encode(IPC::Encoder& encoder, Color const& color)
+bool IPC::encode(Encoder& encoder, Color const& color)
 {
     encoder << color.value();
     return true;
 }
 
-ErrorOr<void> IPC::decode(IPC::Decoder& decoder, Color& color)
+ErrorOr<void> IPC::decode(Decoder& decoder, Color& color)
 {
     u32 rgba;
     TRY(decoder.decode(rgba));

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.cpp
@@ -333,7 +333,7 @@ Optional<Core::DateTime> parse_date_time(StringView date_string)
 
 }
 
-bool IPC::encode(IPC::Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
+bool IPC::encode(Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
 {
     encoder << cookie.name;
     encoder << cookie.value;
@@ -347,7 +347,7 @@ bool IPC::encode(IPC::Encoder& encoder, Web::Cookie::ParsedCookie const& cookie)
     return true;
 }
 
-ErrorOr<void> IPC::decode(IPC::Decoder& decoder, Web::Cookie::ParsedCookie& cookie)
+ErrorOr<void> IPC::decode(Decoder& decoder, Web::Cookie::ParsedCookie& cookie)
 {
     TRY(decoder.decode(cookie.name));
     TRY(decoder.decode(cookie.value));

--- a/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
+++ b/Userland/Libraries/LibWeb/Cookie/ParsedCookie.h
@@ -30,7 +30,7 @@ Optional<ParsedCookie> parse_cookie(String const& cookie_string);
 
 namespace IPC {
 
-bool encode(IPC::Encoder&, Web::Cookie::ParsedCookie const&);
-ErrorOr<void> decode(IPC::Decoder&, Web::Cookie::ParsedCookie&);
+bool encode(Encoder&, Web::Cookie::ParsedCookie const&);
+ErrorOr<void> decode(Decoder&, Web::Cookie::ParsedCookie&);
 
 }


### PR DESCRIPTION
Spotted this while trying to search for specific IPC encode/decode
implementations. Now they are all the same, so searching is easier.