### PR TITLE
Applications: Make settings applications track their modified state

### DIFF
--- a/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
+++ b/Userland/Applications/BrowserSettings/ContentFilterSettingsWidget.cpp
@@ -114,12 +114,15 @@ ContentFilterSettingsWidget::ContentFilterSettingsWidget()
     m_domain_list_view = find_descendant_of_type_named<GUI::ListView>("domain_list_view");
     m_add_new_domain_button = find_descendant_of_type_named<GUI::Button>("add_new_domain_button");
 
-    m_enable_content_filtering_checkbox->set_checked(Config::read_bool("Browser", "Preferences", "EnableContentFilters"));
+    m_enable_content_filtering_checkbox->set_checked(Config::read_bool("Browser", "Preferences", "EnableContentFilters"), GUI::AllowCallback::No);
+    m_enable_content_filtering_checkbox->on_checked = [&](auto) { set_modified(true); };
 
     m_add_new_domain_button->on_click = [&](unsigned) {
         String text;
-        if (GUI::InputBox::show(window(), text, "Enter domain name", "Add domain to Content Filter") == GUI::Dialog::ExecOK)
+        if (GUI::InputBox::show(window(), text, "Enter domain name", "Add domain to Content Filter") == GUI::Dialog::ExecOK) {
             m_domain_list_model->add_domain(std::move(text));
+            set_modified(true);
+        }
     };
 
     m_domain_list_model = make_ref_counted<DomainListModel>();
@@ -128,8 +131,10 @@ ContentFilterSettingsWidget::ContentFilterSettingsWidget()
     m_domain_list_view->set_model(m_domain_list_model);
 
     auto delete_action = GUI::CommonActions::make_delete_action([&](GUI::Action const&) {
-        if (!m_domain_list_view->selection().is_empty())
+        if (!m_domain_list_view->selection().is_empty()) {
             m_domain_list_model->delete_domain(m_domain_list_view->selection().first().row());
+            set_modified(true);
+        }
     });
     m_entry_context_menu = GUI::Menu::construct();
     m_entry_context_menu->add_action(delete_action);

--- a/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/ClockSettingsWidget.cpp
@@ -35,6 +35,7 @@ ClockSettingsWidget::ClockSettingsWidget()
     m_custom_format_input->set_enabled(false);
     m_custom_format_input->on_change = [&] {
         m_time_format = m_custom_format_input->get_text();
+        set_modified(true);
         update_clock_preview();
     };
 
@@ -60,6 +61,7 @@ ClockSettingsWidget::ClockSettingsWidget()
             return;
         m_show_seconds_checkbox->set_enabled(true);
         m_custom_format_input->set_enabled(false);
+        set_modified(true);
         update_time_format_string();
     };
 
@@ -68,10 +70,12 @@ ClockSettingsWidget::ClockSettingsWidget()
             return;
         m_show_seconds_checkbox->set_enabled(true);
         m_custom_format_input->set_enabled(false);
+        set_modified(true);
         update_time_format_string();
     };
 
     m_show_seconds_checkbox->on_checked = [&](bool) {
+        set_modified(true);
         update_time_format_string();
     };
 
@@ -80,6 +84,7 @@ ClockSettingsWidget::ClockSettingsWidget()
             return;
         m_show_seconds_checkbox->set_enabled(false);
         m_custom_format_input->set_enabled(true);
+        set_modified(true);
     };
 
     m_clock_preview_update_timer = Core::Timer::create_repeating(1000, [&]() {

--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
@@ -50,6 +50,9 @@ TimeZoneSettingsWidget::TimeZoneSettingsWidget()
     m_time_zone_combo_box->set_only_allow_values_from_model(true);
     m_time_zone_combo_box->set_model(*StringViewListModel::create(time_zones));
     m_time_zone_combo_box->set_text(m_time_zone);
+    m_time_zone_combo_box->on_change = [&](auto, auto) {
+        set_modified(true);
+    };
 
     auto time_zone_map_bitmap = Gfx::Bitmap::try_load_from_file("/res/graphics/map.png"sv).release_value_but_fixme_should_propagate_errors();
     auto time_zone_rect = time_zone_map_bitmap->rect().shrunken(TIME_ZONE_MAP_NORTHERN_TRIM, 0, TIME_ZONE_MAP_SOUTHERN_TRIM, 0);

--- a/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/BackgroundSettingsWidget.cpp
@@ -61,6 +61,7 @@ void BackgroundSettingsWidget::create_frame()
         }
 
         m_monitor_widget->set_wallpaper(path);
+        set_modified(true);
     };
 
     m_context_menu = GUI::Menu::construct();
