### PR TITLE
LibGUI: Calculate width of table headers when there is no content

### DIFF
--- a/Userland/Libraries/LibGUI/HeaderView.cpp
+++ b/Userland/Libraries/LibGUI/HeaderView.cpp
@@ -82,7 +82,7 @@ HeaderView::VisibleSectionRange HeaderView::visible_section_range() const
     auto is_horizontal = m_orientation == Orientation::Horizontal;
     auto rect = m_table_view.visible_content_rect();
     auto start = is_horizontal ? rect.top_left().x() : rect.top_left().y();
-    auto end = is_horizontal ? rect.top_right().x() : rect.bottom_left().y();
+    auto end = is_horizontal ? (rect.top_left().x() + m_table_view.content_width()) : rect.bottom_left().y();
     auto offset = 0;
     VisibleSectionRange range;
     for (; range.end < section_count; ++range.end) {


### PR DESCRIPTION
Calculate the width of table headers without taking into account the content of the table. This way, even if there is no content, the table headers are drawn.