### PR TITLE
LibWeb: Fix `:nth-child()` parsing, amidst some CSS Parser refactorings

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.cpp
@@ -326,41 +326,7 @@ String MediaQuery::to_string() const
         builder.append("not ");
 
     if (m_negated || m_media_type != MediaType::All || !m_media_condition) {
-        switch (m_media_type) {
-        case MediaType::All:
-            builder.append("all");
-            break;
-        case MediaType::Aural:
-            builder.append("aural");
-            break;
-        case MediaType::Braille:
-            builder.append("braille");
-            break;
-        case MediaType::Embossed:
-            builder.append("embossed");
-            break;
-        case MediaType::Handheld:
-            builder.append("handheld");
-            break;
-        case MediaType::Print:
-            builder.append("print");
-            break;
-        case MediaType::Projection:
-            builder.append("projection");
-            break;
-        case MediaType::Screen:
-            builder.append("screen");
-            break;
-        case MediaType::Speech:
-            builder.append("speech");
-            break;
-        case MediaType::TTY:
-            builder.append("tty");
-            break;
-        case MediaType::TV:
-            builder.append("tv");
-            break;
-        }
+        builder.append(CSS::to_string(m_media_type));
         if (m_media_condition)
             builder.append(" and ");
     }
@@ -476,6 +442,62 @@ bool is_media_feature_name(StringView name)
     // FIXME: Add other level 5 feature names
 
     return false;
+}
+
+Optional<MediaQuery::MediaType> media_type_from_string(StringView name)
+{
+    if (name.equals_ignoring_case("all"sv))
+        return MediaQuery::MediaType::All;
+    if (name.equals_ignoring_case("aural"sv))
+        return MediaQuery::MediaType::Aural;
+    if (name.equals_ignoring_case("braille"sv))
+        return MediaQuery::MediaType::Braille;
+    if (name.equals_ignoring_case("embossed"sv))
+        return MediaQuery::MediaType::Embossed;
+    if (name.equals_ignoring_case("handheld"sv))
+        return MediaQuery::MediaType::Handheld;
+    if (name.equals_ignoring_case("print"sv))
+        return MediaQuery::MediaType::Print;
+    if (name.equals_ignoring_case("projection"sv))
+        return MediaQuery::MediaType::Projection;
+    if (name.equals_ignoring_case("screen"sv))
+        return MediaQuery::MediaType::Screen;
+    if (name.equals_ignoring_case("speech"sv))
+        return MediaQuery::MediaType::Speech;
+    if (name.equals_ignoring_case("tty"sv))
+        return MediaQuery::MediaType::TTY;
+    if (name.equals_ignoring_case("tv"sv))
+        return MediaQuery::MediaType::TV;
+    return {};
+}
+
+StringView to_string(MediaQuery::MediaType media_type)
+{
+    switch (media_type) {
+    case MediaQuery::MediaType::All:
+        return "all"sv;
+    case MediaQuery::MediaType::Aural:
+        return "aural"sv;
+    case MediaQuery::MediaType::Braille:
+        return "braille"sv;
+    case MediaQuery::MediaType::Embossed:
+        return "embossed"sv;
+    case MediaQuery::MediaType::Handheld:
+        return "handheld"sv;
+    case MediaQuery::MediaType::Print:
+        return "print"sv;
+    case MediaQuery::MediaType::Projection:
+        return "projection"sv;
+    case MediaQuery::MediaType::Screen:
+        return "screen"sv;
+    case MediaQuery::MediaType::Speech:
+        return "speech"sv;
+    case MediaQuery::MediaType::TTY:
+        return "tty"sv;
+    case MediaQuery::MediaType::TV:
+        return "tv"sv;
+    }
+    VERIFY_NOT_REACHED();
 }
 
 }

--- a/Userland/Libraries/LibWeb/CSS/MediaQuery.h
+++ b/Userland/Libraries/LibWeb/CSS/MediaQuery.h
@@ -258,6 +258,9 @@ String serialize_a_media_query_list(NonnullRefPtrVector<MediaQuery> const&);
 
 bool is_media_feature_name(StringView name);
 
+Optional<MediaQuery::MediaType> media_type_from_string(StringView);
+StringView to_string(MediaQuery::MediaType);
+
 }
 
 namespace AK {

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -115,13 +115,6 @@ void TokenStream<T>::reconsume_current_input_token()
 }
 
 template<typename T>
