### PR TITLE
Kernel: Unblock big lock waiters correctly

### DIFF
--- a/Kernel/Locking/Mutex.cpp
+++ b/Kernel/Locking/Mutex.cpp
@@ -242,9 +242,6 @@ void Mutex::unblock_waiters(Mode previous_mode)
     VERIFY(m_mode == Mode::Unlocked);
 
     m_blocked_thread_lists.with([&](auto& lists) {
-        if (lists.exclusive.is_empty() && lists.shared.is_empty())
-            return;
-
         auto unblock_shared = [&]() {
             if (lists.shared.is_empty())
                 return false;

--- a/Kernel/Locking/Mutex.cpp
+++ b/Kernel/Locking/Mutex.cpp
@@ -282,9 +282,11 @@ void Mutex::unblock_waiters(Mode previous_mode)
 
 auto Mutex::force_unlock_exclusive_if_locked(u32& lock_count_to_restore) -> Mode
 {
+    VERIFY(m_behavior == MutexBehavior::BigLock);
     // NOTE: This may be called from an interrupt handler (not an IRQ handler)
     // and also from within critical sections!
     VERIFY(!Processor::current_in_irq());
+
     auto* current_thread = Thread::current();
     SpinlockLocker lock(m_lock);
     auto current_mode = m_mode;
@@ -319,8 +321,10 @@ auto Mutex::force_unlock_exclusive_if_locked(u32& lock_count_to_restore) -> Mode
 
 void Mutex::restore_exclusive_lock(u32 lock_count, [[maybe_unused]] LockLocation const& location)
 {
+    VERIFY(m_behavior == MutexBehavior::BigLock);
     VERIFY(lock_count > 0);
     VERIFY(!Processor::current_in_irq());
+
     auto* current_thread = Thread::current();
     bool did_block = false;
     SpinlockLocker lock(m_lock);


### PR DESCRIPTION
We were not unblocking any big lock waiters, causing hangs in e.g. `test-pthread` and Quake 3.