### PR TITLE
WindowServer: Fix crash when hovering over title buttons

### DIFF
--- a/Userland/Services/WindowServer/Button.cpp
+++ b/Userland/Services/WindowServer/Button.cpp
@@ -39,7 +39,7 @@ void Button::paint(Screen& screen, Gfx::Painter& painter)
         painter.blit(icon_location, bitmap, bitmap.rect());
     };
 
-    if (m_icon.hover_bitmap && m_hovered)
+    if (m_hovered && m_icon.hover_bitmap && !m_icon.hover_bitmap->is_empty())
         paint_icon(m_icon.hover_bitmap);
     else if (m_icon.bitmap)
         paint_icon(m_icon.bitmap);

--- a/Userland/Services/WindowServer/MultiScaleBitmaps.h
+++ b/Userland/Services/WindowServer/MultiScaleBitmaps.h
@@ -24,6 +24,7 @@ public:
     Gfx::BitmapFormat format() const { return m_format; }
     bool load(StringView filename, StringView default_filename = {});
     void add_bitmap(int scale_factor, NonnullRefPtr<Gfx::Bitmap>&&);
+    bool is_empty() const { return m_bitmaps.is_empty(); }
 
 private:
     MultiScaleBitmaps() = default;


### PR DESCRIPTION
This fixes a crash where if you switched to a theme that has hover
icons for title buttons, then back to a theme that does not. Then
when you next hover over the title buttons the window server would
crash.

This was due to the hover_bitmap multi-scale bitmap pointer being
non-null, but not containing any bitmaps, so hitting an assertion
when painting.