### PR TITLE
LibWeb: Add a new code generator for CSS enums

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(SOURCES "") # avoid pulling SOURCES from parent scope
 
+lagom_tool(GenerateCSSEnums                SOURCES GenerateCSSEnums.cpp LIBS LagomMain)
 lagom_tool(GenerateCSSMediaFeatureID       SOURCES GenerateCSSMediaFeatureID.cpp LIBS LagomMain)
 lagom_tool(GenerateCSSPropertyID           SOURCES GenerateCSSPropertyID.cpp LIBS LagomMain)
 lagom_tool(GenerateCSSValueID              SOURCES GenerateCSSValueID.cpp LIBS LagomMain)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -77,6 +77,7 @@ enum class ValueID;
         enum_generator.appendln("};");
         enum_generator.appendln("Optional<@name:titlecase@> value_id_to_@name:snakecase@(ValueID);");
         enum_generator.appendln("ValueID to_value_id(@name:titlecase@);");
+        enum_generator.appendln("StringView to_string(@name:titlecase@);");
         enum_generator.append("\n");
     });
 
@@ -149,6 +150,31 @@ ValueID to_value_id(@name:titlecase@ @name:snakecase@_value)
             member_generator.append(R"~~~(
     case @name:titlecase@::@member:titlecase@:
         return ValueID::@member:titlecase@;)~~~");
+        }
+
+        enum_generator.append(R"~~~(
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+)~~~");
+
+        enum_generator.append(R"~~~(
+StringView to_string(@name:titlecase@ value)
+{
+    switch (value) {)~~~");
+
+        for (auto& member : members.values()) {
+            auto member_generator = enum_generator.fork();
+            auto member_name = member.to_string();
+            if (member_name.contains('='))
+                continue;
+            member_generator.set("member:css", member_name);
+            member_generator.set("member:titlecase", title_casify(member_name));
+
+            member_generator.append(R"~~~(
+    case @name:titlecase@::@member:titlecase@:
+        return "@member:css@"sv;)~~~");
         }
 
         enum_generator.append(R"~~~(

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -62,7 +62,19 @@ enum class ValueID;
         enum_generator.set("name:titlecase", title_casify(name));
         enum_generator.set("name:snakecase", snake_casify(name));
 
-        enum_generator.appendln("enum class @name:titlecase@ {");
+        // Find the smallest possible type to use.
+        auto member_max_value = members.size() - 1;
+        if (NumericLimits<u8>::max() >= member_max_value) {
+            enum_generator.set("enum_type", "u8");
+        } else if (NumericLimits<u16>::max() >= member_max_value) {
+            enum_generator.set("enum_type", "u16");
+        } else if (NumericLimits<u32>::max() >= member_max_value) {
+            enum_generator.set("enum_type", "u32");
+        } else {
+            enum_generator.set("enum_type", "u64");
+        }
+
+        enum_generator.appendln("enum class @name:titlecase@ : @enum_type@ {");
 
         for (auto& member : members.values()) {
             auto member_name = member.to_string();

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -76,6 +76,7 @@ enum class ValueID;
 
         enum_generator.appendln("};");
         enum_generator.appendln("Optional<@name:titlecase@> value_id_to_@name:snakecase@(ValueID);");
+        enum_generator.appendln("ValueID to_value_id(@name:titlecase@);");
         enum_generator.append("\n");
     });
 
@@ -129,6 +130,30 @@ Optional<@name:titlecase@> value_id_to_@name:snakecase@(ValueID value_id)
         enum_generator.append(R"~~~(
     default:
         return {};
+    }
+}
+)~~~");
+
+        enum_generator.append(R"~~~(
+ValueID to_value_id(@name:titlecase@ @name:snakecase@_value)
+{
+    switch (@name:snakecase@_value) {)~~~");
+
+        for (auto& member : members.values()) {
+            auto member_generator = enum_generator.fork();
+            auto member_name = member.to_string();
+            if (member_name.contains('='))
+                continue;
+            member_generator.set("member:titlecase", title_casify(member_name));
+
+            member_generator.append(R"~~~(
+    case @name:titlecase@::@member:titlecase@:
+        return ValueID::@member:titlecase@;)~~~");
+        }
+
+        enum_generator.append(R"~~~(
+    default:
+        VERIFY_NOT_REACHED();
     }
 }
 )~~~");

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GeneratorUtil.h"
+#include <AK/SourceGenerator.h>
+#include <AK/StringBuilder.h>
+#include <LibCore/ArgsParser.h>
+#include <LibMain/Main.h>
+
+ErrorOr<void> generate_header_file(JsonObject& enums_data, Core::Stream::File& file);
+ErrorOr<void> generate_implementation_file(JsonObject& enums_data, Core::Stream::File& file);
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    StringView generated_header_path;
+    StringView generated_implementation_path;
+    StringView identifiers_json_path;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(generated_header_path, "Path to the Enums header file to generate", "generated-header-path", 'h', "generated-header-path");
+    args_parser.add_option(generated_implementation_path, "Path to the Enums implementation file to generate", "generated-implementation-path", 'c', "generated-implementation-path");
+    args_parser.add_option(identifiers_json_path, "Path to the JSON file to read from", "json-path", 'j', "json-path");
+    args_parser.parse(arguments);
+
+    auto json = TRY(read_entire_file_as_json(identifiers_json_path));
+    VERIFY(json.is_object());
+    auto enums_data = json.as_object();
+
+    auto generated_header_file = TRY(Core::Stream::File::open(generated_header_path, Core::Stream::OpenMode::Write));
+    auto generated_implementation_file = TRY(Core::Stream::File::open(generated_implementation_path, Core::Stream::OpenMode::Write));
+
+    TRY(generate_header_file(enums_data, *generated_header_file));
+    TRY(generate_implementation_file(enums_data, *generated_implementation_file));
+
+    return 0;
+}
+
+ErrorOr<void> generate_header_file(JsonObject& enums_data, Core::Stream::File& file)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.append(R"~~~(
+#pragma once
+
+namespace Web::CSS {
+
+enum class ValueID;
+
+)~~~");
+
+    enums_data.for_each_member([&](auto& name, auto& value) {
+        VERIFY(value.is_array());
+        auto& members = value.as_array();
+
+        auto enum_generator = generator.fork();
+        enum_generator.set("name:titlecase", title_casify(name));
+        enum_generator.appendln("enum class @name:titlecase@ {");
+
+        for (auto& member : members.values()) {
+            auto member_name = member.to_string();
+            // Don't include aliases in the enum.
+            if (member_name.contains('='))
+                continue;
+            auto member_generator = enum_generator.fork();
+            member_generator.set("member:titlecase", title_casify(member_name));
+            member_generator.appendln("    @member:titlecase@,");
+        }
+
+        enum_generator.appendln("};\n");
+    });
+
+    generator.appendln("}");
+
+    TRY(file.write(generator.as_string_view().bytes()));
+    return {};
+}
+
+ErrorOr<void> generate_implementation_file(JsonObject& enums_data, Core::Stream::File& file)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.append(R"~~~(
+#include <LibWeb/CSS/Enums.h>
+
+namespace Web::CSS {
+)~~~");
+
+    // TODO: Generate some things!
+    (void)enums_data;
+
+    generator.appendln("}");
+
+    TRY(file.write(generator.as_string_view().bytes()));
+    return {};
+}

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSPropertyID.cpp
@@ -150,6 +150,7 @@ ErrorOr<void> generate_implementation_file(JsonObject& properties, Core::Stream:
 
     generator.append(R"~~~(
 #include <AK/Assertions.h>
+#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Parser/Parser.h>
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/StyleValue.h>
@@ -512,8 +513,13 @@ bool property_accepts_value(PropertyID property_id, StyleValue& style_value)
                         } else if (type_name == "url") {
                             // FIXME: Handle urls!
                         } else {
-                            warnln("Unrecognized valid-type name: '{}'", type_name);
-                            VERIFY_NOT_REACHED();
+                            // Assume that any other type names are defined in Enums.json.
+                            // If they're not, the output won't compile, but that's fine since it's invalid.
+                            property_generator.set("type_name:snakecase", snake_casify(type_name));
+                            property_generator.append(R"~~~(
+        if (auto converted_identifier = value_id_to_@type_name:snakecase@(style_value.to_identifier()); converted_identifier.has_value())
+            return true;
+)~~~");
                         }
                     }
                 }

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GeneratorUtil.h
@@ -49,6 +49,11 @@ String camel_casify(StringView dashy_name)
     return builder.to_string();
 }
 
