### PR TITLE
Ports: Replace manually linking libraries with libtool patches

### DIFF
--- a/Ports/SDL2_gfx/package.sh
+++ b/Ports/SDL2_gfx/package.sh
@@ -7,9 +7,4 @@ auth_type=sha256
 depends=("SDL2")
 useconfigure=true
 use_fresh_config_sub=true
-configopts=("--with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local")
-
-install() {
-    run make install DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}"
-    run ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_gfx.so -Wl,-soname,libSDL2_gfx.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_gfx.a -Wl,--no-whole-archive
-}
+configopts=("--with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local" "--disable-static" "--enable-shared")

--- a/Ports/SDL2_gfx/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_gfx/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 0f827bb1e7e70c292982d68d1be79c0c64317333 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index ddcc961..4767551 100755
+--- a/configure
++++ b/configure
+@@ -4600,6 +4600,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -7874,6 +7878,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -9291,6 +9299,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -10282,6 +10294,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/SDL2_gfx/patches/ReadMe.md
+++ b/Ports/SDL2_gfx/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for SDL2_gfx on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/SDL2_image/package.sh
+++ b/Ports/SDL2_image/package.sh
@@ -12,15 +12,11 @@ configure() {
         --host="${SERENITY_ARCH}-pc-serenity" \
         --with-sdl-prefix="${SERENITY_INSTALL_ROOT}/usr/local" \
         --enable-webp=false --enable-webp-shared=false     \
+        --disable-static \
+        --enable-shared \
         LDFLAGS="-lgui -lgfx -lipc -lcore -lm"
 }
 
 build() {
     run make -k
-}
-
-install() {
-    run make -k DESTDIR="${SERENITY_INSTALL_ROOT}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_image.so -Wl,-soname,libSDL2_image.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_image.a -Wl,--no-whole-archive -lpng -ljpeg -ltiff
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_image.la
 }

--- a/Ports/SDL2_image/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_image/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 1f0f0c7055a0f2556d9094b5d1c13381541c00bd Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 7eb305d..4299214 100755
+--- a/configure
++++ b/configure
+@@ -4601,6 +4601,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -7389,6 +7393,10 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -8625,6 +8633,10 @@ rm -f core conftest.err conftest.$ac_objext \
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -9527,6 +9539,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/SDL2_image/patches/ReadMe.md
+++ b/Ports/SDL2_image/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for SDL2_image on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/SDL2_mixer/package.sh
+++ b/Ports/SDL2_mixer/package.sh
@@ -15,6 +15,8 @@ configure() {
         --with-sdl-prefix="${SERENITY_INSTALL_ROOT}/usr/local" \
         --enable-music-opus=false \
         --enable-music-opus-shared=false \
+        --disable-static \
+        --enable-shared \
         EXTRA_LDFLAGS="-lgui -lgfx -lipc -lcore -lcompression"
 }
 
@@ -24,10 +26,4 @@ post_configure() {
 
 build() {
     run make -k
-}
-
-install() {
-    run make -k DESTDIR="${SERENITY_INSTALL_ROOT}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_mixer.so -Wl,-soname,libSDL2_mixer.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_mixer.a -Wl,--no-whole-archive -Wl,--no-as-needed -lvorbis -lvorbisfile
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_mixer.la
 }

--- a/Ports/SDL2_mixer/patches/0001-Skip-building-the-playmus-and-playwav-utilities.patch
+++ b/Ports/SDL2_mixer/patches/0001-Skip-building-the-playmus-and-playwav-utilities.patch
@@ -1,7 +1,7 @@
-From a8e2b31abe3f56f21b4835af00620ce29ce6becb Mon Sep 17 00:00:00 2001
+From 45c3472482141099e7a14fa67c159b0dcd4164da Mon Sep 17 00:00:00 2001
 From: Andreas Kling <kling@serenityos.org>
 Date: Mon, 8 Mar 2021 13:15:35 +0100
-Subject: [PATCH] Skip building the playmus and playwav utilities
+Subject: [PATCH 1/2] Skip building the playmus and playwav utilities
 
 ---
  Makefile.in | 14 ++------------

--- a/Ports/SDL2_mixer/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_mixer/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 2bc8e2c1b321c59ef39c7dbe95871f0f08d1d139 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH 2/2] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 4df0be5..9a5f606 100755
+--- a/configure
++++ b/configure
+@@ -4480,6 +4480,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -7268,6 +7272,10 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -8504,6 +8512,10 @@ rm -f core conftest.err conftest.$ac_objext \
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -9406,6 +9418,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/SDL2_mixer/patches/ReadMe.md
+++ b/Ports/SDL2_mixer/patches/ReadMe.md
@@ -5,3 +5,17 @@
 Skip building the playmus and playwav utilities
 
 
