### PR TITLE
AK: Use builtin versions of `llrint{,l,f}`

### DIFF
--- a/AK/Math.h
+++ b/AK/Math.h
@@ -577,11 +577,11 @@ ALWAYS_INLINE I round_to(P value)
     return static_cast<I>(ret);
 #else
     if constexpr (IsSame<P, long double>)
-        return static_cast<I>(llrintl(value));
+        return static_cast<I>(__builtin_llrintl(value));
     if constexpr (IsSame<P, double>)
-        return static_cast<I>(llrint(value));
+        return static_cast<I>(__builtin_llrint(value));
     if constexpr (IsSame<P, float>)
-        return static_cast<I>(llrintf(value));
+        return static_cast<I>(__builtin_llrintf(value));
 #endif
 }
 


### PR DESCRIPTION
This fixes the build on M1 Macs. The error was:
```
FAILED: Tools/ConfigureComponents/CMakeFiles/ConfigureComponents.dir/main.cpp.o
/opt/homebrew/bin/ccache /opt/homebrew/bin/g++-11  -I/Users/erik/git/serenity/Meta/Lagom/../.. -I/Users/erik/git/serenity/Meta/Lagom/../../Userland -I/Users/erik/git/serenity/Meta/Lagom/../../Userland/Libraries -I/Users/erik/git/serenity/Build/lagom -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk -fsigned-char -Wno-unknown-warning-option -Wno-literal-suffix -Wno-implicit-const-int-float-conversion -O2 -Wall -Wextra -Werror -fPIC -g -Wno-maybe-uninitialized -fno-exceptions -fdiagnostics-color=always -fno-semantic-interposition -Wno-expansion-to-defined -std=c++20 -MD -MT Tools/ConfigureComponents/CMakeFiles/ConfigureComponents.dir/main.cpp.o -MF Tools/ConfigureComponents/CMakeFiles/ConfigureComponents.dir/main.cpp.o.d -o Tools/ConfigureComponents/CMakeFiles/ConfigureComponents.dir/main.cpp.o -c /Users/erik/git/serenity/Meta/Lagom/Tools/ConfigureComponents/main.cpp
In file included from /Users/erik/git/serenity/Meta/Lagom/../../AK/FixedPoint.h:16,
                 from /Users/erik/git/serenity/Meta/Lagom/../../AK/Format.h:15,
                 from /Users/erik/git/serenity/Meta/Lagom/Tools/ConfigureComponents/main.cpp:7:
/Users/erik/git/serenity/Meta/Lagom/../../AK/Math.h: In instantiation of 'I AK::round_to(P) [with I = unsigned char; P = float]':
/Users/erik/git/serenity/Meta/Lagom/../../Userland/Libraries/LibGfx/Color.h:203:36:   required from here
/Users/erik/git/serenity/Meta/Lagom/../../AK/Math.h:584:38: error: 'llrintf' was not declared in this scope, and no declarations were found by argument-dependent lookup at the point of instantiation [-fpermissive]
  584 |         return static_cast<I>(llrintf(value));
      |                               ~~~~~~~^~~~~~~
In file included from /opt/homebrew/Cellar/gcc/11.3.0/include/c++/11/cmath:45,
                 from /opt/homebrew/Cellar/gcc/11.3.0/include/c++/11/math.h:36,
                 from /Users/erik/git/serenity/Meta/Lagom/../../Userland/Libraries/LibGfx/Color.h:15,
                 from /Users/erik/git/serenity/Meta/Lagom/../../Userland/Libraries/LibCore/ConfigFile.h:18,
                 from /Users/erik/git/serenity/Meta/Lagom/Tools/ConfigureComponents/main.cpp:14:
/opt/homebrew/Cellar/gcc/11.3.0/lib/gcc/11/gcc/aarch64-apple-darwin21/11/include-fixed/math.h:501:22: note: 'long long int llrintf(float)' declared here, later in the translation unit
  501 | extern long long int llrintf(float);
      |                      ^~~~~~~
```