### PR TITLE
Kernel/USB: Implement more advanced descriptor fetching

### DIFF
--- a/Kernel/Bus/USB/USBConfiguration.cpp
+++ b/Kernel/Bus/USB/USBConfiguration.cpp
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022, Jesse Buhagiar <jesse.buhagiar@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/FixedArray.h>
+#include <Kernel/Bus/USB/USBClasses.h>
+#include <Kernel/Bus/USB/USBConfiguration.h>
+#include <Kernel/Bus/USB/USBInterface.h>
+#include <Kernel/Bus/USB/USBRequest.h>
+
+namespace Kernel::USB {
+
+ErrorOr<void> USBConfiguration::get_interfaces()
+{
+    auto descriptor_hierarchy_buffer = TRY(FixedArray<u8>::try_create(m_descriptor.total_length)); // Buffer for us to store the entire hierarchy into
+
+    // The USB spec is a little bit janky here... Interface and Endpoint descriptors aren't fetched
+    // through a `GET_DESCRIPTOR` request to the device. Instead, the _entire_ hierarchy is returned
+    // to us in one go.
+    auto transfer_length = TRY(m_device.control_transfer(USB_REQUEST_TRANSFER_DIRECTION_DEVICE_TO_HOST, USB_REQUEST_GET_DESCRIPTOR, (DESCRIPTOR_TYPE_CONFIGURATION << 8), 0, m_descriptor.total_length, descriptor_hierarchy_buffer.data()));
+
+    // FIXME: Why does transfer length return the actual size +8 bytes?
+    if (transfer_length < m_descriptor.total_length)
+        return EIO;
+
+    u8* interface_descriptors_base = descriptor_hierarchy_buffer.data() + sizeof(USBConfigurationDescriptor);
+    USBInterfaceDescriptor* interface_descriptor = reinterpret_cast<USBInterfaceDescriptor*>(interface_descriptors_base);
+    Vector<USBEndpointDescriptor> endpoint_descriptors;
+    for (auto interface = 0u; interface < m_descriptor.number_of_interfaces; interface++) {
+        endpoint_descriptors.ensure_capacity(interface_descriptor->number_of_endpoints);
+
+        if constexpr (USB_DEBUG) {
+            dbgln("Interface Descriptor {}", interface);
+            dbgln("interface_id: {:02x}", interface_descriptor->interface_id);
+            dbgln("alternate_setting: {:02x}", interface_descriptor->alternate_setting);
+            dbgln("number_of_endpoints: {:02x}", interface_descriptor->number_of_endpoints);
+            dbgln("interface_class_code: {:02x}", interface_descriptor->interface_class_code);
+            dbgln("interface_sub_class_code: {:02x}", interface_descriptor->interface_sub_class_code);
+            dbgln("interface_protocol: {:02x}", interface_descriptor->interface_protocol);
+            dbgln("interface_string_descriptor_index: {}", interface_descriptor->interface_string_descriptor_index);
+        }
+
+        // Get all the endpoint descriptors
+        for (auto endpoint = 0u; endpoint < interface_descriptor->number_of_endpoints; endpoint++) {
+            u8* raw_endpoint_descriptor_offset = interface_descriptors_base + sizeof(USBInterfaceDescriptor) + (endpoint * sizeof(USBEndpointDescriptor));
+
+            // FIXME: It looks like HID descriptors come BEFORE the endpoint descriptors for a HID device, so we should load
+            // these too eventually.
+            // See here: https://www.usb.org/defined-class-codes
+            if (interface_descriptor->interface_class_code == USB_CLASS_HID)
+                raw_endpoint_descriptor_offset += sizeof(USBHIDDescriptor); // Skip the HID descriptor (this was worked out via buffer inspection)
+
+            USBEndpointDescriptor endpoint_descriptor;
+            memcpy(&endpoint_descriptor, raw_endpoint_descriptor_offset, sizeof(USBEndpointDescriptor));
+
+            if constexpr (USB_DEBUG) {
+                dbgln("Endpoint Descriptor {}", endpoint);
+                dbgln("Endpoint Address: {}", endpoint_descriptor.endpoint_address);
+                dbgln("Endpoint Attribute Bitmap: {:08b}", endpoint_descriptor.endpoint_attributes_bitmap);
+                dbgln("Endpoint Maximum Packet Size: {}", endpoint_descriptor.max_packet_size);
+                dbgln("Endpoint Poll Interval (in frames): {}", endpoint_descriptor.poll_interval_in_frames);
+            }
+
+            endpoint_descriptors.append(endpoint_descriptor);
+        }
+
+        USBInterface device_interface(*this, *interface_descriptor, endpoint_descriptors);
+        m_interfaces.append(device_interface);
+        interface_descriptor += interface_descriptor->number_of_endpoints * sizeof(USBEndpointDescriptor);
+    }
+
+    return {};
+}
+
+}

