### PR TITLE
LibELF+Profiler: Keep track of libraries in non-standard locations

### DIFF
--- a/Userland/DevTools/Profiler/Process.cpp
+++ b/Userland/DevTools/Profiler/Process.cpp
@@ -91,7 +91,9 @@ void LibraryMetadata::handle_mmap(FlatPtr base, size_t size, String const& name)
     } else {
         String path_string = path.to_string();
         String full_path;
-        if (Core::File::looks_like_shared_library(path_string))
+        if (path_string.starts_with('/'))
+            full_path = path_string;
+        else if (Core::File::looks_like_shared_library(path_string))
             full_path = String::formatted("/usr/lib/{}", path);
         else
             full_path = path_string;

--- a/Userland/Libraries/LibELF/DynamicLoader.h
+++ b/Userland/Libraries/LibELF/DynamicLoader.h
@@ -42,7 +42,7 @@ enum class ShouldInitializeWeak {
 
 class DynamicLoader : public RefCounted<DynamicLoader> {
 public:
-    static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> try_create(int fd, String filename);
+    static Result<NonnullRefPtr<DynamicLoader>, DlErrorMessage> try_create(int fd, String filename, String filepath);
     ~DynamicLoader();
 
     String const& filename() const { return m_filename; }
@@ -83,7 +83,7 @@ public:
     DynamicObject const& dynamic_object() const;
 
 private:
-    DynamicLoader(int fd, String filename, void* file_data, size_t file_size);
+    DynamicLoader(int fd, String filename, void* file_data, size_t file_size, String filepath);
 
     class ProgramHeaderRegion {
     public:
@@ -135,6 +135,7 @@ private:
     ssize_t negative_offset_from_tls_block_end(ssize_t tls_offset, size_t value_of_symbol) const;
 
     String m_filename;
+    String m_filepath;
     size_t m_file_size { 0 };
     int m_image_fd { -1 };
     void* m_file_data { nullptr };

--- a/Userland/Utilities/readelf.cpp
+++ b/Userland/Utilities/readelf.cpp
@@ -336,7 +336,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         }
 
         int fd = TRY(Core::System::open(path, O_RDONLY));
-        auto result = ELF::DynamicLoader::try_create(fd, path);
+        auto result = ELF::DynamicLoader::try_create(fd, path, path);
         if (result.is_error()) {
             outln("{}", result.error().text);
             return 1;


### PR DESCRIPTION
This makes libraries that are not installed in `/usr/lib` or `/usr/local/lib` show up in the Profiler, provided that the `mmap` event buffer is long enough to be able to fit the file name.

I'm not too happy with having to pass the file name as well as the full path to the `DynamicLoader` constructor, but right now there are too many assumptions about using the file name only (so I can't just remove the file name), and dynamically filtering out the path everywhere where its needed proved to be difficult due to memory allocation restrictions during process startup.