### PR TITLE
Kernel: Use kernel_mapping_base as the minimum kernel stack address

### DIFF
--- a/Kernel/KSyms.cpp
+++ b/Kernel/KSyms.cpp
@@ -124,7 +124,7 @@ NEVER_INLINE static void dump_backtrace_impl(FlatPtr base_pointer, bool use_ksym
     if (use_ksyms) {
         FlatPtr copied_stack_ptr[2];
         for (FlatPtr* stack_ptr = (FlatPtr*)base_pointer; stack_ptr && recognized_symbol_count < max_recognized_symbol_count; stack_ptr = (FlatPtr*)copied_stack_ptr[0]) {
-            if ((FlatPtr)stack_ptr < kernel_load_base)
+            if ((FlatPtr)stack_ptr < kernel_mapping_base)
                 break;
 
             void* fault_at;


### PR DESCRIPTION
Since KASLR was added kernel_load_base only signifies the address at which the kernel image start, not the start of kernel memory, meaning that a valid kernel stack can be allocated before it in memory.

We use kernel_mapping_base, the lowest address covered by the kernel page directory, as the minimal address when performing safety checks during backtrace generation.