### PR TITLE
LibGfx+PixelPaint: Antialiased outline ellipsis!

### DIFF
--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.cpp
@@ -42,7 +42,7 @@ void EllipseTool::draw_using(GUI::Painter& painter, Gfx::IntPoint const& start_p
         break;
     case FillMode::FillAntiAliased: {
         Gfx::AntiAliasingPainter aa_painter { painter };
-        aa_painter.draw_ellipse(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button));
+        aa_painter.fill_ellipse(ellipse_intersecting_rect, m_editor->color_for(m_drawing_button));
         break;
     }
     default:

--- a/Userland/Applications/PixelPaint/Tools/EllipseTool.h
+++ b/Userland/Applications/PixelPaint/Tools/EllipseTool.h
@@ -31,8 +31,7 @@ public:
 private:
     enum class FillMode {
         Outline,
-        Fill,
-        FillAntiAliased
+        Fill
     };
 
     enum class DrawMode {
@@ -51,9 +50,9 @@ private:
     Gfx::IntPoint m_ellipse_end_position;
     int m_thickness { 1 };
     FillMode m_fill_mode { FillMode::Outline };
-    bool m_last_aa_checkbox_state { false };
     DrawMode m_draw_mode { DrawMode::FromCorner };
     Optional<float> m_aspect_ratio;
+    bool m_antialias_enabled { false };
 };
 
 }

--- a/Userland/Demos/Eyes/EyesWidget.cpp
+++ b/Userland/Demos/Eyes/EyesWidget.cpp
@@ -41,9 +41,9 @@ void EyesWidget::render_eyeball(int row, int column, Gfx::AntiAliasingPainter& p
     auto height_thickness = max(int(eye_height / 5.5), 1);
 
     bounds.shrink(int(eye_width / 12.5), 0);
-    painter.draw_ellipse(bounds, palette().base_text());
+    painter.fill_ellipse(bounds, palette().base_text());
     bounds.shrink(width_thickness, height_thickness);
-    painter.draw_ellipse(bounds, palette().base());
+    painter.fill_ellipse(bounds, palette().base());
 
     Gfx::IntPoint pupil_center = this->pupil_center(bounds);
     Gfx::IntSize pupil_size {
@@ -57,7 +57,7 @@ void EyesWidget::render_eyeball(int row, int column, Gfx::AntiAliasingPainter& p
         pupil_size.height()
     };
 
-    painter.draw_ellipse(pupil, palette().base_text());
+    painter.fill_ellipse(pupil, palette().base_text());
 }
 
 Gfx::IntPoint EyesWidget::pupil_center(Gfx::IntRect& eyeball_bounds) const

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -192,14 +192,14 @@ void Gfx::AntiAliasingPainter::draw_cubic_bezier_curve(FloatPoint const& control
     });
 }
 
-void Gfx::AntiAliasingPainter::draw_circle(IntPoint const& center, int radius, Color color)
+void Gfx::AntiAliasingPainter::fill_circle(IntPoint const& center, int radius, Color color)
 {
     if (radius <= 0)
         return;
     draw_ellipse_part(center, radius, radius, color, false, {});
 }
 
-void Gfx::AntiAliasingPainter::draw_ellipse(IntRect const& a_rect, Color color)
+void Gfx::AntiAliasingPainter::fill_ellipse(IntRect const& a_rect, Color color)
 {
     auto center = a_rect.center();
     auto radius_a = a_rect.width() / 2;
@@ -207,7 +207,7 @@ void Gfx::AntiAliasingPainter::draw_ellipse(IntRect const& a_rect, Color color)
     if (radius_a <= 0 || radius_b <= 0)
         return;
     if (radius_a == radius_b)
-        return draw_circle(center, radius_a, color);
+        return fill_circle(center, radius_a, color);
     auto x_paint_range = draw_ellipse_part(center, radius_a, radius_b, color, false, {});
     // FIXME: This paints some extra fill pixels that are clipped
     draw_ellipse_part(center, radius_b, radius_a, color, true, x_paint_range);
@@ -471,11 +471,11 @@ void Gfx::AntiAliasingPainter::fill_rect_with_rounded_corners(IntRect const& a_r
 
     // FIXME: Don't draw a whole circle each time
     if (top_left_radius)
-        draw_circle(top_left_corner, top_left_radius, color);
+        fill_circle(top_left_corner, top_left_radius, color);
     if (top_right_radius)
-        draw_circle(top_right_corner, top_right_radius, color);
+        fill_circle(top_right_corner, top_right_radius, color);
     if (bottom_left_radius)
-        draw_circle(bottom_left_corner, bottom_left_radius, color);
+        fill_circle(bottom_left_corner, bottom_left_radius, color);
     if (bottom_right_radius)
-        draw_circle(bottom_right_corner, bottom_right_radius, color);
+        fill_circle(bottom_right_corner, bottom_right_radius, color);
 }

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -28,8 +28,9 @@ public:
     void translate(float dx, float dy) { m_transform.translate(dx, dy); }
     void translate(FloatPoint const& delta) { m_transform.translate(delta); }
 
-    void draw_circle(IntPoint const& center, int radius, Color);
-    void draw_ellipse(IntRect const& a_rect, Color);
+    void fill_circle(IntPoint const& center, int radius, Color);
+    void fill_ellipse(IntRect const& a_rect, Color);
+
     void fill_rect_with_rounded_corners(IntRect const&, Color, int radius);
     void fill_rect_with_rounded_corners(IntRect const&, Color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
 

--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.h
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.h
@@ -28,8 +28,15 @@ public:
     void translate(float dx, float dy) { m_transform.translate(dx, dy); }
     void translate(FloatPoint const& delta) { m_transform.translate(delta); }
 
-    void fill_circle(IntPoint const& center, int radius, Color);
-    void fill_ellipse(IntRect const& a_rect, Color);
+    void draw_ellipse(IntRect const& a_rect, Color, int thickness);
+
+    enum class BlendMode {
+        Normal,
+        AlphaSubtract
+    };
+
+    void fill_circle(IntPoint const& center, int radius, Color, BlendMode blend_mode = BlendMode::Normal);
+    void fill_ellipse(IntRect const& a_rect, Color, BlendMode blend_mode = BlendMode::Normal);
 
     void fill_rect_with_rounded_corners(IntRect const&, Color, int radius);
     void fill_rect_with_rounded_corners(IntRect const&, Color, int top_left_radius, int top_right_radius, int bottom_right_radius, int bottom_left_radius);
@@ -44,7 +51,8 @@ private:
             return n >= min && n <= max;
         }
     };
-    Range draw_ellipse_part(IntPoint a_rect, int radius_a, int radius_b, Color, bool flip_x_and_y, Optional<Range> x_clip);
+
+    Range draw_ellipse_part(IntPoint a_rect, int radius_a, int radius_b, Color, bool flip_x_and_y, Optional<Range> x_clip, BlendMode blend_mode);
 
     enum class AntiAliasPolicy {
         OnlyEnds,


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11597044/171395732-76954634-81d9-4b26-9448-cf721444a7fc.png)
> Image: MRW I see an antialiased ellipse 

Was baited into adding this after watching the monthly update, currently this implementation unfortunately requires allocating a temporary bitmap, see commit messages for more details. Other than that is seems to work very well in PixelPaint.
