### PR TITLE
Userland: Depend some apps on WebContent (and others) & Drop CharacterMap from being required

### DIFF
--- a/Userland/Applications/Browser/CMakeLists.txt
+++ b/Userland/Applications/Browser/CMakeLists.txt
@@ -2,7 +2,7 @@ serenity_component(
     Browser
     RECOMMENDED
     TARGETS Browser
-    DEPENDS ImageDecoder RequestServer WebContent WebSocket
+    DEPENDS BrowserSettings ImageDecoder RequestServer WebContent WebSocket
 )
 
 compile_gml(BrowserWindow.gml BrowserWindowGML.h browser_window_gml)

--- a/Userland/Applications/CharacterMap/CMakeLists.txt
+++ b/Userland/Applications/CharacterMap/CMakeLists.txt
@@ -1,6 +1,6 @@
 serenity_component(
     CharacterMap
-    REQUIRED
+    RECOMMENDED
     TARGETS CharacterMap
 )
 

--- a/Userland/Applications/Help/CMakeLists.txt
+++ b/Userland/Applications/Help/CMakeLists.txt
@@ -2,6 +2,7 @@ serenity_component(
     Help
     RECOMMENDED
     TARGETS Help
+    DEPENDS WebContent
 )
 
 compile_gml(HelpWindow.gml HelpWindowGML.h help_window_gml)

--- a/Userland/Applications/Mail/CMakeLists.txt
+++ b/Userland/Applications/Mail/CMakeLists.txt
@@ -2,6 +2,7 @@ serenity_component(
     Mail
     RECOMMENDED
     TARGETS Mail
+    DEPENDS WebContent
 )
 
 compile_gml(MailWindow.gml MailWindowGML.h mail_window_gml)

--- a/Userland/Applications/Spreadsheet/CMakeLists.txt
+++ b/Userland/Applications/Spreadsheet/CMakeLists.txt
@@ -1,6 +1,7 @@
 serenity_component(
     Spreadsheet
     TARGETS Spreadsheet
+    DEPENDS WebContent
 )
 
 compile_gml(CondFormatting.gml CondFormattingGML.h cond_fmt_gml)

--- a/Userland/Applications/Welcome/CMakeLists.txt
+++ b/Userland/Applications/Welcome/CMakeLists.txt
@@ -1,7 +1,7 @@
 serenity_component(
     Welcome
     TARGETS Welcome
-    DEPENDS Help
+    DEPENDS Help WebContent
 )
 
 compile_gml(WelcomeWindow.gml WelcomeWindowGML.h welcome_window_gml)

--- a/Userland/Applications/Welcome/CMakeLists.txt
+++ b/Userland/Applications/Welcome/CMakeLists.txt
@@ -1,6 +1,7 @@
 serenity_component(
     Welcome
     TARGETS Welcome
+    DEPENDS Help
 )
 
 compile_gml(WelcomeWindow.gml WelcomeWindowGML.h welcome_window_gml)

--- a/Userland/DevTools/HackStudio/CMakeLists.txt
+++ b/Userland/DevTools/HackStudio/CMakeLists.txt
@@ -2,7 +2,7 @@ serenity_component(
     HackStudio
     RECOMMENDED
     TARGETS HackStudio
-    DEPENDS CppLanguageServer ShellLanguageServer
+    DEPENDS CppLanguageServer ShellLanguageServer WebContent
 )
 
 add_subdirectory(LanguageServers)

--- a/Userland/Services/WebContent/CMakeLists.txt
+++ b/Userland/Services/WebContent/CMakeLists.txt
@@ -1,6 +1,7 @@
 serenity_component(
     WebContent
     TARGETS WebContent
+    DEPENDS ImageDecoder RequestServer WebSocket
 )
 
 compile_ipc(WebContentServer.ipc WebContentServerEndpoint.h)


### PR DESCRIPTION
- **CharacterMap: Mark this component as ‘recommended’, not ‘required’**

  Despite being a small and useful program, it doesn’t feel being essential enough to be included in every build configuration.

---

- **Browser: Depend on BrowserSettings**

  The app refused to run in the Required+Browser [system configuration], because unveil was angry that BrowserSettings wasn’t being installed.

- **Welcome: Depend on Help**
- **WebContent: Depend on ImageDecoder, RequestServer and WebSocket**
- **Userland: Depend some applications on WebContent if it’s being used**

  Deduced this mostly by looking at unveil()s.

[system configuration]: https://github.com/SerenityOS/serenity/blob/master/Documentation/AdvancedBuildInstructions.md#component-configuration