### PR TITLE
LibC+Kernel: Add various missing `#define`s

### DIFF
--- a/Kernel/API/POSIX/fcntl.h
+++ b/Kernel/API/POSIX/fcntl.h
@@ -39,6 +39,7 @@ extern "C" {
 #define O_NOFOLLOW (1 << 10)
 #define O_CLOEXEC (1 << 11)
 #define O_DIRECT (1 << 12)
+#define O_SYNC (1 << 13)
 
 #define F_RDLCK ((short)0)
 #define F_WRLCK ((short)1)

--- a/Kernel/API/POSIX/netinet/in.h
+++ b/Kernel/API/POSIX/netinet/in.h
@@ -20,6 +20,10 @@ typedef uint32_t in_addr_t;
 #define INADDR_LOOPBACK 0x7f000001
 #define INADDR_BROADCAST 0xffffffff
 
+#define IN_CLASSA_NET 0xff000000
+#define IN_CLASSB_NET 0xffff0000
+#define IN_CLASSC_NET 0xffffff00
+
 #define IN_LOOPBACKNET 127
 
 #define IP_TOS 1

--- a/Kernel/API/POSIX/sys/mman.h
+++ b/Kernel/API/POSIX/sys/mman.h
@@ -36,15 +36,16 @@ extern "C" {
 #define MADV_SET_VOLATILE 0x1
 #define MADV_SET_NONVOLATILE 0x2
 #define MADV_DONTNEED 0x3
+#define MADV_WILLNEED 0x4
+#define MADV_SEQUENTIAL 0x5
+#define MADV_RANDOM 0x6
 
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_madvise.html
 #define POSIX_MADV_NORMAL MADV_NORMAL
 #define POSIX_MADV_DONTNEED MADV_DONTNEED
-
-// Unsupported posix_madvise() advise:
-//  POSIX_MADV_SEQUENTIAL
-//  POSIX_MADV_RANDOM
-//  POSIX_MADV_WILLNEED
+#define POSIX_MADV_WILLNEED MADV_WILLNEED
+#define POSIX_MADV_SEQUENTIAL MADV_SEQUENTIAL
+#define POSIX_MADV_RANDOM MADV_RANDOM
 
 #define MS_SYNC 1
 #define MS_ASYNC 2

--- a/Kernel/API/POSIX/sys/socket.h
+++ b/Kernel/API/POSIX/sys/socket.h
@@ -48,6 +48,8 @@ extern "C" {
 #define IPPROTO_TCP 6
 #define IPPROTO_UDP 17
 #define IPPROTO_IPV6 41
+#define IPPROTO_ESP 50
+#define IPPROTO_AH 51
 #define IPPROTO_ICMPV6 58
 #define IPPROTO_RAW 255
 

--- a/Kernel/API/POSIX/sys/uio.h
+++ b/Kernel/API/POSIX/sys/uio.h
@@ -12,6 +12,9 @@
 extern "C" {
 #endif
 
+// Arbitrary pain threshold.
+#define IOV_MAX 1024
+
 struct iovec {
     void* iov_base;
     size_t iov_len;

--- a/Kernel/Syscalls/read.cpp
+++ b/Kernel/Syscalls/read.cpp
@@ -45,8 +45,7 @@ ErrorOr<FlatPtr> Process::sys$readv(int fd, Userspace<const struct iovec*> iov, 
     if (iov_count < 0)
         return EINVAL;
 
-    // Arbitrary pain threshold.
-    if (iov_count > (int)MiB)
+    if (iov_count > IOV_MAX)
         return EFAULT;
 
     u64 total_length = 0;

--- a/Kernel/Syscalls/write.cpp
+++ b/Kernel/Syscalls/write.cpp
@@ -18,8 +18,7 @@ ErrorOr<FlatPtr> Process::sys$writev(int fd, Userspace<const struct iovec*> iov,
     if (iov_count < 0)
         return EINVAL;
 
-    // Arbitrary pain threshold.
-    if (iov_count > (int)MiB)
+    if (iov_count > IOV_MAX)
         return EFAULT;
 
     u64 total_length = 0;

--- a/Userland/Libraries/LibC/netinet/in.h
+++ b/Userland/Libraries/LibC/netinet/in.h
@@ -58,4 +58,8 @@ static inline uint32_t ntohl(uint32_t value)
 #define IN6_IS_ADDR_LINKLOCAL(addr) \
     (((addr)->s6_addr[0] == 0xfe) && (((addr)->s6_addr[1] & 0xc0) == 0x80))
 
+// RFC# 2373 - 2.7 Multicast Addresses
+#define IN6_IS_ADDR_MULTICAST(addr) \
+    ((addr)->s6_addr[0] == 0xff)
+
 __END_DECLS


### PR DESCRIPTION
Some of these are required right now because we started to advertise POSIX features, and others are useful for a :reyakted: project of mine (and I didn't want to force two large rebuilds in _potentially_ quick succession, especially since they are likely also useful elsewhere).