### PR TITLE
netstat+arp: Add hostname resolution and expand outputting format

### DIFF
--- a/Base/usr/share/man/man1/netstat.md
+++ b/Base/usr/share/man/man1/netstat.md
@@ -5,7 +5,7 @@ netstat
 ## Synopsis
 
 ```sh
-$ netstat [--all] [--list] [--tcp] [--udp] [--numeric] [--program]
+$ netstat [--all] [--list] [--tcp] [--udp] [--numeric] [--program] [--wide]
 ```
 
 ## Description
@@ -20,5 +20,6 @@ Display network connections
 * `-u`, `--udp`: Display only UDP network connections
 * `-n`, `--numeric`: Display numerical addresses
 * `-p`, `--program`: Show the PID and name of the program to which each socket belongs
+* `-W`, `--wide`: Do not truncate IP addresses by printing out the whole symbolic host
 
 <!-- Auto-generated through ArgsParser -->

--- a/Userland/Utilities/netstat.cpp
+++ b/Userland/Utilities/netstat.cpp
@@ -19,6 +19,8 @@
 #include <netdb.h>
 #include <unistd.h>
 
+constexpr int max_formatted_address_length = 21;
+
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath unix"));
@@ -35,6 +37,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool flag_udp = false;
     bool flag_numeric = false;
     bool flag_program = false;
+    bool flag_wide = false;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Display network connections");
@@ -44,6 +47,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     args_parser.add_option(flag_udp, "Display only UDP network connections", "udp", 'u');
     args_parser.add_option(flag_numeric, "Display numerical addresses", "numeric", 'n');
     args_parser.add_option(flag_program, "Show the PID and name of the program to which each socket belongs", "program", 'p');
+    args_parser.add_option(flag_wide, "Do not truncate IP addresses by printing out the whole symbolic host", "wide", 'W');
     args_parser.parse(arguments);
 
     bool has_protocol_flag = (flag_tcp || flag_udp);
@@ -92,8 +96,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     protocol_column = add_column("Proto", Alignment::Left, 5);
     bytes_in_column = add_column("Bytes-In", Alignment::Right, 9);
     bytes_out_column = add_column("Bytes-Out", Alignment::Right, 9);
-    local_address_column = add_column("Local Address", Alignment::Left, 20);
-    peer_address_column = add_column("Peer Address", Alignment::Left, 20);
+    local_address_column = add_column("Local Address", Alignment::Left, 22);
+    peer_address_column = add_column("Peer Address", Alignment::Left, 22);
     state_column = add_column("State", Alignment::Left, 11);
     program_column = flag_program ? add_column("PID/Program", Alignment::Left, 11) : -1;
 
@@ -107,6 +111,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         } else {
             out("{:<{1}}  "sv, string, column.width);
         }
+    };
+
+    auto get_formatted_address = [&](String const& address, String const& port) {
+        if (flag_wide)
+            return String::formatted("{}:{}", address, port);
+
+        if ((address.length() + port.length()) <= max_formatted_address_length)
+            return String::formatted("{}:{}", address, port);
+
+        return String::formatted("{}:{}", address.substring_view(0, max_formatted_address_length - port.length()), port);
     };
 
     auto get_formatted_program = [&](pid_t pid) {
@@ -185,7 +199,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                         peer_port = s_name;
                 }
             }
-            auto formatted_peer_address = String::formatted("{}:{}", peer_address, peer_port);
 
             auto local_address = if_object.get("local_address").to_string();
             if (!flag_numeric) {
@@ -208,7 +221,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
                         local_port = s_name;
                 }
             }
-            auto formatted_local_address = String::formatted("{}:{}", local_address, local_port);
 
             auto state = if_object.get("state").to_string();
             auto origin_pid = (if_object.has("origin_pid")) ? if_object.get("origin_pid").to_u32() : -1;
@@ -223,9 +235,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (bytes_out_column != -1)
                 columns[bytes_out_column].buffer = bytes_out;
             if (local_address_column != -1)
-                columns[local_address_column].buffer = formatted_local_address;
+                columns[local_address_column].buffer = get_formatted_address(local_address, local_port);
             if (peer_address_column != -1)
-                columns[peer_address_column].buffer = formatted_peer_address;
+                columns[peer_address_column].buffer = get_formatted_address(peer_address, peer_port);
             if (state_column != -1)
                 columns[state_column].buffer = state;
             if (flag_program && program_column != -1)
@@ -303,9 +315,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             if (bytes_out_column != -1)
                 columns[bytes_out_column].buffer = "-";
             if (local_address_column != -1)
