### PR TITLE
LibGfx: Fix questionable roundness of antialiased circles at small sizes 

### DIFF
--- a/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
+++ b/Userland/Libraries/LibGfx/AntiAliasingPainter.cpp
@@ -329,13 +329,10 @@ Gfx::AntiAliasingPainter::Range Gfx::AntiAliasingPainter::draw_ellipse_part(
     auto correct = [&] {
         int error = y - y_hat;
 
-        if (!is_circle) {
-            // FIXME: For ellipses the alpha values seem too low, which
-            // can make them look overly pointy. This fixes that, though there's
-            // probably a better solution to be found.
-            // (This issue seems to exist in the base algorithm)
-            error /= 4;
-        }
+        // FIXME: The alpha values seem too low, which makes things look
+        // overly pointy. This fixes that, though there's probably a better
+        // solution to be found. (This issue seems to exist in the base algorithm)
+        error /= 4;
 
         delta2_y += error;
         delta_y += error;


### PR DESCRIPTION
In a picture (in green new rendering, in red old rendering):
![sadage](https://user-images.githubusercontent.com/11597044/172050052-59b562e5-14c9-4588-aedd-e053bf0bc9e2.png)

> _"I find your lack of roundness disturbing"_