### PR TITLE
LibJS: Remove cloneConstructor parameter from CloneArrayBuffer

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.cpp
@@ -7,6 +7,7 @@
 
 #include <LibJS/Runtime/AbstractOperations.h>
 #include <LibJS/Runtime/ArrayBuffer.h>
+#include <LibJS/Runtime/ArrayBufferConstructor.h>
 #include <LibJS/Runtime/GlobalObject.h>
 
 namespace JS {
@@ -121,16 +122,13 @@ ThrowCompletionOr<Value> detach_array_buffer(GlobalObject& global_object, ArrayB
 }
 
 // 25.1.2.4 CloneArrayBuffer ( srcBuffer, srcByteOffset, srcLength, cloneConstructor ), https://tc39.es/ecma262/#sec-clonearraybuffer
-ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(GlobalObject& global_object, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length, FunctionObject& clone_constructor)
+ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(GlobalObject& global_object, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length)
 {
-    auto& vm = global_object.vm();
+    // 1. Assert: IsDetachedBuffer(srcBuffer) is false.
+    VERIFY(!source_buffer.is_detached());
 
-    // 1. Let targetBuffer be ? AllocateArrayBuffer(cloneConstructor, srcLength).
-    auto* target_buffer = TRY(allocate_array_buffer(global_object, clone_constructor, source_length));
-
-    // 2. If IsDetachedBuffer(srcBuffer) is true, throw a TypeError exception.
-    if (source_buffer.is_detached())
-        return vm.throw_completion<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
+    // 2. Let targetBuffer be ? AllocateArrayBuffer(%ArrayBuffer%, srcLength).
+    auto* target_buffer = TRY(allocate_array_buffer(global_object, *global_object.array_buffer_constructor(), source_length));
 
     // 3. Let srcBlock be srcBuffer.[[ArrayBufferData]].
     auto& source_block = source_buffer.buffer();

--- a/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
+++ b/Userland/Libraries/LibJS/Runtime/ArrayBuffer.h
@@ -82,7 +82,7 @@ private:
 
 ThrowCompletionOr<ArrayBuffer*> allocate_array_buffer(GlobalObject&, FunctionObject& constructor, size_t byte_length, Optional<size_t> max_byte_length = {});
 ThrowCompletionOr<Value> detach_array_buffer(GlobalObject&, ArrayBuffer& array_buffer, Optional<Value> key = {});
-ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(GlobalObject&, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length, FunctionObject& clone_constructor);
+ThrowCompletionOr<ArrayBuffer*> clone_array_buffer(GlobalObject&, ArrayBuffer& source_buffer, size_t source_byte_offset, size_t source_length);
 
 // 25.1.2.9 RawBytesToNumeric ( type, rawBytes, isLittleEndian ), https://tc39.es/ecma262/#sec-rawbytestonumeric
 template<typename T>

--- a/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
+++ b/Userland/Libraries/LibJS/Runtime/ErrorTypes.h
@@ -277,8 +277,12 @@
     M(TypedArrayContentTypeMismatch, "Can't create {} from {}")                                                                         \
     M(TypedArrayInvalidBufferLength, "Invalid buffer length for {}: must be a multiple of {}, got {}")                                  \
     M(TypedArrayInvalidByteOffset, "Invalid byte offset for {}: must be a multiple of {}, got {}")                                      \
+    M(TypedArrayInvalidCopy, "Copy between arrays of different content types ({} and {}) is prohibited")                                \
+    M(TypedArrayInvalidTargetOffset, "Invalid target offset: must be {}")                                                               \
     M(TypedArrayOutOfRangeByteOffset, "Typed array byte offset {} is out of range for buffer with length {}")                           \
     M(TypedArrayOutOfRangeByteOffsetOrLength, "Typed array range {}:{} is out of range for buffer with length {}")                      \
+    M(TypedArrayOverflow, "Overflow in {}")                                                                                             \
+    M(TypedArrayOverflowOrOutOfBounds, "Overflow or out of bounds in {}")                                                               \
     M(TypedArrayPrototypeOneArg, "TypedArray.prototype.{}() requires at least one argument")                                            \
     M(TypedArrayFailedSettingIndex, "Failed setting value of index {} of typed array")                                                  \
     M(TypedArrayTypeIsNot, "Typed array {} element type is not {}")                                                                     \

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -626,48 +626,46 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
     if (source_buffer->is_detached())
         return vm.throw_completion<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
 
-    // 6. Let targetName be the String value of target.[[TypedArrayName]].
-    // 7. Let targetType be the Element Type value in Table 69 for targetName.
-    // 8. Let targetElementSize be the Element Size value specified in Table 69 for targetName.
+    // 6. Let targetType be TypedArrayElementType(target).
+    // 7. Let targetElementSize be TypedArrayElementSize(target).
     auto target_element_size = target.element_size();
 
-    // 9. Let targetByteOffset be target.[[ByteOffset]].
+    // 8. Let targetByteOffset be target.[[ByteOffset]].
     auto target_byte_offset = target.byte_offset();
 
-    // 10. Let srcName be the String value of source.[[TypedArrayName]].
-    // 11. Let srcType be the Element Type value in Table 69 for srcName.
-    // 12. Let srcElementSize be the Element Size value specified in Table 69 for srcName.
+    // 9. Let srcType be TypedArrayElementType(source).
+    // 10. Let srcElementSize be TypedArrayElementSize(source).
     auto source_element_size = source.element_size();
 
-    // 13. Let srcLength be source.[[ArrayLength]].
+    // 11. Let srcLength be source.[[ArrayLength]].
     auto source_length = source.array_length();
 
-    // 14. Let srcByteOffset be source.[[ByteOffset]].
+    // 12. Let srcByteOffset be source.[[ByteOffset]].
     auto source_byte_offset = source.byte_offset();
 
-    // 15. If targetOffset is +∞, throw a RangeError exception.
+    // 13. If targetOffset is +∞, throw a RangeError exception.
     if (isinf(target_offset))
         return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayInvalidTargetOffset, "finite");
 
-    // 16. If srcLength + targetOffset > targetLength, throw a RangeError exception.
+    // 14. If srcLength + targetOffset > targetLength, throw a RangeError exception.
     Checked<size_t> checked = source_length;
     checked += static_cast<u32>(target_offset);
     if (checked.has_overflow() || checked.value() > target_length)
         return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayOverflowOrOutOfBounds, "target length");
 
