### PR TITLE
LibC: Implement posix_memalign(3) and aligned_alloc(3)

### DIFF
--- a/Tests/LibC/CMakeLists.txt
+++ b/Tests/LibC/CMakeLists.txt
@@ -10,6 +10,7 @@ set(TEST_SOURCES
     TestLibCString.cpp
     TestLibCTime.cpp
     TestMalloc.cpp
+    TestMemalign.cpp
     TestMemmem.cpp
     TestMkDir.cpp
     TestQsort.cpp

--- a/Tests/LibC/TestMemalign.cpp
+++ b/Tests/LibC/TestMemalign.cpp
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2022, Peter Elliott <pelliott@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibTest/TestCase.h>
+
+#include <LibC/mallocdefs.h>
+#include <stdlib.h>
+
+static constexpr size_t runs = 5000;
+static constexpr size_t ptrs_per_run = 20;
+
+static size_t random_alignment()
+{
+    return 1 << (rand() % 16);
+}
+
+static size_t random_size()
+{
+    int r = rand() % num_size_classes;
+    if (r == num_size_classes - 1) {
+        return rand() % (1 << 17);
+    }
+
+    return size_classes[r] + (rand() % (size_classes[r + 1] - size_classes[r]));
+}
+
+static bool is_aligned(void* ptr, size_t align)
+{
+    return (reinterpret_cast<uintptr_t>(ptr) & (align - 1)) == 0;
+}
+
+TEST_CASE(posix_memalign_fuzz)
+{
+    EXPECT_NO_CRASH("posix_memalign should not crash under regular use", [] {
+        for (size_t i = 0; i < runs; ++i) {
+            size_t align = random_alignment();
+            size_t size = random_size();
+
+            for (size_t j = 0; j < 2; ++j) {
+                void* ptrs[ptrs_per_run];
+
+                for (size_t k = 0; k < ptrs_per_run; ++k) {
+                    EXPECT_EQ(posix_memalign(&(ptrs[k]), align, size), 0);
+                    EXPECT(is_aligned(ptrs[k], align));
+                }
+                for (size_t k = 0; k < ptrs_per_run; ++k) {
+                    free(ptrs[k]);
+                }
+            }
+        }
+
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}
+
+TEST_CASE(posix_memalign_not_power2)
+{
+    char secret_ptr[0];
+    void* memptr = secret_ptr;
+    EXPECT_EQ(posix_memalign(&memptr, 7, 256), EINVAL);
+    EXPECT_EQ(memptr, secret_ptr);
+}
+
+TEST_CASE(aligned_alloc_fuzz)
+{
+    EXPECT_NO_CRASH("aligned_alloc should not crash under regular use", [] {
+        for (size_t i = 0; i < runs; ++i) {
+            size_t align = random_alignment();
+            size_t size = random_size();
+
+            for (size_t j = 0; j < 2; ++j) {
+                void* ptrs[ptrs_per_run];
+
+                for (size_t k = 0; k < ptrs_per_run; ++k) {
+                    ptrs[k] = aligned_alloc(align, size);
+                    EXPECT(ptrs[k]);
+                    EXPECT(is_aligned(ptrs[k], align));
+                }
+                for (size_t k = 0; k < ptrs_per_run; ++k) {
+                    free(ptrs[k]);
+                }
+            }
+        }
+
+        return Test::Crash::Failure::DidNotCrash;
+    });
+}
+
+TEST_CASE(aligned_alloc_not_power2)
+{
+#ifdef __clang__
+#    pragma clang diagnostic push
+#    pragma clang diagnostic ignored "-Wnon-power-of-two-alignment"
+#endif
+    EXPECT_EQ(aligned_alloc(7, 256), nullptr);
+    EXPECT_EQ(errno, EINVAL);
+#ifdef __clang__
+#    pragma clang diagnostic pop
+#endif
+}

--- a/Userland/Libraries/LibC/CMakeLists.txt
+++ b/Userland/Libraries/LibC/CMakeLists.txt
@@ -139,9 +139,6 @@ set(SOURCES ${LIBC_SOURCES} ${AK_SOURCES} ${ELF_SOURCES} ${ASM_SOURCES})
 # Prevent GCC from removing null checks by marking the `FILE*` argument non-null
 set_source_files_properties(stdio.cpp PROPERTIES COMPILE_FLAGS "-fno-builtin-fputc -fno-builtin-fputs -fno-builtin-fwrite")
 
-# Add in the `posix_memalign` symbol to avoid breaking existing binaries.
-set_source_files_properties(stdlib.cpp PROPERTIES COMPILE_FLAGS "-DSERENITY_LIBC_SHOW_POSIX_MEMALIGN")
-
 # Prevent naively implemented string functions (like strlen) from being "optimized" into a call to themselves.
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     set_source_files_properties(string.cpp wchar.cpp PROPERTIES COMPILE_FLAGS "-fno-tree-loop-distribution -fno-tree-loop-distribute-patterns")

--- a/Userland/Libraries/LibC/stdlib.cpp
+++ b/Userland/Libraries/LibC/stdlib.cpp
@@ -1335,14 +1335,3 @@ void _Exit(int status)
 {
     _exit(status);
 }
-
-#ifdef SERENITY_LIBC_SHOW_POSIX_MEMALIGN
-// https://pubs.opengroup.org/onlinepubs/9699919799/functions/posix_memalign.html
-int posix_memalign(void** memptr, size_t alignment, size_t size)
-{
-    (void)memptr;
-    (void)alignment;
-    (void)size;
-    TODO();
-}
-#endif

--- a/Userland/Libraries/LibC/stdlib.h
+++ b/Userland/Libraries/LibC/stdlib.h
@@ -101,11 +101,7 @@ int posix_openpt(int flags);
 int grantpt(int fd);
 int unlockpt(int fd);
 
-// FIXME: Remove the ifdef once we have a working memalign implementation.
-// This is hidden by default until then because many applications prefer
-// `posix_memalign` over other implementations of aligned memory.
-#ifdef SERENITY_LIBC_SHOW_POSIX_MEMALIGN
 int posix_memalign(void**, size_t alignment, size_t size);
-#endif
+__attribute__((malloc, alloc_size(2), alloc_align(1))) void* aligned_alloc(size_t alignment, size_t size);
 
 __END_DECLS


### PR DESCRIPTION
Some ports linked against posix_memalign, but didn't use it, and others
used it if it was Available. So I decided to implement posix_memalign.

My implementation adds almost no overhead to regular mallocs. However, if
an alignment is specified, it will use the smallest ChunkedBlock, for
which aligned chunks exist, and simply use one of the chunks that is
aligned. If it cannot use a ChunkedBlock, for size or alignment reasons,
it will use a BigAllocationBlock, and return a pointer to the first
aligned address past the start of the block. This implementation
supports alignments up to 32768, due to the limitations of the
BigAllocationBlock technique.