### PR TITLE
LibJS: Even MOAR BC fixes 

### DIFF
--- a/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
+++ b/Userland/Libraries/LibJS/Bytecode/ASTCodegen.cpp
@@ -54,7 +54,7 @@ Bytecode::CodeGenerationErrorOr<void> ScopeNode::generate_bytecode(Bytecode::Gen
                 auto const& name = function_declaration.name();
                 auto index = generator.intern_identifier(name);
                 generator.emit<Bytecode::Op::NewFunction>(function_declaration);
-                generator.emit<Bytecode::Op::SetVariable>(index, Bytecode::Op::SetVariable::InitializationMode::Initialize);
+                generator.emit<Bytecode::Op::SetVariable>(index, Bytecode::Op::SetVariable::InitializationMode::InitializeOrSet);
             }
 
             return {};

--- a/Userland/Libraries/LibJS/Heap/Handle.h
+++ b/Userland/Libraries/LibJS/Heap/Handle.h
@@ -95,8 +95,8 @@ public:
 
     auto cell() { return m_handle.cell(); }
     auto cell() const { return m_handle.cell(); }
-    auto value() const { return m_value; }
-    bool is_null() const { return m_handle.is_null(); }
+    auto value() const { return *m_value; }
+    bool is_null() const { return m_handle.is_null() && !m_value.has_value(); }
 
 private:
     explicit Handle(Value value)
@@ -110,7 +110,7 @@ private:
     {
     }
 
-    Value m_value;
+    Optional<Value> m_value;
     Handle<Cell> m_handle;
 };
 

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1050,7 +1050,11 @@ static bool parse_and_run(JS::Interpreter& interpreter, StringView source, Strin
 
             if (s_run_bytecode) {
                 JS::Bytecode::Interpreter bytecode_interpreter(interpreter.global_object(), interpreter.realm());
-                result = bytecode_interpreter.run(*executable);
+                auto result_or_error = bytecode_interpreter.run_and_return_frame(*executable, nullptr);
+                if (result_or_error.value.is_error())
+                    result = result_or_error.value.release_error();
+                else
+                    result = result_or_error.frame->registers[0];
             } else {
                 return ReturnEarly::Yes;
             }


### PR DESCRIPTION
- make the REPL _P_rint again
- no infinite loop on `throw 42`
- allow redefining functions
- switch statements have a lexical env, give them one