### PR TITLE
Mandelbrot: Remove image export confirmation dialog

### DIFF
--- a/Userland/Demos/Mandelbrot/Mandelbrot.cpp
+++ b/Userland/Demos/Mandelbrot/Mandelbrot.cpp
@@ -393,7 +393,6 @@ void Mandelbrot::export_image(String const& export_path, ImageType image_type)
     }
     fwrite(encoded_data.data(), 1, encoded_data.size(), file);
     fclose(file);
-    GUI::MessageBox::show(window(), "Image was successfully exported.", "Mandelbrot", GUI::MessageBox::Type::Information);
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)


### PR DESCRIPTION
Andreas mentioned this dialog is not needed in the monthly update
video[^1].

[^1]: https://youtu.be/yUmHEYs5n34?t=364