### PR TITLE
CI: Fix PVS-Studio Static Analysis Build

### DIFF
--- a/.github/workflows/pvs-studio-static-analysis.yml
+++ b/.github/workflows/pvs-studio-static-analysis.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
     name: Static Analysis
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       PVS_STUDIO_ANALYSIS_ARCH: i686
     if: always() && github.repository == 'SerenityOS/serenity' && github.ref == 'refs/heads/master'


### PR DESCRIPTION
It looks like I broke the PVS-Studio Static Analysis build with
https://github.com/SerenityOS/serenity/pull/13776

This commit fixes that by bumping the base OS to ubuntu-22.04