### PR TITLE
LibGUI: Don't collapse TreeView when invalidated

### DIFF
--- a/Userland/Libraries/LibGUI/TreeView.cpp
+++ b/Userland/Libraries/LibGUI/TreeView.cpp
@@ -28,7 +28,10 @@ TreeView::MetadataForIndex& TreeView::ensure_metadata_for_index(ModelIndex const
     auto it = m_view_metadata.find(index);
     if (it != m_view_metadata.end())
         return *it->value;
+    auto it_old = m_view_metadata_old.find(index);
     auto new_metadata = make<MetadataForIndex>();
+    if (it_old != m_view_metadata_old.end())
+        swap(new_metadata, it_old->value);
     auto& new_metadata_ref = *new_metadata;
     m_view_metadata.set(index, move(new_metadata));
     return new_metadata_ref;
@@ -413,6 +416,9 @@ void TreeView::scroll_into_view(ModelIndex const& a_index, bool, bool scroll_ver
 
 void TreeView::model_did_update(unsigned flags)
 {
+    // Clear metadata but keep the old values and indices
+    // for when they are needed again
+    swap(m_view_metadata_old, m_view_metadata);
     m_view_metadata.clear();
     AbstractTableView::model_did_update(flags);
 }

--- a/Userland/Libraries/LibGUI/TreeView.h
+++ b/Userland/Libraries/LibGUI/TreeView.h
@@ -74,6 +74,7 @@ private:
     void set_open_state_of_all_in_subtree(ModelIndex const& root, bool open);
 
     mutable HashMap<ModelIndex, NonnullOwnPtr<MetadataForIndex>> m_view_metadata;
+    mutable HashMap<ModelIndex, NonnullOwnPtr<MetadataForIndex>> m_view_metadata_old;
 
     RefPtr<Gfx::Bitmap> m_expand_bitmap;
     RefPtr<Gfx::Bitmap> m_collapse_bitmap;


### PR DESCRIPTION
When TreeView::model_did_update gets called (eg. by deleting a file),
the metadata is cleared. This means that the folders in the TreeView
would collapse.

Instead of clearing the metadata on update, keep them in a new HashMap
and retrieve the old values if they exist instead of creating new
metadata.

Fixes #6903.