### PR TITLE
LibJS: Add missing steps and spec comments to PerformEval (+some missing steps In CreateDynamicFunction)

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -1631,7 +1631,7 @@ ThrowCompletionOr<ClassElement::ClassValue> ClassField::class_element_evaluation
 
         // FIXME: A potential optimization is not creating the functions here since these are never directly accessible.
         auto function_code = create_ast_node<ClassFieldInitializerStatement>(m_initializer->source_range(), copy_initializer.release_nonnull(), name);
-        initializer = make_handle(ECMAScriptFunctionObject::create(interpreter.global_object(), String::empty(), String::empty(), *function_code, {}, 0, interpreter.lexical_environment(), interpreter.vm().running_execution_context().private_environment, FunctionKind::Normal, true, false, m_contains_direct_call_to_eval, false));
+        initializer = make_handle(ECMAScriptFunctionObject::create(interpreter.global_object(), String::empty(), String::empty(), *function_code, {}, 0, interpreter.lexical_environment(), interpreter.vm().running_execution_context().private_environment, FunctionKind::Normal, true, false, m_contains_direct_call_to_eval, false, property_key_or_private_name));
         initializer->make_method(target);
     }
 

--- a/Userland/Libraries/LibJS/Parser.h
+++ b/Userland/Libraries/LibJS/Parser.h
@@ -43,7 +43,14 @@ class ScopePusher;
 
 class Parser {
 public:
-    explicit Parser(Lexer lexer, Program::Type program_type = Program::Type::Script);
+    struct EvalInitialState {
+        bool in_eval_function_context { false };
+        bool allow_super_property_lookup { false };
+        bool allow_super_constructor_call { false };
+        bool in_class_field_initializer { false };
+    };
+
+    explicit Parser(Lexer lexer, Program::Type program_type = Program::Type::Script, Optional<EvalInitialState> initial_state_for_eval = {});
 
     NonnullRefPtr<Program> parse_program(bool starts_in_strict_mode = false);
 
@@ -300,6 +307,7 @@ private:
         bool allow_super_property_lookup { false };
         bool allow_super_constructor_call { false };
         bool in_function_context { false };
+        bool in_eval_function_context { false }; // This controls if we allow new.target or not. Note that eval("return") is not allowed, so we have to have a separate state variable for eval.
         bool in_formal_parameter_context { false };
         bool in_generator_function_context { false };
         bool await_expression_is_valid { false };

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.cpp
@@ -29,7 +29,7 @@
 
 namespace JS {
 
-ECMAScriptFunctionObject* ECMAScriptFunctionObject::create(GlobalObject& global_object, FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function)
+ECMAScriptFunctionObject* ECMAScriptFunctionObject::create(GlobalObject& global_object, FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
 {
     Object* prototype = nullptr;
     switch (kind) {
@@ -46,15 +46,15 @@ ECMAScriptFunctionObject* ECMAScriptFunctionObject::create(GlobalObject& global_
         prototype = global_object.async_generator_function_prototype();
         break;
     }
-    return global_object.heap().allocate<ECMAScriptFunctionObject>(global_object, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, parent_scope, private_scope, *prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function);
+    return global_object.heap().allocate<ECMAScriptFunctionObject>(global_object, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, parent_scope, private_scope, *prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name));
 }
 
-ECMAScriptFunctionObject* ECMAScriptFunctionObject::create(GlobalObject& global_object, FlyString name, Object& prototype, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function)
+ECMAScriptFunctionObject* ECMAScriptFunctionObject::create(GlobalObject& global_object, FlyString name, Object& prototype, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, FunctionKind kind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
 {
-    return global_object.heap().allocate<ECMAScriptFunctionObject>(global_object, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, parent_scope, private_scope, prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function);
+    return global_object.heap().allocate<ECMAScriptFunctionObject>(global_object, move(name), move(source_text), ecmascript_code, move(parameters), m_function_length, parent_scope, private_scope, prototype, kind, is_strict, might_need_arguments_object, contains_direct_call_to_eval, is_arrow_function, move(class_field_initializer_name));
 }
 
-ECMAScriptFunctionObject::ECMAScriptFunctionObject(FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> formal_parameters, i32 function_length, Environment* parent_scope, PrivateEnvironment* private_scope, Object& prototype, FunctionKind kind, bool strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function)
+ECMAScriptFunctionObject::ECMAScriptFunctionObject(FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> formal_parameters, i32 function_length, Environment* parent_scope, PrivateEnvironment* private_scope, Object& prototype, FunctionKind kind, bool strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name)
     : FunctionObject(prototype)
     , m_name(move(name))
     , m_function_length(function_length)
@@ -64,6 +64,7 @@ ECMAScriptFunctionObject::ECMAScriptFunctionObject(FlyString name, String source
     , m_ecmascript_code(ecmascript_code)
     , m_realm(global_object().associated_realm())
     , m_source_text(move(source_text))
+    , m_class_field_initializer_name(move(class_field_initializer_name))
     , m_strict(strict)
     , m_might_need_arguments_object(might_need_arguments_object)
     , m_contains_direct_call_to_eval(contains_direct_call_to_eval)

--- a/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
+++ b/Userland/Libraries/LibJS/Runtime/ECMAScriptFunctionObject.h
@@ -32,10 +32,10 @@ public:
         Global,
     };
 
-    static ECMAScriptFunctionObject* create(GlobalObject&, FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false);
-    static ECMAScriptFunctionObject* create(GlobalObject&, FlyString name, Object& prototype, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false);
+    static ECMAScriptFunctionObject* create(GlobalObject&, FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
+    static ECMAScriptFunctionObject* create(GlobalObject&, FlyString name, Object& prototype, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, FunctionKind, bool is_strict, bool might_need_arguments_object = true, bool contains_direct_call_to_eval = true, bool is_arrow_function = false, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name = {});
 
-    ECMAScriptFunctionObject(FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function);
+    ECMAScriptFunctionObject(FlyString name, String source_text, Statement const& ecmascript_code, Vector<FunctionNode::Parameter> parameters, i32 m_function_length, Environment* parent_scope, PrivateEnvironment* private_scope, Object& prototype, FunctionKind, bool is_strict, bool might_need_arguments_object, bool contains_direct_call_to_eval, bool is_arrow_function, Variant<PropertyKey, PrivateName, Empty> class_field_initializer_name);
     virtual void initialize(GlobalObject&) override;
     virtual ~ECMAScriptFunctionObject() override = default;
 
@@ -91,6 +91,8 @@ public:
     // https://html.spec.whatwg.org/multipage/webappapis.html#getting-the-current-value-of-the-event-handler Step 3.11
     void set_script_or_module(ScriptOrModule script_or_module) { m_script_or_module = move(script_or_module); }
 
+    Variant<PropertyKey, PrivateName, Empty> const& class_field_initializer_name() const { return m_class_field_initializer_name; }
+
 protected:
     virtual bool is_strict_mode() const final { return m_strict; }
 
@@ -113,20 +115,21 @@ private:
     i32 m_function_length { 0 };
 
     // Internal Slots of ECMAScript Function Objects, https://tc39.es/ecma262/#table-internal-slots-of-ecmascript-function-objects
-    Environment* m_environment { nullptr };                           // [[Environment]]
-    PrivateEnvironment* m_private_environment { nullptr };            // [[PrivateEnvironment]]
-    Vector<FunctionNode::Parameter> const m_formal_parameters;        // [[FormalParameters]]
-    NonnullRefPtr<Statement> m_ecmascript_code;                       // [[ECMAScriptCode]]
-    Realm* m_realm { nullptr };                                       // [[Realm]]
-    ScriptOrModule m_script_or_module;                                // [[ScriptOrModule]]
-    Object* m_home_object { nullptr };                                // [[HomeObject]]
-    String m_source_text;                                             // [[SourceText]]
-    Vector<InstanceField> m_fields;                                   // [[Fields]]
-    Vector<PrivateElement> m_private_methods;                         // [[PrivateMethods]]
-    ConstructorKind m_constructor_kind : 1 { ConstructorKind::Base }; // [[ConstructorKind]]
-    bool m_strict : 1 { false };                                      // [[Strict]]
-    bool m_is_class_constructor : 1 { false };                        // [[IsClassConstructor]]
-    ThisMode m_this_mode : 2 { ThisMode::Global };                    // [[ThisMode]]
+    Environment* m_environment { nullptr };                                  // [[Environment]]
+    PrivateEnvironment* m_private_environment { nullptr };                   // [[PrivateEnvironment]]
+    Vector<FunctionNode::Parameter> const m_formal_parameters;               // [[FormalParameters]]
+    NonnullRefPtr<Statement> m_ecmascript_code;                              // [[ECMAScriptCode]]
+    Realm* m_realm { nullptr };                                              // [[Realm]]
+    ScriptOrModule m_script_or_module;                                       // [[ScriptOrModule]]
+    Object* m_home_object { nullptr };                                       // [[HomeObject]]
+    String m_source_text;                                                    // [[SourceText]]
+    Vector<InstanceField> m_fields;                                          // [[Fields]]
+    Vector<PrivateElement> m_private_methods;                                // [[PrivateMethods]]
+    Variant<PropertyKey, PrivateName, Empty> m_class_field_initializer_name; // [[ClassFieldInitializerName]]
+    ConstructorKind m_constructor_kind : 1 { ConstructorKind::Base };        // [[ConstructorKind]]
+    bool m_strict : 1 { false };                                             // [[Strict]]
+    bool m_is_class_constructor : 1 { false };                               // [[IsClassConstructor]]
+    ThisMode m_this_mode : 2 { ThisMode::Global };                           // [[ThisMode]]
 
     bool m_might_need_arguments_object : 1 { true };
     bool m_contains_direct_call_to_eval : 1 { true };

--- a/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/FunctionConstructor.cpp
@@ -44,12 +44,16 @@ ThrowCompletionOr<ECMAScriptFunctionObject*> FunctionConstructor::create_dynamic
     VERIFY(vm.execution_context_stack().size() >= 2);
 
     // 2. Let callerContext be the second to top element of the execution context stack.
+    auto& caller_context = *vm.execution_context_stack().at(vm.execution_context_stack().size() - 2);
+
     // 3. Let callerRealm be callerContext's Realm.
+    auto& caller_realm = *caller_context.realm;
+
     // 4. Let calleeRealm be the current Realm Record.
-    // NOTE: All of these are only needed for the next step.
+    auto& callee_realm = *vm.running_execution_context().realm;
 
     // 5. Perform ? HostEnsureCanCompileStrings(callerRealm, calleeRealm).
-    // NOTE: We don't have this yet.
+    TRY(vm.host_ensure_can_compile_strings(caller_realm, callee_realm));
 
     // 6. If newTarget is undefined, set newTarget to constructor.
     if (new_target == nullptr)

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -131,6 +131,17 @@ VM::VM(OwnPtr<CustomData> custom_data)
         return HostResizeArrayBufferResult::Unhandled;
     };
 
+    // 19.2.1.2 HostEnsureCanCompileStrings ( callerRealm, calleeRealm ), https://tc39.es/ecma262/#sec-hostensurecancompilestrings
+    host_ensure_can_compile_strings = [](Realm&, Realm&) -> ThrowCompletionOr<void> {
+        // The host-defined abstract operation HostEnsureCanCompileStrings takes arguments callerRealm (a Realm Record) and calleeRealm (a Realm Record)
+        // and returns either a normal completion containing unused or an abrupt completion.
+        // It allows host environments to block certain ECMAScript functions which allow developers to compile strings into ECMAScript code.
+        // An implementation of HostEnsureCanCompileStrings must conform to the following requirements:
+        //   - If the returned Completion Record is a normal completion, it must be a normal completion containing unused.
+        // The default implementation of HostEnsureCanCompileStrings is to return NormalCompletion(unused).
+        return {};
+    };
+
 #define __JS_ENUMERATE(SymbolName, snake_name) \
     m_well_known_symbol_##snake_name = js_symbol(*this, "Symbol." #SymbolName, false);
     JS_ENUMERATE_WELL_KNOWN_SYMBOLS

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -234,6 +234,7 @@ public:
     Function<void(Function<ThrowCompletionOr<Value>()>, Realm*)> host_enqueue_promise_job;
     Function<JobCallback(FunctionObject&)> host_make_job_callback;
     Function<ThrowCompletionOr<HostResizeArrayBufferResult>(GlobalObject&, size_t)> host_resize_array_buffer;
+    Function<ThrowCompletionOr<void>(Realm&, Realm&)> host_ensure_can_compile_strings;
 
 private:
     explicit VM(OwnPtr<CustomData>);

--- a/Userland/Libraries/LibJS/Tests/classes/class-private-fields.js
+++ b/Userland/Libraries/LibJS/Tests/classes/class-private-fields.js
@@ -111,3 +111,40 @@ test("private identifier not followed by 'in' throws", () => {
 test("cannot have static and non static field with the same description", () => {
     expect("class A { static #simple; #simple; }").not.toEval();
 });
+
+test("'arguments' is not allowed in class field initializer", () => {
+    expect("class A { #a = arguments; }").not.toEval();
+    expect("class B { static #b = arguments; }").not.toEval();
+
+    class C {
+        #c = eval("arguments");
+    }
+
+    expect(() => {
+        new C();
+    }).toThrowWithMessage(SyntaxError, "'arguments' is not allowed in class field initializer");
+
+    expect(() => {
+        class D {
+            static #d = eval("arguments");
+        }
+    }).toThrowWithMessage(SyntaxError, "'arguments' is not allowed in class field initializer");
+});
+
+test("using 'arguments' via indirect eval throws at runtime instead of parse time", () => {
+    const indirect = eval;
+
+    class A {
+        #a = indirect("arguments");
+    }
+
+    expect(() => {
+        new A();
+    }).toThrowWithMessage(ReferenceError, "'arguments' is not defined");
+
+    expect(() => {
+        class B {
+            static #b = indirect("arguments");
+        }
+    }).toThrowWithMessage(ReferenceError, "'arguments' is not defined");
+});

--- a/Userland/Libraries/LibJS/Tests/classes/class-public-fields.js
+++ b/Userland/Libraries/LibJS/Tests/classes/class-public-fields.js
@@ -86,6 +86,43 @@ test("with super class", () => {
     expect(b.super_field).toBe(4);
 });
 
+test("'arguments' is not allowed in class field initializer", () => {
+    expect("class A { a = arguments; }").not.toEval();
+    expect("class B { static b = arguments; }").not.toEval();
+
+    class C {
+        c = eval("arguments");
+    }
+
+    expect(() => {
+        new C();
+    }).toThrowWithMessage(SyntaxError, "'arguments' is not allowed in class field initializer");
+
+    expect(() => {
+        class D {
+            static d = eval("arguments");
+        }
+    }).toThrowWithMessage(SyntaxError, "'arguments' is not allowed in class field initializer");
+});
+
+test("using 'arguments' via indirect eval throws at runtime instead of parse time", () => {
+    const indirect = eval;
+
+    class A {
+        a = indirect("arguments");
+    }
+
+    expect(() => {
+        new A();
+    }).toThrowWithMessage(ReferenceError, "'arguments' is not defined");
+
+    expect(() => {
+        class B {
+            static b = indirect("arguments");
+        }
+    }).toThrowWithMessage(ReferenceError, "'arguments' is not defined");
+});
+
 describe("class fields with a 'special' name", () => {
     test("static", () => {
         class A {

--- a/Userland/Libraries/LibJS/Tests/functions/function-new-target.js
+++ b/Userland/Libraries/LibJS/Tests/functions/function-new-target.js
@@ -20,6 +20,42 @@ test("basic functionality", () => {
     expect(new baz().newTarget).toEqual(baz);
 });
 
+test("retrieving new.target from direct eval", () => {
+    function foo() {
+        return eval("new.target");
+    }
+
+    let result;
+
+    expect(() => {
+        result = foo();
+    }).not.toThrowWithMessage(SyntaxError, "'new.target' not allowed outside of a function");
+
+    expect(result).toBe(undefined);
+
+    expect(() => {
+        result = new foo();
+    }).not.toThrowWithMessage(SyntaxError, "'new.target' not allowed outside of a function");
+
+    expect(result).toBe(foo);
+});
+
+test("cannot retrieve new.target from indirect eval", () => {
+    const indirect = eval;
+
+    function foo() {
+        return indirect("new.target");
+    }
+
+    expect(() => {
+        foo();
+    }).toThrowWithMessage(SyntaxError, "'new.target' not allowed outside of a function");
+
+    expect(() => {
+        new foo();
+    }).toThrowWithMessage(SyntaxError, "'new.target' not allowed outside of a function");
+});
+
 test("syntax error outside of function", () => {
     expect("new.target").not.toEval();
 });

--- a/Userland/Libraries/LibJS/Tests/return.js
+++ b/Userland/Libraries/LibJS/Tests/return.js
@@ -51,3 +51,31 @@ describe("returning from loops", () => {
         expect(foo()).toBe(10);
     });
 });
+
+test("cannot use return in eval", () => {
+    const indirect = eval;
+
+    expect(() => {
+        eval("return 1;");
+    }).toThrowWithMessage(SyntaxError, "'return' not allowed outside of a function");
+
+    expect(() => {
+        indirect("return 1;");
+    }).toThrowWithMessage(SyntaxError, "'return' not allowed outside of a function");
+
+    function foo() {
+        eval("return 1;");
+    }
+
+    expect(() => {
+        foo();
+    }).toThrowWithMessage(SyntaxError, "'return' not allowed outside of a function");
+
+    function bar() {
+        indirect("return 1;");
+    }
+
+    expect(() => {
+        bar();
+    }).toThrowWithMessage(SyntaxError, "'return' not allowed outside of a function");
+});


### PR DESCRIPTION
While adding spec comments to PerformEval, I noticed we were missing
multiple steps.

Namely, these were:
- Checking if the host will allow us to compile the string 
  (allowing LibWeb to perform CSP for eval)
- The parser's initial state depending on the environment around us
  on direct eval:
   - Allowing new.target via eval in functions
   - Allowing super calls and super properties via eval in classes
   - Disallowing the use of the arguments object in class field
     initializers at eval's parse time
- Setting ScriptOrModule of eval's execution context

The spec allows us to apply the additional parsing steps in any order.
The method I have gone with is passing in a struct to the parser's
constructor, which overrides the parser's initial state to (dis)allow
the things stated above from the get-go.

```
Summary:
    Diff Tests:
        +54 ✅    -54 ❌
```