### PR TITLE
LibJS: Reject -00000 as extended year in Date parsing

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
+++ b/Userland/Libraries/LibJS/Runtime/DateConstructor.cpp
@@ -59,6 +59,9 @@ static Value parse_simplified_iso8601(GlobalObject& global_object, String const&
             Optional<int> absolute_year;
             if (!lex_n_digits(6, absolute_year))
                 return false;
+            // The representation of the year 0 as -000000 is invalid.
+            if (absolute_year.value() == 0)
+                return false;
             year = -absolute_year.value();
             return true;
         }

--- a/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Date/Date.parse.js
@@ -30,6 +30,7 @@ test("basic functionality", () => {
     expect(Date.parse("1980-05-30T13:40+1:10")).toBe(NaN);
     expect(Date.parse("1970-06-30T13:30Zoo")).toBe(NaN);
     expect(Date.parse("2020T13:30.40:")).toBe(NaN);
+    expect(Date.parse("-000000")).toBe(NaN);
 });
 
 test("time clip", () => {


### PR DESCRIPTION
This change to Date parsing has already reached consensus (and relevant test262 tests have already been merged in), it was just not merged into the spec text yet. https://github.com/tc39/ecma262/pull/2550