### PR TITLE
HackStudio: Disallow closing last open tab using the middle mouse button.

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -700,7 +700,9 @@ void HackStudioWidget::add_new_editor_tab_widget(GUI::Widget& parent)
 
     tab_widget->on_middle_click = [](auto& widget) {
         auto& wrapper = static_cast<EditorWrapper&>(widget);
-        wrapper.on_tab_close_request(wrapper);
+        if (static_cast<GUI::TabWidget*>(widget.parent())->close_button_enabled()) {
+            wrapper.on_tab_close_request(wrapper);
+        }
     };
 
     tab_widget->on_tab_close_click = [](auto& widget) {

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -81,6 +81,7 @@ public:
     bool is_bar_visible() const { return m_bar_visible; };
 
     void set_close_button_enabled(bool close_button_enabled) { m_close_button_enabled = close_button_enabled; };
+    bool close_button_enabled() const { return m_close_button_enabled; }
 
     void set_reorder_allowed(bool reorder_allowed) { m_reorder_allowed = reorder_allowed; }
     bool reorder_allowed() const { return m_reorder_allowed; }


### PR DESCRIPTION
It was previously possible to close all open tabs using the middle mouse button close shortcut. While this doesn't completely render the application useless, it is inconsistent with the disappearing of the close buttons on the tabs themselves.

There might be a better way to get the actual tab widget, I'm not sure as I'm pretty unfamiliar with the code.

Edit: Now I'm thinking about it, it might actually even be better to promote this behaviour to all LibGUI tabs, so it always closes (or tries to if there's a close button) when clicking on it with middle mouse button, as we'd probably don't want to introduce confusion by assigning a different action. Thoughts?