### PR TITLE
HackStudio: Add "Open in New Tab" context menu entry

### DIFF
--- a/Userland/DevTools/HackStudio/HackStudioWidget.cpp
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.cpp
@@ -471,6 +471,7 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     m_new_plain_file_action = create_new_file_action("Plain &File", "/res/icons/16x16/new.png", "");
 
     m_open_selected_action = create_open_selected_action();
+    m_open_selected_in_new_tab_action = create_open_selected_in_new_tab_action();
     m_show_in_file_manager_action = create_show_in_file_manager_action();
 
     m_new_directory_action = create_new_directory_action();
@@ -490,6 +491,7 @@ NonnullRefPtr<GUI::Menu> HackStudioWidget::create_project_tree_view_context_menu
     new_file_submenu.add_action(*m_new_directory_action);
 
     project_tree_view_context_menu->add_action(*m_open_selected_action);
+    project_tree_view_context_menu->add_action(*m_open_selected_in_new_tab_action);
     project_tree_view_context_menu->add_action(*m_show_in_file_manager_action);
     // TODO: Cut, copy, duplicate with new name...
     project_tree_view_context_menu->add_separator();
@@ -580,6 +582,20 @@ NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_action()
     open_selected_action->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png").release_value_but_fixme_should_propagate_errors());
     open_selected_action->set_enabled(true);
     return open_selected_action;
+}
+
+NonnullRefPtr<GUI::Action> HackStudioWidget::create_open_selected_in_new_tab_action()
+{
+    auto open_selected_in_new_tab_action = GUI::Action::create("Open in New &Tab", [this](const GUI::Action&) {
+        auto files = selected_file_paths();
+        for (auto& file : files) {
+            add_new_editor(*m_current_editor_tab_widget);
+            open_file(file);
+        }
+    });
+    open_selected_in_new_tab_action->set_icon(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/open.png").release_value_but_fixme_should_propagate_errors());
+    open_selected_in_new_tab_action->set_enabled(true);
+    return open_selected_in_new_tab_action;
 }
 
 NonnullRefPtr<GUI::Action> HackStudioWidget::create_show_in_file_manager_action()

--- a/Userland/DevTools/HackStudio/HackStudioWidget.h
+++ b/Userland/DevTools/HackStudio/HackStudioWidget.h
@@ -100,6 +100,7 @@ private:
     NonnullRefPtr<GUI::Action> create_new_file_action(String const& label, String const& icon, String const& extension);
     NonnullRefPtr<GUI::Action> create_new_directory_action();
     NonnullRefPtr<GUI::Action> create_open_selected_action();
+    NonnullRefPtr<GUI::Action> create_open_selected_in_new_tab_action();
     NonnullRefPtr<GUI::Action> create_delete_action();
     NonnullRefPtr<GUI::Action> create_new_project_action();
     NonnullRefPtr<GUI::Action> create_switch_to_next_editor_tab_widget_action();
@@ -216,6 +217,7 @@ private:
 
     RefPtr<GUI::Action> m_new_directory_action;
     RefPtr<GUI::Action> m_open_selected_action;
+    RefPtr<GUI::Action> m_open_selected_in_new_tab_action;
     RefPtr<GUI::Action> m_show_in_file_manager_action;
     RefPtr<GUI::Action> m_delete_action;
     RefPtr<GUI::Action> m_tree_view_rename_action;


### PR DESCRIPTION
This action creates a new editor tab and opens the selected file in the
newly created tab.

![hackstudio-demo](https://user-images.githubusercontent.com/45823462/170384302-faddc8b4-50b2-421e-b6d3-302a377cc0c0.gif)

