### PR TITLE
LibCore+Everywhere: Make Core::Stream::read() methods return Bytes (or StringView)

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibTimeZone/GenerateTimeZoneData.cpp
@@ -316,8 +316,7 @@ static ErrorOr<void> parse_time_zones(StringView time_zone_path, TimeZoneData& t
     Vector<TimeZoneOffset>* last_parsed_zone = nullptr;
 
     while (TRY(file->can_read_line())) {
-        auto nread = TRY(file->read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file->read_line(buffer));
 
         if (line.is_empty() || line.trim_whitespace(TrimMode::Left).starts_with('#'))
             continue;
@@ -374,8 +373,7 @@ static ErrorOr<void> parse_time_zone_coordinates(Core::Stream::BufferedFile& fil
     Array<u8, 1024> buffer {};
 
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
 
         if (line.is_empty() || line.trim_whitespace(TrimMode::Left).starts_with('#'))
             continue;

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GenerateUnicodeData.cpp
@@ -197,8 +197,7 @@ static ErrorOr<void> parse_special_casing(Core::Stream::BufferedFile& file, Unic
     Array<u8, 1024> buffer;
 
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
 
         if (line.is_empty() || line.starts_with('#'))
             continue;
@@ -264,8 +263,7 @@ static ErrorOr<void> parse_prop_list(Core::Stream::BufferedFile& file, PropList&
     Array<u8, 1024> buffer;
 
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
 
         if (line.is_empty() || line.starts_with('#'))
             continue;
@@ -311,8 +309,7 @@ static ErrorOr<void> parse_alias_list(Core::Stream::BufferedFile& file, PropList
     };
 
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
 
         if (line.is_empty() || line.starts_with('#')) {
             if (line.ends_with("Properties"sv))
@@ -345,8 +342,7 @@ static ErrorOr<void> parse_name_aliases(Core::Stream::BufferedFile& file, Unicod
     Array<u8, 1024> buffer;
 
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
 
         if (line.is_empty() || line.starts_with('#'))
             continue;
@@ -387,8 +383,7 @@ static ErrorOr<void> parse_value_alias_list(Core::Stream::BufferedFile& file, St
     };
 
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
 
         if (line.is_empty() || line.starts_with('#'))
             continue;
@@ -421,8 +416,7 @@ static ErrorOr<void> parse_normalization_props(Core::Stream::BufferedFile& file,
     Array<u8, 1024> buffer;
 
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
 
         if (line.is_empty() || line.starts_with('#'))
             continue;
@@ -518,8 +512,7 @@ static ErrorOr<void> parse_block_display_names(Core::Stream::BufferedFile& file,
 {
     Array<u8, 1024> buffer;
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
         if (line.is_empty() || line.starts_with('#'))
             continue;
 
@@ -547,8 +540,7 @@ static ErrorOr<void> parse_unicode_data(Core::Stream::BufferedFile& file, Unicod
     Array<u8, 1024> buffer;
 
     while (TRY(file.can_read_line())) {
-        auto nread = TRY(file.read_line(buffer));
-        StringView line { buffer.data(), nread };
+        auto line = TRY(file.read_line(buffer));
 
         if (line.is_empty())
             continue;

--- a/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibUnicode/GeneratorUtil.h
@@ -259,8 +259,8 @@ inline ErrorOr<JsonValue> read_json_file(StringView path)
 
     // FIXME: When Core::Stream supports reading an entire file, use that.
     while (TRY(file->can_read_line())) {
-        auto nread = TRY(file->read(buffer));
-        TRY(builder.try_append(reinterpret_cast<char const*>(buffer.data()), nread));
+        auto bytes_read = TRY(file->read(buffer));
+        TRY(builder.try_append(StringView { bytes_read }));
     }
 
     return JsonValue::from_string(builder.build());

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -63,7 +63,7 @@ TEST_CASE(file_read_bytes)
 
     auto result = file->read(buffer);
     EXPECT(!result.is_error());
-    EXPECT_EQ(result.value(), 131ul);
+    EXPECT_EQ(result.value().size(), 131ul);
 
     StringView buffer_contents { buffer.bytes() };
     EXPECT_EQ(buffer_contents, expected_buffer_contents);
@@ -193,11 +193,11 @@ TEST_CASE(tcp_socket_read)
     auto maybe_receive_buffer = ByteBuffer::create_uninitialized(64);
     EXPECT(!maybe_receive_buffer.is_error());
     auto receive_buffer = maybe_receive_buffer.release_value();
-    auto maybe_nread = client_socket->read(receive_buffer);
-    EXPECT(!maybe_nread.is_error());
-    auto nread = maybe_nread.release_value();
+    auto maybe_read_bytes = client_socket->read(receive_buffer);
+    EXPECT(!maybe_read_bytes.is_error());
+    auto read_bytes = maybe_read_bytes.release_value();
 
-    StringView received_data { receive_buffer.data(), nread };
+    StringView received_data { read_bytes };
     EXPECT_EQ(sent_data, received_data);
 }
 
@@ -226,11 +226,11 @@ TEST_CASE(tcp_socket_write)
     auto maybe_receive_buffer = ByteBuffer::create_uninitialized(64);
     EXPECT(!maybe_receive_buffer.is_error());
     auto receive_buffer = maybe_receive_buffer.release_value();
-    auto maybe_nread = server_socket->read(receive_buffer);
-    EXPECT(!maybe_nread.is_error());
-    auto nread = maybe_nread.release_value();
+    auto maybe_read_bytes = server_socket->read(receive_buffer);
+    EXPECT(!maybe_read_bytes.is_error());
+    auto read_bytes = maybe_read_bytes.release_value();
 
-    StringView received_data { receive_buffer.data(), nread };
+    StringView received_data { read_bytes };
     EXPECT_EQ(sent_data, received_data);
 }
 
@@ -262,7 +262,7 @@ TEST_CASE(tcp_socket_eof)
     auto maybe_receive_buffer = ByteBuffer::create_uninitialized(1);
     EXPECT(!maybe_receive_buffer.is_error());
     auto receive_buffer = maybe_receive_buffer.release_value();
-    EXPECT_EQ(client_socket->read(receive_buffer).release_value(), 0ul);
+    EXPECT(client_socket->read(receive_buffer).release_value().is_empty());
     EXPECT(client_socket->is_eof());
 }
 
@@ -309,11 +309,11 @@ TEST_CASE(udp_socket_read_write)
     auto maybe_client_receive_buffer = ByteBuffer::create_uninitialized(64);
     EXPECT(!maybe_client_receive_buffer.is_error());
     auto client_receive_buffer = maybe_client_receive_buffer.release_value();
-    auto maybe_nread = client_socket->read(client_receive_buffer);
-    EXPECT(!maybe_nread.is_error());
-    auto nread = maybe_nread.release_value();
+    auto maybe_read_bytes = client_socket->read(client_receive_buffer);
+    EXPECT(!maybe_read_bytes.is_error());
+    auto read_bytes = maybe_read_bytes.release_value();
 
-    StringView client_received_data { client_receive_buffer.data(), nread };
+    StringView client_received_data { read_bytes };
     EXPECT_EQ(udp_reply_data, client_received_data);
 }
 
@@ -353,11 +353,11 @@ TEST_CASE(local_socket_read)
             auto maybe_receive_buffer = ByteBuffer::create_uninitialized(64);
             EXPECT(!maybe_receive_buffer.is_error());
             auto receive_buffer = maybe_receive_buffer.release_value();
-            auto maybe_nread = client_socket->read(receive_buffer);
-            EXPECT(!maybe_nread.is_error());
-            auto nread = maybe_nread.release_value();
+            auto maybe_read_bytes = client_socket->read(receive_buffer);
+            EXPECT(!maybe_read_bytes.is_error());
+            auto read_bytes = maybe_read_bytes.release_value();
 
-            StringView received_data { receive_buffer.data(), nread };
+            StringView received_data { read_bytes };
             EXPECT_EQ(sent_data, received_data);
 
             return 0;
@@ -384,11 +384,11 @@ TEST_CASE(local_socket_write)
         auto maybe_receive_buffer = ByteBuffer::create_uninitialized(pending_bytes);
         EXPECT(!maybe_receive_buffer.is_error());
         auto receive_buffer = maybe_receive_buffer.release_value();
-        auto maybe_nread = server_socket->read(receive_buffer);
-        EXPECT(!maybe_nread.is_error());
-        EXPECT_EQ(maybe_nread.value(), sent_data.length());
+        auto maybe_read_bytes = server_socket->read(receive_buffer);
+        EXPECT(!maybe_read_bytes.is_error());
+        EXPECT_EQ(maybe_read_bytes.value().size(), sent_data.length());
 
-        StringView received_data { receive_buffer.data(), maybe_nread.value() };
+        StringView received_data { maybe_read_bytes.value() };
         EXPECT_EQ(sent_data, received_data);
 
         event_loop.quit(0);

--- a/Tests/LibCore/TestLibCoreStream.cpp
+++ b/Tests/LibCore/TestLibCoreStream.cpp
@@ -426,15 +426,15 @@ TEST_CASE(buffered_long_file_read)
     auto buffer = ByteBuffer::create_uninitialized(4096).release_value();
     EXPECT(!file->seek(255, Core::Stream::SeekMode::SetPosition).is_error());
     EXPECT(file->can_read_line().release_value());
-    auto maybe_nread = file->read_line(buffer);
-    EXPECT(!maybe_nread.is_error());
-    EXPECT_EQ(maybe_nread.value(), 4095ul); // 4095 bytes on the third line
+    auto maybe_line = file->read_line(buffer);
+    EXPECT(!maybe_line.is_error());
+    EXPECT_EQ(maybe_line.value().length(), 4095ul); // 4095 bytes on the third line
 
     // Testing that buffering with seeking works properly
     EXPECT(!file->seek(365, Core::Stream::SeekMode::SetPosition).is_error());
-    auto maybe_after_seek_nread = file->read_line(buffer);
-    EXPECT(!maybe_after_seek_nread.is_error());
-    EXPECT_EQ(maybe_after_seek_nread.value(), 3985ul); // 4095 - 110
+    auto maybe_after_seek_line = file->read_line(buffer);
+    EXPECT(!maybe_after_seek_line.is_error());
+    EXPECT_EQ(maybe_after_seek_line.value().length(), 3985ul); // 4095 - 110
 }
 
 TEST_CASE(buffered_small_file_read)
@@ -456,10 +456,10 @@ TEST_CASE(buffered_small_file_read)
     auto buffer = ByteBuffer::create_uninitialized(4096).release_value();
     for (auto const& line : expected_lines) {
         VERIFY(file->can_read_line().release_value());
-        auto maybe_nread = file->read_line(buffer);
-        EXPECT(!maybe_nread.is_error());
-        EXPECT_EQ(maybe_nread.value(), line.length());
-        EXPECT_EQ(StringView(buffer.span().trim(maybe_nread.value())), line);
+        auto maybe_read_line = file->read_line(buffer);
+        EXPECT(!maybe_read_line.is_error());
+        EXPECT_EQ(maybe_read_line.value().length(), line.length());
+        EXPECT_EQ(StringView(buffer.span().trim(maybe_read_line.value().length())), line);
     }
     EXPECT(!file->can_read_line().is_error());
     EXPECT(!file->can_read_line().value());
@@ -496,13 +496,13 @@ TEST_CASE(buffered_tcp_socket_read)
 
     auto receive_buffer = ByteBuffer::create_uninitialized(64).release_value();
 
-    auto maybe_first_nread = client_socket->read_line(receive_buffer);
-    EXPECT(!maybe_first_nread.is_error());
-    StringView first_received_line { receive_buffer.data(), maybe_first_nread.value() };
+    auto maybe_first_received_line = client_socket->read_line(receive_buffer);
+    EXPECT(!maybe_first_received_line.is_error());
+    auto first_received_line = maybe_first_received_line.value();
     EXPECT_EQ(first_received_line, first_line);
 
-    auto maybe_second_nread = client_socket->read_line(receive_buffer);
-    EXPECT(!maybe_second_nread.is_error());
-    StringView second_received_line { receive_buffer.data(), maybe_second_nread.value() };
+    auto maybe_second_received_line = client_socket->read_line(receive_buffer);
+    EXPECT(!maybe_second_received_line.is_error());
+    auto second_received_line = maybe_second_received_line.value();
     EXPECT_EQ(second_received_line, second_line);
 }

--- a/Tests/LibTLS/TestTLSHandshake.cpp
+++ b/Tests/LibTLS/TestTLSHandshake.cpp
@@ -79,8 +79,8 @@ TEST_CASE(test_TLS_hello_handshake)
     auto tls = MUST(TLS::TLSv12::connect(DEFAULT_SERVER, port, move(options)));
     ByteBuffer contents;
     tls->on_ready_to_read = [&] {
-        auto nread = MUST(tls->read(contents.must_get_bytes_for_writing(4 * KiB)));
-        if (nread == 0) {
+        auto read_bytes = MUST(tls->read(contents.must_get_bytes_for_writing(4 * KiB)));
+        if (read_bytes.is_empty()) {
             FAIL("No data received");
             loop.quit(1);
         }

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -43,8 +43,7 @@ static ErrorOr<void> load_content_filters()
     auto ad_filter_list = TRY(Core::Stream::BufferedFile::create(move(file)));
     auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
     while (TRY(ad_filter_list->can_read_line())) {
-        auto length = TRY(ad_filter_list->read_line(buffer));
-        StringView line { buffer.data(), length };
+        auto line = TRY(ad_filter_list->read_line(buffer));
         if (!line.is_empty())
             Browser::g_content_filters.append(line);
     }

--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -30,8 +30,7 @@ ErrorOr<void> DomainListModel::load()
     auto content_filter_list = TRY(Core::Stream::BufferedFile::create(move(file)));
     auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
     while (TRY(content_filter_list->can_read_line())) {
-        auto length = TRY(content_filter_list->read_line(buffer));
-        StringView line { buffer.data(), length };
+        auto line = TRY(content_filter_list->read_line(buffer));
         dbgln("Content filter for {}", line);
         if (!line.is_empty())
             m_domain_list.append(line);

--- a/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
+++ b/Userland/Applications/FileManager/FileOperationProgressWidget.cpp
@@ -72,13 +72,13 @@ FileOperationProgressWidget::FileOperationProgressWidget(FileOperation operation
     m_notifier = Core::Notifier::construct(helper_pipe_fd, Core::Notifier::Read);
     m_notifier->on_ready_to_read = [this] {
         auto line_buffer = ByteBuffer::create_zeroed(1 * KiB).release_value_but_fixme_should_propagate_errors();
-        auto line_length_or_error = m_helper_pipe->read_line(line_buffer.bytes());
-        if (line_length_or_error.is_error() || line_length_or_error.value() == 0) {
+        auto line_or_error = m_helper_pipe->read_line(line_buffer.bytes());
+        if (line_or_error.is_error() || line_or_error.value().is_empty()) {
             did_error("Read from pipe returned null."sv);
             return;
         }
 
-        StringView line { line_buffer.bytes().data(), line_length_or_error.value() };
+        auto line = line_or_error.release_value();
 
         auto parts = line.split_view(' ');
         VERIFY(!parts.is_empty());

--- a/Userland/Libraries/LibAudio/FlacLoader.cpp
+++ b/Userland/Libraries/LibAudio/FlacLoader.cpp
@@ -114,7 +114,7 @@ MaybeLoaderError FlacLoaderPlugin::parse_header()
     [[maybe_unused]] u128 md5_checksum;
     VERIFY(streaminfo_data->is_aligned_to_byte_boundary());
     auto md5_bytes_read = LOADER_TRY(streaminfo_data->read(md5_checksum.bytes()));
-    FLAC_VERIFY(md5_bytes_read == md5_checksum.my_size(), LoaderError::Category::IO, "MD5 Checksum size");
+    FLAC_VERIFY(md5_bytes_read.size() == md5_checksum.my_size(), LoaderError::Category::IO, "MD5 Checksum size");
     md5_checksum.bytes().copy_to({ m_md5_checksum, sizeof(m_md5_checksum) });
 
     // Parse other blocks

--- a/Userland/Libraries/LibCore/ConfigFile.cpp
+++ b/Userland/Libraries/LibCore/ConfigFile.cpp
@@ -88,9 +88,7 @@ ErrorOr<void> ConfigFile::reparse()
 
     auto buffer = TRY(ByteBuffer::create_uninitialized(4096));
     while (TRY(m_file->can_read_line())) {
-        auto length = TRY(m_file->read_line(buffer));
-
-        StringView line { buffer.data(), length };
+        auto line = TRY(m_file->read_line(buffer));
         size_t i = 0;
 
         while (i < line.length() && (line[i] == ' ' || line[i] == '\t' || line[i] == '\n'))

--- a/Userland/Libraries/LibCore/InputBitStream.h
+++ b/Userland/Libraries/LibCore/InputBitStream.h
@@ -31,7 +31,7 @@ public:
 
     // ^Stream
     virtual bool is_readable() const override { return m_stream.is_readable(); }
-    virtual ErrorOr<size_t> read(Bytes bytes) override
+    virtual ErrorOr<Bytes> read(Bytes bytes) override
     {
         if (m_current_byte.has_value() && is_aligned_to_byte_boundary()) {
             bytes[0] = m_current_byte.release_value();

--- a/Userland/Libraries/LibCore/MemoryStream.h
+++ b/Userland/Libraries/LibCore/MemoryStream.h
@@ -29,15 +29,15 @@ public:
     // FIXME: It doesn't make sense to truncate a memory stream. Therefore, we don't do anything here. Is that fine?
     virtual ErrorOr<void> truncate(off_t) override { return Error::from_errno(ENOTSUP); }
 
-    virtual ErrorOr<size_t> read(Bytes bytes) override
+    virtual ErrorOr<Bytes> read(Bytes bytes) override
     {
         auto to_read = min(remaining(), bytes.size());
         if (to_read == 0)
-            return 0;
+            return Bytes {};
 
         m_bytes.slice(m_offset, to_read).copy_to(bytes);
         m_offset += to_read;
-        return bytes.size();
+        return bytes.trim(to_read);
     }
 
     virtual ErrorOr<off_t> seek(i64 offset, SeekMode seek_mode = SeekMode::SetPosition) override

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.cpp
@@ -107,7 +107,7 @@ ErrorOr<void> send_version_identifier_and_method_selection_message(Core::Stream:
         return Error::from_string_literal("SOCKS negotiation failed: Failed to send version identifier and method selection message");
 
     Socks5InitialResponse response;
-    size = TRY(socket.read({ &response, sizeof(response) }));
+    size = TRY(socket.read({ &response, sizeof(response) })).size();
     if (size != sizeof(response))
         return Error::from_string_literal("SOCKS negotiation failed: Failed to receive initial response");
 
@@ -169,7 +169,7 @@ ErrorOr<Reply> send_connect_request_message(Core::Stream::Socket& socket, Core::
         return Error::from_string_literal("SOCKS negotiation failed: Failed to send connect request");
 
     Socks5ConnectResponseHeader response_header;
-    size = TRY(socket.read({ &response_header, sizeof(response_header) }));
+    size = TRY(socket.read({ &response_header, sizeof(response_header) })).size();
     if (size != sizeof(response_header))
         return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response header");
 
@@ -177,26 +177,26 @@ ErrorOr<Reply> send_connect_request_message(Core::Stream::Socket& socket, Core::
         return Error::from_string_literal("SOCKS negotiation failed: Invalid version identifier");
 
     u8 response_address_type;
-    size = TRY(socket.read({ &response_address_type, sizeof(response_address_type) }));
+    size = TRY(socket.read({ &response_address_type, sizeof(response_address_type) })).size();
     if (size != sizeof(response_address_type))
         return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response address type");
 
     switch (AddressType(response_address_type)) {
     case AddressType::IPV4: {
         u8 response_address_data[4];
-        size = TRY(socket.read({ response_address_data, sizeof(response_address_data) }));
+        size = TRY(socket.read({ response_address_data, sizeof(response_address_data) })).size();
         if (size != sizeof(response_address_data))
             return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response address data");
         break;
     }
     case AddressType::DomainName: {
         u8 response_address_length;
-        size = TRY(socket.read({ &response_address_length, sizeof(response_address_length) }));
+        size = TRY(socket.read({ &response_address_length, sizeof(response_address_length) })).size();
         if (size != sizeof(response_address_length))
             return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response address length");
         ByteBuffer buffer;
         buffer.resize(response_address_length);
-        size = TRY(socket.read(buffer));
+        size = TRY(socket.read(buffer)).size();
         if (size != response_address_length)
             return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response address data");
         break;
@@ -207,7 +207,7 @@ ErrorOr<Reply> send_connect_request_message(Core::Stream::Socket& socket, Core::
     }
 
     u16 bound_port;
-    size = TRY(socket.read({ &bound_port, sizeof(bound_port) }));
+    size = TRY(socket.read({ &bound_port, sizeof(bound_port) })).size();
     if (size != sizeof(bound_port))
         return Error::from_string_literal("SOCKS negotiation failed: Failed to receive connect response bound port");
 
@@ -247,7 +247,7 @@ ErrorOr<u8> send_username_password_authentication_message(Core::Stream::Socket& 
         return Error::from_string_literal("SOCKS negotiation failed: Failed to send username/password authentication message");
 
     Socks5UsernamePasswordResponse response;
-    size = TRY(socket.read({ &response, sizeof(response) }));
+    size = TRY(socket.read({ &response, sizeof(response) })).size();
     if (size != sizeof(response))
         return Error::from_string_literal("SOCKS negotiation failed: Failed to receive username/password authentication response");
 

--- a/Userland/Libraries/LibCore/SOCKSProxyClient.h
+++ b/Userland/Libraries/LibCore/SOCKSProxyClient.h
@@ -37,7 +37,7 @@ public:
     virtual ~SOCKSProxyClient() override;
 
     // ^Stream::Stream
-    virtual ErrorOr<size_t> read(Bytes bytes) override { return m_socket.read(bytes); }
+    virtual ErrorOr<Bytes> read(Bytes bytes) override { return m_socket.read(bytes); }
     virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_socket.write(bytes); }
     virtual bool is_eof() const override { return m_socket.is_eof(); }
     virtual bool is_open() const override { return m_socket.is_open(); }

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -552,9 +552,9 @@ ErrorOr<pid_t> LocalSocket::peer_pid() const
 #endif
 }
 
-ErrorOr<size_t> LocalSocket::read_without_waiting(Bytes buffer)
+ErrorOr<Bytes> LocalSocket::read_without_waiting(Bytes buffer)
 {
-    return TRY(m_helper.read(buffer, MSG_DONTWAIT)).size();
+    return m_helper.read(buffer, MSG_DONTWAIT);
 }
 
 ErrorOr<int> LocalSocket::release_fd()

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -444,7 +444,7 @@ public:
     ErrorOr<int> receive_fd(int flags);
     ErrorOr<void> send_fd(int fd);
     ErrorOr<pid_t> peer_pid() const;
-    ErrorOr<size_t> read_without_waiting(Bytes buffer);
+    ErrorOr<Bytes> read_without_waiting(Bytes buffer);
 
     /// Release the fd associated with this LocalSocket. After the fd is
     /// released, the socket will be considered "closed" and all operations done

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -557,10 +557,10 @@ public:
 
     // Reads into the buffer until \n is encountered.
     // The size of the Bytes object is the maximum amount of bytes that will be
-    // read. Returns the amount of bytes read.
-    ErrorOr<size_t> read_line(Bytes buffer)
+    // read. Returns the bytes read as a StringView.
+    ErrorOr<StringView> read_line(Bytes buffer)
     {
-        return TRY(read_until(buffer, "\n"sv)).size();
+        return StringView { TRY(read_until(buffer, "\n"sv)) };
     }
 
     ErrorOr<Bytes> read_until(Bytes buffer, StringView candidate)
@@ -769,7 +769,7 @@ public:
         return m_helper.stream().truncate(length);
     }
 
-    ErrorOr<size_t> read_line(Bytes buffer) { return m_helper.read_line(move(buffer)); }
+    ErrorOr<StringView> read_line(Bytes buffer) { return m_helper.read_line(move(buffer)); }
     ErrorOr<Bytes> read_until(Bytes buffer, StringView candidate) { return m_helper.read_until(move(buffer), move(candidate)); }
     template<size_t N>
     ErrorOr<Bytes> read_until_any_of(Bytes buffer, Array<StringView, N> candidates) { return m_helper.read_until_any_of(move(buffer), move(candidates)); }
@@ -790,7 +790,7 @@ private:
 
 class BufferedSocketBase : public Socket {
 public:
-    virtual ErrorOr<size_t> read_line(Bytes buffer) = 0;
+    virtual ErrorOr<StringView> read_line(Bytes buffer) = 0;
     virtual ErrorOr<Bytes> read_until(Bytes buffer, StringView candidate) = 0;
     virtual ErrorOr<bool> can_read_line() = 0;
     virtual size_t buffer_size() const = 0;
@@ -838,7 +838,7 @@ public:
     virtual ErrorOr<void> set_close_on_exec(bool enabled) override { return m_helper.stream().set_close_on_exec(enabled); }
     virtual void set_notifications_enabled(bool enabled) override { m_helper.stream().set_notifications_enabled(enabled); }
 
-    virtual ErrorOr<size_t> read_line(Bytes buffer) override { return m_helper.read_line(move(buffer)); }
+    virtual ErrorOr<StringView> read_line(Bytes buffer) override { return m_helper.read_line(move(buffer)); }
     virtual ErrorOr<Bytes> read_until(Bytes buffer, StringView candidate) override { return m_helper.read_until(move(buffer), move(candidate)); }
     template<size_t N>
     ErrorOr<Bytes> read_until_any_of(Bytes buffer, Array<StringView, N> candidates) { return m_helper.read_until_any_of(move(buffer), move(candidates)); }

--- a/Userland/Libraries/LibGemini/Job.cpp
+++ b/Userland/Libraries/LibGemini/Job.cpp
@@ -63,7 +63,7 @@ String Job::read_line(size_t size)
 ByteBuffer Job::receive(size_t size)
 {
     ByteBuffer buffer = ByteBuffer::create_uninitialized(size).release_value_but_fixme_should_propagate_errors();
-    auto nread = MUST(m_socket->read(buffer));
+    auto nread = MUST(m_socket->read(buffer)).size();
     return buffer.slice(0, nread);
 }
 

--- a/Userland/Libraries/LibGemini/Job.cpp
+++ b/Userland/Libraries/LibGemini/Job.cpp
@@ -56,8 +56,8 @@ bool Job::can_read_line() const
 String Job::read_line(size_t size)
 {
     ByteBuffer buffer = ByteBuffer::create_uninitialized(size).release_value_but_fixme_should_propagate_errors();
-    auto nread = MUST(m_socket->read_until(buffer, "\r\n"sv));
-    return String::copy(buffer.span().slice(0, nread));
+    auto bytes_read = MUST(m_socket->read_until(buffer, "\r\n"sv));
+    return String::copy(bytes_read);
 }
 
 ByteBuffer Job::receive(size_t size)

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -172,7 +172,7 @@ ErrorOr<ByteBuffer> Job::receive(size_t size)
         auto result = m_socket->read(buffer);
         if (result.is_error() && result.error().is_errno() && result.error().code() == EINTR)
             continue;
-        nread = TRY(result);
+        nread = TRY(result).size();
         break;
     } while (true);
     return buffer.slice(0, nread);

--- a/Userland/Libraries/LibHTTP/Job.cpp
+++ b/Userland/Libraries/LibHTTP/Job.cpp
@@ -157,8 +157,8 @@ void Job::register_on_ready_to_read(Function<void()> callback)
 ErrorOr<String> Job::read_line(size_t size)
 {
     auto buffer = TRY(ByteBuffer::create_uninitialized(size));
-    auto nread = TRY(m_socket->read_until(buffer, "\r\n"sv));
-    return String::copy(buffer.span().slice(0, nread));
+    auto bytes_read = TRY(m_socket->read_until(buffer, "\r\n"sv));
+    return String::copy(bytes_read);
 }
 
 ErrorOr<ByteBuffer> Job::receive(size_t size)

--- a/Userland/Libraries/LibProtocol/Request.cpp
+++ b/Userland/Libraries/LibProtocol/Request.cpp
@@ -51,10 +51,10 @@ void Request::stream_into_impl(T& stream)
                 break;
             if (result.is_error())
                 continue;
-            auto nread = result.value();
-            if (nread == 0)
+            auto read_bytes = result.release_value();
+            if (read_bytes.is_empty())
                 break;
-            if (!stream.write_or_error({ buf, nread })) {
+            if (!stream.write_or_error(read_bytes)) {
                 // FIXME: What do we do here?
                 TODO();
             }

--- a/Userland/Libraries/LibTLS/Socket.cpp
+++ b/Userland/Libraries/LibTLS/Socket.cpp
@@ -18,18 +18,18 @@ constexpr static size_t MaximumApplicationDataChunkSize = 16 * KiB;
 
 namespace TLS {
 
-ErrorOr<size_t> TLSv12::read(Bytes bytes)
+ErrorOr<Bytes> TLSv12::read(Bytes bytes)
 {
     m_eof = false;
     auto size_to_read = min(bytes.size(), m_context.application_buffer.size());
     if (size_to_read == 0) {
         m_eof = true;
-        return 0;
+        return Bytes {};
     }
 
     m_context.application_buffer.span().slice(0, size_to_read).copy_to(bytes);
     m_context.application_buffer = m_context.application_buffer.slice(size_to_read, m_context.application_buffer.size() - size_to_read);
-    return size_to_read;
+    return Bytes { bytes.data(), size_to_read };
 }
 
 String TLSv12::read_line(size_t max_size)
@@ -186,7 +186,7 @@ ErrorOr<void> TLSv12::read_from_socket()
 
     u8 buffer[16 * KiB];
     Bytes bytes { buffer, array_size(buffer) };
-    size_t nread = 0;
+    Bytes read_bytes {};
     auto& stream = underlying_stream();
     do {
         auto result = stream.read(bytes);
@@ -198,9 +198,9 @@ ErrorOr<void> TLSv12::read_from_socket()
             }
             continue;
         }
-        nread = result.release_value();
-        consume(bytes.slice(0, nread));
-    } while (nread > 0 && !m_context.critical_error);
+        read_bytes = result.release_value();
+        consume(read_bytes);
+    } while (!read_bytes.is_empty() && !m_context.critical_error);
 
     return {};
 }

--- a/Userland/Libraries/LibTLS/TLSv12.h
+++ b/Userland/Libraries/LibTLS/TLSv12.h
@@ -356,9 +356,9 @@ public:
 
     /// Reads into a buffer, with the maximum size being the size of the buffer.
     /// The amount of bytes read can be smaller than the size of the buffer.
-    /// Returns either the amount of bytes read, or an errno in the case of
+    /// Returns either the bytes that were read, or an errno in the case of
     /// failure.
-    virtual ErrorOr<size_t> read(Bytes) override;
+    virtual ErrorOr<Bytes> read(Bytes) override;
 
     /// Tries to write the entire contents of the buffer. It is possible for
     /// less than the full buffer to be written. Returns either the amount of

--- a/Userland/Libraries/LibWebSocket/Impl/WebSocketImpl.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/WebSocketImpl.cpp
@@ -56,8 +56,8 @@ void WebSocketImpl::connect(ConnectionInfo const& connection_info)
 ErrorOr<ByteBuffer> WebSocketImpl::read(int max_size)
 {
     auto buffer = TRY(ByteBuffer::create_uninitialized(max_size));
-    auto nread = TRY(m_socket->read(buffer));
-    return buffer.slice(0, nread);
+    auto read_bytes = TRY(m_socket->read(buffer));
+    return buffer.slice(0, read_bytes.size());
 }
 
 ErrorOr<String> WebSocketImpl::read_line(size_t size)

--- a/Userland/Libraries/LibWebSocket/Impl/WebSocketImpl.cpp
+++ b/Userland/Libraries/LibWebSocket/Impl/WebSocketImpl.cpp
@@ -63,8 +63,8 @@ ErrorOr<ByteBuffer> WebSocketImpl::read(int max_size)
 ErrorOr<String> WebSocketImpl::read_line(size_t size)
 {
     auto buffer = TRY(ByteBuffer::create_uninitialized(size));
-    auto nread = TRY(m_socket->read_line(buffer));
-    return String::copy(buffer.span().slice(0, nread));
+    auto line = TRY(m_socket->read_line(buffer));
+    return line.to_string();
 }
 
 }

--- a/Userland/Services/EchoServer/Client.cpp
+++ b/Userland/Services/EchoServer/Client.cpp
@@ -30,16 +30,16 @@ ErrorOr<void> Client::drain_socket()
     auto buffer = TRY(ByteBuffer::create_uninitialized(1024));
 
     while (TRY(m_socket->can_read_without_blocking())) {
-        auto nread = TRY(m_socket->read(buffer));
+        auto bytes_read = TRY(m_socket->read(buffer));
 
-        dbgln("Read {} bytes.", nread);
+        dbgln("Read {} bytes.", bytes_read.size());
 
         if (m_socket->is_eof()) {
             Core::deferred_invoke([this, strong_this = NonnullRefPtr(*this)] { quit(); });
             break;
         }
 
-        TRY(m_socket->write({ buffer.data(), nread }));
+        TRY(m_socket->write(bytes_read));
     }
 
     return {};

--- a/Userland/Services/FileOperation/main.cpp
+++ b/Userland/Services/FileOperation/main.cpp
@@ -238,15 +238,15 @@ ErrorOr<int> execute_work_items(Vector<WorkItem> const& items)
             while (true) {
                 print_progress();
                 auto bytes_read = TRY(source_file->read(buffer.bytes()));
-                if (bytes_read == 0)
+                if (bytes_read.is_empty())
                     break;
-                if (auto result = destination_file->write(buffer); result.is_error()) {
+                if (auto result = destination_file->write(bytes_read); result.is_error()) {
                     // FIXME: Return the formatted string directly. There is no way to do this right now without the temporary going out of scope and being destroyed.
                     report_warning(String::formatted("Failed to write to destination file: {}", result.error()));
                     return result.error();
                 }
-                item_done += bytes_read;
-                executed_work_bytes += bytes_read;
+                item_done += bytes_read.size();
+                executed_work_bytes += bytes_read.size();
                 print_progress();
                 // FIXME: Remove this once the kernel is smart enough to schedule other threads
                 //        while we're doing heavy I/O. Right now, copying a large file will totally

--- a/Userland/Services/LookupServer/LookupServer.cpp
+++ b/Userland/Services/LookupServer/LookupServer.cpp
@@ -239,7 +239,7 @@ ErrorOr<Vector<DNSAnswer>> LookupServer::lookup(DNSName const& name, String cons
     TRY(udp_socket->write(buffer));
 
     u8 response_buffer[4096];
-    int nrecv = TRY(udp_socket->read({ response_buffer, sizeof(response_buffer) }));
+    int nrecv = TRY(udp_socket->read({ response_buffer, sizeof(response_buffer) })).size();
     if (udp_socket->is_eof())
         return Vector<DNSAnswer> {};
 

--- a/Userland/Services/TelnetServer/Client.cpp
+++ b/Userland/Services/TelnetServer/Client.cpp
@@ -76,9 +76,9 @@ ErrorOr<void> Client::drain_socket()
     auto buffer = TRY(ByteBuffer::create_uninitialized(1024));
 
     while (TRY(m_socket->can_read_without_blocking())) {
-        auto nread = TRY(m_socket->read(buffer));
+        auto read_bytes = TRY(m_socket->read(buffer));
 
-        m_parser.write({ buffer.data(), nread });
+        m_parser.write(StringView { read_bytes });
 
         if (m_socket->is_eof()) {
             Core::deferred_invoke([this, strong_this = NonnullRefPtr(*this)] { quit(); });

--- a/Userland/Services/WebServer/Client.cpp
+++ b/Userland/Services/WebServer/Client.cpp
@@ -64,9 +64,9 @@ void Client::start()
             if (!maybe_can_read.value())
                 break;
 
-            auto maybe_nread = m_socket->read_until_any_of(buffer, Array { "\r"sv, "\n"sv, "\r\n"sv });
-            if (maybe_nread.is_error()) {
-                warnln("Failed to read a line from the request: {}", maybe_nread.error());
+            auto maybe_bytes_read = m_socket->read_until_any_of(buffer, Array { "\r"sv, "\n"sv, "\r\n"sv });
+            if (maybe_bytes_read.is_error()) {
+                warnln("Failed to read a line from the request: {}", maybe_bytes_read.error());
                 die();
                 return;
             }
@@ -76,7 +76,7 @@ void Client::start()
                 break;
             }
 
-            builder.append(StringView { buffer.data(), maybe_nread.value() });
+            builder.append(StringView { maybe_bytes_read.value() });
             builder.append("\r\n");
         }
 


### PR DESCRIPTION
As seen in #13687, (which this fixes,) having `read()` return the number of bytes read is quite error-prone: Users have to manually assemble a `Bytes` or `StringView` or whatever else, from the buffer's data and the size returned from `read()`. It's easy to forget to do this and just use the passed-in buffer.

This PR changes these to return a `Bytes` object representing the bytes that were read. So it's the same as `Bytes { buffer.data(), bytes_read }`, but done for you so you don't have to think about it. `read_line()` is the odd one out, and now returns a `StringView`, since everyone who reads line-by-line is dealing with string data.

cc @sin-ack 