### PR TITLE
LibGUI: Phrase help action more specifically

### DIFF
--- a/Userland/Libraries/LibGUI/CommonActions.cpp
+++ b/Userland/Libraries/LibGUI/CommonActions.cpp
@@ -113,7 +113,7 @@ NonnullRefPtr<Action> make_quit_action(Function<void(Action&)> callback)
 
 NonnullRefPtr<Action> make_help_action(Function<void(Action&)> callback, Core::Object* parent)
 {
-    auto action = Action::create("&Contents", { Mod_None, Key_F1 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-help.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
+    auto action = Action::create("&Manual", { Mod_None, Key_F1 }, Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-help.png").release_value_but_fixme_should_propagate_errors(), move(callback), parent);
     action->set_status_tip("Show help contents");
     return action;
 }


### PR DESCRIPTION
Previously the option created by `make_help_action()` was unclear in its
meaning, by renaming the option to 'Manual' this should more
meaningfully represent the effect of the action.
Old:
![image](https://user-images.githubusercontent.com/49450250/168400070-32fad1db-bdae-4130-9e70-4041e0cdfaff.png)

New:
![image](https://user-images.githubusercontent.com/49450250/168400033-5e70d29a-a284-42bf-abad-a7e353013d24.png)