### PR TITLE
Browser: Add option to filter entries in Storage Inspector

### DIFF
--- a/Userland/Applications/Browser/CookiesModel.cpp
+++ b/Userland/Applications/Browser/CookiesModel.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "CookiesModel.h"
+#include <AK/FuzzyMatch.h>
 
 namespace Browser {
 
@@ -24,6 +25,13 @@ void CookiesModel::clear_items()
     end_insert_rows();
 
     did_update(DontInvalidateIndices);
+}
+
+int CookiesModel::row_count(GUI::ModelIndex const& index) const
+{
+    if (!index.is_valid())
+        return m_cookies.size();
+    return 0;
 }
 
 String CookiesModel::column_name(int column) const
@@ -74,6 +82,19 @@ GUI::Variant CookiesModel::data(GUI::ModelIndex const& index, GUI::ModelRole rol
     }
 
     VERIFY_NOT_REACHED();
+}
+
+TriState CookiesModel::data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const
+{
+    auto needle = term.as_string();
+    if (needle.is_empty())
+        return TriState::True;
+
+    auto const& cookie = m_cookies[index.row()];
+    auto haystack = String::formatted("{} {} {} {}", cookie.domain, cookie.path, cookie.name, cookie.value);
+    if (fuzzy_match(needle, haystack).score > 0)
+        return TriState::True;
+    return TriState::False;
 }
 
 }

--- a/Userland/Applications/Browser/CookiesModel.h
+++ b/Userland/Applications/Browser/CookiesModel.h
@@ -27,11 +27,12 @@ public:
 
     void set_items(AK::Vector<Web::Cookie::Cookie> items);
     void clear_items();
-    virtual int row_count(GUI::ModelIndex const&) const override { return m_cookies.size(); }
+    virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int column) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
+    virtual TriState data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;
 
 private:
     AK::Vector<Web::Cookie::Cookie> m_cookies;

--- a/Userland/Applications/Browser/LocalStorageModel.cpp
+++ b/Userland/Applications/Browser/LocalStorageModel.cpp
@@ -6,6 +6,8 @@
 
 #include "LocalStorageModel.h"
 
+#include <AK/FuzzyMatch.h>
+
 namespace Browser {
 
 void LocalStorageModel::set_items(OrderedHashMap<String, String> map)
@@ -24,6 +26,13 @@ void LocalStorageModel::clear_items()
     end_insert_rows();
 
     did_update(DontInvalidateIndices);
+}
+
+int LocalStorageModel::row_count(GUI::ModelIndex const& index) const
+{
+    if (!index.is_valid())
+        return m_local_storage_entries.size();
+    return 0;
 }
 
 String LocalStorageModel::column_name(int column) const
@@ -64,6 +73,22 @@ GUI::Variant LocalStorageModel::data(GUI::ModelIndex const& index, GUI::ModelRol
     }
 
     VERIFY_NOT_REACHED();
+}
+
+TriState LocalStorageModel::data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const
+{
+    auto needle = term.as_string();
+    if (needle.is_empty())
+        return TriState::True;
+
+    auto const& keys = m_local_storage_entries.keys();
+    auto const& local_storage_key = keys[index.row()];
+    auto const& local_storage_value = m_local_storage_entries.get(local_storage_key).value_or({});
+
+    auto haystack = String::formatted("{} {}", local_storage_key, local_storage_value);
+    if (fuzzy_match(needle, haystack).score > 0)
+        return TriState::True;
+    return TriState::False;
 }
 
 }

--- a/Userland/Applications/Browser/LocalStorageModel.h
+++ b/Userland/Applications/Browser/LocalStorageModel.h
@@ -20,11 +20,12 @@ public:
 
     void set_items(OrderedHashMap<String, String> map);
     void clear_items();
-    virtual int row_count(GUI::ModelIndex const&) const override { return m_local_storage_entries.size(); }
+    virtual int row_count(GUI::ModelIndex const&) const override;
     virtual int column_count(GUI::ModelIndex const& = GUI::ModelIndex()) const override { return Column::__Count; }
     virtual String column_name(int column) const override;
     virtual GUI::ModelIndex index(int row, int column = 0, GUI::ModelIndex const& = GUI::ModelIndex()) const override;
     virtual GUI::Variant data(GUI::ModelIndex const& index, GUI::ModelRole role = GUI::ModelRole::Display) const override;
+    virtual TriState data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const override;
 
 private:
     OrderedHashMap<String, String> m_local_storage_entries;

--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -21,22 +21,36 @@ StorageWidget::StorageWidget()
     auto& tab_widget = *find_descendant_of_type_named<GUI::TabWidget>("tab_widget");
 
     m_cookies_table_view = tab_widget.find_descendant_of_type_named<GUI::TableView>("cookies_tableview");
