### PR TITLE
LibJS: Change internal slots of Duration to store mathematical values

### DIFF
--- a/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/CalendarPrototype.cpp
@@ -174,9 +174,9 @@ JS_DEFINE_NATIVE_FUNCTION(CalendarPrototype::date_add)
     // 7. Let overflow be ? ToTemporalOverflow(options).
     auto overflow = TRY(to_temporal_overflow(global_object, options));
 
-    // 8. Let balanceResult be ! BalanceDuration(duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], "day").
+    // 8. Let balanceResult be ? BalanceDuration(duration.[[Days]], duration.[[Hours]], duration.[[Minutes]], duration.[[Seconds]], duration.[[Milliseconds]], duration.[[Microseconds]], duration.[[Nanoseconds]], "day").
     // FIXME: Narrowing conversion from 'double' to 'i64'
-    auto balance_result = MUST(balance_duration(global_object, duration->days(), duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), Crypto::SignedBigInteger::create_from(duration->nanoseconds()), "day"sv));
+    auto balance_result = TRY(balance_duration(global_object, duration->days(), duration->hours(), duration->minutes(), duration->seconds(), duration->milliseconds(), duration->microseconds(), Crypto::SignedBigInteger::create_from(duration->nanoseconds()), "day"sv));
 
     // 9. Let result be ? AddISODate(date.[[ISOYear]], date.[[ISOMonth]], date.[[ISODay]], duration.[[Years]], duration.[[Months]], duration.[[Weeks]], balanceResult.[[Days]], overflow).
     auto result = TRY(add_iso_date(global_object, date->iso_year(), date->iso_month(), date->iso_day(), duration->years(), duration->months(), duration->weeks(), balance_result.days, overflow));

--- a/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
+++ b/Userland/Libraries/LibJS/Runtime/Temporal/DurationPrototype.cpp
@@ -63,7 +63,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::years_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Years]].
+    // 3. Return 𝔽(duration.[[Years]]).
     return Value(duration->years());
 }
 
@@ -74,7 +74,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::months_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Months]].
+    // 3. Return 𝔽(duration.[[Months]]).
     return Value(duration->months());
 }
 
@@ -85,7 +85,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::weeks_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Weeks]].
+    // 3. Return 𝔽(duration.[[Weeks]]).
     return Value(duration->weeks());
 }
 
@@ -96,7 +96,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::days_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Days]].
+    // 3. Return 𝔽(duration.[[Days]]).
     return Value(duration->days());
 }
 
@@ -107,7 +107,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::hours_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Hours]].
+    // 3. Return 𝔽(duration.[[Hours]]).
     return Value(duration->hours());
 }
 
@@ -118,7 +118,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::minutes_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Minutes]].
+    // 3. Return 𝔽(duration.[[Minutes]]).
     return Value(duration->minutes());
 }
 
@@ -129,7 +129,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::seconds_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Seconds]].
+    // 3. Return 𝔽(duration.[[Seconds]]).
     return Value(duration->seconds());
 }
 
@@ -140,7 +140,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::milliseconds_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Milliseconds]].
+    // 3. Return 𝔽(duration.[[Milliseconds]]).
     return Value(duration->milliseconds());
 }
 
@@ -151,7 +151,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::microseconds_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Microseconds]].
+    // 3. Return 𝔽(duration.[[Microseconds]]).
     return Value(duration->microseconds());
 }
 
@@ -162,7 +162,7 @@ JS_DEFINE_NATIVE_FUNCTION(DurationPrototype::nanoseconds_getter)
     // 2. Perform ? RequireInternalSlot(duration, [[InitializedTemporalDuration]]).
     auto* duration = TRY(typed_this_object(global_object));
 
-    // 3. Return duration.[[Nanoseconds]].
+    // 3. Return 𝔽(duration.[[Nanoseconds]]).
     return Value(duration->nanoseconds());
 }
 

--- a/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.prototype.since.js
+++ b/Userland/Libraries/LibJS/Tests/builtins/Temporal/PlainDate/PlainDate.prototype.since.js
@@ -13,9 +13,9 @@ describe("correct behavior", () => {
         const dateTwo = new Temporal.PlainDate(2022, 12, 25);
         const sinceDuration = dateTwo.since(dateOne);
 
-        expect(sinceDuration.years).toBe(-0);
-        expect(sinceDuration.months).toBe(-0);
-        expect(sinceDuration.weeks).toBe(-0);
+        expect(sinceDuration.years).toBe(0);
+        expect(sinceDuration.months).toBe(0);
+        expect(sinceDuration.weeks).toBe(0);
         expect(sinceDuration.days).toBe(406);
         expect(sinceDuration.hours).toBe(0);
         expect(sinceDuration.minutes).toBe(0);
@@ -30,10 +30,10 @@ describe("correct behavior", () => {
         const equalDateTwo = new Temporal.PlainDate(1, 1, 1);
 
         const checkResults = result => {
-            expect(result.years).toBe(-0);
-            expect(result.months).toBe(-0);
-            expect(result.weeks).toBe(-0);
-            expect(result.days).toBe(-0);
+            expect(result.years).toBe(0);
+            expect(result.months).toBe(0);
+            expect(result.weeks).toBe(0);
+            expect(result.days).toBe(0);
             expect(result.hours).toBe(0);
             expect(result.minutes).toBe(0);
             expect(result.seconds).toBe(0);
@@ -53,9 +53,9 @@ describe("correct behavior", () => {
         const dateTwo = new Temporal.PlainDate(2022, 12, 25);
         const sinceDuration = dateOne.since(dateTwo);
 
-        expect(sinceDuration.years).toBe(-0);
-        expect(sinceDuration.months).toBe(-0);
-        expect(sinceDuration.weeks).toBe(-0);
+        expect(sinceDuration.years).toBe(0);
+        expect(sinceDuration.months).toBe(0);
+        expect(sinceDuration.weeks).toBe(0);
         expect(sinceDuration.days).toBe(-406);
         expect(sinceDuration.hours).toBe(0);
         expect(sinceDuration.minutes).toBe(0);
@@ -106,9 +106,9 @@ describe("correct behavior", () => {
         const dateTwo = new Temporal.PlainDate(2022, 12, 25);
         const sinceDuration = dateTwo.since("2021-11-14");
 
-        expect(sinceDuration.years).toBe(-0);
-        expect(sinceDuration.months).toBe(-0);
-        expect(sinceDuration.weeks).toBe(-0);
+        expect(sinceDuration.years).toBe(0);
+        expect(sinceDuration.months).toBe(0);
+        expect(sinceDuration.weeks).toBe(0);
         expect(sinceDuration.days).toBe(406);
         expect(sinceDuration.hours).toBe(0);
         expect(sinceDuration.minutes).toBe(0);


### PR DESCRIPTION
Fixes 125 test262 tests, bringing Temporal from 92.6% to 95.4% passing.