### PR TITLE
Kernel: Fix typo in Ramdisk

### DIFF
--- a/Kernel/Storage/Ramdisk/Controller.h
+++ b/Kernel/Storage/Ramdisk/Controller.h
@@ -19,7 +19,6 @@ class AsyncBlockDeviceRequest;
 
 class RamdiskController final : public StorageController {
 public:
-public:
     static NonnullRefPtr<RamdiskController> initialize();
     virtual ~RamdiskController() override;
 


### PR DESCRIPTION
Remove the duplicate/extraneous access specifier. Sorry for the trivial PR, I wanted to take the opportunity to get more comfortable with the contrib process before making any substantial changes :)