### PR TITLE
Ports: Remove spaces in specifier in 2 printf calls in acpica-tools port

### DIFF
--- a/Ports/acpica-tools/patches/0001--Stop-compiler-warnings-on-dangling-pointer.patch
+++ b/Ports/acpica-tools/patches/0001--Stop-compiler-warnings-on-dangling-pointer.patch
@@ -1,7 +1,7 @@
 From bf6a3c66f9f4a536ad7bab3eb7f149c7062de851 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 27 May 2022 10:18:35 +0300
-Subject: [PATCH 1/2] Stop compiler warnings on dangling pointer
+Subject: [PATCH 1/3] Stop compiler warnings on dangling pointer
 
 ---
  source/components/utilities/utdebug.c | 2 +-

--- a/Ports/acpica-tools/patches/0002-Disable-sprintf-debug-message-due-to-formatting-erro.patch
+++ b/Ports/acpica-tools/patches/0002-Disable-sprintf-debug-message-due-to-formatting-erro.patch
@@ -1,7 +1,7 @@
 From a62c4eb1dcf574cd1f02224cd1120e3435864413 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 27 May 2022 10:19:35 +0300
-Subject: [PATCH 2/2] Disable sprintf debug message due to formatting errors
+Subject: [PATCH 2/3] Disable sprintf debug message due to formatting errors
 
 ---
  source/compiler/dtfield.c | 6 +++---

--- a/Ports/acpica-tools/patches/0003-Fix-printf-bad-specifier-formatting.patch
+++ b/Ports/acpica-tools/patches/0003-Fix-printf-bad-specifier-formatting.patch
@@ -1,0 +1,34 @@
+From 0168b0f6eeaa6322b35681a19f4f9d36723955dc Mon Sep 17 00:00:00 2001
+From: Liav A <liavalb@gmail.com>
+Date: Fri, 27 May 2022 22:00:38 +0300
+Subject: [PATCH 3/3] Fix printf bad specifier formatting
+
+---
+ source/common/dmtable.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/source/common/dmtable.c b/source/common/dmtable.c
+index 440c5fb..d722e3d 100644
+--- a/source/common/dmtable.c
++++ b/source/common/dmtable.c
+@@ -977,7 +977,7 @@ AcpiDmLineHeader (
+     {
+         if (ByteLength)
+         {
+-            AcpiOsPrintf ("[%3.3Xh %4.4d% 4d] %28s : ",
++            AcpiOsPrintf ("[%3.3Xh %4.4d %4d] %28s : ",
+                 Offset, Offset, ByteLength, Name);
+         }
+         else
+@@ -1011,7 +1011,7 @@ AcpiDmLineHeader2 (
+         }
+         else
+         {
+-            AcpiOsPrintf ("%36s % 3d : ",
++            AcpiOsPrintf ("%36s %3d : ",
+                 Name, Value);
+         }
+     }
+-- 
+2.36.0
+

--- a/Ports/acpica-tools/patches/ReadMe.md
+++ b/Ports/acpica-tools/patches/ReadMe.md
@@ -8,3 +8,7 @@ Use static variable to prevent using a dangling pointer from a previous stack tr
 ## `0002-Disable-sprintf-debug-message-due-to-formatting-erro.patch`
 
 Disable sprintf debug message with formatting issues.
+
+## `0003-Fix-printf-bad-specifier-formatting.patch`
+
+Fix sprintf specifier being written in a bad format leading to iASL to crash.


### PR DESCRIPTION
The specifiers are badly written and lead to a crash when using iASL.
This happens because our printf doesn't understand how to handle a space
between the percent symbol and the actual formatted type specifier after
it. To fix this, we just remove the spaces in a new patch file.