### PR TITLE
LibWeb: Add basic constructor/prototype to exotic objects

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/LocationConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationConstructor.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/LocationConstructor.h>
+#include <LibWeb/Bindings/LocationPrototype.h>
+#include <LibWeb/Bindings/WindowObject.h>
+
+namespace Web::Bindings {
+
+LocationConstructor::LocationConstructor(JS::GlobalObject& global_object)
+    : NativeFunction(*global_object.function_prototype())
+{
+}
+
+LocationConstructor::~LocationConstructor() = default;
+
+JS::ThrowCompletionOr<JS::Value> LocationConstructor::call()
+{
+    return vm().throw_completion<JS::TypeError>(global_object(), JS::ErrorType::ConstructorWithoutNew, "Location");
+}
+
+JS::ThrowCompletionOr<JS::Object*> LocationConstructor::construct(FunctionObject&)
+{
+    return vm().throw_completion<JS::TypeError>(global_object(), JS::ErrorType::NotAConstructor, "Location");
+}
+
+void LocationConstructor::initialize(JS::GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    auto& window = static_cast<WindowObject&>(global_object);
+
+    NativeFunction::initialize(global_object);
+    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<LocationPrototype>("Location"), 0);
+    define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/LocationConstructor.h
+++ b/Userland/Libraries/LibWeb/Bindings/LocationConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace Web::Bindings {
+
+class LocationConstructor : public JS::NativeFunction {
+    JS_OBJECT(LocationConstructor, JS::NativeFunction);
+
+public:
+    explicit LocationConstructor(JS::GlobalObject&);
+    virtual void initialize(JS::GlobalObject&) override;
+    virtual ~LocationConstructor() override;
+
+    virtual JS::ThrowCompletionOr<JS::Value> call() override;
+    virtual JS::ThrowCompletionOr<JS::Object*> construct(JS::FunctionObject& new_target) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/LocationObject.cpp
@@ -14,6 +14,7 @@
 #include <LibWeb/Bindings/CrossOriginAbstractOperations.h>
 #include <LibWeb/Bindings/DOMExceptionWrapper.h>
 #include <LibWeb/Bindings/LocationObject.h>
+#include <LibWeb/Bindings/LocationPrototype.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/DOM/DOMException.h>
 #include <LibWeb/DOM/Document.h>
@@ -23,7 +24,7 @@ namespace Web::Bindings {
 
 // https://html.spec.whatwg.org/multipage/history.html#the-location-interface
 LocationObject::LocationObject(JS::GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : Object(static_cast<WindowObject&>(global_object).ensure_web_prototype<LocationPrototype>("Location"))
     , m_default_properties(heap())
 {
 }

--- a/Userland/Libraries/LibWeb/Bindings/LocationPrototype.h
+++ b/Userland/Libraries/LibWeb/Bindings/LocationPrototype.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::Bindings {
+
+class LocationPrototype final : public JS::Object {
+    JS_OBJECT(LocationPrototype, JS::Object);
+
+public:
+    explicit LocationPrototype(JS::GlobalObject& global_object)
+        : JS::Object(*global_object.object_prototype())
+    {
+    }
+};
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorConstructor.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/NavigatorConstructor.h>
+#include <LibWeb/Bindings/NavigatorPrototype.h>
+#include <LibWeb/Bindings/WindowObject.h>
+
+namespace Web::Bindings {
+
+NavigatorConstructor::NavigatorConstructor(JS::GlobalObject& global_object)
+    : NativeFunction(*global_object.function_prototype())
+{
+}
+
+NavigatorConstructor::~NavigatorConstructor() = default;
+
+JS::ThrowCompletionOr<JS::Value> NavigatorConstructor::call()
+{
+    return vm().throw_completion<JS::TypeError>(global_object(), JS::ErrorType::ConstructorWithoutNew, "Navigator");
+}
+
+JS::ThrowCompletionOr<JS::Object*> NavigatorConstructor::construct(FunctionObject&)
+{
+    return vm().throw_completion<JS::TypeError>(global_object(), JS::ErrorType::NotAConstructor, "Navigator");
+}
+
+void NavigatorConstructor::initialize(JS::GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    auto& window = static_cast<WindowObject&>(global_object);
+
+    NativeFunction::initialize(global_object);
+    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<NavigatorPrototype>("Navigator"), 0);
+    define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorConstructor.h
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace Web::Bindings {
+
+class NavigatorConstructor : public JS::NativeFunction {
+    JS_OBJECT(NavigatorConstructor, JS::NativeFunction);
+
+public:
+    explicit NavigatorConstructor(JS::GlobalObject&);
+    virtual void initialize(JS::GlobalObject&) override;
+    virtual ~NavigatorConstructor() override;
+
+    virtual JS::ThrowCompletionOr<JS::Value> call() override;
+    virtual JS::ThrowCompletionOr<JS::Object*> construct(JS::FunctionObject& new_target) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorObject.cpp
@@ -7,13 +7,14 @@
 #include <LibJS/Runtime/Array.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibWeb/Bindings/NavigatorObject.h>
+#include <LibWeb/Bindings/NavigatorPrototype.h>
 #include <LibWeb/Loader/ResourceLoader.h>
 
 namespace Web {
 namespace Bindings {
 
 NavigatorObject::NavigatorObject(JS::GlobalObject& global_object)
-    : Object(*global_object.object_prototype())
+    : Object(static_cast<WindowObject&>(global_object).ensure_web_prototype<NavigatorPrototype>("Navigator"))
 {
 }
 

--- a/Userland/Libraries/LibWeb/Bindings/NavigatorPrototype.h
+++ b/Userland/Libraries/LibWeb/Bindings/NavigatorPrototype.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::Bindings {
+
+class NavigatorPrototype final : public JS::Object {
+    JS_OBJECT(NavigatorPrototype, JS::Object);
+
+public:
+    explicit NavigatorPrototype(JS::GlobalObject& global_object)
+        : JS::Object(*global_object.object_prototype())
+    {
+    }
+};
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/WindowConstructor.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowConstructor.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibWeb/Bindings/WindowConstructor.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/Bindings/WindowPrototype.h>
+
+namespace Web::Bindings {
+
+WindowConstructor::WindowConstructor(JS::GlobalObject& global_object)
+    : NativeFunction(*global_object.function_prototype())
+{
+}
+
+WindowConstructor::~WindowConstructor() = default;
+
+JS::ThrowCompletionOr<JS::Value> WindowConstructor::call()
+{
+    return vm().throw_completion<JS::TypeError>(global_object(), JS::ErrorType::ConstructorWithoutNew, "Window");
+}
+
+JS::ThrowCompletionOr<JS::Object*> WindowConstructor::construct(FunctionObject&)
+{
+    return vm().throw_completion<JS::TypeError>(global_object(), JS::ErrorType::NotAConstructor, "Window");
+}
+
+void WindowConstructor::initialize(JS::GlobalObject& global_object)
+{
+    auto& vm = this->vm();
+    auto& window = static_cast<WindowObject&>(global_object);
+
+    NativeFunction::initialize(global_object);
+    define_direct_property(vm.names.prototype, &window.ensure_web_prototype<WindowPrototype>("Window"), 0);
+    define_direct_property(vm.names.length, JS::Value(0), JS::Attribute::Configurable);
+}
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/WindowConstructor.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowConstructor.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/NativeFunction.h>
+
+namespace Web::Bindings {
+
+class WindowConstructor : public JS::NativeFunction {
+    JS_OBJECT(WindowConstructor, JS::NativeFunction);
+
+public:
+    explicit WindowConstructor(JS::GlobalObject&);
+    virtual void initialize(JS::GlobalObject&) override;
+    virtual ~WindowConstructor() override;
+
+    virtual JS::ThrowCompletionOr<JS::Value> call() override;
+    virtual JS::ThrowCompletionOr<JS::Object*> construct(JS::FunctionObject& new_target) override;
+
+private:
+    virtual bool has_constructor() const override { return true; }
+};
+
+}

--- a/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObject.cpp
@@ -35,6 +35,7 @@
 #include <LibWeb/Bindings/StorageWrapper.h>
 #include <LibWeb/Bindings/WindowObject.h>
 #include <LibWeb/Bindings/WindowObjectHelper.h>
+#include <LibWeb/Bindings/WindowPrototype.h>
 #include <LibWeb/Crypto/Crypto.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
@@ -59,7 +60,7 @@ void WindowObject::initialize_global_object()
 {
     Base::initialize_global_object();
 
-    Object::set_prototype(&ensure_web_prototype<EventTargetPrototype>("EventTarget"));
+    Object::set_prototype(&ensure_web_prototype<WindowPrototype>("Window"));
 
     // FIXME: These should be native accessors, not properties
     define_direct_property("window", this, JS::Attribute::Enumerable);

--- a/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
@@ -228,6 +228,8 @@
 #include <LibWeb/Bindings/IntersectionObserverPrototype.h>
 #include <LibWeb/Bindings/KeyboardEventConstructor.h>
 #include <LibWeb/Bindings/KeyboardEventPrototype.h>
+#include <LibWeb/Bindings/LocationConstructor.h>
+#include <LibWeb/Bindings/LocationPrototype.h>
 #include <LibWeb/Bindings/MediaQueryListConstructor.h>
 #include <LibWeb/Bindings/MediaQueryListEventConstructor.h>
 #include <LibWeb/Bindings/MediaQueryListEventPrototype.h>
@@ -238,6 +240,8 @@
 #include <LibWeb/Bindings/MessageEventPrototype.h>
 #include <LibWeb/Bindings/MouseEventConstructor.h>
 #include <LibWeb/Bindings/MouseEventPrototype.h>
+#include <LibWeb/Bindings/NavigatorConstructor.h>
+#include <LibWeb/Bindings/NavigatorPrototype.h>
 #include <LibWeb/Bindings/NodeConstructor.h>
 #include <LibWeb/Bindings/NodeIteratorConstructor.h>
 #include <LibWeb/Bindings/NodeIteratorPrototype.h>
@@ -321,6 +325,8 @@
 #include <LibWeb/Bindings/URLSearchParamsPrototype.h>
 #include <LibWeb/Bindings/WebSocketConstructor.h>
 #include <LibWeb/Bindings/WebSocketPrototype.h>
+#include <LibWeb/Bindings/WindowConstructor.h>
+#include <LibWeb/Bindings/WindowPrototype.h>
 #include <LibWeb/Bindings/WorkerConstructor.h>
 #include <LibWeb/Bindings/WorkerPrototype.h>
 #include <LibWeb/Bindings/XMLHttpRequestConstructor.h>
@@ -449,11 +455,13 @@
     ADD_WINDOW_OBJECT_INTERFACE(ImageData)                                                          \
     ADD_WINDOW_OBJECT_INTERFACE(IntersectionObserver)                                               \
     ADD_WINDOW_OBJECT_INTERFACE(KeyboardEvent)                                                      \
+    ADD_WINDOW_OBJECT_INTERFACE(Location)                                                           \
     ADD_WINDOW_OBJECT_INTERFACE(MediaQueryList)                                                     \
     ADD_WINDOW_OBJECT_INTERFACE(MediaQueryListEvent)                                                \
     ADD_WINDOW_OBJECT_INTERFACE(MessageChannel)                                                     \
     ADD_WINDOW_OBJECT_INTERFACE(MessageEvent)                                                       \
     ADD_WINDOW_OBJECT_INTERFACE(MouseEvent)                                                         \
+    ADD_WINDOW_OBJECT_INTERFACE(Navigator)                                                          \
     ADD_WINDOW_OBJECT_INTERFACE(Node)                                                               \
     ADD_WINDOW_OBJECT_INTERFACE(NodeIterator)                                                       \
     ADD_WINDOW_OBJECT_INTERFACE(NodeList)                                                           \
@@ -498,6 +506,7 @@
     ADD_WINDOW_OBJECT_INTERFACE(Worker)                                                             \
     ADD_WINDOW_OBJECT_INTERFACE(XMLHttpRequest)                                                     \
     ADD_WINDOW_OBJECT_INTERFACE(XMLHttpRequestEventTarget)                                          \
+    ADD_WINDOW_OBJECT_INTERFACE(Window)                                                             \
     ADD_WINDOW_OBJECT_CONSTRUCTOR_AND_PROTOTYPE(Audio, AudioConstructor, HTMLAudioElementPrototype) \
     ADD_WINDOW_OBJECT_CONSTRUCTOR_AND_PROTOTYPE(Image, ImageConstructor, HTMLImageElementPrototype) \
     ADD_WINDOW_OBJECT_CONSTRUCTOR_AND_PROTOTYPE(Option, OptionConstructor, HTMLOptionElementPrototype)

--- a/Userland/Libraries/LibWeb/Bindings/WindowPrototype.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowPrototype.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibJS/Runtime/GlobalObject.h>
+#include <LibJS/Runtime/Object.h>
+#include <LibJS/Runtime/VM.h>
+#include <LibWeb/Bindings/EventTargetPrototype.h>
+#include <LibWeb/Bindings/WindowObject.h>
+#include <LibWeb/Forward.h>
+
+namespace Web::Bindings {
+
+class WindowPrototype final : public JS::Object {
+    JS_OBJECT(WindowPrototype, JS::Object);
+
+public:
+    explicit WindowPrototype(JS::GlobalObject& global_object)
+        : JS::Object(static_cast<WindowObject&>(global_object).ensure_web_prototype<EventTargetPrototype>("EventTarget"))
+    {
+    }
+};
+
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -9,11 +9,14 @@ set(SOURCES
     Bindings/EventWrapperFactory.cpp
     Bindings/IDLAbstractOperations.cpp
     Bindings/ImageConstructor.cpp
+    Bindings/LocationConstructor.cpp
     Bindings/LocationObject.cpp
     Bindings/MainThreadVM.cpp
+    Bindings/NavigatorConstructor.cpp
     Bindings/NavigatorObject.cpp
     Bindings/NodeWrapperFactory.cpp
     Bindings/OptionConstructor.cpp
+    Bindings/WindowConstructor.cpp
     Bindings/WindowObject.cpp
     Bindings/WindowProxy.cpp
     Bindings/Wrappable.cpp


### PR DESCRIPTION
The aim of this pull request is just to add a basic constructor and prototype to the currently implemented exotic objects.

This should fix things like:
```js
Object.getPrototypeOf(window.location).__intern___ = 0
```
which would leak to all objects before this change, and:
```js
window.Window.prototype.__intern___ = 0
```
which wouldn't work simply because `window.Window` didn't exist before.