### PR TITLE
Piano+LibDSP: Move keyboard logic to LibDSP

### DIFF
--- a/Userland/Applications/Piano/AudioPlayerLoop.cpp
+++ b/Userland/Applications/Piano/AudioPlayerLoop.cpp
@@ -64,7 +64,7 @@ void AudioPlayerLoop::enqueue_audio()
         do {
             m_track_manager.fill_buffer(m_buffer);
             m_wav_writer.write_samples(reinterpret_cast<u8*>(m_buffer.data()), buffer_size);
-        } while (m_track_manager.time());
+        } while (m_track_manager.transport()->time());
         m_track_manager.reset();
         m_track_manager.set_should_loop(true);
         m_wav_writer.finalize();

--- a/Userland/Applications/Piano/KeysWidget.h
+++ b/Userland/Applications/Piano/KeysWidget.h
@@ -9,6 +9,8 @@
 #pragma once
 
 #include "Music.h"
+#include <AK/NonnullRefPtr.h>
+#include <LibDSP/Keyboard.h>
 #include <LibGUI/Frame.h>
 
 class TrackManager;
@@ -18,14 +20,11 @@ class KeysWidget final : public GUI::Frame {
 public:
     virtual ~KeysWidget() override = default;
 
-    int key_code_to_key(int key_code) const;
+    static i8 key_code_to_key(int key_code);
     int mouse_note() const;
 
-    void set_key(int key, Switch);
-    bool note_is_set(int note) const;
-
 private:
-    explicit KeysWidget(TrackManager&);
+    KeysWidget(NonnullRefPtr<LibDSP::Keyboard>);
 
     virtual void paint_event(GUI::PaintEvent&) override;
     virtual void mousedown_event(GUI::MouseEvent&) override;
@@ -34,9 +33,9 @@ private:
 
     int note_for_event_position(Gfx::IntPoint const&) const;
 
-    TrackManager& m_track_manager;
+    void set_key(i8 key, LibDSP::Keyboard::Switch);
 
-    u8 m_key_on[note_count] { 0 };
+    NonnullRefPtr<LibDSP::Keyboard> m_keyboard;
 
     bool m_mouse_down { false };
     int m_mouse_note { -1 };

--- a/Userland/Applications/Piano/KnobsWidget.cpp
+++ b/Userland/Applications/Piano/KnobsWidget.cpp
@@ -35,7 +35,7 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
     m_values_container->set_fixed_height(10);
 
     m_volume_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.current_track().volume()));
-    m_octave_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.octave()));
+    m_octave_value = m_values_container->add<GUI::Label>(String::number(m_track_manager.keyboard()->virtual_keyboard_octave()));
 
     m_knobs_container = add<GUI::Widget>();
     m_knobs_container->set_layout<GUI::HorizontalBoxLayout>();
@@ -57,13 +57,13 @@ KnobsWidget::KnobsWidget(TrackManager& track_manager, MainWidget& main_widget)
     m_octave_knob = m_knobs_container->add<GUI::VerticalSlider>();
     m_octave_knob->set_tooltip("Z: octave down, X: octave up");
     m_octave_knob->set_range(octave_min - 1, octave_max - 1);
-    m_octave_knob->set_value((octave_max - 1) - (m_track_manager.octave() - 1));
+    m_octave_knob->set_value((octave_max - 1) - (m_track_manager.keyboard()->virtual_keyboard_octave() - 1));
     m_octave_knob->set_step(1);
     m_octave_knob->on_change = [this](int value) {
         int new_octave = octave_max - value;
         if (m_change_underlying)
             m_main_widget.set_octave_and_ensure_note_change(new_octave);
-        VERIFY(new_octave == m_track_manager.octave());
+        VERIFY(new_octave == m_track_manager.keyboard()->virtual_keyboard_octave());
         m_octave_value->set_text(String::number(new_octave));
     };
 
@@ -117,7 +117,7 @@ void KnobsWidget::update_knobs()
     m_change_underlying = false;
 
     m_volume_knob->set_value(volume_max - m_track_manager.current_track().volume());
-    m_octave_knob->set_value(octave_max - m_track_manager.octave());
+    m_octave_knob->set_value(octave_max - m_track_manager.keyboard()->virtual_keyboard_octave());
 
     m_change_underlying = true;
 }

--- a/Userland/Applications/Piano/MainWidget.cpp
+++ b/Userland/Applications/Piano/MainWidget.cpp
@@ -46,7 +46,7 @@ MainWidget::MainWidget(TrackManager& track_manager, AudioPlayerLoop& loop)
     m_keys_and_knobs_container->set_fixed_height(130);
     m_keys_and_knobs_container->set_fill_with_background_color(true);
 
