### PR TITLE
Meta: Re-enable automatic virtualization detection on Windows

### DIFF
--- a/Meta/run.sh
+++ b/Meta/run.sh
@@ -22,6 +22,7 @@ SCRIPT_DIR="$(dirname "${0}")"
 if [ -z ${SERENITY_VIRTUALIZATION_SUPPORT+x} ]; then
     VIRTUALIZATION_SUPPORT="0"
     [ -e /dev/kvm ] && [ -r /dev/kvm ] && [ -w /dev/kvm ] && [ "$SERENITY_ARCH" != "aarch64" ] && [ "$(uname -m)" != "aarch64" ] && VIRTUALIZATION_SUPPORT="1"
+    command -v wslpath >/dev/null && VIRTUALIZATION_SUPPORT="1"
 else
     VIRTUALIZATION_SUPPORT="$SERENITY_VIRTUALIZATION_SUPPORT"
 fi


### PR DESCRIPTION
Before, we wouldn't enable virtualization on Windows anymore unless SERENITY_VIRTUALIZATION_SUPPORT was set explicitly. As far as we know, there's no automatic way of detecting whether WHPX is enabled or not. So we'll just enable virtualization on Windows by default, and if that doesn't work the user can still disable it manually with
SERENITY_VIRTUALIZATION_SUPPORT=0.

@GMTA tested that this doesn't break virtualization on Linux.