### PR TITLE
FileManager: Don't show new dotfiles if the option is disabled

### DIFF
--- a/Userland/Libraries/LibGUI/FileSystemModel.cpp
+++ b/Userland/Libraries/LibGUI/FileSystemModel.cpp
@@ -384,6 +384,8 @@ void FileSystemModel::handle_file_event(Core::FileWatcherEvent const& event)
         LexicalPath path { event.event_path };
         auto& parts = path.parts_view();
         StringView child_name = parts.last();
+        if (!m_should_show_dotfiles && child_name.starts_with("."))
+            break;
 
         auto parent_name = path.parent().string();
         auto parent = node_for_path(parent_name);


### PR DESCRIPTION
**Bug description:**
When creating a dotfile while FileManager is open and the "show dotfiles" option is off, the new file is shown.

**To reproduce:**
- Open FileManager
- Run `touch .test.txt` (or create one by right clicking in FileManager)
- File is shown in FileManager (bug)
- If you delete some file (or somehow make the window refresh the file contents) the file gets hidden again (which probably means that this behavior was not intended)

![image](https://user-images.githubusercontent.com/21157395/167263336-7cf86f41-77f6-4f74-a242-759f796650e3.png)

This pull request fixes this bug by checking if the filename starts with a '.' before adding the newly created file through `FileSystemModel::handle_file_event`.
