### PR TITLE
LibTest: Add JUnit xml output and publish test results in CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -207,11 +207,12 @@ jobs:
           sudo mount -t ext2 -o loop,rw _disk_image fsmount
           echo "Results: "
           sudo cat fsmount/home/anon/test-results.log
-          if ! sudo grep -q "Failed: 0" fsmount/home/anon/test-results.log
-          then
+          sudo cp fsmount/home/anon/junit.xml .
+          if [ ! -e ./junit.xml ]; then
             echo "::error :^( Tests failed, failing job"
             exit 1
           fi
+          sudo umount fsmount
           echo "::endgroup::"
         timeout-minutes: 60
 
@@ -220,6 +221,15 @@ jobs:
         if: ${{ !cancelled() && matrix.debug-options == 'NORMAL_DEBUG'}}
         working-directory: ${{ github.workspace }}/Build/${{ matrix.arch }}
         run: '[ ! -e debug.log ] || cat debug.log'
+
+      - name: Upload Test Results
+        if: ${{ !cancelled() && matrix.debug-options == 'NORMAL_DEBUG'}}
+        uses: actions/upload-artifact@v3
+        with:
+          name: Test Results (GNU ${{ matrix.arch }})
+          path: ${{ github.workspace }}/Build/${{ matrix.arch }}/junit.xml
+          if-no-files-found: error
+          retention-days: 1 # default is 90
 
       - name: Check manpages for completeness
         if: ${{ matrix.debug-options == 'NORMAL_DEBUG' && matrix.arch == 'i686'}}
@@ -234,3 +244,15 @@ jobs:
           ninja image
           /usr/bin/time ../../Meta/export-argsparser-manpages.sh --verify-git-state
         timeout-minutes: 10
+
+  # Needed for test-results workflow
+  event_file:
+    name: "Event File"
+    runs-on: ubuntu-latest
+    steps:
+    - name: Upload
+      uses: actions/upload-artifact@v3
+      with:
+        name: Event File
+        path: ${{ github.event_path }}
+        retention-days: 1 # default is 90

--- a/.github/workflows/test-results.yml
+++ b/.github/workflows/test-results.yml
@@ -1,0 +1,46 @@
+name: Test Results
+
+# Note: This workflow copied from https://github.com/EnricoMi/publish-unit-test-result-action/blob/v1.35/README.md#support-fork-repositories-and-dependabot-branches
+on:
+  workflow_run:
+    workflows: [Build, lint, and test]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  test-results:
+    name: Test Results
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      checks: write
+      # Enable if we want to have the job comment "oy tests failed" on PRs
+      # pull-requests: write
+    if: github.event.workflow_run.conclusion != 'skipped'
+
+    steps:
+      - name: Download and Extract Artifacts
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+           mkdir -p artifacts && cd artifacts
+
+           artifacts_url=${{ github.event.workflow_run.artifacts_url }}
+
+           gh api "$artifacts_url" -q '.artifacts[] | [.name, .archive_download_url] | @tsv' | while read artifact
+           do
+             IFS=$'\t' read name url <<< "$artifact"
+             gh api $url > "$name.zip"
+             unzip -d "$name" "$name.zip"
+           done
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        with:
+          commit: ${{ github.event.workflow_run.head_sha }}
+          event_file: artifacts/Event File/event.json
+          event_name: ${{ github.event.workflow_run.event }}
+          files: "artifacts/**/*.xml"
+          comment_mode: off

--- a/Base/home/anon/Tests/run-tests-and-shutdown.sh
+++ b/Base/home/anon/Tests/run-tests-and-shutdown.sh
@@ -5,7 +5,7 @@ echo "==== Running Tests on SerenityOS ===="
 
 export LLVM_PROFILE_FILE="$HOME/profiles/%p-profile.profraw"
 
-run-tests --show-progress=false
+run-tests --show-progress=false --junit
 fail_count=$?
 
 unset LLVM_PROFILE_FILE

