### PR TITLE
Ports: More fixes for `dev` and the READMEs

### DIFF
--- a/Ports/.port_include.sh
+++ b/Ports/.port_include.sh
@@ -671,7 +671,7 @@ do_generate_patch_readme() {
         {
             echo "## \`$patch\`"
             echo
-            sed -e 's/^Co-Authored-By: .*$//g' < "$tempdir/$patch.desc"
+            sed -e '/^Co-Authored-By: /d' < "$tempdir/$patch.desc"
             echo
         } >> ReadMe.md
         count=$((count + 1))

--- a/Ports/.strip_env.sh
+++ b/Ports/.strip_env.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
 exec env -i SERENITY_STRIPPED_ENV=1 \
+    HOME="${HOME}" \
+    USER="${USER}" \
+    TERM="${TERM}" \
+    PATH="${PATH}" \
     MAKEJOBS="${MAKEJOBS:-}" \
     IN_SERENITY_PORT_DEV="${IN_SERENITY_PORT_DEV:-}" \
     SERENITY_ARCH="${SERENITY_ARCH:-}" \

--- a/Ports/SDL2-GNUBoy/patches/ReadMe.md
+++ b/Ports/SDL2-GNUBoy/patches/ReadMe.md
@@ -5,4 +5,3 @@
 Rewrite the makefile for serenity
 
 
-

--- a/Ports/bash/patches/ReadMe.md
+++ b/Ports/bash/patches/ReadMe.md
@@ -3,6 +3,7 @@
 ## `0001-accept.c-Include-sys-select.h.patch`
 
 accept.c: Include sys/select.h
+
 This is transitively pulled in by other headers in some systems,
 serenity is not one of them.
 

--- a/Ports/binutils/patches/ReadMe.md
+++ b/Ports/binutils/patches/ReadMe.md
@@ -1,9 +1,14 @@
-# Patches for Binutils on SerenityOS
+# Patches for binutils on SerenityOS
 
 ## `binutils.patch`
 
-Teaches the assembler, BFD, and the linker about the SerenityOS target triple.
+Add support for SerenityOS
 
-On x86_64, we override the default base address of non-PIE executables, because
-the default (0x400000) is too close to the beginning of the address space, and
-DynamicLoader often ends up allocating internal data at that address.
+Teaches the assembler, BFD, and the linker about the SerenityOS target
+triple.
+
+On x86_64, we override the default base address of non-PIE executables,
+because the default (0x400000) is too close to the beginning of the
+address space, and DynamicLoader often ends up allocating internal data
+at that address. See commit 292398b5857d0104f7c33fdb5d79f45fe8b395dd.
+

--- a/Ports/c-ray/patches/ReadMe.md
+++ b/Ports/c-ray/patches/ReadMe.md
@@ -10,11 +10,9 @@ Add a dummy configure file
 Disable checkBuf() on serenity
 
 
-
 ## `0003-Let-c-ray-define-its-own-version-of-vasprintf.patch`
 
 Let c-ray define its own version of vasprintf
-
 
 
 ## `0004-Link-with-the-needed-serenity-libraries.patch`
@@ -22,12 +20,9 @@ Let c-ray define its own version of vasprintf
 Link with the needed serenity libraries
 
 
-
-
 ## `0005-Use-usleep-on-serenity.patch`
 
 Use usleep() on serenity
-
 
 
 ## `0006-Reduce-HDR-scene-settings-a-bit.patch`
@@ -40,13 +35,10 @@ Reduce HDR scene settings a bit
 Replace the micro symbol with a 'u'
 
 
-
-
 ## `0008-Make-SDL-use-software-rendering.patch`
 
 Make SDL use software rendering
 
 Serenity does not support accelerated rendering
-
 
 

--- a/Ports/cmatrix/patches/ReadMe.md
+++ b/Ports/cmatrix/patches/ReadMe.md
@@ -5,10 +5,8 @@
 Use manual include & library paths for ncurses
 
 
-
 ## `0002-Include-curses.h-from-ncurses-in-serenity.patch`
 
 Include curses.h from <ncurses> in serenity
-
 
 

--- a/Ports/curl/patches/ReadMe.md
+++ b/Ports/curl/patches/ReadMe.md
@@ -5,4 +5,3 @@
 Teach curl.h about serenity's <sys/select.h> include
 
 
-

--- a/Ports/dropbear/patches/ReadMe.md
+++ b/Ports/dropbear/patches/ReadMe.md
@@ -5,17 +5,14 @@
 Disable some default options
 
 
-
 ## `0002-Disable-SSP.patch`
 
 Disable SSP
 
 
-
 ## `0003-Include-sys-select.h.patch`
 
 Include <sys/select.h>
-
 
 
 ## `0004-Install-in-bindir.patch`
@@ -25,10 +22,8 @@ Install in bindir
 FIXME: Not sure what this is exactly doing.
 
 
-
 ## `0005-Remove-some-unsupported-socket-operations.patch`
 
 Remove some unsupported socket operations
-
 
 

--- a/Ports/ed/patches/ReadMe.md
+++ b/Ports/ed/patches/ReadMe.md
@@ -5,7 +5,6 @@
 Make CC and friends overridable from the env
 
 
-
 ## `0002-Use-stdbool-instead-of-rolling-a-manual-Bool.patch`
 
 Use stdbool instead of rolling a manual Bool
@@ -14,7 +13,6 @@ Use stdbool instead of rolling a manual Bool
 ## `0003-Manually-link-with-pcre2.patch`
 
 Manually link with pcre2
-
 
 
 ## `0004-Use-pcre2-for-regex-instead-of-libc-s-regex.h.patch`

--- a/Ports/emu2/patches/ReadMe.md
+++ b/Ports/emu2/patches/ReadMe.md
@@ -10,7 +10,6 @@ Include <strings.h>
 Replace a use of rindex() with strrchr()
 
 
-
 ## `0003-Install-into-usr-local.patch`
 
 Install into /usr/local
@@ -19,6 +18,5 @@ Install into /usr/local
 ## `0004-Don-t-use-setitimer.patch`
 
 Don't use setitimer()
-
 
 

--- a/Ports/fio/patches/0002-fio-add-serenityos-platform-support.patch
+++ b/Ports/fio/patches/0002-fio-add-serenityos-platform-support.patch
@@ -3,6 +3,13 @@ From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 21 Dec 2021 23:47:36 -0800
 Subject: [PATCH 2/4] Port: fio - Add SerenityOS platform support
 
+`fio` abstracts individual operating system support out into to an
+`os/os-<name>.h` header where you can select which platform features
+are available and implement missing function stubs for our operating
+system.
+
+This patch implements basic OS support for Serenity just to get fio up
+and running.
 ---
  os/os-serenity.h | 87 ++++++++++++++++++++++++++++++++++++++++++++++++
  os/os.h          |  3 ++

--- a/Ports/fio/patches/0003-fio-add-serenityos-support-to-configure.patch
+++ b/Ports/fio/patches/0003-fio-add-serenityos-support-to-configure.patch
@@ -3,6 +3,9 @@ From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 21 Dec 2021 23:48:09 -0800
 Subject: [PATCH 3/4] Port: Add SerenityOS support to configure
 
+This patch implements targetos detection for serenity, and also
+disables shared memory support automatically for serenity, as it's not
+currently supported.
 ---
  configure | 3 +++
  1 file changed, 3 insertions(+)

--- a/Ports/fio/patches/0004-fio-disable-rdtsc-support-for-serenityos.patch
+++ b/Ports/fio/patches/0004-fio-disable-rdtsc-support-for-serenityos.patch
@@ -3,6 +3,11 @@ From: Brian Gianforcaro <b.gianfo@gmail.com>
 Date: Tue, 21 Dec 2021 23:48:46 -0800
 Subject: [PATCH 4/4] Port: fio - Disable rdtsc support for serenity
 
+This patch disables the function which uses `rdtsc` to get the current
+clock time, as that instruction isn't allowed to be called from user
+space by serenity.
+
+If you did attempt to call it you would trip a segfault.
 ---
  arch/arch-x86.h | 3 ++-
  1 file changed, 2 insertions(+), 1 deletion(-)

--- a/Ports/fio/patches/ReadMe.md
+++ b/Ports/fio/patches/ReadMe.md
@@ -1,25 +1,40 @@
-# Patches for fio 3.29 on SerenityOS
+# Patches for fio on SerenityOS
 
 ## `0001-fio-remove-non-existent-header-sys-ipc.patch`
 
-Serenity currently doesn't have a <sys/ipc.h> header, so we have to patch the include out.
+Port: fio, remove non existent header sys/ipc.h
+
+Serenity doesn't currently have this header, and
+it doesn't appear to be needed on our platform so
+remove it for the port.
 
 ## `0002-fio-add-serenityos-platform-support.patch`
 
-`fio` abstracts individual operating system support out into to an `os/os-<name>.h` header
-where you can select which platform features are available and implement missing function
-stubs for our operating system. 
+Port: fio - Add SerenityOS platform support
 
-This patch implements basic OS support for Serenity just to get fio up and running.
+`fio` abstracts individual operating system support out into to an
+`os/os-<name>.h` header where you can select which platform features
+are available and implement missing function stubs for our operating
+system.
+
+This patch implements basic OS support for Serenity just to get fio up
+and running.
 
 ## `0003-fio-add-serenityos-support-to-configure.patch`
 
-This patch implements targetos detection for serenity, and also disables shared memory
-support automatically for serenity, as it's not currently supported.
+Port: Add SerenityOS support to configure
+
+This patch implements targetos detection for serenity, and also
+disables shared memory support automatically for serenity, as it's not
+currently supported.
 
 ## `0004-fio-disable-rdtsc-support-for-serenityos.patch`
- 
-This patch disables the function which uses `rdtsc` to get the current clock time,
-as that instruction isn't allowed to be called from user space by serenity.
+
+Port: fio - Disable rdtsc support for serenity
+
+This patch disables the function which uses `rdtsc` to get the current
+clock time, as that instruction isn't allowed to be called from user
+space by serenity.
 
 If you did attempt to call it you would trip a segfault.
+

--- a/Ports/glib/patches/0004-disable-IPV6-support.patch
+++ b/Ports/glib/patches/0004-disable-IPV6-support.patch
@@ -3,7 +3,7 @@ From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Thu, 12 Aug 2021 20:33:11 +0200
 Subject: [PATCH 04/12] meson.build: Disable IPV6 support
 
-Serenity does not ahve IPV6 support so disable it
+Serenity does not have IPV6 support so disable it
 ---
  meson.build | 2 ++
  1 file changed, 2 insertions(+)

--- a/Ports/glib/patches/0013-nameser.h-is-not-needed.patch
+++ b/Ports/glib/patches/0013-nameser.h-is-not-needed.patch
@@ -1,7 +1,7 @@
 From fb55058ea91d87802c696aa58bcaf97a6ff5b827 Mon Sep 17 00:00:00 2001
 From: Kenneth Myhra <kennethmyhra@gmail.com>
 Date: Fri, 13 Aug 2021 22:32:25 +0200
-Subject: [PATCH 13/13] arpa/nameser.h is not needed, and Serenity do not have it at the moment.
+Subject: [PATCH 13/13] arpa/nameser.h is not needed, and Serenity does not have it at the moment.
 
 ---
  gio/gnetworking.h.in | 2 ++

--- a/Ports/glib/patches/ReadMe.md
+++ b/Ports/glib/patches/ReadMe.md
@@ -1,111 +1,67 @@
-# Patches for glib (and submodules) on SerenityOS
+# Patches for glib on SerenityOS
 
 ## `0001-poll.h-is-located-at-root.patch`
 
-glib includes poll.h from sys/poll.h, but our poll.h is located at root.
+meson.build: 'poll.h' is located at root, not 'sys/poll.h'
 
-### Status
-- [ ] Local?
-- [X] Should be merged to upstream?
-- [ ] Resolves issue(s) with our side of things
-- [ ] Hack
 
 ## `0002-use-glib-in-built-C_IN.patch`
 
-We do not have C_IN so use glib's in-built C_IN
+gio/meson.build: Use glib's in-built C_IN
 
-### Status
-- [X] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [ ] Hack
+Since we do not have C_IN and glib has functionality for providing it,
+let glib provide it.
 
 ## `0003-let-glib-know-where-our-resolv.h-is.patch`
 
-Let glib's res_query_test know where our resolv.h is located.
+gio/meson.build: Let glib know where our 'resolv.h' is located
 
-### Status
-- [ ] Local?
-- [X] Should be merged to upstream?
-- [ ] Resolves issue(s) with our side of things
-- [ ] Hack
 
 ## `0004-disable-IPV6-support.patch`
 
-Disable IPV6 support since we do not support that yet.
+meson.build: Disable IPV6 support
 
-### Status
-- [X] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [ ] Hack
+Serenity does not have IPV6 support so disable it
 
 ## `0005-serenity-does-not-have-IN_MULTICAST.patch`
 
-Since Serenity does not have IN_MULTICAST we just return 0 instead of calling IN_MULTICAST.
+gio/ginetaddress.c: Serenity does not have IN_MULTICAST, just return 0
 
-### Status
-- [ ] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [X] Hack
+Since Serenity does not have IN_MULTICAST we just return 0
 
 ## `0006-conflict-rename-gio-mount-function.patch`
 
-Somehow we get a conflict with glib's mount function. This patch renames glib's mount function to gio_mount.
+gio/gio-tool-mount.c: Rename glib/gio mount function to gio_mount
 
-### Status
-- [ ] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [X] Hack
+Somehow glib picks up on Serenity's mount function and gets confused
 
 ## `0009-include-section-with-missing-functionality.patch`
 
-This includes a bigger section with functionality that Serenity is missing.
+gio/gthredresolver.c: Need to include this section
 
-### Status
-- [ ] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [ ] Hack
+Serenity is missing all that is defined in this section so let's
+include it.
 
 ## `0010-stub-for-function-dn_expand.patch`
 
-Adds a stub for the function dn_expand.
+gio/gthreadedresolver.c: Add stub for function dn_expand.
 
-### Status
-- [ ] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [X] Hack
+Serenity is missing dn_expand so include a stub for it
 
 ## `0011-ntohl-ntohs-located-in-arpa-inet.h.patch`
 
-In Serenity ntohl/ntohs is located in arpa/inet.h, other stuff glib needs is included in 'netinet/in.h'.
+gio/xdgmime/xdgmimecache.c: ntohl/ntohs is located in 'arpa/inet.h'
 
-### Status
-- [ ] Local?
-- [X] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [ ] Hack
+In Serenity ntohl/ntohs is located in arpa/inet.h, other stuff glib
+needs is included in 'netinet/in.h'.
 
 ## `0012-include-strings.h-for-strcasecmp.patch`
 
-Include 'strings.h' for strcasecmp.
+Include 'strings.h' for strcasecmp
 
-### Status
-- [ ] Local?
-- [X] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [ ] Hack
 
 ## `0013-nameser.h-is-not-needed.patch`
 
-glib compiles fine without arpa/nameser.h so do not include since we do not yet support it.
+arpa/nameser.h is not needed, and Serenity does not have it at the moment.
 
-### Status
-- [ ] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issue(s) with our side of things
-- [X] Hack
+

--- a/Ports/halflife/patches/ReadMe.md
+++ b/Ports/halflife/patches/ReadMe.md
@@ -1,19 +1,31 @@
-# Patches for halflife
+# Patches for halflife on SerenityOS
 
 ## `fwgs-add-serenity.patch`
 
-Add SerenityOS to the supported architectures of FWGS.
+Build: Add SerenityOS to list of compatible systems
+
+This is required by the build system to spit out a library with
+the correct name/platform.
 
 ## `fwgs-dont-format-nan-loop.patch`
 
-This keeps FWGS from formatting a NaN value multiple times each frame,
-which would otherwise result in a big performance hit.
+Engine: Keep HTTP from endlessly formatting NaN values
+
+For whatever reason, our progress count for HTTP downloads stays at 0.
+This results in the engine calculating a NaN progress value many times
+each frame, which results in a significant performance hit.
 
 ## `hlsdk-add-serenity.patch`
 
-Add SerenityOS to the supported architectures of hlsdk.
+Build: Add SerenityOS to list of compatible systems
+
+This is required by the build system to spit out a library with
+the correct name/platform.
 
 ## `hlsdk-strings-compat.patch`
 
-This bypasses a bunch of `str[n]cmpcase` errors that occur due to weird LibC compatibility problems.
+Build: Add `__STRINGS_H_COMPAT_HACK` macro
+
+This bypasses a bunch of `str[n]cmpcase` errors that occur due to weird
+LibC compatibility problems.
 

--- a/Ports/libuv/patches/ReadMe.md
+++ b/Ports/libuv/patches/ReadMe.md
@@ -1,72 +1,37 @@
-# Patches for LibUV on SerenityOS
+# Patches for libuv on SerenityOS
 
 ## `0001-unix-Stub-out-get-set-priority-for-serenity.patch`
 
-Serenity does not have `{get,set}priority()`, this stubs them out.
+unix: Stub out {get,set}priority for serenity
 
-### Status
-- [X] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issues(s) with our side of things
-- [X] Hack
 
 ## `0002-fs-Stub-out-unsupported-syscalls.patch`
 
-Makes libuv use `statvfs` instead of `statfs`.
+fs: Stub out unsupported syscalls
 
-### Status
-- [ ] Local?
-- [X] Should be merged to upstream?
-- [ ] Resolves issues(s) with our side of things
-- [ ] Hack
 
 ## `0003-stream-Don-t-use-AF_INET6.patch`
 
-Serenity does not support IPv6, this removes them.
+stream: Don't use AF_INET6
 
-### Status
-- [ ] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issues(s) with our side of things
-- [ ] Hack
 
 ## `0004-tcp-Don-t-use-SO_LINGER.patch`
 
-Serenity does not support `SO_LINGER`, this removes them.
+tcp: Don't use SO_LINGER
 
-### Status
-- [ ] Local?
-- [ ] Should be merged to upstream?
-- [X] Resolves issues(s) with our side of things
-- [X] Hack
 
 ## `0005-build-Add-SerenityOS-platform-definitions.patch`
 
-Adds SerenityOS platform definitions to the build.
+build: Add SerenityOS platform definitions
 
-### Status
-- [ ] Local?
-- [X] Should be merged to upstream?
-- [ ] Resolves issues(s) with our side of things
-- [ ] Hack
 
 ## `0006-include-Teach-the-header-about-serenity.patch`
 
-Make the header include guards understand that SerenityOS is a thing.
+include: Teach the header about serenity
 
-### Status
-- [ ] Local?
-- [X] Should be merged to upstream?
-- [ ] Resolves issues(s) with our side of things
-- [ ] Hack
 
 ## `0007-build-Add-platform-specific-stubs-and-implementation.patch`
 
-Adds implementations for libuv's primitives specific to SerenityOS.
+build: Add platform-specific stubs and implementations
 
-### Status
-- [ ] Local?
-- [X] Should be merged to upstream?
-- [ ] Resolves issues(s) with our side of things
-- [ ] Hack
 

--- a/Ports/libzip/patches/ReadMe.md
+++ b/Ports/libzip/patches/ReadMe.md
@@ -5,5 +5,3 @@
 Disable some unneeded options
 
 
-
-

--- a/Ports/lua/patches/ReadMe.md
+++ b/Ports/lua/patches/ReadMe.md
@@ -5,8 +5,3 @@
 Add a serenity target to the makefile
 
 
-
-
-
-
-

--- a/Ports/mandoc/patches/ReadMe.md
+++ b/Ports/mandoc/patches/ReadMe.md
@@ -35,7 +35,6 @@ Use pcre2 for regex
 Use the patched-in version of glob.h
 
 
-
 ## `0008-Build-the-patched-in-glob-implementation.patch`
 
 Build the patched-in glob implementation

--- a/Ports/neofetch/patches/ReadMe.md
+++ b/Ports/neofetch/patches/ReadMe.md
@@ -5,5 +5,3 @@
 Add support for serenity
 
 
-
-

--- a/Ports/openssh/patches/ReadMe.md
+++ b/Ports/openssh/patches/ReadMe.md
@@ -5,9 +5,6 @@
 ifdef out missing functionality
 
 
-
-
-
 ## `0002-Add-a-missing-stdio.h-include.patch`
 
 Add a missing stdio.h include
@@ -18,11 +15,9 @@ Add a missing stdio.h include
 Fix pledges to conform to serenity's pledge()
 
 
-
 ## `0004-Remove-inet_aton-redefinition.patch`
 
 Remove inet_aton() redefinition
-
 
 
 ## `0005-Assume-SSH-2.0-and-sidestep-some-scanf-issues.patch`
@@ -30,11 +25,9 @@ Remove inet_aton() redefinition
 Assume SSH 2.0 and sidestep some scanf issues
 
 
-
 ## `0006-Use-sendfd-recvfd-on-serenity.patch`
 
 Use sendfd/recvfd on serenity
-
 
 
 ## `0007-Use-unveil-for-privsep.patch`

--- a/Ports/openssl/patches/ReadMe.md
+++ b/Ports/openssl/patches/ReadMe.md
@@ -5,10 +5,8 @@
 Add a serenity configuration
 
 
-
 ## `0002-Add-build-configuration-info-for-serenity.patch`
 
 Add build configuration info for serenity
-
 
 

--- a/Ports/openttd/patches/ReadMe.md
+++ b/Ports/openttd/patches/ReadMe.md
@@ -5,7 +5,6 @@
 All sorts of fixes for the build
 
 
-
 ## `0002-Memory.patch`
 
 Memory

--- a/Ports/opfor/patches/ReadMe.md
+++ b/Ports/opfor/patches/ReadMe.md
@@ -1,6 +1,9 @@
-# Patches for opfor
+# Patches for opfor on SerenityOS
 
 ## `hlsdk-add-serenity.patch`
 
-Add SerenityOS to the supported architectures of hlsdk.
+Build: Add SerenityOS to list of compatible systems
+
+This is required by the build system to spit out a library with
+the correct name/platform.
 

--- a/Ports/pcre/patches/ReadMe.md
+++ b/Ports/pcre/patches/ReadMe.md
@@ -3,5 +3,6 @@
 ## `0001-test-Disable-S-on-serenity.patch`
 
 test: Disable '-S' on serenity
+
 This flag uses setrlimit(), which is not supported.
 

--- a/Ports/ruby/patches/ReadMe.md
+++ b/Ports/ruby/patches/ReadMe.md
@@ -5,7 +5,6 @@
 Teach configure about serenity
 
 
-
 ## `0002-Remove-locale-defines.patch`
 
 Remove locale defines

--- a/Ports/sl/patches/ReadMe.md
+++ b/Ports/sl/patches/ReadMe.md
@@ -5,4 +5,3 @@
 Add an install target
 
 
-

--- a/Ports/zlib/patches/ReadMe.md
+++ b/Ports/zlib/patches/ReadMe.md
@@ -2,6 +2,9 @@
 
 ## `fix-cross-compilation.patch`
 
-Backports an upstream fix for a bug that caused the host compiler to be used
-for linking even though the cross-compiler was specified in the `CC`
-environment variable.
+Fix configure issue that discarded provided CC definition.
+
+Backports an upstream fix for a bug that caused the host compiler to be
+used for linking even though the cross-compiler was specified in the
+`CC` environment variable.
+

--- a/Ports/zlib/patches/fix-cross-compilation.patch
+++ b/Ports/zlib/patches/fix-cross-compilation.patch
@@ -3,6 +3,9 @@ From: Mark Adler <madler@alumni.caltech.edu>
 Date: Mon, 28 Mar 2022 18:34:10 -0700
 Subject: [PATCH] Fix configure issue that discarded provided CC definition.
 
+Backports an upstream fix for a bug that caused the host compiler to be
+used for linking even though the cross-compiler was specified in the
+`CC` environment variable.
 ---
  configure | 3 +++
  1 file changed, 3 insertions(+)

--- a/Ports/zstd/patches/ReadMe.md
+++ b/Ports/zstd/patches/ReadMe.md
@@ -5,10 +5,8 @@
 Fix linker soname flags
 
 
-
 ## `0002-Make-platform.h-understand-that-serenity-is-posix-co.patch`
 
 Make platform.h understand that serenity is posix-compliant
-
 
 


### PR DESCRIPTION
This PR (among other things) fixes an issue that I accidentally introduced in #14066, where I unset variables that are necessary for Git to work properly, resulting in `./package.sh dev` being broken.

Additionally, I copied some patch descriptions from the ReadMe into the respective patches, fixed a whitespace issue where lines with `Co-Authored-By` weren't fully deleted, and regenerated all ReadMe files.