### PR TITLE
Kernel: The UBSAN story in the aarch64 Kernel

### DIFF
--- a/Documentation/AdvancedBuildInstructions.md
+++ b/Documentation/AdvancedBuildInstructions.md
@@ -42,6 +42,7 @@ directory to `Build/i686` and then running `ninja <target>`:
 
 There are some optional features that can be enabled during compilation that are intended to help with specific types of development work or introduce experimental features. Currently, the following build options are available:
 - `ENABLE_ADDRESS_SANITIZER` and `ENABLE_KERNEL_ADDRESS_SANITIZER`: builds in runtime checks for memory corruption bugs (like buffer overflows and memory leaks) in Lagom test cases and the kernel, respectively.
+- `ENABLE_KERNEL_UNDEFINED_SANITIZER`: builds in runtime checks for detecting undefined behavior in the kernel.
 - `ENABLE_KERNEL_COVERAGE_COLLECTION`: enables the KCOV API and kernel coverage collection instrumentation. Only useful for coverage guided kernel fuzzing.
 - `ENABLE_USERSPACE_COVERAGE_COLLECTION`: enables coverage collection instrumentation for userspace. Currently only works with a Clang build.
 - `ENABLE_MEMORY_SANITIZER`: enables runtime checks for uninitialized memory accesses in Lagom test cases.

--- a/Kernel/Arch/aarch64/ASM_wrapper.h
+++ b/Kernel/Arch/aarch64/ASM_wrapper.h
@@ -23,6 +23,11 @@ inline void set_ttbr0_el1(FlatPtr ttbr0_el1)
     asm("msr ttbr0_el1, %[value]" ::[value] "r"(ttbr0_el1));
 }
 
