### PR TITLE
WebContent: Use ConsoleGlobalObject for the console's global object :^)

### DIFF
--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -35,7 +35,7 @@ WebContentConsoleClient::WebContentConsoleClient(JS::Console& console, WeakPtr<J
     console_global_object->initialize_global_object();
     vm.pop_execution_context();
 
-    m_console_global_object = JS::make_handle(console_global_object);
+    m_interpreter->realm().set_global_object(*console_global_object);
 }
 
 void WebContentConsoleClient::handle_input(String const& js_source)

--- a/Userland/Services/WebContent/WebContentConsoleClient.h
+++ b/Userland/Services/WebContent/WebContentConsoleClient.h
@@ -29,7 +29,6 @@ private:
 
     ConnectionFromClient& m_client;
     WeakPtr<JS::Interpreter> m_interpreter;
-    JS::Handle<ConsoleGlobalObject> m_console_global_object;
 
     void clear_output();
     void print_html(String const& line);


### PR DESCRIPTION
Seems like this got missed when ESOs were implemented. Now we can use
`$0` again!