### PR TITLE
ThemeEditor: A few small improvements

### DIFF
--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -105,6 +105,8 @@ void PreviewWidget::update_preview_window_locations()
 
     constexpr int inactive_offset_x = -20;
     constexpr int inactive_offset_y = -20;
+    constexpr int hightlight_offset_x = 140;
+    constexpr int hightlight_offset_y = 60;
 
     m_active_window_rect = Gfx::IntRect(0, 0, 320, 220);
     m_inactive_window_rect = m_active_window_rect.translated(inactive_offset_x, inactive_offset_y);
@@ -119,6 +121,10 @@ void PreviewWidget::update_preview_window_locations()
     m_inactive_window_rect.set_y(combind_frame_rect.y() + y_delta);
     m_active_window_rect.set_x(m_inactive_window_rect.x() - inactive_offset_x);
     m_active_window_rect.set_y(m_inactive_window_rect.y() - inactive_offset_y);
+    m_highlight_window_rect = Gfx::IntRect(0, 0, 160, 70)
+                                  .translated(m_active_window_rect.x(), m_active_window_rect.y())
+                                  .translated(hightlight_offset_x, hightlight_offset_y)
+                                  .translated(x_delta, y_delta);
 
     m_gallery->set_relative_rect(m_active_window_rect);
 }
@@ -129,9 +135,20 @@ void PreviewWidget::paint_preview(GUI::PaintEvent&)
     paint_window("Active window", m_active_window_rect, Gfx::WindowTheme::WindowState::Active, inactive_window_icon());
 }
 
+void PreviewWidget::paint_hightlight_window()
+{
+    GUI::Painter painter(*this);
+    paint_window("Highlight window", m_highlight_window_rect, Gfx::WindowTheme::WindowState::Highlighted, inactive_window_icon(), 1);
+    auto button_rect = Gfx::IntRect(0, 0, 80, 22).centered_within(m_highlight_window_rect);
+    Gfx::StylePainter::paint_button(painter, button_rect, preview_palette(), Gfx::ButtonStyle::Normal, false, false, false, true, false, false);
+    painter.draw_text(button_rect, ":^)", Gfx::TextAlignment::Center, preview_palette().color(foreground_role()), Gfx::TextElision::Right, Gfx::TextWrapping::DontWrap);
+}
+
 void PreviewWidget::second_paint_event(GUI::PaintEvent&)
 {
     GUI::Painter painter(*this);
+
+    paint_hightlight_window();
 
     if (!m_color_filter)
         return;

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -35,10 +35,12 @@ private:
     virtual void resize_event(GUI::ResizeEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
+    void paint_hightlight_window();
     void update_preview_window_locations();
 
     Gfx::IntRect m_active_window_rect;
     Gfx::IntRect m_inactive_window_rect;
+    Gfx::IntRect m_highlight_window_rect;
 
     OwnPtr<Gfx::ColorBlindnessFilter> m_color_filter = nullptr;
     RefPtr<MiniWidgetGallery> m_gallery;

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -35,6 +35,11 @@ private:
     virtual void resize_event(GUI::ResizeEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
 
+    void update_preview_window_locations();
+
+    Gfx::IntRect m_active_window_rect;
+    Gfx::IntRect m_inactive_window_rect;
+
     OwnPtr<Gfx::ColorBlindnessFilter> m_color_filter = nullptr;
     RefPtr<MiniWidgetGallery> m_gallery;
 };


### PR DESCRIPTION

- Center the preview windows within the frame, accounting for the frame properties (i.e. the border width, title height etc).
  - (As part of this the preview window height was reduced a little)    
- Add a preview of a window in the 'Highlighted' state
   -  This state has sometimes been missed in themes, so this may help avoid that.

| Before                                                                                                                                        | After                                                                                                                                         |
|-----------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
| ![Screenshot from 2022-04-28 20-49-34](https://user-images.githubusercontent.com/11597044/165834389-157d0263-7191-4930-9a71-03d29aea022f.png) | ![Screenshot from 2022-04-28 20-50-52](https://user-images.githubusercontent.com/11597044/165834396-924e1413-65b2-4f38-99bd-c367edf83f3a.png) |