### PR TITLE
Userland: Replace common spawn patterns with Core::Process::spawn() 

### DIFF
--- a/Userland/Applets/Network/main.cpp
+++ b/Userland/Applets/Network/main.cpp
@@ -12,6 +12,7 @@
 #include <LibGUI/ImageWidget.h>
 #include <LibGUI/Menu.h>
 #include <LibGUI/Notification.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Bitmap.h>
 #include <LibMain/Main.h>
@@ -49,17 +50,7 @@ private:
     {
         if (event.button() != GUI::MouseButton::Primary)
             return;
-
-        pid_t child_pid;
-        char const* argv[] = { "SystemMonitor", "-t", "network", nullptr };
-
-        if ((errno = posix_spawn(&child_pid, "/bin/SystemMonitor", nullptr, nullptr, const_cast<char**>(argv), environ))) {
-            perror("posix_spawn");
-            return;
-        }
-
-        if (disown(child_pid) < 0)
-            perror("disown");
+        GUI::Process::spawn_or_show_error(window(), "/bin/SystemMonitor", Array { "-t", "network" });
     }
 
     virtual void update_widget()

--- a/Userland/Applications/Assistant/Providers.cpp
+++ b/Userland/Applications/Assistant/Providers.cpp
@@ -11,6 +11,7 @@
 #include <LibCore/DirIterator.h>
 #include <LibCore/ElapsedTimer.h>
 #include <LibCore/File.h>
+#include <LibCore/Process.h>
 #include <LibCore/StandardPaths.h>
 #include <LibDesktop/Launcher.h>
 #include <LibGUI/Clipboard.h>
@@ -48,15 +49,10 @@ void FileResult::activate() const
 
 void TerminalResult::activate() const
 {
-    pid_t pid;
-    char const* argv[] = { "Terminal", "-k", "-e", title().characters(), nullptr };
-
-    if ((errno = posix_spawn(&pid, "/bin/Terminal", nullptr, nullptr, const_cast<char**>(argv), environ))) {
-        perror("posix_spawn");
-    } else {
-        if (disown(pid) < 0)
-            perror("disown");
-    }
+    // FIXME: This should be a GUI::Process::spawn_or_show_error(), however this is a
+    // Assistant::Result object, which does not have access to the application's GUI::Window* pointer
+    // (which spawn_or_show_error() needs incase it has to open a error message box).
+    (void)Core::Process::spawn("/bin/Terminal", Array { "-k", "-e", title().characters() });
 }
 
 void URLResult::activate() const

--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.cpp
@@ -15,6 +15,7 @@
 #include <LibGUI/Layout.h>
 #include <LibGUI/Margins.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/Process.h>
 #include <LibGfx/Palette.h>
 #include <LibTimeZone/TimeZone.h>
 #include <LibUnicode/DateTimeFormat.h>
@@ -156,13 +157,7 @@ Optional<Gfx::FloatPoint> TimeZoneSettingsWidget::compute_time_zone_location() c
     return Gfx::FloatPoint { mercadian_x, mercadian_y };
 }
 
-void TimeZoneSettingsWidget::set_time_zone() const
+void TimeZoneSettingsWidget::set_time_zone()
 {
-    pid_t child_pid = 0;
-    char const* argv[] = { "/bin/timezone", m_time_zone.characters(), nullptr };
-
-    if ((errno = posix_spawn(&child_pid, "/bin/timezone", nullptr, nullptr, const_cast<char**>(argv), environ))) {
-        perror("posix_spawn");
-        exit(1);
-    }
+    GUI::Process::spawn_or_show_error(window(), "/bin/timezone", Array { m_time_zone.characters() });
 }

--- a/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.h
+++ b/Userland/Applications/ClockSettings/TimeZoneSettingsWidget.h
@@ -26,7 +26,7 @@ private:
 
     void set_time_zone_location();
     Optional<Gfx::FloatPoint> compute_time_zone_location() const;
-    void set_time_zone() const;
+    void set_time_zone();
 
     String m_time_zone;
     RefPtr<GUI::ComboBox> m_time_zone_combo_box;

--- a/Userland/Applications/CrashReporter/main.cpp
+++ b/Userland/Applications/CrashReporter/main.cpp
@@ -31,6 +31,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/LinkLabel.h>
 #include <LibGUI/MessageBox.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/Progressbar.h>
 #include <LibGUI/TabWidget.h>
 #include <LibGUI/TextEditor.h>
