### PR TITLE
Ports: AvailablePorts.md: Add link to ports.serenityos.net

### DIFF
--- a/Ports/AvailablePorts.md
+++ b/Ports/AvailablePorts.md
@@ -2,6 +2,8 @@
 
 Please make sure to keep this list up to date when adding and updating ports. :^)
 
+This list is also available at [ports.serenityos.net](https://ports.serenityos.net)
+
 | Port                                                | Name                                                            | Version                  | Website                                                                        |
 |-----------------------------------------------------|-----------------------------------------------------------------|--------------------------|--------------------------------------------------------------------------------|
 | [`Another-World`](Another-World/)                   | Another World Bytecode Interpreter                              |                          | https://github.com/fabiensanglard/Another-World-Bytecode-Interpreter           |


### PR DESCRIPTION
https://ports.serenityos.net/ is based on and load the data from [AvailablePorts.md](https://github.com/SerenityOS/serenity/blob/master/Ports/AvailablePorts.md) each hour.

Contributors then add icons, screenshots, categories, descriptions etc.

Right now we are at 380 edits from 4 contributors but coverage is still [spotty](https://ports.serenityos.net/data-coverage-all-ports). My hope is by adding a link this early on(I started working on the site 8 days ago, still a lot of cool stuff to add) is to increase contributions but I genuinely feel the site add _some_ value over the current listing, especially categories and listing of new ports feels useful.