### PR TITLE
Meta: Use Ubuntu 22.04 images for static analysis

### DIFF
--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PVS_STUDIO_ANALYSIS_ARCH: i686
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'

--- a/.github/workflows/sonar-cloud-static-analysis.yml
+++ b/.github/workflows/sonar-cloud-static-analysis.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'
     env:
       # Latest scanner version is tracked on: https://sonarcloud.io/documentation/analysis/scan/sonarscanner/


### PR DESCRIPTION
Fixes https://github.com/SerenityOS/serenity/commit/2f1029e7c40c68284192c0a31b0da87edb58ed20 while `ubuntu-latest` is not `ubuntu-22.04`.

See also https://github.com/SerenityOS/serenity/pull/13776#issuecomment-1136670362.