@@ -264,14 +265,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto& debug_button = *widget->find_descendant_of_type_named<GUI::Button>("debug_button");
     debug_button.set_icon(TRY(Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-hack-studio.png")));
     debug_button.on_click = [&](int) {
-        pid_t child;
-        const char* argv[4] = { "HackStudio", "-c", coredump_path, nullptr };
-        if ((errno = posix_spawn(&child, "/bin/HackStudio", nullptr, nullptr, const_cast<char**>(argv), environ))) {
-            perror("posix_spawn");
-        } else {
-            if (disown(child) < 0)
-                perror("disown");
-        }
+        GUI::Process::spawn_or_show_error(window, "/bin/HackStudio", Array { "-c", coredump_path });
     };
 
     auto& save_backtrace_button = *widget->find_descendant_of_type_named<GUI::Button>("save_backtrace_button");

--- a/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
+++ b/Userland/Applications/KeyboardSettings/KeyboardSettingsWidget.cpp
@@ -21,6 +21,7 @@
 #include <LibGUI/Label.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Model.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/Widget.h>
 #include <LibGUI/Window.h>
 #include <LibGfx/Font/FontDatabase.h>
@@ -281,12 +282,6 @@ void KeyboardSettingsWidget::apply_settings()
 
 void KeyboardSettingsWidget::set_keymaps(Vector<String> const& keymaps, String const& active_keymap)
 {
-    pid_t child_pid;
-
     auto keymaps_string = String::join(',', keymaps);
-    char const* argv[] = { "/bin/keymap", "-s", keymaps_string.characters(), "-m", active_keymap.characters(), nullptr };
-    if ((errno = posix_spawn(&child_pid, "/bin/keymap", nullptr, nullptr, const_cast<char**>(argv), environ))) {
-        perror("posix_spawn");
-        exit(1);
-    }
+    GUI::Process::spawn_or_show_error(window(), "/bin/keymap", Array { "-s", keymaps_string.characters(), "-m", active_keymap.characters() });
 }

--- a/Userland/Applications/SystemMonitor/main.cpp
+++ b/Userland/Applications/SystemMonitor/main.cpp
@@ -38,6 +38,7 @@
 #include <LibGUI/Menubar.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
+#include <LibGUI/Process.h>
 #include <LibGUI/SeparatorWidget.h>
 #include <LibGUI/SortingProxyModel.h>
 #include <LibGUI/StackWidget.h>
@@ -470,17 +471,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
         "&Profile Process", { Mod_Ctrl, Key_P },
         Gfx::Bitmap::try_load_from_file("/res/icons/16x16/app-profiler.png").release_value_but_fixme_should_propagate_errors(), [&](auto&) {
             pid_t pid = selected_id(ProcessModel::Column::PID);
-            if (pid != -1) {
-                auto pid_string = String::number(pid);
-                pid_t child;
-                const char* argv[] = { "/bin/Profiler", "--pid", pid_string.characters(), nullptr };
-                if ((errno = posix_spawn(&child, "/bin/Profiler", nullptr, nullptr, const_cast<char**>(argv), environ))) {
-                    perror("posix_spawn");
-                } else {
-                    if (disown(child) < 0)
-                        perror("disown");
-                }
-            }
+            if (pid == -1)
+                return;
+            auto pid_string = String::number(pid);
+            GUI::Process::spawn_or_show_error(window, "/bin/Profiler", Array { "--pid", pid_string.characters() });
         },
         &process_table_view);
 

--- a/Userland/Services/LaunchServer/Launcher.cpp
+++ b/Userland/Services/LaunchServer/Launcher.cpp
@@ -13,6 +13,7 @@
 #include <AK/StringBuilder.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
+#include <LibCore/Process.h>
 #include <LibDesktop/AppFile.h>
 #include <errno.h>
 #include <serenity.h>
@@ -183,20 +184,7 @@ bool Launcher::open_with_handler_name(const URL& url, String const& handler_name
 
 bool spawn(String executable, Vector<String> const& arguments)
 {
-    Vector<char const*> argv { executable.characters() };
-    for (auto& arg : arguments)
-        argv.append(arg.characters());
-    argv.append(nullptr);
-
-    pid_t child_pid;
-    if ((errno = posix_spawn(&child_pid, executable.characters(), nullptr, nullptr, const_cast<char**>(argv.data()), environ))) {
-        perror("posix_spawn");
-        return false;
-    } else {
-        if (disown(child_pid) < 0)
-            perror("disown");
-    }
-    return true;
+    return !Core::Process::spawn(executable, arguments).is_error();
 }
 
 Handler Launcher::get_handler_for_executable(Handler::Type handler_type, String const& executable) const

--- a/Userland/Services/WindowServer/KeymapSwitcher.cpp
+++ b/Userland/Services/WindowServer/KeymapSwitcher.cpp
@@ -7,6 +7,7 @@
 #include <AK/JsonObject.h>
 #include <LibCore/ConfigFile.h>
 #include <LibCore/File.h>
+#include <LibCore/Process.h>
 #include <WindowServer/KeymapSwitcher.h>
 #include <spawn.h>
 #include <unistd.h>
@@ -101,12 +102,9 @@ String KeymapSwitcher::get_current_keymap() const
 
 void KeymapSwitcher::setkeymap(const AK::String& keymap)
 {
-    pid_t child_pid;
-    char const* argv[] = { "/bin/keymap", "-m", keymap.characters(), nullptr };
-    if ((errno = posix_spawn(&child_pid, "/bin/keymap", nullptr, nullptr, const_cast<char**>(argv), environ))) {
-        perror("posix_spawn");
+    if (Core::Process::spawn("/bin/keymap", Array { "-m", keymap.characters() }).is_error())
         dbgln("Failed to call /bin/keymap, error: {} ({})", errno, strerror(errno));
-    }
+
     if (on_keymap_change)
         on_keymap_change(keymap);
 }


### PR DESCRIPTION
Now that the QoL changes from #13999 are merged, we can delete a bunch of duplicate code around userspace :^)