### PR TITLE
ThemeEditor: Show unsaved changes prompt on quit and use ‘open’ icon on path picker button

### DIFF
--- a/Userland/Applications/ThemeEditor/MainWidget.cpp
+++ b/Userland/Applications/ThemeEditor/MainWidget.cpp
@@ -231,7 +231,10 @@ ErrorOr<void> MainWidget::initialize_menubar(GUI::Window& window)
     })));
 
     TRY(file_menu->try_add_separator());
-    TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) { GUI::Application::the()->quit(); })));
+    TRY(file_menu->try_add_action(GUI::CommonActions::make_quit_action([&](auto&) {
+        if (request_close() == GUI::Window::CloseRequestDecision::Close)
+            GUI::Application::the()->quit();
+    })));
 
     auto accessibility_menu = TRY(window.try_add_menu("&Accessibility"));
 

--- a/Userland/Applications/ThemeEditor/PathProperty.gml
+++ b/Userland/Applications/ThemeEditor/PathProperty.gml
@@ -17,8 +17,8 @@
 
     @GUI::Button {
         name: "path_picker_button"
-        fixed_width: 20
-        text: "..."
+        fixed_width: 22
+        icon: "/res/icons/16x16/open.png"
         tooltip: "Choose..."
     }
 }


### PR DESCRIPTION
~~This probably should be merged after #13937, just to make resolving conflicts easier ¯\\_(ツ)_/¯~~ it got merged!!

---

- **ThemeEditor: Show unsaved changes prompt also in the quit action**

  While the app displayed the prompt on the close button press, the quit action from the menu didn’t do so.

- **ThemeEditor: Use ‘open’ icon instead of ellipsis on path picker button**

  The ellipsis seemed a little unclear for me.

  before | after this change
  :-:|:-:
  ![](https://user-images.githubusercontent.com/16520278/169622910-a51ca1bd-c31a-4659-bfc4-a2070ff8b136.png) | ![](https://user-images.githubusercontent.com/16520278/169621936-4f1a779e-2ba8-4f25-a875-943bfef5d816.png)
