### PR TITLE
Browser: Set an icon for the ‘Edit Bookmark’ Dialog

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -33,6 +33,7 @@ public:
     {
         auto editor = BookmarkEditor::construct(parent_window, title, url);
         editor->set_title("Edit Bookmark");
+        editor->set_icon(g_icon_bag.bookmark_filled);
 
         if (editor->exec() == Dialog::ExecOK) {
             return Vector<JsonValue> { editor->title(), editor->url() };


### PR DESCRIPTION
current master | this change
---|---
![](https://user-images.githubusercontent.com/16520278/166827583-1b0eb006-ff81-48ff-a131-cf9a684b030e.png) | ![](https://user-images.githubusercontent.com/16520278/166824885-a30c91ec-e933-4e17-82bb-f84cb9c94384.png)
