### PR TITLE
LibCore: Output invalid DateTime::to_string() specifiers as literals

### DIFF
--- a/Userland/Libraries/LibCore/DateTime.cpp
+++ b/Userland/Libraries/LibCore/DateTime.cpp
@@ -239,11 +239,15 @@ String DateTime::to_string(StringView format) const
                 format_time_zone_offset(false);
                 break;
             case ':':
-                if (++i == format_len)
-                    return String::empty();
-                if (format[i] != 'z')
-                    return String::empty();
-
+                if (++i == format_len) {
+                    builder.append("%:");
+                    break;
+                }
+                if (format[i] != 'z') {
+                    builder.append("%:");
+                    builder.append(format[i]);
+                    break;
+                }
                 format_time_zone_offset(true);
                 break;
             case 'Z':
@@ -253,7 +257,9 @@ String DateTime::to_string(StringView format) const
                 builder.append('%');
                 break;
             default:
-                return String();
+                builder.append('%');
+                builder.append(format[i]);
+                break;
             }
         }
     }


### PR DESCRIPTION
While working on #13764 I noticed that DateTime::to_string() would just
return an empty String if the format included an invalid specifier
(eg `%Q`). This seems to be a mistake. POSIX date(1), which I believe
we are basing our implementation on, only replaces valid specifiers,
and any invalid ones get included as literals in the output.

For example, on Linux `date "+%Quiz"` returns "%Quiz", but we were
returning "".