-void TokenStream<T>::rewind_to_position(int position)
-{
-    VERIFY(position <= m_iterator_offset);
-    m_iterator_offset = position;
-}
-
-template<typename T>
 void TokenStream<T>::skip_whitespace()
 {
     while (peek_token().is(Token::Type::Whitespace))

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -1202,28 +1202,8 @@ Optional<MediaQuery::MediaType> Parser::parse_media_type(TokenStream<ComponentVa
     }
 
     auto ident = token.token().ident();
-    if (ident.equals_ignoring_case("all")) {
-        return MediaQuery::MediaType::All;
-    } else if (ident.equals_ignoring_case("aural")) {
-        return MediaQuery::MediaType::Aural;
-    } else if (ident.equals_ignoring_case("braille")) {
-        return MediaQuery::MediaType::Braille;
-    } else if (ident.equals_ignoring_case("embossed")) {
-        return MediaQuery::MediaType::Embossed;
-    } else if (ident.equals_ignoring_case("handheld")) {
-        return MediaQuery::MediaType::Handheld;
-    } else if (ident.equals_ignoring_case("print")) {
-        return MediaQuery::MediaType::Print;
-    } else if (ident.equals_ignoring_case("projection")) {
-        return MediaQuery::MediaType::Projection;
-    } else if (ident.equals_ignoring_case("screen")) {
-        return MediaQuery::MediaType::Screen;
-    } else if (ident.equals_ignoring_case("speech")) {
-        return MediaQuery::MediaType::Speech;
-    } else if (ident.equals_ignoring_case("tty")) {
-        return MediaQuery::MediaType::TTY;
-    } else if (ident.equals_ignoring_case("tv")) {
-        return MediaQuery::MediaType::TV;
+    if (auto media_type = media_type_from_string(ident); media_type.has_value()) {
+        return media_type.release_value();
     }
 
     tokens.rewind_to_position(position);

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -36,7 +36,7 @@ static void log_parse_error(SourceLocation const& location = SourceLocation::cur
 
 namespace Web::CSS::Parser {
 
-ParsingContext::ParsingContext(DOM::Document const& document, Optional<AK::URL> const url)
+ParsingContext::ParsingContext(DOM::Document const& document, AK::URL url)
     : m_document(&document)
     , m_url(move(url))
 {
@@ -62,7 +62,7 @@ bool ParsingContext::in_quirks_mode() const
 // https://www.w3.org/TR/css-values-4/#relative-urls
 AK::URL ParsingContext::complete_url(String const& addr) const
 {
-    return m_url.has_value() ? m_url->complete_url(addr) : AK::URL::create_with_url_or_path(addr);
+    return m_url.complete_url(addr);
 }
 
 template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.cpp
@@ -5108,9 +5108,9 @@ Parser::ParseErrorOr<NonnullRefPtr<StyleValue>> Parser::parse_css_value(Property
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     case PropertyID::TextDecorationLine: {
-        TokenStream tokens { component_values };
-        auto parsed_value = parse_text_decoration_line_value(tokens);
-        if (parsed_value && !tokens.has_next_token())
+        TokenStream value_tokens { component_values };
+        auto parsed_value = parse_text_decoration_line_value(value_tokens);
+        if (parsed_value && !value_tokens.has_next_token())
             return parsed_value.release_nonnull();
         return ParseError::SyntaxError;
     }

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -310,7 +310,7 @@ private:
     Optional<Length> parse_length(ComponentValue const&);
     Optional<Ratio> parse_ratio(TokenStream<ComponentValue>&);
     Optional<UnicodeRange> parse_unicode_range(TokenStream<ComponentValue>&);
-    Optional<UnicodeRange> create_unicode_range_from_tokens(TokenStream<ComponentValue>&, int start_position, int end_position);
+    Optional<UnicodeRange> parse_unicode_range(StringView);
 
     enum class AllowedDataUrlType {
         None,

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -104,8 +104,6 @@ public:
     void reconsume_current_input_token();
 
     StateTransaction begin_transaction() { return StateTransaction(*this); }
-    int position() const { return m_iterator_offset; }
-    void rewind_to_position(int);
 
     void skip_whitespace();
 

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -36,7 +36,7 @@ class ParsingContext {
 public:
     ParsingContext() = default;
     explicit ParsingContext(DOM::Document const&);
-    explicit ParsingContext(DOM::Document const&, Optional<AK::URL> const);
+    explicit ParsingContext(DOM::Document const&, AK::URL);
     explicit ParsingContext(DOM::ParentNode&);
 
     bool in_quirks_mode() const;
@@ -49,7 +49,7 @@ public:
 private:
     DOM::Document const* m_document { nullptr };
     PropertyID m_current_property_id { PropertyID::Invalid };
-    Optional<AK::URL> m_url;
+    AK::URL m_url;
 };
 
 template<typename T>

--- a/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Parser.h
@@ -169,11 +169,7 @@ private:
     template<typename T>
     RefPtr<Supports> parse_a_supports(TokenStream<T>&);
 
-    enum class AllowTrailingTokens {
-        No,
-        Yes
-    };
-    Optional<Selector::SimpleSelector::ANPlusBPattern> parse_a_n_plus_b_pattern(TokenStream<ComponentValue>&, AllowTrailingTokens = AllowTrailingTokens::No);
+    Optional<Selector::SimpleSelector::ANPlusBPattern> parse_a_n_plus_b_pattern(TokenStream<ComponentValue>&);
 
     enum class TopLevel {
         No,


### PR DESCRIPTION
Some highlights:
- **Fix parsing of An+B patterns that have internal whitespace.** I broke this a month ago and didn't notice, oops.
- **Make ParsingContext::m_url not Optional.** It's always given a value, so the Optional is unnecessary.
- **Use ErrorOr everywhere that was using Result.** Very happy with how this turned out! It's bothered me for a while that ParsingResult mixed errors with "Done", so that's been made more hygienic. I'd like to TRY _(groan from audience)_ using it more but this PR is already getting chonky.
- **Replace manual rewinding of TokenStream with an RAII StateTransaction type.** This should be clearer and less error-prone. It also forced me to structure the code differently in places, in a good way.
- **Split the UnicodeRange parsing in a more sensible way.** These were awkwardly coupled, passing a TokenStream and offsets between them. Now, one just passes a StringView to the other.