### PR TITLE
LibGUI: Implement dynamic layout system

### DIFF
--- a/Base/usr/share/man/man5/GML-Introduction.md
+++ b/Base/usr/share/man/man5/GML-Introduction.md
@@ -69,6 +69,7 @@ Or right clicking on a folder in the TreeView and using
         -   [ToolbarContainer](help://man/5/GML-Widget-ToolbarContainer)
         -   [Tray](help://man/5/GML-Widget-Tray)
         -   [TreeView](help://man/5/GML-Widget-TreeView)
+        -   [UI Dimensions](help://man/5/GML-UI-Dimensions)
         -   [UrlBox](help://man/5/GML-Widget-UrlBox)
         -   [ValueSlider](help://man/5/GML-Widget-ValueSlider)
         -   [VerticalProgressbar](help://man/5/GML-Widget-VerticalProgressbar)
@@ -76,3 +77,4 @@ Or right clicking on a folder in the TreeView and using
         -   [VerticalSlider](help://man/5/GML-Widget-VerticalSlider)
         -   [VerticalSplitter](help://man/5/GML-Widget-VerticalSplitter)
         -   [Widget](help://man/5/GML-Widget)
+

--- a/Base/usr/share/man/man5/GML-Syntax.md
+++ b/Base/usr/share/man/man5/GML-Syntax.md
@@ -90,6 +90,7 @@ A property's `value` is required to be either a JSON value or another object. Ob
 Among the supported JSON values, these types can be further distinguished:
 
 -   `int`: Regular JSON integer, note that JSON floats are not currently used.
+-   `ui_dimension`: either positive integers, that work just like `int`, or special meaning values as JSON strings; see [UI Dimensions](help://man/5/GML-UI-Dimensions)
 -   `bool`: Regular JSON boolean, may be enclosed in quotes but this is discouraged.
 -   `string`: JSON string, also used as a basis for other types.
 -   `readonly_string`: String-valued property that cannot be changed from C++ later.
@@ -99,6 +100,7 @@ Among the supported JSON values, these types can be further distinguished:
     -   `text_wrapping`: Special case of `enum` for `Gfx::TextWrapping`. One of `Wrap` or `DontWrap`.
 -   `rect`: A JSON object of four `int`s specifying a rectangle. The keys are `x`, `y`, `width`, `height`.
 -   `size`: A JSON array of two `int`s specifying two sizes in the format `[width, height]`.
+-   `ui_size`: A JSON array of two `ui_dimension`s specifying two sizes in the format `[width, height]`
 -   `margins`: A JSON array or object specifying four-directional margins as `int`s. If this is a JSON object, the four keys `top`, `right`, `bottom`, `left` are used. If this is a JSON array, there can be one to four integers. These have the following meaning (see also `GUI::Margins`):
     -   `[ all_four_margins ]`
     -   `[ top_and_bottom, right_and_left ]`
@@ -232,3 +234,4 @@ GML files can be found in the SerenityOS source tree with the `*.gml` extension.
     }
 }
 ```
+

--- a/Base/usr/share/man/man5/GML-UI-Dimensions.md
+++ b/Base/usr/share/man/man5/GML-UI-Dimensions.md
@@ -1,0 +1,29 @@
+## Name
+
+UI Dimensions
+
+# Description
+
+UI Dimension (or [GUI::UIDimension](file:///usr/src/serenity/Userland/Libraries/LibGUI/UIDimensions.h) in c++) is a special, union — of positive integer and enum — like, type that is used to represent dimensions in a user interface context.
+
+It can either store positive integers ≥0 or special meaning values from a pre determined set.
+
+## Basic Syntax
+
+In GML UI Dimensions that are "regular" values (integer ≥0) are represented by JSON's int type,
+while "special" values are represented by their name as a JSON string type.
+
+# Special Values
+
+Special Values carry size information that would otherwise not be intuitively possible to be transported by an integer (positive or negative) alone.
+
+Importantly, while any "regular" UI Dimension values might (by convention) be assigned to any UI Dimesion property, many properties only allow a subset "special" values to be assigned to them.
+
+| Name              | c++ name                                   | GML/JSON representation | general meaning                                 |
+|-------------------|--------------------------------------------|-------------------------|-------------------------------------------------|
+| Regular           | `GUI::SpecialDimension::Regular` (mock)    | int ≥0                  |
+| Grow              | `GUI::SpecialDimension::Grow`              | `"grow"`                | grow to the maximum size the surrounding allows |
+| OpportunisticGrow | `GUI::SpecialDimension::OpportunisticGrow` | `"opportunistic_grow"`  | grow when the opportunity arises, meaning — only when all other widgets have already grown to their maximum size, and only opportunistically growing widgets are left |
+| Fit               | `GUI::SpecialDimension::Fit`               | `"fit"`                 | grow exactly to the size of the surrounding as determined by other factors, but do not call for e.g. expansion of the parent container it self |
+| Shrink            | `GUI::SpecialDimension::Shrink`            | `"shrink"`              | shrink to the smallest size possible |
+

--- a/Base/usr/share/man/man5/GML-Widget-ScrollableContainerWidget.md
+++ b/Base/usr/share/man/man5/GML-Widget-ScrollableContainerWidget.md
@@ -6,21 +6,29 @@ GML Scrollable Container Widget
 
 Defines a GUI scrollable container widget.
 
+Unlike other container widgets, this one does not allow multiple child widgets to be added, and thus also does not support setting a layout.
+
 ## Synopsis
 
 `@GUI::ScrollableContainerWidget`
+
+Content declared as `content_widget` property.
 
 ## Examples
 
 ```gml
 @GUI::ScrollableContainerWidget {
-
+	content_widget: @GUI::Widget {
+		[...]
+	}
 }
 ```
 
 ## Registered Properties
 
-| Property                           | Type | Possible values | Description                                 |
-|------------------------------------|------|-----------------|---------------------------------------------|
-| scrollbars_enabled                 | bool | true or false   | Status of scrollbar                         |
-| should_hide_unnecessary_scrollbars | bool | true or false   | Whether to hide scrollbars when unnecessary |
+| Property                           | Type          | Possible values        | Description                                 |
+|------------------------------------|---------------|------------------------|---------------------------------------------|
+| ~~layout~~                         |               | none                   | Does not take layout                        |
+| scrollbars_enabled                 | bool          | true or false          | Status of scrollbar                         |
+| should_hide_unnecessary_scrollbars | bool          | true or false          | Whether to hide scrollbars when unnecessary |
+| content_widget                     | widget object | Any Subclass of Widget | The Widget to be displayed in the Container |

--- a/Base/usr/share/man/man5/GML-Widget.md
+++ b/Base/usr/share/man/man5/GML-Widget.md
@@ -4,7 +4,8 @@ Defines a GUI widget.
 
 ```gml
 @GUI::Widget {
-  fixed_width: 250
+  min_width: 
+  preferred_width: "opportunistic_grow"
   fixed_height: 215
   fill_with_background_color: true
   layout: @GUI::VerticalBoxLayout {
@@ -15,35 +16,39 @@ Defines a GUI widget.
 
 ## Registered Properties
 
-| Property                    | Type          | Possible values                                       | Description                                                                                       |
-| --------------------------- | ------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| x                           | int           |                                                       | x offset relative to parent                                                                       |
-| y                           | int           |                                                       | y offset relative to parent                                                                       |
-| visible                     | bool          |                                                       | Whether widget and children are drawn                                                             |
-| focused                     | bool          |                                                       | Whether widget should be tab-focused on start                                                     |
-| focus_policy                | enum          | ClickFocus, NoFocus, TabFocus, StrongFocus            | How the widget can receive focus                                                                  |
-| enabled                     | bool          |                                                       | Whether this widget is enabled for interactive purposes, e.g. can be clicked                      |
-| tooltip                     | string        |                                                       | Mouse tooltip to show when hovering over this widget                                              |
-| min_size                    | size          |                                                       | Minimum size this widget wants to occupy                                                          |
-| max_size                    | size          |                                                       | Maximum size this widget wants to occupy                                                          |
-| width                       | int           |                                                       | Width of the widget, independent of its layout size calculation                                   |
-| height                      | int           |                                                       | Height of the widget, independent of its layout size calculation                                  |
-| min_width                   | int           | smaller than max_width                                | Minimum width this widget wants to occupy                                                         |
-| min_height                  | int           | smaller than max_height                               | Minimum height this widget wants to occupy                                                        |
-| max_width                   | int           | greater than min_width                                | Maximum width this widget wants to occupy                                                         |
-| max_height                  | int           | greater than min_height                               | Maximum height this widget wants to occupy                                                        |
-| fixed_width                 | int           |                                                       | Both maximum and minimum width; widget is fixed-width                                             |
-| fixed_height                | int           |                                                       | Both maximum and minimum height; widget is fixed-height                                           |
-| fixed_size                  | size          |                                                       | Both maximum and minimum size; widget is fixed-size                                               |
-| shrink_to_fit               | bool          |                                                       | Whether the widget shrinks as much as possible while still respecting its childrens minimum sizes |
-| font                        | string        | Any system-known font                                 | Font family                                                                                       |
-| font_size                   | int           | Font size that is available on this family            | Font size                                                                                         |
-| font_weight                 | font_weight   | Font weight that is available on this family and size | Font weight                                                                                       |
-| font_type                   | enum          | FixedWidth, Normal                                    | Font type                                                                                         |
-| foreground_color            | color         |                                                       | Color of foreground elements such as text                                                         |
-| foreground_role             | string        | Any theme palette color role name                     | Palette color role (depends on system theme) for the foreground elements                          |
-| background_color            | color         |                                                       | Color of the widget background                                                                    |
-| background_role             | string        | Any theme palette color role name                     | Palette color role (depends on system theme) for the widget background                            |
-| fill_width_background_color | bool          |                                                       | Whether to fill the widget's background with the background color                                 |
-| layout                      | layout object |                                                       | Layout object for layouting this widget's children                                                |
-| relative_rect               | rect          |                                                       | Rectangle for relatively positioning the widget to the parent                                     |
+| Property                    | Type          | Possible values                                       | Description                                                                                        |
+| --------------------------- | ------------- | ----------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| x                           | int           |                                                       | x offset relative to parent                                                                        |
+| y                           | int           |                                                       | y offset relative to parent                                                                        |
+| visible                     | bool          |                                                       | Whether widget and children are drawn                                                              |
+| focused                     | bool          |                                                       | Whether widget should be tab-focused on start                                                      |
+| focus_policy                | enum          | ClickFocus, NoFocus, TabFocus, StrongFocus            | How the widget can receive focus                                                                   |
+| enabled                     | bool          |                                                       | Whether this widget is enabled for interactive purposes, e.g. can be clicked                       |
+| tooltip                     | string        |                                                       | Mouse tooltip to show when hovering over this widget                                               |
+| min_size                    | ui_size       | {Regular, Shrink}²                                    | Minimum size this widget wants to occupy (Shrink is equivalent to 0)                               |
+| max_size                    | ui_size       | {Regular, Grow}²                                      | Maximum size this widget wants to occupy                                                           |
+| preferred_size              | ui_size       | {Regular, Shrink, Fit, OpportunisticGrow, Grow}²      | Preferred size this widget wants to occupy, if not otherwise constrained (Shrink means min_size)   |
+| width                       | int           |                                                       | Width of the widget, independent of its layout size calculation                                    |
+| height                      | int           |                                                       | Height of the widget, independent of its layout size calculation                                   |
+| min_width                   | ui_dimension  | Regular, Shrink                                       | Minimum width this widget wants to occupy (Shrink is equivalent to 0)                              |
+| min_height                  | ui_dimension  | Regular, Shrink                                       | Minimum height this widget wants to occupy (Shrink is equivalent to 0                              |
+| max_width                   | ui_dimension  | Regular, Grow                                         | Maximum width this widget wants to occupy                                                          |
+| max_height                  | ui_dimension  | Regular, Grow                                         | Maximum height this widget wants to occupy                                                         |
+| preferred_width             | ui_dimension  | Regular, Shrink, Fit, OpportunisticGrow, Grow         | Preferred width this widget wants to occupy, if not otherwise constrained (Shrink means min_size)  |
+| preferred_height            | ui_dimension  | Regular, Shrink, Fit, OpportunisticGrow, Grow         | Preferred height this widget wants to occupy, if not otherwise constrained (Shrink means min_size) |
+| fixed_width                 | ui_dimension  | Regular (currently only integer values ≥0 allowed)    | Both maximum and minimum width; widget is fixed-width                                              |
+| fixed_height                | ui_dimension  | Regular (currently only integer values ≥0 allowed)    | Both maximum and minimum height; widget is fixed-height                                            |
+| fixed_size                  | ui_size       | {Regular}²                                            | Both maximum and minimum size; widget is fixed-size                                                |
+| shrink_to_fit               | bool          |                                                       | Whether the widget shrinks as much as possible while still respecting its childrens minimum sizes  |
+| font                        | string        | Any system-known font                                 | Font family                                                                                        |
+| font_size                   | int           | Font size that is available on this family            | Font size                                                                                          |
+| font_weight                 | font_weight   | Font weight that is available on this family and size | Font weight                                                                                        |
+| font_type                   | enum          | FixedWidth, Normal                                    | Font type                                                                                          |
+| foreground_color            | color         |                                                       | Color of foreground elements such as text                                                          |
+| foreground_role             | string        | Any theme palette color role name                     | Palette color role (depends on system theme) for the foreground elements                           |
+| background_color            | color         |                                                       | Color of the widget background                                                                     |
+| background_role             | string        | Any theme palette color role name                     | Palette color role (depends on system theme) for the widget background                             |
+| fill_width_background_color | bool          |                                                       | Whether to fill the widget's background with the background color                                  |
+| layout                      | layout object |                                                       | Layout object for layouting this widget's children                                                 |
+| relative_rect               | rect          |                                                       | Rectangle for relatively positioning the widget to the parent                                      |
+

--- a/Userland/Applications/CharacterMap/CharacterMapWindow.gml
+++ b/Userland/Applications/CharacterMap/CharacterMapWindow.gml
@@ -37,6 +37,8 @@
 
             @GUI::GlyphMapWidget {
                 name: "glyph_map"
+                min_height: 80
+                min_width: 80
             }
 
             @GUI::Widget {

--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -93,8 +93,7 @@
             fixed_width: 150
         }
 
-        // HACK: We need something like Layout::add_spacer() in GML! :^)
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::DialogButton {
             name: "close_button"

--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -82,13 +82,12 @@
         fixed_height: 32
         layout: @GUI::HorizontalBoxLayout {}
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "debug_button"
             text: "Debug in Hack Studio"
-            fixed_width: 150
         }
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "save_backtrace_button"
             text: "Save Backtrace"
             fixed_width: 150
@@ -97,10 +96,9 @@
         // HACK: We need something like Layout::add_spacer() in GML! :^)
         @GUI::Widget {}
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "close_button"
             text: "Close"
-            fixed_width: 70
         }
     }
 }

--- a/Userland/Applications/CrashReporter/CrashReporterWindow.gml
+++ b/Userland/Applications/CrashReporter/CrashReporterWindow.gml
@@ -85,12 +85,13 @@
         @GUI::DialogButton {
             name: "debug_button"
             text: "Debug in Hack Studio"
+            preferred_width: 160
         }
 
         @GUI::DialogButton {
             name: "save_backtrace_button"
             text: "Save Backtrace"
-            fixed_width: 150
+            preferred_width: 160
         }
 
         @GUI::Layout::Spacer {}

--- a/Userland/Applications/DisplaySettings/BackgroundSettings.gml
+++ b/Userland/Applications/DisplaySettings/BackgroundSettings.gml
@@ -28,22 +28,20 @@
 
         @GUI::IconView {
             name: "wallpaper_view"
+            preferred_width: "opportunistic_grow"
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_width: "fit"
             layout: @GUI::VerticalBoxLayout {}
 
             @GUI::Button {
                 name: "wallpaper_open_button"
                 tooltip: "Select wallpaper from file system"
                 text: "Browse..."
-                shrink_to_fit: true
             }
 
-            @GUI::Widget {
-                fixed_height: 12
-            }
+            @GUI::Layout::Spacer {}
 
             @GUI::Label {
                 text: "Mode:"
@@ -55,9 +53,7 @@
                 name: "mode_combo"
             }
 
-            @GUI::Widget {
-                fixed_height: 12
-            }
+            @GUI::Layout::Spacer {}
 
             @GUI::Label {
                 text: "Color:"

--- a/Userland/Applications/DisplaySettings/FontSettings.gml
+++ b/Userland/Applications/DisplaySettings/FontSettings.gml
@@ -6,7 +6,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {
             spacing: 6
         }
@@ -17,14 +17,13 @@
             text_alignment: "CenterLeft"
         }
 
-        @GUI::Frame {
+        @GUI::Label {
             background_role: "Base"
+            shadow: "Sunken"
+            shape: "Container"
+            thickness: 2
             fill_with_background_color: true
-            layout: @GUI::VerticalBoxLayout {}
-
-            @GUI::Label {
-                name: "default_font_label"
-            }
+            name: "default_font_label"
         }
 
         @GUI::Button {
@@ -35,7 +34,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {
             spacing: 6
         }
@@ -46,14 +45,13 @@
             text_alignment: "CenterLeft"
         }
 
-        @GUI::Frame {
+        @GUI::Label {
             background_role: "Base"
+            shadow: "Sunken"
+            shape: "Container"
+            thickness: 2
             fill_with_background_color: true
-            layout: @GUI::VerticalBoxLayout {}
-
-            @GUI::Label {
-                name: "fixed_width_font_label"
-            }
+            name: "fixed_width_font_label"
         }
 
         @GUI::Button {
@@ -63,5 +61,5 @@
         }
     }
 
-    @GUI::Widget {}
+    @GUI::Layout::Spacer {}
 }

--- a/Userland/Applications/DisplaySettings/MonitorSettings.gml
+++ b/Userland/Applications/DisplaySettings/MonitorSettings.gml
@@ -15,7 +15,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {
             margins: [8, 8, 6, 16]
         }
@@ -38,7 +38,7 @@
         title: "Screen settings"
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {}
 
             @GUI::Label {
@@ -64,7 +64,7 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {}
 
             @GUI::Label {
@@ -84,6 +84,8 @@
                 text: "2x"
                 fixed_width: 50
             }
+
+            @GUI::Layout::Spacer {}
         }
     }
 }

--- a/Userland/Applications/DisplaySettings/ThemesSettings.gml
+++ b/Userland/Applications/DisplaySettings/ThemesSettings.gml
@@ -23,13 +23,13 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {}
 
             @GUI::Label {
                 text: "Theme:"
                 text_alignment: "CenterLeft"
-                fixed_width: 95
+                preferred_width: 95
             }
 
             @GUI::ComboBox {

--- a/Userland/Applications/FileManager/FileManagerWindow.gml
+++ b/Userland/Applications/FileManager/FileManagerWindow.gml
@@ -36,6 +36,7 @@
 
             @GUI::Breadcrumbbar {
                 name: "breadcrumbbar"
+                min_width: 80
             }
         }
     }

--- a/Userland/Applications/FileManager/PropertiesWindow.cpp
+++ b/Userland/Applications/FileManager/PropertiesWindow.cpp
@@ -145,6 +145,7 @@ PropertiesWindow::PropertiesWindow(String const& path, bool disable_rename, Wind
     auto& button_widget = main_widget.add<GUI::Widget>();
     button_widget.set_layout<GUI::HorizontalBoxLayout>();
     button_widget.set_fixed_height(22);
+    button_widget.set_preferred_width(GUI::SpecialDimension::Grow);
     button_widget.layout()->set_spacing(5);
 
     button_widget.layout()->add_spacer();

--- a/Userland/Applications/FontEditor/FontEditorWindow.gml
+++ b/Userland/Applications/FontEditor/FontEditorWindow.gml
@@ -25,7 +25,7 @@
             }
 
             @GUI::Widget {
-                shrink_to_fit: true
+                preferred_height: "fit"
                 layout: @GUI::VerticalBoxLayout {}
 
                 @GUI::SpinBox {
@@ -67,12 +67,13 @@
                     @GUI::Widget {
                         name: "glyph_map_container"
                         layout: @GUI::VerticalBoxLayout {}
+                        preferred_height: "opportunistic_grow"
                     }
 
                     @GUI::GroupBox {
                         name: "font_metadata_groupbox"
                         title: "Metadata"
-                        shrink_to_fit: true
+                        preferred_height: "fit"
                         layout: @GUI::VerticalBoxLayout {
                             margins: [6, 6, 6, 6]
                         }

--- a/Userland/Applications/MouseSettings/Theme.gml
+++ b/Userland/Applications/MouseSettings/Theme.gml
@@ -12,7 +12,7 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {
                 spacing: 8
             }

--- a/Userland/Applications/Run/Run.gml
+++ b/Userland/Applications/Run/Run.gml
@@ -38,28 +38,28 @@
     }
 
     @GUI::Widget {
-        layout: @GUI::HorizontalBoxLayout {}
-        fixed_height: 22
+        layout: @GUI::HorizontalBoxLayout {
+            spacing: 6
+        }
+
+        preferred_height: "shrink"
 
         // HACK: using an empty widget as a spacer
         @GUI::Widget {}
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "ok_button"
             text: "OK"
-            fixed_width: 80
         }
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "cancel_button"
             text: "Cancel"
-            fixed_width: 80
         }
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "browse_button"
             text: "Browse..."
-            fixed_width: 80
         }
     }
 }

--- a/Userland/Applications/Run/Run.gml
+++ b/Userland/Applications/Run/Run.gml
@@ -41,11 +41,9 @@
         layout: @GUI::HorizontalBoxLayout {
             spacing: 6
         }
-
         preferred_height: "shrink"
 
-        // HACK: using an empty widget as a spacer
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::DialogButton {
             name: "ok_button"

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -52,17 +52,17 @@ RunWindow::RunWindow()
         m_ok_button->click();
     };
 
-    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    m_ok_button = *main_widget.find_descendant_of_type_named<GUI::DialogButton>("ok_button");
     m_ok_button->on_click = [this](auto) {
         do_run();
     };
 
-    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
+    m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::DialogButton>("cancel_button");
     m_cancel_button->on_click = [this](auto) {
         close();
     };
 
-    m_browse_button = *find_descendant_of_type_named<GUI::Button>("browse_button");
+    m_browse_button = *find_descendant_of_type_named<GUI::DialogButton>("browse_button");
     m_browse_button->on_click = [this](auto) {
         Optional<String> path = GUI::FilePicker::get_open_filepath(this, {}, Core::StandardPaths::home_directory(), false, GUI::Dialog::ScreenPosition::Center);
         if (path.has_value())

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -427,7 +427,9 @@ ConditionView::~ConditionView()
 
 ConditionsView::ConditionsView()
 {
-    set_layout<GUI::VerticalBoxLayout>().set_spacing(2);
+    auto& layout = set_layout<GUI::VerticalBoxLayout>();
+    layout.set_spacing(4);
+    layout.set_margins({ 6 });
 }
 
 void ConditionsView::set_formats(Vector<ConditionalFormat>* formats)

--- a/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
+++ b/Userland/Applications/Spreadsheet/CellTypeDialog.cpp
@@ -281,7 +281,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
                 auto& foreground_container = static_formatting_container.add<GUI::Widget>();
                 foreground_container.set_layout<GUI::HorizontalBoxLayout>();
                 foreground_container.layout()->set_margins({ 4, 0, 0 });
-                foreground_container.set_shrink_to_fit(true);
+                foreground_container.set_preferred_height(GUI::SpecialDimension::Fit);
 
                 auto& foreground_label = foreground_container.add<GUI::Label>();
                 foreground_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);
@@ -301,7 +301,7 @@ void CellTypeDialog::setup_tabs(GUI::TabWidget& tabs, Vector<Position> const& po
                 auto& background_container = static_formatting_container.add<GUI::Widget>();
                 background_container.set_layout<GUI::HorizontalBoxLayout>();
                 background_container.layout()->set_margins({ 4, 0, 0 });
-                background_container.set_shrink_to_fit(true);
+                background_container.set_preferred_height(GUI::SpecialDimension::Fit);
 
                 auto& background_label = background_container.add<GUI::Label>();
                 background_label.set_text_alignment(Gfx::TextAlignment::CenterLeft);

--- a/Userland/Applications/Spreadsheet/CondFormatting.gml
+++ b/Userland/Applications/Spreadsheet/CondFormatting.gml
@@ -16,7 +16,7 @@
             spacing: 10
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::Button {
             name: "add_button"
@@ -30,6 +30,6 @@
             fixed_width: 70
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
     }
 }

--- a/Userland/Applications/Spreadsheet/CondFormatting.gml
+++ b/Userland/Applications/Spreadsheet/CondFormatting.gml
@@ -11,7 +11,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {
             spacing: 10
         }

--- a/Userland/Applications/Spreadsheet/CondFormatting.gml
+++ b/Userland/Applications/Spreadsheet/CondFormatting.gml
@@ -6,8 +6,11 @@
         spacing: 4
     }
 
-    @Spreadsheet::ConditionsView {
-        name: "conditions_view"
+    @GUI::ScrollableContainerWidget {
+        should_hide_unnecessary_scrollbars: true
+        content_widget: @Spreadsheet::ConditionsView {
+            name: "conditions_view"
+        }
     }
 
     @GUI::Widget {

--- a/Userland/Applications/Spreadsheet/CondView.gml
+++ b/Userland/Applications/Spreadsheet/CondView.gml
@@ -1,8 +1,9 @@
 @GUI::Widget {
     layout: @GUI::VerticalBoxLayout {}
+    preferred_height: "fit"
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {}
 
         @GUI::Label {
@@ -12,14 +13,14 @@
 
         @GUI::TextEditor {
             name: "formula_editor"
-            fixed_height: 25
+            fixed_height: 44
             tooltip: "Use 'value' to refer to the current cell's value"
             font_type: "FixedWidth"
         }
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {}
 
         @GUI::Label {
@@ -33,7 +34,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_height: "fit"
         layout: @GUI::HorizontalBoxLayout {}
 
         @GUI::Label {

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -167,6 +167,7 @@ static ErrorOr<NonnullRefPtr<GUI::Window>> create_find_window(VT::TerminalWidget
     window->set_window_type(GUI::WindowType::ToolWindow);
     window->set_title("Find in Terminal");
     window->set_resizable(false);
+    window->set_obey_widget_min_size(false);
     window->resize(300, 90);
 
     auto main_widget = TRY(window->try_set_main_widget<GUI::Widget>());

--- a/Userland/Applications/Terminal/main.cpp
+++ b/Userland/Applications/Terminal/main.cpp
@@ -286,6 +286,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 
     auto window = TRY(GUI::Window::try_create());
     window->set_title("Terminal");
+    window->set_obey_widget_min_size(false);
     window->set_double_buffering_enabled(false);
 
     auto terminal = TRY(window->try_set_main_widget<VT::TerminalWidget>(ptm_fd, true));

--- a/Userland/Applications/ThemeEditor/AlignmentProperty.gml
+++ b/Userland/Applications/ThemeEditor/AlignmentProperty.gml
@@ -2,7 +2,7 @@
     layout: @GUI::HorizontalBoxLayout {
         spacing: 4
     }
-    shrink_to_fit: true
+    preferred_height: "fit"
 
     @GUI::Label {
         name: "name"

--- a/Userland/Applications/ThemeEditor/ColorProperty.gml
+++ b/Userland/Applications/ThemeEditor/ColorProperty.gml
@@ -2,7 +2,7 @@
     layout: @GUI::HorizontalBoxLayout {
         spacing: 4
     }
-    shrink_to_fit: true
+    preferred_height: "fit"
 
     @GUI::Label {
         name: "name"

--- a/Userland/Applications/ThemeEditor/FlagProperty.gml
+++ b/Userland/Applications/ThemeEditor/FlagProperty.gml
@@ -2,7 +2,7 @@
     layout: @GUI::HorizontalBoxLayout {
         spacing: 4
     }
-    shrink_to_fit: true
+    preferred_height: "fit"
 
     @GUI::CheckBox {
         name: "checkbox"

--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -384,7 +384,7 @@ void MainWidget::add_property_tab(PropertyTab const& property_tab)
         group_box->layout()->set_spacing(12);
         // 1px less on the left makes the text line up with the group title.
         group_box->layout()->set_margins({ 8, 8, 8, 7 });
-        group_box->set_shrink_to_fit(true);
+        group_box->set_preferred_height(GUI::SpecialDimension::Fit);
 
         for (auto const& property : group.properties) {
             NonnullRefPtr<GUI::Widget> row_widget = group_box->add<GUI::Widget>();

--- a/Userland/Applications/ThemeEditor/MetricProperty.gml
+++ b/Userland/Applications/ThemeEditor/MetricProperty.gml
@@ -2,7 +2,7 @@
     layout: @GUI::HorizontalBoxLayout {
         spacing: 4
     }
-    shrink_to_fit: true
+    preferred_height: "fit"
 
     @GUI::Label {
         name: "name"

--- a/Userland/Applications/ThemeEditor/PathProperty.gml
+++ b/Userland/Applications/ThemeEditor/PathProperty.gml
@@ -2,7 +2,7 @@
     layout: @GUI::HorizontalBoxLayout {
         spacing: 4
     }
-    shrink_to_fit: true
+    preferred_height: "fit"
 
     @GUI::Label {
         name: "name"

--- a/Userland/Applications/ThemeEditor/ThemeEditor.gml
+++ b/Userland/Applications/ThemeEditor/ThemeEditor.gml
@@ -5,9 +5,11 @@
     @GUI::Frame {
         layout: @GUI::HorizontalBoxLayout {}
         name: "preview_frame"
+        fixed_width: 400
     }
 
     @GUI::TabWidget {
         name: "property_tabs"
+        min_width: 300
     }
 }

--- a/Userland/Applications/ThemeEditor/main.cpp
+++ b/Userland/Applications/ThemeEditor/main.cpp
@@ -65,7 +65,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     };
 
     window->resize(820, 520);
-    window->set_resizable(false);
+    window->set_resizable(true);
     window->show();
     window->set_icon(app_icon.bitmap_for_size(16));
     return app->exec();

--- a/Userland/Applications/Welcome/WelcomeWindow.gml
+++ b/Userland/Applications/Welcome/WelcomeWindow.gml
@@ -85,7 +85,7 @@
                 text: "Next Tip"
             }
 
-            @GUI::Widget {}
+            @GUI::Layout::Spacer {}
 
             @GUI::HorizontalSeparator {
                 fixed_height: 2
@@ -107,7 +107,7 @@
             autosize: true
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::Button {
             name: "close_button"

--- a/Userland/Demos/WidgetGallery/DemoWizardPage1.gml
+++ b/Userland/Demos/WidgetGallery/DemoWizardPage1.gml
@@ -28,6 +28,5 @@
         }
     }
 
-    // Spacer
-    @GUI::Widget {}
+    @GUI::Layout::Spacer {}
 }

--- a/Userland/Demos/WidgetGallery/DemoWizardPage2.gml
+++ b/Userland/Demos/WidgetGallery/DemoWizardPage2.gml
@@ -14,6 +14,5 @@
         fixed_height: 28
     }
 
-    // Spacer
-    @GUI::Widget {}
+    @GUI::Layout::Spacer {}
 }

--- a/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/BasicsTab.gml
@@ -92,7 +92,7 @@
             @GUI::Widget {
                 layout: @GUI::VerticalBoxLayout {}
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
 
                 @GUI::Button {
                     name: "normal_button"
@@ -105,7 +105,7 @@
                     enabled: "false"
                 }
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
             }
 
             @GUI::VerticalSeparator {}
@@ -113,7 +113,7 @@
             @GUI::Widget {
                 layout: @GUI::VerticalBoxLayout {}
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
 
                 @GUI::Button {
                     name: "enabled_coolbar_button"
@@ -128,7 +128,7 @@
                     button_style: "Coolbar"
                 }
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
             }
         }
 
@@ -144,7 +144,7 @@
                     fixed_width: 60
                     layout: @GUI::VerticalBoxLayout {}
 
-                    @GUI::Widget {}
+                    @GUI::Layout::Spacer {}
 
                     @GUI::RadioButton {
                         name: "top_radiobutton"
@@ -157,16 +157,16 @@
                         text: "Radio 2"
                     }
 
-                    @GUI::Widget {}
+                    @GUI::Layout::Spacer {}
                 }
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
 
                 @GUI::Widget {
                     fixed_width: 70
                     layout: @GUI::VerticalBoxLayout {}
 
-                    @GUI::Widget {}
+                    @GUI::Layout::Spacer {}
 
                     @GUI::CheckBox {
                         name: "top_checkbox"
@@ -179,10 +179,10 @@
                         enabled: false
                     }
 
-                    @GUI::Widget {}
+                    @GUI::Layout::Spacer {}
                 }
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
             }
 
             @GUI::VerticalSeparator {}
@@ -190,7 +190,7 @@
             @GUI::Widget {
                 layout: @GUI::VerticalBoxLayout {}
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
 
                 @GUI::Button {
                     name: "icon_button"
@@ -203,7 +203,7 @@
                     enabled: "false"
                 }
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
             }
         }
     }
@@ -278,7 +278,7 @@
                     }
                 }
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
 
                 @GUI::Button {
                     name: "font_button"
@@ -295,7 +295,7 @@
                     text: "Input dialog..."
                 }
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
             }
         }
 

--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -61,7 +61,6 @@
         @GUI::Scrollbar {
             name: "enabled_scrollbar"
             fixed_height: 16
-            fixed_width: -1
             min: 0
             max: 100
             value: 50
@@ -76,7 +75,6 @@
         @GUI::Scrollbar {
             name: "disabled_scrollbar"
             fixed_height: 16
-            fixed_width: -1
         }
 
         @GUI::Widget {}

--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -60,7 +60,6 @@
 
         @GUI::Scrollbar {
             name: "enabled_scrollbar"
-            fixed_height: 16
             min: 0
             max: 100
             value: 50
@@ -74,7 +73,6 @@
 
         @GUI::Scrollbar {
             name: "disabled_scrollbar"
-            fixed_height: 16
         }
 
         @GUI::Layout::Spacer {}

--- a/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
+++ b/Userland/Demos/WidgetGallery/GalleryGML/SlidersTab.gml
@@ -56,7 +56,7 @@
             margins: [0, 8]
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::Scrollbar {
             name: "enabled_scrollbar"
@@ -66,18 +66,18 @@
             value: 50
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::HorizontalSeparator {}
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::Scrollbar {
             name: "disabled_scrollbar"
             fixed_height: 16
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
     }
 
     @GUI::GroupBox {

--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -929,7 +929,7 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_add_terminal_action()
 
 void HackStudioWidget::reveal_action_tab(GUI::Widget& widget)
 {
-    if (m_action_tab_widget->min_height() < 200)
+    if (m_action_tab_widget->effective_min_size().height().value_verify_regular() < 200)
         m_action_tab_widget->set_fixed_height(200);
     m_action_tab_widget->set_active_widget(&widget);
 }

--- a/Userland/DevTools/Profiler/TimelineContainer.cpp
+++ b/Userland/DevTools/Profiler/TimelineContainer.cpp
@@ -23,7 +23,7 @@ TimelineContainer::TimelineContainer(GUI::Widget& header_container, TimelineView
     update_widget_sizes();
     update_widget_positions();
 
-    int initial_height = min(300, timeline_view.height() + horizontal_scrollbar().max_height() + frame_thickness() * 2);
+    int initial_height = min(300, timeline_view.height() + horizontal_scrollbar().effective_preferred_size().height().value_verify_regular() + frame_thickness() * 2);
     set_fixed_height(initial_height);
 
     m_timeline_view->on_scale_change = [this] {
@@ -48,16 +48,16 @@ void TimelineContainer::update_widget_sizes()
 {
     {
         m_timeline_view->do_layout();
-        auto preferred_size = m_timeline_view->layout()->preferred_size();
-        m_timeline_view->resize(preferred_size);
-        set_content_size(preferred_size);
+        auto preferred_size = m_timeline_view->effective_preferred_size();
+        m_timeline_view->resize(Gfx::IntSize(preferred_size));
+        set_content_size(Gfx::IntSize(preferred_size));
     }
 
     {
         m_header_container->do_layout();
-        auto preferred_size = m_header_container->layout()->preferred_size();
-        m_header_container->resize(preferred_size);
-        set_size_occupied_by_fixed_elements({ preferred_size.width(), 0 });
+        auto preferred_size = m_header_container->effective_preferred_size();
+        m_header_container->resize(Gfx::IntSize(preferred_size));
+        set_size_occupied_by_fixed_elements({ preferred_size.width().value_verify_regular(), 0 });
     }
 }
 

--- a/Userland/Games/Hearts/main.cpp
+++ b/Userland/Games/Hearts/main.cpp
@@ -104,7 +104,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Hearts", app_icon, window)));
 
     window->set_resizable(false);
-    window->resize(Hearts::Game::width, Hearts::Game::height + statusbar.max_height());
+    window->resize(Hearts::Game::width, Hearts::Game::height + statusbar.max_height().value_verify_regular());
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
     game.setup(player_name);

--- a/Userland/Games/Minesweeper/Field.cpp
+++ b/Userland/Games/Minesweeper/Field.cpp
@@ -518,7 +518,7 @@ void Field::set_field_size(Difficulty difficulty, size_t rows, size_t columns, s
     m_mine_count = mine_count;
     set_fixed_size(frame_thickness() * 2 + m_columns * square_size(), frame_thickness() * 2 + m_rows * square_size());
     reset();
-    m_on_size_changed(min_size());
+    m_on_size_changed(Gfx::IntSize(min_size()));
 }
 
 void Field::set_single_chording(bool enabled)

--- a/Userland/Games/Minesweeper/main.cpp
+++ b/Userland/Games/Minesweeper/main.cpp
@@ -90,7 +90,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     container->layout()->add_spacer();
 
     auto field = TRY(widget->try_add<Field>(flag_label, time_label, face_button, [&](auto size) {
-        size.set_height(size.height() + container->min_size().height());
+        size.set_height(size.height() + container->min_size().height().value_verify_regular());
         window->resize(size);
     }));
 

--- a/Userland/Games/Solitaire/main.cpp
+++ b/Userland/Games/Solitaire/main.cpp
@@ -206,7 +206,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     TRY(help_menu->try_add_action(GUI::CommonActions::make_about_action("Solitaire", app_icon, window)));
 
     window->set_resizable(false);
-    window->resize(Solitaire::Game::width, Solitaire::Game::height + statusbar.max_height());
+    window->resize(Solitaire::Game::width, Solitaire::Game::height + statusbar.max_height().value_verify_regular());
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
 

--- a/Userland/Games/Spider/main.cpp
+++ b/Userland/Games/Spider/main.cpp
@@ -268,7 +268,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     help_menu->add_action(GUI::CommonActions::make_about_action("Spider", app_icon, window));
 
     window->set_resizable(false);
-    window->resize(Spider::Game::width, Spider::Game::height + statusbar.max_height());
+    window->resize(Spider::Game::width, Spider::Game::height + statusbar.max_height().value_verify_regular());
     window->set_icon(app_icon.bitmap_for_size(16));
     window->show();
 

--- a/Userland/Libraries/LibGUI/AboutDialog.cpp
+++ b/Userland/Libraries/LibGUI/AboutDialog.cpp
@@ -79,8 +79,7 @@ AboutDialog::AboutDialog(StringView name, Gfx::Bitmap const* icon, Window* paren
     button_container.set_fixed_height(22);
     button_container.set_layout<HorizontalBoxLayout>();
     button_container.layout()->add_spacer();
-    auto& ok_button = button_container.add<Button>("OK");
-    ok_button.set_fixed_width(80);
+    auto& ok_button = button_container.add<DialogButton>("OK");
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -75,20 +75,26 @@ void AbstractScrollableWidget::mousewheel_event(MouseEvent& event)
 void AbstractScrollableWidget::custom_layout()
 {
     auto inner_rect = frame_inner_rect_for_size(size());
-    int height_wanted_by_horizontal_scrollbar = m_horizontal_scrollbar->is_visible() ? m_horizontal_scrollbar->min_height() : 0;
-    int width_wanted_by_vertical_scrollbar = m_vertical_scrollbar->is_visible() ? m_vertical_scrollbar->min_width() : 0;
+    int height_wanted_by_horizontal_scrollbar = m_horizontal_scrollbar->is_visible() ? m_horizontal_scrollbar->effective_min_size().height().value_verify_regular() : 0;
+    int width_wanted_by_vertical_scrollbar = m_vertical_scrollbar->is_visible() ? m_vertical_scrollbar->effective_min_size().width().value_verify_regular() : 0;
 
-    m_vertical_scrollbar->set_relative_rect(
-        inner_rect.right() + 1 - m_vertical_scrollbar->min_width(),
-        inner_rect.top(),
-        m_vertical_scrollbar->min_width(),
-        inner_rect.height() - height_wanted_by_horizontal_scrollbar);
+    {
+        int vertical_scrollbar_width = m_vertical_scrollbar->effective_min_size().width().value_verify_regular();
+        m_vertical_scrollbar->set_relative_rect(
+            inner_rect.right() + 1 - vertical_scrollbar_width,
+            inner_rect.top(),
+            vertical_scrollbar_width,
+            inner_rect.height() - height_wanted_by_horizontal_scrollbar);
+    }
 
-    m_horizontal_scrollbar->set_relative_rect(
-        inner_rect.left(),
-        inner_rect.bottom() + 1 - m_horizontal_scrollbar->min_height(),
-        inner_rect.width() - width_wanted_by_vertical_scrollbar,
-        m_horizontal_scrollbar->min_height());
+    {
+        int horizontal_scrollbar_height = m_horizontal_scrollbar->effective_min_size().height().value_verify_regular();
+        m_horizontal_scrollbar->set_relative_rect(
+            inner_rect.left(),
+            inner_rect.bottom() + 1 - horizontal_scrollbar_height,
+            inner_rect.width() - width_wanted_by_vertical_scrollbar,
+            horizontal_scrollbar_height);
+    }
 
     m_corner_widget->set_visible(m_vertical_scrollbar->is_visible() && m_horizontal_scrollbar->is_visible());
     if (m_corner_widget->is_visible()) {
@@ -106,8 +112,8 @@ void AbstractScrollableWidget::resize_event(ResizeEvent& event)
 Gfx::IntSize AbstractScrollableWidget::available_size() const
 {
     auto inner_size = Widget::content_size();
-    unsigned available_width = max(inner_size.width() - m_size_occupied_by_fixed_elements.width(), 0);
-    unsigned available_height = max(inner_size.height() - m_size_occupied_by_fixed_elements.height(), 0);
+    int available_width = max(inner_size.width() - m_size_occupied_by_fixed_elements.width(), 0);
+    int available_height = max(inner_size.height() - m_size_occupied_by_fixed_elements.height(), 0);
     return { available_width, available_height };
 }
 

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.cpp
@@ -106,6 +106,7 @@ void AbstractScrollableWidget::custom_layout()
 void AbstractScrollableWidget::resize_event(ResizeEvent& event)
 {
     Frame::resize_event(event);
+    update_scrollbar_visibility();
     update_scrollbar_ranges();
 }
 
@@ -125,26 +126,22 @@ Gfx::IntSize AbstractScrollableWidget::excess_size() const
     return { excess_width, excess_height };
 }
 
+void AbstractScrollableWidget::set_should_hide_unnecessary_scrollbars(bool should_hide_unnecessary_scrollbars)
+{
+    if (m_should_hide_unnecessary_scrollbars == should_hide_unnecessary_scrollbars)
+        return;
+
+    m_should_hide_unnecessary_scrollbars = should_hide_unnecessary_scrollbars;
+    if (should_hide_unnecessary_scrollbars)
+        update_scrollbar_ranges();
+    else {
+        m_horizontal_scrollbar->set_visible(true);
+        m_vertical_scrollbar->set_visible(true);
+    }
+}
+
 void AbstractScrollableWidget::update_scrollbar_ranges()
 {
-    if (should_hide_unnecessary_scrollbars()) {
-        if (excess_size().height() - height_occupied_by_horizontal_scrollbar() <= 0 && excess_size().width() - width_occupied_by_vertical_scrollbar() <= 0) {
-            m_horizontal_scrollbar->set_visible(false);
-            m_vertical_scrollbar->set_visible(false);
-        } else {
-            auto vertical_initial_visibility = m_vertical_scrollbar->is_visible();
-            auto horizontal_initial_visibility = m_horizontal_scrollbar->is_visible();
-
-            m_vertical_scrollbar->set_visible(excess_size().height() > 0);
-            m_horizontal_scrollbar->set_visible(excess_size().width() > 0);
-
-            if (m_vertical_scrollbar->is_visible() != vertical_initial_visibility)
-                m_horizontal_scrollbar->set_visible(excess_size().width() > 0);
-            if (m_horizontal_scrollbar->is_visible() != horizontal_initial_visibility)
-                m_vertical_scrollbar->set_visible(excess_size().height() > 0);
-        }
-    }
-
     m_horizontal_scrollbar->set_range(0, excess_size().width());
     m_horizontal_scrollbar->set_page_step(visible_content_rect().width() - m_horizontal_scrollbar->step());
 
@@ -152,11 +149,38 @@ void AbstractScrollableWidget::update_scrollbar_ranges()
     m_vertical_scrollbar->set_page_step(visible_content_rect().height() - m_vertical_scrollbar->step());
 }
 
+void AbstractScrollableWidget::update_scrollbar_visibility()
+{
+    if (should_hide_unnecessary_scrollbars()) {
+        int horizontal_buffer = rect().width() - 2 * frame_thickness() - m_min_content_size.width();
+        int vertical_buffer = rect().height() - 2 * frame_thickness() - m_min_content_size.height();
+        bool horizontal_scrollbar_should_be_visible = false, vertical_scrollbar_should_be_visible = false;
+        vertical_scrollbar_should_be_visible = vertical_buffer < 0;
+        if (vertical_scrollbar_should_be_visible)
+            horizontal_buffer -= m_vertical_scrollbar->width();
+        horizontal_scrollbar_should_be_visible = horizontal_buffer < 0;
+        if (horizontal_scrollbar_should_be_visible)
+            vertical_buffer -= m_horizontal_scrollbar->height();
+        vertical_scrollbar_should_be_visible = vertical_buffer < 0;
+
+        m_horizontal_scrollbar->set_visible(horizontal_scrollbar_should_be_visible);
+        m_vertical_scrollbar->set_visible(vertical_scrollbar_should_be_visible);
+    }
+}
+
 void AbstractScrollableWidget::set_content_size(Gfx::IntSize const& size)
 {
     if (m_content_size == size)
         return;
     m_content_size = size;
+    update_scrollbar_ranges();
+}
+
+void AbstractScrollableWidget::set_min_content_size(Gfx::IntSize const& min_size)
+{
+    if (m_min_content_size == min_size)
+        return;
+    m_min_content_size = min_size;
     update_scrollbar_ranges();
 }
 
@@ -300,5 +324,15 @@ Gfx::IntPoint AbstractScrollableWidget::to_widget_position(Gfx::IntPoint const& 
     widget_position.translate_by(-horizontal_scrollbar().value(), -vertical_scrollbar().value());
     widget_position.translate_by(frame_thickness(), frame_thickness());
     return widget_position;
+}
+
+Optional<UISize> AbstractScrollableWidget::calculated_min_size() const
+{
+    auto vertical_scrollbar_min_size = m_vertical_scrollbar->effective_min_size(),
+         horizontal_scrollbar_min_size = m_horizontal_scrollbar->effective_min_size();
+
+    return { UISize {
+        horizontal_scrollbar_min_size.width().regular_sum_with_verify(vertical_scrollbar_min_size.width()).regular_sum_with_verify(2 * frame_thickness()),
+        vertical_scrollbar_min_size.height().regular_sum_with_verify(horizontal_scrollbar_min_size.height()).regular_sum_with_verify(2 * frame_thickness()) } };
 }
 }

--- a/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
+++ b/Userland/Libraries/LibGUI/AbstractScrollableWidget.h
@@ -18,9 +18,12 @@ class AbstractScrollableWidget : public Frame {
 public:
     virtual ~AbstractScrollableWidget() override = default;
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
     Gfx::IntSize content_size() const { return m_content_size; }
     int content_width() const { return m_content_size.width(); }
     int content_height() const { return m_content_size.height(); }
+    Gfx::IntSize min_content_size() const { return m_min_content_size; }
 
     Gfx::IntRect visible_content_rect() const;
 
@@ -60,7 +63,7 @@ public:
 
     virtual Margins content_margins() const override;
 
-    void set_should_hide_unnecessary_scrollbars(bool b) { m_should_hide_unnecessary_scrollbars = b; }
+    void set_should_hide_unnecessary_scrollbars(bool);
     bool should_hide_unnecessary_scrollbars() const { return m_should_hide_unnecessary_scrollbars; }
 
     Gfx::IntPoint to_content_position(Gfx::IntPoint const& widget_position) const;
@@ -76,9 +79,12 @@ protected:
     virtual void mousewheel_event(MouseEvent&) override;
     virtual void did_scroll() { }
     void set_content_size(Gfx::IntSize const&);
+    void set_min_content_size(Gfx::IntSize const&);
     void set_size_occupied_by_fixed_elements(Gfx::IntSize const&);
     virtual void on_automatic_scrolling_timer_fired() {};
     int autoscroll_threshold() const { return m_autoscroll_threshold; }
+    void update_scrollbar_visibility();
+    void update_scrollbar_ranges();
 
 private:
     class AbstractScrollableWidgetScrollbar final : public Scrollbar {
@@ -100,13 +106,13 @@ private:
     };
     friend class ScrollableWidgetScrollbar;
 
-    void update_scrollbar_ranges();
     void handle_wheel_event(MouseEvent&, Widget&);
 
     RefPtr<AbstractScrollableWidgetScrollbar> m_vertical_scrollbar;
     RefPtr<AbstractScrollableWidgetScrollbar> m_horizontal_scrollbar;
     RefPtr<Widget> m_corner_widget;
     Gfx::IntSize m_content_size;
+    Gfx::IntSize m_min_content_size;
     Gfx::IntSize m_size_occupied_by_fixed_elements;
     bool m_scrollbars_enabled { true };
     bool m_should_hide_unnecessary_scrollbars { false };

--- a/Userland/Libraries/LibGUI/AbstractTableView.cpp
+++ b/Userland/Libraries/LibGUI/AbstractTableView.cpp
@@ -411,7 +411,7 @@ void AbstractTableView::layout_headers()
         int y = frame_thickness();
         int width = max(content_width(), rect().width() - frame_thickness() * 2 - row_header_width - vertical_scrollbar_width);
 
-        column_header().set_relative_rect(x, y, width, column_header().min_size().height());
+        column_header().set_relative_rect(x, y, width, column_header().effective_min_size().height().value_verify_regular());
     }
 
     if (row_header().is_visible()) {
@@ -422,7 +422,7 @@ void AbstractTableView::layout_headers()
         int y = frame_thickness() + column_header_height - vertical_scrollbar().value();
         int height = max(content_height(), rect().height() - frame_thickness() * 2 - column_header_height - horizontal_scrollbar_height);
 
-        row_header().set_relative_rect(x, y, row_header().min_size().width(), height);
+        row_header().set_relative_rect(x, y, row_header().effective_min_size().width().value_verify_regular(), height);
     }
 
     if (row_header().is_visible() && column_header().is_visible()) {

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -27,7 +27,7 @@ public:
     void set_tooltip(String const& tooltip)
     {
         m_label->set_text(Gfx::parse_ampersand_string(tooltip));
-        int tooltip_width = m_label->min_width() + 10;
+        int tooltip_width = m_label->effective_min_size().width().value_verify_regular() + 10;
         int line_count = m_label->text().count("\n");
         int glyph_height = m_label->font().glyph_height();
         int tooltip_height = glyph_height * (1 + line_count) + ((glyph_height + 1) / 2) * line_count + 8;

--- a/Userland/Libraries/LibGUI/Application.cpp
+++ b/Userland/Libraries/LibGUI/Application.cpp
@@ -31,6 +31,7 @@ public:
         int line_count = m_label->text().count("\n");
         int glyph_height = m_label->font().glyph_height();
         int tooltip_height = glyph_height * (1 + line_count) + ((glyph_height + 1) / 2) * line_count + 8;
+        set_obey_widget_min_size(false);
 
         Gfx::IntRect desktop_rect = Desktop::the().rect();
         if (tooltip_width > desktop_rect.width())

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2020, Andreas Kling <kling@serenityos.org>
+ * Copyright (c) 2022, Frhun <serenitystuff@frhun.de>
  *
  * SPDX-License-Identifier: BSD-2-Clause
  */
@@ -23,74 +24,118 @@ BoxLayout::BoxLayout(Orientation orientation)
         "orientation", [this] { return m_orientation == Gfx::Orientation::Vertical ? "Vertical" : "Horizontal"; }, nullptr);
 }
 
-Gfx::IntSize BoxLayout::preferred_size() const
+UISize BoxLayout::preferred_size() const
 {
-    Gfx::IntSize size;
-    size.set_primary_size_for_orientation(orientation(), preferred_primary_size());
-    size.set_secondary_size_for_orientation(orientation(), preferred_secondary_size());
-    return size;
-}
+    VERIFY(m_owner);
 
-int BoxLayout::preferred_primary_size() const
-{
-    auto widget = verify_cast<GUI::Widget>(parent());
-    int size = 0;
+    UIDimension result_primary { 0 };
+    UIDimension result_secondary { 0 };
 
+    bool first_item { true };
     for (auto& entry : m_entries) {
         if (!entry.widget || !entry.widget->is_visible())
             continue;
-        int preferred_primary_size = -1;
-        if (entry.widget->is_shrink_to_fit() && entry.widget->layout()) {
-            preferred_primary_size = entry.widget->layout()->preferred_size().primary_size_for_orientation(orientation());
+
+        UISize min_size = entry.widget->effective_min_size();
+        UISize max_size = entry.widget->max_size();
+        UISize preferred_size = entry.widget->effective_preferred_size();
+
+        if (result_primary != GUI::SpecialDimension::Grow) {
+            UIDimension item_primary_size = clamp(
+                preferred_size.primary_size_for_orientation(orientation()),
+                min_size.primary_size_for_orientation(orientation()),
+                max_size.primary_size_for_orientation(orientation()));
+
+            if (item_primary_size.is_regular_value())
+                result_primary.add_if_regular(item_primary_size.value_verify_regular());
+
+            if (item_primary_size.is_grow())
+                result_primary = SpecialDimension::Grow;
+
+            if (!first_item)
+                result_primary.add_if_regular(spacing());
         }
-        int item_size = max(0, preferred_primary_size);
-        int min_size = entry.widget->min_size().primary_size_for_orientation(orientation());
-        if (min_size != -1)
-            item_size = max(min_size, item_size);
-        int max_size = entry.widget->max_size().primary_size_for_orientation(orientation());
-        if (max_size != -1)
-            item_size = min(max_size, item_size);
-        size += item_size + spacing();
+
+        {
+            UIDimension secondary_preferred_size = preferred_size.secondary_size_for_orientation(orientation());
+
+            if (secondary_preferred_size == GUI::SpecialDimension::OpportunisticGrow)
+                secondary_preferred_size = 0;
+
+            UIDimension item_secondary_size = clamp(
+                secondary_preferred_size,
+                min_size.secondary_size_for_orientation(orientation()),
+                max_size.secondary_size_for_orientation(orientation()));
+
+            result_secondary = max(item_secondary_size, result_secondary);
+        }
+
+        first_item = false;
     }
-    if (size > 0)
-        size -= spacing();
 
-    auto content_margins = widget->content_margins();
+    result_primary.add_if_regular(
+        margins().primary_total_for_orientation(orientation())
+        + m_owner->content_margins().primary_total_for_orientation(orientation()));
+
+    result_secondary.add_if_regular(
+        margins().secondary_total_for_orientation(orientation())
+        + m_owner->content_margins().secondary_total_for_orientation(orientation()));
+
     if (orientation() == Gfx::Orientation::Horizontal)
-        size += margins().left() + margins().right() + content_margins.left() + content_margins.right();
+        return { result_primary, result_secondary };
     else
-        size += margins().top() + margins().bottom() + content_margins.top() + content_margins.bottom();
-
-    if (!size)
-        return -1;
-    return size;
+        return { result_secondary, result_primary };
 }
 
-int BoxLayout::preferred_secondary_size() const
+UISize BoxLayout::min_size() const
 {
-    auto widget = verify_cast<GUI::Widget>(parent());
-    int size = 0;
+    VERIFY(m_owner);
+
+    UIDimension result_primary { 0 };
+    UIDimension result_secondary { 0 };
+
+    bool first_item { true };
     for (auto& entry : m_entries) {
         if (!entry.widget || !entry.widget->is_visible())
             continue;
-        int min_size = entry.widget->min_size().secondary_size_for_orientation(orientation());
-        int preferred_secondary_size = -1;
-        if (entry.widget->is_shrink_to_fit() && entry.widget->layout()) {
-            preferred_secondary_size = entry.widget->layout()->preferred_size().secondary_size_for_orientation(orientation());
-            size = max(size, preferred_secondary_size);
+
+        UISize min_size = entry.widget->effective_min_size();
+
+        {
+            UIDimension primary_min_size = min_size.primary_size_for_orientation(orientation());
+
+            VERIFY(primary_min_size.is_one_of({ GUI::SpecialDimension::Shrink, GUI::SpecialDimension::Regular }));
+
+            if (primary_min_size.is_regular_value())
+                result_primary.add_if_regular(primary_min_size.value_verify_regular());
+
+            if (!first_item)
+                result_primary.add_if_regular(spacing());
         }
-        size = max(min_size, size);
+
+        {
+            UIDimension secondary_min_size = min_size.secondary_size_for_orientation(orientation());
+
+            VERIFY(secondary_min_size.is_one_of({ GUI::SpecialDimension::Shrink, GUI::SpecialDimension::Regular }));
+
+            result_secondary = max(result_secondary, secondary_min_size);
+        }
+
+        first_item = false;
     }
 
-    auto content_margins = widget->content_margins();
-    if (orientation() == Gfx::Orientation::Horizontal)
-        size += margins().top() + margins().bottom() + content_margins.top() + content_margins.bottom();
-    else
-        size += margins().left() + margins().right() + content_margins.left() + content_margins.right();
+    result_primary.add_if_regular(
+        margins().primary_total_for_orientation(orientation())
+        + m_owner->content_margins().primary_total_for_orientation(orientation()));
 
-    if (!size)
-        return -1;
-    return size;
+    result_secondary.add_if_regular(
+        margins().secondary_total_for_orientation(orientation())
+        + m_owner->content_margins().secondary_total_for_orientation(orientation()));
+
+    if (orientation() == Gfx::Orientation::Horizontal)
+        return { result_primary, result_secondary };
+    else
+        return { result_secondary, result_primary };
 }
 
 void BoxLayout::run(Widget& widget)
@@ -100,102 +145,215 @@ void BoxLayout::run(Widget& widget)
 
     struct Item {
         Widget* widget { nullptr };
-        int min_size { -1 };
-        int max_size { -1 };
+        UIDimension min_size { SpecialDimension::Shrink };
+        UIDimension max_size { SpecialDimension::Grow };
+        UIDimension preferred_size { SpecialDimension::Shrink };
         int size { 0 };
         bool final { false };
     };
 
     Vector<Item, 32> items;
+    int opportunistic_growth_item_count = 0;
+    int opportunistic_growth_items_base_size_total = 0;
 
     for (size_t i = 0; i < m_entries.size(); ++i) {
         auto& entry = m_entries[i];
         if (entry.type == Entry::Type::Spacer) {
-            items.append(Item { nullptr, -1, -1 });
+            items.append(Item { nullptr, { SpecialDimension::Shrink }, { SpecialDimension::Grow }, { SpecialDimension::Grow } });
             continue;
         }
         if (!entry.widget)
             continue;
         if (!entry.widget->is_visible())
             continue;
-        auto min_size = entry.widget->min_size();
-        auto max_size = entry.widget->max_size();
+        auto min_size = entry.widget->effective_min_size().primary_size_for_orientation(orientation());
+        auto max_size = entry.widget->max_size().primary_size_for_orientation(orientation());
+        auto preferred_size = entry.widget->effective_preferred_size().primary_size_for_orientation(orientation());
 
-        if (entry.widget->is_shrink_to_fit() && entry.widget->layout()) {
-            auto preferred_size = entry.widget->layout()->preferred_size();
-            min_size = max_size = preferred_size;
+        if (preferred_size == GUI::SpecialDimension::OpportunisticGrow) {
+            opportunistic_growth_item_count++;
+            opportunistic_growth_items_base_size_total += min_size.value_or_zero_if_shrink_with_verify();
+        } else {
+            preferred_size = clamp(preferred_size, min_size, max_size);
         }
 
-        items.append(Item { entry.widget.ptr(), min_size.primary_size_for_orientation(orientation()), max_size.primary_size_for_orientation(orientation()) });
+        items.append(
+            Item {
+                entry.widget.ptr(),
+                min_size,
+                max_size,
+                preferred_size });
     }
 
     if (items.is_empty())
         return;
 
     Gfx::IntRect content_rect = widget.content_rect();
-    int available_size = content_rect.size().primary_size_for_orientation(orientation()) - spacing() * (items.size() - 1);
-    int unfinished_items = items.size();
-
-    if (orientation() == Gfx::Orientation::Horizontal)
-        available_size -= margins().left() + margins().right();
-    else
-        available_size -= margins().top() + margins().bottom();
+    int uncommitted_size = content_rect.size().primary_size_for_orientation(orientation())
+        - spacing() * (items.size() - 1)
+        - margins().primary_total_for_orientation(orientation());
+    int unfinished_regular_items = items.size() - opportunistic_growth_item_count;
+    int max_amongst_the_min_sizes = 0;
+    int max_amongst_the_min_sizes_of_opportunistially_growing_items = 0;
+    int regular_items_to_layout = 0;
+    int regular_items_min_size_total = 0;
 
     // Pass 1: Set all items to their minimum size.
     for (auto& item : items) {
-        item.size = 0;
-        if (item.min_size >= 0)
-            item.size = item.min_size;
-        available_size -= item.size;
+        VERIFY(item.min_size.is_one_of({ GUI::SpecialDimension::Regular, GUI::SpecialDimension::Shrink }));
+        item.size = item.min_size.value_or_zero_if_shrink_with_verify();
+        uncommitted_size -= item.size;
 
-        if (item.min_size >= 0 && item.max_size >= 0 && item.min_size == item.max_size) {
+        if (item.min_size.is_regular_value() && item.max_size.is_regular_value() && item.min_size == item.max_size) {
             // Fixed-size items finish immediately in the first pass.
             item.final = true;
-            --unfinished_items;
+            if (item.preferred_size == GUI::SpecialDimension::OpportunisticGrow) {
+                opportunistic_growth_item_count--;
+                opportunistic_growth_items_base_size_total -= item.min_size.value_or_zero_if_shrink_with_verify();
+            } else {
+                --unfinished_regular_items;
+            }
+        } else if (item.preferred_size != GUI::SpecialDimension::OpportunisticGrow && item.widget) {
+            max_amongst_the_min_sizes = max(max_amongst_the_min_sizes, item.min_size.value_or_zero_if_shrink_with_verify());
+            regular_items_to_layout++;
+            regular_items_min_size_total += item.size;
+        } else if (item.preferred_size == GUI::SpecialDimension::OpportunisticGrow) {
+            max_amongst_the_min_sizes_of_opportunistially_growing_items = max(max_amongst_the_min_sizes_of_opportunistially_growing_items, item.min_size.value_or_zero_if_shrink_with_verify());
         }
     }
 
-    // Pass 2: Distribute remaining available size evenly, respecting each item's maximum size.
-    while (unfinished_items && available_size > 0) {
-        int slice = available_size / unfinished_items;
-        // If available_size does not divide evenly by unfinished_items,
+    // Pass 2: Set all non final, non spacer items to the previously encountered maximum min_size of these kind of items
+    // This is done to ensure even growth, if the items don't have the same min_size, which most won't have.
+    // If you are unsure what effect this has, try looking at widget gallery with, and without this, it'll be obvious.
+    if (uncommitted_size > 0) {
+        int total_growth_if_not_overcommitet = regular_items_to_layout * max_amongst_the_min_sizes - regular_items_min_size_total;
+        int overcommitment_if_all_same_min_size = total_growth_if_not_overcommitet - uncommitted_size;
+        for (auto& item : items) {
+            if (item.final || item.preferred_size == GUI::SpecialDimension::OpportunisticGrow || !item.widget)
+                continue;
+            int extra_needed_space = max_amongst_the_min_sizes - item.size;
+
+            if (overcommitment_if_all_same_min_size > 0) {
+                extra_needed_space -= (overcommitment_if_all_same_min_size * extra_needed_space + (total_growth_if_not_overcommitet - 1)) / (total_growth_if_not_overcommitet);
+            }
+
+            VERIFY(extra_needed_space >= 0);
+            VERIFY(uncommitted_size >= extra_needed_space);
+
+            item.size += extra_needed_space;
+            if (item.max_size.is_regular_value() && item.size > item.max_size.value_verify_regular())
+                item.size = item.max_size.value_verify_regular();
+            uncommitted_size -= item.size - item.min_size.value_or_zero_if_shrink_with_verify();
+        }
+    }
+
+    // Pass 3: Determine final item size for non spacers, and non opportunisticially growing widgets
+    int loop_counter = 0; // This doubles as a safegurad for when the loop below doesn't finish for some reason, and as a mechanism to ensure it runs at least once.
+    // This has to run at least once, to handle the case where the loop for evening out the min sizes was in a overcommited state,
+    // and gave the Widget a larger size than it's preferred size.
+    while (unfinished_regular_items && (uncommitted_size > 0 || loop_counter++ == 0)) {
+        VERIFY(loop_counter < 100);
+        int slice = uncommitted_size / unfinished_regular_items;
+        // If uncommitted_size does not divide evenly by unfinished_regular_items,
         // there are some extra pixels that have to be distributed.
-        int pixels = available_size - slice * unfinished_items;
-        available_size = 0;
+        int pixels = uncommitted_size - slice * unfinished_regular_items;
+        uncommitted_size = 0;
 
         for (auto& item : items) {
             if (item.final)
+                continue;
+            if (!item.widget)
+                continue;
+            if (item.preferred_size == GUI::SpecialDimension::OpportunisticGrow)
                 continue;
 
             int pixel = pixels ? 1 : 0;
             pixels -= pixel;
             int item_size_with_full_slice = item.size + slice + pixel;
-            item.size = item_size_with_full_slice;
 
-            if (item.max_size >= 0)
-                item.size = min(item.max_size, item_size_with_full_slice);
+            UIDimension resulting_size { 0 };
+            resulting_size = max(item.size, item_size_with_full_slice);
+            resulting_size = min(resulting_size, item.preferred_size);
+            resulting_size = min(resulting_size, item.max_size);
 
-            // If the slice was more than we needed, return remained to available_size.
-            int remainder_to_give_back = item_size_with_full_slice - item.size;
-            available_size += remainder_to_give_back;
-
-            if (item.max_size >= 0 && item.size == item.max_size) {
-                // We've hit the item's max size. Don't give it any more space.
+            if (resulting_size.is_shrink()) {
+                // FIXME: Propagate this error, so it is obvious where the mistake is actually made.
+                if (!item.min_size.is_regular_value())
+                    dbgln("BoxLayout: underconstrained widget set to zero size: {} {}", item.widget->class_name(), item.widget->name());
+                resulting_size = item.min_size.value_or_zero_if_shrink_with_verify();
                 item.final = true;
-                --unfinished_items;
+            }
+
+            if (resulting_size.is_grow())
+                resulting_size = item_size_with_full_slice;
+
+            item.size = resulting_size.value_verify_regular();
+
+            // If the slice was more than we needed, return remainder to available_size.
+            // Note that this will in some cases even return more than the slice size.
+            uncommitted_size += item_size_with_full_slice - item.size;
+
+            if (item.final
+                || (item.max_size.is_regular_value() && item.max_size.value_verify_regular() == item.size)
+                || (item.preferred_size.is_regular_value() && item.preferred_size.value_verify_regular() == item.size)) {
+                item.final = true;
+                --unfinished_regular_items;
             }
         }
     }
 
-    // Pass 3: Place the widgets.
+    // Pass 4: Even out min_size for oportunistically growing items, analogous to pass 2
+    if (uncommitted_size > 0 && opportunistic_growth_item_count > 0) {
+        int total_growth_if_not_overcommitet = opportunistic_growth_item_count * max_amongst_the_min_sizes_of_opportunistially_growing_items - opportunistic_growth_items_base_size_total;
+        int overcommitment_if_all_same_min_size = total_growth_if_not_overcommitet - uncommitted_size;
+        for (auto& item : items) {
+            if (item.final || item.preferred_size != GUI::SpecialDimension::OpportunisticGrow || !item.widget)
+                continue;
+            int extra_needed_space = max_amongst_the_min_sizes_of_opportunistially_growing_items - item.size;
+
+            if (overcommitment_if_all_same_min_size > 0 && total_growth_if_not_overcommitet > 0) {
+                extra_needed_space -= (overcommitment_if_all_same_min_size * extra_needed_space + (total_growth_if_not_overcommitet - 1)) / (total_growth_if_not_overcommitet);
+            }
+
+            VERIFY(extra_needed_space >= 0);
+            VERIFY(uncommitted_size >= extra_needed_space);
+
+            item.size += extra_needed_space;
+            if (item.max_size.is_regular_value() && item.size > item.max_size.value_verify_regular())
+                item.size = item.max_size.value_verify_regular();
+            uncommitted_size -= item.size - item.min_size.value_or_zero_if_shrink_with_verify();
+        }
+    }
+
+    loop_counter = 0;
+    // Pass 5: Determine the size for the opportunistically growing items.
+    while (opportunistic_growth_item_count > 0 && uncommitted_size > 0) {
+        VERIFY(loop_counter++ < 200);
+        int opportunistic_growth_item_extra_size = uncommitted_size / opportunistic_growth_item_count;
+        int pixels = uncommitted_size - opportunistic_growth_item_count * opportunistic_growth_item_extra_size;
+        VERIFY(pixels >= 0);
+        for (auto& item : items) {
+            if (item.preferred_size != GUI::SpecialDimension::OpportunisticGrow || item.final || !item.widget)
+                continue;
+
+            int pixel = (pixels > 0 ? 1 : 0);
+            pixels -= pixel;
+            int previous_size = item.size;
+            item.size += opportunistic_growth_item_extra_size + pixel;
+            if (item.max_size.is_regular_value() && item.size >= item.max_size.value_verify_regular()) {
+                item.size = item.max_size.value_verify_regular();
+                item.final = true;
+                opportunistic_growth_item_count--;
+            }
+            uncommitted_size -= item.size - previous_size;
+        }
+    }
+
+    // Pass 6: Place the widgets.
     int current_x = margins().left() + content_rect.x();
     int current_y = margins().top() + content_rect.y();
 
-    auto widget_rect_with_margins_subtracted = content_rect;
-    widget_rect_with_margins_subtracted.take_from_left(margins().left());
-    widget_rect_with_margins_subtracted.take_from_top(margins().top());
-    widget_rect_with_margins_subtracted.take_from_right(margins().right());
-    widget_rect_with_margins_subtracted.take_from_bottom(margins().bottom());
+    auto widget_rect_with_margins_subtracted = margins().applied_to(content_rect);
 
     for (auto& item : items) {
         Gfx::IntRect rect { current_x, current_y, 0, 0 };
@@ -204,17 +362,17 @@ void BoxLayout::run(Widget& widget)
 
         if (item.widget) {
             int secondary = widget.content_size().secondary_size_for_orientation(orientation());
-            if (orientation() == Gfx::Orientation::Horizontal)
-                secondary -= margins().top() + margins().bottom();
-            else
-                secondary -= margins().left() + margins().right();
+            secondary -= margins().secondary_total_for_orientation(orientation());
 
-            int min_secondary = item.widget->min_size().secondary_size_for_orientation(orientation());
-            int max_secondary = item.widget->max_size().secondary_size_for_orientation(orientation());
-            if (min_secondary >= 0)
-                secondary = max(secondary, min_secondary);
-            if (max_secondary >= 0)
-                secondary = min(secondary, max_secondary);
+            UIDimension min_secondary = item.widget->effective_min_size().secondary_size_for_orientation(orientation());
+            UIDimension max_secondary = item.widget->max_size().secondary_size_for_orientation(orientation());
+            UIDimension preferred_secondary = item.widget->effective_preferred_size().secondary_size_for_orientation(orientation());
+            if (preferred_secondary.is_regular_value())
+                secondary = min(secondary, preferred_secondary.value_verify_regular());
+            if (min_secondary.is_regular_value())
+                secondary = max(secondary, min_secondary.value_verify_regular());
+            if (max_secondary.is_regular_value())
+                secondary = min(secondary, max_secondary.value_verify_regular());
 
             rect.set_secondary_size_for_orientation(orientation(), secondary);
 

--- a/Userland/Libraries/LibGUI/BoxLayout.cpp
+++ b/Userland/Libraries/LibGUI/BoxLayout.cpp
@@ -153,6 +153,7 @@ void BoxLayout::run(Widget& widget)
     };
 
     Vector<Item, 32> items;
+    int spacer_count = 0;
     int opportunistic_growth_item_count = 0;
     int opportunistic_growth_items_base_size_total = 0;
 
@@ -160,6 +161,7 @@ void BoxLayout::run(Widget& widget)
         auto& entry = m_entries[i];
         if (entry.type == Entry::Type::Spacer) {
             items.append(Item { nullptr, { SpecialDimension::Shrink }, { SpecialDimension::Grow }, { SpecialDimension::Grow } });
+            spacer_count++;
             continue;
         }
         if (!entry.widget)
@@ -190,9 +192,9 @@ void BoxLayout::run(Widget& widget)
 
     Gfx::IntRect content_rect = widget.content_rect();
     int uncommitted_size = content_rect.size().primary_size_for_orientation(orientation())
-        - spacing() * (items.size() - 1)
+        - spacing() * (items.size() - 1 - spacer_count)
         - margins().primary_total_for_orientation(orientation());
-    int unfinished_regular_items = items.size() - opportunistic_growth_item_count;
+    int unfinished_regular_items = items.size() - spacer_count - opportunistic_growth_item_count;
     int max_amongst_the_min_sizes = 0;
     int max_amongst_the_min_sizes_of_opportunistially_growing_items = 0;
     int regular_items_to_layout = 0;
@@ -349,6 +351,12 @@ void BoxLayout::run(Widget& widget)
         }
     }
 
+    // Determine size of the spacers, according to the still uncommitted size
+    int spacer_width = 0;
+    if (spacer_count > 0 && uncommitted_size > 0) {
+        spacer_width = uncommitted_size / spacer_count;
+    }
+
     // Pass 6: Place the widgets.
     int current_x = margins().left() + content_rect.x();
     int current_y = margins().top() + content_rect.y();
@@ -382,12 +390,17 @@ void BoxLayout::run(Widget& widget)
                 rect.center_horizontally_within(widget_rect_with_margins_subtracted);
 
             item.widget->set_relative_rect(rect);
-        }
 
-        if (orientation() == Gfx::Orientation::Horizontal)
-            current_x += rect.width() + spacing();
-        else
-            current_y += rect.height() + spacing();
+            if (orientation() == Gfx::Orientation::Horizontal)
+                current_x += rect.width() + spacing();
+            else
+                current_y += rect.height() + spacing();
+        } else {
+            if (orientation() == Gfx::Orientation::Horizontal)
+                current_x += spacer_width;
+            else
+                current_y += spacer_width;
+        }
     }
 }
 

--- a/Userland/Libraries/LibGUI/BoxLayout.h
+++ b/Userland/Libraries/LibGUI/BoxLayout.h
@@ -22,15 +22,13 @@ public:
     Gfx::Orientation orientation() const { return m_orientation; }
 
     virtual void run(Widget&) override;
-    virtual Gfx::IntSize preferred_size() const override;
+    virtual UISize preferred_size() const override;
+    virtual UISize min_size() const override;
 
 protected:
     explicit BoxLayout(Gfx::Orientation);
 
 private:
-    int preferred_primary_size() const;
-    int preferred_secondary_size() const;
-
     Gfx::Orientation m_orientation;
 };
 

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -16,6 +16,7 @@
 #include <LibGfx/StylePainter.h>
 
 REGISTER_WIDGET(GUI, Button)
+REGISTER_WIDGET(GUI, DialogButton)
 
 namespace GUI {
 

--- a/Userland/Libraries/LibGUI/Button.cpp
+++ b/Userland/Libraries/LibGUI/Button.cpp
@@ -23,8 +23,8 @@ namespace GUI {
 Button::Button(String text)
     : AbstractButton(move(text))
 {
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ GUI::SpecialDimension::OpportunisticGrow, 22 });
     set_focus_policy(GUI::FocusPolicy::StrongFocus);
 
     on_focus_change = [this](bool has_focus, auto) {
@@ -251,6 +251,28 @@ void Button::timer_event(Core::TimerEvent&)
 
         update();
     }
+}
+
+Optional<UISize> Button::calculated_min_size() const
+{
+    int horizontal = 0, vertical = 0;
+
+    if (!text().is_empty()) {
+        auto& font = this->font();
+        horizontal = font.width(text()) + 2;
+        vertical = font.glyph_height() + 4; // FIXME: Use actual maximum total height
+    }
+
+    if (m_icon) {
+        vertical = max(vertical, m_icon->height());
+
+        horizontal += m_icon->width() + icon_spacing();
+    }
+
+    horizontal += 8;
+    vertical += 4;
+
+    return UISize(horizontal, vertical);
 }
 
 }

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -57,6 +57,8 @@ public:
     void set_mimic_pressed(bool mimic_pressed);
     bool is_mimic_pressed() const { return m_mimic_pressed; };
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
 protected:
     explicit Button(String text = {});
     virtual void mousedown_event(MouseEvent&) override;

--- a/Userland/Libraries/LibGUI/Button.h
+++ b/Userland/Libraries/LibGUI/Button.h
@@ -76,4 +76,16 @@ private:
     bool m_mimic_pressed { false };
 };
 
+class DialogButton final : public Button {
+    C_OBJECT(DialogButton);
+
+public:
+    virtual ~DialogButton() override {};
+    explicit DialogButton(String text = {})
+        : Button(text)
+    {
+        set_preferred_width(80);
+    }
+};
+
 }

--- a/Userland/Libraries/LibGUI/CheckBox.cpp
+++ b/Userland/Libraries/LibGUI/CheckBox.cpp
@@ -30,8 +30,8 @@ CheckBox::CheckBox(String text)
         { CheckBoxPosition::Left, "Left" },
         { CheckBoxPosition::Right, "Right" });
 
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 22, 22 });
+    set_preferred_size({ GUI::SpecialDimension::OpportunisticGrow, 22 });
 }
 
 void CheckBox::paint_event(PaintEvent& event)

--- a/Userland/Libraries/LibGUI/ColorInput.cpp
+++ b/Userland/Libraries/LibGUI/ColorInput.cpp
@@ -18,8 +18,8 @@ namespace GUI {
 ColorInput::ColorInput()
     : TextEditor(TextEditor::SingleLine)
 {
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ GUI::SpecialDimension::OpportunisticGrow, 22 });
     TextEditor::on_change = [this] {
         auto parsed_color = Color::from_string(text());
         if (parsed_color.has_value())

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -232,15 +232,13 @@ void ColorPicker::build_ui()
     button_container.layout()->set_spacing(4);
     button_container.layout()->add_spacer();
 
-    auto& ok_button = button_container.add<Button>();
-    ok_button.set_fixed_width(80);
+    auto& ok_button = button_container.add<DialogButton>();
     ok_button.set_text("OK");
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };
 
-    auto& cancel_button = button_container.add<Button>();
-    cancel_button.set_fixed_width(80);
+    auto& cancel_button = button_container.add<DialogButton>();
     cancel_button.set_text("Cancel");
     cancel_button.on_click = [this](auto) {
         done(ExecResult::Cancel);

--- a/Userland/Libraries/LibGUI/ComboBox.cpp
+++ b/Userland/Libraries/LibGUI/ComboBox.cpp
@@ -56,8 +56,8 @@ ComboBox::ComboBox()
     REGISTER_STRING_PROPERTY("placeholder", editor_placeholder, set_editor_placeholder);
     REGISTER_BOOL_PROPERTY("model_only", only_allow_values_from_model, set_only_allow_values_from_model);
 
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ GUI::SpecialDimension::OpportunisticGrow, 22 });
 
     m_editor = add<ComboBoxEditor>();
     m_editor->set_frame_thickness(0);

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -6,7 +6,7 @@
     }
 
     @GUI::Widget {
-        shrink_to_fit: true
+        preferred_width: 103
         layout: @GUI::VerticalBoxLayout {
             margins: [0, 4]
         }
@@ -19,7 +19,7 @@
 
         @GUI::Tray {
             name: "common_locations_tray"
-            fixed_width: 95
+            min_width: 60
         }
 
         @GUI::Label {
@@ -37,15 +37,18 @@
         layout: @GUI::VerticalBoxLayout {}
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::HorizontalBoxLayout {}
 
             @GUI::TextBox {
                 name: "location_textbox"
+                preferred_width: "opportunistic_grow"
+                min_width: 80
             }
 
             @GUI::Toolbar {
                 name: "toolbar"
+                preferred_width: "shrink"
             }
         }
 
@@ -54,7 +57,7 @@
         }
 
         @GUI::Widget {
-            shrink_to_fit: true
+            preferred_height: "fit"
             layout: @GUI::VerticalBoxLayout {}
 
             @GUI::Widget {

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -79,7 +79,7 @@
                 fixed_height: 22
                 layout: @GUI::HorizontalBoxLayout {}
 
-                @GUI::Widget {}
+                @GUI::Layout::Spacer {}
 
                 @GUI::DialogButton {
                     name: "cancel_button"

--- a/Userland/Libraries/LibGUI/FilePickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FilePickerDialog.gml
@@ -69,10 +69,9 @@
                     fixed_width: 20
                 }
 
-                @GUI::Button {
+                @GUI::DialogButton {
                     name: "ok_button"
                     text: "OK"
-                    fixed_width: 75
                 }
             }
 
@@ -82,10 +81,9 @@
 
                 @GUI::Widget {}
 
-                @GUI::Button {
+                @GUI::DialogButton {
                     name: "cancel_button"
                     text: "Cancel"
-                    fixed_width: 75
                 }
             }
         }

--- a/Userland/Libraries/LibGUI/FontPickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FontPickerDialog.gml
@@ -73,16 +73,14 @@
 
         @GUI::Widget {}
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "ok_button"
             text: "OK"
-            fixed_width: 80
         }
 
