### PR TITLE
AK: Introduce a new round_to helper, to leverage the HW's rounding capabilities

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -261,7 +261,7 @@ constexpr T tan(T angle)
     CONSTEXPR_STATE(tan, angle);
 
 #if ARCH(I386) || ARCH(X86_64)
-    double ret, one;
+    T ret, one;
     asm(
         "fptan"
         : "=t"(one), "=u"(ret)
@@ -532,6 +532,89 @@ using Hyperbolic::cosh;
 using Hyperbolic::sinh;
 using Hyperbolic::tanh;
 
+template<Integral I, FloatingPoint P>
+ALWAYS_INLINE I round_to(P value)
+{
+#if ARCH(I386) || ARCH(X86_64)
+    // Note: fistps outputs into a signed integer location (i16, i32, i64),
+    //       so lets be nice and tell the compiler that.
+    Conditional<sizeof(I) >= sizeof(i16), MakeSigned<I>, i16> ret;
+    if constexpr (sizeof(I) == sizeof(i64)) {
+        asm("fistpll %0"
+            : "=m"(ret)
+            : "t"(value)
+            : "st");
+    } else if constexpr (sizeof(I) == sizeof(i32)) {
+        asm("fistpl %0"
+            : "=m"(ret)
+            : "t"(value)
+            : "st");
+    } else {
+        asm("fistps %0"
+            : "=m"(ret)
+            : "t"(value)
+            : "st");
+    }
+    return static_cast<I>(ret);
+#else
+    if constexpr (IsSame<P, long double>)
+        return static_cast<I>(llrintl(value));
+    if constexpr (IsSame<P, double>)
+        return static_cast<I>(llrint(value));
+    if constexpr (IsSame<P, float>)
+        return static_cast<I>(llrintf(value));
+#endif
+}
+
+#ifdef __SSE__
+template<Integral I>
+ALWAYS_INLINE I round_to(float value)
+{
+    if constexpr (sizeof(I) == sizeof(i64)) {
+        // Note: Outputting into 64-bit registers or memory locations requires the
+        //       REX prefix, so we have to fall back to long doubles on i686
+#    if ARCH(X86_64)
+        i64 ret;
+        asm("cvtss2si %1, %0"
+            : "=r"(ret)
+            : "xm"(value));
+        return static_cast<I>(ret);
+#    else
+        return round_to<I, long double>(value);
+#    endif
+    }
+    i32 ret;
+    asm("cvtss2si %1, %0"
+        : "=r"(ret)
+        : "xm"(value));
+    return static_cast<I>(ret);
+}
+#endif
+#ifdef __SSE2__
+template<Integral I>
+ALWAYS_INLINE I round_to(double value)
+{
+    if constexpr (sizeof(I) == sizeof(i64)) {
+        // Note: Outputting into 64-bit registers or memory locations requires the
+        //       REX prefix, so we have to fall back to long doubles on i686
+#    if ARCH(X86_64)
+        i64 ret;
+        asm("cvtsd2si %1, %0"
+            : "=r"(ret)
+            : "xm"(value));
+        return static_cast<I>(ret);
+#    else
+        return round_to<I, long double>(value);
+#    endif
+    }
+    i32 ret;
+    asm("cvtsd2si %1, %0"
+        : "=r"(ret)
+        : "xm"(value));
+    return static_cast<I>(ret);
+}
+#endif
+
 template<FloatingPoint T>
 constexpr T pow(T x, T y)
 {
@@ -559,5 +642,6 @@ constexpr T pow(T x, T y)
 }
 
 #undef CONSTEXPR_STATE
-
 }
+
+using AK::round_to;

--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -21,20 +21,14 @@ bool AffineTransform::is_identity_or_translation() const
     return a() == 1 && b() == 0 && c() == 0 && d() == 1;
 }
 
