### PR TITLE
Passwordbox Reveal Button

### DIFF
--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -5,8 +5,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGUI/Painter.h>
 #include <LibGUI/TextBox.h>
-
+#include <LibGfx/Palette.h>
 REGISTER_WIDGET(GUI, TextBox)
 REGISTER_WIDGET(GUI, PasswordBox)
 REGISTER_WIDGET(GUI, UrlBox)
@@ -71,11 +72,59 @@ void TextBox::add_input_to_history(String input)
     m_history_index++;
 }
 
+constexpr u32 password_box_substitution_code_point = '*';
+
 PasswordBox::PasswordBox()
     : TextBox()
 {
-    set_substitution_code_point('*');
+    set_substitution_code_point(password_box_substitution_code_point);
     set_text_is_secret(true);
+    REGISTER_BOOL_PROPERTY("show_reveal_button", is_showing_reveal_button, set_show_reveal_button);
+}
+
+Gfx::IntRect PasswordBox::reveal_password_button_rect() const
+{
+    constexpr i32 button_box_padding = 3;
+    auto button_box_size = height() - button_box_padding - button_box_padding;
+    return { width() - button_box_size - button_box_padding, button_box_padding, button_box_size, button_box_size };
+}
+
+void PasswordBox::paint_event(PaintEvent& event)
+{
+    TextBox::paint_event(event);
+
+    if (is_showing_reveal_button()) {
+        auto button_rect = reveal_password_button_rect();
+
+        Painter painter(*this);
+        painter.add_clip_rect(event.rect());
+
+        auto icon_color = palette().button_text();
+        if (substitution_code_point().has_value()) {
+            icon_color = palette().disabled_text_front();
+        }
+        i32 dot_indicator_padding = height() / 5;
+
+        Gfx::IntRect dot_indicator_rect = { button_rect.x() + dot_indicator_padding, button_rect.y() + dot_indicator_padding, button_rect.width() - dot_indicator_padding * 2, button_rect.height() - dot_indicator_padding * 2 };
+        painter.fill_ellipse(dot_indicator_rect, icon_color);
+
+        Gfx::IntPoint arc_start_point { dot_indicator_rect.x() - dot_indicator_padding / 2, dot_indicator_rect.y() + dot_indicator_padding / 2 };
+        Gfx::IntPoint arc_end_point = { dot_indicator_rect.top_right().x() + dot_indicator_padding / 2, dot_indicator_rect.top_right().y() + dot_indicator_padding / 2 };
+        Gfx::IntPoint arc_center_point = { dot_indicator_rect.center().x(), dot_indicator_rect.top() - dot_indicator_padding };
+        painter.draw_quadratic_bezier_curve(arc_center_point, arc_start_point, arc_end_point, icon_color, 1);
+    }
+}
+
+void PasswordBox::mousedown_event(GUI::MouseEvent& event)
+{
+    if (is_showing_reveal_button() && reveal_password_button_rect().contains(event.position())) {
+        Optional<u32> next_substitution_code_point;
+        if (!substitution_code_point().has_value())
+            next_substitution_code_point = password_box_substitution_code_point;
+        set_substitution_code_point(next_substitution_code_point);
+    } else {
+        TextBox::mousedown_event(event);
+    }
 }
 
 UrlBox::UrlBox()

