### PR TITLE
Kernel: Add RegionTree and remove VirtualRangeAllocator from aarch64

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -434,11 +434,11 @@ else()
         Memory/MemoryManager.cpp
         Memory/PrivateInodeVMObject.cpp
         Memory/Region.cpp
+        Memory/RegionTree.cpp
         Memory/RingBuffer.cpp
         Memory/SharedInodeVMObject.cpp
         Memory/ScatterGatherList.cpp
         Memory/VirtualRange.cpp
-        Memory/VirtualRangeAllocator.cpp
         Memory/VMObject.cpp
     )
 


### PR DESCRIPTION
Fixes aarch64 build