### PR TITLE
Games+LibWeb: Have you heard the good word about antialiasing?

### DIFF
--- a/Userland/Games/Breakout/Game.cpp
+++ b/Userland/Games/Breakout/Game.cpp
@@ -11,6 +11,7 @@
 #include <LibGUI/Application.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
+#include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/StandardCursor.h>
 #include <unistd.h>
 
@@ -124,10 +125,11 @@ void Game::paint_event(GUI::PaintEvent& event)
 {
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
+    Gfx::AntiAliasingPainter aa_painter { painter };
 
     painter.fill_rect(rect(), Color::Black);
 
-    painter.fill_ellipse(enclosing_int_rect(m_ball.rect()), Color::Red);
+    aa_painter.fill_ellipse(enclosing_int_rect(m_ball.rect()), Color::Red);
 
     painter.fill_rect(enclosing_int_rect(m_paddle.rect), Color::White);
 

--- a/Userland/Games/Chess/ChessWidget.cpp
+++ b/Userland/Games/Chess/ChessWidget.cpp
@@ -12,6 +12,7 @@
 #include <LibCore/File.h>
 #include <LibGUI/MessageBox.h>
 #include <LibGUI/Painter.h>
+#include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/Font/Font.h>
 #include <LibGfx/Font/FontDatabase.h>
 #include <LibGfx/Path.h>
@@ -151,7 +152,8 @@ void ChessWidget::paint_event(GUI::PaintEvent& event)
                     move_point = { (7 - square.file) * tile_width, square.rank * tile_height };
                 }
 
-                painter.fill_ellipse({ move_point + point_offset, rect_size }, Gfx::Color::LightGray);
+                Gfx::AntiAliasingPainter aa_painter { painter };
+                aa_painter.fill_ellipse({ move_point + point_offset, rect_size }, Gfx::Color::LightGray);
             }
         }
 

--- a/Userland/Games/Pong/Game.cpp
+++ b/Userland/Games/Pong/Game.cpp
@@ -6,6 +6,7 @@
 
 #include "Game.h"
 #include <AK/Random.h>
+#include <LibGfx/AntiAliasingPainter.h>
 
 namespace Pong {
 
@@ -66,16 +67,18 @@ void Game::paint_event(GUI::PaintEvent& event)
     GUI::Painter painter(*this);
     painter.add_clip_rect(event.rect());
 
+    Gfx::AntiAliasingPainter aa_painter { painter };
+
     painter.fill_rect(rect(), Color::Black);
     painter.fill_rect(enclosing_int_rect(m_net.rect()), m_net.color);
 
-    painter.fill_ellipse(enclosing_int_rect(m_ball.rect()), Color::Red);
+    aa_painter.fill_ellipse(enclosing_int_rect(m_ball.rect()), Color::Red);
 
     painter.fill_rect(enclosing_int_rect(m_player1_paddle.rect), m_player1_paddle.color);
     painter.fill_rect(enclosing_int_rect(m_player2_paddle.rect), m_player2_paddle.color);
 
     if (m_cursor_paddle_target_y.has_value())
-        painter.fill_ellipse(cursor_paddle_target_rect(), Color::Blue);
+        aa_painter.fill_ellipse(cursor_paddle_target_rect(), Color::Blue);
 
     painter.draw_text(player_1_score_rect(), String::formatted("{}", m_player_1_score), Gfx::TextAlignment::TopLeft, Color::White);
     painter.draw_text(player_2_score_rect(), String::formatted("{}", m_player_2_score), Gfx::TextAlignment::TopLeft, Color::White);

--- a/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
+++ b/Userland/Libraries/LibWeb/Painting/MarkerPaintable.cpp
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+#include <LibGfx/AntiAliasingPainter.h>
 #include <LibGfx/StylePainter.h>
 #include <LibWeb/Layout/ListItemMarkerBox.h>
 #include <LibWeb/Painting/MarkerPaintable.h>
@@ -43,20 +44,17 @@ void MarkerPaintable::paint(PaintContext& context, PaintPhase phase) const
     Gfx::IntRect marker_rect { 0, 0, marker_width, marker_width };
     marker_rect.center_within(enclosing);
 
+    Gfx::AntiAliasingPainter aa_painter { context.painter() };
+
     switch (layout_box().list_style_type()) {
     case CSS::ListStyleType::Square:
         context.painter().fill_rect(marker_rect, color);
         break;
     case CSS::ListStyleType::Circle:
-        // For some reason for draw_ellipse() the ellipse is outside of the rect while for fill_ellipse() the ellipse is inside.
-        // Scale the marker_rect with sqrt(2) to get an ellipse arc (circle) that appears as if it was inside of the marker_rect.
-        marker_rect.set_height(marker_rect.height() / 1.41);
-        marker_rect.set_width(marker_rect.width() / 1.41);
-        marker_rect.center_within(enclosing);
-        context.painter().draw_ellipse_intersecting(marker_rect, color);
+        aa_painter.draw_ellipse(marker_rect, color, 1);
         break;
     case CSS::ListStyleType::Disc:
-        context.painter().fill_ellipse(marker_rect, color);
+        aa_painter.fill_ellipse(marker_rect, color);
         break;
     case CSS::ListStyleType::Decimal:
     case CSS::ListStyleType::DecimalLeadingZero:


### PR DESCRIPTION
Since #14193 was merged, I think these all make a notable (but subtle) improvement over the non-aa versions. 

**Screenshot:**
![image](https://user-images.githubusercontent.com/11597044/172053776-5a52f788-b6ae-411e-9508-542b54d3ba32.png)
 
**Top left:** Antialiased list markers in LibWeb
**Bottom left:** Antialiased move markers in chess 
**Top right:** Antialiased ball in breakout
**Bottom right:** Antialiased ball in pong

P.s. You may want to open the screenshot in a new tab to view at 100%

