### PR TITLE
LibCore: Add Stream::write_all

### DIFF
--- a/Userland/Libraries/LibCore/InputBitStream.h
+++ b/Userland/Libraries/LibCore/InputBitStream.h
@@ -42,7 +42,7 @@ public:
     }
     virtual bool is_writable() const override { return m_stream.is_writable(); }
     virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_stream.write(bytes); }
-    virtual bool write_or_error(ReadonlyBytes bytes) override { return m_stream.write_or_error(bytes); }
+    virtual ErrorOr<void> write_all(ReadonlyBytes bytes) override { return m_stream.write_all(bytes); }
     virtual bool is_eof() const override { return m_stream.is_eof() && !m_current_byte.has_value(); }
     virtual bool is_open() const override { return m_stream.is_open(); }
     virtual void close() override
@@ -159,7 +159,7 @@ public:
     }
     virtual bool is_writable() const override { return m_stream.is_writable(); }
     virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_stream.write(bytes); }
-    virtual bool write_or_error(ReadonlyBytes bytes) override { return m_stream.write_or_error(bytes); }
+    virtual ErrorOr<void> write_all(ReadonlyBytes bytes) override { return m_stream.write_all(bytes); }
     virtual bool is_eof() const override { return m_stream.is_eof() && !m_current_byte.has_value(); }
     virtual bool is_open() const override { return m_stream.is_open(); }
     virtual void close() override

--- a/Userland/Libraries/LibCore/MemoryStream.h
+++ b/Userland/Libraries/LibCore/MemoryStream.h
@@ -72,13 +72,13 @@ public:
         m_offset += nwritten;
         return nwritten;
     }
-    virtual bool write_or_error(ReadonlyBytes bytes) override
+    virtual ErrorOr<void> write_all(ReadonlyBytes bytes) override
     {
         if (remaining() < bytes.size())
-            return false;
+            return Error::from_errno(EOVERFLOW);
 
         MUST(write(bytes));
-        return true;
+        return {};
     }
 
     Bytes bytes() { return m_bytes; }

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -63,7 +63,7 @@ ErrorOr<ByteBuffer> Stream::read_all()
     return output;
 }
 
-bool Stream::write_or_error(ReadonlyBytes buffer)
+ErrorOr<void> Stream::write_all(ReadonlyBytes buffer)
 {
     VERIFY(buffer.size());
 
@@ -75,13 +75,13 @@ bool Stream::write_or_error(ReadonlyBytes buffer)
                 continue;
             }
 
-            return false;
+            return result.error();
         }
 
         nwritten += result.value();
     } while (nwritten < buffer.size());
 
-    return true;
+    return {};
 }
 
 ErrorOr<off_t> SeekableStream::tell() const

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -45,9 +45,10 @@ public:
     /// bytes written into the stream, or an errno in the case of failure.
     virtual ErrorOr<size_t> write(ReadonlyBytes) = 0;
     /// Same as write, but does not return until either the entire buffer
-    /// contents are written or an error occurs. Returns whether the entire
-    /// contents were written without an error.
-    virtual bool write_or_error(ReadonlyBytes);
+    /// contents are written or an error occurs. Returns success or the error in
+    /// case one occurred.
+    virtual ErrorOr<void> write_all(ReadonlyBytes);
+    inline bool write_or_error(ReadonlyBytes buffer) { return !write_all(buffer).is_error(); }
 
     /// Returns whether the stream has reached the end of file. For sockets,
     /// this most likely means that the protocol has disconnected (in the case


### PR DESCRIPTION
write_or_error is nice, but it lacks a way to get the actual error
that occurred. write_all does essentially the same, but instead of
returning a boolean it returns the actual error.