+## `0002-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/SDL2_net/package.sh
+++ b/Ports/SDL2_net/package.sh
@@ -3,11 +3,7 @@ port=SDL2_net
 version=2.0.1
 useconfigure=true
 use_fresh_config_sub=true
-configopts=("--with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local")
+configopts=("--with-sdl-prefix=${SERENITY_INSTALL_ROOT}/usr/local" "--disable-static" "--enable-shared")
 files="https://www.libsdl.org/projects/SDL_net/release/SDL2_net-${version}.tar.gz SDL2_net-${version}.tar.gz 15ce8a7e5a23dafe8177c8df6e6c79b6749a03fff1e8196742d3571657609d21"
 auth_type=sha256
 depends=("SDL2")
-
-post_install() {
-    run ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_net.so -Wl,-soname,libSDL2_net.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_net.a -Wl,--no-whole-archive
-}

--- a/Ports/SDL2_net/patches/0001-Undefine-SIOCGIFCONF-on-serenity.patch
+++ b/Ports/SDL2_net/patches/0001-Undefine-SIOCGIFCONF-on-serenity.patch
@@ -1,7 +1,7 @@
-From 39364e14fd4259ab6c618a228f0b06dc8b9af24b Mon Sep 17 00:00:00 2001
+From 1e79dfd03eeaf33b9249b2a74a9dede5c5da3a59 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 16 Jun 2021 11:08:32 +0200
-Subject: [PATCH 1/2] Undefine 'SIOCGIFCONF' on serenity
+Subject: [PATCH 1/3] Undefine 'SIOCGIFCONF' on serenity
 
 FIXME: We don't know why yet.
 ---

--- a/Ports/SDL2_net/patches/0002-Include-sys-select.h.patch
+++ b/Ports/SDL2_net/patches/0002-Include-sys-select.h.patch
@@ -1,7 +1,7 @@
-From 5827fd456bcd7747fca2bb4f447c59ce7886a061 Mon Sep 17 00:00:00 2001
+From ef51fb40f756e2d7a7de4d285590305c782ba9b7 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 16 Jun 2021 11:08:32 +0200
-Subject: [PATCH 2/2] Include sys/select.h
+Subject: [PATCH 2/3] Include sys/select.h
 
 ---
  SDLnetsys.h | 1 +

--- a/Ports/SDL2_net/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_net/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,94 @@
+From 3986e0cc88c73b1ecb21b831f807333e1c46dad7 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH 3/3] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/configure b/configure
+index 8c1d2d4..8ea327f 100755
+--- a/configure
++++ b/configure
+@@ -4487,6 +4487,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -7272,6 +7276,10 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -8508,6 +8516,10 @@ rm -f core conftest.err conftest.$ac_objext \
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -9410,6 +9422,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+@@ -14947,6 +14970,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/SDL2_net/patches/ReadMe.md
+++ b/Ports/SDL2_net/patches/ReadMe.md
@@ -11,3 +11,17 @@ FIXME: We don't know why yet.
 Include sys/select.h
 
 
+## `0003-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/SDL2_ttf/package.sh
+++ b/Ports/SDL2_ttf/package.sh
@@ -12,11 +12,8 @@ configure() {
         --host="${SERENITY_ARCH}-pc-serenity" \
         --with-sdl-prefix="${SERENITY_INSTALL_ROOT}/usr/local" \
         --with-x=no \
+        --disable-static \
+        --enable-shared \
         FT2_CFLAGS="-I${SERENITY_INSTALL_ROOT}/usr/local/include/freetype2" \
         LIBS="-lgui -lgfx -lipc -lcore -lcompress"
-}
-
-install() {
-    run make install DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}"
-    run ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_ttf.so -Wl,-soname,libSDL2_ttf.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libSDL2_ttf.a -Wl,--no-whole-archive -lfreetype
 }

