### PR TITLE
Kernel+Terminal: Modified state and close warnings for background/foreground processes in Terminal + /proc/{pid}/children to make this easier 

### DIFF
--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -172,11 +172,14 @@ public:
     static ErrorOr<NonnullRefPtr<ProcFSProcessPropertyInode>> try_create_for_file_description_link(ProcFS const&, unsigned, ProcessID);
     static ErrorOr<NonnullRefPtr<ProcFSProcessPropertyInode>> try_create_for_thread_stack(ProcFS const&, ThreadID, ProcessID);
     static ErrorOr<NonnullRefPtr<ProcFSProcessPropertyInode>> try_create_for_pid_property(ProcFS const&, SegmentedProcFSIndex::MainProcessProperty, ProcessID);
+    static ErrorOr<NonnullRefPtr<ProcFSProcessPropertyInode>> try_create_for_child_process_link(ProcFS const&, ProcessID, ProcessID);
 
 private:
     ProcFSProcessPropertyInode(ProcFS const&, SegmentedProcFSIndex::MainProcessProperty, ProcessID);
     ProcFSProcessPropertyInode(ProcFS const&, ThreadID, ProcessID);
     ProcFSProcessPropertyInode(ProcFS const&, unsigned, ProcessID);
+    ProcFSProcessPropertyInode(ProcFS const&, ProcessID, ProcessID);
+
     // ^Inode
     virtual ErrorOr<void> attach(OpenFileDescription& description) override;
     virtual void did_seek(OpenFileDescription&, off_t) override;

--- a/Kernel/KBufferBuilder.h
+++ b/Kernel/KBufferBuilder.h
@@ -52,6 +52,11 @@ public:
         return m_buffer->bytes();
     }
 
+    size_t length() const
+    {
+        return m_size;
+    }
+
 private:
     explicit KBufferBuilder(NonnullOwnPtr<KBuffer>);
 

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -591,6 +591,9 @@ public:
     ErrorOr<size_t> procfs_get_file_description_link(unsigned fd, KBufferBuilder& builder) const;
     ErrorOr<void> traverse_file_descriptions_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)> callback) const;
     ErrorOr<NonnullRefPtr<Inode>> lookup_file_descriptions_directory(ProcFS const&, StringView name) const;
+    ErrorOr<NonnullRefPtr<Inode>> lookup_children_directory(ProcFS const&, StringView name) const;
+    ErrorOr<void> traverse_children_directory(FileSystemID, Function<ErrorOr<void>(FileSystem::DirectoryEntryView const&)> callback) const;
+    ErrorOr<size_t> procfs_get_child_proccess_link(ProcessID child_pid, KBufferBuilder& builder) const;
 
 private:
     inline PerformanceEventBuffer* current_perf_events_buffer()

--- a/Kernel/ProcessExposed.cpp
+++ b/Kernel/ProcessExposed.cpp
@@ -67,6 +67,11 @@ InodeIndex build_segmented_index_for_file_description(ProcessID pid, unsigned fd
     return build_segmented_index_with_unknown_property(pid, ProcessSubDirectory::OpenFileDescriptions, fd);
 }
 
+InodeIndex build_segmented_index_for_children(ProcessID pid, ProcessID child_pid)
+{
+    return build_segmented_index_with_unknown_property(pid, ProcessSubDirectory::Children, child_pid.value());
+}
+
 }
 
 static size_t s_allocate_global_inode_index()

--- a/Kernel/ProcessExposed.h
+++ b/Kernel/ProcessExposed.h
@@ -36,6 +36,7 @@ enum class ProcessSubDirectory {
     Reserved = 0,
     OpenFileDescriptions = 1,
     Stacks = 2,
+    Children = 3
 };
 
 void read_segments(u32& primary, ProcessSubDirectory& sub_directory, MainProcessProperty& property);