-        @GUI::Button {
+        @GUI::DialogButton {
             name: "cancel_button"
             text: "Cancel"
-            fixed_width: 80
         }
     }
 }

--- a/Userland/Libraries/LibGUI/FontPickerDialog.gml
+++ b/Userland/Libraries/LibGUI/FontPickerDialog.gml
@@ -6,9 +6,11 @@
 
     @GUI::Widget {
         layout: @GUI::HorizontalBoxLayout {}
+        min_height: 80
 
         @GUI::Widget {
             layout: @GUI::VerticalBoxLayout {}
+            min_width: 120
 
             @GUI::Label {
                 text: "Family:"
@@ -58,20 +60,22 @@
 
     @GUI::GroupBox {
         layout: @GUI::VerticalBoxLayout {}
+        margins: [0]
         title: "Sample text"
-        fixed_height: 80
+        preferred_height: 80
 
         @GUI::Label {
             name: "sample_text_label"
             text: "The quick brown fox jumps over the lazy dog."
+            preferred_height: "grow"
         }
     }
 
     @GUI::Widget {
-        fixed_height: 22
         layout: @GUI::HorizontalBoxLayout {}
+        preferred_height: "fit"
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::DialogButton {
             name: "ok_button"

--- a/Userland/Libraries/LibGUI/Forward.h
+++ b/Userland/Libraries/LibGUI/Forward.h
@@ -23,6 +23,7 @@ class CheckBox;
 class ComboBox;
 class Command;
 class CommandPalette;
+class DialogButton;
 class DragEvent;
 class DropEvent;
 class EditingEngine;

--- a/Userland/Libraries/LibGUI/GML/Parser.cpp
+++ b/Userland/Libraries/LibGUI/GML/Parser.cpp
@@ -42,64 +42,64 @@ static ErrorOr<NonnullRefPtr<Object>> parse_gml_object(Queue<Token>& tokens)
     auto class_name = tokens.dequeue();
     object->set_name(class_name.m_view);
 
-    if (peek() != Token::Type::LeftCurly)
-        return Error::from_string_literal("Expected {{"sv);
+    if (peek() == Token::Type::LeftCurly) {
 
-    tokens.dequeue();
+        tokens.dequeue();
 
-    NonnullRefPtrVector<Comment> pending_comments;
-    for (;;) {
-        if (peek() == Token::Type::RightCurly) {
-            // End of object
-            break;
+        NonnullRefPtrVector<Comment> pending_comments;
+        for (;;) {
+            if (peek() == Token::Type::RightCurly) {
+                // End of object
+                break;
+            }
+
+            if (peek() == Token::Type::ClassMarker) {
+                // It's a child object.
+
+                while (!pending_comments.is_empty())
+                    TRY(object->add_sub_object_child(pending_comments.take_last()));
+
+                TRY(object->add_sub_object_child(TRY(parse_gml_object(tokens))));
+            } else if (peek() == Token::Type::Identifier) {
+                // It's a property.
+
+                while (!pending_comments.is_empty())
+                    TRY(object->add_property_child(pending_comments.take_last()));
+
+                auto property_name = tokens.dequeue();
+
+                if (property_name.m_view.is_empty())
+                    return Error::from_string_literal("Expected non-empty property name"sv);
+
+                if (peek() != Token::Type::Colon)
+                    return Error::from_string_literal("Expected ':'"sv);
+
+                tokens.dequeue();
+
+                RefPtr<ValueNode> value;
+                if (peek() == Token::Type::ClassMarker)
+                    value = TRY(parse_gml_object(tokens));
+                else if (peek() == Token::Type::JsonValue)
+                    value = TRY(try_make_ref_counted<JsonValueNode>(TRY(JsonValueNode::from_string(tokens.dequeue().m_view))));
+
+                auto property = TRY(try_make_ref_counted<KeyValuePair>(property_name.m_view, value.release_nonnull()));
+                TRY(object->add_property_child(property));
+            } else if (peek() == Token::Type::Comment) {
+                pending_comments.append(TRY(Node::from_token<Comment>(tokens.dequeue())));
+            } else {
+                return Error::from_string_literal("Expected child, property, comment, or }}"sv);
+            }
         }
 
-        if (peek() == Token::Type::ClassMarker) {
-            // It's a child object.
+        // Insert any left-over comments as sub object children, as these will be serialized last
+        while (!pending_comments.is_empty())
+            TRY(object->add_sub_object_child(pending_comments.take_first()));
 
-            while (!pending_comments.is_empty())
-                TRY(object->add_sub_object_child(pending_comments.take_first()));
+        if (peek() != Token::Type::RightCurly)
+            return Error::from_string_literal("Expected }}"sv);
 
-            TRY(object->add_sub_object_child(TRY(parse_gml_object(tokens))));
-        } else if (peek() == Token::Type::Identifier) {
-            // It's a property.
-
-            while (!pending_comments.is_empty())
-                TRY(object->add_property_child(pending_comments.take_first()));
-
-            auto property_name = tokens.dequeue();
-
-            if (property_name.m_view.is_empty())
-                return Error::from_string_literal("Expected non-empty property name"sv);
-
-            if (peek() != Token::Type::Colon)
-                return Error::from_string_literal("Expected ':'"sv);
-
-            tokens.dequeue();
-
-            RefPtr<ValueNode> value;
-            if (peek() == Token::Type::ClassMarker)
-                value = TRY(parse_gml_object(tokens));
-            else if (peek() == Token::Type::JsonValue)
-                value = TRY(try_make_ref_counted<JsonValueNode>(TRY(JsonValueNode::from_string(tokens.dequeue().m_view))));
-
-            auto property = TRY(try_make_ref_counted<KeyValuePair>(property_name.m_view, value.release_nonnull()));
-            TRY(object->add_property_child(property));
-        } else if (peek() == Token::Type::Comment) {
-            pending_comments.append(TRY(Node::from_token<Comment>(tokens.dequeue())));
-        } else {
-            return Error::from_string_literal("Expected child, property, comment, or }}"sv);
-        }
+        tokens.dequeue();
     }
-
-    // Insert any left-over comments as sub object children, as these will be serialized last
-    while (!pending_comments.is_empty())
-        TRY(object->add_sub_object_child(pending_comments.take_first()));
-
-    if (peek() != Token::Type::RightCurly)
-        return Error::from_string_literal("Expected }}"sv);
-
-    tokens.dequeue();
 
     return object;
 }

--- a/Userland/Libraries/LibGUI/InputBox.cpp
+++ b/Userland/Libraries/LibGUI/InputBox.cpp
@@ -73,7 +73,7 @@ void InputBox::build(InputType input_type)
         m_text_editor->set_placeholder(m_placeholder);
 
     auto& button_container_outer = widget.add<Widget>();
-    button_container_outer.set_fixed_height(22);
+    button_container_outer.set_preferred_height(SpecialDimension::Fit);
     button_container_outer.set_layout<VerticalBoxLayout>();
 
     auto& button_container_inner = button_container_outer.add<Widget>();

--- a/Userland/Libraries/LibGUI/Label.cpp
+++ b/Userland/Libraries/LibGUI/Label.cpp
@@ -23,6 +23,8 @@ Label::Label(String text)
     REGISTER_TEXT_ALIGNMENT_PROPERTY("text_alignment", text_alignment, set_text_alignment);
     REGISTER_TEXT_WRAPPING_PROPERTY("text_wrapping", text_wrapping, set_text_wrapping);
 
+    set_preferred_size({ SpecialDimension::OpportunisticGrow, 22 });
+
     set_frame_thickness(0);
     set_frame_shadow(Gfx::FrameShadow::Plain);
     set_frame_shape(Gfx::FrameShape::NoFrame);
@@ -112,10 +114,15 @@ void Label::size_to_fit()
     set_fixed_width(font().width(m_text) + m_autosize_padding * 2);
 }
 
-int Label::preferred_height() const
+int Label::text_calculated_preferred_height() const
 {
     // FIXME: The 4 is taken from Gfx::Painter and should be available as
     //        a constant instead.
     return Gfx::TextLayout(&font(), Utf8View { m_text }, text_rect()).bounding_rect(Gfx::TextWrapping::Wrap, 4).height();
+}
+
+Optional<UISize> Label::calculated_preferred_size() const
+{
+    return GUI::UISize(SpecialDimension::Grow, text_calculated_preferred_height());
 }
 }

--- a/Userland/Libraries/LibGUI/Label.h
+++ b/Userland/Libraries/LibGUI/Label.h
@@ -39,7 +39,8 @@ public:
     bool is_autosize() const { return m_autosize; }
     void set_autosize(bool, size_t padding = 0);
 
-    int preferred_height() const;
+    virtual Optional<UISize> calculated_preferred_size() const override;
+    int text_calculated_preferred_height() const;
 
     Gfx::IntRect text_rect() const;
 

--- a/Userland/Libraries/LibGUI/Layout.h
+++ b/Userland/Libraries/LibGUI/Layout.h
@@ -12,6 +12,7 @@
 #include <LibCore/Object.h>
 #include <LibGUI/Forward.h>
 #include <LibGUI/Margins.h>
+#include <LibGUI/UIDimensions.h>
 #include <LibGfx/Forward.h>
 
 namespace Core {
@@ -48,7 +49,8 @@ public:
     void remove_widget(Widget&);
 
     virtual void run(Widget&) = 0;
-    virtual Gfx::IntSize preferred_size() const = 0;
+    virtual UISize preferred_size() const = 0;
+    virtual UISize min_size() const = 0;
 
     void notify_adopted(Badge<Widget>, Widget&);
     void notify_disowned(Badge<Widget>, Widget&);

--- a/Userland/Libraries/LibGUI/Margins.h
+++ b/Userland/Libraries/LibGUI/Margins.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <LibGfx/Orientation.h>
 #include <LibGfx/Rect.h>
 
 namespace GUI {
@@ -76,6 +77,22 @@ public:
     Margins operator+(Margins const& other) const
     {
         return Margins { top() + other.top(), right() + other.right(), bottom() + other.bottom(), left() + other.left() };
+    }
+
+    [[nodiscard]] int primary_total_for_orientation(Gfx::Orientation const orientation) const
+    {
+        if (orientation == Gfx::Orientation::Horizontal)
+            return m_left + m_right;
+        else
+            return m_top + m_bottom;
+    }
+
+    [[nodiscard]] int secondary_total_for_orientation(Gfx::Orientation const orientation) const
+    {
+        if (orientation == Gfx::Orientation::Vertical)
+            return m_left + m_right;
+        else
+            return m_top + m_bottom;
     }
 
 private:

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -176,7 +176,8 @@ void MessageBox::build()
     int width = (button_count * button_width) + ((button_count - 1) * button_container.layout()->spacing()) + 32;
     width = max(width, text_width + icon_width + 56);
 
-    set_rect(x(), y(), width, 80 + label.max_height());
+    // FIXME: Use shrink from new layout system
+    set_rect(x(), y(), width, 80 + label.preferred_height());
     set_resizable(false);
 }
 

--- a/Userland/Libraries/LibGUI/MessageBox.cpp
+++ b/Userland/Libraries/LibGUI/MessageBox.cpp
@@ -177,7 +177,7 @@ void MessageBox::build()
     width = max(width, text_width + icon_width + 56);
 
     // FIXME: Use shrink from new layout system
-    set_rect(x(), y(), width, 80 + label.preferred_height());
+    set_rect(x(), y(), width, 80 + label.text_calculated_preferred_height());
     set_resizable(false);
 }
 

--- a/Userland/Libraries/LibGUI/PasswordInputDialog.gml
+++ b/Userland/Libraries/LibGUI/PasswordInputDialog.gml
@@ -68,7 +68,7 @@
             }
         }
 
-        @GUI::Widget {}
+        @GUI::Layout::Spacer {}
 
         @GUI::Widget {
             shrink_to_fit: true

--- a/Userland/Libraries/LibGUI/RadioButton.cpp
+++ b/Userland/Libraries/LibGUI/RadioButton.cpp
@@ -21,8 +21,8 @@ RadioButton::RadioButton(String text)
 {
     set_exclusive(true);
     set_checkable(true);
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 22, 22 });
+    set_preferred_size({ GUI::SpecialDimension::OpportunisticGrow, 22 });
 }
 
 Gfx::IntSize RadioButton::circle_size()
@@ -59,6 +59,15 @@ void RadioButton::click(unsigned)
     if (!is_enabled())
         return;
     set_checked(true);
+}
+
+Optional<UISize> RadioButton::calculated_min_size() const
+{
+    int horizontal = 2 + 7, vertical = 0;
+    auto& font = this->font();
+    vertical = max(font.glyph_height(), circle_size().height());
+    horizontal += font.width(text());
+    return UISize(horizontal, vertical);
 }
 
 }

