### PR TITLE
Spreadsheet+LibGUI: add undo/redo functionality where missing 

### DIFF
--- a/Userland/Applications/Spreadsheet/Cell.cpp
+++ b/Userland/Applications/Spreadsheet/Cell.cpp
@@ -191,21 +191,4 @@ void Cell::copy_from(Cell const& other)
     m_thrown_value = other.m_thrown_value;
 }
 
-CellUndoCommand::CellUndoCommand(Cell& cell, String const& previous_data)
-    : m_cell(cell)
-    , m_current_data(cell.data())
-    , m_previous_data(previous_data)
-{
-}
-
-void CellUndoCommand::undo()
-{
-    m_cell.set_data(m_previous_data);
-}
-
-void CellUndoCommand::redo()
-{
-    m_cell.set_data(m_current_data);
-}
-
 }

--- a/Userland/Applications/Spreadsheet/Cell.h
+++ b/Userland/Applications/Spreadsheet/Cell.h
@@ -121,17 +121,4 @@ private:
     Format m_evaluated_formats;
 };
 
-class CellUndoCommand : public GUI::Command {
-public:
-    CellUndoCommand(Cell&, String const&);
-
-    virtual void undo() override;
-    virtual void redo() override;
-
-private:
-    Cell& m_cell;
-    String m_current_data;
-    String m_previous_data;
-};
-
 }

--- a/Userland/Applications/Spreadsheet/Spreadsheet.cpp
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.cpp
@@ -751,4 +751,11 @@ URL Position::to_url(Sheet const& sheet) const
     return url;
 }
 
+CellChange::CellChange(Cell& cell, String const& previous_data)
+    : m_cell(cell)
+    , m_previous_data(previous_data)
+{
+    m_new_data = cell.data();
+}
+
 }

--- a/Userland/Applications/Spreadsheet/Spreadsheet.h
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.h
@@ -135,7 +135,7 @@ public:
         Cut
     };
 
-    void copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to = {}, CopyOperation copy_operation = CopyOperation::Copy);
+    Vector<CellChange> copy_cells(Vector<Position> from, Vector<Position> to, Optional<Position> resolve_relative_to = {}, CopyOperation copy_operation = CopyOperation::Copy);
 
     /// Gives the bottom-right corner of the smallest bounding box containing all the written data, optionally limited to the given column.
     Position written_data_bounds(Optional<size_t> column_index = {}) const;

--- a/Userland/Applications/Spreadsheet/Spreadsheet.h
+++ b/Userland/Applications/Spreadsheet/Spreadsheet.h
@@ -22,6 +22,20 @@
 
 namespace Spreadsheet {
 
+class CellChange {
+public:
+    CellChange(Cell&, String const&);
+
+    auto& cell() { return m_cell; }
+    auto& previous_data() { return m_previous_data; }
+    auto& new_data() { return m_new_data; }
+
+private:
+    Cell& m_cell;
+    String m_previous_data;
+    String m_new_data;
+};
+
 class Sheet : public Core::Object {
     C_OBJECT(Sheet);
 

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.cpp
@@ -165,4 +165,29 @@ void SheetModel::update()
     m_sheet->update();
     did_update(UpdateFlag::DontInvalidateIndices);
 }
+
+CellsUndoCommand::CellsUndoCommand(Vector<CellChange> cell_changes)
+{
+    m_cell_changes = cell_changes;
+}
+
+CellsUndoCommand::CellsUndoCommand(Cell& cell, String const& previous_data)
+{
+    m_cell_changes.append(CellChange(cell, previous_data));
+}
+
+void CellsUndoCommand::undo()
+{
+    for (size_t i = 0; i < m_cell_changes.size(); ++i) {
+        m_cell_changes[i].cell().set_data(m_cell_changes[i].previous_data());
+    }
+}
+
+void CellsUndoCommand::redo()
+{
+    for (size_t i = 0; i < m_cell_changes.size(); ++i) {
+        m_cell_changes[i].cell().set_data(m_cell_changes[i].new_data());
+    }
+}
+
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -40,4 +40,16 @@ private:
     NonnullRefPtr<Sheet> m_sheet;
 };
 
+class CellsUndoCommand : public GUI::Command {
+public:
+    CellsUndoCommand(Cell&, String const&);
+    CellsUndoCommand(Vector<CellChange>);
+
+    virtual void undo() override;
+    virtual void redo() override;
+
+private:
+    Vector<CellChange> m_cell_changes;
+};
+
 }

--- a/Userland/Applications/Spreadsheet/SpreadsheetModel.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetModel.h
@@ -30,6 +30,7 @@ public:
     void update();
 
     Function<void(Cell&, String&)> on_cell_data_change;
+    Function<void(Vector<CellChange>)> on_cells_data_change;
 
 private:
     explicit SheetModel(Sheet& sheet)

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -281,7 +281,7 @@ void SpreadsheetWidget::setup_tabs(NonnullRefPtrVector<Sheet> new_sheets)
     for (auto& sheet : new_sheets) {
         auto& new_view = m_tab_widget->add_tab<SpreadsheetView>(sheet.name(), sheet);
         new_view.model()->on_cell_data_change = [&](auto& cell, auto& previous_data) {
-            undo_stack().push(make<CellUndoCommand>(cell, previous_data));
+            undo_stack().push(make<CellsUndoCommand>(cell, previous_data));
             window()->set_modified(true);
         };
         new_view.on_selection_changed = [&](Vector<Position>&& selection) {

--- a/Userland/Libraries/LibGUI/TableView.cpp
+++ b/Userland/Libraries/LibGUI/TableView.cpp
@@ -174,7 +174,8 @@ void TableView::keydown_event(KeyEvent& event)
     auto is_delete = event.key() == Key_Delete;
     auto is_backspace = event.key() == Key_Backspace;
     auto is_clear = is_delete || is_backspace;
-    if (is_editable() && edit_triggers() & EditTrigger::AnyKeyPressed && (event.code_point() != 0 || is_clear)) {
+    auto has_ctrl = event.modifiers() & KeyModifier::Mod_Ctrl;
+    if (is_editable() && edit_triggers() & EditTrigger::AnyKeyPressed && (event.code_point() != 0 || is_clear) && !has_ctrl) {
         begin_editing(cursor_index());
         if (m_editing_delegate) {
             if (is_delete) {


### PR DESCRIPTION
Add ability to undo / redo actions performed in the Spreadsheet when extending a cell, when dragging and dropping cells, and when copying and pasting.