### PR TITLE
Userland: Allow all apps to connect to InspectorServer optionally

### DIFF
--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -59,13 +59,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio recvfd sendfd unix cpath rpath wpath proc exec"));
 
+    auto app = TRY(GUI::Application::try_create(arguments));
+
     char const* specified_url = nullptr;
 
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(specified_url, "URL to open", "url", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
-
-    auto app = GUI::Application::construct(arguments);
 
     Config::pledge_domain("Browser");
     Config::monitor_domain("Browser");

--- a/Userland/Applications/CharacterMap/main.cpp
+++ b/Userland/Applications/CharacterMap/main.cpp
@@ -48,12 +48,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/CharacterMap.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio recvfd sendfd rpath"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     String query;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_option(query, "Search character names using this query, and print them as a list.", "search", 's', "query");
     args_parser.parse(arguments);
 

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -140,6 +140,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool unlink_on_exit = false;
 
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.set_general_help("Show information from an application crash coredump.");
     args_parser.add_positional_argument(coredump_path, "Coredump path", "coredump-path");
     args_parser.add_option(unlink_on_exit, "Delete the coredump after its parsed", "unlink", 0);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -74,7 +74,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     act.sa_handler = SIG_IGN;
     TRY(Core::System::sigaction(SIGCHLD, &act, nullptr));
 
+    auto app = TRY(GUI::Application::try_create(arguments));
+
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     bool is_desktop_mode { false };
     bool is_selection_mode { false };
     bool ignore_path_resolution { false };
@@ -84,8 +87,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(ignore_path_resolution, "Use raw path, do not resolve real path", "raw", 'r');
     args_parser.add_positional_argument(initial_location, "Path to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
-
-    auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::pledge("stdio thread recvfd sendfd cpath rpath wpath fattr proc exec unix"));
 

--- a/Userland/Applications/FontEditor/main.cpp
+++ b/Userland/Applications/FontEditor/main.cpp
@@ -29,10 +29,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::seal_allowlist());
 
     Config::pledge_domain("FontEditor");
