### PR TITLE
LibGfx+FontEditor: Separate handling of font indices and codepoints

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -553,7 +553,7 @@ void FontEditorWidget::initialize(String const& path, RefPtr<Gfx::BitmapFont>&& 
     m_glyph_editor_width_spinbox->set_value(m_edited_font->raw_glyph_width(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
 
     m_glyph_editor_present_checkbox->set_visible(m_edited_font->is_fixed_width());
-    m_glyph_editor_present_checkbox->set_checked(m_edited_font->contains_raw_glyph(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
+    m_glyph_editor_present_checkbox->set_checked(m_edited_font->contains_glyph(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
     m_fixed_width_checkbox->set_checked(m_edited_font->is_fixed_width(), GUI::AllowCallback::No);
 
     m_name_textbox->set_text(m_edited_font->name(), GUI::AllowCallback::No);
@@ -834,7 +834,7 @@ void FontEditorWidget::update_statusbar()
         builder.appendff(" {}", glyph_name.value());
     }
 
-    if (m_edited_font->contains_raw_glyph(glyph))
+    if (m_edited_font->contains_glyph(glyph))
         builder.appendff(" [{}x{}]", m_edited_font->raw_glyph_width(glyph), m_edited_font->glyph_height());
     else if (Gfx::Emoji::emoji_for_code_point(glyph))
         builder.appendff(" [emoji]");
@@ -947,7 +947,7 @@ void FontEditorWidget::paste_glyphs()
     m_glyph_map_widget->set_selection(selection.start() + range_bound_glyph_count - 1, -range_bound_glyph_count + 1);
 
     if (m_edited_font->is_fixed_width())
-        m_glyph_editor_present_checkbox->set_checked(m_edited_font->contains_raw_glyph(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
+        m_glyph_editor_present_checkbox->set_checked(m_edited_font->contains_glyph(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
     else
         m_glyph_editor_width_spinbox->set_value(m_edited_font->raw_glyph_width(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
 

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -49,7 +49,7 @@ void GlyphEditorWidget::paint_event(GUI::PaintEvent& event)
     for (int x = 1; x < font().max_glyph_width(); ++x)
         painter.draw_line({ x * m_scale, 0 }, { x * m_scale, font().glyph_height() * m_scale }, palette().threed_shadow2());
 
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
 
     for (int y = 0; y < font().glyph_height(); ++y) {
         for (int x = 0; x < font().max_glyph_width(); ++x) {
@@ -66,7 +66,7 @@ void GlyphEditorWidget::paint_event(GUI::PaintEvent& event)
 
 bool GlyphEditorWidget::is_glyph_empty()
 {
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     for (int x = 0; x < font().max_glyph_width(); x++)
         for (int y = 0; y < font().glyph_height(); y++)
             if (bitmap.bit_at(x, y))
@@ -87,7 +87,7 @@ void GlyphEditorWidget::mousedown_event(GUI::MouseEvent& event)
         draw_at_mouse(event);
     } else {
         memset(m_movable_bits, 0, sizeof(m_movable_bits));
-        auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+        auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
         for (int x = 0; x < bitmap.width(); x++) {
             for (int y = 0; y < bitmap.height(); y++) {
                 int movable_x = Gfx::GlyphBitmap::max_width() + x;
@@ -136,7 +136,7 @@ void GlyphEditorWidget::draw_at_mouse(GUI::MouseEvent const& event)
         return;
     int x = (event.x() - 1) / m_scale;
     int y = (event.y() - 1) / m_scale;
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     if (x < 0 || x >= bitmap.width())
         return;
     if (y < 0 || y >= bitmap.height())
@@ -153,7 +153,7 @@ void GlyphEditorWidget::move_at_mouse(GUI::MouseEvent const& event)
 {
     int x_delta = ((event.x() - 1) / m_scale) - m_scaled_offset_x;
     int y_delta = ((event.y() - 1) / m_scale) - m_scaled_offset_y;
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     if (abs(x_delta) > bitmap.width() || abs(y_delta) > bitmap.height())
         return;
     for (int x = 0; x < bitmap.width(); x++) {
@@ -190,7 +190,7 @@ void GlyphEditorWidget::rotate_90(Direction direction)
     if (on_undo_event)
         on_undo_event();
 
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     auto matrix = glyph_as_matrix(bitmap);
 
     for (int y = 0; y < bitmap.height(); y++) {
@@ -215,7 +215,7 @@ void GlyphEditorWidget::flip_vertically()
     if (on_undo_event)
         on_undo_event();
 
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     auto matrix = glyph_as_matrix(bitmap);
 
     for (int y = 0; y < bitmap.height(); y++) {
@@ -237,7 +237,7 @@ void GlyphEditorWidget::flip_horizontally()
     if (on_undo_event)
         on_undo_event();
 
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     auto matrix = glyph_as_matrix(bitmap);
 
     for (int y = 0; y < bitmap.height(); y++) {

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.cpp
@@ -42,10 +42,10 @@ NonnullRefPtr<Font> BitmapFont::clone() const
     auto* new_range_mask = static_cast<u8*>(malloc(m_range_mask_size));
     memcpy(new_range_mask, m_range_mask, m_range_mask_size);
     size_t bytes_per_glyph = sizeof(u32) * glyph_height();
-    auto* new_rows = static_cast<u8*>(kmalloc_array(m_glyph_count, bytes_per_glyph));
-    memcpy(new_rows, m_rows, bytes_per_glyph * m_glyph_count);
-    auto* new_widths = static_cast<u8*>(malloc(m_glyph_count));
-    memcpy(new_widths, m_glyph_widths, m_glyph_count);
+    auto* new_rows = static_cast<u8*>(kmalloc_array(glyph_count(), bytes_per_glyph));
+    memcpy(new_rows, m_rows, bytes_per_glyph * glyph_count());
+    auto* new_widths = static_cast<u8*>(malloc(glyph_count()));
+    memcpy(new_widths, m_glyph_widths, glyph_count());
     return adopt_ref(*new BitmapFont(m_name, m_family, new_rows, new_widths, m_fixed_width, m_glyph_width, m_glyph_height, m_glyph_spacing, m_range_mask_size, new_range_mask, m_baseline, m_mean_line, m_presentation_size, m_weight, m_slope, true));
 }
 
@@ -74,7 +74,7 @@ NonnullRefPtr<BitmapFont> BitmapFont::unmasked_character_set() const
     auto* new_rows = static_cast<u8*>(kmalloc_array(s_max_glyph_count, bytes_per_glyph));
     auto* new_widths = static_cast<u8*>(calloc(s_max_glyph_count, 1));
     for (size_t code_point = 0; code_point < s_max_glyph_count; ++code_point) {
-        auto index = glyph_index(code_point);
+        auto index = raw_glyph_index(code_point);
         if (index.has_value()) {
             memcpy(&new_widths[code_point], &m_glyph_widths[index.value()], 1);
             memcpy(&new_rows[code_point * bytes_per_glyph], &m_rows[index.value() * bytes_per_glyph], bytes_per_glyph);
@@ -142,7 +142,8 @@ BitmapFont::BitmapFont(String name, String family, u8* rows, u8* widths, bool is
     for (size_t i = 0, index = 0; i < m_range_mask_size; ++i) {
         for (size_t j = 0; j < 8; ++j) {
             if (m_range_mask[i] & (1 << j)) {
-                m_glyph_count += 256;
+                m_page_count += 1;
+                m_page_indices.append(m_range_indices.size());
                 m_range_indices.append(index++);
             } else {
                 m_range_indices.append({});
@@ -153,7 +154,7 @@ BitmapFont::BitmapFont(String name, String family, u8* rows, u8* widths, bool is
     if (!m_fixed_width) {
         u8 maximum = 0;
         u8 minimum = 255;
-        for (size_t i = 0; i < m_glyph_count; ++i) {
+        for (size_t i = 0; i < glyph_count(); ++i) {
             minimum = min(minimum, m_glyph_widths[i]);
             maximum = max(maximum, m_glyph_widths[i]);
         }
@@ -241,8 +242,8 @@ bool BitmapFont::write_to_file(String const& path)
     size_t bytes_per_glyph = sizeof(u32) * m_glyph_height;
     stream << ReadonlyBytes { &header, sizeof(header) };
     stream << ReadonlyBytes { m_range_mask, m_range_mask_size };
-    stream << ReadonlyBytes { m_rows, m_glyph_count * bytes_per_glyph };
-    stream << ReadonlyBytes { m_glyph_widths, m_glyph_count };
+    stream << ReadonlyBytes { m_rows, glyph_count() * bytes_per_glyph };
+    stream << ReadonlyBytes { m_glyph_widths, glyph_count() };
 
     stream.flush();
     return !stream.handle_any_error();
@@ -250,9 +251,19 @@ bool BitmapFont::write_to_file(String const& path)
 
 Glyph BitmapFont::glyph(u32 code_point) const
 {
-    // Note: Until all fonts support the 0xFFFD replacement
-    // character, fall back to painting '?' if necessary.
-    auto index = glyph_index(code_point).value_or('?');
+    return glyph_at(glyph_index(code_point));
+}
+
+Optional<Glyph> BitmapFont::raw_glyph(u32 code_point) const
+{
+    auto index = raw_glyph_index(code_point);
+    if (!index.has_value())
+        return {};
+    return glyph_at(index.value());
+}
+
+Glyph BitmapFont::glyph_at(size_t index) const
+{
     auto width = m_glyph_widths[index];
     return Glyph(
         GlyphBitmap(m_rows, index * m_glyph_height, { width, m_glyph_height }),
@@ -261,17 +272,25 @@ Glyph BitmapFont::glyph(u32 code_point) const
         m_glyph_height);
 }
 
-Glyph BitmapFont::raw_glyph(u32 code_point) const
+size_t BitmapFont::glyph_index(u32 code_point) const
 {
-    auto width = m_glyph_widths[code_point];
-    return Glyph(
-        GlyphBitmap(m_rows, code_point * m_glyph_height, { width, m_glyph_height }),
-        0,
-        width,
-        m_glyph_height);
+    auto maybe_index = raw_glyph_index(code_point);
+
+    if (!maybe_index.has_value() || glyph_width_at(maybe_index.value()) == 0) {
+        maybe_index = raw_glyph_index(0xFFFD);
+
+        if (!maybe_index.has_value() || glyph_width_at(maybe_index.value()) == 0) {
+            // Note: Until all fonts support the 0xFFFD replacement
+            // character, fall back to painting '?' if necessary.
+            maybe_index = raw_glyph_index('?');
+            VERIFY(maybe_index.has_value());
+        }
+    }
+
+    return maybe_index.value();
 }
 
-Optional<size_t> BitmapFont::glyph_index(u32 code_point) const
+Optional<size_t> BitmapFont::raw_glyph_index(u32 code_point) const
 {
     auto index = code_point / 256;
     if (index >= m_range_indices.size())
@@ -281,18 +300,38 @@ Optional<size_t> BitmapFont::glyph_index(u32 code_point) const
     return m_range_indices[index].value() * 256 + code_point % 256;
 }
 
+u32 BitmapFont::index_to_code_point(size_t index) const
+{
+    size_t page = index / 256;
+    return m_page_indices[page] * 256 + index % 256;
+}
+
 bool BitmapFont::contains_glyph(u32 code_point) const
 {
-    auto index = glyph_index(code_point);
-    return index.has_value() && m_glyph_widths[index.value()] > 0;
+    auto index = raw_glyph_index(code_point);
+    return index.has_value() && glyph_width_at(index.value()) > 0;
 }
 
 u8 BitmapFont::glyph_width(u32 code_point) const
 {
     if (is_ascii(code_point) && !is_ascii_printable(code_point))
         return 0;
-    auto index = glyph_index(code_point);
-    return m_fixed_width || !index.has_value() ? m_glyph_width : m_glyph_widths[index.value()];
+
+    if (m_fixed_width) {
+        return m_glyph_width;
+    }
+
+    return glyph_width_at(glyph_index(code_point));
+}
+
+u8 BitmapFont::raw_glyph_width(u32 code_point) const
+{
+    if (m_fixed_width) {
+        return m_glyph_width;
+    }
+
+    auto index = raw_glyph_index(code_point);
+    return !index.has_value() ? 0 : glyph_width_at(index.value());
 }
 
 int BitmapFont::glyph_or_emoji_width_for_variable_width_font(u32 code_point) const
@@ -300,12 +339,7 @@ int BitmapFont::glyph_or_emoji_width_for_variable_width_font(u32 code_point) con
     // FIXME: This is a hack in lieu of proper code point identification.
     // 0xFFFF is arbitrary but also the end of the Basic Multilingual Plane.
     if (code_point < 0xFFFF) {
-        auto index = glyph_index(code_point);
-        if (!index.has_value())
-            return glyph_width(0xFFFD);
-        if (m_glyph_widths[index.value()] > 0)
-            return glyph_width(code_point);
-        return glyph_width(0xFFFD);
+        return glyph_width(code_point);
     }
 
     auto const* emoji = Emoji::emoji_for_code_point(code_point);

--- a/Userland/Libraries/LibGfx/Font/BitmapFont.h
+++ b/Userland/Libraries/LibGfx/Font/BitmapFont.h
@@ -48,10 +48,20 @@ public:
     virtual u8 slope() const override { return m_slope; }
     void set_slope(u8 slope) { m_slope = slope; }
 
+    /// Returns the glyph with the specified code point if it exists, otherwise
+    /// the fallback glyph.
     Glyph glyph(u32 code_point) const override;
-    Glyph raw_glyph(u32 code_point) const;
+    /// Returns the glyph with the specified code point.
+    Optional<Glyph> raw_glyph(u32 code_point) const;
+    /// Returns the glyph with the specified internal index. Since it is
+    /// unlikely for a font to have all characters filled in, it is inefficient
+    /// to store bitmap data for all unset characters. As a consequence, pages
+    /// of 256 characters may be dropped from memory if they are completely
+    /// empty to reduce memory usage.
+    Glyph glyph_at(size_t index) const;
+    /// Returns whether the glyph with the specified code point exists in this
+    /// font, that is, if it is allocated and has non-zero width.
     bool contains_glyph(u32 code_point) const override;
-    bool contains_raw_glyph(u32 code_point) const { return m_glyph_widths[code_point] > 0; }
 
     ALWAYS_INLINE int glyph_or_emoji_width(u32 code_point) const override
     {
@@ -65,7 +75,8 @@ public:
     int preferred_line_height() const override { return glyph_height() + m_line_gap; }
 
     u8 glyph_width(u32 code_point) const override;
-    u8 raw_glyph_width(u32 code_point) const { return m_glyph_widths[code_point]; }
+    u8 raw_glyph_width(u32 code_point) const;
+    u8 glyph_width_at(size_t index) const { return m_glyph_widths[index]; }
 
     u8 min_glyph_width() const override { return m_min_glyph_width; }
     u8 max_glyph_width() const override { return m_max_glyph_width; }
@@ -98,14 +109,25 @@ public:
     u8 glyph_spacing() const override { return m_glyph_spacing; }
     void set_glyph_spacing(u8 spacing) { m_glyph_spacing = spacing; }
 
+    inline size_t glyph_count() const override { return m_page_count * 256; }
+    /// Returns the index of the glyph that will actually be used to draw this
+    /// code point, that is, either the index of the glyph for this code point
+    /// if it exists (is stored in this font and has non-zero size), otherwise
+    /// the index of the fallback glyph.
+    size_t glyph_index(u32 code_point) const;
+    /// Returns the index of the glyph for this code point, if it is stored in
+    /// this font.
+    Optional<size_t> raw_glyph_index(u32 code_point) const;
+    /// Returns the code point for the glyph at the specified internal index.
+    u32 index_to_code_point(size_t index) const;
+
     void set_glyph_width(u32 code_point, u8 width)
     {
         VERIFY(m_glyph_widths);
-        m_glyph_widths[code_point] = width;
+        auto maybe_index = raw_glyph_index(code_point);
+        VERIFY(maybe_index.has_value());
+        m_glyph_widths[maybe_index.value()] = width;
     }
-
-    size_t glyph_count() const override { return m_glyph_count; }
-    Optional<size_t> glyph_index(u32 code_point) const;
 
     u16 range_size() const { return m_range_mask_size; }
     bool is_range_empty(u32 code_point) const { return !(m_range_mask[code_point / 256 / 8] & 1 << (code_point / 256 % 8)); }
@@ -132,11 +154,12 @@ private:
 
     String m_name;
     String m_family;
-    size_t m_glyph_count { 0 };
+    size_t m_page_count { 0 };
 
     u16 m_range_mask_size { 0 };
     u8* m_range_mask { nullptr };
     Vector<Optional<size_t>> m_range_indices;
+    Vector<size_t> m_page_indices;
 
     u8* m_rows { nullptr };
     u8* m_glyph_widths { nullptr };


### PR DESCRIPTION
BitmapFont internally saved character data in a table that doesn't
necessarily have its indices matching with each glyph's code points,
due to dropping pages of 256 characters when none of those characters
are set to save space. However, the previous BitmapFont::glyph() and
raw_glyph() methods both take a code point as parameter, but differ
in implementation in two ways:

1. glyph() returns '?' character if the actually requested code point
   doesn't exist in the font, and
2. glyph() looks up the glyph index for the bitmap table, while
   raw_glyph passes the code point through as the index directly.

The second behavior is incorrect, since the index into the table
doesn't have to match the code point.

This makes raw_glyph retain its API of taking a code point, but making
it look up the actual index in addition, and returning an optional
Glyph in case the glyph data isn't allocated in memory. Additionally,
this adds a glyph_at function taking an actual index into the table,
copying the previous behavior of raw_glyph. The behavior of glyph_index
has also been changed to return the index of the glyph that glyph()
would return, and an analogue to raw_glyph, raw_glyph_index, retains
the original behavior of glyph_index. Similar changes were also done
to glyph_width and raw_glyph_width, again adding a glyph_width_at which
takes a direct index into the table, as raw_glyph_width did before.

Finally, this adds index_to_codepoint which is the reverse of
raw_glyph_index, taking a table index and returning the corresponding
glyph's code point, to make iterating over all glyphs in the font
easier.