--- a/Userland/Libraries/LibGUI/TextBox.h
+++ b/Userland/Libraries/LibGUI/TextBox.h
@@ -42,8 +42,23 @@ private:
 
 class PasswordBox : public TextBox {
     C_OBJECT(PasswordBox)
+public:
+    bool is_showing_reveal_button() const { return m_show_reveal_button; }
+    void set_show_reveal_button(bool show)
+    {
+        m_show_reveal_button = show;
+        update();
+    }
+
 private:
     PasswordBox();
+
+    virtual void paint_event(PaintEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+
+    Gfx::IntRect reveal_password_button_rect() const;
+
+    bool m_show_reveal_button { false };
 };
 
 class UrlBox : public TextBox {

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -226,7 +226,7 @@ void TextEditor::doubleclick_event(MouseEvent& event)
 
     auto position = text_position_at(event.position());
 
-    if (m_substitution_code_point) {
+    if (m_substitution_code_point.has_value()) {
         // NOTE: If we substitute the code points, we don't want double clicking to only select a single word, since
         //       whitespace isn't visible anymore.
         m_selection = document().range_for_entire_line(position.line());
@@ -409,7 +409,7 @@ void TextEditor::paint_event(PaintEvent& event)
     // NOTE: This lambda and TextEditor::text_width_for_font() are used to substitute all glyphs with m_substitution_code_point if necessary.
     //       Painter::draw_text() and Gfx::Font::width() should not be called directly, but using this lambda and TextEditor::text_width_for_font().
     auto draw_text = [&](Gfx::IntRect const& rect, auto const& raw_text, Gfx::Font const& font, Gfx::TextAlignment alignment, Gfx::TextAttributes attributes, bool substitute = true) {
-        if (m_substitution_code_point && substitute) {
+        if (m_substitution_code_point.has_value() && substitute) {
             painter.draw_text(rect, substitution_code_point_view(raw_text.length()), font, alignment, attributes.color);
         } else {
             painter.draw_text(rect, raw_text, font, alignment, attributes.color);
@@ -1090,7 +1090,7 @@ int TextEditor::content_x_for_position(TextPosition const& position) const
 
 int TextEditor::text_width_for_font(auto const& text, Gfx::Font const& font) const
 {
-    if (m_substitution_code_point)
+    if (m_substitution_code_point.has_value())
         return font.width(substitution_code_point_view(text.length()));
     else
         return font.width(text);
@@ -1098,13 +1098,13 @@ int TextEditor::text_width_for_font(auto const& text, Gfx::Font const& font) con
 
 Utf32View TextEditor::substitution_code_point_view(size_t length) const
 {
-    VERIFY(m_substitution_code_point);
+    VERIFY(m_substitution_code_point.has_value());
     if (!m_substitution_string_data)
         m_substitution_string_data = make<Vector<u32>>();
     if (!m_substitution_string_data->is_empty())
         VERIFY(m_substitution_string_data->first() == m_substitution_code_point);
     while (m_substitution_string_data->size() < length)
-        m_substitution_string_data->append(m_substitution_code_point);
+        m_substitution_string_data->append(m_substitution_code_point.value());
     return Utf32View { m_substitution_string_data->data(), length };
 }
 
@@ -2066,9 +2066,10 @@ void TextEditor::set_should_autocomplete_automatically(bool value)
     m_autocomplete_timer = nullptr;
 }
 
-void TextEditor::set_substitution_code_point(u32 code_point)
+void TextEditor::set_substitution_code_point(Optional<u32> code_point)
 {
-    VERIFY(is_unicode(code_point));
+    if (code_point.has_value())
+        VERIFY(is_unicode(code_point.value()));
     m_substitution_string_data.clear();
     m_substitution_code_point = code_point;
 }

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -191,8 +191,8 @@ public:
     bool should_autocomplete_automatically() const { return m_autocomplete_timer; }
     void set_should_autocomplete_automatically(bool);
 
-    u32 substitution_code_point() const { return m_substitution_code_point; }
-    void set_substitution_code_point(u32 code_point);
+    const Optional<u32>& substitution_code_point() const { return m_substitution_code_point; }
+    void set_substitution_code_point(Optional<u32> code_point);
 
     bool is_in_drag_select() const { return m_in_drag_select; }
 
@@ -371,8 +371,7 @@ private:
     int m_horizontal_content_padding { 3 };
     TextRange m_selection;
 
-    // NOTE: If non-zero, all glyphs will be substituted with this one.
-    u32 m_substitution_code_point { 0 };
+    Optional<u32> m_substitution_code_point;
     mutable OwnPtr<Vector<u32>> m_substitution_string_data; // Used to avoid repeated String construction.
 
     RefPtr<Menu> m_context_menu;


### PR DESCRIPTION
This PR adds a button to the PasswordBox which allows for revealing of the typed password. 
The button is only shown when the property `show_reveal_button` is `true`. It's default is `false` to not unintentionally alter existing GUIs.

Unrevealed state:
![image](https://user-images.githubusercontent.com/57399807/167260573-6c2fef31-8f97-44c2-81ae-199624ae7d7d.png)

Revealed state:
![image](https://user-images.githubusercontent.com/57399807/167260590-d880cc8e-5b30-477a-b7e4-c604947501c2.png)

I added this because of some password related stuff I am working on and it bugged me during developing that the password can not be shown :^). The eye icon is not the prettiest but I could not come with something better.