### PR TITLE
LibWeb: Allow multiple text-decoration-lines

### DIFF
--- a/Base/res/html/misc/text-decoration.html
+++ b/Base/res/html/misc/text-decoration.html
@@ -8,6 +8,7 @@
 .strikethrough { text-decoration: line-through dotted green; }
 .blink { text-decoration: blink; }
 .current-color { color: #8B4513; text-decoration: underline; }
+.overboard { text-decoration: double overline underline line-through magenta; }
 </style>
 </head>
 <body>
@@ -16,5 +17,6 @@
 	<p class="strikethrough">Wombling</p>
 	<p class="blink">FREE!</p>
 	<p class="current-color">This underline should match the text color</p>
+	<p class="overboard">This should have an underline, overline and line-through, all in glorious magenta.</p>
 </body>
 </html>

--- a/Userland/Libraries/LibWeb/CSS/ComputedValues.h
+++ b/Userland/Libraries/LibWeb/CSS/ComputedValues.h
@@ -121,7 +121,7 @@ public:
     Optional<int> const& z_index() const { return m_noninherited.z_index; }
     CSS::TextAlign text_align() const { return m_inherited.text_align; }
     CSS::TextJustify text_justify() const { return m_inherited.text_justify; }
-    CSS::TextDecorationLine text_decoration_line() const { return m_noninherited.text_decoration_line; }
+    Vector<CSS::TextDecorationLine> text_decoration_line() const { return m_noninherited.text_decoration_line; }
     CSS::LengthPercentage text_decoration_thickness() const { return m_noninherited.text_decoration_thickness; }
     CSS::TextDecorationStyle text_decoration_style() const { return m_noninherited.text_decoration_style; }
     Color text_decoration_color() const { return m_noninherited.text_decoration_color; }
@@ -217,7 +217,8 @@ protected:
         CSS::Clear clear { InitialValues::clear() };
         CSS::Display display { InitialValues::display() };
         Optional<int> z_index;
-        CSS::TextDecorationLine text_decoration_line { InitialValues::text_decoration_line() };
+        // FIXME: Store this as flags in a u8.
+        Vector<CSS::TextDecorationLine> text_decoration_line { InitialValues::text_decoration_line() };
         CSS::LengthPercentage text_decoration_thickness { InitialValues::text_decoration_thickness() };
         CSS::TextDecorationStyle text_decoration_style { InitialValues::text_decoration_style() };
         Color text_decoration_color { InitialValues::color() };
@@ -282,7 +283,7 @@ public:
     void set_z_index(Optional<int> value) { m_noninherited.z_index = value; }
     void set_text_align(CSS::TextAlign text_align) { m_inherited.text_align = text_align; }
     void set_text_justify(CSS::TextJustify text_justify) { m_inherited.text_justify = text_justify; }
-    void set_text_decoration_line(CSS::TextDecorationLine value) { m_noninherited.text_decoration_line = value; }
+    void set_text_decoration_line(Vector<CSS::TextDecorationLine> value) { m_noninherited.text_decoration_line = move(value); }
     void set_text_decoration_thickness(CSS::LengthPercentage value) { m_noninherited.text_decoration_thickness = value; }
     void set_text_decoration_style(CSS::TextDecorationStyle value) { m_noninherited.text_decoration_style = value; }
     void set_text_decoration_color(Color value) { m_noninherited.text_decoration_color = value; }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -319,6 +319,7 @@ private:
     RefPtr<StyleValue> parse_shadow_value(Vector<ComponentValue> const&, AllowInsetKeyword);
     RefPtr<StyleValue> parse_single_shadow_value(TokenStream<ComponentValue>&, AllowInsetKeyword);
     RefPtr<StyleValue> parse_text_decoration_value(Vector<ComponentValue> const&);
+    RefPtr<StyleValue> parse_text_decoration_line_value(TokenStream<ComponentValue>&);
     RefPtr<StyleValue> parse_transform_value(Vector<ComponentValue> const&);
     RefPtr<StyleValue> parse_transform_origin_value(Vector<ComponentValue> const&);
 

--- a/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
+++ b/Userland/Libraries/LibWeb/CSS/ResolvedCSSStyleDeclaration.cpp
@@ -140,8 +140,16 @@ RefPtr<StyleValue> ResolvedCSSStyleDeclaration::style_value_for_property(Layout:
     }
     case CSS::PropertyID::TextAlign:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_align()));
