### PR TITLE
LibGL+LibGPU+LibSoftGPU: Implement and expose glClipPlane

### DIFF
--- a/Userland/Libraries/LibGL/CMakeLists.txt
+++ b/Userland/Libraries/LibGL/CMakeLists.txt
@@ -1,10 +1,11 @@
 set(SOURCES
+    ClipPlanes.cpp
     ContextParameter.cpp
     GLAPI.cpp
     GLContext.cpp
-    Matrix.cpp
     Lighting.cpp
     Lists.cpp
+    Matrix.cpp
     Stencil.cpp
     Tex/NameAllocator.cpp
     Tex/Texture2D.cpp

--- a/Userland/Libraries/LibGL/ClipPlanes.cpp
+++ b/Userland/Libraries/LibGL/ClipPlanes.cpp
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2021, Jesse Buhagiar <jooster669@gmail.com>
+ * Copyright (c) 2021, Stephan Unverwerth <s.unverwerth@serenityos.org>
+ * Copyright (c) 2022, Jelle Raaijmakers <jelle@gmta.nl>
+ * Copyright (c) 2022, Ryan Bethke <ryanbethke11@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Debug.h>
+#include <LibGL/GLContext.h>
+
+namespace GL {
+
+void GLContext::gl_clip_plane(GLenum plane, GLdouble const* equation)
+{
+    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_clip_plane, plane, equation);
+
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+    RETURN_WITH_ERROR_IF((plane < GL_CLIP_PLANE0) || (plane > GL_CLIP_PLANE5), GL_INVALID_ENUM);
+
+    auto plane_idx = static_cast<size_t>(plane) - GL_CLIP_PLANE0;
+
+    auto eqn = FloatVector4(equation[0], equation[1], equation[2], equation[3]);
+    m_clip_plane_attributes.eye_clip_plane[plane_idx] = m_model_view_matrix * eqn;
+    m_clip_planes_dirty = true;
+}
+
+void GLContext::gl_get_clip_plane(GLenum plane, GLdouble* equation)
+{
+    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
+    RETURN_WITH_ERROR_IF((plane < GL_CLIP_PLANE0) || (plane > GL_CLIP_PLANE5), GL_INVALID_ENUM);
+
+    auto plane_idx = static_cast<size_t>(plane) - GL_CLIP_PLANE0;
+    equation[0] = static_cast<GLdouble>(m_clip_plane_attributes.eye_clip_plane[plane_idx][0]);
+    equation[1] = static_cast<GLdouble>(m_clip_plane_attributes.eye_clip_plane[plane_idx][1]);
+    equation[2] = static_cast<GLdouble>(m_clip_plane_attributes.eye_clip_plane[plane_idx][2]);
+    equation[3] = static_cast<GLdouble>(m_clip_plane_attributes.eye_clip_plane[plane_idx][3]);
+}
+
+void GLContext::sync_clip_planes()
+{
+    if (!m_clip_planes_dirty)
+        return;
+    m_clip_planes_dirty = false;
+
+    // TODO: Replace magic number 6 with device-dependent constant
+    Vector<FloatVector4, 6> user_clip_planes;
+    for (size_t plane_idx = 0; plane_idx < 6; ++plane_idx) {
+        if ((m_clip_plane_attributes.enabled & (1 << plane_idx)) != 0u) {
+            user_clip_planes.append(m_clip_plane_attributes.eye_clip_plane[plane_idx]);
+        }
+    }
+    m_rasterizer->set_clip_planes(user_clip_planes);
+}
+
+}

--- a/Userland/Libraries/LibGL/ContextParameter.cpp
+++ b/Userland/Libraries/LibGL/ContextParameter.cpp
@@ -52,6 +52,8 @@ Optional<ContextParameter> GLContext::get_context_parameter(GLenum name)
         return ContextParameter { .type = GL_BOOL, .is_capability = true, .value = { .boolean_value = m_lighting_enabled } };
     case GL_LINE_SMOOTH:
         return ContextParameter { .type = GL_BOOL, .is_capability = true, .value = { .boolean_value = m_line_smooth } };
+    case GL_MAX_CLIP_PLANES:
+        return ContextParameter { .type = GL_INT, .value = { .integer_value = static_cast<GLint>(m_device_info.max_clip_planes) } };
     case GL_MAX_LIGHTS:
         return ContextParameter { .type = GL_INT, .value = { .integer_value = static_cast<GLint>(m_device_info.num_lights) } };
     case GL_MAX_MODELVIEW_STACK_DEPTH:
@@ -169,6 +171,17 @@ void GLContext::gl_disable(GLenum capability)
     bool update_rasterizer_options = false;
 
     switch (capability) {
+    case GL_CLIP_PLANE0:
+    case GL_CLIP_PLANE1:
+    case GL_CLIP_PLANE2:
+    case GL_CLIP_PLANE3:
+    case GL_CLIP_PLANE4:
+    case GL_CLIP_PLANE5: {
+        auto plane_idx = static_cast<size_t>(capability) - GL_CLIP_PLANE0;
+        m_clip_plane_attributes.enabled &= ~(1 << plane_idx);
+        m_clip_planes_dirty = true;
+        break;
+    }
     case GL_COLOR_MATERIAL:
         m_color_material_enabled = false;
         break;
@@ -308,6 +321,17 @@ void GLContext::gl_enable(GLenum capability)
     bool update_rasterizer_options = false;
 
     switch (capability) {
+    case GL_CLIP_PLANE0:
+    case GL_CLIP_PLANE1:
+    case GL_CLIP_PLANE2:
+    case GL_CLIP_PLANE3:
+    case GL_CLIP_PLANE4:
+    case GL_CLIP_PLANE5: {
+        auto plane_idx = static_cast<size_t>(capability) - GL_CLIP_PLANE0;
+        m_clip_plane_attributes.enabled |= (1 << plane_idx);
+        m_clip_planes_dirty = true;
+        break;
+    }
     case GL_COLOR_MATERIAL:
         m_color_material_enabled = true;
         break;

--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -481,6 +481,7 @@ extern "C" {
 #define GL_ADD 0x0104
 
 // User clipping planes
+#define GL_MAX_CLIP_PLANES 0x0D32
 #define GL_CLIP_PLANE0 0x3000
 #define GL_CLIP_PLANE1 0x3001
 #define GL_CLIP_PLANE2 0x3002
@@ -682,6 +683,7 @@ GLAPI void glRecti(GLint x1, GLint y1, GLint x2, GLint y2);
 GLAPI void glGetTexLevelParameteriv(GLenum target, GLint level, GLenum pname, GLint* params);
 GLAPI void glPointSize(GLfloat size);
 GLAPI void glClipPlane(GLenum plane, GLdouble const* equation);
+GLAPI void glGetClipPlane(GLenum plane, GLdouble* equation);
 GLAPI void glArrayElement(GLint i);
 GLAPI void glCopyTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height);
 

--- a/Userland/Libraries/LibGL/GLAPI.cpp
+++ b/Userland/Libraries/LibGL/GLAPI.cpp
@@ -399,6 +399,11 @@ void glGetBooleanv(GLenum pname, GLboolean* data)
     g_gl_context->gl_get_booleanv(pname, data);
 }
 
+void glGetClipPlane(GLenum plane, GLdouble* equation)
+{
+    g_gl_context->gl_get_clip_plane(plane, equation);
+}
+
 void glGetDoublev(GLenum pname, GLdouble* params)
 {
     g_gl_context->gl_get_doublev(pname, params);

--- a/Userland/Libraries/LibGL/GLContext.cpp
+++ b/Userland/Libraries/LibGL/GLContext.cpp
@@ -794,16 +794,6 @@ void GLContext::gl_depth_mask(GLboolean flag)
     m_rasterizer->set_options(options);
 }
 
-void GLContext::gl_clip_plane(GLenum plane, [[maybe_unused]] GLdouble const* equation)
-{
-    APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_clip_plane, plane, equation);
-
-    RETURN_WITH_ERROR_IF(m_in_draw_state, GL_INVALID_OPERATION);
-    RETURN_WITH_ERROR_IF((plane < GL_CLIP_PLANE0) || (plane > GL_CLIP_PLANE5), GL_INVALID_ENUM);
-
-    dbgln_if(GL_DEBUG, "GLContext FIXME: implement gl_clip_plane() (equation = [{} {} {} {}])", equation[0], equation[1], equation[2], equation[3]);
-}
-
 void GLContext::gl_draw_pixels(GLsizei width, GLsizei height, GLenum format, GLenum type, void const* data)
 {
     APPEND_TO_CALL_LIST_AND_RETURN_IF_NEEDED(gl_draw_pixels, width, height, format, type, data);
@@ -1215,6 +1205,7 @@ void GLContext::sync_device_config()
     sync_device_texcoord_config();
     sync_light_state();
     sync_stencil_configuration();
+    sync_clip_planes();
 }
 
 void GLContext::build_extension_string()

--- a/Userland/Libraries/LibGL/GLContext.h
+++ b/Userland/Libraries/LibGL/GLContext.h
@@ -197,6 +197,7 @@ public:
     void gl_get_light(GLenum light, GLenum pname, void* params, GLenum type);
     void gl_get_material(GLenum face, GLenum pname, void* params, GLenum type);
     void gl_clip_plane(GLenum plane, GLdouble const* equation);
+    void gl_get_clip_plane(GLenum plane, GLdouble* equation);
     void gl_array_element(GLint i);
     void gl_copy_tex_sub_image_2d(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint x, GLint y, GLsizei width, GLsizei height);
     void gl_point_size(GLfloat size);
@@ -207,6 +208,7 @@ private:
     void sync_device_texcoord_config();
     void sync_light_state();
     void sync_stencil_configuration();
+    void sync_clip_planes();
 
     void build_extension_string();
 
@@ -306,6 +308,13 @@ private:
 
     GLenum m_current_read_buffer = GL_BACK;
     GLenum m_current_draw_buffer = GL_BACK;
+
+    // User-defined clip planes
+    struct ClipPlaneAttributes {
+        Array<FloatVector4, 6> eye_clip_plane; // TODO: Change to use device-defined constant
+        GLuint enabled { 0 };
+    } m_clip_plane_attributes;
+    bool m_clip_planes_dirty { true };
 
     // Client side arrays
     bool m_client_side_vertex_array_enabled { false };

--- a/Userland/Libraries/LibGPU/Device.h
+++ b/Userland/Libraries/LibGPU/Device.h
@@ -61,6 +61,7 @@ public:
     virtual void set_light_state(unsigned, Light const&) = 0;
     virtual void set_material_state(Face, Material const&) = 0;
     virtual void set_stencil_configuration(Face, StencilConfiguration const&) = 0;
+    virtual void set_clip_planes(Vector<FloatVector4> const&) = 0;
 
     virtual RasterPosition raster_position() const = 0;
     virtual void set_raster_position(RasterPosition const& raster_position) = 0;

--- a/Userland/Libraries/LibGPU/DeviceInfo.h
+++ b/Userland/Libraries/LibGPU/DeviceInfo.h
@@ -15,6 +15,7 @@ struct DeviceInfo final {
     String device_name;
     unsigned num_texture_units;
     unsigned num_lights;
+    unsigned max_clip_planes;
     u8 stencil_bits;
     bool supports_npot_textures;
 };

--- a/Userland/Libraries/LibSoftGPU/Clipper.h
+++ b/Userland/Libraries/LibSoftGPU/Clipper.h
@@ -16,12 +16,13 @@ namespace SoftGPU {
 class Clipper final {
 public:
     enum class ClipPlane : u8 {
-        LEFT = 0,
-        RIGHT,
-        TOP,
-        BOTTOM,
-        NEAR,
-        FAR
+        Left = 0,
+        Right,
+        Top,
+        Bottom,
+        Near,
+        Far,
+        User, // Within view space
     };
 
     Clipper() = default;
@@ -29,6 +30,7 @@ public:
     void clip_points_against_frustum(Vector<GPU::Vertex>& vertices);
     bool clip_line_against_frustum(GPU::Vertex& from, GPU::Vertex& to);
     void clip_triangle_against_frustum(Vector<GPU::Vertex>& input_vecs);
+    void clip_triangle_against_user_defined(Vector<GPU::Vertex>& input_verts, Vector<FloatVector4>& user_planes);
 
 private:
     Vector<GPU::Vertex> m_vertex_buffer;

--- a/Userland/Libraries/LibSoftGPU/Config.h
+++ b/Userland/Libraries/LibSoftGPU/Config.h
@@ -19,6 +19,7 @@ namespace SoftGPU {
 static constexpr bool ENABLE_STATISTICS_OVERLAY = false;
 static constexpr int MILLISECONDS_PER_STATISTICS_PERIOD = 500;
 static constexpr int NUM_LIGHTS = 8;
+static constexpr int MAX_CLIP_PLANES = 6;
 static constexpr int SUBPIXEL_BITS = 6;
 
 // See: https://www.khronos.org/opengl/wiki/Common_Mistakes#Texture_edge_color_problem

--- a/Userland/Libraries/LibSoftGPU/Device.cpp
+++ b/Userland/Libraries/LibSoftGPU/Device.cpp
@@ -793,6 +793,7 @@ GPU::DeviceInfo Device::info() const
         .device_name = "SoftGPU",
         .num_texture_units = GPU::NUM_SAMPLERS,
         .num_lights = NUM_LIGHTS,
+        .max_clip_planes = MAX_CLIP_PLANES,
         .stencil_bits = sizeof(GPU::StencilType) * 8,
         .supports_npot_textures = true,
     };
@@ -1142,6 +1143,9 @@ void Device::draw_primitives(GPU::PrimitiveType primitive_type, FloatMatrix4x4 c
         m_clipped_vertices.append(triangle.vertices[2]);
         m_clipper.clip_triangle_against_frustum(m_clipped_vertices);
 
+        if (m_clip_planes.size() > 0)
+            m_clipper.clip_triangle_against_user_defined(m_clipped_vertices, m_clip_planes);
+
         if (m_clipped_vertices.size() < 3)
             continue;
 
@@ -1462,6 +1466,11 @@ void Device::set_stencil_configuration(GPU::Face face, GPU::StencilConfiguration
 void Device::set_raster_position(GPU::RasterPosition const& raster_position)
 {
     m_raster_position = raster_position;
+}
+
+void Device::set_clip_planes(Vector<FloatVector4> const& clip_planes)
+{
+    m_clip_planes = clip_planes;
 }
 
 void Device::set_raster_position(FloatVector4 const& position, FloatMatrix4x4 const& model_view_transform, FloatMatrix4x4 const& projection_transform)

--- a/Userland/Libraries/LibSoftGPU/Device.h
+++ b/Userland/Libraries/LibSoftGPU/Device.h
@@ -68,6 +68,7 @@ public:
     virtual void set_light_state(unsigned, GPU::Light const&) override;
     virtual void set_material_state(GPU::Face, GPU::Material const&) override;
     virtual void set_stencil_configuration(GPU::Face, GPU::StencilConfiguration const&) override;
+    virtual void set_clip_planes(Vector<FloatVector4> const&) override;
 
     virtual GPU::RasterPosition raster_position() const override { return m_raster_position; }
     virtual void set_raster_position(GPU::RasterPosition const& raster_position) override;
@@ -107,6 +108,7 @@ private:
     Array<GPU::Light, NUM_LIGHTS> m_lights;
     Array<GPU::Material, 2u> m_materials;
     GPU::RasterPosition m_raster_position;
+    Vector<FloatVector4> m_clip_planes;
     Array<GPU::StencilConfiguration, 2u> m_stencil_configuration;
 };
 


### PR DESCRIPTION
This commit implements glClipPlane and its supporting calls, backed
by new support for user-defined clip planes in the software GPU clipper.

This fixes some visual bugs seen in the Quake III port, in which mirrors
would only reflect correctly from close distances.