### PR TITLE
LibGUI+Applications: Add command-line option to open FooSettings applications on a specific tab

### DIFF
--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,8 +28,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Browser Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->add_tab<BrowserSettingsWidget>("Browser"));
-    (void)TRY(window->add_tab<ContentFilterSettingsWidget>("Content Filtering"));
+    (void)TRY(window->add_tab<BrowserSettingsWidget>("Browser", "browser"));
+    (void)TRY(window->add_tab<ContentFilterSettingsWidget>("Content Filtering", "content-filtering"));
 
     window->show();
     return app->exec();

--- a/Userland/Applications/BrowserSettings/main.cpp
+++ b/Userland/Applications/BrowserSettings/main.cpp
@@ -7,6 +7,7 @@
 #include "BrowserSettingsWidget.h"
 #include "ContentFilterSettingsWidget.h"
 #include <LibConfig/Client.h>
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -19,6 +20,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("Browser");
 
+    StringView selected_tab;
+    Core::ArgsParser args_parser;
+    args_parser.add_option(selected_tab, "Tab, one of 'browser' or 'content-filtering'", "open-tab", 't', "tab");
+    args_parser.parse(arguments);
+
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/home", "r"));
     TRY(Core::System::unveil("/home/anon/.config/BrowserContentFilters.txt", "rwc"));
@@ -30,6 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     (void)TRY(window->add_tab<BrowserSettingsWidget>("Browser", "browser"));
     (void)TRY(window->add_tab<ContentFilterSettingsWidget>("Content Filtering", "content-filtering"));
+    window->set_active_tab(selected_tab);
 
     window->show();
     return app->exec();

