### PR TITLE
ThemeEditor: Show modified status, and other quality-of-life changes

### DIFF
--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
  * Copyright (c) 2022, the SerenityOS developers.
  *
@@ -82,12 +82,14 @@ private:
 PreviewWidget::PreviewWidget(Gfx::Palette const& initial_preview_palette)
     : GUI::AbstractThemePreview(initial_preview_palette)
 {
-    on_palette_change = [&] {
-        m_gallery->set_preview_palette(preview_palette());
-        update_preview_window_locations();
-    };
     m_gallery = add<MiniWidgetGallery>();
     set_greedy_for_hits(true);
+}
+
+void PreviewWidget::palette_changed()
+{
+    m_gallery->set_preview_palette(preview_palette());
+    update_preview_window_locations();
 }
 
 void PreviewWidget::set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter> color_filter)

--- a/Userland/Applications/ThemeEditor/PreviewWidget.h
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
  * Copyright (c) 2022, the SerenityOS developers.
  *
@@ -34,6 +34,7 @@ private:
     virtual void second_paint_event(GUI::PaintEvent&) override;
     virtual void resize_event(GUI::ResizeEvent&) override;
     virtual void drop_event(GUI::DropEvent&) override;
+    virtual void palette_changed() override;
 
     void paint_hightlight_window();
     void update_preview_window_locations();

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
  * Copyright (c) 2021, Jakob-Niklas See <git@nwex.de>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
  * Copyright (c) 2022, Filiph Sandström <filiph.sandstrom@filfatstudios.com>
  *
@@ -58,19 +58,11 @@ private:
     }
 };
 
-struct AlignmentValue {
-    String title;
-    Gfx::TextAlignment setting_value;
-};
-
 class AlignmentModel final : public GUI::Model {
-
 public:
-    AlignmentModel()
+    static ErrorOr<NonnullRefPtr<AlignmentModel>> try_create()
     {
-        m_alignments.empend("Center", Gfx::TextAlignment::Center);
-        m_alignments.empend("Left", Gfx::TextAlignment::CenterLeft);
-        m_alignments.empend("Right", Gfx::TextAlignment::CenterRight);
+        return adopt_nonnull_ref_or_enomem(new (nothrow) AlignmentModel());
     }
 
     virtual ~AlignmentModel() = default;
@@ -89,7 +81,17 @@ public:
     }
 
 private:
-    Vector<AlignmentValue> m_alignments;
+    AlignmentModel() = default;
+
+    struct AlignmentValue {
+        String title;
+        Gfx::TextAlignment setting_value;
+    };
+    Vector<AlignmentValue> m_alignments {
+        { "Center", Gfx::TextAlignment::Center },
+        { "Left", Gfx::TextAlignment::CenterLeft },
+        { "Right", Gfx::TextAlignment::CenterRight },
+    };
 };
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
@@ -197,7 +199,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     alignment_combo_box.set_selected_index((size_t)Gfx::AlignmentRole::TitleAlignment - 1);
 
     alignment_input.set_only_allow_values_from_model(true);
