### PR TITLE
WindowServer: Call screen_resolution_changed after window screens clear

### DIFF
--- a/Userland/Services/WindowServer/WindowManager.cpp
+++ b/Userland/Services/WindowServer/WindowManager.cpp
@@ -116,8 +116,6 @@ bool WindowManager::set_screen_layout(ScreenLayout&& screen_layout, bool save, S
 
     reload_icon_bitmaps_after_scale_change();
 
-    Compositor::the().screen_resolution_changed();
-
     tell_wms_screen_rects_changed();
 
     for_each_window_stack([&](auto& window_stack) {
@@ -128,6 +126,8 @@ bool WindowManager::set_screen_layout(ScreenLayout&& screen_layout, bool save, S
         });
         return IterationDecision::Continue;
     });
+
+    Compositor::the().screen_resolution_changed();
 
     if (save)
         Screen::layout().save_config(*m_config);


### PR DESCRIPTION
When the user executes chres to change to a new resolution, the
WindowManager removes for each window its intersections with the
screens (window.screens()) and recalculates its rect. Finally, a
Window::set_rect call sets the window's new rectangle. The set_rect
call also triggers a call to Compositor::invalidate_occlusions which
fills for each window the intersections with the screens again in
window.screens().
In case chres switches to an already present resolution the set_rect
call exits prematurely as it checks if the window's rect really
changed. This means that nobody calls invalidate_occlusions
resulting in a rendering issue for each window.

Moving the call to Compositor::screen_resolution_changed after the
clearing of window.screens() and recalc of the window rect for each
window resolves the rendering issue as screen_resolution_changed
calls invalidate_occlusions.