### PR TITLE
NetworkServer: Support setting default gateway

### DIFF
--- a/Base/usr/share/man/man5/Network.md
+++ b/Base/usr/share/man/man5/Network.md
@@ -20,14 +20,16 @@ The interface that is not listed in this config file is not set up and disabled 
 * `DHCP` (default: `false`) - Whether the DHCP client should be run on this interface.
 * `IPv4Address` (default: `0.0.0.0`) - The static IPv4 address for the interface. Used only when `DHCP` is `false`.
 * `IPv4Netmask` (default: `0.0.0.0`) - The static IPv4 netmask for the interface. Used only when `DHCP` is `false`.
+* `IPv4Gateway` (default: `0.0.0.0`) - The static IPv4 default gateway for the interface. Used only when `DHCP` is `false`.
 
 ## Example
 
 ```ini
-# Set static IP address to 10.0.0.5 and mask to 255.0.0.0
+# Set static IP address to 10.0.0.5/8 and default gateway to 10.0.0.1
 [ep1s0]
 IPv4Address=10.0.0.5
 IPv4Netmask=255.0.0.0
+IPv4Gateway=10.0.0.1
 
 # Try to run DHCP discovery on ep0s8.
 [ep0s8]


### PR DESCRIPTION
This commit adds an IPv4Gateway to Network.ini. If that option is set to
value other than 0.0.0.0, the NetworkServer adds a default route (e.g.
with address 0.0.0.0/0) with the specified destination.