### PR TITLE
CrashReporter: Fix "Save Backtrace" button

### DIFF
--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -91,6 +91,7 @@
         @GUI::Button {
             name: "save_backtrace_button"
             text: "Save Backtrace"
+            fixed_width: 150
         }
 
         // HACK: We need something like Layout::add_spacer() in GML! :^)

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -284,13 +284,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         LexicalPath lexical_path(String::formatted("{}_{}_backtrace.txt", pid, app_name));
         auto file_or_error = FileSystemAccessClient::Client::the().try_save_file(window, lexical_path.title(), lexical_path.extension());
-        if (file_or_error.is_error()) {
-            GUI::MessageBox::show(window, String::formatted("Couldn't save file: {}.", file_or_error.error()), "Saving backtrace failed", GUI::MessageBox::Type::Error);
+        if (file_or_error.is_error())
             return;
-        }
 
         auto file = file_or_error.value();
-        file->write(full_backtrace.to_string());
+        if (!file->write(full_backtrace.to_string()))
+            GUI::MessageBox::show(window, String::formatted("Couldn't save file: {}.", file_or_error.error()), "Saving backtrace failed", GUI::MessageBox::Type::Error);
     };
 
     (void)Threading::BackgroundAction<ThreadBacktracesAndCpuRegisters>::construct(


### PR DESCRIPTION
This PR solves two issues with the Save Backtrace button in CrashReporter:

- Inconsistent size of the button when resizing the window
- Display of an error when the action is properly cancelled

Before: 

https://user-images.githubusercontent.com/26030965/164197273-94911288-d87a-44cb-956d-aa6443f7aac6.mp4

After:

https://user-images.githubusercontent.com/26030965/164197489-544ae618-05cc-4bae-a95c-51e3e6c362f0.mp4