-    // 17. If target.[[ContentType]] ≠ source.[[ContentType]], throw a TypeError exception.
+    // 15. If target.[[ContentType]] ≠ source.[[ContentType]], throw a TypeError exception.
     if (target.content_type() != source.content_type())
         return vm.throw_completion<TypeError>(global_object, ErrorType::TypedArrayInvalidCopy, target.class_name(), source.class_name());
 
-    // FIXME: 18. If both IsSharedArrayBuffer(srcBuffer) and IsSharedArrayBuffer(targetBuffer) are true, then
+    // FIXME: 16. If both IsSharedArrayBuffer(srcBuffer) and IsSharedArrayBuffer(targetBuffer) are true, then
     // FIXME: a. If srcBuffer.[[ArrayBufferData]] and targetBuffer.[[ArrayBufferData]] are the same Shared Data Block values, let same be true; else let same be false.
 
-    // 19. Else, let same be SameValue(srcBuffer, targetBuffer).
+    // 17. Else, let same be SameValue(srcBuffer, targetBuffer).
     auto same = same_value(source_buffer, target_buffer);
 
-    size_t source_byte_index;
+    size_t source_byte_index = 0;
 
-    // 20. If same is true, then
+    // 18. If same is true, then
     if (same) {
         // a. Let srcByteLength be source.[[ByteLength]].
         auto source_byte_length = source.byte_length();
@@ -678,12 +676,13 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
 
         // d. Let srcByteIndex be 0.
         source_byte_index = 0;
-    } else {
-        // 21. Else, let srcByteIndex be srcByteOffset.
+    }
+    // 19. Else, let srcByteIndex be srcByteOffset.
+    else {
         source_byte_index = source_byte_offset;
     }
 
