### PR TITLE
LibGUI: Take only valid sizes when calculating BoxLayout preferred size

### DIFF
--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -39,15 +39,17 @@ int BoxLayout::preferred_primary_size() const
     for (auto& entry : m_entries) {
         if (!entry.widget || !entry.widget->is_visible())
             continue;
-        int min_size = entry.widget->min_size().primary_size_for_orientation(orientation());
-        int max_size = entry.widget->max_size().primary_size_for_orientation(orientation());
         int preferred_primary_size = -1;
         if (entry.widget->is_shrink_to_fit() && entry.widget->layout()) {
             preferred_primary_size = entry.widget->layout()->preferred_size().primary_size_for_orientation(orientation());
         }
         int item_size = max(0, preferred_primary_size);
-        item_size = max(min_size, item_size);
-        item_size = min(max_size, item_size);
+        int min_size = entry.widget->min_size().primary_size_for_orientation(orientation());
+        if (min_size != -1)
+            item_size = max(min_size, item_size);
+        int max_size = entry.widget->max_size().primary_size_for_orientation(orientation());
+        if (max_size != -1)
+            item_size = min(max_size, item_size);
         size += item_size + spacing();
     }
     if (size > 0)


### PR DESCRIPTION
We ran a `min()` function to clamp child widgets to their maximum size, but if it wasn’t set, it got -1 and made the widget able to shrink completely.

For #13937 :^)