### PR TITLE
LibGUI+Applications:  Center theme previews in ThemeEditor and DisplaySettings 

### DIFF
--- a/Userland/Applications/DisplaySettings/ThemePreviewWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemePreviewWidget.cpp
@@ -28,19 +28,23 @@ void ThemePreviewWidget::paint_preview(GUI::PaintEvent&)
 {
     GUI::Painter painter(*this);
 
-    auto active_window_rect = rect().shrunken(48, 100).translated(4, 26);
+    auto active_window_rect = frame_inner_rect().shrunken(48, 100);
     auto inactive_window_rect = active_window_rect.translated(-8, -32);
     auto message_box = active_window_rect.shrunken(100, 60);
+
+    Array<Window, 3> window_group {
+        active_window_rect, inactive_window_rect, message_box
+    };
+    center_window_group_within(window_group, frame_inner_rect());
 
     paint_window("Inactive Window", inactive_window_rect, Gfx::WindowTheme::WindowState::Inactive, inactive_window_icon());
     paint_window("Active Window", active_window_rect, Gfx::WindowTheme::WindowState::Active, active_window_icon());
     paint_window("Alert", message_box, Gfx::WindowTheme::WindowState::Highlighted, active_window_icon(), 1);
 
     auto draw_centered_button = [&](auto window_rect, auto text, int button_width, int button_height) {
-        auto box_center = window_rect.center();
-        Gfx::IntRect button_rect { box_center.x() - button_width / 2, box_center.y() - button_height / 2, button_width, button_height };
-        Gfx::StylePainter::paint_button(
-            painter, button_rect, preview_palette(), Gfx::ButtonStyle::Normal, false, false, false, true, false, false);
+        Gfx::IntRect button_rect { 0, 0, button_width, button_height };
+        button_rect.center_within(window_rect);
+        Gfx::StylePainter::paint_button(painter, button_rect, preview_palette(), Gfx::ButtonStyle::Normal, false, false, false, true, false, false);
         painter.draw_text(button_rect, text, Gfx::TextAlignment::Center, preview_palette().color(foreground_role()), Gfx::TextElision::Right, Gfx::TextWrapping::DontWrap);
     };
 

--- a/Userland/Applications/DisplaySettings/ThemesSettings.gml
+++ b/Userland/Applications/DisplaySettings/ThemesSettings.gml
@@ -7,7 +7,7 @@
     @GUI::Frame {
         layout: @GUI::HorizontalBoxLayout {}
         name: "preview_frame"
-        fixed_width: 304
+        fixed_width: 306
         fixed_height: 201
     }
 

--- a/Userland/Applications/ThemeEditor/PreviewWidget.cpp
+++ b/Userland/Applications/ThemeEditor/PreviewWidget.cpp
@@ -100,33 +100,20 @@ void PreviewWidget::set_color_filter(OwnPtr<Gfx::ColorBlindnessFilter> color_fil
 
 void PreviewWidget::update_preview_window_locations()
 {
-    auto to_frame_rect = [&](Gfx::IntRect rect) {
-        return Gfx::WindowTheme::current().frame_rect_for_window(
-            Gfx::WindowTheme::WindowType::Normal, rect, preview_palette(), 0);
-    };
-
     constexpr int inactive_offset_x = -20;
     constexpr int inactive_offset_y = -20;
     constexpr int hightlight_offset_x = 140;
-    constexpr int hightlight_offset_y = 60;
+    constexpr int hightlight_offset_y = 80;
 
     m_active_window_rect = Gfx::IntRect(0, 0, 320, 220);
     m_inactive_window_rect = m_active_window_rect.translated(inactive_offset_x, inactive_offset_y);
-    auto active_frame = to_frame_rect(m_active_window_rect);
-    auto x_delta = m_active_window_rect.x() - active_frame.x();
-    auto y_delta = m_active_window_rect.y() - active_frame.y();
+    m_highlight_window_rect = Gfx::IntRect(m_active_window_rect.location(), { 160, 70 }).translated(hightlight_offset_x, hightlight_offset_y);
 
-    // Center preview windows accounting for the window frames,
-    // which can vary in size depending on properties of the theme.
-    auto combind_frame_rect = active_frame.united(to_frame_rect(m_inactive_window_rect)).centered_within(frame_inner_rect());
-    m_inactive_window_rect.set_x(combind_frame_rect.x() + x_delta);
-    m_inactive_window_rect.set_y(combind_frame_rect.y() + y_delta);
-    m_active_window_rect.set_x(m_inactive_window_rect.x() - inactive_offset_x);
-    m_active_window_rect.set_y(m_inactive_window_rect.y() - inactive_offset_y);
-    m_highlight_window_rect = Gfx::IntRect(0, 0, 160, 70)
-                                  .translated(m_active_window_rect.x(), m_active_window_rect.y())
-                                  .translated(hightlight_offset_x, hightlight_offset_y)
-                                  .translated(x_delta, y_delta);
+    Array<Window, 3> window_group {
+        m_active_window_rect, m_inactive_window_rect, m_highlight_window_rect
+    };
+
+    center_window_group_within(window_group, frame_inner_rect());
 
     m_gallery->set_relative_rect(m_active_window_rect);
 }

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.cpp
@@ -158,4 +158,31 @@ void AbstractThemePreview::paint_event(GUI::PaintEvent& event)
     paint_preview(event);
 }
 
+void AbstractThemePreview::center_window_group_within(Span<Window> windows, Gfx::IntRect const& bounds)
+{
+    VERIFY(windows.size() >= 1);
+
+    auto to_frame_rect = [&](Gfx::IntRect const& rect) {
+        return Gfx::WindowTheme::current().frame_rect_for_window(
+            Gfx::WindowTheme::WindowType::Normal, rect, m_preview_palette, 0);
+    };
+
+    auto leftmost_x_value = windows[0].rect.x();
+    auto topmost_y_value = windows[0].rect.y();
+    auto combind_frame_rect = to_frame_rect(windows[0].rect);
+    for (auto& window : windows.slice(1)) {
+        if (window.rect.x() < leftmost_x_value)
+            leftmost_x_value = window.rect.x();
+        if (window.rect.y() < topmost_y_value)
+            topmost_y_value = window.rect.y();
+        combind_frame_rect = combind_frame_rect.united(to_frame_rect(window.rect));
+    }
+
+    combind_frame_rect.center_within(bounds);
+    auto frame_offset = to_frame_rect({}).location();
+    for (auto& window : windows) {
+        window.rect.set_left(combind_frame_rect.left() + (window.rect.x() - leftmost_x_value) - frame_offset.x());
+        window.rect.set_top(combind_frame_rect.top() + (window.rect.y() - topmost_y_value) - frame_offset.y());
+    }
+}
 }

--- a/Userland/Libraries/LibGUI/AbstractThemePreview.h
+++ b/Userland/Libraries/LibGUI/AbstractThemePreview.h
@@ -31,6 +31,11 @@ public:
     Function<void(String const&)> on_theme_load_from_file;
     Function<void()> on_palette_change;
 
+    struct Window {
+        Gfx::IntRect& rect;
+    };
+    void center_window_group_within(Span<Window> windows, Gfx::IntRect const& bounds);
+
 protected:
     explicit AbstractThemePreview(Gfx::Palette const&);
 


### PR DESCRIPTION
This adds `AbstractThemePreview::center_window_group_within()` as a general way to center a bunch of windows within some bounding box. 

I've switched ThemeEditor to use this (rather than calculate it manually), and also used this method in DisplaySettings which before was slightly uncentered (which bugged me).
