### PR TITLE
LibMarkdown: Miscellaneous commonmark compatibility changes

### DIFF
--- a/Userland/Libraries/LibMarkdown/CodeBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.cpp
@@ -34,7 +34,7 @@ String CodeBlock::render_to_html(bool) const
     else
         builder.append(escape_html_entities(m_code));
 
-    builder.append("\n</code>");
+    builder.append("</code>");
 
     if (m_style.length() >= 2)
         builder.append("</strong>");
@@ -142,7 +142,6 @@ OwnPtr<CodeBlock> CodeBlock::parse_backticks(LineIterator& lines)
 
     ++lines;
 
-    bool first = true;
     StringBuilder builder;
 
     while (true) {
@@ -157,11 +156,8 @@ OwnPtr<CodeBlock> CodeBlock::parse_backticks(LineIterator& lines)
             if (close_fence[0] == fence[0] && close_fence.length() >= fence.length())
                 break;
         }
-
-        if (!first)
-            builder.append('\n');
         builder.append(line);
-        first = false;
+        builder.append('\n');
     }
 
     return make<CodeBlock>(language, style, builder.build());
@@ -169,7 +165,6 @@ OwnPtr<CodeBlock> CodeBlock::parse_backticks(LineIterator& lines)
 
 OwnPtr<CodeBlock> CodeBlock::parse_indent(LineIterator& lines)
 {
-    bool first = true;
     StringBuilder builder;
 
     while (true) {
@@ -184,10 +179,8 @@ OwnPtr<CodeBlock> CodeBlock::parse_indent(LineIterator& lines)
         line = line.substring_view(prefix_length.value());
         ++lines;
 
-        if (!first)
-            builder.append('\n');
         builder.append(line);
-        first = false;
+        builder.append('\n');
     }
 
     return make<CodeBlock>("", "", builder.build());

--- a/Userland/Libraries/LibMarkdown/CodeBlock.h
+++ b/Userland/Libraries/LibMarkdown/CodeBlock.h
@@ -33,6 +33,9 @@ private:
     String m_code;
     String m_language;
     String m_style;
+
+    static OwnPtr<CodeBlock> parse_backticks(LineIterator& lines);
+    static OwnPtr<CodeBlock> parse_indent(LineIterator& lines);
 };
 
 }

--- a/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
@@ -97,7 +97,7 @@ OwnPtr<ContainerBlock> ContainerBlock::parse(LineIterator& lines)
         if (lines.is_end())
             break;
 
-        if ((*lines).is_empty()) {
+        if ((*lines).is_whitespace()) {
             has_trailing_blank_lines = true;
             ++lines;
 

--- a/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
+++ b/Userland/Libraries/LibMarkdown/ContainerBlock.cpp
@@ -108,11 +108,11 @@ OwnPtr<ContainerBlock> ContainerBlock::parse(LineIterator& lines)
         }
 
         bool any = try_parse_block<Table>(lines, blocks)
+            || try_parse_block<HorizontalRule>(lines, blocks)
             || try_parse_block<List>(lines, blocks)
             || try_parse_block<CodeBlock>(lines, blocks)
             || try_parse_block<CommentBlock>(lines, blocks)
             || try_parse_block<Heading>(lines, blocks)
-            || try_parse_block<HorizontalRule>(lines, blocks)
             || try_parse_block<BlockQuote>(lines, blocks);
 
         if (any) {

--- a/Userland/Libraries/LibMarkdown/Heading.cpp
+++ b/Userland/Libraries/LibMarkdown/Heading.cpp
@@ -57,7 +57,7 @@ OwnPtr<Heading> Heading::parse(LineIterator& lines)
             break;
     }
 
-    if (!level || level >= line.length() || line[level] != ' ')
+    if (!level || level >= line.length() || line[level] != ' ' || level > 6)
         return {};
 
     StringView title_view = line.substring_view(level + 1, line.length() - level - 1);

--- a/Userland/Libraries/LibMarkdown/Heading.cpp
+++ b/Userland/Libraries/LibMarkdown/Heading.cpp
@@ -50,17 +50,28 @@ OwnPtr<Heading> Heading::parse(LineIterator& lines)
         return {};
 
     StringView line = *lines;
+    size_t indent = 0;
+
+    // Allow for up to 3 spaces of indentation.
+    // https://spec.commonmark.org/0.30/#example-68
+    for (size_t i = 0; i < 3; ++i) {
+        if (line[i] != ' ')
+            break;
+
+        ++indent;
+    }
+
     size_t level;
 
-    for (level = 0; level < line.length(); level++) {
-        if (line[level] != '#')
+    for (level = 0; indent + level < line.length(); level++) {
+        if (line[indent + level] != '#')
             break;
     }
 
-    if (!level || level >= line.length() || line[level] != ' ' || level > 6)
+    if (!level || indent + level >= line.length() || line[indent + level] != ' ' || level > 6)
         return {};
 
-    StringView title_view = line.substring_view(level + 1, line.length() - level - 1);
+    StringView title_view = line.substring_view(indent + level + 1);
     auto text = Text::parse(title_view);
     auto heading = make<Heading>(move(text), level);
 

--- a/Userland/Libraries/LibMarkdown/HorizontalRule.cpp
+++ b/Userland/Libraries/LibMarkdown/HorizontalRule.cpp
@@ -8,6 +8,7 @@
 #include <AK/StringBuilder.h>
 #include <LibMarkdown/HorizontalRule.h>
 #include <LibMarkdown/Visitor.h>
+#include <LibRegex/Regex.h>
 
 namespace Markdown {
 
@@ -34,6 +35,8 @@ RecursionDecision HorizontalRule::walk(Visitor& visitor) const
     return RecursionDecision::Continue;
 }
 
+static Regex<ECMA262> thematic_break_re("^ {0,3}([\\*\\-_])(\\s*\\1\\s*){2,}$");
+
 OwnPtr<HorizontalRule> HorizontalRule::parse(LineIterator& lines)
 {
     if (lines.is_end())
@@ -41,16 +44,9 @@ OwnPtr<HorizontalRule> HorizontalRule::parse(LineIterator& lines)
 
     StringView line = *lines;
 
-    if (line.length() < 3)
+    auto match = thematic_break_re.match(line);
+    if (!match.success)
         return {};
-    if (!line.starts_with('-') && !line.starts_with('_') && !line.starts_with('*'))
-        return {};
-
-    auto first_character = line.characters_without_null_termination()[0];
-    for (auto ch : line) {
-        if (ch != first_character)
-            return {};
-    }
 
     ++lines;
     return make<HorizontalRule>();

--- a/Userland/Libraries/LibMarkdown/Text.cpp
+++ b/Userland/Libraries/LibMarkdown/Text.cpp
@@ -327,7 +327,7 @@ Vector<Text::Token> Text::tokenize(StringView str)
             in_space = false;
         }
 
-        if (ch == '\\' && offset + 1 < str.length()) {
+        if (ch == '\\' && offset + 1 < str.length() && ispunct(str[offset + 1])) {
             current_token.append(str[offset + 1]);
             ++offset;
         } else if (ch == '*' || ch == '_' || ch == '`') {


### PR DESCRIPTION
bigger changes:
- indented code blocks.
- improved heading compliance.
- improved code fence compliance.

tests passed:
273/652 -> 327/652
