### PR TITLE
Kernel: Remove big lock from `sys$accept4`

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -40,7 +40,7 @@ enum class NeedsBigProcessLock {
 //   - VERIFY_NO_PROCESS_BIG_LOCK(this)
 //
 #define ENUMERATE_SYSCALLS(S)                               \
-    S(accept4, NeedsBigProcessLock::Yes)                    \
+    S(accept4, NeedsBigProcessLock::No)                     \
     S(access, NeedsBigProcessLock::Yes)                     \
     S(adjtime, NeedsBigProcessLock::No)                     \
     S(alarm, NeedsBigProcessLock::Yes)                      \


### PR DESCRIPTION
The only thing we needed to check is whether `socket.accept()` returns a socket, and if not, we go back to blocking again.