### PR TITLE
Userland: `Button::set_default()` all* the Dialogs!

### DIFF
--- a/Userland/Applications/Browser/BookmarksBarWidget.cpp
+++ b/Userland/Applications/Browser/BookmarksBarWidget.cpp
@@ -57,20 +57,15 @@ private:
         m_title_textbox->set_text(title);
         m_title_textbox->set_focus(true);
         m_title_textbox->select_all();
-        m_title_textbox->on_return_pressed = [this] {
-            done(ExecResult::OK);
-        };
 
         m_url_textbox = *widget.find_descendant_of_type_named<GUI::TextBox>("url_textbox");
         m_url_textbox->set_text(url);
-        m_url_textbox->on_return_pressed = [this] {
-            done(ExecResult::OK);
-        };
 
         auto& ok_button = *widget.find_descendant_of_type_named<GUI::Button>("ok_button");
         ok_button.on_click = [this](auto) {
             done(ExecResult::OK);
         };
+        ok_button.set_default(true);
 
         auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
         cancel_button.on_click = [this](auto) {

--- a/Userland/Applications/HexEditor/FindDialog.cpp
+++ b/Userland/Applications/HexEditor/FindDialog.cpp
@@ -130,10 +130,6 @@ FindDialog::FindDialog()
         m_find_all_button->set_enabled(!m_text_editor->text().is_empty());
     };
 
-    m_text_editor->on_return_pressed = [this] {
-        m_find_button->click();
-    };
-
     m_find_button->on_click = [this](auto) {
         auto text = m_text_editor->text();
         if (!text.is_empty()) {
@@ -141,6 +137,7 @@ FindDialog::FindDialog()
             done(ExecResult::OK);
         }
     };
