### PR TITLE
AK: Use default sin and cos on aarch64 build

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -255,7 +255,8 @@ constexpr void sincos(T angle, T& sin_val, T& cos_val)
         : "=t"(cos_val), "=u"(sin_val)
         : "0"(angle));
 #else
-    __builtin_sincosf(angle, sin_val, cos_val);
+    sin_val = sin(angle);
+    cos_val = cos(angle);
 #endif
 }
 


### PR DESCRIPTION
This fixes the build on Mac, which doesn't have `__builtin_sincosf` for double arguments.

PR https://github.com/SerenityOS/serenity/pull/13429 fixed this correctly, but https://github.com/SerenityOS/serenity/pull/13427 was merged.