### PR TITLE
Everywhere: Make the superbuild-required part of Lagom compile with `-Wold-style-cast`

### DIFF
--- a/AK/ByteBuffer.h
+++ b/AK/ByteBuffer.h
@@ -292,7 +292,7 @@ private:
     NEVER_INLINE ErrorOr<void> try_ensure_capacity_slowpath(size_t new_capacity)
     {
         new_capacity = kmalloc_good_size(new_capacity);
-        auto* new_buffer = (u8*)kmalloc(new_capacity);
+        auto* new_buffer = static_cast<u8*>(kmalloc(new_capacity));
         if (!new_buffer)
             return Error::from_errno(ENOMEM);
 

--- a/AK/Checked.h
+++ b/AK/Checked.h
@@ -286,7 +286,7 @@ public:
         checked += v;
         return checked.has_overflow();
 #else
-        return __builtin_add_overflow_p(u, v, (T)0);
+        return __builtin_add_overflow_p(u, v, static_cast<T>(0));
 #endif
     }
 
@@ -299,7 +299,7 @@ public:
         checked *= v;
         return checked.has_overflow();
 #else
-        return __builtin_mul_overflow_p(u, v, (T)0);
+        return __builtin_mul_overflow_p(u, v, static_cast<T>(0));
 #endif
     }
 

--- a/AK/FixedPoint.h
+++ b/AK/FixedPoint.h
@@ -52,7 +52,7 @@ public:
     template<FloatingPoint F>
     explicit ALWAYS_INLINE operator F() const
     {
-        return (F)m_value * pow<F>(0.5, precision);
+        return static_cast<F>(m_value) * pow<F>(0.5, precision);
     }
 #endif
 
@@ -344,17 +344,17 @@ public:
 
     // Casting from a float should be faster than casting to a float
     template<FloatingPoint F>
-    bool operator==(F other) const { return *this == (This)other; }
+    bool operator==(F other) const { return *this == static_cast<This>(other); }
     template<FloatingPoint F>
-    bool operator!=(F other) const { return *this != (This)other; }
+    bool operator!=(F other) const { return *this != static_cast<This>(other); }
     template<FloatingPoint F>
-    bool operator>(F other) const { return *this > (This)other; }
+    bool operator>(F other) const { return *this > static_cast<This>(other); }
     template<FloatingPoint F>
-    bool operator>=(F other) const { return *this >= (This)other; }
+    bool operator>=(F other) const { return *this >= static_cast<This>(other); }
     template<FloatingPoint F>
-    bool operator<(F other) const { return *this < (This)other; }
+    bool operator<(F other) const { return *this < static_cast<This>(other); }
     template<FloatingPoint F>
-    bool operator<=(F other) const { return *this <= (This)other; }
+    bool operator<=(F other) const { return *this <= static_cast<This>(other); }
 
     template<size_t P, typename U>
     operator FixedPoint<P, U>() const

--- a/AK/HashTable.h
+++ b/AK/HashTable.h
@@ -485,7 +485,7 @@ private:
         if (!new_buckets)
             return Error::from_errno(ENOMEM);
 
-        m_buckets = (BucketType*)new_buckets;
+        m_buckets = static_cast<BucketType*>(new_buckets);
 
         m_capacity = new_capacity;
         m_deleted_count = 0;

--- a/AK/JsonParser.cpp
+++ b/AK/JsonParser.cpp
@@ -259,14 +259,14 @@ ErrorOr<JsonValue> JsonParser::parse_number()
         double sign = (whole < 0) ? -1 : 1;
 
         auto divider = pow(10.0, static_cast<double>(fraction_buffer.size()));
