### PR TITLE
LoginServer: Change login fail message to avoid enumeration attacks

### DIFF
--- a/Userland/Services/LoginServer/LoginWindow.gml
+++ b/Userland/Services/LoginServer/LoginWindow.gml
@@ -30,8 +30,6 @@
                 text_alignment: "CenterLeft"
             }
 
-            @GUI::Widget {}
-
             @GUI::Button {
                 name: "log_in"
                 text: "Log in"

--- a/Userland/Services/LoginServer/main.cpp
+++ b/Userland/Services/LoginServer/main.cpp
@@ -72,15 +72,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         window->set_password("");
 
+        auto fail_message = "Can't log in: invalid username or password.";
+
         auto account = Core::Account::from_name(username.characters());
         if (account.is_error()) {
-            window->set_fail_message(String::formatted("Can't log in: {}.", account.error()));
+            window->set_fail_message(fail_message);
             dbgln("failed graphical login for user {}: {}", username, account.error());
             return;
         }
 
         if (!account.value().authenticate(password)) {
-            window->set_fail_message("Can't log in: invalid password.");
+            window->set_fail_message(fail_message);
             dbgln("failed graphical login for user {}: invalid password", username);
             return;
         }


### PR DESCRIPTION
The current message distinguishes between a user that doesn't exist, and
an invalid password. This is considered to be bad practice, because an
attack can first check if a user exists before guessing that users
password.

Also it's just tradition or something.