### PR TITLE
Kernel: Fix flushing double buffers with DisplayConnectors

### DIFF
--- a/Kernel/API/FB.h
+++ b/Kernel/API/FB.h
@@ -72,9 +72,11 @@ ALWAYS_INLINE int fb_flush_buffers(int fd, int index, FBRect const* rects, unsig
     return ioctl(fd, GRAPHICS_IOCTL_FLUSH_HEAD_BUFFERS, &fb_flush_rects);
 }
 
-ALWAYS_INLINE int fb_flush_head(int fd)
+ALWAYS_INLINE int fb_flush_head(int fd, int index)
 {
-    return ioctl(fd, GRAPHICS_IOCTL_FLUSH_HEAD, nullptr);
+    FBFlush fb_flush;
+    fb_flush.buffer_index = index;
+    return ioctl(fd, GRAPHICS_IOCTL_FLUSH_HEAD, &fb_flush);
 }
 
 __END_DECLS

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -182,6 +182,7 @@ set(KERNEL_SOURCES
     Memory/RingBuffer.cpp
     Memory/ScatterGatherList.cpp
     Memory/ScopedAddressSpaceSwitcher.cpp
+    Memory/SharedFramebufferVMObject.cpp
     Memory/SharedInodeVMObject.cpp
     Memory/VMObject.cpp
     Memory/VirtualRange.cpp

--- a/Kernel/Forward.h
+++ b/Kernel/Forward.h
@@ -25,6 +25,7 @@ class DiskCache;
 class DoubleBuffer;
 class File;
 class OpenFileDescription;
+class DisplayConnector;
 class FileSystem;
 class FutexQueue;
 class IPv4Socket;

--- a/Kernel/Graphics/Bochs/DisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/DisplayConnector.cpp
@@ -68,7 +68,7 @@ void BochsDisplayConnector::disable_console()
     m_framebuffer_console->disable();
 }
 
-ErrorOr<void> BochsDisplayConnector::flush_first_surface()
+ErrorOr<void> BochsDisplayConnector::flush_surface(size_t)
 {
     return Error::from_errno(ENOTSUP);
 }

--- a/Kernel/Graphics/Bochs/DisplayConnector.h
+++ b/Kernel/Graphics/Bochs/DisplayConnector.h
@@ -24,14 +24,14 @@ class BochsDisplayConnector
 public:
     TYPEDEF_DISTINCT_ORDERED_ID(u16, IndexID);
 
-    static NonnullRefPtr<BochsDisplayConnector> must_create(PhysicalAddress framebuffer_address);
+    static NonnullRefPtr<BochsDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
 
     virtual IndexID index_id() const;
 
 protected:
     ErrorOr<void> create_attached_framebuffer_console();
 
-    explicit BochsDisplayConnector(PhysicalAddress framebuffer_address);
+    BochsDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
 
     virtual bool mutable_mode_setting_capable() const override final { return true; }
     virtual bool double_framebuffering_capable() const override { return false; }
@@ -45,15 +45,11 @@ protected:
     // Note: Paravirtualized hardware doesn't require a defined refresh rate for modesetting.
     virtual bool refresh_rate_support() const override final { return false; }
 
-    virtual ErrorOr<size_t> write_to_first_surface(u64 offset, UserOrKernelBuffer const&, size_t length) override final;
     virtual ErrorOr<void> flush_first_surface() override final;
 
     virtual void enable_console() override final;
     virtual void disable_console() override final;
 
-    const PhysicalAddress m_framebuffer_address;
     RefPtr<Graphics::GenericFramebufferConsole> m_framebuffer_console;
-    OwnPtr<Memory::Region> m_framebuffer_region;
-    u8* m_framebuffer_data {};
 };
 }

--- a/Kernel/Graphics/Bochs/DisplayConnector.h
+++ b/Kernel/Graphics/Bochs/DisplayConnector.h
@@ -45,7 +45,7 @@ protected:
     // Note: Paravirtualized hardware doesn't require a defined refresh rate for modesetting.
     virtual bool refresh_rate_support() const override final { return false; }
 
-    virtual ErrorOr<void> flush_first_surface() override final;
+    virtual ErrorOr<void> flush_surface(size_t buffer_index) override final;
 
     virtual void enable_console() override final;
     virtual void disable_console() override final;

--- a/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/Bochs/GraphicsAdapter.cpp
@@ -43,13 +43,14 @@ UNMAP_AFTER_INIT ErrorOr<void> BochsGraphicsAdapter::initialize_adapter(PCI::Dev
     // Note: If we use VirtualBox graphics adapter (which is based on Bochs one), we need to use IO ports
     // Note: Bochs (the real bochs graphics adapter in the Bochs emulator) uses revision ID of 0x0
     // and doesn't support memory-mapped IO registers.
+    auto bar0_space_size = PCI::get_BAR_space_size(pci_device_identifier.address(), 0);
     if (pci_device_identifier.revision_id().value() == 0x0
         || (pci_device_identifier.hardware_id().vendor_id == 0x80ee && pci_device_identifier.hardware_id().device_id == 0xbeef)) {
-        m_display_connector = BochsDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0));
+        m_display_connector = BochsDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), bar0_space_size);
     } else {
         auto registers_mapping = TRY(Memory::map_typed_writable<BochsDisplayMMIORegisters volatile>(PhysicalAddress(PCI::get_BAR2(pci_device_identifier.address()) & 0xfffffff0)));
         VERIFY(registers_mapping.region);
-        m_display_connector = QEMUDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), move(registers_mapping));
+        m_display_connector = QEMUDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR0(pci_device_identifier.address()) & 0xfffffff0), bar0_space_size, move(registers_mapping));
     }
 
     // Note: According to Gerd Hoffmann - "The linux driver simply does