@@ -45,6 +46,8 @@ InodeIndex build_segmented_index_for_main_property(ProcessID, ProcessSubDirector
 InodeIndex build_segmented_index_for_main_property_in_pid_directory(ProcessID, MainProcessProperty property);
 InodeIndex build_segmented_index_for_thread_stack(ProcessID, ThreadID);
 InodeIndex build_segmented_index_for_file_description(ProcessID, unsigned);
+InodeIndex build_segmented_index_for_children(ProcessID, ProcessID);
+
 }
 
 class ProcFSComponentRegistry {

--- a/Kernel/ProcessProcFSTraits.cpp
+++ b/Kernel/ProcessProcFSTraits.cpp
@@ -55,6 +55,7 @@ ErrorOr<void> Process::ProcessProcFSTraits::traverse_as_directory(FileSystemID f
     TRY(callback({ "..", { fsid, ProcFSComponentRegistry::the().root_directory().component_index() }, DT_DIR }));
     TRY(callback({ "fd", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::OpenFileDescriptions) }, DT_DIR }));
     TRY(callback({ "stacks", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::Stacks) }, DT_DIR }));
+    TRY(callback({ "children", { fsid, SegmentedProcFSIndex::build_segmented_index_for_sub_directory(process->pid(), SegmentedProcFSIndex::ProcessSubDirectory::Children) }, DT_DIR }));
     TRY(callback({ "unveil", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::Unveil) }, DT_REG }));
     TRY(callback({ "pledge", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::Pledge) }, DT_REG }));
     TRY(callback({ "fds", { fsid, SegmentedProcFSIndex::build_segmented_index_for_main_property_in_pid_directory(process->pid(), SegmentedProcFSIndex::MainProcessProperty::OpenFileDescriptions) }, DT_DIR }));

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -26,6 +26,7 @@
 #include <LibGUI/ItemListModel.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
+#include <LibGUI/MessageBox.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
@@ -334,9 +335,42 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(file_menu->try_add_action(open_settings_action));
     TRY(file_menu->try_add_separator());
-    TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([](auto&) {
+
+    auto tty_has_foreground_process = [&] {
+        pid_t fg_pid = tcgetpgrp(ptm_fd);
+        return fg_pid != -1 && fg_pid != shell_pid;
+    };
+
+    auto shell_child_process_count = [&] {
+        Core::DirIterator iterator(String::formatted("/proc/{}/children", shell_pid), Core::DirIterator::Flags::SkipParentAndBaseDir);
+        int background_process_count = 0;
+        while (iterator.has_next()) {
+            ++background_process_count;
+            (void)iterator.next_path();
+        }
+        return background_process_count;
+    };
+
+    auto check_terminal_quit = [&]() -> int {
+        Optional<String> close_message;
+        if (tty_has_foreground_process()) {
+            close_message = "There is still a process running in this terminal. Closing the terminal will kill it.";
+        } else {
+            auto child_process_count = shell_child_process_count();
+            if (child_process_count > 1)
+                close_message = String::formatted("There are {} background processes running in this terminal. Closing the terminal may kill them.", child_process_count);
+            else if (child_process_count == 1)
+                close_message = "There is a background process running in this terminal. Closing the terminal may kill it.";
+        }
+        if (close_message.has_value())
+            return GUI::MessageBox::show(window, *close_message, "Close this terminal?", GUI::MessageBox::Type::Warning, GUI::MessageBox::InputType::OKCancel);
+        return GUI::MessageBox::ExecOK;
+    };
+
+    TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) {
         dbgln("Terminal: Quit menu activated!");
-        GUI::Application::the()->quit();
+        if (check_terminal_quit() == GUI::MessageBox::ExecOK)
+            GUI::Application::the()->quit();
     })));
 
     auto edit_menu = TRY(window->try_add_menu("&Edit"));
@@ -365,8 +399,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         find_window->close();
     };
 
+    window->on_close_request = [&]() -> GUI::Window::CloseRequestDecision {
+        if (check_terminal_quit() == GUI::MessageBox::ExecOK)
+            return GUI::Window::CloseRequestDecision::Close;
+        return GUI::Window::CloseRequestDecision::StayOpen;
+    };
+
     TRY(Core::System::unveil("/res", "r"));
     TRY(Core::System::unveil("/bin", "r"));
+    TRY(Core::System::unveil("/proc", "r"));
     TRY(Core::System::unveil("/bin/Terminal", "x"));
     TRY(Core::System::unveil("/bin/TerminalSettings", "x"));
     TRY(Core::System::unveil("/bin/utmpupdate", "x"));
