### PR TITLE
LibGUI: Improve widget size calculation in ScrollableContainerWidget

### DIFF
--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -44,13 +44,14 @@ void ScrollableContainerWidget::update_widget_size()
             new_size.set_width(preferred_size.width());
         if (preferred_size.height() != -1)
             new_size.set_height(preferred_size.height());
-    } else {
-        auto min_size = m_widget->min_size();
-        new_size = Gfx::Size {
-            max(new_size.width(), min_size.width()),
-            max(new_size.height(), min_size.height())
-        };
     }
+
+    auto min_size = m_widget->min_size();
+    new_size = Gfx::Size {
+        max(new_size.width(), min_size.width()),
+        max(new_size.height(), min_size.height()),
+    };
+
     m_widget->resize(new_size);
     set_content_size(new_size);
 }

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -37,25 +37,22 @@ void ScrollableContainerWidget::update_widget_size()
     if (!m_widget)
         return;
     m_widget->do_layout();
+    auto new_size = Widget::content_size();
     if (m_widget->is_shrink_to_fit() && m_widget->layout()) {
-        auto new_size = Widget::content_size();
         auto preferred_size = m_widget->layout()->preferred_size();
         if (preferred_size.width() != -1)
             new_size.set_width(preferred_size.width());
         if (preferred_size.height() != -1)
             new_size.set_height(preferred_size.height());
-        m_widget->resize(new_size);
-        set_content_size(new_size);
     } else {
-        auto inner_size = Widget::content_size();
         auto min_size = m_widget->min_size();
-        auto new_size = Gfx::Size {
-            max(inner_size.width(), min_size.width()),
-            max(inner_size.height(), min_size.height())
+        new_size = Gfx::Size {
+            max(new_size.width(), min_size.width()),
+            max(new_size.height(), min_size.height())
         };
-        m_widget->resize(new_size);
-        set_content_size(new_size);
     }
+    m_widget->resize(new_size);
+    set_content_size(new_size);
 }
 
 void ScrollableContainerWidget::resize_event(GUI::ResizeEvent& event)

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -38,12 +38,20 @@ void ScrollableContainerWidget::update_widget_size()
         return;
     m_widget->do_layout();
     auto new_size = Widget::content_size();
-    if (m_widget->is_shrink_to_fit() && m_widget->layout()) {
+
+    if (m_widget->layout()) {
         auto preferred_size = m_widget->layout()->preferred_size();
-        if (preferred_size.width() != -1)
-            new_size.set_width(preferred_size.width());
-        if (preferred_size.height() != -1)
-            new_size.set_height(preferred_size.height());
+        if (m_widget->is_shrink_to_fit()) {
+            if (preferred_size.width() != -1)
+                new_size.set_width(preferred_size.width());
+            if (preferred_size.height() != -1)
+                new_size.set_height(preferred_size.height());
+        } else {
+            new_size = Gfx::Size {
+                max(new_size.width(), preferred_size.width()),
+                max(new_size.height(), preferred_size.height())
+            };
+        }
     }
 
     auto min_size = m_widget->min_size();


### PR DESCRIPTION
- **LibGUI: Reuse common parts in ScrollableContainerWidget**
  No functional changes.
- **LibGUI: Always use widget’s minimum size in ScrollableContainerWidget**
  I don’t know if it makes much sense to use `min_size` and `shrink_to_fit` at the same time, but it will make the code a bit cleaner later.

* **LibGUI: Try use layout's preferred size for the content size**
  Previously this was only done if the widget had `shrink_to_fit` property enabled.

---
screenshots (with #13942 cherry-picked):

master | this pr
---|---
![gml playground screenshot](https://user-images.githubusercontent.com/16520278/167255523-0d8a99bf-6747-4990-b043-2be07e6bce50.png) | ![another gml playground screenshot](https://user-images.githubusercontent.com/16520278/167255526-0d39ac87-58bb-4f36-ac37-98f9cf8fe193.png)

that being said, i really don’t know what I’m doing

![🙂](https://user-images.githubusercontent.com/16520278/167255078-29e8e792-386e-423e-8d0e-012501fee0ef.jpg)