--- a/Ports/SDL2_ttf/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/SDL2_ttf/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,94 @@
+From 1aec7f15c8d70f249b051a65823215c382fa0498 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/configure b/configure
+index 02724d0..fec4760 100755
+--- a/configure
++++ b/configure
+@@ -4841,6 +4841,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -7634,6 +7638,10 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -8919,6 +8927,10 @@ rm -f core conftest.err conftest.$ac_objext \
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -9846,6 +9858,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+@@ -15654,6 +15677,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/SDL2_ttf/patches/ReadMe.md
+++ b/Ports/SDL2_ttf/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for SDL2_ttf on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libassuan/package.sh
+++ b/Ports/libassuan/package.sh
@@ -13,11 +13,5 @@ pre_configure() {
 }
 
 configure() {
-    run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" "${configopts[@]}"
-}
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libassuan.so -Wl,-soname,libassuan.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libassuan.a -Wl,--no-whole-archive -lgpg-error
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libassuan.la
+    run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" --disable-static --enable-shared "${configopts[@]}"
 }

--- a/Ports/libassuan/patches/0001-Include-sys-time.h.patch
+++ b/Ports/libassuan/patches/0001-Include-sys-time.h.patch
@@ -1,7 +1,7 @@
-From f5ca6465464e4649a81fa3694e69e71efd3e5f46 Mon Sep 17 00:00:00 2001
+From 4bd9445c203d7d46d40a31c54699681fc6042de7 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 14 Apr 2021 04:32:19 +0200
-Subject: [PATCH] Include sys/time.h
+Subject: [PATCH 1/2] Include sys/time.h
 
 ---
  src/assuan-socket.c | 1 +

--- a/Ports/libassuan/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libassuan/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 2b1a1933641853db42a37f772efc6d5271e3db16 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH 2/2] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 7bee4db..dfbc3ea 100755
+--- a/configure
++++ b/configure
+@@ -5961,6 +5961,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -8990,6 +8994,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -10406,6 +10414,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -11421,6 +11433,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libassuan/patches/ReadMe.md
+++ b/Ports/libassuan/patches/ReadMe.md
@@ -5,3 +5,17 @@
 Include sys/time.h
 
 
+## `0002-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libgcrypt/package.sh
+++ b/Ports/libgcrypt/package.sh
@@ -16,9 +16,3 @@ pre_configure() {
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" "${configopts[@]}"
 }
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgcrypt.so -Wl,-soname,libgcrypt.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgcrypt.a -Wl,--no-whole-archive -lgpg-error
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgcrypt.la
-}

--- a/Ports/libgcrypt/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libgcrypt/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From dfef4a23509c2f239d0fda51abfd3574147a620d Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 906cbcb..1929b30 100755
+--- a/configure
++++ b/configure
+@@ -6522,6 +6522,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9546,6 +9550,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -10962,6 +10970,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -11977,6 +11989,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libgcrypt/patches/ReadMe.md
+++ b/Ports/libgcrypt/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libgcrypt on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libgpg-error/package.sh
+++ b/Ports/libgpg-error/package.sh
@@ -12,9 +12,3 @@ auth_type=sha256
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" "${configopts[@]}"
 }
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgpg-error.so -Wl,-soname,libgpg-error.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgpg-error.a -Wl,--no-whole-archive -lintl
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libgpg-error.la
-}

--- a/Ports/libgpg-error/patches/0001-Include-errno.h.patch
+++ b/Ports/libgpg-error/patches/0001-Include-errno.h.patch
@@ -1,7 +1,7 @@
-From ea4d2441210e9bacb778e892227ed99ff496a9e1 Mon Sep 17 00:00:00 2001
+From bd7b392f9447112458e9e5cfd89a2b25d544c465 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 14 Apr 2021 04:32:34 +0200
-Subject: [PATCH 1/2] Include errno.h
+Subject: [PATCH 1/3] Include errno.h
 
 ---
  src/mkerrcodes.c | 1 +

--- a/Ports/libgpg-error/patches/0002-Stub-out-the-gpgrt-lock-impl.patch
+++ b/Ports/libgpg-error/patches/0002-Stub-out-the-gpgrt-lock-impl.patch
@@ -1,7 +1,7 @@
-From 473f87074e63a2786d42035c919e061c8574b7fe Mon Sep 17 00:00:00 2001
+From 29782147d325747be57381458bc9dffb9bbfaf57 Mon Sep 17 00:00:00 2001
 From: Gunnar Beutner <gbeutner@serenityos.org>
 Date: Wed, 14 Apr 2021 04:32:34 +0200
-Subject: [PATCH 2/2] Stub out the gpgrt lock impl
+Subject: [PATCH 2/3] Stub out the gpgrt lock impl
 
 ---
  src/syscfg/lock-obj-pub.i686-pc-serenity.h | 17 +++++++++++++++++

