### PR TITLE
LibGUI: Fix weird behavior when switching lines using Ctrl+Shift+[Up,Down]

### DIFF
--- a/Userland/Libraries/LibGUI/EditingEngine.h
+++ b/Userland/Libraries/LibGUI/EditingEngine.h
@@ -50,10 +50,16 @@ protected:
 
     WeakPtr<TextEditor> m_editor;
 
+    enum class DidMoveALine {
+        No,
+        Yes,
+    };
+
     void move_one_left();
     void move_one_right();
-    void move_one_up(KeyEvent const& event);
-    void move_one_down(KeyEvent const& event);
+    void move_one_helper(KeyEvent const& event, VerticalDirection direction);
+    DidMoveALine move_one_up(KeyEvent const& event);
+    DidMoveALine move_one_down(KeyEvent const& event);
     void move_to_previous_span();
     void move_to_next_span();
     void move_to_logical_line_beginning();

--- a/Userland/Libraries/LibGUI/TextEditor.h
+++ b/Userland/Libraries/LibGUI/TextEditor.h
@@ -373,7 +373,7 @@ private:
     bool m_cursor_line_highlighting { true };
     size_t m_soft_tab_width { 4 };
     int m_horizontal_content_padding { 3 };
-    TextRange m_selection;
+    TextRange m_selection {};
 
     Optional<u32> m_substitution_code_point;
     mutable OwnPtr<Vector<u32>> m_substitution_string_data; // Used to avoid repeated String construction.

--- a/Userland/Libraries/LibGUI/TextRange.h
+++ b/Userland/Libraries/LibGUI/TextRange.h
@@ -61,8 +61,8 @@ private:
     TextPosition normalized_start() const { return m_start < m_end ? m_start : m_end; }
     TextPosition normalized_end() const { return m_start < m_end ? m_end : m_start; }
 
-    TextPosition m_start;
-    TextPosition m_end;
+    TextPosition m_start {};
+    TextPosition m_end {};
 };
 
 }

--- a/Userland/Libraries/LibGUI/Widget.h
+++ b/Userland/Libraries/LibGUI/Widget.h
@@ -52,6 +52,15 @@ enum class VerticalDirection {
     Down
 };
 
+constexpr VerticalDirection key_code_to_vertical_direction(KeyCode const& key)
+{
+    if (key == Key_Up)
+        return VerticalDirection::Up;
+    if (key == Key_Down)
+        return VerticalDirection::Down;
+    VERIFY_NOT_REACHED();
+}
+
 enum class AllowCallback {
     No,
     Yes


### PR DESCRIPTION
On this demonstration video, Ctrl+Shift+Up is fixed, but Ctrl+Shift+Down still does the old behavior


https://user-images.githubusercontent.com/26030965/168887599-be180ca0-328c-41da-b715-b020733f462a.mp4