### PR TITLE
Ports/fontconfig: Don't build documentation

### DIFF
--- a/Ports/fontconfig/package.sh
+++ b/Ports/fontconfig/package.sh
@@ -6,7 +6,7 @@ use_fresh_config_sub="true"
 depends=("libxml2" "freetype")
 files="https://www.freedesktop.org/software/fontconfig/release/fontconfig-${version}.tar.xz fontconfig-${version}.tar.xz a5f052cb73fd479ffb7b697980510903b563bbb55b8f7a2b001fcfb94026003c"
 auth_type="sha256"
-configopts=("--prefix=/usr/local" "--enable-libxml2" "LDFLAGS=-ldl -lxml2")
+configopts=("--prefix=/usr/local" "--enable-libxml2" "--disable-docs" "LDFLAGS=-ldl -lxml2")
 
 export CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2"
 export LIBXML2_CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/libxml2/"


### PR DESCRIPTION
On my system the compilation stopped work since it couldn't build the
docs, but we don't need them anyway, since we don't support traditional
`man`.