### PR TITLE
Bump required QEMU version to 6.2.0 and build CI on Ubuntu 22.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         debug-options: ['ALL_DEBUG', 'NORMAL_DEBUG']
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
         arch: ['i686', 'x86_64']
         # If ccache is broken and you would like to bust the ccache cache on Github Actions, increment this:
         ccache-mark: [0]
@@ -39,18 +39,12 @@ jobs:
       # Do we need to update the package cache first?
       # sudo apt-get update -qq
       - name: "Install Ubuntu dependencies"
-        # These packages are already part of the ubuntu-20.04 image:
+        # These packages are already part of the ubuntu-22.04 image:
         # cmake libgmp-dev npm shellcheck
         # Packages below aren't.
-        #
-        # We add the canonical-server/server-backports PPA to get updated QEMU releases without having to manage
-        #    yet another cache in github actions
-        # We add the ubuntu-toolchain-r/test PPA to get gcc-11 on 20.04
         run: |
-          sudo add-apt-repository ppa:canonical-server/server-backports
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
+          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main'
           sudo apt-get update
           sudo apt-get install -y clang-format-14 ccache e2fsprogs gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build qemu-utils qemu-system-i386 unzip
       - name: Install JS dependencies

--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -4,7 +4,7 @@ on: [push, pull_request_target]
 
 jobs:
   notify_discord:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.repository == 'SerenityOS/serenity' && (github.event_name == 'pull_request_target' || (github.event_name == 'push' && github.ref == 'refs/heads/master'))
 
     steps:

--- a/.github/workflows/libjs-test262.yml
+++ b/.github/workflows/libjs-test262.yml
@@ -47,7 +47,6 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           sudo apt-get update
           sudo apt-get install -y ninja-build unzip gcc-11 g++-11 jq wget
           test -e /opt/wabt-1.0.27 || (

--- a/.github/workflows/lintcommits.yml
+++ b/.github/workflows/lintcommits.yml
@@ -7,7 +7,7 @@ on: [pull_request_target]
 
 jobs:
   lint_commits:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.repository == 'SerenityOS/serenity'
 
     steps:

--- a/.github/workflows/manpages.yml
+++ b/.github/workflows/manpages.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   convert_using_pandoc:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -20,14 +20,13 @@ jobs:
           sudo wget -O /etc/apt/sources.list.d/viva64.list https://files.pvs-studio.com/beta/etc/viva64.list
 
       - name: "Install Ubuntu dependencies"
-        # These packages are already part of the ubuntu-20.04 image:
+        # These packages are already part of the ubuntu-22.04 image:
         # cmake libgmp-dev npm shellcheck
         # Packages below aren't.
         #
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
+          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main'
           sudo apt-get update
           sudo apt-get install -y clang-format-14 gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build unzip pvs-studio
 

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -54,13 +54,12 @@ jobs:
       # TODO: Is there someway to share these steps with the cmake.yml?
 
       - name: "Install Ubuntu dependencies"
-        # These packages are already part of the ubuntu-20.04 image:
+        # These packages are already part of the ubuntu-22.04 image:
         # cmake libgmp-dev npm shellcheck
         # Packages below aren't.
         run: |
-          sudo add-apt-repository ppa:ubuntu-toolchain-r/test
           wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
+          sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main'
           sudo apt-get update
           sudo apt-get install -y clang-format-14 gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build unzip
 

--- a/.github/workflows/twitter.yml
+++ b/.github/workflows/twitter.yml
@@ -4,7 +4,7 @@ on: [ push ]
 
 jobs:
   notify_twitter:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
 
     steps:

--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -31,10 +31,12 @@ Now on Ubuntu or Debian you can install gcc-11 with apt like this:
 sudo apt install gcc-11 g++-11
 ```
 
-#### QEMU 5 or later
+#### QEMU 6.2 or later
 
-QEMU version 5 is available in Ubuntu 20.10, but it is recommended to build Qemu as provided by the toolchain by running `Toolchain/BuildQemu.sh`.
-Note that you might need additional dev packages:
+Version 6.2 of QEMU is available in Ubuntu 22.04. On earlier versions of Ubuntu,
+you can build the recommended version of QEMU as provided by the toolchain by running
+`Toolchain/BuildQemu.sh`.
+Note that you might need additional dev packages in order to build QEMU on your machine:
 
 ```console
 sudo apt install libgtk-3-dev libpixman-1-dev libsdl2-dev libspice-server-dev

--- a/Meta/Azure/Lagom.yml
+++ b/Meta/Azure/Lagom.yml
@@ -13,7 +13,7 @@ jobs:
 
     - name: job_pool
       ${{ if eq(parameters.os, 'Linux') }}:
-        value: ubuntu-20.04
+        value: ubuntu-22.04
       ${{ if eq(parameters.os, 'macOS') }}:
         value: macos-11
 

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -15,7 +15,7 @@ jobs:
       value: $(Build.SourcesDirectory)/.ccache
 
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
 
     steps:
     - template: Setup.yml

--- a/Meta/Azure/Setup.yml
+++ b/Meta/Azure/Setup.yml
@@ -7,10 +7,8 @@ steps:
 
   - ${{ if eq(parameters.os, 'Serenity') }}:
     - script: |
-        sudo add-apt-repository ppa:canonical-server/server-backports
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-14 main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main'
         sudo apt-get update
         sudo apt-get install clang-format-14 ccache e2fsprogs gcc-11 g++-11 libstdc++-11-dev libmpfr-dev libmpc-dev ninja-build qemu-utils qemu-system-i386 unzip lld
       displayName: 'Install Dependencies'
@@ -18,9 +16,8 @@ steps:
   - ${{ if eq(parameters.os, 'Linux') }}:
     - script: |
         sudo apt-get purge -y clang-11 clang-12 gcc-10
-        sudo add-apt-repository ppa:ubuntu-toolchain-r/test
         wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main'
+        sudo add-apt-repository 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-13 main'
         sudo apt-get update
         sudo apt-get install ccache gcc-11 g++-11 clang-13 libstdc++-11-dev ninja-build unzip
 

--- a/Meta/Azure/Toolchain.yml
+++ b/Meta/Azure/Toolchain.yml
@@ -9,7 +9,7 @@ jobs:
       value: 20GB
 
     pool:
-      vmImage: ubuntu-20.04
+      vmImage: ubuntu-22.04
 
     steps:
     - template: Setup.yml

--- a/Meta/build-image-qemu.sh
+++ b/Meta/build-image-qemu.sh
@@ -66,7 +66,7 @@ else
 fi
 
 disk_usage() {
-    # shellcheck disable=SC2003
+    # shellcheck disable=SC2003,SC2307
     expr "$(${GNUDU} -sk --apparent-size "$1" | cut -f1)"
 }
 

--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -104,15 +104,19 @@ fi
     fi
 }
 