-        value = JsonValue((double)whole + sign * (fraction / divider));
+        value = JsonValue(static_cast<double>(whole) + sign * (fraction / divider));
     } else {
 #endif
         auto to_unsigned_result = number_string.to_uint<u64>();
         if (to_unsigned_result.has_value()) {
             auto number = *to_unsigned_result;
             if (number <= NumericLimits<u32>::max())
-                value = JsonValue((u32)number);
+                value = JsonValue(static_cast<u32>(number));
             else
                 value = JsonValue(number);
         } else {
@@ -274,7 +274,7 @@ ErrorOr<JsonValue> JsonParser::parse_number()
             if (!number.has_value())
                 return Error::from_string_literal("JsonParser: Error while parsing number"sv);
             if (number.value() <= NumericLimits<i32>::max()) {
-                value = JsonValue((i32)number.value());
+                value = JsonValue(static_cast<i32>(number.value()));
             } else {
                 value = JsonValue(number.value());
             }

--- a/AK/JsonValue.h
+++ b/AK/JsonValue.h
@@ -227,16 +227,16 @@ public:
     {
 #if !defined(KERNEL)
         if (is_double())
-            return (T)as_double();
+            return static_cast<T>(as_double());
 #endif
         if (type() == Type::Int32)
-            return (T)as_i32();
+            return static_cast<T>(as_i32());
         if (type() == Type::UnsignedInt32)
-            return (T)as_u32();
+            return static_cast<T>(as_u32());
         if (type() == Type::Int64)
-            return (T)as_i64();
+            return static_cast<T>(as_i64());
         if (type() == Type::UnsignedInt64)
-            return (T)as_u64();
+            return static_cast<T>(as_u64());
         return default_value;
     }
 

--- a/AK/LEB128.h
+++ b/AK/LEB128.h
@@ -97,7 +97,7 @@ struct LEB128 {
 
         if ((num_bytes * 7) < 64 && (byte & 0x40)) {
             // sign extend
-            temp |= ((u64)(-1) << (num_bytes * 7));
+            temp |= (~0ULL << (num_bytes * 7));
         }
 
         // Now that we've accumulated into an i64, make sure it fits into result

--- a/AK/Math.h
+++ b/AK/Math.h
@@ -113,7 +113,7 @@ constexpr T sqrt(T x)
 template<FloatingPoint T>
 constexpr T rsqrt(T x)
 {
-    return (T)1. / sqrt(x);
+    return static_cast<T>(1.) / sqrt(x);
 }
 
 #ifdef __SSE__
@@ -317,7 +317,7 @@ constexpr T asin(T x)
     CONSTEXPR_STATE(asin, x);
     if (x > 1 || x < -1)
         return NaN<T>;
-    if (x > (T)0.5 || x < (T)-0.5)
+    if (x > static_cast<T>(0.5) || x < static_cast<T>(-0.5))
         return 2 * atan<T>(x / (1 + sqrt<T>(1 - x * x)));
     T squared = x * x;
     T value = x;
@@ -540,7 +540,7 @@ constexpr T acosh(T x)
 template<FloatingPoint T>
 constexpr T atanh(T x)
 {
-    return log<T>((1 + x) / (1 - x)) / (T)2.0l;
+    return log<T>((1 + x) / (1 - x)) / static_cast<T>(2.0l);
 }
 
 }
@@ -648,8 +648,8 @@ constexpr T pow(T x, T y)
         return 0;
     if (y == 1)
         return x;
-    int y_as_int = (int)y;
-    if (y == (T)y_as_int) {
+    int y_as_int = static_cast<int>(y);
+    if (y == static_cast<T>(y_as_int)) {
         T result = x;
         for (int i = 0; i < fabs<T>(y) - 1; ++i)
             result *= x;

--- a/AK/NonnullOwnPtr.h
+++ b/AK/NonnullOwnPtr.h
@@ -178,7 +178,7 @@ template<typename T>
 struct Traits<NonnullOwnPtr<T>> : public GenericTraits<NonnullOwnPtr<T>> {
     using PeekType = T*;
     using ConstPeekType = const T*;
-    static unsigned hash(NonnullOwnPtr<T> const& p) { return ptr_hash((FlatPtr)p.ptr()); }
+    static unsigned hash(NonnullOwnPtr<T> const& p) { return ptr_hash(reinterpret_cast<FlatPtr>(p.ptr())); }
     static bool equals(NonnullOwnPtr<T> const& a, NonnullOwnPtr<T> const& b) { return a.ptr() == b.ptr(); }
 };
 

--- a/AK/PrintfImplementation.h
+++ b/AK/PrintfImplementation.h
@@ -198,16 +198,16 @@ ALWAYS_INLINE int print_double(PutChFunc putch, CharType*& bufptr, double number
     if (sign)
         number = -number;
 
-    length = print_decimal(putch, bufptr, (i64)number, sign, always_sign, left_pad, zero_pad, whole_width, false, 1);
+    length = print_decimal(putch, bufptr, static_cast<i64>(number), sign, always_sign, left_pad, zero_pad, whole_width, false, 1);
     if (precision > 0) {
         putch(bufptr, '.');
         length++;
-        double fraction = number - (i64)number;
+        double fraction = number - static_cast<i64>(number);
 
         for (u32 i = 0; i < precision; ++i)
             fraction = fraction * 10;
 
-        return length + print_decimal(putch, bufptr, (i64)fraction, false, false, false, true, precision, false, 1);
+        return length + print_decimal(putch, bufptr, static_cast<i64>(fraction), false, false, false, true, precision, false, 1);
     }
 
     return length;

--- a/AK/Singleton.h
+++ b/AK/Singleton.h
@@ -48,7 +48,7 @@ public:
             Kernel::ScopedCritical critical;
 #endif
             if constexpr (allow_create) {
-                if (obj == nullptr && obj_var.compare_exchange_strong(obj, (T*)0x1, AK::memory_order_acq_rel)) {
+                if (obj == nullptr && obj_var.compare_exchange_strong(obj, reinterpret_cast<T*>(0x1), AK::memory_order_acq_rel)) {
                     // We're the first one
                     obj = InitFunction();
                     obj_var.store(obj, AK::memory_order_release);
@@ -56,7 +56,7 @@ public:
                 }
             }
             // Someone else was faster, wait until they're done
-            while (obj == (T*)0x1) {
+            while (obj == reinterpret_cast<T*>(0x1)) {
 #ifdef KERNEL
                 Kernel::Processor::wait_check();
 #else
@@ -68,7 +68,7 @@ public:
                 // We should always return an instance if we allow creating one
                 VERIFY(obj != nullptr);
             }
-            VERIFY(obj != (T*)0x1);
+            VERIFY(obj != reinterpret_cast<T*>(0x1));
         }
         return obj;
     }

--- a/AK/StackInfo.cpp
+++ b/AK/StackInfo.cpp
@@ -32,7 +32,7 @@ StackInfo::StackInfo()
         fprintf(stderr, "pthread_getattr_np: %s\n", strerror(-rc));
         VERIFY_NOT_REACHED();
     }
-    if ((rc = pthread_attr_getstack(&attr, (void**)&m_base, &m_size)) != 0) {
+    if ((rc = pthread_attr_getstack(&attr, reinterpret_cast<void**>(&m_base), &m_size)) != 0) {
         fprintf(stderr, "pthread_attr_getstack: %s\n", strerror(-rc));
         VERIFY_NOT_REACHED();
     }

--- a/AK/StdLibExtras.h
+++ b/AK/StdLibExtras.h
@@ -118,8 +118,8 @@ inline void swap(T& a, U& b)
 {
     if (&a == &b)
         return;
-    U tmp = move((U&)a);
-    a = (T &&) move(b);
+    U tmp = move(static_cast<U&>(a));
+    a = static_cast<T&&>(move(b));
     b = move(tmp);
 }
 

--- a/AK/String.h
+++ b/AK/String.h
@@ -267,7 +267,7 @@ public:
     {
         if (buffer.is_empty())
             return empty();
-        return String((char const*)buffer.data(), buffer.size(), should_chomp);
+        return String(reinterpret_cast<char const*>(buffer.data()), buffer.size(), should_chomp);
     }
 
     [[nodiscard]] static String vformatted(StringView fmtstr, TypeErasedFormatParams&);

--- a/AK/StringBuilder.cpp
+++ b/AK/StringBuilder.cpp
@@ -95,7 +95,7 @@ String StringBuilder::to_string() const
 {
     if (is_empty())
         return String::empty();
-    return String((char const*)data(), length());
+    return String(reinterpret_cast<char const*>(data()), length());
 }
 
 String StringBuilder::build() const

--- a/AK/StringHash.h
+++ b/AK/StringHash.h
@@ -14,7 +14,7 @@ constexpr u32 string_hash(char const* characters, size_t length, u32 seed = 0)
 {
     u32 hash = seed;
     for (size_t i = 0; i < length; ++i) {
-        hash += (u32)characters[i];
+        hash += characters[i];
         hash += (hash << 10);
         hash ^= (hash >> 6);
     }

--- a/AK/StringImpl.cpp
+++ b/AK/StringImpl.cpp
@@ -98,7 +98,7 @@ RefPtr<StringImpl> StringImpl::create_lowercased(char const* cstring, size_t len
     char* buffer;
     auto impl = create_uninitialized(length, buffer);
     for (size_t i = 0; i < length; ++i)
-        buffer[i] = (char)to_ascii_lowercase(cstring[i]);
+        buffer[i] = static_cast<char>(to_ascii_lowercase(cstring[i]));
     return impl;
 }
 
@@ -111,7 +111,7 @@ RefPtr<StringImpl> StringImpl::create_uppercased(char const* cstring, size_t len
     char* buffer;
     auto impl = create_uninitialized(length, buffer);
     for (size_t i = 0; i < length; ++i)
-        buffer[i] = (char)to_ascii_uppercase(cstring[i]);
+        buffer[i] = static_cast<char>(to_ascii_uppercase(cstring[i]));
     return impl;
 }
 

--- a/AK/StringView.cpp
+++ b/AK/StringView.cpp
@@ -34,7 +34,7 @@ StringView::StringView(FlyString const& string)
 #endif
 
 StringView::StringView(ByteBuffer const& buffer)
-    : m_characters((char const*)buffer.data())
+    : m_characters(reinterpret_cast<char const*>(buffer.data()))
     , m_length(buffer.size())
 {
 }

--- a/AK/StringView.h
+++ b/AK/StringView.h
@@ -25,13 +25,13 @@ public:
         , m_length(length)
     {
         if (!is_constant_evaluated())
-            VERIFY(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
+            VERIFY(!Checked<FlatPtr>::addition_would_overflow(reinterpret_cast<FlatPtr>(characters), length));
     }
     ALWAYS_INLINE StringView(unsigned char const* characters, size_t length)
-        : m_characters((char const*)characters)
+        : m_characters(reinterpret_cast<char const*>(characters))
         , m_length(length)
     {
-        VERIFY(!Checked<uintptr_t>::addition_would_overflow((uintptr_t)characters, length));
+        VERIFY(!Checked<FlatPtr>::addition_would_overflow(reinterpret_cast<FlatPtr>(characters), length));
     }
     ALWAYS_INLINE constexpr StringView(char const* cstring)
         : m_characters(cstring)

--- a/AK/Time.cpp
+++ b/AK/Time.cpp
@@ -234,9 +234,9 @@ Time Time::operator-(Time const& other) const
     VERIFY(other.m_nanoseconds < 1'000'000'000);
 
     if (other.m_nanoseconds)
-        return *this + Time((i64) ~(u64)other.m_seconds, 1'000'000'000 - other.m_nanoseconds);
+        return *this + Time(static_cast<i64>(~static_cast<u64>(other.m_seconds)), 1'000'000'000 - other.m_nanoseconds);
 
-    if (other.m_seconds != (i64)-0x8000'0000'0000'0000)
+    if (other.m_seconds != static_cast<i64>(-0x8000'0000'0000'0000))
         return *this + Time(-other.m_seconds, 0);
 
     // Only remaining case: We want to subtract -0x8000'0000'0000'0000 seconds,

--- a/AK/Traits.h
+++ b/AK/Traits.h
@@ -57,7 +57,7 @@ requires(IsFloatingPoint<T>) struct Traits<T> : public GenericTraits<T> {
 
 template<typename T>
 requires(IsPointer<T> && !Detail::IsPointerOfType<char, T>) struct Traits<T> : public GenericTraits<T> {
-    static unsigned hash(T p) { return ptr_hash((FlatPtr)p); }
+    static unsigned hash(T p) { return ptr_hash(reinterpret_cast<FlatPtr>(p)); }
     static constexpr bool is_trivial() { return true; }
 };
 

--- a/AK/Types.h
+++ b/AK/Types.h
@@ -74,9 +74,9 @@ static constexpr FlatPtr explode_byte(u8 b)
         return value << 56 | value << 48 | value << 40 | value << 32 | value << 24 | value << 16 | value << 8 | value;
 }
 
-static_assert(explode_byte(0xff) == (FlatPtr)0xffffffffffffffffull);
-static_assert(explode_byte(0x80) == (FlatPtr)0x8080808080808080ull);
-static_assert(explode_byte(0x7f) == (FlatPtr)0x7f7f7f7f7f7f7f7full);
+static_assert(explode_byte(0xff) == static_cast<FlatPtr>(0xffffffffffffffffull));
+static_assert(explode_byte(0x80) == static_cast<FlatPtr>(0x8080808080808080ull));
+static_assert(explode_byte(0x7f) == static_cast<FlatPtr>(0x7f7f7f7f7f7f7f7full));
 static_assert(explode_byte(0) == 0);
 
 constexpr size_t align_up_to(const size_t value, const size_t alignment)

--- a/AK/UnicodeUtils.h
+++ b/AK/UnicodeUtils.h
@@ -14,22 +14,22 @@ template<typename Callback>
 [[nodiscard]] constexpr int code_point_to_utf8(u32 code_point, Callback callback)
 {
     if (code_point <= 0x7f) {
-        callback((char)code_point);
+        callback(static_cast<char>(code_point));
         return 1;
     } else if (code_point <= 0x07ff) {
-        callback((char)(((code_point >> 6) & 0x1f) | 0xc0));
-        callback((char)(((code_point >> 0) & 0x3f) | 0x80));
+        callback(static_cast<char>(((code_point >> 6) & 0x1f) | 0xc0));
+        callback(static_cast<char>(((code_point >> 0) & 0x3f) | 0x80));
         return 2;
     } else if (code_point <= 0xffff) {
-        callback((char)(((code_point >> 12) & 0x0f) | 0xe0));
-        callback((char)(((code_point >> 6) & 0x3f) | 0x80));
-        callback((char)(((code_point >> 0) & 0x3f) | 0x80));
+        callback(static_cast<char>(((code_point >> 12) & 0x0f) | 0xe0));
+        callback(static_cast<char>(((code_point >> 6) & 0x3f) | 0x80));
+        callback(static_cast<char>(((code_point >> 0) & 0x3f) | 0x80));
         return 3;
     } else if (code_point <= 0x10ffff) {
-        callback((char)(((code_point >> 18) & 0x07) | 0xf0));
-        callback((char)(((code_point >> 12) & 0x3f) | 0x80));
-        callback((char)(((code_point >> 6) & 0x3f) | 0x80));
-        callback((char)(((code_point >> 0) & 0x3f) | 0x80));
+        callback(static_cast<char>(((code_point >> 18) & 0x07) | 0xf0));
+        callback(static_cast<char>(((code_point >> 12) & 0x3f) | 0x80));
+        callback(static_cast<char>(((code_point >> 6) & 0x3f) | 0x80));
+        callback(static_cast<char>(((code_point >> 0) & 0x3f) | 0x80));
         return 4;
     }
     return -1;

--- a/AK/Userspace.h
+++ b/AK/Userspace.h
@@ -69,7 +69,7 @@ inline Userspace<T> static_ptr_cast(Userspace<U> const& ptr)
 #else
     auto casted_ptr = static_cast<T>(ptr.ptr());
 #endif
-    return Userspace<T>((FlatPtr)casted_ptr);
+    return Userspace<T>(bit_cast<FlatPtr>(casted_ptr));
 }
 
 }

--- a/AK/Utf32View.h
+++ b/AK/Utf32View.h
@@ -52,7 +52,7 @@ public:
 private:
     Utf32CodePointIterator(u32 const* ptr, size_t length)
         : m_ptr(ptr)
-        , m_length((ssize_t)length)
+        , m_length(static_cast<ssize_t>(length))
     {
     }
     u32 const* m_ptr { nullptr };
@@ -98,7 +98,7 @@ public:
     {
         VERIFY(it.m_ptr >= m_code_points);
         VERIFY(it.m_ptr < m_code_points + m_length);
-        return ((ptrdiff_t)it.m_ptr - (ptrdiff_t)m_code_points) / sizeof(u32);
+        return (reinterpret_cast<ptrdiff_t>(it.m_ptr) - reinterpret_cast<ptrdiff_t>(m_code_points)) / sizeof(u32);
     }
 
     Utf32View substring_view(size_t offset, size_t length) const

--- a/AK/Utf8View.h
+++ b/AK/Utf8View.h
@@ -119,7 +119,7 @@ public:
     }
 
 private:
-    u8 const* begin_ptr() const { return (u8 const*)m_string.characters_without_null_termination(); }
+    u8 const* begin_ptr() const { return reinterpret_cast<u8 const*>(m_string.characters_without_null_termination()); }
     u8 const* end_ptr() const { return begin_ptr() + m_string.length(); }
     size_t calculate_length() const;
 

--- a/AK/WeakPtr.h
+++ b/AK/WeakPtr.h
@@ -44,7 +44,7 @@ public:
     template<typename U>
     WeakPtr& operator=(WeakPtr<U> const& other) requires(IsBaseOf<T, U>)
     {
-        if ((void const*)this != (void const*)&other)
+        if (static_cast<void const*>(this) != static_cast<void const*>(&other))
             m_link = other.m_link;
         return *this;
     }

--- a/AK/Weakable.h
+++ b/AK/Weakable.h
@@ -45,7 +45,7 @@ public:
             Kernel::ScopedCritical critical;
 #endif
             if (!(m_consumers.fetch_add(1u << 1, AK::MemoryOrder::memory_order_acquire) & 1u)) {
-                T* ptr = (T*)m_ptr.load(AK::MemoryOrder::memory_order_acquire);
+                T* ptr = static_cast<T*>(m_ptr.load(AK::MemoryOrder::memory_order_acquire));
                 if (ptr && ptr->try_ref())
                     ref = adopt_ref(*ptr);
             }
@@ -64,7 +64,7 @@ public:
         // has been triggered as there is a possible race! But it's "unsafe"
         // anyway because we return a raw pointer without ensuring a
         // reference...
-        return (T*)m_ptr.load(AK::MemoryOrder::memory_order_acquire);
+        return static_cast<T*>(m_ptr.load(AK::MemoryOrder::memory_order_acquire));
     }
 
     bool is_null() const

--- a/Meta/CMake/Superbuild/CMakeLists.txt
+++ b/Meta/CMake/Superbuild/CMakeLists.txt
@@ -69,6 +69,11 @@ include(ExternalProject)
 
 # Collect options for Lagom build
 set(lagom_options "")
+
+# NOTE: This should go in the global compile options, or at least the Lagom compile options.
+#       But preventing everyone from using C-style casts is too much work at once,
+#       let's just keep C-style casts out of the superbuild for now and expand on it later.
+list(APPEND lagom_options "-DCMAKE_CXX_FLAGS:STRING=-Wold-style-cast")
 macro(serenity_option name)
     set(${ARGV})
     list(APPEND lagom_options "-D${name}:STRING=${${name}}")

--- a/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/LibEDID/GeneratePnpIDs.cpp
@@ -143,7 +143,7 @@ static ErrorOr<HashMap<String, PnpIdData>> parse_pnp_ids_database(Core::File& pn
             return Error::from_string_literal("Invalid row start tag"sv);
 
         auto row_string = pnp_ids_file_contents.substring_view(row_start_tag_end.value() + 1, row_end.value() - row_start_tag_end.value() - 1);
-        Vector<String, (size_t)PnpIdColumns::ColumnCount> columns;
+        Vector<String, static_cast<size_t>(PnpIdColumns::ColumnCount)> columns;
         for (size_t column_row_offset = 0;;) {
             static auto const column_start_tag = "<td>"sv;
             auto column_start = row_string.find(column_start_tag, column_row_offset);
@@ -164,12 +164,12 @@ static ErrorOr<HashMap<String, PnpIdData>> parse_pnp_ids_database(Core::File& pn
             column_row_offset = column_end.value() + column_end_tag.length();
         }
 
-        if (columns.size() != (size_t)PnpIdColumns::ColumnCount)
+        if (columns.size() != static_cast<size_t>(PnpIdColumns::ColumnCount))
             return Error::from_string_literal("Unexpected number of columns found"sv);
 
-        auto approval_date = TRY(parse_approval_date(columns[(size_t)PnpIdColumns::ApprovalDate]));
-        auto decoded_manufacturer_name = TRY(decode_html_entities(columns[(size_t)PnpIdColumns::ManufacturerName]));
-        auto hash_set_result = pnp_id_data.set(columns[(size_t)PnpIdColumns::ManufacturerId], PnpIdData { .manufacturer_name = decoded_manufacturer_name, .approval_date = move(approval_date) });
+        auto approval_date = TRY(parse_approval_date(columns[static_cast<size_t>(PnpIdColumns::ApprovalDate)]));
+        auto decoded_manufacturer_name = TRY(decode_html_entities(columns[static_cast<size_t>(PnpIdColumns::ManufacturerName)]));
+        auto hash_set_result = pnp_id_data.set(columns[static_cast<size_t>(PnpIdColumns::ManufacturerId)], PnpIdData { .manufacturer_name = decoded_manufacturer_name, .approval_date = move(approval_date) });
         if (hash_set_result != AK::HashSetResult::InsertedNewEntry)
             return Error::from_string_literal("Duplicate manufacturer ID encountered"sv);
 

--- a/Meta/Lagom/Tools/CodeGenerators/StateMachineGenerator/main.cpp
+++ b/Meta/Lagom/Tools/CodeGenerators/StateMachineGenerator/main.cpp
@@ -89,7 +89,7 @@ parse_state_machine(StringView input)
         } else {
             lexer.consume_specific('\'');
             if (lexer.next_is('\\')) {
-                num = (int)lexer.consume_escaped_character('\\');
+                num = static_cast<int>(lexer.consume_escaped_character('\\'));
             } else {
                 num = lexer.consume_until('\'').to_int().value();
                 lexer.ignore();

--- a/Userland/Libraries/LibCore/AnonymousBuffer.h
+++ b/Userland/Libraries/LibCore/AnonymousBuffer.h
@@ -52,7 +52,7 @@ public:
         static_assert(IsVoid<T> || IsTrivial<T>);
         if (!m_impl)
             return nullptr;
-        return (T*)m_impl->data();
+        return static_cast<T*>(m_impl->data());
     }
 
     template<typename T>
@@ -61,7 +61,7 @@ public:
         static_assert(IsVoid<T> || IsTrivial<T>);
         if (!m_impl)
             return nullptr;
-        return (const T*)m_impl->data();
+        return static_cast<const T*>(m_impl->data());
     }
 
 private:

--- a/Userland/Libraries/LibCore/EventLoop.cpp
+++ b/Userland/Libraries/LibCore/EventLoop.cpp
@@ -211,7 +211,7 @@ public:
         auto serialized = response.to_string();
         u32 length = serialized.length();
         // FIXME: Propagate errors
-        MUST(m_socket->write({ (u8 const*)&length, sizeof(length) }));
+        MUST(m_socket->write({ reinterpret_cast<u8 const*>(&length), sizeof(length) }));
         MUST(m_socket->write(serialized.bytes()));
     }
 
@@ -257,7 +257,7 @@ public:
         if (type == "SetInspectedObject") {
             auto address = request.get("address").to_number<FlatPtr>();
             for (auto& object : Object::all_objects()) {
-                if ((FlatPtr)&object == address) {
+                if (reinterpret_cast<FlatPtr>(&object) == address) {
                     if (auto inspected_object = m_inspected_object.strong_ref())
                         inspected_object->decrement_inspector_count({});
                     m_inspected_object = object;
@@ -271,7 +271,7 @@ public:
         if (type == "SetProperty") {
             auto address = request.get("address").to_number<FlatPtr>();
             for (auto& object : Object::all_objects()) {
-                if ((FlatPtr)&object == address) {
+                if (reinterpret_cast<FlatPtr>(&object) == address) {
                     bool success = object.set_property(request.get("name").to_string(), request.get("value"));
                     JsonObject response;
                     response.set("type", "SetProperty");

--- a/Userland/Libraries/LibCore/File.cpp
+++ b/Userland/Libraries/LibCore/File.cpp
@@ -265,7 +265,7 @@ ErrorOr<String> File::read_link(String const& link_path)
     // (See above.)
     if (rc == statbuf.st_size)
         return { *buffer };
-    return String { buffer_ptr, (size_t)rc };
+    return String { buffer_ptr, static_cast<size_t>(rc) };
 }
 
 #endif

--- a/Userland/Libraries/LibCore/IODevice.cpp
+++ b/Userland/Libraries/LibCore/IODevice.cpp
@@ -51,7 +51,7 @@ ByteBuffer IODevice::read(size_t max_size)
         return {};
     }
     auto buffer = buffer_result.release_value();
-    auto* buffer_ptr = (char*)buffer.data();
+    auto* buffer_ptr = reinterpret_cast<char*>(buffer.data());
 
     memcpy(buffer_ptr, m_buffered_data.data(), size);
     m_buffered_data.remove(0, size);
@@ -142,7 +142,7 @@ ByteBuffer IODevice::read_all()
             set_eof(true);
             break;
         }
-        data.append((u8 const*)read_buffer, nread);
+        data.append(reinterpret_cast<u8 const*>(read_buffer), nread);
     }
 
     auto result = ByteBuffer::copy(data);
@@ -166,7 +166,7 @@ String IODevice::read_line(size_t max_size)
             dbgln("IODevice::read_line: At EOF but there's more than max_size({}) buffered", max_size);
             return {};
         }
-        auto line = String((char const*)m_buffered_data.data(), m_buffered_data.size(), Chomp);
+        auto line = String(reinterpret_cast<char const*>(m_buffered_data.data()), m_buffered_data.size(), Chomp);
         m_buffered_data.clear();
         return line;
     }
@@ -204,7 +204,7 @@ bool IODevice::populate_read_buffer(size_t size) const
         return {};
     }
     auto buffer = buffer_result.release_value();
-    auto* buffer_ptr = (char*)buffer.data();
+    auto* buffer_ptr = reinterpret_cast<char*>(buffer.data());
 
     int nread = ::read(m_fd, buffer_ptr, size);
     if (nread < 0) {
@@ -294,7 +294,7 @@ void IODevice::set_fd(int fd)
 
 bool IODevice::write(StringView v)
 {
-    return write((u8 const*)v.characters_without_null_termination(), v.length());
+    return write(reinterpret_cast<u8 const*>(v.characters_without_null_termination()), v.length());
 }
 
 LineIterator::LineIterator(IODevice& device, bool is_end)

--- a/Userland/Libraries/LibCore/LocalServer.cpp
+++ b/Userland/Libraries/LibCore/LocalServer.cpp
@@ -92,7 +92,7 @@ bool LocalServer::listen(String const& address)
         return false;
     }
     auto un = un_optional.value();
-    rc = ::bind(m_fd, (sockaddr const*)&un, sizeof(un));
+    rc = ::bind(m_fd, reinterpret_cast<sockaddr const*>(&un), sizeof(un));
     if (rc < 0) {
         perror("bind");
         return false;
@@ -115,7 +115,7 @@ ErrorOr<NonnullOwnPtr<Stream::LocalSocket>> LocalServer::accept()
     sockaddr_un un;
     socklen_t un_size = sizeof(un);
 #ifndef AK_OS_MACOS
-    int accepted_fd = ::accept4(m_fd, (sockaddr*)&un, &un_size, SOCK_NONBLOCK | SOCK_CLOEXEC);
+    int accepted_fd = ::accept4(m_fd, reinterpret_cast<sockaddr*>(&un), &un_size, SOCK_NONBLOCK | SOCK_CLOEXEC);
 #else
     int accepted_fd = ::accept(m_fd, (sockaddr*)&un, &un_size);
 #endif

--- a/Userland/Libraries/LibCore/NetworkJob.cpp
+++ b/Userland/Libraries/LibCore/NetworkJob.cpp
@@ -50,7 +50,7 @@ void NetworkJob::did_fail(Error error)
     NonnullRefPtr<NetworkJob> protector(*this);
 
     m_error = error;
-    dbgln_if(NETWORKJOB_DEBUG, "{}{{{:p}}} job did_fail! error: {} ({})", class_name(), this, (unsigned)error, to_string(error));
+    dbgln_if(NETWORKJOB_DEBUG, "{}{{{:p}}} job did_fail! error: {} ({})", class_name(), this, static_cast<unsigned>(error), to_string(error));
     VERIFY(on_finish);
     on_finish(false);
     shutdown(ShutdownMode::DetachFromSocket);

--- a/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/SignedBigInteger.h
@@ -45,7 +45,7 @@ public:
         return { UnsignedBigInteger::create_invalid(), false };
     }
 
-    static SignedBigInteger import_data(StringView data) { return import_data((u8 const*)data.characters_without_null_termination(), data.length()); }
+    static SignedBigInteger import_data(StringView data) { return import_data(reinterpret_cast<u8 const*>(data.characters_without_null_termination()), data.length()); }
     static SignedBigInteger import_data(u8 const* ptr, size_t length);
 
     static SignedBigInteger create_from(i64 value)
@@ -87,7 +87,7 @@ public:
 
     void set_to(i32 other)
     {
-        m_unsigned_data.set_to((u32)other);
+        m_unsigned_data.set_to(static_cast<u32>(other));
         m_sign = other < 0;
     }
     void set_to(SignedBigInteger const& other)

--- a/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
+++ b/Userland/Libraries/LibCrypto/BigInt/UnsignedBigInteger.h
@@ -36,7 +36,7 @@ public:
 
     static UnsignedBigInteger create_invalid();
 
-    static UnsignedBigInteger import_data(StringView data) { return import_data((u8 const*)data.characters_without_null_termination(), data.length()); }
+    static UnsignedBigInteger import_data(StringView data) { return import_data(reinterpret_cast<u8 const*>(data.characters_without_null_termination()), data.length()); }
     static UnsignedBigInteger import_data(u8 const* ptr, size_t length)
     {
         return UnsignedBigInteger(ptr, length);

--- a/Userland/Libraries/LibGfx/Color.h
+++ b/Userland/Libraries/LibGfx/Color.h
@@ -261,7 +261,10 @@ public:
 
     constexpr Color lightened(float amount = 1.2f) const
     {
-        return Color(min(255, (int)((float)red() * amount)), min(255, (int)((float)green() * amount)), min(255, (int)((float)blue() * amount)), alpha());
+        return Color(min(255, static_cast<int>(static_cast<float>(red()) * amount)),
+            min(255, static_cast<int>(static_cast<float>(green()) * amount)),
+            min(255, static_cast<int>(static_cast<float>(blue()) * amount)),
+            alpha());
     }
 
     Vector<Color> shades(u32 steps, float max = 1.f) const;
@@ -387,9 +390,9 @@ public:
             break;
         }
 
-        u8 out_r = (u8)(r * 255);
-        u8 out_g = (u8)(g * 255);
-        u8 out_b = (u8)(b * 255);
+        u8 out_r = static_cast<u8>(r * 255);
+        u8 out_g = static_cast<u8>(g * 255);
+        u8 out_b = static_cast<u8>(b * 255);
         return Color(out_r, out_g, out_b);
     }
 

--- a/Userland/Libraries/LibJS/Runtime/Value.h
+++ b/Userland/Libraries/LibJS/Runtime/Value.h
@@ -24,7 +24,7 @@
 // 2 ** 53 - 1
 static constexpr double MAX_ARRAY_LIKE_INDEX = 9007199254740991.0;
 // Unique bit representation of negative zero (only sign bit set)
-static constexpr u64 NEGATIVE_ZERO_BITS = ((u64)1 << 63);
+static constexpr u64 NEGATIVE_ZERO_BITS = (1ull << 63);
 
 namespace JS {
 
@@ -299,7 +299,7 @@ public:
         if (m_type == Type::Int32 && m_value.as_i32 >= 0)
             return m_value.as_i32;
         VERIFY(as_double() >= 0);
-        return (u32)min(as_double(), (double)NumericLimits<u32>::max());
+        return static_cast<u32>(min(as_double(), static_cast<double>(NumericLimits<u32>::max())));
     }
 
     u64 encoded() const { return m_value.encoded; }

--- a/Userland/Libraries/LibSystem/syscall.h
+++ b/Userland/Libraries/LibSystem/syscall.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <AK/BitCast.h>
 #include <Kernel/API/Syscall.h>
 #include <sys/types.h>
 
@@ -20,6 +21,14 @@ uintptr_t syscall4(uintptr_t function, uintptr_t arg0, uintptr_t arg1, uintptr_t
 
 #ifdef __cplusplus
 
+// To get rid of C-style casts, we need to conditionally static_cast or reinterpret_cast the syscall arguments.
+#    define CAST_ARGUMENT(argument)                                                  \
+        uintptr_t argument##_ptr;                                                    \
+        if constexpr (requires(decltype(argument) a) { static_cast<uintptr_t>(a); }) \
+            argument##_ptr = static_cast<uintptr_t>(argument);                       \
+        else                                                                         \
+            argument##_ptr = reinterpret_cast<uintptr_t>(argument)
+
 inline uintptr_t syscall(auto function)
 {
     return syscall0(function);
@@ -27,22 +36,38 @@ inline uintptr_t syscall(auto function)
 
 inline uintptr_t syscall(auto function, auto arg0)
 {
-    return syscall1((uintptr_t)function, (uintptr_t)arg0);
+    CAST_ARGUMENT(arg0);
+
+    return syscall1(static_cast<uintptr_t>(function), arg0_ptr);
 }
 
 inline uintptr_t syscall(auto function, auto arg0, auto arg1)
 {
-    return syscall2((uintptr_t)function, (uintptr_t)arg0, (uintptr_t)arg1);
+    CAST_ARGUMENT(arg0);
+    CAST_ARGUMENT(arg1);
+
+    return syscall2(static_cast<uintptr_t>(function), arg0_ptr, arg1_ptr);
 }
 
 inline uintptr_t syscall(auto function, auto arg0, auto arg1, auto arg2)
 {
-    return syscall3((uintptr_t)function, (uintptr_t)arg0, (uintptr_t)arg1, (uintptr_t)arg2);
+    CAST_ARGUMENT(arg0);
+    CAST_ARGUMENT(arg1);
+    CAST_ARGUMENT(arg2);
+
+    return syscall3(static_cast<uintptr_t>(function), arg0_ptr, arg1_ptr, arg2_ptr);
 }
 
 inline uintptr_t syscall(auto function, auto arg0, auto arg1, auto arg2, auto arg3)
 {
-    return syscall4((uintptr_t)function, (uintptr_t)arg0, (uintptr_t)arg1, (uintptr_t)arg2, (uintptr_t)arg3);
+    CAST_ARGUMENT(arg0);
+    CAST_ARGUMENT(arg1);
+    CAST_ARGUMENT(arg2);
+    CAST_ARGUMENT(arg3);
+
+    return syscall4(static_cast<uintptr_t>(function), arg0_ptr, arg1_ptr, arg2_ptr, arg3_ptr);
 }
+
+#    undef CAST_ARGUMENT
 
 #endif


### PR DESCRIPTION
Step towards enabling `-Wold-style-cast` for banning C-style casts. See #5487.

The great thing is that this already tackles some of the most common AK headers, which should then just work in the actual build.