### PR TITLE
LibWeb: Use correct global object in legacy factory functions

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/AudioConstructor.cpp
@@ -38,7 +38,7 @@ JS::ThrowCompletionOr<JS::Value> AudioConstructor::call()
 JS::ThrowCompletionOr<JS::Object*> AudioConstructor::construct(FunctionObject&)
 {
     // 1. Let document be the current global object's associated Document.
-    auto& window = static_cast<WindowObject&>(global_object());
+    auto& window = static_cast<WindowObject&>(HTML::current_global_object());
     auto& document = window.impl().associated_document();
 
     // 2. Let audio be the result of creating an element given document, audio, and the HTML namespace.

--- a/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/ImageConstructor.cpp
@@ -38,7 +38,7 @@ JS::ThrowCompletionOr<JS::Value> ImageConstructor::call()
 JS::ThrowCompletionOr<JS::Object*> ImageConstructor::construct(FunctionObject&)
 {
     // 1. Let document be the current global object's associated Document.
-    auto& window = static_cast<WindowObject&>(global_object());
+    auto& window = static_cast<WindowObject&>(HTML::current_global_object());
     auto& document = window.impl().associated_document();
 
     // 2. Let img be the result of creating an element given document, img, and the HTML namespace.


### PR DESCRIPTION
In my previous pull request, it was noticed (https://github.com/SerenityOS/serenity/pull/13499#discussion_r841661008) that the previously implemented legacy factory functions are using the incorrect global object, this pull request should change them to use the correct one.