### PR TITLE
Meta: Look for e2fsck in PATH on build-image-qemu.sh

### DIFF
--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -40,6 +40,10 @@ else
     if [ ! -f "$E2FSCK" ]; then
         E2FSCK=/sbin/e2fsck
     fi
+
+    if [ ! -f "$E2FSCK" ]; then
+        E2FSCK=e2fsck
+    fi
 fi
 
 SCRIPT_DIR="$(dirname "${0}")"


### PR DESCRIPTION
This patch adds a branch in `build-image-qemu.sh` to look for `e2fsck` in the PATH if it is not found in `/usr/sbin` or `/sbin`. This is the case in certain Linux distros, such as NixOS.