### PR TITLE
Kernel: Remove big lock from `sys$set_coredump_metadata`

### DIFF
--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -148,7 +148,7 @@ enum class NeedsBigProcessLock {
     S(sched_setparam, NeedsBigProcessLock::No)              \
     S(sendfd, NeedsBigProcessLock::No)                      \
     S(sendmsg, NeedsBigProcessLock::Yes)                    \
-    S(set_coredump_metadata, NeedsBigProcessLock::Yes)      \
+    S(set_coredump_metadata, NeedsBigProcessLock::No)       \
     S(set_mmap_name, NeedsBigProcessLock::Yes)              \
     S(set_process_name, NeedsBigProcessLock::Yes)           \
     S(set_thread_name, NeedsBigProcessLock::Yes)            \

--- a/Kernel/Process.cpp
+++ b/Kernel/Process.cpp
@@ -874,15 +874,18 @@ void Process::set_dumpable(bool dumpable)
 
 ErrorOr<void> Process::set_coredump_property(NonnullOwnPtr<KString> key, NonnullOwnPtr<KString> value)
 {
-    // Write it into the first available property slot.
-    for (auto& slot : m_coredump_properties) {
-        if (slot.key)
-            continue;
-        slot.key = move(key);
-        slot.value = move(value);
-        return {};
-    }
-    return ENOBUFS;
+    return m_coredump_properties.with([&](auto& coredump_properties) -> ErrorOr<void> {
+        // Write it into the first available property slot.
+        for (auto& slot : coredump_properties) {
+            if (slot.key)
+                continue;
+            slot.key = move(key);
+            slot.value = move(value);
+            return {};
+        }
+
+        return ENOBUFS;
+    });
 }
 
 ErrorOr<void> Process::try_set_coredump_property(StringView key, StringView value)

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -500,11 +500,14 @@ public:
     template<typename Callback>
     ErrorOr<void> for_each_coredump_property(Callback callback) const
     {
-        for (auto const& property : m_coredump_properties) {
-            if (property.key && property.value)
-                TRY(callback(*property.key, *property.value));
-        }
-        return {};
+        return m_coredump_properties.with([&](auto const& coredump_properties) -> ErrorOr<void> {
+            for (auto const& property : coredump_properties) {
+                if (property.key && property.value)
+                    TRY(callback(*property.key, *property.value));
+            }
+
+            return {};
+        });
     }
 
     ErrorOr<void> set_coredump_property(NonnullOwnPtr<KString> key, NonnullOwnPtr<KString> value);
@@ -833,7 +836,7 @@ private:
         OwnPtr<KString> value;
     };
 
-    Array<CoredumpProperty, 4> m_coredump_properties;
+    SpinlockProtected<Array<CoredumpProperty, 4>> m_coredump_properties;
     NonnullRefPtrVector<Thread> m_threads_for_coredump;
 
     mutable RefPtr<ProcessProcFSTraits> m_procfs_traits;

--- a/Kernel/Syscalls/execve.cpp
+++ b/Kernel/Syscalls/execve.cpp
@@ -525,8 +525,9 @@ ErrorOr<void> Process::do_exec(NonnullRefPtr<OpenFileDescription> main_program_d
         return {};
     }));
 
-    for (auto& property : m_coredump_properties)
+    m_coredump_properties.for_each([](auto& property) {
         property = {};
+    });
 
     auto* current_thread = Thread::current();
     current_thread->reset_signals_for_exec();

--- a/Kernel/Syscalls/process.cpp
+++ b/Kernel/Syscalls/process.cpp
@@ -50,7 +50,7 @@ ErrorOr<FlatPtr> Process::sys$set_process_name(Userspace<char const*> user_name,
 
 ErrorOr<FlatPtr> Process::sys$set_coredump_metadata(Userspace<Syscall::SC_set_coredump_metadata_params const*> user_params)
 {
-    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this)
+    VERIFY_NO_PROCESS_BIG_LOCK(this)
     auto params = TRY(copy_typed_from_user(user_params));
 
     if (params.key.length == 0 || params.key.length > 16 * KiB)


### PR DESCRIPTION
The only requirement for this syscall is to make
Process::m_coredump_properties SpinlockProtected.