### PR TITLE
SystemMonitor: Consistently use u64 for ValueFormat::text_formatter

### DIFF
--- a/Userland/Applications/SystemMonitor/GraphWidget.h
+++ b/Userland/Applications/SystemMonitor/GraphWidget.h
@@ -26,7 +26,7 @@ public:
     struct ValueFormat {
         Gfx::ColorRole graph_color_role { Gfx::ColorRole::Base };
         Color text_shadow_color { Color::Transparent };
-        Function<String(size_t)> text_formatter;
+        Function<String(u64)> text_formatter;
     };
     void set_value_format(size_t index, ValueFormat&& format)
     {

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -661,13 +661,13 @@ void build_performance_tab(GUI::Widget& graphs_container)
             cpu_graph.set_max(100);
             cpu_graph.set_value_format(0, {
                                               .graph_color_role = ColorRole::SyntaxPreprocessorStatement,
-                                              .text_formatter = [](int value) {
+                                              .text_formatter = [](u64 value) {
                                                   return String::formatted("Total: {}%", value);
                                               },
                                           });
             cpu_graph.set_value_format(1, {
                                               .graph_color_role = ColorRole::SyntaxPreprocessorValue,
-                                              .text_formatter = [](int value) {
+                                              .text_formatter = [](u64 value) {
                                                   return String::formatted("Kernel: {}%", value);
                                               },
                                           });
@@ -687,19 +687,19 @@ void build_performance_tab(GUI::Widget& graphs_container)
     auto& memory_graph = *graphs_container.find_descendant_of_type_named<SystemMonitor::GraphWidget>("memory_graph");
     memory_graph.set_value_format(0, {
                                          .graph_color_role = ColorRole::SyntaxComment,
-                                         .text_formatter = [](int bytes) {
+                                         .text_formatter = [](u64 bytes) {
                                              return String::formatted("Committed: {}", human_readable_size(bytes));
                                          },
                                      });
     memory_graph.set_value_format(1, {
                                          .graph_color_role = ColorRole::SyntaxPreprocessorStatement,
-                                         .text_formatter = [](int bytes) {
+                                         .text_formatter = [](u64 bytes) {
                                              return String::formatted("Allocated: {}", human_readable_size(bytes));
                                          },
                                      });
     memory_graph.set_value_format(2, {
                                          .graph_color_role = ColorRole::SyntaxPreprocessorValue,
-                                         .text_formatter = [](int bytes) {
+                                         .text_formatter = [](u64 bytes) {
                                              return String::formatted("Kernel heap: {}", human_readable_size(bytes));
                                          },
                                      });


### PR DESCRIPTION
ValueFormat::text_formatter is called with a u64 retrieved from
GraphWidget::m_values. However, the function pointer definition used
size_t and all the users of text_formatter used int.  If bytes was over
~2 billion, we would interpret bytes to be negative. We then pass this
into `human_readable_size` which converts it to a u64, making it out to
be about 15.9 EiB.

This is fixed by making everything in the path take a u64.

Before:
![Screenshot from 2022-05-05 20-15-18](https://user-images.githubusercontent.com/25595356/167009546-31f788b1-12d2-48a1-8e91-2aa5a54148df.png)

After:
![Screenshot from 2022-05-05 17-57-50](https://user-images.githubusercontent.com/25595356/167009562-455bfddb-90e8-4cb4-8c1f-1dd23b00cdf7.png)
