### PR TITLE
HexEditor: Show endianness in the value inspector

### DIFF
--- a/Userland/Applications/HexEditor/HexEditorWidget.cpp
+++ b/Userland/Applications/HexEditor/HexEditorWidget.cpp
@@ -275,7 +275,7 @@ void HexEditorWidget::update_inspector_values(size_t position)
     }
 
     // Populate the model
-    NonnullRefPtr<ValueInspectorModel> value_inspector_model = make_ref_counted<ValueInspectorModel>();
+    NonnullRefPtr<ValueInspectorModel> value_inspector_model = make_ref_counted<ValueInspectorModel>(m_value_inspector_little_endian);
     if (byte_read_count >= 1) {
         u8 unsigned_byte_value = 0;
         if (m_value_inspector_little_endian)

--- a/Userland/Applications/HexEditor/ValueInspectorModel.h
+++ b/Userland/Applications/HexEditor/ValueInspectorModel.h
@@ -34,7 +34,8 @@ public:
         Value
     };
 
-    explicit ValueInspectorModel()
+    explicit ValueInspectorModel(bool is_little_endian)
+        : m_is_little_endian(is_little_endian)
     {
         for (int i = 0; i < ValueType::__Count; i++)
             set_parsed_value(static_cast<ValueType>(i), "");
@@ -61,7 +62,7 @@ public:
         case Column::Type:
             return "Type";
         case Column::Value:
-            return "Value";
+            return m_is_little_endian ? "Value (Little Endian)" : "Value (Big Endian)";
         }
         VERIFY_NOT_REACHED();
     }
@@ -131,5 +132,6 @@ public:
     }
 
 private:
+    bool m_is_little_endian = false;
     Array<String, ValueType::__Count> m_values = {};
 };


### PR DESCRIPTION
Resolves #13653. The Value Inspector now specifies whether values are interpreted as little endian or big endian in a column header. 