### PR TITLE
Kernel: Do not include AK/Platform.h in mcontext headers

### DIFF
--- a/Kernel/Arch/aarch64/mcontext.h
+++ b/Kernel/Arch/aarch64/mcontext.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Platform.h>
 #include <Kernel/API/POSIX/sys/types.h>
 
 #ifdef __cplusplus

--- a/Kernel/Arch/mcontext.h
+++ b/Kernel/Arch/mcontext.h
@@ -6,10 +6,8 @@
 
 #pragma once
 
-#include <AK/Platform.h>
-
-#if ARCH(X86_64) || ARCH(I386)
+#if defined(__i386__) || defined(__x86_64__)
 #    include <Kernel/Arch/x86/mcontext.h>
-#elif ARCH(AARCH64)
+#elif defined(__aarch64__)
 #    include <Kernel/Arch/aarch64/mcontext.h>
 #endif

--- a/Kernel/Arch/x86/mcontext.h
+++ b/Kernel/Arch/x86/mcontext.h
@@ -6,7 +6,6 @@
 
 #pragma once
 
-#include <AK/Platform.h>
 #include <Kernel/API/POSIX/sys/types.h>
 
 #ifdef __cplusplus
@@ -14,7 +13,7 @@ extern "C" {
 #endif
 
 struct __attribute__((packed)) __mcontext {
-#if ARCH(I386)
+#ifdef __i386__
     uint32_t eax;
     uint32_t ecx;
     uint32_t edx;


### PR DESCRIPTION
Including signal.h would cause several ports to fail on build, because it would end up including AK/Platform.h through these mcontext headers. This is problematic because AK/Platform.h defines several macros with very common names, such as `NAKED` (breaks radare2), and `NO_SANITIZE_ADDRESS` and `ALWAYS_INLINE` (breaks ruby).