### PR TITLE
AK: Introduce cutoff to insertion sort for Quicksort

### DIFF
--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -79,6 +79,16 @@ concept ArrayLike = requires(ArrayT array, SizeT index)
     -> SameAs<RemoveReference<ContainedT>*>;
 };
 
+// Any indexable data structure.
+template<typename ArrayT, typename ContainedT, typename SizeT = size_t>
+concept Indexable = requires(ArrayT array, SizeT index)
+{
+    {
+        array[index]
+    }
+    -> OneOf<RemoveReference<ContainedT>&, RemoveReference<ContainedT>>;
+};
+
 template<typename Func, typename... Args>
 concept VoidFunction = requires(Func func, Args... args)
 {
@@ -119,6 +129,7 @@ using AK::Concepts::ArrayLike;
 using AK::Concepts::Enum;
 using AK::Concepts::FloatingPoint;
 using AK::Concepts::Fundamental;
+using AK::Concepts::Indexable;
 using AK::Concepts::Integral;
 using AK::Concepts::IterableContainer;
 using AK::Concepts::IteratorFunction;

--- a/AK/InsertionSort.h
+++ b/AK/InsertionSort.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022, Marc Luqué <marc.luque@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Concepts.h>
+#include <AK/StdLibExtras.h>
+
+namespace AK {
+
+// Standard Insertion Sort, with `end` inclusive!
+template<typename Collection, typename Comparator, typename T = decltype(declval<Collection>()[declval<int>()])>
+void insertion_sort(Collection& col, ssize_t start, ssize_t end, Comparator comparator) requires(Indexable<Collection, T>)
+{
+    for (ssize_t i = start + 1; i <= end; ++i) {
+        for (ssize_t j = i; j > 0 && comparator(col[j], col[j - 1]); --j)
+            swap(col[j], col[j - 1]);
+    }
+}
+
+template<typename Collection, typename Comparator, typename T = decltype(declval<Collection>()[declval<int>()])>
+void insertion_sort(Collection& collection, Comparator comparator) requires(Indexable<Collection, T>)
+{
+    insertion_sort(collection, 0, collection.size() - 1, move(comparator));
+}
+
+template<typename Collection, typename T = decltype(declval<Collection>()[declval<int>()])>
+void insertion_sort(Collection& collection) requires(Indexable<Collection, T>)
+{
+    insertion_sort(collection, 0, collection.size() - 1, [](auto& a, auto& b) { return a < b; });
+}
+
+}
+
+using AK::insertion_sort;

--- a/AK/QuickSort.h
+++ b/AK/QuickSort.h
@@ -136,18 +136,6 @@ void single_pivot_quick_sort(Iterator start, Iterator end, LessThan less_than)
     }
 }
 
