### PR TITLE
Documentation: Only install the x86 and AArch64 qemu backends on Arch

### DIFF
--- a/Documentation/BuildInstructions.md
+++ b/Documentation/BuildInstructions.md
@@ -48,7 +48,7 @@ for details.
 ### Arch Linux / Manjaro
 
 ```console
-sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu-desktop qemu-emulators-full ccache rsync unzip
+sudo pacman -S --needed base-devel cmake curl mpfr libmpc gmp e2fsprogs ninja qemu-desktop qemu-system-x86 qemu-system-aarch64 ccache rsync unzip
 ```
 Optional: `fuse2fs` for [building images without root](https://github.com/SerenityOS/serenity/pull/11224).
 


### PR DESCRIPTION
The qemu-emuulators-full package installs qemu backends for *all*
supported architectures, but we only need x86 and AArch64.

This decreases the installed size of dependencies by 800 MiB.