### PR TITLE
LibJS: Reorder and reduce steps of InitializeDateTimeFormat

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Intl/DateTimeFormatConstructor.cpp
@@ -151,8 +151,8 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
     // 18. Set dateTimeFormat.[[Locale]] to r.[[locale]].
     date_time_format.set_locale(move(result.locale));
 
-    // 19. Set calendar to r.[[ca]].
-    // 20. Set dateTimeFormat.[[Calendar]] to calendar.
+    // 19. Set resolvedCalendar to r.[[ca]].
+    // 20. Set dateTimeFormat.[[Calendar]] to resolvedCalendar.
     if (result.ca.has_value())
         date_time_format.set_calendar(result.ca.release_value());
 
@@ -176,68 +176,52 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
 
     Optional<Unicode::HourCycle> hour_cycle_value;
 
-    // 25. If r.[[hc]] is null, then
-    if (!result.hc.has_value()) {
-        // a. Let hc be hcDefault.
-        hour_cycle_value = default_hour_cycle;
-    }
-
-    // 26. If hour12 is true, then
+    // 25. If hour12 is true, then
     if (hour12.is_boolean() && hour12.as_bool()) {
-        // a. If hcDefault is "h11" or "h23", then
-        if ((default_hour_cycle == Unicode::HourCycle::H11) || (default_hour_cycle == Unicode::HourCycle::H23)) {
-            // i. Let hc be "h11".
+        // a. If hcDefault is "h11" or "h23", let hc be "h11". Otherwise, let hc be "h12".
+        if ((default_hour_cycle == Unicode::HourCycle::H11) || (default_hour_cycle == Unicode::HourCycle::H23))
             hour_cycle_value = Unicode::HourCycle::H11;
-        }
-        // b. Else,
-        else {
-            // i. Let hc be "h12".
+        else
             hour_cycle_value = Unicode::HourCycle::H12;
-        }
+
     }
-    // 27. Else if hour12 is false, then
+    // 26. Else if hour12 is false, then
     else if (hour12.is_boolean() && !hour12.as_bool()) {
-        // a. If hcDefault is "h11" or "h23", then
-        if ((default_hour_cycle == Unicode::HourCycle::H11) || (default_hour_cycle == Unicode::HourCycle::H23)) {
-            // i. Let hc be "h23".
+        // a. If hcDefault is "h11" or "h23", let hc be "h23". Otherwise, let hc be "h24".
+        if ((default_hour_cycle == Unicode::HourCycle::H11) || (default_hour_cycle == Unicode::HourCycle::H23))
             hour_cycle_value = Unicode::HourCycle::H23;
-        }
-        // b. Else,
-        else {
-            // i. Let hc be "h24".
+        else
             hour_cycle_value = Unicode::HourCycle::H24;
-        }
+
     }
-    // 28. Else,
+    // 27. Else,
     else {
-        // a. Let hc be r.[[hc]].
+        // a. Assert: hour12 is undefined.
+        VERIFY(hour12.is_undefined());
+
+        // b. Let hc be r.[[hc]].
         if (result.hc.has_value())
             hour_cycle_value = Unicode::hour_cycle_from_string(*result.hc);
 
-        // b. Assert: hour12 is undefined.
-        VERIFY(hour12.is_undefined());
+        // c. If hc is null, set hc to hcDefault.
+        if (!hour_cycle_value.has_value())
+            hour_cycle_value = default_hour_cycle;
     }
 
-    // 29. Set dateTimeFormat.[[HourCycle]] to hc.
+    // 28. Set dateTimeFormat.[[HourCycle]] to hc.
     if (hour_cycle_value.has_value())
         date_time_format.set_hour_cycle(*hour_cycle_value);
 
-    // 30. Let formatOptions be a new Record.
-    Unicode::CalendarPattern format_options {};
-
-    // 31. Set formatOptions.[[hourCycle]] to hc.
-    format_options.hour_cycle = hour_cycle_value;
-
-    // 32. Let timeZone be ? Get(options, "timeZone").
+    // 29. Let timeZone be ? Get(options, "timeZone").
     auto time_zone_value = TRY(options->get(vm.names.timeZone));
     String time_zone;
 