+String snake_casify(String const& dashy_name)
+{
+    return dashy_name.replace("-", "_", true);
+}
+
 ErrorOr<JsonValue> read_entire_file_as_json(StringView filename)
 {
     auto file = TRY(Core::Stream::File::open(filename, Core::Stream::OpenMode::Read));

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SOURCES
     CSS/CSSSupportsRule.cpp
     CSS/DefaultStyleSheetSource.cpp
     CSS/Display.cpp
+    CSS/Enums.cpp
     CSS/FontFace.cpp
     CSS/Frequency.cpp
     CSS/Length.cpp
@@ -615,6 +616,16 @@ libweb_js_wrapper(WebSockets/WebSocket)
 libweb_js_wrapper(XHR/ProgressEvent)
 libweb_js_wrapper(XHR/XMLHttpRequest)
 libweb_js_wrapper(XHR/XMLHttpRequestEventTarget)
+
+invoke_generator(
+    "Enums"
+    Lagom::GenerateCSSEnums
+    "${CMAKE_CURRENT_SOURCE_DIR}/CSS/Enums.json"
+    ""
+    "CSS/Enums.h"
+    "CSS/Enums.cpp"
+    arguments -j "${CMAKE_CURRENT_SOURCE_DIR}/CSS/Enums.json"
+)
 
 invoke_generator(
     "MediaFeatureID"

--- a/Userland/Libraries/LibWeb/CSS/Enums.json
+++ b/Userland/Libraries/LibWeb/CSS/Enums.json
@@ -1,0 +1,216 @@
+{
+    "align-items": [
+        "flex-start",
+        "flex-end",
+        "center",
+        "baseline",
+        "stretch"
+    ],
+    "background-attachment": [
+        "fixed",
+        "local",
+        "scroll"
+    ],
+    "background-box": [
+        "border-box",
+        "content-box",
+        "padding-box"
+    ],
+    "box-sizing": [
+        "border-box",
+        "content-box"
+    ],
+    "clear": [
+        "none",
+        "left",
+        "right",
+        "both"
+    ],
+    "cursor": [
+        "auto",
+        "default",
+        "none",
+        "context-menu",
+        "help",
+        "pointer",
+        "progress",
+        "wait",
+        "cell",
+        "crosshair",
+        "text",
+        "vertical-text",
+        "alias",
+        "copy",
+        "move",
+        "no-drop",
+        "not-allowed",
+        "grab",
+        "grabbing",
+        "e-resize",
+        "n-resize",
+        "ne-resize",
+        "nw-resize",
+        "s-resize",
+        "se-resize",
+        "sw-resize",
+        "w-resize",
+        "ew-resize",
+        "ns-resize",
+        "nesw-resize",
+        "nwse-resize",
+        "col-resize",
+        "row-resize",
+        "all-scroll",
+        "zoom-in",
+        "zoom-out"
+    ],
+    "flex-direction": [
+        "row",
+        "row-reverse",
+        "column",
+        "column-reverse"
+    ],
+    "flex-wrap": [
+        "nowrap",
+        "wrap",
+        "wrap-reverse"
+    ],
+    "float": [
+        "none",
+        "left",
+        "right"
+    ],
+    "font-variant": [
+        "normal",
+        "small-caps"
+    ],
+    "image-rendering": [
+        "auto",
+        "crisp-edges",
+        "high-quality",
+        "pixelated",
+        "smooth"
+    ],
+    "justify-content": [
+        "flex-start",
+        "flex-end",
+        "center",
+        "space-between",
+        "space-around"
+    ],
+    "line-style": [
+        "none",
+        "hidden",
+        "dotted",
+        "dashed",
+        "solid",
+        "double",
+        "groove",
+        "ridge",
+        "inset",
+        "outset"
+    ],
+    "list-style-type": [
+        "circle",
+        "decimal",
+        "decimal-leading-zero",
+        "disc",
+        "lower-alpha",
+        "lower-latin",
+        "lower-roman",
+        "none",
+        "square",
+        "upper-alpha",
+        "upper-latin",
+        "upper-roman"
+    ],
+    "overflow": [
+        "auto",
+        "clip",
+        "hidden",
+        "scroll",
+        "visible"
+    ],
+    "pointer-events": [
+        "auto",
+        "all",
+        "none"
+    ],
+    "position": [
+        "absolute",
+        "fixed",
+        "relative",
+        "static",
+        "sticky"
+    ],
+    "position-edge": [
+        "left",
+        "right",
+        "top",
+        "bottom"
+    ],
+    "repeat": [
+        "no-repeat",
+        "repeat",
+        "round",
+        "space"
+    ],
+    "text-align": [
+        "center",
+        "justify",
+        "left",
+        "right",
+        "-libweb-center"
+    ],
+    "text-decoration-line": [
+        "blink",
+        "line-through",
+        "none",
+        "overline",
+        "underline"
+    ],
+    "text-decoration-style": [
+        "dashed",
+        "dotted",
+        "double",
+        "solid",
+        "wavy"
+    ],
+    "text-justify": [
+        "auto",
+        "none",
+        "inter-word",
+        "inter-character",
+        "distribute=inter-character"
+    ],
+    "text-transform": [
+        "capitalize",
+        "full-size-kana",
+        "full-width",
+        "lowercase",
+        "none",
+        "uppercase"
+    ],
+    "vertical-align": [
+        "baseline",
+        "bottom",
+        "middle",
+        "sub",
+        "super",
+        "text-bottom",
+        "text-top",
+        "top"
+    ],
+    "visibility": [
+        "collapse",
+        "hidden",
+        "visible"
+    ],
+    "white-space": [
+        "normal",
+        "nowrap",
+        "pre",
+        "pre-line",
+        "pre-wrap"
+    ]
+}

--- a/Userland/Libraries/LibWeb/CSS/LengthBox.h
+++ b/Userland/Libraries/LibWeb/CSS/LengthBox.h
@@ -6,8 +6,7 @@
 
 #pragma once
 
-#include <LibWeb/CSS/Length.h>
-#include <LibWeb/CSS/StyleValue.h>
+#include <LibWeb/CSS/Percentage.h>
 
 namespace Web::CSS {
 

--- a/Userland/Libraries/LibWeb/CSS/Properties.json
+++ b/Userland/Libraries/LibWeb/CSS/Properties.json
@@ -2,12 +2,8 @@
   "align-items": {
     "inherited": false,
     "initial": "stretch",
-    "valid-identifiers": [
-      "center",
-      "baseline",
-      "flex-end",
-      "flex-start",
-      "stretch"
+    "valid-types": [
+      "align-items"
     ]
   },
   "background": {
@@ -29,20 +25,16 @@
     "affects-layout": false,
     "inherited": false,
     "initial": "scroll",
-    "valid-identifiers": [
-      "fixed",
-      "local",
-      "scroll"
+    "valid-types": [
+      "background-attachment"
     ]
   },
   "background-clip": {
     "affects-layout": false,
     "inherited": false,
     "initial": "border-box",
-    "valid-identifiers": [
-      "border-box",
-      "content-box",
-      "padding-box"
+    "valid-types": [
+      "background-box"
     ]
   },
   "background-color": {
@@ -71,10 +63,8 @@
     "affects-layout": false,
     "inherited": false,
     "initial": "padding-box",
-    "valid-identifiers": [
-      "border-box",
-      "content-box",
-      "padding-box"
+    "valid-types": [
+      "background-box"
     ]
   },
   "background-position": {
@@ -102,13 +92,12 @@
     "inherited": false,
     "initial": "repeat",
     "max-values": 2,
+    "valid-types": [
+      "repeat"
+    ],
     "valid-identifiers": [
-      "no-repeat",
-      "repeat",
       "repeat-x",
-      "repeat-y",
-      "round",
-      "space"
+      "repeat-y"
     ]
   },
   "background-size": {
@@ -206,17 +195,8 @@
     "affects-layout": false,
     "initial": "none",
     "inherited": false,
-    "valid-identifiers": [
-      "dashed",
-      "dotted",
-      "double",
-      "groove",
-      "hidden",
-      "inset",
-      "none",
-      "outset",
-      "ridge",
-      "solid"
+    "valid-types": [
+      "line-style"
     ]
   },
   "border-bottom-width": {
@@ -274,17 +254,8 @@
     "affects-layout": false,
     "initial": "none",
     "inherited": false,
-    "valid-identifiers": [
-      "dashed",
-      "dotted",
-      "double",
-      "groove",
-      "hidden",
-      "inset",
-      "none",
-      "outset",
-      "ridge",
-      "solid"
+    "valid-types": [
+      "line-style"
     ]
   },
   "border-left-width": {
@@ -328,17 +299,8 @@
     "affects-layout": false,
     "initial": "none",
     "inherited": false,
-    "valid-identifiers": [
-      "dashed",
-      "dotted",
-      "double",
-      "groove",
-      "hidden",
-      "inset",
-      "none",
-      "outset",
-      "ridge",
-      "solid"
+    "valid-types": [
+      "line-style"
     ]
   },
   "border-right-width": {
@@ -373,17 +335,8 @@
       "border-left-style"
     ],
     "max-values": 4,
-    "valid-identifiers": [
-      "dashed",
-      "dotted",
-      "double",
-      "groove",
-      "hidden",
-      "inset",
-      "none",
-      "outset",
-      "ridge",
-      "solid"
+    "valid-types": [
+      "line-style"
     ]
   },
   "border-top-color": {
@@ -418,17 +371,8 @@
     "affects-layout": false,
     "initial": "none",
     "inherited": false,
-    "valid-identifiers": [
-      "dashed",
-      "dotted",
-      "double",
-      "groove",
-      "hidden",
-      "inset",
-      "none",
-      "outset",
-      "ridge",
-      "solid"
+    "valid-types": [
+      "line-style"
     ]
   },
   "border-top-width": {
@@ -492,9 +436,8 @@
   "box-sizing": {
     "inherited": false,
     "initial": "content-box",
-    "valid-identifiers": [
-      "border-box",
-      "content-box"
+    "valid-types": [
+      "box-sizing"
     ]
   },
   "caption-side": {
@@ -508,11 +451,8 @@
   "clear": {
     "inherited": false,
     "initial": "none",
-    "valid-identifiers": [
-      "both",
-      "left",
-      "none",
-      "right"
+    "valid-types": [
+      "clear"
     ]
   },
   "clip": {
@@ -553,45 +493,8 @@
     "inherited": true,
     "initial": "auto",
     "valid-types": [
-      "url"
-    ],
-    "valid-identifiers": [
-      "alias",
-      "all-scroll",
-      "auto",
-      "cell",
-      "col-resize",
-      "context-menu",
-      "copy",
-      "crosshair",
-      "default",
-      "e-resize",
-      "ew-resize",
-      "grab",
-      "grabbing",
-      "help",
-      "move",
-      "n-resize",
-      "ne-resize",
-      "nesw-resize",
-      "no-drop",
-      "none",
-      "not-allowed",
-      "ns-resize",
-      "nw-resize",
-      "nwse-resize",
-      "pointer",
-      "progress",
-      "row-resize",
-      "s-resize",
-      "se-resize",
-      "sw-resize",
-      "text",
-      "vertical-text",
-      "w-resize",
-      "wait",
-      "zoom-in",
-      "zoom-out"
+      "url",
+      "cursor"
     ]
   },
   "direction": {
@@ -660,11 +563,8 @@
   "flex-direction": {
     "inherited": false,
     "initial": "row",
-    "valid-identifiers": [
-      "column",
-      "column-reverse",
-      "row",
-      "row-reverse"
+    "valid-types": [
+      "flex-direction"
     ]
   },
   "flex-flow": {
@@ -699,19 +599,15 @@
   "flex-wrap": {
     "inherited": false,
     "initial": "nowrap",
-    "valid-identifiers": [
-      "nowrap",
-      "wrap",
-      "wrap-reverse"
+    "valid-types": [
+      "flex-wrap"
     ]
   },
   "float": {
     "inherited": false,
     "initial": "none",
-    "valid-identifiers": [
-      "left",
-      "none",
-      "right"
+    "valid-types": [
+      "float"
     ]
   },
   "font": {
@@ -763,9 +659,8 @@
   "font-variant": {
     "inherited": true,
     "initial": "normal",
-    "valid-identifiers": [
-      "normal",
-      "small-caps"
+    "valid-types": [
+      "font-variant"
     ]
   },
   "font-weight": {
@@ -799,23 +694,15 @@
     "affects-layout": false,
     "inherited": true,
     "initial": "auto",
-    "valid-identifiers": [
-      "auto",
-      "crisp-edges",
-      "high-quality",
-      "pixelated",
-      "smooth"
+    "valid-types": [
+      "image-rendering"
     ]
   },
   "justify-content": {
     "inherited": false,
     "initial": "flex-start",
-    "valid-identifiers": [
-      "center",
-      "flex-end",
-      "flex-start",
-      "space-around",
-      "space-between"
+    "valid-types": [
+      "justify-content"
     ]
   },
   "left": {
@@ -889,21 +776,8 @@
     "inherited": true,
     "initial": "disc",
     "valid-types": [
-      "string"
-    ],
-    "valid-identifiers": [
-      "circle",
-      "decimal",
-      "decimal-leading-zero",
-      "disc",
-      "lower-alpha",
-      "lower-latin",
-      "lower-roman",
-      "none",
-      "square",
-      "upper-alpha",
-      "upper-latin",
-      "upper-roman"
+      "string",
+      "list-style-type"
     ]
   },
   "margin": {
@@ -1077,17 +951,8 @@
     "affects-layout": false,
     "inherited": false,
     "initial": "none",
-    "valid-identifiers": [
-      "dashed",
-      "dotted",
-      "double",
-      "groove",
-      "hidden",
-      "inset",
-      "none",
-      "outset",
-      "ridge",
-      "solid"
+    "valid-types": [
+      "line-style"
     ]
   },
   "outline-width": {
@@ -1111,34 +976,22 @@
     "inherited": false,
     "initial": "visible",
     "max-values": 2,
-    "valid-identifiers": [
-      "auto",
-      "clip",
-      "hidden",
-      "scroll",
-      "visible"
+    "valid-types": [
+      "overflow"
     ]
   },
   "overflow-x": {
     "inherited": false,
     "initial": "visible",
-    "valid-identifiers": [
-      "auto",
-      "clip",
-      "hidden",
-      "scroll",
-      "visible"
+    "valid-types": [
+      "overflow"
     ]
   },
   "overflow-y": {
     "inherited": false,
     "initial": "visible",
-    "valid-identifiers": [
-      "auto",
-      "clip",
-      "hidden",
-      "scroll",
-      "visible"
+    "valid-types": [
+      "overflow"
     ]
   },
   "padding": {
@@ -1207,21 +1060,15 @@
     "affects-layout": false,
     "inherited": true,
     "initial": "auto",
-    "valid-identifiers": [
-      "auto",
-      "all",
-      "none"
+    "valid-types": [
+      "pointer-events"
     ]
   },
   "position": {
     "inherited": false,
     "initial": "static",
-    "valid-identifiers": [
-      "absolute",
-      "fixed",
-      "relative",
-      "static",
-      "sticky"
+    "valid-types": [
+      "position"
     ]
   },
   "right": {
@@ -1262,12 +1109,8 @@
   "text-align": {
     "inherited": true,
     "initial": "left",
-    "valid-identifiers": [
-      "center",
-      "justify",
-      "left",
-      "right",
-      "-libweb-center"
+    "valid-types": [
+      "text-align"
     ]
   },
   "text-decoration": {
@@ -1294,24 +1137,16 @@
     "affects-layout": false,
     "inherited": true,
     "initial": "none",
-    "valid-identifiers": [
-      "blink",
-      "line-through",
-      "none",
-      "overline",
-      "underline"
+    "valid-types": [
+      "text-decoration-line"
     ]
   },
   "text-decoration-style": {
     "affects-layout": false,
     "inherited": false,
     "initial": "solid",
-    "valid-identifiers": [
-      "dashed",
-      "dotted",
-      "double",
-      "solid",
-      "wavy"
+    "valid-types": [
+      "text-decoration-style"
     ]
   },
   "text-decoration-thickness": {
@@ -1341,12 +1176,8 @@
   "text-justify": {
     "inherited": true,
     "initial": "auto",
-    "valid-identifiers": [
-      "auto",
-      "none",
-      "inter-word",
-      "inter-character",
-      "distribute"
+    "valid-types": [
+      "text-justify"
     ]
   },
   "text-shadow": {
@@ -1360,13 +1191,8 @@
   "text-transform": {
     "inherited": true,
     "initial": "none",
-    "valid-identifiers": [
-      "capitalize",
-      "full-size-kana",
-      "full-width",
-      "lowercase",
-      "none",
-      "uppercase"
+    "valid-types": [
+      "text-transform"
     ]
   },
   "top": {
@@ -1421,17 +1247,8 @@
     "initial": "baseline",
     "valid-types": [
       "length",
-      "percentage"
-    ],
-    "valid-identifiers": [
-      "baseline",
-      "bottom",
-      "middle",
-      "sub",
-      "super",
-      "text-bottom",
-      "text-top",
-      "top"
+      "percentage",
+      "vertical-align"
     ],
     "quirks": [
       "unitless-length"
@@ -1440,10 +1257,8 @@
   "visibility": {
     "inherited": true,
     "initial": "visible",
-    "valid-identifiers": [
-      "collapse",
-      "hidden",
-      "visible"
+    "valid-types": [
+      "visibility"
     ]
   },
   "width": {
@@ -1463,12 +1278,8 @@
   "white-space": {
     "inherited": true,
     "initial": "normal",
-    "valid-identifiers": [
-      "normal",
-      "nowrap",
-      "pre",
-      "pre-line",
-      "pre-wrap"
+    "valid-types": [
+      "white-space"
     ]
   },
   "word-spacing": {

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -7,6 +7,7 @@
 
 #include <AK/Debug.h>
 #include <AK/NonnullRefPtr.h>
+#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/ResolvedCSSStyleDeclaration.h>
 #include <LibWeb/CSS/StyleComputer.h>
 #include <LibWeb/DOM/Document.h>
@@ -28,17 +29,6 @@ String ResolvedCSSStyleDeclaration::item(size_t index) const
 {
     (void)index;
     return {};
-}
-
-static CSS::ValueID to_css_value_id(CSS::BoxSizing value)
-{
-    switch (value) {
-    case CSS::BoxSizing::BorderBox:
-        return CSS::ValueID::BorderBox;
-    case CSS::BoxSizing::ContentBox:
-        return CSS::ValueID::ContentBox;
-    }
-    VERIFY_NOT_REACHED();
 }
 
 static RefPtr<StyleValue> style_value_for_display(CSS::Display display)
@@ -115,377 +105,6 @@ static RefPtr<StyleValue> style_value_for_display(CSS::Display display)
     TODO();
 }
 
-static CSS::ValueID to_css_value_id(CSS::Float value)
-{
-    switch (value) {
-    case Float::None:
-        return CSS::ValueID::None;
-    case Float::Left:
-        return CSS::ValueID::Left;
-    case Float::Right:
-        return CSS::ValueID::Right;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::Clear value)
-{
-    switch (value) {
-    case Clear::None:
-        return CSS::ValueID::None;
-    case Clear::Left:
-        return CSS::ValueID::Left;
-    case Clear::Right:
-        return CSS::ValueID::Right;
-    case Clear::Both:
-        return CSS::ValueID::Both;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::TextDecorationLine value)
-{
-    switch (value) {
-    case TextDecorationLine::None:
-        return CSS::ValueID::None;
-    case TextDecorationLine::Underline:
-        return CSS::ValueID::Underline;
-    case TextDecorationLine::Overline:
-        return CSS::ValueID::Overline;
-    case TextDecorationLine::LineThrough:
-        return CSS::ValueID::LineThrough;
-    case TextDecorationLine::Blink:
-        return CSS::ValueID::Blink;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::TextDecorationStyle value)
-{
-    switch (value) {
-    case TextDecorationStyle::Solid:
-        return CSS::ValueID::Solid;
-    case TextDecorationStyle::Double:
-        return CSS::ValueID::Double;
-    case TextDecorationStyle::Dotted:
-        return CSS::ValueID::Dotted;
-    case TextDecorationStyle::Dashed:
-        return CSS::ValueID::Dashed;
-    case TextDecorationStyle::Wavy:
-        return CSS::ValueID::Wavy;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::Cursor value)
-{
-    switch (value) {
-    case Cursor::Auto:
-        return CSS::ValueID::Auto;
-    case Cursor::Default:
-        return CSS::ValueID::Default;
-    case Cursor::None:
-        return CSS::ValueID::None;
-    case Cursor::ContextMenu:
-        return CSS::ValueID::ContextMenu;
-    case Cursor::Help:
-        return CSS::ValueID::Help;
-    case Cursor::Pointer:
-        return CSS::ValueID::Pointer;
-    case Cursor::Progress:
-        return CSS::ValueID::Progress;
-    case Cursor::Wait:
-        return CSS::ValueID::Wait;
-    case Cursor::Cell:
-        return CSS::ValueID::Cell;
-    case Cursor::Crosshair:
-        return CSS::ValueID::Crosshair;
-    case Cursor::Text:
-        return CSS::ValueID::Text;
-    case Cursor::VerticalText:
-        return CSS::ValueID::VerticalText;
-    case Cursor::Alias:
-        return CSS::ValueID::Alias;
-    case Cursor::Copy:
-        return CSS::ValueID::Copy;
-    case Cursor::Move:
-        return CSS::ValueID::Move;
-    case Cursor::NoDrop:
-        return CSS::ValueID::NoDrop;
-    case Cursor::NotAllowed:
-        return CSS::ValueID::NotAllowed;
-    case Cursor::Grab:
-        return CSS::ValueID::Grab;
-    case Cursor::Grabbing:
-        return CSS::ValueID::Grabbing;
-    case Cursor::EResize:
-        return CSS::ValueID::EResize;
-    case Cursor::NResize:
-        return CSS::ValueID::NResize;
-    case Cursor::NeResize:
-        return CSS::ValueID::NeResize;
-    case Cursor::NwResize:
-        return CSS::ValueID::NwResize;
-    case Cursor::SResize:
-        return CSS::ValueID::SResize;
-    case Cursor::SeResize:
-        return CSS::ValueID::SeResize;
-    case Cursor::SwResize:
-        return CSS::ValueID::SwResize;
-    case Cursor::WResize:
-        return CSS::ValueID::WResize;
-    case Cursor::EwResize:
-        return CSS::ValueID::EwResize;
-    case Cursor::NsResize:
-        return CSS::ValueID::NsResize;
-    case Cursor::NeswResize:
-        return CSS::ValueID::NeswResize;
-    case Cursor::NwseResize:
-        return CSS::ValueID::NwseResize;
-    case Cursor::ColResize:
-        return CSS::ValueID::ColResize;
-    case Cursor::RowResize:
-        return CSS::ValueID::RowResize;
-    case Cursor::AllScroll:
-        return CSS::ValueID::AllScroll;
-    case Cursor::ZoomIn:
-        return CSS::ValueID::ZoomIn;
-    case Cursor::ZoomOut:
-        return CSS::ValueID::ZoomOut;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::TextAlign value)
-{
-    switch (value) {
-    case TextAlign::Left:
-        return CSS::ValueID::Left;
-    case TextAlign::Center:
-        return CSS::ValueID::Center;
-    case TextAlign::Right:
-        return CSS::ValueID::Right;
-    case TextAlign::Justify:
-        return CSS::ValueID::Justify;
-    case TextAlign::LibwebCenter:
-        return CSS::ValueID::LibwebCenter;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::TextTransform value)
-{
-    switch (value) {
-    case TextTransform::None:
-        return CSS::ValueID::None;
-    case TextTransform::Capitalize:
-        return CSS::ValueID::Capitalize;
-    case TextTransform::Uppercase:
-        return CSS::ValueID::Uppercase;
-    case TextTransform::Lowercase:
-        return CSS::ValueID::Lowercase;
-    case TextTransform::FullWidth:
-        return CSS::ValueID::FullWidth;
-    case TextTransform::FullSizeKana:
-        return CSS::ValueID::FullSizeKana;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::Position value)
-{
-    switch (value) {
-    case Position::Static:
-        return CSS::ValueID::Static;
-    case Position::Relative:
-        return CSS::ValueID::Relative;
-    case Position::Absolute:
-        return CSS::ValueID::Absolute;
-    case Position::Fixed:
-        return CSS::ValueID::Fixed;
-    case Position::Sticky:
-        return CSS::ValueID::Sticky;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::WhiteSpace value)
-{
-    switch (value) {
-    case WhiteSpace::Normal:
-        return CSS::ValueID::Normal;
-    case WhiteSpace::Pre:
-        return CSS::ValueID::Pre;
-    case WhiteSpace::Nowrap:
-        return CSS::ValueID::Nowrap;
-    case WhiteSpace::PreLine:
-        return CSS::ValueID::PreLine;
-    case WhiteSpace::PreWrap:
-        return CSS::ValueID::PreWrap;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::FlexDirection value)
-{
-    switch (value) {
-    case FlexDirection::Row:
-        return CSS::ValueID::Row;
-    case FlexDirection::RowReverse:
-        return CSS::ValueID::RowReverse;
-    case FlexDirection::Column:
-        return CSS::ValueID::Column;
-    case FlexDirection::ColumnReverse:
-        return CSS::ValueID::ColumnReverse;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::FlexWrap value)
-{
-    switch (value) {
-    case FlexWrap::Nowrap:
-        return CSS::ValueID::Nowrap;
-    case FlexWrap::Wrap:
-        return CSS::ValueID::Wrap;
-    case FlexWrap::WrapReverse:
-        return CSS::ValueID::WrapReverse;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::ImageRendering value)
-{
-    switch (value) {
-    case ImageRendering::Auto:
-        return CSS::ValueID::Auto;
-    case ImageRendering::CrispEdges:
-        return CSS::ValueID::CrispEdges;
-    case ImageRendering::HighQuality:
-        return CSS::ValueID::HighQuality;
-    case ImageRendering::Pixelated:
-        return CSS::ValueID::Pixelated;
-    case ImageRendering::Smooth:
-        return CSS::ValueID::Smooth;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::JustifyContent value)
-{
-    switch (value) {
-    case JustifyContent::FlexStart:
-        return CSS::ValueID::FlexStart;
-    case JustifyContent::FlexEnd:
-        return CSS::ValueID::FlexEnd;
-    case JustifyContent::Center:
-        return CSS::ValueID::Center;
-    case JustifyContent::SpaceBetween:
-        return CSS::ValueID::SpaceBetween;
-    case JustifyContent::SpaceAround:
-        return CSS::ValueID::SpaceAround;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::Overflow value)
-{
-    switch (value) {
-    case Overflow::Auto:
-        return CSS::ValueID::Auto;
-    case Overflow::Clip:
-        return CSS::ValueID::Clip;
-    case Overflow::Hidden:
-        return CSS::ValueID::Hidden;
-    case Overflow::Scroll:
-        return CSS::ValueID::Scroll;
-    case Overflow::Visible:
-        return CSS::ValueID::Visible;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::VerticalAlign value)
-{
-    switch (value) {
-    case CSS::VerticalAlign::Baseline:
-        return CSS::ValueID::Baseline;
-    case CSS::VerticalAlign::Bottom:
-        return CSS::ValueID::Bottom;
-    case CSS::VerticalAlign::Middle:
-        return CSS::ValueID::Middle;
-    case CSS::VerticalAlign::Sub:
-        return CSS::ValueID::Sub;
-    case CSS::VerticalAlign::Super:
-        return CSS::ValueID::Super;
-    case CSS::VerticalAlign::TextBottom:
-        return CSS::ValueID::TextBottom;
-    case CSS::VerticalAlign::TextTop:
-        return CSS::ValueID::TextTop;
-    case CSS::VerticalAlign::Top:
-        return CSS::ValueID::Top;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::ListStyleType value)
-{
-    switch (value) {
-    case ListStyleType::None:
-        return CSS::ValueID::None;
-    case ListStyleType::Disc:
-        return CSS::ValueID::Disc;
-    case ListStyleType::Circle:
-        return CSS::ValueID::Circle;
-    case ListStyleType::Square:
-        return CSS::ValueID::Square;
-    case ListStyleType::Decimal:
-        return CSS::ValueID::Decimal;
-    case ListStyleType::DecimalLeadingZero:
-        return CSS::ValueID::DecimalLeadingZero;
-    case ListStyleType::LowerAlpha:
-        return CSS::ValueID::LowerAlpha;
-    case ListStyleType::LowerLatin:
-        return CSS::ValueID::LowerLatin;
-    case ListStyleType::LowerRoman:
-        return CSS::ValueID::LowerRoman;
-    case ListStyleType::UpperAlpha:
-        return CSS::ValueID::UpperAlpha;
-    case ListStyleType::UpperLatin:
-        return CSS::ValueID::UpperLatin;
-    case ListStyleType::UpperRoman:
-        return CSS::ValueID::UpperRoman;
-    }
-    VERIFY_NOT_REACHED();
-}
-
-static CSS::ValueID to_css_value_id(CSS::LineStyle value)
-{
-    switch (value) {
-    case CSS::LineStyle::None:
-        return CSS::ValueID::None;
-    case CSS::LineStyle::Hidden:
-        return CSS::ValueID::Hidden;
-    case CSS::LineStyle::Dotted:
-        return CSS::ValueID::Dotted;
-    case CSS::LineStyle::Dashed:
-        return CSS::ValueID::Dashed;
-    case CSS::LineStyle::Solid:
-        return CSS::ValueID::Solid;
-    case CSS::LineStyle::Double:
-        return CSS::ValueID::Double;
-    case CSS::LineStyle::Groove:
-        return CSS::ValueID::Groove;
-    case CSS::LineStyle::Ridge:
-        return CSS::ValueID::Ridge;
-    case CSS::LineStyle::Inset:
-        return CSS::ValueID::Inset;
-    case CSS::LineStyle::Outset:
-        return CSS::ValueID::Outset;
-    }
-    VERIFY_NOT_REACHED();
-}
-
 static NonnullRefPtr<StyleValue> value_or_default(Optional<StyleProperty> property, NonnullRefPtr<StyleValue> default_style)
 {
     if (property.has_value())
@@ -506,11 +125,11 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
 {
     switch (property_id) {
     case CSS::PropertyID::Float:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().float_()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().float_()));
     case CSS::PropertyID::Clear:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().clear()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().clear()));
     case CSS::PropertyID::Cursor:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().cursor()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().cursor()));
     case CSS::PropertyID::Display:
         return style_value_for_display(layout_node.computed_values().display());
     case CSS::PropertyID::ZIndex: {
@@ -520,21 +139,21 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
         return NumericStyleValue::create_integer(maybe_z_index.release_value());
     }
     case CSS::PropertyID::TextAlign:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().text_align()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_align()));
     case CSS::PropertyID::TextDecorationLine:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().text_decoration_line()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_decoration_line()));
     case CSS::PropertyID::TextDecorationStyle:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().text_decoration_style()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_decoration_style()));
     case CSS::PropertyID::TextTransform:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().text_transform()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_transform()));
     case CSS::PropertyID::Position:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().position()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().position()));
     case CSS::PropertyID::WhiteSpace:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().white_space()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().white_space()));
     case CSS::PropertyID::FlexDirection:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().flex_direction()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_direction()));
     case CSS::PropertyID::FlexWrap:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().flex_wrap()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().flex_wrap()));
     case CSS::PropertyID::FlexBasis: {
         switch (layout_node.computed_values().flex_basis().type) {
         case FlexBasis::Content:
@@ -556,9 +175,9 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::Opacity:
         return NumericStyleValue::create_float(layout_node.computed_values().opacity());
     case CSS::PropertyID::ImageRendering:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().image_rendering()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().image_rendering()));
     case CSS::PropertyID::JustifyContent:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().justify_content()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().justify_content()));
     case CSS::PropertyID::BoxShadow: {
         auto box_shadow_layers = layout_node.computed_values().box_shadow();
         if (box_shadow_layers.is_empty())
@@ -682,45 +301,45 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     case CSS::PropertyID::BorderLeftColor:
         return ColorStyleValue::create(layout_node.computed_values().border_left().color);
     case CSS::PropertyID::BorderTopStyle:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().border_top().line_style));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_top().line_style));
     case CSS::PropertyID::BorderRightStyle:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().border_right().line_style));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_right().line_style));
     case CSS::PropertyID::BorderBottomStyle:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().border_bottom().line_style));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_bottom().line_style));
     case CSS::PropertyID::BorderLeftStyle:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().border_left().line_style));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().border_left().line_style));
     case CSS::PropertyID::BorderTop: {
         auto border = layout_node.computed_values().border_top();
         auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_css_value_id(border.line_style));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
         auto color = ColorStyleValue::create(border.color);
         return BorderStyleValue::create(width, style, color);
     }
     case CSS::PropertyID::BorderRight: {
         auto border = layout_node.computed_values().border_right();
         auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_css_value_id(border.line_style));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
         auto color = ColorStyleValue::create(border.color);
         return BorderStyleValue::create(width, style, color);
     }
     case CSS::PropertyID::BorderBottom: {
         auto border = layout_node.computed_values().border_bottom();
         auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_css_value_id(border.line_style));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
         auto color = ColorStyleValue::create(border.color);
         return BorderStyleValue::create(width, style, color);
     }
     case CSS::PropertyID::BorderLeft: {
         auto border = layout_node.computed_values().border_left();
         auto width = LengthStyleValue::create(Length::make_px(border.width));
-        auto style = IdentifierStyleValue::create(to_css_value_id(border.line_style));
+        auto style = IdentifierStyleValue::create(to_value_id(border.line_style));
         auto color = ColorStyleValue::create(border.color);
         return BorderStyleValue::create(width, style, color);
     }
     case CSS::PropertyID::OverflowX:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().overflow_x()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_x()));
     case CSS::PropertyID::OverflowY:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().overflow_y()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().overflow_y()));
     case CSS::PropertyID::Color:
         return ColorStyleValue::create(layout_node.computed_values().color());
     case PropertyID::BackgroundColor:
@@ -753,11 +372,11 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
                 return PercentageStyleValue::create(length_percentage->percentage());
             VERIFY_NOT_REACHED();
         }
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().vertical_align().get<CSS::VerticalAlign>()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().vertical_align().get<CSS::VerticalAlign>()));
     case CSS::PropertyID::ListStyleType:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().list_style_type()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().list_style_type()));
     case CSS::PropertyID::BoxSizing:
-        return IdentifierStyleValue::create(to_css_value_id(layout_node.computed_values().box_sizing()));
+        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().box_sizing()));
     case CSS::PropertyID::Invalid:
         return IdentifierStyleValue::create(CSS::ValueID::Invalid);
     case CSS::PropertyID::Custom:

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -400,12 +400,10 @@ Optional<StyleProperty> ResolvedCSSStyleDeclaration::property(PropertyID propert
 
     if (!m_element->layout_node()) {
         auto style = m_element->document().style_computer().compute_style(const_cast<DOM::Element&>(*m_element));
-        if (auto maybe_property = style->property(property_id); maybe_property.has_value()) {
-            return StyleProperty {
-                .property_id = property_id,
-                .value = maybe_property.release_value(),
-            };
-        }
+        return StyleProperty {
+            .property_id = property_id,
+            .value = style->property(property_id),
+        };
         return {};
     }
 

--- a/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleComputer.cpp
@@ -772,7 +772,7 @@ static NonnullRefPtr<StyleValue> get_inherit_value(CSS::PropertyID property_id, 
 
     if (!parent_element || !parent_element->computed_css_values())
         return property_initial_value(property_id);
-    return parent_element->computed_css_values()->property(property_id).release_value();
+    return parent_element->computed_css_values()->property(property_id);
 };
 
 void StyleComputer::compute_defaulted_property_value(StyleProperties& style, DOM::Element const* element, CSS::PropertyID property_id, Optional<CSS::Selector::PseudoElement> pseudo_element) const
@@ -835,11 +835,9 @@ float StyleComputer::root_element_font_size() const
     if (!computed_root_style)
         return default_root_element_font_size;
 
-    auto maybe_root_value = computed_root_style->property(CSS::PropertyID::FontSize);
-    if (!maybe_root_value.has_value())
-        return default_root_element_font_size;
+    auto root_value = computed_root_style->property(CSS::PropertyID::FontSize);
 
-    return maybe_root_value.value()->to_length().to_px(viewport_rect(), computed_root_style->computed_font().pixel_metrics(), default_root_element_font_size, default_root_element_font_size);
+    return root_value->to_length().to_px(viewport_rect(), computed_root_style->computed_font().pixel_metrics(), default_root_element_font_size, default_root_element_font_size);
 }
 
 void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* element, Optional<CSS::Selector::PseudoElement> pseudo_element) const
@@ -853,9 +851,9 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
 
     auto* parent_element = get_parent_element(element, pseudo_element);
 
-    auto font_size = style.property(CSS::PropertyID::FontSize).value();
-    auto font_style = style.property(CSS::PropertyID::FontStyle).value();
-    auto font_weight = style.property(CSS::PropertyID::FontWeight).value();
+    auto font_size = style.property(CSS::PropertyID::FontSize);
+    auto font_style = style.property(CSS::PropertyID::FontStyle);
+    auto font_weight = style.property(CSS::PropertyID::FontWeight);
 
     int weight = Gfx::FontWeight::Regular;
     if (font_weight->is_identifier()) {
@@ -930,7 +928,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
         auto parent_font_size = [&]() -> float {
             if (!parent_element || !parent_element->computed_css_values())
                 return font_size_in_px;
-            auto value = parent_element->computed_css_values()->property(CSS::PropertyID::FontSize).value();
+            auto value = parent_element->computed_css_values()->property(CSS::PropertyID::FontSize);
             if (value->is_length()) {
                 auto length = static_cast<LengthStyleValue const&>(*value).to_length();
                 if (length.is_absolute() || length.is_relative())
@@ -1028,7 +1026,7 @@ void StyleComputer::compute_font(StyleProperties& style, DOM::Element const* ele
 
     RefPtr<Gfx::Font> found_font;
 
-    auto family_value = style.property(PropertyID::FontFamily).value();
+    auto family_value = style.property(PropertyID::FontFamily);
     if (family_value->is_value_list()) {
         auto const& family_list = static_cast<StyleValueList const&>(*family_value).values();
         for (auto const& family : family_list) {
@@ -1068,7 +1066,7 @@ void StyleComputer::absolutize_values(StyleProperties& style, DOM::Element const
 {
     auto font_metrics = style.computed_font().pixel_metrics();
     float root_font_size = root_element_font_size();
-    float font_size = style.property(CSS::PropertyID::FontSize).value()->to_length().to_px(viewport_rect(), font_metrics, root_font_size, root_font_size);
+    float font_size = style.property(CSS::PropertyID::FontSize)->to_length().to_px(viewport_rect(), font_metrics, root_font_size, root_font_size);
 
     for (size_t i = 0; i < style.m_property_values.size(); ++i) {
         auto& value_slot = style.m_property_values[i];

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -194,18 +194,7 @@ Optional<CSS::FlexDirection> StyleProperties::flex_direction() const
     auto value = property(CSS::PropertyID::FlexDirection);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Row:
-        return CSS::FlexDirection::Row;
-    case CSS::ValueID::RowReverse:
-        return CSS::FlexDirection::RowReverse;
-    case CSS::ValueID::Column:
-        return CSS::FlexDirection::Column;
-    case CSS::ValueID::ColumnReverse:
-        return CSS::FlexDirection::ColumnReverse;
-    default:
-        return {};
-    }
+    return value_id_to_flex_direction(value.value()->to_identifier());
 }
 
 Optional<CSS::FlexWrap> StyleProperties::flex_wrap() const
@@ -213,16 +202,7 @@ Optional<CSS::FlexWrap> StyleProperties::flex_wrap() const
     auto value = property(CSS::PropertyID::FlexWrap);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Wrap:
-        return CSS::FlexWrap::Wrap;
-    case CSS::ValueID::Nowrap:
-        return CSS::FlexWrap::Nowrap;
-    case CSS::ValueID::WrapReverse:
-        return CSS::FlexWrap::WrapReverse;
-    default:
-        return {};
-    }
+    return value_id_to_flex_wrap(value.value()->to_identifier());
 }
 
 Optional<CSS::FlexBasisData> StyleProperties::flex_basis() const
@@ -276,20 +256,7 @@ Optional<CSS::ImageRendering> StyleProperties::image_rendering() const
     auto value = property(CSS::PropertyID::ImageRendering);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Auto:
-        return CSS::ImageRendering::Auto;
-    case CSS::ValueID::CrispEdges:
-        return CSS::ImageRendering::CrispEdges;
-    case CSS::ValueID::HighQuality:
-        return CSS::ImageRendering::HighQuality;
-    case CSS::ValueID::Pixelated:
-        return CSS::ImageRendering::Pixelated;
-    case CSS::ValueID::Smooth:
-        return CSS::ImageRendering::Smooth;
-    default:
-        return {};
-    }
+    return value_id_to_image_rendering(value.value()->to_identifier());
 }
 
 Optional<CSS::JustifyContent> StyleProperties::justify_content() const
@@ -297,20 +264,7 @@ Optional<CSS::JustifyContent> StyleProperties::justify_content() const
     auto value = property(CSS::PropertyID::JustifyContent);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::FlexStart:
-        return CSS::JustifyContent::FlexStart;
-    case CSS::ValueID::FlexEnd:
-        return CSS::JustifyContent::FlexEnd;
-    case CSS::ValueID::Center:
-        return CSS::JustifyContent::Center;
-    case CSS::ValueID::SpaceBetween:
-        return CSS::JustifyContent::SpaceBetween;
-    case CSS::ValueID::SpaceAround:
-        return CSS::JustifyContent::SpaceAround;
-    default:
-        return {};
-    }
+    return value_id_to_justify_content(value.value()->to_identifier());
 }
 
 Vector<CSS::Transformation> StyleProperties::transformations() const
@@ -383,20 +337,7 @@ Optional<CSS::AlignItems> StyleProperties::align_items() const
     auto value = property(CSS::PropertyID::AlignItems);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::FlexStart:
-        return CSS::AlignItems::FlexStart;
-    case CSS::ValueID::FlexEnd:
-        return CSS::AlignItems::FlexEnd;
-    case CSS::ValueID::Center:
-        return CSS::AlignItems::Center;
-    case CSS::ValueID::Baseline:
-        return CSS::AlignItems::Baseline;
-    case CSS::ValueID::Stretch:
-        return CSS::AlignItems::Stretch;
-    default:
-        return {};
-    }
+    return value_id_to_align_items(value.value()->to_identifier());
 }
 
 Optional<CSS::Position> StyleProperties::position() const
@@ -404,20 +345,7 @@ Optional<CSS::Position> StyleProperties::position() const
     auto value = property(CSS::PropertyID::Position);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Static:
-        return CSS::Position::Static;
-    case CSS::ValueID::Relative:
-        return CSS::Position::Relative;
-    case CSS::ValueID::Absolute:
-        return CSS::Position::Absolute;
-    case CSS::ValueID::Fixed:
-        return CSS::Position::Fixed;
-    case CSS::ValueID::Sticky:
-        return CSS::Position::Sticky;
-    default:
-        return {};
-    }
+    return value_id_to_position(value.value()->to_identifier());
 }
 
 bool StyleProperties::operator==(StyleProperties const& other) const
@@ -451,20 +379,7 @@ Optional<CSS::TextAlign> StyleProperties::text_align() const
     auto value = property(CSS::PropertyID::TextAlign);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Left:
-        return CSS::TextAlign::Left;
-    case CSS::ValueID::Center:
-        return CSS::TextAlign::Center;
-    case CSS::ValueID::Right:
-        return CSS::TextAlign::Right;
-    case CSS::ValueID::Justify:
-        return CSS::TextAlign::Justify;
-    case CSS::ValueID::LibwebCenter:
-        return CSS::TextAlign::LibwebCenter;
-    default:
-        return {};
-    }
+    return value_id_to_text_align(value.value()->to_identifier());
 }
 
 Optional<CSS::TextJustify> StyleProperties::text_justify() const
@@ -472,19 +387,7 @@ Optional<CSS::TextJustify> StyleProperties::text_justify() const
     auto value = property(CSS::PropertyID::TextJustify);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Auto:
-        return CSS::TextJustify::Auto;
-    case CSS::ValueID::None:
-        return CSS::TextJustify::None;
-    case CSS::ValueID::InterWord:
-        return CSS::TextJustify::InterWord;
-    case CSS::ValueID::Distribute:
-    case CSS::ValueID::InterCharacter:
-        return CSS::TextJustify::InterCharacter;
-    default:
-        return {};
-    }
+    return value_id_to_text_justify(value.value()->to_identifier());
 }
 
 Optional<CSS::PointerEvents> StyleProperties::pointer_events() const
