### PR TITLE
LibJS: Remove callerRealm from HostEnsureCanCompileStrings and add a couple of missing spec steps to PerformEval

### DIFF
--- a/Userland/Libraries/LibJS/AST.cpp
+++ b/Userland/Libraries/LibJS/AST.cpp
@@ -432,7 +432,7 @@ Completion CallExpression::execute(Interpreter& interpreter, GlobalObject& globa
         && callee_reference.name().as_string() == vm.names.eval.as_string()) {
 
         auto script_value = arg_list.size() == 0 ? js_undefined() : arg_list[0];
-        return perform_eval(script_value, global_object, vm.in_strict_mode() ? CallerMode::Strict : CallerMode::NonStrict, EvalMode::Direct);
+        return perform_eval(global_object, script_value, vm.in_strict_mode() ? CallerMode::Strict : CallerMode::NonStrict, EvalMode::Direct);
     }
 
     return call(global_object, function, this_value, move(arg_list));

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.cpp
@@ -579,9 +579,14 @@ ThrowCompletionOr<Value> perform_eval(GlobalObject& global_object, Value x, Call
         return vm.throw_completion<SyntaxError>(global_object, error.to_string());
     }
 
-    auto strict_eval = strict_caller == CallerMode::Strict;
-    if (program->is_strict_mode())
+    bool strict_eval = false;
+
+    // 12. If strictCaller is true, let strictEval be true.
+    if (strict_caller == CallerMode::Strict)
         strict_eval = true;
+    // 13. Else, let strictEval be IsStrict of script.
+    else
+        strict_eval = program->is_strict_mode();
 
     // 14. Let runningContext be the running execution context.
     // 15. NOTE: If direct is true, runningContext will be the execution context that performed the direct eval. If direct is false, runningContext will be the execution context for the invocation of the eval function.

--- a/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
+++ b/Userland/Libraries/LibJS/Runtime/AbstractOperations.h
@@ -56,7 +56,7 @@ enum class EvalMode {
     Direct,
     Indirect
 };
-ThrowCompletionOr<Value> perform_eval(Value, GlobalObject&, CallerMode, EvalMode);
+ThrowCompletionOr<Value> perform_eval(GlobalObject&, Value, CallerMode, EvalMode);
 
 ThrowCompletionOr<void> eval_declaration_instantiation(VM& vm, GlobalObject& global_object, Program const& program, Environment* variable_environment, Environment* lexical_environment, PrivateEnvironment* private_environment, bool strict);
 

--- a/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
+++ b/Userland/Libraries/LibJS/Runtime/GlobalObject.cpp
@@ -489,7 +489,7 @@ JS_DEFINE_NATIVE_FUNCTION(GlobalObject::parse_int)
 // 19.2.1 eval ( x ), https://tc39.es/ecma262/#sec-eval-x
 JS_DEFINE_NATIVE_FUNCTION(GlobalObject::eval)
 {
-    return perform_eval(vm.argument(0), global_object, CallerMode::NonStrict, EvalMode::Indirect);
+    return perform_eval(global_object, vm.argument(0), CallerMode::NonStrict, EvalMode::Indirect);
 }
 
 // 19.2.6.1.1 Encode ( string, unescapedSet ), https://tc39.es/ecma262/#sec-encode

--- a/Userland/Libraries/LibJS/Runtime/VM.cpp
+++ b/Userland/Libraries/LibJS/Runtime/VM.cpp
@@ -132,9 +132,9 @@ VM::VM(OwnPtr<CustomData> custom_data)
     };
 
     // 19.2.1.2 HostEnsureCanCompileStrings ( callerRealm, calleeRealm ), https://tc39.es/ecma262/#sec-hostensurecancompilestrings
-    host_ensure_can_compile_strings = [](Realm&, Realm&) -> ThrowCompletionOr<void> {
-        // The host-defined abstract operation HostEnsureCanCompileStrings takes arguments callerRealm (a Realm Record) and calleeRealm (a Realm Record)
-        // and returns either a normal completion containing unused or an abrupt completion.
+    host_ensure_can_compile_strings = [](Realm&) -> ThrowCompletionOr<void> {
+        // The host-defined abstract operation HostEnsureCanCompileStrings takes argument calleeRealm (a Realm Record)
+        // and returns either a normal completion containing unused or a throw completion.
         // It allows host environments to block certain ECMAScript functions which allow developers to compile strings into ECMAScript code.
         // An implementation of HostEnsureCanCompileStrings must conform to the following requirements:
         //   - If the returned Completion Record is a normal completion, it must be a normal completion containing unused.

--- a/Userland/Libraries/LibJS/Runtime/VM.h
+++ b/Userland/Libraries/LibJS/Runtime/VM.h
@@ -234,7 +234,7 @@ public:
     Function<void(Function<ThrowCompletionOr<Value>()>, Realm*)> host_enqueue_promise_job;
     Function<JobCallback(FunctionObject&)> host_make_job_callback;
     Function<ThrowCompletionOr<HostResizeArrayBufferResult>(GlobalObject&, size_t)> host_resize_array_buffer;
-    Function<ThrowCompletionOr<void>(Realm&, Realm&)> host_ensure_can_compile_strings;
+    Function<ThrowCompletionOr<void>(Realm&)> host_ensure_can_compile_strings;
 
 private:
     explicit VM(OwnPtr<CustomData>);


### PR DESCRIPTION
LibJS: Remove callerRealm from HostEnsureCanCompileStrings

This is a normative change in the ecma262 spec.

See: https://github.com/tc39/ecma262/commit/2527be4

-----

LibJS: Add a couple of missing spec steps to PerformEval

I missed these in https://github.com/SerenityOS/serenity/commit/34f902fb524808b308efe4568ff5a026d2cb4884.