### PR TITLE
Documentation: Update the required packages for arch based systems

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -48,7 +48,7 @@ for details.
 ### Arch Linux / Manjaro
 
 ```console
-sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu qemu-arch-extra ccache rsync unzip
+sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu-desktop qemu-emulators-full ccache rsync unzip
 ```
 Optional: `fuse2fs` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
 


### PR DESCRIPTION
Since qemu 7 the Arch Linux repository is using a different naming system for the various required packages. This patch updates the required dependencies for running serenity.

See https://archlinux.org/news/qemu-700-changes-split-package-setup/