### PR TITLE
Toolchain: Explicitly install llvm-config and FileCheck

### DIFF
--- a/Toolchain/CMake/LLVMConfig.cmake
+++ b/Toolchain/CMake/LLVMConfig.cmake
@@ -14,12 +14,12 @@ set(LLVM_ENABLE_RUNTIMES "compiler-rt" CACHE STRING "")
 set(LLVM_ENABLE_PER_TARGET_RUNTIME_DIR ON CACHE BOOL "")
 set(LLVM_ENABLE_BINDINGS OFF CACHE BOOL "")
 set(LLVM_INCLUDE_BENCHMARKS OFF CACHE BOOL "")
-set(LLVM_BUILD_UTILS OFF CACHE BOOL "")
+set(LLVM_BUILD_UTILS ON CACHE BOOL "")
 set(LLVM_INCLUDE_TESTS OFF CACHE BOOL "")
 set(LLVM_BUILD_LLVM_DYLIB ON CACHE BOOL "")
 set(LLVM_LINK_LLVM_DYLIB ON CACHE BOOL "")
-set(LLVM_INSTALL_UTILS OFF CACHE BOOL "")
-set(LLVM_INSTALL_TOOLCHAIN_ONLY ON CACHE BOOL "")
+set(LLVM_INSTALL_UTILS ON CACHE BOOL "")
+set(LLVM_INSTALL_TOOLCHAIN_ONLY OFF CACHE BOOL "Don't install headers, utils, and tools")
 set(LLVM_INSTALL_BINUTILS_SYMLINKS OFF CACHE BOOL "")
 
 set(CLANG_ENABLE_CLANGD OFF CACHE BOOL "")
@@ -56,6 +56,7 @@ endforeach()
 set(LLVM_TOOLCHAIN_TOOLS
         llvm-addr2line
         llvm-ar
+        llvm-config
         llvm-cov
         llvm-cxxfilt
         llvm-dwarfdump
@@ -74,6 +75,11 @@ set(LLVM_TOOLCHAIN_TOOLS
         llvm-strip
         llvm-symbolizer
         CACHE STRING "")
+
+set(LLVM_TOOLCHAIN_UTILITIES
+        FileCheck
+        CACHE STRING ""
+)
 
 set(LLVM_RUNTIME_TARGETS ${targets} CACHE STRING "")
 set(LLVM_BUILTIN_TARGETS ${targets} CACHE STRING "")


### PR DESCRIPTION
Also disable the "toolchain only build" to ensure we install llvm
headers for when we want to build host tools that link against llvm.