--- a/Userland/Libraries/LibGUI/RadioButton.h
+++ b/Userland/Libraries/LibGUI/RadioButton.h
@@ -19,6 +19,8 @@ public:
 
     virtual void click(unsigned modifiers = 0) override;
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
 protected:
     explicit RadioButton(String text = {});
     virtual void paint_event(PaintEvent&) override;

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -37,31 +37,25 @@ void ScrollableContainerWidget::update_widget_size()
     if (!m_widget)
         return;
     m_widget->do_layout();
-    auto new_size = Widget::content_size();
-
-    if (m_widget->layout()) {
+    if (m_widget->is_shrink_to_fit() && m_widget->layout()) {
+        auto new_size = Widget::content_size();
         auto preferred_size = m_widget->layout()->preferred_size();
-        if (m_widget->is_shrink_to_fit()) {
-            if (preferred_size.width() != -1)
-                new_size.set_width(preferred_size.width());
-            if (preferred_size.height() != -1)
-                new_size.set_height(preferred_size.height());
-        } else {
-            new_size = Gfx::Size {
-                max(new_size.width(), preferred_size.width()),
-                max(new_size.height(), preferred_size.height())
-            };
-        }
+        if (preferred_size.width().is_regular_value())
+            new_size.set_width(preferred_size.width().value_verify_regular());
+        if (preferred_size.height().is_regular_value())
+            new_size.set_height(preferred_size.height().value_verify_regular());
+        m_widget->resize(new_size);
+        set_content_size(new_size);
+    } else {
+        auto inner_size = Widget::content_size();
+        auto min_size = m_widget->min_size();
+        auto new_size = Gfx::Size {
+            max(inner_size.width(), min_size.width().value_verify_regular()),
+            max(inner_size.height(), min_size.height().value_verify_regular())
+        };
+        m_widget->resize(new_size);
+        set_content_size(new_size);
     }
-
-    auto min_size = m_widget->min_size();
-    new_size = Gfx::Size {
-        max(new_size.width(), min_size.width()),
-        max(new_size.height(), min_size.height()),
-    };
-
-    m_widget->resize(new_size);
-    set_content_size(new_size);
 }
 
 void ScrollableContainerWidget::resize_event(GUI::ResizeEvent& event)

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -48,10 +48,10 @@ void ScrollableContainerWidget::update_widget_size()
         set_content_size(new_size);
     } else {
         auto inner_size = Widget::content_size();
-        auto min_size = m_widget->min_size();
+        auto min_size = m_widget->effective_min_size();
         auto new_size = Gfx::Size {
-            max(inner_size.width(), min_size.width().value_verify_regular()),
-            max(inner_size.height(), min_size.height().value_verify_regular())
+            max(inner_size.width(), min_size.width().value_or_zero_if_shrink_with_verify()),
+            max(inner_size.height(), min_size.height().value_or_zero_if_shrink_with_verify())
         };
         m_widget->resize(new_size);
         set_content_size(new_size);

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.cpp
@@ -58,11 +58,29 @@ void ScrollableContainerWidget::update_widget_size()
     }
 }
 