--- a/Kernel/Graphics/Bochs/QEMUDisplayConnector.cpp
+++ b/Kernel/Graphics/Bochs/QEMUDisplayConnector.cpp
@@ -12,9 +12,9 @@
 
 namespace Kernel {
 
-NonnullRefPtr<QEMUDisplayConnector> QEMUDisplayConnector::must_create(PhysicalAddress framebuffer_address, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
+NonnullRefPtr<QEMUDisplayConnector> QEMUDisplayConnector::must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
 {
-    auto device_or_error = DeviceManagement::try_create_device<QEMUDisplayConnector>(framebuffer_address, move(registers_mapping));
+    auto device_or_error = DeviceManagement::try_create_device<QEMUDisplayConnector>(framebuffer_address, framebuffer_resource_size, move(registers_mapping));
     VERIFY(!device_or_error.is_error());
     auto connector = device_or_error.release_value();
     MUST(connector->create_attached_framebuffer_console());
@@ -31,8 +31,8 @@ ErrorOr<void> QEMUDisplayConnector::fetch_and_initialize_edid()
     return {};
 }
 
-QEMUDisplayConnector::QEMUDisplayConnector(PhysicalAddress framebuffer_address, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
-    : BochsDisplayConnector(framebuffer_address)
+QEMUDisplayConnector::QEMUDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile> registers_mapping)
+    : BochsDisplayConnector(framebuffer_address, framebuffer_resource_size)
     , m_registers(move(registers_mapping))
 {
 }
@@ -111,10 +111,7 @@ ErrorOr<void> QEMUDisplayConnector::set_mode_setting(ModeSetting const& mode_set
     if ((u16)width != m_registers->bochs_regs.xres || (u16)height != m_registers->bochs_regs.yres) {
         return Error::from_errno(ENOTIMPL);
     }
-    auto rounded_size = TRY(Memory::page_round_up(width * sizeof(u32) * height * 2));
-    m_framebuffer_region = TRY(MM.allocate_kernel_region(m_framebuffer_address.page_base(), rounded_size, "Framebuffer"sv, Memory::Region::Access::ReadWrite));
-    [[maybe_unused]] auto result = m_framebuffer_region->set_write_combine(true);
-    m_framebuffer_data = m_framebuffer_region->vaddr().offset(m_framebuffer_address.offset_in_page()).as_ptr();
+
     m_framebuffer_console->set_resolution(width, height, width * sizeof(u32));
 
     DisplayConnector::ModeSetting mode_set {

--- a/Kernel/Graphics/Bochs/QEMUDisplayConnector.h
+++ b/Kernel/Graphics/Bochs/QEMUDisplayConnector.h
@@ -22,13 +22,13 @@ class QEMUDisplayConnector final
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<QEMUDisplayConnector> must_create(PhysicalAddress framebuffer_address, Memory::TypedMapping<BochsDisplayMMIORegisters volatile>);
+    static NonnullRefPtr<QEMUDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile>);
 
     virtual IndexID index_id() const override;
 
 private:
     ErrorOr<void> fetch_and_initialize_edid();
-    QEMUDisplayConnector(PhysicalAddress framebuffer_address, Memory::TypedMapping<BochsDisplayMMIORegisters volatile>);
+    QEMUDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, Memory::TypedMapping<BochsDisplayMMIORegisters volatile>);
 
     virtual bool double_framebuffering_capable() const override { return true; }
     virtual ErrorOr<void> set_mode_setting(ModeSetting const&) override;

--- a/Kernel/Graphics/DisplayConnector.cpp
+++ b/Kernel/Graphics/DisplayConnector.cpp
@@ -48,18 +48,10 @@ ErrorOr<size_t> DisplayConnector::read(OpenFileDescription&, u64, UserOrKernelBu
 {
     return Error::from_errno(ENOTIMPL);
 }
-ErrorOr<size_t> DisplayConnector::write(OpenFileDescription&, u64 offset, UserOrKernelBuffer const& framebuffer_data, size_t length)
+
+ErrorOr<size_t> DisplayConnector::write(OpenFileDescription&, u64, UserOrKernelBuffer const&, size_t)
 {
-    SpinlockLocker locker(m_control_lock);
-    // FIXME: We silently ignore the request if we are in console mode.
-    // WindowServer is not ready yet to handle errors such as EBUSY currently.
-    if (console_mode()) {
-        return length;
-    }
-    if (offset + length > m_framebuffer_region->size())
-        return Error::from_errno(EOVERFLOW);
-    TRY(framebuffer_data.read(m_framebuffer_data + offset, 0, length));
-    return length;
+    return Error::from_errno(ENOTIMPL);
 }
 
 void DisplayConnector::will_be_destroyed()

--- a/Kernel/Graphics/DisplayConnector.cpp
+++ b/Kernel/Graphics/DisplayConnector.cpp
@@ -370,6 +370,8 @@ ErrorOr<void> DisplayConnector::ioctl(OpenFileDescription&, unsigned request, Us
         // FIXME: We silently ignore the request if we are in console mode.
         // WindowServer is not ready yet to handle errors such as EBUSY currently.
         MutexLocker locker(m_flushing_lock);
+        auto user_flush = static_ptr_cast<FBFlush const*>(arg);
+        auto flush = TRY(copy_typed_from_user(user_flush));
         SpinlockLocker control_locker(m_control_lock);
         if (console_mode()) {
             return {};
@@ -378,7 +380,7 @@ ErrorOr<void> DisplayConnector::ioctl(OpenFileDescription&, unsigned request, Us
         if (!flush_support())
             return Error::from_errno(ENOTSUP);
 
-        TRY(flush_first_surface());
+        TRY(flush_surface(flush.buffer_index));
         return {};
     }
     }

--- a/Kernel/Graphics/DisplayConnector.h
+++ b/Kernel/Graphics/DisplayConnector.h
@@ -119,7 +119,7 @@ protected:
     DisplayConnector(size_t framebuffer_resource_size, bool enable_write_combine_optimization);
     virtual void enable_console() = 0;
     virtual void disable_console() = 0;
-    virtual ErrorOr<void> flush_first_surface() = 0;
+    virtual ErrorOr<void> flush_surface(size_t buffer_index) = 0;
     virtual ErrorOr<void> flush_rectangle(size_t buffer_index, FBRect const& rect);
 
     ErrorOr<void> initialize_edid_for_generic_monitor();

--- a/Kernel/Graphics/Intel/NativeDisplayConnector.cpp
+++ b/Kernel/Graphics/Intel/NativeDisplayConnector.cpp
@@ -222,7 +222,7 @@ void IntelNativeDisplayConnector::disable_console()
     m_framebuffer_console->disable();
 }
 
-ErrorOr<void> IntelNativeDisplayConnector::flush_first_surface()
+ErrorOr<void> IntelNativeDisplayConnector::flush_surface(size_t)
 {
     return Error::from_errno(ENOTSUP);
 }

--- a/Kernel/Graphics/Intel/NativeDisplayConnector.h
+++ b/Kernel/Graphics/Intel/NativeDisplayConnector.h
@@ -81,7 +81,7 @@ class IntelNativeDisplayConnector final
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<IntelNativeDisplayConnector> must_create(PhysicalAddress framebuffer_address, PhysicalAddress registers_region_address, size_t registers_region_length);
+    static NonnullRefPtr<IntelNativeDisplayConnector> must_create(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, PhysicalAddress registers_region_address, size_t registers_region_length);
 
 private:
     // ^DisplayConnector
@@ -93,7 +93,6 @@ private:
     virtual ErrorOr<void> set_safe_mode_setting() override;
     virtual ErrorOr<void> set_y_offset(size_t y) override;
     virtual ErrorOr<void> unblank() override;
-    virtual ErrorOr<size_t> write_to_first_surface(u64 offset, UserOrKernelBuffer const&, size_t length) override final;
     virtual ErrorOr<void> flush_first_surface() override final;
     virtual void enable_console() override;
     virtual void disable_console() override;
@@ -104,7 +103,7 @@ private:
 
     ErrorOr<void> initialize_gmbus_settings_and_read_edid();
 
-    IntelNativeDisplayConnector(PhysicalAddress framebuffer_address, NonnullOwnPtr<Memory::Region> registers_region);
+    IntelNativeDisplayConnector(PhysicalAddress framebuffer_address, size_t framebuffer_resource_size, NonnullOwnPtr<Memory::Region> registers_region);
 
     ErrorOr<void> create_attached_framebuffer_console();
 
@@ -156,10 +155,7 @@ private:
     Optional<IntelGraphics::PLLSettings> create_pll_settings(u64 target_frequency, u64 reference_clock, IntelGraphics::PLLMaxSettings const&);
 
     mutable Spinlock m_registers_lock;
-    const PhysicalAddress m_framebuffer_address;
     RefPtr<Graphics::GenericFramebufferConsole> m_framebuffer_console;
-    OwnPtr<Memory::Region> m_framebuffer_region;
-    u8* m_framebuffer_data {};
 
     const PhysicalAddress m_registers;
     NonnullOwnPtr<Memory::Region> m_registers_region;

--- a/Kernel/Graphics/Intel/NativeDisplayConnector.h
+++ b/Kernel/Graphics/Intel/NativeDisplayConnector.h
@@ -93,7 +93,7 @@ private:
     virtual ErrorOr<void> set_safe_mode_setting() override;
     virtual ErrorOr<void> set_y_offset(size_t y) override;
     virtual ErrorOr<void> unblank() override;
-    virtual ErrorOr<void> flush_first_surface() override final;
+    virtual ErrorOr<void> flush_surface(size_t buffer_index) override final;
     virtual void enable_console() override;
     virtual void disable_console() override;
     virtual bool partial_flush_support() const override { return false; }

--- a/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
+++ b/Kernel/Graphics/Intel/NativeGraphicsAdapter.cpp
@@ -43,11 +43,12 @@ ErrorOr<void> IntelNativeGraphicsAdapter::initialize_adapter()
     dbgln_if(INTEL_GRAPHICS_DEBUG, "Intel Native Graphics Adapter @ {}", address);
     auto bar0_space_size = PCI::get_BAR_space_size(address, 0);
     VERIFY(bar0_space_size == 0x80000);
+    auto bar2_space_size = PCI::get_BAR_space_size(address, 2);
     dmesgln("Intel Native Graphics Adapter @ {}, MMIO @ {}, space size is {:x} bytes", address, PhysicalAddress(PCI::get_BAR0(address)), bar0_space_size);
     dmesgln("Intel Native Graphics Adapter @ {}, framebuffer @ {}", address, PhysicalAddress(PCI::get_BAR2(address)));
     PCI::enable_bus_mastering(address);
 
-    m_display_connector = IntelNativeDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR2(address) & 0xfffffff0), PhysicalAddress(PCI::get_BAR0(address) & 0xfffffff0), bar0_space_size);
+    m_display_connector = IntelNativeDisplayConnector::must_create(PhysicalAddress(PCI::get_BAR2(address) & 0xfffffff0), bar2_space_size, PhysicalAddress(PCI::get_BAR0(address) & 0xfffffff0), bar0_space_size);
     return {};
 }
 

