### PR TITLE
PixelPaint: Allow configuring 'new image' defaults

### DIFF
--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "CreateNewImageDialog.h"
+#include <LibConfig/Client.h>
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Button.h>
 #include <LibGUI/Label.h>
@@ -33,6 +34,8 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     m_name_textbox->on_change = [this] {
         m_image_name = m_name_textbox->text();
     };
+    auto default_name = Config::read_string("PixelPaint", "NewImage", "Name");
+    m_name_textbox->set_text(default_name);
 
     auto& width_label = main_widget.add<GUI::Label>("Width:");
     width_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -72,8 +75,10 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     width_spinbox.set_range(1, 16384);
     height_spinbox.set_range(1, 16384);
 
-    width_spinbox.set_value(510);
-    height_spinbox.set_value(356);
+    auto default_width = Config::read_i32("PixelPaint", "NewImage", "Width", 510);
+    auto default_height = Config::read_i32("PixelPaint", "NewImage", "Height", 356);
+    width_spinbox.set_value(default_width);
+    height_spinbox.set_value(default_height);
 }
 
 }


### PR DESCRIPTION
This allows you to configure the default name, width, and height of the 'new image' dialog. This is done by editing the config in
~/.config/PixelPaint.ini (no GUI at the moment).

![image](https://user-images.githubusercontent.com/11597044/168472725-9f907d37-e377-4113-8205-497904592d00.png)


Fixes #13967

(Quick fix for @djwisdom)