### PR TITLE
LibC: Hide `posix_memalign` by default

### DIFF
--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -130,6 +130,9 @@ set(SOURCES ${LIBC_SOURCES} ${AK_SOURCES} ${ELF_SOURCES} ${ASM_SOURCES})
 # Prevent GCC from removing null checks by marking the `FILE*` argument non-null
 set_source_files_properties(stdio.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin-fputc -fno-builtin-fputs -fno-builtin-fwrite")
 
+# Add in the `posix_memalign` symbol to avoid breaking existing binaries.
+set_source_files_properties(stdlib.cpp PROPERTIES COMPILE_FLAGS "-DSERENITY_LIBC_SHOW_POSIX_MEMALIGN")
+
 add_library(LibCStaticWithoutDeps STATIC ${SOURCES})
 target_link_libraries(LibCStaticWithoutDeps ssp LibTimeZone)
 add_dependencies(LibCStaticWithoutDeps LibM LibSystem LibUBSanitizer)

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -1336,6 +1336,7 @@ void _Exit(int status)
     _exit(status);
 }
 
+#ifdef SERENITY_LIBC_SHOW_POSIX_MEMALIGN
 // https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_memalign.html
 int posix_memalign(void** memptr, size_t alignment, size_t size)
 {
@@ -1344,3 +1345,4 @@ int posix_memalign(void** memptr, size_t alignment, size_t size)
     (void)size;
     TODO();
 }
+#endif

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -101,6 +101,11 @@ int posix_openpt(int flags);
 int grantpt(int fd);
 int unlockpt(int fd);
 
+// FIXME: Remove the ifdef once we have a working memalign implementation.
+// This is hidden by default until then because many applications prefer
+// `posix_memalign` over other implementations of aligned memory.
+#ifdef SERENITY_LIBC_SHOW_POSIX_MEMALIGN
 int posix_memalign(void**, size_t alignment, size_t size);
+#endif
 
 __END_DECLS


### PR DESCRIPTION
This should keep ports from preferring `posix_memalign` over other implementations of aligned memory.