### PR TITLE
 Ports: AvailablePorts.md: Add link to ports.serenityos.net

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -2,6 +2,8 @@
 
 Please make sure to keep this list up to date when adding and updating ports. :^)
 
+This list is also available at [`https://ports.serenityos.net`](ports.serenityos.net)  
+
 | Port                                                | Name                                                            | Version                  | Website                                                                        |
 |-----------------------------------------------------|-----------------------------------------------------------------|--------------------------|--------------------------------------------------------------------------------|
 | [`Another-World`](Another-World/)                   | Another World Bytecode Interpreter                              |                          | https://github.com/fabiensanglard/Another-World-Bytecode-Interpreter           |


### PR DESCRIPTION
This might be a shameless plug :-O

https://ports.serenityos.net/ is based on and load the data from https://github.com/SerenityOS/serenity/edit/master/Ports/AvailablePorts.md each hour.

Contributors then add icons, screenshots, categories, descriptions etc.

We are at 340+ edits so far but it's still a shitload of data missing. My hope is by adding a link this early on is to increase contributions but I genuinely feel the site add _some_ value over the current listing.