@@ -93,6 +94,7 @@ void BackgroundSettingsWidget::create_frame()
         m_wallpaper_view->selection().clear();
         m_monitor_widget->set_wallpaper(path.value());
         m_background_settings_changed = true;
+        set_modified(true);
     };
 
     m_mode_combo = *find_descendant_of_type_named<GUI::ComboBox>("mode_combo");
@@ -103,6 +105,7 @@ void BackgroundSettingsWidget::create_frame()
         m_monitor_widget->set_wallpaper_mode(m_modes.at(index.row()));
         m_background_settings_changed = !first_mode_change;
         first_mode_change = false;
+        set_modified(true);
     };
 
     m_color_input = *find_descendant_of_type_named<GUI::ColorInput>("color_input");
@@ -113,6 +116,7 @@ void BackgroundSettingsWidget::create_frame()
         m_monitor_widget->set_background_color(m_color_input->color());
         m_background_settings_changed = !first_color_change;
         first_color_change = false;
+        set_modified(true);
     };
 }
 
@@ -133,7 +137,7 @@ void BackgroundSettingsWidget::load_current_settings()
         mode = "center";
     }
     m_monitor_widget->set_wallpaper_mode(mode);
-    m_mode_combo->set_selected_index(m_modes.find_first_index(mode).value_or(0));
+    m_mode_combo->set_selected_index(m_modes.find_first_index(mode).value_or(0), GUI::AllowCallback::No);
 
     auto palette_desktop_color = palette().desktop_background();
     auto background_color = ws_config->read_entry("Background", "Color", "");
@@ -144,7 +148,7 @@ void BackgroundSettingsWidget::load_current_settings()
             palette_desktop_color = opt_color.value();
     }
 
-    m_color_input->set_color(palette_desktop_color);
+    m_color_input->set_color(palette_desktop_color, GUI::AllowCallback::No);
     m_monitor_widget->set_background_color(palette_desktop_color);
     m_background_settings_changed = false;
 }

--- a/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/DesktopSettingsWidget.cpp
@@ -26,14 +26,20 @@ void DesktopSettingsWidget::create_frame()
     load_from_gml(desktop_settings_gml);
 
     m_workspace_rows_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("workspace_rows_spinbox");
+    m_workspace_rows_spinbox->on_change = [&](auto) {
+        set_modified(true);
+    };
     m_workspace_columns_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("workspace_columns_spinbox");
+    m_workspace_columns_spinbox->on_change = [&](auto) {
+        set_modified(true);
+    };
 }
 
 void DesktopSettingsWidget::load_current_settings()
 {
     auto& desktop = GUI::Desktop::the();
-    m_workspace_rows_spinbox->set_value(desktop.workspace_rows());
-    m_workspace_columns_spinbox->set_value(desktop.workspace_columns());
+    m_workspace_rows_spinbox->set_value(desktop.workspace_rows(), GUI::AllowCallback::No);
+    m_workspace_columns_spinbox->set_value(desktop.workspace_columns(), GUI::AllowCallback::No);
 }
 
 void DesktopSettingsWidget::apply_settings()

--- a/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/FontSettingsWidget.cpp
@@ -30,6 +30,7 @@ FontSettingsWidget::FontSettingsWidget()
         auto font_picker = GUI::FontPicker::construct(window(), &m_default_font_label->font(), false);
         if (font_picker->exec() == GUI::Dialog::ExecOK) {
             update_label_with_font(*m_default_font_label, *font_picker->font());
+            set_modified(true);
         }
     };
 
@@ -42,6 +43,7 @@ FontSettingsWidget::FontSettingsWidget()
         auto font_picker = GUI::FontPicker::construct(window(), &m_fixed_width_font_label->font(), true);
         if (font_picker->exec() == GUI::Dialog::ExecOK) {
             update_label_with_font(*m_fixed_width_font_label, *font_picker->font());
+            set_modified(true);
         }
     };
 }

