### PR TITLE
LibCore: Core::Directory improvements

### DIFF
--- a/Userland/Libraries/LibCore/Directory.cpp
+++ b/Userland/Libraries/LibCore/Directory.cpp
@@ -61,7 +61,7 @@ ErrorOr<Directory> Directory::create(LexicalPath path, CreateDirectories create_
 
 ErrorOr<void> Directory::ensure_directory(LexicalPath const& path)
 {
-    if (path.basename() == "/")
+    if (path.basename() == "/" || path.basename() == ".")
         return {};
 
     TRY(ensure_directory(path.parent()));

--- a/Userland/Libraries/LibCore/Directory.h
+++ b/Userland/Libraries/LibCore/Directory.h
@@ -33,8 +33,8 @@ public:
         Yes,
     };
 
-    static ErrorOr<Directory> create(LexicalPath path, CreateDirectories);
-    static ErrorOr<Directory> create(String path, CreateDirectories);
+    static ErrorOr<Directory> create(LexicalPath path, CreateDirectories, mode_t creation_mode = 0755);
+    static ErrorOr<Directory> create(String path, CreateDirectories, mode_t creation_mode = 0755);
     static ErrorOr<Directory> adopt_fd(int fd, Optional<LexicalPath> path = {});
 
     ErrorOr<NonnullOwnPtr<Stream::File>> open(StringView filename, Stream::OpenMode mode) const;
@@ -47,7 +47,7 @@ public:
 
 private:
     Directory(int directory_fd, Optional<LexicalPath> path);
-    static ErrorOr<void> ensure_directory(LexicalPath const& path);
+    static ErrorOr<void> ensure_directory(LexicalPath const& path, mode_t creation_mode = 0755);
 
     Optional<LexicalPath> m_path;
     int m_directory_fd;

--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -10,11 +10,11 @@
 #include <LibArchive/Zip.h>
 #include <LibCompress/Deflate.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Directory.h>
 #include <LibCore/File.h>
 #include <LibCore/MappedFile.h>
 #include <LibCore/System.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 static bool unpack_zip_member(Archive::ZipMember zip_member, bool quiet)
 {
@@ -120,9 +120,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     }
 
     if (!output_directory_path.is_null()) {
-        auto mkdir_error = Core::System::mkdir(output_directory_path, 0755);
-        if (mkdir_error.is_error() && mkdir_error.error().code() != EEXIST)
-            return mkdir_error.release_error();
+        TRY(Core::Directory::create(output_directory_path, Core::Directory::CreateDirectories::Yes));
         TRY(Core::System::chdir(output_directory_path));
     }
 


### PR DESCRIPTION
**LibCore: Prevent infinite recursion in Directory::ensure_directory()**

If a relative path was passed in, then repeatedly asking for its parent
will never reach `/`. The top-level path in that case is `.`.

**LibCore: Add an optional permissions mask to Directory::create()**

Being able to pass a mask is the one feature `mkdir()` had that this
didn't. Adding it here means everyone can use the nicer Directory API.

**Utilities/unzip: Use Core::Directory to create output directory**