+void ScrollableContainerWidget::update_widget_min_size()
+{
+    if (!m_widget)
+        set_min_content_size({});
+
+    set_min_content_size(Gfx::IntSize(m_widget->effective_min_size().replace_component_if_matching_with(SpecialDimension::Shrink, UISize { 0, 0 })));
+}
+
 void ScrollableContainerWidget::resize_event(GUI::ResizeEvent& event)
 {
     AbstractScrollableWidget::resize_event(event);
-    update_widget_position();
     update_widget_size();
+    update_widget_position();
+}
+
+void ScrollableContainerWidget::layout_relevant_change_occured()
+{
+    update_widget_min_size();
+    update_scrollbar_visibility();
+    update_scrollbar_ranges();
+    update_widget_size();
+    update_widget_position();
+    update();
 }
 
 void ScrollableContainerWidget::set_widget(GUI::Widget* widget)
@@ -79,6 +97,7 @@ void ScrollableContainerWidget::set_widget(GUI::Widget* widget)
         add_child(*m_widget);
         m_widget->move_to_back();
     }
+    update_widget_min_size();
     update_widget_size();
     update_widget_position();
 }

--- a/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
+++ b/Userland/Libraries/LibGUI/ScrollableContainerWidget.h
@@ -24,10 +24,12 @@ public:
 protected:
     virtual void did_scroll() override;
     virtual void resize_event(GUI::ResizeEvent&) override;
