### PR TITLE
Utilities: Refactor and improve du

### DIFF
--- a/Base/usr/share/man/man1/du.md
+++ b/Base/usr/share/man/man1/du.md
@@ -21,6 +21,7 @@ Without any options, `du` recursively prints the disk usage of each directory ar
 * `-d N`, `--max-depth N`: Print the size of each entry only if it is `N` or fewer levels below the root of the file hierarchy
 * `--exclude pattern`: Exclude entries that match the glob pattern `pattern`. This option will exclude those entries from the disk usage of the file hierarchy
 * `-h`, `--human-readable`: Print the size of each entry in human-readable units (B, KiB, MiB...) instead of in `block-size` bytes
+* `-k`: Use a block size of 1024 bytes (1 KiB). Equivalent to `--max-depth 1024`
 * `-s`, `--summarize`: Print only the size of each argument, not entries in the file hierarchy. Equivalent to `--max-depth 0`
 * `-t size`, `--threshold size`: Do not print entries smaller than `size` if positive, or entries greater than `size` if negative. This option will not affect the reported disk usage
 * `--time time-type`: Show timestamp of type `time-type` for each entry. Available choices are: mtime, modification (modification timestamp), ctime, status, use (change timestamp) and atime, access (access timestamp)

--- a/Base/usr/share/man/man1/du.md
+++ b/Base/usr/share/man/man1/du.md
@@ -17,6 +17,7 @@ Without any options, `du` recursively prints the disk usage of each directory ar
 * `-a`, `--all`: Print the sizes of all files in the file hierarchy, not just directories
 * `--apparent-size`: Print apparent sizes, rather than disk usage
 * `-B size`, `--block-size size`: Print the sizes in a unit of `size` bytes instead of the default block size of 512 bytes
+* `-c`. `--total`: Print the total size of all arguments
 * `-d N`, `--max-depth N`: Print the size of each entry only if it is `N` or fewer levels below the root of the file hierarchy
 * `--exclude pattern`: Exclude entries that match the glob pattern `pattern`. This option will exclude those entries from the disk usage of the file hierarchy
 * `-h`, `--human-readable`: Print the size of each entry in human-readable units (B, KiB, MiB...) instead of in `block-size` bytes

--- a/Base/usr/share/man/man1/du.md
+++ b/Base/usr/share/man/man1/du.md
@@ -17,10 +17,10 @@ Without any options, `du` recursively prints the disk usage of each directory ar
 * `-a`, `--all`: Print the sizes of all files in the file hierarchy, not just directories
 * `--apparent-size`: Print apparent sizes, rather than disk usage
 * `-d N`, `--max-depth N`: Print the size of each entry only if it is `N` or fewer levels below the root of the file hierarchy
-* `--exclude pattern`: Exclude entries that match the glob pattern `pattern`
+* `--exclude pattern`: Exclude entries that match the glob pattern `pattern`. This option will exclude those entries from the disk usage of the file hierarchy
 * `-h`, `--human-readable`: Print the size of each entry in human-readable units (B, KiB, MiB...)
 * `-s`, `--summarize`: Print only the size of each argument, not entries in the file hierarchy. Equivalent to `--max-depth 0`
-* `-t size`, `--threshold size`: Do not print entries smaller than `size` if positive, or entries greater than `size` if negative
+* `-t size`, `--threshold size`: Do not print entries smaller than `size` if positive, or entries greater than `size` if negative. This option will not affect the reported disk usage
 * `--time time-type`: Show timestamp of type `time-type` for each entry. Available choices are: mtime, modification (modification timestamp), ctime, status, use (change timestamp) and atime, access (access timestamp)
 * `-X file`, `--exclude-from file`: Exclude entries that match any of the newline-delimited glob patterns in `file`
 

--- a/Base/usr/share/man/man1/du.md
+++ b/Base/usr/share/man/man1/du.md
@@ -5,27 +5,28 @@ du - print disk usage
 ## Synopsis
 
 ```**sh
-$ du [files...]
+$ du [options...] [files...]
 ```
 
 ## Description
 