--- a/Kernel/Graphics/VGA/DisplayConnector.cpp
+++ b/Kernel/Graphics/VGA/DisplayConnector.cpp
@@ -56,7 +56,7 @@ void GenericDisplayConnector::disable_console()
     m_framebuffer_console->disable();
 }
 
-ErrorOr<void> GenericDisplayConnector::flush_first_surface()
+ErrorOr<void> GenericDisplayConnector::flush_surface(size_t)
 {
     return Error::from_errno(ENOTSUP);
 }

--- a/Kernel/Graphics/VGA/DisplayConnector.h
+++ b/Kernel/Graphics/VGA/DisplayConnector.h
@@ -39,15 +39,11 @@ protected:
     // Note: This is possibly a paravirtualized hardware, but since we don't know, we assume there's no refresh rate...
     virtual bool refresh_rate_support() const override final { return false; }
 
-    virtual ErrorOr<size_t> write_to_first_surface(u64 offset, UserOrKernelBuffer const&, size_t length) override final;
     virtual ErrorOr<void> flush_first_surface() override final;
 
     virtual void enable_console() override final;
     virtual void disable_console() override final;
 
-    const PhysicalAddress m_framebuffer_address;
     RefPtr<Graphics::GenericFramebufferConsole> m_framebuffer_console;
-    OwnPtr<Memory::Region> m_framebuffer_region;
-    u8* m_framebuffer_data {};
 };
 }

--- a/Kernel/Graphics/VGA/DisplayConnector.h
+++ b/Kernel/Graphics/VGA/DisplayConnector.h
@@ -39,7 +39,7 @@ protected:
     // Note: This is possibly a paravirtualized hardware, but since we don't know, we assume there's no refresh rate...
     virtual bool refresh_rate_support() const override final { return false; }
 
-    virtual ErrorOr<void> flush_first_surface() override final;
+    virtual ErrorOr<void> flush_surface(size_t buffer_index) override final;
 
     virtual void enable_console() override final;
     virtual void disable_console() override final;