+    virtual void layout_relevant_change_occured() override;
 
 private:
     void update_widget_size();
     void update_widget_position();
+    void update_widget_min_size();
     virtual bool load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, RefPtr<Core::Object> (*unregistered_child_handler)(String const&)) override;
 
     ScrollableContainerWidget();

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -206,8 +206,7 @@ void Scrollbar::paint_event(PaintEvent& event)
         hovered_component_for_painting = Component::None;
 
     painter.fill_rect_with_dither_pattern(rect(), palette().button().lightened(1.3f), palette().button());
-    if (m_gutter_click_state != GutterClickState::NotPressed && has_scrubber() && hovered_component_for_painting == Component::Gutter) {
-        VERIFY(!scrubber_rect().is_null());
+    if (m_gutter_click_state != GutterClickState::NotPressed && has_scrubber() && !scrubber_rect().is_null() && hovered_component_for_painting == Component::Gutter) {
         Gfx::IntRect rect_to_fill = rect();
         if (orientation() == Orientation::Vertical) {
             if (m_gutter_click_state == GutterClickState::BeforeScrubber) {

--- a/Userland/Libraries/LibGUI/Scrollbar.cpp
+++ b/Userland/Libraries/LibGUI/Scrollbar.cpp
@@ -76,11 +76,7 @@ Scrollbar::Scrollbar(Orientation orientation)
 {
     m_automatic_scrolling_timer = add<Core::Timer>();
 
-    if (orientation == Orientation::Vertical) {
-        set_fixed_width(16);
-    } else {
-        set_fixed_height(16);
-    }
+    set_preferred_size({ GUI::SpecialDimension::Fit });
 
     m_automatic_scrolling_timer->set_interval(100);
     m_automatic_scrolling_timer->on_timeout = [this] {
@@ -443,6 +439,22 @@ void Scrollbar::update_animated_scroll()
     double new_distance = initial_distance * ease_percent;
     int new_value = m_start_value + (int)round(new_distance);
     AbstractSlider::set_value(new_value);
+}
+
+Optional<UISize> Scrollbar::calculated_min_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { default_button_size(), 2 * default_button_size() } };
+    else
+        return { { 2 * default_button_size(), default_button_size() } };
+}
+
+Optional<UISize> Scrollbar::calculated_preferred_size() const
+{
+    if (orientation() == Gfx::Orientation::Vertical)
+        return { { GUI::SpecialDimension::Shrink, GUI::SpecialDimension::Grow } };
+    else
+        return { { GUI::SpecialDimension::Grow, GUI::SpecialDimension::Shrink } };
 }
 
 }

--- a/Userland/Libraries/LibGUI/Scrollbar.h
+++ b/Userland/Libraries/LibGUI/Scrollbar.h
@@ -40,6 +40,9 @@ public:
     virtual void increase_slider_by_steps(int steps) override { set_target_value(m_target_value + step() * steps); }
     virtual void decrease_slider_by_steps(int steps) override { set_target_value(m_target_value - step() * steps); }
 
+    virtual Optional<UISize> calculated_min_size() const override;
+    virtual Optional<UISize> calculated_preferred_size() const override;
+
     enum Component {
         None,
         DecrementButton,

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -41,7 +41,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
     window->m_tab_widget = TRY(main_widget->try_add<GUI::TabWidget>());
 
     auto button_container = TRY(main_widget->try_add<GUI::Widget>());
-    button_container->set_shrink_to_fit(true);
+    button_container->set_preferred_size({ SpecialDimension::Grow, SpecialDimension::Fit });
     (void)TRY(button_container->try_set_layout<GUI::HorizontalBoxLayout>());
     button_container->layout()->set_spacing(6);
 

--- a/Userland/Libraries/LibGUI/SettingsWindow.cpp
+++ b/Userland/Libraries/LibGUI/SettingsWindow.cpp
@@ -46,8 +46,7 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
     button_container->layout()->set_spacing(6);
 
     if (show_defaults_button == ShowDefaultsButton::Yes) {
-        window->m_reset_button = TRY(button_container->try_add<GUI::Button>("Defaults"));
-        window->m_reset_button->set_fixed_width(75);
+        window->m_reset_button = TRY(button_container->try_add<GUI::DialogButton>("Defaults"));
         window->m_reset_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
             window->reset_default_values();
         };
@@ -55,22 +54,19 @@ ErrorOr<NonnullRefPtr<SettingsWindow>> SettingsWindow::create(String title, Show
 
     TRY(button_container->layout()->try_add_spacer());
 
-    window->m_ok_button = TRY(button_container->try_add<GUI::Button>("OK"));
-    window->m_ok_button->set_fixed_width(75);
+    window->m_ok_button = TRY(button_container->try_add<GUI::DialogButton>("OK"));
     window->m_ok_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
         window->apply_settings();
         GUI::Application::the()->quit();
     };
 
-    window->m_cancel_button = TRY(button_container->try_add<GUI::Button>("Cancel"));
-    window->m_cancel_button->set_fixed_width(75);
+    window->m_cancel_button = TRY(button_container->try_add<GUI::DialogButton>("Cancel"));
     window->m_cancel_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
         window->cancel_settings();
         GUI::Application::the()->quit();
     };
 
-    window->m_apply_button = TRY(button_container->try_add<GUI::Button>("Apply"));
-    window->m_apply_button->set_fixed_width(75);
+    window->m_apply_button = TRY(button_container->try_add<GUI::DialogButton>("Apply"));
     window->m_apply_button->on_click = [window = window->make_weak_ptr<SettingsWindow>()](auto) mutable {
         window->apply_settings();
     };

--- a/Userland/Libraries/LibGUI/SpinBox.cpp
+++ b/Userland/Libraries/LibGUI/SpinBox.cpp
@@ -15,8 +15,8 @@ namespace GUI {
 
 SpinBox::SpinBox()
 {
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ GUI::SpecialDimension::OpportunisticGrow, 22 });
     m_editor = add<TextBox>();
     m_editor->set_text("0");
     m_editor->on_change = [this, weak_this = make_weak_ptr()] {

--- a/Userland/Libraries/LibGUI/Splitter.cpp
+++ b/Userland/Libraries/LibGUI/Splitter.cpp
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include "UIDimensions.h"
 #include <LibGUI/BoxLayout.h>
 #include <LibGUI/Painter.h>
 #include <LibGUI/Splitter.h>
@@ -190,6 +191,7 @@ void Splitter::recompute_grabbables()
         set_hovered_grabbable(&m_grabbables[old_hovered_index.value()]);
 }
 
+// FIXME: Respect the child widgets min and max sizes
 void Splitter::mousemove_event(MouseEvent& event)
 {
     auto* grabbable = grabbable_at(event.position());
@@ -222,11 +224,27 @@ void Splitter::mousemove_event(MouseEvent& event)
     }
 
     if (m_orientation == Orientation::Horizontal) {
-        m_first_resizee->set_fixed_width(fixed_resizee() == FixedResizee::First ? new_first_resizee_size.width() : -1);
-        m_second_resizee->set_fixed_width(fixed_resizee() == FixedResizee::Second ? new_second_resizee_size.width() : -1);
+        if (fixed_resizee() == FixedResizee::First) {
+            m_first_resizee->set_fixed_width(new_first_resizee_size.width());
+            m_second_resizee->set_min_width(SpecialDimension::Shrink);
+            m_second_resizee->set_max_width(SpecialDimension::Grow);
+        } else {
+            VERIFY(fixed_resizee() == FixedResizee::Second);
+            m_second_resizee->set_fixed_width(new_second_resizee_size.width());
+            m_first_resizee->set_min_width(SpecialDimension::Shrink);
+            m_first_resizee->set_max_width(SpecialDimension::Grow);
+        }
     } else {
-        m_first_resizee->set_fixed_height(fixed_resizee() == FixedResizee::First ? new_first_resizee_size.height() : -1);
-        m_second_resizee->set_fixed_height(fixed_resizee() == FixedResizee::Second ? new_second_resizee_size.height() : -1);
+        if (fixed_resizee() == FixedResizee::First) {
+            m_first_resizee->set_fixed_height(new_first_resizee_size.height());
+            m_second_resizee->set_min_height(SpecialDimension::Shrink);
+            m_second_resizee->set_max_height(SpecialDimension::Grow);
+        } else {
+            VERIFY(fixed_resizee() == FixedResizee::Second);
+            m_second_resizee->set_fixed_height(new_second_resizee_size.height());
+            m_first_resizee->set_min_height(SpecialDimension::Shrink);
+            m_first_resizee->set_max_height(SpecialDimension::Grow);
+        }
     }
 
     invalidate_layout();
@@ -253,8 +271,10 @@ void Splitter::custom_layout()
                 break;
             }
         }
