### PR TITLE
Ports: Make the number of compile jobs configurable

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -2,6 +2,7 @@
 set -eu
 
 SCRIPT="$(dirname "${0}")"
+export MAKEJOBS="${MAKEJOBS:-$(nproc)}"
 
 maybe_source() {
     if [ -f "$1" ]; then
@@ -46,7 +47,7 @@ host_env() {
 
 packagesdb="${DESTDIR}/usr/Ports/packages.db"
 
-makeopts=("-j$(nproc)")
+makeopts=("-j${MAKEJOBS}")
 installopts=()
 configscript=configure
 configopts=()

--- a/Ports/cmake/package.sh
+++ b/Ports/cmake/package.sh
@@ -12,7 +12,7 @@ configure() {
 }
 
 build() {
-    run ninja
+    run ninja -j${MAKEJOBS}
 }
 
 install() {

--- a/Ports/llvm/package.sh
+++ b/Ports/llvm/package.sh
@@ -50,7 +50,7 @@ configure() {
 }
 
 build() {
-    ninja -C llvm-build
+    ninja -j${MAKEJOBS} -C llvm-build
 }
 
 install() {


### PR DESCRIPTION
I've decided to not go ahead and mass-replace all build commands, as there is no real need to at the moment. I changed two of the heavy ports (that weren't already using `makeargs` anyways) for my own personal use, the rest can follow as people see fit.