--- a/Kernel/Graphics/VMWare/Console.cpp
+++ b/Kernel/Graphics/VMWare/Console.cpp
@@ -43,7 +43,7 @@ void VMWareFramebufferConsole::enqueue_refresh_timer()
     refresh_timer->setup(CLOCK_MONOTONIC, refresh_interval, [this]() {
         if (m_enabled.load() && m_dirty) {
             MUST(g_io_work->try_queue([this]() {
-                MUST(m_parent_display_connector->flush_first_surface());
+                MUST(m_parent_display_connector->flush_surface(0));
                 m_dirty = false;
             }));
         }

--- a/Kernel/Graphics/VMWare/DisplayConnector.cpp
+++ b/Kernel/Graphics/VMWare/DisplayConnector.cpp
@@ -72,7 +72,7 @@ void VMWareDisplayConnector::disable_console()
     m_framebuffer_console->disable();
 }
 
-ErrorOr<void> VMWareDisplayConnector::flush_first_surface()
+ErrorOr<void> VMWareDisplayConnector::flush_surface(size_t)
 {
     // FIXME: Cache these values but keep them in sync with the parent adapter.
     auto width = m_parent_adapter->primary_screen_width({});

--- a/Kernel/Graphics/VMWare/DisplayConnector.h
+++ b/Kernel/Graphics/VMWare/DisplayConnector.h
@@ -23,10 +23,10 @@ class VMWareDisplayConnector : public DisplayConnector {
     friend class DeviceManagement;
 
 public:
-    static NonnullRefPtr<VMWareDisplayConnector> must_create(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address);
+    static NonnullRefPtr<VMWareDisplayConnector> must_create(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
 
 private:
-    VMWareDisplayConnector(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address);
+    VMWareDisplayConnector(VMWareGraphicsAdapter const& parent_adapter, PhysicalAddress framebuffer_address, size_t framebuffer_resource_size);
     ErrorOr<void> create_attached_framebuffer_console();
 
     virtual bool mutable_mode_setting_capable() const override { return true; }
@@ -41,7 +41,6 @@ private:
     // Note: Paravirtualized hardware doesn't require a defined refresh rate for modesetting.
     virtual bool refresh_rate_support() const override { return false; }
 
-    virtual ErrorOr<size_t> write_to_first_surface(u64 offset, UserOrKernelBuffer const&, size_t length) override;
     virtual ErrorOr<void> flush_first_surface() override;
     virtual ErrorOr<void> flush_rectangle(size_t buffer_index, FBRect const& rect) override;
 
@@ -49,12 +48,7 @@ private:
     virtual void disable_console() override;
 
 private:
-    u8* framebuffer_data() { return m_framebuffer_data; }
-
-    const PhysicalAddress m_framebuffer_address;
     NonnullRefPtr<VMWareGraphicsAdapter> m_parent_adapter;
     RefPtr<VMWareFramebufferConsole> m_framebuffer_console;
-    OwnPtr<Memory::Region> m_framebuffer_region;
-    u8* m_framebuffer_data {};
 };
 }

--- a/Kernel/Graphics/VMWare/DisplayConnector.h
+++ b/Kernel/Graphics/VMWare/DisplayConnector.h
@@ -41,7 +41,7 @@ private:
     // Note: Paravirtualized hardware doesn't require a defined refresh rate for modesetting.
     virtual bool refresh_rate_support() const override { return false; }
 
-    virtual ErrorOr<void> flush_first_surface() override;
+    virtual ErrorOr<void> flush_surface(size_t buffer_index) override;
     virtual ErrorOr<void> flush_rectangle(size_t buffer_index, FBRect const& rect) override;
 
     virtual void enable_console() override;

--- a/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
+++ b/Kernel/Graphics/VMWare/GraphicsAdapter.cpp
@@ -181,7 +181,9 @@ UNMAP_AFTER_INIT ErrorOr<void> VMWareGraphicsAdapter::initialize_adapter()
     // Note: enable the device by modesetting the primary screen resolution
     modeset_primary_screen_resolution(640, 480);
 
-    m_display_connector = VMWareDisplayConnector::must_create(*this, PhysicalAddress(PCI::get_BAR1(pci_address()) & 0xfffffff0));
+    auto bar1_space_size = PCI::get_BAR_space_size(pci_address(), 1);
+
+    m_display_connector = VMWareDisplayConnector::must_create(*this, PhysicalAddress(PCI::get_BAR1(pci_address()) & 0xfffffff0), bar1_space_size);
     TRY(m_display_connector->set_safe_mode_setting());
     return {};
 }

--- a/Kernel/Graphics/VirtIOGPU/Console.cpp
+++ b/Kernel/Graphics/VirtIOGPU/Console.cpp
@@ -11,24 +11,6 @@ namespace Kernel::Graphics::VirtIOGPU {
 
 constexpr static AK::Time refresh_interval = AK::Time::from_milliseconds(16);
 
-void DirtyRect::union_rect(size_t x, size_t y, size_t width, size_t height)
-{
-    if (width == 0 || height == 0)
-        return;
-    if (m_is_dirty) {
-        m_x0 = min(x, m_x0);
-        m_y0 = min(y, m_y0);
-        m_x1 = max(x + width, m_x1);
-        m_y1 = max(y + height, m_y1);
-    } else {
-        m_is_dirty = true;
-        m_x0 = x;
-        m_y0 = y;
-        m_x1 = x + width;
-        m_y1 = y + height;
-    }
-}
-
 NonnullRefPtr<Console> Console::initialize(VirtIODisplayConnector& parent_display_connector)
 {
     auto current_resolution = parent_display_connector.current_mode_setting();
@@ -47,23 +29,22 @@ void Console::set_resolution(size_t, size_t, size_t)
     // FIXME: Update some values here?
 }
 
-void Console::flush(size_t x, size_t y, size_t width, size_t height)
+void Console::flush(size_t, size_t, size_t, size_t)
 {
-    m_dirty_rect.union_rect(x, y, width, height);
+    m_dirty = true;
 }
 
 void Console::enqueue_refresh_timer()
 {
     NonnullRefPtr<Timer> refresh_timer = adopt_ref(*new Timer());
     refresh_timer->setup(CLOCK_MONOTONIC, refresh_interval, [this]() {
-        auto rect = m_dirty_rect;
-        if (m_enabled.load() && rect.is_dirty()) {
+        if (m_enabled.load() && m_dirty) {
             MUST(g_io_work->try_queue([this]() {
                 {
                     MutexLocker locker(m_parent_display_connector->m_flushing_lock);
                     MUST(m_parent_display_connector->flush_first_surface());
                 }
-                m_dirty_rect.clear();
+                m_dirty = false;
             }));
         }
         enqueue_refresh_timer();
@@ -78,7 +59,7 @@ void Console::enable()
     m_width = current_resolution.horizontal_active;
     m_height = current_resolution.vertical_active;
     m_pitch = current_resolution.horizontal_stride;
-    m_dirty_rect.union_rect(0, 0, m_width, m_height);
+    m_dirty = true;
 }
 
 u8* Console::framebuffer_data()

--- a/Kernel/Graphics/VirtIOGPU/Console.cpp
+++ b/Kernel/Graphics/VirtIOGPU/Console.cpp
@@ -42,7 +42,7 @@ void Console::enqueue_refresh_timer()
             MUST(g_io_work->try_queue([this]() {
                 {
                     MutexLocker locker(m_parent_display_connector->m_flushing_lock);
-                    MUST(m_parent_display_connector->flush_first_surface());
+                    MUST(m_parent_display_connector->flush_surface(0));
                 }
                 m_dirty = false;
             }));

--- a/Kernel/Graphics/VirtIOGPU/Console.h
+++ b/Kernel/Graphics/VirtIOGPU/Console.h
@@ -12,24 +12,6 @@
 
 namespace Kernel::Graphics::VirtIOGPU {
 
-class DirtyRect {
-public:
-    void union_rect(size_t x, size_t y, size_t width, size_t height);
-    bool is_dirty() const { return m_is_dirty; }
-    size_t x() const { return m_x0; }
-    size_t y() const { return m_y0; }
-    size_t width() const { return m_x1 - m_x0; }
-    size_t height() const { return m_y1 - m_y0; }
-    void clear() { m_is_dirty = false; }
-
-private:
-    bool m_is_dirty { false };
-    size_t m_x0 { 0 };
-    size_t m_y0 { 0 };
-    size_t m_x1 { 0 };
-    size_t m_y1 { 0 };
-};
-
 class Console final : public GenericFramebufferConsole {
 public:
     static NonnullRefPtr<Console> initialize(VirtIODisplayConnector& parent_display_connector);
@@ -44,7 +26,7 @@ private:
 
     Console(VirtIODisplayConnector const& parent_display_connector, DisplayConnector::ModeSetting current_resolution);
     NonnullRefPtr<VirtIODisplayConnector> m_parent_display_connector;
-    DirtyRect m_dirty_rect;
+    bool m_dirty { false };
 };
 
 }

--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
@@ -29,20 +29,15 @@ class VirtIODisplayConnector final : public DisplayConnector {
     friend class Graphics::VirtIOGPU::Console;
     friend class DeviceManagement;
 
-private:
-    struct Buffer {
-        size_t framebuffer_offset { 0 };
-        u8* framebuffer_data { nullptr };
-        Graphics::VirtIOGPU::Protocol::Rect dirty_rect {};
-        Graphics::VirtIOGPU::ResourceID resource_id { 0 };
-    };
-
 public:
     static NonnullRefPtr<VirtIODisplayConnector> must_create(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id);
 
     void set_edid_bytes(Badge<VirtIOGraphicsAdapter>, Array<u8, 128> const& edid_bytes);
     void set_safe_mode_setting_after_initialization(Badge<VirtIOGraphicsAdapter>);
-    Graphics::VirtIOGPU::Protocol::DisplayInfoResponse::Display display_information(Badge<VirtIOGraphicsAdapter>);
+    Graphics::VirtIOGPU::ScanoutID scanout_id() const { return m_scanout_id; }
+    Graphics::VirtIOGPU::Protocol::DisplayInfoResponse::Display display_information(Badge<VirtIOGraphicsAdapter>) const;
+
+    void draw_ntsc_test_pattern(Badge<VirtIOGraphicsAdapter>);
 
 private:
     void initialize_console();
@@ -59,45 +54,28 @@ private:
     // Note: Paravirtualized hardware doesn't require a defined refresh rate for modesetting.
     virtual bool refresh_rate_support() const override { return false; }
 
-    virtual ErrorOr<size_t> write_to_first_surface(u64 offset, UserOrKernelBuffer const&, size_t length) override;
     virtual ErrorOr<void> flush_first_surface() override;
     virtual ErrorOr<void> flush_rectangle(size_t buffer_index, FBRect const& rect) override;
 
     virtual void enable_console() override;
     virtual void disable_console() override;
 
+    static bool is_valid_buffer_index(size_t buffer_index)
+    {
+        return buffer_index == 0 || buffer_index == 1;
+    }
+
 private:
     VirtIODisplayConnector(VirtIOGraphicsAdapter& graphics_adapter, Graphics::VirtIOGPU::ScanoutID scanout_id);
+
+    void flush_displayed_image(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
+    void set_dirty_displayed_rect(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
 
     void query_display_information();
     ErrorOr<void> query_edid_from_virtio_adapter();
     void query_display_edid();
 
-    void flush_dirty_window(Graphics::VirtIOGPU::Protocol::Rect const&, Buffer&);
-    void transfer_framebuffer_data_to_host(Graphics::VirtIOGPU::Protocol::Rect const&, Buffer&);
-    void flush_displayed_image(Graphics::VirtIOGPU::Protocol::Rect const&, Buffer&);
-
-    // Basic 2D framebuffer methods
-    static size_t calculate_framebuffer_size(size_t width, size_t height)
-    {
-        // VirtIO resources can only map on page boundaries!
-        return Memory::page_round_up(sizeof(u32) * width * height).value();
-    }
-    u8* framebuffer_data();
-    void draw_ntsc_test_pattern(Buffer&);
-    void clear_to_black(Buffer&);
-    ErrorOr<void> create_framebuffer();
-    void create_buffer(Buffer&, size_t, size_t);
-    void set_buffer(int);
-    static bool is_valid_buffer_index(int buffer_index)
-    {
-        return buffer_index == 0 || buffer_index == 1;
-    }
-    Buffer& buffer_from_index(int buffer_index)
-    {
-        return buffer_index == 0 ? m_main_buffer : m_back_buffer;
-    }
-    Buffer& current_buffer() const { return *m_current_buffer; }
+    void clear_to_black();
 
     // Member data
     // Context used for kernel operations (e.g. flushing resources to scanout)
@@ -109,13 +87,7 @@ private:
     Graphics::VirtIOGPU::ScanoutID m_scanout_id;
 
     // 2D framebuffer Member data
-    size_t m_buffer_size { 0 };
-    Buffer* m_current_buffer { nullptr };
-    Atomic<int, AK::memory_order_relaxed> m_last_set_buffer_index { 0 };
-    Buffer m_main_buffer;
-    Buffer m_back_buffer;
-    OwnPtr<Memory::Region> m_framebuffer;
-    RefPtr<Memory::VMObject> m_framebuffer_sink_vmobject;
+    Atomic<size_t, AK::memory_order_relaxed> m_last_set_buffer_index { 0 };
 
     constexpr static size_t NUM_TRANSFER_REGION_PAGES = 256;
 };

--- a/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
+++ b/Kernel/Graphics/VirtIOGPU/DisplayConnector.h
@@ -54,7 +54,7 @@ private:
     // Note: Paravirtualized hardware doesn't require a defined refresh rate for modesetting.
     virtual bool refresh_rate_support() const override { return false; }
 
-    virtual ErrorOr<void> flush_first_surface() override;
+    virtual ErrorOr<void> flush_surface(size_t buffer_index) override;
     virtual ErrorOr<void> flush_rectangle(size_t buffer_index, FBRect const& rect) override;
 
     virtual void enable_console() override;
@@ -70,6 +70,7 @@ private:
 
     void flush_displayed_image(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
     void set_dirty_displayed_rect(Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
+    Graphics::VirtIOGPU::Protocol::Rect const& dirty_displayed_rect(bool main_buffer);
 
     void query_display_information();
     ErrorOr<void> query_edid_from_virtio_adapter();
@@ -87,7 +88,7 @@ private:
     Graphics::VirtIOGPU::ScanoutID m_scanout_id;
 
     // 2D framebuffer Member data
-    Atomic<size_t, AK::memory_order_relaxed> m_last_set_buffer_index { 0 };
+    size_t m_last_set_buffer_index { 0 };
 
     constexpr static size_t NUM_TRANSFER_REGION_PAGES = 256;
 };

--- a/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
+++ b/Kernel/Graphics/VirtIOGPU/GraphicsAdapter.h
@@ -52,8 +52,10 @@ public:
 
     ErrorOr<void> mode_set_resolution(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, size_t width, size_t height);
     void set_dirty_displayed_rect(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
+    Graphics::VirtIOGPU::Protocol::Rect const& dirty_displayed_rect(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, bool main_buffer);
     void flush_displayed_image(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& dirty_rect, bool main_buffer);
     void transfer_framebuffer_data_to_host(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, Graphics::VirtIOGPU::Protocol::Rect const& rect, bool main_buffer);
+    void set_scanout_buffer(Badge<VirtIODisplayConnector>, VirtIODisplayConnector&, bool main_buffer);
 
 private:
     ErrorOr<void> attach_physical_range_to_framebuffer(VirtIODisplayConnector& connector, bool main_buffer, size_t framebuffer_offset, size_t framebuffer_size);

--- a/Kernel/Memory/SharedFramebufferVMObject.cpp
+++ b/Kernel/Memory/SharedFramebufferVMObject.cpp
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <Kernel/FileSystem/Inode.h>
+#include <Kernel/Locking/Spinlock.h>
+#include <Kernel/Memory/SharedFramebufferVMObject.h>
+
+namespace Kernel::Memory {
+
+ErrorOr<NonnullRefPtr<SharedFramebufferVMObject>> SharedFramebufferVMObject::try_create_for_physical_range(PhysicalAddress paddr, size_t size)
+{
+    auto real_framebuffer_vmobject = TRY(AnonymousVMObject::try_create_for_physical_range(paddr, size));
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
+    auto committed_pages = TRY(MM.commit_user_physical_pages(ceil_div(size, static_cast<size_t>(PAGE_SIZE))));
+    auto vm_object = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SharedFramebufferVMObject(move(new_physical_pages), move(committed_pages), real_framebuffer_vmobject)));
+    TRY(vm_object->create_fake_writes_framebuffer_vm_object());
+    TRY(vm_object->create_real_writes_framebuffer_vm_object());
+    return vm_object;
+}
+
+ErrorOr<NonnullRefPtr<SharedFramebufferVMObject>> SharedFramebufferVMObject::try_create_at_arbitrary_physical_range(size_t size)
+{
+    auto real_framebuffer_vmobject = TRY(AnonymousVMObject::try_create_with_size(size, AllocationStrategy::AllocateNow));
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(size));
+    auto committed_pages = TRY(MM.commit_user_physical_pages(ceil_div(size, static_cast<size_t>(PAGE_SIZE))));
+    auto vm_object = TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SharedFramebufferVMObject(move(new_physical_pages), move(committed_pages), real_framebuffer_vmobject)));
+    TRY(vm_object->create_fake_writes_framebuffer_vm_object());
+    TRY(vm_object->create_real_writes_framebuffer_vm_object());
+    return vm_object;
+}
+
+ErrorOr<NonnullRefPtr<SharedFramebufferVMObject::FakeWritesFramebufferVMObject>> SharedFramebufferVMObject::FakeWritesFramebufferVMObject::try_create(Badge<SharedFramebufferVMObject>, SharedFramebufferVMObject const& parent_object)
+{
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(0));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) FakeWritesFramebufferVMObject(parent_object, move(new_physical_pages)));
+}
+
+ErrorOr<NonnullRefPtr<SharedFramebufferVMObject::RealWritesFramebufferVMObject>> SharedFramebufferVMObject::RealWritesFramebufferVMObject::try_create(Badge<SharedFramebufferVMObject>, SharedFramebufferVMObject const& parent_object)
+{
+    auto new_physical_pages = TRY(VMObject::try_create_physical_pages(0));
+    return adopt_nonnull_ref_or_enomem(new (nothrow) RealWritesFramebufferVMObject(parent_object, move(new_physical_pages)));
+}
+
+ErrorOr<void> SharedFramebufferVMObject::create_fake_writes_framebuffer_vm_object()
+{
+    m_fake_writes_framebuffer_vmobject = TRY(FakeWritesFramebufferVMObject::try_create({}, *this));
+    return {};
+}
+
+ErrorOr<void> SharedFramebufferVMObject::create_real_writes_framebuffer_vm_object()
+{
+    m_real_writes_framebuffer_vmobject = TRY(RealWritesFramebufferVMObject::try_create({}, *this));
+    return {};
+}
+
+Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::real_framebuffer_physical_pages()
+{
+    return m_real_framebuffer_vmobject->physical_pages();
+}
+Span<RefPtr<PhysicalPage> const> SharedFramebufferVMObject::real_framebuffer_physical_pages() const
+{
+    return m_real_framebuffer_vmobject->physical_pages();
+}
+
+Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::fake_sink_framebuffer_physical_pages()
+{
+    return m_physical_pages.span();
+}
+
+Span<RefPtr<PhysicalPage> const> SharedFramebufferVMObject::fake_sink_framebuffer_physical_pages() const
+{
+    return m_physical_pages.span();
+}
+
+void SharedFramebufferVMObject::switch_to_fake_sink_framebuffer_writes(Badge<Kernel::DisplayConnector>)
+{
+    SpinlockLocker locker(m_writes_state_lock);
+    m_writes_are_faked = true;
+    for_each_region([](Region& region) {
+        region.remap();
+    });
+}
+void SharedFramebufferVMObject::switch_to_real_framebuffer_writes(Badge<Kernel::DisplayConnector>)
+{
+    SpinlockLocker locker(m_writes_state_lock);
+    m_writes_are_faked = false;
+    for_each_region([](Region& region) {
+        region.remap();
+    });
+}
+
+Span<RefPtr<PhysicalPage> const> SharedFramebufferVMObject::physical_pages() const
+{
+    SpinlockLocker locker(m_writes_state_lock);
+    if (m_writes_are_faked) {
+        return VMObject::physical_pages();
+    }
+    return m_real_framebuffer_vmobject->physical_pages();
+}
+Span<RefPtr<PhysicalPage>> SharedFramebufferVMObject::physical_pages()
+{
+    SpinlockLocker locker(m_writes_state_lock);
+    if (m_writes_are_faked) {
+        return VMObject::physical_pages();
+    }
+    return m_real_framebuffer_vmobject->physical_pages();
+}
+
+SharedFramebufferVMObject::SharedFramebufferVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, CommittedPhysicalPageSet committed_pages, AnonymousVMObject& real_framebuffer_vmobject)
+    : VMObject(move(new_physical_pages))
+    , m_real_framebuffer_vmobject(real_framebuffer_vmobject)
+    , m_committed_pages(move(committed_pages))
+{
+    // Allocate all pages right now. We know we can get all because we committed the amount needed
+    for (size_t i = 0; i < page_count(); ++i)
+        m_physical_pages[i] = m_committed_pages.take_one();
+}
+
+}

