### PR TITLE
Shell: Complete for current path when the text is empty

### DIFF
--- a/Userland/Shell/AST.cpp
+++ b/Userland/Shell/AST.cpp
@@ -392,7 +392,7 @@ Vector<Line::CompletionSuggestion> Node::complete_for_editor(Shell& shell, size_
     }
     auto result = hit_test_position(offset);
     if (!result.matching_node)
-        return {};
+        return shell.complete_path("", "", 0, Shell::ExecutableOnly::No, result.closest_command_node.ptr(), nullptr, Shell::EscapeMode::Bareword);
     auto node = result.matching_node;
     if (node->is_bareword() || node != result.closest_node_with_semantic_meaning)
         node = result.closest_node_with_semantic_meaning;


### PR DESCRIPTION
For example, when typing `cd <tab>`, the shell will show a list of files in the current directory. This behavior is similar to typing `cd ./<tab>`.
It makes it easier to `cd` into directories without having to list them first.

@alimpfard Is this behavior ok ?