-        if (!has_child_to_fill_space)
-            child_widgets.last().set_fixed_size({ -1, -1 });
+        if (!has_child_to_fill_space) {
+            child_widgets.last().set_preferred_size(SpecialDimension::Grow);
+            child_widgets.last().set_max_size(SpecialDimension::Grow);
+        }
     }
 }
 

--- a/Userland/Libraries/LibGUI/Statusbar.cpp
+++ b/Userland/Libraries/LibGUI/Statusbar.cpp
@@ -62,9 +62,10 @@ void Statusbar::update_segment(size_t index)
             segment.set_fixed_width(width);
         }
     } else if (segment.mode() == Segment::Mode::Fixed) {
-        if (segment.max_width() != -1)
-            segment.set_restored_width(segment.max_width());
-        segment.set_fixed_width(segment.max_width());
+        if (segment.max_width().is_regular_value()) {
+            segment.set_restored_width(segment.max_width().value_verify_regular());
+            segment.set_fixed_width(segment.max_width());
+        }
     }
 
     if (segment.override_text().is_null()) {
@@ -84,7 +85,7 @@ void Statusbar::update_segment(size_t index)
         segment.set_text(segment.override_text());
         segment.set_frame_shape(Gfx::FrameShape::NoFrame);
         if (segment.mode() != Segment::Mode::Proportional)
-            segment.set_fixed_width(-1);
+            segment.set_fixed_width(GUI::SpecialDimension::Grow);
     }
 }
 

