### PR TITLE
WindowServer: Make window frame flashing use the highlight color

### DIFF
--- a/Userland/Services/WindowServer/WindowFrame.cpp
+++ b/Userland/Services/WindowServer/WindowFrame.cpp
@@ -258,7 +258,7 @@ Gfx::WindowTheme::WindowState WindowFrame::window_state_for_theme() const
     auto& wm = WindowManager::the();
 
     if (m_flash_timer && m_flash_timer->is_active())
-        return m_flash_counter & 1 ? Gfx::WindowTheme::WindowState::Active : Gfx::WindowTheme::WindowState::Inactive;
+        return m_flash_counter & 1 ? Gfx::WindowTheme::WindowState::Highlighted : Gfx::WindowTheme::WindowState::Inactive;
 
     if (&m_window == wm.highlight_window())
         return Gfx::WindowTheme::WindowState::Highlighted;


### PR DESCRIPTION
Now, when windows flash, the "active" color of the window title frame's flash is the highlight color instead of the standard window color. The "inactive" color of the flash is still the disabled color as before.

Reasoning behind this change in aesthetics: There are four [1] window title frame colors with specific UI purposes:
1. "Active" for the normal active window, obvious purpose.
2. "Moving" for the window that is being dragged or resized by the user. Responsible for acting as a visual click feedback as a kind of subdued button.
3. "Inactive" for any inactive windows, obvious purpose.
4. "Highlight".

The purpose of "Highlight" is in the name, though it's non-obvious what that exactly entails. Before, only alt-tab selecting windows would use the highlight color for showing the current target window. In my opinion this points to the purpose of "highlight" being to move the user's focus to another window when the simple active state is not enough. Then it makes sense to have the window flashing use the highlight color. The entire purpose of window flashing is to shift the user's focus to a dialog window that might not be close to the window they just clicked. Using the highlight color enables an even stronger emphasis than before. It enables a cleaner separation between the purpose of the two frame colors, as well as making the "Highlight" frame more common.

[1] Technically there are eight, as the title frame has a gradient by default. We can count the gradient as one color for this purpose.