### PR TITLE
Kernel+ifconfig: Remove default gateway related code

### DIFF
--- a/Base/usr/share/man/man1/ifconfig.md
+++ b/Base/usr/share/man/man1/ifconfig.md
@@ -5,7 +5,7 @@ ifconfig
 ## Synopsis
 
 ```sh
-$ ifconfig [--ipv4 ip] [--adapter adapter] [--gateway gateway] [--mask mask]
+$ ifconfig [--ipv4 ip] [--adapter adapter] [--mask mask]
 ```
 
 ## Description
@@ -16,7 +16,6 @@ Display or modify the configuration of each network interface.
 
 * `-i ip`, `--ipv4 ip`: Set the IP address of the selected network
 * `-a adapter`, `--adapter adapter`: Select a specific network adapter to configure
-* `-g gateway`, `--gateway gateway`: Set the default gateway of the selected network
 * `-m mask`, `--mask mask`: Set the network mask of the selected network
 
 <!-- Auto-generated through ArgsParser -->

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -55,10 +55,6 @@ private:
                 auto ipv4_netmask = TRY(adapter.ipv4_netmask().to_string());
                 TRY(obj.add("ipv4_netmask", ipv4_netmask->view()));
             }
-            if (!adapter.ipv4_gateway().is_zero()) {
-                auto ipv4_gateway = TRY(adapter.ipv4_gateway().to_string());
-                TRY(obj.add("ipv4_gateway", ipv4_gateway->view()));
-            }
             TRY(obj.add("packets_in", adapter.packets_in()));
             TRY(obj.add("bytes_in", adapter.bytes_in()));
             TRY(obj.add("packets_out", adapter.packets_out()));

--- a/Kernel/Net/NetworkAdapter.cpp
+++ b/Kernel/Net/NetworkAdapter.cpp
@@ -159,9 +159,4 @@ void NetworkAdapter::set_ipv4_netmask(IPv4Address const& netmask)
     m_ipv4_netmask = netmask;
 }
 
-void NetworkAdapter::set_ipv4_gateway(IPv4Address const& gateway)
-{
-    m_ipv4_gateway = gateway;
-}
-
 }

--- a/Kernel/Net/NetworkAdapter.h
+++ b/Kernel/Net/NetworkAdapter.h
@@ -55,7 +55,6 @@ public:
     IPv4Address ipv4_address() const { return m_ipv4_address; }
     IPv4Address ipv4_netmask() const { return m_ipv4_netmask; }
     IPv4Address ipv4_broadcast() const { return IPv4Address { (m_ipv4_address.to_u32() & m_ipv4_netmask.to_u32()) | ~m_ipv4_netmask.to_u32() }; }
-    IPv4Address ipv4_gateway() const { return m_ipv4_gateway; }
     virtual bool link_up() { return false; }
     virtual i32 link_speed()
     {
@@ -66,7 +65,6 @@ public:
 
     void set_ipv4_address(IPv4Address const&);
     void set_ipv4_netmask(IPv4Address const&);
-    void set_ipv4_gateway(IPv4Address const&);
 
     void send(MACAddress const&, ARPPacket const&);
     void fill_in_ipv4_header(PacketWithTimestamp&, IPv4Address const&, MACAddress const&, IPv4Address const&, IPv4Protocol, size_t, u8 type_of_service, u8 ttl);
@@ -103,7 +101,6 @@ private:
     MACAddress m_mac_address;
     IPv4Address m_ipv4_address;
     IPv4Address m_ipv4_netmask;
-    IPv4Address m_ipv4_gateway;
 
     // FIXME: Make this configurable
     static constexpr size_t max_packet_buffers = 1024;

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -67,7 +67,6 @@ void NetworkTask_main(void*)
         if (adapter.class_name() == "LoopbackAdapter"sv) {
             adapter.set_ipv4_address({ 127, 0, 0, 1 });
             adapter.set_ipv4_netmask({ 255, 0, 0, 0 });
-            adapter.set_ipv4_gateway({ 0, 0, 0, 0 });
         }
 
         adapter.on_receive = [&]() {

--- a/Userland/Utilities/ifconfig.cpp
+++ b/Userland/Utilities/ifconfig.cpp
@@ -27,18 +27,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     char const* value_ipv4 = nullptr;
     char const* value_adapter = nullptr;
-    char const* value_gateway = nullptr;
     char const* value_mask = nullptr;
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Display or modify the configuration of each network interface.");
     args_parser.add_option(value_ipv4, "Set the IP address of the selected network", "ipv4", 'i', "ip");
     args_parser.add_option(value_adapter, "Select a specific network adapter to configure", "adapter", 'a', "adapter");
-    args_parser.add_option(value_gateway, "Set the default gateway of the selected network", "gateway", 'g', "gateway");
     args_parser.add_option(value_mask, "Set the network mask of the selected network", "mask", 'm', "mask");
     args_parser.parse(arguments);
 
-    if (!value_ipv4 && !value_adapter && !value_gateway && !value_mask) {
+    if (!value_ipv4 && !value_adapter && !value_mask) {
         auto file = TRY(Core::File::open("/proc/net/adapters", Core::OpenMode::ReadOnly));
         auto json = TRY(JsonValue::from_string(file->read_all()));
 
@@ -49,7 +47,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             auto class_name = if_object.get("class_name").to_string();
             auto mac_address = if_object.get("mac_address").to_string();
             auto ipv4_address = if_object.get("ipv4_address").to_string();
-            auto gateway = if_object.get("ipv4_gateway").to_string();
             auto netmask = if_object.get("ipv4_netmask").to_string();
             auto packets_in = if_object.get("packets_in").to_u32();
             auto bytes_in = if_object.get("bytes_in").to_u32();
@@ -61,7 +58,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             outln("\tmac: {}", mac_address);
             outln("\tipv4: {}", ipv4_address);
             outln("\tnetmask: {}", netmask);
-            outln("\tgateway: {}", gateway);
             outln("\tclass: {}", class_name);
             outln("\tRX: {} packets {} bytes ({})", packets_in, bytes_in, human_readable_size(bytes_in));
             outln("\tTX: {} packets {} bytes ({})", packets_out, bytes_out, human_readable_size(bytes_out));
@@ -137,30 +133,6 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
             int rc = ioctl(fd, SIOCSIFNETMASK, &ifr);
             if (rc < 0) {
                 perror("ioctl(SIOCSIFNETMASK)");
-                return 1;
-            }
-        }
-
-        if (value_gateway) {
-            auto address = IPv4Address::from_string(value_gateway);
-
-            int fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_IP);
-            if (fd < 0) {
-                perror("socket");
-                return 1;
-            }
-
-            struct rtentry rt;
-            memset(&rt, 0, sizeof(rt));
-
-            rt.rt_dev = const_cast<char*>(ifname.characters());
-            rt.rt_gateway.sa_family = AF_INET;
-            ((sockaddr_in&)rt.rt_gateway).sin_addr.s_addr = address.value().to_in_addr_t();
-            rt.rt_flags = RTF_UP | RTF_GATEWAY;
-
-            int rc = ioctl(fd, SIOCADDRT, &rt);
-            if (rc < 0) {
-                perror("ioctl(SIOCADDRT)");
                 return 1;
             }
         }


### PR DESCRIPTION
This doesn't make sense since now we have global routing tables implemented and wasn't used anywhere (ifconfig displayed `null` in the gateway field)

**Kernel: Stop exposing gateway field**
**ifconfig: Stop supporting setting/displaying default gateway**