### PR TITLE
Utilities: Small fixes in arp command

### DIFF
--- a/Userland/Utilities/arp.cpp
+++ b/Userland/Utilities/arp.cpp
@@ -25,7 +25,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath tty"));
+    TRY(Core::System::pledge("stdio rpath tty inet"));
     TRY(Core::System::unveil("/proc/net/arp", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 


### PR DESCRIPTION
**Utilities: Pledge inet in arp command**
Previously the arp command would crash when trying to set/delete from
the table.

**Utilities: Update arp to use newer APIs**
Updates the arp command to use Core::System for the socket and
ioctl calls.
Updates command line arguments to StringView.
