### PR TITLE
LibWeb: Bring BorderRadiusStyleValue::to_string() closer to spec

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -292,6 +292,8 @@ String BorderStyleValue::to_string() const
 
 String BorderRadiusStyleValue::to_string() const
 {
+    if (m_horizontal_radius == m_vertical_radius)
+        return m_horizontal_radius.to_string();
     return String::formatted("{} / {}", m_horizontal_radius.to_string(), m_vertical_radius.to_string());
 }
 


### PR DESCRIPTION
This change is related to this section from the [spec](https://www.w3.org/TR/css-backgrounds-3/#border-radius)

> The two [<length-percentage>](https://www.w3.org/TR/css-values-4/#typedef-length-percentage) values of the [border-*-radius]() properties define the radii of a quarter ellipse that defines the shape of the corner of the outer border edge (see the diagram below). The first value is the horizontal radius, the second the vertical radius. If the second value is omitted it is copied from the first.

To be honest, this is the first time I'm messing with something like this so maybe the spec isn't really saying that this MUST be done this way, but omitting the second value is the behavior in the major browsers so I guess it's what should be done.