### PR TITLE
Ports/acpica-tools: Use `./package.sh dev` to align patches and ReadMe

### DIFF
--- a/Ports/acpica-tools/patches/0001-Stop-compiler-warnings-on-dangling-pointer.patch
+++ b/Ports/acpica-tools/patches/0001-Stop-compiler-warnings-on-dangling-pointer.patch
@@ -1,8 +1,10 @@
-From bf6a3c66f9f4a536ad7bab3eb7f149c7062de851 Mon Sep 17 00:00:00 2001
+From d8b37ad7569de3883ae7d40eb55d3b2fdd763d35 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 27 May 2022 10:18:35 +0300
 Subject: [PATCH 1/3] Stop compiler warnings on dangling pointer
 
+Use static variable to prevent using a dangling pointer from a previous
+stack trace.
 ---
  source/components/utilities/utdebug.c | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
@@ -21,5 +23,5 @@ index f789e68..fd18f5c 100644
  
      AcpiGbl_EntryStackPointer = &CurrentSp;
 -- 
-2.36.0
+2.36.1
 

--- a/Ports/acpica-tools/patches/0002-Disable-sprintf-debug-message-with-formatting-issues.patch
+++ b/Ports/acpica-tools/patches/0002-Disable-sprintf-debug-message-with-formatting-issues.patch
@@ -1,7 +1,7 @@
-From a62c4eb1dcf574cd1f02224cd1120e3435864413 Mon Sep 17 00:00:00 2001
+From a8a2509d9e9a0eb293747fa44a63dd899077db98 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 27 May 2022 10:19:35 +0300
-Subject: [PATCH 2/3] Disable sprintf debug message due to formatting errors
+Subject: [PATCH 2/3] Disable sprintf debug message with formatting issues
 
 ---
  source/compiler/dtfield.c | 6 +++---
@@ -25,5 +25,5 @@ index f931631..f9fb310 100644
          Length = ByteLength;
      }
 -- 
-2.36.0
+2.36.1
 

--- a/Ports/acpica-tools/patches/0003-Fix-printf-bad-specifier-formatting.patch
+++ b/Ports/acpica-tools/patches/0003-Fix-printf-bad-specifier-formatting.patch
@@ -1,8 +1,10 @@
-From 0168b0f6eeaa6322b35681a19f4f9d36723955dc Mon Sep 17 00:00:00 2001
+From 85ad6c144eb08d3cd94a4b28ac57e46df9f9c497 Mon Sep 17 00:00:00 2001
 From: Liav A <liavalb@gmail.com>
 Date: Fri, 27 May 2022 22:00:38 +0300
 Subject: [PATCH 3/3] Fix printf bad specifier formatting
 
+Fix sprintf specifier being written in a bad format leading to iASL to
+crash.
 ---
  source/common/dmtable.c | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
@@ -30,5 +32,5 @@ index 440c5fb..d722e3d 100644
          }
      }
 -- 
-2.36.0
+2.36.1
 

--- a/Ports/acpica-tools/patches/ReadMe.md
+++ b/Ports/acpica-tools/patches/ReadMe.md
@@ -1,14 +1,21 @@
-# Patches for nyancat on SerenityOS
+# Patches for acpica-tools on SerenityOS
 
-## `0001--Stop-compiler-warnings-on-dangling-pointer.patch`
+## `0001-Stop-compiler-warnings-on-dangling-pointer.patch`
 
-Use static variable to prevent using a dangling pointer from a previous stack trace.
+Stop compiler warnings on dangling pointer
 
+Use static variable to prevent using a dangling pointer from a previous
+stack trace.
 
-## `0002-Disable-sprintf-debug-message-due-to-formatting-erro.patch`
+## `0002-Disable-sprintf-debug-message-with-formatting-issues.patch`
 
-Disable sprintf debug message with formatting issues.
+Disable sprintf debug message with formatting issues
+
 
 ## `0003-Fix-printf-bad-specifier-formatting.patch`
 
-Fix sprintf specifier being written in a bad format leading to iASL to crash.
+Fix printf bad specifier formatting
+
+Fix sprintf specifier being written in a bad format leading to iASL to
+crash.
+


### PR DESCRIPTION
This prevents manual changes to the ReadMe to get lost in the future.

Fixes some issues with #14117 and #14110 where the ReadMe and patches were not generated with the `./package.sh dev` command.

Conflicts with #14121 (this has more fixes).