-    // 33. If timeZone is undefined, then
+    // 30. If timeZone is undefined, then
     if (time_zone_value.is_undefined()) {
         // a. Set timeZone to ! DefaultTimeZone().
         time_zone = Temporal::default_time_zone();
     }
-    // 34. Else,
+    // 31. Else,
     else {
         // a. Set timeZone to ? ToString(timeZone).
         time_zone = TRY(time_zone_value.to_string(global_object));
@@ -252,14 +236,20 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         time_zone = Temporal::canonicalize_time_zone_name(time_zone);
     }
 
-    // 35. Set dateTimeFormat.[[TimeZone]] to timeZone.
+    // 32. Set dateTimeFormat.[[TimeZone]] to timeZone.
     date_time_format.set_time_zone(move(time_zone));
 
-    // 36. Let hasExplicitFormatComponents be false.
+    // 33. Let formatOptions be a new Record.
+    Unicode::CalendarPattern format_options {};
+
+    // 34. Set formatOptions.[[hourCycle]] to hc.
+    format_options.hour_cycle = hour_cycle_value;
+
+    // 35. Let hasExplicitFormatComponents be false.
     // NOTE: Instead of using a boolean, we track any explicitly provided component name for nicer exception messages.
     PropertyKey const* explicit_format_component = nullptr;
 
-    // 37. For each row of Table 6, except the header row, in table order, do
+    // 36. For each row of Table 6, except the header row, in table order, do
     TRY(for_each_calendar_field(global_object, format_options, [&](auto& option, auto const& property, auto const& values) -> ThrowCompletionOr<void> {
         using ValueType = typename RemoveReference<decltype(option)>::ValueType;
 
@@ -298,26 +288,26 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         return {};
     }));
 
-    // 38. Let matcher be ? GetOption(options, "formatMatcher", "string", « "basic", "best fit" », "best fit").
+    // 37. Let matcher be ? GetOption(options, "formatMatcher", "string", « "basic", "best fit" », "best fit").
     matcher = TRY(get_option(global_object, *options, vm.names.formatMatcher, Value::Type::String, AK::Array { "basic"sv, "best fit"sv }, "best fit"sv));
 
