### PR TITLE
Meta/Lagom: Fix leaks in the IDL Wrapper generator

### DIFF
--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLParser.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLParser.h
@@ -18,7 +18,7 @@ namespace IDL {
 class Parser {
 public:
     Parser(String filename, StringView contents, String import_base_path);
-    NonnullRefPtr<Interface> parse();
+    Interface& parse();
 
 private:
     // https://webidl.spec.whatwg.org/#dfn-special-operation
@@ -31,7 +31,7 @@ private:
     void assert_specific(char ch);
     void assert_string(StringView expected);
     void consume_whitespace();
-    Optional<NonnullRefPtr<Interface>> resolve_import(auto path);
+    Optional<Interface&> resolve_import(auto path);
 
     HashMap<String, String> parse_extended_attributes();
     void parse_attribute(HashMap<String, String>& extended_attributes, Interface&);
@@ -53,8 +53,9 @@ private:
     NonnullRefPtr<Type> parse_type();
     void parse_constant(Interface&);
 
-    static HashMap<String, NonnullRefPtr<Interface>> s_resolved_imports;
-    HashTable<String> required_imported_paths;
+    static HashTable<NonnullOwnPtr<Interface>> s_interfaces;
+    static HashMap<String, Interface*> s_resolved_imports;
+
     String import_base_path;
     String filename;
     StringView input;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLTypes.h
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/IDLTypes.h
@@ -141,7 +141,7 @@ struct CallbackFunction {
     bool is_legacy_treat_non_object_as_null { false };
 };
 
-struct Interface;
+class Interface;
 
 struct ParameterizedType : public Type {
     ParameterizedType() = default;
@@ -167,7 +167,13 @@ static inline size_t get_shortest_function_length(Vector<Function&> const& overl
     return longest_length;
 }
 
-struct Interface : public RefCounted<Interface> {
+class Interface {
+    AK_MAKE_NONCOPYABLE(Interface);
+    AK_MAKE_NONMOVABLE(Interface);
+
+public:
+    explicit Interface() = default;
+
     String name;
     String parent_name;
 
@@ -198,7 +204,7 @@ struct Interface : public RefCounted<Interface> {
     HashMap<String, Dictionary> dictionaries;
     HashMap<String, Enumeration> enumerations;
     HashMap<String, Typedef> typedefs;
-    HashMap<String, NonnullRefPtr<Interface>> mixins;
+    HashMap<String, Interface*> mixins;
     HashMap<String, CallbackFunction> callback_functions;
 
     // Added for convenience after parsing
@@ -212,7 +218,7 @@ struct Interface : public RefCounted<Interface> {
 
     String module_own_path;
     HashTable<String> required_imported_paths;
-    NonnullRefPtrVector<Interface> imported_modules;
+    Vector<Interface&> imported_modules;
 
     HashMap<String, Vector<Function&>> overload_sets;
     HashMap<String, Vector<Function&>> static_overload_sets;

--- a/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibWeb/WrapperGenerator/main.cpp
@@ -83,21 +83,21 @@ int main(int argc, char** argv)
     if (import_base_path.is_null())
         import_base_path = lexical_path.dirname();
 
-    auto interface = IDL::Parser(path, data, import_base_path).parse();
+    auto& interface = IDL::Parser(path, data, import_base_path).parse();
 
     if (namespace_.is_one_of("Crypto", "CSS", "DOM", "Encoding", "HTML", "UIEvents", "Geometry", "HighResolutionTime", "IntersectionObserver", "NavigationTiming", "RequestIdleCallback", "ResizeObserver", "SVG", "Selection", "URL", "WebSockets", "XHR")) {
         StringBuilder builder;
         builder.append(namespace_);
         builder.append("::");
-        builder.append(interface->name);
-        interface->fully_qualified_name = builder.to_string();
+        builder.append(interface.name);
+        interface.fully_qualified_name = builder.to_string();
     } else {
-        interface->fully_qualified_name = interface->name;
+        interface.fully_qualified_name = interface.name;
     }
 
     if constexpr (WRAPPER_GENERATOR_DEBUG) {
         dbgln("Attributes:");
-        for (auto& attribute : interface->attributes) {
+        for (auto& attribute : interface.attributes) {
             dbgln("  {}{}{} {}",
                 attribute.readonly ? "readonly " : "",
                 attribute.type->name,
@@ -106,7 +106,7 @@ int main(int argc, char** argv)
         }
 
         dbgln("Functions:");
-        for (auto& function : interface->functions) {
+        for (auto& function : interface.functions) {
             dbgln("  {}{} {}",
                 function.return_type->name,
                 function.return_type->nullable ? "?" : "",
@@ -120,7 +120,7 @@ int main(int argc, char** argv)
         }
 
         dbgln("Static Functions:");
-        for (auto& function : interface->static_functions) {
+        for (auto& function : interface.static_functions) {
             dbgln("  static {}{} {}",
                 function.return_type->name,
                 function.return_type->nullable ? "?" : "",
@@ -135,34 +135,34 @@ int main(int argc, char** argv)
     }
 
     if (header_mode)
-        IDL::generate_header(*interface);
+        IDL::generate_header(interface);
 
     if (implementation_mode)
-        IDL::generate_implementation(*interface);
+        IDL::generate_implementation(interface);
 
     if (constructor_header_mode)
-        IDL::generate_constructor_header(*interface);
+        IDL::generate_constructor_header(interface);
 
     if (constructor_implementation_mode)
-        IDL::generate_constructor_implementation(*interface);
+        IDL::generate_constructor_implementation(interface);
 
     if (prototype_header_mode)
-        IDL::generate_prototype_header(*interface);
+        IDL::generate_prototype_header(interface);
 
     if (prototype_implementation_mode)
-        IDL::generate_prototype_implementation(*interface);
+        IDL::generate_prototype_implementation(interface);
 
     if (iterator_header_mode)
-        IDL::generate_iterator_header(*interface);
+        IDL::generate_iterator_header(interface);
 
     if (iterator_implementation_mode)
-        IDL::generate_iterator_implementation(*interface);
+        IDL::generate_iterator_implementation(interface);
 
     if (iterator_prototype_header_mode)
-        IDL::generate_iterator_prototype_header(*interface);
+        IDL::generate_iterator_prototype_header(interface);
 
     if (iterator_prototype_implementation_mode)
-        IDL::generate_iterator_prototype_implementation(*interface);
+        IDL::generate_iterator_prototype_implementation(interface);
 
     return 0;
 }


### PR DESCRIPTION
## Overview

Makes it so the IDL Wrapper Generator doesn't have any RefPtr cycles on exit, and therefore doesn't leak any memory.

## Motivation

This change doesn't have any visible impact yet, as for now the IDL code generator is never run with leak detection unless by manually testing it. However, after #13473 , the IDL code generators will be run on Lagom and as such compiled with the -DENABLE_ADDRESS_SANITIZER=ON flag during the CI tests, and that will trigger the issue!

## Description of the issue

By using RefPtrs to handle interfaces, the IDL parser could store cyclic references to interfaces that import each other. One main example is the "EventTarget.idl" and the "AbortSignal.idl" files, which both reference each other. This caused huge amounts of memory not to be freed on exit.

## Proposed fix

The parsed IDL interfaces are now stored in a HashTable of NonnullOwnPtr<Interface>, which serves as the sole reference for every parsed interface. All other usages of the Interface are changed to use references instead of RefPtrs, or occasionally as raw pointers where references don't fit inside the data structures.

This new HashTable is static, and as such will automatically be freed prior to exiting the generator. This ensures that the code generator properly cleans up after itself.