### PR TITLE
WindowServer: Fade between old and new wallpaper settings

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -936,7 +936,7 @@ void Painter::blit_dimmed(IntPoint const& position, Gfx::Bitmap const& source, I
     });
 }
 
-void Painter::draw_tiled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& source)
+void Painter::draw_tiled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& source, float opacity)
 {
     VERIFY((source.scale() == 1 || source.scale() == scale()) && "draw_tiled_bitmap only supports integer upsampling");
 
@@ -944,6 +944,11 @@ void Painter::draw_tiled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& so
     auto clipped_rect = dst_rect.intersected(clip_rect());
     if (clipped_rect.is_empty())
         return;
+
+    if (opacity < 1.0f) {
+dbgln("draw_tiled_bitmap with opacity {}", opacity);
+        return;
+    }
 
     int scale = this->scale();
     clipped_rect *= scale;
@@ -982,7 +987,7 @@ void Painter::draw_tiled_bitmap(IntRect const& a_dst_rect, Gfx::Bitmap const& so
     VERIFY_NOT_REACHED();
 }
 
-void Painter::blit_offset(IntPoint const& a_position, Gfx::Bitmap const& source, IntRect const& a_src_rect, IntPoint const& offset)
+void Painter::blit_offset(IntPoint const& a_position, Gfx::Bitmap const& source, IntRect const& a_src_rect, IntPoint const& offset, float opacity)
 {
     auto src_rect = IntRect { a_src_rect.location() - offset, a_src_rect.size() };
     auto position = a_position;
@@ -994,7 +999,7 @@ void Painter::blit_offset(IntPoint const& a_position, Gfx::Bitmap const& source,
         position.set_y(position.y() - src_rect.y());
         src_rect.set_y(0);
     }
-    blit(position, source, src_rect);
+    blit(position, source, src_rect, opacity);
 }
 
 void Painter::blit(IntPoint const& position, Gfx::Bitmap const& source, IntRect const& a_src_rect, float opacity, bool apply_alpha)

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -68,8 +68,8 @@ public:
     void blit_dimmed(IntPoint const&, Gfx::Bitmap const&, IntRect const& src_rect);
     void blit_brightened(IntPoint const&, Gfx::Bitmap const&, IntRect const& src_rect);
     void blit_filtered(IntPoint const&, Gfx::Bitmap const&, IntRect const& src_rect, Function<Color(Color)>);
-    void draw_tiled_bitmap(IntRect const& dst_rect, Gfx::Bitmap const&);
-    void blit_offset(IntPoint const&, Gfx::Bitmap const&, IntRect const& src_rect, IntPoint const&);
+    void draw_tiled_bitmap(IntRect const& dst_rect, Gfx::Bitmap const&, float = 1.0f);
+    void blit_offset(IntPoint const&, Gfx::Bitmap const&, IntRect const& src_rect, IntPoint const&, float = 1.0f);
     void blit_disabled(IntPoint const&, Gfx::Bitmap const&, IntRect const&, Palette const&);
     void blit_tiled(IntRect const&, Gfx::Bitmap const&, IntRect const& src_rect);
     void draw_text(IntRect const&, StringView, Font const&, TextAlignment = TextAlignment::TopLeft, Color = Color::Black, TextElision = TextElision::None, TextWrapping = TextWrapping::DontWrap);

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -306,6 +306,7 @@ void ConnectionFromClient::set_window_opacity(i32 window_id, float opacity)
 
 void ConnectionFromClient::set_wallpaper(Gfx::ShareableBitmap const& bitmap)
 {
+    dbgln("ConnectionFromClient::set_wallpaper");
     Compositor::the().set_wallpaper(bitmap.bitmap());
     async_set_wallpaper_finished(true);
 }

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -70,6 +70,7 @@ WindowManager::WindowManager(Gfx::PaletteImpl const& palette)
 
 void WindowManager::reload_config()
 {
+    dbgln("WindowManager::reload_config");
     m_config = Core::ConfigFile::open("/etc/WindowServer.ini", Core::ConfigFile::AllowWriting::Yes).release_value_but_fixme_should_propagate_errors();
 
     unsigned workspace_rows = (unsigned)m_config->read_num_entry("Workspace", "Rows", default_window_stack_rows);
@@ -2071,6 +2072,7 @@ void WindowManager::end_dnd_drag()
 
 void WindowManager::invalidate_after_theme_or_font_change()
 {
+    dbgln("!!!! invalidate_after_theme_or_font_change");
     Compositor::the().set_background_color(m_config->read_entry("Background", "Color", palette().desktop_background().to_string()));
     WindowFrame::reload_config();
     for_each_window_stack([&](auto& window_stack) {


### PR DESCRIPTION
Still work in progress...

https://user-images.githubusercontent.com/10320822/161440279-d50432ba-ba6c-4802-b0aa-1e895b9e19e8.mp4

Known issues:

- [ ] Support fading for tiled backgrounds
- `Painter::draw_scaled_bitmap` produces artifacts unless background is cleared, we currently hide this bug here: https://github.com/SerenityOS/serenity/blob/fd821213191f78a897dcacef40e8658737e9526e/Userland/Services/WindowServer/Compositor.cpp#L306 This PR no longer does this call. Can sometimes be seen when e.g. stretching the background and popping up the context menu
- Phantom `set_wallpaper` IPC calls are delivered randomly, causing phantom fade animations to happen. Looks like it's #11595 See around second 15 in the attached video