### PR TITLE
LibGUI+Browser: Fix crash when activating a "Tab n" action

### DIFF
--- a/Userland/Applications/Browser/BrowserWindow.cpp
+++ b/Userland/Applications/Browser/BrowserWindow.cpp
@@ -111,8 +111,10 @@ BrowserWindow::BrowserWindow(CookieJar& cookie_jar, URL url)
         m_tab_widget->activate_previous_tab();
     };
 
-    for (int i = 0; i <= 7; ++i) {
+    for (size_t i = 0; i <= 7; ++i) {
         m_window_actions.on_tabs.append([this, i] {
+            if (i >= m_tab_widget->tab_count())
+                return;
             m_tab_widget->set_tab_index(i);
         });
     }

--- a/Userland/Libraries/LibGUI/TabWidget.h
+++ b/Userland/Libraries/LibGUI/TabWidget.h
@@ -29,6 +29,7 @@ public:
     bool has_vertical_tabs() const { return m_tab_position == TabPosition::Left || m_tab_position == TabPosition::Right; }
 
     Optional<size_t> active_tab_index() const;
+    size_t tab_count() { return m_tabs.size(); }
 
     Widget* active_widget() { return m_active_widget.ptr(); }
     Widget const* active_widget() const { return m_active_widget.ptr(); }


### PR DESCRIPTION
Previously we would try setting the tab index regardless if that tab actually existed, resulting in Browser crashing by either pressing Control + N or using the CommandPalette.

I'm not sure if returning early should maybe be a property of the `set_tab_index` api, let me know what you think.