### PR TITLE
LibVT+Terminal: Make Terminal cursor customizable

### DIFF
--- a/Base/home/anon/.config/Terminal.ini
+++ b/Base/home/anon/.config/Terminal.ini
@@ -7,3 +7,6 @@ MaxHistorySize=1024
 Opacity=255
 Bell=Visible
 ColorScheme=Default
+[Cursor]
+Shape=Block
+Blinking=true

--- a/Kernel/TTY/VirtualConsole.cpp
+++ b/Kernel/TTY/VirtualConsole.cpp
@@ -358,7 +358,12 @@ void VirtualConsole::emit(u8 const* data, size_t size)
         TTY::emit(data[i], true);
 }
 
-void VirtualConsole::set_cursor_style(VT::CursorStyle)
+void VirtualConsole::set_cursor_shape(VT::CursorShape)
+{
+    // Do nothing
+}
+
+void VirtualConsole::set_cursor_blinking(bool)
 {
     // Do nothing
 }

--- a/Kernel/TTY/VirtualConsole.h
+++ b/Kernel/TTY/VirtualConsole.h
@@ -101,7 +101,8 @@ private:
     virtual void terminal_did_resize(u16 columns, u16 rows) override;
     virtual void terminal_history_changed(int) override;
     virtual void emit(u8 const*, size_t) override;
-    virtual void set_cursor_style(VT::CursorStyle) override;
+    virtual void set_cursor_shape(VT::CursorShape) override;
+    virtual void set_cursor_blinking(bool) override;
 
     // ^CharacterDevice
     virtual StringView class_name() const override { return "VirtualConsole"sv; }

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -62,6 +62,8 @@ public:
                 m_parent_terminal.set_show_scrollbar(value);
             else if (key == "ConfirmClose" && on_confirm_close_changed)
                 on_confirm_close_changed(value);
+        } else if (group == "Cursor" && key == "Blinking") {
+            m_parent_terminal.set_cursor_blinking(value);
         }
     }
 
@@ -88,6 +90,9 @@ public:
                 font = Gfx::FontDatabase::default_fixed_width_font();
             m_parent_terminal.set_font_and_resize_to_fit(*font);
             m_parent_terminal.window()->resize(m_parent_terminal.size());
+        } else if (group == "Cursor" && key == "Shape") {
+            auto cursor_shape = VT::TerminalWidget::parse_cursor_shape(value).value_or(VT::CursorShape::Block);
+            m_parent_terminal.set_cursor_shape(cursor_shape);
         }
     }
 
@@ -313,6 +318,12 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     } else {
         terminal->set_bell_mode(VT::TerminalWidget::BellMode::Visible);
     }
+
+    auto cursor_shape = VT::TerminalWidget::parse_cursor_shape(Config::read_string("Terminal", "Cursor", "Shape", "Block")).value_or(VT::CursorShape::Block);
+    terminal->set_cursor_shape(cursor_shape);
+
+    auto cursor_blinking = Config::read_bool("Terminal", "Cursor", "Blinking", true);
+    terminal->set_cursor_blinking(cursor_blinking);
 
     auto find_window = TRY(create_find_window(terminal));
 

--- a/Userland/Applications/TerminalSettings/CMakeLists.txt
+++ b/Userland/Applications/TerminalSettings/CMakeLists.txt
@@ -15,4 +15,4 @@ set(SOURCES
 )
 
 serenity_app(TerminalSettings ICON app-terminal)
-target_link_libraries(TerminalSettings LibGUI LibConfig LibMain)
+target_link_libraries(TerminalSettings LibGUI LibConfig LibMain LibVT)

