### PR TITLE
Kernel/Graphics: Consider disabled functionality when trying to run WindowServer

### DIFF
--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -72,14 +72,6 @@ static ErrorOr<void> determine_system_mode()
 
     g_system_mode = system_mode;
     dbgln("Read system_mode: {}", g_system_mode);
-
-    // FIXME: Support more than one framebuffer detection
-    struct stat file_state;
-    int rc = lstat("/dev/fb0", &file_state);
-    if (rc == 0 && g_system_mode == "text") {
-        dbgln("WARNING: Text mode with framebuffers won't work as expected! Consider using 'fbdev=off'.");
-    }
-    dbgln("System in {} mode", g_system_mode);
     return {};
 }
 

--- a/Userland/Services/SystemServer/main.cpp
+++ b/Userland/Services/SystemServer/main.cpp
@@ -72,6 +72,14 @@ static ErrorOr<void> determine_system_mode()
 
     g_system_mode = system_mode;
     dbgln("Read system_mode: {}", g_system_mode);
+
+    struct stat file_state;
+    int rc = lstat("/dev/gpu/connector0", &file_state);
+    if (rc != 0 && g_system_mode == "graphical") {
+        dbgln("WARNING: No device nodes at /dev/gpu/ directory. This is probably a sign of disabled graphics functionality.");
+        dbgln("To cope with this, I'll turn off graphical mode.");
+        g_system_mode = "text";
+    }
     return {};
 }
 


### PR DESCRIPTION
So after https://github.com/SerenityOS/serenity/pull/13845 is merged, I tested for disabled functionality and it worked for the most part but we still need to fix these issues to be able to boot safely and completely.