### PR TITLE
Kernel: Simplify the mount syscall before trying to fix the filesystem-mounts hierarchy design

### DIFF
--- a/Kernel/FileSystem/DevPtsFS.cpp
+++ b/Kernel/FileSystem/DevPtsFS.cpp
@@ -12,9 +12,9 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullRefPtr<DevPtsFS>> DevPtsFS::try_create()
+ErrorOr<NonnullRefPtr<FileSystem>> DevPtsFS::try_create()
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) DevPtsFS);
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) DevPtsFS));
 }
 
 DevPtsFS::DevPtsFS() = default;

--- a/Kernel/FileSystem/DevPtsFS.h
+++ b/Kernel/FileSystem/DevPtsFS.h
@@ -20,7 +20,7 @@ class DevPtsFS final : public FileSystem {
 
 public:
     virtual ~DevPtsFS() override;
-    static ErrorOr<NonnullRefPtr<DevPtsFS>> try_create();
+    static ErrorOr<NonnullRefPtr<FileSystem>> try_create();
 
     virtual ErrorOr<void> initialize() override;
     virtual StringView class_name() const override { return "DevPtsFS"sv; }

--- a/Kernel/FileSystem/DevTmpFS.cpp
+++ b/Kernel/FileSystem/DevTmpFS.cpp
@@ -11,9 +11,9 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullRefPtr<DevTmpFS>> DevTmpFS::try_create()
+ErrorOr<NonnullRefPtr<FileSystem>> DevTmpFS::try_create()
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) DevTmpFS);
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) DevTmpFS));
 }
 
 DevTmpFS::DevTmpFS() = default;

--- a/Kernel/FileSystem/DevTmpFS.h
+++ b/Kernel/FileSystem/DevTmpFS.h
@@ -20,7 +20,7 @@ class DevTmpFS final : public FileSystem {
 
 public:
     virtual ~DevTmpFS() override;
-    static ErrorOr<NonnullRefPtr<DevTmpFS>> try_create();
+    static ErrorOr<NonnullRefPtr<FileSystem>> try_create();
 
     virtual ErrorOr<void> initialize() override;
     virtual StringView class_name() const override { return "DevTmpFS"sv; }

--- a/Kernel/FileSystem/Ext2FileSystem.cpp
+++ b/Kernel/FileSystem/Ext2FileSystem.cpp
@@ -49,9 +49,9 @@ static u8 to_ext2_file_type(mode_t mode)
     return EXT2_FT_UNKNOWN;
 }
 
-ErrorOr<NonnullRefPtr<Ext2FS>> Ext2FS::try_create(OpenFileDescription& file_description)
+ErrorOr<NonnullRefPtr<FileSystem>> Ext2FS::try_create(OpenFileDescription& file_description)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) Ext2FS(file_description));
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Ext2FS(file_description)));
 }
 
 Ext2FS::Ext2FS(OpenFileDescription& file_description)

--- a/Kernel/FileSystem/Ext2FileSystem.h
+++ b/Kernel/FileSystem/Ext2FileSystem.h
@@ -86,7 +86,7 @@ public:
         FileSize64bits = 1 << 1,
     };
 
-    static ErrorOr<NonnullRefPtr<Ext2FS>> try_create(OpenFileDescription&);
+    static ErrorOr<NonnullRefPtr<FileSystem>> try_create(OpenFileDescription&);
 
     virtual ~Ext2FS() override;
     virtual ErrorOr<void> initialize() override;

--- a/Kernel/FileSystem/ISO9660FileSystem.cpp
+++ b/Kernel/FileSystem/ISO9660FileSystem.cpp
@@ -168,9 +168,9 @@ private:
     Vector<DirectoryState> m_directory_stack;
 };
 
-ErrorOr<NonnullRefPtr<ISO9660FS>> ISO9660FS::try_create(OpenFileDescription& description)
+ErrorOr<NonnullRefPtr<FileSystem>> ISO9660FS::try_create(OpenFileDescription& description)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) ISO9660FS(description));
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ISO9660FS(description)));
 }
 
 ISO9660FS::ISO9660FS(OpenFileDescription& description)

--- a/Kernel/FileSystem/ISO9660FileSystem.h
+++ b/Kernel/FileSystem/ISO9660FileSystem.h
@@ -305,7 +305,7 @@ public:
         }
     };
 
-    static ErrorOr<NonnullRefPtr<ISO9660FS>> try_create(OpenFileDescription&);
+    static ErrorOr<NonnullRefPtr<FileSystem>> try_create(OpenFileDescription&);
 
     virtual ~ISO9660FS() override;
     virtual ErrorOr<void> initialize() override;

