### PR TITLE
Browser: Allow the browser to load local file via FileSystemAccessServer

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -183,8 +183,9 @@ public:
     /// Ensures that the required space is available.
     ErrorOr<Bytes> get_bytes_for_writing(size_t length)
     {
-        TRY(try_ensure_capacity(size() + length));
-        return Bytes { data() + size(), length };
+        auto const old_size = size();
+        TRY(try_resize(old_size + length));
+        return Bytes { data() + old_size, length };
     }
 
     /// Like get_bytes_for_writing, but crashes if allocation fails.

--- a/Userland/Applications/Browser/main.cpp
+++ b/Userland/Applications/Browser/main.cpp
@@ -83,6 +83,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/etc/passwd", "r"));
     TRY(Core::System::unveil("/etc/timezone", "r"));
+    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/portal/image", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil("/tmp/portal/request", "rw"));

--- a/Userland/Applications/Help/MainWidget.cpp
+++ b/Userland/Applications/Help/MainWidget.cpp
@@ -267,22 +267,7 @@ ErrorOr<void> MainWidget::initialize_fallibles(GUI::Window& window)
 void MainWidget::open_url(URL const& url)
 {
     if (url.protocol() == "file") {
-        auto path = url.path();
-        auto source_result = m_manual_model->page_view(path);
-        if (source_result.is_error()) {
-            GUI::MessageBox::show(window(), String::formatted("{}", source_result.error()), "Failed to open man page", GUI::MessageBox::Type::Error);
-            return;
-        }
-
-        auto source = source_result.value();
-        String html;
-        {
-            auto md_document = Markdown::Document::parse(source);
-            VERIFY(md_document);
-            html = md_document->render_to_html();
-        }
-
-        m_web_view->load_html(html, url);
+        m_web_view->load(url);
         m_web_view->scroll_to_top();
 
         GUI::Application::the()->deferred_invoke([&, path = url.path()] {

--- a/Userland/Applications/Help/main.cpp
+++ b/Userland/Applications/Help/main.cpp
@@ -33,6 +33,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/usr/share/man", "r"));
+    TRY(Core::System::unveil("/tmp/portal/filesystemaccess", "rw"));
     TRY(Core::System::unveil("/tmp/portal/launch", "rw"));
     TRY(Core::System::unveil("/tmp/portal/webcontent", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -37,7 +37,7 @@ public:
     /// Tries to fill the entire buffer through reading. Returns whether the
     /// buffer was filled without an error.
     virtual bool read_or_error(Bytes);
-    ErrorOr<ByteBuffer> read_all();
+    virtual ErrorOr<ByteBuffer> read_all(size_t block_size = 4096);
 
     virtual bool is_writable() const { return false; }
     /// Tries to write the entire contents of the buffer. It is possible for
@@ -62,6 +62,9 @@ public:
     virtual ~Stream()
     {
     }
+
+protected:
+    ErrorOr<ByteBuffer> read_all_impl(size_t block_size, size_t file_size = 0);
 };
 
 enum class SeekMode {
@@ -197,6 +200,7 @@ public:
 
     virtual bool is_readable() const override;
     virtual ErrorOr<Bytes> read(Bytes) override;
+    virtual ErrorOr<ByteBuffer> read_all(size_t block_size = 4096) override;
     virtual bool is_writable() const override;
     virtual ErrorOr<size_t> write(ReadonlyBytes) override;
     virtual bool is_eof() const override;

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -146,7 +146,7 @@ void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> co
 
     if (file->is_directory()) {
         GUI::MessageBox::show_error(request_data.parent_window, String::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
-        request_data.promise->resolve(Error::from_string_literal("Cannot open directory"sv));
+        request_data.promise->resolve(Error::from_errno(EISDIR));
         return;
     }
 

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.cpp
@@ -28,8 +28,8 @@ Client& Client::the()
 
 Result Client::try_request_file_read_only_approved(GUI::Window* parent_window, String const& path)
 {
-    m_promise = Core::Promise<Result>::construct();
-    m_parent_window = parent_window;
+    auto const id = get_new_id();
+    m_promises.set(id, PromiseAndWindow { Core::Promise<Result>::construct(), parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -42,19 +42,19 @@ Result Client::try_request_file_read_only_approved(GUI::Window* parent_window, S
     });
 
     if (path.starts_with('/')) {
-        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, path);
+        async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, path);
     } else {
         auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
-        async_request_file_read_only_approved(parent_window_server_client_id, parent_window_id, full_path);
+        async_request_file_read_only_approved(id, parent_window_server_client_id, parent_window_id, full_path);
     }
 
-    return m_promise->await();
+    return handle_promise(id);
 }
 
 Result Client::try_request_file(GUI::Window* parent_window, String const& path, Core::OpenMode mode)
 {
-    m_promise = Core::Promise<Result>::construct();
-    m_parent_window = parent_window;
+    auto const id = get_new_id();
+    m_promises.set(id, PromiseAndWindow { Core::Promise<Result>::construct(), parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -67,19 +67,19 @@ Result Client::try_request_file(GUI::Window* parent_window, String const& path, 
     });
 
     if (path.starts_with('/')) {
-        async_request_file(parent_window_server_client_id, parent_window_id, path, mode);
+        async_request_file(id, parent_window_server_client_id, parent_window_id, path, mode);
     } else {
         auto full_path = LexicalPath::join(Core::File::current_working_directory(), path).string();
-        async_request_file(parent_window_server_client_id, parent_window_id, full_path, mode);
+        async_request_file(id, parent_window_server_client_id, parent_window_id, full_path, mode);
     }
 
-    return m_promise->await();
+    return handle_promise(id);
 }
 
 Result Client::try_open_file(GUI::Window* parent_window, String const& window_title, StringView path, Core::OpenMode requested_access)
 {
-    m_promise = Core::Promise<Result>::construct();
-    m_parent_window = parent_window;
+    auto const id = get_new_id();
+    m_promises.set(id, PromiseAndWindow { Core::Promise<Result>::construct(), parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -91,15 +91,15 @@ Result Client::try_open_file(GUI::Window* parent_window, String const& window_ti
         GUI::ConnectionToWindowServer::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_prompt_open_file(parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
+    async_prompt_open_file(id, parent_window_server_client_id, parent_window_id, window_title, path, requested_access);
 
-    return m_promise->await();
+    return handle_promise(id);
 }
 
 Result Client::try_save_file(GUI::Window* parent_window, String const& name, String const ext, Core::OpenMode requested_access)
 {
-    m_promise = Core::Promise<Result>::construct();
-    m_parent_window = parent_window;
+    auto const id = get_new_id();
+    m_promises.set(id, PromiseAndWindow { Core::Promise<Result>::construct(), parent_window });
 
     auto parent_window_server_client_id = GUI::ConnectionToWindowServer::the().expose_client_id();
     auto child_window_server_client_id = expose_window_server_client_id();
@@ -111,51 +111,69 @@ Result Client::try_save_file(GUI::Window* parent_window, String const& name, Str
         GUI::ConnectionToWindowServer::the().async_remove_window_stealing_for_client(child_window_server_client_id, parent_window_id);
     });
 
-    async_prompt_save_file(parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
+    async_prompt_save_file(id, parent_window_server_client_id, parent_window_id, name.is_null() ? "Untitled" : name, ext.is_null() ? "txt" : ext, Core::StandardPaths::home_directory(), requested_access);
 
-    return m_promise->await();
+    return handle_promise(id);
 }
 
-void Client::handle_prompt_end(i32 error, Optional<IPC::File> const& ipc_file, Optional<String> const& chosen_file)
+void Client::handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& ipc_file, Optional<String> const& chosen_file)
 {
-    VERIFY(m_promise);
+    auto potential_data = m_promises.get(request_id);
+    VERIFY(potential_data.has_value());
+    auto& request_data = potential_data.value();
     if (error != 0) {
         // We don't want to show an error message for non-existent files since some applications may want
         // to handle it as opening a new, named file.
         if (error != -1 && error != ENOENT)
-            GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
-        m_promise->resolve(Error::from_errno(error));
+            GUI::MessageBox::show_error(request_data.parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
+        request_data.promise->resolve(Error::from_errno(error));
         return;
     }
 
     auto file = Core::File::construct();
     auto fd = ipc_file->take_fd();
     if (!file->open(fd, Core::OpenMode::ReadWrite, Core::File::ShouldCloseFileDescriptor::Yes) && file->error() != ENOENT) {
-        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
-        m_promise->resolve(Error::from_errno(file->error()));
+        GUI::MessageBox::show_error(request_data.parent_window, String::formatted("Opening \"{}\" failed: {}", *chosen_file, strerror(error)));
+        request_data.promise->resolve(Error::from_errno(file->error()));
         return;
     }
 
     if (file->is_device()) {
-        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
-        m_promise->resolve(Error::from_string_literal("Cannot open device files"sv));
+        GUI::MessageBox::show_error(request_data.parent_window, String::formatted("Opening \"{}\" failed: Cannot open device files", *chosen_file));
+        request_data.promise->resolve(Error::from_string_literal("Cannot open device files"sv));
         return;
     }
 
     if (file->is_directory()) {
-        GUI::MessageBox::show_error(m_parent_window, String::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
-        m_promise->resolve(Error::from_string_literal("Cannot open directory"sv));
+        GUI::MessageBox::show_error(request_data.parent_window, String::formatted("Opening \"{}\" failed: Cannot open directory", *chosen_file));
+        request_data.promise->resolve(Error::from_string_literal("Cannot open directory"sv));
         return;
     }
 
     file->set_filename(move(*chosen_file));
-    m_promise->resolve(file);
+    request_data.promise->resolve(file);
 }
 
 void Client::die()
 {
-    if (m_promise)
-        handle_prompt_end(ECONNRESET, {}, "");
+    for (auto const& entry : m_promises)
+        handle_prompt_end(entry.key, ECONNRESET, {}, "");
+}
+
+int Client::get_new_id()
+{
+    auto const new_id = m_last_id++;
+    // Note: This verify shouldn't fail, and we should provide a valid ID
+    // But we probably have more issues if this test fails.
+    VERIFY(!m_promises.contains(new_id));
+    return new_id;
+}
+
+Result Client::handle_promise(int id)
+{
+    auto result = m_promises.get(id)->promise->await();
+    m_promises.remove(id);
+    return result;
 }
 
 }

--- a/Userland/Libraries/LibFileSystemAccessClient/Client.h
+++ b/Userland/Libraries/LibFileSystemAccessClient/Client.h
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <AK/HashMap.h>
 #include <FileSystemAccessServer/FileSystemAccessClientEndpoint.h>
 #include <FileSystemAccessServer/FileSystemAccessServerEndpoint.h>
 #include <LibCore/File.h>
@@ -41,10 +42,18 @@ private:
     {
     }
 
-    virtual void handle_prompt_end(i32 error, Optional<IPC::File> const& fd, Optional<String> const& chosen_file) override;
+    virtual void handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> const& fd, Optional<String> const& chosen_file) override;
 
-    RefPtr<Core::Promise<Result>> m_promise;
-    GUI::Window* m_parent_window { nullptr };
+    int get_new_id();
+    Result handle_promise(int);
+
+    struct PromiseAndWindow {
+        RefPtr<Core::Promise<Result>> promise {};
+        GUI::Window* parent_window { nullptr };
+    };
+
+    HashMap<int, PromiseAndWindow> m_promises {};
+    int m_last_id { 0 };
 };
 
 }

--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -274,6 +274,7 @@ set(SOURCES
     Layout/TextNode.cpp
     Layout/TreeBuilder.cpp
     Loader/ContentFilter.cpp
+    Loader/FileRequest.cpp
     Loader/FrameLoader.cpp
     Loader/ImageLoader.cpp
     Loader/ImageResource.cpp

--- a/Userland/Libraries/LibWeb/Loader/FileRequest.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FileRequest.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2022, Lucas Chollet <lucas.chollet@free.fr>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "FileRequest.h"
+
+namespace Web {
+
+FileRequest::FileRequest(String path)
+    : m_path(move(path))
+{
+}
+
+String FileRequest::path() const
+{
+    return m_path;
+}
+
+}

--- a/Userland/Libraries/LibWeb/Loader/FileRequest.h
+++ b/Userland/Libraries/LibWeb/Loader/FileRequest.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022, Lucas Chollet <lucas.chollet@free.fr>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Error.h>
+#include <AK/Function.h>
+#include <AK/RefCounted.h>
+#include <AK/String.h>
+
+namespace Web {
+
+class FileRequest : public RefCounted<FileRequest> {
+public:
+    explicit FileRequest(String path);
+
+    String path() const;
+
+    Function<void(ErrorOr<i32>)> on_file_request_finish;
+
+private:
+    String m_path {};
+};
+
+}

--- a/Userland/Libraries/LibWeb/Loader/LoadRequest.cpp
+++ b/Userland/Libraries/LibWeb/Loader/LoadRequest.cpp
@@ -19,6 +19,7 @@ LoadRequest LoadRequest::create_for_url_on_page(const AK::URL& url, Page* page)
         String cookie = page->client().page_did_request_cookie(url, Cookie::Source::Http);
         if (!cookie.is_empty())
             request.set_header("Cookie", cookie);
+        request.set_page(*page);
     }
 
     return request;

--- a/Userland/Libraries/LibWeb/Loader/LoadRequest.h
+++ b/Userland/Libraries/LibWeb/Loader/LoadRequest.h
@@ -12,6 +12,7 @@
 #include <AK/URL.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web {
 
@@ -36,6 +37,9 @@ public:
 
     void start_timer() { m_load_timer.start(); };
     Time load_time() const { return m_load_timer.elapsed_time(); }
+
+    Optional<Page&>& page() { return m_page; };
+    void set_page(Page& page) { m_page = page; }
 
     unsigned hash() const
     {
@@ -70,6 +74,7 @@ private:
     HashMap<String, String> m_headers;
     ByteBuffer m_body;
     Core::ElapsedTimer m_load_timer;
+    Optional<Page&> m_page;
 };
 
 }

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.h
@@ -14,6 +14,7 @@
 #include <LibCore/Object.h>
 #include <LibCore/Proxy.h>
 #include <LibWeb/Loader/Resource.h>
+#include <LibWeb/Page/Page.h>
 
 namespace Web {
 
@@ -98,6 +99,7 @@ private:
     HashTable<NonnullRefPtr<ResourceLoaderConnectorRequest>> m_active_requests;
     NonnullRefPtr<ResourceLoaderConnector> m_connector;
     String m_user_agent;
+    Optional<Page&> m_page {};
 };
 
 }

--- a/Userland/Libraries/LibWeb/Page/Page.h
+++ b/Userland/Libraries/LibWeb/Page/Page.h
@@ -18,6 +18,7 @@
 #include <LibGfx/StandardCursor.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Loader/FileRequest.h>
 
 namespace Web {
 
@@ -110,6 +111,8 @@ public:
     virtual String page_did_request_cookie(const AK::URL&, Cookie::Source) { return {}; }
     virtual void page_did_set_cookie(const AK::URL&, Cookie::ParsedCookie const&, Cookie::Source) { }
     virtual void page_did_update_resource_count(i32) { }
+
+    virtual void request_file(NonnullRefPtr<FileRequest>&) = 0;
 
 protected:
     virtual ~PageClient() = default;

--- a/Userland/Libraries/LibWebView/CMakeLists.txt
+++ b/Userland/Libraries/LibWebView/CMakeLists.txt
@@ -16,6 +16,6 @@ set(GENERATED_SOURCES
 )
 
 serenity_lib(LibWebView webview)
-target_link_libraries(LibWebView LibGfx LibGUI LibImageDecoderClient LibIPC LibProtocol LibWeb)
+target_link_libraries(LibWebView LibFileSystemAccessClient LibGfx LibGUI LibImageDecoderClient LibIPC LibProtocol LibWeb)
 
 add_subdirectory(DumpLayoutTree)

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -112,6 +112,7 @@ public:
     String notify_server_did_request_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::Source source);
     void notify_server_did_set_cookie(Badge<WebContentClient>, const AK::URL& url, Web::Cookie::ParsedCookie const& cookie, Web::Cookie::Source source);
     void notify_server_did_update_resource_count(i32 count_waiting);
+    void notify_server_did_request_file(Badge<WebContentClient>, String const& path, i32);
 
 private:
     OutOfProcessWebView();

--- a/Userland/Libraries/LibWebView/WebContentClient.cpp
+++ b/Userland/Libraries/LibWebView/WebContentClient.cpp
@@ -200,4 +200,9 @@ void WebContentClient::did_update_resource_count(i32 count_waiting)
     m_view.notify_server_did_update_resource_count(count_waiting);
 }
 
+void WebContentClient::did_request_file(String const& path, i32 request_id)
+{
+    m_view.notify_server_did_request_file({}, path, request_id);
+}
+
 }

--- a/Userland/Libraries/LibWebView/WebContentClient.h
+++ b/Userland/Libraries/LibWebView/WebContentClient.h
@@ -61,6 +61,7 @@ private:
     virtual Messages::WebContentClient::DidRequestCookieResponse did_request_cookie(AK::URL const&, u8) override;
     virtual void did_set_cookie(AK::URL const&, Web::Cookie::ParsedCookie const&, u8) override;
     virtual void did_update_resource_count(i32 count_waiting) override;
+    virtual void did_request_file(String const& path, i32) override;
 
     OutOfProcessWebView& m_view;
 };

--- a/Userland/Services/FileSystemAccessServer/ConnectionFromClient.h
+++ b/Userland/Services/FileSystemAccessServer/ConnectionFromClient.h
@@ -27,19 +27,19 @@ public:
 private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::Stream::LocalSocket>);
 
-    virtual void request_file_read_only_approved(i32, i32, String const&) override;
-    virtual void request_file(i32, i32, String const&, Core::OpenMode const&) override;
-    virtual void prompt_open_file(i32, i32, String const&, String const&, Core::OpenMode const&) override;
-    virtual void prompt_save_file(i32, i32, String const&, String const&, String const&, Core::OpenMode const&) override;
+    virtual void request_file_read_only_approved(i32, i32, i32, String const&) override;
+    virtual void request_file(i32, i32, i32, String const&, Core::OpenMode const&) override;
+    virtual void prompt_open_file(i32, i32, i32, String const&, String const&, Core::OpenMode const&) override;
+    virtual void prompt_save_file(i32, i32, i32, String const&, String const&, String const&, Core::OpenMode const&) override;
 
-    void prompt_helper(Optional<String> const&, Core::OpenMode const&);
+    void prompt_helper(i32, Optional<String> const&, Core::OpenMode const&);
     RefPtr<GUI::Window> create_dummy_child_window(i32, i32);
 
     enum class ShouldPrompt {
         No,
         Yes
     };
-    void request_file_handler(i32, i32, String const&, Core::OpenMode const&, ShouldPrompt);
+    void request_file_handler(i32, i32, i32, String const&, Core::OpenMode const&, ShouldPrompt);
 
     virtual Messages::FileSystemAccessServer::ExposeWindowServerClientIdResponse expose_window_server_client_id() override;
 

--- a/Userland/Services/FileSystemAccessServer/FileSystemAccessClient.ipc
+++ b/Userland/Services/FileSystemAccessServer/FileSystemAccessClient.ipc
@@ -1,4 +1,4 @@
 endpoint FileSystemAccessClient
 {
-    handle_prompt_end(i32 error, Optional<IPC::File> fd, Optional<String> chosen_file) =|
+    handle_prompt_end(i32 request_id, i32 error, Optional<IPC::File> fd, Optional<String> chosen_file) =|
 }

--- a/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
+++ b/Userland/Services/FileSystemAccessServer/FileSystemAccessServer.ipc
@@ -3,10 +3,10 @@
 
 endpoint FileSystemAccessServer
 {
-    request_file_read_only_approved(i32 window_server_client_id, i32 window_id, String path) =|
-    request_file(i32 window_server_client_id, i32 window_id, String path, Core::OpenMode requested_access) =|
-    prompt_open_file(i32 window_server_client_id, i32 window_id, String window_title, String path_to_view, Core::OpenMode requested_access) =|
-    prompt_save_file(i32 window_server_client_id, i32 window_id,String title, String ext, String path_to_view, Core::OpenMode requested_access) =|
+    request_file_read_only_approved(i32 request_id, i32 window_server_client_id, i32 window_id, String path) =|
+    request_file(i32 request_id, i32 window_server_client_id, i32 window_id, String path, Core::OpenMode requested_access) =|
+    prompt_open_file(i32 request_id, i32 window_server_client_id, i32 window_id, String window_title, String path_to_view, Core::OpenMode requested_access) =|
+    prompt_save_file(i32 request_id, i32 window_server_client_id, i32 window_id, String title, String ext, String path_to_view, Core::OpenMode requested_access) =|
 
     expose_window_server_client_id() => (i32 client_id)
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -13,6 +13,7 @@
 #include <LibWeb/CSS/PreferredColorScheme.h>
 #include <LibWeb/Cookie/ParsedCookie.h>
 #include <LibWeb/Forward.h>
+#include <LibWeb/Loader/FileRequest.h>
 #include <WebContent/Forward.h>
 #include <WebContent/WebContentClientEndpoint.h>
 #include <WebContent/WebContentConsoleClient.h>
@@ -30,6 +31,8 @@ public:
     virtual void die() override;
 
     void initialize_js_console(Badge<PageHost>);
+
+    void request_file(NonnullRefPtr<Web::FileRequest>&);
 
 private:
     explicit ConnectionFromClient(NonnullOwnPtr<Core::Stream::LocalSocket>);
@@ -64,6 +67,7 @@ private:
     virtual void set_preferred_color_scheme(Web::CSS::PreferredColorScheme const&) override;
     virtual void set_has_focus(bool) override;
     virtual void set_is_scripting_enabled(bool) override;
+    virtual void handle_file_return(i32 error, Optional<IPC::File> const& file, i32 request_id) override;
 
     virtual void js_console_input(String const&) override;
     virtual void run_javascript(String const&) override;
@@ -91,6 +95,9 @@ private:
     WeakPtr<JS::Interpreter> m_interpreter;
     OwnPtr<WebContentConsoleClient> m_console_client;
     JS::Handle<JS::GlobalObject> m_console_global_object;
+
+    HashMap<int, NonnullRefPtr<Web::FileRequest>> m_requested_files {};
+    int last_id { 0 };
 };
 
 }

--- a/Userland/Services/WebContent/PageHost.cpp
+++ b/Userland/Services/WebContent/PageHost.cpp
@@ -263,4 +263,9 @@ void PageHost::page_did_update_resource_count(i32 count_waiting)
     m_client.async_did_update_resource_count(count_waiting);
 }
 