-    case CSS::PropertyID::TextDecorationLine:
-        return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_decoration_line()));
+    case CSS::PropertyID::TextDecorationLine: {
+        auto text_decoration_lines = layout_node.computed_values().text_decoration_line();
+        if (text_decoration_lines.is_empty())
+            return IdentifierStyleValue::create(ValueID::None);
+        NonnullRefPtrVector<StyleValue> style_values;
+        for (auto const& line : text_decoration_lines) {
+            style_values.append(IdentifierStyleValue::create(to_value_id(line)));
+        }
+        return StyleValueList::create(move(style_values), StyleValueList::Separator::Space);
+    }
     case CSS::PropertyID::TextDecorationStyle:
         return IdentifierStyleValue::create(to_value_id(layout_node.computed_values().text_decoration_style()));
     case CSS::PropertyID::TextTransform:

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.cpp
@@ -490,10 +490,23 @@ CSS::Display StyleProperties::display() const
     }
 }
 
-Optional<CSS::TextDecorationLine> StyleProperties::text_decoration_line() const
+Vector<CSS::TextDecorationLine> StyleProperties::text_decoration_line() const
 {
     auto value = property(CSS::PropertyID::TextDecorationLine);
-    return value_id_to_text_decoration_line(value->to_identifier());
+
+    if (value->is_value_list()) {
+        Vector<CSS::TextDecorationLine> lines;
+        auto& values = value->as_value_list().values();
+        for (auto const& item : values) {
+            lines.append(value_id_to_text_decoration_line(item.to_identifier()).value());
+        }
+        return lines;
+    }
+
+    if (value->is_identifier() && value->to_identifier() == ValueID::None)
+        return {};
+
+    VERIFY_NOT_REACHED();
 }
 
 Optional<CSS::TextDecorationStyle> StyleProperties::text_decoration_style() const

--- a/Userland/Libraries/LibWeb/CSS/StyleProperties.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleProperties.h
@@ -55,7 +55,7 @@ public:
     Optional<CSS::Cursor> cursor() const;
     Optional<CSS::WhiteSpace> white_space() const;
     Optional<CSS::LineStyle> line_style(CSS::PropertyID) const;
-    Optional<CSS::TextDecorationLine> text_decoration_line() const;
+    Vector<CSS::TextDecorationLine> text_decoration_line() const;
     Optional<CSS::TextDecorationStyle> text_decoration_style() const;
     Optional<CSS::TextTransform> text_transform() const;
     Vector<CSS::ShadowData> text_shadow() const;

--- a/Userland/Libraries/LibWeb/Layout/Node.cpp
+++ b/Userland/Libraries/LibWeb/Layout/Node.cpp
@@ -453,9 +453,7 @@ void NodeWithStyle::apply_style(const CSS::StyleProperties& computed_style)
     if (pointer_events.has_value())
         computed_values.set_pointer_events(pointer_events.value());
 
-    auto text_decoration_line = computed_style.text_decoration_line();
-    if (text_decoration_line.has_value())
-        computed_values.set_text_decoration_line(text_decoration_line.value());
+    computed_values.set_text_decoration_line(computed_style.text_decoration_line());
 
     auto text_decoration_style = computed_style.text_decoration_style();
     if (text_decoration_style.has_value())


### PR DESCRIPTION
tl;dr: Have you ever wanted to do THIS?

![image](https://user-images.githubusercontent.com/222642/163422167-9d5c5915-385e-40c4-a322-d4ed785b2e21.png)

Well, now you can!

---

The spec grammar for `text-decoration-line` is:

`none | [ underline || overline || line-through || blink ]`

Which means that it's either `none`, or any combination of the other
values. This patch makes that parse for `text-decoration-line` and
`text-decoration`, stores the results as a Vector, and adjusts
`paint_text_decoration()` to run as a loop over all the values that are
provided.

As noted, storing a Vector of values is a bit wasteful, as they could be
stored as flags in a single `u8`. But I was getting too confused trying
to do that in a nice way.