--- a/Userland/Libraries/LibGUI/TextBox.cpp
+++ b/Userland/Libraries/LibGUI/TextBox.cpp
@@ -18,8 +18,8 @@ namespace GUI {
 TextBox::TextBox()
     : TextEditor(TextEditor::SingleLine)
 {
-    set_min_width(32);
-    set_fixed_height(22);
+    set_min_size({ 40, 22 });
+    set_preferred_size({ GUI::SpecialDimension::OpportunisticGrow, 22 });
 }
 
 void TextBox::keydown_event(GUI::KeyEvent& event)

--- a/Userland/Libraries/LibGUI/TextEditor.cpp
+++ b/Userland/Libraries/LibGUI/TextEditor.cpp
@@ -743,6 +743,17 @@ void TextEditor::paint_event(PaintEvent& event)
         painter.fill_rect(cursor_content_rect(), palette().text_cursor());
 }
 
+Optional<UISize> TextEditor::calculated_min_size() const
+{
+    auto margins = content_margins();
+    int horizontal = margins.left() + margins.right(),
+        vertical = margins.top() + margins.bottom();
+    int vertical_content_size = font().glyph_height() + 4;
+    if (!is_multi_line() && m_icon)
+        vertical_content_size = max(vertical_content_size, icon_size() + 2);
+    return UISize(horizontal, vertical);
+}
+
 void TextEditor::select_all()
 {
     TextPosition start_of_document { 0, 0 };

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -224,6 +224,8 @@ public:
     Optional<size_t> search_result_index() const { return m_search_result_index; }
     Vector<TextRange> const& search_results() const { return m_search_results; }
 
+    virtual Optional<UISize> calculated_min_size() const override;
+
 protected:
     explicit TextEditor(Type = Type::MultiLine);
 

--- a/Userland/Libraries/LibGUI/Toolbar.cpp
+++ b/Userland/Libraries/LibGUI/Toolbar.cpp
@@ -133,4 +133,13 @@ void Toolbar::paint_event(PaintEvent& event)
     painter.fill_rect(event.rect(), palette().button());
 }
 
+Optional<UISize> Toolbar::calculated_preferred_size() const
+{
+    if (m_orientation == Gfx::Orientation::Horizontal)
+        return { { GUI::SpecialDimension::Grow, GUI::SpecialDimension::Fit } };
+    else
+        return { { GUI::SpecialDimension::Fit, GUI::SpecialDimension::Grow } };
+    VERIFY_NOT_REACHED();
+}
+
 }

--- a/Userland/Libraries/LibGUI/Toolbar.h
+++ b/Userland/Libraries/LibGUI/Toolbar.h
@@ -27,6 +27,8 @@ public:
     bool has_frame() const { return m_has_frame; }
     void set_has_frame(bool has_frame) { m_has_frame = has_frame; }
 
+    virtual Optional<UISize> calculated_preferred_size() const override;
+
 protected:
     explicit Toolbar(Gfx::Orientation = Gfx::Orientation::Horizontal, int button_size = 16);
 

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2022, Frhun <serenitystuff@frhun.de>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include <AK/JsonValue.h>
+#include <AK/Optional.h>
+#include <LibGfx/Rect.h>
+#include <LibGfx/Size.h>
+#include <initializer_list>
+
+namespace GUI {
+
+// The constants used for special values
+// Their order here, also defines their order among each other for min, max; operations, excluding Regular
+enum class SpecialDimension : int {
+    Regular = 0, // only really useful for is_one_of
+    Grow = -1,
+    OpportunisticGrow = -2,
+    Fit = -3,
+    Shrink = -4,
+};
+
+class UIDimension {
+
+    friend constexpr auto AK::max<GUI::UIDimension>(const GUI::UIDimension&, const GUI::UIDimension&) -> GUI::UIDimension;
+    friend constexpr auto AK::min<GUI::UIDimension>(const GUI::UIDimension&, const GUI::UIDimension&) -> GUI::UIDimension;
+
+private:
+    int m_value;
+
+public:
+    UIDimension() = delete;
+
+    UIDimension(int value)
+    {
+        VERIFY(value >= 0);
+        m_value = value;
+    }
+
+    UIDimension(SpecialDimension special)
+        : m_value { int(special) }
+    {
+    }
+
+    [[nodiscard]] inline bool is_special_value() const
+    {
+        return m_value < 0;
+    }
+
+    [[nodiscard]] inline bool is_regular_value() const
+    {
+        return m_value >= 0;
+    }
+
+    [[nodiscard]] inline bool is_shrink() const
+    {
+        return m_value == int(SpecialDimension::Shrink);
+    }
+
+    [[nodiscard]] inline bool is_grow() const
+    {
+        return m_value == int(SpecialDimension::Grow);
+    }
+
+    [[nodiscard]] inline bool is_opportunistic_grow() const
+    {
+        return m_value == int(SpecialDimension::OpportunisticGrow);
+    }
+
+    [[nodiscard]] inline bool is_fit() const
+    {
+        return m_value == int(SpecialDimension::Fit);
+    }
+
+    [[nodiscard]] inline bool is_one_of(std::initializer_list<SpecialDimension> valid_values)
+    {
+        for (SpecialDimension v : valid_values) {
+            if (m_value == int(v) || (v == SpecialDimension::Regular && is_regular_value()))
+                return true;
+        }
+        return false;
+    }
+
+    [[nodiscard]] inline bool operator==(UIDimension const& other) const
+    {
+        return m_value == other.m_value;
+    }
+
+    [[nodiscard]] inline UIDimension regular_sum_with_verify(UIDimension const& other) const
+    {
+        VERIFY(is_regular_value() && other.is_regular_value());
+        return UIDimension { m_value + other.m_value };
+    }
+
+    inline void add_to_regular_with_verify(int to_add)
+    {
+        VERIFY(is_regular_value());
+        VERIFY(m_value >= -to_add);
+        m_value += to_add;
+    }
+
+    inline void add_if_regular(int to_add)
+    {
+        if (is_regular_value()) {
+            m_value += to_add;
+        }
+    }
+
+    [[nodiscard]] inline int value_or_zero_if_shrink_with_verify() const
+    {
+        if (m_value >= 0)
+            return m_value;
+        if (m_value == int(SpecialDimension::Shrink))
+            return 0;
+        VERIFY_NOT_REACHED();
+    }
+
+    [[nodiscard]] inline int value_verify_regular() const
+    {
+        VERIFY(is_regular_value());
+        return m_value;
+    }
+
+    [[nodiscard]] AK::JsonValue as_json_value() const
+    {
+        if (is_regular_value())
+            return m_value;
+        else {
+            if (is_shrink())
+                return "shrink";
+            else if (is_grow())
+                return "grow";
+            else if (is_opportunistic_grow())
+                return "opportunistic_grow";
+            else if (is_fit())
+                return "fit";
+            else
+                VERIFY_NOT_REACHED();
+        }
+    }
+
+    [[nodiscard]] static Optional<UIDimension> construct_from_json_value(AK::JsonValue const value)
+    {
+        if (value.is_string()) {
+            String value_literal = value.as_string();
+            if (value_literal == "shrink")
+                return UIDimension { SpecialDimension::Shrink };
+            else if (value_literal == "grow")
+                return UIDimension { SpecialDimension::Grow };
+            else if (value_literal == "opportunistic_grow")
+                return UIDimension { SpecialDimension::OpportunisticGrow };
+            else if (value_literal == "fit")
+                return UIDimension { SpecialDimension::Fit };
+            else
+                return {};
+        } else {
+            int value_int = value.to_i32();
+            if (value_int < 0)
+                return {};
+            return UIDimension(value_int);
+        }
+    }
+};
+
+class UISize : public Gfx::Size<UIDimension> {
+
+public:
+    UISize() = delete;
+
+    UISize(int in_width, int in_height)
+        : Gfx::Size<UIDimension>(in_width, in_height)
+    {
+        VERIFY(width().is_regular_value() && height().is_regular_value());
+    }
+
+    UISize(Gfx::IntSize size)
+        : UISize(size.width(), size.height())
+    {
+    }
+
+    UISize(SpecialDimension special)
+        : Gfx::Size<UIDimension>(UIDimension { special }, UIDimension { special })
+    {
+    }
+
+    UISize(UIDimension width, UIDimension height)
+        : Gfx::Size<UIDimension>(width, height)
+    {
+    }
+
+    inline UISize replace_component_if_matching_with(UIDimension to_match, UISize replacement)
+    {
+        if (width() == to_match)
+            set_width(replacement.width());
+        if (height() == to_match)
+            set_height(replacement.height());
+        return *this;
+    }
+
+    [[nodiscard]] inline bool has_only_regular_values() const
+    {
+        return width().is_regular_value() && height().is_regular_value();
+    }
+
+    [[nodiscard]] inline bool either_is(UIDimension to_match) const
+    {
+        return (width() == to_match || height() == to_match);
+    }
+
+    explicit operator Gfx::IntSize() const
+    {
+        return Gfx::IntSize(width().value_verify_regular(), height().value_verify_regular());
+    }
+};
+
+}
+
+namespace AK {
+
+template<>
+inline auto max<GUI::UIDimension>(const GUI::UIDimension& a, const GUI::UIDimension& b) -> GUI::UIDimension
+{
+    if ((a.is_regular_value() && b.is_regular_value()) || (a.is_special_value() && b.is_special_value()))
+        return a.m_value > b.m_value ? a : b;
+    if (a.is_grow() || b.is_grow())
+        return GUI::UIDimension { GUI::SpecialDimension::Grow };
+    if (a.is_opportunistic_grow() || b.is_opportunistic_grow())
+        return GUI::UIDimension { GUI::SpecialDimension::OpportunisticGrow };
+    if (a.is_fit() || b.is_fit())
+        return GUI::UIDimension { GUI::SpecialDimension::Fit };
+    if (a.is_shrink())
+        return b;
+    if (b.is_shrink())
+        return a;
+    VERIFY_NOT_REACHED();
+}
+
+template<>
+inline auto min<GUI::UIDimension>(const GUI::UIDimension& a, const GUI::UIDimension& b) -> GUI::UIDimension
+{
+    if ((a.is_regular_value() && b.is_regular_value()) || (a.is_special_value() && b.is_special_value()))
+        return a.m_value < b.m_value ? a : b;
+    if (a.is_shrink() || b.is_shrink())
+        return GUI::UIDimension { GUI::SpecialDimension::Shrink };
+    if (a.is_regular_value())
+        return a;
+    if (b.is_regular_value())
+        return b;
+    if (a.is_fit() || b.is_fit())
+        return GUI::UIDimension { GUI::SpecialDimension::Fit };
+    if (a.is_opportunistic_grow() || b.is_opportunistic_grow())
+        return GUI::UIDimension { GUI::SpecialDimension::OpportunisticGrow };
+    VERIFY_NOT_REACHED();
+}
+
+template<>
+inline auto clamp<GUI::UIDimension>(const GUI::UIDimension& input, const GUI::UIDimension& lower_bound, const GUI::UIDimension& upper_bound) -> GUI::UIDimension
+{
+    return min(max(input, lower_bound), upper_bound);
+}
+
+}
+
+#define REGISTER_UI_DIMENSION_PROPERTY(property_name, getter, setter)         \
+    register_property(                                                        \
+        property_name,                                                        \
+        [this] {                                                              \
+            return this->getter().as_json_value();                            \
+        },                                                                    \
+        [this](auto& value) {                                                 \
+            auto result = GUI::UIDimension::construct_from_json_value(value); \
+            if (result.has_value())                                           \
+                this->setter(result.value());                                 \
+            return result.has_value();                                        \
+        });
+
+#define REGISTER_UI_SIZE_PROPERTY(property_name, getter, setter)               \
+    register_property(                                                         \
+        property_name,                                                         \
+        [this] {                                                               \
+            auto size = this->getter();                                        \
+            JsonObject size_object;                                            \
+            size_object.set("width", size.width().as_json_value());            \
+            size_object.set("height", size.height().as_json_value());          \
+            return size_object;                                                \
+        },                                                                     \
+        [this](auto& value) {                                                  \
+            if (!value.is_object())                                            \
+                return false;                                                  \
+            auto result_width = GUI::UIDimension::construct_from_json_value(   \
+                value.as_object().get("width"));                               \
+            auto result_height = GUI::UIDimension::construct_from_json_value(  \
+                value.as_object().get("height"));                              \
+            if (result_width.has_value() && result_height.has_value()) {       \
+                GUI::UISize size(result_width.value(), result_height.value()); \
+                setter(size);                                                  \
+                return true;                                                   \
+            }                                                                  \
+            return false;                                                      \
+        });

--- a/Userland/Libraries/LibGUI/UIDimensions.h
+++ b/Userland/Libraries/LibGUI/UIDimensions.h
@@ -278,6 +278,13 @@ inline auto clamp<GUI::UIDimension>(const GUI::UIDimension& input, const GUI::UI
             return result.has_value();                                        \
         });
 
+#define REGISTER_READONLY_UI_DIMENSION_PROPERTY(property_name, getter) \
+    register_property(                                                 \
+        property_name,                                                 \
+        [this] {                                                       \
+            return this->getter().as_json_value();                     \
+        });
+
 #define REGISTER_UI_SIZE_PROPERTY(property_name, getter, setter)               \
     register_property(                                                         \
         property_name,                                                         \
@@ -301,4 +308,15 @@ inline auto clamp<GUI::UIDimension>(const GUI::UIDimension& input, const GUI::UI
                 return true;                                                   \
             }                                                                  \
             return false;                                                      \
+        });
+
+#define REGISTER_READONLY_UI_SIZE_PROPERTY(property_name, getter)     \
+    register_property(                                                \
+        property_name,                                                \
+        [this] {                                                      \
+            auto size = this->getter();                               \
+            JsonObject size_object;                                   \
+            size_object.set("width", size.width().as_json_value());   \
+            size_object.set("height", size.height().as_json_value()); \
+            return size_object;                                       \
         });

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -50,8 +50,10 @@ Widget::Widget()
     REGISTER_STRING_PROPERTY("tooltip", tooltip, set_tooltip);
 
     REGISTER_UI_SIZE_PROPERTY("min_size", min_size, set_min_size);
+    REGISTER_READONLY_UI_SIZE_PROPERTY("effective_min_size", effective_min_size);
     REGISTER_UI_SIZE_PROPERTY("max_size", max_size, set_max_size);
     REGISTER_UI_SIZE_PROPERTY("preferred_size", preferred_size, set_preferred_size);
