### PR TITLE
LibWeb: Don't treat any empty resources as errors

### DIFF
--- a/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
+++ b/Userland/Libraries/LibWeb/Loader/FrameLoader.cpp
@@ -331,11 +331,6 @@ void FrameLoader::resource_did_load()
     }
     m_redirects_count = 0;
 
-    if (!resource()->has_encoded_data() && url.to_string() != "about:blank") {
-        load_error_page(url, "No data");
-        return;
-    }
-
     if (resource()->has_encoding()) {
         dbgln_if(RESOURCE_DEBUG, "This content has MIME type '{}', encoding '{}'", resource()->mime_type(), resource()->encoding().value());
     } else {


### PR DESCRIPTION
HTML, CSS, JS and text files (among other things) can all legitimately
be empty. Other types may be invalid, but that will be caught when
trying to parse it as a document, so this check can safely be removed.