@@ -375,7 +416,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(Core::System::unveil("/tmp/portal/config", "rw"));
     TRY(Core::System::unveil(nullptr, nullptr));
 
+    auto modified_state_check_timer = Core::Timer::create_repeating(500, [&] {
+        window->set_modified(tty_has_foreground_process() || shell_child_process_count() > 0);
+    });
+
     window->show();
+    modified_state_check_timer->start();
     int result = app->exec();
     dbgln("Exiting terminal, updating utmp");
     utmp_update(ptsname, 0, false);

--- a/Userland/Applications/TerminalSettings/TerminalSettingsMain.gml
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsMain.gml
@@ -61,4 +61,17 @@
             orientation: "Horizontal"
         }
     }
+
+    @GUI::GroupBox {
+        title: "Exit Behaviour"
+        shrink_to_fit: true
+        layout: @GUI::VerticalBoxLayout {
+            margins: [16, 8, 8]
+        }
+
+        @GUI::CheckBox {
+            name: "terminal_confirm_close"
+            text: "Ask before closing if processes are running in the terminal"
+        }
+    }
 }

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
@@ -83,6 +83,15 @@ TerminalSettingsMainWidget::TerminalSettingsMainWidget()
         Config::write_bool("Terminal", "Terminal", "ShowScrollBar", show_scrollbar);
     };
     show_scrollbar_checkbox.set_checked(m_show_scrollbar);
+
+    m_confirm_close = Config::read_bool("Terminal", "Terminal", "ConfirmClose", true);
+    m_orignal_confirm_close = m_confirm_close;
+    auto& confirm_close_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("terminal_confirm_close");
+    confirm_close_checkbox.on_checked = [&](bool confirm_close) {
+        m_confirm_close = confirm_close;
+        Config::write_bool("Terminal", "Terminal", "ConfirmClose", confirm_close);
+    };
+    confirm_close_checkbox.set_checked(m_confirm_close);
 }
 
 TerminalSettingsViewWidget::TerminalSettingsViewWidget()
@@ -190,12 +199,14 @@ void TerminalSettingsMainWidget::apply_settings()
     m_original_max_history_size = m_max_history_size;
     m_orignal_show_scrollbar = m_show_scrollbar;
     m_original_bell_mode = m_bell_mode;
+    m_orignal_confirm_close = m_confirm_close;
     write_back_settings();
 }
 void TerminalSettingsMainWidget::write_back_settings() const
 {
     Config::write_i32("Terminal", "Terminal", "MaxHistorySize", static_cast<i32>(m_original_max_history_size));
     Config::write_bool("Terminal", "Terminal", "ShowScrollBar", m_orignal_show_scrollbar);
+    Config::write_bool("Terminal", "Terminal", "ConfirmClose", m_orignal_confirm_close);
     Config::write_string("Terminal", "Window", "Bell", stringify_bell(m_original_bell_mode));
 }
 

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
@@ -29,10 +29,12 @@ private:
     VT::TerminalWidget::BellMode m_bell_mode = VT::TerminalWidget::BellMode::Disabled;
     size_t m_max_history_size;
     bool m_show_scrollbar { true };
+    bool m_confirm_close { true };
 
     VT::TerminalWidget::BellMode m_original_bell_mode;
     size_t m_original_max_history_size;
     bool m_orignal_show_scrollbar { true };
+    bool m_orignal_confirm_close { true };
 };
 
 class TerminalSettingsViewWidget final : public GUI::SettingsWindow::Tab {


### PR DESCRIPTION
This is my attempt at solving #13751, and implementing a terminal close warning (similar to the one in gnome terminal, & others).

Demo:

https://user-images.githubusercontent.com/11597044/166516311-27c2ca7c-7d7a-4e94-a284-bb705df08127.mp4



When there are process(es) running in the terminal the "close modified" state will be set, and on attempting to close the terminal you'll get a warning if there's a foreground process or background processes running. (The warning indicates that it's due to background processes if no foreground process is running).

This now also adds `/proc/{pid}/children` to make it easier to lookup the child processes of a process. 





