### PR TITLE
DHCPClient: Don't reset the interface if its already configured

### DIFF
--- a/Userland/Services/DHCPClient/DHCPv4Client.cpp
+++ b/Userland/Services/DHCPClient/DHCPv4Client.cpp
@@ -151,18 +151,15 @@ void DHCPv4Client::try_discover_ifs()
     if (ifs_result.is_error())
         return;
 
-    dbgln("Interfaces with DHCP enabled: {}", m_interfaces_with_dhcp_enabled);
+    dbgln_if(DHCPV4CLIENT_DEBUG, "Interfaces with DHCP enabled: {}", m_interfaces_with_dhcp_enabled);
     bool sent_discover_request = false;
     Interfaces& ifs = ifs_result.value();
     for (auto& iface : ifs.ready) {
-        dbgln("Checking interface {} / {}", iface.ifname, iface.current_ip_address);
+        dbgln_if(DHCPV4CLIENT_DEBUG, "Checking interface {} / {}", iface.ifname, iface.current_ip_address);
         if (!m_interfaces_with_dhcp_enabled.contains_slow(iface.ifname))
             continue;
-        if (iface.current_ip_address != IPv4Address { 0, 0, 0, 0 }) {
-            dbgln_if(DHCPV4CLIENT_DEBUG, "Resetting params for {}", iface.ifname);
-            set_params(iface, IPv4Address { 0, 0, 0, 0 }, IPv4Address { 0, 0, 0, 0 }, {});
-            iface.current_ip_address = IPv4Address { 0, 0, 0, 0 };
-        }
+        if (iface.current_ip_address != IPv4Address { 0, 0, 0, 0 })
+            continue;
 
         dhcp_discover(iface);
         sent_discover_request = true;


### PR DESCRIPTION
Resetting the interface just based on the fact that it already has an IP assigned doesn't make much sense, considering that we frequently end up here after having configured an interface via DHCP already.

Instead, just keep the part that prevents us from sending DHCP discoveries to interfaces that shouldn't be using DHCP.

While we are at it, place some of the logging behind a debug flag, as this function is apparently meant to be run frequently.

This partially reverts commit e14d4482a18f250787cbf64bae596de1f7278d8d.