### PR TITLE
Ports: Exclude non-working utilities from the coreutils installation

### DIFF
--- a/Ports/coreutils/package.sh
+++ b/Ports/coreutils/package.sh
@@ -9,3 +9,11 @@ https://ftpmirror.gnu.org/gnu/coreutils/coreutils-${version}.tar.gz.sig coreutil
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"
 auth_type="sig"
 auth_opts=("--keyring" "./gnu-keyring.gpg" "coreutils-${version}.tar.gz.sig")
+
+# Exclude some non-working utilities:
+#  - arch, coreutils, and hostname are already excluded in the default configuration
+#  - chcon and runcon are SELinux utilities
+#  - df requires one of the read_file_system_list implementations in gnulib/lib/mountlist.c
+#  - pinky, users, and who require utmp
+#  - nice is just something that doesn't exist
+configopts+=("--enable-no-install-program=arch,coreutils,hostname,chcon,runcon,df,pinky,users,who,nice")


### PR DESCRIPTION
I didn't intend for coreutils to actually be used productively, but if someone does, now they will at least not find any utilities that are immediately obvious to be broken.

Fixes #13690.