-    m_keys_widget = m_keys_and_knobs_container->add<KeysWidget>(track_manager);
+    m_keys_widget = m_keys_and_knobs_container->add<KeysWidget>(track_manager.keyboard());
 
     m_knobs_widget = m_keys_and_knobs_container->add<KnobsWidget>(track_manager, *this);
 
@@ -85,7 +85,7 @@ void MainWidget::keydown_event(GUI::KeyEvent& event)
     else
         m_keys_pressed[event.key()] = true;
 
-    note_key_action(event.key(), On);
+    note_key_action(event.key(), LibDSP::Keyboard::Switch::On);
     special_key_action(event.key());
     m_keys_widget->update();
 }
@@ -94,24 +94,26 @@ void MainWidget::keyup_event(GUI::KeyEvent& event)
 {
     m_keys_pressed[event.key()] = false;
 
-    note_key_action(event.key(), Off);
+    note_key_action(event.key(), LibDSP::Keyboard::Switch::Off);
     m_keys_widget->update();
 }
 
-void MainWidget::note_key_action(int key_code, Switch switch_note)
+void MainWidget::note_key_action(int key_code, LibDSP::Keyboard::Switch switch_note)
 {
-    int key = m_keys_widget->key_code_to_key(key_code);
-    m_keys_widget->set_key(key, switch_note);
+    auto key = m_keys_widget->key_code_to_key(key_code);
+    if (key == -1)
+        return;
+    m_track_manager.keyboard()->set_keyboard_note_in_active_octave(key, switch_note);
 }
 
 void MainWidget::special_key_action(int key_code)
 {
     switch (key_code) {
     case Key_Z:
-        set_octave_and_ensure_note_change(Down);
+        set_octave_and_ensure_note_change(LibDSP::Keyboard::Direction::Down);
         break;
     case Key_X:
-        set_octave_and_ensure_note_change(Up);
+        set_octave_and_ensure_note_change(LibDSP::Keyboard::Direction::Up);
         break;
     case Key_C:
         m_knobs_widget->cycle_waveform();
@@ -124,36 +126,38 @@ void MainWidget::special_key_action(int key_code)
 
 void MainWidget::turn_off_pressed_keys()
 {
-    m_keys_widget->set_key(m_keys_widget->mouse_note(), Off);
+    if (m_keys_widget->mouse_note() != -1)
+        m_track_manager.keyboard()->set_keyboard_note_in_active_octave(m_keys_widget->mouse_note(), LibDSP::Keyboard::Switch::Off);
     for (int i = 0; i < key_code_count; ++i) {
         if (m_keys_pressed[i])
-            note_key_action(i, Off);
+            note_key_action(i, LibDSP::Keyboard::Switch::Off);
     }
 }
 
 void MainWidget::turn_on_pressed_keys()
 {
-    m_keys_widget->set_key(m_keys_widget->mouse_note(), On);
+    if (m_keys_widget->mouse_note() != -1)
+        m_track_manager.keyboard()->set_keyboard_note_in_active_octave(m_keys_widget->mouse_note(), LibDSP::Keyboard::Switch::On);
     for (int i = 0; i < key_code_count; ++i) {
         if (m_keys_pressed[i])
-            note_key_action(i, On);
+            note_key_action(i, LibDSP::Keyboard::Switch::On);
     }
 }
 
 void MainWidget::set_octave_and_ensure_note_change(int octave)
 {
     turn_off_pressed_keys();
-    m_track_manager.set_octave(octave);
+    MUST(m_track_manager.keyboard()->set_virtual_keyboard_octave(octave));
     turn_on_pressed_keys();
 
     m_knobs_widget->update_knobs();
     m_keys_widget->update();
 }
 
-void MainWidget::set_octave_and_ensure_note_change(Direction direction)
+void MainWidget::set_octave_and_ensure_note_change(LibDSP::Keyboard::Direction direction)
 {
     turn_off_pressed_keys();
-    m_track_manager.set_octave(direction);
+    m_track_manager.keyboard()->change_virtual_keyboard_octave(direction);
     turn_on_pressed_keys();
 
     m_knobs_widget->update_knobs();

--- a/Userland/Applications/Piano/MainWidget.h
+++ b/Userland/Applications/Piano/MainWidget.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "Music.h"
+#include <LibDSP/Keyboard.h>
 #include <LibGUI/Widget.h>
 
 class AudioPlayerLoop;
@@ -28,7 +29,7 @@ public:
 
     void add_track_actions(GUI::Menu&);
 
-    void set_octave_and_ensure_note_change(Direction);
+    void set_octave_and_ensure_note_change(LibDSP::Keyboard::Direction);
     void set_octave_and_ensure_note_change(int);
 
 private:
@@ -38,7 +39,7 @@ private:
     virtual void keyup_event(GUI::KeyEvent&) override;
     virtual void custom_event(Core::CustomEvent&) override;
 
-    void note_key_action(int key_code, Switch);
+    void note_key_action(int key_code, LibDSP::Keyboard::Switch);
     void special_key_action(int key_code);
 
     void turn_off_pressed_keys();
@@ -56,5 +57,6 @@ private:
     RefPtr<KnobsWidget> m_knobs_widget;
     RefPtr<PlayerWidget> m_player_widget;
 
+    // Not the piano keys, but the computer keyboard keys!
     bool m_keys_pressed[key_code_count] { false };
 };

--- a/Userland/Applications/Piano/Music.h
+++ b/Userland/Applications/Piano/Music.h
@@ -33,11 +33,6 @@ constexpr double sample_rate = 44100;
 // Headroom for the synth
 constexpr double volume_factor = 0.8;
 
-enum Switch {
-    Off,
-    On,
-};
-
 enum Direction {
     Down,
     Up,

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -160,7 +160,7 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
             painter.draw_text(note_name_rect, String::formatted("{}", note / notes_per_octave + 1), Gfx::TextAlignment::CenterLeft);
     }
 
-    int x = m_roll_width * (static_cast<double>(m_track_manager.time()) / roll_length);
+    int x = m_roll_width * (static_cast<double>(m_track_manager.transport()->time()) / roll_length);
     if (x > x_offset && x <= x_offset + widget_inner_rect().width())
         painter.draw_line({ x, 0 }, { x, roll_height }, Gfx::Color::Black);
 

--- a/Userland/Applications/Piano/RollWidget.cpp
+++ b/Userland/Applications/Piano/RollWidget.cpp
@@ -126,7 +126,7 @@ void RollWidget::paint_event(GUI::PaintEvent& event)
             int distance_to_next_x = next_x_pos - x_pos;
             Gfx::IntRect rect(x_pos, y_pos, distance_to_next_x, note_height);
 
-            if (keys_widget() && keys_widget()->note_is_set(note))
+            if (m_track_manager.keyboard()->is_pressed(note))
                 painter.fill_rect(rect, note_pressed_color.with_alpha(128));
         }
     }

