### PR TITLE
Kernel/USB: Add support for bulk transfers

### DIFF
--- a/Kernel/Bus/USB/UHCI/UHCIController.h
+++ b/Kernel/Bus/USB/UHCI/UHCIController.h
@@ -45,6 +45,7 @@ public:
     ErrorOr<void> spawn_port_process();
 
     virtual ErrorOr<size_t> submit_control_transfer(Transfer& transfer) override;
+    virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) override;
 
     void get_port_status(Badge<UHCIRootHub>, u8, HubStatus&);
     ErrorOr<void> set_port_feature(Badge<UHCIRootHub>, u8, HubFeatureSelector);

--- a/Kernel/Bus/USB/USBController.h
+++ b/Kernel/Bus/USB/USBController.h
@@ -24,6 +24,7 @@ public:
     virtual ErrorOr<void> start() = 0;
 
     virtual ErrorOr<size_t> submit_control_transfer(Transfer&) = 0;
+    virtual ErrorOr<size_t> submit_bulk_transfer(Transfer& transfer) = 0;
 
     u8 allocate_address();
 

--- a/Kernel/Bus/USB/USBPipe.h
+++ b/Kernel/Bus/USB/USBPipe.h
@@ -57,6 +57,7 @@ public:
     void set_device_address(i8 addr) { m_device_address = addr; }
 
     ErrorOr<size_t> control_transfer(u8 request_type, u8 request, u16 value, u16 index, u16 length, void* data);
+    ErrorOr<size_t> bulk_transfer(u16 length, void* data);
 
     Pipe(USBController const& controller, Type type, Direction direction, u16 max_packet_size);
     Pipe(USBController const& controller, Type type, Direction direction, USBEndpointDescriptor& endpoint);

--- a/Kernel/Bus/USB/USBTransfer.cpp
+++ b/Kernel/Bus/USB/USBTransfer.cpp
@@ -43,4 +43,13 @@ void Transfer::set_setup_packet(USBRequestData const& request)
     m_request = request;
 }
 
+ErrorOr<void> Transfer::write_buffer(u16 len, void* data)
+{
+    VERIFY(len <= m_data_buffer->size());
+    m_transfer_data_size = len;
+    memcpy(buffer().as_ptr(), data, len);
+
+    return {};
+}
+
 }

--- a/Kernel/Bus/USB/USBTransfer.h
+++ b/Kernel/Bus/USB/USBTransfer.h
@@ -28,6 +28,8 @@ public:
     void set_complete() { m_complete = true; }
     void set_error_occurred() { m_error_occurred = true; }
 
+    ErrorOr<void> write_buffer(u16 len, void* data);
+
     // `const` here makes sure we don't blow up by writing to a physical address
     USBRequestData const& request() const { return m_request; }
     Pipe const& pipe() const { return m_pipe; }
@@ -47,4 +49,5 @@ private:
     bool m_complete { false };                   // Has this transfer been completed?
     bool m_error_occurred { false };             // Did an error occur during this transfer?
 };
+
 }


### PR DESCRIPTION
This commit introduces support for USB bulk transfers. Confirmed tested & working on https://github.com/b14ckcat/serenity/tree/msc_driver where I'm using the code in this commit to talk to the QEMU virtual mass storage class (i.e. USB flash drive) device.