### PR TITLE
CI: Add aarch64 architecture to azure CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -21,13 +21,16 @@ jobs:
       matrix:
         debug-options: ['ALL_DEBUG', 'NORMAL_DEBUG']
         os: [ubuntu-20.04]
-        arch: ['i686', 'x86_64']
+        arch: ['i686', 'x86_64', 'aarch64']
         # If ccache is broken and you would like to bust the ccache cache on Github Actions, increment this:
         ccache-mark: [0]
         exclude:
           # We currently manually disable the ALL_DEBUG build on x86_64 for sake of saving CI time, as it is not our main target right now
           - debug-options: 'ALL_DEBUG'
             arch: 'x86_64'
+          # We currently manually disable the ALL_DEBUG build on aarch64 for sake of saving CI time, as it is not our main target right now
+          - debug-options: 'ALL_DEBUG'
+            arch: 'aarch64'
 
     steps:
       - uses: actions/checkout@v2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,3 +40,7 @@ stages:
       - template: Meta/Azure/Serenity.yml
         parameters:
           arch: 'x86_64'
+
+      - template: Meta/Azure/Serenity.yml
+        parameters:
+          arch: 'aarch64'


### PR DESCRIPTION
This will check whether the build succeeds for `aarch64`.