### PR TITLE
LibCore+Spreadsheet: Set mime type for sheets files and recognize them by this mime type

### DIFF
--- a/Userland/Applications/Spreadsheet/ExportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ExportDialog.cpp
@@ -292,7 +292,7 @@ Result<void, String> ExportDialog::make_and_run_for(StringView mime, Core::File&
 
     if (mime == "text/csv") {
         return export_xsv();
-    } else if (mime == "text/plain" && file.filename().ends_with(".sheets")) {
+    } else if (mime == "application/x-sheets+json") {
         return export_worksheet();
     } else {
         auto page = GUI::WizardPage::construct(

--- a/Userland/Applications/Spreadsheet/ImportDialog.cpp
+++ b/Userland/Applications/Spreadsheet/ImportDialog.cpp
@@ -245,7 +245,7 @@ Result<NonnullRefPtrVector<Sheet>, String> ImportDialog::make_and_run_for(GUI::W
 
     if (mime == "text/csv") {
         return import_xsv();
-    } else if (mime == "text/plain" && file.filename().ends_with(".sheets")) {
+    } else if (mime == "application/x-sheets+json") {
         return import_worksheet();
     } else {
         auto page = GUI::WizardPage::construct(

--- a/Userland/Libraries/LibCore/MimeData.cpp
+++ b/Userland/Libraries/LibCore/MimeData.cpp
@@ -89,6 +89,8 @@ String guess_mime_type_based_on_filename(StringView path)
         return "text/html";
     if (path.ends_with(".csv", CaseSensitivity::CaseInsensitive))
         return "text/csv";
+    if (path.ends_with(".sheets", CaseSensitivity::CaseInsensitive))
+        return "application/x-sheets+json";
     // FIXME: Share this, TextEditor and HackStudio language detection somehow.
     auto basename = LexicalPath::basename(path);
     if (path.ends_with(".cpp", CaseSensitivity::CaseInsensitive)


### PR DESCRIPTION
- **LibCore: Set mime type for .sheets files to `application/x-sheets+json`**

  This is our own format, used by Spreadsheet.

- **Spreadsheet: Recognize sheets files by mime type, not by file extension**

  These conditions weren’t executed since 933a717f3b and always showed a file import/export wizard.