### PR TITLE
LibC: Make asctime_r() in time.cpp POSIX compliant

### DIFF
--- a/Userland/Libraries/LibC/time.cpp
+++ b/Userland/Libraries/LibC/time.cpp
@@ -208,8 +208,11 @@ char* asctime_r(const struct tm* tm, char* buffer)
     constexpr size_t assumed_len = 26;
     size_t filled_size = strftime(buffer, assumed_len, "%a %b %e %T %Y\n", tm);
 
-    // Verify that the buffer was large enough.
-    VERIFY(filled_size != 0);
+    // If the buffer was not large enough, set EOVERFLOW and return null.
+    if (filled_size == 0) {
+        errno = EOVERFLOW;
+        return nullptr;
+    }
 
     return buffer;
 }


### PR DESCRIPTION
Previously, we passed an expected length of 26 to strftime().
This caused the program to crash if the year was too large.
To fix this, the length has now been set to 68, which still fits inside the buffer.
Time.h could also be improved by resizing the asctime() buffer to not waste space.