--- a/Kernel/Memory/SharedFramebufferVMObject.h
+++ b/Kernel/Memory/SharedFramebufferVMObject.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2022, Liav A. <liavalb@hotmail.co.il>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <Kernel/Forward.h>
+#include <Kernel/Memory/AllocationStrategy.h>
+#include <Kernel/Memory/AnonymousVMObject.h>
+#include <Kernel/Memory/MemoryManager.h>
+#include <Kernel/Memory/PageFaultResponse.h>
+#include <Kernel/PhysicalAddress.h>
+
+namespace Kernel::Memory {
+
+class SharedFramebufferVMObject final : public VMObject {
+public:
+    class FakeWritesFramebufferVMObject final : public VMObject {
+    public:
+        static ErrorOr<NonnullRefPtr<FakeWritesFramebufferVMObject>> try_create(Badge<SharedFramebufferVMObject>, SharedFramebufferVMObject const& parent_object);
+
+    private:
+        FakeWritesFramebufferVMObject(SharedFramebufferVMObject const& parent_object, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+            : VMObject(move(new_physical_pages))
+            , m_parent_object(parent_object)
+        {
+        }
+        virtual StringView class_name() const override { return "FakeWritesFramebufferVMObject"sv; }
+        virtual ErrorOr<NonnullRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
+        virtual Span<RefPtr<PhysicalPage> const> physical_pages() const override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
+        virtual Span<RefPtr<PhysicalPage>> physical_pages() override { return m_parent_object->fake_sink_framebuffer_physical_pages(); }
+        NonnullRefPtr<SharedFramebufferVMObject> m_parent_object;
+    };
+
+    class RealWritesFramebufferVMObject final : public VMObject {
+    public:
+        static ErrorOr<NonnullRefPtr<RealWritesFramebufferVMObject>> try_create(Badge<SharedFramebufferVMObject>, SharedFramebufferVMObject const& parent_object);
+
+    private:
+        RealWritesFramebufferVMObject(SharedFramebufferVMObject const& parent_object, FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages)
+            : VMObject(move(new_physical_pages))
+            , m_parent_object(parent_object)
+        {
+        }
+        virtual StringView class_name() const override { return "RealWritesFramebufferVMObject"sv; }
+        virtual ErrorOr<NonnullRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
+        virtual Span<RefPtr<PhysicalPage> const> physical_pages() const override { return m_parent_object->real_framebuffer_physical_pages(); }
+        virtual Span<RefPtr<PhysicalPage>> physical_pages() override { return m_parent_object->real_framebuffer_physical_pages(); }
+        NonnullRefPtr<SharedFramebufferVMObject> m_parent_object;
+    };
+
+    virtual ~SharedFramebufferVMObject() override = default;
+
+    static ErrorOr<NonnullRefPtr<SharedFramebufferVMObject>> try_create_for_physical_range(PhysicalAddress paddr, size_t size);
+    static ErrorOr<NonnullRefPtr<SharedFramebufferVMObject>> try_create_at_arbitrary_physical_range(size_t size);
+    virtual ErrorOr<NonnullRefPtr<VMObject>> try_clone() override { return Error::from_errno(ENOTIMPL); }
+
+    void switch_to_fake_sink_framebuffer_writes(Badge<Kernel::DisplayConnector>);
+    void switch_to_real_framebuffer_writes(Badge<Kernel::DisplayConnector>);
+
+    virtual Span<RefPtr<PhysicalPage> const> physical_pages() const override;
+    virtual Span<RefPtr<PhysicalPage>> physical_pages() override;
+
+    Span<RefPtr<PhysicalPage>> fake_sink_framebuffer_physical_pages();
+    Span<RefPtr<PhysicalPage> const> fake_sink_framebuffer_physical_pages() const;
+
+    Span<RefPtr<PhysicalPage>> real_framebuffer_physical_pages();
+    Span<RefPtr<PhysicalPage> const> real_framebuffer_physical_pages() const;
+
+    FakeWritesFramebufferVMObject const& fake_writes_framebuffer_vmobject() const { return *m_fake_writes_framebuffer_vmobject; }
+    FakeWritesFramebufferVMObject& fake_writes_framebuffer_vmobject() { return *m_fake_writes_framebuffer_vmobject; }
+
+    RealWritesFramebufferVMObject const& real_writes_framebuffer_vmobject() const { return *m_real_writes_framebuffer_vmobject; }
+    RealWritesFramebufferVMObject& real_writes_framebuffer_vmobject() { return *m_real_writes_framebuffer_vmobject; }
+
+private:
+    SharedFramebufferVMObject(FixedArray<RefPtr<PhysicalPage>>&& new_physical_pages, CommittedPhysicalPageSet, AnonymousVMObject& real_framebuffer_vmobject);
+
+    virtual StringView class_name() const override { return "SharedFramebufferVMObject"sv; }
+
+    ErrorOr<void> create_fake_writes_framebuffer_vm_object();
+    ErrorOr<void> create_real_writes_framebuffer_vm_object();
+
+    NonnullRefPtr<AnonymousVMObject> m_real_framebuffer_vmobject;
+    RefPtr<FakeWritesFramebufferVMObject> m_fake_writes_framebuffer_vmobject;
+    RefPtr<RealWritesFramebufferVMObject> m_real_writes_framebuffer_vmobject;
+    bool m_writes_are_faked { false };
+    mutable RecursiveSpinlock m_writes_state_lock;
+    CommittedPhysicalPageSet m_committed_pages;
+};
+
+}

--- a/Kernel/Memory/VMObject.h
+++ b/Kernel/Memory/VMObject.h
@@ -34,8 +34,9 @@ public:
     virtual bool is_private_inode() const { return false; }
 
     size_t page_count() const { return m_physical_pages.size(); }
-    Span<RefPtr<PhysicalPage> const> physical_pages() const { return m_physical_pages.span(); }
-    Span<RefPtr<PhysicalPage>> physical_pages() { return m_physical_pages.span(); }
+
+    virtual Span<RefPtr<PhysicalPage> const> physical_pages() const { return m_physical_pages.span(); }
+    virtual Span<RefPtr<PhysicalPage>> physical_pages() { return m_physical_pages.span(); }
 
     size_t size() const { return m_physical_pages.size() * PAGE_SIZE; }
 

--- a/Kernel/TTY/ConsoleManagement.cpp
+++ b/Kernel/TTY/ConsoleManagement.cpp
@@ -84,9 +84,10 @@ void ConsoleManagement::switch_to(unsigned index)
     // if needed. This will ensure we clear the screen and also that WindowServer won't print anything
     // in between.
     if (m_active_console->is_graphical() && !was_graphical) {
+        m_active_console->set_active(true);
         GraphicsManagement::the().activate_graphical_mode();
-    }
-    if (!m_active_console->is_graphical() && was_graphical) {
+        return;
+    } else if (!m_active_console->is_graphical() && was_graphical) {
         GraphicsManagement::the().deactivate_graphical_mode();
     }
     m_active_console->set_active(true);

--- a/Userland/Libraries/LibC/sys/ioctl_numbers.h
+++ b/Userland/Libraries/LibC/sys/ioctl_numbers.h
@@ -72,6 +72,10 @@ struct FBFlushRects {
     struct FBRect const* rects;
 };
 
+struct FBFlush {
+    int buffer_index;
+};
+
 enum ConsoleModes {
     KD_TEXT = 0x00,
     KD_GRAPHICS = 0x01,

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -723,13 +723,6 @@ void Compositor::flush(Screen& screen)
         // now so that they can be sent to the device.
         screen.flush_display(screen_data.m_buffers_are_flipped ? 1 : 0);
     }
-
-    // Note: We write all contents from the internal buffer of WindowServer Screen
-    // to the actual framebuffer with the write() syscall, but after we flush the screen
-    // to ensure we are in a "clean state"...
-    // FIXME: This write is completely inefficient and needs to be done in chunks
-    // only when appropriate...
-    screen.write_all_display_contents();
 }
 
 void Compositor::invalidate_screen()