-`du` prints disk usage data for every argument, in KiB (kibibytes).
+Without any options, `du` recursively prints the disk usage of each directory argument and its subdirectories, and of each file argument.
 
 ## Options
 
-* `-a`, `--all`: Write counts for all files, not just directories
+* `-a`, `--all`: Print the sizes of all files in the file hierarchy, not just directories
 * `--apparent-size`: Print apparent sizes, rather than disk usage
-* `-d N`, `--max-depth N`: Print the total for a directory or file only if it is N or fewer levels below the command line argument
-* `-s`, `--summarize`: Display only a total for each argument
-* `-t size`, `--threshold size`: Exclude entries smaller than size if positive, or entries greater than size if negative
-* `--time time-type`: Show time of time time-type of any file in the directory, or any of its subdirectories. Available choices: mtime, modification, ctime, status, use, atime, access
-* `--exclude pattern`: Exclude files that match pattern
-* `-X file, --exclude_from`: Exclude files that match any pattern in file
+* `-d N`, `--max-depth N`: Print the size of each entry only if it is `N` or fewer levels below the root of the file hierarchy
+* `--exclude pattern`: Exclude entries that match the glob pattern `pattern`
+* `-h`, `--human-readable`: Print the size of each entry in human-readable units (B, KiB, MiB...)
+* `-s`, `--summarize`: Print only the size of each argument, not entries in the file hierarchy. Equivalent to `--max-depth 0`
+* `-t size`, `--threshold size`: Do not print entries smaller than `size` if positive, or entries greater than `size` if negative
+* `--time time-type`: Show timestamp of type `time-type` for each entry. Available choices are: mtime, modification (modification timestamp), ctime, status, use (change timestamp) and atime, access (access timestamp)
+* `-X file`, `--exclude-from file`: Exclude entries that match any of the newline-delimited glob patterns in `file`
 
 ## Arguments
 
-* `files`: Files to print disk usage of
+* `files`: Directories or files to print disk usage of
 
 ## Examples
 

--- a/Base/usr/share/man/man1/du.md
+++ b/Base/usr/share/man/man1/du.md
@@ -17,6 +17,7 @@ Without any options, `du` recursively prints the disk usage of each directory ar
 * `-a`, `--all`: Print the sizes of all files in the file hierarchy, not just directories
 * `--apparent-size`: Print apparent sizes, rather than disk usage
 * `-B size`, `--block-size size`: Print the sizes in a unit of `size` bytes instead of the default block size of 512 bytes
+* `-b`, `--bytes`: Print the apparent size of each entry in bytes. Equivalent to `--apparent-size` and `--block-size 1`
 * `-c`. `--total`: Print the total size of all arguments
 * `-d N`, `--max-depth N`: Print the size of each entry only if it is `N` or fewer levels below the root of the file hierarchy
 * `--exclude pattern`: Exclude entries that match the glob pattern `pattern`. This option will exclude those entries from the disk usage of the file hierarchy

--- a/Base/usr/share/man/man1/du.md
+++ b/Base/usr/share/man/man1/du.md
@@ -10,7 +10,7 @@ $ du [options...] [files...]
 
 ## Description
 
-Without any options, `du` recursively prints the disk usage of each directory argument and its subdirectories, and of each file argument.
+Without any options, `du` recursively prints the disk usage of each directory argument and its subdirectories, and of each file argument. By default, the sizes are displayed in a unit of 512 bytes.
 
 ## Options
 

--- a/Base/usr/share/man/man1/du.md
+++ b/Base/usr/share/man/man1/du.md
@@ -16,9 +16,10 @@ Without any options, `du` recursively prints the disk usage of each directory ar
 
 * `-a`, `--all`: Print the sizes of all files in the file hierarchy, not just directories
 * `--apparent-size`: Print apparent sizes, rather than disk usage