+    m_find_button->set_default(true);
 
     m_find_all_button->on_click = [this](auto) {
         m_find_all = true;

--- a/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
+++ b/Userland/Applications/HexEditor/GoToOffsetDialog.cpp
@@ -119,13 +119,10 @@ GoToOffsetDialog::GoToOffsetDialog()
     m_offset_from_box->set_selected_index(0);
     m_offset_from_box->set_only_allow_values_from_model(true);
 
-    m_text_editor->on_return_pressed = [this] {
-        m_go_button->click();
-    };
-
     m_go_button->on_click = [this](auto) {
         done(ExecResult::OK);
     };
+    m_go_button->set_default(true);
 
     m_text_editor->on_change = [this]() {
         auto text = m_text_editor->text();

--- a/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewImageDialog.cpp
@@ -54,6 +54,7 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };
+    ok_button.set_default(true);
 
     auto& cancel_button = button_container.add<GUI::Button>("Cancel");
     cancel_button.on_click = [this](auto) {
@@ -66,10 +67,6 @@ CreateNewImageDialog::CreateNewImageDialog(GUI::Window* parent_window)
 
     height_spinbox.on_change = [this](int value) {
         m_image_size.set_height(value);
-    };
-
-    m_name_textbox->on_return_pressed = [this] {
-        done(ExecResult::OK);
     };
 
     width_spinbox.set_range(1, 16384);

--- a/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
+++ b/Userland/Applications/PixelPaint/CreateNewLayerDialog.cpp
@@ -53,6 +53,7 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize const& suggested_size, G
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };
+    ok_button.set_default(true);
 
     auto& cancel_button = button_container.add<GUI::Button>("Cancel");
     cancel_button.on_click = [this](auto) {
@@ -65,10 +66,6 @@ CreateNewLayerDialog::CreateNewLayerDialog(Gfx::IntSize const& suggested_size, G
 
     height_spinbox.on_change = [this](int value) {
         m_layer_size.set_height(value);
-    };
-
-    m_name_textbox->on_return_pressed = [this] {
-        done(ExecResult::OK);
     };
 
     width_spinbox.set_range(1, 16384);

--- a/Userland/Applications/PixelPaint/EditGuideDialog.cpp
+++ b/Userland/Applications/PixelPaint/EditGuideDialog.cpp
@@ -70,6 +70,7 @@ EditGuideDialog::EditGuideDialog(GUI::Window* parent_window, String const& offse
 
         done(ExecResult::OK);
     };
+    ok_button->set_default(true);
 
     cancel_button->on_click = [this](auto) {
         done(ExecResult::Cancel);

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
@@ -48,9 +48,6 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize const& suggested_size, GUI::Wi
         }
         m_desired_size.set_width(value);
     };
-    width_spinbox->on_return_pressed = [this]() {
-        done(ExecResult::OK);
-    };
 
     height_spinbox->set_value(m_desired_size.height());
     height_spinbox->on_change = [this, width_spinbox, keep_aspect_ratio_checkbox](int value) {
@@ -60,9 +57,6 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize const& suggested_size, GUI::Wi
             m_desired_size.set_width(width_spinbox->value());
         }
         m_desired_size.set_height(value);
-    };
-    height_spinbox->on_return_pressed = [this]() {
-        done(ExecResult::OK);
     };
 
     keep_aspect_ratio_checkbox->on_checked = [this, height_spinbox](bool is_checked) {
@@ -102,6 +96,7 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize const& suggested_size, GUI::Wi
     ok_button->on_click = [this](auto) {
         done(ExecResult::OK);
     };
+    ok_button->set_default(true);
 
     cancel_button->on_click = [this](auto) {
         done(ExecResult::Cancel);

--- a/Userland/Applications/Run/RunWindow.cpp
+++ b/Userland/Applications/Run/RunWindow.cpp
@@ -48,14 +48,12 @@ RunWindow::RunWindow()
     m_path_combo_box = *main_widget.find_descendant_of_type_named<GUI::ComboBox>("path");
     m_path_combo_box->set_model(m_path_history_model);
     m_path_combo_box->set_selected_index(0);
-    m_path_combo_box->on_return_pressed = [this] {
-        m_ok_button->click();
-    };
 
     m_ok_button = *main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
     m_ok_button->on_click = [this](auto) {
         do_run();
     };
+    m_ok_button->set_default(true);
 
     m_cancel_button = *main_widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
     m_cancel_button->on_click = [this](auto) {

--- a/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
+++ b/Userland/DevTools/HackStudio/Dialogs/NewProjectDialog.cpp
@@ -71,21 +71,14 @@ NewProjectDialog::NewProjectDialog(GUI::Window* parent)
     m_name_input->on_change = [&]() {
         update_dialog();
     };
-    m_name_input->on_return_pressed = [&]() {
-        if (m_input_valid)
-            do_create_project();
-    };
     m_create_in_input = *main_widget.find_descendant_of_type_named<GUI::TextBox>("create_in_input");
     m_create_in_input->on_change = [&]() {
         update_dialog();
     };
-    m_create_in_input->on_return_pressed = [&]() {
-        if (m_input_valid)
-            do_create_project();
-    };
     m_full_path_label = *main_widget.find_descendant_of_type_named<GUI::Label>("full_path_label");
 
     m_ok_button = *main_widget.find_descendant_of_type_named<GUI::Button>("ok_button");
+    m_ok_button->set_default(true);
     m_ok_button->on_click = [this](auto) {
         do_create_project();
     };

--- a/Userland/Libraries/LibGUI/ColorPicker.cpp
+++ b/Userland/Libraries/LibGUI/ColorPicker.cpp
@@ -238,6 +238,7 @@ void ColorPicker::build_ui()
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };
+    ok_button.set_default(true);
 
     auto& cancel_button = button_container.add<Button>();
     cancel_button.set_fixed_width(80);

--- a/Userland/Libraries/LibGUI/FontPicker.cpp
+++ b/Userland/Libraries/LibGUI/FontPicker.cpp
@@ -161,6 +161,7 @@ FontPicker::FontPicker(Window* parent_window, Gfx::Font const* current_font, boo
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };
+    ok_button.set_default(true);
 
     auto& cancel_button = *widget.find_descendant_of_type_named<GUI::Button>("cancel_button");
     cancel_button.on_click = [this](auto) {

--- a/Userland/Services/Taskbar/ShutdownDialog.cpp
+++ b/Userland/Services/Taskbar/ShutdownDialog.cpp
@@ -102,6 +102,7 @@ ShutdownDialog::ShutdownDialog()
     ok_button.on_click = [this](auto) {
         done(ExecResult::OK);
     };
+    ok_button.set_default(true);
     auto& cancel_button = button_container.add<GUI::Button>("Cancel");
     cancel_button.set_fixed_size(80, 23);
     cancel_button.on_click = [this](auto) {


### PR DESCRIPTION
sort of continuation of https://github.com/SerenityOS/serenity/pull/12129

- **Userland: Use default buttons instead of manually handling return press**

  Besides simplifying the code, this will also draw outline for these buttons as a cue for a user!

  <details>
  <summary>8 screenshots</summary>

  ![Browser: Edit Bookmark](https://user-images.githubusercontent.com/16520278/171685540-8ffea210-1d23-4a80-a2b2-3f2264ad7daf.png) ![HexEditor: Go to offset](https://user-images.githubusercontent.com/16520278/171685548-35fcf341-68e1-4231-8f49-9373b38f04fb.png) ![HexEditor: Find](https://user-images.githubusercontent.com/16520278/171685545-e373d65c-0141-48ac-962f-86e5592443be.png) ![PixelPaint: New Image](https://user-images.githubusercontent.com/16520278/171685553-24f993ce-78f5-4f07-af8a-9ce30d1f3f93.png) ![PixelPaint: New Layer](https://user-images.githubusercontent.com/16520278/171685555-84283a16-1cd1-472b-aab8-219d0f65edd6.png) ![PixelPaint: Resize Image](https://user-images.githubusercontent.com/16520278/171685557-6e89165c-be38-4041-b9a1-ceeedfe8ee3c.png)
  ![HackStudio: New Project](https://user-images.githubusercontent.com/16520278/171685551-9ccb5f7c-bf57-483d-8354-70a9e3c6725e.png) ![Run](https://user-images.githubusercontent.com/16520278/171685558-4c6cca5a-adc2-4796-a8c2-0a2c89f11005.png)
 </details>

- **PixelPaint: Use default buttons in EditGuideDialog**

  ![screenshot](https://user-images.githubusercontent.com/16520278/171686897-d4be17cd-dd91-4caa-940e-5decbccd42c5.png)

- **Taskbar: Use default buttons in ShutdownDialog**

  ![screenshot](https://user-images.githubusercontent.com/16520278/171687745-b4d55bb5-2bb2-4920-8065-f7329e65e0ab.png)

- **LibGUI: Use default buttons in ColorPicker and FontPicker**

  > **Note**
  > Couldn’t do this for FilePicker, as we need return press events to change the location path. :/

  ColorPicker | FontPicker
  :-:|:-:
  ![Screenshot](https://user-images.githubusercontent.com/16520278/171694840-3c9c7251-e3de-432e-ac71-b7e35c72977f.png) | ![Screenshot](https://user-images.githubusercontent.com/16520278/171694842-6f24d7cd-5a7d-47d7-82aa-fe840074d7c0.png)