### PR TITLE
LibJS: Convert Console to use MarkedVector<Value>

### DIFF
--- a/Userland/Libraries/LibJS/Console.h
+++ b/Userland/Libraries/LibJS/Console.h
@@ -61,7 +61,7 @@ public:
     GlobalObject const& global_object() const { return m_global_object; }
 
     VM& vm();
-    Vector<Value> vm_arguments();
+    MarkedVector<Value> vm_arguments();
 
     HashMap<String, unsigned>& counters() { return m_counters; }
     HashMap<String, unsigned> const& counters() const { return m_counters; }
@@ -86,7 +86,7 @@ public:
     void output_debug_message(LogLevel log_level, String output) const;
 
 private:
-    ThrowCompletionOr<String> value_vector_to_string(Vector<Value>&);
+    ThrowCompletionOr<String> value_vector_to_string(MarkedVector<Value> const&);
     ThrowCompletionOr<String> format_time_since(Core::ElapsedTimer timer);
 
     GlobalObject& m_global_object;
@@ -104,10 +104,10 @@ public:
     {
     }
 
-    using PrinterArguments = Variant<Console::Group, Console::Trace, Vector<Value>>;
+    using PrinterArguments = Variant<Console::Group, Console::Trace, MarkedVector<Value>>;
 
-    ThrowCompletionOr<Value> logger(Console::LogLevel log_level, Vector<Value>& args);
-    ThrowCompletionOr<Vector<Value>> formatter(Vector<Value>& args);
+    ThrowCompletionOr<Value> logger(Console::LogLevel log_level, MarkedVector<Value> const& args);
+    ThrowCompletionOr<MarkedVector<Value>> formatter(MarkedVector<Value> const& args);
     virtual ThrowCompletionOr<Value> printer(Console::LogLevel log_level, PrinterArguments) = 0;
 
     virtual void clear() = 0;

--- a/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp
+++ b/Userland/Libraries/LibWeb/HTML/WorkerDebugConsoleClient.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibJS/Heap/MarkedVector.h>
 #include <LibJS/Runtime/Completion.h>
 #include <LibWeb/HTML/WorkerDebugConsoleClient.h>
 
@@ -52,7 +53,7 @@ JS::ThrowCompletionOr<JS::Value> WorkerDebugConsoleClient::printer(JS::Console::
         return JS::js_undefined();
     }
 
-    auto output = String::join(" ", arguments.get<Vector<JS::Value>>());
+    auto output = String::join(" ", arguments.get<JS::MarkedVector<JS::Value>>());
     m_console.output_debug_message(log_level, output);
 
     switch (log_level) {

--- a/Userland/Services/WebContent/WebContentConsoleClient.cpp
+++ b/Userland/Services/WebContent/WebContentConsoleClient.cpp
@@ -162,7 +162,7 @@ JS::ThrowCompletionOr<JS::Value> WebContentConsoleClient::printer(JS::Console::L
         return JS::js_undefined();
     }
 
-    auto output = String::join(" ", arguments.get<Vector<JS::Value>>());
+    auto output = String::join(" ", arguments.get<JS::MarkedVector<JS::Value>>());
     m_console.output_debug_message(log_level, output);
 
     StringBuilder html;

--- a/Userland/Utilities/js.cpp
+++ b/Userland/Utilities/js.cpp
@@ -1374,7 +1374,7 @@ public:
             return JS::js_undefined();
         }
 
-        auto output = String::join(" ", arguments.get<Vector<JS::Value>>());
+        auto output = String::join(" ", arguments.get<JS::MarkedVector<JS::Value>>());
         m_console.output_debug_message(log_level, output);
 
         switch (log_level) {


### PR DESCRIPTION
Using a Vector<Value> is unsafe as GC cannot see the stored values.
This is then vended to outside users of ConsoleClient, e.g. LibWeb and
WebContent, which is then outside of LibJS's control.

An example issue is if the client stores it for later use and forgets
to visit the stored values, meaning they can be destroyed at any time.
We can save the client from this by vending a MarkedVector<Value> to
them.