--- a/Meta/Azure/Serenity.yml
+++ b/Meta/Azure/Serenity.yml
@@ -79,10 +79,10 @@ jobs:
         sudo cat fsmount/home/anon/test-results.log
         echo "##[endgroup]"
 
-        if ! sudo grep -q "Failed: 0" fsmount/home/anon/test-results.log
-        then
-          echo "##[error]:^( Tests failed, failing job"
-          exit 1
+        sudo cp fsmount/home/anon/junit.xml .
+        if [ ! -e ./junit.xml ]; then
+            echo "##[error]:^( Tests failed, failing job"
+            return 1
         fi
         sudo umount fsmount
       displayName: 'Test'
@@ -92,6 +92,14 @@ jobs:
         SERENITY_QEMU_CPU: 'max,vmx=off'
         SERENITY_KERNEL_CMDLINE: 'fbdev=off panic=shutdown system_mode=self-test'
         SERENITY_RUN: 'ci'
+
+    - task: PublishTestResults@2
+      inputs:
+        testResultsFormat: 'JUnit'
+        testResultsFiles: $(Build.SourcesDirectory)/Build/${{ parameters.arch }}clang/junit.xml
+        testRunTitle: 'Serenity_Clang_${{ parameters.arch }}_Coverage_${{ parameters.coverage }}'
+        platform: ${{ parameters.arch }}_Clang
+        failTaskOnFailedTests: true
 
     - script: |
         [ ! -e debug.log ] || cat debug.log

--- a/Tests/AK/TestString.cpp
+++ b/Tests/AK/TestString.cpp
@@ -327,3 +327,14 @@ TEST_CASE(roman_numerals)
     auto four_thousand = String::roman_number_from(4000);
     EXPECT_EQ(four_thousand, "4000");
 }
+
+TEST_CASE(view_lines)
+{
+    String multiline = "well\nhello\nfriends\n";
+    auto lines = multiline.view().lines();
+
+    EXPECT_EQ(lines.size(), 4U);
+    EXPECT_EQ(lines[0], "well");
+    EXPECT_EQ(lines[1], "hello");
+    EXPECT_EQ(lines[2], "friends");
+}

