### PR TITLE
Spreadsheet: Simplify file load/save logic

### DIFF
--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.cpp
@@ -125,11 +125,7 @@ SpreadsheetWidget::SpreadsheetWidget(GUI::Window& parent_window, NonnullRefPtrVe
         if (!request_close())
             return;
 
-        Optional<String> load_path = GUI::FilePicker::get_open_filepath(window());
-        if (!load_path.has_value())
-            return;
-
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window(), *load_path);
+        auto response = FileSystemAccessClient::Client::the().try_open_file(window());
         if (response.is_error())
             return;
         load_file(*response.value());

--- a/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
+++ b/Userland/Applications/Spreadsheet/SpreadsheetWidget.h
@@ -23,7 +23,7 @@ class SpreadsheetWidget final
 public:
     virtual ~SpreadsheetWidget() override = default;
 
-    void save(StringView filename);
+    void save(Core::File&);
     void load_file(Core::File&);
     bool request_close();
     void add_sheet();

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -57,11 +57,7 @@ Result<bool, String> Workbook::open_file(Core::File& file)
     auto mime = Core::guess_mime_type_based_on_filename(file.filename());
 
     // Make an import dialog, we might need to import it.
-    auto result = ImportDialog::make_and_run_for(m_parent_window, mime, file, *this);
-    if (result.is_error())
-        return result.error();
-
-    m_sheets = result.release_value();
+    m_sheets = TRY(ImportDialog::make_and_run_for(m_parent_window, mime, file, *this));
 
     set_filename(file.filename());
 
@@ -99,9 +95,7 @@ Result<bool, String> Workbook::save(StringView filename)
     }
 
     // Make an export dialog, we might need to import it.
-    auto result = ExportDialog::make_and_run_for(mime, *file, *this);
-    if (result.is_error())
-        return result.error();
+    TRY(ExportDialog::make_and_run_for(mime, *file, *this));
 
     set_filename(filename);
     set_dirty(false);

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -64,25 +64,14 @@ Result<bool, String> Workbook::open_file(Core::File& file)
     return true;
 }
 
-Result<bool, String> Workbook::save(StringView filename)
+Result<bool, String> Workbook::write_to_file(Core::File& file)
 {
-    auto mime = Core::guess_mime_type_based_on_filename(filename);
-    auto file = Core::File::construct(filename);
-    file->open(Core::OpenMode::WriteOnly);
-    if (!file->is_open()) {
-        StringBuilder sb;
-        sb.append("Failed to open ");
-        sb.append(filename);
-        sb.append(" for write. Error: ");
-        sb.append(file->error_string());
-
-        return sb.to_string();
-    }
+    auto mime = Core::guess_mime_type_based_on_filename(file.filename());
 
     // Make an export dialog, we might need to import it.
-    TRY(ExportDialog::make_and_run_for(mime, *file, *this));
+    TRY(ExportDialog::make_and_run_for(mime, file, *this));
 
-    set_filename(filename);
+    set_filename(file.filename());
     set_dirty(false);
     return true;
 }

--- a/Userland/Applications/Spreadsheet/Workbook.cpp
+++ b/Userland/Applications/Spreadsheet/Workbook.cpp
@@ -64,21 +64,6 @@ Result<bool, String> Workbook::open_file(Core::File& file)
     return true;
 }
 
-Result<bool, String> Workbook::load(StringView filename)
-{
-    auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(&m_parent_window, filename);
-    if (response.is_error()) {
-        StringBuilder sb;
-        sb.append("Failed to open ");
-        sb.append(filename);
-        sb.append(" for reading. Error: ");
-        sb.appendff("{}", response.error());
-        return sb.to_string();
-    }
-
-    return open_file(*response.value());
-}
-
 Result<bool, String> Workbook::save(StringView filename)
 {
     auto mime = Core::guess_mime_type_based_on_filename(filename);

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -18,7 +18,6 @@ public:
     Workbook(NonnullRefPtrVector<Sheet>&& sheets, GUI::Window& parent_window);
 
     Result<bool, String> save(StringView filename);
-    Result<bool, String> load(StringView filename);
     Result<bool, String> open_file(Core::File&);
 
     String const& current_filename() const { return m_current_filename; }

--- a/Userland/Applications/Spreadsheet/Workbook.h
+++ b/Userland/Applications/Spreadsheet/Workbook.h
@@ -17,8 +17,8 @@ class Workbook {
 public:
     Workbook(NonnullRefPtrVector<Sheet>&& sheets, GUI::Window& parent_window);
 
-    Result<bool, String> save(StringView filename);
     Result<bool, String> open_file(Core::File&);
+    Result<bool, String> write_to_file(Core::File&);
 
     String const& current_filename() const { return m_current_filename; }
     bool set_filename(String const& filename);

--- a/Userland/Applications/Spreadsheet/main.cpp
+++ b/Userland/Applications/Spreadsheet/main.cpp
@@ -71,10 +71,8 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     window->show();
 
     if (filename) {
-        auto response = FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, filename);
-        if (response.is_error())
-            return 1;
-        spreadsheet_widget.load_file(*response.value());
+        auto file = TRY(FileSystemAccessClient::Client::the().try_request_file_read_only_approved(window, filename));
+        spreadsheet_widget.load_file(file);
     }
 
     return app->exec();


### PR DESCRIPTION
- **Spreadsheet: Use TRY() on file load and save**
- **Spreadsheet: Remove unused Workbook::load() function**
- **Spreadsheet: Open files using FileSystemAccessClient::try_open_file()**
- **Spreadsheet: Make save functions take a Core::File instead of a filename**
  This allows us to use FileSystemAccessClient functions.