### PR TITLE
LibArchive/Tar: Handle ESPIPE on seek instead of crashing

### DIFF
--- a/Userland/Libraries/LibArchive/TarStream.h
+++ b/Userland/Libraries/LibArchive/TarStream.h
@@ -44,6 +44,8 @@ public:
     ErrorOr<void> for_each_extended_header(F func);
 
 private:
+    bool discard(size_t count);
+
     TarFileHeader m_header;
     InputStream& m_stream;
     unsigned long m_file_offset { 0 };


### PR DESCRIPTION
If the tar file is from standard input, we would crash when asserting on the result of `InputFileStream::discard_or_error()`, which returns false because we cannot seek on a pipe. Instead, we can handle this error by reading from the pipe.