### PR TITLE
Spreadsheet: Sort functions by name in the help window

### DIFF
--- a/Userland/Applications/Spreadsheet/HelpWindow.cpp
+++ b/Userland/Applications/Spreadsheet/HelpWindow.cpp
@@ -7,6 +7,7 @@
 #include "HelpWindow.h"
 #include "SpreadsheetWidget.h"
 #include <AK/LexicalPath.h>
+#include <AK/QuickSort.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Frame.h>
 #include <LibGUI/ListView.h>
@@ -45,6 +46,7 @@ public:
         object.for_each_member([this](auto& name, auto&) {
             m_keys.append(name);
         });
+        AK::quick_sort(m_keys);
         invalidate();
     }
 


### PR DESCRIPTION
I noticed there was no clear organization in the Spreadsheet Functions Help window. Closely related functions like `min` and `minIf` wouldn't appear next to each other, so it was difficult to see at a glance which functions were supported. This PR sorts the functions in alphabetical order.