--- a/Kernel/FileSystem/Plan9FileSystem.cpp
+++ b/Kernel/FileSystem/Plan9FileSystem.cpp
@@ -9,9 +9,9 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullRefPtr<Plan9FS>> Plan9FS::try_create(OpenFileDescription& file_description)
+ErrorOr<NonnullRefPtr<FileSystem>> Plan9FS::try_create(OpenFileDescription& file_description)
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) Plan9FS(file_description));
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) Plan9FS(file_description)));
 }
 
 Plan9FS::Plan9FS(OpenFileDescription& file_description)

--- a/Kernel/FileSystem/Plan9FileSystem.h
+++ b/Kernel/FileSystem/Plan9FileSystem.h
@@ -20,7 +20,7 @@ class Plan9FS final : public FileBackedFileSystem {
 
 public:
     virtual ~Plan9FS() override;
-    static ErrorOr<NonnullRefPtr<Plan9FS>> try_create(OpenFileDescription&);
+    static ErrorOr<NonnullRefPtr<FileSystem>> try_create(OpenFileDescription&);
 
     virtual ErrorOr<void> initialize() override;
 

--- a/Kernel/FileSystem/ProcFS.cpp
+++ b/Kernel/FileSystem/ProcFS.cpp
@@ -37,9 +37,9 @@ UNMAP_AFTER_INIT ProcFSComponentRegistry::ProcFSComponentRegistry()
 {
 }
 
-ErrorOr<NonnullRefPtr<ProcFS>> ProcFS::try_create()
+ErrorOr<NonnullRefPtr<FileSystem>> ProcFS::try_create()
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) ProcFS());
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) ProcFS));
 }
 
 ProcFS::ProcFS() = default;

--- a/Kernel/FileSystem/ProcFS.h
+++ b/Kernel/FileSystem/ProcFS.h
@@ -28,7 +28,7 @@ class ProcFS final : public FileSystem {
 
 public:
     virtual ~ProcFS() override;
-    static ErrorOr<NonnullRefPtr<ProcFS>> try_create();
+    static ErrorOr<NonnullRefPtr<FileSystem>> try_create();
 
     virtual ErrorOr<void> initialize() override;
     virtual StringView class_name() const override { return "ProcFS"sv; }

--- a/Kernel/FileSystem/SysFS.cpp
+++ b/Kernel/FileSystem/SysFS.cpp
@@ -68,9 +68,9 @@ SysFSRootDirectory::SysFSRootDirectory()
     m_buses_directory = buses_directory;
 }
 
-ErrorOr<NonnullRefPtr<SysFS>> SysFS::try_create()
+ErrorOr<NonnullRefPtr<FileSystem>> SysFS::try_create()
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) SysFS);
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) SysFS));
 }
 
 SysFS::SysFS() = default;

--- a/Kernel/FileSystem/SysFS.h
+++ b/Kernel/FileSystem/SysFS.h
@@ -118,7 +118,7 @@ class SysFS final : public FileSystem {
 
 public:
     virtual ~SysFS() override;
-    static ErrorOr<NonnullRefPtr<SysFS>> try_create();
+    static ErrorOr<NonnullRefPtr<FileSystem>> try_create();
 
     virtual ErrorOr<void> initialize() override;
     virtual StringView class_name() const override { return "SysFS"sv; }

--- a/Kernel/FileSystem/TmpFS.cpp
+++ b/Kernel/FileSystem/TmpFS.cpp
@@ -10,9 +10,9 @@
 
 namespace Kernel {
 
-ErrorOr<NonnullRefPtr<TmpFS>> TmpFS::try_create()
+ErrorOr<NonnullRefPtr<FileSystem>> TmpFS::try_create()
 {
-    return adopt_nonnull_ref_or_enomem(new (nothrow) TmpFS);
+    return TRY(adopt_nonnull_ref_or_enomem(new (nothrow) TmpFS));
 }
 
 TmpFS::TmpFS() = default;

--- a/Kernel/FileSystem/TmpFS.h
+++ b/Kernel/FileSystem/TmpFS.h
@@ -19,7 +19,7 @@ class TmpFS final : public FileSystem {
 
 public:
     virtual ~TmpFS() override;
-    static ErrorOr<NonnullRefPtr<TmpFS>> try_create();
+    static ErrorOr<NonnullRefPtr<FileSystem>> try_create();
     virtual ErrorOr<void> initialize() override;
 
     virtual StringView class_name() const override { return "TmpFS"sv; }


### PR DESCRIPTION
This is mainly a preparation before I try (again) to fix #11283.
The next PR will try to create a way to fix that issue, hopefully for good.