### PR TITLE
LibConfig+ConfigServer: Write config values synchronously

### DIFF
--- a/Userland/Libraries/LibConfig/Client.cpp
+++ b/Userland/Libraries/LibConfig/Client.cpp
@@ -57,17 +57,17 @@ bool Client::read_bool(StringView domain, StringView group, StringView key, bool
 
 void Client::write_string(StringView domain, StringView group, StringView key, StringView value)
 {
-    async_write_string_value(domain, group, key, value);
+    write_string_value(domain, group, key, value);
 }
 
 void Client::write_i32(StringView domain, StringView group, StringView key, i32 value)
 {
-    async_write_i32_value(domain, group, key, value);
+    write_i32_value(domain, group, key, value);
 }
 
 void Client::write_bool(StringView domain, StringView group, StringView key, bool value)
 {
-    async_write_bool_value(domain, group, key, value);
+    write_bool_value(domain, group, key, value);
 }
 
 void Client::remove_key(StringView domain, StringView group, StringView key)

--- a/Userland/Services/ConfigServer/ConfigServer.ipc
+++ b/Userland/Services/ConfigServer/ConfigServer.ipc
@@ -11,8 +11,8 @@ endpoint ConfigServer
     read_i32_value(String domain, String group, String key) => (Optional<i32> value)
     read_bool_value(String domain, String group, String key) => (Optional<bool> value)
 
-    write_string_value(String domain, String group, String key, String value) =|
-    write_i32_value(String domain, String group, String key, i32 value) =|
-    write_bool_value(String domain, String group, String key, bool value)  =|
+    write_string_value(String domain, String group, String key, String value) => ()
+    write_i32_value(String domain, String group, String key, i32 value) => ()
+    write_bool_value(String domain, String group, String key, bool value)  => ()
     remove_key(String domain, String group, String key) =|
 }


### PR DESCRIPTION
This patch fixes the issue of pressing the ok button of a settings menu without saving the changes, or not reverting the changes when pressing the cancel button because the app has died before the new values make it to the other end.

For example before the fix, here I have in the terminal settings the opacity at 100%
![01](https://user-images.githubusercontent.com/19346060/163602246-413029a9-60ee-47d1-8a39-e6f98919426e.png)

Now I changed it to 10% 
![02](https://user-images.githubusercontent.com/19346060/163602370-6ffc64c1-c342-4f8a-a82e-80a9097b9227.png)

Then I pressed cancel
![03](https://user-images.githubusercontent.com/19346060/163602405-1dd1a367-3476-4eaa-8b7c-30ed768d4d2f.png)

But the change stayed because from my understanding the TerminalSetting app has died before the request for the old values has been delivered to the server, as the connection has been lost. 

This also fixes #13630
