### PR TITLE
Kernel: Skip setting region name if none is given to mmap

### DIFF
--- a/Kernel/Syscalls/mmap.cpp
+++ b/Kernel/Syscalls/mmap.cpp
@@ -240,7 +240,8 @@ ErrorOr<FlatPtr> Process::sys$mmap(Userspace<Syscall::SC_mmap_params const*> use
         region->set_shared(true);
     if (map_stack)
         region->set_stack(true);
-    region->set_name(move(name));
+    if (name)
+        region->set_name(move(name));
 
     PerformanceManager::add_mmap_perf_event(*this, *region);
 


### PR DESCRIPTION
This keeps us from accidentally overwriting an already set region name, for example when we are mapping a file (as, in this case, the file name is already stored in the region).