### PR TITLE
LibGUI: Show column names when using FilteringProxyModel with TableView

### DIFF
--- a/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.cpp
@@ -33,6 +33,11 @@ int FilteringProxyModel::column_count(ModelIndex const& index) const
     return m_model->column_count(m_matching_indices[index.row()]);
 }
 
+String FilteringProxyModel::column_name(int column) const
+{
+    return m_model->column_name(column);
+}
+
 Variant FilteringProxyModel::data(ModelIndex const& index, ModelRole role) const
 {
     if (!index.is_valid())

--- a/Userland/Libraries/LibGUI/FilteringProxyModel.h
+++ b/Userland/Libraries/LibGUI/FilteringProxyModel.h
@@ -29,6 +29,7 @@ public:
 
     virtual int row_count(ModelIndex const& = ModelIndex()) const override;
     virtual int column_count(ModelIndex const& = ModelIndex()) const override;
+    virtual String column_name(int) const override;
     virtual Variant data(ModelIndex const&, ModelRole = ModelRole::Display) const override;
     virtual void invalidate() override;
     virtual ModelIndex index(int row, int column = 0, ModelIndex const& parent = ModelIndex()) const override;


### PR DESCRIPTION
This PR fixes missing column names when using **FilteringProxyModel** with **TableView**

![image](https://user-images.githubusercontent.com/5783815/167183292-b6805175-14e5-413e-8b33-97e054812075.png)