+void PageHost::request_file(NonnullRefPtr<Web::FileRequest>& file_request)
+{
+    m_client.request_file(file_request);
+}
+
 }

--- a/Userland/Services/WebContent/PageHost.h
+++ b/Userland/Services/WebContent/PageHost.h
@@ -66,6 +66,7 @@ private:
     virtual String page_did_request_cookie(const URL&, Web::Cookie::Source) override;
     virtual void page_did_set_cookie(const URL&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override;
     virtual void page_did_update_resource_count(i32) override;
+    virtual void request_file(NonnullRefPtr<Web::FileRequest>&) override;
 
     explicit PageHost(ConnectionFromClient&);
 

--- a/Userland/Services/WebContent/WebContentClient.ipc
+++ b/Userland/Services/WebContent/WebContentClient.ipc
@@ -35,6 +35,7 @@ endpoint WebContentClient
     did_request_cookie(URL url, u8 source) => (String cookie)
     did_set_cookie(URL url, Web::Cookie::ParsedCookie cookie, u8 source) =|
     did_update_resource_count(i32 count_waiting) =|
+    did_request_file(String path, i32 request_id) =|
 
     did_output_js_console_message(i32 message_index) =|
     did_get_js_console_messages(i32 start_index, Vector<String> message_types, Vector<String> messages) =|

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -1,4 +1,5 @@
 #include <AK/URL.h>
+#include <LibIPC/File.h>
 #include <LibCore/AnonymousBuffer.h>
 #include <LibGfx/ShareableBitmap.h>
 #include <LibWeb/CSS/PreferredColorScheme.h>
@@ -51,4 +52,6 @@ endpoint WebContentServer
 
     get_local_storage_entries() => (OrderedHashMap<String,String> entries)
     get_session_storage_entries() => (OrderedHashMap<String,String> entries)
+
+    handle_file_return(i32 error, Optional<IPC::File> file, i32 request_id) =|
 }

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -176,9 +176,9 @@ endpoint WindowServer
 
     set_flash_flush(bool enabled) =|
 
