### PR TITLE
Userland+DisplaySettings: Link to cursor themes from "Themes" tab

### DIFF
--- a/Userland/Applets/Keymap/KeymapStatusWindow.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWindow.cpp
@@ -16,7 +16,7 @@ void KeymapStatusWidget::mousedown_event(GUI::MouseEvent& event)
     if (event.button() != GUI::MouseButton::Primary)
         return;
 
-    Core::Process::spawn("/bin/KeyboardSettings");
+    MUST(Core::Process::spawn("/bin/KeyboardSettings"));
 }
 
 KeymapStatusWindow::KeymapStatusWindow()

--- a/Userland/Applets/Keymap/KeymapStatusWindow.cpp
+++ b/Userland/Applets/Keymap/KeymapStatusWindow.cpp
@@ -6,9 +6,9 @@
  */
 
 #include "KeymapStatusWindow.h"
-#include <LibCore/Process.h>
 #include <LibGUI/ConnectionToWindowMangerServer.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/Process.h>
 #include <LibKeyboard/CharacterMap.h>
 
 void KeymapStatusWidget::mousedown_event(GUI::MouseEvent& event)
@@ -16,7 +16,7 @@ void KeymapStatusWidget::mousedown_event(GUI::MouseEvent& event)
     if (event.button() != GUI::MouseButton::Primary)
         return;
 
-    MUST(Core::Process::spawn("/bin/KeyboardSettings"));
+    GUI::Process::spawn_or_show_error(window(), "/bin/KeyboardSettings");
 }
 
 KeymapStatusWindow::KeymapStatusWindow()

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -292,7 +292,7 @@ void BrowserWindow::build_menus()
     settings_menu.add_separator();
     auto open_settings_action = GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png").release_value_but_fixme_should_propagate_errors(),
         [](auto&) {
-            Core::Process::spawn("/bin/BrowserSettings");
+            MUST(Core::Process::spawn("/bin/BrowserSettings"));
         });
     settings_menu.add_action(move(open_settings_action));
 

--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -16,7 +16,6 @@
 #include "Tab.h"
 #include <Applications/Browser/BrowserWindowGML.h>
 #include <LibConfig/Client.h>
-#include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/Stream.h>
 #include <LibGUI/AboutDialog.h>
@@ -27,6 +26,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/SeparatorWidget.h>
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/TabWidget.h>
@@ -291,8 +291,8 @@ void BrowserWindow::build_menus()
 
     settings_menu.add_separator();
     auto open_settings_action = GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png").release_value_but_fixme_should_propagate_errors(),
-        [](auto&) {
-            MUST(Core::Process::spawn("/bin/BrowserSettings"));
+        [this](auto&) {
+            GUI::Process::spawn_or_show_error(this, "/bin/BrowserSettings");
         });
     settings_menu.add_action(move(open_settings_action));
 

--- a/Userland/Applications/DisplaySettings/ThemesSettings.gml
+++ b/Userland/Applications/DisplaySettings/ThemesSettings.gml
@@ -4,29 +4,55 @@
         margins: [8]
     }
 
