### PR TITLE
LibCore: Automatically create config directories if necessary

### DIFF
--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -12,6 +12,7 @@
 
 #include <AK/LexicalPath.h>
 #include <AK/String.h>
+#include <LibCore/Directory.h>
 #include <LibCore/File.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
@@ -200,8 +201,8 @@ void NewProjectDialog::do_create_project()
         if (result != GUI::MessageBox::ExecResult::ExecYes)
             return;
 
-        auto created = Core::File::ensure_parent_directories(maybe_project_full_path.value());
-        if (!created) {
+        auto created = Core::Directory::create(maybe_project_full_path.value(), Core::Directory::CreateDirectories::Yes);
+        if (!created.is_error()) {
             GUI::MessageBox::show_error(this, String::formatted("Could not create directory {}", create_in));
             return;
         }

--- a/Userland/Libraries/LibCore/CMakeLists.txt
+++ b/Userland/Libraries/LibCore/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     ConfigFile.cpp
     Command.cpp
     DateTime.cpp
+    Directory.cpp
     DirIterator.cpp
     ElapsedTimer.cpp
     Event.cpp

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -6,23 +6,28 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/LexicalPath.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ConfigFile.h>
+#include <LibCore/Directory.h>
 #include <LibCore/StandardPaths.h>
+#include <LibCore/System.h>
 #include <pwd.h>
+#include <sys/types.h>
 
 namespace Core {
 
 ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open_for_lib(String const& lib_name, AllowWriting allow_altering)
 {
-    String directory = StandardPaths::config_directory();
-    auto path = String::formatted("{}/lib/{}.ini", directory, lib_name);
+    String directory_name = String::formatted("{}/lib", StandardPaths::config_directory());
+    auto directory = TRY(Directory::create(directory_name, Directory::CreateDirectories::Yes));
+    auto path = String::formatted("{}/{}.ini", directory, lib_name);
     return ConfigFile::open(path, allow_altering);
 }
 
 ErrorOr<NonnullRefPtr<ConfigFile>> ConfigFile::open_for_app(String const& app_name, AllowWriting allow_altering)
 {
-    String directory = StandardPaths::config_directory();
+    auto directory = TRY(Directory::create(StandardPaths::config_directory(), Directory::CreateDirectories::Yes));
     auto path = String::formatted("{}/{}.ini", directory, app_name);
     return ConfigFile::open(path, allow_altering);
 }

--- a/Userland/Libraries/LibCore/ConfigFile.h
+++ b/Userland/Libraries/LibCore/ConfigFile.h
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <AK/Forward.h>
 #include <AK/HashMap.h>
 #include <AK/RefCounted.h>
 #include <AK/RefPtr.h>

--- a/Userland/Libraries/LibCore/Directory.cpp
+++ b/Userland/Libraries/LibCore/Directory.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Directory.h"
+#include "DirIterator.h"
+#include "System.h"
+#include <dirent.h>
+
+namespace Core {
+
+// We assume that the fd is a valid directory.
+Directory::Directory(int fd, Optional<LexicalPath> path)
+    : m_path(move(path))
+    , m_directory_fd(fd)
+{
+}
+
+Directory::Directory(Directory&& other)
+    : m_path(move(other.m_path))
+    , m_directory_fd(other.m_directory_fd)
+{
+    other.m_directory_fd = -1;
+}
+
+Directory::~Directory()
+{
+    if (m_directory_fd != -1)
+        MUST(System::close(m_directory_fd));
+}
+
+ErrorOr<bool> Directory::is_valid_directory(int fd)
+{
+    auto stat = TRY(System::fstat(fd));
+    return stat.st_mode & S_IFDIR;
+}
+
+ErrorOr<Directory> Directory::adopt_fd(int fd, Optional<LexicalPath> path)
+{
+    // This will also fail if the fd is invalid in the first place.
+    if (!TRY(Directory::is_valid_directory(fd)))
+        return Error::from_errno(ENOTDIR);
+    return Directory { fd, move(path) };
+}
+
+ErrorOr<Directory> Directory::create(String path, CreateDirectories create_directories)
+{
+    return create(LexicalPath { move(path) }, create_directories);
+}
+
+ErrorOr<Directory> Directory::create(LexicalPath path, CreateDirectories create_directories)
+{
+    if (create_directories == CreateDirectories::Yes)
+        TRY(ensure_directory(path));
+    // FIXME: doesn't work on Linux probably
+    auto fd = TRY(System::open(path.string(), O_CLOEXEC));
+    return adopt_fd(fd, move(path));
+}
+
+ErrorOr<void> Directory::ensure_directory(LexicalPath const& path)
+{
+    if (path.basename() == "/")
+        return {};
+
+    TRY(ensure_directory(path.parent()));
+
+    auto return_value = System::mkdir(path.string(), 0755);
+    // We don't care if the directory already exists.
+    if (return_value.is_error() && return_value.error().code() != EEXIST)
+        return return_value;
+
+    return {};
+}
+
+ErrorOr<LexicalPath> Directory::path() const
+{
+    if (!m_path.has_value())
+        return Error::from_string_literal("Directory wasn't created with a path");
+    return m_path.value();
+}
+
+ErrorOr<NonnullOwnPtr<Stream::File>> Directory::open(StringView filename, Stream::OpenMode mode) const
+{
+    auto fd = TRY(System::openat(m_directory_fd, filename, Stream::File::open_mode_to_options(mode)));
+    return Stream::File::adopt_fd(fd, mode);
+}
+
+ErrorOr<struct stat> Directory::stat() const
+{
+    return System::fstat(m_directory_fd);
+}
+
+ErrorOr<DirIterator> Directory::create_iterator() const
+{
+    return DirIterator { TRY(path()).string() };
+}
+
+}

--- a/Userland/Libraries/LibCore/Directory.h
+++ b/Userland/Libraries/LibCore/Directory.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Format.h>
+#include <AK/LexicalPath.h>
+#include <AK/Noncopyable.h>
+#include <AK/Optional.h>
+#include <LibCore/Stream.h>
+#include <dirent.h>
+#include <sys/stat.h>
+
+namespace Core {
+
+class DirIterator;
+
+// Deal with real system directories. Any Directory instance always refers to a valid existing directory.
+class Directory {
+    AK_MAKE_NONCOPYABLE(Directory);
+
+public:
+    Directory(Directory&&);
+    ~Directory();
+
+    // When this flag is set, both the directory attempted to instantiate as well as all of its parents are created with mode 0755 if necessary.
+    enum class CreateDirectories : bool {
+        No,
+        Yes,
+    };
+
+    static ErrorOr<Directory> create(LexicalPath path, CreateDirectories);
+    static ErrorOr<Directory> create(String path, CreateDirectories);
+    static ErrorOr<Directory> adopt_fd(int fd, Optional<LexicalPath> path = {});
+
+    ErrorOr<NonnullOwnPtr<Stream::File>> open(StringView filename, Stream::OpenMode mode) const;
+    ErrorOr<struct stat> stat() const;
+    ErrorOr<DirIterator> create_iterator() const;
+
+    ErrorOr<LexicalPath> path() const;
+
+    static ErrorOr<bool> is_valid_directory(int fd);
+
+private:
+    Directory(int directory_fd, Optional<LexicalPath> path);
+    static ErrorOr<void> ensure_directory(LexicalPath const& path);
+
+    Optional<LexicalPath> m_path;
+    int m_directory_fd;
+};
+
+}
+
+namespace AK {
+template<>
+struct Formatter<Core::Directory> : Formatter<StringView> {
+    ErrorOr<void> format(FormatBuilder& builder, Core::Directory const& directory)
+    {
+        auto path = directory.path();
+        if (path.is_error())
+            return Formatter<StringView>::format(builder, "<unknown>");
+        return Formatter<StringView>::format(builder, path.release_value().string());
+    }
+};
+
+}

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -181,42 +181,6 @@ String File::real_path_for(String const& filename)
     return real_path;
 }
 
-bool File::ensure_parent_directories(String const& path)
-{
-    char* parent_buffer = strdup(path.characters());
-    ScopeGuard free_buffer = [parent_buffer] { free(parent_buffer); };
-
-    char const* parent = dirname(parent_buffer);
-
-    return ensure_directories(parent);
-}
-
-bool File::ensure_directories(String const& path)
-{
-    VERIFY(path.starts_with("/"));
-
-    int saved_errno = 0;
-    ScopeGuard restore_errno = [&saved_errno] { errno = saved_errno; };
-
-    int rc = mkdir(path.characters(), 0755);
-    saved_errno = errno;
-
-    if (rc == 0 || errno == EEXIST)
-        return true;
-
-    if (errno != ENOENT)
-        return false;
-
-    bool ok = ensure_parent_directories(path);
-    saved_errno = errno;
-    if (!ok)
-        return false;
-
-    rc = mkdir(path.characters(), 0755);
-    saved_errno = errno;
-    return rc == 0;
-}
-
 String File::current_working_directory()
 {
     char* cwd = getcwd(nullptr, 0);

--- a/Userland/Libraries/LibCore/File.h
+++ b/Userland/Libraries/LibCore/File.h
@@ -37,8 +37,6 @@ public:
 
     static bool exists(String const& filename);
     static ErrorOr<size_t> size(String const& filename);
-    static bool ensure_parent_directories(String const& path);
-    static bool ensure_directories(String const& path);
     static String current_working_directory();
     static String absolute_path(String const& path);
 

--- a/Userland/Libraries/LibCore/LockFile.cpp
+++ b/Userland/Libraries/LibCore/LockFile.cpp
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <LibCore/File.h>
+#include <LibCore/Directory.h>
 #include <LibCore/LockFile.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -16,7 +16,7 @@ namespace Core {
 LockFile::LockFile(char const* filename, Type type)
     : m_filename(filename)
 {
-    if (!Core::File::ensure_parent_directories(m_filename))
+    if (Core::Directory::create(LexicalPath(m_filename).parent(), Core::Directory::CreateDirectories::Yes).is_error())
         return;
 
     m_fd = open(filename, O_RDONLY | O_CREAT | O_CLOEXEC, 0666);

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -205,6 +205,8 @@ public:
 
     virtual ~File() override { close(); }
 
+    static int open_mode_to_options(OpenMode mode);
+
 private:
     File(OpenMode mode)
         : m_mode(mode)

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -10,6 +10,7 @@
 
 #include <AK/Error.h>
 #include <AK/StringView.h>
+#include <dirent.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <pwd.h>
@@ -68,7 +69,8 @@ ErrorOr<int> fcntl(int fd, int command, ...);
 ErrorOr<void*> mmap(void* address, size_t, int protection, int flags, int fd, off_t, size_t alignment = 0, StringView name = {});
 ErrorOr<void> munmap(void* address, size_t);
 ErrorOr<int> anon_create(size_t size, int options);
-ErrorOr<int> open(StringView path, int options, ...);
+ErrorOr<int> open(StringView path, int options, mode_t mode = 0);
+ErrorOr<int> openat(int fd, StringView path, int options, mode_t mode = 0);
 ErrorOr<void> close(int fd);
 ErrorOr<void> ftruncate(int fd, off_t length);
 ErrorOr<struct stat> stat(StringView path);

--- a/Userland/Services/ConfigServer/main.cpp
+++ b/Userland/Services/ConfigServer/main.cpp
@@ -14,6 +14,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio accept rpath wpath cpath"));
     TRY(Core::System::unveil(Core::StandardPaths::config_directory(), "rwc"));
+    TRY(Core::System::unveil(Core::StandardPaths::home_directory(), "rwc"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     Core::EventLoop event_loop;

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -16,7 +16,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments)
 {
-    TRY(Core::System::pledge("stdio proc exec rpath"));
+    TRY(Core::System::pledge("stdio proc exec rpath cpath"));
     auto keyboard_settings_config = TRY(Core::ConfigFile::open_for_app("KeyboardSettings"));
 
     TRY(Core::System::unveil("/bin/keymap", "x"));

--- a/Userland/Services/SystemServer/Service.cpp
+++ b/Userland/Services/SystemServer/Service.cpp
@@ -11,6 +11,7 @@
 #include <AK/JsonObject.h>
 #include <AK/StringBuilder.h>
 #include <LibCore/ConfigFile.h>
+#include <LibCore/Directory.h>
 #include <LibCore/File.h>
 #include <LibCore/SocketAddress.h>
 #include <LibCore/System.h>
@@ -34,8 +35,7 @@ void Service::setup_socket(SocketDescriptor& socket)
 {
     VERIFY(socket.fd == -1);
 
-    auto ok = Core::File::ensure_parent_directories(socket.path);
-    VERIFY(ok);
+    MUST(Core::Directory::create(LexicalPath(socket.path).parent(), Core::Directory::CreateDirectories::Yes));
 
     // Note: we use SOCK_CLOEXEC here to make sure we don't leak every socket to
     // all the clients. We'll make the one we do need to pass down !CLOEXEC later

--- a/Userland/Utilities/install.cpp
+++ b/Userland/Utilities/install.cpp
@@ -7,6 +7,7 @@
 #include <AK/LexicalPath.h>
 #include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Directory.h>
 #include <LibCore/File.h>
 #include <LibCore/FilePermissionsMask.h>
 #include <LibCore/System.h>
@@ -35,7 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     if (create_leading_dest_components) {
         String destination_dir_absolute = Core::File::absolute_path(destination_dir);
-        Core::File::ensure_directories(destination_dir_absolute);
+        MUST(Core::Directory::create(destination_dir_absolute, Core::Directory::CreateDirectories::Yes));
     }
 
     for (auto const& source : sources) {


### PR DESCRIPTION
If the .config directory (or its children, like lib) was deleted,
ConfigFile would crash because it would try to open or create a file in a directory that didn't exist. Therefore, for user and library configs (but not system configs), ensure that the parent directories exist. This allows the user to delete the entire .config folder and all apps still work. (Except those which can't handle missing config. That's a separate issue though.)
    
Fixes #13555
    
Note: Some changes to pledges and unveils are necessary for this to work. The only one who can recreate .config at the moment is ConfigServer, as others probably don't pledge the user home directory.

This PR also contains the new Core::Directory, which has the fixed ConfigFile as its first user.