### PR TITLE
LibWeb: Stop inactive requestAnimationFrame() callbacks from running 

### DIFF
--- a/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
+++ b/Userland/Libraries/LibWeb/HTML/AnimationFrameCallbackDriver.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, the SerenityOS developers.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/Function.h>
+#include <AK/IDAllocator.h>
+#include <LibCore/Timer.h>
+#include <LibWeb/HTML/EventLoop/EventLoop.h>
+
+namespace Web::HTML {
+
+struct AnimationFrameCallbackDriver {
+    using Callback = Function<void(i32)>;
+
+    AnimationFrameCallbackDriver()
+    {
+        m_timer = Core::Timer::create_single_shot(16, [] {
+            HTML::main_thread_event_loop().schedule();
+        });
+    }
+
+    i32 add(Callback handler)
+    {
+        auto id = m_id_allocator.allocate();
+        m_callbacks.set(id, move(handler));
+        if (!m_timer->is_active())
+            m_timer->start();
+        return id;
+    }
+
+    bool remove(i32 id)
+    {
+        auto it = m_callbacks.find(id);
+        if (it == m_callbacks.end())
+            return false;
+        m_callbacks.remove(it);
+        m_id_allocator.deallocate(id);
+        return true;
+    }
+
+    void run()
+    {
+        auto taken_callbacks = move(m_callbacks);
+        for (auto& [id, callback] : taken_callbacks)
+            callback(id);
+    }
+
+    bool has_callbacks() const
+    {
+        return !m_callbacks.is_empty();
+    }
+
+private:
+    HashMap<i32, Callback> m_callbacks;
+    IDAllocator m_id_allocator;
+    RefPtr<Core::Timer> m_timer;
+};
+
+}

--- a/Userland/Libraries/LibWeb/HTML/Window.h
+++ b/Userland/Libraries/LibWeb/HTML/Window.h
@@ -18,12 +18,12 @@
 #include <LibWeb/DOM/Document.h>
 #include <LibWeb/DOM/Event.h>
 #include <LibWeb/DOM/EventTarget.h>
+#include <LibWeb/HTML/AnimationFrameCallbackDriver.h>
 #include <LibWeb/HTML/BrowsingContext.h>
 #include <LibWeb/HTML/GlobalEventHandlers.h>
 
 namespace Web::HTML {
 
-class RequestAnimationFrameCallback;
 class IdleCallback;
 
 class Window final
@@ -59,7 +59,7 @@ public:
     String prompt(String const&, String const&);
     i32 request_animation_frame(NonnullOwnPtr<Bindings::CallbackType> js_callback);
     void cancel_animation_frame(i32);
-    bool has_animation_frame_callbacks() const { return !m_request_animation_frame_callbacks.is_empty(); }
+    bool has_animation_frame_callbacks() const { return m_animation_frame_callback_driver.has_callbacks(); }
 
     i32 set_timeout(Bindings::TimerHandler handler, i32 timeout, JS::MarkedVector<JS::Value> arguments);
     i32 set_interval(Bindings::TimerHandler handler, i32 timeout, JS::MarkedVector<JS::Value> arguments);
@@ -122,6 +122,8 @@ public:
     u32 request_idle_callback(NonnullOwnPtr<Bindings::CallbackType> callback);
     void cancel_idle_callback(u32);
 
+    AnimationFrameCallbackDriver& animation_frame_callback_driver() { return m_animation_frame_callback_driver; }
+
 private:
     explicit Window(DOM::Document&);
 
@@ -149,7 +151,7 @@ private:
     NonnullOwnPtr<CSS::Screen> m_screen;
     RefPtr<DOM::Event> m_current_event;
 
-    HashMap<i32, NonnullRefPtr<RequestAnimationFrameCallback>> m_request_animation_frame_callbacks;
+    AnimationFrameCallbackDriver m_animation_frame_callback_driver;
 
     // https://w3c.github.io/requestidlecallback/#dfn-list-of-idle-request-callbacks
     NonnullRefPtrVector<IdleCallback> m_idle_request_callbacks;


### PR DESCRIPTION
Previously requestAnimationFrame() callbacks were registered with a
static global RequestAnimationFrameDriver shared between all windows.
This led to callbacks still running after navigating away from a page
(This could be seen with the WASM GoL demo).

This commit moves the RequestAnimationFrameDriver to be a member
of the HTML::Window object, then uses the 'active document'
parameter of run_animation_frame_callbacks() to run only
the active callbacks.

---

Before this change after going to the WASM GoL demo, then navigating back:
![Screenshot from 2022-05-05 20-26-28](https://user-images.githubusercontent.com/11597044/167010974-e0997d60-cfd6-4da5-a5fe-37508783e36b.png)
The `requestAnimationFrame()` callback loop stays running using 95% of the CPU.

After:
\<Imagine an idle CPU\>

