### PR TITLE
LibGPU: Don't dlopen using absolute path

### DIFF
--- a/Userland/Libraries/LibGPU/Driver.cpp
+++ b/Userland/Libraries/LibGPU/Driver.cpp
@@ -20,7 +20,7 @@ namespace GPU {
 static HashMap<String, String> const s_driver_path_map
 {
 #if defined(__serenity__)
-    { "softgpu", "/usr/lib/libsoftgpu.so" },
+    { "softgpu", "libsoftgpu.so" },
 #elif defined(__APPLE__)
     { "softgpu", "./liblagom-softgpu.dylib" },
 #else


### PR DESCRIPTION
Using the absolute path makes the code more brittle for no benefit, since dlopen can do the lookup automatically.