### PR TITLE
Toolchain: Allow BuildQemu to fail the download once

### DIFF
--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -20,8 +20,9 @@ echo SYSROOT is "$SYSROOT"
 mkdir -p "$DIR/Tarballs"
 
 pushd "$DIR/Tarballs"
-    if [ ! -e "$QEMU_VERSION.tar.xz" ]; then
-        curl -O "https://download.qemu.org/$QEMU_VERSION.tar.xz"
+    md5="$(md5sum $QEMU_VERSION.tar.xz | cut -f1 -d' ')"
+    if [ ! -e "$QEMU_VERSION.tar.xz" ] || [ "$md5" != "$QEMU_MD5SUM" ]; then
+        curl -C - -O "https://download.qemu.org/$QEMU_VERSION.tar.xz"
     else
         echo "Skipped downloading $QEMU_VERSION"
     fi


### PR DESCRIPTION
Historical context:
 - I ran BuildQemu.sh yesterday, and I stopped it to spare some compilation power of my laptop.
 - Today I ran it again, but the tarball hasn't been completely downloaded, i.e. had a bad md5.
 - So I had to run the script again, and it bothered me much more than it should have.

So here is my solution to this huge issue :smile: