### PR TITLE
Base: Added info to Mail documentation

### DIFF
--- a/Base/usr/share/man/man1/Mail.md
+++ b/Base/usr/share/man/man1/Mail.md
@@ -12,7 +12,7 @@ $ Mail
 
 ## Description
 
-Mail is an e-mail client for Serenity. It can connect to real e-mail servers.
+Mail is an e-mail client for Serenity. It can connect to real e-mail servers using the IMAP protocol.
 Currently, a configuration file is required. This must be stored in `~/.config/Mail.ini`
 See the Examples section for an example configuration file.
 


### PR DESCRIPTION
Clarify that the Mail app only supports the IMAP protocol and not the POP protocol (which is a bit older).