### PR TITLE
Add is_not_empty to string types

### DIFF
--- a/AK/FlyString.h
+++ b/AK/FlyString.h
@@ -50,6 +50,7 @@ public:
     }
 
     bool is_empty() const { return !m_impl || !m_impl->length(); }
+    bool is_not_empty() const { return !is_empty(); }
     bool is_null() const { return !m_impl; }
 
     bool operator==(FlyString const& other) const { return m_impl == other.m_impl; }

--- a/AK/String.h
+++ b/AK/String.h
@@ -165,6 +165,7 @@ public:
 
     [[nodiscard]] bool is_null() const { return !m_impl; }
     [[nodiscard]] ALWAYS_INLINE bool is_empty() const { return length() == 0; }
+    [[nodiscard]] ALWAYS_INLINE bool is_not_empty() const { return !is_empty(); }
     [[nodiscard]] ALWAYS_INLINE size_t length() const { return m_impl ? m_impl->length() : 0; }
     // Includes NUL-terminator, if non-nullptr.
     [[nodiscard]] ALWAYS_INLINE char const* characters() const { return m_impl ? m_impl->characters() : nullptr; }

--- a/AK/StringBuilder.h
+++ b/AK/StringBuilder.h
@@ -68,6 +68,7 @@ public:
 
     [[nodiscard]] size_t length() const { return m_buffer.size(); }
     [[nodiscard]] bool is_empty() const { return m_buffer.is_empty(); }
+    [[nodiscard]] bool is_not_empty() const { return !is_empty(); }
     void trim(size_t count) { m_buffer.resize(m_buffer.size() - count); }
 
     template<class SeparatorType, class CollectionType>

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -61,6 +61,7 @@ public:
         return m_characters == nullptr;
     }
     [[nodiscard]] constexpr bool is_empty() const { return m_length == 0; }
