### PR TITLE
TelnetServer: Ignore null and \n when parsing

### DIFF
--- a/Userland/Services/TelnetServer/Parser.cpp
+++ b/Userland/Services/TelnetServer/Parser.cpp
@@ -24,6 +24,10 @@ void Parser::write(StringView data)
                 if (on_data)
                     on_data("\n");
                 break;
+            case '\0':
+            case '\n':
+                // Ignore.
+                break;
             default:
                 if (on_data)
                     on_data(StringView(&ch, 1));


### PR DESCRIPTION
This fixes issues with carriage return sequences.

Before, using `<CR><NUL>` as the return sequence wouldn't work at all,
and when using `<CR><LF>` there was an extra newline after every newline.

After this patch, the behaviour should be closer to the Telnet RFC.

I tested this on Ubuntu, macOS, and Windows (PuTTY) and it works with basic commands, at least.

Fixes #11569