### PR TITLE
LibWeb: Add "which" attribute to UIEvent

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -980,7 +980,7 @@ NonnullRefPtr<Event> Document::create_event(String const& interface)
     } else if (interface_lowercase == "messageevent") {
         event = HTML::MessageEvent::create("");
     } else if (interface_lowercase.is_one_of("mouseevent", "mouseevents")) {
-        event = UIEvents::MouseEvent::create("", 0, 0, 0, 0);
+        event = UIEvents::MouseEvent::create("");
     } else if (interface_lowercase == "storageevent") {
         event = Event::create(""); // FIXME: Create StorageEvent
     } else if (interface_lowercase == "svgevents") {

--- a/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLElement.cpp
@@ -395,7 +395,7 @@ bool HTMLElement::fire_a_synthetic_pointer_event(FlyString const& type, DOM::Ele
     // 1. Let event be the result of creating an event using PointerEvent.
     // 2. Initialize event's type attribute to e.
     // FIXME: Actually create a PointerEvent!
-    auto event = UIEvents::MouseEvent::create(type, 0.0, 0.0, 0.0, 0.0);
+    auto event = UIEvents::MouseEvent::create(type);
 
     // 3. Initialize event's bubbles and cancelable attributes to true.
     event->set_bubbles(true);

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -191,12 +191,12 @@ bool EventHandler::handle_mouseup(Gfx::IntPoint const& position, unsigned button
                 return false;
             }
             auto offset = compute_mouse_event_offset(position, paintable->layout_node());
-            node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::mouseup, offset.x(), offset.y(), position.x(), position.y()));
+            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(UIEvents::EventNames::mouseup, offset.x(), offset.y(), position.x(), position.y(), button));
             handled_event = true;
 
             bool run_activation_behavior = true;
             if (node.ptr() == m_mousedown_target && button == GUI::MouseButton::Primary) {
-                run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::click, offset.x(), offset.y(), position.x(), position.y()));
+                run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(UIEvents::EventNames::click, offset.x(), offset.y(), position.x(), position.y(), button));
             }
 
             if (run_activation_behavior) {
@@ -308,7 +308,7 @@ bool EventHandler::handle_mousedown(Gfx::IntPoint const& position, unsigned butt
 
         m_mousedown_target = node;
         auto offset = compute_mouse_event_offset(position, paintable->layout_node());
-        node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::mousedown, offset.x(), offset.y(), position.x(), position.y()));
+        node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(UIEvents::EventNames::mousedown, offset.x(), offset.y(), position.x(), position.y(), button));
     }
 
     // NOTE: Dispatching an event may have disturbed the world.
@@ -416,7 +416,7 @@ bool EventHandler::handle_mousemove(Gfx::IntPoint const& position, unsigned butt
             }
 
             auto offset = compute_mouse_event_offset(position, paintable->layout_node());
-            node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::mousemove, offset.x(), offset.y(), position.x(), position.y()));
+            node->dispatch_event(UIEvents::MouseEvent::create_from_platform_event(UIEvents::EventNames::mousemove, offset.x(), offset.y(), position.x(), position.y()));
             // NOTE: Dispatching an event may have disturbed the world.
             if (!paint_root() || paint_root() != node->document().paint_box())
                 return true;

--- a/Userland/Libraries/LibWeb/Page/EventHandler.cpp
+++ b/Userland/Libraries/LibWeb/Page/EventHandler.cpp
@@ -194,56 +194,59 @@ bool EventHandler::handle_mouseup(Gfx::IntPoint const& position, unsigned button
             node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::mouseup, offset.x(), offset.y(), position.x(), position.y()));
             handled_event = true;
 
