### PR TITLE
LibGfx+FontEditor+Utilities: Add BDF export facilities for fonts

### DIFF
--- a/Userland/Applications/FontEditor/FontEditor.cpp
+++ b/Userland/Applications/FontEditor/FontEditor.cpp
@@ -553,7 +553,7 @@ void FontEditorWidget::initialize(String const& path, RefPtr<Gfx::BitmapFont>&& 
     m_glyph_editor_width_spinbox->set_value(m_edited_font->raw_glyph_width(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
 
     m_glyph_editor_present_checkbox->set_visible(m_edited_font->is_fixed_width());
-    m_glyph_editor_present_checkbox->set_checked(m_edited_font->contains_raw_glyph(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
+    m_glyph_editor_present_checkbox->set_checked(m_edited_font->contains_glyph(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
     m_fixed_width_checkbox->set_checked(m_edited_font->is_fixed_width(), GUI::AllowCallback::No);
 
     m_name_textbox->set_text(m_edited_font->name(), GUI::AllowCallback::No);
@@ -834,7 +834,7 @@ void FontEditorWidget::update_statusbar()
         builder.appendff(" {}", glyph_name.value());
     }
 
-    if (m_edited_font->contains_raw_glyph(glyph))
+    if (m_edited_font->contains_glyph(glyph))
         builder.appendff(" [{}x{}]", m_edited_font->raw_glyph_width(glyph), m_edited_font->glyph_height());
     else if (Gfx::Emoji::emoji_for_code_point(glyph))
         builder.appendff(" [emoji]");
@@ -947,7 +947,7 @@ void FontEditorWidget::paste_glyphs()
     m_glyph_map_widget->set_selection(selection.start() + range_bound_glyph_count - 1, -range_bound_glyph_count + 1);
 
     if (m_edited_font->is_fixed_width())
-        m_glyph_editor_present_checkbox->set_checked(m_edited_font->contains_raw_glyph(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
+        m_glyph_editor_present_checkbox->set_checked(m_edited_font->contains_glyph(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
     else
         m_glyph_editor_width_spinbox->set_value(m_edited_font->raw_glyph_width(m_glyph_map_widget->active_glyph()), GUI::AllowCallback::No);
 

--- a/Userland/Applications/FontEditor/FontEditor.h
+++ b/Userland/Applications/FontEditor/FontEditor.h
@@ -71,6 +71,7 @@ private:
     RefPtr<GUI::Action> m_open_action;
     RefPtr<GUI::Action> m_save_action;
     RefPtr<GUI::Action> m_save_as_action;
+    RefPtr<GUI::Action> m_export_action;
 
     RefPtr<GUI::Action> m_cut_action;
     RefPtr<GUI::Action> m_copy_action;

--- a/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
+++ b/Userland/Applications/FontEditor/GlyphEditorWidget.cpp
@@ -49,7 +49,7 @@ void GlyphEditorWidget::paint_event(GUI::PaintEvent& event)
     for (int x = 1; x < font().max_glyph_width(); ++x)
         painter.draw_line({ x * m_scale, 0 }, { x * m_scale, font().glyph_height() * m_scale }, palette().threed_shadow2());
 
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
 
     for (int y = 0; y < font().glyph_height(); ++y) {
         for (int x = 0; x < font().max_glyph_width(); ++x) {
@@ -66,7 +66,7 @@ void GlyphEditorWidget::paint_event(GUI::PaintEvent& event)
 
 bool GlyphEditorWidget::is_glyph_empty()
 {
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     for (int x = 0; x < font().max_glyph_width(); x++)
         for (int y = 0; y < font().glyph_height(); y++)
             if (bitmap.bit_at(x, y))
@@ -87,7 +87,7 @@ void GlyphEditorWidget::mousedown_event(GUI::MouseEvent& event)
         draw_at_mouse(event);
     } else {
         memset(m_movable_bits, 0, sizeof(m_movable_bits));
-        auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+        auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
         for (int x = 0; x < bitmap.width(); x++) {
             for (int y = 0; y < bitmap.height(); y++) {
                 int movable_x = Gfx::GlyphBitmap::max_width() + x;
@@ -136,7 +136,7 @@ void GlyphEditorWidget::draw_at_mouse(GUI::MouseEvent const& event)
         return;
     int x = (event.x() - 1) / m_scale;
     int y = (event.y() - 1) / m_scale;
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     if (x < 0 || x >= bitmap.width())
         return;
     if (y < 0 || y >= bitmap.height())
@@ -153,7 +153,7 @@ void GlyphEditorWidget::move_at_mouse(GUI::MouseEvent const& event)
 {
     int x_delta = ((event.x() - 1) / m_scale) - m_scaled_offset_x;
     int y_delta = ((event.y() - 1) / m_scale) - m_scaled_offset_y;
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     if (abs(x_delta) > bitmap.width() || abs(y_delta) > bitmap.height())
         return;
     for (int x = 0; x < bitmap.width(); x++) {
@@ -190,7 +190,7 @@ void GlyphEditorWidget::rotate_90(Direction direction)
     if (on_undo_event)
         on_undo_event();
 
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     auto matrix = glyph_as_matrix(bitmap);
 
     for (int y = 0; y < bitmap.height(); y++) {
@@ -215,7 +215,7 @@ void GlyphEditorWidget::flip_vertically()
     if (on_undo_event)
         on_undo_event();
 
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     auto matrix = glyph_as_matrix(bitmap);
 
     for (int y = 0; y < bitmap.height(); y++) {
@@ -237,7 +237,7 @@ void GlyphEditorWidget::flip_horizontally()
     if (on_undo_event)
         on_undo_event();
 
-    auto bitmap = font().raw_glyph(m_glyph).glyph_bitmap();
+    auto bitmap = font().raw_glyph(m_glyph).value().glyph_bitmap();
     auto matrix = glyph_as_matrix(bitmap);
 
     for (int y = 0; y < bitmap.height(); y++) {

--- a/Userland/Libraries/LibCore/InputBitStream.h
+++ b/Userland/Libraries/LibCore/InputBitStream.h
@@ -42,7 +42,7 @@ public:
     }
     virtual bool is_writable() const override { return m_stream.is_writable(); }
     virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_stream.write(bytes); }
-    virtual bool write_or_error(ReadonlyBytes bytes) override { return m_stream.write_or_error(bytes); }
+    virtual ErrorOr<void> write_all(ReadonlyBytes bytes) override { return m_stream.write_all(bytes); }
     virtual bool is_eof() const override { return m_stream.is_eof() && !m_current_byte.has_value(); }
     virtual bool is_open() const override { return m_stream.is_open(); }
     virtual void close() override
@@ -159,7 +159,7 @@ public:
     }
     virtual bool is_writable() const override { return m_stream.is_writable(); }
     virtual ErrorOr<size_t> write(ReadonlyBytes bytes) override { return m_stream.write(bytes); }
-    virtual bool write_or_error(ReadonlyBytes bytes) override { return m_stream.write_or_error(bytes); }
+    virtual ErrorOr<void> write_all(ReadonlyBytes bytes) override { return m_stream.write_all(bytes); }
     virtual bool is_eof() const override { return m_stream.is_eof() && !m_current_byte.has_value(); }
     virtual bool is_open() const override { return m_stream.is_open(); }
     virtual void close() override

--- a/Userland/Libraries/LibCore/MemoryStream.h
+++ b/Userland/Libraries/LibCore/MemoryStream.h
@@ -72,13 +72,13 @@ public:
         m_offset += nwritten;
         return nwritten;
     }
-    virtual bool write_or_error(ReadonlyBytes bytes) override
+    virtual ErrorOr<void> write_all(ReadonlyBytes bytes) override
     {
         if (remaining() < bytes.size())
-            return false;
+            return Error::from_errno(EOVERFLOW);
 
         MUST(write(bytes));
-        return true;
+        return {};
     }
 
     Bytes bytes() { return m_bytes; }

--- a/Userland/Libraries/LibCore/Stream.cpp
+++ b/Userland/Libraries/LibCore/Stream.cpp
@@ -63,7 +63,7 @@ ErrorOr<ByteBuffer> Stream::read_all()
     return output;
 }
 
-bool Stream::write_or_error(ReadonlyBytes buffer)
+ErrorOr<void> Stream::write_all(ReadonlyBytes buffer)
 {
     VERIFY(buffer.size());
 
@@ -75,13 +75,13 @@ bool Stream::write_or_error(ReadonlyBytes buffer)
                 continue;
             }
 
-            return false;
+            return result.error();
         }
 
         nwritten += result.value();
     } while (nwritten < buffer.size());
 
-    return true;
+    return {};
 }
 
 ErrorOr<off_t> SeekableStream::tell() const

--- a/Userland/Libraries/LibCore/Stream.h
+++ b/Userland/Libraries/LibCore/Stream.h
@@ -45,9 +45,10 @@ public:
     /// bytes written into the stream, or an errno in the case of failure.
     virtual ErrorOr<size_t> write(ReadonlyBytes) = 0;
     /// Same as write, but does not return until either the entire buffer
-    /// contents are written or an error occurs. Returns whether the entire
-    /// contents were written without an error.
-    virtual bool write_or_error(ReadonlyBytes);
+    /// contents are written or an error occurs. Returns success or the error in
+    /// case one occurred.
+    virtual ErrorOr<void> write_all(ReadonlyBytes);
+    inline bool write_or_error(ReadonlyBytes buffer) { return !write_all(buffer).is_error(); }
 
     /// Returns whether the stream has reached the end of file. For sockets,
     /// this most likely means that the protocol has disconnected (in the case

--- a/Userland/Libraries/LibGfx/CMakeLists.txt
+++ b/Userland/Libraries/LibGfx/CMakeLists.txt
@@ -14,6 +14,7 @@ set(SOURCES
     Filters/ColorBlindnessFilter.cpp
     Filters/FastBoxBlurFilter.cpp
     Filters/LumaFilter.cpp
+    Font/BDFWriter.cpp
     Font/BitmapFont.cpp
     Font/Emoji.cpp
     Font/FontDatabase.cpp

--- a/Userland/Libraries/LibGfx/Font/BDFWriter.cpp
+++ b/Userland/Libraries/LibGfx/Font/BDFWriter.cpp
@@ -1,0 +1,205 @@
+/*
+ * Copyright (c) 2022, Marco Rebhan <me@dblsaiko.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include "BDFWriter.h"
+#include "FontStyleMapping.h"
+#include <LibCore/FileStream.h>
+
+namespace Gfx {
+
+static ErrorOr<void> vwrite(Core::Stream::Stream& stream, StringView fmtstr, AK::TypeErasedFormatParams& params)
+{
+    String s = String::vformatted(fmtstr, params);
+    return stream.write_all(s.bytes());
+}
+
+template<typename... Parameters>
+static ErrorOr<void> write(Core::Stream::Stream& stream, CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    AK::VariadicFormatParams variadic_format_parameters { parameters... };
+    return vwrite(stream, fmtstr.view(), variadic_format_parameters);
+}
+
+template<typename... Parameters>
+static ErrorOr<void> writeln(Core::Stream::Stream& stream, CheckedFormatString<Parameters...>&& fmtstr, Parameters const&... parameters)
+{
+    AK::VariadicFormatParams variadic_format_parameters { parameters... };
+    TRY(vwrite(stream, fmtstr.view(), variadic_format_parameters));
+    return write(stream, "\n");
+}
+
+static ErrorOr<void> writeln(Core::Stream::Stream& stream)
+{
+    return write(stream, "\n");
+}
+
+static ErrorOr<void> write_font_header(Core::Stream::Stream& stream, BitmapFont const& font);
+
+static ErrorOr<void> write_glyph_data(Core::Stream::Stream& stream, BitmapFont const& font, size_t index);
+
+ErrorOr<void> write_bdf(String const& path, BitmapFont const& font)
+{
+    auto stream = TRY(Core::Stream::File::open(path, Core::Stream::OpenMode::Write | Core::Stream::OpenMode::Truncate));
+    return write_bdf(*stream, font);
+}
+
+ErrorOr<void> write_bdf(Core::Stream::Stream& stream, BitmapFont const& font)
+{
+    TRY(writeln(stream, "STARTFONT 2.1"));
+    TRY(write_font_header(stream, font));
+
+    size_t actual_chars = 0;
+
+    for (size_t i = 0; i < font.glyph_count(); i += 1) {
+        if (font.glyph_width_at(i) == 0)
+            continue; // unset
+
+        Glyph const& g = font.glyph_at(i);
+
+        if (!g.is_glyph_bitmap())
+            continue; // this is a color one, don't export it for now
+
+        actual_chars += 1;
+    }
+
+    TRY(writeln(stream, "CHARS {}", actual_chars));
+
+    for (size_t i = 0; i < font.glyph_count(); i += 1) {
+        if (font.glyph_width_at(i) == 0)
+            continue; // unset
+
+        Glyph const& g = font.glyph_at(i);
+
+        if (!g.is_glyph_bitmap())
+            continue; // this is a color one, don't export it for now
+
+        TRY(write_glyph_data(stream, font, i));
+    }
+
+    TRY(writeln(stream, "ENDFONT"));
+
+    return {};
+}
+
+static ErrorOr<void> write_font_header(Core::Stream::Stream& stream, BitmapFont const& font)
+{
+    TRY(writeln(stream, "COMMENT {}", font.human_readable_name()));
+
+    char const* foundry = "SerenityOS";
+    String const& family = font.family();
+    StringView const& weight = weight_to_name(font.weight());
+    int relative_weight = font.weight() / 10;
+
+    // The RELATIVE_WEIGHT field is defined as ranged 10 - 90, however the max
+    // defined weight in SerenityOS is 950, so shrink range 80-95 into 80-90.
+    if (relative_weight > 80) {
+        relative_weight = 80 + ((relative_weight - 80) / 3 * 2);
+    }
+
+    char const* slant_names[4] = { "R", "I", "O", "RI" };
+    StringView const& slant = font.slope() < 5 ? slant_names[font.slope()] : "OT";
+    char const* width_name = "Normal";
+    char const* additional_style = "";
+    int pixel_size = font.preferred_line_height();
+    int point_size = font.preferred_line_height() * 10;
+    int x_res = 72;
+    int y_res = 72;
+    char const* spacing = font.is_fixed_width() ? "C" : "P";
+    int average_width = (font.max_glyph_width() + font.min_glyph_width()) * 10 / 2;
+    char const* charset_registry = "ISO10646"; // Unicode
+    char const* charset_encoding = "1";
+
+    int line_gap = font.preferred_line_height() - font.glyph_height();
+
+    int descent = font.glyph_height() - font.baseline();
+    int yoff = 1 - descent;
+
+    TRY(writeln(
+        stream,
+        "FONT -{}-{}-{}-{}-{}-{}-{}-{}-{}-{}-{}-{}-{}-{}",
+        foundry,
+        family,
+        weight,
+        slant,
+        width_name,
+        additional_style,
+        pixel_size,
+        point_size,
+        x_res,
+        y_res,
+        spacing,
+        average_width,
+        charset_registry,
+        charset_encoding));
+    TRY(writeln(stream, "SIZE {} {} {}", font.presentation_size(), x_res, y_res));
+    TRY(writeln(stream, "FONTBOUNDINGBOX {} {} {} {}", font.max_glyph_width(), font.glyph_height(), 0, yoff));
+
+    // See https://www.x.org/releases/X11R7.6-RC1/doc/xorg-docs/specs/XLFD/xlfd.html
+    // for more information on these fields.
+    TRY(writeln(stream, "STARTPROPERTIES {}", 19));
+    TRY(writeln(stream, "FAMILY_NAME \"{}\"", family));
+    TRY(writeln(stream, "FOUNDRY \"{}\"", foundry));
+    TRY(writeln(stream, "SETWIDTH_NAME \"{}\"", width_name));
+    TRY(writeln(stream, "ADD_STYLE_NAME \"{}\"", additional_style));
+    TRY(writeln(stream, "WEIGHT_NAME \"{}\"", weight));
+    TRY(writeln(stream, "RELATIVE_WEIGHT {}", relative_weight));
+    TRY(writeln(stream, "SLANT \"{}\"", slant));
+    TRY(writeln(stream, "PIXEL_SIZE {}", pixel_size));
+    TRY(writeln(stream, "POINT_SIZE {}", point_size));
+    TRY(writeln(stream, "RESOLUTION_X {}", x_res));
+    TRY(writeln(stream, "RESOLUTION_Y {}", y_res));
+    TRY(writeln(stream, "SPACING \"{}\"", spacing));
+    TRY(writeln(stream, "AVERAGE_WIDTH {}", average_width));
+    TRY(writeln(stream, "CHARSET_REGISTRY \"{}\"", charset_registry));
+    TRY(writeln(stream, "CHARSET_ENCODING \"{}\"", charset_encoding));
+    TRY(writeln(stream, "FONT_ASCENT {}", font.baseline() + line_gap));
+    TRY(writeln(stream, "FONT_DESCENT {}", descent));
+    TRY(writeln(stream, "X_HEIGHT {}", font.x_height()));
+    TRY(writeln(stream, "DEFAULT_CHAR {}", 65533));
+    TRY(writeln(stream, "ENDPROPERTIES"));
+
+    return {};
+}
+
+static ErrorOr<void> write_glyph_data(Core::Stream::Stream& stream, BitmapFont const& font, size_t index)
+{
+    int descent = font.glyph_height() - font.baseline();
+    int yoff = 1 - descent;
+
+    u32 code_point = font.index_to_codepoint(index);
+    TRY(writeln(stream, "STARTCHAR U+{:04X}", code_point));
+    TRY(writeln(stream, "ENCODING {}", code_point));
+
+    u8 width = font.is_fixed_width() ? font.glyph_fixed_width() : font.glyph_width_at(index);
+
+    TRY(writeln(stream, "SWIDTH {} {}", (width + font.glyph_spacing()) * 1000 / (int)font.point_size(), 0));
+    TRY(writeln(stream, "DWIDTH {} {}", (width + font.glyph_spacing()), 0));
+
+    TRY(writeln(stream, "BBX {} {} {} {}", width, font.glyph_height(), 0, yoff));
+    TRY(writeln(stream, "BITMAP"));
+
+    Glyph const& g = font.glyph_at(index);
+
+    for (int y = 0; y < font.glyph_height(); y += 1) {
+        for (int x_chunk = 0; x_chunk < (width + 7) / 8; x_chunk += 1) {
+            u8 data = 0;
+            auto const& bitmap = g.glyph_bitmap();
+
+            for (int sub_chunk = 0; sub_chunk < 8; sub_chunk += 1) {
+                data = data << 1 | (bitmap.bit_at(x_chunk * 8 + sub_chunk, y) ? 1 : 0);
+            }
+
+            TRY(write(stream, "{:02X}", data));
+        }
+
+        TRY(writeln(stream));
+    }
+
+    TRY(writeln(stream, "ENDCHAR"));
+    return {};
+}
+
+}

--- a/Userland/Libraries/LibGfx/Font/BDFWriter.h
+++ b/Userland/Libraries/LibGfx/Font/BDFWriter.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022, Marco Rebhan <me@dblsaiko.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#pragma once
+
+#include "BitmapFont.h"
+#include <LibCore/Stream.h>
+
+namespace Gfx {
+
+ErrorOr<void> write_bdf(String const& path, BitmapFont const& font);
+
+ErrorOr<void> write_bdf(Core::Stream::Stream& stream, BitmapFont const& font);
+
+}

--- a/Userland/Utilities/CMakeLists.txt
+++ b/Userland/Utilities/CMakeLists.txt
@@ -7,7 +7,7 @@ list(APPEND REQUIRED_TARGETS
     touch tr true umount uname uniq uptime w wc which whoami xargs yes less
 )
 list(APPEND RECOMMENDED_TARGETS
-    adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip init install keymap lsirq lsof lspci man mknod mktemp
+    adjtime aplay abench asctl bt checksum chres cksum copy fortune gunzip gzip font2bdf init install keymap lsirq lsof lspci man mknod mktemp
     nc netstat notify ntpquery open pape passwd pls printf pro shot tar tt unzip zip
 )
 
@@ -116,6 +116,7 @@ target_link_libraries(fgrep LibMain)
 target_link_libraries(file LibGfx LibIPC LibCompress LibMain)
 target_link_libraries(find LibMain)
 target_link_libraries(flock LibMain)
+target_link_libraries(font2bdf LibMain LibGfx)
 target_link_libraries(fortune LibMain)
 target_link_libraries(functrace LibDebug LibX86 LibMain)
 target_link_libraries(gml-format LibGUI LibMain)

--- a/Userland/Utilities/font2bdf.cpp
+++ b/Userland/Utilities/font2bdf.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2022, Marco Rebhan <me@dblsaiko.net>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/ArgsParser.h>
+#include <LibCore/File.h>
+#include <LibCore/System.h>
+#include <LibGfx/Font/BDFWriter.h>
+#include <LibGfx/Font/BitmapFont.h>
+#include <LibMain/Main.h>
+#include <sysexits.h>
+
+ErrorOr<int> serenity_main(Main::Arguments arguments)
+{
+    TRY(Core::System::pledge("stdio rpath wpath cpath"));
+
+    StringView path;
+    StringView output_path;
+
+    Core::ArgsParser args_parser;
+    args_parser.add_positional_argument(path, "Path to font file", "path");
+    args_parser.add_option(output_path, "Path to output file", "output", 'o', "path");
+    args_parser.set_general_help("Convert a SerenityOS font into BDF format.");
+    args_parser.parse(arguments);
+
+    if (!Core::File::exists(path)) {
+        warnln("File does not exist: '{}'", path);
+        return EX_NOINPUT;
+    }
+
+    auto font = Gfx::BitmapFont::load_from_file(path);
+
+    if (!font) {
+        warnln("Failed to load font file: '{}'", path);
+        return EX_DATAERR;
+    }
+
+    OwnPtr<Core::Stream::File> output;
+
+    if (output_path.is_null()) {
+        output = TRY(Core::Stream::File::adopt_fd(fileno(stdout), Core::Stream::OpenMode::Write));
+    } else {
+        auto result = Core::Stream::File::open(output_path, Core::Stream::OpenMode::Write | Core::Stream::OpenMode::Truncate);
+
+        if (result.is_error()) {
+            warnln("Failed to create output file: '{}': {}", path, result.error());
+            return EX_CANTCREAT;
+        }
+
+        output = result.release_value();
+    }
+
+    auto result = Gfx::write_bdf(*output, *font);
+
+    if (result.is_error()) {
+        warnln("Failed to write output file: '{}': {}", path, result.error());
+        return EX_IOERR;
+    }
+
+    return EX_OK;
+}


### PR DESCRIPTION
Adds a [BDF](https://en.wikipedia.org/wiki/Glyph_Bitmap_Distribution_Format) export menu entry in Font Editor, and a font2bdf command-line utility doing the same thing.

Depends on #14104, #14113.