-    @GUI::Frame {
-        layout: @GUI::HorizontalBoxLayout {}
-        name: "preview_frame"
-        fixed_width: 306
-        fixed_height: 201
-    }
+    @GUI::GroupBox {
+        layout: @GUI::VerticalBoxLayout {
+            margins: [14, 14, 4]
+        }
+        title: "Window Theme"
+        fixed_height: 294
 
-    @GUI::Widget {
-        fixed_height: 20
-    }
-
-    @GUI::Widget {
-        shrink_to_fit: true
-        layout: @GUI::HorizontalBoxLayout {}
-
-        @GUI::Label {
-            text: "Theme:"
-            text_alignment: "CenterLeft"
-            fixed_width: 95
+        @GUI::Frame {
+            layout: @GUI::HorizontalBoxLayout {}
+            name: "preview_frame"
+            fixed_width: 306
+            fixed_height: 201
         }
 
-        @GUI::ComboBox {
-            name: "themes_combo"
+        @GUI::Widget {
+            fixed_height: 20
+        }
+
+        @GUI::Widget {
+            shrink_to_fit: true
+            layout: @GUI::HorizontalBoxLayout {}
+
+            @GUI::Label {
+                text: "Theme:"
+                text_alignment: "CenterLeft"
+                fixed_width: 95
+            }
+
+            @GUI::ComboBox {
+                name: "themes_combo"
+            }
+        }
+    }
+
+    @GUI::GroupBox {
+        layout: @GUI::VerticalBoxLayout {
+            margins: [14, 14, 4]
+        }
+        title: "Cursor Theme"
+        shrink_to_fit: true
+
+        @GUI::Button {
+            name: "cursor_themes_button"
+            text: "Change in Mouse Settings..."
+            fixed_width: 200
+        }
+
+        @GUI::Widget {
+            fixed_height: 10
         }
     }
 }

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/DirIterator.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/ItemListModel.h>
+#include <LibGUI/Process.h>
 
 namespace DisplaySettings {
 
@@ -36,7 +37,6 @@ ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
         }
     }
     VERIFY(m_selected_theme);
-
     m_theme_preview = find_descendant_of_type_named<GUI::Frame>("preview_frame")->add<ThemePreviewWidget>(palette());
     m_themes_combo = *find_descendant_of_type_named<GUI::ComboBox>("themes_combo");
     m_themes_combo->set_only_allow_values_from_model(true);
@@ -47,6 +47,13 @@ ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
         set_modified(true);
     };
     m_themes_combo->set_selected_index(current_theme_index, GUI::AllowCallback::No);
+
+    auto mouse_settings_icon = Gfx::Bitmap::try_load_from_file("res/icons/16x16/app-mouse.png").release_value_but_fixme_should_propagate_errors();
+    m_cursor_themes_button = *find_descendant_of_type_named<GUI::Button>("cursor_themes_button");
+    m_cursor_themes_button->set_icon(mouse_settings_icon);
+    m_cursor_themes_button->on_click = [&](auto) {
+        GUI::Process::spawn_or_show_error(window(), "/bin/MouseSettings", Array { "-t", "cursor-theme" });
+    };
 }
 
 void ThemesSettingsWidget::apply_settings()

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.h
@@ -28,8 +28,9 @@ private:
 
     RefPtr<GUI::ComboBox> m_themes_combo;
     RefPtr<ThemePreviewWidget> m_theme_preview;
-
     Gfx::SystemThemeMetaData const* m_selected_theme { nullptr };
+
+    RefPtr<GUI::Button> m_cursor_themes_button;
 
     bool& m_background_settings_changed;
 

--- a/Userland/Applications/DisplaySettings/main.cpp
+++ b/Userland/Applications/DisplaySettings/main.cpp
@@ -21,7 +21,7 @@
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath unix"));
+    TRY(Core::System::pledge("stdio thread recvfd sendfd rpath cpath wpath unix proc exec"));
 
     auto app = TRY(GUI::Application::try_create(arguments));
     Config::pledge_domain("WindowManager");

--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -5,7 +5,6 @@
  */
 
 #include <AK/QuickSort.h>
-#include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibDesktop/AppFile.h>
 #include <LibGUI/Application.h>
@@ -14,6 +13,7 @@
 #include <LibGUI/IconView.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Model.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/Statusbar.h>
 #include <LibGUI/Window.h>
 #include <LibMain/Main.h>
@@ -104,7 +104,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto launch_origin_rect = icon_view->to_widget_rect(icon_view->content_rect(index)).translated(icon_view->screen_relative_rect().location());
         setenv("__libgui_launch_origin_rect", String::formatted("{},{},{},{}", launch_origin_rect.x(), launch_origin_rect.y(), launch_origin_rect.width(), launch_origin_rect.height()).characters(), 1);
-        MUST(Core::Process::spawn(executable));
+        GUI::Process::spawn_or_show_error(window, executable);
     };
 
     auto statusbar = TRY(main_widget->try_add<GUI::Statusbar>());

