### PR TITLE
LibGUI: Polish up undo/redo interactions

### DIFF
--- a/Userland/Libraries/LibGUI/CommonActions.cpp
+++ b/Userland/Libraries/LibGUI/CommonActions.cpp
@@ -67,7 +67,7 @@ NonnullRefPtr<Action> make_undo_action(Function<void(Action&)> callback, Core::O
 
 NonnullRefPtr<Action> make_redo_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return Action::create("&Redo", { Mod_Ctrl, Key_Y }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/redo.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return Action::create("&Redo", { Mod_Ctrl | Mod_Shift, Key_Z }, { Mod_Ctrl, Key_Y }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/redo.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_delete_action(Function<void(Action&)> callback, Core::Object* parent)
@@ -181,12 +181,12 @@ NonnullRefPtr<Action> make_zoom_out_action(Function<void(Action&)> callback, Cor
 
 NonnullRefPtr<Action> make_rotate_clockwise_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return GUI::Action::create("Rotate Clock&wise", { Mod_Ctrl | Mod_Shift, Key_X }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-cw.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return GUI::Action::create("Rotate Clock&wise", { Mod_Ctrl | Mod_Shift, Key_GreaterThan }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-cw.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 NonnullRefPtr<Action> make_rotate_counterclockwise_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    return GUI::Action::create("Rotate &Counterclockwise", { Mod_Ctrl | Mod_Shift, Key_Z }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-ccw.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    return GUI::Action::create("Rotate &Counterclockwise", { Mod_Ctrl | Mod_Shift, Key_LessThan }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/edit-rotate-ccw.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
 }
 
 }

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -762,7 +762,7 @@ String InsertTextCommand::action_text() const
 
 bool InsertTextCommand::merge_with(GUI::Command const& other)
 {
-    if (!is<InsertTextCommand>(other))
+    if (!is<InsertTextCommand>(other) || commit_time_expired())
         return false;
 
     auto const& typed_other = static_cast<InsertTextCommand const&>(other);
@@ -780,6 +780,7 @@ bool InsertTextCommand::merge_with(GUI::Command const& other)
     m_text = builder.to_string();
     m_range.set_end(typed_other.m_range.end());
 
+    m_timestamp = Time::now_monotonic();
     return true;
 }
 
@@ -862,19 +863,24 @@ String RemoveTextCommand::action_text() const
 
 bool RemoveTextCommand::merge_with(GUI::Command const& other)
 {
-    if (!is<RemoveTextCommand>(other))
+    if (!is<RemoveTextCommand>(other) || commit_time_expired())
         return false;
-    auto& typed_other = static_cast<RemoveTextCommand const&>(other);
+
+    auto const& typed_other = static_cast<RemoveTextCommand const&>(other);
+
     if (m_range.start() != typed_other.m_range.end())
         return false;
     if (m_range.start().line() != m_range.end().line())
         return false;
+
     // Merge backspaces
     StringBuilder builder(m_text.length() + typed_other.m_text.length());
     builder.append(typed_other.m_text);
     builder.append(m_text);
     m_text = builder.to_string();
     m_range.set_start(typed_other.m_range.start());
+
+    m_timestamp = Time::now_monotonic();
     return true;
 }
 

--- a/Userland/Libraries/LibGUI/TextDocument.cpp
+++ b/Userland/Libraries/LibGUI/TextDocument.cpp
@@ -764,16 +764,22 @@ bool InsertTextCommand::merge_with(GUI::Command const& other)
 {
     if (!is<InsertTextCommand>(other))
         return false;
-    auto& typed_other = static_cast<InsertTextCommand const&>(other);
+
+    auto const& typed_other = static_cast<InsertTextCommand const&>(other);
+    if (typed_other.m_text.is_whitespace() && !m_text.is_whitespace())
+        return false; // Skip if other is whitespace while this is not
+
     if (m_range.end() != typed_other.m_range.start())
         return false;
     if (m_range.start().line() != m_range.end().line())
         return false;
+
     StringBuilder builder(m_text.length() + typed_other.m_text.length());
     builder.append(m_text);
     builder.append(typed_other.m_text);
     m_text = builder.to_string();
     m_range.set_end(typed_other.m_range.end());
+
     return true;
 }
 

--- a/Userland/Libraries/LibGUI/TextDocument.h
+++ b/Userland/Libraries/LibGUI/TextDocument.h
@@ -12,6 +12,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/Optional.h>
 #include <AK/RefCounted.h>
+#include <AK/Time.h>
 #include <AK/Utf32View.h>
 #include <LibCore/Forward.h>
 #include <LibGUI/Command.h>
@@ -24,6 +25,8 @@
 #include <LibRegex/Regex.h>
 
 namespace GUI {
+
+constexpr Time COMMAND_COMMIT_TIME = Time::from_milliseconds(400);
 
 struct TextDocumentSpan {
     TextRange range;
@@ -202,6 +205,9 @@ public:
     }
 
 protected:
+    bool commit_time_expired() const { return Time::now_monotonic() - m_timestamp >= COMMAND_COMMIT_TIME; }
+
+    Time m_timestamp = Time::now_monotonic();
     TextDocument& m_document;
     TextDocument::Client const* m_client { nullptr };
 };


### PR DESCRIPTION
 - Add ctrl+shift+z redo. This change is mostly for taste, but it is the general default with applications on Linux and is how MacOS handle redo (though with cmd instead of ctrl of course). The old Microsoft style redo shortcut ctrl+y is still present as the secondary shortcut. This required rebinding rotate clockwise/counterclockwise to avoid collision.
 - Avoid merging text insertion commands when starting to insert whitespace, this means that when typing a sequence of words each word and its leading whitespace will become an individual undo/redo step.
 - Avoid merging text edit commands if the existing command was last modified too long ago. Now when you type, pause, and then type some more those will become separate undo/redo steps.