### PR TITLE
ClockSettings+LibC+LibCore: Various improvements to taskbar clock formatting

### DIFF
--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.gml
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.gml
@@ -8,7 +8,7 @@
     @GUI::GroupBox {
         title: "Time Format"
         shrink_to_fit: false
-        fixed_height: 160
+        fixed_height: 200
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
         }
@@ -26,13 +26,20 @@
 
             @GUI::RadioButton {
                 name: "24hour_radio"
-                text: "24-hour (12:34:56)"
+                text: "24-hour"
             }
 
             @GUI::RadioButton {
                 name: "12hour_radio"
-                text: "12-hour (12:34 a.m)"
+                text: "12-hour"
             }
+
+            @GUI::CheckBox {
+                name: "seconds_checkbox"
+                text: "Show seconds"
+            }
+
+            @GUI::HorizontalSeparator {}
 
             @GUI::RadioButton {
                 name: "custom_radio"

--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.h
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.h
@@ -18,7 +18,10 @@ private:
     virtual void apply_settings() override;
     virtual void reset_default_values() override;
 
+    void update_time_format_string();
+
     RefPtr<GUI::RadioButton> m_24_hour_radio;
+    RefPtr<GUI::CheckBox> m_show_seconds_checkbox;
     RefPtr<GUI::TextBox> m_custom_format_input;
 
     String m_date_format;

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -250,9 +250,13 @@ size_t strftime(char* destination, size_t max_size, char const* format, const st
             case 'H':
                 builder.appendff("{:02}", tm->tm_hour);
                 break;
-            case 'I':
-                builder.appendff("{:02}", tm->tm_hour % 12);
+            case 'I': {
+                int display_hour = tm->tm_hour % 12;
+                if (display_hour == 0)
+                    display_hour = 12;
+                builder.appendff("{:02}", display_hour);
                 break;
+            }
             case 'j':
                 builder.appendff("{:03}", tm->tm_yday + 1);
                 break;
@@ -268,9 +272,13 @@ size_t strftime(char* destination, size_t max_size, char const* format, const st
             case 'p':
                 builder.append(tm->tm_hour < 12 ? "a.m." : "p.m.");
                 break;
-            case 'r':
-                builder.appendff("{:02}:{:02}:{:02} {}", tm->tm_hour % 12, tm->tm_min, tm->tm_sec, tm->tm_hour < 12 ? "a.m." : "p.m.");
+            case 'r': {
+                int display_hour = tm->tm_hour % 12;
+                if (display_hour == 0)
+                    display_hour = 12;
+                builder.appendff("{:02}:{:02}:{:02} {}", display_hour, tm->tm_min, tm->tm_sec, tm->tm_hour < 12 ? "a.m." : "p.m.");
                 break;
+            }
             case 'R':
                 builder.appendff("{:02}:{:02}", tm->tm_hour, tm->tm_min);
                 break;

--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -270,13 +270,13 @@ size_t strftime(char* destination, size_t max_size, char const* format, const st
                 builder.append('\n');
                 break;
             case 'p':
-                builder.append(tm->tm_hour < 12 ? "a.m." : "p.m.");
+                builder.append(tm->tm_hour < 12 ? "AM" : "PM");
                 break;
             case 'r': {
                 int display_hour = tm->tm_hour % 12;
                 if (display_hour == 0)
                     display_hour = 12;
-                builder.appendff("{:02}:{:02}:{:02} {}", display_hour, tm->tm_min, tm->tm_sec, tm->tm_hour < 12 ? "a.m." : "p.m.");
+                builder.appendff("{:02}:{:02}:{:02} {}", display_hour, tm->tm_min, tm->tm_sec, tm->tm_hour < 12 ? "AM" : "PM");
                 break;
             }
             case 'R':

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -173,13 +173,13 @@ String DateTime::to_string(StringView format) const
                 builder.append('\n');
                 break;
             case 'p':
-                builder.append(tm.tm_hour < 12 ? "a.m." : "p.m.");
+                builder.append(tm.tm_hour < 12 ? "AM" : "PM");
                 break;
             case 'r': {
                 int display_hour = tm.tm_hour % 12;
                 if (display_hour == 0)
                     display_hour = 12;
-                builder.appendff("{:02}:{:02}:{:02} {}", display_hour, tm.tm_min, tm.tm_sec, tm.tm_hour < 12 ? "a.m." : "p.m.");
+                builder.appendff("{:02}:{:02}:{:02} {}", display_hour, tm.tm_min, tm.tm_sec, tm.tm_hour < 12 ? "AM" : "PM");
                 break;
             }
             case 'R':
@@ -427,19 +427,19 @@ Optional<DateTime> DateTime::parse(StringView format, String const& string)
             }
             break;
         case 'p': {
-            auto ampm = string.substring_view(string_pos, 4);
-            if (ampm == "p.m." && tm.tm_hour < 12) {
+            auto ampm = string.substring_view(string_pos, 2);
+            if (ampm == "PM" && tm.tm_hour < 12) {
                 tm.tm_hour += 12;
             }
-            string_pos += 4;
+            string_pos += 2;
             break;
         }
         case 'r': {
-            auto ampm = string.substring_view(string_pos, 4);
-            if (ampm == "p.m." && tm.tm_hour < 12) {
+            auto ampm = string.substring_view(string_pos, 2);
+            if (ampm == "PM" && tm.tm_hour < 12) {
                 tm.tm_hour += 12;
             }
-            string_pos += 4;
+            string_pos += 2;
             break;
         }
         case 'R': {

--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -153,9 +153,13 @@ String DateTime::to_string(StringView format) const
             case 'H':
                 builder.appendff("{:02}", tm.tm_hour);
                 break;
-            case 'I':
-                builder.appendff("{:02}", tm.tm_hour % 12);
+            case 'I': {
+                int display_hour = tm.tm_hour % 12;
+                if (display_hour == 0)
+                    display_hour = 12;
+                builder.appendff("{:02}", display_hour);
                 break;
+            }
             case 'j':
                 builder.appendff("{:03}", tm.tm_yday + 1);
                 break;
@@ -171,9 +175,13 @@ String DateTime::to_string(StringView format) const
             case 'p':
                 builder.append(tm.tm_hour < 12 ? "a.m." : "p.m.");
                 break;
-            case 'r':
-                builder.appendff("{:02}:{:02}:{:02} {}", tm.tm_hour % 12, tm.tm_min, tm.tm_sec, tm.tm_hour < 12 ? "a.m." : "p.m.");
+            case 'r': {
+                int display_hour = tm.tm_hour % 12;
+                if (display_hour == 0)
+                    display_hour = 12;
+                builder.appendff("{:02}:{:02}:{:02} {}", display_hour, tm.tm_min, tm.tm_sec, tm.tm_hour < 12 ? "a.m." : "p.m.");
                 break;
+            }
             case 'R':
                 builder.appendff("{:02}:{:02}", tm.tm_hour, tm.tm_min);
                 break;


### PR DESCRIPTION
This pull request improves time formatting and the ClockSettings application with suggestions from Discord. 
- Formatting of 12-hour time has been improved.
- Taskbar clock settings in ClockSettings now has a toggle for whether to show seconds or not.

![clock-improvements](https://user-images.githubusercontent.com/36554078/163074893-04dba158-3091-40ea-908b-8e84783d9d8b.png)