--- a/Ports/libgpg-error/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libgpg-error/patches/0003-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 8c73450cf10645d91bb3fbe4e240184765d2af92 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH 3/3] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 24b0799..1838edf 100755
+--- a/configure
++++ b/configure
+@@ -6615,6 +6615,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9639,6 +9643,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -11055,6 +11063,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -12070,6 +12082,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libgpg-error/patches/ReadMe.md
+++ b/Ports/libgpg-error/patches/ReadMe.md
@@ -10,3 +10,17 @@ Include errno.h
 Stub out the gpgrt lock impl
 
 
+## `0003-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libiconv/package.sh
+++ b/Ports/libiconv/package.sh
@@ -7,9 +7,3 @@ files="https://ftpmirror.gnu.org/gnu/libiconv/libiconv-${version}.tar.gz libicon
 auth_type="sha256"
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub" "libcharset/build-aux/config.sub")
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    run ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.so -Wl,-soname,libiconv.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.a -Wl,--no-whole-archive
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libiconv.la
-}

--- a/Ports/libiconv/patches/0001-Stub-out-getprogname-for-serenity.patch
+++ b/Ports/libiconv/patches/0001-Stub-out-getprogname-for-serenity.patch
@@ -1,7 +1,7 @@
-From 9b61ddd52828042b106d7d4c3fef582be9c933e7 Mon Sep 17 00:00:00 2001
+From 74f7065ed6f9cf338f53657ea08e980328dd27c6 Mon Sep 17 00:00:00 2001
 From: Vincent Sanders <vince@kyllikki.org>
 Date: Sun, 6 Oct 2019 11:11:16 +0100
-Subject: [PATCH 1/1] Stub out getprogname() for serenity
+Subject: [PATCH 1/2] Stub out getprogname() for serenity
 
 ---
  srclib/getprogname.c | 2 ++

--- a/Ports/libiconv/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libiconv/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From bdcb52aa7f451346423c3468ab124c57464b1b5a Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH 2/2] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 3488d1d..33b4956 100755
+--- a/configure
++++ b/configure
+@@ -7376,6 +7376,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -10688,6 +10692,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -12206,6 +12214,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -13274,6 +13286,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libiconv/patches/ReadMe.md
+++ b/Ports/libiconv/patches/ReadMe.md
@@ -5,3 +5,17 @@
 Stub out getprogname() for serenity
 
 
+## `0002-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libjpeg/package.sh
+++ b/Ports/libjpeg/package.sh
@@ -2,12 +2,7 @@
 port=libjpeg
 version=9e
 useconfigure=true
+configopts=("--disable-static" "--enable-shared")
 files="https://ijg.org/files/jpegsrc.v${version}.tar.gz jpeg-${version}.tar.gz 4077d6a6a75aeb01884f708919d25934c93305e49f7e3f36db9129320e6f4f3d"
 auth_type=sha256
 workdir="jpeg-$version"
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libjpeg.so -Wl,-soname,libjpeg.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libjpeg.a -Wl,--no-whole-archive
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libjpeg.la
-}

--- a/Ports/libjpeg/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libjpeg/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 9847675448e5a0169589de8610c0c96463d157b0 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 9e1d1fc..a95ac5d 100755
+--- a/configure
++++ b/configure
+@@ -7089,6 +7089,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -10551,6 +10555,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -12081,6 +12089,10 @@ printf "%s\n" "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -13153,6 +13165,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libjpeg/patches/ReadMe.md
+++ b/Ports/libjpeg/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libjpeg on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libksba/package.sh
+++ b/Ports/libksba/package.sh
@@ -15,9 +15,3 @@ pre_configure() {
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" "${configopts[@]}"
 }
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libksba.so -Wl,-soname,libksba.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libksba.a -Wl,--no-whole-archive -lgpg-error
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libksba.la
-}

