### PR TITLE
Kernel: Print out assertion info in __assertion_failed on aarch64

### DIFF
--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -93,8 +93,21 @@ void __stack_chk_fail()
     Prekernel::halt();
 }
 
-[[noreturn]] void __assertion_failed(char const*, char const*, unsigned int, char const*)
+[[noreturn]] void __assertion_failed(char const* msg, char const* file, unsigned line, char const* func)
 {
+    auto& uart = Prekernel::UART::the();
+
+    uart.print_str("\r\n\r\nASSERTION FAILED: ");
+    uart.print_str(msg);
+
+    uart.print_str("\r\n");
+    uart.print_str(file);
+    uart.print_str(":");
+    uart.print_num(line);
+
+    uart.print_str(" in ");
+    uart.print_str(func);
+
     Prekernel::halt();
 }
 


### PR DESCRIPTION
Failed assertions will now be printed to the UART on aarch64 in the following way:

```
Assertion failed in kernel
Msg: false
File: ./Kernel/Arch/aarch64/init.cpp:52 void init()
```

This is intended to avoid using Format/Kprintf which themselves have a bunch of dependencies that we have not yet moved to aarch64.