@@ -492,17 +395,7 @@ Optional<CSS::PointerEvents> StyleProperties::pointer_events() const
     auto value = property(CSS::PropertyID::PointerEvents);
     if (!value.has_value())
         return {};
-
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Auto:
-        return CSS::PointerEvents::Auto;
-    case CSS::ValueID::All:
-        return CSS::PointerEvents::All;
-    case CSS::ValueID::None:
-        return CSS::PointerEvents::None;
-    default:
-        return {};
-    }
+    return value_id_to_pointer_events(value.value()->to_identifier());
 }
 
 Optional<CSS::WhiteSpace> StyleProperties::white_space() const
@@ -510,20 +403,7 @@ Optional<CSS::WhiteSpace> StyleProperties::white_space() const
     auto value = property(CSS::PropertyID::WhiteSpace);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Normal:
-        return CSS::WhiteSpace::Normal;
-    case CSS::ValueID::Nowrap:
-        return CSS::WhiteSpace::Nowrap;
-    case CSS::ValueID::Pre:
-        return CSS::WhiteSpace::Pre;
-    case CSS::ValueID::PreLine:
-        return CSS::WhiteSpace::PreLine;
-    case CSS::ValueID::PreWrap:
-        return CSS::WhiteSpace::PreWrap;
-    default:
-        return {};
-    }
+    return value_id_to_white_space(value.value()->to_identifier());
 }
 
 Optional<CSS::LineStyle> StyleProperties::line_style(CSS::PropertyID property_id) const
