### PR TITLE
Base+Browser+LibWeb+WebContent: Add ability to inspect session storage

### DIFF
--- a/Base/res/html/misc/storage.html
+++ b/Base/res/html/misc/storage.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Storage test</title>
+</head>
+<body>
+    <h1>Storage test</h1>
+    <p>
+        <h2>Local Storage</h2>
+        <label>Key: </label><input type="text" size="30" id="localStorageKey" />
+        <label>Value: </label><input type="text" size="30" id="localStorageValue" />
+        <br>
+        <br>
+        <input type="button" id="addLS" value="Add" />
+        <input type="button" id="removeLS" value="Remove" />
+        <input type="button" id="getLS" value="Get" />
+
+        <p id="localStorageGetValue"></p>
+    </p>
+
+    <p>
+        <h2>Session Storage</h2>
+        <label>Key: </label><input type="text" size="30" id="sessionStorageKey" />
+        <label>Value: </label><input type="text" size="30" id="sessionStorageValue" />
+        <br>
+        <br>
+        <input type="button" id="addSS" value="Add" />
+        <input type="button" id="removeSS" value="Remove" />
+        <input type="button" id="getSS" value="Get" />
+
+        <p id="sessionStorageGetValue"></p>
+    </p>
+
+
+</body>
+
+<script>
+    document.getElementById('addLS').addEventListener('click', function () {
+        const key = getTextBoxValue("localStorageKey");
+        const value = getTextBoxValue("localStorageValue");
+        addValue('local', key, value);
+    });
+
+    document.getElementById('removeLS').addEventListener('click', function () {
+        const key = getTextBoxValue("localStorageKey");
+        removeValue('local', key);
+    });
+
+    document.getElementById('getLS').addEventListener('click', function () {
+        const key = getTextBoxValue("localStorageKey");
+        getValue('local', key, "localStorageGetValue");
+    });
+
+    document.getElementById('addSS').addEventListener('click', function () {
+        const key = getTextBoxValue("sessionStorageKey");
+        const value = getTextBoxValue("sessionStorageValue");
+        addValue('session', key, value);
+    });
+
+    document.getElementById('removeSS').addEventListener('click', function () {
+        const key = getTextBoxValue("sessionStorageKey");
+        removeValue('session', key);
+    });
+
+    document.getElementById('getSS').addEventListener('click', function () {
+        const key = getTextBoxValue("sessionStorageKey");
+        getValue('session', key, "sessionStorageGetValue");
+    });
+
+    function getTextBoxValue(id) {
+        const textBox = document.getElementById(id);
+        if (!textBox.value)
+            return "";
+
+        return textBox.value;
+    }
+
+    function addValue(storageType, key, value) {
+        if (!key)
+            return;
+
+        if (!value)
+            return;
+
+        let storage;
+        if (storageType === 'local')
+            storage = window.localStorage;
+        else
+            storage = window.sessionStorage;
+
+        storage.setItem(key, value)
+    }
+
+    function removeValue(storageType, key) {
+        if (!key)
+            return;
+
+        let storage;
+        if (storageType === 'local')
+            storage = window.localStorage;
+        else
+            storage = window.sessionStorage;
+
+        storage.removeItem(key)
+    }
+
+    function getValue(storageType, key, resultID) {
+        if (!key) {
+            document.getElementById(resultID).innerHTML = "No value found for '" + key + "'";
+            return;
+        }
+
+        let storage;
+        if (storageType === 'local')
+            storage = window.localStorage;
+        else
+            storage = window.sessionStorage;
+
+        const value = storage.getItem(key);
+        if (!value) {
+            document.getElementById(resultID).innerHTML = "No value found for '" + key + "'";
+            return;
+        }
+
+        document.getElementById(resultID).innerHTML = "Value for key '" + key + "' = " + storage.getItem(key);
+    }
+</script>
+</html>

--- a/Base/res/html/misc/welcome.html
+++ b/Base/res/html/misc/welcome.html
@@ -167,6 +167,7 @@
             <li><a href="script-preparation-test.html">Test for the early return steps 6-8 of the "prepare a script" algorithm</a></li>
             <li><a href="async-js.html">Basic test for async functions and their integration with the LibWeb event loop</a></li>
             <li><a href="worker_parent.html">Workers</a></li>