+* `-B size`, `--block-size size`: Print the sizes in a unit of `size` bytes instead of the default block size of 512 bytes
 * `-d N`, `--max-depth N`: Print the size of each entry only if it is `N` or fewer levels below the root of the file hierarchy
 * `--exclude pattern`: Exclude entries that match the glob pattern `pattern`. This option will exclude those entries from the disk usage of the file hierarchy
-* `-h`, `--human-readable`: Print the size of each entry in human-readable units (B, KiB, MiB...)
+* `-h`, `--human-readable`: Print the size of each entry in human-readable units (B, KiB, MiB...) instead of in `block-size` bytes
 * `-s`, `--summarize`: Print only the size of each argument, not entries in the file hierarchy. Equivalent to `--max-depth 0`
 * `-t size`, `--threshold size`: Do not print entries smaller than `size` if positive, or entries greater than `size` if negative. This option will not affect the reported disk usage
 * `--time time-type`: Show timestamp of type `time-type` for each entry. Available choices are: mtime, modification (modification timestamp), ctime, status, use (change timestamp) and atime, access (access timestamp)

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -122,9 +122,9 @@ ErrorOr<off_t> print_space_usage(String const& path, unsigned depth)
         }
     } else {
         if (s_option.apparent_size)
-            size = path_stat.st_blocks * 512;
-        else
             size = path_stat.st_size;
+        else
+            size = path_stat.st_blocks * 512;
     }
 
     for (auto const& pattern : s_option.excluded_patterns) {

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -54,8 +54,7 @@ ErrorOr<void> parse_args(Main::Arguments const& arguments)
 
     Core::ArgsParser::Option time_option {
         true,
-        "Show time of type time-type of any file in the directory, or any of its subdirectories. "
-        "Available choices: mtime, modification, ctime, status, use, atime, access",
+        "Show timestamp of type time-type for each entry. Available choices are: mtime, modification (modification timestamp), ctime, status, use (change timestamp) and atime, access (access timestamp)",
         "time",
         0,
         "time-type",
@@ -75,16 +74,16 @@ ErrorOr<void> parse_args(Main::Arguments const& arguments)
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Display actual or apparent disk usage of files or directories.");
-    args_parser.add_option(s_option.all, "Write counts for all files, not just directories", "all", 'a');
+    args_parser.add_option(s_option.all, "Print the sizes of both files and directories", "all", 'a');
     args_parser.add_option(s_option.apparent_size, "Print apparent sizes, rather than disk usage", "apparent-size", 0);
+    args_parser.add_option(s_option.max_depth, "Print the size of an entry only if it is N or fewer levels below the root of the file hierarchy", "max-depth", 'd', "N");
+    args_parser.add_option(exclude_pattern, "Exclude entries that match pattern", "exclude", 0, "pattern");
     args_parser.add_option(s_option.human_readable, "Print human-readable sizes", "human-readable", 'h');
-    args_parser.add_option(s_option.max_depth, "Print the total for a directory or file only if it is N or fewer levels below the command line argument", "max-depth", 'd', "N");
-    args_parser.add_option(summarize, "Display only a total for each argument", "summarize", 's');
-    args_parser.add_option(s_option.threshold, "Exclude entries smaller than size if positive, or entries greater than size if negative", "threshold", 't', "size");
+    args_parser.add_option(summarize, "Print only the size of each argument", "summarize", 's');
+    args_parser.add_option(s_option.threshold, "Exclude entries smaller than size if positive, or greater than size if negative", "threshold", 't', "size");
     args_parser.add_option(move(time_option));
-    args_parser.add_option(exclude_pattern, "Exclude files that match pattern", "exclude", 0, "pattern");
-    args_parser.add_option(exclude_from, "Exclude files that match any pattern in file", "exclude_from", 'X', "file");
-    args_parser.add_positional_argument(s_option.files, "File to process", "file", Core::ArgsParser::Required::No);
+    args_parser.add_option(exclude_from, "Exclude entries that match any pattern in file", "exclude-from", 'X', "file");
+    args_parser.add_positional_argument(s_option.files, "Directories or files to process", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
     if (summarize)

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -30,33 +30,32 @@ struct DuOption {
     bool all = false;
     bool apparent_size = false;
     int threshold = 0;
+    unsigned max_depth = UINT_MAX;
     TimeType time_type = TimeType::NotUsed;
     Vector<String> excluded_patterns;
+    Vector<StringView> files;
 };
 
-static ErrorOr<void> parse_args(Main::Arguments arguments, Vector<String>& files, DuOption& du_option, int& max_depth);
-static ErrorOr<off_t> print_space_usage(String const& path, DuOption const& du_option, int max_depth, bool inside_dir = false);
+static DuOption s_option;
+
+static ErrorOr<void> parse_args(Main::Arguments const& arguments);
+static ErrorOr<off_t> print_space_usage(String const& path, unsigned max_depth, bool inside_dir = false);
 
 ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
-    Vector<String> files;
-    DuOption du_option;
-    int max_depth = INT_MAX;
+    TRY(parse_args(arguments));
 
-    TRY(parse_args(arguments, files, du_option, max_depth));
-
-    for (auto const& file : files)
-        TRY(print_space_usage(file, du_option, max_depth));
+    for (auto const& file : s_option.files)
+        TRY(print_space_usage(file, s_option.max_depth));
 
     return 0;
 }
 
-ErrorOr<void> parse_args(Main::Arguments arguments, Vector<String>& files, DuOption& du_option, int& max_depth)
+ErrorOr<void> parse_args(Main::Arguments const& arguments)
 {
     bool summarize = false;
-    char const* pattern = nullptr;
+    char const* exclude_pattern = nullptr;
     char const* exclude_from = nullptr;
-    Vector<StringView> files_to_process;
 
     Core::ArgsParser::Option time_option {
         true,
@@ -65,13 +64,13 @@ ErrorOr<void> parse_args(Main::Arguments arguments, Vector<String>& files, DuOpt
         "time",
         0,
         "time-type",
-        [&du_option](StringView s) {
+        [](StringView s) {
             if (s == "mtime"sv || s == "modification"sv)
-                du_option.time_type = DuOption::TimeType::Modification;
+                s_option.time_type = DuOption::TimeType::Modification;
             else if (s == "ctime"sv || s == "status"sv || s == "use"sv)
-                du_option.time_type = DuOption::TimeType::Status;
+                s_option.time_type = DuOption::TimeType::Status;
             else if (s == "atime"sv || s == "access"sv)
-                du_option.time_type = DuOption::TimeType::Access;
+                s_option.time_type = DuOption::TimeType::Access;
             else
                 return false;
 
@@ -81,44 +80,37 @@ ErrorOr<void> parse_args(Main::Arguments arguments, Vector<String>& files, DuOpt
 
     Core::ArgsParser args_parser;
     args_parser.set_general_help("Display actual or apparent disk usage of files or directories.");
-    args_parser.add_option(du_option.all, "Write counts for all files, not just directories", "all", 'a');
-    args_parser.add_option(du_option.apparent_size, "Print apparent sizes, rather than disk usage", "apparent-size", 0);
-    args_parser.add_option(du_option.human_readable, "Print human-readable sizes", "human-readable", 'h');
-    args_parser.add_option(max_depth, "Print the total for a directory or file only if it is N or fewer levels below the command line argument", "max-depth", 'd', "N");
+    args_parser.add_option(s_option.all, "Write counts for all files, not just directories", "all", 'a');
+    args_parser.add_option(s_option.apparent_size, "Print apparent sizes, rather than disk usage", "apparent-size", 0);
+    args_parser.add_option(s_option.human_readable, "Print human-readable sizes", "human-readable", 'h');
+    args_parser.add_option(s_option.max_depth, "Print the total for a directory or file only if it is N or fewer levels below the command line argument", "max-depth", 'd', "N");
     args_parser.add_option(summarize, "Display only a total for each argument", "summarize", 's');
-    args_parser.add_option(du_option.threshold, "Exclude entries smaller than size if positive, or entries greater than size if negative", "threshold", 't', "size");
+    args_parser.add_option(s_option.threshold, "Exclude entries smaller than size if positive, or entries greater than size if negative", "threshold", 't', "size");
     args_parser.add_option(move(time_option));
-    args_parser.add_option(pattern, "Exclude files that match pattern", "exclude", 0, "pattern");
+    args_parser.add_option(exclude_pattern, "Exclude files that match pattern", "exclude", 0, "pattern");
     args_parser.add_option(exclude_from, "Exclude files that match any pattern in file", "exclude_from", 'X', "file");
-    args_parser.add_positional_argument(files_to_process, "File to process", "file", Core::ArgsParser::Required::No);
+    args_parser.add_positional_argument(s_option.files, "File to process", "file", Core::ArgsParser::Required::No);
     args_parser.parse(arguments);
 
     if (summarize)
-        max_depth = 0;
-
-    if (pattern)
-        du_option.excluded_patterns.append(pattern);
+        s_option.max_depth = 0;
+    if (exclude_pattern)
+        s_option.excluded_patterns.append(exclude_pattern);
     if (exclude_from) {
         auto file = TRY(Core::File::open(exclude_from, Core::OpenMode::ReadOnly));
-        auto const buff = file->read_all();
+        auto buff = file->read_all();
         if (!buff.is_empty()) {
-            String patterns = String::copy(buff, Chomp);
-            du_option.excluded_patterns.extend(patterns.split('\n'));
+            auto patterns = String::copy(buff, Chomp);
+            s_option.excluded_patterns.extend(patterns.split('\n'));
         }
     }
-
-    for (auto const& file : files_to_process) {
-        files.append(file);
-    }
-
-    if (files.is_empty()) {
-        files.append(".");
-    }
+    if (s_option.files.is_empty())
+        s_option.files.append(".");
 
     return {};
 }
 
-ErrorOr<off_t> print_space_usage(String const& path, DuOption const& du_option, int max_depth, bool inside_dir)
+ErrorOr<off_t> print_space_usage(String const& path, unsigned max_depth, bool inside_dir)
 {
     struct stat path_stat = TRY(Core::System::lstat(path.characters()));
     off_t directory_size = 0;
@@ -132,32 +124,32 @@ ErrorOr<off_t> print_space_usage(String const& path, DuOption const& du_option, 
 
         while (di.has_next()) {
             auto const child_path = di.next_full_path();
-            directory_size += TRY(print_space_usage(child_path, du_option, max_depth, true));
+            directory_size += TRY(print_space_usage(child_path, max_depth, true));
         }
     }
 
     auto const basename = LexicalPath::basename(path);
-    for (auto const& pattern : du_option.excluded_patterns) {
+    for (auto const& pattern : s_option.excluded_patterns) {
         if (basename.matches(pattern, CaseSensitivity::CaseSensitive))
             return { 0 };
     }
 
     off_t size = path_stat.st_size;
-    if (du_option.apparent_size) {
+    if (s_option.apparent_size) {
         constexpr auto block_size = 512;
         size = path_stat.st_blocks * block_size;
     }
 
-    if (inside_dir && !du_option.all && !is_directory)
+    if (inside_dir && !s_option.all && !is_directory)
         return size;
 
     if (is_directory)
         size = directory_size;
 
-    if ((du_option.threshold > 0 && size < du_option.threshold) || (du_option.threshold < 0 && size > -du_option.threshold))
+    if ((s_option.threshold > 0 && size < s_option.threshold) || (s_option.threshold < 0 && size > -s_option.threshold))
         return { 0 };
 
-    if (du_option.human_readable) {
+    if (s_option.human_readable) {
         out("{}", human_readable_size(size));
     } else {
         constexpr long long block_size = 1024;
@@ -165,11 +157,11 @@ ErrorOr<off_t> print_space_usage(String const& path, DuOption const& du_option, 
         out("{}", size);
     }
 
-    if (du_option.time_type == DuOption::TimeType::NotUsed) {
+    if (s_option.time_type == DuOption::TimeType::NotUsed) {
         outln("\t{}", path);
     } else {
         auto time = path_stat.st_mtime;
-        switch (du_option.time_type) {
+        switch (s_option.time_type) {
         case DuOption::TimeType::Access:
             time = path_stat.st_atime;
             break;

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -132,10 +132,9 @@ ErrorOr<off_t> print_space_usage(String const& path, unsigned depth)
             size = path_stat.st_size;
     }
 
-    auto const basename = LexicalPath::basename(path);
     for (auto const& pattern : s_option.excluded_patterns) {
-        if (basename.matches(pattern, CaseSensitivity::CaseSensitive))
-            return { 0 };
+        if (path.matches(pattern, CaseSensitivity::CaseSensitive))
+            return 0;
     }
 
     if ((s_option.threshold > 0 && size < s_option.threshold) || (s_option.threshold < 0 && size > -s_option.threshold))

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -59,6 +59,7 @@ ErrorOr<void> parse_args(Main::Arguments const& arguments)
 {
     bool summarize = false;
     bool block_size_1k = false;
+    bool bytes = false;
     char const* exclude_pattern = nullptr;
     char const* exclude_from = nullptr;
 
@@ -87,6 +88,7 @@ ErrorOr<void> parse_args(Main::Arguments const& arguments)
     args_parser.add_option(s_option.all, "Print the sizes of both files and directories", "all", 'a');
     args_parser.add_option(s_option.apparent_size, "Print apparent sizes, rather than disk usage", "apparent-size", 0);
     args_parser.add_option(s_option.block_size, "Print the sizes in a unit of size bytes", "block-size", 'B', "size");
+    args_parser.add_option(bytes, "Print apparent sizes in bytes", "bytes", 'b');
     args_parser.add_option(s_option.total, "Print the total size of all arguments", "total", 'c');
     args_parser.add_option(s_option.max_depth, "Print the size of an entry only if it is N or fewer levels below the root of the file hierarchy", "max-depth", 'd', "N");
     args_parser.add_option(exclude_pattern, "Exclude entries that match pattern", "exclude", 0, "pattern");
@@ -108,6 +110,10 @@ ErrorOr<void> parse_args(Main::Arguments const& arguments)
         s_option.max_depth = 0;
     if (block_size_1k)
         s_option.block_size = 1024;
+    if (bytes) {
+        s_option.apparent_size = true;
+        s_option.block_size = 1;
+    }
     if (exclude_pattern)
         s_option.excluded_patterns.append(exclude_pattern);
     if (exclude_from) {

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -4,19 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-#include <AK/LexicalPath.h>
 #include <AK/NumberFormat.h>
-#include <AK/String.h>
-#include <AK/Vector.h>
 #include <LibCore/ArgsParser.h>
 #include <LibCore/DateTime.h>
 #include <LibCore/DirIterator.h>
 #include <LibCore/File.h>
 #include <LibCore/System.h>
 #include <LibMain/Main.h>
-#include <limits.h>
-#include <string.h>
-#include <sys/stat.h>
+#include <sys/param.h>
 
 struct DuOption {
     enum class TimeType {
@@ -144,8 +139,7 @@ ErrorOr<off_t> print_space_usage(String const& path, unsigned depth)
         out("{}", human_readable_size(size));
     } else {
         constexpr long long block_size = 1024;
-        size = size / block_size + (size % block_size != 0);
-        out("{}", size);
+        out("{}", howmany(size, block_size));
     }
 
     if (s_option.time_type == DuOption::TimeType::NotUsed) {

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -110,6 +110,7 @@ ErrorOr<off_t> print_space_usage(String const& path, unsigned depth)
     bool is_directory = S_ISDIR(path_stat.st_mode);
     off_t size = 0;
     if (is_directory) {
+        size = path_stat.st_size; // According to POSIX, we include the size of the directory itself.
         Core::DirIterator di { path, Core::DirIterator::SkipParentAndBaseDir };
         if (di.has_error()) {
             outln("du: cannot read directory '{}': {}", path, di.error_string());
@@ -137,7 +138,7 @@ ErrorOr<off_t> print_space_usage(String const& path, unsigned depth)
     if (s_option.human_readable) {
         out("{}", human_readable_size(size));
     } else {
-        constexpr long long block_size = 1024;
+        constexpr long long block_size = 512;
         out("{}", howmany(size, block_size));
     }
 

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -58,6 +58,7 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 ErrorOr<void> parse_args(Main::Arguments const& arguments)
 {
     bool summarize = false;
+    bool block_size_1k = false;
     char const* exclude_pattern = nullptr;
     char const* exclude_from = nullptr;
 
@@ -90,6 +91,7 @@ ErrorOr<void> parse_args(Main::Arguments const& arguments)
     args_parser.add_option(s_option.max_depth, "Print the size of an entry only if it is N or fewer levels below the root of the file hierarchy", "max-depth", 'd', "N");
     args_parser.add_option(exclude_pattern, "Exclude entries that match pattern", "exclude", 0, "pattern");
     args_parser.add_option(s_option.human_readable, "Print human-readable sizes", "human-readable", 'h');
+    args_parser.add_option(block_size_1k, "Use a block size of 1024 bytes", nullptr, 'k');
     args_parser.add_option(summarize, "Print only the size of each argument", "summarize", 's');
     args_parser.add_option(s_option.threshold, "Exclude entries smaller than size if positive, or greater than size if negative", "threshold", 't', "size");
     args_parser.add_option(move(time_option));
@@ -104,6 +106,8 @@ ErrorOr<void> parse_args(Main::Arguments const& arguments)
 
     if (summarize)
         s_option.max_depth = 0;
+    if (block_size_1k)
+        s_option.block_size = 1024;
     if (exclude_pattern)
         s_option.excluded_patterns.append(exclude_pattern);
     if (exclude_from) {

--- a/Userland/Utilities/du.cpp
+++ b/Userland/Utilities/du.cpp
@@ -24,6 +24,7 @@ struct DuOption {
     bool human_readable = false;
     bool all = false;
     bool apparent_size = false;
+    bool total = false;
     int threshold = 0;
     int block_size = 512;
     unsigned max_depth = UINT_MAX;
@@ -41,9 +42,16 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
 {
     TRY(parse_args(arguments));
 
+    off_t total = 0;
     for (auto const& file : s_option.files)
-        TRY(print_space_usage(file, 0));
+        total += TRY(print_space_usage(file, 0));
 
+    if (s_option.total) {
+        if (s_option.human_readable)
+            outln("{}\ttotal", human_readable_size(total));
+        else
+            outln("{}\ttotal", howmany(total, s_option.block_size));
+    }
     return 0;
 }
 
@@ -78,6 +86,7 @@ ErrorOr<void> parse_args(Main::Arguments const& arguments)
     args_parser.add_option(s_option.all, "Print the sizes of both files and directories", "all", 'a');
     args_parser.add_option(s_option.apparent_size, "Print apparent sizes, rather than disk usage", "apparent-size", 0);
     args_parser.add_option(s_option.block_size, "Print the sizes in a unit of size bytes", "block-size", 'B', "size");
+    args_parser.add_option(s_option.total, "Print the total size of all arguments", "total", 'c');
     args_parser.add_option(s_option.max_depth, "Print the size of an entry only if it is N or fewer levels below the root of the file hierarchy", "max-depth", 'd', "N");
     args_parser.add_option(exclude_pattern, "Exclude entries that match pattern", "exclude", 0, "pattern");
     args_parser.add_option(s_option.human_readable, "Print human-readable sizes", "human-readable", 'h');


### PR DESCRIPTION
* Make sure the size calculation is correct even if `--max-depth` or `--threshold` is specified.
* Correctly implement apparent size calculation (`st_size`).
* Improve POSIX correctness by using a default block size of 512 bytes and including the size of directories themselves.
* Add more options.
* Clarify some documentation.

Fixes #12899.