### PR TITLE
ClockSettings: Usability improvements

### DIFF
--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
@@ -48,13 +48,17 @@ ClockSettingsWidget::ClockSettingsWidget()
         m_custom_format_input->set_enabled(true);
     }
 
-    m_24_hour_radio->on_checked = [&](bool) {
+    m_24_hour_radio->on_checked = [&](bool checked) {
+        if (!checked)
+            return;
         m_show_seconds_checkbox->set_enabled(true);
         m_custom_format_input->set_enabled(false);
         update_time_format_string();
     };
 
-    twelve_hour_radio.on_checked = [&](bool) {
+    twelve_hour_radio.on_checked = [&](bool checked) {
+        if (!checked)
+            return;
         m_show_seconds_checkbox->set_enabled(true);
         m_custom_format_input->set_enabled(false);
         update_time_format_string();
@@ -64,7 +68,9 @@ ClockSettingsWidget::ClockSettingsWidget()
         update_time_format_string();
     };
 
-    custom_radio.on_checked = [&](bool) {
+    custom_radio.on_checked = [&](bool checked) {
+        if (!checked)
+            return;
         m_show_seconds_checkbox->set_enabled(false);
         m_custom_format_input->set_enabled(true);
     };

--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.gml
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.gml
@@ -8,7 +8,7 @@
     @GUI::GroupBox {
         title: "Time Format"
         shrink_to_fit: false
-        fixed_height: 200
+        fixed_height: 240
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
         }
@@ -48,6 +48,26 @@
 
             @GUI::TextBox {
                 name: "custom_format_input"
+            }
+        }
+
+        @GUI::Widget {
+            layout: @GUI::HorizontalBoxLayout {
+                spacing: 4
+            }
+
+            @GUI::Label {
+                text: "Preview:"
+                text_alignment: "CenterLeft"
+            }
+
+            @GUI::Frame {
+                layout: @GUI::VerticalBoxLayout {}
+
+                @GUI::Label {
+                    name: "clock_preview"
+                    text: "12:34:56"
+                }
             }
         }
     }

--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.h
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.h
@@ -19,10 +19,14 @@ private:
     virtual void reset_default_values() override;
 
     void update_time_format_string();
+    void update_clock_preview();
 
     RefPtr<GUI::RadioButton> m_24_hour_radio;
     RefPtr<GUI::CheckBox> m_show_seconds_checkbox;
     RefPtr<GUI::TextBox> m_custom_format_input;
+    RefPtr<GUI::Label> m_clock_preview;
 
-    String m_date_format;
+    RefPtr<Core::Timer> m_clock_preview_update_timer;
+
+    String m_time_format;
 };

--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.gml
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.gml
@@ -9,7 +9,7 @@
         title: "Time Zone Settings"
         layout: @GUI::VerticalBoxLayout {
             margins: [16, 8, 8]
-            spacing: 16
+            spacing: 14
         }
 
         @GUI::Label {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/164450987-19565eef-0a3e-4491-87d6-b453c318ebcb.png)

A few small changes to ClockSettings to make it nicer to use:

- When loading the clock format, try to match it against one of the radio-button options instead of always making it appear as "custom".
- Keep the format text in the custom-format box when switching to "custom".
- Tweak timezone layout spacing to not crop the ComboBox.
- Show a preview of how the clock would appear using the chosen format.