@@ -531,30 +411,7 @@ Optional<CSS::LineStyle> StyleProperties::line_style(CSS::PropertyID property_id
     auto value = property(property_id);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::None:
-        return CSS::LineStyle::None;
-    case CSS::ValueID::Hidden:
-        return CSS::LineStyle::Hidden;
-    case CSS::ValueID::Dotted:
-        return CSS::LineStyle::Dotted;
-    case CSS::ValueID::Dashed:
-        return CSS::LineStyle::Dashed;
-    case CSS::ValueID::Solid:
-        return CSS::LineStyle::Solid;
-    case CSS::ValueID::Double:
-        return CSS::LineStyle::Double;
-    case CSS::ValueID::Groove:
-        return CSS::LineStyle::Groove;
-    case CSS::ValueID::Ridge:
-        return CSS::LineStyle::Ridge;
-    case CSS::ValueID::Inset:
-        return CSS::LineStyle::Inset;
-    case CSS::ValueID::Outset:
-        return CSS::LineStyle::Outset;
-    default:
-        return {};
-    }
+    return value_id_to_line_style(value.value()->to_identifier());
 }
 
 Optional<CSS::Float> StyleProperties::float_() const
@@ -562,16 +419,7 @@ Optional<CSS::Float> StyleProperties::float_() const
     auto value = property(CSS::PropertyID::Float);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::None:
