### PR TITLE
Kernel+route: Add support for route flags

### DIFF
--- a/Kernel/API/POSIX/net/route.h
+++ b/Kernel/API/POSIX/net/route.h
@@ -24,6 +24,7 @@ struct rtentry {
 
 #define RTF_UP 0x1      /* do not delete the route */
 #define RTF_GATEWAY 0x2 /* the route is a gateway and not an end host */
+#define RTF_HOST 0x4    /* host entry (net otherwise) */
 
 #ifdef __cplusplus
 }

--- a/Kernel/GlobalProcessExposed.cpp
+++ b/Kernel/GlobalProcessExposed.cpp
@@ -114,6 +114,7 @@ private:
                 TRY(obj.add("gateway", gateway->view()));
                 auto netmask = TRY(it.netmask.to_string());
                 TRY(obj.add("genmask", netmask->view()));
+                TRY(obj.add("flags", it.flags));
                 TRY(obj.add("interface", it.adapter->name()));
                 TRY(obj.finish());
             }

--- a/Kernel/Net/Routing.cpp
+++ b/Kernel/Net/Routing.cpp
@@ -135,9 +135,9 @@ SpinlockProtected<Route::RouteList>& routing_table()
     return *s_routing_table;
 }
 
-ErrorOr<void> update_routing_table(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, RefPtr<NetworkAdapter> adapter, UpdateTable update)
+ErrorOr<void> update_routing_table(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, u16 flags, RefPtr<NetworkAdapter> adapter, UpdateTable update)
 {
-    auto route_entry = adopt_ref_if_nonnull(new (nothrow) Route { destination, gateway, netmask, adapter.release_nonnull() });
+    auto route_entry = adopt_ref_if_nonnull(new (nothrow) Route { destination, gateway, netmask, flags, adapter.release_nonnull() });
     if (!route_entry)
         return ENOMEM;
 

--- a/Kernel/Net/Routing.h
+++ b/Kernel/Net/Routing.h
@@ -15,22 +15,24 @@
 namespace Kernel {
 
 struct Route : public RefCounted<Route> {
-    Route(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, NonnullRefPtr<NetworkAdapter> adapter)
+    Route(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, u16 flags, NonnullRefPtr<NetworkAdapter> adapter)
         : destination(destination)
         , gateway(gateway)
         , netmask(netmask)
+        , flags(flags)
         , adapter(adapter)
     {
     }
 
     bool operator==(Route const& other) const
     {
-        return destination == other.destination && gateway == other.gateway && netmask == other.netmask && adapter.ptr() == other.adapter.ptr();
+        return destination == other.destination && gateway == other.gateway && netmask == other.netmask && flags == other.flags && adapter.ptr() == other.adapter.ptr();
     }
 
     const IPv4Address destination;
     const IPv4Address gateway;
     const IPv4Address netmask;
+    const u16 flags;
     NonnullRefPtr<NetworkAdapter> adapter;
 
     IntrusiveListNode<Route, RefPtr<Route>> route_list_node {};
@@ -50,7 +52,7 @@ enum class UpdateTable {
 };
 
 void update_arp_table(IPv4Address const&, MACAddress const&, UpdateTable update);
-ErrorOr<void> update_routing_table(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, RefPtr<NetworkAdapter> const adapter, UpdateTable update);
+ErrorOr<void> update_routing_table(IPv4Address const& destination, IPv4Address const& gateway, IPv4Address const& netmask, u16 flags, RefPtr<NetworkAdapter> const adapter, UpdateTable update);
 
 enum class AllowUsingGateway {
     Yes,


### PR DESCRIPTION
**Kernel: Add support for route flags**
Previously the routing table did not store the route flags. This
adds basic support and exposes them in the /proc directory so that a
userspace caller can query the route and identify the type of each
route.

**route: Add the flags column**