+            <li><a href="storage.html">Web Storage API</a></li>
             <li><h3>Canvas</h3></li>
             <li><a href="canvas.html">canvas 2D test</a></li>
             <li><a href="canvas-rotate.html">canvas rotate()</a></li>

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -556,6 +556,10 @@ void BrowserWindow::create_new_tab(URL url, bool activate)
         return active_tab().view().get_local_storage_entries();
     };
 
+    new_tab.on_get_session_storage_entries = [this]() {
+        return active_tab().view().get_session_storage_entries();
+    };
+
     new_tab.load(url);
 
     dbgln_if(SPAM_DEBUG, "Added new tab {:p}, loading {}", &new_tab, url);

--- a/Userland/Applications/Browser/CMakeLists.txt
+++ b/Userland/Applications/Browser/CMakeLists.txt
@@ -23,7 +23,7 @@ set(SOURCES
     History.cpp
     IconBag.cpp
     InspectorWidget.cpp
-    LocalStorageModel.cpp
+    StorageModel.cpp
     StorageWidget.cpp
     StorageWidgetGML.h
     Tab.cpp

--- a/Userland/Applications/Browser/StorageModel.cpp
+++ b/Userland/Applications/Browser/StorageModel.cpp
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include "LocalStorageModel.h"
+#include "StorageModel.h"
 
 #include <AK/FuzzyMatch.h>
 
 namespace Browser {
 
-void LocalStorageModel::set_items(OrderedHashMap<String, String> map)
+void StorageModel::set_items(OrderedHashMap<String, String> map)
 {
     begin_insert_rows({}, m_local_storage_entries.size(), m_local_storage_entries.size());
     m_local_storage_entries = map;
@@ -19,7 +19,7 @@ void LocalStorageModel::set_items(OrderedHashMap<String, String> map)
     did_update(DontInvalidateIndices);
 }
 
-void LocalStorageModel::clear_items()
+void StorageModel::clear_items()
 {
     begin_insert_rows({}, m_local_storage_entries.size(), m_local_storage_entries.size());
     m_local_storage_entries.clear();
@@ -28,14 +28,14 @@ void LocalStorageModel::clear_items()
     did_update(DontInvalidateIndices);
 }
 
-int LocalStorageModel::row_count(GUI::ModelIndex const& index) const
+int StorageModel::row_count(GUI::ModelIndex const& index) const
 {
     if (!index.is_valid())
         return m_local_storage_entries.size();
     return 0;
 }
 
-String LocalStorageModel::column_name(int column) const
+String StorageModel::column_name(int column) const
 {
     switch (column) {
     case Column::Key:
@@ -49,14 +49,14 @@ String LocalStorageModel::column_name(int column) const
     return {};
 }
 
-GUI::ModelIndex LocalStorageModel::index(int row, int column, GUI::ModelIndex const&) const
+GUI::ModelIndex StorageModel::index(int row, int column, GUI::ModelIndex const&) const
 {
     if (static_cast<size_t>(row) < m_local_storage_entries.size())
         return create_index(row, column, NULL);
     return {};
 }
 
-GUI::Variant LocalStorageModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
+GUI::Variant StorageModel::data(GUI::ModelIndex const& index, GUI::ModelRole role) const
 {
     if (role != GUI::ModelRole::Display)
         return {};
@@ -75,7 +75,7 @@ GUI::Variant LocalStorageModel::data(GUI::ModelIndex const& index, GUI::ModelRol
     VERIFY_NOT_REACHED();
 }
 
-TriState LocalStorageModel::data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const
+TriState StorageModel::data_matches(GUI::ModelIndex const& index, GUI::Variant const& term) const
 {
     auto needle = term.as_string();
     if (needle.is_empty())

--- a/Userland/Applications/Browser/StorageModel.h
+++ b/Userland/Applications/Browser/StorageModel.h
@@ -10,7 +10,7 @@
 
 namespace Browser {
 
-class LocalStorageModel final : public GUI::Model {
+class StorageModel final : public GUI::Model {
 public:
     enum Column {
         Key,

--- a/Userland/Applications/Browser/StorageWidget.cpp
+++ b/Userland/Applications/Browser/StorageWidget.cpp
@@ -6,7 +6,7 @@
 
 #include "StorageWidget.h"
 #include "CookiesModel.h"
-#include "LocalStorageModel.h"
+#include "StorageModel.h"
 #include <AK/Variant.h>
 #include <Applications/Browser/StorageWidgetGML.h>
 #include <LibGUI/TabWidget.h>
@@ -39,7 +39,7 @@ StorageWidget::StorageWidget()
 
     m_local_storage_table_view = tab_widget.find_descendant_of_type_named<GUI::TableView>("local_storage_tableview");
     m_local_storage_textbox = tab_widget.find_descendant_of_type_named<GUI::TextBox>("local_storage_filter_textbox");
-    m_local_storage_model = adopt_ref(*new LocalStorageModel());
+    m_local_storage_model = adopt_ref(*new StorageModel());
 
     m_local_storage_filtering_model = MUST(GUI::FilteringProxyModel::create(*m_local_storage_model));
     m_local_storage_filtering_model->set_filter_term("");
@@ -53,6 +53,23 @@ StorageWidget::StorageWidget()
     m_local_storage_table_view->set_model(m_local_storage_filtering_model);
     m_local_storage_table_view->set_column_headers_visible(true);
     m_local_storage_table_view->set_alternating_row_colors(true);
+
+    m_session_storage_table_view = tab_widget.find_descendant_of_type_named<GUI::TableView>("session_storage_tableview");
+    m_session_storage_textbox = tab_widget.find_descendant_of_type_named<GUI::TextBox>("session_storage_filter_textbox");
+    m_session_storage_model = adopt_ref(*new StorageModel());
+
+    m_session_storage_filtering_model = MUST(GUI::FilteringProxyModel::create(*m_session_storage_model));
+    m_session_storage_filtering_model->set_filter_term("");
+
+    m_session_storage_textbox->on_change = [this] {
+        m_session_storage_filtering_model->set_filter_term(m_session_storage_textbox->text());
+        if (m_session_storage_filtering_model->row_count() != 0)
+            m_session_storage_table_view->set_cursor(m_session_storage_filtering_model->index(0, 0), GUI::AbstractView::SelectionUpdate::Set);
+    };
+
+    m_session_storage_table_view->set_model(m_session_storage_filtering_model);
+    m_session_storage_table_view->set_column_headers_visible(true);
+    m_session_storage_table_view->set_alternating_row_colors(true);
 }
 
 void StorageWidget::set_cookies_entries(Vector<Web::Cookie::Cookie> entries)
@@ -73,6 +90,16 @@ void StorageWidget::set_local_storage_entries(OrderedHashMap<String, String> ent
 void StorageWidget::clear_local_storage_entries()
 {
     m_local_storage_model->clear_items();
+}
+
+void StorageWidget::set_session_storage_entries(OrderedHashMap<String, String> entries)
+{
+    m_session_storage_model->set_items(entries);
+}
+
+void StorageWidget::clear_session_storage_entries()
+{
+    m_session_storage_model->clear_items();
 }
 
 }

--- a/Userland/Applications/Browser/StorageWidget.gml
+++ b/Userland/Applications/Browser/StorageWidget.gml
@@ -50,5 +50,27 @@
                 }
             }
         }
+
+        @GUI::Widget {
+            title: "Session Storage"
+            layout: @GUI::VerticalBoxLayout {
+                margins: [4]
+            }
+
+            @GUI::TextBox {
+                name: "session_storage_filter_textbox"
+                placeholder: "Filter"
+            }
+
+            @GUI::GroupBox {
+                layout: @GUI::VerticalBoxLayout {
+                    margins: [6]
+                }
+
+                @GUI::TableView {
+                    name: "session_storage_tableview"
+                }
+            }
+        }
     }
 }

--- a/Userland/Applications/Browser/StorageWidget.h
+++ b/Userland/Applications/Browser/StorageWidget.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "CookiesModel.h"
-#include "LocalStorageModel.h"
+#include "StorageModel.h"
 #include "Tab.h"
 #include <LibGUI/FilteringProxyModel.h>
 #include <LibGUI/TextBox.h>
@@ -27,6 +27,9 @@ public:
     void set_local_storage_entries(OrderedHashMap<String, String> entries);
     void clear_local_storage_entries();
 
+    void set_session_storage_entries(OrderedHashMap<String, String> entries);
+    void clear_session_storage_entries();
+
 private:
     StorageWidget();
 
@@ -37,8 +40,13 @@ private:
 
     RefPtr<GUI::TableView> m_local_storage_table_view;
     RefPtr<GUI::TextBox> m_local_storage_textbox;
-    RefPtr<LocalStorageModel> m_local_storage_model;
+    RefPtr<StorageModel> m_local_storage_model;
     RefPtr<GUI::FilteringProxyModel> m_local_storage_filtering_model;
+
+    RefPtr<GUI::TableView> m_session_storage_table_view;
+    RefPtr<GUI::TextBox> m_session_storage_textbox;
+    RefPtr<StorageModel> m_session_storage_model;
+    RefPtr<GUI::FilteringProxyModel> m_session_storage_filtering_model;
 };
 
 }

--- a/Userland/Applications/Browser/Tab.cpp
+++ b/Userland/Applications/Browser/Tab.cpp
@@ -615,6 +615,12 @@ void Tab::show_storage_inspector()
         m_storage_widget->set_local_storage_entries(local_storage_entries);
     }
 