-            // FIXME: This is ad-hoc and incorrect. The reason this exists is
-            //        because we are missing browsing context navigation:
-            //
-            //        https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
-            //
-            //        Additionally, we currently cannot spawn a new top-level
-            //        browsing context for new tab operations, because the new
-            //        top-level browsing context would be in another process. To
-            //        fix this, there needs to be some way to be able to
-            //        communicate with browsing contexts in remote WebContent
-            //        processes, and then step 8 of this algorithm needs to be
-            //        implemented in BrowsingContext::choose_a_browsing_context:
-            //
-            //        https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
-            if (RefPtr<HTML::HTMLAnchorElement> link = node->enclosing_link_element()) {
-                NonnullRefPtr document = *m_browsing_context.active_document();
-                auto href = link->href();
-                auto url = document->parse_url(href);
-                dbgln("Web::EventHandler: Clicking on a link to {}", url);
-                if (button == GUI::MouseButton::Primary) {
-                    if (href.starts_with("javascript:")) {
-                        document->run_javascript(href.substring_view(11, href.length() - 11));
-                    } else if (!url.fragment().is_null() && url.equals(document->url(), AK::URL::ExcludeFragment::Yes)) {
-                        m_browsing_context.scroll_to_anchor(url.fragment());
-                    } else {
-                        if (m_browsing_context.is_top_level()) {
-                            if (auto* page = m_browsing_context.page())
-                                page->client().page_did_click_link(url, link->target(), modifiers);
-                        }
-                    }
-                } else if (button == GUI::MouseButton::Middle) {
-                    if (auto* page = m_browsing_context.page())
-                        page->client().page_did_middle_click_link(url, link->target(), modifiers);
-                } else if (button == GUI::MouseButton::Secondary) {
-                    if (auto* page = m_browsing_context.page())
-                        page->client().page_did_request_link_context_menu(m_browsing_context.to_top_level_position(position), url, link->target(), modifiers);
-                }
-            } else if (button == GUI::MouseButton::Secondary) {
-                if (is<HTML::HTMLImageElement>(*node)) {
-                    auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
-                    auto image_url = image_element.document().parse_url(image_element.src());
-                    if (auto* page = m_browsing_context.page())
-                        page->client().page_did_request_image_context_menu(m_browsing_context.to_top_level_position(position), image_url, "", modifiers, image_element.bitmap());
-                } else if (auto* page = m_browsing_context.page()) {
-                    page->client().page_did_request_context_menu(m_browsing_context.to_top_level_position(position));
-                }
+            bool run_activation_behavior = true;
+            if (node.ptr() == m_mousedown_target && button == GUI::MouseButton::Primary) {
+                run_activation_behavior = node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::click, offset.x(), offset.y(), position.x(), position.y()));
             }
 