--- a/Userland/Applications/Piano/Track.h
+++ b/Userland/Applications/Piano/Track.h
@@ -14,6 +14,7 @@
 #include <AK/NonnullRefPtr.h>
 #include <AK/SinglyLinkedList.h>
 #include <LibDSP/Effects.h>
+#include <LibDSP/Keyboard.h>
 #include <LibDSP/Music.h>
 #include <LibDSP/Synthesizers.h>
 #include <LibDSP/Transport.h>
@@ -26,7 +27,7 @@ class Track {
     AK_MAKE_NONMOVABLE(Track);
 
 public:
-    Track(NonnullRefPtr<LibDSP::Transport>);
+    Track(NonnullRefPtr<LibDSP::Transport>, NonnullRefPtr<LibDSP::Keyboard>);
     ~Track() = default;
 
     Vector<Audio::Sample> const& recorded_sample() const { return m_recorded_sample; }
@@ -39,8 +40,8 @@ public:
     void reset();
     String set_recorded_sample(StringView path);
     void set_roll_note(int note, u32 on_sample, u32 off_sample);
-    void set_keyboard_note(int note, Switch state);
     void set_volume(int volume);
+    void set_active(bool active) { m_is_active_track = active; }
 
 private:
     Audio::Sample recorded_sample(size_t note);
@@ -57,5 +58,6 @@ private:
 
     SinglyLinkedList<RollNote> m_roll_notes[note_count];
     RollIter m_roll_iterators[note_count];
-    Array<Optional<RollNote>, note_count> m_keyboard_notes;
+    NonnullRefPtr<LibDSP::Keyboard> m_keyboard;
+    bool m_is_active_track { false };
 };

--- a/Userland/Applications/Piano/Track.h
+++ b/Userland/Applications/Piano/Track.h
@@ -16,6 +16,7 @@
 #include <LibDSP/Effects.h>
 #include <LibDSP/Music.h>
 #include <LibDSP/Synthesizers.h>
+#include <LibDSP/Transport.h>
 
 using LibDSP::RollNote;
 using RollIter = AK::SinglyLinkedListIterator<SinglyLinkedList<RollNote>, RollNote>;
