### PR TITLE
LibGfx(+LibWeb+ImageViewer+PixelPaint): Implement SmoothPixels scaling mode and use it

### DIFF
--- a/Userland/Applications/ImageViewer/main.cpp
+++ b/Userland/Applications/ImageViewer/main.cpp
@@ -240,6 +240,10 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     });
     nearest_neighbor_action->set_checked(true);
 
+    auto smooth_pixels_action = GUI::Action::create_checkable("&Smooth Pixels", [&](auto&) {
+        widget->set_scaling_mode(Gfx::Painter::ScalingMode::SmoothPixels);
+    });
+
     auto bilinear_action = GUI::Action::create_checkable("&Bilinear", [&](auto&) {
         widget->set_scaling_mode(Gfx::Painter::ScalingMode::BilinearBlend);
     });
@@ -314,9 +318,11 @@ ErrorOr<int> serenity_main(Main::Arguments arguments)
     auto scaling_mode_group = make<GUI::ActionGroup>();
     scaling_mode_group->set_exclusive(true);
     scaling_mode_group->add_action(*nearest_neighbor_action);
+    scaling_mode_group->add_action(*smooth_pixels_action);
     scaling_mode_group->add_action(*bilinear_action);
 
     TRY(scaling_mode_menu->try_add_action(nearest_neighbor_action));
+    TRY(scaling_mode_menu->try_add_action(smooth_pixels_action));
     TRY(scaling_mode_menu->try_add_action(bilinear_action));
 
     TRY(view_menu->try_add_separator());

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.cpp
@@ -24,7 +24,7 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize const& suggested_size, GUI::Wi
     m_starting_aspect_ratio = m_desired_size.width() / static_cast<float>(m_desired_size.height());
 
     set_title("Resize Image");
-    resize(260, 210);
+    resize(260, 228);
     set_icon(parent_window->icon());
 
     auto& main_widget = set_main_widget<GUI::Widget>();
@@ -68,9 +68,11 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize const& suggested_size, GUI::Wi
     };
 
     auto nearest_neighbor_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("nearest_neighbor_radio");
+    auto smooth_pixels_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("smooth_pixels_radio");
     auto bilinear_radio = main_widget.find_descendant_of_type_named<GUI::RadioButton>("bilinear_radio");
 
     VERIFY(nearest_neighbor_radio);
+    VERIFY(smooth_pixels_radio);
     VERIFY(bilinear_radio);
 
     m_scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor;