+    [[nodiscard]] constexpr bool is_not_empty() const { return !is_empty(); }
 
     [[nodiscard]] constexpr char const* characters_without_null_termination() const { return m_characters; }
     [[nodiscard]] constexpr size_t length() const { return m_length; }

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -16,10 +16,12 @@ TEST_CASE(construct_empty)
 {
     EXPECT(String().is_null());
     EXPECT(String().is_empty());
+    EXPECT(!String().is_not_empty());
     EXPECT(!String().characters());
 
     EXPECT(!String("").is_null());
     EXPECT(String("").is_empty());
+    EXPECT(!String("").is_not_empty());
     EXPECT(String("").characters() != nullptr);
 
     EXPECT(String("").impl() == String::empty().impl());
@@ -29,6 +31,7 @@ TEST_CASE(construct_contents)
 {
     String test_string = "ABCDEF";
     EXPECT(!test_string.is_empty());
+    EXPECT(test_string.is_not_empty());
     EXPECT(!test_string.is_null());
     EXPECT_EQ(test_string.length(), 6u);
     EXPECT_EQ(test_string.length(), strlen(test_string.characters()));

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -151,6 +151,8 @@ TEST_CASE(flystring)
         FlyString a("foo");
         FlyString b("foo");
         EXPECT_EQ(a.impl(), b.impl());
+        EXPECT(a.is_not_empty());
+        EXPECT(b.is_not_empty());
     }
 
     {

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -161,6 +161,7 @@ TEST_CASE(flystring)
         StringBuilder builder;
         builder.append('f');
         builder.append("oo");
+        EXPECT(builder.is_not_empty());
         FlyString c = builder.to_string();
         EXPECT_EQ(a.impl(), b.impl());
         EXPECT_EQ(a.impl(), c.impl());

--- a/Tests/AK/TestStringView.cpp
+++ b/Tests/AK/TestStringView.cpp
@@ -13,6 +13,7 @@ TEST_CASE(construct_empty)
 {
     EXPECT(StringView().is_null());
     EXPECT(StringView().is_empty());
+    EXPECT(!StringView().is_not_empty());
     EXPECT(!StringView().characters_without_null_termination());
     EXPECT_EQ(StringView().length(), 0u);
 }
@@ -103,6 +104,9 @@ TEST_CASE(lines)
     EXPECT_EQ(test_string_vector.at(0).is_empty(), true);
     EXPECT_EQ(test_string_vector.at(1).is_empty(), true);
     EXPECT_EQ(test_string_vector.at(2).is_empty(), true);
+    EXPECT_EQ(test_string_vector.at(0).is_not_empty(), false);
+    EXPECT_EQ(test_string_vector.at(1).is_not_empty(), false);
+    EXPECT_EQ(test_string_vector.at(2).is_not_empty(), false);
 }
 
 TEST_CASE(find)
@@ -170,6 +174,7 @@ TEST_CASE(constexpr_stuff)
 #define do_test()                                                       \
     static_assert(test_constexpr.length() == 3);                        \
     static_assert(!test_constexpr.is_empty());                          \
+    static_assert(test_constexpr.is_not_empty());                       \
     static_assert(test_constexpr.is_one_of("foo", "bar", "baz"));       \
     static_assert(test_constexpr.is_one_of("foo"sv, "bar"sv, "baz"sv)); \
     static_assert(test_constexpr != "fob"sv);                           \

--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -144,7 +144,7 @@ private:
             if (ip_address != "null")
                 connected_adapters++;
 
-            if (!adapter_info.is_empty())
+            if (adapter_info.is_not_empty())
                 adapter_info.append('\n');
 
             adapter_info.appendff("{}: {} ", ifname, ip_address);

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -196,7 +196,7 @@ void BrowserWindow::build_menus()
     m_copy_selection_action = GUI::CommonActions::make_copy_action([this](auto&) {
         auto& tab = active_tab();
         auto selected_text = tab.view().selected_text();
-        if (!selected_text.is_empty())
+        if (selected_text.is_not_empty())
             GUI::Clipboard::the().set_plain_text(selected_text);
     });
 
@@ -477,7 +477,7 @@ ErrorOr<void> BrowserWindow::load_search_engines(GUI::Menu& settings_menu)
     search_engine_menu.add_action(custom_search_engine_action);
     m_search_engine_actions.add_action(custom_search_engine_action);
 
-    if (!search_engine_set && !g_search_engine.is_empty()) {
+    if (!search_engine_set && g_search_engine.is_not_empty()) {
         custom_search_engine_action->set_checked(true);
         custom_search_engine_action->set_status_tip(g_search_engine);
     }

--- a/Userland/Applications/Browser/CookieJar.cpp
+++ b/Userland/Applications/Browser/CookieJar.cpp
@@ -28,7 +28,7 @@ String CookieJar::get_cookie(const URL& url, Web::Cookie::Source source)
 
     for (auto const& cookie : cookie_list) {
         // If there is an unprocessed cookie in the cookie-list, output the characters %x3B and %x20 ("; ")
-        if (!builder.is_empty())
+        if (builder.is_not_empty())
             builder.append("; ");
 
         // Output the cookie's name, the %x3D ("=") character, and the cookie's value.

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -42,7 +42,7 @@ namespace Browser {
 
 URL url_from_user_input(String const& input)
 {
-    if (input.starts_with("?") && !g_search_engine.is_empty())
+    if (input.starts_with("?") && g_search_engine.is_not_empty())
         return URL(g_search_engine.replace("{}", URL::percent_encode(input.substring_view(1))));
 
     URL url_with_http_schema = URL(String::formatted("http://{}", input));

--- a/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
+++ b/Userland/Applications/CharacterMap/CharacterMapWidget.cpp
@@ -70,7 +70,7 @@ CharacterMapWidget::CharacterMapWidget()
 
     m_go_to_glyph_action = GUI::Action::create("Go to glyph...", { Mod_Ctrl, Key_G }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-to.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         String input;
-        if (GUI::InputBox::show(window(), input, "Hexadecimal:", "Go to glyph") == GUI::InputBox::ExecOK && !input.is_empty()) {
+        if (GUI::InputBox::show(window(), input, "Hexadecimal:", "Go to glyph") == GUI::InputBox::ExecOK && input.is_not_empty()) {
             auto maybe_code_point = AK::StringUtils::convert_to_uint_from_hex(input);
             if (!maybe_code_point.has_value())
                 return;

--- a/Userland/Applications/DisplaySettings/MonitorWidget.h
+++ b/Userland/Applications/DisplaySettings/MonitorWidget.h
@@ -52,7 +52,7 @@ private:
 
     bool is_different_to_current_wallpaper_path(String const& path)
     {
-        return (!path.is_empty() && path != m_desktop_wallpaper_path) || (path.is_empty() && m_desktop_wallpaper_path != nullptr);
+        return (path.is_not_empty() && path != m_desktop_wallpaper_path) || (path.is_empty() && m_desktop_wallpaper_path != nullptr);
     }
 };
 

--- a/Userland/Libraries/LibJS/Console.cpp
+++ b/Userland/Libraries/LibJS/Console.cpp
@@ -433,7 +433,7 @@ ThrowCompletionOr<String> Console::value_vector_to_string(Vector<Value>& values)
 {
     StringBuilder builder;
     for (auto const& item : values) {
-        if (!builder.is_empty())
+        if (builder.is_not_empty())
             builder.append(' ');
         builder.append(TRY(item.to_string(global_object())));
     }
@@ -446,7 +446,7 @@ ThrowCompletionOr<String> Console::format_time_since(Core::ElapsedTimer timer)
     auto duration = TRY(Temporal::balance_duration(global_object(), 0, 0, 0, 0, elapsed_ms, 0, "0"_sbigint, "year"));
 
     auto append = [&](StringBuilder& builder, auto format, auto... number) {
-        if (!builder.is_empty())
+        if (builder.is_not_empty())
             builder.append(' ');
         builder.appendff(format, number...);
     };

--- a/Userland/Libraries/LibRegex/RegexParser.cpp
+++ b/Userland/Libraries/LibRegex/RegexParser.cpp
@@ -625,7 +625,7 @@ ALWAYS_INLINE bool PosixExtendedParser::parse_repetition_symbol(ByteCode& byteco
         while (match(TokenType::Char)) {
             number_builder.append(consume().value());
         }
-        if (!number_builder.is_empty()) {
+        if (number_builder.is_not_empty()) {
             auto value = number_builder.build().to_uint();
             if (!value.has_value() || minimum > value.value() || *value > s_maximum_repetition_count)
                 return set_error(Error::InvalidBraceContent);

--- a/Userland/Libraries/LibSQL/Tuple.cpp
+++ b/Userland/Libraries/LibSQL/Tuple.cpp
@@ -178,7 +178,7 @@ String Tuple::to_string() const
 {
     StringBuilder builder;
     for (auto& part : m_data) {
-        if (!builder.is_empty()) {
+        if (builder.is_not_empty()) {
             builder.append('|');
         }
         builder.append(part.to_string());

--- a/Userland/Libraries/LibUnicode/Locale.cpp
+++ b/Userland/Libraries/LibUnicode/Locale.cpp
@@ -901,7 +901,7 @@ String LanguageID::to_string() const
     auto append_segment = [&](Optional<String> const& segment) {
         if (!segment.has_value())
             return;
-        if (!builder.is_empty())
+        if (builder.is_not_empty())
             builder.append('-');
         builder.append(*segment);
     };
@@ -922,7 +922,7 @@ String LocaleID::to_string() const
     auto append_segment = [&](Optional<String> const& segment) {
         if (!segment.has_value() || segment->is_empty())
             return;
-        if (!builder.is_empty())
+        if (builder.is_not_empty())
             builder.append('-');
         builder.append(*segment);
     };

--- a/Userland/Libraries/LibWeb/DOM/Document.cpp
+++ b/Userland/Libraries/LibWeb/DOM/Document.cpp
@@ -424,7 +424,7 @@ String Document::title() const
         if (is_ascii_space(code_point)) {
             last_was_space = true;
         } else {
-            if (last_was_space && !builder.is_empty())
+            if (last_was_space && builder.is_not_empty())
                 builder.append(' ');
             builder.append_code_point(code_point);
             last_was_space = false;


### PR DESCRIPTION
This PR adds the convenient method `is_not_empty` to the following String classes:
- String
- FlyString
- StringBuilder
- StringView

I feel this is a more expressive way to denote that a string "is not empty" compared to using the "not" (!) operator, which sometimes  can be hard to notice in between the parentheses.

So instead of writing: `if(!someString.is_empty())`, you could write: `if(someString.is_not_empty())`.

This is a similar to Dart lang's String method [isNotEmpty](https://api.dart.dev/stable/2.16.1/dart-core/String/isNotEmpty.html). 

Dart also have this method in it's [List](https://api.dart.dev/stable/1.10.1/dart-core/List/isNotEmpty.html) and other collection classes, which perhaps could be inspiration for serenity's collections.

I mentioned this on Discord and believe there are various opinions on this API change, but I'll leave that up to the maintainers.