@@ -25,7 +26,7 @@ class Track {
     AK_MAKE_NONMOVABLE(Track);
 
 public:
-    explicit Track(u32 const& time);
+    Track(NonnullRefPtr<LibDSP::Transport>);
     ~Track() = default;
 
     Vector<Audio::Sample> const& recorded_sample() const { return m_recorded_sample; }
@@ -50,9 +51,7 @@ private:
 
     int m_volume;
 
-    u32 const& m_time;
-
-    NonnullRefPtr<LibDSP::Transport> m_temporary_transport;
+    NonnullRefPtr<LibDSP::Transport> m_transport;
     NonnullRefPtr<LibDSP::Effects::Delay> m_delay;
     NonnullRefPtr<LibDSP::Synthesizers::Classic> m_synth;
 

--- a/Userland/Applications/Piano/TrackManager.cpp
+++ b/Userland/Applications/Piano/TrackManager.cpp
@@ -91,7 +91,7 @@ void TrackManager::add_track()
     m_tracks.append(make<Track>(m_transport));
 }
 
-int TrackManager::next_track_index()
+int TrackManager::next_track_index() const
 {
     auto next_track_index = m_current_track + 1;
     if (next_track_index >= m_tracks.size())

--- a/Userland/Applications/Piano/TrackManager.cpp
+++ b/Userland/Applications/Piano/TrackManager.cpp
@@ -13,8 +13,10 @@
 
 TrackManager::TrackManager()
     : m_transport(make_ref_counted<LibDSP::Transport>(120, 4))
+    , m_keyboard(make_ref_counted<LibDSP::Keyboard>(m_transport))
 {
     add_track();
+    m_tracks[m_current_track]->set_active(true);
 }
 
 void TrackManager::time_forward(int amount)
@@ -59,36 +61,16 @@ void TrackManager::reset()
 
     m_transport->set_time(0);
 
-    for (auto& track : m_tracks)
+    for (auto& track : m_tracks) {
         track->reset();
-}
-
-void TrackManager::set_keyboard_note(int note, Switch note_switch)
-{
-    m_tracks[m_current_track]->set_keyboard_note(note, note_switch);
-}
-
-void TrackManager::set_octave(Direction direction)
-{
-    if (direction == Up) {
-        if (m_octave < octave_max)
-            ++m_octave;
-    } else {
-        if (m_octave > octave_min)
-            --m_octave;
+        track->set_active(false);
     }
-}
-
-void TrackManager::set_octave(int octave)
-{
-    if (octave <= octave_max && octave >= octave_min) {
-        m_octave = octave;
-    }
+    m_tracks[m_current_track]->set_active(true);
 }
 
 void TrackManager::add_track()
 {
-    m_tracks.append(make<Track>(m_transport));
+    m_tracks.append(make<Track>(m_transport, m_keyboard));
 }
 
 int TrackManager::next_track_index() const

--- a/Userland/Applications/Piano/TrackManager.h
+++ b/Userland/Applications/Piano/TrackManager.h
@@ -35,7 +35,8 @@ public:
         m_current_track = track_index;
     }
 
-    int time() const { return m_time; }
+    NonnullRefPtr<LibDSP::Transport> transport() const { return m_transport; }
+    // Legacy API, do not add new users.
     void time_forward(int amount);
 
     void fill_buffer(Span<Sample>);
@@ -58,7 +59,7 @@ private:
 
     int m_octave { 4 };
 
-    u32 m_time { 0 };
+    NonnullRefPtr<LibDSP::Transport> m_transport;
 
     bool m_should_loop { true };
 };

--- a/Userland/Applications/Piano/TrackManager.h
+++ b/Userland/Applications/Piano/TrackManager.h
@@ -46,7 +46,7 @@ public:
     void set_octave(Direction);
     void set_octave(int octave);
     void add_track();
-    int next_track_index();
+    int next_track_index() const;
 
 private:
     Vector<NonnullOwnPtr<Track>> m_tracks;

--- a/Userland/Libraries/LibDSP/CMakeLists.txt
+++ b/Userland/Libraries/LibDSP/CMakeLists.txt
@@ -3,6 +3,7 @@ set(SOURCES
     Track.cpp
     Effects.cpp
     Synthesizers.cpp
+    Keyboard.cpp
 )
 
 serenity_lib(LibDSP dsp)

