### PR TITLE
LibWeb: Improve spec compliance of some HTML elements

### DIFF
--- a/Userland/Libraries/LibWeb/DOM/Document.h
+++ b/Userland/Libraries/LibWeb/DOM/Document.h
@@ -67,6 +67,9 @@ public:
     void set_url(const AK::URL& url) { m_url = url; }
     AK::URL url() const { return m_url; }
 
+    String url_string() const { return m_url.to_string(); }
+    String document_uri() const { return m_url.to_string(); }
+
     Origin origin() const;
     void set_origin(Origin const& origin);
 

--- a/Userland/Libraries/LibWeb/DOM/Document.idl
+++ b/Userland/Libraries/LibWeb/DOM/Document.idl
@@ -29,6 +29,9 @@ interface Document : Node {
 
     readonly attribute DOMImplementation implementation;
 
+    [ImplementedAs=url_string] readonly attribute USVString URL;
+    readonly attribute USVString documentURI;
+
     readonly attribute DOMString characterSet;
     readonly attribute DOMString charset;
     readonly attribute DOMString inputEncoding;

--- a/Userland/Libraries/LibWeb/DOM/Node.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Node.cpp
@@ -78,6 +78,13 @@ Node::~Node()
     deallocate_node_id(m_id);
 }
 
+// https://dom.spec.whatwg.org/#dom-node-baseuri
+String Node::base_uri() const
+{
+    // FIXME: Return this’s node document’s document base URL, serialized.
+    return document().url_string();
+}
+
 const HTML::HTMLAnchorElement* Node::enclosing_link_element() const
 {
     for (auto* node = this; node; node = node->parent()) {

--- a/Userland/Libraries/LibWeb/DOM/Node.h
+++ b/Userland/Libraries/LibWeb/DOM/Node.h
@@ -113,6 +113,8 @@ public:
 
     virtual FlyString node_name() const = 0;
 
+    String base_uri() const;
+
     String descendant_text_content() const;
     String text_content() const;
     void set_text_content(String const&);

--- a/Userland/Libraries/LibWeb/DOM/Node.idl
+++ b/Userland/Libraries/LibWeb/DOM/Node.idl
@@ -7,6 +7,8 @@ interface Node : EventTarget {
     readonly attribute unsigned short nodeType;
     readonly attribute DOMString nodeName;
 
+    readonly attribute USVString baseURI;
+
     boolean hasChildNodes();
     [SameObject] readonly attribute NodeList childNodes;
     readonly attribute Node? firstChild;

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -138,4 +138,28 @@ void HTMLImageElement::set_height(unsigned height)
     set_attribute(HTML::AttributeNames::height, String::number(height));
 }
 
+// https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-naturalwidth
+unsigned HTMLImageElement::natural_width() const
+{
+    // Return the density-corrected intrinsic width of the image, in CSS pixels,
+    // if the image has intrinsic dimensions and is available.
+    if (m_image_loader.has_image())
+        return m_image_loader.width();
+
+    // ...or else 0.
+    return 0;
+}
+
+// https://html.spec.whatwg.org/multipage/embedded-content.html#dom-img-naturalheight
+unsigned HTMLImageElement::natural_height() const
+{
+    // Return the density-corrected intrinsic height of the image, in CSS pixels,
+    // if the image has intrinsic dimensions and is available.
+    if (m_image_loader.has_image())
+        return m_image_loader.height();
+
+    // ...or else 0.
+    return 0;
+}
+
 }

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.cpp
@@ -101,6 +101,11 @@ unsigned HTMLImageElement::width() const
     if (auto* paint_box = this->paint_box())
         return paint_box->content_width();
 
+    // NOTE: This step seems to not be in the spec, but all browsers do it.
+    auto width_attr = get_attribute(HTML::AttributeNames::width);
+    if (auto converted = width_attr.to_uint(); converted.has_value())
+        return *converted;
+
     // ...or else the density-corrected intrinsic width and height of the image, in CSS pixels,
     // if the image has intrinsic dimensions and is available but not being rendered.
     if (m_image_loader.has_image())
@@ -123,6 +128,11 @@ unsigned HTMLImageElement::height() const
     // Return the rendered height of the image, in CSS pixels, if the image is being rendered.
     if (auto* paint_box = this->paint_box())
         return paint_box->content_height();
+
+    // NOTE: This step seems to not be in the spec, but all browsers do it.
+    auto height_attr = get_attribute(HTML::AttributeNames::height);
+    if (auto converted = height_attr.to_uint(); converted.has_value())
+        return *converted;
 
     // ...or else the density-corrected intrinsic height and height of the image, in CSS pixels,
     // if the image has intrinsic dimensions and is available but not being rendered.

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.h
@@ -39,6 +39,9 @@ public:
     unsigned height() const;
     void set_height(unsigned);
 
+    unsigned natural_width() const;
+    unsigned natural_height() const;
+
 private:
     virtual void apply_presentational_hints(CSS::StyleProperties&) const override;
 

--- a/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLImageElement.idl
@@ -15,5 +15,7 @@ interface HTMLImageElement : HTMLElement {
 
     [CEReactions] attribute unsigned long width;
     [CEReactions] attribute unsigned long height;
+    readonly attribute unsigned long naturalWidth;
+    readonly attribute unsigned long naturalHeight;
 
 };

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.cpp
@@ -5,7 +5,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/StringBuilder.h>
+#include <LibWeb/DOM/Node.h>
+#include <LibWeb/DOM/Text.h>
 #include <LibWeb/HTML/HTMLOptionElement.h>
+#include <LibWeb/HTML/HTMLScriptElement.h>
+#include <LibWeb/HTML/HTMLSelectElement.h>
+#include <ctype.h>
 
 namespace Web::HTML {
 
@@ -47,6 +53,99 @@ void HTMLOptionElement::set_selected(bool selected)
     m_selected = selected;
     m_dirty = true;
     ask_for_a_reset();
+}
+
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-value
+String HTMLOptionElement::value() const
+{
+    // The value of an option element is the value of the value content attribute, if there is one.
+    if (auto value_attr = get_attribute(HTML::AttributeNames::value); !value_attr.is_null())
+        return value_attr;
+
+    // ...or, if there is not, the value of the element's text IDL attribute.
+    return text();
+}
+
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-value
+void HTMLOptionElement::set_value(String value)
+{
+    set_attribute(HTML::AttributeNames::value, value);
+}
+
+// https://infra.spec.whatwg.org/#strip-and-collapse-ascii-whitespace
+static String strip_and_collapse_whitespace(StringView string)
+{
+    // Replace any sequence of one or more consecutive code points that are ASCII whitespace in the string with a single U+0020 SPACE code point.
+    StringBuilder builder;
+    for (size_t i = 0; i < string.length(); ++i) {
+        if (isspace(string[i])) {
+            builder.append(' ');
+            while (i < string.length()) {
+                if (isspace(string[i])) {
+                    ++i;
+                    continue;
+                }
+                builder.append(string[i]);
+                break;
+            }
+            continue;
+        }
+        builder.append(string[i]);
+    }
+
+    // ...and then remove any leading and trailing ASCII whitespace from that string.
+    return builder.to_string().trim_whitespace();
+}
+
+static void concatenate_descendants_text_content(DOM::Node const* node, StringBuilder& builder)
+{
+    // FIXME: SVGScriptElement should also be skipped, but it doesn't exist yet.
+    if (is<HTMLScriptElement>(node))
+        return;
+    if (is<DOM::Text>(node))
+        builder.append(verify_cast<DOM::Text>(node)->data());
+    node->for_each_child([&](auto const& node) {
+        concatenate_descendants_text_content(&node, builder);
+    });
+}
+
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-text
+String HTMLOptionElement::text() const
+{
+    StringBuilder builder;
+
+    // Concatenation of data of all the Text node descendants of the option element, in tree order,
+    // excluding any that are descendants of descendants of the option element that are themselves
+    // script or SVG script elements.
+    for_each_child([&](auto const& node) {
+        concatenate_descendants_text_content(&node, builder);
+    });
+
+    // Return the result of stripping and collapsing ASCII whitespace from the above concatenation.
+    return strip_and_collapse_whitespace(builder.to_string());
+}
+
+// https://html.spec.whatwg.org/multipage/form-elements.html#dom-option-text
+void HTMLOptionElement::set_text(String text)
+{
+    string_replace_all(text);
+}
+
+// https://html.spec.whatwg.org/multipage/form-elements.html#concept-option-index
+int HTMLOptionElement::index() const
+{
+    // An option element's index is the number of option elements that are in the same list of options but that come before it in tree order.
+    if (auto select_element = first_ancestor_of_type<HTMLSelectElement>()) {
+        int index = 0;
+        for (auto const& option_element : select_element->list_of_options()) {
+            if (&option_element == this)
+                return index;
+            ++index;
+        }
+    }
+
+    // If the option element is not in a list of options, then the option element's index is zero.
+    return 0;
 }
 
 // https://html.spec.whatwg.org/multipage/form-elements.html#ask-for-a-reset

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.h
@@ -21,6 +21,14 @@ public:
     bool selected() const { return m_selected; }
     void set_selected(bool);
 
+    String value() const;
+    void set_value(String);
+
+    String text() const;
+    void set_text(String);
+
+    int index() const;
+
 private:
     friend class Bindings::OptionConstructor;
     friend class HTMLSelectElement;

--- a/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.idl
+++ b/Userland/Libraries/LibWeb/HTML/HTMLOptionElement.idl
@@ -4,7 +4,10 @@ interface HTMLOptionElement : HTMLElement {
 
     [Reflect] attribute boolean disabled;
     [Reflect=selected] attribute boolean defaultSelected;
-
     attribute boolean selected;
+    [CEReactions] attribute DOMString value;
+
+    [CEReactions] attribute DOMString text;
+    readonly attribute long index;
 
 };


### PR DESCRIPTION
This pull request improves the spec compliance of Document, Node, HTMLImageElement and HTMLOptionElement.
Also, an extra step (apparently outside of the spec?) was added to HTMLImageElement::{width,height}() to fix the case where an width/height attribute is assigned to the HTML element.

_I hope everything is fine, especially `HTMLOptionElement::text()` since I couldn't find anything exactly like this in the codebase to base my code from. =P_