### PR TITLE
CI: Ensure that Azure nightly pipeline doesn't run on CI or PR triggers

### DIFF
--- a/Meta/Azure/nightly-pipeline.yml
+++ b/Meta/Azure/nightly-pipeline.yml
@@ -6,6 +6,11 @@ schedules:
     include:
     - master
 
+# Github YAML pipelines have CI and PR triggers on by default.
+# We only want this pipeline to run nightly
+pr: none
+trigger: none
+
 stages:
   - stage: Toolchain
     dependsOn: []


### PR DESCRIPTION
GitHub YAML pipelines have both of these on by default, so we need to
explicitly disable them.

> For example, YAML pipelines in a GitHub repository have CI triggers and PR triggers enabled by default. For information on disabling default triggers, see [Triggers in Azure Pipelines](https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=azure-devops) and navigate to the section that covers your repository type.

https://docs.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml