### PR TITLE
readelf: Don't error out on invalid interpreter path

### DIFF
--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -323,16 +323,14 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         if (interpreter_file_or_error.is_error()) {
             warnln("Unable to map interpreter file {}: {}", interpreter_path, interpreter_file_or_error.error());
-            return -1;
-        }
+        } else {
+            auto interpreter_image_data = interpreter_file_or_error.value()->bytes();
 
-        auto interpreter_image_data = interpreter_file_or_error.value()->bytes();
+            ELF::Image interpreter_image(interpreter_image_data);
 
-        ELF::Image interpreter_image(interpreter_image_data);
-
-        if (!interpreter_image.is_valid()) {
-            warnln("ELF interpreter image is invalid");
-            return -1;
+            if (!interpreter_image.is_valid()) {
+                warnln("ELF interpreter image is invalid");
+            }
         }
 
         int fd = TRY(Core::System::open(path, O_RDONLY));


### PR DESCRIPTION
This lets us inspect ELF binaries with un-loadable program interpreters,
same as binutils and llvm-readelf.

for e.g., here's a simple Linux binary that would refuse to be readelf'd before this patch:

![readelf-ok](https://user-images.githubusercontent.com/8388494/166133926-7daf5a11-9230-4538-9149-2ef0b7a92ef0.png)

llvm-readelf-14 is happy to print out the program headers from a serenity binary :)

```
$ llvm-readelf-14 -l ./Build/x86_64clang/Root/bin/ls

Elf file type is DYN (Shared object file)
Entry point 0x9000
There are 10 program headers, starting at offset 64

Program Headers:
  Type           Offset   VirtAddr           PhysAddr           FileSiz  MemSiz   Flg Align
  PHDR           0x000040 0x0000000000000040 0x0000000000000040 0x000230 0x000230 R   0x8
  INTERP         0x000270 0x0000000000000270 0x0000000000000270 0x000013 0x000013 R   0x1
      [Requesting program interpreter: /usr/lib/Loader.so]
  LOAD           0x000000 0x0000000000000000 0x0000000000000000 0x008e44 0x008e44 R   0x1000
  LOAD           0x009000 0x0000000000009000 0x0000000000009000 0x00e420 0x00e420 R E 0x1000
  LOAD           0x018000 0x0000000000018000 0x0000000000018000 0x000660 0x000660 RW  0x1000
  LOAD           0x018660 0x0000000000019660 0x0000000000019660 0x00c660 0x00e988 RW  0x1000
  DYNAMIC        0x0180b8 0x00000000000180b8 0x00000000000180b8 0x0001f0 0x0001f0 RW  0x8
  GNU_RELRO      0x018000 0x0000000000018000 0x0000000000018000 0x000660 0x001000 R   0x1
  GNU_EH_FRAME   0x006ed0 0x0000000000006ed0 0x0000000000006ed0 0x00052c 0x00052c R   0x4
  GNU_STACK      0x000000 0x0000000000000000 0x0000000000000000 0x000000 0x000000 RW  0x0

 Section to Segment mapping:
  Segment Sections...
   00     
   01     .interp 
   02     .interp .dynsym .gnu.hash .dynstr .rela.dyn .relr.dyn .rela.plt .rodata __llvm_prf_names .eh_frame_hdr .eh_frame 
   03     .text .init .fini .plt 
   04     .init_array .fini_array .data.rel.ro .dynamic .got .got.plt 
   05     .data __llvm_prf_cnts __llvm_prf_data __llvm_prf_vnds .bss 
   06     .dynamic 
   07     .init_array .fini_array .data.rel.ro .dynamic .got .got.plt 
   08     .eh_frame_hdr 
   09     
   None   .debug_abbrev .debug_info .debug_str_offsets .debug_str .debug_addr .comment .debug_line .debug_line_str .debug_aranges .debug_rnglists __llvm_covfun __llvm_covmap .symtab .shstrtab .strtab 
```