### PR TITLE
pro: Only attempt to parse a proxy url if it is provided

### DIFF
--- a/Userland/Utilities/pro.cpp
+++ b/Userland/Utilities/pro.cpp
@@ -191,7 +191,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 1;
     }
 
-    Core::ProxyData proxy_data = TRY(Core::ProxyData::parse_url(proxy_spec));
+    Core::ProxyData proxy_data {};
+    if (!proxy_spec.is_empty())
+        proxy_data = TRY(Core::ProxyData::parse_url(proxy_spec));
 
     Core::EventLoop loop;
     bool received_actual_headers = false;


### PR DESCRIPTION
Otherwise we'd end up trying to parse an empty string as a proxy url
which is certainly not one.

cc @awesomekling 