--- a/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/MonitorSettingsWidget.cpp
@@ -92,6 +92,7 @@ void MonitorSettingsWidget::create_frame()
         // Try to auto re-arrange things if there are overlaps or disconnected screens
         m_screen_layout.normalize();
         selected_screen_index_or_resolution_changed();
+        set_modified(true);
     };
 
     m_display_scale_radio_1x = *find_descendant_of_type_named<GUI::RadioButton>("scale_1x");
@@ -103,6 +104,7 @@ void MonitorSettingsWidget::create_frame()
             m_screen_layout.normalize();
             m_monitor_widget->set_desktop_scale_factor(1);
             m_monitor_widget->update();
+            set_modified(true);
         }
     };
     m_display_scale_radio_2x = *find_descendant_of_type_named<GUI::RadioButton>("scale_2x");
@@ -114,6 +116,7 @@ void MonitorSettingsWidget::create_frame()
             m_screen_layout.normalize();
             m_monitor_widget->set_desktop_scale_factor(2);
             m_monitor_widget->update();
+            set_modified(true);
         }
     };
 
@@ -209,12 +212,12 @@ void MonitorSettingsWidget::selected_screen_index_or_resolution_changed()
         dbgln("unexpected ScaleFactor {}, setting to 1", screen.scale_factor);
         screen.scale_factor = 1;
     }
-    (screen.scale_factor == 1 ? m_display_scale_radio_1x : m_display_scale_radio_2x)->set_checked(true);
+    (screen.scale_factor == 1 ? m_display_scale_radio_1x : m_display_scale_radio_2x)->set_checked(true, GUI::AllowCallback::No);
     m_monitor_widget->set_desktop_scale_factor(screen.scale_factor);
 
     // Select the current selected resolution as it may differ
     m_monitor_widget->set_desktop_resolution(current_resolution);
-    m_resolution_combo->set_selected_index(index);
+    m_resolution_combo->set_selected_index(index, GUI::AllowCallback::No);
 
     m_monitor_widget->update();
 }

--- a/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
+++ b/Userland/Applications/DisplaySettings/ThemesSettingsWidget.cpp
@@ -44,8 +44,9 @@ ThemesSettingsWidget::ThemesSettingsWidget(bool& background_settings_changed)
     m_themes_combo->on_change = [this](auto&, const GUI::ModelIndex& index) {
         m_selected_theme = &m_themes.at(index.row());
         m_theme_preview->set_theme(m_selected_theme->path);
+        set_modified(true);
     };
-    m_themes_combo->set_selected_index(current_theme_index);
+    m_themes_combo->set_selected_index(current_theme_index, GUI::AllowCallback::No);
 }
 
 void ThemesSettingsWidget::apply_settings()

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -187,6 +187,7 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
         if (!selection.is_empty()) {
             auto& selected_keymap = keymaps_list_model.keymap_at(selection.first().row());
             keymaps_list_model.set_active_keymap(selected_keymap);
+            set_modified(true);
         }
     };
 
@@ -202,8 +203,10 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
 
     m_add_keymap_button->on_click = [&](auto) {
         auto keymap = KeymapSelectionDialog::select_keymap(window(), keymaps_list_model.keymaps());
-        if (!keymap.is_empty())
+        if (!keymap.is_empty()) {
             keymaps_list_model.add_keymap(keymap);
+            set_modified(true);
+        }
     };
 
     m_remove_keymap_button = find_descendant_of_type_named<GUI::Button>("remove_keymap_button");
@@ -218,6 +221,7 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
         }
         if (active_keymap_deleted)
             keymaps_list_model.set_active_keymap(keymaps_list_model.keymap_at(0));
+        set_modified(true);
     };
 
     m_selected_keymaps_listview->on_selection_change = [&]() {
@@ -243,6 +247,9 @@ KeyboardSettingsWidget::KeyboardSettingsWidget()
 
     m_num_lock_checkbox = find_descendant_of_type_named<GUI::CheckBox>("num_lock_checkbox");
     m_num_lock_checkbox->set_checked(Config::read_bool("KeyboardSettings", "StartupEnable", "NumLock", true));
+    m_num_lock_checkbox->on_checked = [&](auto) {
+        set_modified(true);
+    };
 }
 
 KeyboardSettingsWidget::~KeyboardSettingsWidget()

