### PR TITLE
LibGfx: Add the glyph spacing also to spaces in `Painter::draw_text_run()`

### DIFF
--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -2327,7 +2327,7 @@ void Painter::draw_text_run(FloatPoint const& baseline_start, Utf8View const& st
     for (auto code_point_iterator = string.begin(); code_point_iterator != string.end(); ++code_point_iterator) {
         auto code_point = *code_point_iterator;
         if (code_point == ' ') {
-            x += space_width;
+            x += space_width + font.glyph_spacing();
             last_code_point = code_point;
             continue;
         }


### PR DESCRIPTION
This caused the text selection not to match the selected glyph after some words.

master | this change
---|---
![](https://user-images.githubusercontent.com/16520278/167311542-acdf0c9d-d73b-433e-a482-92b924766f8b.png) | ![](https://user-images.githubusercontent.com/16520278/167311543-b6cd58d2-6f66-45ca-8c7b-279238a46b6e.png)

(if you look carefully then you’ll see that in the selection in Text Editor the spacing is *after* the glyph, where in the Browser it’s *before* the glyph. Very strange but i’m not going to debug it right now ![:yakbait:](https://cdn.discordapp.com/emojis/873672505309679758.png?size=20))