### PR TITLE
Ports: Fix build issues with libiconv and mpc on Clang

### DIFF
--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -8,6 +8,6 @@ auth_type="sha256"
 
 install() {
     run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    run ${SERENITY_ARCH}-pc-serenity-gcc -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.so -Wl,-soname,libiconv.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.a -Wl,--no-whole-archive
+    run ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.so -Wl,-soname,libiconv.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.a -Wl,--no-whole-archive
     rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.la
 }

--- a/Ports/mpc/package.sh
+++ b/Ports/mpc/package.sh
@@ -4,7 +4,7 @@ version=1.2.1
 useconfigure=true
 use_fresh_config_sub=true
 config_sub_path=build-aux/config.sub
-configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--with-sysroot=/")
+configopts=("--target=${SERENITY_ARCH}-pc-serenity" "--with-sysroot=${SERENITY_INSTALL_ROOT}")
 files="https://ftpmirror.gnu.org/gnu/mpc/mpc-${version}.tar.gz mpc-${version}.tar.gz
 https://ftpmirror.gnu.org/gnu/mpc/mpc-${version}.tar.gz.sig mpc-${version}.tar.gz.sig
 https://ftpmirror.gnu.org/gnu/gnu-keyring.gpg gnu-keyring.gpg"


### PR DESCRIPTION
One is a pretty trivial case where we previously hardcoded GCC. For the other one, we were telling `mpc` that our host system root is the sysroot that we want to compile for, which is obviously not correct.