### PR TITLE
BrowserSettings: "Defaults"  button now updates checkbox

### DIFF
--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -18,6 +18,8 @@
 #include <LibGUI/ListView.h>
 #include <LibGUI/Menu.h>
 
+static bool default_enable_content_filtering = true;
+
 static String filter_list_file_path()
 {
     return String::formatted("{}/BrowserContentFilters.txt", Core::StandardPaths::config_directory());
@@ -148,4 +150,5 @@ void ContentFilterSettingsWidget::apply_settings()
 void ContentFilterSettingsWidget::reset_default_values()
 {
     m_domain_list_model->reset_default_values();
+    m_enable_content_filtering_checkbox->set_checked(default_enable_content_filtering);
 }


### PR DESCRIPTION
This PR fixes "defaults" button not updating "enable content filtering"
 checkbox.
 
 ContentFilterSettingsWidget::reset_default_values() now sets default
 checkbox value

Closes #13908.