-    // 22. Let targetByteIndex be targetOffset × targetElementSize + targetByteOffset.
+    // 20. Let targetByteIndex be targetOffset × targetElementSize + targetByteOffset.
     Checked<size_t> checked_target_byte_index(static_cast<size_t>(target_offset));
     checked_target_byte_index *= target_element_size;
     checked_target_byte_index += target_byte_offset;
@@ -691,7 +690,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
         return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayOverflow, "target byte index");
     auto target_byte_index = checked_target_byte_index.value();
 
-    // 23. Let limit be targetByteIndex + targetElementSize × srcLength.
+    // 21. Let limit be targetByteIndex + targetElementSize × srcLength.
     Checked<size_t> checked_limit(source_length);
     checked_limit *= target_element_size;
     checked_limit += target_byte_index;
@@ -699,7 +698,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
         return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayOverflow, "target limit");
     auto limit = checked_limit.value();
 
-    // 24. If srcType is the same as targetType, then
+    // 22. If srcType is the same as targetType, then
     if (source.element_name() == target.element_name()) {
         // a. NOTE: If srcType and targetType are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
         // b. Repeat, while targetByteIndex < limit,
@@ -708,7 +707,9 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
         //     iii. Set srcByteIndex to srcByteIndex + 1.
         //     iv. Set targetByteIndex to targetByteIndex + 1.
         target_buffer->buffer().overwrite(target_byte_index, source_buffer->buffer().data() + source_byte_index, limit - target_byte_index);
-    } else {
+    }
+    // 23. Else,
+    else {
         // a. Repeat, while targetByteIndex < limit,
         while (target_byte_index < limit) {
             // i. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, srcType, true, Unordered).
@@ -722,6 +723,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
         }
     }
 
+    // 24. Return unused.
     return {};
 }
 
