### PR TITLE
Revert "FileManager: Reduce scope of some variables related to context menu"

### DIFF
--- a/Userland/Applications/FileManager/main.cpp
+++ b/Userland/Applications/FileManager/main.cpp
@@ -1153,6 +1153,8 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
     TRY(tree_view_directory_context_menu->try_add_action(properties_action));
 
     RefPtr<GUI::Menu> file_context_menu;
+    NonnullRefPtrVector<LauncherHandler> current_file_handlers;
+    RefPtr<GUI::Action> file_context_menu_action_default_action;
 
     directory_view->on_context_menu_request = [&](GUI::ModelIndex const& index, GUI::ContextMenuEvent const& event) {
         if (index.is_valid()) {
@@ -1163,8 +1165,6 @@ ErrorOr<int> run_in_windowed_mode(String const& initial_location, String const& 
                 folder_specific_paste_action->set_enabled(should_get_enabled);
                 directory_context_menu->popup(event.screen_position(), directory_open_action);
             } else {
-                NonnullRefPtrVector<LauncherHandler> current_file_handlers;
-                RefPtr<GUI::Action> file_context_menu_action_default_action;
                 file_context_menu = GUI::Menu::construct("Directory View File");
 
                 bool added_launch_file_handlers = add_launch_handler_actions_to_menu(file_context_menu, directory_view, node.full_path(), file_context_menu_action_default_action, current_file_handlers);


### PR DESCRIPTION
This reverts commit 61dc48977832c7f705b9ccd29b74c9dd69ef5627.

This commit was causing FileManager to crash whenever you selected to
open a file using the context menu.

<details><summary>Backtrace</summary>
```
23.424 CrashReporter(39:40): 0x00000002f78f23e7: [/bin/FileManager] FileManager::DirectoryView::launch(AK::URL const&, FileManager::LauncherHandler const&) const +0x27 (NonnullRefPtr.h:186 => DirectoryView.h:34 => DirectoryView.cpp:481)
23.424 CrashReporter(39:40): 0x00000002f7907aaf: [/bin/FileManager] AK::Function<void (FileManager::LauncherHandler const&)>::CallableWrapper<add_launch_handler_actions_to_menu(AK::RefPtr<GUI::Menu, AK::RefPtrTraits<GUI::Menu> >&, FileManager::DirectoryView const&, AK::String const&, AK::RefPtr<GUI::Action, AK::RefPtrTraits<GUI::Action> >&, AK::NonnullRefPtrVector<FileManager::LauncherHandler, 0ul>&)::{lambda(auto:1&)#1}>::call(FileManager::LauncherHandler const&) +0x8f (main.cpp:295 => Function.h:151)
23.431 CrashReporter(39:40): 0x00000002f78ee193: [/bin/FileManager] AK::Function<void (GUI::Action&)>::CallableWrapper<FileManager::LauncherHandler::create_launch_action(AK::Function<void (FileManager::LauncherHandler const&)>)::{lambda(auto:1&)#1}>::call(GUI::Action&) +0x43 (Function.h:91)
23.432 CrashReporter(39:40): 0x00000011cc77fdd5: [/usr/lib/libgui.so.serenity] GUI::Action::activate(Core::Object*) +0x115 (Function.h:91)
23.432 CrashReporter(39:40): 0x00000011cc8b621d: [/usr/lib/libgui.so.serenity] GUI::ConnectionToWindowServer::menu_item_activated(int, unsigned int) +0x4d (ConnectionToWindowServer.cpp:301)
23.432 CrashReporter(39:40): 0x00000011cc8cb7bf: [/usr/lib/libgui.so.serenity] WindowClientStub::handle(IPC::Message const&) +0x57f (WindowClientEndpoint.h:3138)
23.432 CrashReporter(39:40): 0x0000000747c64006: [/usr/lib/libipc.so.serenity] IPC::ConnectionBase::handle_messages() +0xc6 (Connection.cpp:92)
23.436 CrashReporter(39:40): 0x00000011cc8c0dbd: [/usr/lib/libgui.so.serenity] AK::Function<void ()>::CallableWrapper<IPC::Connection<WindowClientEndpoint, WindowServerEndpoint>::Connection(IPC::Stub&, AK::NonnullOwnPtr<Core::Stream::LocalSocket>)::{lambda()#1}>::call() +0x4d (Connection.h:80 => Function.h:151)
23.436 CrashReporter(39:40): 0x0000001bffeca013: [/usr/lib/libcore.so.serenity] AK::Function<void ()>::CallableWrapper<Core::Stream::LocalSocket::setup_notifier()::{lambda()#1}>::call() +0x43 (Function.h:91)
23.436 CrashReporter(39:40): 0x0000001bffeb9ba5: [/usr/lib/libcore.so.serenity] Core::Notifier::event(Core::Event&) [clone .localalias] +0x85 (Function.h:91)
23.450 CrashReporter(39:40): 0x0000001bffebb35a: [/usr/lib/libcore.so.serenity] Core::Object::dispatch_event(Core::Event&, Core::Object*) +0x8a (Object.cpp:220)
23.450 CrashReporter(39:40): 0x0000001bffea595b: [/usr/lib/libcore.so.serenity] Core::EventLoop::pump(Core::EventLoop::WaitMode) +0x15b (EventLoop.cpp:470)
23.453 CrashReporter(39:40): 0x0000001bffea6279: [/usr/lib/libcore.so.serenity] Core::EventLoop::exec() +0x119 (EventLoop.cpp:427)
23.453 CrashReporter(39:40): 0x00000002f79142df: [/bin/FileManager] run_in_windowed_mode(AK::String const&, AK::String const&) +0x517f (main.cpp:1311)
23.453 CrashReporter(39:40): 0x00000002f7915cb9: [/bin/FileManager] serenity_main(Main::Arguments) +0x7c9 (main.cpp:129)
23.453 CrashReporter(39:40): 0x00000002f78ed3ba: [/bin/FileManager] main +0x9a (Main.cpp:39)
23.453 CrashReporter(39:40): 0x00000002f78ed5ef: [/bin/FileManager] _entry +0x6f (crt0.cpp:49)
```
</details>

I think somewhere we're losing a ref on a RefPtr? It doesn't make a lot of sense to me *why* this commit caused the crash, but the logic of `add_launch_handler_actions_to_menu()` is confusing me a lot.