### PR TITLE
touch+LibC+Kernel: Use custom timestamps with utimensat() and futimens()

### DIFF
--- a/Kernel/API/POSIX/sys/stat.h
+++ b/Kernel/API/POSIX/sys/stat.h
@@ -70,6 +70,9 @@ struct stat {
 #define st_mtime st_mtim.tv_sec
 #define st_ctime st_ctim.tv_sec
 
+#define UTIME_OMIT -1
+#define UTIME_NOW -2
+
 #ifdef __cplusplus
 }
 #endif

--- a/Kernel/API/Syscall.h
+++ b/Kernel/API/Syscall.h
@@ -185,6 +185,7 @@ enum class NeedsBigProcessLock {
     S(unlink, NeedsBigProcessLock::No)                      \
     S(unveil, NeedsBigProcessLock::Yes)                     \
     S(utime, NeedsBigProcessLock::Yes)                      \
+    S(utimensat, NeedsBigProcessLock::Yes)                  \
     S(waitid, NeedsBigProcessLock::Yes)                     \
     S(write, NeedsBigProcessLock::Yes)                      \
     S(writev, NeedsBigProcessLock::Yes)                     \
@@ -414,6 +415,13 @@ struct SC_pledge_params {
 struct SC_unveil_params {
     StringArgument path;
     StringArgument permissions;
+};
+
+struct SC_utimensat_params {
+    int dirfd;
+    StringArgument path;
+    struct timespec const* times;
+    int flag;
 };
 
 struct SC_waitid_params {

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -281,6 +281,7 @@ set(KERNEL_SOURCES
     Syscalls/unlink.cpp
     Syscalls/unveil.cpp
     Syscalls/utime.cpp
+    Syscalls/utimensat.cpp
     Syscalls/waitid.cpp
     Syscalls/inode_watcher.cpp
     Syscalls/write.cpp

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -1545,6 +1545,8 @@ ErrorOr<void> Ext2FSInode::set_atime(time_t t)
     MutexLocker locker(m_inode_lock);
     if (fs().is_readonly())
         return EROFS;
+    if (t > INT32_MAX)
+        return EINVAL;
     m_raw_inode.i_atime = t;
     set_metadata_dirty(true);
     return {};

--- a/Kernel/FileSystem/VirtualFileSystem.h
+++ b/Kernel/FileSystem/VirtualFileSystem.h
@@ -64,6 +64,7 @@ public:
     ErrorOr<void> access(StringView path, int mode, Custody& base);
     ErrorOr<InodeMetadata> lookup_metadata(StringView path, Custody& base, int options = 0);
     ErrorOr<void> utime(StringView path, Custody& base, time_t atime, time_t mtime);
+    ErrorOr<void> utimensat(StringView path, Custody& base, timespec const& atime, timespec const& mtime, int options = 0);
     ErrorOr<void> rename(StringView oldpath, StringView newpath, Custody& base);
     ErrorOr<void> mknod(StringView path, mode_t, dev_t, Custody& base);
     ErrorOr<NonnullRefPtr<Custody>> open_directory(StringView path, Custody& base);

--- a/Kernel/Process.h
+++ b/Kernel/Process.h
@@ -353,6 +353,7 @@ public:
     ErrorOr<FlatPtr> sys$mkdir(Userspace<char const*> pathname, size_t path_length, mode_t mode);
     ErrorOr<FlatPtr> sys$times(Userspace<tms*>);
     ErrorOr<FlatPtr> sys$utime(Userspace<char const*> pathname, size_t path_length, Userspace<const struct utimbuf*>);
+    ErrorOr<FlatPtr> sys$utimensat(Userspace<Syscall::SC_utimensat_params const*>);
     ErrorOr<FlatPtr> sys$link(Userspace<Syscall::SC_link_params const*>);
     ErrorOr<FlatPtr> sys$unlink(int dirfd, Userspace<char const*> pathname, size_t path_length, int flags);
     ErrorOr<FlatPtr> sys$symlink(Userspace<Syscall::SC_symlink_params const*>);

--- a/Kernel/Syscalls/utimensat.cpp
+++ b/Kernel/Syscalls/utimensat.cpp
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2022, Ariel Don <ariel@arieldon.com>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <AK/Assertions.h>
+#include <AK/StringView.h>
+#include <Kernel/FileSystem/VirtualFileSystem.h>
+#include <Kernel/KLexicalPath.h>
+#include <Kernel/Process.h>
+
+namespace Kernel {
+
+ErrorOr<FlatPtr> Process::sys$utimensat(Userspace<Syscall::SC_utimensat_params const*> user_params)
+{
+    VERIFY_PROCESS_BIG_LOCK_ACQUIRED(this);
+    TRY(require_promise(Pledge::fattr));
+
+    auto params = TRY(copy_typed_from_user(user_params));
+    auto now = kgettimeofday().to_truncated_seconds();
+
+    timespec times[2];
+    if (params.times) {
+        TRY(copy_from_user(times, params.times, sizeof(times)));
+        if (times[0].tv_nsec == UTIME_NOW)
+            times[0].tv_sec = now;
+        if (times[1].tv_nsec == UTIME_NOW)
+            times[1].tv_sec = now;
+    } else {
+        // According to POSIX, both access and modification times are set to
+        // the current time given a nullptr.
+        times[0].tv_sec = now;
+        times[0].tv_nsec = UTIME_NOW;
+        times[1].tv_sec = now;
+        times[1].tv_nsec = UTIME_NOW;
+    }
+
+    int dirfd = params.dirfd;
+    auto path = TRY(get_syscall_path_argument(params.path));
+
+    RefPtr<Custody> base;
+    if (dirfd == AT_FDCWD) {
+        base = current_directory();
+    } else {
+        auto base_description = TRY(open_file_description(dirfd));
+        if (!KLexicalPath::is_absolute(path->view()) && !base_description->is_directory())
+            return ENOTDIR;
+        if (!base_description->custody())
+            return EINVAL;
+        base = base_description->custody();
+    }
+
+    auto& atime = times[0];
+    auto& mtime = times[1];
+    int follow_symlink = params.flag & AT_SYMLINK_NOFOLLOW ? O_NOFOLLOW_NOERROR : 0;
+    TRY(VirtualFileSystem::the().utimensat(path->view(), *base, atime, mtime, follow_symlink));
+    return 0;
+}
+
+}

--- a/Userland/Libraries/LibC/fcntl.cpp
+++ b/Userland/Libraries/LibC/fcntl.cpp
@@ -11,6 +11,7 @@
 #include <stdarg.h>
 #include <string.h>
 #include <syscall.h>
+#include <time.h>
 
 extern "C" {
 
@@ -101,5 +102,51 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice)
     (void)len;
     (void)advice;
     return 0;
+}
+
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/utimensat.html
+int utimensat(int dirfd, char const* path, struct timespec const times[2], int flag)
+{
+    if (!path) {
+        errno = EFAULT;
+        return -1;
+    }
+
+    size_t path_length = strlen(path);
+    if (path_length > INT32_MAX) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // POSIX allows AT_SYMLINK_NOFOLLOW flag or no flags.
+    if (flag & ~AT_SYMLINK_NOFOLLOW) {
+        errno = EINVAL;
+        return -1;
+    }
+
+    // Return early without error since both changes are to be omitted.
+    if (times && times[0].tv_nsec == UTIME_OMIT && times[1].tv_nsec == UTIME_OMIT)
+        return 0;
+
+    // According to POSIX, when times is a nullptr, it's equivalent to setting
+    // both last access time and last modification time to the current time.
+    // Setting the times argument to nullptr if it matches this case prevents
+    // the need to copy it in the kernel.
+    if (times && times[0].tv_nsec == UTIME_NOW && times[1].tv_nsec == UTIME_NOW)
+        times = nullptr;
+
+    if (times) {
+        for (int i = 0; i < 2; ++i) {
+            if ((times[i].tv_nsec != UTIME_NOW && times[i].tv_nsec != UTIME_OMIT)
+                && (times[i].tv_nsec < 0 || times[i].tv_nsec >= 1'000'000'000L)) {
+                errno = EINVAL;
+                return -1;
+            }
+        }
+    }
+
+    Syscall::SC_utimensat_params params { dirfd, { path, path_length }, times, flag };
+    int rc = syscall(SC_utimensat, &params);
+    __RETURN_WITH_ERRNO(rc, rc, -1);
 }
 }

--- a/Userland/Libraries/LibC/fcntl.h
+++ b/Userland/Libraries/LibC/fcntl.h
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <Kernel/API/POSIX/fcntl.h>
+#include <Kernel/API/POSIX/sys/stat.h>
 
 __BEGIN_DECLS
 
@@ -28,5 +29,7 @@ int inode_watcher_add_watch(int fd, char const* path, size_t path_length, unsign
 int inode_watcher_remove_watch(int fd, int wd);
 
 int posix_fadvise(int fd, off_t offset, off_t len, int advice);
+
+int utimensat(int dirfd, char const* path, struct timespec const times[2], int flag);
 
 __END_DECLS

--- a/Userland/Libraries/LibC/stat.cpp
+++ b/Userland/Libraries/LibC/stat.cpp
@@ -109,4 +109,10 @@ int fstatat(int fd, char const* path, struct stat* statbuf, int flags)
 {
     return do_stat(fd, path, statbuf, !(flags & AT_SYMLINK_NOFOLLOW));
 }
+
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html
+int futimens(int fd, struct timespec const times[2])
+{
+    return utimensat(fd, "", times, 0);
+}
 }

--- a/Userland/Libraries/LibC/sys/stat.h
+++ b/Userland/Libraries/LibC/sys/stat.h
@@ -23,5 +23,6 @@ int fstat(int fd, struct stat* statbuf);
 int lstat(char const* path, struct stat* statbuf);
 int stat(char const* path, struct stat* statbuf);
 int fstatat(int fd, char const* path, struct stat* statbuf, int flags);
+int futimens(int fd, struct timespec const times[2]);
 
 __END_DECLS

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -117,6 +117,11 @@ ErrorOr<NonnullOwnPtr<File>> File::adopt_fd(int fd, OpenMode mode)
     return file;
 }
 
+bool File::exists(StringView filename)
+{
+    return !Core::System::stat(filename).is_error();
+}
+
 int File::open_mode_to_options(OpenMode mode)
 {
     int flags = 0;

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -179,6 +179,7 @@ class File final : public SeekableStream {
 public:
     static ErrorOr<NonnullOwnPtr<File>> open(StringView filename, OpenMode, mode_t = 0644);
     static ErrorOr<NonnullOwnPtr<File>> adopt_fd(int fd, OpenMode);
+    static bool exists(StringView filename);
 
     File(File&& other) { operator=(move(other)); }
 

--- a/Userland/Utilities/touch.cpp
+++ b/Userland/Utilities/touch.cpp
@@ -1,51 +1,251 @@
 /*
  * Copyright (c) 2018-2021, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Ariel Don <ariel@arieldon.com>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <AK/CheckedFormatString.h>
+#include <AK/GenericLexer.h>
+#include <AK/Time.h>
 #include <LibCore/ArgsParser.h>
+#include <LibCore/Stream.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
+#include <LibTimeZone/TimeZone.h>
+#include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <time.h>
 
-static bool file_exists(String const& path)
+static String program_name;
+
+template<typename... Parameters>
+[[noreturn]] static void err(CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
 {
-    struct stat st;
-    int rc = stat(path.characters(), &st);
-    if (rc < 0) {
-        if (errno == ENOENT)
-            return false;
-    }
-    if (rc == 0) {
-        return true;
-    }
-    perror("stat");
+    warn("{}: ", program_name);
+    warnln(move(fmtstr), parameters...);
     exit(1);
+}
+
+inline static bool validate_timestamp(unsigned year, unsigned month, unsigned day, unsigned hour, unsigned minute, unsigned second)
+{
+    return (year >= 1970) && (month >= 1 && month <= 12) && (day >= 1 && day <= static_cast<unsigned>(days_in_month(year, month))) && (hour <= 23) && (minute <= 59) && (second <= 59);
+}
+
+static void parse_time(StringView input_time, timespec& atime, timespec& mtime)
+{
+    // Parse [[CC]YY]MMDDhhmm[.SS] format, where brackets signify optional
+    // parameters.
+    if (input_time.length() < 8)
+        err("invalid time format '{}' -- too short", input_time);
+    else if (input_time.length() > 15)
+        err("invalid time format '{}' -- too long", input_time);
+
+    Vector<u8> parameters;
+    GenericLexer lexer(input_time);
+    unsigned year, month, day, hour, minute, second;
+
+    auto lex_number = [&]() {
+        auto literal = lexer.consume(2);
+        if (literal.length() < 2)
+            err("invalid time format '{}' -- expected 2 digits per parameter", input_time);
+        auto maybe_parameter = literal.to_uint();
+        if (maybe_parameter.has_value())
+            parameters.append(maybe_parameter.value());
+        else
+            err("invalid time format '{}'", input_time);
+    };
+
+    while (!lexer.is_eof() && lexer.next_is(isdigit))
+        lex_number();
+    if (parameters.size() > 6)
+        err("invalid time format '{}' -- too many parameters", input_time);
+
+    if (lexer.consume_specific('.')) {
+        lex_number();
+        second = parameters.take_last();
+    } else {
+        second = 0;
+    }
+
+    auto current_year = seconds_since_epoch_to_year(time(nullptr));
+    auto current_century = current_year / 100;
+    if (parameters.size() == 6)
+        year = parameters.take_first() * 100 + parameters.take_first();
+    else if (parameters.size() == 5)
+        year = current_century * 100 + parameters.take_first();
+    else
+        year = current_year;
+
+    minute = parameters.take_last();
+    hour = parameters.take_last();
+    day = parameters.take_last();
+    month = parameters.take_last();
+
+    if (validate_timestamp(year, month, day, hour, minute, second))
+        atime = mtime = AK::Time::from_timestamp(year, month, day, hour, minute, second, 0).to_timespec();
+    else
+        err("invalid time format '{}'", input_time);
+}
+
+static void parse_datetime(StringView input_datetime, timespec& atime, timespec& mtime)
+{
+    // Parse YYYY-MM-DDThh:mm:SS[.frac][tz] or YYYY-MM-DDThh:mm:SS[,frac][tz]
+    // formats, where brackets signify optional parameters.
+    GenericLexer lexer(input_datetime);
+    unsigned year, month, day, hour, minute, second, millisecond;
+    StringView time_zone;
+
+    auto lex_number = [&](unsigned& value, size_t n) {
+        auto maybe_value = lexer.consume(n).to_uint();
+        if (!maybe_value.has_value())
+            err("invalid datetime format '{}' -- expected number at index {}", input_datetime, lexer.tell());
+        else
+            value = maybe_value.value();
+    };
+
+    lex_number(year, 4);
+    if (!lexer.consume_specific('-'))
+        err("invalid datetime format '{}' -- expected '-' after year", input_datetime);
+    lex_number(month, 2);
+    if (!lexer.consume_specific('-'))
+        err("invalid datetime format '{}' -- expected '-' after month", input_datetime);
+    lex_number(day, 2);
+
+    // Parse the time designator -- a single 'T' or ' ' according to POSIX.
+    if (!lexer.consume_specific('T') && !lexer.consume_specific(' '))
+        err("invalid datetime format '{}' -- expected 'T' or ' ' for time designator", input_datetime);
+
+    lex_number(hour, 2);
+    if (!lexer.consume_specific(':'))
+        err("invalid datetime format '{}' -- expected ':' after hour", input_datetime);
+    lex_number(minute, 2);
+    if (!lexer.consume_specific(':'))
+        err("invalid datetime format '{}' -- expected ':' after minute", input_datetime);
+    lex_number(second, 2);
+
+    millisecond = 0;
+    if (!lexer.is_eof()) {
+        if (lexer.consume_specific(',') || lexer.consume_specific('.')) {
+            auto fractional_second = lexer.consume_while(isdigit);
+            if (fractional_second.is_empty())
+                err("invalid datetime format '{}' -- expected floating seconds", input_datetime);
+            for (u8 i = 0; i < 3 && i < fractional_second.length(); ++i) {
+                unsigned n = fractional_second[i] - '0';
+                switch (i) {
+                case 0:
+                    millisecond += 100 * n;
+                    break;
+                case 1:
+                    millisecond += 10 * n;
+                    break;
+                case 2:
+                    millisecond += n;
+                    break;
+                default:
+                    VERIFY_NOT_REACHED();
+                }
+            }
+        }
+
+        time_zone = lexer.consume_all();
+        if (!time_zone.is_empty() && time_zone != "Z")
+            err("invalid datetime format '{}' -- failed to parse time zone", input_datetime);
+    }
+
+    if (validate_timestamp(year, month, day, hour, minute, second)) {
+        auto timestamp = AK::Time::from_timestamp(year, month, day, hour, minute, second, millisecond);
+        auto time = timestamp.to_timespec();
+        if (time_zone.is_empty() && TimeZone::system_time_zone() != "UTC") {
+            auto offset = TimeZone::get_time_zone_offset(TimeZone::system_time_zone(), timestamp);
+            if (offset.has_value())
+                time.tv_sec -= offset.value().seconds;
+            else
+                err("failed to get the system time zone");
+        }
+        atime = mtime = time;
+    } else {
+        err("invalid datetime format '{}'", input_datetime);
+    }
+}
+
+static void reference_time(StringView reference_path, timespec& atime, timespec& mtime)
+{
+    auto maybe_buffer = Core::System::stat(reference_path);
+    if (maybe_buffer.is_error())
+        err("failed to reference times of '{}': {}", reference_path, maybe_buffer.release_error());
+    auto buffer = maybe_buffer.release_value();
+    atime.tv_sec = buffer.st_atime;
+    atime.tv_nsec = buffer.st_atim.tv_nsec;
+    mtime.tv_sec = buffer.st_mtime;
+    mtime.tv_nsec = buffer.st_mtim.tv_nsec;
 }
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(Core::System::pledge("stdio rpath cpath fattr"));
 
+    program_name = arguments.strings[0];
+
     Vector<String> paths;
 
+    timespec times[2];
+    auto& atime = times[0];
+    auto& mtime = times[1];
+
+    bool update_atime = false;
+    bool update_mtime = false;
+    bool no_create_file = false;
+
+    String input_datetime = "";
+    String input_time = "";
+    String reference_path = "";
+
     Core::ArgsParser args_parser;
-    args_parser.set_general_help("Create a file, or update its mtime (time of last modification).");
+    args_parser.set_general_help("Create a file or update file access time and/or modification time.");
     args_parser.add_ignored(nullptr, 'f');
+    args_parser.add_option(update_atime, "Change access time of file", nullptr, 'a');
+    args_parser.add_option(no_create_file, "Do not create a file if it does not exist", nullptr, 'c');
+    args_parser.add_option(update_mtime, "Change modification time of file", nullptr, 'm');
+    args_parser.add_option(input_datetime, "Use specified datetime instead of current time", nullptr, 'd', "datetime");
+    args_parser.add_option(input_time, "Use specified time instead of current time", nullptr, 't', "time");
+    args_parser.add_option(reference_path, "Use time of file specified by reference path instead of current time", nullptr, 'r', "reference");
     args_parser.add_positional_argument(paths, "Files to touch", "path", Core::ArgsParser::Required::Yes);
     args_parser.parse(arguments);
 
+    if (input_datetime.is_empty() + input_time.is_empty() + reference_path.is_empty() < 2)
+        err("cannot specify a time with more than one option");
+
+    if (!input_datetime.is_empty())
+        parse_datetime(input_datetime, atime, mtime);
+    else if (!input_time.is_empty())
+        parse_time(input_time, atime, mtime);
+    else if (!reference_path.is_empty())
+        reference_time(reference_path, atime, mtime);
+    else
+        atime.tv_nsec = mtime.tv_nsec = UTIME_NOW;
+
+    // According to POSIX, if neither -a nor -m are specified, then the program
+    // should behave as if both are specified.
+    if (!update_atime && !update_mtime)
+        update_atime = update_mtime = true;
+    if (update_atime && !update_mtime)
+        mtime.tv_nsec = UTIME_OMIT;
+    if (update_mtime && !update_atime)
+        atime.tv_nsec = UTIME_OMIT;
+
     for (auto path : paths) {
-        if (file_exists(path)) {
-            if (auto result = Core::System::utime(path, {}); result.is_error())
-                warnln("{}", result.release_error());
-        } else {
+        if (Core::Stream::File::exists(path)) {
+            if (utimensat(AT_FDCWD, path.characters(), times, 0) == -1)
+                err("failed to touch '{}': {}", path, strerror(errno));
+        } else if (!no_create_file) {
             int fd = TRY(Core::System::open(path, O_CREAT, 0100644));
+            if (futimens(fd, times) == -1)
+                err("failed to touch '{}': {}", path, strerror(errno));
             TRY(Core::System::close(fd));
         }
     }


### PR DESCRIPTION
This PR adds the option to specify custom timestamps for `touch` using the options `-d`, `-t`, and `-r`. It also includes options `-a`, `-m`, and `-c`. These are options specified by POSIX, [here](https://pubs.opengroup.org/onlinepubs/9699919799/utilities/touch.html).

- Use `-d` to specify a timestamp in format `YYYY-MM-DDThh:mm:SS[.frac][tz]` or `YYYY-MM-DDThh:mm:SS[,frac][tz]`.
- Use `-t`  to specify a timestamp in format `[[CC]YY]MMDDhhmm[.SS]`. As an example, "05131200.27" translates to "2022-05-13 12:00:27".
- Use `-r` to reference a timestamp from another file.
- Use `-a` to modify the last access time.
- Use `-m` to modify the last modification time.
- Use `-c` to avoid creating a file if it does not already exist.

To implement these options, I added two POSIX library calls in LibC --`utimensat()` and `futimens()` -- as well as a syscall also named `utimensat()`. The POSIX documentation for these calls is available online [here](https://pubs.opengroup.org/onlinepubs/9699919799/functions/futimens.html).

Note, it doesn't appear that Serenity's standard ext2 file system supports nanoseconds because ext2 stores `i_atime` and `i_mtime` as type `__u32` in `Kernel/FileSystem/ext2_fs.h`. However, the member variable `tv_nsec` in `struct timespec` that stores nanoseconds is still used for constants `UTIME_OMIT` and `UTIME_NOW`.