### PR TITLE
LibMarkdown: Correct typo in forward declaration of HorizontalRule

### DIFF
--- a/Userland/Libraries/LibMarkdown/Forward.h
+++ b/Userland/Libraries/LibMarkdown/Forward.h
@@ -16,7 +16,7 @@ class BlockQuote;
 class CodeBlock;
 class ContainerBlock;
 class Heading;
-class HoriziontalRule;
+class HorizontalRule;
 class List;
 class Paragraph;
 class Table;


### PR DESCRIPTION
HoriziontalRule -> HorizontalRule