+    if (on_get_session_storage_entries) {
+        auto session_storage_entries = on_get_session_storage_entries();
+        m_storage_widget->clear_session_storage_entries();
+        m_storage_widget->set_session_storage_entries(session_storage_entries);
+    }
+
     auto* window = m_storage_widget->window();
     window->show();
     window->move_to_front();

--- a/Userland/Applications/Browser/Tab.h
+++ b/Userland/Applications/Browser/Tab.h
@@ -66,6 +66,7 @@ public:
     Function<void()> on_dump_cookies;
     Function<Vector<Web::Cookie::Cookie>()> on_get_cookies_entries;
     Function<OrderedHashMap<String, String>()> on_get_local_storage_entries;
+    Function<OrderedHashMap<String, String>()> on_get_session_storage_entries;
 
     enum class InspectorTarget {
         Document,

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -495,6 +495,11 @@ OrderedHashMap<String, String> OutOfProcessWebView::get_local_storage_entries()
     return client().get_local_storage_entries();
 }
 
+OrderedHashMap<String, String> OutOfProcessWebView::get_session_storage_entries()
+{
+    return client().get_session_storage_entries();
+}
+
 void OutOfProcessWebView::set_content_filters(Vector<String> filters)
 {
     client().async_set_content_filters(filters);

--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.h
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.h
@@ -53,6 +53,7 @@ public:
     String dump_layout_tree();
 
     OrderedHashMap<String, String> get_local_storage_entries();
+    OrderedHashMap<String, String> get_session_storage_entries();
 
     void set_content_filters(Vector<String>);
     void set_proxy_mappings(Vector<String> proxies, HashMap<String, size_t> mappings);

--- a/Userland/Services/WebContent/ConnectionFromClient.cpp
+++ b/Userland/Services/WebContent/ConnectionFromClient.cpp
@@ -493,4 +493,11 @@ Messages::WebContentServer::GetLocalStorageEntriesResponse ConnectionFromClient:
     auto local_storage = document->window().local_storage();
     return local_storage->map();
 }
