### PR TITLE
LibC+Ports: Set the correct prefix for libxml2 

### DIFF
--- a/Ports/libxml2/package.sh
+++ b/Ports/libxml2/package.sh
@@ -6,11 +6,10 @@ use_fresh_config_sub=true
 files="https://download.gnome.org/sources/libxml2/2.9/libxml2-${version}.tar.xz libxml2-${version}.tar.xz 276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e"
 auth_type=sha256
 depends=("libiconv" "xz")
-configopts=("--prefix=${SERENITY_INSTALL_ROOT}/usr/local" "--without-python")
+configopts=("--with-sysroot=${SERENITY_INSTALL_ROOT}" "--prefix=/usr/local" "--without-python")
 
 install() {
-    # Leave out DESTDIR - otherwise the prefix breaks
-    run make install
+    run make DESTDIR="${SERENITY_INSTALL_ROOT}" install
 
     # Link shared library
     run ${SERENITY_ARCH}-pc-serenity-gcc -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.so -Wl,-soname,libxml2.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.a -Wl,--no-whole-archive -llzma

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -11,6 +11,13 @@
 
 __BEGIN_DECLS
 
+#define POSIX_FADV_DONTNEED 1
+#define POSIX_FADV_NOREUSE 2
+#define POSIX_FADV_NORMAL 3
+#define POSIX_FADV_RANDOM 4
+#define POSIX_FADV_SEQUENTIAL 5
+#define POSIX_FADV_WILLNEED 6
+
 int creat(char const* path, mode_t);
 int open(char const* path, int options, ...);
 int openat(int dirfd, char const* path, int options, ...);


### PR DESCRIPTION
The prefix should apply both inside and outside the system. Having the full host path there only confuses software that is built inside the system, as well as other ports that prepend the host path themselves additionally.

For convenience, an additional change is included that defines the POSIX fadvise constants, as they are now required by `xz` (a dependency of `libxml2`) now that we officially declare that we support `posix_fadvise`.