### PR TITLE
LibWeb: Add XMLHttpRequest::open() overload 

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLGenerators.cpp
@@ -1533,7 +1533,8 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@function.name:snakecase@)
         auto argument_count = overloaded_function.parameters.size();
 
         function_generator.set("argument_count", String::number(argument_count));
-        function_generator.set("arguments_match_check", generate_arguments_match_check(overloaded_function));
+        auto arguments_match_check = generate_arguments_match_check(overloaded_function);
+        function_generator.set("arguments_match_check", arguments_match_check);
         function_generator.set("overload_suffix", String::number(i));
 
         if (argument_count > fetched_arguments) {
@@ -1553,10 +1554,16 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@function.name:snakecase@)
 )~~~");
         }
 
-        function_generator.append(R"~~~(
+        if (arguments_match_check.is_empty()) {
+            function_generator.append(R"~~~(
+    return @function.name:snakecase@@overload_suffix@(vm, global_object);
+)~~~");
+        } else {
+            function_generator.append(R"~~~(
     if (@arguments_match_check@)
         return @function.name:snakecase@@overload_suffix@(vm, global_object);
 )~~~");
+        }
 
         if (!is_last) {
             function_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLGenerators.cpp
@@ -1530,7 +1530,7 @@ JS_DEFINE_NATIVE_FUNCTION(@class_name@::@function.name:snakecase@)
     auto fetched_arguments = 0u;
     for (auto i = 0u; i < overloaded_functions.size(); ++i) {
         auto const& overloaded_function = overloaded_functions[i];
-        auto argument_count = overloaded_function.length();
+        auto argument_count = overloaded_function.parameters.size();
 
         function_generator.set("argument_count", String::number(argument_count));
         function_generator.set("arguments_match_check", generate_arguments_match_check(overloaded_function));

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLGenerators.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLGenerators.cpp
@@ -1475,7 +1475,7 @@ static Optional<String> generate_arguments_match_check_for_count(Vector<IDL::Par
     Vector<String> conditions;
     for (auto i = 0u; i < argument_count; ++i) {
         auto const& parameter = parameters[i];
-        if (parameter.type->is_string() || parameter.type->is_numeric())
+        if (parameter.type->is_string() || parameter.type->is_primitive())
             continue;
         auto argument = String::formatted("arg{}", i);
         StringBuilder condition;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLTypes.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLTypes.h
@@ -61,6 +61,9 @@ struct Type : public RefCounted<Type> {
 
     // https://webidl.spec.whatwg.org/#dfn-numeric-type
     bool is_numeric() const { return is_integer() || name.is_one_of("float", "unrestricted float", "double", "unrestricted double"); }
+
+    // https://webidl.spec.whatwg.org/#dfn-primitive-type
+    bool is_primitive() const { return is_numeric() || name.is_one_of("bigint", "boolean"); }
 };
 
 struct Parameter {

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.h
@@ -55,6 +55,7 @@ public:
     Bindings::XMLHttpRequestResponseType response_type() const { return m_response_type; }
 
     DOM::ExceptionOr<void> open(String const& method, String const& url);
+    DOM::ExceptionOr<void> open(String const& method, String const& url, bool async, String const& username = {}, String const& password = {});
     DOM::ExceptionOr<void> send(String body);
 
     DOM::ExceptionOr<void> set_request_header(String const& header, String const& value);

--- a/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
+++ b/Userland/Libraries/LibWeb/XHR/XMLHttpRequest.idl
@@ -27,6 +27,7 @@ interface XMLHttpRequest : XMLHttpRequestEventTarget {
     attribute XMLHttpRequestResponseType responseType;
 
     undefined open(DOMString method, DOMString url);
+    undefined open(ByteString method, USVString url, boolean async, optional USVString? username = {}, optional USVString? password = {});
     undefined setRequestHeader(DOMString name, DOMString value);
     undefined send(optional USVString body = {});
 


### PR DESCRIPTION
In addition to the `XMLHttpRequest::open()` overload this PR also contains some fixes for the `IDLGenerators`. I had to update the `IDLGenerators` to be able to generate code that would compile for the parameter types of this overload.