### PR TITLE
LibCore: Add syscall wrapper for `poll()`

### DIFF
--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -371,15 +371,13 @@ ErrorOr<bool> PosixSocketHelper::can_read_without_blocking(int timeout) const
 {
     struct pollfd the_fd = { .fd = m_fd, .events = POLLIN, .revents = 0 };
 
-    // FIXME: Convert this to Core::System
-    int rc;
+    ErrorOr<int> result = 0;
     do {
-        rc = ::poll(&the_fd, 1, timeout);
-    } while (rc < 0 && errno == EINTR);
+        result = System::poll(&the_fd, 1, timeout);
+    } while (result.is_error() && result.error().code() == EINTR);
 
-    if (rc < 0) {
-        return Error::from_syscall("poll", -errno);
-    }
+    if (result.is_error())
+        return result.error();
 
     return (the_fd.revents & POLLIN) > 0;
 }

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -1260,4 +1260,12 @@ ErrorOr<void> access(StringView pathname, int mode)
 #endif
 }
 
+ErrorOr<int> poll(struct pollfd* fds, nfds_t nfds, int timeout_ms)
+{
+    auto const rc = ::poll(fds, nfds, timeout_ms);
+    if (rc < 0)
+        return Error::from_syscall("poll"sv, -errno);
+    return rc;
+}
+
 }

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -13,6 +13,7 @@
 #include <dirent.h>
 #include <fcntl.h>
 #include <grp.h>
+#include <poll.h>
 #include <pwd.h>
 #include <signal.h>
 #include <spawn.h>
@@ -158,5 +159,6 @@ ErrorOr<int> posix_openpt(int flags);
 ErrorOr<void> grantpt(int fildes);
 ErrorOr<void> unlockpt(int fildes);
 ErrorOr<void> access(StringView pathname, int mode);
+ErrorOr<int> poll(struct pollfd* fds, nfds_t nfds, int timeout_ms);
 
 }


### PR DESCRIPTION
Also use it `PosixSocketHelper::can_read_without_blocking()`.

This removes one FIXME.