+    m_cookies_textbox = tab_widget.find_descendant_of_type_named<GUI::TextBox>("cookies_filter_textbox");
     m_cookies_model = adopt_ref(*new CookiesModel());
 
-    m_cookie_sorting_model = MUST(GUI::SortingProxyModel::create(*m_cookies_model));
-    m_cookie_sorting_model->set_sort_role(GUI::ModelRole::Display);
+    m_cookies_filtering_model = MUST(GUI::FilteringProxyModel::create(*m_cookies_model));
+    m_cookies_filtering_model->set_filter_term("");
 
-    m_cookies_table_view->set_model(m_cookie_sorting_model);
+    m_cookies_textbox->on_change = [this] {
+        m_cookies_filtering_model->set_filter_term(m_cookies_textbox->text());
+        if (m_cookies_filtering_model->row_count() != 0)
+            m_cookies_table_view->set_cursor(m_cookies_filtering_model->index(0, 0), GUI::AbstractView::SelectionUpdate::Set);
+    };
+
+    m_cookies_table_view->set_model(m_cookies_filtering_model);
     m_cookies_table_view->set_column_headers_visible(true);
     m_cookies_table_view->set_alternating_row_colors(true);
 
     m_local_storage_table_view = tab_widget.find_descendant_of_type_named<GUI::TableView>("local_storage_tableview");
+    m_local_storage_textbox = tab_widget.find_descendant_of_type_named<GUI::TextBox>("local_storage_filter_textbox");
     m_local_storage_model = adopt_ref(*new LocalStorageModel());
 
-    m_local_storage_sorting_model = MUST(GUI::SortingProxyModel::create(*m_local_storage_model));
-    m_local_storage_sorting_model->set_sort_role(GUI::ModelRole::Display);
+    m_local_storage_filtering_model = MUST(GUI::FilteringProxyModel::create(*m_local_storage_model));
+    m_local_storage_filtering_model->set_filter_term("");
 
-    m_local_storage_table_view->set_model(m_local_storage_sorting_model);
+    m_local_storage_textbox->on_change = [this] {
+        m_local_storage_filtering_model->set_filter_term(m_local_storage_textbox->text());
+        if (m_local_storage_filtering_model->row_count() != 0)
+            m_local_storage_table_view->set_cursor(m_local_storage_filtering_model->index(0, 0), GUI::AbstractView::SelectionUpdate::Set);
+    };
+
+    m_local_storage_table_view->set_model(m_local_storage_filtering_model);
     m_local_storage_table_view->set_column_headers_visible(true);
     m_local_storage_table_view->set_alternating_row_colors(true);
 }

--- a/Userland/Applications/Browser/StorageWidget.gml
+++ b/Userland/Applications/Browser/StorageWidget.gml
@@ -13,6 +13,11 @@
                 margins: [4]
             }
 
+            @GUI::TextBox {
+                name: "cookies_filter_textbox"
+                placeholder: "Filter"
+            }
+
             @GUI::GroupBox {
                 layout: @GUI::VerticalBoxLayout {
                     margins: [6]
@@ -28,6 +33,11 @@
             title: "Local Storage"
             layout: @GUI::VerticalBoxLayout {
                 margins: [4]
+            }
+
+            @GUI::TextBox {
+                name: "local_storage_filter_textbox"
+                placeholder: "Filter"
             }
 
             @GUI::GroupBox {

--- a/Userland/Applications/Browser/StorageWidget.h
+++ b/Userland/Applications/Browser/StorageWidget.h
@@ -9,7 +9,8 @@
 #include "CookiesModel.h"
 #include "LocalStorageModel.h"
 #include "Tab.h"
-#include <LibGUI/SortingProxyModel.h>
+#include <LibGUI/FilteringProxyModel.h>
+#include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 #include <LibWeb/Cookie/Cookie.h>
 
@@ -30,11 +31,14 @@ private:
     StorageWidget();
 
     RefPtr<GUI::TableView> m_cookies_table_view;
+    RefPtr<GUI::TextBox> m_cookies_textbox;
     RefPtr<CookiesModel> m_cookies_model;
-    RefPtr<GUI::SortingProxyModel> m_cookie_sorting_model;
+    RefPtr<GUI::FilteringProxyModel> m_cookies_filtering_model;
+
     RefPtr<GUI::TableView> m_local_storage_table_view;
+    RefPtr<GUI::TextBox> m_local_storage_textbox;
     RefPtr<LocalStorageModel> m_local_storage_model;
-    RefPtr<GUI::SortingProxyModel> m_local_storage_sorting_model;
+    RefPtr<GUI::FilteringProxyModel> m_local_storage_filtering_model;
 };
 
 }


### PR DESCRIPTION
This PR adds option to filter cookies and local storage entries in Storage Inspector window.

Requires https://github.com/SerenityOS/serenity/pull/13934 to render column names properly