### PR TITLE
Kernel: Implement more of the initialization process for the aarch64 Kernel

### DIFF
--- a/Kernel/Arch/aarch64/Processor.cpp
+++ b/Kernel/Arch/aarch64/Processor.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022, Timon Kruiper <timonkruiper@gmail.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+
+#include <Kernel/Arch/Processor.h>
+#include <Kernel/Arch/aarch64/ASM_wrapper.h>
+#include <Kernel/Arch/aarch64/Prekernel/Aarch64_asm_utils.h>
+#include <Kernel/Arch/aarch64/Prekernel/Prekernel.h>
+
+extern "C" uintptr_t vector_table_el1;
+
+namespace Kernel {
+
+Processor* g_current_processor;
+
+void Processor::initialize(u32 cpu)
+{
+    VERIFY(g_current_processor == nullptr);
+
+    auto current_exception_level = static_cast<u64>(Kernel::Aarch64::Asm::get_current_exception_level());
+    dbgln("CPU{} started in: EL{}", cpu, current_exception_level);
+
+    dbgln("Drop CPU{} to EL1", cpu);
+    Prekernel::drop_to_exception_level_1();
+
+    // Load EL1 vector table
+    el1_vector_table_install(&vector_table_el1);
+
+    g_current_processor = this;
+}
+}

--- a/Kernel/Arch/aarch64/Processor.h
+++ b/Kernel/Arch/aarch64/Processor.h
@@ -22,6 +22,7 @@ class PageDirectory;
 };
 
 class Thread;
+class Processor;
 
 // FIXME This needs to go behind some sort of platform abstraction
 //       it is used between Thread and Processor.
@@ -30,8 +31,13 @@ struct [[gnu::aligned(16)]] FPUState
     u8 buffer[512];
 };
 
+// FIXME: Remove this once we support SMP in aarch64
+extern Processor* g_current_processor;
+
 class Processor {
 public:
+    void initialize(u32 cpu);
+
     void set_specific(ProcessorSpecificDataID /*specific_id*/, void* /*ptr*/)
     {
         VERIFY_NOT_REACHED();
@@ -79,9 +85,9 @@ public:
         VERIFY_NOT_REACHED();
     }
 
+    // FIXME: When aarch64 supports multiple cores, return the correct core id here.
     ALWAYS_INLINE static u32 current_id()
     {
-        VERIFY_NOT_REACHED();
         return 0;
     }
 
@@ -127,7 +133,10 @@ public:
         return nullptr;
     }
 
-    ALWAYS_INLINE static Processor& current() { VERIFY_NOT_REACHED(); }
+    ALWAYS_INLINE static Processor& current()
+    {
+        return *g_current_processor;
+    }
 
     static void deferred_call_queue(Function<void()> /* callback */)
     {

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -5,9 +5,9 @@ PHDRS
 {
   text PT_LOAD ;
   data PT_LOAD ;
+  ksyms PT_LOAD ;
   bss PT_LOAD ;
   super_pages PT_LOAD ;
-  ksyms PT_LOAD ;
 }
 
 SECTIONS
@@ -34,6 +34,13 @@ SECTIONS
         *(.data*)
     } :data
 
+    .ksyms ALIGN(4K) : AT (ADDR(.ksyms))
+    {
+        start_of_kernel_ksyms = .;
+        *(.kernel_symbols)
+        end_of_kernel_ksyms = .;
+    } :ksyms
+
     .bss ALIGN(4K) (NOLOAD) : AT (ADDR(.bss))
     {
 	start_of_bss = .;
@@ -48,13 +55,6 @@ SECTIONS
     {
         *(.super_pages)
     } :super_pages
-
-    .ksyms ALIGN(4K) : AT (ADDR(.ksyms))
-    {
-        start_of_kernel_ksyms = .;
-        *(.kernel_symbols)
-        end_of_kernel_ksyms = .;
-    } :ksyms
 
     /*
         FIXME: 8MB is enough space for all of the tables required to identity map 

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -1,11 +1,13 @@
 ENTRY(start)
 
+/* TODO: Add FLAGS to the program headers */
 PHDRS
 {
   text PT_LOAD ;
   data PT_LOAD ;
   bss PT_LOAD ;
-  ksyms PT_LOAD FLAGS(PF_R) ;
+  super_pages PT_LOAD ;
+  ksyms PT_LOAD ;
 }
 
 SECTIONS
@@ -20,6 +22,10 @@ SECTIONS
 
     .rodata ALIGN(4K) : AT (ADDR(.rodata))
     {
+        start_ctors = .;
+        *(.init_array)
+        end_ctors = .;
+
         *(.rodata*)
     } :data
 
@@ -33,7 +39,15 @@ SECTIONS
 	start_of_bss = .;
         *(.bss)
 	end_of_bss = .;
+
+        . = ALIGN(4K);
+        *(.heap)
     } :bss
+
+    .super_pages ALIGN(4K) (NOLOAD) : AT (ADDR(.super_pages))
+    {
+        *(.super_pages)
+    } :super_pages
 
     .ksyms ALIGN(4K) : AT (ADDR(.ksyms))
     {

--- a/Kernel/Arch/aarch64/linker.ld
+++ b/Kernel/Arch/aarch64/linker.ld
@@ -22,6 +22,10 @@ SECTIONS
 
     .rodata ALIGN(4K) : AT (ADDR(.rodata))
     {
+        start_heap_ctors = .;
+        *libkernel_heap.a:*(.init_array)
+        end_heap_ctors = .;
+
         start_ctors = .;
         *(.init_array)
         end_ctors = .;

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -398,21 +398,21 @@ if (NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
     )
 else()
     set(PREKERNEL_SOURCES
-        Arch/aarch64/Prekernel/PrekernelMMU.cpp
-        Arch/aarch64/Prekernel/PrekernelExceptions.cpp
-        Arch/aarch64/Prekernel/PrekernelCommon.cpp
-        Arch/aarch64/Prekernel/boot.S
         Arch/aarch64/Prekernel/Aarch64_asm_utils.S
+        Arch/aarch64/Prekernel/boot.S
+        Arch/aarch64/Prekernel/PrekernelCommon.cpp
+        Arch/aarch64/Prekernel/PrekernelExceptions.cpp
+        Arch/aarch64/Prekernel/PrekernelMMU.cpp
 
         Prekernel/UBSanitizer.cpp
     )
     set(RPI_SOURCES
-        Arch/aarch64/RPi/GPIO.cpp
         Arch/aarch64/RPi/Framebuffer.cpp
+        Arch/aarch64/RPi/GPIO.cpp
         Arch/aarch64/RPi/Mailbox.cpp
+        Arch/aarch64/RPi/MMIO.cpp
         Arch/aarch64/RPi/Timer.cpp
         Arch/aarch64/RPi/UART.cpp
-        Arch/aarch64/RPi/MMIO.cpp
     )
     set(SOURCES
         ${AK_SOURCES}
@@ -422,6 +422,7 @@ else()
         Arch/aarch64/BootPPMParser.cpp
         Arch/aarch64/CrashHandler.cpp
         Arch/aarch64/Dummy.cpp
+        Arch/aarch64/init.cpp
         Arch/aarch64/kprintf.cpp
         Arch/aarch64/MainIdRegister.cpp
         Arch/aarch64/PageDirectory.cpp
@@ -431,27 +432,26 @@ else()
         Arch/aarch64/ScopedCritical.cpp
         Arch/aarch64/SmapDisabler.cpp
         Arch/aarch64/Spinlock.cpp
-        Arch/aarch64/init.cpp
         Arch/aarch64/vector_table.S
 
         # Files from base Kernel
-        MiniStdLib.cpp
         KSyms.cpp
+        MiniStdLib.cpp
 
         Memory/AddressSpace.cpp
         Memory/AnonymousVMObject.cpp
         Memory/InodeVMObject.cpp
-        Memory/PhysicalRegion.cpp
-        Memory/PhysicalPage.cpp
-        Memory/PhysicalZone.cpp
-        Memory/PageDirectory.cpp
         Memory/MemoryManager.cpp
+        Memory/PageDirectory.cpp
+        Memory/PhysicalPage.cpp
+        Memory/PhysicalRegion.cpp
+        Memory/PhysicalZone.cpp
         Memory/PrivateInodeVMObject.cpp
         Memory/Region.cpp
         Memory/RegionTree.cpp
         Memory/RingBuffer.cpp
-        Memory/SharedInodeVMObject.cpp
         Memory/ScatterGatherList.cpp
+        Memory/SharedInodeVMObject.cpp
         Memory/VirtualRange.cpp
         Memory/VMObject.cpp
     )

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -434,7 +434,6 @@ else()
         Arch/aarch64/vector_table.S
 
         # Files from base Kernel
-        Heap/kmalloc.cpp
         MiniStdLib.cpp
         KSyms.cpp
 
@@ -565,9 +564,8 @@ endif()
 add_compile_definitions(KERNEL)
 add_link_options(LINKER:-z,notext)
 
-if (NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
-    add_library(kernel_heap STATIC ${KERNEL_HEAP_SOURCES})
-endif()
+add_library(kernel_heap STATIC ${KERNEL_HEAP_SOURCES})
+
 add_executable(Kernel ${SOURCES})
 add_dependencies(Kernel generate_EscapeSequenceStateMachine.h)
 
@@ -598,12 +596,10 @@ if (ENABLE_KERNEL_LTO)
     endif()
 endif()
 
-if (NOT "${SERENITY_ARCH}" STREQUAL "aarch64")
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        target_link_libraries(Kernel PRIVATE kernel_heap gcc)
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
-        target_link_libraries(Kernel PRIVATE kernel_heap clang_rt.builtins)
-    endif()
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    target_link_libraries(Kernel PRIVATE kernel_heap gcc)
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang$")
+    target_link_libraries(Kernel PRIVATE kernel_heap clang_rt.builtins)
 endif()
 
 add_custom_command(

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -426,6 +426,7 @@ else()
         Arch/aarch64/MainIdRegister.cpp
         Arch/aarch64/PageDirectory.cpp
         Arch/aarch64/Panic.cpp
+        Arch/aarch64/Processor.cpp
         Arch/aarch64/SafeMem.cpp
         Arch/aarch64/ScopedCritical.cpp
         Arch/aarch64/SmapDisabler.cpp


### PR DESCRIPTION
This PR contains a simple implementation of the Processor class, and moves some of the initialization into it.

It also reorders the NOLOAD sections to the end of the ELF file, such that objcopy doesn't add them to the binary and thus saves 6MBs in the final `kernel8.img`. 
