### PR TITLE
LibCore: Make Core::System::mkdir() comfier to use

### DIFF
--- a/Userland/Libraries/LibCore/Directory.cpp
+++ b/Userland/Libraries/LibCore/Directory.cpp
@@ -64,14 +64,7 @@ ErrorOr<void> Directory::ensure_directory(LexicalPath const& path)
     if (path.basename() == "/")
         return {};
 
-    TRY(ensure_directory(path.parent()));
-
-    auto return_value = System::mkdir(path.string(), 0755);
-    // We don't care if the directory already exists.
-    if (return_value.is_error() && return_value.error().code() != EEXIST)
-        return return_value;
-
-    return {};
+    return System::mkdir(path.string(), 0755, System::TreatExistingDirectoryAsError::No, System::CreateParentDirectories::Yes);
 }
 
 ErrorOr<LexicalPath> Directory::path() const

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -114,7 +114,16 @@ ErrorOr<pid_t> setsid();
 ErrorOr<void> drop_privileges();
 ErrorOr<bool> isatty(int fd);
 ErrorOr<void> symlink(StringView target, StringView link_path);
-ErrorOr<void> mkdir(StringView path, mode_t);
+
+enum class TreatExistingDirectoryAsError {
+    No,
+    Yes
+};
+enum class CreateParentDirectories {
+    No,
+    Yes
+};
+ErrorOr<void> mkdir(StringView path, mode_t, TreatExistingDirectoryAsError, CreateParentDirectories);
 ErrorOr<void> chdir(StringView path);
 ErrorOr<void> rmdir(StringView path);
 ErrorOr<pid_t> fork();

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -262,8 +262,7 @@ ErrorOr<int> execute_work_items(Vector<WorkItem> const& items)
         case WorkItem::Type::CreateDirectory: {
             outln("MKDIR {}", item.destination);
             // FIXME: Support deduplication like open_destination_file() when the directory already exists.
-            if (mkdir(item.destination.characters(), 0755) < 0 && errno != EEXIST)
-                return Error::from_syscall("mkdir", -errno);
+            TRY(Core::System::mkdir(item.destination.characters(), 0755, Core::System::TreatExistingDirectoryAsError::No, Core::System::CreateParentDirectories::Yes));
             break;
         }
 

--- a/Userland/Services/SQLServer/main.cpp
+++ b/Userland/Services/SQLServer/main.cpp
@@ -9,18 +9,11 @@
 #include <LibIPC/MultiServer.h>
 #include <LibMain/Main.h>
 #include <SQLServer/ConnectionFromClient.h>
