### PR TITLE
LibGfx: Implement antialiased ellipses and use in various places

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -18,6 +18,7 @@
 #include <LibGUI/TextBox.h>
 #include <LibGUI/ValueSlider.h>
 #include <LibGfx/Rect.h>
+#include <LibGfx/AntiAliasingPainter.h>
 
 namespace PixelPaint {
 
@@ -35,9 +36,11 @@ void EllipseTool::draw_using(GUI::Painter& painter, Gfx::IntPoint const& start_p
     case FillMode::Outline:
         painter.draw_ellipse_intersecting(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button), thickness);
         break;
-    case FillMode::Fill:
-        painter.fill_ellipse(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button));
+    case FillMode::Fill: {
+        Gfx::AntiAliasingPainter aa_painter { painter };
+        aa_painter.draw_ellipse(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button));
         break;
+    }
     default:
         VERIFY_NOT_REACHED();
     }

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.h
@@ -32,6 +32,7 @@ private:
     enum class FillMode {
         Outline,
         Fill,
+        FillAntiAliased
     };
 
     enum class DrawMode {
@@ -50,6 +51,7 @@ private:
     Gfx::IntPoint m_ellipse_end_position;
     int m_thickness { 1 };
     FillMode m_fill_mode { FillMode::Outline };
+    bool m_last_aa_checkbox_state { false };
     DrawMode m_draw_mode { DrawMode::FromCorner };
     Optional<float> m_aspect_ratio;
 };

--- a/Userland/Demos/Eyes/EyesWidget.cpp
+++ b/Userland/Demos/Eyes/EyesWidget.cpp
@@ -20,18 +20,19 @@ void EyesWidget::track_mouse_move(Gfx::IntPoint const& point)
 void EyesWidget::paint_event(GUI::PaintEvent& event)
 {
     GUI::Painter painter(*this);
+    Gfx::AntiAliasingPainter aa_painter { painter };
 
     painter.clear_rect(event.rect(), Gfx::Color());
 
     for (int i = 0; i < m_full_rows; i++) {
         for (int j = 0; j < m_eyes_in_row; j++)
-            render_eyeball(i, j, painter);
+            render_eyeball(i, j, aa_painter);
     }
     for (int i = 0; i < m_extra_columns; ++i)
-        render_eyeball(m_full_rows, i, painter);
+        render_eyeball(m_full_rows, i, aa_painter);
 }
 
-void EyesWidget::render_eyeball(int row, int column, GUI::Painter& painter) const
+void EyesWidget::render_eyeball(int row, int column, Gfx::AntiAliasingPainter& painter) const
 {
     auto eye_width = width() / m_eyes_in_row;
     auto eye_height = height() / m_num_rows;
@@ -40,9 +41,9 @@ void EyesWidget::render_eyeball(int row, int column, GUI::Painter& painter) cons
     auto height_thickness = max(int(eye_height / 5.5), 1);
 
     bounds.shrink(int(eye_width / 12.5), 0);
-    painter.fill_ellipse(bounds, palette().base_text());
+    painter.draw_ellipse(bounds, palette().base_text());
     bounds.shrink(width_thickness, height_thickness);
-    painter.fill_ellipse(bounds, palette().base());
+    painter.draw_ellipse(bounds, palette().base());
 
     Gfx::IntPoint pupil_center = this->pupil_center(bounds);
     Gfx::IntSize pupil_size {
@@ -56,7 +57,7 @@ void EyesWidget::render_eyeball(int row, int column, GUI::Painter& painter) cons
         pupil_size.height()
     };
 
-    painter.fill_ellipse(pupil, palette().base_text());
+    painter.draw_ellipse(pupil, palette().base_text());
 }
 
 Gfx::IntPoint EyesWidget::pupil_center(Gfx::IntRect& eyeball_bounds) const

--- a/Userland/Demos/Eyes/EyesWidget.h
+++ b/Userland/Demos/Eyes/EyesWidget.h
@@ -9,6 +9,7 @@
 
 #include <LibGUI/MouseTracker.h>
 #include <LibGUI/Widget.h>
+#include <LibGfx/AntiAliasingPainter.h>
 
 class EyesWidget final : public GUI::Widget
     , GUI::MouseTracker {
@@ -29,7 +30,7 @@ private:
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void track_mouse_move(Gfx::IntPoint const&) override;
 
-    void render_eyeball(int row, int column, GUI::Painter&) const;
+    void render_eyeball(int row, int column, Gfx::AntiAliasingPainter& aa_painter) const;
     Gfx::IntPoint pupil_center(Gfx::IntRect& eyeball_bounds) const;
 
     Gfx::IntPoint m_mouse_position;

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -28,11 +28,23 @@ public:
     void translate(float dx, float dy) { m_transform.translate(dx, dy); }
     void translate(FloatPoint const& delta) { m_transform.translate(delta); }
 
-    void draw_circle(IntPoint center, int radius, Color);
+    void draw_circle(IntPoint const& center, int radius, Color);
+    void draw_ellipse(IntRect const& a_rect, Color);
     void fill_rect_with_rounded_corners(IntRect const&, Color, int radius);
     void fill_rect_with_rounded_corners(IntRect const&, Color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
 
 private:
+    struct Range {
+        int min;
+        int max;
+
+        inline bool contains_inclusive(int n) const
+        {
+            return n >= min && n <= max;
+        }
+    };
+    Range draw_ellipse_part(IntPoint a_rect, int radius_a, int radius_b, Color, bool flip_x_and_y, Optional<Range> x_clip);
+
     enum class AntiAliasPolicy {
         OnlyEnds,
         Full,


### PR DESCRIPTION
![Screenshot from 2022-04-27 20-55-39](https://user-images.githubusercontent.com/11597044/165622613-65288418-629a-4320-96a2-dc9ac6a74661.png)

This is a continuation of my closed PR #13170, which tried to make these changes but had a few issues.

This PR generalises the circle drawing function from #12979 to ellipses. Most of the code is shared between circles and
ellipses, however, circles are still a special case as they can be rendered with 8-way symmetry.

I've updated the Eyes demo to use this method and added an option in Pixel Paint to enable anti-aliasing for filled ellipses.
I may add support for non-filled ellipses/circles in a future PR.

