### PR TITLE
LibGUI: Display line number next to the first visual line

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -466,6 +466,10 @@ void TextEditor::paint_event(PaintEvent& event)
         for (size_t i = first_visible_line; i <= last_visible_line; ++i) {
             bool is_current_line = i == m_cursor.line();
             auto ruler_line_rect = ruler_content_rect(i);
+            // NOTE: Shrink the rectangle to be only on the first visual line.
+            auto const line_height = font().preferred_line_height();
+            if (ruler_line_rect.height() > line_height)
+                ruler_line_rect.set_height(line_height);
             // NOTE: Use Painter::draw_text() directly here, as we want to always draw the line numbers in clear text.
             painter.draw_text(
                 ruler_line_rect.shrunken(2, 0),


### PR DESCRIPTION
The number was previously vertically centered, but it prevents from quickly seeing a line change.

Before:
![te-before](https://user-images.githubusercontent.com/26030965/164987983-7bf3ddf3-7f7f-4aaa-8cf3-dd4e41fe5bca.png)

After:
![te-after](https://user-images.githubusercontent.com/26030965/164987987-db9b2db6-4b16-4e2a-b457-e336d4b1d8e7.png)

