### PR TITLE
Browser: Remove STL utility include from CookiesModel

### DIFF
--- a/Userland/Applications/Browser/CookiesModel.cpp
+++ b/Userland/Applications/Browser/CookiesModel.cpp
@@ -6,8 +6,6 @@
 
 #include "CookiesModel.h"
 
-#include <utility>
-
 namespace Browser {
 
 void CookiesModel::set_items(AK::Vector<Web::Cookie::Cookie> items)


### PR DESCRIPTION
This broke clang builds

See: https://dev.azure.com/SerenityOS/SerenityOS/_build/results?buildId=14654&view=logs&j=1792fc0c-aa2f-5547-0702-e8eb3cee2177&t=419c1473-5af3-5c24-9e2e-2e8533c287ae