### PR TITLE
LibWeb: Tighten-up parsing of transform functions

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/CMakeLists.txt
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES "") # avoid pulling SOURCES from parent scope
 lagom_tool(GenerateCSSEnums                SOURCES GenerateCSSEnums.cpp LIBS LagomMain)
 lagom_tool(GenerateCSSMediaFeatureID       SOURCES GenerateCSSMediaFeatureID.cpp LIBS LagomMain)
 lagom_tool(GenerateCSSPropertyID           SOURCES GenerateCSSPropertyID.cpp LIBS LagomMain)
+lagom_tool(GenerateCSSTransformFunctions   SOURCES GenerateCSSTransformFunctions.cpp LIBS LagomMain)
 lagom_tool(GenerateCSSValueID              SOURCES GenerateCSSValueID.cpp LIBS LagomMain)
 
 add_subdirectory(WrapperGenerator)

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSTransformFunctions.cpp
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2022, Sam Atkins <atkinssj@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "GeneratorUtil.h"
+#include <AK/SourceGenerator.h>
+#include <AK/StringBuilder.h>
+#include <LibCore/ArgsParser.h>
+#include <LibMain/Main.h>
+
+ErrorOr<void> generate_header_file(JsonObject& transforms_data, Core::Stream::File& file);
+ErrorOr<void> generate_implementation_file(JsonObject& transforms_data, Core::Stream::File& file);
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    StringView generated_header_path;
+    StringView generated_implementation_path;
+    StringView identifiers_json_path;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_option(generated_header_path, "Path to the TransformFunctions header file to generate", "generated-header-path", 'h', "generated-header-path");
+    args_parser.add_option(generated_implementation_path, "Path to the TransformFunctions implementation file to generate", "generated-implementation-path", 'c', "generated-implementation-path");
+    args_parser.add_option(identifiers_json_path, "Path to the JSON file to read from", "json-path", 'j', "json-path");
+    args_parser.parse(arguments);
+
+    auto json = TRY(read_entire_file_as_json(identifiers_json_path));
+    VERIFY(json.is_object());
+    auto transforms_data = json.as_object();
+
+    auto generated_header_file = TRY(Core::Stream::File::open(generated_header_path, Core::Stream::OpenMode::Write));
+    auto generated_implementation_file = TRY(Core::Stream::File::open(generated_implementation_path, Core::Stream::OpenMode::Write));
+
+    TRY(generate_header_file(transforms_data, *generated_header_file));
+    TRY(generate_implementation_file(transforms_data, *generated_implementation_file));
+
+    return 0;
+}
+
+static String title_casify_transform_function(StringView input)
+{
+    // Transform function names look like `fooBar`, so we just have to make the first character uppercase.
+    StringBuilder builder;
+    builder.append(toupper(input[0]));
+    builder.append(input.substring_view(1));
+    return builder.to_string();
+}
+
+ErrorOr<void> generate_header_file(JsonObject& transforms_data, Core::Stream::File& file)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.append(R"~~~(
+namespace Web::CSS {
+
+)~~~");
+
+    generator.appendln("enum class TransformFunction {");
+    transforms_data.for_each_member([&](auto& name, auto&) {
+        auto member_generator = generator.fork();
+        member_generator.set("name:titlecase", title_casify_transform_function(name));
+        member_generator.appendln("    @name:titlecase@,");
+    });
+    generator.appendln("};");
+
+    generator.appendln("\n}");
+
+    TRY(file.write(generator.as_string_view().bytes()));
+    return {};
+}
+
+ErrorOr<void> generate_implementation_file(JsonObject& transforms_data, Core::Stream::File& file)
+{
+    StringBuilder builder;
+    SourceGenerator generator { builder };
+
+    generator.append(R"~~~(
+namespace Web::CSS {
+)~~~");
+
+    transforms_data.for_each_member([&](auto& name, auto& value) {
+        (void)name;
+        (void)value;
+    });
+
+    generator.appendln("}");
+
+    TRY(file.write(generator.as_string_view().bytes()));
+    return {};
+}

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -74,6 +74,7 @@ set(SOURCES
     CSS/Supports.cpp
     CSS/SyntaxHighlighter/SyntaxHighlighter.cpp
     CSS/Time.cpp
+    CSS/TransformFunctions.cpp
     CSS/ValueID.cpp
     CSS/ValueID.h
     Cookie/ParsedCookie.cpp
@@ -645,6 +646,16 @@ invoke_generator(
     "CSS/PropertyID.h"
     "CSS/PropertyID.cpp"
     arguments -j "${CMAKE_CURRENT_SOURCE_DIR}/CSS/Properties.json"
+)
+
+invoke_generator(
+    "TransformFunctions"
+    Lagom::GenerateCSSTransformFunctions
+    "${CMAKE_CURRENT_SOURCE_DIR}/CSS/TransformFunctions.json"
+    ""
+    "CSS/TransformFunctions.h"
+    "CSS/TransformFunctions.cpp"
+    arguments -j "${CMAKE_CURRENT_SOURCE_DIR}/CSS/TransformFunctions.json"
 )
 
 invoke_generator(

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4772,12 +4772,18 @@ RefPtr<StyleValue> Parser::parse_text_decoration_line_value(TokenStream<Componen
 RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& component_values)
 {
     NonnullRefPtrVector<StyleValue> transformations;
+    auto tokens = TokenStream { component_values };
+    tokens.skip_whitespace();
 
-    for (auto& part : component_values) {
-        if (part.is(Token::Type::Whitespace))
-            continue;
+    while (tokens.has_next_token()) {
+        tokens.skip_whitespace();
+        auto& part = tokens.next_token();
+
         if (part.is(Token::Type::Ident) && part.token().ident().equals_ignoring_case("none")) {
             if (!transformations.is_empty())
+                return nullptr;
+            tokens.skip_whitespace();
+            if (tokens.has_next_token())
                 return nullptr;
             return IdentifierStyleValue::create(ValueID::None);
         }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -4769,33 +4769,6 @@ RefPtr<StyleValue> Parser::parse_text_decoration_line_value(TokenStream<Componen
     return StyleValueList::create(move(style_values), StyleValueList::Separator::Space);
 }
 
-static Optional<CSS::TransformFunction> parse_transform_function_name(StringView name)
-{
-    if (name == "matrix")
-        return CSS::TransformFunction::Matrix;
-    if (name == "translate")
-        return CSS::TransformFunction::Translate;
-    if (name == "translateX")
-        return CSS::TransformFunction::TranslateX;
-    if (name == "translateY")
-        return CSS::TransformFunction::TranslateY;
-    if (name == "scale")
-        return CSS::TransformFunction::Scale;
-    if (name == "scaleX")
-        return CSS::TransformFunction::ScaleX;
-    if (name == "scaleY")
-        return CSS::TransformFunction::ScaleY;
-    if (name == "rotate")
-        return CSS::TransformFunction::Rotate;
-    if (name == "skew")
-        return CSS::TransformFunction::Skew;
-    if (name == "skewX")
-        return CSS::TransformFunction::SkewX;
-    if (name == "skewY")
-        return CSS::TransformFunction::SkewY;
-    return {};
-}
-
 RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& component_values)
 {
     NonnullRefPtrVector<StyleValue> transformations;
@@ -4811,7 +4784,7 @@ RefPtr<StyleValue> Parser::parse_transform_value(Vector<ComponentValue> const& c
 
         if (!part.is_function())
             return nullptr;
-        auto maybe_function = parse_transform_function_name(part.function().name());
+        auto maybe_function = transform_function_from_string(part.function().name());
         if (!maybe_function.has_value())
             return nullptr;
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.cpp
@@ -1315,45 +1315,7 @@ String TextDecorationStyleValue::to_string() const
 String TransformationStyleValue::to_string() const
 {
     StringBuilder builder;
-
-    switch (m_transform_function) {
-    case TransformFunction::Matrix:
-        builder.append("matrix");
-        break;
-    case TransformFunction::Translate:
-        builder.append("translate");
-        break;
-    case TransformFunction::TranslateX:
-        builder.append("translateX");
-        break;
-    case TransformFunction::TranslateY:
-        builder.append("translateY");
-        break;
-    case TransformFunction::Scale:
-        builder.append("scale");
-        break;
-    case TransformFunction::ScaleX:
-        builder.append("scaleX");
-        break;
-    case TransformFunction::ScaleY:
-        builder.append("scaleY");
-        break;
-    case TransformFunction::Rotate:
-        builder.append("rotate");
-        break;
-    case TransformFunction::Skew:
-        builder.append("skew");
-        break;
-    case TransformFunction::SkewX:
-        builder.append("skewX");
-        break;
-    case TransformFunction::SkewY:
-        builder.append("skewY");
-        break;
-    default:
-        VERIFY_NOT_REACHED();
-    }
-
+    builder.append(CSS::to_string(m_transform_function));
     builder.append('(');
     builder.join(", ", m_values);
     builder.append(')');

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -34,6 +34,7 @@
 #include <LibWeb/CSS/PropertyID.h>
 #include <LibWeb/CSS/Resolution.h>
 #include <LibWeb/CSS/Time.h>
+#include <LibWeb/CSS/TransformFunctions.h>
 #include <LibWeb/CSS/ValueID.h>
 #include <LibWeb/Forward.h>
 #include <LibWeb/Loader/ImageResource.h>
@@ -71,20 +72,6 @@ inline Gfx::Painter::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_val
     }
     VERIFY_NOT_REACHED();
 }
-
-enum class TransformFunction {
-    Matrix,
-    Translate,
-    TranslateX,
-    TranslateY,
-    Scale,
-    ScaleX,
-    ScaleY,
-    Rotate,
-    Skew,
-    SkewX,
-    SkewY,
-};
 
 class StyleValue : public RefCounted<StyleValue> {
 public:

--- a/Userland/Libraries/LibWeb/CSS/TransformFunctions.json
+++ b/Userland/Libraries/LibWeb/CSS/TransformFunctions.json
@@ -1,0 +1,35 @@
+{
+    "matrix": {
+        "parameters": "<number>{6}"
+    },
+    "translate": {
+        "parameters": "<length-percentage>{1,2}"
+    },
+    "translateX": {
+        "parameters": "<length-percentage>"
+    },
+    "translateY": {
+        "parameters": "<length-percentage>"
+    },
+    "scale": {
+        "parameters": "<number>{1,2}"
+    },
+    "scaleX": {
+        "parameters": "<number>"
+    },
+    "scaleY": {
+        "parameters": "<number>"
+    },
+    "rotate": {
+        "parameters": "<angle>"
+    },
+    "skew": {
+        "parameters": "<angle>{1,2}"
+    },
+    "skewX": {
+        "parameters": "<angle>"
+    },
+    "skewY": {
+        "parameters": "<angle>"
+    }
+}


### PR DESCRIPTION
Previously, the parsing of functions in the `transform` property was very forgiving - you could pass any number and combination of percentages, lengths, angles and numbers to any function and it would accept that. This PR makes the parser correctly reject invalid types or numbers of arguments, using a new code generator. Then I fixed up a few other issues I saw there.

There's a lot less payoff here than the enums code generator, but I like generating code. :sweat_smile: