### PR TITLE
LibGUI+LibGfx: Invert (solid color) button icons with low contrast ratios

### DIFF
--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -78,6 +78,13 @@ void Button::paint_event(PaintEvent& event)
     }
 
     if (m_icon) {
+        auto solid_color = m_icon->solid_color(60);
+        // Note: 4.5 is the minimum recommended constrast ratio for text on the web:
+        // (https://developer.mozilla.org/en-US/docs/Web/Accessibility/Understanding_WCAG/Perceivable/Color_contrast)
+        // Reusing that threshold here as it seems to work reasonably well.
+        bool should_invert_icon = solid_color.has_value() && palette().button().contrast_ratio(*solid_color) < 4.5f;
+        if (should_invert_icon)
+            m_icon->invert();
         if (is_enabled()) {
             if (is_hovered())
                 painter.blit_brightened(icon_location, *m_icon, m_icon->rect());
@@ -86,6 +93,8 @@ void Button::paint_event(PaintEvent& event)
         } else {
             painter.blit_disabled(icon_location, *m_icon, m_icon->rect(), palette());
         }
+        if (should_invert_icon)
+            m_icon->invert();
     }
     auto& font = is_checked() ? this->font().bold_variant() : this->font();
     if (m_icon && !text().is_empty()) {

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -469,6 +469,14 @@ ErrorOr<NonnullRefPtr<Bitmap>> Bitmap::to_bitmap_backed_by_anonymous_buffer() co
     return bitmap;
 }
 
+void Bitmap::invert()
+{
+    for (auto y = 0; y < height(); y++) {
+        for (auto x = 0; x < width(); x++)
+            set_pixel(x, y, get_pixel(x, y).inverted());
+    }
+}
+
 Bitmap::~Bitmap()
 {
     if (m_needs_munmap) {

--- a/Userland/Libraries/LibGfx/Bitmap.cpp
+++ b/Userland/Libraries/LibGfx/Bitmap.cpp
@@ -608,4 +608,21 @@ bool Bitmap::visually_equals(Bitmap const& other) const
     return true;
 }
 
+Optional<Color> Bitmap::solid_color(u8 alpha_threshold) const
+{
+    Optional<Color> color;
+    for (auto y = 0; y < height(); ++y) {
+        for (auto x = 0; x < width(); ++x) {
+            auto const& pixel = get_pixel(x, y);
+            if (has_alpha_channel() && pixel.alpha() <= alpha_threshold)
+                continue;
+            if (!color.has_value())
+                color = pixel;
+            else if (pixel != color)
+                return {};
+        }
+    }
+    return color;
+}
+
 }

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -121,6 +121,8 @@ public:
 
     [[nodiscard]] ShareableBitmap to_shareable_bitmap() const;
 
+    void invert();
+
     ~Bitmap();
 
     [[nodiscard]] u8* scanline_u8(int physical_y);

--- a/Userland/Libraries/LibGfx/Bitmap.h
+++ b/Userland/Libraries/LibGfx/Bitmap.h
@@ -240,6 +240,8 @@ public:
 
     [[nodiscard]] bool visually_equals(Bitmap const&) const;
 
+    [[nodiscard]] Optional<Color> solid_color(u8 alpha_threshold = 0) const;
+
 private:
     Bitmap(BitmapFormat, IntSize const&, int, BackingStore const&);
     Bitmap(BitmapFormat, IntSize const&, int, size_t pitch, void*);

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -221,6 +221,15 @@ public:
         return (red() * 0.2126f + green() * 0.7152f + blue() * 0.0722f);
     }
 
+    constexpr float contrast_ratio(Color const& other)
+    {
+        auto l1 = luminosity();
+        auto l2 = other.luminosity();
+        auto darkest = min(l1, l2) / 255.;
+        auto brightest = max(l1, l2) / 255.;
+        return (brightest + 0.05) / (darkest + 0.05);
+    }
+
     constexpr Color to_grayscale() const
     {
         auto gray = luminosity();


### PR DESCRIPTION
On some dark themes, it becomes impossible to see dark button icons against their dark button backgrounds. 
This change tries to mitigate that by inverting the icon color if the contrast ratio (against the button background) is less the 4.5 (the recommended minimum for text).

This is only done for icons that are a solid color (e.g. all back), where the desired icon would likely be the same inverted anyway.

**Demo:**
(Look at the undo/redo buttons, along with the line, ellipse, and rectangle tools)

https://user-images.githubusercontent.com/11597044/167319953-5880e1c5-36c9-4817-abe9-01b05ee37a6e.mp4

Before these changes the icons looked like this:

![image](https://user-images.githubusercontent.com/11597044/167319890-e386029b-2398-4c5d-9634-8c7c57ba2cd1.png)
^ the line, rectangle, and ellipse tools icons before (barely visible) 

I've made these changes to the base `GUI::Button` class as there's lots of apps all over the system where this applies. 

(Fixes a lot of cases of https://github.com/SerenityOS/serenity/issues/13978)

**Note:** This PR should not close #13978 entirely there's still more work to be done (some more complex icons will still need dark variants) 