--- a/Kernel/Bus/USB/USBConfiguration.h
+++ b/Kernel/Bus/USB/USBConfiguration.h
@@ -9,6 +9,7 @@
 #include <AK/Vector.h>
 #include <Kernel/Bus/USB/USBDescriptors.h>
 #include <Kernel/Bus/USB/USBDevice.h>
+#include <Kernel/Bus/USB/USBInterface.h>
 
 namespace Kernel::USB {
 
@@ -17,22 +18,27 @@ class Device;
 class USBConfiguration {
 public:
     USBConfiguration() = delete;
-    USBConfiguration(Device& device, USBConfigurationDescriptor const configuration_descriptor)
+    USBConfiguration(Device& device, USBConfigurationDescriptor const descriptor)
         : m_device(device)
-        , m_descriptor(configuration_descriptor)
+        , m_descriptor(descriptor)
     {
+        m_interfaces.ensure_capacity(descriptor.number_of_interfaces);
     }
 
     Device const& device() const { return m_device; }
+    USBConfigurationDescriptor const& descriptor() const { return m_descriptor; }
 
     u8 interface_count() const { return m_descriptor.number_of_interfaces; }
     u8 configuration_id() const { return m_descriptor.configuration_value; }
     u8 attributes() const { return m_descriptor.attributes_bitmap; }
     u16 max_power_ma() const { return m_descriptor.max_power_in_ma * 2u; } // Note: "Power" is used incorrectly here, however it's what it's called in the descriptor/documentation
 
+    ErrorOr<void> get_interfaces();
+
 private:
-    Device& m_device;                  // Reference to the device linked to this configuration
-    USBConfigurationDescriptor m_descriptor; // Descriptor that backs this configuration
+    Device& m_device;                              // Reference to the device linked to this configuration
+    USBConfigurationDescriptor const m_descriptor; // Descriptor that backs this configuration
+    Vector<USBInterface> m_interfaces;             // Interfaces for this device
 };
 
 }

--- a/Kernel/Bus/USB/USBConfiguration.h
+++ b/Kernel/Bus/USB/USBConfiguration.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Jesse Buhagiar <jesse.buhagiar@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+#include <Kernel/Bus/USB/USBDescriptors.h>
+#include <Kernel/Bus/USB/USBDevice.h>
+
+namespace Kernel::USB {
+
+class Device;
+
+class USBConfiguration {
+public:
+    USBConfiguration() = delete;
+    USBConfiguration(Device& device, USBConfigurationDescriptor const configuration_descriptor)
+        : m_device(device)
+        , m_descriptor(configuration_descriptor)
+    {
+    }
+
+    Device const& device() const { return m_device; }
+
+    u8 interface_count() const { return m_descriptor.number_of_interfaces; }
+    u8 configuration_id() const { return m_descriptor.configuration_value; }
+    u8 attributes() const { return m_descriptor.attributes_bitmap; }
+    u16 max_power_ma() const { return m_descriptor.max_power_in_ma * 2u; } // Note: "Power" is used incorrectly here, however it's what it's called in the descriptor/documentation
+
+private:
+    Device& m_device;                  // Reference to the device linked to this configuration
+    USBConfigurationDescriptor m_descriptor; // Descriptor that backs this configuration
+};
+
+}

--- a/Kernel/Bus/USB/USBDescriptors.h
+++ b/Kernel/Bus/USB/USBDescriptors.h
@@ -108,6 +108,19 @@ struct [[gnu::packed]] USBHubDescriptor {
     // NOTE: This does not contain DeviceRemovable or PortPwrCtrlMask because a struct cannot have two VLAs in a row.
 };
 
+//
+//  USB Human Interface Device (HID) Descriptor
+//  ==============
+//
+struct [[gnu::packed]] USBHIDDescriptor {
+    USBDescriptorCommon descriptor_header;
+    u16 hid_bcd;
+    u8 country_code;
+    u8 number_of_report_descriptors;
+    u8 following_descriptor_type;
+    u16 hid_report_descriptor_size;
+};
+
 static constexpr u8 DESCRIPTOR_TYPE_DEVICE = 0x01;
 static constexpr u8 DESCRIPTOR_TYPE_CONFIGURATION = 0x02;
 static constexpr u8 DESCRIPTOR_TYPE_STRING = 0x03;

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -138,4 +138,9 @@ ErrorOr<void> Device::enumerate_device()
     return {};
 }
 
