### PR TITLE
Kernel: Put USB request constants in namespace & misc formatting

### DIFF
--- a/Kernel/Bus/PCI/Definitions.h
+++ b/Kernel/Bus/PCI/Definitions.h
@@ -14,9 +14,7 @@
 #include <Kernel/Debug.h>
 #include <Kernel/PhysicalAddress.h>
 
-namespace Kernel {
-
-namespace PCI {
+namespace Kernel::PCI {
 
 enum class HeaderType {
     Device = 0,
@@ -293,7 +291,6 @@ private:
 
 class Domain;
 class Device;
-}
 
 }
 

--- a/Kernel/Bus/PCI/Device.cpp
+++ b/Kernel/Bus/PCI/Device.cpp
@@ -8,8 +8,7 @@
 #include <Kernel/Bus/PCI/API.h>
 #include <Kernel/Bus/PCI/Device.h>
 
-namespace Kernel {
-namespace PCI {
+namespace Kernel::PCI {
 
 Device::Device(Address address)
     : m_pci_address(address)
@@ -55,5 +54,4 @@ void Device::disable_extended_message_signalled_interrupts()
     TODO();
 }
 
-}
 }

--- a/Kernel/Bus/PCI/Device.h
+++ b/Kernel/Bus/PCI/Device.h
@@ -9,8 +9,7 @@
 #include <AK/Types.h>
 #include <Kernel/Bus/PCI/Definitions.h>
 
-namespace Kernel {
-namespace PCI {
+namespace Kernel::PCI {
 
 class Device {
 public:
@@ -36,5 +35,4 @@ private:
     Address m_pci_address;
 };
 
-}
 }

--- a/Kernel/Bus/PCI/Initializer.cpp
+++ b/Kernel/Bus/PCI/Initializer.cpp
@@ -14,8 +14,7 @@
 #include <Kernel/Panic.h>
 #include <Kernel/Sections.h>
 
-namespace Kernel {
-namespace PCI {
+namespace Kernel::PCI {
 
 READONLY_AFTER_INIT bool g_pci_access_io_probe_failed;
 READONLY_AFTER_INIT bool g_pci_access_is_disabled_from_commandline;
@@ -82,5 +81,4 @@ UNMAP_AFTER_INIT bool test_pci_io()
     return false;
 }
 
-}
 }

--- a/Kernel/Bus/PCI/Initializer.h
+++ b/Kernel/Bus/PCI/Initializer.h
@@ -6,13 +6,11 @@
 
 #pragma once
 
-namespace Kernel {
-namespace PCI {
+namespace Kernel::PCI {
 
 extern bool g_pci_access_io_probe_failed;
 extern bool g_pci_access_is_disabled_from_commandline;
 
 void initialize();
 
-}
 }

--- a/Kernel/Bus/USB/USBRequest.h
+++ b/Kernel/Bus/USB/USBRequest.h
@@ -9,6 +9,8 @@
 
 #include <AK/Types.h>
 
+namespace Kernel::USB {
+
 //
 // bmRequestType fields
 //
@@ -39,3 +41,5 @@ static constexpr u8 USB_REQUEST_GET_DESCRIPTOR = 0x06;
 static constexpr u8 USB_REQUEST_SET_DESCRIPTOR = 0x07;
 static constexpr u8 USB_REQUEST_GET_CONFIGURATION = 0x08;
 static constexpr u8 USB_REQUEST_SET_CONFIGURATION = 0x09;
+
+}


### PR DESCRIPTION
Moved constants in USBRequest.h from global scope to the Kernel::USB namespace, also changed PCI nested namespace in some files to use the nicer & consistent C++17 syntax.