-        return CSS::Float::None;
-    case CSS::ValueID::Left:
-        return CSS::Float::Left;
-    case CSS::ValueID::Right:
-        return CSS::Float::Right;
-    default:
-        return {};
-    }
+    return value_id_to_float(value.value()->to_identifier());
 }
 
 Optional<CSS::Clear> StyleProperties::clear() const
@@ -579,18 +427,7 @@ Optional<CSS::Clear> StyleProperties::clear() const
     auto value = property(CSS::PropertyID::Clear);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::None:
-        return CSS::Clear::None;
-    case CSS::ValueID::Left:
-        return CSS::Clear::Left;
-    case CSS::ValueID::Right:
-        return CSS::Clear::Right;
-    case CSS::ValueID::Both:
-        return CSS::Clear::Both;
-    default:
-        return {};
-    }
+    return value_id_to_clear(value.value()->to_identifier());
 }
 
 CSS::ContentData StyleProperties::content() const
@@ -651,82 +488,7 @@ Optional<CSS::Cursor> StyleProperties::cursor() const
     auto value = property(CSS::PropertyID::Cursor);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Auto:
-        return CSS::Cursor::Auto;
-    case CSS::ValueID::Default:
-        return CSS::Cursor::Default;
-    case CSS::ValueID::None:
-        return CSS::Cursor::None;
-    case CSS::ValueID::ContextMenu:
-        return CSS::Cursor::ContextMenu;
-    case CSS::ValueID::Help:
-        return CSS::Cursor::Help;
-    case CSS::ValueID::Pointer:
-        return CSS::Cursor::Pointer;
-    case CSS::ValueID::Progress:
-        return CSS::Cursor::Progress;
-    case CSS::ValueID::Wait:
-        return CSS::Cursor::Wait;
-    case CSS::ValueID::Cell:
-        return CSS::Cursor::Cell;
-    case CSS::ValueID::Crosshair:
-        return CSS::Cursor::Crosshair;
-    case CSS::ValueID::Text:
-        return CSS::Cursor::Text;
-    case CSS::ValueID::VerticalText:
-        return CSS::Cursor::VerticalText;
-    case CSS::ValueID::Alias:
-        return CSS::Cursor::Alias;
-    case CSS::ValueID::Copy:
-        return CSS::Cursor::Copy;
-    case CSS::ValueID::Move:
-        return CSS::Cursor::Move;
-    case CSS::ValueID::NoDrop:
-        return CSS::Cursor::NoDrop;
-    case CSS::ValueID::NotAllowed:
-        return CSS::Cursor::NotAllowed;
-    case CSS::ValueID::Grab:
-        return CSS::Cursor::Grab;
-    case CSS::ValueID::Grabbing:
-        return CSS::Cursor::Grabbing;
-    case CSS::ValueID::EResize:
-        return CSS::Cursor::EResize;
-    case CSS::ValueID::NResize:
-        return CSS::Cursor::NResize;
-    case CSS::ValueID::NeResize:
-        return CSS::Cursor::NeResize;
-    case CSS::ValueID::NwResize:
-        return CSS::Cursor::NwResize;
-    case CSS::ValueID::SResize:
-        return CSS::Cursor::SResize;
-    case CSS::ValueID::SeResize:
-        return CSS::Cursor::SeResize;
-    case CSS::ValueID::SwResize:
-        return CSS::Cursor::SwResize;
-    case CSS::ValueID::WResize:
-        return CSS::Cursor::WResize;
-    case CSS::ValueID::EwResize:
-        return CSS::Cursor::EwResize;
-    case CSS::ValueID::NsResize:
-        return CSS::Cursor::NsResize;
-    case CSS::ValueID::NeswResize:
-        return CSS::Cursor::NeswResize;
-    case CSS::ValueID::NwseResize:
-        return CSS::Cursor::NwseResize;
-    case CSS::ValueID::ColResize:
-        return CSS::Cursor::ColResize;
-    case CSS::ValueID::RowResize:
-        return CSS::Cursor::RowResize;
-    case CSS::ValueID::AllScroll:
-        return CSS::Cursor::AllScroll;
-    case CSS::ValueID::ZoomIn:
-        return CSS::Cursor::ZoomIn;
-    case CSS::ValueID::ZoomOut:
-        return CSS::Cursor::ZoomOut;
-    default:
-        return {};
-    }
+    return value_id_to_cursor(value.value()->to_identifier());
 }
 
 Optional<CSS::Visibility> StyleProperties::visibility() const
