### PR TITLE
Base: Evenly space title bar icons in Coffee theme

### DIFF
--- a/Base/res/themes/Coffee.ini
+++ b/Base/res/themes/Coffee.ini
@@ -77,5 +77,9 @@ TitleAlignment=Left
 IsDark=false
 TitleButtonsIconOnly=true
 
+[Metrics]
+TitleButtonWidth=16
+TitleHeight=20
+
 [Paths]
 TitleButtonIcons=/res/icons/themes/Coffee/16x16/


### PR DESCRIPTION
This PR makes the spacing on the Coffee title bar icons equal at the top/bottom and left/right.
This is an incredibly minor change but I think it improves the look a fair bit.

| Before                                                                                                                                        | After                                                                                                                                         |
|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot from 2022-04-26 11-02-45](https://user-images.githubusercontent.com/11597044/165276543-86b03ed7-7b6d-4474-a39e-96722e6effea.png) | ![Screenshot from 2022-04-26 11-03-59](https://user-images.githubusercontent.com/11597044/165276548-76e4eac6-04c8-4d56-866f-bfac1afc9b66.png) |