### PR TITLE
Browser: Always show menu for additional bookmarks when one is hidden

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -233,7 +233,7 @@ void BookmarksBarWidget::update_content_size()
 
     for (size_t i = 0; i < m_bookmarks.size(); ++i) {
         auto& bookmark = m_bookmarks.at(i);
-        if (x_position + bookmark.width() > width()) {
+        if (x_position + bookmark.width() + m_additional->width() > width()) {
             m_last_visible_index = i;
             break;
         }


### PR DESCRIPTION
This pull request fixes the additional bookmarks menu button getting pushed all they way to the right until a bookmark is out of bounds of the bar by instead collapsing a bookmark into the menu as soon as it intersects with the additional button.

master:

https://user-images.githubusercontent.com/42888162/170989535-d7719367-f2c4-46bb-ab76-4b8fbabd7687.mp4

this pull request:

https://user-images.githubusercontent.com/42888162/170989595-8707cf58-4334-4cce-b313-730df3e0a010.mp4


