### PR TITLE
Spreadsheet: Shortcut to copy cell directly above currently edited cell

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -281,6 +281,22 @@ void InfinitelyScrollableTableView::drop_event(GUI::DropEvent& event)
     }
 }
 
+void InfinitelyScrollableTableView::keydown_event(GUI::KeyEvent& event) {
+    if ( event.key() == Key_D && event.modifiers() & Mod_Ctrl ) {
+        auto active_cell_index = cursor_index();
+        int row_index = active_cell_index.row();
+        if ( row_index > 0 ) {
+            auto above_cell_index = model()->index(row_index - 1, active_cell_index.column());
+            auto above_cell = model()->data(above_cell_index);
+            model()->set_data(active_cell_index, above_cell);
+        }
+        event.accept();
+        return;
+    }
+
+    GUI::TableView::keydown_event(event);
+}
+
 void SpreadsheetView::update_with_model()
 {
     m_sheet_model->update();

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.cpp
@@ -281,11 +281,12 @@ void InfinitelyScrollableTableView::drop_event(GUI::DropEvent& event)
     }
 }
 
-void InfinitelyScrollableTableView::keydown_event(GUI::KeyEvent& event) {
-    if ( event.key() == Key_D && event.modifiers() & Mod_Ctrl ) {
+void InfinitelyScrollableTableView::keydown_event(GUI::KeyEvent& event)
+{
+    if (event.key() == Key_D && event.modifiers() & Mod_Ctrl) {
         auto active_cell_index = cursor_index();
         int row_index = active_cell_index.row();
-        if ( row_index > 0 ) {
+        if (row_index > 0) {
             auto above_cell_index = model()->index(row_index - 1, active_cell_index.column());
             auto above_cell = model()->data(above_cell_index);
             model()->set_data(active_cell_index, above_cell);

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -65,6 +65,7 @@ class InfinitelyScrollableTableView : public GUI::TableView {
 public:
     Function<void()> on_reaching_vertical_end;
     Function<void()> on_reaching_horizontal_end;
+
 private:
     InfinitelyScrollableTableView()
         : m_horizontal_scroll_end_timer(Core::Timer::construct())
@@ -110,6 +111,7 @@ public:
     void move_cursor(GUI::AbstractView::CursorMovement);
 
     NonnullRefPtr<SheetModel> model() { return m_sheet_model; };
+
 private:
     virtual void hide_event(GUI::HideEvent&) override;
     virtual void show_event(GUI::ShowEvent&) override;

--- a/Userland/Applications/Spreadsheet/SpreadsheetView.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetView.h
@@ -65,7 +65,6 @@ class InfinitelyScrollableTableView : public GUI::TableView {
 public:
     Function<void()> on_reaching_vertical_end;
     Function<void()> on_reaching_horizontal_end;
-
 private:
     InfinitelyScrollableTableView()
         : m_horizontal_scroll_end_timer(Core::Timer::construct())
@@ -77,6 +76,7 @@ private:
     virtual void mousedown_event(GUI::MouseEvent&) override;
     virtual void mouseup_event(GUI::MouseEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
+    virtual void keydown_event(GUI::KeyEvent&) override;
 
     bool m_is_hovering_extend_zone { false };
     bool m_is_hovering_cut_zone { false };
@@ -110,7 +110,6 @@ public:
     void move_cursor(GUI::AbstractView::CursorMovement);
 
     NonnullRefPtr<SheetModel> model() { return m_sheet_model; };
-
 private:
     virtual void hide_event(GUI::HideEvent&) override;
     virtual void show_event(GUI::ShowEvent&) override;

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -46,7 +46,7 @@ public:
     }
 
     void initialize_menubar(GUI::Window&);
-
+    void copy_cell_above();
     void undo();
     void redo();
     auto& undo_stack() { return m_undo_stack; }
@@ -88,6 +88,7 @@ private:
     RefPtr<GUI::Action> m_paste_action;
     RefPtr<GUI::Action> m_undo_action;
     RefPtr<GUI::Action> m_redo_action;
+    RefPtr<GUI::Action> m_copy_cell_above_action;
 
     RefPtr<GUI::Action> m_functions_help_action;
     RefPtr<GUI::Action> m_about_action;


### PR DESCRIPTION
Implement first part of excel Ctrl-D shortcut, which copies content of cell directly above currently edited one.

