### PR TITLE
AK: Use concepts for AK::Atomic and implement atomic_{add,sub,and,or,xor}_fetch

### DIFF
--- a/AK/Atomic.h
+++ b/AK/Atomic.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, César Torres <shortanemoia@protonmail.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -12,136 +13,167 @@
 
 namespace AK {
 
-static inline void atomic_signal_fence(MemoryOrder order) noexcept
+static ALWAYS_INLINE void atomic_signal_fence(MemoryOrder order) noexcept
 {
     return __atomic_signal_fence(order);
 }
 
-static inline void atomic_thread_fence(MemoryOrder order) noexcept
+static ALWAYS_INLINE void atomic_thread_fence(MemoryOrder order) noexcept
 {
     return __atomic_thread_fence(order);
 }
 
-static inline void full_memory_barrier() noexcept
+static ALWAYS_INLINE void full_memory_barrier() noexcept
 {
     atomic_signal_fence(AK::MemoryOrder::memory_order_acq_rel);
     atomic_thread_fence(AK::MemoryOrder::memory_order_acq_rel);
 }
 
-template<typename T>
-static inline T atomic_exchange(volatile T* var, T desired, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_exchange(T volatile* var, T desired, MemoryOrder order = memory_order_seq_cst) noexcept
 {
-    return __atomic_exchange_n(var, desired, order);
+    // FIXME: Remove once clang allows implements atomic enums
+#ifdef __clang__
+    if constexpr (Enum<T>)
+        return (T)__atomic_exchange_n(reinterpret_cast<UnderlyingType<T>*>(const_cast<T*>(var)), static_cast<UnderlyingType<T>>(desired), order);
+    else
+#endif
+        return __atomic_exchange_n(var, desired, order);
 }
 
-template<typename T, typename V = RemoveVolatile<T>>
-static inline V* atomic_exchange(volatile T** var, V* desired, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T, typename V = RemoveVolatile<T>>
+[[nodiscard]] static ALWAYS_INLINE bool atomic_compare_exchange_strong(T volatile* var, V& expected, V desired, MemoryOrder order = memory_order_seq_cst) noexcept
 {
-    return __atomic_exchange_n(var, desired, order);
+    // FIXME: Remove once clang allows implements atomic enums
+#ifdef __clang__
+    if constexpr (Enum<T>) {
+        if (order == memory_order_acq_rel || order == memory_order_release)
+            return __atomic_compare_exchange_n(const_cast<UnderlyingType<V>*>((UnderlyingType<V> const volatile*)var), reinterpret_cast<UnderlyingType<V>*>(&expected), static_cast<UnderlyingType<T>>(desired), false, memory_order_release, memory_order_acquire);
+        return __atomic_compare_exchange_n(const_cast<UnderlyingType<V>*>((UnderlyingType<V> const volatile*)var), reinterpret_cast<UnderlyingType<V>*>(&expected), static_cast<UnderlyingType<T>>(desired), false, order, order);
+    } else
+#endif
+    {
+        if (order == memory_order_acq_rel || order == memory_order_release)
+            return __atomic_compare_exchange_n(const_cast<V*>(var), &expected, desired, false, memory_order_release, memory_order_acquire);
+        return __atomic_compare_exchange_n(const_cast<V*>(var), &expected, desired, false, order, order);
+    }
 }
 
-template<typename T, typename V = RemoveVolatile<T>>
-static inline V* atomic_exchange(volatile T** var, std::nullptr_t, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T, typename V = RemoveVolatile<T>>
+[[nodiscard]] static ALWAYS_INLINE bool atomic_compare_exchange_strong(T volatile* var, V& expected, std::nullptr_t, MemoryOrder order = memory_order_seq_cst) noexcept
 {
-    return __atomic_exchange_n(const_cast<V**>(var), nullptr, order);
+    // FIXME: Remove once clang allows implements atomic enums
+#ifdef __clang__
+    if constexpr (Enum<T>) {
+        if (order == memory_order_acq_rel || order == memory_order_release)
+            return __atomic_compare_exchange_n(reinterpret_cast<UnderlyingType<V> const*>(const_cast<V*>(var)), reinterpret_cast<UnderlyingType<V>*>(&expected), nullptr, false, memory_order_release, memory_order_acquire);
+        return __atomic_compare_exchange_n(reinterpret_cast<UnderlyingType<V> const*>(const_cast<V*>(var)), reinterpret_cast<UnderlyingType<V>*>(&expected), nullptr, false, order, order);
+    } else
+#endif
+    {
+        if (order == memory_order_acq_rel || order == memory_order_release)
+            return __atomic_compare_exchange_n(const_cast<V*>(var), &expected, nullptr, false, memory_order_release, memory_order_acquire);
+        return __atomic_compare_exchange_n(const_cast<V*>(var), &expected, nullptr, false, order, order);
+    }
 }
 
-template<typename T>
-[[nodiscard]] static inline bool atomic_compare_exchange_strong(volatile T* var, T& expected, T desired, MemoryOrder order = memory_order_seq_cst) noexcept
-{
-    if (order == memory_order_acq_rel || order == memory_order_release)
-        return __atomic_compare_exchange_n(var, &expected, desired, false, memory_order_release, memory_order_acquire);
-    return __atomic_compare_exchange_n(var, &expected, desired, false, order, order);
-}
-
-template<typename T, typename V = RemoveVolatile<T>>
-[[nodiscard]] static inline bool atomic_compare_exchange_strong(volatile T** var, V*& expected, V* desired, MemoryOrder order = memory_order_seq_cst) noexcept
-{
-    if (order == memory_order_acq_rel || order == memory_order_release)
-        return __atomic_compare_exchange_n(var, &expected, desired, false, memory_order_release, memory_order_acquire);
-    return __atomic_compare_exchange_n(var, &expected, desired, false, order, order);
-}
-
-template<typename T, typename V = RemoveVolatile<T>>
-[[nodiscard]] static inline bool atomic_compare_exchange_strong(volatile T** var, V*& expected, std::nullptr_t, MemoryOrder order = memory_order_seq_cst) noexcept
-{
-    if (order == memory_order_acq_rel || order == memory_order_release)
-        return __atomic_compare_exchange_n(const_cast<V**>(var), &expected, nullptr, false, memory_order_release, memory_order_acquire);
-    return __atomic_compare_exchange_n(const_cast<V**>(var), &expected, nullptr, false, order, order);
-}
-
-template<typename T>
-static inline T atomic_fetch_add(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_fetch_add(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
     return __atomic_fetch_add(var, val, order);
 }
 
-template<typename T>
-static inline T atomic_fetch_sub(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_fetch_sub(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
     return __atomic_fetch_sub(var, val, order);
 }
 
-template<typename T>
-static inline T atomic_fetch_and(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_fetch_and(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
     return __atomic_fetch_and(var, val, order);
 }
 
-template<typename T>
-static inline T atomic_fetch_or(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_fetch_or(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
     return __atomic_fetch_or(var, val, order);
 }
 
-template<typename T>
-static inline T atomic_fetch_xor(volatile T* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_fetch_xor(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
     return __atomic_fetch_xor(var, val, order);
 }
 
-template<typename T>
-static inline T atomic_load(volatile T* var, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_add_fetch(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
-    return __atomic_load_n(var, order);
+    return __atomic_add_fetch(var, val, order);
 }
 
-template<typename T, typename V = RemoveVolatile<T>>
-static inline V* atomic_load(volatile T** var, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_sub_fetch(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
-    return __atomic_load_n(const_cast<V**>(var), order);
+    return __atomic_sub_fetch(var, val, order);
 }
 
-template<typename T>
-static inline void atomic_store(volatile T* var, T desired, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_and_fetch(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
-    __atomic_store_n(var, desired, order);
+    return __atomic_and_fetch(var, val, order);
 }
 
-template<typename T, typename V = RemoveVolatile<T>>
-static inline void atomic_store(volatile T** var, V* desired, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_or_fetch(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
-    __atomic_store_n(var, desired, order);
+    return __atomic_or_fetch(var, val, order);
 }
 
-template<typename T, typename V = RemoveVolatile<T>>
-static inline void atomic_store(volatile T** var, std::nullptr_t, MemoryOrder order = memory_order_seq_cst) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_xor_fetch(T volatile* var, T val, MemoryOrder order = memory_order_seq_cst) noexcept
 {
-    __atomic_store_n(const_cast<V**>(var), nullptr, order);
+    return __atomic_xor_fetch(var, val, order);
 }
 
-template<typename T>
-static inline bool atomic_is_lock_free(volatile T* ptr = nullptr) noexcept
+template<IntegralLike T>
+static ALWAYS_INLINE T atomic_load(T volatile* var, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    // FIXME: Remove once clang allows implements atomic enums
+#ifdef __clang__
+    if constexpr (Enum<T>)
+        return (T)__atomic_load_n(reinterpret_cast<UnderlyingType<T> const*>(const_cast<T*>(var)), order);
+    else
+#endif
+        return __atomic_load_n(const_cast<T*>(var), order);
+}
+
+template<IntegralLike T, typename V = RemoveVolatile<T>>
+static ALWAYS_INLINE void atomic_store(T volatile* var, V desired, MemoryOrder order = memory_order_seq_cst) noexcept
+{
+    // FIXME: Remove once clang allows implements atomic enums
+#ifdef __clang__
+    if constexpr (Enum<T>)
+        __atomic_store_n(reinterpret_cast<UnderlyingType<V> const*>(const_cast<V*>(var)), desired, order);
+    else
+#endif
+        __atomic_store_n(const_cast<V*>(var), desired, order);
+}
+
+template<IntegralLike T>
+static ALWAYS_INLINE bool atomic_is_lock_free(T volatile* ptr = nullptr) noexcept
 {
     return __atomic_is_lock_free(sizeof(T), ptr);
 }
 
-template<typename T, MemoryOrder DefaultMemoryOrder = AK::MemoryOrder::memory_order_seq_cst>
+template<IntegralLike T, AK::MemoryOrder DefaultMemoryOrder = memory_order_seq_cst>
 class Atomic {
-    // FIXME: This should work through concepts/requires clauses, but according to the compiler,
-    //        "IsIntegral is not more specialized than IsFundamental".
-    //        Additionally, Enums are not fundamental types except that they behave like them in every observable way.
-    static_assert(IsFundamental<T> | IsEnum<T>, "Atomic doesn't support non-primitive types, because it relies on compiler intrinsics. If you put non-primitives into it, you'll get linker errors like \"undefined reference to __atomic_store\".");
+    static_assert(DependentFalse<Atomic>, "Do not use the general definition of AK::Atomic<>.");
+};
+
+template<Enum T, MemoryOrder DefaultMemoryOrder>
+class Atomic<T, DefaultMemoryOrder> {
     T m_value { 0 };
 
 public:
@@ -156,26 +188,19 @@ public:
     {
     }
 
-    volatile T* ptr() noexcept
+    ALWAYS_INLINE T volatile* ptr() noexcept
     {
         return &m_value;
     }
 
-    T exchange(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    ALWAYS_INLINE T exchange(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        // We use this hack to prevent unnecessary initialization, even if T has a default constructor.
-        // NOTE: Will need to investigate if it pessimizes the generated assembly.
-        alignas(T) u8 buffer[sizeof(T)];
-        T* ret = reinterpret_cast<T*>(buffer);
-        __atomic_exchange(&m_value, &desired, ret, order);
-        return *ret;
+        return atomic_exchange(&m_value, desired, order);
     }
 
-    [[nodiscard]] bool compare_exchange_strong(T& expected, T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    [[nodiscard]] ALWAYS_INLINE bool compare_exchange_strong(T& expected, T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        if (order == memory_order_acq_rel || order == memory_order_release)
-            return __atomic_compare_exchange(&m_value, &expected, &desired, false, memory_order_release, memory_order_acquire);
-        return __atomic_compare_exchange(&m_value, &expected, &desired, false, order, order);
+        return atomic_compare_exchange_strong(&m_value, expected, desired, order);
     }
 
     ALWAYS_INLINE operator T() const volatile noexcept
@@ -185,10 +210,7 @@ public:
 
     ALWAYS_INLINE T load(MemoryOrder order = DefaultMemoryOrder) const volatile noexcept
     {
-        alignas(T) u8 buffer[sizeof(T)];
-        T* ret = reinterpret_cast<T*>(buffer);
-        __atomic_load(&m_value, ret, order);
-        return *ret;
+        return atomic_load(&m_value, order);
     }
 
     // NOLINTNEXTLINE(misc-unconventional-assign-operator) We want operator= to exchange the value, so returning an object of type Atomic& here does not make sense
@@ -225,26 +247,24 @@ public:
     {
     }
 
-    volatile T* ptr() noexcept
+    ALWAYS_INLINE T volatile* ptr() noexcept
     {
         return &m_value;
     }
 
-    T exchange(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    ALWAYS_INLINE T exchange(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        return __atomic_exchange_n(&m_value, desired, order);
+        return atomic_exchange(&m_value, desired, order);
     }
 
-    [[nodiscard]] bool compare_exchange_strong(T& expected, T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    [[nodiscard]] ALWAYS_INLINE bool compare_exchange_strong(T& expected, T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        if (order == memory_order_acq_rel || order == memory_order_release)
-            return __atomic_compare_exchange_n(&m_value, &expected, desired, false, memory_order_release, memory_order_acquire);
-        return __atomic_compare_exchange_n(&m_value, &expected, desired, false, order, order);
+        return atomic_compare_exchange_strong(&m_value, expected, desired, order);
     }
 
     ALWAYS_INLINE T operator++() volatile noexcept
     {
-        return fetch_add(1) + 1;
+        return add_fetch(1);
     }
 
     ALWAYS_INLINE T operator++(int) volatile noexcept
@@ -254,17 +274,17 @@ public:
 
     ALWAYS_INLINE T operator+=(T val) volatile noexcept
     {
-        return fetch_add(val) + val;
+        return add_fetch(val);
     }
 
     ALWAYS_INLINE T fetch_add(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        return __atomic_fetch_add(&m_value, val, order);
+        return atomic_fetch_add(&m_value, val, order);
     }
 
     ALWAYS_INLINE T operator--() volatile noexcept
     {
-        return fetch_sub(1) - 1;
+        return sub_fetch(1);
     }
 
     ALWAYS_INLINE T operator--(int) volatile noexcept
@@ -274,42 +294,67 @@ public:
 
     ALWAYS_INLINE T operator-=(T val) volatile noexcept
     {
-        return fetch_sub(val) - val;
+        return sub_fetch(val);
     }
 
     ALWAYS_INLINE T fetch_sub(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        return __atomic_fetch_sub(&m_value, val, order);
+        return atomic_fetch_sub(&m_value, val, order);
     }
 
     ALWAYS_INLINE T operator&=(T val) volatile noexcept
     {
-        return fetch_and(val) & val;
+        return and_fetch(val);
     }
 
     ALWAYS_INLINE T fetch_and(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        return __atomic_fetch_and(&m_value, val, order);
+        return atomic_fetch_and(&m_value, val, order);
     }
 
     ALWAYS_INLINE T operator|=(T val) volatile noexcept
     {
-        return fetch_or(val) | val;
+        return or_fetch(val);
     }
 
     ALWAYS_INLINE T fetch_or(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        return __atomic_fetch_or(&m_value, val, order);
+        return atomic_fetch_or(&m_value, val, order);
     }
 
     ALWAYS_INLINE T operator^=(T val) volatile noexcept
     {
-        return fetch_xor(val) ^ val;
+        return xor_fetch(val);
     }
 
     ALWAYS_INLINE T fetch_xor(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        return __atomic_fetch_xor(&m_value, val, order);
+        return atomic_fetch_xor(&m_value, val, order);
+    }
+
+    ALWAYS_INLINE T add_fetch(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    {
+        return atomic_add_fetch(&m_value, val, order);
+    }
+
+    ALWAYS_INLINE T sub_fetch(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    {
+        return atomic_sub_fetch(&m_value, val, order);
+    }
+
+    ALWAYS_INLINE T and_fetch(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    {
+        return atomic_and_fetch(&m_value, val, order);
+    }
+
+    ALWAYS_INLINE T or_fetch(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    {
+        return atomic_or_fetch(&m_value, val, order);
+    }
+
+    ALWAYS_INLINE T xor_fetch(T val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    {
+        return atomic_xor_fetch(&m_value, val, order);
     }
 
     ALWAYS_INLINE operator T() const volatile noexcept
@@ -319,7 +364,7 @@ public:
 
     ALWAYS_INLINE T load(MemoryOrder order = DefaultMemoryOrder) const volatile noexcept
     {
-        return __atomic_load_n(&m_value, order);
+        return atomic_load(&m_value, order);
     }
 
     // NOLINTNEXTLINE(misc-unconventional-assign-operator) We want operator= to exchange the value, so returning an object of type Atomic& here does not make sense
@@ -331,18 +376,18 @@ public:
 
     ALWAYS_INLINE void store(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        __atomic_store_n(&m_value, desired, order);
+        atomic_store(&m_value, desired, order);
     }
 
     ALWAYS_INLINE bool is_lock_free() const volatile noexcept
     {
-        return __atomic_is_lock_free(sizeof(m_value), &m_value);
+        return atomic_is_lock_free(sizeof(m_value), &m_value);
     }
 };
 
-template<typename T, MemoryOrder DefaultMemoryOrder>
-class Atomic<T*, DefaultMemoryOrder> {
-    T* m_value { nullptr };
+template<Pointer T, MemoryOrder DefaultMemoryOrder>
+class Atomic<T, DefaultMemoryOrder> {
+    T m_value { nullptr };
 
 public:
     Atomic() noexcept = default;
@@ -351,93 +396,101 @@ public:
     Atomic(Atomic const&) = delete;
     Atomic(Atomic&&) = delete;
 
-    constexpr Atomic(T* val) noexcept
+    constexpr Atomic(T val) noexcept
         : m_value(val)
     {
     }
 
-    volatile T** ptr() noexcept
+    ALWAYS_INLINE T ptr() noexcept
     {
         return &m_value;
     }
 
-    T* exchange(T* desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    ALWAYS_INLINE T exchange(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        return __atomic_exchange_n(&m_value, desired, order);
+        return atomic_exchange(&m_value, desired, order);
     }
 
-    [[nodiscard]] bool compare_exchange_strong(T*& expected, T* desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    [[nodiscard]] ALWAYS_INLINE bool compare_exchange_strong(T& expected, T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        if (order == memory_order_acq_rel || order == memory_order_release)
-            return __atomic_compare_exchange_n(&m_value, &expected, desired, false, memory_order_release, memory_order_acquire);
-        return __atomic_compare_exchange_n(&m_value, &expected, desired, false, order, order);
+        return atomic_compare_exchange_strong(&m_value, expected, desired, order);
     }
 
-    T* operator++() volatile noexcept
+    ALWAYS_INLINE T operator++() volatile noexcept
     {
-        return fetch_add(1) + 1;
+        return add_fetch(1);
     }
 
-    T* operator++(int) volatile noexcept
+    ALWAYS_INLINE T operator++(int) volatile noexcept
     {
         return fetch_add(1);
     }
 
-    T* operator+=(ptrdiff_t val) volatile noexcept
+    ALWAYS_INLINE T operator+=(ptrdiff_t val) volatile noexcept
     {
-        return fetch_add(val) + val;
+        return add_fetch(val);
     }
 
-    T* fetch_add(ptrdiff_t val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    ALWAYS_INLINE T fetch_add(ptrdiff_t val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         return __atomic_fetch_add(&m_value, val * sizeof(*m_value), order);
     }
 
-    T* operator--() volatile noexcept
+    ALWAYS_INLINE T operator--() volatile noexcept
     {
-        return fetch_sub(1) - 1;
+        return sub_fetch(1);
     }
 
-    T* operator--(int) volatile noexcept
+    ALWAYS_INLINE T operator--(int) volatile noexcept
     {
         return fetch_sub(1);
     }
 
-    T* operator-=(ptrdiff_t val) volatile noexcept
+    ALWAYS_INLINE T operator-=(ptrdiff_t val) volatile noexcept
     {
-        return fetch_sub(val) - val;
+        return sub_fetch(val);
     }
 
-    T* fetch_sub(ptrdiff_t val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    ALWAYS_INLINE T fetch_sub(ptrdiff_t val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
         return __atomic_fetch_sub(&m_value, val * sizeof(*m_value), order);
     }
 
-    operator T*() const volatile noexcept
+    ALWAYS_INLINE T add_fetch(ptrdiff_t val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    {
+        return __atomic_add_fetch(&m_value, val * sizeof(*m_value), order);
+    }
+
+    ALWAYS_INLINE T sub_fetch(ptrdiff_t val, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    {
+        return __atomic_sub_fetch(&m_value, val * sizeof(*m_value), order);
+    }
+
+    ALWAYS_INLINE operator T() const volatile noexcept
     {
         return load();
     }
 
-    T* load(MemoryOrder order = DefaultMemoryOrder) const volatile noexcept
+    ALWAYS_INLINE T load(MemoryOrder order = DefaultMemoryOrder) const volatile noexcept
     {
-        return __atomic_load_n(&m_value, order);
+        return atomic_load(&m_value, order);
     }
 
     // NOLINTNEXTLINE(misc-unconventional-assign-operator) We want operator= to exchange the value, so returning an object of type Atomic& here does not make sense
-    T* operator=(T* desired) volatile noexcept
+    ALWAYS_INLINE T operator=(T desired) volatile noexcept
     {
         store(desired);
         return desired;
     }
 
-    void store(T* desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
+    ALWAYS_INLINE void store(T desired, MemoryOrder order = DefaultMemoryOrder) volatile noexcept
     {
-        __atomic_store_n(&m_value, desired, order);
+        atomic_store(&m_value, desired, order);
     }
 
-    bool is_lock_free() const volatile noexcept
+    ALWAYS_INLINE bool is_lock_free() const volatile noexcept
     {
-        return __atomic_is_lock_free(sizeof(m_value), &m_value);
+        return atomic_is_lock_free(sizeof(m_value), &m_value);
     }
 };
 }

--- a/AK/Concepts.h
+++ b/AK/Concepts.h
@@ -6,9 +6,17 @@
 
 #pragma once
 
-#include <AK/Forward.h>
 #include <AK/IterationDecision.h>
 #include <AK/StdLibExtras.h>
+#include <AK/Types.h>
+
+namespace AK {
+// Some basic forward delcarations
+// We need them so we can #include this file in Forward.h, so we can use concepts in types forward declared there.
+class StringView;
+template<typename T>
+class Span;
+}
 
 namespace AK::Concepts {
 
@@ -50,6 +58,12 @@ concept AnyString = Detail::IsConstructible<StringView, T>;
 
 template<typename T, typename U>
 concept HashCompatible = IsHashCompatible<Detail::Decay<T>, Detail::Decay<U>>;
+
+template<typename T>
+concept Pointer = IsPointer<T>;
+
+template<typename T>
+concept IntegralLike = Integral<T> || Enum<T> || Pointer<T>;
 
 // FIXME: remove once Clang formats these properly.
 // clang-format off
@@ -120,11 +134,13 @@ using AK::Concepts::Enum;
 using AK::Concepts::FloatingPoint;
 using AK::Concepts::Fundamental;
 using AK::Concepts::Integral;
+using AK::Concepts::IntegralLike;
 using AK::Concepts::IterableContainer;
 using AK::Concepts::IteratorFunction;
 using AK::Concepts::IteratorPairWith;
 using AK::Concepts::OneOf;
 using AK::Concepts::OneOfIgnoringCV;
+using AK::Concepts::Pointer;
 using AK::Concepts::SameAs;
 using AK::Concepts::Signed;
 using AK::Concepts::SpecializationOf;

--- a/AK/Forward.h
+++ b/AK/Forward.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/Concepts.h>
 #include <AK/Types.h>
 
 namespace AK {
@@ -58,7 +59,7 @@ class SimpleIterator;
 using ReadonlyBytes = Span<const u8>;
 using Bytes = Span<u8>;
 
-template<typename T, AK::MemoryOrder DefaultMemoryOrder>
+template<IntegralLike T, AK::MemoryOrder DefaultMemoryOrder>
 class Atomic;
 
 template<typename T>

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/GenerateCSSEnums.cpp
@@ -47,6 +47,7 @@ ErrorOr<void> generate_header_file(JsonObject& enums_data, Core::Stream::File& f
 #pragma once
 
 #include <AK/Optional.h>
+#include <AK/StringView.h>
 
 namespace Web::CSS {
 

--- a/Tests/AK/TestAtomic.cpp
+++ b/Tests/AK/TestAtomic.cpp
@@ -131,6 +131,45 @@ TEST_CASE(fetch_add)
     EXPECT(a_pu8.load() == &v_u8[1] && static_cast<u8*>(a_pu8) == &v_u8[1]);
 }
 
+TEST_CASE(add_fetch)
+{
+    Atomic<u32> a_u32(5);
+    EXPECT(a_u32.add_fetch(2) == 7);
+    EXPECT(a_u32.load() == 7 && static_cast<u32>(a_u32) == 7);
+
+    Atomic<u16> a_u16(5);
+    EXPECT(a_u16.add_fetch(2) == 7);
+    EXPECT(a_u16.load() == 7 && static_cast<u16>(a_u16) == 7);
+
+    Atomic<u8> a_u8(5);
+    EXPECT(a_u8.add_fetch(2) == 7);
+    EXPECT(a_u8.load() == 7 && static_cast<u8>(a_u8) == 7);
+
+    u32 v_u32[6];
+    Atomic<u32*> a_pu32(&v_u32[2]);
+    EXPECT(a_pu32.load() == &v_u32[2] && static_cast<u32*>(a_pu32) == &v_u32[2]);
+    EXPECT(a_pu32.add_fetch(2) == &v_u32[4]);
+    EXPECT(a_pu32.load() == &v_u32[4] && static_cast<u32*>(a_pu32) == &v_u32[4]);
+    EXPECT(a_pu32.add_fetch(-3) == &v_u32[1]);
+    EXPECT(a_pu32.load() == &v_u32[1] && static_cast<u32*>(a_pu32) == &v_u32[1]);
+
+    u16 v_u16[6];
+    Atomic<u16*> a_pu16(&v_u16[2]);
+    EXPECT(a_pu16.load() == &v_u16[2] && static_cast<u16*>(a_pu16) == &v_u16[2]);
+    EXPECT(a_pu16.add_fetch(2) == &v_u16[4]);
+    EXPECT(a_pu16.load() == &v_u16[4] && static_cast<u16*>(a_pu16) == &v_u16[4]);
+    EXPECT(a_pu16.add_fetch(-3) == &v_u16[1]);
+    EXPECT(a_pu16.load() == &v_u16[1] && static_cast<u16*>(a_pu16) == &v_u16[1]);
+
+    u8 v_u8[6];
+    Atomic<u8*> a_pu8(&v_u8[2]);
+    EXPECT(a_pu8.load() == &v_u8[2] && static_cast<u8*>(a_pu8) == &v_u8[2]);
+    EXPECT(a_pu8.add_fetch(2) == &v_u8[4]);
+    EXPECT(a_pu8.load() == &v_u8[4] && static_cast<u8*>(a_pu8) == &v_u8[4]);
+    EXPECT(a_pu8.add_fetch(-3) == &v_u8[1]);
+    EXPECT(a_pu8.load() == &v_u8[1] && static_cast<u8*>(a_pu8) == &v_u8[1]);
+}
+
 TEST_CASE(fetch_sub)
 {
     Atomic<u32> a_u32(5);
@@ -167,6 +206,45 @@ TEST_CASE(fetch_sub)
     EXPECT(a_pu8.fetch_sub(2) == &v_u8[2]);
     EXPECT(a_pu8.load() == &v_u8[0] && static_cast<u8*>(a_pu8) == &v_u8[0]);
     EXPECT(a_pu8.fetch_sub(-3) == &v_u8[0]);
+    EXPECT(a_pu8.load() == &v_u8[3] && static_cast<u8*>(a_pu8) == &v_u8[3]);
+}
+
+TEST_CASE(sub_fetch)
+{
+    Atomic<u32> a_u32(5);
+    EXPECT(a_u32.sub_fetch(2) == 3);
+    EXPECT(a_u32.load() == 3 && static_cast<u32>(a_u32) == 3);
+
+    Atomic<u16> a_u16(5);
+    EXPECT(a_u16.sub_fetch(2) == 3);
+    EXPECT(a_u16.load() == 3 && static_cast<u16>(a_u16) == 3);
+
+    Atomic<u8> a_u8(5);
+    EXPECT(a_u8.sub_fetch(2) == 3);
+    EXPECT(a_u8.load() == 3 && static_cast<u8>(a_u8) == 3);
+
+    u32 v_u32[6];
+    Atomic<u32*> a_pu32(&v_u32[2]);
+    EXPECT(a_pu32.load() == &v_u32[2] && static_cast<u32*>(a_pu32) == &v_u32[2]);
+    EXPECT(a_pu32.sub_fetch(2) == &v_u32[0]);
+    EXPECT(a_pu32.load() == &v_u32[0] && static_cast<u32*>(a_pu32) == &v_u32[0]);
+    EXPECT(a_pu32.sub_fetch(-3) == &v_u32[3]);
+    EXPECT(a_pu32.load() == &v_u32[3] && static_cast<u32*>(a_pu32) == &v_u32[3]);
+
+    u16 v_u16[6];
+    Atomic<u16*> a_pu16(&v_u16[2]);
+    EXPECT(a_pu16.load() == &v_u16[2] && static_cast<u16*>(a_pu16) == &v_u16[2]);
+    EXPECT(a_pu16.sub_fetch(2) == &v_u16[0]);
+    EXPECT(a_pu16.load() == &v_u16[0] && static_cast<u16*>(a_pu16) == &v_u16[0]);
+    EXPECT(a_pu16.sub_fetch(-3) == &v_u16[3]);
+    EXPECT(a_pu16.load() == &v_u16[3] && static_cast<u16*>(a_pu16) == &v_u16[3]);
+
+    u8 v_u8[6];
+    Atomic<u8*> a_pu8(&v_u8[2]);
+    EXPECT(a_pu8.load() == &v_u8[2] && static_cast<u8*>(a_pu8) == &v_u8[2]);
+    EXPECT(a_pu8.sub_fetch(2) == &v_u8[0]);
+    EXPECT(a_pu8.load() == &v_u8[0] && static_cast<u8*>(a_pu8) == &v_u8[0]);
+    EXPECT(a_pu8.sub_fetch(-3) == &v_u8[3]);
     EXPECT(a_pu8.load() == &v_u8[3] && static_cast<u8*>(a_pu8) == &v_u8[3]);
 }
 
@@ -299,6 +377,27 @@ TEST_CASE(fetch_and)
     EXPECT((a_u8 &= 0x0d) == 0x0d);
 }
 
+TEST_CASE(and_fetch)
+{
+    Atomic<u32> a_u32(0xdeadbeef);
+    EXPECT(a_u32.and_fetch(0x8badf00d) == 0x8aadb00d);
+    EXPECT(a_u32.load() == 0x8aadb00d && static_cast<u32>(a_u32) == 0x8aadb00d);
+    a_u32 = 0xdeadbeef;
+    EXPECT((a_u32 &= 0x8badf00d) == 0x8aadb00d);
+
+    Atomic<u16> a_u16(0xbeef);
+    EXPECT(a_u16.and_fetch(0xf00d) == 0xb00d);
+    EXPECT(a_u16.load() == 0xb00d && static_cast<u16>(a_u16) == 0xb00d);
+    a_u16 = 0xbeef;
+    EXPECT((a_u16 &= 0xf00d) == 0xb00d);
+
+    Atomic<u8> a_u8(0xef);
+    EXPECT(a_u8.and_fetch(0x0d) == 0x0d);
+    EXPECT(a_u8.load() == 0x0d && static_cast<u8>(a_u8) == 0x0d);
+    a_u8 = 0xef;
+    EXPECT((a_u8 &= 0x0d) == 0x0d);
+}
+
 TEST_CASE(fetch_or)
 {
     Atomic<u32> a_u32(0xaadb00d);
@@ -320,6 +419,27 @@ TEST_CASE(fetch_or)
     EXPECT((a_u8 |= 0xef) == 0xef);
 }
 
+TEST_CASE(or_fetch)
+{
+    Atomic<u32> a_u32(0xaadb00d);
+    EXPECT(a_u32.or_fetch(0xdeadbeef) == 0xdeadbeef);
+    EXPECT(a_u32.load() == 0xdeadbeef && static_cast<u32>(a_u32) == 0xdeadbeef);
+    a_u32 = 0xaadb00d;
+    EXPECT((a_u32 |= 0xdeadbeef) == 0xdeadbeef);
+
+    Atomic<u16> a_u16(0xb00d);
+    EXPECT(a_u16.or_fetch(0xbeef) == 0xbeef);
+    EXPECT(a_u16.load() == 0xbeef && static_cast<u16>(a_u16) == 0xbeef);
+    a_u16 = 0xb00d;
+    EXPECT((a_u16 |= 0xbeef) == 0xbeef);
+
+    Atomic<u8> a_u8(0x0d);
+    EXPECT(a_u8.or_fetch(0xef) == 0xef);
+    EXPECT(a_u8.load() == 0xef && static_cast<u8>(a_u8) == 0xef);
+    a_u8 = 0x0d;
+    EXPECT((a_u8 |= 0xef) == 0xef);
+}
+
 TEST_CASE(fetch_xor)
 {
     Atomic<u32> a_u32(0x55004ee2);
@@ -336,6 +456,27 @@ TEST_CASE(fetch_xor)
 
     Atomic<u8> a_u8(0xe2);
     EXPECT(a_u8.fetch_xor(0xef) == 0xe2);
+    EXPECT(a_u8.load() == 0x0d && static_cast<u8>(a_u8) == 0x0d);
+    a_u8 = 0xe2;
+    EXPECT((a_u8 ^= 0xef) == 0x0d);
+}
+
+TEST_CASE(xor_fetch)
+{
+    Atomic<u32> a_u32(0x55004ee2);
+    EXPECT(a_u32.xor_fetch(0xdeadbeef) == 0x8badf00d);
+    EXPECT(a_u32.load() == 0x8badf00d && static_cast<u32>(a_u32) == 0x8badf00d);
+    a_u32 = 0x55004ee2;
+    EXPECT((a_u32 ^= 0xdeadbeef) == 0x8badf00d);
+
+    Atomic<u16> a_u16(0x4ee2);
+    EXPECT(a_u16.xor_fetch(0xbeef) == 0xf00d);
+    EXPECT(a_u16.load() == 0xf00d && static_cast<u16>(a_u16) == 0xf00d);
+    a_u16 = 0x4ee2;
+    EXPECT((a_u16 ^= 0xbeef) == 0xf00d);
+
+    Atomic<u8> a_u8(0xe2);
+    EXPECT(a_u8.xor_fetch(0xef) == 0x0d);
     EXPECT(a_u8.load() == 0x0d && static_cast<u8>(a_u8) == 0x0d);
     a_u8 = 0xe2;
     EXPECT((a_u8 ^= 0xef) == 0x0d);


### PR DESCRIPTION
This solves a FIXME that had been in AK::Atomic since forever, and implements some the missing atomic_{add,sub,and,or,xor}_fetch as both free functions and member functions of Atomic<>. Operations that use certain functions from AK::Atomic might be faster now since every operation should take one less instruction (or just as fast, in case the optimizer realized it before).