### PR TITLE
Meta: Fix qemu-img not being found on WSL

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -99,11 +99,15 @@ if [ -f _disk_image ]; then
     fi
 fi
 
+# source qemy-paths.sh for the SERENITY_QEMU_IMG_BIN variable so qemu-img works
+# correctly on windows
+. "$(dirname "${0}")/qemu-paths.sh"
+
 if [ $USE_EXISTING -eq 1 ];  then
     OLD_DISK_SIZE_BYTES=$(wc -c < _disk_image)
     if [ $DISK_SIZE_BYTES -gt "$OLD_DISK_SIZE_BYTES" ]; then
         echo "resizing disk image..."
-        qemu-img resize -f raw _disk_image $DISK_SIZE_BYTES || die "could not resize disk image"
+        "$SERENITY_QEMU_IMG_BIN" resize -f raw _disk_image $DISK_SIZE_BYTES || die "could not resize disk image"
         if ! resize2fs _disk_image; then
             rm -f _disk_image
             USE_EXISTING=0
@@ -115,7 +119,7 @@ fi
 
 if [ $USE_EXISTING -ne 1 ]; then
     printf "setting up disk image... "
-    qemu-img create -q -f raw _disk_image $DISK_SIZE_BYTES || die "could not create disk image"
+    "$SERENITY_QEMU_IMG_BIN" create -q -f raw _disk_image $DISK_SIZE_BYTES || die "could not create disk image"
     chown "$SUDO_UID":"$SUDO_GID" _disk_image || die "could not adjust permissions on disk image"
     echo "done"
 

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -101,7 +101,8 @@ fi
 
 # source qemy-paths.sh for the SERENITY_QEMU_IMG_BIN variable so qemu-img works
 # correctly on windows
-. "$(dirname "${0}")/qemu-paths.sh"
+# shellcheck disable=SC1090,SC1091
+. "$SCRIPT_DIR/qemu-paths.sh"
 
 if [ $USE_EXISTING -eq 1 ];  then
     OLD_DISK_SIZE_BYTES=$(wc -c < _disk_image)

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -99,8 +99,8 @@ if [ -f _disk_image ]; then
     fi
 fi
 