-            if (node.ptr() == m_mousedown_target && button == GUI::MouseButton::Primary) {
-                node->dispatch_event(UIEvents::MouseEvent::create(UIEvents::EventNames::click, offset.x(), offset.y(), position.x(), position.y()));
+            if (run_activation_behavior) {
+                // FIXME: This is ad-hoc and incorrect. The reason this exists is
+                //        because we are missing browsing context navigation:
+                //
+                //        https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate
+                //
+                //        Additionally, we currently cannot spawn a new top-level
+                //        browsing context for new tab operations, because the new
+                //        top-level browsing context would be in another process. To
+                //        fix this, there needs to be some way to be able to
+                //        communicate with browsing contexts in remote WebContent
+                //        processes, and then step 8 of this algorithm needs to be
+                //        implemented in BrowsingContext::choose_a_browsing_context:
+                //
+                //        https://html.spec.whatwg.org/multipage/browsers.html#the-rules-for-choosing-a-browsing-context-given-a-browsing-context-name
+                if (RefPtr<HTML::HTMLAnchorElement> link = node->enclosing_link_element()) {
+                    NonnullRefPtr document = *m_browsing_context.active_document();
+                    auto href = link->href();
+                    auto url = document->parse_url(href);
+                    dbgln("Web::EventHandler: Clicking on a link to {}", url);
+                    if (button == GUI::MouseButton::Primary) {
+                        if (href.starts_with("javascript:")) {
+                            document->run_javascript(href.substring_view(11, href.length() - 11));
+                        } else if (!url.fragment().is_null() && url.equals(document->url(), AK::URL::ExcludeFragment::Yes)) {
+                            m_browsing_context.scroll_to_anchor(url.fragment());
+                        } else {
+                            if (m_browsing_context.is_top_level()) {
+                                if (auto* page = m_browsing_context.page())
+                                    page->client().page_did_click_link(url, link->target(), modifiers);
+                            }
+                        }
+                    } else if (button == GUI::MouseButton::Middle) {
+                        if (auto* page = m_browsing_context.page())
+                            page->client().page_did_middle_click_link(url, link->target(), modifiers);
+                    } else if (button == GUI::MouseButton::Secondary) {
+                        if (auto* page = m_browsing_context.page())
+                            page->client().page_did_request_link_context_menu(m_browsing_context.to_top_level_position(position), url, link->target(), modifiers);
+                    }
+                } else if (button == GUI::MouseButton::Secondary) {
+                    if (is<HTML::HTMLImageElement>(*node)) {
+                        auto& image_element = verify_cast<HTML::HTMLImageElement>(*node);
+                        auto image_url = image_element.document().parse_url(image_element.src());
+                        if (auto* page = m_browsing_context.page())
+                            page->client().page_did_request_image_context_menu(m_browsing_context.to_top_level_position(position), image_url, "", modifiers, image_element.bitmap());
+                    } else if (auto* page = m_browsing_context.page()) {
+                        page->client().page_did_request_context_menu(m_browsing_context.to_top_level_position(position));
+                    }
+                }
             }
         }
     }

--- a/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/KeyboardEvent.h
@@ -58,6 +58,8 @@ public:
 
     bool get_modifier_state(String const& key_arg);
 