-    TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath"));
 
     char const* path = nullptr;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(path, "The font file for editing.", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -25,12 +25,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/usr/share/man", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
+    TRY(Core::System::unveil("/tmp/portal/inspectables", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     char const* start_page = nullptr;
     unsigned section = 0;
 
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     // FIXME: These custom Args are a hack. What we want to do is have an optional int arg, then an optional string.
     // However, when only a string is provided, it gets forwarded to the int argument since that is first, and
     // parsing fails. This hack instead forwards it to the start_page in that case.

--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -47,6 +47,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     char const* path = nullptr;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(path, "The image file to be displayed.", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -22,6 +22,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     StringView path;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(path, "Keyboard character mapping file.", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -18,14 +18,14 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    auto app = TRY(GUI::Application::try_create(arguments));
+
     StringView path;
     Core::ArgsParser args_parser;
     args_parser.add_positional_argument(path, "Keyboard character mapping file.", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
     TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd unix"));
-
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
 
     TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd"));
 

--- a/Userland/Applications/PDFViewer/main.cpp
+++ b/Userland/Applications/PDFViewer/main.cpp
@@ -18,12 +18,14 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    auto app = TRY(GUI::Application::try_create(arguments));
+
     char const* file_path = nullptr;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(file_path, "PDF file to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = GUI::Icon::default_icon("app-pdf-viewer");
 
     Config::pledge_domain("PDFViewer");

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -28,6 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     char const* image_file = nullptr;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(image_file, "Image file to open", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -28,11 +28,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread"));
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     char const* filename = nullptr;
 
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(filename, "File to read from", "file", Core::ArgsParser::Required::No);
 
     args_parser.parse(arguments);

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -331,7 +331,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio thread proc recvfd sendfd rpath exec unix"));
 
-    auto app = TRY(GUI::Application::try_create(arguments, Core::EventLoop::MakeInspectable::Yes));
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("SystemMonitor");
 
@@ -355,10 +355,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/bin/Profiler", "rx"));
     TRY(Core::System::unveil("/bin/Inspector", "rx"));
+    TRY(Core::System::unveil("/tmp/portal/inspectables", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     StringView args_tab = "processes"sv;
     Core::ArgsParser parser;
+    parser.add_inspector_server_connection_option();
     parser.add_option(args_tab, "Tab, one of 'processes', 'graphs', 'fs', 'hardware', or 'network'", "open-tab", 't', "tab");
     parser.parse(arguments);
     StringView args_tab_view = args_tab;

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -251,6 +251,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool keep_open = false;
 
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_option(command_to_execute, "Execute this command inside the terminal", nullptr, 'e', "command");
     args_parser.add_option(keep_open, "Keep the terminal open after the command has finished executing", nullptr, 'k');
 

--- a/Userland/Applications/TextEditor/main.cpp
+++ b/Userland/Applications/TextEditor/main.cpp
@@ -27,6 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     char const* preview_mode = "auto";
     char const* file_to_edit = nullptr;
     Core::ArgsParser parser;
+    parser.add_inspector_server_connection_option();
     parser.add_option(preview_mode, "Preview mode, one of 'none', 'html', 'markdown', 'auto'", "preview-mode", '\0', "mode");
     parser.add_positional_argument(file_to_edit, "File to edit, with optional starting line and column number", "file[:line[:column]]", Core::ArgsParser::Required::No);
     parser.parse(arguments);

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -161,11 +161,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix"));
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     char const* file_to_edit = nullptr;
 
     Core::ArgsParser parser;
+    parser.add_inspector_server_connection_option();
     parser.add_positional_argument(file_to_edit, "Theme file to edit", "file", Core::ArgsParser::Required::No);
     parser.parse(arguments);
 

--- a/Userland/Demos/Eyes/main.cpp
+++ b/Userland/Demos/Eyes/main.cpp
@@ -26,7 +26,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     int grid_rows = -1;
     int grid_columns = -1;
 
+    auto app = TRY(GUI::Application::try_create(arguments));
+
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_option(num_eyes, "Number of eyes", "num-eyes", 'n', "number");
     args_parser.add_option(max_in_row, "Maximum number of eyes in a row", "max-in-row", 'm', "number");
     args_parser.add_option(grid_rows, "Number of rows in grid (incompatible with --number)", "grid-rows", 'r', "number");
@@ -34,8 +37,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.parse(arguments);
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix cpath wpath thread"));
-
-    auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd tty rpath cpath wpath proc exec unix fattr thread ptrace"));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domains({ "HackStudio", "Terminal" });
 
     auto window = GUI::Window::construct();
@@ -54,6 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     char const* path_argument = nullptr;
     bool mode_coredump = false;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(path_argument, "Path to a workspace or a file", "path", Core::ArgsParser::Required::No);
     args_parser.add_option(mode_coredump, "Debug a coredump in HackStudio", "coredump", 'c');
     args_parser.parse(arguments);

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -70,10 +70,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Desktop::Launcher::add_allowed_handler_with_only_specific_urls("/bin/Help", { URL::create_with_file_protocol("/usr/share/man/man1/Playground.md") }));
     TRY(Desktop::Launcher::seal_allowlist());
 
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath"));
-
     char const* path = nullptr;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_positional_argument(path, "GML file to edit", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -45,9 +45,12 @@ static bool generate_profile(pid_t& pid);
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
+    auto app = TRY(GUI::Application::try_create(arguments));
+
     int pid = 0;
     char const* perfcore_file_arg = nullptr;
     Core::ArgsParser args_parser;
+    args_parser.add_inspector_server_connection_option();
     args_parser.add_option(pid, "PID to profile", "pid", 'p', "PID");
     args_parser.add_positional_argument(perfcore_file_arg, "Path of perfcore file", "perfcore-file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
@@ -57,7 +60,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    auto app = TRY(GUI::Application::try_create(arguments));
     auto app_icon = TRY(GUI::Icon::try_create_default_icon("app-profiler"));
 
     String perfcore_file;

--- a/Userland/Libraries/LibCore/ArgsParser.cpp
+++ b/Userland/Libraries/LibCore/ArgsParser.cpp
@@ -9,6 +9,7 @@
 #include <AK/Format.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/EventLoop.h>
 #include <LibCore/Version.h>
 #include <getopt.h>
 #include <limits.h>
@@ -558,6 +559,25 @@ void ArgsParser::add_option(Vector<size_t>& values, char const* help_string, cha
             return parsed_all_values;
         },
         hide_mode
+    };
+
+    add_option(move(option));
+}
+
+void ArgsParser::add_inspector_server_connection_option()
+{
+    Option option {
+        false,
+        "Make application inspectable",
+        "inspectable",
+        0,
+        nullptr,
+        [](char const* value) {
+            VERIFY(value == nullptr);
+            EventLoop::make_inspectable();
+            return true;
+        },
+        OptionHideMode::Markdown,
     };
 
     add_option(move(option));

--- a/Userland/Libraries/LibCore/ArgsParser.h
+++ b/Userland/Libraries/LibCore/ArgsParser.h
@@ -90,6 +90,8 @@ public:
     void add_option(Optional<size_t>& value, char const* help_string, char const* long_name, char short_name, char const* value_name, OptionHideMode hide_mode = OptionHideMode::None);
     void add_option(Vector<size_t>& values, char const* help_string, char const* long_name, char short_name, char const* value_name, char separator = ',', OptionHideMode hide_mode = OptionHideMode::None);
 
+    void add_inspector_server_connection_option();
+
     void add_positional_argument(Arg&&);
     void add_positional_argument(char const*& value, char const* help_string, char const* name, Required required = Required::Yes);
     void add_positional_argument(String& value, char const* help_string, char const* name, Required required = Required::Yes);

--- a/Userland/Libraries/LibCore/EventLoop.h
+++ b/Userland/Libraries/LibCore/EventLoop.h
@@ -44,6 +44,8 @@ public:
     ~EventLoop();
     static void initialize_wake_pipes();
 
+    static void make_inspectable();
+
     int exec();
 
     enum class WaitMode {


### PR DESCRIPTION
The new --inspectable option (strictly opt-in) for ArgsParser makes an app connect to InspectorServer if desired. This is to facilitate easier debugging with InspectorServer.

Note that some apps cause the InspectorServer to spin infinitely once the Inspector tries to inspect them. These are bugs not caused but exposed by this PR.