### PR TITLE
Fixes File Manager crash when browsing to subfolders in /proc

### DIFF
--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -62,12 +62,13 @@ bool FileSystemModel::Node::fetch_data(String const& full_path, bool is_root)
 
     if (S_ISLNK(mode)) {
         auto sym_link_target_or_error = Core::File::read_link(full_path);
-        if (sym_link_target_or_error.is_error())
+        if (sym_link_target_or_error.is_error()) {
             perror("readlink");
-
-        symlink_target = sym_link_target_or_error.release_value();
-        if (symlink_target.is_null())
-            perror("readlink");
+        } else {
+            symlink_target = sym_link_target_or_error.release_value();
+            if (symlink_target.is_null())
+                perror("readlink");
+        }
     }
 
     if (S_ISDIR(mode)) {

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -272,15 +272,16 @@ void Launcher::for_each_handler_for_path(String const& path, Function<bool(Handl
 
     if (S_ISLNK(st.st_mode)) {
         auto link_target_or_error = Core::File::read_link(path);
-        if (link_target_or_error.is_error())
+        if (link_target_or_error.is_error()) {
             perror("read_link");
-
-        auto link_target = LexicalPath { link_target_or_error.release_value() };
-        LexicalPath absolute_link_target = link_target.is_absolute() ? link_target : LexicalPath::join(LexicalPath::dirname(path), link_target.string());
-        auto real_path = Core::File::real_path_for(absolute_link_target.string());
-        return for_each_handler_for_path(real_path, [&](auto const& handler) -> bool {
-            return f(handler);
-        });
+        } else {
+            auto link_target = LexicalPath { link_target_or_error.release_value() };
+            LexicalPath absolute_link_target = link_target.is_absolute() ? link_target : LexicalPath::join(LexicalPath::dirname(path), link_target.string());
+            auto real_path = Core::File::real_path_for(absolute_link_target.string());
+            return for_each_handler_for_path(real_path, [&](auto const& handler) -> bool {
+                return f(handler);
+            });
+        }
     }
 
     if ((st.st_mode & S_IFMT) == S_IFREG && (st.st_mode & (S_IXUSR | S_IXGRP | S_IXOTH)))


### PR DESCRIPTION
Fixes a crash when expanding /proc in the side panel of the File Manager.

https://github.com/SerenityOS/serenity/issues/13435