+    REGISTER_READONLY_UI_SIZE_PROPERTY("effective_preferred_size", effective_preferred_size);
     REGISTER_INT_PROPERTY("width", width, set_width);
     REGISTER_UI_DIMENSION_PROPERTY("min_width", min_width, set_min_width);
     REGISTER_UI_DIMENSION_PROPERTY("max_width", max_width, set_max_width);

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -1162,27 +1162,36 @@ bool Widget::load_from_gml_ast(NonnullRefPtr<GUI::GML::Node> ast, RefPtr<Core::O
     object->for_each_child_object_interruptible([&](auto child_data) {
         auto class_name = child_data->name();
 
-        RefPtr<Core::Object> child;
-        if (auto* registration = Core::ObjectClassRegistration::find(class_name)) {
-            child = registration->construct();
-            if (!child || !registration->is_derived_from(widget_class)) {
-                dbgln("Invalid widget class: '{}'", class_name);
+        // It is very questionable if this pseudo object should exist, but it works fine like this for now.
+        if (class_name == "GUI::Layout::Spacer") {
+            if (!this->layout()) {
+                dbgln("Specified GUI::Layout::Spacer in GML, but the parent has no Layout.");
                 return IterationDecision::Break;
             }
+            this->layout()->add_spacer();
         } else {
-            child = unregistered_child_handler(class_name);
-        }
-        if (!child)
-            return IterationDecision::Break;
+            RefPtr<Core::Object> child;
+            if (auto* registration = Core::ObjectClassRegistration::find(class_name)) {
+                child = registration->construct();
+                if (!child || !registration->is_derived_from(widget_class)) {
+                    dbgln("Invalid widget class: '{}'", class_name);
+                    return IterationDecision::Break;
+                }
+            } else {
+                child = unregistered_child_handler(class_name);
+            }
+            if (!child)
+                return IterationDecision::Break;
+            add_child(*child);
 
-        add_child(*child);
-        // This is possible as we ensure that Widget is a base class above.
-        static_ptr_cast<Widget>(child)->load_from_gml_ast(child_data, unregistered_child_handler);
+            // This is possible as we ensure that Widget is a base class above.
+            static_ptr_cast<Widget>(child)->load_from_gml_ast(child_data, unregistered_child_handler);
 
-        if (is_tab_widget) {
-            // FIXME: We need to have the child added before loading it so that it can access us. But the TabWidget logic requires the child to not be present yet.
-            remove_child(*child);
-            reinterpret_cast<TabWidget*>(this)->add_widget(*static_ptr_cast<Widget>(child));
+            if (is_tab_widget) {
+                // FIXME: We need to have the child added before loading it so that it can access us. But the TabWidget logic requires the child to not be present yet.
+                remove_child(*child);
+                reinterpret_cast<TabWidget*>(this)->add_widget(*static_ptr_cast<Widget>(child));
+            }
         }
 
         return IterationDecision::Continue;

--- a/Userland/Libraries/LibGUI/Widget.cpp
+++ b/Userland/Libraries/LibGUI/Widget.cpp
@@ -199,6 +199,14 @@ Widget::Widget()
 
 Widget::~Widget() = default;
 
+void Widget::layout_relevant_change_occured()
+{
+    if (auto* parent = parent_widget())
+        parent->layout_relevant_change_occured();
+    else
+        invalidate_layout();
+}
+
 void Widget::child_event(Core::ChildEvent& event)
 {
     if (event.type() == Event::ChildAdded) {
@@ -207,6 +215,7 @@ void Widget::child_event(Core::ChildEvent& event)
                 layout()->insert_widget_before(verify_cast<Widget>(*event.child()), verify_cast<Widget>(*event.insertion_before_child()));
             else
                 layout()->add_widget(verify_cast<Widget>(*event.child()));
+            layout_relevant_change_occured();
         }
         if (window() && event.child() && is<Widget>(*event.child()))
             window()->did_add_widget({}, verify_cast<Widget>(*event.child()));
@@ -217,6 +226,7 @@ void Widget::child_event(Core::ChildEvent& event)
                 layout()->remove_widget(verify_cast<Widget>(*event.child()));
             else
                 invalidate_layout();
+            layout_relevant_change_occured();
         }
         if (window() && event.child() && is<Widget>(*event.child()))
             window()->did_remove_widget({}, verify_cast<Widget>(*event.child()));

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -352,6 +352,7 @@ protected:
     // This is called after children have been painted.
     virtual void second_paint_event(PaintEvent&);
 
+    virtual void layout_relevant_change_occured();
     virtual void custom_layout() { }
     virtual void did_change_font() { }
     virtual void did_layout() { }

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -9,6 +9,7 @@
 #include <AK/EnumBits.h>
 #include <AK/JsonObject.h>
 #include <AK/NonnullRefPtr.h>
+#include <AK/Optional.h>
 #include <AK/String.h>
 #include <AK/Variant.h>
 #include <LibCore/Object.h>
@@ -18,6 +19,7 @@
 #include <LibGUI/Forward.h>
 #include <LibGUI/GML/AST.h>
 #include <LibGUI/Margins.h>
+#include <LibGUI/UIDimensions.h>
 #include <LibGfx/Color.h>
 #include <LibGfx/Forward.h>
 #include <LibGfx/Orientation.h>
@@ -80,40 +82,73 @@ public:
         return layout;
     }
 
-    Gfx::IntSize min_size() const { return m_min_size; }
-    void set_min_size(Gfx::IntSize const&);
-    void set_min_size(int width, int height) { set_min_size({ width, height }); }
+    UISize min_size() const { return m_min_size; }
+    void set_min_size(UISize const&);
+    void set_min_size(UIDimension width, UIDimension height) { set_min_size({ width, height }); }
 
-    int min_width() const { return m_min_size.width(); }
-    int min_height() const { return m_min_size.height(); }
-    void set_min_width(int width) { set_min_size(width, min_height()); }
-    void set_min_height(int height) { set_min_size(min_width(), height); }
+    UIDimension min_width() const { return m_min_size.width(); }
+    UIDimension min_height() const { return m_min_size.height(); }
+    void set_min_width(UIDimension width) { set_min_size(width, min_height()); }
+    void set_min_height(UIDimension height) { set_min_size(min_width(), height); }
 
-    Gfx::IntSize max_size() const { return m_max_size; }
-    void set_max_size(Gfx::IntSize const&);
-    void set_max_size(int width, int height) { set_max_size({ width, height }); }
+    UISize max_size() const { return m_max_size; }
+    void set_max_size(UISize const&);
+    void set_max_size(UIDimension width, UIDimension height) { set_max_size({ width, height }); }
 
-    int max_width() const { return m_max_size.width(); }
-    int max_height() const { return m_max_size.height(); }
-    void set_max_width(int width) { set_max_size(width, max_height()); }
-    void set_max_height(int height) { set_max_size(max_width(), height); }
+    UIDimension max_width() const { return m_max_size.width(); }
+    UIDimension max_height() const { return m_max_size.height(); }
+    void set_max_width(UIDimension width) { set_max_size(width, max_height()); }
+    void set_max_height(UIDimension height) { set_max_size(max_width(), height); }
 
-    void set_fixed_size(Gfx::IntSize const& size)
+    UISize preferred_size() const { return m_preferred_size; }
+    void set_preferred_size(UISize const&);
+    void set_preferred_size(UIDimension width, UIDimension height) { set_preferred_size({ width, height }); }
+
+    UIDimension preferred_width() const { return m_preferred_size.width(); }
+    UIDimension preferred_height() const { return m_preferred_size.height(); }
+    void set_preferred_width(UIDimension width) { set_preferred_size(width, preferred_height()); }
+    void set_preferred_height(UIDimension height) { set_preferred_size(preferred_width(), height); }
+
+    virtual Optional<UISize> calculated_preferred_size() const;
+    virtual Optional<UISize> calculated_min_size() const;
+
+    UISize effective_preferred_size() const
     {
+        auto effective_preferred_size = preferred_size();
+        if (effective_preferred_size.either_is(GUI::SpecialDimension::Shrink))
+            effective_preferred_size.replace_component_if_matching_with(GUI::SpecialDimension::Shrink, effective_min_size());
+        if (effective_preferred_size.either_is(GUI::SpecialDimension::Fit) && calculated_preferred_size().has_value())
+            effective_preferred_size.replace_component_if_matching_with(GUI::SpecialDimension::Fit, calculated_preferred_size().value());
+        return effective_preferred_size;
+    }
+
+    UISize effective_min_size() const
+    {
+        auto effective_min_size = min_size();
+        if (effective_min_size.either_is(GUI::SpecialDimension::Shrink) && calculated_min_size().has_value())
+            effective_min_size.replace_component_if_matching_with(GUI::SpecialDimension::Shrink, calculated_min_size().value());
+        return effective_min_size;
+    }
+
+    void set_fixed_size(UISize const& size)
+    {
+        VERIFY(size.has_only_regular_values());
         set_min_size(size);
         set_max_size(size);
     }
 
-    void set_fixed_size(int width, int height) { set_fixed_size({ width, height }); }
+    void set_fixed_size(UIDimension width, UIDimension height) { set_fixed_size({ width, height }); }
 
-    void set_fixed_width(int width)
+    void set_fixed_width(UIDimension width)
     {
+        VERIFY(width.is_regular_value());
         set_min_width(width);
         set_max_width(width);
     }
 
-    void set_fixed_height(int height)
+    void set_fixed_height(UIDimension height)
     {
+        VERIFY(height.is_regular_value());
         set_min_height(height);
         set_max_height(height);
     }
@@ -300,8 +335,9 @@ public:
     bool load_from_gml(StringView);
     bool load_from_gml(StringView, RefPtr<Core::Object> (*unregistered_child_handler)(String const&));
 
+    // FIXME: remove this when all uses of shrink_to_fit are eliminated
     void set_shrink_to_fit(bool);
-    bool is_shrink_to_fit() const { return m_shrink_to_fit; }
+    bool is_shrink_to_fit() const { return preferred_width().is_shrink() || preferred_height().is_shrink(); }
 
     bool has_pending_drop() const;
 
@@ -377,8 +413,9 @@ private:
     NonnullRefPtr<Gfx::Font> m_font;
     String m_tooltip;
 
-    Gfx::IntSize m_min_size { -1, -1 };
-    Gfx::IntSize m_max_size { -1, -1 };
+    UISize m_min_size { SpecialDimension::Shrink };
+    UISize m_max_size { SpecialDimension::Grow };
+    UISize m_preferred_size { SpecialDimension::Grow };
     Margins m_grabbable_margins;
 
     bool m_fill_with_background_color { false };
@@ -389,7 +426,6 @@ private:
     bool m_updates_enabled { true };
     bool m_accepts_emoji_input { false };
     bool m_accepts_command_palette { true };
-    bool m_shrink_to_fit { false };
     bool m_default_font { true };
 
     NonnullRefPtr<Gfx::PaletteImpl> m_palette;

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -90,6 +90,7 @@ Window::Window(Core::Object* parent)
     REGISTER_RECT_PROPERTY("rect", rect, set_rect);
     REGISTER_SIZE_PROPERTY("base_size", base_size, set_base_size);
     REGISTER_SIZE_PROPERTY("size_increment", size_increment, set_size_increment);
+    REGISTER_BOOL_PROPERTY("obey_widget_min_size", is_obeying_widget_min_size, set_obey_widget_min_size);
 }
 
 Window::~Window()
@@ -1018,6 +1019,14 @@ void Window::set_forced_shadow(bool shadow)
     ConnectionToWindowServer::the().async_set_forced_shadow(m_window_id, shadow);
 }
 
+void Window::set_obey_widget_min_size(bool obey_widget_min_size)
+{
+    if (m_obey_widget_min_size != obey_widget_min_size) {
+        m_obey_widget_min_size = obey_widget_min_size;
+        schedule_relayout();
+    }
+}
+
 void Window::set_maximized(bool maximized)
 {
     m_maximized = maximized;
@@ -1033,8 +1042,15 @@ void Window::schedule_relayout()
         return;
     m_layout_pending = true;
     deferred_invoke([this] {
-        if (main_widget())
+        if (main_widget()) {
             main_widget()->do_layout();
+            if (m_obey_widget_min_size) {
+                auto min_size = main_widget()->effective_min_size();
+                set_minimum_size(
+                    (min_size.width() == GUI::SpecialDimension::Shrink ? 0 : min_size.width().value_verify_regular()),
+                    (min_size.height() == GUI::SpecialDimension::Shrink ? 0 : min_size.height().value_verify_regular()));
+            }
+        }
         update();
         m_layout_pending = false;
     });

--- a/Userland/Libraries/LibGUI/Window.cpp
+++ b/Userland/Libraries/LibGUI/Window.cpp
@@ -723,10 +723,9 @@ void Window::set_main_widget(Widget* widget)
     if (m_main_widget) {
         add_child(*widget);
         auto new_window_rect = rect();
-        if (m_main_widget->min_width() >= 0)
-            new_window_rect.set_width(max(new_window_rect.width(), m_main_widget->min_width()));
-        if (m_main_widget->min_height() >= 0)
-            new_window_rect.set_height(max(new_window_rect.height(), m_main_widget->min_height()));
+        auto new_widget_min_size = m_main_widget->effective_min_size();
+        new_window_rect.set_width(max(new_window_rect.width(), new_widget_min_size.width().value_or_zero_if_shrink_with_verify()));
+        new_window_rect.set_height(max(new_window_rect.height(), new_widget_min_size.height().value_or_zero_if_shrink_with_verify()));
         set_rect(new_window_rect);
         m_main_widget->set_relative_rect({ {}, new_window_rect.size() });
         m_main_widget->set_window(this);

--- a/Userland/Libraries/LibGUI/Window.h
+++ b/Userland/Libraries/LibGUI/Window.h
@@ -50,6 +50,9 @@ public:
     bool is_resizable() const { return m_resizable; }
     void set_resizable(bool resizable) { m_resizable = resizable; }
 
+    bool is_obeying_widget_min_size() { return m_obey_widget_min_size; }
+    void set_obey_widget_min_size(bool);
+
     bool is_minimizable() const { return m_minimizable; }
     void set_minimizable(bool minimizable) { m_minimizable = minimizable; }
 
@@ -287,6 +290,7 @@ private:
     bool m_double_buffering_enabled { true };
     bool m_modal { false };
     bool m_resizable { true };
+    bool m_obey_widget_min_size { true };
     Optional<Gfx::IntSize> m_resize_aspect_ratio {};
     bool m_minimizable { true };
     bool m_closeable { true };

--- a/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
+++ b/Userland/Libraries/LibGUI/Wizards/WizardDialog.cpp
@@ -46,14 +46,12 @@ WizardDialog::WizardDialog(Window* parent_window)
     nav_container_widget.layout()->set_spacing(0);
     nav_container_widget.layout()->add_spacer();
 
-    m_back_button = nav_container_widget.add<Button>("< Back");
-    m_back_button->set_fixed_width(75);
+    m_back_button = nav_container_widget.add<DialogButton>("< Back");
     m_back_button->on_click = [&](auto) {
         pop_page();
     };
 
-    m_next_button = nav_container_widget.add<Button>("Next >");
-    m_next_button->set_fixed_width(75);
+    m_next_button = nav_container_widget.add<DialogButton>("Next >");
     m_next_button->on_click = [&](auto) {
         VERIFY(has_pages());
 
@@ -70,8 +68,7 @@ WizardDialog::WizardDialog(Window* parent_window)
     auto& button_spacer = nav_container_widget.add<Widget>();
     button_spacer.set_fixed_width(10);
 
-    m_cancel_button = nav_container_widget.add<Button>("Cancel");
-    m_cancel_button->set_fixed_width(75);
+    m_cancel_button = nav_container_widget.add<DialogButton>("Cancel");
     m_cancel_button->on_click = [&](auto) {
         handle_cancel();
     };

--- a/Userland/Services/LoginServer/LoginWindow.gml
+++ b/Userland/Services/LoginServer/LoginWindow.gml
@@ -30,6 +30,8 @@
                 text_alignment: "CenterLeft"
             }
 
+            @GUI::Layout::Spacer {}
+
             @GUI::Button {
                 name: "log_in"
                 text: "Log in"

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -107,7 +107,7 @@ RefPtr<NotificationWindow> NotificationWindow::get_window_by_id(i32 id)
 void NotificationWindow::resize_to_fit_text()
 {
     auto line_height = m_text_label->font().glyph_height();
-    auto total_height = m_text_label->preferred_height();
+    auto total_height = m_text_label->text_calculated_preferred_height();
 
     m_text_label->set_fixed_height(total_height);
     set_height(40 - line_height + total_height);

--- a/Userland/Services/NotificationServer/NotificationWindow.cpp
+++ b/Userland/Services/NotificationServer/NotificationWindow.cpp
@@ -123,7 +123,7 @@ void NotificationWindow::enter_event(Core::Event&)
 void NotificationWindow::leave_event(Core::Event&)
 {
     m_hovering = false;
-    m_text_label->set_fixed_height(-1);
+    m_text_label->set_preferred_height(GUI::SpecialDimension::Grow);
     set_height(40);
 }
 

--- a/Userland/Services/Taskbar/ClockWidget.cpp
+++ b/Userland/Services/Taskbar/ClockWidget.cpp
@@ -178,7 +178,7 @@ void ClockWidget::paint_event(GUI::PaintEvent& event)
     Gfx::Font const& font = Gfx::FontDatabase::default_font();
     int const frame_width = frame_thickness();
     int const ideal_width = m_time_width;
-    int const widget_width = max_width();
+    int const widget_width = max_width().value_verify_regular();
     int const translation_x = (widget_width - ideal_width) / 2 - frame_width;
 
     painter.draw_text(frame_inner_rect().translated(translation_x, frame_width), time_text, font, Gfx::TextAlignment::CenterLeft, palette().window_text());

--- a/Userland/Services/Taskbar/TaskbarWindow.cpp
+++ b/Userland/Services/Taskbar/TaskbarWindow.cpp
@@ -57,6 +57,7 @@ TaskbarWindow::TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu)
 {
     set_window_type(GUI::WindowType::Taskbar);
     set_title("Taskbar");
+    set_obey_widget_min_size(false);
 
     on_screen_rects_change(GUI::Desktop::the().rects(), GUI::Desktop::the().main_screen_index());
 
@@ -76,7 +77,10 @@ TaskbarWindow::TaskbarWindow(NonnullRefPtr<GUI::Menu> start_menu)
 
     m_task_button_container = main_widget.add<GUI::Widget>();
     m_task_button_container->set_layout<GUI::HorizontalBoxLayout>();
+    m_task_button_container->set_preferred_width(GUI::SpecialDimension::Grow);
     m_task_button_container->layout()->set_spacing(3);
+
+    main_widget.layout()->add_spacer();
 
     m_default_icon = Gfx::Bitmap::try_load_from_file("/res/icons/16x16/window.png").release_value_but_fixme_should_propagate_errors();
 
@@ -140,7 +144,9 @@ void TaskbarWindow::update_applet_area()
 NonnullRefPtr<GUI::Button> TaskbarWindow::create_button(WindowIdentifier const& identifier)
 {
     auto& button = m_task_button_container->add<TaskbarButton>(identifier);
+    m_task_button_container->invalidate_layout();
     button.set_min_size(20, 21);
+    button.set_preferred_size(140, 21);
     button.set_max_size(140, 21);
     button.set_text_alignment(Gfx::TextAlignment::CenterLeft);
     button.set_icon(*m_default_icon);


### PR DESCRIPTION
This introduces (and already makes use of it in some places) a new dynamic layout system for LibGUI.

It started out as me wanting to have more options than just "shrink_to_fit", like "grow_to_size_of_largest_neighbour", and a preferred size system, and so on and so forth.
After i played around with that for a while i noticed that it had the tendency to get very messy , adding another property to widget for every little layout behavior. (and also needing many of them twice for horizontal and vertical)
### This is what i came up with to fix that problem:
 - Widgets have the following size properties:
   - settable sizes: (just normal members of widget)
     - min_size
     - preferred_size
     - max_size
   - calculated sizes: (used by subclasses of widget to inform the layout system of custom sizing constraints; e.g. Button text width)
     - calculated_min_size
     - calculated_preferred_size
     - (AFAICT calculated_max_size wouldn't make sense)
   - effective sizes: (uses the values of the corresponding settable sizes, or getting a value from the calculated sizes if the settable sizes were set to a special value that indicates that)
     - effective_min_size
     - effective_preferred_size
 - UISizes are special tagged union like values, that can either represent int-s ≥0 or special values
   - possible special values:
     - shrink
     - fit
     - opportunistic grow
     - grow
   - implemented as header only, to make the best use of inlining optimizations
   - represented ad strings in GML
   - not every value is permitted for every property (always checked with VERIFY at setter, and point of use, to avoid nasty surprises when more special values are added)

### List of Features: (non exhaustive)
 - Containers fitting the size of their children, both for preferred and minimum size
 - Layout spacers growing to zero size (previously not possible, see the three dialog launching buttons in the lower right of WidgetGallerys "Basics" tab)
 - Windows using the min_size of their content to determine the size their minimum size
 - ScrollableContainerWidget Being filled by their content, without scrollbars being visible until they are needed, and then the content reacting to the presence of those scrollbars; try https://gist.github.com/frhun/5c7d4adfb5e6c8fdf9cb8ba65f120378 in GML Playground for a demo)
 - Widgets "opportunistically" growing to the size their context permits, without causing the surrounding container try to expand themselves
 - "DialogButton"s for consistent look everywhere, without having to set a specific size in every instance
 - GML support for Layout spacers

### Demos:
[1](https://cdn.discordapp.com/attachments/830529037251641374/975910055406862336/Bildschirmaufzeichnung_vom_10.05.2022_205320.webm)
[2](https://cdn.discordapp.com/attachments/830529037251641374/975910056094736414/Bildschirmaufzeichnung_vom_17.05.2022_003756.webm)
[3](https://cdn.discordapp.com/attachments/830529037251641374/975910056484798474/file-picker.webm)
[4](https://cdn.discordapp.com/attachments/830529037251641374/981673017174270002/Bildschirmaufzeichnung_vom_01.06.2022_233458.webm)

### Things to do after this is merged:
 - implement the calculated min/preferred size for Label, Button, TabWidget
 - use the preferred size of the main widget to determine the size of the window, similar to what obey_widget_min_size does
   - use that to determine the sizes of things like InputDialog, MessageDialog, Tooltips, etc.
 - implement the same minimum size property in AbstractScrollableWidget utilized by ScrollableContainerWidget to get flicker free on-demand scrollbars in Browser