### PR TITLE
AK: Allow Optional<T&> to exist

### DIFF
--- a/AK/HashMap.h
+++ b/AK/HashMap.h
@@ -127,7 +127,7 @@ public:
     void ensure_capacity(size_t capacity) { m_table.ensure_capacity(capacity); }
     ErrorOr<void> try_ensure_capacity(size_t capacity) { return m_table.try_ensure_capacity(capacity); }
 
-    Optional<typename Traits<V>::PeekType> get(const K& key) const requires(!IsPointer<typename Traits<V>::PeekType>)
+    Optional<typename Traits<V>::ConstPeekType> get(const K& key) const requires(!IsPointer<typename Traits<V>::PeekType>)
     {
         auto it = find(key);
         if (it == end())

--- a/AK/StdLibExtraDetails.h
+++ b/AK/StdLibExtraDetails.h
@@ -26,6 +26,24 @@ template<class T>
 using AddConst = const T;
 
 template<class T>
+struct __AddConstToReferencedType {
+    using Type = T;
+};
+
+template<class T>
+struct __AddConstToReferencedType<T&> {
+    using Type = AddConst<T>&;
+};
+
+template<class T>
+struct __AddConstToReferencedType<T&&> {
+    using Type = AddConst<T>&&;
+};
+
+template<class T>
+using AddConstToReferencedType = typename __AddConstToReferencedType<T>::Type;
+
+template<class T>
 struct __RemoveConst {
     using Type = T;
 };
@@ -577,6 +595,7 @@ inline constexpr bool IsOneOf = (IsSame<T, Ts> || ...);
 
 }
 using AK::Detail::AddConst;