+ErrorOr<size_t> Device::control_transfer(u8 request_type, u8 request, u16 value, u16 index, u16 length, void* data)
+{
+    return TRY(m_default_pipe->control_transfer(request_type, request, value, index, length, data));
+}
+
 }

--- a/Kernel/Bus/USB/USBDevice.cpp
+++ b/Kernel/Bus/USB/USBDevice.cpp
@@ -132,6 +132,7 @@ ErrorOr<void> Device::enumerate_device()
         }
 
         USBConfiguration device_configuration(*this, configuration_descriptor);
+        TRY(device_configuration.get_interfaces());
         m_configurations.append(device_configuration);
     }
 

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -47,6 +47,8 @@ public:
     USBController& controller() { return *m_controller; }
     USBController const& controller() const { return *m_controller; }
 
+    ErrorOr<size_t> control_transfer(u8 request_type, u8 request, u16 value, u16 index, u16 length, void* data);
+
 protected:
     Device(NonnullRefPtr<USBController> controller, u8 address, u8 port, DeviceSpeed speed, NonnullOwnPtr<Pipe> default_pipe);
 

--- a/Kernel/Bus/USB/USBDevice.h
+++ b/Kernel/Bus/USB/USBDevice.h
@@ -8,11 +8,14 @@
 
 #include <AK/OwnPtr.h>
 #include <AK/Types.h>
+#include <AK/Vector.h>
+#include <Kernel/Bus/USB/USBConfiguration.h>
 #include <Kernel/Bus/USB/USBPipe.h>
 
 namespace Kernel::USB {
 
 class USBController;
+class USBConfiguration;
 
 //
 // Some nice info from FTDI on device enumeration and how some of this
@@ -55,6 +58,7 @@ protected:
     u16 m_vendor_id { 0 };                      // This device's vendor ID assigned by the USB group
     u16 m_product_id { 0 };                     // This device's product ID assigned by the USB group
     USBDeviceDescriptor m_device_descriptor {}; // Device Descriptor obtained from USB Device
+    Vector<USBConfiguration> m_configurations;  // Configurations for this device
 
     NonnullRefPtr<USBController> m_controller;
     NonnullOwnPtr<Pipe> m_default_pipe; // Default communication pipe (endpoint0) used during enumeration

--- a/Kernel/Bus/USB/USBInterface.h
+++ b/Kernel/Bus/USB/USBInterface.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Jesse Buhagiar <jesse.buhagiar@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Vector.h>
+
+namespace Kernel::USB {
+
+class USBConfiguration;
+
+class USBInterface final {
+public:
+    USBInterface() = delete;
+    USBInterface(USBConfiguration const& configuration, USBInterfaceDescriptor const descriptor, Vector<USBEndpointDescriptor> const& endpoint_descriptors)
+        : m_configuration(configuration)
+        , m_descriptor(descriptor)
+        , m_endpoint_descriptors(endpoint_descriptors)
+    {
+        m_endpoint_descriptors.ensure_capacity(descriptor.number_of_endpoints);
+    }
+
+private:
+    USBConfiguration const& m_configuration;              // Configuration that this interface belongs to
+    USBInterfaceDescriptor const m_descriptor;            // Descriptor backing this interface
+    Vector<USBEndpointDescriptor> m_endpoint_descriptors; // Endpoint descriptors for this interface (that we can use to open an endpoint)
+};
+
+}

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -30,6 +30,7 @@ set(KERNEL_SOURCES
     Bus/USB/SysFSUSB.cpp
     Bus/USB/UHCI/UHCIController.cpp
     Bus/USB/UHCI/UHCIRootHub.cpp
+    Bus/USB/USBConfiguration.cpp
     Bus/USB/USBController.cpp
     Bus/USB/USBDevice.cpp
     Bus/USB/USBHub.cpp


### PR DESCRIPTION
This PR extends the USBD by adding the ability three new types of descriptors when the device is enumerated: Configuration Descriptors, Interface Descriptors and Endpoint Descriptors. 

The code has been architected in a way that allows these descriptors to be stored in a hierarchy per device, meaning at any point in the descriptor chain it is possible to work backwards to find what device the descriptor belongs to.