### PR TITLE
Passwordbox Reveal Button

### DIFF
--- a/Userland/Libraries/LibGUI/TextBox.h
+++ b/Userland/Libraries/LibGUI/TextBox.h
@@ -42,8 +42,23 @@ private:
 
 class PasswordBox : public TextBox {
     C_OBJECT(PasswordBox)
+public:
+    bool is_showing_reveal_button() const { return m_show_reveal_button; }
+    void set_show_reveal_button(bool show)
+    {
+        m_show_reveal_button = show;
+        update();
+    }
+
 private:
     PasswordBox();
+
+    virtual void paint_event(PaintEvent&) override;
+    virtual void mousedown_event(GUI::MouseEvent&) override;
+
+    Gfx::IntRect reveal_password_button_rect() const;
+
+    bool m_show_reveal_button { false };
 };
 
 class UrlBox : public TextBox {

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -191,8 +191,8 @@ public:
     bool should_autocomplete_automatically() const { return m_autocomplete_timer; }
     void set_should_autocomplete_automatically(bool);
 
-    u32 substitution_code_point() const { return m_substitution_code_point; }
-    void set_substitution_code_point(u32 code_point);
+    Optional<u32> const& substitution_code_point() const { return m_substitution_code_point; }
+    void set_substitution_code_point(Optional<u32> code_point);
 
     bool is_in_drag_select() const { return m_in_drag_select; }
 
@@ -371,8 +371,7 @@ private:
     int m_horizontal_content_padding { 3 };
     TextRange m_selection;
 
-    // NOTE: If non-zero, all glyphs will be substituted with this one.
-    u32 m_substitution_code_point { 0 };
+    Optional<u32> m_substitution_code_point;
     mutable OwnPtr<Vector<u32>> m_substitution_string_data; // Used to avoid repeated String construction.
 
     RefPtr<Menu> m_context_menu;


### PR DESCRIPTION
This PR adds a button to the PasswordBox which allows for revealing of the typed password.
The button is only shown when the property show_reveal_button is true. It's default is false to not unintentionally alter existing GUIs.

Unrevealed state:
![image](https://user-images.githubusercontent.com/5813055/167263239-a1d3622e-935d-4f76-91ae-b7278377bbc5.png)

Revealed state:
![image](https://user-images.githubusercontent.com/5813055/167263229-88ff1825-9c62-4eb8-abc2-0bd8415f76d0.png)

I added this because of some password related stuff I am working on and it bugged me during developing that the password can not be shown :^). The eye icon is not the prettiest but I could not come with something better.