-    alignment_input.set_model(adopt_ref(*new AlignmentModel()));
+    alignment_input.set_model(TRY(AlignmentModel::try_create()));
     alignment_input.set_selected_index((size_t)startup_preview_palette.alignment(Gfx::AlignmentRole::TitleAlignment));
     alignment_input.on_change = [&](auto&, auto& index) {
         auto role = alignment_combo_box.model()->index(alignment_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_alignment_role();

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -26,6 +26,7 @@
 #include <LibGUI/ItemListModel.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/SpinBox.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Window.h>
@@ -312,8 +313,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         if (auto sync_result = theme->sync(); sync_result.is_error()) {
-            // FIXME: Expose this to the user, since failing to save is important to know about!
-            dbgln("Failed to save theme file: {}", sync_result.error());
+            GUI::MessageBox::show_error(window, String::formatted("Failed to save theme file: {}", sync_result.error()));
         }
     };
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -285,6 +285,9 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         auto selected_color_role = color_combo_box.model()->index(color_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_color_role();
         color_input.set_color(preview_widget.preview_palette().color(selected_color_role), GUI::AllowCallback::No);
 
+        auto selected_alignment_role = alignment_combo_box.model()->index(alignment_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_alignment_role();
+        alignment_input.set_selected_index((size_t)(preview_widget.preview_palette().alignment(selected_alignment_role), GUI::AllowCallback::No));
+
         auto selected_flag_role = flag_combo_box.model()->index(flag_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_flag_role();
         flag_input.set_checked(preview_widget.preview_palette().flag(selected_flag_role), GUI::AllowCallback::No);
 

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -256,11 +256,17 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     path_input.set_text(startup_preview_palette.path(Gfx::PathRole::TitleButtonIcons));
 
     path_picker_button.on_click = [&](auto) {
-        // FIXME: Open at the path_input location. Right now that's panicking the kernel though! :^(
         auto role = path_combo_box.model()->index(path_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_path_role();
         bool open_folder = (role == Gfx::PathRole::TitleButtonIcons);
         auto window_title = String::formatted(open_folder ? "Select {} folder" : "Select {} file", path_combo_box.text());
-        auto result = GUI::FilePicker::get_open_filepath(window, window_title, "/res/icons", open_folder);
+        auto target_path = path_input.text();
+        if (Core::File::exists(target_path)) {
+            if (!Core::File::is_directory(target_path))
+                target_path = LexicalPath::dirname(target_path);
+        } else {
+            target_path = "/res/icons";
+        }
+        auto result = GUI::FilePicker::get_open_filepath(window, window_title, target_path, open_folder);
         if (!result.has_value())
             return;
         path_input.set_text(*result);

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -180,7 +180,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     color_combo_box.set_model(TRY(RoleModel<Gfx::ColorRole>::try_create(color_roles)));
     color_combo_box.on_change = [&](auto&, auto& index) {
         auto role = index.model()->data(index, GUI::ModelRole::Custom).to_color_role();
-        color_input.set_color(preview_widget.preview_palette().color(role));
+        color_input.set_color(preview_widget.preview_palette().color(role), GUI::AllowCallback::No);
     };
     color_combo_box.set_selected_index((size_t)Gfx::ColorRole::Window - 1);
 
@@ -190,7 +190,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         preview_palette.set_color(role, color_input.color());
         preview_widget.set_preview_palette(preview_palette);
     };
-    color_input.set_color(startup_preview_palette.color(Gfx::ColorRole::Window));
+    color_input.set_color(startup_preview_palette.color(Gfx::ColorRole::Window), GUI::AllowCallback::No);
 
     alignment_combo_box.set_model(TRY(RoleModel<Gfx::AlignmentRole>::try_create(alignment_roles)));
     alignment_combo_box.on_change = [&](auto&, auto& index) {
@@ -201,7 +201,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     alignment_input.set_only_allow_values_from_model(true);
     alignment_input.set_model(TRY(AlignmentModel::try_create()));
-    alignment_input.set_selected_index((size_t)startup_preview_palette.alignment(Gfx::AlignmentRole::TitleAlignment));
+    alignment_input.set_selected_index((size_t)startup_preview_palette.alignment(Gfx::AlignmentRole::TitleAlignment), GUI::AllowCallback::No);
     alignment_input.on_change = [&](auto&, auto& index) {
         auto role = alignment_combo_box.model()->index(alignment_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_alignment_role();
         auto preview_palette = preview_widget.preview_palette();
@@ -243,7 +243,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     path_combo_box.set_model(TRY(RoleModel<Gfx::PathRole>::try_create(path_roles)));
     path_combo_box.on_change = [&](auto&, auto& index) {
         auto role = index.model()->data(index, GUI::ModelRole::Custom).to_path_role();
-        path_input.set_text(preview_widget.preview_palette().path(role));
+        path_input.set_text(preview_widget.preview_palette().path(role), GUI::AllowCallback::No);
     };
     path_combo_box.set_selected_index((size_t)Gfx::PathRole::TitleButtonIcons - 1);
 
@@ -253,7 +253,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         preview_palette.set_path(role, path_input.text());
         preview_widget.set_preview_palette(preview_palette);
     };
-    path_input.set_text(startup_preview_palette.path(Gfx::PathRole::TitleButtonIcons));
+    path_input.set_text(startup_preview_palette.path(Gfx::PathRole::TitleButtonIcons), GUI::AllowCallback::No);
 
     path_picker_button.on_click = [&](auto) {
         auto role = path_combo_box.model()->index(path_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_path_role();
@@ -283,7 +283,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         update_window_title();
 
         auto selected_color_role = color_combo_box.model()->index(color_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_color_role();
-        color_input.set_color(preview_widget.preview_palette().color(selected_color_role));
+        color_input.set_color(preview_widget.preview_palette().color(selected_color_role), GUI::AllowCallback::No);
 
         auto selected_flag_role = flag_combo_box.model()->index(flag_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_flag_role();
         flag_input.set_checked(preview_widget.preview_palette().flag(selected_flag_role), GUI::AllowCallback::No);
@@ -292,7 +292,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         metric_input.set_value(preview_widget.preview_palette().metric(selected_metric_role), GUI::AllowCallback::No);
 
         auto selected_path_role = path_combo_box.model()->index(path_combo_box.selected_index()).data(GUI::ModelRole::Custom).to_path_role();
-        path_input.set_text(preview_widget.preview_palette().path(selected_path_role));
+        path_input.set_text(preview_widget.preview_palette().path(selected_path_role), GUI::AllowCallback::No);
     };
 
     auto save_to_result = [&](auto const& response) {

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
  * Copyright (c) 2022, the SerenityOS developers.
  *
@@ -71,9 +71,9 @@ void AbstractThemePreview::load_theme_bitmaps()
 void AbstractThemePreview::set_preview_palette(Gfx::Palette const& palette)
 {
     m_preview_palette = palette;
-    if (on_palette_change) {
+    palette_changed();
+    if (on_palette_change)
         on_palette_change();
-    }
     load_theme_bitmaps();
     update();
 }

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.h
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (c) 2020, Andreas Kling <kling@serenityos.org>
- * Copyright (c) 2021, Sam Atkins <atkinssj@serenityos.org>
+ * Copyright (c) 2021-2022, Sam Atkins <atkinssj@serenityos.org>
  * Copyright (c) 2021, Antonio Di Stefano <tonio9681@gmail.com>
  * Copyright (c) 2022, the SerenityOS developers.
  *
@@ -44,6 +44,8 @@ protected:
         VERIFY(m_inactive_window_icon);
         return *m_inactive_window_icon;
     }
+
+    virtual void palette_changed() {};
 
 private:
     virtual void paint_preview(GUI::PaintEvent&) = 0;

--- a/Userland/Libraries/LibGUI/ColorInput.cpp
+++ b/Userland/Libraries/LibGUI/ColorInput.cpp
@@ -23,7 +23,7 @@ ColorInput::ColorInput()
     TextEditor::on_change = [this] {
         auto parsed_color = Color::from_string(text());
         if (parsed_color.has_value())
-            set_color_without_changing_text(parsed_color.value());
+            set_color_internal(parsed_color.value(), AllowCallback::Yes, false);
     };
 
     REGISTER_STRING_PROPERTY("color_picker_title", color_picker_title, set_color_picker_title);
@@ -37,21 +37,21 @@ Gfx::IntRect ColorInput::color_rect() const
     return { width() - color_box_size - color_box_padding, color_box_padding, color_box_size, color_box_size };
 }
 
-void ColorInput::set_color_without_changing_text(Color color)
+void ColorInput::set_color_internal(Color color, AllowCallback allow_callback, bool change_text)
 {
     if (m_color == color)
         return;
     m_color = color;
+    if (change_text)
+        set_text(m_color_has_alpha_channel ? color.to_string() : color.to_string_without_alpha(), AllowCallback::No);
     update();
-    if (on_change)
+    if (allow_callback == AllowCallback::Yes && on_change)
         on_change();
 }
 
-void ColorInput::set_color(Color color)
+void ColorInput::set_color(Color color, AllowCallback allow_callback)
 {
-    if (m_color == color)
-        return;
-    set_text(m_color_has_alpha_channel ? color.to_string() : color.to_string_without_alpha());
+    set_color_internal(color, allow_callback, true);
 };
 
 void ColorInput::mousedown_event(MouseEvent& event)

--- a/Userland/Libraries/LibGUI/ColorInput.h
+++ b/Userland/Libraries/LibGUI/ColorInput.h
@@ -21,7 +21,7 @@ public:
     bool has_alpha_channel() const { return m_color_has_alpha_channel; }
     void set_color_has_alpha_channel(bool has_alpha) { m_color_has_alpha_channel = has_alpha; }
 
-    void set_color(Color);
+    void set_color(Color, AllowCallback = AllowCallback::Yes);
     Color color() { return m_color; }
 
     void set_color_picker_title(String title) { m_color_picker_title = move(title); }
@@ -39,7 +39,7 @@ private:
     ColorInput();
 
     Gfx::IntRect color_rect() const;
-    void set_color_without_changing_text(Color);
+    void set_color_internal(Color, AllowCallback, bool change_text);
 
     Color m_color;
     String m_color_picker_title { "Select color" };


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/165931706-efb2a153-78cd-4c6f-bc6b-68d81bd51388.png)

- As seen in the picture, we now show the modified state in the `X` button, and prompt about saving the changes.
- Clicking the "..." for selecting a path now starts you in that path if possible.
- If a file got opened for saving but then the writing to it failed, you now get a pop-up dialog about it instead of a log message.
- Fix that the "Alignment" selector didn't have a value set when loading a theme file.
- A couple of minor code-style tweaks.