### PR TITLE
LibCore: Allow inspecting any process launched with MAKE_INSPECTABLE=1

### DIFF
--- a/Base/usr/share/man/man1/Inspector.md
+++ b/Base/usr/share/man/man1/Inspector.md
@@ -18,7 +18,8 @@ $ Inspector [pid]
 
 Inspector facilitates process inspection via RPC.
 
-The inspected process must have previously allowed the
+To inspect a process, it must have `MAKE_INSPECTABLE=1` in its environment,
+and it must have previously allowed the
 [`accept`(2)](help://man/2/accept) system call with
 [`pledge`(2)](help://man/2/pledge) to allow inspection
 via UNIX socket.

--- a/Userland/Applets/ClipboardHistory/main.cpp
+++ b/Userland/Applets/ClipboardHistory/main.cpp
@@ -18,7 +18,7 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix"));
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("ClipboardHistory");
     Config::monitor_domain("ClipboardHistory");

--- a/Userland/Applets/ResourceGraph/main.cpp
+++ b/Userland/Applets/ResourceGraph/main.cpp
@@ -269,7 +269,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath unix"));
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath"));
 

--- a/Userland/Applications/3DFileViewer/main.cpp
+++ b/Userland/Applications/3DFileViewer/main.cpp
@@ -356,7 +356,7 @@ bool GLContextWidget::load_file(Core::File& file)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix prot_exec"));
 

--- a/Userland/Applications/Assistant/main.cpp
+++ b/Userland/Applications/Assistant/main.cpp
@@ -207,7 +207,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return 0;
     }
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
     auto window = GUI::Window::construct();
     window->set_minimizable(false);
 

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -67,7 +67,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(specified_url, "URL to open", "url", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("Browser");
     Config::monitor_domain("Browser");

--- a/Userland/Applications/KeyboardMapper/main.cpp
+++ b/Userland/Applications/KeyboardMapper/main.cpp
@@ -25,7 +25,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd unix"));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::pledge("stdio getkeymap thread rpath cpath wpath recvfd sendfd"));
 

--- a/Userland/Applications/Magnifier/main.cpp
+++ b/Userland/Applications/Magnifier/main.cpp
@@ -18,7 +18,7 @@
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd unix"));
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd"));
     TRY(Core::System::unveil("/res", "r"));

--- a/Userland/Applications/Mail/main.cpp
+++ b/Userland/Applications/Mail/main.cpp
@@ -20,7 +20,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath unix inet"));
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("Mail");
 

--- a/Userland/Applications/Piano/main.cpp
+++ b/Userland/Applications/Piano/main.cpp
@@ -29,7 +29,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio thread rpath cpath wpath recvfd sendfd unix"));
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     TrackManager track_manager;
 

--- a/Userland/Applications/PixelPaint/main.cpp
+++ b/Userland/Applications/PixelPaint/main.cpp
@@ -23,7 +23,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio thread recvfd sendfd rpath unix wpath cpath"));
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("PixelPaint");
 
     char const* image_file = nullptr;

--- a/Userland/Applications/SpaceAnalyzer/main.cpp
+++ b/Userland/Applications/SpaceAnalyzer/main.cpp
@@ -302,7 +302,7 @@ static String get_absolute_path_to_selected_node(SpaceAnalyzer::TreeMapWidget co
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     RefPtr<Tree> tree = adopt_ref(*new Tree(""));
 

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath fattr unix cpath wpath thread"));
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     char const* filename = nullptr;
 

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -331,7 +331,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio thread proc recvfd sendfd rpath exec unix"));
 
-    auto app = TRY(GUI::Application::try_create(arguments, Core::EventLoop::MakeInspectable::Yes));
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("SystemMonitor");
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -161,7 +161,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd thread rpath cpath wpath unix"));
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     char const* file_to_edit = nullptr;
 

--- a/Userland/DevTools/HackStudio/main.cpp
+++ b/Userland/DevTools/HackStudio/main.cpp
@@ -38,7 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd tty rpath cpath wpath proc exec unix fattr thread ptrace"));
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domains({ "HackStudio", "Terminal" });
 
     auto window = GUI::Window::construct();

--- a/Userland/Services/FileSystemAccessServer/main.cpp
+++ b/Userland/Services/FileSystemAccessServer/main.cpp
@@ -14,7 +14,7 @@ ErrorOr<int> serenity_main(Main::Arguments)
 {
     TRY(Core::System::pledge("stdio recvfd sendfd rpath cpath wpath unix thread"));
 
-    auto app = GUI::Application::construct(0, nullptr);
+    auto app = TRY(GUI::Application::try_create(0, nullptr));
     app->set_quit_when_last_window_deleted(false);
 
     auto client = TRY(IPC::take_over_accepted_client_from_system_server<FileSystemAccessServer::ConnectionFromClient>());

--- a/Userland/Services/LoginServer/main.cpp
+++ b/Userland/Services/LoginServer/main.cpp
@@ -54,7 +54,7 @@ static void login(Core::Account const& account, LoginWindow& window)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     TRY(Core::System::pledge("stdio recvfd sendfd rpath exec proc id"));
     TRY(Core::System::unveil("/home", "r"));

--- a/Userland/Utilities/chres.cpp
+++ b/Userland/Utilities/chres.cpp
@@ -26,7 +26,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     // A Core::EventLoop is all we need, but ConnectionToWindowServer needs a full Application object.
     char* dummy_argv[] = { arguments.argv[0] };
-    auto app = GUI::Application::construct(1, dummy_argv);
+    auto app = TRY(GUI::Application::try_create(1, dummy_argv));
     auto screen_layout = GUI::ConnectionToWindowServer::the().get_screen_layout();
     if (screen < 0 || (size_t)screen >= screen_layout.screens.size()) {
         warnln("invalid screen index: {}", screen);

--- a/Userland/Utilities/copy.cpp
+++ b/Userland/Utilities/copy.cpp
@@ -64,7 +64,7 @@ static Options parse_options(Main::Arguments arguments)
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     Options options = parse_options(arguments);
 

--- a/Userland/Utilities/pape.cpp
+++ b/Userland/Utilities/pape.cpp
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(path, "Wallpaper to set", "path", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     if (show_all) {
         Core::DirIterator wallpapers_directory_iterator("/res/wallpapers", Core::DirIterator::SkipDots);

--- a/Userland/Utilities/paste.cpp
+++ b/Userland/Utilities/paste.cpp
@@ -62,7 +62,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_positional_argument(watch_command, "Command to run in watch mode", "command", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     auto& clipboard = GUI::Clipboard::the();
 

--- a/Userland/Utilities/shot.cpp
+++ b/Userland/Utilities/shot.cpp
@@ -109,7 +109,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         output_path = Core::DateTime::now().to_string("screenshot-%Y-%m-%d-%H-%M-%S.png");
     }
 
-    auto app = GUI::Application::construct(arguments.argc, arguments.argv);
+    auto app = TRY(GUI::Application::try_create(arguments));
     Optional<Gfx::IntRect> crop_region;
     if (select_region) {
         auto window = GUI::Window::construct();

--- a/Userland/Utilities/wsctl.cpp
+++ b/Userland/Utilities/wsctl.cpp
@@ -10,7 +10,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    auto app = GUI::Application::construct(arguments);
+    auto app = TRY(GUI::Application::try_create(arguments));
 
     int flash_flush = -1;
     Core::ArgsParser args_parser;


### PR DESCRIPTION
...plus some related tweaking, because I can't help myself.

Now, if you want to inspect something, run it like this:
```
env MAKE_INSPECTABLE=1 FileManager
```

The `MakeInspectable` argument to the Application and EventLoop constructors is still here, since I thought that could still be useful. If either the env var is set, OR the argument is set to `MakeInspectable::Yes`, then the process will be inspectable.

I also bumped into #10638 repeatedly but couldn't figure it out.