-# source qemy-paths.sh for the SERENITY_QEMU_IMG_BIN variable so qemu-img works
-# correctly on windows
+# Source qemu-paths.sh for the SERENITY_QEMU_IMG_BIN variable so qemu-img works
+# correctly on Windows.
 # shellcheck disable=SC1090,SC1091
 . "$SCRIPT_DIR/qemu-paths.sh"
 

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -36,7 +36,7 @@ if (( ${#files[@]} )); then
         exit 1
     fi
 
-    shellcheck "${files[@]}"
+    shellcheck -P "./Meta/" "${files[@]}"
 
     for file in "${files[@]}"; do
         if (< "$file" grep -qE "grep [^|);]*-[^- ]*P"); then

--- a/Meta/lint-shell-scripts.sh
+++ b/Meta/lint-shell-scripts.sh
@@ -36,7 +36,7 @@ if (( ${#files[@]} )); then
         exit 1
     fi
 
-    shellcheck -P "./Meta/" "${files[@]}"
+    shellcheck "${files[@]}"
 
     for file in "${files[@]}"; do
         if (< "$file" grep -qE "grep [^|);]*-[^- ]*P"); then

--- a/Meta/qemu-paths.sh
+++ b/Meta/qemu-paths.sh
@@ -14,9 +14,8 @@ if command -v wslpath >/dev/null; then
     QEMU_INSTALL_DIR=$(PowerShell.exe -Command Get-ItemPropertyValue 'HKLM:\SOFTWARE\QEMU' -Name Install_Dir)
 
     if [ -z "$QEMU_INSTALL_DIR" ]; then
-        if [ "$KVM_SUPPORT" -eq "0" ]; then
-            die "Could not determine where QEMU for Windows is installed. Please make sure QEMU is installed or set SERENITY_QEMU_IMG_BIN and SERENITY_QEMU_BIN if it is already installed."
-        fi
+        echo "die: Could not determine where QEMU for Windows is installed. Please make sure QEMU is installed or set SERENITY_QEMU_IMG_BIN and SERENITY_QEMU_BIN if it is already installed."
+        exit 1
     else
         KVM_SUPPORT="0"
         QEMU_BINARY_PREFIX="$(wslpath -- "${QEMU_INSTALL_DIR}" | tr -d '\r\n')/"
@@ -38,5 +37,6 @@ if [ -z "$SERENITY_QEMU_BIN" ]; then
     fi
 fi
 
+export KVM_SUPPORT
 export SERENITY_QEMU_IMG_BIN
 export SERENITY_QEMU_BIN

--- a/Meta/qemu-paths.sh
+++ b/Meta/qemu-paths.sh
@@ -2,15 +2,15 @@
 
 set -e
 
-# sourcing this file will export SERENITY_QEMU_IMG_BIN and SERENITY_QEMU_BIN
-# in such a way that they will contain the correct paths also under WSL
+# Sourcing this file will export SERENITY_QEMU_IMG_BIN and SERENITY_QEMU_BIN
+# in such a way that they will contain the correct paths also under WSL.
 
 if command -v wslpath >/dev/null; then
-    # existence of wslpath implies we are running inside WSL on Windows
-    # the Windows installation of QEMU adds the install directory of itself
-    # to the registry, we use powershell to get the install directory
+    # The existence of wslpath implies we are running inside WSL on Windows.
+    # The Windows installation of QEMU adds the install directory of itself
+    # to the registry, we use PowerShell to get the install directory.
 
-    # System32 and cohorts must be on the PATH for the build to work anyways so using powershell without full path is fine
+    # System32 and cohorts must be on the PATH for the build to work anyways so using powershell without full path is fine.
     QEMU_INSTALL_DIR=$(PowerShell.exe -Command Get-ItemPropertyValue 'HKLM:\SOFTWARE\QEMU' -Name Install_Dir)
 
     if [ -z "$QEMU_INSTALL_DIR" ]; then

--- a/Meta/qemu-paths.sh
+++ b/Meta/qemu-paths.sh
@@ -10,8 +10,8 @@ if command -v wslpath >/dev/null; then
     # the Windows installation of QEMU adds the install directory of itself
     # to the registry, we use powershell to get the install directory
 
-    # Use full path to powershell, just in case it is not on the path already
-    QEMU_INSTALL_DIR=$(/mnt/c/Windows/System32/WindowsPowershell/v1.0/powershell.exe -Command Get-ItemPropertyValue 'HKLM:\SOFTWARE\QEMU' -Name Install_Dir)
+    # System32 and cohorts must be on the PATH for the build to work anyways so using powershell without full path is fine
+    QEMU_INSTALL_DIR=$(PowerShell.exe -Command Get-ItemPropertyValue 'HKLM:\SOFTWARE\QEMU' -Name Install_Dir)
 
     if [ -z "$QEMU_INSTALL_DIR" ]; then
         if [ "$KVM_SUPPORT" -eq "0" ]; then

--- a/Meta/qemu-paths.sh
+++ b/Meta/qemu-paths.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+set -e
+
+# sourcing this file will export SERENITY_QEMU_IMG_BIN and SERENITY_QEMU_BIN
+# in such a way that they will contain the correct paths also under WSL
+
+if command -v wslpath >/dev/null; then
+    # existence of wslpath implies we are running inside WSL on Windows
+    # the Windows installation of QEMU adds the install directory of itself
+    # to the registry, we use powershell to get the install directory
+
+    # Use full path to powershell, just in case it is not on the path already
+    QEMU_INSTALL_DIR=$(/mnt/c/Windows/System32/WindowsPowershell/v1.0/powershell.exe -Command Get-ItemPropertyValue 'HKLM:\SOFTWARE\QEMU' -Name Install_Dir)
+
+    if [ -z "$QEMU_INSTALL_DIR" ]; then
+        if [ "$KVM_SUPPORT" -eq "0" ]; then
+            die "Could not determine where QEMU for Windows is installed. Please make sure QEMU is installed or set SERENITY_QEMU_IMG_BIN and SERENITY_QEMU_BIN if it is already installed."
+        fi
+    else
+        KVM_SUPPORT="0"
+        QEMU_BINARY_PREFIX="$(wslpath -- "${QEMU_INSTALL_DIR}" | tr -d '\r\n')/"
+        QEMU_BINARY_SUFFIX=".exe"
+    fi
+fi
+
+if [ -z "$SERENITY_QEMU_IMG_BIN" ]; then
+    SERENITY_QEMU_IMG_BIN="${QEMU_BINARY_PREFIX}qemu-img${QEMU_BINARY_SUFFIX}"
+fi
+
+if [ -z "$SERENITY_QEMU_BIN" ]; then
+    if [ "$SERENITY_ARCH" = "aarch64" ]; then
+        SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-aarch64${QEMU_BINARY_SUFFIX}"
+    elif [ "$SERENITY_ARCH" = "x86_64" ]; then
+        SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-x86_64${QEMU_BINARY_SUFFIX}"
+    else
+        SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-i386${QEMU_BINARY_SUFFIX}"
+    fi
+fi
+
+export SERENITY_QEMU_IMG_BIN
+export SERENITY_QEMU_BIN

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -56,29 +56,7 @@ PATH="$SCRIPT_DIR/../Toolchain/Local/i686/bin:$PATH"
 
 SERENITY_RUN="${SERENITY_RUN:-$1}"
 
-if [ -z "$SERENITY_QEMU_BIN" ]; then
-    if command -v wslpath >/dev/null; then
-        # Some Windows systems don't have reg.exe's directory on the PATH by default.
-        PATH=$PATH:/mnt/c/Windows/System32
-        QEMU_INSTALL_DIR=$(reg.exe query 'HKLM\Software\QEMU' /v Install_Dir /t REG_SZ | grep '^    Install_Dir' | sed 's/    / /g' | cut -f4- -d' ')
-        if [ -z "$QEMU_INSTALL_DIR" ]; then
-            if [ "$VIRTUALIZATION_SUPPORT" -eq "0" ]; then
-                die "Could not determine where QEMU for Windows is installed. Please make sure QEMU is installed or set SERENITY_QEMU_BIN if it is already installed."
-            fi
-        else
-            QEMU_BINARY_PREFIX="$(wslpath -- "${QEMU_INSTALL_DIR}" | tr -d '\r\n')/"
-            QEMU_BINARY_SUFFIX=".exe"
-        fi
-    fi
-    if [ "$SERENITY_ARCH" = "aarch64" ]; then
-        SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-aarch64${QEMU_BINARY_SUFFIX}"
-    elif [ "$SERENITY_ARCH" = "x86_64" ]; then
-        SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-x86_64${QEMU_BINARY_SUFFIX}"
-    else
-        SERENITY_QEMU_BIN="${QEMU_BINARY_PREFIX}qemu-system-i386${QEMU_BINARY_SUFFIX}"
-    fi
-fi
-
+ "$(dirname "${0}")/qemu-paths.sh"
 
 # For default values, see Kernel/CommandLine.cpp
 [ -z "$SERENITY_KERNEL_CMDLINE" ] && SERENITY_KERNEL_CMDLINE="hello"
@@ -335,7 +313,7 @@ $SERENITY_EXTRA_QEMU_ARGS
 -device isa-cirrus-vga
 -device isa-ide
 $SERENITY_BOOT_DRIVE
--device i8042 
+-device i8042
 -device ide-hd,drive=disk
 "
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -56,7 +56,10 @@ PATH="$SCRIPT_DIR/../Toolchain/Local/i686/bin:$PATH"
 
 SERENITY_RUN="${SERENITY_RUN:-$1}"
 
- "$(dirname "${0}")/qemu-paths.sh"
+# shellcheck disable=SC1090,SC1091
+. "$SCRIPT_DIR/qemu-paths.sh"
+
+[ "$KVM_SUPPORT" -eq "1" ] && SERENITY_VIRT_TECH_ARG="-enable-kvm"
 
 # For default values, see Kernel/CommandLine.cpp
 [ -z "$SERENITY_KERNEL_CMDLINE" ] && SERENITY_KERNEL_CMDLINE="hello"


### PR DESCRIPTION
Meta/build-image-qemu.sh used qemu-img straight without considering WSL.
I refactored logic from Meta/run.sh to Meta/qemu-paths.sh so it can be
sourced in any shell script and added SERENITY_QEMU_IMG_BIN variable that
configures where the qemu-img is located.

---

As things often go, I was just browsing around the internet on a lazy Sunday afternoon and ended up reading about SerenityOS somehow. Cue me multiple hours later, after watching 6+ months of update videos, I decide to see how hard it could possibly be to get things running locally. Thankfully to me not very hard at all, although I did need to manually fix `qemu-img` to `qemu-img.exe` (and needed to QEMU install directory to the path).

The thankful folks at the Discord pointed me a bit more to the right direction and I took some time from my evening to make this patch.

It "works on my machine" and it shouldn't have broken anything. Using `../../Meta/qemu-paths.sh` is less than optimal in my opinion but it seems that it should work correctly in all cases at the moment. It would probably be nicer to have in a more stable manner, something like `"$SERENITY_ROOT_PATH/Meta/qemu-paths.sh"` but I couldn't figure out how to do that.

I hope the commit message is in the correct style, I couldn't see any documentation relating to it.