### PR TITLE
LibGui: Fix Value/OpacitySlider value changes for values less than 0

### DIFF
--- a/Userland/Libraries/LibGUI/OpacitySlider.cpp
+++ b/Userland/Libraries/LibGUI/OpacitySlider.cpp
@@ -103,7 +103,9 @@ int OpacitySlider::value_at(Gfx::IntPoint const& position) const
     if (position.x() > inner_rect.right())
         return max();
     float relative_offset = (float)(position.x() - inner_rect.x()) / (float)inner_rect.width();
-    return relative_offset * (float)max();
+
+    int range = max() - min();
+    return min() + (int)(relative_offset * (float)range);
 }
 
 void OpacitySlider::mousedown_event(MouseEvent& event)

--- a/Userland/Libraries/LibGUI/ValueSlider.cpp
+++ b/Userland/Libraries/LibGUI/ValueSlider.cpp
@@ -139,7 +139,9 @@ int ValueSlider::value_at(Gfx::IntPoint const& position) const
     if (position.x() > bar_rect().right())
         return max();
     float relative_offset = (float)(position.x() - bar_rect().left()) / (float)bar_rect().width();
-    return (int)(relative_offset * (float)max());
+
+    int range = max() - min();
+    return min() + (int)(relative_offset * (float)range);
 }
 
 void ValueSlider::set_value(int value, AllowCallback allow_callback, DoClamp do_clamp)


### PR DESCRIPTION
This patch fixes a value glitch when changing the slider value via
draging the knob with the mouse and having a min value smaller than 0.
Before this patch it was not possible to drag the value blow 0 and it
just snapped to the configured min value if the mouse was at the most
left position. Now the value is calculated from the value range and
mouse position within the widget.