### PR TITLE
LibIPC: Process remaining read bytes before shutting down due to EOF

### DIFF
--- a/Userland/Libraries/LibIPC/Connection.cpp
+++ b/Userland/Libraries/LibIPC/Connection.cpp
@@ -136,6 +136,8 @@ ErrorOr<Vector<u8>> ConnectionBase::read_as_much_as_possible_from_socket_without
         auto bytes_read = maybe_bytes_read.release_value();
         if (bytes_read.is_empty()) {
             deferred_invoke([this] { shutdown(); });
+            if (!bytes.is_empty())
+                break;
             return Error::from_string_literal("IPC connection EOF"sv);
         }
 


### PR DESCRIPTION
Previously we would shut down an ipc connection regardless of if there were still bytes that have been read and not been handed over to processing, causing WindowServer not to receive WindowServer::SetFlashFlush messages sent by `wsctl -f` except the first one.

This pull request fixes that behavior by still shutting the connection down due to having reached EOF while also processing remaining bytes.

Resolves #12954

See also #8912 which fixes the same issue that this patch fixes but also seems to have initially broken SettingsWindow cancel not actually closing the window unless the cursor got moved as described in #12003. Pull request #12547 fixing the SettingsWindow behavior broke `wsctl` again by always shutting down.

The graphics stack is also broken regarding `wsctl -f` at the moment though this will get fixed by #13941 