-    set_window_parent_from_client(i32 client_id, i32 parent_id, i32 child_id) =|
+    set_window_parent_from_client(i32 client_id, i32 parent_id, i32 child_id) => ()
     get_window_rect_from_client(i32 client_id, i32 window_id) => (Gfx::IntRect rect)
-    add_window_stealing_for_client(i32 client_id, i32 window_id) =|
-    remove_window_stealing_for_client(i32 client_id, i32 window_id) =|
-    remove_window_stealing(i32 window_id) =|
+    add_window_stealing_for_client(i32 client_id, i32 window_id) => ()
+    remove_window_stealing_for_client(i32 client_id, i32 window_id) => ()
+    remove_window_stealing(i32 window_id) => ()
 }

--- a/Userland/Utilities/headless-browser.cpp
+++ b/Userland/Utilities/headless-browser.cpp
@@ -17,6 +17,7 @@
 #include <LibCore/IODevice.h>
 #include <LibCore/MemoryStream.h>
 #include <LibCore/Stream.h>
+#include <LibCore/System.h>
 #include <LibCore/Timer.h>
 #include <LibGemini/GeminiRequest.h>
 #include <LibGemini/GeminiResponse.h>
@@ -212,6 +213,12 @@ public:
 
     virtual void page_did_set_cookie(AK::URL const&, Web::Cookie::ParsedCookie const&, Web::Cookie::Source) override
     {
+    }
+
+    void request_file(NonnullRefPtr<Web::FileRequest>& request) override
+    {
+        auto const file = Core::System::open(request->path(), O_RDONLY);
+        request->on_file_request_finish(file);
     }
 
 private:


### PR DESCRIPTION
Few things that justify some design choices :
 - Loading code in ResourceLoader is implemented following the same design as for external request. It is now done in an asynchronous way.
 - FileSystemAccessServer was not able to answer concurrent requests, as there was only one promise slot. I extended it by using a HashMap and unique ids for each request.
 - FSAS was sometimes trying to set a parent to a window with a revoked permission. Making the operation synchronous resolve the issue.

Close #5259 