-    // 39. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
+    // 38. Let dateStyle be ? GetOption(options, "dateStyle", "string", « "full", "long", "medium", "short" », undefined).
     auto date_style = TRY(get_option(global_object, *options, vm.names.dateStyle, Value::Type::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
 
-    // 40. Set dateTimeFormat.[[DateStyle]] to dateStyle.
+    // 39. Set dateTimeFormat.[[DateStyle]] to dateStyle.
     if (!date_style.is_undefined())
         date_time_format.set_date_style(date_style.as_string().string());
 
-    // 41. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
+    // 40. Let timeStyle be ? GetOption(options, "timeStyle", "string", « "full", "long", "medium", "short" », undefined).
     auto time_style = TRY(get_option(global_object, *options, vm.names.timeStyle, Value::Type::String, AK::Array { "full"sv, "long"sv, "medium"sv, "short"sv }, Empty {}));
 
-    // 42. Set dateTimeFormat.[[TimeStyle]] to timeStyle.
+    // 41. Set dateTimeFormat.[[TimeStyle]] to timeStyle.
     if (!time_style.is_undefined())
         date_time_format.set_time_style(time_style.as_string().string());
 
     Optional<Unicode::CalendarPattern> best_format {};
 
-    // 43. If dateStyle is not undefined or timeStyle is not undefined, then
+    // 42. If dateStyle is not undefined or timeStyle is not undefined, then
     if (date_time_format.has_date_style() || date_time_format.has_time_style()) {
         // a. If hasExplicitFormatComponents is true, then
         if (explicit_format_component != nullptr) {
@@ -325,13 +315,13 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
             return vm.throw_completion<TypeError>(global_object, ErrorType::IntlInvalidDateTimeFormatOption, *explicit_format_component, "dateStyle or timeStyle"sv);
         }
 
-        // b. Let styles be dataLocaleData.[[styles]].[[<calendar>]].
+        // b. Let styles be dataLocaleData.[[styles]].[[<resolvedCalendar>]].
         // c. Let bestFormat be DateTimeStyleFormat(dateStyle, timeStyle, styles).
         best_format = date_time_style_format(data_locale, date_time_format);
     }
-    // 44. Else,
+    // 43. Else,
     else {
-        // a. Let formats be dataLocaleData.[[formats]].[[<calendar>]].
+        // a. Let formats be dataLocaleData.[[formats]].[[<resolvedCalendar>]].
         auto formats = Unicode::get_calendar_available_formats(data_locale, date_time_format.calendar());
 
         // b. If matcher is "basic", then
@@ -346,7 +336,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         }
     }
 
-    // 45. For each row in Table 6, except the header row, in table order, do
+    // 44. For each row in Table 6, except the header row, in table order, do
     date_time_format.for_each_calendar_field_zipped_with(*best_format, [&](auto& date_time_format_field, auto const& best_format_field, auto) {
         // a. Let prop be the name given in the Property column of the row.
         // b. If bestFormat has a field [[<prop>]], then
@@ -360,13 +350,13 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
     String pattern;
     Vector<Unicode::CalendarRangePattern> range_patterns;
 
-    // 46. If dateTimeFormat.[[Hour]] is undefined, then
+    // 45. If dateTimeFormat.[[Hour]] is undefined, then
     if (!date_time_format.has_hour()) {
         // a. Set dateTimeFormat.[[HourCycle]] to undefined.
         date_time_format.clear_hour_cycle();
     }
 
-    // 47. If dateTimeformat.[[HourCycle]] is "h11" or "h12", then
+    // 46. If dateTimeformat.[[HourCycle]] is "h11" or "h12", then
     if ((hour_cycle_value == Unicode::HourCycle::H11) || (hour_cycle_value == Unicode::HourCycle::H12)) {
         // a. Let pattern be bestFormat.[[pattern12]].
         if (best_format->pattern12.has_value()) {
@@ -380,7 +370,7 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         // b. Let rangePatterns be bestFormat.[[rangePatterns12]].
         range_patterns = Unicode::get_calendar_range12_formats(data_locale, date_time_format.calendar(), best_format->skeleton);
     }
-    // 48. Else,
+    // 47. Else,
     else {
         // a. Let pattern be bestFormat.[[pattern]].
         pattern = move(best_format->pattern);
@@ -389,13 +379,13 @@ ThrowCompletionOr<DateTimeFormat*> initialize_date_time_format(GlobalObject& glo
         range_patterns = Unicode::get_calendar_range_formats(data_locale, date_time_format.calendar(), best_format->skeleton);
     }
 
-    // 49. Set dateTimeFormat.[[Pattern]] to pattern.
+    // 48. Set dateTimeFormat.[[Pattern]] to pattern.
     date_time_format.set_pattern(move(pattern));
 
-    // 50. Set dateTimeFormat.[[RangePatterns]] to rangePatterns.
+    // 49. Set dateTimeFormat.[[RangePatterns]] to rangePatterns.
     date_time_format.set_range_patterns(move(range_patterns));
 
-    // 51. Return dateTimeFormat.
+    // 50. Return dateTimeFormat.
     return &date_time_format;
 }
 

--- a/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/StringPrototype.cpp
@@ -1037,7 +1037,6 @@ JS_DEFINE_NATIVE_FUNCTION(StringPrototype::sup)
 // 19.1.1 String.prototype.localeCompare ( that [ , locales [ , options ] ] ), https://tc39.es/ecma402/#sup-String.prototype.localeCompare
 JS_DEFINE_NATIVE_FUNCTION(StringPrototype::locale_compare)
 {
-    // FIXME: This can throw (spec issue)
     // 1. Let O be ? RequireObjectCoercible(this value).
     auto object = TRY(require_object_coercible(global_object, vm.this_value(global_object)));
 


### PR DESCRIPTION
These are editorial changes in the Intl spec. See:
tc39/ecma402@7d0326c
tc39/ecma402@05a299b
tc39/ecma402@8c24ea7
tc39/ecma402@fd8dea9