### PR TITLE
LibGfx: Draw complex emojis correctly

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2323,14 +2323,18 @@ void Painter::draw_text_run(FloatPoint const& baseline_start, Utf8View const& st
     float space_width = font.glyph_or_emoji_width(' ');
 
     u32 last_code_point = 0;
-    for (auto code_point : string) {
+
+    for (auto code_point_iterator = string.begin(); code_point_iterator != string.end(); ++code_point_iterator) {
+        auto code_point = *code_point_iterator;
         if (code_point == ' ') {
             x += space_width;
             last_code_point = code_point;
             continue;
         }
+
+        // FIXME: this is probably not the real space taken for complex emojis
         x += font.glyphs_horizontal_kerning(last_code_point, code_point);
-        draw_glyph_or_emoji({ static_cast<int>(lroundf(x)), y }, code_point, font, color);
+        draw_glyph_or_emoji({ static_cast<int>(lroundf(x)), y }, code_point_iterator, font, color);
         x += font.glyph_or_emoji_width(code_point) + font.glyph_spacing();
         last_code_point = code_point;
     }


### PR DESCRIPTION
Previously draw_text_run only passed a single code point to
draw_glyph_or_emoji. This lead e.g. to broken unicode flag support.
Improve this by passing along the code_point iterator, so the emoji code
can detect the correct emojis and advance it as needed.