### PR TITLE
LibM+AK+UserspaceEmulator: Delegate rounding to the hardware 

### DIFF
--- a/AK/FPControl.h
+++ b/AK/FPControl.h
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022, Leon Albrecht <leon.a@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+// FIXME: Add equivalent datastructures for aarch64
+VALIDATE_IS_X86();
+
+namespace AK {
+
+enum class RoundingMode : u8 {
+    NEAREST = 0b00,
+    DOWN = 0b01,
+    UP = 0b10,
+    TRUNC = 0b11
+};
+
+union X87ControlWord {
+    u16 cw;
+    struct {
+        u16 mask_invalid : 1;              // IM
+        u16 mask_denorm : 1;               // DM
+        u16 mask_zero_div : 1;             // ZM
+        u16 mask_overflow : 1;             // OM
+        u16 mask_underflow : 1;            // UM
+        u16 mask_precision : 1;            // PM
+        u16 : 2;                           // unused
+        u16 precision : 2;                 // PC
+        RoundingMode rounding_control : 2; // RC
+        u16 infinity_control : 1;          // X
+        u16 : 3;                           // unused
+    };
+};
+static_assert(sizeof(X87ControlWord) == sizeof(u16));
+
+union MXCSR {
+    u32 mxcsr;
+    struct {
+        u32 invalid_operation_flag : 1;    // IE
+        u32 denormal_operation_flag : 1;   // DE
+        u32 divide_by_zero_flag : 1;       // ZE
+        u32 overflow_flag : 1;             // OE
+        u32 underflow_flag : 1;            // UE
+        u32 precision_flag : 1;            // PE
+        u32 denormals_are_zero : 1;        // DAZ
+        u32 invalid_operation_mask : 1;    // IM
+        u32 denormal_operation_mask : 1;   // DM
+        u32 divide_by_zero_mask : 1;       // ZM
+        u32 overflow_mask : 1;             // OM
+        u32 underflow_mask : 1;            // UM
+        u32 precision_mask : 1;            // PM
+        RoundingMode rounding_control : 2; // RC
+        u32 flush_to_zero : 1;             // FTZ
+        u32 __reserved : 16;
+    };
+};
+static_assert(sizeof(MXCSR) == sizeof(u32));
+
+ALWAYS_INLINE X87ControlWord get_cw_x87()
+{
+    X87ControlWord control_word;
+    asm("fnstcw %0"
+        : "=m"(control_word));
+    return control_word;
+}
+ALWAYS_INLINE void set_cw_x87(X87ControlWord control_word)
+{
+    asm("fldcw %0" ::"m"(control_word));
+}
+
+ALWAYS_INLINE MXCSR get_mxcsr()
+{
+    MXCSR mxcsr;
+    asm("stmxcsr %0"
+        : "=m"(mxcsr));
+    return mxcsr;
+}
+ALWAYS_INLINE void set_mxcsr(MXCSR mxcsr)
+{
+    asm("ldmxcsr %0" ::"m"(mxcsr));
+}
+
+class X87RoundingModeScope {
+public:
+    X87RoundingModeScope(RoundingMode rounding_mode)
+    {
+        m_cw = get_cw_x87();
+        auto cw = m_cw;
+        cw.rounding_control = rounding_mode;
+        set_cw_x87(cw);
+    }
+    ~X87RoundingModeScope()
+    {
+        set_cw_x87(m_cw);
+    }
+
+private:
+    X87ControlWord m_cw;
+};
+
+class SSERoundingModeScope {
+public:
+    SSERoundingModeScope(RoundingMode rounding_mode)
+    {
+        m_mxcsr = get_mxcsr();
+        auto mxcsr = m_mxcsr;
+        mxcsr.rounding_control = rounding_mode;
+        set_mxcsr(mxcsr);
+    }
+    ~SSERoundingModeScope()
+    {
+        set_mxcsr(m_mxcsr);
+    }
+
+private:
+    MXCSR m_mxcsr;
+};
+
+}

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -130,6 +130,21 @@ constexpr float sqrt(float x)
     return res;
 }
 
