### PR TITLE
LibWeb: Make default text-decoration-thickness a fraction of font height

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -25,7 +25,7 @@ public:
     static CSS::TextJustify text_justify() { return CSS::TextJustify::Auto; }
     static CSS::Position position() { return CSS::Position::Static; }
     static CSS::TextDecorationLine text_decoration_line() { return CSS::TextDecorationLine::None; }
-    static CSS::Length text_decoration_thickness() { return Length::make_px(1); }
+    static CSS::Length text_decoration_thickness() { return Length::make_auto(); }
     static CSS::TextDecorationStyle text_decoration_style() { return CSS::TextDecorationStyle::Solid; }
     static CSS::TextTransform text_transform() { return CSS::TextTransform::None; }
     static CSS::Display display() { return CSS::Display { CSS::Display::Outside::Inline, CSS::Display::Inside::Flow }; }

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -324,7 +324,7 @@ static void paint_text_decoration(Gfx::Painter& painter, Layout::Node const& tex
     int line_thickness = [&] {
         CSS::Length computed_thickness = text_node.computed_values().text_decoration_thickness().resolved(text_node, CSS::Length(1, CSS::Length::Type::Em));
         if (computed_thickness.is_auto())
-            return CSS::InitialValues::text_decoration_thickness().to_px(text_node);
+            return max(glyph_height * 0.1f, 1.f);
 
         return computed_thickness.to_px(text_node);
     }();


### PR DESCRIPTION
Previously the default was always 1px, which didn’t look great on higher font sizes.

This changes the default thickness to one-tenth to the font height. The one-tenth part was chosen arbitrarily, but I think it does the job pretty well. :^)

master |  this pr
---|---
![](https://user-images.githubusercontent.com/16520278/161635334-1c35958e-24e6-461d-b312-b9729e5ef3c8.png) | ![](https://user-images.githubusercontent.com/16520278/161635326-e5c2706f-2e3c-4f4c-91e8-aa0176f18a7e.png)
