### PR TITLE
Documentation: Fix Typo in TransferringFiles.md

### DIFF
--- a/Documentation/TransferringFiles.md
+++ b/Documentation/TransferringFiles.md
@@ -47,7 +47,7 @@ cd Ports
 cd openssh
 ./package.sh
 cd ../..
-Meta/serenity.run
+Meta/serenity.sh run
 ```
 - From within SerenityOS, check that you have a working sftp app:
 


### PR DESCRIPTION
Quite simple: Changed typo in command example from Meta/serenity.run to Meta/serenity.sh run