### PR TITLE
LibJS: Add RegExp.$1...$9 static properties

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpConstructor.cpp
@@ -21,12 +21,49 @@ void RegExpConstructor::initialize(GlobalObject& global_object)
     auto& vm = this->vm();
     NativeFunction::initialize(global_object);
 
+    // FIXME: RegExp's realm needs to be considered before setting these properties.
+    [[maybe_unused]] auto* rm = this->realm();
+
     // 22.2.4.1 RegExp.prototype, https://tc39.es/ecma262/#sec-regexp.prototype
     define_direct_property(vm.names.prototype, global_object.regexp_prototype(), 0);
 
     define_native_accessor(*vm.well_known_symbol_species(), symbol_species_getter, {}, Attribute::Configurable);
 
     define_direct_property(vm.names.length, Value(2), Attribute::Configurable);
+
+    u8 attr = Attribute::Configurable | Attribute::Writable | Attribute::Enumerable;
+    // The initial value of all these internal slots is the empty String.
+
+    // RegExp.input [[Get]] && [[Set]]
+    define_direct_property("input", js_string(vm, ""), attr);
+    define_direct_property("$_", js_string(vm, ""), attr);
+
+    // RegExp.lastMatch [[Get]]
+    define_direct_property("lastMatch", js_string(vm, ""), attr);
+    define_direct_property("$&", js_string(vm, ""), attr);
+
+    // RegExp.lastParen [[Get]]
+    define_direct_property("lastParen", js_string(vm, ""), attr);
+    define_direct_property("$+", js_string(vm, ""), attr);
+
+    // RegExp.leftContext [[Get]]
+    define_direct_property("leftContext", js_string(vm, ""), attr);
+    define_direct_property("$`", js_string(vm, ""), attr);
+
+    // RegExp.rightContext [[Get]]
+    define_direct_property("rightContext", js_string(vm, ""), attr);
+    define_direct_property("$'", js_string(vm, ""), attr);
+
+    // RegExp.$1...$9 [[Get]]
+    define_direct_property("$1", js_string(vm, ""), attr);
+    define_direct_property("$2", js_string(vm, ""), attr);
+    define_direct_property("$3", js_string(vm, ""), attr);
+    define_direct_property("$4", js_string(vm, ""), attr);
+    define_direct_property("$5", js_string(vm, ""), attr);
+    define_direct_property("$6", js_string(vm, ""), attr);
+    define_direct_property("$7", js_string(vm, ""), attr);
+    define_direct_property("$8", js_string(vm, ""), attr);
+    define_direct_property("$9", js_string(vm, ""), attr);
 }
 
 // 22.2.3.1 RegExp ( pattern, flags ), https://tc39.es/ecma262/#sec-regexp-pattern-flags

--- a/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/RegExpPrototype.cpp
@@ -6,7 +6,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/Array.h>
 #include <AK/CharacterTypes.h>
+// #include <AK/FlyString.h>
 #include <AK/Function.h>
 #include <AK/Utf16View.h>
 #include <LibJS/Runtime/AbstractOperations.h>
@@ -20,6 +22,10 @@
 #include <LibJS/Runtime/StringPrototype.h>
 
 namespace JS {
+
+static constexpr AK::Array<StringView, 10> k_group_names = {
+    "", "$1", "$2", "$3", "$4", "$5", "$6", "$7", "$8", "$9"
+};
 
 RegExpPrototype::RegExpPrototype(GlobalObject& global_object)
     : PrototypeObject(*global_object.object_prototype())
@@ -295,6 +301,11 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(GlobalObject& global_object,
             captured_value = js_undefined();
             // ii. Append undefined to indices.
             indices.append({});
+
+            if (i >= 1 && i <= 9) {
+                // Set RegExp.$1 ... RegExp.$9
+                TRY(global_object.regexp_constructor()->set(k_group_names[i].characters_without_null_termination(), js_undefined(), Object::ShouldThrowExceptions::Yes));
+            }
         }
         // c. Else,
         else {
@@ -308,6 +319,11 @@ static ThrowCompletionOr<Value> regexp_builtin_exec(GlobalObject& global_object,
             captured_value = js_string(vm, capture.view.u16_view());
             // vi Append capture to indices.
             indices.append(Match::create(capture));
+
+            if (i >= 1 && i <= 9) {
+                // Set RegExp.$1 ... RegExp.$9
+                TRY(global_object.regexp_constructor()->set(k_group_names[i].characters_without_null_termination(), captured_value, Object::ShouldThrowExceptions::Yes));
+            }
         }
 
         // d. Perform ! CreateDataPropertyOrThrow(A, ! ToString(𝔽(i)), capturedValue).

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.exec.js
@@ -16,6 +16,7 @@ test("basic unnamed captures", () => {
     expect(res.length).toBe(2);
     expect(res[0]).toBe("fooooo");
     expect(res[1]).toBe("ooooo");
+    expect(RegExp.$1).toBe("ooooo");
     expect(res.groups).toBe(undefined);
     expect(res.index).toBe(0);
 
@@ -26,6 +27,8 @@ test("basic unnamed captures", () => {
     expect(res[0]).toBe("foo");
     expect(res[1]).toBe("foo");
     expect(res[2]).toBe(undefined);
+    expect(RegExp.$1).toBe("foo");
+    expect(RegExp.$2).toBe(undefined);
     expect(res.groups).toBe(undefined);
     expect(res.index).toBe(0);
 
@@ -36,6 +39,8 @@ test("basic unnamed captures", () => {
     expect(res[0]).toBe("bar");
     expect(res[1]).toBe(undefined);
     expect(res[2]).toBe("bar");
+    expect(RegExp.$1).toBe(undefined);
+    expect(RegExp.$2).toBe("bar");
     expect(res.groups).toBe(undefined);
     expect(res.index).toBe(0);
 });
@@ -48,6 +53,7 @@ test("basic named captures", () => {
     expect(res.index).toBe(0);
     expect(res[0]).toBe("fooooo");
     expect(res[1]).toBe("ooooo");
+    expect(RegExp.$1).toBe("ooooo");
     expect(res.groups).not.toBe(undefined);
     expect(res.groups.os).toBe("ooooo");
 });

--- a/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.test.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/RegExp/RegExp.prototype.test.js
@@ -92,6 +92,19 @@ test("override exec with non-function", () => {
     expect(re.test("test")).toBe(true);
 });
 
+test("basic unnamed captures", () => {
+    /f(o.*)/.test("fooooo");
+    expect(RegExp.$1).toBe("ooooo");
+
+    /(foo)(bar)?/.test("foo");
+    expect(RegExp.$1).toBe("foo");
+    expect(RegExp.$2).toBe(undefined);
+
+    /(foo)?(bar)/.test("bar");
+    expect(RegExp.$1).toBe(undefined);
+    expect(RegExp.$2).toBe("bar");
+});
+
 test("property escapes", () => {
     expect(/\p{ASCII}/.test("a")).toBeFalse();
     expect(/\p{ASCII}/.test("p{ASCII}")).toBeTrue();


### PR DESCRIPTION
When call `exec` and `test`, the captured group values will initialize RegExp.$1...$9