--- a/Userland/Applications/MailSettings/MailSettingsWidget.cpp
+++ b/Userland/Applications/MailSettings/MailSettingsWidget.cpp
@@ -46,15 +46,27 @@ MailSettingsWidget::MailSettingsWidget()
 
     m_server_inputbox = *find_descendant_of_type_named<GUI::TextBox>("server_input");
     m_server_inputbox->set_text(Config::read_string("Mail", "Connection", "Server", ""));
+    m_server_inputbox->on_change = [&]() {
+        set_modified(true);
+    };
 
     m_port_combobox = *find_descendant_of_type_named<GUI::ComboBox>("port_input");
     m_port_combobox->set_text(Config::read_string("Mail", "Connection", "Port", "993"));
     m_port_combobox->set_only_allow_values_from_model(false);
     m_port_combobox->set_model(*GUI::ItemListModel<String>::create(m_common_ports));
+    m_port_combobox->on_change = [&](auto, auto) {
+        set_modified(true);
+    };
 
     m_tls_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("tls_input");
     m_tls_checkbox->set_checked(Config::read_bool("Mail", "Connection", "TLS", false));
+    m_tls_checkbox->on_checked = [&](auto) {
+        set_modified(true);
+    };
 
     m_email_inputbox = *find_descendant_of_type_named<GUI::TextBox>("email_input");
     m_email_inputbox->set_text(Config::read_string("Mail", "User", "Username", ""));
+    m_email_inputbox->on_change = [&]() {
+        set_modified(true);
+    };
 }

--- a/Userland/Applications/MouseSettings/MouseWidget.cpp
+++ b/Userland/Applications/MouseSettings/MouseWidget.cpp
@@ -25,28 +25,41 @@ MouseWidget::MouseWidget()
     m_speed_label = *find_descendant_of_type_named<GUI::Label>("speed_label");
     m_speed_slider = *find_descendant_of_type_named<GUI::HorizontalSlider>("speed_slider");
     m_speed_slider->set_range(WindowServer::mouse_accel_min * speed_slider_scale, WindowServer::mouse_accel_max * speed_slider_scale);
-    m_speed_slider->on_change = [&](int value) {
-        m_speed_label->set_text(String::formatted("{} %", value));
-    };
     int const slider_value = float { speed_slider_scale } * GUI::ConnectionToWindowServer::the().get_mouse_acceleration();
-    m_speed_slider->set_value(slider_value);
+    m_speed_slider->set_value(slider_value, GUI::AllowCallback::No);
+    m_speed_slider->on_change = [&](int) {
+        update_speed_label();
+        set_modified(true);
+    };
 
     m_scroll_length_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("scroll_length_spinbox");
     m_scroll_length_spinbox->set_min(WindowServer::scroll_step_size_min);
-    m_scroll_length_spinbox->set_value(GUI::ConnectionToWindowServer::the().get_scroll_step_size());
+    m_scroll_length_spinbox->set_value(GUI::ConnectionToWindowServer::the().get_scroll_step_size(), GUI::AllowCallback::No);
+    m_scroll_length_spinbox->on_change = [&](auto) {
+        set_modified(true);
+    };
 
     m_double_click_arrow_widget = *find_descendant_of_type_named<MouseSettings::DoubleClickArrowWidget>("double_click_arrow_widget");
     m_double_click_speed_label = *find_descendant_of_type_named<GUI::Label>("double_click_speed_label");
     m_double_click_speed_slider = *find_descendant_of_type_named<GUI::HorizontalSlider>("double_click_speed_slider");
     m_double_click_speed_slider->set_min(WindowServer::double_click_speed_min);
     m_double_click_speed_slider->set_max(WindowServer::double_click_speed_max);
+    m_double_click_speed_slider->set_value(GUI::ConnectionToWindowServer::the().get_double_click_speed(), GUI::AllowCallback::No);
     m_double_click_speed_slider->on_change = [&](int speed) {
         m_double_click_arrow_widget->set_double_click_speed(speed);
-        m_double_click_speed_label->set_text(String::formatted("{} ms", speed));
+        update_double_click_speed_label();
+        set_modified(true);
     };
