### PR TITLE
LibCore+RequestServer: Proxies of the sock variety

### DIFF
--- a/Userland/Applications/Browser/Browser.h
+++ b/Userland/Applications/Browser/Browser.h
@@ -14,6 +14,8 @@ namespace Browser {
 extern String g_home_url;
 extern String g_search_engine;
 extern Vector<String> g_content_filters;
+extern Vector<String> g_proxies;
+extern HashMap<String, size_t> g_proxy_mappings;
 extern bool g_content_filters_enabled;
 extern IconBag g_icon_bag;
 

--- a/Userland/Applications/Browser/BrowserWindow.h
+++ b/Userland/Applications/Browser/BrowserWindow.h
@@ -41,6 +41,7 @@ public:
     GUI::Action& inspect_dom_node_action() { return *m_inspect_dom_node_action; }
 
     void content_filters_changed();
+    void proxy_mappings_changed();
 
 private:
     explicit BrowserWindow(CookieJar&, URL);

--- a/Userland/Applications/Browser/DownloadWidget.cpp
+++ b/Userland/Applications/Browser/DownloadWidget.cpp
@@ -8,7 +8,7 @@
 #include "DownloadWidget.h"
 #include <AK/NumberFormat.h>
 #include <AK/StringBuilder.h>
-#include <LibConfig/Client.h>
+#include <LibCore/Proxy.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/Stream.h>
 #include <LibDesktop/Launcher.h>
@@ -20,8 +20,10 @@
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Progressbar.h>
 #include <LibGUI/Window.h>
-#include <LibProtocol/RequestClient.h>
 #include <LibWeb/Loader/ResourceLoader.h>
+
+#include <LibConfig/Client.h>
+#include <LibProtocol/RequestClient.h>
 
 namespace Browser {
 

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -118,6 +118,8 @@ Tab::Tab(BrowserWindow& window)
     else
         m_web_content_view->set_content_filters({});
 
+    m_web_content_view->set_proxy_mappings(g_proxies, g_proxy_mappings);
+
     auto& go_back_button = toolbar.add_action(window.go_back_action());
     go_back_button.on_context_menu_request = [this](auto& context_menu_event) {
         if (!m_history.can_go_back())
@@ -514,6 +516,11 @@ void Tab::content_filters_changed()
         m_web_content_view->set_content_filters(g_content_filters);
     else
         m_web_content_view->set_content_filters({});
+}
+
+void Tab::proxy_mappings_changed()
+{
+    m_web_content_view->set_proxy_mappings(g_proxies, g_proxy_mappings);
 }
 
 void Tab::action_entered(GUI::Action& action)

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -51,6 +51,7 @@ public:
     void did_become_active();
     void context_menu_requested(Gfx::IntPoint const& screen_position);
     void content_filters_changed();
+    void proxy_mappings_changed();
 
     void action_entered(GUI::Action&);
     void action_left(GUI::Action&);

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -31,6 +31,8 @@ String g_search_engine;
 String g_home_url;
 Vector<String> g_content_filters;
 bool g_content_filters_enabled { true };
+Vector<String> g_proxies;
+HashMap<String, size_t> g_proxy_mappings;
 IconBag g_icon_bag;
 
 }
@@ -95,6 +97,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     Browser::g_icon_bag = TRY(Browser::IconBag::try_create());
 
     TRY(load_content_filters());
+
+    for (auto& group : Config::list_groups("Browser")) {
+        if (!group.starts_with("Proxy:"))
+            continue;
+
+        for (auto& key : Config::list_keys("Browser", group)) {
+            auto proxy_spec = group.substring_view(6);
+            auto existing_proxy = Browser::g_proxies.find(proxy_spec);
+            if (existing_proxy.is_end())
+                Browser::g_proxies.append(proxy_spec);
+
+            Browser::g_proxy_mappings.set(key, existing_proxy.index());
+        }
+    }
 
     URL first_url = Browser::url_from_user_input(Browser::g_home_url);
     if (specified_url) {

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -26,6 +26,7 @@ set(SOURCES
     ProcessStatisticsReader.cpp
     Property.cpp
     SecretString.cpp
+    SOCKSProxyClient.cpp
     Stream.cpp
     StandardPaths.cpp
     System.cpp

--- a/Userland/Libraries/LibCore/Proxy.h
+++ b/Userland/Libraries/LibCore/Proxy.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Types.h>
+#include <LibIPC/Forward.h>
+
+namespace Core {
+// FIXME: Username/password support.
+struct ProxyData {
+    enum Type {
+        Direct,
+        SOCKS5,
+    } type { Type::Direct };
+
+    u32 host_ipv4 { 0 };
+    int port { 0 };
+
+    bool operator==(ProxyData const& other) const = default;
+};
+}
+
+namespace IPC {
+bool encode(Encoder&, Core::ProxyData const&);
+ErrorOr<void> decode(Decoder&, Core::ProxyData&);
+}

--- a/Userland/Libraries/LibCore/Proxy.h
+++ b/Userland/Libraries/LibCore/Proxy.h
@@ -7,7 +7,9 @@
 #pragma once
 
 #include <AK/Error.h>
+#include <AK/IPv4Address.h>
 #include <AK/Types.h>
+#include <AK/URL.h>
 #include <LibIPC/Forward.h>
 
 namespace Core {
@@ -22,6 +24,30 @@ struct ProxyData {
     int port { 0 };
 
     bool operator==(ProxyData const& other) const = default;
+
+    static ErrorOr<ProxyData> parse_url(URL const& url)
+    {
+        if (!url.is_valid())
+            return Error::from_string_literal("Invalid proxy URL");
+
+        ProxyData proxy_data;
+        if (url.scheme() != "socks5")
+            return Error::from_string_literal("Unsupported proxy type");
+
+        proxy_data.type = ProxyData::Type::SOCKS5;
+
+        auto host_ipv4 = IPv4Address::from_string(url.host());
+        if (!host_ipv4.has_value())
+            return Error::from_string_literal("Invalid proxy host, must be an IPv4 address");
+        proxy_data.host_ipv4 = host_ipv4->to_u32();
+
+        auto port = url.port();
+        if (!port.has_value())
+            return Error::from_string_literal("Invalid proxy, must have a port");
+        proxy_data.port = *port;
+
+        return proxy_data;
+    }
 };
 }
 

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/MemoryStream.h>
+#include <LibCore/SOCKSProxyClient.h>
+
+enum class Method : u8 {
+    NoAuth = 0x00,
+    GSSAPI = 0x01,
+    UsernamePassword = 0x02,
+    NoAcceptableMethods = 0xFF,
+};
+
+enum class AddressType : u8 {
+    IPV4 = 0x01,
+    DomainName = 0x03,
+    IPV6 = 0x04,
+};
+
+enum class Reply {
+    Succeeded = 0x00,
+    GeneralSocksServerFailure = 0x01,
+    ConnectionNotAllowedByRuleset = 0x02,
+    NetworkUnreachable = 0x03,
+    HostUnreachable = 0x04,
+    ConnectionRefused = 0x05,
+    TTLExpired = 0x06,
+    CommandNotSupported = 0x07,
+    AddressTypeNotSupported = 0x08,
+};
+
+struct [[gnu::packed]] Socks5VersionIdentifierAndMethodSelectionMessage {
+    u8 version_identifier;
+    u8 method_count;
+    // NOTE: We only send a single method, so we don't need to make this variable-length.
+    u8 methods[1];
+};
+
+struct [[gnu::packed]] Socks5InitialResponse {
+    u8 version_identifier;
+    u8 method;
+};
+
+struct [[gnu::packed]] Socks5ConnectRequestHeader {
+    u8 version_identifier;
+    u8 command;
+    u8 reserved;
+};
+
+struct [[gnu::packed]] Socks5ConnectRequestTrailer {
+    u16 port;
+};
+
+struct [[gnu::packed]] Socks5ConnectResponseHeader {
+    u8 version_identifier;
+    u8 status;
+    u8 reserved;
+};
+
+struct [[gnu::packed]] Socks5ConnectResponseTrailer {
+    u8 bind_port;
+};
+
+struct [[gnu::packed]] Socks5UsernamePasswordResponse {
+    u8 version_identifier;
+    u8 status;
+};
+
+namespace {
+StringView reply_response_name(Reply reply)
+{
+    switch (reply) {
+    case Reply::Succeeded:
+        return "Succeeded";
+    case Reply::GeneralSocksServerFailure:
+        return "GeneralSocksServerFailure";
+    case Reply::ConnectionNotAllowedByRuleset:
+        return "ConnectionNotAllowedByRuleset";
+    case Reply::NetworkUnreachable:
+        return "NetworkUnreachable";
+    case Reply::HostUnreachable:
+        return "HostUnreachable";
+    case Reply::ConnectionRefused:
+        return "ConnectionRefused";
+    case Reply::TTLExpired:
+        return "TTLExpired";
+    case Reply::CommandNotSupported:
+        return "CommandNotSupported";
+    case Reply::AddressTypeNotSupported:
+        return "AddressTypeNotSupported";
+    }
+    VERIFY_NOT_REACHED();
+}
+
+ErrorOr<void> send_version_identifier_and_method_selection_message(Core::Stream::Socket& socket, Core::SOCKSProxyClient::Version version, Method method)
+{
+    Socks5VersionIdentifierAndMethodSelectionMessage message {
+        .version_identifier = to_underlying(version),
+        .method_count = 1,
+        .methods = { to_underlying(method) },
+    };
+    auto size = TRY(socket.write({ &message, sizeof(message) }));
+    if (size != sizeof(message))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send version identifier and method selection message");
+
+    Socks5InitialResponse response;
+    size = TRY(socket.read({ &response, sizeof(response) }));
+    if (size != sizeof(response))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to receive initial response");
+
+    if (response.version_identifier != to_underlying(version))
+        return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
+
+    if (response.method != to_underlying(method))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to negotiate a method");
+
+    return {};
+}
+
+ErrorOr<Reply> send_connect_request_message(Core::Stream::Socket& socket, Core::SOCKSProxyClient::Version version, Core::SOCKSProxyClient::HostOrIPV4 target, int port, Core::SOCKSProxyClient::Command command)
+{
+    DuplexMemoryStream stream;
+
+    Socks5ConnectRequestHeader header {
+        .version_identifier = to_underlying(version),
+        .command = to_underlying(command),
+        .reserved = 0,
+    };
+    Socks5ConnectRequestTrailer trailer {
+        .port = htons(port),
+    };
+
+    auto size = stream.write({ &header, sizeof(header) });
+    if (size != sizeof(header))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send connect request header");
+
+    TRY(target.visit(
+        [&](String const& hostname) -> ErrorOr<void> {
+            u8 address_data[2];
+            address_data[0] = to_underlying(AddressType::DomainName);
+            address_data[1] = hostname.length();
+            auto size = stream.write({ address_data, sizeof(address_data) });
+            if (size != array_size(address_data))
+                return Error::from_string_literal("SOCKS negotiation failed: Failed to send connect request address data");
+            stream.write({ hostname.characters(), hostname.length() });
+            return {};
+        },
+        [&](u32 ipv4) -> ErrorOr<void> {
+            u8 address_data[5];
+            address_data[0] = to_underlying(AddressType::IPV4);
+            u32 network_ordered_ipv4 = NetworkOrdered<u32>(ipv4);
+            memcpy(address_data + 1, &network_ordered_ipv4, sizeof(network_ordered_ipv4));
+            auto size = stream.write({ address_data, sizeof(address_data) });
+            if (size != array_size(address_data))
+                return Error::from_string_literal("SOCKS negotiation failed: Failed to send connect request address data");
+            return {};
+        }));
+
+    size = stream.write({ &trailer, sizeof(trailer) });
+    if (size != sizeof(trailer))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send connect request trailer");
+
+    auto buffer = stream.copy_into_contiguous_buffer();
+    size = TRY(socket.write({ buffer.data(), buffer.size() }));
+    if (size != buffer.size())
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send connect request");
+
+    Socks5ConnectResponseHeader response_header;
+    size = TRY(socket.read({ &response_header, sizeof(response_header) }));
+    if (size != sizeof(response_header))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response header");
+
+    if (response_header.version_identifier != to_underlying(version))
+        return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
+
+    u8 response_address_type;
+    size = TRY(socket.read({ &response_address_type, sizeof(response_address_type) }));
+    if (size != sizeof(response_address_type))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response address type");
+
+    switch (AddressType(response_address_type)) {
+    case AddressType::IPV4: {
+        u8 response_address_data[4];
+        size = TRY(socket.read({ response_address_data, sizeof(response_address_data) }));
+        if (size != sizeof(response_address_data))
+            return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response address data");
+        break;
+    }
+    case AddressType::DomainName: {
+        u8 response_address_length;
+        size = TRY(socket.read({ &response_address_length, sizeof(response_address_length) }));
+        if (size != sizeof(response_address_length))
+            return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response address length");
+        ByteBuffer buffer;
+        buffer.resize(response_address_length);
+        size = TRY(socket.read(buffer));
+        if (size != response_address_length)
+            return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response address data");
+        break;
+    }
+    case AddressType::IPV6:
+    default:
+        return Error::from_string_literal("SOCKS negotiation failed: Invalid connect response address type");
+    }
+
+    u16 bound_port;
+    size = TRY(socket.read({ &bound_port, sizeof(bound_port) }));
+    if (size != sizeof(bound_port))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response bound port");
+
+    return Reply(response_header.status);
+}
+
+ErrorOr<u8> send_username_password_authentication_message(Core::Stream::Socket& socket, Core::SOCKSProxyClient::UsernamePasswordAuthenticationData const& auth_data)
+{
+    DuplexMemoryStream stream;
+
+    u8 version = 0x01;
+    auto size = stream.write({ &version, sizeof(version) });
+    if (size != sizeof(version))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send username/password authentication message");
+
+    u8 username_length = auth_data.username.length();
+    size = stream.write({ &username_length, sizeof(username_length) });
+    if (size != sizeof(username_length))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send username/password authentication message");
+
+    size = stream.write({ auth_data.username.characters(), auth_data.username.length() });
+    if (size != auth_data.username.length())
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send username/password authentication message");
+
+    u8 password_length = auth_data.password.length();
+    size = stream.write({ &password_length, sizeof(password_length) });
+    if (size != sizeof(password_length))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send username/password authentication message");
+
+    size = stream.write({ auth_data.password.characters(), auth_data.password.length() });
+    if (size != auth_data.password.length())
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send username/password authentication message");
+
+    auto buffer = stream.copy_into_contiguous_buffer();
+    size = TRY(socket.write(buffer));
+    if (size != buffer.size())
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to send username/password authentication message");
+
+    Socks5UsernamePasswordResponse response;
+    size = TRY(socket.read({ &response, sizeof(response) }));
+    if (size != sizeof(response))
+        return Error::from_string_literal("SOCKS negotiation failed: Failed to receive username/password authentication response");
+
+    if (response.version_identifier != version)
+        return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
+
+    return response.status;
+}
+}
+
+namespace Core {
+
+SOCKSProxyClient::~SOCKSProxyClient()
+{
+    close();
+    m_socket.on_ready_to_read = nullptr;
+}
+
+ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> SOCKSProxyClient::connect(Socket& underlying, Version version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data, Command command)
+{
+    if (version != Version::V5)
+        return Error::from_string_literal("SOCKS version not supported");
+
+    return auth_data.visit(
+        [&](Empty) -> ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> {
+            TRY(send_version_identifier_and_method_selection_message(underlying, version, Method::NoAuth));
+            auto reply = TRY(send_connect_request_message(underlying, version, target, target_port, command));
+            if (reply != Reply::Succeeded) {
+                underlying.close();
+                return Error::from_string_literal(reply_response_name(reply));
+            }
+
+            return adopt_nonnull_own_or_enomem(new SOCKSProxyClient {
+                underlying,
+                nullptr,
+            });
+        },
+        [&](UsernamePasswordAuthenticationData const& auth_data) -> ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> {
+            TRY(send_version_identifier_and_method_selection_message(underlying, version, Method::UsernamePassword));
+            auto auth_response = TRY(send_username_password_authentication_message(underlying, auth_data));
+            if (auth_response != 0) {
+                underlying.close();
+                return Error::from_string_literal("SOCKS authentication failed");
+            }
+
+            auto reply = TRY(send_connect_request_message(underlying, version, target, target_port, command));
+            if (reply != Reply::Succeeded) {
+                underlying.close();
+                return Error::from_string_literal(reply_response_name(reply));
+            }
+
+            return adopt_nonnull_own_or_enomem(new SOCKSProxyClient {
+                underlying,
+                nullptr,
+            });
+        });
+}
+
+ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> SOCKSProxyClient::connect(HostOrIPV4 const& server, int server_port, Version version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data, Command command)
+{
+    auto underlying = TRY(server.visit(
+        [&](u32 ipv4) {
+            return Core::Stream::TCPSocket::connect({ IPv4Address(ipv4), static_cast<u16>(server_port) });
+        },
+        [&](String const& hostname) {
+            return Core::Stream::TCPSocket::connect(hostname, static_cast<u16>(server_port));
+        }));
+
+    auto socket = TRY(connect(*underlying, version, target, target_port, auth_data, command));
+    socket->m_own_underlying_socket = move(underlying);
+    dbgln("SOCKS proxy connected, have {} available bytes", TRY(socket->m_socket.pending_bytes()));
+    return socket;
+}
+
+}

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.h
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/OwnPtr.h>
+#include <LibCore/Proxy.h>
+#include <LibCore/Stream.h>
+
+namespace Core {
+class SOCKSProxyClient final : public Stream::Socket {
+public:
+    enum class Version : u8 {
+        V4 = 0x04,
+        V5 = 0x05,
+    };
+
+    struct UsernamePasswordAuthenticationData {
+        String username;
+        String password;
+    };
+
+    enum class Command : u8 {
+        Connect = 0x01,
+        Bind = 0x02,
+        UDPAssociate = 0x03,
+    };
+
+    using HostOrIPV4 = Variant<String, u32>;
+
+    static ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> connect(Socket& underlying, Version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data = {}, Command = Command::Connect);
+    static ErrorOr<NonnullOwnPtr<SOCKSProxyClient>> connect(HostOrIPV4 const& server, int server_port, Version, HostOrIPV4 const& target, int target_port, Variant<UsernamePasswordAuthenticationData, Empty> const& auth_data = {}, Command = Command::Connect);
+
+    virtual ~SOCKSProxyClient() override;
+
+    // ^Stream::Stream
+    virtual ErrorOr<size_t> read(Bytes bytes) override { return m_socket.read(bytes); }
+    virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_socket.write(bytes); }
+    virtual bool is_eof() const override { return m_socket.is_eof(); }
+    virtual bool is_open() const override { return m_socket.is_open(); }
+    virtual void close() override { m_socket.close(); }
+
+    // ^Stream::Socket
+    virtual ErrorOr<size_t> pending_bytes() const override { return m_socket.pending_bytes(); }
+    virtual ErrorOr<bool> can_read_without_blocking(int timeout = 0) const override { return m_socket.can_read_without_blocking(timeout); }
+    virtual ErrorOr<void> set_blocking(bool enabled) override { return m_socket.set_blocking(enabled); }
+    virtual ErrorOr<void> set_close_on_exec(bool enabled) override { return m_socket.set_close_on_exec(enabled); }
+    virtual void set_notifications_enabled(bool enabled) override { m_socket.set_notifications_enabled(enabled); }
+
+private:
+    SOCKSProxyClient(Socket& socket, OwnPtr<Socket> own_socket)
+        : m_socket(socket)
+        , m_own_underlying_socket(move(own_socket))
+    {
+        m_socket.on_ready_to_read = [this] { on_ready_to_read(); };
+    }
+
+    Socket& m_socket;
+    OwnPtr<Socket> m_own_underlying_socket;
+};
+}

--- a/Userland/Libraries/LibIPC/Decoder.cpp
+++ b/Userland/Libraries/LibIPC/Decoder.cpp
@@ -8,6 +8,7 @@
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/DateTime.h>
+#include <LibCore/Proxy.h>
 #include <LibIPC/Decoder.h>
 #include <LibIPC/Dictionary.h>
 #include <LibIPC/File.h>
@@ -182,6 +183,16 @@ ErrorOr<void> decode(Decoder& decoder, Core::DateTime& datetime)
     i64 timestamp;
     TRY(decoder.decode(timestamp));
     datetime = Core::DateTime::from_timestamp(static_cast<time_t>(timestamp));
+    return {};
+}
+
+ErrorOr<void> decode(Decoder& decoder, Core::ProxyData& data)
+{
+    UnderlyingType<decltype(data.type)> type;
+    TRY(decoder.decode(type));
+    data.type = static_cast<Core::ProxyData::Type>(type);
+    TRY(decoder.decode(data.host_ipv4));
+    TRY(decoder.decode(data.port));
     return {};
 }
 

--- a/Userland/Libraries/LibIPC/Encoder.cpp
+++ b/Userland/Libraries/LibIPC/Encoder.cpp
@@ -11,6 +11,7 @@
 #include <AK/URL.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibCore/DateTime.h>
+#include <LibCore/Proxy.h>
 #include <LibIPC/Dictionary.h>
 #include <LibIPC/Encoder.h>
 #include <LibIPC/File.h>
@@ -200,6 +201,14 @@ bool encode(Encoder& encoder, Core::AnonymousBuffer const& buffer)
 bool encode(Encoder& encoder, Core::DateTime const& datetime)
 {
     encoder << static_cast<i64>(datetime.timestamp());
+    return true;
+}
+
+bool encode(Encoder& encoder, Core::ProxyData const& proxy)
+{
+    encoder << to_underlying(proxy.type);
+    encoder << proxy.host_ipv4;
+    encoder << proxy.port;
     return true;
 }
 

--- a/Userland/Libraries/LibProtocol/RequestClient.cpp
+++ b/Userland/Libraries/LibProtocol/RequestClient.cpp
@@ -21,7 +21,7 @@ void RequestClient::ensure_connection(URL const& url, ::RequestServer::CacheLeve
 }
 
 template<typename RequestHashMapTraits>
-RefPtr<Request> RequestClient::start_request(String const& method, URL const& url, HashMap<String, String, RequestHashMapTraits> const& request_headers, ReadonlyBytes request_body)
+RefPtr<Request> RequestClient::start_request(String const& method, URL const& url, HashMap<String, String, RequestHashMapTraits> const& request_headers, ReadonlyBytes request_body, Core::ProxyData const& proxy_data)
 {
     IPC::Dictionary header_dictionary;
     for (auto& it : request_headers)
@@ -31,7 +31,7 @@ RefPtr<Request> RequestClient::start_request(String const& method, URL const& ur
     if (body_result.is_error())
         return nullptr;
 
-    auto response = IPCProxy::start_request(method, url, header_dictionary, body_result.release_value());
+    auto response = IPCProxy::start_request(method, url, header_dictionary, body_result.release_value(), proxy_data);
     auto request_id = response.request_id();
     if (request_id < 0 || !response.response_fd().has_value())
         return nullptr;
@@ -91,5 +91,5 @@ void RequestClient::certificate_requested(i32 request_id)
 
 }
 
-template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, URL const&, HashMap<String, String> const& request_headers, ReadonlyBytes request_body);
-template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, URL const&, HashMap<String, String, CaseInsensitiveStringTraits> const& request_headers, ReadonlyBytes request_body);
+template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, URL const&, HashMap<String, String> const& request_headers, ReadonlyBytes request_body, Core::ProxyData const&);
+template RefPtr<Protocol::Request> Protocol::RequestClient::start_request(String const& method, URL const&, HashMap<String, String, CaseInsensitiveStringTraits> const& request_headers, ReadonlyBytes request_body, Core::ProxyData const&);

