### PR TITLE
LibWeb: Make about:blank load correctly

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -331,7 +331,7 @@ void FrameLoader::resource_did_load()
     }
     m_redirects_count = 0;
 
-    if (!resource()->has_encoded_data()) {
+    if (!resource()->has_encoded_data() && url.to_string() != "about:blank") {
         load_error_page(url, "No data");
         return;
     }

--- a/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/ResourceLoader.cpp
@@ -150,8 +150,12 @@ void ResourceLoader::load(LoadRequest& request, Function<void(ReadonlyBytes, Has
     if (url.protocol() == "about") {
         dbgln_if(SPAM_DEBUG, "Loading about: URL {}", url);
         log_success(request);
-        deferred_invoke([success_callback = move(success_callback)] {
-            success_callback(String::empty().to_byte_buffer(), {}, {});
+
+        HashMap<String, String, CaseInsensitiveStringTraits> response_headers;
+        response_headers.set("Content-Type", "text/html; charset=UTF-8");
+
+        deferred_invoke([success_callback = move(success_callback), response_headers = move(response_headers)] {
+            success_callback(String::empty().to_byte_buffer(), response_headers, {});
         });
         return;
     }


### PR DESCRIPTION
- Don't treat an empty `about:blank` resource as an error.
- Give `about:` urls a content-type so `FrameLoader::parse_document()`
  won't reject them.

Previously, we would instead get an error page:
![image](https://user-images.githubusercontent.com/222642/168268070-8526b8b2-74bd-48b3-b36c-1aa1931c9187.png)
