### PR TITLE
LibJS: Do not negate zero into negative zero in ToIntegerOrInfinity

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Value.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Value.cpp
@@ -800,7 +800,7 @@ ThrowCompletionOr<double> Value::to_integer_or_infinity(GlobalObject& global_obj
     if (number.is_infinity())
         return number.as_double();
     auto integer = floor(fabs(number.as_double()));
-    if (number.as_double() < 0)
+    if (number.as_double() < 0 && integer != 0)
         integer = -integer;
     return integer;
 }


### PR DESCRIPTION
When the input value was in the range of [-1, 0] we would incorrectly negate the resulting integer, resulting in -0 instead of the expected 0

```
test/built-ins/Date/prototype/valueOf/S9.4_A3_T1.js ❌ -> ✅
```