### PR TITLE
Lagom/Fuzzers: Add CSS parser fuzzer

### DIFF
--- a/Meta/Lagom/Fuzzers/CMakeLists.txt
+++ b/Meta/Lagom/Fuzzers/CMakeLists.txt
@@ -20,6 +20,7 @@ endfunction()
 
 add_simple_fuzzer(FuzzBMPLoader LagomGfx)
 add_simple_fuzzer(FuzzBrotli LagomCompress)
+add_simple_fuzzer(FuzzCSSParser LagomWeb)
 add_simple_fuzzer(FuzzCyrillicDecoder LagomTextCodec)
 add_simple_fuzzer(FuzzDeflateCompression LagomCompress)
 add_simple_fuzzer(FuzzDeflateDecompression LagomCompress)

--- a/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
+++ b/Meta/Lagom/Fuzzers/FuzzCSSParser.cpp
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022, Luke Wilde <lukew@serenityos.org>
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+#include <LibCore/EventLoop.h>
+#include <LibWeb/CSS/Parser/Parser.h>
+#include <LibWeb/DOM/Document.h>
+
+extern "C" int LLVMFuzzerTestOneInput(uint8_t const* data, size_t size)
+{
+    Core::EventLoop loop;
+    auto document = Web::DOM::Document::create();
+    (void)Web::parse_css_stylesheet(Web::CSS::Parser::ParsingContext(document), { data, size });
+    return 0;
+}


### PR DESCRIPTION
With LibWeb now usable in Lagom, we can now fuzz parts of the engine. The first target is the CSS parser :^)