@@ -822,62 +824,113 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
 // 23.2.3.25 %TypedArray%.prototype.slice ( start, end ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.slice
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
 {
+    auto start = vm.argument(0);
+    auto end = vm.argument(1);
+
+    // 1. Let O be the this value.
+    // 2. Perform ? ValidateTypedArray(O).
     auto* typed_array = TRY(validate_typed_array_from_this(global_object));
 
+    // 3. Let len be O.[[ArrayLength]].
     auto length = typed_array->array_length();
 
-    auto relative_start = TRY(vm.argument(0).to_integer_or_infinity(global_object));
+    // 4. Let relativeStart be ? ToIntegerOrInfinity(start).
+    auto relative_start = TRY(start.to_integer_or_infinity(global_object));
 
-    i32 k;
+    i32 k = 0;
+
+    // 5. If relativeStart is -∞, let k be 0.
     if (Value(relative_start).is_negative_infinity())
         k = 0;
+    // 6. Else if relativeStart < 0, let k be max(len + relativeStart, 0).
     else if (relative_start < 0)
         k = max(length + relative_start, 0);
+    // 7. Else, let k be min(relativeStart, len).
     else
         k = min(relative_start, length);
 
-    double relative_end;
-    if (vm.argument(1).is_undefined())
+    double relative_end = 0;
+
+    // 8. If end is undefined, let relativeEnd be len; else let relativeEnd be ? ToIntegerOrInfinity(end).
+    if (end.is_undefined())
         relative_end = length;
     else
-        relative_end = TRY(vm.argument(1).to_integer_or_infinity(global_object));
+        relative_end = TRY(end.to_integer_or_infinity(global_object));
 
-    i32 final;
+    i32 final = 0;
+
+    // 9. If relativeEnd is -∞, let final be 0.
     if (Value(relative_end).is_negative_infinity())
         final = 0;
+    // 10. Else if relativeEnd < 0, let final be max(len + relativeEnd, 0).
     else if (relative_end < 0)
         final = max(length + relative_end, 0);
+    // 11. Else, let final be min(relativeEnd, len).
     else
         final = min(relative_end, length);
 
+    // 12. Let count be max(final - k, 0).
     auto count = max(final - k, 0);
 
+    // 13. Let A be ? TypedArraySpeciesCreate(O, « 𝔽(count) »).
     MarkedVector<Value> arguments(vm.heap());
     arguments.empend(count);
     auto* new_array = TRY(typed_array_species_create(global_object, *typed_array, move(arguments)));
 
+    // 14. If count > 0, then
     if (count > 0) {
+        // a. If IsDetachedBuffer(O.[[ViewedArrayBuffer]]) is true, throw a TypeError exception.
         if (typed_array->viewed_array_buffer()->is_detached())
             return vm.throw_completion<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
 
+        // b. Let srcType be TypedArrayElementType(O).
+        // c. Let targetType be TypedArrayElementType(A).
+
+        // d. If srcType is different from targetType, then
         if (typed_array->element_name() != new_array->element_name()) {
+            // i. Let n be 0.
+            // ii. Repeat, while k < final,
             for (i32 n = 0; k < final; ++k, ++n) {
+                // 1. Let Pk be ! ToString(𝔽(k)).
+                // 2. Let kValue be ! Get(O, Pk).
                 auto k_value = MUST(typed_array->get(k));
+
+                // 3. Perform ! Set(A, ! ToString(𝔽(n)), kValue, true).
                 MUST(new_array->set(n, k_value, Object::ShouldThrowExceptions::Yes));
+
+                // 4. Set k to k + 1.
+                // 5. Set n to n + 1.
             }
-        } else {
+        }
+        // e. Else,
+        else {
+            // i. Let srcBuffer be O.[[ViewedArrayBuffer]].
+            auto& source_buffer = *typed_array->viewed_array_buffer();
+
+            // ii. Let targetBuffer be A.[[ViewedArrayBuffer]].
+            auto& target_buffer = *new_array->viewed_array_buffer();
+
+            // iii. Let elementSize be TypedArrayElementSize(O).
             auto element_size = typed_array->element_size();
 
+            // iv. NOTE: If srcType and targetType are the same, the transfer must be performed in a manner that preserves the bit-level encoding of the source data.
+
+            // v. Let srcByteOffset be O.[[ByteOffset]].
+            auto source_byte_offset = typed_array->byte_offset();
+
+            // vi. Let targetByteIndex be A.[[ByteOffset]].
+            auto target_byte_index = new_array->byte_offset();
+
+            // vii. Let srcByteIndex be (k × elementSize) + srcByteOffset.
             Checked<u32> source_byte_index = k;
             source_byte_index *= element_size;
-            source_byte_index += typed_array->byte_offset();
+            source_byte_index += source_byte_offset;
             if (source_byte_index.has_overflow()) {
                 dbgln("TypedArrayPrototype::slice: source_byte_index overflowed, returning as if succeeded.");
                 return new_array;
             }
 
-            auto target_byte_index = new_array->byte_offset();
-
+            // viii. Let limit be targetByteIndex + count × elementSize.
             Checked<u32> limit = count;
             limit *= element_size;
             limit += target_byte_index;
@@ -886,15 +939,21 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::slice)
                 return new_array;
             }
 
-            auto& source_buffer = *typed_array->viewed_array_buffer();
-            auto& target_buffer = *new_array->viewed_array_buffer();
+            // ix. Repeat, while targetByteIndex < limit,
             for (; target_byte_index < limit.value(); ++source_byte_index, ++target_byte_index) {
+                // 1. Let value be GetValueFromBuffer(srcBuffer, srcByteIndex, Uint8, true, Unordered).
                 auto value = source_buffer.get_value<u8>(source_byte_index.value(), true, ArrayBuffer::Unordered);
+
+                // 2. Perform SetValueInBuffer(targetBuffer, targetByteIndex, Uint8, value, true, Unordered).
                 target_buffer.set_value<u8>(target_byte_index, value, true, ArrayBuffer::Unordered);
+
+                // 3. Set srcByteIndex to srcByteIndex + 1.
+                // 4. Set targetByteIndex to targetByteIndex + 1.
             }
         }
     }
 
+    // 15. Return A.
     return new_array;
 }
 
