### PR TITLE
LibSoftGPU: Optimize Clipper

### DIFF
--- a/Userland/Libraries/LibSoftGPU/Clipper.cpp
+++ b/Userland/Libraries/LibSoftGPU/Clipper.cpp
@@ -16,19 +16,18 @@ namespace SoftGPU {
 template<Clipper::ClipPlane plane>
 static constexpr bool point_within_clip_plane(FloatVector4 const& vertex)
 {
-    if constexpr (plane == Clipper::ClipPlane::LEFT) {
+    if constexpr (plane == Clipper::ClipPlane::LEFT)
         return vertex.x() >= -vertex.w();
-    } else if constexpr (plane == Clipper::ClipPlane::RIGHT) {
+    else if constexpr (plane == Clipper::ClipPlane::RIGHT)
         return vertex.x() <= vertex.w();
-    } else if constexpr (plane == Clipper::ClipPlane::TOP) {
+    else if constexpr (plane == Clipper::ClipPlane::TOP)
         return vertex.y() <= vertex.w();
-    } else if constexpr (plane == Clipper::ClipPlane::BOTTOM) {
+    else if constexpr (plane == Clipper::ClipPlane::BOTTOM)
         return vertex.y() >= -vertex.w();
-    } else if constexpr (plane == Clipper::ClipPlane::NEAR) {
+    else if constexpr (plane == Clipper::ClipPlane::NEAR)
         return vertex.z() >= -vertex.w();
-    } else if constexpr (plane == Clipper::ClipPlane::FAR) {
+    else if constexpr (plane == Clipper::ClipPlane::FAR)
         return vertex.z() <= vertex.w();
-    }
     return false;
 }
 

--- a/Userland/Libraries/LibSoftGPU/Clipper.h
+++ b/Userland/Libraries/LibSoftGPU/Clipper.h
@@ -29,8 +29,7 @@ public:
     void clip_triangle_against_frustum(Vector<GPU::Vertex>& input_vecs);
 
 private:
-    Vector<GPU::Vertex> list_a;
-    Vector<GPU::Vertex> list_b;
+    Vector<GPU::Vertex> m_vertex_buffer;
 };
 
 }


### PR DESCRIPTION
Three optimizations are applied:

1. If the list of vertices to clip is empty, return immediately after clearing the output list.
2. Remember the previous vertex instead of recalculating whether it is within the clip plane.
3. Instead of copying and swapping lists around, operate on the input and output lists directly. This prevents a lot of `malloc`/`free` traffic as a result of vector assignments.

This takes the clipping code CPU load from 3.9% down to 1.8% for Quake 3 on my machine.