-#include <stdio.h>
-#include <sys/stat.h>
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio accept unix rpath wpath cpath"));
-
-    if (mkdir("/home/anon/sql", 0700) < 0 && errno != EEXIST) {
-        perror("mkdir");
-        return 1;
-    }
-
+    TRY(Core::System::mkdir("/home/anon/sql", 0700, Core::System::TreatExistingDirectoryAsError::No, Core::System::CreateParentDirectories::No));
     TRY(Core::System::unveil("/home/anon/sql", "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -392,7 +392,7 @@ static ErrorOr<void> prepare_synthetic_filesystems()
     TRY(Core::System::mount(-1, "/sys", "sys", 0));
     TRY(Core::System::mount(-1, "/dev", "dev", 0));
 
-    TRY(Core::System::mkdir("/dev/audio", 0755));
+    TRY(Core::System::mkdir("/dev/audio", 0755, Core::System::TreatExistingDirectoryAsError::Yes, Core::System::CreateParentDirectories::No));
 
     TRY(Core::System::symlink("/proc/self/fd/0", "/dev/stdin"));
     TRY(Core::System::symlink("/proc/self/fd/1", "/dev/stdout"));
@@ -400,7 +400,7 @@ static ErrorOr<void> prepare_synthetic_filesystems()
 
     populate_devtmpfs();
 
-    TRY(Core::System::mkdir("/dev/pts", 0755));
+    TRY(Core::System::mkdir("/dev/pts", 0755, Core::System::TreatExistingDirectoryAsError::Yes, Core::System::CreateParentDirectories::No));
 
     TRY(Core::System::mount(-1, "/dev/pts", "devpts", 0));
 
@@ -464,7 +464,7 @@ static ErrorOr<void> create_tmp_coredump_directory()
     dbgln("Creating /tmp/coredump directory");
     auto old_umask = umask(0);
     // FIXME: the coredump directory should be made read-only once CrashDaemon is no longer responsible for compressing coredumps
-    TRY(Core::System::mkdir("/tmp/coredump", 0777));
+    TRY(Core::System::mkdir("/tmp/coredump", 0777, Core::System::TreatExistingDirectoryAsError::Yes, Core::System::CreateParentDirectories::No));
     umask(old_umask);
     return {};
 }

--- a/Userland/Utilities/mktemp.cpp
+++ b/Userland/Utilities/mktemp.cpp
@@ -39,7 +39,7 @@ static ErrorOr<String> make_temp(String const& pattern, bool directory, bool dry
             if (stat_or_error.is_error() && stat_or_error.error().code() == ENOENT)
                 return path;
         } else if (directory) {
-            TRY(Core::System::mkdir(path.view(), 0700));
+            TRY(Core::System::mkdir(path.view(), 0700, Core::System::TreatExistingDirectoryAsError::Yes, Core::System::CreateParentDirectories::No));
             return path;
         } else {
             auto fd_or_error = Core::System::open(path.view(), O_RDWR | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);

--- a/Userland/Utilities/tar.cpp
+++ b/Userland/Utilities/tar.cpp
@@ -161,11 +161,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                     break;
                 }
                 case Archive::TarFileType::Directory: {
-                    MUST(Core::Directory::create(parent_path, Core::Directory::CreateDirectories::Yes));
-
-                    auto result_or_error = Core::System::mkdir(absolute_path, header.mode());
-                    if (result_or_error.is_error() && result_or_error.error().code() != EEXIST)
-                        return result_or_error.error();
+                    TRY(Core::System::mkdir(absolute_path, header.mode(), Core::System::TreatExistingDirectoryAsError::No, Core::System::CreateParentDirectories::Yes));
                     break;
                 }
                 default:

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -14,7 +14,6 @@
 #include <LibCore/MappedFile.h>
 #include <LibCore/System.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 static bool unpack_zip_member(Archive::ZipMember zip_member, bool quiet)
 {
@@ -120,9 +119,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     if (!output_directory_path.is_null()) {
-        auto mkdir_error = Core::System::mkdir(output_directory_path, 0755);
-        if (mkdir_error.is_error() && mkdir_error.error().code() != EEXIST)
-            return mkdir_error.release_error();
+        TRY(Core::System::mkdir(output_directory_path, 0755, Core::System::TreatExistingDirectoryAsError::No, Core::System::CreateParentDirectories::Yes));
         TRY(Core::System::chdir(output_directory_path));
     }
 

--- a/Userland/Utilities/useradd.cpp
+++ b/Userland/Utilities/useradd.cpp
@@ -114,7 +114,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         home = home_path;
 
     if (create_home_dir) {
-        auto mkdir_error = Core::System::mkdir(home, 0700);
+        auto mkdir_error = Core::System::mkdir(home, 0700, Core::System::TreatExistingDirectoryAsError::Yes, Core::System::CreateParentDirectories::No);
         if (mkdir_error.is_error()) {
             int code = mkdir_error.release_error().code();
             warnln("Failed to create directory {}: {}", home, strerror(code));


### PR DESCRIPTION
While making some other changes, I noticed that a lot of users of `mkdir()` manually check for EEXIST and ignore it, since they just want the directory to exist and don't care if they created it. Since we control the API for `Core::System::mkdir()`, let's make that an option so there's less boilerplate.

Another rough edge is that `mkdir()` doesn't create parent directories. So, let's make that an option too!