### PR TITLE
chown: change ownership of multiple files at once

### DIFF
--- a/Base/usr/share/man/man1/chown.md
+++ b/Base/usr/share/man/man1/chown.md
@@ -23,6 +23,10 @@ $ chown anon:anon file
 
 # Change 'file' owner to 'root', leave group unchanged:
 # chown root file
+
+# Change 'file1' and 'file2' owner and group to 'anon':
+$ chown anon:anon file1 file2
+
 ```
 
 ## See also


### PR DESCRIPTION
Instead of having to run `chown` for every file you need, you can run it once and pass a lot of files

This also means you can pass shell wildcards (like `*`) and every single match will have its ownership changed