### PR TITLE
AK: Use static_cast to cast to base type

### DIFF
--- a/AK/Variant.h
+++ b/AK/Variant.h
@@ -148,7 +148,7 @@ private:
     {
         // Warning: Internal type shenanigans - VariantsConstrutors<T, Base> <- Base
         //          Not the other way around, so be _really_ careful not to cause issues.
-        return *reinterpret_cast<Base*>(this);
+        return *static_cast<Base*>(this);
     }
 };
 


### PR DESCRIPTION
This is an issue on systems that don't have the empty base class
optimisation (such as windows), and we normally don't need to care -
however static_cast is technically the right thing to use, so let's use
that instead.

Co-Authored-By: Daniel Bertalan <dani@danielbertalan.dev>