### PR TITLE
 Kernel/Storage: Migrate the partition code to use the ErrorOr container 

### DIFF
--- a/Kernel/Storage/Partition/EBRPartitionTable.cpp
+++ b/Kernel/Storage/Partition/EBRPartitionTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,13 +9,13 @@
 
 namespace Kernel {
 
-Result<NonnullOwnPtr<EBRPartitionTable>, PartitionTable::Error> EBRPartitionTable::try_to_initialize(StorageDevice const& device)
+ErrorOr<NonnullOwnPtr<EBRPartitionTable>> EBRPartitionTable::try_to_initialize(StorageDevice const& device)
 {
-    auto table = adopt_nonnull_own_or_enomem(new (nothrow) EBRPartitionTable(device)).release_value_but_fixme_should_propagate_errors();
+    auto table = TRY(adopt_nonnull_own_or_enomem(new (nothrow) EBRPartitionTable(device)));
     if (table->is_protective_mbr())
-        return { PartitionTable::Error::MBRProtective };
+        return Error::from_errno(ENOTSUP);
     if (!table->is_valid())
-        return { PartitionTable::Error::Invalid };
+        return Error::from_errno(EINVAL);
     return table;
 }
 

--- a/Kernel/Storage/Partition/EBRPartitionTable.h
+++ b/Kernel/Storage/Partition/EBRPartitionTable.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/NonnullOwnPtr.h>
 #include <AK/RefPtr.h>
 #include <AK/Result.h>
@@ -20,7 +21,7 @@ class EBRPartitionTable : public MBRPartitionTable {
 public:
     ~EBRPartitionTable();
 
-    static Result<NonnullOwnPtr<EBRPartitionTable>, PartitionTable::Error> try_to_initialize(StorageDevice const&);
+    static ErrorOr<NonnullOwnPtr<EBRPartitionTable>> try_to_initialize(StorageDevice const&);
     explicit EBRPartitionTable(StorageDevice const&);
     virtual bool is_valid() const override { return m_valid; };
 

--- a/Kernel/Storage/Partition/GUIDPartitionTable.cpp
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -47,11 +47,11 @@ struct [[gnu::packed]] GUIDPartitionHeader {
     u32 crc32_entries_array;
 };
 
-Result<NonnullOwnPtr<GUIDPartitionTable>, PartitionTable::Error> GUIDPartitionTable::try_to_initialize(StorageDevice const& device)
+ErrorOr<NonnullOwnPtr<GUIDPartitionTable>> GUIDPartitionTable::try_to_initialize(StorageDevice const& device)
 {
-    auto table = adopt_nonnull_own_or_enomem(new (nothrow) GUIDPartitionTable(device)).release_value_but_fixme_should_propagate_errors();
+    auto table = TRY(adopt_nonnull_own_or_enomem(new (nothrow) GUIDPartitionTable(device)));
     if (!table->is_valid())
-        return { PartitionTable::Error::Invalid };
+        return Error::from_errno(EINVAL);
     return table;
 }
 

--- a/Kernel/Storage/Partition/GUIDPartitionTable.h
+++ b/Kernel/Storage/Partition/GUIDPartitionTable.h
@@ -1,11 +1,12 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Error.h>
 #include <AK/RefPtr.h>
 #include <AK/Result.h>
 #include <AK/Types.h>
@@ -20,7 +21,7 @@ public:
     virtual ~GUIDPartitionTable() = default;
     ;
 
-    static Result<NonnullOwnPtr<GUIDPartitionTable>, PartitionTable::Error> try_to_initialize(StorageDevice const&);
+    static ErrorOr<NonnullOwnPtr<GUIDPartitionTable>> try_to_initialize(StorageDevice const&);
     explicit GUIDPartitionTable(StorageDevice const&);
 
     virtual bool is_valid() const override { return m_valid; };

--- a/Kernel/Storage/Partition/MBRPartitionTable.cpp
+++ b/Kernel/Storage/Partition/MBRPartitionTable.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,15 +15,15 @@ namespace Kernel {
 #define EBR_CHS_CONTAINER 0x05
 #define EBR_LBA_CONTAINER 0x0F
 
-Result<NonnullOwnPtr<MBRPartitionTable>, PartitionTable::Error> MBRPartitionTable::try_to_initialize(StorageDevice const& device)
+ErrorOr<NonnullOwnPtr<MBRPartitionTable>> MBRPartitionTable::try_to_initialize(StorageDevice const& device)
 {
-    auto table = adopt_nonnull_own_or_enomem(new (nothrow) MBRPartitionTable(device)).release_value_but_fixme_should_propagate_errors();
+    auto table = TRY(adopt_nonnull_own_or_enomem(new (nothrow) MBRPartitionTable(device)));
     if (table->contains_ebr())
-        return { PartitionTable::Error::ContainsEBR };
+        return Error::from_errno(ENOTSUP);
     if (table->is_protective_mbr())
-        return { PartitionTable::Error::MBRProtective };
+        return Error::from_errno(ENOTSUP);
     if (!table->is_valid())
-        return { PartitionTable::Error::Invalid };
+        return Error::from_errno(EINVAL);
     return table;
 }
 

--- a/Kernel/Storage/Partition/MBRPartitionTable.h
+++ b/Kernel/Storage/Partition/MBRPartitionTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <AK/ByteBuffer.h>
+#include <AK/Error.h>
 #include <AK/RefPtr.h>
 #include <AK/Result.h>
 #include <AK/Vector.h>
@@ -41,7 +42,7 @@ public:
 public:
     ~MBRPartitionTable();
 
-    static Result<NonnullOwnPtr<MBRPartitionTable>, PartitionTable::Error> try_to_initialize(StorageDevice const&);
+    static ErrorOr<NonnullOwnPtr<MBRPartitionTable>> try_to_initialize(StorageDevice const&);
     static OwnPtr<MBRPartitionTable> try_to_initialize(StorageDevice const&, u32 start_lba);
     explicit MBRPartitionTable(StorageDevice const&);
     MBRPartitionTable(StorageDevice const&, u32 start_lba);

--- a/Kernel/Storage/Partition/PartitionTable.h
+++ b/Kernel/Storage/Partition/PartitionTable.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -15,13 +15,6 @@
 namespace Kernel {
 
 class PartitionTable {
-public:
-    enum class Error {
-        Invalid,
-        MBRProtective,
-        ContainsEBR,
-    };
-
 public:
     Optional<DiskPartitionMetadata> partition(unsigned index);
     size_t partitions_count() const { return m_partitions.size(); }

--- a/Kernel/Storage/StorageManagement.h
+++ b/Kernel/Storage/StorageManagement.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Liav A. <liavalb@hotmail.co.il>
+ * Copyright (c) 2020-2022, Liav A. <liavalb@hotmail.co.il>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -45,7 +45,7 @@ private:
 
     void dump_storage_devices_and_partitions() const;
 
-    OwnPtr<PartitionTable> try_to_initialize_partition_table(StorageDevice const&) const;
+    ErrorOr<NonnullOwnPtr<PartitionTable>> try_to_initialize_partition_table(StorageDevice const&) const;
 
     RefPtr<BlockDevice> boot_block_device() const;
 


### PR DESCRIPTION
That code used the old AK::Result container, which leads to overly
complicated initialization flow when trying to figure out the correct
partition table type. Instead, when using the ErrorOr container the code
is much simpler and more understandable.