### PR TITLE
InspectorServer: Defer removal of InspectableProcess from table

### DIFF
--- a/Userland/Services/InspectorServer/InspectableProcess.cpp
+++ b/Userland/Services/InspectorServer/InspectableProcess.cpp
@@ -6,6 +6,7 @@
 
 #include "InspectableProcess.h"
 #include <AK/JsonObject.h>
+#include <LibCore/EventLoop.h>
 
 namespace InspectorServer {
 
@@ -27,7 +28,7 @@ InspectableProcess::InspectableProcess(pid_t pid, NonnullOwnPtr<Core::Stream::Lo
         char c;
         [[maybe_unused]] auto buffer = m_socket->read({ &c, 1 });
         if (m_socket->is_eof()) {
-            g_processes.remove(m_pid);
+            Core::deferred_invoke([pid = this->m_pid] { g_processes.remove(pid); });
             return;
         }
     };


### PR DESCRIPTION
This prevents a crash when the inspected process closes the socket (i.e.
when the app is exited). This crash was caused by the InspectableProcess
removing itself from the global process table within a callback Function
that is stored as part of the InspectableProcess.