@@ -734,16 +496,7 @@ Optional<CSS::Visibility> StyleProperties::visibility() const
     auto value = property(CSS::PropertyID::Visibility);
     if (!value.has_value() || !value.value()->is_identifier())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Visible:
-        return CSS::Visibility::Visible;
-    case CSS::ValueID::Hidden:
-        return CSS::Visibility::Hidden;
-    case CSS::ValueID::Collapse:
-        return CSS::Visibility::Collapse;
-    default:
-        return {};
-    }
+    return value_id_to_visibility(value.value()->to_identifier());
 }
 
 CSS::Display StyleProperties::display() const
@@ -794,20 +547,7 @@ Optional<CSS::TextDecorationLine> StyleProperties::text_decoration_line() const
     auto value = property(CSS::PropertyID::TextDecorationLine);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::None:
-        return CSS::TextDecorationLine::None;
-    case CSS::ValueID::Underline:
-        return CSS::TextDecorationLine::Underline;
-    case CSS::ValueID::Overline:
-        return CSS::TextDecorationLine::Overline;
-    case CSS::ValueID::LineThrough:
-        return CSS::TextDecorationLine::LineThrough;
-    case CSS::ValueID::Blink:
-        return CSS::TextDecorationLine::Blink;
-    default:
-        return {};
-    }
+    return value_id_to_text_decoration_line(value.value()->to_identifier());
 }
 
 Optional<CSS::TextDecorationStyle> StyleProperties::text_decoration_style() const
