### PR TITLE
Toolchain: Update Platform files to match those in upstream cmake

### DIFF
--- a/Toolchain/CMake/ClangToolchain.txt.in
+++ b/Toolchain/CMake/ClangToolchain.txt.in
@@ -1,9 +1,10 @@
-list(APPEND CMAKE_MODULE_PATH "@SERENITY_SOURCE_DIR@/Toolchain/CMake")
+if (${CMAKE_VERSION} VERSION_LESS "3.25.0")
+  list(APPEND CMAKE_MODULE_PATH "@SERENITY_SOURCE_DIR@/Toolchain/CMake")
+endif()
 
 set(CMAKE_SYSTEM_NAME SerenityOS)
 set(CMAKE_SYSTEM_PROCESSOR "@SERENITY_ARCH@")
 
-set(SERENITYOS 1)
 set(triple @SERENITY_ARCH@-pc-serenity)
 set(TOOLCHAIN_ROOT @SERENITY_SOURCE_DIR@/Toolchain/Local/clang/)
 set(TOOLCHAIN_PATH ${TOOLCHAIN_ROOT}/bin)
@@ -27,8 +28,6 @@ set(CMAKE_OBJCOPY ${TOOLCHAIN_PATH}/llvm-objcopy)
 set(CMAKE_RANLIB ${TOOLCHAIN_PATH}/llvm-ranlib)
 set(CMAKE_STRIP ${TOOLCHAIN_PATH}/llvm-strip)
 set(SERENITY_CXXFILT ${TOOLCHAIN_PATH}/llvm-cxxfilt)
-
-set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack,-z,max-page-size=0x1000,-z,separate-code")
 
 # FIXME: We could eliminate this setting by building LibC and support asm files (crti.o, crtn.o)
 #        in a separate build stage before the main build to ensure that LibC is available

--- a/Toolchain/CMake/GNUToolchain.txt.in
+++ b/Toolchain/CMake/GNUToolchain.txt.in
@@ -1,9 +1,10 @@
-list(APPEND CMAKE_MODULE_PATH "@SERENITY_SOURCE_DIR@/Toolchain/CMake")
+if (${CMAKE_VERSION} VERSION_LESS "3.25.0")
+  list(APPEND CMAKE_MODULE_PATH "@SERENITY_SOURCE_DIR@/Toolchain/CMake")
+endif()
 
 set(CMAKE_SYSTEM_NAME SerenityOS)
 set(CMAKE_SYSTEM_PROCESSOR "@SERENITY_ARCH@")
 
-set(SERENITYOS 1)
 set(triple @SERENITY_ARCH@-pc-serenity)
 set(TOOLCHAIN_PATH @SERENITY_SOURCE_DIR@/Toolchain/Local/@SERENITY_ARCH@/bin)
 set(TOOLCHAIN_PREFIX ${TOOLCHAIN_PATH}/${triple}-)
@@ -24,8 +25,6 @@ set(CMAKE_OBJCOPY ${TOOLCHAIN_PREFIX}objcopy)
 set(CMAKE_RANLIB ${TOOLCHAIN_PREFIX}gcc-ranlib)
 set(CMAKE_STRIP ${TOOLCHAIN_PREFIX}strip)
 set(SERENITY_CXXFILT ${TOOLCHAIN_PREFIX}c++filt)
-
-set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack,-z,max-page-size=0x1000,-z,separate-code")
 
 # FIXME: We could eliminate this setting by building LibC and support asm files (crti.o, crtn.o)
 #        in a separate build stage before the main build to ensure that LibC is available

--- a/Toolchain/CMake/Platform/README.md
+++ b/Toolchain/CMake/Platform/README.md
@@ -1,0 +1,4 @@
+
+This directory contains Platform files for CMake to identify flags for SerenityOS when ``CMAKE_SYSTEM_NAME`` is "SerenityOS".
+
+Please keep these files in sync with upstream ``Modules/Platform/SerenityOS*.cmake`` in https://gitlab.kitware.com/cmake/cmake

--- a/Toolchain/CMake/Platform/SerenityOS-Clang-ASM.cmake
+++ b/Toolchain/CMake/Platform/SerenityOS-Clang-ASM.cmake
@@ -1,0 +1,2 @@
+include(Platform/SerenityOS-GNU)
+__serenity_compiler_gnu(ASM)

--- a/Toolchain/CMake/Platform/SerenityOS-Clang-C.cmake
+++ b/Toolchain/CMake/Platform/SerenityOS-Clang-C.cmake
@@ -1,0 +1,2 @@
+include(Platform/SerenityOS-GNU)
+__serenity_compiler_gnu(C)

--- a/Toolchain/CMake/Platform/SerenityOS-Clang-CXX.cmake
+++ b/Toolchain/CMake/Platform/SerenityOS-Clang-CXX.cmake
@@ -1,0 +1,2 @@
+include(Platform/SerenityOS-GNU)
+__serenity_compiler_gnu(CXX)