--- a/Userland/Applications/ClockSettings/main.cpp
+++ b/Userland/Applications/ClockSettings/main.cpp
@@ -29,8 +29,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-analog-clock"); // FIXME: Create a ClockSettings icon.
 
     auto window = TRY(GUI::SettingsWindow::create("Clock Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    (void)TRY(window->add_tab<ClockSettingsWidget>("Clock"));
-    (void)TRY(window->add_tab<TimeZoneSettingsWidget>("Time Zone"));
+    (void)TRY(window->add_tab<ClockSettingsWidget>("Clock", "clock"));
+    (void)TRY(window->add_tab<TimeZoneSettingsWidget>("Time Zone", "time-zone"));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(540, 570);
 

--- a/Userland/Applications/ClockSettings/main.cpp
+++ b/Userland/Applications/ClockSettings/main.cpp
@@ -7,6 +7,7 @@
 #include "ClockSettingsWidget.h"
 #include "TimeZoneSettingsWidget.h"
 #include <LibConfig/Client.h>
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -20,6 +21,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
 
     Config::pledge_domain("Taskbar");
+
+    StringView selected_tab;
+    Core::ArgsParser args_parser;
+    args_parser.add_option(selected_tab, "Tab, one of 'clock' or 'time-zone'", "open-tab", 't', "tab");
+    args_parser.parse(arguments);
+
     TRY(Core::System::pledge("stdio rpath recvfd sendfd proc exec"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/timezone", "x"));
@@ -33,6 +40,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     (void)TRY(window->add_tab<TimeZoneSettingsWidget>("Time Zone", "time-zone"));
     window->set_icon(app_icon.bitmap_for_size(16));
     window->resize(540, 570);
+    window->set_active_tab(selected_tab);
 
     window->show();
     return app->exec();

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2019-2020, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -30,11 +30,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     bool background_settings_changed = false;
 
     auto window = TRY(GUI::SettingsWindow::create("Display Settings"));
-    (void)TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background", background_settings_changed));
-    (void)TRY(window->add_tab<DisplaySettings::ThemesSettingsWidget>("Themes", background_settings_changed));
-    (void)TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts"));
-    (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor"));
-    (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces"));
+    (void)TRY(window->add_tab<DisplaySettings::BackgroundSettingsWidget>("Background", "background", background_settings_changed));
+    (void)TRY(window->add_tab<DisplaySettings::ThemesSettingsWidget>("Themes", "themes", background_settings_changed));
+    (void)TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts", "fonts"));
+    (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor", "monitor"));
+    (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces", "workspaces"));
 
     window->set_icon(app_icon.bitmap_for_size(16));
 

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -12,6 +12,7 @@
 #include "MonitorSettingsWidget.h"
 #include "ThemesSettingsWidget.h"
 #include <LibConfig/Client.h>
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -25,6 +26,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("WindowManager");
 
+    StringView selected_tab;
+    Core::ArgsParser args_parser;
+    args_parser.add_option(selected_tab, "Tab, one of 'background', 'fonts', 'monitor', 'themes', or 'workspaces'", "open-tab", 't', "tab");
+    args_parser.parse(arguments);
+
     auto app_icon = GUI::Icon::default_icon("app-display-settings");
 
     bool background_settings_changed = false;
@@ -35,6 +41,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     (void)TRY(window->add_tab<DisplaySettings::FontSettingsWidget>("Fonts", "fonts"));
     (void)TRY(window->add_tab<DisplaySettings::MonitorSettingsWidget>("Monitor", "monitor"));
     (void)TRY(window->add_tab<DisplaySettings::DesktopSettingsWidget>("Workspaces", "workspaces"));
+    window->set_active_tab(selected_tab);
 
     window->set_icon(app_icon.bitmap_for_size(16));
 

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Hüseyin Aslıtürk <asliturk@hotmail.com>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -31,7 +31,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Keyboard Settings"));
     window->set_icon(app_icon.bitmap_for_size(16));
-    auto keyboard_settings_widget = TRY(window->add_tab<KeyboardSettingsWidget>("Keyboard"));
+    auto keyboard_settings_widget = TRY(window->add_tab<KeyboardSettingsWidget>("Keyboard", "keyboard"));
 
     window->on_active_window_change = [&](bool is_active_window) {
         keyboard_settings_widget->window_activated(is_active_window);

--- a/Userland/Applications/KeyboardSettings/main.cpp
+++ b/Userland/Applications/KeyboardSettings/main.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "KeyboardSettingsWidget.h"
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/SettingsWindow.h>
@@ -20,6 +21,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("KeyboardSettings");
 
+    StringView selected_tab;
+    Core::ArgsParser args_parser;
+    args_parser.add_option(selected_tab, "Tab, only option is 'keyboard'", "open-tab", 't', "tab");
+    args_parser.parse(arguments);
+
     TRY(Core::System::pledge("stdio rpath recvfd sendfd proc exec"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin/keymap", "x"));
@@ -32,6 +38,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::SettingsWindow::create("Keyboard Settings"));
     window->set_icon(app_icon.bitmap_for_size(16));
     auto keyboard_settings_widget = TRY(window->add_tab<KeyboardSettingsWidget>("Keyboard", "keyboard"));
+    window->set_active_tab(selected_tab);
 
     window->on_active_window_change = [&](bool is_active_window) {
         keyboard_settings_widget->window_activated(is_active_window);

--- a/Userland/Applications/MailSettings/main.cpp
+++ b/Userland/Applications/MailSettings/main.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2021, the SerenityOS developers.
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -28,7 +28,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-mail");
 
     auto window = TRY(GUI::SettingsWindow::create("Mail Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    (void)TRY(window->add_tab<MailSettingsWidget>("Mail"));
+    (void)TRY(window->add_tab<MailSettingsWidget>("Mail", "mail"));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/MailSettings/main.cpp
+++ b/Userland/Applications/MailSettings/main.cpp
@@ -7,6 +7,7 @@
 
 #include "MailSettingsWidget.h"
 #include <LibConfig/Client.h>
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -21,6 +22,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     Config::pledge_domain("Mail");
 
+    StringView selected_tab;
+    Core::ArgsParser args_parser;
+    args_parser.add_option(selected_tab, "Tab, only option is 'mail'", "open-tab", 't', "tab");
+    args_parser.parse(arguments);
+
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
@@ -30,6 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto window = TRY(GUI::SettingsWindow::create("Mail Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     (void)TRY(window->add_tab<MailSettingsWidget>("Mail", "mail"));
     window->set_icon(app_icon.bitmap_for_size(16));
+    window->set_active_tab(selected_tab);
 
     window->show();
     return app->exec();

--- a/Userland/Applications/MouseSettings/main.cpp
+++ b/Userland/Applications/MouseSettings/main.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2020, Idan Horowitz <idan.horowitz@serenityos.org>
  * Copyright (c) 2021, the SerenityOS developers.
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -26,8 +26,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app_icon = GUI::Icon::default_icon("app-mouse");
 
     auto window = TRY(GUI::SettingsWindow::create("Mouse Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
-    (void)TRY(window->add_tab<MouseWidget>("Mouse"));
-    (void)TRY(window->add_tab<ThemeWidget>("Cursor Theme"));
+    (void)TRY(window->add_tab<MouseWidget>("Mouse", "mouse"));
+    (void)TRY(window->add_tab<ThemeWidget>("Cursor Theme", "cursor-theme"));
     window->set_icon(app_icon.bitmap_for_size(16));
 
     window->show();

--- a/Userland/Applications/MouseSettings/main.cpp
+++ b/Userland/Applications/MouseSettings/main.cpp
@@ -9,6 +9,7 @@
 
 #include "MouseWidget.h"
 #include "ThemeWidget.h"
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Icon.h>
@@ -23,12 +24,18 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio cpath rpath recvfd sendfd"));
 
+    StringView selected_tab;
+    Core::ArgsParser args_parser;
+    args_parser.add_option(selected_tab, "Tab, one of 'cursor-theme' or 'mouse'", "open-tab", 't', "tab");
+    args_parser.parse(arguments);
+
     auto app_icon = GUI::Icon::default_icon("app-mouse");
 
     auto window = TRY(GUI::SettingsWindow::create("Mouse Settings", GUI::SettingsWindow::ShowDefaultsButton::Yes));
     (void)TRY(window->add_tab<MouseWidget>("Mouse", "mouse"));
     (void)TRY(window->add_tab<ThemeWidget>("Cursor Theme", "cursor-theme"));
     window->set_icon(app_icon.bitmap_for_size(16));
+    window->set_active_tab(selected_tab);
 
     window->show();
     return app->exec();

--- a/Userland/Applications/TerminalSettings/main.cpp
+++ b/Userland/Applications/TerminalSettings/main.cpp
@@ -28,8 +28,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::SettingsWindow::create("Terminal Settings"));
     window->set_icon(app_icon.bitmap_for_size(16));
-    (void)TRY(window->add_tab<TerminalSettingsMainWidget>("Terminal"));
-    (void)TRY(window->add_tab<TerminalSettingsViewWidget>("View"));
+    (void)TRY(window->add_tab<TerminalSettingsMainWidget>("Terminal", "terminal"));
+    (void)TRY(window->add_tab<TerminalSettingsViewWidget>("View", "view"));
 
     window->show();
     return app->exec();

--- a/Userland/Applications/TerminalSettings/main.cpp
+++ b/Userland/Applications/TerminalSettings/main.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "TerminalSettingsWidget.h"
+#include <LibCore/ArgsParser.h>
 #include <LibCore/System.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/ConnectionToWindowServer.h>
@@ -20,6 +21,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("Terminal");
 
+    StringView selected_tab;
+    Core::ArgsParser args_parser;
+    args_parser.add_option(selected_tab, "Tab, one of 'terminal' or 'view'", "open-tab", 't', "tab");
+    args_parser.parse(arguments);
+
     TRY(Core::System::pledge("stdio rpath recvfd sendfd"));
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil(nullptr, nullptr));
@@ -30,6 +36,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->set_icon(app_icon.bitmap_for_size(16));
     (void)TRY(window->add_tab<TerminalSettingsMainWidget>("Terminal", "terminal"));
     (void)TRY(window->add_tab<TerminalSettingsViewWidget>("View", "view"));
+    window->set_active_tab(selected_tab);
 
     window->show();
     return app->exec();

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -2,7 +2,7 @@
  * Copyright (c) 2020, Idan Horowitz <idan.horowitz@serenityos.org>
  * Copyright (c) 2021-2022, the SerenityOS developers.
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -41,9 +41,9 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
         window->m_reset_button = TRY(button_container->try_add<GUI::Button>("Defaults"));
         window->m_reset_button->set_fixed_width(75);
         window->m_reset_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
-            for (auto& tab : window->m_tabs) {
-                tab.reset_default_values();
-                tab.apply_settings();
+            for (auto& [id, tab] : window->m_tabs) {
+                tab->reset_default_values();
+                tab->apply_settings();
             }
         };
     }
@@ -53,24 +53,24 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
     window->m_ok_button = TRY(button_container->try_add<GUI::Button>("OK"));
     window->m_ok_button->set_fixed_width(75);
     window->m_ok_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
-        for (auto& tab : window->m_tabs)
-            tab.apply_settings();
+        for (auto& [id, tab] : window->m_tabs)
+            tab->apply_settings();
         GUI::Application::the()->quit();
     };
 
     window->m_cancel_button = TRY(button_container->try_add<GUI::Button>("Cancel"));
     window->m_cancel_button->set_fixed_width(75);
     window->m_cancel_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
-        for (auto& tab : window->m_tabs)
-            tab.cancel_settings();
+        for (auto& [id, tab] : window->m_tabs)
+            tab->cancel_settings();
         GUI::Application::the()->quit();
     };
 
     window->m_apply_button = TRY(button_container->try_add<GUI::Button>("Apply"));
     window->m_apply_button->set_fixed_width(75);
     window->m_apply_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
-        for (auto& tab : window->m_tabs)
-            tab.apply_settings();
+        for (auto& [id, tab] : window->m_tabs)
+            tab->apply_settings();
     };
 
     return window;

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -76,4 +76,18 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
     return window;
 }
 
+Optional<NonnullRefPtr<SettingsWindow::Tab>> SettingsWindow::get_tab(StringView id) const
+{
+    auto tab = m_tabs.find(id);
+    if (tab == m_tabs.end())
+        return {};
+    return tab->value;
+}
+
+void SettingsWindow::set_active_tab(StringView id)
+{
+    if (auto tab = get_tab(id); tab.has_value())
+        m_tab_widget->set_active_widget(tab.value());
+}
+
 }

--- a/Userland/Libraries/LibGUI/SettingsWindow.h
+++ b/Userland/Libraries/LibGUI/SettingsWindow.h
@@ -1,13 +1,14 @@
 /*
  * Copyright (c) 2020, Idan Horowitz <idan.horowitz@serenityos.org>
  * Copyright (c) 2021-2022, the SerenityOS developers.
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/Window.h>
@@ -34,10 +35,10 @@ public:
     virtual ~SettingsWindow() override = default;
 
     template<class T, class... Args>
-    ErrorOr<NonnullRefPtr<T>> add_tab(String title, Args&&... args)
+    ErrorOr<NonnullRefPtr<T>> add_tab(String title, StringView id, Args&&... args)
     {
         auto tab = TRY(m_tab_widget->try_add_tab<T>(move(title), forward<Args>(args)...));
-        TRY(m_tabs.try_append(tab));
+        TRY(m_tabs.try_set(id, tab));
         return tab;
     }
 
@@ -45,7 +46,7 @@ private:
     SettingsWindow() = default;
 
     RefPtr<GUI::TabWidget> m_tab_widget;
-    NonnullRefPtrVector<Tab> m_tabs;
+    HashMap<StringView, NonnullRefPtr<Tab>> m_tabs;
 
     RefPtr<GUI::Button> m_ok_button;
     RefPtr<GUI::Button> m_cancel_button;

--- a/Userland/Libraries/LibGUI/SettingsWindow.h
+++ b/Userland/Libraries/LibGUI/SettingsWindow.h
@@ -42,6 +42,9 @@ public:
         return tab;
     }
 
+    Optional<NonnullRefPtr<Tab>> get_tab(StringView id) const;
+    void set_active_tab(StringView id);
+
 private:
     SettingsWindow() = default;
 


### PR DESCRIPTION
So now you can do `MouseSettings -t cursor-theme` to open the "Cursor Theme" tab directly. mild_convenience++

This is probably more useful for opening a specific tab programmatically, which is not something we currently need.

Also, I'm sure there's some way of making SettingsWindow handle this automatically since it knows which tab IDs exist... but it only knows that after the Window is created. :thonk: