### PR TITLE
Kernel: Add a DisplayConnector object to Bochs graphics to manage the framebuffer

### DIFF
--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -74,7 +74,9 @@ set(KERNEL_SOURCES
     Devices/HID/PS2MouseDevice.cpp
     Devices/HID/VMWareMouseDevice.cpp
     GlobalProcessExposed.cpp
+    Graphics/Bochs/DisplayConnector.cpp
     Graphics/Bochs/GraphicsAdapter.cpp
+    Graphics/Bochs/VBoxDisplayConnector.cpp
     Graphics/Console/BootFramebufferConsole.cpp
     Graphics/Console/GenericFramebufferConsole.cpp
     Graphics/Console/ContiguousFramebufferConsole.cpp

--- a/Kernel/Graphics/Bochs/Definitions.h
+++ b/Kernel/Graphics/Bochs/Definitions.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel {
+
+#define VBE_DISPI_IOPORT_INDEX 0x01CE
+#define VBE_DISPI_IOPORT_DATA 0x01CF
+
+#define BOCHS_DISPLAY_LITTLE_ENDIAN 0x1e1e1e1e
+#define BOCHS_DISPLAY_BIG_ENDIAN 0xbebebebe
+
+#define VBE_DISPI_ID5 0xB0C5
+
+enum class BochsFramebufferSettings {
+    Enabled = 0x1,
+    LinearFramebuffer = 0x40,
+};
+
+enum class BochsDISPIRegisters {
+    ID = 0x0,
+    XRES = 0x1,
+    YRES = 0x2,
+    BPP = 0x3,
+    ENABLE = 0x4,
+    BANK = 0x5,
+    VIRT_WIDTH = 0x6,
+    VIRT_HEIGHT = 0x7,
+    X_OFFSET = 0x8,
+    Y_OFFSET = 0x9,
+};
+
+struct [[gnu::packed]] DISPIInterface {
+    u16 index_id;
+    u16 xres;
+    u16 yres;
+    u16 bpp;
+    u16 enable;
+    u16 bank;
+    u16 virt_width;
+    u16 virt_height;
+    u16 x_offset;
+    u16 y_offset;
+};
+
+struct [[gnu::packed]] ExtensionRegisters {
+    u32 region_size;
+    u32 framebuffer_byteorder;
+};
+
+struct [[gnu::packed]] BochsDisplayMMIORegisters {
+    u8 edid_data[0x400];
+    u16 vga_ioports[0x10];
+    u8 reserved[0xE0];
+    DISPIInterface bochs_regs;
+    u8 reserved2[0x100 - sizeof(DISPIInterface)];
+    ExtensionRegisters extension_regs;
+};
+
+}

--- a/Kernel/Graphics/Bochs/DisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/DisplayConnector.cpp
@@ -1,0 +1,150 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Debug.h>
+#include <Kernel/Graphics/Bochs/Definitions.h>
+#include <Kernel/Graphics/Bochs/DisplayConnector.h>
+#include <Kernel/Graphics/Console/ContiguousFramebufferConsole.h>
+#include <Kernel/Graphics/GraphicsManagement.h>
+
+namespace Kernel {
+
+NonnullOwnPtr<BochsDisplayConnector> BochsDisplayConnector::must_create(PhysicalAddress framebuffer_address, NonnullOwnPtr<Memory::Region> registers_region, size_t registers_region_offset)
+{
+    auto connector = adopt_own_if_nonnull(new (nothrow) BochsDisplayConnector(framebuffer_address, move(registers_region), registers_region_offset)).release_nonnull();
+    MUST(connector->create_attached_framebuffer_console());
+    return connector;
+}
+
+ErrorOr<void> BochsDisplayConnector::create_attached_framebuffer_console()
+{
+    // We assume safe resolution is 1024x768x32
+    m_framebuffer_console = Graphics::ContiguousFramebufferConsole::initialize(m_framebuffer_address, 1024, 768, 1024 * sizeof(u32));
+    GraphicsManagement::the().set_console(*m_framebuffer_console);
+    return {};
+}
+
+void BochsDisplayConnector::enable_console()
+{
+    VERIFY(m_framebuffer_console);
+    m_framebuffer_console->enable();
+}
+void BochsDisplayConnector::disable_console()
+{
+    VERIFY(m_framebuffer_console);
+    m_framebuffer_console->disable();
+}
+
+BochsDisplayConnector::BochsDisplayConnector(PhysicalAddress framebuffer_address)
+    : DisplayConnector()
+    , m_framebuffer_address(framebuffer_address)
+{
+}
+
+BochsDisplayConnector::BochsDisplayConnector(PhysicalAddress framebuffer_address, NonnullOwnPtr<Memory::Region> registers_region, size_t registers_region_offset)
+    : DisplayConnector()
+    , m_framebuffer_address(framebuffer_address)
+{
+    m_registers.region = move(registers_region);
+    m_registers.offset = registers_region_offset;
+}
+
+BochsDisplayConnector::IndexID BochsDisplayConnector::index_id() const
+{
+    return m_registers->bochs_regs.index_id;
+}
+
+void BochsDisplayConnector::set_framebuffer_to_big_endian_format()
+{
+    MutexLocker locker(m_modeset_lock);
+    dbgln_if(BXVGA_DEBUG, "BochsDisplayConnector set_framebuffer_to_big_endian_format");
+    full_memory_barrier();
+    if (m_registers->extension_regs.region_size == 0xFFFFFFFF || m_registers->extension_regs.region_size == 0)
+        return;
+    full_memory_barrier();
+    m_registers->extension_regs.framebuffer_byteorder = BOCHS_DISPLAY_BIG_ENDIAN;
+    full_memory_barrier();
+}
+
+void BochsDisplayConnector::set_framebuffer_to_little_endian_format()
+{
+    MutexLocker locker(m_modeset_lock);
+    dbgln_if(BXVGA_DEBUG, "BochsDisplayConnector set_framebuffer_to_little_endian_format");
+    full_memory_barrier();
+    if (m_registers->extension_regs.region_size == 0xFFFFFFFF || m_registers->extension_regs.region_size == 0)
+        return;
+    full_memory_barrier();
+    m_registers->extension_regs.framebuffer_byteorder = BOCHS_DISPLAY_LITTLE_ENDIAN;
+    full_memory_barrier();
+}
+
+ErrorOr<void> BochsDisplayConnector::set_safe_resolution()
+{
+    DisplayConnector::Resolution safe_resolution { 1024, 768, {} };
+    return set_resolution(safe_resolution);
+}
+
+ErrorOr<void> BochsDisplayConnector::unblank()
+{
+    MutexLocker locker(m_modeset_lock);
+    full_memory_barrier();
+    m_registers->vga_ioports[0] = 0x20;
+    full_memory_barrier();
+    return {};
+}
+
+ErrorOr<void> BochsDisplayConnector::set_y_offset(size_t y_offset)
+{
+    MutexLocker locker(m_modeset_lock);
+    m_registers->bochs_regs.y_offset = y_offset;
+    return {};
+}
+
+ErrorOr<DisplayConnector::Resolution> BochsDisplayConnector::get_resolution()
+{
+    MutexLocker locker(m_modeset_lock);
+    return Resolution { m_registers->bochs_regs.xres, m_registers->bochs_regs.yres, {} };
+}
+
+ErrorOr<void> BochsDisplayConnector::set_resolution(Resolution const& resolution)
+{
+    MutexLocker locker(m_modeset_lock);
+    VERIFY(m_framebuffer_console);
+    size_t width = resolution.width;
+    size_t height = resolution.height;
+
+    if (Checked<size_t>::multiplication_would_overflow(width, height, sizeof(u32)))
+        return EOVERFLOW;
+
+    dbgln_if(BXVGA_DEBUG, "BochsDisplayConnector resolution registers set to - {}x{}", width, height);
+    m_registers->bochs_regs.enable = 0;
+    full_memory_barrier();
+    m_registers->bochs_regs.xres = width;
+    m_registers->bochs_regs.yres = height;
+    m_registers->bochs_regs.virt_width = width;
+    m_registers->bochs_regs.virt_height = height * 2;
+    m_registers->bochs_regs.bpp = 32;
+    full_memory_barrier();
+    m_registers->bochs_regs.enable = to_underlying(BochsFramebufferSettings::Enabled) | to_underlying(BochsFramebufferSettings::LinearFramebuffer);
+    full_memory_barrier();
+    m_registers->bochs_regs.bank = 0;
+    if (index_id().value() == VBE_DISPI_ID5) {
+        set_framebuffer_to_little_endian_format();
+    }
+
+    if ((u16)width != m_registers->bochs_regs.xres || (u16)height != m_registers->bochs_regs.yres) {
+        return Error::from_errno(ENOTIMPL);
+    }
+    m_framebuffer_console->set_resolution(width, height, width * sizeof(u32));
+    return {};
+}
+
+ErrorOr<ByteBuffer> BochsDisplayConnector::get_edid() const
+{
+    return ByteBuffer::copy(const_cast<u8 const*>(m_registers->edid_data), sizeof(m_registers->edid_data));
+}
+
+}

--- a/Kernel/Graphics/Bochs/DisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/DisplayConnector.cpp
@@ -83,7 +83,7 @@ void BochsDisplayConnector::set_framebuffer_to_little_endian_format()
 
 ErrorOr<void> BochsDisplayConnector::set_safe_resolution()
 {
-    DisplayConnector::Resolution safe_resolution { 1024, 768, {} };
+    DisplayConnector::Resolution safe_resolution { 1024, 768, 32, {} };
     return set_resolution(safe_resolution);
 }
 
@@ -106,7 +106,7 @@ ErrorOr<void> BochsDisplayConnector::set_y_offset(size_t y_offset)
 ErrorOr<DisplayConnector::Resolution> BochsDisplayConnector::get_resolution()
 {
     MutexLocker locker(m_modeset_lock);
-    return Resolution { m_registers->bochs_regs.xres, m_registers->bochs_regs.yres, {} };
+    return Resolution { m_registers->bochs_regs.xres, m_registers->bochs_regs.yres, 32, {} };
 }
 
 ErrorOr<void> BochsDisplayConnector::set_resolution(Resolution const& resolution)
@@ -115,6 +115,11 @@ ErrorOr<void> BochsDisplayConnector::set_resolution(Resolution const& resolution
     VERIFY(m_framebuffer_console);
     size_t width = resolution.width;
     size_t height = resolution.height;
+    size_t bpp = resolution.bpp;
+    if (bpp != 32) {
+        dbgln_if(BXVGA_DEBUG, "BochsDisplayConnector - no support for non-32bpp resolutions");
+        return Error::from_errno(ENOTSUP);
+    }
 
     if (Checked<size_t>::multiplication_would_overflow(width, height, sizeof(u32)))
         return EOVERFLOW;

--- a/Kernel/Graphics/Bochs/DisplayConnector.h
+++ b/Kernel/Graphics/Bochs/DisplayConnector.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/RefPtr.h>
+#include <AK/Try.h>
+#include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
+#include <Kernel/Graphics/DisplayConnector.h>
+#include <Kernel/Locking/Spinlock.h>
+#include <Kernel/Memory/TypedMapping.h>
+
+namespace Kernel {
+
+struct BochsDisplayMMIORegisters;
+class BochsDisplayConnector
+    : public DisplayConnector {
+    friend class BochsGraphicsAdapter;
+
+public:
+    TYPEDEF_DISTINCT_ORDERED_ID(u16, IndexID);
+
+    static NonnullOwnPtr<BochsDisplayConnector> must_create(PhysicalAddress framebuffer_address, NonnullOwnPtr<Memory::Region> registers_region, size_t registers_region_offset);
+
+    virtual IndexID index_id() const;
+
+protected:
+    ErrorOr<void> create_attached_framebuffer_console();
+
+    explicit BochsDisplayConnector(PhysicalAddress framebuffer_address);
+
+private:
+    BochsDisplayConnector(PhysicalAddress framebuffer_address, NonnullOwnPtr<Memory::Region> registers_region, size_t registers_region_offset);
+
+    void enable_console();
+    void disable_console();
+
+    virtual bool modesetting_capable() const override { return true; }
+    virtual bool double_framebuffering_capable() const override { return true; }
+    virtual ErrorOr<ByteBuffer> get_edid() const override;
+    virtual ErrorOr<void> set_resolution(Resolution const&) override;
+    virtual ErrorOr<void> set_safe_resolution() override;
+    virtual ErrorOr<Resolution> get_resolution() override;
+    virtual ErrorOr<void> set_y_offset(size_t y) override;
+    virtual ErrorOr<void> unblank() override;
+
+    void set_framebuffer_to_big_endian_format();
+    void set_framebuffer_to_little_endian_format();
+
+protected:
+    Mutex m_modeset_lock;
+
+private:
+    const PhysicalAddress m_framebuffer_address;
+    Memory::TypedMapping<BochsDisplayMMIORegisters volatile> m_registers;
+    RefPtr<Graphics::GenericFramebufferConsole> m_framebuffer_console;
+};
+}

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -6,127 +6,64 @@
 
 #include <AK/Atomic.h>
 #include <AK/Checked.h>
+#include <AK/Try.h>
 #include <Kernel/Arch/x86/IO.h>
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/IDs.h>
 #include <Kernel/Debug.h>
+#include <Kernel/Graphics/Bochs/Definitions.h>
+#include <Kernel/Graphics/Bochs/DisplayConnector.h>
 #include <Kernel/Graphics/Bochs/GraphicsAdapter.h>
+#include <Kernel/Graphics/Bochs/VBoxDisplayConnector.h>
 #include <Kernel/Graphics/Console/ContiguousFramebufferConsole.h>
 #include <Kernel/Graphics/GraphicsManagement.h>
 #include <Kernel/Memory/TypedMapping.h>
 #include <Kernel/Sections.h>
 
-#define VBE_DISPI_IOPORT_INDEX 0x01CE
-#define VBE_DISPI_IOPORT_DATA 0x01CF
-
-#define VBE_DISPI_ID5 0xB0C5
-
-#define BOCHS_DISPLAY_LITTLE_ENDIAN 0x1e1e1e1e
-#define BOCHS_DISPLAY_BIG_ENDIAN 0xbebebebe
-
 namespace Kernel {
-
-enum class BochsFramebufferSettings {
-    Enabled = 0x1,
-    LinearFramebuffer = 0x40,
-};
-
-enum class BochsDISPIRegisters {
-    ID = 0x0,
-    XRES = 0x1,
-    YRES = 0x2,
-    BPP = 0x3,
-    ENABLE = 0x4,
-    BANK = 0x5,
-    VIRT_WIDTH = 0x6,
-    VIRT_HEIGHT = 0x7,
-    X_OFFSET = 0x8,
-    Y_OFFSET = 0x9,
-};
-
-struct [[gnu::packed]] DISPIInterface {
-    u16 index_id;
-    u16 xres;
-    u16 yres;
-    u16 bpp;
-    u16 enable;
-    u16 bank;
-    u16 virt_width;
-    u16 virt_height;
-    u16 x_offset;
-    u16 y_offset;
-};
-
-struct [[gnu::packed]] ExtensionRegisters {
-    u32 region_size;
-    u32 framebuffer_byteorder;
-};
-
-struct [[gnu::packed]] BochsDisplayMMIORegisters {
-    u8 edid_data[0x400];
-    u16 vga_ioports[0x10];
-    u8 reserved[0xE0];
-    DISPIInterface bochs_regs;
-    u8 reserved2[0x100 - sizeof(DISPIInterface)];
-    ExtensionRegisters extension_regs;
-};
 
 UNMAP_AFTER_INIT NonnullRefPtr<BochsGraphicsAdapter> BochsGraphicsAdapter::initialize(PCI::DeviceIdentifier const& pci_device_identifier)
 {
     PCI::HardwareID id = pci_device_identifier.hardware_id();
     VERIFY((id.vendor_id == PCI::VendorID::QEMUOld && id.device_id == 0x1111) || (id.vendor_id == PCI::VendorID::VirtualBox && id.device_id == 0xbeef));
-    return adopt_ref(*new BochsGraphicsAdapter(pci_device_identifier));
-}
-
-void BochsGraphicsAdapter::set_framebuffer_to_big_endian_format()
-{
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter set_framebuffer_to_big_endian_format");
-    full_memory_barrier();
-    if (m_registers->extension_regs.region_size == 0xFFFFFFFF || m_registers->extension_regs.region_size == 0)
-        return;
-    full_memory_barrier();
-    m_registers->extension_regs.framebuffer_byteorder = BOCHS_DISPLAY_BIG_ENDIAN;
-    full_memory_barrier();
-}
-
-void BochsGraphicsAdapter::set_framebuffer_to_little_endian_format()
-{
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter set_framebuffer_to_little_endian_format");
-    full_memory_barrier();
-    if (m_registers->extension_regs.region_size == 0xFFFFFFFF || m_registers->extension_regs.region_size == 0)
-        return;
-    full_memory_barrier();
-    m_registers->extension_regs.framebuffer_byteorder = BOCHS_DISPLAY_LITTLE_ENDIAN;
-    full_memory_barrier();
+    auto adapter = adopt_ref(*new BochsGraphicsAdapter(pci_device_identifier));
+    MUST(adapter->initialize_adapter(pci_device_identifier));
+    return adapter;
 }
 
 UNMAP_AFTER_INIT BochsGraphicsAdapter::BochsGraphicsAdapter(PCI::DeviceIdentifier const& pci_device_identifier)
     : PCI::Device(pci_device_identifier.address())
-    , m_mmio_registers(PCI::get_BAR2(pci_device_identifier.address()) & 0xfffffff0)
-    , m_registers(Memory::map_typed_writable<BochsDisplayMMIORegisters volatile>(m_mmio_registers).release_value_but_fixme_should_propagate_errors())
 {
-    // We assume safe resolution is 1024x768x32
-    m_framebuffer_console = Graphics::ContiguousFramebufferConsole::initialize(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), 1024, 768, 1024 * sizeof(u32));
-    GraphicsManagement::the().set_console(*m_framebuffer_console);
-
-    auto vendor_id = pci_device_identifier.hardware_id().vendor_id;
-    auto device_id = pci_device_identifier.hardware_id().device_id;
-    auto revision_id = pci_device_identifier.revision_id();
-
-    auto is_bochs = vendor_id == PCI::VendorID::QEMUOld && device_id == 0x1111 && revision_id == 0;
-    auto is_virtualbox = vendor_id == PCI::VendorID::VirtualBox && device_id == 0xbeef;
-
-    if (is_bochs || is_virtualbox)
-        m_io_required = true;
-
     if (pci_device_identifier.class_code().value() == 0x3 && pci_device_identifier.subclass_code().value() == 0x0)
         m_is_vga_capable = true;
+}
+
+UNMAP_AFTER_INIT ErrorOr<void> BochsGraphicsAdapter::initialize_adapter(PCI::DeviceIdentifier const& pci_device_identifier)
+{
+    // Note: If we use VirtualBox graphics adapter (which is based on Bochs one), we need to use IO ports
+    // Note: Bochs (the real bochs graphics adapter in the Bochs emulator) uses revision ID of 0x0
+    // and doesn't support memory-mapped IO registers.
+    if (pci_device_identifier.revision_id().value() == 0x0
+        || (pci_device_identifier.hardware_id().vendor_id == 0x80ee && pci_device_identifier.hardware_id().device_id == 0xbeef)) {
+        m_display_connector = VBoxDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0));
+    } else {
+        auto registers_mapping = TRY(Memory::map_typed_writable<BochsDisplayMMIORegisters volatile>(PhysicalAddress(PCI::get_BAR2(pci_device_identifier.address()) & 0xfffffff0)));
+        VERIFY(registers_mapping.region);
+        m_display_connector = BochsDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), registers_mapping.region.release_nonnull(), registers_mapping.offset);
+    }
 
     // Note: According to Gerd Hoffmann - "The linux driver simply does
     // the unblank unconditionally. With bochs-display this is not needed but
     // it also has no bad side effect".
-    unblank();
-    set_safe_resolution();
+    // FIXME: If the error is ENOTIMPL, ignore it for now until we implement
+    // unblank support for VBoxDisplayConnector class too.
+    auto result = m_display_connector->unblank();
+    if (result.is_error() && result.error().code() != ENOTIMPL)
+        return result;
+
+    TRY(m_display_connector->set_safe_resolution());
+
+    return {};
 }
 
 UNMAP_AFTER_INIT void BochsGraphicsAdapter::initialize_framebuffer_devices()
@@ -144,151 +81,45 @@ bool BochsGraphicsAdapter::vga_compatible() const
     return m_is_vga_capable;
 }
 
-void BochsGraphicsAdapter::unblank()
+ErrorOr<ByteBuffer> BochsGraphicsAdapter::get_edid(size_t output_port_index) const
 {
-    full_memory_barrier();
-    m_registers->vga_ioports[0] = 0x20;
-    full_memory_barrier();
+    if (output_port_index != 0)
+        return Error::from_errno(ENODEV);
+    return m_display_connector->get_edid();
 }
 
-void BochsGraphicsAdapter::set_safe_resolution()
+ErrorOr<void> BochsGraphicsAdapter::set_resolution(size_t output_port_index, size_t width, size_t height)
 {
-    VERIFY(m_framebuffer_console);
-    auto result = try_to_set_resolution(0, 1024, 768);
-    VERIFY(result);
+    if (output_port_index != 0)
+        return Error::from_errno(ENODEV);
+    return m_display_connector->set_resolution({ width, height, {} });
 }
-
-static void set_register_with_io(u16 index, u16 data)
+ErrorOr<void> BochsGraphicsAdapter::set_y_offset(size_t output_port_index, size_t y)
 {
-    IO::out16(VBE_DISPI_IOPORT_INDEX, index);
-    IO::out16(VBE_DISPI_IOPORT_DATA, data);
-}
-
-static u16 get_register_with_io(u16 index)
-{
-    IO::out16(VBE_DISPI_IOPORT_INDEX, index);
-    return IO::in16(VBE_DISPI_IOPORT_DATA);
-}
-
-BochsGraphicsAdapter::IndexID BochsGraphicsAdapter::index_id() const
-{
-    if (m_io_required) {
-        return get_register_with_io(0);
-    }
-    return m_registers->bochs_regs.index_id;
-}
-
-void BochsGraphicsAdapter::set_resolution_registers_via_io(size_t width, size_t height)
-{
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter resolution registers set to - {}x{}", width, height);
-
-    set_register_with_io(to_underlying(BochsDISPIRegisters::ENABLE), 0);
-    set_register_with_io(to_underlying(BochsDISPIRegisters::XRES), (u16)width);
-    set_register_with_io(to_underlying(BochsDISPIRegisters::YRES), (u16)height);
-    set_register_with_io(to_underlying(BochsDISPIRegisters::VIRT_WIDTH), (u16)width);
-    set_register_with_io(to_underlying(BochsDISPIRegisters::VIRT_HEIGHT), (u16)height * 2);
-    set_register_with_io(to_underlying(BochsDISPIRegisters::BPP), 32);
-    set_register_with_io(to_underlying(BochsDISPIRegisters::ENABLE), to_underlying(BochsFramebufferSettings::Enabled) | to_underlying(BochsFramebufferSettings::LinearFramebuffer));
-    set_register_with_io(to_underlying(BochsDISPIRegisters::BANK), 0);
-}
-
-void BochsGraphicsAdapter::set_resolution_registers(size_t width, size_t height)
-{
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter resolution registers set to - {}x{}", width, height);
-    m_registers->bochs_regs.enable = 0;
-    full_memory_barrier();
-    m_registers->bochs_regs.xres = width;
-    m_registers->bochs_regs.yres = height;
-    m_registers->bochs_regs.virt_width = width;
-    m_registers->bochs_regs.virt_height = height * 2;
-    m_registers->bochs_regs.bpp = 32;
-    full_memory_barrier();
-    m_registers->bochs_regs.enable = to_underlying(BochsFramebufferSettings::Enabled) | to_underlying(BochsFramebufferSettings::LinearFramebuffer);
-    full_memory_barrier();
-    m_registers->bochs_regs.bank = 0;
-    if (index_id().value() == VBE_DISPI_ID5) {
-        set_framebuffer_to_little_endian_format();
-    }
-}
-
-bool BochsGraphicsAdapter::try_to_set_resolution(size_t output_port_index, size_t width, size_t height)
-{
-    // Note: There's only one output port for this adapter
-    VERIFY(output_port_index == 0);
-    VERIFY(m_framebuffer_console);
-    if (Checked<size_t>::multiplication_would_overflow(width, height, sizeof(u32)))
-        return false;
-
-    if (m_io_required)
-        set_resolution_registers_via_io(width, height);
-    else
-        set_resolution_registers(width, height);
-    dbgln_if(BXVGA_DEBUG, "BochsGraphicsAdapter resolution test - {}x{}", width, height);
-    if (m_io_required) {
-        if (!validate_setup_resolution_with_io(width, height))
-            return false;
-    } else {
-        if (!validate_setup_resolution(width, height))
-            return false;
-    }
-
-    dbgln("BochsGraphicsAdapter: resolution set to {}x{}", width, height);
-    m_framebuffer_console->set_resolution(width, height, width * sizeof(u32));
-    return true;
-}
-
-bool BochsGraphicsAdapter::validate_setup_resolution_with_io(size_t width, size_t height)
-{
-    if ((u16)width != get_register_with_io(to_underlying(BochsDISPIRegisters::XRES)) || (u16)height != get_register_with_io(to_underlying(BochsDISPIRegisters::YRES))) {
-        return false;
-    }
-    return true;
-}
-
-bool BochsGraphicsAdapter::validate_setup_resolution(size_t width, size_t height)
-{
-    if ((u16)width != m_registers->bochs_regs.xres || (u16)height != m_registers->bochs_regs.yres) {
-        return false;
-    }
-    return true;
-}
-
-bool BochsGraphicsAdapter::set_y_offset(size_t output_port_index, size_t y_offset)
-{
-    VERIFY(output_port_index == 0);
+    if (output_port_index != 0)
+        return Error::from_errno(ENODEV);
     if (m_console_enabled)
-        return false;
-    m_registers->bochs_regs.y_offset = y_offset;
-    return true;
+        return Error::from_errno(EBUSY);
+    return m_display_connector->set_y_offset(y);
 }
 
 void BochsGraphicsAdapter::enable_consoles()
 {
     SpinlockLocker lock(m_console_mode_switch_lock);
-    VERIFY(m_framebuffer_console);
     m_console_enabled = true;
-    m_registers->bochs_regs.y_offset = 0;
+    MUST(m_display_connector->set_y_offset(0));
     if (m_framebuffer_device)
         m_framebuffer_device->deactivate_writes();
-    m_framebuffer_console->enable();
+    m_display_connector->enable_console();
 }
 void BochsGraphicsAdapter::disable_consoles()
 {
     SpinlockLocker lock(m_console_mode_switch_lock);
-    VERIFY(m_framebuffer_console);
     VERIFY(m_framebuffer_device);
     m_console_enabled = false;
-    m_registers->bochs_regs.y_offset = 0;
-    m_framebuffer_console->disable();
+    MUST(m_display_connector->set_y_offset(0));
+    m_display_connector->disable_console();
     m_framebuffer_device->activate_writes();
-}
-
-ErrorOr<ByteBuffer> BochsGraphicsAdapter::get_edid(size_t output_port_index) const
-{
-    if (output_port_index != 0)
-        return Error::from_errno(ENODEV);
-
-    return ByteBuffer::copy(const_cast<u8 const*>(m_registers->edid_data), sizeof(m_registers->edid_data));
 }
 
 }

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -92,7 +92,7 @@ ErrorOr<void> BochsGraphicsAdapter::set_resolution(size_t output_port_index, siz
 {
     if (output_port_index != 0)
         return Error::from_errno(ENODEV);
-    return m_display_connector->set_resolution({ width, height, {} });
+    return m_display_connector->set_resolution({ width, height, 32, {} });
 }
 ErrorOr<void> BochsGraphicsAdapter::set_y_offset(size_t output_port_index, size_t y)
 {

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -8,7 +8,6 @@
 
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Device.h>
-#include <Kernel/Graphics/Console/GenericFramebufferConsole.h>
 #include <Kernel/Graphics/FramebufferDevice.h>
 #include <Kernel/Graphics/GenericGraphicsAdapter.h>
 #include <Kernel/Memory/TypedMapping.h>
@@ -19,12 +18,10 @@ namespace Kernel {
 class GraphicsManagement;
 struct BochsDisplayMMIORegisters;
 
+class BochsDisplayConnector;
 class BochsGraphicsAdapter final : public GenericGraphicsAdapter
     , public PCI::Device {
     friend class GraphicsManagement;
-
-private:
-    TYPEDEF_DISTINCT_ORDERED_ID(u16, IndexID);
 
 public:
     static NonnullRefPtr<BochsGraphicsAdapter> initialize(PCI::DeviceIdentifier const&);
@@ -39,9 +36,11 @@ public:
 private:
     ErrorOr<ByteBuffer> get_edid(size_t output_port_index) const override;
 
+    ErrorOr<void> initialize_adapter(PCI::DeviceIdentifier const&);
+
     // ^GenericGraphicsAdapter
-    virtual bool try_to_set_resolution(size_t output_port_index, size_t width, size_t height) override;
-    virtual bool set_y_offset(size_t output_port_index, size_t y) override;
+    virtual ErrorOr<void> set_resolution(size_t output_port_index, size_t width, size_t height) override;
+    virtual ErrorOr<void> set_y_offset(size_t output_port_index, size_t y) override;
 
     virtual void initialize_framebuffer_devices() override;
 
@@ -50,28 +49,11 @@ private:
 
     explicit BochsGraphicsAdapter(PCI::DeviceIdentifier const&);
 
-    IndexID index_id() const;
-
-    void set_safe_resolution();
-    void unblank();
-
-    bool validate_setup_resolution(size_t width, size_t height);
-    u32 find_framebuffer_address();
-    void set_resolution_registers(size_t width, size_t height);
-    void set_resolution_registers_via_io(size_t width, size_t height);
-    bool validate_setup_resolution_with_io(size_t width, size_t height);
-    void set_y_offset(size_t);
-
-    void set_framebuffer_to_big_endian_format();
-    void set_framebuffer_to_little_endian_format();
-
-    PhysicalAddress m_mmio_registers;
-    Memory::TypedMapping<BochsDisplayMMIORegisters volatile> m_registers;
+    OwnPtr<BochsDisplayConnector> m_display_connector;
     RefPtr<FramebufferDevice> m_framebuffer_device;
-    RefPtr<Graphics::GenericFramebufferConsole> m_framebuffer_console;
+
     Spinlock m_console_mode_switch_lock;
     bool m_console_enabled { false };
-    bool m_io_required { false };
     bool m_is_vga_capable { false };
 };
 }

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.h
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.h
@@ -36,9 +36,9 @@ public:
 
     virtual bool vga_compatible() const override;
 
+private:
     ErrorOr<ByteBuffer> get_edid(size_t output_port_index) const override;
 
-private:
     // ^GenericGraphicsAdapter
     virtual bool try_to_set_resolution(size_t output_port_index, size_t width, size_t height) override;
     virtual bool set_y_offset(size_t output_port_index, size_t y) override;

--- a/Kernel/Graphics/Bochs/VBoxDisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/VBoxDisplayConnector.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/Arch/x86/IO.h>
+#include <Kernel/Debug.h>
+#include <Kernel/Graphics/Bochs/Definitions.h>
+#include <Kernel/Graphics/Bochs/VBoxDisplayConnector.h>
+
+namespace Kernel {
+
+NonnullOwnPtr<VBoxDisplayConnector> VBoxDisplayConnector::must_create(PhysicalAddress framebuffer_address)
+{
+    auto connector = adopt_own_if_nonnull(new (nothrow) VBoxDisplayConnector(framebuffer_address)).release_nonnull();
+    MUST(connector->create_attached_framebuffer_console());
+    return connector;
+}
+
+VBoxDisplayConnector::VBoxDisplayConnector(PhysicalAddress framebuffer_address)
+    : BochsDisplayConnector(framebuffer_address)
+{
+}
+
+static void set_register_with_io(u16 index, u16 data)
+{
+    IO::out16(VBE_DISPI_IOPORT_INDEX, index);
+    IO::out16(VBE_DISPI_IOPORT_DATA, data);
+}
+
+static u16 get_register_with_io(u16 index)
+{
+    IO::out16(VBE_DISPI_IOPORT_INDEX, index);
+    return IO::in16(VBE_DISPI_IOPORT_DATA);
+}
+
+ErrorOr<ByteBuffer> VBoxDisplayConnector::get_edid() const
+{
+    return Error::from_errno(ENOTIMPL);
+}
+
+BochsDisplayConnector::IndexID VBoxDisplayConnector::index_id() const
+{
+    return get_register_with_io(0);
+}
+
+ErrorOr<void> VBoxDisplayConnector::set_resolution(Resolution const& resolution)
+{
+    MutexLocker locker(m_modeset_lock);
+    size_t width = resolution.width;
+    size_t height = resolution.height;
+
+    dbgln_if(BXVGA_DEBUG, "VBoxDisplayConnector resolution registers set to - {}x{}", width, height);
+
+    set_register_with_io(to_underlying(BochsDISPIRegisters::ENABLE), 0);
+    set_register_with_io(to_underlying(BochsDISPIRegisters::XRES), (u16)width);
+    set_register_with_io(to_underlying(BochsDISPIRegisters::YRES), (u16)height);
+    set_register_with_io(to_underlying(BochsDISPIRegisters::VIRT_WIDTH), (u16)width);
+    set_register_with_io(to_underlying(BochsDISPIRegisters::VIRT_HEIGHT), (u16)height * 2);
+    set_register_with_io(to_underlying(BochsDISPIRegisters::BPP), 32);
+    set_register_with_io(to_underlying(BochsDISPIRegisters::ENABLE), to_underlying(BochsFramebufferSettings::Enabled) | to_underlying(BochsFramebufferSettings::LinearFramebuffer));
+    set_register_with_io(to_underlying(BochsDISPIRegisters::BANK), 0);
+    if ((u16)width != get_register_with_io(to_underlying(BochsDISPIRegisters::XRES)) || (u16)height != get_register_with_io(to_underlying(BochsDISPIRegisters::YRES))) {
+        return Error::from_errno(ENOTIMPL);
+    }
+    return {};
+}
+
+ErrorOr<DisplayConnector::Resolution> VBoxDisplayConnector::get_resolution()
+{
+    MutexLocker locker(m_modeset_lock);
+    return Resolution { get_register_with_io(to_underlying(BochsDISPIRegisters::XRES)), get_register_with_io(to_underlying(BochsDISPIRegisters::YRES)), {} };
+}
+
+ErrorOr<void> VBoxDisplayConnector::set_y_offset(size_t y_offset)
+{
+    MutexLocker locker(m_modeset_lock);
+    set_register_with_io(to_underlying(BochsDISPIRegisters::Y_OFFSET), (u16)y_offset);
+    return {};
+}
+
+ErrorOr<void> VBoxDisplayConnector::unblank()
+{
+    return Error::from_errno(ENOTIMPL);
+}
+
+}

--- a/Kernel/Graphics/Bochs/VBoxDisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/VBoxDisplayConnector.cpp
@@ -50,6 +50,11 @@ ErrorOr<void> VBoxDisplayConnector::set_resolution(Resolution const& resolution)
     MutexLocker locker(m_modeset_lock);
     size_t width = resolution.width;
     size_t height = resolution.height;
+    size_t bpp = resolution.bpp;
+    if (bpp != 32) {
+        dbgln_if(BXVGA_DEBUG, "VBoxDisplayConnector - no support for non-32bpp resolutions");
+        return Error::from_errno(ENOTSUP);
+    }
 
     dbgln_if(BXVGA_DEBUG, "VBoxDisplayConnector resolution registers set to - {}x{}", width, height);
 
@@ -70,7 +75,8 @@ ErrorOr<void> VBoxDisplayConnector::set_resolution(Resolution const& resolution)
 ErrorOr<DisplayConnector::Resolution> VBoxDisplayConnector::get_resolution()
 {
     MutexLocker locker(m_modeset_lock);
-    return Resolution { get_register_with_io(to_underlying(BochsDISPIRegisters::XRES)), get_register_with_io(to_underlying(BochsDISPIRegisters::YRES)), {} };
+    auto width = get_register_with_io(to_underlying(BochsDISPIRegisters::XRES));
+    return Resolution { width, get_register_with_io(to_underlying(BochsDISPIRegisters::YRES)), 32, {} };
 }
 
 ErrorOr<void> VBoxDisplayConnector::set_y_offset(size_t y_offset)

--- a/Kernel/Graphics/Bochs/VBoxDisplayConnector.h
+++ b/Kernel/Graphics/Bochs/VBoxDisplayConnector.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Graphics/Bochs/DisplayConnector.h>
+
+namespace Kernel {
+
+class VBoxDisplayConnector final
+    : public BochsDisplayConnector {
+
+public:
+    static NonnullOwnPtr<VBoxDisplayConnector> must_create(PhysicalAddress framebuffer_address);
+
+    virtual IndexID index_id() const override;
+
+private:
+    virtual bool double_framebuffering_capable() const override { return false; }
+    virtual ErrorOr<ByteBuffer> get_edid() const override;
+    virtual ErrorOr<void> set_resolution(Resolution const&) override;
+    virtual ErrorOr<Resolution> get_resolution() override;
+    virtual ErrorOr<void> set_y_offset(size_t y) override;
+    virtual ErrorOr<void> unblank() override;
+
+    explicit VBoxDisplayConnector(PhysicalAddress framebuffer_address);
+};
+}

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Types.h>
+
+namespace Kernel {
+
+class DisplayConnector {
+public:
+    struct Resolution {
+        size_t width;
+        size_t height;
+        Optional<size_t> refresh_rate;
+    };
+
+    virtual ~DisplayConnector() = default;
+
+    virtual bool modesetting_capable() const = 0;
+    virtual bool double_framebuffering_capable() const = 0;
+    virtual ErrorOr<ByteBuffer> get_edid() const = 0;
+    virtual ErrorOr<void> set_resolution(Resolution const&) = 0;
+    virtual ErrorOr<void> set_safe_resolution() = 0;
+    virtual ErrorOr<Resolution> get_resolution() = 0;
+    virtual ErrorOr<void> set_y_offset(size_t y) = 0;
+    virtual ErrorOr<void> unblank() = 0;
+
+protected:
+    DisplayConnector() = default;
+};
+}

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -15,6 +15,7 @@ public:
     struct Resolution {
         size_t width;
         size_t height;
+        size_t bpp;
         Optional<size_t> refresh_rate;
     };
 

--- a/Kernel/Graphics/FramebufferDevice.cpp
+++ b/Kernel/Graphics/FramebufferDevice.cpp
@@ -198,10 +198,7 @@ ErrorOr<void> FramebufferDevice::set_head_resolution(size_t head, size_t width, 
     auto adapter = m_graphics_adapter.strong_ref();
     if (!adapter)
         return Error::from_errno(EIO);
-    auto result = adapter->try_to_set_resolution(0, width, height);
-    // FIXME: Find a better way to return here a ErrorOr<void>.
-    if (!result)
-        return Error::from_errno(ENOTSUP);
+    TRY(adapter->set_resolution(0, width, height));
     m_framebuffer_width = width;
     m_framebuffer_height = height;
     m_framebuffer_pitch = width * sizeof(u32);
@@ -218,16 +215,10 @@ ErrorOr<void> FramebufferDevice::set_head_buffer(size_t head, bool second_buffer
     if (!adapter)
         return Error::from_errno(EIO);
     if (second_buffer) {
-        if (!adapter->set_y_offset(0, m_framebuffer_height)) {
-            // FIXME: Find a better ErrorOr<void> here.
-            return Error::from_errno(ENOTSUP);
-        }
+        TRY(adapter->set_y_offset(0, m_framebuffer_height));
         m_y_offset = m_framebuffer_height;
     } else {
-        if (!adapter->set_y_offset(0, 0)) {
-            // FIXME: Find a better ErrorOr<void> here.
-            return Error::from_errno(ENOTSUP);
-        }
+        TRY(adapter->set_y_offset(0, 0));
         m_y_offset = 0;
     }
     return {};

--- a/Kernel/Graphics/GenericGraphicsAdapter.h
+++ b/Kernel/Graphics/GenericGraphicsAdapter.h
@@ -31,8 +31,8 @@ public:
 
     virtual ErrorOr<ByteBuffer> get_edid(size_t output_port_index) const = 0;
 
-    virtual bool try_to_set_resolution(size_t output_port_index, size_t width, size_t height) = 0;
-    virtual bool set_y_offset(size_t output_port_index, size_t y) = 0;
+    virtual ErrorOr<void> set_resolution(size_t output_port_index, size_t width, size_t height) = 0;
+    virtual ErrorOr<void> set_y_offset(size_t output_port_index, size_t y) = 0;
 
 protected:
     GenericGraphicsAdapter() = default;

--- a/Kernel/Graphics/VGA/ISAAdapter.cpp
+++ b/Kernel/Graphics/VGA/ISAAdapter.cpp
@@ -38,13 +38,4 @@ void ISAVGAAdapter::initialize_framebuffer_devices()
 {
 }
 
-bool ISAVGAAdapter::try_to_set_resolution(size_t, size_t, size_t)
-{
-    return false;
-}
-bool ISAVGAAdapter::set_y_offset(size_t, size_t)
-{
-    return false;
-}
-
 }

--- a/Kernel/Graphics/VGA/ISAAdapter.h
+++ b/Kernel/Graphics/VGA/ISAAdapter.h
@@ -24,9 +24,6 @@ public:
     // Note: We simply don't support old VGA framebuffer modes (like the 320x200 256-colors one)
     virtual bool framebuffer_devices_initialized() const override { return false; }
 
-    virtual bool try_to_set_resolution(size_t output_port_index, size_t width, size_t height) override;
-    virtual bool set_y_offset(size_t output_port_index, size_t y) override;
-
 private:
     ISAVGAAdapter();
 

--- a/Kernel/Graphics/VGACompatibleAdapter.h
+++ b/Kernel/Graphics/VGACompatibleAdapter.h
@@ -22,8 +22,14 @@ public:
 
     virtual bool vga_compatible() const override final { return true; }
 
-    virtual bool try_to_set_resolution(size_t, size_t, size_t) override { return false; }
-    virtual bool set_y_offset(size_t, size_t) override { return false; }
+    virtual ErrorOr<void> set_resolution(size_t, size_t, size_t) override
+    {
+        return Error::from_errno(ENOTSUP);
+    }
+    virtual ErrorOr<void> set_y_offset(size_t, size_t) override
+    {
+        return Error::from_errno(ENOTSUP);
+    }
 
     ErrorOr<ByteBuffer> get_edid(size_t) const override { return Error::from_errno(ENOTSUP); }
 

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -97,8 +97,8 @@ private:
     virtual bool modesetting_capable() const override { return false; }
     virtual bool double_framebuffering_capable() const override { return false; }
 
-    virtual bool try_to_set_resolution(size_t, size_t, size_t) override { return false; }
-    virtual bool set_y_offset(size_t, size_t) override { return false; }
+    virtual ErrorOr<void> set_resolution(size_t, size_t, size_t) override { return Error::from_errno(ENOTSUP); }
+    virtual ErrorOr<void> set_y_offset(size_t, size_t) override { return Error::from_errno(ENOTSUP); }
 
     struct Scanout {
         RefPtr<Graphics::VirtIOGPU::FramebufferDevice> framebuffer;


### PR DESCRIPTION
Based on #12181. I intend to introduce (in small steps now) a new design for the Graphics subsystem in our Kernel. The idea is to replace framebuffers with a device called DisplayConnector which is not exposing a mmap interface as we can't reliably control it when switching between console mode and desktop mode. So instead, we allow userspace to write to the framebuffer by doing the `write(2)` syscall on that device.

So for now, this is only the head start of this small goal (so I don't replace framebuffer devices, yet), as series of patch series that will continue after this PR.