--- a/Toolchain/CMake/Platform/SerenityOS-GNU-ASM.cmake
+++ b/Toolchain/CMake/Platform/SerenityOS-GNU-ASM.cmake
@@ -1,0 +1,2 @@
+include(Platform/SerenityOS-GNU)
+__serenity_compiler_gnu(ASM)

--- a/Toolchain/CMake/Platform/SerenityOS-GNU-C.cmake
+++ b/Toolchain/CMake/Platform/SerenityOS-GNU-C.cmake
@@ -1,0 +1,2 @@
+include(Platform/SerenityOS-GNU)
+__serenity_compiler_gnu(C)

--- a/Toolchain/CMake/Platform/SerenityOS-GNU-CXX.cmake
+++ b/Toolchain/CMake/Platform/SerenityOS-GNU-CXX.cmake
@@ -1,0 +1,2 @@
+include(Platform/SerenityOS-GNU)
+__serenity_compiler_gnu(CXX)

--- a/Toolchain/CMake/Platform/SerenityOS-GNU.cmake
+++ b/Toolchain/CMake/Platform/SerenityOS-GNU.cmake
@@ -1,0 +1,24 @@
+# This module is shared by multiple languages; use include blocker.
+include_guard()
+
+set(CMAKE_EXE_LINKER_FLAGS_INIT "-Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack,-z,separate-code,-z,max-page-size=0x1000")
+
+macro(__serenity_compiler_gnu lang)
+  set(CMAKE_SHARED_LIBRARY_RUNTIME_${lang}_FLAG "-Wl,-rpath,")
+  set(CMAKE_SHARED_LIBRARY_RUNTIME_${lang}_FLAG_SEP ":")
+  set(CMAKE_SHARED_LIBRARY_RPATH_LINK_${lang}_FLAG "-Wl,-rpath-link,")
+  set(CMAKE_SHARED_LIBRARY_SONAME_${lang}_FLAG "-Wl,-soname,")
+  set(CMAKE_EXE_EXPORTS_${lang}_FLAG "-Wl,--export-dynamic")
+
+  set(CMAKE_SHARED_LIBRARY_CREATE_${lang}_FLAGS "-shared -Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack,-z,separate-code")
+
+  # Initialize link type selection flags.  These flags are used when
+  # building a shared library, shared module, or executable that links
+  # to other libraries to select whether to use the static or shared
+  # versions of the libraries.
+  foreach(type SHARED_LIBRARY SHARED_MODULE EXE)
+    set(CMAKE_${type}_LINK_STATIC_${lang}_FLAGS "-Wl,-Bstatic")
+    set(CMAKE_${type}_LINK_DYNAMIC_${lang}_FLAGS "-Wl,-Bdynamic")
+  endforeach()
+
+endmacro()

--- a/Toolchain/CMake/Platform/SerenityOS.cmake
+++ b/Toolchain/CMake/Platform/SerenityOS.cmake
@@ -1,24 +1,12 @@
+
+set(SERENITYOS 1)
+
 set(CMAKE_DL_LIBS "-ldl")
-set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG "-Wl,-rpath,")
-set(CMAKE_SHARED_LIBRARY_RUNTIME_C_FLAG_SEP ":")
 set(CMAKE_SHARED_LIBRARY_RPATH_ORIGIN_TOKEN "\$ORIGIN")
-set(CMAKE_SHARED_LIBRARY_RPATH_LINK_C_FLAG "-Wl,-rpath-link,")
-set(CMAKE_SHARED_LIBRARY_SONAME_C_FLAG "-Wl,-soname,")
-set(CMAKE_EXE_EXPORTS_C_FLAG "-Wl,--export-dynamic")
 set(CMAKE_SHARED_LIBRARY_SUFFIX ".so")
-set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-shared -Wl,--hash-style=gnu,-z,relro,-z,now,-z,noexecstack,-z,separate-code")
 
 # Shared libraries with no builtin soname may not be linked safely by
 # specifying the file path.
 set(CMAKE_PLATFORM_USES_PATH_WHEN_NO_SONAME 1)
-
-# Initialize C link type selection flags.  These flags are used when
-# building a shared library, shared module, or executable that links
-# to other libraries to select whether to use the static or shared
-# versions of the libraries.
-foreach(type SHARED_LIBRARY SHARED_MODULE EXE)
-  set(CMAKE_${type}_LINK_STATIC_C_FLAGS "-Wl,-Bstatic")
-  set(CMAKE_${type}_LINK_DYNAMIC_C_FLAGS "-Wl,-Bdynamic")
-endforeach()
 
 include(Platform/UnixPaths)


### PR DESCRIPTION
Serenity support was merged into the CMake master branch for the 3.25.0
milestone (https://gitlab.kitware.com/cmake/cmake/-/merge_requests/6837)

Remove some settings that are now redundant from the Toolchain files.