### PR TITLE
Ports/libzip: Remove `DESTDIR` from `make install`

### DIFF
--- a/Ports/libzip/package.sh
+++ b/Ports/libzip/package.sh
@@ -13,5 +13,5 @@ configure() {
 }
 
 install() {
-    run make DESTDIR=$SERENITY_BUILD_DIR/Root install
+    run make install
 }


### PR DESCRIPTION
CMake already picks up the install location. Passing `DESTDIR` resulted
in installing to `$DESTDIR/$DESTDIR/Root`.