### PR TITLE
LibWeb: Use Unicode data for CSS text-transform property

### DIFF
--- a/Userland/Libraries/LibWeb/CMakeLists.txt
+++ b/Userland/Libraries/LibWeb/CMakeLists.txt
@@ -380,6 +380,7 @@ set(GENERATED_SOURCES
 
 serenity_lib(LibWeb web)
 target_link_libraries(LibWeb LibCore LibJS LibMarkdown LibGemini LibGUI LibGfx LibTextCodec LibProtocol LibImageDecoderClient LibWasm LibXML)
+link_with_unicode_data(LibWeb)
 
 function(libweb_js_wrapper class)
     cmake_parse_arguments(PARSE_ARGV 1 LIBWEB_WRAPPER "ITERABLE" "" "")

--- a/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
+++ b/Userland/Libraries/LibWeb/Painting/PaintableBox.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibUnicode/CharacterTypes.h>
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/HTML/HTMLHtmlElement.h>
 #include <LibWeb/Layout/BlockContainer.h>
@@ -381,9 +382,9 @@ static void paint_text_fragment(PaintContext& context, Layout::TextNode const& t
         auto text = text_node.text_for_rendering();
         auto text_transform = text_node.computed_values().text_transform();
         if (text_transform == CSS::TextTransform::Uppercase)
-            text = text_node.text_for_rendering().to_uppercase();
+            text = Unicode::to_unicode_uppercase_full(text_node.text_for_rendering());
         if (text_transform == CSS::TextTransform::Lowercase)
-            text = text_node.text_for_rendering().to_lowercase();
+            text = Unicode::to_unicode_lowercase_full(text_node.text_for_rendering());
 
         Gfx::FloatPoint baseline_start { fragment_absolute_rect.x(), fragment_absolute_rect.y() + fragment.baseline() };
         Utf8View view { text.substring_view(fragment.start(), fragment.length()) };


### PR DESCRIPTION
Previously it was only transforming ASCII characters.

before | this pr
---|---
![](https://user-images.githubusercontent.com/16520278/166827122-b5c58c45-4994-4172-9f09-6e94f0b2b92c.png) | ![](https://user-images.githubusercontent.com/16520278/166827131-4e97bb16-75e4-45ce-867f-8379f29b0cc7.png)
