### PR TITLE
Kernel: Limit free space between randomized memory allocations

### DIFF
--- a/AK/IntrusiveRedBlackTree.h
+++ b/AK/IntrusiveRedBlackTree.h
@@ -55,6 +55,14 @@ public:
         return node_to_value(*node);
     }
 
+    Container find_smallest_not_below(K key)
+    {
+        auto* node = static_cast<TreeNode*>(BaseTree::find_smallest_not_below(this->m_root, key));
+        if (!node)
+            return nullptr;
+        return node_to_value(*node);
+    }
+
     void insert(K key, V& value)
     {
         auto& node = value.*member;
@@ -208,6 +216,7 @@ class IntrusiveRedBlackTree<K, V, NonnullRefPtr<V>, member> : public IntrusiveRe
 public:
     [[nodiscard]] NonnullRefPtr<V> find(K key) const { return IntrusiveRedBlackTree<K, V, RefPtr<V>, member>::find(key).release_nonnull(); }
     [[nodiscard]] NonnullRefPtr<V> find_largest_not_above(K key) const { return IntrusiveRedBlackTree<K, V, RefPtr<V>, member>::find_largest_not_above(key).release_nonnull(); }
+    [[nodiscard]] NonnullRefPtr<V> find_smallest_not_below(K key) const { return IntrusiveRedBlackTree<K, V, RefPtr<V>, member>::find_smallest_not_below(key).release_nonnull(); }
 };
 
 }

--- a/AK/RedBlackTree.h
+++ b/AK/RedBlackTree.h
@@ -467,6 +467,14 @@ public:
         return &node->value;
     }
 
+    [[nodiscard]] V* find_smallest_not_below(K key)
+    {
+        auto* node = static_cast<Node*>(BaseTree::find_smallest_not_below(this->m_root, key));
+        if (!node)
+            return nullptr;
+        return &node->value;
+    }
+
     ErrorOr<void> try_insert(K key, V const& value)
     {
         return try_insert(key, V(value));

--- a/Kernel/Memory/RegionTree.cpp
+++ b/Kernel/Memory/RegionTree.cpp
@@ -121,6 +121,26 @@ ErrorOr<VirtualRange> RegionTree::allocate_range_randomized(size_t size, size_t 
         if (!m_total_range.contains(random_address, size))
             continue;
 
+#if ARCH(I386)
+        // Attempt to limit the amount of wasted address space on platforms with small address sizes (read: i686).
+        // This works by only allowing arbitrary random allocations until a certain threshold, to create more possibilities for placing mappings.
+        // After the threshold has been reached, new allocations can only be placed randomly within a certain range from the adjacent allocations.
+        VirtualAddress random_address_end { random_address.get() + size };
+        constexpr size_t max_allocations_until_limited = 200;
+        constexpr size_t max_space_between_allocations = 1 * MiB;
+
+        if (m_regions.size() >= max_allocations_until_limited) {
+            auto* lower_allocation = m_regions.find_largest_not_above(random_address.get());
+            auto* upper_allocation = m_regions.find_smallest_not_below(random_address_end.get());
+
+            bool lower_in_range = (!lower_allocation || random_address - lower_allocation->range().end() <= VirtualAddress(max_space_between_allocations));
+            bool upper_in_range = (!upper_allocation || upper_allocation->range().base() - random_address_end <= VirtualAddress(max_space_between_allocations));
+
+            if (!upper_in_range && !lower_in_range)
+                continue;
+        }
+#endif
+
         auto range_or_error = allocate_range_specific(random_address, size);
         if (!range_or_error.is_error())
             return range_or_error.release_value();


### PR DESCRIPTION
This is an attempt to salvage more memory from our address space by limiting how far away from existing mappings new randomized mappings can be created.

It works by allowing completely randomized placements until a certain threshold (in this case, 100 allocated regions) to allow for more possible placements once the limiter is active. After that, the distance between the attempted mapping and the nearest existing mapping is checked and, if the distance is bigger than a certain threshold, rejected.

Note that, as a relative newcomer on the topic, I just picked the thresholds basically arbitrary, as I can't make any educated guesses on what thresholds would be most "efficient". However, I do plan to go back to my original test case and see how much space I can reasonably let it waste before running out of memory again. Also, I haven't yet put in support for placing allocations just _before_ existing mappings, so those will be erroneously rejected in the initial version of the PR.

This works around an issue where we would run out of memory while linking a bunch of small object files against a large library using Clang, as it would map the (rather small) object files with multiple megabytes of free space in between, and end up not being able to fit the 60MB behemoth that is `libLLVM.so`.