-    m_double_click_speed_slider->set_value(GUI::ConnectionToWindowServer::the().get_double_click_speed());
+
     m_switch_buttons_checkbox = *find_descendant_of_type_named<GUI::CheckBox>("switch_buttons_input");
-    m_switch_buttons_checkbox->set_checked(GUI::ConnectionToWindowServer::the().get_buttons_switched());
+    m_switch_buttons_checkbox->set_checked(GUI::ConnectionToWindowServer::the().get_buttons_switched(), GUI::AllowCallback::No);
+    m_switch_buttons_checkbox->on_checked = [&](auto) {
+        set_modified(true);
+    };
+
+    update_speed_label();
+    update_double_click_speed_label();
+    m_double_click_arrow_widget->set_double_click_speed(m_double_click_speed_slider->value());
 }
 
 void MouseWidget::apply_settings()
@@ -64,4 +77,14 @@ void MouseWidget::reset_default_values()
     m_scroll_length_spinbox->set_value(default_scroll_length);
     m_double_click_speed_slider->set_value(double_click_speed_default);
     m_switch_buttons_checkbox->set_checked(false);
+}
+
+void MouseWidget::update_speed_label()
+{
+    m_speed_label->set_text(String::formatted("{} %", m_speed_slider->value()));
+}
+
+void MouseWidget::update_double_click_speed_label()
+{
+    m_double_click_speed_label->set_text(String::formatted("{} ms", m_double_click_speed_slider->value()));
 }

--- a/Userland/Applications/MouseSettings/MouseWidget.h
+++ b/Userland/Applications/MouseSettings/MouseWidget.h
@@ -22,6 +22,9 @@ public:
 private:
     MouseWidget();
 
+    void update_speed_label();
+    void update_double_click_speed_label();
+
     RefPtr<GUI::HorizontalSlider> m_speed_slider;
     RefPtr<GUI::Label> m_speed_label;
     RefPtr<GUI::SpinBox> m_scroll_length_spinbox;

--- a/Userland/Applications/MouseSettings/ThemeWidget.cpp
+++ b/Userland/Applications/MouseSettings/ThemeWidget.cpp
@@ -121,10 +121,11 @@ ThemeWidget::ThemeWidget()
     m_theme_name_box = find_descendant_of_type_named<GUI::ComboBox>("theme_name_box");
     m_theme_name_box->on_change = [this](String const& value, GUI::ModelIndex const&) mutable {
         m_mouse_cursor_model->change_theme(value);
+        set_modified(true);
     };
     m_theme_name_box->set_model(ThemeModel::create());
     m_theme_name_box->model()->invalidate();
-    m_theme_name_box->set_text(theme_name);
+    m_theme_name_box->set_text(theme_name, GUI::AllowCallback::No);
 }
 
 void ThemeWidget::apply_settings()

--- a/Userland/Applications/MouseSettings/ThemeWidget.h
+++ b/Userland/Applications/MouseSettings/ThemeWidget.h
@@ -75,5 +75,5 @@ private:
 
     RefPtr<GUI::TableView> m_cursors_tableview;
     RefPtr<GUI::ComboBox> m_theme_name_box;
-    String m_theme_name;
+    RefPtr<MouseCursorModel> m_mouse_cursor_model;
 };

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.cpp
@@ -43,36 +43,40 @@ TerminalSettingsMainWidget::TerminalSettingsMainWidget()
 
     switch (m_bell_mode) {
     case VT::TerminalWidget::BellMode::Visible:
-        visual_bell_radio.set_checked(true);
+        visual_bell_radio.set_checked(true, GUI::AllowCallback::No);
         break;
     case VT::TerminalWidget::BellMode::AudibleBeep:
-        beep_bell_radio.set_checked(true);
+        beep_bell_radio.set_checked(true, GUI::AllowCallback::No);
         break;
     case VT::TerminalWidget::BellMode::Disabled:
-        no_bell_radio.set_checked(true);
+        no_bell_radio.set_checked(true, GUI::AllowCallback::No);
         break;
     }
 
     beep_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::AudibleBeep;
         Config::write_string("Terminal", "Window", "Bell", stringify_bell(m_bell_mode));