-                columns[local_address_column].buffer = String::formatted("{}:{}", local_address, local_port);
+                columns[local_address_column].buffer = get_formatted_address(local_address, local_port);
             if (peer_address_column != -1)
-                columns[peer_address_column].buffer = String::formatted("{}:{}", peer_address, peer_port);
+                columns[peer_address_column].buffer = get_formatted_address(peer_address, peer_port);
             if (state_column != -1)
                 columns[state_column].buffer = "-";
             if (flag_program && program_column != -1)

--- a/Userland/Utilities/netstat.cpp
+++ b/Userland/Utilities/netstat.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <AK/HashMap.h>
+#include <AK/IPv4Address.h>
 #include <AK/JsonArray.h>
 #include <AK/JsonObject.h>
 #include <AK/QuickSort.h>
@@ -20,11 +21,12 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio rpath"));
+    TRY(Core::System::pledge("stdio rpath unix"));
     TRY(Core::System::unveil("/proc/net", "r"));
     TRY(Core::System::unveil("/proc/all", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/services", "r"));
+    TRY(Core::System::unveil("/tmp/portal/lookup", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
     bool flag_all = false;
@@ -161,7 +163,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
             auto bytes_in = if_object.get("bytes_in").to_string();
             auto bytes_out = if_object.get("bytes_out").to_string();
+
             auto peer_address = if_object.get("peer_address").to_string();
+            if (!flag_numeric) {
+                auto from_string = IPv4Address::from_string(peer_address);
+                auto addr = from_string.value().to_in_addr_t();
+                auto* hostent = gethostbyaddr(&addr, sizeof(in_addr), AF_INET);
+                if (hostent != nullptr) {
+                    auto host_name = StringView(hostent->h_name);
+                    if (!host_name.is_empty())
+                        peer_address = host_name;
+                }
+            }
 
             auto peer_port = if_object.get("peer_port").to_string();
             if (!flag_numeric) {
@@ -175,6 +188,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto formatted_peer_address = String::formatted("{}:{}", peer_address, peer_port);
 
             auto local_address = if_object.get("local_address").to_string();
+            if (!flag_numeric) {
+                auto from_string = IPv4Address::from_string(local_address);
+                auto addr = from_string.value().to_in_addr_t();
+                auto* hostent = gethostbyaddr(&addr, sizeof(in_addr), AF_INET);
+                if (hostent != nullptr) {
+                    auto host_name = StringView(hostent->h_name);
+                    if (!host_name.is_empty())
+                        local_address = host_name;
+                }
+            }
 
             auto local_port = if_object.get("local_port").to_string();
             if (!flag_numeric) {
@@ -228,6 +251,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto& if_object = value.as_object();
 
             auto local_address = if_object.get("local_address").to_string();
+            if (!flag_numeric) {
+                auto from_string = IPv4Address::from_string(local_address);
+                auto addr = from_string.value().to_in_addr_t();
+                auto* hostent = gethostbyaddr(&addr, sizeof(in_addr), AF_INET);
+                if (hostent != nullptr) {
+                    auto host_name = StringView(hostent->h_name);
+                    if (!host_name.is_empty())
+                        local_address = host_name;
+                }
+            }
 
             auto local_port = if_object.get("local_port").to_string();
             if (!flag_numeric) {
@@ -240,6 +273,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             }
 
             auto peer_address = if_object.get("peer_address").to_string();
+            if (!flag_numeric) {
+                auto from_string = IPv4Address::from_string(peer_address);
+                auto addr = from_string.value().to_in_addr_t();
+                auto* hostent = gethostbyaddr(&addr, sizeof(in_addr), AF_INET);
+                if (hostent != nullptr) {
+                    auto host_name = StringView(hostent->h_name);
+                    if (!host_name.is_empty())
+                        peer_address = host_name;
+                }
+            }
 
             auto peer_port = if_object.get("peer_port").to_string();
             if (!flag_numeric) {


### PR DESCRIPTION
**arp: Add hostname resolution**

**netstat: Add hostname resolution**

**netstat: Add the wide flag option**
Previously netstat would print the whole line of an ip address or
resolved hostname. If the hostname was longer than the address column
length, it would push following columns into disaligned output.

This sets the default behavior to truncate any IP address or symbolic
hostname that is larger than the maximum address column size to provide
cleaner output. In the event the user wishes to see the whole address
name, they can then pass the wide option that will output as wide as
necessary to print the whole name.

![serenity_netstat](https://user-images.githubusercontent.com/54456386/163690562-e10f76b6-257f-4020-b91b-d109f77901ab.png)

