### PR TITLE
LibWeb: Dont abort when parsing data- properties that contain dashes

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
+++ b/Userland/Libraries/LibWeb/HTML/DOMStringMap.cpp
@@ -52,7 +52,7 @@ Vector<DOMStringMap::NameValuePair> DOMStringMap::get_name_value_pairs() const
                     // Skip the next character
                     ++character_index;
 
-                    return;
+                    continue;
                 }
             }
 


### PR DESCRIPTION
This allows us to parse properties like `asset-url`, when before it would just be ignored