### PR TITLE
Applets: Add a network graph applet

### DIFF
--- a/AK/CircularQueue.h
+++ b/AK/CircularQueue.h
@@ -64,6 +64,7 @@ public:
     }
 
     const T& at(size_t index) const { return elements()[(m_head + index) % Capacity]; }
+    T& at(size_t index) { return elements()[(m_head + index) % Capacity]; }
 
     const T& first() const { return at(0); }
     const T& last() const { return at(size() - 1); }
@@ -90,8 +91,33 @@ public:
         size_t m_index { 0 };
     };
 
+    class Iterator {
+    public:
+        bool operator!=(Iterator const& other) { return m_index != other.m_index; }
+        Iterator& operator++()
+        {
+            ++m_index;
+            return *this;
+        }
+
+        T& operator*() const { return m_queue.at(m_index); }
+
+    private:
+        friend class CircularQueue;
+        Iterator(CircularQueue& queue, size_t const index)
+            : m_queue(queue)
+            , m_index(index)
+        {
+        }
+        CircularQueue& m_queue;
+        size_t m_index { 0 };
+    };
+
     ConstIterator begin() const { return ConstIterator(*this, 0); }
     ConstIterator end() const { return ConstIterator(*this, size()); }
+
+    Iterator begin() { return Iterator(*this, 0); }
+    Iterator end() { return Iterator(*this, size()); }
 
     size_t head_index() const { return m_head; }
 

--- a/Base/etc/WindowServer.ini
+++ b/Base/etc/WindowServer.ini
@@ -32,7 +32,7 @@ DoubleClickSpeed=250
 Mode=stretch
 
 [Applet]
-Order=WorkspacePicker,CPUGraph,MemoryGraph,Network,ClipboardHistory,Audio,Keymap
+Order=WorkspacePicker,CPUGraph,MemoryGraph,NetworkGraph,Network,ClipboardHistory,Audio,Keymap
 
 [Workspaces]
 Rows=2

--- a/Base/home/anon/.config/SystemServer.ini
+++ b/Base/home/anon/.config/SystemServer.ini
@@ -3,7 +3,7 @@ Priority=low
 KeepAlive=true
 
 [ResourceGraph.Applet]
-Arguments=--cpu=CPUGraph,#00bb00 --memory=MemoryGraph,#00bbbb
+Arguments=--cpu=CPUGraph,#00bb00 --memory=MemoryGraph,#00bbbb --network=NetworkGraph,#bbbb00
 Priority=low
 KeepAlive=true
 


### PR DESCRIPTION
This resource graph applet shows incoming network traffic graphically, and the tooltip shows both TX and RX. The data of all adapters is combined. There's even automatic scaling!

![image](https://user-images.githubusercontent.com/28656157/161433351-c6ab8357-237b-48f7-9da8-9a65ca17d8ed.png)
