### PR TITLE
LibGUI+WindowServer: Propagate action icon changes to buttons and menus

### DIFF
--- a/Userland/Libraries/LibGUI/Action.cpp
+++ b/Userland/Libraries/LibGUI/Action.cpp
@@ -225,7 +225,15 @@ void Action::set_group(Badge<ActionGroup>, ActionGroup* group)
 
 void Action::set_icon(Gfx::Bitmap const* icon)
 {
+    if (m_icon == icon)
+        return;
     m_icon = icon;
+    for_each_toolbar_button([icon](auto& button) {
+        button.set_icon(icon);
+    });
+    for_each_menu_item([](auto& menu_item) {
+        menu_item.update_from_action({});
+    });
 }
 
 void Action::set_text(String text)

--- a/Userland/Libraries/LibGUI/MenuItem.cpp
+++ b/Userland/Libraries/LibGUI/MenuItem.cpp
@@ -74,7 +74,8 @@ void MenuItem::update_window_server()
         return;
     auto& action = *m_action;
     auto shortcut_text = action.shortcut().is_valid() ? action.shortcut().to_string() : String();
-    ConnectionToWindowServer::the().async_update_menu_item(m_menu_id, m_identifier, -1, action.text(), action.is_enabled(), action.is_checkable(), action.is_checkable() ? action.is_checked() : false, m_default, shortcut_text);
+    auto icon = action.icon() ? action.icon()->to_shareable_bitmap() : Gfx::ShareableBitmap();
+    ConnectionToWindowServer::the().async_update_menu_item(m_menu_id, m_identifier, -1, action.text(), action.is_enabled(), action.is_checkable(), action.is_checkable() ? action.is_checked() : false, m_default, shortcut_text, icon);
 }
 
 void MenuItem::set_menu_id(Badge<Menu>, unsigned int menu_id)

--- a/Userland/Services/WindowServer/ConnectionFromClient.cpp
+++ b/Userland/Services/WindowServer/ConnectionFromClient.cpp
@@ -170,7 +170,7 @@ void ConnectionFromClient::dismiss_menu(i32 menu_id)
 
 void ConnectionFromClient::update_menu_item(i32 menu_id, i32 identifier, [[maybe_unused]] i32 submenu_id,
     String const& text, bool enabled, bool checkable, bool checked, bool is_default,
-    String const& shortcut)
+    String const& shortcut, Gfx::ShareableBitmap const& icon)
 {
     auto it = m_menus.find(menu_id);
     if (it == m_menus.end()) {
@@ -183,6 +183,7 @@ void ConnectionFromClient::update_menu_item(i32 menu_id, i32 identifier, [[maybe
         did_misbehave("UpdateMenuItem: Bad menu item identifier");
         return;
     }
+    menu_item->set_icon(icon.bitmap());
     menu_item->set_text(text);
     menu_item->set_shortcut_text(shortcut);
     menu_item->set_enabled(enabled);

--- a/Userland/Services/WindowServer/ConnectionFromClient.h
+++ b/Userland/Services/WindowServer/ConnectionFromClient.h
@@ -96,7 +96,7 @@ private:
     virtual void add_menu(i32, i32) override;
     virtual void add_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&, Gfx::ShareableBitmap const&, bool) override;
     virtual void add_menu_separator(i32) override;
-    virtual void update_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&) override;
+    virtual void update_menu_item(i32, i32, i32, String const&, bool, bool, bool, bool, String const&, Gfx::ShareableBitmap const&) override;
     virtual void remove_menu_item(i32 menu_id, i32 identifier) override;
     virtual void flash_menubar_menu(i32, i32) override;
     virtual void create_window(i32, Gfx::IntRect const&, bool, bool, bool, bool, bool,

--- a/Userland/Services/WindowServer/WindowServer.ipc
+++ b/Userland/Services/WindowServer/WindowServer.ipc
@@ -23,7 +23,18 @@ endpoint WindowServer
 
     add_menu_separator(i32 menu_id) =|
 
-    update_menu_item(i32 menu_id, i32 identifier, i32 submenu_id, [UTF8] String text, bool enabled, bool checkable, bool checked, bool is_default, [UTF8] String shortcut) =|
+    update_menu_item(
+        i32 menu_id,
+        i32 identifier,
+        i32 submenu_id,
+        [UTF8] String text,
+        bool enabled,
+        bool checkable,
+        bool checked,
+        bool is_default,
+        [UTF8] String shortcut,
+        Gfx::ShareableBitmap icon) =|
+
     remove_menu_item(i32 menu_id, i32 identifier) =|
     flash_menubar_menu(i32 window_id, i32 menu_id) =|
 


### PR DESCRIPTION
Previously when setting an action's icon we would only change the bitmap stored by the action. This pull request adds logic to propagate that change to toolbar buttons as well as window menus.
    
This fixes an issue in SoundPlayer that would cause the play button not to reflect the play state.