### PR TITLE
GMLPlayground+LibGUI: Keep being modified after formatting

### DIFF
--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -227,7 +227,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(edit_menu->try_add_action(GUI::Action::create("&Format GML", { Mod_Ctrl | Mod_Shift, Key_I }, [&](auto&) {
         auto formatted_gml_or_error = GUI::GML::format_gml(editor->text());
         if (!formatted_gml_or_error.is_error()) {
-            editor->set_text(formatted_gml_or_error.release_value());
+            editor->replace_all_text_while_keeping_undo_stack(formatted_gml_or_error.release_value());
         } else {
             GUI::MessageBox::show(
                 window,

--- a/Userland/DevTools/Playground/main.cpp
+++ b/Userland/DevTools/Playground/main.cpp
@@ -227,7 +227,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(edit_menu->try_add_action(GUI::Action::create("&Format GML", { Mod_Ctrl | Mod_Shift, Key_I }, [&](auto&) {
         auto formatted_gml_or_error = GUI::GML::format_gml(editor->text());
         if (!formatted_gml_or_error.is_error()) {
-            editor->replace_all_text_while_keeping_undo_stack(formatted_gml_or_error.release_value());
+            editor->replace_all_text_without_resetting_undo_stack(formatted_gml_or_error.release_value());
         } else {
             GUI::MessageBox::show(
                 window,

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -884,6 +884,40 @@ void RemoveTextCommand::undo()
     m_document.set_all_cursors(new_cursor);
 }
 
+ReplaceAllTextCommand::ReplaceAllTextCommand(GUI::TextDocument& document, String const& text, GUI::TextRange const& range)
+    : TextDocumentUndoCommand(document)
+    , m_text(text)
+    , m_range(range)
+{
+}
+
+void ReplaceAllTextCommand::redo()
+{
+    m_document.remove(m_range);
+    m_document.set_all_cursors(m_range.start());
+    auto new_cursor = m_document.insert_at(m_range.start(), m_text, m_client);
+    m_range.set_end(new_cursor);
+    m_document.set_all_cursors(new_cursor);
+}
+
+void ReplaceAllTextCommand::undo()
+{
+    m_document.remove(m_range);
+    m_document.set_all_cursors(m_range.start());
+    auto new_cursor = m_document.insert_at(m_range.start(), m_text);
+    m_document.set_all_cursors(new_cursor);
+}
+
+bool ReplaceAllTextCommand::merge_with(GUI::Command const&)
+{
+    return false;
+}
+
+String ReplaceAllTextCommand::action_text() const
+{
+    return "Playground format text";
+}
+
 TextPosition TextDocument::insert_at(TextPosition const& position, StringView text, Client const* client)
 {
     TextPosition cursor = position;

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -884,10 +884,11 @@ void RemoveTextCommand::undo()
     m_document.set_all_cursors(new_cursor);
 }
 
-ReplaceAllTextCommand::ReplaceAllTextCommand(GUI::TextDocument& document, String const& text, GUI::TextRange const& range)
+ReplaceAllTextCommand::ReplaceAllTextCommand(GUI::TextDocument& document, String const& text, GUI::TextRange const& range, String const& action_text)
     : TextDocumentUndoCommand(document)
     , m_text(text)
     , m_range(range)
+    , m_action_text(action_text)
 {
 }
 
@@ -916,7 +917,7 @@ bool ReplaceAllTextCommand::merge_with(GUI::Command const&)
 
 String ReplaceAllTextCommand::action_text() const
 {
-    return "Playground format text";
+    return m_action_text;
 }
 
 TextPosition TextDocument::insert_at(TextPosition const& position, StringView text, Client const* client)

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -905,6 +905,7 @@ void ReplaceAllTextCommand::undo()
     m_document.remove(m_range);
     m_document.set_all_cursors(m_range.start());
     auto new_cursor = m_document.insert_at(m_range.start(), m_text);
+    m_range.set_end(new_cursor);
     m_document.set_all_cursors(new_cursor);
 }
 

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -236,4 +236,20 @@ private:
     TextRange m_range;
 };
 
+class ReplaceAllTextCommand : public GUI::TextDocumentUndoCommand {
+
+public:
+    ReplaceAllTextCommand(GUI::TextDocument& document, String const& text, GUI::TextRange const& range);
+    void redo() override;
+    void undo() override;
+    bool merge_with(GUI::Command const&) override;
+    String action_text() const override;
+    String const& text() const { return m_text; }
+    TextRange const& range() const { return m_range; }
+
+private:
+    String m_text;
+    GUI::TextRange m_range;
+};
+
 }

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -236,10 +236,10 @@ private:
     TextRange m_range;
 };
 
-class ReplaceAllTextCommand : public GUI::TextDocumentUndoCommand {
+class ReplaceAllTextCommand final : public GUI::TextDocumentUndoCommand {
 
 public:
-    ReplaceAllTextCommand(GUI::TextDocument& document, String const& text, GUI::TextRange const& range);
+    ReplaceAllTextCommand(GUI::TextDocument& document, String const& text, GUI::TextRange const& range, String const& action_text);
     void redo() override;
     void undo() override;
     bool merge_with(GUI::Command const&) override;
@@ -250,6 +250,7 @@ public:
 private:
     String m_text;
     GUI::TextRange m_range;
+    String m_action_text;
 };
 
 }

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1446,14 +1446,14 @@ void TextEditor::insert_at_cursor_or_replace_selection(StringView text)
     }
 }
 
-void TextEditor::replace_all_text_while_keeping_undo_stack(StringView text)
+void TextEditor::replace_all_text_without_resetting_undo_stack(StringView text)
 {
     auto start = GUI::TextPosition(0, 0);
     auto last_line_index = line_count() - 1;
     auto end = GUI::TextPosition(last_line_index, line(last_line_index).length());
     auto range = GUI::TextRange(start, end);
     auto normalized_range = range.normalized();
-    execute<ReplaceAllTextCommand>(text, range);
+    execute<ReplaceAllTextCommand>(text, range, "GML Playground Format Text");
     did_change();
     set_cursor(normalized_range.start());
     update();

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1446,6 +1446,19 @@ void TextEditor::insert_at_cursor_or_replace_selection(StringView text)
     }
 }
 
+void TextEditor::replace_all_text_while_keeping_undo_stack(StringView text)
+{
+    auto start = GUI::TextPosition(0, 0);
+    auto last_line_index = line_count() - 1;
+    auto end = GUI::TextPosition(last_line_index, line(last_line_index).length());
+    auto range = GUI::TextRange(start, end);
+    auto normalized_range = range.normalized();
+    execute<ReplaceAllTextCommand>(text, range);
+    did_change();
+    set_cursor(normalized_range.start());
+    update();
+}
+
 void TextEditor::cut()
 {
     if (!is_editable())

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -123,6 +123,7 @@ public:
     TextRange normalized_selection() const { return m_selection.normalized(); }
 
     void insert_at_cursor_or_replace_selection(StringView);
+    void replace_all_text_while_keeping_undo_stack(StringView text);
     bool write_to_file(String const& path);
     bool write_to_file(Core::File&);
     bool has_selection() const { return m_selection.is_valid(); }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -123,7 +123,7 @@ public:
     TextRange normalized_selection() const { return m_selection.normalized(); }
 
     void insert_at_cursor_or_replace_selection(StringView);
-    void replace_all_text_while_keeping_undo_stack(StringView text);
+    void replace_all_text_without_resetting_undo_stack(StringView text);
     bool write_to_file(String const& path);
     bool write_to_file(Core::File&);
     bool has_selection() const { return m_selection.is_valid(); }


### PR DESCRIPTION
Extracted the text modifying part of `TextDocument::set_text()` out into a new method `TextDocument::modify_text()`. So that `modify_text` can be used, when caller doesn't want to clear the `undo_stack`.

`set_text` is used, for example when loading files, where we dont want to be able to undo to the file before. `modify_text` can be used, for example by GMLPlayground to format text, while still being able to undo and the `window->is_modified()` intact.

Closes #11810 