### PR TITLE
Ports: Fix `clean_all` in `build_all.sh` and add argument to clean only

### DIFF
--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -89,6 +89,9 @@ if [ "$build" == true ]; then
             popd > /dev/null
         fi
     done
+    if [ "$verbose" == true ]; then
+        echo "Built these ports: $built_ports"
+    fi
 fi
 
 if [ "$some_failed" == false ]; then

--- a/Ports/build_all.sh
+++ b/Ports/build_all.sh
@@ -28,6 +28,26 @@ esac
 some_failed=false
 built_ports=""
 
+if [ "$clean" == true ]; then
+    for file in *; do
+        if [ -d "$file" ]; then
+            pushd ${file} > /dev/null
+            port=$(basename "$file")
+            if ! [ -f package.sh ]; then
+                echo "ERROR: Skipping cleaning of $port because its package.sh script is missing."
+                popd > /dev/null
+                continue
+            fi
+            if [ "$verbose" == true ]; then
+                ./package.sh clean_all
+            else
+                ./package.sh clean_all > /dev/null 2>&1
+            fi
+            popd > /dev/null
+        fi
+    done
+fi
+
 for file in *; do
     if [ -d $file ]; then
         pushd $file > /dev/null
@@ -50,13 +70,6 @@ for file in *; do
                 continue
             fi
 
-            if [ "$clean" == true ]; then
-                if [ "$verbose" == true ]; then
-                    ./package.sh clean_all
-                else
-                    ./package.sh clean_all > /dev/null 2>&1
-                fi
-            fi
             if [ "$verbose" == true ]; then
                 if ./package.sh; then
                     echo "Built ${port}."


### PR DESCRIPTION
This fixes the cleaning of dependencies when running the `build_all.sh` script. Previously dependencies would be built without cleaning them.

The new `clean_only` argument can be used to do what is says, cleaning all ports without rebuilding them.

Lastly, the verbose mode prints a list of successfully built ports after building is finished, so you can see which ports did not fail to build.

The reason I needed this is for switching from `i686` to `x86_64`. When you do, all the ports need to be cleaned. It would be better to build the ports inside `Build/$SERENITY_ARCH/Ports`, so this won't be necessary, but that may be a future PR.

PS: This bug is also present in `build_installed.sh`.