--- a/Ports/libksba/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libksba/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 253d1b4ca2d00e63cf66fcd04794ff7d85ca4013 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index e9b010b..964315e 100755
+--- a/configure
++++ b/configure
+@@ -5986,6 +5986,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9015,6 +9019,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -10431,6 +10439,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -11446,6 +11458,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libksba/patches/ReadMe.md
+++ b/Ports/libksba/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libksba on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libmodplug/package.sh
+++ b/Ports/libmodplug/package.sh
@@ -7,11 +7,3 @@ configopts=("ac_cv_c_bigendian=no")
 files="https://download.sourceforge.net/modplug-xmms/libmodplug-${version}.tar.gz libmodplug-${version}.tar.gz 457ca5a6c179656d66c01505c0d95fafaead4329b9dbaa0f997d00a3508ad9de"
 auth_type=sha256
 workdir="libmodplug-$version"
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    MODPLUG_LIBDIR="${SERENITY_INSTALL_ROOT}/usr/local/lib"
-    ${CC} -shared -o ${MODPLUG_LIBDIR}/libmodplug.so.1 -Wl,-soname,libmodplug.so -Wl,--whole-archive ${MODPLUG_LIBDIR}/libmodplug.a -Wl,--no-whole-archive
-    ln -rsf ${MODPLUG_LIBDIR}/libmodplug.so.1 ${MODPLUG_LIBDIR}/libmodplug.so
-    rm -f ${MODPLUG_LIBDIR}/libmodplug.la
-}

--- a/Ports/libmodplug/patches/0001-Include-strings.h.patch
+++ b/Ports/libmodplug/patches/0001-Include-strings.h.patch
@@ -1,7 +1,7 @@
-From 8042f44a1358f080e28e727b3deecd43b046a8f7 Mon Sep 17 00:00:00 2001
+From 05bfb2d4b183e7ab23f9c57ccea2022a46178c26 Mon Sep 17 00:00:00 2001
 From: xSlendiX <gamingxslendix@gmail.com>
 Date: Sat, 18 Sep 2021 16:19:50 +0300
-Subject: [PATCH] Include strings.h
+Subject: [PATCH 1/2] Include strings.h
 
 ---
  src/libmodplug/stdafx.h | 1 +

--- a/Ports/libmodplug/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libmodplug/patches/0002-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,94 @@
+From 14e9290db59b2a95ea2aa841c4799d1dba648887 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH 2/2] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/configure b/configure
+index f3d01df..01f0360 100755
+--- a/configure
++++ b/configure
+@@ -6573,6 +6573,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9867,6 +9871,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -11385,6 +11393,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -12456,6 +12468,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+@@ -16421,6 +16444,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libmodplug/patches/ReadMe.md
+++ b/Ports/libmodplug/patches/ReadMe.md
@@ -5,3 +5,17 @@
 Include strings.h
 
 
+## `0002-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libogg/package.sh
+++ b/Ports/libogg/package.sh
@@ -2,12 +2,7 @@
 port=libogg
 version=1.3.5
 useconfigure=true
+configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub=true
 files="https://github.com/xiph/ogg/releases/download/v${version}/libogg-${version}.tar.gz libogg-${version}.tar.gz 0eb4b4b9420a0f51db142ba3f9c64b333f826532dc0f48c6410ae51f4799b664"
 auth_type=sha256
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libogg.so -Wl,-soname,libogg.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libogg.a -Wl,--no-whole-archive
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libogg.la
-}

--- a/Ports/libogg/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libogg/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From e92cdea5d51443fa7c573cfbc73543d2e78f9a9c Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 3181fb7..b78fdf1 100755
+--- a/configure
++++ b/configure
+@@ -4697,6 +4697,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -8028,6 +8032,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -9550,6 +9558,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -10630,6 +10642,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libogg/patches/ReadMe.md
+++ b/Ports/libogg/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libogg on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libpng/package.sh
+++ b/Ports/libpng/package.sh
@@ -2,14 +2,8 @@
 port=libpng
 version=1.6.37
 useconfigure=true
+configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub=true
 files="https://download.sourceforge.net/libpng/libpng-${version}.tar.gz libpng-${version}.tar.gz daeb2620d829575513e35fecc83f0d3791a620b9b93d800b763542ece9390fb4"
 auth_type=sha256
 depends=("zlib")
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libpng16.so -Wl,-soname,libpng16.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libpng16.a -Wl,--no-whole-archive -lz
-    ln -sf libpng16.so ${SERENITY_INSTALL_ROOT}/usr/local/lib/libpng.so
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libpng16.la ${SERENITY_INSTALL_ROOT}/usr/local/lib/libpng.la
-}

--- a/Ports/libpng/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libpng/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From d556fcb6726b513794ab48818e453b8af848d2f1 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 1b2c463..ac2ad0b 100755
+--- a/configure
++++ b/configure
+@@ -5728,6 +5728,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9172,6 +9176,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -10690,6 +10698,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -11758,6 +11770,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libpng/patches/ReadMe.md
+++ b/Ports/libpng/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libpng on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libsodium/package.sh
+++ b/Ports/libsodium/package.sh
@@ -2,14 +2,9 @@
 port=libsodium
 version=1.0.18
 useconfigure=true
+configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 workdir=libsodium-${version}
 files="https://download.libsodium.org/libsodium/releases/libsodium-${version}.tar.gz libsodium-${version}.tar.gz 6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1"
 auth_type=sha256
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -pthread -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libsodium.so -Wl,-soname,libsodium.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libsodium.a -Wl,--no-whole-archive
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libsodium.la
-}

--- a/Ports/libsodium/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libsodium/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 24fdb0b1d714807f338b1a96ae7c30db19e9a7e2 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 6063204..73853e4 100755
+--- a/configure
++++ b/configure
+@@ -10278,6 +10278,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -13296,6 +13300,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -14814,6 +14822,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -15882,6 +15894,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libsodium/patches/ReadMe.md
+++ b/Ports/libsodium/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libsodium on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libtheora/package.sh
+++ b/Ports/libtheora/package.sh
@@ -2,21 +2,9 @@
 port=libtheora
 version=1.1.1
 useconfigure=true
+configopts=()
 use_fresh_config_sub=true
 files="https://ftp.osuosl.org/pub/xiph/releases/theora/libtheora-${version}.tar.bz2 libtheora-${version}.tar.bz2 b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc"
 auth_type="sha256"
 depends=("libvorbis")
-configopts=("--disable-examples")
-
-build_shared() {
-    local name=$1
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/${name}.so -Wl,-soname,${name}.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/${name}.a -Wl,--no-whole-archive
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/${name}.la
-}
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    build_shared libtheora
-    build_shared libtheoradec
-    build_shared libtheoraenc
-}
+configopts=("--disable-examples" "--disable-static" "--enable-shared")

--- a/Ports/libtheora/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libtheora/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 8c634afaee47bbf9a3fffc0452b740d040a4df98 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 9703bcb..548051c 100755
+--- a/configure
++++ b/configure
+@@ -5643,6 +5643,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -8216,6 +8220,10 @@ $as_echo_n "checking for $compiler option to produce PIC... " >&6; }
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -9540,6 +9548,10 @@ rm -f core conftest.err conftest.$ac_objext conftest_ipa8_conftest.oo \
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -10475,6 +10487,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libtheora/patches/ReadMe.md
+++ b/Ports/libtheora/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libtheora on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libtiff/package.sh
+++ b/Ports/libtiff/package.sh
@@ -2,14 +2,8 @@
 port=libtiff
 version=4.3.0
 useconfigure=true
+configopts=("--disable-static" "--enable-shared")
 workdir="tiff-$version"
 files="http://download.osgeo.org/libtiff/tiff-${version}.tar.gz tiff-${version}.tar.gz 0e46e5acb087ce7d1ac53cf4f56a09b221537fc86dfc5daaad1c2e89e1b37ac8"
 auth_type="sha256"
 depends=("libjpeg" "zstd" "xz")
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libtiff.so -Wl,-soname,libtiff.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libtiff.a -Wl,--no-whole-archive -lzstd -llzma -ljpeg
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libtiffxx.so -Wl,-soname,libtiffxx.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libtiffxx.a -Wl,--no-whole-archive -lzstd -llzma -ljpeg
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libtiff.la ${SERENITY_INSTALL_ROOT}/usr/local/lib/libtiffxx.la
-}

--- a/Ports/libtiff/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libtiff/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,94 @@
+From 9f36cd059f2ea7ae5233519fd7f486850d623014 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 34 ++++++++++++++++++++++++++++++++++
+ 1 file changed, 34 insertions(+)
+
+diff --git a/configure b/configure
+index 1d9918f..e1e8caa 100755
+--- a/configure
++++ b/configure
+@@ -6439,6 +6439,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -10022,6 +10026,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -11544,6 +11552,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -12624,6 +12636,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+@@ -17019,6 +17042,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libtiff/patches/ReadMe.md
+++ b/Ports/libtiff/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libtiff on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libvorbis/package.sh
+++ b/Ports/libvorbis/package.sh
@@ -2,17 +2,8 @@
 port=libvorbis
 version=1.3.7
 useconfigure=true
+configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub=true
 files="https://github.com/xiph/vorbis/releases/download/v${version}/libvorbis-${version}.tar.gz libvorbis-${version}.tar.gz 0e982409a9c3fc82ee06e08205b1355e5c6aa4c36bca58146ef399621b0ce5ab"
 auth_type=sha256
 depends=("libogg")
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbis.so -Wl,-soname,libvorbis.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbis.a -Wl,--no-whole-archive -logg
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbis.la
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbisenc.so -Wl,-soname,libvorbisenc.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbisenc.a -Wl,--no-whole-archive -lvorbis
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbisenc.la
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbisfile.so -Wl,-soname,libvorbisfile.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbisfile.a -Wl,--no-whole-archive -lvorbis
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libvorbisfile.la
-}

--- a/Ports/libvorbis/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libvorbis/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From ba4fc4788b1955cbfd2edea3756ad65cbccec395 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index e72b5c7..bfebd8a 100755
+--- a/configure
++++ b/configure
+@@ -5945,6 +5945,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9091,6 +9095,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -10613,6 +10621,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -11693,6 +11705,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libvorbis/patches/ReadMe.md
+++ b/Ports/libvorbis/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libvorbis on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/libxml2/package.sh
+++ b/Ports/libxml2/package.sh
@@ -6,12 +6,4 @@ use_fresh_config_sub=true
 files="https://download.gnome.org/sources/libxml2/2.9/libxml2-${version}.tar.xz libxml2-${version}.tar.xz 276130602d12fe484ecc03447ee5e759d0465558fbc9d6bd144e3745306ebf0e"
 auth_type=sha256
 depends=("libiconv" "xz")
-configopts=("--with-sysroot=${SERENITY_INSTALL_ROOT}" "--prefix=/usr/local" "--without-python")
-
-install() {
-    run make DESTDIR="${SERENITY_INSTALL_ROOT}" install
-
-    # Link shared library
-    run ${SERENITY_ARCH}-pc-serenity-gcc -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.so -Wl,-soname,libxml2.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.a -Wl,--no-whole-archive -llzma
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libxml2.la
-}
+configopts=("--with-sysroot=${SERENITY_INSTALL_ROOT}" "--prefix=/usr/local" "--without-python" "--disable-static" "--enable-shared")

--- a/Ports/libxml2/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/libxml2/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 897e1d8be1554c6588941574e620a90600b024d0 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 6156015..cfd0935 100755
+--- a/configure
++++ b/configure
+@@ -6148,6 +6148,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9300,6 +9304,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -10822,6 +10830,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -11902,6 +11914,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/libxml2/patches/ReadMe.md
+++ b/Ports/libxml2/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for libxml2 on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/npth/package.sh
+++ b/Ports/npth/package.sh
@@ -10,9 +10,3 @@ auth_type=sha256
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" "${configopts[@]}"
 }
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -pthread -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libnpth.so -Wl,-soname,libnpth.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libnpth.a -Wl,--no-whole-archive
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libnpth.la
-}

--- a/Ports/npth/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/npth/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 224a54e5860c10b15fd88a962c509f670f91d311 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 22ab8e0..51a7571 100755
+--- a/configure
++++ b/configure
+@@ -6517,6 +6517,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -9540,6 +9544,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -10956,6 +10964,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -11960,6 +11972,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/npth/patches/ReadMe.md
+++ b/Ports/npth/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for npth on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/ntbtls/package.sh
+++ b/Ports/ntbtls/package.sh
@@ -15,9 +15,3 @@ pre_configure() {
 configure() {
     run ./configure --host="${SERENITY_ARCH}-pc-serenity" --build="$($workdir/build-aux/config.guess)" "${configopts[@]}"
 }
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/libntbtls.so -Wl,-soname,libntbtls.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/libntbtls.a -Wl,--no-whole-archive -lgpg-error -lksba -lgcrypt
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/libntbtls.la
-}

--- a/Ports/ntbtls/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/ntbtls/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From d4848aa8e5c1783c7d942a45fc2c7780315e4afe Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index 9685eda..6fd2d94 100755
+--- a/configure
++++ b/configure
+@@ -7527,6 +7527,10 @@ sysv4 | sysv4.3*)
+ tpf*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -10556,6 +10560,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -11972,6 +11980,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -12987,6 +12999,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/ntbtls/patches/ReadMe.md
+++ b/Ports/ntbtls/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for ntbtls on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+

--- a/Ports/xz/package.sh
+++ b/Ports/xz/package.sh
@@ -2,14 +2,9 @@
 port=xz
 version=5.2.5
 useconfigure=true
