### PR TITLE
LibWebView: Fix bug where browser theme does not update properly

### DIFF
--- a/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
+++ b/Userland/Libraries/LibWebView/OutOfProcessWebView.cpp
@@ -188,6 +188,7 @@ void OutOfProcessWebView::theme_change_event(GUI::ThemeChangeEvent& event)
 {
     GUI::AbstractScrollableWidget::theme_change_event(event);
     client().async_update_system_theme(Gfx::current_system_theme_buffer());
+    client().async_load_url(m_url);
     request_repaint();
 }
 


### PR DESCRIPTION
This is done by refreshing current webpage
Fixes the following issue: https://github.com/SerenityOS/serenity/issues/13328