### PR TITLE
FileManager: Random micro cleanup

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -131,8 +131,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
 void do_copy(Vector<String> const& selected_file_paths, FileOperation file_operation)
 {
-    if (selected_file_paths.is_empty())
-        VERIFY_NOT_REACHED();
+    VERIFY(!selected_file_paths.is_empty());
 
     StringBuilder copy_text;
     if (file_operation == FileOperation::Move) {
@@ -343,9 +342,7 @@ ErrorOr<int> run_in_desktop_mode()
     auto cut_action = GUI::CommonActions::make_cut_action(
         [&](auto&) {
             auto paths = directory_view->selected_file_paths();
-
-            if (paths.is_empty())
-                VERIFY_NOT_REACHED();
+            VERIFY(!paths.is_empty());
 
             do_copy(paths, FileOperation::Move);
         },
@@ -355,9 +352,7 @@ ErrorOr<int> run_in_desktop_mode()
     auto copy_action = GUI::CommonActions::make_copy_action(
         [&](auto&) {
             auto paths = directory_view->selected_file_paths();
-
-            if (paths.is_empty())
-                VERIFY_NOT_REACHED();
+            VERIFY(!paths.is_empty());
 
             do_copy(paths, FileOperation::Copy);
         },
@@ -727,12 +722,9 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     auto cut_action = GUI::CommonActions::make_cut_action(
         [&](auto&) {
             auto paths = directory_view->selected_file_paths();
-
             if (paths.is_empty())
                 paths = tree_view_selected_file_paths();
-
-            if (paths.is_empty())
-                VERIFY_NOT_REACHED();
+            VERIFY(!paths.is_empty());
 
             do_copy(paths, FileOperation::Move);
             refresh_tree_view();
@@ -743,12 +735,9 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     auto copy_action = GUI::CommonActions::make_copy_action(
         [&](auto&) {
             auto paths = directory_view->selected_file_paths();
-
             if (paths.is_empty())
                 paths = tree_view_selected_file_paths();
-
-            if (paths.is_empty())
-                VERIFY_NOT_REACHED();
+            VERIFY(!paths.is_empty());
 
             do_copy(paths, FileOperation::Copy);
             refresh_tree_view();

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -938,7 +938,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     TRY(edit_menu->try_add_separator());
     TRY(edit_menu->try_add_action(select_all_action));
 
-    auto action_show_dotfiles = GUI::Action::create_checkable("&Show Dotfiles", { Mod_Ctrl, Key_H }, [&](auto& action) {
+    auto show_dotfiles_action = GUI::Action::create_checkable("&Show Dotfiles", { Mod_Ctrl, Key_H }, [&](auto& action) {
         directory_view->set_should_show_dotfiles(action.is_checked());
         directories_model->set_should_show_dotfiles(action.is_checked());
         refresh_tree_view();
@@ -947,11 +947,11 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
 
     auto show_dotfiles = Config::read_bool("FileManager", "DirectoryView", "ShowDotFiles", false);
     directory_view->set_should_show_dotfiles(show_dotfiles);
-    action_show_dotfiles->set_checked(show_dotfiles);
+    show_dotfiles_action->set_checked(show_dotfiles);
 
     auto const initial_location_contains_dotfile = initial_location.contains("/."sv);
-    action_show_dotfiles->set_checked(initial_location_contains_dotfile);
-    action_show_dotfiles->on_activation(action_show_dotfiles);
+    show_dotfiles_action->set_checked(initial_location_contains_dotfile);
+    show_dotfiles_action->on_activation(show_dotfiles_action);
 
     auto view_menu = TRY(window->try_add_menu("&View"));
     auto layout_menu = TRY(view_menu->try_add_submenu("&Layout"));
@@ -966,7 +966,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     TRY(view_menu->try_add_action(directory_view->view_as_table_action()));
     TRY(view_menu->try_add_action(directory_view->view_as_columns_action()));
     TRY(view_menu->try_add_separator());
-    TRY(view_menu->try_add_action(action_show_dotfiles));
+    TRY(view_menu->try_add_action(show_dotfiles_action));
 
     auto go_to_location_action = GUI::Action::create("Go to &Location...", { Mod_Ctrl, Key_L }, Key_F6, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/go-to.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
         toolbar_container.set_visible(true);
@@ -1142,7 +1142,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     TRY(directory_view_context_menu->try_add_action(paste_action));
     TRY(directory_view_context_menu->try_add_action(directory_view->open_terminal_action()));
     TRY(directory_view_context_menu->try_add_separator());
-    TRY(directory_view_context_menu->try_add_action(action_show_dotfiles));
+    TRY(directory_view_context_menu->try_add_action(show_dotfiles_action));
     TRY(directory_view_context_menu->try_add_separator());
     TRY(directory_view_context_menu->try_add_action(properties_action));
 

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1159,8 +1159,6 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     TRY(tree_view_directory_context_menu->try_add_action(properties_action));
 
     RefPtr<GUI::Menu> file_context_menu;
-    NonnullRefPtrVector<LauncherHandler> current_file_handlers;
-    RefPtr<GUI::Action> file_context_menu_action_default_action;
 
     directory_view->on_context_menu_request = [&](GUI::ModelIndex const& index, GUI::ContextMenuEvent const& event) {
         if (index.is_valid()) {
@@ -1171,6 +1169,8 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
                 folder_specific_paste_action->set_enabled(should_get_enabled);
                 directory_context_menu->popup(event.screen_position(), directory_open_action);
             } else {
+                NonnullRefPtrVector<LauncherHandler> current_file_handlers;
+                RefPtr<GUI::Action> file_context_menu_action_default_action;
                 file_context_menu = GUI::Menu::construct("Directory View File");
 
                 bool added_launch_file_handlers = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -671,7 +671,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     layout_location_action->set_checked(show_location);
     breadcrumb_toolbar.set_visible(show_location);
 
-    toolbar_container.set_visible(show_location | show_toolbar);
+    toolbar_container.set_visible(show_location || show_toolbar);
 
     layout_statusbar_action = GUI::Action::create_checkable("&Status Bar", [&](auto& action) {
         action.is_checked() ? statusbar.set_visible(true) : statusbar.set_visible(false);
@@ -694,7 +694,7 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     location_textbox.on_focusout = [&] {
         if (show_location)
             breadcrumb_toolbar.set_visible(true);
-        if (!(show_location | show_toolbar))
+        if (!(show_location || show_toolbar))
             toolbar_container.set_visible(false);
 
         location_toolbar.set_visible(false);

--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1076,12 +1076,6 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
             }
         }
 
-        struct stat st;
-        if (lstat(new_path.characters(), &st)) {
-            perror("stat");
-            return;
-        }
-
         mkdir_action->set_enabled(can_write_in_path);
         touch_action->set_enabled(can_write_in_path);
         paste_action->set_enabled(can_write_in_path && GUI::Clipboard::the().fetch_mime_type() == "text/uri-list");


### PR DESCRIPTION
Wanted to move code from the main() function and use classes instead, but I’ve ended up with this. oh well

- **FileManager: Use VERIFY() instead of if checks with VERIFY_NOT_REACHED**

  Besides micro simplifying the code, this will also show the failed condition in the console, instead of vague `ASSERTION FAILED: false`.

- **FileManager: Rename `action_show_dotfiles` to `show_dotfiles_action`**

  All actions are named that way.

- **FileManager: Don't use bitwise OR operators on booleans**
- **FileManager: Reduce scope of some variables related to context menu**
- **FileManager: Remove unused lstat() call**
