### PR TITLE
LibDSP: Refactorings and sample ranges

### DIFF
--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -45,8 +45,11 @@ void Track::fill_sample(Sample& sample)
             m_keyboard_notes[i] = {};
     }
 
-    auto synthesized_sample = m_synth->process(playing_notes).get<LibDSP::Sample>();
-    auto delayed_sample = m_delay->process(synthesized_sample).get<LibDSP::Sample>();
+    auto synthesized_sample = LibDSP::Signal { FixedArray<Audio::Sample>::must_create_but_fixme_should_propagate_errors(1) };
+    m_synth->process(playing_notes, synthesized_sample);
+    auto delayed_signal = LibDSP::Signal { FixedArray<Audio::Sample>::must_create_but_fixme_should_propagate_errors(1) };
+    m_delay->process(synthesized_sample, delayed_signal);
+    auto delayed_sample = delayed_signal.get<FixedArray<Audio::Sample>>()[0];
 
     // HACK: Convert to old Piano range: 16-bit int
     delayed_sample *= NumericLimits<i16>::max();

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -27,7 +27,7 @@ Track::Track(u32 const& time)
 
 void Track::fill_sample(Sample& sample)
 {
-    m_temporary_transport->time() = m_time;
+    m_temporary_transport->set_time(m_time);
 
     auto playing_notes = LibDSP::RollNotes {};
 

--- a/Userland/Applications/Piano/Track.cpp
+++ b/Userland/Applications/Piano/Track.cpp
@@ -18,7 +18,7 @@
 
 Track::Track(u32 const& time)
     : m_time(time)
-    , m_temporary_transport(LibDSP::Transport::construct(120, 4))
+    , m_temporary_transport(make_ref_counted<LibDSP::Transport>(120, 4))
     , m_delay(make_ref_counted<LibDSP::Effects::Delay>(m_temporary_transport))
     , m_synth(make_ref_counted<LibDSP::Synthesizers::Classic>(m_temporary_transport))
 {

--- a/Userland/Libraries/LibDSP/Clip.cpp
+++ b/Userland/Libraries/LibDSP/Clip.cpp
@@ -16,7 +16,7 @@ Sample AudioClip::sample_at(u32 time)
 
 void NoteClip::set_note(RollNote note)
 {
-    VERIFY(note.pitch >= 0 && note.pitch < note_count);
+    VERIFY(note.pitch >= 0 && note.pitch < note_frequencies.size());
     VERIFY(note.off_sample < m_length);
     VERIFY(note.length() >= 2);
 

--- a/Userland/Libraries/LibDSP/Clip.h
+++ b/Userland/Libraries/LibDSP/Clip.h
@@ -47,7 +47,7 @@ class NoteClip final : public Clip {
 public:
     void set_note(RollNote note);
 
-    Array<SinglyLinkedList<RollNote>, note_count>& notes() { return m_notes; }
+    Array<SinglyLinkedList<RollNote>, note_count> const& notes() const { return m_notes; }
 
 private:
     Array<SinglyLinkedList<RollNote>, note_count> m_notes;

--- a/Userland/Libraries/LibDSP/Clip.h
+++ b/Userland/Libraries/LibDSP/Clip.h
@@ -1,27 +1,21 @@
 /*
- * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Music.h"
+#include <AK/RefCounted.h>
 #include <AK/SinglyLinkedList.h>
 #include <AK/Types.h>
-#include <LibCore/Object.h>
+#include <LibDSP/Music.h>
 
 namespace LibDSP {
 
 // A clip is a self-contained snippet of notes or audio that can freely move inside and in between tracks.
-class Clip : public Core::Object {
-    C_OBJECT_ABSTRACT(Clip)
+class Clip : public RefCounted<Clip> {
 public:
-    Clip(u32 start, u32 length)
-        : m_start(start)
-        , m_length(length)
-    {
-    }
     virtual ~Clip() = default;
 
     u32 start() const { return m_start; }
@@ -29,6 +23,12 @@ public:
     u32 end() const { return m_start + m_length; }
 
 protected:
+    Clip(u32 start, u32 length)
+        : m_start(start)
+        , m_length(length)
+    {
+    }
+
     u32 m_start;
     u32 m_length;
 };

--- a/Userland/Libraries/LibDSP/Clip.h
+++ b/Userland/Libraries/LibDSP/Clip.h
@@ -47,10 +47,10 @@ class NoteClip final : public Clip {
 public:
     void set_note(RollNote note);
 
-    Array<SinglyLinkedList<RollNote>, note_count> const& notes() const { return m_notes; }
+    Array<SinglyLinkedList<RollNote>, note_frequencies.size()> const& notes() const { return m_notes; }
 
 private:
-    Array<SinglyLinkedList<RollNote>, note_count> m_notes;
+    Array<SinglyLinkedList<RollNote>, note_frequencies.size()> m_notes;
 };
 
 }

--- a/Userland/Libraries/LibDSP/Effects.h
+++ b/Userland/Libraries/LibDSP/Effects.h
@@ -20,7 +20,7 @@ public:
     Delay(NonnullRefPtr<Transport>);
 
 private:
-    virtual Signal process_impl(Signal const&) override;
+    virtual void process_impl(Signal const&, Signal&) override;
     void handle_delay_time_change();
 
     ProcessorRangeParameter m_delay_decay;
@@ -38,7 +38,7 @@ public:
     Mastering(NonnullRefPtr<Transport>);
 
 private:
-    virtual Signal process_impl(Signal const&) override;
+    virtual void process_impl(Signal const&, Signal&) override;
 };
 
 }

--- a/Userland/Libraries/LibDSP/Effects.h
+++ b/Userland/Libraries/LibDSP/Effects.h
@@ -1,15 +1,15 @@
 /*
- * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Processor.h"
-#include "ProcessorParameter.h"
-#include "Transport.h"
 #include <AK/Types.h>
+#include <LibDSP/Processor.h>
+#include <LibDSP/ProcessorParameter.h>
+#include <LibDSP/Transport.h>
 
 namespace LibDSP::Effects {
 

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -84,7 +84,7 @@ struct Signal : public Variant<Sample, RollNotes> {
 // We calculate note frequencies relative to A4:
 // 440.0 * pow(pow(2.0, 1.0 / 12.0), N)
 // Where N is the note distance from A.
-constexpr double note_frequencies[] = {
+constexpr Array<double, 84> note_frequencies = {
     // Octave 1
     32.703195662574764,
     34.647828872108946,
@@ -177,7 +177,6 @@ constexpr double note_frequencies[] = {
     3729.3100921447249,
     3951.0664100489994,
 };
-constexpr size_t const note_count = array_size(note_frequencies);
 
 constexpr double const middle_c = note_frequencies[36];
 

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -15,10 +15,9 @@
 
 namespace LibDSP {
 
-// FIXME: Audio::Frame is 64-bit float, which is quite large for long clips.
 using Sample = Audio::Sample;
 
-Sample const SAMPLE_OFF = { 0.0, 0.0 };
+constexpr Sample const SAMPLE_OFF = { 0.0, 0.0 };
 
 struct RollNote {
     constexpr u32 length() const { return (off_sample - on_sample) + 1; }
@@ -28,7 +27,7 @@ struct RollNote {
     u8 pitch;
     i8 velocity;
 
-    Envelope to_envelope(u32 time, u32 attack_samples, u32 decay_samples, u32 release_samples)
+    constexpr Envelope to_envelope(u32 time, u32 attack_samples, u32 decay_samples, u32 release_samples) const
     {
         i64 time_since_end = static_cast<i64>(time) - static_cast<i64>(off_sample);
         // We're before the end of this note.
@@ -58,7 +57,7 @@ struct RollNote {
         return Envelope::from_release(static_cast<double>(time_since_end) / static_cast<double>(release_samples));
     }
 
-    constexpr bool is_playing(u32 time) { return on_sample <= time && time <= off_sample; }
+    constexpr bool is_playing(u32 time) const { return on_sample <= time && time <= off_sample; }
 };
 
 enum class SignalType : u8 {
@@ -178,8 +177,8 @@ constexpr double note_frequencies[] = {
     3729.3100921447249,
     3951.0664100489994,
 };
-constexpr size_t note_count = array_size(note_frequencies);
+constexpr size_t const note_count = array_size(note_frequencies);
 
-constexpr double middle_c = note_frequencies[36];
+constexpr double const middle_c = note_frequencies[36];
 
 }

--- a/Userland/Libraries/LibDSP/Processor.h
+++ b/Userland/Libraries/LibDSP/Processor.h
@@ -34,6 +34,7 @@ public:
     SignalType input_type() const { return m_input_type; }
     SignalType output_type() const { return m_output_type; }
     Vector<ProcessorParameter&>& parameters() { return m_parameters; }
+    Vector<ProcessorParameter&> const& parameters() const { return m_parameters; }
 
 private:
     SignalType const m_input_type;

--- a/Userland/Libraries/LibDSP/Processor.h
+++ b/Userland/Libraries/LibDSP/Processor.h
@@ -24,12 +24,11 @@ class Processor : public RefCounted<Processor> {
 
 public:
     virtual ~Processor() = default;
-    Signal process(Signal const& input_signal)
+    void process(Signal const& input_signal, Signal& output_signal)
     {
         VERIFY(input_signal.type() == m_input_type);
-        auto processed = process_impl(input_signal);
-        VERIFY(processed.type() == m_output_type);
-        return processed;
+        process_impl(input_signal, output_signal);
+        VERIFY(output_signal.type() == m_output_type);
     }
     SignalType input_type() const { return m_input_type; }
     SignalType output_type() const { return m_output_type; }
@@ -47,7 +46,7 @@ protected:
         , m_transport(move(transport))
     {
     }
-    virtual Signal process_impl(Signal const& input_signal) = 0;
+    virtual void process_impl(Signal const& input_signal, Signal& output_signal) = 0;
 
     NonnullRefPtr<Transport> m_transport;
     Vector<ProcessorParameter&> m_parameters;

--- a/Userland/Libraries/LibDSP/Processor.h
+++ b/Userland/Libraries/LibDSP/Processor.h
@@ -1,15 +1,18 @@
 /*
- * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
+#include <AK/Function.h>
 #include <AK/Noncopyable.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
 #include <AK/StdLibExtras.h>
+#include <AK/String.h>
 #include <AK/Types.h>
-#include <LibCore/Object.h>
 #include <LibDSP/Music.h>
 #include <LibDSP/ProcessorParameter.h>
 #include <LibDSP/Transport.h>
@@ -17,13 +20,10 @@
 namespace LibDSP {
 
 // A processor processes notes or audio into notes or audio. Processors are e.g. samplers, synthesizers, effects, arpeggiators etc.
-class Processor : public Core::Object {
-    C_OBJECT_ABSTRACT(Processor);
+class Processor : public RefCounted<Processor> {
 
 public:
-    virtual ~Processor()
-    {
-    }
+    virtual ~Processor() = default;
     Signal process(Signal const& input_signal)
     {
         VERIFY(input_signal.type() == m_input_type);

--- a/Userland/Libraries/LibDSP/ProcessorParameter.h
+++ b/Userland/Libraries/LibDSP/ProcessorParameter.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -9,8 +9,9 @@
 #include <AK/FixedPoint.h>
 #include <AK/Format.h>
 #include <AK/Forward.h>
+#include <AK/Function.h>
+#include <AK/String.h>
 #include <AK/Types.h>
-#include <LibCore/Object.h>
 #include <LibDSP/Music.h>
 
 namespace LibDSP {

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -66,7 +66,7 @@ Signal Classic::process_impl(Signal const& input_signal)
 }
 
 // Linear ADSR envelope with no peak adjustment.
-double Classic::volume_from_envelope(Envelope const& envelope)
+double Classic::volume_from_envelope(Envelope const& envelope) const
 {
     switch (static_cast<EnvelopeState>(envelope)) {
     case EnvelopeState::Off:
@@ -102,12 +102,12 @@ double Classic::wave_position(u8 note)
     VERIFY_NOT_REACHED();
 }
 
-double Classic::samples_per_cycle(u8 note)
+double Classic::samples_per_cycle(u8 note) const
 {
     return m_transport->sample_rate() / note_frequencies[note];
 }
 
-double Classic::sin_position(u8 note)
+double Classic::sin_position(u8 note) const
 {
     double spc = samples_per_cycle(note);
     double cycle_pos = m_transport->time() / spc;
@@ -115,14 +115,14 @@ double Classic::sin_position(u8 note)
 }
 
 // Absolute value of the saw wave "flips" the negative portion into the positive, creating a ramp up and down.
-double Classic::triangle_position(u8 note)
+double Classic::triangle_position(u8 note) const
 {
     double saw = saw_position(note);
     return AK::fabs(saw) * 2 - 1;
 }
 
 // The first half of the cycle period is 1, the other half -1.
-double Classic::square_position(u8 note)
+double Classic::square_position(u8 note) const
 {
     double spc = samples_per_cycle(note);
     double progress = AK::fmod(static_cast<double>(m_transport->time()), spc) / spc;
@@ -130,7 +130,7 @@ double Classic::square_position(u8 note)
 }
 
 // Modulus creates inverse saw, which we need to flip and scale.
-double Classic::saw_position(u8 note)
+double Classic::saw_position(u8 note) const
 {
     double spc = samples_per_cycle(note);
     double unscaled = spc - AK::fmod(static_cast<double>(m_transport->time()), spc);

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -41,7 +41,7 @@ Signal Classic::process_impl(Signal const& input_signal)
 
     // "Press" the necessary notes in the internal representation,
     // and "release" all of the others
-    for (u8 i = 0; i < note_count; ++i) {
+    for (u8 i = 0; i < note_frequencies.size(); ++i) {
         if (auto maybe_note = in.get(i); maybe_note.has_value())
             m_playing_notes.set(i, maybe_note.value());
 

--- a/Userland/Libraries/LibDSP/Synthesizers.cpp
+++ b/Userland/Libraries/LibDSP/Synthesizers.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>.
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -7,11 +7,12 @@
 #include <AK/HashMap.h>
 #include <AK/Math.h>
 #include <AK/Random.h>
+#include <AK/RefPtr.h>
+#include <AK/StdLibExtras.h>
 #include <LibAudio/Sample.h>
 #include <LibDSP/Envelope.h>
 #include <LibDSP/Processor.h>
 #include <LibDSP/Synthesizers.h>
-#include <math.h>
 
 namespace LibDSP::Synthesizers {
 

--- a/Userland/Libraries/LibDSP/Synthesizers.h
+++ b/Userland/Libraries/LibDSP/Synthesizers.h
@@ -47,7 +47,7 @@ public:
     Waveform wave() const { return m_waveform.value(); }
 
 private:
-    virtual Signal process_impl(Signal const&) override;
+    virtual void process_impl(Signal const&, Signal&) override;
 
     double volume_from_envelope(Envelope const&) const;
     double wave_position(u8 note);

--- a/Userland/Libraries/LibDSP/Synthesizers.h
+++ b/Userland/Libraries/LibDSP/Synthesizers.h
@@ -49,13 +49,13 @@ public:
 private:
     virtual Signal process_impl(Signal const&) override;
 
-    double volume_from_envelope(Envelope const&);
+    double volume_from_envelope(Envelope const&) const;
     double wave_position(u8 note);
-    double samples_per_cycle(u8 note);
-    double sin_position(u8 note);
-    double triangle_position(u8 note);
-    double square_position(u8 note);
-    double saw_position(u8 note);
+    double samples_per_cycle(u8 note) const;
+    double sin_position(u8 note) const;
+    double triangle_position(u8 note) const;
+    double square_position(u8 note) const;
+    double saw_position(u8 note) const;
     double noise_position(u8 note);
     double get_random_from_seed(u64 note);
 

--- a/Userland/Libraries/LibDSP/Synthesizers.h
+++ b/Userland/Libraries/LibDSP/Synthesizers.h
@@ -66,7 +66,7 @@ private:
     ProcessorRangeParameter m_release;
 
     RollNotes m_playing_notes;
-    Array<double, note_count> last_random;
+    Array<double, note_frequencies.size()> last_random;
 };
 
 }

--- a/Userland/Libraries/LibDSP/Synthesizers.h
+++ b/Userland/Libraries/LibDSP/Synthesizers.h
@@ -1,13 +1,13 @@
 /*
- * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>.
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "LibDSP/Music.h"
 #include <AK/SinglyLinkedList.h>
+#include <LibDSP/Music.h>
 #include <LibDSP/Processor.h>
 #include <LibDSP/ProcessorParameter.h>
 #include <LibDSP/Transport.h>

--- a/Userland/Libraries/LibDSP/Track.cpp
+++ b/Userland/Libraries/LibDSP/Track.cpp
@@ -79,8 +79,8 @@ void NoteTrack::compute_current_clips_signal()
         return;
 
     // FIXME: performance?
-    for (auto& note_list : playing_clip->notes()) {
-        for (auto& note : note_list) {
+    for (auto const& note_list : playing_clip->notes()) {
+        for (auto const& note : note_list) {
             if (note.on_sample >= time && note.off_sample >= time)
                 break;
             if (note.on_sample <= time && note.off_sample >= time)

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -1,27 +1,24 @@
 /*
- * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Clip.h"
-#include "Music.h"
-#include "Processor.h"
-#include <LibCore/Object.h>
+#include <AK/NonnullRefPtrVector.h>
+#include <AK/RefCounted.h>
+#include <AK/RefPtr.h>
+#include <LibDSP/Clip.h>
+#include <LibDSP/Music.h>
+#include <LibDSP/Processor.h>
 
 namespace LibDSP {
 
 // A track is also known as a channel and serves as a container for the audio pipeline: clips -> processors -> mixing & output
-class Track : public Core::Object {
-    C_OBJECT_ABSTRACT(Track)
+class Track : public RefCounted<Track> {
 public:
-    Track(NonnullRefPtr<Transport> transport)
-        : m_transport(move(transport))
-    {
-    }
-    virtual ~Track() override = default;
+    virtual ~Track() = default;
 
     virtual bool check_processor_chain_valid() const = 0;
     bool add_processor(NonnullRefPtr<Processor> new_processor);
@@ -33,6 +30,10 @@ public:
     NonnullRefPtr<Transport> const transport() const { return m_transport; }
 
 protected:
+    Track(NonnullRefPtr<Transport> transport)
+        : m_transport(move(transport))
+    {
+    }
     bool check_processor_chain_valid_with_initial_type(SignalType initial_type) const;
 
     // Subclasses override to provide the base signal to the processing chain

--- a/Userland/Libraries/LibDSP/Track.h
+++ b/Userland/Libraries/LibDSP/Track.h
@@ -27,7 +27,7 @@ public:
     Sample current_signal();
 
     NonnullRefPtrVector<Processor> const& processor_chain() const { return m_processor_chain; }
-    NonnullRefPtr<Transport> const transport() const { return m_transport; }
+    NonnullRefPtr<Transport const> transport() const { return m_transport; }
 
 protected:
     Track(NonnullRefPtr<Transport> transport)

--- a/Userland/Libraries/LibDSP/Transport.h
+++ b/Userland/Libraries/LibDSP/Transport.h
@@ -15,7 +15,6 @@ namespace LibDSP {
 // The DAW-wide timekeeper and synchronizer
 class Transport final : public RefCounted<Transport> {
 public:
-    constexpr u32& time() { return m_time; }
     constexpr u32 time() const { return m_time; }
     constexpr u16 beats_per_minute() const { return m_beats_per_minute; }
     constexpr double current_second() const { return static_cast<double>(m_time) / m_sample_rate; }
@@ -23,6 +22,8 @@ public:
     constexpr double sample_rate() const { return m_sample_rate; }
     constexpr double ms_sample_rate() const { return m_sample_rate / 1000.; }
     constexpr double current_measure() const { return m_time / samples_per_measure(); }
+
+    void set_time(u32 time) { m_time = time; }
 
     Transport(u16 beats_per_minute, u8 beats_per_measure, u32 sample_rate)
         : m_beats_per_minute(beats_per_minute)

--- a/Userland/Libraries/LibDSP/Transport.h
+++ b/Userland/Libraries/LibDSP/Transport.h
@@ -1,20 +1,19 @@
 /*
- * Copyright (c) 2021, kleines Filmröllchen <filmroellchen@serenityos.org>
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
 #pragma once
 
-#include "Music.h"
+#include <AK/RefCounted.h>
 #include <AK/Types.h>
-#include <LibCore/Object.h>
+#include <LibDSP/Music.h>
 
 namespace LibDSP {
 
 // The DAW-wide timekeeper and synchronizer
-class Transport final : public Core::Object {
-    C_OBJECT(Transport)
+class Transport final : public RefCounted<Transport> {
 public:
     constexpr u32& time() { return m_time; }
     constexpr u16 beats_per_minute() const { return m_beats_per_minute; }
@@ -24,7 +23,6 @@ public:
     constexpr double ms_sample_rate() const { return m_sample_rate / 1000.; }
     constexpr double current_measure() const { return m_time / samples_per_measure(); }
 
-private:
     Transport(u16 beats_per_minute, u8 beats_per_measure, u32 sample_rate)
         : m_beats_per_minute(beats_per_minute)
         , m_beats_per_measure(beats_per_measure)
@@ -36,6 +34,7 @@ private:
     {
     }
 
+private:
     // FIXME: You can't make more than 24h of (48kHz) music with this.
     // But do you want to, really? :^)
     u32 m_time { 0 };

--- a/Userland/Libraries/LibDSP/Transport.h
+++ b/Userland/Libraries/LibDSP/Transport.h
@@ -16,6 +16,7 @@ namespace LibDSP {
 class Transport final : public RefCounted<Transport> {
 public:
     constexpr u32& time() { return m_time; }
+    constexpr u32 time() const { return m_time; }
     constexpr u16 beats_per_minute() const { return m_beats_per_minute; }
     constexpr double current_second() const { return static_cast<double>(m_time) / m_sample_rate; }
     constexpr double samples_per_measure() const { return (1.0 / m_beats_per_minute) * 60.0 * m_sample_rate; }


### PR DESCRIPTION
Next step in #6528, this will prepare LibDSP to handle all of the track management. A major part is to move the old sample-based APIs to sample range-based APIs which is standard practice in DAWs.