+
+Messages::WebContentServer::GetSessionStorageEntriesResponse ConnectionFromClient::get_session_storage_entries()
+{
+    auto* document = page().top_level_browsing_context().active_document();
+    auto session_storage = document->window().session_storage();
+    return session_storage->map();
+}
 }

--- a/Userland/Services/WebContent/ConnectionFromClient.h
+++ b/Userland/Services/WebContent/ConnectionFromClient.h
@@ -69,6 +69,7 @@ private:
     virtual void js_console_request_messages(i32) override;
 
     virtual Messages::WebContentServer::GetLocalStorageEntriesResponse get_local_storage_entries() override;
+    virtual Messages::WebContentServer::GetSessionStorageEntriesResponse get_session_storage_entries() override;
 
     virtual Messages::WebContentServer::GetSelectedTextResponse get_selected_text() override;
     virtual void select_all() override;

--- a/Userland/Services/WebContent/WebContentServer.ipc
+++ b/Userland/Services/WebContent/WebContentServer.ipc
@@ -49,5 +49,5 @@ endpoint WebContentServer
     set_is_scripting_enabled(bool is_scripting_enabled) =|
 
     get_local_storage_entries() => (OrderedHashMap<String,String> entries)
-
+    get_session_storage_entries() => (OrderedHashMap<String,String> entries)
 }


### PR DESCRIPTION
This PR adds ability to inspect session storage in Storage Inspector window.
I also added test page for Web Storage API.
![image](https://user-images.githubusercontent.com/5783815/167272737-e269f69e-cdb7-4974-b902-83d5b2203833.png)

![image](https://user-images.githubusercontent.com/5783815/167272764-9b37ed6c-f7f8-4f38-9924-cf100699cf52.png)
