### PR TITLE
LibGfx: Avoid signed comparison in find_largest_image

### DIFF
--- a/Userland/Libraries/LibGfx/ICOLoader.cpp
+++ b/Userland/Libraries/LibGfx/ICOLoader.cpp
@@ -123,7 +123,7 @@ static size_t find_largest_image(ICOLoadingContext const& context)
     size_t index = 0;
     size_t largest_index = 0;
     for (auto const& desc : context.images) {
-        if (desc.width * desc.height > max_area) {
+        if (static_cast<size_t>(desc.width) * static_cast<size_t>(desc.height) > max_area) {
             max_area = desc.width * desc.height;
             largest_index = index;
         }


### PR DESCRIPTION
I believe the issue was caused by the product of two u16s being promoted
to int. As such, a static_casting the result should fix the problem.