### PR TITLE
Toolchain: Don't compile QEMU with spice support

### DIFF
--- a/Toolchain/BuildQemu.sh
+++ b/Toolchain/BuildQemu.sh
@@ -68,7 +68,8 @@ echo Using $UI_LIB based UI
 pushd "$DIR/Build/qemu"
     "$DIR"/Tarballs/$QEMU_VERSION/configure --prefix="$PREFIX" \
                                             --target-list=aarch64-softmmu,i386-softmmu,x86_64-softmmu \
-                                            --enable-$UI_LIB || exit 1
+                                            --enable-$UI_LIB \
+                                            --disable-spice || exit 1
     make -j "$MAKEJOBS" || exit 1
     make install || exit 1
 popd


### PR DESCRIPTION
Explicitly disable compiling QEMU against spice, since otherwise
when the spice library is installed, QEMU will automatically compile
against it and will fail to start with "qemu-system-i386: Display
spice is incompatible with the GL context".