-static float hypotenuse(float x, float y)
-{
-    // FIXME: This won't handle overflow :(
-    return sqrtf(x * x + y * y);
-}
-
 float AffineTransform::x_scale() const
 {
-    return hypotenuse(m_values[0], m_values[1]);
+    return AK::hypot(m_values[0], m_values[1]);
 }
 
 float AffineTransform::y_scale() const
 {
-    return hypotenuse(m_values[2], m_values[3]);
+    return AK::hypot(m_values[2], m_values[3]);
 }
 
 FloatPoint AffineTransform::scale() const
@@ -124,8 +118,9 @@ AffineTransform& AffineTransform::multiply(AffineTransform const& other)
 
 AffineTransform& AffineTransform::rotate_radians(float radians)
 {
-    float sin_angle = sinf(radians);
-    float cos_angle = cosf(radians);
+    float sin_angle;
+    float cos_angle;
+    AK::sincos(radians, sin_angle, cos_angle);
     AffineTransform rotation(cos_angle, sin_angle, -sin_angle, cos_angle, 0, 0);
     multiply(rotation);
     return *this;

--- a/Userland/Libraries/LibGfx/AffineTransform.cpp
+++ b/Userland/Libraries/LibGfx/AffineTransform.cpp
@@ -158,7 +158,7 @@ IntPoint AffineTransform::map(IntPoint const& point) const
     float mapped_x;
     float mapped_y;
     map(static_cast<float>(point.x()), static_cast<float>(point.y()), mapped_x, mapped_y);
-    return { roundf(mapped_x), roundf(mapped_y) };
+    return { round_to<int>(mapped_x), round_to<int>(mapped_y) };
 }
 
 template<>
@@ -174,8 +174,8 @@ template<>
 IntSize AffineTransform::map(IntSize const& size) const
 {
     return {
-        roundf(static_cast<float>(size.width()) * x_scale()),
-        roundf(static_cast<float>(size.height()) * y_scale()),
+        round_to<int>(static_cast<float>(size.width()) * x_scale()),
+        round_to<int>(static_cast<float>(size.height()) * y_scale()),
     };
 }
 

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -200,10 +200,10 @@ public:
 
     Color interpolate(Color const& other, float weight) const noexcept
     {
-        u8 r = red() + roundf(static_cast<float>(other.red() - red()) * weight);
-        u8 g = green() + roundf(static_cast<float>(other.green() - green()) * weight);
-        u8 b = blue() + roundf(static_cast<float>(other.blue() - blue()) * weight);
-        u8 a = alpha() + roundf(static_cast<float>(other.alpha() - alpha()) * weight);
+        u8 r = red() + round_to<u8>(static_cast<float>(other.red() - red()) * weight);
+        u8 g = green() + round_to<u8>(static_cast<float>(other.green() - green()) * weight);
+        u8 b = blue() + round_to<u8>(static_cast<float>(other.blue() - blue()) * weight);
+        u8 a = alpha() + round_to<u8>(static_cast<float>(other.alpha() - alpha()) * weight);
         return Color(r, g, b, a);
     }
 

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1387,7 +1387,7 @@ void draw_text_line(IntRect const& a_rect, Utf8View const& text, Font const& fon
             continue;
         }
 
-        int kerning = static_cast<int>(lroundf(font.glyphs_horizontal_kerning(last_code_point, code_point)));
+        int kerning = round_to<int>(font.glyphs_horizontal_kerning(last_code_point, code_point));
         if (kerning != 0.f)
             point.translate_by(direction == TextDirection::LTR ? kerning : -kerning, 0);
 
@@ -2334,7 +2334,7 @@ void Painter::draw_text_run(FloatPoint const& baseline_start, Utf8View const& st
 
         // FIXME: this is probably not the real space taken for complex emojis
         x += font.glyphs_horizontal_kerning(last_code_point, code_point);
-        draw_glyph_or_emoji({ static_cast<int>(lroundf(x)), y }, code_point_iterator, font, color);
+        draw_glyph_or_emoji({ round_to<int>(x), y }, code_point_iterator, font, color);
         x += font.glyph_or_emoji_width(code_point) + font.glyph_spacing();
         last_code_point = code_point;
     }

