### PR TITLE
Ports: Set right launcher command for Quake

### DIFF
--- a/Ports/quake/package.sh
+++ b/Ports/quake/package.sh
@@ -8,4 +8,5 @@ makeopts=("V=1" "SYMBOLS_ON=Y")
 depends=("SDL2")
 launcher_name=Quake
 launcher_category=Games
-launcher_command=quake
+launcher_command=/bin/quake
+icon_file=quake.png


### PR DESCRIPTION
By setting the absolute path for `launcher_command`, the menu item actually shows up. Provide an `icon_file` as well so it's pretty.