### PR TITLE
LibGfx: Fix bounds overflow in JPGLoader

### DIFF
--- a/Userland/Libraries/LibGfx/JPGLoader.cpp
+++ b/Userland/Libraries/LibGfx/JPGLoader.cpp
@@ -420,6 +420,8 @@ static Optional<Vector<Macroblock>> decode_huffman_stream(JPGLoadingContext& con
 
 static inline bool bounds_okay(const size_t cursor, const size_t delta, const size_t bound)
 {
+    if (Checked<size_t>::addition_would_overflow(delta, cursor))
+        return false;
     return (delta + cursor) < bound;
 }
 


### PR DESCRIPTION
Taotao Gu has been fuzzing serenity libs with their custom fuzzer.
They reported some issues it found privately, this overflow was found
in the JPGLoader using that fuzzer.

Reported-by: Taotao Gu <gutaotao1995@qq.com>