+        set_modified(true);
     };
     visual_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::Visible;
         Config::write_string("Terminal", "Window", "Bell", stringify_bell(m_bell_mode));
+        set_modified(true);
     };
     no_bell_radio.on_checked = [this](bool) {
         m_bell_mode = VT::TerminalWidget::BellMode::Disabled;
         Config::write_string("Terminal", "Window", "Bell", stringify_bell(m_bell_mode));
+        set_modified(true);
     };
 
     m_max_history_size = Config::read_i32("Terminal", "Terminal", "MaxHistorySize");
     m_original_max_history_size = m_max_history_size;
     auto& history_size_spinbox = *find_descendant_of_type_named<GUI::SpinBox>("history_size_spinbox");
-    history_size_spinbox.set_value(m_max_history_size);
+    history_size_spinbox.set_value(m_max_history_size, GUI::AllowCallback::No);
     history_size_spinbox.on_change = [this](int value) {
         m_max_history_size = value;
         Config::write_i32("Terminal", "Terminal", "MaxHistorySize", static_cast<i32>(m_max_history_size));
+        set_modified(true);
     };
 
     m_show_scrollbar = Config::read_bool("Terminal", "Terminal", "ShowScrollBar", true);
@@ -81,8 +85,9 @@ TerminalSettingsMainWidget::TerminalSettingsMainWidget()
     show_scrollbar_checkbox.on_checked = [&](bool show_scrollbar) {
         m_show_scrollbar = show_scrollbar;
         Config::write_bool("Terminal", "Terminal", "ShowScrollBar", show_scrollbar);
+        set_modified(true);
     };
-    show_scrollbar_checkbox.set_checked(m_show_scrollbar);
+    show_scrollbar_checkbox.set_checked(m_show_scrollbar, GUI::AllowCallback::No);
 
     m_confirm_close = Config::read_bool("Terminal", "Terminal", "ConfirmClose", true);
     m_orignal_confirm_close = m_confirm_close;
@@ -90,8 +95,9 @@ TerminalSettingsMainWidget::TerminalSettingsMainWidget()
     confirm_close_checkbox.on_checked = [&](bool confirm_close) {
         m_confirm_close = confirm_close;
         Config::write_bool("Terminal", "Terminal", "ConfirmClose", confirm_close);
+        set_modified(true);
     };
-    confirm_close_checkbox.set_checked(m_confirm_close);
+    confirm_close_checkbox.set_checked(m_confirm_close, GUI::AllowCallback::No);
 }
 
 TerminalSettingsViewWidget::TerminalSettingsViewWidget()
@@ -105,6 +111,7 @@ TerminalSettingsViewWidget::TerminalSettingsViewWidget()
     slider.on_change = [this](int value) {
         m_opacity = value;
         Config::write_i32("Terminal", "Window", "Opacity", static_cast<i32>(m_opacity));
+        set_modified(true);
     };
 
     m_color_scheme = Config::read_string("Terminal", "Window", "ColorScheme");
@@ -128,6 +135,7 @@ TerminalSettingsViewWidget::TerminalSettingsViewWidget()
     color_scheme_combo.on_change = [&](auto&, const GUI::ModelIndex& index) {
         m_color_scheme = index.data().as_string();
         Config::write_string("Terminal", "Window", "ColorScheme", m_color_scheme);
+        set_modified(true);
     };
 
     auto& font_button = *find_descendant_of_type_named<GUI::Button>("terminal_font_button");
@@ -147,6 +155,7 @@ TerminalSettingsViewWidget::TerminalSettingsViewWidget()
             font_text.set_text(m_font->human_readable_name());
             font_text.set_font(m_font);
             Config::write_string("Terminal", "Text", "Font", m_font->qualified_name());
+            set_modified(true);
         }
     };
 
@@ -166,10 +175,12 @@ TerminalSettingsViewWidget::TerminalSettingsViewWidget()
                 : Gfx::FontDatabase::the().get_by_name(font_name);
             Config::write_string("Terminal", "Text", "Font", m_font->qualified_name());
         }
+        set_modified(true);
     };
     // The "use default font" setting is not stored itself - we automatically set it if the actually present font is the default,
     // whether that was filled in by the above defaulting code or by the user.