@@ -1017,36 +1076,61 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::sort)
 // 23.2.3.28 %TypedArray%.prototype.subarray ( begin, end ), https://tc39.es/ecma262/#sec-%typedarray%.prototype.subarray
 JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::subarray)
 {
+    auto begin = vm.argument(0);
+    auto end = vm.argument(1);
+
+    // 1. Let O be the this value.
+    // 2. Perform ? RequireInternalSlot(O, [[TypedArrayName]]).
     auto* typed_array = TRY(typed_array_from_this(global_object));
 
-    auto length = typed_array->array_length();
+    // 3. Assert: O has a [[ViewedArrayBuffer]] internal slot.
+    // 4. Let buffer be O.[[ViewedArrayBuffer]].
+    auto* buffer = typed_array->viewed_array_buffer();
 
-    auto relative_begin = TRY(vm.argument(0).to_integer_or_infinity(global_object));
+    // 5. Let srcLength be O.[[ArrayLength]].
+    auto source_length = typed_array->array_length();
 
-    i32 begin_index;
+    // 6. Let relativeBegin be ? ToIntegerOrInfinity(begin).
+    auto relative_begin = TRY(begin.to_integer_or_infinity(global_object));
+
+    i32 begin_index = 0;
+
+    // 7. If relativeBegin is -∞, let beginIndex be 0.
     if (Value(relative_begin).is_negative_infinity())
         begin_index = 0;
+    // 8. Else if relativeBegin < 0, let beginIndex be max(srcLength + relativeBegin, 0).
     else if (relative_begin < 0)
-        begin_index = max(length + relative_begin, 0);
+        begin_index = max(source_length + relative_begin, 0);
+    // 9. Else, let beginIndex be min(relativeBegin, srcLength).
     else
-        begin_index = min(relative_begin, length);
+        begin_index = min(relative_begin, source_length);
 
-    double relative_end;
-    if (vm.argument(1).is_undefined())
-        relative_end = length;
+    double relative_end = 0;
+
+    // 10. If end is undefined, let relativeEnd be srcLength; else let relativeEnd be ? ToIntegerOrInfinity(end).
+    if (end.is_undefined())
+        relative_end = source_length;
     else
-        relative_end = TRY(vm.argument(1).to_integer_or_infinity(global_object));
+        relative_end = TRY(end.to_integer_or_infinity(global_object));
 
-    i32 end_index;
+    i32 end_index = 0;
+
+    // 11. If relativeEnd is -∞, let endIndex be 0.
     if (Value(relative_end).is_negative_infinity())
         end_index = 0;
+    // 12. Else if relativeEnd < 0, let endIndex be max(srcLength + relativeEnd, 0).
     else if (relative_end < 0)
-        end_index = max(length + relative_end, 0);
+        end_index = max(source_length + relative_end, 0);
+    // 13. Else, let endIndex be min(relativeEnd, srcLength).
     else
-        end_index = min(relative_end, length);
+        end_index = min(relative_end, source_length);
 
+    // 14. Let newLength be max(endIndex - beginIndex, 0).
     auto new_length = max(end_index - begin_index, 0);
 
+    // 15. Let elementSize be TypedArrayElementSize(O).
+    // 16. Let srcByteOffset be O.[[ByteOffset]].
+    // 17. Let beginByteOffset be srcByteOffset + beginIndex × elementSize.
     Checked<u32> begin_byte_offset = begin_index;
     begin_byte_offset *= typed_array->element_size();
     begin_byte_offset += typed_array->byte_offset();
@@ -1055,10 +1139,13 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::subarray)
         return typed_array;
     }
 
+    // 18. Let argumentsList be « buffer, 𝔽(beginByteOffset), 𝔽(newLength) ».
     MarkedVector<Value> arguments(vm.heap());
-    arguments.empend(typed_array->viewed_array_buffer());
+    arguments.empend(buffer);
     arguments.empend(begin_byte_offset.value());
     arguments.empend(new_length);
+
+    // 19. Return ? TypedArraySpeciesCreate(O, argumentsList).
     return TRY(typed_array_species_create(global_object, *typed_array, move(arguments)));
 }
 
@@ -1176,17 +1263,16 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
         if (buffer->is_detached())
             return vm.throw_completion<TypeError>(global_object, ErrorType::DetachedArrayBuffer);
 
