### PR TITLE
LibGUI: Consider favicon size when scrolling text horizontally

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -452,7 +452,10 @@ void TextEditor::paint_event(PaintEvent& event)
         painter.draw_line(ruler_rect.top_right(), ruler_rect.bottom_right(), palette().ruler_border());
     }
 
-    painter.translate(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
+    auto horizontal_scrollbar_value = horizontal_scrollbar().value();
+    painter.translate(-horizontal_scrollbar_value, -vertical_scrollbar().value());
+    if (m_icon && horizontal_scrollbar_value > 0)
+        painter.translate(min(icon_size() + icon_padding(), horizontal_scrollbar_value), 0);
     painter.translate(gutter_width(), 0);
     painter.translate(ruler_width(), 0);
 


### PR DESCRIPTION
If a favicon exists and the horizontal scroll value is bigger than 0,
translate the TextEditor painter by the favicon size and padding.

The text would scroll over the favicon when the text was long enough to
trigger a horizontal scroll.

Fixes #13669.

Note for reviewer:
There's another bug not mentioned, the cursor is not visible in a texteditor with an icon if the text scrolls horizontally far enough (this exists with or without this commit). I thought it was outside the scope of this PR to fix that, but I can look into it or open an issue.