### PR TITLE
Meta: Validate explicitly set TOOLCHAIN in `serenity.sh`

### DIFF
--- a/Meta/serenity.sh
+++ b/Meta/serenity.sh
@@ -8,7 +8,7 @@ print_help() {
     cat <<EOF
 Usage: $NAME COMMAND [TARGET] [TOOLCHAIN] [ARGS...]
   Supported TARGETs: aarch64, i686, x86_64, lagom. Defaults to SERENITY_ARCH, or i686 if not set.
-  Supported TOOLCHAINs: GNU, Clang. Defaults to GNU if not set.
+  Supported TOOLCHAINs: GNU, Clang. Defaults to SERENITY_TOOLCHAIN, or GNU if not set.
   Supported COMMANDs:
     build:      Compiles the target binaries, [ARGS...] are passed through to ninja
     install:    Installs the target binary
@@ -92,21 +92,16 @@ CMAKE_ARGS=()
 HOST_COMPILER=""
 
 # Toolchain selection only applies to non-lagom targets.
-if [ "$TARGET" != "lagom" ]; then
-    case "$1" in
-        GNU|Clang)
-            TOOLCHAIN_TYPE="$1"; shift
-            ;;
-        *)
-            if [ -n "$1" ]; then
-                echo "WARNING: unknown toolchain '$1'. Defaulting to GNU."
-                echo "         Valid values are 'Clang', 'GNU' (default)"
-            fi
-            TOOLCHAIN_TYPE="GNU"
-            ;;
-    esac
-    CMAKE_ARGS+=( "-DSERENITY_TOOLCHAIN=$TOOLCHAIN_TYPE" )
+if [ "$TARGET" != "lagom" ] && [ -n "$1" ]; then
+    TOOLCHAIN_TYPE="$1"; shift
+else
+    TOOLCHAIN_TYPE="${SERENITY_TOOLCHAIN:-"GNU"}"
 fi
+if ! [[ "${TOOLCHAIN_TYPE}" =~ ^(GNU|Clang)$ ]]; then
+    >&2 echo "ERROR: unknown toolchain '${TOOLCHAIN_TYPE}'."
+    exit 1
+fi
+CMAKE_ARGS+=( "-DSERENITY_TOOLCHAIN=$TOOLCHAIN_TYPE" )
 
 CMD_ARGS=( "$@" )
 


### PR DESCRIPTION
Previously, `serenity.sh rebuild-toolchain x86_64 clang` would simply start building GCC instead and call it a day. With this change, if a toolchain is passed as an argument, it is validated if it is either "GNU" or "Clang" and exits with an error otherwise.

The `TOOLCHAIN` value defaults to the `SERENITY_TOOLCHAIN` environment variable if not provided explicitly.

This solves my issue of accidentally mistyping the toolchain on the command line :^)