-        // d. Let typedArrayName be the String value of O.[[TypedArrayName]].
-        // e. Let elementSize be the Element Size value specified in Table 64 for typedArrayName.
+        // d. Let elementSize be TypedArrayElementSize(O).
         auto element_size = typed_array->element_size();
 
-        // f. Let byteOffset be O.[[ByteOffset]].
+        // e. Let byteOffset be O.[[ByteOffset]].
         auto byte_offset = typed_array->byte_offset();
 
         // FIXME: Not exactly sure what we should do when overflow occurs.
         //        Just return as if succeeded for now. (This goes for steps g to j)
 
-        // g. Let toByteIndex be to × elementSize + byteOffset.
+        // f. Let toByteIndex be to × elementSize + byteOffset.
         Checked<size_t> to_byte_index_checked = static_cast<size_t>(to);
         to_byte_index_checked *= element_size;
         to_byte_index_checked += byte_offset;
@@ -1195,7 +1281,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
             return typed_array;
         }
 
-        // h. Let fromByteIndex be from × elementSize + byteOffset.
+        // g. Let fromByteIndex be from × elementSize + byteOffset.
         Checked<size_t> from_byte_index_checked = static_cast<size_t>(from);
         from_byte_index_checked *= element_size;
         from_byte_index_checked += byte_offset;
@@ -1204,7 +1290,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
             return typed_array;
         }
 
-        // i. Let countBytes be count × elementSize.
+        // h. Let countBytes be count × elementSize.
         Checked<size_t> count_bytes_checked = static_cast<size_t>(count);
         count_bytes_checked *= element_size;
         if (count_bytes_checked.has_overflow()) {
@@ -1225,7 +1311,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
 
         i8 direction;
 
-        // j. If fromByteIndex < toByteIndex and toByteIndex < fromByteIndex + countBytes, then
+        // i. If fromByteIndex < toByteIndex and toByteIndex < fromByteIndex + countBytes, then
         if (from_byte_index < to_byte_index && to_byte_index < from_plus_count.value()) {
             // i. Let direction be -1.
             direction = -1;
@@ -1242,13 +1328,14 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::copy_within)
 
             // iii. Set toByteIndex to toByteIndex + countBytes - 1.
             to_byte_index = to_plus_count.value() - 1;
-        } else {
-            // k. Else,
+        }
+        // j. Else,
+        else {
             // i. Let direction be 1.
             direction = 1;
         }
 
-        // l. Repeat, while countBytes > 0,
+        // k. Repeat, while countBytes > 0,
         for (; count_bytes > 0; --count_bytes) {
             // i. Let value be GetValueFromBuffer(buffer, fromByteIndex, Uint8, true, Unordered).
             auto value = buffer->get_value<u8>(from_byte_index, true, ArrayBuffer::Order::Unordered);

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -647,17 +647,17 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
 
     // 15. If targetOffset is +∞, throw a RangeError exception.
     if (isinf(target_offset))
-        return vm.throw_completion<RangeError>(global_object, "Invalid target offset");
+        return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayInvalidTargetOffset, "finite");
 
     // 16. If srcLength + targetOffset > targetLength, throw a RangeError exception.
     Checked<size_t> checked = source_length;
     checked += static_cast<u32>(target_offset);
     if (checked.has_overflow() || checked.value() > target_length)
-        return vm.throw_completion<RangeError>(global_object, "Overflow or out of bounds in target length");
+        return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayOverflowOrOutOfBounds, "target length");
 
     // 17. If target.[[ContentType]] ≠ source.[[ContentType]], throw a TypeError exception.
     if (target.content_type() != source.content_type())
-        return vm.throw_completion<TypeError>(global_object, "Copy between arrays of different content types is prohibited");
+        return vm.throw_completion<TypeError>(global_object, ErrorType::TypedArrayInvalidCopy, target.class_name(), source.class_name());
 
     // FIXME: 18. If both IsSharedArrayBuffer(srcBuffer) and IsSharedArrayBuffer(targetBuffer) are true, then
     // FIXME: a. If srcBuffer.[[ArrayBufferData]] and targetBuffer.[[ArrayBufferData]] are the same Shared Data Block values, let same be true; else let same be false.
