### PR TITLE
LibSoftGPU+LibGfx: Artifacts & performance improvements

### DIFF
--- a/Userland/Libraries/LibGfx/Vector2.h
+++ b/Userland/Libraries/LibGfx/Vector2.h
@@ -17,8 +17,9 @@ namespace Gfx {
 
 template<class T>
 using Vector2 = VectorN<2, T>;
-using FloatVector2 = Vector2<float>;
 using DoubleVector2 = Vector2<double>;
+using FloatVector2 = Vector2<float>;
+using IntVector2 = Vector2<int>;
 
 }
 
@@ -36,4 +37,5 @@ struct Formatter<Gfx::Vector2<T>> : Formatter<StringView> {
 
 using Gfx::DoubleVector2;
 using Gfx::FloatVector2;
+using Gfx::IntVector2;
 using Gfx::Vector2;

--- a/Userland/Libraries/LibGfx/Vector3.h
+++ b/Userland/Libraries/LibGfx/Vector3.h
@@ -17,8 +17,9 @@ namespace Gfx {
 
 template<class T>
 using Vector3 = VectorN<3, T>;
-using FloatVector3 = Vector3<float>;
 using DoubleVector3 = Vector3<double>;
+using FloatVector3 = Vector3<float>;
+using IntVector3 = Vector3<int>;
 
 }
 
@@ -36,4 +37,5 @@ struct Formatter<Gfx::Vector3<T>> : Formatter<StringView> {
 
 using Gfx::DoubleVector3;
 using Gfx::FloatVector3;
+using Gfx::IntVector3;
 using Gfx::Vector3;

--- a/Userland/Libraries/LibGfx/Vector4.h
+++ b/Userland/Libraries/LibGfx/Vector4.h
@@ -17,8 +17,9 @@ namespace Gfx {
 
 template<class T>
 using Vector4 = VectorN<4, T>;
-using FloatVector4 = Vector4<float>;
 using DoubleVector4 = Vector4<double>;
+using FloatVector4 = Vector4<float>;
+using IntVector4 = Vector4<int>;
 
 }
 
@@ -36,4 +37,5 @@ struct Formatter<Gfx::Vector4<T>> : Formatter<StringView> {
 
 using Gfx::DoubleVector4;
 using Gfx::FloatVector4;
+using Gfx::IntVector4;
 using Gfx::Vector4;

--- a/Userland/Libraries/LibGfx/VectorN.h
+++ b/Userland/Libraries/LibGfx/VectorN.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
  * Copyright (c) 2022, the SerenityOS developers.
  *
  * SPDX-License-Identifier: BSD-2-Clause
@@ -27,8 +28,12 @@
 #endif
 
 namespace Gfx {
+
 template<size_t N, typename T>
 requires(N >= 2 && N <= 4) class VectorN final {
+    template<size_t U, typename V>
+    friend class VectorN;
+
     static_assert(LOOP_UNROLL_N >= N, "Unroll the entire loop for performance.");
 
 public:
@@ -226,7 +231,22 @@ public:
             return String::formatted("[{},{},{},{}]", x(), y(), z(), w());
     }
 
+    template<typename U>
+    [[nodiscard]] VectorN<N, U> to_rounded() const
+    {
+        VectorN<N, U> result;
+        UNROLL_LOOP
+        for (auto i = 0u; i < N; ++i) {
+            if constexpr (IsSame<T, float>)
+                result.m_data[i] = static_cast<U>(lrintf(m_data[i]));
+            else
+                result.m_data[i] = static_cast<U>(lrint(m_data[i]));
+        }
+        return result;
+    }
+
 private:
     AK::Array<T, N> m_data;
 };
+
 }

--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -19,6 +19,7 @@ namespace SoftGPU {
 static constexpr bool ENABLE_STATISTICS_OVERLAY = false;
 static constexpr int MILLISECONDS_PER_STATISTICS_PERIOD = 500;
 static constexpr int NUM_LIGHTS = 8;
+static constexpr int SUBPIXEL_BITS = 6;
 
 // See: https://www.khronos.org/opengl/wiki/Common_Mistakes#Texture_edge_color_problem
 // FIXME: make this dynamically configurable through ConfigServer

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -58,7 +58,7 @@ constexpr static f32x4 edge_function4(FloatVector2 const& a, FloatVector2 const&
 }
 
 template<typename T, typename U>
-constexpr static auto interpolate(const T& v0, const T& v1, const T& v2, Vector3<U> const& barycentric_coords)
+constexpr static auto interpolate(T const& v0, T const& v1, T const& v2, Vector3<U> const& barycentric_coords)
 {
     return v0 * barycentric_coords.x() + v1 * barycentric_coords.y() + v2 * barycentric_coords.z();
 }

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -1010,7 +1010,7 @@ ALWAYS_INLINE void Device::shade_fragments(PixelQuad& quad)
 
     // FIXME: exponential fog is not vectorized, we should add a SIMD exp function that calculates an approximation.
     if (m_options.fog_enabled) {
-        auto factor = expand4(0.0f);
+        f32x4 factor;
         switch (m_options.fog_mode) {
         case GPU::FogMode::Linear:
             factor = (m_options.fog_end - quad.fog_depth) / (m_options.fog_end - m_options.fog_start);

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -23,13 +23,13 @@
 
 namespace SoftGPU {
 
-static long long g_num_rasterized_triangles;
-static long long g_num_pixels;
-static long long g_num_pixels_shaded;
-static long long g_num_pixels_blended;
-static long long g_num_sampler_calls;
-static long long g_num_stencil_writes;
-static long long g_num_quads;
+static u64 g_num_rasterized_triangles;
+static u64 g_num_pixels;
+static u64 g_num_pixels_shaded;
+static u64 g_num_pixels_blended;
+static u64 g_num_sampler_calls;
+static u64 g_num_stencil_writes;
+static u64 g_num_quads;
 
 using AK::SIMD::any;
 using AK::SIMD::exp;

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -26,7 +26,6 @@
 #include <LibGPU/TexCoordGenerationConfig.h>
 #include <LibGPU/Vertex.h>
 #include <LibGfx/Bitmap.h>
-#include <LibGfx/Matrix3x3.h>
 #include <LibGfx/Matrix4x4.h>
 #include <LibGfx/Rect.h>
 #include <LibGfx/Vector4.h>

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -77,7 +77,7 @@ private:
     void draw_statistics_overlay(Gfx::Bitmap&);
     Gfx::IntRect get_rasterization_rect_of_size(Gfx::IntSize size);
 
-    void rasterize_triangle(Triangle const& triangle);
+    void rasterize_triangle(Triangle const&);
     void setup_blend_factors();
     void shade_fragments(PixelQuad&);
     bool test_alpha(PixelQuad&);

--- a/Userland/Libraries/LibSoftGPU/Image.cpp
+++ b/Userland/Libraries/LibSoftGPU/Image.cpp
@@ -9,10 +9,123 @@
 
 namespace SoftGPU {
 
+static constexpr FloatVector4 unpack_color(void const* ptr, GPU::ImageFormat format)
+{
+    constexpr auto one_over_255 = 1.0f / 255;
+    switch (format) {
+    case GPU::ImageFormat::RGB888: {
+        auto rgb = reinterpret_cast<u8 const*>(ptr);
+        return {
+            rgb[0] * one_over_255,
+            rgb[1] * one_over_255,
+            rgb[2] * one_over_255,
+            1.0f,
+        };
+    }
+    case GPU::ImageFormat::BGR888: {
+        auto bgr = reinterpret_cast<u8 const*>(ptr);
+        return {
+            bgr[2] * one_over_255,
+            bgr[1] * one_over_255,
+            bgr[0] * one_over_255,
+            1.0f,
+        };
+    }
+    case GPU::ImageFormat::RGBA8888: {
+        auto rgba = *reinterpret_cast<u32 const*>(ptr);
+        return {
+            (rgba & 0xff) * one_over_255,
+            ((rgba >> 8) & 0xff) * one_over_255,
+            ((rgba >> 16) & 0xff) * one_over_255,
+            ((rgba >> 24) & 0xff) * one_over_255,
+        };
+    }
+    case GPU::ImageFormat::BGRA8888: {
+        auto bgra = *reinterpret_cast<u32 const*>(ptr);
+        return {
+            ((bgra >> 16) & 0xff) * one_over_255,
+            ((bgra >> 8) & 0xff) * one_over_255,
+            (bgra & 0xff) * one_over_255,
+            ((bgra >> 24) & 0xff) * one_over_255,
+        };
+    }
+    case GPU::ImageFormat::RGB565: {
+        auto rgb = *reinterpret_cast<u16 const*>(ptr);
+        return {
+            ((rgb >> 11) & 0x1f) / 31.f,
+            ((rgb >> 5) & 0x3f) / 63.f,
+            (rgb & 0x1f) / 31.f,
+            1.0f
+        };
+    }
+    case GPU::ImageFormat::L8: {
+        auto luminance = *reinterpret_cast<u8 const*>(ptr);
+        auto clamped_luminance = luminance * one_over_255;
+        return {
+            clamped_luminance,
+            clamped_luminance,
+            clamped_luminance,
+            1.0f,
+        };
+    }
+    case GPU::ImageFormat::L8A8: {
+        auto luminance_and_alpha = reinterpret_cast<u8 const*>(ptr);
+        auto clamped_luminance = luminance_and_alpha[0] * one_over_255;
+        return {
+            clamped_luminance,
+            clamped_luminance,
+            clamped_luminance,
+            luminance_and_alpha[1] * one_over_255,
+        };
+    }
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
+static constexpr void pack_color(FloatVector4 const& color, void* ptr, GPU::ImageFormat format)
+{
+    auto r = static_cast<u8>(clamp(color.x(), 0.0f, 1.0f) * 255);
+    auto g = static_cast<u8>(clamp(color.y(), 0.0f, 1.0f) * 255);
+    auto b = static_cast<u8>(clamp(color.z(), 0.0f, 1.0f) * 255);
+    auto a = static_cast<u8>(clamp(color.w(), 0.0f, 1.0f) * 255);
+
+    switch (format) {
+    case GPU::ImageFormat::RGB888:
+        reinterpret_cast<u8*>(ptr)[0] = r;
+        reinterpret_cast<u8*>(ptr)[1] = g;
+        reinterpret_cast<u8*>(ptr)[2] = b;
+        return;
+    case GPU::ImageFormat::BGR888:
+        reinterpret_cast<u8*>(ptr)[2] = b;
+        reinterpret_cast<u8*>(ptr)[1] = g;
+        reinterpret_cast<u8*>(ptr)[0] = r;
+        return;
+    case GPU::ImageFormat::RGBA8888:
+        *reinterpret_cast<u32*>(ptr) = r | (g << 8) | (b << 16) | (a << 24);
+        return;
+    case GPU::ImageFormat::BGRA8888:
+        *reinterpret_cast<u32*>(ptr) = b | (g << 8) | (r << 16) | (a << 24);
+        return;
+    case GPU::ImageFormat::RGB565:
+        *reinterpret_cast<u16*>(ptr) = (r & 0x1f) | ((g & 0x3f) << 5) | ((b & 0x1f) << 11);
+        return;
+    case GPU::ImageFormat::L8:
+        *reinterpret_cast<u8*>(ptr) = r;
+        return;
+    case GPU::ImageFormat::L8A8:
+        reinterpret_cast<u8*>(ptr)[0] = r;
+        reinterpret_cast<u8*>(ptr)[1] = a;
+        return;
+    default:
+        VERIFY_NOT_REACHED();
+    }
+}
+
 Image::Image(void* const ownership_token, unsigned width, unsigned height, unsigned depth, unsigned max_levels, unsigned layers)
     : GPU::Image(ownership_token)
     , m_num_layers(layers)
-    , m_mipmap_buffers(FixedArray<RefPtr<Typed3DBuffer<GPU::ColorType>>>::must_create_but_fixme_should_propagate_errors(layers * max_levels))
+    , m_mipmap_buffers(FixedArray<RefPtr<Typed3DBuffer<FloatVector4>>>::must_create_but_fixme_should_propagate_errors(layers * max_levels))
 {
     VERIFY(width > 0);
     VERIFY(height > 0);
@@ -27,7 +140,7 @@ Image::Image(void* const ownership_token, unsigned width, unsigned height, unsig
     unsigned level;
     for (level = 0; level < max_levels; ++level) {
         for (unsigned layer = 0; layer < layers; ++layer)
-            m_mipmap_buffers[layer * layers + level] = MUST(Typed3DBuffer<GPU::ColorType>::try_create(width, height, depth));
+            m_mipmap_buffers[layer * layers + level] = MUST(Typed3DBuffer<FloatVector4>::try_create(width, height, depth));
 
         if (width <= 1 && height <= 1 && depth <= 1)
             break;

--- a/Userland/Libraries/LibSoftGPU/PixelQuad.h
+++ b/Userland/Libraries/LibSoftGPU/PixelQuad.h
@@ -15,7 +15,7 @@
 namespace SoftGPU {
 
 struct PixelQuad final {
-    Vector2<AK::SIMD::f32x4> screen_coordinates;
+    Vector2<AK::SIMD::i32x4> screen_coordinates;
     Vector3<AK::SIMD::f32x4> barycentrics;
     AK::SIMD::f32x4 depth;
     Vector4<AK::SIMD::f32x4> vertex_color;

--- a/Userland/Libraries/LibSoftGPU/Triangle.h
+++ b/Userland/Libraries/LibSoftGPU/Triangle.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
  * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -8,11 +9,14 @@
 #pragma once
 
 #include <LibGPU/Vertex.h>
+#include <LibGfx/Vector2.h>
 
 namespace SoftGPU {
 
 struct Triangle {
     GPU::Vertex vertices[3];
+    IntVector2 subpixel_coordinates[3];
+    i32 area;
 };
 
 }


### PR DESCRIPTION
* Move back to `i32`-based subpixel rasterization with some additional changes to prevent Quake 1 artifacts
* Remove color conversion from `Image`; always use `FloatVector4`. Results in 1-2 FPS extra in Quake 1 on my machine.

The goal of all of this was to fix Tux Racer's intro screen, see the missing diagonal line of pixels in the bottom center:
![Screenshot_20220429_152257](https://user-images.githubusercontent.com/3210731/165952877-c83b7de6-2304-4930-acb2-2d694111783a.png)

And after:
![Screenshot_20220429_152231](https://user-images.githubusercontent.com/3210731/165952940-2e1a2a02-cb68-4182-bb62-86a5781b960b.png)