### PR TITLE
CI: Use proper paths to template files in nightly-pipeline.yml

### DIFF
--- a/Meta/Azure/nightly-pipeline.yml
+++ b/Meta/Azure/nightly-pipeline.yml
@@ -10,12 +10,12 @@ stages:
   - stage: Toolchain
     dependsOn: []
     jobs:
-      - template: Meta/Azure/Toolchain.yml
+      - template: Toolchain.yml
 
-  - stage: SerenityOS (Coverage)
+  - stage: SerenityOS_Coverage
     dependsOn: Toolchain
     jobs:
-      - template: Meta/Azure/Serenity.yml
+      - template: Serenity.yml
         parameters:
           arch: 'x86_64'
           coverage: 'ON'


### PR DESCRIPTION
Azure paths are relative to the pipeline file.

Given the errors on the nightly pipeline Linus made, it was looking for Meta/Azure/Meta/Azure/Toolchain.yml and friends.