### PR TITLE
WindowServer: Stop spurious debug spam after flushing the framebuffer

### DIFF
--- a/Userland/Services/WindowServer/HardwareScreenBackend.cpp
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.cpp
@@ -143,7 +143,7 @@ ErrorOr<void> HardwareScreenBackend::flush_framebuffer_rects(int buffer_index, S
     int rc = fb_flush_buffers(m_framebuffer_fd, buffer_index, flush_rects.data(), (unsigned)flush_rects.size());
     if (rc == -ENOTSUP)
         m_can_device_flush_buffers = false;
-    else
+    else if (rc != 0)
         return Error::from_syscall("fb_flush_buffers", rc);
     return {};
 }
@@ -153,7 +153,7 @@ ErrorOr<void> HardwareScreenBackend::flush_framebuffer()
     int rc = fb_flush_head(m_framebuffer_fd);
     if (rc == -ENOTSUP)
         m_can_device_flush_entire_framebuffer = false;
-    else
+    else if (rc != 0)
         return Error::from_syscall("fb_flush_head", rc);
     return {};
 }


### PR DESCRIPTION
This became apparent when using the VirtIO graphics device, because the
HardwareScreenBackend object needs to allow flushing of the framebuffer
constantly, and due to incorrect if-else flow, even a non-error response
from the ioctl was leading to a debug spam.