### PR TITLE
Kernel: Enable PS2 keyboard scan code translation if not already enabled

### DIFF
--- a/Kernel/Devices/HID/I8042Controller.h
+++ b/Kernel/Devices/HID/I8042Controller.h
@@ -30,6 +30,7 @@ enum I8042Command : u8 {
     DisableFirstPS2Port = 0xAD,
     EnableFirstPS2Port = 0xAE,
     WriteSecondPS2PortInputBuffer = 0xD4,
+    SetScanCodeSet = 0xF0,
     GetDeviceID = 0xF2,
     SetSampleRate = 0xF3,
     EnablePacketStreaming = 0xF4,


### PR DESCRIPTION
On the QEMU microvm machine type, it became apparent that the BIOS was
not setting the i8042 controller to function as expected. To ensure that
the controller is always outputting correct scan codes, set it to scan
code 2 and enable first port translation to ensure all scan codes are
translated to scan code set 1. This is the expected behavior when using
SeaBIOS, but on qboot (the BIOS for the QEMU microvm machine type), the
firmware doesn't take care of this so we need to do this ourselves.