### PR TITLE
Kernel: Fix aarch64 kernel build on case sensitive file systems

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -404,7 +404,7 @@ else()
         Arch/aarch64/UART.cpp
         Arch/aarch64/Utils.cpp
 
-        Arch/aarch64/Dummy.cpp
+        Arch/aarch64/dummy.cpp
 
         # Preload specific
         Arch/aarch64/init.cpp


### PR DESCRIPTION
The dummy file has the wrong case, so it would fail to be found on case
sensitive file systems.

The memory manager also got refactored, VirtualRangeAllocator was
removed and RegionTree was added.