### PR TITLE
LibMarkdown: Add strike through text to markdown

### DIFF
--- a/Userland/Libraries/LibMarkdown/Text.h
+++ b/Userland/Libraries/LibMarkdown/Text.h
@@ -121,6 +121,21 @@ public:
         virtual RecursionDecision walk(Visitor&) const override;
     };
 
+    class StrikeThroughNode : public Node {
+    public:
+        NonnullOwnPtr<Node> striked_text;
+
+        StrikeThroughNode(NonnullOwnPtr<Node> striked_text)
+            : striked_text(move(striked_text))
+        {
+        }
+
+        virtual void render_to_html(StringBuilder& builder) const override;
+        virtual void render_for_terminal(StringBuilder& builder) const override;
+        virtual size_t terminal_length() const override;
+        virtual RecursionDecision walk(Visitor&) const override;
+    };
+
     size_t terminal_length() const;
 
     String render_to_html() const;
@@ -172,6 +187,7 @@ private:
     static NonnullOwnPtr<Node> parse_emph(Vector<Token>::ConstIterator& tokens, bool in_link);
     static NonnullOwnPtr<Node> parse_code(Vector<Token>::ConstIterator& tokens);
     static NonnullOwnPtr<Node> parse_link(Vector<Token>::ConstIterator& tokens);
+    static NonnullOwnPtr<Node> parse_strike_through(Vector<Token>::ConstIterator& tokens);
 
     OwnPtr<Node> m_node;
 };

--- a/Userland/Libraries/LibMarkdown/Visitor.h
+++ b/Userland/Libraries/LibMarkdown/Visitor.h
@@ -44,6 +44,7 @@ public:
     virtual RecursionDecision visit(Text::EmphasisNode const&) { return RecursionDecision::Recurse; }
     virtual RecursionDecision visit(Text::LinkNode const&) { return RecursionDecision::Recurse; }
     virtual RecursionDecision visit(Text::MultiNode const&) { return RecursionDecision::Recurse; }
+    virtual RecursionDecision visit(Text::StrikeThroughNode const&) { return RecursionDecision::Recurse; }
     virtual RecursionDecision visit(Text::TextNode const&) { return RecursionDecision::Recurse; }
 
     virtual RecursionDecision visit(String const&) { return RecursionDecision::Recurse; }


### PR DESCRIPTION
Using ~~ text ~~ syntax will strike out the text between the two tildes.

Only missing portion is the terminal rendering of strike through text.
The ansi escape codes for strike through text are \e[9m and \e[29m but
it appears the terminal does not support these. Please correct me if I
am wrong.

I tested that the render_to_terminal function was being called by giving
it bold ANSI escape codes, and that did work so the function is being
called correctly.