### PR TITLE
Base: Spawn the LookupServer for generate-manpages SystemMode

### DIFF
--- a/Base/etc/SystemServer.ini
+++ b/Base/etc/SystemServer.ini
@@ -57,7 +57,7 @@ SocketPermissions=660
 Priority=low
 KeepAlive=true
 User=lookup
-SystemModes=text,graphical,self-test
+SystemModes=text,graphical,self-test,generate-manpages
 
 [DHCPClient]
 Priority=low


### PR DESCRIPTION
Previously the CI would hang on the "Check manpages for completeness"
step on any utility that unveils the /tmp/portal/lookup file because
it was not created during the generate-manpages SystemMode.

This will allow utilities that resolve hostnames (e.g. netstat, arp) to
pass the export-argsparser-mangpages.sh check.