### PR TITLE
LibJS: Reorder parsing for TimeSpecWithOptionalTimeZoneNotAmbiguous

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/ISO8601.cpp
@@ -1149,6 +1149,15 @@ bool ISO8601Parser::parse_time_spec_with_optional_time_zone_not_ambiguous()
     //     TimeHour : TimeMinute : TimeSecond TimeFraction[opt] TimeZone[opt]
     //     TimeHour TimeMinute TimeSecondNotValidMonth TimeZone[opt]
     //     TimeHour TimeMinute TimeSecond TimeFraction TimeZone[opt]
+    // NOTE: Reverse order here because `TimeHour TimeZoneNumericUTCOffsetNotAmbiguous[opt] TimeZoneBracketedAnnotation[opt]` can
+    // be a subset of `TimeHourNotValidMonth TimeZone`, so we'd not attempt to parse that but may not exhaust the input string.
+    {
+        StateTransaction transaction { *this };
+        if (parse_time_hour_not_valid_month() && parse_time_zone()) {
+            transaction.commit();
+            return true;
+        }
+    }
     {
         StateTransaction transaction { *this };
         if (parse_time_hour()) {
@@ -1192,13 +1201,6 @@ bool ISO8601Parser::parse_time_spec_with_optional_time_zone_not_ambiguous()
                 transaction.commit();
                 return true;
             }
-        }
-    }
-    {
-        StateTransaction transaction { *this };
-        if (parse_time_hour_not_valid_month() && parse_time_zone()) {
-            transaction.commit();
-            return true;
         }
     }
     {


### PR DESCRIPTION
Because `TimeHour TimeZoneNumericUTCOffsetNotAmbiguous[opt] TimeZoneBracketedAnnotation[opt]` can be a subset of `TimeHourNotValidMonth TimeZone` we would not exhaust the whole input in some cases, which would result in an incorrectly thrown exception.