### PR TITLE
Base: Add note about optipng to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ Nobody is perfect, and sometimes we mess things up. That said, here are some goo
 * Squash your commits when making revisions after a patch review.
 * Add your personal copyright line to files when making substantive changes. (Optional but encouraged!)
 * Check the spelling of your code, comments and commit messages.
+* If you have images that go along with your code, run `optipng -strip all` on them to optimize and strip away useless metadata - this can reduce file size from multiple kilobytes to a couple hundred bytes.
 
 **Don't:**
 


### PR DESCRIPTION
A trick I learned from @linusg which is very useful and needs
to be a part of PRs where images are involved.