### PR TITLE
LibJS: Do not throw a TypeError when sorted a detached TypedArray

### DIFF
--- a/Tests/LibJS/test-js.cpp
+++ b/Tests/LibJS/test-js.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Runtime/ArrayBuffer.h>
 #include <LibTest/JavaScriptTestRunner.h>
 
 TEST_ROOT("Userland/Libraries/LibJS/Tests");
@@ -74,6 +75,16 @@ TESTJS_GLOBAL_FUNCTION(mark_as_garbage, markAsGarbage)
     TRY(reference.delete_(global_object));
 
     return JS::js_undefined();
+}
+
+TESTJS_GLOBAL_FUNCTION(detach_array_buffer, detachArrayBuffer)
+{
+    auto array_buffer = vm.argument(0);
+    if (!array_buffer.is_object() || !is<JS::ArrayBuffer>(array_buffer.as_object()))
+        return vm.throw_completion<JS::TypeError>(global_object, JS::ErrorType::NotAnObjectOfType, "ArrayBuffer");
+
+    auto& array_buffer_object = static_cast<JS::ArrayBuffer&>(array_buffer.as_object());
+    return JS::detach_array_buffer(global_object, array_buffer_object, vm.argument(1));
 }
 
 TESTJS_RUN_FILE_FUNCTION(String const& test_file, JS::Interpreter& interpreter, JS::ExecutionContext&)

--- a/Userland/Libraries/LibJS/Contrib/Test262/$262Object.cpp
+++ b/Userland/Libraries/LibJS/Contrib/Test262/$262Object.cpp
@@ -62,17 +62,14 @@ JS_DEFINE_NATIVE_FUNCTION($262Object::create_realm)
     return Value(realm->$262());
 }
 
-// 25.1.2.3 DetachArrayBuffer, https://tc39.es/ecma262/#sec-detacharraybuffer
 JS_DEFINE_NATIVE_FUNCTION($262Object::detach_array_buffer)
 {
     auto array_buffer = vm.argument(0);
     if (!array_buffer.is_object() || !is<ArrayBuffer>(array_buffer.as_object()))
         return vm.throw_completion<TypeError>(global_object);
+
     auto& array_buffer_object = static_cast<ArrayBuffer&>(array_buffer.as_object());
-    if (!same_value(array_buffer_object.detach_key(), vm.argument(1)))
-        return vm.throw_completion<TypeError>(global_object);
-    array_buffer_object.detach_buffer();
-    return js_null();
+    return JS::detach_array_buffer(global_object, array_buffer_object, vm.argument(1));
 }
 
 JS_DEFINE_NATIVE_FUNCTION($262Object::eval_script)

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -96,6 +96,30 @@ ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject& global_objec
     return obj;
 }
 
+// 25.1.2.3 DetachArrayBuffer ( arrayBuffer [ , key ] ), https://tc39.es/ecma262/#sec-detacharraybuffer
+ThrowCompletionOr<Value> detach_array_buffer(GlobalObject& global_object, ArrayBuffer& array_buffer, Optional<Value> key)
+{
+    auto& vm = global_object.vm();
+
+    // 1. Assert: IsSharedArrayBuffer(arrayBuffer) is false.
+    // FIXME: Check for shared buffer
+
+    // 2. If key is not present, set key to undefined.
+    if (!key.has_value())
+        key = js_undefined();
+
+    // 3. If SameValue(arrayBuffer.[[ArrayBufferDetachKey]], key) is false, throw a TypeError exception.
+    if (!same_value(array_buffer.detach_key(), *key))
+        return vm.throw_completion<TypeError>(global_object, ErrorType::DetachKeyMismatch, *key, array_buffer.detach_key());
+
+    // 4. Set arrayBuffer.[[ArrayBufferData]] to null.
+    // 5. Set arrayBuffer.[[ArrayBufferByteLength]] to 0.
+    array_buffer.detach_buffer();
+
+    // 6. Return unused.
+    return js_null();
+}
+
 // 25.1.2.4 CloneArrayBuffer ( srcBuffer, srcByteOffset, srcLength, cloneConstructor ), https://tc39.es/ecma262/#sec-clonearraybuffer
 ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(GlobalObject& global_object, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length, FunctionObject& clone_constructor)
 {

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -81,6 +81,7 @@ private:
 };
 
 ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject&, FunctionObject& constructor, size_t byte_length, Optional<size_t> max_byte_length = {});
+ThrowCompletionOr<Value> detach_array_buffer(GlobalObject&, ArrayBuffer& array_buffer, Optional<Value> key = {});
 ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(GlobalObject&, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length, FunctionObject& clone_constructor);
 
 // 25.1.2.9 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/ecma262/#sec-rawbytestonumeric

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -29,6 +29,7 @@
     M(DerivedConstructorReturningInvalidValue, "Derived constructor return invalid value")                                              \
     M(DescWriteNonWritable, "Cannot write to non-writable property '{}'")                                                               \
     M(DetachedArrayBuffer, "ArrayBuffer is detached")                                                                                   \
+    M(DetachKeyMismatch, "Provided detach key {} does not match the ArrayBuffer's detach key {}")                                       \
     M(DivisionByZero, "Division by zero")                                                                                               \
     M(DynamicImportNotAllowed, "Dynamic Imports are not allowed")                                                                       \
     M(FinalizationRegistrySameTargetAndValue, "Target and held value must not be the same")                                             \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -952,9 +952,6 @@ static ThrowCompletionOr<void> typed_array_merge_sort(GlobalObject& global_objec
 
             auto value = TRY(result.to_number(global_object));
 
-            if (buffer.is_detached())
-                return vm.throw_completion<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
-
             if (value.is_nan())
                 comparison_result = 0;
             else

--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.sort.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.sort.js
@@ -51,3 +51,21 @@ test("basic functionality", () => {
         expect(typedArray[2]).toBe(1n);
     });
 });
+
+test("detached buffer", () => {
+    TYPED_ARRAYS.forEach(T => {
+        const typedArray = new T(3);
+        typedArray[0] = 3;
+        typedArray[1] = 1;
+        typedArray[2] = 2;
+
+        typedArray.sort((a, b) => {
+            detachArrayBuffer(typedArray.buffer);
+            return a - b;
+        });
+
+        expect(typedArray[0]).toBeUndefined();
+        expect(typedArray[1]).toBeUndefined();
+        expect(typedArray[2]).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Normative change which fixes the following test262 test:
`test/built-ins/TypedArray/prototype/sort/sort-tonumber.js`