### PR TITLE
mkfifo: Add support for setting permissions with -m

### DIFF
--- a/Userland/Utilities/mkfifo.cpp
+++ b/Userland/Utilities/mkfifo.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <LibCore/ArgsParser.h>
+#include <LibCore/FilePermissionsMask.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
 #include <sys/stat.h>
@@ -13,13 +14,20 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio dpath"));
 
+    String mode_string;
+    mode_t mask_reference_mode = 0777;
     mode_t mode = 0666;
     Vector<StringView> paths;
 
     Core::ArgsParser args_parser;
-    // FIXME: add -m for file modes
+    args_parser.add_option(mode_string, "Set FIFO permissions", "mode", 'm', "mode");
     args_parser.add_positional_argument(paths, "Paths of FIFOs to create", "paths");
     args_parser.parse(arguments);
+
+    if (!mode_string.is_empty()) {
+        auto mask = TRY(Core::FilePermissionsMask::parse(mode_string));
+        mode = mask.apply(mask_reference_mode);
+    }
 
     int exit_code = 0;
     for (auto path : paths) {


### PR DESCRIPTION
This is modeled after the implementation in Mkdir.