### PR TITLE
LibWeb: InlineFormattingContext don't break text lines if white-space: nowrap

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/InlineFormattingContext.cpp
@@ -252,7 +252,8 @@ void InlineFormattingContext::generate_line_boxes(LayoutMode layout_mode)
 
         case InlineLevelIterator::Item::Type::Text: {
             auto& text_node = verify_cast<Layout::TextNode>(*item.node);
-            if (line_builder.break_if_needed(layout_mode, item.border_box_width())) {
+
+            if (text_node.computed_values().white_space() != CSS::WhiteSpace::Nowrap && line_builder.break_if_needed(layout_mode, item.border_box_width())) {
                 // If whitespace caused us to break, we swallow the whitespace instead of
                 // putting it on the next line.
 


### PR DESCRIPTION
If white-space is nowrap then we don't want to break a text_node
into multiple line boxes. This fixes the width calculation in the
min-content case for white-space: nowrap elements. Before this
the min-width would be the width of the biggest line box.