-template<typename Iterator>
-void quick_sort(Iterator start, Iterator end)
-{
-    single_pivot_quick_sort(start, end, [](auto& a, auto& b) { return a < b; });
-}
-
-template<typename Iterator, typename LessThan>
-void quick_sort(Iterator start, Iterator end, LessThan less_than)
-{
-    single_pivot_quick_sort(start, end, move(less_than));
-}
-
 template<typename Collection, typename LessThan>
 void quick_sort(Collection& collection, LessThan less_than)
 {

--- a/AK/QuickSort.h
+++ b/AK/QuickSort.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/InsertionSort.h>
 #include <AK/StdLibExtras.h>
 
 namespace AK {
@@ -14,10 +15,21 @@ namespace AK {
  * pivot quick_sort below. The other quick_sort below should only be used when
  * you are stuck with simple iterators to a container and you don't have access
  * to the container itself.
+ *
+ * We use a cutoff to insertion sort for partitions of size 7 or smaller.
+ * The idea is to avoid recursion for small partitions.
+ * The value 7 here is a magic number. According to princeton's CS algorithm class
+ * a value between 5 and 15 should work well in most situations:
+ * https://algs4.cs.princeton.edu/23quicksort/
  */
 template<typename Collection, typename LessThan>
 void dual_pivot_quick_sort(Collection& col, int start, int end, LessThan less_than)
 {
+    if ((end + 1) - start <= 7) {
+        AK::insertion_sort(col, start, end, less_than);
+        return;
+    }
+
     while (start < end) {
         int size = end - start + 1;
         if (size > 3) {

--- a/Tests/AK/CMakeLists.txt
+++ b/Tests/AK/CMakeLists.txt
@@ -35,6 +35,7 @@ set(AK_TEST_SOURCES
     TestIPv4Address.cpp
     TestIPv6Address.cpp
     TestIndexSequence.cpp
+    TestInsertionSort.cpp
     TestIntegerMath.cpp
     TestIntrusiveList.cpp
     TestIntrusiveRedBlackTree.cpp

--- a/Tests/AK/TestInsertionSort.cpp
+++ b/Tests/AK/TestInsertionSort.cpp
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022, Marc Luqué <marc.luque@outlook.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <AK/InsertionSort.h>
+#include <AK/Random.h>
+#include <AK/Vector.h>
+
+static constexpr int const n = 10;
+static constexpr int const iterations = 10;
+static constexpr int const seed = 1337;
+
+TEST_CASE(sorts_ascending)
+{
+    srand(seed);
+
+    for (int i = 0; i < iterations; ++i) {
+        Vector<int, n> ints;
+        for (int j = 0; j < n; ++j) {
+            ints.append(get_random<int>());
+        }
+        Vector<int, n> ints_copy = ints;
+
+        insertion_sort(ints);
+        insertion_sort(ints_copy);
+
+        for (int j = 0; j < n - 1; ++j) {
+            EXPECT(ints[j] <= ints[j + 1]);
+            EXPECT_EQ(ints[j], ints_copy[j]);
+            EXPECT_EQ(ints[j + 1], ints_copy[j + 1]);
+        }
+    }
+}
+
+TEST_CASE(sorts_decending)
+{
+    srand(seed);
+
+    for (int i = 0; i < iterations; ++i) {
+        Vector<int, n> ints;
+        for (int j = 0; j < n; ++j) {
+            ints.append(get_random<int>());
+        }
+        Vector<int, n> ints_copy = ints;
+
+        insertion_sort(ints, [](auto& a, auto& b) { return a > b; });
+        insertion_sort(ints_copy, [](auto& a, auto& b) { return a > b; });
+
+        for (int j = 0; j < n - 1; ++j) {
+            EXPECT(ints[j] >= ints[j + 1]);
+            EXPECT_EQ(ints[j], ints_copy[j]);
+            EXPECT_EQ(ints[j + 1], ints_copy[j + 1]);
+        }
+    }
+}

--- a/Userland/DevTools/Profiler/Profile.cpp
+++ b/Userland/DevTools/Profiler/Profile.cpp
@@ -25,7 +25,7 @@ namespace Profiler {
 
 static void sort_profile_nodes(Vector<NonnullRefPtr<ProfileNode>>& nodes)
 {
-    quick_sort(nodes.begin(), nodes.end(), [](auto& a, auto& b) {
+    quick_sort(nodes, [](auto& a, auto& b) {
         return a->event_count() >= b->event_count();
     });
 

--- a/Userland/Libraries/LibGUI/RegularEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/RegularEditingEngine.cpp
@@ -57,10 +57,7 @@ void RegularEditingEngine::sort_selected_lines()
 
     auto& lines = m_editor->document().lines();
 
-    auto start = lines.begin() + (int)first_line;
-    auto end = lines.begin() + (int)last_line + 1;
-
-    quick_sort(start, end, [](auto& a, auto& b) {
+    dual_pivot_quick_sort(lines, static_cast<int>(first_line), static_cast<int>(last_line + 1), [](auto& a, auto& b) {
         return strcmp_utf32(a.code_points(), b.code_points(), min(a.length(), b.length())) < 0;
     });
 

--- a/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
+++ b/Userland/Libraries/LibWeb/URL/URLSearchParams.cpp
@@ -208,7 +208,7 @@ void URLSearchParams::set(String const& name, String const& value)
 void URLSearchParams::sort()
 {
     // 1. Sort all name-value pairs, if any, by their names. Sorting must be done by comparison of code units. The relative order between name-value pairs with equal names must be preserved.
-    quick_sort(m_list.begin(), m_list.end(), [](auto& a, auto& b) {
+    quick_sort(m_list, [](auto& a, auto& b) {
         Utf8View a_code_points { a.name };
         Utf8View b_code_points { b.name };
 


### PR DESCRIPTION
Continuation of #13256

The cutoff value 7 is a magic number here, values [5, 15] should work well according to [this CS algorithm class](https://algs4.cs.princeton.edu/23quicksort/). The main idea of the cutoff is to reduce recursion performed by Quicksort to speed up the sorting of small partitions.

I benchmarked this on my machine (outside of the project) and observed ~20% improvement for collections >= 1000. In other benchmarks for collections smaller than this, the algorithm with and without cutoff performed the same. I also tried to investigate how much we have to sort such large collections. At this moment, I found ~8 instances of sorting with collections >= 1000 (e.g., in the browser while surfing to discord.com. Presumably some SVG <path> being segmentized).
I thought about using a higher cutoff value since this could allow to effectively sort all collections with size <= 15 by using insertion sort which is supposed to be faster. I would greatly appreciate someone's feedback on that idea.
However, the count difference between collections with size <= 7 and <= 15 is only 40 instances:
```
grep "Sorting Collection" debug.log  | cut -d: -f5 | sed -r 's/\s+//g' | sort -n | uniq -c
  15329 0
   5672 1
   2203 2
    765 3
    592 4
     84 5
     17 6
     17 7
      9 8
      8 9
     10 10
      1 11
      2 12
      3 13
      6 14
      1 15
      3 16
      1 17
      2 18
      1 19
      2 22
      1 23
      2 24
      1 25
      2 27
      2 29
      1 40
      1 43
      1 46
      1 55
      1 60
      1 71
      1 152
      1 324
```
Thank you bgianf for investigating that.

I also tested how binary insertion sort (instead of linearly looking for the place to put the pivot, we binary search the place) would perform here. I observed that for these small arrays, insertion sort would perform better. Timsort employs binary insertion sort for sizes up to 64, where supposedly the binary search outweighs the linear search.