--- a/Userland/Applications/Settings/main.cpp
+++ b/Userland/Applications/Settings/main.cpp
@@ -104,7 +104,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
         auto launch_origin_rect = icon_view->to_widget_rect(icon_view->content_rect(index)).translated(icon_view->screen_relative_rect().location());
         setenv("__libgui_launch_origin_rect", String::formatted("{},{},{},{}", launch_origin_rect.x(), launch_origin_rect.y(), launch_origin_rect.width(), launch_origin_rect.height()).characters(), 1);
-        Core::Process::spawn(executable);
+        MUST(Core::Process::spawn(executable));
     };
 
     auto statusbar = TRY(main_widget->try_add<GUI::Statusbar>());

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -328,7 +328,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto open_settings_action = GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png").release_value_but_fixme_should_propagate_errors(),
         [&](auto&) {
-            Core::Process::spawn("/bin/TerminalSettings");
+            MUST(Core::Process::spawn("/bin/TerminalSettings"));
         });
 
     TRY(terminal->context_menu().try_add_separator());
@@ -336,7 +336,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::Action::create("Open New &Terminal", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-terminal.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
-        Core::Process::spawn("/bin/Terminal");
+        MUST(Core::Process::spawn("/bin/Terminal"));
     })));
 
     TRY(file_menu->try_add_action(open_settings_action));

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -11,7 +11,6 @@
 #include <LibConfig/Listener.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DirIterator.h>
-#include <LibCore/Process.h>
 #include <LibCore/System.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Action.h>
@@ -27,6 +26,7 @@
 #include <LibGUI/Menu.h>
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/TextBox.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
@@ -328,7 +328,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto open_settings_action = GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/settings.png").release_value_but_fixme_should_propagate_errors(),
         [&](auto&) {
-            MUST(Core::Process::spawn("/bin/TerminalSettings"));
+            GUI::Process::spawn_or_show_error(window, "/bin/TerminalSettings");
         });
 
     TRY(terminal->context_menu().try_add_separator());
@@ -336,7 +336,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto file_menu = TRY(window->try_add_menu("&File"));
     TRY(file_menu->try_add_action(GUI::Action::create("Open New &Terminal", { Mod_Ctrl | Mod_Shift, Key_N }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-terminal.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
-        MUST(Core::Process::spawn("/bin/Terminal"));
+        GUI::Process::spawn_or_show_error(window, "/bin/Terminal");
     })));
 
     TRY(file_menu->try_add_action(open_settings_action));

--- a/Userland/Applications/Welcome/WelcomeWidget.cpp
+++ b/Userland/Applications/Welcome/WelcomeWidget.cpp
@@ -54,7 +54,7 @@ WelcomeWidget::WelcomeWidget()
     m_help_button = *find_descendant_of_type_named<GUI::Button>("help_button");
     m_help_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/book-open.png").release_value_but_fixme_should_propagate_errors());
     m_help_button->on_click = [](auto) {
-        Core::Process::spawn("/bin/Help"sv);
+        MUST(Core::Process::spawn("/bin/Help"sv));
     };
 
     m_new_button = *find_descendant_of_type_named<GUI::Button>("new_button");

--- a/Userland/Applications/Welcome/WelcomeWidget.cpp
+++ b/Userland/Applications/Welcome/WelcomeWidget.cpp
@@ -9,12 +9,12 @@
 #include <Applications/Welcome/WelcomeWindowGML.h>
 #include <LibConfig/Client.h>
 #include <LibCore/File.h>
-#include <LibCore/Process.h>
 #include <LibGUI/Application.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/CheckBox.h>
 #include <LibGUI/Label.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/Process.h>
 #include <LibGfx/Font/BitmapFont.h>
 #include <LibGfx/Palette.h>
 #include <LibMarkdown/Document.h>
@@ -53,8 +53,8 @@ WelcomeWidget::WelcomeWidget()
 
     m_help_button = *find_descendant_of_type_named<GUI::Button>("help_button");
     m_help_button->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/book-open.png").release_value_but_fixme_should_propagate_errors());
