### PR TITLE
LibWeb: Add SVGDefsElement

### DIFF
--- a/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
+++ b/Userland/Libraries/LibWeb/Bindings/WindowObjectHelper.h
@@ -269,6 +269,8 @@
 #include <LibWeb/Bindings/SVGCircleElementPrototype.h>
 #include <LibWeb/Bindings/SVGClipPathElementConstructor.h>
 #include <LibWeb/Bindings/SVGClipPathElementPrototype.h>
+#include <LibWeb/Bindings/SVGDefsElementConstructor.h>
+#include <LibWeb/Bindings/SVGDefsElementPrototype.h>
 #include <LibWeb/Bindings/SVGElementConstructor.h>
 #include <LibWeb/Bindings/SVGElementPrototype.h>
 #include <LibWeb/Bindings/SVGEllipseElementConstructor.h>
@@ -487,6 +489,7 @@
     ADD_WINDOW_OBJECT_INTERFACE(SVGElement)                                                         \
     ADD_WINDOW_OBJECT_INTERFACE(SVGCircleElement)                                                   \
     ADD_WINDOW_OBJECT_INTERFACE(SVGClipPathElement)                                                 \
+    ADD_WINDOW_OBJECT_INTERFACE(SVGDefsElement)                                                     \
     ADD_WINDOW_OBJECT_INTERFACE(SVGEllipseElement)                                                  \
     ADD_WINDOW_OBJECT_INTERFACE(SVGGeometryElement)                                                 \
     ADD_WINDOW_OBJECT_INTERFACE(SVGGraphicsElement)                                                 \

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -318,6 +318,7 @@ set(SOURCES
     SVG/AttributeParser.cpp
     SVG/SVGAnimatedLength.cpp
     SVG/SVGClipPathElement.cpp
+    SVG/SVGDefsElement.cpp
     SVG/SVGElement.cpp
     SVG/SVGElement.cpp
     SVG/SVGGElement.cpp
@@ -584,6 +585,7 @@ libweb_js_wrapper(RequestIdleCallback/IdleDeadline)
 libweb_js_wrapper(ResizeObserver/ResizeObserver)
 libweb_js_wrapper(SVG/SVGAnimatedLength)
 libweb_js_wrapper(SVG/SVGClipPathElement)
+libweb_js_wrapper(SVG/SVGDefsElement)
 libweb_js_wrapper(SVG/SVGElement)
 libweb_js_wrapper(SVG/SVGGeometryElement)
 libweb_js_wrapper(SVG/SVGGraphicsElement)

--- a/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
+++ b/Userland/Libraries/LibWeb/DOM/ElementFactory.cpp
@@ -78,6 +78,7 @@
 #include <LibWeb/HTML/HTMLVideoElement.h>
 #include <LibWeb/SVG/SVGCircleElement.h>
 #include <LibWeb/SVG/SVGClipPathElement.h>
+#include <LibWeb/SVG/SVGDefsElement.h>
 #include <LibWeb/SVG/SVGEllipseElement.h>
 #include <LibWeb/SVG/SVGGElement.h>
 #include <LibWeb/SVG/SVGLineElement.h>
@@ -266,6 +267,8 @@ NonnullRefPtr<Element> create_element(Document& document, FlyString local_name, 
         return adopt_ref(*new SVG::SVGClipPathElement(document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::circle)
         return adopt_ref(*new SVG::SVGCircleElement(document, move(qualified_name)));
+    if (lowercase_tag_name.equals_ignoring_case(SVG::TagNames::defs))
+        return adopt_ref(*new SVG::SVGDefsElement(document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::ellipse)
         return adopt_ref(*new SVG::SVGEllipseElement(document, move(qualified_name)));
     if (lowercase_tag_name == SVG::TagNames::line)

--- a/Userland/Libraries/LibWeb/Forward.h
+++ b/Userland/Libraries/LibWeb/Forward.h
@@ -297,6 +297,7 @@ namespace Web::SVG {
 class SVGAnimatedLength;
 class SVGCircleElement;
 class SVGClipPathElement;
+class SVGDefsElement;
 class SVGElement;
 class SVGEllipseElement;
 class SVGGeometryElement;
@@ -523,6 +524,7 @@ class SubmitEventWrapper;
 class SubtleCryptoWrapper;
 class SVGAnimatedLengthWrapper;
 class SVGCircleElementWrapper;
+class SVGDefsElementWrapper;
 class SVGClipPathElementWrapper;
 class SVGElementWrapper;
 class SVGEllipseElementWrapper;

--- a/Userland/Libraries/LibWeb/SVG/SVGDefsElement.cpp
+++ b/Userland/Libraries/LibWeb/SVG/SVGDefsElement.cpp
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022, Simon Danner <danner.simon@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibWeb/SVG/SVGDefsElement.h>
+
+namespace Web::SVG {
+
+SVGDefsElement::SVGDefsElement(DOM::Document& document, DOM::QualifiedName qualified_name)
+    : SVGGraphicsElement(document, move(qualified_name))
+{
+}
+
+SVGDefsElement::~SVGDefsElement()
+{
+}
+
+RefPtr<Layout::Node> SVGDefsElement::create_layout_node(NonnullRefPtr<CSS::StyleProperties>)
+{
+    return nullptr;
+}
+
+}

--- a/Userland/Libraries/LibWeb/SVG/SVGDefsElement.h
+++ b/Userland/Libraries/LibWeb/SVG/SVGDefsElement.h
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022, Simon Danner <danner.simon@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibWeb/SVG/SVGGraphicsElement.h>
+
+namespace Web::SVG {
+
+class SVGDefsElement final : public SVGGraphicsElement {
+public:
+    using WrapperType = Bindings::SVGDefsElementWrapper;
+
+    SVGDefsElement(DOM::Document&, DOM::QualifiedName);
+    virtual ~SVGDefsElement();
+
+    virtual RefPtr<Layout::Node> create_layout_node(NonnullRefPtr<CSS::StyleProperties>) override;
+};
+
+}

--- a/Userland/Libraries/LibWeb/SVG/SVGDefsElement.idl
+++ b/Userland/Libraries/LibWeb/SVG/SVGDefsElement.idl
@@ -1,0 +1,3 @@
+[Exposed=Window]
+interface SVGDefsElement : SVGGraphicsElement {
+};

--- a/Userland/Libraries/LibWeb/SVG/TagNames.h
+++ b/Userland/Libraries/LibWeb/SVG/TagNames.h
@@ -25,6 +25,7 @@ namespace Web::SVG::TagNames {
 #define ENUMERATE_SVG_TAGS             \
     ENUMERATE_SVG_GRAPHICS_TAGS        \
     __ENUMERATE_SVG_TAG(clipPath)      \
+    __ENUMERATE_SVG_TAG(defs)          \
     __ENUMERATE_SVG_TAG(desc)          \
     __ENUMERATE_SVG_TAG(foreignObject) \
     __ENUMERATE_SVG_TAG(script)        \


### PR DESCRIPTION
* Similarly to clipPath, this doesn't need to get rendered, so return no
  LayoutNode.