### PR TITLE
LibC: Make h_errno thread-local.

### DIFF
--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -829,4 +829,26 @@ int getnameinfo(const struct sockaddr* __restrict addr, socklen_t addrlen, char*
 
     return 0;
 }
+
+void herror(char const* s)
+{
+    dbgln("herror(): {}: {}", s, hstrerror(h_errno));
+    warnln("{}: {}", s, hstrerror(h_errno));
+}
+
+char const* hstrerror(int err)
+{
+    switch (err) {
+    case HOST_NOT_FOUND:
+        return "The specified host is unknown.";
+    case NO_DATA:
+        return "The requested name is valid but does not have an IP address.";
+    case NO_RECOVERY:
+        return "A nonrecoverable name server error occurred.";
+    case TRY_AGAIN:
+        return "A temporary error occurred on an authoritative name server. Try again later.";
+    default:
+        return "Unknown error.";
+    }
+}
 }

--- a/Userland/Libraries/LibC/netdb.cpp
+++ b/Userland/Libraries/LibC/netdb.cpp
@@ -19,7 +19,11 @@
 
 extern "C" {
 
+#ifdef NO_TLS
 int h_errno;
+#else
+__thread int h_errno;
+#endif
 
 static hostent __gethostbyname_buffer;
 static in_addr_t __gethostbyname_address;

--- a/Userland/Libraries/LibC/netdb.h
+++ b/Userland/Libraries/LibC/netdb.h
@@ -56,6 +56,7 @@ extern __thread int h_errno;
 
 #define HOST_NOT_FOUND 101
 #define NO_DATA 102
+#define NO_ADDRESS NO_DATA
 #define NO_RECOVERY 103
 #define TRY_AGAIN 104
 
@@ -104,5 +105,8 @@ int getaddrinfo(char const* __restrict node, char const* __restrict service, con
 void freeaddrinfo(struct addrinfo* res);
 char const* gai_strerror(int errcode);
 int getnameinfo(const struct sockaddr* __restrict addr, socklen_t addrlen, char* __restrict host, socklen_t hostlen, char* __restrict serv, socklen_t servlen, int flags);
+
+void herror(char const* s);
+char const* hstrerror(int err);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/netdb.h
+++ b/Userland/Libraries/LibC/netdb.h
@@ -48,7 +48,11 @@ struct protoent* getprotobynumber(int proto);
 struct protoent* getprotoent(void);
 void setprotoent(int stay_open);
 
+#ifdef NO_TLS
 extern int h_errno;
+#else
+extern __thread int h_errno;
+#endif
 
 #define HOST_NOT_FOUND 101
 #define NO_DATA 102


### PR DESCRIPTION
This PR makes `h_errno` a thread-local variable, which it should be as per POSIX, along with adding some missing functions for describing its values.