+using AK::Detail::AddConstToReferencedType;
 using AK::Detail::AddLvalueReference;
 using AK::Detail::AddRvalueReference;
 using AK::Detail::AssertSize;

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -16,8 +16,8 @@ namespace AK {
 
 template<typename T>
 struct GenericTraits {
-    using PeekType = T;
-    using ConstPeekType = T;
+    using PeekType = T&;
+    using ConstPeekType = T const&;
     static constexpr bool is_trivial() { return false; }
     static constexpr bool equals(const T& a, const T& b) { return a == b; }
     template<Concepts::HashCompatible<T> U>

--- a/AK/Vector.h
+++ b/AK/Vector.h
@@ -163,7 +163,7 @@ public:
     VisibleType& last() { return at(size() - 1); }
 
     template<typename TUnaryPredicate>
-    Optional<VisibleType> first_matching(TUnaryPredicate predicate) requires(!contains_reference)
+    Optional<VisibleType&> first_matching(TUnaryPredicate predicate) requires(!contains_reference)
     {
         for (size_t i = 0; i < size(); ++i) {
             if (predicate(at(i))) {
@@ -174,7 +174,7 @@ public:
     }
 
     template<typename TUnaryPredicate>
-    Optional<VisibleType> last_matching(TUnaryPredicate predicate) requires(!contains_reference)
+    Optional<VisibleType&> last_matching(TUnaryPredicate predicate) requires(!contains_reference)
     {
         for (ssize_t i = size() - 1; i >= 0; --i) {
             if (predicate(at(i))) {

--- a/Tests/AK/TestOptional.cpp
+++ b/Tests/AK/TestOptional.cpp
@@ -211,3 +211,61 @@ TEST_CASE(test_copy_ctor_and_dtor_called)
     static_assert(!IsDestructible<Optional<NonDestructible>>);
 #endif
 }
+
+TEST_CASE(basic_optional_reference)
+{
+    Optional<int&> x;
+    EXPECT_EQ(x.has_value(), false);
+    int a = 3;
+    x = a;
+    EXPECT_EQ(x.has_value(), true);
+    EXPECT_EQ(x.value(), 3);
+    EXPECT_EQ(&x.value(), &a);
+
+    Optional<int const&> y;
+    EXPECT_EQ(y.has_value(), false);
+    int b = 3;
+    y = b;
+    EXPECT_EQ(y.has_value(), true);
+    EXPECT_EQ(y.value(), 3);
+    EXPECT_EQ(&y.value(), &b);
+    static_assert(IsConst<RemoveReference<decltype(y.value())>>);
+}
+
+TEST_CASE(move_optional_reference)
+{
+    Optional<int&> x;
+    EXPECT_EQ(x.has_value(), false);
+    int b = 3;
+    x = b;
+    EXPECT_EQ(x.has_value(), true);
+    EXPECT_EQ(x.value(), 3);
+
+    Optional<int&> y;
+    y = move(x);
+    EXPECT_EQ(y.has_value(), true);
+    EXPECT_EQ(y.value(), 3);
+    EXPECT_EQ(x.has_value(), false);
+}
+
+TEST_CASE(short_notation_reference)
+{
+    StringView test = "foo";
+    Optional<StringView&> value = test;
+
+    EXPECT_EQ(value->length(), 3u);
+    EXPECT_EQ(*value, "foo");
+}
+
+TEST_CASE(comparison_reference)
+{
+    StringView test = "foo";
+    Optional<StringView&> opt0;
+    Optional<StringView const&> opt1 = test;
+    Optional<String> opt2 = "foo";
+    Optional<StringView> opt3 = "bar";
+
+    EXPECT_NE(opt0, opt1);
+    EXPECT_EQ(opt1, opt2);
+    EXPECT_NE(opt1, opt3);
+}

--- a/Userland/Libraries/LibGUI/FileSystemModel.h
+++ b/Userland/Libraries/LibGUI/FileSystemModel.h
@@ -151,7 +151,7 @@ private:
     String name_for_uid(uid_t) const;
     String name_for_gid(gid_t) const;
 
-    Node const* node_for_path(String const&) const;
+    Optional<Node const&> node_for_path(String const&) const;
 
     HashMap<uid_t, String> m_user_names;
     HashMap<gid_t, String> m_group_names;

--- a/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.cpp
+++ b/Userland/Libraries/LibWeb/WebAssembly/WebAssemblyInstanceObject.cpp
@@ -34,7 +34,7 @@ void WebAssemblyInstanceObject::initialize(JS::GlobalObject& global_object)
     for (auto& export_ : instance.exports()) {
         export_.value().visit(
             [&](Wasm::FunctionAddress const& address) {
-                auto object = cache.function_instances.get(address);
+                Optional<JS::FunctionObject*> object = cache.function_instances.get(address);
                 if (!object.has_value()) {
                     object = create_native_function(global_object, address, export_.name());
                     cache.function_instances.set(address, *object);
@@ -42,7 +42,7 @@ void WebAssemblyInstanceObject::initialize(JS::GlobalObject& global_object)
                 m_exports_object->define_direct_property(export_.name(), *object, JS::default_attributes);
             },
             [&](Wasm::MemoryAddress const& address) {
-                auto object = cache.memory_instances.get(address);
+                Optional<WebAssemblyMemoryObject*> object = cache.memory_instances.get(address);
                 if (!object.has_value()) {
                     object = heap().allocate<Web::Bindings::WebAssemblyMemoryObject>(global_object, global_object, address);
                     cache.memory_instances.set(address, *object);


### PR DESCRIPTION
Regarding concerns raised in #11193:

>  I think `Optional<T&>` should have the semantics of `T&`

No, Optional is not supposed to prefer either option, if you wish to get a `T&`, call `.value()` on the optional.

> it is not absolutely clear what should happen [when `operator=(T const&)` is called]

it is perfectly clear if Optional remains non-opinionated, it used to contain some T&, now it contains another.

> IMO, these [`int&` and `Optional<int&>`] should behave the same way

No, just as `Optional<int>` does not behave the same way as `int` for any other operator, why should `operator=` be special?

cc @BenWiederhake @creator1creeper1 @BertalanD (participating in #11193), @sin-ack (`LibGUI: Return Optional<Node const&> from node_for_path()`).