+SERENITY_QEMU_MIN_REQ_MAJOR_VERSION=6
+SERENITY_QEMU_MIN_REQ_MINOR_VERSION=2
+SERENITY_QEMU_MIN_REQ_VERSION="$SERENITY_QEMU_MIN_REQ_MAJOR_VERSION.$SERENITY_QEMU_MIN_REQ_MINOR_VERSION"
 if ! command -v "$SERENITY_QEMU_BIN" >/dev/null 2>&1 ; then
-    die "Please install QEMU version 5.0 or newer or use the Toolchain/BuildQemu.sh script."
+    die "Please install QEMU version $SERENITY_QEMU_MIN_REQ_VERSION or newer or use the Toolchain/BuildQemu.sh script."
 fi
 
-SERENITY_QEMU_MIN_REQ_VERSION=5
 installed_major_version=$("$SERENITY_QEMU_BIN" -version | head -n 1 | sed -E 's/QEMU emulator version ([1-9][0-9]*|0).*/\1/')
 installed_minor_version=$("$SERENITY_QEMU_BIN" -version | head -n 1 | sed -E 's/QEMU emulator version [0-9]+\.([1-9][0-9]*|0).*/\1/')
-if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_VERSION" ]; then
-    echo "Required QEMU >= 5.0! Found $($SERENITY_QEMU_BIN -version | head -n 1)"
+if [ "$installed_major_version" -lt "$SERENITY_QEMU_MIN_REQ_MAJOR_VERSION" ] ||
+   { [ "$installed_major_version" -eq "$SERENITY_QEMU_MIN_REQ_MAJOR_VERSION" ] &&
+     [ "$installed_minor_version" -lt "$SERENITY_QEMU_MIN_REQ_MINOR_VERSION" ]; }; then
+    echo "Required QEMU >= $SERENITY_QEMU_MIN_REQ_VERSION! Found $($SERENITY_QEMU_BIN -version | head -n 1)"
     echo "Please install a newer version of QEMU or use the Toolchain/BuildQemu.sh script."
     die
 fi


### PR DESCRIPTION
This PR updates BuildInstructions.md to bump the minimum required QEMU version to 6.2

It also updates Meta/run.sh to check for the new QEMU version and add support for minor release numbers in the version checking logic

The change to Meta/run.sh caused CI to fail, since the Github Actions workers were using the default version of QEMU in ubuntu-20.04, which was 6.0, not 6.2. In order to get CI to pass, I went ahead and updated the Github Actions workers to ubuntu-22.04

Once I updated the Github Actions workers to ubuntu-22.04, the build started failing again due to a few lints, so I made little fixes for those