@@ -815,20 +555,7 @@ Optional<CSS::TextDecorationStyle> StyleProperties::text_decoration_style() cons
     auto value = property(CSS::PropertyID::TextDecorationStyle);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Solid:
-        return CSS::TextDecorationStyle::Solid;
-    case CSS::ValueID::Double:
-        return CSS::TextDecorationStyle::Double;
-    case CSS::ValueID::Dotted:
-        return CSS::TextDecorationStyle::Dotted;
-    case CSS::ValueID::Dashed:
-        return CSS::TextDecorationStyle::Dashed;
-    case CSS::ValueID::Wavy:
-        return CSS::TextDecorationStyle::Wavy;
-    default:
-        return {};
-    }
+    return value_id_to_text_decoration_style(value.value()->to_identifier());
 }
 
 Optional<CSS::TextTransform> StyleProperties::text_transform() const
@@ -836,22 +563,7 @@ Optional<CSS::TextTransform> StyleProperties::text_transform() const
     auto value = property(CSS::PropertyID::TextTransform);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::None:
-        return CSS::TextTransform::None;
-    case CSS::ValueID::Lowercase:
-        return CSS::TextTransform::Lowercase;
-    case CSS::ValueID::Uppercase:
-        return CSS::TextTransform::Uppercase;
-    case CSS::ValueID::Capitalize:
-        return CSS::TextTransform::Capitalize;
-    case CSS::ValueID::FullWidth:
-        return CSS::TextTransform::FullWidth;
-    case CSS::ValueID::FullSizeKana:
-        return CSS::TextTransform::FullSizeKana;
-    default:
-        return {};
-    }
+    return value_id_to_text_transform(value.value()->to_identifier());
 }
 
 Optional<CSS::ListStyleType> StyleProperties::list_style_type() const
@@ -859,34 +571,7 @@ Optional<CSS::ListStyleType> StyleProperties::list_style_type() const
     auto value = property(CSS::PropertyID::ListStyleType);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::None:
-        return CSS::ListStyleType::None;
-    case CSS::ValueID::Disc:
-        return CSS::ListStyleType::Disc;
-    case CSS::ValueID::Circle:
-        return CSS::ListStyleType::Circle;
-    case CSS::ValueID::Square:
-        return CSS::ListStyleType::Square;
-    case CSS::ValueID::Decimal:
-        return CSS::ListStyleType::Decimal;
-    case CSS::ValueID::DecimalLeadingZero:
-        return CSS::ListStyleType::DecimalLeadingZero;
-    case CSS::ValueID::LowerAlpha:
-        return CSS::ListStyleType::LowerAlpha;
-    case CSS::ValueID::LowerLatin:
-        return CSS::ListStyleType::LowerLatin;
-    case CSS::ValueID::UpperAlpha:
-        return CSS::ListStyleType::UpperAlpha;
-    case CSS::ValueID::UpperLatin:
-        return CSS::ListStyleType::UpperLatin;
-    case CSS::ValueID::UpperRoman:
-        return CSS::ListStyleType::UpperRoman;
-    case CSS::ValueID::LowerRoman:
-        return CSS::ListStyleType::LowerRoman;
-    default:
-        return {};
-    }
+    return value_id_to_list_style_type(value.value()->to_identifier());
 }
 
 Optional<CSS::Overflow> StyleProperties::overflow_x() const
@@ -904,20 +589,7 @@ Optional<CSS::Overflow> StyleProperties::overflow(CSS::PropertyID property_id) c
     auto value = property(property_id);
     if (!value.has_value())
         return {};
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Auto:
-        return CSS::Overflow::Auto;
-    case CSS::ValueID::Visible:
-        return CSS::Overflow::Visible;
-    case CSS::ValueID::Hidden:
-        return CSS::Overflow::Hidden;
-    case CSS::ValueID::Clip:
-        return CSS::Overflow::Clip;
-    case CSS::ValueID::Scroll:
-        return CSS::Overflow::Scroll;
-    default:
-        return {};
-    }
+    return value_id_to_overflow(value.value()->to_identifier());
 }
 
 Vector<ShadowData> StyleProperties::shadow(PropertyID property_id) const
@@ -966,15 +638,7 @@ Optional<CSS::BoxSizing> StyleProperties::box_sizing() const
     auto value = property(CSS::PropertyID::BoxSizing);
     if (!value.has_value())
         return {};
-
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::BorderBox:
-        return CSS::BoxSizing::BorderBox;
-    case CSS::ValueID::ContentBox:
-        return CSS::BoxSizing::ContentBox;
-    default:
-        return {};
-    }
+    return value_id_to_box_sizing(value.value()->to_identifier());
 }
 
 Variant<CSS::VerticalAlign, CSS::LengthPercentage> StyleProperties::vertical_align() const
@@ -983,28 +647,8 @@ Variant<CSS::VerticalAlign, CSS::LengthPercentage> StyleProperties::vertical_ali
     if (!value.has_value())
         VERIFY_NOT_REACHED();
 
-    if (value.value()->is_identifier()) {
-        switch (value.value()->to_identifier()) {
-        case CSS::ValueID::Baseline:
-            return CSS::VerticalAlign::Baseline;
-        case CSS::ValueID::Bottom:
-            return CSS::VerticalAlign::Bottom;
-        case CSS::ValueID::Middle:
-            return CSS::VerticalAlign::Middle;
-        case CSS::ValueID::Sub:
-            return CSS::VerticalAlign::Sub;
-        case CSS::ValueID::Super:
-            return CSS::VerticalAlign::Super;
-        case CSS::ValueID::TextBottom:
-            return CSS::VerticalAlign::TextBottom;
-        case CSS::ValueID::TextTop:
-            return CSS::VerticalAlign::TextTop;
-        case CSS::ValueID::Top:
-            return CSS::VerticalAlign::Top;
-        default:
-            VERIFY_NOT_REACHED();
-        }
-    }
+    if (value.value()->is_identifier())
+        return value_id_to_vertical_align(value.value()->to_identifier()).release_value();
 
     if (value.value()->is_length())
         return CSS::LengthPercentage(value.value()->to_length());
@@ -1020,15 +664,7 @@ Optional<CSS::FontVariant> StyleProperties::font_variant() const
     auto value = property(CSS::PropertyID::FontVariant);
     if (!value.has_value())
         return {};