--- a/Userland/Applications/TerminalSettings/TerminalSettingsView.gml
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsView.gml
@@ -60,6 +60,34 @@
     }
 
     @GUI::GroupBox {
+        title: "Cursor settings"
+        shrink_to_fit: true
+        layout: @GUI::VerticalBoxLayout {
+            margins: [16, 8, 8]
+        }
+
+        @GUI::RadioButton {
+            name: "terminal_cursor_block"
+            text: "Block cursor"
+        }
+
+        @GUI::RadioButton {
+            name: "terminal_cursor_underline"
+            text: "Underline cursor"
+        }
+
+        @GUI::RadioButton {
+            name: "terminal_cursor_bar"
+            text: "Bar cursor"
+        }
+
+        @GUI::CheckBox {
+            name: "terminal_cursor_blinking"
+            text: "Blinking cursor"
+        }
+    }
+
+    @GUI::GroupBox {
         title: "Color Scheme"
         fixed_height: 70
         layout: @GUI::VerticalBoxLayout {

--- a/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
+++ b/Userland/Applications/TerminalSettings/TerminalSettingsWidget.h
@@ -26,7 +26,7 @@ private:
     static VT::TerminalWidget::BellMode parse_bell(StringView bell_string);
     static String stringify_bell(VT::TerminalWidget::BellMode bell_mode);
 
-    VT::TerminalWidget::BellMode m_bell_mode = VT::TerminalWidget::BellMode::Disabled;
+    VT::TerminalWidget::BellMode m_bell_mode { VT::TerminalWidget::BellMode::Disabled };
     size_t m_max_history_size;
     bool m_show_scrollbar { true };
     bool m_confirm_close { true };
@@ -50,8 +50,12 @@ private:
     RefPtr<Gfx::Font> m_font;
     float m_opacity;
     String m_color_scheme;
+    VT::CursorShape m_cursor_shape { VT::CursorShape::Block };
+    bool m_cursor_is_blinking_set { true };
 
     RefPtr<Gfx::Font> m_original_font;
     float m_original_opacity;
     String m_original_color_scheme;
+    VT::CursorShape m_original_cursor_shape;
+    bool m_original_cursor_is_blinking_set;
 };

--- a/Userland/Libraries/LibVT/Terminal.cpp
+++ b/Userland/Libraries/LibVT/Terminal.cpp
@@ -61,32 +61,6 @@ void Terminal::alter_ansi_mode(bool should_set, Parameters params)
 
 void Terminal::alter_private_mode(bool should_set, Parameters params)
 {
-    auto steady_cursor_to_blinking = [](CursorStyle style) {
-        switch (style) {
-        case SteadyBar:
-            return BlinkingBar;
-        case SteadyBlock:
-            return BlinkingBlock;
-        case SteadyUnderline:
-            return BlinkingUnderline;
-        default:
-            return style;
-        }
-    };
-
-    auto blinking_cursor_to_steady = [](CursorStyle style) {
-        switch (style) {
-        case BlinkingBar:
-            return SteadyBar;
-        case BlinkingBlock:
-            return SteadyBlock;
-        case BlinkingUnderline:
-            return SteadyUnderline;
-        default:
-            return style;
-        }
-    };
-
     for (auto mode : params) {
         switch (mode) {
         case 1:
@@ -105,23 +79,22 @@ void Terminal::alter_private_mode(bool should_set, Parameters params)
         case 12:
             if (should_set) {
                 // Start blinking cursor
-                m_cursor_style = steady_cursor_to_blinking(m_cursor_style);
+                m_client.set_cursor_blinking(true);
             } else {
                 // Stop blinking cursor
-                m_cursor_style = blinking_cursor_to_steady(m_cursor_style);
+                m_client.set_cursor_blinking(false);
             }
-            m_client.set_cursor_style(m_cursor_style);
             break;
         case 25:
             if (should_set) {
                 // Show cursor
-                m_cursor_style = m_saved_cursor_style;
-                m_client.set_cursor_style(m_cursor_style);
+                m_cursor_shape = m_saved_cursor_shape;
+                m_client.set_cursor_shape(m_cursor_shape);
             } else {
                 // Hide cursor
-                m_saved_cursor_style = m_cursor_style;
-                m_cursor_style = None;
-                m_client.set_cursor_style(None);
+                m_saved_cursor_shape = m_cursor_shape;
+                m_cursor_shape = VT::CursorShape::None;
+                m_client.set_cursor_shape(VT::CursorShape::None);
             }
             break;
         case 1047:
@@ -674,22 +647,28 @@ void Terminal::DECSCUSR(Parameters params)
         style = params[0];
     switch (style) {
     case 1:
-        m_client.set_cursor_style(BlinkingBlock);
+        m_client.set_cursor_shape(VT::CursorShape::Block);
+        m_client.set_cursor_blinking(true);
         break;
     case 2:
-        m_client.set_cursor_style(SteadyBlock);
+        m_client.set_cursor_shape(VT::CursorShape::Block);
+        m_client.set_cursor_blinking(false);
         break;
     case 3:
-        m_client.set_cursor_style(BlinkingUnderline);
+        m_client.set_cursor_shape(VT::CursorShape::Underline);
+        m_client.set_cursor_blinking(true);
         break;
     case 4:
-        m_client.set_cursor_style(SteadyUnderline);
+        m_client.set_cursor_shape(VT::CursorShape::Underline);
+        m_client.set_cursor_blinking(false);
         break;
     case 5:
-        m_client.set_cursor_style(BlinkingBar);
+        m_client.set_cursor_shape(VT::CursorShape::Bar);
+        m_client.set_cursor_blinking(true);
         break;
     case 6:
-        m_client.set_cursor_style(SteadyBar);
+        m_client.set_cursor_shape(VT::CursorShape::Bar);
+        m_client.set_cursor_blinking(false);
         break;
     default:
         dbgln("Unknown cursor style {}", style);

--- a/Userland/Libraries/LibVT/Terminal.h
+++ b/Userland/Libraries/LibVT/Terminal.h
@@ -29,14 +29,11 @@ class VirtualConsole;
 
 namespace VT {
 
-enum CursorStyle {
+enum class CursorShape {
     None,
-    BlinkingBlock,
-    SteadyBlock,
-    BlinkingUnderline,
-    SteadyUnderline,
-    BlinkingBar,
-    SteadyBar
+    Block,
+    Underline,
+    Bar,
 };
 
 enum CursorKeysMode {
@@ -54,7 +51,8 @@ public:
     virtual void terminal_did_resize(u16 columns, u16 rows) = 0;
     virtual void terminal_history_changed(int delta) = 0;
     virtual void emit(u8 const*, size_t) = 0;
-    virtual void set_cursor_style(CursorStyle) = 0;
+    virtual void set_cursor_shape(CursorShape) = 0;
+    virtual void set_cursor_blinking(bool) = 0;
 };
 
 class Terminal : public EscapeSequenceExecutor {
@@ -428,8 +426,9 @@ protected:
     bool m_swallow_current { false };
     bool m_stomp { false };
 
-    CursorStyle m_cursor_style { BlinkingBlock };
-    CursorStyle m_saved_cursor_style { BlinkingBlock };
+    CursorShape m_cursor_shape { VT::CursorShape::Block };
+    CursorShape m_saved_cursor_shape { VT::CursorShape::Block };
+    bool m_cursor_is_blinking_set { true };
 
     bool m_needs_bracketed_paste { false };
 

--- a/Userland/Libraries/LibVT/TerminalWidget.h
+++ b/Userland/Libraries/LibVT/TerminalWidget.h
@@ -96,6 +96,13 @@ public:
 
     void set_color_scheme(StringView);
 
+    VT::CursorShape cursor_shape() { return m_cursor_shape; }
+    virtual void set_cursor_blinking(bool) override;
+    virtual void set_cursor_shape(CursorShape) override;
+
+    static Optional<VT::CursorShape> parse_cursor_shape(StringView);
+    static String stringify_cursor_shape(VT::CursorShape);
+
 private:
     TerminalWidget(int ptm_fd, bool automatic_size_policy);
 
@@ -124,7 +131,6 @@ private:
     virtual void terminal_did_resize(u16 columns, u16 rows) override;
     virtual void terminal_history_changed(int delta) override;
     virtual void emit(u8 const*, size_t) override;
-    virtual void set_cursor_style(CursorStyle) override;
 
     // ^GUI::Clipboard::ClipboardClient
     virtual void clipboard_content_did_change(String const&) override { update_paste_action(); }
@@ -196,7 +202,8 @@ private:
     bool m_cursor_blink_state { true };
     bool m_automatic_size_policy { false };
 
-    VT::CursorStyle m_cursor_style { BlinkingBlock };
+    VT::CursorShape m_cursor_shape { VT::CursorShape::Block };
+    bool m_cursor_is_blinking_set { true };
 
     enum class AutoScrollDirection {
         None,


### PR DESCRIPTION
This PR adds an entry in the terminal settings for customising caret. The API for that already existed but every shape for the cursor in the `enum CursorStyle` was doubled for its blinking and steady variation, so it also features a rework of that which changes `enum CursorStyle` to `enum CursorShape` and makes blinking a boolean flag.


![caret_demo](https://user-images.githubusercontent.com/15251385/168054015-382a5f88-3854-46bd-9ed6-f6b68f8be290.gif)
