### PR TITLE
LibGUI: Check if event loop is alive before quitting it in Dialog::close

### DIFF
--- a/Userland/Libraries/LibGUI/Dialog.cpp
+++ b/Userland/Libraries/LibGUI/Dialog.cpp
@@ -116,7 +116,7 @@ void Dialog::event(Core::Event& event)
 void Dialog::close()
 {
     Window::close();
-    m_event_loop->quit(ExecCancel);
+    done(ExecCancel);
 }
 
 }


### PR DESCRIPTION
Previously we would quit the event loop of a dialog without checking if it is still alive in the Window::close overload. This patch updates the implementation to make use of the existing done method, handling closes more gracefully.

This fixes a CommandPalette crashing when opening an about dialog, as since 1074c399f37be9c2e56215f7defaa1aa2eed125b the command palette dialog would handle a WindowBecameInactive event after closing itself due to the action already being called.