### PR TITLE
WebServer: Add utf-8 charset to Content-Type header for text/plain

### DIFF
--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -176,7 +176,10 @@ ErrorOr<void> Client::send_response(InputStream& response, HTTP::HttpRequest con
     builder.append("X-Frame-Options: SAMEORIGIN\r\n");
     builder.append("X-Content-Type-Options: nosniff\r\n");
     builder.append("Pragma: no-cache\r\n");
-    builder.appendff("Content-Type: {}\r\n", content_info.type);
+    if (content_info.type == "text/plain")
+        builder.appendff("Content-Type: {}; charset=utf-8\r\n", content_info.type);
+    else
+        builder.appendff("Content-Type: {}\r\n", content_info.type);
     builder.appendff("Content-Length: {}\r\n", content_info.length);
     builder.append("\r\n");
 


### PR DESCRIPTION
Our .txt-files seems to be saved as utf-8. When loading them in Firefox via WebServer the encoding is messed up because we don't set a explicit charset. This PR fixes that.

**To be clear, I don't know C++! I can't really do the kind of refactoring that should probably been done. But this fixes the issue I've had. Not sure if it's worth merging or not...**

![image](https://user-images.githubusercontent.com/93391300/162542308-410dac1f-2752-4f99-ac2e-1ab941271767.png)


![image](https://user-images.githubusercontent.com/93391300/162542342-da86456b-c70e-46b9-80c9-8b0062840db5.png)
