### PR TITLE
LibCore: Add ability to hide ArgsParser opt.s from specific usage texts

### DIFF
--- a/Base/usr/share/man/man1/UserspaceEmulator.md
+++ b/Base/usr/share/man/man1/UserspaceEmulator.md
@@ -10,9 +10,6 @@ $ UserspaceEmulator [--report-to-debug] [--pause] [--profile] [--profile-interva
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `--report-to-debug`: Write reports to the debug log
 * `-p`, `--pause`: Pause on startup
 * `--profile`: Generate a ProfileViewer-compatible profile

--- a/Base/usr/share/man/man1/config.md
+++ b/Base/usr/share/man/man1/config.md
@@ -14,9 +14,6 @@ Show or modify values in the configuration files through ConfigServer.
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-r`, `--remove`: Remove key
 
 ## Arguments:

--- a/Base/usr/share/man/man1/fortune.md
+++ b/Base/usr/share/man/man1/fortune.md
@@ -12,9 +12,6 @@ $ fortune [path]
 
 Open a fortune cookie, receive a free quote for the day!
 
-## Options:
-
-
 ## Arguments:
 
 * `path`: Path to JSON file with quotes (/res/fortunes.json by default)

--- a/Base/usr/share/man/man1/fortune.md
+++ b/Base/usr/share/man/man1/fortune.md
@@ -14,9 +14,6 @@ Open a fortune cookie, receive a free quote for the day!
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 
 ## Arguments:
 

--- a/Base/usr/share/man/man1/grep.md
+++ b/Base/usr/share/man/man1/grep.md
@@ -10,9 +10,6 @@ $ grep [--recursive] [--extended-regexp] [--regexp Pattern] [-i] [--line-numbers
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-r`, `--recursive`: Recursively scan files
 * `-E`, `--extended-regexp`: Extended regular expressions
 * `-e Pattern`, `--regexp Pattern`: Pattern

--- a/Base/usr/share/man/man1/gunzip.md
+++ b/Base/usr/share/man/man1/gunzip.md
@@ -10,9 +10,6 @@ $ gunzip [--keep] [--stdout] <FILE...>
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-k`, `--keep`: Keep (don't delete) input files
 * `-c`, `--stdout`: Write to stdout, keep original files unchanged
 

--- a/Base/usr/share/man/man1/gzip.md
+++ b/Base/usr/share/man/man1/gzip.md
@@ -10,9 +10,6 @@ $ gzip [--keep] [--stdout] [--decompress] <FILES...>
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-k`, `--keep`: Keep (don't delete) input files
 * `-c`, `--stdout`: Write to stdout, keep original files unchanged
 * `-d`, `--decompress`: Decompress

--- a/Base/usr/share/man/man1/ifconfig.md
+++ b/Base/usr/share/man/man1/ifconfig.md
@@ -14,9 +14,6 @@ Display or modify the configuration of each network interface.
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-i ip`, `--ipv4 ip`: Set the IP address of the selected network
 * `-a adapter`, `--adapter adapter`: Select a specific network adapter to configure
 * `-g gateway`, `--gateway gateway`: Set the default gateway of the selected network

--- a/Base/usr/share/man/man1/lsof.md
+++ b/Base/usr/share/man/man1/lsof.md
@@ -14,9 +14,6 @@ List open files of a processes. This can mean actual files in the file system, s
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-p pid`: Select by PID
 * `-d fd`: Select by file descriptor
 * `-u login/UID`: Select by login/UID

--- a/Base/usr/share/man/man1/nc.md
+++ b/Base/usr/share/man/man1/nc.md
@@ -14,9 +14,6 @@ Network cat: Connect to network sockets as if it were a file.
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-l`, `--listen`: Listen instead of connecting
 * `-v`, `--verbose`: Log everything that's happening
 * `-u`, `--udp`: UDP mode

--- a/Base/usr/share/man/man1/netstat.md
+++ b/Base/usr/share/man/man1/netstat.md
@@ -14,9 +14,6 @@ Display network connections
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-a`, `--all`: Display both listening and non-listening sockets
 * `-l`, `--list`: Display only listening sockets
 * `-t`, `--tcp`: Display only TCP network connections

--- a/Base/usr/share/man/man1/nl.md
+++ b/Base/usr/share/man/man1/nl.md
@@ -10,9 +10,6 @@ $ nl [--body-numbering style] [--increment number] [--separator string] [--start
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-b style`, `--body-numbering style`: Line numbering style: 't' for non-empty lines, 'a' for all lines, 'n' for no lines
 * `-i number`, `--increment number`: Line count increment
 * `-s string`, `--separator string`: Separator between line numbers and lines

--- a/Base/usr/share/man/man1/ntpquery.md
+++ b/Base/usr/share/man/man1/ntpquery.md
@@ -10,9 +10,6 @@ $ ntpquery [--adjust] [--set] [--verbose] [host]
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-a`, `--adjust`: Gradually adjust system time (requires root)
 * `-s`, `--set`: Immediately set system time (requires root)
 * `-v`, `--verbose`: Verbose output

--- a/Base/usr/share/man/man1/passwd.md
+++ b/Base/usr/share/man/man1/passwd.md
@@ -14,9 +14,6 @@ Modify an account password.
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-d`, `--delete`: Delete password
 * `-l`, `--lock`: Lock password
 * `-u`, `--unlock`: Unlock password

--- a/Base/usr/share/man/man1/profile.md
+++ b/Base/usr/share/man/man1/profile.md
@@ -10,9 +10,6 @@ $ profile [-p PID] [-a] [-e] [-d] [-f] [-w] [-c command] [-t event_type]
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-p PID`: Target PID
 * `-a`: Profile all processes (super-user only), result at /proc/profile
 * `-e`: Enable

--- a/Base/usr/share/man/man1/readelf.md
+++ b/Base/usr/share/man/man1/readelf.md
@@ -10,9 +10,6 @@ $ readelf [--all] [--file-header] [--program-headers] [--section-headers] [--hea
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-a`, `--all`: Display all
 * `-h`, `--file-header`: Display ELF header
 * `-l`, `--program-headers`: Display program headers

--- a/Base/usr/share/man/man1/shot.md
+++ b/Base/usr/share/man/man1/shot.md
@@ -10,9 +10,6 @@ $ shot [--clipboard] [--delay seconds] [--screen index] [--region] [output]
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-c`, `--clipboard`: Output to clipboard
 * `-d seconds`, `--delay seconds`: Seconds to wait before taking a screenshot
 * `-s index`, `--screen index`: The index of the screen (default: -1 for all screens)

--- a/Base/usr/share/man/man1/sql.md
+++ b/Base/usr/share/man/man1/sql.md
@@ -14,9 +14,6 @@ This is a client for the SerenitySQL database server.
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-d database`, `--database database`: Database to connect to
 * `-r file`, `--read file`: File to read
 * `-s file`, `--source file`: File to source

--- a/Base/usr/share/man/man1/strace.md
+++ b/Base/usr/share/man/man1/strace.md
@@ -14,9 +14,6 @@ Trace all syscalls and their result.
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-p pid`, `--pid pid`: Trace the given PID
 * `-o output`, `--output output`: Filename to write output to
 * `-e exclude`, `--exclude exclude`: Comma-delimited syscalls to exclude

--- a/Base/usr/share/man/man1/tail.md
+++ b/Base/usr/share/man/man1/tail.md
@@ -14,9 +14,6 @@ Print the end ('tail') of a file.
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-f`, `--follow`: Output data as it is written to the file
 * `-n number`, `--lines number`: Fetch the specified number of lines
 

--- a/Base/usr/share/man/man1/tr.md
+++ b/Base/usr/share/man/man1/tr.md
@@ -10,9 +10,6 @@ $ tr [--complement] [--delete] [--squeeze-repeats] <from> [to]
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-c`, `--complement`: Take the complement of the first set
 * `-d`, `--delete`: Delete characters instead of replacing
 * `-s`, `--squeeze-repeats`: Omit repeated characters listed in the last given set from the output

--- a/Base/usr/share/man/man1/traceroute.md
+++ b/Base/usr/share/man/man1/traceroute.md
@@ -10,9 +10,6 @@ $ traceroute [--max-hops hops] [--max-retries tries] [--timeout seconds] <destin
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-h hops`, `--max-hops hops`: use at most <hops> to the destination
 * `-r tries`, `--max-retries tries`: retry TTL at most <tries> times
 * `-t seconds`, `--timeout seconds`: wait at most <seconds> for a response

--- a/Base/usr/share/man/man1/tree.md
+++ b/Base/usr/share/man/man1/tree.md
@@ -10,9 +10,6 @@ $ tree [--all] [--only-directories] [--maximum-depth level] [directories...]
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-a`, `--all`: Show hidden files
 * `-d`, `--only-directories`: Show only directories
 * `-L level`, `--maximum-depth level`: Maximum depth of the tree

--- a/Base/usr/share/man/man1/truncate.md
+++ b/Base/usr/share/man/man1/truncate.md
@@ -10,9 +10,6 @@ $ truncate [--size size] [--reference file] <file>
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-s size`, `--size size`: Resize the target file to (or by) this size. Prefix with + or - to expand or shrink the file, or a bare number to set the size exactly
 * `-r file`, `--reference file`: Resize the target file to match the size of this one
 

--- a/Base/usr/share/man/man1/utmpupdate.md
+++ b/Base/usr/share/man/man1/utmpupdate.md
@@ -10,9 +10,6 @@ $ utmpupdate [--create] [--delete] [--PID PID] [--from From] <tty>
 
 ## Options:
 
-* `--help`: Display help message and exit
-* `--version`: Print version
-* `--complete`: Perform autocompletion
 * `-c`, `--create`: Create entry
 * `-d`, `--delete`: Delete entry
 * `-p PID`, `--PID PID`: PID

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -299,10 +299,21 @@ void ArgsParser::print_usage_markdown(FILE* file, char const* argv0)
         outln(file, "\n## Description\n\n{}", m_general_help);
     }
 
-    if (!m_options.is_empty())
+    auto should_display_option = [](Option& opt) {
+        return !(opt.hide_mode == OptionHideMode::Markdown || opt.hide_mode == OptionHideMode::CommandLineAndMarkdown);
+    };
+
+    size_t options_to_display = 0;
+    for (auto& opt : m_options) {
+        if (!should_display_option(opt))
+            continue;
+        options_to_display++;
+    }
+
+    if (options_to_display > 0)
         outln(file, "\n## Options:\n");
     for (auto& opt : m_options) {
-        if (opt.hide_mode == OptionHideMode::Markdown || opt.hide_mode == OptionHideMode::CommandLineAndMarkdown)
+        if (!should_display_option(opt))
             continue;
 
         auto print_argument = [&]() {

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -30,6 +30,14 @@ public:
         Ignore,
     };
 
+    /// When an option is hidden.
+    /// If the hide mode is not None, then it's always hidden from the usage/synopsis.
+    enum class OptionHideMode {
+        None,
+        Markdown,
+        CommandLineAndMarkdown,
+    };
+
     struct Option {
         bool requires_argument { true };
         char const* help_string { nullptr };
@@ -37,7 +45,7 @@ public:
         char short_name { 0 };
         char const* value_name { nullptr };
         Function<bool(char const*)> accept_value;
-        bool hide_from_help_and_autocomplete { false };
+        OptionHideMode hide_mode { OptionHideMode::None };
 
         String name_for_display() const
         {
@@ -70,17 +78,17 @@ public:
     void print_version(FILE*);
 
     void add_option(Option&&);
-    void add_ignored(char const* long_name, char short_name, bool hidden = false);
-    void add_option(bool& value, char const* help_string, char const* long_name, char short_name, bool hidden = false);
-    void add_option(char const*& value, char const* help_string, char const* long_name, char short_name, char const* value_name, bool hidden = false);
-    void add_option(String& value, char const* help_string, char const* long_name, char short_name, char const* value_name, bool hidden = false);
-    void add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name, bool hidden = false);
-    void add_option(int& value, char const* help_string, char const* long_name, char short_name, char const* value_name, bool hidden = false);
-    void add_option(unsigned& value, char const* help_string, char const* long_name, char short_name, char const* value_name, bool hidden = false);
-    void add_option(double& value, char const* help_string, char const* long_name, char short_name, char const* value_name, bool hidden = false);
-    void add_option(Optional<double>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, bool hidden = false);
-    void add_option(Optional<size_t>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, bool hidden = false);
-    void add_option(Vector<size_t>& values, char const* help_string, char const* long_name, char short_name, char const* value_name, char separator = ',', bool hidden = false);
+    void add_ignored(char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(bool& value, char const* help_string, char const* long_name, char short_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(char const*& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(String& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(StringView& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(int& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(unsigned& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(double& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(Optional<double>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(Optional<size_t>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
+    void add_option(Vector<size_t>& values, char const* help_string, char const* long_name, char short_name, char const* value_name, char separator = ',', OptionHideMode hide_mode = OptionHideMode::None);
 
     void add_positional_argument(Arg&&);
     void add_positional_argument(char const*& value, char const* help_string, char const* name, Required required = Required::Yes);


### PR DESCRIPTION
This adds the ability to hide certain options from certain help texts.
`--complete` is always hidden, whereas `--help` and `--version` are
hidden from Markdown help text only.
Note that in all cases these three options are hidden from the short
usage line.

![](https://cdn.discordapp.com/attachments/830739873119207426/960314780957155338/unknown.png)