@@ -688,7 +688,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
     checked_target_byte_index *= target_element_size;
     checked_target_byte_index += target_byte_offset;
     if (checked_target_byte_index.has_overflow())
-        return vm.throw_completion<RangeError>(global_object, "Overflow in target byte index");
+        return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayOverflow, "target byte index");
     auto target_byte_index = checked_target_byte_index.value();
 
     // 23. Let limit be targetByteIndex + targetElementSize × srcLength.
@@ -696,7 +696,7 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
     checked_limit *= target_element_size;
     checked_limit += target_byte_index;
     if (checked_limit.has_overflow())
-        return vm.throw_completion<RangeError>(global_object, "Overflow in target limit");
+        return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayOverflow, "target limit");
     auto limit = checked_limit.value();
 
     // 24. If srcType is the same as targetType, then
@@ -748,13 +748,13 @@ static ThrowCompletionOr<void> set_typed_array_from_array_like(GlobalObject& glo
 
     // 6. If targetOffset is +∞, throw a RangeError exception.
     if (isinf(target_offset))
-        return vm.throw_completion<RangeError>(global_object, "Invalid target offset");
+        return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayInvalidTargetOffset, "finite");
 
     // 7. If srcLength + targetOffset > targetLength, throw a RangeError exception.
     Checked<size_t> checked = source_length;
     checked += static_cast<u32>(target_offset);
     if (checked.has_overflow() || checked.value() > target_length)
-        return vm.throw_completion<RangeError>(global_object, "Overflow or out of bounds in target length");
+        return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayOverflowOrOutOfBounds, "target length");
 
     // 8. Let k be 0.
     size_t k = 0;
@@ -800,7 +800,7 @@ JS_DEFINE_NATIVE_FUNCTION(TypedArrayPrototype::set)
 
     // 5. If targetOffset < 0, throw a RangeError exception.
     if (target_offset < 0)
-        return vm.throw_completion<RangeError>(global_object, "Invalid target offset");
+        return vm.throw_completion<RangeError>(global_object, ErrorType::TypedArrayInvalidTargetOffset, "positive");
 
     // 6. If source is an Object that has a [[TypedArrayName]] internal slot, then
     if (source.is_object() && is<TypedArrayBase>(source.as_object())) {

--- a/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/TypedArrayPrototype.cpp
@@ -7,7 +7,6 @@
  */
 
 #include <LibJS/Runtime/AbstractOperations.h>
-#include <LibJS/Runtime/ArrayBufferConstructor.h>
 #include <LibJS/Runtime/ArrayIterator.h>
 #include <LibJS/Runtime/GlobalObject.h>
 #include <LibJS/Runtime/TypedArray.h>
@@ -670,11 +669,10 @@ static ThrowCompletionOr<void> set_typed_array_from_typed_array(GlobalObject& gl
         // a. Let srcByteLength be source.[[ByteLength]].
         auto source_byte_length = source.byte_length();
 
-        // b. Set srcBuffer to ? CloneArrayBuffer(srcBuffer, srcByteOffset, srcByteLength, %ArrayBuffer%).
-        source_buffer = TRY(clone_array_buffer(global_object, *source_buffer, source_byte_offset, source_byte_length, *global_object.array_buffer_constructor()));
-        // c. NOTE: %ArrayBuffer% is used to clone srcBuffer because is it known to not have any observable side-effects.
+        // b. Set srcBuffer to ? CloneArrayBuffer(srcBuffer, srcByteOffset, srcByteLength).
+        source_buffer = TRY(clone_array_buffer(global_object, *source_buffer, source_byte_offset, source_byte_length));
 
-        // d. Let srcByteIndex be 0.
+        // c. Let srcByteIndex be 0.
         source_byte_index = 0;
     }
     // 19. Else, let srcByteIndex be srcByteOffset.


### PR DESCRIPTION
This is a normative change in the ECMA-262 spec. But before implementing this change, this PR first implements an editorial change so that the TypedArray spec diffs make more sense.