### PR TITLE
Profiler: Show more specific sample percentage fractions

### DIFF
--- a/Userland/DevTools/Profiler/ProfileModel.cpp
+++ b/Userland/DevTools/Profiler/ProfileModel.cpp
@@ -111,14 +111,19 @@ GUI::Variant ProfileModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
         return {};
     }
     if (role == GUI::ModelRole::Display) {
+        auto round_percentages = [this](auto percentage) {
+            return roundf(static_cast<float>(percentage) / static_cast<float>(m_profile.filtered_event_indices().size())
+                       * percent_digits_rounding_constant)
+                * 100.0f / percent_digits_rounding_constant;
+        };
         if (index.column() == Column::SampleCount) {
             if (m_profile.show_percentages())
-                return ((float)node->event_count() / (float)m_profile.filtered_event_indices().size()) * 100.0f;
+                return round_percentages(node->event_count());
             return node->event_count();
         }
         if (index.column() == Column::SelfCount) {
             if (m_profile.show_percentages())
-                return ((float)node->self_count() / (float)m_profile.filtered_event_indices().size()) * 100.0f;
+                return round_percentages(node->self_count());
             return node->self_count();
         }
         if (index.column() == Column::ObjectName)

--- a/Userland/DevTools/Profiler/ProfileModel.h
+++ b/Userland/DevTools/Profiler/ProfileModel.h
@@ -13,6 +13,10 @@ namespace Profiler {
 
 class Profile;
 
+// Number of digits after the decimal point for sample percentages.
+static constexpr int const number_of_percent_digits = 3;
+static constexpr float const percent_digits_rounding_constant = AK::pow(10, number_of_percent_digits);
+
 class ProfileModel final : public GUI::Model {
 public:
     static NonnullRefPtr<ProfileModel> create(Profile& profile)

--- a/Userland/DevTools/Profiler/main.cpp
+++ b/Userland/DevTools/Profiler/main.cpp
@@ -222,9 +222,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         return min(end_of_trace, max(timestamp, start_of_trace));
     };
 
-    auto const format_sample_count = [&profile](auto sample_count) {
+    // FIXME: Make this constexpr once String is able to.
+    auto const sample_count_percent_format_string = String::formatted("{{:.{}f}}%", number_of_percent_digits);
+    auto const format_sample_count = [&profile, sample_count_percent_format_string](auto const sample_count) {
         if (profile->show_percentages())
-            return String::formatted("{:.3f}%", sample_count.as_float_or(0.0));
+            return String::formatted(sample_count_percent_format_string, sample_count.as_float_or(0.0));
         return String::formatted("{} Samples", sample_count.to_i32());
     };
 


### PR DESCRIPTION
This was already partially solved by Ali when changing the Variant implementation (I think), but this is a proper solution. The profiler now has precise control over how many digits after the decimal point it shows, both in the call graph as well as in the flame graph status bar. If our pretty-printer would also cooperate, this could be even nicer but that's a yak for another day.