--- a/Userland/Libraries/LibTest/JavaScriptTestRunner.h
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunner.h
@@ -168,8 +168,8 @@ extern IntermediateRunFileResult (*g_run_file)(String const&, JS::Interpreter&, 
 
 class TestRunner : public ::Test::TestRunner {
 public:
-    TestRunner(String test_root, String common_path, bool print_times, bool print_progress, bool print_json, bool detailed_json)
-        : ::Test::TestRunner(move(test_root), print_times, print_progress, print_json, detailed_json)
+    TestRunner(String test_root, String common_path, bool print_times, bool print_progress, OutputFormat output_format)
+        : ::Test::TestRunner(move(test_root), print_times, print_progress, output_format)
         , m_common_path(move(common_path))
     {
         g_test_root = m_test_root;
@@ -264,10 +264,9 @@ inline ErrorOr<JsonValue> get_test_results(JS::Interpreter& interpreter)
 inline void TestRunner::do_run_single_test(String const& test_path, size_t, size_t)
 {
     auto file_result = run_file_test(test_path);
-    if (!m_print_json)
+    if (m_output_format == OutputFormat::UTF8)
         print_file_result(file_result);
-
-    if (needs_detailed_suites())
+    else
         ensure_suites().extend(file_result.suites);
 }
 

--- a/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
+++ b/Userland/Libraries/LibTest/JavaScriptTestRunnerMain.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv)
 #else
         false;
 #endif
-    bool print_json = false;
+    bool print_json = getenv("LIBTEST_JSON_FD") != nullptr;
     bool per_file = false;
     char const* specified_test_root = nullptr;
     String common_path;
@@ -187,7 +187,13 @@ int main(int argc, char** argv)
         g_vm->enable_default_host_import_module_dynamically_hook();
     }
 
-    Test::JS::TestRunner test_runner(test_root, common_path, print_times, print_progress, print_json, per_file);
+    auto output_format = Test::TestRunner::OutputFormat::UTF8;
+    if (per_file)
+        output_format = Test::TestRunner::OutputFormat::DetailedJSON;
+    else if (print_json)
+        output_format = Test::TestRunner::OutputFormat::JSON;
+
+    Test::JS::TestRunner test_runner(test_root, common_path, print_times, print_progress, output_format);
     test_runner.run(test_glob);
 
     g_vm = nullptr;

--- a/Userland/Libraries/LibTest/Macros.h
+++ b/Userland/Libraries/LibTest/Macros.h
@@ -12,90 +12,89 @@
 #include <AK/Math.h>
 #include <LibTest/CrashTest.h>
 
-namespace AK {
-template<typename... Parameters>
-void warnln(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&...);
-}
-
 namespace Test {
-// Declare a helper so that we can call it from VERIFY in included headers
+// Declare helpers so that we can call them from VERIFY in included headers
 void current_test_case_did_fail();
+
+template<typename... Parameters>
+void report_test_details(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters);
+
 }
 
 #undef VERIFY
-#define VERIFY(x)                                                                                    \
-    do {                                                                                             \
-        if (!(x)) {                                                                                  \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: VERIFY({}) failed", __FILE__, __LINE__, #x); \
-            ::Test::current_test_case_did_fail();                                                    \
-        }                                                                                            \
+#define VERIFY(x)                                                                                                   \
+    do {                                                                                                            \
+        if (!(x)) {                                                                                                 \
+            ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: VERIFY({}) failed", __FILE__, __LINE__, #x); \
+            ::Test::current_test_case_did_fail();                                                                   \
+        }                                                                                                           \
     } while (false)
 
 #undef VERIFY_NOT_REACHED
-#define VERIFY_NOT_REACHED()                                                                           \
-    do {                                                                                               \
-        ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: VERIFY_NOT_REACHED() called", __FILE__, __LINE__); \
-        ::abort();                                                                                     \
+#define VERIFY_NOT_REACHED()                                                                                          \
+    do {                                                                                                              \
+        ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: VERIFY_NOT_REACHED() called", __FILE__, __LINE__); \
+        ::abort();                                                                                                    \
     } while (false)
 
 #undef TODO
-#define TODO()                                                                           \
-    do {                                                                                 \
-        ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: TODO() called", __FILE__, __LINE__); \
-        ::abort();                                                                       \
+#define TODO()                                                                                          \
+    do {                                                                                                \
+        ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: TODO() called", __FILE__, __LINE__); \
+        ::abort();                                                                                      \
     } while (false)
 
-#define EXPECT_EQ(a, b)                                                                                                                                                                      \
-    do {                                                                                                                                                                                     \
-        auto lhs = (a);                                                                                                                                                                      \
-        auto rhs = (b);                                                                                                                                                                      \
-        if (lhs != rhs) {                                                                                                                                                                    \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, FormatIfSupported { rhs }); \
-            ::Test::current_test_case_did_fail();                                                                                                                                            \
-        }                                                                                                                                                                                    \
+#define EXPECT_EQ(a, b)                                                                                                                                                                                     \
+    do {                                                                                                                                                                                                    \
+        auto lhs = (a);                                                                                                                                                                                     \
+        auto rhs = (b);                                                                                                                                                                                     \
+        if (lhs != rhs) {                                                                                                                                                                                   \
+            ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, FormatIfSupported { rhs }); \
+            ::Test::current_test_case_did_fail();                                                                                                                                                           \
+        }                                                                                                                                                                                                   \
     } while (false)
 