+inline void set_sp_el1(FlatPtr sp_el1)
+{
+    asm("msr sp_el1, %[value]" ::[value] "r"(sp_el1));
+}
+
 inline void flush()
 {
     asm("dsb ish");

--- a/Kernel/Arch/aarch64/Exceptions.cpp
+++ b/Kernel/Arch/aarch64/Exceptions.cpp
@@ -46,6 +46,10 @@ static void drop_to_el1()
     hypervisor_configuration_register_el2.RW = 1; // EL1 to use 64-bit mode
     Aarch64::HCR_EL2::write(hypervisor_configuration_register_el2);
 
+    // Set up initial exception stack
+    // FIXME: Define in linker script
+    Aarch64::Asm::set_sp_el1(0x40000);
+
     Aarch64::SPSR_EL2 saved_program_status_register_el2 = {};
 
     // Mask (disable) all interrupts

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -14,7 +14,7 @@ namespace Kernel::Aarch64 {
 
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/ID-AA64MMFR0-EL1--AArch64-Memory-Model-Feature-Register-0
 // Memory Model Feature Register 0
-struct ID_AA64MMFR0_EL1 {
+struct alignas(u64) ID_AA64MMFR0_EL1 {
     int PARange : 4;
     int ASIDBits : 4;
     int BigEnd : 4;
@@ -41,10 +41,11 @@ struct ID_AA64MMFR0_EL1 {
         return feature_register;
     }
 };
+static_assert(sizeof(ID_AA64MMFR0_EL1) == 8);
 
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/TCR-EL1--Translation-Control-Register--EL1-
 // Translation Control Register
-struct TCR_EL1 {
+struct alignas(u64) TCR_EL1 {
 
     enum Shareability {
         NonSharable = 0b00,
@@ -155,7 +156,7 @@ static_assert(sizeof(TCR_EL1) == 8);
 
 // https://developer.arm.com/documentation/ddi0595/2021-03/AArch64-Registers/SCTLR-EL1--System-Control-Register--EL1-
 // System Control Register
-struct SCTLR_EL1 {
+struct alignas(u64) SCTLR_EL1 {
     int M : 1;
     int A : 1;
     int C : 1;
@@ -235,7 +236,7 @@ static_assert(sizeof(SCTLR_EL1) == 8);
 
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/HCR-EL2--Hypervisor-Configuration-Register
 // Hypervisor Configuration Register
-struct HCR_EL2 {
+struct alignas(u64) HCR_EL2 {
     int VM : 1;
     int SWIO : 1;
     int PTW : 1;
@@ -300,7 +301,7 @@ static_assert(sizeof(HCR_EL2) == 8);
 
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/SCR-EL3--Secure-Configuration-Register
 // Secure Configuration Register
-struct SCR_EL3 {
+struct alignas(u64) SCR_EL3 {
     int NS : 1;
     int IRQ : 1;
     int FIQ : 1;
@@ -354,7 +355,7 @@ struct SCR_EL3 {
 };
 static_assert(sizeof(SCR_EL3) == 8);
 
-struct SPSR_EL2 {
+struct alignas(u64) SPSR_EL2 {
     enum Mode : u16 {
         EL0t = 0b0000,
         EL1t = 0b0100,
@@ -405,7 +406,7 @@ static_assert(sizeof(SPSR_EL2) == 8);
 
 // https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/SPSR-EL3--Saved-Program-Status-Register--EL3-
 // Saved Program Status Register
-struct SPSR_EL3 {
+struct alignas(u64) SPSR_EL3 {
     enum Mode : uint16_t {
         EL0t = 0b0000,
         EL1t = 0b0100,
@@ -454,7 +455,7 @@ static_assert(sizeof(SPSR_EL3) == 8);
 
 // https://developer.arm.com/documentation/ddi0595/2020-12/AArch64-Registers/MAIR-EL1--Memory-Attribute-Indirection-Register--EL1-?lang=en#fieldset_0-63_0
 // Memory Attribute Indirection Register
-struct MAIR_EL1 {
+struct alignas(u64) MAIR_EL1 {
     using AttributeEncoding = uint8_t;
     AttributeEncoding Attr[8];
 

--- a/Kernel/Arch/aarch64/Registers.h
+++ b/Kernel/Arch/aarch64/Registers.h
@@ -466,4 +466,25 @@ struct alignas(u64) MAIR_EL1 {
 };
 static_assert(sizeof(MAIR_EL1) == 8);
 
+// https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Registers/ESR-EL1--Exception-Syndrome-Register--EL1-
+// Exception Syndrome Register (EL1)
+struct ESR_EL1 {
+    u64 ISS : 25;
+    u64 IL : 1;
+    u64 EC : 6;
+    u64 ISS2 : 5;
+    u64 : 27;
+
+    static inline ESR_EL1 read()
+    {
+        ESR_EL1 esr_el1;
+
+        asm("mrs %[value], esr_el1"
+            : [value] "=r"(esr_el1));
+
+        return esr_el1;
+    }
+};
+static_assert(sizeof(ESR_EL1) == 8);
+
 }

--- a/Kernel/Arch/aarch64/init.cpp
+++ b/Kernel/Arch/aarch64/init.cpp
@@ -17,6 +17,7 @@
 #include <Kernel/Arch/aarch64/RPi/Mailbox.h>
 #include <Kernel/Arch/aarch64/RPi/Timer.h>
 #include <Kernel/Arch/aarch64/RPi/UART.h>
+#include <Kernel/Arch/aarch64/Registers.h>
 #include <Kernel/KSyms.h>
 #include <Kernel/Panic.h>
 
@@ -45,7 +46,12 @@ extern "C" void exception_common(TrapFrame const* const trap_frame)
         dbgln("elr_el1: {:x}", trap_frame->elr_el1);
         dbgln("tpidr_el1: {:x}", trap_frame->tpidr_el1);
         dbgln("sp_el0: {:x}", trap_frame->sp_el0);
+
+        auto esr_el1 = Kernel::Aarch64::ESR_EL1::read();
+        dbgln("esr_el1: EC({:#b}) IL({:#b}) ISS({:#b}) ISS2({:#b})", esr_el1.EC, esr_el1.IL, esr_el1.ISS, esr_el1.ISS2);
     }
+
+    Kernel::Processor::halt();
 }
 
 typedef void (*ctor_func_t)();

--- a/Kernel/Arch/aarch64/vector_table.S
+++ b/Kernel/Arch/aarch64/vector_table.S
@@ -106,10 +106,10 @@
 .align 11
 vector_table_el1:
     // Exceptions taken from Current EL, with SP_EL0
-    unimplemented_entry
-    unimplemented_entry
-    unimplemented_entry
-    unimplemented_entry
+    table_entry synchronous_current_elsp_el0
+    table_entry irq_current_elsp_el0
+    table_entry fiq_current_elsp_el0
+    table_entry system_error_current_elsp_el0
 
     // Exceptions taken from Current EL, with SP_ELx, x>0
     table_entry synchronous_current_elsp_elx
@@ -148,6 +148,30 @@ fiq_current_elsp_elx:
     eret
 
 system_error_current_elsp_elx:
+    save_current_context
+    bl exception_common
+    restore_previous_context
+    eret
+
+synchronous_current_elsp_el0:
+    save_current_context
+    bl exception_common
+    restore_previous_context
+    eret
+
+irq_current_elsp_el0:
+    save_current_context
+    bl exception_common
+    restore_previous_context
+    eret
+
+fiq_current_elsp_el0:
+    save_current_context
+    bl exception_common
+    restore_previous_context
+    eret
+
+system_error_current_elsp_el0:
     save_current_context
     bl exception_common
     restore_previous_context

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -460,9 +460,13 @@ endif()
 add_compile_options(-fsigned-char)
 add_compile_options(-Wno-unknown-warning-option -Wvla -Wnull-dereference)
 add_compile_options(-fno-rtti -ffreestanding -fbuiltin)
+
 if ("${SERENITY_ARCH}" STREQUAL "i686" OR "${SERENITY_ARCH}" STREQUAL "x86_64")
     add_compile_options(-mno-80387 -mno-mmx -mno-sse -mno-sse2)
+elseif("${SERENITY_ARCH}" STREQUAL "aarch64")
+    add_compile_options(-mgeneral-regs-only)
 endif()
+
 add_compile_options(-fno-asynchronous-unwind-tables)
 add_compile_options(-fstack-protector-strong)
 add_compile_options(-fno-exceptions)

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -546,8 +546,10 @@ elseif (ENABLE_USERSPACE_COVERAGE_COLLECTION)
     add_compile_definitions(SKIP_PATH_VALIDATION_FOR_COVERAGE_INSTRUMENTATION)
 endif()
 
-# Kernel Undefined Behavior Sanitizer (KUBSAN)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+if (ENABLE_KERNEL_UNDEFINED_SANITIZER)
+    # Kernel Undefined Behavior Sanitizer (KUBSAN)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+endif()
 
 # Kernel Address Sanitize (KASAN) implementation is still a work in progress, this option
 # is not currently meant to be used, besides when developing Kernel ASAN support.

--- a/Kernel/CMakeLists.txt
+++ b/Kernel/CMakeLists.txt
@@ -486,7 +486,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 
 
     # Prevent naively implemented string functions (like strlen) from being "optimized" into a call to themselves.
-    set_source_files_properties(MiniStdlib.cpp
+    set_source_files_properties(MiniStdLib.cpp
         PROPERTIES COMPILE_FLAGS "-fno-tree-loop-distribution -fno-tree-loop-distribute-patterns")
 
     add_link_options(LINKER:-z,pack-relative-relocs)

--- a/Meta/CMake/serenity_options.cmake
+++ b/Meta/CMake/serenity_options.cmake
@@ -10,6 +10,7 @@ serenity_option(ENABLE_PNP_IDS_DOWNLOAD ON CACHE BOOL "Enable download of the pn
 serenity_option(ENABLE_KERNEL_ADDRESS_SANITIZER OFF CACHE BOOL "Enable kernel address sanitizer testing in gcc/clang")
 serenity_option(ENABLE_KERNEL_COVERAGE_COLLECTION  OFF CACHE BOOL "Enable KCOV and kernel coverage instrumentation in gcc/clang")
 serenity_option(ENABLE_KERNEL_LTO OFF CACHE BOOL "Build the kernel with link-time optimization")
+serenity_option(ENABLE_KERNEL_UNDEFINED_SANITIZER ON CACHE BOOL "Enable the Kernel Undefined Behavior Sanitizer (KUBSAN)")
 serenity_option(ENABLE_EXTRA_KERNEL_DEBUG_SYMBOLS  OFF CACHE BOOL "Enable -Og and -ggdb3 options for Kernel code for easier debugging")
 serenity_option(ENABLE_MOLD_LINKER OFF CACHE BOOL "Link the SerenityOS userland with the mold linker")
 serenity_option(ENABLE_USERSPACE_COVERAGE_COLLECTION OFF CACHE BOOL "Enable code coverage instrumentation for userspace binaries in clang")


### PR DESCRIPTION
# UBSAN story
This series of commits began with me checking out if disabling UBSAN on the aarch64 Kernel build actually worked. You know what, it did not work, and exceptions were generated. Next up, these exceptions were not handled, since the proper handlers were not installed.

Without UBSAN the compiler is now able to optimize more, which caused multiple things to break and generate more exceptions. One of which was a data abort, caused by a misaligned memory access. All these exceptions and compiler errors are fixed by these commits.

Next up, I realized that disabling UBSAN, significantly reduced the size of the Kernel binary by 73%(!).

I decided it would be a good idea to disable UBSAN for now for the aarch64 build, since enabling it shadowed certain issues that were in the code, but were never actually discovered because of UBSAN. 
# Miscellaneous
Also adds two fixes for the recent GCC 12.1.0 merge (#13954)
- Disabling vectorization for the aarch64 build
- Fixing capitalization for MiniStdLib in Kernel CMake file.

<details><summary>Spoiler for my next aarch64 PR</summary> I'm gonna work on interrupt support :) </details>