### PR TITLE
LibGL: Add glNormal3d and glNormal3dv stubs

### DIFF
--- a/Userland/Libraries/LibGL/GL/gl.h
+++ b/Userland/Libraries/LibGL/GL/gl.h
@@ -645,6 +645,8 @@ GLAPI void glStencilMask(GLuint mask);
 GLAPI void glStencilMaskSeparate(GLenum face, GLuint mask);
 GLAPI void glStencilOp(GLenum sfail, GLenum dpfail, GLenum dppass);
 GLAPI void glStencilOpSeparate(GLenum face, GLenum sfail, GLenum dpfail, GLenum dppass);
+GLAPI void glNormal3d(GLdouble nx, GLdouble ny, GLdouble nz);
+GLAPI void glNormal3dv(GLdouble const* v);
 GLAPI void glNormal3f(GLfloat nx, GLfloat ny, GLfloat nz);
 GLAPI void glNormal3fv(GLfloat const* v);
 GLAPI void glNormalPointer(GLenum type, GLsizei stride, void const* pointer);

--- a/Userland/Libraries/LibGL/GLAPI.cpp
+++ b/Userland/Libraries/LibGL/GLAPI.cpp
@@ -651,6 +651,16 @@ void glNewList(GLuint list, GLenum mode)
     return g_gl_context->gl_new_list(list, mode);
 }
 
+void glNormal3d(GLdouble nx, GLdouble ny, GLdouble nz)
+{
+    g_gl_context->gl_normal(static_cast<GLfloat>(nx), static_cast<GLfloat>(ny), static_cast<GLfloat>(nz));
+}
+
+void glNormal3dv(GLdouble const* v)
+{
+    g_gl_context->gl_normal(static_cast<GLfloat>(v[0]), static_cast<GLfloat>(v[1]), static_cast<GLfloat>(v[2]));
+}
+
 void glNormal3f(GLfloat nx, GLfloat ny, GLfloat nz)
 {
     g_gl_context->gl_normal(nx, ny, nz);


### PR DESCRIPTION
This adds stubs for the missing glNormal3d and glNormal3dv functions.

I call them stubs as the glNormal3f function doesn't appear to do a normal calculation (looks like a stub to me), and did the double versions the same way I saw for glNormal3f.

Lmk if I missed something!