### PR TITLE
LibWeb: Skip anchor activation behavior if the click event was cancelled

### DIFF
--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -194,56 +194,59 @@ bool EventHandler::handle_mouseup(Gfx::IntPoint const& position, unsigned button
             node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::mouseup, offset.x(), offset.y(), position.x(), position.y()));
             handled_event = true;
 
-            // FIXME: This is ad-hoc and incorrect. The reason this exists is
-            //        because we are missing browsing context navigation:
-            //
-            //        https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
-            //
-            //        Additionally, we currently cannot spawn a new top-level
-            //        browsing context for new tab operations, because the new
-            //        top-level browsing context would be in another process. To
-            //        fix this, there needs to be some way to be able to
-            //        communicate with browsing contexts in remote WebContent
-            //        processes, and then step 8 of this algorithm needs to be
-            //        implemented in BrowsingContext::choose_a_browsing_context:
-            //
-            //        https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
-            if (RefPtr<HTML::HTMLAnchorElement> link = node->enclosing_link_element()) {
-                NonnullRefPtr document = *m_browsing_context.active_document();
-                auto href = link->href();
-                auto url = document->parse_url(href);
-                dbgln("Web::EventHandler: Clicking on a link to {}", url);
-                if (button == GUI::MouseButton::Primary) {
-                    if (href.starts_with("javascript:")) {
-                        document->run_javascript(href.substring_view(11, href.length() - 11));
-                    } else if (!url.fragment().is_null() && url.equals(document->url(), AK::URL::ExcludeFragment::Yes)) {
-                        m_browsing_context.scroll_to_anchor(url.fragment());
-                    } else {
-                        if (m_browsing_context.is_top_level()) {
-                            if (auto* page = m_browsing_context.page())
-                                page->client().page_did_click_link(url, link->target(), modifiers);
-                        }
-                    }
-                } else if (button == GUI::MouseButton::Middle) {
-                    if (auto* page = m_browsing_context.page())
-                        page->client().page_did_middle_click_link(url, link->target(), modifiers);
-                } else if (button == GUI::MouseButton::Secondary) {
-                    if (auto* page = m_browsing_context.page())
-                        page->client().page_did_request_link_context_menu(m_browsing_context.to_top_level_position(position), url, link->target(), modifiers);
-                }
-            } else if (button == GUI::MouseButton::Secondary) {
-                if (is<HTML::HTMLImageElement>(*node)) {
-                    auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
-                    auto image_url = image_element.document().parse_url(image_element.src());
-                    if (auto* page = m_browsing_context.page())
-                        page->client().page_did_request_image_context_menu(m_browsing_context.to_top_level_position(position), image_url, "", modifiers, image_element.bitmap());
-                } else if (auto* page = m_browsing_context.page()) {
-                    page->client().page_did_request_context_menu(m_browsing_context.to_top_level_position(position));
-                }
+            bool run_activation_behavior = true;
+            if (node.ptr() == m_mousedown_target && button == GUI::MouseButton::Primary) {
+                run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::click, offset.x(), offset.y(), position.x(), position.y()));
             }
 
-            if (node.ptr() == m_mousedown_target && button == GUI::MouseButton::Primary) {
-                node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::click, offset.x(), offset.y(), position.x(), position.y()));
+            if (run_activation_behavior) {
+                // FIXME: This is ad-hoc and incorrect. The reason this exists is
+                //        because we are missing browsing context navigation:
+                //
+                //        https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
+                //
+                //        Additionally, we currently cannot spawn a new top-level
+                //        browsing context for new tab operations, because the new
+                //        top-level browsing context would be in another process. To
+                //        fix this, there needs to be some way to be able to
+                //        communicate with browsing contexts in remote WebContent
+                //        processes, and then step 8 of this algorithm needs to be
+                //        implemented in BrowsingContext::choose_a_browsing_context:
+                //
+                //        https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
+                if (RefPtr<HTML::HTMLAnchorElement> link = node->enclosing_link_element()) {
+                    NonnullRefPtr document = *m_browsing_context.active_document();
+                    auto href = link->href();
+                    auto url = document->parse_url(href);
+                    dbgln("Web::EventHandler: Clicking on a link to {}", url);
+                    if (button == GUI::MouseButton::Primary) {
+                        if (href.starts_with("javascript:")) {
+                            document->run_javascript(href.substring_view(11, href.length() - 11));
+                        } else if (!url.fragment().is_null() && url.equals(document->url(), AK::URL::ExcludeFragment::Yes)) {
+                            m_browsing_context.scroll_to_anchor(url.fragment());
+                        } else {
+                            if (m_browsing_context.is_top_level()) {
+                                if (auto* page = m_browsing_context.page())
+                                    page->client().page_did_click_link(url, link->target(), modifiers);
+                            }
+                        }
+                    } else if (button == GUI::MouseButton::Middle) {
+                        if (auto* page = m_browsing_context.page())
+                            page->client().page_did_middle_click_link(url, link->target(), modifiers);
+                    } else if (button == GUI::MouseButton::Secondary) {
+                        if (auto* page = m_browsing_context.page())
+                            page->client().page_did_request_link_context_menu(m_browsing_context.to_top_level_position(position), url, link->target(), modifiers);
+                    }
+                } else if (button == GUI::MouseButton::Secondary) {
+                    if (is<HTML::HTMLImageElement>(*node)) {
+                        auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
+                        auto image_url = image_element.document().parse_url(image_element.src());
+                        if (auto* page = m_browsing_context.page())
+                            page->client().page_did_request_image_context_menu(m_browsing_context.to_top_level_position(position), image_url, "", modifiers, image_element.bitmap());
+                    } else if (auto* page = m_browsing_context.page()) {
+                        page->client().page_did_request_context_menu(m_browsing_context.to_top_level_position(position));
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
To be honest, this feels more like a hack over a hack, but I have no idea if/how I could improve this code so I just tried to fix the issue at hand without potentially breaking something else :^)