### PR TITLE
Kernel: Increase the default userspace stack size to 4 MiB

### DIFF
--- a/Kernel/Thread.h
+++ b/Kernel/Thread.h
@@ -1025,7 +1025,7 @@ public:
     static IterationDecision for_each(Callback);
 
     static constexpr u32 default_kernel_stack_size = 65536;
-    static constexpr u32 default_userspace_stack_size = 1 * MiB;
+    static constexpr u32 default_userspace_stack_size = 4 * MiB;
 
     u64 time_in_user() const { return m_total_time_scheduled_user; }
     u64 time_in_kernel() const { return m_total_time_scheduled_kernel; }


### PR DESCRIPTION
This makes the main thread stack size the same as [the default stack size when creating new threads](https://github.com/SerenityOS/serenity/blob/81f1929a6fed63e6778e6ac71136dde8971bad6b/Kernel/API/Syscall.h#L357), while still keeping away from the self-imposed limit of 8 MiB that we defined as "[the highest reasonable stack size](https://github.com/SerenityOS/serenity/blob/81f1929a6fed63e6778e6ac71136dde8971bad6b/Userland/Libraries/LibPthread/pthread.cpp#L35)".

This solves a stack overflow issue with Clang on `x86_64`, which recurses quite deep when compiling certain source files.