+configopts=("--disable-static" "--enable-shared")
 use_fresh_config_sub=true
 config_sub_paths=("build-aux/config.sub")
 files="https://tukaani.org/xz/xz-${version}.tar.gz xz-${version}.tar.gz f6f4910fd033078738bd82bfba4f49219d03b17eb0794eb91efbae419f4aba10"
 auth_type=sha256
 depends=("zlib" "libiconv")
-
-install() {
-    run make DESTDIR=${SERENITY_INSTALL_ROOT} "${installopts[@]}" install
-    ${CC} -pthread -shared -o ${SERENITY_INSTALL_ROOT}/usr/local/lib/liblzma.so -Wl,-soname,liblzma.so -Wl,--whole-archive ${SERENITY_INSTALL_ROOT}/usr/local/lib/liblzma.a -Wl,--no-whole-archive -lz -liconv
-    rm -f ${SERENITY_INSTALL_ROOT}/usr/local/lib/liblzma.la
-}

--- a/Ports/xz/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
+++ b/Ports/xz/patches/0001-libtool-Enable-shared-library-support-for-SerenityOS.patch
@@ -1,0 +1,76 @@
+From 6e8ac02a635810a8be768d6e7bcac786e9e15908 Mon Sep 17 00:00:00 2001
+From: Tim Schumacher <timschumi@gmx.de>
+Date: Sun, 29 May 2022 15:01:28 +0200
+Subject: [PATCH] libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+---
+ configure | 23 +++++++++++++++++++++++
+ 1 file changed, 23 insertions(+)
+
+diff --git a/configure b/configure
+index f103a6b..099c1e4 100755
+--- a/configure
++++ b/configure
+@@ -8734,6 +8734,10 @@ tpf*)
+ os2*)
+   lt_cv_deplibs_check_method=pass_all
+   ;;
++
++serenity*)
++  lt_cv_deplibs_check_method=pass_all
++  ;;
+ esac
+ 
+ fi
+@@ -12063,6 +12067,10 @@ lt_prog_compiler_static=
+       lt_prog_compiler_static='-Bstatic'
+       ;;
+ 
++    serenity*)
++      lt_prog_compiler_can_build_shared=yes
++      ;;
++
+     *)
+       lt_prog_compiler_can_build_shared=no
+       ;;
+@@ -13583,6 +13591,10 @@ $as_echo "$lt_cv_irix_exported_symbol" >&6; }
+       hardcode_shlibpath_var=no
+       ;;
+ 
++    serenity*)
++      ld_shlibs=yes
++      ;;
++
+     *)
+       ld_shlibs=no
+       ;;
+@@ -14651,6 +14663,17 @@ uts4*)
+   shlibpath_var=LD_LIBRARY_PATH
+   ;;
+ 
++serenity*)
++  version_type=linux
++  need_lib_prefix=no
++  need_version=no
++  library_names_spec='${libname}${release}${shared_ext}${versuffix} ${libname}${release}${shared_ext}${major} ${libname}${shared_ext}'
++  soname_spec='${libname}${release}${shared_ext}${major}'
++  shlibpath_var=LD_LIBRARY_PATH
++  shlibpath_overrides_runpath=no
++  dynamic_linker='SerenityOS LibELF'
++  ;;
++
+ *)
+   dynamic_linker=no
+   ;;
+-- 
+2.36.1
+

--- a/Ports/xz/patches/ReadMe.md
+++ b/Ports/xz/patches/ReadMe.md
@@ -1,0 +1,16 @@
+# Patches for xz on SerenityOS
+
+## `0001-libtool-Enable-shared-library-support-for-SerenityOS.patch`
+
+libtool: Enable shared library support for SerenityOS
+
+For some odd reason, libtool handles the configuration for shared
+libraries entirely statically and in its configure script. If no
+shared library support is "present", building shared libraries is
+disabled entirely.
+
+Fix that by just adding the appropriate configuration options for
+`serenity`. This allows us to finally create dynamic libraries
+automatically using libtool, without having to manually link the
+static library into a shared library.
+


### PR DESCRIPTION
This looks big, but it's really just largely the same change across 22 ports. Most ports are fine with the "normal" `libtool` patch, a few needed to have a duplicated chunk because some contents were actually duplicated in the `configure` script. This also explicitly asks `configure` to stop building static libraries and start building shared libraries everywhere.

This adds quite a few lines to the patches (and makes some of the ports not patch-less anymore), but I figured it would be a good stress test before attempting to upstream that patch into `libtool`. Once that is done, I expect the patches to gradually phase out again after the various upstreams switch to a newer revision of `libtool`.

Also, let me know if I should squash those patches, I guess...