### PR TITLE
LibGUI+AK: Implement case inversion in Vim emulation

### DIFF
--- a/AK/String.cpp
+++ b/AK/String.cpp
@@ -388,6 +388,11 @@ String String::to_titlecase() const
     return StringUtils::to_titlecase(*this);
 }
 
+String String::invert_case() const
+{
+    return StringUtils::invert_case(*this);
+}
+
 bool operator<(char const* characters, String const& string)
 {
     return string.view() > characters;

--- a/AK/String.h
+++ b/AK/String.h
@@ -121,6 +121,7 @@ public:
     [[nodiscard]] String to_uppercase() const;
     [[nodiscard]] String to_snakecase() const;
     [[nodiscard]] String to_titlecase() const;
+    [[nodiscard]] String invert_case() const;
 
     [[nodiscard]] bool is_whitespace() const { return StringUtils::is_whitespace(*this); }
 

--- a/AK/StringUtils.cpp
+++ b/AK/StringUtils.cpp
@@ -462,6 +462,20 @@ String to_titlecase(StringView str)
     return builder.to_string();
 }
 
+String invert_case(StringView str)
+{
+    StringBuilder builder(str.length());
+
+    for (auto ch : str) {
+        if (is_ascii_lower_alpha(ch))
+            builder.append(to_ascii_uppercase(ch));
+        else
+            builder.append(to_ascii_lowercase(ch));
+    }
+
+    return builder.to_string();
+}
+
 String replace(StringView str, StringView needle, StringView replacement, bool all_occurrences)
 {
     if (str.is_empty())

--- a/AK/StringUtils.h
+++ b/AK/StringUtils.h
@@ -78,6 +78,7 @@ Optional<size_t> find_any_of(StringView haystack, StringView needles, SearchDire
 
 String to_snakecase(StringView);
 String to_titlecase(StringView);
+String invert_case(StringView);
 
 String replace(StringView, StringView needle, StringView replacement, bool all_occurrences = false);
 size_t count(StringView, StringView needle);

--- a/Userland/Libraries/LibGUI/VimEditingEngine.cpp
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.cpp
@@ -1149,6 +1149,10 @@ bool VimEditingEngine::on_key_in_visual_mode(KeyEvent const& event)
             casefold_selection(Casing::Uppercase);
             switch_to_normal_mode();
             return true;
+        case (KeyCode::Key_Tilde):
+            casefold_selection(Casing::Invertcase);
+            switch_to_normal_mode();
+            return true;
         default:
             break;
         }
@@ -1427,6 +1431,9 @@ void VimEditingEngine::casefold_selection(Casing casing)
         return;
     case Casing::Lowercase:
         m_editor->insert_at_cursor_or_replace_selection(m_editor->selected_text().to_lowercase());
+        return;
+    case Casing::Invertcase:
+        m_editor->insert_at_cursor_or_replace_selection(m_editor->selected_text().invert_case());
         return;
     }
 }

--- a/Userland/Libraries/LibGUI/VimEditingEngine.h
+++ b/Userland/Libraries/LibGUI/VimEditingEngine.h
@@ -162,7 +162,8 @@ private:
 
     enum class Casing {
         Uppercase,
-        Lowercase
+        Lowercase,
+        Invertcase
     };
 
     VimMode m_vim_mode { VimMode::Normal };


### PR DESCRIPTION
Add invert_case() to AK to convert uppercase characters to lowercase
and lowercase characters to uppercase.

In Vim emulation, when in visual mode and text selected, on key tilde
`~`, invert the case of the selected text using invert_case().