+    virtual u32 which() const override { return m_key_code; }
+
 private:
     KeyboardEvent(FlyString const& event_name, KeyboardEventInit const& event_init)
         : UIEvent(event_name, event_init)

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.cpp
@@ -4,23 +4,53 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGUI/Event.h>
 #include <LibWeb/HTML/EventNames.h>
 #include <LibWeb/UIEvents/EventNames.h>
 #include <LibWeb/UIEvents/MouseEvent.h>
 
 namespace Web::UIEvents {
 
-MouseEvent::MouseEvent(FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y)
-    : UIEvent(event_name)
-    , m_offset_x(offset_x)
-    , m_offset_y(offset_y)
-    , m_client_x(client_x)
-    , m_client_y(client_y)
+MouseEvent::MouseEvent(FlyString const& event_name, MouseEventInit const& event_init)
+    : UIEvent(event_name, event_init)
+    , m_offset_x(event_init.offset_x)
+    , m_offset_y(event_init.offset_y)
+    , m_client_x(event_init.client_x)
+    , m_client_y(event_init.client_y)
+    , m_button(event_init.button)
 {
     set_event_characteristics();
 }
 
-MouseEvent::~MouseEvent() = default;
+// https://www.w3.org/TR/uievents/#dom-mouseevent-button
+static i16 determine_button(unsigned mouse_button)
+{
+    switch (mouse_button) {
+    case GUI::MouseButton::Primary:
+        return 0;
+    case GUI::MouseButton::Middle:
+        return 1;
+    case GUI::MouseButton::Secondary:
+        return 2;
+    case GUI::MouseButton::Backward:
+        return 3;
+    case GUI::MouseButton::Forward:
+        return 4;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+NonnullRefPtr<MouseEvent> MouseEvent::create_from_platform_event(FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button)
+{
+    MouseEventInit event_init {};
+    event_init.offset_x = offset_x;
+    event_init.offset_y = offset_y;
+    event_init.client_x = client_x;
+    event_init.client_y = client_y;
+    event_init.button = determine_button(mouse_button);
+    return MouseEvent::create(event_name, event_init);
+}
 
 void MouseEvent::set_event_characteristics()
 {

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -45,6 +45,8 @@ public:
 
     i16 button() const { return m_button; }
 
+    virtual u32 which() const override { return m_button + 1; }
+
 private:
     MouseEvent(FlyString const& event_name, MouseEventInit const& event_init);
 

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.h
@@ -12,16 +12,27 @@
 
 namespace Web::UIEvents {
 
+struct MouseEventInit : public EventModifierInit {
+    double offset_x = 0;
+    double offset_y = 0;
+    double client_x = 0;
+    double client_y = 0;
+
+    i16 button = 0;
+};
+
 class MouseEvent final : public UIEvent {
 public:
     using WrapperType = Bindings::MouseEventWrapper;
 
-    static NonnullRefPtr<MouseEvent> create(FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y)
+    static NonnullRefPtr<MouseEvent> create(FlyString const& event_name, MouseEventInit const& event_init = {})
     {
-        return adopt_ref(*new MouseEvent(event_name, offset_x, offset_y, client_x, client_y));
+        return adopt_ref(*new MouseEvent(event_name, event_init));
     }
 
-    virtual ~MouseEvent() override;
+    static NonnullRefPtr<MouseEvent> create_from_platform_event(FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y, unsigned mouse_button = 1);
+
+    virtual ~MouseEvent() override = default;
 
     double offset_x() const { return m_offset_x; }
     double offset_y() const { return m_offset_y; }
@@ -32,16 +43,18 @@ public:
     double x() const { return client_x(); }
     double y() const { return client_y(); }
 
-protected:
-    MouseEvent(FlyString const& event_name, double offset_x, double offset_y, double client_x, double client_y);
+    i16 button() const { return m_button; }
 
 private:
+    MouseEvent(FlyString const& event_name, MouseEventInit const& event_init);
+
     void set_event_characteristics();
 
     double m_offset_x { 0 };
     double m_offset_y { 0 };
     double m_client_x { 0 };
     double m_client_y { 0 };
+    i16 m_button { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/MouseEvent.idl
@@ -7,4 +7,18 @@ interface MouseEvent : UIEvent {
     readonly attribute double x;
     readonly attribute double y;
 
+    readonly attribute short button;
+
+};
+
+dictionary MouseEventInit : EventModifierInit {
+
+    // FIXME: offsetX and offsetY shouldn't be here.
+    double offsetX = 0;
+    double offsetY = 0;
+    double clientX = 0;
+    double clientY = 0;
+
+    short button = 0;
+
 };

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.h
@@ -35,6 +35,7 @@ public:
 
     HTML::Window const* view() const { return m_view; }
     int detail() const { return m_detail; }
+    virtual u32 which() const { return 0; }
 
     void init_ui_event(String const& type, bool bubbles, bool cancelable, HTML::Window* view, int detail)
     {

--- a/Userland/Libraries/LibWeb/UIEvents/UIEvent.idl
+++ b/Userland/Libraries/LibWeb/UIEvents/UIEvent.idl
@@ -7,6 +7,8 @@ interface UIEvent : Event {
 
     // NOTE: This is "deprecated, but supported for backwards-compatibility with widely-deployed implementations."
     [ImplementedAs=init_ui_event] undefined initUIEvent(DOMString typeArg, optional boolean bubblesArg = false, optional boolean cancelableArg = false, optional Window? viewArg = null, optional long detailArg = 0);
+
+    readonly attribute unsigned long which;
 };
 
 dictionary UIEventInit : EventInit {


### PR DESCRIPTION
This PR is a follow-up to https://github.com/SerenityOS/serenity/pull/13580 (not sure If I'm doing this right tho), it should do the necessary changes to add the ["which" attribute](https://docs.w3cub.com/dom/uievent/which) to UIEvent. While I was at it, I also took the opportunity to improve MouseEvent a bit.