--- a/Userland/Libraries/LibDSP/Keyboard.cpp
+++ b/Userland/Libraries/LibDSP/Keyboard.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "Keyboard.h"
+#include "Music.h"
+#include <AK/Error.h>
+#include <AK/NumericLimits.h>
+
+namespace LibDSP {
+
+void Keyboard::set_keyboard_note(u8 pitch, Keyboard::Switch note_switch)
+{
+    VERIFY(pitch < note_frequencies.size());
+
+    if (note_switch == Switch::Off) {
+        m_pressed_notes.remove(pitch);
+        return;
+    }
+
+    auto fake_note = RollNote {
+        .on_sample = m_transport->time(),
+        .off_sample = NumericLimits<u32>::max(),
+        .pitch = pitch,
+        .velocity = NumericLimits<i8>::max(),
+    };
+
+    m_pressed_notes.set(pitch, fake_note);
+}
+void Keyboard::set_keyboard_note_in_active_octave(i8 octave_offset, Switch note_switch)
+{
+    u8 real_note = octave_offset + (m_virtual_keyboard_octave - 1) * notes_per_octave;
+    set_keyboard_note(real_note, note_switch);
+}
+
+void Keyboard::change_virtual_keyboard_octave(Direction direction)
+{
+    if (direction == Direction::Up) {
+        if (m_virtual_keyboard_octave < octave_max)
+            ++m_virtual_keyboard_octave;
+    } else {
+        if (m_virtual_keyboard_octave > octave_min)
+            --m_virtual_keyboard_octave;
+    }
+}
+
+ErrorOr<void> Keyboard::set_virtual_keyboard_octave(u8 octave)
+{
+    if (octave <= octave_max && octave >= octave_min) {
+        m_virtual_keyboard_octave = octave;
+        return {};
+    }
+    return Error::from_string_literal("Octave out of range");
+}
+
+bool Keyboard::is_pressed(u8 pitch) const
+{
+    return m_pressed_notes.get(pitch).has_value() && m_pressed_notes.get(pitch)->is_playing(m_transport->time());
+}
+
+bool Keyboard::is_pressed_in_active_octave(i8 octave_offset) const
+{
+    return is_pressed(octave_offset + virtual_keyboard_octave_base());
+}
+
+}

--- a/Userland/Libraries/LibDSP/Keyboard.h
+++ b/Userland/Libraries/LibDSP/Keyboard.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021-2022, kleines Filmröllchen <filmroellchen@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/NonnullRefPtr.h>
+#include <AK/RefCounted.h>
+#include <LibDSP/Music.h>
+#include <LibDSP/Transport.h>
+
+namespace LibDSP {
+
+class Keyboard : public RefCounted<Keyboard> {
+
+public:
+    enum class Direction : bool {
+        Down,
+        Up,
+    };
+    enum class Switch : bool {
+        Off,
+        On,
+    };
+
+    Keyboard(NonnullRefPtr<Transport> transport)
+        : m_transport(move(transport))
+    {
+    }
+
+    u8 virtual_keyboard_octave() const { return m_virtual_keyboard_octave; }
+    u8 virtual_keyboard_octave_base() const { return (m_virtual_keyboard_octave - octave_min) * 12; }
+    // Automatically clips the octave between the minimum and maximum.
+    void change_virtual_keyboard_octave(Direction);
+    // Errors out if the set octave is out of range.
+    ErrorOr<void> set_virtual_keyboard_octave(u8 octave);
+
+    void set_keyboard_note(u8 pitch, Switch note_switch);
+    void set_keyboard_note_in_active_octave(i8 octave_offset, Switch note_switch);
+
+    RollNotes const& notes() const { return m_pressed_notes; }
+    Optional<RollNote> note_at(u8 pitch) const { return m_pressed_notes.get(pitch); }
+    bool is_pressed(u8 pitch) const;
+    bool is_pressed_in_active_octave(i8 octave_offset) const;
+
+private:
+    u8 m_virtual_keyboard_octave { 4 };
+    RollNotes m_pressed_notes;
+
+    NonnullRefPtr<Transport> m_transport;
+
+    static constexpr int const octave_min = 1;
+    static constexpr int const octave_max = 7;
+};
+
+}

--- a/Userland/Libraries/LibDSP/Music.h
+++ b/Userland/Libraries/LibDSP/Music.h
@@ -196,6 +196,7 @@ constexpr Array<double, 84> note_frequencies = {
     3951.0664100489994,
 };
 
+constexpr size_t const notes_per_octave = 12;
 constexpr double const middle_c = note_frequencies[36];
 
 }


### PR DESCRIPTION
You know the drill. Next step of #6528 , this removes (almost) all keyboard logic from Piano. No functional changes (except maybe performance idk)