### PR TITLE
TextEditor: Allow typing AltGr+letter into editor

### DIFF
--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -931,7 +931,8 @@ void TextEditor::keydown_event(KeyEvent& event)
         return;
     }
 
-    if (!event.ctrl() && !event.alt() && event.code_point() != 0) {
+    // AltGr is emulated as Ctrl+Alt; if Ctrl is set check if it's not for AltGr
+    if ((!event.ctrl() || event.altgr()) && !event.alt() && event.code_point() != 0) {
         TemporaryChange change { m_should_keep_autocomplete_box, true };
         add_code_point(event.code_point());
         return;


### PR DESCRIPTION
Previous check did not allow AltGr+letter to be used due to
AltGr being emulated as Ctrl+Alt. That caused .ctrl() to be true.

In the new code we check that ctrl() is not set or if it is set,
it is with altgr() and if so, we pass the character into the editor.

This closes #14016 