-#define EXPECT_EQ_TRUTH(a, b)                                                                                             \
-    do {                                                                                                                  \
-        auto lhs = (a);                                                                                                   \
-        auto rhs = (b);                                                                                                   \
-        bool ltruth = static_cast<bool>(lhs);                                                                             \
-        bool rtruth = static_cast<bool>(rhs);                                                                             \
-        if (ltruth != rtruth) {                                                                                           \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ_TRUTH({}, {}) failed with lhs={} ({}) and rhs={} ({})", \
-                __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, ltruth, FormatIfSupported { rhs }, rtruth);        \
-            ::Test::current_test_case_did_fail();                                                                         \
-        }                                                                                                                 \
+#define EXPECT_EQ_TRUTH(a, b)                                                                                                            \
+    do {                                                                                                                                 \
+        auto lhs = (a);                                                                                                                  \
+        auto rhs = (b);                                                                                                                  \
+        bool ltruth = static_cast<bool>(lhs);                                                                                            \
+        bool rtruth = static_cast<bool>(rhs);                                                                                            \
+        if (ltruth != rtruth) {                                                                                                          \
+            ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ_TRUTH({}, {}) failed with lhs={} ({}) and rhs={} ({})", \
+                __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, ltruth, FormatIfSupported { rhs }, rtruth);                       \
+            ::Test::current_test_case_did_fail();                                                                                        \
+        }                                                                                                                                \
     } while (false)
 
 // If you're stuck and `EXPECT_EQ` seems to refuse to print anything useful,
 // try this: It'll spit out a nice compiler error telling you why it doesn't print.
