### PR TITLE
DHCPClient: Improve DHCP compatibility

### DIFF
--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "DHCPv4Client.h"
+#include <AK/Array.h>
 #include <AK/Debug.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
@@ -365,6 +366,12 @@ void DHCPv4Client::dhcp_request(DHCPv4Transaction& transaction, DHCPv4Packet con
     auto maybe_dhcp_server_ip = offer.parse_options().get<IPv4Address>(DHCPOption::ServerIdentifier);
     if (maybe_dhcp_server_ip.has_value())
         builder.add_option(DHCPOption::ServerIdentifier, sizeof(IPv4Address), &maybe_dhcp_server_ip.value());
+
+    AK::Array<DHCPOption, 2> parameter_request_list = {
+        DHCPOption::SubnetMask,
+        DHCPOption::Router,
+    };
+    builder.add_option(DHCPOption::ParameterRequestList, parameter_request_list.size(), &parameter_request_list);
 
     auto& dhcp_packet = builder.build();
 

--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, the SerenityOS developers.
+ * Copyright (c) 2020-2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -361,6 +361,11 @@ void DHCPv4Client::dhcp_request(DHCPv4Transaction& transaction, DHCPv4Packet con
     // set packet options
     builder.set_message_type(DHCPMessageType::DHCPRequest);
     builder.add_option(DHCPOption::RequestedIPAddress, sizeof(IPv4Address), &offer.yiaddr());
+
+    auto maybe_dhcp_server_ip = offer.parse_options().get<IPv4Address>(DHCPOption::ServerIdentifier);
+    if (maybe_dhcp_server_ip.has_value())
+        builder.add_option(DHCPOption::ServerIdentifier, sizeof(IPv4Address), &maybe_dhcp_server_ip.value());
+
     auto& dhcp_packet = builder.build();
 
     // broadcast the "request" request


### PR DESCRIPTION
Some DHCP servers (including Mikrotik ones) will NAK the DHCP request if the ServerIdentifier option is not sent with the DHCPRequest packet.

A ParameterRequestList of `Router` and `SubnetMask` is also explicitly sent with the Request packet to ensure better compatibility.