--- a/Userland/Services/WindowServer/Compositor.cpp
+++ b/Userland/Services/WindowServer/Compositor.cpp
@@ -630,7 +630,7 @@ void Compositor::flush(Screen& screen)
         }
         if (!bounding_flash.is_empty()) {
             if (screen.can_device_flush_entire_buffer()) {
-                screen.flush_display_entire_framebuffer();
+                screen.flush_display_entire_framebuffer((!screen_data.m_screen_can_set_buffer || !screen_data.m_buffers_are_flipped) ? 0 : 1);
             } else if (device_can_flush_buffers) {
                 // If the device needs a flush we need to let it know that we
                 // modified the front buffer!

--- a/Userland/Services/WindowServer/HardwareScreenBackend.cpp
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.cpp
@@ -135,9 +135,9 @@ ErrorOr<void> HardwareScreenBackend::flush_framebuffer_rects(int buffer_index, S
     return {};
 }
 
-ErrorOr<void> HardwareScreenBackend::flush_framebuffer()
+ErrorOr<void> HardwareScreenBackend::flush_framebuffer(int buffer_index)
 {
-    int rc = fb_flush_head(m_framebuffer_fd);
+    int rc = fb_flush_head(m_framebuffer_fd, buffer_index);
     if (rc == -ENOTSUP)
         m_can_device_flush_entire_framebuffer = false;
     else

--- a/Userland/Services/WindowServer/HardwareScreenBackend.h
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.h
@@ -34,8 +34,6 @@ public:
     virtual ErrorOr<void> set_head_mode_setting(GraphicsHeadModeSetting) override;
     virtual ErrorOr<GraphicsHeadModeSetting> get_head_mode_setting() override;
 
-    virtual ErrorOr<void> write_all_contents(Gfx::IntRect const&) override;
-
     String m_device {};
     int m_framebuffer_fd { -1 };
 

--- a/Userland/Services/WindowServer/HardwareScreenBackend.h
+++ b/Userland/Services/WindowServer/HardwareScreenBackend.h
@@ -26,7 +26,7 @@ public:
 
     virtual ErrorOr<void> flush_framebuffer_rects(int buffer_index, Span<FBRect const> rects) override;
 
-    virtual ErrorOr<void> flush_framebuffer() override;
+    virtual ErrorOr<void> flush_framebuffer(int buffer_index) override;
 
     virtual ErrorOr<void> unmap_framebuffer() override;
     virtual ErrorOr<void> map_framebuffer() override;

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -558,11 +558,6 @@ void Screen::flush_display(int buffer_index)
     flush_rects.pending_flush_rects.clear_with_capacity();
 }
 
-void Screen::write_all_display_contents()
-{
-    MUST(m_backend->write_all_contents(m_physical_rect));
-}
-
 void Screen::flush_display_entire_framebuffer()
 {
     VERIFY(m_backend->m_can_device_flush_entire_framebuffer);

--- a/Userland/Services/WindowServer/Screen.cpp
+++ b/Userland/Services/WindowServer/Screen.cpp
@@ -545,7 +545,7 @@ void Screen::flush_display(int buffer_index)
     }
 
     if (m_backend->m_can_device_flush_entire_framebuffer) {
-        auto return_value = m_backend->flush_framebuffer();
+        auto return_value = m_backend->flush_framebuffer(buffer_index);
         if (return_value.is_error())
             dbgln("Screen #{}: Error flushing display: {}", index(), return_value.error());
     } else {
@@ -558,10 +558,10 @@ void Screen::flush_display(int buffer_index)
     flush_rects.pending_flush_rects.clear_with_capacity();
 }
 
-void Screen::flush_display_entire_framebuffer()
+void Screen::flush_display_entire_framebuffer(int buffer_index)
 {
     VERIFY(m_backend->m_can_device_flush_entire_framebuffer);
-    auto return_value = m_backend->flush_framebuffer();
+    auto return_value = m_backend->flush_framebuffer(buffer_index);
     if (return_value.is_error())
         dbgln("Screen #{}: Error flushing display front buffer: {}", index(), return_value.error());
 }

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -176,8 +176,6 @@ public:
 
     CompositorScreenData& compositor_screen_data() { return *m_compositor_screen_data; }
 
-    void write_all_display_contents();
-
 private:
     Screen(size_t);
     bool open_device();

--- a/Userland/Services/WindowServer/Screen.h
+++ b/Userland/Services/WindowServer/Screen.h
@@ -172,7 +172,7 @@ public:
     void queue_flush_display_rect(Gfx::IntRect const& rect);
     void flush_display(int buffer_index);
     void flush_display_front_buffer(int front_buffer_index, Gfx::IntRect&);
-    void flush_display_entire_framebuffer();
+    void flush_display_entire_framebuffer(int buffer_index);
 
     CompositorScreenData& compositor_screen_data() { return *m_compositor_screen_data; }
 

--- a/Userland/Services/WindowServer/ScreenBackend.h
+++ b/Userland/Services/WindowServer/ScreenBackend.h
@@ -36,8 +36,6 @@ public:
     virtual ErrorOr<void> set_head_mode_setting(GraphicsHeadModeSetting) = 0;
     virtual ErrorOr<GraphicsHeadModeSetting> get_head_mode_setting() = 0;
 
-    virtual ErrorOr<void> write_all_contents(Gfx::IntRect const&) { return {}; }
-
     bool m_can_device_flush_buffers { true };
     bool m_can_device_flush_entire_framebuffer { true };
     bool m_can_set_head_buffer { false };

--- a/Userland/Services/WindowServer/ScreenBackend.h
+++ b/Userland/Services/WindowServer/ScreenBackend.h
@@ -31,7 +31,7 @@ public:
     virtual ErrorOr<void> unmap_framebuffer() = 0;
     virtual ErrorOr<void> map_framebuffer() = 0;
 
-    virtual ErrorOr<void> flush_framebuffer() = 0;
+    virtual ErrorOr<void> flush_framebuffer(int buffer_index) = 0;
 
     virtual ErrorOr<void> set_head_mode_setting(GraphicsHeadModeSetting) = 0;
     virtual ErrorOr<GraphicsHeadModeSetting> get_head_mode_setting() = 0;

--- a/Userland/Services/WindowServer/VirtualScreenBackend.h
+++ b/Userland/Services/WindowServer/VirtualScreenBackend.h
@@ -30,7 +30,7 @@ private:
 
     virtual ErrorOr<void> flush_framebuffer_rects(int, Span<FBRect const>) override { return {}; }
 
-    virtual ErrorOr<void> flush_framebuffer() override { return {}; }
+    virtual ErrorOr<void> flush_framebuffer(int) override { return {}; }
 
     virtual ErrorOr<void> unmap_framebuffer() override;
     virtual ErrorOr<void> map_framebuffer() override;


### PR DESCRIPTION
Still needs some more love, but this fixes some issues with the new whole-framebuffer flushing mechanism.

This is on top of #14029

@supercomputer7 