@@ -81,6 +83,10 @@ ResizeImageDialog::ResizeImageDialog(Gfx::IntSize const& suggested_size, GUI::Wi
     nearest_neighbor_radio->on_checked = [this](bool is_checked) {
         if (is_checked)
             m_scaling_mode = Gfx::Painter::ScalingMode::NearestNeighbor;
+    };
+    smooth_pixels_radio->on_checked = [this](bool is_checked) {
+        if (is_checked)
+            m_scaling_mode = Gfx::Painter::ScalingMode::SmoothPixels;
     };
     bilinear_radio->on_checked = [this](bool is_checked) {
         if (is_checked)

--- a/Userland/Applications/PixelPaint/ResizeImageDialog.gml
+++ b/Userland/Applications/PixelPaint/ResizeImageDialog.gml
@@ -82,6 +82,12 @@
         }
 
         @GUI::RadioButton {
+            name: "smooth_pixels_radio"
+            text: "Smooth Pixels"
+            autosize: true
+        }
+
+        @GUI::RadioButton {
             name: "bilinear_radio"
             text: "Bilinear"
             autosize: true

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1094,7 +1094,7 @@ ALWAYS_INLINE static void do_draw_integer_scaled_bitmap(Gfx::Bitmap& target, Int
     }
 }
 
-template<bool has_alpha_channel, bool do_bilinear_blend, typename GetPixel>
+template<bool has_alpha_channel, Painter::ScalingMode scaling_mode, typename GetPixel>
 ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect const& dst_rect, IntRect const& clipped_rect, Gfx::Bitmap const& source, FloatRect const& src_rect, GetPixel get_pixel, float opacity)
 {
     auto int_src_rect = enclosing_int_rect(src_rect);
@@ -1102,7 +1102,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
     if (clipped_src_rect.is_empty())
         return;
 
-    if constexpr (!do_bilinear_blend) {
+    if constexpr (scaling_mode == Painter::ScalingMode::NearestNeighbor) {
         if (dst_rect == clipped_rect && int_src_rect == src_rect && !(dst_rect.width() % int_src_rect.width()) && !(dst_rect.height() % int_src_rect.height())) {
             int hfactor = dst_rect.width() / int_src_rect.width();
             int vfactor = dst_rect.height() / int_src_rect.height();
@@ -1139,7 +1139,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
                 continue;
 
             Color src_pixel;
-            if constexpr (do_bilinear_blend) {
+            if constexpr (scaling_mode == Painter::ScalingMode::BilinearBlend) {
                 auto scaled_x0 = clamp((desired_x - half_pixel) >> 32, clipped_src_rect.left(), clipped_src_rect.right());
                 auto scaled_x1 = clamp((desired_x + half_pixel) >> 32, clipped_src_rect.left(), clipped_src_rect.right());
                 auto scaled_y0 = clamp((desired_y - half_pixel) >> 32, clipped_src_rect.top(), clipped_src_rect.bottom());
@@ -1179,10 +1179,10 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
 {
     switch (scaling_mode) {
     case Painter::ScalingMode::NearestNeighbor:
-        do_draw_scaled_bitmap<has_alpha_channel, false>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::NearestNeighbor>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;
     case Painter::ScalingMode::BilinearBlend:
-        do_draw_scaled_bitmap<has_alpha_channel, true>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::BilinearBlend>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;
     }
 }

--- a/Userland/Libraries/LibGfx/Painter.cpp
+++ b/Userland/Libraries/LibGfx/Painter.cpp
@@ -1102,7 +1102,7 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
     if (clipped_src_rect.is_empty())
         return;
 
-    if constexpr (scaling_mode == Painter::ScalingMode::NearestNeighbor) {
+    if constexpr (scaling_mode == Painter::ScalingMode::NearestNeighbor || scaling_mode == Painter::ScalingMode::SmoothPixels) {
         if (dst_rect == clipped_rect && int_src_rect == src_rect && !(dst_rect.width() % int_src_rect.width()) && !(dst_rect.height() % int_src_rect.height())) {
             int hfactor = dst_rect.width() / int_src_rect.width();
             int vfactor = dst_rect.height() / int_src_rect.height();
@@ -1157,6 +1157,27 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
                 auto bottom = bottom_left.interpolate(bottom_right, x_ratio);
 
                 src_pixel = top.interpolate(bottom, y_ratio);
+            } else if constexpr (scaling_mode == Painter::ScalingMode::SmoothPixels) {
+                auto scaled_x1 = clamp(desired_x >> 32, clipped_src_rect.left(), clipped_src_rect.right());
+                auto scaled_x0 = clamp(scaled_x1 - 1, clipped_src_rect.left(), clipped_src_rect.right());
+                auto scaled_y1 = clamp(desired_y >> 32, clipped_src_rect.top(), clipped_src_rect.bottom());
+                auto scaled_y0 = clamp(scaled_y1 - 1, clipped_src_rect.top(), clipped_src_rect.bottom());
+
+                float x_ratio = (desired_x & fractional_mask) / (float)shift;
+                float y_ratio = (desired_y & fractional_mask) / (float)shift;
+
+                float scaled_x_ratio = clamp(x_ratio * dst_rect.width() / (float)src_rect.width(), 0.0f, 1.0f);
+                float scaled_y_ratio = clamp(y_ratio * dst_rect.height() / (float)src_rect.height(), 0.0f, 1.0f);
+
+                auto top_left = get_pixel(source, scaled_x0, scaled_y0);
+                auto top_right = get_pixel(source, scaled_x1, scaled_y0);
+                auto bottom_left = get_pixel(source, scaled_x0, scaled_y1);
+                auto bottom_right = get_pixel(source, scaled_x1, scaled_y1);
+
+                auto top = top_left.interpolate(top_right, scaled_x_ratio);
+                auto bottom = bottom_left.interpolate(bottom_right, scaled_x_ratio);
+
+                src_pixel = top.interpolate(bottom, scaled_y_ratio);
             } else {
                 auto scaled_x = clamp(desired_x >> 32, clipped_src_rect.left(), clipped_src_rect.right());
                 auto scaled_y = clamp(desired_y >> 32, clipped_src_rect.top(), clipped_src_rect.bottom());
@@ -1180,6 +1201,9 @@ ALWAYS_INLINE static void do_draw_scaled_bitmap(Gfx::Bitmap& target, IntRect con
     switch (scaling_mode) {
     case Painter::ScalingMode::NearestNeighbor:
         do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::NearestNeighbor>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
+        break;
+    case Painter::ScalingMode::SmoothPixels:
+        do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::SmoothPixels>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);
         break;
     case Painter::ScalingMode::BilinearBlend:
         do_draw_scaled_bitmap<has_alpha_channel, Painter::ScalingMode::BilinearBlend>(target, dst_rect, clipped_rect, source, src_rect, get_pixel, opacity);

--- a/Userland/Libraries/LibGfx/Painter.h
+++ b/Userland/Libraries/LibGfx/Painter.h
@@ -36,6 +36,7 @@ public:
 
     enum class ScalingMode {
         NearestNeighbor,
+        SmoothPixels,
         BilinearBlend,
     };
 

--- a/Userland/Libraries/LibWeb/CSS/StyleValue.h
+++ b/Userland/Libraries/LibWeb/CSS/StyleValue.h
@@ -67,8 +67,9 @@ inline Gfx::Painter::ScalingMode to_gfx_scaling_mode(CSS::ImageRendering css_val
     case CSS::ImageRendering::Smooth:
         return Gfx::Painter::ScalingMode::BilinearBlend;
     case CSS::ImageRendering::CrispEdges:
-    case CSS::ImageRendering::Pixelated:
         return Gfx::Painter::ScalingMode::NearestNeighbor;
+    case CSS::ImageRendering::Pixelated:
+        return Gfx::Painter::ScalingMode::SmoothPixels;
     }
     VERIFY_NOT_REACHED();
 }


### PR DESCRIPTION
![250% zoom test](https://user-images.githubusercontent.com/16520278/172066605-fa763437-8b9b-4744-a92d-73b9068dc1e5.png)

https://user-images.githubusercontent.com/16520278/172066940-670d50a7-7e5a-4dea-ba2f-b94a470f7e59.mp4

---

- **LibGfx: Pass scaling mode as an enum in do_draw_scaled_bitmap**
- **LibGfx: Implement SmoothPixels scaling mode**

  If you wanted to upscale an image, you had two options:
  - use Nearest Neighbor: it's probably a good choice. The image stays sharp.. unless you aren't using integer scales.
  - use Bilinear blending, but this on the other hand, doesn't handle upscaling well. It just blurs everything.

  But what if we could take the best of both of them and make the image sharp on integers and just blur it a little when needed?

  Well, there's Smooth Pixels! (*the name probably could be better tho*)

  This mode is similar to the Bilinear Blend, with the main difference is that the blend ratio is multiplied by the current scale, so the blur on corners can be only 1px wide.

  From my testing this mode doesn't handles downscaling as good as the Bilinear blending though.

- **LibWeb: Use SmoothPixels scaling mode as the pixelated**

  It's probably not in 1:1 as spec says, as it wants us to first upscale the image to the nearest integer and then downscale it bilinearly. But this mode still falls into the general description of the value:

  > The image is scaled in a way that preserves the pixelated nature of the original as much as possible, but allows minor smoothing instead of awkward distortion when necessary.
  > — *https://drafts.csswg.org/css-images/#valdef-image-rendering-pixelated*

  Also, this way we don't have to allocate the memory just for the integer scale. :^) :^)

- **ImageViewer: Add Smooth Pixels image scaling option**
- **PixelPaint: Add Smooth Pixels scaling option**