### PR TITLE
LibJS: Allow TypeArray to become detached in TypedArray.prototype.set

### DIFF
--- a/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.set.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/TypedArray/TypedArray.prototype.set.js
@@ -82,6 +82,28 @@ test("length is 1", () => {
     });
 });
 
+test("detached buffer", () => {
+    TYPED_ARRAYS.forEach(({ array: T }) => {
+        let typedArray = new T(2);
+        typedArray[0] = 1;
+        typedArray[1] = 2;
+
+        let object = { length: 2 };
+
+        Object.defineProperty(object, 0, {
+            get: () => {
+                detachArrayBuffer(typedArray.buffer);
+            },
+        });
+
+        expect(() => {
+            typedArray.set(object);
+        }).not.toThrow();
+
+        expect(typedArray.length).toBe(0);
+    });
+});
+
 describe("errors", () => {
     function argumentErrorTests(T) {
         test(`requires at least one argument (${T.name})`, () => {


### PR DESCRIPTION
This is a normative change in the ECMA-262 spec. See:
https://github.com/tc39/ecma262/commit/4d570c4