### PR TITLE
Arm64/mark processor fns not reachable

### DIFF
--- a/Kernel/Arch/aarch64/CrashHandler.cpp
+++ b/Kernel/Arch/aarch64/CrashHandler.cpp
@@ -13,6 +13,7 @@ namespace Kernel {
 
 void handle_crash(Kernel::RegisterState const&, char const*, int, bool)
 {
+    VERIFY_NOT_REACHED();
 }
 
 }

--- a/Kernel/Arch/aarch64/PageDirectory.cpp
+++ b/Kernel/Arch/aarch64/PageDirectory.cpp
@@ -11,23 +11,28 @@ namespace Kernel::Memory {
 
 void PageDirectory::register_page_directory(PageDirectory*)
 {
+    VERIFY_NOT_REACHED();
 }
 
 void PageDirectory::deregister_page_directory(PageDirectory*)
 {
+    VERIFY_NOT_REACHED();
 }
 
 RefPtr<PageDirectory> PageDirectory::find_current()
 {
+    VERIFY_NOT_REACHED();
     return nullptr;
 }
 
 void activate_kernel_page_directory(PageDirectory const&)
 {
+    VERIFY_NOT_REACHED();
 }
 
 void activate_page_directory(PageDirectory const&, Thread*)
 {
+    VERIFY_NOT_REACHED();
 }
 
 }

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -32,36 +32,63 @@ struct [[gnu::aligned(16)]] FPUState
 
 class Processor {
 public:
-    void set_specific(ProcessorSpecificDataID /*specific_id*/, void* /*ptr*/) { }
+    void set_specific(ProcessorSpecificDataID /*specific_id*/, void* /*ptr*/)
+    {
+        VERIFY_NOT_REACHED();
+    }
     template<typename T>
-    T* get_specific() { return 0; }
+    T* get_specific()
+    {
+        VERIFY_NOT_REACHED();
+        return 0;
+    }
 
-    ALWAYS_INLINE static void pause() { }
-    ALWAYS_INLINE static void wait_check() { }
+    ALWAYS_INLINE static void pause()
+    {
+        VERIFY_NOT_REACHED();
+    }
+    ALWAYS_INLINE static void wait_check()
+    {
+        VERIFY_NOT_REACHED();
+    }
 
-    ALWAYS_INLINE u8 physical_address_bit_width() const { return 0; }
-    ALWAYS_INLINE u8 virtual_address_bit_width() const { return 0; }
+    ALWAYS_INLINE u8 physical_address_bit_width() const
+    {
+        VERIFY_NOT_REACHED();
+        return 0;
+    }
+
+    ALWAYS_INLINE u8 virtual_address_bit_width() const
+    {
+        VERIFY_NOT_REACHED();
+        return 0;
+    }
 
     ALWAYS_INLINE static bool is_initialized()
     {
+        VERIFY_NOT_REACHED();
         return false;
     }
 
     ALWAYS_INLINE static void flush_tlb_local(VirtualAddress&, size_t&)
     {
+        VERIFY_NOT_REACHED();
     }
 
     ALWAYS_INLINE static void flush_tlb(Memory::PageDirectory const*, VirtualAddress const&, size_t)
     {
+        VERIFY_NOT_REACHED();
     }
 
     ALWAYS_INLINE static u32 current_id()
     {
+        VERIFY_NOT_REACHED();
         return 0;
     }
 
     ALWAYS_INLINE static Thread* current_thread()
     {
+        VERIFY_NOT_REACHED();
         return 0;
     }
 
@@ -77,26 +104,36 @@ public:
 
     ALWAYS_INLINE static FlatPtr current_in_irq()
     {
+        VERIFY_NOT_REACHED();
         return 0;
     }
 
-    ALWAYS_INLINE static u64 read_cpu_counter() { return 0; }
+    ALWAYS_INLINE static u64 read_cpu_counter()
+    {
+        VERIFY_NOT_REACHED();
+        return 0;
+    }
 
-    ALWAYS_INLINE static void enter_critical() { }
-    ALWAYS_INLINE static void leave_critical() { }
+    ALWAYS_INLINE static void enter_critical() { VERIFY_NOT_REACHED(); }
+    ALWAYS_INLINE static void leave_critical() { VERIFY_NOT_REACHED(); }
     ALWAYS_INLINE static u32 in_critical()
     {
+        VERIFY_NOT_REACHED();
         return 0;
     }
 
     ALWAYS_INLINE static Thread* idle_thread()
     {
+        VERIFY_NOT_REACHED();
         return nullptr;
     }
 
     ALWAYS_INLINE static Processor& current() { VERIFY_NOT_REACHED(); }
 
-    static void deferred_call_queue(Function<void()> /* callback */) { }
+    static void deferred_call_queue(Function<void()> /* callback */)
+    {
+        VERIFY_NOT_REACHED();
+    }
 
     [[noreturn]] static void halt()
     {

--- a/Kernel/Arch/aarch64/ScopedCritical.cpp
+++ b/Kernel/Arch/aarch64/ScopedCritical.cpp
@@ -15,15 +15,23 @@ ScopedCritical::~ScopedCritical() = default;
 
 ScopedCritical::ScopedCritical(ScopedCritical&& /*from*/)
 {
+    VERIFY_NOT_REACHED();
 }
 
 ScopedCritical& ScopedCritical::operator=(ScopedCritical&& /*from*/)
 {
+    VERIFY_NOT_REACHED();
     return *this;
 }
 
-void ScopedCritical::leave() { }
+void ScopedCritical::leave()
+{
+    VERIFY_NOT_REACHED();
+}
 
-void ScopedCritical::enter() { }
+void ScopedCritical::enter()
+{
+    VERIFY_NOT_REACHED();
+}
 
 }

--- a/Kernel/Arch/aarch64/Spinlock.h
+++ b/Kernel/Arch/aarch64/Spinlock.h
@@ -24,20 +24,24 @@ public:
 
     ALWAYS_INLINE u32 lock()
     {
+        VERIFY_NOT_REACHED();
         return 0;
     }
 
     ALWAYS_INLINE void unlock(u32 /*prev_flags*/)
     {
+        VERIFY_NOT_REACHED();
     }
 
     [[nodiscard]] ALWAYS_INLINE bool is_locked() const
     {
+        VERIFY_NOT_REACHED();
         return false;
     }
 
     ALWAYS_INLINE void initialize()
     {
+        VERIFY_NOT_REACHED();
     }
 };
 
