### PR TITLE
LibGUI: Check if a property is a GML Object in ScrollableContainerWidget

### DIFF
--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -96,7 +96,7 @@ bool ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> 
     });
 
     auto content_widget_value = object->get_property("content_widget"sv);
-    if (!content_widget_value.is_null() && !is<Object>(content_widget_value.ptr())) {
+    if (!content_widget_value.is_null() && !is<GUI::GML::Object>(content_widget_value.ptr())) {
         dbgln("content widget is not an object");
         return false;
     }
@@ -108,7 +108,7 @@ bool ScrollableContainerWidget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> 
         return false;
     }
 
-    if (!content_widget_value.is_null() && is<Object>(content_widget_value.ptr())) {
+    if (!content_widget_value.is_null() && is<GUI::GML::Object>(content_widget_value.ptr())) {
         auto content_widget = static_ptr_cast<GUI::GML::Object>(content_widget_value);
         auto class_name = content_widget->name();
 


### PR DESCRIPTION
Previously we couldn't set the content widget from GML because it was looking for a `GUI::Object`, not a `GML::Object`.

*But now we can!*
![gml playground screenshot](https://user-images.githubusercontent.com/16520278/167245568-2b4dfe33-6cf7-40eb-9a3b-f278a11cb945.png)

This should help with debugging layout issues in #13937 :^)