-
-    switch (value.value()->to_identifier()) {
-    case CSS::ValueID::Normal:
-        return CSS::FontVariant::Normal;
-    case CSS::ValueID::SmallCaps:
-        return CSS::FontVariant::SmallCaps;
-    default:
-        return {};
-    }
+    return value_id_to_font_variant(value.value()->to_identifier());
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -961,7 +961,7 @@ Vector<ShadowData> StyleProperties::text_shadow() const
     return shadow(PropertyID::TextShadow);
 }
 
-CSS::BoxSizing StyleProperties::box_sizing() const
+Optional<CSS::BoxSizing> StyleProperties::box_sizing() const
 {
     auto value = property(CSS::PropertyID::BoxSizing);
     if (!value.has_value())

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -74,7 +74,7 @@ public:
     Optional<CSS::Overflow> overflow_x() const;
     Optional<CSS::Overflow> overflow_y() const;
     Vector<CSS::ShadowData> box_shadow() const;
-    CSS::BoxSizing box_sizing() const;
+    Optional<CSS::BoxSizing> box_sizing() const;
     Optional<CSS::PointerEvents> pointer_events() const;
     Variant<CSS::VerticalAlign, CSS::LengthPercentage> vertical_align() const;
     Optional<CSS::FontVariant> font_variant() const;

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -39,7 +39,7 @@ public:
     auto const& properties() const { return m_property_values; }
 
     void set_property(CSS::PropertyID, NonnullRefPtr<StyleValue> value);
-    Optional<NonnullRefPtr<StyleValue>> property(CSS::PropertyID) const;
+    NonnullRefPtr<StyleValue> property(CSS::PropertyID) const;
 
     Length length_or_fallback(CSS::PropertyID, Length const& fallback) const;
     LengthPercentage length_percentage_or_fallback(CSS::PropertyID, LengthPercentage const& fallback) const;

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -25,6 +25,7 @@
 #include <LibGfx/Painter.h>
 #include <LibWeb/CSS/Angle.h>
 #include <LibWeb/CSS/Display.h>
+#include <LibWeb/CSS/Enums.h>
 #include <LibWeb/CSS/Frequency.h>
 #include <LibWeb/CSS/Length.h>
 #include <LibWeb/CSS/Number.h>
@@ -39,35 +40,10 @@
 
 namespace Web::CSS {
 
-enum class AlignItems {
-    FlexStart,
-    FlexEnd,
-    Center,
-    Baseline,
-    Stretch,
-};
-
-enum class BackgroundAttachment {
-    Fixed,
-    Local,
-    Scroll,
-};
-
-enum class BackgroundBox {
-    BorderBox,
-    ContentBox,
-    PaddingBox,
-};
-
 enum class BackgroundSize {
     Contain,
     Cover,
     LengthPercentage,
-};
-
-enum class BoxSizing {
-    BorderBox,
-    ContentBox,
 };
 
 enum class ShadowPlacement {
@@ -75,88 +51,10 @@ enum class ShadowPlacement {
     Inner,
 };
 
-enum class Clear {
-    None,
-    Left,
-    Right,
-    Both,
-};
-
-enum class Cursor {
-    Auto,
-    Default,
-    None,
-    ContextMenu,
-    Help,
-    Pointer,
-    Progress,
-    Wait,
-    Cell,
-    Crosshair,
-    Text,
-    VerticalText,
-    Alias,
-    Copy,
-    Move,
-    NoDrop,
-    NotAllowed,
-    Grab,
-    Grabbing,
-    EResize,
-    NResize,
-    NeResize,
-    NwResize,
-    SResize,
-    SeResize,
-    SwResize,
-    WResize,
-    EwResize,
-    NsResize,
-    NeswResize,
-    NwseResize,
-    ColResize,
-    RowResize,
-    AllScroll,
-    ZoomIn,
-    ZoomOut,
-};
-
 enum class FlexBasis {
     Content,
     LengthPercentage,
     Auto,
-};
-
-enum class FlexDirection {
-    Row,
-    RowReverse,
-    Column,
-    ColumnReverse,
-};
-
-enum class FlexWrap {
-    Nowrap,
-    Wrap,
-    WrapReverse
-};
-
-enum class Float {
-    None,
-    Left,
-    Right,
-};
-
-enum class FontVariant {
-    Normal,
-    SmallCaps,
-};
-
-enum class ImageRendering {
-    Auto,
-    CrispEdges,
-    HighQuality,
-    Pixelated,
-    Smooth,
 };
 
 // FIXME: Find a better place for this helper.
@@ -174,72 +72,6 @@ inline Gfx::Painter::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_val
     VERIFY_NOT_REACHED();
 }
 
-enum class JustifyContent {
-    FlexStart,
-    FlexEnd,
-    Center,
-    SpaceBetween,
-    SpaceAround,
-};
-
-enum class LineStyle {
-    None,
-    Hidden,
-    Dotted,
-    Dashed,
-    Solid,
-    Double,
-    Groove,
-    Ridge,
-    Inset,
-    Outset,
-};
-
-enum class ListStyleType {
-    None,
-    Disc,
-    Circle,
-    Square,
-    Decimal,
-    DecimalLeadingZero,
-    LowerAlpha,
-    LowerLatin,
-    LowerRoman,
-    UpperAlpha,
-    UpperLatin,
-    UpperRoman,
-};
-
-enum class Overflow : u8 {
-    Auto,
-    Clip,
-    Hidden,
-    Scroll,
-    Visible,
-};
-
-enum class Position {
-    Static,
-    Relative,
-    Absolute,
-    Fixed,
-    Sticky,
-};
-
-enum class PositionEdge {
-    Left,
-    Right,
-    Top,
-    Bottom,
-};
-
-enum class Repeat : u8 {
-    NoRepeat,
-    Repeat,
-    Round,
-    Space,
-};
-
 constexpr StringView to_string(Repeat value)
 {
     switch (value) {
@@ -256,46 +88,6 @@ constexpr StringView to_string(Repeat value)
     }
 }
 
-enum class TextAlign {
-    Left,
-    Center,
-    Right,
-    Justify,
-    LibwebCenter,
-};
-
-enum class TextDecorationLine {
-    None,
-    Underline,
-    Overline,
-    LineThrough,
-    Blink,
-};
-
-enum class TextDecorationStyle {
-    Solid,
-    Double,
-    Dotted,
-    Dashed,
-    Wavy,
-};
-
-enum class TextJustify {
-    Auto,
-    None,
-    InterWord,
-    InterCharacter,
-};
-
-enum class TextTransform {
-    None,
-    Capitalize,
-    Uppercase,
-    Lowercase,
-    FullWidth,
-    FullSizeKana,
-};
-
 enum class TransformFunction {
     Matrix,
     Translate,
@@ -308,37 +100,6 @@ enum class TransformFunction {
     Skew,
     SkewX,
     SkewY,
-};
-
-enum class VerticalAlign {
-    Baseline,
-    Bottom,
-    Middle,
-    Sub,
-    Super,
-    TextBottom,
-    TextTop,
-    Top,
-};
-
-enum class Visibility {
-    Visible,
-    Hidden,
-    Collapse,
-};
-
-enum class WhiteSpace {
-    Normal,
-    Pre,
-    Nowrap,
-    PreLine,
-    PreWrap,
-};
-
-enum class PointerEvents {
-    Auto,
-    All,
-    None
 };
 
 class StyleValue : public RefCounted<StyleValue> {

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -72,22 +72,6 @@ inline Gfx::Painter::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_val
     VERIFY_NOT_REACHED();
 }
 
-constexpr StringView to_string(Repeat value)
-{
-    switch (value) {
-    case Repeat::NoRepeat:
-        return "no-repeat"sv;
-    case Repeat::Repeat:
-        return "repeat"sv;
-    case Repeat::Round:
-        return "round"sv;
-    case Repeat::Space:
-        return "space"sv;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-}
-
 enum class TransformFunction {
     Matrix,
     Translate,

--- a/Userland/Libraries/LibWeb/HTML/HTMLBlinkElement.cpp
+++ b/Userland/Libraries/LibWeb/HTML/HTMLBlinkElement.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibCore/Timer.h>
-#include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/HTML/HTMLBlinkElement.h>
 
 namespace Web::HTML {

--- a/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
+++ b/Userland/Libraries/LibWeb/Layout/ImageBox.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <LibGfx/Font/FontDatabase.h>
-#include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/Layout/ImageBox.h>
 #include <LibWeb/Painting/ImagePaintable.h>

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -363,7 +363,8 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     }
     computed_values.set_background_color(computed_style.color_or_fallback(CSS::PropertyID::BackgroundColor, *this, CSS::InitialValues::background_color()));
 
-    computed_values.set_box_sizing(computed_style.box_sizing());
+    if (auto box_sizing = computed_style.box_sizing(); box_sizing.has_value())
+        computed_values.set_box_sizing(box_sizing.release_value());
 
     if (auto maybe_font_variant = computed_style.font_variant(); maybe_font_variant.has_value())
         computed_values.set_font_variant(maybe_font_variant.release_value());

--- a/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
+++ b/Userland/Libraries/LibWeb/Painting/BackgroundPainting.h
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <LibGfx/Forward.h>
-#include <LibWeb/CSS/StyleValue.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Painting/BorderPainting.h>
 #include <LibWeb/Painting/PaintContext.h>


### PR DESCRIPTION
It's been bothering me for a while that we have so many "ValueID to some other enum, or vice versa" functions, so let's generate them instead! And then, let's also use them for type-checking property values, so we don't have to repeat the same 10 line-style identifiers over and over in Properties.json.

As a bonus, I noticed we were returning Optional from `StyleProperties::property()`, when it's only ever called once every property has been assigned a value. (And it would be invalid to call it before then anyway.) So, we can just return the value instead.