### PR TITLE
LibC: Declare and implement some functions in <complex.h>

### DIFF
--- a/Userland/Libraries/LibC/complex.cpp
+++ b/Userland/Libraries/LibC/complex.cpp
@@ -5,6 +5,7 @@
  */
 
 #include <complex.h>
+#include <math.h>
 
 extern "C" {
 
@@ -43,4 +44,95 @@ long double(cimagl)(long double complex z)
 {
     return cimagl(z);
 }
+
+
+// https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/functions/cabs.html
+float cabsf(float complex z)
+{
+    return hypotf(crealf(z), cimagf(z));
+}
+
+double cabs(double complex z)
+{
+    return hypot(creal(z), cimag(z));
+}
+
+long double cabsl(long double complex z)
+{
+    return hypotl(creall(z), cimagl(z));
+}
+
+// https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/functions/carg.html
+float cargf(float complex z)
+{
+    return atan2f(cimagf(z), crealf(z));
+}
+
+double carg(double complex z)
+{
+    return atan2(cimag(z), creal(z));
+}
+
+long double cargl(long double complex z)
+{
+    return atan2l(cimagl(z), creall(z));
+}
+
+// https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/functions/clog.html
+float complex clogf(float complex z)
+{
+    return CMPLXF(logf(cabsf(z)), cargf(z));
+}
+
+double complex clog(double complex z)
+{
+    return CMPLX(log(cabs(z)), carg(z));
+}
+
+long double complex clogl(long double complex z)
+{
+    return CMPLXL(logl(cabsl(z)), cargl(z));
+}
+
+// https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/functions/conj.html
+float complex conjf(float complex z)
+{
+    return CMPLXF(crealf(z), -cimagf(z));
+}
+
+double complex conj(double complex z)
+{
+    return CMPLX(creal(z), -cimag(z));
+}
+
+long double complex conj(long double complex z)
+{
+    return CMPLXL(creall(z), -cimagl(z));
+}
+
+// https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/functions/cproj.html
+float complex cprojf(float complex z)
+{
+    if (isinf(crealf(z)) || isinf(cimagf(z))) {
+        return CMPLXF(INFINITY, copysignf(0.0f, cimagf(z)));
+    }
+    return z;
+}
+
+double complex cproj(double complex z)
+{
+    if (isinf(creal(z)) || isinf(cimag(z))) {
+        return CMPLX(INFNINITY, copysign(0.0, cimag(z)));
+    }
+    return z;
+}
+
+long double complex cprojl(long double complex z)
+{
+    if (isinf(creall(z)) || isinf(cimagl(z))) {
+        return CMPLXL(INFINITY, copysignl(0.0L, cimagl(z)));
+    }
+    return z;
+}
+
 }

--- a/Userland/Libraries/LibC/complex.cpp
+++ b/Userland/Libraries/LibC/complex.cpp
@@ -122,7 +122,7 @@ float complex cprojf(float complex z)
 double complex cproj(double complex z)
 {
     if (isinf(creal(z)) || isinf(cimag(z))) {
-        return CMPLX(INFNINITY, copysign(0.0, cimag(z)));
+        return CMPLX(INFINITY, copysign(0.0, cimag(z)));
     }
     return z;
 }

--- a/Userland/Libraries/LibC/complex.h
+++ b/Userland/Libraries/LibC/complex.h
@@ -41,4 +41,24 @@ long double cimagl(long double complex z);
 #define cimagf(z) ((float)__imag__((float complex)z))
 #define cimagl(z) ((long double)__imag__((long double complex)z))
 
+double cabs(double complex z);
+flot cabsf(float complex z);
+long double cabsl(long double complex z);
+
+double carg(double complex z);
+float cargf(float complex z);
+long double cargl(long double complex z);
+
+double complex clog(double complex z);
+float complex clogf(float complex z);
+long double complex clogl(long double complex z);
+
+double complex conj(double complex z);
+float complex conjf(float complex z);
+long double complex conjl(long double complex z);
+
+double complex cproj(double complex z);
+float complex cprojf(float complex z);
+long double complex cprojl(long double complex z);
+
 __END_DECLS


### PR DESCRIPTION
In this commit one will find the declarations and implementations of the function families of cabs, conj, cproj, clog and carg.  
These implementations are pretty straightforward and just follow the mathematical definitions.
Useful links:
- https://www.open-std.org/jtc1/sc22/wg14/www/docs/n2731.pdf
- https://pubs.opengroup.org/onlinepubs/9699919799.2018edition/