-    use_default_font_button.set_checked(m_font == Gfx::FontDatabase::the().default_fixed_width_font());
+    use_default_font_button.set_checked(m_font == Gfx::FontDatabase::the().default_fixed_width_font(), GUI::AllowCallback::No);
+    font_selection.set_enabled(!use_default_font_button.is_checked());
 }
 
 VT::TerminalWidget::BellMode TerminalSettingsMainWidget::parse_bell(StringView bell_string)

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -274,9 +274,9 @@ String ComboBox::text() const
     return m_editor->text();
 }
 
-void ComboBox::set_text(String const& text)
+void ComboBox::set_text(String const& text, AllowCallback allow_callback)
 {
-    m_editor->set_text(text);
+    m_editor->set_text(text, allow_callback);
 }
 
 void ComboBox::set_only_allow_values_from_model(bool b)

--- a/Userland/Libraries/LibGUI/ComboBox.h
+++ b/Userland/Libraries/LibGUI/ComboBox.h
@@ -21,7 +21,7 @@ public:
     virtual ~ComboBox() override;
 
     String text() const;
-    void set_text(String const&);
+    void set_text(String const&, AllowCallback = AllowCallback::Yes);
 
     void open();
     void close();

--- a/Userland/Libraries/LibGUI/SettingsWindow.h
+++ b/Userland/Libraries/LibGUI/SettingsWindow.h
@@ -23,6 +23,18 @@ public:
         virtual void apply_settings() = 0;
         virtual void cancel_settings() { }
         virtual void reset_default_values() { }
+
+        SettingsWindow& settings_window() { return *m_window; }
+        void set_settings_window(SettingsWindow& settings_window) { m_window = settings_window; }
+
+        void set_modified(bool modified)
+        {
+            if (m_window)
+                m_window->set_modified(modified);
+        }
+
+    private:
+        WeakPtr<SettingsWindow> m_window;
     };
 
     enum class ShowDefaultsButton {
@@ -39,11 +51,18 @@ public:
     {
         auto tab = TRY(m_tab_widget->try_add_tab<T>(move(title), forward<Args>(args)...));
         TRY(m_tabs.try_set(id, tab));
+        tab->set_settings_window(*this);
         return tab;
     }
 
     Optional<NonnullRefPtr<Tab>> get_tab(StringView id) const;
     void set_active_tab(StringView id);
+
+    void apply_settings();
+    void cancel_settings();
+    void reset_default_values();
+
+    void set_modified(bool);
 
 private:
     SettingsWindow() = default;

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -1576,14 +1576,8 @@ void TextEditor::did_change(AllowCallback allow_callback)
     recompute_all_visual_lines();
     hide_autocomplete_if_needed();
     m_needs_rehighlight = true;
-    if (!m_has_pending_change_notification) {
-        m_has_pending_change_notification = true;
-        deferred_invoke([this, allow_callback] {
-            m_has_pending_change_notification = false;
-            if (on_change && allow_callback == AllowCallback::Yes)
-                on_change();
-        });
-    }
+    if (on_change && allow_callback == AllowCallback::Yes)
+        on_change();
 }
 void TextEditor::set_mode(const Mode mode)
 {

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -361,7 +361,6 @@ private:
     bool m_ruler_visible { false };
     bool m_gutter_visible { false };
     bool m_needs_rehighlight { false };
-    bool m_has_pending_change_notification { false };
     bool m_automatic_indentation_enabled { false };
     WrappingMode m_wrapping_mode { WrappingMode::NoWrap };
     bool m_visualize_trailing_whitespace { true };

--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -2260,6 +2260,9 @@ void WindowManager::apply_cursor_theme(String const& theme_name)
 
     Compositor::the().invalidate_cursor();
     m_config->write_entry("Mouse", "CursorTheme", theme_name);
+    if (auto result = m_config->sync(); result.is_error()) {
+        dbgln("Failed to save config file: {}", result.error());
+    }
 }
 
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/222642/167903972-0bd0a9b6-db7b-45c3-ae4d-53c850c71af8.png)

This is done to all of the FooSettings apps. As a bonus, the "Apply" button is only enabled when there are unsaved changes to apply.