### PR TITLE
Ports: Sanitize environment before handling Ports

### DIFF
--- a/Meta/lint-ports.py
+++ b/Meta/lint-ports.py
@@ -21,6 +21,7 @@ PORT_TABLE_FILE = 'AvailablePorts.md'
 IGNORE_FILES = {
     '.gitignore',
     '.port_include.sh',
+    '.strip_env.sh',
     PORT_TABLE_FILE,
     'build_all.sh',
     'build_installed.sh',

--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -2,6 +2,12 @@
 set -eu
 
 SCRIPT="$(dirname "${0}")"
+
+if [ -z "${SERENITY_STRIPPED_ENV:-}" ]; then
+    exec "${SCRIPT}/.strip_env.sh" "${@}"
+fi
+unset SERENITY_STRIPPED_ENV
+
 export MAKEJOBS="${MAKEJOBS:-$(nproc)}"
 
 maybe_source() {

--- a/Ports/.strip_env.sh
+++ b/Ports/.strip_env.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+exec env -i SERENITY_STRIPPED_ENV=1 \
+    MAKEJOBS="${MAKEJOBS:-}" \
+    IN_SERENITY_PORT_DEV="${IN_SERENITY_PORT_DEV:-}" \
+    SERENITY_ARCH="${SERENITY_ARCH:-}" \
+    SERENITY_TOOLCHAIN="${SERENITY_TOOLCHAIN:-}" \
+    "${@}"


### PR DESCRIPTION
We were previously passing all kinds of funny flags to compiler and linker from ports to their dependencies. I'm surprised nothing else was already found to be broken.

This fixes the weird issues that we saw with RetroArch in #13957.

Time to redo the failing ports list I guess.