### PR TITLE
PixelPaint: Set title of default image to 'Untitled'

### DIFF
--- a/Userland/Applications/PixelPaint/MainWidget.cpp
+++ b/Userland/Applications/PixelPaint/MainWidget.cpp
@@ -796,6 +796,7 @@ void MainWidget::create_default_image()
     m_layer_list_widget->set_image(image);
 
     auto& editor = create_new_editor(*image);
+    editor.set_title("Untitled");
     editor.set_active_layer(bg_layer);
     editor.undo_stack().set_current_unmodified();
 }


### PR DESCRIPTION
This adds a title to the default image that is created on startup.