### PR TITLE
Shell: Refresh PATH cache after running shellrc files

### DIFF
--- a/Userland/Shell/Shell.h
+++ b/Userland/Shell/Shell.h
@@ -241,6 +241,7 @@ public:
 
     String get_history_path();
     void print_path(StringView path);
+    void cache_path();
 
     bool read_single_line();
 
@@ -343,7 +344,6 @@ private:
     void bring_cursor_to_beginning_of_a_line() const;
 
     Optional<int> resolve_job_spec(StringView);
-    void cache_path();
     void add_entry_to_cache(String const&);
     void remove_entry_from_cache(StringView);
     void stop_all_jobs();

--- a/Userland/Shell/main.cpp
+++ b/Userland/Shell/main.cpp
@@ -225,6 +225,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         };
         run_rc_file(Shell::Shell::global_init_file_path);
         run_rc_file(Shell::Shell::local_init_file_path);
+        shell->cache_path();
     }
 
     {


### PR DESCRIPTION
Fixes #13485 

(Maybe this can be improved further, ie: only refresh cache if PATH actually changed)