--- a/Userland/Libraries/LibProtocol/RequestClient.h
+++ b/Userland/Libraries/LibProtocol/RequestClient.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <AK/HashMap.h>
+// Need to include this before RequestClientEndpoint.h as that one includes LibIPC/(De En)coder.h, which would bomb if included before this.
+#include <LibCore/Proxy.h>
 #include <LibIPC/ConnectionToServer.h>
 #include <RequestServer/RequestClientEndpoint.h>
 #include <RequestServer/RequestServerEndpoint.h>
@@ -22,7 +24,7 @@ class RequestClient final
 
 public:
     template<typename RequestHashMapTraits = Traits<String>>
-    RefPtr<Request> start_request(String const& method, URL const&, HashMap<String, String, RequestHashMapTraits> const& request_headers = {}, ReadonlyBytes request_body = {});
+    RefPtr<Request> start_request(String const& method, URL const&, HashMap<String, String, RequestHashMapTraits> const& request_headers = {}, ReadonlyBytes request_body = {}, Core::ProxyData const& = {});
 
     void ensure_connection(URL const&, ::RequestServer::CacheLevel);
 

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -95,7 +95,7 @@ ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect(String const& host, u16 port, Opt
 
 ErrorOr<NonnullOwnPtr<TLSv12>> TLSv12::connect(String const& host, Core::Stream::Socket& underlying_stream, Options options)
 {
-    StreamVariantType socket { &underlying_stream };
+    TRY(underlying_stream.set_blocking(false));
     auto tls_socket = make<TLSv12>(&underlying_stream, move(options));
     tls_socket->set_sni(host);
     Core::EventLoop loop;

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -280,6 +280,7 @@ set(SOURCES
     Loader/ImageLoader.cpp
     Loader/ImageResource.cpp
     Loader/LoadRequest.cpp
+    Loader/ProxyMappings.cpp
     Loader/Resource.cpp
     Loader/ResourceLoader.cpp
     MimeSniff/MimeType.cpp

--- a/Userland/Libraries/LibWeb/Loader/ProxyMappings.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ProxyMappings.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "ProxyMappings.h"
+
+Web::ProxyMappings& Web::ProxyMappings::the()
+{
+    static ProxyMappings instance {};
+    return instance;
+}
+
+Core::ProxyData Web::ProxyMappings::proxy_for_url(AK::URL const& url) const
+{
+    auto url_string = url.to_string();
+    for (auto& it : m_mappings) {
+        dbgln("Checking {} against {}...", url, it.key);
+        if (url_string.matches(it.key)) {
+            dbgln("Matched!");
+            auto result = Core::ProxyData::parse_url(m_proxies[it.value]);
+            if (result.is_error()) {
+                dbgln("Failed to parse proxy URL: {}", m_proxies[it.value]);
+                continue;
+            }
+            return result.release_value();
+        }
+    }
+
+    dbgln("No luck!");
+    return {};
+}
+
+void Web::ProxyMappings::set_mappings(Vector<String> proxies, OrderedHashMap<String, size_t> mappings)
+{
+    m_proxies = move(proxies);
+    m_mappings = move(mappings);
+
+    dbgln("Proxy mappings updated: proxies: {}", m_proxies);
+}

--- a/Userland/Libraries/LibWeb/Loader/ProxyMappings.h
+++ b/Userland/Libraries/LibWeb/Loader/ProxyMappings.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Ali Mohammad Pur <mpfard@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/HashMap.h>
+#include <AK/URL.h>
+#include <AK/Vector.h>
+#include <LibCore/Proxy.h>
+
+namespace Web {
+
+class ProxyMappings {
+public:
+    static ProxyMappings& the();
+
+    Core::ProxyData proxy_for_url(AK::URL const&) const;
+    void set_mappings(Vector<String> proxies, OrderedHashMap<String, size_t> mappings);
+
+private:
+    ProxyMappings() = default;
+    ~ProxyMappings() = default;
+
+    Vector<String> m_proxies;
+    OrderedHashMap<String, size_t> m_mappings;
+};
+
+}

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.cpp
@@ -500,6 +500,11 @@ void OutOfProcessWebView::set_content_filters(Vector<String> filters)
     client().async_set_content_filters(filters);
 }
 
+void OutOfProcessWebView::set_proxy_mappings(Vector<String> proxies, HashMap<String, size_t> mappings)
+{
+    client().async_set_proxy_mappings(move(proxies), move(mappings));
+}
+
 void OutOfProcessWebView::set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme)
 {
     client().async_set_preferred_color_scheme(color_scheme);

--- a/Userland/Libraries/LibWeb/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWeb/OutOfProcessWebView.h
@@ -55,6 +55,7 @@ public:
     OrderedHashMap<String, String> get_local_storage_entries();
 
     void set_content_filters(Vector<String>);
+    void set_proxy_mappings(Vector<String> proxies, HashMap<String, size_t> mappings);
     void set_preferred_color_scheme(Web::CSS::PreferredColorScheme);
 
     Function<void(Gfx::IntPoint const& screen_position)> on_context_menu_request;

--- a/Userland/Services/RequestServer/ConnectionFromClient.cpp
+++ b/Userland/Services/RequestServer/ConnectionFromClient.cpp
@@ -6,6 +6,7 @@
 
 #include <AK/Badge.h>
 #include <AK/NonnullOwnPtr.h>
+#include <LibCore/Proxy.h>
 #include <RequestServer/ConnectionFromClient.h>
 #include <RequestServer/Protocol.h>
 #include <RequestServer/Request.h>
@@ -35,7 +36,7 @@ Messages::RequestServer::IsSupportedProtocolResponse ConnectionFromClient::is_su
     return supported;
 }
 
-Messages::RequestServer::StartRequestResponse ConnectionFromClient::start_request(String const& method, URL const& url, IPC::Dictionary const& request_headers, ByteBuffer const& request_body)
+Messages::RequestServer::StartRequestResponse ConnectionFromClient::start_request(String const& method, URL const& url, IPC::Dictionary const& request_headers, ByteBuffer const& request_body, Core::ProxyData const& proxy_data)
 {
     if (!url.is_valid()) {
         dbgln("StartRequest: Invalid URL requested: '{}'", url);
@@ -46,7 +47,7 @@ Messages::RequestServer::StartRequestResponse ConnectionFromClient::start_reques
         dbgln("StartRequest: No protocol handler for URL: '{}'", url);
         return { -1, Optional<IPC::File> {} };
     }
-    auto request = protocol->start_request(*this, method, url, request_headers.entries(), request_body);
+    auto request = protocol->start_request(*this, method, url, request_headers.entries(), request_body, proxy_data);
     if (!request) {
         dbgln("StartRequest: Protocol handler failed to start request: '{}'", url);
         return { -1, Optional<IPC::File> {} };

--- a/Userland/Services/RequestServer/ConnectionFromClient.h
+++ b/Userland/Services/RequestServer/ConnectionFromClient.h
@@ -7,6 +7,8 @@
 #pragma once
 
 #include <AK/HashMap.h>
+// Need to include this before RequestClientEndpoint.h as that one includes LibIPC/(De En)coder.h, which would bomb if included before this.
+#include <LibCore/Proxy.h>
 #include <LibIPC/ConnectionFromClient.h>
 #include <RequestServer/Forward.h>
 #include <RequestServer/RequestClientEndpoint.h>
@@ -32,7 +34,7 @@ private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
     virtual Messages::RequestServer::IsSupportedProtocolResponse is_supported_protocol(String const&) override;
-    virtual Messages::RequestServer::StartRequestResponse start_request(String const&, URL const&, IPC::Dictionary const&, ByteBuffer const&) override;
+    virtual Messages::RequestServer::StartRequestResponse start_request(String const&, URL const&, IPC::Dictionary const&, ByteBuffer const&, Core::ProxyData const&) override;
     virtual Messages::RequestServer::StopRequestResponse stop_request(i32) override;
     virtual Messages::RequestServer::SetCertificateResponse set_certificate(i32, String const&, String const&) override;
     virtual void ensure_connection(URL const& url, ::RequestServer::CacheLevel const& cache_level) override;

--- a/Userland/Services/RequestServer/GeminiProtocol.cpp
+++ b/Userland/Services/RequestServer/GeminiProtocol.cpp
@@ -17,7 +17,7 @@ GeminiProtocol::GeminiProtocol()
 {
 }
 
-OwnPtr<Request> GeminiProtocol::start_request(ConnectionFromClient& client, String const&, const URL& url, HashMap<String, String> const&, ReadonlyBytes)
+OwnPtr<Request> GeminiProtocol::start_request(ConnectionFromClient& client, String const&, const URL& url, HashMap<String, String> const&, ReadonlyBytes, Core::ProxyData proxy_data)
 {
     Gemini::GeminiRequest request;
     request.set_url(url);
@@ -31,7 +31,7 @@ OwnPtr<Request> GeminiProtocol::start_request(ConnectionFromClient& client, Stri
     auto protocol_request = GeminiRequest::create_with_job({}, client, *job, move(output_stream));
     protocol_request->set_request_fd(pipe_result.value().read_fd);
 
-    ConnectionCache::get_or_create_connection(ConnectionCache::g_tls_connection_cache, url, *job);
+    ConnectionCache::get_or_create_connection(ConnectionCache::g_tls_connection_cache, url, *job, proxy_data);
 
     return protocol_request;
 }

--- a/Userland/Services/RequestServer/GeminiProtocol.h
+++ b/Userland/Services/RequestServer/GeminiProtocol.h
@@ -15,7 +15,7 @@ public:
     GeminiProtocol();
     virtual ~GeminiProtocol() override = default;
 
-    virtual OwnPtr<Request> start_request(ConnectionFromClient&, String const& method, const URL&, HashMap<String, String> const&, ReadonlyBytes body) override;
+    virtual OwnPtr<Request> start_request(ConnectionFromClient&, String const& method, const URL&, HashMap<String, String> const&, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/HttpCommon.h
+++ b/Userland/Services/RequestServer/HttpCommon.h
@@ -61,7 +61,7 @@ void init(TSelf* self, TJob job)
 }
 
 template<typename TBadgedProtocol, typename TPipeResult>
-OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ConnectionFromClient& client, String const& method, const URL& url, HashMap<String, String> const& headers, ReadonlyBytes body, TPipeResult&& pipe_result)
+OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ConnectionFromClient& client, String const& method, const URL& url, HashMap<String, String> const& headers, ReadonlyBytes body, TPipeResult&& pipe_result, Core::ProxyData proxy_data = {})
 {
     using TJob = typename TBadgedProtocol::Type::JobType;
     using TRequest = typename TBadgedProtocol::Type::RequestType;
@@ -89,9 +89,9 @@ OwnPtr<Request> start_request(TBadgedProtocol&& protocol, ConnectionFromClient& 
     protocol_request->set_request_fd(pipe_result.value().read_fd);
 
     if constexpr (IsSame<typename TBadgedProtocol::Type, HttpsProtocol>)
-        ConnectionCache::get_or_create_connection(ConnectionCache::g_tls_connection_cache, url, *job);
+        ConnectionCache::get_or_create_connection(ConnectionCache::g_tls_connection_cache, url, *job, proxy_data);
     else
-        ConnectionCache::get_or_create_connection(ConnectionCache::g_tcp_connection_cache, url, *job);
+        ConnectionCache::get_or_create_connection(ConnectionCache::g_tcp_connection_cache, url, *job, proxy_data);
 
     return protocol_request;
 }

--- a/Userland/Services/RequestServer/HttpProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpProtocol.cpp
@@ -22,9 +22,9 @@ HttpProtocol::HttpProtocol()
 {
 }
 
-OwnPtr<Request> HttpProtocol::start_request(ConnectionFromClient& client, String const& method, const URL& url, HashMap<String, String> const& headers, ReadonlyBytes body)
+OwnPtr<Request> HttpProtocol::start_request(ConnectionFromClient& client, String const& method, const URL& url, HashMap<String, String> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
 {
-    return Detail::start_request(Badge<HttpProtocol> {}, client, method, url, headers, body, get_pipe_for_request());
+    return Detail::start_request(Badge<HttpProtocol> {}, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
 }
 
 }

--- a/Userland/Services/RequestServer/HttpProtocol.h
+++ b/Userland/Services/RequestServer/HttpProtocol.h
@@ -27,7 +27,7 @@ public:
     HttpProtocol();
     ~HttpProtocol() override = default;
 
-    virtual OwnPtr<Request> start_request(ConnectionFromClient&, String const& method, const URL&, HashMap<String, String> const& headers, ReadonlyBytes body) override;
+    virtual OwnPtr<Request> start_request(ConnectionFromClient&, String const& method, const URL&, HashMap<String, String> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/HttpsProtocol.cpp
+++ b/Userland/Services/RequestServer/HttpsProtocol.cpp
@@ -22,9 +22,9 @@ HttpsProtocol::HttpsProtocol()
 {
 }
 
-OwnPtr<Request> HttpsProtocol::start_request(ConnectionFromClient& client, String const& method, const URL& url, HashMap<String, String> const& headers, ReadonlyBytes body)
+OwnPtr<Request> HttpsProtocol::start_request(ConnectionFromClient& client, String const& method, const URL& url, HashMap<String, String> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data)
 {
-    return Detail::start_request(Badge<HttpsProtocol> {}, client, method, url, headers, body, get_pipe_for_request());
+    return Detail::start_request(Badge<HttpsProtocol> {}, client, method, url, headers, body, get_pipe_for_request(), proxy_data);
 }
 
 }

--- a/Userland/Services/RequestServer/HttpsProtocol.h
+++ b/Userland/Services/RequestServer/HttpsProtocol.h
@@ -27,7 +27,7 @@ public:
     HttpsProtocol();
     ~HttpsProtocol() override = default;
 
-    virtual OwnPtr<Request> start_request(ConnectionFromClient&, String const& method, const URL&, HashMap<String, String> const& headers, ReadonlyBytes body) override;
+    virtual OwnPtr<Request> start_request(ConnectionFromClient&, String const& method, const URL&, HashMap<String, String> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) override;
 };
 
 }

--- a/Userland/Services/RequestServer/Protocol.h
+++ b/Userland/Services/RequestServer/Protocol.h
@@ -8,6 +8,7 @@
 
 #include <AK/RefPtr.h>
 #include <AK/URL.h>
+#include <LibCore/Proxy.h>
 #include <RequestServer/Forward.h>
 
 namespace RequestServer {
@@ -17,7 +18,7 @@ public:
     virtual ~Protocol();
 
     String const& name() const { return m_name; }
-    virtual OwnPtr<Request> start_request(ConnectionFromClient&, String const& method, const URL&, HashMap<String, String> const& headers, ReadonlyBytes body) = 0;
+    virtual OwnPtr<Request> start_request(ConnectionFromClient&, String const& method, const URL&, HashMap<String, String> const& headers, ReadonlyBytes body, Core::ProxyData proxy_data = {}) = 0;
 
     static Protocol* find_by_name(String const&);
 

--- a/Userland/Services/RequestServer/RequestServer.ipc
+++ b/Userland/Services/RequestServer/RequestServer.ipc
@@ -6,7 +6,7 @@ endpoint RequestServer
     // Test if a specific protocol is supported, e.g "http"
     is_supported_protocol(String protocol) => (bool supported)
 
-    start_request(String method, URL url, IPC::Dictionary request_headers, ByteBuffer request_body) => (i32 request_id, Optional<IPC::File> response_fd)
+    start_request(String method, URL url, IPC::Dictionary request_headers, ByteBuffer request_body, Core::ProxyData proxy_data) => (i32 request_id, Optional<IPC::File> response_fd)
     stop_request(i32 request_id) => (bool success)
     set_certificate(i32 request_id, String certificate, String key) => (bool success)
 

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -59,6 +59,7 @@ private:
     virtual Messages::WebContentServer::GetHoveredNodeIdResponse get_hovered_node_id() override;
     virtual Messages::WebContentServer::DumpLayoutTreeResponse dump_layout_tree() override;
     virtual void set_content_filters(Vector<String> const&) override;
+    virtual void set_proxy_mappings(Vector<String> const&, HashMap<String, size_t> const&) override;
     virtual void set_preferred_color_scheme(Web::CSS::PreferredColorScheme const&) override;
     virtual void set_has_focus(bool) override;
     virtual void set_is_scripting_enabled(bool) override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -43,6 +43,7 @@ endpoint WebContentServer
     select_all() =|
 
     set_content_filters(Vector<String> filters) =|
+    set_proxy_mappings(Vector<String> proxies, HashMap<String,size_t> mappings) =|
     set_preferred_color_scheme(Web::CSS::PreferredColorScheme color_scheme) =|
     set_has_focus(bool has_focus) =|
     set_is_scripting_enabled(bool is_scripting_enabled) =|


### PR DESCRIPTION
~~Currently not wired up beyond LibHTTP, but that's just the tedious part, as it werks.~~
Wired up to the browser, plus a config format for patterns (in ~/.config/Browser.ini)
```ini
[Proxy:(proxy_url)]
glob_matching_full_url=whatever
```
(the value could probably be used to switch between different url matching modes (e.g. host only, ignore port, etc etc) but it's unused right now)

As an example, to tunnel every http request through 192.168.1.2:6969:
```ini
[Proxy:socks5://192.168.1.2:6969]
http://*=whatever
```

This _should_ have GUI at some point, but I'm no GUI guy.