### PR TITLE
Kernel: Unify Kernel task names for consistency

### DIFF
--- a/Kernel/Bus/USB/UHCI/UHCIController.cpp
+++ b/Kernel/Bus/USB/UHCI/UHCIController.cpp
@@ -509,7 +509,7 @@ size_t UHCIController::poll_transfer_queue(QueueHead& transfer_queue)
 ErrorOr<void> UHCIController::spawn_port_process()
 {
     RefPtr<Thread> usb_hotplug_thread;
-    (void)Process::create_kernel_process(usb_hotplug_thread, TRY(KString::try_create("UHCI hotplug")), [&] {
+    (void)Process::create_kernel_process(usb_hotplug_thread, TRY(KString::try_create("UHCI Hot Plug Task")), [&] {
         for (;;) {
             if (m_root_hub)
                 m_root_hub->check_for_port_updates();

--- a/Kernel/Net/NetworkTask.cpp
+++ b/Kernel/Net/NetworkTask.cpp
@@ -43,7 +43,7 @@ static HashTable<RefPtr<TCPSocket>>* delayed_ack_sockets;
 void NetworkTask::spawn()
 {
     RefPtr<Thread> thread;
-    auto name = KString::try_create("NetworkTask");
+    auto name = KString::try_create("Network Task");
     if (name.is_error())
         TODO();
     (void)Process::create_kernel_process(thread, name.release_value(), NetworkTask_main, nullptr);

--- a/Kernel/Scheduler.cpp
+++ b/Kernel/Scheduler.cpp
@@ -405,7 +405,7 @@ UNMAP_AFTER_INIT void Scheduler::initialize()
     VERIFY(s_colonel_process);
     VERIFY(idle_thread);
     idle_thread->set_priority(THREAD_PRIORITY_MIN);
-    idle_thread->set_name(KString::must_create("idle thread #0"));
+    idle_thread->set_name(KString::must_create("Idle Task #0"));
 
     set_idle_thread(idle_thread);
 }

--- a/Kernel/Tasks/FinalizerTask.cpp
+++ b/Kernel/Tasks/FinalizerTask.cpp
@@ -11,6 +11,8 @@
 
 namespace Kernel {
 
+static constexpr StringView finalizer_task_name = "Finalizer Task"sv;
+
 static void finalizer_task(void*)
 {
     Thread::current()->set_priority(THREAD_PRIORITY_LOW);
@@ -20,14 +22,14 @@ static void finalizer_task(void*)
         if (g_finalizer_has_work.exchange(false, AK::MemoryOrder::memory_order_acq_rel) == true)
             Thread::finalize_dying_threads();
         else
-            g_finalizer_wait_queue->wait_forever("FinalizerTask");
+            g_finalizer_wait_queue->wait_forever(finalizer_task_name);
     }
 };
 
 UNMAP_AFTER_INIT void FinalizerTask::spawn()
 {
     RefPtr<Thread> finalizer_thread;
-    auto finalizer_process = Process::create_kernel_process(finalizer_thread, KString::must_create("FinalizerTask"), finalizer_task, nullptr);
+    auto finalizer_process = Process::create_kernel_process(finalizer_thread, KString::must_create(finalizer_task_name), finalizer_task, nullptr);
     VERIFY(finalizer_process);
     g_finalizer = finalizer_thread;
 }

--- a/Kernel/Tasks/SyncTask.cpp
+++ b/Kernel/Tasks/SyncTask.cpp
@@ -15,8 +15,8 @@ namespace Kernel {
 UNMAP_AFTER_INIT void SyncTask::spawn()
 {
     RefPtr<Thread> syncd_thread;
-    (void)Process::create_kernel_process(syncd_thread, KString::must_create("SyncTask"), [] {
-        dbgln("SyncTask is running");
+    (void)Process::create_kernel_process(syncd_thread, KString::must_create("VFS Sync Task"), [] {
+        dbgln("VFS SyncTask is running");
         for (;;) {
             VirtualFileSystem::sync();
             (void)Thread::current()->sleep(Time::from_seconds(1));

--- a/Kernel/WorkQueue.cpp
+++ b/Kernel/WorkQueue.cpp
@@ -16,7 +16,7 @@ WorkQueue* g_io_work;
 
 UNMAP_AFTER_INIT void WorkQueue::initialize()
 {
-    g_io_work = new WorkQueue("IO WorkQueue");
+    g_io_work = new WorkQueue("IO WorkQueue Task");
 }
 
 UNMAP_AFTER_INIT WorkQueue::WorkQueue(StringView name)


### PR DESCRIPTION
This change unifies the naming convention for kernel tasks.

The goal of this change is to:

- Make the task names more descriptive, so users can more
  easily understand their purpose in System Monitor.

- Unify the naming convention so they are consistent.