### PR TITLE
LibWeb: Fix 2 issues that broke the CSS transform test page

### DIFF
--- a/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
+++ b/Userland/Libraries/LibWeb/Layout/FormattingContext.cpp
@@ -204,6 +204,10 @@ float FormattingContext::compute_auto_height_for_block_level_element(FormattingS
 
     auto const& box_state = state.get(box);
 
+    auto display = box.computed_values().display();
+    if (display.is_flex_inside())
+        return box_state.content_height;
+
     // https://www.w3.org/TR/CSS22/visudet.html#normal-block
     // 10.6.3 Block-level non-replaced elements in normal flow when 'overflow' computes to 'visible'
 

--- a/Userland/Libraries/LibWeb/Painting/PaintContext.h
+++ b/Userland/Libraries/LibWeb/Painting/PaintContext.h
@@ -37,9 +37,9 @@ public:
     bool has_focus() const { return m_focus; }
     void set_has_focus(bool focus) { m_focus = focus; }
 
-    PaintContext clone() const
+    PaintContext clone(Gfx::Painter& painter) const
     {
-        auto clone = PaintContext(m_painter, m_palette, m_scroll_offset);
+        auto clone = PaintContext(painter, m_palette, m_scroll_offset);
         clone.m_viewport_rect = m_viewport_rect;
         clone.m_should_show_line_box_borders = m_should_show_line_box_borders;
         clone.m_focus = m_focus;

--- a/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
+++ b/Userland/Libraries/LibWeb/Painting/StackingContext.cpp
@@ -262,7 +262,7 @@ void StackingContext::paint(PaintContext& context) const
             return;
         auto bitmap = bitmap_or_error.release_value_but_fixme_should_propagate_errors();
         Gfx::Painter painter(bitmap);
-        auto paint_context = context.clone();
+        auto paint_context = context.clone(painter);
         paint_internal(paint_context);
 
         auto transform_origin = this->transform_origin();


### PR DESCRIPTION
After seeing that the CSS transform test page broke in Linus' showcase in the March update video I bisected the two issues.

- height: auto was handled incorrectly for flex containers, this was bisected to 5da7ebb806cd3be5b126ec22bfda926c7319e4f7, but that just surfaced the underlying problem.
- transformed stacking contexts weren't showing up, this was bisected to 54c3053bc3b0d5719fd928cee8e648d78d54b0eb