-#define EXPECT_EQ_FORCE(a, b)                                                                                                                    \
-    do {                                                                                                                                         \
-        auto lhs = (a);                                                                                                                          \
-        auto rhs = (b);                                                                                                                          \
-        if (lhs != rhs) {                                                                                                                        \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, lhs, rhs); \
-            ::Test::current_test_case_did_fail();                                                                                                \
-        }                                                                                                                                        \
+#define EXPECT_EQ_FORCE(a, b)                                                                                                                                   \
+    do {                                                                                                                                                        \
+        auto lhs = (a);                                                                                                                                         \
+        auto rhs = (b);                                                                                                                                         \
+        if (lhs != rhs) {                                                                                                                                       \
+            ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_EQ({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, lhs, rhs); \
+            ::Test::current_test_case_did_fail();                                                                                                               \
+        }                                                                                                                                                       \
     } while (false)
 
-#define EXPECT_NE(a, b)                                                                                                                                                                      \
-    do {                                                                                                                                                                                     \
-        auto lhs = (a);                                                                                                                                                                      \
-        auto rhs = (b);                                                                                                                                                                      \
-        if (lhs == rhs) {                                                                                                                                                                    \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_NE({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, FormatIfSupported { rhs }); \
-            ::Test::current_test_case_did_fail();                                                                                                                                            \
-        }                                                                                                                                                                                    \
+#define EXPECT_NE(a, b)                                                                                                                                                                                     \
+    do {                                                                                                                                                                                                    \
+        auto lhs = (a);                                                                                                                                                                                     \
+        auto rhs = (b);                                                                                                                                                                                     \
+        if (lhs == rhs) {                                                                                                                                                                                   \
+            ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_NE({}, {}) failed with lhs={} and rhs={}", __FILE__, __LINE__, #a, #b, FormatIfSupported { lhs }, FormatIfSupported { rhs }); \
+            ::Test::current_test_case_did_fail();                                                                                                                                                           \
+        }                                                                                                                                                                                                   \
     } while (false)
 
-#define EXPECT(x)                                                                                    \
-    do {                                                                                             \
-        if (!(x)) {                                                                                  \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT({}) failed", __FILE__, __LINE__, #x); \
-            ::Test::current_test_case_did_fail();                                                    \
-        }                                                                                            \
+#define EXPECT(x)                                                                                                   \
+    do {                                                                                                            \
+        if (!(x)) {                                                                                                 \
+            ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: EXPECT({}) failed", __FILE__, __LINE__, #x); \
+            ::Test::current_test_case_did_fail();                                                                   \
+        }                                                                                                           \
     } while (false)
 
 #define EXPECT_APPROXIMATE(a, b)                                                                                \
@@ -104,17 +103,17 @@ void current_test_case_did_fail();
         auto expect_close_rhs = b;                                                                              \
         auto expect_close_diff = static_cast<double>(expect_close_lhs) - static_cast<double>(expect_close_rhs); \
         if (AK::fabs(expect_close_diff) > 0.0000005) {                                                          \
-            ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_APPROXIMATE({}, {})"                             \
-                         " failed with lhs={}, rhs={}, (lhs-rhs)={}",                                           \
+            ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: EXPECT_APPROXIMATE({}, {})"              \
+                                        " failed with lhs={}, rhs={}, (lhs-rhs)={}",                            \
                 __FILE__, __LINE__, #a, #b, expect_close_lhs, expect_close_rhs, expect_close_diff);             \
             ::Test::current_test_case_did_fail();                                                               \
         }                                                                                                       \
     } while (false)
 
-#define FAIL(message)                                                                  \
-    do {                                                                               \
-        ::AK::warnln("\033[31;1mFAIL\033[0m: {}:{}: {}", __FILE__, __LINE__, message); \
-        ::Test::current_test_case_did_fail();                                          \
+#define FAIL(message)                                                                                 \
+    do {                                                                                              \
+        ::Test::report_test_details("\033[31;1mFAIL\033[0m: {}:{}: {}", __FILE__, __LINE__, message); \
+        ::Test::current_test_case_did_fail();                                                         \
     } while (false)
 
 // To use, specify the lambda to execute in a sub process and verify it exits:

--- a/Userland/Libraries/LibTest/Results.h
+++ b/Userland/Libraries/LibTest/Results.h
@@ -34,6 +34,7 @@ struct Suite {
     // precedence over a passed test
     Result most_severe_test_result { Result::Pass };
     Vector<Case> tests {};
+    u64 total_duration_us = { 0 };
 };
 
 struct Counts {

--- a/Userland/Libraries/LibTest/TestCase.h
+++ b/Userland/Libraries/LibTest/TestCase.h
@@ -37,9 +37,20 @@ private:
     bool m_is_benchmark;
 };
 
-// Helper to hide implementation of TestSuite from users
+// Helpers to hide implementation of TestSuite from users
 void add_test_case_to_suite(NonnullRefPtr<TestCase> const& test_case);
 void set_suite_setup_function(Function<void()> setup);
+void vreport_test_details(StringView fmtstr, AK::TypeErasedFormatParams&);
+
+template<typename... Parameters>
+void report_test_details(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    AK::VariadicFormatParams variadic_format_params { parameters... };
+    AK::vout(stderr, fmtstr.view(), variadic_format_params, true);
+    // TypeErasedFormatParams are "consumed" when formatting, so create another copy...
+    AK::VariadicFormatParams variadic_format_params2 { parameters... };
+    vreport_test_details(fmtstr.view(), variadic_format_params2);
+}
 }
 
 #define TEST_SETUP                                                  \

--- a/Userland/Libraries/LibTest/TestSuite.cpp
+++ b/Userland/Libraries/LibTest/TestSuite.cpp
@@ -8,10 +8,19 @@
 #include <LibTest/Macros.h> // intentionally first -- we redefine VERIFY and friends in here
 
 #include <AK/Function.h>
+#include <AK/JsonArray.h>
+#include <AK/JsonObject.h>
+#include <AK/JsonValue.h>
+#include <AK/LexicalPath.h>
+#include <AK/String.h>
+#include <AK/StringView.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
 #include <LibTest/TestSuite.h>
+#include <fcntl.h>
 #include <stdlib.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 namespace Test {
 
@@ -56,20 +65,35 @@ void set_suite_setup_function(Function<void()> setup)
     TestSuite::the().set_suite_setup(move(setup));
 }
 
+// Declared in TestCase.h
+void vreport_test_details(StringView fmtstr, AK::TypeErasedFormatParams& params)
+{
+    TestSuite::the().vreport_test_details(fmtstr, params);
+}
+
+void TestSuite::vreport_test_details(StringView fmtstr, AK::TypeErasedFormatParams& params)
+{
+    MUST(vformat(m_current_test_case_details, fmtstr, params));
+}
+
 int TestSuite::main(String const& suite_name, int argc, char** argv)
 {
-    m_suite_name = suite_name;
+    m_suite_name = LexicalPath(suite_name).basename();
 
     Core::ArgsParser args_parser;
+
+    String json_fd_str = getenv("LIBTEST_JSON_FD");
 
     bool do_tests_only = getenv("TESTS_ONLY") != nullptr;
     bool do_benchmarks_only = false;
     bool do_list_cases = false;
+    bool do_output_json = !json_fd_str.is_empty();
     char const* search_string = "*";
 
-    args_parser.add_option(do_tests_only, "Only run tests.", "tests", 0);
-    args_parser.add_option(do_benchmarks_only, "Only run benchmarks.", "bench", 0);
-    args_parser.add_option(do_list_cases, "List available test cases.", "list", 0);
+    args_parser.add_option(do_tests_only, "Only run tests.", "tests", '\0');
+    args_parser.add_option(do_benchmarks_only, "Only run benchmarks.", "bench", '\0');
+    args_parser.add_option(do_list_cases, "List available test cases.", "list", '\0');
+    args_parser.add_option(do_output_json, "Dump results as JSON", "json", '\0');
     args_parser.add_positional_argument(search_string, "Only run matching cases.", "pattern", Core::ArgsParser::Required::No);
     args_parser.parse(argc, argv);
 
@@ -79,7 +103,7 @@ int TestSuite::main(String const& suite_name, int argc, char** argv)
     auto const& matching_tests = find_cases(search_string, !do_benchmarks_only, !do_tests_only);
 
     if (do_list_cases) {
-        outln("Available cases for {}:", suite_name);
+        outln("Available cases for {}:", m_suite_name);
         for (auto const& test : matching_tests) {
             outln("    {}", test.name());
         }
@@ -88,7 +112,28 @@ int TestSuite::main(String const& suite_name, int argc, char** argv)
 
     outln("Running {} cases out of {}.", matching_tests.size(), m_cases.size());
 
-    return run(matching_tests);
+    RefPtr<Core::File> json_file;
+    if (!json_fd_str.is_empty()) {
+        auto maybe_fd = json_fd_str.to_int();
+        if (!maybe_fd.has_value()) {
+            warnln("Invalid FD {} passed to Test Suite!", json_fd_str);
+            do_output_json = false;
+        } else {
+            json_file = Core::File::construct();
+            bool opened = json_file->open(maybe_fd.release_value(), Core::OpenMode::WriteOnly, Core::File::ShouldCloseFileDescriptor::Yes);
+            VERIFY(opened);
+        }
+    }
+    if (do_output_json && !json_file) {
+        auto json_filename = String::formatted("./{}.json", m_suite_name);
+        auto maybe_file = Core::File::open(json_filename, Core::OpenMode::WriteOnly);
+        if (maybe_file.is_error())
+            warnln("Unable to open {} for json output", json_filename);
+        else
+            json_file = maybe_file.release_value();
+    }
+
+    return run(matching_tests, move(json_file));
 }
 
 NonnullRefPtrVector<TestCase> TestSuite::find_cases(String const& search, bool find_tests, bool find_benchmarks)
@@ -111,18 +156,19 @@ NonnullRefPtrVector<TestCase> TestSuite::find_cases(String const& search, bool f
     return matches;
 }
 
-int TestSuite::run(NonnullRefPtrVector<TestCase> const& tests)
+int TestSuite::run(NonnullRefPtrVector<TestCase> const& tests, RefPtr<Core::File> json_output)
 {
     size_t test_count = 0;
     size_t test_failed_count = 0;
     size_t benchmark_count = 0;
+    JsonArray test_array;
     TestElapsedTimer global_timer;
 
     for (auto const& t : tests) {
-        auto const test_type = t.is_benchmark() ? "benchmark" : "test";
-
+        auto const test_type = t.is_benchmark() ? "benchmark"sv : "test"sv;
         warnln("Running {} '{}'.", test_type, t.name());
         m_current_test_case_passed = true;
+        m_current_test_case_details.clear();
 
         TestElapsedTimer timer;
         t.func()();
@@ -141,18 +187,38 @@ int TestSuite::run(NonnullRefPtrVector<TestCase> const& tests)
         if (!m_current_test_case_passed) {
             test_failed_count++;
         }
+
+        if (json_output) {
+            JsonObject current_test;
+            current_test.set("name", t.name());
+            current_test.set("type", test_type);
+            current_test.set("elapsed_ms", time);
+            current_test.set("result", m_current_test_case_passed ? "PASSED" : "FAILED");
+            current_test.set("details", m_current_test_case_details.to_string());
+            test_array.append(current_test);
+        }
     }
 
+    auto total_ms = global_timer.elapsed_milliseconds();
     dbgln("Finished {} tests and {} benchmarks in {}ms ({}ms tests, {}ms benchmarks, {}ms other).",
         test_count,
         benchmark_count,
-        global_timer.elapsed_milliseconds(),
+        total_ms,
         m_testtime,
         m_benchtime,
-        global_timer.elapsed_milliseconds() - (m_testtime + m_benchtime));
+        total_ms - (m_testtime + m_benchtime));
     dbgln("Out of {} tests, {} passed and {} failed.", test_count, test_count - test_failed_count, test_failed_count);
+
+    if (json_output) {
+        JsonObject root;
+        root.set("name", m_suite_name);
+        root.set("total_ms", total_ms);
+        root.set("passed", test_count - test_failed_count);
+        root.set("failed", test_failed_count);
+        root.set("results", test_array);
+        json_output->write(root.to_string());
+    }
 
     return (int)test_failed_count;
 }
-
 }

--- a/Userland/Libraries/LibTest/TestSuite.h
+++ b/Userland/Libraries/LibTest/TestSuite.h
@@ -13,6 +13,8 @@
 #include <AK/Function.h>
 #include <AK/NonnullRefPtrVector.h>
 #include <AK/String.h>
+#include <AK/StringBuilder.h>
+#include <LibCore/Forward.h>
 #include <LibTest/TestCase.h>
 
 namespace Test {
@@ -33,7 +35,7 @@ public:
         s_global = nullptr;
     }
 
-    int run(NonnullRefPtrVector<TestCase> const&);
+    int run(NonnullRefPtrVector<TestCase> const&, RefPtr<Core::File> json_output);
     int main(String const& suite_name, int argc, char** argv);
     NonnullRefPtrVector<TestCase> find_cases(String const& search, bool find_tests, bool find_benchmarks);
     void add_case(NonnullRefPtr<TestCase> const& test_case)
@@ -42,6 +44,8 @@ public:
     }
 
     void current_test_case_did_fail() { m_current_test_case_passed = false; }
+
+    void vreport_test_details(StringView fmtstr, AK::TypeErasedFormatParams&);
 
     void set_suite_setup(Function<void()> setup) { m_setup = move(setup); }
 
@@ -52,6 +56,7 @@ private:
     u64 m_benchtime = 0;
     String m_suite_name;
     bool m_current_test_case_passed = true;
+    StringBuilder m_current_test_case_details;
     Function<void()> m_setup;
 };
 


### PR DESCRIPTION
- Tell LibTest Tests how to output JSON test results. Write them to a secret fd back to `run-tests` when the LIBTEST_JSON_FD environment variable is set.

- Update `run-tests` to create Test::Suite objects for each test it runs. Works best when said tests report their results back via the LIBTEST_JSON_FD.

- Teach LibTest how to output JUnit XML test reports for TestRunners.

- Add test publish job to Azure and Github Actions using the new JUnit format.