--- a/Userland/Libraries/LibGfx/Rect.h
+++ b/Userland/Libraries/LibGfx/Rect.h
@@ -697,24 +697,46 @@ public:
         return Rect<U>(*this);
     }
 
-    template<typename U>
+    template<FloatingPoint U>
     [[nodiscard]] ALWAYS_INLINE Rect<U> to_rounded() const
     {
+        // FIXME: We may get away with `rint[lf]?()` here.
+        //        This would even give us some more control of these internals,
+        //        while the break-tie algorithm does not really matter
         if constexpr (IsSame<T, float>) {
             return {
-                static_cast<U>(llroundf(x())),
-                static_cast<U>(llroundf(y())),
-                static_cast<U>(llroundf(width())),
-                static_cast<U>(llroundf(height())),
-            };
-        } else {
-            return {
-                static_cast<U>(llroundd(x())),
-                static_cast<U>(llroundd(y())),
-                static_cast<U>(llroundd(width())),
-                static_cast<U>(llroundd(height())),
+                static_cast<U>(roundf(x())),
+                static_cast<U>(roundf(y())),
+                static_cast<U>(roundf(width())),
+                static_cast<U>(roundf(height())),
             };
         }
+        if constexpr (IsSame<T, double>) {
+            return {
+                static_cast<U>(round(x())),
+                static_cast<U>(round(y())),
+                static_cast<U>(round(width())),
+                static_cast<U>(round(height())),
+            };
+        }
+
+        return {
+            static_cast<U>(roundl(x())),
+            static_cast<U>(roundl(y())),
+            static_cast<U>(roundl(width())),
+            static_cast<U>(roundl(height())),
+        };
+    }
+
+    template<Integral I>
+    ALWAYS_INLINE Rect<I> to_rounded() const
+    {
+        return {
+            round_to<I>(x()),
+            round_to<I>(y()),
+            round_to<I>(width()),
+            round_to<I>(height()),
+        };
     }
 
     [[nodiscard]] String to_string() const;

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1296,14 +1296,14 @@ void Device::set_raster_position(FloatVector4 const& position, FloatMatrix4x4 co
     m_raster_position.eye_coordinate_distance = eye_coordinates.length();
 }
 
-Gfx::IntRect Device::get_rasterization_rect_of_size(Gfx::IntSize size)
+Gfx::IntRect Device::get_rasterization_rect_of_size(Gfx::IntSize size) const
 {
     // Round the X and Y floating point coordinates to the nearest integer; OpenGL 1.5 spec:
     // "Any fragments whose centers lie inside of this rectangle (or on its bottom or left
     // boundaries) are produced in correspondence with this particular group of elements."
     return {
-        static_cast<int>(lroundf(m_raster_position.window_coordinates.x())),
-        static_cast<int>(lroundf(m_raster_position.window_coordinates.y())),
+        round_to<int>(m_raster_position.window_coordinates.x()),
+        round_to<int>(m_raster_position.window_coordinates.y()),
         size.width(),
         size.height(),
     };

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -76,7 +76,7 @@ public:
 
 private:
     void draw_statistics_overlay(Gfx::Bitmap&);
-    Gfx::IntRect get_rasterization_rect_of_size(Gfx::IntSize size);
+    Gfx::IntRect get_rasterization_rect_of_size(Gfx::IntSize size) const;
 
     void rasterize_triangle(Triangle const& triangle);
     void setup_blend_factors();


### PR DESCRIPTION
Before re were spending 11-15% of time in `round()` while running [Cookie Clicker](https://orteil.dashnet.org/cookieclicker)
This should remove that

----

Profiling results while showing cookie clicker:
```
i686 + sse2 (master): draw_scaled_bitmap : 30.59% (16.76% self)
    - roundf 11.53%
    - blit 1.98%
    - blit_with_opacity 0.04%
i686 + sse2 (new): draw_scaled_bitmap : 18.01% (12.69% self)
    - blit 4.66%
    - blit_with_opacity 0.01%
```