### PR TITLE
LibKeyboard+Applets: Add click to cycle functionality to Keymap applet

### DIFF
--- a/Userland/Applets/Keymap/KeymapStatusWindow.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWindow.cpp
@@ -1,22 +1,28 @@
 /*
  * Copyright (c) 2021, Timur Sultanov <SultanovTS@yandex.ru>
+ * Copyright (c) 2022, Thitat Auareesuksakul <thitat@flux.ci>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "KeymapStatusWindow.h"
+#include <LibCore/ConfigFile.h>
 #include <LibCore/Process.h>
 #include <LibGUI/ConnectionToWindowMangerServer.h>
 #include <LibGUI/Painter.h>
 #include <LibKeyboard/CharacterMap.h>
+#include <spawn.h>
 
 void KeymapStatusWidget::mousedown_event(GUI::MouseEvent& event)
 {
-    if (event.button() != GUI::MouseButton::Primary)
-        return;
+    if (event.button() == GUI::MouseButton::Primary) {
+        if (parent())
+            static_cast<KeymapStatusWindow*>(parent())->cycle_keymaps();
+    }
 
-    Core::Process::spawn("/bin/KeyboardSettings");
+    if (event.button() == GUI::MouseButton::Secondary)
+        Core::Process::spawn("/bin/KeyboardSettings");
 }
 
 KeymapStatusWindow::KeymapStatusWindow()
@@ -25,10 +31,40 @@ KeymapStatusWindow::KeymapStatusWindow()
     set_has_alpha_channel(true);
     m_status_widget = &set_main_widget<KeymapStatusWidget>();
 
+    m_file_watcher = MUST(Core::FileWatcher::create());
+    m_file_watcher->on_change = [this](auto&) {
+        refresh_keymaps();
+    };
+
+    MUST(m_file_watcher->add_watch(Keyboard::Keymap::config_file_path(), Core::FileWatcherEvent::Type::ContentModified));
+
+    refresh_keymaps(false);
+}
+
+void KeymapStatusWindow::refresh_keymaps(bool repaint_background)
+{
+    m_keymaps.clear();
+    m_keymaps = MUST(Keyboard::Keymap::read_all());
+
     auto current_keymap = MUST(Keyboard::CharacterMap::fetch_system_map());
     auto current_keymap_name = current_keymap.character_map_name();
-    m_status_widget->set_tooltip(current_keymap_name);
-    m_status_widget->set_text(current_keymap_name.substring(0, 2));
+    auto it = m_keymaps.find_if([&](auto const& value) {
+        return value.name() == current_keymap_name;
+    });
+
+    if (!it.is_end())
+        m_keymap_index = it.index();
+    else
+        m_keymap_index = -1;
+
+    set_keymap_text(current_keymap_name, repaint_background);
+}
+
+void KeymapStatusWindow::cycle_keymaps()
+{
+    m_keymap_index = (m_keymap_index + 1) % m_keymaps.size();
+    auto keymap_name = m_keymaps[m_keymap_index].name();
+    set_keymap(keymap_name);
 }
 
 void KeymapStatusWindow::wm_event(GUI::WMEvent& event)
@@ -40,10 +76,24 @@ void KeymapStatusWindow::wm_event(GUI::WMEvent& event)
     }
 }
 
-void KeymapStatusWindow::set_keymap_text(String const& keymap)
+void KeymapStatusWindow::set_keymap(String const& keymap)
 {
-    GUI::Painter painter(*m_status_widget);
-    painter.clear_rect(m_status_widget->rect(), Color::from_argb(0));
+    pid_t child_pid;
+    char const* argv[] = { "/bin/keymap", "-m", keymap.characters(), nullptr };
+    if ((errno = posix_spawn(&child_pid, "/bin/keymap", nullptr, nullptr, const_cast<char**>(argv), environ))) {
+        perror("posix_spawn");
+        dbgln("Failed to call /bin/keymap, error: {} ({})", errno, strerror(errno));
+    }
+
+    set_keymap_text(keymap);
+}
+
+void KeymapStatusWindow::set_keymap_text(String const& keymap, bool repaint_background)
+{
+    if (repaint_background) {
+        GUI::Painter painter(*m_status_widget);
+        painter.clear_rect(m_status_widget->rect(), Color::from_argb(0));
+    }
 
     m_status_widget->set_tooltip(keymap);
     m_status_widget->set_text(keymap.substring(0, 2));

--- a/Userland/Applets/Keymap/KeymapStatusWindow.h
+++ b/Userland/Applets/Keymap/KeymapStatusWindow.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Timur Sultanov <SultanovTS@yandex.ru>
+ * Copyright (c) 2022, Thitat Auareesuksakul <thitat@flux.ci>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -7,25 +8,33 @@
 
 #pragma once
 
+#include <LibCore/FileWatcher.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Window.h>
+#include <LibKeyboard/Keymap.h>
 
 class KeymapStatusWidget : public GUI::Label {
     C_OBJECT(KeymapStatusWidget);
 
     virtual void mousedown_event(GUI::MouseEvent& event) override;
 };
+
 class KeymapStatusWindow final : public GUI::Window {
     C_OBJECT(KeymapStatusWindow)
 public:
     virtual ~KeymapStatusWindow() override = default;
+    void cycle_keymaps();
 
 private:
     virtual void wm_event(GUI::WMEvent&) override;
 
     KeymapStatusWindow();
+    void refresh_keymaps(bool repaint_background = true);
+    void set_keymap(String const& keymap);
+    void set_keymap_text(String const& keymap, bool repaint_background = true);
 
     RefPtr<KeymapStatusWidget> m_status_widget;
-
-    void set_keymap_text(String const& keymap);
+    RefPtr<Core::FileWatcher> m_file_watcher;
+    Vector<Keyboard::Keymap> m_keymaps;
+    ssize_t m_keymap_index { -1 };
 };

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -25,6 +25,7 @@
 #include <LibGUI/Window.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibKeyboard/CharacterMap.h>
+#include <LibKeyboard/Keymap.h>
 #include <spawn.h>
 
 class KeymapSelectionDialog final : public GUI::Dialog {
@@ -163,10 +164,7 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     m_initial_active_keymap = keymap_object.get("keymap").to_string();
     dbgln("KeyboardSettings thinks the current keymap is: {}", m_initial_active_keymap);
 
-    auto mapper_config(Core::ConfigFile::open("/etc/Keyboard.ini").release_value_but_fixme_should_propagate_errors());
-    auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
-
-    auto keymaps_vector = keymaps.split(',');
+    auto keymaps_vector = Keyboard::Keymap::read_all().release_value_but_fixme_should_propagate_errors();
 
     m_selected_keymaps_listview = find_descendant_of_type_named<GUI::ListView>("selected_keymaps");
     m_selected_keymaps_listview->horizontal_scrollbar().set_visible(false);
@@ -174,8 +172,8 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
     auto& keymaps_list_model = static_cast<KeymapModel&>(*m_selected_keymaps_listview->model());
 
     for (auto& keymap : keymaps_vector) {
-        m_initial_keymap_list.append(keymap);
-        keymaps_list_model.add_keymap(keymap);
+        m_initial_keymap_list.append(keymap.name());
+        keymaps_list_model.add_keymap(keymap.name());
     }
 
     keymaps_list_model.set_active_keymap(m_initial_active_keymap);

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -8,9 +8,9 @@
 
 #include "KeyboardSettingsWidget.h"
 #include <LibCore/System.h>
-#include <LibKeyboard/Keymap.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/SettingsWindow.h>
+#include <LibKeyboard/Keymap.h>
 #include <LibMain/Main.h>
 
 // Including this after to avoid LibIPC errors

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -1,12 +1,14 @@
 /*
  * Copyright (c) 2020, Hüseyin Aslıtürk <asliturk@hotmail.com>
  * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include "KeyboardSettingsWidget.h"
 #include <LibCore/System.h>
+#include <LibKeyboard/Keymap.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/SettingsWindow.h>
 #include <LibMain/Main.h>
@@ -24,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/keymap", "x"));
     TRY(Core::System::unveil("/proc/keymap", "r"));
-    TRY(Core::System::unveil("/etc/Keyboard.ini", "r"));
+    TRY(Core::System::unveil(Keyboard::Keymap::config_file_path(), "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     auto app_icon = GUI::Icon::default_icon("app-keyboard-settings");

--- a/Userland/Libraries/LibKeyboard/CMakeLists.txt
+++ b/Userland/Libraries/LibKeyboard/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(SOURCES
     CharacterMap.cpp
     CharacterMapFile.cpp
+    Keymap.cpp
 )
 
 serenity_lib(LibKeyboard keyboard)

--- a/Userland/Libraries/LibKeyboard/Keymap.cpp
+++ b/Userland/Libraries/LibKeyboard/Keymap.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Thitat Auareesuksakul <thitat@flux.ci>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Keymap.h"
+#include <AK/Try.h>
+#include <AK/Vector.h>
+#include <LibCore/ConfigFile.h>
+
+namespace Keyboard {
+
+Keymap::Keymap(StringView const& keymap_name)
+    : m_name(keymap_name)
+{
+}
+
+ErrorOr<Vector<Keymap>> Keymap::read_all()
+{
+    auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini"));
+    auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
+
+    auto keymap_names = keymaps.split_view(',');
+    if (keymap_names.size() == 0)
+        return Error::from_string_literal("Empty list of keymaps");
+
+    auto keymap_vector = Vector<Keymap>();
+    keymap_vector.ensure_capacity(keymap_names.size());
+
+    for (StringView const& name : keymap_names) {
+        keymap_vector.append(Keymap(name));
+    }
+
+    return keymap_vector;
+}
+
+}

--- a/Userland/Libraries/LibKeyboard/Keymap.h
+++ b/Userland/Libraries/LibKeyboard/Keymap.h
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022, Thitat Auareesuksakul <thitat@flux.ci>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/String.h>
+#include <AK/Vector.h>
+
+namespace Keyboard {
+
+class Keymap {
+
+public:
+    Keymap(StringView const& keymap_name);
+    static ErrorOr<Vector<Keymap>> read_all();
+
+    String const& name() const { return m_name; }
+
+    static char const* config_file_path() { return "/etc/Keyboard.ini"; }
+
+private:
+    String m_name;
+};
+
+}

--- a/Userland/Services/KeyboardPreferenceLoader/CMakeLists.txt
+++ b/Userland/Services/KeyboardPreferenceLoader/CMakeLists.txt
@@ -9,4 +9,4 @@ set(SOURCES
 )
 
 serenity_bin(KeyboardPreferenceLoader)
-target_link_libraries(KeyboardPreferenceLoader LibCore LibMain)
+target_link_libraries(KeyboardPreferenceLoader LibCore LibKeyboard LibMain)

--- a/Userland/Services/KeyboardPreferenceLoader/main.cpp
+++ b/Userland/Services/KeyboardPreferenceLoader/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, the SerenityOS developers.
+ * Copyright (c) 2021-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +7,7 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
+#include <LibKeyboard/Keymap.h>
 #include <LibMain/Main.h>
 #include <errno.h>
 #include <spawn.h>
@@ -20,18 +21,14 @@ ErrorOr<int> serenity_main(Main::Arguments)
     auto keyboard_settings_config = TRY(Core::ConfigFile::open_for_app("KeyboardSettings"));
 
     TRY(Core::System::unveil("/bin/keymap", "x"));
-    TRY(Core::System::unveil("/etc/Keyboard.ini", "r"));
+    TRY(Core::System::unveil(Keyboard::Keymap::config_file_path(), "r"));
     TRY(Core::System::unveil("/dev/keyboard0", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
-    auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini"));
-    auto keymaps = mapper_config->read_entry("Mapping", "Keymaps", "");
 
-    auto keymaps_vector = keymaps.split(',');
-    if (keymaps_vector.size() == 0)
-        exit(1);
+    auto keymaps_vector = TRY(Keyboard::Keymap::read_all());
 
     pid_t child_pid;
-    char const* argv[] = { "/bin/keymap", "-m", keymaps_vector.first().characters(), nullptr };
+    char const* argv[] = { "/bin/keymap", "-m", keymaps_vector.first().name().characters(), nullptr };
     if ((errno = posix_spawn(&child_pid, "/bin/keymap", nullptr, nullptr, const_cast<char**>(argv), environ))) {
         perror("posix_spawn");
         exit(1);

--- a/Userland/Services/WindowServer/CMakeLists.txt
+++ b/Userland/Services/WindowServer/CMakeLists.txt
@@ -40,5 +40,5 @@ set(SOURCES
 )
 
 serenity_bin(WindowServer)
-target_link_libraries(WindowServer LibCore LibGfx LibThreading LibIPC LibMain)
+target_link_libraries(WindowServer LibCore LibGfx LibKeyboard LibThreading LibIPC LibMain)
 serenity_install_headers(Services/WindowServer)

--- a/Userland/Services/WindowServer/KeymapSwitcher.h
+++ b/Userland/Services/WindowServer/KeymapSwitcher.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Timur Sultanov <SultanovTS@yandex.ru>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -37,8 +38,6 @@ private:
     void setkeymap(AK::String const&);
 
     RefPtr<Core::FileWatcher> m_file_watcher;
-
-    char const* m_keyboard_config = "/etc/Keyboard.ini";
 };
 
 }

--- a/Userland/Services/WindowServer/main.cpp
+++ b/Userland/Services/WindowServer/main.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,6 +16,7 @@
 #include <LibCore/System.h>
 #include <LibGfx/Palette.h>
 #include <LibGfx/SystemTheme.h>
+#include <LibKeyboard/Keymap.h>
 #include <LibMain/Main.h>
 #include <signal.h>
 #include <string.h>
@@ -25,7 +27,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/tmp", "cw"));
     TRY(Core::System::unveil("/etc/WindowServer.ini", "rwc"));
-    TRY(Core::System::unveil("/etc/Keyboard.ini", "r"));
+    TRY(Core::System::unveil(Keyboard::Keymap::config_file_path(), "r"));
     TRY(Core::System::unveil("/dev", "rw"));
     TRY(Core::System::unveil("/bin/keymap", "x"));
     TRY(Core::System::unveil("/proc/keymap", "r"));

--- a/Userland/Utilities/keymap.cpp
+++ b/Userland/Utilities/keymap.cpp
@@ -10,6 +10,7 @@
 #include <LibCore/ConfigFile.h>
 #include <LibCore/System.h>
 #include <LibKeyboard/CharacterMap.h>
+#include <LibKeyboard/Keymap.h>
 #include <LibMain/Main.h>
 #include <stdio.h>
 
@@ -36,7 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio setkeymap getkeymap rpath wpath cpath"));
     TRY(Core::System::unveil("/res/keymaps", "r"));
-    TRY(Core::System::unveil("/etc/Keyboard.ini", "rwc"));
+    TRY(Core::System::unveil(Keyboard::Keymap::config_file_path(), "rwc"));
 
     String mapping;
     String mappings;
@@ -53,7 +54,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 0;
     }
 
-    auto mapper_config = TRY(Core::ConfigFile::open("/etc/Keyboard.ini", Core::ConfigFile::AllowWriting::Yes));
+    auto mapper_config = TRY(Core::ConfigFile::open(Keyboard::Keymap::config_file_path(), Core::ConfigFile::AllowWriting::Yes));
 
     int rc = 0;
 


### PR DESCRIPTION
This PR adds the click to cycle functionaility for the Keymap applet. (inspired by the KDE keymap applet)
The original keyboard settings panel is still accessible via a right click.

There's also some refactoring to unify `/etc/Keyboard.ini` file reading logic into `LibKeyboard`.