@@ -49,29 +53,35 @@ public:
     RecursiveSpinlock(LockRank rank = LockRank::None)
     {
         (void)rank;
+        VERIFY_NOT_REACHED();
     }
 
     ALWAYS_INLINE u32 lock()
     {
+        VERIFY_NOT_REACHED();
         return 0;
     }
 
     ALWAYS_INLINE void unlock(u32 /*prev_flags*/)
     {
+        VERIFY_NOT_REACHED();
     }
 
     [[nodiscard]] ALWAYS_INLINE bool is_locked() const
     {
+        VERIFY_NOT_REACHED();
         return false;
     }
 
     [[nodiscard]] ALWAYS_INLINE bool is_locked_by_current_processor() const
     {
+        VERIFY_NOT_REACHED();
         return false;
     }
 
     ALWAYS_INLINE void initialize()
     {
+        VERIFY_NOT_REACHED();
     }
 };
 

--- a/Kernel/Arch/aarch64/dummy.cpp
+++ b/Kernel/Arch/aarch64/dummy.cpp
@@ -43,7 +43,10 @@ void __panic(char const*, unsigned int, char const*)
 // Random
 namespace Kernel {
 
-void get_fast_random_bytes(Bytes) { }
+void get_fast_random_bytes(Bytes)
+{
+    VERIFY_NOT_REACHED();
+}
 
 }
 
@@ -54,20 +57,24 @@ static Singleton<SpinlockProtected<Inode::AllInstancesList>> s_all_instances;
 
 SpinlockProtected<Inode::AllInstancesList>& Inode::all_instances()
 {
+    VERIFY_NOT_REACHED();
     return s_all_instances;
 }
 
 RefPtr<Memory::SharedInodeVMObject> Inode::shared_vmobject() const
 {
+    VERIFY_NOT_REACHED();
     return RefPtr<Memory::SharedInodeVMObject>(nullptr);
 }
 
 void Inode::will_be_destroyed()
 {
+    VERIFY_NOT_REACHED();
 }
 
 ErrorOr<void> Inode::set_shared_vmobject(Memory::SharedInodeVMObject&)
 {
+    VERIFY_NOT_REACHED();
     return {};
 }
 
