### PR TITLE
LibWeb: Add missing preprocessing step to the css tokenizer

### DIFF
--- a/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
+++ b/Userland/Libraries/LibWeb/CSS/Parser/Tokenizer.cpp
@@ -223,6 +223,8 @@ Tokenizer::Tokenizer(StringView input, String const& encoding)
                 }
             } else if (code_point == '\f') {
                 builder.append('\n');
+            } else if (code_point == 0x00) {
+                builder.append_code_point(REPLACEMENT_CHARACTER);
             } else if (code_point >= 0xD800 && code_point <= 0xDFFF) {
                 builder.append_code_point(REPLACEMENT_CHARACTER);
             } else {


### PR DESCRIPTION
This was in the spec comment above, but not in the code :^)

Fixes all the tests on https://wpt.live/css/css-syntax/input-preprocessing.html