-    m_help_button->on_click = [](auto) {
-        MUST(Core::Process::spawn("/bin/Help"sv));
+    m_help_button->on_click = [&](auto) {
+        GUI::Process::spawn_or_show_error(window(), "/bin/Help"sv);
     };
 
     m_new_button = *find_descendant_of_type_named<GUI::Button>("new_button");

--- a/Userland/Libraries/LibCore/Process.cpp
+++ b/Userland/Libraries/LibCore/Process.cpp
@@ -1,11 +1,14 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #include <AK/String.h>
+#include <AK/Vector.h>
 #include <LibCore/Process.h>
+#include <LibCore/System.h>
 #include <errno.h>
 #include <spawn.h>
 
@@ -17,21 +20,65 @@ extern char** environ;
 
 namespace Core {
 
-pid_t Process::spawn(StringView path)
-{
-    String path_string = path;
+struct ArgvList {
+    String m_path;
+    Vector<char const*, 10> m_argv;
 
-    pid_t pid;
-    char const* argv[] = { path_string.characters(), nullptr };
-    if ((errno = posix_spawn(&pid, path_string.characters(), nullptr, nullptr, const_cast<char**>(argv), environ))) {
-        perror("Process::spawn posix_spawn");
-    } else {
-#ifdef __serenity__
-        if (disown(pid) < 0)
-            perror("Process::spawn disown");
-#endif
+    ArgvList(String path, size_t size)
+        : m_path { path }
+    {
+        m_argv.ensure_capacity(size + 2);
+        m_argv.append(m_path.characters());
     }
-    return pid;
+
+    void append(char const* arg)
+    {
+        m_argv.append(arg);
+    }
+
+    Span<char const*> get()
+    {
+        if (m_argv.is_empty() || m_argv.last() != nullptr)
+            m_argv.append(nullptr);
+        return m_argv;
+    }
+
+    ErrorOr<pid_t> spawn()
+    {
+        auto pid = TRY(System::posix_spawn(m_path.characters(), nullptr, nullptr, const_cast<char**>(get().data()), environ));
+#ifdef __serenity__
+        TRY(System::disown(pid));
+#endif
+        return pid;
+    }
+};
+
+ErrorOr<pid_t> Process::spawn(StringView path, Span<String const> arguments)
+{
+    ArgvList argv { path, arguments.size() };
+    for (auto const& arg : arguments)
+        argv.append(arg.characters());
+    return argv.spawn();
+}
+
+ErrorOr<pid_t> Process::spawn(StringView path, Span<StringView const> arguments)
+{
+    Vector<String> backing_strings;
+    backing_strings.ensure_capacity(arguments.size());
+    ArgvList argv { path, arguments.size() };
+    for (auto const& arg : arguments) {
+        backing_strings.append(arg);
+        argv.append(backing_strings.last().characters());
+    }
+    return argv.spawn();
+}
+
+ErrorOr<pid_t> Process::spawn(StringView path, Span<char const* const> arguments)
+{
+    ArgvList argv { path, arguments.size() };
+    for (auto arg : arguments)
+        argv.append(arg);
+    return argv.spawn();
 }
 
 }

--- a/Userland/Libraries/LibCore/Process.h
+++ b/Userland/Libraries/LibCore/Process.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,12 +8,15 @@
 #pragma once
 
 #include <AK/Forward.h>
+#include <AK/Span.h>
 
 namespace Core {
 
 class Process {
 public:
-    static pid_t spawn(StringView path);
+    static ErrorOr<pid_t> spawn(StringView path, Span<String const> arguments);
+    static ErrorOr<pid_t> spawn(StringView path, Span<StringView const> arguments);
+    static ErrorOr<pid_t> spawn(StringView path, Span<char const* const> arguments = {});
 };
 
 }

--- a/Userland/Libraries/LibCore/System.cpp
+++ b/Userland/Libraries/LibCore/System.cpp
@@ -661,12 +661,22 @@ ErrorOr<void> clock_settime(clockid_t clock_id, struct timespec* ts)
 #endif
 }
 
-ErrorOr<pid_t> posix_spawnp(StringView const path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[])
+static ALWAYS_INLINE ErrorOr<pid_t> posix_spawn_wrapper(StringView path, posix_spawn_file_actions_t const* file_actions, posix_spawnattr_t const* attr, char* const arguments[], char* const envp[], StringView function_name, decltype(::posix_spawn) spawn_function)
 {
     pid_t child_pid;
-    if ((errno = ::posix_spawnp(&child_pid, path.to_string().characters(), file_actions, attr, arguments, envp)))
-        return Error::from_syscall("posix_spawnp"sv, -errno);
+    if ((errno = spawn_function(&child_pid, path.to_string().characters(), file_actions, attr, arguments, envp)))
+        return Error::from_syscall(function_name, -errno);
     return child_pid;
+}
+
+ErrorOr<pid_t> posix_spawn(StringView path, posix_spawn_file_actions_t const* file_actions, posix_spawnattr_t const* attr, char* const arguments[], char* const envp[])
+{
+    return posix_spawn_wrapper(path, file_actions, attr, arguments, envp, "posix_spawn"sv, ::posix_spawn);
+}
+
+ErrorOr<pid_t> posix_spawnp(StringView path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[])
+{
+    return posix_spawn_wrapper(path, file_actions, attr, arguments, envp, "posix_spawnp"sv, ::posix_spawnp);
 }
 
 ErrorOr<off_t> lseek(int fd, off_t offset, int whence)

--- a/Userland/Libraries/LibCore/System.h
+++ b/Userland/Libraries/LibCore/System.h
@@ -97,7 +97,8 @@ ErrorOr<Optional<struct group>> getgrnam(StringView name);
 ErrorOr<Optional<struct passwd>> getpwuid(uid_t);
 ErrorOr<Optional<struct group>> getgrgid(gid_t);
 ErrorOr<void> clock_settime(clockid_t clock_id, struct timespec* ts);
-ErrorOr<pid_t> posix_spawnp(StringView const path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);
+ErrorOr<pid_t> posix_spawn(StringView path, posix_spawn_file_actions_t const* file_actions, posix_spawnattr_t const* attr, char* const arguments[], char* const envp[]);
+ErrorOr<pid_t> posix_spawnp(StringView path, posix_spawn_file_actions_t* const file_actions, posix_spawnattr_t* const attr, char* const arguments[], char* const envp[]);
 ErrorOr<off_t> lseek(int fd, off_t, int whence);
 
 struct WaitPidResult {

--- a/Userland/Libraries/LibDesktop/AppFile.cpp
+++ b/Userland/Libraries/LibDesktop/AppFile.cpp
@@ -130,7 +130,7 @@ bool AppFile::spawn() const
         return false;
 
     auto pid = Core::Process::spawn(executable());
-    if (pid < 0)
+    if (pid.is_error())
         return false;
 
     return true;

--- a/Userland/Libraries/LibGUI/CMakeLists.txt
+++ b/Userland/Libraries/LibGUI/CMakeLists.txt
@@ -79,6 +79,7 @@ set(SOURCES
     PasswordInputDialog.cpp
     PasswordInputDialogGML.h
     PersistentModelIndex.cpp
+    Process.cpp
     ProcessChooser.cpp
     Progressbar.cpp
     RadioButton.cpp

--- a/Userland/Libraries/LibGUI/Process.cpp
+++ b/Userland/Libraries/LibGUI/Process.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Format.h>
+#include <AK/StringView.h>
+#include <LibGUI/MessageBox.h>
+#include <LibGUI/Process.h>
+
+template<typename StringType>
+void spawn_or_show_error(GUI::Window* parent_window, StringView path, Span<StringType const> arguments)
+{
+    auto spawn_result = Core::Process::spawn(path, arguments);
+    if (spawn_result.is_error())
+        GUI::MessageBox::show_error(parent_window, String::formatted("Failed to spawn {}: {}", path, spawn_result.error()));
+}
+
+namespace GUI {
+
+void Process::spawn_or_show_error(Window* parent_window, StringView path, Span<String const> arguments)
+{
+    ::spawn_or_show_error<String>(parent_window, path, arguments);
+}
+
+void Process::spawn_or_show_error(Window* parent_window, StringView path, Span<StringView const> arguments)
+{
+    ::spawn_or_show_error<StringView>(parent_window, path, arguments);
+}
+
+void Process::spawn_or_show_error(Window* parent_window, StringView path, Span<char const* const> arguments)
+{
+    ::spawn_or_show_error<char const*>(parent_window, path, arguments);
+}
+
+}

--- a/Userland/Libraries/LibGUI/Process.h
+++ b/Userland/Libraries/LibGUI/Process.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022, MacDue <macdue@dueutil.tech>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <LibCore/Process.h>
+#include <LibGUI/Forward.h>
+
+namespace GUI {
+
+struct Process {
+    static void spawn_or_show_error(Window* parent_window, StringView path, Span<String const> arguments);
+    static void spawn_or_show_error(Window* parent_window, StringView path, Span<StringView const> arguments);
+    static void spawn_or_show_error(Window* parent_window, StringView path, Span<char const* const> arguments = {});
+};
+
+}

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -154,7 +154,7 @@ ClockWidget::ClockWidget()
     m_calendar_launcher->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-calendar.png").release_value_but_fixme_should_propagate_errors());
     m_calendar_launcher->set_tooltip("Calendar");
     m_calendar_launcher->on_click = [](auto) {
-        Core::Process::spawn("/bin/Calendar"sv);
+        MUST(Core::Process::spawn("/bin/Calendar"));
     };
 }
 

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -6,8 +6,8 @@
 
 #include "ClockWidget.h"
 #include <LibConfig/Client.h>
-#include <LibCore/Process.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/SeparatorWidget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Font/FontDatabase.h>
@@ -153,8 +153,8 @@ ClockWidget::ClockWidget()
     m_calendar_launcher->set_fixed_size(24, 24);
     m_calendar_launcher->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-calendar.png").release_value_but_fixme_should_propagate_errors());
     m_calendar_launcher->set_tooltip("Calendar");
-    m_calendar_launcher->on_click = [](auto) {
-        MUST(Core::Process::spawn("/bin/Calendar"));
+    m_calendar_launcher->on_click = [this](auto) {
+        GUI::Process::spawn_or_show_error(window(), "/bin/Calendar");
     };
 }
 

--- a/Userland/Services/Taskbar/QuickLaunchWidget.cpp
+++ b/Userland/Services/Taskbar/QuickLaunchWidget.cpp
@@ -48,9 +48,7 @@ ErrorOr<void> QuickLaunchEntryAppFile::launch() const
 
 ErrorOr<void> QuickLaunchEntryExecutable::launch() const
 {
-    auto pid = Core::Process::spawn(m_path);
-    if (pid < 0)
-        return Error::from_syscall("Core::Process::spawn", -errno);
+    TRY(Core::Process::spawn(m_path));
     return {};
 }
 

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -11,7 +11,6 @@
 #include <LibConfig/Client.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/EventLoop.h>
-#include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
 #include <LibCore/System.h>
 #include <LibDesktop/AppFile.h>
@@ -21,6 +20,7 @@
 #include <LibGUI/ConnectionToWindowMangerServer.h>
 #include <LibGUI/ConnectionToWindowServer.h>
 #include <LibGUI/Menu.h>
+#include <LibGUI/Process.h>
 #include <LibGfx/SystemTheme.h>
 #include <LibMain/Main.h>
 #include <WindowServer/Window.h>
@@ -32,7 +32,15 @@
 #include <unistd.h>
 
 static ErrorOr<Vector<String>> discover_apps_and_categories();
-static ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu();
+struct WindowRefence {
+    GUI::Window* window { nullptr };
+    GUI::Window* get()
+    {
+        VERIFY(window);
+        return window;
+    }
+};
+static ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu(WindowRefence&);
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
@@ -53,10 +61,15 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     TRY(Core::System::pledge("stdio recvfd sendfd proc exec rpath"));
 
-    auto menu = TRY(build_system_menu());
+    // FIXME: Have to awkwardly pass a reference to the window pointer to build_system_menu(), that will be resolved later.
+    // (It is always valid at use)
+    WindowRefence window_ref {};
+    auto menu = TRY(build_system_menu(window_ref));
     menu->realize_menu_if_needed();
 
     auto window = TRY(TaskbarWindow::try_create(move(menu)));
+    window_ref.window = window.ptr();
+
     window->show();
 
     window->make_window_manager(
@@ -103,13 +116,13 @@ ErrorOr<Vector<String>> discover_apps_and_categories()
     return sorted_app_categories;
 }
 
-ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu()
+ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu(WindowRefence& window_ref)
 {
     Vector<String> const sorted_app_categories = TRY(discover_apps_and_categories());
     auto system_menu = TRY(GUI::Menu::try_create("\xE2\x9A\xA1")); // HIGH VOLTAGE SIGN
 
-    system_menu->add_action(GUI::Action::create("&About SerenityOS", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/ladyball.png").release_value_but_fixme_should_propagate_errors(), [](auto&) {
-        MUST(Core::Process::spawn("/bin/About"sv));
+    system_menu->add_action(GUI::Action::create("&About SerenityOS", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/ladyball.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+        GUI::Process::spawn_or_show_error(window_ref.get(), "/bin/About"sv);
     }));
 
     system_menu->add_separator();
@@ -228,13 +241,13 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu()
         }
     }
 
-    system_menu->add_action(GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-settings.png").release_value_but_fixme_should_propagate_errors(), [](auto&) {
-        MUST(Core::Process::spawn("/bin/Settings"sv));
+    system_menu->add_action(GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-settings.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+        GUI::Process::spawn_or_show_error(window_ref.get(), "/bin/Settings"sv);
     }));
 
     system_menu->add_separator();
-    system_menu->add_action(GUI::Action::create("&Help", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-help.png").release_value_but_fixme_should_propagate_errors(), [](auto&) {
-        MUST(Core::Process::spawn("/bin/Help"sv));
+    system_menu->add_action(GUI::Action::create("&Help", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-help.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
+        GUI::Process::spawn_or_show_error(window_ref.get(), "/bin/Help"sv);
     }));
     system_menu->add_action(GUI::Action::create("&Run...", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-run.png").release_value_but_fixme_should_propagate_errors(), [](auto&) {
         posix_spawn_file_actions_t spawn_actions;

--- a/Userland/Services/Taskbar/main.cpp
+++ b/Userland/Services/Taskbar/main.cpp
@@ -109,7 +109,7 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu()
     auto system_menu = TRY(GUI::Menu::try_create("\xE2\x9A\xA1")); // HIGH VOLTAGE SIGN
 
     system_menu->add_action(GUI::Action::create("&About SerenityOS", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/ladyball.png").release_value_but_fixme_should_propagate_errors(), [](auto&) {
-        Core::Process::spawn("/bin/About"sv);
+        MUST(Core::Process::spawn("/bin/About"sv));
     }));
 
     system_menu->add_separator();
@@ -229,12 +229,12 @@ ErrorOr<NonnullRefPtr<GUI::Menu>> build_system_menu()
     }
 
     system_menu->add_action(GUI::Action::create("&Settings", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-settings.png").release_value_but_fixme_should_propagate_errors(), [](auto&) {
-        Core::Process::spawn("/bin/Settings"sv);
+        MUST(Core::Process::spawn("/bin/Settings"sv));
     }));
 
     system_menu->add_separator();
     system_menu->add_action(GUI::Action::create("&Help", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-help.png").release_value_but_fixme_should_propagate_errors(), [](auto&) {
-        Core::Process::spawn("/bin/Help"sv);
+        MUST(Core::Process::spawn("/bin/Help"sv));
     }));
     system_menu->add_action(GUI::Action::create("&Run...", Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-run.png").release_value_but_fixme_should_propagate_errors(), [](auto&) {
         posix_spawn_file_actions_t spawn_actions;


### PR DESCRIPTION
This setting was a little hard to find, adding a link here removes a few clicks & puts all the theming actions in one place. 

![image](https://user-images.githubusercontent.com/11597044/167515421-797f4372-d1e8-4def-8e07-5ea829aba1ae.png)


**Other OoL changes:**
- `Core::Process::spawn()` can now accept a `Span<StringView>` of arguments
   - The lack of argument support for has bugged me few times before.
- `Core::Process::spawn()` now returns `ErrorOr<pid_t>`  
- The core `Core::System::posix_spawn()` wrapper has been implemented 
- A helper `GUI::Process::spawn_or_show_error()` has been added to `LibGUI`
  - (Since `Core::Process::spawn()` now returns `ErrorOr` the return can't simply be ignored, so this makes use of it in a useful way) 