### PR TITLE
Ports: Remove the `/usr/lib` pkg-config path

### DIFF
--- a/Ports/.hosted_defs.sh
+++ b/Ports/.hosted_defs.sh
@@ -45,6 +45,6 @@ fi
 
 export PKG_CONFIG_DIR=""
 export PKG_CONFIG_SYSROOT_DIR="${SERENITY_BUILD_DIR}/Root"
-export PKG_CONFIG_LIBDIR="${PKG_CONFIG_SYSROOT_DIR}/usr/lib/pkgconfig/:${PKG_CONFIG_SYSROOT_DIR}/usr/local/lib/pkgconfig"
+export PKG_CONFIG_LIBDIR="${PKG_CONFIG_SYSROOT_DIR}/usr/local/lib/pkgconfig"
 
 export SERENITY_INSTALL_ROOT="${SERENITY_BUILD_DIR}/Root"


### PR DESCRIPTION
Our Ports are exclusively installed to `/usr/local/lib`, so having `/usr/lib` in there as well doesn't make much sense.

While this doesn't fully fix `ncurses` installing its pkg-config files into weird locations, it makes the path slightly less :yakid2:.