+#    ifdef __SSE2__
+template<>
+constexpr double sqrt(double x)
+{
+    if (is_constant_evaluated())
+        return __builtin_sqrt(x);
+
+    double res;
+    asm("sqrtsd %1, %0"
+        : "=x"(res)
+        : "x"(x));
+    return res;
+}
+#    endif
+
 template<>
 constexpr float rsqrt(float x)
 {

--- a/Userland/DevTools/UserspaceEmulator/CMakeLists.txt
+++ b/Userland/DevTools/UserspaceEmulator/CMakeLists.txt
@@ -20,7 +20,7 @@ set(SOURCES
     main.cpp
 )
 
-add_compile_options(-mmmx -Wno-psabi)
+add_compile_options(-mmmx -Wno-psabi -frounding-math)
 
 serenity_bin(UserspaceEmulator)
 target_link_libraries(UserspaceEmulator LibX86 LibDebug LibCore LibPthread LibLine)

--- a/Userland/DevTools/UserspaceEmulator/SoftVPU.h
+++ b/Userland/DevTools/UserspaceEmulator/SoftVPU.h
@@ -6,12 +6,14 @@
 
 #pragma once
 
+#include <AK/FPControl.h>
 #include <AK/SIMD.h>
 #include <AK/Types.h>
 #include <LibX86/Instruction.h>
 #include <math.h>
 
 namespace UserspaceEmulator {
+using AK::RoundingMode;
 using namespace AK::SIMD;
 class Emulator;
 class SoftCPU;
@@ -57,51 +59,17 @@ public:
         // FIXME: More with VEX prefix
     };
 
-    i32 lround(float value) const
-    {
-        // FIXME: This is not yet 100% correct
-        using enum RoundingMode;
-        switch ((RoundingMode)rounding_control) {
-        case NEAREST:
-            return ::lroundf(value);
-        case DOWN:
-            return floorf(value);
-        case UP:
-            return ceilf(value);
-        case TRUNC:
-            return truncf(value);
-        default:
-            VERIFY_NOT_REACHED();
-        }
-    }
-
 private:
     friend SoftCPU;
     Emulator& m_emulator;
     SoftCPU& m_cpu;
 
     XMM m_xmm[8];
-    union {
-        u32 m_mxcsr;
-        struct {
-            u32 invalid_operation_flag : 1;  // IE
-            u32 denormal_operation_flag : 1; // DE
-            u32 divide_by_zero_flag : 1;     // ZE
-            u32 overflow_flag : 1;           // OE
-            u32 underflow_flag : 1;          // UE
-            u32 precision_flag : 1;          // PE
-            u32 denormals_are_zero : 1;      // FIXME: DAZ
-            u32 invalid_operation_mask : 1;  // IM
-            u32 denormal_operation_mask : 1; // DM
-            u32 devide_by_zero_mask : 1;     // ZM
-            u32 overflow_mask : 1;           // OM
-            u32 underflow_mask : 1;          // UM
-            u32 precision_mask : 1;          // PM
-            u32 rounding_control : 2;        // FIXME: RC
-            u32 flush_to_zero : 1;           // FIXME: FTZ
-            u32 __reserved : 16;
-        };
-    };
+
+    // FIXME: Maybe unimplemented features:
+    // * DAZ
+    // * FTZ
+    AK::MXCSR m_mxcsr;
 
     void PREFETCHTNTA(X86::Instruction const&);
     void PREFETCHT0(X86::Instruction const&);


### PR DESCRIPTION
#### AK: Add a cpp-y, more fine grained version of fenv.h: FPControl.h

This allows direct inlining and hides away some assembly and
bit-fiddling when manipulating the floating point environment.

This only implements the x87/SSE versions, as of now.

#### LibM: Delegate rounding to fully to the FRNDINT instruction

Also fixes the types of two intermediate results

#### UserspaceEmulator: Delegate rounding to the actual hardware

This also makes us a bit more accurate, due to better rounding of
intermediate results.

This also gives us the flush-to-zero and denormals-are-zero SSE settings
for free! (Assuming UE is build with SSE)

#### AK: Add an SSE2 specific implementation of sqrt(double)


----

Note: [quickbench result for roundl](https://quick-bench.com/q/ZeRIPrT8ccCDmiHIYeDK5IC8xyE)
E: This is not the impl of round anymore, but the performance benefit should be similar for ceil/floor, which also accelerates the new impl of round