### PR TITLE
LibWeb: Check recursively if CSS functions contain `var()` or `attr()`

### DIFF
--- a/Base/res/html/misc/custom-properties.html
+++ b/Base/res/html/misc/custom-properties.html
@@ -45,6 +45,11 @@
             border: var(--border);
         }
 
+        .test-inside-a-function {
+            --blue: 255;
+            background-color: rgb(255, 0, var(--blue));
+        }
+
         .test-mixed {
             background: var(--background-color) url("background-repeat.png") var(--background-position) no-repeat;
         }
@@ -176,6 +181,18 @@
     <div class="box test-nested">
         <pre>.test-nested</pre>
         This should have a 10px solid orange border
+    </div>
+
+    <pre>
+        .test-inside-a-function {
+            --blue: 255;
+            background-color: rgb(255, 0, var(--blue));
+        }
+    </pre>
+
+    <div class="box test-inside-a-function">
+        <pre>.test-inside-a-function</pre>
+        This should be fuchsia
     </div>
 
     <h2>Mixed var()</h2>


### PR DESCRIPTION
Previously, `var()` inside functions like `rgb()` wasn’t resolved.

master | this change
:-:|:-:
![broken test](https://user-images.githubusercontent.com/16520278/171679570-02360274-aee8-483d-879e-cf056ed28751.png) | ![working test](https://user-images.githubusercontent.com/16520278/171676296-27133314-5739-4e71-bde7-00d56b30207d.png)

This will set the background color for badges in the New category on https://ports.serenityos.net/. :^)

![ports-badges](https://user-images.githubusercontent.com/16520278/171676307-b9769ba8-3f88-483f-aefd-ea5e12b985ec.png)

