### PR TITLE
unzip: Create parent directory before extracting files

### DIFF
--- a/Userland/Utilities/unzip.cpp
+++ b/Userland/Utilities/unzip.cpp
@@ -27,6 +27,7 @@ static bool unpack_zip_member(Archive::ZipMember zip_member, bool quiet)
             outln(" extracting: {}", zip_member.name);
         return true;
     }
+    MUST(Core::Directory::create(LexicalPath(zip_member.name).parent(), Core::Directory::CreateDirectories::Yes));
     auto new_file = Core::File::construct(zip_member.name);
     if (!new_file->open(Core::OpenMode::WriteOnly)) {
         warnln("Can't write file {}: {}", zip_member.name, new_file->error_string());


### PR DESCRIPTION
This allows us to successfully extract the UCD 13.0.0 ZIP inside SerenityOS.