@@ -78,11 +85,13 @@ namespace Kernel {
 
 ErrorOr<void> UserOrKernelBuffer::write(void const*, size_t, size_t)
 {
+    VERIFY_NOT_REACHED();
     return {};
 }
 
 ErrorOr<void> UserOrKernelBuffer::read(void*, size_t, size_t) const
 {
+    VERIFY_NOT_REACHED();
     return {};
 }
 
@@ -127,37 +136,83 @@ bool g_kernel_symbols_available = false;
 
 namespace Kernel {
 
-void dump_backtrace(PrintToScreen) { }
+void dump_backtrace(PrintToScreen)
+{
+    VERIFY_NOT_REACHED();
+}
 
 // KString.cpp
-ErrorOr<NonnullOwnPtr<KString>> KString::try_create_uninitialized(size_t, char*&) { return ENOMEM; }
-ErrorOr<NonnullOwnPtr<KString>> KString::try_create(StringView) { return ENOMEM; }
-void KString::operator delete(void*) { }
+ErrorOr<NonnullOwnPtr<KString>> KString::try_create_uninitialized(size_t, char*&)
+{
+    VERIFY_NOT_REACHED();
+    return ENOMEM;
+}
+ErrorOr<NonnullOwnPtr<KString>> KString::try_create(StringView)
+{
+    VERIFY_NOT_REACHED();
+    return ENOMEM;
+}
+void KString::operator delete(void*)
+{
+    VERIFY_NOT_REACHED();
+}
 
 // SafeMem.h
 bool safe_memset(void*, int, size_t, void*&);
-bool safe_memset(void*, int, size_t, void*&) { return false; }
+bool safe_memset(void*, int, size_t, void*&)
+{
+    VERIFY_NOT_REACHED();
+    return false;
+}
 
 ssize_t safe_strnlen(char const*, unsigned long, void*&);
-ssize_t safe_strnlen(char const*, unsigned long, void*&) { return 0; }
+ssize_t safe_strnlen(char const*, unsigned long, void*&)
+{
+    VERIFY_NOT_REACHED();
+    return 0;
+}
 
 bool safe_memcpy(void*, void const*, unsigned long, void*&);
-bool safe_memcpy(void*, void const*, unsigned long, void*&) { return false; }
+bool safe_memcpy(void*, void const*, unsigned long, void*&)
+{
+    VERIFY_NOT_REACHED();
+    return false;
+}
 
 Optional<bool> safe_atomic_compare_exchange_relaxed(u32 volatile*, u32&, u32);
-Optional<bool> safe_atomic_compare_exchange_relaxed(u32 volatile*, u32&, u32) { return {}; }
+Optional<bool> safe_atomic_compare_exchange_relaxed(u32 volatile*, u32&, u32)
+{
+    VERIFY_NOT_REACHED();
+    return {};
+}
 
 Optional<u32> safe_atomic_load_relaxed(u32 volatile*);
-Optional<u32> safe_atomic_load_relaxed(u32 volatile*) { return {}; }
+Optional<u32> safe_atomic_load_relaxed(u32 volatile*)
+{
+    VERIFY_NOT_REACHED();
+    return {};
+}
 
 Optional<u32> safe_atomic_fetch_add_relaxed(u32 volatile*, u32);
-Optional<u32> safe_atomic_fetch_add_relaxed(u32 volatile*, u32) { return {}; }
+Optional<u32> safe_atomic_fetch_add_relaxed(u32 volatile*, u32)
+{
+    VERIFY_NOT_REACHED();
+    return {};
+}
 
 Optional<u32> safe_atomic_exchange_relaxed(u32 volatile*, u32);
-Optional<u32> safe_atomic_exchange_relaxed(u32 volatile*, u32) { return {}; }
+Optional<u32> safe_atomic_exchange_relaxed(u32 volatile*, u32)
+{
+    VERIFY_NOT_REACHED();
+    return {};
+}
 
 bool safe_atomic_store_relaxed(u32 volatile*, u32);
-bool safe_atomic_store_relaxed(u32 volatile*, u32) { return {}; }
+bool safe_atomic_store_relaxed(u32 volatile*, u32)
+{
+    VERIFY_NOT_REACHED();
+    return {};
+}
 
 }
 
@@ -166,11 +221,20 @@ extern "C" {
 FlatPtr kernel_mapping_base;
 
 void kernelputstr(char const*, size_t);
-void kernelputstr(char const*, size_t) { }
+void kernelputstr(char const*, size_t)
+{
+    VERIFY_NOT_REACHED();
+}
 
 void kernelcriticalputstr(char const*, size_t);
-void kernelcriticalputstr(char const*, size_t) { }
+void kernelcriticalputstr(char const*, size_t)
+{
+    VERIFY_NOT_REACHED();
+}
 
 void kernelearlyputstr(char const*, size_t);
-void kernelearlyputstr(char const*, size_t) { }
+void kernelearlyputstr(char const*, size_t)
+{
+    VERIFY_NOT_REACHED();
+}
 }

--- a/Kernel/Arch/aarch64/dummy.cpp
+++ b/Kernel/Arch/aarch64/dummy.cpp
@@ -18,11 +18,6 @@
 #include <Kernel/Sections.h>
 #include <Kernel/UserOrKernelBuffer.h>
 
-// This is a temporary file to get a non-empty Kernel binary on aarch64.
-// The prekernel currently never jumps to the kernel. This is dead code.
-void dummy();
-void dummy() { }
-
 // Scheduler
 namespace Kernel {
 


### PR DESCRIPTION
Once https://github.com/SerenityOS/serenity/pull/13512 has landed, assertions will print useful info the the UART.

This PR builds on that by adding `VERIFY_NOT_REACHED` to all the stubed functionality. Triggering a kernel halt + error message when any are hit (and thus informing the developer what needs implementing next!)